### PR TITLE
Codec coherence test, Decoder is a fold

### DIFF
--- a/ouroboros-consensus/demo-playground/LedgerState.hs
+++ b/ouroboros-consensus/demo-playground/LedgerState.hs
@@ -14,7 +14,7 @@ import           Control.Concurrent.STM (TBQueue, TVar, atomically, modifyTVar',
 import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Data.Functor (($>))
-import qualified Data.Text as T (unpack)
+import           Data.Text (Text, unpack)
 
 import           Protocol.Driver
 import           Protocol.Channel
@@ -96,8 +96,8 @@ spawnLedgerStateListeners _ourselves cfg _q initialChain ledgerVar cps = do
           , points = \_ -> pure client
           }
 
-        throwOnUnexpected :: Result t -> IO t
-        throwOnUnexpected (Unexpected txt) = error (T.unpack txt)
+        throwOnUnexpected :: Result Text t -> IO t
+        throwOnUnexpected (Unexpected txt) = error (unpack txt)
         throwOnUnexpected (Normal t)       = pure t
 
         consumerPeer = chainSyncClientPeer (chainSyncClientExample chainV client)

--- a/ouroboros-consensus/demo-playground/NamedPipe.hs
+++ b/ouroboros-consensus/demo-playground/NamedPipe.hs
@@ -11,7 +11,7 @@ import           Control.Monad (when)
 import qualified Codec.CBOR.Encoding as CBOR (Encoding)
 import           Data.ByteString (ByteString)
 import           Data.Semigroup ((<>))
-import qualified Data.Text as T (unpack)
+import           Data.Text (Text, unpack)
 import           GHC.Stack
 import           System.Directory (removeFile)
 import           System.IO
@@ -88,7 +88,7 @@ withTxPipe node ioMode destroyAfterUse action = do
 runPeerUsingNamedPipeCbor
   :: NodeId
   -> NodeId
-  -> Codec IO CBOR.Encoding ByteString tr begin
+  -> Codec IO Text CBOR.Encoding ByteString tr begin
   -> Peer proto tr (status begin) end IO a
   -> IO a
 runPeerUsingNamedPipeCbor myId targetId codec peer =
@@ -97,4 +97,4 @@ runPeerUsingNamedPipeCbor myId targetId codec peer =
        in throwOnUnexpected =<< useCodecWithDuplex channel codec peer
   where
   throwOnUnexpected (Normal t) = pure t
-  throwOnUnexpected (Unexpected txt) = error (T.unpack txt)
+  throwOnUnexpected (Unexpected txt) = error (unpack txt)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -34,6 +34,7 @@ import           Data.Function (on)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
+import           Data.Text (Text)
 import           Data.Time
 
 import           Protocol.Channel
@@ -316,7 +317,7 @@ data NetworkLayer up b m = NetworkLayer {
       -- connection.
     , registerUpstream :: forall concreteSend concreteRecv.
                           up
-                       -> Codec m concreteSend concreteRecv (ChainSyncMessage b (Point b)) 'StIdle
+                       -> Codec m Text concreteSend concreteRecv (ChainSyncMessage b (Point b)) 'StIdle
                        -> (forall a. (Duplex m m concreteSend concreteRecv -> m a) -> m a)
                        -> m ()
 
@@ -329,7 +330,7 @@ data NetworkLayer up b m = NetworkLayer {
       -- is given the chance to /create/ a channel for the lifetime of the
       -- connection.
     , registerDownstream :: forall concreteSend concreteRecv.
-                            Codec m concreteSend concreteRecv (ChainSyncMessage b (Point b)) 'StIdle
+                            Codec m Text concreteSend concreteRecv (ChainSyncMessage b (Point b)) 'StIdle
                          -> (forall a. (Duplex m m concreteSend concreteRecv -> m a) -> m a)
                          -> m ()
     }

--- a/ouroboros-network/src/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Node.hs
@@ -15,6 +15,7 @@ import           Data.Hashable
 import           Data.List hiding (inits)
 import           Data.Maybe (catMaybes)
 import           Data.Semigroup (Semigroup (..))
+import           Data.Text (Text)
 import           Data.Tuple (swap)
 import           GHC.Generics (Generic)
 
@@ -370,7 +371,8 @@ relayNode nid initChain chans = do
   where
 
     codec
-      :: Codec m (SomeTransition (ChainSyncMessage block (Point block)))
+      :: Codec m Text
+                 (SomeTransition (ChainSyncMessage block (Point block)))
                  (SomeTransition (ChainSyncMessage block (Point block)))
                  (ChainSyncMessage block (Point block))
                  'StIdle

--- a/ouroboros-network/src/Ouroboros/Network/Pipe.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Pipe.hs
@@ -18,7 +18,7 @@ import           Control.Concurrent (forkIO, threadDelay)
 import           Control.Concurrent.Async
 import           Control.Concurrent.STM
 import           Control.Monad.ST (stToIO)
-import qualified Data.Text as T (unpack)
+import           Data.Text (Text, unpack)
 import           System.IO (Handle, hIsEOF, hFlush)
 import           System.Process (createPipe)
 
@@ -75,11 +75,11 @@ demo chain0 updates = do
                              IO ()
         consumerPeer = chainSyncClientPeer (chainSyncClientExample consumerVar pureClient)
 
-        codec :: Codec IO CBOR.Encoding BS.ByteString (ChainSyncMessage block (Point block)) 'StIdle
+        codec :: Codec IO Text CBOR.Encoding BS.ByteString (ChainSyncMessage block (Point block)) 'StIdle
         codec = hoistCodec stToIO codecChainSync
 
-        throwOnUnexpected :: String -> Result t -> IO t
-        throwOnUnexpected str (Unexpected txt) = error $ str ++ " " ++ T.unpack txt
+        throwOnUnexpected :: String -> Result Text t -> IO t
+        throwOnUnexpected str (Unexpected txt) = error $ str ++ " " ++ unpack txt
         throwOnUnexpected _   (Normal t) = pure t
 
     -- Fork the producer and consumer

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/Chain/Codec/Id.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/Chain/Codec/Id.hs
@@ -2,12 +2,13 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 {-# OPTIONS_GHC "-fwarn-incomplete-patterns" #-}
 
 module Ouroboros.Network.Protocol.Chain.Codec.Id where
 
-import Data.Text (pack)
+import Data.Text (Text, pack)
 
 import Protocol.Codec
 import Protocol.Transition
@@ -21,16 +22,21 @@ import Ouroboros.Network.Protocol.Chain.Type
 -- have the appropriate initial state type.
 codecChainExchange
   :: Applicative m =>
-     Codec m
+     Codec m Text
            (SomeTransition (TrChainExchange point header))
            (SomeTransition (TrChainExchange point header))
            (TrChainExchange point header)
            'StInit
 codecChainExchange = codecInit
 
+type DecoderAt point header m at =
+  Decoder Text (SomeTransition (TrChainExchange point header)) m
+          (Decoded (TrChainExchange point header) at (Codec m Text (SomeTransition (TrChainExchange point header)) (SomeTransition (TrChainExchange point header)) (TrChainExchange point header)))
+
 codecInit
-  :: Applicative m =>
-     Codec m
+  :: forall m point header .
+     ( Applicative m )
+  => Codec m Text
            (SomeTransition (TrChainExchange point header))
            (SomeTransition (TrChainExchange point header))
            (TrChainExchange point header)
@@ -38,15 +44,24 @@ codecInit
 codecInit = Codec
   { encode = Encoder $ \tr -> case tr of
       TrInit _ -> Encoded (SomeTransition tr) codecIdle
-  , decode = Decoder $ pure $ Partial $ \mtr -> case mtr of
-      Just (SomeTransition tr@(TrInit _)) -> Decoder $ pure $ Done Nothing (Decoded tr codecIdle)
-      _ -> Decoder $ pure $ Fail Nothing (pack "expected TrInit")
+  , decode =
+      let loop :: DecoderAt point header m 'StInit
+          loop = Fold $ pure $ Partial $ Response
+            { end  = pure $ Left $ pack "expected TrInit"
+            , more = \trs -> Fold $ case trs of
+                SomeTransition tr@(TrInit _) : rest ->
+                  pure $ Complete rest $ pure $ Right $ Decoded tr codecIdle
+                _ : rest ->
+                  pure $ Complete rest $ pure $ Left $ pack "expected TrInit"
+                [] -> runFold loop
+            }
+      in loop
   }
 
-
 codecIdle
-  :: Applicative m =>
-     Codec m
+  :: forall m point header .
+     ( Applicative m )
+  => Codec m Text
            (SomeTransition (TrChainExchange point header))
            (SomeTransition (TrChainExchange point header))
            (TrChainExchange point header)
@@ -57,19 +72,28 @@ codecIdle = Codec
       TrRequest (ReqDownload _) -> Encoded (SomeTransition tr) codecBusy_Download
       TrRequest (ReqNext)       -> Encoded (SomeTransition tr) codecBusy_Next
       TrConsumerDone            -> Encoded (SomeTransition tr) codecDone
-  , decode = Decoder $ pure $ Partial $ \mtr -> case mtr of
-      Just (SomeTransition tr@(TrRequest req)) -> case req of
-        ReqImprove _  -> Decoder $ pure $ Done Nothing (Decoded tr codecBusy_Improve)
-        ReqDownload _ -> Decoder $ pure $ Done Nothing (Decoded tr codecBusy_Download)
-        ReqNext       -> Decoder $ pure $ Done Nothing (Decoded tr codecBusy_Next)
-      Just (SomeTransition TrConsumerDone) ->
-        Decoder $ pure $ Done Nothing (Decoded TrConsumerDone codecDone)
-      _ -> Decoder $ pure $ Fail Nothing (pack "expected TrRequest or TrConsumerDone")
+  , decode =
+      let loop :: DecoderAt point header m 'StIdle
+          loop = Fold $ pure $ Partial $ Response
+            { end  = pure $ Left $ pack "expected TrRequest or TrConsumerDone"
+            , more = \trs -> Fold $ case trs of
+                SomeTransition tr@(TrRequest req) : rest -> pure $ case req of
+                  ReqImprove _  -> Complete rest $ pure $ Right $ Decoded tr codecBusy_Improve
+                  ReqDownload _ -> Complete rest $ pure $ Right $ Decoded tr codecBusy_Download
+                  ReqNext       -> Complete rest $ pure $ Right $ Decoded tr codecBusy_Next
+                SomeTransition TrConsumerDone : rest ->
+                  pure $ Complete rest $ pure $ Right $ Decoded TrConsumerDone codecDone
+                _ : rest ->
+                  pure $ Complete rest $ pure $ Left $ pack "expected TrRequest or TrConsumerDone"
+                [] -> runFold loop
+            }
+      in loop
   }
 
 codecBusy_Improve
-  :: Applicative m =>
-     Codec m
+  :: forall m point header .
+     ( Applicative m )
+  => Codec m Text
            (SomeTransition (TrChainExchange point header))
            (SomeTransition (TrChainExchange point header))
            (TrChainExchange point header)
@@ -78,17 +102,26 @@ codecBusy_Improve = Codec
   { encode = Encoder $ \tr -> case tr of
       TrRespond (ResImprove _) -> Encoded (SomeTransition tr) codecIdle
       TrRespond (ResForked _)  -> Encoded (SomeTransition tr) codecIdle
-  , decode = Decoder $ pure $ Partial $ \mtr -> case mtr of
-      Just (SomeTransition tr@(TrRespond (ResImprove _))) ->
-        Decoder $ pure $ Done Nothing (Decoded tr codecIdle)
-      Just (SomeTransition (TrRespond (ResForked it))) ->
-        Decoder $ pure $ Done Nothing (Decoded (TrRespond (ResForked it)) codecIdle)
-      _ -> Decoder $ pure $ Fail Nothing (pack "expected improve or fork")
+  , decode =
+      let loop :: DecoderAt point header m ('StBusy 'Improve)
+          loop = Fold $ pure $ Partial $ Response
+            { end  = pure $ Left $ pack "expected improve or fork"
+            , more = \trs -> Fold $ case trs of
+                SomeTransition tr@(TrRespond (ResImprove _)) : rest ->
+                  pure $ Complete rest $ pure $ Right $ Decoded tr codecIdle
+                SomeTransition (TrRespond (ResForked it)) : rest ->
+                  pure $ Complete rest $ pure $ Right $ Decoded (TrRespond (ResForked it)) codecIdle
+                _ : rest ->
+                  pure $ Complete rest $ pure $ Left $ pack "expected improve or fork"
+                [] -> runFold loop
+            }
+      in loop
   }
 
 codecBusy_Download
-  :: Applicative m =>
-     Codec m
+  :: forall m point header .
+     ( Applicative m )
+  => Codec m Text
            (SomeTransition (TrChainExchange point header))
            (SomeTransition (TrChainExchange point header))
            (TrChainExchange point header)
@@ -98,20 +131,29 @@ codecBusy_Download = Codec
       TrRespond (ResDownloadOne _)  -> Encoded (SomeTransition tr) codecBusy_Download
       TrRespond (ResDownloadDone _) -> Encoded (SomeTransition tr) codecIdle
       TrRespond (ResForked _)       -> Encoded (SomeTransition tr) codecIdle
-  , decode = Decoder $ pure $ Partial $ \mtr -> case mtr of
-      Just (SomeTransition tr@(TrRespond (ResDownloadOne _))) ->
-        Decoder $ pure $ Done Nothing (Decoded tr codecBusy_Download)
-      Just (SomeTransition tr@(TrRespond (ResDownloadDone _))) ->
-        Decoder $ pure $ Done Nothing (Decoded tr codecIdle)
-      Just (SomeTransition (TrRespond (ResForked it))) ->
-        Decoder $ pure $ Done Nothing (Decoded (TrRespond (ResForked it)) codecIdle)
-      _ -> Decoder $ pure $ Fail Nothing (pack "expected download or fork")
+  , decode =
+      let loop :: DecoderAt point header m ('StBusy 'Download)
+          loop = Fold $ pure $ Partial $ Response
+            { end  = pure $ Left $ pack "expected download or fork"
+            , more = \trs -> Fold $ case trs of
+                SomeTransition tr@(TrRespond (ResDownloadOne _)) : rest ->
+                  pure $ Complete rest $ pure $ Right $ Decoded tr codecBusy_Download
+                SomeTransition tr@(TrRespond (ResDownloadDone _)) : rest ->
+                  pure $ Complete rest $ pure $ Right $ Decoded tr codecIdle
+                SomeTransition (TrRespond (ResForked it)) : rest ->
+                  pure $ Complete rest $ pure $ Right $ Decoded (TrRespond (ResForked it)) codecIdle
+                _ : rest ->
+                  pure $ Complete rest $ pure $ Left $ pack "expected download or fork"
+                [] -> runFold loop
+            }
+      in loop
   }
 
 
 codecBusy_Next
-  :: Applicative m =>
-     Codec m
+  :: forall m point header .
+     ( Applicative m )
+  => Codec m Text
            (SomeTransition (TrChainExchange point header))
            (SomeTransition (TrChainExchange point header))
            (TrChainExchange point header)
@@ -121,25 +163,33 @@ codecBusy_Next = Codec
       TrRespond (ResExtend _) -> Encoded (SomeTransition tr) codecIdle
       TrRespond (ResForked _) -> Encoded (SomeTransition tr) codecIdle
       TrProducerDone          -> Encoded (SomeTransition tr) codecDone
-  , decode = Decoder $ pure $ Partial $ \mtr -> case mtr of
-      Just (SomeTransition tr@(TrRespond (ResExtend _))) ->
-        Decoder $ pure $ Done Nothing (Decoded tr codecIdle)
-      Just (SomeTransition (TrRespond (ResForked it))) ->
-        Decoder $ pure $ Done Nothing (Decoded (TrRespond (ResForked it)) codecIdle)
-      Just (SomeTransition TrProducerDone) ->
-        Decoder $ pure $ Done Nothing (Decoded TrProducerDone codecDone)
-      _ -> Decoder $ pure $ Fail Nothing (pack "expected extend or fork or done")
+  , decode =
+      let loop :: DecoderAt point header m ('StBusy 'Next)
+          loop = Fold $ pure $ Partial $ Response
+            { end  = pure $ Left $ pack "expected extend or fork or done"
+            , more = \trs -> Fold $ case trs of
+                SomeTransition tr@(TrRespond (ResExtend _)) : rest ->
+                  pure $ Complete rest $ pure $ Right $ Decoded tr codecIdle
+                SomeTransition (TrRespond (ResForked it)) : rest ->
+                  pure $ Complete rest $ pure $ Right $ Decoded (TrRespond (ResForked it)) codecIdle
+                SomeTransition TrProducerDone : rest ->
+                  pure $ Complete rest $ pure $ Right $ Decoded TrProducerDone codecDone
+                _ : rest ->
+                  pure $ Complete rest $ pure $ Left $ pack "expected extend or fork or done"
+                [] -> runFold loop
+            }
+      in loop
   }
 
 
 codecDone
   :: Applicative m =>
-     Codec m
+     Codec m Text
            (SomeTransition (TrChainExchange point header))
            (SomeTransition (TrChainExchange point header))
            (TrChainExchange point header)
            'StDone
 codecDone = Codec
   { encode = Encoder $ \tr -> case tr of { }
-  , decode = Decoder $ pure $ Fail Nothing (pack "expected some transition")
+  , decode = Fold $ pure $ Complete [] $ pure $ Left $ pack "expected some transition"
   }

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/Chain/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/Chain/Node.hs
@@ -298,7 +298,7 @@ runWithChainSelectionSTM eqBlockHeader headerBlockNo conc mkConsumer mkProducer 
     (_, Seq.EmptyR)          -> True
     (_ Seq.:> l, _ Seq.:> r) -> headerBlockNo l > headerBlockNo r
 
-throwOnUnexpected :: Applicative m => Result t -> m t
+throwOnUnexpected :: (Show fail, Applicative m) => Result fail t -> m t
 throwOnUnexpected (Unexpected txt) = error (show txt)
 throwOnUnexpected (Normal t) = pure t
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/Codec/Cbor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/Codec/Cbor.hs
@@ -2,12 +2,13 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+{-# OPTIONS_GHC "-fno-warn-name-shadowing" #-}
+
 module Ouroboros.Network.Protocol.Codec.Cbor where
 
 import           Control.Monad.ST
 
 import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS (null)
 import           Data.Text (Text, pack)
 
 import qualified Codec.CBOR.Decoding as CBOR hiding (DecodeAction(Fail, Done))
@@ -47,11 +48,11 @@ cborDecoder decoder = Fold (idecode [] =<< CBOR.deserialiseIncremental decoder)
               -- If there's more input, recurse on 'idecode' with the input
               -- chunks.
               { end  = k Nothing >>= \final -> case final of
-                  CBOR.Fail bs _ (CBOR.DeserialiseFailure _ str) ->
-                    -- 'bs' ought to be null, but we won't check.
+                  CBOR.Fail _bs _ (CBOR.DeserialiseFailure _ str) ->
+                    -- '_bs' ought to be null, but we won't check.
                     pure $ Left $ pack str
-                  CBOR.Done bs _ it ->
-                    -- 'bs' ought to be null, but we won't check.
+                  CBOR.Done _bs _ it ->
+                    -- '_bs' ought to be null, but we won't check.
                     pure $ Right it
                   -- The `IDecode` representation isn't as sharp as the
                   -- `Decoder` representation: it can give a partial decode even after

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/Codec/Cbor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/Codec/Cbor.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Ouroboros.Network.Protocol.Codec.Cbor where
 
 import           Control.Monad.ST
 
 import           Data.ByteString (ByteString)
-import qualified Data.Text as T (pack)
+import qualified Data.ByteString as BS (null)
+import           Data.Text (Text, pack)
 
 import qualified Codec.CBOR.Decoding as CBOR hiding (DecodeAction(Fail, Done))
 import qualified Codec.CBOR.Encoding as CBOR
@@ -17,14 +19,46 @@ import           Protocol.Codec
 -- | Convert a CBOR decoder type into a Protocol.Codec.Decoder.
 cborDecoder
   :: forall s tr state .
-     CBOR.Decoder s (Decoded tr state (Codec (ST s) CBOR.Encoding ByteString tr))
-  -> Decoder (ST s) ByteString (Decoded tr state (Codec (ST s) CBOR.Encoding ByteString tr))
-cborDecoder decoder = Decoder (idecode <$> CBOR.deserialiseIncremental decoder)
+     CBOR.Decoder s (Decoded tr state (Codec (ST s) Text CBOR.Encoding ByteString tr))
+  -> Decoder Text ByteString (ST s) (Decoded tr state (Codec (ST s) Text CBOR.Encoding ByteString tr))
+cborDecoder decoder = Fold (idecode [] =<< CBOR.deserialiseIncremental decoder)
   where
   idecode
-    :: CBOR.IDecode s (Decoded tr state (Codec (ST s) CBOR.Encoding ByteString tr))
-    -> DecoderStep (ST s) ByteString (Decoded tr state (Codec (ST s) CBOR.Encoding ByteString tr))
-  idecode term = case term of
-    CBOR.Fail bs _ (CBOR.DeserialiseFailure _ str) -> Fail (Just bs) (T.pack str)
-    CBOR.Done bs _ it -> Done (Just bs) it
-    CBOR.Partial k -> Partial $ Decoder . fmap idecode . k
+    :: [ByteString]
+    -> CBOR.IDecode s (Decoded tr state (Codec (ST s) Text CBOR.Encoding ByteString tr))
+    -> ST s (Choice [ByteString] (ST s) (Either Text (Decoded tr state (Codec (ST s) Text CBOR.Encoding ByteString tr))))
+  idecode inputs term = case term of
+    CBOR.Fail bs _ (CBOR.DeserialiseFailure _ str) ->
+      pure $ Complete (bs : inputs) $ pure $ Left $ pack str
+    CBOR.Done bs _ it ->
+      pure $ Complete (bs : inputs) $ pure $ Right $ it
+    -- At a partial, feed all of the inputs we have in scope before presenting
+    -- a 'Response'.
+    CBOR.Partial k ->
+      let feedInputs
+            :: [ByteString]
+            -> (Maybe ByteString -> ST s (CBOR.IDecode s (Decoded tr state (Codec (ST s) Text CBOR.Encoding ByteString tr))))
+            -> ST s (Choice [ByteString] (ST s) (Either Text (Decoded tr state (Codec (ST s) Text CBOR.Encoding ByteString tr))))
+          feedInputs inputs k = case inputs of
+            (i : is) -> k (Just i) >>= idecode is
+            [] -> pure $ Partial $ Response
+              -- Known inputs are exhausted. If the next step is end of stream,
+              -- there could be errors, because the 'IDecode' type is too big.
+              -- If there's more input, recurse on 'idecode' with the input
+              -- chunks.
+              { end  = k Nothing >>= \final -> case final of
+                  CBOR.Fail bs _ (CBOR.DeserialiseFailure _ str) ->
+                    -- 'bs' ought to be null, but we won't check.
+                    pure $ Left $ pack str
+                  CBOR.Done bs _ it ->
+                    -- 'bs' ought to be null, but we won't check.
+                    pure $ Right it
+                  -- The `IDecode` representation isn't as sharp as the
+                  -- `Decoder` representation: it can give a partial decode even after
+                  -- the end of stream is given, and so the user is in limbo with
+                  -- neither a success, nor a failure...
+                  CBOR.Partial _ ->
+                    pure $ Left $ pack "CBOR decoder is still partial after end of input stream"
+              , more = \bss -> Fold $ idecode bss term
+              }
+      in  feedInputs inputs k

--- a/typed-transitions/src/Protocol/Channel.hs
+++ b/typed-transitions/src/Protocol/Channel.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE GADTs #-}
 
+{-# OPTIONS_GHC "-fno-warn-name-shadowing" #-}
+
 module Protocol.Channel
   ( Duplex (..)
   , hoistDuplex

--- a/typed-transitions/src/Protocol/Channel.hs
+++ b/typed-transitions/src/Protocol/Channel.hs
@@ -5,6 +5,7 @@
 module Protocol.Channel
   ( Duplex (..)
   , hoistDuplex
+  , prependDuplexRecv
   , uniformDuplex
   , Channel
   , uniformChannel
@@ -46,6 +47,19 @@ hoistDuplex snat rnat duplex = Duplex
   { send = fmap (hoistDuplex snat rnat) . snat . send duplex
   , recv = (fmap . fmap) (hoistDuplex snat rnat) (rnat (recv duplex))
   }
+
+-- | Put some data at the head of the duplex receive side.
+prependDuplexRecv
+  :: ( Functor sm, Applicative rm )
+  => [recv]
+  -> Duplex sm rm send recv
+  -> Duplex sm rm send recv
+prependDuplexRecv lst duplex = case lst of
+  [] -> duplex
+  (i : is) -> Duplex
+    { send = fmap (prependDuplexRecv lst) . send duplex
+    , recv = pure (Just i, prependDuplexRecv is duplex)
+    }
 
 uniformDuplex :: (Functor rm, Functor sm) => (s -> sm ()) -> rm (Maybe r) -> Duplex sm rm s r
 uniformDuplex send recv = Duplex

--- a/typed-transitions/src/Protocol/Driver.hs
+++ b/typed-transitions/src/Protocol/Driver.hs
@@ -6,8 +6,6 @@
 
 module Protocol.Driver where
 
-import Data.Text (Text)
-
 import Protocol.Channel
 import Protocol.Core
 import Protocol.Codec
@@ -38,11 +36,26 @@ import Protocol.Codec
 -- (decode is not inverse to encode). It's also possible that a decoder
 -- fails because a transition was expected, but the 'Duplex' closed. This also
 -- gives rise to an 'Unexpected' value, because the decoder will fail.
-data Result t where
-  Normal     :: t -> Result t
+data Result fail t where
+  Normal     :: t -> Result fail t
   -- | Unexpected data was given. This includes the case of an EOF.
-  Unexpected :: Text -> Result t
+  Unexpected :: fail -> Result fail t
   deriving (Show)
+
+-- | Feed a 'Fold' using the receive side of a 'Duplex'. Leftovers of the
+-- fold will be prepended onto the remaining duplex.
+--
+-- Like 'Protocol.Channel.foldOverInput', but for a 'Duplex'.
+foldOverDuplex
+  :: ( Functor n, Monad m )
+  => Fold [recv] m r
+  -> Duplex n m send recv
+  -> m (r, Duplex n m send recv)
+foldOverDuplex fold duplex = runFold fold >>= \choice -> case choice of
+  Complete leftovers it -> flip (,) (prependDuplexRecv leftovers duplex) <$> it
+  Partial step -> recv duplex >>= \(inp, duplex') -> case inp of
+    Nothing -> flip (,) duplex' <$> end step
+    Just i  -> foldOverDuplex (more step [i]) duplex'
 
 -- | Drive a 'Peer' using a 'Duplex', by way of a 'Codec' which describes
 -- the relationship between the concrete representation understood by the
@@ -50,71 +63,24 @@ data Result t where
 --
 -- A failure to decode arises as an 'Unexpected :: Result t'.
 useCodecWithDuplex
- :: forall m concreteSend concreteRecv p tr status init end t .
+ :: forall m fail concreteSend concreteRecv p tr status init end t .
     ( Monad m )
  => Duplex m m concreteSend concreteRecv
- -> Codec m concreteSend concreteRecv tr init
+ -> Codec m fail concreteSend concreteRecv tr init
  -> Peer p tr (status init) end m t
- -> m (Result t)
-useCodecWithDuplex = go Nothing
-  where
-  -- Tracks leftovers from the duplex.
-  go :: forall status' state .
-        Maybe concreteRecv
-     -> Duplex m m concreteSend concreteRecv
-     -> Codec m concreteSend concreteRecv tr state
-     -> Peer p tr (status' state) end m t
-     -> m (Result t)
-  go leftovers duplex codec peer = case peer of
-    PeerDone t -> pure $ Normal t
-    PeerLift m -> m >>= go leftovers duplex codec
-    -- Encode the transition, dump it to the duplex, and continue with the
-    -- new codec and duplex.
-    PeerYield exc next -> do
-      let enc = runEncoder (encode codec) (exchangeTransition exc)
-          codec' = encCodec enc
-      duplex' <- send duplex (representation enc)
-      go leftovers duplex' codec' next
-    -- Awaiting is more complex than yielding, because we need to deal with
-    -- the possibility of leftovers.
-    -- Alternatively, we could redefine the 'Duplex' type so that it has a
-    -- way to push leftovers back onto the channel.
-    PeerAwait k -> runDecoder (decode codec) >>= startDecoding leftovers duplex k
-
-  startDecoding
-    :: forall state .
-       Maybe concreteRecv
-    -> Duplex m m concreteSend concreteRecv
-    -> (forall inter . tr state inter -> Peer p tr (ControlNext (TrControl p state inter) 'Awaiting 'Yielding 'Finished inter) end m t)
-    -> DecoderStep m concreteRecv (Decoded tr state (Codec m concreteSend concreteRecv tr))
-    -> m (Result t)
-  startDecoding leftovers duplex k step = case step of
-    Fail _ txt -> pure $ Unexpected txt
-    -- We just started decoding. We haven't fed any input yet. And still, the
-    -- decoder is done. That's bizarre but not necessarily wrong. It _must_ be
-    -- the case that `leftovers'` is empty, otherwise the decoder conjured
-    -- some leftovers from nothing.
-    Done _ (Decoded tr codec') -> go leftovers duplex codec' (k tr)
-    -- Typically, the decoder will be partial. We start by passing the
-    -- leftovers if any. NB: giving `Nothing` to `l` means there's no more
-    -- input.
-    Partial l -> case leftovers of
-      Just piece -> runDecoder (l (Just piece)) >>= decodeFromDuplex duplex k
-      Nothing -> decodeFromDuplex duplex k step
-
-  decodeFromDuplex
-    :: forall state .
-       Duplex m m concreteSend concreteRecv
-    -> (forall inter . tr state inter -> Peer p tr (ControlNext (TrControl p state inter) 'Awaiting 'Yielding 'Finished inter) end m t)
-    -> DecoderStep m concreteRecv (Decoded tr state (Codec m concreteSend concreteRecv tr))
-    -> m (Result t)
-  decodeFromDuplex duplex k step = case step of
-    Fail _ txt -> pure $ Unexpected txt
-    -- Leftovers are given as 'Just' even if they are empty.
-    -- Not ideal but shouldn't be a problem in practice.
-    Done leftovers (Decoded tr codec') -> go leftovers duplex codec' (k tr)
-    -- Read from the duplex and carry on. A premature end-of-input will
-    -- result in a Fail and therefore an Unexpected.
-    Partial l -> recv duplex >>= \next -> case next of
-      (mPiece, duplex') ->
-        runDecoder (l mPiece) >>= decodeFromDuplex duplex' k
+ -> m (Result fail t)
+useCodecWithDuplex duplex codec peer = case peer of
+  PeerDone t -> pure $ Normal t
+  PeerLift m -> m >>= useCodecWithDuplex duplex codec
+  -- Encode the transition, dump it to the duplex, and continue with the
+  -- new codec and duplex.
+  PeerYield exc next -> do
+    let enc = runEncoder (encode codec) (exchangeTransition exc)
+        codec' = encCodec enc
+    duplex' <- send duplex (representation enc)
+    useCodecWithDuplex duplex' codec' next
+  PeerAwait k -> do
+    (result, duplex') <- foldOverDuplex (decode codec) duplex
+    case result of
+      Left fail -> pure $ Unexpected fail
+      Right (Decoded tr codec') -> useCodecWithDuplex duplex' codec' (k tr)

--- a/typed-transitions/src/Protocol/Path.hs
+++ b/typed-transitions/src/Protocol/Path.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Protocol.Path where
+
+import Data.Kind (Type)
+
+-- | A rather general type which controls applications of some `cons`
+-- type constructor by way of a list of states.
+--
+-- 'TransitionPath' is a simple first example. It gives some sequence of
+-- transitions through the states listed in the type.
+data Path (cons :: Type -> [st] -> Type) (states :: [st]) where
+  PathCons :: cons (Path cons (b ': rest)) (a ': b ': rest)
+           -> Path cons (a ': b ': rest)
+  PathNil  :: Path cons '[a]
+
+data Transition (tr :: st -> st -> Type) (next :: Type) (states :: [st]) where
+  Transition :: tr a b -> next -> Transition tr next (a ': b ': rest)
+
+type TransitionPath tr = Path (Transition tr)
+
+data From (begin :: st) (path :: [st] -> Type) where
+  From :: path (begin ': rest) -> From begin path
+
+foldPath
+  :: forall cons states b .
+     (forall k states . (k -> b) -> cons k states -> b)
+  -> b
+  -> Path cons states
+  -> b
+foldPath comb b path = case path of
+  PathNil -> b
+  PathCons cons -> comb (foldPath comb b) cons

--- a/typed-transitions/src/Protocol/PingPong/Codec.hs
+++ b/typed-transitions/src/Protocol/PingPong/Codec.hs
@@ -6,13 +6,13 @@
 
 module Protocol.PingPong.Codec where
 
-import Data.Text (pack)
+import Data.Text (Text, pack)
 
 import Protocol.Codec
 
 import Protocol.PingPong.Type
 
-pingPongCodec :: Monad m => Codec m String String PingPongMessage 'StIdle
+pingPongCodec :: Monad m => Codec m Text String String PingPongMessage 'StIdle
 pingPongCodec = pingPongCodecIdle
 
 -- | Here is a complete codec for the ping/pong protocol at 'StIdle.
@@ -33,7 +33,7 @@ pingPongCodec = pingPongCodecIdle
 --   TrGood :: Transition ('Idle param) ('Busy param)
 --
 --
-pingPongCodecIdle :: Monad m => Codec m String String PingPongMessage 'StIdle
+pingPongCodecIdle :: Monad m => Codec m Text String String PingPongMessage 'StIdle
 pingPongCodecIdle = Codec
   { encode = Encoder $ \tr -> case tr of
       MsgPing -> Encoded "ping" pingPongCodecBusy
@@ -41,34 +41,38 @@ pingPongCodecIdle = Codec
   , decode = decodeIdle ""
   }
   where
-  decodeIdle acc = Decoder $ pure $ Partial $ \mStr -> case mStr of
-    Nothing -> Decoder $ pure $ Fail (Just acc) (pack "expected ping or done")
-    Just str ->
-      if length acc + length str < 4
-      then decodeIdle (acc ++ str)
-      else case take 4 (acc ++ str) of
-        "ping" -> Decoder $ pure $ Done (Just (drop 4 (acc ++ str))) (Decoded MsgPing pingPongCodecBusy)
-        "done" -> Decoder $ pure $ Done (Just (drop 4 (acc ++ str))) (Decoded MsgDone pingPongCodecDone)
-        _      -> Decoder $ pure $ Fail (Just (drop 4 (acc ++ str))) (pack "expected ping")
+  decodeIdle acc = Fold $ pure $ Partial $ Response
+    { end  = pure $ Left (pack "expected ping or done")
+    , more = \strs ->
+        let str = mconcat strs
+        in  if length acc + length str < 4
+            then decodeIdle (acc ++ str)
+            else Fold $ pure $ Complete [drop 4 (acc ++ str)] $ pure $ case take 4 (acc ++ str) of
+              "ping" -> Right $ Decoded MsgPing pingPongCodecBusy
+              "done" -> Right $ Decoded MsgDone pingPongCodecDone
+              _      -> Left  $ pack "expected ping"
+    }
 
-pingPongCodecBusy :: Monad m => Codec m String String PingPongMessage 'StBusy
+pingPongCodecBusy :: Monad m => Codec m Text String String PingPongMessage 'StBusy
 pingPongCodecBusy = Codec
   { encode = Encoder $ \tr -> case tr of
       MsgPong -> Encoded "pong" pingPongCodecIdle
   , decode = decodePong ""
   }
   where
-  decodePong acc = Decoder $ pure $ Partial $ \mStr -> case mStr of
-    Nothing -> Decoder $ pure $ Fail (Just acc) (pack "expected pong")
-    Just str ->
-      if length acc + length str < 4
-      then decodePong (acc ++ str)
-      else case take 4 (acc ++ str) of
-        "pong" -> Decoder $ pure $ Done (Just (drop 4 (acc ++ str))) (Decoded MsgPong pingPongCodecIdle)
-        _      -> Decoder $ pure $ Fail (Just (drop 4 (acc ++ str))) (pack "expected pong")
+  decodePong acc = Fold $ pure $ Partial $ Response
+    { end  = pure $ Left (pack "expected pong")
+    , more = \strs ->
+        let str = mconcat strs
+        in if length acc + length str < 4
+           then decodePong (acc ++ str)
+           else Fold $ pure $ Complete [drop 4 (acc ++ str)] $ pure $ case take 4 (acc ++ str) of
+             "pong" -> Right $ Decoded MsgPong pingPongCodecIdle
+             _      -> Left  $ pack "expected pong"
+    }
 
-pingPongCodecDone :: Monad m => Codec m String String PingPongMessage 'StDone
+pingPongCodecDone :: Monad m => Codec m Text String String PingPongMessage 'StDone
 pingPongCodecDone = Codec
   { encode = Encoder $ \tr -> case tr of { }
-  , decode = Decoder $ pure $ Fail Nothing (pack "done")
+  , decode = Fold $ pure $ Complete [] $ pure $ Left $ pack "done"
   }

--- a/typed-transitions/test/Main.hs
+++ b/typed-transitions/test/Main.hs
@@ -2,11 +2,13 @@ module Main (main) where
 
 import           Test.Tasty
 
+import qualified Test.Protocol.Codec as Codec (tests)
+
 main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
 tests =
   testGroup "typed-transitions"
-  [
+  [ Codec.tests
   ]

--- a/typed-transitions/test/Test/Protocol/Codec.hs
+++ b/typed-transitions/test/Test/Protocol/Codec.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+
+module Test.Protocol.Codec where
+
+import Test.QuickCheck
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+import qualified Test.Protocol.Codec.PingPong as PingPong (tests)
+
+tests :: TestTree
+tests = testGroup "Codec"
+  [ PingPong.tests
+  ]

--- a/typed-transitions/test/Test/Protocol/Codec/Coherent.hs
+++ b/typed-transitions/test/Test/Protocol/Codec/Coherent.hs
@@ -1,0 +1,440 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+{-# OPTIONS_GHC "-fwarn-incomplete-patterns" #-}
+
+module Test.Protocol.Codec.Coherent where
+
+import Data.Either (partitionEithers)
+import Data.List (intercalate, sortBy)
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import Data.Functor.Identity (Identity (..))
+import Data.Kind (Type)
+import Data.Maybe (mapMaybe)
+import Data.Type.Equality
+
+import Test.QuickCheck
+
+import Protocol.Codec
+import Protocol.Path
+
+-- | Test the coherence of a 'CodecTree' (use 'codecTreePaths' to get one).
+--
+-- This test checks 2 properties:
+-- 
+-- 1. Local coherence of each encoder/decoder. If the decoder fails to invert
+--    the encoder, then it's locally incoherent.
+-- 2. Global coherence of the codec itself. If any 2 paths disagree on the
+--    encoding at the same spot in the path, then the codec is globally
+--    incoherent.
+--
+prop_coherent
+  :: (concrete -> concrete -> Bool)
+     -- ^ Equality of encoding
+  -> (forall from to . tr from to -> String)
+     -- ^ Show transition, for counterexample reporting.
+  -> (concrete -> String)
+     -- ^ Show encoding, for counterexample reporting.
+  -> (fail -> String)
+     -- ^ Show decoding failure reason.
+  -> CodecTree fail concrete tr (a ': b ': rest)
+     -- ^ The tree of decodings. Use Test.Protocol.Codec.Coherent.codecTree
+     -- to get this.
+  -> Property
+prop_coherent eq showTr showEncoding showFail tree =
+  noLocalIncoherent .&&. noMutuallyIncoherent
+
+  where
+
+  paths = codecTreePaths tree
+
+  (incoherent, coherent) = partitionEithers (classifyLocal <$> NE.toList paths)
+
+  noLocalIncoherent :: Property
+  noLocalIncoherent = case incoherent of
+    [] -> property True
+    _  ->
+      let counterExampleStrings =
+            fmap (showLocalIncoherence showTr showEncoding showFail) incoherent
+          counterExampleString = intercalate "\n" counterExampleStrings
+      in  counterexample counterExampleString (property False)
+
+  noMutuallyIncoherent :: Property
+  noMutuallyIncoherent = case mutuallyIncoherent of
+    [] -> property True
+    _  ->
+      let counterExampleStrings =
+            fmap (showNonAgreement showTr showEncoding) mutuallyIncoherent
+          counterExampleString = mconcat
+            [ show (length mutuallyIncoherent)
+            , " counterexamples. Showing at most 10.\n"
+            , "======================================\n"
+            , intercalate "\n" (take 10 counterExampleStrings)
+            , "\n======================================\n"
+            ]
+      in  counterexample counterExampleString (property False)
+
+  -- To check for mutual incoherence, the idea is to take all pairs of all
+  -- coherent paths in the tree and then check whether they agree on encodings
+  -- ('agreement eq'). In fact, we don't need strictly _all_ pairs, since
+  -- 'agreement eq' commutes, and 'agreement eq a a = Nothing' if 'eq' really
+  -- is equality. So we can just take the unique pairs.
+
+  {-
+  uniquePairs :: [t] -> [(t, t)]
+  uniquePairs [] = []
+  uniquePairs (x : xs) = fmap ((,) x) xs ++ uniquePairs xs
+
+  mutuallyIncoherent = mapMaybe (uncurry (agreement eq)) (uniquePairs coherent)
+  -}
+
+  -- But this isn't so great, because if path `a` disagrees at some point
+  -- with path `b`, then it will also disagree with every path including `b`,
+  -- so we'll get a bunch of duplicate counterexamples, unless `a` and `b`
+  -- disagree only at the end of the path.
+
+  -- So what's a better way? Simple option is to just look for the first
+  -- mutually incoherent pair and then immediately stop.
+  --
+  -- When we get a mutual incoherence we want to eliminate all other paths
+  -- containing that prefix from the rest of the list.
+  -- Take the head of the list, and run it over the tail of the list.
+  -- At each step, run `agreement eq x y` where `x` is the original head.
+  -- If it's nothing, keep `y` in the output list; otherwise, filter the
+  -- remainder to eliminate every path which contains the offending path, and
+  -- recurse on what remains.
+
+  -- Combine `t`s into matching pairs (witnessed by `r`), and filter
+  -- other `t`s w.r.t. that matching pair.
+  pairs :: (r -> t -> Bool) -> (t -> t -> Maybe r) -> [t] -> [r]
+  pairs p f [] = []
+  pairs p f (t:ts) =
+    -- Run the matcher with `t` against the rest of the list to find
+    -- an `[r]`, and also a shorter `[t]`: everything in `ts'` was false
+    -- under `p r` for every `r` in `rs`.
+    let (rs, ts') = go p (f t) ts
+        rs' = pairs p f ts'
+    in  rs ++ rs'
+    where
+    go :: (r -> t -> Bool) -> (t -> Maybe r) -> [t] -> ([r], [t])
+    go p f [] = ([], [])
+    go p f (t : ts) = case f t of
+      Nothing -> go p f ts
+      Just r  -> let (rs, ts') = go p f (filter (not . p r) ts) in (r:rs, ts')
+
+  -- True if the locally-coherent path contains the coherent part of the
+  -- mutually-incoherent path: that is, the same "trace" of `Encode | Decode`
+  -- from root to end.
+  subPath
+    :: MutuallyIncoherent concrete tr (a ': b ': rest)
+    -> LocallyCoherent concrete tr (a ': b ': rest)
+    -> Bool
+  subPath m l = subPathOn const m l || subPathOn (flip const) m l
+
+  subPathOn
+    :: (Side -> Side -> Side)
+       -- ^ Select a side to compare against the locally-coherent part's side.
+    -> MutuallyIncoherent concrete tr (a ': b ': rest)
+    -> LocallyCoherent concrete tr (a ': b ': rest)
+    -> Bool
+  subPathOn pick (PathCons m) (PathCons l) = case m of
+    MutuallyIncoherentHere _ _ _                 -> True
+    MutuallyIncoherentThere _ _ sideA sideB subM -> case l of
+      CoherentThere _ side subL ->
+        (pick sideA sideB == side) && subPathOn pick subM subL
+
+  -- This is OK, but we really ought to get the shortest one first.
+  -- In general, it's not possible to determine that a shorter
+  -- MutuallyIncoherent characterizes a longer one.
+
+  mutuallyIncoherent = sortBy compareLength (pairs subPath (agreement eq) coherent)
+
+  compareLength
+    :: MutuallyIncoherent concrete tr states
+    -> MutuallyIncoherent concrete tr states
+    -> Ordering
+  compareLength (PathCons left) (PathCons right) = case left of
+    MutuallyIncoherentHere _ _ _ -> case right of
+      MutuallyIncoherentHere _ _ _ -> EQ
+      MutuallyIncoherentThere _ _ _ _ _ -> LT
+    MutuallyIncoherentThere _ _ _ _ subLeft -> case right of
+      MutuallyIncoherentHere _ _ _ -> GT
+      MutuallyIncoherentThere _ _ _ _ subRight ->
+        compareLength subLeft subRight
+  compareLength PathNil PathNil      = EQ
+
+
+data Good concrete tr from to = Good
+  { goodTransition :: tr from to
+  , goodEncoding   :: concrete
+  }
+
+data Bad fail concrete tr from to = forall to' . Bad
+  { badTransition :: tr from to
+    -- ^ This transition ...
+  , badEncoding   :: concrete
+    -- ^ ... encodes to this ...
+  , badDecoding   :: Either fail (tr from to')
+    -- ^ ... but decodes to this, or 'Left' if the decoder failed.
+  }
+
+data Coherence fail concrete tr k states where
+  Coherent
+    :: Good concrete tr a b
+    -> k -- ^ Encoder path
+    -> k -- ^ Decoder path
+    -> Coherence fail concrete tr k (a ': b ': rest)
+  Incoherent
+    :: Bad fail concrete tr a b
+    -> Coherence fail concrete tr k (a ': b ': rest)
+
+-- | The rather general 'Path' type here is used to define a tree where all
+-- children of a node are constrained by the terminal vertex type.
+type CodecTree fail concrete tr = Path (Coherence fail concrete tr)
+
+-- | Useful for generating arbitrary paths: we want
+--     Gen (exists b rest . TransitionPath tr (a ': b ': rest))
+-- which is expressed by
+--     Gen (SomeTransitionPath tr a)
+data SomeTransitionPath tr begin where
+  SomeTransitionPath :: TransitionPath tr (begin ': next ': rest) -> SomeTransitionPath tr begin
+
+codecTree
+  :: forall m tr concreteEnc concreteDec a b states fail r .
+     ( Monad m )
+  => (forall from x . concreteEnc -> Decoder fail concreteDec m x -> m (Either fail x))
+     -- ^ How to decode from a concrete encoded type.
+     -- Useful that this is abstract. In the case of a CBOR decoder, the encoded
+     -- thing can be sliced up as you like, perhaps even at random (put the
+     -- decoder into IO).
+  -> (forall from to to' . tr from to -> tr from to' -> Maybe (to :~: to'))
+     -- ^ Equality test on transitions at a given initial state, which also
+     -- produces the equality of the terminal states. These are not equivalent
+     -- notions: two different transitions can have the same initial and
+     -- terminal states.
+  -> Codec m fail concreteEnc concreteDec tr a
+  -> TransitionPath tr (a ': b ': states)
+  -> m (CodecTree fail concreteEnc tr (a ': b ': states))
+codecTree unencode match codec (PathCons (Transition tr next)) = do
+  let Encoded concrete codecE = runEncoder (encode codec) tr
+  result <- unencode concrete (decode codec)
+  case result of
+    Left fail -> pure $ PathCons (Incoherent (Bad tr concrete (Left fail)))
+    Right (Decoded tr' codecD) -> case match tr tr' of
+      Nothing -> pure $ PathCons (Incoherent (Bad tr concrete (Right tr')))
+      Just Refl -> case next of
+        PathNil -> pure $ PathCons (Coherent (Good tr concrete) PathNil PathNil)
+        -- After matching on PathCons, we know that the type of next
+        -- has, in its final parameter is of the form (a ': b ': states), so
+        -- we can recurse.
+        PathCons _ -> do
+          byEncoder <- codecTree unencode match codecE next
+          byDecoder <- codecTree unencode match codecD next
+          pure $ PathCons (Coherent (Good tr concrete) byEncoder byDecoder)
+
+data Side where
+  Encode :: Side
+  Decode :: Side
+
+deriving instance Eq Side
+deriving instance Show Side
+
+-- | Defined for use in the 'CodecPath' type.
+data CodecResult fail concrete tr k states where
+  -- | A good result, with more following results. This one includes a
+  -- 'Side' so we know that the next results are relevant to either the
+  -- encoder or decoder path.
+  GoodResult :: Good concrete tr a b
+             -> Side
+             -> k
+             -> CodecResult fail concrete tr k (a ': b ': c ': rest)
+  -- | A bad result. Immediately ends the path (no use of `k`).
+  BadResult  :: Bad fail concrete tr a b
+             -> CodecResult fail concrete tr k (a ': b ': rest)
+  -- | A final good result. No 'Side' is included.
+  AllGood    :: Good concrete tr a b
+             -> CodecResult fail concrete tr k '[a, b]
+
+-- | The definition of 'Result' is tailored for this type: for n+2 states,
+-- it's either n+1 good results, with n 'Side's (one between each). Or
+-- it's m < n+1 good results, terminating in a bad result.
+type CodecPath fail concrete tr = Path (CodecResult fail concrete tr)
+
+-- | All paths in the codec tree. All paths are at most the length of the
+-- path used to construct the codec tree by 'codecTree'. Some paths are
+-- shorter just in case they terminate in 'Incoherent'.
+--
+-- Beware: there are as many as 2^(n-1) paths in a binary tree of height n.
+codecTreePaths
+  :: CodecTree fail concrete tr states
+  -> NonEmpty (CodecPath fail concrete tr states)
+codecTreePaths path = case path of
+  PathNil -> PathNil NE.:| []
+  PathCons cons -> case cons of
+    Incoherent bad -> PathCons (BadResult bad) NE.:| []
+    Coherent good PathNil PathNil -> PathCons (AllGood good) NE.:| []
+    Coherent good byEncoder@(PathCons _) byDecoder@(PathCons _) ->
+      let encoderPaths = codecTreePaths byEncoder
+          decoderPaths = codecTreePaths byDecoder
+          prependGood tag path = PathCons (GoodResult good tag path)
+      in  (prependGood Encode <$> encoderPaths) <> (prependGood Decode <$> decoderPaths)
+
+-- What we'll do is partition the list of CodecPaths into those which are all
+-- 'GoodResult', and those which end in a 'BadResult'.
+
+-- A local incoherence is a path where every cons is a transition, between
+-- every 2 cons's is a Tag, and at the end is a 'Bad'.
+
+data LocalIncoherence fail concrete tr k states where
+  -- | Prefix of a path that ends in an incoherence. The choice of
+  -- a ': b ': c ': rest for the final parameter ensures that this is never
+  -- the last in the path.
+  IncoherentThere :: Good concrete tr a b
+                  -> Side
+                  -> k
+                  -> LocalIncoherence fail concrete tr k (a ': b ': c ': rest)
+  -- | Final spot in a path that ends in an incoherence.
+  IncoherentHere  :: Bad fail concrete tr from to
+                  -> LocalIncoherence fail concrete tr k (a ': b ': rest)
+
+-- The issue with this type is that there's no guarantee that a 'Bad' is in
+-- there. It could just be a bunch of 'IncoherentThere' constructors.
+type LocallyIncoherent fail concrete tr = Path (LocalIncoherence fail concrete tr)
+
+data LocalCoherence concrete tr k states where
+  -- | A 'Side' is included only if there's more to come, ensured by the
+  -- 3 cons's in the final type parameter.
+  CoherentThere :: Good concrete tr a b
+                -> Side
+                -> k
+                -> LocalCoherence concrete tr k (a ': b ': c ': rest)
+  -- | The end of a locally-coherent path. No 'Side' is included.
+  CoherentHere :: Good concrete tr a b
+               -> LocalCoherence concrete tr k '[a, b]
+
+type LocallyCoherent concrete tr = Path (LocalCoherence concrete tr)
+
+-- | Classify a 'CodecPath' according to local coherence.
+classifyLocal
+  :: CodecPath fail concrete tr (a ': b ': rest)
+  -> Either (LocallyIncoherent fail concrete tr (a ': b ': rest))
+            (LocallyCoherent concrete tr (a ': b ': rest))
+classifyLocal (PathCons cons) = case cons of
+  BadResult bad -> Left $ PathCons (IncoherentHere bad)
+  AllGood good -> Right $ PathCons (CoherentHere good)
+  GoodResult good side sub@(PathCons _) -> case classifyLocal sub of
+    Left  incoh -> Left  $ PathCons (IncoherentThere good side incoh)
+    Right coh   -> Right $ PathCons (CoherentThere good side coh)
+
+showLocalIncoherence
+  :: forall fail concrete tr states .
+     (forall from to . tr from to -> String)
+  -> (concrete -> String)
+  -> (fail -> String)
+  -> LocallyIncoherent fail concrete tr states
+  -> String
+showLocalIncoherence showTr showEncoding showFail = foldPath showOne mempty
+  where
+  showOne :: (forall k states . (k -> String) -> LocalIncoherence fail concrete tr k states -> String)
+  showOne recurse it = case it of
+    IncoherentThere good side k -> mconcat
+      [ showTr (goodTransition good)
+      , " : "
+      , show side
+      , " : "
+      , recurse k
+      ]
+    IncoherentHere bad -> mconcat
+      [ "incoherent codec at "
+      , showTr (badTransition bad)
+      , " : "
+        -- Can't pattern match on (badDecoding bad) because of the existential
+        -- type variable.
+      , case bad of
+          Bad _ _ (Left fail) -> mconcat
+            [ "failed to decode with reason "
+            , showFail fail
+            ]
+          Bad _ _ (Right tr) -> mconcat
+            [ "decoded a different transition "
+            , showTr tr
+            ]
+      ]
+
+
+data MutualIncoherence concrete tr k states where
+  MutuallyIncoherentThere
+    :: tr a b
+    -> concrete
+    -> Side
+    -> Side
+    -> k
+    -> MutualIncoherence concrete tr k (a ': b ': c ': rest)
+  MutuallyIncoherentHere
+    :: tr a b
+    -> concrete
+    -> concrete
+    -> MutualIncoherence concrete tr k (a ': b ': rest)
+
+-- | Stops at the first mutual incoherence.
+--
+type MutuallyIncoherent concrete tr = Path (MutualIncoherence concrete tr)
+
+-- | Determine whether 2 locally-coherent paths agree on corresponding
+-- concrete representations.
+agreement
+  :: (concrete -> concrete -> Bool)
+  -> LocallyCoherent concrete tr (a ': b ': rest)
+  -> LocallyCoherent concrete tr (a ': b ': rest)
+  -> Maybe (MutuallyIncoherent concrete tr (a ': b ': rest))
+agreement eq (PathCons left) (PathCons right) = case (left, right) of
+  (CoherentHere goodL, CoherentHere goodR) ->
+    if encodingL `eq` encodingR
+    then Nothing
+    else Just (PathCons (MutuallyIncoherentHere tr encodingL encodingR))
+    where
+    encodingL = goodEncoding goodL
+    encodingR = goodEncoding goodR
+    tr = goodTransition goodL -- = goodTransition goodR by assumption.
+  (CoherentThere goodL sideL subL, CoherentThere goodR sideR subR) ->
+    if encodingL `eq` encodingR
+    then (\path -> PathCons (MutuallyIncoherentThere tr encodingL sideL sideR path)) <$> sub
+    else Just (PathCons (MutuallyIncoherentHere tr encodingL encodingR))
+    where
+    sub = agreement eq subL subR
+    encodingL = goodEncoding goodL
+    encodingR = goodEncoding goodR
+    tr = goodTransition goodL
+
+showNonAgreement
+  :: forall concrete tr states .
+     (forall from to . tr from to -> String)
+  -> (concrete -> String)
+  -> MutuallyIncoherent concrete tr states
+  -> String
+showNonAgreement showTr showEncoding = foldPath showOne mempty
+  where
+  showOne :: (forall k states . (k -> String) -> MutualIncoherence concrete tr k states -> String)
+  showOne recurse it = case it of
+    MutuallyIncoherentThere tr _ sideA sideB k -> mconcat
+      [ showTr tr
+      , " : "
+      , show (sideA, sideB)
+      , " : "
+      , recurse k
+      ]
+    MutuallyIncoherentHere tr encodingA encodingB -> mconcat
+      [ "encoding disagreement at "
+      , showTr tr
+      , " : ("
+      , showEncoding encodingA
+      , ") /= ("
+      , showEncoding encodingB
+      , ")"
+      ]

--- a/typed-transitions/test/Test/Protocol/Codec/PingPong.hs
+++ b/typed-transitions/test/Test/Protocol/Codec/PingPong.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+
+module Test.Protocol.Codec.PingPong where
+
+import Data.Functor.Identity (runIdentity)
+import Data.Type.Equality
+import Data.Text (Text, pack)
+
+import Test.QuickCheck
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+import Protocol.Codec
+import Protocol.Path
+
+import Protocol.PingPong.Codec
+import Protocol.PingPong.Type
+
+import Test.Protocol.Codec.Coherent
+
+prop_ping_pong_coherent :: Property
+prop_ping_pong_coherent = forAllShow genPath showPath doTest
+  where
+
+  -- TODO proper show. Can use 'showTr' to get this.
+  showPath = \_ -> "some path"
+
+  doTest :: SomeTransitionPath PingPongMessage 'StIdle -> Property
+  doTest (SomeTransitionPath path) =
+    prop_coherent (==) show show show (runIdentity (codecTree decodeFull eqTr pingPongCodec path))
+
+  -- PingPongMessage is so simple that every path from 'StIdle is determined
+  -- by a non-negative number.
+  pathOfLength :: Word -> SomeTransitionPath PingPongMessage 'StIdle
+  pathOfLength 0 = SomeTransitionPath $ PathCons $ Transition MsgDone PathNil
+  pathOfLength n = case pathOfLength (n-1) of
+    SomeTransitionPath it -> SomeTransitionPath $ PathCons $ Transition MsgPing $
+      PathCons $ Transition MsgPong $ it
+
+  -- To generate a path, just pick a non-negative number.
+  -- Don't pick one that's too big; the coherence test is space hungry; it
+  -- deals with all possible paths through the codec (2^{length of path}).
+  -- FIXME we could ease this restriction by randomly testing decoder paths.
+  genPath = pathOfLength <$> choose (0, 5)
+
+  eqTr :: forall from to to' .
+          PingPongMessage from to
+       -> PingPongMessage from to'
+       -> Maybe (to :~: to')
+  eqTr MsgPing MsgPing = Just Refl
+  eqTr MsgPong MsgPong = Just Refl
+  eqTr MsgDone MsgDone = Just Refl
+  eqTr _       _       = Nothing
+
+  decodeFull :: Monad m => String -> Decoder Text String m x -> m (Either Text x)
+  decodeFull str decoder = do
+    (it, remaining) <- foldOverInput decoder (singletonInput [str])
+    case remaining of
+      Nothing -> pure it
+      -- If there's more input, we'll drain it. giving a list of all of the
+      -- remaining inputs. Those inputs happen to be of type [String], so
+      -- we mconcat it twice to get the entire remaining input as a String.
+      Just input -> drainInput input >>= \lst -> case mconcat (mconcat lst) of
+        []    -> pure it
+        bad@(_ : _) -> pure $ Left $ pack $ "decoder did not use all of its input: " ++ bad
+
+tests :: TestTree
+tests = testGroup "PingPong"
+  [ testProperty "coherent codec" prop_ping_pong_coherent
+  ]

--- a/typed-transitions/typed-transitions.cabal
+++ b/typed-transitions/typed-transitions.cabal
@@ -18,9 +18,10 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Protocol.Channel
                      , Protocol.Codec
-                     , Protocol.Driver
-                     , Protocol.Transition
                      , Protocol.Core
+                     , Protocol.Driver
+                     , Protocol.Path
+                     , Protocol.Transition
                      , Protocol.PingPong.Type
                      , Protocol.PingPong.Client
                      , Protocol.PingPong.Codec
@@ -59,6 +60,9 @@ test-suite test-typed-transitions
   main-is:        Main.hs
   hs-source-dirs: test
   other-modules:    Test.Protocol.Channel
+                    Test.Protocol.Codec
+                    Test.Protocol.Codec.Coherent
+                    Test.Protocol.Codec.PingPong
   build-depends:    base >=4.9 && <4.13
                   , async
                   , bytestring
@@ -66,4 +70,6 @@ test-suite test-typed-transitions
                   , tasty
                   , tasty-quickcheck
                   , text
+                  , transformers
                   , typed-transitions
+  ghc-options:    -rtsopts


### PR DESCRIPTION
What we have here is a way to test _every possible codec path_ through a given transition path for

1. Local coherence: every decoder inverts its encoder.
2. Mutual coherence: all encodings are equal for every edge (transition) in the path, regardless of which codec path was taken (encode then decode versus encode then encode, etc.).

This is mostly done [here](typed-transitions/test/Test/Protocol/Codec/Coherent.hs) by way of the `Path` datatype, which as it turns out could also be used to define `Peer`, but that's for another day.

Testing every possible path is, obviously, quite heavy on time and space, so only short paths should be used (< 10 maybe?). If this proves to be an issue, we can do randomized testing on _codec paths_: instead of building the entire tree, randomly follow some parameter number of chains of encode/decode choices, then test them for local and mutual coherence as we do now.

Also changed in here is the definition of the incremental decoder. Previously the form of the `IDecode` from cborg was used, but it was annoying because the `IDecode` can be `Partial` even after a `Nothing` was given to signal end of input stream. With the `Fold` representation given [here](typed-transitions/src/Protocol/Codec.hs), a decoder _must_ give a result (fail or ok) when the input stream is exhausted. This means a decoder is not a monad, but that's ok (_should_ a decoder be a monad, anyway?).