### PR TITLE
Stylish-haskell, ordering in .cabal

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,4 @@
 packages: .
+
+package ouroboros-network
+  tests: True

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -66,7 +66,7 @@ library
                        TupleSections,
                        TypeApplications,
                        TypeFamilies,
-                       TypeInType,
+                       TypeInType
   build-depends:       base         >=4.9 && <4.12,
                        array,
                        bytestring   >=0.10 && <0.11,


### PR DESCRIPTION
Every .hs file in the repo was using a different import style, sometimes
multiple within one file. Also, they were not sorted. This was going to lead to
unnecessary merge conflicts; this PR runs stylish-haskell with the settings we
use in cardano-sl.

It also orders the modules/extensions in .cabal alphabetically to further
reduce merge conflicts, and makes the test use the library rather than the src/
directory directly.