### PR TITLE
chain sync protocol termination

### DIFF
--- a/typed-transitions/src/Protocol/ChainSync/Client.hs
+++ b/typed-transitions/src/Protocol/ChainSync/Client.hs
@@ -94,13 +94,13 @@ chainSyncClientPeer (SendMsgRequestNext stNext stAwait) =
     over MsgRequestNext $
     await $ \resp ->
     case resp of
-      MsgRollForward header pHead -> hole $ do
+      MsgRollForward header pHead -> lift $ do
           next <- recvMsgRollForward header pHead
           pure $ chainSyncClientPeer next
         where
           ClientStNext{recvMsgRollForward} = stNext
 
-      MsgRollBackward pRollback pHead -> hole $ do
+      MsgRollBackward pRollback pHead -> lift $ do
           next <- recvMsgRollBackward pRollback pHead
           pure $ chainSyncClientPeer next
         where
@@ -109,14 +109,14 @@ chainSyncClientPeer (SendMsgRequestNext stNext stAwait) =
       -- This code could be factored more easily by changing the protocol type
       -- to put both roll forward and back under a single constructor.
       MsgAwaitReply ->
-        hole $ do
+        lift $ do
           ClientStNext{recvMsgRollForward, recvMsgRollBackward} <- stAwait
           pure $ await $ \resp' ->
             case resp' of
-              MsgRollForward header pHead -> hole $ do
+              MsgRollForward header pHead -> lift $ do
                 next <- recvMsgRollForward header pHead
                 pure $ chainSyncClientPeer next
-              MsgRollBackward pRollback pHead -> hole $ do
+              MsgRollBackward pRollback pHead -> lift $ do
                 next <- recvMsgRollBackward pRollback pHead
                 pure $ chainSyncClientPeer next
 
@@ -124,11 +124,11 @@ chainSyncClientPeer (SendMsgFindIntersect points stIntersect) =
     over (MsgFindIntersect points) $
     await $ \resp ->
     case resp of
-      MsgIntersectImproved pIntersect pHead -> hole $ do
+      MsgIntersectImproved pIntersect pHead -> lift $ do
         next <- recvMsgIntersectImproved pIntersect pHead
         pure $ chainSyncClientPeer next
 
-      MsgIntersectUnchanged pHead -> hole $ do
+      MsgIntersectUnchanged pHead -> lift $ do
         next <- recvMsgIntersectUnchanged pHead
         pure $ chainSyncClientPeer next
   where

--- a/typed-transitions/src/Protocol/ChainSync/Client.hs
+++ b/typed-transitions/src/Protocol/ChainSync/Client.hs
@@ -59,24 +59,42 @@ data ClientStIdle header point m a where
     -> ClientStIntersect header point m a
     -> ClientStIdle header point m a
 
+  -- | The client decided to end the protocol.
+  --
+  SendMsgDone
+    :: a
+    -> ClientStIdle header point m a
+
 -- | In the 'StNext' protocol state, the client does not have agency and is
--- waiting to receive either a roll forward or roll back message. It must be
--- prepared to handle either.
+-- waiting to receive either
+--
+--  * a roll forward,
+--  * roll back message,
+--  * the terminating message.
+--
+-- It must be prepared to handle any of these.
 --
 data ClientStNext header point m a =
      ClientStNext {
        recvMsgRollForward  :: header -> point -> m (ClientStIdle header point m a),
-       recvMsgRollBackward :: point  -> point -> m (ClientStIdle header point m a)
+       recvMsgRollBackward :: point  -> point -> m (ClientStIdle header point m a),
+       recvMsgDoneServer   :: a
      }
 
 -- | In the 'StIntersect' protocol state, the client does not have agency and
--- is waiting to receive either an intersection improved or unchanged message.
--- It must be prepared to handle either.
+-- is waiting to receive:
+--
+--  * an intersection improved,
+--  * unchanged message,
+--  * the termination message.
+--
+-- It must be prepared to handle any of these.
 --
 data ClientStIntersect header point m a =
      ClientStIntersect {
        recvMsgIntersectImproved  :: point -> point -> m (ClientStIdle header point m a),
-       recvMsgIntersectUnchanged ::          point -> m (ClientStIdle header point m a)
+       recvMsgIntersectUnchanged ::          point -> m (ClientStIdle header point m a),
+       recvMsgIntersectDone      :: a
      }
 
 
@@ -110,7 +128,7 @@ chainSyncClientPeer (SendMsgRequestNext stNext stAwait) =
       -- to put both roll forward and back under a single constructor.
       MsgAwaitReply ->
         lift $ do
-          ClientStNext{recvMsgRollForward, recvMsgRollBackward} <- stAwait
+          ClientStNext{recvMsgRollForward, recvMsgRollBackward, recvMsgDoneServer} <- stAwait
           pure $ await $ \resp' ->
             case resp' of
               MsgRollForward header pHead -> lift $ do
@@ -119,6 +137,13 @@ chainSyncClientPeer (SendMsgRequestNext stNext stAwait) =
               MsgRollBackward pRollback pHead -> lift $ do
                 next <- recvMsgRollBackward pRollback pHead
                 pure $ chainSyncClientPeer next
+              MsgDone ->
+                done recvMsgDoneServer
+
+      -- The server decided to end the protocol.
+      MsgDone -> done recvMsgDoneServer
+        where
+          ClientStNext{recvMsgDoneServer} = stNext
 
 chainSyncClientPeer (SendMsgFindIntersect points stIntersect) =
     over (MsgFindIntersect points) $
@@ -131,9 +156,15 @@ chainSyncClientPeer (SendMsgFindIntersect points stIntersect) =
       MsgIntersectUnchanged pHead -> lift $ do
         next <- recvMsgIntersectUnchanged pHead
         pure $ chainSyncClientPeer next
+
+      -- The server decided to end the protocol
+      MsgDone -> done recvMsgIntersectDone
   where
     ClientStIntersect {
       recvMsgIntersectImproved,
-      recvMsgIntersectUnchanged
+      recvMsgIntersectUnchanged,
+      recvMsgIntersectDone
     } = stIntersect
 
+chainSyncClientPeer (SendMsgDone a) = 
+  out MsgDone (done a)

--- a/typed-transitions/src/Protocol/ChainSync/Server.hs
+++ b/typed-transitions/src/Protocol/ChainSync/Server.hs
@@ -82,15 +82,15 @@ chainSyncServerPeer ServerStIdle{recvMsgRequestNext, recvMsgFindIntersect} =
 
     await $ \req ->
     case req of
-      MsgRequestNext -> hole $ do
+      MsgRequestNext -> lift $ do
         mresp <- recvMsgRequestNext
         pure $ case mresp of
           Left  resp    -> handleStNext resp
-          Right waiting -> part MsgAwaitReply $ hole $ do
+          Right waiting -> part MsgAwaitReply $ lift $ do
                              resp <- waiting
                              pure $ handleStNext resp
 
-      MsgFindIntersect points -> hole $ do
+      MsgFindIntersect points -> lift $ do
         resp <- recvMsgFindIntersect points
         pure $ handleStIntersect resp 
 

--- a/typed-transitions/src/Protocol/ChainSync/Type.hs
+++ b/typed-transitions/src/Protocol/ChainSync/Type.hs
@@ -34,7 +34,6 @@ data ChainSyncState where
 
   -- | Both the client and server are in the terminal state. They're done.
   StDone      :: ChainSyncState
-  --TODO: currently there is no termination mechanism
 
 -- | Sub-cases of the 'StNext' state. This is needed since the server can
 -- either send one reply back, or two.
@@ -117,6 +116,11 @@ data ChainSyncMessage header point from to where
   --
   MsgIntersectUnchanged ::          point -> ChainSyncMessage header point StIntersect StIdle
 
+  -- | The consumer or producer decided to terminate the protocol.  Termination
+  -- might happen at any point of the protocol.
+  --
+  MsgDone :: ChainSyncMessage header point any StDone
+
 instance Show (ChainSyncMessage header point from to) where
   show MsgRequestNext          = "MsgRequestNext"
   show MsgAwaitReply           = "MsgAwaitReply"
@@ -125,4 +129,6 @@ instance Show (ChainSyncMessage header point from to) where
   show MsgFindIntersect{}      = "MsgFindIntersect"
   show MsgIntersectImproved{}  = "MsgIntersectImproved"
   show MsgIntersectUnchanged{} = "MsgIntersectUnchanged"
+  show MsgDone{}               = "MsgDone"
+
 

--- a/typed-transitions/typed-transitions.cabal
+++ b/typed-transitions/typed-transitions.cabal
@@ -30,6 +30,10 @@ library
                      , Protocol.PingPong.Server
                      , Protocol.PingPong.Direct
                      , Protocol.PingPongExamples
+                     , Protocol.ChainSync.Type
+                     , Protocol.ChainSync.Client
+                     , Protocol.ChainSync.Server
+                     , Protocol.ChainSync.Direct
   -- other-modules:       
   other-extensions:    GADTs
                      , RankNTypes


### PR DESCRIPTION
I modified the `ChainSync` typed protocol with `MsgDone` which might be send by any party at any time to terminate the protocol.

@avieth this also adds `ChainSync` modules into `typed-transistions.cabal` file.