### PR TITLE
Network of nodes over named pipes

### DIFF
--- a/demo-playground/DummyPayload.hs
+++ b/demo-playground/DummyPayload.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE KindSignatures     #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module DummyPayload (
+    DummyPayload(..)
+  , Payload
+  , fixupBlock
+  ) where
+
+import           Block
+import           Chain (Chain (..))
+import           Ouroboros
+import           Serialise
+
+data DummyPayload (p :: OuroborosProtocol) = DummyPayload Int
+
+type Payload = DummyPayload 'OuroborosBFT
+
+instance Show (DummyPayload p) where
+    show (DummyPayload x) = show x
+
+deriving instance Eq (DummyPayload p)
+
+instance Serialise (DummyPayload p) where
+    encode  (DummyPayload x) = encodeInt x
+    decode  = DummyPayload <$> decodeInt
+
+instance HasHeader DummyPayload where
+    blockHash      (DummyPayload x) = HeaderHash x
+    blockPrevHash  (DummyPayload x) = HeaderHash (pred x)
+    blockSlot      (DummyPayload x) = Slot (toEnum x)
+    blockNo        (DummyPayload x) = BlockNo (toEnum x)
+    blockSigner    (DummyPayload _) = BlockSigner 0
+    blockBodyHash  (DummyPayload x) = BodyHash x
+    blockInvariant _ = True
+
+fixupBlock :: Chain Payload -> DummyPayload p -> DummyPayload p
+fixupBlock Genesis                _ = DummyPayload 1
+fixupBlock (_ :> DummyPayload x) _  = DummyPayload $! x + 1

--- a/demo-playground/Logging.hs
+++ b/demo-playground/Logging.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Logging (
+    LogEvent -- opaque
+  , loggerConsumer
+  , showNetworkTraffic
+  ) where
+
+import           Control.Concurrent.STM
+import           Control.Monad
+import           Data.Semigroup ((<>))
+import           GHC.Stack
+
+import           Block
+import           Chain (Chain (..))
+import qualified Chain
+import           ConsumersAndProducers
+import           Ouroboros (NodeId)
+import           ProtocolInterfaces
+
+data LogEvent = LogEvent {
+    msg    :: String
+  , sender :: NodeId
+  }
+
+showNetworkTraffic :: HasCallStack => TBQueue LogEvent -> IO ()
+showNetworkTraffic q = forever $ do
+    LogEvent{..} <- atomically $ readTBQueue q
+    putStrLn $ "[conv_with:" <> show sender <> "] " <> msg
+
+-- | Add logging to the example consumer
+loggerConsumer :: forall p block. (Show (block p), HasHeader block)
+               => TBQueue LogEvent
+               -> TVar (Chain (block p))
+               -> NodeId
+               -> ConsumerHandlers (block p) IO
+loggerConsumer q chainvar ourProducer =
+    addLogging $ exampleConsumer chainvar
+  where
+    addLogging :: ConsumerHandlers (block p) IO -> ConsumerHandlers (block p) IO
+    addLogging c = ConsumerHandlers {
+          getChainPoints = do
+            pts <- getChainPoints c
+            logMsg $ "getChainPoints, sending " <> show pts <> " to " <> show ourProducer
+            return pts
+
+        , addBlock = \b -> do
+            logMsg $ "Received " <> show b <> " from " <> show ourProducer
+            addBlock c b
+            logChain
+
+        , rollbackTo = \p -> do
+            logMsg $ "Rolling back to " <> show p
+            rollbackTo c p
+            logChain
+        }
+
+    logChain :: IO ()
+    logChain = atomically $ do
+        chain <- readTVar chainvar
+        let m = "Current chain candidate: " <> show (Chain.toList chain)
+        writeTBQueue q $ LogEvent m ourProducer
+
+    logMsg :: String -> IO ()
+    logMsg m = atomically $ writeTBQueue q $ LogEvent m ourProducer

--- a/demo-playground/Main.hs
+++ b/demo-playground/Main.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Main (main) where
+
+import qualified Control.Concurrent.Async as Async
+import           Control.Concurrent.STM (TBQueue, TVar, atomically, newTBQueue,
+                     newTVar)
+import           Control.Monad
+import           Data.Aeson
+import           Data.Aeson.TH
+import qualified Data.ByteString as B
+import           Data.Foldable
+import           Data.Map (Map)
+import qualified Data.Map.Strict as M
+import           Data.Maybe
+import           Data.Semigroup ((<>))
+import           Data.String.Conv (toS)
+import           Options.Applicative
+
+import           Chain (Chain (..))
+import qualified Chain
+import           ChainProducerState
+import           ConsumersAndProducers
+import qualified Node
+import           Ouroboros
+
+import           DummyPayload
+import           Logging
+import qualified NamedPipe
+
+data NodeRole = CoreNode
+              -- ^ In our experiment, these can actually produce blocks.
+              | RelayNode
+              deriving (Show, Eq)
+
+data NodeSetup = NodeSetup {
+    nodeId       :: NodeId
+  , producers    :: [NodeId]
+  , consumers    :: [NodeId]
+  , initialChain :: Chain Payload
+  , role         :: NodeRole
+  }
+
+instance FromJSON NodeRole where
+    parseJSON = withText "role" $ \s -> case s of
+        "core"  -> pure CoreNode
+        "relay" -> pure RelayNode
+        _       -> fail $ "Invalid NodeRole: " <> show s
+
+instance FromJSON NodeId where
+    parseJSON v = CoreId <$> parseJSON v
+
+instance FromJSON (Chain Payload) where
+    parseJSON = withArray "initialChain" $ \a -> do
+        (xs :: [Int]) <- parseJSON (Array a)
+        pure $ toChain xs
+
+toChain :: [Int] -> Chain Payload
+toChain = go Genesis
+  where
+      go :: Chain Payload -> [Int] -> Chain Payload
+      go acc []     = acc
+      go acc (x:xs) = go (acc :> (DummyPayload x)) xs
+
+deriveFromJSON defaultOptions ''NodeSetup
+
+data NetworkTopology = NetworkTopology [NodeSetup]
+
+deriveFromJSON defaultOptions ''NetworkTopology
+
+type NetworkMap = Map NodeId NodeSetup
+
+toNetworkMap :: NetworkTopology -> NetworkMap
+toNetworkMap (NetworkTopology xs) =
+    foldl' (\acc ns -> M.insert (nodeId ns) ns acc) mempty xs
+
+data CLI = CLI
+  { myNodeId     :: NodeId
+  , topologyFile :: FilePath
+  }
+
+sample :: Parser CLI
+sample = CLI
+      <$> option (fmap CoreId auto)
+          ( long "node-id"
+         <> short 'n'
+         <> metavar "NODE-ID"
+         <> help "The ID for this node" )
+      <*> strOption
+         ( long "topology"
+         <> short 't'
+         <> metavar "FILEPATH"
+         <> help "The path to a file describing the topology."
+         )
+
+main :: IO ()
+main = runNode =<< execParser opts
+  where
+    opts = info (sample <**> helper)
+      ( fullDesc
+     <> progDesc "Run a node with the chain-following protocol hooked in."
+     )
+
+runNode :: CLI -> IO ()
+runNode CLI{..} = do
+    let isLogger   = myNodeId == CoreId 0
+    topoE <- eitherDecode . toS <$> B.readFile topologyFile
+    case topoE of
+         Left e -> error e
+         Right t -> do
+             let topology      = toNetworkMap t
+                 NodeSetup{..} = fromMaybe (error "note not found.") $
+                                   M.lookup myNodeId topology
+
+             putStrLn $ "**************************************"
+             putStrLn $ "I am Node = " <> show myNodeId
+             putStrLn $ "My consumers are " <> show consumers
+             putStrLn $ "My producers are " <> show producers
+             putStrLn $ "**************************************"
+
+             -- Creates a TBQueue to be used by all the logger threads to monitor
+             -- the traffic.
+             loggingQueue    <- atomically $ newTBQueue 50
+             terminalThread  <-
+               case isLogger of
+                    True  -> (:[]) <$> spawnTerminalLogger loggingQueue
+                    False -> mempty
+
+             -- The calls to the 'Unix' functions are flipped here, as for each
+             -- of my producers I want to create a consumer node and for each
+             -- of my consumers I want to produce something.
+             (upstream, consumerThreads) <-
+               fmap unzip $ forM producers $ \pId ->
+                 case isLogger of
+                      True  -> spawnLogger loggingQueue pId
+                      False -> spawnConsumer initialChain pId
+
+             cps <- atomically $ newTVar (initChainProducerState initialChain)
+             producerThreads <- forM consumers (spawnProducer cps)
+
+             Node.forkRelayKernel upstream cps
+             when (role == CoreNode) $ do
+                 Node.forkCoreKernel slotDuration
+                                     (chainFrom initialChain 100)
+                                     fixupBlock
+                                     cps
+
+             let allThreads = terminalThread <> producerThreads
+                                             <> consumerThreads
+             void $ Async.waitAnyCancel allThreads
+
+  where
+      spawnTerminalLogger :: TBQueue LogEvent -> IO (Async.Async ())
+      spawnTerminalLogger q = do
+          Async.async $ showNetworkTraffic q
+
+      spawnLogger :: TBQueue LogEvent
+                  -> NodeId
+                  -> IO (TVar (Chain Payload), Async.Async ())
+      spawnLogger q targetId = do
+          chVar <- atomically $ newTVar Genesis
+          a     <- Async.async $ NamedPipe.runConsumer myNodeId targetId $
+                     loggerConsumer q chVar targetId
+          pure (chVar, a)
+
+      spawnConsumer :: Chain Payload
+                    -> NodeId
+                    -> IO (TVar (Chain Payload), Async.Async ())
+      spawnConsumer myChain producerNodeId = do
+          chVar <- atomically $ newTVar myChain
+          a     <- Async.async $ NamedPipe.runConsumer myNodeId producerNodeId $
+                     exampleConsumer chVar
+          pure (chVar, a)
+
+      spawnProducer :: TVar (ChainProducerState Payload)
+                    -> NodeId
+                    -> IO (Async.Async ())
+      spawnProducer cps consumerNodeId = Async.async $
+          NamedPipe.runProducer myNodeId consumerNodeId $
+            exampleProducer cps
+
+chainFrom :: Chain Payload -> Int -> Chain Payload
+chainFrom Genesis n =
+    foldl (\acc b -> Chain.addBlock (DummyPayload b) acc) Genesis [1..n]
+chainFrom c@(_ :> DummyPayload x) n =
+    foldl (\acc b -> Chain.addBlock (DummyPayload b) acc) c [x+1..x+n]
+
+slotDuration :: Int
+slotDuration = 2 * 1000000

--- a/demo-playground/NamedPipe.hs
+++ b/demo-playground/NamedPipe.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module NamedPipe (
+    runConsumer
+  , runProducer
+  ) where
+
+import           Control.Exception (SomeException, bracket, catch)
+import           Data.Semigroup ((<>))
+import           GHC.Stack
+import           System.Directory (removeFile)
+import           System.IO
+import           System.Posix.Files (createNamedPipe, otherReadMode, ownerModes,
+                     unionFileModes)
+
+import           Block (HasHeader)
+import           ConsumersAndProducers
+import           Ouroboros
+import qualified Pipe as P
+import           Serialise (Serialise)
+
+-- | Creates two pipes, one for reading, one for writing.
+withPipe :: HasCallStack
+         => (NodeId, NodeId)
+         -> ((Handle, Handle) -> IO a)
+         -> IO a
+withPipe (fromNode, toNode) action = do
+    let (src,tgt) = (dashify fromNode, dashify toNode)
+    let readName  = "ouroboros-" <> tgt <> "-to-" <> src
+    let writeName = "ouroboros-" <> src <> "-to-" <> tgt
+    bracket (do createNamedPipe readName  (unionFileModes ownerModes otherReadMode)
+                    `catch` (\(_ :: SomeException) -> pure ())
+                createNamedPipe writeName (unionFileModes ownerModes otherReadMode)
+                    `catch` (\(_ :: SomeException) -> pure ())
+                (,) <$> openFile readName   ReadWriteMode
+                    <*> openFile writeName  ReadWriteMode
+            ) (\(r,w) -> do
+                hClose r
+                hClose w
+                -- Destroy the pipes
+                removeFile readName
+                  `catch` (\(_ :: SomeException) -> pure ())
+                removeFile writeName
+                  `catch` (\(_ :: SomeException) -> pure ())
+                )
+            action
+  where
+    dashify :: NodeId -> String
+    dashify (CoreId n)  = "core-node-"  <> show n
+    dashify (RelayId n) = "relay-node-" <> show n
+
+-- | Runs a producer protocol over a named pipe (technically speaking two
+-- pipes, one for reads, one for writes).
+runProducer :: (HasHeader block, Serialise (block p))
+            => NodeId
+            -> NodeId
+            -> ProducerHandlers (block p) IO r
+            -> IO ()
+runProducer myId targetId producer =
+    withPipe (myId, targetId) $ \(hndRead, hndWrite) ->
+      P.runProducer hndRead hndWrite producer
+
+-- | Runs a consumer protocol over a named pipe (technically speaking two
+-- pipes, one for reads, one for writes).
+runConsumer :: (HasHeader block, Serialise (block p))
+            => NodeId
+            -> NodeId
+            -> ConsumerHandlers (block p) IO
+            -> IO ()
+runConsumer myNodeId targetId consumer =
+    withPipe (myNodeId, targetId) $ \(hndRead, hndWrite) ->
+      P.runConsumer hndRead hndWrite consumer

--- a/demo-playground/README.md
+++ b/demo-playground/README.md
@@ -1,0 +1,24 @@
+
+## Demo playground
+
+Little playground to try in the wild the chain-following protocol where
+consumers and producers run on named pipes and the communication happens out-of-process.
+
+## Running the demo
+
+You have to specify your network topology in a json file. There are two
+examples inside `demo-playgroud`. The node 0 has a special meaning: it's a
+"logger" node which can be attached to all the different nodes in the network
+to inspect the traffic. For example, to setup a minimal example, runs in three
+separate terminal (in this order):
+
+```
+cabal new-run demo-playground -- -t demo-playground/simple-topology.json -n 0
+cabal new-run demo-playground -- -t demo-playground/simple-topology.json -n 2
+cabal new-run demo-playground -- -t demo-playground/simple-topology.json -n 1
+```
+
+You will see that the logger waits to receive traffic from the core node 2,
+and when 1 start, the logger will receive the (up-to-date) chain from both peers,
+which means that node 1 and node 2 synced and now node 1 is following the chain
+of node 2.

--- a/demo-playground/example-topology.json
+++ b/demo-playground/example-topology.json
@@ -1,0 +1,42 @@
+[
+    { "nodeId": 0
+    , "producers": [1,2,3,4,5]
+    , "consumers": []
+    , "initialChain": []
+    , "role": "relay"
+    },
+    { "nodeId": 1
+    , "producers": [2,3]
+    , "consumers": [0,4,5]
+    , "initialChain": [1]
+    , "role": "relay"
+    }
+    ,
+    { "nodeId": 2
+    , "producers": []
+    , "consumers": [0, 1]
+    , "initialChain": [1,2,3]
+    , "role": "core"
+    }
+    ,
+    { "nodeId": 3
+    , "producers": []
+    , "consumers": [0,1]
+    , "initialChain": [1,2,3,4]
+    , "role": "core"
+    }
+    ,
+    { "nodeId": 4
+    , "producers": [1]
+    , "consumers": [0]
+    , "initialChain": []
+    , "role": "relay"
+    }
+    ,
+    { "nodeId": 5
+    , "producers": [1]
+    , "consumers": [0]
+    , "initialChain": []
+    , "role": "relay"
+    }
+]

--- a/demo-playground/simple-topology.json
+++ b/demo-playground/simple-topology.json
@@ -1,0 +1,20 @@
+[
+    { "nodeId": 0
+    , "producers": [1,2]
+    , "consumers": []
+    , "initialChain": []
+    , "role": "relay"
+    },
+    { "nodeId": 1
+    , "producers": [2]
+    , "consumers": [0]
+    , "initialChain": []
+    , "role": "relay"
+    },
+    { "nodeId": 2
+    , "producers": []
+    , "consumers": [0, 1]
+    , "initialChain": []
+    , "role": "core"
+    }
+]

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -91,6 +91,26 @@ library
 
   ghc-options:         -Wall
 
+executable demo-playground
+  hs-source-dirs:      demo-playground
+  main-is:             Main.hs
+  ghc-options:         -threaded -Wall -O2 "-with-rtsopts=-N"
+  other-modules:       DummyPayload
+                       Logging
+                       NamedPipe
+  build-depends:       base,
+                       aeson,
+                       async,
+                       bytestring,
+                       directory,
+                       string-conv,
+                       stm,
+                       containers,
+                       QuickCheck,
+                       optparse-applicative,
+                       ouroboros-network,
+                       unix
+
 test-suite tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test

--- a/src/Chain.hs
+++ b/src/Chain.hs
@@ -66,8 +66,7 @@ import           Prelude hiding (drop, head)
 
 import           Block (Block (..), BlockHeader (..), BlockNo (..),
                      BlockNo (..), BodyHash (..), HasHeader (..),
-                     HeaderHash (..), HeaderHash (..), Slot (..), Slot (..),
-                     hashBody, hashHeader)
+                     HeaderHash (..), Slot (..), hashBody, hashHeader)
 import           Serialise
 
 import           Control.Exception (assert)


### PR DESCRIPTION
This adds a demonstration of running a network of nodes (relay or edge nodes)
over named pipes. See README for instructions on how to run it.

This makes a few small semantics-preserving refactoring to the existing
infrastructure, primarily to make things a bit more reuseable/composable.

