### PR TITLE
Add State Machine Tests for ImmutableDB

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -145,6 +145,7 @@ library
                        time,
                        transformers,
                        vector            >=0.12  && <0.13,
+                       unliftio-core     >=0.1.1 && <0.2,
 
                        QuickCheck        >=2.12 && <2.13
 
@@ -257,9 +258,14 @@ test-suite test-storage
                     Test.Ouroboros.Storage
                     Test.Ouroboros.Storage.Util
                     Test.Ouroboros.Storage.FS
+                    Test.Ouroboros.Storage.FS.Sim.Error
                     Test.Ouroboros.Storage.FS.StateMachine
                     Test.Ouroboros.Storage.ImmutableDB
+                    Test.Ouroboros.Storage.ImmutableDB.CumulEpochSizes
+                    Test.Ouroboros.Storage.ImmutableDB.Model
                     Test.Ouroboros.Storage.ImmutableDB.Sim
+                    Test.Ouroboros.Storage.ImmutableDB.StateMachine
+                    Test.Ouroboros.Storage.ImmutableDB.TestBlock
                     Test.Util.RefEnv
   build-depends:    base,
                     ouroboros-network,
@@ -267,6 +273,7 @@ test-suite test-storage
                     io-sim-classes,
 
                     bifunctors,
+                    binary,
                     bytestring,
                     containers,
                     directory,
@@ -277,12 +284,14 @@ test-suite test-storage
                     QuickCheck,
                     quickcheck-state-machine >=0.6.0,
                     random,
+                    stm,
                     tasty,
                     tasty-hunit,
                     tasty-quickcheck,
                     temporary,
                     transformers,
-                    tree-diff
+                    tree-diff,
+                    unliftio-core
 
   ghc-options:      -Wall
                     -fno-ignore-asserts

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/MockFS.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/MockFS.hs
@@ -46,6 +46,7 @@ module Ouroboros.Storage.FS.Sim.MockFS (
   , OpenHandleState   -- opaque
   , ClosedHandleState -- opaque
   , FilePtr           -- opaque
+  , Files
   , mockFiles
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
@@ -14,9 +14,11 @@ module Ouroboros.Storage.FS.Sim.STM (
     , runSimFS
     , simHasFS
     , liftErrSimFS
+    , Buffer(MockBufferUnused)
     ) where
 
 import           Control.Monad.Catch
+import           Control.Monad.IO.Unlift
 import           Control.Monad.Reader
 import           Control.Monad.State
 import           Data.Proxy
@@ -66,6 +68,12 @@ instance MonadSTM m => MonadState MockFS (SimFS m) where
 
 instance MonadTrans SimFS where
   lift = SimFS . lift
+
+instance MonadIO m => MonadIO (SimFS m) where
+  liftIO = lift . liftIO
+
+instance MonadUnliftIO m => MonadUnliftIO (SimFS m) where
+  withRunInIO = wrappedWithRunInIO SimFS unSimFS
 
 newtype TrSimFS m a = TrSimFS { trSimFS :: m a }
   deriving (Functor, Applicative, Monad)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -124,9 +124,19 @@ data ImmutableDB m = ImmutableDB
       -- new 'Epoch' to start, which must be 'getCurrentEpoch' + 1, so no
       -- skipping allowed.
 
-    -- | When given a start (first argument) and a stop (second argument)
-    -- position (both inclusive bounds), return an 'Iterator' to efficiently
-    -- stream binary blocks out of the database.
+    -- | Return an 'Iterator' to efficiently stream binary blocks out of the
+    -- database.
+    --
+    -- Optionally, a start position (first argument) and/or a stop position
+    -- (second argument) can be given that will be used to determine from
+    -- which 'EpochSlot' streaming will start and/or stop (both inclusive
+    -- bounds).
+    --
+    -- When no start position is given, streaming wil start from the first
+    -- blob in the database. When no stop position is given, streaming will
+    -- stop at the last blob currently in the database. This means that
+    -- appends happening while streaming will not be visible to the iterator.
+    -- (TODO ok?)
     --
     -- Use 'iteratorNext' to stream from the iterator.
     --
@@ -146,8 +156,8 @@ data ImmutableDB m = ImmutableDB
     -- prematurely closed with 'iteratorClose'.
   , streamBinaryBlobs
       :: HasCallStack
-      => EpochSlot
-      -> EpochSlot
+      => Maybe EpochSlot
+      -> Maybe EpochSlot
       -> m (Iterator m)
 
     -- | Throw 'ImmutableDB' errors
@@ -189,8 +199,8 @@ data Iterator m = Iterator
 withIterator :: (HasCallStack, MonadMask m)
              => ImmutableDB m
                 -- ^ The database
-             -> EpochSlot -- ^ Start streaming from here (inclusive)
-             -> EpochSlot -- ^ End streaming here (inclusive)
+             -> Maybe EpochSlot -- ^ Start streaming from here (inclusive)
+             -> Maybe EpochSlot -- ^ End streaming here (inclusive)
              -> (Iterator m -> m a)
                 -- ^ Action to perform using the iterator
              -> m a
@@ -230,8 +240,8 @@ iteratorToList it = go mempty
 -- given range.
 blobProducer :: (Monad m, HasCallStack)
              => ImmutableDB m
-             -> EpochSlot   -- ^ When to start streaming (inclusive).
-             -> EpochSlot   -- ^ When to stop streaming (inclusive).
+             -> Maybe EpochSlot   -- ^ When to start streaming (inclusive).
+             -> Maybe EpochSlot   -- ^ When to stop streaming (inclusive).
              -> Producer (EpochSlot, ByteString) m ()
 blobProducer db start end = do
     it <- lift $ streamBinaryBlobs db start end

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -443,14 +443,15 @@ getBinaryBlobImpl hasFS@HasFS{..} err db@ImmutableDBHandle {..} readEpochSlot = 
             (offsetAfter:offset:_) -> return (offset, offsetAfter - offset)
             _ -> error "impossible: _currentEpochOffsets out of sync"
           where
-            toDrop = fromEnum lastSlot - fromEnum relativeSlot
+            toDrop = fromEnum (lastSlot - relativeSlot)
             lastSlot = _nextExpectedRelativeSlot - 1
 
       -- Otherwise, the offsets will have to be read from an index file
       False -> withFile hasFS indexFile ReadMode $ \iHnd -> do
         -- Grab the offset in bytes of the requested slot.
-        let indexSeekPosition = fromEnum relativeSlot * indexEntrySizeBytes
-        hSeek iHnd AbsoluteSeek (toEnum indexSeekPosition)
+        let indexSeekPosition = fromIntegral (getRelativeSlot relativeSlot)
+                              * fromIntegral indexEntrySizeBytes
+        hSeek iHnd AbsoluteSeek indexSeekPosition
         -- Compute the offset on disk and the blob size.
         let nbBytesToGet = indexEntrySizeBytes * 2
         -- Note the use of hGetRightSize: we must get enough bytes from the

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -618,7 +618,8 @@ streamBinaryBlobsImpl hasFS@HasFS{..} err db@ImmutableDBHandle {..} start end = 
         nextExpectedEpochSlot =
           EpochSlot _currentEpoch _nextExpectedRelativeSlot
 
-    validateIteratorRange err nextExpectedEpochSlot _epochSizes start end
+    validateIteratorRange err nextExpectedEpochSlot
+      (\epoch -> lookupEpochSize err epoch _epochSizes) start end
 
     -- Helper function to open the index file of an epoch.
     let openIndex epoch

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -1,7 +1,8 @@
+{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE TupleSections       #-}
 -- | Immutable on-disk database of binary blobs
 --
 -- = Logical format
@@ -94,26 +95,19 @@
 --
 -- You can use 'isOpen' to check whether a database is open or closed.
 --
--- = (Re)opening the database
---
--- The database can be closed and reopened. However, you cannot reopen the
--- database on a finalised epoch. It is possible to reopen the same epoch the
--- database was appending to the last time it was open. It is not allowed to
--- skip epochs when reopening the database. When opening a database, an error
--- will be thrown if any of the files corresponding to past epochs are
--- missing.
---
--- TODO replace the current 'openDB' with a function to reopen the database at
--- the right place, i.e. the last epoch, looking at the files on disk.
---
---
 -- = Errors
 --
--- Whenever a 'FileSystemError' is thrown during a write operation
+-- Whenever an 'UnexpectedError' is thrown during a write operation
 -- ('appendBinaryBlob', 'startNewEpoch'), the database will be automatically
 -- closed because we can not guarantee a consistent state in the face of file
--- system errors. TODO which guarantees TODO validation + reopen.
+-- system errors. See the 'reopen' operation and the paragraph below about
+-- reopening the database for more information.
 --
+-- = (Re)opening the database
+--
+-- The database can be closed and reopened. In case the database was closed
+-- because of an unexpected error, the same database can be reopened again
+-- with 'reopen' using a 'RecoveryPolicy'.
 --
 -- = Concurrency
 --
@@ -196,24 +190,26 @@
 -- may be reopened on the same epoch to continue appending to it.
 --
 module Ouroboros.Storage.ImmutableDB.Impl
-  ( -- * Opening a database
-    openDB
+  ( openDB, lastEpochOnDisk, openLastEpoch
   ) where
 
-import           Control.Monad (forM_, unless, when, zipWithM_)
-import           Control.Monad.Catch (ExitCase (..), MonadMask, generalBracket)
-import           Control.Monad.Class.MonadSTM (MonadSTM (..))
+import           Control.Exception (assert)
+import           Control.Monad (when, unless, mplus, foldM, forM_, zipWithM_)
+import           Control.Monad.Catch (MonadMask, ExitCase(..), generalBracket)
+import           Control.Monad.Class.MonadSTM (MonadSTM(..))
 
+import           Data.Bifunctor (first)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Builder as BS
 import qualified Data.ByteString.Lazy as BL
+import           Data.Either (isRight)
 import           Data.Function (on)
-import           Data.List (isSuffixOf)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import           Data.Map (Map)
 import qualified Data.Map as Map
-import           Data.Maybe (isJust, fromMaybe)
+import           Data.Maybe (fromMaybe, isJust, mapMaybe)
+import           Data.Set (Set)
 import qualified Data.Set as Set
 
 import           GHC.Stack (HasCallStack, callStack)
@@ -237,7 +233,7 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 
 -- | An opaque handle to an immutable database of binary blobs.
 data ImmutableDBHandle m = ImmutableDBHandle
-    { _dbInternalState :: !(TMVar m (Maybe (InternalState m)))
+    { _dbInternalState :: !(TMVar m (Either ClosedState (OpenState m)))
     , _dbFolder        :: !FsPath
     }
 
@@ -245,7 +241,8 @@ data ImmutableDBHandle m = ImmutableDBHandle
 instance Eq (ImmutableDBHandle m) where
   (==) = (==) `on` _dbFolder
 
-data InternalState m = InternalState
+-- | Internal state when the database is open.
+data OpenState m = OpenState
     { _currentEpoch             :: !Epoch
     -- ^ The current 'Epoch' the immutable store is writing into.
     , _currentEpochWriteHandle  :: !(FsHandle m)
@@ -268,35 +265,54 @@ data InternalState m = InternalState
     -- ^ The ID of the next iterator that will be created.
     }
 
+
+-- | Internal state when the database is closed. This contains data that
+-- should be restored when the database is reopened. Data not present here
+-- will be recovered when reopening.
+data ClosedState = ClosedState
+    { _closedEpochSizes     :: !(Map Epoch EpochSize)
+    -- ^ See '_epochSizes'.
+    , _closedNextIteratorID :: !IteratorID
+    -- ^ See '_nextIteratorID'.
+    , _closedLastEpoch      :: !Epoch
+    -- ^ See '_currentEpoch'.
+    }
+
 {------------------------------------------------------------------------------
   ImmutableDB API
 ------------------------------------------------------------------------------}
 
 -- | Open the database, creating it from scratch if the 'FsPath' points to a
--- non-existing directory.
+-- non-existing directory or reopening an existing one using the given
+-- 'RecoveryPolicy'.
+--
+-- In addition to the database, the 'EpochSlot' of the last blob stored in it
+-- is returned, or 'Nothing' in case the database is empty.
 --
 -- A 'Map' with the size for each epoch (the past epochs and the most recent
--- one) must be passed. When a size is missing for an epoch, a
+-- one) must be passed. When a size is missing for an epoch present on disk, a
 -- 'MissingEpochSizeError' error will be thrown.
 --
 -- The given 'Epoch' is opened for appending. If the given epoch was
--- previously finalised, an 'OpenFinalisedEpochError' error will be thrown. If
--- the epoch is not the first epoch (0), all previous epoch files must be
--- present on disk and have complete indices (excluding the opened epoch). If
--- an epoch or index file is missing, a 'MissingFileError' is thrown. The
--- actual contents of the epoch and index files are not checked.
+-- previously finalised, i.e. there are files corresponding to later epochs,
+-- an 'OpenFinalisedEpochError' error will be thrown, unless the
+-- 'RestoreLastValidEpoch' recovery policy is used.
+--
+-- See 'RecoveryPolicy' for more details on the different policies.
 --
 -- __Note__: To be used in conjunction with 'withDB'.
 openDB :: (HasCallStack, MonadSTM m, MonadMask m)
        => HasFS m
        -> ErrorHandling ImmutableDBError m
-       -> FsPath -> Epoch -> Map Epoch EpochSize
-       -> m (ImmutableDB m)
-openDB hasFS err dbFolder epoch epochSizes = do
-    dbh <- openDBImpl hasFS err dbFolder epoch epochSizes
-    return ImmutableDB
+       -> FsPath -> Epoch -> Map Epoch EpochSize -> RecoveryPolicy e m
+       -> m (ImmutableDB m, Maybe EpochSlot)
+openDB hasFS err dbFolder epoch epochSizes recPol = do
+    (dbh, lastBlobLocation) <-
+      openDBImpl hasFS err dbFolder epoch epochSizes recPol
+    return $ (, lastBlobLocation) $ ImmutableDB
       { closeDB           = closeDBImpl           hasFS     dbh
       , isOpen            = isOpenImpl                      dbh
+      , reopen            = reopenImpl            hasFS err dbh
       , getNextEpochSlot  = getNextEpochSlotImpl        err dbh
       , getBinaryBlob     = getBinaryBlobImpl     hasFS err dbh
       , appendBinaryBlob  = appendBinaryBlobImpl  hasFS err dbh
@@ -305,103 +321,132 @@ openDB hasFS err dbFolder epoch epochSizes = do
       , immutableDBErr    = err
       }
 
+-- | Return the last epoch for which a file is stored on disk.
+--
+-- The file(s) in question are not checked, they might be empty or invalid.
+lastEpochOnDisk :: (HasCallStack, Monad m)
+                => HasFS m
+                -> FsPath
+                -> m (Maybe Epoch)
+lastEpochOnDisk HasFS{..} dbFolder = do
+    filesInDBFolder <- listDirectory dbFolder
+    return $ case mapMaybe extractEpochNumber $ Set.toList filesInDBFolder of
+      [] -> Nothing
+      epochs  -> Just $ maximum epochs
+  where
+    extractEpochNumber :: String -> Maybe Epoch
+    extractEpochNumber s = do
+      ("epoch", epoch) <- parseDBFile s
+      return epoch
+
+-- | Open the database at the last epoch on disk.
+--
+-- Combination of 'openDB' and 'lastEpochOnDisk'.
+openLastEpoch :: (HasCallStack, MonadSTM m, MonadMask m)
+              => HasFS m
+              -> ErrorHandling ImmutableDBError m
+              -> FsPath -> Map Epoch EpochSize -> RecoveryPolicy e m
+              -> m (ImmutableDB m, Maybe EpochSlot)
+openLastEpoch hasFS err dbFolder epochSizes recPol = do
+    epochToOpen <- fromMaybe 0 <$> lastEpochOnDisk hasFS dbFolder
+    openDB hasFS err dbFolder epochToOpen epochSizes recPol
+
 {------------------------------------------------------------------------------
   ImmutableDB Implementation
 ------------------------------------------------------------------------------}
 
-openDBImpl :: forall m. (HasCallStack, MonadSTM m, MonadMask m)
+openDBImpl :: forall m e. (HasCallStack, MonadSTM m, MonadMask m)
            => HasFS m
            -> ErrorHandling ImmutableDBError m
            -> FsPath
            -> Epoch
            -> Map Epoch EpochSize
-           -> m (ImmutableDBHandle m)
-openDBImpl hasFS@HasFS{..} err dbFolder currentEpoch epochSizes = do
-    checkEpochSizes
-    filesInDBFolder <- do
-      createDirectoryIfMissing True dbFolder
-      Set.toList <$> listDirectory dbFolder
-    let datFiles = filter (".dat" `isSuffixOf`) filesInDBFolder
-    checkEpochConsistency datFiles
-    checkPreviousEpochs datFiles
-    case currentEpoch of
-      -- If it is the first epoch, just open it
-      0 -> do
-        st <- mkInternalState hasFS err dbFolder 0 epochSizes initialIteratorId
-        stVar <- atomically $ newTMVar (Just st)
-        return $ ImmutableDBHandle stVar dbFolder
+           -> RecoveryPolicy e m
+           -> m (ImmutableDBHandle m, LastBlobLocation)
+openDBImpl hasFS@HasFS{..} err dbFolder epoch epochSizes recPol = do
+    createDirectoryIfMissing True dbFolder
+    checkEpochSizes epoch
+    (epochToOpen, mbLastBlobLocation) <-
+      recovery hasFS err dbFolder epoch epochSizes recPol
 
-      -- If it is not the first epoch, first open the previous epoch and
-      -- finalise it using 'startNewEpochImpl'.
-      _ -> do
-        st <- mkInternalState hasFS err dbFolder (currentEpoch - 1) epochSizes
-                initialIteratorId
-        stVar <- atomically $ newTMVar (Just st)
-        let db = ImmutableDBHandle stVar dbFolder
-        epochSize <- lookupEpochSize err currentEpoch epochSizes
-        _newEpoch <- startNewEpochImpl hasFS err db epochSize
-        return db
+    st <- mkOpenState hasFS err dbFolder epochToOpen epochSizes initialIteratorId
+
+    stVar <- atomically $ newTMVar (Right st)
+    let db = ImmutableDBHandle stVar dbFolder
+    case mbLastBlobLocation of
+      Just lastBlobLocation -> return (db, lastBlobLocation)
+      Nothing               -> (db,) <$> lastBlobInDB hasFS st dbFolder
   where
-    -- | Check that each @epoch, epoch <= 'currentEpoch'@ is present in
+    -- | Check that each @epoch, epoch <= epochToOpen@ is present in
     -- 'epochSizes'. Report the first missing one starting from epoch 0.
-    checkEpochSizes :: HasCallStack => m ()
-    checkEpochSizes = zipWithM_
+    checkEpochSizes :: HasCallStack => Epoch -> m ()
+    checkEpochSizes epochToOpen = zipWithM_
       (\expected mbActual ->
         case mbActual of
           Just actual | actual == expected -> return ()
           _ -> throwUserError err $ MissingEpochSizeError expected)
-      [0..currentEpoch]
+      [0..epochToOpen]
       -- Pad with 'Nothing's to stop early termination of 'zipWithM_'
       (map (Just . fst) (Map.toAscList epochSizes) ++ repeat Nothing)
-
-    -- | Check that there is no newer epoch than the one we're opening
-    checkEpochConsistency :: HasCallStack => [String] -> m ()
-    checkEpochConsistency = mapM_ $ \name -> case parseEpochNumber name of
-      Just n | n > currentEpoch ->
-        throwUserError err $ OpenFinalisedEpochError currentEpoch n
-      _ -> return ()
-
-    -- | Check if all previous epochs have index and epoch files.
-    checkPreviousEpochs :: HasCallStack
-                        => [String] -> m ()
-    checkPreviousEpochs datFiles = do
-      let fileSet = Set.fromList datFiles
-      forM_ (Map.toAscList epochSizes) $ \(epoch, _epochSize) ->
-        -- checkEpochConsistency has already checked that there are no files
-        -- for a later epoch. This check just excludes the current epoch file,
-        -- which can be new and may not exist on disk.
-        when (epoch < currentEpoch) $ do
-          let epochFile = renderFile "epoch" epoch
-              indexFile = renderFile "index" epoch
-          when (head epochFile `Set.notMember` fileSet) $
-            throwUnexpectedError err $ MissingFileError epochFile callStack
-          when (head indexFile `Set.notMember` fileSet) $
-            throwUnexpectedError err $ MissingFileError indexFile callStack
 
 closeDBImpl :: (HasCallStack, MonadSTM m, MonadMask m)
             => HasFS m
             -> ImmutableDBHandle m
             -> m ()
 closeDBImpl hasFS@HasFS{..} ImmutableDBHandle {..} = do
-    mbInternalState <- atomically $ swapTMVar _dbInternalState Nothing
-    case mbInternalState of
+    internalState <- atomically $ takeTMVar _dbInternalState
+    case internalState of
       -- Already closed
-      Nothing -> return ()
-      Just InternalState {..} -> do
+      Left  _ -> atomically $ putTMVar _dbInternalState internalState
+      Right OpenState {..} -> do
+        let closedState = closedStateFromInternalState internalState
+        -- Close the database before doing the file-system operations so that
+        -- in case these fail, we don't leave the database open.
+        atomically $ putTMVar _dbInternalState (Left closedState)
         hClose _currentEpochWriteHandle
         -- Also write an index file of the current (possible incomplete) epoch
         writeSlotOffsets hasFS _dbFolder _currentEpoch _currentEpochOffsets
 
 isOpenImpl :: MonadSTM m => ImmutableDBHandle m -> m Bool
 isOpenImpl ImmutableDBHandle {..} =
-    isJust <$> atomically (readTMVar _dbInternalState)
+    isRight <$> atomically (readTMVar _dbInternalState)
+
+
+-- Note that recovery will stop when an 'FsError' is thrown, as usual.
+reopenImpl :: forall m e. (HasCallStack, MonadSTM m, MonadMask m)
+           => HasFS m
+           -> ErrorHandling ImmutableDBError m
+           -> ImmutableDBHandle m
+           -> RecoveryPolicy e m
+           -> m LastBlobLocation
+reopenImpl hasFS@HasFS{..} err@ErrorHandling{..} ImmutableDBHandle{..} recPol = do
+    internalState <- atomically $ takeTMVar _dbInternalState
+    (openState, mbLastBlobLocation) <- case internalState of
+      -- When still open,
+      Right ost -> do
+        -- Put the state back and do nothing
+        atomically $ putTMVar _dbInternalState internalState
+        return (ost, Nothing)
+      Left ClosedState {..} -> do
+        (epochToReopen, mbLastBlobLocation) <-
+          recovery hasFS err _dbFolder _closedLastEpoch _closedEpochSizes recPol
+        -- TODO the index file is opened again by 'mkOpenState' after we have
+        -- already opened it in 'recovery'. Should we avoid try to avoid this?
+        newOpenState <- mkOpenState hasFS err _dbFolder epochToReopen
+                          _closedEpochSizes _closedNextIteratorID
+        atomically $ putTMVar _dbInternalState (Right newOpenState)
+        return (newOpenState, mbLastBlobLocation)
+    case mbLastBlobLocation of
+      Just lastBlobLocation -> return lastBlobLocation
+      Nothing               -> lastBlobInDB hasFS openState _dbFolder
+
 
 getNextEpochSlotImpl :: (HasCallStack, MonadSTM m)
                      => ErrorHandling ImmutableDBError m
                      -> ImmutableDBHandle m
                      -> m EpochSlot
 getNextEpochSlotImpl err db@ImmutableDBHandle {..} = do
-    InternalState {..} <- getInternalState err db
+    OpenState {..} <- getOpenState err db
     return $ EpochSlot _currentEpoch _nextExpectedRelativeSlot
 
 getBinaryBlobImpl
@@ -413,7 +458,7 @@ getBinaryBlobImpl
   -> m (Maybe ByteString)
 getBinaryBlobImpl hasFS@HasFS{..} err db@ImmutableDBHandle {..} readEpochSlot = do
     let EpochSlot epoch relativeSlot = readEpochSlot
-    InternalState {..} <- getInternalState err db
+    OpenState {..} <- getOpenState err db
 
     -- Check if the requested slot is not in the future.
     let nextExpectedEpochSlot =
@@ -483,8 +528,8 @@ appendBinaryBlobImpl :: (HasCallStack, MonadSTM m, MonadMask m)
                      -> RelativeSlot
                      -> BS.Builder
                      -> m ()
-appendBinaryBlobImpl HasFS{..} err db relativeSlot builder =
-    modifyInternalState err db $ \st@InternalState {..} -> do
+appendBinaryBlobImpl hasFS@HasFS{..} err db relativeSlot builder =
+    modifyOpenState hasFS err db $ \st@OpenState {..} -> do
       let eHnd = _currentEpochWriteHandle
 
       -- Check that the slot is >= the expected next slot and thus not in the
@@ -529,8 +574,8 @@ startNewEpochImpl :: (HasCallStack, MonadSTM m, MonadMask m)
                   -> ImmutableDBHandle m
                   -> EpochSize
                   -> m Epoch
-startNewEpochImpl hasFS@HasFS{..} err db newEpochSize = modifyInternalState err db $ \st -> do
-    let InternalState {..} = st
+startNewEpochImpl hasFS@HasFS{..} err db newEpochSize = modifyOpenState hasFS err db $ \st -> do
+    let OpenState {..} = st
 
     -- We can close the epoch file
     hClose _currentEpochWriteHandle
@@ -557,7 +602,7 @@ startNewEpochImpl hasFS@HasFS{..} err db newEpochSize = modifyInternalState err 
 
     let newEpoch      = succ _currentEpoch
         newEpochSizes = Map.insert newEpoch newEpochSize _epochSizes
-    newState <- mkInternalState
+    newState <- mkOpenState
                   hasFS
                   err
                   (_dbFolder db)
@@ -614,7 +659,7 @@ streamBinaryBlobsImpl :: forall m
                       -> Maybe EpochSlot  -- ^ When to stop streaming (inclusive).
                       -> m (Iterator m)
 streamBinaryBlobsImpl hasFS@HasFS{..} err db@ImmutableDBHandle {..} mbStart mbEnd = do
-    InternalState {..} <- getInternalState err db
+    OpenState {..} <- getOpenState err db
     let nextExpectedEpochSlot =
           EpochSlot _currentEpoch _nextExpectedRelativeSlot
 
@@ -713,8 +758,8 @@ streamBinaryBlobsImpl hasFS@HasFS{..} err db@ImmutableDBHandle {..} mbStart mbEn
             { _it_state = itState
             , _it_end   = end
             }
-      -- Safely increment '_nextIteratorID' in the 'InternalState'.
-      modifyInternalState err db $ \st@InternalState {..} ->
+      -- Safely increment '_nextIteratorID' in the 'OpenState'.
+      modifyOpenState hasFS err db $ \st@OpenState {..} ->
         let it = Iterator
               { iteratorNext  = iteratorNextImpl  hasFS err db ith
               , iteratorClose = iteratorCloseImpl hasFS        ith
@@ -725,7 +770,7 @@ streamBinaryBlobsImpl hasFS@HasFS{..} err db@ImmutableDBHandle {..} mbStart mbEn
   where
     mkEmptyIterator :: m (Iterator m)
     mkEmptyIterator =
-      modifyInternalState err db $ \st@InternalState {..} ->
+      modifyOpenState hasFS err db $ \st@OpenState {..} ->
         let it = Iterator
               { iteratorNext  = return IteratorExhausted
               , iteratorClose = return ()
@@ -791,14 +836,14 @@ iteratorNextImpl hasFS@HasFS{..} err db it@IteratorHandle {..} = do
         -- Epoch exhausted, open the next epoch
         Nothing -> do
           hClose eHnd
-          st <- getInternalState err db
+          st <- getOpenState err db
           openNextNonEmptyEpoch (epoch + 1) st
 
     -- Start opening epochs (starting from the given epoch number) until we
     -- encounter a non-empty one, then update the iterator state accordingly.
     -- If no non-empty epoch can be found, the iterator is closed.
-    openNextNonEmptyEpoch :: Epoch -> InternalState m -> m ()
-    openNextNonEmptyEpoch epoch st@InternalState {..}
+    openNextNonEmptyEpoch :: Epoch -> OpenState m -> m ()
+    openNextNonEmptyEpoch epoch st@OpenState {..}
       | epoch > _epoch _it_end
       = iteratorCloseImpl hasFS it
       | otherwise = do
@@ -850,22 +895,24 @@ iteratorCloseImpl HasFS{..} IteratorHandle {..} = do
   Internal functions
 ------------------------------------------------------------------------------}
 
--- | Create the internal state based on a potentially empty epoch.
+
+-- | Create the internal open state based on a potentially empty epoch.
 --
 -- Open the epoch file for appending. If it already existed, the state is
 -- reconstructed from the index file on disk.
 --
 -- If the existing index file is invalid ('isValidIndex'), an
--- 'InvalidFileError' is thrown.
-mkInternalState :: (HasCallStack, MonadMask m)
-                => HasFS m
-                -> ErrorHandling ImmutableDBError m
-                -> FsPath
-                -> Epoch
-                -> Map Epoch EpochSize
-                -> IteratorID
-                -> m (InternalState m)
-mkInternalState hasFS@HasFS{..} err dbFolder epoch epochSizes nextIteratorID = do
+-- 'InvalidFileError' is thrown. If the size of the epoch file does not match
+-- the last offset in the index file, an 'InvalidFileError' is thrown.
+mkOpenState :: (HasCallStack, MonadMask m)
+            => HasFS m
+            -> ErrorHandling ImmutableDBError m
+            -> FsPath
+            -> Epoch
+            -> Map Epoch EpochSize
+            -> IteratorID
+            -> m (OpenState m)
+mkOpenState hasFS@HasFS{..} err dbFolder epoch epochSizes nextIteratorID = do
     let epochFile = dbFolder <> renderFile "epoch" epoch
         indexFile = dbFolder <> renderFile "index" epoch
     indexExists  <- doesFileExist indexFile
@@ -893,21 +940,27 @@ mkInternalState hasFS@HasFS{..} err dbFolder epoch epochSizes nextIteratorID = d
     let nextExpectedRelativeSlot :: RelativeSlot
         nextExpectedRelativeSlot = fromIntegral (length epochOffsets - 1)
     epochSize <- lookupEpochSize err epoch epochSizes
-    when (nextExpectedRelativeSlot >= fromIntegral epochSize) $
+    -- Note that when the file is finalised, 'nextExpectedRelativeSlot' will
+    -- be equal to 'epochSize'. This is valid, the user should call
+    -- 'startNewEpoch' with an epoch size.
+    when (nextExpectedRelativeSlot > fromIntegral epochSize) $
       throwUserError err $ SlotGreaterThanEpochSizeError
                              nextExpectedRelativeSlot
                              epoch
                              epochSize
 
     eHnd          <- hOpen epochFile AppendMode
-    epochFileSize <- hGetSize eHnd
+    -- If 'hGetSize' fails, 'hClose' the handle, otherwise we leave an open
+    -- handle lying around. This is particularly important for the state
+    -- machine tests.
+    epochFileSize <- EH.onException hasFsErr (hGetSize eHnd) (hClose eHnd)
 
     -- The last offset of the index file must match the epoch file size
     when (epochFileSize /= NE.head epochOffsets) $ do
       hClose eHnd
       throwUnexpectedError err $ InvalidFileError epochFile callStack
 
-    return InternalState
+    return OpenState
       { _currentEpoch             = epoch
       , _currentEpochWriteHandle  = eHnd
       , _currentEpochOffsets      = epochOffsets
@@ -916,19 +969,19 @@ mkInternalState hasFS@HasFS{..} err dbFolder epoch epochSizes nextIteratorID = d
       , _nextIteratorID           = nextIteratorID
       }
 
--- | Get the 'InternalState' of the given database, throw a 'ClosedDBError' in
+-- | Get the 'OpenState' of the given database, throw a 'ClosedDBError' in
 -- case it is closed.
-getInternalState :: (HasCallStack, MonadSTM m)
-                 => ErrorHandling ImmutableDBError m
-                 -> ImmutableDBHandle m
-                 -> m (InternalState m)
-getInternalState err ImmutableDBHandle {..} = do
-    mbInternalState <- atomically (readTMVar _dbInternalState)
-    case mbInternalState of
-       Nothing            -> throwUserError err ClosedDBError
-       Just internalState -> return internalState
+getOpenState :: (HasCallStack, MonadSTM m)
+             => ErrorHandling ImmutableDBError m
+             -> ImmutableDBHandle m
+             -> m (OpenState m)
+getOpenState err ImmutableDBHandle {..} = do
+    internalState <- atomically (readTMVar _dbInternalState)
+    case internalState of
+       Left  _         -> throwUserError err ClosedDBError
+       Right openState -> return openState
 
--- | Modify the internal state of the database.
+-- | Modify the internal state of an open database.
 --
 -- In case the database is closed, a 'ClosedDBError' is thrown.
 --
@@ -942,12 +995,13 @@ getInternalState err ImmutableDBHandle {..} = do
 --
 -- TODO(adn): we should really just use 'MVar' rather than 'TMVar', but we
 -- currently don't have a simulator for code using 'MVar'.
-modifyInternalState :: forall m r. (HasCallStack, MonadSTM m, MonadMask m)
-                    => ErrorHandling ImmutableDBError m
-                    -> ImmutableDBHandle m
-                    -> (InternalState m -> m (InternalState m, r))
-                    -> m r
-modifyInternalState err@ErrorHandling{..} ImmutableDBHandle {..} action = do
+modifyOpenState :: forall m r. (HasCallStack, MonadSTM m, MonadMask m)
+                => HasFS m
+                -> ErrorHandling ImmutableDBError m
+                -> ImmutableDBHandle m
+                -> (OpenState m -> m (OpenState m, r))
+                -> m r
+modifyOpenState HasFS{..} err@ErrorHandling{..} ImmutableDBHandle {..} action = do
     (mr, ()) <- generalBracket open close (EH.try err . mutation)
     case mr of
       Left  e      -> throwError e
@@ -957,33 +1011,361 @@ modifyInternalState err@ErrorHandling{..} ImmutableDBHandle {..} action = do
     -- so that 'close' knows which error is thrown (@Either e (s, r)@ vs. @(s,
     -- r)@).
 
-    open :: m (Maybe (InternalState m))
+    open :: m (Either ClosedState (OpenState m))
     open = atomically $ takeTMVar _dbInternalState
 
-    close :: Maybe (InternalState m)
-          -> ExitCase (Either ImmutableDBError (InternalState m, r))
+    close :: Either ClosedState (OpenState m)
+          -> ExitCase (Either ImmutableDBError (OpenState m, r))
           -> m ()
-    close mbSt ec = atomically $ case ec of
+    close st ec = case ec of
       -- Restore the original state in case of an abort
-      ExitCaseAbort         -> putTMVar _dbInternalState mbSt
+      ExitCaseAbort         -> atomically $ putTMVar _dbInternalState st
       -- In case of an exception, most likely at the HasFS layer, close the DB
       -- for safety.
-      ExitCaseException _ex -> putTMVar _dbInternalState Nothing
+      ExitCaseException _ex -> do
+        atomically $ putTMVar _dbInternalState $
+          Left $ closedStateFromInternalState st
+        closeOpenHandles st
       -- In case of success, update to the newest state
-      ExitCaseSuccess (Right (st', _)) -> putTMVar _dbInternalState (Just st')
+      ExitCaseSuccess (Right (ost, _)) ->
+        atomically $ putTMVar _dbInternalState (Right ost)
       -- In case of an error (not an exception)
-      ExitCaseSuccess (Left (UnexpectedError {})) ->
+      ExitCaseSuccess (Left (UnexpectedError {})) -> do
         -- When unexpected, close the DB for safety
-        putTMVar _dbInternalState Nothing
+        atomically $ putTMVar _dbInternalState $
+          Left $ closedStateFromInternalState st
+        closeOpenHandles st
       ExitCaseSuccess (Left (UserError {})) ->
         -- When a user error, just restore the previous state
-        putTMVar _dbInternalState mbSt
+        atomically $ putTMVar _dbInternalState st
 
     mutation :: HasCallStack
-             => Maybe (InternalState m)
-             -> m (InternalState m, r)
-    mutation Nothing   = throwUserError err ClosedDBError
-    mutation (Just st) = action st
+             => Either ClosedState (OpenState m)
+             -> m (OpenState m, r)
+    mutation (Left _)    = throwUserError err ClosedDBError
+    mutation (Right ost) = action ost
+
+    -- TODO what if this fails?
+    closeOpenHandles :: Either ClosedState (OpenState m) -> m ()
+    closeOpenHandles (Left _) = return ()
+    closeOpenHandles (Right OpenState {..}) = hClose _currentEpochWriteHandle
+
+-- | Create a 'ClosedState' from an internal state, open or closed.
+closedStateFromInternalState :: Either ClosedState (OpenState m)
+                             -> ClosedState
+closedStateFromInternalState (Left cst) = cst
+closedStateFromInternalState (Right OpenState {..}) = ClosedState
+  { _closedEpochSizes     = _epochSizes
+  , _closedNextIteratorID = _nextIteratorID
+  , _closedLastEpoch      = _currentEpoch
+  }
+
+
+-- | The location of the last blob stored in the database. 'Nothing' in case
+-- the database stores no blobs, i.e. is empty.
+--
+-- This type synonyms is meant for internal used, mainly to avoid @'Maybe'
+-- ('Maybe' 'EpochSlot')@.
+type LastBlobLocation = Maybe EpochSlot
+
+-- | Return the 'EpochSlot' corresponding to the last blob stored in the
+-- database. When the database is empty, 'Nothing' is returned.
+--
+-- When the current epoch is still empty, opens the index of the previous
+-- epoch until a filled slot is found.
+lastBlobInDB :: forall m. (HasCallStack, MonadMask m)
+             => HasFS m
+             -> OpenState m
+             -> FsPath
+             -> m LastBlobLocation
+lastBlobInDB hasFS@HasFS{..} OpenState{..} dbFolder
+    | _nextExpectedRelativeSlot > 0
+    = return $ Just $ EpochSlot _currentEpoch (_nextExpectedRelativeSlot - 1)
+    | otherwise
+    = go _currentEpoch
+  where
+    -- | Open previous index files looking for the last filled slot.
+    -- Look at the epoch file /before/ the given epoch.
+    go :: Epoch -> m LastBlobLocation
+    go 0          = return Nothing
+    go epochAfter = do
+      let epoch = epochAfter - 1
+      index <- loadIndex hasFS dbFolder epoch
+      case lastFilledSlot index of
+        Just relSlot -> return $ Just $ EpochSlot epoch relSlot
+        Nothing      -> go epoch
+
+
+-- | Go through all files, making two sets: the set of epoch-xxx.dat
+-- files, and the set of index-xxx.dat files, discarding all others.
+dbFilesOnDisk :: Set String -> (Set Epoch, Set Epoch)
+dbFilesOnDisk = foldr categorise mempty
+  where
+    categorise file fs@(epochFiles, indexFiles) = case parseDBFile file of
+      Just ("epoch", n) -> (Set.insert n epochFiles, indexFiles)
+      Just ("index", n) -> (epochFiles, Set.insert n indexFiles)
+      _                 -> fs
+
+-- | Execute the 'RecoveryPolicy'.
+--
+-- Precondition: the size for each epoch <= the epoch to reopen must be
+-- present in the map of epoch sizes.
+recovery :: forall m e. (HasCallStack, MonadMask m)
+         => HasFS m
+         -> ErrorHandling ImmutableDBError m
+         -> FsPath -> Epoch -> Map Epoch EpochSize
+         -> RecoveryPolicy e m
+         -> m (Epoch, Maybe LastBlobLocation)
+            -- ^ The epoch to (re)open and the last block location if we know
+            -- it.
+recovery hasFS@HasFS{..} err dbFolder epochToReopen epochSizes recPol = do
+    filesInDBFolder <- listDirectory dbFolder
+    let (epochFiles, indexFiles) = dbFilesOnDisk filesInDBFolder
+    case recPol of
+      NoValidation -> do
+        errorOnFilesStartingFrom (succ epochToReopen) epochFiles indexFiles
+        return (epochToReopen, Nothing)
+
+      ValidateMostRecentEpoch epochFileParser
+        | epochToReopen `Set.member`epochFiles -> do
+          -- Epoch file is on disk, so validate it
+          lastBlobLocation <- validateEpochs [epochToReopen] epochFileParser
+          errorOnFilesStartingFrom (succ epochToReopen) epochFiles indexFiles
+          -- When we found the lastBlobLocation, return it. If we didn't find
+          -- it, don't say the 'LastBlobLocation' is Nothing (= empty
+          -- database), because we didn't look at previous epochs. Just say we
+          -- don't know the 'LastBlobLocation'
+          return (epochToReopen, maybe Nothing (Just . Just) lastBlobLocation)
+
+        | otherwise -> do
+          -- No epoch file on disk to validate -> a fresh epoch.
+
+          -- When the index file exists, but the epoch file not, report that
+          -- the latter is missing.
+          let indexFile = dbFolder <> renderFile "index" epochToReopen
+              epochFile = dbFolder <> renderFile "epoch" epochToReopen
+          indexFileExists <- doesFileExist indexFile
+          when indexFileExists $
+            throwUnexpectedError err $ MissingFileError epochFile callStack
+
+          errorOnFilesStartingFrom (succ epochToReopen) epochFiles indexFiles
+          return (epochToReopen, Nothing)
+
+      ValidateAllEpochs epochFileParser -> do
+        lastBlobLocation <- validateEpochs [0..epochToReopen] epochFileParser
+        errorOnFilesStartingFrom (succ epochToReopen) epochFiles indexFiles
+        return (epochToReopen, Just lastBlobLocation)
+
+      RestoreToLastValidEpoch epochFileParser -> do
+        (freshEpochOrEpochToReopen, lastBlobLocation) <-
+           restoreToLastValidEpoch [0..epochToReopen] epochFileParser
+        -- When it's a fresh epoch, remove all files starting from that epoch
+        -- (inclusive), as a left-over index file may be lying around. When
+        -- reopening an epoch, remove all files starting from the next epoch.
+        removeFilesStartingFrom (either id succ freshEpochOrEpochToReopen)
+          epochFiles indexFiles
+        return (either id id freshEpochOrEpochToReopen, Just lastBlobLocation)
+
+  where
+    -- | Returns True when the epoch is finalised. If so, the epoch should not
+    -- be reopened, but the next \"fresh\" epoch (@epoch + 1@) should be
+    -- opened. Also returns the last slot stored in the epoch.
+    --
+    -- Precondition: the epoch file corresponding to the given epoch must
+    -- exist on disk.
+    --
+    -- The index file doesn't have to exist.
+    --
+    -- See inline comments for the exact validation/reparation that is
+    -- performed.
+    validateEpoch :: HasCallStack
+                  => Bool  -- ^ True = repair invalid/missing files, False =
+                           -- throw an error for invalid/missing files
+                  -> Epoch -> EpochFileParser e m (Int, RelativeSlot)
+                  -> m (Bool, Maybe RelativeSlot)
+    validateEpoch repair epoch epochFileParser = do
+      -- According to the precondition, this should never throw a
+      -- 'MissingEpochSizeError'.
+      epochSize <- lookupEpochSize err epoch epochSizes
+
+      let epochFile = dbFolder <> renderFile "epoch" epoch
+      (slotOffsets, mbErr) <- first reconstructSlotOffsets <$>
+        runEpochFileParser epochFileParser epochFile
+      let reconstructedIndex = indexFromSlotOffsets slotOffsets
+
+      -- When an error was reported, it means that the epoch file contained
+      -- some more data that could not be parsed.
+      when (isJust mbErr) $
+        if repair
+          -- Truncate the epoch to get rid of this extra data
+          then withFile hasFS epochFile AppendMode $ \eHnd ->
+                 hTruncate eHnd (NE.head slotOffsets)
+          else throwUnexpectedError err $ InvalidFileError epochFile callStack
+
+      -- Load a valid index file from disk
+      let indexFile = dbFolder <> renderFile "index" epoch
+      mbIndex <- do
+        indexFileExists <- doesFileExist indexFile
+        if indexFileExists
+          then do
+            index <- loadIndex hasFS dbFolder epoch
+            if isValidIndex index
+               && indexSlots index <= epochSize
+               -- Also check that the last offset in the index matches
+               -- that of the reconstructed index.
+               && lastSlotOffset index == NE.head slotOffsets
+              then return $ Just index
+              else if repair
+                then return Nothing
+                else throwUnexpectedError err $
+                     InvalidFileError indexFile callStack
+          else if repair
+            then return Nothing
+            else throwUnexpectedError err $ MissingFileError indexFile callStack
+
+      case mbIndex of
+        -- When the index file on disk matches the reconstructed index, we
+        -- don't have to do anything.
+        Just index | index == reconstructedIndex ->
+          -- We assume the correctness of 'runEpochFileParser', which means
+          -- that @indexSlots reconstructedIndex@ can not be >
+          -- @lastEpochSize@. If this is violated, this will be caught by
+          -- 'mkOpenState' (called after this function) anyway, which will
+          -- throw a 'SlotGreaterThanEpochSizeError'.
+          return ( epochSize == indexSlots reconstructedIndex
+                 , lastFilledSlot reconstructedIndex)
+
+        -- A finalised epoch file might contain unfilled slots at the end,
+        -- which won't be present in the reconstructed index. The index file
+        -- on disk will know about these and will not match the reconstructed
+        -- index. In this case, we will believe the index file as long as the
+        -- reconstructed index is a prefix of the index file.
+        --
+        -- This case also covers a finalised empty epoch, which results in an
+        -- empty epoch file with a non-empty index file.
+        Just index
+          | reconstructedIndex `isPrefixOf` index
+          -> return (epochSize == indexSlots index, lastFilledSlot index)
+
+
+        -- The other cases are: no valid index file on disk or it doesn't
+        -- match the reconstructed index.
+        _ -> do
+          if repair
+            then writeIndex hasFS dbFolder epoch reconstructedIndex
+
+            -- We can get in this case if the index file on disk seems valid,
+            -- but the reconstructed index is not a prefix of it.
+            else throwUnexpectedError err $ InvalidFileError indexFile callStack
+          return ( epochSize == indexSlots reconstructedIndex
+                 , lastFilledSlot reconstructedIndex)
+
+    -- | Validate all the given epochs using 'validateEpoch'. Return the
+    -- location of the last blob stored in the epochs.
+    validateEpochs :: HasCallStack
+                   => [Epoch]
+                   -> EpochFileParser e m (Int, RelativeSlot)
+                   -> m LastBlobLocation
+    validateEpochs epochs epochFileParser = foldM go Nothing epochs
+      where
+        go :: LastBlobLocation -> Epoch -> m LastBlobLocation
+        go lastBlobLocation epoch = do
+          let epochFile = dbFolder <> renderFile "epoch" epoch
+          epochFileExists <- doesFileExist epochFile
+          if epochFileExists
+            then do
+              (_, mbLastFilledSlot) <- validateEpoch False epoch epochFileParser
+              return $ mplus (EpochSlot epoch <$> mbLastFilledSlot)
+                             lastBlobLocation
+            else throwUnexpectedError err $ MissingFileError epochFile callStack
+
+    -- | Validate and try to repair all files in the list of epochs. When an
+    -- epoch is encountered that is not yet finalised, reopen it.
+    --
+    --'Left': fresh epoch that has no corresponding files on disk, or
+    -- rather, it __may__ not have any.
+    --
+    -- 'Right': reopen an epoch that has an epoch file and a (possibly
+    -- reconstructed) index file on disk.
+    restoreToLastValidEpoch :: HasCallStack
+                            => [Epoch]
+                            -> EpochFileParser e m (Int, RelativeSlot)
+                            -> m (Either Epoch Epoch, LastBlobLocation)
+    restoreToLastValidEpoch epochs epochFileParser = go 0 Nothing epochs
+      where
+        go :: Epoch -> LastBlobLocation -> [Epoch]
+           -> m (Either Epoch Epoch, LastBlobLocation)
+        go prevEpoch lastBlobLocation [] =
+          return (Right prevEpoch, lastBlobLocation)
+        go _ lastBlobLocation (epoch:epochs') = do
+          let epochFile = dbFolder <> renderFile "epoch" epoch
+          epochFileExists <- doesFileExist epochFile
+          if not epochFileExists
+            -- If an epoch file is missing (and all the ones before it were
+            -- finalised), open this epoch file as a fresh one.
+            then return (Left epoch, lastBlobLocation)
+            else do
+              (isFinalised, mbLastFilledSlot) <-
+                validateEpoch True epoch epochFileParser
+              let lastBlobLocation' = mplus
+                    (EpochSlot epoch <$> mbLastFilledSlot) lastBlobLocation
+              if isFinalised
+                then go epoch lastBlobLocation' epochs'
+                else return (Right epoch, lastBlobLocation')
+
+    -- | Throw an 'InvalidFileError' for any epoch or index files on disk that
+    -- are from an epoch later than the given one. The two sets indicates
+    -- which epoch/index files are present on disk.
+    errorOnFilesStartingFrom :: HasCallStack
+                             => Epoch -> Set Epoch -> Set Epoch -> m ()
+    errorOnFilesStartingFrom epoch epochFiles indexFiles
+      | Just lastEpoch <- Set.lookupMax epochFiles
+      , lastEpoch > epoch
+      = throwUserError err $ OpenFinalisedEpochError epoch lastEpoch
+      | Just lastIndex <- Set.lookupMax indexFiles
+      , lastIndex > epoch
+      = throwUserError err $ OpenFinalisedEpochError epoch lastIndex
+      | otherwise
+      = return ()
+
+    -- | Remove all epoch and index starting from the given epoch (included).
+    -- The two sets indicates which epoch/index files are present on disk.
+    removeFilesStartingFrom :: Epoch -> Set Epoch -> Set Epoch -> m ()
+    removeFilesStartingFrom epoch epochFiles indexFiles = do
+        forM_ (takeWhile (>= epoch) (Set.toDescList epochFiles)) $ \e ->
+          removeFile (dbFolder <> renderFile "epoch" e)
+        forM_ (takeWhile (>= epoch) (Set.toDescList indexFiles)) $ \i ->
+          removeFile (dbFolder <> renderFile "index" i)
+
+-- | Given a list of increasing 'SlotOffset's together with the 'Int' (blob
+-- size) and 'RelativeSlot' corresponding to the offset, reconstruct a
+-- non-empty list of (decreasing) slot offsets.
+--
+-- The input list (typically returned by 'EpochFileParser') is assumed to be
+-- valid: __strictly__ monotonically increasing offsets as well as
+-- __strictly__ monotonically increasing relative slots.
+--
+-- The 'RelativeSlot's are used to detect empty/unfilled slots that will
+-- result in repeated offsets in the output, indicating that the size of the
+-- slot is 0.
+--
+-- The output list will always have 0 as last element.
+reconstructSlotOffsets :: [(SlotOffset, (Int, RelativeSlot))]
+                       -> NonEmpty SlotOffset
+reconstructSlotOffsets = go 0 [] 0
+  where
+    go :: SlotOffset
+       -> [SlotOffset]
+       -> RelativeSlot
+       -> [(SlotOffset, (Int, RelativeSlot))]
+       -> NonEmpty SlotOffset
+    go offsetAfterLast offsets expectedRelSlot ((offset, (len, relSlot)):olrs') =
+      assert (offsetAfterLast == offset) $
+      assert (relSlot >= expectedRelSlot) $
+      let backfill = indexBackfill relSlot expectedRelSlot offset
+      in go (offset + fromIntegral len) (offset : backfill <> offsets)
+            (succ relSlot) olrs'
+    go offsetAfterLast offsets _lastRelSlot [] = offsetAfterLast NE.:| offsets
 
 -- | Return the slots to backfill the index file with.
 --

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
@@ -14,7 +14,11 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Vector.Unboxed as V
 import           Data.Word (Word64)
 
+import           GHC.Stack (HasCallStack)
+
 import           System.IO (IOMode (..))
+
+import           Ouroboros.Consensus.Util (lastMaybe)
 
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types (FsPath)
@@ -29,7 +33,7 @@ import           Ouroboros.Storage.Util
 
 -- | In-memory representation of the index file.
 newtype Index = MkIndex { getIndex :: V.Vector SlotOffset }
-  deriving (Show)
+  deriving (Show, Eq)
 
 -- | Return the number of slots in the index (the number of offsets - 1).
 indexSlots :: Index -> EpochSize
@@ -41,8 +45,13 @@ indexEntrySizeBytes :: Int
 indexEntrySizeBytes = 8
 {-# INLINE indexEntrySizeBytes #-}
 
+-- | Return the expected size (number of bytes) the given 'Index' requires
+-- when writing it to a file.
+indexExpectedFileSize :: Index -> Int
+indexExpectedFileSize (MkIndex offsets) = V.length offsets * indexEntrySizeBytes
+
 -- | Loads an index file in memory.
-loadIndex :: MonadMask m
+loadIndex :: (HasCallStack, MonadMask m)
           => HasFS m
           -> FsPath
           -> Epoch
@@ -53,12 +62,38 @@ loadIndex hasFS dbFolder epoch = do
       BL.toStrict . BS.toLazyByteString <$> readAll hasFS hnd
     return $ indexFromByteString indexContents
 
--- | Write a non-empty list of 'SlotOffset's to a file.
+-- | Write an index to an index file.
 --
--- Property: for @dbFolder@, @epoch@, and @offsets@:
+-- Property: for @hasFS@, @dbFolder@, @epoch@, and @offsets@:
 --
--- > 'writeSlotOffsets' dbFolder epoch offsets
--- > index <- loadIndex dbFolder epoch
+-- > 'writeIndex' hasFS dbFolder epoch index
+-- > index' <- loadIndex hasFS dbFolder epoch
+--
+-- Then it must be that:
+--
+-- > index === index'
+writeIndex :: MonadMask m
+           => HasFS m
+           -> FsPath
+           -> Epoch
+           -> Index
+           -> m ()
+writeIndex hasFS@HasFS{..} dbFolder epoch (MkIndex offsets) = do
+    let indexFile = dbFolder <> renderFile "index" epoch
+    withFile hasFS indexFile AppendMode $ \iHnd -> do
+      -- NOTE: open it in AppendMode and truncate it first, otherwise we might
+      -- just overwrite part of the data stored in the index file.
+      void $ hTruncate iHnd 0
+      void $ hPut iHnd $ V.foldl'
+        (\acc offset -> acc <> encodeIndexEntry offset) mempty offsets
+  -- TODO efficient enough?
+
+-- | Write a non-empty list of 'SlotOffset's to an index file.
+--
+-- Property: for @hasFS@, @dbFolder@, @epoch@, and @offsets@:
+--
+-- > 'writeSlotOffsets' hasFS dbFolder epoch offsets
+-- > index <- loadIndex hasFS dbFolder epoch
 --
 -- Then it must be that:
 --
@@ -117,7 +152,7 @@ indexToSlotOffsets (MkIndex offsets)
   | otherwise
   = 0 NE.:| []
 
--- | Return the 'SlotOffset' of the last slot in the index file.
+-- | Return the last 'SlotOffset' in the index file.
 lastSlotOffset :: Index -> SlotOffset
 lastSlotOffset (MkIndex offsets)
   | V.null offsets = 0
@@ -206,3 +241,16 @@ filledSlots index = go (firstFilledSlot index)
   where
     go Nothing     = []
     go (Just slot) = slot : go (nextFilledSlot index slot)
+
+-- | Return the last filled slot in the index.
+lastFilledSlot :: Index -> Maybe RelativeSlot
+lastFilledSlot = lastMaybe . filledSlots
+-- TODO optimise
+
+-- | Check if the first 'Index' is a prefix of the second 'Index'.
+isPrefixOf :: Index -> Index -> Bool
+isPrefixOf (MkIndex pre) (MkIndex offsets)
+    | V.length pre > V.length offsets
+    = False
+    | otherwise
+    = V.and $ V.zipWith (==) pre offsets

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
@@ -126,7 +126,7 @@ lastSlotOffset (MkIndex offsets)
 -- | Check whether the given slot is within the index.
 containsSlot :: Index -> RelativeSlot -> Bool
 containsSlot (MkIndex offsets) (RelativeSlot slot) =
-  fromIntegral slot < V.length offsets - 1
+  slot < fromIntegral (V.length offsets) - 1
 
 -- | Return the offset for the given slot is filled.
 --

--- a/ouroboros-consensus/src/Ouroboros/Storage/Util/ErrorHandling.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Util/ErrorHandling.hs
@@ -15,6 +15,7 @@ module Ouroboros.Storage.Util.ErrorHandling (
   , monadError
   , exceptions
   , exceptT
+  , monadCatch
   , embed
   , liftErrNewtype
   , liftErrReader
@@ -23,6 +24,8 @@ module Ouroboros.Storage.Util.ErrorHandling (
 
 import           Control.Exception (Exception)
 import qualified Control.Exception as E
+import           Control.Monad.Catch (MonadCatch)
+import qualified Control.Monad.Catch as C
 import           Control.Monad.Except (ExceptT, MonadError)
 import qualified Control.Monad.Except as M
 import           Control.Monad.Reader (ReaderT (..), runReaderT)
@@ -58,6 +61,12 @@ monadError = ErrorHandling {
 
 exceptT :: Monad m => ErrorHandling e (ExceptT e m)
 exceptT = monadError
+
+monadCatch :: (MonadCatch m, Exception e) => ErrorHandling e m
+monadCatch = ErrorHandling {
+      throwError = C.throwM
+    , catchError = C.catch
+    }
 
 exceptions :: Exception e => ErrorHandling e IO
 exceptions = ErrorHandling {

--- a/ouroboros-consensus/src/Ouroboros/Storage/Util/ErrorHandling.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Util/ErrorHandling.hs
@@ -11,6 +11,7 @@
 module Ouroboros.Storage.Util.ErrorHandling (
     ErrorHandling(..)
   , try
+  , onException
   , monadError
   , exceptions
   , exceptT
@@ -41,6 +42,13 @@ data ErrorHandling e m = ErrorHandling {
 
 try :: Monad m => ErrorHandling e m -> m a -> m (Either e a)
 try ErrorHandling{..} act = (Right <$> act) `catchError` (return . Left)
+
+-- | Like @finally@, but only performs the final action if there was an
+-- exception raised by the computation.
+onException :: Monad m => ErrorHandling e m -> m a -> m b -> m a
+onException ErrorHandling{..} act onEx = act `catchError` \e -> do
+    _ <- onEx
+    throwError e
 
 monadError :: MonadError e m => ErrorHandling e m
 monadError = ErrorHandling {

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
@@ -1,0 +1,640 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+-- | 'HasFS' instance wrapping 'SimFS' that generates errors, suitable for
+-- testing error handling.
+module Test.Ouroboros.Storage.FS.Sim.Error
+  ( -- * Simulate Errors monad
+    SimErrorFS
+  , runSimErrorFS
+  , mkSimErrorHasFS
+  , withErrors
+  , Buffer(MockBufferUnused)
+    -- * Streams
+  , Stream(..)
+  , streamShrink
+  , mkStream
+  , runStream
+  , always
+  , mkStreamGen
+  , ErrorStream
+    -- * Generating corruption for 'hPut'
+  , PutCorruption(..)
+  , corrupt
+    -- * Error streams for 'HasFS'
+  , Errors(..)
+  , simpleErrors
+    -- * Testing examples
+  , mockErrorDemo
+  ) where
+
+import           Control.Monad (replicateM, void)
+import           Control.Monad.Catch (MonadCatch(..), MonadMask(..),
+                                      MonadThrow(..))
+import           Control.Monad.Class.MonadFork (MonadFork)
+import           Control.Monad.Class.MonadSTM (MonadSTM(..))
+import           Control.Monad.Except (runExceptT)
+import           Control.Monad.IO.Unlift (MonadIO(liftIO),
+                                          MonadUnliftIO(withRunInIO),
+                                          wrappedWithRunInIO)
+import           Control.Monad.Reader (ReaderT(ReaderT), ask, runReaderT)
+import           Control.Monad.State (MonadState(state, get))
+import           Control.Monad.Trans (MonadTrans(lift))
+
+import           Data.ByteString.Builder (Builder)
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Lazy as BL
+import           Data.List (intercalate, dropWhileEnd)
+import           Data.Maybe (isNothing, catMaybes)
+import           Data.Proxy (Proxy(..))
+import           Data.Type.Coercion (Coercion(..))
+import           Data.Word (Word64)
+
+import           GHC.Stack (HasCallStack, callStack)
+
+import           Test.QuickCheck (Gen, Arbitrary(..))
+import qualified Test.QuickCheck as QC
+
+import           Ouroboros.Consensus.Util (whenJust)
+
+import           Ouroboros.Storage.FS.API
+import           Ouroboros.Storage.FS.API.Example (example)
+import           Ouroboros.Storage.FS.API.Types
+import           Ouroboros.Storage.FS.Sim.MockFS (MockFS, Handle, handleFsPath)
+import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
+import           Ouroboros.Storage.FS.Sim.STM (SimFS)
+import qualified Ouroboros.Storage.FS.Sim.STM as Sim
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+import           Test.Ouroboros.Storage.Util (Blob(..))
+
+
+
+-- TODO what about FsUnexpectedException? Should we generate those too?
+
+
+{-------------------------------------------------------------------------------
+  Streams
+-------------------------------------------------------------------------------}
+
+-- | A 'Stream' is a possibly infinite stream of @'Maybe' a@s.
+newtype Stream a = Stream { getStream :: [Maybe a] }
+    deriving (Show, Functor)
+
+instance Semigroup (Stream a) where
+  Stream s1 <> Stream s2 = Stream (zipWith pickLast s1 s2)
+    where
+      pickLast (Just x) Nothing = Just x
+      pickLast _        mbY     = mbY
+
+instance Monoid (Stream a) where
+  mempty  = Stream (repeat Nothing)
+  mappend = (<>)
+
+-- | Shrink the given 'Stream' by shrinking the stream itself, not the
+-- individual elements of the stream.
+--
+-- __Note:__ Only works with finite 'Stream's.
+streamShrink :: Stream a -> [Stream a]
+streamShrink (Stream es) = Stream <$> QC.shrinkList (const []) es
+
+-- | Create a 'Stream' based on the given possibly infinite list of @'Maybe'
+-- a@s.
+mkStream :: [Maybe a] -> Stream a
+mkStream = Stream
+
+-- | Advance the 'Stream'. Return the @'Maybe' a@ and the remaining 'Stream'.
+runStream :: Stream a -> (Maybe a, Stream a)
+runStream s@(Stream [])     = (Nothing, s)
+runStream   (Stream (a:as)) = (a, Stream as)
+
+-- | Make a 'Stream' that always generates the given @a@.
+always :: a -> Stream a
+always a = Stream (repeat (Just a))
+
+-- | Make a 'Stream' generator based on a @a@ generator.
+--
+-- The generator generates a finite stream of 10 elements, where each element
+-- has a chance of being either 'Nothing' or an element generated with the
+-- given @a@ generator (wrapped in a 'Just').
+--
+-- The first argument is the likelihood (as used by 'QC.frequency') of a
+-- 'Just' where 'Nothing' has likelihood 2.
+mkStreamGen :: Int -> Gen a -> Gen (Stream a)
+mkStreamGen justLikelihood genA =
+    mkStream . dropWhileEnd isNothing <$> replicateM 10 mbGenA
+  where
+    mbGenA = QC.frequency
+      [ (2, return Nothing)
+      , (justLikelihood, Just <$> genA)
+      ]
+
+-- | An 'ErrorStream' is a possibly infinite 'Stream' of (@Maybe@)
+-- @'FsErrorType'@s.
+--
+-- 'Nothing' indicates that there is no error.
+--
+-- Each time the 'ErrorStream' is used (see 'runErrorStream'), the first
+-- element ('Nothing' in case the list is empty) is taken from the list and an
+-- 'ErrorStream' with the remainder of the list is returned. The first element
+-- represents whether an error should be returned or not.
+--
+-- An 'FsError' consists of a number of fields: 'fsErrorType', a
+-- 'fsErrorPath', etc. Only the first fields is interesting. Therefore, we
+-- only generate the 'FsErrorType'. The 'FsErrorType' will be used to
+-- construct the actual 'FsError'.
+type ErrorStream = Stream FsErrorType
+
+
+{-------------------------------------------------------------------------------
+  Generating corruption for hPut
+-------------------------------------------------------------------------------}
+
+-- | Model possible corruptions that could happen to a 'hPut' call.
+data PutCorruption
+    = SubstituteWithJunk Blob
+      -- ^ The blob to write is substituted with corrupt junk
+    | DropRatioLastBytes Int
+      -- ^ Drop a number of bytes from the end of a blob where the number is
+      -- @n/10@ of the total number bytes the blob is long.
+      --
+      -- As we don't know how long the blobs will be, using an absolute number
+      -- makes less sense, as we might end up dropping everything from each
+      -- blob.
+
+-- When used as part of a QuickCheck tag, it's better to not show the
+-- Blob/Int, otherwise we get a separate tag for each Blob/Int.
+instance Show PutCorruption where
+  show (SubstituteWithJunk _) = "SubstituteWithJunk"
+  show (DropRatioLastBytes _) = "DropRatioLastBytes"
+
+instance Arbitrary PutCorruption where
+  arbitrary = QC.oneof
+      [ SubstituteWithJunk <$> arbitrary
+      , DropRatioLastBytes <$> QC.choose (0, 10)
+      ]
+  shrink (SubstituteWithJunk blob) =
+      [SubstituteWithJunk blob' | blob' <- shrink blob]
+  shrink (DropRatioLastBytes tenths) =
+      [DropRatioLastBytes tenths'  | tenths' <- shrink tenths]
+
+-- | Apply the 'PutCorruption' to the 'Builder'.
+corrupt :: Builder -> PutCorruption -> Builder
+corrupt bld pc = case pc of
+    SubstituteWithJunk blob   -> getBlob blob
+    DropRatioLastBytes tenths -> BS.lazyByteString bs'
+      where
+        bs = BS.toLazyByteString bld
+        toTake :: Double
+        toTake = fromIntegral (BL.length bs) * fromIntegral (10 - tenths) / 10.0
+        bs' = BL.take (round toTake) bs
+
+-- | 'ErrorStream' with possible 'PutCorruption'.
+--
+-- We use a @Maybe@ because not every error needs to be accompanied with data
+-- corruption.
+type ErrorStreamWithCorruption = Stream (FsErrorType, Maybe PutCorruption)
+
+{-------------------------------------------------------------------------------
+  Simulated errors
+-------------------------------------------------------------------------------}
+
+-- | Error streams for the methods of the 'HasFS' type class.
+--
+-- An 'ErrorStream' is provided for each method of the 'HasFS' type class.
+-- This 'ErrorStream' will be used to generate potential errors that will be
+-- thrown by the corresponding method.
+--
+-- For 'hPut', an 'ErrorStreamWithCorruption' is provided to simulate
+-- corruption.
+--
+-- An 'ErrorStreams' is used in conjunction with 'SimErrorFS', which is a layer
+-- on top of 'SimFS' that simulates methods throwing 'FsError's.
+data Errors = Errors
+  { _newBuffer :: ErrorStream
+  , _dumpState :: ErrorStream
+
+    -- Operations on files
+  , _hOpen      :: ErrorStream
+  , _hClose     :: ErrorStream
+  , _hSeek      :: ErrorStream
+  , _hGet       :: ErrorStream
+  , _hPut       :: ErrorStreamWithCorruption
+  , _hPutBuffer :: ErrorStream
+  , _hTruncate  :: ErrorStream
+  , _hGetSize   :: ErrorStream
+
+    -- Operations on directories
+  , _createDirectory          :: ErrorStream
+  , _createDirectoryIfMissing :: ErrorStream
+  , _listDirectory            :: ErrorStream
+  , _doesDirectoryExist       :: ErrorStream
+  , _doesFileExist            :: ErrorStream
+  , _removeFile               :: ErrorStream
+  }
+
+instance Show Errors where
+  show Errors {..} =
+      "Errors {"  <> intercalate ", " streams <> "}"
+    where
+      -- | Show a stream unless it is empty
+      s :: Show a => String -> Stream a -> Maybe String
+      s _   (Stream []) = Nothing
+      -- While the testsuite currently never prints an infinite streams, it's
+      -- better to protect us against it when it were to happen accidentally.
+      s fld (Stream xs) = Just $ fld <> " = " <> show (take 50 xs)
+
+      streams :: [String]
+      streams = catMaybes
+        [ s "_newBuffer"                _newBuffer
+        , s "_dumpState"                _dumpState
+        , s "_hOpen"                    _hOpen
+        , s "_hClose"                   _hClose
+        , s "_hSeek"                    _hSeek
+        , s "_hGet"                     _hGet
+        , s "_hPut"                     _hPut
+        , s "_hPutBuffer"               _hPutBuffer
+        , s "_hTruncate"                _hTruncate
+        , s "_hGetSize"                 _hGetSize
+        , s "_createDirectory"          _createDirectory
+        , s "_createDirectoryIfMissing" _createDirectoryIfMissing
+        , s "_listDirectory"            _listDirectory
+        , s "_doesDirectoryExist"       _doesDirectoryExist
+        , s "_doesFileExist"            _doesFileExist
+        , s "_removeFile"               _removeFile
+        ]
+
+instance Semigroup Errors where
+  egs1 <> egs2 = Errors
+      { _newBuffer                = combine _newBuffer
+      , _dumpState                = combine _dumpState
+      , _hOpen                    = combine _hOpen
+      , _hClose                   = combine _hClose
+      , _hSeek                    = combine _hSeek
+      , _hGet                     = combine _hGet
+      , _hPut                     = combine _hPut
+      , _hPutBuffer               = combine _hPutBuffer
+      , _hTruncate                = combine _hTruncate
+      , _hGetSize                 = combine _hGetSize
+      , _createDirectory          = combine _createDirectory
+      , _createDirectoryIfMissing = combine _createDirectoryIfMissing
+      , _listDirectory            = combine _listDirectory
+      , _doesDirectoryExist       = combine _doesDirectoryExist
+      , _doesFileExist            = combine _doesFileExist
+      , _removeFile               = combine _removeFile
+      }
+    where
+      combine :: (Errors -> Stream a) -> Stream a
+      combine f = f egs1 <> f egs2
+
+instance Monoid Errors where
+  mappend = (<>)
+  mempty = simpleErrors mempty
+
+-- | Use the given 'ErrorStream' for each field/method. No corruption of
+-- 'hPut'.
+simpleErrors :: ErrorStream -> Errors
+simpleErrors es = Errors
+    { _newBuffer                = es
+    , _dumpState                = es
+    , _hOpen                    = es
+    , _hClose                   = es
+    , _hSeek                    = es
+    , _hGet                     = es
+    , _hPut                     = fmap (, Nothing) es
+    , _hPutBuffer               = es
+    , _hTruncate                = es
+    , _hGetSize                 = es
+    , _createDirectory          = es
+    , _createDirectoryIfMissing = es
+    , _listDirectory            = es
+    , _doesDirectoryExist       = es
+    , _doesFileExist            = es
+    , _removeFile               = es
+    }
+
+instance Arbitrary Errors where
+  arbitrary = do
+    let streamGen l = mkStreamGen l . QC.elements
+        -- TODO which errors are possible for these operations below (that
+        -- have dummy for now)?
+        dummy = streamGen 2 [ FsInsufficientPermissions ]
+    _newBuffer          <- dummy
+    _dumpState          <- dummy
+    -- TODO let this one fail:
+    let _hClose = mkStream []
+    _hTruncate          <- dummy
+    _doesDirectoryExist <- dummy
+    _doesFileExist      <- dummy
+    _hOpen <- streamGen 1
+      [ FsResourceDoesNotExist, FsResourceInappropriateType
+      , FsResourceAlreadyInUse, FsResourceAlreadyExist
+      , FsInsufficientPermissions ]
+    _hSeek      <- streamGen 3 [ FsReachedEOF ]
+    _hGet       <- streamGen 3 [ FsReachedEOF ]
+    _hPut       <- mkStreamGen 2 $ (,) <$> return FsDeviceFull <*> arbitrary
+    _hPutBuffer <- streamGen 3 [ FsDeviceFull ]
+    _hGetSize   <- streamGen 2 [ FsResourceDoesNotExist ]
+    _createDirectory <- streamGen 3
+      [ FsInsufficientPermissions, FsResourceInappropriateType
+      , FsResourceAlreadyExist ]
+    _createDirectoryIfMissing <- streamGen 3
+      [ FsInsufficientPermissions, FsResourceInappropriateType
+      , FsResourceAlreadyExist ]
+    _listDirectory <- streamGen 3
+      [ FsInsufficientPermissions, FsResourceInappropriateType
+      , FsResourceDoesNotExist ]
+    _removeFile    <- streamGen 3
+      [ FsInsufficientPermissions, FsResourceAlreadyInUse
+      , FsResourceDoesNotExist, FsResourceInappropriateType ]
+    return Errors {..}
+
+  shrink err@Errors {..} = catMaybes
+      [ (\s' -> err { _newBuffer = s' })                <$> dropLast _newBuffer
+      , (\s' -> err { _dumpState = s' })                <$> dropLast _dumpState
+      , (\s' -> err { _hOpen = s' })                    <$> dropLast _hOpen
+      , (\s' -> err { _hClose = s' })                   <$> dropLast _hClose
+      , (\s' -> err { _hSeek = s' })                    <$> dropLast _hSeek
+      , (\s' -> err { _hGet = s' })                     <$> dropLast _hGet
+      , (\s' -> err { _hPut = s' })                     <$> dropLast _hPut
+      , (\s' -> err { _hPutBuffer = s' })               <$> dropLast _hPutBuffer
+      , (\s' -> err { _hTruncate = s' })                <$> dropLast _hTruncate
+      , (\s' -> err { _hGetSize = s' })                 <$> dropLast _hGetSize
+      , (\s' -> err { _createDirectory = s' })          <$> dropLast _createDirectory
+      , (\s' -> err { _createDirectoryIfMissing = s' }) <$> dropLast _createDirectoryIfMissing
+      , (\s' -> err { _listDirectory = s' })            <$> dropLast _listDirectory
+      , (\s' -> err { _doesDirectoryExist = s' })       <$> dropLast _doesDirectoryExist
+      , (\s' -> err { _doesFileExist = s' })            <$> dropLast _doesFileExist
+      , (\s' -> err { _removeFile = s' })               <$> dropLast _removeFile
+      ]
+    where
+      dropLast :: Stream a -> Maybe (Stream a)
+      dropLast (Stream []) = Nothing
+      dropLast (Stream xs) = Just $ Stream $ zipWith const xs (drop 1 xs)
+
+
+{-------------------------------------------------------------------------------
+  Simulate Errors monad
+-------------------------------------------------------------------------------}
+
+newtype SimErrorFS m a =
+  SimErrorFS { unSimErrorFS :: ReaderT (TVar m Errors) (SimFS m) a }
+  deriving ( Functor
+           , Applicative
+           , Monad
+           , MonadThrow
+           , MonadCatch
+           , MonadMask
+           , MonadFork
+           )
+
+type instance FsHandle (SimErrorFS m) = FsHandle (SimFS m)
+data instance Buffer   (SimErrorFS m) = MockBufferUnused
+
+instance MonadTrans SimErrorFS where
+  lift m = liftSim (lift m)
+
+instance MonadIO m => MonadIO (SimErrorFS m) where
+  liftIO = lift . liftIO
+
+newtype TrSimErrorFS m a = TrSimErrorFS { trSimErrorFS :: m a }
+  deriving (Functor, Applicative, Monad)
+
+instance MonadTrans TrSimErrorFS where
+  lift = TrSimErrorFS
+
+instance MonadUnliftIO m => MonadUnliftIO (SimErrorFS m) where
+  withRunInIO = wrappedWithRunInIO SimErrorFS unSimErrorFS
+
+instance (MonadFork (SimErrorFS m) , MonadSTM m) => MonadSTM (SimErrorFS m) where
+  type Tr (SimErrorFS m)      = TrSimErrorFS (Tr m)
+  type TVar (SimErrorFS m)    = TVar m
+  type TMVar (SimErrorFS m)   = TMVar m
+  type TBQueue (SimErrorFS m) = TBQueue m
+
+  atomically        = lift . atomically . trSimErrorFS
+  newTVar           = lift . newTVar
+  readTVar          = lift . readTVar
+  writeTVar       t = lift . writeTVar t
+  retry             = lift   retry
+
+  newTMVar          = lift . newTMVar
+  newTMVarIO        = lift . newTMVarIO
+  newEmptyTMVar     = lift   newEmptyTMVar
+  newEmptyTMVarIO   = lift   newEmptyTMVarIO
+  takeTMVar         = lift . takeTMVar
+  tryTakeTMVar      = lift . tryTakeTMVar
+  putTMVar        t = lift . putTMVar    t
+  tryPutTMVar     t = lift . tryPutTMVar t
+  swapTMVar       t = lift . swapTMVar   t
+  readTMVar         = lift . readTMVar
+  tryReadTMVar      = lift . tryReadTMVar
+  isEmptyTMVar      = lift . isEmptyTMVar
+
+  newTBQueue        = lift . newTBQueue
+  readTBQueue       = lift . readTBQueue
+  writeTBQueue    q = lift . writeTBQueue q
+
+
+instance (Monad m, MonadState MockFS (SimFS m))
+  => MonadState MockFS (SimErrorFS m) where
+  state f = liftSim (state f)
+
+
+mkSimErrorHasFS :: forall m. MonadSTM m
+                => HasFS (SimFS m) -> HasFS (SimErrorFS m)
+mkSimErrorHasFS HasFS {..} = HasFS
+    { newBuffer = \_ -> return MockBufferUnused
+      -- Lenses would be nice for the setters
+    , dumpState =
+        withErr err ["<dumpState>"] dumpState "dumpState"
+        _dumpState (\e es -> es { _dumpState = e })
+    , hOpen      = \p m ->
+        withErr err  p (hOpen p m) "hOpen"
+        _hOpen (\e es -> es { _hOpen = e })
+    , hClose     = \h ->
+        withErr' err h (hClose h) "hClose"
+        _hClose (\e es -> es { _hClose = e })
+    , hSeek      = \h m n ->
+        withErr' err h (hSeek h m n) "hSeek"
+        _hSeek (\e es -> es { _hSeek = e })
+    , hGet       = \h n ->
+        withErr' err h (hGet h n) "hGet"
+        _hGet (\e es -> es { _hGet = e })
+    , hPut       = hPut' err hPut
+    , hPutBuffer = \h _ d ->
+        withErr' err h (hPutBuffer h Sim.MockBufferUnused d) "hPutBuffer"
+        _hPutBuffer (\e es -> es { _hPutBuffer = e })
+    , hTruncate  = \h w ->
+        withErr' err h (hTruncate h w) "hTruncate"
+        _hTruncate (\e es -> es { _hTruncate = e })
+    , hGetSize   =  \h ->
+        withErr' err h (hGetSize h) "hGetSize"
+        _hGetSize (\e es -> es { _hGetSize = e })
+
+    , createDirectory          = \p ->
+        withErr err p (createDirectory p) "createDirectory"
+        _createDirectory (\e es -> es { _createDirectory = e })
+    , createDirectoryIfMissing = \b p ->
+        withErr err p (createDirectoryIfMissing b p) "createDirectoryIfMissing"
+        _createDirectoryIfMissing (\e es -> es { _createDirectoryIfMissing = e })
+    , listDirectory            = \p ->
+        withErr err p (listDirectory p) "listDirectory"
+        _listDirectory (\e es -> es { _listDirectory = e })
+    , doesDirectoryExist       = \p ->
+        withErr err p (doesDirectoryExist p) "doesDirectoryExist"
+        _doesDirectoryExist (\e es -> es { _doesDirectoryExist = e })
+    , doesFileExist            = \p ->
+        withErr err p (doesFileExist p) "doesFileExist"
+        _doesFileExist (\e es -> es { _doesFileExist = e })
+    , removeFile               = \p ->
+        withErr err p (removeFile p) "removeFile"
+        _removeFile (\e es -> es { _removeFile = e })
+    , hasFsErr = err
+    }
+  where
+    err = liftErrSimErrorFS hasFsErr
+
+
+-- | Runs a 'SimErrorFS' computation provided an 'Errors' and an initial
+-- 'MockFS', producing a result and the final state of the filesystem.
+runSimErrorFS :: MonadSTM m
+              => SimErrorFS m a
+              -> MockFS
+              -> Errors
+              -> m (a, MockFS)
+runSimErrorFS (SimErrorFS action) mockFS errors = do
+    errorsVar <- atomically $ newTVar errors
+    Sim.runSimFS (runReaderT action errorsVar) mockFS
+
+-- | Execute the next action using the given 'Errors'. After the action is
+-- finished, the previous 'Errors' are restored.
+withErrors :: MonadSTM m => Errors -> SimErrorFS m a -> SimErrorFS m a
+withErrors tempErrors action = do
+    errorsVar <- SimErrorFS ask
+    originalErrors <- atomically $ do
+      originalErrors <- readTVar errorsVar
+      writeTVar errorsVar tempErrors
+      return originalErrors
+    res <- action
+    atomically $ writeTVar errorsVar originalErrors
+    return res
+
+
+{-------------------------------------------------------------------------------
+  Utilities
+-------------------------------------------------------------------------------}
+
+-- | Lift a 'SimFS' into a 'SimErrorFS'.
+liftSim :: Monad m => SimFS m a -> SimErrorFS m a
+liftSim = SimErrorFS . lift
+
+liftErrSimErrorFS :: forall e m. ErrorHandling e (SimFS m)
+                  -> ErrorHandling e (SimErrorFS m)
+liftErrSimErrorFS = EH.liftErrNewtype Coercion
+                  . EH.liftErrReader (Proxy @(TVar m Errors))
+
+-- | Advance to the next error in the stream of some 'ErrorStream' in the
+-- 'Errors' stored in 'SimErrorFSE'. Extracts the right error stream from the
+-- state with the @getter@ and stores the advanced error stream in the state
+-- with the @setter@.
+next :: MonadSTM m
+     => (Errors -> Stream a)            -- ^ @getter@
+     -> (Stream a -> Errors -> Errors)  -- ^ @setter@
+     -> SimErrorFS m (Maybe a)
+next getter setter = do
+    errorsVar <- SimErrorFS ask
+    atomically $ do
+      errors <- readTVar errorsVar
+      let (mb, s') = runStream (getter errors)
+      writeTVar errorsVar (setter s' errors)
+      return mb
+
+-- | Execute an action or throw an error, depending on the corresponding
+-- 'ErrorStream' (see 'nextError').
+withErr :: (MonadSTM m, HasCallStack)
+        => ErrorHandling FsError (SimErrorFS m)
+        -> FsPath     -- ^ The path for the error, if thrown
+        -> SimFS m a  -- ^ Action in case no error is thrown
+        -> String     -- ^ Extra message for in the 'fsErrorString'
+        -> (Errors -> ErrorStream)           -- ^ @getter@
+        -> (ErrorStream -> Errors -> Errors) -- ^ @setter@
+        -> SimErrorFS m a
+withErr ErrorHandling {..} path action msg getter setter = do
+    mbErr <- next getter setter
+    case mbErr of
+      Nothing      -> liftSim action
+      Just errType -> throwError FsError
+        { fsErrorType   = errType
+        , fsErrorPath   = path
+        , fsErrorString = "simulated error: " <> msg
+        , fsErrorStack  = callStack
+        , fsLimitation  = False
+        }
+
+-- | Variant of 'withErr' that works with 'Handle's.
+--
+-- The path of the handle is retrieved from the 'MockFS' using 'handleFsPath'.
+withErr' :: (MonadSTM m, HasCallStack)
+         => ErrorHandling FsError (SimErrorFS m)
+         -> Handle     -- ^ The handle to get the path for the error from, if
+                       -- thrown
+         -> SimFS m a  -- ^ Action in case no error is thrown
+         -> String     -- ^ Extra message for in the 'fsErrorString'
+         -> (Errors -> ErrorStream)           -- ^ @getter@
+         -> (ErrorStream -> Errors -> Errors) -- ^ @setter@
+         -> SimErrorFS m a
+withErr' err handle action msg getter setter = do
+    mockFS <- get
+    withErr err (handleFsPath mockFS handle) action msg getter setter
+
+-- | Execute the wrapped 'hPut' or throw an error and apply possible
+-- corruption to the blob to write, depending on the corresponding
+-- 'ErrorStreamWithCorruption' (see 'nextError').
+hPut'  :: (MonadSTM m, HasCallStack)
+       => ErrorHandling FsError (SimErrorFS m)
+       -> (Handle -> Builder -> SimFS m Word64)  -- ^ Wrapped 'hPut'
+       -> Handle -> Builder -> SimErrorFS m Word64
+hPut' ErrorHandling{..} hPutWrapped handle bld = do
+    mockFS <- get
+    let path = handleFsPath mockFS handle
+    mbErrMbCorr <- next _hPut (\e es -> es { _hPut = e })
+    case mbErrMbCorr of
+      Nothing      -> liftSim (hPutWrapped handle bld)
+      Just (errType, mbCorr) -> do
+        whenJust mbCorr $ \corr ->
+          void $ liftSim (hPutWrapped handle (corrupt bld corr))
+        throwError FsError
+          { fsErrorType   = errType
+          , fsErrorPath   = path
+          , fsErrorString = "simulated error: hPut" <> case mbCorr of
+              Nothing   -> ""
+              Just corr -> " with corruption: " <> show corr
+          , fsErrorStack  = callStack
+          , fsLimitation  = False
+          }
+
+
+{-------------------------------------------------------------------------------
+  Demo
+-------------------------------------------------------------------------------}
+
+mockErrorDemo :: IO ()
+mockErrorDemo = do
+    -- let errors = mempty
+    -- let errors = simpleErrors $ alwaysError FsDeviceFull
+    errors <- QC.generate arbitrary
+    let hasFS = mkSimErrorHasFS (Sim.simHasFS EH.exceptT)
+    res <- runExceptT $ runSimErrorFS (example hasFS) Mock.example errors
+    case res of
+      Left  err      -> putStrLn (prettyFsError err)
+      Right (bs, fs) -> putStrLn (Mock.pretty fs) >> print bs

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
@@ -76,9 +76,10 @@ import           Ouroboros.Storage.FS.Sim.Pure
 import qualified Ouroboros.Storage.IO as F
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 
-import           Ouroboros.Consensus.Util
 import qualified Ouroboros.Consensus.Util.Classify as C
 import           Ouroboros.Consensus.Util.Condense
+
+import           Test.Ouroboros.Storage.Util (collects)
 
 import           Test.Util.RefEnv (RefEnv)
 import qualified Test.Util.RefEnv as RE
@@ -886,13 +887,6 @@ tests tmpDir = testGroup "HasFS" [
 -- for execution.
 mountUnused :: MountPoint
 mountUnused = error "mount point not used during command generation"
-
-{-------------------------------------------------------------------------------
-  QuickCheck auxiliary
--------------------------------------------------------------------------------}
-
-collects :: Show a => [a] -> Property -> Property
-collects = repeatedly collect
 
 {-------------------------------------------------------------------------------
   Debugging

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -57,18 +57,15 @@ tests = testGroup "ImmutableDB"
     , testProperty "append/get roundtrip" prop_appendAndGetRoundtrip
     , testProperty "Appending and getting to/from different slots" prop_appendAndGet
     , testCase     "AppendToSlotInThePastError equivalence" test_AppendToSlotInThePastErrorEquivalence
-    , testCase     "OpenFinalisedEpochError equivalence" test_OpenFinalisedEpochErrorEquivalence
     , testCase     "ReadFutureSlotError equivalence" test_ReadFutureSlotErrorEquivalence
     , testCase     "SlotGreaterThanEpochSizeError equivalence" test_SlotGreaterThanEpochSizeErrorEquivalence
       -- demoScript
     , testCase     "demoScript equivalence" test_demoSimEquivalence
     , testCase     "Check index file layout" test_index_layout
     , testCase     "Starting a new epoch pads the previous epoch's index" test_startNewEpochPadsTheIndexFile
-    , testCase     "Opening a DB with a missing epoch size gives an error" test_OpenDBMissingEpochSizeErrorEquivalence
+    , testCase     "Opening a DB with a missing epoch size gives an error" test_openDBMissingEpochSizeErrorEquivalence
     , testCase     "openDB with an empty index file" test_openDBEmptyIndexFileEquivalence
-    , testCase     "Skipping epochs when opening a DB gives an error" test_openDBSkipEpochsMissingFileErrorEquivalence
-    , testCase     "Reopening a DB on the next epoch pads the previous epoch" test_reopenDBNextEpochsNothingEquivalence
-    , testCase     "Reopen the database" test_reopenDatabaseEquivalence
+    , testCase     "Reopen the database" test_reopenDBEquivalence
     , testCase     "closeDB is idempotent" test_closeDBIdempotentEquivalence
     , testCase     "appendBinaryBlob after closeDB throws a ClosedDBError" test_closeDBAppendBinaryBlobEquivalence
     , testGroup "Iterators"
@@ -84,13 +81,13 @@ tests = testGroup "ImmutableDB"
 withTestDB :: (HasCallStack, MonadSTM m, MonadMask m)
            => HasFS m
            -> ErrorHandling ImmutableDBError m
-           -> Epoch -> Map Epoch EpochSize
+           -> Map Epoch EpochSize
            -> (ImmutableDB m -> m a)
            -> m a
-withTestDB hasFS err epoch epochSizes =
-    withDB (openDB hasFS err ["test"] epoch epochSizes)
+withTestDB hasFS err epochSizes f =
+    withDB (openDB hasFS err ["test"] 0 epochSizes NoValidation) (\db _ -> f db)
 
-withSimTestDB :: Epoch -> Map Epoch EpochSize
+withSimTestDB :: Map Epoch EpochSize
               -> (ImmutableDB (SimFS IO) -> SimFS IO a)
               -> SimFS IO a
 withSimTestDB = withTestDB
@@ -153,7 +150,7 @@ prop_appendAndGet (AppendAndGet append get) = label labelToApply $
       r <- run $ tryImmDB $ Sim.runSimFS script Mock.empty
       assertion r
   where
-    script = withSimTestDB 0 (M.singleton 0 epochSize) $ \db -> do
+    script = withSimTestDB (M.singleton 0 epochSize) $ \db -> do
         appendBinaryBlob db 5 "first"
         _ <- startNewEpoch db epochSize
         appendBinaryBlob db 3 "second"
@@ -213,7 +210,7 @@ prop_appendAndGet (AppendAndGet append get) = label labelToApply $
 
 test_appendAndGet :: Assertion
 test_appendAndGet = withMockFS tryImmDB (expectDBResult ((@?= Just "haskell") . fst)) $ \hasFS err ->
-    withTestDB hasFS err 0 (M.singleton 0 10) $ \db -> do
+    withTestDB hasFS err (M.singleton 0 10) $ \db -> do
       appendBinaryBlob db 0 "haskell"
       getBinaryBlob db (EpochSlot 0 0)
 
@@ -221,7 +218,7 @@ prop_appendAndGetRoundtrip :: Property
 prop_appendAndGetRoundtrip = monadicIO $ do
     input <- pick arbitrary
     run $ apiEquivalenceDB (expectDBResult (@?= Just (builderToBS input))) $ \hasFS err ->
-      withTestDB hasFS err 0 (M.singleton 0 10) $ \db -> do
+      withTestDB hasFS err (M.singleton 0 10) $ \db -> do
         appendBinaryBlob db 0 (getBuilder input)
         getBinaryBlob db (EpochSlot 0 0)
 
@@ -240,7 +237,7 @@ test_demoSimEquivalence = apiEquivalenceDB (expectDBResult (@?= blobs)) $ \hasFS
 test_AppendToSlotInThePastErrorEquivalence :: HasCallStack => Assertion
 test_AppendToSlotInThePastErrorEquivalence =
     apiEquivalenceDB (expectUserError isAppendToSlotInThePastError) $ \hasFS err ->
-      withTestDB hasFS err 0 (M.singleton 0 10) $ \db -> do
+      withTestDB hasFS err (M.singleton 0 10) $ \db -> do
         appendBinaryBlob db 3 "test"
         appendBinaryBlob db 2 "haskell"
   where
@@ -250,43 +247,31 @@ test_AppendToSlotInThePastErrorEquivalence =
 test_ReadFutureSlotErrorEquivalence :: HasCallStack => Assertion
 test_ReadFutureSlotErrorEquivalence =
     apiEquivalenceDB (expectUserError isReadFutureSlotError) $ \hasFS err ->
-      withTestDB hasFS err 0 (M.singleton 0 10) $ \db -> do
+      withTestDB hasFS err (M.singleton 0 10) $ \db -> do
         _ <- getBinaryBlob db (EpochSlot 0 0)
         return ()
   where
     isReadFutureSlotError ReadFutureSlotError {} = True
     isReadFutureSlotError _                      = False
 
--- Trying to re-open the DB not on the most-recent-epoch should trigger an
--- error, both in Sim and IO.
-test_OpenFinalisedEpochErrorEquivalence :: HasCallStack => Assertion
-test_OpenFinalisedEpochErrorEquivalence =
-    apiEquivalenceDB (expectUserError isOpenFinalisedEpochError) $ \hasFS err -> do
-      withTestDB hasFS err 0 (M.singleton 0 10) $ \db -> do
-        appendBinaryBlob db 0 "test"
-        _ <- startNewEpoch db 10
-        appendBinaryBlob db 0 "haskell"
-      -- The second withDB should fail.
-      withTestDB hasFS err 0 (M.fromList [(0, 10), (1, 10)]) $ \_ ->
-        return ()
-  where
-    isOpenFinalisedEpochError OpenFinalisedEpochError {} = True
-    isOpenFinalisedEpochError _                          = False
-
 test_SlotGreaterThanEpochSizeErrorEquivalence :: HasCallStack => Assertion
 test_SlotGreaterThanEpochSizeErrorEquivalence =
     apiEquivalenceDB (expectUserError isSlotGreaterThanEpochSizeError) $ \hasFS err ->
-      withTestDB hasFS err 0 (M.singleton 0 10) $ \db ->
+      withTestDB hasFS err (M.singleton 0 10) $ \db ->
         appendBinaryBlob db 11 "test"
   where
     isSlotGreaterThanEpochSizeError SlotGreaterThanEpochSizeError {} = True
     isSlotGreaterThanEpochSizeError _                                = False
 
-test_OpenDBMissingEpochSizeErrorEquivalence :: Assertion
-test_OpenDBMissingEpochSizeErrorEquivalence =
-    apiEquivalenceDB (expectUserError isMissingEpochSizeError) $ \hasFS err ->
-      withTestDB hasFS err 3 (M.fromList [(0, 10), (2, 10)]) $ \_db ->
-        return ()
+test_openDBMissingEpochSizeErrorEquivalence :: Assertion
+test_openDBMissingEpochSizeErrorEquivalence =
+    apiEquivalenceDB (expectUserError isMissingEpochSizeError) $ \hasFS err -> do
+      withTestDB hasFS err (M.singleton 0 10) $ \db -> do
+          appendBinaryBlob db 0 "test"
+          _ <- startNewEpoch db 10
+          appendBinaryBlob db 0 "haskell"
+        -- The second withDB should fail.
+      withTestDB hasFS err (M.singleton 1 10) $ \_ -> return ()
   where
     isMissingEpochSizeError MissingEpochSizeError {} = True
     isMissingEpochSizeError _                        = False
@@ -301,55 +286,31 @@ test_openDBEmptyIndexFileEquivalence =
       hClose h1
       hClose h2
 
-      withTestDB hasFS err 0 (M.singleton 0 5) $ \db -> do
-        appendBinaryBlob db 0 "a"
-        appendBinaryBlob db 3 "b"
-        _ <- startNewEpoch db 5
-        appendBinaryBlob db 2 "c"
-        b1 <- getBinaryBlob db (EpochSlot 0 0)
-        b2 <- getBinaryBlob db (EpochSlot 0 3)
-        b3 <- getBinaryBlob db (EpochSlot 1 2)
-        return [b1, b2, b3]
+      withTestDB hasFS err (M.singleton 0 5) $ \_db ->
+          return ()
   where
     isInvalidFileError InvalidFileError {} = True
     isInvalidFileError _                   = False
 
-test_openDBSkipEpochsMissingFileErrorEquivalence :: Assertion
-test_openDBSkipEpochsMissingFileErrorEquivalence =
-    apiEquivalenceDB (expectUnexpectedError isMissingFileError) $ \hasFS err ->
-      withTestDB hasFS err 3 (M.fromList (zip [0..3] (repeat 5))) $ \_db ->
-        return ()
-  where
-    isMissingFileError MissingFileError {} = True
-    isMissingFileError _                   = False
-
-test_reopenDBNextEpochsNothingEquivalence :: Assertion
-test_reopenDBNextEpochsNothingEquivalence =
-    apiEquivalenceDB (expectDBResult (@?= Nothing)) $ \hasFS err -> do
-      withTestDB hasFS err 0 (M.singleton 0 10) $ \db ->
-        appendBinaryBlob db 0 "c"
-      withTestDB hasFS err 1 (M.fromList [(0, 10), (1, 10)]) $ \db ->
-        getBinaryBlob db (EpochSlot 0 3)
-
-test_reopenDatabaseEquivalence :: Assertion
-test_reopenDatabaseEquivalence =
+test_reopenDBEquivalence :: Assertion
+test_reopenDBEquivalence =
     apiEquivalenceDB (expectDBResult (@?= EpochSlot 0 6)) $ \hasFS err -> do
-      withTestDB hasFS err 0 (M.singleton 0 10) $ \db ->
+      withTestDB hasFS err (M.singleton 0 10) $ \db ->
         appendBinaryBlob db 5 "a"
-      withTestDB hasFS err 0 (M.singleton 0 10) $ \db ->
+      withTestDB hasFS err (M.singleton 0 10) $ \db ->
         getNextEpochSlot db
 
 test_closeDBIdempotentEquivalence :: Assertion
 test_closeDBIdempotentEquivalence =
     apiEquivalenceDB (expectDBResult (@?= ())) $ \hasFS err -> do
-      db <- openDB hasFS err ["test"] 0 (M.singleton 0 10)
+      db <- fst <$> openDB hasFS err ["test"] 0 (M.singleton 0 10) NoValidation
       closeDB db
       closeDB db
 
 test_closeDBAppendBinaryBlobEquivalence :: Assertion
 test_closeDBAppendBinaryBlobEquivalence =
     apiEquivalenceDB (expectUserError isClosedDBError) $ \hasFS err -> do
-      db <- openDB hasFS err ["test"] 0 (M.singleton 0 10)
+      db <- fst <$> openDB hasFS err ["test"] 0 (M.singleton 0 10) NoValidation
       closeDB db
       appendBinaryBlob db 0 "foo"
   where
@@ -385,7 +346,7 @@ byteStringToWord64s bs = go 0
 -- > | 0| 1| 6| 6| 6|13|
 test_index_layout :: Assertion
 test_index_layout = withMockFS tryImmDB assrt $ \hasFS err ->
-    withTestDB hasFS err 0 (M.singleton 0 10) $ \db -> do
+    withTestDB hasFS err (M.singleton 0 10) $ \db -> do
        appendBinaryBlob db 0 "a"
        appendBinaryBlob db 1 "bravo"
        appendBinaryBlob db 4 "haskell"
@@ -396,7 +357,7 @@ test_index_layout = withMockFS tryImmDB assrt $ \hasFS err ->
 
 test_startNewEpochPadsTheIndexFile :: Assertion
 test_startNewEpochPadsTheIndexFile = withMockFS tryImmDB assrt $ \hasFS err ->
-    withTestDB hasFS err 0 (M.singleton 0 10) $ \db -> do
+    withTestDB hasFS err (M.singleton 0 10) $ \db -> do
       appendBinaryBlob db 0 "a"
       appendBinaryBlob db 1 "bravo"
       appendBinaryBlob db 4 "haskell"
@@ -419,7 +380,7 @@ test_startNewEpochPadsTheIndexFile = withMockFS tryImmDB assrt $ \hasFS err ->
 test_iterator_basics :: Assertion
 test_iterator_basics = apiEquivalenceDB
       (expectDBResult (@?= ["a", "b", "c", "d", "e", "f", "g"])) $ \hasFS err ->
-    withTestDB hasFS err 0 (M.singleton 0 10) $ \db -> do
+    withTestDB hasFS err (M.singleton 0 10) $ \db -> do
       appendBinaryBlob db 0 "a"
       appendBinaryBlob db 1 "b"
       appendBinaryBlob db 2 "c"
@@ -537,7 +498,7 @@ prop_iterator IteratorContentsAndRange {..} = monadicIO $ do
         expectedBlobs = map (builderToBS . snd) contents
         -- Default to 0, 0 when there are no blobs
         lastAppended  = fromMaybe (EpochSlot 0 0) $ contentsLastAppended contents
-        script        = withSimTestDB 0 (M.singleton 0 fixedEpochSize) $ \db -> do
+        script        = withSimTestDB (M.singleton 0 fixedEpochSize) $ \db -> do
                           executeDBActions db _dbActions
                           withIterator db (Just _start) (Just _end) iteratorToList
     r <- run $ tryImmDB $ Sim.runSimFS script Mock.empty

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -432,7 +432,7 @@ test_iterator_basics = apiEquivalenceDB
       _ <- startNewEpoch db 5 -- Now in epoch 3
       _ <- startNewEpoch db 5 -- Now in epoch 4
       appendBinaryBlob db 4 "not included"
-      withIterator db (EpochSlot 0 0) (EpochSlot 4 2) iteratorToList
+      withIterator db (Just (EpochSlot 0 0)) (Just (EpochSlot 4 2)) iteratorToList
 
 data DBAction
   = StartNewEpoch
@@ -539,7 +539,7 @@ prop_iterator IteratorContentsAndRange {..} = monadicIO $ do
         lastAppended  = fromMaybe (EpochSlot 0 0) $ contentsLastAppended contents
         script        = withSimTestDB 0 (M.singleton 0 fixedEpochSize) $ \db -> do
                           executeDBActions db _dbActions
-                          withIterator db _start _end iteratorToList
+                          withIterator db (Just _start) (Just _end) iteratorToList
     r <- run $ tryImmDB $ Sim.runSimFS script Mock.empty
     case r of
       Left (UserError (SlotGreaterThanEpochSizeError {}) _)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
@@ -1,0 +1,249 @@
+{-# LANGUAGE DeriveGeneric #-}
+-- | Data structure to convert between 'Slot's and 'EpochSlot's.
+module Test.Ouroboros.Storage.ImmutableDB.CumulEpochSizes
+  ( CumulEpochSizes
+  , singleton
+  , snoc
+  , toList
+  , lastEpoch
+  , lastEpochSize
+  , maxSlot
+  , epochSize
+  , slotToEpochSlot
+  , epochSlotToSlot
+
+  , tests
+  )
+  where
+
+import qualified Data.Foldable as Foldable
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import           Data.Sequence (Seq(..))
+import qualified Data.Sequence as Seq
+
+import           GHC.Generics (Generic)
+
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Ouroboros.Network.Block (Slot(..))
+
+import           Ouroboros.Storage.ImmutableDB.Types
+
+
+
+{------------------------------------------------------------------------------
+  CumulEpochSizes
+------------------------------------------------------------------------------}
+
+
+-- ^ A sequence of the cumulative size of each epoch, from old to new. For
+-- example, say we have the following epoch sizes (from old to new):
+--
+-- > 100, 150, 200, 200, 2160
+--
+-- These will be represented as:
+--
+-- > [100, 250, 450, 650, 2810]
+--
+-- This allows us to recover the original size of each epoch and to convert
+-- 'Slot's to 'EpochSlot's (and vice versa).
+--
+newtype CumulEpochSizes = CES (Seq EpochSize) -- Guaranteed to be non-empty.
+    deriving (Show, Eq, Generic)
+
+-- | Create a 'CumulEpochSizes' using the given size for the first epoch.
+singleton :: EpochSize -> CumulEpochSizes
+singleton = CES . Seq.singleton
+
+-- | Add a new epoch to the end with the given size.
+snoc :: CumulEpochSizes -> EpochSize -> CumulEpochSizes
+snoc _         0  = error "Epoch size must be > 0"
+snoc (CES ces) es = case ces of
+    Empty -> error "Impossible: empty CumulEpochSizes"
+    _ :|> lastEs -> CES (ces :|> lastEs + es)
+
+-- | Helper to build a 'CumulEpochSizes' from a non-empty list of epoc sizes.
+fromNonEmpty :: NonEmpty EpochSize -> CumulEpochSizes
+fromNonEmpty (es NE.:| ess) =
+    Foldable.foldl' snoc (singleton es) ess
+
+-- | Convert to a list of (non-cumulative) epoch sizes.
+--
+-- > [100, 250, 450, 650, 2810]
+-- > ->
+-- > [100, 150, 200, 200, 2160]
+toList :: CumulEpochSizes -> [EpochSize]
+toList (CES ces) = zipWith (-) (Foldable.toList ces) (0 : Foldable.toList ces)
+
+-- | Return the last added epoch.
+--
+-- Epochs start at 0.
+lastEpoch :: CumulEpochSizes -> Epoch
+lastEpoch (CES ces) = fromIntegral (Seq.length ces) - 1
+
+-- | Return the size of the last added epoch.
+lastEpochSize :: CumulEpochSizes -> EpochSize
+lastEpochSize (CES Empty) = error "Impossible: empty CumulEpochSizes"
+lastEpochSize (CES (Empty        :|> lastEs)) = lastEs
+lastEpochSize (CES (_ :|> prevEs :|> lastEs)) = lastEs - prevEs
+
+-- | Return the last slot that a blob could be stored at, i.e. the slot
+-- corresponding to the last relative slot of the last epoch.
+maxSlot :: CumulEpochSizes -> Slot
+maxSlot (CES Empty) = error "Impossible: empty CumulEpochSizes"
+maxSlot (CES (_ :|> lastEs)) = fromIntegral lastEs - 1
+
+-- | Return the size of the given epoch if known.
+epochSize :: CumulEpochSizes -> Epoch -> Maybe EpochSize
+epochSize (CES ces) epoch =
+    case Seq.splitAt (fromIntegral epoch) ces of
+      (Empty,        at :<| _) -> Just at
+      (_ :|> before, at :<| _) -> Just (at - before)
+      _                        -> Nothing
+
+-- | Make sure the the given epoch is the last epoch for which the size is
+-- stored. No-op if the current last epoch is <= the given epoch.
+rollBackToEpoch :: CumulEpochSizes -> Epoch -> CumulEpochSizes
+rollBackToEpoch (CES ces) epoch = CES $ Seq.take (succ (fromIntegral epoch)) ces
+
+-- | Convert a 'Slot' to an 'EpochSlot'
+--
+-- For example:
+--
+-- > epochs:              0    1    2    3     4
+-- > epoch sizes:       [100, 150, 200, 200, 2160]
+-- > cumul epoch sizes: [100, 250, 450, 650, 2810]
+-- > slot: 260 -> epoch slot: (2, 10)
+slotToEpochSlot :: CumulEpochSizes -> Slot -> Maybe EpochSlot
+slotToEpochSlot (CES ces) slot
+    | _ :|> origLastEs <- ces
+    , slot' < origLastEs
+    = case Seq.dropWhileR (> slot') ces of
+        ces'@(_ :|> lastEs) -> Just $ EpochSlot
+          { _epoch        = fromIntegral (Seq.length ces')
+          , _relativeSlot = RelativeSlot (slot' - lastEs)
+          }
+        Empty -> Just $ EpochSlot
+          { _epoch        = 0
+          , _relativeSlot = RelativeSlot slot'
+          }
+    | _ :|> origLastEs <- ces
+    , origLastEs == slot'
+      -- If the slot == the size of the last epoch, return (epoch + 1, 0).
+    = Just $ EpochSlot
+        { _epoch        = fromIntegral (Seq.length ces)
+        , _relativeSlot = 0
+        }
+    | otherwise
+    = Nothing
+  where
+    slot' = fromIntegral slot
+
+-- | Convert an 'EpochSlot' to a 'Slot'
+--
+-- For example:
+--
+-- > epochs:              0    1    2    3     4
+-- > epoch sizes:       [100, 150, 200, 200, 2160]
+-- > cumul epoch sizes: [100, 250, 450, 650, 2810]
+-- > epoch slot: (2, 10) -> slot: 260
+epochSlotToSlot :: CumulEpochSizes -> EpochSlot -> Maybe Slot
+epochSlotToSlot (CES ces) (EpochSlot epoch relSlot)
+    | relSlot == 0
+    , fromIntegral epoch == Seq.length ces
+    , _ :|> lastEs <- ces
+      -- Handle EpochSlot n 0 where n = the last epoch + 1
+    = Just (fromIntegral lastEs)
+    | otherwise
+    = case Seq.splitAt (fromIntegral epoch) ces of
+        (_ :|> before, at :<| _)
+          | relSlot' < at - before
+          -> Just $ fromIntegral (before + relSlot')
+        (Empty, at :<| _)
+          | relSlot' < at
+          -> Just $ Slot relSlot'
+        _ -> Nothing
+  where
+    relSlot' :: EpochSize
+    relSlot' = getRelativeSlot relSlot
+
+
+{------------------------------------------------------------------------------
+  Tests
+------------------------------------------------------------------------------}
+
+
+instance Arbitrary CumulEpochSizes where
+  arbitrary =
+    fromNonEmpty . NE.fromList . fmap getPositive . getNonEmpty <$> arbitrary
+  shrink ces =
+    [ fromNonEmpty . NE.fromList . fmap getPositive . getNonEmpty $ es'
+    | let es = NonEmpty . fmap Positive $ toList ces
+    , es' <- shrink es
+    ]
+
+chooseSlot :: Slot -> Slot -> Gen Slot
+chooseSlot (Slot start) (Slot end) = Slot <$> choose (start, end)
+
+shrinkSlot :: Slot -> [Slot]
+shrinkSlot (Slot w) = [Slot w' | w' <- shrink w]
+
+shrinkRelSlot :: RelativeSlot -> [RelativeSlot]
+shrinkRelSlot (RelativeSlot w) = [RelativeSlot w' | w' <- shrink w]
+
+shrinkEpochSlot :: EpochSlot -> [EpochSlot]
+shrinkEpochSlot (EpochSlot epoch relSlot) =
+    [EpochSlot epoch' relSlot  | epoch' <- shrink epoch] ++
+    [EpochSlot epoch  relSlot' | relSlot' <- shrinkRelSlot relSlot]
+
+prop_ces_roundtrip :: CumulEpochSizes -> Property
+prop_ces_roundtrip ces = fromNonEmpty (NE.fromList (toList ces)) === ces
+
+prop_epochSize :: CumulEpochSizes -> Epoch -> Property
+prop_epochSize ces epoch =
+    epochSize ces epoch === toList ces !? fromIntegral epoch
+  where
+    xs !? i
+      | 0 <= i, i < Foldable.length xs = Just (xs !! i)
+      | otherwise                      = Nothing
+
+prop_slotToEpochSlot_epochSlotToSlot :: CumulEpochSizes -> Property
+prop_slotToEpochSlot_epochSlotToSlot ces =
+    forAllShrink genValidSlot shrinkSlot $ \slot ->
+      (slotToEpochSlot ces slot >>= epochSlotToSlot ces) === Just slot
+  where
+    genValidSlot = chooseSlot 0 (maxSlot ces + 1)
+
+prop_epochSlotToSlot_invalid :: CumulEpochSizes -> Property
+prop_epochSlotToSlot_invalid ces =
+    forAllShrink genInvalidEpochSlot shrinkInvalidEpochSlot $ \epochSlot ->
+      epochSlotToSlot ces epochSlot === Nothing
+  where
+    genInvalidEpochSlot = genEpochSlot `suchThat` isInvalid
+    genEpochSlot = EpochSlot <$> arbitrary <*> (RelativeSlot <$> arbitrary)
+    shrinkInvalidEpochSlot epochSlot =
+      filter isInvalid (shrinkEpochSlot epochSlot)
+    isInvalid (EpochSlot epoch relSlot)
+      | Just sz <- epochSize ces epoch
+      = relSlot >= fromIntegral sz
+      | otherwise
+      = False
+
+prop_slotToEpochSlot_greater_than_maxSlot :: CumulEpochSizes -> Property
+prop_slotToEpochSlot_greater_than_maxSlot ces =
+    forAllShrink genInvalidSlot shrinkSlot $ \invalidSlot ->
+      slotToEpochSlot ces invalidSlot === Nothing
+  where
+    genInvalidSlot = chooseSlot (succ (maxSlot ces)) maxBound
+
+tests :: TestTree
+tests = testGroup "CumulEpochSizes"
+    [ testProperty "CumulEpochSizes/List roundtrip" prop_ces_roundtrip
+    , testProperty "EpochSize" prop_epochSize
+    , testProperty "slotToEpochSlot/epochSlotToSlot" prop_slotToEpochSlot_epochSlotToSlot
+    , testProperty "epochSlotToSlot returns Nothing when the epochSlot is invalid" prop_epochSlotToSlot_invalid
+    , testProperty "slotToEpochSlot returns Nothing when the slot is greater than maxSlot" prop_slotToEpochSlot_greater_than_maxSlot
+    ]

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -1,0 +1,310 @@
+{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE TupleSections    #-}
+-- | Model for the 'ImmutableDB' based on a chain.
+--
+-- The chain is just a list of slots that can be unfilled (@Nothing@) or
+-- filled (@Just ByteString@).
+module Test.Ouroboros.Storage.ImmutableDB.Model
+  ( DBModel(..)
+  , dbmBlobs
+  , initDBModel
+  , IteratorModel
+  , openDBModel
+  , lookupNextEpochSlot
+  , getLastBlobLocation
+  ) where
+
+import           Control.Monad (when)
+import           Control.Monad.State (MonadState, get, gets, put, modify)
+
+import           Data.ByteString (ByteString)
+import           Data.ByteString.Builder (Builder)
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Lazy as BL
+import           Data.List (genericReplicate, dropWhileEnd)
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Maybe (listToMaybe, fromMaybe, mapMaybe, isNothing)
+
+import           GHC.Generics (Generic)
+import           GHC.Stack (HasCallStack, withFrozenCallStack)
+
+import           Ouroboros.Consensus.Util (lastMaybe)
+
+import           Ouroboros.Network.Block (Slot(..))
+
+import           Ouroboros.Storage.ImmutableDB.API
+import           Ouroboros.Storage.ImmutableDB.Util hiding (lookupEpochSize)
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
+
+import           Test.Ouroboros.Storage.ImmutableDB.CumulEpochSizes (CumulEpochSizes)
+import qualified Test.Ouroboros.Storage.ImmutableDB.CumulEpochSizes as CES
+
+
+data DBModel = DBModel
+  { dbmChain           :: [Maybe ByteString]
+    -- ^ 'Nothing' when a slot is empty
+  , dbmNextSlot        :: Slot
+    -- ^ The number of the next available slot
+  , dbmCumulEpochSizes :: CumulEpochSizes
+  , dbmIterators       :: Map IteratorID IteratorModel
+  , dbmNextIterator    :: IteratorID
+  } deriving (Show, Generic)
+
+initDBModel :: EpochSize -- ^ The size of the first epoch
+            -> DBModel
+initDBModel firstEpochSize = DBModel
+  { dbmChain           = []
+  , dbmNextSlot        = 0
+  , dbmCumulEpochSizes = CES.singleton firstEpochSize
+  , dbmIterators       = Map.empty
+  , dbmNextIterator    = initialIteratorId
+  }
+
+dbmBlobs :: DBModel -> Map EpochSlot ByteString
+dbmBlobs dbm@DBModel {..} = foldr add Map.empty (zip (map Slot [0..]) dbmChain)
+  where
+    add (_,    Nothing)   = id
+    add (slot, Just blob) = Map.insert (slotToEpochSlot dbm slot) blob
+
+
+-- | Model for an 'Iterator'.
+--
+-- The first 'Slot' = return the next filled slot (doesn't have to exist) >=
+-- this 'Slot'. The second 'Slot': last filled slot to return (inclusive).
+--
+-- An iterator is open iff its is present in 'dbmIterators'
+newtype IteratorModel = IteratorModel (Slot, Slot)
+  deriving (Show, Eq, Generic)
+
+
+
+
+{------------------------------------------------------------------------------
+  ImmutableDB API
+------------------------------------------------------------------------------}
+
+openDBModel :: MonadState DBModel m
+            => ErrorHandling ImmutableDBError m
+            -> EpochSize
+            -> (DBModel, ImmutableDB m)
+openDBModel err firstEpochSize = (dbModel, db)
+  where
+    dbModel = initDBModel firstEpochSize
+    db = ImmutableDB
+      { closeDB           = return ()
+      , isOpen            = return True
+      , reopen            = const reopenModel -- No recovery
+      , getNextEpochSlot  = getNextEpochSlotModel
+      , getBinaryBlob     = getBinaryBlobModel     err
+      , appendBinaryBlob  = appendBinaryBlobModel  err
+      , startNewEpoch     = startNewEpochModel
+      , streamBinaryBlobs = streamBinaryBlobsModel err
+      , immutableDBErr    = err
+      }
+
+{------------------------------------------------------------------------------
+  Helpers
+------------------------------------------------------------------------------}
+
+impossible :: HasCallStack => String -> a
+impossible msg = withFrozenCallStack (error ("Impossible: " ++ msg))
+
+mustBeJust :: HasCallStack => String -> Maybe a -> a
+mustBeJust msg = fromMaybe (impossible msg)
+
+lookupNextEpochSlot :: HasCallStack => DBModel -> EpochSlot
+lookupNextEpochSlot dbm@DBModel {..} = case slotToEpochSlot dbm dbmNextSlot of
+    -- TODO imitates the Impl
+    EpochSlot epoch 0 | epoch == currentEpoch + 1
+      -> EpochSlot currentEpoch (fromIntegral epochSize)
+    epochSlot -> epochSlot
+  where
+    currentEpoch = CES.lastEpoch dbmCumulEpochSizes
+    epochSize    = lookupEpochSize dbm currentEpoch
+
+lookupEpochSize :: HasCallStack => DBModel -> Epoch -> EpochSize
+lookupEpochSize DBModel {..} epoch =
+    mustBeJust msg $ CES.epochSize dbmCumulEpochSizes epoch
+  where
+    msg = "epoch (" <> show epoch <> ") size unknown (" <>
+          show dbmCumulEpochSizes <> ")"
+
+epochSlotToSlot :: HasCallStack => DBModel -> EpochSlot -> Slot
+epochSlotToSlot DBModel {..} epochSlot =
+    mustBeJust msg $ CES.epochSlotToSlot dbmCumulEpochSizes epochSlot
+  where
+    msg = "epochSlot (" <> show epochSlot <>
+          ") could not be converted to a slot"
+
+slotToEpochSlot :: HasCallStack => DBModel -> Slot -> EpochSlot
+slotToEpochSlot DBModel {..} slot =
+    mustBeJust msg $ CES.slotToEpochSlot dbmCumulEpochSizes slot
+  where
+    msg = "slot (" <> show slot <>
+          ") could not be converted to an epochSlot (" <>
+          show dbmCumulEpochSizes <> ")"
+
+lookupBySlot :: HasCallStack => Slot -> [Maybe b] -> Maybe b
+lookupBySlot (Slot i) = go i
+  where
+    go 0 (blob:_)  = blob
+    go n (_:blobs) = go (n - 1) blobs
+    go _ []        = error "lookupBySlot: index out of bounds"
+
+getLastBlobLocation :: DBModel -> Maybe EpochSlot
+getLastBlobLocation dbm@DBModel {..} =
+    fmap (slotToEpochSlot dbm) $
+    lastMaybe $ zipWith const [0..] $ dropWhileEnd isNothing dbmChain
+
+
+{------------------------------------------------------------------------------
+  ImmutableDB Implementation
+------------------------------------------------------------------------------}
+
+reopenModel :: MonadState DBModel m => m (Maybe EpochSlot)
+reopenModel = gets getLastBlobLocation
+
+
+getNextEpochSlotModel :: (HasCallStack, MonadState DBModel m)
+                      => m EpochSlot
+getNextEpochSlotModel = gets lookupNextEpochSlot
+
+getBinaryBlobModel :: (HasCallStack, MonadState DBModel m)
+                   => ErrorHandling ImmutableDBError m
+                   -> EpochSlot
+                   -> m (Maybe ByteString)
+getBinaryBlobModel err readEpochSlot = do
+    dbm@DBModel {..} <- get
+    let nextEpochSlot = lookupNextEpochSlot dbm
+    when (readEpochSlot >= nextEpochSlot) $ throwUserError err $
+      ReadFutureSlotError readEpochSlot nextEpochSlot
+
+    let EpochSlot epoch relativeSlot = readEpochSlot
+        -- We already know that 'readEpochSlot' does not lie in the future, so
+        -- the size of the corresponding epoch must be known.
+        epochSize = lookupEpochSize dbm epoch
+    when (getRelativeSlot relativeSlot >= epochSize) $ throwUserError err $
+      SlotGreaterThanEpochSizeError relativeSlot epoch epochSize
+
+    let slot = epochSlotToSlot dbm readEpochSlot
+
+    return $ lookupBySlot slot dbmChain
+
+
+appendBinaryBlobModel :: (HasCallStack, MonadState DBModel m)
+                      => ErrorHandling ImmutableDBError m
+                      -> RelativeSlot
+                      -> Builder
+                      -> m ()
+appendBinaryBlobModel err relSlot bld = do
+    dbm@DBModel {..} <- get
+    let EpochSlot currentEpoch nextRelSlot = lookupNextEpochSlot dbm
+
+    when (relSlot < nextRelSlot) $
+      throwUserError err $ AppendToSlotInThePastError relSlot nextRelSlot
+
+    let epochSize = lookupEpochSize dbm currentEpoch
+    when (getRelativeSlot relSlot >= epochSize) $ throwUserError err $
+      SlotGreaterThanEpochSizeError relSlot currentEpoch epochSize
+
+    let appendEpochSlot = EpochSlot currentEpoch relSlot
+        appendSlot = epochSlotToSlot dbm appendEpochSlot
+        blob = BL.toStrict $ BS.toLazyByteString bld
+        toPad = fromIntegral (appendSlot - dbmNextSlot)
+
+    -- TODO snoc list?
+    put dbm
+      { dbmChain    = dbmChain ++ (replicate toPad Nothing ++ [Just blob])
+      , dbmNextSlot = appendSlot + 1
+      }
+
+startNewEpochModel :: MonadState DBModel m
+                   => EpochSize
+                   -> m Epoch
+startNewEpochModel nextEpochSize = do
+    dbm@DBModel {..} <- get
+    let toPad = CES.maxSlot dbmCumulEpochSizes + 1 - dbmNextSlot
+        newEpoch = CES.lastEpoch dbmCumulEpochSizes + 1
+
+    put dbm
+      { dbmChain = dbmChain ++ genericReplicate toPad Nothing
+        -- We use 'genericReplicate' instead of the regular 'replicate', which
+        -- takes an 'Int', because when converting from a 'Slot' (~= 'Word')
+        -- to an 'Int', it could underflow. While this scenario is not very
+        -- realistic, it can turn up in the StateMachine tests, in which case
+        -- we want it to fail with a better error than the error thrown by
+        -- 'fromEnum'.
+      , dbmNextSlot = dbmNextSlot + fromIntegral toPad
+      , dbmCumulEpochSizes = CES.snoc dbmCumulEpochSizes nextEpochSize }
+    return newEpoch
+
+streamBinaryBlobsModel :: (HasCallStack, MonadState DBModel m)
+                       => ErrorHandling ImmutableDBError m
+                       -> Maybe EpochSlot
+                       -> Maybe EpochSlot
+                       -> m (Iterator m)
+streamBinaryBlobsModel err mbStart mbEnd = do
+    dbm@DBModel {..} <- get
+    let nextEpochSlot = lookupNextEpochSlot dbm
+        getEpochSize epoch = return $ lookupEpochSize dbm epoch
+    validateIteratorRange err nextEpochSlot getEpochSize mbStart mbEnd
+
+    case length $ dropWhileEnd isNothing dbmChain of
+      -- Empty database, return an empty iterator
+      0 -> do
+        put dbm { dbmNextIterator = succ dbmNextIterator }
+        return Iterator
+          { iteratorNext  = return IteratorExhausted
+          , iteratorClose = return ()
+          , iteratorID    = dbmNextIterator
+          }
+      n -> do
+        let currentSlot = fromIntegral n - 1
+            start = maybe 0 (epochSlotToSlot dbm) mbStart
+            end   = maybe currentSlot (epochSlotToSlot dbm) mbEnd
+            itm   = IteratorModel (start, end)
+            itID  = dbmNextIterator
+        put dbm
+          { dbmNextIterator = succ dbmNextIterator
+          , dbmIterators    = Map.insert dbmNextIterator itm dbmIterators
+          }
+        return Iterator
+          { iteratorNext  = iteratorNextModel  itID
+          , iteratorClose = iteratorCloseModel itID
+          , iteratorID    = itID
+          }
+
+
+iteratorNextModel :: (HasCallStack, MonadState DBModel m)
+                  => IteratorID
+                  -> m IteratorResult
+iteratorNextModel itID = do
+    dbm@DBModel {..} <- get
+    case Map.lookup itID dbmIterators of
+      Nothing -> return IteratorExhausted
+      Just (IteratorModel (minNext, end)) -> do
+        let mbBlob = listToMaybe
+                   $ takeWhile ((<= end) . fst)
+                   $ dropWhile ((< minNext) . fst)
+                   $ mapMaybe (\(slot, mbBlob') -> (slot,) <$> mbBlob')
+                   $ zip [0..] dbmChain
+        case mbBlob of
+          Nothing -> do
+            iteratorCloseModel itID
+            return IteratorExhausted
+          Just (next, blob) -> do
+            if next > end
+              then iteratorCloseModel itID
+              else
+                let next' = succ next
+                    itm'  = IteratorModel (next', end)
+                in put dbm { dbmIterators = Map.insert itID itm' dbmIterators }
+            return $ IteratorResult (slotToEpochSlot dbm next) blob
+
+iteratorCloseModel :: MonadState DBModel m
+                   => IteratorID -> m ()
+iteratorCloseModel itID = modify $ \dbm@DBModel {..} ->
+    dbm { dbmIterators = Map.delete itID dbmIterators }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Sim.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Sim.hs
@@ -16,9 +16,11 @@ import           Ouroboros.Storage.ImmutableDB.API
 
 
 demoScript :: (HasCallStack, MonadMask m)
-           => (Epoch -> Map Epoch EpochSize -> m (ImmutableDB m))
+           => (    Epoch -> Map Epoch EpochSize -> RecoveryPolicy e m
+                -> m (ImmutableDB m, Maybe EpochSlot)
+              )
            -> m [Maybe ByteString]
-demoScript openDB = withDB (openDB 0 (Map.singleton 0 10)) $ \db -> do
+demoScript openDB = withDB (openDB 0 (Map.singleton 0 10) NoValidation) $ \db _ -> do
       -- Append some blob in the DB
       appendBinaryBlob db 0 "haskell"
       appendBinaryBlob db 1 "nice"

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -1,0 +1,1154 @@
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DeriveTraversable    #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans      #-}
+module Test.Ouroboros.Storage.ImmutableDB.StateMachine
+    ( tests
+    , showLabelledExamples
+    , showLabelledErrorExamples
+    ) where
+
+import           Prelude hiding (elem, notElem)
+
+import           Control.Monad (when, unless)
+import           Control.Monad.Catch (MonadMask)
+import           Control.Monad.Except (ExceptT(..), runExceptT)
+import           Control.Monad.State (MonadState, State, StateT, runState,
+                                      evalStateT, get, put, lift)
+
+import           Data.Bifunctor (first)
+import           Data.ByteString (ByteString)
+import           Data.Foldable (toList)
+import           Data.Function (on)
+import           Data.Functor.Classes (Eq1, Show1)
+import           Data.List (sortBy)
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Maybe (listToMaybe, isJust, isNothing)
+import           Data.Proxy (Proxy(..))
+import           Data.TreeDiff (Expr(App))
+import           Data.TreeDiff.Class (ToExpr(..))
+import           Data.Typeable (Typeable)
+
+import qualified Generics.SOP as SOP
+
+import           GHC.Generics (Generic, Generic1, from)
+import           GHC.Stack (HasCallStack, callStack)
+
+import           System.Random (getStdRandom, randomR)
+
+import           Test.QuickCheck
+import qualified Test.QuickCheck.Monadic as QCM
+import           Test.QuickCheck.Random (mkQCGen)
+import           Test.StateMachine
+import qualified Test.StateMachine.Sequential as QSM
+import qualified Test.StateMachine.Types as QSM
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Text.Show.Pretty (ppShow)
+
+import           Ouroboros.Consensus.Util (lastMaybe)
+import qualified Ouroboros.Consensus.Util.Classify as C
+
+import           Ouroboros.Network.Block (Slot(..))
+
+import           Ouroboros.Storage.FS.API (HasFS(..))
+import           Ouroboros.Storage.FS.API.Types (FsPath, FsError(..),
+                                                 FsErrorType(..), sameFsError)
+import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
+import           Ouroboros.Storage.FS.Sim.STM (SimFS, runSimFS, simHasFS)
+import           Ouroboros.Storage.ImmutableDB
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+import           Test.Ouroboros.Storage.FS.Sim.Error (SimErrorFS, runSimErrorFS,
+                                                      mkSimErrorHasFS, Errors,
+                                                      withErrors)
+import           Test.Ouroboros.Storage.ImmutableDB.Model
+import           Test.Ouroboros.Storage.ImmutableDB.CumulEpochSizes (CumulEpochSizes)
+import qualified Test.Ouroboros.Storage.ImmutableDB.CumulEpochSizes as CES
+import           Test.Ouroboros.Storage.ImmutableDB.TestBlock hiding (tests)
+import           Test.Ouroboros.Storage.Util (collects, tryImmDB)
+
+import           Test.Util.RefEnv (RefEnv)
+import qualified Test.Util.RefEnv as RE
+
+
+{-------------------------------------------------------------------------------
+  Abstract model
+-------------------------------------------------------------------------------}
+
+-- | Commands
+--
+-- 'Cmd' will be instantiated to:
+--
+-- > Cmd (IterRef m r)
+-- > Cmd (Iterator m)
+--
+-- Where @m@ can be 'PureM', 'RealM', or 'RealErrM', and @r@ can be 'Symbolic'
+-- or 'Concrete'.
+data Cmd it
+  = GetBinaryBlob     EpochSlot
+  | AppendBinaryBlob  RelativeSlot TestBlock
+  | StartNewEpoch     EpochSize
+  | StreamBinaryBlobs (Maybe EpochSlot) (Maybe EpochSlot)
+  | IteratorNext      it
+  | IteratorClose     it
+  deriving (Generic, Show, Functor, Foldable, Traversable)
+
+deriving instance SOP.Generic         (Cmd it)
+deriving instance SOP.HasDatatypeInfo (Cmd it)
+
+-- | A 'Cmd' together with 'Errors'.
+--
+-- When executing the 'Cmd', these 'Errors' are passed to 'SimErrorFS' to
+-- simulate file system errors thrown at the 'HasFS' level. When 'Nothing', no
+-- errors will be thrown.
+data CmdErr it = CmdErr
+  { _cmdErr :: Maybe Errors
+  , _cmd    :: Cmd it
+  } deriving (Generic, Functor, Foldable, Traversable)
+
+instance Show it => Show (CmdErr it) where
+  showsPrec d (CmdErr mbErrors cmd) = showParen (d > 10) $
+      showString constr . showsPrec 11 cmd
+    where
+      constr = case mbErrors of
+        Nothing  -> "Cmd "
+        Just err -> "Cmd " <> show err <> " "
+
+-- | Return type for successful database operations.
+data Success it
+  = Unit       ()
+  | Blob       (Maybe ByteString)
+  | Epoch      Epoch
+  | Iter       it
+  | IterResult IteratorResult
+  deriving (Eq, Show, Functor, Foldable, Traversable)
+
+-- | Run the command against the given database.
+run :: (HasCallStack, Monad m)
+    => ImmutableDB m
+    -> Cmd (Iterator m)
+    -> m (Success (Iterator m))
+run db cmd = case cmd of
+  GetBinaryBlob eps     -> Blob       <$> getBinaryBlob db eps
+  AppendBinaryBlob s b  -> Unit       <$> appendBinaryBlob db s (testBlockToBuilder b)
+  StartNewEpoch epsz    -> Epoch      <$> startNewEpoch db epsz
+  StreamBinaryBlobs s e -> Iter       <$> streamBinaryBlobs db s e
+  IteratorNext it       -> IterResult <$> iteratorNext it
+  IteratorClose it      -> Unit       <$> iteratorClose it
+
+
+
+{-------------------------------------------------------------------------------
+  Instantiating the semantics
+-------------------------------------------------------------------------------}
+
+-- | Responses are either successful termination or an error.
+newtype Resp it = Resp { getResp :: Either ImmutableDBError (Success it) }
+  deriving (Functor, Foldable, Traversable)
+
+-- | The 'Eq' instance for 'Resp' uses 'sameImmutableDBError'.
+instance Eq it => Eq (Resp it) where
+  Resp (Left  e) == Resp (Left  e') = sameImmutableDBError e e'
+  Resp (Right a) == Resp (Right a') = a == a'
+  _              == _               = False
+
+-- | Don't print the callstack and parameters in the 'ImmutableDBError', just
+-- the 'FsErrorType' or the constructor name.
+instance Show it => Show (Resp it) where
+  show (Resp resp) = "(Resp " <> str <> ")"
+    where
+      str = case resp of
+        Left (UnexpectedError (FileSystemError fse)) -> show (fsErrorType fse)
+        Left (UnexpectedError ue)                    -> cmdName (from ue)
+        Left (UserError ue _)                        -> show ue
+        Right success                                -> show success
+
+-- | The monad used to run pure model/mock implementation of the database.
+type PureM = ExceptT ImmutableDBError (State DBModel)
+
+-- | The type of the pure model/mock implementation of the database.
+type ModelDBPure = ImmutableDB PureM
+
+-- | The monad used to run the real database.
+type RealM = SimFS IO
+
+-- | The type of the real database.
+type RealDB = ImmutableDB RealM
+
+-- | The monad used to run the real database when simulating errors.
+type RealErrM = SimErrorFS IO
+
+-- | The type of the real database when simulating errors.
+type RealDBErr = ImmutableDB RealErrM
+
+
+-- | Run a command against the pure model
+runPure :: DBModel
+        -> ModelDBPure
+        -> Cmd (Iterator PureM)
+        -> (Resp (Iterator PureM), DBModel)
+runPure dbm mdb cmd = first Resp $ runState (runExceptT (run mdb cmd)) dbm
+
+{-------------------------------------------------------------------------------
+  Collect arguments
+-------------------------------------------------------------------------------}
+
+-- | Collect all iterators created. For example, @t@ could be 'Cmd' or 'CmdErr'.
+iters :: Traversable t => t it -> [it]
+iters = toList
+
+
+{-------------------------------------------------------------------------------
+  Model
+-------------------------------------------------------------------------------}
+
+-- | Concrete or symbolic references to a real (or model) iterator
+type IterRef m = Reference (Opaque (Iterator m))
+
+-- | Mapping between iterator references and mocked iterators
+type KnownIters m = RefEnv (Opaque (Iterator m)) (Iterator PureM)
+
+-- | Execution model
+data Model m r = Model
+  { dbModel     :: DBModel
+    -- ^ A model of the database, used as state for the 'HasImmutableDB'
+    -- instance of 'ModelDB'.
+  , mockDB      :: ModelDBPure
+    -- ^ A handle to the mocked database.
+  , knownIters  :: KnownIters m r
+    -- ^ Store a mapping between iterator references and mocked iterators.
+  , simulatedError :: Maybe FsError
+    -- ^ Record the simulated error ('FsError') that was thrown. As soon as a
+    -- simulated 'FsError' was thrown, the test will stop.
+  } deriving (Show, Generic)
+
+-- | Initial model
+initModel :: DBModel -> ModelDBPure -> Model m r
+initModel dbModel mockDB = Model
+    { knownIters  = RE.empty
+    , simulatedError = Nothing
+    , ..
+    }
+
+-- | Key property of the model is that we can go from real to mock responses
+toMock :: (Functor t, Eq1 r) => Model m r -> At t m r -> t (Iterator PureM)
+toMock Model {..} (At t) = fmap (knownIters RE.!) t
+
+-- | Step the mock semantics
+--
+-- We cannot step the whole Model here (see 'lockstep', below)
+step :: Eq1 r => Model m r -> At Cmd m r -> (Resp (Iterator PureM), DBModel)
+step model@Model{..} cmd = runPure dbModel mockDB (toMock model cmd)
+
+-- | Step the mock semantics with a 'CmdErr'
+--
+-- In the case of a simulated error, we need the actual response to know how
+-- to update the model (see 'lockstep', below).
+stepErr :: Eq1 r => Model m r -> At CmdErr m r -> Resp (Iterator PureM)
+stepErr model (At (CmdErr mbErrors cmd)) = case (mbErrors, resp) of
+    -- No simulated errors, just step
+    (Nothing, _) -> resp
+    -- Even though an error was simulated, another error was thrown before it.
+    -- Note that the error is UnexpectedError iff it is simulated. In this
+    -- case, return the expected result without a simulated error
+    (Just _, Resp (Left (UserError {}))) -> resp
+    -- An error was simulated and will be thrown, so mock an error.
+    (Just _, _) -> Resp (Left mockedError)
+  where
+    (resp, _) = step model (At cmd)
+
+
+{-------------------------------------------------------------------------------
+  Wrapping in quickcheck-state-machine references
+-------------------------------------------------------------------------------}
+
+-- | Instantiate functor @t@ to @t ('IterRef' m r)@.
+--
+-- Needed because we need to (partially) apply @'At' t m@ to @r@.
+newtype At t m r = At { unAt :: t (IterRef m r) }
+  deriving (Generic)
+
+-- | Don't print the 'At' constructor.
+instance Show (t (IterRef m r)) => Show (At t m r) where
+  show = show . unAt
+
+deriving instance Eq1 r => Eq (At Resp m r)
+
+deriving instance Generic1          (At Cmd m)
+deriving instance Rank2.Foldable    (At Cmd m)
+deriving instance Rank2.Functor     (At Cmd m)
+deriving instance Rank2.Traversable (At Cmd m)
+
+deriving instance Generic1          (At CmdErr m)
+deriving instance Rank2.Foldable    (At CmdErr m)
+deriving instance Rank2.Functor     (At CmdErr m)
+deriving instance Rank2.Traversable (At CmdErr m)
+
+deriving instance Generic1          (At Resp m)
+deriving instance Rank2.Foldable    (At Resp m)
+
+
+{-------------------------------------------------------------------------------
+  Events
+-------------------------------------------------------------------------------}
+
+-- | An event records the model before and after a command along with the
+-- command itself, and a mocked version of the response.
+data Event m r = Event
+  { eventBefore   :: Model     m r
+  , eventCmdErr   :: At CmdErr m r
+  , eventAfter    :: Model     m r
+  , eventMockResp :: Resp (Iterator PureM)
+  } deriving (Show)
+
+eventCmd :: Event m r -> At Cmd m r
+eventCmd = At . _cmd . unAt . eventCmdErr
+
+eventMockCmd :: Eq1 r => Event m r -> Cmd (Iterator PureM)
+eventMockCmd ev@Event {..} = toMock eventBefore (eventCmd ev)
+
+
+-- | Construct an event
+lockstep :: (Show1 r, Eq1 r)
+         => Model     m r
+         -> At CmdErr m r
+         -> At Resp   m r
+         -> Event     m r
+lockstep model@Model {..} cmdErr@(At (CmdErr mbErrors cmd)) (At resp) = Event
+    { eventBefore   = model
+    , eventCmdErr   = cmdErr
+    , eventAfter    = model'
+    , eventMockResp = mockResp
+    }
+  where
+    (mockResp, dbModel') = step model (At cmd)
+    newIters = RE.fromList $ zip (iters resp) (iters mockResp)
+    model' = model
+      { dbModel        = dbModel'
+      , knownIters     = knownIters `RE.union` newIters
+      , simulatedError = simulatedErr
+      }
+    -- Record the simulated error if one was thrown.
+    simulatedErr = case (mbErrors, getResp resp) of
+        (Just _, Left (UnexpectedError (FileSystemError fse))) -> Just fse
+        _                                                      -> Nothing
+
+-- | The error thrown when mocking a simulated 'FileSystemError'.
+mockedError :: HasCallStack => ImmutableDBError
+mockedError = UnexpectedError $ FileSystemError $ FsError
+  { fsErrorType   = FsIllegalOperation
+  , fsErrorPath   = ["<mockedError>"]
+  , fsErrorString = "mocked error"
+  , fsErrorStack  = callStack
+  , fsLimitation  = False
+  }
+
+isMockedError :: ImmutableDBError -> Bool
+isMockedError = sameImmutableDBError mockedError
+
+{-------------------------------------------------------------------------------
+  Generator
+-------------------------------------------------------------------------------}
+
+
+-- | Generate a 'Cmd'.
+generator :: Model m Symbolic -> Gen (At Cmd m Symbolic)
+generator Model {..} = At <$> frequency
+    [ (1, GetBinaryBlob <$> frequency [ (10, genEpochSlotInThePast)
+                                      , (1, genEpochSlotInTheFuture)
+                                      , (1, genEpochSlot) ])
+    , (2, StartNewEpoch <$> genEpochSize)
+    , (3, do
+            relSlot <- genRelSlot
+            return $ AppendBinaryBlob relSlot (TestBlock relSlot))
+    , (1, frequency
+            -- An iterator with a random and likely invalid range,
+            [ (1, StreamBinaryBlobs <$> (Just <$> genEpochSlot)
+                                    <*> (Just <$> genEpochSlot))
+            -- An iterator that is more likely to be valid. A
+            -- SlotGreaterThanEpochSizeError is still possible.
+            , (2, do
+                    start <- genEpochSlotInThePast
+                    end   <- genEpochSlotInThePast `suchThat` (>= start)
+                    return $ StreamBinaryBlobs (Just start) (Just end))
+            -- Same as above, but with possible empty bounds
+            , (2, do
+                    start <- genEpochSlotInThePast
+                    end   <- genEpochSlotInThePast `suchThat` (>= start)
+                    mbStart <- elements [Nothing, Just start]
+                    mbEnd   <- elements [Nothing, Just end]
+                    return $ StreamBinaryBlobs mbStart mbEnd)
+            ])
+      -- Only if there are iterators can we generate commands that manipulate
+      -- them.
+    , (if Map.null dbmIterators then 0 else 4,
+       do
+         iter <- elements $ RE.keys knownIters
+         frequency [ (4, return $ IteratorNext  iter)
+                   , (1, return $ IteratorClose iter) ])
+    ]
+  where
+    DBModel {..} = dbModel
+    currentEpochSize = CES.lastEpochSize dbmCumulEpochSizes
+
+    EpochSlot maxEpoch nextSlot = lookupNextEpochSlot dbModel
+
+    genEpochSize = choose (1, 20)
+
+    -- + x because we also want relative slots that are greater than the epoch
+    -- size
+    genRelSlot = RelativeSlot <$> choose (0, currentEpochSize + 2)
+
+    genEpochSlot = EpochSlot <$> arbitrary <*> genRelSlot
+
+    genEpochSlotInThePast = do
+      epoch <- choose (0, maxEpoch)
+      slot  <- if epoch == maxEpoch
+               then choose (0, getRelativeSlot nextSlot - 1)
+               else arbitrary
+      return (EpochSlot epoch (RelativeSlot slot))
+
+    genEpochSlotInTheFuture = do
+      epoch <- choose (maxEpoch, maxBound)
+      slot  <- if epoch == maxEpoch
+               then choose (getRelativeSlot nextSlot, maxBound)
+               else arbitrary
+      return (EpochSlot epoch (RelativeSlot slot))
+
+-- | Generate a 'CmdErr' without 'Errors'
+generatorNoErr :: Model m Symbolic -> Maybe (Gen (At CmdErr m Symbolic))
+generatorNoErr m =
+    Just $ At . CmdErr Nothing . unAt <$> generator m
+
+-- | Generate a 'CmdErr' that can have 'Errors'
+generatorErr :: Model m Symbolic -> Maybe (Gen (At CmdErr m Symbolic))
+generatorErr m@Model {..}
+    | isJust simulatedError  -- If an error was thrown, stop testing
+    = Nothing
+    | otherwise
+    = Just $ At <$> frequency
+      -- We want to make some progress
+      [ (4, CmdErr Nothing <$> genModel)
+      , (1, CmdErr <$> (Just <$> arbitrary) <*> genModel) ]
+  where
+    genModel = unAt <$> generator m
+
+
+{-------------------------------------------------------------------------------
+  Shrinking
+-------------------------------------------------------------------------------}
+
+-- | Shrinker
+shrinker :: At CmdErr m Symbolic -> [At CmdErr m Symbolic]
+shrinker (At (CmdErr mbErrors cmd)) = fmap At $
+    [ CmdErr mbErrors' cmd  | mbErrors' <- shrink mbErrors ] ++
+    [ CmdErr mbErrors  cmd' | At cmd'   <- shrinkCmd (At cmd) ]
+
+-- | Shrink a 'Cmd'.
+shrinkCmd :: At Cmd m Symbolic -> [At Cmd m Symbolic]
+shrinkCmd (At cmd) = fmap At $ case cmd of
+    AppendBinaryBlob relSlot _ ->
+      [ AppendBinaryBlob relSlot' (TestBlock relSlot')
+      | relSlot' <- shrinkRelativeSlot relSlot]
+    StartNewEpoch epochSize ->
+      [StartNewEpoch epochSize' | epochSize' <- shrink epochSize
+                                , epochSize' > 0]
+    StreamBinaryBlobs mbStart mbEnd ->
+      [ StreamBinaryBlobs mbStart' mbEnd
+      | mbStart' <- shrinkMbEpochSlot mbStart] ++
+      [ StreamBinaryBlobs mbStart  mbEnd'
+      | mbEnd'   <- shrinkMbEpochSlot mbEnd]
+    GetBinaryBlob epochSlot ->
+      [GetBinaryBlob epochSlot' | epochSlot' <- shrinkEpochSlot epochSlot]
+    IteratorNext  {} -> []
+    IteratorClose {} -> []
+  where
+    shrinkRelativeSlot :: RelativeSlot -> [RelativeSlot]
+    shrinkRelativeSlot = genericShrink
+    shrinkMbEpochSlot :: Maybe EpochSlot -> [Maybe EpochSlot]
+    shrinkMbEpochSlot Nothing   = []
+    shrinkMbEpochSlot (Just es) = Nothing : map Just (shrinkEpochSlot es)
+    shrinkEpochSlot :: EpochSlot -> [EpochSlot]
+    shrinkEpochSlot (EpochSlot epoch relSlot) =
+      [EpochSlot epoch' relSlot  | epoch'   <- shrink epoch] ++
+      [EpochSlot epoch  relSlot' | relSlot' <- shrinkRelativeSlot relSlot]
+
+{-------------------------------------------------------------------------------
+  The final state machine
+-------------------------------------------------------------------------------}
+
+
+-- | Mock a response
+--
+-- We do this by running the pure semantics and then generating mock
+-- references for any new handles.
+mock :: Typeable m
+     => Model           m Symbolic
+     -> At CmdErr       m Symbolic
+     -> GenSym (At Resp m Symbolic)
+mock model cmdErr = At <$> traverse (const genSym) resp
+  where
+    resp = stepErr model cmdErr
+
+precondition :: Model m Symbolic -> At CmdErr m Symbolic -> Logic
+precondition Model {..} (At (CmdErr _ cmd)) =
+    Boolean (isNothing simulatedError) .&&
+    forall (iters cmd) (`elem` RE.keys knownIters)
+
+transition :: (Show1 r, Eq1 r)
+           => Model m r -> At CmdErr m r -> At Resp m r -> Model m r
+transition model cmdErr = eventAfter . lockstep model cmdErr
+
+postcondition :: Model m Concrete
+              -> At CmdErr m Concrete
+              -> At Resp m Concrete
+              -> Logic
+postcondition model cmdErr@(At (CmdErr mbErrors _)) resp = case unAt resp of
+    -- Check that the UnexpectedError that was simulated
+    Resp (Left (UnexpectedError {}))
+      | Just _ <- mbErrors -> Top
+
+    -- Report an unexpected success when a simulated error was supposed to be
+    -- thrown
+    Resp (Right _)
+      | Just _ <- mbErrors ->
+      Bot .// "postconditionErr expected failure"
+
+    -- Otherwise: expected success or expected error. Even when simulating an
+    -- error, it is possible that we expect another error to be thrown, which
+    -- can happen before the simulated is thrown.
+    _ -> toMock (eventAfter ev) resp .== eventMockResp ev
+  where
+    ev = lockstep model cmdErr resp
+
+toResp :: (Typeable m, MonadMask n)
+       => n (Success (Iterator m)) -> n (At Resp m Concrete)
+toResp n = At . fmap (reference . Opaque) . Resp <$> tryImmDB n
+
+-- | Ignores the 'Errors'
+semantics :: (MonadMask m, Typeable m)
+          => ImmutableDB m -> At CmdErr m Concrete
+          -> m (At Resp m Concrete)
+semantics db (At (CmdErr _ cmd)) = toResp $ run db (opaque <$> cmd)
+
+semanticsErr :: RealDBErr -> At CmdErr RealErrM Concrete
+             -> RealErrM (At Resp RealErrM Concrete)
+semanticsErr db (At cmdErr) = case opaque <$> cmdErr of
+    CmdErr Nothing _         -> semantics db (At cmdErr)
+    CmdErr (Just errors) cmd -> At . fmap (reference . Opaque) <$> do
+      res <- withErrors errors $ tryImmDB $ run db cmd
+      case res of
+        Left _ -> return (Resp res)
+        -- When by coincidence no error was thrown, force an error to be
+        -- thrown, as we need the outcome to be deterministic. The mocked
+        -- response for this command must match the actual command. When
+        -- constructing the mocked response, we don't know yet whether the
+        -- simulated error will be thrown in practice or not. We assume it is
+        -- thrown, so we must make sure here it is actually thrown.
+        Right _ -> do
+          when (unexpectedErrorShouldCloseDB cmd) $ closeDB db
+          return $ Resp (Left forcedError)
+
+forcedFsError :: HasCallStack => FsError
+forcedFsError = FsError
+  { fsErrorType   = FsIllegalOperation
+  , fsErrorPath   = ["<forcedError>"]
+  , fsErrorString = "forced error"
+  , fsErrorStack  = callStack
+  , fsLimitation  = False
+  }
+
+forcedError :: HasCallStack => ImmutableDBError
+forcedError = UnexpectedError $ FileSystemError forcedFsError
+
+-- | Should an 'UnexpectedError' thrown during the 'Cmd' close the database?
+--
+-- Yes for write operations, no for read operations.
+unexpectedErrorShouldCloseDB :: Cmd it -> Bool
+unexpectedErrorShouldCloseDB cmd = case cmd of
+    AppendBinaryBlob  {} -> True
+    StartNewEpoch     {} -> True
+    GetBinaryBlob     {} -> False
+    StreamBinaryBlobs {} -> False
+    IteratorNext      {} -> False
+    IteratorClose     {} -> False
+
+-- | The state machine proper
+sm :: RealDB
+   -> DBModel
+   -> ModelDBPure
+   -> StateMachine (Model RealM) (At CmdErr RealM) RealM (At Resp RealM)
+sm db dbm mdb = StateMachine
+  { initModel     = initModel dbm mdb
+  , transition    = transition
+  , precondition  = precondition
+  , postcondition = postcondition
+  , generator     = generatorNoErr
+  , shrinker      = const shrinker
+  , semantics     = semantics db
+  , mock          = mock
+  , invariant     = Nothing
+  , distribution  = Nothing
+  }
+
+-- | The state machine with errors
+smErr :: RealDBErr
+      -> DBModel
+      -> ModelDBPure
+      -> StateMachine (Model RealErrM) (At CmdErr RealErrM) RealErrM (At Resp RealErrM)
+smErr db dbm mdb = StateMachine
+  { initModel     = initModel dbm mdb
+  , transition    = transition
+  , precondition  = precondition
+  , postcondition = postcondition
+  , generator     = generatorErr
+  , shrinker      = const shrinker
+  , semantics     = semanticsErr db
+  , mock          = mock
+  , invariant     = Nothing
+  , distribution  = Nothing
+  }
+
+{-------------------------------------------------------------------------------
+  Validation
+-------------------------------------------------------------------------------}
+
+validate :: forall m. Monad m
+         => Model m Concrete -> ImmutableDB m
+         -> m ()
+validate Model {..} db = flip evalStateT dbModel $ do
+    itDB    <- runDB    $ streamBinaryBlobs db     Nothing Nothing
+    itModel <- runModel $ streamBinaryBlobs mockDB Nothing Nothing
+    let loop = do
+          dbRes    <- runDB    $ iteratorNext itDB
+          modelRes <- runModel $ iteratorNext itModel
+          case (dbRes, modelRes) of
+            -- The database should be a prefix of the model, so this is
+            -- fine
+            (IteratorExhausted, _) -> return ()
+            (IteratorResult {},  IteratorResult {})
+              | dbRes == modelRes -> loop
+            _ -> fail $ "Mismatch between database (" <> show dbRes <>
+                        ") and model (" <> show modelRes <> ")"
+    loop
+  where
+    runDB :: m a -> StateT DBModel m a
+    runDB = lift
+
+    runModel :: PureM a -> StateT DBModel m a
+    runModel m = do
+      s <- get
+      case runState (runExceptT m) s of
+        (Left e,  _)  -> fail $ prettyImmutableDBError e
+        (Right a, s') -> put s' >> return a
+
+
+{-------------------------------------------------------------------------------
+  Labelling
+-------------------------------------------------------------------------------}
+
+data Tag
+  = TagGetBinaryBlobJust
+
+  | TagGetBinaryBlobNothing
+
+  | TagReadFutureSlotError
+
+  | TagSlotGreaterThanEpochSizeError
+
+  | TagAppendToSlotInThePastError
+
+  | TagGetFromEmptyEpoch
+
+  | TagEmptyEpochsInARow Int
+
+  | TagIteratorStartsOnEmptySlot
+
+  | TagIteratorStartsInEmptyEpoch
+
+  | TagIteratorStreamedNBlobs Int
+
+  | TagIteratorWithoutBounds
+
+  | TagErrorDuringAppendBinaryBlob
+
+  | TagErrorDuringStartNewEpoch
+
+  | TagErrorDuringGetBinaryBlob
+
+  | TagErrorDuringStreamBinaryBlobs
+
+  | TagErrorDuringIteratorNext
+
+  | TagErrorDuringIteratorClose
+
+  deriving (Show, Eq)
+
+
+-- | Predicate on events
+type EventPred m = C.Predicate (Event m Symbolic) Tag
+
+-- | Convenience combinator for creating classifiers for successful commands
+successful :: (    Event m Symbolic
+                -> Success (Iterator PureM)
+                -> Either Tag (EventPred m)
+              )
+           -> EventPred m
+successful f = C.predicate $ \ev -> case eventMockResp ev of
+    Resp (Left  _ ) -> Right $ successful f
+    Resp (Right ok) -> f ev ok
+
+-- | Convenience combinator for creating classifiers for failed commands
+failed :: (    Event m Symbolic
+            -> ImmutableDBError
+            -> Either Tag (EventPred m)
+          )
+       -> EventPred m
+failed f = C.predicate $ \ev -> case eventMockResp ev of
+    Resp (Left  e) -> f ev e
+    Resp (Right _) -> Right $ failed f
+
+-- | Convenience combinator for creating classifiers for commands failed with
+-- a 'UserError'
+failedUserError :: (    Event m Symbolic
+                     -> UserError
+                     -> Either Tag (EventPred m)
+                   )
+                -> EventPred m
+failedUserError f = failed $ \ev e -> case e of
+    UserError ue _ -> f ev ue
+    _              -> Right $ failedUserError f
+
+
+
+-- | Convenience combinator for creating classifiers for commands during which
+-- a generated FsError was thrown
+errorExpected :: (Event m Symbolic -> Either Tag (EventPred m))
+              -> EventPred m
+errorExpected f = C.predicate $ \ev ->
+    case eventMockResp ev of
+      Resp (Left  e) | isMockedError e -> f ev
+      Resp _ -> Right $ errorExpected f
+
+
+-- | Tag commands
+--
+-- Tagging works on symbolic events, so that we can tag without doing real IO.
+tag :: forall m. [Event m Symbolic] -> [Tag]
+tag = C.classify
+    [ tagGetBinaryBlobJust
+    , tagGetBinaryBlobNothing
+    , tagReadFutureSlotError
+    , tagSlotGreaterThanEpochSizeError
+    , tagAppendToSlotInThePastError
+    , tagGetFromEmptyEpoch
+    , tagEmptyEpochsInARow 0
+    , tagIteratorStartsOnEmptySlot
+    , tagIteratorStartsInEmptyEpoch
+    , tagIteratorStreamedNBlobs Map.empty
+    , tagIteratorWithoutBounds
+    , tagErrorDuringAppendBinaryBlob
+    , tagErrorDuringStartNewEpoch
+    , tagErrorDuringGetBinaryBlob
+    , tagErrorDuringStreamBinaryBlobs
+    , tagErrorDuringIteratorNext
+    , tagErrorDuringIteratorClose
+    ]
+  where
+    tagGetBinaryBlobJust :: EventPred m
+    tagGetBinaryBlobJust = successful $ \ev r -> case r of
+      Blob (Just _) | GetBinaryBlob {} <- unAt $ eventCmd ev ->
+        Left TagGetBinaryBlobJust
+      _ -> Right tagGetBinaryBlobJust
+
+    tagGetBinaryBlobNothing :: EventPred m
+    tagGetBinaryBlobNothing = successful $ \ev r -> case r of
+      Blob Nothing | GetBinaryBlob {} <- unAt $ eventCmd ev ->
+        Left TagGetBinaryBlobNothing
+      _ -> Right tagGetBinaryBlobNothing
+
+    tagReadFutureSlotError :: EventPred m
+    tagReadFutureSlotError = failedUserError $ \_ e -> case e of
+      ReadFutureSlotError {} -> Left TagReadFutureSlotError
+      _ -> Right tagReadFutureSlotError
+
+    tagSlotGreaterThanEpochSizeError :: EventPred m
+    tagSlotGreaterThanEpochSizeError = failedUserError $ \_ e -> case e of
+      SlotGreaterThanEpochSizeError {} -> Left TagSlotGreaterThanEpochSizeError
+      _ -> Right tagSlotGreaterThanEpochSizeError
+
+    tagAppendToSlotInThePastError :: EventPred m
+    tagAppendToSlotInThePastError = failedUserError $ \_ e -> case e of
+      AppendToSlotInThePastError {} -> Left TagAppendToSlotInThePastError
+      _ -> Right tagAppendToSlotInThePastError
+
+    tagGetFromEmptyEpoch :: EventPred m
+    tagGetFromEmptyEpoch = successful $ \ev r -> case r of
+      Blob Nothing
+        | At (GetBinaryBlob (EpochSlot epoch _)) <- eventCmd ev
+          -- No blobs start in the given epoch
+        , not $ any ((epoch ==) .  _epoch) $ Map.keys $ dbmBlobs
+        $ dbModel $ eventBefore ev
+        -> Left  TagGetFromEmptyEpoch
+      _ -> Right tagGetFromEmptyEpoch
+
+    tagEmptyEpochsInARow :: Int -> EventPred m
+    tagEmptyEpochsInARow before = C.Predicate
+      { C.predApply = \ev -> case eventMockResp ev of
+          Resp (Right _)
+            | At (StartNewEpoch {}) <- eventCmd ev
+            -> Right $ tagEmptyEpochsInARow (before + 1)
+          _ -> Right $ tagEmptyEpochsInARow 0
+      , C.predFinish = case before > 0 of
+          True  -> Just $ TagEmptyEpochsInARow before
+          False -> Nothing
+      }
+
+    tagIteratorStartsOnEmptySlot :: EventPred m
+    tagIteratorStartsOnEmptySlot = successful $ \ev _ -> case eventCmd ev of
+      At (StreamBinaryBlobs (Just start) _)
+        | Map.notMember start $ dbmBlobs $ dbModel $ eventBefore ev
+        -> Left  TagIteratorStartsOnEmptySlot
+      _ -> Right tagIteratorStartsOnEmptySlot
+
+    tagIteratorStartsInEmptyEpoch :: EventPred m
+    tagIteratorStartsInEmptyEpoch = successful $ \ev _ -> case eventCmd ev of
+      At (StreamBinaryBlobs (Just (EpochSlot epoch _)) _)
+        | not $ any ((epoch ==) .  _epoch) $ Map.keys $ dbmBlobs
+        $ dbModel $ eventBefore ev
+        -> Left  TagIteratorStartsInEmptyEpoch
+      _ -> Right tagIteratorStartsInEmptyEpoch
+
+    tagIteratorStreamedNBlobs :: Map (Iterator PureM) Int
+                              -> EventPred m
+    tagIteratorStreamedNBlobs blobsStreamed = C.Predicate
+      { C.predApply = \ev -> case eventMockResp ev of
+          Resp (Right (IterResult (IteratorResult {})))
+            | IteratorNext it <- eventMockCmd ev
+            -> Right $ tagIteratorStreamedNBlobs $
+               Map.insertWith (+) it 1 blobsStreamed
+          _ -> Right $ tagIteratorStreamedNBlobs blobsStreamed
+      , C.predFinish = do
+          -- Find the entry with the highest value, i.e. the iterator that has
+          -- streamed the most blobs
+          (_, streamed) <- listToMaybe $ sortBy (flip compare `on` snd) $
+                           Map.toList blobsStreamed
+          return $ TagIteratorStreamedNBlobs streamed
+      }
+
+    tagIteratorWithoutBounds :: EventPred m
+    tagIteratorWithoutBounds = successful $ \ev _ -> case eventCmd ev of
+      At (StreamBinaryBlobs Nothing Nothing) -> Left TagIteratorWithoutBounds
+      _ -> Right tagIteratorWithoutBounds
+
+    tagErrorDuringAppendBinaryBlob :: EventPred m
+    tagErrorDuringAppendBinaryBlob = errorExpected $ \ev -> case eventCmd ev of
+      At (AppendBinaryBlob {}) -> Left TagErrorDuringAppendBinaryBlob
+      _ -> Right tagErrorDuringAppendBinaryBlob
+
+    tagErrorDuringStartNewEpoch :: EventPred m
+    tagErrorDuringStartNewEpoch = errorExpected $ \ev -> case eventCmd ev of
+      At (StartNewEpoch {}) -> Left TagErrorDuringStartNewEpoch
+      _ -> Right tagErrorDuringStartNewEpoch
+
+    tagErrorDuringGetBinaryBlob :: EventPred m
+    tagErrorDuringGetBinaryBlob = errorExpected $ \ev -> case eventCmd ev of
+      At (GetBinaryBlob {}) -> Left TagErrorDuringGetBinaryBlob
+      _ -> Right tagErrorDuringGetBinaryBlob
+
+    tagErrorDuringStreamBinaryBlobs :: EventPred m
+    tagErrorDuringStreamBinaryBlobs = errorExpected $ \ev -> case eventCmd ev of
+      At (StreamBinaryBlobs {}) -> Left TagErrorDuringStreamBinaryBlobs
+      _ -> Right tagErrorDuringStreamBinaryBlobs
+
+    tagErrorDuringIteratorNext :: EventPred m
+    tagErrorDuringIteratorNext = errorExpected $ \ev -> case eventCmd ev of
+      At (IteratorNext {}) -> Left TagErrorDuringIteratorNext
+      _ -> Right tagErrorDuringIteratorNext
+
+    tagErrorDuringIteratorClose :: EventPred m
+    tagErrorDuringIteratorClose = errorExpected $ \ev -> case eventCmd ev of
+      At (IteratorClose {}) -> Left TagErrorDuringIteratorClose
+      _ -> Right tagErrorDuringIteratorClose
+
+
+-- | Step the model using a 'QSM.Command' (i.e., a command associated with
+-- an explicit set of variables)
+execCmd :: Model m Symbolic
+        -> QSM.Command (At CmdErr m) (At Resp m)
+        -> Event m Symbolic
+execCmd model (QSM.Command cmdErr resp _vars) = lockstep model cmdErr resp
+
+-- | 'execCmds' is just the repeated form of 'execCmd'
+execCmds :: forall m
+          . Model m Symbolic
+         -> QSM.Commands (At CmdErr m) (At Resp m) -> [Event m Symbolic]
+execCmds model = \(QSM.Commands cs) -> go model cs
+  where
+    go :: Model m Symbolic -> [QSM.Command (At CmdErr m) (At Resp m)]
+       -> [Event m Symbolic]
+    go _ []        = []
+    go m (c : cs) = let ev = execCmd m c in ev : go (eventAfter ev) cs
+
+
+{-------------------------------------------------------------------------------
+  Required instances
+
+  The 'ToExpr' constraints come from "Data.TreeDiff".
+-------------------------------------------------------------------------------}
+
+instance CommandNames (At Cmd m) where
+  cmdName (At cmd) = constrName cmd
+  cmdNames (_ :: Proxy (At Cmd m r)) =
+    constrNames (Proxy @(Cmd (IterRef m r)))
+
+instance CommandNames (At CmdErr m) where
+  cmdName (At (CmdErr _ cmd)) = constrName cmd
+  cmdNames (_ :: Proxy (At CmdErr m r)) =
+    constrNames (Proxy @(Cmd (IterRef m r)))
+
+instance Show (Iterator PureM) where
+  show it = "<iterator " <> show (iteratorID it) <> ">"
+
+instance Show ModelDBPure where
+  show _ = "<ModelDB>"
+
+instance ToExpr Slot where
+  toExpr (Slot w) = App "Slot" [toExpr w]
+
+instance ToExpr EpochSlot
+instance ToExpr RelativeSlot
+instance ToExpr IteratorID
+instance ToExpr CumulEpochSizes
+instance ToExpr IteratorModel
+instance ToExpr DBModel
+
+instance ToExpr FsError where
+  toExpr fsError = App (show fsError) []
+
+instance ToExpr ModelDBPure where
+  toExpr db = App (show db) []
+
+instance ToExpr (Iterator PureM) where
+  toExpr it = App (show it) []
+
+instance ToExpr (Model m Concrete)
+
+-- Orphan instance to store 'Iterator's in a 'Map'.
+instance Ord (Iterator m) where
+  compare = compare `on` iteratorID
+
+{-------------------------------------------------------------------------------
+  Top-level tests
+-------------------------------------------------------------------------------}
+
+-- | Show minimal examples for each of the generated tags
+--
+showLabelledExamples'
+  :: Maybe Int
+  -- ^ Seed
+  -> Int
+  -- ^ Number of tests to run to find examples
+  -> (Tag -> Bool)
+  -- ^ Tag filter (can be @const True@)
+  -> (    ImmutableDB m
+       -> DBModel
+       -> ModelDBPure
+       -> StateMachine (Model m) (At CmdErr m) m (At Resp m)
+     )
+  -- ^ The state machine
+  -> IO ()
+showLabelledExamples' mbReplay numTests focus stateMachine = do
+    replaySeed <- case mbReplay of
+      Nothing   -> getStdRandom (randomR (1,999999))
+      Just seed -> return seed
+
+    labelledExamplesWith (stdArgs { replay     = Just (mkQCGen replaySeed, 0)
+                                  , maxSuccess = numTests
+                                  }) $
+      forAllShrinkShow (QSM.generateCommands smUnused Nothing)
+                       (QSM.shrinkCommands   smUnused)
+                       ppShow $ \cmds ->
+        collects (filter focus . tag . execCmds (QSM.initModel smUnused) $ cmds) $
+          property True
+  where
+    (dbm, mdb) = mkDBModel
+    smUnused = stateMachine dbUnused dbm mdb
+
+
+showLabelledExamples :: IO ()
+showLabelledExamples =
+    showLabelledExamples' Nothing 1000 nonError sm
+  where
+    nonError TagErrorDuringAppendBinaryBlob = False
+    nonError TagErrorDuringStartNewEpoch    = False
+    nonError TagErrorDuringGetBinaryBlob    = False
+    nonError _                              = True
+
+showLabelledErrorExamples :: IO ()
+showLabelledErrorExamples =
+    showLabelledExamples' Nothing 1000 (const True) smErr
+
+prop_sequential :: Property
+prop_sequential = forAllCommands smUnused Nothing $ \cmds ->
+    QCM.monadic (ioProperty . runSimIO) $ do
+      (db, Nothing) <- QCM.run $
+        openDB hasFS EH.monadCatch dbFolder 0 (Map.singleton 0 firstEpochSize)
+          NoValidation
+      let sm' = sm db dbm mdb
+      (hist, model, res) <- runCommands sm' cmds
+      lastBlobLocation <- QCM.run $ do
+        closeDB db
+        lastBlobLocation <- reopen db NoValidation
+        validate model db
+        closeDB db
+        return lastBlobLocation
+
+      let lastBlobLocationModel = getLastBlobLocation $ dbModel model
+
+      prettyCommands sm' hist
+        $ tabulate "Tags" (map show $ tag (execCmds (QSM.initModel sm') cmds))
+        $ res === Ok .&&. lastBlobLocationModel === lastBlobLocation
+  where
+    (dbm, mdb) = mkDBModel
+    smUnused = sm dbUnused dbm mdb
+    hasFS = hasFSRealM
+
+
+prop_sequential_errors :: Property
+prop_sequential_errors = forAllCommands smUnused Nothing $ \cmds ->
+    QCM.monadic (ioProperty . runSimErrorIO) $ do
+      (db, Nothing) <- QCM.run $
+        openDB hasFS EH.monadCatch dbFolder 0 (Map.singleton 0 firstEpochSize)
+          NoValidation
+      let sm' = smErr db dbm mdb
+      (hist, model, res) <- runCommands sm' cmds
+      let events = execCmds (QSM.initModel sm') cmds
+          mbLastEvent = lastMaybe events
+      reopenedEpoch <- QCM.run $ do
+        checkIfDBClosedWhenNecessary db mbLastEvent
+        -- If we don't close all (open) iterators, we may still have open
+        -- handles to database files that have to be removed while
+        -- reopening/restoring the database.
+        closeIterators model
+        let recPol = RestoreToLastValidEpoch $ testBlockEpochFileParser' hasFS
+        _lastBlobLocation <- reopen db recPol -- TODO check
+        reopenedEpoch <- getCurrentEpoch db
+        validate model db
+        closeDB db
+        return reopenedEpoch
+
+      let (errSimulated, errDuring, errForced, errMsg) = case mbLastEvent of
+            Nothing -> let none = "no commands" in (none, none, none, none)
+            Just ev -> case simulatedError model of
+              Nothing  -> ("no", "no error", "no error", "no error")
+              Just fsErr -> ("yes", cmdName (eventCmd ev),
+                             if sameFsError fsErr forcedFsError
+                             then "forced" else "unforced",
+                             fsErrorString fsErr)
+          lastModelEpoch   = CES.lastEpoch $ dbmCumulEpochSizes $ dbModel model
+          epochsRolledBack = lastModelEpoch - reopenedEpoch
+          reopenedEpochStr
+            | reopenedEpoch > 3 = ">3"
+            | otherwise         = show reopenedEpoch
+
+      prettyCommands sm' hist
+        $ tabulate "Tags"                   (map show (tag events))
+        $ tabulate "Error simulated"        [errSimulated]
+        $ tabulate "Error simulated during" [errDuring]
+        $ tabulate "Error forced"           [errForced]
+        $ tabulate "Error msg"              [errMsg]
+        $ tabulate "Reopened epoch"         [reopenedEpochStr]
+        $ tabulate "Epochs rolled back"     [show epochsRolledBack]
+        $ res === Ok .&&. epochsRolledBack <= 1
+  where
+    (dbm, mdb) = mkDBModel
+    smUnused = smErr dbUnused dbm mdb
+    hasFS = hasFSRealErrM
+
+    checkIfDBClosedWhenNecessary db mbLastEvent = do
+      open <- isOpen db
+      case mbLastEvent of
+        Nothing -> return ()
+        Just ev
+          | isJust $ simulatedError (eventAfter ev)
+          , unexpectedErrorShouldCloseDB (unAt (eventCmd ev))
+          -> when open $
+             fail "Database is still open while it should be closed"
+          | otherwise
+          -> unless open $
+             fail "Database is closed while it should be open"
+
+closeIterators :: Monad m => Model m Concrete -> m ()
+closeIterators Model {..} =
+  mapM_ (iteratorClose . opaque) (RE.keys knownIters)
+
+tests :: TestTree
+tests = testGroup "ImmutableDB q-s-m"
+    [ testProperty "sequential" prop_sequential
+    , testProperty "sequential with errors" prop_sequential_errors
+    ]
+
+runSimIO :: SimFS IO a -> IO a
+runSimIO m = fst <$> runSimFS m Mock.empty
+
+runSimErrorIO :: SimErrorFS IO a -> IO a
+runSimErrorIO m = fst <$> runSimErrorFS m Mock.empty mempty
+
+firstEpochSize :: EpochSize
+firstEpochSize = 10
+
+dbFolder :: FsPath
+dbFolder = ["test"]
+
+mkDBModel :: MonadState DBModel m
+          => (DBModel, ImmutableDB (ExceptT ImmutableDBError m))
+mkDBModel = openDBModel EH.exceptT firstEpochSize
+
+dbUnused :: ImmutableDB m
+dbUnused = error "semantics and DB used during command generation"
+
+hasFSRealM :: HasFS RealM
+hasFSRealM = simHasFS EH.monadCatch
+
+hasFSRealErrM :: HasFS RealErrM
+hasFSRealErrM = mkSimErrorHasFS hasFSRealM
+
+
+-- TODO use condense?
+
+{-------------------------------------------------------------------------------
+  generics-sop auxiliary
+-------------------------------------------------------------------------------}
+
+cmdConstrInfo :: Proxy (Cmd it)
+              -> SOP.NP SOP.ConstructorInfo (SOP.Code (Cmd it))
+cmdConstrInfo = SOP.constructorInfo . SOP.datatypeInfo
+
+constrName :: forall it. Cmd it -> String
+constrName a =
+    SOP.hcollapse $ SOP.hliftA2 go (cmdConstrInfo p) (SOP.unSOP (SOP.from a))
+  where
+    go :: SOP.ConstructorInfo a -> SOP.NP SOP.I a -> SOP.K String a
+    go nfo _ = SOP.K $ SOP.constructorName nfo
+
+    p = Proxy @(Cmd it)
+
+constrNames :: Proxy (Cmd it) -> [String]
+constrNames p =
+    SOP.hcollapse $ SOP.hmap go (cmdConstrInfo p)
+  where
+    go :: SOP.ConstructorInfo a -> SOP.K String a
+    go nfo = SOP.K $ SOP.constructorName nfo

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE TupleSections    #-}
+-- | Block used for the state machine tests
+module Test.Ouroboros.Storage.ImmutableDB.TestBlock
+  ( TestBlock(..)
+  , testBlockRepeat
+  , testBlockSize
+  , testBlockToBuilder
+  , testBlockEpochFileParser
+  , testBlockEpochFileParser'
+
+  , tests
+  ) where
+
+import           Control.Monad (void, when, replicateM)
+import           Control.Monad.Catch (MonadMask)
+
+import qualified Data.Binary as Bin
+import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Lazy as BL
+
+import           GHC.Generics (Generic)
+
+import           System.IO (IOMode(..))
+
+import           Test.QuickCheck
+import qualified Test.QuickCheck.Monadic as QCM
+import qualified Test.StateMachine.Utils as QSM
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Ouroboros.Storage.FS.API (HasFS(..), withFile)
+import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
+import           Ouroboros.Storage.FS.Sim.STM (SimFS, runSimFS, simHasFS)
+import           Ouroboros.Storage.ImmutableDB.Types
+import           Ouroboros.Storage.ImmutableDB.Util (readAll)
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+
+{-------------------------------------------------------------------------------
+  TestBlock
+-------------------------------------------------------------------------------}
+
+
+newtype TestBlock = TestBlock { tbRelativeSlot :: RelativeSlot }
+    deriving (Generic, Eq, Ord)
+
+instance Show TestBlock where
+    show = show . getRelativeSlot . tbRelativeSlot
+
+instance Arbitrary TestBlock where
+    arbitrary = TestBlock . RelativeSlot <$> arbitrary
+
+-- | The binary representation of 'TestBlock' consists of repeating its
+-- 'RelativeSlot' @n@ times, where @n = 'testBlockSize'@.
+testBlockRepeat :: Int
+testBlockRepeat = 10
+
+-- | The number of bytes the binary representation 'TestBlock' takes up.
+testBlockSize :: Int
+testBlockSize = testBlockRepeat * 8
+
+-- | The encoding of TestBlock @x@ is the encoding of @x@ as a 'Word',
+-- repeated 10 times. This means that:
+--
+-- * We know the size of each block (no delimiters needed)
+-- * We know the relative slot of the block
+-- * We know when the block is corrupted
+instance Bin.Binary TestBlock where
+    put (TestBlock (RelativeSlot relSlot)) =
+      mconcat $ replicate testBlockRepeat (Bin.put relSlot)
+    get = do
+      (w:ws) <- replicateM testBlockRepeat Bin.get
+      when (any (/= w) ws) $
+        fail "Corrupt TestBlock"
+      return $ TestBlock (RelativeSlot w)
+
+newtype TestBlocks = TestBlocks [TestBlock]
+    deriving (Show)
+
+instance Arbitrary TestBlocks where
+    arbitrary = TestBlocks <$> orderedList
+    shrink (TestBlocks testBlocks) =
+      TestBlocks <$> shrinkList (const []) testBlocks
+
+testBlockToBuilder :: TestBlock -> BS.Builder
+testBlockToBuilder = BS.lazyByteString . Bin.encode
+
+
+{-------------------------------------------------------------------------------
+  EpochFileParser
+-------------------------------------------------------------------------------}
+
+testBlockEpochFileParser :: MonadMask m
+                         => HasFS m
+                         -> EpochFileParser String m TestBlock
+testBlockEpochFileParser hasFS@HasFS{..} = EpochFileParser $ \fsPath ->
+    withFile hasFS fsPath ReadMode $ \eHnd -> do
+      bytesInFile <- hGetSize eHnd
+      parse (fromIntegral bytesInFile) 0 [] . BS.toLazyByteString <$>
+        readAll hasFS eHnd
+  where
+    parse :: SlotOffset
+          -> SlotOffset
+          -> [(SlotOffset, TestBlock)]
+          -> BL.ByteString
+          -> ([(SlotOffset, TestBlock)], Maybe String)
+    parse bytesInFile offset parsed bs
+      | offset >= bytesInFile
+      = (reverse parsed, Nothing)
+      | otherwise
+      = case Bin.decodeOrFail bs of
+          Left (_, _, e) -> (reverse parsed, Just e)
+          Right (remaining, bytesConsumed, testBlock) ->
+            let newOffset = offset + fromIntegral bytesConsumed
+                newParsed = (offset, testBlock) : parsed
+            in parse bytesInFile newOffset newParsed remaining
+
+testBlockEpochFileParser' :: MonadMask m
+                          => HasFS m
+                          -> EpochFileParser String m (Int, RelativeSlot)
+testBlockEpochFileParser' hasFS = (\tb -> (testBlockSize, tbRelativeSlot tb)) <$>
+    testBlockEpochFileParser hasFS
+
+
+prop_testBlockEpochFileParser :: TestBlocks -> Property
+prop_testBlockEpochFileParser (TestBlocks blocks) = QCM.monadicIO $ do
+    (offsetsAndBlocks, mbErr) <- QCM.run $ runSimIO $ do
+      writeBlocks
+      readBlocks
+    QSM.liftProperty (mbErr === Nothing)
+    let (offsets', blocks') = unzip offsetsAndBlocks
+        offsets = dropLast $ scanl (+) 0 $
+          map (const (fromIntegral testBlockSize)) blocks
+    QSM.liftProperty (blocks  ===  blocks')
+    QSM.liftProperty (offsets === offsets')
+  where
+    dropLast xs = zipWith const xs (drop 1 xs)
+    file = ["test"]
+    hasFS@HasFS{..} = simHasFS EH.exceptions
+    writeBlocks = do
+      let bld = foldMap testBlockToBuilder blocks
+      withFile hasFS file AppendMode $ \eHnd -> void $ hPut eHnd bld
+    readBlocks = runEpochFileParser (testBlockEpochFileParser hasFS) file
+
+    runSimIO :: SimFS IO a -> IO a
+    runSimIO m = fst <$> runSimFS m Mock.empty
+
+
+{-------------------------------------------------------------------------------
+  Top-level tests
+-------------------------------------------------------------------------------}
+
+
+tests :: TestTree
+tests = testGroup "TestBlock"
+    [ testProperty "testBlockEpochFileParser" prop_testBlockEpochFileParser
+    ]


### PR DESCRIPTION
*  Let `validateIteratorRange` take a function instead of a map.

*  Make bounds optional for `ImmutableDB` iterators to make it easy to stream
   over *all* blobs in the database.

* New helpers `lastEpochOnDisk` and `openLastEpoch` to open the database at
  its most recent epoch instead of having to pass the epoch to open
  explicitly.

* New `reopen` operation to reopen a closed database (manually closed or
  because of an unexpected error).

* New: `RecoveryPolicy`, to be passed to `openDB` and `reopen`. This policy
  determines the validation and recovery that must be done when (re)opening
  the database. See the docstring of `RecoveryPolicy`.

* `openDB` and `reopen` return the last epoch slot that stores a blob, or
  `Nothing` in case of an empty database.

* Add quickcheck-state-machine tests for `ImmutableDB`.

* Add`SimErrorFS` to simulate errors at the `HasFS` layer while testing an
  `ImmutableDB`.

* Turn the internal state of the `ImmutableDB` from a `Maybe (InternalState
  m)` into an `Either ClosedState (OpenState m)`. The `ClosedState` will store
  the data needed when reopening a closed `ImmutableDB`.