### PR TITLE
untyped transitions

### DIFF
--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -76,6 +76,7 @@ library
                        Ouroboros.Network.Protocol.ChainSync.Direct
                        Ouroboros.Network.Protocol.ChainSync.Server
                        Ouroboros.Network.Protocol.ChainSync.Type
+                       Ouroboros.Network.Protocol.ChainSync.Encoding
   other-modules:
 -- Old experiments, not currently building:
 --                     Types

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -72,7 +72,10 @@ library
                        Ouroboros.Network.Protocol.Chain.Producer
                        Ouroboros.Network.Protocol.Chain.Node
                        Ouroboros.Network.Protocol.Channel.Sim
-                       Ouroboros.Network.Protocol.Untyped
+                       Ouroboros.Network.Protocol.ChainSync.Client
+                       Ouroboros.Network.Protocol.ChainSync.Direct
+                       Ouroboros.Network.Protocol.ChainSync.Server
+                       Ouroboros.Network.Protocol.ChainSync.Type
   other-modules:
 -- Old experiments, not currently building:
 --                     Types

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -63,6 +63,8 @@ library
                        Ouroboros.Network.MonadClass.MonadTimer
                        Ouroboros.Network.Node
                        Ouroboros.Network.Pipe
+                       Ouroboros.Network.Pipe2
+                       Ouroboros.Network.ChainSyncExamples
                        Ouroboros.Network.Protocol
                        Ouroboros.Network.ProtocolInterfaces
                        Ouroboros.Network.Serialise

--- a/src/Ouroboros/Network/ChainSyncExamples.hs
+++ b/src/Ouroboros/Network/ChainSyncExamples.hs
@@ -25,7 +25,7 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
 -- this is not a realistic chain representation.
 --
 chainSyncClientExample :: forall header m stm a.
-                          (HasHeader header, MonadSTM m stm)
+                          (HasHeader header, MonadSTM m)
                        => TVar m (Chain header)
                        -> m (ChainSyncClient header (Point header) m a)
 chainSyncClientExample chainvar =

--- a/src/Ouroboros/Network/Pipe2.hs
+++ b/src/Ouroboros/Network/Pipe2.hs
@@ -7,7 +7,7 @@ import           Codec.Serialise.Class (Serialise)
 import qualified Codec.CBOR.Read as CBOR (DeserialiseFailure)
 import           Data.ByteString (ByteString)
 
-import           Ouroboros.Network.Protocol.Untyped
+import           Protocol.Untyped
 import           Ouroboros.Network.ByteChannel (ByteChannel)
 import           Ouroboros.Network.MsgChannel
 import           Ouroboros.Network.Codec

--- a/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
@@ -12,7 +12,7 @@
 --
 -- For execution, a conversion into the typed protocol is provided.
 --
-module Protocol.ChainSync.Client (
+module Ouroboros.Network.Protocol.ChainSync.Client (
       -- * Protocol type for the client
       -- | The protocol states from the point of view of the client.
       ChainSyncClient
@@ -25,7 +25,7 @@ module Protocol.ChainSync.Client (
     ) where
 
 import Protocol.Core
-import Protocol.ChainSync.Type
+import Ouroboros.Network.Protocol.ChainSync.Type
 
 
 -- | A chain sync protocol client, on top of some effect 'm'.

--- a/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Protocol.ChainSync.Direct where
+module Ouroboros.Network.Protocol.ChainSync.Direct where
 
-import Protocol.ChainSync.Client as Client
-import Protocol.ChainSync.Server as Server
+import Ouroboros.Network.Protocol.ChainSync.Client as Client
+import Ouroboros.Network.Protocol.ChainSync.Server as Server
 
 -- | The 'ClientStream m' and 'ServerStream m' types are complementary. The
 -- former can be used to feed the latter directly, in the same thread.

--- a/src/Ouroboros/Network/Protocol/ChainSync/Encoding.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Encoding.hs
@@ -4,8 +4,8 @@
 
 module Ouroboros.Network.Protocol.ChainSync.Encoding where
 
-import Ouroboros.Network.Protocol.ChainSync.Type
-import Ouroboros.Network.Protocol.Untyped (SomeMessage(..))
+import Protocol.ChainSync.Type
+import Protocol.Untyped (SomeMessage(..))
 
 import Data.Monoid ((<>))
 import Codec.CBOR.Encoding (Encoding, encodeListLen, encodeWord)

--- a/src/Ouroboros/Network/Protocol/ChainSync/Encoding.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Encoding.hs
@@ -4,8 +4,9 @@
 
 module Ouroboros.Network.Protocol.ChainSync.Encoding where
 
-import Protocol.ChainSync.Type
 import Protocol.Untyped (SomeMessage(..))
+
+import Ouroboros.Network.Protocol.ChainSync.Type
 
 import Data.Monoid ((<>))
 import Codec.CBOR.Encoding (Encoding, encodeListLen, encodeWord)
@@ -24,6 +25,7 @@ encodeChainSyncMessage (SomeMessage msg) =
     MsgFindIntersect     ps   -> encodeListLen 2 <> encodeWord 4 <> encode ps
     MsgIntersectImproved p p' -> encodeListLen 3 <> encodeWord 5 <> encode p <> encode p'
     MsgIntersectUnchanged  p  -> encodeListLen 2 <> encodeWord 6 <> encode p
+    MsgDone                   -> encodeListLen 1 <> encodeWord 7
 
 decodeChainSyncMessage :: forall header point s.
                           (Serialise header, Serialise point)
@@ -41,4 +43,5 @@ decodeChainSyncMessage = do
     4 -> SomeMessage <$> (MsgFindIntersect      <$> decode)
     5 -> SomeMessage <$> (MsgIntersectImproved  <$> decode <*> decode)
     6 -> SomeMessage <$> (MsgIntersectUnchanged <$> decode)
+    7 -> return (SomeMessage MsgDone)
 

--- a/src/Ouroboros/Network/Protocol/ChainSync/Server.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Server.hs
@@ -12,7 +12,7 @@
 --
 -- For execution, a conversion into the typed protocol is provided.
 --
-module Protocol.ChainSync.Server  (
+module Ouroboros.Network.Protocol.ChainSync.Server  (
       -- * Protocol type for the server
       -- | The protocol states from the point of view of the server.
       ChainSyncServer
@@ -25,7 +25,7 @@ module Protocol.ChainSync.Server  (
     ) where
 
 import Protocol.Core
-import Protocol.ChainSync.Type
+import Ouroboros.Network.Protocol.ChainSync.Type
 
 
 -- | A chain sync protocol server, on top of some effect 'm'.

--- a/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 -- | The type of the chain synchronisation protocol.
 --
@@ -10,8 +11,6 @@
 -- definition of the protocol: what is allowed and what is not allowed.
 --
 module Ouroboros.Network.Protocol.ChainSync.Type where
-
-import Data.Typeable (Typeable)
 
 import Protocol.Core
 
@@ -37,8 +36,6 @@ data ChainSyncState where
 
   -- | Both the client and server are in the terminal state. They're done.
   StDone      :: ChainSyncState
-
-deriving instance Typeable ChainSyncState
 
 -- | Sub-cases of the 'StNext' state. This is needed since the server can
 -- either send one reply back, or two.

--- a/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -2,13 +2,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 -- | The type of the chain synchronisation protocol.
 --
 -- Since we are using a typed protocol framework this is in some sense /the/
 -- definition of the protocol: what is allowed and what is not allowed.
 --
-module Protocol.ChainSync.Type where
+module Ouroboros.Network.Protocol.ChainSync.Type where
 
 import Protocol.Core
 

--- a/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -11,6 +11,8 @@
 --
 module Ouroboros.Network.Protocol.ChainSync.Type where
 
+import Data.Typeable (Typeable)
+
 import Protocol.Core
 
 
@@ -35,6 +37,8 @@ data ChainSyncState where
 
   -- | Both the client and server are in the terminal state. They're done.
   StDone      :: ChainSyncState
+
+deriving instance Typeable ChainSyncState
 
 -- | Sub-cases of the 'StNext' state. This is needed since the server can
 -- either send one reply back, or two.

--- a/typed-transitions/src/Protocol/Untyped.hs
+++ b/typed-transitions/src/Protocol/Untyped.hs
@@ -11,7 +11,7 @@
 --
 -- This view is useful for executing protocols.
 --
-module Ouroboros.Network.Protocol.Untyped where
+module Protocol.Untyped where
 
 import qualified Protocol.Core as Typed
 

--- a/typed-transitions/typed-transitions.cabal
+++ b/typed-transitions/typed-transitions.cabal
@@ -21,6 +21,7 @@ library
                      , Protocol.Transition
                      , Protocol.Nat
                      , Protocol.Core
+                     , Protocol.Untyped
                      , Protocol.Chain.ConsumerStream
                      , Protocol.Chain.Type
                      , Protocol.Chain.ProducerStream
@@ -30,10 +31,6 @@ library
                      , Protocol.PingPong.Server
                      , Protocol.PingPong.Direct
                      , Protocol.PingPongExamples
-                     , Protocol.ChainSync.Type
-                     , Protocol.ChainSync.Client
-                     , Protocol.ChainSync.Server
-                     , Protocol.ChainSync.Direct
   -- other-modules:       
   other-extensions:    GADTs
                      , RankNTypes


### PR DESCRIPTION
@dcoutts I moved untyped transitions to `typed-transisions` and added a quantified constraint in [asUntypedPeer](https://github.com/input-output-hk/ouroboros-network/compare/avieth/typed-transitions...coot/untyped-transitions?expand=1#diff-e728c1432ff1e805ecdf51b50f8c7ad0L46) and [castTransition](https://github.com/input-output-hk/ouroboros-network/compare/avieth/typed-transitions...coot/untyped-transitions?expand=1#diff-e728c1432ff1e805ecdf51b50f8c7ad0R77) instead of a constraint in `SomeMessage`.  However, I am not sure if this really solves the problem or it just pushes is down to callees: I needed to add quantified constraints in `Peer2`, just using `DeriveDataTypeable` extension in [ChainSync.Type](https://github.com/input-output-hk/ouroboros-network/compare/avieth/typed-transitions...coot/untyped-transitions?expand=1#diff-9d4dcc950b153d16542255a34a5e4b47R6) does not seem enough.