### PR TITLE
Correctly deal with time

### DIFF
--- a/demo-playground/start-node.sh
+++ b/demo-playground/start-node.sh
@@ -14,4 +14,4 @@ set -x
 cabal new-run demo-playground -- \
     --system-start "$now" --slot-duration 2 \
     node -t demo-playground/simple-topology.json \
-         $@ 
+         $@

--- a/io-sim-classes/src/Control/Monad/Class/MonadSay.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSay.hs
@@ -1,7 +1,12 @@
 module Control.Monad.Class.MonadSay where
 
+import           Control.Monad.State
+
 class Monad m => MonadSay m where
   say :: String -> m ()
 
 instance MonadSay IO where
   say = print
+
+instance MonadSay m => MonadSay (StateT s m) where
+  say = lift . say

--- a/ouroboros-consensus/demo-playground/Run.hs
+++ b/ouroboros-consensus/demo-playground/Run.hs
@@ -23,6 +23,7 @@ import           Ouroboros.Network.Chain (pointHash)
 import qualified Ouroboros.Network.Pipe as P
 import           Ouroboros.Network.Protocol.ChainSync.Codec.Cbor
 
+import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Ledger.Mock as Mock
@@ -113,7 +114,7 @@ handleSimpleNode p CLI{..} (TopologyInfo myNodeId topologyFile) = do
                  , adoptedNewChain = logChain loggingQueue
                  }
 
-             btime  <- realBlockchainTime systemStart slotDuration
+             btime  <- realBlockchainTime slotDuration systemStart
              kernel <- nodeKernel
                          pInfoConfig
                          pInfoInitState

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -60,7 +60,6 @@ library
                        Ouroboros.Consensus.Util.Chain
                        Ouroboros.Consensus.Util.Classify
                        Ouroboros.Consensus.Util.Condense
-                       Ouroboros.Consensus.Util.DepFn
                        Ouroboros.Consensus.Util.HList
                        Ouroboros.Consensus.Util.Orphans
                        Ouroboros.Consensus.Util.Random
@@ -147,9 +146,7 @@ library
                        time,
                        transformers,
                        vector            >=0.12  && <0.13,
-                       unliftio-core     >=0.1.1 && <0.2,
-
-                       QuickCheck        >=2.12 && <2.13
+                       unliftio-core     >=0.1.1 && <0.2
 
   if os(windows)
      build-depends:       Win32
@@ -208,7 +205,8 @@ test-suite test-consensus
                     Test.Dynamic.Praos
                     Test.Dynamic.Util
                     Test.Ouroboros
-                    Test.Orphans.Arbitrary
+                    Test.Util.Orphans.Arbitrary
+                    Test.Util.DepFn
   build-depends:    base,
                     typed-transitions,
                     ouroboros-network,
@@ -234,7 +232,7 @@ test-suite test-consensus
 
 test-suite test-crypto
   type:             exitcode-stdio-1.0
-  hs-source-dirs:   test-crypto
+  hs-source-dirs:   test-crypto, test-util
   default-language: Haskell2010
   main-is:          Main.hs
   other-modules:
@@ -242,6 +240,8 @@ test-suite test-crypto
                     Test.Crypto.Hash
                     Test.Crypto.KES
                     Test.Crypto.VRF
+                    Test.Util.Orphans.Arbitrary
+                    Test.Util.QuickCheck
   build-depends:    base,
                     ouroboros-network,
                     ouroboros-consensus,
@@ -249,7 +249,8 @@ test-suite test-crypto
                     bytestring,
                     QuickCheck,
                     tasty,
-                    tasty-quickcheck
+                    tasty-quickcheck,
+                    time
 
   ghc-options:      -Wall
                     -fno-ignore-asserts

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -24,6 +24,7 @@ library
      hs-source-dirs:   src-unix/
 
   exposed-modules:
+                       Ouroboros.Consensus.BlockchainTime
                        Ouroboros.Consensus.Crypto.DSIGN
                        Ouroboros.Consensus.Crypto.DSIGN.Class
                        Ouroboros.Consensus.Crypto.DSIGN.Ed448
@@ -199,6 +200,7 @@ test-suite test-consensus
   default-language: Haskell2010
   main-is:          Main.hs
   other-modules:
+                    Test.Consensus.BlockchainTime
                     Test.Dynamic.BFT
                     Test.Dynamic.General
                     Test.Dynamic.LeaderSchedule
@@ -222,8 +224,10 @@ test-suite test-consensus
                     QuickCheck,
                     serialise,
                     tasty,
+                    tasty-hunit,
                     tasty-quickcheck,
-                    text
+                    text,
+                    time
 
   ghc-options:      -Wall
                     -fno-ignore-asserts

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -213,12 +213,16 @@ newtype SlotLength = SlotLength { getSlotLength :: FixedDiffTime }
 slotLengthFromMillisec :: Integer -> SlotLength
 slotLengthFromMillisec = SlotLength . FixedDiffTime . conv
   where
+    -- Explicit type annotation here means that /if/ we change the precision,
+    -- we are forced to reconsider this code.
     conv :: Integer -> Fixed E3
     conv = MkFixed
 
 slotLengthToMillisec :: SlotLength -> Integer
 slotLengthToMillisec = conv . fixedDiffTime . getSlotLength
   where
+    -- Explicit type annotation here means that /if/ we change the precision,
+    -- we are forced to reconsider this code.
     conv :: Fixed E3 -> Integer
     conv (MkFixed n) = n
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -146,7 +146,10 @@ realBlockchainTime slotLen start = do
 -- > fixedToUTC (fixedFromUTC t) ~= t
 -- > fixedFromUTC (fixedToUTC t) == t
 newtype FixedUTC = FixedUTC { fixedSecondsSinceEpoch :: Fixed E3 }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord)
+
+instance Show FixedUTC where
+  show = show . fixedToUTC
 
 fixedFromUTC :: UTCTime -> FixedUTC
 fixedFromUTC = FixedUTC . conv . utcToSystemTime
@@ -173,7 +176,10 @@ getCurrentFixedUTC = fixedFromUTC <$> getCurrentTime
 -- > fixedToNominal (fixedFromNominal d) ~= d
 -- > fixedFromNominal (fixedToNominal t) == t
 newtype FixedDiffTime = FixedDiffTime { fixedDiffTime :: Fixed E3 }
-  deriving (Show, Eq, Ord, Num)
+  deriving (Eq, Ord, Num)
+
+instance Show FixedDiffTime where
+  show = show . fixedDiffToNominal
 
 fixedDiffFromNominal :: NominalDiffTime -> FixedDiffTime
 fixedDiffFromNominal = FixedDiffTime . doubleToFixed round . realToFrac

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -1,0 +1,293 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NumericUnderscores         #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
+
+module Ouroboros.Consensus.BlockchainTime (
+    -- * Abstract definition
+    BlockchainTime(..)
+  , onSlot
+    -- * Use in testing
+  , NumSlots(..)
+  , finalSlot
+  , testBlockchainTime
+    -- * Real blockchain time
+  , realBlockchainTime
+    -- * Time utilities
+  , FixedUTC(..)
+  , fixedFromUTC
+  , fixedToUTC
+  , getCurrentFixedUTC
+  , FixedDiffTime(..)
+  , fixedDiffFromNominal
+  , fixedDiffToNominal
+  , fixedDiffToMicroseconds
+  , threadDelayByFixedDiff
+  , multFixedDiffTime
+  , diffFixedUTC
+  , addFixedUTC
+    -- * Time to slots and back again
+  , SlotLength(..)
+  , slotLengthFromMillisec
+  , slotLengthToMillisec
+  , SystemStart(..)
+  , startOfSlot
+  , slotAtTime
+  , timeUntilNextSlot
+  , getCurrentSlotIO
+  , waitUntilNextSlotIO
+    -- * Re-exports
+  , Slot(..)
+  ) where
+
+import           Control.Monad
+import           Data.Fixed
+import           Data.Proxy
+import           Data.Time
+import           Data.Time.Clock.System
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadTimer
+
+import           Ouroboros.Consensus.Util.STM
+import           Ouroboros.Network.Block (Slot (..))
+
+{-------------------------------------------------------------------------------
+  Abstract definition
+-------------------------------------------------------------------------------}
+
+-- | Blockchain time
+--
+-- When we run the blockchain, there is a single, global time. We abstract over
+-- this here to allow to query this time (in terms of the current slot), and
+-- execute an action each time we advance a slot.
+data BlockchainTime m = BlockchainTime {
+      -- | Get current slot
+      getCurrentSlot :: Tr m Slot
+
+      -- | Spawn a thread to run an action each time the slot changes
+    , onSlotChange   :: (Slot -> m ()) -> m ()
+    }
+
+-- | Execute action on specific slot
+onSlot :: MonadSTM m => BlockchainTime m -> Slot -> m () -> m ()
+onSlot BlockchainTime{..} slot act = onSlotChange $ \slot' -> do
+    when (slot == slot') act
+
+{-------------------------------------------------------------------------------
+  Use in testing
+-------------------------------------------------------------------------------}
+
+-- | Number of slots
+newtype NumSlots = NumSlots Int
+  deriving (Show)
+
+finalSlot :: NumSlots -> Slot
+finalSlot (NumSlots n) = Slot (fromIntegral n)
+
+-- | Construct new blockchain time that ticks at the specified slot duration
+--
+-- NOTE: This is just one way to construct time. We can of course also connect
+-- this to the real time (if we are in IO), or indeed to a manual tick
+-- (in a demo).
+--
+-- NOTE: The number of slots is only there to make sure we terminate the
+-- thread (otherwise the system will keep waiting).
+testBlockchainTime :: forall m. (MonadSTM m, MonadTimer m)
+                   => NumSlots           -- ^ Number of slots
+                   -> Duration (Time m)  -- ^ Slot duration
+                   -> m (BlockchainTime m)
+testBlockchainTime (NumSlots numSlots) slotLen = do
+    slotVar <- atomically $ newTVar firstSlot
+    fork $ replicateM_ numSlots $ do
+        threadDelay slotLen
+        atomically $ modifyTVar slotVar succ
+    return BlockchainTime {
+        getCurrentSlot = readTVar slotVar
+      , onSlotChange   = onEachChange id firstSlot (readTVar slotVar)
+      }
+  where
+    firstSlot :: Slot
+    firstSlot = 0
+
+{-------------------------------------------------------------------------------
+  "Real" blockchain time
+-------------------------------------------------------------------------------}
+
+-- | Real blockchain time
+--
+-- TODO: Right now this requires a single specific slot duration. This is
+-- not going to be the case when we move to Praos. We need to think this
+-- through carefully.
+realBlockchainTime :: SlotLength -> SystemStart -> IO (BlockchainTime IO)
+realBlockchainTime slotLen start = do
+    first   <- getCurrentSlotIO slotLen start
+    slotVar <- atomically $ newTVar first
+    fork $ forever $ do
+      -- In each iteration of the loop, we recompute how long to wait until
+      -- the next slot. This minimizes clock skew.
+      next <- waitUntilNextSlotIO slotLen start
+      atomically $ writeTVar slotVar next
+    return BlockchainTime {
+        getCurrentSlot = readTVar slotVar
+      , onSlotChange   = onEachChange id first (readTVar slotVar)
+      }
+
+{-------------------------------------------------------------------------------
+  Time utilities
+
+  We avoid using Double here to avoid rounding problems.
+-------------------------------------------------------------------------------}
+
+-- | Fixed precision UTC time (resolution: milliseconds)
+--
+-- > fixedToUTC (fixedFromUTC t) ~= t
+-- > fixedFromUTC (fixedToUTC t) == t
+newtype FixedUTC = FixedUTC { fixedSecondsSinceEpoch :: Fixed E3 }
+  deriving (Show, Eq, Ord)
+
+fixedFromUTC :: UTCTime -> FixedUTC
+fixedFromUTC = FixedUTC . conv . utcToSystemTime
+  where
+    conv :: SystemTime -> Fixed E3
+    conv (MkSystemTime secs nsecs) = MkFixed $
+          (fromIntegral secs * 1_000)
+        + (fromIntegral nsecs `div` 1_000_000)
+
+fixedToUTC :: FixedUTC -> UTCTime
+fixedToUTC = systemToUTCTime . conv . fixedSecondsSinceEpoch
+  where
+    conv :: Fixed E3 -> SystemTime
+    conv (MkFixed millisecs) = MkSystemTime {
+          systemSeconds     = fromIntegral $  millisecs `div` 1_000
+        , systemNanoseconds = fromIntegral $ (millisecs `mod` 1_000) * 1_000_000
+        }
+
+getCurrentFixedUTC :: IO FixedUTC
+getCurrentFixedUTC = fixedFromUTC <$> getCurrentTime
+
+-- | Fixed precision time span (resolution: milliseconds)
+--
+-- > fixedToNominal (fixedFromNominal d) ~= d
+-- > fixedFromNominal (fixedToNominal t) == t
+newtype FixedDiffTime = FixedDiffTime { fixedDiffTime :: Fixed E3 }
+  deriving (Show, Eq, Ord, Num)
+
+fixedDiffFromNominal :: NominalDiffTime -> FixedDiffTime
+fixedDiffFromNominal = FixedDiffTime . doubleToFixed round . realToFrac
+
+fixedDiffToNominal :: FixedDiffTime -> NominalDiffTime
+fixedDiffToNominal = realToFrac . fixedToDouble . fixedDiffTime
+
+fixedDiffToMicroseconds :: FixedDiffTime -> Int
+fixedDiffToMicroseconds (FixedDiffTime d) = round (d * 1_000_000)
+
+threadDelayByFixedDiff :: FixedDiffTime -> IO ()
+threadDelayByFixedDiff = threadDelay . fixedDiffToMicroseconds
+
+multFixedDiffTime :: Int -> FixedDiffTime -> FixedDiffTime
+multFixedDiffTime n (FixedDiffTime d) = FixedDiffTime (fromIntegral n * d)
+
+diffFixedUTC :: FixedUTC -> FixedUTC -> FixedDiffTime
+diffFixedUTC (FixedUTC t) (FixedUTC t') = FixedDiffTime (t - t')
+
+addFixedUTC :: FixedDiffTime -> FixedUTC -> FixedUTC
+addFixedUTC (FixedDiffTime d) (FixedUTC t) = FixedUTC (t + d)
+
+{-------------------------------------------------------------------------------
+  Time to slots and back again
+-------------------------------------------------------------------------------}
+
+-- | Slot length
+newtype SlotLength = SlotLength { getSlotLength :: FixedDiffTime }
+  deriving (Show)
+
+slotLengthFromMillisec :: Integer -> SlotLength
+slotLengthFromMillisec = SlotLength . FixedDiffTime . conv
+  where
+    conv :: Integer -> Fixed E3
+    conv = MkFixed
+
+slotLengthToMillisec :: SlotLength -> Integer
+slotLengthToMillisec = conv . fixedDiffTime . getSlotLength
+  where
+    conv :: Fixed E3 -> Integer
+    conv (MkFixed n) = n
+
+-- | System start
+--
+-- Slots are counted from the system start.
+newtype SystemStart = SystemStart { getSystemStart :: FixedUTC }
+  deriving (Show)
+
+-- | Compute start of the specified slot
+--
+-- > slotAtTime (startOfSlot slot) == (slot, 0)
+startOfSlot :: SlotLength -> SystemStart -> Slot -> FixedUTC
+startOfSlot (SlotLength d) (SystemStart start) (Slot n) =
+    addFixedUTC (multFixedDiffTime (fromIntegral n) d) start
+
+-- | Compute slot at the specified time and how far we are into that slot
+--
+-- > now - slotLen < startOfSlot (fst (slotAtTime now)) <= now
+-- > 0 <= snd (slotAtTime now) < slotLen
+slotAtTime :: SlotLength -> SystemStart -> FixedUTC -> (Slot, FixedDiffTime)
+slotAtTime (SlotLength d) (SystemStart start) now = conv $
+              (fixedDiffTime (now `diffFixedUTC` start))
+    `divMod'` (fixedDiffTime d)
+  where
+    conv :: (Word, Fixed E3) -> (Slot, FixedDiffTime)
+    conv (slot, time) = (Slot slot, FixedDiffTime time)
+
+-- | Compute time until the next slot and the number of that next slot
+--
+-- > 0 < fst (timeUntilNextSlot now) <= slotLen
+-- > timeUntilNextSlot (startOfSlot slot) == (slotLen, slot + 1)
+-- > slotAtTime (now + fst (timeUntilNextSlot now)) == bimap (+1) (const 0) (slotAtTime now)
+-- > fst (slotAtTime (now + fst (timeUntilNextSlot now))) == snd (timeUntilNextSlot now)
+timeUntilNextSlot :: SlotLength
+                  -> SystemStart
+                  -> FixedUTC
+                  -> (FixedDiffTime, Slot)
+timeUntilNextSlot slotLen start now =
+    (getSlotLength slotLen - timeInCurrentSlot, currentSlot + 1)
+  where
+    (currentSlot, timeInCurrentSlot) = slotAtTime slotLen start now
+
+-- | Get current slot
+getCurrentSlotIO :: SlotLength -> SystemStart -> IO Slot
+getCurrentSlotIO slotLen start =
+    fst . slotAtTime slotLen start <$> getCurrentFixedUTC
+
+-- | Wait until next slot, and return number of that slot
+waitUntilNextSlotIO :: SlotLength -> SystemStart -> IO Slot
+waitUntilNextSlotIO slotLen start = do
+    now <- getCurrentFixedUTC
+    let (delay, nextSlot) = timeUntilNextSlot slotLen start now
+    threadDelayByFixedDiff delay
+    return nextSlot
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+-- | Convert 'Double' to fixed precision
+--
+-- For precision 'E1', we have
+--
+-- >           1.000 1.010 1.040 1.049 1.050  1.051 1.090 1.100
+-- > floor   | 1.0   1.0   1.0   1.0   1.0    1.0   1.0   1.1
+-- > round   | 1.0   1.0   1.0   1.0   1.0(*) 1.1   1.1   1.1
+-- > ceiling | 1.0   1.1   1.1   1.1   1.1    1.1   1.1   1.1
+--
+-- (*): See <https://en.wikipedia.org/wiki/IEEE_754#Rounding_rules>
+doubleToFixed :: forall a. HasResolution a
+              => (Double -> Integer) -- ^ Rounding policy
+              -> Double -> Fixed a
+doubleToFixed r d = MkFixed $ r (d * fromIntegral (resolution (Proxy @a)))
+
+-- | Convert fixed precision number to 'Double'
+fixedToDouble :: HasResolution a => Fixed a -> Double
+fixedToDouble = realToFrac

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Mock.hs
@@ -11,8 +11,6 @@ module Ouroboros.Consensus.Crypto.DSIGN.Mock
     , verKeyIdFromSigned
     ) where
 
-import qualified Data.ByteString.Base16 as B16
-import qualified Data.ByteString.Char8 as SB8
 import           GHC.Generics (Generic)
 
 import           Ouroboros.Network.Serialise
@@ -47,9 +45,7 @@ mkSig :: Serialise a => a -> SignKeyDSIGN MockDSIGN -> SigDSIGN MockDSIGN
 mkSig a (SignKeyMockDSIGN n) = SigMockDSIGN (getHash $ hash @ShortHash a) n
 
 instance Condense (SigDSIGN MockDSIGN) where
-    condense (SigMockDSIGN n i) = (SB8.unpack . B16.encode $ n)
-                                <> ":"
-                                <> show i
+    condense (SigMockDSIGN _ i) = show i
 
 instance Serialise (VerKeyDSIGN MockDSIGN)
 instance Serialise (SignKeyDSIGN MockDSIGN)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock.hs
@@ -41,12 +41,11 @@ module Ouroboros.Consensus.Ledger.Mock (
 import           Codec.Serialise
 import           Control.Monad.Except
 import           Crypto.Random (MonadRandom)
+import           Data.FingerTree (Measured (measure))
 import qualified Data.IntMap.Strict as IntMap
-import           Data.FingerTree (Measured(measure))
 import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy
-import           Data.Semigroup ((<>))
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           GHC.Generics (Generic)
@@ -222,17 +221,19 @@ deriving instance (SimpleBlockCrypto c, OuroborosTag p, Eq (Payload p (SimplePre
 deriving instance (SimpleBlockCrypto c, OuroborosTag p, Ord (Payload p (SimplePreHeader p c))) => Ord (SimpleBlock p c)
 
 instance (SimpleBlockCrypto c, OuroborosTag p, Condense (Payload p (SimplePreHeader p c)), Serialise (Payload p (SimplePreHeader p c))) => Condense (SimpleBlock p c) where
-  condense (SimpleBlock hdr@(SimpleHeader _ pl) (SimpleBody txs)) =
-      condensedHash (blockPrevHash hdr)
-          <> "-"
-          <> condense (blockHash hdr)
-          <> ",("
-          <> condense pl
-          <> ",("
-          <> condense (getSlot $ blockSlot hdr)
-          <> ","
-          <> condense txs
-          <> "))])))"
+  condense (SimpleBlock hdr@(SimpleHeader _ pl) (SimpleBody txs)) = mconcat [
+        "("
+      , condensedHash (blockPrevHash hdr)
+      , "->"
+      , condense (blockHash hdr)
+      , ","
+      , condense pl
+      , ","
+      , condense (getSlot $ blockSlot hdr)
+      , ","
+      , condense txs
+      , ")"
+      ]
 
 condensedHash :: Show (HeaderHash b) => Network.Hash b -> String
 condensedHash GenesisHash     = "genesis"

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -241,6 +241,7 @@ instance PraosCrypto c => OuroborosTag (Praos c) where
     return $ bi : cs
 
   -- NOTE: We redefine `preferCandidate` but NOT `compareCandidates`
+  -- NOTE: See note regarding clock skew.
   preferCandidate PraosNodeConfig{..} slot ours cand
     | forksAtMostKBlocks k ours' cand' &&
       Chain.length cand' > Chain.length ours'
@@ -248,7 +249,7 @@ instance PraosCrypto c => OuroborosTag (Praos c) where
     | otherwise
     = Nothing
     where
-      clip = upToSlot slot
+      clip = upToSlot (slot + 1)
 
       ours' = clip ours
       cand' = clip cand

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -81,6 +81,15 @@ instance All Condense as => Condense (HList as) where
 instance (Condense a, Condense b) => Condense (a, b) where
   condense (a, b) = condense (a :* b :* Nil)
 
+instance (Condense a, Condense b, Condense c) => Condense (a, b, c) where
+  condense (a, b, c) = condense (a :* b :* c :* Nil)
+
+instance (Condense a, Condense b, Condense c, Condense d) => Condense (a, b, c, d) where
+  condense (a, b, c, d) = condense (a :* b :* c :* d :* Nil)
+
+instance (Condense a, Condense b, Condense c, Condense d, Condense e) => Condense (a, b, c, d, e) where
+  condense (a, b, c, d, e) = condense (a :* b :* c :* d :* e :* Nil)
+
 instance (Condense k, Condense a) => Condense (Map k a) where
   condense = condense . Map.toList
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -5,19 +5,15 @@ import           Control.Monad.Identity
 import           Control.Monad.Trans
 import           Crypto.Random
 
-import           Test.QuickCheck (Arbitrary (..), Gen)
-
 import           Ouroboros.Network.Block (Slot (..))
 import           Ouroboros.Network.Chain (Chain (..))
 import           Ouroboros.Network.Node (NodeId (..))
-import           Ouroboros.Network.Serialise (Serialise)
 
-import           Ouroboros.Consensus.Crypto.DSIGN.Class (DSIGNAlgorithm (..))
-import           Ouroboros.Consensus.Crypto.Hash.Class (Hash,
-                     HashAlgorithm (..), hash)
-import           Ouroboros.Consensus.Crypto.VRF.Class (VRFAlgorithm (..))
 import           Ouroboros.Consensus.Util.Condense
-import           Ouroboros.Consensus.Util.Random (withSeed)
+
+{-------------------------------------------------------------------------------
+  Condense
+-------------------------------------------------------------------------------}
 
 instance Condense Slot where
   condense (Slot n) = condense n
@@ -30,54 +26,9 @@ instance Condense block => Condense (Chain block) where
     condense Genesis   = "Genesis"
     condense (cs :> b) = condense cs <> " :> " <> condense b
 
-instance DSIGNAlgorithm v => Arbitrary (SignKeyDSIGN v) where
-
-    arbitrary = do
-        seed <- arbitrary
-        return $ withSeed seed genKeyDSIGN
-
-    shrink = const []
-
-instance (Serialise a, Arbitrary a, HashAlgorithm h) => Arbitrary (Hash h a) where
-
-    arbitrary = hash <$> arbitrary
-    shrink = const []
-
-instance DSIGNAlgorithm v => Arbitrary (VerKeyDSIGN v) where
-    arbitrary = deriveVerKeyDSIGN <$> arbitrary
-    shrink = const []
-
-instance DSIGNAlgorithm v => Arbitrary (SigDSIGN v) where
-
-    arbitrary = do
-        a    <- arbitrary :: Gen Int
-        sk   <- arbitrary
-        seed <- arbitrary
-        return $ withSeed seed $ signDSIGN a sk
-
-    shrink = const []
-
-instance VRFAlgorithm v => Arbitrary (SignKeyVRF v) where
-
-    arbitrary = do
-        seed <- arbitrary
-        return $ withSeed seed genKeyVRF
-
-    shrink = const []
-
-instance VRFAlgorithm v => Arbitrary (VerKeyVRF v) where
-    arbitrary = deriveVerKeyVRF <$> arbitrary
-    shrink = const []
-
-instance VRFAlgorithm v => Arbitrary (CertVRF v) where
-
-    arbitrary = do
-        a    <- arbitrary :: Gen Int
-        sk   <- arbitrary
-        seed <- arbitrary
-        return $ withSeed seed $ fmap snd $ evalVRF a sk
-
-    shrink = const []
+{-------------------------------------------------------------------------------
+  MonadRandom
+-------------------------------------------------------------------------------}
 
 instance MonadRandom m => MonadRandom (IdentityT m) where
      getRandomBytes = lift . getRandomBytes

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -7,6 +7,7 @@ import           Crypto.Random
 
 import           Test.QuickCheck (Arbitrary (..), Gen)
 
+import           Ouroboros.Network.Block (Slot (..))
 import           Ouroboros.Network.Chain (Chain (..))
 import           Ouroboros.Network.Node (NodeId (..))
 import           Ouroboros.Network.Serialise (Serialise)
@@ -17,6 +18,9 @@ import           Ouroboros.Consensus.Crypto.Hash.Class (Hash,
 import           Ouroboros.Consensus.Crypto.VRF.Class (VRFAlgorithm (..))
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Random (withSeed)
+
+instance Condense Slot where
+  condense (Slot n) = condense n
 
 instance Condense NodeId where
   condense (CoreId  i) = "c" ++ show i

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Random.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Random.hs
@@ -33,6 +33,8 @@ import           Data.Word (Word64)
 import           Numeric.Natural (Natural)
 import           Test.QuickCheck
 
+import           Control.Monad.Class.MonadSay
+
 import           Ouroboros.Network.Serialise (Serialise)
 
 {-------------------------------------------------------------------------------
@@ -101,7 +103,7 @@ nullSeed = Seed (0,0,0,0,0)
 
 -- | Add DRNG to a monad stack
 newtype ChaChaT m a = ChaChaT { unChaChaT :: StateT ChaChaDRG m a }
-  deriving (Functor, Applicative, Monad, MonadTrans)
+  deriving (Functor, Applicative, Monad, MonadTrans, MonadSay)
 
 instance Monad m => MonadRandom (ChaChaT m) where
   getRandomBytes = ChaChaT . state . randomBytesGenerate

--- a/ouroboros-consensus/test-consensus/Main.hs
+++ b/ouroboros-consensus/test-consensus/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import           Test.Tasty
 
+import qualified Test.Consensus.BlockchainTime (tests)
 import qualified Test.Dynamic.BFT (tests)
 import qualified Test.Dynamic.LeaderSchedule (tests)
 import qualified Test.Dynamic.Praos (tests)
@@ -12,7 +13,8 @@ main = defaultMain tests
 tests :: TestTree
 tests =
   testGroup "ouroboros-consensus"
-  [ Test.Dynamic.BFT.tests
+  [ Test.Consensus.BlockchainTime.tests
+  , Test.Dynamic.BFT.tests
   , Test.Dynamic.LeaderSchedule.tests
   , Test.Dynamic.Praos.tests
   ]

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
@@ -12,7 +12,7 @@ import           Test.Tasty.QuickCheck
 
 import           Ouroboros.Consensus.BlockchainTime
 
-import           Test.Orphans.Arbitrary ()
+import           Test.Util.Orphans.Arbitrary ()
 
 tests :: TestTree
 tests = testGroup "BlockchainTime" [

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
@@ -1,0 +1,175 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RecordWildCards    #-}
+
+module Test.Consensus.BlockchainTime (tests) where
+
+import           Data.Bifunctor
+import           Data.Time
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
+
+import           Ouroboros.Consensus.BlockchainTime
+
+import           Test.Orphans.Arbitrary ()
+
+tests :: TestTree
+tests = testGroup "BlockchainTime" [
+      testProperty "UTC_Fixed_UTC"         prop_UTC_Fixed_UTC
+    , testProperty "Nominal_Fixed_Nominal" prop_Nominal_Fixed_Nominal
+    , testProperty "Fixed_UTC_Fixed"       prop_Fixed_UTC_Fixed
+    , testProperty "Fixed_Nominal_Fixed"   prop_Fixed_Nominal_Fixed
+    , testProperty "startOfSlot"           prop_startOfSlot
+    , testProperty "slotAtTime"            prop_slotAtTime
+    , testProperty "timeUntilNextSlot"     prop_timeUntilNextSlot
+    , testProperty "timeFromStartOfSlot"   prop_timeFromStartOfSlot
+    , testProperty "slotAfterTime"         prop_slotAfterTime
+    , testProperty "delayNextSlot"         prop_delayNextSlot
+    ]
+
+{-------------------------------------------------------------------------------
+  Roundtrip properties for time conversion functions
+-------------------------------------------------------------------------------}
+
+-- > fixedToUTC (fixedFromUTC t) ~= t
+prop_UTC_Fixed_UTC :: UTCTime -> Property
+prop_UTC_Fixed_UTC t =
+      counterexample ("t':  " ++ show t')
+    . counterexample ("t'': " ++ show t'')
+    $ realToFrac (diffUTCTime t t'') < maxError
+  where
+    t'  = fixedFromUTC t
+    t'' = fixedToUTC   t'
+
+    maxError :: Double
+    maxError = 0.001 -- millisecond resolution
+
+-- > fixedFromUTC (fixedToUTC t) == t
+prop_Fixed_UTC_Fixed :: FixedUTC -> Property
+prop_Fixed_UTC_Fixed t = fixedFromUTC (fixedToUTC t) === t
+
+-- > fixedToNominal (fixedFromNominal d) ~= d
+prop_Nominal_Fixed_Nominal :: NominalDiffTime -> Property
+prop_Nominal_Fixed_Nominal d =
+      counterexample ("t':  " ++ show d')
+    . counterexample ("t'': " ++ show d'')
+    $ realToFrac (d - d'') < maxError
+  where
+    d'  = fixedDiffFromNominal d
+    d'' = fixedDiffToNominal   d'
+
+    maxError :: Double
+    maxError = 0.001 -- millisecond resolution
+
+-- > fixedFromNominal (fixedToNominal t) == t
+prop_Fixed_Nominal_Fixed :: FixedDiffTime -> Property
+prop_Fixed_Nominal_Fixed t = fixedDiffFromNominal (fixedDiffToNominal t) === t
+
+{-------------------------------------------------------------------------------
+  Properties of the time utilities
+-------------------------------------------------------------------------------}
+
+-- > slotAtTime (startOfSlot slot)) == (slot, 0)
+prop_startOfSlot :: SlotLength -> SystemStart -> Slot -> Property
+prop_startOfSlot slotLen start slot =
+      counterexample ("slotStart: " ++ show slotStart)
+    $ slotAtTime slotLen start slotStart === (slot, 0)
+  where
+    slotStart = startOfSlot slotLen start slot
+
+-- > now - slotLen < startOfSlot (fst (slotAtTime now)) <= now
+-- > 0 <= snd (slotAtTime now) < slotLen
+prop_slotAtTime :: SlotLength -> SystemStart -> FixedDiffTime -> Property
+prop_slotAtTime slotLen start execTime =
+      counterexample ("now:         " ++ show now)
+    . counterexample ("currentSlot: " ++ show currentSlot)
+    . counterexample ("timeSpent:   " ++ show timeSpent)
+    . counterexample ("slotStart:   " ++ show slotStart)
+    $    addFixedUTC (negate slotLen') now < startOfSlot slotLen start currentSlot
+    .&&. slotStart <= now
+    .&&. 0 <= timeSpent
+    .&&. timeSpent < getSlotLength slotLen
+  where
+    now                      = addFixedUTC execTime (getSystemStart start)
+    (currentSlot, timeSpent) = slotAtTime slotLen start now
+    slotStart                = startOfSlot slotLen start currentSlot
+    slotLen'                 = getSlotLength slotLen
+
+-- > 0 < fst (timeUntilNextSlot now) <= slotLen
+prop_timeUntilNextSlot :: SlotLength -> SystemStart -> FixedDiffTime -> Property
+prop_timeUntilNextSlot slotLen start execTime =
+      counterexample ("now:      " ++ show now)
+    . counterexample ("timeLeft: " ++ show timeLeft)
+    $    0 < timeLeft
+    .&&. timeLeft <= getSlotLength slotLen
+  where
+    now               = addFixedUTC execTime (getSystemStart start)
+    (timeLeft, _next) = timeUntilNextSlot slotLen start now
+
+-- > timeUntilNextSlot (startOfSlot slot) == (slotLen, slot + 1)
+prop_timeFromStartOfSlot :: SlotLength -> SystemStart -> Slot -> Property
+prop_timeFromStartOfSlot slotLen start slot =
+      counterexample ("slotStart: " ++ show slotStart)
+    $ timeUntilNextSlot slotLen start slotStart ===
+      (getSlotLength slotLen, slot + 1)
+  where
+    slotStart = startOfSlot slotLen start slot
+
+-- > slotAtTime (now + fst (timeUntilNextSlot now)) == bimap (+1) (const 0) (slotAtTime now)
+-- > fst (slotAtTime (now + fst (timeUntilNextSlot now))) == snd (timeUntilNextSlot now)
+prop_slotAfterTime :: SlotLength -> SystemStart -> FixedDiffTime -> Property
+prop_slotAfterTime slotLen start execTime =
+      counterexample ("now:        " ++ show now)
+    . counterexample ("timeLeft:   " ++ show timeLeft)
+    . counterexample ("afterDelay: " ++ show afterDelay)
+    $    slotAtTime slotLen start afterDelay ===
+         bimap (+1) (const 0) (slotAtTime slotLen start now)
+    .&&. fst (slotAtTime slotLen start afterDelay) === next
+  where
+    now              = addFixedUTC execTime (getSystemStart start)
+    (timeLeft, next) = timeUntilNextSlot slotLen start now
+    afterDelay       = addFixedUTC timeLeft now
+
+{-------------------------------------------------------------------------------
+  Test for IO
+-------------------------------------------------------------------------------}
+
+-- | Parameters for testing 'timeUntilNextSlot' in some actual IO code
+data TestDelayIO = TestDelayIO {
+      -- | System start
+      --
+      -- Since we don't actually " start " the system in any way, we specify
+      -- this as an offset _before_ the start of the test.
+      tdioStart'  :: FixedDiffTime
+
+      -- | Slot length
+      --
+      -- Since this test is run in IO, we will keep the slot length short.
+    , tdioSlotLen :: SlotLength
+    }
+  deriving (Show)
+
+instance Arbitrary TestDelayIO where
+  arbitrary = do
+      tdioStart'  <- arbitrary
+      tdioSlotLen <- slotLengthFromMillisec <$> choose (1, 1_000)
+      return TestDelayIO{..}
+
+-- | Just as a sanity check, also run the tests in IO
+--
+-- We override the maxinum number of tests since there are slow.
+prop_delayNextSlot :: TestDelayIO -> Property
+prop_delayNextSlot TestDelayIO{..} = withMaxSuccess 10 $ ioProperty $ do
+    tdioStart         <- pickSystemStart
+    slotAtStartOfTest <- getCurrentSlotIO    tdioSlotLen tdioStart
+    nextSlot          <- waitUntilNextSlotIO tdioSlotLen tdioStart
+    slotAfterDelay    <- getCurrentSlotIO    tdioSlotLen tdioStart
+    assertEqual "slotAtStartOfTest + 1" (slotAtStartOfTest + 1) slotAfterDelay
+    assertEqual "nextSlot"              nextSlot                slotAfterDelay
+  where
+    pickSystemStart :: IO SystemStart
+    pickSystemStart = pick <$> getCurrentFixedUTC
+      where
+        pick :: FixedUTC -> SystemStart
+        pick = SystemStart . addFixedUTC (negate tdioStart')

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
@@ -101,11 +101,17 @@ prop_timeUntilNextSlot :: SlotLength -> SystemStart -> FixedDiffTime -> Property
 prop_timeUntilNextSlot slotLen start execTime =
       counterexample ("now:      " ++ show now)
     . counterexample ("timeLeft: " ++ show timeLeft)
+    . tabulate "Edge case:" [edgeCase]
     $    0 < timeLeft
     .&&. timeLeft <= getSlotLength slotLen
   where
     now               = addFixedUTC execTime (getSystemStart start)
     (timeLeft, _next) = timeUntilNextSlot slotLen start now
+
+    edgeCase :: String
+    edgeCase | timeLeft <= 1                     = "<= 1"
+             | timeLeft >= getSlotLength slotLen = ">= slotLen"
+             | otherwise                         = "in the middle"
 
 -- > timeUntilNextSlot (startOfSlot slot) == (slotLen, slot + 1)
 prop_timeFromStartOfSlot :: SlotLength -> SystemStart -> Slot -> Property

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -27,6 +27,7 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
+import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Node
 import           Ouroboros.Consensus.Protocol.Abstract

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -36,7 +36,7 @@ import           Ouroboros.Network.Chain (Chain)
 
 import           Test.Dynamic.General
 import           Test.Dynamic.Util
-import           Test.Orphans.Arbitrary ()
+import           Test.Util.Orphans.Arbitrary ()
 
 tests :: TestTree
 tests = testGroup "Dynamic chain generation" [

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -30,6 +30,7 @@ import           Control.Monad.IOSim (VTime)
 
 import           Ouroboros.Network.Chain
 
+import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Node
 import           Ouroboros.Consensus.Util.Orphans ()

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -32,6 +32,7 @@ import           Ouroboros.Network.Block (Slot (..))
 import           Ouroboros.Network.Chain (Chain)
 import           Ouroboros.Network.Node
 
+import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Node
 import           Ouroboros.Consensus.Protocol.Abstract

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -28,6 +28,7 @@ import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.Protocol.ChainSync.Codec.Id
 import           Ouroboros.Network.Protocol.ChainSync.Type
 
+import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Crypto.Hash
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -43,7 +43,7 @@ import           Ouroboros.Consensus.Util.Random
 
 import           Test.Dynamic.General
 import           Test.Dynamic.Util
-import           Test.Util.Orphans.Arbitrary
+import           Test.Util.Orphans.Arbitrary ()
 
 tests :: TestTree
 tests = testGroup "Dynamic chain generation"

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -33,8 +33,8 @@ import           Ouroboros.Network.Chain
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.Node
 
+import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
-import           Ouroboros.Consensus.Node (NumSlots (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.Praos
 import           Ouroboros.Consensus.Util.Chain (dropLastBlocks, lastSlot)

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -43,6 +43,7 @@ import           Ouroboros.Consensus.Util.Random
 
 import           Test.Dynamic.General
 import           Test.Dynamic.Util
+import           Test.Util.Orphans.Arbitrary
 
 tests :: TestTree
 tests = testGroup "Dynamic chain generation"

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
@@ -31,6 +31,7 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (Chain (..))
 import qualified Ouroboros.Network.Chain as Chain
 
+import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo (HasCreator (..))
 import           Ouroboros.Consensus.Node
 import           Ouroboros.Consensus.Protocol.LeaderSchedule

--- a/ouroboros-consensus/test-crypto/Test/Crypto/DSIGN.hs
+++ b/ouroboros-consensus/test-crypto/Test/Crypto/DSIGN.hs
@@ -17,7 +17,7 @@ import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random (Seed, withSeed)
 
-import           Test.Util.Orphans.Arbitrary
+import           Test.Util.Orphans.Arbitrary ()
 
 --
 -- The list of all tests

--- a/ouroboros-consensus/test-crypto/Test/Crypto/DSIGN.hs
+++ b/ouroboros-consensus/test-crypto/Test/Crypto/DSIGN.hs
@@ -10,11 +10,14 @@ import           Test.QuickCheck (Property, (==>))
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
+import           Ouroboros.Network.Serialise (prop_serialise)
+import           Ouroboros.Network.Serialise (Serialise)
+
 import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random (Seed, withSeed)
-import           Ouroboros.Network.Serialise (prop_serialise)
-import           Ouroboros.Network.Serialise (Serialise)
+
+import           Test.Util.Orphans.Arbitrary
 
 --
 -- The list of all tests

--- a/ouroboros-consensus/test-crypto/Test/Crypto/Hash.hs
+++ b/ouroboros-consensus/test-crypto/Test/Crypto/Hash.hs
@@ -12,9 +12,12 @@ import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
+import           Ouroboros.Network.Serialise
+
 import           Ouroboros.Consensus.Crypto.Hash
 import           Ouroboros.Consensus.Util.Orphans ()
-import           Ouroboros.Network.Serialise
+
+import           Test.Util.Orphans.Arbitrary ()
 
 --
 -- The list of all tests

--- a/ouroboros-consensus/test-crypto/Test/Crypto/KES.hs
+++ b/ouroboros-consensus/test-crypto/Test/Crypto/KES.hs
@@ -15,10 +15,14 @@ import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
+import           Ouroboros.Network.Serialise (Serialise, prop_serialise)
+
 import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Crypto.KES
 import           Ouroboros.Consensus.Util.Random
-import           Ouroboros.Network.Serialise (Serialise, prop_serialise)
+
+import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.QuickCheck
 
 --
 -- The list of all tests

--- a/ouroboros-consensus/test-crypto/Test/Crypto/VRF.hs
+++ b/ouroboros-consensus/test-crypto/Test/Crypto/VRF.hs
@@ -10,10 +10,13 @@ import           Test.QuickCheck (Property, counterexample, (==>))
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
+import           Ouroboros.Network.Serialise (Serialise, prop_serialise)
+
 import           Ouroboros.Consensus.Crypto.VRF
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random (Seed, withSeed)
-import           Ouroboros.Network.Serialise (Serialise, prop_serialise)
+
+import           Test.Util.Orphans.Arbitrary ()
 
 --
 -- The list of all tests

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
@@ -19,7 +19,7 @@ module Test.Ouroboros.Storage.ImmutableDB.CumulEpochSizes
 import qualified Data.Foldable as Foldable
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import           Data.Sequence (Seq(..))
+import           Data.Sequence (Seq (..))
 import qualified Data.Sequence as Seq
 
 import           GHC.Generics (Generic)
@@ -28,7 +28,7 @@ import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Ouroboros.Network.Block (Slot(..))
+import           Ouroboros.Network.Block (Slot (..))
 
 import           Ouroboros.Storage.ImmutableDB.Types
 
@@ -62,7 +62,7 @@ singleton = CES . Seq.singleton
 snoc :: CumulEpochSizes -> EpochSize -> CumulEpochSizes
 snoc _         0  = error "Epoch size must be > 0"
 snoc (CES ces) es = case ces of
-    Empty -> error "Impossible: empty CumulEpochSizes"
+    Empty        -> error "Impossible: empty CumulEpochSizes"
     _ :|> lastEs -> CES (ces :|> lastEs + es)
 
 -- | Helper to build a 'CumulEpochSizes' from a non-empty list of epoc sizes.
@@ -93,7 +93,7 @@ lastEpochSize (CES (_ :|> prevEs :|> lastEs)) = lastEs - prevEs
 -- | Return the last slot that a blob could be stored at, i.e. the slot
 -- corresponding to the last relative slot of the last epoch.
 maxSlot :: CumulEpochSizes -> Slot
-maxSlot (CES Empty) = error "Impossible: empty CumulEpochSizes"
+maxSlot (CES Empty)          = error "Impossible: empty CumulEpochSizes"
 maxSlot (CES (_ :|> lastEs)) = fromIntegral lastEs - 1
 
 -- | Return the size of the given epoch if known.
@@ -106,8 +106,8 @@ epochSize (CES ces) epoch =
 
 -- | Make sure the the given epoch is the last epoch for which the size is
 -- stored. No-op if the current last epoch is <= the given epoch.
-rollBackToEpoch :: CumulEpochSizes -> Epoch -> CumulEpochSizes
-rollBackToEpoch (CES ces) epoch = CES $ Seq.take (succ (fromIntegral epoch)) ces
+_rollBackToEpoch :: CumulEpochSizes -> Epoch -> CumulEpochSizes
+_rollBackToEpoch (CES ces) epoch = CES $ Seq.take (succ (fromIntegral epoch)) ces
 
 -- | Convert a 'Slot' to an 'EpochSlot'
 --

--- a/ouroboros-consensus/test-util/Test/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/test-util/Test/Orphans/Arbitrary.hs
@@ -1,12 +1,13 @@
+{-# LANGUAGE NumericUnderscores #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Test.Orphans.Arbitrary () where
 
-import           Test.QuickCheck
+import           Data.Time
+import           Test.QuickCheck hiding (Fixed (..))
 
+import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
-import           Ouroboros.Consensus.Node
-
 
 minNumCoreNodes, minNumSlots :: Int
 minNumCoreNodes = 2
@@ -20,3 +21,55 @@ instance Arbitrary NumCoreNodes where
 instance Arbitrary NumSlots where
   arbitrary = NumSlots <$> choose (minNumSlots, 100)
   shrink (NumSlots n) = NumSlots <$> (filter (>= minNumSlots) $ shrink n)
+
+-- | Picks time span between 0 seconds and (roughly) 50 years
+instance Arbitrary NominalDiffTime where
+  arbitrary = conv <$> choose (0, 50 * daysPerYear * secondsPerDay)
+    where
+      conv :: Double -> NominalDiffTime
+      conv = realToFrac
+
+-- | Picks moment between 'dawnOfTime' and (roughly) 50 years later
+--
+-- Uses instance for 'NominalDiffTime'
+instance Arbitrary UTCTime where
+  arbitrary = (`addUTCTime` dawnOfTime) <$> arbitrary
+
+-- | Defined in terms of instance for 'NominalDiffTime'
+instance Arbitrary FixedDiffTime where
+   arbitrary = fixedDiffFromNominal <$> arbitrary
+
+-- | Defined in terms of instance for 'UTCTime'
+instance Arbitrary FixedUTC where
+  arbitrary = fixedFromUTC <$> arbitrary
+
+-- | Length between 0.001 and 20 seconds, millisecond granularity
+instance Arbitrary SlotLength where
+  arbitrary = slotLengthFromMillisec <$> choose (1, 20 * 1_000)
+
+-- | Defined in terms of 'FixedUTC'
+instance Arbitrary SystemStart where
+  arbitrary = SystemStart <$> arbitrary
+
+instance Arbitrary Slot where
+  arbitrary = Slot . getPositive <$> arbitrary
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+-- | Average number of days per year
+--
+-- <https://en.wikipedia.org/wiki/Year>
+daysPerYear :: Double
+daysPerYear = 365.2425
+
+-- | Seconds per day
+secondsPerDay :: Double
+secondsPerDay = 24 * 60 * 60
+
+-- | Dawn of time
+--
+-- Everybody knows nothing happened before 2000-01-01 00:00:00
+dawnOfTime :: UTCTime
+dawnOfTime = read "2000-01-01 00:00:00"

--- a/ouroboros-consensus/test-util/Test/Util/DepFn.hs
+++ b/ouroboros-consensus/test-util/Test/Util/DepFn.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Testing dependent functions
-module Ouroboros.Consensus.Util.DepFn (
+module Test.Util.DepFn (
     -- * Infrastructure: generic
     All
     -- * Testing dependent functions

--- a/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
@@ -1,10 +1,9 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Orphans.Arbitrary () where
+module Test.Util.Orphans.Arbitrary () where
 
 import           Data.Time
-import           Numeric.Natural (Natural)
 import           Test.QuickCheck hiding (Fixed (..))
 
 import           Ouroboros.Network.Serialise (Serialise)
@@ -15,8 +14,7 @@ import           Ouroboros.Consensus.Crypto.Hash.Class (Hash,
                      HashAlgorithm (..), hash)
 import           Ouroboros.Consensus.Crypto.VRF.Class (VRFAlgorithm (..))
 import           Ouroboros.Consensus.Demo
-import           Ouroboros.Consensus.Util.Condense
-import           Ouroboros.Consensus.Util.Random (withSeed)
+import           Ouroboros.Consensus.Util.Random (Seed (..), withSeed)
 
 minNumCoreNodes, minNumSlots :: Int
 minNumCoreNodes = 2
@@ -144,20 +142,3 @@ secondsPerDay = 24 * 60 * 60
 -- Everybody knows nothing happened before 2000-01-01 00:00:00
 dawnOfTime :: UTCTime
 dawnOfTime = read "2000-01-01 00:00:00"
-
-{-------------------------------------------------------------------------------
-  Auxiliary: crypto
--------------------------------------------------------------------------------}
-
-genNatBetween :: Natural -> Natural -> Gen Natural
-genNatBetween from to = do
-    i <- choose (toInteger from, toInteger to)
-    return $ fromIntegral i
-
-genNat :: Gen Natural
-genNat = do
-    NonNegative i <- arbitrary :: Gen (NonNegative Integer)
-    return $ fromIntegral i
-
-shrinkNat :: Natural -> [Natural]
-shrinkNat = map fromIntegral . shrink . toInteger

--- a/ouroboros-consensus/test-util/Test/Util/QuickCheck.hs
+++ b/ouroboros-consensus/test-util/Test/Util/QuickCheck.hs
@@ -1,0 +1,26 @@
+module Test.Util.QuickCheck (
+    -- * Natural numbers
+    genNatBetween
+  , genNat
+  , shrinkNat
+  ) where
+
+import           Numeric.Natural (Natural)
+import           Test.QuickCheck
+
+{-------------------------------------------------------------------------------
+  Natural numbers
+-------------------------------------------------------------------------------}
+
+genNatBetween :: Natural -> Natural -> Gen Natural
+genNatBetween from to = do
+    i <- choose (toInteger from, toInteger to)
+    return $ fromIntegral i
+
+genNat :: Gen Natural
+genNat = do
+    NonNegative i <- arbitrary :: Gen (NonNegative Integer)
+    return $ fromIntegral i
+
+shrinkNat :: Natural -> [Natural]
+shrinkNat = map fromIntegral . shrink . toInteger


### PR DESCRIPTION
The demo was rejecting chains because the new block was produced "in the
future"; except that here "in the future" was merely caused by clock skew. We
now prune blocks that are ahead by more than one block instead.

Closes #280.