### PR TITLE
WIP: Use consensus layer node in tests

### DIFF
--- a/src/Ouroboros/Consensus/Crypto/VRF/Class.hs
+++ b/src/Ouroboros/Consensus/Crypto/VRF/Class.hs
@@ -20,7 +20,7 @@ import           Data.Proxy (Proxy (..))
 import           GHC.Generics (Generic)
 import           Numeric.Natural
 import           Test.QuickCheck (Arbitrary (..), Gen, Property, counterexample,
-                                  (==>))
+                     (==>))
 
 import           Ouroboros.Consensus.Util.Random (Seed, withSeed)
 import           Ouroboros.Network.Serialise
@@ -54,8 +54,8 @@ data CertifiedVRF v a = CertifiedVRF {
   deriving Generic
 
 deriving instance VRFAlgorithm v => Show (CertifiedVRF v a)
-deriving instance VRFAlgorithm v => Eq (CertifiedVRF v a)
-deriving instance VRFAlgorithm v => Ord (CertifiedVRF v a)
+deriving instance VRFAlgorithm v => Eq   (CertifiedVRF v a)
+deriving instance VRFAlgorithm v => Ord  (CertifiedVRF v a)
 
 instance VRFAlgorithm v => Serialise (CertifiedVRF v a) where
   -- use generic instance for now

--- a/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -110,10 +110,10 @@ chainExtLedgerState cfg (c :> b) st = chainExtLedgerState cfg c st >>=
 -- | Validation of an entire chain
 verifyChain :: ProtocolLedgerView b
             => NodeConfig (BlockProtocol b)
-            -> Chain b
             -> ExtLedgerState b
+            -> Chain b
             -> Bool
-verifyChain cfg c st =
-    case runExcept (chainExtLedgerState cfg c st) of
+verifyChain cfg initSt c =
+    case runExcept (chainExtLedgerState cfg c initSt) of
       Left  _err -> False
       Right _st' -> True

--- a/src/Ouroboros/Consensus/Ledger/Mock.hs
+++ b/src/Ouroboros/Consensus/Ledger/Mock.hs
@@ -167,6 +167,7 @@ data SimpleHeader p c = SimpleHeader {
 
 deriving instance (SimpleBlockCrypto c, OuroborosTag p) => Show (SimpleHeader p c)
 deriving instance (SimpleBlockCrypto c, OuroborosTag p) => Eq   (SimpleHeader p c)
+deriving instance (SimpleBlockCrypto c, OuroborosTag p) => Ord  (SimpleHeader p c)
 
 -- | The preheader is the header without the ouroboros protocol specific payload
 --
@@ -185,13 +186,13 @@ instance SimpleBlockCrypto c => Condense (SimplePreHeader p c) where
     condense = show
 
 data SimpleBody = SimpleBody { getSimpleBody :: Set Tx }
-  deriving (Generic, Show, Eq)
+  deriving (Generic, Show, Eq, Ord)
 
 data SimpleBlock p c = SimpleBlock {
       simpleHeader :: SimpleHeader p c
     , simpleBody   :: SimpleBody
     }
-  deriving (Generic, Show, Eq)
+  deriving (Generic, Show, Eq, Ord)
 
 instance (SimpleBlockCrypto c, OuroborosTag p) => Condense (SimpleBlock p c) where
   condense (SimpleBlock hdr@(SimpleHeader _ pl) (SimpleBody txs)) =

--- a/src/Ouroboros/Consensus/Node.hs
+++ b/src/Ouroboros/Consensus/Node.hs
@@ -5,18 +5,26 @@
 {-# LANGUAGE TypeApplications    #-}
 
 module Ouroboros.Consensus.Node (
-    NodeId(..)
-  , RelayNode(..)
-  , relayNode
+    NodeKernel(..)
+  , nodeKernel
+    -- * Network layer abstraction
+  , NetworkLayer(..)
+  , NetworkCallbacks(..)
+  , initNetworkLayer
+    -- * Re-exports from the network layer
+  , NodeId(..)
+  , Chan(..)
+  , Network.createCoupledChannels
   ) where
 
 import           Control.Monad
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import           Data.Maybe (catMaybes)
+import           Data.Maybe (fromMaybe)
+import           Data.Set (Set)
+import qualified Data.Set as Set
 
 import           Ouroboros.Network.Block
-import           Ouroboros.Network.Chain hiding (selectChain)
+import           Ouroboros.Network.Chain (Chain (..), ChainUpdate (..), Point)
+import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState
 import           Ouroboros.Network.ConsumersAndProducers
 import           Ouroboros.Network.MonadClass
@@ -32,135 +40,215 @@ import           Ouroboros.Consensus.Util.Orphans ()
 -- in the networking layer to make the division clearer.
 
 import           Ouroboros.Network.Node (Chan (..), NodeId (..))
+import qualified Ouroboros.Network.Node as Network
 
 {-------------------------------------------------------------------------------
   Relay node
 -------------------------------------------------------------------------------}
 
 -- | Interface against running relay node
-data RelayNode m pid cid b = RelayNode {
+data NodeKernel m pid cid b = NodeKernel {
       -- | Register a new upstream node (chain producer)
-      registerProducer :: Chan m (MsgConsumer b) (MsgProducer b)
-                       -> pid
+      registerUpstream :: pid
+                       -> Chan m (MsgConsumer b) (MsgProducer b)
                        -> m ()
 
       -- | Register a new downstream node (chain consumer)
-    , registerConsumer :: Chan m (MsgProducer b) (MsgConsumer b)
-                       -> cid
-                       -> m ()
+    , registerDownstream :: cid
+                         -> Chan m (MsgProducer b) (MsgConsumer b)
+                         -> m ()
+
+      -- | Get current chain
+    , getCurrentChain :: Tr m (Chain b)
+
+      -- | Publish block
+    , publishBlock :: (Point b -> BlockNo -> Tr m b) -> m ()
     }
 
-relayNode :: ( MonadSTM m
+nodeKernel :: forall m b up down. ( MonadSTM m
              , MonadSay m
              , ProtocolLedgerView b
              , Show b
-             , Show cid
-             , Show pid
-             , Ord pid
+             , Show down
+             , Show up
+             , Ord b
              )
           => NodeId
           -> NodeConfig (BlockProtocol b)
           -> ExtLedgerState b
           -> Chain b
-          -> m (RelayNode m pid cid b)
-relayNode nid cfg initLedgerState initChain = do
-    cpsVar   <- atomically $ newTVar (initChainProducerState initChain)
-    upstream <- atomically $ newTVar Map.empty
-    fork $ chainSelection cfg upstream cpsVar
-    return RelayNode {
-        registerProducer = intRegisterProducer nid cfg initLedgerState upstream
-      , registerConsumer = intRegisterConsumer nid cpsVar
+          -> ([ChainUpdate b] -> Tr m ())
+          -> m (NodeKernel m up down b)
+nodeKernel us cfg initLedgerState initChain notifyUpdates = do
+    ourChainVar <- atomically $ newTVar initChain
+    updatesVar  <- atomically $ newEmptyTMVar
+
+    -- NOTE: Right now "header validation" is actually just "full validation",
+    -- because we cannot validate headers without also having the ledger. Once
+    -- we have the header/body split, we're going to have to be more precise
+    -- about what we can and cannot validate.
+    nw <- initNetworkLayer us initChain NetworkCallbacks {
+              prioritizeChains     = selectChain cfg
+            , validateChainHeaders = verifyChain cfg initLedgerState
+            , chainDownloaded      = \newChain -> atomically $
+                -- We are supposed to validate the chain bodies now
+                -- This is a potentially expensive operation, which we model
+                -- by putting it in a processing queue
+                putTMVar updatesVar newChain
+            }
+
+    -- We should never write to the chain without calling 'notifyUpdates'
+    let updateChain :: Chain b -> [ChainUpdate b] -> Tr m ()
+        updateChain newChain upd = do
+          writeTVar ourChainVar newChain
+          notifyUpdates upd
+          networkChainAdopted nw newChain
+
+    -- Thread to do chain validation and adoption
+    fork $ forever $ do
+         newChain <- atomically $ takeTMVar updatesVar
+         -- ... validating ... mumble mumble mumble ...
+         atomically $ do
+           ourChain <- readTVar ourChainVar
+           when (newChain `longerThan` ourChain) $ do
+             let i :: Point b
+                 i = fromMaybe Chain.genesisPoint $
+                       Chain.intersectChains newChain ourChain
+
+                 upd :: [ChainUpdate b]
+                 upd = (if i /= Chain.headPoint ourChain
+                         then (RollBack i :)
+                         else id)
+                     $ map AddBlock (fromPoint i newChain)
+
+             updateChain newChain upd
+
+    return NodeKernel {
+        registerUpstream   = networkRegisterUpstream   nw
+      , registerDownstream = networkRegisterDownstream nw
+      , getCurrentChain    = readTVar ourChainVar
+      , publishBlock       = \mkBlock -> atomically $ do
+            ourChain <- readTVar ourChainVar
+            newBlock <- mkBlock (Chain.headPoint ourChain)
+                                (Chain.headBlockNo ourChain)
+            let newChain = ourChain :> newBlock
+            updateChain newChain [AddBlock newBlock]
       }
 
 {-------------------------------------------------------------------------------
-  Dealing with consumers (downstream nodes)
+  Attempt to mock what the network API will eventually look like
 -------------------------------------------------------------------------------}
 
-intRegisterConsumer :: ( MonadSTM m
-                       , MonadSay m
-                       , HasHeader b
-                       , Show b
-                       , Show cid
-                       )
-                    => NodeId
-                    -> TVar m (ChainProducerState b)
-                    -> Chan m (MsgProducer b) (MsgConsumer b)
-                    -> cid
-                    -> m ()
-intRegisterConsumer nid cpsVar chan cid =
-    fork $ producerSideProtocol1 (exampleProducer cpsVar)
-             (loggingSend (ProducerId nid cid) (sendMsg chan))
-             (loggingRecv (ProducerId nid cid) (recvMsg chan))
+data NetworkLayer up down b m = NetworkLayer {
+      -- | Notify network layer that a new chain is adopted
+      --
+      -- This can be used when adopting upstream chains (in response to
+      -- 'chainDownloaded'), but also when producing new blocks locally.
+      networkChainAdopted :: Chain b -> Tr m ()
 
-{-------------------------------------------------------------------------------
-  Dealing with producers (upstream nodes)
--------------------------------------------------------------------------------}
+      -- | Notify network layer of new upstream node
+      --
+      -- NOTE: Eventually it will be the responsibility of the network layer
+      -- itself to register and deregister peers.
+    , networkRegisterUpstream :: up
+                              -> Chan m (MsgConsumer b) (MsgProducer b)
+                              -> m ()
 
-intRegisterProducer :: ( MonadSTM m
-                       , MonadSay m
-                       , ProtocolLedgerView b
-                       , Show b
-                       , Show pid
-                       , Ord pid
-                       )
-                    => NodeId
-                    -> NodeConfig (BlockProtocol b)
-                    -> ExtLedgerState b
-                    -> TVar m (Map pid (TVar m (Maybe (Chain b))))
-                    -> Chan m (MsgConsumer b) (MsgProducer b)
-                    -> pid
-                    -> m ()
-intRegisterProducer nid cfg initLedgerState upstream chan pid = do
-    chainVar     <- atomically $ newTVar Genesis
-    candidateVar <- atomically $ newTVar Nothing
-    fork $ consumerSideProtocol1 (exampleConsumer chainVar)
-             (loggingSend (ConsumerId nid pid) (sendMsg chan))
-             (loggingRecv (ConsumerId nid pid) (recvMsg chan))
-    fork $ chainValidation cfg initLedgerState chainVar candidateVar
-    atomically $ modifyTVar' upstream $ Map.insert pid candidateVar
 
-chainValidation :: forall b m. (MonadSTM m, ProtocolLedgerView b)
-                => NodeConfig (BlockProtocol b)
-                -> ExtLedgerState b
-                -> TVar m (Chain b)
-                -> TVar m (Maybe (Chain b))
-                -> m ()
-chainValidation cfg initLedgerState chainVar candidateVar = do
-    st <- atomically (newTVar genesisPoint)
-    forever (atomically (update st))
+      -- | Notify netwok layer of a new downstream node
+      --
+      -- NOTE: Eventually it will be the responsibility of the network layer
+      -- itself to register and deregister peers.
+    , networkRegisterDownstream :: down
+                                -> Chan m (MsgProducer b) (MsgConsumer b)
+                                -> m ()
+    }
+
+data NetworkCallbacks b m = NetworkCallbacks {
+      -- | Notify consensus layer chain has been downloaded
+      --
+      -- It is up to the consensus layer now to validate the blocks and
+      -- (potentially) adopt the chain.
+      chainDownloaded      :: Chain b -> m ()
+
+      -- | Validate chain headers
+    , validateChainHeaders :: Chain b -> Bool
+
+      -- | Prioritize chains
+      --
+      -- TODO: This should eventually return a list, rather than a single chain.
+    , prioritizeChains     :: Chain b -> [Chain b] -> Chain b
+    }
+
+initNetworkLayer :: forall m b up down.
+                    ( MonadSTM m
+                    , MonadSay m
+                    , HasHeader b
+                    , Show b
+                    , Show down
+                    , Show up
+                    , Ord b
+                    )
+                 => NodeId   -- ^ Our node ID
+                 -> Chain b  -- ^ Initial chain
+                 -> NetworkCallbacks b m
+                 -> m (NetworkLayer up down b m)
+initNetworkLayer us initChain NetworkCallbacks{..} = do
+    cpsVar        <- atomically $ newTVar $ initChainProducerState initChain
+    potentialsVar <- atomically $ newTVar Set.empty
+
+    return $ NetworkLayer {
+        networkChainAdopted = modifyTVar cpsVar . switchFork
+      , networkRegisterDownstream = \down chan ->
+          fork $ producerSideProtocol1 (exampleProducer cpsVar)
+                   (loggingSend (ProducerId us down) (sendMsg chan))
+                   (loggingRecv (ProducerId us down) (recvMsg chan))
+      , networkRegisterUpstream = \up chan -> do
+          chainVar <- atomically $ newTVar Genesis
+          fork $ consumerSideProtocol1 (exampleConsumer chainVar)
+                   (loggingSend (ConsumerId us up) (sendMsg chan))
+                   (loggingRecv (ConsumerId us up) (recvMsg chan))
+          fork $ monitor Chain.headPoint
+                         Chain.genesisPoint
+                         chainVar $ \newChain ->
+              if validateChainHeaders newChain
+                then newPotentialChain cpsVar potentialsVar newChain
+                else -- We should at this point disregard this peer,
+                     -- but the MonadSTM abstraction we work with doesn't
+                     -- give us thread IDs. For now we just ignore the
+                     -- chain and keep monitoring the peer
+                     return ()
+      }
   where
-    update :: TVar m (Point b) -> Tr m ()
-    update stateVar = do
-      chain <- readTVar chainVar
-      point <- readTVar stateVar
-      check (headPoint chain /= point)
-      writeTVar stateVar (headPoint chain)
-      let candidateChain | verifyChain cfg chain initLedgerState = Just chain
-                         | otherwise                             = Nothing
-      writeTVar candidateVar candidateChain
+    newPotentialChain :: TVar m (ChainProducerState b)
+                      -> TVar m (Set (Chain b))
+                      -> Chain b
+                      -> m ()
+    newPotentialChain cpsVar potentialsVar newChain = do
+      atomically $ do
+        ourChain <- chainState <$> readTVar cpsVar
+        when (newChain `longerThan` ourChain) $
+          modifyTVar potentialsVar $ Set.insert newChain
 
-chainSelection :: forall b m pid.
-                  ( OuroborosTag (BlockProtocol b)
-                  , MonadSTM m
-                  , SupportedBlock (BlockProtocol b) b
-                  , HasHeader b
-                  )
-               => NodeConfig (BlockProtocol b)
-               -> TVar m (Map pid (TVar m (Maybe (Chain b))))
-               -> TVar m (ChainProducerState b)
-               -> m ()
-chainSelection cfg candidates cpsVar =
-    forever (atomically updateCurrentChain)
-  where
-    updateCurrentChain :: Tr m ()
-    updateCurrentChain = do
-        candidateVars   <- Map.elems <$> readTVar candidates
-        candidateChains <- catMaybes <$> mapM readTVar candidateVars
-        cps@ChainProducerState{chainState = ourChain} <- readTVar cpsVar
-        let chain' = selectChain cfg ourChain candidateChains
-        if headPoint chain' == headPoint ourChain
-          then retry
-          else writeTVar cpsVar (switchFork chain' cps)
+      -- At this point we would download blocks, which will be ready
+      -- some point later. For now of course we have the entire chain
+      -- available. We inform the consensus layer that the longest of
+      -- these chains is "now available".
+
+      mDownloaded <- atomically $ do
+        ourChain   <- chainState <$> readTVar cpsVar
+        potentials <- readTVar potentialsVar
+        let potentials' = Set.filter (`longerThan` ourChain) potentials
+        writeTVar potentialsVar potentials'
+        return $ do
+            guard $ not (Set.null potentials')
+            let preferred = prioritizeChains ourChain (Set.toList potentials')
+            guard $ preferred /= ourChain
+            return preferred
+
+      case mDownloaded of
+        Nothing -> return ()
+        Just c  -> chainDownloaded c
 
 {-------------------------------------------------------------------------------
   Logging support
@@ -185,3 +273,27 @@ instance Condense pid => Condense (ProducerId pid) where
 
 instance Condense pid => Condense (ConsumerId pid) where
   condense ConsumerId{..} = condense (consumerUs, consumerThem)
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+longerThan :: Chain b -> Chain b -> Bool
+c `longerThan` c' = Chain.length c > Chain.length c'
+
+monitor :: (MonadSTM m, Eq b)
+        => (a -> b) -> b -> TVar m a -> (a -> m ()) -> m ()
+monitor f b tvar notify = do
+    (a, b') <- atomically $ do
+                 a <- readTVar tvar
+                 let b' = f a
+                 if b' == b
+                   then retry
+                   else return (a, b')
+    notify a
+    monitor f b' tvar notify
+
+-- | The suffix of the chain starting at the specified point
+fromPoint :: HasHeader b => Point b -> Chain b -> [b]
+fromPoint p = dropWhile (\b -> blockSlot b < Chain.pointSlot p)
+            . Chain.toOldestFirst

--- a/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -51,6 +51,7 @@ class ( Show (ChainState    p)
       , Show (ValidationErr p)
       , forall ph. Show      ph => Show      (Payload p ph)
       , forall ph. Eq        ph => Eq        (Payload p ph)
+      , forall ph. Ord       ph => Ord       (Payload p ph)
       , forall ph. Condense  ph => Condense  (Payload p ph)
       , forall ph. Serialise ph => Serialise (Payload p ph)
       ) => OuroborosTag p where
@@ -108,11 +109,13 @@ class ( Show (ChainState    p)
               -> Chain b
   selectChain _ ourChain candidates =
       -- will prioritize our own since sortBy is stable
+      -- TODO: .. but not forking more than k? for all protocols?
       head $ sortBy (flip (comparing Chain.length)) (ourChain : candidates)
 
   -- | Check if a node is the leader
   checkIsLeader :: (HasNodeState p m, MonadRandom m)
-                => NodeConfig p -> Slot
+                => NodeConfig p
+                -> Slot
                 -> LedgerView p
                 -> ChainState p
                 -> m (Maybe (IsLeader p))

--- a/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -98,6 +98,7 @@ instance BftCrypto c => OuroborosTag (Bft c) where
 
 deriving instance BftCrypto c => Show     (Payload (Bft c) ph)
 deriving instance BftCrypto c => Eq       (Payload (Bft c) ph)
+deriving instance BftCrypto c => Ord      (Payload (Bft c) ph)
 deriving instance BftCrypto c => Condense (Payload (Bft c) ph)
 
 instance BftCrypto c => Serialise (Payload (Bft c) ph) where

--- a/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
+++ b/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
@@ -65,6 +65,7 @@ instance OuroborosTag p => OuroborosTag (ExtNodeConfig cfg p) where
   applyChainState (EncNodeConfig cfg _) = applyChainState cfg
 
 deriving instance (OuroborosTag p, Eq       ph) => Eq       (Payload (ExtNodeConfig cfg p) ph)
+deriving instance (OuroborosTag p, Ord      ph) => Ord      (Payload (ExtNodeConfig cfg p) ph)
 deriving instance (OuroborosTag p, Show     ph) => Show     (Payload (ExtNodeConfig cfg p) ph)
 deriving instance (OuroborosTag p, Condense ph) => Condense (Payload (ExtNodeConfig cfg p) ph)
 

--- a/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -67,7 +67,8 @@ data PraosExtraFields c = PraosExtraFields {
   deriving Generic
 
 deriving instance PraosCrypto c => Show (PraosExtraFields c)
-deriving instance PraosCrypto c => Eq (PraosExtraFields c)
+deriving instance PraosCrypto c => Eq   (PraosExtraFields c)
+deriving instance PraosCrypto c => Ord  (PraosExtraFields c)
 
 instance VRFAlgorithm (PraosVRF c) => Serialise (PraosExtraFields c)
   -- use Generic instance for now
@@ -170,6 +171,7 @@ instance PraosCrypto c => OuroborosTag (Praos c) where
 
 deriving instance PraosCrypto c => Show (Payload (Praos c) ph)
 deriving instance PraosCrypto c => Eq   (Payload (Praos c) ph)
+deriving instance PraosCrypto c => Ord  (Payload (Praos c) ph)
 
 instance PraosCrypto c => Condense (Payload (Praos c) ph) where
     condense (PraosPayload sig _) = condense sig

--- a/src/Ouroboros/Consensus/Protocol/Test.hs
+++ b/src/Ouroboros/Consensus/Protocol/Test.hs
@@ -80,6 +80,7 @@ instance OuroborosTag p => OuroborosTag (TestProtocol p) where
 
 deriving instance (OuroborosTag p, Show ph) => Show (Payload (TestProtocol p) ph)
 deriving instance (OuroborosTag p, Eq   ph) => Eq   (Payload (TestProtocol p) ph)
+deriving instance (OuroborosTag p, Ord  ph) => Ord  (Payload (TestProtocol p) ph)
 
 instance Condense (Payload p ph)
       => Condense (Payload (TestProtocol p) ph) where

--- a/src/Ouroboros/Consensus/Util.hs
+++ b/src/Ouroboros/Consensus/Util.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns           #-}
 {-# LANGUAGE CPP                    #-}
 {-# LANGUAGE DeriveGeneric          #-}
 {-# LANGUAGE FlexibleContexts       #-}
@@ -12,7 +13,9 @@
 
 module Ouroboros.Consensus.Util (
     -- * Miscellaneous
-    repeatedly
+    foldlM'
+  , repeatedly
+  , repeatedlyM
   , chunks
   , byteStringChunks
   , lazyByteStringChunks
@@ -58,8 +61,18 @@ import qualified Ouroboros.Consensus.Util.HList as HList
   Miscellaneous
 -------------------------------------------------------------------------------}
 
+foldlM' :: forall m a b. Monad m => (b -> a -> m b) -> b -> [a] -> m b
+foldlM' f = go
+  where
+    go :: b -> [a] -> m b
+    go !acc []     = return acc
+    go !acc (x:xs) = f acc x >>= \acc' -> go acc' xs
+
 repeatedly :: (a -> b -> b) -> ([a] -> b -> b)
 repeatedly = flip . foldl' . flip
+
+repeatedlyM :: Monad m => (a -> b -> m b) -> ([a] -> b -> m b)
+repeatedlyM = flip . foldlM' . flip
 
 chunks :: Int -> [a] -> [[a]]
 chunks _ [] = []

--- a/src/Ouroboros/Network/Chain.hs
+++ b/src/Ouroboros/Network/Chain.hs
@@ -77,7 +77,7 @@ import           Ouroboros.Network.Serialise
 --
 
 data Chain block = Genesis | Chain block :> block
-  deriving (Eq, Show, Functor)
+  deriving (Eq, Ord, Show, Functor)
 
 infixl 5 :>
 

--- a/test-consensus/Test/DynamicPraos.hs
+++ b/test-consensus/Test/DynamicPraos.hs
@@ -60,7 +60,7 @@ tests = testGroup "Dynamic chain generation" [
     ]
 
 prop_simple_praos_convergence :: Seed -> Property
-prop_simple_praos_convergence seed = runST $ test_simple_praos_convergence seed
+prop_simple_praos_convergence seed = ioProperty $ test_simple_praos_convergence seed
 
 -- Run Praos on the broadcast network, and check that all nodes converge to the
 -- same final chain

--- a/test-consensus/Test/DynamicPraos.hs
+++ b/test-consensus/Test/DynamicPraos.hs
@@ -21,7 +21,7 @@ module Test.DynamicPraos (
     tests
   ) where
 
-import           Control.Monad.ST.Lazy
+import           Control.Monad.ST.Lazy (runST)
 import           Data.Foldable (foldlM)
 import qualified Data.IntMap.Strict as IntMap
 import           Data.Map.Strict (Map)
@@ -60,7 +60,7 @@ tests = testGroup "Dynamic chain generation" [
     ]
 
 prop_simple_praos_convergence :: Seed -> Property
-prop_simple_praos_convergence seed = ioProperty $ test_simple_praos_convergence seed
+prop_simple_praos_convergence seed = runST $ test_simple_praos_convergence seed
 
 -- Run Praos on the broadcast network, and check that all nodes converge to the
 -- same final chain


### PR DESCRIPTION
This modifies the dynamic protocol tests to use the new consensus layer node. Praos is however failing, for instance with

```
test-consensus -p 'simple Praos' --quickcheck-replay=147162 
```

It looks like this might be down to multiple problems:

* Assertion failure in `readerInstruction`. This is way down in the guts of the network layer, not sure what is going on there.
* We might need to support rollback for Praos, because we might have temporary forks due to the fact that multiple leaders can be selected at once.