### PR TITLE
Add missing tryReadTBQueue implementations to MonadSTM instances

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
@@ -111,6 +111,7 @@ instance (MonadFork (SimFS m) , MonadSTM m) => MonadSTM (SimFS m) where
 
   newTBQueue        = lift . newTBQueue
   readTBQueue       = lift . readTBQueue
+  tryReadTBQueue    = lift . tryReadTBQueue
   writeTBQueue    q = lift . writeTBQueue q
 
 simHasFS :: forall m. MonadSTM m => ErrorHandling FsError m -> HasFS (SimFS m)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
@@ -442,6 +442,7 @@ instance (MonadFork (SimErrorFS m) , MonadSTM m) => MonadSTM (SimErrorFS m) wher
 
   newTBQueue        = lift . newTBQueue
   readTBQueue       = lift . readTBQueue
+  tryReadTBQueue    = lift . tryReadTBQueue
   writeTBQueue    q = lift . writeTBQueue q
 
 


### PR DESCRIPTION
`tryReadTBQueue` was added to the `MonadSTM` type class in 77b111ef18b8b0f593b433262dc6abfe0e71de22.

If we add `-Werror=missing-methods` to `ghc-options`, this won't happen again.
