### PR TITLE
Add removeFile to HasFS

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
@@ -88,6 +88,9 @@ data HasFS m = HasFS {
     -- | Check if the path exists and is a file
   , doesFileExist            :: HasCallStack => FsPath -> m Bool
 
+    -- | Remove the file (which must exist)
+  , removeFile               :: HasCallStack => FsPath -> m ()
+
     -- | Error handling
   , hasFsErr :: ErrorHandling FsError m
   }

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
@@ -65,6 +65,8 @@ ioHasFS mount = HasFS {
         Dir.doesFileExist (root fp)
     , createDirectoryIfMissing = \createParent fp -> rethrowFsError fp $
         Dir.createDirectoryIfMissing createParent (root fp)
+    , removeFile = \fp -> rethrowFsError fp $
+        Dir.removeFile (root fp)
     , hasFsErr = EH.exceptions
     }
   where

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/Pure.hs
@@ -54,6 +54,7 @@ pureHasFS err = HasFS {
     , listDirectory            = Mock.listDirectory            err'
     , doesDirectoryExist       = Mock.doesDirectoryExist       err'
     , doesFileExist            = Mock.doesFileExist            err'
+    , removeFile               = Mock.removeFile               err'
     , hasFsErr                 = err'
     }
   where

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
@@ -125,6 +125,7 @@ simHasFS err = HasFS {
     , listDirectory            = Mock.listDirectory            err'
     , doesDirectoryExist       = Mock.doesDirectoryExist       err'
     , doesFileExist            = Mock.doesFileExist            err'
+    , removeFile               = Mock.removeFile               err'
     , hasFsErr                 = err'
     }
   where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS.hs
@@ -77,6 +77,8 @@ tests tmpDir = testGroup "HasFS"
       -- doesDirectoryExist
     , testCase     "doesDirectoryExist yields True  for an existing directory"    test_doesDirectoryExistOK
     , testCase     "doesDirectoryExist yields False for a non-existing directory" test_doesDirectoryExistKO
+
+    , testCase     "removeFile equivalence" test_removeFile
       -- example
     , testCase     "example equivalence" test_example
     ]
@@ -307,3 +309,11 @@ test_doesDirectoryExistOK = withMockFS tryFS (expectFsResult ((@?= True) . fst))
 test_doesDirectoryExistKO :: Assertion
 test_doesDirectoryExistKO = withMockFS tryFS (expectFsResult ((@?= False) . fst )) $ \HasFS{..} _err ->
     doesDirectoryExist ["test-dir"]
+
+test_removeFile :: Assertion
+test_removeFile = apiEquivalenceFs (expectFsResult (@?= False)) $ \HasFS{..} _err -> do
+    let file = ["foo.txt"]
+    h1 <- hOpen file IO.WriteMode
+    hClose h1
+    removeFile file
+    doesFileExist file

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
@@ -130,6 +130,7 @@ data Cmd fp h =
   | ListDirectory      (PathExpr fp)
   | DoesDirectoryExist (PathExpr fp)
   | DoesFileExist      (PathExpr fp)
+  | RemoveFile         (PathExpr fp)
   deriving (Generic, Show, Functor, Foldable, Traversable)
 
 deriving instance SOP.Generic         (Cmd fp h)
@@ -171,6 +172,7 @@ run HasFS{..} = go
     go (ListDirectory      pe  ) = withPE pe (const Strings) $ listDirectory
     go (DoesDirectoryExist pe  ) = withPE pe (const Bool)    $ doesDirectoryExist
     go (DoesFileExist      pe  ) = withPE pe (const Bool)    $ doesFileExist
+    go (RemoveFile         pe  ) = withPE pe (const Unit)    $ removeFile
 
     withPE :: PathExpr FsPath
            -> (FsPath -> a -> Success FsPath (FsHandle m))
@@ -382,6 +384,7 @@ generator Model{..} = oneof $ concat [
         , fmap At $ ListDirectory      <$> genPathExpr
         , fmap At $ DoesDirectoryExist <$> genPathExpr
         , fmap At $ DoesFileExist      <$> genPathExpr
+        , fmap At $ RemoveFile         <$> genPathExpr
         ]
 
     withHandle :: [Gen (Cmd :@ Symbolic)]
@@ -940,6 +943,7 @@ instance (Condense fp, Condense h) => Condense (Cmd fp h) where
       go (ListDirectory fp)        = ["listDirectory", condense fp]
       go (DoesDirectoryExist fp)   = ["doesDirectoryExist", condense fp]
       go (DoesFileExist fp)        = ["doesFileExist", condense fp]
+      go (RemoveFile fp)           = ["removeFile", condense fp]
 
 instance Condense1 r => Condense (Cmd :@ r) where
   condense (At cmd) = condense cmd


### PR DESCRIPTION
This operation is needed for @kderme's  VolatileDB (#163) and the recovery I'm working on for the ImmutableDB (empty or invalid database files should be removed).

See the docstring of `Ouroboros.Storage.FS.Sim.MockFS.removeFile` for more
details.