### PR TITLE
Test dependent functions

### DIFF
--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -39,6 +39,7 @@ library
                        ProtocolInterfaces
                        Serialise
                        Sim
+                       Util.Singletons
   other-modules:
 -- Old experiments, not currently building:
 --                     Types
@@ -96,7 +97,9 @@ test-suite tests
   main-is:             Main.hs
   other-modules:       Test.Chain
                        Test.ChainProducerState
+                       Test.DepFn
                        Test.Node
+                       Test.Ouroboros
                        Test.Pipe
                        Test.Sim
   default-language:    Haskell2010

--- a/src/Block.hs
+++ b/src/Block.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 
 -- | Reference implementation of a representation of a block in a block chain.
 --
@@ -38,7 +39,9 @@ data Block (p :: OuroborosProtocol) = Block {
        blockHeader :: BlockHeader p,
        blockBody   :: BlockBody
      }
-  deriving (Show, Eq)
+
+deriving instance KnownOuroborosProtocol p => Show (Block p)
+deriving instance KnownOuroborosProtocol p => Eq   (Block p)
 
 -- | A block header. It retains simplified versions of all the essential
 -- elements.
@@ -51,7 +54,9 @@ data BlockHeader (p :: OuroborosProtocol) = BlockHeader {
        headerSigner   :: BlockSigner, -- ^ Who signed this block
        headerBodyHash :: BodyHash     -- ^ The hash of the corresponding block body
      }
-  deriving (Show, Eq)
+
+deriving instance KnownOuroborosProtocol p => Show (BlockHeader p)
+deriving instance KnownOuroborosProtocol p => Eq   (BlockHeader p)
 
 -- | A block body.
 --

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -329,7 +329,8 @@ relayNode nid chans = do
 -- occupied, it will replace it with its block.
 --
 coreNode :: forall p m stm.
-        ( MonadSTM m stm
+        ( KnownOuroborosProtocol p
+        , MonadSTM m stm
         , MonadTimer m
         , MonadSay m
         )

--- a/src/Ouroboros.hs
+++ b/src/Ouroboros.hs
@@ -1,5 +1,10 @@
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 module Ouroboros (
     -- * Typed used across all protocols
@@ -7,10 +12,16 @@ module Ouroboros (
   , NodeId(..)
     -- * Generalize over the Ouroboros protocols
   , OuroborosProtocol(..)
+  , Sing(..)
+  , KnownOuroborosProtocol
+  , singKnownOuroborosProtocol
   ) where
 
 import           Data.Hashable
 import           GHC.Generics
+import           Test.QuickCheck
+
+import           Util.Singletons
 
 {-------------------------------------------------------------------------------
   Types used across all protocols
@@ -27,9 +38,50 @@ data NodeId = CoreId Int
 instance Hashable NodeId -- let generic instance do the job
 
 {-------------------------------------------------------------------------------
-  Generalize over the various Ouroboros protocols
+  Ouroboros protocol and its lifted version
 -------------------------------------------------------------------------------}
 
 data OuroborosProtocol =
     OuroborosBFT
   | OuroborosPraos
+
+instance Arbitrary OuroborosProtocol where
+  arbitrary = elements [OuroborosBFT] -- only BFT implemented right now
+
+data instance Sing (p :: OuroborosProtocol) where
+  SingBFT   :: Sing 'OuroborosBFT
+  SingPraos :: Sing 'OuroborosPraos
+
+instance SingI 'OuroborosBFT   where sing = SingBFT
+instance SingI 'OuroborosPraos where sing = SingPraos
+
+instance SingKind OuroborosProtocol where
+  type Demote OuroborosProtocol = OuroborosProtocol
+
+  fromSing SingBFT   = OuroborosBFT
+  fromSing SingPraos = OuroborosPraos
+
+  toSing OuroborosBFT   = SomeSing SingBFT
+  toSing OuroborosPraos = SomeSing SingPraos
+
+{-------------------------------------------------------------------------------
+  Generalize over the various Ouroboros protocols
+-------------------------------------------------------------------------------}
+
+class KnownOuroborosProtocol (p :: OuroborosProtocol) where
+
+singKnownOuroborosProtocol :: Sing p -> (KnownOuroborosProtocol p => r) -> r
+singKnownOuroborosProtocol SingBFT   k = k
+singKnownOuroborosProtocol SingPraos k = k
+
+{-------------------------------------------------------------------------------
+  BFT
+-------------------------------------------------------------------------------}
+
+instance KnownOuroborosProtocol 'OuroborosBFT where
+
+{-------------------------------------------------------------------------------
+  Praos
+-------------------------------------------------------------------------------}
+
+instance KnownOuroborosProtocol 'OuroborosPraos where

--- a/src/Util/Singletons.hs
+++ b/src/Util/Singletons.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE PolyKinds              #-}
+{-# LANGUAGE RankNTypes             #-}
+{-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeInType             #-}
+{-# LANGUAGE TypeOperators          #-}
+
+-- | Singletons
+--
+-- This provides the core of the 'singletons' package, using the same name,
+-- but without pulling in all the dependencies and craziness.
+module Util.Singletons (
+    Sing(..)
+  , SingI(..)
+  , SomeSing(..)
+  , withSomeSing
+  , SingKind(..)
+  ) where
+
+import           Data.Kind (Type)
+
+-- | Data family of singletons
+data family Sing (a :: k)
+
+-- | Singletons for lists
+--
+-- NOTE: Unlike the singletons library, we do /not/ require instances for the
+-- elements of the list.
+data instance Sing (xs :: [k]) where
+  SNil  :: Sing '[]
+  SCons :: Sing xs -> Sing (x ': xs)
+
+class SingI (a :: k) where
+  sing :: Sing a
+
+instance             SingI '[]       where sing = SNil
+instance SingI xs => SingI (x ': xs) where sing = SCons sing
+
+data SomeSing k where
+  SomeSing :: Sing (a :: k) -> SomeSing k
+
+withSomeSing :: forall k r. SingKind k
+             => Demote k
+             -> (forall (a :: k). Sing a -> r)
+             -> r
+withSomeSing d k = case toSing @k d :: SomeSing k of
+                     SomeSing s -> k s
+
+class SingKind k where
+  type Demote k = (r :: Type) | r -> k
+
+  fromSing :: Sing (a :: k) -> Demote k
+  toSing :: Demote k -> SomeSing k

--- a/test/Test/ChainProducerState.hs
+++ b/test/Test/ChainProducerState.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TypeOperators  #-}
 
 module Test.ChainProducerState (tests) where
 
@@ -12,9 +13,12 @@ import           Chain (Block, Chain, ChainUpdate (..), Point (..),
                      genesisPoint, headPoint, pointOnChain)
 import qualified Chain
 import           ChainProducerState
+import           Ouroboros
 
 import           Test.Chain (TestBlockChain (..), TestBlockChainAndUpdates (..),
                      TestChainFork (..), mkRollbackPoint)
+import           Test.DepFn
+import           Test.Ouroboros
 
 tests :: TestTree
 tests =
@@ -42,16 +46,16 @@ tests =
 -- | Check that readers start in the expected state, at the right point and
 -- in the rollback state.
 --
-prop_init_lookup :: ChainProducerStateTest p -> Bool
-prop_init_lookup (ChainProducerStateTest c _ p) =
+prop_init_lookup :: ChainProducerStateTest :-> Bool
+prop_init_lookup = simpleProp $ \_ (ChainProducerStateTest c _ p) ->
     let (c', rid) = initReader p c in
     lookupReader c' rid == ReaderState p ReaderBackTo rid
 
 -- | As above but check that when we move the reader on by one, from the
 -- rollback state, they stay at the same point but are now in the forward state.
 --
-prop_init_next_lookup :: ChainProducerStateTest p -> Bool
-prop_init_next_lookup (ChainProducerStateTest c _ p) =
+prop_init_next_lookup :: ChainProducerStateTest :-> Bool
+prop_init_next_lookup = simpleProp $ \_ (ChainProducerStateTest c _ p) ->
     let (c', rid)     = initReader p c
         Just (u, c'') = readerInstruction rid c'
     in u == RollBack p
@@ -60,16 +64,16 @@ prop_init_next_lookup (ChainProducerStateTest c _ p) =
 -- | Check that after moving the reader point that the reader is in the
 -- expected state, at the right point and in the rollback state.
 --
-prop_update_lookup :: ChainProducerStateTest p -> Bool
-prop_update_lookup (ChainProducerStateTest c rid p) =
+prop_update_lookup :: ChainProducerStateTest :-> Bool
+prop_update_lookup = simpleProp $ \_ (ChainProducerStateTest c rid p) ->
     let c' = updateReader rid p c in
     lookupReader c' rid == ReaderState p ReaderBackTo rid
 
 -- | As above but check that when we move the reader on by one, from the
 -- rollback state, they stay at the same point but are now in the forward state.
 --
-prop_update_next_lookup :: ChainProducerStateTest p -> Bool
-prop_update_next_lookup (ChainProducerStateTest c rid p) =
+prop_update_next_lookup :: ChainProducerStateTest :-> Bool
+prop_update_next_lookup = simpleProp $ \_ (ChainProducerStateTest c rid p) ->
     let c'            = updateReader rid p c
         Just (u, c'') = readerInstruction rid c'
     in u == RollBack p
@@ -83,8 +87,8 @@ prop_update_next_lookup (ChainProducerStateTest c rid p) =
 -- The limitation of this test is that it applies all the updates to the
 -- producer first and then syncronises without changing the producer.
 --
-prop_producer_sync1 :: TestBlockChainAndUpdates p -> Bool
-prop_producer_sync1 (TestBlockChainAndUpdates c us) =
+prop_producer_sync1 :: TestBlockChainAndUpdates :-> Bool
+prop_producer_sync1 = simpleProp $ \_ (TestBlockChainAndUpdates c us) ->
     let producer0        = initChainProducerState c
         (producer1, rid) = initReader (Chain.headPoint c) producer0
         Just producer    = applyChainUpdates us producer1
@@ -101,8 +105,8 @@ prop_producer_sync1 (TestBlockChainAndUpdates c us) =
 -- interleaving of applying changes to the producer and doing syncronisation
 -- steps between the producer and consumer.
 --
-prop_producer_sync2 :: TestBlockChainAndUpdates p -> [Bool] -> Bool
-prop_producer_sync2 (TestBlockChainAndUpdates chain0 us0) choices =
+prop_producer_sync2 :: TestBlockChainAndUpdates :-> ([Bool] -> Bool)
+prop_producer_sync2 = simpleProp $ \_ (TestBlockChainAndUpdates chain0 us0) choices ->
     let producer0        = initChainProducerState chain0
         (producer1, rid) = initReader (Chain.headPoint chain0) producer0
 
@@ -133,8 +137,8 @@ prop_producer_sync2 (TestBlockChainAndUpdates chain0 us0) choices =
         Just (u, p') -> go rid p' c' [] []
           where Just c' = Chain.applyChainUpdate u c
 
-prop_switchFork :: ChainProducerStateForkTest p -> Bool
-prop_switchFork (ChainProducerStateForkTest cps f) =
+prop_switchFork :: ChainProducerStateForkTest :-> Bool
+prop_switchFork = simpleProp $ \_ (ChainProducerStateForkTest cps f) ->
   let cps' = switchFork f cps
   in
       invChainProducerState cps'
@@ -165,6 +169,9 @@ data ChainProducerStateTest p
     = ChainProducerStateTest (ChainProducerState (Block p)) ReaderId Point
   deriving Show
 
+instance SingShow ChainProducerStateTest where
+  singShow s = singKnownOuroborosProtocol s $ show
+
 genReaderState :: Int   -- ^ length of the chain
                -> Chain (Block p)
                -> Gen ReaderState
@@ -187,9 +194,9 @@ fixupReaderStates = go 0
   go _ []       = []
   go n (r : rs) = r { readerId = n } : go (n + 1) rs
 
-instance Arbitrary (ChainProducerStateTest p) where
-  arbitrary = do
-    TestBlockChain c <- arbitrary
+instance SingArbitrary ChainProducerStateTest where
+  singArbitrary protocol = do
+    TestBlockChain c <- singArbitrary protocol
     let n = Chain.length c
     rs <- fixupReaderStates <$> listOf1 (genReaderState n c)
     rid <- choose (0, length rs - 1)
@@ -202,25 +209,28 @@ data ChainProducerStateForkTest p
     = ChainProducerStateForkTest (ChainProducerState (Block p)) (Chain (Block p))
   deriving Show
 
-instance Arbitrary (ChainProducerStateForkTest p) where
-  arbitrary = do
-    TestChainFork _ c f <- arbitrary
+instance SingShow ChainProducerStateForkTest where
+  singShow s = singKnownOuroborosProtocol s $ show
+
+instance SingArbitrary ChainProducerStateForkTest where
+  singArbitrary p = do
+    TestChainFork _ c f <- singArbitrary p
     let l = Chain.length c
     rs <- fixupReaderStates <$> listOf (genReaderState l c)
     return $ ChainProducerStateForkTest (ChainProducerState c rs) f
 
-  shrink (ChainProducerStateForkTest (ChainProducerState c rs) f)
+  singShrink p (ChainProducerStateForkTest (ChainProducerState c rs) f)
     -- shrink readers
      = [ ChainProducerStateForkTest (ChainProducerState c rs') f
        | rs' <- shrinkList (const []) rs
        ]
     -- shrink the fork chain
     ++ [ ChainProducerStateForkTest (ChainProducerState c rs) f'
-       | TestBlockChain f' <- shrink (TestBlockChain f)
+       | TestBlockChain f' <- singShrink p (TestBlockChain f)
        ]
     -- shrink chain and fix up readers
     ++ [ ChainProducerStateForkTest (ChainProducerState c' (fixupReaderPointer c' `map` rs)) f
-       | TestBlockChain c' <- shrink (TestBlockChain c)
+       | TestBlockChain c' <- singShrink p (TestBlockChain c)
        ]
     where
       fixupReaderPointer :: Chain (Block p) -> ReaderState -> ReaderState
@@ -229,12 +239,12 @@ instance Arbitrary (ChainProducerStateForkTest p) where
           then r
           else r { readerPoint = headPoint c' }
 
-prop_arbitrary_ChainProducerStateForkTest :: ChainProducerStateForkTest p -> Bool
-prop_arbitrary_ChainProducerStateForkTest (ChainProducerStateForkTest c f) =
+prop_arbitrary_ChainProducerStateForkTest :: ChainProducerStateForkTest :-> Bool
+prop_arbitrary_ChainProducerStateForkTest = simpleProp $ \_ (ChainProducerStateForkTest c f) ->
     invChainProducerState c && Chain.valid f
 
-prop_shrink_ChainProducerStateForkTest :: ChainProducerStateForkTest p -> Bool
-prop_shrink_ChainProducerStateForkTest c =
+prop_shrink_ChainProducerStateForkTest :: ChainProducerStateForkTest :-> Bool
+prop_shrink_ChainProducerStateForkTest = simpleProp $ \p c ->
     and [ invChainProducerState c' && Chain.valid f
-        | ChainProducerStateForkTest c' f <- shrink c
+        | ChainProducerStateForkTest c' f <- singShrink p c
         ]

--- a/test/Test/DepFn.hs
+++ b/test/Test/DepFn.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeInType           #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Testing dependent functions
+module Test.DepFn (
+    -- * Infrastructure: generic
+    All
+    -- * Testing dependent functions
+  , DepArgs(..)
+  , DepFn(..)
+  , SingArbitrary(..)
+  , SingShow(..)
+  ) where
+
+import           Data.Kind (Constraint, Type)
+import           Test.QuickCheck
+
+import           Util.Singletons
+
+{-------------------------------------------------------------------------------
+  Generic auxiliary
+-------------------------------------------------------------------------------}
+
+type family All (f :: k -> Constraint) (xs :: [k]) :: Constraint where
+  All _ '[]       = ()
+  All f (x ': xs) = (f x, All f xs)
+
+{-------------------------------------------------------------------------------
+  'Testable' support for dependently typed functions
+-------------------------------------------------------------------------------}
+
+data DepArgs :: [k -> Type] -> k -> Type where
+  Nil  :: DepArgs '[] t
+  (:*) :: f t -> DepArgs fs t -> DepArgs (f ': fs) t
+
+infixr :*
+
+newtype DepFn (fs :: [k -> Type]) a = DepFn {
+    applyDepFn :: forall (t :: k). Sing (t :: k) -> DepArgs fs t -> a
+  }
+
+class SingArbitrary (f :: k -> Type) where
+  singArbitrary :: Sing t -> Gen (f t)
+
+  singShrink :: Sing t -> f t -> [f t]
+  singShrink _ _ = []
+
+class SingShow (f :: k -> Type) where
+  singShow :: Sing t -> f t -> String
+
+instance (All SingArbitrary fs, SingI fs) => SingArbitrary (DepArgs fs) where
+  singArbitrary (st :: Sing t) = go sing
+    where
+      go :: All SingArbitrary fs' => Sing fs' -> Gen (DepArgs fs' t)
+      go SNil       = return Nil
+      go (SCons ss) = (:*) <$> singArbitrary st <*> go ss
+
+  singShrink (st :: Sing t) = go
+    where
+      go :: All SingArbitrary fs' => DepArgs fs' t -> [DepArgs fs' t]
+      go Nil       = return Nil
+      go (x :* xs) = (:*) <$> singShrink st x <*> go xs
+
+instance All SingShow fs => SingShow (DepArgs fs) where
+  singShow _              Nil       = "[]"
+  singShow (st :: Sing t) (x :* xs) = "[" ++ singShow st x ++ go xs
+    where
+      go :: All SingShow fs' => DepArgs fs' t -> String
+      go Nil         = "]"
+      go (x' :* xs') = "," ++ singShow st x' ++ go xs'
+
+instance ( SingKind k
+         , Arbitrary (Demote k)
+         , All SingArbitrary fs
+         , All SingShow fs
+         , SingI fs
+         , Testable a
+         ) => Testable (DepFn (fs :: [k -> Type]) a) where
+  property (DepFn f) = property $ do
+    t :: Demote k <- arbitrary
+    withSomeSing t $ \st -> do
+      return $ forAllShrink
+                 (shownSingAs st <$> singArbitrary st)
+                 (liftReshow st $ singShrink st)
+                 (f st . fromShownAs)
+
+{-------------------------------------------------------------------------------
+  Internal: labelling
+-------------------------------------------------------------------------------}
+
+data ShownAs a = ShownAs String a
+
+fromShownAs :: ShownAs a -> a
+fromShownAs (ShownAs _ a) = a
+
+shownSingAs :: SingShow f => Sing a -> f a -> ShownAs (f a)
+shownSingAs sa fa = ShownAs (singShow sa fa) fa
+
+liftReshow :: (SingShow g, Functor t)
+           => Sing b -> (f a -> t (g b)) -> ShownAs (f a) -> t (ShownAs (g b))
+liftReshow sb f (ShownAs _ a) = fmap (\b -> ShownAs (singShow sb b) b) (f a)
+
+instance Show (ShownAs a) where
+  show (ShownAs l _) = l
+
+{-------------------------------------------------------------------------------
+  Example
+-------------------------------------------------------------------------------}
+
+data Univ = Two | Many
+
+instance Arbitrary Univ where
+  arbitrary = elements [Two, Many]
+
+data instance Sing (k :: Univ) where
+  SingTwo  :: Sing ('Two  :: Univ)
+  SingMany :: Sing ('Many :: Univ)
+
+instance SingI ('Two  :: Univ) where sing = SingTwo
+instance SingI ('Many :: Univ) where sing = SingMany
+
+instance SingKind Univ where
+  type Demote Univ = Univ
+
+  fromSing SingTwo  = Two
+  fromSing SingMany = Many
+
+  toSing Two  = SomeSing SingTwo
+  toSing Many = SomeSing SingMany
+
+data Val :: Univ -> Type where
+  ValTwo  :: Bool -> Val 'Two
+  ValMany :: Int  -> Val 'Many
+
+deriving instance Show (Val t)
+
+instance Eq (Val t) where
+  ValTwo  x == ValTwo  y = x == y
+  ValMany x == ValMany y = x == y
+
+instance SingShow Val where
+  singShow _ = show
+
+instance SingArbitrary Val where
+  singArbitrary SingTwo  = ValTwo  <$> arbitrary
+  singArbitrary SingMany = ValMany <$> arbitrary
+
+prop_example :: DepFn '[Val, Val] Bool
+prop_example = DepFn $ \_sing (x :* y :* Nil) -> x == y
+
+_example :: IO ()
+_example = quickCheck prop_example

--- a/test/Test/Ouroboros.hs
+++ b/test/Test/Ouroboros.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE GADTs         #-}
+{-# LANGUAGE PolyKinds     #-}
+{-# LANGUAGE RankNTypes    #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | Helper functions for defining tests that abstract over the
+-- choice of ouroboros protocol
+module Test.Ouroboros (
+    (:->)
+  , simpleProp
+  ) where
+
+import           Ouroboros
+import           Test.DepFn
+
+-- TODO: We may wish to make this a type family so that we can write stuff like
+-- @a :-> b :-> c@ to mean @DepFn '[a, b] c@. For now this will do though.
+type (:->) (a :: (k -> *)) b = DepFn '[a] b
+
+simpleProp :: (forall p. KnownOuroborosProtocol p => Sing p -> a p -> b) -> (a :-> b)
+simpleProp k = DepFn $ \protocol (a :* Nil) ->
+                 singKnownOuroborosProtocol protocol $
+                   k protocol a

--- a/test/Test/Pipe.hs
+++ b/test/Test/Pipe.hs
@@ -1,13 +1,17 @@
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Pipe (tests) where
 
 import           Block (Block, HeaderHash (..), Slot (..))
 import           Chain (Chain (..), Point (..))
+import           Ouroboros
 import           Pipe (demo2)
 import           Protocol
 import           Serialise (prop_serialise)
 
 import           Test.Chain (TestBlockChainAndUpdates (..), genBlockChain)
+import           Test.DepFn
+import           Test.Ouroboros
 
 import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
@@ -30,33 +34,42 @@ tests =
 -- Properties
 --
 
-prop_pipe_demo :: TestBlockChainAndUpdates p -> Property
-prop_pipe_demo (TestBlockChainAndUpdates chain updates) =
+prop_pipe_demo :: TestBlockChainAndUpdates :-> Property
+prop_pipe_demo = simpleProp $ \_ (TestBlockChainAndUpdates chain updates) ->
     ioProperty $ demo2 chain updates
 
 prop_serialise_MsgConsumer :: MsgConsumer -> Bool
 prop_serialise_MsgConsumer = prop_serialise
 
-prop_serialise_MsgProducer :: MsgProducer (Block p) -> Bool
-prop_serialise_MsgProducer = prop_serialise
+newtype BlockProducer p = BlockProducer {
+    blockProducer :: MsgProducer (Block p)
+  }
+  deriving (Show)
+
+instance SingShow BlockProducer where
+  singShow s = singKnownOuroborosProtocol s $ show
+
+prop_serialise_MsgProducer :: BlockProducer :-> Bool
+prop_serialise_MsgProducer = simpleProp $ \_ -> prop_serialise . blockProducer
 
 instance Arbitrary MsgConsumer where
   arbitrary = oneof [ pure MsgRequestNext
                     , MsgSetHead <$> arbitrary
                     ]
 
-instance Arbitrary block => Arbitrary (MsgProducer block) where
-  arbitrary = oneof [ MsgRollBackward <$> arbitrary
-                    , MsgRollForward  <$> arbitrary
-                    , pure MsgAwaitReply
-                    , MsgIntersectImproved <$> arbitrary <*> arbitrary
-                    , pure MsgIntersectUnchanged
-                    ]
+instance SingArbitrary BlockProducer where
+  singArbitrary s = BlockProducer <$>
+      oneof [ MsgRollBackward <$> arbitrary
+            , MsgRollForward  <$> singArbitrary s
+            , pure MsgAwaitReply
+            , MsgIntersectImproved <$> arbitrary <*> arbitrary
+            , pure MsgIntersectUnchanged
+            ]
 
 instance Arbitrary Point where
   arbitrary = Point <$> (Slot <$> arbitraryBoundedIntegral)
                     <*> (HeaderHash <$> arbitraryBoundedIntegral)
 
-instance Arbitrary (Block p) where
-  arbitrary = do _ :> b <- genBlockChain 1
-                 return b
+instance SingArbitrary Block where
+  singArbitrary _ = do _ :> b <- genBlockChain 1
+                       return b


### PR DESCRIPTION
In preparation for future changes, this introduces the `KnownOuroborosProtocol`
type class. `Eq` and `Show` instances of `Block` and `BlockHeader` are now
dependent on this, even though that's technically not yet necessary (but it
will be).

I then also added a module that supports testing dependently typed functions;
after all, the choice of Ouroboros protocol now influences the types that we're
tesitng, so picking a protocol randomly then gives you a test of a different
type. The key idea is to represent a dependent function such as

```haskell
forall (u :: Univ). Val u -> Val u -> Bool
```

as

```haskell
DepFn '[Val, Val] Bool
```

where the `u` parameter has been abstracted over. Such functions are then
testable provided we can generate random values of `Val u` for _all_ `u`. We'd
need quantified constraint to express that directly, so instead introduced a
type class

```haskell
class SingArbitrary (f :: k -> Type) where
  singArbitrary :: Sing t -> Gen (f t)
```

The singleton argument allows us to pattern match "on the type parameter" if we
need to, for example, we can write something like

```haskell
instance SingArbitrary Val where
  singArbitrary SingTwo  = ValTwo  <$> arbitrary
  singArbitrary SingMany = ValMany <$> arbitrary
```

It also means that we can bring some type class constraints into scope if we
need to; for example, _all_ protocols are instances of `KnownOuroborosProtocol`
(and, as a consequence, blocks across _all_ protocols are `Show`able, for
instance). We can convince the type checker of this fact using

```haskell
singKnownOuroborosProtocol :: Sing p -> (KnownOuroborosProtocol p => r) -> r
```