### PR TITLE
Implement BlockTag BlockUnderTest, expand LedgerState

### DIFF
--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -20,7 +20,6 @@ library
   -- At this experiment/prototype stage everything is exposed.
   -- This has to be tidied up once the design becomes clear.
   exposed-modules:
-                       Ouroboros.Consensus.Block.Abstract
                        Ouroboros.Consensus.Block.SimpleUTxO
                        Ouroboros.Consensus.Crypto.DSIGN
                        Ouroboros.Consensus.Crypto.DSIGN.Class
@@ -38,11 +37,12 @@ library
                        Ouroboros.Consensus.Crypto.VRF.Class
                        Ouroboros.Consensus.Crypto.VRF.Mock
                        Ouroboros.Consensus.Crypto.VRF.Simple
+                       Ouroboros.Consensus.Ledger.Abstract
+                       Ouroboros.Consensus.Ledger.Mock
                        Ouroboros.Consensus.Protocol.Abstract
                        Ouroboros.Consensus.Protocol.BFT
                        Ouroboros.Consensus.Protocol.Praos
                        Ouroboros.Consensus.Protocol.Test
-                       Ouroboros.Consensus.Test.MockLedger
                        Ouroboros.Consensus.Util
                        Ouroboros.Consensus.Util.DepFn
                        Ouroboros.Consensus.Util.HList

--- a/src/Ouroboros/Consensus/Block/SimpleUTxO.hs
+++ b/src/Ouroboros/Consensus/Block/SimpleUTxO.hs
@@ -16,8 +16,8 @@ import           GHC.Natural (naturalToWordMaybe)
 
 import qualified Ouroboros.Consensus.Crypto.Hash as H
 import           Ouroboros.Consensus.Crypto.Hash.MD5 (MD5)
-import           Ouroboros.Consensus.Test.MockLedger (HasUtxo (..))
-import qualified Ouroboros.Consensus.Test.MockLedger as Mock
+import           Ouroboros.Consensus.Ledger.Mock (HasUtxo (..))
+import qualified Ouroboros.Consensus.Ledger.Mock as Mock
 import           Ouroboros.Consensus.Util (Condense (..))
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Serialise

--- a/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TypeFamilies   #-}
 
--- | Abstract definition of a block
-module Ouroboros.Consensus.Block.Abstract (
-    BlockTag(..)
+-- | Abstract definition of a ledger
+module Ouroboros.Consensus.Ledger.Abstract (
+    UpdateLedger(..)
   ) where
 
 {-------------------------------------------------------------------------------
@@ -11,21 +11,12 @@ module Ouroboros.Consensus.Block.Abstract (
 -------------------------------------------------------------------------------}
 
 -- | The (open) universe of blocks
-class BlockTag (b :: *) where
-  data family Block       b :: *
-  data family BlockHeader b :: *
-  data family BlockBody   b :: *
-  type family LedgerState b :: *
-
-  -- TODO: Not entirely sure we need these
-  blockHeader :: Block b -> BlockHeader b
-  blockBody   :: Block b -> BlockBody   b
+class UpdateLedger (b :: *) where
+  data family LedgerState b :: *
 
   -- Apply a block to the ledger state
-  --
-  -- This is the key part of this type class.
   --
   -- TODO: We need to support rollback, so this probably won't be a pure
   -- function but rather something that lives in a monad with some actions
   -- that we can compute a "running diff" so that we can go back in time.
-  applyBlock  :: Block b -> LedgerState b -> LedgerState b
+  applyLedgerState  :: b -> LedgerState b -> LedgerState b

--- a/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE FunctionalDependencies     #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -32,7 +33,7 @@ import           Ouroboros.Network.Serialise (Serialise)
 --
 -- This class encodes the part that is independent from any particular
 -- block representation.
-class OuroborosTag (p :: *) where
+class Show (OuroborosLedgerState p) => OuroborosTag (p :: *) where
   -- | The protocol specific part that should included in the block
   --
   -- The type argument is the type of the block header /without/ the
@@ -45,11 +46,21 @@ class OuroborosTag (p :: *) where
   -- | Evidence that a node is the leader
   data family ProofIsLeader p :: *
 
+  -- | Protocol-specific part of the ledger state
+  data family OuroborosLedgerState p :: *
+
   -- | Construct the ouroboros-specific payload of a block
   --
   -- Gets the proof that we are the leader and the preheader as arguments.
   mkOuroborosPayload :: (MonadOuroborosState p m, MonadRandom m, Serialise ph)
                      => ProofIsLeader p -> ph -> m (OuroborosPayload p ph)
+
+  applyOuroborosLedgerState :: OuroborosPayload p ph
+                            -> OuroborosLedgerState p
+                            -> OuroborosLedgerState p
+
+  -- TODO: We need the dual of 'applyOuroborosLedgerState' for rollbacks.
+  -- rollbackOuroborosLedgerState :: ...
 
 -- | Interaction between the Ouroboros protocol and the ledger state
 class OuroborosTag p => RunOuroboros p l where

--- a/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -19,6 +19,7 @@ module Ouroboros.Consensus.Protocol.BFT (
   , BftCrypto(..)
     -- * BFT specific types
   , OuroborosState(..)
+  , OuroborosLedgerState(..)
   ) where
 
 import           GHC.Generics (Generic)
@@ -54,12 +55,19 @@ instance BftCrypto c => OuroborosTag (Bft c) where
   -- | For BFT the proof that we are a leader is trivial
   data ProofIsLeader (Bft c) = BftProof
 
+  -- | For BFT the ledger state is trivial.
+  -- NOTE: For \"permissive BFT\" this would not be trivial, because validation
+  -- would need to know statistical properties about the whole chain.
+  data OuroborosLedgerState (Bft c) = BftLedgerState deriving Show
+
   mkOuroborosPayload BftProof preheader = do
       BftState{..} <- getOuroborosState
       signature <- signed preheader bftSignKey
       return $ BftPayload {
           bftSignature = signature
         }
+
+  applyOuroborosLedgerState _ _ = BftLedgerState
 
 deriving instance BftCrypto c => Show (OuroborosPayload (Bft c) ph)
 deriving instance BftCrypto c => Eq   (OuroborosPayload (Bft c) ph)

--- a/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -66,6 +66,9 @@ instance PraosCrypto c => OuroborosTag (Praos c) where
       , praosLeaderId :: Int
       }
 
+  -- This is a placeholder for now (Lars).
+  data OuroborosLedgerState (Praos c) = PraosLedgerState deriving Show
+
   mkOuroborosPayload PraosProof{..} preheader = do
       PraosState{..} <- getOuroborosState
       let extraFields = PraosExtraFields {
@@ -78,6 +81,8 @@ instance PraosCrypto c => OuroborosTag (Praos c) where
           praosSignature   = signature
         , praosExtraFields = extraFields
         }
+
+  applyOuroborosLedgerState _ _ = PraosLedgerState
 
 instance (PraosCrypto c, PraosLedgerView l) => RunOuroboros (Praos c) l where
     checkIsLeader slot l = do

--- a/src/Ouroboros/Consensus/Protocol/Test.hs
+++ b/src/Ouroboros/Consensus/Protocol/Test.hs
@@ -19,6 +19,7 @@ module Ouroboros.Consensus.Protocol.Test (
   , TestProtocolStateView(..)
     -- * Constructors
   , OuroborosState(..)
+  , OuroborosLedgerState(..)
   ) where
 
 import           GHC.Generics (Generic)
@@ -33,7 +34,8 @@ data TestProtocol p
 
 instance OuroborosTag p => OuroborosTag (TestProtocol p) where
   -- The state is unchanged
-  newtype OuroborosState (TestProtocol p) = TestState (OuroborosState p)
+  newtype OuroborosState (TestProtocol p)       = TestState (OuroborosState p)
+  newtype OuroborosLedgerState (TestProtocol p) = TestLedgerState (OuroborosLedgerState p)
 
   -- Payload is the standard payload plus additional fields we want to test for
   data OuroborosPayload (TestProtocol p) ph = TestPayload {
@@ -55,6 +57,11 @@ instance OuroborosTag p => OuroborosTag (TestProtocol p) where
           testPayloadStd   = standardPayload
         , testPayloadStake = testProofStake
         }
+
+  applyOuroborosLedgerState (TestPayload std _) (TestLedgerState ls) =
+      TestLedgerState (applyOuroborosLedgerState std ls)
+
+deriving instance (OuroborosTag p) => Show (OuroborosLedgerState (TestProtocol p))
 
 deriving instance Show (OuroborosPayload p ph)
                => Show (OuroborosPayload (TestProtocol p) ph)

--- a/test-consensus/Test/Dynamic.hs
+++ b/test-consensus/Test/Dynamic.hs
@@ -1,15 +1,20 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TupleSections        #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS -fno-warn-unused-binds #-}
+{-# OPTIONS -fno-warn-orphans #-}
 
 module Test.Dynamic (
     tests
@@ -18,9 +23,13 @@ module Test.Dynamic (
 import           Control.Monad
 import           Control.Monad.ST.Lazy
 import           Crypto.Random (DRG)
+import           Data.Foldable (foldlM)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe
 import           Data.Proxy
+import           Data.Set (Set)
+import qualified Data.Set as Set
 import           Test.QuickCheck
 
 import           Test.Tasty
@@ -29,16 +38,18 @@ import           Test.Tasty.QuickCheck
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain
 import           Ouroboros.Network.ChainProducerState
-import           Ouroboros.Network.MonadClass
+import           Ouroboros.Network.MonadClass hiding (recvMsg, sendMsg)
 import           Ouroboros.Network.Node
 import           Ouroboros.Network.Protocol
 import           Ouroboros.Network.Serialise
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Mock
+import           Ouroboros.Consensus.Crypto.Hash.Class (hash)
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.Test
-import           Ouroboros.Consensus.Test.MockLedger
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.STM
 
@@ -59,7 +70,7 @@ test_simple_bft_convergence :: forall m n.
                                , Show (Time m)
                                )
                             => Seed -> n Property
-test_simple_bft_convergence seed =
+test_simple_bft_convergence seed = do
     fmap isValid $ withProbe $ go
   where
     numNodes, numSlots :: Int
@@ -68,12 +79,59 @@ test_simple_bft_convergence seed =
 
     go :: Probe m (Map NodeId (Chain BlockUnderTest)) -> m ()
     go p = do
+      txMap <- genTxMap
       finalChains <- broadcastNetwork
                        numSlots
                        nodeInit
-                       (LedgerState (fromIntegral numNodes))
+                       txMap
+                       initialLedgerState
                        (seedToChaCha seed)
       probeOutput p finalChains
+
+    -- TODO: We might want to have some more interesting transactions in
+    -- the future here.
+    genTxMap :: m (Map Slot (Set Tx))
+    genTxMap = do
+        -- Give everybody 1000 coins at the beginning.
+        let genesisTx = Tx mempty [(a, 1000)
+                                  | a <- Map.keys (testAddressDistribution initialLedgerState)
+                                  ]
+
+            -- TODO: This doesn't do anything at the moment, but ideally
+            -- we would need some randomness to shuffle the TxOut, divvy the
+            -- unspent output and distribute it randomly to the nodes, to
+            -- create an interesting test.
+            divvy :: Int -> [TxOut] -> m [TxOut]
+            divvy currentSlot xs = do
+              let totalCoins = foldl (\acc (_,c) -> acc + c) 0 xs
+              return $ foldl (\acc ((addr, _),nid) ->
+                               if currentSlot `mod` nid == 0 then (addr, totalCoins) : acc
+                                                             else (addr, 0) : acc
+                             ) mempty (zip xs [1..])
+
+        -- Move the stake around. Use the previous Tx in the accumulator a
+        -- like a UTxO, as we are moving all the stake all the time, in order
+        -- to make the observable state interesting.
+        Map.fromList . snd <$>
+            foldlM (\(prevTx@(Tx _ oldTxOut), acc) sl -> do
+                    let txIn  = Set.fromList $ [ (hash prevTx, n) | n <- [0 .. numNodes - 1] ]
+                    txOut <- divvy sl oldTxOut
+                    let newTx = Tx txIn txOut
+                    return (newTx, (Slot $ fromIntegral sl, Set.singleton newTx) : acc)
+                  ) (genesisTx, [(Slot 1, Set.singleton genesisTx)]) [2 .. numSlots]
+
+    initialLedgerState :: ExtLedgerState BlockUnderTest
+    initialLedgerState = ExtLedgerState {
+          testNumNodes = fromIntegral numNodes
+        -- NOTE: We could in principle move this into the 'OuroborosState'
+        -- for the protocol under test, but we would need a way to expose it
+        -- in our ledger view, as we do need this mapping to compute the stake
+        -- given an incoming transaction.
+        , testAddressDistribution = Map.fromList $
+              zip (map (:[]) $ take numNodes ['a' .. 'z'])
+                  (map CoreId [0 .. numNodes - 1])
+        , testLedgerState = SimpleLedgerState mempty (TestLedgerState BftLedgerState)
+        }
 
     nodeInit :: Map NodeId (OuroborosState ProtocolUnderTest, Chain BlockUnderTest)
     nodeInit = Map.fromList $ [ (CoreId i, (mkState i, Genesis))
@@ -101,18 +159,46 @@ test_simple_bft_convergence seed =
 
 type ProtocolUnderTest = TestProtocol (Bft BftMockCrypto)
 type BlockUnderTest    = SimpleBlock ProtocolUnderTest SimpleBlockStandardCrypto
+type HeaderUnderTest   = SimpleHeader ProtocolUnderTest SimpleBlockStandardCrypto
 
--- | TODO: Right now this just records the number of nodes, but we should also
--- record the stake
-data LedgerState = LedgerState {
-      ledgerNumNodes :: Word
+
+data ExtLedgerState b = ExtLedgerState {
+      testNumNodes            :: Word
+    , testAddressDistribution :: Map Addr NodeId
+    -- ^ Some form of mapping that allows us to partition incoming transactions
+    -- in a way that we can accumulate the stake properly.
+    , testLedgerState         :: LedgerState b
     }
 
-instance BftLedgerView LedgerState where
-  bftNumNodes = ledgerNumNodes
+deriving instance Show (LedgerState b) => Show (ExtLedgerState b)
 
-instance TestProtocolLedgerView LedgerState where
-  stakeForNode _ _ = 1234
+applyExtLedgerState :: UpdateLedger b
+                     => b
+                     -> ExtLedgerState b
+                     -> ExtLedgerState b
+applyExtLedgerState b ExtLedgerState{..} =
+    ExtLedgerState {
+          testNumNodes = testNumNodes
+        , testAddressDistribution = testAddressDistribution
+        , testLedgerState = applyLedgerState b testLedgerState
+    }
+
+
+-- Simple function which can answer the question: "Is this address owned by
+-- this node?"
+ourAddr :: NodeId -> Addr -> ExtLedgerState b -> Bool
+ourAddr myNodeId address st =
+    fmap ((==) myNodeId) (Map.lookup address (testAddressDistribution st))
+        == Just True
+
+instance BftLedgerView (ExtLedgerState b) where
+  bftNumNodes = testNumNodes
+
+instance TestProtocolLedgerView (ExtLedgerState (SimpleBlock p c)) where
+  stakeForNode nodeId st =
+      Map.foldl (\acc (a, stake) ->
+                 if ourAddr nodeId a st then acc + stake else acc
+                ) 0 (simpleUtxo . testLedgerState $ st)
 
 {-------------------------------------------------------------------------------
   Infrastructure
@@ -123,28 +209,35 @@ instance TestProtocolLedgerView LedgerState where
 --
 -- We run for the specified number of blocks, then return the final state of
 -- each node.
-broadcastNetwork :: forall m p c l gen.
+broadcastNetwork :: forall m p c gen.
                     ( MonadSTM   m
                     , MonadTimer m
                     , MonadSay   m
                     , Show      (OuroborosPayload p (SimplePreHeader p c))
+                    , Show      (LedgerState (SimpleBlock p c))
                     , Serialise (OuroborosPayload p (SimplePreHeader p c))
                     , SimpleBlockCrypto c
-                    , RunOuroboros p l
+                    , RunOuroboros p (ExtLedgerState (SimpleBlock p c))
                     , DRG gen
                     )
                  => Int
                  -- ^ Number of slots to run for
                  -> Map NodeId (OuroborosState p, Chain (SimpleBlock p c))
                  -- ^ Node initial state and initial chain
-                 -> l
+                 -> Map Slot (Set Tx)
+                 -- ^ For each slot, the transactions to be incorporated into
+                 -- a block.
+                 -> ExtLedgerState (SimpleBlock p c)
                  -- ^ Initial ledger state
                  -> gen
                  -- ^ Initial random number state
                  -> m (Map NodeId (Chain (SimpleBlock p c)))
-broadcastNetwork numSlots nodeInit initLedger initRNG = do
+broadcastNetwork numSlots nodeInit txMap initLedger initRNG = do
+    -- Creates the communication channels, /including/ the one to be used
+    -- to talk to ourselves. Such \"feedback loop\" is handy to be able to
+    -- /actually/ apply the ledger rules.
     chans <- fmap Map.fromList $ forM nodeIds $ \us -> do
-               fmap (us, ) $ fmap Map.fromList $ forM (filter (/= us) nodeIds) $ \them ->
+               fmap (us, ) $ fmap Map.fromList $ forM nodeIds $ \them ->
                  fmap (them, ) $
                    createCoupledChannels
                      @(MsgProducer (SimpleBlock p c))
@@ -157,10 +250,32 @@ broadcastNetwork numSlots nodeInit initLedger initRNG = do
     nodes <- forM (Map.toList nodeInit) $ \(us, (initSt, initChain)) -> do
       varRes <- atomically $ newTVar Nothing
       varSt  <- atomically $ newTVar initSt
+      varL   <- atomically $ newTVar initLedger
+
+      let ourOwnConsumer :: Chan m (MsgConsumer (SimpleBlock p c))
+                                   (MsgProducer (SimpleBlock p c))
+          ourOwnConsumer =
+              let loopbackRecv = snd (chans Map.! us Map.! us)
+              in Chan {
+                     sendMsg = sendMsg loopbackRecv
+                   , recvMsg = do
+                       msgToMyself <- recvMsg loopbackRecv
+                       case msgToMyself of
+                           MsgRollForward b -> do
+                               atomically $
+                                 modifyTVar' varL (applyExtLedgerState b)
+                           _ -> return ()
+                       return msgToMyself
+                  }
+
       varCPS <- relayNode us initChain $ NodeChannels {
-          consumerChans = map (\them -> snd (chans Map.! them Map.! us)) (filter (/= us) nodeIds)
-        , producerChans = map (\them -> fst (chans Map.! us Map.! them)) (filter (/= us) nodeIds)
+          consumerChans =
+              map (\them -> snd (chans Map.! them Map.! us)) (filter (/= us) nodeIds)
+              <> [ourOwnConsumer]
+        , producerChans =
+              map (\them -> fst (chans Map.! us Map.! them)) nodeIds
         }
+
 
       let runProtocol :: MonadPseudoRandomT gen (OuroborosStateT p (Tr m)) a
                       -> Tr m a
@@ -172,8 +287,10 @@ broadcastNetwork numSlots nodeInit initLedger initRNG = do
         timer (slotDuration (Proxy @m) * fromIntegral slotId) $ do
           let slot = Slot (fromIntegral slotId)
 
-          -- TODO: We should have a proper ledger here (Alfredo)
-          mIsLeader <- atomically $ runProtocol $ checkIsLeader slot initLedger
+          -- TODO: We *do not* update the ledger state here. That's done in
+          -- our \"loopback\" consumer.
+          currentLedger <- atomically $ readTVar varL
+          mIsLeader <- atomically $ runProtocol $ checkIsLeader slot currentLedger
           case mIsLeader of
             Nothing    -> return ()
             Just proof -> atomically $ do
@@ -182,7 +299,8 @@ broadcastNetwork numSlots nodeInit initLedger initRNG = do
                   prevHash = castHash (headHash chain)
                   prevNo   = headBlockNo chain
                   curNo    = succ prevNo
-              block <- runProtocol $ forgeBlock slot curNo prevHash proof
+                  txs      = fromMaybe mempty $ Map.lookup slot txMap
+              block <- runProtocol $ forgeBlock slot curNo prevHash txs proof
               writeTVar varCPS cps{ chainState = chain :> block }
 
       timer (slotDuration (Proxy @m) * fromIntegral (numSlots + 10)) $
@@ -199,6 +317,7 @@ broadcastNetwork numSlots nodeInit initLedger initRNG = do
 
     numNodes :: Int
     numNodes = Map.size nodeInit
+
 
 slotDuration :: MonadTimer m => proxy m -> Duration (Time m)
 slotDuration _ = 1000000


### PR DESCRIPTION
This commit tries to expand the broadcast test to be more interesting.
In particular, it tries to use some mock transactions to populate the
UTxO, and use a TestLedgerState which is threaded through the program
execution and that is used when the ledger rules needs to be applied.

@edsko Let's review on Monday. I ran out of time and my eyes started to become glassy. I think this does 98% of what you envisioned but I would like to crosscheck with you.