### PR TITLE
haddock

### DIFF
--- a/typed-transitions/default.nix
+++ b/typed-transitions/default.nix
@@ -15,4 +15,5 @@ mkDerivation {
     base async bytestring QuickCheck tasty tasty-quickcheck text
   ];
   license = stdenv.lib.licenses.bsd3;
+  enableSeparateDocOutput = false;
 }


### PR DESCRIPTION
@avieth this is a failry bengine PR, which allows to access haddock under the `./result` link created with `nix-build -A typed-transitions`.