### PR TITLE
Volatile db

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -84,6 +84,11 @@ library
                        Ouroboros.Storage.ImmutableDB.Util
                        Ouroboros.Storage.Util
                        Ouroboros.Storage.Util.ErrorHandling
+                       Ouroboros.Storage.VolatileDB
+                       Ouroboros.Storage.VolatileDB.API
+                       Ouroboros.Storage.VolatileDB.Impl
+                       Ouroboros.Storage.VolatileDB.Types
+                       Ouroboros.Storage.VolatileDB.Util
                        Ouroboros.Storage.IO
 
   default-language:    Haskell2010

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -277,6 +277,9 @@ test-suite test-storage
                     Test.Ouroboros.Storage.ImmutableDB.Sim
                     Test.Ouroboros.Storage.ImmutableDB.StateMachine
                     Test.Ouroboros.Storage.ImmutableDB.TestBlock
+                    Test.Ouroboros.Storage.VolatileDB
+                    Test.Ouroboros.Storage.VolatileDB.Model
+                    Test.Ouroboros.Storage.VolatileDB.StateMachine
                     Test.Util.RefEnv
   build-depends:    base,
                     ouroboros-network,
@@ -286,6 +289,7 @@ test-suite test-storage
                     bifunctors,
                     binary,
                     bytestring,
+                    cereal,
                     containers,
                     directory,
                     exceptions,

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB.hs
@@ -1,0 +1,7 @@
+module Ouroboros.Storage.VolatileDB
+  ( module Ouroboros.Storage.VolatileDB.API
+  , module Ouroboros.Storage.VolatileDB.Impl
+  ) where
+
+import Ouroboros.Storage.VolatileDB.API
+import Ouroboros.Storage.VolatileDB.Impl

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes       #-}
+module Ouroboros.Storage.VolatileDB.API
+  ( VolatileDB(..)
+  , withDB
+
+  , module Ouroboros.Storage.VolatileDB.Types
+  ) where
+
+import Control.Monad.Catch (MonadMask, bracket)
+import Data.ByteString (ByteString)
+import Data.ByteString.Builder (Builder)
+
+import GHC.Stack (HasCallStack)
+
+import Ouroboros.Storage.VolatileDB.Types
+
+-- | Open the database using the given function, perform the given action
+-- using the database, and closes the database using its 'closeDB' function,
+-- in case of success or when an exception was raised.
+withDB :: (HasCallStack, MonadMask m)
+       => m (VolatileDB blockId m)
+          -- ^ How to open the database
+       -> (VolatileDB blockId m -> m a)
+          -- ^ Action to perform using the database
+       -> m a
+withDB openDB = bracket openDB closeDB
+
+data VolatileDB blockId m = VolatileDB {
+      closeDB  :: HasCallStack => m ()
+    , isOpenDB :: HasCallStack => m Bool
+    , reOpenDB :: HasCallStack => m ()
+    , getBlock :: HasCallStack => blockId -> m (Maybe ByteString)
+    , putBlock :: HasCallStack => blockId -> Builder -> m ()
+    , garbageCollect :: HasCallStack => Slot -> m ()
+}

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
@@ -1,0 +1,557 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE MultiWayIf                 #-}
+-- Volatile on-disk database of binary blobs
+--
+-- Logic
+--
+-- The db is a key-value store of binary blocks and is parametric
+-- on the key of blocks, named blockId. The only constraints are that one must provide
+-- a function (toSlot :: blockId -> Slot), as well as an Ord instance of blockId.
+-- The database uses in memory indexes, which are created on each reopening. reopening
+-- includes parsing all blocks of the dbFolder, so it can be an expensive operation
+-- if the database gets big. That's why the intention of this db is to be used for only
+-- the tip of the blockchain, when there is still volatility on which blocks are included.
+-- The db is agnostic to the format of the blocks, so a parser must be provided.
+-- In addition to getBlock and putBlock, the db provides also the ability to garbage-collect
+-- old blocks. The actual garbage-collection happens in terms of files and not blocks: a file
+-- is deleted/garbage-collected only if its latest block is old enough. A block is old enough
+-- if its toSlot value is old enough and not based on its Ord instance. This type of garbage
+-- collection makes the deletion of blocks depend on the number of blocks we insert on
+-- each file, as well as the order of insertion, so it's not deterministic on blocks themselves.
+--
+-- Errors
+--
+-- On any exception or error the db closes and its Internal State is lost, inluding in memory
+-- indexes. We try to make sure that even on errors the fs represantation of the db remains
+-- consistent and the Internal State can be recovered on reopening. In general we try to make
+-- sure that at any point, losing the in-memory Internal State is not fatal to the db as it can
+-- recovered. This is important since we must always expect unexpected shutdowns, power loss,
+-- sleep mode etc. This is achived by leting only basic operations on the db:
+-- + putBlock only appends a new block on a file. Losing an update means we only lose a block,
+--   which can be recovered.
+-- + garbage collect deletes only whole files.
+-- + there is no modify block operation. Thanks to that we need not keep any rollback journals
+--   to make sure we are safe in case of unexpected shutdowns.
+--
+-- Concurency
+--
+-- The same db should only be opened once
+-- Multiple threads can share the same db as concurency if fully supported.
+--
+-- FS Layout:
+--
+-- On disk represantation is as follows:
+--
+--  dbFolder\
+--    blocks-0.dat
+--    blocks-1.dat
+--    ...
+--
+--  If on opening any other filename which does not follow blocks-i.dat is found
+--  an error is raised. The Ordering of blocks is not guarranteed to be followed,
+--  files can be garbage-collected.
+--
+module Ouroboros.Storage.VolatileDB.Impl
+    ( -- * Opening a database
+      openDB
+      -- * tests only
+    , VolatileDBEnv(..)
+    , InternalState(..)
+    , filePath
+    , getInternalState
+    , openDBFull
+    ) where
+
+import           Control.Monad
+import           Control.Monad.Catch (ExitCase (..), MonadMask, generalBracket)
+import           Control.Monad.Class.MonadSTM
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Builder as BS
+import           Data.Int (Int64)
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Maybe
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           GHC.Stack
+import qualified System.IO as IO
+
+import           Ouroboros.Storage.FS.API
+import           Ouroboros.Storage.FS.API.Types
+import           Ouroboros.Storage.VolatileDB.API
+import           Ouroboros.Storage.VolatileDB.Util
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+{------------------------------------------------------------------------------
+  Main Types
+------------------------------------------------------------------------------}
+
+data VolatileDBEnv m blockId = VolatileDBEnv {
+      _dbInternalState  :: !(TMVar m (Maybe (InternalState m blockId)))
+      -- TODO(kde) remove this
+    , _dbFolder         :: !FsPath
+    , _maxBlocksPerFile :: !Int
+    , _parser           :: !(Parser m blockId)
+    , _toSlot           :: (blockId -> Slot)
+    }
+
+data InternalState m blockId = InternalState {
+      _currentWriteHandle         :: !(FsHandle m) -- The unique open file we append blocks.
+    , _currentWritePath           :: !String -- The path of the file above.
+    , _currentWriteOffset         :: !Int64 -- The 'WriteHandle' for the same file.
+    , _currentNextId              :: !Int -- The next file name Id.
+    , _currentBlockId             :: !(Maybe blockId) -- The newest block in the db.
+    , _currentMap                 :: !(Index blockId) -- The content of each file.
+    , _currentRevMap              :: !(ReverseIndex blockId) -- Where to find each block from slot.
+    }
+
+-- Eq instance mainly for testing.
+instance Eq blockId => Eq (InternalState m blockId) where
+    x == y =
+               _currentWritePath x == _currentWritePath y
+            && _currentWriteOffset x == _currentWriteOffset y
+            && _currentNextId x == _currentNextId y
+            && _currentBlockId x == _currentBlockId y
+            && _currentMap x == _currentMap y
+            && _currentRevMap x == _currentRevMap y
+
+instance Show blockId => Show (InternalState m blockId) where
+    show InternalState{..} = show (_currentWritePath, _currentWriteOffset, _currentNextId, _currentBlockId, _currentMap, _currentRevMap)
+
+
+{------------------------------------------------------------------------------
+  VolatileDB API
+------------------------------------------------------------------------------}
+
+openDB :: (HasCallStack, MonadMask m, MonadSTM m, Show blockId, Ord blockId)
+       => HasFS m
+       -> ErrorHandling (VolatileDBError blockId) m
+       -> FsPath
+       -> Parser m blockId
+       -> Int
+       -> (blockId -> Slot)
+       -> m (VolatileDB blockId m)
+openDB h e path p m t = fst <$> openDBFull h e path p m t
+
+openDBFull :: (HasCallStack, MonadMask m, MonadSTM m, Show blockId, Ord blockId)
+           => HasFS m
+           -> ErrorHandling (VolatileDBError blockId) m
+           -> FsPath
+           -> Parser m blockId
+           -> Int
+           -> (blockId -> Slot)
+           -> m (VolatileDB blockId m, VolatileDBEnv m blockId)
+openDBFull hasFS err path parser maxBlocksPerFile toSlot = do
+    env <- openDBImpl hasFS err path parser maxBlocksPerFile toSlot
+    let db = VolatileDB {
+          closeDB        = closeDBImpl  hasFS err env
+        , isOpenDB       = isOpenDBImpl hasFS err env
+        , reOpenDB       = reOpenDBImpl hasFS err env
+        , getBlock       = getBlockImpl hasFS err env
+        , putBlock       = putBlockImpl hasFS err toSlot env
+        , garbageCollect = garbageCollectImpl hasFS err env
+        }
+    return (db, env)
+
+-- After opening the db once, the same @maxBlocksPerFile@ must be provided all
+-- next opens.
+openDBImpl :: (HasCallStack, MonadMask m, MonadSTM m, Show blockId, Ord blockId)
+           => HasFS m
+           -> ErrorHandling (VolatileDBError blockId) m
+           -> FsPath
+           -> Parser m blockId
+           -> Int
+           -> (blockId -> Slot)
+           -> m (VolatileDBEnv m blockId)
+openDBImpl hasFS@HasFS{..} err path parser maxBlocksPerFile toSlot =
+    if maxBlocksPerFile <= 0
+    then EH.throwError err $ InvalidArgumentsError "maxBlocksPerFile can't be 0"
+    else do
+        st <- mkInternalStateDB hasFS err path parser maxBlocksPerFile toSlot
+        stVar <- atomically $ newTMVar $ Just st
+        return $ VolatileDBEnv stVar path maxBlocksPerFile parser toSlot
+
+closeDBImpl :: (MonadSTM m, MonadMask m)
+            => Show blockId
+            => HasFS m
+            -> ErrorHandling (VolatileDBError blockId) m
+            -> VolatileDBEnv m blockId
+            -> m ()
+closeDBImpl HasFS{..} _err VolatileDBEnv{..} = do
+        mbInternalState <- atomically (swapTMVar _dbInternalState Nothing)
+        case mbInternalState of
+            Nothing -> return ()
+            Just InternalState{..} ->
+                hClose _currentWriteHandle
+
+isOpenDBImpl :: (MonadSTM m, MonadMask m)
+             => HasFS m
+             -> ErrorHandling (VolatileDBError blockId) m
+             -> VolatileDBEnv m blockId
+             -> m Bool
+isOpenDBImpl HasFS{..} _err VolatileDBEnv{..} = do
+    mSt <- atomically (readTMVar _dbInternalState)
+    return $ isJust mSt
+
+reOpenDBImpl :: (HasCallStack, MonadMask m, MonadSTM m, Ord blockId, Show blockId)
+             => HasFS m
+             -> ErrorHandling (VolatileDBError blockId) m
+             -> VolatileDBEnv m blockId
+             -> m ()
+reOpenDBImpl hasFS@HasFS{..} err VolatileDBEnv{..} = do
+    modifyTMVar _dbInternalState $ \mbSt -> case mbSt of
+        Just (st@InternalState{..}) -> return (Just st, ())
+        Nothing -> do
+            st <- mkInternalStateDB hasFS err _dbFolder _parser _maxBlocksPerFile _toSlot
+            return (Just st, ())
+
+getBlockImpl :: (MonadSTM m, MonadMask m, Ord blockId, Show blockId)
+             => HasFS m
+             -> ErrorHandling (VolatileDBError blockId) m
+             -> VolatileDBEnv m blockId
+             -> blockId
+             -> m (Maybe ByteString)
+getBlockImpl hasFS@HasFS{..} err env@VolatileDBEnv{..} slot = do
+    modifyState hasFS err env $ \st@InternalState{..} -> do
+        case Map.lookup slot _currentRevMap of
+            Nothing -> return (st, Nothing)
+            Just (file, w, n) ->  do
+                bs <- withFile hasFS (_dbFolder ++ [file]) IO.ReadMode $ \hndl -> do
+                        _ <- hSeek hndl IO.AbsoluteSeek w
+                        hGet hndl n
+                return (st, Just bs)
+
+-- This function follows the approach:
+-- (1) hPut bytes to the file
+-- (2) if full hClose the write file
+-- (3)         hOpen a new write file
+-- (4) update the Internal State.
+-- If there is an error after (1) or after (2) we should make sure that when we reopen a db from scratch,
+-- it can succesfully recover if it does not find an empty file to write and all other files are full.
+-- We should also make sure that the fs can be recovered if we get an exception/error at any moment
+-- and that we are left with an empty Internal State.
+-- We should be careful about not leaking open fds when we open a new file, since this can affect garbage
+-- collection of files.
+putBlockImpl :: forall m. (MonadMask m, MonadSTM m)
+             => forall blockId. (Ord blockId, Show blockId)
+             => HasFS m
+             -> ErrorHandling (VolatileDBError blockId) m
+             -> (blockId -> Slot)
+             -> VolatileDBEnv m blockId
+             -> blockId
+             -> BS.Builder
+             -> m ()
+putBlockImpl hasFS@HasFS{..} err toSlot env@VolatileDBEnv{..} blockId builder = do
+    modifyState hasFS err env $ \st@InternalState{..} -> do
+        case Map.lookup blockId _currentRevMap of
+            Just _ -> return (st, ()) -- trying to put an existing blockId is a no-op.
+            Nothing -> do
+                (mmaxSlot, nBlocks, fileMp) <-
+                    case Map.lookup _currentWritePath _currentMap of
+                        Nothing -> EH.throwError err $ UndisputableLookupError _currentWritePath _currentMap
+                        Just fileInfo -> return fileInfo
+                bytesWritten <- hPut _currentWriteHandle builder
+                let fileMp' = Map.insert _currentWriteOffset (fromIntegral bytesWritten, blockId) fileMp
+                    nBlocks' = nBlocks + 1
+                    mp = Map.insert _currentWritePath (updateSlotNoBlockId mmaxSlot [toSlot blockId], nBlocks', fileMp') _currentMap
+                    revMp = Map.insert blockId (_currentWritePath, _currentWriteOffset, fromIntegral bytesWritten) _currentRevMap
+                    blockId' = fst <$> updateSlot toSlot _currentBlockId [blockId]
+                    st' = st {
+                          _currentWriteOffset = _currentWriteOffset + fromIntegral bytesWritten
+                        , _currentBlockId = blockId'
+                        , _currentMap = mp
+                        , _currentRevMap = revMp
+                    }
+                if nBlocks' < _maxBlocksPerFile
+                then return (st', ())
+                else (\s -> (s,())) <$> nextFile hasFS err env st'
+
+-- The approach we follow here is to try to garbage collect each file.
+-- For each file we update the fs and then we update the Internal State.
+-- If some fs update fails, we are left with an empty Internal State and a subset
+-- of the deleted files in fs. Any unexpected failure (power loss, other exceptions)
+-- has the same results, since the Internal State will be empty on re-opening.
+-- This is ok only if any fs updates leave the fs in a consistent state every moment.
+-- This approach works since we always close the Database in case of errors,
+-- but we should rethink it if this changes in the future.
+garbageCollectImpl :: forall m blockId. (MonadMask m, MonadSTM m, Ord blockId, Show blockId)
+                   => HasFS m
+                   -> ErrorHandling (VolatileDBError blockId) m
+                   -> VolatileDBEnv m blockId
+                   -> Slot
+                   -> m ()
+garbageCollectImpl hasFS@HasFS{..} err env@VolatileDBEnv{..} slot = do
+    modifyState hasFS err env $ \st -> do
+        st' <- foldM (tryCollectFile hasFS err env slot) st (Map.toList (_currentMap st))
+        let currentSlot' = if Map.size (_currentMap st') == 0 then Nothing else (_currentBlockId st')
+        let st'' = st'{_currentBlockId = currentSlot'}
+        return (st'', ())
+
+-- For the given file, we check if it should be garbage collected.
+-- At the same time we return the updated InternalState.
+-- Important note here is that, every call should leave the fs in a
+-- consistent state, without depending on other calls.
+-- This is achieved so far, since fs calls are reduced to
+-- removeFile and truncate 0.
+tryCollectFile :: forall m blockId. (MonadMask m, MonadSTM m, Ord blockId, Show blockId)
+               => HasFS m
+               -> ErrorHandling (VolatileDBError blockId) m
+               -> VolatileDBEnv m blockId
+               -> Slot
+               -> InternalState m blockId
+               -> (String, (Maybe Slot, Int, Map Int64 (Int, blockId)))
+               -> m (InternalState m blockId)
+tryCollectFile hasFS@HasFS{..} err env@VolatileDBEnv{..} slot st@InternalState{..} (file, (mmaxSlot, _, fileMp)) =
+    let isLess       = not $ cmpMaybe mmaxSlot slot
+        isCurrent    = file == _currentWritePath
+        isCurrentNew = _currentWriteOffset == 0
+    in if   | not isLess    -> return st
+            | not isCurrent -> do
+                let bids = snd <$> Map.elems fileMp
+                    rv' = Map.withoutKeys _currentRevMap (Set.fromList bids)
+                removeFile $ _dbFolder ++ [file]
+                return st{_currentMap = Map.delete file _currentMap, _currentRevMap = rv'}
+            | isCurrentNew  -> return st
+            | True          -> do
+                st' <- reOpenFile hasFS err env st
+                let bids = snd <$> Map.elems fileMp
+                    rv' = foldl (flip Map.delete) _currentRevMap bids
+                return st'{_currentRevMap = rv'}
+
+getInternalState :: forall m. (MonadSTM m)
+                 => forall blockId. Ord blockId
+                 => ErrorHandling (VolatileDBError blockId) m
+                 -> VolatileDBEnv m blockId
+                 -> m (InternalState m blockId)
+getInternalState err VolatileDBEnv{..} = do
+    mSt <- atomically (readTMVar _dbInternalState)
+    case mSt of
+        Nothing -> EH.throwError err ClosedDBError
+        Just st -> return st
+
+{------------------------------------------------------------------------------
+  Internal functions
+------------------------------------------------------------------------------}
+
+nextFile :: forall m. (MonadMask m, MonadSTM m)
+         => forall blockId. Ord blockId
+         => HasFS m
+         -> ErrorHandling (VolatileDBError blockId) m
+         -> VolatileDBEnv m blockId
+         -> InternalState m blockId
+         -> m (InternalState m blockId)
+nextFile HasFS{..} _err VolatileDBEnv{..} st@InternalState{..} = do
+    let path = filePath _currentNextId
+    hClose _currentWriteHandle
+    -- TODO(kde) check if file exists already. Issue #292
+    hndl <- hOpen (_dbFolder ++ [path]) IO.AppendMode
+    return $ st {
+          _currentWriteHandle = hndl
+        , _currentWritePath = path
+        , _currentWriteOffset = 0
+        , _currentNextId = _currentNextId + 1
+        , _currentMap = Map.insert path (Nothing, 0, Map.empty) _currentMap
+    }
+
+reOpenFile :: forall m. (MonadMask m, MonadSTM m)
+           => forall blockId. Ord blockId
+           => HasFS m
+           -> ErrorHandling (VolatileDBError blockId) m
+           -> VolatileDBEnv m blockId
+           -> InternalState m blockId
+           -> m (InternalState m blockId)
+reOpenFile HasFS{..} _err VolatileDBEnv{..} st@InternalState{..} = do
+    -- The manual for truncate states that it does not affect offset.
+    -- However the file is open on Append Only, so it should automatically go to the end
+    -- before each write.
+   hTruncate _currentWriteHandle 0
+   return $ st {_currentMap = Map.insert _currentWritePath (Nothing, 0, Map.empty) _currentMap, _currentWriteOffset = 0}
+
+mkInternalStateDB :: (HasCallStack, MonadMask m, MonadSTM m, Show blockId, Ord blockId)
+                  => HasFS m
+                  -> ErrorHandling (VolatileDBError blockId) m
+                  -> FsPath
+                  -> Parser m blockId
+                  -> Int
+                  -> (blockId -> Slot)
+                  -> m (InternalState m blockId)
+mkInternalStateDB hasFS@HasFS{..} err path parser maxBlocksPerFile toSlot = do
+    allFiles <- do
+        createDirectoryIfMissing True path
+        listDirectory path
+    mkInternalState hasFS err path parser maxBlocksPerFile allFiles toSlot
+
+mkInternalState :: forall blockId m. (MonadMask m, HasCallStack, Ord blockId)
+                => HasFS m
+                -> ErrorHandling (VolatileDBError blockId) m
+                -> FsPath
+                -> Parser m blockId
+                -> Int
+                -> Set String
+                -> (blockId -> Slot)
+                -> m (InternalState m blockId)
+mkInternalState hasFS@HasFS{..} err basePath parser n files toSlot = do
+    lastFd <- findNextFd err files
+    let
+        go :: Index blockId
+           -> ReverseIndex blockId
+           -> Maybe blockId
+           -> Maybe (String, Int64) -- The relative path and size of the file with less than n blocks, if any found already.
+           -> [String]
+           -> m (InternalState m blockId)
+        go mp revMp mBlockId hasLessThanN leftFiles = case leftFiles of
+            [] -> do
+                let (fileToWrite, nextFd, mp', offset') = case (hasLessThanN, lastFd) of
+                        (Nothing, Nothing) -> (filePath 0, 1, Map.insert (filePath 0) (Nothing, 0, Map.empty) mp, 0)
+                        (Just _, Nothing) ->
+                            error $ "A file was found with less than " <> show n <> " blocks, but there are no files parsed.\
+                                   \ This is a strong indication that some other process modified internal files of the db"
+                        (Nothing, Just lst) -> let fd' = lst + 1 in
+                            -- If all files are full, we just open a new file.
+                            (filePath fd', lst + 2, Map.insert (filePath fd') (Nothing, 0, Map.empty) mp, 0)
+                        (Just (wrfile, size), Just lst) -> (wrfile, lst + 1, mp, size)
+                hndl <- hOpen (basePath ++ [fileToWrite]) IO.AppendMode
+                return $ InternalState {
+                      _currentWriteHandle = hndl
+                    , _currentWritePath = fileToWrite
+                    , _currentWriteOffset = offset'
+                    , _currentNextId = nextFd
+                    , _currentBlockId = mBlockId
+                    , _currentMap = mp'
+                    , _currentRevMap = revMp
+                }
+            file : restFiles -> do
+                let path = basePath ++ [file]
+                (offset, fileMp) <- parse parser hasFS err path
+                let mMaxBlockId = fst <$> maxSlotMap fileMp toSlot
+                let nBlocks = Map.size fileMp
+                newRevMp <- fromEither err $ reverseMap file revMp fileMp
+                let newMp = Map.insert file (toSlot <$> mMaxBlockId, nBlocks, fileMp) mp
+                let newSlot = updateSlot toSlot mBlockId (snd <$> (concatMap Map.elems $ (\(_, _, x) -> x) <$> Map.elems newMp))
+                newHasLessThanN <-
+                    -- TODO(kde) should we be more lenient here?
+                    -- could assume some order of files.
+                    if nBlocks >= n then return hasLessThanN
+                    else if nBlocks < n && (isJust hasLessThanN)
+                        then EH.throwError err $ VParserError $ SlotsPerFileError n file (fst $ fromJust hasLessThanN)
+                    else return $ Just (file, offset)
+                go newMp newRevMp (fst <$> newSlot) newHasLessThanN restFiles
+    go Map.empty Map.empty Nothing Nothing (Set.toList files)
+
+
+modifyState :: forall blockId m r. (HasCallStack, MonadSTM m, MonadMask m)
+            => HasFS m
+            -> ErrorHandling (VolatileDBError blockId) m
+            -> VolatileDBEnv m blockId
+            -> ((InternalState m blockId) -> m (InternalState m blockId, r))
+            -> m r
+modifyState HasFS{..} err@ErrorHandling{..} VolatileDBEnv{..} action = do
+    (mr, ()) <- generalBracket open close (EH.try err . mutation)
+    case mr of
+      Left  e      -> throwError e
+      Right (_, r) -> return r
+  where
+    open :: m (Maybe (InternalState m blockId))
+    open = atomically $ takeTMVar _dbInternalState
+
+    close :: Maybe (InternalState m blockId)
+          -> ExitCase (Either (VolatileDBError blockId) (InternalState m blockId, r))
+          -> m ()
+    close mst ec = case ec of
+      -- Restore the original state in case of an abort
+      ExitCaseAbort         -> atomically $ putTMVar _dbInternalState mst
+      -- In case of an exception, close the DB for safety.
+      ExitCaseException _ex -> do
+        atomically $ putTMVar _dbInternalState Nothing
+        closeOpenHandle mst
+      -- In case of success, update to the newest state
+      ExitCaseSuccess (Right (newState, _)) ->
+        atomically $ putTMVar _dbInternalState (Just newState)
+      -- In case of an error (not an exception), close the DB for safety
+      ExitCaseSuccess (Left _) -> do
+        atomically $ putTMVar _dbInternalState Nothing
+        closeOpenHandle mst
+
+    mutation :: HasCallStack
+             => Maybe (InternalState m blockId)
+             -> m (InternalState m blockId, r)
+    mutation Nothing         = throwError ClosedDBError
+    mutation (Just oldState) = action oldState
+
+    -- TODO what if this fails?
+    closeOpenHandle :: Maybe (InternalState m blockId) -> m ()
+    closeOpenHandle Nothing                   = return ()
+    closeOpenHandle (Just InternalState {..}) = hClose _currentWriteHandle
+
+
+reverseMap :: forall blockId. Ord blockId
+           => String
+           -> ReverseIndex blockId
+           -> Map Int64 (Int, blockId)
+           -> Either (VolatileDBError blockId) (ReverseIndex blockId)
+reverseMap file revMp mp = foldM f revMp (Map.toList mp)
+    where
+        f :: ReverseIndex blockId
+          -> (Int64, (Int, blockId))
+          -> Either (VolatileDBError blockId) (Map blockId (String, Int64, Int))
+        f rv (w, (n, slot)) = case Map.lookup slot revMp of
+            Nothing -> Right $ Map.insert slot (file, w, n) rv
+            Just (file', _w', _n') -> Left $ VParserError
+                $ DuplicatedSlot $ Map.fromList [(slot, ([file], [file']))]
+
+filePath :: Fd -> String
+filePath fd = "blocks-" ++ show fd ++ ".dat"
+
+-- Throws an error if one of the given file names does not parse.
+findNextFd :: forall m blockId. Monad m
+           => ErrorHandling (VolatileDBError blockId) m
+           -> Set String
+           -> m (Maybe Fd)
+findNextFd err files = foldM go Nothing files
+    where
+        maxMaybe :: Ord a => Maybe a -> a -> a
+        maxMaybe ma a = case ma of
+            Nothing -> a
+            Just a' -> max a' a
+        go :: Maybe Fd -> String -> m (Maybe Fd)
+        go fd file = case parseFd file of
+            Nothing -> EH.throwError err $ VParserError $ InvalidFilename file
+            Just fd' -> return $ Just $ maxMaybe fd fd'
+
+{------------------------------------------------------------------------------
+  Comparing utilities
+------------------------------------------------------------------------------}
+
+maxSlotMap :: Map Int64 (Int, blockId) -> (blockId -> Slot) -> Maybe (blockId, Slot)
+maxSlotMap mp toSlot = maxSlotList toSlot $ snd <$> Map.elems mp
+
+maxSlotList :: (blockId -> Slot) -> [blockId] -> Maybe (blockId, Slot)
+maxSlotList toSlot = updateSlot toSlot Nothing
+
+cmpMaybe :: Ord a => Maybe a -> a -> Bool
+cmpMaybe Nothing _ = False
+cmpMaybe (Just a) a' = a >= a'
+
+updateSlot :: forall blockId. (blockId -> Slot) -> Maybe blockId -> [blockId] -> Maybe (blockId, Slot)
+updateSlot toSlot mbid = foldl cmpr ((\b -> (b, toSlot b)) <$> mbid)
+    where
+        cmpr :: Maybe (blockId, Slot) -> blockId -> Maybe (blockId, Slot)
+        cmpr Nothing bid = Just (bid, toSlot bid)
+        cmpr (Just (bid, sl)) bid' =
+            let sl' = toSlot bid'
+            in Just $ if sl > sl' then (bid, sl) else (bid', sl')
+
+updateSlotNoBlockId :: Maybe Slot -> [Slot] -> Maybe Slot
+updateSlotNoBlockId = foldl cmpr
+    where
+        cmpr :: Maybe Slot -> Slot -> Maybe Slot
+        cmpr Nothing sl' = Just sl'
+        cmpr (Just sl) sl' = Just $ max sl sl'

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+module Ouroboros.Storage.VolatileDB.Types
+    (
+      module Ouroboros.Storage.VolatileDB.Types
+    , module Ouroboros.Network.Block
+    ) where
+
+import           Control.Exception (Exception (..))
+import           Data.Int (Int64)
+import           Data.Map (Map)
+import           Data.Typeable
+
+import           Ouroboros.Network.Block
+import           Ouroboros.Storage.FS.API
+import           Ouroboros.Storage.FS.API.Types
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
+
+type Fd = Int
+
+-- For each file, we store the latest blockId, the number of blocks
+-- and a Map for its contents.
+type Index blockId = Map String (Maybe Slot, Int, Map Int64 (Int, blockId))
+
+-- For each blockId, we store the file we can find the block, the offset and its size
+-- in bytes.
+type ReverseIndex blockId = Map blockId (String, Int64, Int)
+
+-- | Errors which might arise when working with this database.
+data VolatileDBError blockId =
+      FileSystemError FsError
+    | VParserError (ParserError blockId)
+    | UndisputableLookupError String (Index blockId)
+    | InvalidArgumentsError String
+    | ClosedDBError
+    deriving (Show)
+
+instance Eq blockId => Eq (VolatileDBError blockId) where
+    (==) = sameVolatileDBError
+
+instance (Show blockId, Typeable blockId) => Exception (VolatileDBError blockId) where
+    displayException = show
+
+data ParserError blockId =
+      DuplicatedSlot (Map blockId ([String], [String]))
+    | SlotsPerFileError Int String String
+    | InvalidFilename String
+    | DecodeFailed String Int
+    deriving (Show)
+
+instance Eq blockId => Eq (ParserError blockId) where
+    (==) = sameParseError
+
+sameVolatileDBError :: Eq blockId => VolatileDBError blockId -> VolatileDBError blockId -> Bool
+sameVolatileDBError e1 e2 = case (e1, e2) of
+    (FileSystemError fs1, FileSystemError fs2) -> sameFsError fs1 fs2
+    (VParserError p1, VParserError p2) -> p1 == p2
+    (UndisputableLookupError file1 mp1, UndisputableLookupError file2 mp2) ->
+        (file1,mp1) == (file2, mp2)
+    (ClosedDBError, ClosedDBError) -> True
+    (InvalidArgumentsError _, InvalidArgumentsError _) -> True
+    _ -> False
+
+sameParseError :: Eq blockId => ParserError blockId -> ParserError blockId -> Bool
+sameParseError e1 e2 = case (e1, e2) of
+    (DuplicatedSlot _, DuplicatedSlot _) -> True
+    (SlotsPerFileError _ _ _, SlotsPerFileError _ _ _) -> True
+    (InvalidFilename str1, InvalidFilename str2) -> str1 == str2
+    (DecodeFailed _ _, DecodeFailed _ _) -> True
+    _ -> False
+
+-- TODO(kde) unify/move/replace
+newtype Parser m blockId = Parser {
+    parse       :: HasFS m
+                -> ErrorHandling (VolatileDBError blockId) m
+                -> [String]
+                -> m (Int64, Map Int64 (Int, blockId))
+    }

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Ouroboros.Storage.VolatileDB.Util where
+
+import           Control.Monad.Catch (ExitCase (..), MonadMask, generalBracket)
+import           Control.Monad.Class.MonadSTM
+import qualified Data.Text as T
+import           Text.Read (readMaybe)
+
+import           Ouroboros.Storage.VolatileDB.Types
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+{------------------------------------------------------------------------------
+  Utilities
+------------------------------------------------------------------------------}
+
+
+parseFd :: String -> Maybe Fd
+parseFd = readMaybe
+            . T.unpack
+            . snd
+            . T.breakOnEnd "-"
+            . fst
+            . T.breakOn "."
+            . T.pack
+
+fromEither :: Monad m
+           => ErrorHandling e m
+           -> Either e a
+           -> m a
+fromEither err = \case
+    Left e -> EH.throwError err e
+    Right a -> return a
+
+modifyTMVar :: (MonadSTM m, MonadMask m)
+            => TMVar m a
+            -> (a -> m (a,b))
+            -> m b
+modifyTMVar m action =
+    snd . fst <$> generalBracket (atomically $ takeTMVar m)
+       (\oldState ec -> atomically $ case ec of
+            ExitCaseSuccess (newState,_) -> putTMVar m newState
+            ExitCaseException _ex        -> putTMVar m oldState
+            ExitCaseAbort                -> putTMVar m oldState
+       ) action

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage.hs
@@ -6,6 +6,7 @@ import GHC.Stack (HasCallStack)
 
 import qualified Test.Ouroboros.Storage.FS as FS
 import qualified Test.Ouroboros.Storage.ImmutableDB as ImmutableDB
+import qualified Test.Ouroboros.Storage.VolatileDB as VolatileDB
 import           Test.Tasty (TestTree, testGroup)
 
 
@@ -17,6 +18,5 @@ tests :: HasCallStack => FilePath -> TestTree
 tests tmpDir = testGroup "Storage"
     [ FS.tests tmpDir
     , ImmutableDB.tests
-    , testGroup "Volatile Storage"
-      [ ]
+    , VolatileDB.tests
     ]

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB.hs
@@ -1,0 +1,371 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Test.Ouroboros.Storage.VolatileDB (tests) where
+
+import           Control.Monad.Catch (MonadMask)
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad
+import qualified Data.Binary as Binary
+import qualified Data.ByteString.Builder as BL
+import qualified Data.ByteString.Lazy.Char8 as C8
+import           Data.List (nub)
+import qualified Data.Map.Strict as M
+import           Data.Maybe
+import           Data.Serialize
+import qualified Data.Set as Set
+import qualified System.IO as IO
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Ouroboros.Storage.FS.API
+import           Ouroboros.Storage.FS.API.Types
+import           Ouroboros.Storage.VolatileDB.API
+import           Ouroboros.Storage.VolatileDB.Impl (openDB)
+import qualified Ouroboros.Storage.VolatileDB.Impl as Internal hiding (openDB)
+import           Ouroboros.Storage.VolatileDB.Util (modifyTMVar)
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+import           Test.Ouroboros.Storage.Util
+import qualified Test.Ouroboros.Storage.VolatileDB.StateMachine as StateMachine
+
+tests :: HasCallStack => TestTree
+tests = testGroup "VolatileDB"
+  [
+    testProperty "list parsing round trips" prop_roundTrips
+  , testProperty "put/get rounftrips" prop_VolatileRoundTrips
+  , testProperty "reOpen" prop_VolatileReOpenState
+  , testProperty "reOpen and Write" prop_VolatileReOpenWrite
+  , testProperty "garbage collect" prop_VolatileGarbageCollect
+  , testProperty "garbage collect state" prop_VolatileGarbageState
+  , testProperty "remove empty file to Write" prop_VolatileReopenRemoveEmptyFile
+  , testProperty "no slot returns Nothing" prop_VolatileNoSlot
+  , testProperty "duplicated slot" prop_VolatileDuplicatedSlot
+  , testProperty "duplicated slot" prop_VolatileDecodeFail
+  , testProperty "undisputable lookup" prop_VolatileUndisputableLookup
+  , testProperty "undisputable lookup with closed handle" prop_VolatileUndisputableLookupClose
+  , testProperty "Invalid argument" prop_VolatileInvalidArg
+  , testProperty "Invalid filename" prop_VolatileParseFileNameError
+  , testProperty "Invalid number of blocks" prop_VolatileSlotsPerFileError
+  , StateMachine.tests
+  ]
+
+withTestDB :: (HasCallStack, MonadSTM m, MonadMask m)
+           => HasFS m
+           -> ErrorHandling (VolatileDBError MyBlockId) m
+           -> FsPath
+           -> Parser m MyBlockId
+           -> Int
+           -> (VolatileDB MyBlockId m -> m a)
+           -> m a
+withTestDB hasFS err path parser n = withDB (openDB hasFS err path parser n toSlot)
+
+prop_roundTrips :: HasCallStack => [MyBlockId] -> Property
+prop_roundTrips ls = property $ (binarySize * (length ls), ls) === (fromIntegral $ C8.length bs, ls')
+    where
+        bs = C8.concat $ Binary.encode . toBlock <$> ls
+        ls' = go bs
+        go bs' =
+            if C8.length bs' == 0 then []
+            else
+                let (bs1, bsRest) = C8.splitAt (fromIntegral binarySize) bs'
+                    sl = fromBlock $ Binary.decode bs1
+                in sl : go bsRest
+
+-- Write some blocks and then try to get them back.
+prop_VolatileRoundTrips :: HasCallStack => [MyBlockId] -> Property
+prop_VolatileRoundTrips ls = monadicIO $ do
+    let ls' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> ls
+    let expected :: [Either String MyBlockId] = (Right <$> ls)
+    run $ apiEquivalenceVolDB (expectVolDBResult (@?= expected)) (\hasFS err ->
+        withTestDB hasFS err ["demo"] myParser 5 $ \db -> do
+            forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+            bss <- forM ls $ \slot -> getBlock db slot
+            return $ (fmap fromBlock) <$> decode <$> catMaybes bss
+        )
+
+-- Check if the db works normaly after reopening.
+prop_VolatileReOpenWrite :: HasCallStack => [MyBlockId] -> [MyBlockId] -> Property
+prop_VolatileReOpenWrite ls1 ls2 = monadicIO $ do
+    let ls1' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> ls1
+    let ls2' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> ls2
+    let expected :: [Either String MyBlockId] = Right <$> (ls1 <> ls2)
+    run $ apiEquivalenceVolDB (expectVolDBResult (@?= expected)) (\hasFS err -> do
+                db <- openDB hasFS err ["reopen"] myParser 5 toSlot
+                forM_ ls1' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+                closeDB db
+                reOpenDB db
+                forM_ ls2' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+                ret <- forM (ls1 <> ls2) $ \slot -> getBlock db slot
+                closeDB db
+                return $ (fmap fromBlock) <$> decode <$> catMaybes ret
+        )
+
+-- Check state equality after reopening.
+prop_VolatileReOpenState :: HasCallStack => [MyBlockId] -> Property
+prop_VolatileReOpenState ls = monadicIO $ do
+        let ls' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> ls
+        run $ apiEquivalenceVolDB (expectVolDBResult (@?= True)) (\hasFS err -> do
+            (db, env) <- Internal.openDBFull hasFS err ["reopen2"] myParser 5 toSlot
+            forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+            st1 <- Internal.getInternalState err env
+            let mp1 :: (Index MyBlockId) = Internal._currentMap st1
+            closeDB db
+            reOpenDB db
+            st2 <- Internal.getInternalState err env
+            let mp2 = Internal._currentMap st2
+            closeDB db
+            return $ mp1 == mp2
+            )
+
+-- Check if db succesfully garbage-collects.
+prop_VolatileGarbageCollect :: HasCallStack => MyBlockId -> [MyBlockId] -> [MyBlockId] -> Property
+prop_VolatileGarbageCollect special ls1 ls2 = monadicIO $ do
+    let blocksPerFile = 5
+    let specialEnc = Binary.encode $ toBlock special
+    let st1 = Set.filter (/= special) $ Set.fromList ls1
+    let ls1' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> Set.toList st1
+    let st2 = Set.filter (\sl -> sl /= special && not (sl `Set.member` st1)) $ Set.fromList ls2
+    let ls2' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> Set.toList st2
+    let ls' = ls1' <> [(special, specialEnc)] <> ls2'
+    let lss = chunk blocksPerFile ls'
+    let maximumM :: [(MyBlockId, C8.ByteString)] -> Bool
+        maximumM [] = False
+        maximumM ls = fst (maximum ls) >= special
+    let lss' = filter maximumM lss
+    let ls'' = concat lss'
+    let expected :: [Either String MyBlockId] = Right . fst <$> ls''
+    run $ apiEquivalenceVolDB (expectVolDBResult (@?= expected)) (\hasFS err ->
+            withTestDB hasFS err ["garbage-collect"] myParser blocksPerFile $ \db -> do
+                forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+                garbageCollect db (toSlot special)
+                mBss <- sequence <$> (forM ls' $ \(slot, _) -> EH.try err $ getBlock db slot)
+                case mBss of
+                    Left e -> throwError err e
+                    Right bss -> return $ (fmap fromBlock) <$> decode <$> catMaybes bss
+        )
+
+-- split at regular intervals
+chunk :: Int -> [a] -> [[a]]
+chunk _ [] = []
+chunk n xs = y1 : chunk n y2
+    where
+        (y1, y2) = splitAt n xs
+
+-- Check if the db can close and reopen after garbage collection.
+prop_VolatileGarbageState :: HasCallStack => MyBlockId -> [MyBlockId] -> [MyBlockId] -> Property
+prop_VolatileGarbageState special ls1 ls2 = withMaxSuccess 20 $ monadicIO $ do
+        let blocksPerFile = 5
+        let specialEnc = Binary.encode $ toBlock special
+        let set1 = Set.filter (/= special) $ Set.fromList ls1
+        let ls1' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> Set.toList set1
+        let set2 = Set.filter (\sl -> sl /= special && not (sl `Set.member` set1)) $ Set.fromList ls2
+        let ls2' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> Set.toList set2
+        let ls' = ls1' <> [(special, specialEnc)] <> ls2'
+        run $ apiEquivalenceVolDB  (expectVolDBResult (@?= True)) (\hasFS err -> do
+            (db, env) <- Internal.openDBFull hasFS err ["garbage-state"] myParser blocksPerFile toSlot
+            forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+            garbageCollect db (toSlot special)
+            st1 <- Internal.getInternalState err env
+            closeDB db
+            reOpenDB db
+            st2 <- Internal.getInternalState err env
+            closeDB db
+            return $ st1 == st2
+            )
+
+-- Try to reopen the db after deleting an empty write file.
+prop_VolatileReopenRemoveEmptyFile :: HasCallStack => [MyBlockId] -> Property
+prop_VolatileReopenRemoveEmptyFile ls = monadicIO $ do
+    let blocksPerFile = 5
+    let nubLs = nub ls
+    let len = length nubLs
+    let lsRemaining = take (len - mod len blocksPerFile) nubLs
+    let ls' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> lsRemaining
+    run $ apiEquivalenceVolDB (expectVolDBResult (@?= (Just(Nothing, 0, M.empty), True))) (\hasFS err -> do
+            (db, env) <- Internal.openDBFull hasFS err ["no-file"] myParser 5 toSlot
+            forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+            st1 <- Internal.getInternalState err env
+            closeDB db
+            let path = Internal._currentWritePath st1
+            let fileStats = M.lookup path (Internal._currentMap st1)
+            removeFile hasFS ["no-file", path]
+            reOpenDB db
+            st2 <- Internal.getInternalState err env
+            return (fileStats, st1 == st2)
+        )
+
+-- Trying to get a block that does not exist should return Nothing
+prop_VolatileNoSlot :: HasCallStack => [MyBlockId] -> MyBlockId -> Property
+prop_VolatileNoSlot ls special = monadicIO $ do
+        let ls' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> (filter (/= special) ls)
+        run $ apiEquivalenceVolDB (expectVolDBResult (@?= Nothing)) (\hasFS err ->
+            withTestDB hasFS err ["no-slot"] myParser 5 $ \db -> do
+                forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+                getBlock db special
+            )
+
+-- Intentionally corrupt a file of the db, to check if we get DuplicatedSlot.
+-- Trying to parse a file with duplicated blockId, should throw an error.
+prop_VolatileDuplicatedSlot :: HasCallStack => [MyBlockId] -> MyBlockId -> Property
+prop_VolatileDuplicatedSlot ls special = mod (1 + length (nub ls)) 5 /= 0 ==> monadicIO $ do
+    let specialEnc = Binary.encode $ toBlock special
+    let ls' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> ls
+    let fExpected = \case
+            Right (False, Left (VParserError (DuplicatedSlot _))) -> return ()
+            somethingElse -> fail $ "IO failed with " <> show somethingElse <> " instead of DuplicatedSlot"
+    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
+            (db, env) <- Internal.openDBFull hasFS err ["double-slot"] myParser 5 toSlot
+            putBlock db special (BL.lazyByteString specialEnc)
+            forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+            -- here we intentionally corrupt the fs, so that we can get the wanted error.
+            st <- Internal.getInternalState err env
+            let hndl = Internal._currentWriteHandle st
+            _ <- hPut hasFS hndl (BL.lazyByteString specialEnc)
+            closeDB db
+            expectedErr <- EH.try err $ reOpenDB db
+            -- we also check if db closes in case of errors.
+            isOpen <- isOpenDB db
+            -- try to close, to make sure we clean-up, even if tests fail.
+            -- trying to close a closed db is a no-op.
+            closeDB db
+            return (isOpen, expectedErr)
+        )
+
+-- Intentionally corrupt a file of the db, to check if we get DecodeFail.
+prop_VolatileDecodeFail :: HasCallStack => [MyBlockId] -> Property
+prop_VolatileDecodeFail ls = monadicIO $ do
+    let ls' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> ls
+    let fExpected = \case
+            Right (False, Left (VParserError (DecodeFailed _str n))) -> n @?= 3
+            somethingElse -> fail $ "IO failed with " <> show somethingElse <> " instead of DecodeFailed"
+    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
+            (db, env) <- Internal.openDBFull hasFS err ["decode-fail"] myParser 5 toSlot
+            forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+            -- here we intentionally corrupt the fs, so that we can get the wanted error.
+            st <- Internal.getInternalState err env
+            let hndl = Internal._currentWriteHandle st
+            _ <- hPut hasFS hndl (BL.lazyByteString $ C8.pack "123")
+            closeDB db
+            expectedErr <- EH.try err $ reOpenDB db
+            -- we also check if db closes in case of errors.
+            isOpen <- isOpenDB db
+            closeDB db
+            return (isOpen, expectedErr)
+        )
+
+-- Intentially corrupt the Internal State of the db, to check if we get UndisputableLookupError.
+prop_VolatileUndisputableLookup :: HasCallStack => [MyBlockId] -> Property
+prop_VolatileUndisputableLookup ls = mod (length (nub ls)) 5 /= 0 ==> monadicIO $ do
+    let nubLs = nub ls
+    let tl = last nubLs
+    let ls' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> nubLs
+    let fExpected = \case
+            Right (False, Left (UndisputableLookupError _path _mp)) -> return ()
+            somethingElse -> fail $ "IO failed with " <> show somethingElse <> " instead of UndisputableLookupError"
+    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
+            (db, env) <- Internal.openDBFull hasFS err ["undisputable-lookup"] myParser 5 toSlot
+            forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+            -- here we intentionally corrupt the state, so that we can get the wanted error
+            modifyTMVar (Internal._dbInternalState env) $ \mbSt -> case mbSt of
+                Nothing -> throwError err ClosedDBError
+                Just st -> return $ (Just $ st {
+                                  Internal._currentMap = M.delete (Internal._currentWritePath st) (Internal._currentMap st)
+                                , Internal._currentRevMap = M.delete tl (Internal._currentRevMap st)
+                                }, ())
+            expectedErr <- EH.try err $ putBlock db tl (BL.lazyByteString $ Binary.encode $ toBlock tl)
+            isOpen <- isOpenDB db
+            closeDB db
+            return (isOpen, expectedErr)
+        )
+
+-- Like above but we also close the write handle. On exceptions, the cleanup code closes the
+-- write handles, so it is interesting to check what happens if the handle is already closed.
+prop_VolatileUndisputableLookupClose :: HasCallStack => [MyBlockId] -> Property
+prop_VolatileUndisputableLookupClose ls = mod (length (nub ls)) 5 /= 0 ==> monadicIO $ do
+    let nubLs = nub ls
+    let tl = last nubLs
+    let ls' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> nubLs
+    let fExpected = \case
+            Right (False, Left (UndisputableLookupError _path _mp)) -> return ()
+            somethingElse -> fail $ "IO failed with " <> show somethingElse <> " instead of UndisputableLookupError"
+    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
+            (db, env) <- Internal.openDBFull hasFS err ["undisputable-lookup"] myParser 5 toSlot
+            forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+            -- here we intentionally corrupt the state, so that we can get the wanted error
+            modifyTMVar (Internal._dbInternalState env) $ \mbSt -> case mbSt of
+                Nothing -> throwError err ClosedDBError
+                Just st -> do
+                    hClose hasFS (Internal._currentWriteHandle st)
+                    return $ (Just $ st {
+                                  Internal._currentMap = M.delete (Internal._currentWritePath st) (Internal._currentMap st)
+                                , Internal._currentRevMap = M.delete tl (Internal._currentRevMap st)
+                                }, ())
+            expectedErr <- EH.try err $ putBlock db tl (BL.lazyByteString $ Binary.encode $ toBlock tl)
+            isOpen <- isOpenDB db
+            closeDB db
+            return (isOpen, expectedErr)
+        )
+
+prop_VolatileInvalidArg :: HasCallStack => Property
+prop_VolatileInvalidArg = monadicIO $ do
+    let fExpected = \case
+            Left (InvalidArgumentsError _str) -> return ()
+            somethingElse -> fail $ "IO failed with " <> show somethingElse <> " instead of InvalidArgumentsError"
+    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
+            _ <- Internal.openDBFull hasFS err ["invalid-arg"] myParser 0 toSlot
+            return ()
+        )
+
+-- Create a new file in the db folder with invalid name and check if we get
+-- the expected error.
+prop_VolatileParseFileNameError :: HasCallStack => Property
+prop_VolatileParseFileNameError = monadicIO $ do
+    let fExpected = \case
+            Right (False, Left (VParserError (InvalidFilename str))) -> str @?= "invalid-file-name"
+            somethingElse -> fail $ "IO failed with " <> show somethingElse <> " instead of InvalidFilename"
+    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
+            (db, _env) <- Internal.openDBFull hasFS err ["invalid-arg"] myParser 5 toSlot
+            closeDB db
+            withFile hasFS ["invalid-arg", "invalid-file-name"] IO.AppendMode $ \_hndl -> do
+                return ()
+            expectedErr <- EH.try err $ reOpenDB db
+            isOpen <- isOpenDB db
+            closeDB db
+            return (isOpen, expectedErr)
+        )
+
+-- Intentiolly create a file with less blocks than needed and check if we get SlotsPerFileError
+prop_VolatileSlotsPerFileError :: HasCallStack => [MyBlockId] -> Property
+prop_VolatileSlotsPerFileError ls = monadicIO $ do
+    let blocksPerFile = 5
+    let ls' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> nub ls
+    let fExpected = \case
+            Right (False, Left (VParserError (SlotsPerFileError n _file _file'))) -> n @?= (blocksPerFile)
+            somethingElse -> fail $ "IO failed with " <> show somethingElse <> " instead of SlotsPerFileError"
+    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
+            (db, env) <- Internal.openDBFull hasFS err ["number-of-slots"] myParser 5 toSlot
+            forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
+            st <- Internal.getInternalState err env
+            let nextFd = Internal._currentNextId st
+            let path = Internal.filePath nextFd
+            closeDB db
+            withFile hasFS ["number-of-slots", path] IO.AppendMode $ \_hndl -> do
+                return ()
+            expectedErr <- EH.try err $ reOpenDB db
+            isOpen <- isOpenDB db
+            closeDB db
+            return (isOpen, expectedErr)
+        )
+

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE KindSignatures   #-}
+{-# LANGUAGE RankNTypes       #-}
+{-# LANGUAGE RecordWildCards  #-}
+-- | In-memory Model implementation of 'VolatileDB' for testing
+module Test.Ouroboros.Storage.VolatileDB.Model
+    (
+      DBModel (..)
+    , initDBModel
+    , openDBModel
+    ) where
+
+import           Control.Monad.State (MonadState, get, put)
+import           Data.ByteString (ByteString)
+import           Data.ByteString.Builder
+import           Data.ByteString.Lazy (toStrict)
+import           Data.Map (Map)
+import qualified Data.Map as Map
+
+import           Ouroboros.Storage.VolatileDB.API
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+data DBModel blockId = DBModel {
+      open           :: Bool
+    , mp             :: Map blockId ByteString
+    , latestGarbaged :: Maybe Slot
+    } deriving (Show)
+
+initDBModel :: DBModel blockId
+initDBModel = DBModel {
+      open = True
+    , mp = Map.empty
+    , latestGarbaged = Nothing
+}
+
+openDBModel :: MonadState (DBModel blockId) m
+            => (Ord blockId, Show blockId)
+            => ErrorHandling (VolatileDBError blockId) m
+            -> (DBModel blockId, VolatileDB blockId m)
+openDBModel err = (dbModel, db)
+    where
+        dbModel = initDBModel
+        db = VolatileDB {
+              closeDB  = closeDBModel
+            , isOpenDB = isOpenModel
+            , reOpenDB = reOpenModel
+            , getBlock = getBlockModel err
+            , putBlock = putBlockModel err
+            , garbageCollect = garbageCollectModel err
+        }
+
+closeDBModel :: MonadState (DBModel blockId) m => m ()
+closeDBModel = do
+    dbm <- get
+    put $ dbm {open = False}
+
+isOpenModel :: MonadState (DBModel blockId) m => m Bool
+isOpenModel = do
+    DBModel {..} <- get
+    return open
+
+reOpenModel :: MonadState (DBModel blockId) m => m ()
+reOpenModel = do
+    dbm <- get
+    put $ dbm {open = True}
+
+getBlockModel :: forall m blockId. (MonadState (DBModel blockId) m, Ord blockId, Show blockId)
+              => ErrorHandling (VolatileDBError blockId) m
+              -> blockId
+              -> m (Maybe ByteString)
+getBlockModel err sl = do
+    DBModel {..} <- get
+    if not open then EH.throwError err ClosedDBError
+    else return $ Map.lookup sl mp
+
+putBlockModel :: MonadState (DBModel blockId) m
+              => Ord blockId
+              => ErrorHandling (VolatileDBError blockId) m
+              -> blockId
+              -> Builder
+              -> m ()
+putBlockModel err sl bs = do
+    dbm@DBModel {..} <- get
+    if not open then EH.throwError err ClosedDBError
+    else case Map.lookup sl mp of
+        Nothing -> put dbm{mp = Map.insert sl (toStrict $ toLazyByteString bs) mp}
+        Just _bs -> return ()
+
+garbageCollectModel :: MonadState (DBModel blockId) m
+                    => Ord blockId
+                    => ErrorHandling (VolatileDBError blockId) m
+                    -> Slot
+                    -> m ()
+garbageCollectModel err sl = do
+    dbm@DBModel {..} <- get
+    if not open then EH.throwError err ClosedDBError
+    else put dbm {latestGarbaged = Just $ maxMaybe latestGarbaged sl}
+
+maxMaybe :: Ord slot => Maybe slot -> slot -> slot
+maxMaybe Nothing sl = sl
+maxMaybe (Just sl') sl = max sl' sl

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -1,0 +1,274 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DeriveTraversable    #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Ouroboros.Storage.VolatileDB.StateMachine (tests) where
+
+import           Prelude
+
+import           Control.Monad.Except
+import           Control.Monad.State
+import           Data.Bifunctor (first)
+import qualified Data.Binary as Binary
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Builder as BS
+import           Data.Functor.Classes
+import           Data.Kind (Type)
+import           Data.TreeDiff (ToExpr)
+import           Data.TreeDiff.Class
+import           GHC.Stack
+import           GHC.Generics
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic
+import           Test.StateMachine
+import           Test.StateMachine.Types
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
+import           Ouroboros.Storage.FS.Sim.STM
+import           Ouroboros.Storage.VolatileDB.API
+import           Ouroboros.Storage.VolatileDB.Impl (openDB)
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+import           Test.Ouroboros.Storage.Util
+import           Test.Ouroboros.Storage.VolatileDB.Model
+
+newtype At t (r :: Type -> Type) = At t
+  deriving (Generic)
+
+-- | Alias for 'At'
+type (:@) t r = At t r
+
+data Success
+  = Unit ()
+  | Blob (Maybe ByteString)
+  | Bl   Bool
+  deriving (Eq, Show)
+
+newtype Resp = Resp {getResp :: Either (VolatileDBError MyBlockId) Success}
+    deriving (Show, Eq)
+
+data Cmd
+    = IsOpen
+    | Close
+    | ReOpen
+    | GetBlock MyBlockId
+    | PutBlock MyBlockId
+    | GarbageCollect MyBlockId
+    deriving (Show)
+
+deriving instance Generic1          (At Cmd)
+deriving instance Rank2.Foldable    (At Cmd)
+deriving instance Rank2.Functor     (At Cmd)
+deriving instance Rank2.Traversable (At Cmd)
+deriving instance Show1 r => Show   (Cmd :@ r)
+
+deriving instance Generic1        (At Resp)
+deriving instance Rank2.Foldable  (At Resp)
+deriving instance Show1 r => Show (Resp :@ r)
+
+instance Show (Model r) where
+    show = show . toShow
+
+
+deriving instance Show (ModelShow r)
+deriving instance Generic (DBModel MyBlockId)
+deriving instance Generic (ModelShow r)
+deriving instance Generic Slot
+deriving instance ToExpr Slot
+deriving instance ToExpr (DBModel MyBlockId)
+deriving instance ToExpr (ModelShow r)
+
+
+instance ToExpr (Model r) where
+    toExpr = toExpr . toShow
+
+instance CommandNames (At Cmd) where
+    cmdName (At cmd) = case cmd of
+        GetBlock _ -> "GetBlock"
+        PutBlock _ -> "PutBlock"
+        GarbageCollect _ -> "GarbageCollect"
+        IsOpen -> "IsOpen"
+        Close -> "Close"
+        ReOpen -> "ReOpen"
+    cmdNames _ = ["not", "suported", "yet"]
+
+data Model (r :: Type -> Type) = Model
+  { dbModel     :: DBModel MyBlockId
+    -- ^ A model of the database, used as state for the 'HasImmutableDB'
+    -- instance of 'ModelDB'.
+  , mockDB      :: ModelDBPure
+    -- ^ A handle to the mocked database.
+  } deriving (Generic)
+
+data ModelShow (r :: Type -> Type) = Model'
+  { msdbModel        :: DBModel MyBlockId
+  }
+
+toShow :: Model r -> ModelShow r
+toShow (Model dbm _) = Model' dbm
+
+type PureM = ExceptT (VolatileDBError MyBlockId) (State (DBModel MyBlockId))
+type ModelDBPure = VolatileDB MyBlockId PureM
+
+-- | An event records the model before and after a command along with the
+-- command itself, and a mocked version of the response.
+
+data Event r = Event
+  { eventBefore   :: Model  r
+  , eventCmd      :: At Cmd r
+  , eventAfter    :: Model  r
+  , eventMockResp :: Resp
+  } deriving (Show)
+
+lockstep :: forall r. (Show1 r, Eq1 r)
+         => Model   r
+         -> At Cmd  r
+         -> At Resp r
+         -> Event   r
+lockstep model@Model {..} (At cmd) (At _resp) = Event
+    { eventBefore   = model
+    , eventCmd      = At cmd
+    , eventAfter    = model'
+    , eventMockResp = mockResp
+    }
+  where
+    (mockResp, dbModel') = step model (At cmd)
+    model' = model {dbModel = dbModel'}
+
+-- | Key property of the model is that we can go from real to mock responses
+toMock :: Eq1 r => Model r -> At t r -> t
+toMock _ (At t) = t
+
+step :: Eq1 r => Model r -> At Cmd r -> (Resp, DBModel MyBlockId)
+step model@Model{..} cmd = runPure dbModel mockDB (toMock model cmd)
+
+runPure :: DBModel MyBlockId
+        -> ModelDBPure
+        -> Cmd
+        -> (Resp, DBModel MyBlockId)
+runPure dbm mdb cmd =
+    first Resp $ runState (runExceptT $ runDB mdb cmd) dbm
+
+runDB :: (HasCallStack, Monad m)
+      => VolatileDB MyBlockId m
+      -> Cmd
+      -> m Success
+runDB db cmd = case cmd of
+    GetBlock bid -> Blob <$> getBlock db bid
+    PutBlock bid -> Unit <$> putBlock db bid (BS.lazyByteString $ Binary.encode $ toBlock bid)
+    GarbageCollect bid -> Unit <$> garbageCollect db (toSlot bid)
+    IsOpen -> Bl <$> isOpenDB db
+    Close -> Unit <$> closeDB db
+    ReOpen -> Unit <$> reOpenDB db
+
+
+sm :: VolatileDB MyBlockId (SimFS IO) -> DBModel MyBlockId -> ModelDBPure -> StateMachine Model (At Cmd) (SimFS IO) (At Resp)
+sm db dbm vdb = StateMachine {
+        initModel     = initModelImpl dbm vdb
+      , transition    = transitionImpl
+      , precondition  = preconditionImpl
+      , postcondition = postconditionImpl
+      , generator     = generatorImpl
+      , shrinker      = shrinkerImpl
+      , semantics     = semanticsImpl db
+      , mock          = mockImpl
+      , invariant     = Nothing
+      , distribution  = Nothing
+    }
+
+initModelImpl :: DBModel MyBlockId -> ModelDBPure -> Model r
+initModelImpl dbm vdm = Model {
+      dbModel = dbm
+    , mockDB = vdm
+    }
+
+transitionImpl :: (Show1 r, Eq1 r) => Model r -> At Cmd r -> At Resp r -> Model r
+transitionImpl model cmd = eventAfter . lockstep model cmd
+
+preconditionImpl :: Model Symbolic -> At Cmd Symbolic -> Logic
+preconditionImpl m@Model {..} (At cmd) =
+    Not (knownLimitation m (At cmd))
+
+postconditionImpl :: Model Concrete -> At Cmd Concrete -> At Resp Concrete -> Logic
+postconditionImpl model cmd resp =
+    toMock (eventAfter ev) resp .== eventMockResp ev
+  where
+    ev = lockstep model cmd resp
+
+generatorImpl :: Model Symbolic -> Maybe (Gen (At Cmd Symbolic))
+generatorImpl Model {..} = Just $ At <$> do
+    sl <- arbitrary
+    frequency
+        [ (3, return $ GetBlock sl)
+        , (3, return $ PutBlock sl)
+        , (1, return $ GarbageCollect sl)
+        , (1, return $ IsOpen)
+        , (1, return $ Close)
+        , (1, return $ ReOpen)
+        ]
+
+shrinkerImpl :: Model Symbolic -> At Cmd Symbolic -> [At Cmd Symbolic]
+shrinkerImpl _ _ = []
+
+semanticsImpl :: VolatileDB MyBlockId (SimFS IO) -> At Cmd Concrete -> SimFS IO (At Resp Concrete)
+semanticsImpl m (At cmd) = At . Resp <$> tryVolDB (runDB m cmd)
+
+mockImpl :: Model Symbolic -> At Cmd Symbolic -> GenSym (At Resp Symbolic)
+mockImpl model cmd = At <$> return mockResp
+    where
+        (mockResp, _dbModel') = step model cmd
+
+knownLimitation :: Model Symbolic -> Cmd :@ Symbolic -> Logic
+knownLimitation model (At cmd) = case cmd of
+    GetBlock bid -> isLimitation (latestGarbaged $ dbModel model) (toSlot bid)
+    PutBlock bid -> isLimitation (latestGarbaged $ dbModel model) (toSlot bid)
+    GarbageCollect _sl -> Bot
+    IsOpen -> Bot
+    Close -> Bot
+    ReOpen -> Bot
+    where
+        isLimitation :: (Show slot, Ord slot) => Maybe slot -> slot -> Logic
+        isLimitation Nothing _sl = Bot
+        isLimitation (Just slot') slot = slot' .>  slot
+
+mkDBModel :: MonadState (DBModel MyBlockId) m => (DBModel MyBlockId, VolatileDB MyBlockId (ExceptT (VolatileDBError MyBlockId) m))
+mkDBModel = openDBModel EH.exceptT
+
+prop_sequential :: Property
+prop_sequential =
+    forAllCommands smUnused Nothing $ \cmds -> monadic (ioProperty . runSimIO) $ do
+        let hasFS = simHasFS EH.monadCatch
+        db <- run $ openDB hasFS EH.monadCatch ["test-volatile"] myParser 7 toSlot
+        let sm' = sm db dbm vdb
+        (hist, _model, res) <- runCommands sm' cmds
+        prettyCommands sm' hist $
+            checkCommandNames cmds (res === Ok)
+        run $ closeDB db
+        return ()
+    where
+        (dbm, vdb) = mkDBModel
+        smUnused = sm (error "semantics and DB used during command generation") dbm vdb
+
+tests :: TestTree
+tests = testGroup "Volatile" [
+        testProperty "q-s-m" $ prop_sequential
+    ]
+
+-- TODO(kde) unify/move/replace
+runSimIO :: SimFS IO a -> IO a
+runSimIO m = fst <$> runSimFS m Mock.empty


### PR DESCRIPTION
This pr introduces volatile db and adds some tests

The db is a key-value store of binary blocks and is parametric on the key of blocks, named blockId. The only constraints are that one must provide
a function (toSlot :: blockId -> Slot), as well as an Ord instance of blockId.
The database uses in memory indexes, which are created on each reopening. reopening
includes parsing all blocks of the dbFolder, so it can be an expensive operation
if the database gets big. That's why the intention of this db is to be used for only
the tip of the blockchain, when there is still volatility on which blocks are included.
The db is agnostic to the format of the blocks, so a parser must be provided.
In addition to getBlock and putBlock, the db provides also the ability to garbage-collect
old blocks. The actual garbage-collection happens in terms of files and not blocks: a file
is deleted/garbage-collected only if its latest block is old enough. A block is old enough
if its toSlot value is old enough and not based on its Ord instance. This type of garbage
collection makes the deletion of blocks depend on the number of blocks we insert on
each file, as well as the order of insertion, so it's not deterministic on blocks themselves.

related issue: https://github.com/input-output-hk/ouroboros-network/issues/202