### PR TITLE
improved dynamic Praos test error reporting and fixed failing test

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Class.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Class.hs
@@ -7,7 +7,7 @@
 -- | Abstract digital signatures.
 module Ouroboros.Consensus.Crypto.DSIGN.Class
     ( DSIGNAlgorithm (..)
-    , SignedDSIGN
+    , SignedDSIGN (..)
     , signedDSIGN
     , verifySignedDSIGN
     ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Mock.hs
@@ -8,6 +8,7 @@ module Ouroboros.Consensus.Crypto.DSIGN.Mock
     ( MockDSIGN
     , SignKeyDSIGN(..)
     , VerKeyDSIGN(..)
+    , verKeyIdFromSigned
     ) where
 
 import qualified Data.ByteString.Base16 as B16
@@ -53,3 +54,7 @@ instance Condense (SigDSIGN MockDSIGN) where
 instance Serialise (VerKeyDSIGN MockDSIGN)
 instance Serialise (SignKeyDSIGN MockDSIGN)
 instance Serialise (SigDSIGN MockDSIGN)
+
+-- | Get the id of the signer from a signature. Used for testing.
+verKeyIdFromSigned :: SignedDSIGN MockDSIGN a -> Int
+verKeyIdFromSigned (SignedDSIGN (SigMockDSIGN _ i)) = i

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -56,6 +56,7 @@ import           Ouroboros.Network.MonadClass
 import           Ouroboros.Network.Protocol.ChainSync.Client
 import           Ouroboros.Network.Protocol.ChainSync.Server
 import           Ouroboros.Network.Protocol.ChainSync.Type
+import           Ouroboros.Network.Serialise (Serialise)
 
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -75,7 +76,7 @@ import qualified Ouroboros.Network.Node as Network
 
 -- | Core node ID
 newtype CoreNodeId = CoreNodeId Int
-  deriving (Show, Eq, Ord, Condense)
+  deriving (Show, Eq, Ord, Condense, Serialise)
 
 fromCoreNodeId :: CoreNodeId -> NodeId
 fromCoreNodeId (CoreNodeId n) = CoreId n

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -44,14 +44,23 @@ import           Test.Dynamic.General
 import           Test.Dynamic.Util
 
 tests :: TestTree
-tests = testGroup "Dynamic chain generation" [
-      testProperty "simple Praos convergence" $
-        prop_simple_praos_convergence
+tests = testGroup "Dynamic chain generation"
+    [ testProperty "simple Praos convergence - special crowded case" $
+        testPraos $ Seed ( 49644418094676
+                         , 40315957626756
+                         , 42668365444963
+                         , 9796082466547
+                         , 32684299622558
+                         )
+    , testProperty "simple Praos convergence" testPraos
+    ]
+  where
+    testPraos :: Seed -> Property
+    testPraos = prop_simple_praos_convergence
           (NumSlots (fromIntegral numSlots))
           (NumCoreNodes 3)
           params
-    ]
-  where
+
     params@PraosParams{..} = defaultDemoPraosParams
     numSlots  = praosK * praosSlotsPerEpoch * numEpochs
     numEpochs = 3
@@ -75,9 +84,20 @@ prop_simple_praos_convergence numSlots numCoreNodes params =
             -> Property
     isValid nodeIds trace = counterexample (show trace) $
       case trace of
-        [(_, final)] ->   collect (shortestLength final)
-                     $    Map.keys final === nodeIds
-                     .&&. prop_all_common_prefix praosK (Map.elems final)
+        [(_, final)] ->
+            let schedule = leaderScheduleFromTrace numSlots final
+                longest  = longestCrowdedRun schedule
+                crowded  = crowdedRunLength longest
+            in    counterexample (tracesToDot final)
+                $ counterexample (condense schedule)
+                $ counterexample (show longest)
+                $ label ("longest crowded run " <> show crowded)
+                $ collect (shortestLength final)
+                $ (Map.keys final === nodeIds)
+                  .&&. if crowded >= fromIntegral praosK
+                        then label "too crowded"     $ property True
+                        else label "not too crowded" $
+                                prop_all_common_prefix praosK (Map.elems final)
         _otherwise   -> property False
 
 prop_all_common_prefix :: (HasHeader b, Condense b, Eq b)


### PR DESCRIPTION
The dynamic Praos test failed in the unlikely case that there was a period of multiple leaders (possibly interripted by slots without leader) of length at least k.

After making the test pass in this case, the problem disappears.

Test output was also improved, giving a dot-file in case of failure and labelling longest multiple-leader periods.