### PR TITLE
Initial merge of typed protocols 

### DIFF
--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -105,6 +105,7 @@ library
                        hashable     >=1.2 && <1.3,
                        memory       >=0.14 && <0.15,
                        mtl,
+                       network      >=2.6 && <2.8,
                        process,
                        random       >=1.1 && <1.2,
                        semigroups   >=0.18 && <0.19,

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -42,6 +42,7 @@ library
                        Ouroboros.Network.MonadClass.MonadProbe
                        Ouroboros.Network.MonadClass.MonadSay
                        Ouroboros.Network.MonadClass.MonadSendRecv
+                       Ouroboros.Network.MonadClass.MonadST
                        Ouroboros.Network.MonadClass.MonadSTM
                        Ouroboros.Network.MonadClass.MonadSTMTimer
                        Ouroboros.Network.MonadClass.MonadTimer

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -57,6 +57,10 @@ library
                        Ouroboros.Network.Protocol.PingPong.Client
                        Ouroboros.Network.Protocol.PingPong.Server
                        Ouroboros.Network.Protocol.PingPong.Direct
+                       Ouroboros.Network.Protocol.ChainSync.Type
+                       Ouroboros.Network.Protocol.ChainSync.Client
+                       Ouroboros.Network.Protocol.ChainSync.Server
+                       Ouroboros.Network.Protocol.ChainSync.Direct
   other-modules:
 -- Old experiments, not currently building:
 --                     Types

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -53,6 +53,7 @@ library
                        Ouroboros.Network.Sim
                        Ouroboros.Network.Testing.ConcreteBlock
                        Ouroboros.Network.Protocol.Typed
+                       Ouroboros.Network.Protocol.Untyped
                        Ouroboros.Network.Protocol.PingPong.Type
                        Ouroboros.Network.Protocol.PingPong.Client
                        Ouroboros.Network.Protocol.PingPong.Server

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -110,6 +110,7 @@ library
                        QuickCheck   >=2.12 && <2.13
 
   ghc-options:         -Wall
+                       -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts
 
 executable demo-playground

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -52,6 +52,7 @@ library
                        Ouroboros.Network.Serialise
                        Ouroboros.Network.Sim
                        Ouroboros.Network.Testing.ConcreteBlock
+                       Ouroboros.Network.Protocol.Typed
   other-modules:
 -- Old experiments, not currently building:
 --                     Types
@@ -120,6 +121,7 @@ executable demo-playground
                        Payload
                        Logging
                        NamedPipe
+  default-language:    Haskell2010
   build-depends:       base,
                        aeson,
                        async,

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -53,6 +53,10 @@ library
                        Ouroboros.Network.Sim
                        Ouroboros.Network.Testing.ConcreteBlock
                        Ouroboros.Network.Protocol.Typed
+                       Ouroboros.Network.Protocol.PingPong.Type
+                       Ouroboros.Network.Protocol.PingPong.Client
+                       Ouroboros.Network.Protocol.PingPong.Server
+                       Ouroboros.Network.Protocol.PingPong.Direct
   other-modules:
 -- Old experiments, not currently building:
 --                     Types

--- a/pkg.nix
+++ b/pkg.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, array, base, base16-bytestring, bytestring, cborg
 , clock, containers, cryptonite, fingertree, free, hashable, memory, mtl
-, process , QuickCheck, random , semigroups , stdenv, stm, serialise
-, string-conv, tasty, tasty-quickcheck , text , transformers, unliftio, void
+, network, process, QuickCheck, random, semigroups, stdenv, stm, serialise
+, string-conv, tasty, tasty-quickcheck, text, transformers, unliftio, void
 , nixpkgs
 }:
 mkDerivation {
@@ -11,8 +11,8 @@ mkDerivation {
     [ ".hs" "LICENSE" "ChangeLog.md" "ouroboros-network.cabal" "cabal.project" ];
   libraryHaskellDepends = [
     array aeson base base16-bytestring bytestring cborg clock containers
-    cryptonite fingertree free hashable memory mtl process QuickCheck random
-    semigroups serialise stm string-conv tasty tasty-quickcheck text
+    cryptonite fingertree free hashable memory mtl network process QuickCheck
+    random semigroups serialise stm string-conv tasty tasty-quickcheck text
     transformers unliftio void
   ];
   testHaskellDepends = [

--- a/src/Ouroboros/Network/ByteChannel.hs
+++ b/src/Ouroboros/Network/ByteChannel.hs
@@ -1,0 +1,207 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Ouroboros.Network.ByteChannel (
+      ByteChannel(..)
+    , ReadResult(..)
+    , fixedInputByteChannel
+    , handleAsByteChannel
+    , socketAsByteChannel
+    , createPipeByteChannel
+    , createLocalsocketAsByteChannel
+    , withFifosByteChannel
+    ) where
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import           Data.ByteString.Lazy.Internal (smallChunkSize)
+
+import qualified System.IO      as IO
+                   ( Handle, withFile, IOMode(..), hFlush )
+import qualified System.Process as IO (createPipe)
+
+import qualified Network.Socket            as Socket hiding (recv)
+import qualified Network.Socket.ByteString as Socket (sendMany, recv)
+
+import Prelude hiding (read)
+
+
+-- | One end of a bidirectional channel. It is a reliable, ordered channel
+-- of bytes without message boundaries.
+--
+-- This corresponds with IPC facilities like TCP sockets or local pipes.
+--
+data ByteChannel bytes m = ByteChannel {
+       -- | Read some number of bytes from the channel, or @Nothing@ for EOF.
+       --
+       -- This is a blocking I\/O operation. It may raise exceptions (as
+       -- appropriate for the monad and kind of channel).
+       --
+       read  :: m (ReadResult bytes (ByteChannel bytes m)),
+
+       -- | Write a vector of chunks to the channel. This allows for (but does
+       -- not guarante) vectored writes. All bytes are written.
+       --
+       -- This is a blocking I\/O operation.  It may raise exceptions (as
+       -- appropriate for the monad and kind of channel).
+       --
+       write :: [bytes] -> m (ByteChannel bytes m)
+     }
+
+data ReadResult bytes channel = ReadChunk bytes channel | ChannelClosed
+
+-- | A 'ByteChannel' with a fixed input, and where all output is discarded.
+--
+-- The input is guaranteed to be supplied via 'read' with the given chunk
+-- boundaries.
+--
+-- Only useful for testing. In particular the fixed chunk boundaries can be
+-- used to test that framing and other codecs work with any possible chunking.
+--
+fixedInputByteChannel :: Applicative m => [bytes] -> ByteChannel bytes m
+fixedInputByteChannel chunks =
+    ByteChannel {read, write}
+  where
+    -- This is basically an unfoldr
+    read = case chunks of
+             []              -> pure ChannelClosed
+             (chunk:chunks') -> pure (ReadChunk chunk channel')
+               where
+                 channel' = fixedInputByteChannel chunks'
+
+    write _ = pure (fixedInputByteChannel chunks)
+
+{-
+bufferedByteChannel :: MonadSTM m stm
+                    => m (ByteChannel bytes m,
+                          ByteChannel bytes m)
+bufferedByteChannel = do
+    mvar1 <- newEmptyMVar
+    mvar2 <- newEmptyMVar
+
+    let channelA = mvarsAsChannel mvar1 mvar2
+        channelB = mvarsAsChannel mvar2 mvar1
+
+    return (channelA, channelB)
+
+  where
+    mvarsAsChannel mvarRead mvarWrite =
+      where
+        channel     = ByteChannel {read, write}
+        read        = do mchunk <- atomically $ takeTMVar mvarRead
+                         case mchunk of
+                           Nothing    -> return Nothing
+                           Just chunk -> return (Just (chunk, channel))
+
+        write chunk = do atomically $ putTMVar mvarWrite chunk
+                         return channel
+-}
+
+-- | Make a 'ByteChannel' from a pair of IO 'Handle's, one for reading and one
+-- for writing.
+--
+-- The Handles should be open in the appropriate read or write mode, and in
+-- binary mode. Writes are flushed after each batch of writes, so it is safe to
+-- use a buffering mode.
+--
+-- For bidirectional handles it is safe to pass the same handle for both.
+--
+handleAsByteChannel :: IO.Handle -- ^ Read handle
+                    -> IO.Handle -- ^ Write handle
+                    -> ByteChannel ByteString IO
+handleAsByteChannel hndRead hndWrite =
+    channel
+  where
+    channel = ByteChannel {read, write}
+
+    read = do
+      chunk <- BS.hGetSome hndRead smallChunkSize
+      if BS.null chunk
+        then return ChannelClosed
+        else return (ReadChunk chunk channel)
+
+    write chunks = do
+      -- No special vectored write support.
+      mapM_ (BS.hPut hndWrite) chunks
+      IO.hFlush hndWrite
+      return channel
+
+
+-- | Make a 'ByteChannel' from a 'Socket'. The socket must be a stream socket
+-- type and status connected.
+--
+socketAsByteChannel :: Socket.Socket -> ByteChannel ByteString IO
+socketAsByteChannel socket =
+    channel
+  where
+    channel = ByteChannel {read, write}
+
+    read = do
+      -- We rely on the behaviour of stream sockets that a zero length chunk
+      -- indicates EOF.
+      chunk <- Socket.recv socket smallChunkSize
+      if BS.null chunk
+        then return ChannelClosed
+        else return (ReadChunk chunk channel)
+
+    write chunk = do
+      -- Use vectored writes.
+      -- TODO: limit write sizes, or break them into multiple sends.
+      Socket.sendMany socket chunk
+      return channel
+
+
+-- | Create a local pipe, with both ends in this process, and expose that as
+-- a pair of 'ByteChannel's, one for each end.
+--
+-- This is primarily for testing purposes since it does not allow actual IPC.
+--
+createPipeByteChannel :: IO (ByteChannel ByteString IO,
+                             ByteChannel ByteString IO)
+createPipeByteChannel = do
+    -- Create two pipes (each one is unidirectional) to make both ends of
+    -- a bidirectional channel
+    (hndReadA, hndWriteB) <- IO.createPipe
+    (hndReadB, hndWriteA) <- IO.createPipe
+
+    let channelA = handleAsByteChannel hndReadA hndWriteA
+        channelB = handleAsByteChannel hndReadB hndWriteB
+
+    return (channelA, channelB)
+
+
+-- | Create a local socket, with both ends in this process, and expose that as
+-- a pair of 'ByteChannel's, one for each end.
+--
+-- This is primarily for testing purposes since it does not allow actual IPC.
+--
+createLocalsocketAsByteChannel :: Socket.Family -- ^ Usually AF_UNIX or AF_INET
+                               -> IO (ByteChannel ByteString IO,
+                                      ByteChannel ByteString IO)
+createLocalsocketAsByteChannel family = do
+    -- Create a socket pair to make both ends of a bidirectional channel
+    (socketA, socketB) <- Socket.socketPair family Socket.Stream
+                                            Socket.defaultProtocol
+
+    let channelA = socketAsByteChannel socketA
+        channelB = socketAsByteChannel socketB
+
+    return (channelA, channelB)
+
+
+-- | Open a pair of Unix FIFOs, and expose that as a 'ByteChannel'.
+--
+-- The peer process needs to open the same files but the other way around,
+-- for writing and reading.
+--
+-- This is primarily for the purpose of demonstrations that use communication
+-- between multiple local processes. It is Unix specific.
+--
+withFifosByteChannel :: FilePath -- ^ FIFO for reading
+                     -> FilePath -- ^ FIFO for writing
+                     -> (ByteChannel ByteString IO -> IO a) -> IO a
+withFifosByteChannel fifoPathRead fifoPathWrite action =
+    IO.withFile fifoPathRead  IO.ReadMode  $ \hndRead  ->
+    IO.withFile fifoPathWrite IO.WriteMode $ \hndWrite ->
+      let channel = handleAsByteChannel hndRead hndWrite
+       in action channel
+

--- a/src/Ouroboros/Network/ChainSyncExamples.hs
+++ b/src/Ouroboros/Network/ChainSyncExamples.hs
@@ -1,0 +1,179 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Network.ChainSyncExamples (
+    chainSyncClientExample
+  , chainSyncServerExample
+  ) where
+
+import           Ouroboros.Network.Block (HasHeader (..))
+import           Ouroboros.Network.Chain (Chain (..), Point (..), ChainUpdate(..))
+import qualified Ouroboros.Network.Chain as Chain
+import           Ouroboros.Network.ChainProducerState (ChainProducerState, ReaderId)
+import qualified Ouroboros.Network.ChainProducerState as ChainProducerState
+import           Ouroboros.Network.MonadClass
+import           Ouroboros.Network.Protocol.ChainSync.Client
+import           Ouroboros.Network.Protocol.ChainSync.Server
+
+
+-- | An instance of the client side of the chain sync protocol that
+-- consumes into a 'Chain' stored in a 'TVar'.
+--
+-- This is of course only useful in tests and reference implementations since
+-- this is not a realistic chain representation.
+--
+chainSyncClientExample :: forall header m stm a.
+                          (HasHeader header, MonadSTM m stm)
+                       => TVar m (Chain header)
+                       -> m (ChainSyncClient header (Point header) m a)
+chainSyncClientExample chainvar =
+    initialise <$> getChainPoints
+  where
+    initialise :: [Point header] -> ClientStIdle header (Point header) m a
+    initialise points =
+      SendMsgFindIntersect points $
+      -- In this consumer example, we do not care about whether the server
+      -- found an intersection or not. If not, we'll just sync from genesis.
+      --
+      -- Alternative policies here include:
+      --  iteratively finding the best intersection
+      --  rejecting the server if there is no intersection in the last K blocks
+      --
+      ClientStIntersect {
+        recvMsgIntersectImproved  = \_ _ -> return requestNext,
+        recvMsgIntersectUnchanged = \  _ -> return requestNext
+      }
+
+    requestNext :: ClientStIdle header (Point header) m a
+    requestNext =
+      SendMsgRequestNext
+        handleNext
+        -- We received a wait message, and we have the opportunity to do
+        -- something. In this example we don't take up that opportunity.
+        (return handleNext)
+
+    handleNext :: ClientStNext header (Point header) m a
+    handleNext =
+      ClientStNext {
+        recvMsgRollForward  = \header _pHead -> do
+          addBlock header
+          return requestNext
+
+      , recvMsgRollBackward = \pIntersect _pHead -> do
+          rollback pIntersect
+          return requestNext 
+      }
+
+    getChainPoints :: m [Point header]
+    getChainPoints =
+        Chain.selectPoints recentOffsets <$> atomically (readTVar chainvar)
+
+    addBlock :: header -> m ()
+    addBlock b = atomically $ do
+        chain <- readTVar chainvar
+        let !chain' = Chain.addBlock b chain
+        writeTVar chainvar chain'
+
+    rollback :: Point header -> m ()
+    rollback p = atomically $ do
+        chain <- readTVar chainvar
+        --TODO: handle rollback failure
+        let (Just !chain') = Chain.rollback p chain
+        writeTVar chainvar chain'
+
+-- | Offsets from the head of the chain to select points on the consumer's
+-- chain to send to the producer. The specific choice here is fibonacci up
+-- to 2160.
+--
+recentOffsets :: [Int]
+recentOffsets = [0,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2584]
+
+
+-- | An instance of the server side of the chain sync protocol that reads from
+-- a pure 'ChainProducerState' stored in a 'TVar'.
+--
+-- This is of course only useful in tests and reference implementations since
+-- this is not a realistic chain representation.
+--
+chainSyncServerExample :: forall header m stm a.
+                          (HasHeader header, MonadSTM m stm)
+                       => TVar m (ChainProducerState header)
+                       -> m (ChainSyncServer header (Point header) m a)
+chainSyncServerExample chainvar =
+    idle <$> newReader
+  where
+    idle :: ReaderId -> ServerStIdle header (Point header) m a
+    idle r =
+      ServerStIdle {
+        recvMsgRequestNext   = handleRequestNext r,
+        recvMsgFindIntersect = handleFindIntersect r
+      }
+
+    handleRequestNext :: ReaderId
+                      -> m (Either (ServerStNext header (Point header) m a)
+                                (m (ServerStNext header (Point header) m a)))
+    handleRequestNext r = do
+      mupdate <- tryReadChainUpdate r
+      case mupdate of
+        Just update -> return (Left  (sendNext r update))
+        Nothing     -> return (Right (sendNext r <$> readChainUpdate r))
+                       -- Reader is at the head, have to block and wait for
+                       -- the producer's state to change.
+
+    sendNext :: ReaderId
+             -> ChainUpdate header
+             -> ServerStNext header (Point header) m a
+    sendNext r (AddBlock b) = SendMsgRollForward  b undefined (idle r)
+    sendNext r (RollBack p) = SendMsgRollBackward p undefined (idle r)
+
+    handleFindIntersect :: ReaderId
+                        -> [Point header]
+                        -> m (ServerStIntersect header (Point header) m a)
+    handleFindIntersect r points = do
+      -- TODO: guard number of points
+      -- Find the first point that is on our chain
+      changed <- improveReadPoint r points
+      case changed of
+        Just (pt, tip) -> return $ SendMsgIntersectImproved pt tip     (idle r)
+        Nothing        -> return $ SendMsgIntersectUnchanged undefined (idle r)
+
+    newReader :: m ReaderId
+    newReader = atomically $ do
+      cps <- readTVar chainvar
+      let (cps', rid) = ChainProducerState.initReader Chain.genesisPoint cps
+      writeTVar chainvar cps'
+      return rid
+
+    improveReadPoint :: ReaderId -> [Point header] -> m (Maybe (Point header, Point header))
+    improveReadPoint rid points =
+      atomically $ do
+        cps <- readTVar chainvar
+        case ChainProducerState.findFirstPoint points cps of
+          Nothing     -> return Nothing
+          Just ipoint -> do
+            let !cps' = ChainProducerState.updateReader rid ipoint cps
+            writeTVar chainvar cps'
+            return (Just (ipoint, Chain.headPoint (ChainProducerState.chainState cps')))
+
+    tryReadChainUpdate :: ReaderId -> m (Maybe (ChainUpdate header))
+    tryReadChainUpdate rid =
+      atomically $ do
+        cps <- readTVar chainvar
+        case ChainProducerState.readerInstruction rid cps of
+          Nothing -> return Nothing
+          Just (u, cps') -> do
+            writeTVar chainvar cps'
+            return $ Just u
+
+    readChainUpdate :: ReaderId -> m (ChainUpdate header)
+    readChainUpdate rid =
+      atomically $ do
+        cps <- readTVar chainvar
+        case ChainProducerState.readerInstruction rid cps of
+          Nothing        -> retry
+          Just (u, cps') -> do
+            writeTVar chainvar cps'
+            return u
+

--- a/src/Ouroboros/Network/Codec.hs
+++ b/src/Ouroboros/Network/Codec.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+module Ouroboros.Network.Codec where
+
+import           Control.Monad.ST (ST)
+import           Ouroboros.Network.MonadClass.MonadST
+
+import qualified Codec.CBOR.Encoding as CBOR (Encoding)
+import qualified Codec.CBOR.Read     as CBOR
+import qualified Codec.CBOR.Decoding as CBOR (Decoder)
+import qualified Codec.CBOR.Write    as CBOR
+import qualified Codec.Serialise     as Serialise
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Builder.Extra as BS
+import qualified Data.ByteString.Lazy.Internal as LBS (smallChunkSize)
+import qualified Data.ByteString.Lazy          as LBS
+
+
+data Codec bytes failure m a = Codec {
+       encode    :: a -> [bytes],
+       decode    :: m (DecodeStep bytes failure m a),
+       chunkNull :: bytes -> Bool
+     }
+
+data DecodeStep bytes failure m a =
+    -- | The decoder has consumed the available input and needs more
+    -- to continue. Provide @'Just'@ if more input is available and
+    -- @'Nothing'@ otherwise, and you will get a new @'DecodeStep'@.
+    Partial (Maybe bytes -> m (DecodeStep bytes failure m a))
+
+    -- | The decoder has successfully finished. Except for the output
+    -- value you also get any unused input as well as the number of
+    -- bytes consumed.
+  | Done a !bytes
+
+    -- | The decoder ran into an error. The decoder either used
+    -- @'fail'@ or was not provided enough input. Contains any
+    -- unconsumed input, the number of bytes consumed, and a
+    -- @'DeserialiseFailure'@ exception describing the reason why the
+    -- failure occurred.
+  | Fail failure
+
+
+
+serialiseCodec :: (MonadST m, Serialise.Serialise a)
+               => Codec ByteString CBOR.DeserialiseFailure m a
+serialiseCodec = cborCodec Serialise.encode Serialise.decode 
+
+cborCodec :: MonadST m
+          => (a -> CBOR.Encoding)
+          -> (forall s. CBOR.Decoder s a)
+          -> Codec ByteString CBOR.DeserialiseFailure m a
+cborCodec cborEncode cborDecode =
+    Codec {
+      encode = convertCborEncoder  cborEncode,
+      decode = convertCborDecoder' cborDecode,
+      chunkNull = BS.null
+    }
+
+convertCborEncoder :: (a -> CBOR.Encoding) -> a -> [ByteString]
+convertCborEncoder cborEncode =
+    LBS.toChunks
+  . toLazyByteString
+  . CBOR.toBuilder
+  . cborEncode
+
+{-# NOINLINE toLazyByteString #-}
+toLazyByteString :: BS.Builder -> LBS.ByteString
+toLazyByteString = BS.toLazyByteStringWith strategy LBS.empty
+  where
+    strategy = BS.untrimmedStrategy 800 LBS.smallChunkSize
+
+convertCborDecoder' :: MonadST m
+                    => (forall s. CBOR.Decoder s a)
+                    -> m (DecodeStep ByteString CBOR.DeserialiseFailure m a)
+convertCborDecoder' cborDecode =
+    withLiftST (convertCborDecoder cborDecode)
+
+convertCborDecoder :: forall s m a. Functor m
+                   => CBOR.Decoder s a
+                   -> (forall b. ST s b -> m b)
+                   -> m (DecodeStep ByteString CBOR.DeserialiseFailure m a)
+convertCborDecoder cborDecode liftST =
+    go <$> liftST (CBOR.deserialiseIncremental cborDecode)
+  where
+    go (CBOR.Done  trailing _ x)          = Done x trailing
+    go (CBOR.Fail _trailing _off failure) = Fail failure
+    go (CBOR.Partial k)                   = Partial (fmap go . liftST . k)
+

--- a/src/Ouroboros/Network/Framing.hs
+++ b/src/Ouroboros/Network/Framing.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+module Ouroboros.Network.Framing where
+
+import           Data.ByteString (ByteString)
+
+import           Ouroboros.Network.ByteChannel as ByteChannel
+import           Ouroboros.Network.MsgChannel  as MsgChannel
+import           Ouroboros.Network.Codec
+import           Ouroboros.Network.MonadClass.MonadST
+
+
+
+-- TODO: add example framing, trivial, or Karl's format, or CBOR equivalent
+
+data Frame = Frame ConversationId ByteString -- embedded message body
+type ConversationId = Int
+
+framingCodec1, framingCodec2 :: MonadST m => Codec ByteString () m Frame
+framingCodec1 = undefined
+framingCodec2 = undefined
+
+
+data DecodeState bytes = Initial | Trailing bytes | Ongoing
+
+applyFraming :: forall bytes failure m msg. 
+                Monad m
+             => Codec bytes failure m msg
+             -> ByteChannel bytes m
+             -> MsgChannel failure m msg
+applyFraming Codec {encode, decode, chunkNull} =
+    msgChannel Initial
+  where
+    msgChannel :: DecodeState bytes -> ByteChannel bytes m -> MsgChannel failure m msg
+    msgChannel decodeState channel =
+      MsgChannel {
+        send = send decodeState channel,
+        recv = recv decodeState channel =<< decode
+      }
+
+    send decodeState channel msg =
+      msgChannel decodeState <$> write channel (encode msg)
+
+    recv :: DecodeState bytes
+         -> ByteChannel bytes m
+         -> DecodeStep bytes failure m msg
+         -> m (RecvResult failure msg (MsgChannel failure m msg))
+
+    recv _ _ (Fail failure) =
+      return (RecvFailure failure)
+
+    recv _ channel (Done msg trailing') =
+      return (RecvMsg msg (msgChannel decodeState' channel))
+      where
+        decodeState' | chunkNull trailing' = Initial
+                     | otherwise           = Trailing trailing'
+
+
+    recv (Trailing trailing) channel (Partial k) =
+      k (Just trailing) >>= recv Ongoing channel
+
+    recv Initial channel (Partial k) =
+      ByteChannel.read channel >>= \res -> case res of
+        ByteChannel.ChannelClosed            -> return MsgChannel.ChannelClosed
+        ByteChannel.ReadChunk chunk channel' -> k (Just chunk) >>= recv Ongoing channel'
+
+    recv Ongoing channel (Partial k) =
+      ByteChannel.read channel >>= \res -> case res of
+        ByteChannel.ChannelClosed            -> k Nothing      >>= recv Ongoing channel
+        ByteChannel.ReadChunk chunk channel' -> k (Just chunk) >>= recv Ongoing channel'
+

--- a/src/Ouroboros/Network/MonadClass.hs
+++ b/src/Ouroboros/Network/MonadClass.hs
@@ -18,6 +18,7 @@ import           Ouroboros.Network.MonadClass.MonadFork as MonadFork
 import           Ouroboros.Network.MonadClass.MonadProbe as MonadProbe
 import           Ouroboros.Network.MonadClass.MonadSay as MonadSay
 import           Ouroboros.Network.MonadClass.MonadSendRecv as MonadSendRecv
+import           Ouroboros.Network.MonadClass.MonadST    as MonadST
 import           Ouroboros.Network.MonadClass.MonadSTM as MonadSTM
 import           Ouroboros.Network.MonadClass.MonadSTMTimer as MonadSTMTimer
 import           Ouroboros.Network.MonadClass.MonadTimer as MonadTimer

--- a/src/Ouroboros/Network/MonadClass.hs
+++ b/src/Ouroboros/Network/MonadClass.hs
@@ -9,6 +9,7 @@ module Ouroboros.Network.MonadClass (
   module MonadFork,
   module MonadConc,
   module MonadSTM,
+  module MonadST,
   module MonadSTMTimer,
   module MonadSendRecv
   ) where

--- a/src/Ouroboros/Network/MonadClass/MonadST.hs
+++ b/src/Ouroboros/Network/MonadClass/MonadST.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE RankNTypes #-}
+module Ouroboros.Network.MonadClass.MonadST where
+
+import Control.Monad.ST (ST, stToIO)
+
+
+-- | This class is for abstracting over 'stToIO' which allows running 'ST'
+-- actions in 'IO'. In this case it is to allow running 'ST' actions within
+-- another monad @m@.
+--
+-- The type of 'stToIO' is:
+--
+-- > stToIO : ST RealWorld a -> IO a
+--
+-- Abstracting over this is tricky because we need to not care about both
+-- the @IO@, and also the @RealWorld@.
+--
+-- A solution is to write an action that is given the @liftST@ as an argument
+-- and where that action itself is polymorphic in the @s@ parameter. This
+-- allows us to instantiate it with @RealWorld@ in the @IO@ case, and the local
+-- @s@ in a case where we are embedding into another @ST@ action.
+--
+class Monad m => MonadST m where
+  withLiftST :: (forall s. (forall a. ST s a -> m a) -> b) -> b
+
+instance MonadST IO where
+  withLiftST = \f -> f stToIO
+
+instance MonadST (ST s) where
+  withLiftST = \f -> f id
+

--- a/src/Ouroboros/Network/MsgChannel.hs
+++ b/src/Ouroboros/Network/MsgChannel.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Ouroboros.Network.MsgChannel (
+      MsgChannel(..)
+    , RecvResult(..)
+    ) where
+
+
+-- | One end of a bidirectional message channel. It is a reliable, ordered
+-- channel with message boundaries.
+--
+data MsgChannel failure m msg = MsgChannel {
+
+       recv :: m (RecvResult failure msg (MsgChannel failure m msg)),
+
+       send :: msg -> m (MsgChannel failure m msg)
+     }
+
+data RecvResult failure msg channel = RecvMsg msg channel
+                                    | RecvFailure failure
+                                    | ChannelClosed
+
+

--- a/src/Ouroboros/Network/PingPongExamples.hs
+++ b/src/Ouroboros/Network/PingPongExamples.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Network.PingPongExamples where
+
+import           Ouroboros.Network.Protocol.PingPong.Server
+import           Ouroboros.Network.Protocol.PingPong.Client
+
+
+-- | The standard stateless ping-pong server instance.
+--
+pingPongServerStandard :: Applicative m => PingPongServer m ()
+pingPongServerStandard =
+    PingPongServer {
+      recvMsgPing = pure pingPongServerStandard,
+      recvMsgDone = ()
+    }
+
+-- | An example ping-pong server instance that counts the number of ping
+-- messages.
+--
+pingPongServerCounting :: Applicative m => Int -> PingPongServer m Int
+pingPongServerCounting !n =
+    PingPongServer {
+      recvMsgPing = pure (pingPongServerCounting (n+1)),
+      recvMsgDone = n
+    }
+
+
+-- | An example ping-pong client that sends pings as fast as possible forever‽
+--
+-- This may not be a good idea‼
+--
+pingPongClientFlood :: Applicative m => PingPongClient m a
+pingPongClientFlood = SendMsgPing (pure pingPongClientFlood)
+
+
+-- | An example ping-pong client that sends a fixed number of ping messages
+-- and then stops.
+--
+pingPongClientCount :: Applicative m => Int -> PingPongClient m ()
+pingPongClientCount 0 = SendMsgStop ()
+pingPongClientCount n = SendMsgPing (pure (pingPongClientCount (n-1)))
+

--- a/src/Ouroboros/Network/Pipe2.hs
+++ b/src/Ouroboros/Network/Pipe2.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Network.Pipe2 where
+
+import           Codec.Serialise.Class (Serialise)
+import qualified Codec.CBOR.Read as CBOR (DeserialiseFailure)
+import           Data.ByteString (ByteString)
+
+import           Ouroboros.Network.Protocol.Untyped
+import           Ouroboros.Network.ByteChannel (ByteChannel)
+import           Ouroboros.Network.MsgChannel
+import           Ouroboros.Network.Codec
+import           Ouroboros.Network.Framing
+
+import           Ouroboros.Network.MonadClass.MonadST
+import           Ouroboros.Network.MonadClass.MonadSTM
+
+import           Ouroboros.Network.Chain (Chain, HasHeader, Point)
+import qualified Ouroboros.Network.Chain as Chain
+import           Ouroboros.Network.ChainProducerState (ChainProducerState)
+
+import           Ouroboros.Network.Protocol.ChainSync.Server
+import           Ouroboros.Network.Protocol.ChainSync.Client
+import           Ouroboros.Network.Protocol.ChainSync.Encoding
+import           Ouroboros.Network.ChainSyncExamples
+
+
+runProducer :: (MonadST m, Chain.HasHeader header, Serialise header)
+            => ChainSyncServer header (Point header) m a
+            -> ByteChannel ByteString m
+            -> m (Either (ProtocolError CBOR.DeserialiseFailure) a)
+runProducer server channel =
+    runPeerWithChannel codec peer channel
+  where
+    peer  = asUntypedPeer (chainSyncServerPeer server)
+    codec = cborCodec encodeChainSyncMessage decodeChainSyncMessage
+
+runConsumer :: (MonadST m, Chain.HasHeader header, Serialise header)
+            => ChainSyncClient header (Point header) m a
+            -> ByteChannel ByteString m
+            -> m (Either (ProtocolError CBOR.DeserialiseFailure) a)
+runConsumer client channel =
+    runPeerWithChannel codec peer channel
+  where
+    peer  = asUntypedPeer (chainSyncClientPeer client)
+    codec = cborCodec encodeChainSyncMessage decodeChainSyncMessage
+
+
+------------------------------------------------
+
+runExampleProducer :: (MonadST m, MonadSTM m stm,
+                       HasHeader header, Serialise header)
+                   => TVar m (ChainProducerState header)
+                   -> ByteChannel ByteString m
+                   -> m (Either (ProtocolError CBOR.DeserialiseFailure) a)
+runExampleProducer cpsVar channel = do
+    server <- chainSyncServerExample cpsVar
+    runProducer server channel
+
+runExampleConsumer :: (MonadST m, MonadSTM m stm,
+                       HasHeader header, Serialise header)
+                   => TVar m (Chain header)
+                   -> ByteChannel ByteString m
+                   -> m (Either (ProtocolError CBOR.DeserialiseFailure) a)
+runExampleConsumer chainVar channel = do
+    client <- chainSyncClientExample chainVar
+    runConsumer client channel
+
+------------------------------------------------
+
+
+data ProtocolError e = ProtocolDecodeFailure e
+                     | ProtocolDisconnected
+                     | ProtocolStateError
+
+runPeerWithChannel :: forall bytes failure msg m a.
+                      Monad m
+                   => Codec bytes failure m (SomeMessage msg)
+                   -> Peer msg m a
+                   -> ByteChannel bytes m
+                   -> m (Either (ProtocolError failure) a)
+runPeerWithChannel codec peer0 bytechannel =
+    go (applyFraming codec bytechannel) peer0
+  where
+    go :: MsgChannel failure m (SomeMessage msg)
+       -> Peer msg m a
+       -> m (Either (ProtocolError failure) a)
+    go _ (PeerDone x) = return (Right x)
+
+    go channel (PeerHole effect) =
+      effect >>= \peer' -> go channel peer'
+
+    go channel (PeerYield msg peer') =
+      send channel msg >>= \channel' -> go channel' peer'
+
+    go channel (PeerAwait k) =
+      recv channel >>= \mmsg ->
+      case mmsg of
+        RecvMsg msg channel' ->
+          case k msg of
+            Just peer' -> go channel' peer'
+            Nothing    -> return (Left ProtocolStateError)
+        RecvFailure e  -> return (Left (ProtocolDecodeFailure e))
+        ChannelClosed  -> return (Left ProtocolDisconnected)
+

--- a/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE GADTs           #-}
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE NamedFieldPuns  #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+-- | A view of the chain synchronisation protocol from the point of view of the
+-- client.
+--
+-- This provides a view that uses less complex types and should be easier to
+-- use than the underlying typed protocol itself.
+--
+-- For execution, a conversion into the typed protocol is provided.
+--
+module Ouroboros.Network.Protocol.ChainSync.Client (
+      -- * Protocol type for the client
+      -- | The protocol states from the point of view of the client.
+      ChainSyncClient
+    , ClientStIdle(..)
+    , ClientStNext(..)
+    , ClientStIntersect(..)
+
+      -- * Execution as a typed protocol
+    , chainSyncClientPeer
+    ) where
+
+import Ouroboros.Network.Protocol.Typed
+         ( Peer, Status(..), hole, over, await )
+import Ouroboros.Network.Protocol.ChainSync.Type
+         ( ChainSyncProtocol, ChainSyncState(..), ChainSyncMessage(..) )
+
+
+-- | A chain sync protocol client, on top of some effect 'm'.
+--
+type ChainSyncClient header point m a = ClientStIdle header point m a
+
+
+-- | In the 'StIdle' protocol state, the server does not have agency and can choose to
+-- send a request next, or a find intersection message.
+--
+data ClientStIdle header point m a where
+
+  -- | Send the 'MsgRequestNext', with handlers for the replies.
+  --
+  -- The handlers for this message are more complicated than most RPCs because
+  -- the server can either send us a reply immediately or it can send us a
+  -- 'MsgAwaitReply' to indicate that the server itself has to block for a
+  -- state change before it can send us the reply.
+  --
+  -- In the waiting case, the client gets the chance to take a local action.
+  --
+  SendMsgRequestNext
+    ::    ClientStNext header point m a
+    -> m (ClientStNext header point m a) -- after MsgAwaitReply
+    -> ClientStIdle header point m a
+
+  -- | Send the 'MsgFindIntersect', with handlers for the replies.
+  --
+  SendMsgFindIntersect
+    :: [point]
+    -> ClientStIntersect header point m a
+    -> ClientStIdle header point m a
+
+-- | In the 'StNext' protocol state, the client does not have agency and is
+-- waiting to receive either a roll forward or roll back message. It must be
+-- prepared to handle either.
+--
+data ClientStNext header point m a =
+     ClientStNext {
+       recvMsgRollForward  :: header -> point -> m (ClientStIdle header point m a),
+       recvMsgRollBackward :: point  -> point -> m (ClientStIdle header point m a)
+     }
+
+-- | In the 'StIntersect' protocol state, the client does not have agency and
+-- is waiting to receive either an intersection improved or unchanged message.
+-- It must be prepared to handle either.
+--
+data ClientStIntersect header point m a =
+     ClientStIntersect {
+       recvMsgIntersectImproved  :: point -> point -> m (ClientStIdle header point m a),
+       recvMsgIntersectUnchanged ::          point -> m (ClientStIdle header point m a)
+     }
+
+
+-- | Interpret a 'ChainSyncClient' action sequence as a 'Peer' on the client
+-- side of the 'ChainSyncProtocol'.
+--
+chainSyncClientPeer
+  :: Monad m
+  => ChainSyncClient header point m a
+  -> Peer ChainSyncProtocol (ChainSyncMessage header point)
+          (Yielding StIdle) (Finished StDone)
+          m a
+
+chainSyncClientPeer (SendMsgRequestNext stNext stAwait) =
+    over MsgRequestNext $
+    await $ \resp ->
+    case resp of
+      MsgRollForward header pHead -> hole $ do
+          next <- recvMsgRollForward header pHead
+          pure $ chainSyncClientPeer next
+        where
+          ClientStNext{recvMsgRollForward} = stNext
+
+      MsgRollBackward pRollback pHead -> hole $ do
+          next <- recvMsgRollBackward pRollback pHead
+          pure $ chainSyncClientPeer next
+        where
+          ClientStNext{recvMsgRollBackward} = stNext
+
+      -- This code could be factored more easily by changing the protocol type
+      -- to put both roll forward and back under a single constructor.
+      MsgAwaitReply ->
+        hole $ do
+          ClientStNext{recvMsgRollForward, recvMsgRollBackward} <- stAwait
+          pure $ await $ \resp' ->
+            case resp' of
+              MsgRollForward header pHead -> hole $ do
+                next <- recvMsgRollForward header pHead
+                pure $ chainSyncClientPeer next
+              MsgRollBackward pRollback pHead -> hole $ do
+                next <- recvMsgRollBackward pRollback pHead
+                pure $ chainSyncClientPeer next
+
+chainSyncClientPeer (SendMsgFindIntersect points stIntersect) =
+    over (MsgFindIntersect points) $
+    await $ \resp ->
+    case resp of
+      MsgIntersectImproved pIntersect pHead -> hole $ do
+        next <- recvMsgIntersectImproved pIntersect pHead
+        pure $ chainSyncClientPeer next
+
+      MsgIntersectUnchanged pHead -> hole $ do
+        next <- recvMsgIntersectUnchanged pHead
+        pure $ chainSyncClientPeer next
+  where
+    ClientStIntersect {
+      recvMsgIntersectImproved,
+      recvMsgIntersectUnchanged
+    } = stIntersect
+

--- a/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Ouroboros.Network.Protocol.ChainSync.Direct where
+
+import Ouroboros.Network.Protocol.ChainSync.Client as Client
+import Ouroboros.Network.Protocol.ChainSync.Server as Server
+
+-- | The 'ClientStream m' and 'ServerStream m' types are complementary. The
+-- former can be used to feed the latter directly, in the same thread.
+-- That's demonstrated here by constructing 'direct'.
+--
+direct :: Monad m
+       => ChainSyncServer header point m a
+       -> ChainSyncClient header point m b
+       -> m (a, b)
+
+--TODO: note that currently these protocols are non-terminating.
+
+direct  ServerStIdle{recvMsgRequestNext}
+       (Client.SendMsgRequestNext stNext stAwait) = do
+    mresp <- recvMsgRequestNext
+    case mresp of
+      Left  resp    -> directStNext resp stNext
+      Right waiting -> do resp <- waiting
+                          stNext' <- stAwait
+                          directStNext resp stNext'
+  where
+    directStNext (SendMsgRollForward header pHead server')
+                  ClientStNext{recvMsgRollForward} = do
+      client' <- recvMsgRollForward header pHead
+      direct server' client'
+
+    directStNext (SendMsgRollBackward pIntersect pHead server')
+                  ClientStNext{recvMsgRollBackward} = do
+      client' <- recvMsgRollBackward pIntersect pHead
+      direct server' client'
+
+direct  ServerStIdle{recvMsgFindIntersect}
+       (Client.SendMsgFindIntersect points
+          ClientStIntersect{recvMsgIntersectImproved,
+                            recvMsgIntersectUnchanged}) = do
+    sIntersect <- recvMsgFindIntersect points
+    case sIntersect of
+      SendMsgIntersectImproved  pIntersect pHead server' -> do
+        client' <- recvMsgIntersectImproved pIntersect pHead
+        direct server' client'
+
+      SendMsgIntersectUnchanged            pHead server' -> do
+        client' <- recvMsgIntersectUnchanged pHead
+        direct server' client'
+

--- a/src/Ouroboros/Network/Protocol/ChainSync/Encoding.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Encoding.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Network.Protocol.ChainSync.Encoding where
+
+import Ouroboros.Network.Protocol.ChainSync.Type
+import Ouroboros.Network.Protocol.Untyped (SomeMessage(..))
+
+import Data.Monoid ((<>))
+import Codec.CBOR.Encoding (Encoding, encodeListLen, encodeWord)
+import Codec.CBOR.Decoding (Decoder, decodeListLen, decodeWord)
+import Codec.Serialise.Class (Serialise(..))
+
+encodeChainSyncMessage :: (Serialise header, Serialise point)
+                       => SomeMessage (ChainSyncMessage header point)
+                       -> Encoding
+encodeChainSyncMessage (SomeMessage msg) =
+  case msg of
+    MsgRequestNext            -> encodeListLen 1 <> encodeWord 0
+    MsgAwaitReply             -> encodeListLen 1 <> encodeWord 1
+    MsgRollForward       h p  -> encodeListLen 3 <> encodeWord 2 <> encode h <> encode p
+    MsgRollBackward      p p' -> encodeListLen 3 <> encodeWord 3 <> encode p <> encode p'
+    MsgFindIntersect     ps   -> encodeListLen 2 <> encodeWord 4 <> encode ps
+    MsgIntersectImproved p p' -> encodeListLen 3 <> encodeWord 5 <> encode p <> encode p'
+    MsgIntersectUnchanged  p  -> encodeListLen 2 <> encodeWord 6 <> encode p
+
+decodeChainSyncMessage :: forall header point s.
+                          (Serialise header, Serialise point)
+                       => Decoder s (SomeMessage (ChainSyncMessage header point))
+decodeChainSyncMessage = do
+  len <- decodeListLen
+  key <- decodeWord
+  case key of
+    0 -> return (SomeMessage MsgRequestNext)
+    1 -> return (SomeMessage MsgAwaitReply)
+    2 -> SomeMessage <$> (MsgRollForward        <$> decode <*> decode
+                                          :: Decoder s (ChainSyncMessage header point (StNext StCanAwait) StIdle))
+    3 -> SomeMessage <$> (MsgRollBackward       <$> decode <*> decode
+                                          :: Decoder s (ChainSyncMessage header point (StNext StCanAwait) StIdle))
+    4 -> SomeMessage <$> (MsgFindIntersect      <$> decode)
+    5 -> SomeMessage <$> (MsgIntersectImproved  <$> decode <*> decode)
+    6 -> SomeMessage <$> (MsgIntersectUnchanged <$> decode)
+

--- a/src/Ouroboros/Network/Protocol/ChainSync/Server.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Server.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE GADTs           #-}
+{-# LANGUAGE DataKinds       #-}
+{-# LANGUAGE NamedFieldPuns  #-}
+
+-- | A view of the chain synchronisation protocol from the point of view of the
+-- server.
+--
+-- This provides a view that uses less complex types and should be easier to
+-- use than the underlying typed protocol itself.
+--
+-- For execution, a conversion into the typed protocol is provided.
+--
+module Ouroboros.Network.Protocol.ChainSync.Server  (
+      -- * Protocol type for the server
+      -- | The protocol states from the point of view of the server.
+      ChainSyncServer
+    , ServerStIdle(..)
+    , ServerStNext(..)
+    , ServerStIntersect(..)
+
+      -- * Execution as a typed protocol
+    , chainSyncServerPeer
+    ) where
+
+import Ouroboros.Network.Protocol.Typed
+         ( Peer, Status(..), hole, over, part, await )
+import Ouroboros.Network.Protocol.ChainSync.Type
+         ( ChainSyncProtocol, ChainSyncState(..), ChainSyncMessage(..) )
+
+
+-- | A chain sync protocol server, on top of some effect 'm'.
+--
+type ChainSyncServer header point m a = ServerStIdle header point m a
+
+
+-- | In the 'StIdle' protocol state, the server does not have agency. Instead
+-- it is waiting for either a next update request or a find intersection
+-- request. It must be prepared to handle either.
+--
+data ServerStIdle header point m a = ServerStIdle {
+
+       recvMsgRequestNext   :: m (Either (ServerStNext header point m a)
+                                      (m (ServerStNext header point m a))),
+
+       recvMsgFindIntersect :: [point]
+                            -> m (ServerStIntersect header point m a)
+     }
+
+-- | In the 'StNext' protocol state, the server has agency and must send either
+-- a roll forward or roll back message.
+--
+data ServerStNext header point m a where
+   SendMsgRollForward  :: header -> point
+                       -> ServerStIdle header point m a
+                       -> ServerStNext header point m a
+
+   SendMsgRollBackward :: point -> point
+                       -> ServerStIdle header point m a
+                       -> ServerStNext header point m a
+
+-- | In the 'StIntersect' protocol state, the server has agency and must send
+-- either an intersection improved or unchanged message.
+--
+data ServerStIntersect header point m a where
+   SendMsgIntersectImproved  :: point -> point
+                             -> ServerStIdle header point m a
+                             -> ServerStIntersect header point m a
+
+   SendMsgIntersectUnchanged :: point
+                             -> ServerStIdle header point m a
+                             -> ServerStIntersect header point m a
+
+
+-- | Interpret a 'ChainSyncServer' action sequence as a 'Peer' on the server
+-- side of the 'ChainSyncProtocol'.
+--
+chainSyncServerPeer
+  :: Monad m
+  => ChainSyncServer header point m a
+  -> Peer ChainSyncProtocol (ChainSyncMessage header point)
+          (Awaiting StIdle) (Finished StDone)
+          m a
+chainSyncServerPeer ServerStIdle{recvMsgRequestNext, recvMsgFindIntersect} =
+
+    await $ \req ->
+    case req of
+      MsgRequestNext -> hole $ do
+        mresp <- recvMsgRequestNext
+        pure $ case mresp of
+          Left  resp    -> handleStNext resp
+          Right waiting -> part MsgAwaitReply $ hole $ do
+                             resp <- waiting
+                             pure $ handleStNext resp
+
+      MsgFindIntersect points -> hole $ do
+        resp <- recvMsgFindIntersect points
+        pure $ handleStIntersect resp 
+
+  where
+    handleStNext (SendMsgRollForward  header pHead next) =
+      over (MsgRollForward header pHead)
+           (chainSyncServerPeer next)
+
+    handleStNext (SendMsgRollBackward pIntersect pHead next) =
+      over (MsgRollBackward pIntersect pHead)
+           (chainSyncServerPeer next)
+
+    handleStIntersect (SendMsgIntersectImproved pIntersect pHead next) =
+      over (MsgIntersectImproved pIntersect pHead)
+           (chainSyncServerPeer next)
+
+    handleStIntersect (SendMsgIntersectUnchanged pHead next) =
+      over (MsgIntersectUnchanged pHead)
+           (chainSyncServerPeer next)
+

--- a/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | The type of the chain synchronisation protocol.
+--
+-- Since we are using a typed protocol framework this is in some sense /the/
+-- definition of the protocol: what is allowed and what is not allowed.
+--
+module Ouroboros.Network.Protocol.ChainSync.Type where
+
+import Ouroboros.Network.Protocol.Typed (Partition)
+
+
+-- | The states in the state transition diagram of the chain sync protocol.
+--
+data ChainSyncState where
+
+  -- | Both client and server are idle. The client can send a request and
+  -- the server is waiting for a request.
+  StIdle      :: ChainSyncState
+
+  -- | The client has sent a next update request. The client is now waiting
+  -- for a response, and the server is busy getting ready to send a response.
+  -- There are two possibilities here, since the server can send a reply
+  -- immediately or it can send an initial await message followed later by
+  -- the normal reply.
+  StNext      :: StNextKind -> ChainSyncState
+
+  -- | The client has sent an intersection request. The client is now waiting
+  -- for a response, and the server is busy getting ready to send a response.
+  StIntersect :: ChainSyncState
+
+  -- | Both the client and server are in the terminal state. They're done.
+  StDone      :: ChainSyncState
+  --TODO: currently there is no termination mechanism
+
+-- | Sub-cases of the 'StNext' state. This is needed since the server can
+-- either send one reply back, or two.
+--
+data StNextKind where
+  StCanAwait  :: StNextKind -- ^ The server can reply or send an await msg.
+  StMustReply :: StNextKind -- ^ The server must now reply, having already
+                                -- sent an await message.
+
+
+-- | A type to identify the client\/server partition of states in our protocol.
+data ChainSyncProtocol
+
+-- | We have to explain to the framework what our states mean, in terms of
+-- which party has agency in each state.
+--
+type instance Partition ChainSyncProtocol st client server terminal =
+  ChainSyncStatePartition st client server terminal
+
+-- | Idle states are where it is for the client to send a message,
+-- busy states are where the server is expected to send a reply.
+--
+type family ChainSyncStatePartition st client server terminal :: k where
+  ChainSyncStatePartition  StIdle      client server terminal = client
+  ChainSyncStatePartition (StNext k)   client server terminal = server
+  ChainSyncStatePartition  StIntersect client server terminal = server
+  ChainSyncStatePartition  StDone      client server terminal = terminal
+
+
+-- | The messages in the chain sync protocol.
+--
+-- In this protocol the consumer always initiates things and the producer
+-- replies.
+--
+data ChainSyncMessage header point from to where
+
+  -- | Request the next update from the producer. The response can be a roll
+  -- forward, a roll back or wait.
+  --
+  MsgRequestNext :: ChainSyncMessage header point StIdle (StNext StCanAwait)
+
+  -- | Acknowledge the request but require the consumer to wait for the next
+  -- update. This means that the consumer is synced with the producer, and
+  -- the producer its waiting for its own chain state to change.
+  --
+  MsgAwaitReply :: ChainSyncMessage header point (StNext StCanAwait) (StNext StMustReply)
+
+  -- | Tell the consumer to extend their chain with the given header.
+  --
+  -- The message also tells the consumer about the head point of the producer.
+  --
+  MsgRollForward :: header -> point -> ChainSyncMessage header point (StNext any) StIdle
+
+  -- | Tell the consumer to roll back to a given point on their chain.
+  --
+  -- The message also tells the consumer about the head point of the producer.
+  --
+  MsgRollBackward :: point  -> point -> ChainSyncMessage header point (StNext any) StIdle
+
+  -- | Ask the producer to try to find an improved intersection point between
+  -- the consumer and producer's chains. The consumer sends a sequence of
+  -- points and it is up to the producer to find the first intersection point
+  -- on its chain and send it back to the consumer.
+  --
+  MsgFindIntersect :: [point] -> ChainSyncMessage header point StIdle StIntersect
+
+  -- | The reply to the consumer about an intersection found, but /only/ if this
+  -- is an improvement over previously established intersection point. The
+  -- consumer can decide weather to send more points.
+  --
+  -- The message also tells the consumer about the head point of the producer.
+  --
+  MsgIntersectImproved  :: point -> point -> ChainSyncMessage header point StIntersect StIdle
+
+  -- | The reply to the consumer that no intersection was found: none of the
+  -- points the consumer supplied are on the producer chain.
+  --
+  -- The message also tells the consumer about the head point of the producer.
+  --
+  MsgIntersectUnchanged ::          point -> ChainSyncMessage header point StIntersect StIdle
+
+instance Show (ChainSyncMessage header point from to) where
+  show MsgRequestNext          = "MsgRequestNext"
+  show MsgAwaitReply           = "MsgAwaitReply"
+  show MsgRollForward{}        = "MsgRollForward"
+  show MsgRollBackward{}       = "MsgRollBackward"
+  show MsgFindIntersect{}      = "MsgFindIntersect"
+  show MsgIntersectImproved{}  = "MsgIntersectImproved"
+  show MsgIntersectUnchanged{} = "MsgIntersectUnchanged"
+

--- a/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -40,9 +40,10 @@ data ChainSyncState where
 -- either send one reply back, or two.
 --
 data StNextKind where
-  StCanAwait  :: StNextKind -- ^ The server can reply or send an await msg.
-  StMustReply :: StNextKind -- ^ The server must now reply, having already
-                                -- sent an await message.
+  -- | The server can reply or send an await msg.
+  StCanAwait  :: StNextKind
+  -- | The server must now reply, having already sent an await message.
+  StMustReply :: StNextKind
 
 
 -- | A type to identify the client\/server partition of states in our protocol.

--- a/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -79,7 +79,7 @@ data ChainSyncMessage header point from to where
 
   -- | Acknowledge the request but require the consumer to wait for the next
   -- update. This means that the consumer is synced with the producer, and
-  -- the producer its waiting for its own chain state to change.
+  -- the producer is waiting for its own chain state to change.
   --
   MsgAwaitReply :: ChainSyncMessage header point (StNext StCanAwait) (StNext StMustReply)
 

--- a/src/Ouroboros/Network/Protocol/PingPong/Client.hs
+++ b/src/Ouroboros/Network/Protocol/PingPong/Client.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+
+module Ouroboros.Network.Protocol.PingPong.Client where
+
+import Ouroboros.Network.Protocol.Typed
+import Ouroboros.Network.Protocol.PingPong.Type
+
+
+-- | A ping-pong client, on top of some effect 'm'.
+--
+-- At each step the client has a choice: ping or stop.
+--
+-- This type encodes the pattern of state transitions the client can go through.
+-- For the ping\/pong case this is trivial. We start from one main state,
+-- issue a ping and move into a state where we expect a single response,
+-- bringing us back to the same main state.
+--
+-- If we had another state in which a different set of options were available
+-- then we would need a second type like this. The two would be mutually
+-- recursive if we can get in both directions, or perhaps just one way such
+-- as a special initialising state or special terminating state.
+--
+data ClientStream m a where
+  -- | Choose to go for sending a ping message. The ping has no body so
+  -- all we have to provide here is a continuation for the single legal
+  -- reply message.
+  --
+  Ping           :: m (ClientStream m a) -- ^ continuation for Pong response
+                 -> ClientStream m a
+
+  -- | Choose to terminate the protocol. This is an actual but nullary message,
+  -- we terminate with the local result value. So this ends up being much like
+  -- 'return' in this case, but in general the termination is a message that
+  -- can communicate final information.
+  --
+  Stop           :: a -> ClientStream m a
+
+
+-- | Interpret a particular client action sequence into the client side of the
+-- 'PingPong' protocol.
+--
+streamClient
+  :: Monad m
+  => ClientStream m a
+  -> Peer PingPongProtocol PingPongMessage
+          (Yielding StIdle) (Finished StDone)
+          m a
+
+streamClient (Stop result) =
+    -- We do an actual transition using 'out', meaning sending a message, to go
+    -- from the 'StIdle' to 'StDone' state. Once in the 'StDone' state we can
+    -- actually stop using 'done', with a return value.
+    out MsgDone (done result)
+
+streamClient (Ping kPong) =
+
+    -- Send our message with 'over'.
+    over MsgPing $
+
+    -- The type of our protocol means that we're now into the 'StBusy' state
+    -- and the only thing we can do next is local effects or wait for a reply.
+    -- We'll wait for a reply.
+    await $ \resp ->
+
+    -- Now in this case there is only one possible response, and we have
+    -- one corresponding continuation 'kPong' to handle that response.
+    -- The pong reply has no content so there's nothing to pass to our
+    -- continuation, but if there were we would.
+    case resp of
+      MsgPong -> hole $ do
+        next <- kPong
+        pure $ streamClient next
+

--- a/src/Ouroboros/Network/Protocol/PingPong/Client.hs
+++ b/src/Ouroboros/Network/Protocol/PingPong/Client.hs
@@ -26,7 +26,7 @@ data PingPongClient m a where
   -- all we have to provide here is a continuation for the single legal
   -- reply message.
   --
-  SendMsgPing    :: m (PingPongClient m a) -- ^ continuation for Pong response
+  SendMsgPing    :: m (PingPongClient m a) -- continuation for Pong response
                  -> PingPongClient m a
 
   -- | Choose to terminate the protocol. This is an actual but nullary message,

--- a/src/Ouroboros/Network/Protocol/PingPong/Direct.hs
+++ b/src/Ouroboros/Network/Protocol/PingPong/Direct.hs
@@ -9,15 +9,15 @@ import Ouroboros.Network.Protocol.PingPong.Server as Server
 -- That's demonstrated here by constructing 'direct'.
 --
 direct :: Monad m
-       => ServerStream m a
-       -> ClientStream m b
+       => PingPongServer m a
+       -> PingPongClient m b
        -> m (a, b)
 
-direct ServerStream{handleDone} (Client.Stop clientResult) =
-    pure (handleDone, clientResult)
+direct PingPongServer{recvMsgDone} (Client.SendMsgStop clientResult) =
+    pure (recvMsgDone, clientResult)
 
-direct ServerStream{handlePing} (Client.Ping kPong) = do
-    server' <- handlePing
+direct PingPongServer{recvMsgPing} (Client.SendMsgPing kPong) = do
+    server' <- recvMsgPing
     client' <- kPong
     direct server' client'
 

--- a/src/Ouroboros/Network/Protocol/PingPong/Direct.hs
+++ b/src/Ouroboros/Network/Protocol/PingPong/Direct.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE NamedFieldPuns #-}
+module Ouroboros.Network.Protocol.PingPong.Direct where
+
+import Ouroboros.Network.Protocol.PingPong.Client as Client
+import Ouroboros.Network.Protocol.PingPong.Server as Server
+
+-- | The 'ClientStream m' and 'ServerStream m' types are complementary. The
+-- former can be used to feed the latter directly, in the same thread.
+-- That's demonstrated here by constructing 'direct'.
+--
+direct :: Monad m
+       => ServerStream m a
+       -> ClientStream m b
+       -> m (a, b)
+
+direct ServerStream{handleDone} (Client.Stop clientResult) =
+    pure (handleDone, clientResult)
+
+direct ServerStream{handlePing} (Client.Ping kPong) = do
+    server' <- handlePing
+    client' <- kPong
+    direct server' client'
+

--- a/src/Ouroboros/Network/Protocol/PingPong/Server.hs
+++ b/src/Ouroboros/Network/Protocol/PingPong/Server.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Ouroboros.Network.Protocol.PingPong.Server where
+
+import Ouroboros.Network.Protocol.Typed
+import Ouroboros.Network.Protocol.PingPong.Type
+
+
+data ServerStream m a = ServerStream { 
+    -- | The client sent us a ping message. We have no choices here, and
+    -- the response is nullary, all we have are local effects.
+    handlePing  :: m (ServerStream m a)
+
+    -- | The client terminated. Here we have a pure return value, but we
+    -- could have done another action in 'm' if we wanted to.
+  , handleDone  :: a
+  }
+
+
+-- | Interpret a particular server action sequence into the server side of the
+-- 'PingPong' protocol.
+--
+streamServer
+  :: Monad m
+  => ServerStream m a
+  -> Peer PingPongProtocol PingPongMessage
+          (Awaiting StIdle) (Finished StDone)
+          m a
+streamServer ServerStream{..} =
+
+    -- In the 'StIdle' the server is awaiting a request message
+    await $ \req ->
+
+    -- The client got to choose between two messages and we have to handle
+    -- either of them
+    case req of
+
+      -- The client sent the done transition, so we're in the 'StDone' state
+      -- so all we can do is stop using 'done', with a return value.
+      MsgDone -> done handleDone
+
+      -- The client sent us a ping request, so now we're in the 'StBusy' state
+      -- which means it's the server's turn to send.
+      MsgPing -> hole $ do
+        next <- handlePing
+        pure $ over MsgPong (streamServer next)
+

--- a/src/Ouroboros/Network/Protocol/PingPong/Server.hs
+++ b/src/Ouroboros/Network/Protocol/PingPong/Server.hs
@@ -8,27 +8,27 @@ import Ouroboros.Network.Protocol.Typed
 import Ouroboros.Network.Protocol.PingPong.Type
 
 
-data ServerStream m a = ServerStream { 
+data PingPongServer m a = PingPongServer {
     -- | The client sent us a ping message. We have no choices here, and
     -- the response is nullary, all we have are local effects.
-    handlePing  :: m (ServerStream m a)
+    recvMsgPing  :: m (PingPongServer m a)
 
     -- | The client terminated. Here we have a pure return value, but we
     -- could have done another action in 'm' if we wanted to.
-  , handleDone  :: a
+  , recvMsgDone  :: a
   }
 
 
 -- | Interpret a particular server action sequence into the server side of the
 -- 'PingPong' protocol.
 --
-streamServer
+pingPongServerPeer
   :: Monad m
-  => ServerStream m a
+  => PingPongServer m a
   -> Peer PingPongProtocol PingPongMessage
           (Awaiting StIdle) (Finished StDone)
           m a
-streamServer ServerStream{..} =
+pingPongServerPeer PingPongServer{..} =
 
     -- In the 'StIdle' the server is awaiting a request message
     await $ \req ->
@@ -39,11 +39,11 @@ streamServer ServerStream{..} =
 
       -- The client sent the done transition, so we're in the 'StDone' state
       -- so all we can do is stop using 'done', with a return value.
-      MsgDone -> done handleDone
+      MsgDone -> done recvMsgDone
 
       -- The client sent us a ping request, so now we're in the 'StBusy' state
       -- which means it's the server's turn to send.
       MsgPing -> hole $ do
-        next <- handlePing
-        pure $ over MsgPong (streamServer next)
+        next <- recvMsgPing
+        pure $ over MsgPong (pingPongServerPeer next)
 

--- a/src/Ouroboros/Network/Protocol/PingPong/Type.hs
+++ b/src/Ouroboros/Network/Protocol/PingPong/Type.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Ouroboros.Network.Protocol.PingPong.Type where
+
+import Ouroboros.Network.Protocol.Typed
+
+
+-- | States in the ping pong system.
+data PingPongState where
+  StIdle :: PingPongState
+  StBusy :: PingPongState
+  StDone :: PingPongState
+
+-- | A type to identify the client\/server partition of states in our protocol.
+data PingPongProtocol
+
+-- | We have to explain to the framework what our states mean, in terms of
+-- who is expected to send and receive in the different states.
+--
+type instance Partition PingPongProtocol st client server terminal =
+  PingPongStatePartition st client server terminal
+
+-- | Idle states are where it is for the client to send a message,
+-- busy states are where the server is expected to send a reply.
+--
+type family PingPongStatePartition st client server terminal :: k where
+  PingPongStatePartition StIdle client server terminal = client
+  PingPongStatePartition StBusy client server terminal = server
+  PingPongStatePartition StDone client server terminal = terminal
+
+-- | The actual messages in our protocol.
+--
+-- These involve transitions between different states within the 'StPingPong'
+-- states. A ping request goes from idle to busy, and a pong response go from
+-- busy to idle.
+--
+-- This example is so simple that we have all the messages directly as
+-- constructors within this type. In more complex cases it may be better to
+-- factor all (or related) requests and all responses within one case (in which
+-- case the state transitions may depend on the particular message via the
+-- usual GADT tricks).
+--
+data PingPongMessage from to where
+  MsgPing :: PingPongMessage StIdle StBusy
+  MsgPong :: PingPongMessage StBusy StIdle
+  MsgDone :: PingPongMessage StIdle StDone
+
+instance Show (PingPongMessage from to) where
+  show MsgPing = "MsgPing"
+  show MsgPong = "MsgPong"
+  show MsgDone = "MsgDone"
+

--- a/src/Ouroboros/Network/Protocol/Typed.hs
+++ b/src/Ouroboros/Network/Protocol/Typed.hs
@@ -49,12 +49,12 @@ data Peer p (tr :: st -> st -> Type) (from :: Status st) (to :: Status st) f t w
        , TrControl p from inter ~ control
        )
     => Exchange p tr from inter control
-    -> Peer p tr (ControlNext control 'Yielding 'Awaiting 'Finished inter) to f t
-    -> Peer p tr ('Yielding from) to f t
+    -> Peer p tr (ControlNext control Yielding Awaiting Finished inter) to f t
+    -> Peer p tr (Yielding from) to f t
   PeerAwait
     :: ( Typeable from )
-    => (forall inter . tr from inter -> Peer p tr (ControlNext (TrControl p from inter) 'Awaiting 'Yielding 'Finished inter) to f t)
-    -> Peer p tr ('Awaiting from) to f t
+    => (forall inter . tr from inter -> Peer p tr (ControlNext (TrControl p from inter) Awaiting Yielding Finished inter) to f t)
+    -> Peer p tr (Awaiting from) to f t
 
 -- | In a client/server model, one side will be awaiting when the other is
 -- receiving. This type will be included in a description of either side of
@@ -70,9 +70,9 @@ data Status k where
 --
 -- See 'stepping'.
 type family Complement (status :: st -> Status st) :: st -> Status st where
-  Complement 'Awaiting = 'Yielding
-  Complement 'Yielding = 'Awaiting
-  Complement 'Finished = 'Finished
+  Complement Awaiting = Yielding
+  Complement Yielding = Awaiting
+  Complement Finished = Finished
 
 -- | Description of control flow: either hold onto it or release it.
 data Control where
@@ -97,19 +97,19 @@ type family Partition (p :: r) (st :: k) (a :: t) (b :: t) (c :: t) :: t
 -- It's the same thing except that we're picking 'Hold if the XOR is false
 -- (they are the same) and 'Release otherwise.
 type TrControl p from to =
-  Partition p from (Partition p to 'Hold 'Release 'Terminate)
-                   (Partition p to 'Release 'Hold 'Terminate)
+  Partition p from (Partition p to Hold Release Terminate)
+                   (Partition p to Release Hold Terminate)
                    -- This part is weird. If 'from' is in the terminal set,
                    -- then ...
-                   'Terminate
+                   Terminate
 
 -- | This family is used in the definition of 'Peer' to determine whether, given
 -- a parituclar transition, a yielding side continues to yield or begins
 -- awaiting, and vice verse for an awaiting side.
 type family ControlNext control a b c where
-  ControlNext 'Hold      a b c = a
-  ControlNext 'Release   a b c = b
-  ControlNext 'Terminate a b c = c
+  ControlNext Hold      a b c = a
+  ControlNext Release   a b c = b
+  ControlNext Terminate a b c = c
 
 -- | Included in every yield, this gives not only the transition, but a
 -- 'Control' code to hold or release. The constructor for yielding will
@@ -120,10 +120,10 @@ type family ControlNext control a b c where
 -- unifies with _both_ 'Hold and 'Release, which would allow the yielding and
 -- awaiting sides to get out of sync.
 data Exchange p tr from to control where
-  Part :: tr from to -> Exchange p tr from to 'Hold
+  Part :: tr from to -> Exchange p tr from to Hold
   -- | Radio terminology. End of transmission and response is expected.
-  Over :: tr from to -> Exchange p tr from to 'Release
-  Out  :: tr from to -> Exchange p tr from to 'Terminate
+  Over :: tr from to -> Exchange p tr from to Release
+  Out  :: tr from to -> Exchange p tr from to Terminate
 
 -- | Get the transition from an 'Exchange'.
 exchangeTransition :: Exchange p tr from to control -> tr from to
@@ -142,40 +142,40 @@ yield
      , TrControl p from inter ~ control
      )
   => Exchange p tr from inter control
-  -> Peer p tr (ControlNext control 'Yielding 'Awaiting 'Finished inter) to f t
-  -> Peer p tr ('Yielding from) to f t
+  -> Peer p tr (ControlNext control Yielding Awaiting Finished inter) to f t
+  -> Peer p tr (Yielding from) to f t
 yield = PeerYield
 
 out
   :: ( Typeable from
-     , TrControl p from inter ~ 'Terminate
+     , TrControl p from inter ~ Terminate
      )
   => tr from inter
-  -> Peer p tr ('Finished inter) to f t
-  -> Peer p tr ('Yielding from) to f t
+  -> Peer p tr (Finished inter) to f t
+  -> Peer p tr (Yielding from) to f t
 out tr = yield (Out tr)
 
 over
   :: ( Typeable from
-     , TrControl p from inter ~ 'Release
+     , TrControl p from inter ~ Release
      )
   => tr from inter
-  -> Peer p tr ('Awaiting inter) to f t
-  -> Peer p tr ('Yielding from) to f t
+  -> Peer p tr (Awaiting inter) to f t
+  -> Peer p tr (Yielding from) to f t
 over tr = yield (Over tr)
 
 part
   :: ( Typeable from
-     , TrControl p from inter ~ 'Hold
+     , TrControl p from inter ~ Hold
      )
   => tr from inter
-  -> Peer p tr ('Yielding inter) to f t
-  -> Peer p tr ('Yielding from) to f t
+  -> Peer p tr (Yielding inter) to f t
+  -> Peer p tr (Yielding from) to f t
 part tr = yield (Part tr)
 
 await
   :: ( Typeable from )
-  => (forall inter . tr from inter -> Peer p tr (ControlNext (TrControl p from inter) 'Awaiting 'Yielding 'Finished inter) to f t)
-  -> Peer p tr ('Awaiting from) to f t
+  => (forall inter . tr from inter -> Peer p tr (ControlNext (TrControl p from inter) Awaiting Yielding Finished inter) to f t)
+  -> Peer p tr (Awaiting from) to f t
 await = PeerAwait
 

--- a/src/Ouroboros/Network/Protocol/Typed.hs
+++ b/src/Ouroboros/Network/Protocol/Typed.hs
@@ -1,0 +1,181 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+-- | Using a type transition system to describe either side of a
+-- request\/response application.
+module Ouroboros.Network.Protocol.Typed (
+    Peer(..),
+    Status(..),
+    Partition,
+    done,
+    hole,
+    part,
+    over,
+    out,
+    await,
+    exchangeTransition,
+    ) where
+
+import           Data.Kind     (Type)
+import           Data.Typeable
+
+
+-- | The other definitions in this module are to support or to use this
+-- datatype. It's somewhat like a pipe or conduit, but it's one-sided. It
+-- yields to and awaits from the same end. The type of thing which is produced
+-- or expected depends upon the type transition system 'tr', which also
+-- controls, by way of the partition 'p' (see the type family 'Partition'),
+-- at what point a yielder becomes an awaiter.
+data Peer p (tr :: st -> st -> Type) (from :: Status st) (to :: Status st) f t where
+  PeerDone :: t -> Peer p tr end end f t
+  PeerHole :: f (Peer p tr from to f t) -> Peer p tr from to f t
+  -- | When yielding a transition, there must be proof that, under 'p', the
+  -- transition either holds or releases control. This is enough to allow GHC
+  -- to deduce that the continuation in a complementary 'PeerAwait' (one which
+  -- is awaiting on the same initial state) will either
+  --   - continue to await if this one continues to yield (hold)
+  --   - begin to yield if this one begins to await (release)
+  -- See the defition of 'connect', where this property is used explicitly.
+  --
+  -- Typeable is here for the benefit of casting a transition on unknown
+  -- endpoints into one on a known endpoint, to facilitate passing them
+  -- through a channel. It's also in the 'PeerAwait' constructor.
+  PeerYield
+    :: ( Typeable from
+       , TrControl p from inter ~ control
+       )
+    => Exchange p tr from inter control
+    -> Peer p tr (ControlNext control 'Yielding 'Awaiting 'Finished inter) to f t
+    -> Peer p tr ('Yielding from) to f t
+  PeerAwait
+    :: ( Typeable from )
+    => (forall inter . tr from inter -> Peer p tr (ControlNext (TrControl p from inter) 'Awaiting 'Yielding 'Finished inter) to f t)
+    -> Peer p tr ('Awaiting from) to f t
+
+-- | In a client/server model, one side will be awaiting when the other is
+-- receiving. This type will be included in a description of either side of
+-- the a protocol application. See 'Peer'.
+data Status k where
+  Awaiting :: k -> Status k
+  Yielding :: k -> Status k
+  Finished :: k -> Status k
+
+-- | This would be far more useful if GHC could understand that
+--
+--   forall st . Complement (Complement st) = st
+--
+-- See 'stepping'.
+type family Complement (status :: st -> Status st) :: st -> Status st where
+  Complement 'Awaiting = 'Yielding
+  Complement 'Yielding = 'Awaiting
+  Complement 'Finished = 'Finished
+
+-- | Description of control flow: either hold onto it or release it.
+data Control where
+  Hold      :: Control
+  Release   :: Control
+  Terminate :: Control
+
+-- | 'p' partitions 'k' by picking, for each 'st :: k', one of 3 options,
+-- here called 'a', 'b', and 'c'.
+--
+-- To use a 'Peer p (tr :: k -> k -> Type)', there must be an instance of
+-- 'Parition p st a b c' for all 'st :: k'.
+type family Partition (p :: r) (st :: k) (a :: t) (b :: t) (c :: t) :: t
+
+-- | Picks 'Hold if 'from' and 'to' lie in the same partition.
+-- Picks 'Release otherwise.
+--
+-- To make sense of this, think of how to implement XOR on a Church boolean.
+--
+--   cb1 `xor` cb2 = \true false -> cb1 (cb2 false true) (cb2 true false)
+--
+-- It's the same thing except that we're picking 'Hold if the XOR is false
+-- (they are the same) and 'Release otherwise.
+type TrControl p from to =
+  Partition p from (Partition p to 'Hold 'Release 'Terminate)
+                   (Partition p to 'Release 'Hold 'Terminate)
+                   -- This part is weird. If 'from' is in the terminal set,
+                   -- then ...
+                   'Terminate
+
+-- | This family is used in the definition of 'Peer' to determine whether, given
+-- a parituclar transition, a yielding side continues to yield or begins
+-- awaiting, and vice verse for an awaiting side.
+type family ControlNext control a b c where
+  ControlNext 'Hold      a b c = a
+  ControlNext 'Release   a b c = b
+  ControlNext 'Terminate a b c = c
+
+-- | Included in every yield, this gives not only the transition, but a
+-- 'Control' code to hold or release. The constructor for yielding will
+-- require that 'Hold or 'Release is equal to an application of 'TrControl'
+-- on the relevant state endpoints. In this way, every transition either
+-- picks out exactly one of 'Hold or 'Release, or the type family is "stuck"
+-- and the program won't type check; it means you can't have a transition which
+-- unifies with _both_ 'Hold and 'Release, which would allow the yielding and
+-- awaiting sides to get out of sync.
+data Exchange p tr from to control where
+  Part :: tr from to -> Exchange p tr from to 'Hold
+  -- | Radio terminology. End of transmission and response is expected.
+  Over :: tr from to -> Exchange p tr from to 'Release
+  Out  :: tr from to -> Exchange p tr from to 'Terminate
+
+-- | Get the transition from an 'Exchange'.
+exchangeTransition :: Exchange p tr from to control -> tr from to
+exchangeTransition (Part tr) = tr
+exchangeTransition (Over tr) = tr
+exchangeTransition (Out tr)  = tr
+
+done :: t -> Peer p tr end end m t
+done = PeerDone
+
+hole :: f (Peer p tr from to f t) -> Peer p tr from to f t
+hole = PeerHole
+
+yield
+  :: ( Typeable from
+     , TrControl p from inter ~ control
+     )
+  => Exchange p tr from inter control
+  -> Peer p tr (ControlNext control 'Yielding 'Awaiting 'Finished inter) to f t
+  -> Peer p tr ('Yielding from) to f t
+yield = PeerYield
+
+out
+  :: ( Typeable from
+     , TrControl p from inter ~ 'Terminate
+     )
+  => tr from inter
+  -> Peer p tr ('Finished inter) to f t
+  -> Peer p tr ('Yielding from) to f t
+out tr = yield (Out tr)
+
+over
+  :: ( Typeable from
+     , TrControl p from inter ~ 'Release
+     )
+  => tr from inter
+  -> Peer p tr ('Awaiting inter) to f t
+  -> Peer p tr ('Yielding from) to f t
+over tr = yield (Over tr)
+
+part
+  :: ( Typeable from
+     , TrControl p from inter ~ 'Hold
+     )
+  => tr from inter
+  -> Peer p tr ('Yielding inter) to f t
+  -> Peer p tr ('Yielding from) to f t
+part tr = yield (Part tr)
+
+await
+  :: ( Typeable from )
+  => (forall inter . tr from inter -> Peer p tr (ControlNext (TrControl p from inter) 'Awaiting 'Yielding 'Finished inter) to f t)
+  -> Peer p tr ('Awaiting from) to f t
+await = PeerAwait
+

--- a/src/Ouroboros/Network/Protocol/Untyped.hs
+++ b/src/Ouroboros/Network/Protocol/Untyped.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE GADTs #-}
+
+-- | An view of the typed protocol where we forget the strong typing on the
+-- protocol state transitions and just retain the protocol actions.
+--
+-- This view is useful for executing protocols.
+--
+module Ouroboros.Network.Protocol.Untyped where
+
+import qualified Ouroboros.Network.Protocol.Typed as Typed
+
+import Data.Proxy
+import Data.Typeable (Typeable, (:~:)(Refl), eqT)
+import Data.Kind (Type)
+
+
+-- | This is like 'Typed.Peer' but without the strong typing on the protocol
+-- state transitions.
+--
+-- Because it is not strongly typed, the 'PeerAwait' can fail if given an
+-- unexpected message that is not correct for the protocol state.
+--
+-- This form can be used for interpreting against a channel (message or byte
+-- based with a suitable codec).
+--
+data Peer msg m a
+  = PeerDone   a
+  | PeerHole  (m (Peer msg m a))
+  | PeerYield (SomeMessage msg) (Peer msg m a)
+  | PeerAwait (SomeMessage msg -> Maybe (Peer msg m a))
+
+
+asUntypedPeer :: forall p st
+                        (msg     :: st -> st -> Type)
+                        (statusf :: st -> Typed.Status st)
+                        (statust :: st -> Typed.Status st)
+                        (from    :: st)
+                        (to      :: st)
+                        m a .
+                 Monad m
+              => Typed.Peer p msg (statusf from) (statust to) m a
+              -> Peer msg m a
+
+asUntypedPeer (Typed.PeerDone a) = PeerDone a
+
+asUntypedPeer (Typed.PeerHole f) = PeerHole (fmap asUntypedPeer f)
+
+asUntypedPeer (Typed.PeerYield msg k) =
+    PeerYield (SomeMessage (Typed.exchangeTransition msg))
+              (asUntypedPeer k)
+
+asUntypedPeer (Typed.PeerAwait k) =
+    PeerAwait $ \amsg ->
+      case castTransition (Proxy :: Proxy from) amsg of
+        Unexpected   -> Nothing
+        Expected msg -> Just (asUntypedPeer (k msg))
+
+
+data SomeMessage (msg :: st -> st -> Type) where
+  -- | Must ensure Typeable here, because we can't do it at 'castTransition'.
+  -- That would require stating that every type in the state kind is
+  -- typeable. Quantified constraints could help, although a short attempt at
+  -- that did not work.
+  SomeMessage :: Typeable from => msg from to -> SomeMessage msg
+
+
+data TransitionFrom msg from where
+  Expected   :: msg from to -> TransitionFrom msg from
+  Unexpected :: TransitionFrom msg from
+
+castTransition
+  :: forall st (msg :: st -> st -> Type) (from :: st) .
+     ( Typeable from )
+  => Proxy from
+  -> SomeMessage msg
+  -> TransitionFrom msg from
+castTransition _proxy (SomeMessage (m :: msg from' to)) =
+    case eqT of
+      Just (Refl :: from :~: from') -> Expected m
+      Nothing                       -> Unexpected
+


### PR DESCRIPTION
This brings the first parts of the typed protocol framework into the current code base.

It adds the core typed protocol `Peer` type, plus the ping pong and chain sync protocols.

It also adds a view of the protocol without the strong typing on the protocol states. This is a slightly different way of factoring the channel functionality compare with the original branch. It is quite close to the existing `Pipe` demo. It keeps the basic form of a `Peer` but hides the strong types, meaning that there is one dynamic test on receive (rather than this being guaranteed by the type), but which is the right form for pushing in messages from the wire.