### PR TITLE
Provide a proper nix-shell experience, with coherent dependencies, cabal-install and Hoogle

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,4 +19,6 @@ let
       (overrides self super) // (cardanopkgs self super);
   };
 in
-  import ./pkgs.nix { inherit nixpkgs; inherit compiler; }
+  (import ./pkgs.nix { inherit nixpkgs; inherit compiler; }) // {
+    inherit nixpkgs compiler;
+  }

--- a/nix/overrides.nix
+++ b/nix/overrides.nix
@@ -1,5 +1,6 @@
 { nixpkgs }:
   /* Building on 8.6.* with QuickCheck 2.12 requires some special package overrides */
+  with nixpkgs.haskell.lib;
   self: super: {
     memory = self.callPackage ./memory-0.14.18.nix {};
     microlens-th = self.callPackage ./microlens-th-0.4.2.3.nix {};
@@ -11,12 +12,13 @@
     optparse-applicative = self.callPackage ./optparse-applicative-0.14.3.0.nix {};
     quickcheck-instances = self.callPackage ./quickcheck-instances-0.3.19.nix {};
     test-framework-quickcheck2 = self.callPackage ./test-framework-quickcheck2-0.3.0.5.nix {};
-    quickcheck-state-machine = self.callPackage ./quickcheck-state-machine-0.6.0.nix {};
+    /* quickcheck-state-machine fails 1 test */
+    quickcheck-state-machine = dontCheck (doJailbreak (self.callPackage ./quickcheck-state-machine-0.6.0.nix {}));
     psqueues = self.callPackage ./psqueues-0.2.7.1.nix {};
     ChasingBottoms = self.callPackage ./ChasingBottoms-1.3.1.5.nix {};
     contravariant = self.callPackage ./contravariant-1.5.nix {};
     /* Tests seem to fail for this one */
-    doctest = nixpkgs.haskell.lib.dontCheck (self.callPackage ./doctest-0.16.0.1.nix {});
+    doctest = dontCheck (self.callPackage ./doctest-0.16.0.1.nix {});
     polyparse = self.callPackage ./polyparse-1.12.1.nix {};
     haskell-src-exts = self.callPackage ./haskell-src-exts-1.20.3.nix {};
     haskell-src-meta = self.callPackage ./haskell-src-meta-0.8.0.3.nix {};
@@ -35,7 +37,7 @@
     semigroupoids = self.callPackage ./semigroupoids-5.3.1.nix {};
     free = self.callPackage ./free-5.1.nix {};
     /* Still doesn't admit QuickCheck >= 2.12 so we disable tests */
-    aeson = nixpkgs.haskell.lib.dontCheck (self.callPackage ./aeson-1.4.2.0.nix {});
+    aeson = dontCheck (self.callPackage ./aeson-1.4.2.0.nix {});
     aeson-compat = self.callPackage ./aeson-compat-0.3.9.nix {};
     aeson-options-HEAD = self.callPackage ./aeson-options-HEAD.nix {};
     io-streams = self.callPackage ./io-streams-1.5.0.1.nix {};
@@ -50,6 +52,9 @@
     cborg = self.callPackage ./cborg-0.2.1.0.nix {};
     feed = self.callPackage ./feed-1.0.1.0.nix {};
 
+    persistent = doJailbreak super.persistent;
+    graphviz = doJailbreak super.graphviz;
+
     /* One test case fails. Hopefully fix will come soon. */
-    iohk-monitoring = nixpkgs.haskell.lib.dontCheck (self.callPackage ./iohk-monitoring-HEAD.nix {});
+    iohk-monitoring = dontCheck (self.callPackage ./iohk-monitoring-HEAD.nix {});
   }

--- a/nsh.sh
+++ b/nsh.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+nixopts="--cores 0 -j4 --no-build-output"
+nix-shell ${nixopts} "$@"

--- a/nsh.sh
+++ b/nsh.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -x
 
 nixopts="--cores 0 -j4 --no-build-output"
 nix-shell ${nixopts} "$@"

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,7 +1,7 @@
 { nixpkgs
 , compiler
 , haddock    ? false
-, test       ? false
+, test       ? true
 , benchmarks ? false
 }:
 with builtins;

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+{ withHoogle ? false
+}:
+let
+  pkgs  = import ./.;
+in
+with builtins; with pkgs.compiler;
+  shellFor {
+    packages    = p: attrValues (removeAttrs pkgs ["compiler" "nixpkgs"]);
+    withHoogle  = withHoogle;
+    buildInputs = [ cabal-install ];
+  }


### PR DESCRIPTION
1. Enable tests by default
2. `doJailbreak`/`dontCheck` some packages
3. Supply a somewhat proper `shell.nix`
4. `nsh.sh` is a convenience script to enable faster & less noisy entry into `nix-shell`.
5. local Hoogle for all used packages is available within the shell if `--arg withHoogle true` is passed.  This is disabled by default, because it adds some (~23) dependencies.

The following works now:
```
ouroboros-network$ ./nsh.sh
+ nixopts='--cores 0 -j4 --no-build-output'
+ nix-shell --cores 0 -j4 --no-build-output

[nix-shell:~/ouroboros-network]$ cd ouroboros-consensus/

[nix-shell:~/ouroboros-network/ouroboros-consensus]$ cabal new-repl Test.Pipe
Build profile: -w ghc-8.6.3 -O1
In order, the following will be built (use -v for more details):
 - ouroboros-network-0.1.0.0 (test:tests) (ephemeral targets)
Preprocessing test suite 'tests' for ouroboros-network-0.1.0.0..
GHCi, version 8.6.3: http://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/deepfire/.ghci
[ 1 of 13] Compiling Test.Chain       ( test/Test/Chain.hs, interpreted )
[ 2 of 13] Compiling Test.ChainFragment ( test/Test/ChainFragment.hs, interpreted )
[ 3 of 13] Compiling Test.ChainProducerState ( test/Test/ChainProducerState.hs, interpreted )
[ 4 of 13] Compiling Test.Ouroboros.Network.Node ( test/Test/Ouroboros/Network/Node.hs, interpreted )
[ 5 of 13] Compiling Test.Ouroboros.Network.Protocol.ReqResp.Codec.Coherence ( test/Test/Ouroboros/Network/Protocol/ReqResp/Codec/Coherence.hs, interpreted )
[ 6 of 13] Compiling Test.Ouroboros.Network.Protocol.Stream ( test/Test/Ouroboros/Network/Protocol/Stream.hs, interpreted )
[ 7 of 13] Compiling Test.Ouroboros.Network.Testing.Arbitrary ( test/Test/Ouroboros/Network/Testing/Arbitrary.hs, interpreted )
[ 8 of 13] Compiling Test.Ouroboros.Network.Testing.Utils ( test/Test/Ouroboros/Network/Testing/Utils.hs, interpreted )
[ 9 of 13] Compiling Test.Ouroboros.Network.Protocol.ReqResp ( test/Test/Ouroboros/Network/Protocol/ReqResp.hs, interpreted )
[10 of 13] Compiling Test.Ouroboros.Network.Protocol.ChainSync ( test/Test/Ouroboros/Network/Protocol/ChainSync.hs, interpreted )
[11 of 13] Compiling Test.Ouroboros.Network.Protocol.BlockFetch ( test/Test/Ouroboros/Network/Protocol/BlockFetch.hs, interpreted )
[12 of 13] Compiling Test.Pipe        ( test/Test/Pipe.hs, interpreted )
[13 of 13] Compiling Main             ( test/Main.hs, interpreted )
Ok, 13 modules loaded.
*Test.Chain> 
Leaving GHCi.
```