### PR TITLE
block fetch codec

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -53,6 +53,7 @@ library
                        Ouroboros.Network.Protocol.BlockFetch.Type
                        Ouroboros.Network.Protocol.BlockFetch.Client
                        Ouroboros.Network.Protocol.BlockFetch.Server
+                       Ouroboros.Network.Protocol.BlockFetch.Direct
 
                        -- TODO rename.
                        Ouroboros.Network.ChainSyncExamples

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -116,6 +116,7 @@ test-suite tests
                        Test.ChainProducerState
                        Test.Ouroboros.Network.Testing.Utils
                        Test.Ouroboros.Network.Testing.Arbitrary
+                       Test.Ouroboros.Network.Testing.Utils
                        Test.Ouroboros.Network.Protocol.Stream
                        Test.Ouroboros.Network.Protocol.BlockFetch
                        Test.Ouroboros.Network.Protocol.BlockFetch.Codec.Coherence

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -118,7 +118,7 @@ test-suite tests
                        Test.Ouroboros.Network.Testing.Arbitrary
                        Test.Ouroboros.Network.Protocol.Stream
                        Test.Ouroboros.Network.Protocol.BlockFetch
-                       Test.Ouroboros.Network.Protocol.BlockFetch.Codec
+                       Test.Ouroboros.Network.Protocol.BlockFetch.Codec.Coherence
                        Test.Ouroboros.Network.Node
                        Test.Pipe
   default-language:    Haskell2010

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -114,7 +114,9 @@ test-suite tests
                        Test.ChainFragment
                        Test.ChainProducerState
                        Test.Ouroboros.Network.Testing.Utils
+                       Test.Ouroboros.Network.Testing.Arbitrary
                        Test.Ouroboros.Network.Protocol.Stream
+                       Test.Ouroboros.Network.Protocol.BlockFetch
                        Test.Ouroboros.Network.Node
                        Test.Pipe
   default-language:    Haskell2010

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -118,6 +118,7 @@ test-suite tests
                        Test.Ouroboros.Network.Testing.Arbitrary
                        Test.Ouroboros.Network.Protocol.Stream
                        Test.Ouroboros.Network.Protocol.BlockFetch
+                       Test.Ouroboros.Network.Protocol.BlockFetch.Codec
                        Test.Ouroboros.Network.Node
                        Test.Pipe
   default-language:    Haskell2010
@@ -136,8 +137,10 @@ test-suite tests
                        mtl,
                        pipes,
                        QuickCheck,
+                       serialise,
                        tasty,
-                       tasty-quickcheck
+                       tasty-quickcheck,
+                       text
 
   ghc-options:         -Wall
                        -fno-ignore-asserts

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -134,6 +134,7 @@ test-suite tests
                        cborg,
                        containers,
                        fingertree,
+                       free,
                        mtl,
                        pipes,
                        QuickCheck,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -109,6 +109,7 @@ test-suite tests
   other-modules:       Test.Chain
                        Test.ChainFragment
                        Test.ChainProducerState
+                       Test.Ouroboros.Network.Testing.Utils
                        Test.Ouroboros.Network.Protocol.Stream
                        Test.Ouroboros.Network.Node
                        Test.Pipe
@@ -121,6 +122,8 @@ test-suite tests
                        io-sim            >=0.1 && < 0.2,
 
                        array,
+                       bytestring,
+                       cborg,
                        containers,
                        fingertree,
                        mtl,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -50,6 +50,9 @@ library
                        Ouroboros.Network.Protocol.Stream.Client
                        Ouroboros.Network.Protocol.Stream.Server
                        Ouroboros.Network.Protocol.Stream.Direct
+                       Ouroboros.Network.Protocol.BlockFetch.Type
+                       Ouroboros.Network.Protocol.BlockFetch.Client
+                       Ouroboros.Network.Protocol.BlockFetch.Server
 
                        -- TODO rename.
                        Ouroboros.Network.ChainSyncExamples

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -54,6 +54,7 @@ library
                        Ouroboros.Network.Protocol.BlockFetch.Client
                        Ouroboros.Network.Protocol.BlockFetch.Server
                        Ouroboros.Network.Protocol.BlockFetch.Direct
+                       Ouroboros.Network.Protocol.BlockFetch.Codec.Cbor
 
                        -- TODO rename.
                        Ouroboros.Network.ChainSyncExamples

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -119,7 +119,10 @@ test-suite tests
                        Test.Ouroboros.Network.Testing.Utils
                        Test.Ouroboros.Network.Protocol.Stream
                        Test.Ouroboros.Network.Protocol.BlockFetch
+                       Test.Ouroboros.Network.Protocol.BlockFetch.Client
+                       Test.Ouroboros.Network.Protocol.BlockFetch.Server
                        Test.Ouroboros.Network.Protocol.BlockFetch.Codec.Coherence
+                       Test.Ouroboros.Network.Protocol.BlockFetch.Pipe
                        Test.Ouroboros.Network.Node
                        Test.Pipe
   default-language:    Haskell2010
@@ -130,6 +133,7 @@ test-suite tests
                        io-sim-classes,
                        io-sim            >=0.1 && < 0.2,
 
+                       async,
                        array,
                        bytestring,
                        cborg,
@@ -138,8 +142,10 @@ test-suite tests
                        free,
                        mtl,
                        pipes,
+                       process,
                        QuickCheck,
                        serialise,
+                       stm,
                        tasty,
                        tasty-quickcheck,
                        text

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Client.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Ouroboros.Network.Protocol.BlockFetch.Client where
+
+import Protocol.Core
+
+import Ouroboros.Network.Protocol.BlockFetch.Type
+
+{-------------------------------------------------------------------------------
+  Client stream of @'BlockFetchClientProtocol'@ protocol
+-------------------------------------------------------------------------------}
+
+data BlockFetchClientSender header m a where
+
+  -- | Send a request for a range of blocks.
+  --
+  SendBlockRequestMsg
+    :: ChainRange header
+    -> m (BlockFetchClientSender header m a)
+    -> BlockFetchClientSender header m a
+
+  -- | The client decided to end the protocol.
+  --
+  SendMsgDone
+    :: a
+    -> BlockFetchClientSender header m a
+
+blockFetchClientSenderStream
+  :: ( Functor m )
+  => BlockFetchClientSender header m a
+  -> Peer BlockFetchClientProtocol
+      (BlockRequestClientMessage header)
+      ('Yielding 'StClientIdle)
+      ('Finished 'StClientDone)
+      m a
+blockFetchClientSenderStream (SendBlockRequestMsg range next) =
+  part (MessageRequestRange range) $
+    lift (blockFetchClientSenderStream <$> next)
+blockFetchClientSenderStream (SendMsgDone a) = out MessageDone (done a)
+
+{-------------------------------------------------------------------------------
+  Client stream of @'BlockFetchServerProtocol'@ protocol
+-------------------------------------------------------------------------------}
+
+-- | Handlers for server responses>
+--
+data BlockFetchClientReceiver block m a =
+     BlockFetchClientReceiver {
+
+       -- | The server has started streaming blocks.
+       --
+       recvMsgStartBatch :: block -> m (BlockFetchClientReceiveBlocks block m a),
+
+       -- | The block fetch request failed because a requested range was not on
+       -- a producer's chain.
+       --
+       recvMsgNoBlocks   :: m (BlockFetchClientReceiver block m a),
+
+       -- | The server terminated the protocol.
+       --
+       recvMsgDoneClient :: a
+     }
+
+-- | Block download handlers.
+--
+data BlockFetchClientReceiveBlocks block m a =
+     BlockFetchClientReceiveBlocks {
+       recvMsgBlock       :: block -> m (BlockFetchClientReceiveBlocks block m a),
+       recvMsgBatchDone   :: m (BlockFetchClientReceiver block m a),
+       recvMsgServerError :: m (BlockFetchClientReceiver block m a)
+     }
+
+-- | Construct @'Peer' 'BlockFetchServerProtocol'@ from
+-- @'BlockFetchClientReceiver'@.
+--
+blockFetchClientReceiverStream
+  :: forall m block header a.
+     ( Functor m )
+  => BlockFetchClientReceiver block m a
+  -> Peer BlockFetchServerProtocol
+      (BlockRequestServerMessage header block)
+      ('Awaiting 'StServerAwaiting)
+      ('Finished 'StServerDone)
+      m a
+blockFetchClientReceiverStream BlockFetchClientReceiver{recvMsgStartBatch,recvMsgNoBlocks,recvMsgDoneClient} =
+  await $ \msg -> case msg of
+    MessageStartBatch block -> lift (fetchBlocks <$> recvMsgStartBatch block)
+    MessageNoBlocks         -> lift (blockFetchClientReceiverStream <$> recvMsgNoBlocks)
+    MessageServerDone       -> done recvMsgDoneClient
+ where
+  fetchBlocks
+    :: BlockFetchClientReceiveBlocks block m a
+    -> Peer BlockFetchServerProtocol
+        (BlockRequestServerMessage header block)
+        ('Awaiting 'StServerSending)
+        ('Finished 'StServerDone)
+        m a
+  fetchBlocks BlockFetchClientReceiveBlocks{recvMsgBlock,recvMsgBatchDone,recvMsgServerError} =
+    await $ \msg -> case msg of
+      MessageBlock block -> lift (fetchBlocks <$> recvMsgBlock block)
+      MessageBatchDone   -> lift (blockFetchClientReceiverStream <$> recvMsgBatchDone)
+      MessageServerError -> lift (blockFetchClientReceiverStream <$> recvMsgServerError)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Client.hs
@@ -51,7 +51,7 @@ data BlockFetchClientReceiver block m a =
 
        -- | The server has started streaming blocks.
        --
-       recvMsgStartBatch :: block -> m (BlockFetchClientReceiveBlocks block m a),
+       recvMsgStartBatch :: m (BlockFetchClientReceiveBlocks block m a),
 
        -- | The block fetch request failed because a requested range was not on
        -- a producer's chain.
@@ -86,9 +86,9 @@ blockFetchClientReceiverStream
       m a
 blockFetchClientReceiverStream BlockFetchClientReceiver{recvMsgStartBatch,recvMsgNoBlocks,recvMsgDoneClient} =
   await $ \msg -> case msg of
-    MessageStartBatch block -> lift (fetchBlocks <$> recvMsgStartBatch block)
-    MessageNoBlocks         -> lift (blockFetchClientReceiverStream <$> recvMsgNoBlocks)
-    MessageServerDone       -> done recvMsgDoneClient
+    MessageStartBatch -> lift (fetchBlocks <$> recvMsgStartBatch)
+    MessageNoBlocks   -> lift (blockFetchClientReceiverStream <$> recvMsgNoBlocks)
+    MessageServerDone -> done recvMsgDoneClient
  where
   fetchBlocks
     :: BlockFetchClientReceiveBlocks block m a

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Client.hs
@@ -32,8 +32,8 @@ blockFetchClientSenderStream
   => BlockFetchClientSender header m a
   -> Peer BlockFetchClientProtocol
       (BlockRequestClientMessage header)
-      ('Yielding 'StClientIdle)
-      ('Finished 'StClientDone)
+      (Yielding StClientIdle)
+      (Finished StClientDone)
       m a
 blockFetchClientSenderStream (SendBlockRequestMsg range next) =
   part (MessageRequestRange range) $
@@ -81,8 +81,8 @@ blockFetchClientReceiverStream
   => BlockFetchClientReceiver block m a
   -> Peer BlockFetchServerProtocol
       (BlockRequestServerMessage header block)
-      ('Awaiting 'StServerAwaiting)
-      ('Finished 'StServerDone)
+      (Awaiting StServerAwaiting)
+      (Finished StServerDone)
       m a
 blockFetchClientReceiverStream BlockFetchClientReceiver{recvMsgStartBatch,recvMsgNoBlocks,recvMsgDoneClient} =
   await $ \msg -> case msg of
@@ -94,8 +94,8 @@ blockFetchClientReceiverStream BlockFetchClientReceiver{recvMsgStartBatch,recvMs
     :: BlockFetchClientReceiveBlocks block m a
     -> Peer BlockFetchServerProtocol
         (BlockRequestServerMessage header block)
-        ('Awaiting 'StServerSending)
-        ('Finished 'StServerDone)
+        (Awaiting StServerSending)
+        (Finished StServerDone)
         m a
   fetchBlocks BlockFetchClientReceiveBlocks{recvMsgBlock,recvMsgBatchDone,recvMsgServerError} =
     await $ \msg -> case msg of

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Client.hs
@@ -39,8 +39,8 @@ blockFetchClientSenderFromProducer
   -> BlockFetchClientSender range m a
 blockFetchClientSenderFromProducer producer = BlockFetchClientSender $
   Pipes.next producer >>= \nxt -> case nxt of
-  Left a                   -> return $ BlockFetchClientDone a
-  Right (range, producer') -> return $ BlockFetchClientRange range (blockFetchClientSenderFromProducer producer')
+    Left a                   -> return $ BlockFetchClientDone a
+    Right (range, producer') -> return $ BlockFetchClientRange range (blockFetchClientSenderFromProducer producer')
 
 blockFetchClientSenderStream
   :: ( Monad m )

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec/Cbor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec/Cbor.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE EmptyCase #-}
+module Ouroboros.Network.Protocol.BlockFetch.Codec.Cbor where
+
+import Prelude hiding (fail)
+import Control.Monad.Fail (fail)
+import Control.Monad.ST
+
+import Data.ByteString (ByteString)
+import Data.Monoid ((<>))
+import Data.Text (Text)
+import qualified Data.Text as T
+import Codec.CBOR.Encoding (Encoding, encodeListLen, encodeWord)
+import Codec.CBOR.Decoding (decodeListLen, decodeWord)
+import qualified Codec.CBOR.Decoding as CBOR (Decoder)
+import Codec.Serialise.Class (Serialise)
+import qualified Codec.Serialise.Class as CBOR
+
+import Protocol.Codec
+
+import Ouroboros.Network.Protocol.BlockFetch.Type
+import Ouroboros.Network.Protocol.Codec.Cbor (cborDecoder)
+
+blockFetchClientCodecIdle
+  :: forall s range .
+     ( Serialise range )
+  => Codec (ST s) Text Encoding ByteString (BlockRequestClientMessage range) StClientIdle
+blockFetchClientCodecIdle = Codec
+  { encode = cborEncodeIdle
+  , decode = cborDecoder cborDecodeIdle
+  }
+ where
+  cborEncodeIdle
+    :: Encoder (BlockRequestClientMessage range) StClientIdle (Encoded Encoding (Codec (ST s) Text Encoding ByteString (BlockRequestClientMessage range)))
+  cborEncodeIdle = Encoder $ \tr -> case tr of
+    MessageRequestRange range -> Encoded (encodeListLen 2 <> encodeWord 0 <> CBOR.encode range) blockFetchClientCodecIdle
+    MessageDone -> Encoded (encodeListLen 1 <> encodeWord 1) blockFetchClientCodecDone
+
+  cborDecodeIdle
+    :: CBOR.Decoder s (Decoded (BlockRequestClientMessage range) StClientIdle (Codec (ST s) Text Encoding ByteString (BlockRequestClientMessage range)))
+  cborDecodeIdle = do
+    _ <- decodeListLen
+    key <- decodeWord
+    case key of
+      0 -> do
+        range <- CBOR.decode
+        pure $ Decoded (MessageRequestRange range) blockFetchClientCodecIdle
+      1 -> pure $ Decoded MessageDone blockFetchClientCodecDone
+      _ -> fail "BlockFetchClientProtocol.idle: unexpected key"
+
+blockFetchClientCodecDone
+  :: forall s range .
+     ( Serialise range )
+  => Codec (ST s) Text Encoding ByteString (BlockRequestClientMessage range) StClientDone
+blockFetchClientCodecDone = Codec
+  { encode = Encoder $ \tr -> case tr of { }
+  , decode = Fold $ pure $ Complete [] $ pure $ Left $ T.pack "no transitions from done"
+  }
+
+blockFetchServerCodecAwaiting
+  :: forall s block .
+     ( Serialise block
+     )
+  => Codec (ST s) Text Encoding ByteString (BlockRequestServerMessage block) StServerAwaiting
+blockFetchServerCodecAwaiting = Codec
+  { encode = cborEncodeIdle
+  , decode = cborDecoder cborDecodeIdle
+  }
+ where
+  cborEncodeIdle
+    :: Encoder (BlockRequestServerMessage block) StServerAwaiting (Encoded Encoding (Codec (ST s) Text Encoding ByteString (BlockRequestServerMessage block)))
+  cborEncodeIdle = Encoder $ \tr -> case tr of
+    MessageStartBatch -> Encoded (encodeListLen 1 <> encodeWord 0) blockFetchServerCodecSending
+    MessageNoBlocks   -> Encoded (encodeListLen 1 <> encodeWord 1) blockFetchServerCodecAwaiting
+    MessageServerDone -> Encoded (encodeListLen 1 <> encodeWord 2) blockFetchServerCodecDone
+
+  cborDecodeIdle
+    :: CBOR.Decoder s (Decoded (BlockRequestServerMessage block) StServerAwaiting (Codec (ST s) Text Encoding ByteString (BlockRequestServerMessage block)))
+  cborDecodeIdle = do
+    _ <- decodeListLen
+    key <- decodeWord
+    case key of
+      0 -> pure $ Decoded MessageStartBatch blockFetchServerCodecSending
+      1 -> pure $ Decoded MessageNoBlocks blockFetchServerCodecAwaiting
+      2 -> pure $ Decoded MessageServerDone blockFetchServerCodecDone
+      _ -> fail "BlockFetchServerProtocol.awaiting: unexpected key"
+
+blockFetchServerCodecSending
+  :: forall s block .
+     ( Serialise block )
+  => Codec (ST s) Text Encoding ByteString (BlockRequestServerMessage block)
+    StServerSending
+blockFetchServerCodecSending = Codec
+  { encode = cborEncodeSending
+  , decode = cborDecoder cborDecodeSending
+  }
+ where
+  cborEncodeSending
+    :: Encoder (BlockRequestServerMessage block) StServerSending (Encoded Encoding (Codec (ST s) Text Encoding ByteString (BlockRequestServerMessage block)))
+  cborEncodeSending = Encoder $ \tr -> case tr of
+    MessageBlock block -> Encoded (encodeListLen 2 <> encodeWord 0 <> CBOR.encode block) blockFetchServerCodecSending
+    MessageBatchDone   -> Encoded (encodeListLen 1 <> encodeWord 1) blockFetchServerCodecAwaiting
+    MessageServerError -> Encoded (encodeListLen 1 <> encodeWord 2) blockFetchServerCodecAwaiting
+
+  cborDecodeSending
+    :: CBOR.Decoder s (Decoded (BlockRequestServerMessage block) StServerSending (Codec (ST s) Text Encoding ByteString (BlockRequestServerMessage block)))
+  cborDecodeSending = do
+    _ <- decodeListLen
+    key <- decodeWord
+    case key of
+      0 -> do
+        block <- CBOR.decode
+        return $ Decoded (MessageBlock block) blockFetchServerCodecSending
+      1 -> pure $ Decoded MessageBatchDone blockFetchServerCodecAwaiting
+      2 -> pure $ Decoded MessageServerError blockFetchServerCodecAwaiting
+      _ -> fail "BlockFetchServerProtocol.sending: unexpected key"
+
+blockFetchServerCodecDone
+  :: forall s block .
+     ( Serialise block )
+  => Codec (ST s) Text Encoding ByteString (BlockRequestServerMessage block) StServerDone
+blockFetchServerCodecDone = Codec
+  { encode = Encoder $ \tr -> case tr of { }
+  , decode = Fold $ pure $ Complete [] $ pure $ Left $ T.pack "no transitions from done"
+  }

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec/Cbor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec/Cbor.hs
@@ -23,6 +23,16 @@ import Protocol.Codec
 import Ouroboros.Network.Protocol.BlockFetch.Type
 import Ouroboros.Network.Protocol.Codec.Cbor (cborDecoder)
 
+{-------------------------------------------------------------------------------
+ @'BlockFetchClientProtocol'@ codec
+-------------------------------------------------------------------------------}
+
+blockFetchClientCodec
+  :: forall s range .
+     ( Serialise range )
+  => Codec (ST s) Text Encoding ByteString (BlockRequestClientMessage range) StClientIdle
+blockFetchClientCodec = blockFetchClientCodecIdle
+
 blockFetchClientCodecIdle
   :: forall s range .
      ( Serialise range )
@@ -58,6 +68,16 @@ blockFetchClientCodecDone = Codec
   { encode = Encoder $ \tr -> case tr of { }
   , decode = Fold $ pure $ Complete [] $ pure $ Left $ T.pack "no transitions from done"
   }
+
+{-------------------------------------------------------------------------------
+ @'BlockFetchServerProtocol'@ codec
+-------------------------------------------------------------------------------}
+
+blockFetchServerCodec
+  :: forall s block .
+     ( Serialise block )
+  => Codec (ST s) Text Encoding ByteString (BlockRequestServerMessage block) StServerAwaiting
+blockFetchServerCodec = blockFetchServerCodecAwaiting
 
 blockFetchServerCodecAwaiting
   :: forall s block .

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
@@ -39,9 +39,9 @@ directBlockFetchServer server client = do
     :: BlockFetchSender header block m a
     -> BlockFetchClientReceiver block m b
     -> m (a, b)
-  directSender (SendMessageStartBatch block mBlockStream) BlockFetchClientReceiver {recvMsgStartBatch} = do
+  directSender (SendMessageStartBatch mBlockStream) BlockFetchClientReceiver {recvMsgStartBatch} = do
     blockStream <- mBlockStream
-    receiveBlocks <- recvMsgStartBatch block
+    receiveBlocks <- recvMsgStartBatch
     directBlocks blockStream receiveBlocks
   directSender (SendMessageNoBlocks server') BlockFetchClientReceiver {recvMsgNoBlocks} = do
     client' <- recvMsgNoBlocks

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
@@ -16,11 +16,13 @@ directBlockFetchClient
   -> BlockFetchClientSender range m b
   -- ^ client of the @'BlockFetchClientProtocol'@ protocol
   -> m (a, b)
-directBlockFetchClient BlockFetchServerReceiver {recvMessageRequestRange} (SendBlockRequestMsg range msender) = do
-  server <- recvMessageRequestRange range
-  sender <- msender
-  directBlockFetchClient server sender
-directBlockFetchClient BlockFetchServerReceiver {recvMessageDone} (SendMsgDone b) = (,b) <$> recvMessageDone
+directBlockFetchClient BlockFetchServerReceiver {recvMessageRequestRange,recvMessageDone} (BlockFetchClientSender sender) =
+  sender >>= request
+ where
+  request (BlockFetchClientRange range sender') = do
+    server <- recvMessageRequestRange range
+    directBlockFetchClient server sender'
+  request (BlockFetchClientDone b) = (,b) <$> recvMessageDone
 
 -- | Direclty connect server and client adts of @'BlockFetchServerProtocol'@.
 --

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
@@ -20,7 +20,7 @@ directBlockFetchClient BlockFetchServerReceiver {recvMessageRequestRange} (SendB
   sender <- msender
   directBlockFetchClient server sender
 directBlockFetchClient BlockFetchServerReceiver {recvMessageDone} (SendMsgDone b) = return (recvMessageDone, b)
-       
+
 -- | Direclty connect server and client adts of @'BlockFetchServerProtocol'@.
 --
 directBlockFetchServer
@@ -46,7 +46,7 @@ directBlockFetchServer server client = do
   directSender (SendMessageNoBlocks server') BlockFetchClientReceiver {recvMsgNoBlocks} = do
     client' <- recvMsgNoBlocks
     directBlockFetchServer server' client'
-  directSender (SendMessageDone a) BlockFetchClientReceiver {recvMsgDoneClient} = return (a, recvMsgDoneClient)
+  directSender (SendMessageServerDone a) BlockFetchClientReceiver {recvMsgDoneClient} = return (a, recvMsgDoneClient)
 
   directBlocks
     :: BlockFetchSendBlocks header block m a

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
@@ -10,9 +10,9 @@ import Ouroboros.Network.Protocol.BlockFetch.Server
 --
 directBlockFetchClient
   :: Monad m
-  => BlockFetchServerReceiver header m a
+  => BlockFetchServerReceiver range m a
   -- ^ server of the @'BlockFetchClientProtocol'@ protocol
-  -> BlockFetchClientSender header m b
+  -> BlockFetchClientSender range m b
   -- ^ client of the @'BlockFetchClientProtocol'@ protocol
   -> m (a, b)
 directBlockFetchClient BlockFetchServerReceiver {recvMessageRequestRange} (SendBlockRequestMsg range msender) = do
@@ -24,9 +24,9 @@ directBlockFetchClient BlockFetchServerReceiver {recvMessageDone} (SendMsgDone b
 -- | Direclty connect server and client adts of @'BlockFetchServerProtocol'@.
 --
 directBlockFetchServer
-  :: forall header block m a b.
+  :: forall block m a b.
      Monad m
-  => BlockFetchServerSender header block m a
+  => BlockFetchServerSender block m a
   -- ^ server of the @'BlockFetchServerProtocol'@ protocol
   -> BlockFetchClientReceiver block m b
   -- ^ client of the @'BlockFetchServerProtocol'@ protocol
@@ -36,7 +36,7 @@ directBlockFetchServer server client = do
   directSender sender client
  where
   directSender
-    :: BlockFetchSender header block m a
+    :: BlockFetchSender block m a
     -> BlockFetchClientReceiver block m b
     -> m (a, b)
   directSender (SendMessageStartBatch mBlockStream) BlockFetchClientReceiver {recvMsgStartBatch} = do
@@ -49,7 +49,7 @@ directBlockFetchServer server client = do
   directSender (SendMessageServerDone a) BlockFetchClientReceiver {recvMsgDoneClient} = return (a, recvMsgDoneClient)
 
   directBlocks
-    :: BlockFetchSendBlocks header block m a
+    :: BlockFetchSendBlocks block m a
     -> BlockFetchClientReceiveBlocks block m b
     -> m (a, b)
   directBlocks (SendMessageBlock block mBlockStream) BlockFetchClientReceiveBlocks {recvMsgBlock} = do

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
@@ -26,13 +26,13 @@ directBlockFetchClient BlockFetchServerReceiver {recvMessageDone} (SendMsgDone b
 directBlockFetchServer
   :: forall header block m a b.
      Monad m
-  => BlockFetchServer header block m a
+  => BlockFetchServerSender header block m a
   -- ^ server of the @'BlockFetchServerProtocol'@ protocol
   -> BlockFetchClientReceiver block m b
   -- ^ client of the @'BlockFetchServerProtocol'@ protocol
   -> m (a, b)
 directBlockFetchServer server client = do
-  sender <- runBlockFetchServer server
+  sender <- runBlockFetchServerSender server
   directSender sender client
  where
   directSender

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 
 module Ouroboros.Network.Protocol.BlockFetch.Direct where
 
@@ -19,7 +20,7 @@ directBlockFetchClient BlockFetchServerReceiver {recvMessageRequestRange} (SendB
   server <- recvMessageRequestRange range
   sender <- msender
   directBlockFetchClient server sender
-directBlockFetchClient BlockFetchServerReceiver {recvMessageDone} (SendMsgDone b) = return (recvMessageDone, b)
+directBlockFetchClient BlockFetchServerReceiver {recvMessageDone} (SendMsgDone b) = (,b) <$> recvMessageDone
 
 -- | Direclty connect server and client adts of @'BlockFetchServerProtocol'@.
 --

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Direct.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Network.Protocol.BlockFetch.Direct where
+
+import Ouroboros.Network.Protocol.BlockFetch.Client
+import Ouroboros.Network.Protocol.BlockFetch.Server
+
+-- | Directly connect server and client adts of @'BlockFetchClientProtocol'@.
+--
+directBlockFetchClient
+  :: Monad m
+  => BlockFetchServerReceiver header m a
+  -- ^ server of the @'BlockFetchClientProtocol'@ protocol
+  -> BlockFetchClientSender header m b
+  -- ^ client of the @'BlockFetchClientProtocol'@ protocol
+  -> m (a, b)
+directBlockFetchClient BlockFetchServerReceiver {recvMessageRequestRange} (SendBlockRequestMsg range msender) = do
+  server <- recvMessageRequestRange range
+  sender <- msender
+  directBlockFetchClient server sender
+directBlockFetchClient BlockFetchServerReceiver {recvMessageDone} (SendMsgDone b) = return (recvMessageDone, b)
+       
+-- | Direclty connect server and client adts of @'BlockFetchServerProtocol'@.
+--
+directBlockFetchServer
+  :: forall header block m a b.
+     Monad m
+  => BlockFetchServer header block m a
+  -- ^ server of the @'BlockFetchServerProtocol'@ protocol
+  -> BlockFetchClientReceiver block m b
+  -- ^ client of the @'BlockFetchServerProtocol'@ protocol
+  -> m (a, b)
+directBlockFetchServer server client = do
+  sender <- runBlockFetchServer server
+  directSender sender client
+ where
+  directSender
+    :: BlockFetchSender header block m a
+    -> BlockFetchClientReceiver block m b
+    -> m (a, b)
+  directSender (SendMessageStartBatch block mBlockStream) BlockFetchClientReceiver {recvMsgStartBatch} = do
+    blockStream <- mBlockStream
+    receiveBlocks <- recvMsgStartBatch block
+    directBlocks blockStream receiveBlocks
+  directSender (SendMessageNoBlocks server') BlockFetchClientReceiver {recvMsgNoBlocks} = do
+    client' <- recvMsgNoBlocks
+    directBlockFetchServer server' client'
+  directSender (SendMessageDone a) BlockFetchClientReceiver {recvMsgDoneClient} = return (a, recvMsgDoneClient)
+
+  directBlocks
+    :: BlockFetchSendBlocks header block m a
+    -> BlockFetchClientReceiveBlocks block m b
+    -> m (a, b)
+  directBlocks (SendMessageBlock block mBlockStream) BlockFetchClientReceiveBlocks {recvMsgBlock} = do
+    blockStream   <- mBlockStream
+    receiveBlocks <- recvMsgBlock block
+    directBlocks blockStream receiveBlocks
+  directBlocks (SendMessageBatchDone server') BlockFetchClientReceiveBlocks {recvMsgBatchDone} =
+    recvMsgBatchDone >>= directBlockFetchServer server'

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Server.hs
@@ -59,8 +59,8 @@ blockFetchServerReceiverStream
   => BlockFetchServerReceiver header m a
   -> Peer BlockFetchClientProtocol
       (BlockRequestClientMessage header)
-        ('Awaiting 'StClientIdle)
-        ('Finished 'StClientDone)
+        (Awaiting StClientIdle)
+        (Finished StClientDone)
         m a
 blockFetchServerReceiverStream BlockFetchServerReceiver{recvMessageRequestRange,recvMessageDone} =
   await $ \msg -> case msg of
@@ -124,8 +124,8 @@ blockFetchServerStream
   => BlockFetchServer header block m a
   -> Peer BlockFetchServerProtocol
       (BlockRequestServerMessage header block)
-      ('Yielding 'StServerAwaiting)
-      ('Finished 'StServerDone)
+      (Yielding StServerAwaiting)
+      (Finished StServerDone)
       m a
 blockFetchServerStream server = lift $ handleStAwait <$> runBlockFetchServer server
  where
@@ -133,8 +133,8 @@ blockFetchServerStream server = lift $ handleStAwait <$> runBlockFetchServer ser
     :: BlockFetchSender header block m a
     -> Peer BlockFetchServerProtocol
         (BlockRequestServerMessage header block)
-        ('Yielding 'StServerAwaiting)
-        ('Finished 'StServerDone)
+        (Yielding StServerAwaiting)
+        (Finished StServerDone)
         m a
   handleStAwait (SendMessageStartBatch block msender)
     = part (MessageStartBatch block) (lift $ sendBlocks <$> msender)
@@ -145,8 +145,8 @@ blockFetchServerStream server = lift $ handleStAwait <$> runBlockFetchServer ser
     :: BlockFetchSendBlocks header block m a
     -> Peer BlockFetchServerProtocol
         (BlockRequestServerMessage header block)
-        ('Yielding 'StServerSending)
-        ('Finished 'StServerDone)
+        (Yielding StServerSending)
+        (Finished StServerDone)
         m a
   sendBlocks (SendMessageBlock block msender) =
     part (MessageBlock block) (lift $ sendBlocks <$> msender)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Server.hs
@@ -153,7 +153,7 @@ blockFetchServerStream server = lift $ handleStAwait <$> runBlockFetchServerSend
   sendBlocks (SendMessageBatchDone server') =
     part MessageBatchDone (blockFetchServerStream server')
 
--- | Sender of the @'BlockFetchServerProtocol'@.  It may sand
+-- | Sender of the @'BlockFetchServerProtocol'@.  It may send
 -- @'MessageServerDone'@ under two conditions:
 --
 --  * @'StreamElement' range@ returned @'End'@, which means that the
@@ -182,7 +182,7 @@ blockFetchServerSender serverDone mrange blockStream = BlockFetchServerSender $ 
         Just stream -> do
           stream' <- Pipes.next stream
           case stream' of
-            Left _             -> return $ SendMessageNoBlocks (blockFetchServerSender serverDone mrange blockStream)
+            Left _          -> return $ SendMessageNoBlocks (blockFetchServerSender serverDone mrange blockStream)
             Right (b, next) -> return $ SendMessageStartBatch (sendStream b next)
  where
   sendStream

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Server.hs
@@ -1,0 +1,138 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Network.Protocol.BlockFetch.Server where
+
+import Data.Functor (($>))
+import Protocol.Core
+
+import Ouroboros.Network.Protocol.BlockFetch.Type
+
+{-------------------------------------------------------------------------------
+  Server stream of @'BlockFetchClientProtocol'@ protocol
+-------------------------------------------------------------------------------}
+
+data BlockFetchServerReceiver header m a =
+  BlockFetchServerReceiver {
+    -- | handler for @'MessageRequestRange'@ of the @'BlockFetchClientProtocol'@
+    --
+    recvMessageRequestRange :: ChainRange header -> m (BlockFetchServerReceiver header m a),
+    -- | handler for @'MessageDone'@ of the @'BlockFetchClientProtocol'@
+    --
+    recvMessageDone :: a
+  }
+
+-- | A receiver which applies an action to the received input, e.g. writting the
+-- received @'ChainRange' header@ to an internal queue.
+--
+constantReceiver
+  :: Functor m
+  => (ChainRange header -> m ())
+  -> a
+  -> BlockFetchServerReceiver header m a
+constantReceiver handleRequest recvMessageDone = BlockFetchServerReceiver {
+    recvMessageRequestRange = \range -> handleRequest range $> constantReceiver handleRequest recvMessageDone,
+    recvMessageDone
+  }
+
+blockFetchServerReceiverStream
+  :: forall header m a.
+     Functor m
+  => BlockFetchServerReceiver header m a
+  -> Peer BlockFetchClientProtocol
+      (BlockRequestClientMessage header)
+        ('Awaiting 'StClientIdle)
+        ('Finished 'StClientDone)
+        m a
+blockFetchServerReceiverStream BlockFetchServerReceiver{recvMessageRequestRange,recvMessageDone} =
+  await $ \msg -> case msg of
+    MessageRequestRange range -> lift (blockFetchServerReceiverStream <$> recvMessageRequestRange range)
+    MessageDone -> done recvMessageDone
+
+{-------------------------------------------------------------------------------
+  Server stream of @'BlockFetchServerProtocol'@ protocol
+-------------------------------------------------------------------------------}
+
+-- | @'BlockFetchServer'@ serves blocks to the corresponding client.
+--
+newtype BlockFetchServer header block m a = BlockFetchServer {
+    runBlockFetchServer :: m (BlockFetchSender header block m a)
+  }
+
+-- | Send batches of blocks, when a batch is sent loop using
+-- @'BlockFetchServer'@.
+--
+data BlockFetchSender header block m a where
+
+  -- | Initiate a batch of blocks.
+  SendMessageStartBatch
+    :: block
+    -> m (BlockFetchSendBlocks header block m a)
+    -> BlockFetchSender header block m a
+
+  -- | We served a batch, now loop using @'BlockFetchServer'@
+  SendMessageNoBlocks
+    :: BlockFetchServer header block m a
+    -> BlockFetchSender header block m a
+
+  -- | Server decided to end the protocol.
+  SendMessageDone
+    :: a
+    -> BlockFetchSender header block m a
+
+-- | Stream batch of blocks until 
+--
+data BlockFetchSendBlocks header block m a where
+
+  -- | Send a single block and recurse.
+  --
+  SendMessageBlock
+    :: block
+    -> m (BlockFetchSendBlocks header block m a)
+    -> BlockFetchSendBlocks header block m a
+
+  -- | End of the stream of blocks.
+  --
+  SendMessageBatchDone
+    :: BlockFetchServer header block m a
+    -> BlockFetchSendBlocks header block m a
+
+-- | Interpratation of @'BlockFetchServer'@ as a @'Peer'@ of the
+-- @'BlockFetchServerProtocol'@ protocol.
+--
+blockFetchServerStream
+  :: forall header block m a.
+     Functor m
+  => BlockFetchServer header block m a
+  -> Peer BlockFetchServerProtocol
+      (BlockRequestServerMessage header block)
+      ('Yielding 'StServerAwaiting)
+      ('Finished 'StServerDone)
+      m a
+blockFetchServerStream server = lift $ handleStAwait <$> runBlockFetchServer server
+ where
+  handleStAwait
+    :: BlockFetchSender header block m a
+    -> Peer BlockFetchServerProtocol
+        (BlockRequestServerMessage header block)
+        ('Yielding 'StServerAwaiting)
+        ('Finished 'StServerDone)
+        m a
+  handleStAwait (SendMessageStartBatch block msender)
+    = part (MessageStartBatch block) (lift $ sendBlocks <$> msender)
+  handleStAwait (SendMessageNoBlocks server') = blockFetchServerStream server'
+  handleStAwait (SendMessageDone a)           = out MessageServerDone (done a)
+
+  sendBlocks
+    :: BlockFetchSendBlocks header block m a
+    -> Peer BlockFetchServerProtocol
+        (BlockRequestServerMessage header block)
+        ('Yielding 'StServerSending)
+        ('Finished 'StServerDone)
+        m a
+  sendBlocks (SendMessageBlock block msender) =
+    part (MessageBlock block) (lift $ sendBlocks <$> msender)
+  sendBlocks (SendMessageBatchDone server') =
+    part MessageBatchDone (blockFetchServerStream server')

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Server.hs
@@ -24,7 +24,7 @@ import qualified Pipes
 
 import Protocol.Core
 
-import Ouroboros.Network.MonadClass.MonadSTM (MonadSTM (..))
+import Control.Monad.Class.MonadSTM (MonadSTM (..))
 
 import Ouroboros.Network.Protocol.BlockFetch.Type
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -121,6 +121,7 @@ data ServerState where
   StServerSending  :: ServerState
   -- server termination message
   StServerDone     :: ServerState
+  deriving (Show, Eq)
 
 type instance Partition BlockFetchServerProtocol st client server terminal =
   BlockFetchServerPartition st client server terminal

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -1,6 +1,43 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeFamilies #-}
+
+{-
+ Block fetching consists of two protocols: submission of block ranges 'BlockFetchClientProtocol', and
+ streaming of blocks 'BlockFetchServerProtocol'.
+
+  client server
+   |       |
+   | \     |
+   |  \    | 'BlockFetchClientProtocol' (requesting a range)
+   |   \   |
+   |    \  |
+   |     \ |
+   |     / |
+   |    /  |
+   |\  / / | 'BlockFetchServerProtocol' (streaming blocks)
+   | \/ /  |
+   | /\/ / |
+   |  /\/  |
+   | / /\  |
+   |  /  \ |
+   | /   / |
+   |    /  |
+   |   / / |
+   |  / /  |
+   | / / / |
+   |  / /  |
+   | / /   |
+   |  /    |
+
+  Request submitted by @'BlockFetchClientProtocol'@ are recorded by the server
+  and supplied to the @'BlockFetchServerProtocol'@.  This way we achieve
+  protocol pipelining.
+
+  Both protocol never shift the agency: the 'BlockFetchClientProtocol' keep
+  agancy on the client side and the 'BlockFetchServerProtocol' keeps it on the
+  server side.
+-}
 module Ouroboros.Network.Protocol.BlockFetch.Type where
 
 import Protocol.Core
@@ -14,7 +51,7 @@ data ChainRange header = ChainRange !(Point header) !(Point header)
   deriving (Show, Eq, Ord)
 
 {-------------------------------------------------------------------------------
-  Client protocol: request range submission
+  Client protocol: requesting range of blocks
 -------------------------------------------------------------------------------}
 
 -- | Protocol tag.  @'BlockFetchClientProtocol'@ is a protocol in which the

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -37,6 +37,24 @@
   Both protocol never shift the agency: the 'BlockFetchClientProtocol' keep
   agancy on the client side and the 'BlockFetchServerProtocol' keeps it on the
   server side.
+
+  The receiver of @'BlockFetchClientProtocol'@ writes received ranges to
+  a queue which acumulates @'RangeStream' range@ elements.  The sender of
+  @'BlockFetchServerProtocol'@ is reading this queue and sending back blocks to
+  a @'BlockFetchServerReceiver'@.
+
+  Termination
+
+  If the @'BlockFetchClientSender'@ (of the @'BlockFetchClientProtoco'@) will
+  send @'MessageDone'@ the corresponding @'BlockFetchServerReciever'@ will
+  write @'End'@ to the queue which connects both protocols.  When the
+  @'BlockFetchServerSender'@ will encounter @'End'@, it will send
+  @'MessageServerDone'@ which will terminate the protocol.
+
+  Note: there is no mechanism which ensures that if the
+  @'BlockFetchServerSender'@ will send @'MessageServerDone'@ that the
+  corresponding @'BlockFetchClientProtocol@ will terminate.
+
 -}
 module Ouroboros.Network.Protocol.BlockFetch.Type where
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -80,8 +80,7 @@ data BlockRequestServerMessage header block from to where
 
   -- | Block fetching messages; First block from a batch
   MessageStartBatch
-    :: block
-    -> BlockRequestServerMessage header block StServerAwaiting StServerSending
+    :: BlockRequestServerMessage header block StServerAwaiting StServerSending
   -- | Block streaming
   MessageBlock
     :: block
@@ -104,7 +103,7 @@ data BlockRequestServerMessage header block from to where
     :: BlockRequestServerMessage header block StServerAwaiting StServerDone
 
 instance (Show header, Show block) => Show (BlockRequestServerMessage header block from to) where
-  show (MessageStartBatch block) = "MessageStartBatch " ++ show block
+  show MessageStartBatch         = "MessageStartBatch"
   show (MessageBlock block)      = "MessageBlock " ++ show block
   show MessageBatchDone          = "MessageBatchDone"
   show MessageServerError        = "MessageServerError"

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
+module Ouroboros.Network.Protocol.BlockFetch.Type where
+
+import Protocol.Core
+
+import Ouroboros.Network.Block (StandardHash)
+import Ouroboros.Network.Chain (Point)
+
+-- | Range of headers
+--
+data ChainRange header = ChainRange !(Point header) !(Point header)
+  deriving (Show, Eq, Ord)
+
+{-------------------------------------------------------------------------------
+  Client protocol: request range submission
+-------------------------------------------------------------------------------}
+
+-- | Protocol tag.  @'BlockFetchClientProtocol'@ is a protocol in which the
+-- client has the agency.  It sends requests to its server side with ranges of
+-- blocks.  The server just records them.  They will be handled by the server of
+-- @'BlockFetchServerProtocol'@ which will stream ranges of blocks to its client
+-- side.
+--
+data BlockFetchClientProtocol
+
+data ClientState where
+  StClientIdle :: ClientState
+  StClientDone :: ClientState
+
+type instance Partition BlockFetchClientProtocol st client server terminal =
+  BlockFetchClientPartition st client server terminal
+
+type family BlockFetchClientPartition st (client :: Control) (server :: Control) (terminal :: Control) :: Control where
+  BlockFetchClientPartition 'StClientIdle client server termianl = client
+  BlockFetchClientPartition 'StClientDone client server terminal = terminal
+
+data BlockRequestClientMessage header from to where
+
+  MessageRequestRange
+    :: ChainRange header
+    -> BlockRequestClientMessage header 'StClientIdle 'StClientIdle
+
+  MessageDone
+    :: BlockRequestClientMessage header 'StClientIdle 'StClientDone
+
+instance StandardHash header => Show (BlockRequestClientMessage header from to) where
+  show (MessageRequestRange range) = "MessageRequestRange " ++ show range
+  show MessageDone                 = "MessageDone"
+  
+{-------------------------------------------------------------------------------
+  Server side protocol: stream blocks to the client as requested by the
+ @'BlockFetchClientProtocol'@.
+-------------------------------------------------------------------------------}
+
+-- | Protocol tag.  @'BlockFetchServerProtocol'@ keeps agency on the server
+-- side.  It is designed to stream ranges blocks to its client.  Ranges are
+-- received out side of this protocol, using @'BlockFetchClientProtocol'@.
+--
+data BlockFetchServerProtocol
+
+data ServerState where
+  -- sever being idle
+  StServerAwaiting :: ServerState
+  -- server seding blocks
+  StServerSending  :: ServerState
+  -- server termination message
+  StServerDone     :: ServerState
+
+type instance Partition BlockFetchServerProtocol st client server terminal =
+  BlockFetchServerPartition st client server terminal
+
+type family BlockFetchServerPartition st (client :: Control) (server :: Control) (terminal :: Control) :: Control where
+  BlockFetchServerPartition 'StServerAwaiting client server terminal = server
+  BlockFetchServerPartition 'StServerSending  client server terminal = server
+  BlockFetchServerPartition 'StServerDone     client server terminal = terminal
+
+data BlockRequestServerMessage header block from to where
+
+  -- | Block fetching messages; First block from a batch
+  MessageStartBatch
+    :: block
+    -> BlockRequestServerMessage header block 'StServerAwaiting 'StServerSending
+  -- | Block streaming
+  MessageBlock
+    :: block
+    -> BlockRequestServerMessage header block 'StServerSending StServerSending
+  -- | End of batch
+  MessageBatchDone
+    :: BlockRequestServerMessage header block 'StServerSending 'StServerAwaiting
+
+  -- | Server errors
+  MessageServerError
+    :: BlockRequestServerMessage header block 'StServerSending 'StServerAwaiting
+  MessageNoBlocks
+    :: BlockRequestServerMessage header block 'StServerAwaiting 'StServerAwaiting
+
+  -- | Server side of this protocol can terminate the protocol.  This will
+  -- usually be send when the corresponding client in the
+  -- @'BlockFetchClientProtocol'@ protocol running along will send
+  -- @'MessageDone'@.
+  MessageServerDone
+    :: BlockRequestServerMessage header block 'StServerAwaiting 'StServerDone
+
+instance (Show header, Show block) => Show (BlockRequestServerMessage header block from to) where
+  show (MessageStartBatch block) = "MessageStartBatch " ++ show block
+  show (MessageBlock block)      = "MessageBlock " ++ show block
+  show MessageBatchDone          = "MessageBatchDone"
+  show MessageServerError        = "MessageServerError"
+  show MessageNoBlocks           = "MessageNoBlock"
+  show MessageServerDone         = "MessageServerDone"

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -33,17 +33,17 @@ type instance Partition BlockFetchClientProtocol st client server terminal =
   BlockFetchClientPartition st client server terminal
 
 type family BlockFetchClientPartition st (client :: Control) (server :: Control) (terminal :: Control) :: Control where
-  BlockFetchClientPartition 'StClientIdle client server termianl = client
-  BlockFetchClientPartition 'StClientDone client server terminal = terminal
+  BlockFetchClientPartition StClientIdle client server termianl = client
+  BlockFetchClientPartition StClientDone client server terminal = terminal
 
 data BlockRequestClientMessage header from to where
 
   MessageRequestRange
     :: ChainRange header
-    -> BlockRequestClientMessage header 'StClientIdle 'StClientIdle
+    -> BlockRequestClientMessage header StClientIdle StClientIdle
 
   MessageDone
-    :: BlockRequestClientMessage header 'StClientIdle 'StClientDone
+    :: BlockRequestClientMessage header StClientIdle StClientDone
 
 instance StandardHash header => Show (BlockRequestClientMessage header from to) where
   show (MessageRequestRange range) = "MessageRequestRange " ++ show range
@@ -72,36 +72,36 @@ type instance Partition BlockFetchServerProtocol st client server terminal =
   BlockFetchServerPartition st client server terminal
 
 type family BlockFetchServerPartition st (client :: Control) (server :: Control) (terminal :: Control) :: Control where
-  BlockFetchServerPartition 'StServerAwaiting client server terminal = server
-  BlockFetchServerPartition 'StServerSending  client server terminal = server
-  BlockFetchServerPartition 'StServerDone     client server terminal = terminal
+  BlockFetchServerPartition StServerAwaiting client server terminal = server
+  BlockFetchServerPartition StServerSending  client server terminal = server
+  BlockFetchServerPartition StServerDone     client server terminal = terminal
 
 data BlockRequestServerMessage header block from to where
 
   -- | Block fetching messages; First block from a batch
   MessageStartBatch
     :: block
-    -> BlockRequestServerMessage header block 'StServerAwaiting 'StServerSending
+    -> BlockRequestServerMessage header block StServerAwaiting StServerSending
   -- | Block streaming
   MessageBlock
     :: block
-    -> BlockRequestServerMessage header block 'StServerSending StServerSending
+    -> BlockRequestServerMessage header block StServerSending StServerSending
   -- | End of batch
   MessageBatchDone
-    :: BlockRequestServerMessage header block 'StServerSending 'StServerAwaiting
+    :: BlockRequestServerMessage header block StServerSending StServerAwaiting
 
   -- | Server errors
   MessageServerError
-    :: BlockRequestServerMessage header block 'StServerSending 'StServerAwaiting
+    :: BlockRequestServerMessage header block StServerSending StServerAwaiting
   MessageNoBlocks
-    :: BlockRequestServerMessage header block 'StServerAwaiting 'StServerAwaiting
+    :: BlockRequestServerMessage header block StServerAwaiting StServerAwaiting
 
   -- | Server side of this protocol can terminate the protocol.  This will
   -- usually be send when the corresponding client in the
   -- @'BlockFetchClientProtocol'@ protocol running along will send
   -- @'MessageDone'@.
   MessageServerDone
-    :: BlockRequestServerMessage header block 'StServerAwaiting 'StServerDone
+    :: BlockRequestServerMessage header block StServerAwaiting StServerDone
 
 instance (Show header, Show block) => Show (BlockRequestServerMessage header block from to) where
   show (MessageStartBatch block) = "MessageStartBatch " ++ show block

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Codec/Cbor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Codec/Cbor.hs
@@ -39,7 +39,7 @@ codecIdle
   => Codec (ST s) Text Encoding ByteString (ChainSyncMessage header point) StIdle
 codecIdle = Codec
   { encode = cborEncodeIdle
-  , decode = cborDecoder cborDecodeIdle
+  , decode = cborDecoder T.pack cborDecodeIdle
   }
   where
 
@@ -78,7 +78,7 @@ codecNext_CanAwait
   => Codec (ST s) Text Encoding ByteString (ChainSyncMessage header point) (StNext StCanAwait)
 codecNext_CanAwait = Codec
   { encode = cborEncodeNext
-  , decode = cborDecoder cborDecodeNext
+  , decode = cborDecoder T.pack cborDecodeNext
   }
   where
 
@@ -112,7 +112,7 @@ codecNext_MustReply
   => Codec (ST s) Text Encoding ByteString (ChainSyncMessage header point) (StNext StMustReply)
 codecNext_MustReply = Codec
   { encode = cborEncodeNext
-  , decode = cborDecoder cborDecodeNext
+  , decode = cborDecoder T.pack cborDecodeNext
   }
   where
 
@@ -144,7 +144,7 @@ codecIntersect
   => Codec (ST s) Text Encoding ByteString (ChainSyncMessage header point) StIntersect
 codecIntersect = Codec
   { encode = cborEncodeIntersect
-  , decode = cborDecoder cborDecodeIntersect
+  , decode = cborDecoder T.pack cborDecodeIntersect
   }
   where
 

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -30,7 +30,6 @@ module Ouroboros.Network.Testing.ConcreteBlock (
 import           Data.FingerTree (Measured(measure))
 import           Data.Hashable
 import qualified Data.Text as Text
-import           Test.QuickCheck
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain
@@ -196,23 +195,6 @@ fixupBlockHeaderCF c h b = b'
                        -- See the comment for 'headerPrevHash'
       headerBodyHash = h
     }
-
-
-{-------------------------------------------------------------------------------
-  Arbitrary instances
-
-  TODO: Should we have a policy that Arbitrary instances should not live
-  in the main modules?
--------------------------------------------------------------------------------}
-
---
--- Generators
---
-
-instance Arbitrary BlockBody where
-    arbitrary = BlockBody <$> vectorOf 4 (choose ('A', 'Z'))
-    -- probably no need for shrink, the content is arbitrary and opaque
-    -- if we add one, it might be to shrink to an empty block
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -8,6 +8,7 @@ import qualified Test.ChainProducerState (tests)
 import qualified Test.Pipe (tests)
 import qualified Test.Ouroboros.Network.Node (tests)
 import qualified Test.Ouroboros.Network.Protocol.Stream (tests)
+import qualified Test.Ouroboros.Network.Protocol.BlockFetch (tests)
 
 main :: IO ()
 main = defaultMain tests
@@ -21,4 +22,5 @@ tests =
   , Test.Pipe.tests
   , Test.Ouroboros.Network.Node.tests
   , Test.Ouroboros.Network.Protocol.Stream.tests
+  , Test.Ouroboros.Network.Protocol.BlockFetch.tests
   ]

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -9,6 +9,7 @@ import qualified Test.Pipe (tests)
 import qualified Test.Ouroboros.Network.Node (tests)
 import qualified Test.Ouroboros.Network.Protocol.Stream (tests)
 import qualified Test.Ouroboros.Network.Protocol.BlockFetch (tests)
+import qualified Test.Ouroboros.Network.Protocol.BlockFetch.Codec (tests)
 
 main :: IO ()
 main = defaultMain tests
@@ -23,4 +24,5 @@ tests =
   , Test.Ouroboros.Network.Node.tests
   , Test.Ouroboros.Network.Protocol.Stream.tests
   , Test.Ouroboros.Network.Protocol.BlockFetch.tests
+  , Test.Ouroboros.Network.Protocol.BlockFetch.Codec.tests
   ]

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -10,6 +10,7 @@ import qualified Test.Ouroboros.Network.Node (tests)
 import qualified Test.Ouroboros.Network.Protocol.Stream (tests)
 import qualified Test.Ouroboros.Network.Protocol.BlockFetch (tests)
 import qualified Test.Ouroboros.Network.Protocol.BlockFetch.Codec.Coherence (tests)
+import qualified Test.Ouroboros.Network.Protocol.BlockFetch.Pipe (tests)
 
 main :: IO ()
 main = defaultMain tests
@@ -25,4 +26,5 @@ tests =
   , Test.Ouroboros.Network.Protocol.Stream.tests
   , Test.Ouroboros.Network.Protocol.BlockFetch.tests
   , Test.Ouroboros.Network.Protocol.BlockFetch.Codec.Coherence.tests
+  , Test.Ouroboros.Network.Protocol.BlockFetch.Pipe.tests
   ]

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -9,7 +9,7 @@ import qualified Test.Pipe (tests)
 import qualified Test.Ouroboros.Network.Node (tests)
 import qualified Test.Ouroboros.Network.Protocol.Stream (tests)
 import qualified Test.Ouroboros.Network.Protocol.BlockFetch (tests)
-import qualified Test.Ouroboros.Network.Protocol.BlockFetch.Codec (tests)
+import qualified Test.Ouroboros.Network.Protocol.BlockFetch.Codec.Coherence (tests)
 
 main :: IO ()
 main = defaultMain tests
@@ -24,5 +24,5 @@ tests =
   , Test.Ouroboros.Network.Node.tests
   , Test.Ouroboros.Network.Protocol.Stream.tests
   , Test.Ouroboros.Network.Protocol.BlockFetch.tests
-  , Test.Ouroboros.Network.Protocol.BlockFetch.Codec.tests
+  , Test.Ouroboros.Network.Protocol.BlockFetch.Codec.Coherence.tests
   ]

--- a/ouroboros-network/test/Test/Chain.hs
+++ b/ouroboros-network/test/Test/Chain.hs
@@ -32,6 +32,8 @@ import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.Serialise (prop_serialise)
 import           Ouroboros.Network.Testing.ConcreteBlock
 
+import           Test.Ouroboros.Network.Testing.Arbitrary
+
 
 --
 -- The list of all tests
@@ -218,7 +220,7 @@ genNonNegative = (abs <$> arbitrary) `suchThat` (>= 0)
 
 genBlockChain :: Int -> Gen (Chain Block)
 genBlockChain n = do
-    bodies <- vector n
+    bodies <- map getArbitraryBlockBody <$> vector n
     slots  <- mkSlots <$> vectorOf n genSlotGap
     return (mkChain slots bodies)
   where
@@ -307,7 +309,7 @@ genAddBlock :: (HasHeader block, HeaderHash block ~ ConcreteHeaderHash)
             => Chain block -> Gen Block
 genAddBlock chain = do
     slotGap <- genSlotGap
-    body    <- arbitrary
+    body    <- getArbitraryBlockBody <$> arbitrary
     let pb = mkPartialBlock (addSlotGap slotGap (Chain.headSlot chain)) body
         b  = fixupBlock chain pb
     return b

--- a/ouroboros-network/test/Test/ChainFragment.hs
+++ b/ouroboros-network/test/Test/ChainFragment.hs
@@ -23,6 +23,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 import           Test.Chain (genNonNegative, genSlotGap, addSlotGap,
                              mkPartialBlock, genPoint)
+import           Test.Ouroboros.Network.Testing.Arbitrary (ArbitraryBlockBody (..))
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (ChainUpdate(..), Point(..))
 import           Ouroboros.Network.ChainFragment (ChainFragment,
@@ -324,7 +325,7 @@ prop_shrink_TestHeaderChainFragment c =
 
 genBlockChainFragment :: Int -> Gen (ChainFragment Block)
 genBlockChainFragment n = do
-    bodies <- vector n
+    bodies <- map getArbitraryBlockBody <$> vector n
     slots  <- mkSlots <$> vectorOf n genSlotGap
     return (mkChainFragment slots bodies)
   where
@@ -387,7 +388,7 @@ genAddBlock :: (HasHeader block, HeaderHash block ~ ConcreteHeaderHash)
             => ChainFragment block -> Gen Block
 genAddBlock chain = do
     slotGap <- genSlotGap
-    body    <- arbitrary
+    body    <- getArbitraryBlockBody <$> arbitrary
     let pb = mkPartialBlock (addSlotGap slotGap
                                         (fromMaybe (Slot 0) $ CF.headSlot chain))
                                         body

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
@@ -1,0 +1,238 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Test.Ouroboros.Network.Protocol.BlockFetch where
+
+import qualified Pipes
+
+import           Control.Monad.ST.Lazy (runST)
+import           Control.Monad (void)
+import           Data.Functor (($>))
+import           Data.Functor.Identity (Identity (..))
+import           Data.List (foldl')
+-- import           Data.Word (Word)
+-- import           Data.ByteString (ByteString)
+
+import           Protocol.Core (Those (..), connect)
+
+-- import Ouroboros.Network.Block (StandardHash)
+-- import Ouroboros.Network.Chain (Point (..))
+import Ouroboros.Network.MonadClass (MonadProbe (..), MonadRunProbe (..), MonadSTM (..), MonadTime (..), MonadTimer (..), withProbe)
+
+import Ouroboros.Network.Protocol.BlockFetch.Type
+import Ouroboros.Network.Protocol.BlockFetch.Client
+import Ouroboros.Network.Protocol.BlockFetch.Server
+import Ouroboros.Network.Protocol.BlockFetch.Direct
+
+import Ouroboros.Network.Testing.ConcreteBlock (BlockHeader)
+import Test.Ouroboros.Network.Testing.Arbitrary
+
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests =
+  testGroup "Ouroboros.Network.Protocol.BlockFetch"
+  [ testGroup "BlockFetchClientProtocol"
+    [ testProperty "Test directBlockFetchClient using testing server"
+        prop_directBlockFetchClientProtocol_acc
+    , testProperty "Test connect using testing server"
+        prop_connectBlockFetchClientProtocol_acc
+    , testProperty "Run blockFetchClientProtocol_experiment using connect in ST"
+        prop_connectBlockFetchClientProtocol_ST
+    , testProperty "Run blockFetchClientProtocol_experiment using connect in IO"
+        prop_connectBlockFetchClientProtocol_IO
+    , testProperty "Run blockFetchClientProtocol_experiment using directBlockFetchClient in ST"
+        prop_directBlockFetchClientProtocol_ST
+    , testProperty "Run blockFetchClientProtocol_experiment using directBlockFetchClient in IO"
+        prop_directBlockFetchClientProtocol_IO
+    ]
+  , testGroup "BlockFetchServerProtocol"
+    -- These two tests cover the same scope as the @'BlockFetchClientProtocol'@
+    -- tests above, this is because here we can have a receiver that
+    -- accumulates all received values.
+    [ testProperty "blockFetchServerProtocol_ST"
+        prop_blockFetchServerProtocol_ST
+    , testProperty "blockFetchServerProtocol_IO"
+        prop_blockFetchServerProtocol_IO
+    ]
+  , testGroup "BlockFetchServer: round trip tests"
+    [
+    ]
+  ]
+
+-- | FIXME: find a better place for it, this might be useful elsewhere too.
+runExperiment
+  :: forall m n.
+     ( MonadSTM m
+     , MonadTimer m
+     , MonadProbe m
+     , MonadRunProbe m n
+     )
+  => (Probe m Property -> m ())
+  -> n Property
+runExperiment exp_ = isValid <$> withProbe exp_
+ where
+  isValid :: [(Time m, Property)] -> Property
+  isValid = foldl' (\acu (_,p) -> acu .&&. p) (property True)
+
+-- | Testing server which accumulates received value in its return value.
+--
+accumulatingBlockFetchServerReceiver
+  :: Monad m
+  => BlockFetchServerReceiver header m [ChainRange header]
+accumulatingBlockFetchServerReceiver = go []
+ where
+  go acc =
+    BlockFetchServerReceiver {
+      recvMessageRequestRange = \range -> return $ go (range : acc),
+      recvMessageDone         = reverse acc
+    }
+
+-- | @'directBlockFetchClient'@ is an identity
+--
+prop_directBlockFetchClientProtocol_acc
+  :: [(ArbitraryPoint, ArbitraryPoint)]
+  -> Property
+prop_directBlockFetchClientProtocol_acc as =
+  let ranges = map (\(ArbitraryPoint p, ArbitraryPoint p') -> ChainRange p p') as
+  in
+    fst (runIdentity
+      $ directBlockFetchClient
+          accumulatingBlockFetchServerReceiver
+          (runIdentity $ blockFetchClientSenderFromProducer (Pipes.each ranges >> return ())))
+    === ranges
+
+-- | Test @'blockFetchServerReceiverStream'@ against
+-- @'blockFetchClientSenderStream'@ using @'connect'@.
+--
+prop_connectBlockFetchClientProtocol_acc
+  :: [(ArbitraryPoint, ArbitraryPoint)]
+  -> Property
+prop_connectBlockFetchClientProtocol_acc as =
+  let ranges = map (\(ArbitraryPoint p, ArbitraryPoint p') -> ChainRange p p') as
+      client = runIdentity $ blockFetchClientSenderFromProducer (Pipes.each ranges >> return ())
+  in case  runIdentity $ connect
+            (blockFetchServerReceiverStream accumulatingBlockFetchServerReceiver)
+            (blockFetchClientSenderStream client) of
+        These res _ -> res === ranges
+        This res    -> res === ranges
+        That _      -> property False
+
+-- | Test @'constantReceiver'@ against @'blockFetchClientSenderFromProducer'@ using either
+-- @'directBlockFetchClient'@ or @'connect'@.
+--
+blockFetchClientProtocol_experiment
+  :: forall m.
+     ( MonadSTM m
+     , MonadTimer m
+     , MonadProbe m
+     )
+  => (forall a b. BlockFetchServerReceiver BlockHeader m a -> BlockFetchClientSender BlockHeader m b -> m ())
+  -- ^ either 'directBlockFetchClient' or @'connect'@
+  -> [(ArbitraryPoint, ArbitraryPoint)]
+  -> Probe m Property
+  -> m ()
+blockFetchClientProtocol_experiment run as probe = do
+  let ranges = map (\(ArbitraryPoint p, ArbitraryPoint p') -> ChainRange p p') as
+  var <- atomically $ newTVar []
+  let server = constantReceiver (\a -> atomically $ modifyTVar var (a:)) ()
+  client <- blockFetchClientSenderFromProducer (Pipes.each ranges >> return ())
+
+  _ <- run server client
+
+  res <- atomically $ readTVar var
+  probeOutput probe $ reverse res === ranges
+
+prop_directBlockFetchClientProtocol_ST
+  :: [(ArbitraryPoint, ArbitraryPoint)]
+  -> Property
+prop_directBlockFetchClientProtocol_ST as = runST $ runExperiment $
+  blockFetchClientProtocol_experiment (\ser cli -> void $ directBlockFetchClient ser cli) as
+
+prop_directBlockFetchClientProtocol_IO
+  :: [(ArbitraryPoint, ArbitraryPoint)]
+  -> Property
+prop_directBlockFetchClientProtocol_IO as = ioProperty $ runExperiment $
+  blockFetchClientProtocol_experiment (\ser cli -> void $ directBlockFetchClient ser cli)  as
+
+prop_connectBlockFetchClientProtocol_ST
+  :: [(ArbitraryPoint, ArbitraryPoint)]
+  -> Property
+prop_connectBlockFetchClientProtocol_ST as = runST $ runExperiment $
+  blockFetchClientProtocol_experiment (\ser cli -> void $ connect (blockFetchServerReceiverStream ser) (blockFetchClientSenderStream cli)) as
+
+prop_connectBlockFetchClientProtocol_IO
+  :: [(ArbitraryPoint, ArbitraryPoint)]
+  -> Property
+prop_connectBlockFetchClientProtocol_IO as = ioProperty $ runExperiment $
+  blockFetchClientProtocol_experiment (\ser cli -> void $ connect (blockFetchServerReceiverStream ser) (blockFetchClientSenderStream cli)) as
+
+-- | @'BlockFetchClientReceiver'@ which accumulates received blocks.
+--
+blockFetchClientReceiver
+  :: Applicative m
+  => BlockFetchClientReceiver block m [block]
+blockFetchClientReceiver = receiver []
+ where
+  receiver acc = BlockFetchClientReceiver {
+      recvMsgStartBatch = pure (blockReceiver acc),
+      recvMsgNoBlocks   = pure (receiver acc),
+      recvMsgDoneClient = acc
+    }
+  blockReceiver acc = BlockFetchClientReceiveBlocks {
+      recvMsgBlock       = \b -> pure (blockReceiver (b : acc)),
+      recvMsgBatchDone   = pure (receiver acc),
+      recvMsgServerError = pure (receiver acc)
+    }
+
+-- | Test @'BlockFetchServerProtocol'@ using both @'directBlockFetchServer'@
+-- and @'connect\''@.
+--
+blockFetchServerProtocol_experiment
+  :: forall m.
+     ( MonadSTM m
+     , MonadTimer m
+     , MonadProbe m
+     )
+  => [(Int, Int)]
+  -> Probe m Property
+  -> m ()
+blockFetchServerProtocol_experiment ranges probe = do
+  var  <- atomically $ newTVar ranges
+  var' <- atomically $ newTVar ranges
+  let readRequest v = atomically $ do
+        rs <- readTVar v
+        case rs of
+          []        -> return Nothing
+          (r : rs') -> writeTVar v rs' $> Just r
+
+  let blockStream (Just (x, y)) = return (Just (Pipes.each [x..y] >> return ()))
+      blockStream Nothing       = return Nothing
+
+  let sender = blockFetchServerSender () (readRequest var) blockStream
+  (_, resDirect) <- directBlockFetchServer sender blockFetchClientReceiver
+
+  let sender' = blockFetchServerSender () (readRequest var') blockStream
+  resConn <- connect
+    (blockFetchServerStream sender')
+    (blockFetchClientReceiverStream blockFetchClientReceiver)
+
+  let res = reverse $ concatMap (\(x, y) -> [x..y]) ranges
+
+  case resConn of
+    This _       -> probeOutput probe $ property False
+    That res'    -> probeOutput probe $ res' === res .&&. resDirect === res
+    These _ res' -> probeOutput probe $ res' === res .&&. resDirect === res
+
+prop_blockFetchServerProtocol_ST
+  :: NonEmptyList (Int, Int)
+  -> Property
+prop_blockFetchServerProtocol_ST (NonEmpty as) = runST $ runExperiment $ blockFetchServerProtocol_experiment as
+
+prop_blockFetchServerProtocol_IO
+  :: NonEmptyList (Int, Int)
+  -> Property
+prop_blockFetchServerProtocol_IO (NonEmpty as) = ioProperty $ runExperiment $ blockFetchServerProtocol_experiment as

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
@@ -164,25 +164,33 @@ prop_directBlockFetchClientProtocol_ST
   :: [(ArbitraryPoint, ArbitraryPoint)]
   -> Property
 prop_directBlockFetchClientProtocol_ST as = runST $ runExperiment $
-  blockFetchClientProtocol_experiment (\ser cli -> void $ directBlockFetchClient ser cli) as
+  blockFetchClientProtocol_experiment
+    (\ser cli -> void $ directBlockFetchClient ser cli) as
 
 prop_directBlockFetchClientProtocol_IO
   :: [(ArbitraryPoint, ArbitraryPoint)]
   -> Property
 prop_directBlockFetchClientProtocol_IO as = ioProperty $ runExperiment $
-  blockFetchClientProtocol_experiment (\ser cli -> void $ directBlockFetchClient ser cli)  as
+  blockFetchClientProtocol_experiment
+    (\ser cli -> void $ directBlockFetchClient ser cli)  as
 
 prop_connectBlockFetchClientProtocol_ST
   :: [(ArbitraryPoint, ArbitraryPoint)]
   -> Property
 prop_connectBlockFetchClientProtocol_ST as = runST $ runExperiment $
-  blockFetchClientProtocol_experiment (\ser cli -> void $ connect (blockFetchServerReceiverStream ser) (blockFetchClientSenderStream cli)) as
+  blockFetchClientProtocol_experiment
+    (\ser cli -> void $ connect
+      (blockFetchServerReceiverStream ser)
+      (blockFetchClientSenderStream cli)) as
 
 prop_connectBlockFetchClientProtocol_IO
   :: [(ArbitraryPoint, ArbitraryPoint)]
   -> Property
 prop_connectBlockFetchClientProtocol_IO as = ioProperty $ runExperiment $
-  blockFetchClientProtocol_experiment (\ser cli -> void $ connect (blockFetchServerReceiverStream ser) (blockFetchClientSenderStream cli)) as
+  blockFetchClientProtocol_experiment
+    (\ser cli -> void $ connect
+      (blockFetchServerReceiverStream ser)
+      (blockFetchClientSenderStream cli)) as
 
 -- | @'BlockFetchClientReceiver'@ which accumulates received blocks.
 --
@@ -249,12 +257,14 @@ blockFetchServerProtocol_experiment ranges probe = do
 prop_blockFetchServerProtocol_ST
   :: NonEmptyList (Int, Int)
   -> Property
-prop_blockFetchServerProtocol_ST (NonEmpty as) = runST $ runExperiment $ blockFetchServerProtocol_experiment as
+prop_blockFetchServerProtocol_ST (NonEmpty as) = runST $ runExperiment $
+  blockFetchServerProtocol_experiment as
 
 prop_blockFetchServerProtocol_IO
   :: NonEmptyList (Int, Int)
   -> Property
-prop_blockFetchServerProtocol_IO (NonEmpty as) = ioProperty $ runExperiment $ blockFetchServerProtocol_experiment as
+prop_blockFetchServerProtocol_IO (NonEmpty as) = ioProperty $ runExperiment $
+  blockFetchServerProtocol_experiment as
 
 {-------------------------------------------------------------------------------
 -- Round trip tests

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
@@ -82,7 +82,7 @@ runExperiment exp_ = isValid <$> withProbe exp_
 --
 accumulatingBlockFetchServerReceiver
   :: Monad m
-  => BlockFetchServerReceiver header m [ChainRange header]
+  => BlockFetchServerReceiver range m [range]
 accumulatingBlockFetchServerReceiver = go []
  where
   go acc =
@@ -130,7 +130,7 @@ blockFetchClientProtocol_experiment
      , MonadTimer m
      , MonadProbe m
      )
-  => (forall a b. BlockFetchServerReceiver BlockHeader m a -> BlockFetchClientSender BlockHeader m b -> m ())
+  => (forall a b. BlockFetchServerReceiver (ChainRange BlockHeader) m a -> BlockFetchClientSender (ChainRange BlockHeader) m b -> m ())
   -- ^ either 'directBlockFetchClient' or @'connect'@
   -> [(ArbitraryPoint, ArbitraryPoint)]
   -> Probe m Property

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
@@ -215,7 +215,10 @@ blockFetchClientReceiver = receiver []
 -------------------------------------------------------------------------------}
 
 -- | Test @'BlockFetchServerProtocol'@ using both @'directBlockFetchServer'@
--- and @'connect\''@.
+-- and @'connect\''@.  The test is requesting ranges of integers @(n, m) ::
+-- (Int, In)@.  If ranges for which @x > y@ will be treated as there are no
+-- corresponding blocks (@'Int'@s), otherwise it will stream the list of all
+-- @[x .. y]@.
 --
 blockFetchServerProtocol_experiment
   :: forall m.
@@ -269,6 +272,10 @@ prop_blockFetchServerProtocol_IO (NonEmpty as) = ioProperty $ runExperiment $
 -- Round trip tests
 -------------------------------------------------------------------------------}
 
+-- | Round trip test in either @'IO'@ or in @Free ('SimF' s)@ monad.  It
+-- assures that there can be multiple outstanding range requests, and that the
+-- server returns the exepcted ranges.
+--
 roundTrip_experiment
   :: forall m.
      ( MonadSTM m

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
@@ -116,7 +116,7 @@ prop_directBlockFetchClientProtocol_acc as =
     fst (runIdentity
       $ directBlockFetchClient
           accumulatingBlockFetchServerReceiver
-          (runIdentity $ blockFetchClientSenderFromProducer (Pipes.each ranges >> return ())))
+          (blockFetchClientSenderFromProducer (Pipes.each ranges >> return ())))
     === ranges
 
 -- | Test @'blockFetchServerReceiverStream'@ against
@@ -127,7 +127,7 @@ prop_connectBlockFetchClientProtocol_acc
   -> Property
 prop_connectBlockFetchClientProtocol_acc as =
   let ranges = map (\(ArbitraryPoint p, ArbitraryPoint p') -> ChainRange p p') as
-      client = runIdentity $ blockFetchClientSenderFromProducer (Pipes.each ranges >> return ())
+      client = blockFetchClientSenderFromProducer (Pipes.each ranges >> return ())
   in case  runIdentity $ connect
             (blockFetchServerReceiverStream accumulatingBlockFetchServerReceiver)
             (blockFetchClientSenderStream client) of
@@ -153,7 +153,7 @@ blockFetchClientProtocol_experiment run as probe = do
   let ranges = map (\(ArbitraryPoint p, ArbitraryPoint p') -> ChainRange p p') as
   var <- atomically $ newTVar []
   let server = constantReceiver (\a -> atomically $ modifyTVar var (a:)) (return ())
-  client <- blockFetchClientSenderFromProducer (Pipes.each ranges >> return ())
+      client = blockFetchClientSenderFromProducer (Pipes.each ranges >> return ())
 
   _ <- run server client
 
@@ -289,8 +289,8 @@ roundTrip_experiment
   -> m ()
 roundTrip_experiment runClient runServer ranges (Positive queueSize) probe = do
   (serverReceiver, serverSender) <- connectThroughQueue (fromIntegral queueSize) blockStream
-  clientSender <- blockFetchClientSenderFromProducer
-    (Pipes.each (map Just ranges ++ [Nothing]) >> return ())
+  let clientSender = blockFetchClientSenderFromProducer
+        (Pipes.each (map Just ranges ++ [Nothing]) >> return ())
   fork $ runClient serverReceiver clientSender
   fork $ do
     res <- runServer serverSender blockFetchClientReceiver

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
@@ -8,24 +8,24 @@ import qualified Pipes
 
 import           Control.Monad.ST.Lazy (runST)
 import           Control.Monad (void)
+import           Control.Monad.Free (Free)
+import           Control.Monad.IOSim (SimF)
+
 import           Data.Functor (($>))
 import           Data.Functor.Identity (Identity (..))
 import           Data.List (foldl')
--- import           Data.Word (Word)
--- import           Data.ByteString (ByteString)
 
 import           Protocol.Core (Those (..), connect)
 
--- import Ouroboros.Network.Block (StandardHash)
--- import Ouroboros.Network.Chain (Point (..))
-import Ouroboros.Network.MonadClass ( MonadProbe (..)
-                                    , MonadFork (..)
-                                    , MonadRunProbe (..)
-                                    , MonadSTM (..)
-                                    , MonadTime (..)
-                                    , MonadTimer (..)
-                                    , withProbe
-                                    )
+import Control.Monad.Class.MonadProbe ( MonadProbe (..)
+                                      , MonadRunProbe (..)
+                                      , withProbe
+                                      )
+import Control.Monad.Class.MonadFork ( MonadFork (..))
+import Control.Monad.Class.MonadSTM ( MonadSTM (..))
+import Control.Monad.Class.MonadTimer ( MonadTime (..)
+                                      , MonadTimer (..)
+                                      )
 
 import Ouroboros.Network.Protocol.BlockFetch.Type
 import Ouroboros.Network.Protocol.BlockFetch.Client
@@ -164,7 +164,7 @@ prop_directBlockFetchClientProtocol_ST
   :: [(ArbitraryPoint, ArbitraryPoint)]
   -> Property
 prop_directBlockFetchClientProtocol_ST as = runST $ runExperiment $
-  blockFetchClientProtocol_experiment
+  blockFetchClientProtocol_experiment @(Free (SimF _))
     (\ser cli -> void $ directBlockFetchClient ser cli) as
 
 prop_directBlockFetchClientProtocol_IO

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Client.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Client.hs
@@ -1,0 +1,21 @@
+module Test.Ouroboros.Network.Protocol.BlockFetch.Client where
+
+import Ouroboros.Network.Protocol.BlockFetch.Client
+
+-- | @'BlockFetchClientReceiver'@ which accumulates received blocks.
+--
+blockFetchClientReceiver
+  :: Applicative m
+  => BlockFetchClientReceiver block m [block]
+blockFetchClientReceiver = receiver []
+ where
+  receiver acc = BlockFetchClientReceiver {
+      recvMsgStartBatch = pure (blockReceiver acc),
+      recvMsgNoBlocks   = pure (receiver acc),
+      recvMsgDoneClient = acc
+    }
+  blockReceiver acc = BlockFetchClientReceiveBlocks {
+      recvMsgBlock       = \b -> pure (blockReceiver (b : acc)),
+      recvMsgBatchDone   = pure (receiver acc),
+      recvMsgServerError = pure (receiver acc)
+    }

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
@@ -1,0 +1,94 @@
+-- FIXME: AllowAmbiguousTypes should not be needed.
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC "-Wno-unticked-promoted-constructors" #-}
+module Test.Ouroboros.Network.Protocol.BlockFetch.Codec where
+
+import Control.Monad.ST (runST)
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Type.Equality
+import Data.Text (Text, pack)
+
+import Codec.Serialise.Class (Serialise)
+
+import Test.QuickCheck
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+import Protocol.Codec
+import Protocol.Codec.Coherent
+import Protocol.Path
+
+import Ouroboros.Network.Protocol.BlockFetch.Type
+import Ouroboros.Network.Protocol.BlockFetch.Codec.Cbor
+
+
+prop_block_fetch_client_cbor_coherent
+  :: forall range.
+     ( Serialise range
+     , Show range
+     , Arbitrary range
+     )
+  => Property
+prop_block_fetch_client_cbor_coherent = forAllShow genPath showPath doTest
+ where
+  showPath
+    :: (SomeTransitionPath (BlockRequestClientMessage range) StClientIdle)
+    -> String
+  showPath (SomeTransitionPath path) = foldPath fn "" path
+   where
+    fn :: (k -> String)
+       -> Transition (BlockRequestClientMessage range) k states
+       -> String
+    fn g (Transition tr next) = show tr ++ g next
+
+  doTest
+    :: SomeTransitionPath (BlockRequestClientMessage range) StClientIdle
+    -> Property
+  doTest (SomeTransitionPath path) =
+    prop_coherent (==) show show show (runST (codecTree decodeFull eqTr blockFetchClientCodec' path))
+
+  -- Every path from StClientIdle is uniquelly determined by a list of ranges
+  pathFromList
+    :: [range]
+    -> SomeTransitionPath (BlockRequestClientMessage range) StClientIdle
+  pathFromList [] = SomeTransitionPath $ PathCons $ Transition MessageDone PathNil
+  pathFromList (range : rest) = case pathFromList rest of
+    SomeTransitionPath it -> SomeTransitionPath $ PathCons $ Transition (MessageRequestRange range) it
+
+  genPath :: Gen (SomeTransitionPath (BlockRequestClientMessage range) StClientIdle)
+  genPath = pathFromList <$> resize 5 (listOf arbitrary)
+
+  eqTr :: forall from to to' .
+          BlockRequestClientMessage range from to
+       -> BlockRequestClientMessage range from to'
+       -> Maybe (to :~: to')
+  eqTr MessageRequestRange{} MessageRequestRange{} = Just Refl
+  eqTr MessageDone           MessageDone           = Just Refl
+  eqTr _                     _                     = Nothing
+
+  decodeFull :: Monad m => ByteString -> Decoder Text ByteString m x -> m (Either Text x)
+  decodeFull str decoder = do
+    (it, remaining) <- foldOverInput decoder (singletonInput [str])
+    case remaining of
+      Nothing -> pure it
+      -- If there's more input, we'll drain it. giving a list of all of the
+      -- remaining inputs. Those inputs happen to be of type [String], so
+      -- we mconcat it twice to get the entire remaining input as a String.
+      Just input -> drainInput input >>= \lst ->
+        let rest = mconcat (mconcat lst)
+        in if BS.null rest
+             then pure it
+             else pure $ Left $ pack $ "decoder did not use all of its input: " ++ (show rest)
+
+tests :: TestTree
+tests = testGroup "BlockFetchClientProtocol.Codec.Cbor"
+  [ testProperty "coherent codec" (prop_block_fetch_client_cbor_coherent @(Int, Int))
+  ]

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
@@ -26,6 +26,7 @@ import Protocol.Codec
 import Protocol.Codec.Coherent
 import Protocol.Path
 
+import Ouroboros.Network.Protocol.Codec.Cbor (convertCborCodec')
 import Ouroboros.Network.Protocol.BlockFetch.Type
 import Ouroboros.Network.Protocol.BlockFetch.Codec.Cbor
 
@@ -37,23 +38,13 @@ prop_block_fetch_client_cbor_coherent
      , Arbitrary range
      )
   => Property
-prop_block_fetch_client_cbor_coherent = forAllShow genPath showPath doTest
+prop_block_fetch_client_cbor_coherent = forAllShow genPath (showSomeTransitionPath show) doTest
  where
-  showPath
-    :: (SomeTransitionPath (BlockRequestClientMessage range) StClientIdle)
-    -> String
-  showPath (SomeTransitionPath path) = foldPath fn "" path
-   where
-    fn :: (k -> String)
-       -> Transition (BlockRequestClientMessage range) k states
-       -> String
-    fn g (Transition tr next) = show tr ++ g next
-
   doTest
     :: SomeTransitionPath (BlockRequestClientMessage range) StClientIdle
     -> Property
   doTest (SomeTransitionPath path) =
-    prop_coherent (==) show show show (runST (codecTree decodeFull eqTr blockFetchClientCodec' path))
+    prop_coherent (==) show show show (runST (codecTree decodeFull eqTr (convertCborCodec' blockFetchClientCodec) path))
 
   -- Every path from StClientIdle is uniquelly determined by a list of ranges
   pathFromList
@@ -88,7 +79,85 @@ prop_block_fetch_client_cbor_coherent = forAllShow genPath showPath doTest
              then pure it
              else pure $ Left $ pack $ "decoder did not use all of its input: " ++ (show rest)
 
+prop_block_fetch_server_cbor_coherent
+  :: forall block.
+     ( Serialise block
+     , Show block
+     , Arbitrary block
+     )
+  => Property
+prop_block_fetch_server_cbor_coherent = forAllShow genPath (showSomeTransitionPath show) doTest
+ where
+  doTest
+    :: SomeTransitionPath (BlockRequestServerMessage block) StServerAwaiting
+    -> Property
+  doTest (SomeTransitionPath path) =
+    prop_coherent (==) show show show (runST (codecTree decodeFull eqTr (convertCborCodec' blockFetchServerCodec) path))
+
+  -- TODO: generate paths which send multiple batches
+
+  -- either send @'MessgeNoBlocks'@ followed by @'MessageServerDone'@
+  -- or if the list is non empty @'MessageStartBatch'@, @'MessageBlock'@
+  -- (repeated over all the blocks), followed by @'MessageBatchDone'@ and @'MessageServerDone'@
+  blocksPath :: [block] -> SomeTransitionPath (BlockRequestServerMessage block) StServerAwaiting
+  blocksPath []     = SomeTransitionPath $ PathCons $ Transition MessageNoBlocks $ PathCons $ Transition MessageServerDone $ PathNil
+  blocksPath blocks = case go blocks of
+    SomeTransitionPath it -> SomeTransitionPath $ PathCons $ Transition MessageStartBatch it
+   where
+    go :: [block]
+      -> SomeTransitionPath (BlockRequestServerMessage block) StServerSending
+    go []             = SomeTransitionPath $ PathCons $ Transition MessageBatchDone $ PathCons $ Transition MessageServerDone $ PathNil
+    go (block : rest) = case go rest of
+      SomeTransitionPath it -> SomeTransitionPath $ PathCons $ Transition (MessageBlock block) it
+
+  -- like 'blockPath', but ends block transition with @'MessageServerError'@
+  -- rather than @'MessageBatchDone'@
+  errorPath :: [block] -> SomeTransitionPath (BlockRequestServerMessage block) StServerAwaiting
+  errorPath []     = SomeTransitionPath $ PathCons $ Transition MessageNoBlocks $ PathCons $ Transition MessageServerDone $ PathNil
+  errorPath blocks = case go blocks of
+    SomeTransitionPath it -> SomeTransitionPath $ PathCons $ Transition MessageStartBatch it
+   where
+    go :: [block]
+      -> SomeTransitionPath (BlockRequestServerMessage block) StServerSending
+    go []             = SomeTransitionPath $ PathCons $ Transition MessageServerError $ PathCons $ Transition MessageServerDone $ PathNil
+    go (block : rest) = case go rest of
+      SomeTransitionPath it -> SomeTransitionPath $ PathCons $ Transition (MessageBlock block) it
+
+  genPath :: Gen (SomeTransitionPath (BlockRequestServerMessage block) StServerAwaiting)
+  genPath = oneof
+    [ blocksPath <$> resize 5 (listOf arbitrary)
+    , errorPath  <$> resize 5 (listOf arbitrary)
+    ]
+
+  eqTr :: forall from to to' .
+          BlockRequestServerMessage block from to
+       -> BlockRequestServerMessage block from to'
+       -> Maybe (to :~: to')
+  eqTr MessageStartBatch  MessageStartBatch  = Just Refl
+  eqTr (MessageBlock _)   (MessageBlock _)   = Just Refl
+  eqTr MessageBatchDone   MessageBatchDone   = Just Refl
+  eqTr MessageServerError MessageServerError = Just Refl
+  eqTr MessageNoBlocks    MessageNoBlocks    = Just Refl
+  eqTr MessageServerDone  MessageServerDone  = Just Refl
+  eqTr _                  _                  = Nothing
+
+  decodeFull :: Monad m => ByteString -> Decoder Text ByteString m x -> m (Either Text x)
+  decodeFull str decoder = do
+    (it, remaining) <- foldOverInput decoder (singletonInput [str])
+    case remaining of
+      Nothing -> pure it
+      -- If there's more input, we'll drain it. giving a list of all of the
+      -- remaining inputs. Those inputs happen to be of type [String], so
+      -- we mconcat it twice to get the entire remaining input as a String.
+      Just input -> drainInput input >>= \lst ->
+        let rest = mconcat (mconcat lst)
+        in if BS.null rest
+             then pure it
+             else pure $ Left $ pack $ "decoder did not use all of its input: " ++ (show rest)
+
 tests :: TestTree
-tests = testGroup "BlockFetchClientProtocol.Codec.Cbor"
-  [ testProperty "coherent codec" (prop_block_fetch_client_cbor_coherent @(Int, Int))
+tests = testGroup "BlockFetchProtocol.Codec.Cbor"
+  [ testProperty "BlockFetchClientProtocol: coherent cbor codec" (prop_block_fetch_client_cbor_coherent @(Int, Int))
+  , testProperty "BlockFetchServerProtcol: coher cbor codec"
+    (prop_block_fetch_server_cbor_coherent @Int)
   ]

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Codec/Coherence.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Codec/Coherence.hs
@@ -14,7 +14,6 @@ import Control.Monad.ST (runST)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Type.Equality
-import Data.Text (Text, pack)
 
 import Codec.Serialise.Class (Serialise)
 
@@ -65,7 +64,7 @@ prop_block_fetch_client_cbor_coherent = forAllShow genPath (showSomeTransitionPa
   eqTr MessageDone           MessageDone           = Just Refl
   eqTr _                     _                     = Nothing
 
-  decodeFull :: Monad m => ByteString -> Decoder Text ByteString m x -> m (Either Text x)
+  decodeFull :: Monad m => ByteString -> Decoder BlockFetchClientCodecError ByteString m x -> m (Either BlockFetchClientCodecError x)
   decodeFull str decoder = do
     (it, remaining) <- foldOverInput decoder (singletonInput [str])
     case remaining of
@@ -77,7 +76,7 @@ prop_block_fetch_client_cbor_coherent = forAllShow genPath (showSomeTransitionPa
         let rest = mconcat (mconcat lst)
         in if BS.null rest
              then pure it
-             else pure $ Left $ pack $ "decoder did not use all of its input: " ++ (show rest)
+             else pure $ Left $ BFClientCodecErrInputLeft (show rest)
 
 prop_block_fetch_server_cbor_coherent
   :: forall block.
@@ -141,7 +140,7 @@ prop_block_fetch_server_cbor_coherent = forAllShow genPath (showSomeTransitionPa
   eqTr MessageServerDone  MessageServerDone  = Just Refl
   eqTr _                  _                  = Nothing
 
-  decodeFull :: Monad m => ByteString -> Decoder Text ByteString m x -> m (Either Text x)
+  decodeFull :: Monad m => ByteString -> Decoder BlockFetchServerCodecError ByteString m x -> m (Either BlockFetchServerCodecError x)
   decodeFull str decoder = do
     (it, remaining) <- foldOverInput decoder (singletonInput [str])
     case remaining of
@@ -153,7 +152,7 @@ prop_block_fetch_server_cbor_coherent = forAllShow genPath (showSomeTransitionPa
         let rest = mconcat (mconcat lst)
         in if BS.null rest
              then pure it
-             else pure $ Left $ pack $ "decoder did not use all of its input: " ++ (show rest)
+             else pure $ Left $ BFServerCodecErrInputLeft (show rest)
 
 tests :: TestTree
 tests = testGroup "BlockFetchProtocol.Codec.Cbor"

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Codec/Coherence.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Codec/Coherence.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC "-Wno-unticked-promoted-constructors" #-}
-module Test.Ouroboros.Network.Protocol.BlockFetch.Codec where
+module Test.Ouroboros.Network.Protocol.BlockFetch.Codec.Coherence where
 
 import Control.Monad.ST (runST)
 import Data.ByteString (ByteString)

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Pipe.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Pipe.hs
@@ -1,0 +1,221 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Test.Ouroboros.Network.Protocol.BlockFetch.Pipe
+  ( tests
+  ) where
+
+import           Control.Arrow ((***))
+import           Control.Monad (void, unless)
+import           Control.Monad.Free (Free)
+import           Control.Monad.ST.Lazy (runST)
+import           Data.ByteString (ByteString)
+import           Data.Functor (($>))
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Maybe (fromMaybe)
+import           System.Process (createPipe)
+
+import qualified Pipes
+
+import           Control.Monad.IOSim (SimF)
+
+import           Protocol.Codec
+import           Protocol.Channel
+import           Protocol.Driver
+
+import           Ouroboros.Network.Chain (Chain (..), HasHeader, Point)
+import qualified Ouroboros.Network.Chain as Chain
+import           Ouroboros.Network.Serialise hiding (liftST)
+import           Ouroboros.Network.Pipe (pipeDuplex)
+
+import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadProbe
+
+import           Ouroboros.Network.Protocol.BlockFetch.Client
+import           Ouroboros.Network.Protocol.BlockFetch.Server
+import           Ouroboros.Network.Protocol.BlockFetch.Codec.Cbor
+
+import           Ouroboros.Network.Testing.ConcreteBlock
+import           Test.Chain (TestBlockChain (..))
+import           Test.Ouroboros.Network.Testing.Arbitrary
+import           Test.Ouroboros.Network.Testing.Utils (runExperiment, tmvarChannels)
+import           Test.Ouroboros.Network.Protocol.BlockFetch.Client
+
+import           Test.QuickCheck hiding (Result)
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Network.Protocol.BlockFetch.Pipe"
+  [ testProperty "PipeClientDemoIO" (ioProperty . prop_blockFetchClientDemoIO . map (getArbitraryPoint *** getArbitraryPoint))
+  , testProperty "ClientDemoST" (prop_blockFetchClientDemoST . map (getArbitraryPoint *** getArbitraryPoint))
+  , testProperty "PipeServerDemoIO" (ioProperty . uncurry prop_blockFetchServerDemoIO . fromChains . map getTestBlockChain)
+  , testProperty "ServerDemoST" (uncurry prop_blockFetchServerDemoST . fromChains . map getTestBlockChain)
+  ]
+
+blockFetchClientDemo_experiment
+  :: forall m header.
+     ( MonadST m
+     , MonadSTM m
+     , MonadProbe m
+     , HasHeader header
+     , Serialise header
+     , Eq header
+     )
+  => Duplex m m Encoding ByteString
+  -> Duplex m m Encoding ByteString
+  -> [(Point header, Point header)]
+  -> Probe m Property
+  -> m ()
+blockFetchClientDemo_experiment cliChan serChan ranges probe = withLiftST @m $ \liftST -> do
+  var     <- atomically $ newTVar []
+  doneVar <- atomically $ newTVar False
+
+  let client = blockFetchClientSenderFromProducer (Pipes.each ranges)
+      server = constantReceiver (atomically . modifyTVar' var . (:)) (return ())
+
+      cliPeer = blockFetchClientSenderStream client
+      serPeer = blockFetchServerReceiverStream server
+
+      codec = hoistCodec liftST blockFetchClientCodec
+
+  fork $ do
+    useCodecWithDuplex serChan codec serPeer >>= throwOnUnexpected "server" 
+    results <- atomically $ readTVar var
+    probeOutput probe (reverse results === ranges)
+    atomically $ writeTVar doneVar True
+
+  fork $ void (useCodecWithDuplex cliChan codec cliPeer >>= throwOnUnexpected "client")
+
+  atomically $ do
+    done <- readTVar doneVar
+    unless done retry
+
+throwOnUnexpected :: (Applicative m, Show fail) => String -> Result fail t -> m t
+throwOnUnexpected id_ (Unexpected txt) = error $ id_ ++ " " ++ show txt
+throwOnUnexpected _   (Normal t)       = pure t
+
+prop_blockFetchClientDemoST
+  :: ( HasHeader header
+     , Serialise header
+     , Eq header
+     )
+  => [(Point header, Point header)]
+  -> Property
+prop_blockFetchClientDemoST ranges =
+  runST $ runExperiment $ \probe -> do
+    (cliChan, serChan) <- tmvarChannels
+    blockFetchClientDemo_experiment @(Free (SimF _)) cliChan serChan ranges probe
+
+prop_blockFetchClientDemoIO
+  :: ( HasHeader header
+     , Serialise header
+     , Eq header
+     )
+  => [(Point header, Point header)]
+  -> IO Property
+prop_blockFetchClientDemoIO ranges = runExperiment $ \probe -> do
+  (serRead, cliWrite) <- createPipe
+  (cliRead, serWrite) <- createPipe
+  let cliChan = pipeDuplex cliRead cliWrite
+      serChan = pipeDuplex serRead serWrite
+
+  blockFetchClientDemo_experiment cliChan serChan ranges probe
+
+blockFetchServerDemo_experiment
+  :: forall m.
+     ( MonadST m
+     , MonadSTM m
+     , MonadProbe m
+     )
+  => Duplex m m Encoding ByteString
+  -> Duplex m m Encoding ByteString
+  -> [(Point Block, Point Block)]
+  -> ((Point Block, Point Block) -> [(Point Block, BlockBody)])
+  -> Probe m Property
+  -> m ()
+blockFetchServerDemo_experiment cliChan serChan ranges blocks probe = withLiftST @m $ \liftST -> do
+
+  var     <- atomically $ newTVar ranges
+  doneVar <- atomically $ newTVar False
+
+  let server :: BlockFetchServerSender (Point Block, BlockBody) m ()
+      server = blockFetchServerSender
+                (error "blockFetchServerSender: server must be lasy in the return value")
+                (readRange var)
+                (\range -> return $ Just $ Pipes.each (blocks range))
+      client :: BlockFetchClientReceiver (Point Block, BlockBody) m [(Point Block, BlockBody)]
+      client = blockFetchClientReceiver
+
+      cliPeer = blockFetchClientReceiverStream client
+      serPeer = blockFetchServerStream server
+
+      codec = hoistCodec liftST blockFetchServerCodec
+
+  fork $ void $ useCodecWithDuplex serChan codec serPeer >>= throwOnUnexpected "server"
+
+  fork $ do
+    results <- (useCodecWithDuplex cliChan codec cliPeer >>= throwOnUnexpected "client")
+    let expected = concatMap blocks ranges
+    probeOutput probe (reverse results === expected)
+    atomically $ writeTVar doneVar True
+
+  atomically $ do
+    done <- readTVar doneVar
+    unless done retry
+
+ where
+  readRange :: TVar m [range] -> m (StreamElement range)
+  readRange v = atomically $ do
+    rs <- readTVar v
+    case rs of
+      []         -> return End
+      (r : rest) -> writeTVar v rest $> Element r
+
+prop_blockFetchServerDemoST
+  :: [(Point Block, Point Block)]
+  -> ((Point Block, Point Block) -> [(Point Block, BlockBody)])
+  -> Property
+prop_blockFetchServerDemoST ranges blocks =
+  runST $ runExperiment $ \probe -> do
+    (cliChan, serChan) <- tmvarChannels
+    blockFetchServerDemo_experiment cliChan serChan ranges blocks probe
+
+prop_blockFetchServerDemoIO
+  :: [(Point Block, Point Block)]
+  -> ((Point Block, Point Block) -> [(Point Block, BlockBody)])
+  -> IO Property
+prop_blockFetchServerDemoIO ranges blocks = runExperiment $ \probe -> do
+  (serRead, cliWrite) <- createPipe
+  (cliRead, serWrite) <- createPipe
+  let cliChan = pipeDuplex cliRead cliWrite
+      serChan = pipeDuplex serRead serWrite
+
+  blockFetchServerDemo_experiment cliChan serChan ranges blocks probe
+
+fromChains
+  :: [Chain Block]
+  -> ( [(Point Block, Point Block)]
+     , (Point Block, Point Block) -> [(Point Block, BlockBody)]
+     )
+fromChains = go ([], Map.empty)
+ where
+  go :: ( [(Point Block, Point Block)]
+        , Map (Point Block, Point Block) [(Point Block, BlockBody)]
+        )
+     -> [Chain Block]
+     -> ( [(Point Block, Point Block)]
+        , (Point Block, Point Block) -> [(Point Block, BlockBody)]
+        )
+  go (ranges, bodies) []         = (ranges, fromMaybe [] . (bodies Map.!?))
+  go (ranges, bodies) (chain : rest) = case chain of
+    Genesis -> go (ranges, bodies) rest
+    _ :> _  ->
+      let range   = (Chain.genesisPoint, Chain.headPoint chain)
+          bodies' = Chain.foldChain
+            (\acc b -> (Chain.blockPoint b, blockBody b) : acc)
+            [] chain
+      in go (range : ranges, Map.insert range bodies' bodies) rest

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Server.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch/Server.hs
@@ -1,0 +1,16 @@
+module Test.Ouroboros.Network.Protocol.BlockFetch.Server where
+
+import Ouroboros.Network.Protocol.BlockFetch.Server
+
+-- | Testing server which accumulates received value in its return value.
+--
+accumulatingBlockFetchServerReceiver
+  :: Monad m
+  => BlockFetchServerReceiver range m [range]
+accumulatingBlockFetchServerReceiver = go []
+ where
+  go acc =
+    BlockFetchServerReceiver {
+      recvMessageRequestRange = \range -> return $ go (range : acc),
+      recvMessageDone         = return (reverse acc)
+    }

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testing/Arbitrary.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testing/Arbitrary.hs
@@ -6,7 +6,9 @@ import Ouroboros.Network.Chain (Point (..))
 
 import           Test.QuickCheck
 
-newtype ArbitraryPoint = ArbitraryPoint (Point BlockHeader)
+newtype ArbitraryPoint = ArbitraryPoint {
+    getArbitraryPoint :: Point BlockHeader
+  }
   deriving (Show, Eq)
 
 instance Arbitrary ArbitraryPoint where
@@ -14,3 +16,13 @@ instance Arbitrary ArbitraryPoint where
     slot <- Slot <$> arbitrary
     hash <- HeaderHash <$> arbitrary
     return $ ArbitraryPoint $ Point slot (BlockHash hash)
+
+newtype ArbitraryBlockBody = ArbitraryBlockBody {
+    getArbitraryBlockBody :: BlockBody
+  }
+  deriving (Show, Eq)
+
+instance Arbitrary ArbitraryBlockBody where
+    arbitrary = ArbitraryBlockBody . BlockBody <$> vectorOf 4 (choose ('A', 'Z'))
+    -- probably no need for shrink, the content is arbitrary and opaque
+    -- if we add one, it might be to shrink to an empty block

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testing/Arbitrary.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testing/Arbitrary.hs
@@ -1,0 +1,16 @@
+module Test.Ouroboros.Network.Testing.Arbitrary where
+
+import Ouroboros.Network.Testing.ConcreteBlock
+import Ouroboros.Network.Block (Slot (..), Hash (..))
+import Ouroboros.Network.Chain (Point (..))
+
+import           Test.QuickCheck
+
+newtype ArbitraryPoint = ArbitraryPoint (Point BlockHeader)
+  deriving (Show, Eq)
+
+instance Arbitrary ArbitraryPoint where
+  arbitrary = do
+    slot <- Slot <$> arbitrary
+    hash <- HeaderHash <$> arbitrary
+    return $ ArbitraryPoint $ Point slot (BlockHash hash)

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testing/Utils.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testing/Utils.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module Test.Ouroboros.Network.Testing.Utils where
+
+import           Codec.CBOR.Encoding as CBOR (Encoding)
+import qualified Codec.CBOR.Write as CBOR
+import           Data.List (foldl')
+import           Data.ByteString (ByteString)
+
+import           Protocol.Channel
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadTimer
+import           Control.Monad.Class.MonadProbe
+
+import           Test.QuickCheck
+
+
+-- | FIXME: find a better place for it, this might be useful elsewhere too.
+runExperiment
+  :: forall m n.
+     ( MonadSTM m
+     , MonadTimer m
+     , MonadProbe m
+     , MonadRunProbe m n
+     )
+  => (Probe m Property -> m ())
+  -> n Property
+runExperiment exp_ = isValid <$> withProbe exp_
+ where
+  isValid :: [(Time m, Property)] -> Property
+  isValid = foldl' (\acu (_,p) -> acu .&&. p) (property True)
+
+tmvarChannels
+  :: forall m. MonadSTM m
+  => m (Duplex m m Encoding ByteString, Duplex m m Encoding ByteString)
+tmvarChannels = do
+  left  <- atomically newEmptyTMVar
+  right <- atomically newEmptyTMVar
+  let
+    leftChan  = uniformDuplex (atomically . putTMVar left . CBOR.toStrictByteString)  (fmap Just (atomically $ takeTMVar right))
+    rightChan = uniformDuplex (atomically . putTMVar right . CBOR.toStrictByteString) (fmap Just (atomically $ takeTMVar left))
+  pure (leftChan, rightChan)

--- a/typed-transitions/test/Test/Protocol/Codec/PingPong.hs
+++ b/typed-transitions/test/Test/Protocol/Codec/PingPong.hs
@@ -14,12 +14,11 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
 import Protocol.Codec
+import Protocol.Codec.Coherent
 import Protocol.Path
 
 import Protocol.PingPong.Codec
 import Protocol.PingPong.Type
-
-import Test.Protocol.Codec.Coherent
 
 prop_ping_pong_coherent :: Property
 prop_ping_pong_coherent = forAllShow genPath showPath doTest

--- a/typed-transitions/typed-transitions.cabal
+++ b/typed-transitions/typed-transitions.cabal
@@ -18,6 +18,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Protocol.Channel
                      , Protocol.Codec
+                     , Protocol.Codec.Coherent
                      , Protocol.Core
                      , Protocol.Driver
                      , Protocol.Path
@@ -44,6 +45,7 @@ library
                      , BangPatterns
                      , StandaloneDeriving
   build-depends:       base
+                     , QuickCheck
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -58,7 +60,6 @@ test-suite test-typed-transitions
   hs-source-dirs: test
   other-modules:    Test.Protocol.Channel
                     Test.Protocol.Codec
-                    Test.Protocol.Codec.Coherent
                     Test.Protocol.Codec.PingPong
   build-depends:    base
                   , async


### PR DESCRIPTION
This PR should be reviewed after: #62 (it builds on top of it)
This PR includes:
* codec for block fetch mini-protocol
* consistency tests
* block fetch protocol tests using channels (and thus the codec) in simulation
* block fetch protocols test using over a local pipe (thus in IO)

The PR solves #124 adn #125