### PR TITLE
Fix warning about missing ChangeLog.md in io-sim-classes

### DIFF
--- a/io-sim-classes/io-sim-classes.cabal
+++ b/io-sim-classes/io-sim-classes.cabal
@@ -9,7 +9,6 @@ maintainer:
 copyright:           2018 IOHK
 category:            Control
 build-type:          Simple
-extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
 
 source-repository head


### PR DESCRIPTION
The full warning is:

    Warning: File listed in io-sim-classes/io-sim-classes.cabal file does not
    exist: ChangeLog.md