### PR TITLE
Remove unused FsPtr associated type of HasFS

### DIFF
--- a/src/Ouroboros/Storage/FS/Class.hs
+++ b/src/Ouroboros/Storage/FS/Class.hs
@@ -28,7 +28,6 @@ module Ouroboros.Storage.FS.Class (
     -- * Actual HasFS monad stacks will have ExceptT at the top
     , HasFSE
     , FsHandleE
-    , FsPtrE
     , BufferE
     -- * Re-exports from System.IO
     , SeekMode(..)
@@ -128,7 +127,6 @@ sameFsError e1 e2 = case (e1, e2) of
 
 class Monad m => HasFS m where
     type FsHandle m :: *
-    type FsPtr m    :: *
     data Buffer m   :: *
 
     newBuffer :: Int -> m (Buffer m)
@@ -166,5 +164,4 @@ class Monad m => HasFS m where
 
 type HasFSE    m = HasFS    (ExceptT FsError m)
 type FsHandleE m = FsHandle (ExceptT FsError m)
-type FsPtrE    m = FsPtr    (ExceptT FsError m)
 type BufferE   m = Buffer   (ExceptT FsError m)

--- a/src/Ouroboros/Storage/FS/IO.hs
+++ b/src/Ouroboros/Storage/FS/IO.hs
@@ -126,7 +126,6 @@ withAbsPath p act = asks (makeAbsolute p) >>= liftIOE . act
 
 instance HasFS IOFSE where
     type FsHandle IOFSE = F.FHandle
-    type FsPtr    IOFSE = Ptr Word8
     data Buffer   IOFSE =
         BufferIO {-# UNPACK #-} !(ForeignPtr Word8) {-# UNPACK #-} !Int
 
@@ -198,7 +197,7 @@ newBufferIO len = do
     return $! BufferIO fptr len
 
 withBuffer :: Buffer IOFSE
-           -> (FsPtr IOFSE -> Int -> IO a)
+           -> (Ptr Word8 -> Int -> IO a)
            -> IO a
 withBuffer (BufferIO fptr len) action =
     withForeignPtr fptr $ \ptr -> action ptr len

--- a/src/Ouroboros/Storage/FS/Sim.hs
+++ b/src/Ouroboros/Storage/FS/Sim.hs
@@ -160,7 +160,6 @@ data MockHandle m = MockHandle {
 
 instance (MonadMask m, MonadSTM m) => HasFS (SimFSE m) where
     type FsHandle (SimFSE m) = MockHandle m
-    type FsPtr    (SimFSE m) = DiskOffset
     data Buffer   (SimFSE m) = BufferMock !BS.ByteString
 
     dumpState  = mockDumpState


### PR DESCRIPTION
This associated type isn't used (anymore) by any of `HasFS`s methods or
functions parameterising over `HasFS`.