### PR TITLE
Add tests for frequencySt

### DIFF
--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -97,6 +97,7 @@ test-suite tests
                        Test.Sim
                        Test.GlobalState
                        Test.ArbitrarySt
+                       Test.Combinators
   default-language:    Haskell2010
   default-extensions:  NamedFieldPuns
   build-depends:       base,

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,6 +6,7 @@ import qualified Test.Chain (tests)
 import qualified Test.ChainProducerState (tests)
 import qualified Test.Sim (tests)
 import qualified Test.Node (tests)
+import qualified Test.Combinators (tests)
 
 main :: IO ()
 main = defaultMain tests
@@ -17,4 +18,5 @@ tests =
   , Test.ChainProducerState.tests
   , Test.Sim.tests
   , Test.Node.tests
+  , Test.Combinators.tests
   ]

--- a/test/Test/Chain.hs
+++ b/test/Test/Chain.hs
@@ -13,6 +13,8 @@ module Test.Chain
   , TestBlockChain(..)
   , TestChainFork(..)
   , mkRollbackPoint
+  , frequencySt
+  , genNonNegative
   ) where
 
 import           Block

--- a/test/Test/Combinators.hs
+++ b/test/Test/Combinators.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE FunctionalDependencies #-}
+module Test.Combinators (
+    tests
+    ) where
+
+import Control.Monad.State
+
+import Ouroboros
+import Test.GlobalState (initialBftState)
+
+import Test.QuickCheck
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+import Test.Chain (frequencySt, genNonNegative)
+import Test.ArbitrarySt
+
+
+tests :: TestTree
+tests =
+  testGroup "Combinators"
+  [ testGroup "frequencySt"
+    [ testProperty "correctly threads the state across" $ prop_frequencySt_state
+    , testProperty "picks different frequencies" $ prop_frequencySt_choices
+    ]
+  ]
+
+
+prop_frequencySt_state :: Property
+prop_frequencySt_state = property $ do
+    -- Creates a small frequency list, each of which increment the state by 1
+    -- and yield the given frequency.
+    n <- choose (1, 6)
+    let xs = map (\freq -> (freq, modify (+1) >> return freq)) [0..n]
+    -- Start from an initial non-negative state and assert that frequencySt
+    -- /does/ modify the state.
+    initialState <- genNonNegative
+    finalState <- execStateT (frequencySt xs) initialState
+    return $   counterexample "Final state /= initialState" (finalState =/= initialState)
+          .&&. counterexample "State is threaded" (finalState === initialState + 1)
+
+
+newtype Choice = Choice Int deriving (Show, Eq)
+
+instance ArbitrarySt 'OuroborosBFT Choice where
+    arbitrarySt = frequencySt [
+        (1, return $ Choice 1)
+      , (2, return $ Choice 2)
+      , (3, return $ Choice 3)
+      ]
+
+prop_frequencySt_choices :: Property
+prop_frequencySt_choices = 
+  forAll (evalStateT arbitrarySt initialBftState) $ \(Choice i) ->
+         classify (i == 1) "frequency == 1" True
+    .&&. classify (i == 2) "frequency == 2" True
+    .&&. classify (i == 3) "frequency == 3" True
+
+


### PR DESCRIPTION
This commit adds two tests for frequencySt (our own flavour of
Test.QuickCheck.frequency): one tests that the state is correctly
threaded through, another one that we do still pick different elements
at different frequencies, using `classify`.

Running the properties would result in something like:

```
  Combinators
    frequencySt
      correctly threads the state across:     OK
        +++ OK, passed 100 tests.
      picks different frequencies:            OK
        +++ OK, passed 100 tests:
        52% frequency == 3
        35% frequency == 2
        13% frequency == 1
```