### PR TITLE
Simplify the MsgSetHead message in the protocol

### DIFF
--- a/src/Chain.hs
+++ b/src/Chain.hs
@@ -248,16 +248,12 @@ applyChainUpdates = flip (foldl (flip applyChainUpdate))
 findIntersection
   :: HasHeader block
   => Chain block
-  -> Point
   -> [Point]
   -> Maybe Point
-findIntersection c hpoint points =
-    go (hpoint : points)
-  where
-    go [] = Nothing
-    go (p:ps)
-        | pointOnChain p c = Just p
-        | otherwise        = go ps
+findIntersection c []     = Nothing
+findIntersection c (p:ps)
+  | pointOnChain p c      = Just p
+  | otherwise             = findIntersection c ps
 
 intersectChains
   :: HasHeader block

--- a/src/Chain.hs
+++ b/src/Chain.hs
@@ -57,6 +57,7 @@ module Chain (
   TestChainAndPoint(..),
   TestChainFork(..),
   isPrefixOf,
+  mkRollbackPoint,
   tests,
   ) where
 

--- a/src/ChainProducerState.hs
+++ b/src/ChainProducerState.hs
@@ -7,8 +7,7 @@ import           Block (Block, BlockHeader, HasHeader)
 import           Chain ( Chain, Point(..), blockPoint, ChainUpdate(..)
                        , genesisPoint, headPoint , pointOnChain
                        , TestBlockChainAndUpdates(..), TestBlockChain(..)
-                       , TestChainFork(..), mkRollbackPoint
-                       , genBlockChain, genPoint)
+                       , TestChainFork(..), mkRollbackPoint )
 import qualified Chain
 
 import           Data.List (sort, group, find, unfoldr)
@@ -266,8 +265,8 @@ fixupReaderStates = go 0
 
 instance Arbitrary ChainProducerStateTest where
   arbitrary = do
-    NonNegative n <- arbitrary
-    c <- genBlockChain n
+    TestBlockChain c <- arbitrary
+    let n = Chain.length c
     rs <- fixupReaderStates <$> listOf1 (genReaderState n c)
     rid <- choose (0, length rs - 1)
     p <- if n == 0

--- a/src/ConsumerProtocol.hs
+++ b/src/ConsumerProtocol.hs
@@ -42,7 +42,7 @@ import           Control.Monad.Free (Free (..))
 import           Control.Monad.Free as Free
 import           Control.Monad.ST.Lazy (runST)
 import           Data.FingerTree (ViewL (..))
-import           Data.FingerTree as FT
+--import qualified Data.FingerTree as FT
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.List as L
@@ -177,8 +177,7 @@ data ProducerHandlers block m r = ProducerHandlers {
      }
 
 -- |
--- TODO:
---  * n-consumers to producer (currently 1-consumer to producer)
+--
 producerSideProtocol1
   :: forall block pid m r.
      ( Show pid


### PR DESCRIPTION
Instead of sending the head and a list of points, we just send a list of points. The producer does not actually need to know the consumer's head point, just the rollback/intersection point.

In partcular the producer side of the protocol is simplified since we do not need separate opening and ongoing phases, just one phase. We initialise the reader's intersection point to be the genesis block. This also means a reader can start from the genesis without sending an opening MsgSetHead.

It also changes one of the properties slightly since it means we always find an intersection, even if that is just the genesis block. So one property is simplified.