### PR TITLE
SimM exceptions

### DIFF
--- a/io-sim-classes/io-sim-classes.cabal
+++ b/io-sim-classes/io-sim-classes.cabal
@@ -27,6 +27,7 @@ library
                        Control.Monad.Class.MonadSay
                        Control.Monad.Class.MonadST
                        Control.Monad.Class.MonadSTM
+                       Control.Monad.Class.MonadThrow
                        Control.Monad.Class.MonadTimer
   default-language:    Haskell2010
   other-extensions:    CPP

--- a/io-sim-classes/src/Control/Monad/Class/MonadThrow.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadThrow.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE DefaultSignatures #-}
+
+module Control.Monad.Class.MonadThrow
+  ( MonadThrow(..)
+  , MonadCatch(..)
+  , MonadMask(..)
+  , Exception(..)
+  , SomeException
+  ) where
+
+import           Control.Exception (Exception(..), SomeException)
+import qualified Control.Exception as IO
+
+
+-- | Throwing exceptions, and resource handling in the presence of exceptions.
+--
+-- Does not include the ability to respond to exceptions.
+--
+class Monad m => MonadThrow m where
+
+  {-# MINIMAL throwM #-}
+  throwM :: Exception e => e -> m a 
+
+  bracket  :: m a -> (a -> m b) -> (a -> m c) -> m c
+  bracket_ :: m a -> m b -> m c -> m c 
+  finally  :: m a -> m b -> m a
+
+  default bracket :: MonadMask m => m a -> (a -> m b) -> (a -> m c) -> m c
+  default finally :: MonadMask m => m a -> m b -> m a
+
+  bracket before after thing =
+    mask $ \restore -> do
+      a <- before
+      r <- restore (thing a) `onException` after a
+      _ <- after a
+      return r
+
+  bracket_ before after thing = bracket before (const after) (const thing)
+
+  a `finally` sequel =
+    mask $ \restore -> do
+      r <- restore a `onException` sequel
+      _ <- sequel
+      return r
+
+
+-- | Catching exceptions.
+--
+-- Covers standard utilities to respond to exceptions.
+--
+class MonadThrow m => MonadCatch m where
+
+  {-# MINIMAL catch #-}
+  catch      :: Exception e => m a -> (e -> m a) -> m a
+  catchJust  :: Exception e => (e -> Maybe b) -> m a -> (b -> m a) -> m a
+
+  try        :: Exception e => m a -> m (Either e a) 
+  tryJust    :: Exception e => (e -> Maybe b) -> m a -> m (Either b a)
+
+  handle     :: Exception e => (e -> m a) -> m a -> m a
+  handleJust :: Exception e => (e -> Maybe b) -> (b -> m a) -> m a -> m a
+
+  onException    :: m a -> m b -> m a
+  bracketOnError :: m a -> (a -> m b) -> (a -> m c) -> m c
+
+  default bracketOnError
+                 :: MonadMask m => m a -> (a -> m b) -> (a -> m c) -> m c
+
+  catchJust p a handler =
+      catch a handler'
+    where
+      handler' e = case p e of
+                     Nothing -> throwM e
+                     Just b  -> handler b
+
+  try a = catch (Right `fmap` a) (return . Left)
+
+  tryJust p a = do
+    r <- try a
+    case r of
+      Right v -> return (Right v)
+      Left  e -> case p e of
+                   Nothing -> throwM e
+                   Just b  -> return (Left b)
+
+  handle       = flip catch
+  handleJust p = flip (catchJust p)
+
+  onException action what =
+    action `catch` \e -> do
+              _ <- what
+              throwM (e :: SomeException)
+
+  bracketOnError before after thing =
+    mask $ \restore -> do
+      a <- before
+      restore (thing a) `onException` after a
+
+
+-- | Support for safely working in the presence of asynchronous exceptions.
+--
+-- This is typically not needed directly as the utilities in 'MonadThrow' and
+-- 'MonadCatch' cover most use cases.
+--
+class MonadCatch m => MonadMask m where
+
+  {-# MINIMAL mask #-}
+  mask :: ((forall a. m a -> m a) -> m b) -> m b
+
+  mask_ :: m a -> m a
+  mask_ action = mask $ \_ -> action
+
+
+--
+-- Instance for IO uses the existing base library implementations
+--
+
+instance MonadThrow IO where
+
+  throwM   = IO.throwIO
+
+  bracket  = IO.bracket
+  bracket_ = IO.bracket_
+  finally  = IO.finally
+
+
+instance MonadCatch IO where
+
+  catch      = IO.catch
+
+  catchJust  = IO.catchJust
+  try        = IO.try
+  tryJust    = IO.tryJust
+  handle     = IO.handle
+  handleJust = IO.handleJust
+  onException    = IO.onException
+  bracketOnError = IO.bracketOnError
+
+
+instance MonadMask IO where
+
+  mask  = IO.mask
+  mask_ = IO.mask_
+

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -33,6 +33,7 @@ library
                        TypeFamilies
   build-depends:       base              >=4.9 && <4.13,
                        io-sim-classes    >=0.1 && <0.2,
+                       exceptions        >=0.10,
                        containers,
                        psqueues          >=0.2 && <0.3
 

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -48,8 +48,10 @@ import qualified Control.Monad.ST.Strict as StrictST
 import           Data.STRef.Lazy
 
 import           Control.Monad.Fail as MonadFail
+import qualified Control.Monad.Catch as Exceptions
+
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadThrow as MonadThrow
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSTM hiding (TVar)
@@ -208,6 +210,9 @@ instance MonadThrow (SimM s) where
     _ <- after
     return r
 
+instance Exceptions.MonadThrow (SimM s) where
+  throwM = MonadThrow.throwM
+
 instance MonadThrow (STM s) where
   throwM e = STM $ \_ -> ThrowStm (toException e)
 
@@ -224,6 +229,9 @@ instance MonadThrow (STM s) where
     _ <- after
     return r
 
+instance Exceptions.MonadThrow (STM s) where
+  throwM = MonadThrow.throwM
+
 instance MonadCatch (SimM s) where
   catch action handler =
     SimM $ \k -> Catch (runSimM action) (runSimM . handler) k
@@ -232,6 +240,9 @@ instance MonadCatch (SimM s) where
   bracketOnError before after thing = do
     a <- before
     thing a `onException` after a
+
+instance Exceptions.MonadCatch (SimM s) where
+  catch = MonadThrow.catch
 
 
 instance MonadSTM (SimM s) where

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -519,10 +519,10 @@ schedule thread@Thread{
               unblocked = [ tid' | (tid', _) <- reverse wakeup
                                  , Map.member tid' threads ]
               -- We don't interrupt runnable threads to provide fairness
-              -- anywhere else. We do it here by putting the tx that comitted
+              -- anywhere else. We do it here by putting the tx that committed
               -- a transaction to the back of the runqueue, behind all other
               -- runnable threads, and behind the unblocked threads.
-              -- For testing, we should have a more sophiscated policy to show
+              -- For testing, we should have a more sophisticated policy to show
               -- that algorithms are not sensitive to the exact policy, so long
               -- as it is a fair policy (all runnable threads eventually run).
               runqueue' = List.nub (runqueue ++ unblocked) ++ [tid]
@@ -727,7 +727,7 @@ finaliseCommit written = do
   let -- for each thread, what var writes woke it up
       wokeVars    = Map.fromListWith (\l r -> List.nub $ l ++ r)
                       [ (tid, [vid]) | (vid, tids) <- tidss, tid <- tids ]
-      -- threads to wake up, in wake up order, with assoicated vars
+      -- threads to wake up, in wake up order, with associated vars
       wokeThreads = [ (tid, wokeVars Map.! tid)
                     | tid <- ordNub [ tid | (_, tids) <- tidss, tid <- reverse tids ]
                     ]

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -40,7 +40,6 @@ import qualified Data.Set as Set
 import           Control.Exception
                    ( Exception(..), SomeException, ErrorCall(..), assert )
 import qualified System.IO.Error as IO.Error (userError)
-import qualified Data.Typeable as Typeable
 
 import           Control.Monad
 import           Control.Monad.ST.Lazy
@@ -674,7 +673,7 @@ unwindControlStack tid e (ContFrame _k ctl) =
     unwindControlStack tid e ctl
 
 unwindControlStack tid e (CatchFrame handler k ctl) =
-    case Typeable.cast e of
+    case fromException e of
       -- not the right type, unwind to the next containing handler
       Nothing -> unwindControlStack tid e ctl
 

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -41,7 +41,8 @@ tests =
   , testProperty "fork order (SimM)"       (withMaxSuccess 1000 (prop_fork_order_ST))
   , testProperty "fork order (IO)"         (expectFailure prop_fork_order_IO)
   , testGroup "throw/catch unit tests"
-    [ testProperty "1" unit_catch_1
+    [ testProperty "0" unit_catch_0
+    , testProperty "1" unit_catch_1
     , testProperty "2" unit_catch_2
     , testProperty "3" unit_catch_3
     , testProperty "4" unit_catch_4
@@ -262,10 +263,24 @@ prop_fork_order_IO = ioProperty . test_fork_order
 -- Syncronous exceptions
 --
 
-unit_catch_1, unit_catch_2, unit_catch_3, unit_catch_4,
+unit_catch_0, unit_catch_1, unit_catch_2, unit_catch_3, unit_catch_4,
   unit_catch_5, unit_catch_6,
   unit_fork_1, unit_fork_2
   :: Bool
+
+-- unhandled top level exception
+unit_catch_0 =
+    runSimTraceSay example == ["before"]
+ && case traceResult True (runSimTrace example) of
+      Left (FailureException e) -> maybe False (==DivideByZero) $ fromException e
+      _                         -> False
+
+ where
+  example :: SimM s ()
+  example = do
+    say "before"
+    _ <- throwM DivideByZero
+    say "after"
 
 -- normal execution of a catch frame
 unit_catch_1 =

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -43,7 +43,9 @@ prop_stm_graph_io g =
 
 prop_stm_graph_sim :: TestThreadGraph -> Bool
 prop_stm_graph_sim g =
-    Sim.runSim (prop_stm_graph g) == Right ()
+    case Sim.runSim (prop_stm_graph g) of
+       Right () -> True
+       _        -> False
     -- TODO: Note that we do not use Sim.runSimStrictShutdown here to check
     -- that all other threads finished, but perhaps we should and structure
     -- the graph tests so that's the case.


### PR DESCRIPTION
Provide throw and catch for SimM and throw for STM.

Both implements the `exceptions` package's type classes, and our own in the `io-sim-classes` package. Either is fine to use, the choice is up to the user. The `exceptions` package provides its own implementations of `base` IO exception functions, while the `io-sim-classes` classes have extra methods in the class so that the `IO` instane can directly use the `IO` versions from `base`.

Also do a bit of refactoring in preparation for adding async exceptions and masking (not included in this PR).