### PR TITLE
Monomorphize NodeCallbacks

### DIFF
--- a/src/Ouroboros/Consensus/Node.hs
+++ b/src/Ouroboros/Consensus/Node.hs
@@ -128,18 +128,14 @@ data NodeKernel m up down b = NodeKernel {
     }
 
 -- | Callbacks required when initializing the node
-data NodeCallbacks b = NodeCallbacks {
+data NodeCallbacks m b = NodeCallbacks {
       -- | Produce a block
-      produceBlock :: forall m.
-                      ( MonadRandom m
-                      , HasNodeState (BlockProtocol b) m
-                      )
-                   => IsLeader (BlockProtocol b) -- Proof we are leader
+      produceBlock :: IsLeader (BlockProtocol b) -- Proof we are leader
                    -> ExtLedgerState b -- Current ledger state
                    -> Slot             -- Current slot
                    -> Point b          -- Previous point
                    -> BlockNo          -- Previous block number
-                   -> m b
+                   -> NodeStateT (BlockProtocol b) m b
     }
 
 nodeKernel :: forall m (rndT :: (* -> *) -> (* -> *)) b up down.
@@ -160,7 +156,7 @@ nodeKernel :: forall m (rndT :: (* -> *) -> (* -> *)) b up down.
            -> BlockchainTime m
            -> ExtLedgerState b
            -> Chain b
-           -> NodeCallbacks b
+           -> NodeCallbacks (rndT (Tr m)) b
            -> m (NodeKernel m up down b)
 nodeKernel us cfg initState simRnd btime initLedger initChain NodeCallbacks{..} = do
     stateVar    <- atomically $ newTVar initState

--- a/test-consensus/Test/Dynamic/General.hs
+++ b/test-consensus/Test/Dynamic/General.hs
@@ -214,7 +214,7 @@ broadcastNetwork btime nodeInit initLedger initRNG = do
     nodes <- forM (Map.toList nodeInit) $ \(us, (cfg, initSt, initChain)) -> do
       varRes <- atomically $ newTVar Nothing
 
-      let callbacks :: NodeCallbacks (SimpleBlock p c)
+      let callbacks :: NodeCallbacks (MonadPseudoRandomT gen (Tr m)) (SimpleBlock p c)
           callbacks = NodeCallbacks {
               produceBlock = \proof l slot prevPoint prevNo -> do
                 let prevHash  = castHash (Chain.pointHash prevPoint)


### PR DESCRIPTION
The callback was required to be too polymorphic, making it impossible in client
code to use variables generated outside the scope of the node kernel.