### PR TITLE
Stylish-haskell, ordering in .cabal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist-newstyle/
 *.swo
 *~
 result*
+tags

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -4,7 +4,7 @@ synopsis:            A networking layer for the Ouroboros blockchain protocol
 -- description:
 license-file:        LICENSE
 author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts
-maintainer:          
+maintainer:
 copyright:           2018 IOHK
 category:            Network
 build-type:          Simple
@@ -22,22 +22,22 @@ library
   exposed-modules:     Block
                        Chain
                        ChainProducerState
+                       ConsumersAndProducers
                        MonadClass
-                       MonadClass.MonadSay
-                       MonadClass.MonadTimer
-                       MonadClass.MonadProbe
-                       MonadClass.MonadFork
                        MonadClass.MonadConc
+                       MonadClass.MonadFork
+                       MonadClass.MonadProbe
+                       MonadClass.MonadSay
+                       MonadClass.MonadSendRecv
                        MonadClass.MonadSTM
                        MonadClass.MonadSTMTimer
-                       MonadClass.MonadSendRecv
-                       Protocol
-                       ProtocolInterfaces
-                       ConsumersAndProducers
+                       MonadClass.MonadTimer
                        Node
                        Pipe
-                       Sim
+                       Protocol
+                       ProtocolInterfaces
                        Serialise
+                       Sim
   other-modules:
 -- Old experiments, not currently building:
 --                     Types
@@ -45,44 +45,44 @@ library
 --                     ConsumerProtocolSTM
 --                     Chain.Volatile,
   default-language:    Haskell2010
-  other-extensions:    MultiParamTypeClasses,
-                       NamedFieldPuns,
-                       TemplateHaskell,
+  other-extensions:    BangPatterns,
+                       DataKinds,
+                       EmptyCase,
+                       ExistentialQuantification,
                        FlexibleContexts,
+                       FlexibleInstances,
                        FunctionalDependencies,
-                       TypeFamilies,
-                       RecordWildCards,
                        GADTs,
                        GADTSyntax,
-                       ExistentialQuantification,
-                       BangPatterns,
-                       OverloadedStrings,
-                       RankNTypes,
-                       PolyKinds,
-                       DataKinds,
-                       TypeInType,
-                       ScopedTypeVariables,
-                       EmptyCase,
-                       FlexibleInstances,
                        GeneralizedNewtypeDeriving,
+                       MultiParamTypeClasses,
+                       NamedFieldPuns,
+                       OverloadedStrings,
+                       PolyKinds,
+                       RankNTypes,
+                       RecordWildCards,
+                       ScopedTypeVariables,
+                       TemplateHaskell,
                        TupleSections,
-                       TypeApplications
+                       TypeApplications,
+                       TypeFamilies,
+                       TypeInType,
   build-depends:       base         >=4.9 && <4.12,
-                       clock        >=0.7 && <0.8,
-                       fingertree   >=0.1 && <0.2,
-                       stm          >=2.4 && <2.5,
-                       transformers >=0.5 && <0.6,
-                       bytestring   >=0.10 && <0.11,
-                       containers   >=0.5 && <0.6,
                        array,
-                       semigroups   >=0.18 && <0.19,
-                       void         >=0.7 && <0.8,
-                       hashable     >=1.2 && <1.3,
-                       random       >=1.1 && <1.2,
-                       free         >=5.1 && <5.2,
-                       text         >=1.2 && <1.3,
+                       bytestring   >=0.10 && <0.11,
                        cborg        >=0.2.1 && <0.3,
+                       clock        >=0.7 && <0.8,
+                       containers   >=0.5 && <0.6,
+                       fingertree   >=0.1 && <0.2,
+                       free         >=5.1 && <5.2,
+                       hashable     >=1.2 && <1.3,
                        process,
+                       random       >=1.1 && <1.2,
+                       semigroups   >=0.18 && <0.19,
+                       stm          >=2.4 && <2.5,
+                       text         >=1.2 && <1.3,
+                       transformers >=0.5 && <0.6,
+                       void         >=0.7 && <0.8,
 
                        QuickCheck   >=2.12 && <2.13
 
@@ -90,43 +90,28 @@ library
 
 test-suite tests
   type:                exitcode-stdio-1.0
-  hs-source-dirs:      src, test
+  hs-source-dirs:      test
   main-is:             Main.hs
-  other-modules:       Block
-                       Chain
-                       ChainProducerState
-                       ConsumersAndProducers
-                       MonadClass
-                       MonadClass.MonadConc
-                       MonadClass.MonadFork
-                       MonadClass.MonadProbe
-                       MonadClass.MonadSTM
-                       MonadClass.MonadSTMTimer
-                       MonadClass.MonadSay
-                       MonadClass.MonadSendRecv
-                       MonadClass.MonadTimer
-                       Node
-                       Pipe
-                       Protocol
-                       ProtocolInterfaces
-                       Serialise
-                       Sim
-                       Test.Chain
+  other-modules:       Test.Chain
                        Test.ChainProducerState
-                       Test.Sim
                        Test.Node
                        Test.Pipe
+                       Test.Sim
   default-language:    Haskell2010
   default-extensions:  NamedFieldPuns
   build-depends:       base,
+                       ouroboros-network,
+
                        array,
                        bytestring,
+                       cborg,
                        clock,
                        containers,
                        fingertree,
                        free,
                        hashable,
                        mtl,
+                       process,
                        QuickCheck,
                        random,
                        semigroups,
@@ -134,8 +119,6 @@ test-suite tests
                        tasty,
                        tasty-quickcheck,
                        text,
-                       cborg,
-                       process,
                        transformers,
                        void
   ghc-options:         -Wall

--- a/src/Block.hs
+++ b/src/Block.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns             #-}
 
 -- | Reference implementation of a representation of a block in a block chain.
 --
@@ -21,19 +21,19 @@ module Block (
     )
     where
 
-import Data.Hashable
+import           Data.Hashable
 import qualified Data.Text as Text
 
-import Serialise
+import           Serialise
 
-import Test.QuickCheck
+import           Test.QuickCheck
 
 -- | Our highly-simplified version of a block. It retains the separation
 -- between a block header and body, which is a detail needed for the protocols.
 --
 data Block = Block {
-       blockHeader   :: BlockHeader,
-       blockBody     :: BlockBody
+       blockHeader :: BlockHeader,
+       blockBody   :: BlockBody
      }
   deriving (Show, Eq)
 

--- a/src/Chain.hs
+++ b/src/Chain.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE DeriveFunctor       #-}
-{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE DeriveFunctor  #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 -- | Reference implementation of a representation of a block chain
 --
@@ -62,15 +62,15 @@ module Chain (
   prettyPrintChain
   ) where
 
-import Prelude hiding (head, drop)
+import           Prelude hiding (drop, head)
 
-import Block ( Block(..), BlockHeader(..), HasHeader(..)
-             , Slot(..), BlockNo (..), HeaderHash(..)
-             , BodyHash(..), Slot(..), BlockNo(..)
-             , HeaderHash(..), hashHeader, hashBody )
-import Serialise
+import           Block (Block (..), BlockHeader (..), BlockNo (..),
+                     BlockNo (..), BodyHash (..), HasHeader (..),
+                     HeaderHash (..), HeaderHash (..), Slot (..), Slot (..),
+                     hashBody, hashHeader)
+import           Serialise
 
-import Control.Exception (assert)
+import           Control.Exception (assert)
 import qualified Data.List as L
 
 
@@ -212,7 +212,7 @@ selectChain
   => Chain block
   -> Chain block
   -> Chain block
-selectChain c1 c2 = 
+selectChain c1 c2 =
   if headBlockNo c1 >= headBlockNo c2
     then c1
     else c2

--- a/src/ChainProducerState.hs
+++ b/src/ChainProducerState.hs
@@ -3,13 +3,13 @@
 
 module ChainProducerState where
 
-import           Chain ( Chain, HasHeader, Point(..), blockPoint
-                       , ChainUpdate(..), genesisPoint, pointOnChain )
+import           Chain (Chain, ChainUpdate (..), HasHeader, Point (..),
+                     blockPoint, genesisPoint, pointOnChain)
 import qualified Chain
 
-import           Data.List (sort, group, find)
-import           Data.Maybe (fromMaybe)
 import           Control.Exception (assert)
+import           Data.List (find, group, sort)
+import           Data.Maybe (fromMaybe)
 
 
 
@@ -193,7 +193,7 @@ switchFork c (ChainProducerState c' rs) =
       if pointOnChain readerPoint c
         then r
         else r { readerPoint = ipoint, readerNext = ReaderBackTo }
-          
+
 
 -- | What a reader needs to do next. Should they move on to the next block or
 -- do they need to roll back to a previous point on their chain. It also updates

--- a/src/ConsumerProtocolSTM.hs
+++ b/src/ConsumerProtocolSTM.hs
@@ -1,30 +1,36 @@
-{-# LANGUAGE RecordWildCards, NamedFieldPuns #-}
-{-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies, TypeFamilies,
-             FlexibleContexts, ScopedTypeVariables, GADTs, RankNTypes,
-             GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FunctionalDependencies     #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
 module ConsumerProtocolSTM where
 
-import Data.Word
-import Data.List (tails, foldl')
+import           Data.List (foldl', tails)
+import           Data.Word
 --import Data.Maybe
-import Data.Hashable
+import           Data.Hashable
 --import qualified Data.Set as Set
-import qualified Data.Map as Map
 import           Data.Map (Map)
+import qualified Data.Map as Map
 import           Data.PriorityQueue.FingerTree (PQueue)
 import qualified Data.PriorityQueue.FingerTree as PQueue
 
-import Control.Applicative
-import Control.Monad
-import Control.Concurrent.STM (STM, retry)
-import Control.Exception (assert)
-import Control.Monad.ST.Lazy
-import Data.STRef.Lazy
-import System.Random (StdGen, mkStdGen, randomR)
+import           Control.Applicative
+import           Control.Concurrent.STM (STM, retry)
+import           Control.Exception (assert)
+import           Control.Monad
+import           Control.Monad.ST.Lazy
+import           Data.STRef.Lazy
+import           System.Random (StdGen, mkStdGen, randomR)
 
-import Test.QuickCheck
+import           Test.QuickCheck
 
-import ChainExperiment2
+import           ChainExperiment2
 
 
 --
@@ -50,7 +56,7 @@ type MaxReadBlocks = Int
 readRollForwardOnly :: ChainConsumer -> MaxReadBlocks -> STM [Block]
 readRollForwardOnly ChainConsumer{tryPeekChain, tryReadChain} maxBlocks =
     go maxBlocks
-  where 
+  where
     go 0 = return []
     go n = do
       res <- tryPeekChain

--- a/src/ConsumersAndProducers.hs
+++ b/src/ConsumersAndProducers.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module ConsumersAndProducers
   ( ConsumerHandlers
@@ -11,15 +11,12 @@ module ConsumersAndProducers
   )where
 
 import           Block (HasHeader (..))
-import           Chain
-                   ( Chain (..), ChainUpdate (..), Point (..) )
-import qualified Chain
-                   ( selectPoints, addBlock, headPoint, rollback, genesisPoint )
-import           ChainProducerState
-                   ( ChainProducerState(..), ReaderId )
-import qualified ChainProducerState
-                   ( initReader, updateReader, readerInstruction
-                   , findFirstPoint )
+import           Chain (Chain (..), ChainUpdate (..), Point (..))
+import qualified Chain (addBlock, genesisPoint, headPoint, rollback,
+                     selectPoints)
+import           ChainProducerState (ChainProducerState (..), ReaderId)
+import qualified ChainProducerState (findFirstPoint, initReader,
+                     readerInstruction, updateReader)
 import           MonadClass
 import           ProtocolInterfaces
 

--- a/src/MonadClass.hs
+++ b/src/MonadClass.hs
@@ -13,11 +13,11 @@ module MonadClass (
   module MonadSendRecv
   ) where
 
-import MonadClass.MonadSay      as MonadSay
-import MonadClass.MonadTimer    as MonadTimer
-import MonadClass.MonadProbe    as MonadProbe
-import MonadClass.MonadFork     as MonadFork
-import MonadClass.MonadConc     as MonadConc
-import MonadClass.MonadSTM      as MonadSTM
-import MonadClass.MonadSTMTimer as MonadSTMTimer
-import MonadClass.MonadSendRecv as MonadSendRecv
+import           MonadClass.MonadConc as MonadConc
+import           MonadClass.MonadFork as MonadFork
+import           MonadClass.MonadProbe as MonadProbe
+import           MonadClass.MonadSay as MonadSay
+import           MonadClass.MonadSendRecv as MonadSendRecv
+import           MonadClass.MonadSTM as MonadSTM
+import           MonadClass.MonadSTMTimer as MonadSTMTimer
+import           MonadClass.MonadTimer as MonadTimer

--- a/src/MonadClass/MonadConc.hs
+++ b/src/MonadClass/MonadConc.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE TypeFamilies #-}
 module MonadClass.MonadConc (
   MonadConc (..),
-  newEmptyMVar, 
+  newEmptyMVar,
   newMVar
   ) where
 
-import MonadClass.MonadFork
+import           MonadClass.MonadFork
 
 class MonadFork m => MonadConc m where
   type MVar m :: * -> *

--- a/src/MonadClass/MonadProbe.hs
+++ b/src/MonadClass/MonadProbe.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleInstances      #-}
-{-# LANGUAGE TypeFamilies           #-}
-{-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE TypeFamilies           #-}
 module MonadClass.MonadProbe
   ( MonadProbe (..)
   , MonadRunProbe (..)
@@ -10,15 +10,15 @@ module MonadClass.MonadProbe
 
 import qualified Control.Concurrent.STM.TVar as STM
 import           Control.Monad (void)
-import System.Clock (Clock (Monotonic), TimeSpec, getTime, toNanoSecs)
 import           Control.Monad.Free (Free)
 import qualified Control.Monad.Free as Free
 import           Control.Monad.ST.Lazy
+import           System.Clock (Clock (Monotonic), TimeSpec, getTime, toNanoSecs)
 
 import           Data.STRef.Lazy
 
-import           MonadClass.MonadTimer
 import           MonadClass.MonadSTM (atomically)
+import           MonadClass.MonadTimer
 
 import           Sim (SimF)
 import qualified Sim

--- a/src/MonadClass/MonadSTM.hs
+++ b/src/MonadClass/MonadSTM.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE TypeFamilies           #-}
-{-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE TypeFamilies           #-}
 module MonadClass.MonadSTM
   ( MonadSTM (..) ) where
 
 import qualified Control.Concurrent.STM.TVar as STM
 import qualified Control.Monad.STM as STM
 
-import MonadClass.MonadFork
+import           MonadClass.MonadFork
 
 class (MonadFork m, Monad stm) => MonadSTM m stm | m -> stm, stm -> m where
   type TVar m :: * -> *
@@ -26,8 +26,8 @@ class (MonadFork m, Monad stm) => MonadSTM m stm | m -> stm, stm -> m where
 --orElse       :: stm a -> stm a -> stm a --TODO
 
   check        :: Bool -> stm ()
-  check True  = return ()
-  check _     = retry
+  check True = return ()
+  check _    = retry
 
 instance MonadSTM IO STM.STM where
   type TVar IO = STM.TVar

--- a/src/MonadClass/MonadSTMTimer.hs
+++ b/src/MonadClass/MonadSTMTimer.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TypeFamilies           #-}
-{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
 module MonadClass.MonadSTMTimer
   ( MonadSTMTimer (..)
   ) where
@@ -7,12 +7,11 @@ module MonadClass.MonadSTMTimer
 import qualified Control.Concurrent.STM.TVar as STM
 import qualified Control.Monad.STM as STM
 
-import qualified GHC.Event as GHC
-                   ( TimeoutKey, getSystemTimerManager
-                   , registerTimeout, unregisterTimeout, updateTimeout)
+import qualified GHC.Event as GHC (TimeoutKey, getSystemTimerManager,
+                     registerTimeout, unregisterTimeout, updateTimeout)
 
-import MonadClass.MonadSTM
-import MonadClass.MonadTimer
+import           MonadClass.MonadSTM
+import           MonadClass.MonadTimer
 
 data TimeoutState = TimeoutPending | TimeoutFired | TimeoutCancelled
 

--- a/src/MonadClass/MonadTimer.hs
+++ b/src/MonadClass/MonadTimer.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilies     #-}
 module MonadClass.MonadTimer
   ( TimeMeasure (..)
   , MonadTimer (..)

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -1,22 +1,23 @@
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE NamedFieldPuns #-}
 module Node where
 
-import Data.List hiding (inits)
-import Data.Semigroup (Semigroup (..))
-import Data.Maybe (catMaybes)
-import Data.Functor (($>))
-import Data.Tuple (swap)
-import Control.Monad
-import Control.Exception (assert)
+import           Control.Exception (assert)
+import           Control.Monad
+import           Data.Functor (($>))
+import           Data.List hiding (inits)
+import           Data.Maybe (catMaybes)
+import           Data.Semigroup (Semigroup (..))
+import           Data.Tuple (swap)
 
-import MonadClass hiding (sendMsg, recvMsg)
-import Block
-import qualified Chain
+import           Block
 import           Chain (Chain (..), Point)
-import Protocol
-import ConsumersAndProducers
-import ChainProducerState (ChainProducerState (..), ReaderId, initChainProducerState, producerChain, switchFork)
+import qualified Chain
+import           ChainProducerState (ChainProducerState (..), ReaderId,
+                     initChainProducerState, producerChain, switchFork)
+import           ConsumersAndProducers
+import           MonadClass hiding (recvMsg, sendMsg)
+import           Protocol
 
 
 
@@ -37,7 +38,7 @@ longestChainSelection candidateChainVars cpsVar =
       candidateChains <- mapM readTVar candidateChainVars
       cps@ChainProducerState{chainState = chain} <- readTVar cpsVar
       let -- using foldl' since @Chain.selectChain@ is left biased
-          chain' = foldl' Chain.selectChain chain (catMaybes candidateChains) 
+          chain' = foldl' Chain.selectChain chain (catMaybes candidateChains)
       if Chain.headPoint chain' == Chain.headPoint chain
         then retry
         else writeTVar cpsVar (switchFork chain' cps)
@@ -192,7 +193,7 @@ createTwoWaySubscriptionChannels trDelay1 trDelay2 = do
 
 
 -- | Generate a block from a given chain.  Each @block@ is produced at
--- @slotDuration * blockSlot block@ time. 
+-- @slotDuration * blockSlot block@ time.
 --
 -- TODO: invariant: generates blocks for current slots.
 blockGenerator :: forall block m stm.
@@ -326,7 +327,7 @@ relayNode nid chans = do
         (loggingSend (ProducerId nid pid) (sendMsg chan))
         (loggingRecv (ProducerId nid pid) (recvMsg chan))
 
--- | Core node simulation.  Given a chain it will generate a @block@ at its 
+-- | Core node simulation.  Given a chain it will generate a @block@ at its
 -- slot time (i.e. @slotDuration * blockSlot block@).  When the node finds out
 -- that the slot for which it was supposed to generate a block was already
 -- occupied, it will replace it with its block.

--- a/src/Pipe.hs
+++ b/src/Pipe.hs
@@ -1,30 +1,29 @@
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Pipe where
 
+import           Control.Concurrent (forkIO, killThread, threadDelay)
+import           Control.Concurrent.STM
 import           Control.Monad
 import           Control.Monad.IO.Class
-import           Control.Monad.ST (stToIO, RealWorld)
-import           Control.Concurrent.STM
-import           Control.Concurrent (forkIO, killThread, threadDelay)
+import           Control.Monad.ST (RealWorld, stToIO)
 
 import           Chain (Chain, ChainUpdate)
 import qualified Chain
-import           Serialise
-import           ProtocolInterfaces
-import           Protocol
+import           ChainProducerState as ChainProducer (ChainProducerState,
+                     ReaderId, applyChainUpdate, initChainProducerState)
 import           ConsumersAndProducers
-import           ChainProducerState as ChainProducer
-                   ( ChainProducerState, ReaderId
-                   , initChainProducerState, applyChainUpdate )
+import           Protocol
+import           ProtocolInterfaces
+import           Serialise
 
-import qualified Data.ByteString         as  BS
-import qualified Data.ByteString.Builder as  BS
-import qualified Data.ByteString.Lazy.Internal as LBS (smallChunkSize)
-import qualified Codec.CBOR.Read  as CBOR
+import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Write as CBOR
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Lazy.Internal as LBS (smallChunkSize)
 
 import           System.IO (Handle, hFlush)
 import           System.Process (createPipe)

--- a/src/Protocol.hs
+++ b/src/Protocol.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Protocol
   ( MsgConsumer(..)
@@ -16,7 +16,8 @@ import           Control.Monad
 
 import           Chain (ChainUpdate (..), Point (..))
 import           MonadClass
-import           ProtocolInterfaces (ConsumerHandlers(..), ProducerHandlers(..))
+import           ProtocolInterfaces (ConsumerHandlers (..),
+                     ProducerHandlers (..))
 import           Serialise
 
 {-# ANN module "HLint: ignore Use readTVarIO" #-}
@@ -137,7 +138,7 @@ producerSideProtocol1 ProducerHandlers{..} send recv =
       changed <- improveReadPoint r points
       case changed of
         Just (pt, tip) -> send (MsgIntersectImproved pt tip)
-        Nothing -> send MsgIntersectUnchanged
+        Nothing        -> send MsgIntersectUnchanged
 
     updateMsg (AddBlock b) = MsgRollForward b
     updateMsg (RollBack p) = MsgRollBackward p

--- a/src/ProtocolInterfaces.hs
+++ b/src/ProtocolInterfaces.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes     #-}
 module ProtocolInterfaces (
     ConsumerHandlers(..)
   , ProducerHandlers(..)
@@ -7,7 +7,7 @@ module ProtocolInterfaces (
   , liftProducerHandlers
   ) where
 
-import Chain (ChainUpdate (..), Point (..))
+import           Chain (ChainUpdate (..), Point (..))
 
 
 -- | The interface used on the consumer side of the chain consumer protocol
@@ -31,16 +31,16 @@ data ConsumerHandlers block m = ConsumerHandlers {
 -- to query and read the producers chain.
 --
 data ProducerHandlers block m r = ProducerHandlers {
-       newReader             :: m r,
+       newReader          :: m r,
        -- ^ allocate new reader state.  The reference implementation is using
        -- @'ChainProducerState.initReader'@ to mutate its internal state.
-       improveReadPoint      :: r -> [Point] -> m (Maybe (Point, Point)),
+       improveReadPoint   :: r -> [Point] -> m (Maybe (Point, Point)),
        -- ^ find the most optimal intersection between received list of
        -- @'Point'@s and producers chain.  The second point is the current tip.
-       tryReadChainUpdate    :: r -> m (Maybe (ChainUpdate block)),
+       tryReadChainUpdate :: r -> m (Maybe (ChainUpdate block)),
        -- ^ compute chain update for a given reader.  This is a non blocking
        -- operation.
-       readChainUpdate       :: r -> m (ChainUpdate block)
+       readChainUpdate    :: r -> m (ChainUpdate block)
        -- ^ compute chain update for a given reader.  This maybe block, awaiting
        -- for changes of its internal state (producer's chain).
      }

--- a/src/Serialise.hs
+++ b/src/Serialise.hs
@@ -19,14 +19,14 @@ module Serialise (
 
 import qualified Data.ByteString.Lazy as LBS
 #if __GLASGOW_HASKELL__ < 804
-import Data.Monoid
+import           Data.Monoid
 #endif
-import Codec.CBOR.Encoding hiding (Encoding(..), Tokens(..))
-import Codec.CBOR.Encoding        (Encoding)
-import Codec.CBOR.Decoding hiding (DecodeAction(..), TokenType(..))
-import Codec.CBOR.FlatTerm
-import Codec.CBOR.Write (toLazyByteString)
-import Codec.CBOR.Read  (deserialiseFromBytes, DeserialiseFailure)
+import           Codec.CBOR.Decoding hiding (DecodeAction (..), TokenType (..))
+import           Codec.CBOR.Encoding hiding (Encoding (..), Tokens (..))
+import           Codec.CBOR.Encoding (Encoding)
+import           Codec.CBOR.FlatTerm
+import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
+import           Codec.CBOR.Write (toLazyByteString)
 
 
 class Serialise a where

--- a/src/Sim.hs
+++ b/src/Sim.hs
@@ -38,12 +38,12 @@ import           Control.Monad.Free as Free
 import           Control.Monad.ST.Lazy
 import           Data.STRef.Lazy
 
-import           MonadClass.MonadSay
 import           MonadClass.MonadFork
+import           MonadClass.MonadSay
+import           MonadClass.MonadSendRecv
 import           MonadClass.MonadSTM hiding (TVar)
 import qualified MonadClass.MonadSTM as MonadSTM
 import           MonadClass.MonadTimer
-import           MonadClass.MonadSendRecv
 
 {-# ANN module "HLint: ignore Use readTVarIO" #-}
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,12 +1,12 @@
 module Main (main) where
 
-import Test.Tasty
+import           Test.Tasty
 
 import qualified Test.Chain (tests)
 import qualified Test.ChainProducerState (tests)
-import qualified Test.Sim (tests)
 import qualified Test.Node (tests)
 import qualified Test.Pipe (tests)
+import qualified Test.Sim (tests)
 
 main :: IO ()
 main = defaultMain tests

--- a/test/Test/Chain.hs
+++ b/test/Test/Chain.hs
@@ -9,16 +9,16 @@ module Test.Chain
   ) where
 
 import           Block
-import           Chain ( Chain (..), Point (..), ChainUpdate (..), genesisPoint)
+import           Chain (Chain (..), ChainUpdate (..), Point (..), genesisPoint)
 import qualified Chain
 import           Serialise (prop_serialise)
 
 import qualified Data.List as L
-import Data.Maybe (listToMaybe)
+import           Data.Maybe (listToMaybe)
 
-import Test.QuickCheck
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.QuickCheck (testProperty)
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
 
 --
 -- The list of all tests

--- a/test/Test/ChainProducerState.hs
+++ b/test/Test/ChainProducerState.hs
@@ -1,19 +1,20 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 module Test.ChainProducerState (tests) where
 
 import           Data.List (unfoldr)
 
-import Test.QuickCheck
-import Test.Tasty
-import Test.Tasty.QuickCheck
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
 
-import           Chain ( Chain, Block, Point(..), ChainUpdate(..)
-                       , genesisPoint, headPoint , pointOnChain )
+import           Chain (Block, Chain, ChainUpdate (..), Point (..),
+                     genesisPoint, headPoint, pointOnChain)
 import qualified Chain
-import ChainProducerState
+import           ChainProducerState
 
-import           Test.Chain
-                       ( TestBlockChainAndUpdates(..), TestBlockChain(..)
-                       , TestChainFork(..), mkRollbackPoint )
+import           Test.Chain (TestBlockChain (..), TestBlockChainAndUpdates (..),
+                     TestChainFork (..), mkRollbackPoint)
 
 tests :: TestTree
 tests =
@@ -183,7 +184,7 @@ genReaderState n c = do
 fixupReaderStates :: [ReaderState] -> [ReaderState]
 fixupReaderStates = go 0
   where
-  go _ [] = []
+  go _ []       = []
   go n (r : rs) = r { readerId = n } : go (n + 1) rs
 
 instance Arbitrary ChainProducerStateTest where

--- a/test/Test/Node.hs
+++ b/test/Test/Node.hs
@@ -1,35 +1,35 @@
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 module Test.Node where
 
-import Control.Monad (forever, forM, forM_, replicateM)
-import Control.Monad.ST.Lazy (runST)
-import Control.Monad.State (lift, modify', execStateT)
-import Data.Array
-import Data.Functor (void)
-import Data.Graph
-import Data.List (foldl')
-import Data.Maybe (isNothing, listToMaybe)
-import Data.Semigroup ((<>))
-import Data.Tuple (swap)
+import           Control.Monad (forM, forM_, forever, replicateM)
+import           Control.Monad.ST.Lazy (runST)
+import           Control.Monad.State (execStateT, lift, modify')
+import           Data.Array
+import           Data.Functor (void)
+import           Data.Graph
+import           Data.List (foldl')
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (isNothing, listToMaybe)
+import           Data.Semigroup ((<>))
+import           Data.Tuple (swap)
 
-import Test.QuickCheck
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.QuickCheck (testProperty)
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
 
-import Block
-import qualified Chain
+import           Block
 import           Chain (Chain (..))
-import Node
-import MonadClass
+import qualified Chain
+import           MonadClass
+import           Node
+import           Protocol (MsgConsumer, MsgProducer)
 import qualified Sim
-import Protocol (MsgProducer, MsgConsumer)
 
-import Test.Sim (TestThreadGraph (..))
-import Test.Chain (TestBlockChain (..), TestChainFork (..))
+import           Test.Chain (TestBlockChain (..), TestChainFork (..))
+import           Test.Sim (TestThreadGraph (..))
 
 tests :: TestTree
 tests =
@@ -80,7 +80,7 @@ test_blockGenerator chain slotDuration = isValid <$> withProbe (experiment slotD
       fork $ forever $ do
         b <- atomically $ getBlock v
         probeOutput p b
-      
+
 prop_blockGenerator_ST :: TestBlockChain -> Positive Rational -> Bool
 prop_blockGenerator_ST (TestBlockChain chain) (Positive slotDuration) = runST $ test_blockGenerator chain (Sim.VTimeDuration slotDuration)
 
@@ -308,7 +308,7 @@ instance Arbitrary TestNetworkGraph where
         c   <- oneof (map return vs)
         let cs' = if null cs then [c] else cs
         g'' <- connectGraphG g'
-        chains <- map getTestBlockChain <$> replicateM (length cs') arbitrary 
+        chains <- map getTestBlockChain <$> replicateM (length cs') arbitrary
         return $ TestNetworkGraph g'' (zip cs' chains)
      where
         genCoreNodes :: [Int] -> Gen [Int]
@@ -379,7 +379,7 @@ data NetworkTest = NetworkTest
 
 instance Arbitrary NetworkTest where
   arbitrary = NetworkTest <$> arbitrary <*> duration <*> duration <*> duration
-    where 
+    where
       duration = Sim.VTimeDuration . getPositive <$> arbitrary
 
 prop_networkGraph :: NetworkTest

--- a/test/Test/Pipe.hs
+++ b/test/Test/Pipe.hs
@@ -1,17 +1,17 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Pipe (tests) where
 
-import           Block (Block, Slot(..), HeaderHash(..))
-import           Chain (Point(..), Chain(..))
-import           Protocol
+import           Block (Block, HeaderHash (..), Slot (..))
+import           Chain (Chain (..), Point (..))
 import           Pipe (demo2)
+import           Protocol
 import           Serialise (prop_serialise)
 
-import Test.Chain (TestBlockChainAndUpdates(..), genBlockChain)
+import           Test.Chain (TestBlockChainAndUpdates (..), genBlockChain)
 
-import Test.QuickCheck
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.QuickCheck (testProperty)
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
 
 --
 -- The list of all tests

--- a/test/Test/Sim.hs
+++ b/test/Test/Sim.hs
@@ -1,22 +1,22 @@
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE FlexibleContexts    #-}
 module Test.Sim
     ( tests
     , TestThreadGraph (..)
     ) where
 
-import Data.Array
-import Data.Graph
-import Data.List (sortBy)
-import Control.Monad
-import Control.Monad.ST.Lazy (runST)
+import           Control.Monad
+import           Control.Monad.ST.Lazy (runST)
+import           Data.Array
+import           Data.Graph
+import           Data.List (sortBy)
 
-import Test.QuickCheck
-import Test.Tasty
-import Test.Tasty.QuickCheck
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
 
-import MonadClass
+import           MonadClass
 import qualified Sim
 
 tests :: TestTree
@@ -145,13 +145,13 @@ test_timers :: forall m n stm.
                )
             => [Duration (Time m)]
             -> n Property
-test_timers xs = 
+test_timers xs =
     label (lbl xs) . isValid <$> withProbe experiment
   where
     countUnique :: Eq a => [a] -> Int
     countUnique [] = 0
     countUnique (a:as) =
-      let as' = filter (== a) as 
+      let as' = filter (== a) as
       in 1 + countUnique as'
 
     lbl :: Eq a => [a] -> String


### PR DESCRIPTION
Every .hs file in the repo was using a different import style, sometimes
multiple within one file. Also, they were not sorted. This was going to lead to
unnecessary merge conflicts; this PR runs stylish-haskell with the settings we
use in cardano-sl.

It also orders the modules/extensions in .cabal alphabetically to further
reduce merge conflicts, and makes the test use the library rather than the src/
directory directly.