### PR TITLE
more tests for the req resp example

### DIFF
--- a/typed-protocols/src/Network/TypedProtocol/Channel.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Channel.hs
@@ -75,14 +75,14 @@ fixedInputChannel xs0 = do
 -- writing.
 --
 mvarsAsChannel :: MonadSTM m
-               => TMVar m (Maybe a)
-               -> TMVar m (Maybe a)
+               => TMVar m a
+               -> TMVar m a
                -> Channel m a 
 mvarsAsChannel bufferRead bufferWrite =
     Channel{send, recv}
   where
-    send x = atomically (putTMVar bufferWrite (Just x))
-    recv   = atomically (takeTMVar bufferRead)
+    send x = atomically (putTMVar bufferWrite x)
+    recv   = atomically (Just <$> takeTMVar bufferRead)
 
 
 -- | Create a pair of channels that are connected via one-place buffers.

--- a/typed-protocols/src/Network/TypedProtocol/PingPong/Client.hs
+++ b/typed-protocols/src/Network/TypedProtocol/PingPong/Client.hs
@@ -1,7 +1,15 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 
-module Network.TypedProtocol.PingPong.Client where
+module Network.TypedProtocol.PingPong.Client (
+    -- * Normal client
+    PingPongClient(..),
+    pingPongClientPeer,
+    -- * Pipelined client
+    PingPongClientPipelined(..),
+    PingPongSender(..),
+    pingPongClientPeerPipelined,
+  ) where
 
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Pipelined
@@ -123,6 +131,9 @@ data PingPongSender n c m a where
 
 
 
+-- | Interpret a pipelined client as a 'PeerPipelined' on the client side of
+-- the 'PingPong' protocol.
+--
 pingPongClientPeerPipelined
   :: Monad m
   => PingPongClientPipelined                m a

--- a/typed-protocols/src/Network/TypedProtocol/PingPong/Codec.hs
+++ b/typed-protocols/src/Network/TypedProtocol/PingPong/Codec.hs
@@ -33,35 +33,6 @@ codecPingPong =
           _                              -> DecodeFail ("unexpected message: " ++ str)
 
 
-decodeFrameOfLength :: forall m a.
-                       Monad m
-                    => Int
-                    -> (String -> Maybe String -> DecodeStep String String m a)
-                    -> m (DecodeStep String String m a)
-decodeFrameOfLength n k = go [] n
-  where
-    go :: [String] -> Int -> m (DecodeStep String String m a)
-    go chunks required =
-      return $ DecodePartial $ \mchunk ->
-        case mchunk of
-          Nothing -> return $ DecodeFail "not enough input"
-          Just chunk
-            | length chunk >= required
-           -> let (c,c') = splitAt required chunk in
-              return $ k (concat (reverse (c:chunks)))
-                         (if null c' then Nothing else Just c)
-
-            | otherwise
-           -> go (chunk : chunks) (required - length chunk)
-
-{-
-prop_decodeStepSplitAt n = do
-    chan <- fixedInputChannel ["ping", "pong"]
-    runDecoder chan Nothing decoder
-  where
-    decoder = decodeStepSplitAt n Done)
--}
-
 decodeTerminatedFrame :: forall m a.
                          Monad m
                       => Char

--- a/typed-protocols/src/Network/TypedProtocol/PingPong/Examples.hs
+++ b/typed-protocols/src/Network/TypedProtocol/PingPong/Examples.hs
@@ -57,7 +57,6 @@ pingPongClientCount n = SendMsgPing (pure (pingPongClientCount (n-1)))
 -- Pipelined examples
 --
 
-
 -- | A pipelined ping-pong client that sends eagerly rather than waiting to
 -- collect any replies. This is maximum pipelining in some sense, and
 -- correspondingly it gives minimum choice to the environment (drivers).

--- a/typed-protocols/src/Network/TypedProtocol/ReqResp/Client.hs
+++ b/typed-protocols/src/Network/TypedProtocol/ReqResp/Client.hs
@@ -1,7 +1,15 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 
-module Network.TypedProtocol.ReqResp.Client where
+module Network.TypedProtocol.ReqResp.Client (
+    -- * Normal client
+    ReqRespClient(..),
+    reqRespClientPeer,
+    -- * Pipelined client
+    ReqRespClientPipelined(..),
+    ReqRespSender(..),
+    reqRespClientPeerPipelined,
+  ) where
 
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Pipelined
@@ -82,6 +90,10 @@ data ReqRespSender req resp n c m a where
   SendMsgDonePipelined
     :: a -> ReqRespSender req resp Z c m a
 
+
+-- | Interpret a pipelined client as a 'PeerPipelined' on the client side of
+-- the 'ReqResp' protocol.
+--
 reqRespClientPeerPipelined
   :: Monad m
   => ReqRespClientPipelined req resp                  m a

--- a/typed-protocols/src/Network/TypedProtocol/ReqResp/Codec.hs
+++ b/typed-protocols/src/Network/TypedProtocol/ReqResp/Codec.hs
@@ -8,7 +8,7 @@ module Network.TypedProtocol.ReqResp.Codec where
 
 import           Network.TypedProtocol.Codec
 import           Network.TypedProtocol.ReqResp.Type
-
+import           Network.TypedProtocol.PingPong.Codec (decodeTerminatedFrame)
 import           Text.Read (readMaybe)
 
 
@@ -41,23 +41,4 @@ codecReqResp =
              | Just resp <- readMaybe str'
             -> DecodeDone (SomeMessage (MsgResp resp)) trailing
           _ -> DecodeFail ("unexpected message: " ++ str)
-
-
-decodeTerminatedFrame :: forall m a.
-                         Monad m
-                      => Char
-                      -> (String -> Maybe String -> DecodeStep String String m a)
-                      -> m (DecodeStep String String m a)
-decodeTerminatedFrame terminator k = go []
-  where
-    go :: [String] -> m (DecodeStep String String m a)
-    go chunks =
-      return $ DecodePartial $ \mchunk ->
-        case mchunk of
-          Nothing    -> return $ DecodeFail "not enough input"
-          Just chunk ->
-            case break (==terminator) chunk of
-              (c, _:c') -> return $ k (concat (reverse (c:chunks)))
-                                      (if null c' then Nothing else Just c)
-              _         -> go (chunk : chunks)
 

--- a/typed-protocols/src/Network/TypedProtocol/ReqResp/Examples.hs
+++ b/typed-protocols/src/Network/TypedProtocol/ReqResp/Examples.hs
@@ -1,9 +1,14 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE BangPatterns        #-}
 
 module Network.TypedProtocol.ReqResp.Examples where
 
 import           Network.TypedProtocol.ReqResp.Server
 import           Network.TypedProtocol.ReqResp.Client
+
+import           Network.TypedProtocol.Pipelined
 
 
 -- | A request\/response server instance that computes a 'Data.List.mapAccumL'
@@ -21,7 +26,6 @@ reqRespServerMapAccumL f !acc =
     }
 
 
-
 -- | An example request\/response client that sends the given list of requests
 -- and collects the list of responses.
 --
@@ -35,3 +39,45 @@ reqRespClientMap = go []
       SendMsgReq req $ \resp ->
       return (go (resp:resps) reqs)
 
+
+--
+-- Pipelined example
+--
+
+-- | An example request\/response client that sends the given list of requests
+-- and collects the list of responses.
+--
+-- It is pipelined and tries to collect any replies if they are available.
+-- This allows pipelining but keeps it to a minimum, and correspondingly it
+-- gives maximum choice to the environment (drivers).
+--
+-- In theory, with enough and large enough requests and responses, this should
+-- be able to saturate any channel of any bandwidth and latency, because it
+-- should be able to have both peers send essentially continuously.
+--
+reqRespClientMapPipelined :: forall req resp m.
+                             Monad m
+                          => [req]
+                          -> ReqRespClientPipelined req resp m [resp]
+reqRespClientMapPipelined reqs0 =
+    ReqRespClientPipelined (go [] Zero reqs0)
+  where
+    go :: [resp] -> Nat o -> [req] -> ReqRespSender req resp o resp m [resp]
+    go resps Zero reqs =
+      case reqs of
+        []        -> SendMsgDonePipelined (reverse resps)
+        req:reqs' -> sendReq resps Zero req reqs'
+
+    go resps (Succ o) reqs =
+      CollectPipelined
+        (case reqs of
+           []        -> Nothing
+           req:reqs' -> Just (sendReq resps (Succ o) req reqs'))
+        (\resp -> go (resp:resps) o reqs)
+
+    sendReq :: [resp] -> Nat o -> req -> [req]
+            -> ReqRespSender req resp o resp m [resp]
+    sendReq resps o req reqs' =
+      SendMsgReqPipelined req
+        (\resp -> return resp)
+        (go resps (Succ o) reqs')


### PR DESCRIPTION
Example client (inc pipelined) and server based on `mapAccumL` pattern.

Test template filled out with direct tests, building on existing codec tests.