### PR TITLE
Some Node specific changes

### DIFF
--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -252,6 +252,7 @@ test-suite test-consensus
                     containers,
                     cryptonite,
                     mtl,
+                    typed-transitions,
                     tasty,
                     tasty-expected-failure,
                     tasty-quickcheck,

--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -200,7 +200,7 @@ test-suite tests
   other-modules:       Test.Chain
                        Test.ChainProducerState
                        Test.Ouroboros.Network.Protocol.Stream
-                       Test.Node
+                       Test.Ouroboros.Network.Node
                        Test.Pipe
                        Test.Sim
   default-language:    Haskell2010

--- a/src/Ouroboros/Network/Node.hs
+++ b/src/Ouroboros/Network/Node.hs
@@ -113,8 +113,11 @@ chainTransferProtocol delay inputVar outputVar = do
                 return input
       fork $ threadDelay delay >> atomically (writeTVar outputVar input)
 
+-- FIXME: neads a better place, it's not in 'typed-protocol' since it needs
+-- 'MonadSTM' and 'MonadTimer' constraints.
 delayChannel :: forall sm rm send recv.
-                ( MonadSTM rm
+                ( Applicative sm
+                , MonadSTM rm
                 , MonadTimer rm
                 )
              => Duration (Time rm)

--- a/src/Ouroboros/Network/Node.hs
+++ b/src/Ouroboros/Network/Node.hs
@@ -36,6 +36,7 @@ import           Ouroboros.Network.Protocol.ChainSync.Codec.Id (codecChainSync)
 import           Ouroboros.Network.Protocol.ChainSync.Client
 import           Ouroboros.Network.Protocol.ChainSync.Server
 import           Ouroboros.Network.Protocol.ChainSync.Type
+import           Ouroboros.Network.Protocol.Channel.Sim (delayChannel)
 -- FIXME bad module name below. They're examples, sure, but they're also
 -- legit useful.
 import           Ouroboros.Network.ChainSyncExamples
@@ -112,18 +113,6 @@ chainTransferProtocol delay inputVar outputVar = do
                 writeTVar stateVar (Chain.headPoint input)
                 return input
       fork $ threadDelay delay >> atomically (writeTVar outputVar input)
-
--- FIXME: neads a better place, it's not in 'typed-protocol' since it needs
--- 'MonadSTM' and 'MonadTimer' constraints.
-delayChannel :: forall sm rm send recv.
-                ( Applicative sm
-                , MonadSTM rm
-                , MonadTimer rm
-                )
-             => Duration (Time rm)
-             -> Duplex sm rm send recv
-             -> Duplex sm rm send recv
-delayChannel delay = channelRecvEffect (\_ -> threadDelay delay)
 
 -- | Simulated transfer protocol.
 --

--- a/src/Ouroboros/Network/Protocol/Channel/Sim.hs
+++ b/src/Ouroboros/Network/Protocol/Channel/Sim.hs
@@ -2,12 +2,15 @@
 
 module Ouroboros.Network.Protocol.Channel.Sim
   ( simStmChannels
+  , delayChannel
   ) where
 
 import qualified Data.Sequence as Seq
 
 import Ouroboros.Network.MonadClass.MonadSTM
+import Ouroboros.Network.MonadClass.MonadTimer
 import Protocol.Channel
+
 
 -- | Use the simulation STM (via MonadClass) to get 2 channels, one for each
 -- peer. There's no notion of EOF for such a channel, so receiving never gives
@@ -29,3 +32,14 @@ simStmChannels = do
       channelA = uniformChannel (send varA) (recv varB)
       channelB = uniformChannel (send varB) (recv varA)
   pure (channelA, channelB)
+
+-- | Delay a channel on the receiver end.
+--
+delayChannel :: ( Applicative sm
+                , MonadSTM rm
+                , MonadTimer rm
+                )
+             => Duration (Time rm)
+             -> Duplex sm rm send recv
+             -> Duplex sm rm send recv
+delayChannel delay = channelRecvEffect (\_ -> threadDelay delay)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,9 +4,9 @@ import           Test.Tasty
 
 import qualified Test.Chain (tests)
 import qualified Test.ChainProducerState (tests)
-import qualified Test.Node (tests)
 import qualified Test.Pipe (tests)
 import qualified Test.Sim (tests)
+import qualified Test.Ouroboros.Network.Node (tests)
 import qualified Test.Ouroboros.Network.Protocol.Stream (tests)
 
 main :: IO ()
@@ -18,7 +18,7 @@ tests =
   [ Test.Chain.tests
   , Test.ChainProducerState.tests
   , Test.Sim.tests
-  , Test.Node.tests
   , Test.Pipe.tests
+  , Test.Ouroboros.Network.Node.tests
   , Test.Ouroboros.Network.Protocol.Stream.tests
   ]

--- a/test/Test/Node.hs
+++ b/test/Test/Node.hs
@@ -31,8 +31,12 @@ import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
+import           Protocol.Transition (SomeTransition)
+
+import           Ouroboros.Network.Protocol.ChainSync.Type (ChainSyncMessage)
+
 import           Ouroboros.Network.Block
-import           Ouroboros.Network.Chain (Chain (..), chainToList)
+import           Ouroboros.Network.Chain (Chain (..), Point, chainToList)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.MonadClass
 import           Ouroboros.Network.Node

--- a/test/Test/Ouroboros/Network/Node.hs
+++ b/test/Test/Ouroboros/Network/Node.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE GADTs               #-}
 
-module Test.Node where
+module Test.Ouroboros.Network.Node where
 
 import           Control.Monad (forM, forM_, forever, replicateM)
 import           Control.Monad.ST.Lazy (runST)


### PR DESCRIPTION
* logging over a channel (fixes two todos in `avieth/codec`)
* channels with a delay: now delay is applied to the receiving end not the sending part.  This better emulates network delay.
* `channelRecvEffect`, `channelSendEffect`, `channelEffect`: do an effect when receiving, sending or both.