### PR TITLE
Untyped transitions

### DIFF
--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -76,6 +76,7 @@ library
                        Ouroboros.Network.Protocol.ChainSync.Direct
                        Ouroboros.Network.Protocol.ChainSync.Server
                        Ouroboros.Network.Protocol.ChainSync.Type
+                       Ouroboros.Network.Protocol.ChainSync.Encoding
   other-modules:
 -- Old experiments, not currently building:
 --                     Types

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -80,6 +80,10 @@ library
   other-modules:
                        Ouroboros.Network.Pipe2
                        Ouroboros.Network.ChainSyncExamples
+                       Ouroboros.Network.ByteChannel
+                       Ouroboros.Network.Codec
+                       Ouroboros.Network.Framing
+                       Ouroboros.Network.MsgChannel
   default-language:    Haskell2010
   other-extensions:    BangPatterns,
                        DataKinds,

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -78,11 +78,8 @@ library
                        Ouroboros.Network.Protocol.ChainSync.Type
                        Ouroboros.Network.Protocol.ChainSync.Encoding
   other-modules:
--- Old experiments, not currently building:
---                     Types
---                     ChainSelection
---                     ConsumerProtocolSTM
---                     Chain.Volatile,
+                       Ouroboros.Network.Pipe2
+                       Ouroboros.Network.ChainSyncExamples
   default-language:    Haskell2010
   other-extensions:    BangPatterns,
                        DataKinds,

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -72,7 +72,10 @@ library
                        Ouroboros.Network.Protocol.Chain.Producer
                        Ouroboros.Network.Protocol.Chain.Node
                        Ouroboros.Network.Protocol.Channel.Sim
-                       Ouroboros.Network.Protocol.Untyped
+                       Ouroboros.Network.Protocol.ChainSync.Client
+                       Ouroboros.Network.Protocol.ChainSync.Direct
+                       Ouroboros.Network.Protocol.ChainSync.Server
+                       Ouroboros.Network.Protocol.ChainSync.Type
   other-modules:
 -- Old experiments, not currently building:
 --                     Types

--- a/src/Ouroboros/Network/ChainSyncExamples.hs
+++ b/src/Ouroboros/Network/ChainSyncExamples.hs
@@ -24,7 +24,7 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
 -- This is of course only useful in tests and reference implementations since
 -- this is not a realistic chain representation.
 --
-chainSyncClientExample :: forall header m stm a.
+chainSyncClientExample :: forall header m a.
                           (HasHeader header, MonadSTM m)
                        => TVar m (Chain header)
                        -> m (ChainSyncClient header (Point header) m a)
@@ -97,18 +97,20 @@ recentOffsets = [0,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2584]
 -- This is of course only useful in tests and reference implementations since
 -- this is not a realistic chain representation.
 --
-chainSyncServerExample :: forall header m stm a.
-                          (HasHeader header, MonadSTM m stm)
-                       => TVar m (ChainProducerState header)
+chainSyncServerExample :: forall header m a.
+                          (HasHeader header, MonadSTM m)
+                       => a
+                       -> TVar m (ChainProducerState header)
                        -> m (ChainSyncServer header (Point header) m a)
-chainSyncServerExample chainvar =
+chainSyncServerExample recvMsgDoneClient chainvar =
     idle <$> newReader
   where
     idle :: ReaderId -> ServerStIdle header (Point header) m a
     idle r =
       ServerStIdle {
         recvMsgRequestNext   = handleRequestNext r,
-        recvMsgFindIntersect = handleFindIntersect r
+        recvMsgFindIntersect = handleFindIntersect r,
+        recvMsgDoneClient
       }
 
     handleRequestNext :: ReaderId

--- a/src/Ouroboros/Network/ChainSyncExamples.hs
+++ b/src/Ouroboros/Network/ChainSyncExamples.hs
@@ -25,7 +25,7 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
 -- this is not a realistic chain representation.
 --
 chainSyncClientExample :: forall header m stm a.
-                          (HasHeader header, MonadSTM m stm)
+                          (HasHeader header, MonadSTM m)
                        => TVar m (Chain header)
                        -> m (ChainSyncClient header (Point header) m a)
 chainSyncClientExample chainvar =

--- a/src/Ouroboros/Network/Pipe2.hs
+++ b/src/Ouroboros/Network/Pipe2.hs
@@ -7,7 +7,7 @@ import           Codec.Serialise.Class (Serialise)
 import qualified Codec.CBOR.Read as CBOR (DeserialiseFailure)
 import           Data.ByteString (ByteString)
 
-import           Ouroboros.Network.Protocol.Untyped
+import           Protocol.Untyped
 import           Ouroboros.Network.ByteChannel (ByteChannel)
 import           Ouroboros.Network.MsgChannel
 import           Ouroboros.Network.Codec

--- a/src/Ouroboros/Network/Pipe2.hs
+++ b/src/Ouroboros/Network/Pipe2.hs
@@ -49,16 +49,17 @@ runConsumer client channel =
 
 ------------------------------------------------
 
-runExampleProducer :: (MonadST m, MonadSTM m stm,
+runExampleProducer :: (MonadST m, MonadSTM m,
                        HasHeader header, Serialise header)
-                   => TVar m (ChainProducerState header)
+                   => a
+                   -> TVar m (ChainProducerState header)
                    -> ByteChannel ByteString m
                    -> m (Either (ProtocolError CBOR.DeserialiseFailure) a)
-runExampleProducer cpsVar channel = do
-    server <- chainSyncServerExample cpsVar
+runExampleProducer recvMsgDone cpsVar channel = do
+    server <- chainSyncServerExample recvMsgDone cpsVar
     runProducer server channel
 
-runExampleConsumer :: (MonadST m, MonadSTM m stm,
+runExampleConsumer :: (MonadST m, MonadSTM m,
                        HasHeader header, Serialise header)
                    => TVar m (Chain header)
                    -> ByteChannel ByteString m
@@ -88,7 +89,7 @@ runPeerWithChannel codec peer0 bytechannel =
        -> m (Either (ProtocolError failure) a)
     go _ (PeerDone x) = return (Right x)
 
-    go channel (PeerHole effect) =
+    go channel (PeerLift effect) =
       effect >>= \peer' -> go channel peer'
 
     go channel (PeerYield msg peer') =

--- a/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
@@ -12,7 +12,7 @@
 --
 -- For execution, a conversion into the typed protocol is provided.
 --
-module Protocol.ChainSync.Client (
+module Ouroboros.Network.Protocol.ChainSync.Client (
       -- * Protocol type for the client
       -- | The protocol states from the point of view of the client.
       ChainSyncClient
@@ -25,7 +25,7 @@ module Protocol.ChainSync.Client (
     ) where
 
 import Protocol.Core
-import Protocol.ChainSync.Type
+import Ouroboros.Network.Protocol.ChainSync.Type
 
 
 -- | A chain sync protocol client, on top of some effect 'm'.

--- a/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Protocol.ChainSync.Direct where
+module Ouroboros.Network.Protocol.ChainSync.Direct where
 
-import Protocol.ChainSync.Client as Client
-import Protocol.ChainSync.Server as Server
+import Ouroboros.Network.Protocol.ChainSync.Client as Client
+import Ouroboros.Network.Protocol.ChainSync.Server as Server
 
 -- | The 'ClientStream m' and 'ServerStream m' types are complementary. The
 -- former can be used to feed the latter directly, in the same thread.

--- a/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
@@ -33,15 +33,10 @@ direct  ServerStIdle{recvMsgRequestNext}
       client' <- recvMsgRollBackward pIntersect pHead
       direct server' client'
 
-    directStNext (SendMsgDoneNext serverDone)
-                 ClientStNext{recvMsgDoneServer} =
-      return (serverDone, recvMsgDoneServer)
-
 direct  ServerStIdle{recvMsgFindIntersect}
        (Client.SendMsgFindIntersect points
           ClientStIntersect{recvMsgIntersectImproved,
-                            recvMsgIntersectUnchanged,
-                            recvMsgIntersectDone}) = do
+                            recvMsgIntersectUnchanged}) = do
     sIntersect <- recvMsgFindIntersect points
     case sIntersect of
       SendMsgIntersectImproved  pIntersect pHead server' -> do
@@ -51,9 +46,6 @@ direct  ServerStIdle{recvMsgFindIntersect}
       SendMsgIntersectUnchanged            pHead server' -> do
         client' <- recvMsgIntersectUnchanged pHead
         direct server' client'
-
-      SendMsgDoneIntersect serverDone ->
-        return (serverDone, recvMsgIntersectDone)
 
 direct ServerStIdle{recvMsgDoneClient}
        (Client.SendMsgDone clientDone) =

--- a/src/Ouroboros/Network/Protocol/ChainSync/Encoding.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Encoding.hs
@@ -4,8 +4,8 @@
 
 module Ouroboros.Network.Protocol.ChainSync.Encoding where
 
-import Ouroboros.Network.Protocol.ChainSync.Type
-import Ouroboros.Network.Protocol.Untyped (SomeMessage(..))
+import Protocol.ChainSync.Type
+import Protocol.Untyped (SomeMessage(..))
 
 import Data.Monoid ((<>))
 import Codec.CBOR.Encoding (Encoding, encodeListLen, encodeWord)

--- a/src/Ouroboros/Network/Protocol/ChainSync/Encoding.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Encoding.hs
@@ -4,8 +4,9 @@
 
 module Ouroboros.Network.Protocol.ChainSync.Encoding where
 
-import Protocol.ChainSync.Type
 import Protocol.Untyped (SomeMessage(..))
+
+import Ouroboros.Network.Protocol.ChainSync.Type
 
 import Data.Monoid ((<>))
 import Codec.CBOR.Encoding (Encoding, encodeListLen, encodeWord)
@@ -24,6 +25,7 @@ encodeChainSyncMessage (SomeMessage msg) =
     MsgFindIntersect     ps   -> encodeListLen 2 <> encodeWord 4 <> encode ps
     MsgIntersectImproved p p' -> encodeListLen 3 <> encodeWord 5 <> encode p <> encode p'
     MsgIntersectUnchanged  p  -> encodeListLen 2 <> encodeWord 6 <> encode p
+    MsgDone                   -> encodeListLen 1 <> encodeWord 7
 
 decodeChainSyncMessage :: forall header point s.
                           (Serialise header, Serialise point)
@@ -41,4 +43,5 @@ decodeChainSyncMessage = do
     4 -> SomeMessage <$> (MsgFindIntersect      <$> decode)
     5 -> SomeMessage <$> (MsgIntersectImproved  <$> decode <*> decode)
     6 -> SomeMessage <$> (MsgIntersectUnchanged <$> decode)
+    7 -> return (SomeMessage MsgDone)
 

--- a/src/Ouroboros/Network/Protocol/ChainSync/Server.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Server.hs
@@ -68,9 +68,6 @@ data ServerStNext header point m a where
                       -> ServerStIdle header point m a
                       -> ServerStNext header point m a
 
-  SendMsgDoneNext     :: a
-                      -> ServerStNext header point m a
-
 -- | In the 'StIntersect' protocol state, the server has agency and must send
 -- either:
 --
@@ -85,9 +82,6 @@ data ServerStIntersect header point m a where
 
   SendMsgIntersectUnchanged :: point
                             -> ServerStIdle header point m a
-                            -> ServerStIntersect header point m a
-
-  SendMsgDoneIntersect      :: a
                             -> ServerStIntersect header point m a
 
 
@@ -127,9 +121,6 @@ chainSyncServerPeer ServerStIdle{recvMsgRequestNext, recvMsgFindIntersect, recvM
       over (MsgRollBackward pIntersect pHead)
            (chainSyncServerPeer next)
 
-    handleStNext (SendMsgDoneNext a) =
-      out MsgDone (done a)
-
     handleStIntersect (SendMsgIntersectImproved pIntersect pHead next) =
       over (MsgIntersectImproved pIntersect pHead)
            (chainSyncServerPeer next)
@@ -137,6 +128,3 @@ chainSyncServerPeer ServerStIdle{recvMsgRequestNext, recvMsgFindIntersect, recvM
     handleStIntersect (SendMsgIntersectUnchanged pHead next) =
       over (MsgIntersectUnchanged pHead)
            (chainSyncServerPeer next)
-
-    handleStIntersect (SendMsgDoneIntersect a) =
-      out MsgDone (done a)

--- a/src/Ouroboros/Network/Protocol/ChainSync/Server.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Server.hs
@@ -12,7 +12,7 @@
 --
 -- For execution, a conversion into the typed protocol is provided.
 --
-module Protocol.ChainSync.Server  (
+module Ouroboros.Network.Protocol.ChainSync.Server  (
       -- * Protocol type for the server
       -- | The protocol states from the point of view of the server.
       ChainSyncServer
@@ -25,7 +25,7 @@ module Protocol.ChainSync.Server  (
     ) where
 
 import Protocol.Core
-import Protocol.ChainSync.Type
+import Ouroboros.Network.Protocol.ChainSync.Type
 
 
 -- | A chain sync protocol server, on top of some effect 'm'.

--- a/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -119,12 +119,11 @@ data ChainSyncMessage header point from to where
   --
   -- The message also tells the consumer about the head point of the producer.
   --
-  MsgIntersectUnchanged ::          point -> ChainSyncMessage header point StIntersect StIdle
+  MsgIntersectUnchanged :: point -> ChainSyncMessage header point StIntersect StIdle
 
-  -- | The consumer or producer decided to terminate the protocol.  Termination
-  -- might happen at any point of the protocol.
+  -- | Terminating messages
   --
-  MsgDone :: ChainSyncMessage header point any StDone
+  MsgDone :: ChainSyncMessage header point StIdle StDone
 
 instance Show (ChainSyncMessage header point from to) where
   show MsgRequestNext          = "MsgRequestNext"

--- a/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -2,13 +2,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 -- | The type of the chain synchronisation protocol.
 --
 -- Since we are using a typed protocol framework this is in some sense /the/
 -- definition of the protocol: what is allowed and what is not allowed.
 --
-module Protocol.ChainSync.Type where
+module Ouroboros.Network.Protocol.ChainSync.Type where
 
 import Protocol.Core
 

--- a/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -11,6 +11,8 @@
 --
 module Ouroboros.Network.Protocol.ChainSync.Type where
 
+import Data.Typeable (Typeable)
+
 import Protocol.Core
 
 
@@ -35,6 +37,8 @@ data ChainSyncState where
 
   -- | Both the client and server are in the terminal state. They're done.
   StDone      :: ChainSyncState
+
+deriving instance Typeable ChainSyncState
 
 -- | Sub-cases of the 'StNext' state. This is needed since the server can
 -- either send one reply back, or two.

--- a/typed-transitions/src/Protocol/Untyped.hs
+++ b/typed-transitions/src/Protocol/Untyped.hs
@@ -11,7 +11,7 @@
 --
 -- This view is useful for executing protocols.
 --
-module Ouroboros.Network.Protocol.Untyped where
+module Protocol.Untyped where
 
 import qualified Protocol.Core as Typed
 

--- a/typed-transitions/typed-transitions.cabal
+++ b/typed-transitions/typed-transitions.cabal
@@ -21,6 +21,7 @@ library
                      , Protocol.Transition
                      , Protocol.Nat
                      , Protocol.Core
+                     , Protocol.Untyped
                      , Protocol.Chain.ConsumerStream
                      , Protocol.Chain.Type
                      , Protocol.Chain.ProducerStream
@@ -30,10 +31,6 @@ library
                      , Protocol.PingPong.Server
                      , Protocol.PingPong.Direct
                      , Protocol.PingPongExamples
-                     , Protocol.ChainSync.Type
-                     , Protocol.ChainSync.Client
-                     , Protocol.ChainSync.Server
-                     , Protocol.ChainSync.Direct
   -- other-modules:       
   other-extensions:    GADTs
                      , RankNTypes


### PR DESCRIPTION
Some changes to the `ChainSync` protocol:
* only the client can end the protocol with `MsgDone` (which avoids problems with polymorphic termination messages which I run into in #81)
* updated cabal file: included `Pipe2` and `ChainSyncExample`, so they will build in `CI`
* also added:
      - `Ouroboros.Network.ByteChannel`
      - `Ouroboros.Network.Codec`
      - `Ouroboros.Network.Framing`
      - `Ouroboros.Network.MsgChannel`
  to `outher-modules` in `ouroboros-network.cabal`.