### PR TITLE
Remove Hashable requirement

### DIFF
--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -168,5 +168,5 @@ test-suite tests
                        text,
                        transformers,
                        void
-  ghc-options:         -Wall,
+  ghc-options:         -Wall
                        -fno-ignore-asserts

--- a/src/Ouroboros/Network/Block.hs
+++ b/src/Ouroboros/Network/Block.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 -- | Abstract view over blocks
 --
@@ -34,7 +35,6 @@ class ( Eq        (HeaderHash b)
       , Ord       (HeaderHash b)
       , Show      (HeaderHash b)
       , Serialise (HeaderHash b)
-      , Hashable  (HeaderHash b)
       ) => HasHeader b where
     -- TODO: I /think/ we should be able to make this injective, but I'd have
     -- to check after the redesign of the block abstraction (which will live
@@ -57,7 +57,7 @@ deriving instance HasHeader block => Eq       (Hash block)
 deriving instance HasHeader block => Ord      (Hash block)
 deriving instance HasHeader block => Show     (Hash block)
 
-instance HasHeader block => Hashable (Hash block)
+instance (HasHeader block, Hashable (HeaderHash block)) => Hashable (Hash block)
   -- use generic instance
 
 castHash :: HeaderHash b ~ HeaderHash b' => Hash b -> Hash b'


### PR DESCRIPTION
This is only used in the network tests, not in the network library itself, and
it imposes unnecessary constraints on the consensus layer.