### PR TITLE
Use a type family for STM transactions

### DIFF
--- a/demo-playground/Logging.hs
+++ b/demo-playground/Logging.hs
@@ -16,7 +16,6 @@ module Logging (
 import           Control.Concurrent.STM
 import           Control.Monad
 import           Data.Semigroup ((<>))
-import           GHC.Stack
 
 import           Ouroboros.Consensus.Infra.Util
 import           Ouroboros.Network.Block
@@ -32,7 +31,7 @@ data LogEvent = LogEvent {
   , sender :: NodeId
   }
 
-showNetworkTraffic :: HasCallStack => TBQueue LogEvent -> IO ()
+showNetworkTraffic :: TBQueue LogEvent -> IO ()
 showNetworkTraffic q = forever $ do
     LogEvent{..} <- atomically $ readTBQueue q
     putStrLn $ "[conv_with:" <> show sender <> "] " <> msg

--- a/demo-playground/NamedPipe.hs
+++ b/demo-playground/NamedPipe.hs
@@ -6,7 +6,6 @@ module NamedPipe (
 
 import           Control.Exception (SomeException, bracket, catch)
 import           Data.Semigroup ((<>))
-import           GHC.Stack
 import           System.Directory (removeFile)
 import           System.IO
 import           System.Posix.Files (createNamedPipe, otherReadMode, ownerModes,
@@ -19,8 +18,7 @@ import qualified Ouroboros.Network.Pipe as P
 import           Ouroboros.Network.Serialise (Serialise)
 
 -- | Creates two pipes, one for reading, one for writing.
-withPipe :: HasCallStack
-         => (NodeId, NodeId)
+withPipe :: (NodeId, NodeId)
          -> ((Handle, Handle) -> IO a)
          -> IO a
 withPipe (fromNode, toNode) action = do

--- a/src/Ouroboros/Network/ConsumersAndProducers.hs
+++ b/src/Ouroboros/Network/ConsumersAndProducers.hs
@@ -28,9 +28,9 @@ import           Ouroboros.Network.ProtocolInterfaces
 -- This is of course only useful in tests and reference implementations since
 -- this is not a realistic chain representation.
 --
-exampleConsumer :: forall block m stm.
+exampleConsumer :: forall block m.
                    ( HasHeader block
-                   , MonadSTM m stm
+                   , MonadSTM m
                    )
                 => TVar m (Chain block)
                 -> ConsumerHandlers block m
@@ -68,9 +68,9 @@ recentOffsets = [0,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2584]
 -- this is not a realistic chain representation.
 --
 exampleProducer
-  :: forall block m stm.
+  :: forall block m.
      ( HasHeader block
-     , MonadSTM m stm
+     , MonadSTM m
      )
   => TVar m (ChainProducerState block)
   -> ProducerHandlers block m ReaderId

--- a/src/Ouroboros/Network/MonadClass/MonadProbe.hs
+++ b/src/Ouroboros/Network/MonadClass/MonadProbe.hs
@@ -34,7 +34,7 @@ class (MonadProbe m, Monad n) => MonadRunProbe m n | m -> n, n -> m where
   readProbe   :: Probe m a -> n (ProbeTrace m a)
   runM        :: m () -> n ()
 
-withProbe :: (MonadProbe m, MonadRunProbe m n)
+withProbe :: MonadRunProbe m n
           => (Probe m a -> m ())
           -> n (ProbeTrace m a)
 withProbe f = do

--- a/src/Ouroboros/Network/MonadClass/MonadSTM.hs
+++ b/src/Ouroboros/Network/MonadClass/MonadSTM.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
 module Ouroboros.Network.MonadClass.MonadSTM
   ( MonadSTM (..) ) where
 
@@ -9,27 +11,29 @@ import qualified Control.Monad.STM as STM
 
 import           Ouroboros.Network.MonadClass.MonadFork
 
-class (MonadFork m, Monad stm) => MonadSTM m stm | m -> stm, stm -> m where
+class (MonadFork m, Monad (Tr m)) => MonadSTM m where
+  type Tr   m = (n :: * -> *) | n -> m -- ^ STM transactions
   type TVar m :: * -> *
 
-  atomically   :: stm a -> m a
-  newTVar      :: a -> stm (TVar m a)
-  readTVar     :: TVar m a -> stm a
-  writeTVar    :: TVar m a -> a -> stm ()
-  modifyTVar   :: TVar m a -> (a -> a) -> stm ()
+  atomically   :: Tr m a -> m a
+  newTVar      :: a -> Tr m (TVar m a)
+  readTVar     :: TVar m a -> Tr m a
+  writeTVar    :: TVar m a -> a -> Tr m ()
+  modifyTVar   :: TVar m a -> (a -> a) -> Tr m ()
   modifyTVar  v f = readTVar v >>= writeTVar v . f
-  modifyTVar'  :: TVar m a -> (a -> a) -> stm ()
+  modifyTVar'  :: TVar m a -> (a -> a) -> Tr m ()
   modifyTVar' v f = do
     a <- readTVar v
     writeTVar v $! f a
-  retry        :: stm a
---orElse       :: stm a -> stm a -> stm a --TODO
+  retry        :: Tr m a
+--orElse       :: Tr m a -> Tr m a -> Tr m a --TODO
 
-  check        :: Bool -> stm ()
+  check        :: Bool -> Tr m ()
   check True = return ()
   check _    = retry
 
-instance MonadSTM IO STM.STM where
+instance MonadSTM IO where
+  type Tr   IO = STM.STM
   type TVar IO = STM.TVar
 
   atomically  = STM.atomically

--- a/src/Ouroboros/Network/MonadClass/MonadSTM.hs
+++ b/src/Ouroboros/Network/MonadClass/MonadSTM.hs
@@ -12,7 +12,7 @@ import qualified Control.Monad.STM as STM
 import           Ouroboros.Network.MonadClass.MonadFork
 
 class (MonadFork m, Monad (Tr m)) => MonadSTM m where
-  type Tr   m = (n :: * -> *) | n -> m -- ^ STM transactions
+  type Tr   m = (n :: * -> *) | n -> m -- STM transactions
   type TVar m :: * -> *
 
   atomically   :: Tr m a -> m a

--- a/src/Ouroboros/Network/MonadClass/MonadSTMTimer.hs
+++ b/src/Ouroboros/Network/MonadClass/MonadSTMTimer.hs
@@ -15,16 +15,16 @@ import           Ouroboros.Network.MonadClass.MonadTimer
 
 data TimeoutState = TimeoutPending | TimeoutFired | TimeoutCancelled
 
-class MonadSTM m stm => MonadSTMTimer m stm where
+class MonadSTM m => MonadSTMTimer m where
   data Timeout m :: *
 
-  timeoutState   :: Timeout m -> stm TimeoutState
+  timeoutState   :: Timeout m -> Tr m TimeoutState
 
   newTimeout     :: Duration (Time m) -> m (Timeout m)
   updateTimeout  :: Timeout m -> Duration (Time m) -> m ()
   cancelTimeout  :: Timeout m -> m ()
 
-instance MonadSTMTimer IO STM.STM where
+instance MonadSTMTimer IO where
   data Timeout IO = TimeoutIO !(STM.TVar TimeoutState) !GHC.TimeoutKey
 
   timeoutState (TimeoutIO var _key) = STM.readTVar var

--- a/src/Ouroboros/Network/Sim.hs
+++ b/src/Ouroboros/Network/Sim.hs
@@ -116,7 +116,8 @@ instance MonadTimer (Free (SimF s)) where
 instance MonadFork (Free (SimF s)) where
   fork          task = Free.liftF $ Fork task ()
 
-instance MonadSTM (Free (SimF s)) (Free (StmF s)) where
+instance MonadSTM (Free (SimF s)) where
+  type Tr   (Free (SimF s)) = Free (StmF s)
   type TVar (Free (SimF s)) = TVar s
   atomically action = Free.liftF $ Atomically action id
   newTVar         x = Free.liftF $ NewTVar x id
@@ -423,7 +424,7 @@ ordNub = go Set.empty
 -- Examples
 --
 
-example0 :: (MonadSay m, MonadTimer m, MonadSTM m stm) => m ()
+example0 :: (MonadSay m, MonadTimer m, MonadSTM m) => m ()
 example0 = do
   say "starting"
   t <- atomically (newTVar (0 :: Int))
@@ -454,7 +455,7 @@ example1 = do
     say $ show x
 
 -- the trace should contain "1" followed by "2"
-example2 :: (MonadSay m, MonadSTM m stm) => m ()
+example2 :: (MonadSay m, MonadSTM m) => m ()
 example2 = do
   say "starting"
   v <- atomically $ newTVar Nothing

--- a/test/Test/Node.hs
+++ b/test/Test/Node.hs
@@ -56,8 +56,8 @@ partitionProbe
 -- | Block generator should generate blocks in the correct slot time.
 --
 test_blockGenerator
-  :: forall m stm n.
-     ( MonadSTM m stm
+  :: forall m n.
+     ( MonadSTM m
      , MonadTimer m
      , MonadProbe m
      , MonadRunProbe m n
@@ -74,11 +74,7 @@ test_blockGenerator chain slotDuration = isValid <$> withProbe (experiment slotD
         (property True)
 
     experiment
-      :: ( MonadSTM m stm
-         , MonadTimer m
-         , MonadProbe m
-         )
-      => Duration (Time m)
+      :: Duration (Time m)
       -> Probe m Block
       -> m ()
     experiment slotDur p = do
@@ -95,8 +91,7 @@ prop_blockGenerator_IO :: TestBlockChain -> Positive Int -> Property
 prop_blockGenerator_IO (TestBlockChain chain) (Positive slotDuration) =
     ioProperty $ test_blockGenerator chain (slotDuration * 100)
 
-coreToRelaySim :: ( MonadSTM m stm
-                  , MonadTimer m
+coreToRelaySim :: ( MonadSTM m
                   , MonadSay m
                   , MonadProbe m
                   )
@@ -165,8 +160,7 @@ prop_coreToRelay (TestNodeSim chain slotDuration coreTrDelay relayTrDelay) =
       else mchain1 === Just chain
 
 -- Node graph: c → r → r
-coreToRelaySim2 :: ( MonadSTM m stm
-                   , MonadTimer m
+coreToRelaySim2 :: ( MonadSTM m
                    , MonadSay m
                    , MonadProbe m
                    )
@@ -220,8 +214,7 @@ prop_coreToRelay2 (TestNodeSim chain slotDuration coreTrDelay relayTrDelay) =
             mchain2 === Just chain
 
 -- | Node graph: c ↔ r ↔ c
-coreToCoreViaRelaySim :: ( MonadSTM m stm
-                         , MonadTimer m
+coreToCoreViaRelaySim :: ( MonadSTM m
                          , MonadSay m
                          , MonadProbe m
                          )
@@ -335,9 +328,8 @@ instance Arbitrary TestNetworkGraph where
     shrink (TestNetworkGraph g cs) =
         [ TestNetworkGraph g cs' | cs' <- shrinkList (:[]) cs, not (null cs') ]
 
-networkGraphSim :: forall m stm .
-                  ( MonadSTM m stm
-                  , MonadTimer m
+networkGraphSim :: forall m.
+                  ( MonadSTM m
                   , MonadProbe m
                   , MonadSay m
                   )

--- a/test/Test/Sim.hs
+++ b/test/Test/Sim.hs
@@ -42,7 +42,7 @@ prop_stm_graph_sim g =
   where
     trace = Sim.runSimM (prop_stm_graph g)
 
-prop_stm_graph :: MonadSTM m stm => TestThreadGraph -> m ()
+prop_stm_graph :: MonadSTM m => TestThreadGraph -> m ()
 prop_stm_graph (TestThreadGraph g) = do
     vars <- listArray (bounds g) <$>
             sequence [ atomically (newTVar False) | _ <- vertices g ]
@@ -133,13 +133,12 @@ instance Arbitrary TestRationals where
         return $ toRational n / toRational d
   shrink (TestRationals rs) = [ TestRationals rs' | rs' <- shrinkList (const []) rs ]
 
-test_timers :: forall m n stm.
+test_timers :: forall m n.
                ( MonadFork m
-               , MonadSTM m stm
+               , MonadSTM m
                , MonadTimer m
                , MonadProbe m
                , MonadRunProbe m n
-               , Eq (Time m)
                , Show (Time m)
                , Show (Duration (Time m))
                )
@@ -186,11 +185,9 @@ prop_timers_ST (TestRationals xs) =
 prop_timers_IO :: [Positive Int] -> Property
 prop_timers_IO = ioProperty . test_timers . map ((*100) . getPositive)
 
-test_fork_order :: forall m n stm.
+test_fork_order :: forall m n.
                    ( MonadFork m
-                   , MonadSTM m stm
-                   , MonadTimer m
-                   , MonadProbe m
+                   , MonadSTM m
                    , MonadRunProbe m n
                    )
                 => Positive Int


### PR DESCRIPTION
In the existing formulation, if we have two constraints `MonadSTM m stm` and
`MonadSTM m stm'`, ghc cannot figure out that `stm` and `stm'` must be the same
monad, despite the functional dependencies. Using a type family solves this
problem.