### PR TITLE
Generate list not chain in core node

### DIFF
--- a/demo-playground/Logging.hs
+++ b/demo-playground/Logging.hs
@@ -59,7 +59,7 @@ loggerConsumer q chainvar ourProducer =
     logChain :: IO ()
     logChain = atomically $ do
         chain <- readTVar chainvar
-        let m = "Current chain candidate: " <> show (Chain.toList chain)
+        let m = "Current chain candidate: " <> show (Chain.toOldestFirst chain)
         writeTBQueue q $ LogEvent m ourProducer
 
     logMsg :: String -> IO ()

--- a/demo-playground/Main.hs
+++ b/demo-playground/Main.hs
@@ -24,7 +24,6 @@ import           Data.String.Conv (toS)
 import           Options.Applicative
 
 import           Chain (Chain (..))
-import qualified Chain
 import           ChainProducerState
 import           ConsumersAndProducers
 import qualified Node
@@ -185,11 +184,9 @@ runNode CLI{..} = do
           NamedPipe.runProducer myNodeId consumerNodeId $
             exampleProducer cps
 
-chainFrom :: Chain Payload -> Int -> Chain Payload
-chainFrom Genesis n =
-    foldl (\acc b -> Chain.addBlock (DummyPayload b) acc) Genesis [1..n]
-chainFrom c@(_ :> DummyPayload x) n =
-    foldl (\acc b -> Chain.addBlock (DummyPayload b) acc) c [x+1..x+n]
+chainFrom :: Chain Payload -> Int -> [Payload]
+chainFrom Genesis               n = [DummyPayload i | i <- [1..n]]
+chainFrom (_ :> DummyPayload x) n = [DummyPayload i | i <- [x+1..x+n]]
 
 slotDuration :: Int
 slotDuration = 2 * 1000000

--- a/src/Chain.hs
+++ b/src/Chain.hs
@@ -33,8 +33,9 @@ module Chain (
 
   -- ** Basic operations
   head,
-  toList,
-  fromList,
+  toNewestFirst,
+  toOldestFirst,
+  fromNewestFirst,
   drop,
   Chain.length,
   Chain.null,
@@ -157,14 +158,18 @@ headBlockNo (_ :> b) = blockNo b
 
 -- | Produce the list of blocks, from most recent back to genesis
 --
-toList :: Chain block -> [block]
-toList = foldChain (flip (:)) []
+toNewestFirst :: Chain block -> [block]
+toNewestFirst = foldChain (flip (:)) []
+
+-- | Produce the list of blocks, from genesis to the most recent
+toOldestFirst :: Chain block -> [block]
+toOldestFirst = reverse . toNewestFirst
 
 -- | Make a chain from a list of blocks. The head of the list is the head
 -- of the chain.
 --
-fromList :: HasHeader block => [block p] -> Chain (block p)
-fromList bs = assert (valid c) c
+fromNewestFirst :: HasHeader block => [block p] -> Chain (block p)
+fromNewestFirst bs = assert (valid c) c
   where
     c = foldr (flip (:>)) Genesis bs
 
@@ -227,7 +232,7 @@ lookupBySlot (c :> b) slot | blockSlot b == slot = Just b
                            | otherwise           = lookupBySlot c slot
 
 isPrefixOf :: Eq block => Chain block -> Chain block -> Bool
-a `isPrefixOf` b = reverse (toList a) `L.isPrefixOf` reverse (toList b)
+a `isPrefixOf` b = reverse (toNewestFirst a) `L.isPrefixOf` reverse (toNewestFirst b)
 
 
 data ChainUpdate block = AddBlock block

--- a/src/Node.hs
+++ b/src/Node.hs
@@ -356,12 +356,13 @@ forkCoreKernel :: forall block p m stm.
                   )
                => Duration (Time m)
                -- ^ slot duration
-               -> Chain (block p)
+               -> [block p]
+               -- ^ Blocks to produce (in order they should be produced)
                -> (Chain (block p) -> block p -> block p)
                -> TVar m (ChainProducerState (block p))
                -> m ()
 forkCoreKernel slotDuration gchain fixupBlock cpsVar = do
-  blockVar <- blockGenerator slotDuration (reverse $ Chain.toList gchain)
+  blockVar <- blockGenerator slotDuration gchain
   fork $ forever $ applyGeneratedBlock blockVar
 
   where
@@ -400,7 +401,8 @@ coreNode :: forall p m stm.
      => NodeId
      -> Duration (Time m)
      -- ^ slot duration
-     -> Chain (Block p)
+     -> [Block p]
+     -- ^ Blocks to produce (in order they should be produced)
      -> NodeChannels m (MsgProducer (Block p)) MsgConsumer
      -> m (TVar m (ChainProducerState (Block p)))
 coreNode nid slotDuration gchain chans = do


### PR DESCRIPTION
Alfredo previously modified the blockchain generator to take a list of blocks,
rather than a chain, so that it would be valid to give it a chain suffix, but
he didn't push that change through also to the core node itself. This PR makes
the further modification.

It also renames `toList` to `toNewestFirst`, and introduces `toOldestFirst`, so
that we are a bit more explicit about the ordering of the blocks.