### PR TITLE
Partial rewrite of Immutable.DB

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/Immutable/DB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Immutable/DB.hs
@@ -15,32 +15,50 @@ sophisticated ones.
 
 --}
 
-module Ouroboros.Storage.Immutable.DB (
+module Ouroboros.Storage.Immutable.DB
+  ( -- * Types
     ImmutableDB -- opaque
+  , Epoch
+  , EpochSize
   , RelativeSlot(..)
+  , EpochSlot(..)
+    -- * 'ImmutableDBError'
   , ImmutableDBError(..)
   , sameDBError
+  , prettyImmutableDBError
+    -- * API
   , withDB
+  , openDB
+  , closeDB
+  , getNextEpochSlot
+  , getEpochSize
   , getBinaryBlob
   , appendBinaryBlob
+  , startNewEpoch
   -- * Utility functions
   , liftFsError
-  -- * Pretty-printing things
-  , prettyImmutableDBError
   ) where
 
-import           Control.Monad
-import           Control.Monad.Catch
-import           Control.Monad.Except
+import           Control.Monad (void, when, unless, zipWithM_)
+import           Control.Monad.Catch (MonadCatch, MonadMask, ExitCase(..),
+                                      generalBracket, bracket, finally)
+import           Control.Monad.Except (MonadError, ExceptT(ExceptT),
+                                       withExceptT, runExceptT, throwError,
+                                       catchError)
 
 import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BS
+import           Data.Map (Map)
+import qualified Data.Map as Map
 import qualified Data.Text as T
-import           Data.Word
-import           Text.Printf
+import           Data.Word (Word, Word64)
+
+import           Text.Printf (printf)
 import           Text.Read (readMaybe)
 
-import           GHC.Stack
+import           GHC.Stack (CallStack, HasCallStack, callStack,
+                            prettyCallStack)
 
 import           Ouroboros.Storage.FS.Class
 import           Ouroboros.Storage.Util as I
@@ -62,15 +80,28 @@ The key idea is to have, for each epoch, two files on disk:
   * An \"epoch file\" is where the data is actually stored;
   * An \"index file\" used to efficiently seek within the epoch file for the
     relevant data.
+
+TODO: to prevent corruption the same database may only be opened once. Should
+we ensure this with a lock file?
+
 --}
 
 -- This is just a placeholder as we don't have (yet) a proper 'Epoch' type in
 -- this codebase.
 type Epoch = Word
 
--- | A /relative/ 'Slot' within an Epoch.
+type EpochSize = Word
+
+-- | A /relative/ slot within an Epoch.
 newtype RelativeSlot = RelativeSlot { getRelativeSlot :: Word }
-                       deriving (Eq, Num, Show)
+                       deriving (Eq, Ord, Enum, Num, Show)
+
+-- | The combination of an 'Epoch' and a 'RelativeSlot' within the epoch.
+data EpochSlot = EpochSlot
+  { _epoch        :: !Epoch
+  , _relativeSlot :: !RelativeSlot
+  } deriving (Eq, Ord, Show)
+
 
 {------------------------------------------------------------------------------
   Main types
@@ -80,29 +111,33 @@ data InternalState m = InternalState {
       _currentEpoch                    :: !Epoch
     -- ^ The current 'Epoch' the immutable store is writing into.
     , _currentEpochWriteHandle         :: !(FsHandleE m)
-    -- ^ The 'WriteHandle' for the current epoch file.
+    -- ^ The write handle for the current epoch file.
     , _currentIndexWriteHandle         :: !(FsHandleE m)
-    -- ^ The 'WriteHandle' for the current index file.
+    -- ^ The write handle for the current index file.
     , _currentLastIndexOffset          :: !Word64
     -- ^ It keeps around the last offset stored within the index file,
     -- so that we don't have to seek for it when we append.
     , _currentNextExpectedRelativeSlot :: !RelativeSlot
-    -- ^ The next relative slot we expect to see to append data to the epoch file.
+    -- ^ The next relative slot we expect to see to append data to the epoch
+    -- file.
+    --
     -- Invariant: we can't append new data passing as input a slot less than
     -- the expected one.
+    , _currentEpochSizes               :: !(Map Epoch EpochSize)
+    -- ^ The size of all past epochs and the current epoch.
+    --
+    -- Invariant: for each @epoch@, if @epoch <= '_currentEpoch'@, then
+    -- @'Map.elem' epoch '_currentEpochSizes'@.
     }
 
-
-liftFsError :: Functor m => ExceptT FsError m a -> ExceptT ImmutableDBError m a
-liftFsError = withExceptT FileSystemError
-
-mkInternalState :: forall m. (HasCallStack, MonadCatch m, HasFSE m)
+mkInternalState :: (HasCallStack, MonadCatch m, HasFSE m)
                 => FsPath
                 -> Epoch
+                -> Map Epoch EpochSize
                 -> ExceptT ImmutableDBError m (InternalState m)
-mkInternalState dbFolder epoch = do
+mkInternalState dbFolder epoch epochSizes = do
     let epochFile = dbFolder <> renderFile "epoch" epoch
-    let indexFile = dbFolder <> renderFile "index" epoch
+        indexFile = dbFolder <> renderFile "index" epoch
     eHnd <- liftFsError (hOpen epochFile AppendMode)
     iHnd <- liftFsError (do
                 h <- hOpen indexFile AppendMode
@@ -111,7 +146,7 @@ mkInternalState dbFolder epoch = do
                 when isNewFile $ void (hPut h (I.encodeIndexEntry 0))
                 return h
             )
-    return $ InternalState epoch eHnd iHnd 0 (RelativeSlot 0)
+    return $ InternalState epoch eHnd iHnd 0 (RelativeSlot 0) epochSizes
 
 
 -- | An opaque handle to an immutable database of binary blobs.
@@ -126,130 +161,346 @@ data ImmutableDB m = ImmutableDB {
 ------------------------------------------------------------------------------}
 
 -- | Errors which might arise when working with this database.
-data ImmutableDBError =
-    FileSystemError FsError
-  | EpochIsReadOnlyError Epoch Epoch CallStack
+data ImmutableDBError
+  = FileSystemError FsError
+  | OpenFinalisedEpochError Epoch Epoch CallStack
   -- ^ When opening the DB, the user requested access to an epoch which was
   -- already finalised, i.e. not writable anymore.
-  | InconsistentSlotError RelativeSlot RelativeSlot CallStack
+  --
+  -- The first parameter is the requested epoch and the second parameter is
+  -- the last epoch that can be opened.
+  | AppendToSlotInThePastError RelativeSlot RelativeSlot CallStack
   -- ^ When trying to append a new binary blob at the end of an epoch file,
-  -- the input slot was not monotonically increasing with reference to the last
-  -- performed on that epoch file.
-  | SlotDoesNotExistError (Epoch, RelativeSlot) (Epoch, RelativeSlot) CallStack
-  -- ^ When trying to read from the given 'Epoch' the input 'RelativeSlot'
-  -- was not there, either because it's too far in the future or because is
-  -- in the process of being written.
-  deriving Show
+  -- the input slot was not monotonically increasing w.r.t. the last slot that
+  -- was appended to in the epoch.
+  --
+  -- The first parameter is the input slot and the second parameter is the
+  -- next slot available for appending.
+  | ReadFutureSlotError EpochSlot EpochSlot CallStack
+  -- ^ When trying to read the slot from the epoch, the slot was not yet
+  -- occupied, either because it's too far in the future or because it is in
+  -- the process of being written.
+  --
+  -- The first parameter is the requested epoch + slot and the second
+  -- parameter is the last slot that can be read.
+  | SlotGreaterThanEpochSizeError RelativeSlot EpochSize CallStack
+  -- ^ When reading or appending to a slot in an epoch, the input slot was
+  -- greater than or equal to the size of epoch, and thus beyond the last slot
+  -- in the epoch.
+  | MissingFileError FsPath CallStack
+  -- ^ A missing epoch or index file.
+  | MissingEpochSizeError Epoch CallStack
+  -- ^ When opening a DB, the size for each past epoch and the opened epoch
+  -- must be passed. The 'Epoch' parameter is the epoch for which the size was
+  -- missing.
+  deriving (Show)
 
--- | Check two 'ImmutableDBError for shallow equality, i.e. if they have the same
--- type constructor, ignoring the 'CallStack'.
+-- | Check if 'ImmutableDBError's are equal while ignoring their 'CallStack's.
 sameDBError :: ImmutableDBError -> ImmutableDBError -> Bool
 sameDBError e1 e2 = case (e1, e2) of
     (FileSystemError fs1, FileSystemError fs2) -> sameFsError fs1 fs2
-    (FileSystemError _, _) -> False
-    (EpochIsReadOnlyError ep1 ep2 _, EpochIsReadOnlyError ep3 ep4 _) ->
-        ep1 == ep3 && ep2 == ep4
-    (EpochIsReadOnlyError _ _ _, _) -> False
-    (InconsistentSlotError s1 s2 _, InconsistentSlotError s3 s4 _) ->
-        s1 == s3 && s2 == s4
-    (InconsistentSlotError _ _ _, _) -> False
-    (SlotDoesNotExistError expected actual _, SlotDoesNotExistError exp2 act2 _) ->
-        expected == exp2 && actual == act2
-    (SlotDoesNotExistError _ _ _, _) -> False
+    (FileSystemError {}, _) -> False
+    (OpenFinalisedEpochError is1 ns1 _, OpenFinalisedEpochError is2 ns2 _) ->
+        is1 == is2 && ns1 == ns2
+    (OpenFinalisedEpochError {}, _) -> False
+    (AppendToSlotInThePastError is1 ns1 _, AppendToSlotInThePastError is2 ns2 _) ->
+        is1 == is2 && ns1 == ns2
+    (AppendToSlotInThePastError {}, _) -> False
+    (ReadFutureSlotError exp1 act1 _, ReadFutureSlotError exp2 act2 _) ->
+        exp1 == exp2 && act1 == act2
+    (ReadFutureSlotError {}, _) -> False
+    (SlotGreaterThanEpochSizeError s1 sz1 _, SlotGreaterThanEpochSizeError s2 sz2 _) ->
+        s1 == s2 && sz1 == sz2
+    (SlotGreaterThanEpochSizeError {}, _) -> False
+    (MissingFileError p1 _, MissingFileError p2 _) ->
+        p1 == p2
+    (MissingFileError {}, _) -> False
+    (MissingEpochSizeError mis1 _, MissingEpochSizeError mis2 _) ->
+        mis1 == mis2
+    (MissingEpochSizeError {}, _) -> False
 
+-- | Pretty-print an 'ImmutableDBError', including its callstack.
 prettyImmutableDBError :: ImmutableDBError -> String
 prettyImmutableDBError = \case
-    FileSystemError fs   -> prettyFSError fs
-    EpochIsReadOnlyError e1 e2 cs ->
-           "EpochIsReadOnlyError (input epoch was "
-        <> show e1
-        <> ", most recent epoch found: " <> show e2 <>"): "
+    FileSystemError fs -> prettyFSError fs
+    OpenFinalisedEpochError e1 e2 cs ->
+           "OpenFinalisedEpochError (input epoch was "
+        <> show e1 <> ", most recent epoch found: "
+        <> show e2 <> "): "
         <> prettyCallStack cs
-    InconsistentSlotError (RelativeSlot is) (RelativeSlot es) cs   ->
-           "InconsistentSlotError (input epoch was "
-        <> show is
-        <> ", expected was "
-        <> show es
-        <> "): "
+    AppendToSlotInThePastError (RelativeSlot is) (RelativeSlot es) cs ->
+           "AppendToSlotInThePastError (input slot was "
+        <> show is <> ", expected was "
+        <> show es <> "): "
         <> prettyCallStack cs
-    SlotDoesNotExistError current requested cs   ->
-           "SlotDoesNotExistError (current is "
-        <> show current
-        <> ", requested was "
-        <> show requested
-        <> "): "
+    ReadFutureSlotError requested lastSlot cs ->
+           "ReadFutureSlotError (requested was "
+        <> show requested <> ", last was "
+        <> show lastSlot <> "): "
         <> prettyCallStack cs
-
-renderFile :: String -> Epoch -> FsPath
-renderFile fileType epoch = [printf "%s-%03d.dat" fileType epoch]
+    SlotGreaterThanEpochSizeError (RelativeSlot is) sz cs ->
+           "SlotGreaterThanEpochSizeError (input slot was "
+        <> show is <> ", size was "
+        <> show sz <> "): "
+        <> prettyCallStack cs
+    MissingFileError path cs ->
+           "MissingFileError ("
+        <> show path <> "): "
+        <> prettyCallStack cs
+    MissingEpochSizeError missing cs ->
+           "MissingEpochSizeError (missing size for epoch "
+        <> show missing <> "): "
+        <> prettyCallStack cs
 
 withDB :: (HasCallStack, MonadSTM m, MonadMask m, HasFSE m)
        => FsPath
        -> Epoch
+       -> Map Epoch EpochSize
        -> (ImmutableDB m -> m (Either ImmutableDBError a))
        -> m (Either ImmutableDBError a)
-withDB fsPath epoch action = runExceptT $
-    bracket (openDB fsPath epoch) closeDB (ExceptT . action)
+withDB fsPath epoch epochSizes action = runExceptT $
+    bracket (openDB fsPath epoch epochSizes) closeDB (ExceptT . action)
 
 -- | Opens the database, creating it from scratch if the 'FilePath' points to
 -- a non-existing directory. Internally it preloads the most recent 'Epoch'.
+--
+-- A map with the size for each epoch (the past epochs and the most recent
+-- one) must be passed. When a size is missing for an epoch, a
+-- 'MissingEpochSizeError' error will be thrown.
+--
+-- __Note__: Use 'withDB' instead of this function.
 openDB :: (HasCallStack, MonadCatch m, MonadSTM m, HasFSE m)
        => FsPath
        -> Epoch
+       -> Map Epoch EpochSize
        -> ExceptT ImmutableDBError m (ImmutableDB m)
-openDB fp currentEpoch = do
-      allFiles <- liftFsError $ do
-          createDirectoryIfMissing True fp
-          listDirectory fp
-      checkEpochConsistency allFiles
-      st    <- mkInternalState fp currentEpoch
-      stVar <- atomically $ newTMVar st
-      return $ ImmutableDB stVar fp
+openDB fp currentEpoch epochSizes = do
+    checkEpochSizes
+    allFiles <- liftFsError $ do
+        createDirectoryIfMissing True fp
+        listDirectory fp
+    checkEpochConsistency allFiles
+    st    <- mkInternalState fp currentEpoch epochSizes
+    stVar <- atomically $ newTMVar st
+    return $ ImmutableDB stVar fp
   where
-      checkEpochConsistency :: (HasCallStack, MonadError ImmutableDBError m)
-                            => [String]
-                            -> m ()
-      checkEpochConsistency [] = return ()
-      checkEpochConsistency (x:xs) =
-          case parseEpochNumber x of
-               Nothing -> checkEpochConsistency xs
-               Just n  -> if n > currentEpoch
-                             then throwError (EpochIsReadOnlyError currentEpoch n callStack)
-                             else checkEpochConsistency xs
-
-      parseEpochNumber :: String -> Maybe Epoch
-      parseEpochNumber = readMaybe
-                       . T.unpack
-                       . snd
-                       . T.breakOnEnd "-"
-                       . fst
-                       . T.breakOn "."
-                       . T.pack
+    -- | Check that each @epoch, epoch <= 'currentEpoch'@ is present in
+    -- 'epochSizes'. Report the first missing one starting from epoch 0.
+    checkEpochSizes :: (HasCallStack, MonadError ImmutableDBError m)
+                    => m ()
+    checkEpochSizes = zipWithM_
+      (\expected mbActual ->
+        case mbActual of
+          Just actual | actual == expected -> return ()
+          _ -> throwError (MissingEpochSizeError expected callStack))
+      [0..currentEpoch]
+      -- Pad with 'Nothing's to stop early termination of 'zipWithM_'
+      (map (Just . fst) (Map.toAscList epochSizes) ++ repeat Nothing)
 
 
--- | Closes the database, also closing any handle which have been opened in
--- the process.
-closeDB :: (MonadSTM m, MonadMask m, HasFSE m)
+    checkEpochConsistency :: (HasCallStack, MonadError ImmutableDBError m)
+                          => [String]
+                          -> m ()
+    checkEpochConsistency = mapM_ $ \name -> case parseEpochNumber name of
+             Just n | n > currentEpoch
+               -> throwError (OpenFinalisedEpochError currentEpoch n callStack)
+             _ -> return ()
+
+    parseEpochNumber :: String -> Maybe Epoch
+    parseEpochNumber = readMaybe
+                     . T.unpack
+                     . snd
+                     . T.breakOnEnd "-"
+                     . fst
+                     . T.breakOn "."
+                     . T.pack
+
+
+-- | Closes the database, also closing any open handle.
+--
+-- __Note__: Use 'withDB' instead of this function.
+closeDB :: (HasCallStack, MonadSTM m, MonadMask m, HasFSE m)
         => ImmutableDB m -> ExceptT ImmutableDBError m ()
 closeDB ImmutableDB{..} = do
     InternalState{..} <- atomically (takeTMVar _dbInternalState)
     liftFsError $ do
       hClose _currentEpochWriteHandle `finally` hClose _currentIndexWriteHandle
 
+-- | Return the next free 'RelativeSlot' in the current epoch as an
+-- 'EpochSlot'.
+getNextEpochSlot :: (HasFSE m, MonadSTM m)
+                 => ImmutableDB m
+                 -> m (Either ImmutableDBError EpochSlot)
+getNextEpochSlot ImmutableDB {..} = runExceptT $ do
+    InternalState {..} <- atomically (readTMVar _dbInternalState)
+    return $ EpochSlot _currentEpoch _currentNextExpectedRelativeSlot
+
+-- | Look up the size of the given 'Epoch'.
+getEpochSize :: (MonadSTM m)
+             => ImmutableDB m
+             -> Epoch
+             -> m (Maybe EpochSize)
+getEpochSize ImmutableDB {..} epoch = do
+  InternalState {..} <- atomically (readTMVar _dbInternalState)
+  return $ Map.lookup epoch _currentEpochSizes
+
+
+-- | Get the binary blob stored at the given 'EpochSlot'.
+--
+-- Returns 'Nothing' if no blob was stored at the given (valid) slot.
+--
+-- Throws a 'ReadFutureSlotError' if the requested slot is in the future, i.e
+-- >= 'getNextEpochSlot'.
+--
+-- Throws a 'SlotGreaterThanEpochSizeError' if the requested (relative) slot
+-- was exceeded the size of the correspondin epoch.
+--
+-- Throws a 'MissingFileError' if the epoch or index file corresponding with
+-- the requested epoch was missing from disk.
+getBinaryBlob :: forall m. (HasCallStack, HasFSE m, MonadSTM m)
+              => ImmutableDB m
+              -> EpochSlot
+              -> m (Either ImmutableDBError (Maybe ByteString))
+getBinaryBlob ImmutableDB {..} readEpochSlot@(EpochSlot epoch relativeSlot) = runExceptT $ do
+    InternalState {..} <- atomically (readTMVar _dbInternalState)
+
+    -- Step 0: Check if the requested slot is not in the future.
+    let nextExpectedEpochSlot =
+          EpochSlot _currentEpoch _currentNextExpectedRelativeSlot
+    when (readEpochSlot >= nextExpectedEpochSlot) $
+      throwError $ ReadFutureSlotError readEpochSlot nextExpectedEpochSlot callStack
+
+    -- Step 1: Check if the requested slot within the epoch, i.e. it may not
+    -- be greater than or equal to the epoch size.
+    epochSize <- lookupEpochSize epoch _currentEpochSizes
+    when (getRelativeSlot relativeSlot >= epochSize) $
+      throwError $ SlotGreaterThanEpochSizeError relativeSlot epochSize callStack
+
+    -- Step 2: Check if the epoch and index file exists. This is important
+    -- because we might read from a past epoch other than the currently opened
+    -- epoch and we don't know yet whether its file(s) actually exist(s).
+    let epochFile = _dbFolder <> renderFile "epoch" epoch
+        indexFile = _dbFolder <> renderFile "index" epoch
+    (indexFileExists, epochFileExists) <- liftFsError $
+      (,) <$> doesFileExist indexFile <*> doesFileExist epochFile
+    unless indexFileExists $ throwError $ MissingFileError indexFile callStack
+    unless epochFileExists $ throwError $ MissingFileError epochFile callStack
+
+    liftFsError $
+      withFile epochFile ReadMode $ \eHnd ->
+        withFile indexFile ReadMode $ \iHnd -> (do
+          -- Step 3: grab the offset in bytes of the requested slot.
+          let indexSeekPosition = fromEnum relativeSlot * indexEntrySizeBytes
+          _ <- hSeek iHnd AbsoluteSeek (toEnum indexSeekPosition)
+
+          -- Step 4: computes the offset on disk and the blob size.
+          (blobOffset, !blobSize) <- do
+            bytes <- hGet iHnd (indexEntrySizeBytes * 2)
+            -- TODO best place to do this validation?
+            when (indexEntrySizeBytes + 7 > BS.length bytes - 1) $
+              throwError (FsError FsReachedEOF indexFile callStack)
+            let !start = decodeIndexEntry   bytes
+            let !end   = decodeIndexEntryAt indexEntrySizeBytes bytes
+            return (start, end - start)
+
+          if blobSize == 0
+            then return Nothing
+            else do
+              -- Step 5: Seek in the epoch file
+              _ <- hSeek eHnd AbsoluteSeek blobOffset
+              Just <$> hGet eHnd (fromEnum blobSize)) `catchError`
+          \case
+            FsError FsReachedEOF _ _ -> return Nothing
+            e                        -> throwError e
+
+-- | Appends a binary blob at the given relative slot in the current epoch
+-- file.
+--
+-- Throws an 'AppendToSlotInThePastError' if the given relative slot is before
+-- the one returned by 'getNextEpochSlot'
+--
+-- Throws a 'SlotGreaterThanEpochSizeError' if the relative slot exceeds the
+-- size of the current epoch.
+--
+-- TODO the binary blob may not be empty
+appendBinaryBlob :: (HasCallStack, HasFSE m, MonadSTM m, MonadMask m)
+                 => ImmutableDB m
+                 -> RelativeSlot
+                 -> BS.Builder
+                 -> m (Either ImmutableDBError ())
+appendBinaryBlob db relativeSlot builder = runExceptT $ do
+    modifyTMVar (_dbInternalState db) $ \st@InternalState {..} -> do
+      let eHnd = _currentEpochWriteHandle
+          iHnd = _currentIndexWriteHandle
+
+      -- Step 0: Check that the slot is >= the expected next slot and thus
+      -- not in the past.
+      when (relativeSlot < _currentNextExpectedRelativeSlot) $
+        throwError $ AppendToSlotInThePastError relativeSlot
+                     _currentNextExpectedRelativeSlot callStack
+
+      -- Step 1: Check if the requested slot within the epoch, i.e. it may not
+      -- be greater than or equal to the epoch size.
+      epochSize <- lookupEpochSize _currentEpoch _currentEpochSizes
+      when (getRelativeSlot relativeSlot >= epochSize) $
+        throwError $ SlotGreaterThanEpochSizeError relativeSlot epochSize callStack
+
+      -- Step 2: If necessary, backfill the index file for any slot we missed.
+      let (gap, backfill) = indexBackfill relativeSlot
+                                          _currentNextExpectedRelativeSlot
+                                          _currentLastIndexOffset
+      liftFsError $ do
+          when (gap /= 0) $ void $ hPut iHnd backfill
+
+          -- Step 3: Append to the end of the epoch file
+          bytesWritten <- hPut eHnd builder
+
+          -- Step 4: Update the index file
+          let newOffset = _currentLastIndexOffset + bytesWritten
+          void $ hPut iHnd (I.encodeIndexEntry newOffset)
+
+          return $ (st { _currentLastIndexOffset          = newOffset
+                       , _currentNextExpectedRelativeSlot = relativeSlot + 1
+                       }, ())
+
+-- | Close the current epoch and start a new epoch (the epoch number is
+-- incremented by 1).
+--
+-- The size of the new epoch must be started.
+startNewEpoch :: (HasCallStack, HasFSE m, MonadSTM m, MonadMask m)
+              => ImmutableDB m
+              -> EpochSize
+              -> m (Either ImmutableDBError ())
+startNewEpoch db newEpochSize = runExceptT $ do
+    modifyTMVar (_dbInternalState db) $ \InternalState {..} -> do
+      let newEpoch      = succ _currentEpoch
+          newEpochSizes = Map.insert newEpoch newEpochSize _currentEpochSizes
+      newState <- mkInternalState (_dbFolder db) newEpoch newEpochSizes
+      liftFsError $ hClose _currentIndexWriteHandle `finally`
+                    hClose _currentEpochWriteHandle
+      return $ (newState, ())
+
 {------------------------------------------------------------------------------
-  Low-level API
+  Utilities
 ------------------------------------------------------------------------------}
+
+renderFile :: String -> Epoch -> FsPath
+renderFile fileType epoch = [printf "%s-%03d.dat" fileType epoch]
+
+
+liftFsError :: Functor m => ExceptT FsError m a -> ExceptT ImmutableDBError m a
+liftFsError = withExceptT FileSystemError
 
 
 -- | The analogue of `modifyMVar`
 --
--- NOTE: This /takes/ the 'TMVar', _then_ runs the action (which might be in `IO`),
--- and then puts the 'TMVar' back, just like 'modifyMVar' does. Consequently,
--- it has the same gotchas that 'modifyMVar' does; the effects are observable
--- and it is susceptible to deadlock.
+-- NOTE: This /takes/ the 'TMVar', _then_ runs the action (which might be in
+-- `IO`), and then puts the 'TMVar' back, just like 'modifyMVar' does.
+-- Consequently, it has the same gotchas that 'modifyMVar' does; the effects
+-- are observable and it is susceptible to deadlock.
 --
 -- TODO: By rights we should really just use 'MVar' rather than TMVar',
--- but we currently don't have a simular for code using 'MVar'.
+-- but we currently don't have a simulator for code using 'MVar'.
 -- NOTE: Use of `generalBracket` (rather than the `mask ... restore` pattern
 -- of old) is essential to make sure that this still behaves correctly in monad
 -- stacks containing `ExceptT`.
@@ -257,70 +508,31 @@ modifyTMVar :: (MonadSTM m, MonadMask m)
             => TMVar m a
             -> (a -> m (a,b))
             -> m b
-modifyTMVar m action =
-  snd . fst <$> generalBracket (atomically $ takeTMVar m)
+modifyTMVar var action =
+  snd . fst <$> generalBracket (atomically $ takeTMVar var)
                    (\oldState ec -> atomically $ case ec of
-                        ExitCaseSuccess (newState,_) -> putTMVar m newState
-                        ExitCaseException _ex        -> putTMVar m oldState
-                        ExitCaseAbort                -> putTMVar m oldState
+                        ExitCaseSuccess (newState,_) -> putTMVar var newState
+                        ExitCaseException _ex        -> putTMVar var oldState
+                        ExitCaseAbort                -> putTMVar var oldState
                    ) action
 
-modifyInternalState :: (MonadMask m, HasFSE m, MonadSTM m)
-                    => ImmutableDB m
-                    -> Epoch
-                    -> (InternalState m -> ExceptT ImmutableDBError m (InternalState m, a))
-                    -> ExceptT ImmutableDBError m a
-modifyInternalState db newEpoch action = do
-    modifyTMVar (_dbInternalState db) $ \oldState -> do
-        case _currentEpoch oldState < newEpoch of
-            True -> do
-                ns <- mkInternalState (_dbFolder db) newEpoch
-                liftFsError $ do
-                  hClose (_currentIndexWriteHandle oldState)
-                  `finally`
-                  hClose (_currentEpochWriteHandle oldState)
-                action ns
-            False -> action oldState
 
-getBinaryBlob :: forall m. (HasFSE m, MonadSTM m)
-              => ImmutableDB m
-              -> (Epoch, RelativeSlot)
-              -> m (Either ImmutableDBError ByteString)
-getBinaryBlob ImmutableDB{..} (epoch, RelativeSlot relativeSlot) = do
-    InternalState{..} <- atomically (readTMVar _dbInternalState)
-
-    -- Check whether or not the requested slot can be accessed.
-    withSlotGuard _currentEpoch _currentNextExpectedRelativeSlot $ do
-        runExceptT $ liftFsError $ do
-            withFile (_dbFolder <> renderFile "epoch" epoch) ReadMode $ \eHnd ->
-                withFile (_dbFolder <> renderFile "index" epoch) ReadMode $ \iHnd -> do
-                    -- Step 1: grab the offset in bytes of the requested slot.
-                    let indexSeekPosition = fromEnum relativeSlot * indexEntrySizeBytes
-                    _ <- hSeek iHnd AbsoluteSeek (toEnum indexSeekPosition)
-
-                    -- Step 1: computes the offset on disk and the blob size.
-                    (blobOffset, !blobSize) <- do
-                        bytes <- hGet iHnd (indexEntrySizeBytes * 2)
-                        let !start = decodeIndexEntry   bytes
-                        let !end   = decodeIndexEntryAt indexEntrySizeBytes bytes
-                        return (start, end - start)
-
-                    -- Step 2: Seek in the epoch file
-                    _ <- hSeek eHnd AbsoluteSeek blobOffset
-                    hGet eHnd (fromEnum blobSize)
-  where
-    -- Checks that the slot we are trying to access is valid.
-    withSlotGuard :: Epoch
-                  -> RelativeSlot
-                  -> m (Either ImmutableDBError a)
-                  -> m (Either ImmutableDBError a)
-    withSlotGuard currentEpoch (RelativeSlot nextExpectedSlot) action
-      | epoch > currentEpoch || relativeSlot >= nextExpectedSlot =
-          return $ Left
-                 $ SlotDoesNotExistError (currentEpoch, RelativeSlot nextExpectedSlot)
-                                         (epoch, RelativeSlot relativeSlot)
-                                         callStack
-      | otherwise = action
+-- | Look up the size of the given 'Epoch'. Variant of 'getEpochSize' for
+-- internal use.
+--
+-- This should should not fail if the epoch <= the currently opened epoch and
+-- the given mapping is retrieved from the DB, as 'openDB' and 'startNewEpoch'
+-- make sure this mapping is complete.
+--
+-- Throws an 'MissingEpochSizeError' is the epoch is not in the map.
+lookupEpochSize :: (HasCallStack, MonadError ImmutableDBError m)
+                => Epoch -> Map Epoch EpochSize
+                -> m EpochSize
+lookupEpochSize epoch epochSizes
+  | Just epochSize <- Map.lookup epoch epochSizes
+  = return epochSize
+  | otherwise
+  = throwError $ MissingEpochSizeError epoch callStack
 
 
 -- | The size of each entry in the index file, namely 8 bytes for the offset
@@ -330,70 +542,29 @@ indexEntrySizeBytes = 8
 {-# INLINE indexEntrySizeBytes #-}
 
 
--- | Appends a binary blob at the end of the epoch file relative to the input
--- 'Slot', updating its index file accordingly.
-appendBinaryBlob :: (HasCallStack, HasFSE m, MonadSTM m, MonadMask m)
-                 => ImmutableDB m
-                 -> (Epoch, RelativeSlot)
-                 -> BS.Builder
-                 -> m (Either ImmutableDBError ())
-appendBinaryBlob db (epoch, relativeSlot) builder = runExceptT $ do
-    modifyInternalState db epoch $ \st@InternalState{..} -> do
-        let eHnd = _currentEpochWriteHandle
-        let iHnd = _currentIndexWriteHandle
-
-        -- Step 0: Check the consistency of the slot being written and, if
-        -- necessary, backfill the index file for any slot we missed.
-        checkSlotConsistency relativeSlot _currentNextExpectedRelativeSlot
-        let (gap, backfill) = indexBackfill relativeSlot
-                                            _currentNextExpectedRelativeSlot
-                                            _currentLastIndexOffset
-        liftFsError $ do
-            if gap /= 0
-               then void $ hPut iHnd backfill
-               else return ()
-
-            -- Step 1: Append to the end of the epoch file
-            bytesWritten <- hPut eHnd builder
-
-            -- Step 2: Update the index file
-            let newOffset = _currentLastIndexOffset + bytesWritten
-
-            void $ hPut iHnd (I.encodeIndexEntry newOffset)
-
-            return $ (st { _currentLastIndexOffset          = newOffset
-                        , _currentNextExpectedRelativeSlot = relativeSlot + 1
-                        }, ())
-
--- Enforce that the input slot we receive during a new append operation is
--- greater or equal to the next expected one.
-checkSlotConsistency :: (MonadError ImmutableDBError m, HasCallStack)
-                     => RelativeSlot
-                     -> RelativeSlot
-                     -> m ()
-checkSlotConsistency cs@(RelativeSlot currentSlot) es@(RelativeSlot expectedNext) =
-    when (currentSlot < expectedNext) $
-       throwError $ InconsistentSlotError cs es callStack
-
--- | Backfills the index file. Such situation may arise in case we \"skip\"
--- some slots, and we write into the DB, say, for example, every other slot.
--- In this case, we do need to backfill the index file to take into account
--- all the missed slot. The question is: backfill with what? The easiest choice
--- is to backfill with the last seen offset, so that when getting data out of
--- the DB, the difference between these two offset is 0, signalling there is
--- no data to be fetched for that slot.
+-- | Backfills the index file.
+--
+-- Such situation may arise in case we \"skip\" some slots, and we write into
+-- the DB, say, for example, every other slot. In this case, we do need to
+-- backfill the index file to take into account all the missed slots.
+--
+-- The question is: backfill with what? The easiest choice is to backfill with
+-- the last seen offset, so that when getting data out of the DB, the
+-- difference between these two offsets is 0, signalling there is no data to
+-- be fetched for that slot.
+--
 -- There are edge cases, however. First of all, we need to store inside the
--- 'InternalState' the \"last absolute slot seen\", because we need to check it
--- against the input one to determine whether or not we missed a slot.
--- However, the \"last absolute slot seen\" must be
--- a 'Maybe', because any other default value (like 0 for example) would be
--- incorrect. But this poses another problem:
--- Suppose we never wrote into this epoch file yet, and the user decides to
--- write in relative slot 3. Now we have a problem: we do not have any previously
--- stored slot, yet we do need to backfill, because we missed 0 1 and 2. This
--- complicates a bit the logic as we have to handle this case separately.
--- Returns the size of the \"gap\" alongise the (potentially empty) 'Builder'
--- to write.
+-- 'InternalState' the \"last absolute slot seen\", because we need to check
+-- it against the input one to determine whether or not we missed a slot.
+--
+-- However, the \"last absolute slot seen\" must be a 'Maybe', because any
+-- other default value (like 0 for example) would be incorrect. But this poses
+-- another problem: suppose we never wrote into this epoch file yet, and the
+-- user decides to write in relative slot 3. Now we have a problem: we do not
+-- have any previously stored slot, yet we do need to backfill, because we
+-- missed 0 1 and 2. This complicates a bit the logic as we have to handle
+-- this case separately. Returns the size of the \"gap\" alongside the
+-- (potentially empty) 'BS.Builder' to write.
 indexBackfill :: RelativeSlot
               -> RelativeSlot
               -> Word64


### PR DESCRIPTION
* `appendBinaryBlob` now takes a `RelativeSlot` instead of an `EpochSlot`. In
  order to append to a new epoch, one must call the new `startNewEpoch`
  function first.

* When opening a DB, a mapping from epoch to epoch size must be given. When
  starting a new epoch, the size of the new epoch must be given. This size
  mapping is used to distinguish between slots that are blank (return
  `Nothing`) and slots that are beyond the size of the epoch in
  question (throw an Error).

* New getters for the API: `getNextEpochSlot` and `getEpochSize`.

* Rename some existing error constructors to have names that better explain
  the error in question.

* Add new errors and check for them.

* General cleanup of the code.

