### PR TITLE
Praos with KES and "Dynamic" test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dist-newstyle/
 *~
 result*
 tags
+
+.stack-work/

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,245 @@
+# Stylish-haskell configuration file used for cardano-sl by Serokell.
+# It's based on default config provided by `stylish-haskell --defaults` but has some changes
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  - simple_align:
+      cases: true
+      top_level_patterns: true
+      records: true
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: global
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # Default: after_alias
+      list_align: with_module_name
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+
+      # Note: we intentionally disable it to make diffs less verbose and avoid
+      # merge conflicts in some cases.
+      pad_module_names: false
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-#LANGUAGE #-}'.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account. Default: 80.
+columns: 80
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# These syntax-affecting language extensions are enabled so that
+# stylish-haskell wouldn't fail with parsing errors when processing files
+# in projects that have those extensions enabled in the .cabal file
+# rather than locally.
+#
+# To my best knowledge, no harm should result from enabling an extension
+# that isn't actually used in the file/project. —@neongreen
+language_extensions:
+  - BangPatterns
+  - ConstraintKinds
+  - DataKinds
+  - DefaultSignatures
+  - DeriveDataTypeable
+  - DeriveGeneric
+  - ExistentialQuantification
+  - FlexibleContexts
+  - FlexibleInstances
+  - FunctionalDependencies
+  - GADTs
+  - GeneralizedNewtypeDeriving
+  - LambdaCase
+  - MultiParamTypeClasses
+  - MultiWayIf
+  - NoImplicitPrelude
+  - OverloadedStrings
+  - PolyKinds
+  - RecordWildCards
+  - ScopedTypeVariables
+  - StandaloneDeriving
+  - TemplateHaskell
+  - TupleSections
+  - TypeApplications
+  - TypeFamilies
+  - ViewPatterns
+  - ExplicitNamespaces

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -33,6 +33,7 @@ library
                        Ouroboros.Consensus.Crypto.KES
                        Ouroboros.Consensus.Crypto.KES.Class
                        Ouroboros.Consensus.Crypto.KES.Mock
+                       Ouroboros.Consensus.Crypto.KES.Simple
                        Ouroboros.Consensus.Crypto.VRF
                        Ouroboros.Consensus.Crypto.VRF.Class
                        Ouroboros.Consensus.Crypto.VRF.Mock
@@ -123,6 +124,7 @@ library
                        text         >=1.2 && <1.3,
                        transformers >=0.5 && <0.6,
                        unliftio     >=0.2.6.0 && <0.3,
+                       vector       >=0.12 && <0.13,
                        void         >=0.7 && <0.8,
 
                        QuickCheck   >=2.12 && <2.13
@@ -201,7 +203,12 @@ test-suite test-consensus
   default-language: Haskell2010
   main-is:          Main.hs
   other-modules:
-                    Test.Dynamic
+                    Test.Crypto.DSIGN
+                    Test.Crypto.Hash
+                    Test.Crypto.KES
+                    Test.Crypto.VRF
+                    Test.DynamicBFT
+                    Test.DynamicPraos
                     Test.Ouroboros
   build-depends:    base,
                     ouroboros-network,

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -218,6 +218,7 @@ test-suite test-consensus
                     cryptonite,
                     mtl,
                     tasty,
+                    tasty-expected-failure,
                     tasty-quickcheck
   ghc-options:      -Wall
                     -fno-ignore-asserts

--- a/pkg.nix
+++ b/pkg.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, array, base, base16-bytestring, bytestring, cborg
 , clock, containers, cryptonite, fingertree, free, hashable, memory, mtl
-, process, psqueues, QuickCheck, random , semigroups , stdenv, stm, serialise
-, string-conv, tasty, tasty-quickcheck , text , transformers, unliftio, void
-, nixpkgs
+, process, psqueues, QuickCheck, random, semigroups, stdenv, stm, serialise
+, string-conv, tasty, tasty-expected-failure, tasty-quickcheck, text
+, transformers, unliftio, void, nixpkgs
 }:
 mkDerivation {
   pname = "ouroboros-network";
@@ -18,7 +18,7 @@ mkDerivation {
   testHaskellDepends = [
     array base bytestring cborg clock containers
     fingertree free hashable mtl process QuickCheck random semigroups stm tasty
-    tasty-quickcheck text transformers void
+    tasty-expected-failure tasty-quickcheck text transformers void
   ];
   description = "A networking layer for the Ouroboros blockchain protocol";
   license = stdenv.lib.licenses.mit;

--- a/src/Ouroboros/Consensus/Crypto/DSIGN/Class.hs
+++ b/src/Ouroboros/Consensus/Crypto/DSIGN/Class.hs
@@ -7,16 +7,20 @@
 -- | Abstract digital signatures.
 module Ouroboros.Consensus.Crypto.DSIGN.Class
     ( DSIGNAlgorithm (..)
-      -- TODO: Added on top of Lars' stuff
-    , Signed
-    , signed
-    , verifySigned
+    , SignedDSIGN
+    , signedDSIGN
+    , verifySignedDSIGN
+    , prop_dsign_verify_pos
+    , prop_dsign_verify_neg_key
+    , prop_dsign_verify_neg_msg
     ) where
 
 import           Crypto.Random (MonadRandom)
 import           GHC.Generics (Generic)
 import           Ouroboros.Consensus.Util
+import           Test.QuickCheck (Arbitrary (..), Gen, Property, (==>))
 
+import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Network.Serialise
 
 class ( Show (VerKeyDSIGN v)
@@ -41,23 +45,77 @@ class ( Show (VerKeyDSIGN v)
     signDSIGN :: (MonadRandom m, Serialise a) => a -> SignKeyDSIGN v -> m (SigDSIGN v)
     verifyDSIGN :: Serialise a => VerKeyDSIGN v -> a -> SigDSIGN v -> Bool
 
-newtype Signed v a = Signed (SigDSIGN v)
+newtype SignedDSIGN v a = SignedDSIGN (SigDSIGN v)
   deriving (Generic)
 
-deriving instance DSIGNAlgorithm v => Show (Signed v a)
-deriving instance DSIGNAlgorithm v => Eq   (Signed v a)
-deriving instance DSIGNAlgorithm v => Ord  (Signed v a)
+deriving instance DSIGNAlgorithm v => Show (SignedDSIGN v a)
+deriving instance DSIGNAlgorithm v => Eq   (SignedDSIGN v a)
+deriving instance DSIGNAlgorithm v => Ord  (SignedDSIGN v a)
 
-instance Condense (SigDSIGN v) => Condense (Signed v a) where
-    condense (Signed sig) = condense sig
+instance Condense (SigDSIGN v) => Condense (SignedDSIGN v a) where
+    condense (SignedDSIGN sig) = condense sig
 
-instance DSIGNAlgorithm v => Serialise (Signed v a) where
+instance DSIGNAlgorithm v => Serialise (SignedDSIGN v a) where
   -- use Generic instance
+  --
+signedDSIGN :: (DSIGNAlgorithm v, MonadRandom m, Serialise a)
+            => a -> SignKeyDSIGN v -> m (SignedDSIGN v a)
+signedDSIGN a key = SignedDSIGN <$> signDSIGN a key
 
-signed :: (DSIGNAlgorithm v, MonadRandom m, Serialise a)
-       => a -> SignKeyDSIGN v -> m (Signed v a)
-signed a key = Signed <$> signDSIGN a key
+verifySignedDSIGN :: (DSIGNAlgorithm v, Serialise a)
+                  => VerKeyDSIGN v -> a -> SignedDSIGN v a -> Bool
+verifySignedDSIGN key a (SignedDSIGN s) = verifyDSIGN key a s
 
-verifySigned :: (DSIGNAlgorithm v, Serialise a)
-             => VerKeyDSIGN v -> a -> Signed v a -> Bool
-verifySigned key a (Signed s) = verifyDSIGN key a s
+instance DSIGNAlgorithm v => Arbitrary (SignKeyDSIGN v) where
+
+    arbitrary = do
+        seed <- arbitrary
+        return $ withSeed seed genKeyDSIGN
+
+    shrink = const []
+
+instance DSIGNAlgorithm v => Arbitrary (VerKeyDSIGN v) where
+    arbitrary = deriveVerKeyDSIGN <$> arbitrary
+    shrink = const []
+
+instance DSIGNAlgorithm v => Arbitrary (SigDSIGN v) where
+
+    arbitrary = do
+        a    <- arbitrary :: Gen Int
+        sk   <- arbitrary
+        seed <- arbitrary
+        return $ withSeed seed $ signDSIGN a sk
+
+    shrink = const []
+
+prop_dsign_verify_pos :: forall a v. (Serialise a, DSIGNAlgorithm v)
+                      => Seed
+                      -> a
+                      -> SignKeyDSIGN v
+                      -> Bool
+prop_dsign_verify_pos seed a sk =
+    let sig = withSeed seed $ signDSIGN a sk
+        vk  = deriveVerKeyDSIGN sk
+    in  verifyDSIGN vk a sig
+
+prop_dsign_verify_neg_key :: forall a v. (Serialise a, DSIGNAlgorithm v)
+                          => Seed
+                          -> a
+                          -> SignKeyDSIGN v
+                          -> SignKeyDSIGN v
+                          -> Property
+prop_dsign_verify_neg_key seed a sk sk' = sk /= sk' ==>
+    let sig = withSeed seed $ signDSIGN a sk'
+        vk  = deriveVerKeyDSIGN sk
+    in  not $ verifyDSIGN vk a sig
+
+prop_dsign_verify_neg_msg :: forall a v. (Serialise a, Eq a, DSIGNAlgorithm v)
+                          => Seed
+                          -> a
+                          -> a
+                          -> SignKeyDSIGN v
+                          -> Property
+prop_dsign_verify_neg_msg seed a a' sk = a /= a' ==>
+    let sig = withSeed seed $ signDSIGN a sk
+        vk  = deriveVerKeyDSIGN sk
+    in  not $ verifyDSIGN vk a' sig

--- a/src/Ouroboros/Consensus/Crypto/Hash/Class.hs
+++ b/src/Ouroboros/Consensus/Crypto/Hash/Class.hs
@@ -72,11 +72,10 @@ fromHash = foldl' f 0 . SB.unpack . getHash
     f n b = n * 256 + fromIntegral b
 
 prop_hash_correct_byteCount :: forall h a. (HashAlgorithm h, Serialise a)
-                            => Proxy h
-                            -> a
+                            => Hash h a
                             -> Property
-prop_hash_correct_byteCount h a =
-    (SB.length $ getHash $ hash @h a) === (fromIntegral $ byteCount h)
+prop_hash_correct_byteCount h =
+    (SB.length $ getHash h) === (fromIntegral $ byteCount (Proxy :: Proxy h))
 
 prop_hash_show_fromString :: Hash h a -> Property
 prop_hash_show_fromString h = h === fromString (show h)

--- a/src/Ouroboros/Consensus/Crypto/KES.hs
+++ b/src/Ouroboros/Consensus/Crypto/KES.hs
@@ -1,8 +1,10 @@
 -- | Key evolving signatures.
 module Ouroboros.Consensus.Crypto.KES
-    ( module Class
---    , module Mock
+    ( module Ouroboros.Consensus.Crypto.KES.Class
+    , module Ouroboros.Consensus.Crypto.KES.Mock
+    , module Ouroboros.Consensus.Crypto.KES.Simple
     ) where
 
-import           Ouroboros.Consensus.Crypto.KES.Class as Class
---import           Ouroboros.Consensus.Crypto.KES.Mock as Mock
+import           Ouroboros.Consensus.Crypto.KES.Class
+import           Ouroboros.Consensus.Crypto.KES.Mock
+import           Ouroboros.Consensus.Crypto.KES.Simple

--- a/src/Ouroboros/Consensus/Crypto/KES/Class.hs
+++ b/src/Ouroboros/Consensus/Crypto/KES/Class.hs
@@ -1,15 +1,25 @@
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TypeFamilies        #-}
 
 -- | Abstract key evolving signatures.
 module Ouroboros.Consensus.Crypto.KES.Class
     ( KESAlgorithm (..)
+    , SignedKES
+    , signedKES
+    , Duration_Seed_SK (..)
+    , Duration_Seed_SK_Times (..)
     ) where
 
-import           Crypto.Random (MonadRandom)
+import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
+import           Test.QuickCheck (Arbitrary (..), Gen)
 
+import           Ouroboros.Consensus.Util (Condense (..))
+import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Network.Serialise
 
 class ( Show (VerKeyKES v)
@@ -19,6 +29,7 @@ class ( Show (VerKeyKES v)
       , Ord (SignKeyKES v)
       , Serialise (SignKeyKES v)
       , Show (SigKES v)
+      , Condense (SigKES v)
       , Ord (SigKES v)
       , Serialise (SigKES v)
       )
@@ -36,3 +47,91 @@ class ( Show (VerKeyKES v)
             -> SignKeyKES v
             -> m (Maybe (SigKES v, SignKeyKES v))
     verifyKES :: Serialise a => VerKeyKES v -> Natural -> a -> SigKES v -> Bool
+
+newtype SignedKES v a = SignedKES (SigKES v)
+  deriving (Generic)
+
+deriving instance KESAlgorithm v => Show (SignedKES v a)
+deriving instance KESAlgorithm v => Eq   (SignedKES v a)
+deriving instance KESAlgorithm v => Ord  (SignedKES v a)
+
+instance Condense (SigKES v) => Condense (SignedKES v a) where
+    condense (SignedKES sig) = condense sig
+
+instance KESAlgorithm v => Serialise (SignedKES v a) where
+  -- use Generic instance
+
+signedKES :: (KESAlgorithm v, MonadRandom m, Serialise a)
+          => Natural -> a -> SignKeyKES v -> m (Maybe (SignedKES v a, SignKeyKES v))
+signedKES time a key = do
+    m <- signKES time a key
+    return $ case m of
+        Nothing          -> Nothing
+        Just (sig, key') -> Just (SignedKES sig, key')
+
+--
+-- Testing
+--
+
+data Duration_Seed_SK v = Duration_Seed_SK Natural Seed (SignKeyKES v)
+    deriving Generic
+
+deriving instance KESAlgorithm v => Show (Duration_Seed_SK v)
+deriving instance KESAlgorithm v => Eq (Duration_Seed_SK v)
+deriving instance KESAlgorithm v => Serialise (Duration_Seed_SK v)
+
+instance KESAlgorithm v => Arbitrary (Duration_Seed_SK v) where
+
+    arbitrary = do
+        duration <- genNat
+        seed <- arbitrary
+        return $ duration_Seed_SK duration seed
+
+    shrink (Duration_Seed_SK duration seed _) =
+        [duration_Seed_SK d seed | d <- shrinkNat duration]
+
+instance KESAlgorithm v => Arbitrary (VerKeyKES v) where
+
+    arbitrary = do
+        Duration_Seed_SK _ _ sk <- arbitrary
+        return $ deriveVerKeyKES sk
+
+    shrink = const []
+
+data Duration_Seed_SK_Times v a =
+    Duration_Seed_SK_Times Natural Seed (SignKeyKES v) [(Natural, a)]
+    deriving Generic
+
+instance (KESAlgorithm v, Arbitrary a) => Arbitrary (Duration_Seed_SK_Times v a) where
+
+    arbitrary = arbitrary >>= gen_Duration_Seed_SK_Times
+
+    shrink (Duration_Seed_SK_Times d s sk ts) = do
+        Duration_Seed_SK d' s' sk' <- shrink $ Duration_Seed_SK d s sk
+        let ts' = filter ((< d') . fst) ts
+        return $ Duration_Seed_SK_Times d' s' sk' ts'
+
+deriving instance (KESAlgorithm v, Show a) => Show (Duration_Seed_SK_Times v a)
+deriving instance (KESAlgorithm v, Eq a) => Eq (Duration_Seed_SK_Times v a)
+deriving instance (KESAlgorithm v, Serialise a) => Serialise (Duration_Seed_SK_Times v a)
+
+duration_Seed_SK :: KESAlgorithm v => Natural -> Seed -> Duration_Seed_SK v
+duration_Seed_SK duration seed =
+    let sk = withSeed seed $ genKeyKES duration
+    in  Duration_Seed_SK duration seed sk
+
+gen_Duration_Seed_SK_Times :: Arbitrary a
+                           => Duration_Seed_SK v
+                           -> Gen (Duration_Seed_SK_Times v a)
+gen_Duration_Seed_SK_Times (Duration_Seed_SK duration seed sk) = do
+    ts <- genTimes 0
+    return $ Duration_Seed_SK_Times duration seed sk ts
+  where
+    genTimes :: Arbitrary a => Natural -> Gen [(Natural, a)]
+    genTimes j
+        | j >= duration = return []
+        | otherwise = do
+            k  <- genNatBetween j (duration - 1)
+            a  <- arbitrary
+            ns <- genTimes $ k + 1
+            return ((k, a) : ns)

--- a/src/Ouroboros/Consensus/Crypto/KES/Mock.hs
+++ b/src/Ouroboros/Consensus/Crypto/KES/Mock.hs
@@ -1,4 +1,66 @@
--- | Mock digital signatures.
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+-- | Mock key evolving signatures.
 module Ouroboros.Consensus.Crypto.KES.Mock
-    (
+    ( MockKES
+    , VerKeyKES(..)
+    , SignKeyKES(..)
     ) where
+
+import           GHC.Generics (Generic)
+import           Numeric.Natural (Natural)
+
+import           Ouroboros.Consensus.Crypto.Hash
+import           Ouroboros.Consensus.Crypto.KES.Class
+import           Ouroboros.Consensus.Util (Condense (..))
+import           Ouroboros.Consensus.Util.Random
+import           Ouroboros.Network.Serialise (Serialise)
+
+data MockKES
+
+type H = MD5
+
+instance KESAlgorithm MockKES where
+
+    newtype VerKeyKES MockKES = VerKeyMockKES Int
+        deriving (Show, Eq, Ord, Generic, Serialise)
+
+    newtype SignKeyKES MockKES = SignKeyMockKES (VerKeyKES MockKES, Natural, Natural)
+        deriving (Show, Eq, Ord, Generic, Serialise)
+
+    data SigKES MockKES = SigMockKES Natural (SignKeyKES MockKES)
+        deriving (Show, Eq, Ord, Generic)
+
+    genKeyKES duration = do
+        vk <- VerKeyMockKES <$> nonNegIntR
+        return $ SignKeyMockKES (vk, 0, duration)
+
+    deriveVerKeyKES (SignKeyMockKES (vk, _, _)) = vk
+
+    signKES j a (SignKeyMockKES (vk, k, t))
+        | j >= k && j < t = return $ Just
+            ( SigMockKES (fromHash $ hash @H a) (SignKeyMockKES (vk, j, t))
+            , SignKeyMockKES (vk, j + 1, t)
+            )
+        | otherwise       = return Nothing
+
+    verifyKES vk j a (SigMockKES h (SignKeyMockKES (vk', j', _))) =
+        j == j' &&
+        vk == vk' &&
+        fromHash (hash @H a) == h
+
+instance Serialise (SigKES MockKES) where
+
+instance Condense (SigKES MockKES) where
+    condense (SigMockKES n (SignKeyMockKES (VerKeyMockKES v, j, d))) =
+           show n
+        <> ":"
+        <> show v
+        <> ":"
+        <> show j
+        <> ":"
+        <> show d

--- a/src/Ouroboros/Consensus/Crypto/KES/Simple.hs
+++ b/src/Ouroboros/Consensus/Crypto/KES/Simple.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+-- | Mock key evolving signatures.
+module Ouroboros.Consensus.Crypto.KES.Simple
+    ( SimpleKES
+    ) where
+
+import           Control.Monad (replicateM)
+import           Data.Vector (Vector, fromList, (!?))
+import           GHC.Generics (Generic)
+import           Numeric.Natural (Natural)
+
+import           Ouroboros.Consensus.Crypto.DSIGN
+import           Ouroboros.Consensus.Crypto.KES.Class
+import           Ouroboros.Consensus.Util (Condense (..))
+import           Ouroboros.Network.Serialise (Serialise)
+
+data SimpleKES d
+
+instance DSIGNAlgorithm d => KESAlgorithm (SimpleKES d) where
+
+    newtype VerKeyKES (SimpleKES d) = VerKeySimpleKES (Vector (VerKeyDSIGN d))
+        deriving Generic
+
+    newtype SignKeyKES (SimpleKES d) =
+        SignKeySimpleKES ([VerKeyDSIGN d], [(Natural, SignKeyDSIGN d)])
+        deriving Generic
+
+    newtype SigKES (SimpleKES d) = SigSimpleKES (SigDSIGN d)
+        deriving Generic
+
+    genKeyKES duration = do
+        sks <- replicateM (fromIntegral duration) genKeyDSIGN
+        let vks = map deriveVerKeyDSIGN sks
+        return $ SignKeySimpleKES (vks, zip [0..] sks)
+
+    deriveVerKeyKES (SignKeySimpleKES (vks, _)) = VerKeySimpleKES $ fromList vks
+
+    signKES j a (SignKeySimpleKES (vks, xs)) = case dropWhile (\(k, _) -> k < j) xs of
+        []           -> return Nothing
+        (_, sk) : ys -> do
+            sig <- signDSIGN a sk
+            return $ Just (SigSimpleKES sig, SignKeySimpleKES (vks, ys))
+
+    verifyKES (VerKeySimpleKES vks) j a (SigSimpleKES sig) =
+        case vks !? fromIntegral j of
+            Nothing -> False
+            Just vk -> verifyDSIGN vk a sig
+
+deriving instance DSIGNAlgorithm d => Show (VerKeyKES (SimpleKES d))
+deriving instance DSIGNAlgorithm d => Eq (VerKeyKES (SimpleKES d))
+deriving instance DSIGNAlgorithm d => Ord (VerKeyKES (SimpleKES d))
+deriving instance DSIGNAlgorithm d => Serialise (VerKeyKES (SimpleKES d))
+
+deriving instance DSIGNAlgorithm d => Show (SignKeyKES (SimpleKES d))
+deriving instance DSIGNAlgorithm d => Eq (SignKeyKES (SimpleKES d))
+deriving instance DSIGNAlgorithm d => Ord (SignKeyKES (SimpleKES d))
+deriving instance DSIGNAlgorithm d => Serialise (SignKeyKES (SimpleKES d))
+
+deriving instance DSIGNAlgorithm d => Show (SigKES (SimpleKES d))
+deriving instance DSIGNAlgorithm d => Eq (SigKES (SimpleKES d))
+deriving instance DSIGNAlgorithm d => Ord (SigKES (SimpleKES d))
+deriving instance DSIGNAlgorithm d => Serialise (SigKES (SimpleKES d))
+
+instance Condense (SigDSIGN d) => Condense (SigKES (SimpleKES d)) where
+    condense (SigSimpleKES sig) = condense sig

--- a/src/Ouroboros/Consensus/Crypto/VRF/Class.hs
+++ b/src/Ouroboros/Consensus/Crypto/VRF/Class.hs
@@ -10,12 +10,19 @@ module Ouroboros.Consensus.Crypto.VRF.Class
     -- TODO: Added to Lars' stuff, might need to modify
   , CertifiedVRF(..)
   , evalCertified
+  , prop_vrf_max
+  , prop_vrf_verify_pos
+  , prop_vrf_verify_neg
   ) where
 
 import           Crypto.Random (MonadRandom)
+import           Data.Proxy (Proxy (..))
 import           GHC.Generics (Generic)
 import           Numeric.Natural
+import           Test.QuickCheck (Arbitrary (..), Gen, Property, counterexample,
+                                  (==>))
 
+import           Ouroboros.Consensus.Util.Random (Seed, withSeed)
 import           Ouroboros.Network.Serialise
 
 class ( Show (VerKeyVRF v)
@@ -44,10 +51,11 @@ data CertifiedVRF v a = CertifiedVRF {
       certifiedNatural :: Natural
     , certifiedProof   :: CertVRF v
     }
-  deriving (Generic)
+  deriving Generic
 
 deriving instance VRFAlgorithm v => Show (CertifiedVRF v a)
-deriving instance VRFAlgorithm v => Eq   (CertifiedVRF v a)
+deriving instance VRFAlgorithm v => Eq (CertifiedVRF v a)
+deriving instance VRFAlgorithm v => Ord (CertifiedVRF v a)
 
 instance VRFAlgorithm v => Serialise (CertifiedVRF v a) where
   -- use generic instance for now
@@ -55,3 +63,56 @@ instance VRFAlgorithm v => Serialise (CertifiedVRF v a) where
 evalCertified :: (VRFAlgorithm v, MonadRandom m, Serialise a)
               => a -> SignKeyVRF v -> m (CertifiedVRF v a)
 evalCertified a key = uncurry CertifiedVRF <$> evalVRF a key
+
+instance VRFAlgorithm v => Arbitrary (SignKeyVRF v) where
+
+    arbitrary = do
+        seed <- arbitrary
+        return $ withSeed seed genKeyVRF
+
+    shrink = const []
+
+instance VRFAlgorithm v => Arbitrary (VerKeyVRF v) where
+    arbitrary = deriveVerKeyVRF <$> arbitrary
+    shrink = const []
+
+instance VRFAlgorithm v => Arbitrary (CertVRF v) where
+
+    arbitrary = do
+        a    <- arbitrary :: Gen Int
+        sk   <- arbitrary
+        seed <- arbitrary
+        return $ withSeed seed $ fmap snd $ evalVRF a sk
+
+    shrink = const []
+
+prop_vrf_max :: forall a v. (Serialise a, VRFAlgorithm v)
+             => Seed
+             -> a
+             -> SignKeyVRF v
+             -> Property
+prop_vrf_max seed a sk =
+    let (y, _) = withSeed seed $ evalVRF a sk
+        m      = maxVRF (Proxy :: Proxy v)
+    in  counterexample ("expected " ++ show y ++ " <= " ++ show m) $ y <= m
+
+prop_vrf_verify_pos :: forall a v. (Serialise a, VRFAlgorithm v)
+                    => Seed
+                    -> a
+                    -> SignKeyVRF v
+                    -> Bool
+prop_vrf_verify_pos seed a sk =
+    let (y, c) = withSeed seed $ evalVRF a sk
+        vk     = deriveVerKeyVRF sk
+    in  verifyVRF vk a (y, c)
+
+prop_vrf_verify_neg :: forall a v. (Serialise a, VRFAlgorithm v)
+                    => Seed
+                    -> a
+                    -> SignKeyVRF v
+                    -> SignKeyVRF v
+                    -> Property
+prop_vrf_verify_neg seed a sk sk' = sk /= sk' ==>
+    let (y, c) = withSeed seed $ evalVRF a sk'
+        vk     = deriveVerKeyVRF sk
+    in  not $ verifyVRF vk a (y, c)

--- a/src/Ouroboros/Consensus/Crypto/VRF/Mock.hs
+++ b/src/Ouroboros/Consensus/Crypto/VRF/Mock.hs
@@ -6,6 +6,7 @@
 -- | Mock implementations of verifiable random functions.
 module Ouroboros.Consensus.Crypto.VRF.Mock
   ( MockVRF
+  , SignKeyVRF(..)
   ) where
 
 import           Data.Proxy (Proxy (..))

--- a/src/Ouroboros/Consensus/Ledger/Mock.hs
+++ b/src/Ouroboros/Consensus/Ledger/Mock.hs
@@ -179,7 +179,7 @@ data SimplePreHeader p c = SimplePreHeader {
     , headerBlockNo  :: BlockNo
     , headerBodyHash :: Hash (SimpleBlockHash c) SimpleBody
     }
-  deriving (Generic, Show, Eq)
+  deriving (Generic, Show, Eq, Ord)
 
 instance SimpleBlockCrypto c => Condense (SimplePreHeader p c) where
     condense = show

--- a/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -53,7 +53,7 @@ data Bft c
 instance BftCrypto c => OuroborosTag (Bft c) where
   -- | The BFT payload is just the signature
   newtype Payload (Bft c) ph = BftPayload {
-        bftSignature :: Signed (BftDSIGN c) ph
+        bftSignature :: SignedDSIGN (BftDSIGN c) ph
       }
     deriving (Generic)
 
@@ -73,7 +73,7 @@ instance BftCrypto c => OuroborosTag (Bft c) where
   type ChainState     (Bft c) = ()
 
   mkPayload BftNodeConfig{..} _proof preheader = do
-      signature <- signed preheader bftSignKey
+      signature <- signedDSIGN preheader bftSignKey
       return $ BftPayload {
           bftSignature = signature
         }
@@ -87,7 +87,7 @@ instance BftCrypto c => OuroborosTag (Bft c) where
 
   applyChainState BftNodeConfig{..} _l b _cs = do
       -- TODO: Should deal with unknown node IDs
-      if verifySigned (bftVerKeys Map.! expectedLeader)
+      if verifySignedDSIGN (bftVerKeys Map.! expectedLeader)
                       (blockPreHeader b)
                       (bftSignature (blockPayload (Proxy @(Bft c)) b))
         then return ()

--- a/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -1,15 +1,19 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE EmptyDataDeriving    #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE RecordWildCards      #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE EmptyDataDeriving     #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 module Ouroboros.Consensus.Protocol.Praos (
-    Praos
+    StakeDist
+  , Praos
     -- * Tags
   , PraosCrypto(..)
   , PraosStandardCrypto
@@ -19,21 +23,75 @@ module Ouroboros.Consensus.Protocol.Praos (
   , Payload(..)
   ) where
 
+import           Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IntMap
+import           Data.Proxy (Proxy (..))
 import           GHC.Generics (Generic)
 import           Numeric.Natural
 
-import           Ouroboros.Consensus.Crypto.DSIGN.Class
 import           Ouroboros.Consensus.Crypto.DSIGN.Ed448 (Ed448DSIGN)
-import           Ouroboros.Consensus.Crypto.DSIGN.Mock (MockDSIGN)
+import           Ouroboros.Consensus.Crypto.Hash.Class (HashAlgorithm (..),
+                                                        fromHash, hash)
+import           Ouroboros.Consensus.Crypto.Hash.MD5 (MD5)
+import           Ouroboros.Consensus.Crypto.Hash.SHA256 (SHA256)
+import           Ouroboros.Consensus.Crypto.KES.Class
+import           Ouroboros.Consensus.Crypto.KES.Mock
+import           Ouroboros.Consensus.Crypto.KES.Simple
 import           Ouroboros.Consensus.Crypto.VRF.Class
 import           Ouroboros.Consensus.Crypto.VRF.Mock (MockVRF)
 import           Ouroboros.Consensus.Crypto.VRF.Simple (SimpleVRF)
 import           Ouroboros.Consensus.Node (NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.Test
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.HList (HList)
-import           Ouroboros.Network.Block (Slot)
+import           Ouroboros.Consensus.Util.HList (HList (..))
+import           Ouroboros.Network.Block (HasHeader (..), Slot (..))
 import           Ouroboros.Network.Serialise (Serialise)
+
+{-------------------------------------------------------------------------------
+  Praos specific types
+-------------------------------------------------------------------------------}
+
+data VRFType = NONCE | TEST
+    deriving (Show, Eq, Ord, Generic)
+
+instance Serialise VRFType
+  -- use generic instance
+
+data PraosExtraFields c = PraosExtraFields {
+      praosCreator :: Int
+    , praosRho     :: CertifiedVRF (PraosVRF c) (HList [Natural, Slot, VRFType])
+    , praosY       :: CertifiedVRF (PraosVRF c) (HList [Natural, Slot, VRFType])
+    }
+  deriving Generic
+
+deriving instance PraosCrypto c => Show (PraosExtraFields c)
+deriving instance PraosCrypto c => Eq (PraosExtraFields c)
+
+instance VRFAlgorithm (PraosVRF c) => Serialise (PraosExtraFields c)
+  -- use Generic instance for now
+
+data PraosProof c = PraosProof {
+      praosProofRho  :: CertifiedVRF (PraosVRF c) (HList [Natural, Slot, VRFType])
+    , praosProofY    :: CertifiedVRF (PraosVRF c) (HList [Natural, Slot, VRFType])
+    , praosLeaderId  :: Int
+    , praosProofSlot :: Slot
+    }
+
+data PraosValidationError
+  deriving (Show)
+
+type Epoch = Word
+type StakeDist = IntMap Rational
+
+data BlockInfo c = BlockInfo
+    { biSlot  :: Slot
+    , biRho   :: CertifiedVRF (PraosVRF c) (HList [Natural, Slot, VRFType])
+    , biStake :: StakeDist
+    }
+
+deriving instance PraosCrypto c => Show (BlockInfo c)
 
 {-------------------------------------------------------------------------------
   Protocol proper
@@ -42,53 +100,76 @@ import           Ouroboros.Network.Serialise (Serialise)
 data Praos c
 
 instance PraosCrypto c => OuroborosTag (Praos c) where
+
   data Payload (Praos c) ph = PraosPayload {
-        praosSignature   :: Signed (PraosDSIGN c) (ph, PraosExtraFields c)
+        praosSignature   :: SignedKES (PraosKES c) (ph, PraosExtraFields c)
       , praosExtraFields :: PraosExtraFields c
       }
     deriving (Generic)
 
   data NodeConfig (Praos c) = PraosNodeConfig
-      -- just a placeholder for now
+    { praosNodeId        :: NodeId
+    , praosSignKeyVRF    :: SignKeyVRF (PraosVRF c)
+    , praosSlotsPerEpoch :: Word
+    , praosInitialEta    :: Natural
+    , praosInitialStake  :: StakeDist
+    , praosLeaderF       :: Double
+    }
 
-  type NodeState      (Praos c) = PraosNodeState c
-  type LedgerView     (Praos c) = PraosLedgerView c
+  type NodeState      (Praos c) = SignKeyKES (PraosKES c)
+  type LedgerView     (Praos c) = StakeDist
   type IsLeader       (Praos c) = PraosProof c
   type ValidationErr  (Praos c) = PraosValidationError
   type SupportedBlock (Praos c) = HasPayload (Praos c)
-  type ChainState     (Praos c) = ()
+  type ChainState     (Praos c) = [BlockInfo c]
 
-  mkPayload PraosNodeConfig PraosProof{..} preheader = do
-      PraosNodeState{..} <- getNodeState
+  mkPayload PraosNodeConfig{..} PraosProof{..} preheader = do
+      keyKES <- getNodeState
       let extraFields = PraosExtraFields {
-            praosCreator = praosNodeId
+            praosCreator = praosLeaderId
           , praosRho     = praosProofRho
           , praosY       = praosProofY
           }
-      signature <- signed (preheader, extraFields) praosSignKeyDSIGN
-      return $ PraosPayload {
-          praosSignature   = signature
-        , praosExtraFields = extraFields
-        }
+      m <- signedKES
+        (fromIntegral praosProofSlot)
+        (preheader, extraFields)
+        keyKES
+      case m of
+        Nothing               -> error "mkOutoborosPayload: signedKES failed"
+        Just (signed, newKey) -> do
+          putNodeState newKey
+          return $ PraosPayload {
+              praosSignature   = signed
+            , praosExtraFields = extraFields
+            }
 
-  checkIsLeader PraosNodeConfig slot PraosLedgerView{..} _cs = do
-      PraosNodeState{..} <- getNodeState
-      let (rho', y', t) = praosRhoYT slot (CoreId praosNodeId)
-      rho <- evalCertified rho' praosSignKeyVRF
-      y   <- evalCertified y'   praosSignKeyVRF
-      return $ if fromIntegral (certifiedNatural y) < t
-          then Just PraosProof {
-                   praosProofRho = rho
-                 , praosProofY   = y
-                 , praosLeaderId = praosNodeId
-                 }
-          else Nothing
+  checkIsLeader cfg@PraosNodeConfig{..} slot _u cs =
+    case praosNodeId of
+        RelayId _  -> return Nothing
+        CoreId nid -> do
+          let (rho', y', t) = rhoYT cfg cs slot nid
+          rho <- evalCertified rho' praosSignKeyVRF
+          y   <- evalCertified y'   praosSignKeyVRF
+          return $ if fromIntegral (certifiedNatural y) < t
+              then Just PraosProof {
+                       praosProofRho  = rho
+                     , praosProofY    = y
+                     , praosLeaderId  = nid
+                     , praosProofSlot = slot
+                     }
+              else Nothing
 
-  applyChainState PraosNodeConfig PraosLedgerView{..} _b _cs =
-    return () -- TODO (Lars)
+  applyChainState PraosNodeConfig{..} sd b cs = do
+    let PraosPayload{..} = blockPayload (Proxy :: Proxy (Praos c)) b
+        bi = BlockInfo
+            { biSlot  = blockSlot b
+            , biRho   = praosRho praosExtraFields
+            , biStake = sd
+            }
+    return $ bi : cs
 
-deriving instance (PraosCrypto c, Show ph) => Show (Payload (Praos c) ph)
-deriving instance (PraosCrypto c, Eq   ph) => Eq   (Payload (Praos c) ph)
+deriving instance PraosCrypto c => Show (Payload (Praos c) ph)
+deriving instance PraosCrypto c => Eq   (Payload (Praos c) ph)
 
 instance PraosCrypto c => Condense (Payload (Praos c) ph) where
     condense (PraosPayload sig _) = condense sig
@@ -96,71 +177,94 @@ instance PraosCrypto c => Condense (Payload (Praos c) ph) where
 instance (PraosCrypto c, Serialise ph) => Serialise (Payload (Praos c) ph) where
   -- use generic instance
 
-{-------------------------------------------------------------------------------
-  Praos specific types
--------------------------------------------------------------------------------}
+slotEpoch :: NodeConfig (Praos c) -> Slot -> Epoch
+slotEpoch PraosNodeConfig{..} s =
+    fromIntegral $ 1 + div (getSlot s - 1) praosSlotsPerEpoch
 
-data PraosExtraFields c = PraosExtraFields {
-      praosCreator :: Int
-    , praosRho     :: CertifiedVRF (PraosVRF c) (HList [Natural, Slot, VRFType])
-    , praosY       :: CertifiedVRF (PraosVRF c) (HList [Natural, Slot, VRFType])
-    }
-  deriving (Generic)
+blockInfoEpoch :: NodeConfig (Praos c) -> BlockInfo c -> Epoch
+blockInfoEpoch l = slotEpoch l . biSlot
 
-deriving instance PraosCrypto c => Show (PraosExtraFields c)
-deriving instance PraosCrypto c => Eq   (PraosExtraFields c)
+epochStart :: NodeConfig (Praos c) -> Epoch -> Slot
+epochStart PraosNodeConfig{..} e = Slot $ (e - 1) * praosSlotsPerEpoch + 1
 
-instance VRFAlgorithm (PraosVRF c) => Serialise (PraosExtraFields c)
-  -- use Generic instance for now
+infosSlice :: Slot -> Slot -> [BlockInfo c] -> [BlockInfo c]
+infosSlice from to xs = takeWhile (\b -> biSlot b >= from)
+                      $ dropWhile (\b -> biSlot b > to) xs
 
-data PraosNodeState c = PraosNodeState {
-      praosNodeId       :: Int
-    , praosSignKeyDSIGN :: SignKeyDSIGN (PraosDSIGN c) -- TODO: should be KES
-    , praosSignKeyVRF   :: SignKeyVRF (PraosVRF c)
-    }
+infosEta :: forall c. PraosCrypto c
+         => NodeConfig (Praos c)
+         -> [BlockInfo c]
+         -> Epoch
+         -> Natural
+infosEta l _  1 = praosInitialEta l
+infosEta l xs e =
+    let e'   = e - 1
+        eta' = infosEta l xs e'
+        from = epochStart l e'
+        n    = div (2 * praosSlotsPerEpoch l) 3
+        to   = from + fromIntegral (n - 1)
+        rhos = reverse [biRho b | b <- infosSlice from to xs]
+    in  fromHash $ hash @(PraosHash c) $ eta' :* e :* rhos :* Nil
 
-data PraosProof c = PraosProof {
-      praosProofRho :: CertifiedVRF (PraosVRF c) (HList [Natural, Slot, VRFType])
-    , praosProofY   :: CertifiedVRF (PraosVRF c) (HList [Natural, Slot, VRFType])
-    , praosLeaderId :: Int
-    }
+infosStake :: NodeConfig (Praos c) -> [BlockInfo c] -> Epoch -> StakeDist
+infosStake s@PraosNodeConfig{..} xs e = case ys of
+    []                  -> praosInitialStake
+    (BlockInfo{..} : _) -> biStake
+  where
+    e' = if e >= 2 then e - 2 else 0
+    ys = dropWhile (\b -> blockInfoEpoch s b > e') xs
 
-data PraosLedgerView c = PraosLedgerView {
-    praosRhoYT :: Slot
-               -> NodeId
-               -> ( HList '[Natural, Slot, VRFType]
-                  , HList '[Natural, Slot, VRFType]
-                  , Double
-                  )
-  }
+phi :: NodeConfig (Praos c) -> Rational -> Double
+phi PraosNodeConfig{..} r = 1 - (1 - praosLeaderF) ** fromRational r
 
-data PraosValidationError
-  deriving (Show)
+leaderThreshold :: forall c. PraosCrypto c
+                => NodeConfig (Praos c)
+                -> [BlockInfo c]
+                -> Slot
+                -> Int
+                -> Double
+leaderThreshold st xs s n =
+    let a = IntMap.findWithDefault 0 n $ infosStake st xs (slotEpoch st s)
+    in  2 ^ (byteCount (Proxy :: Proxy (PraosHash c)) * 8) * phi st a
 
-data VRFType = NONCE | TEST
-    deriving (Show, Eq, Ord, Generic)
-
-instance Serialise VRFType
-  -- use generic instance
-
+rhoYT :: PraosCrypto c
+      => NodeConfig (Praos c)
+      -> [BlockInfo c]
+      -> Slot
+      -> Int
+      -> ( HList '[Natural, Slot, VRFType]
+         , HList '[Natural, Slot, VRFType]
+         , Double
+         )
+rhoYT st xs s n =
+    let e   = slotEpoch st s
+        eta = infosEta st xs e
+        rho = eta :* s :* NONCE :* Nil
+        y   = eta :* s :* TEST  :* Nil
+        t   = leaderThreshold st xs s n
+    in  (rho, y, t)
 
 {-------------------------------------------------------------------------------
   Crypto models
 -------------------------------------------------------------------------------}
 
-class ( DSIGNAlgorithm (PraosDSIGN c)
-      , VRFAlgorithm   (PraosVRF   c)
-      ) => PraosCrypto c where
-  type family PraosDSIGN c :: * --  TODO: Should be KES
-  type family PraosVRF   c :: *
+class ( KESAlgorithm  (PraosKES c)
+      , VRFAlgorithm  (PraosVRF c)
+      , HashAlgorithm (PraosHash c)
+      ) => PraosCrypto (c :: *) where
+  type family PraosKES c  :: *
+  type family PraosVRF c  :: *
+  type family PraosHash c :: *
 
 data PraosStandardCrypto
 data PraosMockCrypto
 
 instance PraosCrypto PraosStandardCrypto where
-  type PraosDSIGN PraosStandardCrypto = Ed448DSIGN
-  type PraosVRF   PraosStandardCrypto = SimpleVRF
+  type PraosKES  PraosStandardCrypto = SimpleKES Ed448DSIGN
+  type PraosVRF  PraosStandardCrypto = SimpleVRF
+  type PraosHash PraosStandardCrypto = SHA256
 
 instance PraosCrypto PraosMockCrypto where
-  type PraosDSIGN PraosMockCrypto = MockDSIGN
-  type PraosVRF   PraosMockCrypto = MockVRF
+  type PraosKES  PraosMockCrypto = MockKES
+  type PraosVRF  PraosMockCrypto = MockVRF
+  type PraosHash PraosMockCrypto = MD5

--- a/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -31,7 +31,7 @@ import           Numeric.Natural
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Ed448 (Ed448DSIGN)
 import           Ouroboros.Consensus.Crypto.Hash.Class (HashAlgorithm (..),
-                                                        fromHash, hash)
+                     fromHash, hash)
 import           Ouroboros.Consensus.Crypto.Hash.MD5 (MD5)
 import           Ouroboros.Consensus.Crypto.Hash.SHA256 (SHA256)
 import           Ouroboros.Consensus.Crypto.KES.Class
@@ -131,7 +131,7 @@ instance PraosCrypto c => OuroborosTag (Praos c) where
           , praosY       = praosProofY
           }
       m <- signedKES
-        (fromIntegral praosProofSlot)
+        (fromIntegral (getSlot praosProofSlot))
         (preheader, extraFields)
         keyKES
       case m of
@@ -202,7 +202,7 @@ infosEta l xs e =
         eta' = infosEta l xs e'
         from = epochStart l e'
         n    = div (2 * praosSlotsPerEpoch l) 3
-        to   = from + fromIntegral (n - 1)
+        to   = Slot $ getSlot from + fromIntegral (n - 1)
         rhos = reverse [biRho b | b <- infosSlice from to xs]
     in  fromHash $ hash @(PraosHash c) $ eta' :* e :* rhos :* Nil
 

--- a/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -1,9 +1,16 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Ouroboros.Consensus.Util.Orphans () where
 
-import           Ouroboros.Consensus.Util
+import           Ouroboros.Network.Chain (Chain (..))
 import           Ouroboros.Network.Node (NodeId (..))
+
+import           Ouroboros.Consensus.Util
+
 
 instance Condense NodeId where
   condense (CoreId  i) = "c" ++ show i
   condense (RelayId i) = "r" ++ show i
+
+instance Condense block => Condense (Chain block) where
+    condense Genesis   = "Genesis"
+    condense (cs :> b) = condense cs <> " :> " <> condense b

--- a/src/Ouroboros/Network/Block.hs
+++ b/src/Ouroboros/Network/Block.hs
@@ -25,14 +25,14 @@ import           Ouroboros.Network.Serialise
 
 -- | The Ouroboros time slot index for a block.
 newtype Slot = Slot { getSlot :: Word }
-  deriving (Show, Eq, Ord, Hashable, Enum, Serialise)
+  deriving (Show, Eq, Ord, Hashable, Enum, Serialise, Integral, Real, Num)
 
 -- | The 0-based index of the block in the blockchain
 newtype BlockNo = BlockNo Word
   deriving (Show, Eq, Ord, Hashable, Enum, Serialise)
 
 -- | Abstract over the shape of blocks (or indeed just block headers)
-class StandardHash b => HasHeader b where
+class (Serialise b, StandardHash b) => HasHeader b where
     -- TODO: I /think/ we should be able to make this injective, but I'd have
     -- to check after the redesign of the block abstraction (which will live
     -- in the consensus layer), to make sure injectivity is compatible with that

--- a/src/Ouroboros/Network/Block.hs
+++ b/src/Ouroboros/Network/Block.hs
@@ -25,14 +25,14 @@ import           Ouroboros.Network.Serialise
 
 -- | The Ouroboros time slot index for a block.
 newtype Slot = Slot { getSlot :: Word }
-  deriving (Show, Eq, Ord, Hashable, Enum, Serialise, Integral, Real, Num)
+  deriving (Show, Eq, Ord, Hashable, Enum, Serialise)
 
 -- | The 0-based index of the block in the blockchain
 newtype BlockNo = BlockNo Word
   deriving (Show, Eq, Ord, Hashable, Enum, Serialise)
 
 -- | Abstract over the shape of blocks (or indeed just block headers)
-class (Serialise b, StandardHash b) => HasHeader b where
+class StandardHash b => HasHeader b where
     -- TODO: I /think/ we should be able to make this injective, but I'd have
     -- to check after the redesign of the block abstraction (which will live
     -- in the consensus layer), to make sure injectivity is compatible with that

--- a/src/Ouroboros/Network/Chain.hs
+++ b/src/Ouroboros/Network/Chain.hs
@@ -69,7 +69,6 @@ import           Prelude hiding (drop, head, length, null)
 import           Control.Exception (assert)
 import qualified Data.List as L
 
-import           Ouroboros.Consensus.Util (Condense (..))
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Serialise
 
@@ -81,10 +80,6 @@ data Chain block = Genesis | Chain block :> block
   deriving (Eq, Show, Functor)
 
 infixl 5 :>
-
-instance Condense block => Condense (Chain block) where
-    condense Genesis   = "Genesis"
-    condense (cs :> b) = condense cs <> " :> " <> condense b
 
 foldChain :: (a -> b -> a) -> a -> Chain b -> a
 foldChain _blk gen Genesis  = gen

--- a/src/Ouroboros/Network/Chain.hs
+++ b/src/Ouroboros/Network/Chain.hs
@@ -69,6 +69,7 @@ import           Prelude hiding (drop, head, length, null)
 import           Control.Exception (assert)
 import qualified Data.List as L
 
+import           Ouroboros.Consensus.Util (Condense (..))
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Serialise
 
@@ -80,6 +81,10 @@ data Chain block = Genesis | Chain block :> block
   deriving (Eq, Show, Functor)
 
 infixl 5 :>
+
+instance Condense block => Condense (Chain block) where
+    condense Genesis   = "Genesis"
+    condense (cs :> b) = condense cs <> " :> " <> condense b
 
 foldChain :: (a -> b -> a) -> a -> Chain b -> a
 foldChain _blk gen Genesis  = gen

--- a/src/Ouroboros/Network/Node.hs
+++ b/src/Ouroboros/Network/Node.hs
@@ -18,8 +18,10 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (Chain (..), Point)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState (ChainProducerState (..),
-                     ReaderId, initChainProducerState, producerChain,
-                     switchFork)
+                                                       ReaderId,
+                                                       initChainProducerState,
+                                                       producerChain,
+                                                       switchFork)
 import           Ouroboros.Network.ConsumersAndProducers
 import           Ouroboros.Network.MonadClass
 import           Ouroboros.Network.Protocol

--- a/test-consensus/Main.hs
+++ b/test-consensus/Main.hs
@@ -2,7 +2,12 @@ module Main (main) where
 
 import           Test.Tasty
 
-import qualified Test.Dynamic (tests)
+import qualified Test.Crypto.DSIGN (tests)
+import qualified Test.Crypto.Hash (tests)
+import qualified Test.Crypto.KES (tests)
+import qualified Test.Crypto.VRF (tests)
+import qualified Test.DynamicBFT (tests)
+import qualified Test.DynamicPraos (tests)
 
 main :: IO ()
 main = defaultMain tests
@@ -10,5 +15,10 @@ main = defaultMain tests
 tests :: TestTree
 tests =
   testGroup "ouroboros-consensus"
-  [ Test.Dynamic.tests
+  [ Test.Crypto.DSIGN.tests
+  , Test.Crypto.Hash.tests
+  , Test.Crypto.KES.tests
+  , Test.Crypto.VRF.tests
+  , Test.DynamicBFT.tests
+  , Test.DynamicPraos.tests
   ]

--- a/test-consensus/Test/Crypto/DSIGN.hs
+++ b/test-consensus/Test/Crypto/DSIGN.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Test.Crypto.DSIGN
+    ( tests
+    ) where
+
+import           Data.Proxy (Proxy (..))
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Ouroboros.Consensus.Crypto.DSIGN
+import           Ouroboros.Network.Serialise (prop_serialise)
+
+--
+-- The list of all tests
+--
+tests :: TestTree
+tests =
+  testGroup "Crypto.DSIGN"
+  [ testDSIGNAlgorithm (Proxy :: Proxy MockDSIGN)   "MockDSIGN"
+  , testDSIGNAlgorithm (Proxy :: Proxy Ed448DSIGN)  "Ed448DSIGN"
+  , testDSIGNAlgorithm (Proxy :: Proxy RSAPSSDSIGN) "RSAPSSDSIGN"
+  ]
+
+testDSIGNAlgorithm :: forall proxy v. DSIGNAlgorithm v => proxy v -> String -> TestTree
+testDSIGNAlgorithm _ n =
+    testGroup n
+        [ testProperty "serialise VerKey"                 $ prop_serialise @(VerKeyDSIGN v)
+        , testProperty "serialise SignKey"                $ prop_serialise @(SignKeyDSIGN v)
+        , testProperty "serialise Sig"                    $ prop_serialise @(SigDSIGN v)
+        , testProperty "verify positive"                  $ prop_dsign_verify_pos @Int @v
+        , testProperty "verify newgative (wrong key)"     $ prop_dsign_verify_neg_key @Int @v
+        , testProperty "verify newgative (wrong message)" $ prop_dsign_verify_neg_msg @Int @v
+        ]

--- a/test-consensus/Test/Crypto/Hash.hs
+++ b/test-consensus/Test/Crypto/Hash.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Test.Crypto.Hash
+    ( tests
+    ) where
+
+import           Data.Proxy (Proxy (..))
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Ouroboros.Consensus.Crypto.Hash
+import           Ouroboros.Network.Serialise
+
+--
+-- The list of all tests
+--
+tests :: TestTree
+tests =
+  testGroup "Crypto.Hash"
+  [ testHashAlgorithm (Proxy :: Proxy MD5)    "MD5"
+  , testHashAlgorithm (Proxy :: Proxy SHA256) "SHA256"
+  ]
+
+testHashAlgorithm :: forall proxy h. HashAlgorithm h => proxy h -> String -> TestTree
+testHashAlgorithm _ n =
+    testGroup n
+        [ testProperty "byte count"      $ prop_hash_correct_byteCount @h @String
+        , testProperty "serialise"       $ prop_hash_serialise @h
+        , testProperty "show/fromString" $ prop_hash_show_fromString @h @Double
+        ]
+
+prop_hash_serialise :: HashAlgorithm h => Hash h Int -> Property
+prop_hash_serialise = prop_serialise

--- a/test-consensus/Test/Crypto/KES.hs
+++ b/test-consensus/Test/Crypto/KES.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Test.Crypto.KES
+    ( tests
+    ) where
+
+import           Data.Proxy (Proxy (..))
+import           Numeric.Natural (Natural)
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Ouroboros.Consensus.Crypto.DSIGN
+import           Ouroboros.Consensus.Crypto.KES
+import           Ouroboros.Consensus.Util.Random
+import           Ouroboros.Network.Serialise (Serialise, prop_serialise)
+
+--
+-- The list of all tests
+--
+tests :: TestTree
+tests =
+  testGroup "Crypto.KES"
+  [ testKESAlgorithm (Proxy :: Proxy MockKES)                "MockKES"
+  , testKESAlgorithm (Proxy :: Proxy (SimpleKES Ed448DSIGN)) "SimpleKES (with Ed448)"
+  ]
+
+testKESAlgorithm :: KESAlgorithm v => proxy v -> String -> TestTree
+testKESAlgorithm p n =
+    testGroup n
+        [ testProperty "serialise VerKey"                $ prop_KES_serialise_VerKey p
+        , testProperty "serialise SignKey"               $ prop_KES_serialise_SignKey p
+        , testProperty "serialise Sig"                   $ prop_KES_serialise_Sig p
+        , testProperty "verify positive"                 $ prop_KES_verify_pos p
+        , testProperty "verify negative (wrong key)"     $ prop_KES_veriy_neg_key p
+        , testProperty "verify negative (wrong message)" $ prop_KES_veriy_neg_msg p
+        , testProperty "verify negative (wrong time)"    $ prop_KES_veriy_neg_time p
+        ]
+
+prop_KES_serialise_VerKey :: KESAlgorithm v
+                          => proxy v
+                          -> Duration_Seed_SK v
+                          -> Property
+prop_KES_serialise_VerKey _ (Duration_Seed_SK _ _ sk) =
+    prop_serialise (deriveVerKeyKES sk)
+
+prop_KES_serialise_SignKey :: KESAlgorithm v
+                           => proxy v
+                           -> Duration_Seed_SK v
+                           -> Property
+prop_KES_serialise_SignKey _ (Duration_Seed_SK _ _ sk) =
+    prop_serialise sk
+
+prop_KES_serialise_Sig :: KESAlgorithm v
+                       => proxy v
+                       -> Duration_Seed_SK_Times v String
+                       -> Seed
+                       -> Property
+prop_KES_serialise_Sig _ d seed = case withSeed seed $ trySign d of
+    Left e   -> counterexample e False
+    Right xs -> conjoin [prop_serialise sig |(_, _, sig) <- xs]
+
+prop_KES_verify_pos :: KESAlgorithm v
+                    => proxy v
+                    -> Duration_Seed_SK_Times v String
+                    -> Seed
+                    -> Property
+prop_KES_verify_pos _ d seed =
+    let vk = getVerKey d
+    in  case withSeed seed $ trySign d of
+            Left e   -> counterexample e False
+            Right xs -> conjoin [verifyKES vk j a sig | (j, a, sig) <- xs]
+
+prop_KES_veriy_neg_key :: KESAlgorithm v
+                       => proxy v
+                       -> Duration_Seed_SK_Times v Int
+                       -> VerKeyKES v
+                       -> Seed
+                       -> Property
+prop_KES_veriy_neg_key _ d vk seed = getVerKey d /= vk ==>
+    case withSeed seed $ trySign d of
+        Left e   -> counterexample e False
+        Right xs -> conjoin [not $ verifyKES vk j a sig | (j, a, sig) <- xs]
+
+prop_KES_veriy_neg_msg :: KESAlgorithm v
+                       => proxy v
+                       -> Duration_Seed_SK_Times v Double
+                       -> Double
+                       -> Seed
+                       -> Property
+prop_KES_veriy_neg_msg _ d a seed =
+    let vk = getVerKey d
+    in  case withSeed seed $ trySign d of
+            Left e   -> counterexample e False
+            Right xs -> conjoin [a /= a' ==> not $ verifyKES vk j a sig | (j, a', sig) <- xs]
+
+prop_KES_veriy_neg_time :: KESAlgorithm v
+                        => proxy v
+                        -> Duration_Seed_SK_Times v Double
+                        -> Integer
+                        -> Seed
+                        -> Property
+prop_KES_veriy_neg_time _ d i seed =
+    let vk = getVerKey d
+        t  = fromIntegral $ abs i
+    in  case withSeed seed $ trySign d of
+            Left e   -> counterexample e False
+            Right xs -> conjoin [t /= j ==> not $ verifyKES vk t a sig | (j, a, sig) <- xs]
+
+getVerKey :: KESAlgorithm v => Duration_Seed_SK_Times v a -> VerKeyKES v
+getVerKey d = case d of
+    (Duration_Seed_SK_Times _ _ sk _) -> deriveVerKeyKES sk
+
+trySign :: forall m v a.
+           ( MonadRandom m
+           , KESAlgorithm v
+           , Serialise a
+           , Show a)
+        => Duration_Seed_SK_Times v a
+        -> m (Either String [(Natural, a, SigKES v)])
+trySign (Duration_Seed_SK_Times _ _ sk ts) =
+    go sk ts
+  where
+    go :: SignKeyKES v
+       -> [(Natural, a)]
+       -> m (Either String [(Natural, a, SigKES v)])
+    go _ []              = return $ Right []
+    go sk' ((j, a) : xs) = do
+        m <- signKES j a sk'
+        case m of
+            Nothing          -> return $ Left $
+                                    "trySign: error signing " ++
+                                    show a ++ " at " ++ show j ++ " with " ++ show sk
+            Just (sig, sk'') -> do
+                e <- go sk'' xs
+                return $ case e of
+                    Right ys -> Right ((j, a, sig) : ys)
+                    Left  _  -> e

--- a/test-consensus/Test/Crypto/VRF.hs
+++ b/test-consensus/Test/Crypto/VRF.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Test.Crypto.VRF
+    ( tests
+    ) where
+
+import           Data.Proxy (Proxy (..))
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Ouroboros.Consensus.Crypto.VRF
+import           Ouroboros.Network.Serialise (prop_serialise)
+
+--
+-- The list of all tests
+--
+tests :: TestTree
+tests =
+  testGroup "Crypto.VRF"
+  [ testVRFAlgorithm (Proxy :: Proxy MockVRF)   "MockVRF"
+  , testVRFAlgorithm (Proxy :: Proxy SimpleVRF) "SimpleVRF"
+  ]
+
+testVRFAlgorithm :: forall proxy v. VRFAlgorithm v => proxy v -> String -> TestTree
+testVRFAlgorithm _ n =
+    testGroup n
+        [ testProperty "serialise VerKey"  $ prop_serialise @(VerKeyVRF v)
+        , testProperty "serialise SignKey" $ prop_serialise @(SignKeyVRF v)
+        , testProperty "serialise Cert"    $ prop_serialise @(CertVRF v)
+        , testProperty "max"               $ prop_vrf_max @Int @v
+        , testProperty "verify positive"   $ prop_vrf_verify_pos @Int @v
+        , testProperty "verify negative"   $ prop_vrf_verify_neg @Int @v
+        ]

--- a/test-consensus/Test/DynamicBFT.hs
+++ b/test-consensus/Test/DynamicBFT.hs
@@ -17,8 +17,12 @@
 {-# OPTIONS -fno-warn-unused-binds #-}
 {-# OPTIONS -fno-warn-orphans #-}
 
-module Test.Dynamic (
+module Test.DynamicBFT (
     tests
+  , TestConfig(..)
+  , allEqual
+  , nodeStake
+  , broadcastNetwork
   ) where
 
 import           Control.Monad
@@ -52,6 +56,7 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
 import           Ouroboros.Consensus.Protocol.Test
+import           Ouroboros.Consensus.Util (Condense (..))
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.STM
 
@@ -361,7 +366,8 @@ collectJust var = do
       Nothing -> retry
       Just a  -> return a
 
-allEqual :: Eq a => [a] -> Bool
-allEqual []       = True
-allEqual [_]      = True
-allEqual (x:y:xs) = x == y && allEqual (y:xs)
+allEqual :: (Condense a, Eq a) => [a] -> Property
+allEqual []       = property True
+allEqual [_]      = property True
+allEqual (x:y:xs) = counterexample (condense x <> " /= " <> condense y) (x == y)
+               .&&. allEqual (y:xs)

--- a/test-consensus/Test/DynamicPraos.hs
+++ b/test-consensus/Test/DynamicPraos.hs
@@ -31,6 +31,7 @@ import qualified Data.Set as Set
 import           Test.QuickCheck
 
 import           Test.Tasty
+import           Test.Tasty.ExpectedFailure
 import           Test.Tasty.QuickCheck
 
 import           Ouroboros.Network.Block
@@ -51,10 +52,10 @@ import           Ouroboros.Consensus.Protocol.Test
 import           Ouroboros.Consensus.Util.Random
 
 import           Test.DynamicBFT (TestConfig (..), allEqual, broadcastNetwork,
-                                  nodeStake)
+                     nodeStake)
 
 tests :: TestTree
-tests = testGroup "Dynamic chain generation" [
+tests = expectFail $ testGroup "Dynamic chain generation" [
       testProperty "simple Praos convergence" prop_simple_praos_convergence
     ]
 

--- a/test-consensus/Test/DynamicPraos.hs
+++ b/test-consensus/Test/DynamicPraos.hs
@@ -1,0 +1,218 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+{-# OPTIONS -fno-warn-unused-binds #-}
+{-# OPTIONS -fno-warn-orphans #-}
+
+module Test.DynamicPraos (
+    tests
+  ) where
+
+import           Control.Monad.ST.Lazy
+import           Data.Foldable (foldlM)
+import qualified Data.IntMap.Strict as IntMap
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Test.QuickCheck
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Ouroboros.Network.Block
+import           Ouroboros.Network.Chain
+import           Ouroboros.Network.MonadClass
+import           Ouroboros.Network.Node
+
+import           Ouroboros.Consensus.Crypto.Hash.Class (hash)
+import           Ouroboros.Consensus.Crypto.KES (VerKeyKES)
+import           Ouroboros.Consensus.Crypto.KES.Mock
+import           Ouroboros.Consensus.Crypto.VRF.Mock
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Mock
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.ExtNodeConfig
+import           Ouroboros.Consensus.Protocol.Praos
+import           Ouroboros.Consensus.Protocol.Test
+import           Ouroboros.Consensus.Util.Random
+
+import           Test.DynamicBFT (TestConfig (..), allEqual, broadcastNetwork,
+                                  nodeStake)
+
+tests :: TestTree
+tests = testGroup "Dynamic chain generation" [
+      testProperty "simple Praos convergence" prop_simple_praos_convergence
+    ]
+
+prop_simple_praos_convergence :: Seed -> Property
+prop_simple_praos_convergence seed = runST $ test_simple_praos_convergence seed
+
+-- Run Praos on the broadcast network, and check that all nodes converge to the
+-- same final chain
+test_simple_praos_convergence :: forall m n.
+                                 ( MonadSTM m
+                                 , MonadRunProbe m n
+                                 , MonadSay m
+                                 , MonadTimer m
+                                 )
+                              => Seed -> n Property
+test_simple_praos_convergence seed = do
+    fmap isValid $ withProbe $ go
+  where
+    numNodes, numSlots :: Int
+    numNodes = 3
+    numSlots = 10
+
+    go :: Probe m (Map NodeId (Chain BlockUnderTest)) -> m ()
+    go p = do
+      txMap <- genTxMap
+      finalChains <- broadcastNetwork
+                       numSlots
+                       nodeInit
+                       txMap
+                       initLedgerState
+                       (seedToChaCha seed)
+      probeOutput p finalChains
+
+    -- Give everybody 1000 coins at the beginning.
+    genesisTx :: Tx
+    genesisTx = Tx mempty [ (a, 1000)
+                          | a <- Map.keys (testAddressDistribution testConfig)
+                          ]
+
+    -- TODO: We might want to have some more interesting transactions in
+    -- the future here.
+    genTxMap :: m (Map Slot (Set Tx))
+    genTxMap = do
+            -- TODO: This doesn't do anything at the moment, but ideally
+            -- we would need some randomness to shuffle the TxOut, divvy the
+            -- unspent output and distribute it randomly to the nodes, to
+            -- create an interesting test.
+        let divvy :: Int -> [TxOut] -> m [TxOut]
+            divvy currentSlot xs = do
+              let totalCoins = foldl (\acc (_,c) -> acc + c) 0 xs
+              return $ foldl (\acc ((addr, _),nid) ->
+                               if currentSlot `mod` nid == 0 then (addr, totalCoins) : acc
+                                                             else (addr, 0) : acc
+                             ) mempty (zip xs [1..])
+
+        -- Move the stake around. Use the previous Tx in the accumulator a
+        -- like a UTxO, as we are moving all the stake all the time, in order
+        -- to make the observable state interesting.
+        Map.fromList . snd <$>
+            foldlM (\(prevTx@(Tx _ oldTxOut), acc) sl -> do
+                    let txIn  = Set.fromList $ [ (hash prevTx, n) | n <- [0 .. numNodes - 1] ]
+                    txOut <- divvy sl oldTxOut
+                    let newTx = Tx txIn txOut
+                    return (newTx, (Slot $ fromIntegral sl, Set.singleton newTx) : acc)
+                  ) (genesisTx, [(Slot 1, Set.singleton genesisTx)]) [2 .. numSlots]
+
+    testConfig :: TestConfig
+    testConfig = TestConfig {
+          testAddressDistribution =
+            Map.fromList $
+              zip (map (:[]) $ take numNodes ['a' .. 'z'])
+                  (map CoreId [0 .. numNodes - 1])
+        }
+
+    verKeys :: Map NodeId (VerKeyKES (PraosKES PraosMockCrypto))
+    verKeys = Map.fromList [ (CoreId i, VerKeyMockKES i)
+                           | i <- [0 .. numNodes - 1]
+                           ]
+
+    initLedgerState :: ExtLedgerState BlockUnderTest
+    initLedgerState = ExtLedgerState {
+          ledgerState         = SimpleLedgerState (utxo genesisTx)
+        , ouroborosChainState = []
+        }
+
+    nodeInit :: Map NodeId ( NodeConfig ProtocolUnderTest
+                           , NodeState ProtocolUnderTest
+                           , Chain BlockUnderTest
+                           )
+    nodeInit = Map.fromList $ [ (CoreId i, ( mkConfig i
+                                           , mkState i
+                                           , Genesis)
+                                           )
+                              | i <- [0 .. numNodes - 1]
+                              ]
+      where
+        mkConfig :: Int -> NodeConfig ProtocolUnderTest
+        mkConfig i = EncNodeConfig {
+              encNodeConfigP = TestNodeConfig {
+                  testNodeConfigP = PraosNodeConfig {
+                      praosNodeId        = CoreId i
+                    , praosSignKeyVRF    = SignKeyMockVRF i
+                    , praosSlotsPerEpoch = 5
+                    , praosInitialEta    = 0
+                    , praosInitialStake  = initialStake
+                    , praosLeaderF       = 0.5
+                    }
+                , testNodeConfigId = CoreId i
+                }
+            , encNodeConfigExt = testConfig
+            }
+
+        mkState :: Int -> NodeState ProtocolUnderTest
+        mkState nid = SignKeyMockKES (VerKeyMockKES nid, 0, 1 + fromIntegral numSlots)
+
+    isValid :: [(Time m, Map NodeId (Chain BlockUnderTest))] -> Property
+    isValid trace = counterexample (show trace) $
+      case trace of
+        [(_, final)] -> Map.keys final == Map.keys nodeInit
+                   .&&. allEqual (Map.elems final)
+        _otherwise   -> property False
+
+    initialStake :: StakeDist
+    initialStake =
+        let q = recip $ fromIntegral numNodes
+        in  IntMap.fromList [(i, q) | i <- [0 .. numNodes - 1]]
+
+{-------------------------------------------------------------------------------
+  Test blocks
+-------------------------------------------------------------------------------}
+
+type ProtocolUnderTest = ExtNodeConfig TestConfig (TestProtocol (Praos PraosMockCrypto))
+type BlockUnderTest    = SimpleBlock ProtocolUnderTest SimpleBlockStandardCrypto
+type HeaderUnderTest   = SimpleHeader ProtocolUnderTest SimpleBlockStandardCrypto
+
+instance HasPayload (Praos PraosMockCrypto) BlockUnderTest where
+  blockPayload _ = testPayloadP
+                 . encPayloadP
+                 . headerOuroboros
+                 . simpleHeader
+
+instance ProtocolLedgerView BlockUnderTest where
+    protocolLedgerView (EncNodeConfig _ cfg) (SimpleLedgerState u) =
+        ( relativeStakes $ totalStakes cfg u
+        , nodeStake cfg u
+        )
+
+totalStakes :: TestConfig -> Utxo -> Map (Maybe Int) Int
+totalStakes (TestConfig addrDist) = foldl f Map.empty
+  where
+    f :: Map (Maybe Int) Int -> TxOut -> Map (Maybe Int) Int
+    f m (a, stake) = case Map.lookup a addrDist of
+        Just (CoreId nid) -> Map.insertWith (+) (Just nid) stake m
+        _                 -> Map.insertWith (+) Nothing stake m
+
+relativeStakes :: Map (Maybe Int) Int -> StakeDist
+relativeStakes m =
+    let totalStake    = fromIntegral $ sum $ Map.elems m
+    in  IntMap.fromList [ (nid, fromIntegral stake / totalStake)
+                        | (Just nid, stake) <- Map.toList m
+                        ]

--- a/test/Test/Chain.hs
+++ b/test/Test/Chain.hs
@@ -22,7 +22,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (Chain (..), ChainUpdate (..),
-                     Point (..), genesisPoint)
+                                          Point (..), genesisPoint)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.Serialise (prop_serialise)
 import           Ouroboros.Network.Testing.ConcreteBlock
@@ -148,7 +148,7 @@ prop_intersectChains (TestChainFork c l r) =
             && Chain.pointOnChain p l
             && Chain.pointOnChain p r
 
-prop_serialise_chain :: TestBlockChain -> Bool
+prop_serialise_chain :: TestBlockChain -> Property
 prop_serialise_chain (TestBlockChain chain) =
   prop_serialise chain
 

--- a/test/Test/Chain.hs
+++ b/test/Test/Chain.hs
@@ -22,7 +22,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (Chain (..), ChainUpdate (..),
-                                          Point (..), genesisPoint)
+                     Point (..), genesisPoint)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.Serialise (prop_serialise)
 import           Ouroboros.Network.Testing.ConcreteBlock

--- a/test/Test/Node.hs
+++ b/test/Test/Node.hs
@@ -9,8 +9,8 @@ import           Control.Monad (forM, forM_, forever, replicateM)
 import           Control.Monad.ST.Lazy (runST)
 import           Control.Monad.State (execStateT, lift, modify')
 import           Data.Array
-import           Data.Functor (void)
 import           Data.Fixed (Micro)
+import           Data.Functor (void)
 import           Data.Graph
 import           Data.List (foldl')
 import           Data.Map.Strict (Map)

--- a/test/Test/Pipe.hs
+++ b/test/Test/Pipe.hs
@@ -9,7 +9,8 @@ import           Ouroboros.Network.Chain (Chain (..), Point (..))
 import           Ouroboros.Network.Pipe (demo2)
 import           Ouroboros.Network.Protocol
 import           Ouroboros.Network.Serialise (prop_serialise)
-import           Ouroboros.Network.Testing.ConcreteBlock (Block, ConcreteHeaderHash (..))
+import           Ouroboros.Network.Testing.ConcreteBlock (Block,
+                     ConcreteHeaderHash (..))
 
 import           Test.Chain (TestBlockChainAndUpdates (..), genBlockChain)
 

--- a/test/Test/Pipe.hs
+++ b/test/Test/Pipe.hs
@@ -9,8 +9,7 @@ import           Ouroboros.Network.Chain (Chain (..), Point (..))
 import           Ouroboros.Network.Pipe (demo2)
 import           Ouroboros.Network.Protocol
 import           Ouroboros.Network.Serialise (prop_serialise)
-import           Ouroboros.Network.Testing.ConcreteBlock (Block,
-                     ConcreteHeaderHash (..))
+import           Ouroboros.Network.Testing.ConcreteBlock (Block, ConcreteHeaderHash (..))
 
 import           Test.Chain (TestBlockChainAndUpdates (..), genBlockChain)
 
@@ -39,7 +38,7 @@ prop_pipe_demo :: TestBlockChainAndUpdates -> Property
 prop_pipe_demo (TestBlockChainAndUpdates chain updates) =
     ioProperty $ demo2 chain updates
 
-prop_serialise_MsgConsumer :: MsgConsumer Block -> Bool
+prop_serialise_MsgConsumer :: MsgConsumer Block -> Property
 prop_serialise_MsgConsumer = prop_serialise
 
 newtype BlockProducer = BlockProducer {
@@ -47,7 +46,7 @@ newtype BlockProducer = BlockProducer {
   }
   deriving (Show)
 
-prop_serialise_MsgProducer :: BlockProducer -> Bool
+prop_serialise_MsgProducer :: BlockProducer -> Property
 prop_serialise_MsgProducer = prop_serialise . blockProducer
 
 instance Arbitrary (MsgConsumer Block) where


### PR DESCRIPTION
This PR contains

- Definition and implementation of KES
- Tests for all crypto implementations
- implementation of Praos
- "dynamic" test for Praos

The Praos implementation is not complete: There is no validation yet, and chain selection still uses the default implementation.

The "dynamic" test keeps failing when I run it. Not sure whether this is due to a bug or due to the fact that Praos only guarantees equal prefixes, not equal chains (due to the possibility of more than one leader per slot).

I improved error reporting for failing "dynamic" tests a bit, but it's not obvious to me why the chains have diverged.