### PR TITLE
fix pipe sync demo by having the consumer stop when sync'd

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Pipe.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Pipe.hs
@@ -120,8 +120,8 @@ demo chain0 updates = do
         _ <- wait consumer
         _ <- wait producer
 
-        -- Problem: if it doesn't sync, it times out. That was the case before,
-        -- though.
+        -- FIXME: if it doesn't sync, it times out. Is it possible to decide
+        -- when the chain will certainly _not_ sync?
         return True
 
 pipeDuplex

--- a/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
@@ -8,7 +8,7 @@
 
 module Test.Ouroboros.Network.Node where
 
-import           Control.Monad (forM, forM_, forever, replicateM)
+import           Control.Monad (forM, forM_, replicateM)
 import           Control.Monad.ST.Lazy (runST)
 import           Control.Monad.State (execStateT, lift, modify')
 import           Data.Array

--- a/typed-transitions/src/Protocol/Channel.hs
+++ b/typed-transitions/src/Protocol/Channel.hs
@@ -41,7 +41,7 @@ data Duplex sm rm send recv = Duplex
   , recv :: rm (Maybe recv, Duplex sm rm send recv)
   }
 
--- | Change the receive type, as you would fmap a covariant functor.
+-- | Change the send type, as you would fmap a covariant functor.
 fmapDuplex
   :: ( Functor sm, Functor rm )
   => (recv -> recv')


### PR DESCRIPTION
There was an intermittent bug in which the consumer would crash with unexpected end of input. The consumer was set to run forever, no termination condition, so of course it was always trying to read input, even when the pipe closes. The solution: have the client stop when it reaches the expected chain tip.

Also included a warning fix, and some useful fmap/contramap functions for Duplex.