### PR TITLE
ChainSync tests

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -54,10 +54,10 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (Chain (..), ChainUpdate (..), Point)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState
-import           Ouroboros.Network.ChainSyncExamples
 import           Ouroboros.Network.Protocol.ChainSync.Client
 import           Ouroboros.Network.Protocol.ChainSync.Server
 import           Ouroboros.Network.Protocol.ChainSync.Type
+import           Ouroboros.Network.Protocol.ChainSync.Examples
 import           Ouroboros.Network.Serialise (Serialise)
 
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -46,6 +46,7 @@ library
                        Ouroboros.Network.Protocol.ChainSync.Direct
                        Ouroboros.Network.Protocol.ChainSync.Server
                        Ouroboros.Network.Protocol.ChainSync.Type
+                       Ouroboros.Network.Protocol.ChainSync.Examples
                        Ouroboros.Network.Protocol.Stream.Type
                        Ouroboros.Network.Protocol.Stream.Client
                        Ouroboros.Network.Protocol.Stream.Server
@@ -59,9 +60,6 @@ library
                        Ouroboros.Network.Protocol.BlockFetch.Client
                        Ouroboros.Network.Protocol.BlockFetch.Server
                        Ouroboros.Network.Protocol.BlockFetch.Direct
-
-                       -- TODO rename.
-                       Ouroboros.Network.ChainSyncExamples
   default-language:    Haskell2010
   other-extensions:    BangPatterns,
                        DataKinds,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -118,6 +118,7 @@ test-suite tests
                        Test.ChainProducerState
                        Test.Ouroboros.Network.Testing.Arbitrary
                        Test.Ouroboros.Network.Testing.Utils
+                       Test.Ouroboros.Network.Protocol.ChainSync
                        Test.Ouroboros.Network.Protocol.Stream
                        Test.Ouroboros.Network.Protocol.ReqResp.Codec.Coherence
                        Test.Ouroboros.Network.Protocol.ReqResp

--- a/ouroboros-network/src/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Node.hs
@@ -42,10 +42,10 @@ import           Ouroboros.Network.Protocol.ChainSync.Codec.Id (codecChainSync)
 import           Ouroboros.Network.Protocol.ChainSync.Client
 import           Ouroboros.Network.Protocol.ChainSync.Server
 import           Ouroboros.Network.Protocol.ChainSync.Type
+import           Ouroboros.Network.Protocol.ChainSync.Examples
 import           Ouroboros.Network.Protocol.Channel.Sim (delayChannel)
 -- FIXME bad module name below. They're examples, sure, but they're also
 -- legit useful.
-import           Ouroboros.Network.ChainSyncExamples
 import           Ouroboros.Network.Testing.ConcreteBlock hiding (fixupBlock)
 import qualified Ouroboros.Network.Testing.ConcreteBlock as Concrete
 

--- a/ouroboros-network/src/Ouroboros/Network/Pipe.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Pipe.hs
@@ -25,11 +25,11 @@ import           System.Process (createPipe)
 import           Ouroboros.Network.Chain (Chain, ChainUpdate, Point)
 import qualified Ouroboros.Network.Chain as Chain
 import qualified Ouroboros.Network.ChainProducerState as CPS
-import           Ouroboros.Network.ChainSyncExamples
 import           Ouroboros.Network.Protocol.ChainSync.Codec.Cbor
 import           Ouroboros.Network.Protocol.ChainSync.Type
 import           Ouroboros.Network.Protocol.ChainSync.Client
 import           Ouroboros.Network.Protocol.ChainSync.Server
+import           Ouroboros.Network.Protocol.ChainSync.Examples
 import           Ouroboros.Network.Serialise
 
 import           Protocol.Channel

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Examples.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Ouroboros.Network.ChainSyncExamples (
+module Ouroboros.Network.Protocol.ChainSync.Examples (
     chainSyncClientExample
   , Client (..)
   , pureClient

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -7,6 +7,7 @@ import qualified Test.ChainFragment (tests)
 import qualified Test.ChainProducerState (tests)
 import qualified Test.Pipe (tests)
 import qualified Test.Ouroboros.Network.Node (tests)
+import qualified Test.Ouroboros.Network.Protocol.ChainSync (tests)
 import qualified Test.Ouroboros.Network.Protocol.BlockFetch (tests)
 import qualified Test.Ouroboros.Network.Protocol.ReqResp (tests)
 import qualified Test.Ouroboros.Network.Protocol.ReqResp.Codec.Coherence (tests)
@@ -23,6 +24,7 @@ tests =
   , Test.ChainProducerState.tests
   , Test.Pipe.tests
   , Test.Ouroboros.Network.Node.tests
+  , Test.Ouroboros.Network.Protocol.ChainSync.tests
   , Test.Ouroboros.Network.Protocol.BlockFetch.tests
   , Test.Ouroboros.Network.Protocol.Stream.tests
   , Test.Ouroboros.Network.Protocol.ReqResp.tests

--- a/ouroboros-network/test/Test/ChainProducerState.hs
+++ b/ouroboros-network/test/Test/ChainProducerState.hs
@@ -2,7 +2,12 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeOperators  #-}
 
-module Test.ChainProducerState (tests) where
+module Test.ChainProducerState
+  ( ChainProducerStateTest (..)
+  , ChainProducerStateForkTest (..)
+  , tests
+  )
+ where
 
 import           Data.List (unfoldr)
 
@@ -165,7 +170,10 @@ prop_switchFork (ChainProducerStateForkTest cps f) =
 --
 
 data ChainProducerStateTest
-    = ChainProducerStateTest (ChainProducerState Block) ReaderId (Point Block)
+    = ChainProducerStateTest
+        (ChainProducerState Block) -- ^ producer state with a single reader
+        ReaderId                   -- ^ reader's id
+        (Point Block)              -- ^ intersection point of the reader
   deriving Show
 
 genReaderState :: Int   -- ^ length of the chain
@@ -202,7 +210,9 @@ instance Arbitrary ChainProducerStateTest where
     return (ChainProducerStateTest (ChainProducerState c rs) rid p)
 
 data ChainProducerStateForkTest
-    = ChainProducerStateForkTest (ChainProducerState Block) (Chain Block)
+    = ChainProducerStateForkTest
+        (ChainProducerState Block) -- ^ chain producer state
+        (Chain Block)              -- ^ fork of the producer's chain
   deriving Show
 
 instance Arbitrary ChainProducerStateForkTest where

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ChainSync.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ChainSync.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Test.Ouroboros.Network.Protocol.ChainSync where
+
+import Control.Monad (unless)
+import Control.Monad.ST.Lazy (runST)
+import Control.Monad.Free (Free)
+import Data.Functor.Identity (Identity (..))
+import Data.ByteString (ByteString)
+import System.Process (createPipe)
+
+import Codec.Serialise.Class (Serialise)
+import Codec.CBOR.Encoding (Encoding)
+
+import Control.Monad.Class.MonadFork
+import Control.Monad.Class.MonadST
+import Control.Monad.Class.MonadSTM
+import Control.Monad.Class.MonadProbe
+
+import Control.Monad.IOSim (SimF)
+
+import Protocol.Core (Those (..), connect)
+import Protocol.Codec
+import Protocol.Channel
+import Protocol.Driver (Result (..), useCodecWithDuplex)
+
+import Ouroboros.Network.Pipe (pipeDuplex)
+import qualified Ouroboros.Network.ChainProducerState as ChainProducerState
+
+import Ouroboros.Network.Protocol.ChainSync.Client
+import Ouroboros.Network.Protocol.ChainSync.Server
+import Ouroboros.Network.Protocol.ChainSync.Direct
+import Ouroboros.Network.Protocol.ChainSync.Codec.Cbor
+import qualified Ouroboros.Network.Protocol.ChainSync.Examples as ChainSyncExamples
+
+import Ouroboros.Network.Testing.ConcreteBlock (Block (..))
+import Test.ChainProducerState (ChainProducerStateForkTest (..))
+import Test.Ouroboros.Network.Testing.Utils (runExperiment, tmvarChannels)
+
+import Test.QuickCheck hiding (Result)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests =
+  testGroup "Ouroboros.Network.Protocol.ChainSyncProtocol"
+  [ -- testProperty "direct" (prop_direct @Int @Int)
+  -- , testProperty "connect" (prop_connect @Int @Int)
+  {--
+    - , testProperty "ReqRespDemoST" (prop_reqRespDemoExperimentST @Int @Int)
+    - , testProperty "ReqRespDemoIO" (prop_reqRespDemoExperimentIO @Int @Int)
+    - , testProperty "ResRespPipe" (prop_reqRespPipeExperiment @Int @Int)
+    --}
+  ]
+
+chainSyncExperiment
+  :: forall m.
+     ( MonadST m
+     , MonadSTM m
+     , MonadProbe m
+     )
+  => ChainProducerStateForkTest
+  -> Probe m Property
+  -> m ()
+chainSyncExperiment (ChainProducerStateForkTest cps fork) probe = do
+  cpsvar <- atomically $ newTVar cps
+  chainvar <- atomically $ newTVar fork
+  let server = ChainSyncExamples.chainSyncServerExample
+        (error "chainSyncServerExample: lazy in the result type")
+        cpsvar
+      client = ChainSyncExamples.chainSyncClientExample chainvar ChainSyncExamples.pureClient
+  _ <- direct server client
+
+  pchain <- ChainProducerState.producerChain <$> atomically (readTVar cpsvar)
+  cchain <- atomically (readTVar chainvar)
+
+  probeOutput probe (pchain === cchain)
+

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ChainSync.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ChainSync.hs
@@ -4,14 +4,12 @@
 {-# LANGUAGE TypeApplications #-}
 module Test.Ouroboros.Network.Protocol.ChainSync where
 
-import Control.Monad (unless)
+import Control.Monad (unless, void)
 import Control.Monad.ST.Lazy (runST)
 import Control.Monad.Free (Free)
-import Data.Functor.Identity (Identity (..))
 import Data.ByteString (ByteString)
 import System.Process (createPipe)
 
-import Codec.Serialise.Class (Serialise)
 import Codec.CBOR.Encoding (Encoding)
 
 import Control.Monad.Class.MonadFork
@@ -21,11 +19,13 @@ import Control.Monad.Class.MonadProbe
 
 import Control.Monad.IOSim (SimF)
 
-import Protocol.Core (Those (..), connect)
+import Protocol.Core (connect)
 import Protocol.Codec
 import Protocol.Channel
-import Protocol.Driver (Result (..), useCodecWithDuplex)
+import Protocol.Driver (useCodecWithDuplex)
 
+import           Ouroboros.Network.Chain (Point)
+import qualified Ouroboros.Network.Chain as Chain
 import Ouroboros.Network.Pipe (pipeDuplex)
 import qualified Ouroboros.Network.ChainProducerState as ChainProducerState
 
@@ -44,37 +44,145 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
-tests =
-  testGroup "Ouroboros.Network.Protocol.ChainSyncProtocol"
-  [ -- testProperty "direct" (prop_direct @Int @Int)
-  -- , testProperty "connect" (prop_connect @Int @Int)
-  {--
-    - , testProperty "ReqRespDemoST" (prop_reqRespDemoExperimentST @Int @Int)
-    - , testProperty "ReqRespDemoIO" (prop_reqRespDemoExperimentIO @Int @Int)
-    - , testProperty "ResRespPipe" (prop_reqRespPipeExperiment @Int @Int)
-    --}
+tests = testGroup "Ouroboros.Network.Protocol.ChainSyncProtocol"
+  [ testProperty "direct ST" propChainSyncDirectST
+  , testProperty "direct IO" propChainSyncDirectIO
+  , testProperty "connect ST" propChainSyncConnectST
+  , testProperty "connect IO" propChainSyncConnectIO
+  , testProperty "demo ST" propChainSyncDemoST
+  , testProperty "demo IO" propChainSyncDemoIO
+  , testProperty "pipe demo" propChainSyncPipe
   ]
 
-chainSyncExperiment
+-- | Testing @'Client'@ which stops at a given point.
+--
+testClient
+  :: MonadSTM m
+  => TVar m Bool
+  -> Point Block
+  -> ChainSyncExamples.Client Block m ()
+testClient doneVar tip =
+  ChainSyncExamples.Client { 
+      ChainSyncExamples.rollbackward = \point _ ->
+        if point == tip
+          then do
+            atomically $ writeTVar doneVar True
+            return $ Left ()
+          else return $ Right (testClient doneVar tip),
+      ChainSyncExamples.rollforward = \block ->
+        if Chain.blockPoint block == tip
+          then do
+            atomically $ writeTVar doneVar True
+            return $ Left ()
+          else return $ Right (testClient doneVar tip),
+      ChainSyncExamples.points = \_ -> return (testClient doneVar tip)
+    }
+
+-- | An experiment in which the client has a fork of the server chain.  The
+-- experiment finishes successfully if the client receives the server's chain.
+--
+chainSyncForkExperiment
   :: forall m.
      ( MonadST m
      , MonadSTM m
      , MonadProbe m
      )
-  => ChainProducerStateForkTest
+  => (forall a b. ChainSyncServer Block (Point Block) m a
+      -> ChainSyncClient Block (Point Block) m b
+      -> m ())
+  -> ChainProducerStateForkTest
   -> Probe m Property
   -> m ()
-chainSyncExperiment (ChainProducerStateForkTest cps fork) probe = do
-  cpsvar <- atomically $ newTVar cps
-  chainvar <- atomically $ newTVar fork
+chainSyncForkExperiment run (ChainProducerStateForkTest cps chain) probe = do
+  let pchain = ChainProducerState.producerChain cps
+  cpsVar   <- atomically $ newTVar cps
+  chainVar <- atomically $ newTVar chain
+  doneVar  <- atomically $ newTVar False
   let server = ChainSyncExamples.chainSyncServerExample
         (error "chainSyncServerExample: lazy in the result type")
-        cpsvar
-      client = ChainSyncExamples.chainSyncClientExample chainvar ChainSyncExamples.pureClient
-  _ <- direct server client
+        cpsVar
+      client = ChainSyncExamples.chainSyncClientExample chainVar (testClient doneVar (Chain.headPoint pchain))
+  _ <- run server client
 
-  pchain <- ChainProducerState.producerChain <$> atomically (readTVar cpsvar)
-  cchain <- atomically (readTVar chainvar)
-
+  cchain <- atomically $ readTVar chainVar
   probeOutput probe (pchain === cchain)
 
+propChainSyncDirectST :: ChainProducerStateForkTest -> Property
+propChainSyncDirectST cps = runST $ runExperiment $ chainSyncForkExperiment ((fmap . fmap) void direct) cps
+
+propChainSyncDirectIO :: ChainProducerStateForkTest -> Property
+propChainSyncDirectIO cps = ioProperty $ runExperiment $ chainSyncForkExperiment ((fmap . fmap) void direct) cps
+
+propChainSyncConnectST :: ChainProducerStateForkTest -> Property
+propChainSyncConnectST cps = runST $ runExperiment $ chainSyncForkExperiment
+  (\ser cli ->
+      void $ connect (chainSyncServerPeer ser) (chainSyncClientPeer cli)
+  ) cps 
+
+propChainSyncConnectIO :: ChainProducerStateForkTest -> Property
+propChainSyncConnectIO cps = ioProperty $ runExperiment $ chainSyncForkExperiment
+  (\ser cli ->
+      void $  connect (chainSyncServerPeer ser) (chainSyncClientPeer cli)
+  ) cps 
+
+chainSyncDemo
+  :: forall m.
+     ( MonadST m
+     , MonadSTM m
+     , MonadProbe m
+     )
+  => Duplex m m Encoding ByteString
+  -> Duplex m m Encoding ByteString
+  -> ChainProducerStateForkTest
+  -> Probe m Property
+  -> m ()
+chainSyncDemo clientChan serverChan (ChainProducerStateForkTest cps chain) probe = withLiftST @m $ \liftST -> do
+  let pchain = ChainProducerState.producerChain cps
+  cpsVar   <- atomically $ newTVar cps
+  chainVar <- atomically $ newTVar chain
+  doneVar  <- atomically $ newTVar False
+
+  let server = ChainSyncExamples.chainSyncServerExample
+        (error "chainSyncServerExample: lazy in the result type")
+        cpsVar
+
+      client = ChainSyncExamples.chainSyncClientExample chainVar (testClient doneVar (Chain.headPoint pchain))
+
+      codec = hoistCodec liftST codecChainSync
+
+  fork (void $ useCodecWithDuplex serverChan codec (chainSyncServerPeer server))
+  fork (void $ useCodecWithDuplex clientChan codec (chainSyncClientPeer client))
+
+  atomically $ do
+    done <- readTVar doneVar
+    unless done retry
+
+  cchain <- atomically $ readTVar chainVar
+  probeOutput probe (pchain === cchain)
+
+propChainSyncDemoST
+  :: ChainProducerStateForkTest
+  -> Property
+propChainSyncDemoST cps =
+  runST $ runExperiment $ \probe -> do
+    (clientChan, serverChan) <- tmvarChannels
+    chainSyncDemo @(Free (SimF _)) clientChan serverChan cps probe
+
+propChainSyncDemoIO
+  :: ChainProducerStateForkTest
+  -> Property
+propChainSyncDemoIO cps =
+  ioProperty $ runExperiment $ \probe -> do
+    (clientChan, serverChan) <- tmvarChannels
+    chainSyncDemo clientChan serverChan cps probe
+
+propChainSyncPipe
+  :: ChainProducerStateForkTest
+  -> Property
+propChainSyncPipe cps =
+  ioProperty $ runExperiment $ \probe -> do
+    (serRead, cliWrite) <- createPipe
+    (cliRead, serWrite) <- createPipe
+    let clientChan = pipeDuplex cliRead cliWrite
+        serverChan = pipeDuplex serRead serWrite
+    chainSyncDemo clientChan serverChan cps probe


### PR DESCRIPTION
This adds test for `ChainSyncProtocol` using:
* `direct` in `IO` and `SimM`
* `connect` in `IO` and `SimM`
* drive a demo using `useCodexWithDuplex` in `IO` and `SimM`
* run a demo with `useCodexWithDuplex` over a local pipe