### PR TITLE
leader schedule combinator & test

### DIFF
--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -10,6 +10,7 @@ let
           overrides = self: super:
             { psqueues = lib.dontCheck super.psqueues;
               aeson    = lib.dontCheck super.aeson;
+              graphviz = lib.dontCheck super.graphviz;
               QuickCheck = super.QuickCheck_2_12_6_1;
               hspec = super.hspec_2_6_0;
               hspec-core = super.hspec-core_2_6_0;

--- a/ouroboros-consensus/default.nix
+++ b/ouroboros-consensus/default.nix
@@ -1,9 +1,9 @@
 { mkDerivation, aeson, async, base, base16-bytestring, bytestring
-, cborg, containers, cryptonite, directory, exceptions, filepath
-, memory, mtl, optparse-applicative, ouroboros-network, QuickCheck
-, serialise, stdenv, stm, string-conv, tasty, tasty-hunit
-, tasty-quickcheck, temporary, text, time, typed-transitions, unix
-, vector, nixpkgs
+, cborg, containers, cryptonite, directory, exceptions, fgl
+, filepath, graphviz ,memory, mtl, optparse-applicative
+, ouroboros-network, QuickCheck, serialise, stdenv, stm
+, string-conv, tasty, tasty-hunit, tasty-quickcheck, temporary
+, text, time, typed-transitions, unix , vector, nixpkgs
 }:
 mkDerivation {
   pname = "ouroboros-consensus";
@@ -14,8 +14,9 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     base base16-bytestring bytestring cborg containers cryptonite
-    directory exceptions filepath memory mtl ouroboros-network
-    QuickCheck serialise text time typed-transitions unix vector
+    directory exceptions filepath memory mtl
+    ouroboros-network QuickCheck serialise text time
+    typed-transitions unix vector
   ];
   executableHaskellDepends = [
     aeson async base bytestring cborg containers cryptonite directory
@@ -23,9 +24,9 @@ mkDerivation {
     string-conv text typed-transitions unix
   ];
   testHaskellDepends = [
-    base bytestring containers cryptonite directory exceptions mtl
-    ouroboros-network QuickCheck serialise tasty tasty-hunit
-    tasty-quickcheck temporary typed-transitions
+    base bytestring containers cryptonite directory exceptions fgl
+    graphviz mtl ouroboros-network QuickCheck serialise tasty
+    tasty-hunit tasty-quickcheck temporary typed-transitions
   ];
   description = "Consensus layer for the Ouroboros blockchain protocol";
   license = stdenv.lib.licenses.mit;

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -8,7 +8,6 @@ maintainer:          operations@iohk.io
 copyright:           2018 IOHK
 category:            Network
 build-type:          Simple
-extra-source-files:  ChangeLog.md, README.md
 cabal-version:       >=1.10
 
 source-repository head
@@ -49,6 +48,7 @@ library
                        Ouroboros.Consensus.Protocol.Abstract
                        Ouroboros.Consensus.Protocol.BFT
                        Ouroboros.Consensus.Protocol.Genesis
+                       Ouroboros.Consensus.Protocol.LeaderSchedule
                        Ouroboros.Consensus.Protocol.Praos
                        Ouroboros.Consensus.Protocol.Test
                        Ouroboros.Consensus.Protocol.ExtNodeConfig
@@ -182,6 +182,7 @@ test-suite test-consensus
   other-modules:
                     Test.Dynamic.BFT
                     Test.Dynamic.General
+                    Test.Dynamic.LeaderSchedule
                     Test.Dynamic.Network
                     Test.Dynamic.Praos
                     Test.Dynamic.Util
@@ -193,11 +194,14 @@ test-suite test-consensus
 
                     containers,
                     cryptonite,
+                    fgl,
+                    graphviz,
                     mtl,
                     QuickCheck,
                     serialise,
                     tasty,
-                    tasty-quickcheck
+                    tasty-quickcheck,
+                    text
 
   ghc-options:      -Wall
                     -fno-ignore-asserts

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock.hs
@@ -62,6 +62,7 @@ import           Ouroboros.Consensus.Node (NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
+import           Ouroboros.Consensus.Protocol.LeaderSchedule
 import           Ouroboros.Consensus.Protocol.Praos
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.Condense
@@ -358,6 +359,10 @@ instance (PraosCrypto c, SimpleBlockCrypto c')
       => ProtocolLedgerView (SimpleBlock (ExtNodeConfig AddrDist (Praos c)) c') where
   protocolLedgerView (EncNodeConfig _ addrDist) (SimpleLedgerState u _) =
       relativeStakes $ totalStakes addrDist u
+
+instance (PraosCrypto c, SimpleBlockCrypto c')
+      => ProtocolLedgerView (SimpleBlock (WithLeaderSchedule (Praos c)) c') where
+  protocolLedgerView _ _ = ()
 
 {-------------------------------------------------------------------------------
   Compute relative stake

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
@@ -60,7 +60,7 @@ instance OuroborosTag p => OuroborosTag (ExtNodeConfig cfg p) where
   mkPayload (EncNodeConfig cfg _) proof ph =
       EncPayload <$> mkPayload cfg proof ph
 
-  selectChain     (EncNodeConfig cfg _) = selectChain     cfg
+  compareChain    (EncNodeConfig cfg _) = compareChain    cfg
   checkIsLeader   (EncNodeConfig cfg _) = checkIsLeader   cfg
   applyChainState (EncNodeConfig cfg _) = applyChainState cfg
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+module Ouroboros.Consensus.Protocol.LeaderSchedule (
+    LeaderSchedule (..)
+  , WithLeaderSchedule
+  , Payload (..)
+  , NodeConfig (..)
+  ) where
+
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           GHC.Generics (Generic)
+
+import           Ouroboros.Network.Block (Slot (..))
+import           Ouroboros.Network.Serialise (Serialise)
+
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+
+newtype LeaderSchedule = LeaderSchedule {getLeaderSchedule :: Map Slot [Int]}
+    deriving (Show, Eq, Ord)
+
+instance Condense LeaderSchedule where
+    condense (LeaderSchedule m) = show
+                                $ map (\(s, ls) -> (getSlot s, ls))
+                                $ Map.toList m
+
+-- | Extension of protocol @p@ by a static leader schedule.
+data WithLeaderSchedule p
+
+class NoConstraint a
+instance NoConstraint a
+
+instance OuroborosTag p => OuroborosTag (WithLeaderSchedule p) where
+
+  -- | The payload is just the id of the block creator (just for testing).
+  newtype Payload (WithLeaderSchedule p) ph = WLSPayload {getWLSPayload :: Int}
+    deriving (Generic, Condense)
+
+  type ChainState     (WithLeaderSchedule p) = ()
+  type NodeState      (WithLeaderSchedule p) = ()
+  type LedgerView     (WithLeaderSchedule p) = ()
+  type ValidationErr  (WithLeaderSchedule p) = ()
+  type IsLeader       (WithLeaderSchedule p) = ()
+  type SupportedBlock (WithLeaderSchedule p) = NoConstraint
+
+  data NodeConfig (WithLeaderSchedule p) = WLSNodeConfig
+    { lsNodeConfigSchedule :: LeaderSchedule
+    , lsNodeConfigP        :: NodeConfig p
+    , lsNodeConfigNodeId   :: Int
+    }
+
+  mkPayload cfg () _ph = return $ WLSPayload $ lsNodeConfigNodeId cfg
+
+  compareChain WLSNodeConfig{..} = compareChain lsNodeConfigP
+
+  checkIsLeader WLSNodeConfig{..} slot _ _ = return $
+    case Map.lookup slot $ getLeaderSchedule lsNodeConfigSchedule of
+        Nothing                              -> Nothing
+        Just nids
+            | lsNodeConfigNodeId `elem` nids -> Just ()
+            | otherwise                      -> Nothing
+
+  applyChainState _ _ _ _ = return ()
+
+deriving instance (OuroborosTag p, Eq   ph) => Eq   (Payload (WithLeaderSchedule p) ph)
+deriving instance (OuroborosTag p, Ord  ph) => Ord  (Payload (WithLeaderSchedule p) ph)
+deriving instance (OuroborosTag p, Show ph) => Show (Payload (WithLeaderSchedule p) ph)
+
+instance (OuroborosTag p, Serialise ph) => Serialise (Payload (WithLeaderSchedule p) ph) where
+  -- use Generic instance

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Test.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Test.hs
@@ -75,7 +75,7 @@ instance OuroborosTag p => OuroborosTag (TestProtocol p) where
         Nothing    -> return $ Nothing
         Just proof -> return $ Just (proof, stakeOf nodeId)
 
-  selectChain     (TestNodeConfig cfg _) = selectChain     cfg
+  compareChain    (TestNodeConfig cfg _) = compareChain    cfg
   applyChainState (TestNodeConfig cfg _) = applyChainState cfg . fst
 
 deriving instance (OuroborosTag p, Show (Payload p ph)) => Show (Payload (TestProtocol p) ph)

--- a/ouroboros-consensus/test-consensus/Main.hs
+++ b/ouroboros-consensus/test-consensus/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import           Test.Tasty
 
 import qualified Test.Dynamic.BFT (tests)
+import qualified Test.Dynamic.LeaderSchedule (tests)
 import qualified Test.Dynamic.Praos (tests)
 
 main :: IO ()
@@ -12,5 +13,6 @@ tests :: TestTree
 tests =
   testGroup "ouroboros-consensus"
   [ Test.Dynamic.BFT.tests
+  , Test.Dynamic.LeaderSchedule.tests
   , Test.Dynamic.Praos.tests
   ]

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -14,7 +14,6 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-{-# OPTIONS -fno-warn-unused-binds #-}
 {-# OPTIONS -fno-warn-orphans #-}
 
 module Test.Dynamic.BFT (

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -1,0 +1,187 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+{-# OPTIONS -fno-warn-orphans #-}
+
+module Test.Dynamic.LeaderSchedule (
+    tests
+  ) where
+
+import           Control.Monad (replicateM)
+import           Data.Function (on)
+import           Data.List (foldl')
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Test.QuickCheck
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Ouroboros.Network.Block (Slot (..))
+import           Ouroboros.Network.Chain (Chain)
+import           Ouroboros.Network.Node
+
+import           Ouroboros.Consensus.Demo
+import           Ouroboros.Consensus.Ledger.Mock
+import           Ouroboros.Consensus.Node
+import           Ouroboros.Consensus.Protocol.LeaderSchedule
+import           Ouroboros.Consensus.Protocol.Praos
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Consensus.Util.Random
+
+import           Test.Dynamic.General
+import           Test.Dynamic.Praos (prop_all_common_prefix)
+import           Test.Dynamic.Util
+
+tests :: TestTree
+tests = testGroup "Dynamic chain generation"
+    [ testProperty
+        "simple leader schedule convergence" $
+            prop_simple_leader_schedule_convergence
+                (NumSlots (fromIntegral numSlots))
+                (NumCoreNodes 3)
+                params
+    ]
+  where
+    params@PraosParams{..} = defaultDemoPraosParams
+    numSlots  = praosK * praosSlotsPerEpoch * numEpochs
+    numEpochs = 3
+
+prop_simple_leader_schedule_convergence :: NumSlots
+                                        -> NumCoreNodes
+                                        -> PraosParams
+                                        -> Seed
+                                        -> Property
+prop_simple_leader_schedule_convergence numSlots numCoreNodes params seed =
+    forAllShrink
+        (genLeaderSchedule numSlots numCoreNodes params)
+        (shrinkLeaderSchedule numSlots)
+        $ \schedule ->
+            let longest = longestCrowdedRun schedule
+            in    counterexample ("schedule: " <> condense schedule <> "\n" <> show longest)
+                $ label ("longest crowded run " <> show (crowdedRunLength longest))
+                $ prop_simple_protocol_convergence
+                    (protocolInfo (DemoLeaderSchedule schedule params) numCoreNodes)
+                    isValid
+                    numSlots
+                    numCoreNodes
+                    seed
+  where
+    isValid :: [NodeId]
+            -> [(VTime, Map NodeId (Chain (Block DemoLeaderSchedule)))]
+            -> Property
+    isValid nodeIds trace =
+      case trace of
+        [(_, final)] ->   counterexample (tracesToDot' final)
+                     $    collect (shortestLength final)
+                     $    Map.keys final === nodeIds
+                     .&&. prop_all_common_prefix
+                            (fromIntegral $ praosK params)
+                            (Map.elems final)
+        _otherwise   -> property False
+
+    creator :: Block DemoLeaderSchedule -> NodeId
+    creator = CoreId
+            . getWLSPayload
+            . headerOuroboros
+            . simpleHeader
+
+    tracesToDot' :: Map NodeId (Chain (Block DemoLeaderSchedule)) -> String
+    tracesToDot' = tracesToDot creator
+
+{-------------------------------------------------------------------------------
+  Dependent generation and shrinking of leader schedules
+-------------------------------------------------------------------------------}
+
+genLeaderSchedule :: NumSlots
+                  -> NumCoreNodes
+                  -> PraosParams
+                  -> Gen LeaderSchedule
+genLeaderSchedule (NumSlots numSlots) (NumCoreNodes numCoreNodes) PraosParams{..} =
+    flip suchThat notTooCrowded $ do
+        leaders <- replicateM numSlots $ frequency
+            [ ( 4, pick 0)
+            , ( 2, pick 1)
+            , ( 1, pick 2)
+            , ( 1, pick 3)
+            ]
+        return $ LeaderSchedule $ Map.fromList $ zip [1..] leaders
+      where
+        pick :: Int -> Gen [Int]
+        pick = go [0 .. numCoreNodes - 1]
+          where
+            go :: [Int] -> Int -> Gen [Int]
+            go []   _ = return []
+            go _    0 = return []
+            go nids n = do
+                nid <- elements nids
+                xs  <- go (filter (/= nid) nids) (n - 1)
+                return $ nid : xs
+
+        notTooCrowded :: LeaderSchedule -> Bool
+        notTooCrowded schedule =
+            crowdedRunLength (longestCrowdedRun schedule) < fromIntegral praosK
+
+shrinkLeaderSchedule :: NumSlots -> LeaderSchedule -> [LeaderSchedule]
+shrinkLeaderSchedule (NumSlots numSlots) (LeaderSchedule m) =
+    [ LeaderSchedule m'
+    | slot <- [1 .. fromIntegral numSlots]
+    , m'   <- reduceSlot slot m
+    ]
+  where
+    reduceSlot :: Slot -> Map Slot [Int] -> [Map Slot [Int]]
+    reduceSlot s m' = [Map.insert s xs m' | xs <- reduceList $ m' Map.! s]
+
+    reduceList :: [a] -> [[a]]
+    reduceList []       = []
+    reduceList [_]      = []
+    reduceList (x : xs) = xs : map (x :) (reduceList xs)
+
+{-------------------------------------------------------------------------------
+  Crowded Run - longest multi-leader section of a leader schedule
+-------------------------------------------------------------------------------}
+
+-- | Describes a sequence of slots in a leader schedule with slots with
+-- more than one leader, possibly interrupted by slots without leader.
+-- There can be no such sequence, but if there is, first slot and number of
+-- multi-leader slots are given.
+newtype CrowdedRun = CrowdedRun (Maybe (Slot, Int))
+    deriving (Show, Eq)
+
+crowdedRunLength :: CrowdedRun -> Int
+crowdedRunLength (CrowdedRun m) = maybe 0 snd m
+
+instance Ord CrowdedRun where
+    compare = compare `on` crowdedRunLength
+
+noRun :: CrowdedRun
+noRun = CrowdedRun Nothing
+
+incCrowdedRun :: Slot -> CrowdedRun -> CrowdedRun
+incCrowdedRun slot (CrowdedRun Nothing)          = CrowdedRun (Just (slot, 1))
+incCrowdedRun _    (CrowdedRun (Just (slot, n))) = CrowdedRun (Just (slot, n + 1))
+
+longestCrowdedRun :: LeaderSchedule -> CrowdedRun
+longestCrowdedRun (LeaderSchedule m) = fst
+                                     $ foldl' go (noRun, noRun)
+                                     $ Map.toList
+                                     $ fmap length m
+  where
+    go :: (CrowdedRun, CrowdedRun) -> (Slot, Int) -> (CrowdedRun, CrowdedRun)
+    go (x, y) (slot, n)
+        | n == 0    = (x, y)
+        | n == 1    = (x, noRun)
+        | otherwise = let y' = incCrowdedRun slot y in (max x y', y')

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
@@ -1,13 +1,24 @@
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 module Test.Dynamic.Util (
     allEqual
   , shortestLength
+  , tracesToDot
   ) where
 
 import           Data.Foldable (foldl')
+import           Data.Graph.Inductive.Graph
+import           Data.Graph.Inductive.PatriciaTree
+import           Data.GraphViz
+import           Data.GraphViz.Attributes.Complete
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (catMaybes)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.Text.Lazy as Text
 import           Numeric.Natural (Natural)
 import           Test.QuickCheck
 
@@ -55,3 +66,114 @@ allEqual (x : xs@(_:_)) =
 
 shortestLength :: Map NodeId (Chain b) -> Natural
 shortestLength = fromIntegral . minimum . map Chain.length . Map.elems
+
+{-------------------------------------------------------------------------------
+  Generation of a dot-file to represent the trace as a graph
+-------------------------------------------------------------------------------}
+
+data BlockInfo b = BlockInfo
+    { biSlot     :: !Slot
+    , biCreator  :: !(Maybe NodeId)
+    , biHash     :: !(Hash b)
+    , biPrevious :: !(Maybe (Hash b))
+    }
+
+genesisBlockInfo :: BlockInfo b
+genesisBlockInfo = BlockInfo
+    { biSlot     = 0
+    , biCreator  = Nothing
+    , biHash     = GenesisHash
+    , biPrevious = Nothing
+    }
+
+blockInfo :: HasHeader b => (b -> NodeId) -> b -> BlockInfo b
+blockInfo creator b = BlockInfo
+    { biSlot     = blockSlot b
+    , biCreator  = Just $ creator b
+    , biHash     = BlockHash $ blockHash b
+    , biPrevious = Just $ blockPrevHash b
+    }
+
+data NodeLabel = NodeLabel
+    { nlSlot      :: Slot
+    , nlCreator   :: Maybe NodeId
+    , nlBelievers :: Set NodeId
+    }
+
+instance Labellable NodeLabel where
+    toLabelValue NodeLabel{..} = StrLabel $ Text.pack $
+           show (getSlot nlSlot)
+        <> " "
+        <> maybe "" showNodeId nlCreator
+        <> showNodeIds nlBelievers
+      where
+        fromNodeId :: NodeId -> Maybe Int
+        fromNodeId (CoreId nid) = Just nid
+        fromNodeId (RelayId _)  = Nothing
+
+        showNodeId :: NodeId -> String
+        showNodeId = maybe "" show . fromNodeId
+
+        showNodeIds :: Set NodeId -> String
+        showNodeIds nids = case catMaybes $ map fromNodeId $ Set.toList nids of
+            [] -> ""
+            xs -> " [" <> unwords (map show xs) <> "]"
+
+data EdgeLabel = EdgeLabel
+
+instance Labellable EdgeLabel where
+    toLabelValue = const $ StrLabel Text.empty
+
+tracesToDot :: forall b. HasHeader b
+            => (b -> NodeId)
+            -> Map NodeId (Chain b)
+            -> String
+tracesToDot creator traces = Text.unpack $ printDotGraph $ graphToDot quickParams graph
+  where
+    chainBlockInfos :: Chain b -> Map (Hash b) (BlockInfo b)
+    chainBlockInfos = foldChain f (Map.singleton GenesisHash genesisBlockInfo)
+      where
+        f m b = let info = blockInfo creator b
+                in  Map.insert (biHash info) info m
+
+    blockInfos :: Map (Hash b) (BlockInfo b)
+    blockInfos = Map.unions $ map chainBlockInfos $ Map.elems traces
+
+    lastHash :: Chain b -> Hash b
+    lastHash Genesis  = GenesisHash
+    lastHash (_ :> b) = BlockHash $ blockHash b
+
+    blockInfosAndBelievers :: Map (Hash b) (BlockInfo b, Set NodeId)
+    blockInfosAndBelievers = Map.foldlWithKey f i traces
+      where
+        i = (\info -> (info, Set.empty)) <$> blockInfos
+
+        f m nid chain = Map.adjust
+            (\(info, believers) -> (info, Set.insert nid believers))
+            (lastHash chain)
+            m
+
+    hashToId :: Map (Hash b) Node
+    hashToId = Map.fromList $ zip (Map.keys blockInfosAndBelievers) [0..]
+
+    ns :: [LNode NodeLabel]
+    ns = [ ( hashToId Map.! h
+           , NodeLabel
+                { nlSlot      = biSlot info
+                , nlCreator   = biCreator info
+                , nlBelievers = believers
+                }
+           )
+         | (h, (info, believers)) <- Map.toList blockInfosAndBelievers
+         ]
+
+    es :: [LEdge EdgeLabel]
+    es = map g
+       $ catMaybes
+       $ map f
+       [ (biHash info, biPrevious info) | info <- Map.elems blockInfos]
+      where f (h, mh) = (h,) <$> mh
+            g (h1, h2) = (hashToId Map.! h1, hashToId Map.! h2, EdgeLabel)
+
+    graph :: Gr NodeLabel EdgeLabel
+    graph = mkGraph ns es

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -8,7 +8,7 @@ maintainer:
 copyright:           2018 IOHK
 category:            Network
 build-type:          Simple
-extra-source-files:  ChangeLog.md, README.md
+extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
 
 source-repository head

--- a/shell.nix.lars
+++ b/shell.nix.lars
@@ -1,9 +1,0 @@
-{nixpkgs ? import <nixpkgs> { }, ghc ? nixpkgs.ghc}:
-
-with nixpkgs;
-
-haskell.lib.buildStackProject {
-  name = "datastructures";
-  buildInputs = [pkgconfig zlib ncurses gitMinimal];
-  inherit ghc;
-}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,25 @@
 ﻿resolver: nightly-2018-11-15
 packages:
-- .
+- ouroboros-consensus/
 flags: {}
 extra-package-dbs: []
-allow-newer: false
+allow-newer: true
 nix:
     enable: false
 extra-deps:
 - typed-transitions/
+- ouroboros-network/
 - cborg-0.2.1.0
+- ekg-0.4.0.15
+- ekg-core-0.1.1.6
+- ekg-json-0.1.0.6
+- fgl-5.7.0.1
+- graphviz-2999.20.0.2
+- io-streams-haproxy-1.0.0.2
 - serialise-0.2.1.0
+- snap-core-1.0.3.2
+- snap-server-1.1.0.0
 - QuickCheck-2.12.6.1
+- time-units-1.0.0
+- git: https://github.com/input-output-hk/iohk-monitoring-framework
+  commit: 09b269cd1926303902e8dea3c8703b6e588004f5


### PR DESCRIPTION
- New "leader schedule" combinator for protocols which allow prescribing a specific list of leaders for each slot; only chain selection from the underlying protocol is used, everything else is trivial.

-  Dynamic Praos test with fixed leader schedule, using the new combinator. In case of a failing test, a dot-file of the resulting trace is provided to help debugging.

- Improved the ModChainSel combinator and the Genesis chain selection rule (delegating to the underlying protocol for forks less than k blocks deep).

- changed chain selection from "ours against a list of theirs" to "ours against theirs", called it "whichChain" and implemented "selectChain" in terms of "whichChain".