### PR TITLE
Add more MonadSTM apis and rename a couple

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -6,6 +6,8 @@
 module Control.Monad.Class.MonadSTM
   ( MonadSTM (..)
   , MonadFork (..)
+
+  -- * Default 'TMVar' implementation
   , TMVarDefault (..)
   , newTMVarDefault
   , newTMVarIODefault
@@ -19,22 +21,36 @@ module Control.Monad.Class.MonadSTM
   , tryReadTMVarDefault
   , swapTMVarDefault
   , isEmptyTMVarDefault
+
+  -- * Default 'TBQueue' implementation
+  , TQueueDefault (..)
+  , newTQueueDefault
+  , readTQueueDefault
+  , tryReadTQueueDefault
+  , writeTQueueDefault
+  , isEmptyTQueueDefault
+
+  -- * Default 'TBQueue' implementation
   , TBQueueDefault (..)
   , newTBQueueDefault
   , readTBQueueDefault
   , tryReadTBQueueDefault
   , writeTBQueueDefault
+  , isEmptyTBQueueDefault
+  , isFullTBQueueDefault
   ) where
 
 import           Prelude hiding (read)
 
-import qualified Control.Concurrent.STM.TBQueue as STM
-import qualified Control.Concurrent.STM.TMVar as STM
+import qualified Control.Monad.STM as STM
 import qualified Control.Concurrent.STM.TVar as STM
+import qualified Control.Concurrent.STM.TMVar as STM
+import qualified Control.Concurrent.STM.TQueue as STM
+import qualified Control.Concurrent.STM.TBQueue as STM
+
 import           Control.Exception
 import           Control.Monad.Except
 import           Control.Monad.Reader
-import qualified Control.Monad.STM as STM
 import           GHC.Stack
 import           Numeric.Natural (Natural)
 
@@ -85,16 +101,26 @@ class (MonadFork m, Monad (Tr m)) => MonadSTM m where
   swapTMVar       :: TMVar m a -> a -> Tr m a
   isEmptyTMVar    :: TMVar m a      -> Tr m Bool
 
+  type TQueue m  :: * -> *
+  newTQueue      :: Tr m (TQueue m a)
+  readTQueue     :: TQueue m a -> Tr m a
+  tryReadTQueue  :: TQueue m a -> Tr m (Maybe a)
+  writeTQueue    :: TQueue m a -> a -> Tr m ()
+  isEmptyTQueue  :: TQueue m a -> Tr m Bool
+
   type TBQueue m :: * -> *
   newTBQueue     :: Natural -> Tr m (TBQueue m a)
   readTBQueue    :: TBQueue m a -> Tr m a
   tryReadTBQueue :: TBQueue m a -> Tr m (Maybe a)
   writeTBQueue   :: TBQueue m a -> a -> Tr m ()
+  isEmptyTBQueue :: TBQueue m a -> Tr m Bool
+  isFullTBQueue  :: TBQueue m a -> Tr m Bool
 
 instance MonadSTM m => MonadSTM (ReaderT e m) where
   type Tr (ReaderT e m)    = ReaderT e (Tr m)
   type TVar (ReaderT e m)  = TVar m
   type TMVar (ReaderT e m) = TMVar m
+  type TQueue (ReaderT e m)  = TQueue m
   type TBQueue (ReaderT e m) = TBQueue m
 
   atomically (ReaderT t) = ReaderT $ \e -> atomically (t e)
@@ -116,15 +142,24 @@ instance MonadSTM m => MonadSTM (ReaderT e m) where
   swapTMVar t a    = lift $ swapTMVar t a
   isEmptyTMVar     = lift . isEmptyTMVar
 
+  newTQueue        = lift $ newTQueue
+  readTQueue       = lift . readTQueue
+  tryReadTQueue    = lift . tryReadTQueue
+  writeTQueue q a  = lift $ writeTQueue q a
+  isEmptyTQueue    = lift . isEmptyTQueue
+
   newTBQueue       = lift . newTBQueue
   readTBQueue      = lift . readTBQueue
   tryReadTBQueue   = lift . tryReadTBQueue
   writeTBQueue q a = lift $ writeTBQueue q a
+  isEmptyTBQueue   = lift . isEmptyTBQueue
+  isFullTBQueue    = lift . isFullTBQueue
 
 instance (Show e, MonadSTM m) => MonadSTM (ExceptT e m) where
   type Tr (ExceptT e m)      = ExceptT e (Tr m)
   type TVar (ExceptT e m)    = TVar m
   type TMVar (ExceptT e m)   = TMVar m
+  type TQueue (ExceptT e m)  = TQueue m
   type TBQueue (ExceptT e m) = TBQueue m
 
   atomically (ExceptT t) = ExceptT $ atomically t
@@ -146,10 +181,18 @@ instance (Show e, MonadSTM m) => MonadSTM (ExceptT e m) where
   swapTMVar t a          = lift $ swapTMVar t a
   isEmptyTMVar           = lift . isEmptyTMVar
 
+  newTQueue        = lift $ newTQueue
+  readTQueue       = lift . readTQueue
+  tryReadTQueue    = lift . tryReadTQueue
+  writeTQueue q a  = lift $ writeTQueue q a
+  isEmptyTQueue    = lift . isEmptyTQueue
+
   newTBQueue       = lift . newTBQueue
   readTBQueue      = lift . readTBQueue
   tryReadTBQueue   = lift . tryReadTBQueue
   writeTBQueue q a = lift $ writeTBQueue q a
+  isEmptyTBQueue   = lift . isEmptyTBQueue
+  isFullTBQueue    = lift . isFullTBQueue
 
 -- | Wrapper around 'BlockedIndefinitelyOnSTM' that stores a call stack
 data BlockedIndefinitely = BlockedIndefinitely {
@@ -201,6 +244,14 @@ instance MonadSTM IO where
   swapTMVar       = STM.swapTMVar
   isEmptyTMVar    = STM.isEmptyTMVar
 
+  type TQueue IO  = STM.TQueue
+
+  newTQueue       = STM.newTQueue
+  readTQueue      = STM.readTQueue
+  tryReadTQueue   = STM.tryReadTQueue
+  writeTQueue     = STM.writeTQueue
+  isEmptyTQueue   = STM.isEmptyTQueue
+
   type TBQueue IO = STM.TBQueue
 
 #if MIN_VERSION_stm(2,5,0)
@@ -212,6 +263,8 @@ instance MonadSTM IO where
   readTBQueue    = STM.readTBQueue
   tryReadTBQueue = STM.tryReadTBQueue
   writeTBQueue   = STM.writeTBQueue
+  isEmptyTBQueue = STM.isEmptyTBQueue
+  isFullTBQueue  = STM.isFullTBQueue
 
 --
 -- Default TMVar implementation in terms of TVars (used by sim)
@@ -291,6 +344,59 @@ isEmptyTMVarDefault (TMVar t) = do
     Nothing -> return True
     Just _  -> return False
 
+
+--
+-- Default TQueue implementation in terms of TVars (used by sim)
+--
+
+data TQueueDefault m a = TQueue !(TVar m [a])
+                                !(TVar m [a])
+
+newTQueueDefault :: MonadSTM m => Tr m (TQueueDefault m a)
+newTQueueDefault = do
+  read  <- newTVar []
+  write <- newTVar []
+  return (TQueue read write)
+
+writeTQueueDefault :: MonadSTM m => TQueueDefault m a -> a -> Tr m ()
+writeTQueueDefault (TQueue _read write) a = do
+  listend <- readTVar write
+  writeTVar write (a:listend)
+
+readTQueueDefault :: MonadSTM m => TQueueDefault m a -> Tr m a
+readTQueueDefault queue = maybe retry return =<< tryReadTQueueDefault queue
+
+tryReadTQueueDefault :: MonadSTM m => TQueueDefault m a -> Tr m (Maybe a)
+tryReadTQueueDefault (TQueue read write) = do
+  xs <- readTVar read
+  case xs of
+    (x:xs') -> do
+      writeTVar read xs'
+      return (Just x)
+    [] -> do
+      ys <- readTVar write
+      case ys of
+        [] -> return Nothing
+        _  -> do
+          let (z:zs) = reverse ys
+          writeTVar write []
+          writeTVar read zs
+          return (Just z)
+
+isEmptyTQueueDefault :: MonadSTM m => TQueueDefault m a -> Tr m Bool
+isEmptyTQueueDefault (TQueue read write) = do
+  xs <- readTVar read
+  case xs of
+    (_:_) -> return False
+    [] -> do ys <- readTVar write
+             case ys of
+               [] -> return True
+               _  -> return False
+
+--
+-- Default TBQueue implementation in terms of TVars (used by sim)
+--
+
 data TBQueueDefault m a = TBQueue
   !(TVar m Natural) -- read capacity
   !(TVar m [a])     -- elements waiting for read
@@ -342,3 +448,24 @@ writeTBQueueDefault (TBQueue rsize _read wsize write _size) a = do
             else retry
   listend <- readTVar write
   writeTVar write (a:listend)
+
+isEmptyTBQueueDefault :: MonadSTM m => TBQueueDefault m a -> Tr m Bool
+isEmptyTBQueueDefault (TBQueue _rsize read _wsize write _size) = do
+  xs <- readTVar read
+  case xs of
+    (_:_) -> return False
+    [] -> do ys <- readTVar write
+             case ys of
+               [] -> return True
+               _  -> return False
+
+isFullTBQueueDefault :: MonadSTM m => TBQueueDefault m a -> Tr m Bool
+isFullTBQueueDefault (TBQueue rsize _read wsize _write _size) = do
+  w <- readTVar wsize
+  if (w > 0)
+     then return False
+     else do
+         r <- readTVar rsize
+         if (r > 0)
+            then return False
+            else return True

--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -10,9 +10,9 @@ module Control.Monad.Class.MonadSTM
   -- * Default 'TMVar' implementation
   , TMVarDefault (..)
   , newTMVarDefault
-  , newTMVarIODefault
+  , newTMVarMDefault
   , newEmptyTMVarDefault
-  , newEmptyTMVarIODefault
+  , newEmptyTMVarMDefault
   , takeTMVarDefault
   , tryTakeTMVarDefault
   , putTMVarDefault
@@ -71,8 +71,8 @@ class (MonadFork m, Monad (Tr m)) => MonadSTM m where
 --orElse       :: Tr m a -> Tr m a -> Tr m a --TODO
 
   -- Helpful derived functions with default implementations
-  newTVarIO     :: a -> m (TVar m a)
-  newTVarIO     = atomically . newTVar
+  newTVarM     :: a -> m (TVar m a)
+  newTVarM     = atomically . newTVar
 
   modifyTVar   :: TVar m a -> (a -> a) -> Tr m ()
   modifyTVar  v f = readTVar v >>= writeTVar v . f
@@ -89,9 +89,9 @@ class (MonadFork m, Monad (Tr m)) => MonadSTM m where
   -- Additional derived STM APIs
   type TMVar m :: * -> *
   newTMVar        :: a -> Tr m (TMVar m a)
-  newTMVarIO      :: a -> m   (TMVar m a)
+  newTMVarM       :: a -> m   (TMVar m a)
   newEmptyTMVar   ::      Tr m (TMVar m a)
-  newEmptyTMVarIO ::      m   (TMVar m a)
+  newEmptyTMVarM  ::      m   (TMVar m a)
   takeTMVar       :: TMVar m a      -> Tr m a
   tryTakeTMVar    :: TMVar m a      -> Tr m (Maybe a)
   putTMVar        :: TMVar m a -> a -> Tr m ()
@@ -130,9 +130,9 @@ instance MonadSTM m => MonadSTM (ReaderT e m) where
   retry            = lift retry
 
   newTMVar         = lift . newTMVar
-  newTMVarIO       = lift . newTMVarIO
+  newTMVarM        = lift . newTMVarM
   newEmptyTMVar    = lift newEmptyTMVar
-  newEmptyTMVarIO  = lift newEmptyTMVarIO
+  newEmptyTMVarM   = lift newEmptyTMVarM
   takeTMVar        = lift . takeTMVar
   tryTakeTMVar     = lift . tryTakeTMVar
   putTMVar   t a   = lift $ putTMVar t a
@@ -169,9 +169,9 @@ instance (Show e, MonadSTM m) => MonadSTM (ExceptT e m) where
   retry                  = lift retry
 
   newTMVar               = lift . newTMVar
-  newTMVarIO             = lift . newTMVarIO
+  newTMVarM              = lift . newTMVarM
   newEmptyTMVar          = lift newEmptyTMVar
-  newEmptyTMVarIO        = lift newEmptyTMVarIO
+  newEmptyTMVarM         = lift newEmptyTMVarM
   takeTMVar              = lift . takeTMVar
   tryTakeTMVar           = lift . tryTakeTMVar
   putTMVar   t a         = lift $ putTMVar t a
@@ -224,7 +224,7 @@ instance MonadSTM IO where
   writeTVar   = STM.writeTVar
   retry       = STM.retry
 
-  newTVarIO   = STM.newTVarIO
+  newTVarM    = STM.newTVarIO
   modifyTVar  = STM.modifyTVar
   modifyTVar' = STM.modifyTVar'
   check       = STM.check
@@ -232,9 +232,9 @@ instance MonadSTM IO where
   type TMVar IO = STM.TMVar
 
   newTMVar        = STM.newTMVar
-  newTMVarIO      = STM.newTMVarIO
+  newTMVarM       = STM.newTMVarIO
   newEmptyTMVar   = STM.newEmptyTMVar
-  newEmptyTMVarIO = STM.newEmptyTMVarIO
+  newEmptyTMVarM  = STM.newEmptyTMVarIO
   takeTMVar       = STM.takeTMVar
   tryTakeTMVar    = STM.tryTakeTMVar
   putTMVar        = STM.putTMVar
@@ -277,9 +277,9 @@ newTMVarDefault a = do
   t <- newTVar (Just a)
   return (TMVar t)
 
-newTMVarIODefault :: MonadSTM m => a -> m (TMVarDefault m a)
-newTMVarIODefault a = do
-  t <- newTVarIO (Just a)
+newTMVarMDefault :: MonadSTM m => a -> m (TMVarDefault m a)
+newTMVarMDefault a = do
+  t <- newTVarM (Just a)
   return (TMVar t)
 
 newEmptyTMVarDefault :: MonadSTM m => Tr m (TMVarDefault m a)
@@ -287,9 +287,9 @@ newEmptyTMVarDefault = do
   t <- newTVar Nothing
   return (TMVar t)
 
-newEmptyTMVarIODefault :: MonadSTM m => m (TMVarDefault m a)
-newEmptyTMVarIODefault = do
-  t <- newTVarIO Nothing
+newEmptyTMVarMDefault :: MonadSTM m => m (TMVarDefault m a)
+newEmptyTMVarMDefault = do
+  t <- newTVarM Nothing
   return (TMVar t)
 
 takeTMVarDefault :: MonadSTM m => TMVarDefault m a -> Tr m a

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -255,9 +255,9 @@ instance MonadSTM (SimM s) where
   retry             = STM $ \_ -> Retry
 
   newTMVar          = newTMVarDefault
-  newTMVarIO        = newTMVarIODefault
+  newTMVarM         = newTMVarMDefault
   newEmptyTMVar     = newEmptyTMVarDefault
-  newEmptyTMVarIO   = newEmptyTMVarIODefault
+  newEmptyTMVarM    = newEmptyTMVarMDefault
   takeTMVar         = takeTMVarDefault
   tryTakeTMVar      = tryTakeTMVarDefault
   putTMVar          = putTMVarDefault

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -244,6 +244,7 @@ instance MonadSTM (SimM s) where
   type Tr    (SimM s)   = STM s
   type TVar  (SimM s)   = TVar s
   type TMVar (SimM s)   = TMVarDefault (SimM s)
+  type TQueue (SimM s)  = TQueueDefault (SimM s)
   type TBQueue (SimM s) = TBQueueDefault (SimM s)
 
   atomically action = SimM $ \k -> Atomically action k
@@ -266,10 +267,18 @@ instance MonadSTM (SimM s) where
   swapTMVar         = swapTMVarDefault
   isEmptyTMVar      = isEmptyTMVarDefault
 
+  newTQueue         = newTQueueDefault
+  readTQueue        = readTQueueDefault
+  tryReadTQueue     = tryReadTQueueDefault
+  writeTQueue       = writeTQueueDefault
+  isEmptyTQueue     = isEmptyTQueueDefault
+
   newTBQueue        = newTBQueueDefault
   readTBQueue       = readTBQueueDefault
   tryReadTBQueue    = tryReadTBQueueDefault
   writeTBQueue      = writeTBQueueDefault
+  isEmptyTBQueue    = isEmptyTBQueueDefault
+  isFullTBQueue     = isFullTBQueueDefault
 
 instance MonadST (SimM s) where
   withLiftST f = f liftST

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -265,7 +265,7 @@ type Probe m x = TVar m [x]
 
 withProbe :: MonadSTM m => (Probe m x -> m ()) -> m [x]
 withProbe action = do
-    probe <- newTVarIO []
+    probe <- newTVarM []
     action probe
     reverse <$> atomically (readTVar probe)
 
@@ -397,7 +397,7 @@ unit_fork_2 =
   where
     example :: SimM s ()
     example = do
-      resVar <- newEmptyTMVarIO
+      resVar <- newEmptyTMVarM
       fork $ do res <- try (fail "oh noes!")
                 atomically (putTMVar resVar (res :: Either SomeException ()))
       say "parent"

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
@@ -98,9 +98,9 @@ instance (MonadFork (SimFS m) , MonadSTM m) => MonadSTM (SimFS m) where
   retry             = lift   retry
 
   newTMVar          = lift . newTMVar
-  newTMVarIO        = lift . newTMVarIO
+  newTMVarM         = lift . newTMVarM
   newEmptyTMVar     = lift   newEmptyTMVar
-  newEmptyTMVarIO   = lift   newEmptyTMVarIO
+  newEmptyTMVarM    = lift   newEmptyTMVarM
   takeTMVar         = lift . takeTMVar
   tryTakeTMVar      = lift . tryTakeTMVar
   putTMVar        t = lift . putTMVar    t

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
@@ -88,6 +88,7 @@ instance (MonadFork (SimFS m) , MonadSTM m) => MonadSTM (SimFS m) where
   type Tr (SimFS m)      = TrSimFS (Tr m)
   type TVar (SimFS m)    = TVar m
   type TMVar (SimFS m)   = TMVar m
+  type TQueue (SimFS m)  = TQueue m
   type TBQueue (SimFS m) = TBQueue m
 
   atomically        = lift . atomically . trSimFS
@@ -109,10 +110,18 @@ instance (MonadFork (SimFS m) , MonadSTM m) => MonadSTM (SimFS m) where
   tryReadTMVar      = lift . tryReadTMVar
   isEmptyTMVar      = lift . isEmptyTMVar
 
+  newTQueue         = lift   newTQueue
+  readTQueue        = lift . readTQueue
+  tryReadTQueue     = lift . tryReadTQueue
+  writeTQueue     q = lift . writeTQueue q
+  isEmptyTQueue     = lift . isEmptyTQueue
+
   newTBQueue        = lift . newTBQueue
   readTBQueue       = lift . readTBQueue
   tryReadTBQueue    = lift . tryReadTBQueue
   writeTBQueue    q = lift . writeTBQueue q
+  isEmptyTBQueue    = lift . isEmptyTBQueue
+  isFullTBQueue     = lift . isFullTBQueue
 
 simHasFS :: forall m. MonadSTM m => ErrorHandling FsError m -> HasFS (SimFS m)
 simHasFS err = HasFS {

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
@@ -419,6 +419,7 @@ instance (MonadFork (SimErrorFS m) , MonadSTM m) => MonadSTM (SimErrorFS m) wher
   type Tr (SimErrorFS m)      = TrSimErrorFS (Tr m)
   type TVar (SimErrorFS m)    = TVar m
   type TMVar (SimErrorFS m)   = TMVar m
+  type TQueue (SimErrorFS m)  = TQueue m
   type TBQueue (SimErrorFS m) = TBQueue m
 
   atomically        = lift . atomically . trSimErrorFS
@@ -440,10 +441,18 @@ instance (MonadFork (SimErrorFS m) , MonadSTM m) => MonadSTM (SimErrorFS m) wher
   tryReadTMVar      = lift . tryReadTMVar
   isEmptyTMVar      = lift . isEmptyTMVar
 
+  newTQueue         = lift   newTQueue
+  readTQueue        = lift . readTQueue
+  tryReadTQueue     = lift . tryReadTQueue
+  writeTQueue     q = lift . writeTQueue q
+  isEmptyTQueue     = lift . isEmptyTQueue
+
   newTBQueue        = lift . newTBQueue
   readTBQueue       = lift . readTBQueue
   tryReadTBQueue    = lift . tryReadTBQueue
   writeTBQueue    q = lift . writeTBQueue q
+  isEmptyTBQueue    = lift . isEmptyTBQueue
+  isFullTBQueue     = lift . isFullTBQueue
 
 
 instance (Monad m, MonadState MockFS (SimFS m))

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
@@ -429,9 +429,9 @@ instance (MonadFork (SimErrorFS m) , MonadSTM m) => MonadSTM (SimErrorFS m) wher
   retry             = lift   retry
 
   newTMVar          = lift . newTMVar
-  newTMVarIO        = lift . newTMVarIO
+  newTMVarM         = lift . newTMVarM
   newEmptyTMVar     = lift   newEmptyTMVar
-  newEmptyTMVarIO   = lift   newEmptyTMVarIO
+  newEmptyTMVarM    = lift   newEmptyTMVarM
   takeTMVar         = lift . takeTMVar
   tryTakeTMVar      = lift . tryTakeTMVar
   putTMVar        t = lift . putTMVar    t

--- a/ouroboros-network/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Socket.hs
@@ -18,9 +18,10 @@ module Ouroboros.Network.Socket (
     ) where
 
 import           Control.Concurrent.Async
-import qualified Control.Concurrent.STM.TBQueue as STM
-import qualified Control.Concurrent.STM.TMVar as STM
 import qualified Control.Concurrent.STM.TVar as STM
+import qualified Control.Concurrent.STM.TMVar as STM
+import qualified Control.Concurrent.STM.TQueue as STM
+import qualified Control.Concurrent.STM.TBQueue as STM
 import           Control.Monad
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSay
@@ -166,6 +167,13 @@ instance MonadSTM SocketBearer where
     swapTMVar       = fmap SocketBearerSTM . STM.swapTMVar
     isEmptyTMVar    = SocketBearerSTM . STM.isEmptyTMVar
 
+    type TQueue SocketBearer = STM.TQueue
+    newTQueue      = SocketBearerSTM   STM.newTQueue
+    readTQueue     = SocketBearerSTM . STM.readTQueue
+    tryReadTQueue  = SocketBearerSTM . STM.tryReadTQueue
+    writeTQueue    = fmap SocketBearerSTM . STM.writeTQueue
+    isEmptyTQueue  = SocketBearerSTM . STM.isEmptyTQueue
+
     type TBQueue SocketBearer = STM.TBQueue
 
 #if MIN_VERSION_stm(2,5,0)
@@ -177,6 +185,8 @@ instance MonadSTM SocketBearer where
     readTBQueue    = SocketBearerSTM . STM.readTBQueue
     tryReadTBQueue = SocketBearerSTM . STM.tryReadTBQueue
     writeTBQueue   = fmap SocketBearerSTM . STM.writeTBQueue
+    isEmptyTBQueue = SocketBearerSTM . STM.isEmptyTBQueue
+    isFullTBQueue  = SocketBearerSTM . STM.isFullTBQueue
 
 
 setupMux :: Mx.MiniProtocolDescriptions SocketBearer -> SocketCtx -> SocketBearer ()

--- a/ouroboros-network/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Socket.hs
@@ -107,7 +107,7 @@ instance MonadTimer SocketBearer where
     readTimeout (TimeoutSocketbearer var _key) = readTVar var
 
     newTimeout = \usec -> do
-        var <- newTVarIO TimeoutPending
+        var <- newTVarM TimeoutPending
         mgr <- liftIO GHC.getSystemTimerManager
         key <- liftIO $ GHC.registerTimeout mgr usec (STM.atomically (timeoutAction var))
         return (TimeoutSocketbearer var key)
@@ -147,7 +147,7 @@ instance MonadSTM SocketBearer where
     writeTVar   = fmap SocketBearerSTM . STM.writeTVar
     retry       = SocketBearerSTM STM.retry
 
-    newTVarIO   = SocketBearer . STM.newTVarIO
+    newTVarM    = SocketBearer . STM.newTVarIO
     modifyTVar  = fmap SocketBearerSTM . STM.modifyTVar
     modifyTVar' = fmap SocketBearerSTM . STM.modifyTVar'
     check       = SocketBearerSTM . STM.check
@@ -155,9 +155,9 @@ instance MonadSTM SocketBearer where
     type TMVar SocketBearer = STM.TMVar
 
     newTMVar        = SocketBearerSTM . STM.newTMVar
-    newTMVarIO      = SocketBearer . STM.newTMVarIO
+    newTMVarM       = SocketBearer . STM.newTMVarIO
     newEmptyTMVar   = SocketBearerSTM STM.newEmptyTMVar
-    newEmptyTMVarIO = SocketBearer STM.newEmptyTMVarIO
+    newEmptyTMVarM  = SocketBearer STM.newEmptyTMVarIO
     takeTMVar       = SocketBearerSTM . STM.takeTMVar
     tryTakeTMVar    = SocketBearerSTM . STM.tryTakeTMVar
     putTMVar        = fmap SocketBearerSTM . STM.putTMVar
@@ -307,8 +307,8 @@ demo2 chain0 updates = do
     printf $ (Chain.prettyPrintChain "\n" show chain0)
     printf "\n"-}
 
-    producerVar <- newTVarIO (CPS.initChainProducerState chain0)
-    consumerVar <- newTVarIO chain0
+    producerVar <- newTVarM (CPS.initChainProducerState chain0)
+    consumerVar <- newTVarM chain0
     consumerDone <- atomically newEmptyTMVar
 
     let Just expectedChain = Chain.applyChainUpdates updates chain0

--- a/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
@@ -135,7 +135,7 @@ coreToRelaySim :: ( MonadSTM m
                -> Probe m (NodeId, Chain Block)
                -> m ()
 coreToRelaySim duplex chain slotDuration coreTrDelay relayTrDelay probe = do
-  donevar <- newTVarIO False
+  donevar <- newTVarM False
   (coreChans, relayChans) <- if duplex
     then createTwoWaySubscriptionChannels relayTrDelay coreTrDelay
     else createOneWaySubscriptionChannels coreTrDelay relayTrDelay
@@ -211,7 +211,7 @@ coreToRelaySim2 :: ( MonadSTM m
                 -> Probe m (NodeId, Chain Block)
                 -> m ()
 coreToRelaySim2 chain slotDuration coreTrDelay relayTrDelay probe = do
-  donevar <- newTVarIO False
+  donevar <- newTVarM False
   (cr1, r1c) <- createOneWaySubscriptionChannels coreTrDelay relayTrDelay
   (r1r2, r2r1) <- createOneWaySubscriptionChannels relayTrDelay relayTrDelay
 
@@ -281,7 +281,7 @@ coreToCoreViaRelaySim chain1 chain2 slotDuration coreTrDelay relayTrDelay probe 
                         else blockBody <$> Chain.head chain2
       -- the slot at whcih the simulation will end
       lastSlot = max (Chain.headSlot chain1) (Chain.headSlot chain2)
-  donevar <- newTVarIO (0 :: Int)
+  donevar <- newTVarM (0 :: Int)
   (c1r1, r1c1) <- createTwoWaySubscriptionChannels coreTrDelay relayTrDelay
   (r1c2, c2r1) <- createTwoWaySubscriptionChannels relayTrDelay coreTrDelay
 
@@ -625,7 +625,7 @@ type Probe m x = TVar m [x]
 
 withProbe :: MonadSTM m => (Probe m x -> m ()) -> m [x]
 withProbe action = do
-    probe <- newTVarIO []
+    probe <- newTVarM []
     action probe
     reverse <$> atomically (readTVar probe)
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ReqResp.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ReqResp.hs
@@ -101,12 +101,12 @@ reqRespDemoExperiment clientChan serverChan request response =
 
       codec = hoistCodec liftST codecReqResp
 
-  serverResultVar <- newEmptyTMVarIO
+  serverResultVar <- newEmptyTMVarM
   fork $ do
     result <- useCodecWithDuplex serverChan codec serverPeer
     atomically (putTMVar serverResultVar result)
 
-  clientResultVar <- newEmptyTMVarIO
+  clientResultVar <- newEmptyTMVarM
   fork $ do
     result <- useCodecWithDuplex clientChan codec clientPeer
     atomically (putTMVar clientResultVar result)


### PR DESCRIPTION
Extend MonadSTM with TQueue and isEmpty/Full functions

The `TQueue` is useful in cases where the size is limited elsewhere and we don't want to have to duplicate limits.

The `isFullTBQueue` is useful for pipeline tests where we'd like to fail noisily if the expcted level of pipelining is exceded.

Also rename `newTVarIO` to `newTVarM`. The usual naming convenion for these things is the M suffix. Same for `newTMVarIO` and `newEmptyTMVarIO`.