### PR TITLE
Tx submission protocol

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -46,6 +46,9 @@ library
                        Ouroboros.Network.Protocol.ChainSync.Direct
                        Ouroboros.Network.Protocol.ChainSync.Server
                        Ouroboros.Network.Protocol.ChainSync.Type
+                       Ouroboros.Network.Protocol.TxSubmission.Type
+                       Ouroboros.Network.Protocol.TxSubmission.Client
+                       Ouroboros.Network.Protocol.TxSubmission.Server
                        Ouroboros.Network.Protocol.Stream.Type
                        Ouroboros.Network.Protocol.Stream.Client
                        Ouroboros.Network.Protocol.Stream.Server

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -89,6 +89,7 @@ library
                        cborg             >=0.2.1 && <0.3,
                        containers,
                        fingertree        >=0.1.4.2 && <0.2,
+                       exceptions        >=0.10.0 && <0.11.0,
                        hashable          >=1.2 && <1.3,
                        iohk-monitoring,
                        mtl               >=2.2 && <2.3,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -49,6 +49,7 @@ library
                        Ouroboros.Network.Protocol.TxSubmission.Type
                        Ouroboros.Network.Protocol.TxSubmission.Client
                        Ouroboros.Network.Protocol.TxSubmission.Server
+                       Ouroboros.Network.Protocol.TxSubmission.Direct
                        Ouroboros.Network.Protocol.Stream.Type
                        Ouroboros.Network.Protocol.Stream.Client
                        Ouroboros.Network.Protocol.Stream.Server

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Client.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Ouroboros.Network.Protocol.TxSubmission.Client where
+
+import Protocol.Core
+import Ouroboros.Network.Protocol.TxSubmission.Type
+
+import Data.List.NonEmpty (NonEmpty (..))
+import Pipes (Producer)
+import qualified Pipes
+
+newtype TxSubmissionClient tx err m a = TxSubmissionClient {
+    runTxSubmissionClient :: m (TxSubmission tx err m a)
+  }
+
+data TxSubmission tx err m a where
+  TxSubmission
+    :: tx
+    -> TxSubmissionClient tx err m a
+    -> TxSubmission tx err m a
+  TxSubmissionDone
+    :: TxSubmissionHandler err m a
+    -> TxSubmission tx err m a
+
+newtype TxSubmissionHandler err m a = TxSubmissionHandler {
+    runTxSubmissionHandler :: Maybe err -> m a
+  }
+
+txSubmissionClientFromList
+  :: Applicative m
+  => NonEmpty tx
+  -> TxSubmissionHandler err m a
+  -> TxSubmissionClient tx err m a
+txSubmissionClientFromList (tx :| []) txHandler
+  = TxSubmissionClient $ pure $ TxSubmission tx (TxSubmissionClient $ pure $ TxSubmissionDone txHandler)
+txSubmissionClientFromList (tx :| (tx' : txs')) txHandler
+  = TxSubmissionClient $ pure $ TxSubmission tx (txSubmissionClientFromList (tx' :| txs') txHandler)
+
+txSubmissionClientFromProducer
+  :: Monad m
+  => Producer tx m ()
+  -> TxSubmissionHandler err m a
+  -> TxSubmissionClient tx err m a
+txSubmissionClientFromProducer producer txHandler = TxSubmissionClient $
+  Pipes.next producer >>= \nxt -> case nxt of
+    Left _                -> pure $ TxSubmissionDone txHandler
+    Right (tx, producer') -> pure $ TxSubmission tx (txSubmissionClientFromProducer producer' txHandler)
+
+txSubmissionClientStream
+  :: Monad m
+  => TxSubmissionClient tx err m a
+  -> Peer TxSubmissionProtocol (TxSubmissionMessage tx err)
+    (Yielding StIdle)
+    (Finished StDone)
+    m a
+txSubmissionClientStream (TxSubmissionClient submit) = lift $ submit >>= \cli -> case cli of
+  TxSubmission tx scli       ->
+    -- recursievly send all transactions
+    pure $ part (MsgTx tx) (txSubmissionClientStream scli)
+  TxSubmissionDone txHandler ->
+    -- client sent all transactions
+    pure $ over MsgClientDone $
+    -- await for server response
+    await $ \(MsgServerDone merr) ->
+    -- end the protocol
+    lift $ done <$> runTxSubmissionHandler txHandler merr

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Direct.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+module Ouroboros.Network.Protocol.TxSubmission.Direct where
+
+import Ouroboros.Network.Protocol.TxSubmission.Type
+import Ouroboros.Network.Protocol.TxSubmission.Client
+import Ouroboros.Network.Protocol.TxSubmission.Server
+
+direct
+  :: forall (n :: Nat) tx err m a b. Monad m
+  => TxSubmissionServer tx err m a
+  -> TxSubmissionClient n tx err m b
+  -> m (Either err a, b)
+direct = go
+ where
+  go :: TxSubmissionServer tx err m a
+     -> TxSubmissionClient l tx err m b
+     -> m (Either err a, b)
+  go handlers@TxSubmissionServer {handleTx,handleTxDone} (TxSubmissionClient mclient) = do
+    client <- mclient
+    case client of
+      TxSubmission tx client' -> do
+        _ <- handleTx tx
+        go handlers client'
+      TxSubmissionDone b (TxSubmissionErrHandler handleErr) ->
+        handleTxDone >>= \res -> case res of
+          Left err -> (Left err,) <$> handleErr (Just err)
+          Right a  -> return (Right a, b)
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Server.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Ouroboros.Network.Protocol.TxSubmission.Server where
+
+import Data.Functor (($>))
+
+import Protocol.Core
+import Ouroboros.Network.Protocol.TxSubmission.Type
+
+newtype TxSubmissionServer tx err m a = TxSubmissionServer {
+    runTxSubmissionServer :: m (TxSubmissionHandlers tx err m a)
+  }
+
+data TxSubmissionHandlers tx err m a = TxSubmissionHandlers {
+    handleTx     :: tx -> m (TxSubmissionHandlers tx err m a),
+    handleTxDone :: m (Either err a)
+  }
+
+txSubmissionServer
+  :: forall tx err m a.
+     Monad m
+  => (tx -> m ())    -- valid tx handler
+  -> (tx -> m Bool)  -- validate a transaction
+  -> ([tx] -> m err) -- error handler
+  -> a
+  -> TxSubmissionServer tx err m a
+txSubmissionServer handleTx validateTx handleErr result = TxSubmissionServer $ pure (go [])
+ where
+  go :: [tx] -- malformed transactions
+     -> TxSubmissionHandlers tx err m a
+  go errs = TxSubmissionHandlers {
+      handleTx = \tx -> validateTx tx >>= \txValid -> if txValid
+                          then handleTx tx $> go errs
+                          else pure $ go (tx : errs),
+      handleTxDone = case errs of
+        [] -> pure (Right result)
+        _  -> Left <$> handleErr errs
+    }
+
+txSubmissionServerStream
+  :: forall tx err m a.
+     Monad m
+  => TxSubmissionServer tx err m a
+  -> Peer TxSubmissionProtocol (TxSubmissionMessage tx err)
+      (Awaiting StIdle)
+      (Finished StDone)
+      m (Maybe a)
+txSubmissionServerStream (TxSubmissionServer server) = lift $ go <$> server
+ where
+  go :: TxSubmissionHandlers tx err m a
+     -> Peer TxSubmissionProtocol (TxSubmissionMessage tx err)
+          (Awaiting StIdle)
+          (Finished StDone)
+          m (Maybe a)
+  go TxSubmissionHandlers {handleTx, handleTxDone} =
+    await $ \msg -> case msg of
+      MsgTx tx      -> lift $ go <$> handleTx tx
+      MsgClientDone -> lift $ handleTxDone >>= \r -> case r of
+        Right a  -> pure $ out (MsgServerDone Nothing) (done $ Just a)
+        Left err -> pure $ out (MsgServerDone (Just err)) (done Nothing)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE GADTs        #-}
+{-# LANGUAGE DataKinds    #-}
+{-# LANGUAGE TypeFamilies #-}
+module Ouroboros.Network.Protocol.TxSubmission.Type where
+
+import Protocol.Core
+
+data TxSubmissionState where
+  StIdle :: TxSubmissionState -- client is streaming transactions
+  StBusy :: TxSubmissionState -- server received all transactions
+  StDone :: TxSubmissionState -- transaction submission protocol finished
+
+-- |
+-- A type which indentifies client\/server partition of states in the
+-- transaction submission protocol.
+--
+data TxSubmissionProtocol
+
+type instance Partition TxSubmissionProtocol st client server terminal =
+  TxSubmissionPartition st client server terminal
+
+type family TxSubmissionPartition st (client :: Control) (server :: Control) (terminal :: Control) :: Control where
+  TxSubmissionPartition StIdle client server terminal = client -- client is in charge of streaming transactions
+  TxSubmissionPartition StBusy client server terminal = server
+  TxSubmissionPartition StDone client server terminal = terminal
+
+-- |
+-- @'TxSubmissionProtocol'@ messages
+data TxSubmissionMessage tx err from to where
+  MsgTx         :: tx -> TxSubmissionMessage tx err StIdle StIdle
+  MsgClientDone :: TxSubmissionMessage tx err StIdle StBusy
+  MsgServerDone :: Maybe err -> TxSubmissionMessage tx err StBusy StDone

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
@@ -1,32 +1,82 @@
 {-# LANGUAGE GADTs        #-}
 {-# LANGUAGE DataKinds    #-}
+{-# LANGUAGE PolyKinds    #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType   #-}
+{-# LANGUAGE RankNTypes   #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Ouroboros.Network.Protocol.TxSubmission.Type where
 
 import Protocol.Core
 
-data TxSubmissionState where
-  StIdle :: TxSubmissionState -- client is streaming transactions
-  StBusy :: TxSubmissionState -- server received all transactions
-  StDone :: TxSubmissionState -- transaction submission protocol finished
+data Nat = Zero | Succ Nat
+
+data SNat (n :: Nat) where
+  SZero :: SNat Zero
+  SSucc :: SNat n -> SNat (Succ n)
+
+type family DoubleNat (n :: Nat) :: Nat where
+  DoubleNat Zero        = Zero
+  DoubleNat (Succ n)    = Succ (Succ (DoubleNat n))
+
+doubleSNat :: SNat n -> SNat (DoubleNat n)
+doubleSNat SZero     = SZero
+doubleSNat (SSucc n) = SSucc (SSucc (doubleSNat n))
+
+type N32 = DoubleNat (DoubleNat (DoubleNat (DoubleNat (DoubleNat(Succ Zero)))))
+
+s32 :: SNat N32
+s32 = doubleSNat (doubleSNat (doubleSNat (doubleSNat (doubleSNat (SSucc SZero)))))
+
+type family LessEqualThan (n :: Nat) (m :: Nat) :: Bool where
+  LessEqualThan (Succ n) (Succ m) = LessEqualThan n m
+  LessEqualThan Zero     _        = True
+  LessEqualThan (Succ n) Zero     = False
+
+data SBool (b :: Bool) where
+  STrue  :: SBool True
+  SFalse :: SBool False
+
+lessEqualThan :: SNat (n :: Nat) -> SNat (m :: Nat) -> SBool (LessEqualThan n m)
+lessEqualThan (SSucc n) (SSucc m) = lessEqualThan n m
+lessEqualThan SZero     (SSucc _) = STrue
+lessEqualThan SZero     SZero     = STrue
+lessEqualThan (SSucc _) SZero     = SFalse
+
+type family Pred (n :: Nat) :: Nat where
+  Pred (Succ n) = n
+
+spred :: LessEqualThan (Succ Zero) n ~ True => SNat n -> SNat (Pred n)
+spred (SSucc n) = n
+
+data TxSubmissionState (n :: Nat) where
+  StIdle :: Nat -> TxSubmissionState n -- client is streaming transactions
+  StBusy :: forall (m :: Nat). TxSubmissionState m -- server received all transactions
+  StDone :: forall (m :: Nat). TxSubmissionState m -- transaction submission protocol finished
 
 -- |
 -- A type which indentifies client\/server partition of states in the
--- transaction submission protocol.
+-- transaction submission protocol.  @n :: Nat@ is an upper bound for the number
+-- of transaction a client can send using a single instance of this protocol.
 --
-data TxSubmissionProtocol
+data TxSubmissionProtocolN (n :: Nat)
 
-type instance Partition TxSubmissionProtocol st client server terminal =
+type TxSubmissionProtocol32  = TxSubmissionProtocolN N32
+type TxSubmissionProtocol64  = TxSubmissionProtocolN (DoubleNat N32)
+type TxSubmissionProtocol128 = TxSubmissionProtocolN (DoubleNat (DoubleNat N32))
+
+type instance Partition (TxSubmissionProtocolN n) st client server terminal =
   TxSubmissionPartition st client server terminal
 
 type family TxSubmissionPartition st (client :: Control) (server :: Control) (terminal :: Control) :: Control where
-  TxSubmissionPartition StIdle client server terminal = client -- client is in charge of streaming transactions
+  TxSubmissionPartition (StIdle n) client server terminal = client -- client is in charge of streaming transactions
   TxSubmissionPartition StBusy client server terminal = server
   TxSubmissionPartition StDone client server terminal = terminal
 
 -- |
--- @'TxSubmissionProtocol'@ messages
-data TxSubmissionMessage tx err from to where
-  MsgTx         :: tx -> TxSubmissionMessage tx err StIdle StIdle
-  MsgClientDone :: TxSubmissionMessage tx err StIdle StBusy
-  MsgServerDone :: Maybe err -> TxSubmissionMessage tx err StBusy StDone
+-- @'TxSubmissionProtocolN'@ messages
+data TxSubmissionMessage (n :: Nat) tx err from to where
+  MsgTx         :: (LessEqualThan m n ~ True) => tx -> TxSubmissionMessage n tx err (StIdle (m :: Nat)) (StIdle (Succ m))
+  MsgClientDone :: TxSubmissionMessage n tx err (StIdle m) StBusy
+  MsgServerDone :: Maybe err -> TxSubmissionMessage n tx err StBusy StDone


### PR DESCRIPTION
This is an initial draft of the submission protocol.  The protocol defines an upper bound for the number of transactions a client can send in one protocol instance.  The client can stream each transaction to the server and receive feedback on the submitted transactions.