### PR TITLE
Refactor FsError to remove duplication

### DIFF
--- a/src/Ouroboros/Storage/FS/Class.hs
+++ b/src/Ouroboros/Storage/FS/Class.hs
@@ -20,6 +20,7 @@ module Ouroboros.Storage.FS.Class (
     -- * Opaque types and main API
       HasFS(..)
     , FsError(..)
+    , FsErrorType(..)
     , FsUnexpectedException(..)
     , FsPath
     , sameFsError
@@ -57,15 +58,18 @@ type FsPath = [String]
  Handling failure
 ------------------------------------------------------------------------------}
 
-data FsError =
-    FsIllegalOperation FsPath CallStack
-  | FsResourceInappropriateType FsPath CallStack
-  -- ^ e.g the user tried to open a directory with hOpen rather than a file.
-  | FsResourceAlreadyInUse FsPath CallStack
-  | FsResourceDoesNotExist FsPath CallStack
-  | FsResourceAlreadyExist FsPath CallStack
-  | FsReachedEOF FsPath CallStack
+data FsError = FsError FsErrorType FsPath CallStack
   deriving Show
+
+data FsErrorType
+  = FsIllegalOperation
+  | FsResourceInappropriateType
+  -- ^ e.g the user tried to open a directory with hOpen rather than a file.
+  | FsResourceAlreadyInUse
+  | FsResourceDoesNotExist
+  | FsResourceAlreadyExist
+  | FsReachedEOF
+  deriving (Show, Eq)
 
 -- | We define a 'FsUnexpectedException' separated by the rest so that we
 -- can still \"tag\" any exception coming from the underlying concrete monad
@@ -81,46 +85,22 @@ instance Exception FsError where
     displayException = prettyFSError
 
 isResourceDoesNotExistError :: FsError -> Bool
-isResourceDoesNotExistError (FsResourceDoesNotExist _ _) = True
-isResourceDoesNotExistError _                            = False
+isResourceDoesNotExistError (FsError FsResourceDoesNotExist _ _) = True
+isResourceDoesNotExistError _                                    = False
 
 prettyFSError :: FsError -> String
-prettyFSError = \case
-    FsIllegalOperation fp cs          ->
-        "FsIllegalOperation for " <> show fp <> ": " <> prettyCallStack cs
-    FsResourceInappropriateType fp cs ->
-        "FsResourceInappropriateType for " <> show fp <> ": " <> prettyCallStack cs
-    FsResourceAlreadyInUse fp cs      ->
-        "FsResourceAlreadyInUse for " <> show fp <> ": " <> prettyCallStack cs
-    FsResourceDoesNotExist fp cs      ->
-        "FsResourceDoesNotExist for " <> show fp <> ": " <> prettyCallStack cs
-    FsResourceAlreadyExist fp cs      ->
-        "FsResourceAlreadyInUse for " <> show fp <> ": " <> prettyCallStack cs
-    FsReachedEOF fp cs                ->
-        "FsReachedEOF for " <> show fp <> ": " <> prettyCallStack cs
+prettyFSError (FsError et fp cs) =
+    show et <> " for " <> show fp <> ": " <> prettyCallStack cs
 
 
 -- | Check two 'FsError' for shallow equality, i.e. if they have the same
--- type constructor, ignoring the 'CallStack' and the filepath, as different
--- implementations we will use different ways of representing it. For example
--- IO will use an absolute one, a mock implementation only a relative one.
--- This is very useful during tests
--- when comparing different 'HasFS' implementations and assert that they throw
--- the same FsError type, even though the callstack is naturally different.
+-- error type ('FsErrorType') and filepath, ignoring the 'CallStack'.
+--
+-- This is very useful during tests when comparing different 'HasFS'
+-- implementations and assert that they throw the same 'FsErrorType', even
+-- though the callstack is naturally different.
 sameFsError :: FsError -> FsError -> Bool
-sameFsError e1 e2 = case (e1, e2) of
-    (FsIllegalOperation fp1 _, FsIllegalOperation fp2 _)                   -> fp1 == fp2
-    (FsIllegalOperation _ _, _)                                            -> False
-    (FsResourceAlreadyInUse fp1 _, FsResourceAlreadyInUse fp2 _)           -> fp1 == fp2
-    (FsResourceAlreadyInUse _ _, _)                                        -> False
-    (FsResourceInappropriateType fp1 _, FsResourceInappropriateType fp2 _) -> fp1 == fp2
-    (FsResourceInappropriateType _ _, _)                                   -> False
-    (FsResourceDoesNotExist fp1 _, FsResourceDoesNotExist fp2 _)           -> fp1 == fp2
-    (FsResourceDoesNotExist _ _, _)                                        -> False
-    (FsResourceAlreadyExist fp1 _, FsResourceAlreadyExist fp2 _)           -> fp1 == fp2
-    (FsResourceAlreadyExist _ _, _)                                        -> False
-    (FsReachedEOF fp1 _, FsReachedEOF fp2 _)                               -> fp1 == fp2
-    (FsReachedEOF _ _, _)                                                  -> False
+sameFsError (FsError et1 fp1 _) (FsError et2 fp2 _) = et1 == et2 && fp1 == fp2
 
 {------------------------------------------------------------------------------
  Typeclass which abstracts over the filesystem

--- a/src/Ouroboros/Storage/FS/Sim.hs
+++ b/src/Ouroboros/Storage/FS/Sim.hs
@@ -210,6 +210,8 @@ mockDumpState = do
     fs <- atomically $ readTVar fsVar
     return $ prettyShowFS fs
 
+throwFsError :: (HasCallStack, MonadError FsError m) => FsErrorType -> FsPath -> m a
+throwFsError et fp = throwError (FsError et fp callStack)
 
 -- | Mock implementation of 'hOpen'.
 mockOpen :: (HasCallStack, MonadSTM m)
@@ -218,7 +220,7 @@ mockOpen :: (HasCallStack, MonadSTM m)
          -> SimFSE m (MockHandle m)
 mockOpen fp ioMode = modifyMockFS $ \fs -> do
     -- Check if the parent exists
-    parent <- noteT (FsResourceDoesNotExist fp callStack) $
+    parent <- noteT (FsError FsResourceDoesNotExist fp callStack) $
                 index (init fp) (getMockFS fs)
 
     -- Check if the file exist
@@ -227,8 +229,8 @@ mockOpen fp ioMode = modifyMockFS $ \fs -> do
             let tree' = touchFile fp (getMockFS fs)
             return (fs { getMockFS = tree' }, 0)
         Just (FileOnDisk f   ) -> return (fs, BS.length f)
-        Just (FolderOnDisk _ ) -> throwError (FsResourceInappropriateType fp callStack)
-        _ -> throwError (FsResourceDoesNotExist fp callStack)
+        Just (FolderOnDisk _ ) -> throwFsError FsResourceInappropriateType fp
+        _ -> throwFsError FsResourceDoesNotExist fp
 
     let initialOffset
           | ioMode == IO.AppendMode = fileSize
@@ -248,8 +250,8 @@ mockSeek :: forall m. (HasCallStack, MonadSTM m)
          -> SimFSE m Word64
 mockSeek (MockHandle fp _mode curOffsetVar) mode offset = withMockFS $ \fs ->
     case index fp (getMockFS fs) of
-      Nothing -> throwError $ FsResourceDoesNotExist fp callStack
-      Just (FolderOnDisk _) -> throwError $ FsResourceInappropriateType fp callStack
+      Nothing -> throwFsError FsResourceDoesNotExist fp
+      Just (FolderOnDisk _) -> throwFsError FsResourceInappropriateType fp
       Just (FileOnDisk block) -> do
         currentOffset <- readTVar curOffsetVar
         let offset' = case mode of
@@ -262,7 +264,7 @@ mockSeek (MockHandle fp _mode curOffsetVar) mode offset = withMockFS $ \fs ->
   where
     checkOverflow :: DiskOffset -> Int -> ExceptT FsError (Tr m) ()
     checkOverflow newOffset blockSize
-        | newOffset > toEnum blockSize = throwError $ FsReachedEOF fp callStack
+        | newOffset > toEnum blockSize = throwFsError FsReachedEOF fp
         | otherwise = return ()
 
 mockGet :: (HasCallStack, MonadSTM m)
@@ -271,8 +273,8 @@ mockGet :: (HasCallStack, MonadSTM m)
         -> SimFSE m ByteString
 mockGet (MockHandle fp _mode offsetVar) bytesToRead = withMockFS $ \fs -> do
     case index fp (getMockFS fs) of
-      Nothing -> throwError $ FsResourceDoesNotExist fp callStack
-      Just (FolderOnDisk _) -> throwError $ FsResourceInappropriateType fp callStack
+      Nothing -> throwFsError FsResourceDoesNotExist fp
+      Just (FolderOnDisk _) -> throwFsError FsResourceInappropriateType fp
       Just (FileOnDisk block) -> do
         offset <- readTVar offsetVar
         let r = BS.take bytesToRead . BS.drop (fromEnum offset) $ block
@@ -304,12 +306,12 @@ mockPut :: MonadSTM m
         -> Builder
         -> SimFSE m Word64
 mockPut (MockHandle fp IO.ReadMode _) _ =
-    throwError $ FsIllegalOperation fp callStack
+    throwFsError FsIllegalOperation fp
 mockPut (MockHandle fp _mode handleOffsetVar) builder = modifyMockFS $ \fs -> do
     handleOffset <- readTVar handleOffsetVar
     case index fp (getMockFS fs) of
-      Nothing -> throwError $ FsResourceDoesNotExist fp callStack
-      Just (FolderOnDisk _) -> throwError $ FsResourceInappropriateType fp callStack
+      Nothing -> throwFsError FsResourceDoesNotExist fp
+      Just (FolderOnDisk _) -> throwFsError FsResourceInappropriateType fp
       Just (FileOnDisk block) -> do
         let (unchanged, toModify) = BS.splitAt (fromEnum handleOffset) block
             block' = unchanged <> toWrite <> BS.drop (BS.length toWrite) toModify
@@ -335,8 +337,8 @@ mockTruncate :: MonadSTM m
              -> SimFSE m ()
 mockTruncate (MockHandle fp _ _) sz = modifyMockFS $ \fs ->
     case index fp (getMockFS fs) of
-      Nothing -> throwError $ FsResourceDoesNotExist fp callStack
-      Just (FolderOnDisk _) -> throwError $ FsResourceInappropriateType fp callStack
+      Nothing -> throwFsError FsResourceDoesNotExist fp
+      Just (FolderOnDisk _) -> throwFsError FsResourceInappropriateType fp
       Just (FileOnDisk block) -> do
         return ((fs { getMockFS =
             replaceFileContent fp (BS.take (fromEnum sz) block) (getMockFS fs)
@@ -413,9 +415,9 @@ mockCreateDirectory :: (HasCallStack, MonadSTM m)
                     => FsPath
                     -> SimFSE m ()
 mockCreateDirectory dir = modifyMockFS $ \fs -> do
-    _parent <- noteT (FsResourceDoesNotExist dir callStack) $
+    _parent <- noteT (FsError FsResourceDoesNotExist dir callStack) $
                    index (init dir) (getMockFS fs)
-    fs'     <- noteT (FsResourceAlreadyExist dir callStack) $
+    fs'     <- noteT (FsError FsResourceAlreadyExist dir callStack) $
                    mockCreateDirectoryStrict dir (getMockFS fs)
     return (fs { getMockFS = fs' }, ())
 
@@ -424,8 +426,8 @@ mockListDirectory :: (HasCallStack, MonadSTM m)
                   -> SimFSE m [String]
 mockListDirectory fp = withMockFS $ \fs -> do
     case index fp (getMockFS fs) of
-      Nothing -> throwError (FsResourceDoesNotExist fp callStack)
-      Just (FileOnDisk _)   -> throwError (FsResourceInappropriateType fp callStack)
+      Nothing -> throwFsError FsResourceDoesNotExist fp
+      Just (FileOnDisk _)   -> throwFsError FsResourceInappropriateType fp
       Just (FolderOnDisk m) -> return (M.keys m)
 
 mockDoesDirectoryExist :: MonadSTM m


### PR DESCRIPTION
Each constructor of `FsError` has two arguments: `FsPath` and `CallStack`. To
remove this duplication, extract the error type in a new `FsErrorType` type
with a (currently zero-argument) constructor for each type of error. Now
`FsError` only has one constructor which contains the `FsErrorType`, and the
`FsPath` and `CallStack` that are shared by all error types.

Advantages: less code and duplication. Have a look at `prettyFSError` and
`sameFsError`. The separate `FsErrorType` also makes my upcoming work on
generating `FsError`s simpler. For example, to generate errors using
QuickCheck, it is much easier if we can just define an instance of `Arbitrary`
for `FsErrorType` instead of for `FsError`.

Disadvantage: an additional level of indirection.

Note: the docstring of `sameFsError` was out of date, this has also been fixed