### PR TITLE
Build with GHC 8.6.2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,5 @@
-{ compiler   ? "ghc844"
+{ nixpkgs    ? import <nixpkgs> {}
+, compiler   ? "ghc862"
 , haddock    ? true
 , test       ? true
 , benchmarks ? false
@@ -7,8 +8,44 @@ with builtins;
 let
   nixpkgs     = import ./nix/nixpkgs.nix {};
   lib         = nixpkgs.haskell.lib;
-  callCabal2nix = nixpkgs.haskell.packages.${compiler}.callCabal2nix;
-  callPackage = nixpkgs.haskell.packages.${compiler}.callPackage;
+
+  cardano-sl-git = nixpkgs.fetchFromGitHub {
+    owner = "input-output-hk";
+    repo = "cardano-sl";
+    rev = "9c0fc48d49e0104392b31e02ee2e01506ebd39e9";
+    sha256 = "1x8c6f9jr4shkx788xdhfbl2b5rnfh9lb50kr65zxa86r149r46y";
+  };
+  cardanopkgsOverrides = import (cardano-sl-git + /cardanopkgs.nix);
+
+  /* The byron-adapter package needs cardano-sl (the library).
+     cardano-sl packages need some special non-hackage dependencies, and
+     some custom branches of various on-hackage dependencies.
+     ouroboros-network is also a dependency of byron-adapter, and it uses
+     QuickCheck 2.12.
+     Many of the dependencies of cardano-sl are not compatible with this.
+     We also use stm 2.5, which causes similar troubles.
+     To make it all work, we give special overrides, and use the cardanopkgs
+     overlay to get cardano-sl.
+     TODO make this optional, until we can reliably get the cardano-sl overlay
+     (no hard-coded path).
+  */
+  ourOverrides = import ./nix/haskell-overrides.nix { dontCheck = lib.dontCheck; };
+  /* cannot override{ ... }.override{ ... } apparently... so we manually
+     compose the overlays
+  */
+  overlay = self: super: (ourOverrides self super) // (cardanopkgsOverrides self super);
+  /* Override callPackage so it doesn't check or do haddock, by default.
+     Surely this is not the right way to do this.
+  */
+  ghc     = nixpkgs.haskell.packages.${compiler}.override ({
+    overrides = self: super:
+      let
+        cp = path: args: lib.dontCheck (lib.dontHaddock (super.callPackage path args));
+      in
+        overlay (self // { callPackage = cp; }) super;
+  });
+  callPackage   = ghc.callPackage;
+  callCabal2nix = ghc.callCabal2nix;
 
   doHaddock = if haddock
     then lib.doHaddock
@@ -30,24 +67,27 @@ let
     callPackage (iohk-monitoring-src + /iohk-monitoring.nix) {}
   ))));
 
-  io-sim-classes = docNoSeprateOutput(doHaddock(doTest(doBench(
-    cleanSource (callCabal2nix "io-sim-classes"./io-sim-classes {})
-  ))));
+in
+  rec {
 
-  io-sim = docNoSeprateOutput(doHaddock(doTest(doBench(
-    cleanSource (callCabal2nix "io-sim" ./io-sim { inherit  io-sim-classes; })
-  ))));
+    io-sim-classes = docNoSeprateOutput(doHaddock(doTest(doBench(
+      cleanSource (callCabal2nix "io-sim-classes"./io-sim-classes {})
+    ))));
 
-  typed-transitions = docNoSeprateOutput(doHaddock(doTest(doBench(
-    cleanSource (callCabal2nix "typed-transitions" ./typed-transitions {})
-  ))));
+    io-sim = docNoSeprateOutput(doHaddock(doTest(doBench(
+      cleanSource (callCabal2nix "io-sim" ./io-sim { inherit io-sim-classes; })
+    ))));
 
-  ouroboros-network = docNoSeprateOutput(doHaddock(doTest(doBench(
-    cleanSource (callCabal2nix "ouroboros-network" ./ouroboros-network { inherit io-sim io-sim-classes typed-transitions iohk-monitoring; })
-  ))));
+    typed-transitions = docNoSeprateOutput(doHaddock(doTest(doBench(
+      cleanSource (callCabal2nix "typed-transitions" ./typed-transitions {})
+    ))));
 
-  ouroboros-consensus = docNoSeprateOutput(doHaddock(doTest(doBench(
-    cleanSource (callCabal2nix "ouroboros-consensus" ./ouroboros-consensus { inherit io-sim-classes io-sim typed-transitions ouroboros-network; })
-  ))));
+    ouroboros-network = docNoSeprateOutput(doHaddock(doTest(doBench(
+      cleanSource (callCabal2nix "ouroboros-network" ./ouroboros-network { inherit io-sim io-sim-classes typed-transitions iohk-monitoring; })
+    ))));
 
-in { inherit io-sim-classes io-sim typed-transitions ouroboros-network ouroboros-consensus; }
+    ouroboros-consensus = docNoSeprateOutput(doHaddock(doTest(doBench(
+      cleanSource (callCabal2nix "ouroboros-consensus" ./ouroboros-consensus { inherit io-sim-classes io-sim typed-transitions ouroboros-network; })
+    ))));
+
+  }

--- a/io-sim-classes/io-sim-classes.cabal
+++ b/io-sim-classes/io-sim-classes.cabal
@@ -2,6 +2,7 @@ name:                io-sim-classes
 version:             0.1.0.0
 synopsis:            Type classes for concurrency with STM, ST and timing
 -- description:
+license:             MIT
 license-file:        LICENSE
 author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts
 maintainer:

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -2,6 +2,7 @@ name:                io-sim
 version:             0.1.0.0
 synopsis:            A pure simlator for monadic concurrency with STM
 -- description:
+license:             MIT
 license-file:        LICENSE
 author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts
 maintainer:

--- a/nix/ChasingBottoms-1.3.1.5.nix
+++ b/nix/ChasingBottoms-1.3.1.5.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, array, base, containers, mtl, QuickCheck, random
+, stdenv, syb
+}:
+mkDerivation {
+  pname = "ChasingBottoms";
+  version = "1.3.1.5";
+  sha256 = "60f43e0956459606e3432ab528bada79503f928c9fa26e52deaea8961613d341";
+  libraryHaskellDepends = [
+    base containers mtl QuickCheck random syb
+  ];
+  testHaskellDepends = [
+    array base containers mtl QuickCheck random syb
+  ];
+  description = "For testing partial and infinite values";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/Glob-0.10.0.nix
+++ b/nix/Glob-0.10.0.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, base, containers, directory, dlist, filepath, HUnit
+, QuickCheck, stdenv, test-framework, test-framework-hunit
+, test-framework-quickcheck2, transformers, transformers-compat
+}:
+mkDerivation {
+  pname = "Glob";
+  version = "0.10.0";
+  sha256 = "473355bd6ba0a97902e0edada1acbc0d76cfda77596f0188b2cc0ae34272a324";
+  libraryHaskellDepends = [
+    base containers directory dlist filepath transformers
+    transformers-compat
+  ];
+  testHaskellDepends = [
+    base containers directory dlist filepath HUnit QuickCheck
+    test-framework test-framework-hunit test-framework-quickcheck2
+    transformers transformers-compat
+  ];
+  homepage = "http://iki.fi/matti.niemenmaa/glob/";
+  description = "Globbing library";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/HTF-0.13.2.5.nix
+++ b/nix/HTF-0.13.2.5.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, aeson, aeson-pretty, array, base, base64-bytestring
+, bytestring, containers, cpphs, Diff, directory, filepath
+, haskell-src, HUnit, lifted-base, monad-control, mtl, old-time
+, pretty, process, QuickCheck, random, regex-compat, stdenv
+, template-haskell, temporary, text, time, unix
+, unordered-containers, vector, xmlgen
+}:
+mkDerivation {
+  pname = "HTF";
+  version = "0.13.2.5";
+  sha256 = "365af323c6254ec5c33745e1d42ceeba0940992a43f523608c4dc64d7c49aece";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson array base base64-bytestring bytestring containers cpphs Diff
+    directory haskell-src HUnit lifted-base monad-control mtl old-time
+    pretty process QuickCheck random regex-compat text time unix vector
+    xmlgen
+  ];
+  executableHaskellDepends = [
+    array base cpphs directory HUnit mtl old-time random text
+  ];
+  testHaskellDepends = [
+    aeson aeson-pretty base bytestring directory filepath HUnit mtl
+    process random regex-compat template-haskell temporary text
+    unordered-containers
+  ];
+  homepage = "https://github.com/skogsbaer/HTF/";
+  description = "The Haskell Test Framework";
+  license = stdenv.lib.licenses.lgpl21;
+}

--- a/nix/QuickCheck-2.12.6.1.nix
+++ b/nix/QuickCheck-2.12.6.1.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, containers, deepseq, erf, process, random
+, stdenv, template-haskell, tf-random, transformers
+}:
+mkDerivation {
+  pname = "QuickCheck";
+  version = "2.12.6.1";
+  sha256 = "0b2aa7f5c625b5875c36f5f548926fcdaedf4311bd3a4c291fcf10b8d7faa170";
+  libraryHaskellDepends = [
+    base containers deepseq erf random template-haskell tf-random
+    transformers
+  ];
+  testHaskellDepends = [ base deepseq process ];
+  homepage = "https://github.com/nick8325/quickcheck";
+  description = "Automatic testing of Haskell programs";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/aeson-1.4.2.0.nix
+++ b/nix/aeson-1.4.2.0.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, attoparsec, base, base-compat, base-orphans
+, base16-bytestring, bytestring, containers, contravariant, deepseq
+, directory, dlist, filepath, generic-deriving, ghc-prim, hashable
+, hashable-time, integer-logarithms, primitive, QuickCheck
+, quickcheck-instances, scientific, stdenv, tagged, tasty
+, tasty-hunit, tasty-quickcheck, template-haskell, text
+, th-abstraction, time, time-locale-compat, unordered-containers
+, uuid-types, vector
+}:
+mkDerivation {
+  pname = "aeson";
+  version = "1.4.2.0";
+  sha256 = "75ce71814a33d5e5568208e6806a8847e7ba47fea74d30f6a8b1b56ecb318bd0";
+  libraryHaskellDepends = [
+    attoparsec base base-compat bytestring containers contravariant
+    deepseq dlist ghc-prim hashable primitive scientific tagged
+    template-haskell text th-abstraction time time-locale-compat
+    unordered-containers uuid-types vector
+  ];
+  testHaskellDepends = [
+    attoparsec base base-compat base-orphans base16-bytestring
+    bytestring containers directory dlist filepath generic-deriving
+    ghc-prim hashable hashable-time integer-logarithms QuickCheck
+    quickcheck-instances scientific tagged tasty tasty-hunit
+    tasty-quickcheck template-haskell text time time-locale-compat
+    unordered-containers uuid-types vector
+  ];
+  homepage = "https://github.com/bos/aeson";
+  description = "Fast JSON parsing and encoding";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/aeson-compat-0.3.9.nix
+++ b/nix/aeson-compat-0.3.9.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, aeson, attoparsec, attoparsec-iso8601, base
+, base-compat, base-orphans, bytestring, containers, exceptions
+, hashable, QuickCheck, quickcheck-instances, scientific, stdenv
+, tagged, tasty, tasty-hunit, tasty-quickcheck, text, time
+, time-locale-compat, unordered-containers, vector
+}:
+mkDerivation {
+  pname = "aeson-compat";
+  version = "0.3.9";
+  sha256 = "e043941ba761c13a3854fc087521b864b56b2df874154e42aedb67b2a77f23c8";
+  libraryHaskellDepends = [
+    aeson attoparsec attoparsec-iso8601 base base-compat bytestring
+    containers exceptions hashable scientific tagged text time
+    time-locale-compat unordered-containers vector
+  ];
+  testHaskellDepends = [
+    aeson attoparsec base base-compat base-orphans bytestring
+    containers exceptions hashable QuickCheck quickcheck-instances
+    scientific tagged tasty tasty-hunit tasty-quickcheck text time
+    time-locale-compat unordered-containers vector
+  ];
+  homepage = "https://github.com/phadej/aeson-compat#readme";
+  description = "Compatibility layer for aeson";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/aeson-options-HEAD.nix
+++ b/nix/aeson-options-HEAD.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, aeson, base, fetchgit, stdenv }:
+mkDerivation {
+  pname = "aeson-options";
+  version = "0.1.0";
+  src = fetchgit {
+    url = "https://github.com/input-output-hk/aeson-options";
+    sha256 = "12czpbbj3h73cax3r3cmrrrnjm3wa1qwl3gr9zzw5hz9kag7blx0";
+    rev = "a25b839b6d2cf1b21fd53906eeaeb3e767cc369a";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [ aeson base ];
+  homepage = "https://github.com/serokell/aeson-options";
+  description = "Options to derive FromJSON/ToJSON instances";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/attoparsec-iso8601-1.0.1.0.nix
+++ b/nix/attoparsec-iso8601-1.0.1.0.nix
@@ -1,0 +1,11 @@
+{ mkDerivation, attoparsec, base, base-compat, stdenv, text, time
+}:
+mkDerivation {
+  pname = "attoparsec-iso8601";
+  version = "1.0.1.0";
+  sha256 = "499ffbd2d39e79cc4fda5ad0129dbf94fdb72a84aa932dfe2a5f5c5c02074142";
+  libraryHaskellDepends = [ attoparsec base base-compat text time ];
+  homepage = "https://github.com/bos/aeson";
+  description = "Parsing of ISO 8601 dates, originally from aeson";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/base-compat-0.10.5.nix
+++ b/nix/base-compat-0.10.5.nix
@@ -1,0 +1,9 @@
+{ mkDerivation, base, stdenv, unix }:
+mkDerivation {
+  pname = "base-compat";
+  version = "0.10.5";
+  sha256 = "990aea21568956d44ab018c5dbfbaea014b9a0d5295d29ca7550149419a6fb41";
+  libraryHaskellDepends = [ base unix ];
+  description = "A compatibility layer for base";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/base-compat-batteries-0.10.5.nix
+++ b/nix/base-compat-batteries-0.10.5.nix
@@ -1,0 +1,13 @@
+{ mkDerivation, base, base-compat, contravariant, hspec
+, hspec-discover, QuickCheck, stdenv
+}:
+mkDerivation {
+  pname = "base-compat-batteries";
+  version = "0.10.5";
+  sha256 = "175dcfd1453bd02ec955c05181cbf4278af145183b5899c62d3be29d866170ee";
+  libraryHaskellDepends = [ base base-compat contravariant ];
+  testHaskellDepends = [ base hspec QuickCheck ];
+  testToolDepends = [ hspec-discover ];
+  description = "base-compat with extra batteries";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/base-orphans-0.8.nix
+++ b/nix/base-orphans-0.8.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, ghc-prim, hspec, hspec-discover, QuickCheck
+, stdenv
+}:
+mkDerivation {
+  pname = "base-orphans";
+  version = "0.8";
+  sha256 = "aceec656bfb4222ad3035c3d87d80130b42b595b72888f9ab59c6dbb7ed24817";
+  libraryHaskellDepends = [ base ghc-prim ];
+  testHaskellDepends = [ base hspec QuickCheck ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/haskell-compat/base-orphans#readme";
+  description = "Backwards-compatible orphan instances for base";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/canonical-json-0.5.0.1.nix
+++ b/nix/canonical-json-0.5.0.1.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, aeson, base, bytestring, containers, parsec, pretty
+, QuickCheck, stdenv, tasty, tasty-quickcheck, unordered-containers
+, vector
+}:
+mkDerivation {
+  pname = "canonical-json";
+  version = "0.5.0.1";
+  sha256 = "9243e144754c2918d410c1fc496c54520671b9a1594060eb34d46aa79271a2e4";
+  libraryHaskellDepends = [
+    base bytestring containers parsec pretty
+  ];
+  testHaskellDepends = [
+    aeson base bytestring QuickCheck tasty tasty-quickcheck
+    unordered-containers vector
+  ];
+  homepage = "https://github.com/well-typed/canonical-json";
+  description = "Canonical JSON for signing and hashing JSON values";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/cardano-crypto-1.2.0.nix
+++ b/nix/cardano-crypto-1.2.0.nix
@@ -1,0 +1,29 @@
+{ mkDerivation, base, basement, bytestring, cryptonite
+, cryptonite-openssl, deepseq, fetchgit, foundation, gauge
+, hashable, integer-gmp, memory, stdenv
+}:
+mkDerivation {
+  pname = "cardano-crypto";
+  version = "1.2.0";
+  src = fetchgit {
+    url = "https://github.com/avieth/cardano-crypto";
+    sha256 = "11s95894hxsj3g6ka9mhrawhcihdayfapzw0c5bpm5fgs741b6pd";
+    rev = "784dbd11f213af58d70f1306399d941eb222abf8";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base basement bytestring cryptonite cryptonite-openssl deepseq
+    foundation hashable integer-gmp memory
+  ];
+  testHaskellDepends = [
+    base basement bytestring cryptonite foundation memory
+  ];
+  benchmarkHaskellDepends = [
+    base bytestring cryptonite gauge memory
+  ];
+  homepage = "https://github.com/input-output-hk/cardano-crypto#readme";
+  description = "Cryptography primitives for cardano";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/cardano-report-server-0.5.10.nix
+++ b/nix/cardano-report-server-0.5.10.nix
@@ -1,0 +1,102 @@
+{
+  mkDerivation
+, aeson
+, aeson-pretty
+, base
+, bytestring
+, case-insensitive
+, directory
+, exceptions
+, fetchgit
+, filelock
+, filepath
+, formatting
+, http-types
+, lens
+, lens-aeson
+, lifted-base
+, log-warper
+, monad-control
+, mtl
+, network
+, optparse-applicative
+, parsec
+, random
+, stdenv
+, text
+, time
+, transformers
+, universum
+, vector
+, wai
+, wai-extra
+, warp
+, wreq
+}:
+mkDerivation {
+
+pname = "cardano-report-server";
+version = "0.5.10";
+src = fetchgit {
+
+url = "https://github.com/input-output-hk/cardano-report-server.git";
+sha256 = "02n86wbfr3z2xqrc8g8naj0dc5j4644y0l295qzdqlfynmz6a82z";
+rev = "9b96874d0f234554a5779d98762cc0a6773a532a";
+fetchSubmodules = true;
+
+};
+isLibrary = true;
+isExecutable = true;
+libraryHaskellDepends = [
+aeson
+aeson-pretty
+base
+bytestring
+case-insensitive
+directory
+exceptions
+filelock
+filepath
+formatting
+http-types
+lens
+lens-aeson
+lifted-base
+log-warper
+monad-control
+mtl
+network
+optparse-applicative
+parsec
+random
+text
+time
+transformers
+universum
+vector
+wai
+wai-extra
+warp
+wreq
+];
+executableHaskellDepends = [
+base
+directory
+filepath
+http-types
+log-warper
+monad-control
+mtl
+optparse-applicative
+parsec
+random
+universum
+wai-extra
+warp
+];
+doHaddock = false;
+doCheck = false;
+homepage = "https://github.com/input-output-hk/cardano-report-server";
+description = "Reporting server for CSL";
+license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/cborg-0.2.1.0.nix
+++ b/nix/cborg-0.2.1.0.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, aeson, array, base, base16-bytestring
+, base64-bytestring, bytestring, containers, deepseq, fail
+, ghc-prim, half, integer-gmp, primitive, QuickCheck, scientific
+, stdenv, tasty, tasty-hunit, tasty-quickcheck, text, vector
+}:
+mkDerivation {
+  pname = "cborg";
+  version = "0.2.1.0";
+  sha256 = "9198735f7645ae492345505448f790433f5fe407b19e1c6b2ec2a4c76bd97483";
+  libraryHaskellDepends = [
+    array base bytestring containers deepseq ghc-prim half integer-gmp
+    primitive text
+  ];
+  testHaskellDepends = [
+    aeson array base base16-bytestring base64-bytestring bytestring
+    deepseq fail half QuickCheck scientific tasty tasty-hunit
+    tasty-quickcheck text vector
+  ];
+  description = "Concise Binary Object Representation";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/charset-0.3.7.1.nix
+++ b/nix/charset-0.3.7.1.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, array, base, bytestring, containers, semigroups
+, stdenv, unordered-containers
+}:
+mkDerivation {
+  pname = "charset";
+  version = "0.3.7.1";
+  sha256 = "3d415d2883bd7bf0cc9f038e8323f19c71e07dd12a3c712f449ccb8b4daac0be";
+  revision = "1";
+  editedCabalFile = "1z6nxw2g9vgsjq0g159sk8mwj68lwzxzi5iv5ynha0h85jcqxszy";
+  libraryHaskellDepends = [
+    array base bytestring containers semigroups unordered-containers
+  ];
+  homepage = "http://github.com/ekmett/charset";
+  description = "Fast unicode character sets based on complemented PATRICIA tries";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/concurrent-output-1.10.9.nix
+++ b/nix/concurrent-output-1.10.9.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, ansi-terminal, async, base, directory, exceptions
+, process, stdenv, stm, terminal-size, text, transformers, unix
+}:
+mkDerivation {
+  pname = "concurrent-output";
+  version = "1.10.9";
+  sha256 = "8cc49408e957c65359182fbfcda80717b931915d101e4be55ccb26c44b098e57";
+  libraryHaskellDepends = [
+    ansi-terminal async base directory exceptions process stm
+    terminal-size text transformers unix
+  ];
+  description = "Ungarble output from several threads or commands";
+  license = stdenv.lib.licenses.bsd2;
+}

--- a/nix/conduit-1.3.1.nix
+++ b/nix/conduit-1.3.1.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, base, bytestring, containers, deepseq, directory
+, exceptions, filepath, gauge, hspec, kan-extensions
+, mono-traversable, mtl, mwc-random, primitive, QuickCheck
+, resourcet, safe, silently, split, stdenv, text, transformers
+, unix, unliftio, unliftio-core, vector
+}:
+mkDerivation {
+  pname = "conduit";
+  version = "1.3.1";
+  sha256 = "ae129b66ada785c43a693d3b260f0e7b2f01d79fbf04ae43f7341405455320d6";
+  libraryHaskellDepends = [
+    base bytestring directory exceptions filepath mono-traversable mtl
+    primitive resourcet text transformers unix unliftio-core vector
+  ];
+  testHaskellDepends = [
+    base bytestring containers directory exceptions filepath hspec
+    mono-traversable mtl QuickCheck resourcet safe silently split text
+    transformers unliftio vector
+  ];
+  benchmarkHaskellDepends = [
+    base containers deepseq gauge hspec kan-extensions mwc-random
+    transformers vector
+  ];
+  homepage = "http://github.com/snoyberg/conduit";
+  description = "Streaming data processing library";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/contravariant-1.5.nix
+++ b/nix/contravariant-1.5.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, StateVar, stdenv, transformers }:
+mkDerivation {
+  pname = "contravariant";
+  version = "1.5";
+  sha256 = "6ef067b692ad69ffff294b953aa85f3ded459d4ae133c37896222a09280fc3c2";
+  libraryHaskellDepends = [ base StateVar transformers ];
+  homepage = "http://github.com/ekmett/contravariant/";
+  description = "Contravariant functors";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/doctest-0.16.0.1.nix
+++ b/nix/doctest-0.16.0.1.nix
@@ -1,0 +1,28 @@
+{ mkDerivation, base, base-compat, code-page, deepseq, directory
+, filepath, ghc, ghc-paths, hspec, HUnit, mockery, process
+, QuickCheck, setenv, silently, stdenv, stringbuilder, syb
+, transformers, with-location
+}:
+mkDerivation {
+  pname = "doctest";
+  version = "0.16.0.1";
+  sha256 = "9b5275497330607f66aaf2625b798b2ad566867fed3f52cea9de31a23361d780";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base base-compat code-page deepseq directory filepath ghc ghc-paths
+    process syb transformers
+  ];
+  executableHaskellDepends = [
+    base base-compat code-page deepseq directory filepath ghc ghc-paths
+    process syb transformers
+  ];
+  testHaskellDepends = [
+    base base-compat code-page deepseq directory filepath ghc ghc-paths
+    hspec HUnit mockery process QuickCheck setenv silently
+    stringbuilder syb transformers with-location
+  ];
+  homepage = "https://github.com/sol/doctest#readme";
+  description = "Test interactive Haskell examples";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/ekg-0.4.0.15.nix
+++ b/nix/ekg-0.4.0.15.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, aeson, base, bytestring, ekg-core, ekg-json
+, filepath, network, snap-core, snap-server, stdenv, text, time
+, transformers, unordered-containers
+}:
+mkDerivation {
+  pname = "ekg";
+  version = "0.4.0.15";
+  sha256 = "482ae3be495cfe4f03332ad1c79ce8b5ad4f9c8eec824980c664808ae32c6dcc";
+  revision = "5";
+  editedCabalFile = "0jwzwqr4giinq6wvl46399454nm9vc5g6mc2k2mx4wjdcl07qbgm";
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    aeson base bytestring ekg-core ekg-json filepath network snap-core
+    snap-server text time transformers unordered-containers
+  ];
+  homepage = "https://github.com/tibbe/ekg";
+  description = "Remote monitoring of processes";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/ekg-core-0.1.1.6.nix
+++ b/nix/ekg-core-0.1.1.6.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, base, containers, ghc-prim, stdenv, text
+, unordered-containers
+}:
+mkDerivation {
+  pname = "ekg-core";
+  version = "0.1.1.6";
+  sha256 = "66a8dd79ad27659052168f08dd41fabb8593e364de00fb857ef5cc943acd5742";
+  libraryHaskellDepends = [
+    base containers ghc-prim text unordered-containers
+  ];
+  benchmarkHaskellDepends = [ base ];
+  homepage = "https://github.com/tibbe/ekg-core";
+  description = "Tracking of system metrics";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/ekg-json-0.1.0.6.nix
+++ b/nix/ekg-json-0.1.0.6.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, aeson, base, ekg-core, stdenv, text
+, unordered-containers
+}:
+mkDerivation {
+  pname = "ekg-json";
+  version = "0.1.0.6";
+  sha256 = "1e6a80aa0a28bbf41c9c6364cbb5731160d14fa54145f27a82d0b3467a04dd47";
+  revision = "4";
+  editedCabalFile = "16sn4nbqm0rxkf0swi6r2jn6z9x92qmcg9xlx258d98kqb5fkwjg";
+  libraryHaskellDepends = [
+    aeson base ekg-core text unordered-containers
+  ];
+  homepage = "https://github.com/tibbe/ekg-json";
+  description = "JSON encoding of ekg metrics";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/ekg-statsd-HEAD.nix
+++ b/nix/ekg-statsd-HEAD.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, bytestring, ekg-core, fetchgit, network
+, stdenv, text, time, unordered-containers
+}:
+mkDerivation {
+  pname = "ekg-statsd";
+  version = "0.2.4.0";
+  src = fetchgit {
+    url = "https://github.com/avieth/ekg-statsd";
+    sha256 = "16wvyi9aifjvg9r9ppba3rg8ad2fnrjwaxdad5hg5r929ryhabn2";
+    rev = "becbb8e7171d50763b0f80c5b2e9c966dcffb819";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    base bytestring ekg-core network text time unordered-containers
+  ];
+  homepage = "https://github.com/tibbe/ekg-statsd";
+  description = "Push metrics to statsd";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/entropy-0.4.1.4.nix
+++ b/nix/entropy-0.4.1.4.nix
@@ -1,0 +1,13 @@
+{ mkDerivation, base, bytestring, Cabal, directory, filepath
+, process, stdenv, unix
+}:
+mkDerivation {
+  pname = "entropy";
+  version = "0.4.1.4";
+  sha256 = "2e3f6a65c8fde3551a8fb03b0a519b718762fc3278b1a5750f96d399e821eeb9";
+  setupHaskellDepends = [ base Cabal directory filepath process ];
+  libraryHaskellDepends = [ base bytestring unix ];
+  homepage = "https://github.com/TomMD/entropy";
+  description = "A platform independent entropy source";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/ether-HEAD.nix
+++ b/nix/ether-HEAD.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, base, criterion, deepseq, exceptions, fetchgit
+, ghc-prim, lens, mmorph, monad-control, mtl, QuickCheck
+, reflection, stdenv, tagged, tasty, tasty-quickcheck
+, template-haskell, transformers, transformers-base
+, transformers-lift, writer-cps-mtl
+}:
+mkDerivation {
+  pname = "ether";
+  version = "0.5.1.0";
+  src = fetchgit {
+    url = "https://github.com/int-index/ether";
+    sha256 = "0h2md24q9dhxh5r79dy7shry7yxgwf45735fqwlx3j2z0znq9vxs";
+    rev = "84c1d560da241c8111d1a3c98d9a896f0c62087b";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    base exceptions mmorph monad-control mtl reflection tagged
+    template-haskell transformers transformers-base transformers-lift
+    writer-cps-mtl
+  ];
+  testHaskellDepends = [
+    base ghc-prim lens mtl QuickCheck tasty tasty-quickcheck
+    transformers
+  ];
+  benchmarkHaskellDepends = [
+    base criterion deepseq lens mtl transformers
+  ];
+  homepage = "https://int-index.github.io/ether/";
+  description = "Monad transformers and classes";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/fgl-5.7.0.1.nix
+++ b/nix/fgl-5.7.0.1.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, array, base, containers, deepseq, hspec, microbench
+, QuickCheck, stdenv, transformers
+}:
+mkDerivation {
+  pname = "fgl";
+  version = "5.7.0.1";
+  sha256 = "ffce7af67d4e7ee2f6a7c44fbb749c4253ce9bb35b8b1ffe1c93a173a01fe910";
+  libraryHaskellDepends = [
+    array base containers deepseq transformers
+  ];
+  testHaskellDepends = [ base containers hspec QuickCheck ];
+  benchmarkHaskellDepends = [ base deepseq microbench ];
+  description = "Martin Erwig's Functional Graph Library";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/fingertree-0.1.4.2.nix
+++ b/nix/fingertree-0.1.4.2.nix
@@ -4,7 +4,7 @@
 mkDerivation {
   pname = "fingertree";
   version = "0.1.4.2";
-  sha256 = "0zvandj8fysck7ygpn0dw5bhrhmj1s63i326nalxbfkh2ls4iacm";
+  sha256 = "95a948341570bad5a9b2468c388c0eb2c20c57e10dd8fbfc994c7b8764b36a7f";
   libraryHaskellDepends = [ base ];
   testHaskellDepends = [
     base HUnit QuickCheck test-framework test-framework-hunit

--- a/nix/fmt-0.6.1.1.nix
+++ b/nix/fmt-0.6.1.1.nix
@@ -1,0 +1,28 @@
+{ mkDerivation, base, base64-bytestring, bytestring, call-stack
+, containers, criterion, deepseq, doctest, doctest-discover
+, formatting, hspec, interpolate, microlens, neat-interpolation
+, stdenv, text, time, time-locale-compat, vector
+}:
+mkDerivation {
+  pname = "fmt";
+  version = "0.6.1.1";
+  sha256 = "26220b578d56591cb154cfcb1d98ee8f81c1df97f5955dba91dd00061549d2ad";
+  revision = "1";
+  editedCabalFile = "13ypmyg0axadzhycfl0g1s73bk9a2myshf38y8dslf3hlg76wbmv";
+  libraryHaskellDepends = [
+    base base64-bytestring bytestring call-stack containers formatting
+    microlens text time time-locale-compat
+  ];
+  testHaskellDepends = [
+    base bytestring call-stack containers doctest hspec
+    neat-interpolation text vector
+  ];
+  testToolDepends = [ doctest-discover ];
+  benchmarkHaskellDepends = [
+    base bytestring containers criterion deepseq formatting interpolate
+    text vector
+  ];
+  homepage = "http://github.com/aelve/fmt";
+  description = "A new formatting library";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/foldl-1.4.5.nix
+++ b/nix/foldl-1.4.5.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, base, bytestring, comonad, containers
+, contravariant, criterion, hashable, mwc-random, primitive
+, profunctors, semigroupoids, semigroups, stdenv, text
+, transformers, unordered-containers, vector, vector-builder
+}:
+mkDerivation {
+  pname = "foldl";
+  version = "1.4.5";
+  sha256 = "0ba0bd8a8b4273feef61b66b6e251e70f70537c113f8b7f0e3aeab77d8af12a7";
+  libraryHaskellDepends = [
+    base bytestring comonad containers contravariant hashable
+    mwc-random primitive profunctors semigroupoids semigroups text
+    transformers unordered-containers vector vector-builder
+  ];
+  benchmarkHaskellDepends = [ base criterion ];
+  description = "Composable, streaming, and efficient left folds";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/free-5.1.nix
+++ b/nix/free-5.1.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, comonad, containers, distributive, exceptions
+, mtl, profunctors, semigroupoids, stdenv, template-haskell
+, transformers, transformers-base
+}:
+mkDerivation {
+  pname = "free";
+  version = "5.1";
+  sha256 = "70424d5c82dea36a0a29c4f5f6bc047597a947ad46f3d66312e47bbee2eeea84";
+  libraryHaskellDepends = [
+    base comonad containers distributive exceptions mtl profunctors
+    semigroupoids template-haskell transformers transformers-base
+  ];
+  homepage = "http://github.com/ekmett/free/";
+  description = "Monads for free";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/generics-sop-0.4.0.1.nix
+++ b/nix/generics-sop-0.4.0.1.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, criterion, deepseq, ghc-prim, sop-core
+, stdenv, template-haskell
+}:
+mkDerivation {
+  pname = "generics-sop";
+  version = "0.4.0.1";
+  sha256 = "dc99fa6c597b7ce256bdbdfc89fc615f26013e25256dd7e813f05b7845b61398";
+  libraryHaskellDepends = [
+    base ghc-prim sop-core template-haskell
+  ];
+  testHaskellDepends = [ base ];
+  benchmarkHaskellDepends = [
+    base criterion deepseq template-haskell
+  ];
+  description = "Generic Programming using True Sums of Products";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/graphviz-2999.20.0.3.nix
+++ b/nix/graphviz-2999.20.0.3.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, base, bytestring, colour, containers, criterion
+, deepseq, directory, dlist, fgl, fgl-arbitrary, filepath
+, hspec, hspec-discover, mtl, polyparse, process, QuickCheck
+, stdenv, temporary, text, wl-pprint-text
+}:
+mkDerivation {
+  pname = "graphviz";
+  version = "2999.20.0.3";
+  sha256 = "efa0a27a914e4c51ebfc8b11a741f551e97713c22a02d0e60ddbd960f8376212";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base bytestring colour containers directory dlist fgl filepath mtl
+    polyparse process temporary text wl-pprint-text
+  ];
+  testHaskellDepends = [
+    base containers fgl fgl-arbitrary filepath hspec QuickCheck text
+  ];
+  # Causes infinite recursion since callPackage passes graphviz itself as this
+  # dependency. So no tests...
+  #testSystemDepends = [ graphviz ];
+  testToolDepends = [ hspec-discover ];
+  benchmarkHaskellDepends = [ base criterion deepseq text ];
+  homepage = "http://projects.haskell.org/graphviz/";
+  description = "Bindings to Graphviz for graph visualisation";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/haskell-overrides.nix
+++ b/nix/haskell-overrides.nix
@@ -1,0 +1,160 @@
+{ dontCheck
+}:
+let
+in
+  self: super: {
+    # Custom packages not in hackage, needed for cardano-sl.
+    rocksdb-haskell-ng = self.callPackage ./rocksdb-haskell-ng-0.0.0.nix {};
+    cardano-report-server = self.callPackage ./cardano-report-server-0.5.10.nix {};
+    cardano-crypto = self.callPackage ./cardano-crypto-1.2.0.nix {};
+    plutus-prototype = self.callPackage ./plutus-prototype-0.1.0.0.nix {};
+
+    # New quickcheck has _massive_ fallout.
+    # Many packages don't allow for >= 2.12; even more do allow it but fail due
+    # to type changes.
+    # Alas, we use the new features, so need it.
+    QuickCheck = self.callPackage ./QuickCheck-2.12.6.1.nix {};
+    quickcheck-instances = self.callPackage ./quickcheck-instances-0.3.19.nix {};
+    HTF = dontCheck (self.callPackage ./HTF-0.13.2.5.nix {});
+    test-framework-quickcheck2 = self.callPackage ./test-framework-quickcheck2-0.3.0.5.nix {};
+    hspec = self.callPackage ./hspec-2.6.0.nix {};
+    hspec-core = self.callPackage ./hspec-core-2.6.0.nix {};
+    hspec-discover = self.callPackage ./hspec-discover-2.6.0.nix {};
+    hspec-meta= self.callPackage ./hspec-meta-2.6.0.nix {};
+    tasty-hspec = self.callPackage ./tasty-hspec-1.1.5.1.nix {};
+    # Also QuickCheck  version incompatibilty.
+    # Latest version can use QuickCheck 2.12, but its test-suite depends upon
+    # test-framework-quickcheck, which is deprecated and incompatible.
+    ChasingBottoms = dontCheck (self.callPackage ./ChasingBottoms-1.3.1.5.nix {});
+    # 0.14.2.0 incompatible with QuickCheck 2.12
+    optparse-applicative = self.callPackage ./optparse-applicative-0.14.3.0.nix {};
+    # Its test suite is incompatible with quickcheck 2.12.
+    blaze-builder = dontCheck super.blaze-builder;
+    blaze-markup = dontCheck super.blaze-markup;
+    cereal = dontCheck super.cereal;
+    Diff = dontCheck super.Diff;
+    psqueues = dontCheck super.psqueues;
+    # Something needs aeson >= 1.4
+    # That has a big fallout.
+    aeson = dontCheck (self.callPackage ./aeson-1.4.2.0.nix {});
+    aeson-compat = self.callPackage ./aeson-compat-0.3.9.nix {};
+    # serokell package; aeson bound is <1.4.
+    aeson-options = self.callPackage ./aeson-options-HEAD.nix {};
+    base-compat = self.callPackage ./base-compat-0.10.5.nix {};
+    base-compat-batteries = self.callPackage ./base-compat-batteries-0.10.5.nix {};
+    contravariant = self.callPackage ./contravariant-1.5.nix {};
+    either = dontCheck super.either;
+    http-media = self.callPackage ./http-media-0.7.1.3.nix {};
+    o-clock = self.callPackage ./o-clock-1.0.0.1.nix {};
+    insert-ordered-containers = dontCheck super.insert-ordered-containers;
+    swagger2 = self.callPackage ./swagger2-2.3.1.nix {};
+    these = self.callPackage ./these-0.7.5.nix {};
+    fmt = self.callPackage ./fmt-0.6.1.1.nix {};
+    # Must bump aeson upper bound, but not use megaparsec as they do in mainline.
+    serokell-util = self.callPackage ./serokell-util-iohk.nix {};
+    # Why are we still using this?
+    log-warper = self.callPackage ./log-warper-HEAD.nix {};
+
+    servant = self.callPackage ./servant-0.15.nix {};
+    servant-server = self.callPackage ./servant-server-0.15.nix {};
+    servant-client = self.callPackage ./servant-client-0.15.nix {};
+    servant-client-core = self.callPackage ./servant-client-core-0.15.nix {};
+    servant-blaze = self.callPackage ./servant-blaze-0.8.nix {};
+    servant-swagger = self.callPackage ./servant-swagger-1.1.7.nix {};
+    servant-swagger-ui = self.callPackage ./servant-swagger-ui-0.3.2.3.19.3.nix {};
+    servant-swagger-ui-core = self.callPackage ./servant-swagger-ui-core-0.3.2.nix {};
+    servant-swagger-ui-redoc = self.callPackage ./servant-swagger-ui-redoc-0.3.2.1.22.2.nix {};
+    # servant-swagger apparently needs the latest lens package
+    lens = self.callPackage ./lens-4.17.nix {};
+    servant-quickcheck = self.callPackage ./servant-quickcheck-0.0.7.3.nix {};
+    entropy = self.callPackage ./entropy-0.4.1.4.nix {};
+    semigroupoids = self.callPackage ./semigroupoids-5.3.1.nix {};
+    base-orphans = self.callPackage ./base-orphans-0.8.nix {};
+    http-api-data = self.callPackage ./http-api-data-0.4.nix {};
+    http-types = self.callPackage ./http-types-0.12.2.nix {};
+    tagged = self.callPackage ./tagged-0.8.6.nix {};
+    attoparsec-iso8601 = self.callPackage ./attoparsec-iso8601-1.0.1.0.nix {};
+    # They released it with failing tests, maybe?
+    warp = dontCheck (self.callPackage ./warp-3.2.25.nix {});
+    wai-extra = self.callPackage ./wai-extra-3.0.24.3.nix {};
+    resourcet = self.callPackage ./resourcet-1.2.2.nix {};
+    network = dontCheck (self.callPackage ./network-2.8.0.0.nix {});
+    # test suite fails due to some automake/autoreconf issue.
+    # HsNetworkConfig.h is not generated there, but it _is_ for the
+    # library itself.
+    io-streams = self.callPackage ./io-streams-1.5.0.1.nix {};
+    io-streams-haproxy = self.callPackage ./io-streams-haproxy-1.0.0.2.nix {};
+    openssl-streams = self.callPackage ./openssl-streams-1.2.1.3.nix {};
+    snap = self.callPackage ./snap-1.1.1.0.nix {};
+    snap-core = self.callPackage ./snap-core-1.0.3.2.nix {};
+    snap-server = self.callPackage ./snap-server-1.1.0.0.nix {};
+    time-locale-compat = self.callPackage ./time-locale-compat-0.1.1.5.nix {};
+    # We still need this D:
+    # Custom branch bumps its network bound.
+    # mainline froozen/kademlia has no commits since 2015! Perfect software?
+    # Tests also fail... luckily we don't _really_ use it...
+    # But getting it out of the cardano-sl tree would be at least an hour of
+    # surgery.
+    kademlia = dontCheck (self.callPackage ./kademlia-HEAD.nix {});
+
+    generics-sop = self.callPackage ./generics-sop-0.4.0.1.nix {};
+    sop-core = self.callPackage ./sop-core-0.4.0.0.nix {};
+    free = self.callPackage ./free-5.1.nix {};
+
+    # stm API changes also have fallout.
+    stm = self.callPackage ./stm-2.5.0.0.nix {};
+    hedgehog = self.callPackage ./hedgehog-HEAD.nix {};
+    concurrent-output = self.callPackage ./concurrent-output-1.10.9.nix {};
+    unliftio = self.callPackage ./unliftio-0.2.10.nix {};
+    unliftio-core = self.callPackage ./unliftio-core-0.1.2.0.nix {};
+    katip = self.callPackage ./katip-0.7.0.0.nix {};
+    # Custom network-transport{-inmemory,-tcp} required for cardano-sl.
+
+    network-transport = self.callPackage ./network-transport-HEAD.nix {};
+    network-transport-tcp = dontCheck (self.callPackage ./network-transport-tcp-HEAD.nix {});
+    network-transport-inmemory = dontCheck (self.callPackage ./network-transport-inmemory-HEAD.nix {});
+
+    graphviz = self.callPackage ./graphviz-2999.20.0.3.nix {};
+    fgl = self.callPackage ./fgl-5.7.0.1.nix {};
+    polyparse = self.callPackage ./polyparse-1.12.1.nix {};
+    singleton-bool = self.callPackage ./singleton-bool-0.1.4.nix {};
+    microlens-th = self.callPackage ./microlens-th-0.4.2.3.nix {};
+    th-expand-syns = self.callPackage ./th-expand-syns-0.4.4.0.nix {};
+    doctest = self.callPackage ./doctest-0.16.0.1.nix {};
+    Glob = self.callPackage ./Glob-0.10.0.nix {};
+    tasty = self.callPackage ./tasty-1.2.nix {};
+    tasty-expected-failure = self.callPackage ./tasty-expected-failure-0.11.1.1.nix {};
+    tasty-ant-xml = self.callPackage ./tasty-ant-xml-1.1.5.nix {};
+    tasty-hedgehog = self.callPackage ./tasty-hedgehog-0.2.0.0.nix {};
+    memory = self.callPackage ./memory-0.14.18.nix {};
+    safe-exceptions = self.callPackage ./safe-exceptions-0.1.7.0.nix {};
+    unordered-containers = self.callPackage ./unordered-containers-0.2.10.0.nix {};
+    charset = self.callPackage ./charset-0.3.7.1.nix {};
+    ekg = self.callPackage ./ekg-0.4.0.15.nix {};
+    ekg-core = self.callPackage ./ekg-core-0.1.1.6.nix {};
+    ekg-json = self.callPackage ./ekg-json-0.1.0.6.nix {};
+    ekg-statsd = self.callPackage ./ekg-statsd-HEAD.nix {};
+    foldl = self.callPackage ./foldl-1.4.5.nix {};
+    haskell-src-exts = self.callPackage ./haskell-src-exts-1.20.3.nix {};
+    haskell-src-meta = self.callPackage ./haskell-src-meta-0.8.0.3.nix {};
+    fingertree = self.callPackage ./fingertree-0.1.4.2.nix {};
+    lifted-async = self.callPackage ./lifted-async-0.10.0.3.nix {};
+    persistent = self.callPackage ./persistent-2.9.0.nix {};
+    persistent-template = self.callPackage ./persistent-template-2.5.4.nix {};
+    persistent-postgresql = self.callPackage ./persistent-postgresql-2.9.0.nix {};
+    conduit = self.callPackage ./conduit-1.3.1.nix {};
+    quickcheck-state-machine = self.callPackage ./quickcheck-state-machine-0.6.0.nix {};
+    tree-diff = self.callPackage ./tree-diff-0.0.2.nix {};
+    pretty-show = self.callPackage ./pretty-show-1.9.5.nix {};
+
+    # for decodeStringCanonical
+    cborg = self.callPackage ./cborg-0.2.1.0.nix {};
+
+    # Not in nixpkgs apparently... And its test suite demands aseon == 1.4.*
+    canonical-json = dontCheck (self.callPackage ./canonical-json-0.5.0.1.nix {});
+    # ether is deprecated...
+    ether = self.callPackage ./ether-HEAD.nix {};
+
+    # hedge against the ever-changing interface of universum
+    universum = self.callPackage ./universum-iohk.nix {};
+  }

--- a/nix/haskell-src-exts-1.20.3.nix
+++ b/nix/haskell-src-exts-1.20.3.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, array, base, containers, directory, filepath
+, ghc-prim, happy, mtl, pretty, pretty-show, smallcheck, stdenv
+, tasty, tasty-golden, tasty-smallcheck
+}:
+mkDerivation {
+  pname = "haskell-src-exts";
+  version = "1.20.3";
+  sha256 = "433e68a731fb6a1435e86d3eb3b2878db9c5d51dc1f7499d85bbf5ac3ed1e4a8";
+  libraryHaskellDepends = [ array base ghc-prim pretty ];
+  libraryToolDepends = [ happy ];
+  testHaskellDepends = [
+    base containers directory filepath mtl pretty-show smallcheck tasty
+    tasty-golden tasty-smallcheck
+  ];
+  doCheck = false;
+  homepage = "https://github.com/haskell-suite/haskell-src-exts";
+  description = "Manipulating Haskell source: abstract syntax, lexer, parser, and pretty-printer";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/haskell-src-meta-0.8.0.3.nix
+++ b/nix/haskell-src-meta-0.8.0.3.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, base, haskell-src-exts, HUnit, pretty, stdenv, syb
+, template-haskell, test-framework, test-framework-hunit
+, th-orphans
+}:
+mkDerivation {
+  pname = "haskell-src-meta";
+  version = "0.8.0.3";
+  sha256 = "8473e3555080860c2043581b398dbab67319584a568463b074a092fd4d095822";
+  revision = "2";
+  editedCabalFile = "0dp5v0yd0wgijzaggr22glgjswpa65hy84h8awdzd9d78g2fjz6c";
+  libraryHaskellDepends = [
+    base haskell-src-exts pretty syb template-haskell th-orphans
+  ];
+  testHaskellDepends = [
+    base haskell-src-exts HUnit pretty template-haskell test-framework
+    test-framework-hunit
+  ];
+  description = "Parse source to template-haskell abstract syntax";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/hedgehog-HEAD.nix
+++ b/nix/hedgehog-HEAD.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, ansi-terminal, async, base, bytestring
+, concurrent-output, containers, directory, exceptions, fetchgit
+, lifted-async, mmorph, monad-control, mtl, pretty-show, primitive
+, random, resourcet, semigroups, stdenv, stm, template-haskell
+, text, th-lift, time, transformers, transformers-base
+, wl-pprint-annotated
+}:
+mkDerivation {
+  pname = "hedgehog";
+  version = "0.6.1";
+  src = fetchgit {
+    url = "https://github.com/avieth/haskell-hedgehog.git";
+    sha256 = "1r4i41s8rhj38kx5kvj2fwj1a3kiwhw1wiyww9q0ivpb8ifhkbqw";
+    rev = "d965a9002b16b82a548da4c071b0eb0af8ed7838";
+    fetchSubmodules = true;
+  };
+  postUnpack = "sourceRoot+=/hedgehog; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    ansi-terminal async base bytestring concurrent-output containers
+    directory exceptions lifted-async mmorph monad-control mtl
+    pretty-show primitive random resourcet semigroups stm
+    template-haskell text th-lift time transformers transformers-base
+    wl-pprint-annotated
+  ];
+  testHaskellDepends = [
+    base containers pretty-show semigroups text transformers
+  ];
+  homepage = "https://hedgehog.qa";
+  description = "Hedgehog will eat all your bugs";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/hspec-2.6.0.nix
+++ b/nix/hspec-2.6.0.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, hspec-core, hspec-discover
+, hspec-expectations, QuickCheck, stdenv
+}:
+mkDerivation {
+  pname = "hspec";
+  version = "2.6.0";
+  sha256 = "d1ac36509ab32f55eb7be8bee7a3c880fbf1d0654ff67cc416050be716509463";
+  libraryHaskellDepends = [
+    base hspec-core hspec-discover hspec-expectations QuickCheck
+  ];
+  homepage = "http://hspec.github.io/";
+  description = "A Testing Framework for Haskell";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/hspec-core-2.6.0.nix
+++ b/nix/hspec-core-2.6.0.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, ansi-terminal, array, base, call-stack, clock
+, deepseq, directory, filepath, hspec-expectations, hspec-meta
+, HUnit, process, QuickCheck, quickcheck-io, random, setenv
+, silently, stdenv, stm, temporary, tf-random, transformers
+}:
+mkDerivation {
+  pname = "hspec-core";
+  version = "2.6.0";
+  sha256 = "d97811a6666a9da6e20d9ac19baf4dc6c83cebdf22c6143bf71e5cf798596e38";
+  libraryHaskellDepends = [
+    ansi-terminal array base call-stack clock deepseq directory
+    filepath hspec-expectations HUnit QuickCheck quickcheck-io random
+    setenv stm tf-random transformers
+  ];
+  testHaskellDepends = [
+    ansi-terminal array base call-stack clock deepseq directory
+    filepath hspec-expectations hspec-meta HUnit process QuickCheck
+    quickcheck-io random setenv silently stm temporary tf-random
+    transformers
+  ];
+  testToolDepends = [ hspec-meta ];
+  testTarget = "--test-option=--skip --test-option='Test.Hspec.Core.Runner.hspecResult runs specs in parallel'";
+  homepage = "http://hspec.github.io/";
+  description = "A Testing Framework for Haskell";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/hspec-discover-2.6.0.nix
+++ b/nix/hspec-discover-2.6.0.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, directory, filepath, hspec-meta, QuickCheck
+, stdenv
+}:
+mkDerivation {
+  pname = "hspec-discover";
+  version = "2.6.0";
+  sha256 = "82d9417cfe6df8a0289f7bb24b17138f399571997cc9d0e1439cfa7b7e79059f";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [ base directory filepath ];
+  executableHaskellDepends = [ base directory filepath ];
+  testHaskellDepends = [
+    base directory filepath hspec-meta QuickCheck
+  ];
+  testToolDepends = [ hspec-meta ];
+  homepage = "http://hspec.github.io/";
+  description = "Automatically discover and run Hspec tests";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/hspec-meta-2.6.0.nix
+++ b/nix/hspec-meta-2.6.0.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, ansi-terminal, array, base, call-stack, clock
+, deepseq, directory, filepath, hspec-expectations, HUnit
+, QuickCheck, quickcheck-io, random, setenv, stdenv, stm, time
+, transformers
+}:
+mkDerivation {
+  pname = "hspec-meta";
+  version = "2.6.0";
+  sha256 = "e6d701c9f366f6762eb2a86022d1c7a7d7631c100945491ff53b3a3e86212ad8";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    ansi-terminal array base call-stack clock deepseq directory
+    filepath hspec-expectations HUnit QuickCheck quickcheck-io random
+    setenv stm time transformers
+  ];
+  executableHaskellDepends = [
+    ansi-terminal array base call-stack clock deepseq directory
+    filepath hspec-expectations HUnit QuickCheck quickcheck-io random
+    setenv stm time transformers
+  ];
+  homepage = "http://hspec.github.io/";
+  description = "A version of Hspec which is used to test Hspec itself";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/http-api-data-0.4.nix
+++ b/nix/http-api-data-0.4.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, attoparsec, attoparsec-iso8601, base, base-compat
+, bytestring, Cabal, cabal-doctest, containers, cookie, directory
+, doctest, filepath, hashable, hspec, hspec-discover, http-types
+, HUnit, nats, QuickCheck, quickcheck-instances, stdenv, tagged
+, text, time, time-locale-compat, unordered-containers, uuid-types
+}:
+mkDerivation {
+  pname = "http-api-data";
+  version = "0.4";
+  sha256 = "837e3f39f23df2caa23d75a4608f4a0505a1ab23f7290006976a37a373164a8a";
+  setupHaskellDepends = [ base Cabal cabal-doctest ];
+  libraryHaskellDepends = [
+    attoparsec attoparsec-iso8601 base base-compat bytestring
+    containers cookie hashable http-types tagged text time
+    time-locale-compat unordered-containers uuid-types
+  ];
+  testHaskellDepends = [
+    base base-compat bytestring cookie directory doctest filepath hspec
+    HUnit nats QuickCheck quickcheck-instances text time
+    unordered-containers uuid-types
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "http://github.com/fizruk/http-api-data";
+  description = "Converting to/from HTTP API data like URL pieces, headers and query parameters";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/http-media-0.7.1.3.nix
+++ b/nix/http-media-0.7.1.3.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, bytestring, case-insensitive, containers
+, QuickCheck, stdenv, test-framework, test-framework-quickcheck2
+, utf8-string
+}:
+mkDerivation {
+  pname = "http-media";
+  version = "0.7.1.3";
+  sha256 = "394ffcfb4f655721d5965870bf9861c324c14d40ed4dc173e926235fe0fe124f";
+  libraryHaskellDepends = [
+    base bytestring case-insensitive containers utf8-string
+  ];
+  testHaskellDepends = [
+    base bytestring case-insensitive containers QuickCheck
+    test-framework test-framework-quickcheck2 utf8-string
+  ];
+  homepage = "https://github.com/zmthy/http-media";
+  description = "Processing HTTP Content-Type and Accept headers";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/http-types-0.12.2.nix
+++ b/nix/http-types-0.12.2.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, array, base, bytestring, case-insensitive, doctest
+, hspec, QuickCheck, quickcheck-instances, stdenv, text
+}:
+mkDerivation {
+  pname = "http-types";
+  version = "0.12.2";
+  sha256 = "523102d7ba8923e1b399cfd2a1c821e858146ecd934fc147c3acd0fd2b2f9305";
+  libraryHaskellDepends = [
+    array base bytestring case-insensitive text
+  ];
+  testHaskellDepends = [
+    base bytestring doctest hspec QuickCheck quickcheck-instances text
+  ];
+  homepage = "https://github.com/aristidb/http-types";
+  description = "Generic HTTP types for Haskell (for both client and server code)";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/io-streams-1.5.0.1.nix
+++ b/nix/io-streams-1.5.0.1.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, attoparsec, base, bytestring, bytestring-builder
+, deepseq, directory, filepath, HUnit, mtl, network, primitive
+, process, QuickCheck, stdenv, test-framework, test-framework-hunit
+, test-framework-quickcheck2, text, time, transformers, vector
+, zlib, zlib-bindings
+}:
+mkDerivation {
+  pname = "io-streams";
+  version = "1.5.0.1";
+  sha256 = "5dcb3717933197a84f31be74abf545126b3d25eb0e0d64f722c480d3c46b2c8b";
+  revision = "2";
+  editedCabalFile = "1mcab95d6hm098myh9gp7sh10srigjphgvm8s9pfs7jg5hzghy14";
+  configureFlags = [ "-fNoInteractiveTests" ];
+  libraryHaskellDepends = [
+    attoparsec base bytestring bytestring-builder network primitive
+    process text time transformers vector zlib-bindings
+  ];
+  testHaskellDepends = [
+    attoparsec base bytestring bytestring-builder deepseq directory
+    filepath HUnit mtl network primitive process QuickCheck
+    test-framework test-framework-hunit test-framework-quickcheck2 text
+    time transformers vector zlib zlib-bindings
+  ];
+  description = "Simple, composable, and easy-to-use stream I/O";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/io-streams-haproxy-1.0.0.2.nix
+++ b/nix/io-streams-haproxy-1.0.0.2.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, attoparsec, base, bytestring, HUnit, io-streams
+, network, stdenv, test-framework, test-framework-hunit
+, transformers
+}:
+mkDerivation {
+  pname = "io-streams-haproxy";
+  version = "1.0.0.2";
+  sha256 = "77814f8258b5c32707a13e0d30ab2e144e7ad073aee821d6def65554024ed086";
+  revision = "4";
+  editedCabalFile = "06c51a057n5bc9xfbp2m4jz5ds4z1xvmsx5mppch6qfwbz7x5i9l";
+  libraryHaskellDepends = [
+    attoparsec base bytestring io-streams network transformers
+  ];
+  testHaskellDepends = [
+    attoparsec base bytestring HUnit io-streams network test-framework
+    test-framework-hunit transformers
+  ];
+  homepage = "http://snapframework.com/";
+  description = "HAProxy protocol 1.5 support for io-streams";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/kademlia-HEAD.nix
+++ b/nix/kademlia-HEAD.nix
@@ -1,0 +1,35 @@
+{ mkDerivation, base, binary, bytestring, containers, contravariant
+, cryptonite, data-default, errors, extra, fetchgit, HUnit, memory
+, MonadRandom, mtl, network, QuickCheck, quickcheck-instances
+, random, random-shuffle, stdenv, stm, tasty, tasty-hunit
+, tasty-quickcheck, time, transformers, transformers-compat
+}:
+mkDerivation {
+  pname = "kademlia";
+  version = "1.1.0.1";
+  src = fetchgit {
+    url = "https://github.com/avieth/kademlia";
+    sha256 = "067yqv7dr5s649s3xihgzcq5df7j5kpabnd5mq0zll5ar45v6qdr";
+    rev = "38a0575bb303804461f4b6176ca38eba81adbd79";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base bytestring containers contravariant cryptonite extra memory
+    MonadRandom mtl network random random-shuffle stm time transformers
+  ];
+  executableHaskellDepends = [
+    base binary bytestring containers data-default extra MonadRandom
+    mtl network random random-shuffle transformers transformers-compat
+  ];
+  testHaskellDepends = [
+    base binary bytestring containers data-default errors extra HUnit
+    MonadRandom mtl network QuickCheck quickcheck-instances random
+    random-shuffle stm tasty tasty-hunit tasty-quickcheck time
+    transformers transformers-compat
+  ];
+  homepage = "https://github.com/serokell/kademlia";
+  description = "An implementation of the Kademlia DHT Protocol";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/katip-0.7.0.0.nix
+++ b/nix/katip-0.7.0.0.nix
@@ -1,0 +1,35 @@
+{ mkDerivation, aeson, async, auto-update, base, blaze-builder
+, bytestring, containers, criterion, deepseq, directory, either
+, filepath, hostname, microlens, microlens-th, monad-control, mtl
+, old-locale, quickcheck-instances, regex-tdfa, resourcet
+, safe-exceptions, scientific, semigroups, stdenv, stm, string-conv
+, tasty, tasty-golden, tasty-hunit, tasty-quickcheck
+, template-haskell, text, time, time-locale-compat, transformers
+, transformers-base, transformers-compat, unix, unliftio-core
+, unordered-containers
+}:
+mkDerivation {
+  pname = "katip";
+  version = "0.7.0.0";
+  sha256 = "0ba53e13cfa9e717c3e040f0c858f0d1de1417cffaf670542d546951d21885fc";
+  libraryHaskellDepends = [
+    aeson async auto-update base bytestring containers either hostname
+    microlens microlens-th monad-control mtl old-locale resourcet
+    safe-exceptions scientific semigroups stm string-conv
+    template-haskell text time transformers transformers-base
+    transformers-compat unix unliftio-core unordered-containers
+  ];
+  testHaskellDepends = [
+    aeson base bytestring containers directory microlens
+    quickcheck-instances regex-tdfa safe-exceptions stm tasty
+    tasty-golden tasty-hunit tasty-quickcheck template-haskell text
+    time time-locale-compat unordered-containers
+  ];
+  benchmarkHaskellDepends = [
+    aeson async base blaze-builder criterion deepseq directory filepath
+    safe-exceptions text time transformers unix
+  ];
+  homepage = "https://github.com/Soostone/katip";
+  description = "A structured logging framework";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/lens-4.17.nix
+++ b/nix/lens-4.17.nix
@@ -1,0 +1,39 @@
+{ mkDerivation, array, base, base-orphans, bifunctors, bytestring
+, Cabal, cabal-doctest, call-stack, comonad, containers
+, contravariant, criterion, deepseq, directory, distributive
+, doctest, exceptions, filepath, free, generic-deriving, ghc-prim
+, hashable, HUnit, kan-extensions, mtl, nats, parallel, profunctors
+, QuickCheck, reflection, semigroupoids, semigroups, simple-reflect
+, stdenv, tagged, template-haskell, test-framework
+, test-framework-hunit, test-framework-quickcheck2
+, test-framework-th, text, th-abstraction, transformers
+, transformers-compat, unordered-containers, vector, void
+}:
+mkDerivation {
+  pname = "lens";
+  version = "4.17";
+  sha256 = "473664de541023bef44aa29105abbb1e35542e9254cdc846963183e0dd3f08cc";
+  setupHaskellDepends = [ base Cabal cabal-doctest filepath ];
+  libraryHaskellDepends = [
+    array base base-orphans bifunctors bytestring call-stack comonad
+    containers contravariant distributive exceptions filepath free
+    ghc-prim hashable kan-extensions mtl parallel profunctors
+    reflection semigroupoids semigroups tagged template-haskell text
+    th-abstraction transformers transformers-compat
+    unordered-containers vector void
+  ];
+  testHaskellDepends = [
+    base bytestring containers deepseq directory doctest filepath
+    generic-deriving HUnit mtl nats parallel QuickCheck semigroups
+    simple-reflect test-framework test-framework-hunit
+    test-framework-quickcheck2 test-framework-th text transformers
+    unordered-containers vector
+  ];
+  benchmarkHaskellDepends = [
+    base bytestring comonad containers criterion deepseq
+    generic-deriving transformers unordered-containers vector
+  ];
+  homepage = "http://github.com/ekmett/lens/";
+  description = "Lenses, Folds and Traversals";
+  license = stdenv.lib.licenses.bsd2;
+}

--- a/nix/lifted-async-0.10.0.3.nix
+++ b/nix/lifted-async-0.10.0.3.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, async, base, constraints, criterion, deepseq, HUnit
+, lifted-base, monad-control, mtl, stdenv, tasty
+, tasty-expected-failure, tasty-hunit, tasty-th, transformers-base
+}:
+mkDerivation {
+  pname = "lifted-async";
+  version = "0.10.0.3";
+  sha256 = "83d09c355cf7c5d35f179f6f084524f451966ed29beac721f0500ee607822b8c";
+  libraryHaskellDepends = [
+    async base constraints lifted-base monad-control transformers-base
+  ];
+  testHaskellDepends = [
+    async base HUnit lifted-base monad-control mtl tasty
+    tasty-expected-failure tasty-hunit tasty-th
+  ];
+  benchmarkHaskellDepends = [ async base criterion deepseq ];
+  homepage = "https://github.com/maoe/lifted-async";
+  description = "Run lifted IO operations asynchronously and wait for their results";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/log-warper-HEAD.nix
+++ b/nix/log-warper-HEAD.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, aeson, ansi-terminal, base, containers, deepseq
+, directory, fetchgit, filepath, fmt, lifted-async
+, microlens-platform, mmorph, monad-control, monad-loops, mtl
+, o-clock, stdenv, text, time, transformers, transformers-base
+, universum, unix, unordered-containers, vector, yaml
+}:
+mkDerivation {
+  pname = "log-warper";
+  version = "1.8.10.1";
+  src = fetchgit {
+    url = "https://github.com/input-output-hk/log-warper";
+    sha256 = "1did5mw433pfig2p6s8napqml9r45x7vs4szj7hj7li05h3nz5qd";
+    rev = "22a0967b33d70d42e441cc6d69829476c2d3d1b5";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    aeson ansi-terminal base containers deepseq directory filepath fmt
+    lifted-async microlens-platform mmorph monad-control monad-loops
+    mtl o-clock text time transformers transformers-base universum unix
+    unordered-containers vector yaml
+  ];
+  homepage = "https://github.com/serokell/log-warper";
+  description = "Flexible, configurable, monadic and pretty logging";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/memory-0.14.18.nix
+++ b/nix/memory-0.14.18.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, basement, bytestring, deepseq, foundation
+, ghc-prim, stdenv
+}:
+mkDerivation {
+  pname = "memory";
+  version = "0.14.18";
+  sha256 = "f5458d170a291788ac8da896bb44b0cc84021c99dd596c52adf2f7a7f6c03507";
+  revision = "1";
+  editedCabalFile = "0h4d0avv8kv3my4rim79lcamv2dyibld7w6ianq46nhwgr0h2lzm";
+  libraryHaskellDepends = [
+    base basement bytestring deepseq ghc-prim
+  ];
+  testHaskellDepends = [ base basement bytestring foundation ];
+  homepage = "https://github.com/vincenthz/hs-memory";
+  description = "memory and related abstraction stuff";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/microlens-th-0.4.2.3.nix
+++ b/nix/microlens-th-0.4.2.3.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, containers, microlens, stdenv
+, template-haskell, th-abstraction, transformers
+}:
+mkDerivation {
+  pname = "microlens-th";
+  version = "0.4.2.3";
+  sha256 = "321018c6c0aad3f68eb26f6c7e7a518db43039e3f8f19c4634ceb4c7f8051c8f";
+  libraryHaskellDepends = [
+    base containers microlens template-haskell th-abstraction
+    transformers
+  ];
+  testHaskellDepends = [ base microlens ];
+  homepage = "http://github.com/aelve/microlens";
+  description = "Automatic generation of record lenses for microlens";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/network-2.8.0.0.nix
+++ b/nix/network-2.8.0.0.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, base, bytestring, directory, doctest, hspec, HUnit
+, stdenv, unix
+}:
+mkDerivation {
+  pname = "network";
+  version = "2.8.0.0";
+  sha256 = "c8905268b7e3b4cf624a40245bf11b35274a6dd836a5d4d531b5760075645303";
+  libraryHaskellDepends = [ base bytestring unix ];
+  testHaskellDepends = [
+    base bytestring directory doctest hspec HUnit
+  ];
+  homepage = "https://github.com/haskell/network";
+  description = "Low-level networking interface";
+  license = stdenv.lib.licenses.bsd3;
+  /* preConfigure = ''
+    ls -R
+    autoreconf
+    '';
+  buildTools = [ autoconf automake ]; */
+}

--- a/nix/network-transport-HEAD.nix
+++ b/nix/network-transport-HEAD.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, binary, bytestring, deepseq, fetchgit
+, hashable, stdenv, transformers
+}:
+mkDerivation {
+  pname = "network-transport";
+  version = "0.5.1";
+  src = fetchgit {
+    url = "https://github.com/avieth/network-transport";
+    sha256 = "00p4v8l69mh0219l2qnj5zna10q6ngvhrb7v114rmxml1zsp9nsp";
+    rev = "0b8f5a7bec389a4ffa653792cfd203c742a0857b";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    base binary bytestring deepseq hashable transformers
+  ];
+  homepage = "http://haskell-distributed.github.com";
+  description = "Network abstraction layer";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/network-transport-inmemory-HEAD.nix
+++ b/nix/network-transport-inmemory-HEAD.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, base, bytestring, containers, data-accessor
+, fetchgit, network-transport, network-transport-tests, stdenv, stm
+}:
+mkDerivation {
+  pname = "network-transport-inmemory";
+  version = "0.5.1";
+  src = fetchgit {
+    url = "https://github.com/avieth/network-transport-inmemory";
+    sha256 = "0d19dnqxcnmd11v9drrvsxqfy2w8vrsccw2asd2jvxqs4qqfg4b9";
+    rev = "ae3ba7e656c199658e85170dc9d4487e1f31729a";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    base bytestring containers data-accessor network-transport stm
+  ];
+  testHaskellDepends = [
+    base network-transport network-transport-tests
+  ];
+  homepage = "http://haskell-distributed.github.com";
+  description = "In-memory instantiation of Network.Transport";
+  license = stdenv.lib.licenses.bsd3;
+  doCheck = false;
+}

--- a/nix/network-transport-tcp-HEAD.nix
+++ b/nix/network-transport-tcp-HEAD.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, base, bytestring, containers, data-accessor
+, fetchgit, network, network-transport, network-transport-tests
+, stdenv, uuid
+}:
+mkDerivation {
+  pname = "network-transport-tcp";
+  version = "0.6.0";
+  src = fetchgit {
+    url = "https://github.com/avieth/network-transport-tcp";
+    sha256 = "0rygmgj3s865ry045cg8dnnf9idsj6rr1wzsxjc97lmfcv2a12z5";
+    rev = "da5e1544ead1d1b70ca4b7a54fc5f02b1a9a98c9";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    base bytestring containers data-accessor network network-transport
+    uuid
+  ];
+  testHaskellDepends = [
+    base bytestring network network-transport network-transport-tests
+  ];
+  homepage = "http://haskell-distributed.github.com";
+  description = "TCP instantiation of Network.Transport";
+  license = stdenv.lib.licenses.bsd3;
+  doCheck = false;
+}

--- a/nix/o-clock-1.0.0.1.nix
+++ b/nix/o-clock-1.0.0.1.nix
@@ -1,0 +1,22 @@
+{ mkDerivation, base, deepseq, doctest, gauge, ghc-prim, Glob
+, hedgehog, markdown-unlit, stdenv, tasty, tasty-hedgehog
+, tasty-hspec, tiempo, time-units, type-spec
+}:
+mkDerivation {
+  pname = "o-clock";
+  version = "1.0.0.1";
+  sha256 = "d9198d86927002eb7fb9c9ba52afd965719d3a6a1d19818f188d8b06f707bb5a";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [ base ghc-prim ];
+  executableHaskellDepends = [ base ];
+  testHaskellDepends = [
+    base doctest Glob hedgehog markdown-unlit tasty tasty-hedgehog
+    tasty-hspec type-spec
+  ];
+  testToolDepends = [ doctest markdown-unlit ];
+  benchmarkHaskellDepends = [ base deepseq gauge tiempo time-units ];
+  homepage = "https://github.com/serokell/o-clock";
+  description = "Type-safe time library";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/openssl-streams-1.2.1.3.nix
+++ b/nix/openssl-streams-1.2.1.3.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, bytestring, HsOpenSSL, HUnit, io-streams
+, network, stdenv, test-framework, test-framework-hunit
+}:
+mkDerivation {
+  pname = "openssl-streams";
+  version = "1.2.1.3";
+  sha256 = "dc7170e835cf71a132903e2a6ccc976bd2984f9241ea2e4e99a9ece74f868f5f";
+  revision = "2";
+  editedCabalFile = "1004kgdryflpkp19dv4ikilhcn0xbfc5dsp6v3ib34580pcfj7wy";
+  libraryHaskellDepends = [
+    base bytestring HsOpenSSL io-streams network
+  ];
+  testHaskellDepends = [
+    base bytestring HsOpenSSL HUnit io-streams network test-framework
+    test-framework-hunit
+  ];
+  description = "OpenSSL network support for io-streams";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/optparse-applicative-0.14.3.0.nix
+++ b/nix/optparse-applicative-0.14.3.0.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, ansi-wl-pprint, base, bytestring, process
+, QuickCheck, stdenv, transformers, transformers-compat
+}:
+mkDerivation {
+  pname = "optparse-applicative";
+  version = "0.14.3.0";
+  sha256 = "72476302fe555a508917b2d7d6121c7b58ea5434cdc08aeb5d4b652e8f0e7663";
+  libraryHaskellDepends = [
+    ansi-wl-pprint base process transformers transformers-compat
+  ];
+  testHaskellDepends = [ base bytestring QuickCheck ];
+  homepage = "https://github.com/pcapriotti/optparse-applicative";
+  description = "Utilities and combinators for parsing command line options";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/persistent-2.9.0.nix
+++ b/nix/persistent-2.9.0.nix
@@ -1,0 +1,32 @@
+{ mkDerivation, aeson, attoparsec, base, base64-bytestring
+, blaze-html, blaze-markup, bytestring, conduit, containers
+, fast-logger, hspec, http-api-data, monad-control, monad-logger
+, mtl, old-locale, path-pieces, resource-pool, resourcet
+, scientific, silently, stdenv, tagged, template-haskell, text
+, time, transformers, unliftio-core, unordered-containers, vector
+, void
+}:
+mkDerivation {
+  pname = "persistent";
+  version = "2.9.0";
+  sha256 = "e7865ceb4aa1e93ca8c65c789f92c8046a39ecf41283682bcace33e89b77f261";
+  revision = "2";
+  editedCabalFile = "1szx008irw7w2h9qz443mml06sg6w9vazbxxyi67d91hyjlgca2j";
+  libraryHaskellDepends = [
+    aeson attoparsec base base64-bytestring blaze-html blaze-markup
+    bytestring conduit containers fast-logger http-api-data
+    monad-logger mtl old-locale path-pieces resource-pool resourcet
+    scientific silently tagged template-haskell text time transformers
+    unliftio-core unordered-containers vector void
+  ];
+  testHaskellDepends = [
+    aeson attoparsec base base64-bytestring blaze-html bytestring
+    conduit containers fast-logger hspec http-api-data monad-control
+    monad-logger mtl old-locale path-pieces resource-pool resourcet
+    scientific tagged template-haskell text time transformers
+    unordered-containers vector
+  ];
+  homepage = "http://www.yesodweb.com/book/persistent";
+  description = "Type-safe, multi-backend data serialization";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/persistent-postgresql-2.9.0.nix
+++ b/nix/persistent-postgresql-2.9.0.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, aeson, base, blaze-builder, bytestring, conduit
+, containers, monad-logger, persistent, postgresql-libpq
+, postgresql-simple, resource-pool, resourcet, stdenv, text, time
+, transformers, unliftio-core
+}:
+mkDerivation {
+  pname = "persistent-postgresql";
+  version = "2.9.0";
+  sha256 = "bd029ca877f9536398e9703e5886731059dbcbd7015cdc470b54727e7e5b14e7";
+  revision = "1";
+  editedCabalFile = "0xrnww7n6kwr2371fj5xklslbx0114yj3pxcpdzwalmin5wm8vah";
+  libraryHaskellDepends = [
+    aeson base blaze-builder bytestring conduit containers monad-logger
+    persistent postgresql-libpq postgresql-simple resource-pool
+    resourcet text time transformers unliftio-core
+  ];
+  homepage = "http://www.yesodweb.com/book/persistent";
+  description = "Backend for the persistent library using postgresql";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/persistent-template-2.5.4.nix
+++ b/nix/persistent-template-2.5.4.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, aeson, aeson-compat, base, bytestring, containers
+, ghc-prim, hspec, http-api-data, monad-control, monad-logger
+, path-pieces, persistent, QuickCheck, stdenv, tagged
+, template-haskell, text, transformers, unordered-containers
+}:
+mkDerivation {
+  pname = "persistent-template";
+  version = "2.5.4";
+  sha256 = "4cae740ce92f98cb3ae9e092e740753394d5687b887399ee5f87af7f3c730a01";
+  revision = "3";
+  editedCabalFile = "12f4pqxwfv2li78sd9s56p66xd0w465cmjycpkqvg8n1rjxkc8vs";
+  libraryHaskellDepends = [
+    aeson aeson-compat base bytestring containers ghc-prim
+    http-api-data monad-control monad-logger path-pieces persistent
+    tagged template-haskell text transformers unordered-containers
+  ];
+  testHaskellDepends = [
+    aeson base bytestring hspec persistent QuickCheck text transformers
+  ];
+  homepage = "http://www.yesodweb.com/book/persistent";
+  description = "Type-safe, non-relational, multi-backend persistence";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/plutus-prototype-0.1.0.0.nix
+++ b/nix/plutus-prototype-0.1.0.0.nix
@@ -1,0 +1,56 @@
+{
+  mkDerivation
+, base
+, bifunctors
+, binary
+, bytestring
+, cardano-crypto
+, cryptonite
+, ed25519
+, either
+, fetchgit
+, filepath
+, lens
+, memory
+, mtl
+, operational
+, parsec
+, stdenv
+, transformers
+}:
+mkDerivation {
+
+pname = "plutus-prototype";
+version = "0.1.0.0";
+src = fetchgit {
+
+url = "https://github.com/avieth/plutus-prototype";
+sha256 = "1s932rghn4zn441waansp408b5bwk20rc1wsa5693a2nwnp4dijw";
+rev = "d094be301195fcd8ab864d793f114970426a4478";
+fetchSubmodules = true;
+
+};
+enableSeparateDataOutput = true;
+libraryHaskellDepends = [
+base
+bifunctors
+binary
+bytestring
+cardano-crypto
+cryptonite
+ed25519
+either
+filepath
+lens
+memory
+mtl
+operational
+parsec
+transformers
+];
+doHaddock = false;
+doCheck = false;
+homepage = "iohk.io";
+description = "Prototype of the Plutus language";
+license = stdenv.lib.licenses.mit;
+}

--- a/nix/polyparse-1.12.1.nix
+++ b/nix/polyparse-1.12.1.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, bytestring, stdenv, text }:
+mkDerivation {
+  pname = "polyparse";
+  version = "1.12.1";
+  sha256 = "dd8d34e05853ea0ab9b9fee1cbaa51ae33095f7c0c09ff539dcd6d771e0adaa5";
+  libraryHaskellDepends = [ base bytestring text ];
+  homepage = "http://code.haskell.org/~malcolm/polyparse/";
+  description = "A variety of alternative parser combinator libraries";
+  license = "LGPL";
+}

--- a/nix/pretty-show-1.9.5.nix
+++ b/nix/pretty-show-1.9.5.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, array, base, filepath, ghc-prim, happy
+, haskell-lexer, pretty, stdenv, text
+}:
+mkDerivation {
+  pname = "pretty-show";
+  version = "1.9.5";
+  sha256 = "b095bebb79951d2e25a543a591844fb638165672d7b95d325844611297ba423f";
+  isLibrary = true;
+  isExecutable = true;
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    array base filepath ghc-prim haskell-lexer pretty text
+  ];
+  libraryToolDepends = [ happy ];
+  executableHaskellDepends = [ base ];
+  homepage = "http://wiki.github.com/yav/pretty-show";
+  description = "Tools for working with derived `Show` instances and generic inspection of values";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/quickcheck-instances-0.3.19.nix
+++ b/nix/quickcheck-instances-0.3.19.nix
@@ -1,0 +1,22 @@
+{ mkDerivation, array, base, base-compat, bytestring
+, case-insensitive, containers, hashable, old-time, QuickCheck
+, scientific, stdenv, tagged, text, time, transformers
+, transformers-compat, unordered-containers, uuid-types, vector
+}:
+mkDerivation {
+  pname = "quickcheck-instances";
+  version = "0.3.19";
+  sha256 = "57a4aefff05313fb07a651934088d18a584f8bcfeaa02305be65525f12409a56";
+  libraryHaskellDepends = [
+    array base base-compat bytestring case-insensitive containers
+    hashable old-time QuickCheck scientific tagged text time
+    transformers transformers-compat unordered-containers uuid-types
+    vector
+  ];
+  testHaskellDepends = [
+    base containers QuickCheck tagged uuid-types
+  ];
+  homepage = "https://github.com/phadej/qc-instances";
+  description = "Common quickcheck instances";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/quickcheck-state-machine-0.6.0.nix
+++ b/nix/quickcheck-state-machine-0.6.0.nix
@@ -1,6 +1,6 @@
 { mkDerivation, ansi-wl-pprint, base, bytestring, containers
-, directory, doctest, exceptions, fetchgit, filelock, filepath
-, http-client, matrix, monad-logger, mtl, network, persistent
+, directory, doctest, exceptions, filelock, filepath, http-client
+, matrix, monad-logger, mtl, network, persistent
 , persistent-postgresql, persistent-template, pretty-show, process
 , QuickCheck, quickcheck-instances, random, resourcet, servant
 , servant-client, servant-server, stdenv, strict
@@ -10,12 +10,7 @@
 mkDerivation {
   pname = "quickcheck-state-machine";
   version = "0.6.0";
-  src = fetchgit {
-    url = "https://github.com/advancedtelematic/quickcheck-state-machine";
-    sha256 = "0dn45kzx4hgb5bhj03nvx74jqk2a0rnj894gvqrxad3f7zd05y0f";
-    rev = "619620343ad2c862c5855166c815c478a619b76f";
-    fetchSubmodules = true;
-  };
+  sha256 = "3e5f7199282c185986eedbf7cd22e2c68d4ec6ef24bec80c27a33429c555727d";
   libraryHaskellDepends = [
     ansi-wl-pprint base containers exceptions matrix mtl pretty-show
     QuickCheck tree-diff unliftio vector

--- a/nix/resourcet-1.2.2.nix
+++ b/nix/resourcet-1.2.2.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, base, containers, exceptions, hspec, mtl, primitive
+, stdenv, transformers, unliftio-core
+}:
+mkDerivation {
+  pname = "resourcet";
+  version = "1.2.2";
+  sha256 = "1323425aba3827479eb3588efaf7608b12a083327d64ec814f02863c3673cbe5";
+  libraryHaskellDepends = [
+    base containers exceptions mtl primitive transformers unliftio-core
+  ];
+  testHaskellDepends = [ base exceptions hspec transformers ];
+  homepage = "http://github.com/snoyberg/conduit";
+  description = "Deterministic allocation and freeing of scarce resources";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/rocksdb-haskell-ng-0.0.0.nix
+++ b/nix/rocksdb-haskell-ng-0.0.0.nix
@@ -1,0 +1,34 @@
+{
+  mkDerivation
+, base
+, bytestring
+, directory
+, fetchgit
+, rocksdb
+, stdenv
+}:
+mkDerivation {
+
+pname = "rocksdb-haskell-ng";
+version = "0.0.0";
+src = fetchgit {
+
+url = "https://github.com/input-output-hk/rocksdb-haskell-ng.git";
+sha256 = "02jvri8ik8jgrxwa6qmh3xcwqvm4s27iv3sxpjpny79nlhlxvfzp";
+rev = "49f501a082d745f3b880677220a29cafaa181452";
+fetchSubmodules = true;
+
+};
+libraryHaskellDepends = [
+base
+bytestring
+directory
+];
+librarySystemDepends = [
+rocksdb
+];
+doHaddock = false;
+doCheck = false;
+license = stdenv.lib.licenses.bsd3;
+
+}

--- a/nix/safe-exceptions-0.1.7.0.nix
+++ b/nix/safe-exceptions-0.1.7.0.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, base, deepseq, exceptions, hspec, stdenv
+, transformers, void
+}:
+mkDerivation {
+  pname = "safe-exceptions";
+  version = "0.1.7.0";
+  sha256 = "18cddc587b52b6faa0287fb6ad6c964d1562571ea2c8ff57a194dd54b5fba069";
+  revision = "4";
+  editedCabalFile = "0fid41gishzsyb47wzxhd5falandfirqcp760hcja81qjpfmqd32";
+  libraryHaskellDepends = [ base deepseq exceptions transformers ];
+  testHaskellDepends = [ base hspec void ];
+  homepage = "https://github.com/fpco/safe-exceptions#readme";
+  description = "Safe, consistent, and easy exception handling";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/semigroupoids-5.3.1.nix
+++ b/nix/semigroupoids-5.3.1.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, base, base-orphans, bifunctors, Cabal
+, cabal-doctest, comonad, containers, contravariant, distributive
+, doctest, hashable, semigroups, stdenv, tagged, template-haskell
+, transformers, transformers-compat, unordered-containers
+}:
+mkDerivation {
+  pname = "semigroupoids";
+  version = "5.3.1";
+  sha256 = "cd89ec61f86260997c79c09bacb7d6c18031375bc3e5467b36f7cb812793388e";
+  setupHaskellDepends = [ base Cabal cabal-doctest ];
+  libraryHaskellDepends = [
+    base base-orphans bifunctors comonad containers contravariant
+    distributive hashable semigroups tagged template-haskell
+    transformers transformers-compat unordered-containers
+  ];
+  testHaskellDepends = [ base doctest ];
+  homepage = "http://github.com/ekmett/semigroupoids";
+  description = "Semigroupoids: Category sans id";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/serokell-util-iohk.nix
+++ b/nix/serokell-util-iohk.nix
@@ -1,0 +1,34 @@
+{ mkDerivation, aeson, ansi-terminal, base, base16-bytestring
+, base64-bytestring, bytestring, clock, deepseq, exceptions, extra
+, fetchgit, fmt, formatting, hashable, hspec, hspec-discover
+, microlens, microlens-mtl, mtl, o-clock, parsec, process
+, QuickCheck, quickcheck-instances, scientific, stdenv
+, template-haskell, text, th-lift-instances, transformers
+, universum, unordered-containers, vector
+}:
+mkDerivation {
+  pname = "serokell-util";
+  version = "0.9.0";
+  src = fetchgit {
+    url = "https://github.com/input-output-hk/serokell-util";
+    sha256 = "16arrlxjkz9f8rd8v3l0yj70f2ij51didsxcz54jdv3j14pzmb5s";
+    rev = "42586f5ea157b4a5411fbcbe41d1bf28bd942438";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    aeson ansi-terminal base base16-bytestring base64-bytestring
+    bytestring clock deepseq exceptions fmt formatting hashable
+    microlens microlens-mtl mtl o-clock parsec process QuickCheck
+    quickcheck-instances scientific template-haskell text
+    th-lift-instances transformers universum unordered-containers
+    vector
+  ];
+  testHaskellDepends = [
+    aeson base extra hspec QuickCheck quickcheck-instances scientific
+    universum unordered-containers vector
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/serokell/serokell-util";
+  description = "General-purpose functions by Serokell";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/servant-0.15.nix
+++ b/nix/servant-0.15.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, aeson, attoparsec, base, base-compat, bifunctors
+, bytestring, Cabal, cabal-doctest, case-insensitive, doctest
+, hspec, hspec-discover, http-api-data, http-media, http-types
+, mmorph, mtl, network-uri, QuickCheck, quickcheck-instances
+, singleton-bool, stdenv, string-conversions, tagged, text
+, transformers, vault
+}:
+mkDerivation {
+  pname = "servant";
+  version = "0.15";
+  sha256 = "4f3f35c9c0f5e4ee8c2d10c9113ac4a6409a4d57759137e68f43588f5e6bfa39";
+  setupHaskellDepends = [ base Cabal cabal-doctest ];
+  libraryHaskellDepends = [
+    aeson attoparsec base base-compat bifunctors bytestring
+    case-insensitive http-api-data http-media http-types mmorph mtl
+    network-uri QuickCheck singleton-bool string-conversions tagged
+    text transformers vault
+  ];
+  testHaskellDepends = [
+    aeson base base-compat bytestring doctest hspec mtl QuickCheck
+    quickcheck-instances string-conversions text transformers
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "http://haskell-servant.readthedocs.org/";
+  description = "A family of combinators for defining webservices APIs";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/servant-blaze-0.8.nix
+++ b/nix/servant-blaze-0.8.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, base, blaze-html, http-media, servant
+, servant-server, stdenv, wai, warp
+}:
+mkDerivation {
+  pname = "servant-blaze";
+  version = "0.8";
+  sha256 = "46ea88550123d765b2d09073370d0530a51878e7fdf2cf20b070be1f2f10ae94";
+  revision = "2";
+  editedCabalFile = "1cfla60vn4kk5gb7fawlp34jr2k6b2fprysq05561wdfv990x4bj";
+  libraryHaskellDepends = [ base blaze-html http-media servant ];
+  testHaskellDepends = [ base blaze-html servant-server wai warp ];
+  homepage = "http://haskell-servant.readthedocs.org/";
+  description = "Blaze-html support for servant";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/servant-client-0.15.nix
+++ b/nix/servant-client-0.15.nix
@@ -1,0 +1,30 @@
+{ mkDerivation, aeson, base, base-compat, bytestring, containers
+, deepseq, entropy, exceptions, generics-sop, hspec, hspec-discover
+, http-api-data, http-client, http-media, http-types, HUnit
+, kan-extensions, markdown-unlit, monad-control, mtl, network
+, QuickCheck, semigroupoids, servant, servant-client-core
+, servant-server, stdenv, stm, tdigest, text, time, transformers
+, transformers-base, transformers-compat, wai, warp
+}:
+mkDerivation {
+  pname = "servant-client";
+  version = "0.15";
+  sha256 = "2a6c731a479f68ea8f7fe3e124b8b87d14ca9c385ed0751a70461a3c59540a25";
+  libraryHaskellDepends = [
+    base base-compat bytestring containers deepseq exceptions
+    http-client http-media http-types kan-extensions monad-control mtl
+    semigroupoids servant servant-client-core stm text time
+    transformers transformers-base transformers-compat
+  ];
+  testHaskellDepends = [
+    aeson base base-compat bytestring entropy generics-sop hspec
+    http-api-data http-client http-types HUnit kan-extensions
+    markdown-unlit mtl network QuickCheck servant servant-client-core
+    servant-server tdigest text transformers transformers-compat wai
+    warp
+  ];
+  testToolDepends = [ hspec-discover markdown-unlit ];
+  homepage = "http://haskell-servant.readthedocs.org/";
+  description = "Automatic derivation of querying functions for servant";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/servant-client-core-0.15.nix
+++ b/nix/servant-client-core-0.15.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, aeson, base, base-compat, base64-bytestring
+, bytestring, containers, deepseq, exceptions, free, generics-sop
+, hspec, hspec-discover, http-media, http-types, network-uri
+, QuickCheck, safe, servant, stdenv, template-haskell, text
+, transformers
+}:
+mkDerivation {
+  pname = "servant-client-core";
+  version = "0.15";
+  sha256 = "9b8e49e5e3cdda9216c393164e7c4b6d693bb159959dd52648f27f7adbca7960";
+  libraryHaskellDepends = [
+    aeson base base-compat base64-bytestring bytestring containers
+    deepseq exceptions free generics-sop http-media http-types
+    network-uri safe servant template-haskell text transformers
+  ];
+  testHaskellDepends = [ base base-compat deepseq hspec QuickCheck ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "http://haskell-servant.readthedocs.org/";
+  description = "Core functionality and class for client function generation for servant APIs";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/servant-quickcheck-0.0.7.3.nix
+++ b/nix/servant-quickcheck-0.0.7.3.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, aeson, base, base-compat-batteries, blaze-html
+, bytestring, case-insensitive, clock, data-default-class, hspec
+, hspec-core, hspec-discover, http-client, http-media, http-types
+, mtl, pretty, process, QuickCheck, quickcheck-io, servant
+, servant-blaze, servant-client, servant-server, split, stdenv
+, string-conversions, temporary, text, time, transformers, warp
+}:
+mkDerivation {
+  pname = "servant-quickcheck";
+  version = "0.0.7.3";
+  sha256 = "b95c5fbbd5b1535c9d9e8245eeb6d62d06961b0afbd8722767f8e0c25d272035";
+  libraryHaskellDepends = [
+    aeson base base-compat-batteries bytestring case-insensitive clock
+    data-default-class hspec http-client http-media http-types mtl
+    pretty process QuickCheck servant servant-client servant-server
+    split string-conversions temporary text time warp
+  ];
+  testHaskellDepends = [
+    aeson base base-compat-batteries blaze-html bytestring hspec
+    hspec-core http-client QuickCheck quickcheck-io servant
+    servant-blaze servant-client servant-server text transformers warp
+  ];
+  testToolDepends = [ hspec-discover ];
+  description = "QuickCheck entire APIs";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/servant-server-0.15.nix
+++ b/nix/servant-server-0.15.nix
@@ -1,0 +1,36 @@
+{ mkDerivation, aeson, base, base-compat, base64-bytestring
+, bytestring, Cabal, cabal-doctest, containers, directory, doctest
+, exceptions, filepath, hspec, hspec-discover, hspec-wai
+, http-api-data, http-media, http-types, monad-control, mtl
+, network, network-uri, QuickCheck, resourcet, safe, servant
+, should-not-typecheck, stdenv, string-conversions, tagged
+, temporary, text, transformers, transformers-base
+, transformers-compat, wai, wai-app-static, wai-extra, warp, word8
+}:
+mkDerivation {
+  pname = "servant-server";
+  version = "0.15";
+  sha256 = "98034e618ff844f18dbedeb663e1a88a87ce3bc3792e9a40d7e17ca1e96b93e2";
+  isLibrary = true;
+  isExecutable = true;
+  setupHaskellDepends = [ base Cabal cabal-doctest ];
+  libraryHaskellDepends = [
+    base base-compat base64-bytestring bytestring containers exceptions
+    filepath http-api-data http-media http-types monad-control mtl
+    network network-uri resourcet servant string-conversions tagged
+    text transformers transformers-base wai wai-app-static word8
+  ];
+  executableHaskellDepends = [
+    aeson base base-compat servant text wai warp
+  ];
+  testHaskellDepends = [
+    aeson base base-compat base64-bytestring bytestring directory
+    doctest hspec hspec-wai http-types mtl QuickCheck resourcet safe
+    servant should-not-typecheck string-conversions temporary text
+    transformers transformers-compat wai wai-extra
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "http://haskell-servant.readthedocs.org/";
+  description = "A family of combinators for defining webservices APIs and serving them";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/servant-swagger-1.1.7.nix
+++ b/nix/servant-swagger-1.1.7.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, aeson, aeson-pretty, base, base-compat, bytestring
+, Cabal, cabal-doctest, directory, doctest, filepath, hspec
+, hspec-discover, http-media, insert-ordered-containers, lens
+, QuickCheck, servant, singleton-bool, stdenv, swagger2
+, template-haskell, text, time, unordered-containers, utf8-string
+}:
+mkDerivation {
+  pname = "servant-swagger";
+  version = "1.1.7";
+  sha256 = "e31a1020553c2879047e7d15cd1b57b4ec216606554fdecd62e0f4521e81de36";
+  setupHaskellDepends = [ base Cabal cabal-doctest ];
+  libraryHaskellDepends = [
+    aeson aeson-pretty base base-compat bytestring hspec http-media
+    insert-ordered-containers lens QuickCheck servant singleton-bool
+    swagger2 text unordered-containers
+  ];
+  testHaskellDepends = [
+    aeson base base-compat directory doctest filepath hspec lens
+    QuickCheck servant swagger2 template-haskell text time utf8-string
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/haskell-servant/servant-swagger";
+  description = "Generate Swagger specification for your servant API";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/servant-swagger-ui-0.3.2.3.19.3.nix
+++ b/nix/servant-swagger-ui-0.3.2.3.19.3.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, bytestring, file-embed-lzma, servant
+, servant-server, servant-swagger-ui-core, stdenv, swagger2, text
+}:
+mkDerivation {
+  pname = "servant-swagger-ui";
+  version = "0.3.2.3.19.3";
+  sha256 = "87ddb5982ce6b12698f9eff28b5d6fc2ebd00cb406bd48c8d0ff1951a1335e68";
+  revision = "1";
+  editedCabalFile = "0k2s6y93ii3d1myacq70ifpjf9q0mglxdr97wmxll6ixzsn7fjpl";
+  libraryHaskellDepends = [
+    base bytestring file-embed-lzma servant servant-server
+    servant-swagger-ui-core swagger2 text
+  ];
+  homepage = "https://github.com/haskell-servant/servant-swagger-ui";
+  description = "Servant swagger ui";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/servant-swagger-ui-core-0.3.2.nix
+++ b/nix/servant-swagger-ui-core-0.3.2.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, blaze-markup, bytestring, http-media, servant
+, servant-blaze, servant-server, stdenv, swagger2, text
+, transformers, transformers-compat, wai-app-static
+}:
+mkDerivation {
+  pname = "servant-swagger-ui-core";
+  version = "0.3.2";
+  sha256 = "a2cd0e8e68c5de21aea54735f891c4c6e54007c85e93dffd42b89aba419a3ca8";
+  revision = "1";
+  editedCabalFile = "0dd97qvi5w1y90ln58pk0y2vb5f1bhwsix9ym3cnnq8h0snfda4p";
+  libraryHaskellDepends = [
+    base blaze-markup bytestring http-media servant servant-blaze
+    servant-server swagger2 text transformers transformers-compat
+    wai-app-static
+  ];
+  homepage = "https://github.com/haskell-servant/servant-swagger-ui";
+  description = "Servant swagger ui core components";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/servant-swagger-ui-redoc-0.3.2.1.22.2.nix
+++ b/nix/servant-swagger-ui-redoc-0.3.2.1.22.2.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, bytestring, file-embed-lzma, servant
+, servant-server, servant-swagger-ui-core, stdenv, swagger2, text
+}:
+mkDerivation {
+  pname = "servant-swagger-ui-redoc";
+  version = "0.3.2.1.22.2";
+  sha256 = "e09919e7518f8f5b00868eac0c4f80212b5a4950d2c10112696f52446e369934";
+  revision = "1";
+  editedCabalFile = "030zf1z5h96d40ifwagxblz1dij2ypbcqyy0wpqvjqbianyqgcim";
+  libraryHaskellDepends = [
+    base bytestring file-embed-lzma servant servant-server
+    servant-swagger-ui-core swagger2 text
+  ];
+  homepage = "https://github.com/haskell-servant/servant-swagger-ui";
+  description = "Servant swagger ui: ReDoc theme";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/singleton-bool-0.1.4.nix
+++ b/nix/singleton-bool-0.1.4.nix
@@ -1,0 +1,12 @@
+{ mkDerivation, base, stdenv }:
+mkDerivation {
+  pname = "singleton-bool";
+  version = "0.1.4";
+  sha256 = "0195c6e2be1e149e5b687ec3be84fd5089b377345fddd333a9d681eacdfafb2a";
+  revision = "1";
+  editedCabalFile = "0ccd49z9xwa8gr8sclmmn0zc4xq39yyjws4zr6lrw3xjql130nsx";
+  libraryHaskellDepends = [ base ];
+  homepage = "https://github.com/phadej/singleton-bool#readme";
+  description = "Type level booleans";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/snap-1.1.1.0.nix
+++ b/nix/snap-1.1.1.0.nix
@@ -1,0 +1,35 @@
+{ mkDerivation, aeson, async, attoparsec, base, bytestring, cereal
+, clientsession, configurator, containers, deepseq, directory
+, directory-tree, dlist, filepath, hashable, heist, http-streams
+, HUnit, lens, lifted-base, map-syntax, monad-control, mtl
+, mwc-random, pwstore-fast, QuickCheck, smallcheck, snap-core
+, snap-server, stdenv, stm, syb, test-framework
+, test-framework-hunit, test-framework-quickcheck2
+, test-framework-smallcheck, text, time, transformers
+, transformers-base, unordered-containers, xmlhtml
+}:
+mkDerivation {
+  pname = "snap";
+  version = "1.1.1.0";
+  sha256 = "e74b645ed6f97c47ce55e68d416d86363a99f891c876e1e2d5d34d147cde6f22";
+  libraryHaskellDepends = [
+    aeson attoparsec base bytestring cereal clientsession configurator
+    containers directory directory-tree dlist filepath hashable heist
+    lens lifted-base map-syntax monad-control mtl mwc-random
+    pwstore-fast snap-core snap-server stm text time transformers
+    transformers-base unordered-containers xmlhtml
+  ];
+  testHaskellDepends = [
+    aeson async attoparsec base bytestring cereal clientsession
+    configurator containers deepseq directory directory-tree dlist
+    filepath hashable heist http-streams HUnit lens lifted-base
+    map-syntax monad-control mtl mwc-random pwstore-fast QuickCheck
+    smallcheck snap-core snap-server stm syb test-framework
+    test-framework-hunit test-framework-quickcheck2
+    test-framework-smallcheck text time transformers transformers-base
+    unordered-containers xmlhtml
+  ];
+  homepage = "http://snapframework.com/";
+  description = "Top-level package for the Snap Web Framework";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/snap-core-1.0.3.2.nix
+++ b/nix/snap-core-1.0.3.2.nix
@@ -1,0 +1,35 @@
+{ mkDerivation, attoparsec, base, bytestring, bytestring-builder
+, case-insensitive, containers, deepseq, directory, filepath
+, hashable, HUnit, io-streams, lifted-base, monad-control, mtl
+, network, network-uri, old-locale, parallel, QuickCheck, random
+, readable, regex-posix, stdenv, test-framework
+, test-framework-hunit, test-framework-quickcheck2, text, time
+, transformers, transformers-base, unix-compat
+, unordered-containers, vector, zlib
+}:
+mkDerivation {
+  pname = "snap-core";
+  version = "1.0.3.2";
+  sha256 = "4c4398476fe882122ce8adc03f69509588d071fc011f50162cd69706093dd88c";
+  revision = "3";
+  editedCabalFile = "0wlhn33r7c9g7j23y006ddq9d87lkmianvvfrbl8jd8mvjvj2gfa";
+  libraryHaskellDepends = [
+    attoparsec base bytestring bytestring-builder case-insensitive
+    containers directory filepath hashable HUnit io-streams lifted-base
+    monad-control mtl network network-uri old-locale random readable
+    regex-posix text time transformers transformers-base unix-compat
+    unordered-containers vector
+  ];
+  testHaskellDepends = [
+    attoparsec base bytestring bytestring-builder case-insensitive
+    containers deepseq directory filepath hashable HUnit io-streams
+    lifted-base monad-control mtl network network-uri old-locale
+    parallel QuickCheck random readable regex-posix test-framework
+    test-framework-hunit test-framework-quickcheck2 text time
+    transformers transformers-base unix-compat unordered-containers
+    vector zlib
+  ];
+  homepage = "http://snapframework.com/";
+  description = "Snap: A Haskell Web Framework (core interfaces and types)";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/snap-server-1.1.0.0.nix
+++ b/nix/snap-server-1.1.0.0.nix
@@ -1,0 +1,41 @@
+{ mkDerivation, attoparsec, base, base16-bytestring, blaze-builder
+, bytestring, bytestring-builder, case-insensitive, clock
+, containers, criterion, deepseq, directory, filepath, HsOpenSSL
+, http-common, http-streams, HUnit, io-streams, io-streams-haproxy
+, lifted-base, monad-control, mtl, network, old-locale
+, openssl-streams, parallel, QuickCheck, random, snap-core, stdenv
+, test-framework, test-framework-hunit, test-framework-quickcheck2
+, text, threads, time, transformers, unix, unix-compat, vector
+}:
+mkDerivation {
+  pname = "snap-server";
+  version = "1.1.0.0";
+  sha256 = "249ea390a4e54899b310c0dd13b91af007a2b685bd0d9769c3e208dd914d7c6f";
+  revision = "3";
+  editedCabalFile = "0a9d3nqb5rvgm25nak68lp6yj9m6cwhbgdbg5l7ib5i2czcg7yjh";
+  configureFlags = [ "-fopenssl" ];
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    attoparsec base blaze-builder bytestring bytestring-builder
+    case-insensitive clock containers filepath HsOpenSSL io-streams
+    io-streams-haproxy lifted-base mtl network old-locale
+    openssl-streams snap-core text time unix unix-compat vector
+  ];
+  testHaskellDepends = [
+    attoparsec base base16-bytestring blaze-builder bytestring
+    bytestring-builder case-insensitive clock containers deepseq
+    directory filepath HsOpenSSL http-common http-streams HUnit
+    io-streams io-streams-haproxy lifted-base monad-control mtl network
+    old-locale openssl-streams parallel QuickCheck random snap-core
+    test-framework test-framework-hunit test-framework-quickcheck2 text
+    threads time transformers unix unix-compat vector
+  ];
+  benchmarkHaskellDepends = [
+    attoparsec base blaze-builder bytestring bytestring-builder
+    criterion io-streams io-streams-haproxy snap-core vector
+  ];
+  homepage = "http://snapframework.com/";
+  description = "A web server for the Snap Framework";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/sop-core-0.4.0.0.nix
+++ b/nix/sop-core-0.4.0.0.nix
@@ -1,0 +1,9 @@
+{ mkDerivation, base, deepseq, stdenv }:
+mkDerivation {
+  pname = "sop-core";
+  version = "0.4.0.0";
+  sha256 = "a381b0efb8e2dedb6627da6adb0a2b72421f87d43d9b53d68d5b2e866015911d";
+  libraryHaskellDepends = [ base deepseq ];
+  description = "True Sums of Products";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/swagger2-2.3.1.nix
+++ b/nix/swagger2-2.3.1.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, aeson, base, base-compat-batteries, bytestring
+, Cabal, cabal-doctest, containers, cookie, doctest, generics-sop
+, Glob, hashable, hspec, hspec-discover, http-media, HUnit
+, insert-ordered-containers, lens, mtl, network, QuickCheck
+, quickcheck-instances, scientific, stdenv, template-haskell, text
+, time, transformers, transformers-compat, unordered-containers
+, utf8-string, uuid-types, vector
+}:
+mkDerivation {
+  pname = "swagger2";
+  version = "2.3.1";
+  sha256 = "c61fa150dfd4e6f8c17ef66044b7fd1c15f404fc7a91e4dae25e9fb41789271c";
+  setupHaskellDepends = [ base Cabal cabal-doctest ];
+  libraryHaskellDepends = [
+    aeson base base-compat-batteries bytestring containers cookie
+    generics-sop hashable http-media insert-ordered-containers lens mtl
+    network QuickCheck scientific template-haskell text time
+    transformers transformers-compat unordered-containers uuid-types
+    vector
+  ];
+  testHaskellDepends = [
+    aeson base base-compat-batteries bytestring containers doctest Glob
+    hashable hspec HUnit insert-ordered-containers lens mtl QuickCheck
+    quickcheck-instances template-haskell text time
+    unordered-containers utf8-string vector
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/GetShopTV/swagger2";
+  description = "Swagger 2.0 data model";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/tagged-0.8.6.nix
+++ b/nix/tagged-0.8.6.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, deepseq, stdenv, template-haskell
+, transformers
+}:
+mkDerivation {
+  pname = "tagged";
+  version = "0.8.6";
+  sha256 = "ad16def0884cf6f05ae1ae8e90192cf9d8d9673fa264b249499bd9e4fac791dd";
+  libraryHaskellDepends = [
+    base deepseq template-haskell transformers
+  ];
+  homepage = "http://github.com/ekmett/tagged";
+  description = "Haskell 98 phantom types to avoid unsafely passing dummy arguments";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/tasty-1.2.nix
+++ b/nix/tasty-1.2.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, ansi-terminal, async, base, clock, containers, mtl
+, optparse-applicative, stdenv, stm, tagged, unbounded-delays, unix
+, wcwidth
+}:
+mkDerivation {
+  pname = "tasty";
+  version = "1.2";
+  sha256 = "d6185e079ac9c12068582cc6f5b50d37a3d2d3ed1a05a4db454340350b5d8317";
+  libraryHaskellDepends = [
+    ansi-terminal async base clock containers mtl optparse-applicative
+    stm tagged unbounded-delays unix wcwidth
+  ];
+  homepage = "https://github.com/feuerbach/tasty";
+  description = "Modern and extensible testing framework";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/tasty-ant-xml-1.1.5.nix
+++ b/nix/tasty-ant-xml-1.1.5.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, containers, directory, filepath
+, generic-deriving, ghc-prim, mtl, stdenv, stm, tagged, tasty
+, transformers, xml
+}:
+mkDerivation {
+  pname = "tasty-ant-xml";
+  version = "1.1.5";
+  sha256 = "62ccee94bc5c3d7c6ed99037788262d8d971eeac487fe43b06760f969430a5df";
+  libraryHaskellDepends = [
+    base containers directory filepath generic-deriving ghc-prim mtl
+    stm tagged tasty transformers xml
+  ];
+  homepage = "http://github.com/ocharles/tasty-ant-xml";
+  description = "Render tasty output to XML for Jenkins";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/tasty-expected-failure-0.11.1.1.nix
+++ b/nix/tasty-expected-failure-0.11.1.1.nix
@@ -1,0 +1,12 @@
+{ mkDerivation, base, stdenv, tagged, tasty }:
+mkDerivation {
+  pname = "tasty-expected-failure";
+  version = "0.11.1.1";
+  sha256 = "519a5c0d2ef9dd60355479f11ca47423133364f20ad3151f3c8b105313405ac4";
+  revision = "1";
+  editedCabalFile = "1b3fn7d3zwhhwm3gp8cmmsdcrvn9dhshd665xrx1mk6cmy4m8k16";
+  libraryHaskellDepends = [ base tagged tasty ];
+  homepage = "http://github.com/nomeata/tasty-expected-failure";
+  description = "Mark tasty tests as failure expected";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/tasty-hedgehog-0.2.0.0.nix
+++ b/nix/tasty-hedgehog-0.2.0.0.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, hedgehog, stdenv, tagged, tasty
+, tasty-expected-failure
+}:
+mkDerivation {
+  pname = "tasty-hedgehog";
+  version = "0.2.0.0";
+  sha256 = "5a107fc3094efc50663e4634331a296281318b38c9902969c2d2d215d754a182";
+  revision = "6";
+  editedCabalFile = "0d7s1474pvnyad6ilr5rvpama7s468ya9ns4ksbl0827z9vvga43";
+  libraryHaskellDepends = [ base hedgehog tagged tasty ];
+  testHaskellDepends = [
+    base hedgehog tasty tasty-expected-failure
+  ];
+  homepage = "https://github.com/qfpl/tasty-hedgehog";
+  description = "Integration for tasty and hedgehog";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/tasty-hspec-1.1.5.1.nix
+++ b/nix/tasty-hspec-1.1.5.1.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, hspec, hspec-core, QuickCheck, stdenv, tasty
+, tasty-quickcheck, tasty-smallcheck
+}:
+mkDerivation {
+  pname = "tasty-hspec";
+  version = "1.1.5.1";
+  sha256 = "fe889ec0f7b3991c46a07d9ff9cf09608a73a18f434a7480d2a09c79e56f3345";
+  revision = "1";
+  editedCabalFile = "18k4p273qnvfmk5cbm89rjqr0v03v0q22q7bbl7z3bxpwnnkmhqf";
+  libraryHaskellDepends = [
+    base hspec hspec-core QuickCheck tasty tasty-quickcheck
+    tasty-smallcheck
+  ];
+  homepage = "https://github.com/mitchellwrosen/tasty-hspec";
+  description = "Hspec support for the Tasty test framework";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/test-framework-quickcheck2-0.3.0.5.nix
+++ b/nix/test-framework-quickcheck2-0.3.0.5.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, extensible-exceptions, QuickCheck, random
+, stdenv, test-framework
+}:
+mkDerivation {
+  pname = "test-framework-quickcheck2";
+  version = "0.3.0.5";
+  sha256 = "c9f678d4ec30599172eb887031f0bce2012b532daeb713836bd912bff64eee59";
+  libraryHaskellDepends = [
+    base extensible-exceptions QuickCheck random test-framework
+  ];
+  homepage = "http://haskell.github.io/test-framework/";
+  description = "QuickCheck-2 support for the test-framework package";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/th-expand-syns-0.4.4.0.nix
+++ b/nix/th-expand-syns-0.4.4.0.nix
@@ -1,0 +1,13 @@
+{ mkDerivation, base, containers, stdenv, syb, template-haskell }:
+mkDerivation {
+  pname = "th-expand-syns";
+  version = "0.4.4.0";
+  sha256 = "cc0f52d1364ace9ba56f51afd9106a5fe01ed3f5ae45c958c1b0f83be0a6f906";
+  revision = "1";
+  editedCabalFile = "1zbdg3hrqv7rzlsrw4a2vjr3g4nzny32wvjcpxamlvx77b1jvsw9";
+  libraryHaskellDepends = [ base containers syb template-haskell ];
+  testHaskellDepends = [ base template-haskell ];
+  homepage = "https://github.com/DanielSchuessler/th-expand-syns";
+  description = "Expands type synonyms in Template Haskell ASTs";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/these-0.7.5.nix
+++ b/nix/these-0.7.5.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, aeson, base, bifunctors, binary, containers
+, data-default-class, deepseq, hashable, keys, mtl, profunctors
+, QuickCheck, quickcheck-instances, semigroupoids, stdenv, tasty
+, tasty-quickcheck, transformers, transformers-compat
+, unordered-containers, vector, vector-instances
+}:
+mkDerivation {
+  pname = "these";
+  version = "0.7.5";
+  sha256 = "dbac2412ad609d2ccd180722ac73a3f0fb2df300460a78d687660135efec35fb";
+  libraryHaskellDepends = [
+    aeson base bifunctors binary containers data-default-class deepseq
+    hashable keys mtl profunctors QuickCheck semigroupoids transformers
+    transformers-compat unordered-containers vector vector-instances
+  ];
+  testHaskellDepends = [
+    aeson base bifunctors binary containers hashable QuickCheck
+    quickcheck-instances tasty tasty-quickcheck transformers
+    unordered-containers vector
+  ];
+  homepage = "https://github.com/isomorphism/these";
+  description = "An either-or-both data type & a generalized 'zip with padding' typeclass";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/time-locale-compat-0.1.1.5.nix
+++ b/nix/time-locale-compat-0.1.1.5.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, old-locale, stdenv, time }:
+mkDerivation {
+  pname = "time-locale-compat";
+  version = "0.1.1.5";
+  sha256 = "07ff1566de7d851423a843b2de385442319348c621d4f779b3d365ce91ac502c";
+  libraryHaskellDepends = [ base old-locale time ];
+  homepage = "https://github.com/khibino/haskell-time-locale-compat";
+  description = "Compatibile module for time-format locale";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/tree-diff-0.0.2.nix
+++ b/nix/tree-diff-0.0.2.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, aeson, ansi-terminal, ansi-wl-pprint, base
+, base-compat, bytestring, containers, generics-sop, hashable
+, MemoTrie, parsec, parsers, pretty, QuickCheck, scientific, stdenv
+, tagged, tasty, tasty-golden, tasty-quickcheck, text, time
+, trifecta, unordered-containers, uuid-types, vector
+}:
+mkDerivation {
+  pname = "tree-diff";
+  version = "0.0.2";
+  sha256 = "f8690bd14977f66292759f432a9f0d1b15f00b37001e7c4ea1a04c3fa38a9b7e";
+  libraryHaskellDepends = [
+    aeson ansi-terminal ansi-wl-pprint base base-compat bytestring
+    containers generics-sop hashable MemoTrie parsec parsers pretty
+    QuickCheck scientific tagged text time unordered-containers
+    uuid-types vector
+  ];
+  testHaskellDepends = [
+    ansi-terminal ansi-wl-pprint base base-compat parsec QuickCheck
+    tasty tasty-golden tasty-quickcheck trifecta
+  ];
+  homepage = "https://github.com/phadej/tree-diff";
+  description = "Diffing of (expression) trees";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/universum-iohk.nix
+++ b/nix/universum-iohk.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, base, bytestring, containers, deepseq, doctest
+, fetchgit, fmt, formatting, gauge, ghc-prim, Glob, hashable
+, hedgehog, microlens, microlens-mtl, mtl, safe-exceptions, stdenv
+, stm, tasty, tasty-hedgehog, text, transformers, type-operators
+, unordered-containers, utf8-string, vector
+}:
+mkDerivation {
+  pname = "universum";
+  version = "1.2.0";
+  src = fetchgit {
+    url = "https://github.com/input-output-hk/universum";
+    sha256 = "12ppiszywj0dsspwlhb8bzhsrlgszk8rvlhcy8il3ppz99mlnw5g";
+    rev = "7f1b2483f71cacdfd032fe447064d6e0a1df50fc";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    base bytestring containers deepseq fmt formatting ghc-prim hashable
+    microlens microlens-mtl mtl safe-exceptions stm text transformers
+    type-operators unordered-containers utf8-string vector
+  ];
+  testHaskellDepends = [
+    base bytestring doctest Glob hedgehog tasty tasty-hedgehog text
+    utf8-string
+  ];
+  benchmarkHaskellDepends = [
+    base containers gauge unordered-containers
+  ];
+  homepage = "https://github.com/serokell/universum";
+  description = "Custom prelude used in Serokell";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/unliftio-0.2.10.nix
+++ b/nix/unliftio-0.2.10.nix
@@ -1,0 +1,24 @@
+{ mkDerivation, async, base, containers, deepseq, directory
+, filepath, gauge, hspec, process, QuickCheck, stdenv, stm, time
+, transformers, unix, unliftio-core
+}:
+mkDerivation {
+  pname = "unliftio";
+  version = "0.2.10";
+  sha256 = "141d6e858f3c340c881d9853a38076ca09306e45a02fffc36885b9ee11cf1b5c";
+  libraryHaskellDepends = [
+    async base deepseq directory filepath process stm time transformers
+    unix unliftio-core
+  ];
+  testHaskellDepends = [
+    async base containers deepseq directory filepath hspec process
+    QuickCheck stm time transformers unix unliftio-core
+  ];
+  benchmarkHaskellDepends = [
+    async base deepseq directory filepath gauge process stm time
+    transformers unix unliftio-core
+  ];
+  homepage = "https://github.com/fpco/unliftio/tree/master/unliftio#readme";
+  description = "The MonadUnliftIO typeclass for unlifting monads to IO (batteries included)";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/unliftio-core-0.1.2.0.nix
+++ b/nix/unliftio-core-0.1.2.0.nix
@@ -1,0 +1,12 @@
+{ mkDerivation, base, stdenv, transformers }:
+mkDerivation {
+  pname = "unliftio-core";
+  version = "0.1.2.0";
+  sha256 = "24c38b3d610ca2642ed496d1de3d7b6b398ce0410aa0a15f3c7ce636ba8f7a78";
+  revision = "1";
+  editedCabalFile = "0s6xfg9d0i3sfil5gjbamlq017wdxa69csk73bcqjkficg43vm29";
+  libraryHaskellDepends = [ base transformers ];
+  homepage = "https://github.com/fpco/unliftio/tree/master/unliftio-core#readme";
+  description = "The MonadUnliftIO typeclass for unlifting monads to IO";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/unordered-containers-0.2.10.0.nix
+++ b/nix/unordered-containers-0.2.10.0.nix
@@ -1,0 +1,22 @@
+{ mkDerivation, base, bytestring, ChasingBottoms, containers
+, criterion, deepseq, deepseq-generics, hashable, hashmap, HUnit
+, mtl, QuickCheck, random, stdenv, test-framework
+, test-framework-hunit, test-framework-quickcheck2
+}:
+mkDerivation {
+  pname = "unordered-containers";
+  version = "0.2.10.0";
+  sha256 = "65f117bdbdea9efc75fb9fd539873de7687e005d8898bb21821020a4b383c573";
+  libraryHaskellDepends = [ base deepseq hashable ];
+  testHaskellDepends = [
+    base ChasingBottoms containers hashable HUnit QuickCheck
+    test-framework test-framework-hunit test-framework-quickcheck2
+  ];
+  benchmarkHaskellDepends = [
+    base bytestring containers criterion deepseq deepseq-generics
+    hashable hashmap mtl random
+  ];
+  homepage = "https://github.com/tibbe/unordered-containers";
+  description = "Efficient hashing-based container types";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/wai-extra-3.0.24.3.nix
+++ b/nix/wai-extra-3.0.24.3.nix
@@ -1,0 +1,28 @@
+{ mkDerivation, aeson, ansi-terminal, base, base64-bytestring
+, bytestring, case-insensitive, containers, cookie
+, data-default-class, deepseq, directory, fast-logger, hspec
+, http-types, HUnit, iproute, network, old-locale, resourcet
+, stdenv, streaming-commons, text, time, transformers, unix
+, unix-compat, vault, void, wai, wai-logger, word8, zlib
+}:
+mkDerivation {
+  pname = "wai-extra";
+  version = "3.0.24.3";
+  sha256 = "41e8f93ff03947623f5b447c71806f07819e1006f8267c84fd050e89fbafc439";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson ansi-terminal base base64-bytestring bytestring
+    case-insensitive containers cookie data-default-class deepseq
+    directory fast-logger http-types iproute network old-locale
+    resourcet streaming-commons text time transformers unix unix-compat
+    vault void wai wai-logger word8 zlib
+  ];
+  testHaskellDepends = [
+    base bytestring case-insensitive cookie fast-logger hspec
+    http-types HUnit resourcet text time transformers wai zlib
+  ];
+  homepage = "http://github.com/yesodweb/wai";
+  description = "Provides some basic WAI handlers and middleware";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/warp-3.2.25.nix
+++ b/nix/warp-3.2.25.nix
@@ -1,0 +1,34 @@
+{ mkDerivation, array, async, auto-update, base, bsb-http-chunked
+, bytestring, case-insensitive, containers, directory, doctest
+, gauge, ghc-prim, hashable, hspec, http-client, http-date
+, http-types, http2, HUnit, iproute, lifted-base, network, process
+, QuickCheck, silently, simple-sendfile, stdenv, stm
+, streaming-commons, text, time, transformers, unix, unix-compat
+, vault, wai, word8
+}:
+mkDerivation {
+  pname = "warp";
+  version = "3.2.25";
+  sha256 = "7e0b8f2c6f156b5969832923e16fbf87cd1ac20678c5c03ce77cb094f44a8566";
+  libraryHaskellDepends = [
+    array async auto-update base bsb-http-chunked bytestring
+    case-insensitive containers ghc-prim hashable http-date http-types
+    http2 iproute network simple-sendfile stm streaming-commons text
+    unix unix-compat vault wai word8
+  ];
+  testHaskellDepends = [
+    array async auto-update base bsb-http-chunked bytestring
+    case-insensitive containers directory doctest ghc-prim hashable
+    hspec http-client http-date http-types http2 HUnit iproute
+    lifted-base network process QuickCheck silently simple-sendfile stm
+    streaming-commons text time transformers unix unix-compat vault wai
+    word8
+  ];
+  benchmarkHaskellDepends = [
+    auto-update base bytestring containers gauge hashable http-date
+    http-types network unix unix-compat
+  ];
+  homepage = "http://github.com/yesodweb/wai";
+  description = "A fast, light-weight web server for WAI applications";
+  license = stdenv.lib.licenses.mit;
+}

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -2,6 +2,7 @@ name:                ouroboros-consensus
 version:             0.1.0.0
 synopsis:            Consensus layer for the Ouroboros blockchain protocol
 -- description:
+license:             MIT
 license-file:        LICENSE
 author:              IOHK Engineering Team
 maintainer:          operations@iohk.io

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
@@ -104,9 +104,6 @@ instance (MonadFork (SimFS m) , MonadSTM m) => MonadSTM (SimFS m) where
   newTBQueue        = lift . newTBQueue
   readTBQueue       = lift . readTBQueue
   writeTBQueue    q = lift . writeTBQueue q
-#if MIN_VERSION_stm(2,5,0)
-  lengthTBQueue     = lift . lengthTBQueue
-#endif
 
 simHasFS :: forall m. MonadSTM m => ErrorHandling FsError m -> HasFS (SimFS m)
 simHasFS err = HasFS {

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns        #-}
 -- | Immutable on-disk database of binary blobs
 --
 -- = Logical format

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -2,6 +2,7 @@ name:                ouroboros-network
 version:             0.1.0.0
 synopsis:            A networking layer for the Ouroboros blockchain protocol
 -- description:
+license:             MIT
 license-file:        LICENSE
 author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts
 maintainer:


### PR DESCRIPTION
The vast majority of this patch is cabal2nix-generated files for dependencies.

It also includes `cardano-sl` packages in `default.nix`. Not strictly necessary, but I use it for the byron adapter branch.