### PR TITLE
Name shadowing warnings

### DIFF
--- a/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
@@ -8,7 +8,7 @@
 
 module Test.Ouroboros.Network.Node where
 
-import           Control.Monad (forM, forM_, forever, replicateM)
+import           Control.Monad (forM, forM_, replicateM)
 import           Control.Monad.ST.Lazy (runST)
 import           Control.Monad.State (execStateT, lift, modify')
 import           Data.Array

--- a/typed-transitions/src/Protocol/Codec.hs
+++ b/typed-transitions/src/Protocol/Codec.hs
@@ -83,9 +83,9 @@ singletonInput :: Applicative m => input -> Input input m
 singletonInput inp = Input $ pure $ Just $ (inp, noInput)
 
 prependInput :: Applicative m => [input] -> Input input m -> Input input m
-prependInput inp tail = case inp of
-  []      -> tail
-  (i : is) -> Input $ pure (Just (i, prependInput is tail))
+prependInput inp tail_ = case inp of
+  []      -> tail_
+  (i : is) -> Input $ pure (Just (i, prependInput is tail_))
 
 -- | Use an 'Input' to run a 'Fold'.
 -- Notice how, no matter what, the output of the fold is given. That's

--- a/typed-transitions/src/Protocol/Driver.hs
+++ b/typed-transitions/src/Protocol/Driver.hs
@@ -82,5 +82,5 @@ useCodecWithDuplex duplex codec peer = case peer of
   PeerAwait k -> do
     (result, duplex') <- foldOverDuplex (decode codec) duplex
     case result of
-      Left fail -> pure $ Unexpected fail
+      Left fail_ -> pure $ Unexpected fail_
       Right (Decoded tr codec') -> useCodecWithDuplex duplex' codec' (k tr)

--- a/typed-transitions/src/Protocol/Path.hs
+++ b/typed-transitions/src/Protocol/Path.hs
@@ -29,7 +29,7 @@ data From (begin :: st) (path :: [st] -> Type) where
 
 foldPath
   :: forall cons states b .
-     (forall k states . (k -> b) -> cons k states -> b)
+     (forall k states' . (k -> b) -> cons k states' -> b)
   -> b
   -> Path cons states
   -> b


### PR DESCRIPTION
@avieth this PR removes some trivial shadowing warnings in `typed-transitions` (but not where it's good to hide them).