### PR TITLE
Make blockGenerator slightly more flexible

### DIFF
--- a/src/Node.hs
+++ b/src/Node.hs
@@ -2,22 +2,21 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Node where
 
-import           Control.Exception     (assert)
+import           Control.Exception (assert)
 import           Control.Monad
-import           Data.Functor          (($>))
-import           Data.List             hiding (inits)
-import           Data.Maybe            (catMaybes)
-import           Data.Semigroup        (Semigroup (..))
-import           Data.Tuple            (swap)
+import           Data.Functor (($>))
+import           Data.List hiding (inits)
+import           Data.Maybe (catMaybes)
+import           Data.Semigroup (Semigroup (..))
+import           Data.Tuple (swap)
 
 import           Block
-import           Chain                 (Chain (..), Point)
+import           Chain (Chain (..), Point)
 import qualified Chain
-import           ChainProducerState    (ChainProducerState (..), ReaderId,
-                                        initChainProducerState, producerChain,
-                                        switchFork)
+import           ChainProducerState (ChainProducerState (..), ReaderId,
+                     initChainProducerState, producerChain, switchFork)
 import           ConsumersAndProducers
-import           MonadClass            hiding (recvMsg, sendMsg)
+import           MonadClass hiding (recvMsg, sendMsg)
 import           Ouroboros
 import           Protocol
 

--- a/test/Test/Node.hs
+++ b/test/Test/Node.hs
@@ -4,36 +4,36 @@
 {-# LANGUAGE TypeOperators       #-}
 module Test.Node where
 
-import           Control.Monad         (forM, forM_, forever, replicateM)
+import           Control.Monad (forM, forM_, forever, replicateM)
 import           Control.Monad.ST.Lazy (runST)
-import           Control.Monad.State   (execStateT, lift, modify')
+import           Control.Monad.State (execStateT, lift, modify')
 import           Data.Array
-import           Data.Functor          (void)
+import           Data.Functor (void)
 import           Data.Graph
-import           Data.List             (foldl')
-import           Data.Map.Strict       (Map)
-import qualified Data.Map.Strict       as Map
-import           Data.Maybe            (isNothing, listToMaybe)
-import           Data.Semigroup        ((<>))
-import           Data.Tuple            (swap)
+import           Data.List (foldl')
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (isNothing, listToMaybe)
+import           Data.Semigroup ((<>))
+import           Data.Tuple (swap)
 
 import           Test.QuickCheck
-import           Test.Tasty            (TestTree, testGroup)
+import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
 import           Block
-import           Chain                 (Chain (..))
+import           Chain (Chain (..))
 import qualified Chain
 import           MonadClass
 import           Node
 import           Ouroboros
-import           Protocol              (MsgConsumer, MsgProducer)
+import           Protocol (MsgConsumer, MsgProducer)
 import qualified Sim
 
-import           Test.Chain            (TestBlockChain (..), TestChainFork (..))
+import           Test.Chain (TestBlockChain (..), TestChainFork (..))
 import           Test.DepFn
 import           Test.Ouroboros
-import           Test.Sim              (TestThreadGraph (..))
+import           Test.Sim (TestThreadGraph (..))
 
 tests :: TestTree
 tests =

--- a/test/Test/Node.hs
+++ b/test/Test/Node.hs
@@ -4,36 +4,36 @@
 {-# LANGUAGE TypeOperators       #-}
 module Test.Node where
 
-import           Control.Monad (forM, forM_, forever, replicateM)
+import           Control.Monad         (forM, forM_, forever, replicateM)
 import           Control.Monad.ST.Lazy (runST)
-import           Control.Monad.State (execStateT, lift, modify')
+import           Control.Monad.State   (execStateT, lift, modify')
 import           Data.Array
-import           Data.Functor (void)
+import           Data.Functor          (void)
 import           Data.Graph
-import           Data.List (foldl')
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import           Data.Maybe (isNothing, listToMaybe)
-import           Data.Semigroup ((<>))
-import           Data.Tuple (swap)
+import           Data.List             (foldl')
+import           Data.Map.Strict       (Map)
+import qualified Data.Map.Strict       as Map
+import           Data.Maybe            (isNothing, listToMaybe)
+import           Data.Semigroup        ((<>))
+import           Data.Tuple            (swap)
 
 import           Test.QuickCheck
-import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty            (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
 import           Block
-import           Chain (Chain (..))
+import           Chain                 (Chain (..))
 import qualified Chain
 import           MonadClass
 import           Node
 import           Ouroboros
-import           Protocol (MsgConsumer, MsgProducer)
+import           Protocol              (MsgConsumer, MsgProducer)
 import qualified Sim
 
-import           Test.Chain (TestBlockChain (..), TestChainFork (..))
+import           Test.Chain            (TestBlockChain (..), TestChainFork (..))
 import           Test.DepFn
 import           Test.Ouroboros
-import           Test.Sim (TestThreadGraph (..))
+import           Test.Sim              (TestThreadGraph (..))
 
 tests :: TestTree
 tests =
@@ -83,7 +83,7 @@ test_blockGenerator chain slotDuration = isValid <$> withProbe (experiment slotD
       -> Probe m (Block p)
       -> m ()
     experiment slotDur p = do
-      v <- blockGenerator slotDur chain
+      v <- blockGenerator slotDur (reverse $ Chain.toList chain)
       fork $ forever $ do
         b <- atomically $ getBlock v
         probeOutput p b
@@ -343,7 +343,7 @@ instance SingArbitrary TestNetworkGraph where
 
 instance SingShow TestNetworkGraph where
     -- TODO: we need `SingShow` instance for `Chain (Block p)`
-    singShow _p (TestNetworkGraph g _cs) = "TestNetworkGraph " ++ show g 
+    singShow _p (TestNetworkGraph g _cs) = "TestNetworkGraph " ++ show g
 
 networkGraphSim :: forall p m stm .
                   ( KnownOuroborosProtocol p


### PR DESCRIPTION
This PR changes the interface of `blockGenerator` to take a list of blocks rather than a full chain. This opens up more interesting scenarios where we can use it (for example in the `demo-playground`) to provide nodes with an initial chain, and then use the block generator to start producing blocks _from the tip of the initial chain onwards_. At the moment, this is not possible with the current `blockGenerator` as it wants a fully formed `Chain` which _has_ to start from `Genesis`.