### PR TITLE
Test dynamic chain generation

### DIFF
--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -137,6 +137,7 @@ test-suite tests
   other-modules:       Test.Chain
                        Test.ChainProducerState
                        Test.DepFn
+                       Test.Dynamic
                        Test.Node
                        Test.Ouroboros
                        Test.Pipe

--- a/src/Sim.hs
+++ b/src/Sim.hs
@@ -286,7 +286,7 @@ schedule simstate@SimState {
     case removeMinimums timers of
       Nothing -> return []
 
-      Just (time', events, timers') -> assert (time' > time) $ do
+      Just (time', events, timers') -> assert (time' >= time) $ do
         trace <- schedule simstate {
                    runqueue = map (Thread nextTid) events,
                    curTime  = time',

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,7 @@ import           Test.Tasty
 
 import qualified Test.Chain (tests)
 import qualified Test.ChainProducerState (tests)
+import qualified Test.Dynamic (tests)
 import qualified Test.Node (tests)
 import qualified Test.Pipe (tests)
 import qualified Test.Sim (tests)
@@ -19,4 +20,5 @@ tests =
   , Test.Sim.tests
   , Test.Node.tests
   , Test.Pipe.tests
+  , Test.Dynamic.tests
   ]

--- a/test/Test/Dynamic.hs
+++ b/test/Test/Dynamic.hs
@@ -1,0 +1,205 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeApplications    #-}
+
+{-# OPTIONS -fno-warn-unused-binds #-}
+
+module Test.Dynamic (
+    tests
+  ) where
+
+import           Control.Monad
+import           Control.Monad.ST.Lazy
+import           Control.Monad.State
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Proxy
+import           Test.QuickCheck
+
+import           Block
+import           Chain
+import           ChainProducerState
+import           MonadClass
+import           Node
+import           Ouroboros
+import           Protocol
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Dynamic chain generation" [
+      testProperty "simple BFT convergence" prop_simple_bft_convergence
+    ]
+
+-- Run BFT on the broadcast network, and check that all nodes converge to the
+-- same final chain
+test_simple_bft_convergence :: forall m n stm.
+                               ( MonadSTM m stm
+                               , MonadRunProbe m n
+                               , MonadSay m
+                               , MonadProbe m
+                               , Show (Time m)
+                               )
+                            => n Property
+test_simple_bft_convergence =
+    fmap isValid $ withProbe $ go
+  where
+    go :: Probe m (Map NodeId (Chain (Block 'TestLedgerDomain 'OuroborosBFT))) -> m ()
+    go p = do
+      finalChains <- broadcastNetwork
+                       numSlots
+                       nodeInit
+                       appendBlock
+      probeOutput p finalChains
+
+    numNodes :: Int
+    numNodes = 3
+
+    numSlots :: Int
+    numSlots = 10
+
+    appendBlock :: NodeId
+                -> Slot
+                -> Chain (Block 'TestLedgerDomain 'OuroborosBFT)
+                -> StateT Int stm (Chain (Block 'TestLedgerDomain 'OuroborosBFT))
+    appendBlock (RelayId _) _ _ = error "appendBlock: relay cant be leader"
+    appendBlock (CoreId us) (Slot slot) c = do
+        count <- state $ \n -> (n + 1, n + 1)
+        let body :: BlockBody 'TestLedgerDomain
+            body = BlockBody $ concat [
+                       "Block " ++ show count
+                     , " produced in slot " ++ show slot
+                     , " by core node " ++ show us
+                     ]
+
+            header :: BlockHeader 'OuroborosBFT
+            header = BlockHeader {
+                headerHash     = hashHeader header -- not actually recursive!
+              , headerPrevHash = headHash c
+              , headerSlot     = Slot slot
+              , headerBlockNo  = succ $ headBlockNo c
+              , headerSigner   = BlockSigner (fromIntegral us)
+              , headerBodyHash = hashBody body
+              }
+
+            block :: Block 'TestLedgerDomain 'OuroborosBFT
+            block = Block header body
+
+        return $ c :> block
+
+    nodeInit :: Map NodeId (Int, Chain (Block 'TestLedgerDomain 'OuroborosBFT))
+    nodeInit = Map.fromList $ [ (CoreId i, (0, Genesis))
+                              | i <- [0 .. numNodes - 1]
+                              ]
+
+    isValid :: [(Time m, Map NodeId (Chain (Block 'TestLedgerDomain 'OuroborosBFT)))] -> Property
+    isValid trace = counterexample (show trace) $
+      case trace of
+        [(_, final)] -> Map.keys final == Map.keys nodeInit
+                   .&&. allEqual (Map.elems final)
+        _otherwise   -> property False
+
+prop_simple_bft_convergence :: Property
+prop_simple_bft_convergence = runST test_simple_bft_convergence
+
+{-------------------------------------------------------------------------------
+  Infrastructure
+-------------------------------------------------------------------------------}
+
+-- | Setup fully-connected topology, where every node is both a producer
+-- and a consumer
+--
+-- We run for the specified number of blocks, then return the final state of
+-- each node.
+broadcastNetwork :: forall p m stm (dom :: LedgerDomain) st.
+                    ( p   ~ 'OuroborosBFT     -- for now
+                    , dom ~ 'TestLedgerDomain -- for now
+                    , KnownOuroborosProtocol p
+                    , MonadSTM   m stm
+                    , MonadTimer m
+                    , MonadSay   m
+                    , Show     (Block dom p)
+                    , HasHeader (Block dom)
+                    )
+                 => Int
+                 -- ^ Number of slots to run for
+                 -> Map NodeId (st, Chain (Block dom p))
+                 -- ^ Node initial state and initial chain
+                 -> (   NodeId
+                     -> Slot
+                     -> Chain (Block dom p) -> StateT st stm (Chain (Block dom p))
+                    )
+                 -- ^ Produce a block
+                 -> m (Map NodeId (Chain (Block dom p)))
+broadcastNetwork numSlots nodeInit mkBlock = do
+    chans <- fmap Map.fromList $ forM nodeIds $ \us -> do
+               fmap (us, ) $ fmap Map.fromList $ forM (filter (/= us) nodeIds) $ \them ->
+                 fmap (them, ) $
+                   createCoupledChannels
+                     @(MsgProducer (Block dom p))
+                     @MsgConsumer
+                     0
+                     0
+
+    nodes <- forM (Map.toList nodeInit) $ \(us, (initSt, initChain)) -> do
+      varRes <- atomically $ newTVar Nothing
+      varSt  <- atomically $ newTVar initSt
+      varCPS <- relayNode us initChain $ NodeChannels {
+          consumerChans = map (\them -> snd (chans Map.! them Map.! us)) (filter (/= us) nodeIds)
+        , producerChans = map (\them -> fst (chans Map.! us Map.! them)) (filter (/= us) nodeIds)
+        }
+
+      forM_ [1 .. numSlots] $ \slotId ->
+        timer (slotDuration (Proxy @m) * fromIntegral slotId) $ do
+          let isLeader = case us of
+                RelayId _ -> False
+                CoreId i  -> slotId `mod` numNodes == i
+          when isLeader $ atomically $ do
+            cps <- readTVar varCPS
+            st  <- readTVar varSt
+            (chain', st') <- runStateT (mkBlock us (toEnum slotId) (chainState cps)) st
+            writeTVar varCPS cps{ chainState = chain' }
+            writeTVar varSt  st'
+
+      timer (slotDuration (Proxy @m) * fromIntegral (numSlots + 10)) $
+        atomically $ do
+          cps <- readTVar varCPS
+          writeTVar varRes $ Just (us, chainState cps)
+
+      return varRes
+
+    atomically $ Map.fromList <$> collectAllJust nodes
+  where
+    nodeIds :: [NodeId]
+    nodeIds = Map.keys nodeInit
+
+    numNodes :: Int
+    numNodes = Map.size nodeInit
+
+slotDuration :: MonadTimer m => proxy m -> Duration (Time m)
+slotDuration _ = 1000000
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+collectAllJust :: MonadSTM m stm => [TVar m (Maybe a)] -> stm [a]
+collectAllJust = mapM collectJust
+
+collectJust :: MonadSTM m stm => TVar m (Maybe a) -> stm a
+collectJust var = do
+    ma <- readTVar var
+    case ma of
+      Nothing -> retry
+      Just a  -> return a
+
+allEqual :: Eq a => [a] -> Bool
+allEqual []       = True
+allEqual [_]      = True
+allEqual (x:y:xs) = x == y && allEqual (y:xs)

--- a/test/Test/Node.hs
+++ b/test/Test/Node.hs
@@ -126,7 +126,7 @@ coreToRelaySim duplex chain slotDuration coreTrDelay relayTrDelay probe = do
     cps <- coreNode (CoreId 0) slotDuration (Chain.toOldestFirst chain) coreChans
     fork $ observeChainProducerState (CoreId 0) probe cps
   fork $ void $ do
-    cps <- relayNode (RelayId 0) relayChans
+    cps <- relayNode (RelayId 0) Genesis relayChans
     fork $ observeChainProducerState (RelayId 0) probe cps
 
 runCoreToRelaySim :: ( KnownOuroborosProtocol p
@@ -209,10 +209,10 @@ coreToRelaySim2 chain slotDuration coreTrDelay relayTrDelay probe = do
     cps <- coreNode (CoreId 0) slotDuration (Chain.toOldestFirst chain) cr1
     fork $ observeChainProducerState (CoreId 0) probe cps
   fork $ void $ do
-    cps <- relayNode (RelayId 1) (r1c <> r1r2)
+    cps <- relayNode (RelayId 1) Genesis(r1c <> r1r2)
     fork $ observeChainProducerState (RelayId 1) probe cps
   fork $ void $ do
-    cps <- relayNode (RelayId 2) r2r1
+    cps <- relayNode (RelayId 2) Genesis r2r1
     fork $ observeChainProducerState (RelayId 2) probe cps
 
 runCoreToRelaySim2 :: ( KnownOuroborosProtocol p
@@ -271,7 +271,7 @@ coreToCoreViaRelaySim chain1 chain2 slotDuration coreTrDelay relayTrDelay probe 
     cps <- coreNode (CoreId 1) slotDuration (Chain.toOldestFirst chain1) c1r1
     fork $ observeChainProducerState (CoreId 1) probe cps
   fork $ void $ do
-    cps <- relayNode (RelayId 1) (r1c1 <> r1c2)
+    cps <- relayNode (RelayId 1) Genesis (r1c1 <> r1c2)
     fork $ observeChainProducerState (RelayId 1) probe cps
   fork $ void $ do
     cps <- coreNode (CoreId 2) slotDuration (Chain.toOldestFirst chain2) c2r1
@@ -412,7 +412,7 @@ networkGraphSim (TestNetworkGraph g cs) slotDuration coreTrDelay relayTrDelay pr
           coreNode  (CoreId i) slotDuration (Chain.toOldestFirst chain) (channs' Map.! i)
           >>= observeChainProducerState (CoreId i) probe
         Nothing ->
-          relayNode (RelayId i) (channs' Map.! i)
+          relayNode (RelayId i) Genesis (channs' Map.! i)
           >>= observeChainProducerState (RelayId i) probe
 
 runNetworkGraphSim


### PR DESCRIPTION
This adds some infrastructure for testing dynamic chain generation (rather than
generating the chain upfront). This is _almost_ complete, but I am out of time
for now; all the puzzle pieces are in place, except that the nodes don't
_actually_ produce any blocks yet. But we construct a network of nodes, each of
them checks when they are the leader, and when they do, they get a chance to
produce a block; we run the whole thing for a while, and then check that all
chains of all nodes are equal. If they aren't, we provide the STM trace as a
counterexample.