### PR TITLE
Pave the way to have transactions with stake in blocks

### DIFF
--- a/demo-playground/DummyPayload.hs
+++ b/demo-playground/DummyPayload.hs
@@ -11,7 +11,7 @@ module DummyPayload (
   ) where
 
 import           Block
-import           Chain      (Chain (..), addBlock)
+import           Chain      (Chain (..))
 import           Infra.Util
 import           Ouroboros
 import           Serialise
@@ -47,8 +47,6 @@ toChain = go Genesis
       go acc []     = acc
       go acc (x:xs) = go (acc :> (DummyPayload x)) xs
 
-chainFrom :: Chain (DummyPayload p) -> Int -> Chain (DummyPayload p)
-chainFrom Genesis n =
-    foldl (\acc b -> addBlock (DummyPayload b) acc) Genesis [1..n]
-chainFrom c@(_ :> DummyPayload x) n =
-    foldl (\acc b -> addBlock (DummyPayload b) acc) c [x+1..x+n]
+chainFrom :: Chain (DummyPayload p) -> Int -> [DummyPayload p]
+chainFrom Genesis               n = [DummyPayload i | i <- [1..n]]
+chainFrom (_ :> DummyPayload x) n = [DummyPayload i | i <- [x+1..x+n]]

--- a/demo-playground/DummyPayload.hs
+++ b/demo-playground/DummyPayload.hs
@@ -7,6 +7,7 @@ module DummyPayload (
     DummyPayload(..)
   , fixupBlock
   , chainFrom
+  , toChain
   ) where
 
 import           Block
@@ -38,6 +39,13 @@ instance HasHeader DummyPayload where
 fixupBlock :: Chain (DummyPayload p) -> DummyPayload p -> DummyPayload p
 fixupBlock Genesis               _ = DummyPayload 1
 fixupBlock (_ :> DummyPayload x) _ = DummyPayload $! x + 1
+
+toChain :: KnownOuroborosProtocol p => [Int] -> Chain (DummyPayload p)
+toChain = go Genesis
+  where
+      go :: Chain (DummyPayload p) -> [Int] -> Chain (DummyPayload p)
+      go acc []     = acc
+      go acc (x:xs) = go (acc :> (DummyPayload x)) xs
 
 chainFrom :: Chain (DummyPayload p) -> Int -> Chain (DummyPayload p)
 chainFrom Genesis n =

--- a/demo-playground/DummyPayload.hs
+++ b/demo-playground/DummyPayload.hs
@@ -4,18 +4,15 @@
 
 module DummyPayload (
     DummyPayload(..)
-  , Payload
   , fixupBlock
   ) where
 
 import           Block
-import           Chain (Chain (..))
+import           Chain     (Chain (..))
 import           Ouroboros
 import           Serialise
 
 data DummyPayload (p :: OuroborosProtocol) = DummyPayload Int
-
-type Payload = DummyPayload 'OuroborosBFT
 
 instance Show (DummyPayload p) where
     show (DummyPayload x) = show x
@@ -35,6 +32,6 @@ instance HasHeader DummyPayload where
     blockBodyHash  (DummyPayload x) = BodyHash x
     blockInvariant _ = True
 
-fixupBlock :: Chain Payload -> DummyPayload p -> DummyPayload p
-fixupBlock Genesis                _ = DummyPayload 1
-fixupBlock (_ :> DummyPayload x) _  = DummyPayload $! x + 1
+fixupBlock :: Chain (DummyPayload p) -> DummyPayload p -> DummyPayload p
+fixupBlock Genesis               _ = DummyPayload 1
+fixupBlock (_ :> DummyPayload x) _ = DummyPayload $! x + 1

--- a/demo-playground/Main.hs
+++ b/demo-playground/Main.hs
@@ -49,11 +49,14 @@ data NodeRole = CoreNode
               deriving (Show, Eq)
 
 data NodeSetup = NodeSetup {
-    nodeId    :: NodeId
-  , producers :: [NodeId]
-  , consumers :: [NodeId]
-  -- , initialChain :: Chain (Payload pt)
-  , role      :: NodeRole
+    nodeId           :: NodeId
+  , producers        :: [NodeId]
+  , consumers        :: [NodeId]
+  , initialChainData :: [Int]
+  -- ^ A very naive representation of an \"initial chain\". Essentially, given
+  -- a list of integers, is up to the different payloads to use them to come
+  -- up with sensible implementations for a chain.
+  , role             :: NodeRole
   }
 
 instance FromJSON NodeRole where
@@ -64,14 +67,6 @@ instance FromJSON NodeRole where
 
 instance FromJSON NodeId where
     parseJSON v = CoreId <$> parseJSON v
-
--- instance FromJSON (Chain Payload) where
---     parseJSON = withArray "initialChain" $ \a -> do
---         (xs :: [Int]) <- parseJSON (Array a)
---         pure $ toChain xs
-
---toChain :: [Int] -> Chain Payload
---toChain = foldl' (\c i -> chainFrom c i) Genesis
 
 deriveFromJSON defaultOptions ''NodeSetup
 
@@ -157,7 +152,7 @@ runNode CLI{..} = do
                case dictPayloadImplementation sPayloadType of
                  Dict -> do
                    let initialChain :: Chain (Payload pt 'OuroborosBFT)
-                       initialChain = Genesis
+                       initialChain = toChain initialChainData
 
                    -- The calls to the 'Unix' functions are flipped here, as for each
                    -- of my producers I want to create a consumer node and for each

--- a/demo-playground/Main.hs
+++ b/demo-playground/Main.hs
@@ -15,28 +15,28 @@
 module Main (main) where
 
 import qualified Control.Concurrent.Async as Async
-import           Control.Concurrent.STM   (TBQueue, TVar, atomically,
-                                           newTBQueue, newTVar)
+import           Control.Concurrent.STM (TBQueue, TVar, atomically, newTBQueue,
+                     newTVar)
 import           Control.Monad
 import           Data.Aeson
 import           Data.Aeson.TH
-import qualified Data.ByteString          as B
+import qualified Data.ByteString as B
 import           Data.Foldable
-import           Data.Map                 (Map)
-import qualified Data.Map.Strict          as M
+import           Data.Map (Map)
+import qualified Data.Map.Strict as M
 import           Data.Maybe
-import           Data.Semigroup           ((<>))
-import           Data.String.Conv         (toS)
+import           Data.Semigroup ((<>))
+import           Data.String.Conv (toS)
 import           Options.Applicative
 
-import           Chain                    (Chain (..), HasHeader)
+import           Chain (Chain (..), HasHeader)
 import           ChainProducerState
 import           ConsumersAndProducers
 import           Infra.Util
 import qualified Node
 import           Ouroboros
-import           Serialise                hiding ((<>))
-import           Util.Singletons          (Dict (..), withSomeSing)
+import           Serialise hiding ((<>))
+import           Util.Singletons (Dict (..), withSomeSing)
 
 import           Logging
 import qualified NamedPipe
@@ -148,7 +148,7 @@ runNode CLI{..} = do
                     True  -> (:[]) <$> spawnTerminalLogger loggingQueue
                     False -> mempty
 
-             withSomeSing payloadType $ \(sPayloadType :: Sing pt) ->
+             withSomeSing payloadType $ \(sPayloadType :: Sing (pt :: PayloadType)) ->
                case dictPayloadImplementation sPayloadType of
                  Dict -> do
                    let initialChain :: Chain (Payload pt 'OuroborosBFT)

--- a/demo-playground/MockPayload.hs
+++ b/demo-playground/MockPayload.hs
@@ -3,7 +3,14 @@
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE RankNTypes       #-}
 {-# LANGUAGE TypeFamilies     #-}
-module MockPayload (MockBlock, fixupBlock, chainFrom) where
+module MockPayload (
+      MockBlock
+    , fixupBlock
+    , chainFrom
+    , toChain
+    ) where
+
+import           Data.List  (foldl')
 
 import           Block      hiding (BlockBody)
 import           Block.Mock (BlockBody (..))
@@ -15,6 +22,9 @@ type MockBlock p = Block 'MockLedgerDomain p
 
 fixupBlock :: Chain (MockBlock p) -> MockBlock p -> MockBlock p
 fixupBlock = C.fixupBlock
+
+toChain :: KnownOuroborosProtocol p => [Int] -> Chain (MockBlock p)
+toChain = foldl' (\c i -> chainFrom c i) Genesis
 
 chainFrom :: forall p. KnownOuroborosProtocol p
           => Chain (MockBlock p)

--- a/demo-playground/MockPayload.hs
+++ b/demo-playground/MockPayload.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE RankNTypes       #-}
+module MockPayload (fixupBlock, chainFrom) where
+
+import           Block      hiding (BlockBody)
+import           Block.Mock (BlockBody (..))
+import           Chain      (Chain (..))
+import qualified Chain      as C
+import           Ouroboros
+
+type MockBlock p = Block 'MockLedgerDomain p
+
+fixupBlock :: Chain (MockBlock p) -> MockBlock p -> MockBlock p
+fixupBlock = C.fixupBlock
+
+chainFrom :: forall p. KnownOuroborosProtocol p
+          => Chain (MockBlock p)
+          -> Int
+          -> Chain (MockBlock p)
+chainFrom initialChain n = go initialChain 0
+  where
+    go :: KnownOuroborosProtocol p => Chain (MockBlock p) -> Int -> Chain (MockBlock p)
+    go acc i | i == n = acc
+    go acc i =
+      let newHead = mkBlock i (C.head acc)
+      in go (acc :> newHead) (i + 1)
+
+    mkBlock :: Int -> Maybe (MockBlock p) -> MockBlock p
+    mkBlock currentInt mbHead =
+      let body = BlockBody mempty
+      in Block {
+           blockHeader = mkBlockHeader currentInt mbHead (hashBody body)
+         , blockBody   = body
+         }
+    mkBlockHeader :: Int -> Maybe (MockBlock p) -> BodyHash -> BlockHeader p
+    mkBlockHeader slotNo mbHead bHash =
+        let hdr = BlockHeader {
+             headerHash     = hashHeader hdr
+          ,  headerPrevHash = maybe C.genesisHash (hashHeader . blockHeader) mbHead
+          ,  headerSlot     = Slot (fromIntegral $! slotNo + 1)
+          ,  headerBlockNo  = case mbHead of
+                                   Nothing           -> BlockNo 1
+                                   Just (Block bh _) -> succ (headerBlockNo bh)
+          ,  headerSigner   = BlockSigner 0
+          ,  headerBodyHash = bHash
+          } in hdr

--- a/demo-playground/MockPayload.hs
+++ b/demo-playground/MockPayload.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE RankNTypes       #-}
-module MockPayload (fixupBlock, chainFrom) where
+{-# LANGUAGE TypeFamilies     #-}
+module MockPayload (MockBlock, fixupBlock, chainFrom) where
 
 import           Block      hiding (BlockBody)
 import           Block.Mock (BlockBody (..))

--- a/demo-playground/Payload.hs
+++ b/demo-playground/Payload.hs
@@ -65,7 +65,7 @@ instance Condense PayloadType where
 class HasHeader (Payload block) => PayloadImplementation (block :: PayloadType) where
     type Payload block = (b :: OuroborosProtocol -> *) | b -> block
     fixupBlock :: KnownOuroborosProtocol p => Chain (Payload block p) -> (Payload block p) -> (Payload block p)
-    chainFrom  :: KnownOuroborosProtocol p => Chain (Payload block p) -> Int -> Chain (Payload block p)
+    chainFrom  :: KnownOuroborosProtocol p => Chain (Payload block p) -> Int -> [Payload block p]
     toChain    :: KnownOuroborosProtocol p => [Int] -> Chain (Payload block p)
 
 instance PayloadImplementation 'MockPayloadType where

--- a/demo-playground/Payload.hs
+++ b/demo-playground/Payload.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE DataKinds #-}
+
+module Payload (
+      Payload
+    , fixupBlock
+    , chainFrom
+    ) where
+
+import           Block
+import           MockPayload
+import           Ouroboros
+
+type Payload = Block 'MockLedgerDomain 'OuroborosBFT

--- a/demo-playground/Payload.hs
+++ b/demo-playground/Payload.hs
@@ -1,13 +1,77 @@
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
 
 module Payload (
       Payload
+    , PayloadType(..)
+    , Sing(..)
+    , readPayloadType
+    , allPayloadTypes
+    , PayloadImplementation
     , fixupBlock
     , chainFrom
     ) where
 
-import           Block
-import           MockPayload
-import           Ouroboros
+import           Data.List       (intercalate)
+import           Data.Semigroup  ((<>))
 
-type Payload = Block 'MockLedgerDomain 'OuroborosBFT
+import           Block
+import           Chain           (Chain)
+import qualified DummyPayload    as Dummy
+import           Infra.Util
+import qualified MockPayload     as Mock
+import           Ouroboros
+import           Util.Singletons
+
+data PayloadType =
+    DummyPayloadType
+  | MockPayloadType
+  deriving (Enum, Bounded)
+
+data instance Sing (k :: PayloadType) where
+  SDummyPayload :: Sing 'DummyPayloadType
+  SMockPayload  :: Sing 'MockPayloadType
+
+instance SingI 'DummyPayloadType where sing = SDummyPayload
+instance SingI 'MockPayloadType  where sing = SMockPayload
+
+instance SingKind PayloadType where
+  type Demote PayloadType = PayloadType
+
+  fromSing SDummyPayload = DummyPayloadType
+  fromSing SMockPayload  = MockPayloadType
+
+  toSing DummyPayloadType = SomeSing SDummyPayload
+  toSing MockPayloadType  = SomeSing SMockPayload
+
+readPayloadType :: String -> PayloadType
+readPayloadType "dummy" = DummyPayloadType
+readPayloadType "mock"  = MockPayloadType
+readPayloadType x = error $ "Invalid block type: " <> x <> "."
+                         <> "Available choices: " <> allPayloadTypes
+
+allPayloadTypes :: String
+allPayloadTypes = intercalate "," (map condense ([minBound .. maxBound] :: [PayloadType]))
+
+instance Condense PayloadType where
+    condense DummyPayloadType = "dummy"
+    condense MockPayloadType  = "mock"
+
+class HasHeader (Payload block) => PayloadImplementation (block :: PayloadType) where
+    type Payload block = (b :: OuroborosProtocol -> *) | b -> block
+    fixupBlock :: KnownOuroborosProtocol p => Chain (Payload block p) -> (Payload block p) -> (Payload block p)
+    chainFrom  :: KnownOuroborosProtocol p => Chain (Payload block p) -> Int -> Chain (Payload block p)
+
+instance PayloadImplementation 'MockPayloadType where
+    type Payload 'MockPayloadType = Block 'MockLedgerDomain
+    fixupBlock = Mock.fixupBlock
+    chainFrom  = Mock.chainFrom
+
+instance PayloadImplementation 'DummyPayloadType where
+    type Payload 'DummyPayloadType = Dummy.DummyPayload
+    fixupBlock = Dummy.fixupBlock
+    chainFrom  = Dummy.chainFrom

--- a/demo-playground/Payload.hs
+++ b/demo-playground/Payload.hs
@@ -14,6 +14,7 @@ module Payload (
     , PayloadImplementation
     , fixupBlock
     , chainFrom
+    , toChain
     ) where
 
 import           Data.List       (intercalate)
@@ -65,13 +66,16 @@ class HasHeader (Payload block) => PayloadImplementation (block :: PayloadType) 
     type Payload block = (b :: OuroborosProtocol -> *) | b -> block
     fixupBlock :: KnownOuroborosProtocol p => Chain (Payload block p) -> (Payload block p) -> (Payload block p)
     chainFrom  :: KnownOuroborosProtocol p => Chain (Payload block p) -> Int -> Chain (Payload block p)
+    toChain    :: KnownOuroborosProtocol p => [Int] -> Chain (Payload block p)
 
 instance PayloadImplementation 'MockPayloadType where
     type Payload 'MockPayloadType = Block 'MockLedgerDomain
     fixupBlock = Mock.fixupBlock
     chainFrom  = Mock.chainFrom
+    toChain    = Mock.toChain
 
 instance PayloadImplementation 'DummyPayloadType where
     type Payload 'DummyPayloadType = Dummy.DummyPayload
     fixupBlock = Dummy.fixupBlock
     chainFrom  = Dummy.chainFrom
+    toChain    = Dummy.toChain

--- a/demo-playground/README.md
+++ b/demo-playground/README.md
@@ -22,3 +22,24 @@ You will see that the logger waits to receive traffic from the core node 2,
 and when 1 start, the logger will receive the (up-to-date) chain from both peers,
 which means that node 1 and node 2 synced and now node 1 is following the chain
 of node 2.
+
+## Picking a block type
+
+By default, if you run the example the way specified above, the underlying
+protocol will exchange messages where the "block" is a simple `DummyPayload`,
+which is virtually just an integer. However, this can be replaced by more
+interesting (and in the future realistic) implementations for a block by 
+specifying the `-p` flag at the startup. For example:
+
+```
+cabal new-run demo-playground -- -t demo-playground/simple-topology.json -n 2 -p dummy
+```
+
+Would run `Node 2` with the `DummyPayload`, whereas:
+
+```
+cabal new-run demo-playground -- -t demo-playground/simple-topology.json -n 2 -p mock
+```
+
+Will use a `MockPayload` which uses a BlockBody which can host (mock) transactions
+within it.

--- a/demo-playground/example-topology.json
+++ b/demo-playground/example-topology.json
@@ -2,41 +2,41 @@
     { "nodeId": 0
     , "producers": [1,2,3,4,5]
     , "consumers": []
-    , "initialChain": []
+    , "initialChainData": []
     , "role": "relay"
     },
     { "nodeId": 1
     , "producers": [2,3]
     , "consumers": [0,4,5]
-    , "initialChain": [1]
+    , "initialChainData": [1]
     , "role": "relay"
     }
     ,
     { "nodeId": 2
     , "producers": []
     , "consumers": [0, 1]
-    , "initialChain": [1,2,3]
+    , "initialChainData": [1,2,3]
     , "role": "core"
     }
     ,
     { "nodeId": 3
     , "producers": []
     , "consumers": [0,1]
-    , "initialChain": [1,2,3,4]
+    , "initialChainData": [1,2,3,4]
     , "role": "core"
     }
     ,
     { "nodeId": 4
     , "producers": [1]
     , "consumers": [0]
-    , "initialChain": []
+    , "initialChainData": []
     , "role": "relay"
     }
     ,
     { "nodeId": 5
     , "producers": [1]
     , "consumers": [0]
-    , "initialChain": []
+    , "initialChainData": []
     , "role": "relay"
     }
 ]

--- a/demo-playground/simple-topology.json
+++ b/demo-playground/simple-topology.json
@@ -14,7 +14,7 @@
     { "nodeId": 2
     , "producers": []
     , "consumers": [0, 1]
-    , "initialChainData": []
+    , "initialChainData": [1,2,3]
     , "role": "core"
     }
 ]

--- a/demo-playground/simple-topology.json
+++ b/demo-playground/simple-topology.json
@@ -2,19 +2,19 @@
     { "nodeId": 0
     , "producers": [1,2]
     , "consumers": []
-    , "initialChain": []
+    , "initialChainData": []
     , "role": "relay"
     },
     { "nodeId": 1
     , "producers": [2]
     , "consumers": [0]
-    , "initialChain": []
+    , "initialChainData": []
     , "role": "relay"
     },
     { "nodeId": 2
     , "producers": []
     , "consumers": [0, 1]
-    , "initialChain": []
+    , "initialChainData": []
     , "role": "core"
     }
 ]

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -85,7 +85,7 @@ library
                        base16-bytestring       <0.2,
                        cborg        >=0.2.1 && <0.3,
                        clock        >=0.7 && <0.8,
-                       containers   >=0.5.8.0 && <0.6,
+                       containers   >=0.5 && <0.6,
                        cryptonite   >=0.25 && <0.26,
                        fingertree   >=0.1 && <0.2,
                        free         >=5.1 && <5.2,

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -85,7 +85,7 @@ library
                        base16-bytestring       <0.2,
                        cborg        >=0.2.1 && <0.3,
                        clock        >=0.7 && <0.8,
-                       containers   >=0.5 && <0.6,
+                       containers   >=0.5.8.0 && <0.6,
                        cryptonite   >=0.25 && <0.26,
                        fingertree   >=0.1 && <0.2,
                        free         >=5.1 && <5.2,

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -113,6 +113,8 @@ executable demo-playground
   main-is:             Main.hs
   ghc-options:         -threaded -Wall -O2 "-with-rtsopts=-N"
   other-modules:       DummyPayload
+                       MockPayload
+                       Payload
                        Logging
                        NamedPipe
   build-depends:       base,

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -20,6 +20,7 @@ library
   -- At this experiment/prototype stage everything is exposed.
   -- This has to be tidied up once the design becomes clear.
   exposed-modules:     Block
+                       Block.Mock
                        Chain
                        ChainProducerState
                        ConsumersAndProducers

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -41,6 +41,11 @@ library
                        MonadClass.MonadTimer
                        Node
                        Ouroboros
+                       Ouroboros.Infra.Crypto.Mock
+                       Ouroboros.Infra.Exception
+                       Ouroboros.Infra.Util
+                       Ouroboros.Infra.Util.HList
+                       Ouroboros.UTxO.Mock
                        Pipe
                        Protocol
                        ProtocolInterfaces
@@ -80,6 +85,7 @@ library
                        array,
                        base16-bytestring >= 0.1 && <0.2,
                        bytestring   >=0.10 && <0.11,
+                       base16-bytestring       <0.2,
                        cborg        >=0.2.1 && <0.3,
                        clock        >=0.7 && <0.8,
                        containers   >=0.5 && <0.6,
@@ -98,6 +104,7 @@ library
                        transformers >=0.5 && <0.6,
                        unliftio     >=0.2 && <0.3,
                        void         >=0.7 && <0.8,
+                       unliftio     >=0.2.6.0 && <0.3.0.0,
 
                        QuickCheck   >=2.12 && <2.13
 

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -41,10 +41,6 @@ library
                        MonadClass.MonadTimer
                        Node
                        Ouroboros
-                       Ouroboros.Infra.Crypto.Mock
-                       Ouroboros.Infra.Exception
-                       Ouroboros.Infra.Util
-                       Ouroboros.Infra.Util.HList
                        Ouroboros.UTxO.Mock
                        Pipe
                        Protocol

--- a/src/Block.hs
+++ b/src/Block.hs
@@ -23,11 +23,10 @@ module Block (
 
       -- * Working with different ledger domains
     , LedgerDomain(..)
-    , KnownLedgerDomain
+    , KnownLedgerDomain(..)
 
       -- * Hashing
     , hashHeader
-    , hashBody
     )
     where
 
@@ -42,6 +41,10 @@ import           Test.QuickCheck
 data LedgerDomain =
     TestLedgerDomain
   -- ^ A test domain (i.e. unit tests & properties)
+  | MockLedgerDomain
+  -- ^ A mock domain, useful to instrument examples and prototypes. It can
+  -- provide semi-realistic types which are not as-easy to construct as the
+  -- test ones, but definitely less complicated than the \"real\" ones.
   | CardanoLedgerDomain
   -- ^ A \"real world\" ledger domain.
 

--- a/src/Block.hs
+++ b/src/Block.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 -- | Reference implementation of a representation of a block in a block chain.
 --
@@ -18,6 +21,10 @@ module Block (
     , HeaderHash(..)
     , BodyHash(..)
 
+      -- * Working with different ledger domains
+    , LedgerDomain(..)
+    , KnownLedgerDomain
+
       -- * Hashing
     , hashHeader
     , hashBody
@@ -25,23 +32,29 @@ module Block (
     where
 
 import           Data.Hashable
-import qualified Data.Text as Text
+import qualified Data.Text       as Text
 
 import           Ouroboros
 import           Serialise
 
 import           Test.QuickCheck
 
+data LedgerDomain =
+    TestLedgerDomain
+  -- ^ A test domain (i.e. unit tests & properties)
+  | CardanoLedgerDomain
+  -- ^ A \"real world\" ledger domain.
+
 -- | Our highly-simplified version of a block. It retains the separation
 -- between a block header and body, which is a detail needed for the protocols.
 --
-data Block (p :: OuroborosProtocol) = Block {
+data Block (dom :: LedgerDomain) (p :: OuroborosProtocol) = Block {
        blockHeader :: BlockHeader p,
-       blockBody   :: BlockBody
+       blockBody   :: BlockBody dom
      }
 
-deriving instance KnownOuroborosProtocol p => Show (Block p)
-deriving instance KnownOuroborosProtocol p => Eq   (Block p)
+deriving instance (KnownOuroborosProtocol p, Show (BlockBody dom)) => Show (Block dom p)
+deriving instance (KnownOuroborosProtocol p, Eq (BlockBody dom))   => Eq   (Block dom p)
 
 -- | A block header. It retains simplified versions of all the essential
 -- elements.
@@ -58,13 +71,24 @@ data BlockHeader (p :: OuroborosProtocol) = BlockHeader {
 deriving instance KnownOuroborosProtocol p => Show (BlockHeader p)
 deriving instance KnownOuroborosProtocol p => Eq   (BlockHeader p)
 
+-- | Similarly to the 'KnownOuroborosProtocol' class, a 'KnownLedgerDomain'
+-- class allow us to talk about different ledger domains, each with its own
+-- 'BlockBody'.
+class KnownLedgerDomain (dom :: LedgerDomain) where
+  data family BlockBody dom :: *
+  -- | Compute the 'BodyHash' of the 'BlockBody'
+  --
+  hashBody :: BlockBody dom -> BodyHash
+
 -- | A block body.
 --
 -- For this model we use an opaque string as we do not care about the content
 -- because we focus on the blockchain layer (rather than the ledger layer).
 --
-newtype BlockBody    = BlockBody String
-  deriving (Show, Eq, Ord)
+instance KnownLedgerDomain 'TestLedgerDomain where
+  data BlockBody 'TestLedgerDomain = BlockBody String deriving (Show, Eq, Ord)
+
+  hashBody (BlockBody b) = BodyHash (hash b)
 
 -- | The 0-based index of the block in the blockchain
 newtype BlockNo      = BlockNo Word
@@ -89,10 +113,6 @@ newtype HeaderHash   = HeaderHash Int
 newtype BodyHash     = BodyHash Int
   deriving (Show, Eq, Ord, Hashable)
 
--- | Compute the 'BodyHash' of the 'BlockBody'
---
-hashBody :: BlockBody -> BodyHash
-hashBody (BlockBody b) = BodyHash (hash b)
 
 -- | Compute the 'HeaderHash' of the 'BlockHeader'.
 --
@@ -128,7 +148,7 @@ instance HasHeader BlockHeader where
     --
     blockInvariant = \b -> hashHeader b == headerHash b
 
-instance HasHeader Block where
+instance HasHeader (Block 'TestLedgerDomain) where
     blockHash      = headerHash     . blockHeader
     blockPrevHash  = headerPrevHash . blockHeader
     blockSlot      = headerSlot     . blockHeader
@@ -146,7 +166,7 @@ instance HasHeader Block where
 -- Generators
 --
 
-instance Arbitrary BlockBody where
+instance Arbitrary (BlockBody 'TestLedgerDomain) where
     arbitrary = BlockBody <$> vectorOf 4 (choose ('A', 'Z'))
     -- probably no need for shrink, the content is arbitrary and opaque
     -- if we add one, it might be to shrink to an empty block
@@ -155,7 +175,7 @@ instance Arbitrary BlockBody where
 -- Serialisation
 --
 
-instance Serialise (Block p) where
+instance Serialise (Block 'TestLedgerDomain p) where
 
   encode Block {blockHeader, blockBody} =
       encodeListLen 2
@@ -193,7 +213,7 @@ instance Serialise (BlockHeader p) where
                   <*> (BlockSigner <$> decodeWord)
                   <*> (BodyHash <$> decodeInt)
 
-instance Serialise BlockBody where
+instance Serialise (BlockBody 'TestLedgerDomain) where
 
   encode (BlockBody b) = encodeString (Text.pack b)
 

--- a/src/Block.hs
+++ b/src/Block.hs
@@ -33,6 +33,7 @@ module Block (
 import           Data.Hashable
 import qualified Data.Text       as Text
 
+import           Infra.Util
 import           Ouroboros
 import           Serialise
 
@@ -97,6 +98,9 @@ instance KnownLedgerDomain 'TestLedgerDomain where
 newtype BlockNo      = BlockNo Word
   deriving (Show, Eq, Ord, Hashable, Enum)
 
+instance Condense BlockNo where
+    condense (BlockNo w) = show w
+
 -- | An identifier for someone signing a block.
 --
 -- We model this as if there were an enumerated set of valid block signers
@@ -109,12 +113,12 @@ newtype BlockSigner  = BlockSigner Word
 -- | The hash of all the information in a 'BlockHeader'.
 --
 newtype HeaderHash   = HeaderHash Int
-  deriving (Show, Eq, Ord, Hashable)
+  deriving (Show, Eq, Ord, Hashable, Condense)
 
 -- | The hash of all the information in a 'BlockBody'.
 --
 newtype BodyHash     = BodyHash Int
-  deriving (Show, Eq, Ord, Hashable)
+  deriving (Show, Eq, Ord, Hashable, Condense)
 
 
 -- | Compute the 'HeaderHash' of the 'BlockHeader'.

--- a/src/Block.hs
+++ b/src/Block.hs
@@ -31,7 +31,7 @@ module Block (
     where
 
 import           Data.Hashable
-import qualified Data.Text       as Text
+import qualified Data.Text as Text
 
 import           Infra.Util
 import           Ouroboros

--- a/src/Block/Mock.hs
+++ b/src/Block/Mock.hs
@@ -6,15 +6,14 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Block.Mock where
 
-import           Block               (Block (..), BlockHeader (..),
-                                      BodyHash (..), HasHeader (..),
-                                      KnownLedgerDomain (..), LedgerDomain (..))
-import           Data.Maybe          (maybe)
-import           Data.Set            (Set)
-import           GHC.Natural         (naturalToWordMaybe)
+import           Block (Block (..), BlockHeader (..), BodyHash (..),
+                     HasHeader (..), KnownLedgerDomain (..), LedgerDomain (..))
+import           Data.Maybe (maybe)
+import           Data.Set (Set)
+import           GHC.Natural (naturalToWordMaybe)
 
-import qualified Infra.Crypto.Hash   as H
-import           Infra.Util          (Condense (..))
+import qualified Infra.Crypto.Hash as H
+import           Infra.Util (Condense (..))
 import           Ouroboros.UTxO.Mock (HasUtxo (..))
 import qualified Ouroboros.UTxO.Mock as Mock
 import           Serialise

--- a/src/Block/Mock.hs
+++ b/src/Block/Mock.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Block.Mock where
+
+import           Block               (BodyHash (..), KnownLedgerDomain (..),
+                                      LedgerDomain (..))
+import           Data.Set            (Set)
+import qualified Infra.Crypto.Hash   as H
+import           Ouroboros.UTxO.Mock (HasUtxo (..))
+import qualified Ouroboros.UTxO.Mock as Mock
+
+instance KnownLedgerDomain 'MockLedgerDomain where
+    data BlockBody 'MockLedgerDomain = BlockBody {
+        blockData :: Set (Mock.Tx)
+      }
+    hashBody (BlockBody b) = BodyHash (fromEnum $ H.fromHash $ H.hash b)
+
+instance HasUtxo Mock.Tx => HasUtxo (BlockBody 'MockLedgerDomain) where
+  txIns      = txIns      . blockData
+  txOuts     = txOuts     . blockData
+  updateUtxo = updateUtxo . blockData
+  confirmed  = confirmed  . blockData

--- a/src/Block/Mock.hs
+++ b/src/Block/Mock.hs
@@ -23,9 +23,10 @@ instance KnownLedgerDomain 'MockLedgerDomain where
     data BlockBody 'MockLedgerDomain = BlockBody {
           blockData :: Set (Mock.Tx)
         } deriving Show
-    hashBody (BlockBody b) = BodyHash (maybe maxBound fromEnum $ naturalToWordMaybe $ H.fromHash $ H.hash b)
+    hashBody (BlockBody b) =
+      BodyHash (maybe maxBound fromEnum $ naturalToWordMaybe $ H.fromHash $ H.hash b)
 
-instance HasUtxo Mock.Tx => HasUtxo (BlockBody 'MockLedgerDomain) where
+instance HasUtxo (BlockBody 'MockLedgerDomain) where
   txIns      = txIns      . blockData
   txOuts     = txOuts     . blockData
   updateUtxo = updateUtxo . blockData

--- a/src/Block/Mock.hs
+++ b/src/Block/Mock.hs
@@ -1,25 +1,77 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Block.Mock where
 
-import           Block               (BodyHash (..), KnownLedgerDomain (..),
-                                      LedgerDomain (..))
+import           Block               (Block (..), BlockHeader (..),
+                                      BodyHash (..), HasHeader (..),
+                                      KnownLedgerDomain (..), LedgerDomain (..))
+import           Data.Maybe          (maybe)
 import           Data.Set            (Set)
+import           GHC.Natural         (naturalToWordMaybe)
+
 import qualified Infra.Crypto.Hash   as H
+import           Infra.Util          (Condense (..))
 import           Ouroboros.UTxO.Mock (HasUtxo (..))
 import qualified Ouroboros.UTxO.Mock as Mock
+import           Serialise
 
 instance KnownLedgerDomain 'MockLedgerDomain where
     data BlockBody 'MockLedgerDomain = BlockBody {
-        blockData :: Set (Mock.Tx)
-      }
-    hashBody (BlockBody b) = BodyHash (fromEnum $ H.fromHash $ H.hash b)
+          blockData :: Set (Mock.Tx)
+        } deriving Show
+    hashBody (BlockBody b) = BodyHash (maybe maxBound fromEnum $ naturalToWordMaybe $ H.fromHash $ H.hash b)
 
 instance HasUtxo Mock.Tx => HasUtxo (BlockBody 'MockLedgerDomain) where
   txIns      = txIns      . blockData
   txOuts     = txOuts     . blockData
   updateUtxo = updateUtxo . blockData
   confirmed  = confirmed  . blockData
+
+instance Condense (BlockHeader p) => Condense (Block 'MockLedgerDomain p) where
+    condense (Block hdr body) =
+        "{hdr: " <> condense hdr
+                 <> ", body: "
+                 <> condense (hashBody body)
+                 <> "}"
+
+instance HasHeader (Block 'MockLedgerDomain) where
+    blockHash      = headerHash     . blockHeader
+    blockPrevHash  = headerPrevHash . blockHeader
+    blockSlot      = headerSlot     . blockHeader
+    blockNo        = headerBlockNo  . blockHeader
+    blockSigner    = headerSigner   . blockHeader
+    blockBodyHash  = headerBodyHash . blockHeader
+
+    -- | The block invariant is just that the actual block body hash matches the
+    -- body hash listed in the header.
+    --
+    blockInvariant Block { blockBody, blockHeader = BlockHeader {headerBodyHash} } =
+        headerBodyHash == hashBody blockBody
+
+--
+-- Serialisation
+--
+
+instance Serialise (BlockBody 'MockLedgerDomain) where
+
+  encode (BlockBody b) = encodeListLen 1 <> encode b
+  decode = do
+    decodeListLenOf 1
+    BlockBody <$> decode
+
+
+instance Serialise (Block 'MockLedgerDomain p) where
+
+  encode Block {blockHeader, blockBody} =
+      encodeListLen 2
+   <> encode blockHeader
+   <> encode   blockBody
+
+  decode = do
+      decodeListLenOf 2
+      Block <$> decode <*> decode
+

--- a/src/Chain.hs
+++ b/src/Chain.hs
@@ -63,16 +63,16 @@ module Chain (
   prettyPrintChain
   ) where
 
-import           Prelude           hiding (drop, head)
+import           Prelude hiding (drop, head)
 
-import           Block             (Block (..), BlockHeader (..), BlockNo (..),
-                                    BlockNo (..), BodyHash (..), HasHeader (..),
-                                    HeaderHash (..), KnownLedgerDomain,
-                                    Slot (..), hashBody, hashHeader)
+import           Block (Block (..), BlockHeader (..), BlockNo (..),
+                     BlockNo (..), BodyHash (..), HasHeader (..),
+                     HeaderHash (..), KnownLedgerDomain, Slot (..), hashBody,
+                     hashHeader)
 import           Serialise
 
 import           Control.Exception (assert)
-import qualified Data.List         as L
+import qualified Data.List as L
 
 
 --

--- a/src/Chain.hs
+++ b/src/Chain.hs
@@ -63,15 +63,16 @@ module Chain (
   prettyPrintChain
   ) where
 
-import           Prelude hiding (drop, head)
+import           Prelude           hiding (drop, head)
 
-import           Block (Block (..), BlockHeader (..), BlockNo (..),
-                     BlockNo (..), BodyHash (..), HasHeader (..),
-                     HeaderHash (..), Slot (..), hashBody, hashHeader)
+import           Block             (Block (..), BlockHeader (..), BlockNo (..),
+                                    BlockNo (..), BodyHash (..), HasHeader (..),
+                                    HeaderHash (..), KnownLedgerDomain,
+                                    Slot (..), hashBody, hashHeader)
 import           Serialise
 
 import           Control.Exception (assert)
-import qualified Data.List as L
+import qualified Data.List         as L
 
 
 --
@@ -298,7 +299,8 @@ intersectChains c (bs :> b) =
 -- | Fixup block so to fit it on top of a chain.  Only block number, previous
 -- hash and block hash are updated; slot number and signers are kept intact.
 --
-fixupBlock :: HasHeader block => Chain (block p) -> Block p -> Block p
+fixupBlock :: (HasHeader block, KnownLedgerDomain dom)
+           => Chain (block p) -> Block dom p -> Block dom p
 fixupBlock c b@Block{blockBody, blockHeader} =
     b { blockHeader = fixupBlockHeader c (hashBody blockBody) blockHeader }
 

--- a/src/ChainProducerState.hs
+++ b/src/ChainProducerState.hs
@@ -3,14 +3,13 @@
 
 module ChainProducerState where
 
-import           Chain             (Chain, ChainUpdate (..), HasHeader,
-                                    Point (..), blockPoint, genesisPoint,
-                                    pointOnChain)
+import           Chain (Chain, ChainUpdate (..), HasHeader, Point (..),
+                     blockPoint, genesisPoint, pointOnChain)
 import qualified Chain
 
 import           Control.Exception (assert)
-import           Data.List         (find, group, sort)
-import           Data.Maybe        (fromMaybe)
+import           Data.List (find, group, sort)
+import           Data.Maybe (fromMaybe)
 
 
 

--- a/src/ChainProducerState.hs
+++ b/src/ChainProducerState.hs
@@ -3,13 +3,14 @@
 
 module ChainProducerState where
 
-import           Chain (Chain, ChainUpdate (..), HasHeader, Point (..),
-                     blockPoint, genesisPoint, pointOnChain)
+import           Chain             (Chain, ChainUpdate (..), HasHeader,
+                                    Point (..), blockPoint, genesisPoint,
+                                    pointOnChain)
 import qualified Chain
 
 import           Control.Exception (assert)
-import           Data.List (find, group, sort)
-import           Data.Maybe (fromMaybe)
+import           Data.List         (find, group, sort)
+import           Data.Maybe        (fromMaybe)
 
 
 

--- a/src/Infra/Util.hs
+++ b/src/Infra/Util.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                    #-}
 {-# LANGUAGE DeriveGeneric          #-}
 {-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
@@ -21,6 +22,8 @@ module Infra.Util (
   , threadSafeOutput
   , threadSafeOutputHex
   , threadSafeInput
+    -- * Containers
+  , withoutKeys
     -- * Pretty-printing
   , Condense(..)
   ) where
@@ -145,3 +148,14 @@ instance Condense a => Condense (Set a) where
 
 instance (Condense k, Condense a) => Condense (Map k a) where
   condense = condense . Map.toList
+
+{-------------------------------------------------------------------------------
+  Containers
+-------------------------------------------------------------------------------}
+
+withoutKeys :: Ord k => Map k a -> Set k -> Map k a
+#if MIN_VERSION_containers(0,5,8)
+withoutKeys = Map.withoutKeys
+#else
+m `withoutKeys` s = Map.filterWithKey (\k _ -> k `Set.notMember` s) m
+#endif

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -3,22 +3,21 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Node where
 
-import           Control.Exception     (assert)
+import           Control.Exception (assert)
 import           Control.Monad
-import           Data.Functor          (($>))
-import           Data.List             hiding (inits)
-import           Data.Maybe            (catMaybes)
-import           Data.Semigroup        (Semigroup (..))
-import           Data.Tuple            (swap)
+import           Data.Functor (($>))
+import           Data.List hiding (inits)
+import           Data.Maybe (catMaybes)
+import           Data.Semigroup (Semigroup (..))
+import           Data.Tuple (swap)
 
 import           Block
-import           Chain                 (Chain (..), Point)
+import           Chain (Chain (..), Point)
 import qualified Chain
-import           ChainProducerState    (ChainProducerState (..), ReaderId,
-                                        initChainProducerState, producerChain,
-                                        switchFork)
+import           ChainProducerState (ChainProducerState (..), ReaderId,
+                     initChainProducerState, producerChain, switchFork)
 import           ConsumersAndProducers
-import           MonadClass            hiding (recvMsg, sendMsg)
+import           MonadClass hiding (recvMsg, sendMsg)
 import           Ouroboros
 import           Protocol
 

--- a/src/Ouroboros.hs
+++ b/src/Ouroboros.hs
@@ -14,7 +14,7 @@ module Ouroboros (
   , OuroborosProtocol(..)
   , Sing(..)
   , KnownOuroborosProtocol
-  , singKnownOuroborosProtocol
+  , dictKnownOuroborosProtocol
   ) where
 
 import           Data.Hashable
@@ -70,9 +70,9 @@ instance SingKind OuroborosProtocol where
 
 class KnownOuroborosProtocol (p :: OuroborosProtocol) where
 
-singKnownOuroborosProtocol :: Sing p -> (KnownOuroborosProtocol p => r) -> r
-singKnownOuroborosProtocol SingBFT   k = k
-singKnownOuroborosProtocol SingPraos k = k
+dictKnownOuroborosProtocol :: Sing p -> Dict (KnownOuroborosProtocol p)
+dictKnownOuroborosProtocol SingBFT   = Dict
+dictKnownOuroborosProtocol SingPraos = Dict
 
 {-------------------------------------------------------------------------------
   BFT

--- a/src/Ouroboros/Infra/Crypto/Mock.hs
+++ b/src/Ouroboros/Infra/Crypto/Mock.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+-- | Mock implementations of crypto primitives
+--
+-- The intend is that the datatypes (and the choice of which constructors to
+-- export and which not) and functions defined in this module faithfully
+-- model the properties we want from the crypto primitives, but without
+-- actually doing any cryptography.
+module Ouroboros.Infra.Crypto.Mock (
+    -- * Hashing
+    Hash
+  , hash
+  , Hashable
+    -- * PKI
+  , PrivateKey
+  , PublicKey
+  , mkPrivateKey
+  , derivePublicKey
+    -- * Signatures
+  , Signature
+  , signature
+  , Signed
+  , SignatureMismatch(..)
+  , verifySignature
+  ) where
+
+import           Control.Monad.Except
+import           GHC.Generics         (Generic)
+import           GHC.Stack
+
+import           Ouroboros.Infra.Util
+
+{-------------------------------------------------------------------------------
+  Hashing
+-------------------------------------------------------------------------------}
+
+newtype Hash a = Hash String
+  deriving (Show, Eq, Ord, Generic)
+
+instance Condense (Hash a) where
+  condense (Hash h) = show h
+
+hash :: String -> Hash a
+hash = Hash
+
+newtype Hashable b a = Hashable (DecoratedWith (Hash b) a)
+  deriving (Show, Eq, Ord, Generic, Decorates a, Condense)
+
+{-------------------------------------------------------------------------------
+  PKI
+-------------------------------------------------------------------------------}
+
+newtype PrivateKey = PrivateKey Int
+  deriving (Show, Eq, Generic)
+
+instance Condense PrivateKey where
+  condense (PrivateKey n) = "sk" ++ condense n
+
+data PublicKey = PublicKey PrivateKey
+  deriving (Show, Eq, Generic)
+
+instance Condense PublicKey where
+  condense (PublicKey (PrivateKey n)) = "pk" ++ condense n
+
+mkPrivateKey :: Int -> PrivateKey
+mkPrivateKey = PrivateKey
+
+derivePublicKey :: PrivateKey -> PublicKey
+derivePublicKey = PublicKey
+
+{-------------------------------------------------------------------------------
+  Signatures
+-------------------------------------------------------------------------------}
+
+newtype Signature a = Signature PrivateKey
+  deriving (Show, Eq, Generic, Condense)
+
+newtype Signed a = Signed (DecoratedWith (Signature a) a)
+  deriving (Show, Eq, Generic, Decorates a, Condense)
+
+signature :: PrivateKey -> a -> Signature a
+signature sk _ = Signature sk
+
+verifySignature :: (Monad m, HasCallStack, Show a)
+                => PublicKey -> Signed a -> ExceptT SignatureMismatch m ()
+verifySignature pk@(PublicKey sk) signed
+  | sk == sk' = return ()
+  | otherwise = throwError $ SignatureMismatch callStack pk signed
+  where
+    Signature sk' = decoration signed
+
+data SignatureMismatch = forall a. Show a => SignatureMismatch CallStack PublicKey (Signed a)
+
+deriving instance Show SignatureMismatch

--- a/src/Ouroboros/Infra/Crypto/Mock.hs
+++ b/src/Ouroboros/Infra/Crypto/Mock.hs
@@ -30,7 +30,7 @@ module Ouroboros.Infra.Crypto.Mock (
   ) where
 
 import           Control.Monad.Except
-import           GHC.Generics         (Generic)
+import           GHC.Generics (Generic)
 import           GHC.Stack
 
 import           Ouroboros.Infra.Util

--- a/src/Ouroboros/Infra/Exception.hs
+++ b/src/Ouroboros/Infra/Exception.hs
@@ -6,12 +6,12 @@ module Ouroboros.Infra.Exception (
   , wrapExceptionsIO
   ) where
 
-import Data.List (intercalate)
-import Data.Proxy
-import GHC.Stack
-import UnliftIO
+import           Data.List (intercalate)
+import           Data.Proxy
+import           GHC.Stack
+import           UnliftIO
 
-import Ouroboros.Infra.Util.HList
+import           Ouroboros.Infra.Util.HList
 
 {-------------------------------------------------------------------------------
   Wrap exceptions

--- a/src/Ouroboros/Infra/Exception.hs
+++ b/src/Ouroboros/Infra/Exception.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Ouroboros.Infra.Exception (
+    wrapExceptions
+  , wrapExceptionsIO
+  ) where
+
+import Data.List (intercalate)
+import Data.Proxy
+import GHC.Stack
+import UnliftIO
+
+import Ouroboros.Infra.Util.HList
+
+{-------------------------------------------------------------------------------
+  Wrap exceptions
+-------------------------------------------------------------------------------}
+
+wrapExceptions :: (MonadUnliftIO m, HasCallStack, All Show as, IsList as)
+               => Fn as (m b) -> HList as -> m b
+wrapExceptions fn args =
+    catch (applyFn fn args) $ \e ->
+      throwIO $ WrappedException callStack (collapse (Proxy @Show) show args) e
+
+wrapExceptionsIO :: forall m as b.
+                    (MonadUnliftIO m, HasCallStack, All Show as, IsList as)
+                 => Fn as (IO b) -> HList as -> m b
+wrapExceptionsIO fn =
+    wrapExceptions (afterFn (isList :: SList as) (liftIO :: IO b -> m b) fn)
+
+data WrappedException = WrappedException CallStack [String] SomeException
+
+instance Show WrappedException where
+  show (WrappedException cs as e) = unlines [
+        "Exception " ++ displayException e
+      , "Arguments [" ++ intercalate ", " as ++ "]"
+      , prettyCallStack cs
+      ]
+
+instance Exception WrappedException

--- a/src/Ouroboros/Infra/Util.hs
+++ b/src/Ouroboros/Infra/Util.hs
@@ -24,22 +24,22 @@ module Ouroboros.Infra.Util (
   , Condense(..)
   ) where
 
-import qualified Data.ByteString             as Strict
+import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Base16.Lazy as Lazy.Base16
-import qualified Data.ByteString.Lazy        as Lazy
-import qualified Data.ByteString.Lazy.Char8  as Lazy.Char8
-import           Data.List                   (foldl', intercalate)
-import           Data.Map                    (Map)
-import qualified Data.Map.Strict             as Map
+import qualified Data.ByteString.Lazy as Lazy
+import qualified Data.ByteString.Lazy.Char8 as Lazy.Char8
+import           Data.List (foldl', intercalate)
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Proxy
-import           Data.Set                    (Set)
-import qualified Data.Set                    as Set
-import           GHC.Generics                (Generic)
-import           System.IO.Unsafe            (unsafePerformIO)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           GHC.Generics (Generic)
+import           System.IO.Unsafe (unsafePerformIO)
 import           UnliftIO
 
-import           Ouroboros.Infra.Util.HList  (All, HList (..))
-import qualified Ouroboros.Infra.Util.HList  as HList
+import           Ouroboros.Infra.Util.HList (All, HList (..))
+import qualified Ouroboros.Infra.Util.HList as HList
 
 {-------------------------------------------------------------------------------
   Miscellaneous

--- a/src/Ouroboros/Infra/Util.hs
+++ b/src/Ouroboros/Infra/Util.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE DeriveGeneric          #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE TypeApplications       #-}
+{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE UndecidableInstances   #-}
+
+module Ouroboros.Infra.Util (
+    -- * Miscellaneous
+    repeatedly
+  , chunks
+  , byteStringChunks
+  , lazyByteStringChunks
+    -- * Decorating one value with another
+  , DecoratedWith(..)
+  , Decorates(..)
+    -- * Thread-safe input/output
+  , threadSafeOutput
+  , threadSafeOutputHex
+  , threadSafeInput
+    -- * Pretty-printing
+  , Condense(..)
+  ) where
+
+import qualified Data.ByteString             as Strict
+import qualified Data.ByteString.Base16.Lazy as Lazy.Base16
+import qualified Data.ByteString.Lazy        as Lazy
+import qualified Data.ByteString.Lazy.Char8  as Lazy.Char8
+import           Data.List                   (foldl', intercalate)
+import           Data.Map                    (Map)
+import qualified Data.Map.Strict             as Map
+import           Data.Proxy
+import           Data.Set                    (Set)
+import qualified Data.Set                    as Set
+import           GHC.Generics                (Generic)
+import           System.IO.Unsafe            (unsafePerformIO)
+import           UnliftIO
+
+import           Ouroboros.Infra.Util.HList  (All, HList (..))
+import qualified Ouroboros.Infra.Util.HList  as HList
+
+{-------------------------------------------------------------------------------
+  Miscellaneous
+-------------------------------------------------------------------------------}
+
+repeatedly :: (a -> b -> b) -> ([a] -> b -> b)
+repeatedly = flip . foldl' . flip
+
+chunks :: Int -> [a] -> [[a]]
+chunks _ [] = []
+chunks n xs = let (chunk, xs') = splitAt n xs
+              in chunk : chunks n xs'
+
+byteStringChunks :: Int -> Strict.ByteString -> [Strict.ByteString]
+byteStringChunks n = map Strict.pack . chunks n . Strict.unpack
+
+lazyByteStringChunks :: Int -> Lazy.ByteString -> [Lazy.ByteString]
+lazyByteStringChunks n bs
+  | Lazy.null bs = []
+  | otherwise    = let (chunk, bs') = Lazy.splitAt (fromIntegral n) bs
+                   in chunk : lazyByteStringChunks n bs'
+
+{-------------------------------------------------------------------------------
+  Decorating one value with another
+-------------------------------------------------------------------------------}
+
+data DecoratedWith b a = DecoratedWith b a
+  deriving (Show, Eq, Ord, Generic)
+
+class Decorates b a | a -> b where
+  type Decoration a :: *
+  decoration   :: a -> Decoration a
+  decorateWith :: Decoration a -> b -> a
+  undecorate   :: a -> b
+
+instance Decorates a (DecoratedWith b a) where
+  type Decoration (DecoratedWith b a) = b
+  decoration (DecoratedWith b _) = b
+  undecorate (DecoratedWith _ a) = a
+  decorateWith = DecoratedWith
+
+instance (Condense b, Condense a) => Condense (DecoratedWith b a) where
+  condense (DecoratedWith b a) = condense (b, a)
+
+{-------------------------------------------------------------------------------
+  Thread-safe input/output
+-------------------------------------------------------------------------------}
+
+globalIOLock :: MVar ()
+{-# NOINLINE globalIOLock #-}
+globalIOLock = unsafePerformIO $ newMVar ()
+
+threadSafeOutput :: MonadUnliftIO m => Lazy.ByteString -> m ()
+threadSafeOutput a = withMVar globalIOLock $ \() ->
+    liftIO $ Lazy.Char8.putStrLn a
+
+threadSafeOutputHex :: MonadUnliftIO m => Lazy.ByteString -> m ()
+threadSafeOutputHex = threadSafeOutput . Lazy.Base16.encode
+
+threadSafeInput :: MonadUnliftIO m => m Lazy.ByteString
+threadSafeInput = withMVar globalIOLock $ \() ->
+    liftIO $ Lazy.fromStrict <$> Strict.getLine
+
+{-------------------------------------------------------------------------------
+  Condensed but human-readable output
+-------------------------------------------------------------------------------}
+
+class Condense a where
+  condense :: a -> String
+
+instance Condense String where
+  condense = id
+
+instance Condense Int where
+  condense = show
+
+instance {-# OVERLAPPING #-} Condense [String] where
+  condense ss = "[" ++ intercalate "," ss ++ "]"
+
+instance {-# OVERLAPPABLE #-} Condense a => Condense [a] where
+  condense as = "[" ++ intercalate "," (map condense as) ++ "]"
+
+instance All Condense as => Condense (HList as) where
+  condense as = "(" ++ intercalate "," (HList.collapse (Proxy @Condense) condense as) ++ ")"
+
+instance (Condense a, Condense b) => Condense (a, b) where
+  condense (a, b) = condense (a :* b :* Nil)
+
+instance Condense a => Condense (Set a) where
+  condense = condense . Set.toList
+
+instance (Condense k, Condense a) => Condense (Map k a) where
+  condense = condense . Map.toList

--- a/src/Ouroboros/Infra/Util/HList.hs
+++ b/src/Ouroboros/Infra/Util/HList.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE BangPatterns         #-}
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Heterogeneous lists
+--
+-- Intended for qualified import
+module Ouroboros.Infra.Util.HList (
+    -- * Basic definitions
+    HList(..)
+  , All
+    -- * Folding
+  , foldl
+  , foldr
+  , repeatedly
+  , collapse
+    -- * Singletons
+  , SList
+  , IsList(..)
+    -- * n-ary functions
+  , Fn
+  , applyFn
+  , afterFn
+  ) where
+
+import Prelude hiding (foldl, foldr)
+import Data.Kind (Constraint)
+import Data.Proxy
+
+{-------------------------------------------------------------------------------
+  Basic definitions
+-------------------------------------------------------------------------------}
+
+data HList :: [*] -> * where
+  Nil  :: HList '[]
+  (:*) :: a -> HList as -> HList (a ': as)
+
+infixr :*
+
+type family All c as :: Constraint where
+  All c '[]       = ()
+  All c (a ': as) = (c a, All c as)
+
+instance All Show as => Show (HList as) where
+  show = show . collapse (Proxy @Show) show
+
+{-------------------------------------------------------------------------------
+  Folding
+-------------------------------------------------------------------------------}
+
+foldl :: forall c as b proxy. All c as
+      => proxy c
+      -> (forall a. c a => b -> a -> b) -> b -> HList as -> b
+foldl _ f = go
+  where
+    go :: All c as' => b -> HList as' -> b
+    go !acc Nil       = acc
+    go !acc (a :* as) = go (f acc a) as
+
+foldr :: forall c as b proxy. All c as
+      => proxy c
+      -> (forall a. c a => a -> b -> b) -> b -> HList as -> b
+foldr _ f e = go
+  where
+    go :: All c as' => HList as' -> b
+    go Nil       = e
+    go (a :* as) = f a (go as)
+
+-- | Apply function repeatedly for all elements of the list
+--
+-- > repeatedly p = flip . foldl p . flip
+repeatedly :: forall c as b proxy. All c as
+           => proxy c
+           -> (forall a. c a => a -> b -> b) -> (HList as -> b -> b)
+repeatedly p f as e = foldl p (\b a -> f a b) e as
+
+collapse :: forall c as b proxy. All c as
+         => proxy c
+         -> (forall a. c a => a -> b) -> HList as -> [b]
+collapse _ f = go
+  where
+    go :: All c as' => HList as' -> [b]
+    go Nil       = []
+    go (a :* as) = f a : go as
+
+{-------------------------------------------------------------------------------
+  Singleton for HList
+-------------------------------------------------------------------------------}
+
+data SList :: [*] -> * where
+  SNil :: SList '[]
+  SCons :: SList as -> SList (a ': as)
+
+class IsList (xs :: [*]) where
+  isList :: SList xs
+
+instance              IsList '[]       where isList = SNil
+instance IsList as => IsList (a ': as) where isList = SCons isList
+
+{-------------------------------------------------------------------------------
+  n-ary functions
+-------------------------------------------------------------------------------}
+
+type family Fn as b where
+  Fn '[]       b = b
+  Fn (a ': as) b = a -> Fn as b
+
+withArgs :: HList as -> Fn as b -> b
+withArgs Nil       b = b
+withArgs (a :* as) f = withArgs as (f a)
+
+applyFn :: Fn as b -> HList as -> b
+applyFn = flip withArgs
+
+afterFn :: SList as -> (b -> c) -> Fn as b -> Fn as c
+afterFn SNil       g b = g b
+afterFn (SCons ss) g f = afterFn ss g . f

--- a/src/Ouroboros/Infra/Util/HList.hs
+++ b/src/Ouroboros/Infra/Util/HList.hs
@@ -31,9 +31,9 @@ module Ouroboros.Infra.Util.HList (
   , afterFn
   ) where
 
-import Prelude hiding (foldl, foldr)
-import Data.Kind (Constraint)
-import Data.Proxy
+import           Data.Kind (Constraint)
+import           Data.Proxy
+import           Prelude hiding (foldl, foldr)
 
 {-------------------------------------------------------------------------------
   Basic definitions

--- a/src/Ouroboros/UTxO/Mock.hs
+++ b/src/Ouroboros/UTxO/Mock.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE ViewPatterns               #-}
+
+module Ouroboros.UTxO.Mock (
+    -- * Basic definitions
+    PreTx(..)
+  , Tx(..)
+  , mkTx
+  , TxIn
+  , TxOut
+  , Addr
+  , Utxo
+    -- * Compute UTxO
+  , HasUtxo(..)
+  , utxo
+  ) where
+
+import           Data.Map                    (Map)
+import qualified Data.Map.Strict             as Map
+import           Data.Proxy
+import           Data.Set                    (Set)
+import qualified Data.Set                    as Set
+import           GHC.Generics                (Generic)
+
+import           Ouroboros.Infra.Crypto.Mock
+import           Ouroboros.Infra.Util
+import           Ouroboros.Infra.Util.HList  (All, HList)
+import qualified Ouroboros.Infra.Util.HList  as HList
+
+{-------------------------------------------------------------------------------
+  Basic definitions
+-------------------------------------------------------------------------------}
+
+data PreTx = PreTx (Set TxIn) [TxOut]
+  deriving (Show, Eq, Ord, Generic)
+
+instance Condense PreTx where
+  condense (PreTx ins outs) = condense (ins, outs)
+
+newtype Tx = Tx (Hashable Tx PreTx)
+  deriving (Show, Eq, Ord, Generic, Decorates PreTx, Condense)
+
+mkTx :: Hash Tx -> PreTx -> Tx
+mkTx = decorateWith
+
+type TxIn  = (Hash Tx, Int)
+type TxOut = (Addr, Int)
+type Addr  = String
+type Utxo  = Map TxIn TxOut
+
+{-------------------------------------------------------------------------------
+  Computing UTxO
+-------------------------------------------------------------------------------}
+
+class HasUtxo a where
+  txIns      :: a -> Set TxIn
+  txOuts     :: a -> Utxo
+  confirmed  :: a -> Set Tx
+  updateUtxo :: a -> Utxo -> Utxo
+
+utxo :: HasUtxo a => a -> Utxo
+utxo a = updateUtxo a Map.empty
+
+instance HasUtxo Tx where
+  txIns     (undecorate -> PreTx ins _outs) = ins
+  txOuts tx@(undecorate -> PreTx _ins outs) =
+      Map.fromList $ map aux (zip [0..] outs)
+    where
+      aux :: (Int, TxOut) -> (TxIn, TxOut)
+      aux (ix, out) = ((decoration tx, ix), out)
+
+  confirmed       = Set.singleton
+  updateUtxo tx u = u `Map.union` txOuts tx
+
+instance HasUtxo a => HasUtxo (Set a) where
+  txIns           = txIns     . Set.toList
+  txOuts          = txOuts    . Set.toList
+  confirmed       = confirmed . Set.toList
+  updateUtxo as u = (u `Map.union` txOuts as) `Map.withoutKeys` txIns as
+
+instance HasUtxo a => HasUtxo [a] where
+  txIns      = foldr (Set.union . txIns)     Set.empty
+  txOuts     = foldr (Map.union . txOuts)    Map.empty
+  confirmed  = foldr (Set.union . confirmed) Set.empty
+  updateUtxo = repeatedly updateUtxo
+
+instance All HasUtxo as => HasUtxo (HList as) where
+  txIns      = HList.foldr (Proxy @HasUtxo) (Set.union . txIns)     Set.empty
+  txOuts     = HList.foldr (Proxy @HasUtxo) (Map.union . txOuts)    Map.empty
+  confirmed  = HList.foldr (Proxy @HasUtxo) (Set.union . confirmed) Set.empty
+  updateUtxo = HList.repeatedly (Proxy @HasUtxo) updateUtxo

--- a/src/Ouroboros/UTxO/Mock.hs
+++ b/src/Ouroboros/UTxO/Mock.hs
@@ -18,17 +18,17 @@ module Ouroboros.UTxO.Mock (
   ) where
 
 import           Codec.Serialise
-import           Data.Map          (Map)
-import qualified Data.Map.Strict   as Map
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Proxy
-import           Data.Set          (Set)
-import qualified Data.Set          as Set
-import           GHC.Generics      (Generic)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           GHC.Generics (Generic)
 
 import           Infra.Crypto.Hash
 import           Infra.Util
-import           Infra.Util.HList  (All, HList)
-import qualified Infra.Util.HList  as HList
+import           Infra.Util.HList (All, HList)
+import qualified Infra.Util.HList as HList
 
 
 {-------------------------------------------------------------------------------
@@ -74,7 +74,7 @@ instance HasUtxo a => HasUtxo (Set a) where
   txIns           = txIns     . Set.toList
   txOuts          = txOuts    . Set.toList
   confirmed       = confirmed . Set.toList
-  updateUtxo as u = (u `Map.union` txOuts as) `Map.withoutKeys` txIns as
+  updateUtxo as u = (u `Map.union` txOuts as) `withoutKeys` txIns as
 
 instance HasUtxo a => HasUtxo [a] where
   txIns      = foldr (Set.union . txIns)     Set.empty

--- a/src/Util/Singletons.hs
+++ b/src/Util/Singletons.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ConstraintKinds        #-}
+{-# LANGUAGE DataKinds              #-}
 {-# LANGUAGE GADTs                  #-}
 {-# LANGUAGE PolyKinds              #-}
 {-# LANGUAGE RankNTypes             #-}
@@ -18,6 +20,8 @@ module Util.Singletons (
   , SomeSing(..)
   , withSomeSing
   , SingKind(..)
+  -- * Carrying around witnesses
+  , Dict(..)
   ) where
 
 import           Data.Kind (Type)
@@ -54,3 +58,14 @@ class SingKind k where
 
   fromSing :: Sing (a :: k) -> Demote k
   toSing :: Demote k -> SomeSing k
+
+
+-- | Carrying around witnesses
+-- A 'Dict' is a tiny but incredibly useful data structure that allows one to
+-- pass around typeclass instances as if they were first class values. It does
+-- so by capturing the constraints in the type constructor itself. \"Opening\"
+-- the dictionary via pattern matching is enough for GHC to bring in any
+-- instances \"trapped inside the dictionary\" into the rest of the code block.
+
+data Dict a where
+    Dict :: a => Dict a

--- a/test/Test/Chain.hs
+++ b/test/Test/Chain.hs
@@ -23,6 +23,8 @@ import           Serialise             (prop_serialise)
 import qualified Data.List             as L
 import           Data.Maybe            (listToMaybe)
 
+import           Util.Singletons       (Dict (..))
+
 import           Test.QuickCheck
 import           Test.Tasty            (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
@@ -164,7 +166,7 @@ newtype TestBlockChain p = TestBlockChain { getTestBlockChain :: Chain (Block 'T
     deriving (Eq, Show)
 
 instance SingShow TestBlockChain where
-  singShow s = singKnownOuroborosProtocol s $ show
+  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
 
 -- | A test generator for a valid chain of block headers.
 --
@@ -172,7 +174,7 @@ newtype TestHeaderChain p = TestHeaderChain (Chain (BlockHeader p))
     deriving (Eq, Show)
 
 instance SingShow TestHeaderChain where
-  singShow s = singKnownOuroborosProtocol s $ show
+  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
 
 instance SingArbitrary TestBlockChain where
     singArbitrary _ = do
@@ -296,7 +298,7 @@ data TestAddBlock p = TestAddBlock (Chain (Block 'TestLedgerDomain p)) (Block 'T
   deriving Show
 
 instance SingShow TestAddBlock where
-  singShow s = singKnownOuroborosProtocol s $ show
+  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
 
 instance SingArbitrary TestAddBlock where
   singArbitrary p = do
@@ -338,7 +340,7 @@ data TestBlockChainAndUpdates p =
   deriving Show
 
 instance SingShow TestBlockChainAndUpdates where
-  singShow s = singKnownOuroborosProtocol s $ show
+  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
 
 instance SingArbitrary TestBlockChainAndUpdates where
   singArbitrary p = do
@@ -434,7 +436,7 @@ data TestChainAndPoint p = TestChainAndPoint (Chain (Block 'TestLedgerDomain p))
   deriving Show
 
 instance SingShow TestChainAndPoint where
-  singShow s = singKnownOuroborosProtocol s $ show
+  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
 
 instance SingArbitrary TestChainAndPoint where
   singArbitrary p = do
@@ -499,7 +501,7 @@ instance KnownOuroborosProtocol p => Show (TestChainFork p) where
       Chain.prettyPrintChain nl show f2
 
 instance SingShow TestChainFork where
-  singShow s = singKnownOuroborosProtocol s $ show
+  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
 
 instance SingArbitrary TestChainFork where
   singArbitrary p = do

--- a/test/Test/Chain.hs
+++ b/test/Test/Chain.hs
@@ -14,19 +14,18 @@ module Test.Chain
   ) where
 
 import           Block
-import           Chain                 (Chain (..), ChainUpdate (..),
-                                        Point (..), genesisPoint)
+import           Chain (Chain (..), ChainUpdate (..), Point (..), genesisPoint)
 import qualified Chain
 import           Ouroboros
-import           Serialise             (prop_serialise)
+import           Serialise (prop_serialise)
 
-import qualified Data.List             as L
-import           Data.Maybe            (listToMaybe)
+import qualified Data.List as L
+import           Data.Maybe (listToMaybe)
 
-import           Util.Singletons       (Dict (..))
+import           Util.Singletons (Dict (..))
 
 import           Test.QuickCheck
-import           Test.Tasty            (TestTree, testGroup)
+import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
 import           Test.DepFn

--- a/test/Test/ChainProducerState.hs
+++ b/test/Test/ChainProducerState.hs
@@ -1,22 +1,26 @@
+{-# LANGUAGE DataKinds      #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeOperators  #-}
 
 module Test.ChainProducerState (tests) where
 
-import           Data.List (unfoldr)
+import           Data.List             (unfoldr)
 
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Chain (Block, Chain, ChainUpdate (..), Point (..),
-                     genesisPoint, headPoint, pointOnChain)
+import           Block                 (LedgerDomain (TestLedgerDomain))
+import           Chain                 (Block, Chain, ChainUpdate (..),
+                                        Point (..), genesisPoint, headPoint,
+                                        pointOnChain)
 import qualified Chain
 import           ChainProducerState
 import           Ouroboros
 
-import           Test.Chain (TestBlockChain (..), TestBlockChainAndUpdates (..),
-                     TestChainFork (..), mkRollbackPoint)
+import           Test.Chain            (TestBlockChain (..),
+                                        TestBlockChainAndUpdates (..),
+                                        TestChainFork (..), mkRollbackPoint)
 import           Test.DepFn
 import           Test.Ouroboros
 
@@ -166,14 +170,14 @@ prop_switchFork = simpleProp $ \_ (ChainProducerStateForkTest cps f) ->
 --
 
 data ChainProducerStateTest p
-    = ChainProducerStateTest (ChainProducerState (Block p)) ReaderId Point
+    = ChainProducerStateTest (ChainProducerState (Block 'TestLedgerDomain p)) ReaderId Point
   deriving Show
 
 instance SingShow ChainProducerStateTest where
   singShow s = singKnownOuroborosProtocol s $ show
 
 genReaderState :: Int   -- ^ length of the chain
-               -> Chain (Block p)
+               -> Chain (Block 'TestLedgerDomain p)
                -> Gen ReaderState
 genReaderState n c = do
     readerPoint <- frequency
@@ -206,7 +210,7 @@ instance SingArbitrary ChainProducerStateTest where
     return (ChainProducerStateTest (ChainProducerState c rs) rid p)
 
 data ChainProducerStateForkTest p
-    = ChainProducerStateForkTest (ChainProducerState (Block p)) (Chain (Block p))
+    = ChainProducerStateForkTest (ChainProducerState (Block 'TestLedgerDomain p)) (Chain (Block 'TestLedgerDomain p))
   deriving Show
 
 instance SingShow ChainProducerStateForkTest where
@@ -233,7 +237,7 @@ instance SingArbitrary ChainProducerStateForkTest where
        | TestBlockChain c' <- singShrink p (TestBlockChain c)
        ]
     where
-      fixupReaderPointer :: Chain (Block p) -> ReaderState -> ReaderState
+      fixupReaderPointer :: Chain (Block 'TestLedgerDomain p) -> ReaderState -> ReaderState
       fixupReaderPointer c' r@ReaderState{readerPoint} =
         if pointOnChain readerPoint c'
           then r

--- a/test/Test/ChainProducerState.hs
+++ b/test/Test/ChainProducerState.hs
@@ -18,6 +18,8 @@ import qualified Chain
 import           ChainProducerState
 import           Ouroboros
 
+import           Util.Singletons       (Dict (..))
+
 import           Test.Chain            (TestBlockChain (..),
                                         TestBlockChainAndUpdates (..),
                                         TestChainFork (..), mkRollbackPoint)
@@ -174,7 +176,7 @@ data ChainProducerStateTest p
   deriving Show
 
 instance SingShow ChainProducerStateTest where
-  singShow s = singKnownOuroborosProtocol s $ show
+  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
 
 genReaderState :: Int   -- ^ length of the chain
                -> Chain (Block 'TestLedgerDomain p)
@@ -214,7 +216,7 @@ data ChainProducerStateForkTest p
   deriving Show
 
 instance SingShow ChainProducerStateForkTest where
-  singShow s = singKnownOuroborosProtocol s $ show
+  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
 
 instance SingArbitrary ChainProducerStateForkTest where
   singArbitrary p = do

--- a/test/Test/ChainProducerState.hs
+++ b/test/Test/ChainProducerState.hs
@@ -4,25 +4,23 @@
 
 module Test.ChainProducerState (tests) where
 
-import           Data.List             (unfoldr)
+import           Data.List (unfoldr)
 
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Block                 (LedgerDomain (TestLedgerDomain))
-import           Chain                 (Block, Chain, ChainUpdate (..),
-                                        Point (..), genesisPoint, headPoint,
-                                        pointOnChain)
+import           Block (LedgerDomain (TestLedgerDomain))
+import           Chain (Block, Chain, ChainUpdate (..), Point (..),
+                     genesisPoint, headPoint, pointOnChain)
 import qualified Chain
 import           ChainProducerState
 import           Ouroboros
 
-import           Util.Singletons       (Dict (..))
+import           Util.Singletons (Dict (..))
 
-import           Test.Chain            (TestBlockChain (..),
-                                        TestBlockChainAndUpdates (..),
-                                        TestChainFork (..), mkRollbackPoint)
+import           Test.Chain (TestBlockChain (..), TestBlockChainAndUpdates (..),
+                     TestChainFork (..), mkRollbackPoint)
 import           Test.DepFn
 import           Test.Ouroboros
 

--- a/test/Test/Node.hs
+++ b/test/Test/Node.hs
@@ -18,6 +18,8 @@ import           Data.Maybe            (isNothing, listToMaybe)
 import           Data.Semigroup        ((<>))
 import           Data.Tuple            (swap)
 
+import           Util.Singletons       (Dict (..))
+
 import           Test.QuickCheck
 import           Test.Tasty            (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
@@ -149,7 +151,7 @@ data TestNodeSim p = TestNodeSim
   deriving (Show, Eq)
 
 instance SingShow TestNodeSim where
-  singShow s = singKnownOuroborosProtocol s $ show
+  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
 
 instance SingArbitrary TestNodeSim where
   singArbitrary p = do

--- a/test/Test/Node.hs
+++ b/test/Test/Node.hs
@@ -5,38 +5,38 @@
 {-# LANGUAGE TypeOperators       #-}
 module Test.Node where
 
-import           Control.Monad         (forM, forM_, forever, replicateM)
+import           Control.Monad (forM, forM_, forever, replicateM)
 import           Control.Monad.ST.Lazy (runST)
-import           Control.Monad.State   (execStateT, lift, modify')
+import           Control.Monad.State (execStateT, lift, modify')
 import           Data.Array
-import           Data.Functor          (void)
+import           Data.Functor (void)
 import           Data.Graph
-import           Data.List             (foldl')
-import           Data.Map.Strict       (Map)
-import qualified Data.Map.Strict       as Map
-import           Data.Maybe            (isNothing, listToMaybe)
-import           Data.Semigroup        ((<>))
-import           Data.Tuple            (swap)
+import           Data.List (foldl')
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (isNothing, listToMaybe)
+import           Data.Semigroup ((<>))
+import           Data.Tuple (swap)
 
-import           Util.Singletons       (Dict (..))
+import           Util.Singletons (Dict (..))
 
 import           Test.QuickCheck
-import           Test.Tasty            (TestTree, testGroup)
+import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
 import           Block
-import           Chain                 (Chain (..))
+import           Chain (Chain (..))
 import qualified Chain
 import           MonadClass
 import           Node
 import           Ouroboros
-import           Protocol              (MsgConsumer, MsgProducer)
+import           Protocol (MsgConsumer, MsgProducer)
 import qualified Sim
 
-import           Test.Chain            (TestBlockChain (..), TestChainFork (..))
+import           Test.Chain (TestBlockChain (..), TestChainFork (..))
 import           Test.DepFn
 import           Test.Ouroboros
-import           Test.Sim              (TestThreadGraph (..))
+import           Test.Sim (TestThreadGraph (..))
 
 tests :: TestTree
 tests =

--- a/test/Test/Ouroboros.hs
+++ b/test/Test/Ouroboros.hs
@@ -13,6 +13,7 @@ module Test.Ouroboros (
 
 import           Ouroboros
 import           Test.DepFn
+import           Util.Singletons (Dict (..))
 
 -- TODO: We may wish to make this a type family so that we can write stuff like
 -- @a :-> b :-> c@ to mean @DepFn '[a, b] c@. For now this will do though.
@@ -20,5 +21,5 @@ type (:->) (a :: (k -> *)) b = DepFn '[a] b
 
 simpleProp :: (forall p. KnownOuroborosProtocol p => Sing p -> a p -> b) -> (a :-> b)
 simpleProp k = DepFn $ \protocol (a :* Nil) ->
-                 singKnownOuroborosProtocol protocol $
-                   k protocol a
+                 case dictKnownOuroborosProtocol protocol of
+                      Dict -> k protocol a

--- a/test/Test/Pipe.hs
+++ b/test/Test/Pipe.hs
@@ -1,20 +1,24 @@
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeOperators     #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Pipe (tests) where
 
-import           Block (Block, HeaderHash (..), Slot (..))
-import           Chain (Chain (..), Point (..))
+import           Block                 (Block, HeaderHash (..),
+                                        LedgerDomain (..), Slot (..))
+import           Chain                 (Chain (..), Point (..))
 import           Ouroboros
-import           Pipe (demo2)
+import           Pipe                  (demo2)
 import           Protocol
-import           Serialise (prop_serialise)
+import           Serialise             (prop_serialise)
 
-import           Test.Chain (TestBlockChainAndUpdates (..), genBlockChain)
+import           Test.Chain            (TestBlockChainAndUpdates (..),
+                                        genBlockChain)
 import           Test.DepFn
 import           Test.Ouroboros
 
 import           Test.QuickCheck
-import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty            (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
 --
@@ -42,7 +46,7 @@ prop_serialise_MsgConsumer :: MsgConsumer -> Bool
 prop_serialise_MsgConsumer = prop_serialise
 
 newtype BlockProducer p = BlockProducer {
-    blockProducer :: MsgProducer (Block p)
+    blockProducer :: MsgProducer (Block 'TestLedgerDomain p)
   }
   deriving (Show)
 
@@ -70,7 +74,7 @@ instance Arbitrary Point where
   arbitrary = Point <$> (Slot <$> arbitraryBoundedIntegral)
                     <*> (HeaderHash <$> arbitraryBoundedIntegral)
 
-instance SingArbitrary Block where
+instance SingArbitrary (Block 'TestLedgerDomain) where
   singArbitrary _ = do
     c <- genBlockChain 1
     case c of

--- a/test/Test/Pipe.hs
+++ b/test/Test/Pipe.hs
@@ -4,23 +4,21 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Pipe (tests) where
 
-import           Block                 (Block, HeaderHash (..),
-                                        LedgerDomain (..), Slot (..))
-import           Chain                 (Chain (..), Point (..))
+import           Block (Block, HeaderHash (..), LedgerDomain (..), Slot (..))
+import           Chain (Chain (..), Point (..))
 import           Ouroboros
-import           Pipe                  (demo2)
+import           Pipe (demo2)
 import           Protocol
-import           Serialise             (prop_serialise)
+import           Serialise (prop_serialise)
 
-import           Util.Singletons       (Dict (..))
+import           Util.Singletons (Dict (..))
 
-import           Test.Chain            (TestBlockChainAndUpdates (..),
-                                        genBlockChain)
+import           Test.Chain (TestBlockChainAndUpdates (..), genBlockChain)
 import           Test.DepFn
 import           Test.Ouroboros
 
 import           Test.QuickCheck
-import           Test.Tasty            (TestTree, testGroup)
+import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
 --

--- a/test/Test/Pipe.hs
+++ b/test/Test/Pipe.hs
@@ -12,6 +12,8 @@ import           Pipe                  (demo2)
 import           Protocol
 import           Serialise             (prop_serialise)
 
+import           Util.Singletons       (Dict (..))
+
 import           Test.Chain            (TestBlockChainAndUpdates (..),
                                         genBlockChain)
 import           Test.DepFn
@@ -51,7 +53,7 @@ newtype BlockProducer p = BlockProducer {
   deriving (Show)
 
 instance SingShow BlockProducer where
-  singShow s = singKnownOuroborosProtocol s $ show
+  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
 
 prop_serialise_MsgProducer :: BlockProducer :-> Bool
 prop_serialise_MsgProducer = simpleProp $ \_ -> prop_serialise . blockProducer


### PR DESCRIPTION
This PR does a number of things:

- [x] It parametrise a `Block` over a `LedgerDomain` `dom`, allowing us to plug and play different block representations. It supersedes #15 .

- [x] It extends the `demo-playground` with a `MockPayload` which is more complicated than the `DummyPayload` and which `BlockBody` can store (mock) transactions.

- [x] It allows the `demo-playground` to be automatically run with different payloads, specifying which one to choose from the command line.