### PR TITLE
IO sim improvement to get result of main thread easily

### DIFF
--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -33,7 +33,6 @@ library
   build-depends:       base              >=4.9 && <4.13,
                        io-sim-classes    >=0.1 && <0.2,
                        containers,
-                       free,
                        psqueues          >=0.2 && <0.3
 
   ghc-options:         -Wall

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -14,6 +14,7 @@ module Control.Monad.IOSim (
   SimM,
   runSimTrace,
   runSimTraceST,
+  liftST,
   VTime(..),
   VTimeDuration(..),
   ThreadId,

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -43,10 +43,13 @@ prop_stm_graph_io g =
 
 prop_stm_graph_sim :: TestThreadGraph -> Bool
 prop_stm_graph_sim g =
-    not $ null [ () | (_t, tid, Sim.EventThreadStopped) <- trace
-                    , tid == toEnum 0 ]
+    checkTermination (Sim.runSimTrace (prop_stm_graph g))
   where
-    trace = Sim.runSimM (prop_stm_graph g)
+    checkTermination (Sim.Trace _ _ _ trace)      = checkTermination trace
+    checkTermination (Sim.TraceMainReturn _ () _) = True
+    -- Note that we do not check here that all other threads finished
+    -- but perhaps we should structure the grap tests so that's the case
+    checkTermination _                            = False
 
 prop_stm_graph :: MonadSTM m => TestThreadGraph -> m ()
 prop_stm_graph (TestThreadGraph g) = do

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -43,13 +43,10 @@ prop_stm_graph_io g =
 
 prop_stm_graph_sim :: TestThreadGraph -> Bool
 prop_stm_graph_sim g =
-    checkTermination (Sim.runSimTrace (prop_stm_graph g))
-  where
-    checkTermination (Sim.Trace _ _ _ trace)      = checkTermination trace
-    checkTermination (Sim.TraceMainReturn _ () _) = True
-    -- Note that we do not check here that all other threads finished
-    -- but perhaps we should structure the grap tests so that's the case
-    checkTermination _                            = False
+    Sim.runSim (prop_stm_graph g) == Right ()
+    -- Note that we do not use Sim.runSimStrictShutdown here to  check that
+    -- all other threads finished, but perhaps we should and structure the
+    -- graph tests so that's the case.
 
 prop_stm_graph :: MonadSTM m => TestThreadGraph -> m ()
 prop_stm_graph (TestThreadGraph g) = do

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -44,9 +44,9 @@ prop_stm_graph_io g =
 prop_stm_graph_sim :: TestThreadGraph -> Bool
 prop_stm_graph_sim g =
     Sim.runSim (prop_stm_graph g) == Right ()
-    -- Note that we do not use Sim.runSimStrictShutdown here to  check that
-    -- all other threads finished, but perhaps we should and structure the
-    -- graph tests so that's the case.
+    -- TODO: Note that we do not use Sim.runSimStrictShutdown here to check
+    -- that all other threads finished, but perhaps we should and structure
+    -- the graph tests so that's the case.
 
 prop_stm_graph :: MonadSTM m => TestThreadGraph -> m ()
 prop_stm_graph (TestThreadGraph g) = do

--- a/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
@@ -8,7 +8,7 @@
 
 module Test.Ouroboros.Network.Node where
 
-import           Control.Monad (forM, forM_, replicateM, filterM)
+import           Control.Monad (forM, forM_, replicateM, filterM, unless)
 import           Control.Monad.ST.Lazy (runST)
 import           Control.Monad.State (execStateT, lift, modify')
 import           Data.Array
@@ -40,6 +40,7 @@ import qualified Control.Monad.IOSim as Sim
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (Chain (..), chainToList)
 import qualified Ouroboros.Network.Chain as Chain
+import           Ouroboros.Network.ChainProducerState (ChainProducerState (..))
 import           Ouroboros.Network.Node
 import           Ouroboros.Network.Testing.ConcreteBlock as ConcreteBlock
 
@@ -53,7 +54,7 @@ tests =
   [ testGroup "fixed graph topology"
     [ testProperty "core -> relay" prop_coreToRelay
     , testProperty "core -> relay -> relay" prop_coreToRelay2
-    , testProperty "core <-> relay <-> core" prop_coreToCoreViaRelay
+    , testProperty "core <-> relay <-> core" $ prop_coreToCoreViaRelay
     ]
   , testProperty "arbtirary node graph" (withMaxSuccess 50 prop_networkGraph)
   , testProperty "blockGenerator invariant SimM" prop_blockGenerator_ST
@@ -134,6 +135,7 @@ coreToRelaySim :: ( MonadSTM m
                -> Probe m (NodeId, Chain Block)
                -> m ()
 coreToRelaySim duplex chain slotDuration coreTrDelay relayTrDelay probe = do
+  donevar <- newTVarIO False
   (coreChans, relayChans) <- if duplex
     then createTwoWaySubscriptionChannels relayTrDelay coreTrDelay
     else createOneWaySubscriptionChannels coreTrDelay relayTrDelay
@@ -144,6 +146,14 @@ coreToRelaySim duplex chain slotDuration coreTrDelay relayTrDelay probe = do
   fork $ void $ do
     cps <- relayNode (RelayId 0) Genesis relayChans
     fork $ observeChainProducerState (RelayId 0) probe cps
+    atomically $ do
+      chain' <- chainState <$> readTVar cps
+      unless (chain == chain') retry
+      writeTVar donevar True
+
+  atomically $ do
+    done <- readTVar donevar
+    unless done retry
 
 runCoreToRelaySim :: Chain Block
                   -> Sim.VTimeDuration
@@ -207,6 +217,7 @@ coreToRelaySim2 :: ( MonadSTM m
                 -> Probe m (NodeId, Chain Block)
                 -> m ()
 coreToRelaySim2 chain slotDuration coreTrDelay relayTrDelay probe = do
+  donevar <- newTVarIO False
   (cr1, r1c) <- createOneWaySubscriptionChannels coreTrDelay relayTrDelay
   (r1r2, r2r1) <- createOneWaySubscriptionChannels relayTrDelay relayTrDelay
 
@@ -219,6 +230,15 @@ coreToRelaySim2 chain slotDuration coreTrDelay relayTrDelay probe = do
   fork $ void $ do
     cps <- relayNode (RelayId 2) Genesis r2r1
     fork $ observeChainProducerState (RelayId 2) probe cps
+
+    atomically $ do
+      chain' <- chainState <$> readTVar cps
+      unless (chain == chain') retry
+      writeTVar donevar True
+
+  atomically $ do
+    done <- readTVar donevar
+    unless done retry
 
 runCoreToRelaySim2 :: Chain Block
                    -> Sim.VTimeDuration
@@ -246,33 +266,71 @@ prop_coreToRelay2 (TestNodeSim chain slotDuration coreTrDelay relayTrDelay) =
         .&&.
             mchain2 === Just chain
 
+
 -- | Node graph: c ↔ r ↔ c
-coreToCoreViaRelaySim :: ( MonadSTM m
-                         , MonadTimer m
-                         , MonadSay m
-                         , MonadProbe m
-                         , MonadTimer m
-                         )
-                      => Chain Block
-                      -> Chain Block
-                      -> Duration (Time m)
-                      -> Duration (Time m)
-                      -> Duration (Time m)
-                      -> Probe m (NodeId, Chain Block)
-                      -> m ()
+--
+-- This test assumes that @chain1@ and @chain2@ ends on a different slot.  Under
+-- this assumption, we can detect all the three nodes can be terminated when
+-- each nodes' chain reaches max slot length of @chain1@ and @chain2@.
+coreToCoreViaRelaySim
+  :: forall m.
+     ( MonadSTM m
+     , MonadTimer m
+     , MonadSay m
+     , MonadProbe m
+     , MonadTimer m
+     )
+  => Chain Block
+  -> Chain Block
+  -> Duration (Time m)
+  -> Duration (Time m)
+  -> Duration (Time m)
+  -> Probe m (NodeId, Chain Block)
+  -> m ()
 coreToCoreViaRelaySim chain1 chain2 slotDuration coreTrDelay relayTrDelay probe = do
+  let -- we compute last block body, under the assumption that one of the chain has
+      -- more blocks than the other one, we can determine from which chain the last
+      -- block will come in all the nodes.
+      lastBlockBody = if Chain.headBlockNo chain1 > Chain.headBlockNo chain2
+                        then blockBody <$> Chain.head chain1
+                        else blockBody <$> Chain.head chain2
+      -- the slot at whcih the simulation will end
+      lastSlot = max (Chain.headSlot chain1) (Chain.headSlot chain2)
+  donevar <- newTVarIO (0 :: Int)
   (c1r1, r1c1) <- createTwoWaySubscriptionChannels coreTrDelay relayTrDelay
   (r1c2, c2r1) <- createTwoWaySubscriptionChannels relayTrDelay coreTrDelay
 
   fork $ void $ do
     cps <- coreNode (CoreId 1) slotDuration (Chain.toOldestFirst chain1) c1r1
     fork $ observeChainProducerState (CoreId 1) probe cps
+    checkTermination donevar cps lastSlot lastBlockBody
+
   fork $ void $ do
     cps <- relayNode (RelayId 1) Genesis (r1c1 <> r1c2)
     fork $ observeChainProducerState (RelayId 1) probe cps
+    checkTermination donevar cps lastSlot lastBlockBody
+
   fork $ void $ do
     cps <- coreNode (CoreId 2) slotDuration (Chain.toOldestFirst chain2) c2r1
     fork $ observeChainProducerState (CoreId 2) probe cps
+    checkTermination donevar cps lastSlot lastBlockBody
+    
+  -- wait until all the nodes are ready
+  atomically $ readTVar donevar >>= check . (>=3)
+ where
+  -- check if a node can terminate, if so bump the `donevar` value
+  checkTermination
+    :: TVar m Int
+    -> TVar m (ChainProducerState Block)
+    -> Slot
+    -> Maybe BlockBody
+    -> m ()
+  checkTermination donevar cps lastSlot lastBlockBody = atomically $ do
+    c <- chainState <$> readTVar cps
+    let slot = Chain.headSlot c
+        bb   = blockBody <$> Chain.head c
+    check (slot >= lastSlot && bb == lastBlockBody)
+    modifyTVar donevar succ
 
 runCoreToCoreViaRelaySim
   :: Chain Block
@@ -291,40 +349,41 @@ runCoreToCoreViaRelaySim chain1 chain2 slotDuration coreTrDelay relayTrDelay = r
 -- are only two possible chains that each node can finish with.  Note that this
 -- chain might not be the original chain that was passed from the quickcheck
 -- generator: it may happen that a core node will start to build up a chain on
--- some block supplied by the other node.
+-- some block supplied by the other node, which will force the generated blocks
+-- to get modified.
 --
+-- We use a precondition to only test against forks with a different number of
+-- blocks.  This way we can determine upfront the last block in the resulting
+-- chain on each of the nodes (thanks to simplicity of `Chain.selectChain`
+-- function).
+--
+-- TODO: add a generator which generates chains with a diffrent number of
+-- blocks.
 prop_coreToCoreViaRelay :: TestChainFork -> Property
 prop_coreToCoreViaRelay (TestChainFork _ chain1 chain2) =
+  Chain.headBlockNo chain1 /= Chain.headBlockNo chain2 ==>
   let probes = map snd $ runCoreToCoreViaRelaySim chain1 chain2 (Sim.VTimeDuration 3) (Sim.VTimeDuration 1) (Sim.VTimeDuration 1)
 
       isValid :: Maybe (Chain Block)
               -> Maybe (Chain Block)
               -> Property
-      isValid Nothing   Nothing   = chain1 === Genesis .&&. chain2 === Genesis
+      isValid Nothing   Nothing   = chain1 === Genesis .&&. chain2 === Genesis  -- under the slot length assumption, this is impossible
       isValid (Just _)  Nothing   = property False
       isValid Nothing   (Just _)  = property False
       isValid (Just c1) (Just c2) = compareChains c1 c2
-
-
   in
         let dict    = partitionProbe probes
             chainC1 = CoreId 1  `Map.lookup` dict >>= listToMaybe
             chainR1 = RelayId 1 `Map.lookup` dict >>= listToMaybe
             chainC2 = CoreId 2  `Map.lookup` dict >>= listToMaybe
         in
-            isValid chainC1 chainR1 .&&. isValid chainC1 chainC2
+            isValid chainC1 chainR1 .&&. isValid chainC2 chainR1
   where
     compareChains :: Chain Block
                   -> Chain Block
                   -> Property
     compareChains c1 c2 =
-        counterexample (c1_ ++ "\n\n" ++ c2_) (Chain.selectChain c1 c2 === c1)
-      .&&.
-        counterexample (c1_ ++ "\n\n" ++ c2_) (Chain.selectChain c2 c1 === c2)
-      where
-        nl  = "\n    "
-        c1_ = Chain.prettyPrintChain nl show c1
-        c2_ = Chain.prettyPrintChain nl show c2
+       (Chain.selectChain c1 c2 === c1) .&&. (Chain.selectChain c2 c1 === c2)
 
 data TestNetworkGraph = TestNetworkGraph Graph [(Int, Chain Block)]
     deriving Show

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
@@ -8,7 +8,6 @@ import qualified Pipes
 
 import           Control.Monad.ST.Lazy (runST)
 import           Control.Monad (void)
-import           Control.Monad.Free (Free)
 import           Data.Functor (($>))
 import           Data.Functor.Identity (Identity (..))
 
@@ -18,7 +17,7 @@ import Control.Monad.Class.MonadFork (MonadFork (..))
 import Control.Monad.Class.MonadProbe (MonadProbe (..))
 import Control.Monad.Class.MonadSTM (MonadSTM (..))
 import Control.Monad.Class.MonadTimer (MonadTimer (..))
-import Control.Monad.IOSim (SimF)
+import Control.Monad.IOSim (SimM)
 
 import Ouroboros.Network.Protocol.BlockFetch.Type
 import Ouroboros.Network.Protocol.BlockFetch.Client
@@ -143,7 +142,7 @@ prop_directBlockRequestProtocol_ST
   :: [(ArbitraryPoint, ArbitraryPoint)]
   -> Property
 prop_directBlockRequestProtocol_ST as = runST $ runExperiment $
-  blockRequestProtocol_experiment @(Free (SimF _))
+  blockRequestProtocol_experiment @(SimM _)
     (\ser cli -> void $ directBlockRequest ser cli) as
 
 prop_directBlockRequestProtocol_IO
@@ -157,7 +156,7 @@ prop_connectBlockRequestProtocol_ST
   :: [(ArbitraryPoint, ArbitraryPoint)]
   -> Property
 prop_connectBlockRequestProtocol_ST as = runST $ runExperiment $
-  blockRequestProtocol_experiment @(Free (SimF _))
+  blockRequestProtocol_experiment @(SimM _)
     (\ser cli -> void $ connect
       (blockRequestReceiverStream ser)
       (blockRequestSenderStream cli)) as
@@ -251,7 +250,7 @@ prop_blockFetchProtocol_IO (NonEmpty as) = ioProperty $ runExperiment $
 -- Round trip tests
 -------------------------------------------------------------------------------}
 
--- | Round trip test in either @'IO'@ or in @Free ('SimF' s)@ monad.  It
+-- | Round trip test in either @'IO'@ or in @'SimM' s@ monad.  It
 -- assures that there can be multiple outstanding range requests, and that the
 -- server returns the exepcted ranges.
 --
@@ -292,7 +291,7 @@ prop_directRoundTripST
   -> Positive Int
   -> Property
 prop_directRoundTripST ranges queueSize = runST $ runExperiment $
-  roundTrip_experiment @(Free (SimF _))
+  roundTrip_experiment @(SimM _)
     (\ser cli -> void $ directBlockRequest ser cli)
     (\ser cli -> Just . snd <$> directBlockFetch ser cli)
     ranges

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ChainSync.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ChainSync.hs
@@ -6,7 +6,6 @@ module Test.Ouroboros.Network.Protocol.ChainSync where
 
 import Control.Monad (unless, void)
 import Control.Monad.ST.Lazy (runST)
-import Control.Monad.Free (Free)
 import Data.ByteString (ByteString)
 import System.Process (createPipe)
 
@@ -17,7 +16,7 @@ import Control.Monad.Class.MonadST
 import Control.Monad.Class.MonadSTM
 import Control.Monad.Class.MonadProbe
 
-import Control.Monad.IOSim (SimF)
+import Control.Monad.IOSim (SimM)
 
 import Protocol.Core (connect)
 import Protocol.Codec
@@ -166,7 +165,7 @@ propChainSyncDemoST
 propChainSyncDemoST cps =
   runST $ runExperiment $ \probe -> do
     (clientChan, serverChan) <- tmvarChannels
-    chainSyncDemo @(Free (SimF _)) clientChan serverChan cps probe
+    chainSyncDemo @(SimM _) clientChan serverChan cps probe
 
 propChainSyncDemoIO
   :: ChainProducerStateForkTest

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ReqResp.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ReqResp.hs
@@ -6,7 +6,6 @@ module Test.Ouroboros.Network.Protocol.ReqResp where
 
 import Control.Monad (unless)
 import Control.Monad.ST.Lazy (runST)
-import Control.Monad.Free (Free)
 import Data.Functor.Identity (Identity (..))
 import Data.ByteString (ByteString)
 import System.Process (createPipe)
@@ -19,7 +18,7 @@ import Control.Monad.Class.MonadST
 import Control.Monad.Class.MonadSTM
 import Control.Monad.Class.MonadProbe
 
-import Control.Monad.IOSim (SimF)
+import Control.Monad.IOSim (SimM)
 
 import Protocol.Core (Those (..), connect)
 import Protocol.Codec
@@ -140,7 +139,7 @@ prop_reqRespDemoExperimentST
 prop_reqRespDemoExperimentST request response =
   runST $ runExperiment $ \probe -> do
     (clientChan, serverChan) <- tmvarChannels
-    reqRespDemoExperiment @(Free (SimF _)) clientChan serverChan request response probe
+    reqRespDemoExperiment @(SimM _) clientChan serverChan request response probe
 
 prop_reqRespDemoExperimentIO
   :: forall request response.


### PR DESCRIPTION
Switch sim to terminate on main thread termination
    
Originally the simulator followed the behaviour that it would terminate when there were no more runnable threads (and no remaining timers). This does not match GHC's behaviour which terminates when the main thread terminates. So we switch the sim to this behaviour. In addition this makes it easier to return the result of the main thread, so we do that because it's very convenient for tests.

We also return the list of running threads on termination of the main thread. This makes it possible to check for a clean shutdown if that is of interest. For example if one is simulating a tree of threads and one wants to check all threads are shutdown cleanly.

Add an easy to use `runSim`
```
runSim :: forall a. (forall s. SimM s a) -> Either Failure a
```
If one does not care about the trace, this makes getting the final result very easy.

Also add `runSimStrictShutdown` which implements the check mentioned above that there are no more runnable or blocked threads left when the main thread terminates.

Also, export SimIO `liftST` for direct use. When working directly in the SimM monad we can use `liftST` directly without having to go via the hassle of `withLiftSt`.