### PR TITLE
fixing 'forking at most k blocks'

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Chain.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Chain.hs
@@ -66,7 +66,7 @@ forksAtMostKBlocks k ours = go
         else go bs
 
     forkingPoints :: Set (Hash b)
-    forkingPoints = takeR (chainToSeq' ours) k
+    forkingPoints = takeR (chainToSeq' ours) $ k + 1 -- we can roll back at most k blocks
 
     chainToSeq' :: Chain b -> Seq (Hash b)
     chainToSeq' c = GenesisHash :<| (BlockHash . blockHash <$> chainToSeq c)

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -121,7 +121,7 @@ genLeaderSchedule (NumSlots numSlots) (NumCoreNodes numCoreNodes) PraosParams{..
 
         notTooCrowded :: LeaderSchedule -> Bool
         notTooCrowded schedule =
-            crowdedRunLength (longestCrowdedRun schedule) < fromIntegral praosK
+            crowdedRunLength (longestCrowdedRun schedule) <= fromIntegral praosK
 
 shrinkLeaderSchedule :: NumSlots -> LeaderSchedule -> [LeaderSchedule]
 shrinkLeaderSchedule (NumSlots numSlots) (LeaderSchedule m) =

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -45,12 +45,19 @@ import           Test.Dynamic.Util
 
 tests :: TestTree
 tests = testGroup "Dynamic chain generation"
-    [ testProperty "simple Praos convergence - special crowded case" $
+    [ testProperty "simple Praos convergence - special case (issue #131)" $
         testPraos $ Seed ( 49644418094676
                          , 40315957626756
                          , 42668365444963
                          , 9796082466547
                          , 32684299622558
+                         )
+    , testProperty "simple Praos convergence - special crowded case" $
+        testPraos $ Seed ( 8871923881324151440
+                         , 881094692332313449
+                         , 3091285302407489889
+                         , 6410351877547894330
+                         , 14676014321459888687
                          )
     , testProperty "simple Praos convergence" testPraos
     ]
@@ -94,7 +101,7 @@ prop_simple_praos_convergence numSlots numCoreNodes params =
                 $ label ("longest crowded run " <> show crowded)
                 $ collect (shortestLength final)
                 $ (Map.keys final === nodeIds)
-                  .&&. if crowded >= fromIntegral praosK
+                  .&&. if crowded > fromIntegral praosK
                         then label "too crowded"     $ property True
                         else label "not too crowded" $
                                 prop_all_common_prefix praosK (Map.elems final)


### PR DESCRIPTION
Fixed the implementation of "forking at most k blocks" (needed for Praos- and Genesis chain selection): The interpretation is now that "their" chain is "forking at most k blocks" from "our" chain if and only if the forking point (last point of intersection) requires a rollback of _at most k blocks_, which means the intersection point must be among the most recent (k + 1) points.

Adjusted dynamic tests (leader schedule and Praos) accordingly and created a new special case for the Praos test (specific seed) where the "longest crowded run" (period of multiple leaders) actually exceeds k. The old special case from [issue #131](https://github.com/input-output-hk/ouroboros-network/issues/131) does no longer fall into this category.