### PR TITLE
Data store for the immutable part of the blockchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ doc/protocols.toc
 cabal.project.local*
 cabal.project.local~
 dist-newstyle/
+dist/
 *.swp
 *.swo
 *~
@@ -17,3 +18,4 @@ result*
 tags
 
 .stack-work/
+*.tix

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -17,6 +17,12 @@ source-repository head
 
 library
   hs-source-dirs:      src
+
+  if os(windows)
+     hs-Source-Dirs:   src-win32/
+  else
+     hs-Source-Dirs:   src-unix/
+
   -- At this experiment/prototype stage everything is exposed.
   -- This has to be tidied up once the design becomes clear.
   exposed-modules:
@@ -96,11 +102,19 @@ library
                        -- TODO rename.
                        Ouroboros.Network.ChainSyncExamples
 
+                       -- Storing things on disk
+                       Ouroboros.Storage.Immutable.DB
+                       Ouroboros.Storage.FS.Class
+                       Ouroboros.Storage.FS.Sim
+                       Ouroboros.Storage.FS.IO
+                       Ouroboros.Storage.Util
+
   other-modules:
                        Ouroboros.Network.ByteChannel
                        Ouroboros.Network.Codec
                        Ouroboros.Network.Framing
                        Ouroboros.Network.MsgChannel
+                       Ouroboros.Storage.IO
   default-language:    Haskell2010
   other-extensions:    BangPatterns,
                        DataKinds,
@@ -134,7 +148,10 @@ library
                        clock        >=0.7 && <0.8,
                        containers   >=0.6 && <0.7,
                        cryptonite   >=0.25 && <0.26,
+                       directory    < 1.5,
+                       exceptions   < 0.11,
                        fingertree   >=0.1 && <0.2,
+                       filepath     < 1.5.0.0,
                        free         >=5.1 && <5.2,
                        hashable     >=1.2 && <1.3,
                        memory       >=0.14 && <0.15,
@@ -155,6 +172,10 @@ library
                        void         >=0.7 && <0.8,
 
                        QuickCheck   >=2.12 && <2.13
+  if os(windows)
+     Build-depends:       Win32
+  else
+     Build-depends:       unix
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
@@ -257,5 +278,32 @@ test-suite test-consensus
                     tasty-expected-failure,
                     tasty-quickcheck,
                     typed-transitions
+  ghc-options:      -Wall
+                    -fno-ignore-asserts
+
+test-suite test-storage
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test-storage
+  default-language: Haskell2010
+  main-is:          Main.hs
+  other-modules:
+                    Test.Ouroboros.Storage
+                    Test.Ouroboros.Storage.Immutable.Sim
+  build-depends:    base,
+                    ouroboros-network,
+
+                    QuickCheck,
+                    bytestring,
+                    containers,
+                    cryptonite,
+                    directory,
+                    exceptions,
+                    filepath,
+                    mtl,
+                    tasty,
+                    tasty-expected-failure,
+                    tasty-hunit,
+                    tasty-quickcheck,
+                    temporary
   ghc-options:      -Wall
                     -fno-ignore-asserts

--- a/pkg.nix
+++ b/pkg.nix
@@ -1,8 +1,9 @@
 { mkDerivation, aeson, array, base, base16-bytestring, bytestring, cborg
 , clock, containers, cryptonite, fingertree, free, hashable, memory, mtl
 , network, pipes, process, psqueues, QuickCheck, random, semigroups, stdenv
-, stm, serialise, string-conv, tasty, tasty-expected-failure, tasty-quickcheck
-, text, transformers, typed-transitions, unliftio, void, nixpkgs
+, stm, serialise, string-conv, tasty, tasty-expected-failure, tasty-hunit
+, tasty-quickcheck, temporary, text, transformers, typed-transitions, unliftio
+, void, nixpkgs
 }:
 mkDerivation {
   pname = "ouroboros-network";
@@ -13,14 +14,14 @@ mkDerivation {
     array aeson base base16-bytestring bytestring cborg clock containers
     cryptonite fingertree free hashable memory mtl network pipes process
     psqueues QuickCheck random semigroups serialise stm string-conv tasty
-    tasty-quickcheck text transformers typed-transitions unliftio void
+    tasty-quickcheck tasty-hunit temporary text transformers typed-transitions
+    unliftio void
   ];
   testHaskellDepends = [
     array base bytestring cborg clock containers
     fingertree free hashable mtl process QuickCheck random semigroups stm tasty
-    tasty-expected-failure tasty-quickcheck text transformers void
-    tasty-expected-failure tasty-quickcheck text transformers typed-transitions
-    void
+    tasty-expected-failure tasty-hunit tasty-quickcheck temporary text
+    transformers typed-transitions void
   ];
   description = "A networking layer for the Ouroboros blockchain protocol";
   license = stdenv.lib.licenses.mit;

--- a/src-unix/Ouroboros/Storage/IO.hs
+++ b/src-unix/Ouroboros/Storage/IO.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE LambdaCase #-}
+module Ouroboros.Storage.IO (
+      FHandle --opaque(TM)
+    , open
+    , truncate
+    , seek
+    , read
+    , write
+    , close
+    ) where
+
+import           Prelude hiding (read, truncate)
+
+import           Control.Concurrent.MVar (MVar, modifyMVar, newMVar, withMVar)
+import           Control.Exception (throwIO)
+import           Data.ByteString (ByteString)
+import           Data.ByteString.Internal as Internal
+
+import           Data.Word (Word32, Word64, Word8)
+import           Foreign (Ptr)
+import           System.IO (IOMode (..), SeekMode (..))
+import           System.Posix (Fd (..), OpenFileFlags (..), OpenMode (..),
+                     closeFd, fdReadBuf, fdSeek, fdWriteBuf, openFd,
+                     stdFileMode)
+import           System.Posix.Files (setFdSize)
+
+-- A thin wrapper over a POSIX 'Fd', guarded by an MVar so that we can
+-- implement 'close' as an idempotent operation.
+newtype FHandle = FHandle (MVar (Maybe Fd))
+
+-- | Some sensible defaults for the 'OpenFileFlags'. Note that the 'unix'
+-- package /already/ exports a smart constructor called @defaultFileFlags@
+-- already, but we define our own to not be depedent by whichever default
+-- choice unix's library authors made, and to be able to change our minds
+-- later if necessary.
+-- In particular, we are interested in the 'append' and 'exclusive' flags,
+-- which were largely the reason why we introduced this low-level module.
+defaultFileFlags :: OpenFileFlags
+defaultFileFlags = OpenFileFlags {
+    append    = False
+  , exclusive = False
+  , noctty    = False
+  , nonBlock  = False
+  , trunc     = False
+  }
+
+-- | Opens a file from disk.
+open :: FilePath -> IOMode -> IO FHandle
+open filename ioMode = do
+  let (openMode, fileMode, fileFlags)
+       | ioMode == ReadMode    = ( ReadOnly
+                                 , Nothing
+                                 , defaultFileFlags)
+       | ioMode == AppendMode  = ( WriteOnly
+                                 , Just stdFileMode
+                                 , defaultFileFlags { append = True })
+       | otherwise             = ( ReadWrite
+                                 , Just stdFileMode
+                                 , defaultFileFlags)
+  fd <- openFd filename openMode fileMode fileFlags
+  FHandle <$> newMVar (Just fd)
+
+-- | Writes the data pointed by the input 'Ptr Word8' into the input 'FHandle'.
+write :: FHandle -> Ptr Word8 -> Word32 -> IO Word32
+write (FHandle fdVar) data' bytes =
+    withMVar fdVar $ \case
+        Nothing -> throwIO (userError "write: the FHandle is closed.")
+        Just fd -> fmap fromIntegral . fdWriteBuf fd data'
+                                     $ fromIntegral bytes
+
+-- | Seek within the file. Returns the offset within the file after the seek.
+seek :: FHandle -> SeekMode -> Word64 -> IO Word64
+seek (FHandle fdVar) seekMode bytes =
+    withMVar fdVar $ \case
+        Nothing -> throwIO (userError "seek: the FHandle is closed.")
+        Just fd -> fromIntegral <$> fdSeek fd seekMode (fromIntegral bytes)
+
+-- | Reads a given number of bytes from the input 'FHandle'.
+read :: FHandle -> Int -> IO ByteString
+read (FHandle fdVar) bytes =
+    withMVar fdVar $ \case
+        Nothing -> throwIO (userError "read: the FHandle is closed.")
+        Just fd -> Internal.createUptoN bytes $ \ptr ->
+                       fromIntegral <$> fdReadBuf fd ptr (fromIntegral bytes)
+
+-- | Truncates the file managed by the input 'FHandle' to the input size.
+truncate :: FHandle -> Word64 -> IO ()
+truncate (FHandle fdVar) size =
+    withMVar fdVar $ \case
+        Nothing -> throwIO (userError "truncate: the FHandle is closed.")
+        Just fd -> setFdSize fd (fromIntegral size)
+
+
+-- | Closes a 'FHandle'. It's nice to be slightly more lenient here, as the
+-- 'hClose' equivalent from 'System.IO' allows for this operation to be
+-- idempotent.
+close :: FHandle -> IO ()
+close (FHandle fdVar) =
+    modifyMVar fdVar $ \case
+        Nothing -> return (Nothing, ())
+        Just fd -> closeFd fd >> return (Nothing, ())

--- a/src-win32/Ouroboros/Storage/IO.hs
+++ b/src-win32/Ouroboros/Storage/IO.hs
@@ -1,0 +1,53 @@
+module Ouroboros.Storage.IO (
+      FHandle --opaque(TM)
+    , open
+    , truncate
+    , seek
+    , read
+    , write
+    , close
+    ) where
+
+import           Prelude hiding (read, truncate)
+
+import           Control.Exception (IOException, SomeException)
+import qualified Control.Exception as E
+import           Control.Exception.Extensible (throw, try)
+import           Data.Word (Word32, Word8)
+import           Foreign (Ptr)
+import           System.Directory (createDirectoryIfMissing, removeFile)
+import           System.IO
+import           System.Win32 (HANDLE, cREATE_ALWAYS, closeHandle, createFile,
+                     fILE_ATTRIBUTE_NORMAL, fILE_SHARE_NONE, flushFileBuffers,
+                     gENERIC_ALL, gENERIC_READ, gENERIC_WRITE, win32_WriteFile)
+
+data FHandle = FHandle HANDLE
+
+open :: FilePath -> IOMode -> IO FHandle
+open filename ioMode = do
+    let accessMode
+         | ioMode == ReadMode   = gENERIC_READ
+         | ioMode == AppendMode = gENERIC_WRITE
+         | otherwise = gENERIC_ALL
+    fmap FHandle $ createFile filename
+                              accessMode
+                              fILE_SHARE_NONE -- TODO: this is wrong, needs to be changed.
+                              Nothing
+                              cREATE_ALWAYS -- TODO: ditto, ReadMode should enforce is there.
+                              fILE_ATTRIBUTE_NORMAL
+                              Nothing
+
+write :: FHandle -> Ptr Word8 -> Word32 -> IO Word32
+write (FHandle handle) data' length = win32_WriteFile handle data' length Nothing
+
+seek :: FHandle -> SeekMode -> Word64 -> IO Word64
+seek = error "seek: needs a Windows hero to implement."
+
+read :: FHandle -> Int -> IO ByteString
+read = error "read: needs a Windows hero to implement."
+
+truncate :: FHandle -> Word64 -> IO ()
+truncate = error "truncate: needs a Windows hero to implement."
+
+close :: FHandle -> IO ()
+close (FHandle handle) = closeHandle handle

--- a/src/Ouroboros/Consensus/Util.hs
+++ b/src/Ouroboros/Consensus/Util.hs
@@ -16,6 +16,7 @@ module Ouroboros.Consensus.Util (
   , chunks
   , byteStringChunks
   , lazyByteStringChunks
+  , whenJust
     -- * Decorating one value with another
   , DecoratedWith(..)
   , Decorates(..)
@@ -74,6 +75,11 @@ lazyByteStringChunks n bs
   | Lazy.null bs = []
   | otherwise    = let (chunk, bs') = Lazy.splitAt (fromIntegral n) bs
                    in chunk : lazyByteStringChunks n bs'
+
+whenJust :: Applicative f => Maybe a -> (a -> f ()) -> f ()
+whenJust (Just x) f = f x
+whenJust Nothing _  = pure ()
+{-# INLINE whenJust #-}
 
 {-------------------------------------------------------------------------------
   Decorating one value with another

--- a/src/Ouroboros/Storage/FS/Class.hs
+++ b/src/Ouroboros/Storage/FS/Class.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+{-- |
+
+An abstract view over the filesystem.
+
+--}
+
+module Ouroboros.Storage.FS.Class (
+    -- * Opaque types and main API
+      HasFS(..)
+    , FsError(..)
+    , FsUnexpectedException(..)
+    , FsPath
+    , sameFsError
+    , isResourceDoesNotExistError
+    , prettyFSError
+    -- * Actual HasFS monad stacks will have ExceptT at the top
+    , HasFSE
+    , FsHandleE
+    , FsPtrE
+    , BufferE
+    -- * Re-exports from System.IO
+    , SeekMode(..)
+    , IOMode(..)
+    ) where
+
+import           Control.Exception (Exception (..), IOException)
+import           Control.Monad.Except
+
+import           GHC.Stack
+
+import           Data.ByteString (ByteString)
+import           Data.ByteString.Builder (Builder)
+import           Data.Semigroup ((<>))
+import           Data.Word (Word64)
+
+import           System.IO (IOMode (..), SeekMode (..))
+
+{------------------------------------------------------------------------------
+ Abstracting over file paths
+------------------------------------------------------------------------------}
+
+type FsPath = [String]
+
+{------------------------------------------------------------------------------
+ Handling failure
+------------------------------------------------------------------------------}
+
+data FsError =
+    FsIllegalOperation FsPath CallStack
+  | FsResourceInappropriateType FsPath CallStack
+  -- ^ e.g the user tried to open a directory with hOpen rather than a file.
+  | FsResourceAlreadyInUse FsPath CallStack
+  | FsResourceDoesNotExist FsPath CallStack
+  | FsResourceAlreadyExist FsPath CallStack
+  | FsReachedEOF FsPath CallStack
+  deriving Show
+
+-- | We define a 'FsUnexpectedException' separated by the rest so that we
+-- can still \"tag\" any exception coming from the underlying concrete monad
+-- that we don't support in our 'HasFS' abstraction, but without the risk of
+-- polluting the 'FsError' sum type, as introducing such a new type constructor
+-- would force us to catch and deal with this \"unexpected\" exception.
+data FsUnexpectedException = FsUnexpectedException IOException CallStack
+                             deriving Show
+
+instance Exception FsUnexpectedException
+
+instance Exception FsError where
+    displayException = prettyFSError
+
+isResourceDoesNotExistError :: FsError -> Bool
+isResourceDoesNotExistError (FsResourceDoesNotExist _ _) = True
+isResourceDoesNotExistError _                            = False
+
+prettyFSError :: FsError -> String
+prettyFSError = \case
+    FsIllegalOperation fp cs          ->
+        "FsIllegalOperation for " <> show fp <> ": " <> prettyCallStack cs
+    FsResourceInappropriateType fp cs ->
+        "FsResourceInappropriateType for " <> show fp <> ": " <> prettyCallStack cs
+    FsResourceAlreadyInUse fp cs      ->
+        "FsResourceAlreadyInUse for " <> show fp <> ": " <> prettyCallStack cs
+    FsResourceDoesNotExist fp cs      ->
+        "FsResourceDoesNotExist for " <> show fp <> ": " <> prettyCallStack cs
+    FsResourceAlreadyExist fp cs      ->
+        "FsResourceAlreadyInUse for " <> show fp <> ": " <> prettyCallStack cs
+    FsReachedEOF fp cs                ->
+        "FsReachedEOF for " <> show fp <> ": " <> prettyCallStack cs
+
+
+-- | Check two 'FsError' for shallow equality, i.e. if they have the same
+-- type constructor, ignoring the 'CallStack' and the filepath, as different
+-- implementations we will use different ways of representing it. For example
+-- IO will use an absolute one, a mock implementation only a relative one.
+-- This is very useful during tests
+-- when comparing different 'HasFS' implementations and assert that they throw
+-- the same FsError type, even though the callstack is naturally different.
+sameFsError :: FsError -> FsError -> Bool
+sameFsError e1 e2 = case (e1, e2) of
+    (FsIllegalOperation fp1 _, FsIllegalOperation fp2 _)                   -> fp1 == fp2
+    (FsIllegalOperation _ _, _)                                            -> False
+    (FsResourceAlreadyInUse fp1 _, FsResourceAlreadyInUse fp2 _)           -> fp1 == fp2
+    (FsResourceAlreadyInUse _ _, _)                                        -> False
+    (FsResourceInappropriateType fp1 _, FsResourceInappropriateType fp2 _) -> fp1 == fp2
+    (FsResourceInappropriateType _ _, _)                                   -> False
+    (FsResourceDoesNotExist fp1 _, FsResourceDoesNotExist fp2 _)           -> fp1 == fp2
+    (FsResourceDoesNotExist _ _, _)                                        -> False
+    (FsResourceAlreadyExist fp1 _, FsResourceAlreadyExist fp2 _)           -> fp1 == fp2
+    (FsResourceAlreadyExist _ _, _)                                        -> False
+    (FsReachedEOF fp1 _, FsReachedEOF fp2 _)                               -> fp1 == fp2
+    (FsReachedEOF _ _, _)                                                  -> False
+
+{------------------------------------------------------------------------------
+ Typeclass which abstracts over the filesystem
+------------------------------------------------------------------------------}
+
+class Monad m => HasFS m where
+    type FsHandle m :: *
+    type FsPtr m    :: *
+    data Buffer m   :: *
+
+    newBuffer :: Int -> m (Buffer m)
+    dumpState :: m String
+
+    -- Operations of files
+    -- hOpen returns a 'Bool' stating whether the input file is new or not.
+    hOpen      :: HasCallStack => FsPath     -> IOMode -> m (FsHandle m)
+    hClose     :: HasCallStack => FsHandle m -> m ()
+    hSeek      :: HasCallStack => FsHandle m -> SeekMode -> Word64 -> m Word64
+    hGet       :: HasCallStack => FsHandle m -> Int -> m ByteString
+    hPut       :: HasCallStack => FsHandle m -> Builder -> m Word64
+    hPutBuffer :: HasCallStack => FsHandle m -> Buffer m -> Builder -> m Word64
+    hTruncate  :: HasCallStack => FsHandle m -> Word64 -> m ()
+    withFile   :: HasCallStack => FsPath     -> IOMode -> (FsHandle m -> m r) -> m r
+
+    -- Operations of directories
+    createDirectory          :: HasCallStack => FsPath -> m ()
+    createDirectoryIfMissing :: HasCallStack => Bool -> FsPath -> m ()
+    listDirectory            :: HasCallStack => FsPath -> m [String]
+    doesDirectoryExist       :: HasCallStack => FsPath -> m Bool
+    doesFileExist            :: HasCallStack => FsPath -> m Bool
+
+{-------------------------------------------------------------------------------
+  ExceptT support
+
+  To avoid 'HasFS' instance pinning the 'MonadError' constraint on a monad
+  stack to a single type ('FsError'), 'HasFS' instances will look like
+
+  > instance HasFS (ExceptT ..) where ..
+
+  To make working with this a bit more convenient, we define some type aliases
+  here.
+-------------------------------------------------------------------------------}
+
+type HasFSE    m = HasFS    (ExceptT FsError m)
+type FsHandleE m = FsHandle (ExceptT FsError m)
+type FsPtrE    m = FsPtr    (ExceptT FsError m)
+type BufferE   m = Buffer   (ExceptT FsError m)

--- a/src/Ouroboros/Storage/FS/IO.hs
+++ b/src/Ouroboros/Storage/FS/IO.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE ViewPatterns               #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+{-- |
+
+An abstract view over the filesystem.
+
+--}
+
+module Ouroboros.Storage.FS.IO (
+    -- * IO implementation & monad
+      IOFS -- opaque
+    , runIOFS
+    ) where
+
+import           Control.Exception (throwIO)
+import           Control.Monad.Catch
+import           Control.Monad.Except
+import           Control.Monad.Reader
+
+import           GHC.IO.Exception
+import           GHC.Stack
+
+import qualified Data.ByteString.Builder.Extra as BS
+import qualified Data.ByteString.Unsafe as BS
+import           Data.List (foldl', stripPrefix)
+import           Data.Word (Word64, Word8)
+
+import           Foreign (ForeignPtr, Ptr, castPtr, withForeignPtr)
+import           GHC.ForeignPtr (mallocPlainForeignPtrBytes)
+import qualified System.Directory as Dir
+import           System.FilePath (splitDirectories, (</>))
+import           System.IO.Error
+
+import           Ouroboros.Storage.FS.Class
+import qualified Ouroboros.Storage.IO as F
+
+-- | \"Roots\" a FsPath to a particular root.
+makeAbsolute :: FsPath -> FilePath -> FilePath
+makeAbsolute pths currentMountPoint =
+    currentMountPoint </> foldl' (</>) mempty pths
+
+
+-- The 'MountPoint' is conceptually the working directory from where we run
+-- our concrete monad which implements 'HasFS'. To keep up the analogy with the
+-- unix filesystem, we are "mounting" the particular device at the directory
+-- 'MountPoint', so that each 'FsPath' we use inside our monad is
+-- interpreted as a relative one respect to the 'MountPoint', and turned
+-- absolute when we run our monad.
+type MountPoint = FilePath
+
+-- | Tries to catch a subset of the 'IOException's that the input 'IO' action
+-- might throw, reifying them into a 'FsError', or rethrowing in case the
+-- 'IOException' doesn't map to one of the supported 'FsError' constructors.
+-- We need to pass as input the 'MountPoint' so we can make the filepath we
+-- return in the 'FsError' relative, in compliance with other implementations.
+catchFSErrorIO :: HasCallStack => MountPoint -> IO a -> IO (Either FsError a)
+catchFSErrorIO (splitDirectories -> mountPoint) action = do
+    res <- tryIOError action
+    case res of
+         Left err -> handleError err
+         Right a  -> return (Right a)
+    where
+        getPath :: IOError -> IO FsPath
+        getPath ioe = case ioe_filename ioe of
+            Nothing ->
+              throwIO $ FsUnexpectedException
+                  (userError $ "getPath: ioe_filename was empty in " ++ displayException ioe)
+                  callStack
+            Just fp ->
+                 case stripPrefix mountPoint (splitDirectories fp) of
+                      Just path -> return path
+                      Nothing -> throwIO $ FsUnexpectedException
+                          (userError $ "getPath: stripPrefix returned empty path in " ++ displayException ioe)
+                          callStack
+
+        handleError :: HasCallStack => IOError -> IO (Either FsError a)
+        handleError ioErr
+          | isIllegalOperationErrorType eType =
+            return . Left =<< (FsIllegalOperation <$> getPath ioErr <*> pure callStack)
+          | isAlreadyExistsErrorType eType =
+            return . Left =<< (FsResourceAlreadyExist <$> getPath ioErr <*> pure callStack)
+          | isDoesNotExistErrorType eType =
+            return . Left =<< (FsResourceDoesNotExist <$> getPath ioErr <*> pure callStack)
+          | isAlreadyInUseErrorType eType =
+            return . Left =<< (FsResourceAlreadyInUse <$> getPath ioErr <*> pure callStack)
+          | isEOFErrorType eType =
+            return . Left =<< (FsReachedEOF <$> getPath ioErr <*> pure callStack)
+          | eType == InappropriateType =
+            return . Left =<< (FsResourceInappropriateType <$> getPath ioErr <*> pure callStack)
+          | otherwise = throwIO (FsUnexpectedException ioErr callStack)
+         where eType :: IOErrorType
+               eType = ioeGetErrorType ioErr
+
+{------------------------------------------------------------------------------
+  The IOFS monad
+-------------------------------------------------------------------------------}
+
+type IOFSE = ExceptT FsError IOFS
+type IOFS  = ReaderT MountPoint IO
+
+-- | Lifts an 'IO' action into the 'IOFSE' monad. Note how this /must/ be
+-- used as a drop-in replacement for 'liftIO', as the former would also correctly
+-- catch any relevant IO exception and reify it into a 'FsError' one.
+liftIOE :: IO a -> IOFSE a
+liftIOE act = ExceptT $ do
+    mp <- ask
+    lift $ catchFSErrorIO mp act
+
+runIOFS :: IOFS a -> MountPoint -> IO a
+runIOFS r mountPoint = runReaderT r mountPoint
+
+withAbsPath :: FsPath -> (FilePath -> IO a) -> IOFSE a
+withAbsPath p act = asks (makeAbsolute p) >>= liftIOE . act
+
+instance HasFS IOFSE where
+    type FsHandle IOFSE = F.FHandle
+    type FsPtr    IOFSE = Ptr Word8
+    data Buffer   IOFSE =
+        BufferIO {-# UNPACK #-} !(ForeignPtr Word8) {-# UNPACK #-} !Int
+
+    -- TODO(adn) Might be useful to implement this properly by reading all
+    -- the stuff available at the 'MountPoint'.
+    dumpState = return "<dumpState@IO>"
+
+    hOpen path ioMode = withAbsPath path $ \fp -> F.open fp ioMode
+
+    newBuffer              = liftIOE . newBufferIO
+    hClose                 = liftIOE . F.close
+    hSeek     hnd seekMode = liftIOE . F.seek     hnd seekMode
+    hGet      hnd          = liftIOE . F.read     hnd
+    hTruncate hnd          = liftIOE . F.truncate hnd
+
+    hPut hnd builder     = do
+        buf0 <- newBuffer BS.defaultChunkSize
+        hPutBuffer hnd buf0 builder
+    hPutBuffer hnd buf0 = liftIOE . go 0 buf0 . BS.runBuilder
+      where
+        go :: Word64
+           -> Buffer IOFSE
+           -> BS.BufferWriter
+           -> IO Word64
+        go !bytesWritten buf write = do
+          (bytesCount, next) <- withBuffer buf $ \ptr sz -> do
+            -- run the builder, writing into our buffer
+            (n, next) <- write ptr sz
+            -- so now our buffer contains 'n' bytes
+            -- write it all out to the handle leaving our buffer empty
+            bytesCount <- F.write hnd ptr (fromIntegral n)
+            return (bytesCount, next)
+          case next of
+            BS.Done -> return (bytesWritten + fromIntegral bytesCount)
+            BS.More minSize write' | bufferSize buf < minSize -> do
+              -- very unlikely given our strategy of flushing our buffer every time
+              buf' <- newBufferIO minSize
+              go (bytesWritten + fromIntegral bytesCount) buf' write'
+            BS.More _minSize write' ->
+              go (bytesWritten + fromIntegral bytesCount) buf write'
+            BS.Chunk chunk   write' -> do
+              n <- BS.unsafeUseAsCStringLen chunk $ \(ptr, len) ->
+                       F.write hnd (castPtr ptr) (fromIntegral len)
+              go (bytesWritten + fromIntegral n + fromIntegral bytesCount) buf write'
+
+    -- Can't use withAbsPath here, negative occurrence of IO
+    withFile path ioMode action = do
+        fp <- asks (makeAbsolute path)
+        bracket (liftIOE $ F.open fp ioMode) (liftIOE . F.close) action
+
+    createDirectory    path = withAbsPath path $ Dir.createDirectory
+    listDirectory      path = withAbsPath path $ Dir.listDirectory
+    doesDirectoryExist path = withAbsPath path $ Dir.doesDirectoryExist
+    doesFileExist      path = withAbsPath path $ Dir.doesFileExist
+
+    createDirectoryIfMissing createParent path = withAbsPath path $
+        Dir.createDirectoryIfMissing createParent
+
+{-------------------------------------------------------------------------------
+  Auxiliary: buffers
+-------------------------------------------------------------------------------}
+
+bufferSize :: Buffer IOFSE -> Int
+bufferSize (BufferIO _fptr len) = len
+
+newBufferIO :: Int -> IO (Buffer IOFSE)
+newBufferIO len = do
+    fptr <- mallocPlainForeignPtrBytes len
+    return $! BufferIO fptr len
+
+withBuffer :: Buffer IOFSE
+           -> (FsPtr IOFSE -> Int -> IO a)
+           -> IO a
+withBuffer (BufferIO fptr len) action =
+    withForeignPtr fptr $ \ptr -> action ptr len

--- a/src/Ouroboros/Storage/FS/Sim.hs
+++ b/src/Ouroboros/Storage/FS/Sim.hs
@@ -1,0 +1,615 @@
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+{-- |
+
+A mock FS implementation, suitable for testing.
+
+--}
+
+module Ouroboros.Storage.FS.Sim (
+    -- * Mock FS implementation & monad
+      SimFS
+    , SimFSE
+    , MockHandle(..)
+    , MockFS(..)
+    , newEmptyMockFS
+    , runSimFS
+    , prettyShowFS
+    -- * Internals for white-box testing
+    , FsTree(..)
+    , index
+    , touchFile
+    -- * Testing examples
+    , mockDemo
+    , mockDemoScript
+    , demoMockFS
+    ) where
+
+import           Control.Monad.Catch (MonadCatch (..), MonadMask (..),
+                     MonadThrow (..), bracket)
+import           Control.Monad.Except
+import           Control.Monad.Reader
+
+import           GHC.Stack
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as B16
+import           Data.ByteString.Builder (Builder, toLazyByteString)
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Char8 as C8
+import qualified Data.ByteString.Lazy as BL
+import           Data.Functor.Identity
+import           Data.List (foldl')
+import qualified Data.List as L
+import           Data.Map (Map)
+import qualified Data.Map.Strict as M
+import           Data.Semigroup ((<>))
+import           Data.Word (Word64)
+
+import           System.IO (IOMode, SeekMode)
+import qualified System.IO as IO
+
+import           Ouroboros.Network.MonadClass
+import           Ouroboros.Storage.FS.Class
+
+{------------------------------------------------------------------------------
+  The simulation-related types
+------------------------------------------------------------------------------}
+
+type SimFSE m = ExceptT FsError (SimFS m)
+
+newtype SimFS m a =
+    SimFS { unSimFs :: ReaderT (TVar m MockFS) m a }
+    deriving ( Functor
+             , Applicative
+             , Monad
+             , MonadThrow
+             , MonadCatch
+             , MonadMask
+             )
+
+instance MonadTrans SimFS where
+    lift = SimFS . lift
+
+newtype TrSimFS m a = TrSimFS (m a)
+  deriving (Functor, Applicative, Monad)
+
+instance MonadTrans TrSimFS where
+    lift = TrSimFS
+
+instance MonadFork m => MonadFork (SimFS m) where
+  fork (SimFS f) = SimFS $ ReaderT $ \e -> fork (runReaderT f e)
+
+instance (MonadFork (SimFS m) , MonadSTM m) => MonadSTM (SimFS m) where
+  type Tr (SimFS m)      = TrSimFS (Tr m)
+  type TVar (SimFS m)    = TVar m
+  type TMVar (SimFS m)   = TMVar m
+  type TBQueue (SimFS m) = TBQueue m
+
+  atomically (TrSimFS t) = lift $ atomically t
+  newTVar                = lift . newTVar
+  readTVar               = lift . readTVar
+  writeTVar t a          = lift $ writeTVar t a
+  retry                  = lift retry
+
+  newTMVar               = lift . newTMVar
+  newTMVarIO             = lift . newTMVarIO
+  newEmptyTMVar          = lift newEmptyTMVar
+  newEmptyTMVarIO        = lift newEmptyTMVarIO
+  takeTMVar              = lift . takeTMVar
+  tryTakeTMVar           = lift . tryTakeTMVar
+  putTMVar    t a        = lift $ putTMVar t a
+  tryPutTMVar t a        = lift $ tryPutTMVar t a
+  swapTMVar   t a        = lift $ swapTMVar t a
+  readTMVar              = lift . readTMVar
+  tryReadTMVar           = lift . tryReadTMVar
+  isEmptyTMVar           = lift . isEmptyTMVar
+
+  newTBQueue             = lift . newTBQueue
+  readTBQueue            = lift . readTBQueue
+  writeTBQueue q a       = lift $ writeTBQueue q a
+  lengthTBQueue          = lift . lengthTBQueue
+
+
+{-------------------------------------------------------------------------------
+  Mock FS types
+-------------------------------------------------------------------------------}
+
+data MockFS = MockFS {
+    getMockFS :: FsTree ByteString
+  } deriving Show
+
+
+instance Show (MockHandle m) where
+   show MockHandle{..} = "MockHandle { mockHandleFilePath = "
+                      <> show mockHandleFilePath
+                      <> ", mockHandleIOMode = "
+                      <> show mockHandleIOMode
+                      <> ", mockHandleOffset = <tvar> }"
+
+type DiskOffset = Word64
+
+-- | A simple representation of files and folders on disk, where leaves stores
+-- not just the file names but also the actual content of these files.
+data FsTree a =
+      FileOnDisk a
+    | FolderOnDisk (Map String (FsTree a))
+    deriving (Show, Eq)
+
+-- | A mock handle to a file on disk.
+data MockHandle m = MockHandle {
+      mockHandleFilePath :: FsPath
+    , mockHandleIOMode   :: IOMode
+    , mockHandleOffset   :: TVar m DiskOffset
+    }
+
+{------------------------------------------------------------------------------
+ Mock FS implementation
+------------------------------------------------------------------------------}
+
+instance (MonadMask m, MonadSTM m) => HasFS (SimFSE m) where
+    type FsHandle (SimFSE m) = MockHandle m
+    type FsPtr    (SimFSE m) = DiskOffset
+    data Buffer   (SimFSE m) = BufferMock !BS.ByteString
+
+    dumpState  = mockDumpState
+    newBuffer  = newBufferMock
+    hOpen      = mockOpen
+    hClose     = mockClose
+    hSeek      = mockSeek
+    hGet       = mockGet
+    hPut       = mockPut
+    hPutBuffer = mockPutBuffer
+    hTruncate  = mockTruncate
+    withFile   = mockWithFile
+
+    createDirectory          = mockCreateDirectory
+    createDirectoryIfMissing = mockCreateDirectoryIfMissing
+    listDirectory            = mockListDirectory
+    doesDirectoryExist       = mockDoesDirectoryExist
+    doesFileExist            = mockDoesFileExist
+
+
+modifyMockFS :: MonadSTM m
+             => (MockFS -> ExceptT FsError (Tr m) (MockFS, b))
+             -> SimFSE m b
+modifyMockFS action = do
+    fsVar <- getFsVar
+    ExceptT $ lift $ atomically $ do
+      fs  <- readTVar fsVar
+      res <- runExceptT $ action fs
+      case res of
+        Left  err      -> return (Left err)
+        Right (fs', b) -> writeTVar fsVar fs' >> return (Right b)
+
+
+withMockFS :: MonadSTM m
+           => (MockFS -> ExceptT FsError (Tr m) b)
+           -> SimFSE m b
+withMockFS action = modifyMockFS $ \fs -> (fs, ) <$> action fs
+
+
+getFsVar :: Monad m => SimFSE m (TVar m MockFS)
+getFsVar = lift $ SimFS $ ask
+
+
+mockDumpState :: MonadSTM m => SimFSE m String
+mockDumpState = do
+    fsVar <- getFsVar
+    fs <- atomically $ readTVar fsVar
+    return $ prettyShowFS fs
+
+
+-- | Mock implementation of 'hOpen'.
+mockOpen :: (HasCallStack, MonadSTM m)
+         => FsPath
+         -> IOMode
+         -> SimFSE m (MockHandle m)
+mockOpen fp ioMode = modifyMockFS $ \fs -> do
+    -- Check if the parent exists
+    parent <- noteT (FsResourceDoesNotExist fp callStack) $
+                index (init fp) (getMockFS fs)
+
+    -- Check if the file exist
+    (fs', fileSize) <- case index [last fp] parent of
+        Nothing | ioMode /= IO.ReadMode -> do
+            let tree' = touchFile fp (getMockFS fs)
+            return (fs { getMockFS = tree' }, 0)
+        Just (FileOnDisk f   ) -> return (fs, BS.length f)
+        Just (FolderOnDisk _ ) -> throwError (FsResourceInappropriateType fp callStack)
+        _ -> throwError (FsResourceDoesNotExist fp callStack)
+
+    let initialOffset
+          | ioMode == IO.AppendMode = fileSize
+          | otherwise = 0
+    hnd <- MockHandle fp ioMode <$> newTVar (toEnum initialOffset)
+    return (fs', hnd)
+
+-- | Mock implementation of 'hClose', which is trivial.
+mockClose :: Monad m => MockHandle m -> SimFSE m ()
+mockClose _ = return ()
+
+-- | Mock implementation of 'hSeek'
+mockSeek :: forall m. (HasCallStack, MonadSTM m)
+         => MockHandle m
+         -> SeekMode
+         -> Word64
+         -> SimFSE m Word64
+mockSeek (MockHandle fp _mode curOffsetVar) mode offset = withMockFS $ \fs ->
+    case index fp (getMockFS fs) of
+      Nothing -> throwError $ FsResourceDoesNotExist fp callStack
+      Just (FolderOnDisk _) -> throwError $ FsResourceInappropriateType fp callStack
+      Just (FileOnDisk block) -> do
+        currentOffset <- readTVar curOffsetVar
+        let offset' = case mode of
+             IO.AbsoluteSeek -> offset
+             IO.RelativeSeek -> currentOffset + offset
+             IO.SeekFromEnd  -> (toEnum $ BS.length block) - offset
+        checkOverflow offset' (BS.length block)
+        writeTVar curOffsetVar offset'
+        return offset'
+  where
+    checkOverflow :: DiskOffset -> Int -> ExceptT FsError (Tr m) ()
+    checkOverflow newOffset blockSize
+        | newOffset > toEnum blockSize = throwError $ FsReachedEOF fp callStack
+        | otherwise = return ()
+
+mockGet :: (HasCallStack, MonadSTM m)
+        => MockHandle m
+        -> Int
+        -> SimFSE m ByteString
+mockGet (MockHandle fp _mode offsetVar) bytesToRead = withMockFS $ \fs -> do
+    case index fp (getMockFS fs) of
+      Nothing -> throwError $ FsResourceDoesNotExist fp callStack
+      Just (FolderOnDisk _) -> throwError $ FsResourceInappropriateType fp callStack
+      Just (FileOnDisk block) -> do
+        offset <- readTVar offsetVar
+        let r = BS.take bytesToRead . BS.drop (fromEnum offset) $ block
+        writeTVar offsetVar (offset + toEnum bytesToRead)
+        return r
+
+touchFile :: HasCallStack => FsPath -> FsTree ByteString -> FsTree ByteString
+touchFile fp =
+    adjustIndex (init fp) $
+        \case (FolderOnDisk m) -> newFile m
+              _                ->
+                  error $ "touchFile: found a file, not a folder for fp " <> show fp
+  where
+    newFile m = FolderOnDisk $ M.insert (last fp) (FileOnDisk mempty) m
+
+replaceFileContent :: HasCallStack
+                   => FsPath
+                   -> ByteString
+                   -> FsTree ByteString
+                   -> FsTree ByteString
+replaceFileContent fp content =
+    adjustIndex fp $
+        \case (FileOnDisk _) -> FileOnDisk content
+              _              ->
+                  error $ "replaceFileContent: found a folder, not a file for fp " <> show fp
+
+mockPut :: MonadSTM m
+        => MockHandle m
+        -> Builder
+        -> SimFSE m Word64
+mockPut (MockHandle fp IO.ReadMode _) _ =
+    throwError $ FsIllegalOperation fp callStack
+mockPut (MockHandle fp _mode handleOffsetVar) builder = modifyMockFS $ \fs -> do
+    handleOffset <- readTVar handleOffsetVar
+    case index fp (getMockFS fs) of
+      Nothing -> throwError $ FsResourceDoesNotExist fp callStack
+      Just (FolderOnDisk _) -> throwError $ FsResourceInappropriateType fp callStack
+      Just (FileOnDisk block) -> do
+        let (unchanged, toModify) = BS.splitAt (fromEnum handleOffset) block
+            block' = unchanged <> toWrite <> BS.drop (BS.length toWrite) toModify
+        -- Update the offset
+        writeTVar handleOffsetVar (handleOffset + bytesWritten)
+        return ((fs { getMockFS =
+              replaceFileContent fp block' (getMockFS fs)
+          }), bytesWritten)
+  where
+    toWrite      = BL.toStrict . toLazyByteString $ builder
+    bytesWritten = toEnum $ BS.length toWrite
+
+mockPutBuffer :: MonadSTM m
+              => MockHandle m
+              -> Buffer (SimFSE m)
+              -> Builder
+              -> SimFSE m Word64
+mockPutBuffer hnd _buf builder = mockPut hnd builder
+
+mockTruncate :: MonadSTM m
+             => MockHandle m
+             -> Word64
+             -> SimFSE m ()
+mockTruncate (MockHandle fp _ _) sz = modifyMockFS $ \fs ->
+    case index fp (getMockFS fs) of
+      Nothing -> throwError $ FsResourceDoesNotExist fp callStack
+      Just (FolderOnDisk _) -> throwError $ FsResourceInappropriateType fp callStack
+      Just (FileOnDisk block) -> do
+        return ((fs { getMockFS =
+            replaceFileContent fp (BS.take (fromEnum sz) block) (getMockFS fs)
+          }), ())
+
+mockWithFile :: (MonadMask m, MonadSTM m)
+             => FsPath
+             -> IOMode
+             -> (MockHandle m -> SimFSE m r)
+             -> SimFSE m r
+mockWithFile fp ioMode = bracket (mockOpen fp ioMode) mockClose
+
+{------------------------------------------------------------------------------
+  Operations on directories
+------------------------------------------------------------------------------}
+
+mockCreateDirectoryIfMissing :: MonadSTM m
+                             => Bool
+                             -> FsPath
+                             -> SimFSE m ()
+mockCreateDirectoryIfMissing createParents path = modifyMockFS $ \fs -> do
+    return (fs {
+          getMockFS =
+              mockCreateDirectoryIfMissingInternal createParents
+                                                   path
+                                                   (getMockFS fs)
+      }, ())
+
+mockCreateDirectoryIfMissingInternal :: Bool
+                                     -> FsPath
+                                     -> FsTree a
+                                     -> FsTree a
+mockCreateDirectoryIfMissingInternal createParents path0 files
+  | createParents =
+      -- returns the parents paths, but not the empty list [].
+      -- >    inits ["a", "b", "c"]
+      -- > == [[], ["a"], ["a", "b"], ["a", "b", "c"]]
+      -- but we do want only the last 3 elements.
+      let parents = tail (L.inits path0)
+      in foldl (flip mockCreateDirectoryLenient) files parents
+  | otherwise     = mockCreateDirectoryLenient path0 files
+
+-- | Creates a directory and does not throw an error if it exists already.
+mockCreateDirectoryLenient :: HasCallStack
+                           => FsPath
+                           -> FsTree a
+                           -> FsTree a
+mockCreateDirectoryLenient fp =
+  adjustIndex (init fp) $
+      \case FolderOnDisk m -> newDir m
+            _ -> error $ "createDirectory: found file, not folder for fp " <> show fp
+  where
+    newDir m =
+        case M.lookup (last fp) m of
+             Nothing -> FolderOnDisk $ M.insert (last fp) (FolderOnDisk mempty) m
+             Just _ -> FolderOnDisk m
+
+mockCreateDirectoryStrict :: HasCallStack
+                          => FsPath
+                          -> FsTree a
+                          -> Maybe (FsTree a)
+mockCreateDirectoryStrict fp =
+  adjustIndexF (init fp) $
+      \case FolderOnDisk m -> newDir m
+            _ -> error $ "createDirectory: found file, not folder for fp " <> show fp
+  where
+    newDir :: Map String (FsTree a) -> Maybe (FsTree a)
+    newDir m =
+        case M.lookup (last fp) m of
+             Nothing -> Just $ FolderOnDisk $ M.insert (last fp) (FolderOnDisk mempty) m
+             Just _  -> Nothing
+
+mockCreateDirectory :: (HasCallStack, MonadSTM m)
+                    => FsPath
+                    -> SimFSE m ()
+mockCreateDirectory dir = modifyMockFS $ \fs -> do
+    _parent <- noteT (FsResourceDoesNotExist dir callStack) $
+                   index (init dir) (getMockFS fs)
+    fs'     <- noteT (FsResourceAlreadyExist dir callStack) $
+                   mockCreateDirectoryStrict dir (getMockFS fs)
+    return (fs { getMockFS = fs' }, ())
+
+mockListDirectory :: (HasCallStack, MonadSTM m)
+                  => FsPath
+                  -> SimFSE m [String]
+mockListDirectory fp = withMockFS $ \fs -> do
+    case index fp (getMockFS fs) of
+      Nothing -> throwError (FsResourceDoesNotExist fp callStack)
+      Just (FileOnDisk _)   -> throwError (FsResourceInappropriateType fp callStack)
+      Just (FolderOnDisk m) -> return (M.keys m)
+
+mockDoesDirectoryExist :: MonadSTM m
+                       => FsPath
+                       -> SimFSE m Bool
+mockDoesDirectoryExist fp = withMockFS $ \fs ->
+    return $ case index fp (getMockFS fs) of
+               Just (FolderOnDisk _) -> True
+               _                     -> False
+
+mockDoesFileExist :: MonadSTM m
+                  => FsPath
+                  -> SimFSE m Bool
+mockDoesFileExist fp = withMockFS $ \fs ->
+    return $ case index fp (getMockFS fs) of
+         Just (FileOnDisk _) -> True
+         _                   -> False
+
+newBufferMock :: Monad m => Int -> SimFSE m (Buffer (SimFSE m))
+newBufferMock len = do
+    let buf = BS.pack $ replicate len 0x0
+    return $! BufferMock buf
+
+
+{-------------------------------------------------------------------------------
+  Auxiliary and utility functions
+-------------------------------------------------------------------------------}
+
+noteT :: MonadError e m => e -> Maybe a -> m a
+noteT e = maybe (throwError e) return
+
+-- | Index the FsTree by the given FsPath.
+index :: FsPath -> FsTree a -> Maybe (FsTree a)
+index [] t                    = Just t
+index (_:_)  (FileOnDisk _)   = Nothing
+index (p:ps) (FolderOnDisk m) = M.lookup p m >>= index ps
+
+-- | Traverses a 'FsTree' indexing by the given 'FsPath' and, if a match is
+-- found, apply the input action on the tree node.
+adjustIndex :: FsPath
+           -> (FsTree a -> FsTree a)
+           -> FsTree a
+           -> FsTree a
+adjustIndex p f = runIdentity . adjustIndexF p (Identity . f)
+
+-- | General version of 'adjustIndex' parametric over an applicative functor f.
+adjustIndexF :: Applicative f
+             => FsPath
+             -> (FsTree a -> f (FsTree a))
+             -> FsTree a
+             -> f (FsTree a)
+adjustIndexF [] f t = f t
+adjustIndexF (_:_) _ (FileOnDisk _)    = error "adjustIndexF: couldn't apply the function."
+adjustIndexF (p:ps) f (FolderOnDisk m) =
+    let m' = M.alterF (\x -> case x of
+                         Nothing -> pure Nothing
+                         Just ts -> Just <$> adjustIndexF ps f ts
+                     ) p m
+    in FolderOnDisk <$> m'
+
+-- | Renders the 'MockFS' in a human-readable fashion.
+prettyShowFS :: MockFS -> String
+prettyShowFS MockFS{..} =
+    let prettyDisk =
+            map (\(fp, disk) -> "- " <> fp
+                                     <> " -> "
+                                     <> show (hexDump $ B16.encode disk)
+                                     <> " (" <> show disk <> ")")
+                (collectFiles getMockFS)
+    in L.intercalate "\n" prettyDisk <> "\n\n" <> show getMockFS
+    where
+        collectFiles :: FsTree ByteString -> [(String, ByteString)]
+        collectFiles (FileOnDisk _)   = []
+        collectFiles (FolderOnDisk m) =
+            foldl' (\acc x -> case x of
+                   (fn, FileOnDisk c) -> (fn, c) : acc
+                   (_, dir)           -> acc <> collectFiles dir
+            ) [] (M.toList m)
+
+        hexDump :: ByteString -> ByteString
+        hexDump = fst
+                . BS.foldl' (\(acc, n) w8 ->
+                                if n == 2 then (acc <> " " <> BS.singleton w8, 1)
+                                          else (acc <> BS.singleton w8, n + 1)
+                            ) (mempty, 0 :: Int)
+
+
+demoMockFS :: MockFS
+demoMockFS = MockFS {
+    getMockFS = FolderOnDisk $ M.fromList [
+        ("usr", FolderOnDisk $ M.fromList [
+            ("local", FolderOnDisk $ M.fromList [
+                ("bin", FolderOnDisk mempty)
+            ])
+        ])
+      , ("var", FolderOnDisk $ M.fromList [
+           ("log", FolderOnDisk mempty)
+        ,  ("tmp", FolderOnDisk $ M.fromList [
+             ("foo.txt", FileOnDisk mempty)
+           ])
+        ,  ("mail", FolderOnDisk mempty)
+        ,  ("run", FolderOnDisk mempty)
+      ])
+    ]
+    }
+
+newEmptyMockFS :: MockFS
+newEmptyMockFS = MockFS {
+    getMockFS = FolderOnDisk mempty
+  }
+
+{-- This is a good foundation for a AST which can be used by a DSL to generate
+    scripts.
+data SimFsAction m =
+    SimOpen                     FsPath IOMode
+  | SimClose                    (MockHandle m)
+  | SimSeek                     FsPath SeekMode DiskOffset
+  | SimGet                      FsPath Int
+  | SimPut                      FsPath ByteString
+  | SimTruncate                 FsPath Word64
+  | SimListDirectory            FsPath
+  | SimCreateDirectory          FsPath
+  | SimCreateDirectoryIfMissing FsPath Bool
+  deriving Show
+--}
+
+-- | Runs a 'SimFs' computation provided an initial 'MockFS', producing a
+-- result, the final state of the filesystem and a sequence of actions occurred
+-- in the filesystem.
+runSimFS :: MonadSTM m
+         => SimFS m a
+         -> MockFS
+         -> m (a, MockFS)
+runSimFS m s = do
+    fs  <- atomically (newTVar s)
+    a   <- runReaderT (unSimFs m) fs
+    fs' <- atomically (readTVar fs)
+    return (a, fs')
+
+mockDemoScript :: (HasCallStack, HasFS m) => m [ByteString]
+mockDemoScript = do
+  h1 <- hOpen ["cardano.txt"] IO.ReadWriteMode
+  _  <- hPut h1 (BS.byteString $ C8.pack "test")
+  _  <- hSeek h1 IO.AbsoluteSeek 0
+  r1 <- hGet h1 4
+  _  <- hPut h1 (BS.byteString $ C8.pack "ing")
+  h2 <- hOpen ["bar.txt"] IO.ReadWriteMode
+  _  <- hPut h2 (BS.byteString $ C8.pack "blockchain")
+  _  <- hSeek h2 IO.AbsoluteSeek 0
+  r2 <- hGet h2 5
+  _  <- listDirectory []
+  _  <- listDirectory ["var"]
+  createDirectory ["var", "tmp", "my-temp-dir"]
+  createDirectoryIfMissing True ["home", "adinapoli", "test", "foo", "bar"]
+  f1 <- L.sort <$> listDirectory ["var", "tmp"]
+  hClose h1
+  hClose h2
+  checkThat "listDirectory [var, tmp]" ((==) (L.sort ["my-temp-dir", "foo.txt"])) f1
+  checkThat "hGet h1 4" ((==) "test") r1
+  checkThat "hGet h2 5" ((==) "block") r2
+  return [r1, r2]
+
+-- | A homemade version of 'assert' suitable for testing code which won't be
+-- run in production, as unlike 'assert' this is always run regardless of the
+-- optimise flag used.
+checkThat :: (Show a, Monad m)
+          => String
+          -> (a -> Bool)
+          -> a
+          -> m ()
+checkThat label prd a =
+    if prd a then return ()
+             else error $ label
+                        ++ ": condition didn't hold. Actual value was "
+                        ++ show a
+                        ++ "\n"
+                        ++ prettyCallStack callStack
+
+mockDemo :: IO ()
+mockDemo = do
+    (res, fs) <- runSimFS (runExceptT demo) demoMockFS
+    case res of
+      Left  err -> putStrLn (prettyFSError err)
+      Right bs  -> putStrLn (prettyShowFS fs) >> print bs
+  where
+    demo :: ExceptT FsError (SimFS IO) [ByteString]
+    demo = mockDemoScript

--- a/src/Ouroboros/Storage/Immutable/DB.hs
+++ b/src/Ouroboros/Storage/Immutable/DB.hs
@@ -1,0 +1,410 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TupleSections              #-}
+
+{-- |
+
+A very simple and hopefully efficient implementation of the immutable
+on-disk storage, also suitable as reference implementation for more
+sophisticated ones.
+
+--}
+
+module Ouroboros.Storage.Immutable.DB (
+    ImmutableDB -- opaque
+  , RelativeSlot(..)
+  , ImmutableDBError(..)
+  , sameDBError
+  , withDB
+  , getBinaryBlob
+  , appendBinaryBlob
+  -- * Utility functions
+  , liftFsError
+  -- * Pretty-printing things
+  , prettyImmutableDBError
+  ) where
+
+import           Control.Monad
+import           Control.Monad.Catch
+import           Control.Monad.Except
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Builder as BS
+import qualified Data.Text as T
+import           Data.Word
+import           Text.Printf
+import           Text.Read (readMaybe)
+
+import           GHC.Stack
+
+import           Ouroboros.Storage.FS.Class
+import           Ouroboros.Storage.Util as I
+
+import           Ouroboros.Network.MonadClass
+
+
+{-- | Our database is structured on disk this way:
+
+db /
+  epoch-001.dat
+  index-001.dat
+  ..
+  epoch-008.dat
+  index-008.dat
+  ..
+
+The key idea is to have, for each epoch, two files on disk:
+  * An \"epoch file\" is where the data is actually stored;
+  * An \"index file\" used to efficiently seek within the epoch file for the
+    relevant data.
+--}
+
+-- This is just a placeholder as we don't have (yet) a proper 'Epoch' type in
+-- this codebase.
+type Epoch = Word
+
+-- | A /relative/ 'Slot' within an Epoch.
+newtype RelativeSlot = RelativeSlot { getRelativeSlot :: Word }
+                       deriving (Eq, Num, Show)
+
+{------------------------------------------------------------------------------
+  Main types
+------------------------------------------------------------------------------}
+
+data InternalState m = InternalState {
+      _currentEpoch                    :: !Epoch
+    -- ^ The current 'Epoch' the immutable store is writing into.
+    , _currentEpochWriteHandle         :: !(FsHandleE m)
+    -- ^ The 'WriteHandle' for the current epoch file.
+    , _currentIndexWriteHandle         :: !(FsHandleE m)
+    -- ^ The 'WriteHandle' for the current index file.
+    , _currentLastIndexOffset          :: !Word64
+    -- ^ It keeps around the last offset stored within the index file,
+    -- so that we don't have to seek for it when we append.
+    , _currentNextExpectedRelativeSlot :: !RelativeSlot
+    -- ^ The next relative slot we expect to see to append data to the epoch file.
+    -- Invariant: we can't append new data passing as input a slot less than
+    -- the expected one.
+    }
+
+
+liftFsError :: Functor m => ExceptT FsError m a -> ExceptT ImmutableDBError m a
+liftFsError = withExceptT FileSystemError
+
+mkInternalState :: forall m. (HasCallStack, MonadCatch m, HasFSE m)
+                => FsPath
+                -> Epoch
+                -> ExceptT ImmutableDBError m (InternalState m)
+mkInternalState dbFolder epoch = do
+    let epochFile = dbFolder <> renderFile "epoch" epoch
+    let indexFile = dbFolder <> renderFile "index" epoch
+    eHnd <- liftFsError (hOpen epochFile AppendMode)
+    iHnd <- liftFsError (do
+                h <- hOpen indexFile AppendMode
+                isNewFile <- ((==) 0) <$> hSeek h RelativeSeek 0
+                -- Initialise the new index file properly, if needed.
+                when isNewFile $ void (hPut h (I.encodeIndexEntry 0))
+                return h
+            )
+    return $ InternalState epoch eHnd iHnd 0 (RelativeSlot 0)
+
+
+-- | An opaque handle to an immutable database of binary blobs.
+data ImmutableDB m = ImmutableDB {
+      _dbInternalState :: !(TMVar m (InternalState m))
+    , _dbFolder        :: !FsPath
+    }
+
+
+{------------------------------------------------------------------------------
+  API
+------------------------------------------------------------------------------}
+
+-- | Errors which might arise when working with this database.
+data ImmutableDBError =
+    FileSystemError FsError
+  | EpochIsReadOnlyError Epoch Epoch CallStack
+  -- ^ When opening the DB, the user requested access to an epoch which was
+  -- already finalised, i.e. not writable anymore.
+  | InconsistentSlotError RelativeSlot RelativeSlot CallStack
+  -- ^ When trying to append a new binary blob at the end of an epoch file,
+  -- the input slot was not monotonically increasing with reference to the last
+  -- performed on that epoch file.
+  | SlotDoesNotExistError (Epoch, RelativeSlot) (Epoch, RelativeSlot) CallStack
+  -- ^ When trying to read from the given 'Epoch' the input 'RelativeSlot'
+  -- was not there, either because it's too far in the future or because is
+  -- in the process of being written.
+  deriving Show
+
+-- | Check two 'ImmutableDBError for shallow equality, i.e. if they have the same
+-- type constructor, ignoring the 'CallStack'.
+sameDBError :: ImmutableDBError -> ImmutableDBError -> Bool
+sameDBError e1 e2 = case (e1, e2) of
+    (FileSystemError fs1, FileSystemError fs2) -> sameFsError fs1 fs2
+    (FileSystemError _, _) -> False
+    (EpochIsReadOnlyError ep1 ep2 _, EpochIsReadOnlyError ep3 ep4 _) ->
+        ep1 == ep3 && ep2 == ep4
+    (EpochIsReadOnlyError _ _ _, _) -> False
+    (InconsistentSlotError s1 s2 _, InconsistentSlotError s3 s4 _) ->
+        s1 == s3 && s2 == s4
+    (InconsistentSlotError _ _ _, _) -> False
+    (SlotDoesNotExistError expected actual _, SlotDoesNotExistError exp2 act2 _) ->
+        expected == exp2 && actual == act2
+    (SlotDoesNotExistError _ _ _, _) -> False
+
+prettyImmutableDBError :: ImmutableDBError -> String
+prettyImmutableDBError = \case
+    FileSystemError fs   -> prettyFSError fs
+    EpochIsReadOnlyError e1 e2 cs ->
+           "EpochIsReadOnlyError (input epoch was "
+        <> show e1
+        <> ", most recent epoch found: " <> show e2 <>"): "
+        <> prettyCallStack cs
+    InconsistentSlotError (RelativeSlot is) (RelativeSlot es) cs   ->
+           "InconsistentSlotError (input epoch was "
+        <> show is
+        <> ", expected was "
+        <> show es
+        <> "): "
+        <> prettyCallStack cs
+    SlotDoesNotExistError current requested cs   ->
+           "SlotDoesNotExistError (current is "
+        <> show current
+        <> ", requested was "
+        <> show requested
+        <> "): "
+        <> prettyCallStack cs
+
+renderFile :: String -> Epoch -> FsPath
+renderFile fileType epoch = [printf "%s-%03d.dat" fileType epoch]
+
+withDB :: (HasCallStack, MonadSTM m, MonadMask m, HasFSE m)
+       => FsPath
+       -> Epoch
+       -> (ImmutableDB m -> m (Either ImmutableDBError a))
+       -> m (Either ImmutableDBError a)
+withDB fsPath epoch action = runExceptT $
+    bracket (openDB fsPath epoch) closeDB (ExceptT . action)
+
+-- | Opens the database, creating it from scratch if the 'FilePath' points to
+-- a non-existing directory. Internally it preloads the most recent 'Epoch'.
+openDB :: (HasCallStack, MonadCatch m, MonadSTM m, HasFSE m)
+       => FsPath
+       -> Epoch
+       -> ExceptT ImmutableDBError m (ImmutableDB m)
+openDB fp currentEpoch = do
+      allFiles <- liftFsError $ do
+          createDirectoryIfMissing True fp
+          listDirectory fp
+      checkEpochConsistency allFiles
+      st    <- mkInternalState fp currentEpoch
+      stVar <- atomically $ newTMVar st
+      return $ ImmutableDB stVar fp
+  where
+      checkEpochConsistency :: (HasCallStack, MonadError ImmutableDBError m)
+                            => [String]
+                            -> m ()
+      checkEpochConsistency [] = return ()
+      checkEpochConsistency (x:xs) =
+          case parseEpochNumber x of
+               Nothing -> checkEpochConsistency xs
+               Just n  -> if n > currentEpoch
+                             then throwError (EpochIsReadOnlyError currentEpoch n callStack)
+                             else checkEpochConsistency xs
+
+      parseEpochNumber :: String -> Maybe Epoch
+      parseEpochNumber = readMaybe
+                       . T.unpack
+                       . snd
+                       . T.breakOnEnd "-"
+                       . fst
+                       . T.breakOn "."
+                       . T.pack
+
+
+-- | Closes the database, also closing any handle which have been opened in
+-- the process.
+closeDB :: (MonadSTM m, MonadMask m, HasFSE m)
+        => ImmutableDB m -> ExceptT ImmutableDBError m ()
+closeDB ImmutableDB{..} = do
+    InternalState{..} <- atomically (takeTMVar _dbInternalState)
+    liftFsError $ do
+      hClose _currentEpochWriteHandle `finally` hClose _currentIndexWriteHandle
+
+{------------------------------------------------------------------------------
+  Low-level API
+------------------------------------------------------------------------------}
+
+
+-- | The analogue of `modifyMVar`
+--
+-- NOTE: This /takes/ the 'TMVar', _then_ runs the action (which might be in `IO`),
+-- and then puts the 'TMVar' back, just like 'modifyMVar' does. Consequently,
+-- it has the same gotchas that 'modifyMVar' does; the effects are observable
+-- and it is susceptible to deadlock.
+--
+-- TODO: By rights we should really just use 'MVar' rather than TMVar',
+-- but we currently don't have a simular for code using 'MVar'.
+-- NOTE: Use of `generalBracket` (rather than the `mask ... restore` pattern
+-- of old) is essential to make sure that this still behaves correctly in monad
+-- stacks containing `ExceptT`.
+modifyTMVar :: (MonadSTM m, MonadMask m)
+            => TMVar m a
+            -> (a -> m (a,b))
+            -> m b
+modifyTMVar m action =
+  snd . fst <$> generalBracket (atomically $ takeTMVar m)
+                   (\oldState ec -> atomically $ case ec of
+                        ExitCaseSuccess (newState,_) -> putTMVar m newState
+                        ExitCaseException _ex        -> putTMVar m oldState
+                        ExitCaseAbort                -> putTMVar m oldState
+                   ) action
+
+modifyInternalState :: (MonadMask m, HasFSE m, MonadSTM m)
+                    => ImmutableDB m
+                    -> Epoch
+                    -> (InternalState m -> ExceptT ImmutableDBError m (InternalState m, a))
+                    -> ExceptT ImmutableDBError m a
+modifyInternalState db newEpoch action = do
+    modifyTMVar (_dbInternalState db) $ \oldState -> do
+        case _currentEpoch oldState < newEpoch of
+            True -> do
+                ns <- mkInternalState (_dbFolder db) newEpoch
+                liftFsError $ do
+                  hClose (_currentIndexWriteHandle oldState)
+                  `finally`
+                  hClose (_currentEpochWriteHandle oldState)
+                action ns
+            False -> action oldState
+
+getBinaryBlob :: forall m. (HasFSE m, MonadSTM m)
+              => ImmutableDB m
+              -> (Epoch, RelativeSlot)
+              -> m (Either ImmutableDBError ByteString)
+getBinaryBlob ImmutableDB{..} (epoch, RelativeSlot relativeSlot) = do
+    InternalState{..} <- atomically (readTMVar _dbInternalState)
+
+    -- Check whether or not the requested slot can be accessed.
+    withSlotGuard _currentEpoch _currentNextExpectedRelativeSlot $ do
+        runExceptT $ liftFsError $ do
+            withFile (_dbFolder <> renderFile "epoch" epoch) ReadMode $ \eHnd ->
+                withFile (_dbFolder <> renderFile "index" epoch) ReadMode $ \iHnd -> do
+                    -- Step 1: grab the offset in bytes of the requested slot.
+                    let indexSeekPosition = fromEnum relativeSlot * indexEntrySizeBytes
+                    _ <- hSeek iHnd AbsoluteSeek (toEnum indexSeekPosition)
+
+                    -- Step 1: computes the offset on disk and the blob size.
+                    (blobOffset, !blobSize) <- do
+                        bytes <- hGet iHnd (indexEntrySizeBytes * 2)
+                        let !start = decodeIndexEntry   bytes
+                        let !end   = decodeIndexEntryAt indexEntrySizeBytes bytes
+                        return (start, end - start)
+
+                    -- Step 2: Seek in the epoch file
+                    _ <- hSeek eHnd AbsoluteSeek blobOffset
+                    hGet eHnd (fromEnum blobSize)
+  where
+    -- Checks that the slot we are trying to access is valid.
+    withSlotGuard :: Epoch
+                  -> RelativeSlot
+                  -> m (Either ImmutableDBError a)
+                  -> m (Either ImmutableDBError a)
+    withSlotGuard currentEpoch (RelativeSlot nextExpectedSlot) action
+      | epoch > currentEpoch || relativeSlot >= nextExpectedSlot =
+          return $ Left
+                 $ SlotDoesNotExistError (currentEpoch, RelativeSlot nextExpectedSlot)
+                                         (epoch, RelativeSlot relativeSlot)
+                                         callStack
+      | otherwise = action
+
+
+-- | The size of each entry in the index file, namely 8 bytes for the offset
+-- (represented as a Word64).
+indexEntrySizeBytes :: Int
+indexEntrySizeBytes = 8
+{-# INLINE indexEntrySizeBytes #-}
+
+
+-- | Appends a binary blob at the end of the epoch file relative to the input
+-- 'Slot', updating its index file accordingly.
+appendBinaryBlob :: (HasCallStack, HasFSE m, MonadSTM m, MonadMask m)
+                 => ImmutableDB m
+                 -> (Epoch, RelativeSlot)
+                 -> BS.Builder
+                 -> m (Either ImmutableDBError ())
+appendBinaryBlob db (epoch, relativeSlot) builder = runExceptT $ do
+    modifyInternalState db epoch $ \st@InternalState{..} -> do
+        let eHnd = _currentEpochWriteHandle
+        let iHnd = _currentIndexWriteHandle
+
+        -- Step 0: Check the consistency of the slot being written and, if
+        -- necessary, backfill the index file for any slot we missed.
+        checkSlotConsistency relativeSlot _currentNextExpectedRelativeSlot
+        let (gap, backfill) = indexBackfill relativeSlot
+                                            _currentNextExpectedRelativeSlot
+                                            _currentLastIndexOffset
+        liftFsError $ do
+            if gap /= 0
+               then void $ hPut iHnd backfill
+               else return ()
+
+            -- Step 1: Append to the end of the epoch file
+            bytesWritten <- hPut eHnd builder
+
+            -- Step 2: Update the index file
+            let newOffset = _currentLastIndexOffset + bytesWritten
+
+            void $ hPut iHnd (I.encodeIndexEntry newOffset)
+
+            return $ (st { _currentLastIndexOffset          = newOffset
+                        , _currentNextExpectedRelativeSlot = relativeSlot + 1
+                        }, ())
+
+-- Enforce that the input slot we receive during a new append operation is
+-- greater or equal to the next expected one.
+checkSlotConsistency :: (MonadError ImmutableDBError m, HasCallStack)
+                     => RelativeSlot
+                     -> RelativeSlot
+                     -> m ()
+checkSlotConsistency cs@(RelativeSlot currentSlot) es@(RelativeSlot expectedNext) =
+    when (currentSlot < expectedNext) $
+       throwError $ InconsistentSlotError cs es callStack
+
+-- | Backfills the index file. Such situation may arise in case we \"skip\"
+-- some slots, and we write into the DB, say, for example, every other slot.
+-- In this case, we do need to backfill the index file to take into account
+-- all the missed slot. The question is: backfill with what? The easiest choice
+-- is to backfill with the last seen offset, so that when getting data out of
+-- the DB, the difference between these two offset is 0, signalling there is
+-- no data to be fetched for that slot.
+-- There are edge cases, however. First of all, we need to store inside the
+-- 'InternalState' the \"last absolute slot seen\", because we need to check it
+-- against the input one to determine whether or not we missed a slot.
+-- However, the \"last absolute slot seen\" must be
+-- a 'Maybe', because any other default value (like 0 for example) would be
+-- incorrect. But this poses another problem:
+-- Suppose we never wrote into this epoch file yet, and the user decides to
+-- write in relative slot 3. Now we have a problem: we do not have any previously
+-- stored slot, yet we do need to backfill, because we missed 0 1 and 2. This
+-- complicates a bit the logic as we have to handle this case separately.
+-- Returns the size of the \"gap\" alongise the (potentially empty) 'Builder'
+-- to write.
+indexBackfill :: RelativeSlot
+              -> RelativeSlot
+              -> Word64
+              -> (Int, BS.Builder)
+indexBackfill (RelativeSlot relativeSlot) (RelativeSlot nextExpected) lastOffset
+    -- If we missed slot 0 and we are starting some slot ahead, we do need
+    -- to backfill
+    | nextExpected == 0 && relativeSlot /= 0  =
+        let gap = fromEnum relativeSlot
+        in (gap, mconcat (replicate gap (I.encodeIndexEntry lastOffset)))
+    | otherwise =
+        let gap     = fromEnum $ relativeSlot - nextExpected
+            builder = mconcat  $ replicate gap (I.encodeIndexEntry lastOffset)
+        in (gap, builder)

--- a/src/Ouroboros/Storage/Util.hs
+++ b/src/Ouroboros/Storage/Util.hs
@@ -1,0 +1,49 @@
+module Ouroboros.Storage.Util (
+    encodeIndexEntry
+  , decodeIndexEntry
+  , decodeIndexEntryAt
+  ) where
+
+import           Control.Exception (assert)
+
+import           Data.Bits
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Unsafe as BS
+import           Data.Word
+
+-- | Encodes each index entry into a fixed-size sequence of bytes. In particular,
+-- the first parameter is an 'Integer' representing the offset within the epoch
+-- file. However, using a single 'Word32' is enough to represents up to 4GB
+-- epoch files on disk, which is more than enough to be safe during the loss
+-- of precision deriving from the cast \"Integer -> Word32\".
+encodeIndexEntry :: Word64
+                 -- ^ The current offset within the epoch file.
+                 -> BS.Builder
+encodeIndexEntry = BS.word64BE
+
+-- | Decodes the entry of an index file.
+-- Precondition: the input 'ByteString' @must be@ 8 bytes long.
+decodeIndexEntry :: BS.ByteString
+                 -- ^ A binary blob
+                 -> Word64
+decodeIndexEntry = readWord64BE 0
+
+decodeIndexEntryAt :: Int
+                   -- ^ Start reading from the given index
+                   -> BS.ByteString
+                   -- ^ A binary blob
+                   -> Word64
+decodeIndexEntryAt = readWord64BE
+
+readWord64BE :: Int -> BS.ByteString -> Word64
+readWord64BE i bs =
+    assert (i >= 0 && i+7 <= BS.length bs - 1) $
+    fromIntegral (BS.unsafeIndex bs (i + 0)) `shiftL` 56
+  + fromIntegral (BS.unsafeIndex bs (i + 1)) `shiftL` 48
+  + fromIntegral (BS.unsafeIndex bs (i + 2)) `shiftL` 40
+  + fromIntegral (BS.unsafeIndex bs (i + 3)) `shiftL` 32
+  + fromIntegral (BS.unsafeIndex bs (i + 4)) `shiftL` 24
+  + fromIntegral (BS.unsafeIndex bs (i + 5)) `shiftL` 16
+  + fromIntegral (BS.unsafeIndex bs (i + 6)) `shiftL` 8
+  + fromIntegral (BS.unsafeIndex bs (i + 7))

--- a/test-storage/Main.hs
+++ b/test-storage/Main.hs
@@ -1,0 +1,14 @@
+module Main (main) where
+
+import           Test.Tasty
+
+import qualified Test.Ouroboros.Storage (tests)
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests =
+  testGroup "ouroboros-storage"
+  [ Test.Ouroboros.Storage.tests
+  ]

--- a/test-storage/Test/Ouroboros/Storage.hs
+++ b/test-storage/Test/Ouroboros/Storage.hs
@@ -1,0 +1,434 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Test.Ouroboros.Storage
+  ( tests
+  ) where
+
+import           Control.Monad.Catch (MonadMask)
+import           Control.Monad.Except
+import qualified Data.ByteString.Builder as BL
+import qualified Data.ByteString.Builder.Extra as BL
+import qualified Data.ByteString.Lazy.Char8 as C8
+import           Data.Either (isRight)
+import           Data.List (sort)
+import qualified Data.Map.Strict as M
+import           Data.Maybe (isJust)
+import           System.IO.Temp
+
+import qualified System.Directory as Dir
+
+import           Test.Ouroboros.Storage.Immutable.Sim (demoScript)
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Ouroboros.Network.MonadClass
+import           Ouroboros.Storage.FS.Class
+import           Ouroboros.Storage.FS.IO (runIOFS)
+import           Ouroboros.Storage.FS.Sim
+import           Ouroboros.Storage.Immutable.DB
+
+--
+-- The list of all tests
+--
+
+tests :: HasCallStack => TestTree
+tests = testGroup "Storage"
+  [ testGroup "HasFS"
+    [ testCase     "touchFile works" test_touchFile
+    , testCase     "createDirectory works" test_createDirectory
+    , testCase     "listDirectory works" test_listDirectory
+      -- hOpen
+    , testCase     "hOpen on an existent folder succeeds"  test_hOpenDoesExist
+    , testCase     "hOpen on an non-existent folder fails" test_hOpenDoesNotExist
+    , testProperty "hOpen(Sim) == hOpen(IO)"     $ prop_hOpenEquivalence
+    , testProperty "hOpen read contention"       $ prop_hOpenReadContention
+    , testProperty "hOpen read/write contention" $ prop_hOpenReadWriteContention
+    , testProperty "hOpen on directories fails"  $ prop_hOpenDirectory
+      -- hClose
+    , testCase     "hClose twice no-op "  $ test_hCloseTwice
+    , testProperty "hClose twice no-op equivalence"  $ prop_hCloseTwiceEquivalence
+      -- hPut
+    , testProperty "hPut equivalence"  $ prop_hPutEquivalence
+      -- hPutBuffer
+    , testProperty "hPutBuffer chunk boundaries"  $ prop_hPutBufferBoundaries
+      -- hGet
+    , testProperty "hGet equivalence"  $ prop_hGetEquivalence
+      -- hTruncate
+    , testProperty "hTruncate equivalence"  $ prop_hTruncateEquivalence
+      -- doesFileExist
+    , testCase "doesFileExist yields True  for an existing file" $ test_doesFileExistOK
+    , testCase "doesFileExist yields False for a non-existing file" $ test_doesFileExistKO
+      -- doesDirectoryExist
+    , testCase "doesDirectoryExist yields True  for an existing directory" $ test_doesDirectoryExistOK
+    , testCase "doesDirectoryExist yields False for a non-existing directory" $ test_doesDirectoryExistKO
+      -- mockDemo
+    , testProperty "mockDemo equivalence"        $ prop_mockDemo
+    ]
+  , testGroup "Immutable Storage"
+    [ testCase "What you store is what you get" test_appendAndGet
+    , testProperty "append/get roundtrip" prop_appendAndGetRoundtrip
+    , testProperty "Inconsistent slot error equivalence" prop_inconsistentSlotErrorEquivalence
+    , testProperty "Epoch is read only error equivalence" prop_epochIsReadOnlyErrorEquivalence
+    , testProperty "Read from invalid epoch error equivalence" prop_slotDoesNotExistErrorEquivalence
+      -- demoScript
+    , testProperty "demoScript equivalence" prop_demoSimEquivalence
+    ]
+  , testGroup "Volatile Storage"
+    [ ]
+  ]
+
+{------------------------------------------------------------------------------
+ Handy combinators
+-------------------------------------------------------------------------------}
+
+withMockFS :: MonadSTM m
+           => SimFS m (Either e a)
+           -> ((Either e a, MockFS) -> m b)
+           -> m b
+withMockFS sim assertion = do
+    r <- runSimFS sim newEmptyMockFS
+    assertion r
+
+withMockFSE :: MonadSTM m
+            => SimFS m (Either FsError a)
+            -> ((Either FsError a, MockFS) -> m b)
+            -> m b
+withMockFSE = withMockFS
+
+expectError :: (HasCallStack, Show a)
+            => (FsError -> Bool)
+            -> Either FsError a
+            -> String
+            -> Assertion
+expectError errPred r lbl =
+    case r of
+         Right x -> fail ("Return value " <> show x <> " was not an error.")
+         Left  e -> assertEqual (prettyMsg e) True (errPred e)
+    where
+        prettyMsg :: FsError -> String
+        prettyMsg err =
+            lbl <> ": error type was "
+                <> prettyFSError err
+                <> ", which is not what I was expecting."
+
+-- | Given a \"script\", runs it over a simulated FS and over IO (using a
+-- temporary, throw-away folder) and compare the results.
+apiEquivalence :: (HasCallStack, Eq a)
+               => (forall m. (MonadMask m, MonadSTM m, HasCallStack, HasFSE m) => m (Either b a))
+               -> (b -> b -> Bool)
+               -> (b -> String)
+               -> Assertion
+apiEquivalence m cmpError prettyError = do
+    sysTmpDir <- Dir.getTemporaryDirectory
+    withTempDirectory sysTmpDir "cardano." $ \tmpDir -> do
+        (r1, fs') <- runSimFS m newEmptyMockFS
+        r2 <- runIOFS m tmpDir
+        case (r1, r2) of
+            (Left e1, Left e2) ->
+                assertBool ("SimFS & IO didn't agree on the API. "
+                           <> "The implementation differs.\n\n"
+                           <> "Sim returned: " <> prettyError e1  <> "\n\n"
+                           <> "IO  returned: " <> prettyError e2  <> "\n\n")
+                           (e1 `cmpError` e2)
+            (Right x1, Right x2) ->
+                assertBool "SimFS & IO didn't yield the same result."
+                           (x1 == x2)
+            (Left e, Right _) ->
+                fail $ "SimFS returned "
+                    <> prettyError e
+                    <> ", but IO succeeded.\n\n"
+                    <> "Sim FS: " <> show fs' <> "\n\n"
+            (Right _, Left e) ->
+                fail $ "IO returned "
+                    <> prettyError e
+                    <> ", but SimFS succeeded.\n\n"
+                    <> "Sim FS: " <> show fs' <> "\n\n"
+
+{------------------------------------------------------------------------------
+ The tests proper
+-------------------------------------------------------------------------------}
+
+test_touchFile :: Assertion
+test_touchFile = do
+    touchFile ["foo.txt"] (FolderOnDisk mempty) @?=
+        (FolderOnDisk $ M.fromList [("foo.txt", FileOnDisk mempty)])
+    let action = touchFile ["demo", "bar.md"] . touchFile ["demo", "foo.txt"]
+    action (FolderOnDisk $ M.fromList [("demo", FolderOnDisk mempty)]) @?=
+        (FolderOnDisk $ M.fromList [
+            ("demo", FolderOnDisk $ M.fromList [
+              ("foo.txt", FileOnDisk mempty)
+            , ("bar.md", FileOnDisk mempty)
+            ]
+            )])
+
+test_createDirectory :: Assertion
+test_createDirectory = do
+    let action1 = createDirectory ["foo"]
+        result1 = FolderOnDisk $ M.fromList [("foo", FolderOnDisk mempty)]
+        action2 = createDirectoryIfMissing True ["demo", "foo"]
+        result2 = (FolderOnDisk $ M.fromList [
+                    ("demo", FolderOnDisk $ M.fromList [("foo", FolderOnDisk mempty)]
+                  )])
+    withMockFSE (runExceptT action1) $ \(_, fs1) -> getMockFS fs1 @?= result1
+    withMockFSE (runExceptT action2) $ \(_, fs2) -> getMockFS fs2 @?= result2
+
+test_listDirectory :: Assertion
+test_listDirectory = do
+    let script = runExceptT $ do
+             createDirectory ["foo"]
+             withFile ["foo", "foo.txt"] WriteMode $ \_ -> return ()
+             withFile ["foo", "bar.txt"] WriteMode $ \_ -> return ()
+             withFile ["foo", "quux.md"] WriteMode $ \_ -> return ()
+             listDirectory ["foo"]
+    withMockFSE script $ \(r, _) ->
+        case r of
+             Left e     -> fail (show e)
+             Right dirs -> sort dirs @?= sort ["foo.txt", "bar.txt", "quux.md"]
+
+--
+-- hOpen tests
+--
+
+test_hOpenDoesExist :: Assertion
+test_hOpenDoesExist =
+    withMockFSE (runExceptT $ hOpen ["foo.txt"] WriteMode) $ \(r, fs) -> do
+    assertBool "hOpen failed" (isRight r)
+    -- The file must have been created
+    assertBool "file not in the mock FS" $
+        isJust (index ["foo.txt"] (getMockFS fs))
+
+test_hOpenDoesNotExist :: Assertion
+test_hOpenDoesNotExist =
+    withMockFS (runExceptT $ hOpen ["test", "foo.txt"] WriteMode) $ \(r, _) ->
+    expectError isResourceDoesNotExistError r "return type was not FsResourceDoesNotExist"
+
+prop_hOpenEquivalence :: Property
+prop_hOpenEquivalence = monadicIO $ do
+    ioMode   <- pick $ elements [ReadMode, AppendMode, ReadWriteMode]
+    run $ apiEquivalence (runExceptT $ do
+                             h <- hOpen ["foo.txt"] ioMode
+                             hClose h
+                         ) sameFsError prettyFSError
+
+-- Opening two read handles on the same file should be allowed in both
+-- implementations.
+prop_hOpenReadContention :: Property
+prop_hOpenReadContention = monadicIO $ do
+    run $ apiEquivalence (runExceptT $ do
+                             h1 <- hOpen ["foo.txt"] ReadMode
+                             h2 <- hOpen ["foo.txt"] ReadMode
+                             hClose h1
+                             hClose h2
+                         ) sameFsError prettyFSError
+
+prop_hOpenReadWriteContention :: Property
+prop_hOpenReadWriteContention = monadicIO $ do
+    run $ apiEquivalence (runExceptT $ do
+                             h2 <- hOpen ["foo.txt"] WriteMode
+                             h1 <- hOpen ["foo.txt"] ReadMode
+                             hClose h1
+                             hClose h2
+                         ) sameFsError prettyFSError
+
+prop_hOpenDirectory :: Property
+prop_hOpenDirectory = monadicIO $ do
+    run $ apiEquivalence (runExceptT $ do
+                             createDirectoryIfMissing True ["foo"]
+                             h1 <- hOpen ["foo"] WriteMode
+                             hClose h1
+                         ) sameFsError prettyFSError
+
+prop_mockDemo :: Property
+prop_mockDemo = monadicIO $ run $
+    apiEquivalence (runExceptT $ do
+                       -- The mockDemoScript assumes the presence of some
+                       -- files and dirs.
+                       createDirectoryIfMissing True ["var", "tmp"]
+                       withFile ["var", "tmp", "foo.txt"] WriteMode $ \_ ->
+                          return ()
+                       mockDemoScript
+                   ) sameFsError prettyFSError
+
+--
+-- hClose tests
+--
+test_hCloseTwice :: Assertion
+test_hCloseTwice =
+    withMockFS (runExceptT $ do
+                  h1 <- hOpen ["foo.txt"] WriteMode
+                  hClose h1
+                  hClose h1
+               ) $ \(r, _) ->
+    case r of
+         Left e   -> fail $ prettyFSError e
+         Right () -> return ()
+
+prop_hCloseTwiceEquivalence :: Property
+prop_hCloseTwiceEquivalence = monadicIO $ do
+    run $ apiEquivalence (runExceptT $ do
+                             h1 <- hOpen ["test.txt"] WriteMode
+                             hClose h1
+                             hClose h1
+                         ) sameFsError prettyFSError
+
+prop_hPutEquivalence :: Property
+prop_hPutEquivalence = monadicIO $ do
+    run $ apiEquivalence (runExceptT $
+              withFile ["test.txt"] WriteMode $ \h1 ->
+                  hPut h1 (BL.lazyByteString $ C8.pack "haskell-is-nice")
+        ) sameFsError prettyFSError
+
+-- In this test purposefully create a very small buffer and we test that our
+-- 'bytesWritten' count is consistent across chunks boundaries.
+prop_hPutBufferBoundaries :: Property
+prop_hPutBufferBoundaries = monadicIO $ do
+    bufferSize <- pick $ choose (1, 64)
+    input      <- pick $ C8.pack <$> listOf1 (elements ['a' .. 'z'])
+    threshold  <- pick $ choose (1, 512)
+    run $ apiEquivalence (runExceptT $ do
+                             b  <- newBuffer bufferSize
+                             h1 <- hOpen ["test.txt"] WriteMode
+                             bytesWritten  <-
+                                 hPutBuffer h1 b (BL.lazyByteStringThreshold threshold input)
+                             _ <- hSeek h1 AbsoluteSeek 0
+                             r <- hGet h1 (fromIntegral $ C8.length input)
+                             hClose h1
+                             return ( fromIntegral bytesWritten == (C8.length input)
+                                    , bytesWritten
+                                    , r
+                                    , C8.toStrict input == r
+                                    )
+                         ) sameFsError prettyFSError
+
+prop_hGetEquivalence :: Property
+prop_hGetEquivalence = monadicIO $ do
+    run $ apiEquivalence (runExceptT $
+              withFile ["test.txt"] WriteMode $ \h1 -> do
+                  b  <- hPut h1 (BL.lazyByteString $ C8.pack "haskell-is-nice")
+                  _ <- hSeek h1 AbsoluteSeek 0
+                  r1 <- hGet h1 4
+                  r2 <- hGet h1 3
+                  _ <- hSeek h1 RelativeSeek 3
+                  r3 <- hGet h1 4
+                  return (b, [r1,r2,r3])
+        ) sameFsError prettyFSError
+
+prop_hTruncateEquivalence :: Property
+prop_hTruncateEquivalence = monadicIO $ do
+    run $ apiEquivalence (runExceptT $
+             withFile ["test.txt"] WriteMode $ \h1 -> do
+                 b  <- hPut h1 (BL.lazyByteString $ C8.pack "haskell-is-nice")
+                 _ <- hSeek h1 AbsoluteSeek 0
+                 r1 <- hGet h1 15
+                 hTruncate h1 7
+                 _ <- hSeek h1 AbsoluteSeek 0
+                 r2 <- hGet h1 7
+                 hClose h1
+                 return (b, [r1,r2])
+       ) sameFsError prettyFSError
+
+test_doesFileExistOK :: Assertion
+test_doesFileExistOK =
+    withMockFS (runExceptT $ do
+                  h1 <- hOpen ["foo.txt"] WriteMode
+                  hClose h1
+                  doesFileExist ["foo.txt"]
+               ) $ \(r, _) ->
+    case r of
+         Left e  -> fail $ prettyFSError e
+         Right b -> b @? "doesFileExist didn't work as expected"
+
+test_doesFileExistKO :: Assertion
+test_doesFileExistKO =
+    withMockFS (runExceptT $ doesFileExist ["foo.txt"]) $ \(r, _) ->
+    case r of
+         Left e  -> fail $ prettyFSError e
+         Right b -> not b @? "doesFileExist didn't work as expected"
+
+test_doesDirectoryExistOK :: Assertion
+test_doesDirectoryExistOK =
+    withMockFS (runExceptT $ do
+                  createDirectoryIfMissing True ["test-dir"]
+                  doesDirectoryExist ["test-dir"]
+               ) $ \(r, _) ->
+    case r of
+         Left e  -> fail $ prettyFSError e
+         Right b -> b @? "doesDirectoryExist didn't work as expected"
+
+test_doesDirectoryExistKO :: Assertion
+test_doesDirectoryExistKO =
+    withMockFS (runExceptT $ doesDirectoryExist ["test-dir"]) $ \(r, _) ->
+    case r of
+         Left e  -> fail $ prettyFSError e
+         Right b -> not b @? "doesDirectoryExist didn't work as expected"
+
+--
+-- Tests for the immutable storage
+--
+
+test_appendAndGet :: Assertion
+test_appendAndGet =
+    withMockFS (withDB ["demo"] 0 $ \db -> runExceptT $ do
+          ExceptT $ appendBinaryBlob db (0, RelativeSlot 0) (BL.lazyByteString . C8.pack $ "haskell")
+          ExceptT $ getBinaryBlob db (0, RelativeSlot 0)
+    ) $ \(r, _) ->
+      case r of
+           Left e  -> fail $ prettyImmutableDBError e
+           Right b -> b @?= "haskell"
+
+prop_appendAndGetRoundtrip :: Property
+prop_appendAndGetRoundtrip = monadicIO $ do
+    input <- C8.pack <$> pick arbitrary
+    run $ apiEquivalence (withDB ["demo"] 0 $ \db -> runExceptT $ do
+            ExceptT $ appendBinaryBlob db (0, RelativeSlot 0) (BL.lazyByteString input)
+            r <- ExceptT $ getBinaryBlob db (0, RelativeSlot 0)
+            return (r == C8.toStrict input, r)
+        ) sameDBError prettyImmutableDBError
+
+prop_demoSimEquivalence :: HasCallStack => Property
+prop_demoSimEquivalence = monadicIO $ do
+    run $ apiEquivalence demoScript sameDBError prettyImmutableDBError
+
+-- Trying to append to a slot \"in the past\" should be an error, both in Sim
+-- and IO.
+prop_inconsistentSlotErrorEquivalence :: HasCallStack => Property
+prop_inconsistentSlotErrorEquivalence = monadicIO $ do
+    run $ apiEquivalence (withDB ["demo"] 0 $ \db -> runExceptT $ do
+                             ExceptT $ appendBinaryBlob db (0, RelativeSlot 3)
+                                                           (BL.lazyByteString . C8.pack $ "test")
+                             ExceptT $ appendBinaryBlob db (0, RelativeSlot 2)
+                                                           (BL.lazyByteString . C8.pack $ "haskell")
+                             return ()
+                         ) sameDBError prettyImmutableDBError
+
+prop_slotDoesNotExistErrorEquivalence :: HasCallStack => Property
+prop_slotDoesNotExistErrorEquivalence = monadicIO $ do
+    run $ apiEquivalence (withDB ["demo"] 0 $ \db -> runExceptT $ do
+                             _   <- ExceptT $ getBinaryBlob db (0, RelativeSlot 0)
+                             return ()
+                         ) sameDBError prettyImmutableDBError
+
+-- Trying to re-open the DB not on the most-recent-epoch should trigger an
+-- error, both in Sim and IO.
+prop_epochIsReadOnlyErrorEquivalence :: HasCallStack => Property
+prop_epochIsReadOnlyErrorEquivalence = monadicIO $ do
+    run $ apiEquivalence (runExceptT $ do
+                             ExceptT $ withDB ["demo"] 0 $ \db -> runExceptT $ do
+                               ExceptT $ appendBinaryBlob db (0, RelativeSlot 0)
+                                                             (BL.lazyByteString . C8.pack $ "test")
+                               ExceptT $ appendBinaryBlob db (1, RelativeSlot 0)
+                                                             (BL.lazyByteString . C8.pack $ "haskell")
+                             -- The second withDB should fail.
+                             ExceptT $ withDB ["demo"] 0 $ \_ -> return $ Right ()
+                             return ()
+                         ) sameDBError prettyImmutableDBError

--- a/test-storage/Test/Ouroboros/Storage/Immutable/Sim.hs
+++ b/test-storage/Test/Ouroboros/Storage/Immutable/Sim.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Test.Ouroboros.Storage.Immutable.Sim
+    ( demoScript ) where
+
+{-- | An example interaction with the immutable data store using the
+      mock FS.
+--}
+
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Char8 as C8
+
+import           Control.Exception (assert)
+import           Control.Monad.Catch (MonadMask)
+import           Control.Monad.Except
+
+import           GHC.Stack
+import qualified System.IO as IO
+
+import           Ouroboros.Network.MonadClass
+import           Ouroboros.Storage.FS.Class
+import           Ouroboros.Storage.Immutable.DB
+
+
+demoScript :: ( MonadMask m
+              , MonadSTM m
+              , HasCallStack
+              , HasFSE m
+              ) => m (Either ImmutableDBError ())
+demoScript = runExceptT $ do
+    liftFsError $ do
+        createDirectoryIfMissing True ["demo"]
+        -- Create some files
+        h1 <- hOpen ["demo", "epoch-006.dat"] IO.WriteMode
+        h2 <- hOpen ["demo", "index-006.dat"] IO.WriteMode
+        hClose h1
+        hClose h2
+    ExceptT $ withDB ["demo"] 7 $ \db -> runExceptT $ do
+        -- Append some blob in the DB
+        ExceptT $ appendBinaryBlob db (7, RelativeSlot 0) (BS.byteString . C8.pack $ "haskell")
+        ExceptT $ appendBinaryBlob db (7, RelativeSlot 1) (BS.byteString . C8.pack $ "nice")
+        ExceptT $ appendBinaryBlob db (7, RelativeSlot 5) (BS.byteString . C8.pack $ "cardano")
+        ExceptT $ appendBinaryBlob db (7, RelativeSlot 7) (BS.byteString . C8.pack $ "blockchain")
+        ExceptT $ appendBinaryBlob db (8, RelativeSlot 3) (BS.byteString . C8.pack $ "test")
+
+        -- Retrieve some blobs
+        q0 <- ExceptT $ getBinaryBlob db (7, RelativeSlot 0)
+        q1 <- ExceptT $ getBinaryBlob db (7, RelativeSlot 1)
+        q2 <- ExceptT $ getBinaryBlob db (7, RelativeSlot 5)
+        q3 <- ExceptT $ getBinaryBlob db (8, RelativeSlot 3)
+
+        assert (q0 == "haskell" &&
+                q1 == "nice" &&
+                q2 == "cardano" &&
+                q3 == "test"
+               ) $ return ()


### PR DESCRIPTION
This big PR adds a tentative design for an `ImmutableDB`, suitable for efficiently store the immutable part of a blockchain. 

What's in there:

- [x] Low-level primitives for storing/getting binary blobs efficiently;
- [x] An `HasFS` typeclass to abstract over the particular file system (and allow tests to run in a pure setting against a mock FS).
- [x] Tests
- [x] A low-level `FileIO` module for concurrent read/writes on file handles.