### PR TITLE
Add FsDeviceFull and FsInsufficientPermissions to FsError

### DIFF
--- a/src/Ouroboros/Storage/FS/Class.hs
+++ b/src/Ouroboros/Storage/FS/Class.hs
@@ -65,6 +65,8 @@ data FsError =
   | FsResourceDoesNotExist FsPath CallStack
   | FsResourceAlreadyExist FsPath CallStack
   | FsReachedEOF FsPath CallStack
+  | FsDeviceFull FsPath CallStack
+  | FsInsufficientPermissions FsPath CallStack
   deriving Show
 
 -- | We define a 'FsUnexpectedException' separated by the rest so that we
@@ -98,6 +100,10 @@ prettyFSError = \case
         "FsResourceAlreadyInUse for " <> show fp <> ": " <> prettyCallStack cs
     FsReachedEOF fp cs                ->
         "FsReachedEOF for " <> show fp <> ": " <> prettyCallStack cs
+    FsDeviceFull fp cs                ->
+        "FsDeviceFull for " <> show fp <> ": " <> prettyCallStack cs
+    FsInsufficientPermissions fp cs   ->
+        "FsInsufficientPermissions for " <> show fp <> ": " <> prettyCallStack cs
 
 
 -- | Check two 'FsError' for shallow equality, i.e. if they have the same
@@ -121,6 +127,10 @@ sameFsError e1 e2 = case (e1, e2) of
     (FsResourceAlreadyExist _ _, _)                                        -> False
     (FsReachedEOF fp1 _, FsReachedEOF fp2 _)                               -> fp1 == fp2
     (FsReachedEOF _ _, _)                                                  -> False
+    (FsDeviceFull fp1 _, FsDeviceFull fp2 _)                               -> fp1 == fp2
+    (FsDeviceFull _ _, _)                                                  -> False
+    (FsInsufficientPermissions fp1 _, FsInsufficientPermissions fp2 _)     -> fp1 == fp2
+    (FsInsufficientPermissions _ _, _)                                     -> False
 
 {------------------------------------------------------------------------------
  Typeclass which abstracts over the filesystem

--- a/src/Ouroboros/Storage/FS/IO.hs
+++ b/src/Ouroboros/Storage/FS/IO.hs
@@ -97,6 +97,10 @@ catchFSErrorIO (splitDirectories -> mountPoint) action = do
             return . Left =<< (FsResourceAlreadyInUse <$> getPath ioErr <*> pure callStack)
           | isEOFErrorType eType =
             return . Left =<< (FsReachedEOF <$> getPath ioErr <*> pure callStack)
+          | isFullErrorType eType =
+            return . Left =<< (FsDeviceFull <$> getPath ioErr <*> pure callStack)
+          | isPermissionErrorType eType =
+            return . Left =<< (FsInsufficientPermissions <$> getPath ioErr <*> pure callStack)
           | eType == InappropriateType =
             return . Left =<< (FsResourceInappropriateType <$> getPath ioErr <*> pure callStack)
           | otherwise = throwIO (FsUnexpectedException ioErr callStack)


### PR DESCRIPTION
These are based on the IO error/exception types `permissionErrorType` and
`fullErrorType` from `System.IO.Error`. These errors seem very likely to occur
in practice. It would therefore be good to be able to distinguish these from
other `IOException`s.