### PR TITLE
Port all the tests to use the protocol families

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ doc/protocols.toc
 cabal.project.local*
 cabal.project.local~
 dist-newstyle/
+.vimrc
+tags

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -93,7 +93,6 @@ test-suite tests
   main-is:             Main.hs
   other-modules:       Test.Chain
                        Test.ChainProducerState
-                       Test.InCtxt
                        Test.Node
                        Test.Sim
                        Test.GlobalState

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -96,6 +96,7 @@ test-suite tests
                        Test.Node
                        Test.Sim
                        Test.GlobalState
+                       Test.ArbitrarySt
   default-language:    Haskell2010
   default-extensions:  NamedFieldPuns
   build-depends:       base,

--- a/test/Test/ArbitrarySt.hs
+++ b/test/Test/ArbitrarySt.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE FunctionalDependencies #-}
+module Test.ArbitrarySt where
+
+import Test.GlobalState
+
+class ArbitrarySt p a | a -> p where
+    arbitrarySt :: GenSt p a
+    shrinkSt :: a -> [a]
+
+
+

--- a/test/Test/ArbitrarySt.hs
+++ b/test/Test/ArbitrarySt.hs
@@ -1,8 +1,16 @@
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE FunctionalDependencies #-}
 module Test.ArbitrarySt where
 
+import Control.Monad.State
+
 import Test.GlobalState
+import Test.QuickCheck
+import Test.QuickCheck.Property (Property(..))
+
+import Ouroboros
 
 class ArbitrarySt p a | a -> p where
     arbitrarySt :: GenSt p a
@@ -11,4 +19,19 @@ class ArbitrarySt p a | a -> p where
     shrinkSt _ = []
 
 
+data WithSt p a = WithSt (GlobalState p) a
+
+withBft :: prop -> WithSt 'OuroborosBFT prop
+withBft prop = WithSt initialBftState prop
+
+instance (  ArbitrarySt p (a p), Show (a p), Testable prop)
+    => Testable (WithSt p ((a p) -> prop)) where
+    property (WithSt s f) = property $ do
+      a <- evalStateT arbitrarySt s
+      return $ f a
+
+instance Testable (WithSt p Property) where
+    property (WithSt s p) = property $ do
+      a <- evalStateT (lift . unProperty $ p) s
+      return (MkProperty (return a))
 

--- a/test/Test/ArbitrarySt.hs
+++ b/test/Test/ArbitrarySt.hs
@@ -8,7 +8,6 @@ import Control.Monad.State
 
 import Test.GlobalState
 import Test.QuickCheck
-import Test.QuickCheck.Property (Property(..))
 
 import Ouroboros
 
@@ -24,14 +23,9 @@ data WithSt p a = WithSt (GlobalState p) a
 withBft :: prop -> WithSt 'OuroborosBFT prop
 withBft prop = WithSt initialBftState prop
 
-instance (  ArbitrarySt p (a p), Show (a p), Testable prop)
-    => Testable (WithSt p ((a p) -> prop)) where
+instance (ArbitrarySt p a, Show a, Testable prop)
+    => Testable (WithSt p (a -> prop)) where
     property (WithSt s f) = property $ do
       a <- evalStateT arbitrarySt s
       return $ f a
-
-instance Testable (WithSt p Property) where
-    property (WithSt s p) = property $ do
-      a <- evalStateT (lift . unProperty $ p) s
-      return (MkProperty (return a))
 

--- a/test/Test/ArbitrarySt.hs
+++ b/test/Test/ArbitrarySt.hs
@@ -6,7 +6,9 @@ import Test.GlobalState
 
 class ArbitrarySt p a | a -> p where
     arbitrarySt :: GenSt p a
+
     shrinkSt :: a -> [a]
+    shrinkSt _ = []
 
 
 

--- a/test/Test/Chain.hs
+++ b/test/Test/Chain.hs
@@ -30,6 +30,7 @@ import Test.Tasty (TestTree, TestName, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
 import Test.GlobalState
+import Test.ArbitrarySt
 import Data.Map.Strict (Map)
 
 --
@@ -165,12 +166,6 @@ prop_intersectChains (TestChainFork c l r) =
     Just p  -> Chain.headPoint c == p
             && Chain.pointOnChain p l
             && Chain.pointOnChain p r
-
-
-class ArbitrarySt p a | a -> p where
-    arbitrarySt :: GenSt p a
-    shrinkSt :: a -> [a]
-
 
 
 --

--- a/test/Test/Chain.hs
+++ b/test/Test/Chain.hs
@@ -79,22 +79,6 @@ tests =
   ]
 
 
-data WithSt p a = WithSt (GlobalState p) a
-
-withBft :: prop -> WithSt 'OuroborosBFT prop
-withBft prop = WithSt initialBftState prop
-
-instance (  ArbitrarySt p (a p), Show (a p), Testable prop)
-    => Testable (WithSt p ((a p) -> prop)) where
-    property (WithSt s f) = property $ do
-      a <- evalStateT arbitrarySt s
-      return $ f a
-
-instance Testable (WithSt p Property) where
-    property (WithSt s p) = property $ do
-      a <- evalStateT (lift . unProperty $ p) s
-      return (MkProperty (return a))
-
 --
 -- Properties
 --

--- a/test/Test/ChainProducerState.hs
+++ b/test/Test/ChainProducerState.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Test.ChainProducerState (tests) where
 
@@ -22,21 +24,21 @@ import           Test.Chain
 
 tests :: TestTree
 tests =
-  testGroup "ChainProducerState" []
-  -- [ testGroup "Test Arbitrary instances"
-  --   [ testProperty "ChainProducerStateForkTest's generator"
-  --                  prop_arbitrary_ChainProducerStateForkTest
-  --   , testProperty "ChainProducerStateForkTest's shrinker"
-  --                  (withMaxSuccess 25 prop_shrink_ChainProducerStateForkTest)
-  --   ]
-  -- , testProperty "check initial reader state" prop_init_lookup
-  -- , testProperty "check second reader state"  prop_init_next_lookup
-  -- , testProperty "check reader state after updateReader" prop_update_lookup
-  -- , testProperty "check reader state after updateReader2" prop_update_next_lookup
-  -- , testProperty "producer syncronise (1)" prop_producer_sync1
-  -- , testProperty "producer syncronise (2)" prop_producer_sync2
-  -- , testProperty "switch fork" prop_switchFork
-  -- ]
+  testGroup "ChainProducerState"
+  [ testGroup "Test Arbitrary instances"
+    [ testProperty "ChainProducerStateForkTest's generator"
+      (withBft $ prop_arbitrary_ChainProducerStateForkTest @'OuroborosBFT)
+    , testProperty "ChainProducerStateForkTest's shrinker"
+                   (withMaxSuccess 25 (withBft $ prop_shrink_ChainProducerStateForkTest @'OuroborosBFT))
+    ]
+  , testProperty "check initial reader state" (withBft $ prop_init_lookup @'OuroborosBFT)
+  , testProperty "check second reader state"  (withBft $ prop_init_next_lookup @'OuroborosBFT)
+  , testProperty "check reader state after updateReader" (withBft $ prop_update_lookup @'OuroborosBFT)
+  , testProperty "check reader state after updateReader2" (withBft $ prop_update_next_lookup @'OuroborosBFT)
+  , testProperty "producer syncronise (1)" (withBft $ prop_producer_sync1 @'OuroborosBFT)
+  , testProperty "producer syncronise (2)" (withBft $ prop_producer_sync2 @'OuroborosBFT)
+  , testProperty "switch fork" (withBft $ prop_switchFork @'OuroborosBFT)
+  ]
 
 
 --

--- a/test/Test/ChainProducerState.hs
+++ b/test/Test/ChainProducerState.hs
@@ -27,17 +27,17 @@ tests =
   testGroup "ChainProducerState"
   [ testGroup "Test Arbitrary instances"
     [ testProperty "ChainProducerStateForkTest's generator"
-      (withBft $ prop_arbitrary_ChainProducerStateForkTest @'OuroborosBFT)
+      (withBft prop_arbitrary_ChainProducerStateForkTest)
     , testProperty "ChainProducerStateForkTest's shrinker"
-                   (withMaxSuccess 25 (withBft $ prop_shrink_ChainProducerStateForkTest @'OuroborosBFT))
+                   (withMaxSuccess 25 (withBft prop_shrink_ChainProducerStateForkTest))
     ]
-  , testProperty "check initial reader state" (withBft $ prop_init_lookup @'OuroborosBFT)
-  , testProperty "check second reader state"  (withBft $ prop_init_next_lookup @'OuroborosBFT)
-  , testProperty "check reader state after updateReader" (withBft $ prop_update_lookup @'OuroborosBFT)
-  , testProperty "check reader state after updateReader2" (withBft $ prop_update_next_lookup @'OuroborosBFT)
-  , testProperty "producer syncronise (1)" (withBft $ prop_producer_sync1 @'OuroborosBFT)
-  , testProperty "producer syncronise (2)" (withBft $ prop_producer_sync2 @'OuroborosBFT)
-  , testProperty "switch fork" (withBft $ prop_switchFork @'OuroborosBFT)
+  , testProperty "check initial reader state" (withBft prop_init_lookup)
+  , testProperty "check second reader state"  (withBft prop_init_next_lookup)
+  , testProperty "check reader state after updateReader" (withBft prop_update_lookup)
+  , testProperty "check reader state after updateReader2" (withBft prop_update_next_lookup)
+  , testProperty "producer syncronise (1)" (withBft prop_producer_sync1)
+  , testProperty "producer syncronise (2)" (withBft prop_producer_sync2)
+  , testProperty "switch fork" (withBft prop_switchFork)
   ]
 
 

--- a/test/Test/ChainProducerState.hs
+++ b/test/Test/ChainProducerState.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 module Test.ChainProducerState (tests) where
 
 import           Data.List (unfoldr)
@@ -10,6 +12,9 @@ import           Chain ( Chain, Block, Point(..), ChainUpdate(..)
                        , genesisPoint, headPoint , pointOnChain )
 import qualified Chain
 import ChainProducerState
+import Test.ArbitrarySt
+
+import Ouroboros
 
 import           Test.Chain
                        ( TestBlockChainAndUpdates(..), TestBlockChain(..)
@@ -17,21 +22,21 @@ import           Test.Chain
 
 tests :: TestTree
 tests =
-  testGroup "ChainProducerState"
-  [ testGroup "Test Arbitrary instances"
-    [ testProperty "ChainProducerStateForkTest's generator"
-                   prop_arbitrary_ChainProducerStateForkTest
-    , testProperty "ChainProducerStateForkTest's shrinker"
-                   (withMaxSuccess 25 prop_shrink_ChainProducerStateForkTest)
-    ]
-  , testProperty "check initial reader state" prop_init_lookup
-  , testProperty "check second reader state"  prop_init_next_lookup
-  , testProperty "check reader state after updateReader" prop_update_lookup
-  , testProperty "check reader state after updateReader2" prop_update_next_lookup
-  , testProperty "producer syncronise (1)" prop_producer_sync1
-  , testProperty "producer syncronise (2)" prop_producer_sync2
-  , testProperty "switch fork" prop_switchFork
-  ]
+  testGroup "ChainProducerState" []
+  -- [ testGroup "Test Arbitrary instances"
+  --   [ testProperty "ChainProducerStateForkTest's generator"
+  --                  prop_arbitrary_ChainProducerStateForkTest
+  --   , testProperty "ChainProducerStateForkTest's shrinker"
+  --                  (withMaxSuccess 25 prop_shrink_ChainProducerStateForkTest)
+  --   ]
+  -- , testProperty "check initial reader state" prop_init_lookup
+  -- , testProperty "check second reader state"  prop_init_next_lookup
+  -- , testProperty "check reader state after updateReader" prop_update_lookup
+  -- , testProperty "check reader state after updateReader2" prop_update_next_lookup
+  -- , testProperty "producer syncronise (1)" prop_producer_sync1
+  -- , testProperty "producer syncronise (2)" prop_producer_sync2
+  -- , testProperty "switch fork" prop_switchFork
+  -- ]
 
 
 --
@@ -41,7 +46,7 @@ tests =
 -- | Check that readers start in the expected state, at the right point and
 -- in the rollback state.
 --
-prop_init_lookup :: ChainProducerStateTest -> Bool
+prop_init_lookup :: ChainProducerStateTest p -> Bool
 prop_init_lookup (ChainProducerStateTest c _ p) =
     let (c', rid) = initReader p c in
     lookupReader c' rid == ReaderState p ReaderBackTo rid
@@ -49,7 +54,7 @@ prop_init_lookup (ChainProducerStateTest c _ p) =
 -- | As above but check that when we move the reader on by one, from the
 -- rollback state, they stay at the same point but are now in the forward state.
 --
-prop_init_next_lookup :: ChainProducerStateTest -> Bool
+prop_init_next_lookup :: KnownOuroborosProtocol p => ChainProducerStateTest p -> Bool
 prop_init_next_lookup (ChainProducerStateTest c _ p) =
     let (c', rid)     = initReader p c
         Just (u, c'') = readerInstruction rid c'
@@ -59,7 +64,7 @@ prop_init_next_lookup (ChainProducerStateTest c _ p) =
 -- | Check that after moving the reader point that the reader is in the
 -- expected state, at the right point and in the rollback state.
 --
-prop_update_lookup :: ChainProducerStateTest -> Bool
+prop_update_lookup :: ChainProducerStateTest p -> Bool
 prop_update_lookup (ChainProducerStateTest c rid p) =
     let c' = updateReader rid p c in
     lookupReader c' rid == ReaderState p ReaderBackTo rid
@@ -67,7 +72,7 @@ prop_update_lookup (ChainProducerStateTest c rid p) =
 -- | As above but check that when we move the reader on by one, from the
 -- rollback state, they stay at the same point but are now in the forward state.
 --
-prop_update_next_lookup :: ChainProducerStateTest -> Bool
+prop_update_next_lookup :: KnownOuroborosProtocol p => ChainProducerStateTest p -> Bool
 prop_update_next_lookup (ChainProducerStateTest c rid p) =
     let c'            = updateReader rid p c
         Just (u, c'') = readerInstruction rid c'
@@ -82,7 +87,7 @@ prop_update_next_lookup (ChainProducerStateTest c rid p) =
 -- The limitation of this test is that it applies all the updates to the
 -- producer first and then syncronises without changing the producer.
 --
-prop_producer_sync1 :: TestBlockChainAndUpdates -> Bool
+prop_producer_sync1 :: KnownOuroborosProtocol p => TestBlockChainAndUpdates p -> Bool
 prop_producer_sync1 (TestBlockChainAndUpdates c us) =
     let producer0        = initChainProducerState c
         (producer1, rid) = initReader (Chain.headPoint c) producer0
@@ -100,7 +105,10 @@ prop_producer_sync1 (TestBlockChainAndUpdates c us) =
 -- interleaving of applying changes to the producer and doing syncronisation
 -- steps between the producer and consumer.
 --
-prop_producer_sync2 :: TestBlockChainAndUpdates -> [Bool] -> Bool
+prop_producer_sync2 :: KnownOuroborosProtocol p
+                    => TestBlockChainAndUpdates p
+                    -> [Bool] 
+                    -> Bool
 prop_producer_sync2 (TestBlockChainAndUpdates chain0 us0) choices =
     let producer0        = initChainProducerState chain0
         (producer1, rid) = initReader (Chain.headPoint chain0) producer0
@@ -132,7 +140,7 @@ prop_producer_sync2 (TestBlockChainAndUpdates chain0 us0) choices =
         Just (u, p') -> go rid p' c' [] []
           where Just c' = Chain.applyChainUpdate u c
 
-prop_switchFork :: ChainProducerStateForkTest -> Bool
+prop_switchFork :: KnownOuroborosProtocol p => ChainProducerStateForkTest p -> Bool
 prop_switchFork (ChainProducerStateForkTest cps f) =
   let cps' = switchFork f cps
   in
@@ -160,12 +168,12 @@ prop_switchFork (ChainProducerStateForkTest cps f) =
 -- Generators
 --
 
-data ChainProducerStateTest
-    = ChainProducerStateTest (ChainProducerState Block) ReaderId Point
+data ChainProducerStateTest p
+    = ChainProducerStateTest (ChainProducerState (Block p)) ReaderId Point
   deriving Show
 
 genReaderState :: Int   -- ^ length of the chain
-               -> Chain Block
+               -> Chain (Block p)
                -> Gen ReaderState
 genReaderState n c = do
     readerPoint <- frequency
@@ -186,54 +194,58 @@ fixupReaderStates = go 0
   go _ [] = []
   go n (r : rs) = r { readerId = n } : go (n + 1) rs
 
-instance Arbitrary ChainProducerStateTest where
-  arbitrary = do
-    TestBlockChain c <- arbitrary
+instance KnownOuroborosProtocol p => ArbitrarySt p (ChainProducerStateTest p) where
+  arbitrarySt = do
+    TestBlockChain c <- arbitrarySt
     let n = Chain.length c
-    rs <- fixupReaderStates <$> listOf1 (genReaderState n c)
-    rid <- choose (0, length rs - 1)
+    rs <- fixupReaderStates <$> lift (listOf1 (genReaderState n c))
+    rid <- lift $ choose (0, length rs - 1)
     p <- if n == 0
          then return genesisPoint
-         else mkRollbackPoint c <$> choose (0, n)
+         else mkRollbackPoint c <$> lift (choose (0, n))
     return (ChainProducerStateTest (ChainProducerState c rs) rid p)
 
-data ChainProducerStateForkTest
-    = ChainProducerStateForkTest (ChainProducerState Block) (Chain Block)
+data ChainProducerStateForkTest p
+    = ChainProducerStateForkTest (ChainProducerState (Block p)) (Chain (Block p))
   deriving Show
 
-instance Arbitrary ChainProducerStateForkTest where
-  arbitrary = do
-    TestChainFork _ c f <- arbitrary
+instance KnownOuroborosProtocol p => ArbitrarySt p (ChainProducerStateForkTest p) where
+  arbitrarySt = do
+    TestChainFork _ c f <- arbitrarySt
     let l = Chain.length c
-    rs <- fixupReaderStates <$> listOf (genReaderState l c)
+    rs <- fixupReaderStates <$> lift (listOf (genReaderState l c))
     return $ ChainProducerStateForkTest (ChainProducerState c rs) f
 
-  shrink (ChainProducerStateForkTest (ChainProducerState c rs) f)
+  shrinkSt (ChainProducerStateForkTest (ChainProducerState c rs) f)
     -- shrink readers
      = [ ChainProducerStateForkTest (ChainProducerState c rs') f
        | rs' <- shrinkList (const []) rs
        ]
     -- shrink the fork chain
     ++ [ ChainProducerStateForkTest (ChainProducerState c rs) f'
-       | TestBlockChain f' <- shrink (TestBlockChain f)
+       | TestBlockChain f' <- shrinkSt (TestBlockChain f)
        ]
     -- shrink chain and fix up readers
     ++ [ ChainProducerStateForkTest (ChainProducerState c' (fixupReaderPointer c' `map` rs)) f
-       | TestBlockChain c' <- shrink (TestBlockChain c)
+       | TestBlockChain c' <- shrinkSt (TestBlockChain c)
        ]
     where
-      fixupReaderPointer :: Chain Block -> ReaderState -> ReaderState
+      fixupReaderPointer :: Chain (Block p) -> ReaderState -> ReaderState
       fixupReaderPointer c' r@ReaderState{readerPoint} =
         if pointOnChain readerPoint c'
           then r
           else r { readerPoint = headPoint c' }
 
-prop_arbitrary_ChainProducerStateForkTest :: ChainProducerStateForkTest -> Bool
+prop_arbitrary_ChainProducerStateForkTest :: KnownOuroborosProtocol p
+                                          => ChainProducerStateForkTest p
+                                          -> Bool
 prop_arbitrary_ChainProducerStateForkTest (ChainProducerStateForkTest c f) =
     invChainProducerState c && Chain.valid f
 
-prop_shrink_ChainProducerStateForkTest :: ChainProducerStateForkTest -> Bool
+prop_shrink_ChainProducerStateForkTest :: KnownOuroborosProtocol p
+                                       => ChainProducerStateForkTest p
+                                       -> Bool
 prop_shrink_ChainProducerStateForkTest c =
     and [ invChainProducerState c' && Chain.valid f
-        | ChainProducerStateForkTest c' f <- shrink c
+        | ChainProducerStateForkTest c' f <- shrinkSt c
         ]

--- a/test/Test/GlobalState.hs
+++ b/test/Test/GlobalState.hs
@@ -20,6 +20,7 @@ import Control.Monad.State
 import Data.Map.Strict (Map)
 import Data.Maybe (catMaybes)
 import Data.Traversable (for)
+import Data.Function ((&))
 import Test.QuickCheck
 import qualified Data.Map.Strict as Map
 
@@ -32,7 +33,16 @@ import Ouroboros
 data GlobalState p = GlobalState (Map NodeId (OuroborosState p))
 
 initialBftState :: GlobalState 'OuroborosBFT
-initialBftState = GlobalState $ Map.fromList [(CoreId 0, BftState (CoreId 0))]
+initialBftState = GlobalState mempty
+                & putStateFor (CoreId 0) (BftState (CoreId 0))
+                & putStateFor (CoreId 1) (BftState (CoreId 1))
+                & putStateFor (CoreId 2) (BftState (CoreId 2))
+                & putStateFor (CoreId 3) (BftState (CoreId 3))
+                & putStateFor (CoreId 4) (BftState (CoreId 4))
+                & putStateFor (CoreId 5) (BftState (CoreId 5))
+                & putStateFor (CoreId 6) (BftState (CoreId 6))
+                & putStateFor (CoreId 7) (BftState (CoreId 7))
+                & putStateFor (CoreId 8) (BftState (CoreId 8))
 
 stateFor :: NodeId -> GlobalState p -> OuroborosState p
 stateFor nid (GlobalState ss) = ss Map.! nid

--- a/test/Test/GlobalState.hs
+++ b/test/Test/GlobalState.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -8,6 +9,7 @@
 
 module Test.GlobalState (
     GlobalState(..)
+  , initialBftState
   , forLeaders
     -- * QuickCheck support
   , GenSt
@@ -29,8 +31,8 @@ import Ouroboros
 
 data GlobalState p = GlobalState (Map NodeId (OuroborosState p))
 
-instance Arbitrary (GlobalState p) where
-  arbitrary = return (GlobalState mempty)
+initialBftState :: GlobalState 'OuroborosBFT
+initialBftState = GlobalState $ Map.fromList [(CoreId 0, BftState (CoreId 0))]
 
 stateFor :: NodeId -> GlobalState p -> OuroborosState p
 stateFor nid (GlobalState ss) = ss Map.! nid

--- a/test/Test/GlobalState.hs
+++ b/test/Test/GlobalState.hs
@@ -29,6 +29,9 @@ import Ouroboros
 
 data GlobalState p = GlobalState (Map NodeId (OuroborosState p))
 
+instance Arbitrary (GlobalState p) where
+  arbitrary = return (GlobalState mempty)
+
 stateFor :: NodeId -> GlobalState p -> OuroborosState p
 stateFor nid (GlobalState ss) = ss Map.! nid
 

--- a/test/Test/GlobalState.hs
+++ b/test/Test/GlobalState.hs
@@ -41,8 +41,6 @@ initialBftState = GlobalState mempty
                 & putStateFor (CoreId 4) (BftState (CoreId 4))
                 & putStateFor (CoreId 5) (BftState (CoreId 5))
                 & putStateFor (CoreId 6) (BftState (CoreId 6))
-                & putStateFor (CoreId 7) (BftState (CoreId 7))
-                & putStateFor (CoreId 8) (BftState (CoreId 8))
 
 stateFor :: NodeId -> GlobalState p -> OuroborosState p
 stateFor nid (GlobalState ss) = ss Map.! nid

--- a/test/Test/Node.hs
+++ b/test/Test/Node.hs
@@ -32,15 +32,15 @@ import Test.ArbitrarySt
 
 tests :: TestTree
 tests =
-  testGroup "Node" []
-  -- [ testGroup "fixed graph topology"
-  --   [ testProperty "core -> relay" (prop_coreToRelay @OuroborosBFT)
-  --   , testProperty "core -> relay -> relay" prop_coreToRelay2
-  --   , testProperty "core <-> relay <-> core" prop_coreToCoreViaRelay
-  --   ]
-  -- , testProperty "blockGenerator invariant (SimM)" prop_blockGenerator_ST
-  -- , testProperty "blockGenerator invariant (IO)" prop_blockGenerator_IO
-  -- ]
+  testGroup "Node"
+  [ testGroup "fixed graph topology"
+    [ testProperty "core -> relay" (withBft $ prop_coreToRelay @'OuroborosBFT)
+    , testProperty "core -> relay -> relay" (withBft $ prop_coreToRelay2 @'OuroborosBFT)
+    , testProperty "core <-> relay <-> core" (withBft $ prop_coreToCoreViaRelay @'OuroborosBFT)
+    ]
+  , testProperty "blockGenerator invariant (SimM)" (withBft $ prop_blockGenerator_ST @'OuroborosBFT)
+  , testProperty "blockGenerator invariant (IO)" (withBft $ prop_blockGenerator_IO @'OuroborosBFT)
+  ]
 
 
 -- NOTE: it reverses the order of probes

--- a/test/Test/Node.hs
+++ b/test/Test/Node.hs
@@ -34,12 +34,12 @@ tests :: TestTree
 tests =
   testGroup "Node"
   [ testGroup "fixed graph topology"
-    [ testProperty "core -> relay" (withBft $ prop_coreToRelay @'OuroborosBFT)
-    , testProperty "core -> relay -> relay" (withBft $ prop_coreToRelay2 @'OuroborosBFT)
-    , testProperty "core <-> relay <-> core" (withBft $ prop_coreToCoreViaRelay @'OuroborosBFT)
+    [ testProperty "core -> relay" (withBft prop_coreToRelay)
+    , testProperty "core -> relay -> relay" (withBft prop_coreToRelay2)
+    , testProperty "core <-> relay <-> core" (withBft prop_coreToCoreViaRelay)
     ]
-  , testProperty "blockGenerator invariant (SimM)" (withBft $ prop_blockGenerator_ST @'OuroborosBFT)
-  , testProperty "blockGenerator invariant (IO)" (withBft $ prop_blockGenerator_IO @'OuroborosBFT)
+  , testProperty "blockGenerator invariant (SimM)" (withBft prop_blockGenerator_ST)
+  , testProperty "blockGenerator invariant (IO)" (withBft prop_blockGenerator_IO)
   ]
 
 


### PR DESCRIPTION
This is basically the ~homeworks~ work @edsko asked me to perform -- it ports the current test suite to play well with Edsko's work-in-progress work to support a family of protocols.