### PR TITLE
Move concrete block type to its own module

### DIFF
--- a/demo-playground/Logging.hs
+++ b/demo-playground/Logging.hs
@@ -1,8 +1,10 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Logging (
@@ -17,11 +19,12 @@ import           Data.Semigroup ((<>))
 import           GHC.Stack
 
 import           Block
+import           Block.Concrete
 import           Chain (Chain (..))
 import qualified Chain
 import           ConsumersAndProducers
 import           Infra.Util
-import           Ouroboros (NodeId, OuroborosProtocol (..))
+import           Ouroboros (NodeId)
 import           ProtocolInterfaces
 
 data LogEvent = LogEvent {
@@ -34,7 +37,9 @@ showNetworkTraffic q = forever $ do
     LogEvent{..} <- atomically $ readTBQueue q
     putStrLn $ "[conv_with:" <> show sender <> "] " <> msg
 
-instance Condense (BlockHeader 'OuroborosBFT) where
+deriving instance Condense BlockNo
+
+instance Condense BlockHeader where
     condense BlockHeader{..} =
       "{hash: " <> condense headerHash
                 <> ", blockNo: "

--- a/demo-playground/Payload.hs
+++ b/demo-playground/Payload.hs
@@ -20,7 +20,6 @@ module Payload (
 import           Data.List (intercalate)
 import           Data.Semigroup ((<>))
 
-import           Block
 import           Chain (Chain)
 import qualified DummyPayload as Dummy
 import           Infra.Util
@@ -62,14 +61,14 @@ instance Condense PayloadType where
     condense DummyPayloadType = "dummy"
     condense MockPayloadType  = "mock"
 
-class PayloadImplementation (block :: PayloadType) where
-    type Payload block = (b :: OuroborosProtocol -> *) | b -> block
-    fixupBlock :: KnownOuroborosProtocol p => Chain (Payload block p) -> (Payload block p) -> (Payload block p)
-    chainFrom  :: KnownOuroborosProtocol p => Chain (Payload block p) -> Int -> [Payload block p]
-    toChain    :: KnownOuroborosProtocol p => [Int] -> Chain (Payload block p)
+class PayloadImplementation (pt :: PayloadType) where
+    type Payload pt = b | b -> pt
+    fixupBlock :: Chain (Payload pt) -> (Payload pt) -> (Payload pt)
+    chainFrom  :: Chain (Payload pt) -> Int -> [Payload pt]
+    toChain    :: [Int] -> Chain (Payload pt)
 
 instance PayloadImplementation 'MockPayloadType where
-    type Payload 'MockPayloadType = Block 'MockLedgerDomain
+    type Payload 'MockPayloadType = Mock.SimpleUtxoBlock
     fixupBlock = Mock.fixupBlock
     chainFrom  = Mock.chainFrom
     toChain    = Mock.toChain

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -21,6 +21,7 @@ library
   -- This has to be tidied up once the design becomes clear.
   exposed-modules:     Block
                        Block.Mock
+                       Block.Concrete
                        Chain
                        ChainProducerState
                        ConsumersAndProducers

--- a/src/Block.hs
+++ b/src/Block.hs
@@ -1,105 +1,29 @@
-{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeFamilies               #-}
 
--- | Reference implementation of a representation of a block in a block chain.
+-- | Abstract view over blocks
 --
+-- The network layer does not make any concrete assumptions about what blocks
+-- look like.
 module Block (
-      -- * Types
-      Block (..)
-    , BlockHeader(..)
-    , BlockBody(..)
-    , HasHeader(..)
-    , Slot(..)
-    , BlockNo(..)
-    , BlockSigner(..)
-    , HeaderHash(..)
-    , BodyHash(..)
-
-      -- * Working with different ledger domains
-    , LedgerDomain(..)
-    , KnownLedgerDomain(..)
-
-      -- * Hashing
-    , hashHeader
-    )
-    where
+    Slot(..)
+  , BlockNo(..)
+  , BlockSigner(..)
+  , HasHeader(..)
+  ) where
 
 import           Data.Hashable
-import qualified Data.Text as Text
 
-import           Infra.Util
-import           Ouroboros
 import           Serialise
 
-import           Test.QuickCheck
-
-data LedgerDomain =
-    TestLedgerDomain
-  -- ^ A test domain (i.e. unit tests & properties)
-  | MockLedgerDomain
-  -- ^ A mock domain, useful to instrument examples and prototypes. It can
-  -- provide semi-realistic types which are not as-easy to construct as the
-  -- test ones, but definitely less complicated than the \"real\" ones.
-  | CardanoLedgerDomain
-  -- ^ A \"real world\" ledger domain.
-
--- | Our highly-simplified version of a block. It retains the separation
--- between a block header and body, which is a detail needed for the protocols.
---
-data Block (dom :: LedgerDomain) (p :: OuroborosProtocol) = Block {
-       blockHeader :: BlockHeader p,
-       blockBody   :: BlockBody dom
-     }
-
-deriving instance (KnownOuroborosProtocol p, Show (BlockBody dom)) => Show (Block dom p)
-deriving instance (KnownOuroborosProtocol p, Eq (BlockBody dom))   => Eq   (Block dom p)
-
--- | A block header. It retains simplified versions of all the essential
--- elements.
---
-data BlockHeader (p :: OuroborosProtocol) = BlockHeader {
-       headerHash     :: HeaderHash,  -- ^ The cached 'HeaderHash' of this header.
-       headerPrevHash :: HeaderHash,  -- ^ The 'headerHash' of the previous block header
-       headerSlot     :: Slot,        -- ^ The Ouroboros time slot index of this block
-       headerBlockNo  :: BlockNo,     -- ^ The block index from the Genesis
-       headerSigner   :: BlockSigner, -- ^ Who signed this block
-       headerBodyHash :: BodyHash     -- ^ The hash of the corresponding block body
-     }
-
-deriving instance KnownOuroborosProtocol p => Show (BlockHeader p)
-deriving instance KnownOuroborosProtocol p => Eq   (BlockHeader p)
-
--- | Similarly to the 'KnownOuroborosProtocol' class, a 'KnownLedgerDomain'
--- class allow us to talk about different ledger domains, each with its own
--- 'BlockBody'.
-class KnownLedgerDomain (dom :: LedgerDomain) where
-  data family BlockBody dom :: *
-  -- | Compute the 'BodyHash' of the 'BlockBody'
-  --
-  hashBody :: BlockBody dom -> BodyHash
-
--- | A block body.
---
--- For this model we use an opaque string as we do not care about the content
--- because we focus on the blockchain layer (rather than the ledger layer).
---
-instance KnownLedgerDomain 'TestLedgerDomain where
-  data BlockBody 'TestLedgerDomain = BlockBody String deriving (Show, Eq, Ord)
-
-  hashBody (BlockBody b) = BodyHash (hash b)
-
--- | The 0-based index of the block in the blockchain
-newtype BlockNo      = BlockNo Word
+-- | The Ouroboros time slot index for a block.
+newtype Slot = Slot { getSlot :: Word }
   deriving (Show, Eq, Ord, Hashable, Enum)
 
-instance Condense BlockNo where
-    condense (BlockNo w) = show w
+-- | The 0-based index of the block in the blockchain
+newtype BlockNo = BlockNo Word
+  deriving (Show, Eq, Ord, Hashable, Enum)
 
 -- | An identifier for someone signing a block.
 --
@@ -107,121 +31,49 @@ instance Condense BlockNo where
 -- (which for Ouroboros BFT is actually the case), and omit the cryptography
 -- and model things as if the signatures were valid.
 --
-newtype BlockSigner  = BlockSigner Word
+-- TODO: This should go completely; the network layer should not have to
+-- think about signatures at all.
+newtype BlockSigner = BlockSigner Word
   deriving (Show, Eq, Ord, Hashable)
 
--- | The hash of all the information in a 'BlockHeader'.
+-- | Abstract over the shape of blocks (or indeed just block headers)
 --
-newtype HeaderHash   = HeaderHash Int
-  deriving (Show, Eq, Ord, Hashable, Condense)
+-- TODO: does the network layer really need to be aware of body hashes? I think
+-- that can go.
+class ( Eq        (HeaderHash b)
+      , Ord       (HeaderHash b)
+      , Show      (HeaderHash b)
+      , Serialise (HeaderHash b)
+      , Eq        (BodyHash   b)
+      , Ord       (BodyHash   b)
+      , Show      (BodyHash   b)
+      , Serialise (BodyHash   b)
+      ) => HasHeader b where
+    -- TODO: I /think/ we should be able to make these injective, but I'd have
+    -- to check after the redesign of the block abstraction (which will live
+    -- in the consensus layer), to make sure injectivity is compatible with that
+    -- design (and compatible with the concrete instantiation used in the
+    -- network layer tests).
+    type HeaderHash b :: *
+    type BodyHash   b :: *
 
--- | The hash of all the information in a 'BlockBody'.
---
-newtype BodyHash     = BodyHash Int
-  deriving (Show, Eq, Ord, Hashable, Condense)
-
-
--- | Compute the 'HeaderHash' of the 'BlockHeader'.
---
-hashHeader :: BlockHeader p -> HeaderHash
-hashHeader (BlockHeader _ b c d e f) = HeaderHash (hash (b, c, d, e, f))
-
---
--- Class to help us treat blocks and headers similarly
---
-
--- | This class lets us treat chains of block headers and chains of whole
--- blocks in a parametrised way.
---
-class HasHeader b where
-    blockHash      :: b -> HeaderHash
-    blockPrevHash  :: b -> HeaderHash
+    blockHash      :: b -> HeaderHash b
+    blockPrevHash  :: b -> HeaderHash b
     blockSlot      :: b -> Slot
     blockNo        :: b -> BlockNo
     blockSigner    :: b -> BlockSigner
-    blockBodyHash  :: b -> BodyHash
+    blockBodyHash  :: b -> BodyHash b
 
     blockInvariant :: b -> Bool
 
-instance HasHeader (BlockHeader p) where
-    blockHash      = headerHash
-    blockPrevHash  = headerPrevHash
-    blockSlot      = headerSlot
-    blockNo        = headerBlockNo
-    blockSigner    = headerSigner
-    blockBodyHash  = headerBodyHash
+    -- TODO: This really shouldn't exist at all. There _is_ no genesis block,
+    -- and it should have no hash.
+    genesisHash :: proxy b -> HeaderHash b
 
-    -- | The header invariant is that the cached header hash is correct.
-    --
-    blockInvariant = \b -> hashHeader b == headerHash b
+{-------------------------------------------------------------------------------
+  Serialisation
+-------------------------------------------------------------------------------}
 
-instance KnownLedgerDomain dom => HasHeader (Block dom p) where
-    blockHash      = headerHash     . blockHeader
-    blockPrevHash  = headerPrevHash . blockHeader
-    blockSlot      = headerSlot     . blockHeader
-    blockNo        = headerBlockNo  . blockHeader
-    blockSigner    = headerSigner   . blockHeader
-    blockBodyHash  = headerBodyHash . blockHeader
-
-    -- | The block invariant is just that the actual block body hash matches the
-    -- body hash listed in the header.
-    --
-    blockInvariant Block { blockBody, blockHeader = BlockHeader {headerBodyHash} } =
-        headerBodyHash == hashBody blockBody
-
---
--- Generators
---
-
-instance Arbitrary (BlockBody 'TestLedgerDomain) where
-    arbitrary = BlockBody <$> vectorOf 4 (choose ('A', 'Z'))
-    -- probably no need for shrink, the content is arbitrary and opaque
-    -- if we add one, it might be to shrink to an empty block
-
---
--- Serialisation
---
-
-instance Serialise (Block 'TestLedgerDomain p) where
-
-  encode Block {blockHeader, blockBody} =
-      encodeListLen 2
-   <> encode blockHeader
-   <> encode   blockBody
-
-  decode = do
-      decodeListLenOf 2
-      Block <$> decode <*> decode
-
-instance Serialise (BlockHeader p) where
-
-  encode BlockHeader {
-         headerHash     = HeaderHash headerHash,
-         headerPrevHash = HeaderHash headerPrevHash,
-         headerSlot     = Slot headerSlot,
-         headerBlockNo  = BlockNo headerBlockNo,
-         headerSigner   = BlockSigner headerSigner,
-         headerBodyHash = BodyHash headerBodyHash
-       } =
-      encodeListLen 6
-   <> encodeInt  headerHash
-   <> encodeInt  headerPrevHash
-   <> encodeWord headerSlot
-   <> encodeWord headerBlockNo
-   <> encodeWord headerSigner
-   <> encodeInt  headerBodyHash
-
-  decode = do
-      decodeListLenOf 6
-      BlockHeader <$> (HeaderHash <$> decodeInt)
-                  <*> (HeaderHash <$> decodeInt)
-                  <*> (Slot <$> decodeWord)
-                  <*> (BlockNo <$> decodeWord)
-                  <*> (BlockSigner <$> decodeWord)
-                  <*> (BodyHash <$> decodeInt)
-
-instance Serialise (BlockBody 'TestLedgerDomain) where
-
-  encode (BlockBody b) = encodeString (Text.pack b)
-
-  decode = BlockBody . Text.unpack <$> decodeString
+instance Serialise Slot where
+  encode (Slot s) = encodeWord s
+  decode = Slot <$> decodeWord

--- a/src/Block/Concrete.hs
+++ b/src/Block/Concrete.hs
@@ -1,0 +1,224 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+-- | Concrete block
+--
+-- The network library should not export a concrete block type at all, except
+-- that it might need one in its tests (but not exported). Right now this module
+-- serves to isolate this in a specific module so we can identify easily where
+-- it is used; eventually it should be simplified and then moved to the
+-- network layer tests; the more sophiscated block abstraction (abstracted over
+-- an Ouroboros protocol) will live in the consensus layer.
+module Block.Concrete (
+    Block(..)
+  , BlockHeader(..)
+  , BlockBody(..)
+  , hashHeader
+  , ConcreteBodyHash(..)
+  , ConcreteHeaderHash(..)
+  , hashBody
+  , fixupBlock
+  , fixupBlockHeader
+  ) where
+
+import           Data.Hashable
+import           Data.Proxy
+import qualified Data.Text as Text
+import           Test.QuickCheck
+
+import           Block
+import           Chain
+import           Infra.Util
+import           Serialise
+
+{-------------------------------------------------------------------------------
+  Concrete block shape used currently in the network layer
+
+  This should only exist in the network layer /tests/.
+-------------------------------------------------------------------------------}
+
+-- | Our highly-simplified version of a block. It retains the separation
+-- between a block header and body, which is a detail needed for the protocols.
+--
+data Block = Block {
+       blockHeader :: BlockHeader,
+       blockBody   :: BlockBody
+     }
+   deriving (Show, Eq)
+
+data BlockBody = BlockBody String
+  deriving (Show, Eq, Ord)
+
+hashBody :: BlockBody -> ConcreteBodyHash
+hashBody (BlockBody b) = BodyHash (hash b)
+
+-- | A block header. It retains simplified versions of all the essential
+-- elements.
+--
+data BlockHeader = BlockHeader {
+       headerHash     :: ConcreteHeaderHash,  -- ^ The cached 'HeaderHash' of this header.
+       headerPrevHash :: ConcreteHeaderHash,  -- ^ The 'headerHash' of the previous block header
+       headerSlot     :: Slot,                -- ^ The Ouroboros time slot index of this block
+       headerBlockNo  :: BlockNo,             -- ^ The block index from the Genesis
+       headerSigner   :: BlockSigner,         -- ^ Who signed this block
+       headerBodyHash :: ConcreteBodyHash     -- ^ The hash of the corresponding block body
+     }
+   deriving (Show, Eq)
+
+-- | Compute the 'HeaderHash' of the 'BlockHeader'.
+--
+hashHeader :: BlockHeader -> ConcreteHeaderHash
+hashHeader (BlockHeader _ b c d e f) = HeaderHash (hash (b, c, d, e, f))
+
+-- | The hash of all the information in a 'BlockHeader'.
+--
+newtype ConcreteHeaderHash   = HeaderHash Int
+  deriving (Show, Eq, Ord, Hashable, Condense)
+
+-- | The hash of all the information in a 'BlockBody'.
+--
+newtype ConcreteBodyHash     = BodyHash Int
+  deriving (Show, Eq, Ord, Hashable, Condense)
+
+{-------------------------------------------------------------------------------
+  HasHeader instances
+-------------------------------------------------------------------------------}
+
+instance HasHeader BlockHeader where
+    type HeaderHash BlockHeader = ConcreteHeaderHash
+    type BodyHash   BlockHeader = ConcreteBodyHash
+
+    blockHash      = headerHash
+    blockPrevHash  = headerPrevHash
+    blockSlot      = headerSlot
+    blockNo        = headerBlockNo
+    blockSigner    = headerSigner
+    blockBodyHash  = headerBodyHash
+
+    -- | The header invariant is that the cached header hash is correct.
+    --
+    blockInvariant = \b -> hashHeader b == headerHash b
+
+    genesisHash _ = HeaderHash 0
+
+instance HasHeader Block where
+    type HeaderHash Block = ConcreteHeaderHash
+    type BodyHash   Block = ConcreteBodyHash
+
+    blockHash      = headerHash     . blockHeader
+    blockPrevHash  = headerPrevHash . blockHeader
+    blockSlot      = headerSlot     . blockHeader
+    blockNo        = headerBlockNo  . blockHeader
+    blockSigner    = headerSigner   . blockHeader
+    blockBodyHash  = headerBodyHash . blockHeader
+
+    -- | The block invariant is just that the actual block body hash matches the
+    -- body hash listed in the header.
+    --
+    blockInvariant Block { blockBody, blockHeader = BlockHeader {headerBodyHash} } =
+        headerBodyHash == hashBody blockBody
+
+    genesisHash _ = genesisHash (Proxy @BlockHeader)
+
+{-------------------------------------------------------------------------------
+  "Fixup" is used for chain construction in the network tests. These functions
+  don't make much sense for real chains.
+-------------------------------------------------------------------------------}
+
+-- | Fixup block so to fit it on top of a chain.  Only block number, previous
+-- hash and block hash are updated; slot number and signers are kept intact.
+--
+fixupBlock :: (HasHeader block, HeaderHash block ~ ConcreteHeaderHash)
+           => Chain block -> Block -> Block
+fixupBlock c b@Block{blockBody, blockHeader} =
+    b { blockHeader = fixupBlockHeader c (hashBody blockBody) blockHeader }
+
+-- | Fixup block header to fit it on top of a chain.  Only block number and
+-- previous hash are updated; the slot and signer are kept unchanged.
+--
+fixupBlockHeader :: (HasHeader block, HeaderHash block ~ ConcreteHeaderHash)
+                 => Chain block -> ConcreteBodyHash -> BlockHeader -> BlockHeader
+fixupBlockHeader c h b = b'
+  where
+    b' = BlockHeader {
+      headerHash     = hashHeader b',
+      headerPrevHash = headHash c,
+      headerSlot     = headerSlot b,   -- keep the existing slot number
+      headerSigner   = headerSigner b, -- and signer
+      headerBlockNo  = succ $ headBlockNo c,
+      headerBodyHash = h
+    }
+
+{-------------------------------------------------------------------------------
+  Arbitrary instances
+
+  TODO: Should we have a policy that Arbitrary instances should not live
+  in the main modules?
+-------------------------------------------------------------------------------}
+
+--
+-- Generators
+--
+
+instance Arbitrary BlockBody where
+    arbitrary = BlockBody <$> vectorOf 4 (choose ('A', 'Z'))
+    -- probably no need for shrink, the content is arbitrary and opaque
+    -- if we add one, it might be to shrink to an empty block
+
+{-------------------------------------------------------------------------------
+  Serialisation
+-------------------------------------------------------------------------------}
+
+instance Serialise ConcreteHeaderHash where
+  encode (HeaderHash h) = encodeInt h
+  decode = HeaderHash <$> decodeInt
+
+instance Serialise ConcreteBodyHash where
+  encode (BodyHash h) = encodeInt h
+  decode = BodyHash <$> decodeInt
+
+instance Serialise Block where
+
+  encode Block {blockHeader, blockBody} =
+      encodeListLen 2
+   <> encode blockHeader
+   <> encode   blockBody
+
+  decode = do
+      decodeListLenOf 2
+      Block <$> decode <*> decode
+
+instance Serialise BlockHeader where
+
+  encode BlockHeader {
+         headerHash     = HeaderHash headerHash,
+         headerPrevHash = HeaderHash headerPrevHash,
+         headerSlot     = Slot headerSlot,
+         headerBlockNo  = BlockNo headerBlockNo,
+         headerSigner   = BlockSigner headerSigner,
+         headerBodyHash = BodyHash headerBodyHash
+       } =
+      encodeListLen 6
+   <> encodeInt  headerHash
+   <> encodeInt  headerPrevHash
+   <> encodeWord headerSlot
+   <> encodeWord headerBlockNo
+   <> encodeWord headerSigner
+   <> encodeInt  headerBodyHash
+
+  decode = do
+      decodeListLenOf 6
+      BlockHeader <$> (HeaderHash <$> decodeInt)
+                  <*> (HeaderHash <$> decodeInt)
+                  <*> (Slot <$> decodeWord)
+                  <*> (BlockNo <$> decodeWord)
+                  <*> (BlockSigner <$> decodeWord)
+                  <*> (BodyHash <$> decodeInt)
+
+instance Serialise BlockBody where
+
+  encode (BlockBody b) = encodeString (Text.pack b)
+
+  decode = BlockBody . Text.unpack <$> decodeString

--- a/src/Block/Mock.hs
+++ b/src/Block/Mock.hs
@@ -1,16 +1,22 @@
 {-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Block.Mock where
 
-import           Block (Block (..), BlockHeader (..), BodyHash (..),
-                     KnownLedgerDomain (..), LedgerDomain (..))
-import           Data.Maybe (maybe)
+import           Data.Proxy
 import           Data.Set (Set)
+import qualified Data.Set as Set
+import           GHC.Generics (Generic)
 import           GHC.Natural (naturalToWordMaybe)
+
+import           Block
+import           Block.Concrete
 
 import qualified Infra.Crypto.Hash as H
 import           Infra.Util (Condense (..))
@@ -18,18 +24,59 @@ import           Ouroboros.UTxO.Mock (HasUtxo (..))
 import qualified Ouroboros.UTxO.Mock as Mock
 import           Serialise
 
+-- Concrete block representation with a bunch of transactions
+--
+-- For now we just reuse the concrete header from the networking layer.
+data SimpleUtxoBlock = SimpleUtxoBlock {
+      simpleUtxoHeader :: BlockHeader
+    , simpleUtxoBody   :: Set Mock.Tx
+    }
+  deriving (Generic, Show)
+
+instance Condense SimpleUtxoBlock where
+  condense = show -- TODO
+
+simpleUtxoBodyHash :: Set Mock.Tx -> ConcreteBodyHash
+simpleUtxoBodyHash = BodyHash
+                   . maybe 0 fromIntegral
+                   . naturalToWordMaybe
+                   . H.fromHash
+                   . H.hash
+                   . Set.toList
+
+instance HasUtxo SimpleUtxoBlock where
+  txIns      = txIns      . simpleUtxoBody
+  txOuts     = txOuts     . simpleUtxoBody
+  updateUtxo = updateUtxo . simpleUtxoBody
+  confirmed  = confirmed  . simpleUtxoBody
+
+instance HasHeader SimpleUtxoBlock where
+    type HeaderHash SimpleUtxoBlock = ConcreteHeaderHash
+    type BodyHash   SimpleUtxoBlock = ConcreteBodyHash
+
+    blockHash      = headerHash     . simpleUtxoHeader
+    blockPrevHash  = headerPrevHash . simpleUtxoHeader
+    blockSlot      = headerSlot     . simpleUtxoHeader
+    blockNo        = headerBlockNo  . simpleUtxoHeader
+    blockSigner    = headerSigner   . simpleUtxoHeader
+    blockBodyHash  = headerBodyHash . simpleUtxoHeader
+
+    -- | The block invariant is just that the actual block body hash matches the
+    -- body hash listed in the header.
+    --
+    blockInvariant (SimpleUtxoBlock header body) =
+        simpleUtxoBodyHash body == blockBodyHash header
+
+    genesisHash _ = genesisHash (Proxy @BlockHeader)
+
+{-
 instance KnownLedgerDomain 'MockLedgerDomain where
-    data BlockBody 'MockLedgerDomain = BlockBody {
+    data BlockBody 'MockLedgerDomain = MockBlockBody {
           blockData :: Set (Mock.Tx)
-        } deriving Show
-    hashBody (BlockBody b) =
+        } deriving (Show, Eq)
+    hashBody (MockBlockBody b) =
       BodyHash (maybe maxBound fromEnum $ naturalToWordMaybe $ H.fromHash $ H.hash b)
 
-instance HasUtxo (BlockBody 'MockLedgerDomain) where
-  txIns      = txIns      . blockData
-  txOuts     = txOuts     . blockData
-  updateUtxo = updateUtxo . blockData
-  confirmed  = confirmed  . blockData
 
 instance Condense (BlockHeader p) => Condense (Block 'MockLedgerDomain p) where
     condense (Block hdr body) =
@@ -37,26 +84,7 @@ instance Condense (BlockHeader p) => Condense (Block 'MockLedgerDomain p) where
                  <> ", body: "
                  <> condense (hashBody body)
                  <> "}"
+-}
 
---
--- Serialisation
---
-
-instance Serialise (BlockBody 'MockLedgerDomain) where
-
-  encode (BlockBody b) = encodeListLen 1 <> encode b
-  decode = do
-    decodeListLenOf 1
-    BlockBody <$> decode
-
-
-instance Serialise (Block 'MockLedgerDomain p) where
-
-  encode Block {blockHeader, blockBody} =
-      encodeListLen 2
-   <> encode blockHeader
-   <> encode   blockBody
-
-  decode = do
-      decodeListLenOf 2
-      Block <$> decode <*> decode
+instance Serialise SimpleUtxoBlock where
+  -- rely on generics instance

--- a/src/ConsumersAndProducers.hs
+++ b/src/ConsumersAndProducers.hs
@@ -37,7 +37,7 @@ exampleConsumer :: forall block m stm.
 exampleConsumer chainvar =
     ConsumerHandlers {..}
   where
-    getChainPoints :: m [Point]
+    getChainPoints :: m [Point block]
     getChainPoints =
         Chain.selectPoints recentOffsets <$> atomically (readTVar chainvar)
 
@@ -47,7 +47,7 @@ exampleConsumer chainvar =
         let !chain' = Chain.addBlock b chain
         writeTVar chainvar chain'
 
-    rollbackTo :: Point -> m ()
+    rollbackTo :: Point block -> m ()
     rollbackTo p = atomically $ do
         chain <- readTVar chainvar
         --TODO: handle rollback failure
@@ -84,7 +84,7 @@ exampleProducer chainvar =
       writeTVar chainvar cps'
       return rid
 
-    improveReadPoint :: ReaderId -> [Point] -> m (Maybe (Point, Point))
+    improveReadPoint :: ReaderId -> [Point block] -> m (Maybe (Point block, Point block))
     improveReadPoint rid points =
       atomically $ do
         cps <- readTVar chainvar

--- a/src/Infra/Util.hs
+++ b/src/Infra/Util.hs
@@ -125,6 +125,9 @@ instance Condense String where
 instance Condense Int where
   condense = show
 
+instance Condense Word where
+  condense = show
+
 instance Condense Natural where
   condense = show
 

--- a/src/Ouroboros.hs
+++ b/src/Ouroboros.hs
@@ -8,8 +8,7 @@
 
 module Ouroboros (
     -- * Typed used across all protocols
-    Slot(..)
-  , NodeId(..)
+    NodeId(..)
     -- * Generalize over the Ouroboros protocols
   , OuroborosProtocol(..)
   , Sing(..)
@@ -26,10 +25,6 @@ import           Util.Singletons
 {-------------------------------------------------------------------------------
   Types used across all protocols
 -------------------------------------------------------------------------------}
-
--- | The Ouroboros time slot index for a block.
-newtype Slot = Slot { getSlot :: Word }
-  deriving (Show, Eq, Ord, Hashable, Enum)
 
 data NodeId = CoreId Int
             | RelayId Int

--- a/src/Pipe.hs
+++ b/src/Pipe.hs
@@ -146,8 +146,8 @@ demo2 chain0 updates = do
 
     return (expectedChain == chain')
 
-type ConsumerSideProtocol block = Protocol MsgConsumer (MsgProducer block)
-type ProducerSideProtocol block = Protocol (MsgProducer block) MsgConsumer
+type ConsumerSideProtocol block = Protocol (MsgConsumer block) (MsgProducer block)
+type ProducerSideProtocol block = Protocol (MsgProducer block) (MsgConsumer block)
 
 runProducer :: forall block r. (Chain.HasHeader block, Serialise block)
             => Handle -> Handle -> ProducerHandlers block IO r -> IO ()

--- a/src/ProtocolInterfaces.hs
+++ b/src/ProtocolInterfaces.hs
@@ -14,14 +14,14 @@ import           Chain (ChainUpdate (..), Point (..))
 -- to update a local chain to synchronise it with the producer chain.
 --
 data ConsumerHandlers block m = ConsumerHandlers {
-       getChainPoints :: m [Point],
+       getChainPoints :: m [Point block],
        -- ^ get a list of points from which the producer will pick the common
        -- intersection point.  The reference implementation just sends whole
        -- chain.
        addBlock       :: block -> m (),
        -- ^ apply received @'block'@ to its chain.  The reference implementation
        -- is using @'Chain.addBlock'@ to update its internal state.
-       rollbackTo     :: Point -> m ()
+       rollbackTo     :: Point block -> m ()
        -- ^ rollback to a given point.  The reference implementation is using
        -- @'Chain.rollback'@ to update its internal state.
      }
@@ -34,7 +34,7 @@ data ProducerHandlers block m r = ProducerHandlers {
        newReader          :: m r,
        -- ^ allocate new reader state.  The reference implementation is using
        -- @'ChainProducerState.initReader'@ to mutate its internal state.
-       improveReadPoint   :: r -> [Point] -> m (Maybe (Point, Point)),
+       improveReadPoint   :: r -> [Point block] -> m (Maybe (Point block, Point block)),
        -- ^ find the most optimal intersection between received list of
        -- @'Point'@s and producers chain.  The second point is the current tip.
        tryReadChainUpdate :: r -> m (Maybe (ChainUpdate block)),
@@ -75,4 +75,3 @@ liftProducerHandlers lift ProducerHandlers {
       tryReadChainUpdate = \r -> lift (tryReadChainUpdate r),
       readChainUpdate    = \r -> lift (readChainUpdate r)
     }
-

--- a/test/Test/ChainProducerState.hs
+++ b/test/Test/ChainProducerState.hs
@@ -10,19 +10,14 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Block (LedgerDomain (TestLedgerDomain))
-import           Chain (Block, Chain, ChainUpdate (..), Point (..),
-                     genesisPoint, headPoint, pointOnChain)
+import           Block.Concrete (Block (..))
+import           Chain (Chain, ChainUpdate (..), Point (..), genesisPoint,
+                     headPoint, pointOnChain)
 import qualified Chain
 import           ChainProducerState
-import           Ouroboros
-
-import           Util.Singletons (Dict (..))
 
 import           Test.Chain (TestBlockChain (..), TestBlockChainAndUpdates (..),
                      TestChainFork (..), mkRollbackPoint)
-import           Test.DepFn
-import           Test.Ouroboros
 
 tests :: TestTree
 tests =
@@ -50,16 +45,16 @@ tests =
 -- | Check that readers start in the expected state, at the right point and
 -- in the rollback state.
 --
-prop_init_lookup :: ChainProducerStateTest :-> Bool
-prop_init_lookup = simpleProp $ \_ (ChainProducerStateTest c _ p) ->
+prop_init_lookup :: ChainProducerStateTest -> Bool
+prop_init_lookup (ChainProducerStateTest c _ p) =
     let (c', rid) = initReader p c in
     lookupReader c' rid == ReaderState p ReaderBackTo rid
 
 -- | As above but check that when we move the reader on by one, from the
 -- rollback state, they stay at the same point but are now in the forward state.
 --
-prop_init_next_lookup :: ChainProducerStateTest :-> Bool
-prop_init_next_lookup = simpleProp $ \_ (ChainProducerStateTest c _ p) ->
+prop_init_next_lookup :: ChainProducerStateTest -> Bool
+prop_init_next_lookup (ChainProducerStateTest c _ p) =
     let (c', rid)     = initReader p c
         Just (u, c'') = readerInstruction rid c'
     in u == RollBack p
@@ -68,16 +63,16 @@ prop_init_next_lookup = simpleProp $ \_ (ChainProducerStateTest c _ p) ->
 -- | Check that after moving the reader point that the reader is in the
 -- expected state, at the right point and in the rollback state.
 --
-prop_update_lookup :: ChainProducerStateTest :-> Bool
-prop_update_lookup = simpleProp $ \_ (ChainProducerStateTest c rid p) ->
+prop_update_lookup :: ChainProducerStateTest -> Bool
+prop_update_lookup (ChainProducerStateTest c rid p) =
     let c' = updateReader rid p c in
     lookupReader c' rid == ReaderState p ReaderBackTo rid
 
 -- | As above but check that when we move the reader on by one, from the
 -- rollback state, they stay at the same point but are now in the forward state.
 --
-prop_update_next_lookup :: ChainProducerStateTest :-> Bool
-prop_update_next_lookup = simpleProp $ \_ (ChainProducerStateTest c rid p) ->
+prop_update_next_lookup :: ChainProducerStateTest -> Bool
+prop_update_next_lookup (ChainProducerStateTest c rid p) =
     let c'            = updateReader rid p c
         Just (u, c'') = readerInstruction rid c'
     in u == RollBack p
@@ -91,8 +86,8 @@ prop_update_next_lookup = simpleProp $ \_ (ChainProducerStateTest c rid p) ->
 -- The limitation of this test is that it applies all the updates to the
 -- producer first and then syncronises without changing the producer.
 --
-prop_producer_sync1 :: TestBlockChainAndUpdates :-> Bool
-prop_producer_sync1 = simpleProp $ \_ (TestBlockChainAndUpdates c us) ->
+prop_producer_sync1 :: TestBlockChainAndUpdates -> Bool
+prop_producer_sync1 (TestBlockChainAndUpdates c us) =
     let producer0        = initChainProducerState c
         (producer1, rid) = initReader (Chain.headPoint c) producer0
         Just producer    = applyChainUpdates us producer1
@@ -109,8 +104,8 @@ prop_producer_sync1 = simpleProp $ \_ (TestBlockChainAndUpdates c us) ->
 -- interleaving of applying changes to the producer and doing syncronisation
 -- steps between the producer and consumer.
 --
-prop_producer_sync2 :: TestBlockChainAndUpdates :-> ([Bool] -> Bool)
-prop_producer_sync2 = simpleProp $ \_ (TestBlockChainAndUpdates chain0 us0) choices ->
+prop_producer_sync2 :: TestBlockChainAndUpdates -> [Bool] -> Bool
+prop_producer_sync2 (TestBlockChainAndUpdates chain0 us0) choices =
     let producer0        = initChainProducerState chain0
         (producer1, rid) = initReader (Chain.headPoint chain0) producer0
 
@@ -141,8 +136,8 @@ prop_producer_sync2 = simpleProp $ \_ (TestBlockChainAndUpdates chain0 us0) choi
         Just (u, p') -> go rid p' c' [] []
           where Just c' = Chain.applyChainUpdate u c
 
-prop_switchFork :: ChainProducerStateForkTest :-> Bool
-prop_switchFork = simpleProp $ \_ (ChainProducerStateForkTest cps f) ->
+prop_switchFork :: ChainProducerStateForkTest -> Bool
+prop_switchFork (ChainProducerStateForkTest cps f) =
   let cps' = switchFork f cps
   in
       invChainProducerState cps'
@@ -150,7 +145,7 @@ prop_switchFork = simpleProp $ \_ (ChainProducerStateForkTest cps f) ->
         (uncurry readerInv)
         (zip (chainReaders cps) (chainReaders cps'))
   where
-    readerInv :: ReaderState -> ReaderState -> Bool
+    readerInv :: ReaderState block -> ReaderState block -> Bool
     readerInv r r'
       -- the order of readers has not changed
        = readerId r == readerId r'
@@ -169,16 +164,13 @@ prop_switchFork = simpleProp $ \_ (ChainProducerStateForkTest cps f) ->
 -- Generators
 --
 
-data ChainProducerStateTest p
-    = ChainProducerStateTest (ChainProducerState (Block 'TestLedgerDomain p)) ReaderId Point
+data ChainProducerStateTest
+    = ChainProducerStateTest (ChainProducerState Block) ReaderId (Point Block)
   deriving Show
 
-instance SingShow ChainProducerStateTest where
-  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
-
 genReaderState :: Int   -- ^ length of the chain
-               -> Chain (Block 'TestLedgerDomain p)
-               -> Gen ReaderState
+               -> Chain Block
+               -> Gen (ReaderState Block)
 genReaderState n c = do
     readerPoint <- frequency
       [ (2, return (headPoint c))
@@ -192,15 +184,15 @@ genReaderState n c = do
     readerId <- arbitrary
     return $ ReaderState{readerPoint, readerNext, readerId}
 
-fixupReaderStates :: [ReaderState] -> [ReaderState]
+fixupReaderStates :: [ReaderState block] -> [ReaderState block]
 fixupReaderStates = go 0
   where
   go _ []       = []
   go n (r : rs) = r { readerId = n } : go (n + 1) rs
 
-instance SingArbitrary ChainProducerStateTest where
-  singArbitrary protocol = do
-    TestBlockChain c <- singArbitrary protocol
+instance Arbitrary ChainProducerStateTest where
+  arbitrary = do
+    TestBlockChain c <- arbitrary
     let n = Chain.length c
     rs <- fixupReaderStates <$> listOf1 (genReaderState n c)
     rid <- choose (0, length rs - 1)
@@ -209,46 +201,43 @@ instance SingArbitrary ChainProducerStateTest where
          else mkRollbackPoint c <$> choose (0, n)
     return (ChainProducerStateTest (ChainProducerState c rs) rid p)
 
-data ChainProducerStateForkTest p
-    = ChainProducerStateForkTest (ChainProducerState (Block 'TestLedgerDomain p)) (Chain (Block 'TestLedgerDomain p))
+data ChainProducerStateForkTest
+    = ChainProducerStateForkTest (ChainProducerState Block) (Chain Block)
   deriving Show
 
-instance SingShow ChainProducerStateForkTest where
-  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
-
-instance SingArbitrary ChainProducerStateForkTest where
-  singArbitrary p = do
-    TestChainFork _ c f <- singArbitrary p
+instance Arbitrary ChainProducerStateForkTest where
+  arbitrary = do
+    TestChainFork _ c f <- arbitrary
     let l = Chain.length c
     rs <- fixupReaderStates <$> listOf (genReaderState l c)
     return $ ChainProducerStateForkTest (ChainProducerState c rs) f
 
-  singShrink p (ChainProducerStateForkTest (ChainProducerState c rs) f)
+  shrink (ChainProducerStateForkTest (ChainProducerState c rs) f)
     -- shrink readers
      = [ ChainProducerStateForkTest (ChainProducerState c rs') f
        | rs' <- shrinkList (const []) rs
        ]
     -- shrink the fork chain
     ++ [ ChainProducerStateForkTest (ChainProducerState c rs) f'
-       | TestBlockChain f' <- singShrink p (TestBlockChain f)
+       | TestBlockChain f' <- shrink (TestBlockChain f)
        ]
     -- shrink chain and fix up readers
     ++ [ ChainProducerStateForkTest (ChainProducerState c' (fixupReaderPointer c' `map` rs)) f
-       | TestBlockChain c' <- singShrink p (TestBlockChain c)
+       | TestBlockChain c' <- shrink (TestBlockChain c)
        ]
     where
-      fixupReaderPointer :: Chain (Block 'TestLedgerDomain p) -> ReaderState -> ReaderState
+      fixupReaderPointer :: Chain Block -> ReaderState Block -> ReaderState Block
       fixupReaderPointer c' r@ReaderState{readerPoint} =
         if pointOnChain readerPoint c'
           then r
           else r { readerPoint = headPoint c' }
 
-prop_arbitrary_ChainProducerStateForkTest :: ChainProducerStateForkTest :-> Bool
-prop_arbitrary_ChainProducerStateForkTest = simpleProp $ \_ (ChainProducerStateForkTest c f) ->
+prop_arbitrary_ChainProducerStateForkTest :: ChainProducerStateForkTest -> Bool
+prop_arbitrary_ChainProducerStateForkTest (ChainProducerStateForkTest c f) =
     invChainProducerState c && Chain.valid f
 
-prop_shrink_ChainProducerStateForkTest :: ChainProducerStateForkTest :-> Bool
-prop_shrink_ChainProducerStateForkTest = simpleProp $ \p c ->
+prop_shrink_ChainProducerStateForkTest :: ChainProducerStateForkTest -> Bool
+prop_shrink_ChainProducerStateForkTest c =
     and [ invChainProducerState c' && Chain.valid f
-        | ChainProducerStateForkTest c' f <- singShrink p c
+        | ChainProducerStateForkTest c' f <- shrink c
         ]

--- a/test/Test/Pipe.hs
+++ b/test/Test/Pipe.hs
@@ -4,18 +4,14 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Pipe (tests) where
 
-import           Block (Block, HeaderHash (..), LedgerDomain (..), Slot (..))
+import           Block (Slot (..))
+import           Block.Concrete (Block, ConcreteHeaderHash (..))
 import           Chain (Chain (..), Point (..))
-import           Ouroboros
 import           Pipe (demo2)
 import           Protocol
 import           Serialise (prop_serialise)
 
-import           Util.Singletons (Dict (..))
-
 import           Test.Chain (TestBlockChainAndUpdates (..), genBlockChain)
-import           Test.DepFn
-import           Test.Ouroboros
 
 import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
@@ -38,44 +34,41 @@ tests =
 -- Properties
 --
 
-prop_pipe_demo :: TestBlockChainAndUpdates :-> Property
-prop_pipe_demo = simpleProp $ \_ (TestBlockChainAndUpdates chain updates) ->
+prop_pipe_demo :: TestBlockChainAndUpdates -> Property
+prop_pipe_demo (TestBlockChainAndUpdates chain updates) =
     ioProperty $ demo2 chain updates
 
-prop_serialise_MsgConsumer :: MsgConsumer -> Bool
+prop_serialise_MsgConsumer :: MsgConsumer Block -> Bool
 prop_serialise_MsgConsumer = prop_serialise
 
-newtype BlockProducer p = BlockProducer {
-    blockProducer :: MsgProducer (Block 'TestLedgerDomain p)
+newtype BlockProducer = BlockProducer {
+    blockProducer :: MsgProducer Block
   }
   deriving (Show)
 
-instance SingShow BlockProducer where
-  singShow s = case dictKnownOuroborosProtocol s of Dict -> show
+prop_serialise_MsgProducer :: BlockProducer -> Bool
+prop_serialise_MsgProducer = prop_serialise . blockProducer
 
-prop_serialise_MsgProducer :: BlockProducer :-> Bool
-prop_serialise_MsgProducer = simpleProp $ \_ -> prop_serialise . blockProducer
-
-instance Arbitrary MsgConsumer where
+instance Arbitrary (MsgConsumer Block) where
   arbitrary = oneof [ pure MsgRequestNext
                     , MsgSetHead <$> arbitrary
                     ]
 
-instance SingArbitrary BlockProducer where
-  singArbitrary s = BlockProducer <$>
+instance Arbitrary BlockProducer where
+  arbitrary = BlockProducer <$>
       oneof [ MsgRollBackward <$> arbitrary
-            , MsgRollForward  <$> singArbitrary s
+            , MsgRollForward  <$> arbitrary
             , pure MsgAwaitReply
             , MsgIntersectImproved <$> arbitrary <*> arbitrary
             , pure MsgIntersectUnchanged
             ]
 
-instance Arbitrary Point where
+instance Arbitrary (Point Block) where
   arbitrary = Point <$> (Slot <$> arbitraryBoundedIntegral)
                     <*> (HeaderHash <$> arbitraryBoundedIntegral)
 
-instance SingArbitrary (Block 'TestLedgerDomain) where
-  singArbitrary _ = do
+instance Arbitrary Block where
+  arbitrary = do
     c <- genBlockChain 1
     case c of
         _ :> b -> return b


### PR DESCRIPTION
and get rid of its type arguments. The network core is now entirely free from
all the consensus layer generalizations.

This means we don't currently have any tests for the Ouroboros stuff, but I'll
reintroduce that as a second step.