### PR TITLE
Request / Response protocol

### DIFF
--- a/typed-transitions/src/Protocol/Get/Client.hs
+++ b/typed-transitions/src/Protocol/Get/Client.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Protocol.Get.Client where
+
+import Protocol.Core
+import Protocol.Get.Type
+
+-- | Client reqeusting a resource identified by a resouce id.
+data Client m resource resourceId a where
+    Request :: resourceId -> (Maybe resource -> m a) -> Client m resource resourceId a
+
+-- | Interpret @'Client'@ as a client side of the typed @'GetProtocol'@
+--
+streamClient
+  :: Monad m
+  => Client m resource resourceId a
+  -> Peer GetProtocol (GetMessage resource resourceId)
+          (Yielding StIdle) (Finished StDone)
+          m a
+streamClient (Request resourceId handleData) = over (MsgRequest resourceId) $ await $ \msg ->
+  case msg of
+    MsgResponse r -> lift (done <$> handleData (Just r))
+    MsgNoData     -> lift (done <$> handleData Nothing)

--- a/typed-transitions/src/Protocol/Get/Direct.hs
+++ b/typed-transitions/src/Protocol/Get/Direct.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Protocol.Get.Direct where
+
+import Protocol.Get.Client
+import Protocol.Get.Server
+
+-- | The 'Ouroboros.Network.Protocol.Get.Client' and
+-- 'Ouroboros.Network.Protocol.Get.Server' are dual (complementary).
+direct
+  :: Monad m
+  => Server m resource resourceId a
+  -> Client m resource resourceId b
+  -> m (a, b)
+direct Server {..} (Request resourceId req) = do
+  mr <- serverRequest resourceId
+  (serverDone,) <$> req mr
+  

--- a/typed-transitions/src/Protocol/Get/Server.hs
+++ b/typed-transitions/src/Protocol/Get/Server.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Protocol.Get.Server where
+
+import Protocol.Core
+import Protocol.Get.Type
+
+data Server m resource resourceId a = Server {
+    -- | The client requested data identified by `resourceId`.
+    serverRequest :: resourceId -> m (Maybe resource),
+
+    -- | The terminal value returned by the server.
+    serverDone :: a
+  }
+
+-- | Create server side of the @'GetProtocol'@.
+--
+streamServer
+  :: Monad m
+  => Server m resource resourceId a
+  -> Peer GetProtocol (GetMessage resource resourceId)
+          (Awaiting StIdle) (Finished StDone)
+          m a
+streamServer Server {..} = await $ \msg ->
+  case msg of
+    MsgRequest rid -> lift $ do
+      mr <- serverRequest rid
+      case mr of
+        Just r  -> pure $ out (MsgResponse r) (done serverDone)
+        Nothing -> pure $ out MsgNoData (done serverDone)

--- a/typed-transitions/src/Protocol/Get/Type.hs
+++ b/typed-transitions/src/Protocol/Get/Type.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Protocol.Get.Type where
+
+import Protocol.Core
+
+
+-- | States in the get protocol.
+data GetState where
+  StIdle :: GetState
+  StBusy :: GetState
+  StDone :: GetState
+
+-- | A type to ideintiy the client \/server partition of states in the get
+-- protocol.
+--
+data GetProtocol
+
+type instance Partition GetProtocol st client server terminal =
+  GetStatePartition st client server terminal
+
+-- | Idle state is when the client sends a request, busy state is when the
+-- server responds with data and terminates.
+--
+type family GetStatePartition st client server terminal :: k where
+ GetStatePartition StIdle client server terminal = client
+ GetStatePartition StBusy client server terminal = server
+ GetStatePartition StDone client server terminal = terminal
+
+-- | Message protocol
+--
+data GetMessage resource resourceId from to where
+  MsgRequest  :: resourceId -> GetMessage resource resourceId StIdle StBusy
+  MsgResponse :: resource -> GetMessage resource resourceId StBusy StDone
+  MsgNoData   :: GetMessage resource resourceId StBusy StDone
+
+instance
+  (Show resource, Show resourceId)
+  => Show (GetMessage resource resourceId from to)
+ where
+  show (MsgRequest resourceId) = "MsgRequest " ++ show resourceId
+  show (MsgResponse resource)  = "MsgResponse " ++ show resource
+  show MsgNoData               = "MsgNoData"

--- a/typed-transitions/typed-transitions.cabal
+++ b/typed-transitions/typed-transitions.cabal
@@ -30,6 +30,10 @@ library
                      , Protocol.PingPong.Server
                      , Protocol.PingPong.Direct
                      , Protocol.PingPongExamples
+                     , Protocol.Get.Type
+                     , Protocol.Get.Client
+                     , Protocol.Get.Server
+                     , Protocol.Get.Direct
   -- other-modules:       
   other-extensions:    GADTs
                      , RankNTypes


### PR DESCRIPTION
The client ask data with `MsgRequest b` where `b` identifies the
resource of type `a`.  The server answer with `MsgResponse a` or
`MsgNoData`.  There's no recusion (after one step the conversation is done).  This allows to ask for a single block and finish the conversation, if the protocol could continue we'd need additional message to finish a conversation.