### PR TITLE
Fix bug in MockFS.hOpen: allow readers after a writer

### DIFF
--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS.hs
@@ -191,8 +191,10 @@ test_hOpenReadContention = apiEquivalenceFs (expectFsResult (@?= ())) $ \HasFS{.
 
 test_hOpenReadWriteContention :: Assertion
 test_hOpenReadWriteContention = apiEquivalenceFs (expectFsResult (@?= ())) $ \HasFS{..} _err -> do
-    h2 <- hOpen ["foo.txt"] IO.WriteMode
+    h0 <- hOpen ["foo.txt"] IO.WriteMode
+    hClose h0
     h1 <- hOpen ["foo.txt"] IO.ReadMode
+    h2 <- hOpen ["foo.txt"] IO.WriteMode
     hClose h1
     hClose h2
 


### PR DESCRIPTION
The MockFS allows a file to be opened by any number of readers, but only by at
most one writer. There was a bug in the check for this: it disallowed opening
a file in write mode when it was already opened in read mode. Instead, it
should disallow opening a file in write mode when it is already opened
in *write* mode.