### PR TITLE
PiplinedYield

### DIFF
--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -115,8 +115,12 @@ runPipelinedPeerSender queue Codec{encode} Channel{send} = go
     go (SenderEffect k) = k >>= go
     go (SenderDone _ x) = return x
 
-    go (SenderYield stok msg receiver k) = do
+    go (PipelinedYield stok msg receiver k) = do
       atomically (writeTBQueue queue (ReceiveHandler receiver))
+      send (encode stok msg)
+      go k
+
+    go (SenderYield stok msg k) = do
       send (encode stok msg)
       go k
 

--- a/typed-protocols/src/Network/TypedProtocol/PingPong/Client.hs
+++ b/typed-protocols/src/Network/TypedProtocol/PingPong/Client.hs
@@ -95,12 +95,12 @@ pingPongClientPeerSender
 
 pingPongClientPeerSender (SendMsgDonePipelined result) =
   -- Send `MsgDone` and complete the protocol
-  SenderYield TokIdle MsgDone ReceiverDone (SenderDone TokDone result)
+  SenderYield TokIdle MsgDone (SenderDone TokDone result)
 
 pingPongClientPeerSender (SendMsgPingPipelined receive next) =
   -- Piplined yield: send `MsgPing`, imediatelly follow with the next step.
   -- Await for a response in a continuation.
-  SenderYield
+  PipelinedYield
     TokIdle
     MsgPing
     -- response handler

--- a/typed-protocols/src/Network/TypedProtocol/Pipelined.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Pipelined.hs
@@ -7,7 +7,7 @@
 
 module Network.TypedProtocol.Pipelined where
 
-import Network.TypedProtocol.Core hiding (Peer(..))
+import Network.TypedProtocol.Core
 
 
 
@@ -43,3 +43,18 @@ data PeerReceiver (pk :: PeerKind) (st :: ps) (stdone :: ps) m where
                  -> (forall st'. Message st st' -> PeerReceiver pk st' stdone m)
                  -> PeerReceiver pk st stdone m
 
+forgetPipelinining
+  :: forall (pk :: PeerKind) (st :: ps) m a. Functor m
+  => PeerSender pk st m a
+  -> Peer pk st m a
+forgetPipelinining (SenderEffect mp)   = Effect (forgetPipelinining <$> mp)
+forgetPipelinining (SenderDone stok a) = Done stok a
+forgetPipelinining (PipelinedYield stok msg recv next) = Yield stok msg (go recv next)
+ where
+  go :: PeerReceiver pk stCurrent stNext m
+     -> PeerSender pk stNext m a
+     -> Peer pk stCurrent m a
+  go (ReceiverEffect mr) next' = Effect (flip go next' <$> mr)
+  go ReceiverDone        next' = forgetPipelinining next'
+  go (ReceiverAwait stok'' f) next' = Await stok'' (flip go next' . f)
+forgetPipelinining (SenderYield stok msg next) = Yield stok msg (forgetPipelinining next)

--- a/typed-protocols/src/Network/TypedProtocol/Pipelined.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Pipelined.hs
@@ -22,10 +22,14 @@ data PeerSender (pk :: PeerKind) (st :: ps) m a where
 
   SenderYield  :: WeHaveAgency pk st
                -> Message st st'
-               -> PeerReceiver pk (st'  :: ps) (st'' :: ps) m
-               -> PeerSender   pk (st'' :: ps) m a
-               -> PeerSender   pk (st   :: ps) m a
+               -> PeerReceiver pk msg (st' :: ps) (st :: ps) m
+               -> PeerSender   pk msg (st  :: ps) m a
+               -> PeerSender   pk msg (st  :: ps) m a
 
+  RebaseYield  :: WeHaveAgency pk st
+               -> Message st st'
+               -> PeerSender pk msg (st' :: ps) m a
+               -> PeerSender pk msg (st :: ps) m a
 
 data PeerReceiver (pk :: PeerKind) (st :: ps) (stdone :: ps) m where
 

--- a/typed-protocols/src/Network/TypedProtocol/Pipelined.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Pipelined.hs
@@ -20,16 +20,17 @@ data PeerSender (pk :: PeerKind) (st :: ps) m a where
                -> a
                -> PeerSender pk st m a
 
+  PipelinedYield
+               :: WeHaveAgency pk st
+               -> Message st st'
+               -> PeerReceiver pk (st' :: ps) (st :: ps) m
+               -> PeerSender   pk (st  :: ps) m a
+               -> PeerSender   pk (st  :: ps) m a
+
   SenderYield  :: WeHaveAgency pk st
                -> Message st st'
-               -> PeerReceiver pk msg (st' :: ps) (st :: ps) m
-               -> PeerSender   pk msg (st  :: ps) m a
-               -> PeerSender   pk msg (st  :: ps) m a
-
-  RebaseYield  :: WeHaveAgency pk st
-               -> Message st st'
-               -> PeerSender pk msg (st' :: ps) m a
-               -> PeerSender pk msg (st :: ps) m a
+               -> PeerSender pk (st' :: ps) m a
+               -> PeerSender pk (st :: ps) m a
 
 data PeerReceiver (pk :: PeerKind) (st :: ps) (stdone :: ps) m where
 


### PR DESCRIPTION
Simplify signature of `PipeliendYield` (previously `SenderYield`) and add another `SenderYield` constructor of `PeerSender`.

This change is necessary for a `SenderPeer` to be able to terminate a protocol.  Currently the `SenderYield` constructor does not allow for that.  The reason is that on a termination message one wants to use `ReceiverDone`, e.g.
```
SenderYield tok MsgDone ReceiverDone (SenderDone result)
```
Assume that `MsgDone :: Message StIdle StDone`, but then `ReceiverDone` will force that `StIdle` and `StDone` are equal, resulting in a type error.

My solution for that is to add another yeild constructor
```
  SenderYield  :: WeHaveAgency pk st
               -> Message st st'
               -> PeerSender pk (st' :: ps) m a
               -> PeerSender pk (st :: ps) m a
```
With `SenderYield` one can use the above snippet to terminate a protocol;

The `PiplinedYield` constructor (previously named as `SenderYield`) can be simplified to (it starts and ends in the same state `st :: ps`):
```
  PipelinedYield
               :: WeHaveAgency pk st
               -> Message st st'
               -> PeerReceiver pk (st' :: ps) (st :: ps) m
               -> PeerSender   pk (st  :: ps) m a
               -> PeerSender   pk (st  :: ps) m a
```