### PR TITLE
Volatile db: simulated errors

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -292,6 +292,7 @@ test-suite test-storage
                     Test.Ouroboros.Storage.VolatileDB
                     Test.Ouroboros.Storage.VolatileDB.Model
                     Test.Ouroboros.Storage.VolatileDB.StateMachine
+                    Test.Ouroboros.Storage.VolatileDB.TestBlock
                     Test.Util.Orphans.Arbitrary
                     Test.Util.RefEnv
   build-depends:    base,

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
@@ -33,6 +33,7 @@ data VolatileDB blockId m = VolatileDB {
     , reOpenDB       :: HasCallStack => m ()
     , getBlock       :: HasCallStack => blockId -> m (Maybe ByteString)
     , putBlock       :: HasCallStack => blockId -> Builder -> m ()
+    , getBlockIds    :: HasCallStack => m [blockId]
     , garbageCollect :: HasCallStack => SlotNo -> m ()
     , getIsMember    :: HasCallStack => m (blockId -> Bool)
 }

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
@@ -301,7 +301,7 @@ garbageCollectImpl :: forall m blockId. (MonadCatch m, MonadSTM m, Ord blockId)
                    -> m ()
 garbageCollectImpl env@VolatileDBEnv{..} slot = do
     modifyState env $ \hasFS st -> do
-        st' <- foldM (tryCollectFile hasFS env slot) st (Map.toList (_currentMap st))
+        st' <- foldM (tryCollectFile hasFS env slot) st (sortOn (unsafeParseFd . fst) $ Map.toList (_currentMap st))
         let currentSlot' = if Map.size (_currentMap st') == 0 then Nothing else (_currentBlockId st')
         let st'' = st'{_currentBlockId = currentSlot'}
         return (st'', ())

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
@@ -21,7 +21,7 @@ import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
 
-type Fd = Int
+type FileId = Int
 
 -- For each file, we store the latest blockId, the number of blocks
 -- and a Map for its contents.

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
@@ -35,7 +35,6 @@ type ReverseIndex blockId = Map blockId (String, Int64, Int)
 data VolatileDBError blockId =
       FileSystemError FsError
     | VParserError (ParserError blockId)
-    | UndisputableLookupError String (Index blockId)
     | InvalidArgumentsError String
     | ClosedDBError
     deriving (Show)
@@ -50,7 +49,7 @@ data ParserError blockId =
       DuplicatedSlot (Map blockId ([String], [String]))
     | SlotsPerFileError Int String String
     | InvalidFilename String
-    | DecodeFailed String Int
+    | DecodeFailed (Int64, Map Int64 (Int, blockId)) String Int
     deriving (Show)
 
 instance Eq blockId => Eq (ParserError blockId) where
@@ -60,8 +59,6 @@ sameVolatileDBError :: Eq blockId => VolatileDBError blockId -> VolatileDBError 
 sameVolatileDBError e1 e2 = case (e1, e2) of
     (FileSystemError fs1, FileSystemError fs2) -> sameFsError fs1 fs2
     (VParserError p1, VParserError p2) -> p1 == p2
-    (UndisputableLookupError file1 mp1, UndisputableLookupError file2 mp2) ->
-        (file1,mp1) == (file2, mp2)
     (ClosedDBError, ClosedDBError) -> True
     (InvalidArgumentsError _, InvalidArgumentsError _) -> True
     _ -> False

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
@@ -31,6 +31,13 @@ type Index blockId = Map String (Maybe SlotNo, Int, Map Int64 (Int, blockId))
 -- in bytes.
 type ReverseIndex blockId = Map blockId (String, Int64, Int)
 
+-- Controls how the db behaves if it finds files with less blocks than expected.
+data BlocksPerFileMode =
+      Strict -- Will raise an exception, unless only the latest file has less blocks.
+    | LenientFillOldFirst -- Here anexception will not be raised and small files
+                          -- will be written first.
+    | LenientFillOnlyLast -- Only the last file can be written.
+
 -- | Errors which might arise when working with this database.
 data VolatileDBError blockId =
       FileSystemError FsError
@@ -47,7 +54,7 @@ instance (Show blockId, Typeable blockId) => Exception (VolatileDBError blockId)
 
 data ParserError blockId =
       DuplicatedSlot (Map blockId ([String], [String]))
-    | SlotsPerFileError Int String String
+    | SlotsPerFileError String
     | InvalidFilename String
     | DecodeFailed (Int64, Map Int64 (Int, blockId)) String Int
     deriving (Show)
@@ -57,20 +64,20 @@ instance Eq blockId => Eq (ParserError blockId) where
 
 sameVolatileDBError :: Eq blockId => VolatileDBError blockId -> VolatileDBError blockId -> Bool
 sameVolatileDBError e1 e2 = case (e1, e2) of
-    (FileSystemError fs1, FileSystemError fs2) -> sameFsError fs1 fs2
-    (VParserError p1, VParserError p2) -> p1 == p2
-    (ClosedDBError, ClosedDBError) -> True
+    (FileSystemError fs1, FileSystemError fs2)         -> sameFsError fs1 fs2
+    (VParserError p1, VParserError p2)                 -> p1 == p2
+    (ClosedDBError, ClosedDBError)                     -> True
     (InvalidArgumentsError _, InvalidArgumentsError _) -> True
-    _ -> False
+    _                                                  -> False
 
 -- TODO: Why is this not comparing the arguments to 'DuplicatedSlot'?
 sameParseError :: ParserError blockId -> ParserError blockId -> Bool
 sameParseError e1 e2 = case (e1, e2) of
-    (DuplicatedSlot _, DuplicatedSlot _)               -> True
-    (SlotsPerFileError _ _ _, SlotsPerFileError _ _ _) -> True
-    (InvalidFilename str1, InvalidFilename str2)       -> str1 == str2
-    (DecodeFailed _ _, DecodeFailed _ _)               -> True
-    _                                                  -> False
+    (DuplicatedSlot _, DuplicatedSlot _)         -> True
+    (SlotsPerFileError _, SlotsPerFileError _)   -> True
+    (InvalidFilename str1, InvalidFilename str2) -> str1 == str2
+    (DecodeFailed _ _ _ , DecodeFailed _ _ _)    -> True
+    _                                            -> False
 
 -- TODO(kde) unify/move/replace
 newtype Parser m blockId = Parser {

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -8,12 +8,12 @@ module Ouroboros.Storage.VolatileDB.Util where
 import           Control.Monad
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
-import           Data.Int (Int64)
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Set (Set)
 import qualified Data.Text as T
+import           Data.Word (Word64)
 import           Text.Read (readMaybe)
 
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
@@ -81,7 +81,7 @@ filePath fd = "blocks-" ++ show fd ++ ".dat"
   Comparing utilities
 ------------------------------------------------------------------------------}
 
-maxSlotMap :: Map Int64 (Int, blockId) -> (blockId -> Slot) -> Maybe (blockId, Slot)
+maxSlotMap :: Map Word64 (Word64, blockId) -> (blockId -> Slot) -> Maybe (blockId, Slot)
 maxSlotMap mp toSlot = maxSlotList toSlot $ snd <$> Map.elems mp
 
 maxSlotList :: (blockId -> Slot) -> [blockId] -> Maybe (blockId, Slot)

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -81,28 +81,28 @@ filePath fd = "blocks-" ++ show fd ++ ".dat"
   Comparing utilities
 ------------------------------------------------------------------------------}
 
-maxSlotMap :: Map Word64 (Word64, blockId) -> (blockId -> Slot) -> Maybe (blockId, Slot)
+maxSlotMap :: Map Word64 (Word64, blockId) -> (blockId -> SlotNo) -> Maybe (blockId, SlotNo)
 maxSlotMap mp toSlot = maxSlotList toSlot $ snd <$> Map.elems mp
 
-maxSlotList :: (blockId -> Slot) -> [blockId] -> Maybe (blockId, Slot)
+maxSlotList :: (blockId -> SlotNo) -> [blockId] -> Maybe (blockId, SlotNo)
 maxSlotList toSlot = updateSlot toSlot Nothing
 
 cmpMaybe :: Ord a => Maybe a -> a -> Bool
 cmpMaybe Nothing _   = False
 cmpMaybe (Just a) a' = a >= a'
 
-updateSlot :: forall blockId. (blockId -> Slot) -> Maybe blockId -> [blockId] -> Maybe (blockId, Slot)
+updateSlot :: forall blockId. (blockId -> SlotNo) -> Maybe blockId -> [blockId] -> Maybe (blockId, SlotNo)
 updateSlot toSlot mbid = foldl cmpr ((\b -> (b, toSlot b)) <$> mbid)
     where
-        cmpr :: Maybe (blockId, Slot) -> blockId -> Maybe (blockId, Slot)
+        cmpr :: Maybe (blockId, SlotNo) -> blockId -> Maybe (blockId, SlotNo)
         cmpr Nothing bid = Just (bid, toSlot bid)
         cmpr (Just (bid, sl)) bid' =
             let sl' = toSlot bid'
             in Just $ if sl > sl' then (bid, sl) else (bid', sl')
 
-updateSlotNoBlockId :: Maybe Slot -> [Slot] -> Maybe Slot
+updateSlotNoBlockId :: Maybe SlotNo -> [SlotNo] -> Maybe SlotNo
 updateSlotNoBlockId = foldl cmpr
     where
-        cmpr :: Maybe Slot -> Slot -> Maybe Slot
+        cmpr :: Maybe SlotNo -> SlotNo -> Maybe SlotNo
         cmpr Nothing sl'   = Just sl'
         cmpr (Just sl) sl' = Just $ max sl sl'

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -18,7 +18,7 @@ import           Ouroboros.Storage.VolatileDB.Types
 ------------------------------------------------------------------------------}
 
 
-parseFd :: String -> Maybe Fd
+parseFd :: String -> Maybe FileId
 parseFd = readMaybe
             . T.unpack
             . snd

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -1,11 +1,17 @@
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Ouroboros.Storage.VolatileDB.Util where
 
+import           Control.Monad
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
+import           Data.Int (Int64)
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Set (Set)
 import qualified Data.Text as T
 import           Text.Read (readMaybe)
 
@@ -46,3 +52,51 @@ modifyTMVar m action =
             ExitCaseException _ex        -> putTMVar m oldState
             ExitCaseAbort                -> putTMVar m oldState
        ) action
+
+-- Throws an error if one of the given file names does not parse.
+findLastFd :: forall blockId.
+              Set String
+           -> Either (VolatileDBError blockId) (Maybe FileId)
+findLastFd files = foldM go Nothing files
+    where
+        maxMaybe :: Ord a => Maybe a -> a -> a
+        maxMaybe ma a = case ma of
+            Nothing -> a
+            Just a' -> max a' a
+        go :: Maybe FileId -> String -> Either (VolatileDBError blockId) (Maybe FileId)
+        go fd file = case parseFd file of
+            Nothing -> Left $ VParserError $ InvalidFilename file
+            Just fd' -> Right $ Just $ maxMaybe fd fd'
+
+filePath :: FileId -> String
+filePath fd = "blocks-" ++ show fd ++ ".dat"
+
+{------------------------------------------------------------------------------
+  Comparing utilities
+------------------------------------------------------------------------------}
+
+maxSlotMap :: Map Int64 (Int, blockId) -> (blockId -> Slot) -> Maybe (blockId, Slot)
+maxSlotMap mp toSlot = maxSlotList toSlot $ snd <$> Map.elems mp
+
+maxSlotList :: (blockId -> Slot) -> [blockId] -> Maybe (blockId, Slot)
+maxSlotList toSlot = updateSlot toSlot Nothing
+
+cmpMaybe :: Ord a => Maybe a -> a -> Bool
+cmpMaybe Nothing _ = False
+cmpMaybe (Just a) a' = a >= a'
+
+updateSlot :: forall blockId. (blockId -> Slot) -> Maybe blockId -> [blockId] -> Maybe (blockId, Slot)
+updateSlot toSlot mbid = foldl cmpr ((\b -> (b, toSlot b)) <$> mbid)
+    where
+        cmpr :: Maybe (blockId, Slot) -> blockId -> Maybe (blockId, Slot)
+        cmpr Nothing bid = Just (bid, toSlot bid)
+        cmpr (Just (bid, sl)) bid' =
+            let sl' = toSlot bid'
+            in Just $ if sl > sl' then (bid, sl) else (bid', sl')
+
+updateSlotNoBlockId :: Maybe Slot -> [Slot] -> Maybe Slot
+updateSlotNoBlockId = foldl cmpr
+    where
+        cmpr :: Maybe Slot -> Slot -> Maybe Slot
+        cmpr Nothing sl' = Just sl'
+        cmpr (Just sl) sl' = Just $ max sl sl'

--- a/ouroboros-consensus/test-storage/Main.hs
+++ b/ouroboros-consensus/test-storage/Main.hs
@@ -5,9 +5,11 @@ import           System.IO.Temp
 import           Test.Tasty
 
 import qualified Test.Ouroboros.Storage
+import           Test.Ouroboros.Storage.VolatileDB.StateMachine hiding (tests)
 
 main :: IO ()
 main = do
+  showLabelledExamples
   sysTmpDir <- Dir.getTemporaryDirectory
   withTempDirectory sysTmpDir "cardano-s-m" $ \tmpDir ->
     defaultMain (tests tmpDir)

--- a/ouroboros-consensus/test-storage/Main.hs
+++ b/ouroboros-consensus/test-storage/Main.hs
@@ -5,11 +5,9 @@ import           System.IO.Temp
 import           Test.Tasty
 
 import qualified Test.Ouroboros.Storage
-import           Test.Ouroboros.Storage.VolatileDB.StateMachine hiding (tests)
 
 main :: IO ()
 main = do
-  showLabelledExamples
   sysTmpDir <- Dir.getTemporaryDirectory
   withTempDirectory sysTmpDir "cardano-s-m" $ \tmpDir ->
     defaultMain (tests tmpDir)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
@@ -300,7 +300,9 @@ parseImpl hasFS@HasFS{..} err path =
                 bs <- hGet hndl binarySize
                 if BS.length bs == 0 then return (n, mp)
                 else case decode bs of
-                    Left str -> EH.throwError err $ VParserError $ Volatile.DecodeFailed str (BS.length bs)
+                    Left str ->
+                        EH.throwError err $ VParserError $
+                            Volatile.DecodeFailed (n,mp) str (BS.length bs)
                     Right bl -> do
                         let bid = fromBlock bl
                         if elem bid bids

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
@@ -8,25 +8,19 @@ module Test.Ouroboros.Storage.Util where
 
 import           Control.Exception (Exception, SomeException)
 import qualified Control.Exception as E
-import           Control.Monad.Class.MonadThrow (MonadCatch, MonadThrow)
+import           Control.Monad.Class.MonadThrow (MonadCatch)
 import qualified Control.Monad.Class.MonadThrow as C
 
-import qualified Data.Binary as Binary
 import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BS
 import qualified Data.ByteString.Char8 as C8
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as LC8
-import           Data.Int (Int64)
-import qualified Data.Map.Strict as M
-import           Data.Serialize
 import           Data.String (IsString (..))
 import           Data.Typeable
 import           Data.Word (Word64)
 
 import           System.Directory (getTemporaryDirectory)
-import qualified System.IO as IO
 import           System.IO.Temp (withTempDirectory)
 
 import           Test.QuickCheck (ASCIIString (..), Arbitrary (..), Property,
@@ -35,7 +29,7 @@ import           Test.Tasty.HUnit
 
 import           Ouroboros.Consensus.Util (repeatedly)
 
-import           Ouroboros.Storage.FS.API (HasFS (..), withFile)
+import           Ouroboros.Storage.FS.API (HasFS (..))
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.FS.IO (ioHasFS)
 import           Ouroboros.Storage.FS.Sim.MockFS (MockFS)
@@ -46,7 +40,7 @@ import           Ouroboros.Storage.ImmutableDB (ImmutableDBError (..),
 import qualified Ouroboros.Storage.ImmutableDB as Immutable
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
-import           Ouroboros.Storage.VolatileDB (Parser (..), SlotNo (..),
+import           Ouroboros.Storage.VolatileDB (SlotNo (..),
                      VolatileDBError (..), sameVolatileDBError)
 import qualified Ouroboros.Storage.VolatileDB as Volatile
 
@@ -255,58 +249,3 @@ blobFromBS = MkBlob . BS.byteString
 
 instance IsString Blob where
     fromString = blobFromBS . C8.pack
-
-type MyBlockId = Word64
-
-type Block = (Word64, Int)
-
-toBinary :: MyBlockId -> BL.ByteString
-toBinary = Binary.encode . toBlock
-
-fromBinary :: BL.ByteString -> MyBlockId
-fromBinary = fromBlock . Binary.decode
-
-toSlot :: MyBlockId -> SlotNo
-toSlot = SlotNo
-
-toBlock :: MyBlockId -> Block
-toBlock bid = (bid, 0)
-
-fromBlock :: Block -> MyBlockId
-fromBlock (bid, 0) = bid
-fromBlock _        = error "wrong payload"
-
-binarySize :: Int
-binarySize = 16
-
-myParser :: (MonadThrow m) => Volatile.Parser m MyBlockId
-myParser = Volatile.Parser {
-    Volatile.parse = parseImpl
-    }
-
-parseImpl :: forall m h. (MonadThrow m)
-          => HasFS m h
-          -> ErrorHandling (VolatileDBError MyBlockId) m
-          -> [String]
-          -> m (Int64, M.Map Int64 (Int, MyBlockId))
-parseImpl hasFS@HasFS{..} err path =
-    withFile hasFS path IO.ReadMode $ \hndl -> do
-        let go :: M.Map Int64 (Int, MyBlockId)
-               -> Int64
-               -> Int
-               -> [MyBlockId]
-               -> m (Int64, M.Map Int64 (Int, MyBlockId))
-            go mp n trials bids = do
-                bs <- hGet hndl binarySize
-                if BS.length bs == 0 then return (n, mp)
-                else case decode bs of
-                    Left str ->
-                        EH.throwError err $ VParserError $
-                            Volatile.DecodeFailed (n,mp) str (BS.length bs)
-                    Right bl -> do
-                        let bid = fromBlock bl
-                        if elem bid bids
-                        then EH.throwError err $ Volatile.VParserError $ Volatile.DuplicatedSlot $ M.singleton bid (path, path)
-                        else let mp' = M.insert n (binarySize, bid) mp
-                            in go mp' (n + fromIntegral binarySize) (trials + 1) (bid : bids)
-        go M.empty 0 0 []

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
@@ -40,8 +40,8 @@ import           Ouroboros.Storage.ImmutableDB (ImmutableDBError (..),
 import qualified Ouroboros.Storage.ImmutableDB as Immutable
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
-import           Ouroboros.Storage.VolatileDB (SlotNo (..),
-                     VolatileDBError (..), sameVolatileDBError)
+import           Ouroboros.Storage.VolatileDB (VolatileDBError (..), 
+                     sameVolatileDBError)
 import qualified Ouroboros.Storage.VolatileDB as Volatile
 
 {------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB.hs
@@ -17,61 +17,42 @@ import           Control.Monad.Class.MonadThrow
 import qualified Data.Binary as Binary
 import qualified Data.ByteString.Builder as BL
 import qualified Data.ByteString.Lazy.Char8 as C8
-import           Data.List (nub)
-import qualified Data.Map.Strict as M
-import           Data.Maybe
+import           Data.Maybe (catMaybes)
 import           Data.Serialize
 import qualified Data.Set as Set
-import qualified System.IO as IO
 import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Ouroboros.Consensus.Util (SomePair (..))
-
 import           Ouroboros.Storage.FS.API
-import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import           Ouroboros.Storage.VolatileDB.API
-import           Ouroboros.Storage.VolatileDB.Impl (openDB)
+import           Ouroboros.Storage.VolatileDB.Impl
 import qualified Ouroboros.Storage.VolatileDB.Impl as Internal hiding (openDB)
 import           Test.Ouroboros.Storage.Util
 import qualified Test.Ouroboros.Storage.VolatileDB.StateMachine as StateMachine
 import           Test.Ouroboros.Storage.VolatileDB.TestBlock
-
-tests :: HasCallStack => TestTree
-tests = testGroup "VolatileDB"
-  [
-    testProperty "list parsing round trips" prop_roundTrips
-  , testProperty "put/get roundtrips" prop_VolatileRoundTrips
-  , testProperty "reOpen" prop_VolatileReOpenState
-  , testProperty "reOpen and Write" prop_VolatileReOpenWrite
-  , testProperty "garbage collect" prop_VolatileGarbageCollect
-  , testProperty "garbage collect state" $ prop_VolatileGarbageState LenientFillOnlyLast
-  , testProperty "remove empty file to Write" $ prop_VolatileReopenRemoveEmptyFile LenientFillOnlyLast
-  , testProperty "no slot returns Nothing" prop_VolatileNoSlot
-  , testProperty "duplicated slot" $ prop_VolatileDuplicatedSlot LenientFillOnlyLast
-  , testProperty "decode failed" $ prop_VolatileDecodeFail LenientFillOnlyLast
-  , testProperty "recovery from failed decode" $ prop_VolatileDecodeFailRecover LenientFillOnlyLast
-  , testProperty "Invalid argument" prop_VolatileInvalidArg
-  , testProperty "Invalid filename" $ prop_VolatileParseFileNameError LenientFillOnlyLast
-  , testProperty "lenient on number of blocks" $ prop_VolatileLessThanN LenientFillOnlyLast
-  , testProperty "first tries to fill files" prop_VolatileFillFilesFirst
-  , testProperty "can open with different number of blocks per file" prop_VolatileDifferentNumBlocks
-  , StateMachine.tests
-  ]
 
 withTestDB :: (HasCallStack, MonadSTM m, MonadMask m)
            => HasFS m h
            -> ErrorHandling (VolatileDBError BlockId) m
            -> Parser m BlockId
            -> Int
-           -> BlocksPerFileMode
            -> (VolatileDB BlockId m -> m a)
            -> m a
-withTestDB hasFS err parser n bpf = withDB (openDB hasFS err parser n toSlot True bpf)
+withTestDB hasFS err parser n = withDB (openDB hasFS err parser n toSlot)
+
+tests :: HasCallStack => TestTree
+tests = testGroup "VolatileDB"
+  [
+    testProperty "list parsing round trips" prop_roundTrips
+  , testProperty "Invalid argument" prop_VolatileInvalidArg
+  , testProperty "garbage collect" prop_VolatileGarbageCollect
+  , StateMachine.tests
+  ]
 
 prop_roundTrips :: HasCallStack => [BlockId] -> Property
 prop_roundTrips ls = property $ (binarySize * (length ls), ls) === (fromIntegral $ C8.length bs, ls')
@@ -85,47 +66,15 @@ prop_roundTrips ls = property $ (binarySize * (length ls), ls) === (fromIntegral
                     sl = fromBlock $ Binary.decode bs1
                 in sl : go bsRest
 
--- Write some blocks and then try to get them back.
-prop_VolatileRoundTrips :: HasCallStack => [BlockId] -> Property
-prop_VolatileRoundTrips ls = monadicIO $ do
-    let expected :: [Either String BlockId] = (Right <$> ls)
-    run $ apiEquivalenceVolDB (expectVolDBResult (@?= expected)) (\hasFS err ->
-        withTestDB hasFS err myParser 5 LenientFillOnlyLast $ \db -> do
-            putList db ls
-            bss <- forM ls $ \slot -> getBlock db slot
-            return $ (fmap fromBlock) <$> decode <$> catMaybes bss
+prop_VolatileInvalidArg :: HasCallStack => Property
+prop_VolatileInvalidArg = monadicIO $ do
+    let fExpected = \case
+            Left (InvalidArgumentsError _str) -> return ()
+            somethingElse -> fail $ "IO returned " <> show somethingElse <> " instead of InvalidArgumentsError"
+    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
+            _ <- Internal.openDBFull hasFS err (myParser hasFS err) 0 toSlot
+            return ()
         )
-
--- Check if the db works normaly after reopening.
-prop_VolatileReOpenWrite :: HasCallStack => [BlockId] -> [BlockId] -> Property
-prop_VolatileReOpenWrite ls1 ls2 = monadicIO $ do
-    let expected :: [Either String BlockId] = Right <$> (ls1 <> ls2)
-    run $ apiEquivalenceVolDB (expectVolDBResult (@?= expected)) (\hasFS err -> do
-                db <- openDB hasFS err myParser 5 toSlot True LenientFillOnlyLast
-                putList db ls1
-                closeDB db
-                reOpenDB db
-                putList db ls2
-                ret <- forM (ls1 <> ls2) $ \slot -> getBlock db slot
-                closeDB db
-                return $ (fmap fromBlock) <$> decode <$> catMaybes ret
-        )
-
--- Check state equality after reopening.
-prop_VolatileReOpenState :: HasCallStack => [BlockId] -> Property
-prop_VolatileReOpenState ls = monadicIO $ do
-        run $ apiEquivalenceVolDB (expectVolDBResult (@?= True)) (\hasFS err -> do
-            (db, env) <- Internal.openDBFull hasFS err myParser 5 toSlot True LenientFillOnlyLast
-            putList db ls
-            SomePair _stHasFS1 st1 <- Internal.getInternalState env
-            let mp1 :: (Index BlockId) = Internal._currentMap st1
-            closeDB db
-            reOpenDB db
-            SomePair _stHasFS2 st2 <- Internal.getInternalState env
-            let mp2 = Internal._currentMap st2
-            closeDB db
-            return $ mp1 == mp2
-            )
 
 -- Check if db succesfully garbage-collects.
 prop_VolatileGarbageCollect :: HasCallStack => BlockId -> [BlockId] -> [BlockId] -> Property
@@ -145,234 +94,17 @@ prop_VolatileGarbageCollect special ls1 ls2 = monadicIO $ do
     let ls'' = concat lss'
     let expected :: [Either String BlockId] = Right . fst <$> ls''
     run $ apiEquivalenceVolDB (expectVolDBResult (@?= expected)) (\hasFS err ->
-            withTestDB hasFS err myParser blocksPerFile LenientFillOnlyLast $ \db -> do
+            withTestDB hasFS err (myParser hasFS err) blocksPerFile $ \db -> do
                 forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
                 garbageCollect db (toSlot special)
                 mBss <- sequence <$> (forM ls' $ \(slot, _) -> EH.try err $ getBlock db slot)
                 case mBss of
-                    Left e -> throwError err e
+                    Left e -> EH.throwError err e
                     Right bss -> return $ (fmap fromBlock) <$> decode <$> catMaybes bss
         )
 
--- split at regular intervals
 chunk :: Int -> [a] -> [[a]]
 chunk _ [] = []
 chunk n xs = y1 : chunk n y2
     where
         (y1, y2) = splitAt n xs
-
--- Check if the db can close and reopen after garbage collection.
-prop_VolatileGarbageState :: HasCallStack => BlocksPerFileMode -> BlockId -> [BlockId] -> [BlockId] -> Property
-prop_VolatileGarbageState bpf special ls1 ls2 = withMaxSuccess 20 $ monadicIO $ do
-        let blocksPerFile = 5
-        let specialEnc = Binary.encode $ toBlock special
-        let set1 = Set.filter (/= special) $ Set.fromList ls1
-        let ls1' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> Set.toList set1
-        let set2 = Set.filter (\sl -> sl /= special && not (sl `Set.member` set1)) $ Set.fromList ls2
-        let ls2' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> Set.toList set2
-        let ls' = ls1' <> [(special, specialEnc)] <> ls2'
-        run $ apiEquivalenceVolDB  (expectVolDBResult (@?= True)) (\hasFS err -> do
-            (db, env) <- Internal.openDBFull hasFS err myParser blocksPerFile toSlot True bpf
-            forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
-            garbageCollect db (toSlot special)
-            SomePair _stHasFS1 st1 <- Internal.getInternalState env
-            closeDB db
-            reOpenDB db
-            SomePair _stHasFS2 st2 <- Internal.getInternalState env
-            closeDB db
-            return $ Internal.sameInternalState st1 st2
-            )
-
--- Try to reopen the db after deleting an empty write file.
-prop_VolatileReopenRemoveEmptyFile :: HasCallStack => BlocksPerFileMode -> [BlockId] -> Property
-prop_VolatileReopenRemoveEmptyFile bpf ls = monadicIO $ do
-    let blocksPerFile = 5
-    let ls' = nub ls
-    let len = length ls'
-    let ls'' = take (len - mod len blocksPerFile) ls'
-    run $ apiEquivalenceVolDB (expectVolDBResult (@?= (Just(Nothing, 0, M.empty), True))) (\hasFS err -> do
-            (db, env) <- Internal.openDBFull hasFS err myParser 5 toSlot True bpf
-            putList db ls''
-            SomePair _stHasFS1 st1 <- Internal.getInternalState env
-            closeDB db
-            let path = Internal._currentWritePath st1
-            let fileStats = M.lookup path (Internal._currentMap st1)
-            removeFile hasFS [path]
-            reOpenDB db
-            SomePair _stHasFS2 st2 <- Internal.getInternalState env
-            return (fileStats, Internal.sameInternalState st1 st2)
-        )
-
--- Trying to get a block that does not exist should return Nothing
-prop_VolatileNoSlot :: HasCallStack => [BlockId] -> BlockId -> Property
-prop_VolatileNoSlot ls special = monadicIO $ do
-        let ls' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> (filter (/= special) ls)
-        run $ apiEquivalenceVolDB (expectVolDBResult (@?= Nothing)) (\hasFS err ->
-            withTestDB hasFS err myParser 5 LenientFillOnlyLast $ \db -> do
-                forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
-                getBlock db special
-            )
-
--- Intentionally corrupt a file of the db, to check if we get DuplicatedSlot.
--- Trying to parse a file with duplicated blockId, should throw an error.
-prop_VolatileDuplicatedSlot :: HasCallStack => BlocksPerFileMode -> [BlockId] -> BlockId -> Property
-prop_VolatileDuplicatedSlot bpf ls special = mod (1 + length (nub ls)) 5 /= 0 ==> monadicIO $ do
-    let specialEnc = Binary.encode $ toBlock special
-    let fExpected = \case
-            Right (False, Left (VParserError (DuplicatedSlot _))) -> return ()
-            somethingElse -> fail $ "IO return " <> show somethingElse <> " instead of DuplicatedSlot"
-    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
-            (db, env) <- Internal.openDBFull hasFS err myParser 5 toSlot True bpf
-            putBlock db special (BL.lazyByteString specialEnc)
-            putList db ls
-            -- here we intentionally corrupt the fs, so that we can get the wanted error.
-            SomePair stHasFS st <- Internal.getInternalState env
-            let hndl = Internal._currentWriteHandle st
-            _ <- hPut stHasFS hndl (BL.lazyByteString specialEnc)
-            closeDB db
-            expectedErr <- EH.try err $ reOpenDB db
-            -- we also check if db closes in case of errors.
-            isOpen <- isOpenDB db
-            -- try to close, to make sure we clean-up, even if tests fail.
-            -- trying to close a closed db is a no-op.
-            closeDB db
-            return (isOpen, expectedErr)
-        )
-
--- Intentionally corrupt a file of the db, to check if we get DecodeFail.
-prop_VolatileDecodeFail :: HasCallStack => BlocksPerFileMode -> [BlockId] -> Property
-prop_VolatileDecodeFail bpf ls = monadicIO $ do
-    let fExpected = \case
-            Right (False, Left (VParserError (DecodeFailed _ _str n))) -> n @?= 3
-            somethingElse -> fail $ "IO returned " <> show somethingElse <> " instead of DecodeFailed"
-    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
-            (db, env) <- Internal.openDBFull hasFS err myParser 5 toSlot False bpf
-            putList db ls
-            -- here we intentionally corrupt the fs, so that we can get the wanted error.
-            SomePair stHasFS st <- Internal.getInternalState env
-            let hndl = Internal._currentWriteHandle st
-            _ <- hPut stHasFS hndl (BL.lazyByteString $ C8.pack "123")
-            closeDB db
-            expectedErr <- EH.try err $ reOpenDB db
-            -- we also check if db closes in case of errors.
-            isOpen <- isOpenDB db
-            closeDB db
-            return (isOpen, expectedErr)
-        )
-
--- Intentionally corrupt a file of the db, but the db is lenient and can recover.
-prop_VolatileDecodeFailRecover :: HasCallStack => BlocksPerFileMode -> [BlockId] -> Property
-prop_VolatileDecodeFailRecover bpf ls = monadicIO $ do
-    run $ apiEquivalenceVolDB (expectVolDBResult (@?= True)) (\hasFS err -> do
-            (db, env) <- Internal.openDBFull hasFS err myParser 5 toSlot True bpf
-            putList db ls
-            -- here we intentionally corrupt the fs, to see if it can recover.
-            SomePair _ st1 <- Internal.getInternalState env
-            let path = Internal._currentWritePath st1
-            closeDB db
-            _ <- withFile hasFS [path] IO.AppendMode $ \hndl -> do
-                hPut hasFS hndl (BL.lazyByteString $ C8.pack "123")
-            reOpenDB db
-            SomePair _ st2 <- Internal.getInternalState env
-            closeDB db
-            return (Internal._currentMap st1 == Internal._currentMap st2)
-        )
-
-prop_VolatileInvalidArg :: HasCallStack => Property
-prop_VolatileInvalidArg = monadicIO $ do
-    let fExpected = \case
-            Left (InvalidArgumentsError _str) -> return ()
-            somethingElse -> fail $ "IO returned " <> show somethingElse <> " instead of InvalidArgumentsError"
-    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
-            _ <- Internal.openDBFull hasFS err myParser 0 toSlot True LenientFillOnlyLast
-            return ()
-        )
-
--- Create a new file in the db folder with invalid name and check if we get
--- the expected error.
-prop_VolatileParseFileNameError :: BlocksPerFileMode -> HasCallStack => Property
-prop_VolatileParseFileNameError bpf = monadicIO $ do
-    let fExpected = \case
-            Right (False, Left (VParserError (InvalidFilename str))) -> str @?= "invalid-file-name"
-            somethingElse -> fail $ "IO failed with " <> show somethingElse <> " instead of InvalidFilename"
-    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
-            (db, _env) <- Internal.openDBFull hasFS err myParser 5 toSlot True bpf
-            closeDB db
-            withFile hasFS ["invalid-file-name"] IO.AppendMode $ \_hndl -> do
-                return ()
-            expectedErr <- EH.try err $ reOpenDB db
-            isOpen <- isOpenDB db
-            closeDB db
-            return (isOpen, expectedErr)
-        )
-
--- Intentiolly create a file with less blocks than needed and check if we can
--- succesfully reOpen db.
-prop_VolatileLessThanN :: HasCallStack => BlocksPerFileMode -> [BlockId] -> Property
-prop_VolatileLessThanN bpf ls = monadicIO $ do
-    let ls' = (\sl -> (sl, Binary.encode $ toBlock sl)) <$> nub ls
-    run $ apiEquivalenceVolDB (expectVolDBResult (@?=(True,Right ()))) (\hasFS err -> do
-            (db, env) <- Internal.openDBFull hasFS err myParser 5 toSlot True bpf
-            forM_ ls' $ \(slot, enc) -> putBlock db slot (BL.lazyByteString enc)
-            SomePair _stHasFS st <- Internal.getInternalState env
-            let nextFd = Internal._nextNewFileId st
-            let path = Internal.filePath nextFd
-            closeDB db
-            withFile hasFS [path] IO.AppendMode $ \_hndl -> do
-                return ()
-            expectedErr <- EH.try err $ reOpenDB db
-            isOpen <- isOpenDB db
-            closeDB db
-            return (isOpen, expectedErr)
-        )
-
-prop_VolatileFillFilesFirst :: HasCallStack => [BlockId] -> Property
-prop_VolatileFillFilesFirst ls = (length (nub ls)) > 3 ==> monadicIO $ do
-    let nubLs = nub ls
-    let (ls1, ls2) = splitAt (length nubLs - 3) $ nubLs
-    let fExpected = \case
-            Right (Just (Nothing, 0, mp), [], True, path, [(p,s)]) -> (p,s, mp) @?= (path,0, M.empty)
-            somethingelse -> fail $ "failed with " <> show somethingelse
-    run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
-            (db, env) <- Internal.openDBFull hasFS err myParser 3 toSlot True LenientFillOldFirst
-            putList db ls1
-            SomePair _ st1 <- Internal.getInternalState env
-            let nextFd = Internal._nextNewFileId st1
-            let path = Internal.filePath nextFd
-            closeDB db
-            withFile hasFS [path] IO.AppendMode $ \_hndl -> do
-                return ()
-            reOpenDB db
-            SomePair _ st2 <- Internal.getInternalState env
-            putList db ls2
-            SomePair _ st3 <- Internal.getInternalState env
-            let fileEntry = M.lookup path (Internal._currentMap st2)
-            let bl = Internal._nextNewFileId st2 == Internal._nextNewFileId st1 + 1
-            return (fileEntry, Internal._nextWriteFiles st3, bl, path, Internal._nextWriteFiles st2)
-        )
-
-prop_VolatileDifferentNumBlocks :: HasCallStack
-                                => [BlockId] -> [BlockId] -> [BlockId]
-                                -> Int -> Int -> Int
-                                -> Property
-prop_VolatileDifferentNumBlocks ls1 ls2 ls3 a b c =
-    a < 500 && b < 500 && c < 500 && a > 0 && b > 0 && c > 0
-    ==> monadicIO $ do
-    run $ apiEquivalenceVolDB (expectVolDBResult (@?=())) (\hasFS err -> do
-            (db1, _env) <- Internal.openDBFull hasFS err myParser a toSlot True LenientFillOldFirst
-            putList db1 ls1
-            closeDB db1
-            (db2, _env) <- Internal.openDBFull hasFS err myParser a toSlot True LenientFillOldFirst
-            putList db2 ls2
-            closeDB db2
-            (db3, _env) <- Internal.openDBFull hasFS err myParser a toSlot True LenientFillOldFirst
-            putList db3 ls3
-            closeDB db3
-        )
-
-putList :: Monad m
-        => VolatileDB BlockId m
-        -> [BlockId]
-        -> m ()
-putList db ls =
-    forM_ ls $ \bid -> putBlock db bid (BL.lazyByteString . Binary.encode . toBlock $ bid)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB.hs
@@ -39,7 +39,7 @@ import           Test.Ouroboros.Storage.VolatileDB.TestBlock
 withTestDB :: (HasCallStack, MonadSTM m, MonadMask m)
            => HasFS m h
            -> ErrorHandling (VolatileDBError BlockId) m
-           -> Parser m BlockId
+           -> Parser (ParserError BlockId) m BlockId
            -> Int
            -> (VolatileDB BlockId m -> m a)
            -> m a
@@ -77,6 +77,7 @@ prop_VolatileInvalidArg = monadicIO $ do
         )
 
 -- Check if db succesfully garbage-collects.
+-- This can't be replaces by q-s-m because it's a precondition/limitation.
 prop_VolatileGarbageCollect :: HasCallStack => BlockId -> [BlockId] -> [BlockId] -> Property
 prop_VolatileGarbageCollect special ls1 ls2 = monadicIO $ do
     let blocksPerFile = 5

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -1,53 +1,73 @@
-{-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE KindSignatures   #-}
-{-# LANGUAGE RankNTypes       #-}
-{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 -- | In-memory Model implementation of 'VolatileDB' for testing
 module Test.Ouroboros.Storage.VolatileDB.Model
     (
       DBModel (..)
     , initDBModel
     , openDBModel
+    , runCorruptionModel
     ) where
 
 import           Control.Monad.State (MonadState, get, put)
 import           Data.ByteString (ByteString)
 import           Data.ByteString.Builder
 import           Data.ByteString.Lazy (toStrict)
+import           Data.Either
+import           Data.List (sortOn, splitAt)
 import           Data.Map (Map)
 import qualified Data.Map as Map
+import           Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
 
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import           Ouroboros.Storage.VolatileDB.API
+import qualified Ouroboros.Storage.VolatileDB.Impl as Internal
+import           Ouroboros.Storage.VolatileDB.Util
+import           Test.Ouroboros.Storage.VolatileDB.TestBlock (Corruptions,
+                     FileCorruption (..), binarySize)
 
 data DBModel blockId = DBModel {
-      open           :: Bool
+      blocksPerFile  :: Int
+    , open           :: Bool
     , mp             :: Map blockId ByteString
     , latestGarbaged :: Maybe SlotNo
+    , index          :: Map String (Maybe Slot, Int, [blockId])
+    , currentFile    :: String
+    , nextFId        :: FileId
     } deriving (Show)
 
-initDBModel :: DBModel blockId
-initDBModel = DBModel {
-      open = True
-    , mp = Map.empty
+initDBModel ::Int -> DBModel blockId
+initDBModel bpf = DBModel {
+      blocksPerFile  = bpf
+    , open           = True
+    , mp             = Map.empty
     , latestGarbaged = Nothing
+    , index          = Map.singleton (Internal.filePath 0) newFileInfo
+    , currentFile    = Internal.filePath 0
+    , nextFId        = 1
 }
 
 openDBModel :: MonadState (DBModel blockId) m
             => (Ord blockId)
             => ErrorHandling (VolatileDBError blockId) m
+            -> Int
+            -> (blockId -> Slot)
             -> (DBModel blockId, VolatileDB blockId m)
-openDBModel err = (dbModel, db)
+openDBModel err maxNumPerFile toSlot = (dbModel, db)
     where
-        dbModel = initDBModel
-        db = VolatileDB {
+        dbModel = initDBModel maxNumPerFile
+        db =  VolatileDB {
               closeDB        = closeDBModel
             , isOpenDB       = isOpenModel
             , reOpenDB       = reOpenModel
             , getBlock       = getBlockModel err
-            , putBlock       = putBlockModel err
+            , putBlock       = putBlockModel err maxNumPerFile toSlot
             , garbageCollect = garbageCollectModel err
             , getIsMember    = getIsMemberModel err
         }
@@ -79,15 +99,34 @@ getBlockModel err sl = do
 putBlockModel :: MonadState (DBModel blockId) m
               => Ord blockId
               => ErrorHandling (VolatileDBError blockId) m
+              -> Int
+              -> (blockId -> Slot)
               -> blockId
               -> Builder
               -> m ()
-putBlockModel err sl bs = do
+putBlockModel err maxNumPerFile toSlot bid bs = do
     dbm@DBModel {..} <- get
     if not open then EH.throwError err ClosedDBError
-    else case Map.lookup sl mp of
-        Nothing -> put dbm{mp = Map.insert sl (toStrict $ toLazyByteString bs) mp}
+    else case Map.lookup bid mp of
         Just _bs -> return ()
+        Nothing -> do
+            let mp' = Map.insert bid (toStrict $ toLazyByteString bs) mp
+                (mbid, n, bids) = fromMaybe
+                    (error "current file does not exist in index")
+                    (Map.lookup currentFile index)
+                n' = n + 1
+                index' = Map.insert currentFile (updateSlotNoBlockId mbid [toSlot bid], n', bid:bids) index
+                (currentFile', index'', nextFId') =
+                    if n' == maxNumPerFile
+                    then ( Internal.filePath nextFId
+                         , Map.insertWith
+                            (\ _ _ -> (error $ "new file " <> currentFile' <> "already in index"))
+                            currentFile' newFileInfo index'
+                         , nextFId + 1)
+                    else ( currentFile
+                         , index'
+                         , nextFId)
+            put dbm {mp = mp', index = index'', currentFile = currentFile', nextFId = nextFId'}
 
 garbageCollectModel :: MonadState (DBModel blockId) m
                     => ErrorHandling (VolatileDBError blockId) m
@@ -96,7 +135,76 @@ garbageCollectModel :: MonadState (DBModel blockId) m
 garbageCollectModel err sl = do
     dbm@DBModel {..} <- get
     if not open then EH.throwError err ClosedDBError
-    else put dbm {latestGarbaged = Just $ maxMaybe latestGarbaged sl}
+    else do
+        let f :: String -> (Maybe Slot, Int, [blockId]) -> Maybe (Maybe Slot, Int, [blockId])
+            f path (msl,n,bids) = if cmpMaybe msl sl then Just (msl,n,bids)
+                             else if path == currentFile then Just (Nothing,0,[])
+                             else Nothing
+        let index' = Map.mapMaybeWithKey f index
+        put dbm {index = index', latestGarbaged = Just $ maxMaybe latestGarbaged sl}
+
+runCorruptionModel :: forall blockId m. MonadState (DBModel blockId) m
+                   => Ord blockId
+                   => (blockId -> Slot)
+                   -> Corruptions
+                   -> m ()
+runCorruptionModel toSlot corrs = do
+    dbm <- get
+    let dbm' = foldr corrupt dbm corrs
+    put $ recover dbm'
+        where
+            corrupt :: (FileCorruption, String) -> DBModel blockId -> DBModel blockId
+            corrupt (corr, file) dbm = case corr of
+                DeleteFile ->
+                    dbm { mp = mp', index = index'}
+                      where
+                        (_, _, bids) = fromMaybe
+                            (error "tried to corrupt a file which does not exist")
+                            (Map.lookup file (index dbm))
+                        mp' = Map.withoutKeys (mp dbm) (Set.fromList bids)
+                        index' = Map.delete file (index dbm)
+                DropLastBytes n ->
+                    -- this is how many bids we want to drop, not how many will actually be dropped.
+                    let dropBids = (div n (fromIntegral binarySize)) +
+                                   (if mod n (fromIntegral binarySize) == 0 then 0 else 1 )
+                        (_mmax, size, bids) = fromMaybe
+                            (error $ "tried to corrupt file " <> file <>  " which does not exist")
+                            (Map.lookup file (index dbm))
+                        -- we prepend on list of blockIds, so last bytes
+                        -- are actually at the head of the list.
+                        (droppedBids, newBids) = splitAt (fromIntegral dropBids) bids
+                        newMmax = snd <$> maxSlotList toSlot newBids
+                        index' = Map.insert file (newMmax, size - fromIntegral (length droppedBids), newBids) (index dbm)
+                        mp' = Map.withoutKeys (mp dbm) (Set.fromList droppedBids)
+                    in dbm {mp = mp', index = index'}
+                AppendBytes _ -> dbm
+                    -- Appending doesn't actually change anything, since additional bytes will be truncated.
+
+recover :: DBModel blockId -> DBModel blockId
+recover dbm@DBModel {..} = dbm{index = index', currentFile = cFile, nextFId = fid}
+  where
+    lastFd = fromRight (error "filename in index didn't parse" )
+                       (findLastFd $ Set.fromList $ Map.keys index)
+    ls = Map.toList index
+    lessThan = filter (\(_, (_, nBlocks, _)) -> nBlocks < blocksPerFile) ls
+    sorted = sortOn (unsafeParseFd . fst) lessThan
+    (cFile, fid, index') = case (sorted, lastFd) of
+        ([], Nothing) -> (Internal.filePath 0, 1, Map.fromList [(Internal.filePath 0, newFileInfo)])
+        (_, Nothing) -> error "invariant violated"
+        ([], Just lst) -> let fd' = lst + 1 in
+            (Internal.filePath fd', fd' + 1, Map.insert (Internal.filePath fd') newFileInfo index)
+        (_, Just lst) ->
+            let (file, (_msl, _n, _bids)) = last sorted
+            in if unsafeParseFd file == lst then (file, lst + 1, index)
+               else (Internal.filePath $ lst + 2, lst + 2, Map.insert (Internal.filePath $ lst + 1) newFileInfo index)
+
+unsafeParseFd :: String -> FileId
+unsafeParseFd file = fromMaybe
+    (error $ "could not parse filename " <> file <> " of index")
+    (parseFd file)
+
+newFileInfo :: (Maybe a, Int, [b])
+newFileInfo = (Nothing, 0, [])
 
 getIsMemberModel :: MonadState (DBModel blockId) m
                  => Ord blockId

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -108,7 +108,9 @@ reOpenModel :: MonadState (MyState blockId) m
             -> m ()
 reOpenModel err = do
     dbm <- getDB
-    dbm' <- recover err dbm
+    dbm' <- if not $ open dbm
+            then recover err dbm
+            else return dbm
     putDB dbm' {open = True}
 
 getBlockModel :: forall m blockId. (MonadState (MyState blockId) m, Ord blockId)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -322,7 +322,7 @@ prop_sequential =
     forAllCommands smUnused Nothing $ \cmds -> monadicIO $ do
         let test :: HasFS IO h -> PropertyM IO (History (At Cmd) (At Resp), Reason)
             test hasFS = do
-              db <- run $ openDB hasFS EH.monadCatch ["test-volatile"] myParser 7 toSlot
+              db <- run $ openDB hasFS EH.monadCatch myParser 7 toSlot
               let sm' = sm db dbm vdb
               (hist, _model, res) <- runCommands sm' cmds
               run $ closeDB db

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -19,9 +19,11 @@ module Test.Ouroboros.Storage.VolatileDB.StateMachine (tests) where
 
 import           Prelude hiding (elem)
 
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Except
 import           Control.Monad.State
-import           Data.Bifunctor (first)
+import           Data.Bifunctor (bimap)
 import qualified Data.Binary as Binary
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Builder as BS
@@ -41,9 +43,6 @@ import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadThrow
-
 import qualified Ouroboros.Consensus.Util.Classify as C
 import           Ouroboros.Storage.FS.API (HasFS (..))
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
@@ -52,6 +51,7 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import           Ouroboros.Storage.VolatileDB.API
 import           Ouroboros.Storage.VolatileDB.Impl (openDB)
 
+import           Test.Ouroboros.Storage.FS.Sim.Error
 import           Test.Ouroboros.Storage.Util
 import           Test.Ouroboros.Storage.VolatileDB.Model
 import           Test.Ouroboros.Storage.VolatileDB.TestBlock
@@ -67,7 +67,17 @@ data Success
   | Blob     (Maybe ByteString)
   | Bl       Bool
   | IsMember [Bool] -- We compare two functions based on their results on a list of inputs.
-  deriving (Eq, Show)
+  | SimulatedError (Either (VolatileDBError BlockId) Success)
+  deriving Show
+
+instance Eq Success where
+    Unit () == Unit () = True
+    Blob mbs == Blob mbs' = mbs == mbs'
+    Bl bl == Bl bl' = bl == bl'
+    IsMember ls == IsMember ls' = ls == ls'
+    SimulatedError _ == SimulatedError _ = True
+    _ == _ = False
+
 
 newtype Resp = Resp {getResp :: Either (VolatileDBError BlockId) Success}
     deriving (Eq, Show)
@@ -79,14 +89,24 @@ data Cmd
     | GetBlock BlockId
     | PutBlock BlockId
     | GarbageCollect BlockId
-    | AskIfMember [MyBlockId]
+    | AskIfMember [BlockId]
     | Corrupt Corruptions
     deriving (Show)
 
+data CmdErr = CmdErr
+    {
+      cmd :: Cmd
+    , err :: Maybe Errors
+    } deriving (Show)
+
 deriving instance Generic1          (At Cmd)
+deriving instance Generic1          (At CmdErr)
 deriving instance Rank2.Foldable    (At Cmd)
+deriving instance Rank2.Foldable    (At CmdErr)
 deriving instance Rank2.Functor     (At Cmd)
-deriving instance Rank2.Traversable (At Cmd)
+deriving instance Rank2.Functor     (At CmdErr)
+deriving instance Rank2.Traversable (At CmdErr)
+deriving instance Show1 r => Show   (CmdErr :@ r)
 deriving instance Show1 r => Show   (Cmd :@ r)
 
 deriving instance Generic1        (At Resp)
@@ -99,7 +119,11 @@ instance Show (Model r) where
 deriving instance Show (ModelShow r)
 deriving instance Generic (DBModel BlockId)
 deriving instance Generic (ModelShow r)
+deriving instance Generic SlotNo
 deriving instance ToExpr SlotNo
+deriving instance Generic BlockId
+deriving instance Generic (ParserError BlockId)
+deriving instance ToExpr (ParserError BlockId)
 deriving instance ToExpr (DBModel BlockId)
 deriving instance ToExpr (ModelShow r)
 
@@ -119,21 +143,28 @@ instance CommandNames (At Cmd) where
         Corrupt _        -> "Corrupt"
     cmdNames _ = ["not", "suported", "yet"]
 
+instance CommandNames (At CmdErr) where
+    cmdName (At (CmdErr cmd _)) = cmdName (At cmd)
+    cmdNames _ = ["not", "suported", "yet"]
+
+
 data Model (r :: Type -> Type) = Model
-  { dbModel :: DBModel BlockId
+  { dbModel   :: DBModel BlockId
     -- ^ A model of the database.
-  , mockDB  :: ModelDBPure
+  , mockDB    :: ModelDBPure
     -- ^ A handle to the mocked database.
+  , shouldEnd :: Bool
   } deriving (Generic)
 
 data ModelShow (r :: Type -> Type) = Model'
-  { msdbModel        :: DBModel BlockId
+  { msdbModel   :: DBModel BlockId
+  , msShouldEnd :: Bool
   }
 
 toShow :: Model r -> ModelShow r
-toShow (Model dbm _) = Model' dbm
+toShow (Model dbm _ se) = Model' dbm se
 
-type PureM = ExceptT (VolatileDBError BlockId) (State (DBModel BlockId))
+type PureM = ExceptT (VolatileDBError BlockId) (State (DBModel BlockId, Maybe Errors))
 type ModelDBPure = VolatileDB BlockId PureM
 
 -- | An event records the model before and after a command along with the
@@ -146,33 +177,45 @@ data Event r = Event
   } deriving (Show)
 
 lockstep :: forall r.
-            Model   r
-         -> At Cmd  r
-         -> At Resp r
-         -> Event   r
-lockstep model@Model {..} (At cmd) (At _resp) = Event
+            Model     r
+         -> At CmdErr r
+         -> At Resp   r
+         -> Event     r
+lockstep model@Model {..} cmdErr@(At (CmdErr cmd _)) (At resp) = Event
     { eventBefore   = model
     , eventCmd      = At cmd
     , eventAfter    = model'
     , eventMockResp = mockResp
     }
   where
-    (mockResp, dbModel') = step model (At cmd)
-    model' = model {dbModel = dbModel'}
+    (mockResp, dbModel') = step model cmdErr
+    model' = model {
+              dbModel = dbModel'
+            , shouldEnd = case resp of
+                    Resp (Left (VParserError (DecodeFailed _ _ _))) -> True
+                    _                                               -> False
+            }
 
 -- | Key property of the model is that we can go from real to mock responses
 toMock :: Model r -> At t r -> t
 toMock _ (At t) = t
 
-step :: Model r -> At Cmd r -> (Resp, DBModel BlockId)
-step model@Model{..} cmd = runPure dbModel mockDB (toMock model cmd)
+step :: Model r -> At CmdErr r -> (Resp, DBModel BlockId)
+step model@Model{..} cmderr = runPure dbModel mockDB (toMock model cmderr)
 
 runPure :: DBModel BlockId
         -> ModelDBPure
-        -> Cmd
+        -> CmdErr
         -> (Resp, DBModel BlockId)
-runPure dbm mdb cmd =
-    first Resp $ runState (runExceptT $ runDB runCorruptions mdb cmd) dbm
+runPure dbm mdb (CmdErr cmd err) =
+    bimap Resp fst $ flip runState (dbm, err) $ do
+        resp <- runExceptT $ runDB runCorruptions mdb cmd
+        case (err, resp) of
+            (Nothing, _)                       -> return resp
+            (Just _ , Left ClosedDBError)      -> return resp
+            (Just _, _) -> do
+                modify $ \(dbm, err) -> (dbm {open = False}, err)
+                return $ Right $ SimulatedError resp
     where
         runCorruptions :: ModelDBPure -> Corruptions -> PureM Success
         runCorruptions db cors = do
@@ -199,13 +242,18 @@ runDB runCorruptions db cmd = case cmd of
         return $ IsMember $ isMember <$> bids
 
 
-sm :: MonadCatch m => HasFS m h -> VolatileDB BlockId m -> DBModel BlockId -> ModelDBPure -> StateMachine Model (At Cmd) m (At Resp)
+sm :: MonadCatch m
+   => HasFS m h
+   -> VolatileDB BlockId m
+   -> DBModel BlockId
+   -> ModelDBPure
+   -> StateMachine Model (At CmdErr) m (At Resp)
 sm hasFS db dbm vdb = StateMachine {
         initModel     = initModelImpl dbm vdb
       , transition    = transitionImpl
       , precondition  = preconditionImpl
       , postcondition = postconditionImpl
-      , generator     = generatorImpl
+      , generator     = generatorImpl False
       , shrinker      = shrinkerImpl
       , semantics     = semanticsImpl hasFS db
       , mock          = mockImpl
@@ -213,17 +261,38 @@ sm hasFS db dbm vdb = StateMachine {
       , distribution  = Nothing
     }
 
+smErr :: (MonadCatch m, MonadSTM m)
+      => TVar m Errors
+      -> HasFS m h
+      -> VolatileDB BlockId m
+      -> DBModel BlockId
+      -> ModelDBPure
+      -> StateMachine Model (At CmdErr) m (At Resp)
+smErr errorsVar hasFS db dbm vdb = StateMachine {
+     initModel     = initModelImpl dbm vdb
+   , transition    = transitionImpl
+   , precondition  = preconditionImpl
+   , postcondition = postconditionImpl
+   , generator     = generatorImpl True
+   , shrinker      = shrinkerImpl
+   , semantics     = semanticsImplErr errorsVar hasFS db
+   , mock          = mockImpl
+   , invariant     = Nothing
+   , distribution  = Nothing
+ }
+
 initModelImpl :: DBModel BlockId -> ModelDBPure -> Model r
 initModelImpl dbm vdm = Model {
-      dbModel = dbm
-    , mockDB = vdm
+      dbModel   = dbm
+    , mockDB    = vdm
+    , shouldEnd = False
     }
 
-transitionImpl :: Model r -> At Cmd r -> At Resp r -> Model r
+transitionImpl :: Model r -> At CmdErr r -> At Resp r -> Model r
 transitionImpl model cmd = eventAfter . lockstep model cmd
 
-preconditionImpl :: Model Symbolic -> At Cmd Symbolic -> Logic
-preconditionImpl m@Model {..} (At cmd) =
+preconditionImpl :: Model Symbolic -> At CmdErr Symbolic -> Logic
+preconditionImpl m@Model {..} (At (CmdErr cmd _)) =
     Not (knownLimitation m (At cmd))
     .&& case cmd of
         Corrupt cors ->
@@ -232,29 +301,64 @@ preconditionImpl m@Model {..} (At cmd) =
   where
       corruptionFiles = map snd . NE.toList
 
-postconditionImpl :: Model Concrete -> At Cmd Concrete -> At Resp Concrete -> Logic
-postconditionImpl model cmd resp =
+postconditionImpl :: Model Concrete -> At CmdErr Concrete -> At Resp Concrete -> Logic
+postconditionImpl model cmdErr resp =
     toMock (eventAfter ev) resp .== eventMockResp ev
   where
-    ev = lockstep model cmd resp
+    ev = lockstep model cmdErr resp
 
-generatorImpl :: Model Symbolic -> Maybe (Gen (At Cmd Symbolic))
-generatorImpl Model {..} = Just $ At <$> do
-    sl <- arbitrary
+generatorCmdImpl :: Model Symbolic -> Maybe (Gen (At Cmd Symbolic))
+generatorCmdImpl m@Model {..} =
+    if shouldEnd then Nothing else Just $ do
+    sl <- blockIdgenerator m
     let lastGC = latestGarbaged dbModel
-    ls <- filter (newer lastGC . toSlot) <$> arbitrary
-    frequency
-        [ (3, return $ GetBlock sl)
-        , (3, return $ PutBlock sl)
-        , (1, return $ GarbageCollect sl)
-        , (1, return $ IsOpen)
-        , (1, return $ Close)
-        , (1, return $ ReOpen)
-        , (if null ls then 0 else 1, return $ AskIfMember ls)
-        , (if null dbFiles then 0 else 1, Corrupt <$> generateCorruptions (NE.fromList dbFiles))
+    let dbFiles :: [String] = getDBFiles dbModel
+    ls <- filter (newer lastGC . toSlot) <$> (listOf $ blockIdgenerator m)
+    cmd <- frequency
+        [ (15, return $ GetBlock sl)
+        , (15, return $ PutBlock sl)
+        , (5, return $ GarbageCollect sl)
+        , (5, return $ IsOpen)
+        , (5, return $ Close)
+        -- When the db is Closed, we try to ReOpen it asap.
+        -- This helps minimize TagClosedError and create more
+        -- interesting tests.
+        , (if open dbModel then 1 else 100, return $ ReOpen)
+        , (if null ls then 0 else 3, return $ AskIfMember ls)
+        , (if null dbFiles then 0 else 3, Corrupt <$> generateCorruptions (NE.fromList dbFiles))
         ]
-        where
-            dbFiles :: [String] = getDBFiles dbModel
+    return $ At cmd
+
+generatorImpl :: Bool -> Model Symbolic -> Maybe (Gen (At CmdErr Symbolic))
+generatorImpl mkErr m@Model {..} = do
+    genCmd <- generatorCmdImpl m
+    Just $ do
+        At cmd <- genCmd
+        err' <- if noErrorFor cmd then return Nothing
+           else frequency
+                [ (4, return Nothing)
+                , (if mkErr then 1 else 0, Just <$> arbitrary)]
+        let err = erasePutCorruptions err'
+        return $ At $ CmdErr cmd err
+    where
+        eraseCorruptions str = (\(fsErr, _) -> (fsErr, Nothing)) <$> str
+        erasePutCorruptions mErr = do
+            err <- mErr
+            return err {_hPut = eraseCorruptions $ _hPut err}
+        noErrorFor GetBlock {}       = False
+        noErrorFor ReOpen {}         = False
+        noErrorFor IsOpen {}         = False
+        noErrorFor Close {}          = False
+        noErrorFor AskIfMember {}    = False
+        noErrorFor GarbageCollect {} = True
+        noErrorFor PutBlock {}       = False
+        noErrorFor Corrupt {}        = True
+
+blockIdgenerator :: Model Symbolic -> Gen BlockId
+blockIdgenerator Model {..} = do
+    sl <- arbitrary
+    -- list must be non empty
+    elements $ sl : (M.keys $ mp dbModel)
 
 getDBFiles :: DBModel BlockId -> [String]
 getDBFiles DBModel {..} = M.keys index
@@ -263,11 +367,30 @@ newer :: Ord a => Maybe a -> a -> Bool
 newer Nothing _   = True
 newer (Just a) a' = a' >= a
 
-shrinkerImpl :: Model Symbolic -> At Cmd Symbolic -> [At Cmd Symbolic]
+shrinkerImpl :: Model Symbolic -> At CmdErr Symbolic -> [At CmdErr Symbolic]
 shrinkerImpl _ _ = []
 
-semanticsImpl :: MonadCatch m => HasFS m h -> VolatileDB BlockId m -> At Cmd Concrete -> m (At Resp Concrete)
-semanticsImpl hasFS m (At cmd) = At . Resp <$> tryVolDB (runDB (semanticsCorruption hasFS) m cmd)
+semanticsImpl :: MonadCatch m => HasFS m h -> VolatileDB BlockId m -> At CmdErr Concrete -> m (At Resp Concrete)
+semanticsImpl hasFS m (At (CmdErr cmd _)) = At . Resp <$> tryVolDB (runDB (semanticsCorruption hasFS) m cmd)
+
+semanticsImplErr :: (MonadCatch m, MonadSTM m)
+                 => TVar m Errors
+                 -> HasFS m h
+                 -> VolatileDB BlockId m
+                 -> At CmdErr Concrete
+                 -> m (At Resp Concrete)
+semanticsImplErr errorsVar hasFS m (At cmderr) = At . Resp <$> case cmderr of
+    CmdErr cmd Nothing ->
+        tryVolDB (runDB (semanticsCorruption hasFS) m cmd)
+    CmdErr cmd (Just errors) -> do
+        res <- withErrors errorsVar errors $
+            tryVolDB (runDB (semanticsCorruption hasFS) m cmd)
+        case res of
+            Left ClosedDBError -> return res
+            _                  -> do
+                closeDB m
+                -- return res
+                return $ Right $ SimulatedError res
 
 semanticsCorruption :: MonadCatch m
                     => HasFS m h
@@ -280,10 +403,10 @@ semanticsCorruption hasFS db corrs = do
     reOpenDB db
     return $ Unit ()
 
-mockImpl :: Model Symbolic -> At Cmd Symbolic -> GenSym (At Resp Symbolic)
-mockImpl model cmd = At <$> return mockResp
+mockImpl :: Model Symbolic -> At CmdErr Symbolic -> GenSym (At Resp Symbolic)
+mockImpl model cmdErr = At <$> return mockResp
     where
-        (mockResp, _dbModel') = step model cmd
+        (mockResp, _dbModel') = step model cmdErr
 
 knownLimitation :: Model Symbolic -> Cmd :@ Symbolic -> Logic
 knownLimitation model (At cmd) = case cmd of
@@ -300,11 +423,12 @@ knownLimitation model (At cmd) = case cmd of
         isLimitation Nothing _sl       = False
         isLimitation (Just slot') slot = slot' >  slot
 
-mkDBModel :: MonadState (DBModel BlockId) m
+mkDBModel :: MonadState (DBModel BlockId, Maybe Errors) m
           => Int
           -> (BlockId -> Slot)
+          -> Bool
           -> (DBModel BlockId, VolatileDB BlockId (ExceptT (VolatileDBError BlockId) m))
-mkDBModel n toSl = openDBModel EH.exceptT n toSl
+mkDBModel = openDBModel EH.exceptT
 
 -- | Predicate on events
 type EventPred = C.Predicate (Event Symbolic) Tag
@@ -324,16 +448,82 @@ successful f = C.predicate $ \ev -> case eventMockResp ev of
 -- Tagging works on symbolic events, so that we can tag without doing real IO.
 -- TODO(kde) This needs extending as part of #251
 tag :: [Event Symbolic] -> [Tag]
-tag = C.classify
-    [ tagGetBinaryBlobJust
-    ]
+tag [] = [TagEmpty]
+tag ls = C.classify
+    [ tagGetBinaryBlobNothing
+    , tagGetJust $ Left TagGetJust
+    , tagJustReOpenJust
+    , tagReOpenJust
+    , tagGarbageCollect Nothing False
+    , tagCorruptWriteFile
+    , tagAppendRecover
+    , tagIsClosedError
+    ] ls
   where
 
-    tagGetBinaryBlobJust :: EventPred
-    tagGetBinaryBlobJust = successful $ \ev r -> case r of
-        Blob (Just _) | GetBlock {} <- unAt $ eventCmd ev ->
-            Left TagGetBinaryBlobJust
-        _ -> Right tagGetBinaryBlobJust
+    tagGetBinaryBlobNothing :: EventPred
+    tagGetBinaryBlobNothing = successful $ \ev r -> case r of
+        Blob Nothing | GetBlock {} <- unAt $ eventCmd ev ->
+            Left TagGetNothing
+        _ -> Right tagGetBinaryBlobNothing
+
+    tagReOpenJust :: EventPred
+    tagReOpenJust = tagGetJust $ Right $ tagGetJust $ Left TagReOpenGet
+
+    tagJustReOpenJust :: EventPred
+    tagJustReOpenJust = tagGetJust $ Right $ reOpen $ Right $ tagGetJust $ Left TagGetReOpenGet
+
+    tagGarbageCollect :: Maybe BlockId -> Bool -> EventPred
+    tagGarbageCollect msl bl = C.predicate $ \ev -> case (msl, bl, eventMockResp ev, eventCmd ev) of
+        (Nothing, False, Resp (Right (Blob (Just _))), At (GetBlock bid))
+            -> Right $ tagGarbageCollect (Just bid) False
+        (Just bid, False, Resp (Right (Unit ())), At (GarbageCollect bid'))
+            -> Right $ tagGarbageCollect (Just bid) (toSlot bid < toSlot bid')
+        (Just bid, True, Resp (Right (Blob Nothing)), At (GetBlock bid'))
+            -> if bid == bid' then Left TagGarbageCollect
+                              else Right $ tagGarbageCollect msl bl
+        _ -> Right $ tagGarbageCollect msl bl
+
+    tagGetJust :: Either Tag EventPred -> EventPred
+    tagGetJust next = C.predicate $ \ev -> case eventMockResp ev of
+        Resp (Right (Blob (Just _))) -> next
+        _                            -> Right $ tagGetJust next
+
+    reOpen :: Either Tag EventPred -> EventPred
+    reOpen next = C.predicate $ \ev -> case (unAt $ eventCmd ev, eventMockResp ev) of
+        (ReOpen, Resp (Right (Unit ()))) -> next
+        _                                -> Right $ reOpen next
+
+    tagCorruptWriteFile :: EventPred
+    tagCorruptWriteFile = C.predicate $ \ev -> case unAt (eventCmd ev) of
+        Corrupt cors -> if any (\(cor,file) -> (cor == DeleteFile) && (file == (currentFile $ dbModel $ eventBefore ev))) (NE.toList cors)
+                        then Left TagCorruptWriteFile
+                        else Right tagCorruptWriteFile
+        _            -> Right tagCorruptWriteFile
+
+    tagAppendRecover :: EventPred
+    tagAppendRecover =
+        let
+            doesAppend (AppendBytes 0) = False
+            doesAppend (AppendBytes _) = True
+            doesAppend _               = False
+        in  C.predicate $ \ev -> case unAt (eventCmd ev) of
+            Corrupt cors -> if any (\(cor,_file) -> doesAppend cor) (NE.toList cors)
+                            then Left TagAppendRecover
+                            else Right tagAppendRecover
+            _            -> Right tagAppendRecover
+
+    tagIsClosedError :: EventPred
+    tagIsClosedError = C.predicate $ \ev -> case eventMockResp ev of
+        Resp (Left ClosedDBError) -> Left TagClosedError
+        _                         -> Right tagIsClosedError
+
+tagParser :: [Event Symbolic] -> String
+tagParser [] = "TagEmpty"
+tagParser ls = if shouldEnd (eventAfter (last ls))
+               then "TagParseErrorEnd"
+               else "TagNormalEnd"
+
 
 isMemberTrue :: [Event Symbolic] -> Int
 isMemberTrue events = sum $ count <$> events
@@ -353,13 +543,21 @@ isMemberTrue' events = sum $ f <$> events
             Resp (Right (IsMember ls)) -> if length (filter id ls) > 0 then 1 else 0
             Resp (Right _)             -> 0
 
-data Tag = TagGetBinaryBlobJust
+data Tag = TagGetJust
+         | TagGetNothing
+         | TagGetReOpenGet
+         | TagReOpenGet
+         | TagGarbageCollect
+         | TagCorruptWriteFile
+         | TagAppendRecover
+         | TagEmpty
+         | TagClosedError
          deriving Show
 
 prop_sequential :: Property
 prop_sequential =
     forAllCommands smUnused Nothing $ \cmds -> monadicIO $ do
-        let test :: HasFS IO h -> PropertyM IO (History (At Cmd) (At Resp), Reason)
+        let test :: HasFS IO h -> PropertyM IO (History (At CmdErr) (At Resp), Reason)
             test hasFS = do
               db <- run $ openDB hasFS EH.monadCatch myParser 7 toSlot True LenientFillOnlyLast
               let sm' = sm hasFS db dbm vdb
@@ -368,30 +566,81 @@ prop_sequential =
               return (hist, res)
         fsVar <- run $ atomically (newTVar Mock.empty)
         (hist, res) <- test (simHasFS EH.monadCatch fsVar)
+        let events = execCmds (initModel smUnused) cmds
+        let myshow n = if n<5 then show n else if n < 20 then "5-19" else if n < 100 then "20-99" else ">=100"
         prettyCommands smUnused hist
-            $ tabulate "Tags" (map show $ tag (execCmds (initModel smUnused) cmds))
-            $ tabulate "IsMember: Total number of True's" ([show $ isMemberTrue (execCmds (initModel smUnused) cmds)])
-            $ tabulate "IsMember: At least one True" ([show $ isMemberTrue' (execCmds (initModel smUnused) cmds)])
+            $ tabulate "Tags" (map show $ tag events)
+            $ tabulate "Commands" (cmdName . eventCmd <$> events)
+            $ tabulate "IsMember: Total number of True's" [myshow $ isMemberTrue events]
+            $ tabulate "IsMember: At least one True" [show $ isMemberTrue' events]
             $ res === Ok
     where
         -- we use that: MonadState (DBModel BlockId) (State (DBModel BlockId))
-        (dbm, vdb) = mkDBModel 7 toSlot
+        (dbm, vdb) = mkDBModel 7 toSlot True
         smUnused = sm (error "hasFS used during command generation") (error "semantics and DB used during command generation") dbm vdb
 
+prop_sequential_strict_parser :: Property
+prop_sequential_strict_parser =
+    forAllCommands smUnused Nothing $ \cmds -> monadicIO $ do
+        let test :: HasFS IO h
+                 -> PropertyM IO (History (At CmdErr) (At Resp), Reason)
+            test hasFS = do
+                db <- run $ openDB hasFS EH.monadCatch myParser 7 toSlot False LenientFillOnlyLast
+                let sm' = sm hasFS db dbm vdb
+                (hist, _model, res) <- runCommands sm' cmds
+                run $ closeDB db
+                return (hist, res)
+        fsVar <- run $ atomically (newTVar Mock.empty)
+        (hist, res) <- test (simHasFS EH.monadCatch fsVar)
+        let events = execCmds (initModel smUnused) cmds
+        prettyCommands smUnused hist
+            $ tabulate "Tags" [tagParser events]
+            $ res === Ok
+    where
+        -- we use that: MonadState (DBModel BlockId) (State (DBModel BlockId))
+        (dbm, vdb) = mkDBModel 7 toSlot False
+        smUnused = sm (error "hasFS used during command generation") (error "semantics and DB used during command generation") dbm vdb
+
+prop_sequential_errors :: Property
+prop_sequential_errors = withMaxSuccess 50000 $
+    forAllCommands smUnused Nothing $ \cmds -> monadicIO $ do
+        let test :: TVar IO Errors
+                 -> HasFS IO h
+                 -> PropertyM IO (History (At CmdErr) (At Resp), Reason)
+            test errorsVar hasFS = do
+              db <- run $ openDB hasFS EH.monadCatch myParser 7 toSlot True LenientFillOnlyLast
+              let sm' = smErr errorsVar hasFS db dbm vdb
+              (hist, _model, res) <- runCommands sm' cmds
+              run $ closeDB db
+              return (hist, res)
+        errorsVar <- run $ atomically (newTVar mempty)
+        fsVar <- run $ atomically (newTVar Mock.empty)
+        (hist, res) <- test errorsVar (mkSimErrorHasFS EH.monadCatch fsVar errorsVar)
+        let events = execCmds (initModel smUnused) cmds
+        prettyCommands smUnused hist
+            $ res === Ok
+    where
+        -- we use that: MonadState (DBModel BlockId) (State (DBModel BlockId))
+        (dbm, vdb) = mkDBModel 7 toSlot True
+        smUnused = smErr (error "errorsVar unused") (error "hasFS used during command generation") (error "semantics and DB used during command generation") dbm vdb
+
+
 execCmd :: Model Symbolic
-        -> Command (At Cmd) (At Resp)
+        -> Command (At CmdErr) (At Resp)
         -> Event Symbolic
 execCmd model (Command cmdErr resp _vars) = lockstep model cmdErr resp
 
-execCmds :: Model Symbolic -> Commands (At Cmd) (At Resp) -> [Event Symbolic]
+execCmds :: Model Symbolic -> Commands (At CmdErr) (At Resp) -> [Event Symbolic]
 execCmds model (Commands cs) = go model cs
     where
-        go :: Model Symbolic -> [Command (At Cmd) (At Resp)] -> [Event Symbolic]
+        go :: Model Symbolic -> [Command (At CmdErr) (At Resp)] -> [Event Symbolic]
         go _ []        = []
         go m (c : css) = let ev = execCmd m c in ev : go (eventAfter ev) css
 
 
 tests :: TestTree
 tests = testGroup "VolatileDB" [
-        testProperty "q-s-m" $ prop_sequential
+      testProperty "q-s-m" $ prop_sequential
+    , testProperty "q-s-m-Parser" $ prop_sequential_strict_parser
+    , testProperty "q-s-m-Errors" $ prop_sequential_errors
     ]

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -15,7 +15,10 @@
 {-# LANGUAGE TypeOperators       #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Ouroboros.Storage.VolatileDB.StateMachine (tests) where
+module Test.Ouroboros.Storage.VolatileDB.StateMachine
+    ( tests
+    , showLabelledExamples
+    ) where
 
 import           Prelude hiding (elem)
 
@@ -26,32 +29,39 @@ import           Control.Monad.State
 import           Data.Bifunctor (bimap)
 import qualified Data.Binary as Binary
 import           Data.ByteString (ByteString)
-import qualified Data.ByteString.Builder as BS
+import qualified Data.ByteString.Builder as BL
 import           Data.Functor.Classes
 import           Data.Kind (Type)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
+import           Data.Maybe (fromJust, isJust)
 import           Data.Set (Set)
 import qualified Data.Set as S
 import           Data.TreeDiff (ToExpr)
 import           Data.TreeDiff.Class
 import           GHC.Generics
 import           GHC.Stack
+import qualified System.IO as IO
+import           System.Random (getStdRandom, randomR)
 import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
+import           Test.QuickCheck.Random (mkQCGen)
 import           Test.StateMachine
+import           Test.StateMachine.Sequential
 import           Test.StateMachine.Types
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
+import           Text.Show.Pretty (ppShow)
 
+import           Ouroboros.Consensus.Util (SomePair (..))
 import qualified Ouroboros.Consensus.Util.Classify as C
+import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API (HasFS (..))
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
-import           Ouroboros.Storage.FS.Sim.STM
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import           Ouroboros.Storage.VolatileDB.API
-import           Ouroboros.Storage.VolatileDB.Impl (openDB)
+import qualified Ouroboros.Storage.VolatileDB.Impl as Internal hiding (openDB)
 
 import           Test.Ouroboros.Storage.FS.Sim.Error
 import           Test.Ouroboros.Storage.Util
@@ -93,13 +103,16 @@ data Cmd
     | GarbageCollect BlockId
     | AskIfMember [BlockId]
     | Corrupt Corruptions
-    deriving (Show)
+    | CreateFile
+    | CreateInvalidFile
+    | DuplicateBlock (String, BlockId)
+    deriving Show
 
 data CmdErr = CmdErr
     {
       cmd :: Cmd
     , err :: Maybe Errors
-    } deriving (Show)
+    } deriving Show
 
 deriving instance Generic1          (At Cmd)
 deriving instance Generic1          (At CmdErr)
@@ -135,14 +148,17 @@ instance ToExpr (Model r) where
 
 instance CommandNames (At Cmd) where
     cmdName (At cmd) = case cmd of
-        GetBlock _       -> "GetBlock"
-        PutBlock _       -> "PutBlock"
-        GarbageCollect _ -> "GarbageCollect"
-        IsOpen           -> "IsOpen"
-        Close            -> "Close"
-        ReOpen           -> "ReOpen"
-        AskIfMember _    -> "AskIfMember"
-        Corrupt _        -> "Corrupt"
+        GetBlock _        -> "GetBlock"
+        PutBlock _        -> "PutBlock"
+        GarbageCollect _  -> "GarbageCollect"
+        IsOpen            -> "IsOpen"
+        Close             -> "Close"
+        ReOpen            -> "ReOpen"
+        AskIfMember _     -> "AskIfMember"
+        Corrupt _         -> "Corrupt"
+        CreateFile        -> "CreateFile"
+        CreateInvalidFile -> "CreateInvalidFile"
+        DuplicateBlock _  -> "DuplicateBlock"
     cmdNames _ = ["not", "suported", "yet"]
 
 instance CommandNames (At CmdErr) where
@@ -194,8 +210,8 @@ lockstep model@Model {..} cmdErr (At resp) = Event
     model' = model {
               dbModel = dbModel'
             , shouldEnd = case resp of
-                    Resp (Left (VParserError (DecodeFailed _ _ _))) -> True
-                    _                                               -> False
+                    Resp (Left (VParserError _)) -> True
+                    _                            -> False
             }
 
 -- | Key property of the model is that we can go from real to mock responses
@@ -211,7 +227,7 @@ runPure :: DBModel BlockId
         -> (Resp, DBModel BlockId)
 runPure dbm mdb (CmdErr cmd err) =
     bimap Resp fst $ flip runState (dbm, err) $ do
-        resp <- runExceptT $ runDB runCorruptions mdb cmd
+        resp <- runExceptT $ runDB runRest mdb cmd
         case (err, resp) of
             (Nothing, _)                       -> return resp
             (Just _ , Left ClosedDBError)      -> return resp
@@ -219,68 +235,82 @@ runPure dbm mdb (CmdErr cmd err) =
                 modify $ \(dbm', cErr) -> (dbm' {open = False}, cErr)
                 return $ Right $ SimulatedError resp
     where
-        runCorruptions :: ModelDBPure -> Corruptions -> PureM Success
-        runCorruptions db cors = do
-            closeDB db
-            runCorruptionModel toSlot cors
-            reOpenDB db
-            return $ Unit ()
+        runRest :: ModelDBPure -> Cmd -> PureM Success
+        runRest db cmd' = case cmd' of
+            Corrupt cors -> do
+                closeDB db
+                runCorruptionModel toSlot cors
+                reOpenDB db
+                return $ Unit ()
+            CreateFile -> do
+                closeDB db
+                createFileModel
+                reOpenDB db
+                return $ Unit ()
+            CreateInvalidFile -> do
+                closeDB db
+                createInvalidFileModel "invalidFileName.dat"
+                reOpenDB db
+                return $ Unit ()
+            DuplicateBlock bid -> do
+                closeDB db
+                duplicateBlockModel bid
+                reOpenDB db
+                return $ Unit ()
+            _ -> error "invalid cmd"
 
 runDB :: (HasCallStack, Monad m)
-      => (VolatileDB BlockId m -> Corruptions -> m Success)
+      => (VolatileDB BlockId m -> Cmd -> m Success)
       -> VolatileDB BlockId m
       -> Cmd
       -> m Success
-runDB runCorruptions db cmd = case cmd of
+runDB restCmd db cmd = case cmd of
     GetBlock bid       -> Blob <$> getBlock db bid
-    PutBlock bid       -> Unit <$> putBlock db bid (BS.lazyByteString $ Binary.encode $ toBlock bid)
+    PutBlock bid       -> Unit <$> putBlock db bid (BL.lazyByteString $ Binary.encode $ toBlock bid)
     GarbageCollect bid -> Unit <$> garbageCollect db (toSlot bid)
     IsOpen             -> Bl <$> isOpenDB db
     Close              -> Unit <$> closeDB db
     ReOpen             -> Unit <$> reOpenDB db
-    Corrupt cors       -> runCorruptions db cors
+    Corrupt _          -> restCmd db cmd
+    CreateFile         -> restCmd db cmd
+    CreateInvalidFile  -> restCmd db cmd
+    DuplicateBlock _   -> restCmd db cmd
     AskIfMember bids   -> do
         isMember <- getIsMember db
         return $ IsMember $ isMember <$> bids
 
-sm :: MonadCatch m
-   => HasFS m h
-   -> VolatileDB BlockId m
-   -> DBModel BlockId
-   -> ModelDBPure
-   -> StateMachine Model (At CmdErr) m (At Resp)
-sm hasFS db dbm vdb = StateMachine {
-        initModel     = initModelImpl dbm vdb
-      , transition    = transitionImpl
-      , precondition  = preconditionImpl
-      , postcondition = postconditionImpl
-      , generator     = generatorImpl False
-      , shrinker      = shrinkerImpl
-      , semantics     = semanticsImpl hasFS db
-      , mock          = mockImpl
-      , invariant     = Nothing
-      , distribution  = Nothing
-    }
-
 smErr :: (MonadCatch m, MonadSTM m)
-      => TVar m Errors
+      => Bool
+      -> TVar m Errors
       -> HasFS m h
       -> VolatileDB BlockId m
+      -> Internal.VolatileDBEnv m blockId
       -> DBModel BlockId
       -> ModelDBPure
       -> StateMachine Model (At CmdErr) m (At Resp)
-smErr errorsVar hasFS db dbm vdb = StateMachine {
+smErr terminatingCmd errorsVar hasFS db env dbm vdb = StateMachine {
      initModel     = initModelImpl dbm vdb
    , transition    = transitionImpl
    , precondition  = preconditionImpl
    , postcondition = postconditionImpl
-   , generator     = generatorImpl True
+   , generator     = generatorImpl True terminatingCmd
    , shrinker      = shrinkerImpl
-   , semantics     = semanticsImplErr errorsVar hasFS db
+   , semantics     = semanticsImplErr errorsVar hasFS db env
    , mock          = mockImpl
    , invariant     = Nothing
    , distribution  = Nothing
  }
+
+stateMachine :: (MonadCatch m, MonadSTM m)
+             => DBModel BlockId
+             -> ModelDBPure
+             -> StateMachine Model (At CmdErr) m (At Resp)
+stateMachine = smErr
+                True
+                (error "errorsVar unused")
+                (error "hasFS used during command generation")
+                (error "semantics and DB used during command generation")
+                (error "env used during command generation")
 
 initModelImpl :: DBModel BlockId -> ModelDBPure -> Model r
 initModelImpl dbm vdm = Model {
@@ -309,53 +339,66 @@ postconditionImpl model cmdErr resp =
   where
     ev = lockstep model cmdErr resp
 
-generatorCmdImpl :: Model Symbolic -> Maybe (Gen (At Cmd Symbolic))
-generatorCmdImpl m@Model {..} =
+generatorCmdImpl :: Bool -> Model Symbolic -> Maybe (Gen (At Cmd Symbolic))
+generatorCmdImpl terminatingCmd m@Model {..} =
     if shouldEnd then Nothing else Just $ do
     sl <- blockIdgenerator m
     let lastGC = latestGarbaged dbModel
     let dbFiles :: [String] = getDBFiles dbModel
     ls <- filter (newer lastGC . toSlot) <$> (listOf $ blockIdgenerator m)
+    bid <- do
+        let bids = concat $ (\(f,(_, _, bs)) -> map (\b -> (f,b)) bs) <$> (M.toList $ index dbModel)
+        case bids of
+            [] -> return Nothing
+            _  -> Just <$> elements bids
     cmd <- frequency
-        [ (15, return $ GetBlock sl)
-        , (15, return $ PutBlock sl)
-        , (5, return $ GarbageCollect sl)
-        , (5, return $ IsOpen)
-        , (5, return $ Close)
+        [ (150, return $ GetBlock sl)
+        , (150, return $ PutBlock sl)
+        , (50, return $ GarbageCollect sl)
+        , (50, return $ IsOpen)
+        , (50, return $ Close)
+        , (30, return CreateFile)
         -- When the db is Closed, we try to ReOpen it asap.
         -- This helps minimize TagClosedError and create more
         -- interesting tests.
-        , (if open dbModel then 1 else 100, return $ ReOpen)
-        , (if null ls then 0 else 3, return $ AskIfMember ls)
-        , (if null dbFiles then 0 else 3, Corrupt <$> generateCorruptions (NE.fromList dbFiles))
+        , (if open dbModel then 10 else 1000, return $ ReOpen)
+        , (if null ls then 0 else 30, return $ AskIfMember ls)
+        , (if null dbFiles then 0 else 30, Corrupt <$> generateCorruptions (NE.fromList dbFiles))
+        , (if terminatingCmd then 1 else 0, return CreateInvalidFile)
+        , (if terminatingCmd && isJust bid then 1 else 0, return $ DuplicateBlock $ fromJust bid)
         ]
     return $ At cmd
 
-generatorImpl :: Bool -> Model Symbolic -> Maybe (Gen (At CmdErr Symbolic))
-generatorImpl mkErr m@Model {..} = do
-    genCmd <- generatorCmdImpl m
+generatorImpl :: Bool -> Bool -> Model Symbolic -> Maybe (Gen (At CmdErr Symbolic))
+generatorImpl mkErr terminatingCmd m@Model {..} = do
+    genCmd <- generatorCmdImpl terminatingCmd m
     Just $ do
         At cmd <- genCmd
         err' <- if noErrorFor cmd then return Nothing
            else frequency
-                [ (1, return Nothing)
+                [ (8, return Nothing)
                 , (if mkErr then 1 else 0, Just <$> arbitrary)]
         let err = erasePutCorruptions err'
         return $ At $ CmdErr cmd err
     where
+        -- This doesn't reduce the power of tests. This is because we have partial
+        -- writes as part of file Corruption and not as part of simulated errors.
         eraseCorruptions str = (\(fsErr, _) -> (fsErr, Nothing)) <$> str
         erasePutCorruptions mErr = do
             err <- mErr
             -- we don't use corruptions as part of simulated errors.
             return err {_hPut = eraseCorruptions $ _hPut err}
-        noErrorFor GetBlock {}       = False
-        noErrorFor ReOpen {}         = False
-        noErrorFor IsOpen {}         = False
-        noErrorFor Close {}          = False
-        noErrorFor AskIfMember {}    = False
-        noErrorFor GarbageCollect {} = False
-        noErrorFor PutBlock {}       = False
-        noErrorFor Corrupt {}        = True
+        noErrorFor GetBlock {}          = False
+        noErrorFor ReOpen {}            = False
+        noErrorFor IsOpen {}            = False
+        noErrorFor Close {}             = False
+        noErrorFor AskIfMember {}       = False
+        noErrorFor GarbageCollect {}    = False
+        noErrorFor PutBlock {}          = False
+        noErrorFor CreateInvalidFile {} = True
+        noErrorFor CreateFile {}        = True
+        noErrorFor Corrupt {}           = True
+        noErrorFor DuplicateBlock {}    = True
 
 blockIdgenerator :: Model Symbolic -> Gen BlockId
 blockIdgenerator Model {..} = do
@@ -373,38 +416,57 @@ newer (Just a) a' = a' >= a
 shrinkerImpl :: Model Symbolic -> At CmdErr Symbolic -> [At CmdErr Symbolic]
 shrinkerImpl _ _ = []
 
-semanticsImpl :: MonadCatch m => HasFS m h -> VolatileDB BlockId m -> At CmdErr Concrete -> m (At Resp Concrete)
-semanticsImpl hasFS m (At (CmdErr cmd _)) = At . Resp <$> tryVolDB (runDB (semanticsCorruption hasFS) m cmd)
-
 semanticsImplErr :: (MonadCatch m, MonadSTM m)
                  => TVar m Errors
                  -> HasFS m h
                  -> VolatileDB BlockId m
+                 -> Internal.VolatileDBEnv m blockId
                  -> At CmdErr Concrete
                  -> m (At Resp Concrete)
-semanticsImplErr errorsVar hasFS m (At cmderr) = At . Resp <$> case cmderr of
+semanticsImplErr errorsVar hasFS m env (At cmderr) = At . Resp <$> case cmderr of
     CmdErr cmd Nothing ->
-        tryVolDB (runDB (semanticsCorruption hasFS) m cmd)
+        tryVolDB (runDB (semanticsRestCmd hasFS env) m cmd)
     CmdErr cmd (Just errors) -> do
         res <- withErrors errorsVar errors $
-            tryVolDB (runDB (semanticsCorruption hasFS) m cmd)
+            tryVolDB (runDB (semanticsRestCmd hasFS env) m cmd)
         case res of
             Left ClosedDBError -> return res
             _                  -> do
                 closeDB m
-                -- return res
                 return $ Right $ SimulatedError res
 
-semanticsCorruption :: MonadCatch m
-                    => HasFS m h
-                    -> VolatileDB BlockId m
-                    -> Corruptions
-                    -> m Success
-semanticsCorruption hasFS db corrs = do
-    closeDB db
-    forM_ corrs $ \(corr,file) -> corruptFile hasFS corr file
-    reOpenDB db
-    return $ Unit ()
+semanticsRestCmd :: (MonadSTM m, MonadCatch m)
+                 => HasFS m h
+                 -> Internal.VolatileDBEnv m blockId
+                 -> VolatileDB BlockId m
+                 -> Cmd
+                 -> m Success
+semanticsRestCmd hasFS env db cmd = case cmd of
+    Corrupt corrs -> do
+        closeDB db
+        forM_ corrs $ \(corr,file) -> corruptFile hasFS corr file
+        reOpenDB db
+        return $ Unit ()
+    CreateFile -> do
+        createFileImpl hasFS env
+        closeDB db
+        reOpenDB db
+        return $ Unit ()
+    CreateInvalidFile -> do
+        closeDB db
+        withFile hasFS ["invalidFileName.dat"] IO.AppendMode $ \_hndl -> do
+            return ()
+        reOpenDB db
+        return $ Unit ()
+    DuplicateBlock (_file, bid) -> do
+        let specialEnc = Binary.encode $ toBlock bid
+        SomePair stHasFS st <- Internal.getInternalState env
+        let hndl = Internal._currentWriteHandle st
+        _ <- hPut stHasFS hndl (BL.lazyByteString specialEnc)
+        closeDB db
+        reOpenDB db
+        return $ Unit ()
+    _ -> error "invalid cmd"
 
 mockImpl :: Model Symbolic -> At CmdErr Symbolic -> GenSym (At Resp Symbolic)
 mockImpl model cmdErr = At <$> return mockResp
@@ -420,7 +482,10 @@ knownLimitation model (At cmd) = case cmd of
     Close              -> Bot
     ReOpen             -> Bot
     Corrupt _          -> Bot
+    CreateFile         -> Boolean $ not $ open $ dbModel model
     AskIfMember bids   -> exists ((\b -> isLimitation (latestGarbaged $ dbModel model) (toSlot b)) <$> bids) Boolean
+    CreateInvalidFile  -> Boolean $ not $ open $ dbModel model
+    DuplicateBlock _   -> Boolean $ not $ open $ dbModel model
     where
         isLimitation :: (Ord slot) => Maybe slot -> slot -> Bool
         isLimitation Nothing _sl       = False
@@ -429,56 +494,8 @@ knownLimitation model (At cmd) = case cmd of
 mkDBModel :: MonadState (DBModel BlockId, Maybe Errors) m
           => Int
           -> (BlockId -> Slot)
-          -> Bool
           -> (DBModel BlockId, VolatileDB BlockId (ExceptT (VolatileDBError BlockId) m))
 mkDBModel = openDBModel EH.exceptT
-
-prop_sequential :: Property
-prop_sequential =
-    forAllCommands smUnused Nothing $ \cmds -> monadicIO $ do
-        let test :: HasFS IO h -> PropertyM IO (History (At CmdErr) (At Resp), Reason)
-            test hasFS = do
-              db <- run $ openDB hasFS EH.monadCatch myParser 4 toSlot True LenientFillOnlyLast
-              let sm' = sm hasFS db dbm vdb
-              (hist, _model, res) <- runCommands sm' cmds
-              run $ closeDB db
-              return (hist, res)
-        fsVar <- run $ atomically (newTVar Mock.empty)
-        (hist, res) <- test (simHasFS EH.monadCatch fsVar)
-        let events = execCmds (initModel smUnused) cmds
-        let myshow n = if n<5 then show n else if n < 20 then "5-19" else if n < 100 then "20-99" else ">=100"
-        prettyCommands smUnused hist
-            $ tabulate "Tags" (map show $ tag events)
-            $ tabulate "Commands" (cmdName . eventCmd <$> events)
-            $ tabulate "IsMember: Total number of True's" [myshow $ isMemberTrue events]
-            $ tabulate "IsMember: At least one True" [show $ isMemberTrue' events]
-            $ res === Ok
-    where
-        -- we use that: MonadState (DBModel BlockId) (State (DBModel BlockId))
-        (dbm, vdb) = mkDBModel 4 toSlot True
-        smUnused = sm (error "hasFS used during command generation") (error "semantics and DB used during command generation") dbm vdb
-
-prop_sequential_strict_parser :: Property
-prop_sequential_strict_parser =
-    forAllCommands smUnused Nothing $ \cmds -> monadicIO $ do
-        let test :: HasFS IO h
-                 -> PropertyM IO (History (At CmdErr) (At Resp), Reason)
-            test hasFS = do
-                db <- run $ openDB hasFS EH.monadCatch myParser 3 toSlot False LenientFillOnlyLast
-                let sm' = sm hasFS db dbm vdb
-                (hist, _model, res) <- runCommands sm' cmds
-                run $ closeDB db
-                return (hist, res)
-        fsVar <- run $ atomically (newTVar Mock.empty)
-        (hist, res) <- test (simHasFS EH.monadCatch fsVar)
-        let events = execCmds (initModel smUnused) cmds
-        prettyCommands smUnused hist
-            $ tabulate "Tags" [tagParser events]
-            $ res === Ok
-    where
-        -- we use that: MonadState (DBModel BlockId) (State (DBModel BlockId))
-        (dbm, vdb) = mkDBModel 3 toSlot False
-        smUnused = sm (error "hasFS used during command generation") (error "semantics and DB used during command generation") dbm vdb
 
 prop_sequential_errors :: Property
 prop_sequential_errors =
@@ -487,8 +504,8 @@ prop_sequential_errors =
                  -> HasFS IO h
                  -> PropertyM IO (History (At CmdErr) (At Resp), Reason)
             test errorsVar hasFS = do
-              db <- run $ openDB hasFS EH.monadCatch myParser 3 toSlot True LenientFillOnlyLast
-              let sm' = smErr errorsVar hasFS db dbm vdb
+              (db, env) <- run $ Internal.openDBFull hasFS EH.monadCatch (myParser hasFS EH.monadCatch) 3 toSlot
+              let sm' = smErr True errorsVar hasFS db env dbm vdb
               (hist, _model, res) <- runCommands sm' cmds
               run $ closeDB db
               return (hist, res)
@@ -496,19 +513,25 @@ prop_sequential_errors =
         fsVar <- run $ atomically (newTVar Mock.empty)
         (hist, res) <- test errorsVar (mkSimErrorHasFS EH.monadCatch fsVar errorsVar)
         let events = execCmds (initModel smUnused) cmds
+        let myshow n = if n<5 then show n else if n < 20 then "5-19" else if n < 100 then "20-99" else ">=100"
         prettyCommands smUnused hist
-            $ tabulate "Simulated Errors" (tagSimulatedErrors events)
+            $ tabulate "Tags" (map show $ tag events)
+            $ tabulate "Commands" (cmdName . eventCmd <$> events)
+            $ tabulate "Error Tags" (map show $ tagSimulatedErrors events)
+            $ tabulate "IsMember: Total number of True's" [myshow $ isMemberTrue events]
+            $ tabulate "IsMember: At least one True" [show $ isMemberTrue' events]
+            $ tabulate "Ways it end" [tagParser events]
             $ res === Ok
     where
         -- we use that: MonadState (DBModel BlockId) (State (DBModel BlockId))
-        (dbm, vdb) = mkDBModel 3 toSlot True
-        smUnused = smErr (error "errorsVar unused") (error "hasFS used during command generation") (error "semantics and DB used during command generation") dbm vdb
+        (dbm, vdb) = mkDBModel 3 toSlot
+        smUnused = stateMachine
+                    dbm
+                    vdb
 
 tests :: TestTree
-tests = testGroup "VolatileDB" [
-      testProperty "q-s-m" $ prop_sequential
-    , testProperty "q-s-m-Parser" $ prop_sequential_strict_parser
-    , testProperty "q-s-m-Errors" $ prop_sequential_errors
+tests = testGroup "VolatileDB-q-s-m" [
+      testProperty "q-s-m-Errors" $ prop_sequential_errors
     ]
 
 {-------------------------------------------------------------------------------
@@ -524,9 +547,9 @@ successful :: (    Event Symbolic
                 -> Either Tag EventPred
               )
            -> EventPred
-successful f = C.predicate $ \ev -> case eventMockResp ev of
-    Resp (Left  _ ) -> Right $ successful f
-    Resp (Right ok) -> f ev ok
+successful f = C.predicate $ \ev -> case (eventMockResp ev, eventCmd ev) of
+    (Resp (Right ok), At (CmdErr _ Nothing)) -> f ev ok
+    _                                        -> Right $ successful f
 
 -- | Tag commands
 --
@@ -539,10 +562,12 @@ tag ls = C.classify
     , tagGetJust $ Left TagGetJust
     , tagGetReOpenGet
     , tagReOpenJust
-    , tagGarbageCollect S.empty Nothing
+    , tagGarbageCollect True S.empty Nothing
     , tagCorruptWriteFile
     , tagAppendRecover
     , tagIsClosedError
+    , tagGarbageCollectThenReOpen
+    , tagImpossibleToRecover
     ] ls
   where
 
@@ -560,15 +585,18 @@ tag ls = C.classify
 
     -- This rarely succeeds. I think this is because the last part (get -> Nothing) rarelly succeeds.
     -- This happens because when a blockId is deleted is very unlikely to be requested.
-    tagGarbageCollect :: Set BlockId -> Maybe BlockId -> EventPred
-    tagGarbageCollect bids mgced = successful $ \ev suc -> case (mgced, suc, getCmd ev) of
-        (Nothing, _, PutBlock bid)
-            -> Right $ tagGarbageCollect (S.insert bid bids) Nothing
-        (Nothing, _, GarbageCollect bid)
-            -> Right $ tagGarbageCollect bids (Just bid)
-        (Just _gced, Blob Nothing, GetBlock bid) | (S.member bid bids)
-            -> Left TagGarbageCollect
-        _ -> Right $ tagGarbageCollect bids mgced
+    tagGarbageCollect :: Bool -> Set BlockId -> Maybe BlockId -> EventPred
+    tagGarbageCollect keep bids mgced = successful $ \ev suc ->
+        if not keep then Right $ tagGarbageCollect keep bids mgced
+        else case (mgced, suc, getCmd ev) of
+            (Nothing, _, PutBlock bid)
+                -> Right $ tagGarbageCollect True (S.insert bid bids) Nothing
+            (Nothing, _, GarbageCollect bid)
+                -> Right $ tagGarbageCollect True bids (Just bid)
+            (Just _gced, Blob Nothing, GetBlock bid) | (S.member bid bids)
+                -> Left TagGarbageCollect
+            (_, _, Corrupt _) -> Right $ tagGarbageCollect False bids mgced
+            _ -> Right $ tagGarbageCollect True bids mgced
 
     tagGetJust :: Either Tag EventPred -> EventPred
     tagGetJust next = successful $ \_ev suc -> case suc of
@@ -605,12 +633,23 @@ tag ls = C.classify
         Resp (Left ClosedDBError) -> Left TagClosedError
         _                         -> Right tagIsClosedError
 
+    tagGarbageCollectThenReOpen :: EventPred
+    tagGarbageCollectThenReOpen = successful $ \ev _ -> case getCmd ev of
+        GarbageCollect _ -> Right $ tagReOpen False $ Left TagGarbageCollectThenReOpen
+        _                -> Right $ tagGarbageCollectThenReOpen
+
+    tagImpossibleToRecover :: EventPred
+    tagImpossibleToRecover = C.predicate $ \ev ->
+        if shouldEnd (eventBefore ev) || shouldEnd (eventAfter ev)
+            then Left TagImpossibleToRecover
+            else Right tagImpossibleToRecover
+
 getCmd :: Event r -> Cmd
 getCmd ev = cmd $ unAt (eventCmd ev)
 
 tagParser :: [Event Symbolic] -> String
 tagParser [] = "TagEmpty"
-tagParser ls = if shouldEnd (eventAfter (last ls))
+tagParser ls = if any (\e -> shouldEnd (eventBefore e) || shouldEnd (eventAfter e)) ls
                then "TagParseErrorEnd"
                else "TagNormalEnd"
 
@@ -664,6 +703,8 @@ data Tag =
     -- > PutBlock
     -- > GarbageColect
     -- > GetBlock (returns Nothing)
+    -- TODO(kde): This is actually a limitation, since we never
+    -- actually request gced blocks.
     | TagGarbageCollect
 
     -- | Try to delete the current active file.
@@ -679,8 +720,18 @@ data Tag =
     -- | A test with zero commands.
     | TagEmpty
 
-    -- | Returns ClosedDBError.
+    -- | Returns ClosedDBError (whatever Command)
     | TagClosedError
+
+    -- | Gc then Close then Open
+    --
+    -- > GarbageCollect
+    -- > CloseDB
+    -- > ReOpen
+    | TagGarbageCollectThenReOpen
+
+    -- | Command which irreversibly corrupt the db.
+    | TagImpossibleToRecover
     deriving Show
 
 tagSimulatedErrors :: [Event Symbolic] -> [String]
@@ -702,3 +753,31 @@ execCmds model (Commands cs) = go model cs
         go :: Model Symbolic -> [Command (At CmdErr) (At Resp)] -> [Event Symbolic]
         go _ []        = []
         go m (c : css) = let ev = execCmd m c in ev : go (eventAfter ev) css
+
+showLabelledExamples :: IO ()
+showLabelledExamples = showLabelledExamples' Nothing 1000
+
+showLabelledExamples' :: Maybe Int
+                      -- ^ Seed
+                      -> Int
+                      -- ^ Number of tests to run to find examples
+                      -> IO ()
+showLabelledExamples' mReplay numTests = do
+    replaySeed <- case mReplay of
+        Nothing   -> getStdRandom (randomR (1,999999))
+        Just seed -> return seed
+
+    labelledExamplesWith (stdArgs { replay     = Just (mkQCGen replaySeed, 0)
+                                  , maxSuccess = numTests
+                                  }) $
+        forAllShrinkShow (generateCommands smUnused Nothing)
+                         (shrinkCommands   smUnused)
+                         ppShow $ \cmds ->
+            collects (tag . execCmds (initModel smUnused) $ cmds) $
+                property True
+  where
+    (dbm, vdb) = mkDBModel 3 toSlot
+    smUnused :: StateMachine Model (At CmdErr) IO (At Resp)
+    smUnused = stateMachine
+                dbm
+                vdb

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -322,7 +322,7 @@ prop_sequential =
     forAllCommands smUnused Nothing $ \cmds -> monadicIO $ do
         let test :: HasFS IO h -> PropertyM IO (History (At Cmd) (At Resp), Reason)
             test hasFS = do
-              db <- run $ openDB hasFS EH.monadCatch myParser 7 toSlot
+              db <- run $ openDB hasFS EH.monadCatch myParser 7 toSlot True
               let sm' = sm db dbm vdb
               (hist, _model, res) <- runCommands sm' cmds
               run $ closeDB db

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/TestBlock.hs
@@ -7,12 +7,12 @@
 module Test.Ouroboros.Storage.VolatileDB.TestBlock where
 
 import           Control.Monad (forM)
+import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow (MonadThrow)
 import qualified Data.Binary as Binary
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Lazy as BL
-import           Data.Int (Int64)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
@@ -21,12 +21,15 @@ import           Data.Word (Word64)
 import qualified System.IO as IO
 import           Test.QuickCheck
 
-import           Ouroboros.Storage.FS.API (HasFS(..), withFile)
-import qualified Ouroboros.Storage.VolatileDB as Volatile
+import           Ouroboros.Consensus.Util (SomePair (..))
+import           Ouroboros.Storage.FS.API (HasFS (..), withFile)
+import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
-import           Ouroboros.Storage.VolatileDB (VolatileDBError(..),
-                     Parser(..), Slot(..))
+import           Ouroboros.Storage.VolatileDB (Parser (..), Slot (..),
+                     VolatileDBError (..))
+import qualified Ouroboros.Storage.VolatileDB as Volatile
+import qualified Ouroboros.Storage.VolatileDB.Impl as Internal hiding (openDB)
 
 type BlockId = Word
 
@@ -40,7 +43,7 @@ fromBinary bs = do
     block <- decode bs
     case block of
         (bid, 1 :: Int) -> Right bid
-        _ -> Left "wrong payload"
+        _               -> Left "wrong payload"
 
 toSlot :: BlockId -> Slot
 toSlot = Slot
@@ -55,34 +58,37 @@ fromBlock _        = error "wrong payload"
 binarySize :: Int
 binarySize = 16
 
-myParser :: (Monad m, MonadThrow m) => Volatile.Parser m BlockId
-myParser = Volatile.Parser {
-    Volatile.parse = parseImpl
+myParser :: (Monad m, MonadThrow m)
+         => HasFS m h
+         -> ErrorHandling (VolatileDBError BlockId) m
+         -> Volatile.Parser m BlockId
+myParser hasFs err = Volatile.Parser {
+    Volatile.parse = parseImpl hasFs err
     }
 
 parseImpl :: forall m h. (Monad m, MonadThrow m)
           => HasFS m h
           -> ErrorHandling (VolatileDBError BlockId) m
-          -> [String]
-          -> m (Int64, M.Map Int64 (Int, BlockId))
+          -> FsPath
+          -> m (Word64, M.Map Volatile.SlotOffset (Volatile.BlockSize, BlockId))
 parseImpl hasFS@HasFS{..} err path =
     withFile hasFS path IO.ReadMode $ \hndl -> do
-        let go :: M.Map Int64 (Int, BlockId)
-               -> Int64
+        let go :: M.Map Word64 (Word64, BlockId)
+               -> Word64
                -> Int
                -> [BlockId]
-               -> m (Int64, M.Map Int64 (Int, BlockId))
+               -> m (Word64, M.Map Word64 (Word64, BlockId))
             go mp n trials bids = do
                 bs <- hGet hndl binarySize
                 if BS.length bs == 0 then return (n, mp)
                 else case fromBinary bs of
                     Left str ->
                         EH.throwError err $ VParserError $
-                            Volatile.DecodeFailed (n,mp) str (BS.length bs)
+                            Volatile.DecodeFailed (n,mp) str (fromIntegral $ BS.length bs)
                     Right bid ->
                         if elem bid bids
                         then EH.throwError err $ Volatile.VParserError $ Volatile.DuplicatedSlot $ M.singleton bid (path, path)
-                        else let mp' = M.insert n (binarySize, bid) mp
+                        else let mp' = M.insert n (fromIntegral binarySize, bid) mp
                             in go mp' (n + fromIntegral binarySize) (trials + 1) (bid : bids)
         go M.empty 0 0 []
 
@@ -129,3 +135,16 @@ corruptFile hasFS@HasFS{..} corr file = case corr of
         let newFileSize = fileSize + (fromIntegral n)
         _ <- hPut hnd (BB.byteString $ BS.replicate n 0)
         return $ fileSize /= newFileSize
+
+
+createFileImpl :: (MonadSTM m, MonadThrow m)
+               => HasFS m h
+               -> Internal.VolatileDBEnv m blockId
+               -> m ()
+createFileImpl hasFS env = do
+    SomePair _stHasFS st <- Internal.getInternalState env
+    let nextFd = Internal._nextNewFileId st
+    let path = Internal.filePath nextFd
+    withFile hasFS [path] IO.AppendMode $ \_hndl -> do
+        return ()
+    return ()

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/TestBlock.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+-- | Block used for tests
+module Test.Ouroboros.Storage.VolatileDB.TestBlock where
+
+import           Control.Monad (forM)
+import           Control.Monad.Class.MonadThrow (MonadThrow)
+import qualified Data.Binary as Binary
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as BB
+import qualified Data.ByteString.Lazy as BL
+import           Data.Int (Int64)
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as M
+import           Data.Serialize
+import           Data.Word (Word64)
+import qualified System.IO as IO
+import           Test.QuickCheck
+
+import           Ouroboros.Storage.FS.API (HasFS(..), withFile)
+import qualified Ouroboros.Storage.VolatileDB as Volatile
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+import           Ouroboros.Storage.VolatileDB (VolatileDBError(..),
+                     Parser(..), Slot(..))
+
+type BlockId = Word
+
+type TestBlock = (Word, Int)
+
+toBinary :: BlockId -> BL.ByteString
+toBinary = Binary.encode . toBlock
+
+fromBinary :: BS.ByteString -> Either String BlockId
+fromBinary bs = do
+    block <- decode bs
+    case block of
+        (bid, 1 :: Int) -> Right bid
+        _ -> Left "wrong payload"
+
+toSlot :: BlockId -> Slot
+toSlot = Slot
+
+toBlock :: BlockId -> TestBlock
+toBlock bid = (bid, 1)
+
+fromBlock :: TestBlock -> BlockId
+fromBlock (bid, 1) = bid
+fromBlock _        = error "wrong payload"
+
+binarySize :: Int
+binarySize = 16
+
+myParser :: (Monad m, MonadThrow m) => Volatile.Parser m BlockId
+myParser = Volatile.Parser {
+    Volatile.parse = parseImpl
+    }
+
+parseImpl :: forall m h. (Monad m, MonadThrow m)
+          => HasFS m h
+          -> ErrorHandling (VolatileDBError BlockId) m
+          -> [String]
+          -> m (Int64, M.Map Int64 (Int, BlockId))
+parseImpl hasFS@HasFS{..} err path =
+    withFile hasFS path IO.ReadMode $ \hndl -> do
+        let go :: M.Map Int64 (Int, BlockId)
+               -> Int64
+               -> Int
+               -> [BlockId]
+               -> m (Int64, M.Map Int64 (Int, BlockId))
+            go mp n trials bids = do
+                bs <- hGet hndl binarySize
+                if BS.length bs == 0 then return (n, mp)
+                else case fromBinary bs of
+                    Left str ->
+                        EH.throwError err $ VParserError $
+                            Volatile.DecodeFailed (n,mp) str (BS.length bs)
+                    Right bid ->
+                        if elem bid bids
+                        then EH.throwError err $ Volatile.VParserError $ Volatile.DuplicatedSlot $ M.singleton bid (path, path)
+                        else let mp' = M.insert n (binarySize, bid) mp
+                            in go mp' (n + fromIntegral binarySize) (trials + 1) (bid : bids)
+        go M.empty 0 0 []
+
+
+{-------------------------------------------------------------------------------
+  Corruption
+-------------------------------------------------------------------------------}
+
+
+data FileCorruption
+    = DeleteFile
+    | DropLastBytes Word64
+    | AppendBytes Int
+    deriving (Show, Eq)
+
+instance Arbitrary FileCorruption where
+    arbitrary = frequency
+        [ (1, return DeleteFile)
+        , (1, DropLastBytes . getSmall . getPositive <$> arbitrary)
+        , (1, AppendBytes . getSmall . getPositive <$> arbitrary)
+        ]
+
+-- | Multiple corruptions
+type Corruptions = NonEmpty (FileCorruption, String)
+
+-- | The same file will not occur twice.
+generateCorruptions :: NonEmpty String -> Gen Corruptions
+generateCorruptions allFiles = sized $ \n -> do
+    subl  <- sublistOf (NE.toList allFiles) `suchThat` (not . null)
+    k     <- choose (1, 1 `max` n)
+    let files = NE.fromList $ take k subl
+    forM files $ \file -> (, file) <$> arbitrary
+
+corruptFile :: MonadThrow m => HasFS m h -> FileCorruption -> String -> m Bool
+corruptFile hasFS@HasFS{..} corr file = case corr of
+    DeleteFile -> removeFile [file] >> return True
+    DropLastBytes n -> withFile hasFS [file] IO.AppendMode $ \hnd -> do
+        fileSize <- hGetSize hnd
+        let newFileSize = if n >= fileSize then 0 else fileSize - n
+        hTruncate hnd newFileSize
+        return $ fileSize /= newFileSize
+    AppendBytes n -> withFile hasFS [file] IO.AppendMode $ \hnd -> do
+        fileSize <- hGetSize hnd
+        let newFileSize = fileSize + (fromIntegral n)
+        _ <- hPut hnd (BB.byteString $ BS.replicate n 0)
+        return $ fileSize /= newFileSize


### PR DESCRIPTION
This pr addresses remaining issues related to https://github.com/input-output-hk/ouroboros-network/issues/202. For q-s-m refactoring, I followed this blogpost http://www.well-typed.com/blog/2019/01/qsm-in-depth/

This pr:
- remove db Folder from the db environment and makes it opaque in the HasFs mountpoint. https://github.com/input-output-hk/ouroboros-network/pull/163
- improves the way the db handles parsing errors. https://github.com/input-output-hk/ouroboros-network/pull/163
- changes the way db handles files with less blocks than expected and corrupted files. https://github.com/input-output-hk/ouroboros-network/issues/273
- adds tests for corrupted files. https://github.com/input-output-hk/ouroboros-network/issues/273
- adds tests for simulated errors. https://github.com/input-output-hk/ouroboros-network/issues/273
- adds tests for parsers.
- adds tags and labeling. https://github.com/input-output-hk/ouroboros-network/issues/251
- adds getBlockIds api call

For Corruption testsI needed to extend the Model. Now the model is aware of what file has each block at any time. This is important so that it can predict what effect each corruption will have. 

For simulated errors I followed a different approach from ImmutableDB. At Immutable DB the Model does not actually know if the error will be actually thrown in the real Impl. To sync Model and Impl, the db is truncated when there is actually an error. For Volatile DB we use a different approach: the Model can predict if the error will be actually thrown and make only the actual changes until it is thrown. For example for gc it can predict that half the files will be deleted but then there will be a FsError. Or for putBlock it can see if hPut will actually succeed or fail.

Things that can be extended:
- The Model predicts what errors will actually beed thrown but not to great precision. It predicts only when it's necessary (eg only for writes). To make it work we don't actually compare the results when there can be a possible error. The prediction can be extended and be more detailed, so that we can check that Model and Impl throw exactly the same error.
- Tags for real error.
