### PR TITLE
disable tests by default on all ghc versions

### DIFF
--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -8,7 +8,8 @@ let
       let self      = super.pkgs;
           lib       = super.haskell.lib;
           overrides = self: super:
-            { psqueues = lib.dontCheck super.psqueues;
+            { mkDerivation = args: super.mkDerivation (args // { doCheck = false; });
+              psqueues = lib.dontCheck super.psqueues;
               aeson    = lib.dontCheck super.aeson;
               QuickCheck = super.QuickCheck_2_12_6_1;
               hspec = super.hspec_2_6_0;


### PR DESCRIPTION
We use an ultra new version of `QuickCheck`, so for lots of packages, their test suites wouldn't even build.