### PR TITLE
buildable on ghc 8.4.4

### DIFF
--- a/ouroboros-network.cabal
+++ b/ouroboros-network.cabal
@@ -272,6 +272,7 @@ test-suite test-consensus
                     containers,
                     cryptonite,
                     mtl,
+                    serialise,
                     tasty,
                     tasty-quickcheck,
                     typed-transitions

--- a/src/Ouroboros/Consensus/Node.hs
+++ b/src/Ouroboros/Consensus/Node.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE NumericUnderscores  #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -117,7 +116,7 @@ realBlockchainTime systemStart slotDuration = do
     first   <- currentSlot
     slotVar <- atomically $ newTVar first
     fork $ forever $ do
-      threadDelay $ round (slotDuration * 1_000_000)
+      threadDelay $ round (slotDuration * 1000000)
       atomically . writeTVar slotVar =<< currentSlot
     return BlockchainTime {
         getCurrentSlot = readTVar slotVar

--- a/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FunctionalDependencies     #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE QuantifiedConstraints      #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
@@ -50,11 +49,6 @@ import           Ouroboros.Consensus.Util.Random
 -- block representation.
 class ( Show (ChainState    p)
       , Show (ValidationErr p)
-      , forall ph. Show      ph => Show      (Payload p ph)
-      , forall ph. Eq        ph => Eq        (Payload p ph)
-      , forall ph. Ord       ph => Ord       (Payload p ph)
-      , forall ph. Condense  ph => Condense  (Payload p ph)
-      , forall ph. Serialise ph => Serialise (Payload p ph)
       ) => OuroborosTag p where
 
   -- | Static node configuration

--- a/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
+++ b/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
@@ -64,10 +64,10 @@ instance OuroborosTag p => OuroborosTag (ExtNodeConfig cfg p) where
   checkIsLeader   (EncNodeConfig cfg _) = checkIsLeader   cfg
   applyChainState (EncNodeConfig cfg _) = applyChainState cfg
 
-deriving instance (OuroborosTag p, Eq       ph) => Eq       (Payload (ExtNodeConfig cfg p) ph)
-deriving instance (OuroborosTag p, Ord      ph) => Ord      (Payload (ExtNodeConfig cfg p) ph)
-deriving instance (OuroborosTag p, Show     ph) => Show     (Payload (ExtNodeConfig cfg p) ph)
-deriving instance (OuroborosTag p, Condense ph) => Condense (Payload (ExtNodeConfig cfg p) ph)
+deriving instance (OuroborosTag p, Eq       (Payload p ph)) => Eq       (Payload (ExtNodeConfig cfg p) ph)
+deriving instance (OuroborosTag p, Ord      (Payload p ph)) => Ord      (Payload (ExtNodeConfig cfg p) ph)
+deriving instance (OuroborosTag p, Show     (Payload p ph)) => Show     (Payload (ExtNodeConfig cfg p) ph)
+deriving instance (OuroborosTag p, Condense (Payload p ph)) => Condense (Payload (ExtNodeConfig cfg p) ph)
 
-instance (OuroborosTag p, Serialise ph) => Serialise (Payload (ExtNodeConfig cfg p) ph) where
+instance (OuroborosTag p, Serialise (Payload p ph)) => Serialise (Payload (ExtNodeConfig cfg p) ph) where
   -- use Generic instance

--- a/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -68,8 +68,8 @@ instance ( OuroborosTag p
 
     selectChain     (McsNodeConfig cfg) = selectChain' (Proxy :: Proxy c) cfg
 
-deriving instance (OuroborosTag p, Show      ph) => Show      (Payload (ModChainSel p c) ph)
-deriving instance (OuroborosTag p, Eq        ph) => Eq        (Payload (ModChainSel p c) ph)
-deriving instance (OuroborosTag p, Ord       ph) => Ord       (Payload (ModChainSel p c) ph)
-deriving instance (OuroborosTag p, Condense  ph) => Condense  (Payload (ModChainSel p c) ph)
-deriving instance (OuroborosTag p, Serialise ph) => Serialise (Payload (ModChainSel p c) ph)
+deriving instance (OuroborosTag p, Show      (Payload p ph)) => Show      (Payload (ModChainSel p c) ph)
+deriving instance (OuroborosTag p, Eq        (Payload p ph)) => Eq        (Payload (ModChainSel p c) ph)
+deriving instance (OuroborosTag p, Ord       (Payload p ph)) => Ord       (Payload (ModChainSel p c) ph)
+deriving instance (OuroborosTag p, Condense  (Payload p ph)) => Condense  (Payload (ModChainSel p c) ph)
+deriving instance (OuroborosTag p, Serialise (Payload p ph)) => Serialise (Payload (ModChainSel p c) ph)

--- a/src/Ouroboros/Consensus/Protocol/Test.hs
+++ b/src/Ouroboros/Consensus/Protocol/Test.hs
@@ -78,15 +78,15 @@ instance OuroborosTag p => OuroborosTag (TestProtocol p) where
   selectChain     (TestNodeConfig cfg _) = selectChain     cfg
   applyChainState (TestNodeConfig cfg _) = applyChainState cfg . fst
 
-deriving instance (OuroborosTag p, Show ph) => Show (Payload (TestProtocol p) ph)
-deriving instance (OuroborosTag p, Eq   ph) => Eq   (Payload (TestProtocol p) ph)
-deriving instance (OuroborosTag p, Ord  ph) => Ord  (Payload (TestProtocol p) ph)
+deriving instance (OuroborosTag p, Show (Payload p ph)) => Show (Payload (TestProtocol p) ph)
+deriving instance (OuroborosTag p, Eq   (Payload p ph)) => Eq   (Payload (TestProtocol p) ph)
+deriving instance (OuroborosTag p, Ord  (Payload p ph)) => Ord  (Payload (TestProtocol p) ph)
 
 instance Condense (Payload p ph)
       => Condense (Payload (TestProtocol p) ph) where
     condense (TestPayload pld stake) =
         condense pld <> ",stake=" <> condense stake
 
-instance (OuroborosTag p, Serialise ph)
+instance (OuroborosTag p, Serialise (Payload p ph))
       => Serialise (Payload (TestProtocol p) ph) where
   -- use generic instance

--- a/test-consensus/Test/Dynamic/General.hs
+++ b/test-consensus/Test/Dynamic/General.hs
@@ -28,6 +28,7 @@ module Test.Dynamic.General (
   , shortestLength
   ) where
 
+import           Codec.Serialise.Class (Serialise)
 import           Control.Monad
 import           Control.Monad.ST.Lazy (runST)
 import           Crypto.Number.Generate (generateBetween)
@@ -90,7 +91,11 @@ numSlots  = k * kPerEpoch * numEpochs
 type ProtocolUnderTest p = ExtNodeConfig TestConfig (TestProtocol p)
 type BlockUnderTest p    = SimpleBlock (ProtocolUnderTest p) SimpleBlockStandardCrypto
 
-prop_simple_protocol_convergence :: forall p. ProtocolLedgerView (BlockUnderTest p)
+prop_simple_protocol_convergence :: forall p.
+                                    ( ProtocolLedgerView (BlockUnderTest p), OuroborosTag p
+                                    , Serialise (Payload p (SimplePreHeader (ProtocolUnderTest p) SimpleBlockStandardCrypto))
+                                    , Eq (Payload p (SimplePreHeader (ProtocolUnderTest p) SimpleBlockStandardCrypto))
+                                    )
                                  => (Int -> NodeConfig p)
                                  -> (Int -> NodeState (ProtocolUnderTest p))
                                  -> ChainState p
@@ -109,6 +114,9 @@ test_simple_protocol_convergence :: forall m n p.
                                     , MonadSay m
                                     , MonadTimer m
                                     , ProtocolLedgerView (BlockUnderTest p)
+                                    , OuroborosTag p
+                                    , Serialise (Payload p (SimplePreHeader (ProtocolUnderTest p) SimpleBlockStandardCrypto))
+                                    , Eq (Payload p (SimplePreHeader (ProtocolUnderTest p) SimpleBlockStandardCrypto))
                                     )
                                  => (Int -> NodeConfig p)
                                  -> (Int -> NodeState (ProtocolUnderTest p))
@@ -187,6 +195,8 @@ broadcastNetwork :: forall m p c gen.
                     , MonadSay   m
                     , SimpleBlockCrypto c
                     , ProtocolLedgerView (SimpleBlock p c)
+                    , Serialise (Payload p (SimplePreHeader p c))
+                    , Eq (Payload p (SimplePreHeader p c))
                     , DRG gen
                     )
                  => BlockchainTime m


### PR DESCRIPTION
No more quantified constraints or numeric underscores.

Why? I've concluded that it's far more difficult to make cardano-sl
build on 8.6.3, than to make ouroboros-network build on 8.4.4. And we
need to bring cardano-sl in as a dependency in order to do the byron
adapter to download blocks from a real *net.