### PR TITLE
fixed dynamic Praos test

### DIFF
--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -47,6 +47,7 @@ library
                        Ouroboros.Consensus.Protocol.Test
                        Ouroboros.Consensus.Protocol.ExtNodeConfig
                        Ouroboros.Consensus.Util
+                       Ouroboros.Consensus.Util.Chain
                        Ouroboros.Consensus.Util.DepFn
                        Ouroboros.Consensus.Util.HList
                        Ouroboros.Consensus.Util.Orphans

--- a/src/Ouroboros/Consensus/Crypto/Hash/Class.hs
+++ b/src/Ouroboros/Consensus/Crypto/Hash/Class.hs
@@ -71,7 +71,7 @@ fromHash = foldl' f 0 . SB.unpack . getHash
   where
     f n b = n * 256 + fromIntegral b
 
-prop_hash_correct_byteCount :: forall h a. (HashAlgorithm h, Serialise a)
+prop_hash_correct_byteCount :: forall h a. HashAlgorithm h
                             => Hash h a
                             -> Property
 prop_hash_correct_byteCount h =

--- a/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -21,41 +21,33 @@ module Ouroboros.Consensus.Protocol.Praos (
     -- * Type instances
   , NodeConfig(..)
   , Payload(..)
-    -- * Utility functions
-  , lastSlotInChain
-  , intersectChains
-  , chainUpToSlot
   ) where
 
-import           Data.Foldable                          (foldl')
-import           Data.IntMap.Strict                     (IntMap)
-import qualified Data.IntMap.Strict                     as IntMap
-import           Data.Proxy                             (Proxy (..))
-import           Data.Sequence                          (Seq (..))
-import           GHC.Generics                           (Generic)
+import           Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IntMap
+import           Data.Proxy (Proxy (..))
+import           GHC.Generics (Generic)
 import           Numeric.Natural
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Ed448 (Ed448DSIGN)
 import           Ouroboros.Consensus.Crypto.Hash.Class (HashAlgorithm (..),
                      fromHash, hash)
-import           Ouroboros.Consensus.Crypto.Hash.MD5    (MD5)
+import           Ouroboros.Consensus.Crypto.Hash.MD5 (MD5)
 import           Ouroboros.Consensus.Crypto.Hash.SHA256 (SHA256)
 import           Ouroboros.Consensus.Crypto.KES.Class
 import           Ouroboros.Consensus.Crypto.KES.Mock
 import           Ouroboros.Consensus.Crypto.KES.Simple
 import           Ouroboros.Consensus.Crypto.VRF.Class
-import           Ouroboros.Consensus.Crypto.VRF.Mock    (MockVRF)
-import           Ouroboros.Consensus.Crypto.VRF.Simple  (SimpleVRF)
-import           Ouroboros.Consensus.Node               (NodeId (..))
+import           Ouroboros.Consensus.Crypto.VRF.Mock (MockVRF)
+import           Ouroboros.Consensus.Crypto.VRF.Simple (SimpleVRF)
+import           Ouroboros.Consensus.Node (NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.Test
 import           Ouroboros.Consensus.Util
-import           Ouroboros.Consensus.Util.HList         (HList)
-import           Ouroboros.Consensus.Util.HList         (HList (..))
-import           Ouroboros.Network.Block                (HasHeader (..),
-                                                         Slot (..))
-import           Ouroboros.Network.Chain                (Chain (..), foldChain)
-import           Ouroboros.Network.Serialise            (Serialise)
+import           Ouroboros.Consensus.Util.HList (HList)
+import           Ouroboros.Consensus.Util.HList (HList (..))
+import           Ouroboros.Network.Block (HasHeader (..), Slot (..))
+import           Ouroboros.Network.Serialise (Serialise)
 
 {-------------------------------------------------------------------------------
   Praos specific types
@@ -251,34 +243,6 @@ rhoYT st xs s n =
         y   = eta :* s :* TEST  :* Nil
         t   = leaderThreshold st xs s n
     in  (rho, y, t)
-
-lastSlotInChain :: HasHeader b => Chain b -> Maybe Slot
-lastSlotInChain Genesis  = Nothing
-lastSlotInChain (_ :> b) = Just $ blockSlot b
-
-chainToSeq :: Chain b -> Seq b
-chainToSeq = foldChain (:|>) Empty
-
-chainFromSeq :: Seq b -> Chain b
-chainFromSeq = foldl' (:>) Genesis
-
-intersectChains :: Eq b => Chain b -> Chain b -> Chain b
-intersectChains c d = chainFromSeq $ go (chainToSeq c) (chainToSeq d)
-  where
-    go :: Eq b => Seq b -> Seq b -> Seq b
-    go Empty      _          = Empty
-    go _          Empty      = Empty
-    go (x :<| xs) (y :<| ys)
-        | x == y             = x :<| go xs ys
-        | otherwise          = Empty
-
-chainUpToSlot :: HasHeader b => Slot -> Chain b -> Chain b
-chainUpToSlot slot = go
-  where
-    go Genesis = Genesis
-    go bs@(cs :> b)
-        | blockSlot b <= slot = bs
-        | otherwise           = go cs
 
 {-------------------------------------------------------------------------------
   Crypto models

--- a/src/Ouroboros/Consensus/Util/Chain.hs
+++ b/src/Ouroboros/Consensus/Util/Chain.hs
@@ -1,0 +1,51 @@
+-- | Utility functions on chains
+--
+-- Intended for qualified import
+-- > import qualified Ouroboros.Consensus.Util.Chain as Chain
+module Ouroboros.Consensus.Util.Chain (
+    lastSlot
+  , commonPrefix
+  , upToSlot
+  ) where
+
+import           Data.Foldable (foldl')
+import           Data.Sequence (Seq (..))
+
+import           Ouroboros.Network.Block
+import           Ouroboros.Network.Chain
+
+{-------------------------------------------------------------------------------
+  Utility functions on chains
+-------------------------------------------------------------------------------}
+
+lastSlot :: HasHeader b => Chain b -> Maybe Slot
+lastSlot Genesis  = Nothing
+lastSlot (_ :> b) = Just $ blockSlot b
+
+commonPrefix :: Eq b => Chain b -> Chain b -> Chain b
+commonPrefix c d = chainFromSeq $ go (chainToSeq c) (chainToSeq d)
+  where
+    go :: Eq b => Seq b -> Seq b -> Seq b
+    go Empty      _          = Empty
+    go _          Empty      = Empty
+    go (x :<| xs) (y :<| ys)
+        | x == y             = x :<| go xs ys
+        | otherwise          = Empty
+
+upToSlot :: HasHeader b => Slot -> Chain b -> Chain b
+upToSlot slot = go
+  where
+    go Genesis = Genesis
+    go bs@(cs :> b)
+        | blockSlot b <= slot = bs
+        | otherwise           = go cs
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary
+-------------------------------------------------------------------------------}
+
+chainFromSeq :: Seq b -> Chain b
+chainFromSeq = foldl' (:>) Genesis
+
+chainToSeq :: Chain b -> Seq b
+chainToSeq = foldChain (:|>) Empty

--- a/test-consensus/Test/DynamicBFT.hs
+++ b/test-consensus/Test/DynamicBFT.hs
@@ -28,14 +28,14 @@ module Test.DynamicBFT (
 import           Control.Monad
 import           Control.Monad.Except
 import           Control.Monad.ST.Lazy
-import           Crypto.Random (DRG)
-import           Data.Foldable (foldlM)
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import           Crypto.Random                              (DRG)
+import           Data.Foldable                              (foldl', foldlM)
+import           Data.Map.Strict                            (Map)
+import qualified Data.Map.Strict                            as Map
 import           Data.Maybe
 import           Data.Proxy
-import           Data.Set (Set)
-import qualified Data.Set as Set
+import           Data.Set                                   (Set)
+import qualified Data.Set                                   as Set
 import           Test.QuickCheck
 
 import           Test.Tasty
@@ -43,20 +43,22 @@ import           Test.Tasty.QuickCheck
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain
+import qualified Ouroboros.Network.Chain                    as Chain
 import           Ouroboros.Network.ChainProducerState
 import           Ouroboros.Network.MonadClass
 import           Ouroboros.Network.Node
 import           Ouroboros.Network.Protocol
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Mock
-import           Ouroboros.Consensus.Crypto.Hash.Class (hash)
+import           Ouroboros.Consensus.Crypto.Hash.Class      (hash)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
+import qualified Ouroboros.Consensus.Protocol.Praos         as Praos
 import           Ouroboros.Consensus.Protocol.Test
-import           Ouroboros.Consensus.Util (Condense (..))
+import           Ouroboros.Consensus.Util                   (Condense (..))
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.STM
 
@@ -179,8 +181,11 @@ test_simple_bft_convergence seed = do
     isValid trace = counterexample (show trace) $
       case trace of
         [(_, final)] -> Map.keys final == Map.keys nodeInit
-                   .&&. allEqual (Map.elems final)
+                   .&&. allEqual (takeChainPrefix <$> Map.elems final)
         _otherwise   -> property False
+
+    takeChainPrefix :: Chain BlockUnderTest -> Chain BlockUnderTest
+    takeChainPrefix = id -- in BFT, chains should indeed all be equal.
 
 {-------------------------------------------------------------------------------
   Test blocks
@@ -366,8 +371,36 @@ collectJust var = do
       Nothing -> retry
       Just a  -> return a
 
-allEqual :: (Condense a, Eq a) => [a] -> Property
-allEqual []       = property True
-allEqual [_]      = property True
-allEqual (x:y:xs) = counterexample (condense x <> " /= " <> condense y) (x == y)
-               .&&. allEqual (y:xs)
+allEqual :: forall b. (Condense b, Eq b, HasHeader b) => [Chain b] -> Property
+allEqual []             = property True
+allEqual [_]            = property True
+allEqual (x : xs@(_:_)) =
+    let c = foldl' Praos.intersectChains x xs
+    in  foldl' (\prop d -> prop .&&. f c d) (property True) xs
+  where
+    f :: Chain b -> Chain b -> Property
+    f c d = counterexample (g c d) $ c == d
+
+    g :: Chain b -> Chain b -> String
+    g c d = case (Praos.lastSlotInChain c, Praos.lastSlotInChain d) of
+        (Nothing, Nothing) -> error "impossible case"
+        (Nothing, Just t)  ->    "empty intersection of non-empty chains (one reaches slot "
+                              <> show (getSlot t)
+                              <> " and contains "
+                              <> show (Chain.length d)
+                              <> "blocks): "
+                              <> condense d
+        (Just _, Nothing)  -> error "impossible case"
+        (Just s, Just t)   ->    "intersection reaches slot "
+                              <> show (getSlot s)
+                              <> " and has length "
+                              <> show (Chain.length c)
+                              <> ", but at least one chain reaches slot "
+                              <> show (getSlot t)
+                              <> " and has length "
+                              <> show (Chain.length d)
+                              <> ": "
+                              <> condense c
+                              <> " /= "
+                              <> condense d
+

--- a/test-consensus/Test/DynamicBFT.hs
+++ b/test-consensus/Test/DynamicBFT.hs
@@ -28,14 +28,14 @@ module Test.DynamicBFT (
 import           Control.Monad
 import           Control.Monad.Except
 import           Control.Monad.ST.Lazy
-import           Crypto.Random                              (DRG)
-import           Data.Foldable                              (foldl', foldlM)
-import           Data.Map.Strict                            (Map)
-import qualified Data.Map.Strict                            as Map
+import           Crypto.Random (DRG)
+import           Data.Foldable (foldl', foldlM)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Maybe
 import           Data.Proxy
-import           Data.Set                                   (Set)
-import qualified Data.Set                                   as Set
+import           Data.Set (Set)
+import qualified Data.Set as Set
 import           Test.QuickCheck
 
 import           Test.Tasty
@@ -43,22 +43,22 @@ import           Test.Tasty.QuickCheck
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain
-import qualified Ouroboros.Network.Chain                    as Chain
+import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState
 import           Ouroboros.Network.MonadClass
 import           Ouroboros.Network.Node
 import           Ouroboros.Network.Protocol
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Mock
-import           Ouroboros.Consensus.Crypto.Hash.Class      (hash)
+import           Ouroboros.Consensus.Crypto.Hash.Class (hash)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
-import qualified Ouroboros.Consensus.Protocol.Praos         as Praos
 import           Ouroboros.Consensus.Protocol.Test
-import           Ouroboros.Consensus.Util                   (Condense (..))
+import           Ouroboros.Consensus.Util (Condense (..))
+import qualified Ouroboros.Consensus.Util.Chain as Chain
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.STM
 
@@ -375,14 +375,14 @@ allEqual :: forall b. (Condense b, Eq b, HasHeader b) => [Chain b] -> Property
 allEqual []             = property True
 allEqual [_]            = property True
 allEqual (x : xs@(_:_)) =
-    let c = foldl' Praos.intersectChains x xs
+    let c = foldl' Chain.commonPrefix x xs
     in  foldl' (\prop d -> prop .&&. f c d) (property True) xs
   where
     f :: Chain b -> Chain b -> Property
     f c d = counterexample (g c d) $ c == d
 
     g :: Chain b -> Chain b -> String
-    g c d = case (Praos.lastSlotInChain c, Praos.lastSlotInChain d) of
+    g c d = case (Chain.lastSlot c, Chain.lastSlot d) of
         (Nothing, Nothing) -> error "impossible case"
         (Nothing, Just t)  ->    "empty intersection of non-empty chains (one reaches slot "
                               <> show (getSlot t)
@@ -403,4 +403,3 @@ allEqual (x : xs@(_:_)) =
                               <> condense c
                               <> " /= "
                               <> condense d
-

--- a/test-consensus/Test/DynamicPraos.hs
+++ b/test-consensus/Test/DynamicPraos.hs
@@ -22,12 +22,12 @@ module Test.DynamicPraos (
   ) where
 
 import           Control.Monad.ST.Lazy
-import           Data.Foldable                              (foldlM)
-import qualified Data.IntMap.Strict                         as IntMap
-import           Data.Map.Strict                            (Map)
-import qualified Data.Map.Strict                            as Map
-import           Data.Set                                   (Set)
-import qualified Data.Set                                   as Set
+import           Data.Foldable (foldlM)
+import qualified Data.IntMap.Strict as IntMap
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
 import           Test.QuickCheck
 
 import           Test.Tasty
@@ -38,8 +38,8 @@ import           Ouroboros.Network.Chain
 import           Ouroboros.Network.MonadClass
 import           Ouroboros.Network.Node
 
-import           Ouroboros.Consensus.Crypto.Hash.Class      (hash)
-import           Ouroboros.Consensus.Crypto.KES             (VerKeyKES)
+import           Ouroboros.Consensus.Crypto.Hash.Class (hash)
+import           Ouroboros.Consensus.Crypto.KES (VerKeyKES)
 import           Ouroboros.Consensus.Crypto.KES.Mock
 import           Ouroboros.Consensus.Crypto.VRF.Mock
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -48,6 +48,7 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
 import           Ouroboros.Consensus.Protocol.Praos
 import           Ouroboros.Consensus.Protocol.Test
+import qualified Ouroboros.Consensus.Util.Chain as Chain
 import           Ouroboros.Consensus.Util.Random
 
 import           Test.DynamicBFT (TestConfig (..), allEqual, broadcastNetwork,
@@ -178,7 +179,7 @@ test_simple_praos_convergence seed = do
         _otherwise   -> property False
 
     takeChainPrefix :: Chain BlockUnderTest -> Chain BlockUnderTest
-    takeChainPrefix = chainUpToSlot lastSlotToCheck
+    takeChainPrefix = Chain.upToSlot lastSlotToCheck
 
     lastSlotToCheck :: Slot
     lastSlotToCheck = Slot $ round $ (0.9 :: Double) * fromIntegral numSlots


### PR DESCRIPTION
I significantly improved error reporting in case of a failing dynamic test, then checked why the Praos test was failing. It was indeed the case that in the last slot, two node were both leaders. Increasing the number of slots fixed this (by luck), but to make the test more stable, I am now only checking blocks created during the first 90% of all slots for equality. In future, this should be improved by using the proper "common prefix" property from the paper.