### PR TITLE
Async exceptions, and MonadAsync

### DIFF
--- a/io-sim-classes/io-sim-classes.cabal
+++ b/io-sim-classes/io-sim-classes.cabal
@@ -22,6 +22,7 @@ library
   -- At this experiment/prototype stage everything is exposed.
   -- This has to be tidied up once the design becomes clear.
   exposed-modules:
+                       Control.Monad.Class.MonadAsync
                        Control.Monad.Class.MonadFork
                        Control.Monad.Class.MonadSay
                        Control.Monad.Class.MonadST
@@ -40,7 +41,8 @@ library
                        RankNTypes
   build-depends:       base  >=4.9 && <4.13,
                        mtl   >=2.2 && <2.3,
-                       stm   >=2.4 && <2.6
+                       stm   >=2.4 && <2.6,
+                       async >=2.1
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts

--- a/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
@@ -38,6 +38,10 @@ class MonadSTM m => MonadAsync m where
   waitAnyCancel         :: [Async m a] -> m (Async m a, a) 
   waitAnyCatchCancel    :: [Async m a] -> m (Async m a, Either SomeException a)
   waitEither            :: Async m a -> Async m b -> m (Either a b)
+
+  -- | Note, IO-based implementations should override the default
+  -- implementation. See the @async@ package implementation and comments.
+  -- <http://hackage.haskell.org/package/async-2.2.1/docs/src/Control.Concurrent.Async.html#waitEitherCatch>
   waitEitherCatch       :: Async m a -> Async m b -> m (Either (Either SomeException a)
                                                                (Either SomeException b))
   waitEitherCancel      :: Async m a -> Async m b -> m (Either a b)

--- a/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
@@ -1,0 +1,251 @@
+{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE DefaultSignatures      #-}
+{-# LANGUAGE FlexibleContexts       #-}
+
+module Control.Monad.Class.MonadAsync
+  ( MonadAsync (..)
+  ) where
+
+import           Prelude hiding (read)
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Exception (SomeException)
+import qualified Control.Concurrent.Async as Async
+
+class MonadSTM m => MonadAsync m where
+
+  {-# MINIMAL async, cancel, waitCatchSTM, pollSTM #-}
+
+  -- | An asynchronous action
+  type Async m :: * -> *
+
+  async                 :: m a -> m (Async m a)
+  withAsync             :: m a -> (Async m a -> m b) -> m b
+
+  wait                  :: Async m a -> m a
+  poll                  :: Async m a -> m (Maybe (Either SomeException a)) 
+  waitCatch             :: Async m a -> m (Either SomeException a)
+  cancel                :: Async m a -> m ()
+  uninterruptibleCancel :: Async m a -> m ()
+
+  waitSTM               :: Async m a -> Tr m a
+  pollSTM               :: Async m a -> Tr m (Maybe (Either SomeException a))
+  waitCatchSTM          :: Async m a -> Tr m (Either SomeException a)
+
+  waitAny               :: [Async m a] -> m (Async m a, a)
+  waitAnyCatch          :: [Async m a] -> m (Async m a, Either SomeException a)
+  waitAnyCancel         :: [Async m a] -> m (Async m a, a) 
+  waitAnyCatchCancel    :: [Async m a] -> m (Async m a, Either SomeException a)
+  waitEither            :: Async m a -> Async m b -> m (Either a b)
+  waitEitherCatch       :: Async m a -> Async m b -> m (Either (Either SomeException a)
+                                                               (Either SomeException b))
+  waitEitherCancel      :: Async m a -> Async m b -> m (Either a b)
+  waitEitherCatchCancel :: Async m a -> Async m b -> m (Either (Either SomeException a)
+                                                               (Either SomeException b))
+  waitEither_           :: Async m a -> Async m b -> m ()
+  waitBoth              :: Async m a -> Async m b -> m (a, b)
+
+  waitAnySTM            :: [Async m a] -> Tr m (Async m a, a)
+  waitAnyCatchSTM       :: [Async m a] -> Tr m (Async m a, Either SomeException a)
+  waitEitherSTM         :: Async m a -> Async m b -> Tr m (Either a b)
+  waitEitherSTM_        :: Async m a -> Async m b -> Tr m ()
+  waitEitherCatchSTM    :: Async m a -> Async m b
+                        -> Tr m (Either (Either SomeException a)
+                                        (Either SomeException b))
+  waitBothSTM           :: Async m a -> Async m b -> Tr m (a, b) 
+
+  race                  :: m a -> m b -> m (Either a b)
+  race_                 :: m a -> m b -> m ()
+  concurrently          :: m a -> m b -> m (a,b)
+
+  -- default implementations
+  default withAsync     :: MonadMask m => m a -> (Async m a -> m b) -> m b
+  default uninterruptibleCancel
+                        :: MonadMask m => Async m a -> m ()
+  default waitSTM       :: MonadThrow (Tr m) => Async m a -> Tr m a
+  default waitAnyCancel         :: MonadThrow m => [Async m a] -> m (Async m a, a) 
+  default waitAnyCatchCancel    :: MonadThrow m => [Async m a]
+                                -> m (Async m a, Either SomeException a)
+  default waitEitherCancel      :: MonadThrow m => Async m a -> Async m b
+                                -> m (Either a b)
+  default waitEitherCatchCancel :: MonadThrow m => Async m a -> Async m b
+                                -> m (Either (Either SomeException a)
+                                             (Either SomeException b))
+
+  default waitAnySTM     :: MonadThrow (Tr m) => [Async m a] -> Tr m (Async m a, a)
+  default waitEitherSTM  :: MonadThrow (Tr m) => Async m a -> Async m b -> Tr m (Either a b)
+  default waitEitherSTM_ :: MonadThrow (Tr m) => Async m a -> Async m b -> Tr m ()
+  default waitBothSTM    :: MonadThrow (Tr m) => Async m a -> Async m b -> Tr m (a, b) 
+
+
+  withAsync action inner = mask $ \restore -> do
+                             a <- async (restore action)
+                             restore (inner a)
+                               `finally` uninterruptibleCancel a
+
+  wait      = atomically . waitSTM
+  poll      = atomically . pollSTM
+  waitCatch = atomically . waitCatchSTM
+
+  uninterruptibleCancel      = uninterruptibleMask_ . cancel
+  waitSTM action             = waitCatchSTM action >>= either throwM return
+
+  waitAny                    = atomically . waitAnySTM
+  waitAnyCatch               = atomically . waitAnyCatchSTM
+  waitEither      left right = atomically (waitEitherSTM left right)
+  waitEither_     left right = atomically (waitEitherSTM_ left right)
+  waitEitherCatch left right = atomically (waitEitherCatchSTM left right)
+  waitBoth        left right = atomically (waitBothSTM left right)
+
+  waitAnyCancel asyncs =
+    waitAny asyncs `finally` mapM_ cancel asyncs
+
+  waitAnyCatchCancel asyncs =
+    waitAnyCatch asyncs `finally` mapM_ cancel asyncs
+
+  waitEitherCancel left right =
+    waitEither left right `finally` (cancel left >> cancel right)
+
+  waitEitherCatchCancel left right =
+    waitEitherCatch left right `finally` (cancel left >> cancel right)
+
+  -- Our MonadSTM does not cover orElse, so these all use low level versions
+  waitAnySTM []     = retry
+  waitAnySTM (a:as) = do
+    mr <- pollSTM a
+    case mr of
+      Nothing        -> waitAnySTM as
+      Just (Left  e) -> throwM e
+      Just (Right r) -> return (a, r)
+{-
+    foldr orElse retry $
+      map (\a -> do r <- waitSTM a; return (a, r)) asyncs
+-}
+
+  waitAnyCatchSTM []     = retry
+  waitAnyCatchSTM (a:as) = do
+    mr <- pollSTM a
+    case mr of
+      Nothing -> waitAnyCatchSTM as
+      Just r  -> return (a, r)
+{-
+    foldr orElse retry $
+      map (\a -> do r <- waitCatchSTM a; return (a, r)) asyncs
+-}
+
+  waitEitherSTM left right = do
+    ml <- pollSTM left
+    mr <- pollSTM right
+    case (ml, mr) of
+      (Just (Left  e), _) -> throwM e
+      (Just (Right l), _) -> return (Left l)
+      (_, Just (Left  e)) -> throwM e
+      (_, Just (Right r)) -> return (Right r)
+      (Nothing,  Nothing) -> retry
+{-
+    (Left  <$> waitSTM left)
+      `orElse`
+    (Right <$> waitSTM right)
+-}
+
+
+  waitEitherSTM_ left right = do
+    ml <- pollSTM left
+    mr <- pollSTM right
+    case (ml, mr) of
+      (Just (Left  e), _) -> throwM e
+      (Just (Right _), _) -> return ()
+      (_, Just (Left  e)) -> throwM e
+      (_, Just (Right _)) -> return ()
+      (Nothing,  Nothing) -> retry
+{-
+      (void $ waitSTM left)
+        `orElse`
+      (void $ waitSTM right)
+-}
+
+  waitEitherCatchSTM left right = do
+    ml <- pollSTM left
+    mr <- pollSTM right
+    case (ml, mr) of
+      (Just l,  _      ) -> return (Left l)
+      (_,       Just r ) -> return (Right r)
+      (Nothing, Nothing) -> retry
+{-
+      (Left  <$> waitCatchSTM left)
+        `orElse`
+      (Right <$> waitCatchSTM right)
+-}
+
+  waitBothSTM left right = do
+    ml <- pollSTM left
+    mr <- pollSTM right
+    case (ml, mr) of
+      (Just (Left  e), _)              -> throwM e
+      (_,              Just (Left  e)) -> throwM e
+      (Just (Right l), Just (Right r)) -> return (l, r)
+      (_,  _)                          -> retry
+{-
+      a <- waitSTM left
+             `orElse`
+           (waitSTM right >> retry)
+      b <- waitSTM right
+      return (a,b)
+-}
+
+  race            left right = withAsync left  $ \a ->
+                               withAsync right $ \b ->
+                                 waitEither a b
+
+  race_           left right = withAsync left  $ \a ->
+                               withAsync right $ \b ->
+                                 waitEither_ a b
+
+  concurrently    left right = withAsync left  $ \a ->
+                               withAsync right $ \b ->
+                                 waitBoth a b
+
+--
+-- Instance for IO uses the existing async library implementations
+--
+
+instance MonadAsync IO where
+
+  type Async IO = Async.Async
+
+  async                 = Async.async
+  withAsync             = Async.withAsync
+
+  wait                  = Async.wait
+  poll                  = Async.poll
+  waitCatch             = Async.waitCatch
+  cancel                = Async.cancel
+  uninterruptibleCancel = Async.uninterruptibleCancel
+
+  waitSTM               = Async.waitSTM
+  pollSTM               = Async.pollSTM
+  waitCatchSTM          = Async.waitCatchSTM
+
+  waitAny               = Async.waitAny
+  waitAnyCatch          = Async.waitAnyCatch
+  waitAnyCancel         = Async.waitAnyCancel
+  waitAnyCatchCancel    = Async.waitAnyCatchCancel
+  waitEither            = Async.waitEither
+  waitEitherCatch       = Async.waitEitherCatch
+  waitEitherCancel      = Async.waitEitherCancel
+  waitEitherCatchCancel = Async.waitEitherCatchCancel
+  waitEither_           = Async.waitEither_
+  waitBoth              = Async.waitBoth
+
+  waitAnySTM            = Async.waitAnySTM
+  waitAnyCatchSTM       = Async.waitAnyCatchSTM
+  waitEitherSTM         = Async.waitEitherSTM
+  waitEitherSTM_        = Async.waitEitherSTM_
+  waitEitherCatchSTM    = Async.waitEitherCatchSTM
+  waitBothSTM           = Async.waitBothSTM
+
+  race                  = Async.race
+  race_                 = Async.race_
+  concurrently          = Async.concurrently
+

--- a/io-sim-classes/src/Control/Monad/Class/MonadFork.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadFork.hs
@@ -1,11 +1,12 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE FlexibleContexts    #-}
+
 module Control.Monad.Class.MonadFork
   ( MonadFork (..)
   ) where
 
 import qualified Control.Concurrent as IO
-import           Control.Exception
-import           Control.Monad (void)
+import           Control.Exception (Exception(..), SomeException)
 import           Control.Monad.Except
 import           Control.Monad.Reader
 import           System.IO (hFlush, hPutStrLn, stderr)
@@ -15,10 +16,19 @@ forkPrintExceptionLock :: IO.MVar ()
 {-# NOINLINE forkPrintExceptionLock #-}
 forkPrintExceptionLock = unsafePerformIO $ IO.newMVar ()
 
-class Monad m => MonadFork m where
-  fork    :: m () -> m ()
+class (Monad m, Eq   (ThreadId m),
+                Ord  (ThreadId m),
+                Show (ThreadId m)) => MonadFork m where
+
+  type ThreadId m :: *
+
+  fork       :: m () -> m (ThreadId m)
+  myThreadId :: m (ThreadId m)
+  throwTo    :: Exception e => ThreadId m -> e -> m ()
+
 
 instance MonadFork IO where
+  type ThreadId IO = IO.ThreadId
   fork a =
     let handleException :: Either SomeException () -> IO ()
         handleException (Left e) = do
@@ -28,11 +38,21 @@ instance MonadFork IO where
                               ++ ": " ++ displayException e
               hFlush stderr
         handleException (Right x) = return x
-    in void (IO.forkFinally a handleException)
+    in IO.forkFinally a handleException
+
+  myThreadId = IO.myThreadId
+  throwTo    = IO.throwTo
 
 instance MonadFork m => MonadFork (ReaderT e m) where
+  type ThreadId (ReaderT e m) = ThreadId m
   fork (ReaderT f) = ReaderT $ \e -> fork (f e)
+  myThreadId  = lift myThreadId
+  throwTo e t = lift (throwTo e t)
 
 -- NOTE(adn): Is this a sensible instance?
 instance (Show e, MonadFork m) => MonadFork (ExceptT e m) where
+  type ThreadId (ExceptT e m) = ThreadId m
   fork (ExceptT m) = ExceptT $ Right <$> fork (either (error . show) id <$> m)
+  myThreadId  = lift myThreadId
+  throwTo e t = lift (throwTo e t)
+

--- a/io-sim-classes/src/Control/Monad/Class/MonadFork.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadFork.hs
@@ -7,7 +7,6 @@ module Control.Monad.Class.MonadFork
 
 import qualified Control.Concurrent as IO
 import           Control.Exception (Exception(..), SomeException)
-import           Control.Monad.Except
 import           Control.Monad.Reader
 import           System.IO (hFlush, hPutStrLn, stderr)
 import           System.IO.Unsafe (unsafePerformIO)
@@ -46,13 +45,6 @@ instance MonadFork IO where
 instance MonadFork m => MonadFork (ReaderT e m) where
   type ThreadId (ReaderT e m) = ThreadId m
   fork (ReaderT f) = ReaderT $ \e -> fork (f e)
-  myThreadId  = lift myThreadId
-  throwTo e t = lift (throwTo e t)
-
--- NOTE(adn): Is this a sensible instance?
-instance (Show e, MonadFork m) => MonadFork (ExceptT e m) where
-  type ThreadId (ExceptT e m) = ThreadId m
-  fork (ExceptT m) = ExceptT $ Right <$> fork (either (error . show) id <$> m)
   myThreadId  = lift myThreadId
   throwTo e t = lift (throwTo e t)
 

--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE TypeFamilyDependencies #-}
 module Control.Monad.Class.MonadSTM
   ( MonadSTM (..)
-  , MonadFork (..)
 
   -- * Default 'TMVar' implementation
   , TMVarDefault (..)
@@ -54,9 +53,8 @@ import           Control.Monad.Reader
 import           GHC.Stack
 import           Numeric.Natural (Natural)
 
-import           Control.Monad.Class.MonadFork
 
-class (MonadFork m, Monad (Tr m)) => MonadSTM m where
+class (Monad m, Monad (Tr m)) => MonadSTM m where
 
   -- STM transactions
   type Tr   m = (n :: * -> *) | n -> m

--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -192,21 +192,6 @@ instance (Show e, MonadSTM m) => MonadSTM (ExceptT e m) where
   isEmptyTBQueue   = lift . isEmptyTBQueue
   isFullTBQueue    = lift . isFullTBQueue
 
--- | Wrapper around 'BlockedIndefinitelyOnSTM' that stores a call stack
-data BlockedIndefinitely = BlockedIndefinitely {
-      blockedIndefinitelyCallStack :: CallStack
-    , blockedIndefinitelyException :: BlockedIndefinitelyOnSTM
-    }
-  deriving (Show)
-
-instance Exception BlockedIndefinitely where
-  displayException (BlockedIndefinitely cs e) = unlines [
-        displayException e
-      , prettyCallStack cs
-      ]
-
-wrapBlockedIndefinitely :: HasCallStack => IO a -> IO a
-wrapBlockedIndefinitely = handle (throwIO . BlockedIndefinitely callStack)
 
 --
 -- Instance for IO uses the existing STM library implementations
@@ -263,6 +248,24 @@ instance MonadSTM IO where
   writeTBQueue   = STM.writeTBQueue
   isEmptyTBQueue = STM.isEmptyTBQueue
   isFullTBQueue  = STM.isFullTBQueue
+
+
+-- | Wrapper around 'BlockedIndefinitelyOnSTM' that stores a call stack
+data BlockedIndefinitely = BlockedIndefinitely {
+      blockedIndefinitelyCallStack :: CallStack
+    , blockedIndefinitelyException :: BlockedIndefinitelyOnSTM
+    }
+  deriving (Show)
+
+instance Exception BlockedIndefinitely where
+  displayException (BlockedIndefinitely cs e) = unlines [
+        displayException e
+      , prettyCallStack cs
+      ]
+
+wrapBlockedIndefinitely :: HasCallStack => IO a -> IO a
+wrapBlockedIndefinitely = handle (throwIO . BlockedIndefinitely callStack)
+
 
 --
 -- Default TMVar implementation in terms of TVars (used by sim)

--- a/io-sim-classes/src/Control/Monad/Class/MonadThrow.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadThrow.hs
@@ -105,12 +105,12 @@ class MonadThrow m => MonadCatch m where
 --
 class MonadCatch m => MonadMask m where
 
-  {-# MINIMAL mask #-}
-  mask :: ((forall a. m a -> m a) -> m b) -> m b
+  {-# MINIMAL mask, uninterruptibleMask #-}
+  mask, uninterruptibleMask :: ((forall a. m a -> m a) -> m b) -> m b
 
-  mask_ :: m a -> m a
-  mask_ action = mask $ \_ -> action
-
+  mask_, uninterruptibleMask_ :: m a -> m a
+  mask_                action = mask                $ \_ -> action
+  uninterruptibleMask_ action = uninterruptibleMask $ \_ -> action
 
 --
 -- Instance for IO uses the existing base library implementations
@@ -142,4 +142,7 @@ instance MonadMask IO where
 
   mask  = IO.mask
   mask_ = IO.mask_
+
+  uninterruptibleMask  = IO.uninterruptibleMask
+  uninterruptibleMask_ = IO.uninterruptibleMask_
 

--- a/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE DefaultSignatures     #-}
+{-# LANGUAGE FlexibleContexts      #-}
+
 module Control.Monad.Class.MonadTimer (
     MonadTime(..)
   , MonadTimer(..)
@@ -19,7 +20,7 @@ import           Data.Word (Word64)
 import qualified GHC.Event as GHC (TimeoutKey, getSystemTimerManager,
                      registerTimeout, unregisterTimeout, updateTimeout)
 
-import           Control.Monad.Class.MonadFork (fork)
+import           Control.Monad.Class.MonadFork (MonadFork(..))
 import           Control.Monad.Class.MonadSTM
 
 
@@ -105,6 +106,8 @@ class (MonadSTM m, MonadTime m) => MonadTimer m where
   threadDelay d   = void . atomically . awaitTimeout =<< newTimeout d
 
   registerDelay :: Duration (Time m) -> m (TVar m Bool)
+
+  default registerDelay :: MonadFork m => Duration (Time m) -> m (TVar m Bool)
   registerDelay d = do
     v <- atomically $ newTVar False
     t <- newTimeout d

--- a/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
@@ -108,7 +108,7 @@ class (MonadSTM m, MonadTime m) => MonadTimer m where
   registerDelay d = do
     v <- atomically $ newTVar False
     t <- newTimeout d
-    fork $ atomically (awaitTimeout t >>= writeTVar v)
+    _ <- fork $ atomically (awaitTimeout t >>= writeTVar v)
     return v
 
 --

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -60,7 +60,7 @@ import qualified Control.Monad.Class.MonadFork as MonadFork
 import           Control.Monad.Class.MonadThrow as MonadThrow
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadSTM hiding (TVar, ThreadId)
+import           Control.Monad.Class.MonadSTM hiding (TVar)
 import qualified Control.Monad.Class.MonadSTM as MonadSTM
 import           Control.Monad.Class.MonadAsync hiding (Async)
 import qualified Control.Monad.Class.MonadAsync as MonadAsync

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -90,7 +90,7 @@ prop_stm_graph_sim g =
     -- that all other threads finished, but perhaps we should and structure
     -- the graph tests so that's the case.
 
-prop_stm_graph :: MonadSTM m => TestThreadGraph -> m ()
+prop_stm_graph :: (MonadFork m, MonadSTM m) => TestThreadGraph -> m ()
 prop_stm_graph (TestThreadGraph g) = do
     vars <- listArray (bounds g) <$>
             sequence [ atomically (newTVar False) | _ <- vertices g ]

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -591,8 +591,8 @@ unit_async_10 =
                       say "never 2"
           threadDelay 1
           yield
-          -- this one does not block, even though child 2 has exceptions
-          -- masked, since it is blocked in an interruptible throwTo
+          -- this one does not block, child 2 does not have exceptions
+          -- masked (and it is blocked in an interruptible throwTo)
           throwTo tid2 DivideByZero
           threadDelay 1
           say "parent done"
@@ -626,6 +626,8 @@ unit_async_11 =
                       say "never 2"
           threadDelay 1
           yield
+          -- this one does not block, even though child 2 has exceptions
+          -- masked, since it is blocked in an interruptible throwTo
           throwTo tid2 DivideByZero
           threadDelay 1
           say "parent done"

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
@@ -22,6 +22,7 @@ import           Control.Monad.State
 import           Control.Monad.Writer
 
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadFork
 
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Random
@@ -41,9 +42,9 @@ blockUntilChanged f b getA = do
       else return (a, b')
 
 -- | Spawn a new thread that executes an action each time a TVar changes
-onEachChange :: forall m a b. (MonadSTM m, Eq b)
+onEachChange :: forall m a b. (MonadSTM m, MonadFork m, Eq b)
              => (a -> b) -> b -> Tr m a -> (a -> m ()) -> m ()
-onEachChange f initB getA notify = fork $ go initB
+onEachChange f initB getA notify = void $ fork $ go initB
   where
     go :: b -> m ()
     go b = do

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
@@ -25,6 +25,7 @@ import           Data.Proxy
 import           Data.Type.Coercion
 
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadFork
 
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types
@@ -82,7 +83,10 @@ instance MonadTrans TrSimFS where
   lift = TrSimFS
 
 instance MonadFork m => MonadFork (SimFS m) where
+  type ThreadId (SimFS m) = ThreadId m
   fork (SimFS f) = SimFS $ ReaderT $ \e -> fork (runReaderT f e)
+  myThreadId     = lift myThreadId
+  throwTo tid e  = lift (throwTo tid e)
 
 instance (MonadFork (SimFS m) , MonadSTM m) => MonadSTM (SimFS m) where
   type Tr (SimFS m)      = TrSimFS (Tr m)

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -22,6 +22,7 @@ import           Test.QuickCheck
 
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim (runSimOrThrow)
 
@@ -51,6 +52,7 @@ prop_simple_protocol_convergence pInfo isValid numCoreNodes numSlots seed =
 -- Run protocol on the broadcast network, and check resulting chains on all nodes.
 test_simple_protocol_convergence :: forall m p.
                                     ( MonadSTM m
+                                    , MonadFork m
                                     , MonadSay m
                                     , MonadTimer m
                                     , DemoProtocolConstraints p

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -17,6 +17,7 @@ import qualified Data.Set as Set
 
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadTimer
 
 import           Protocol.Channel
@@ -46,6 +47,7 @@ import           Ouroboros.Consensus.Util.STM
 -- each node.
 broadcastNetwork :: forall m p.
                     ( MonadSTM   m
+                    , MonadFork  m
                     , MonadTimer m
                     , MonadSay   m
                     , DemoProtocolConstraints p

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
@@ -415,7 +415,7 @@ instance MonadTrans TrSimErrorFS where
 instance MonadUnliftIO m => MonadUnliftIO (SimErrorFS m) where
   withRunInIO = wrappedWithRunInIO SimErrorFS unSimErrorFS
 
-instance (MonadFork (SimErrorFS m) , MonadSTM m) => MonadSTM (SimErrorFS m) where
+instance (MonadSTM (SimErrorFS m) , MonadSTM m) => MonadSTM (SimErrorFS m) where
   type Tr (SimErrorFS m)      = TrSimErrorFS (Tr m)
   type TVar (SimErrorFS m)    = TVar m
   type TMVar (SimErrorFS m)   = TMVar m

--- a/ouroboros-network/src/Ouroboros/Network/Pipe.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Pipe.hs
@@ -12,6 +12,7 @@ module Ouroboros.Network.Pipe (
 import           Control.Concurrent.Async
 import           Control.Monad
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.ST (stToIO)
 import           Data.Bits
@@ -52,7 +53,7 @@ setupMux :: Mx.MiniProtocolDescriptions IO -> PipeCtx -> IO ()
 setupMux mpds ctx = do
     jobs <- Mx.muxJobs mpds (writePipe ctx) (readPipe ctx) (sduSize ctx)
     aids <- mapM async jobs
-    fork (watcher aids)
+    void $ fork (watcher aids)
 
   where
     watcher as = do
@@ -147,7 +148,7 @@ demo chain0 updates = do
     startPipe b_mps (hndRead1, hndWrite2)
     startPipe a_mps (hndRead2, hndWrite1)
 
-    fork $ sequence_
+    void $ fork $ sequence_
         [ do threadDelay 10000 -- just to provide interest
              atomically $ do
                  p <- readTVar producerVar

--- a/ouroboros-network/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Socket.hs
@@ -53,7 +53,7 @@ setupMux :: Mx.MiniProtocolDescriptions IO -> SocketCtx -> IO ()
 setupMux mpds ctx = do
     jobs <- Mx.muxJobs mpds (writeSocket ctx) (readSocket ctx) (sduSize ctx)
     aids <- mapM async jobs
-    fork (watcher aids)
+    void $ fork (watcher aids)
 
     return ()
   where
@@ -177,7 +177,7 @@ demo2 chain0 updates = do
 
     wd <- async $ clientWatchDog consumerVar
 
-    fork $ sequence_
+    void $ fork $ sequence_
         [ do threadDelay 10000 -- just to provide interest
              atomically $ do
                  p <- readTVar producerVar

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ChainSync.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ChainSync.hs
@@ -132,6 +132,7 @@ chainSyncDemo
   :: forall m.
      ( MonadST m
      , MonadSTM m
+     , MonadFork m
      )
   => Duplex m m Encoding ByteString
   -> Duplex m m Encoding ByteString
@@ -152,8 +153,8 @@ chainSyncDemo clientChan serverChan (ChainProducerStateForkTest cps chain) =
 
       codec = hoistCodec liftST codecChainSync
 
-  fork (void $ useCodecWithDuplex serverChan codec (chainSyncServerPeer server))
-  fork (void $ useCodecWithDuplex clientChan codec (chainSyncClientPeer client))
+  void $ fork (void $ useCodecWithDuplex serverChan codec (chainSyncServerPeer server))
+  void $ fork (void $ useCodecWithDuplex clientChan codec (chainSyncClientPeer client))
 
   atomically $ do
     done <- readTVar doneVar

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ReqResp.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ReqResp.hs
@@ -11,6 +11,7 @@ import System.Process (createPipe)
 import Codec.Serialise.Class (Serialise)
 import Codec.CBOR.Encoding (Encoding)
 
+import Control.Monad (void)
 import Control.Monad.Class.MonadFork
 import Control.Monad.Class.MonadST
 import Control.Monad.Class.MonadSTM
@@ -81,6 +82,7 @@ reqRespDemoExperiment
   :: forall m request response.
      ( MonadST m
      , MonadSTM m
+     , MonadFork m
      , Serialise request
      , Serialise response
      , Eq request
@@ -102,12 +104,12 @@ reqRespDemoExperiment clientChan serverChan request response =
       codec = hoistCodec liftST codecReqResp
 
   serverResultVar <- newEmptyTMVarM
-  fork $ do
+  void $ fork $ do
     result <- useCodecWithDuplex serverChan codec serverPeer
     atomically (putTMVar serverResultVar result)
 
   clientResultVar <- newEmptyTMVarM
-  fork $ do
+  void $ fork $ do
     result <- useCodecWithDuplex clientChan codec clientPeer
     atomically (putTMVar clientResultVar result)
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/Stream.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/Stream.hs
@@ -11,7 +11,9 @@ import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
+import           Control.Monad (void)
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadFork
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import Ouroboros.Network.Protocol.Stream.Client
@@ -56,7 +58,7 @@ readQueue queue = go []
 --
 test_direct
   :: forall m.
-     MonadSTM m
+     (MonadSTM m, MonadFork m)
   => Window
   -> (Int, Int)
   -> m Property
@@ -64,7 +66,7 @@ test_direct (Window window) range = do
     queue <- atomically $ newTBQueue window
     let client = streamClient queue range
     var <- atomically $ newTVar Nothing
-    fork $ do
+    void $ fork $ do
       res <- fst <$> direct listStreamServer client
       atomically $ writeTVar var (Just res)
     cliRes <- readQueue queue

--- a/typed-protocols/src/Network/TypedProtocol/PingPong/Tests.hs
+++ b/typed-protocols/src/Network/TypedProtocol/PingPong/Tests.hs
@@ -24,7 +24,9 @@ import Network.TypedProtocol.PingPong.Examples
 import Network.TypedProtocol.PingPong.Codec
 
 import Data.Functor.Identity (Identity (..))
+import Control.Monad (void)
 import Control.Monad.Class.MonadSTM
+import Control.Monad.Class.MonadFork
 import Control.Monad.IOSim
 
 import Data.List (inits, tails)
@@ -295,10 +297,10 @@ pipelineInterleaving omax cs0 reqs0 resps0 =
 
 -- | Run a non-pipelined client and server over a channel using a codec.
 --
-prop_channel :: MonadSTM m => NonNegative Int -> m Bool
+prop_channel :: (MonadSTM m, MonadFork m) => NonNegative Int -> m Bool
 prop_channel (NonNegative n) = do
     (clientChannel, serverChannel) <- createConnectedChannels
-    fork $ runPeer codec clientChannel client >> return ()
+    void $ fork $ runPeer codec clientChannel client >> return ()
     mn' <- runPeer codec serverChannel server
     case mn' of
       Left failure -> fail failure


### PR DESCRIPTION
Add async exceptions to the IO Sim. Also quite a few tests.

Add a `MonadAsync` class, covering main `async` package API, with `IO` and `SimM` instances.

Remove `MonadFork` as a superclass of `MonadSTM` and deal with the fallout (lots of little changes). The idea here is that we move over to using `MonadAsync` as our default, rather than getting `fork` everywhere via the `MonadFork` superclass.