### PR TITLE
openDB using a function for epoch sizes

### DIFF
--- a/byron-proxy/src/exec/Main.hs
+++ b/byron-proxy/src/exec/Main.hs
@@ -12,8 +12,6 @@ import Control.Monad (forM_, void, when)
 import Data.Functor.Contravariant (Op (..), contramap)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import Data.Map (Map)
-import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -305,16 +303,13 @@ main = withCompileInfo $ do
             { throwError = throwIO
             , catchError = catch
             }
-          epochSizes :: Map Epoch EpochSize
           -- FIXME the 'fromIntegral' casts from 'Word64' to 'Word'.
           -- For sufficiently high k, on certain machines, there could be an
           -- overflow.
-          -- FIXME need to be able to give a function `const epochSlots`.
-          -- 0 to 200 should be fine for now... I think.
-          --
           -- Add 1 to the slot count because we put EBBs at the end of every
           -- epoch.
-          epochSizes = Map.fromList (fmap (\i -> (i, fromIntegral (getSlotCount epochSlots) + 1)) [0..200])
+          epochSizes :: Epoch -> Maybe EpochSize
+          epochSizes = const $ Just (fromIntegral (getSlotCount epochSlots) + 1)
           openDB dbEpoch = DB.openDB
             fs
             errorHandling

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -93,7 +93,7 @@ withTestDB :: (HasCallStack, MonadSTM m, MonadMask m)
            -> (ImmutableDB m -> m a)
            -> m a
 withTestDB hasFS err epochSizes f =
-    withDB (openDB hasFS err ["test"] 0 epochSizes NoValidation) (\db _ -> f db)
+    withDB (openDB_ hasFS err ["test"] 0 epochSizes NoValidation) (\db _ -> f db)
 
 withSimTestDB :: Map Epoch EpochSize
               -> (ImmutableDB (SimFS IO) -> SimFS IO a)
@@ -236,7 +236,7 @@ prop_appendAndGetRoundtrip = monadicIO $ do
 
 test_demoSimEquivalence :: HasCallStack => Assertion
 test_demoSimEquivalence = apiEquivalenceImmDB (expectImmDBResult (@?= blobs)) $ \hasFS err ->
-    demoScript (openDB hasFS err ["test"])
+    demoScript (openDB_ hasFS err ["test"])
   where
     blobs = map Just ["haskell", "nice", "cardano", "test"]
 
@@ -311,14 +311,14 @@ test_reopenDBEquivalence =
 test_closeDBIdempotentEquivalence :: Assertion
 test_closeDBIdempotentEquivalence =
     apiEquivalenceImmDB (expectImmDBResult (@?= ())) $ \hasFS err -> do
-      db <- fst <$> openDB hasFS err ["test"] 0 (M.singleton 0 10) NoValidation
+      db <- fst <$> openDB_ hasFS err ["test"] 0 (M.singleton 0 10) NoValidation
       closeDB db
       closeDB db
 
 test_closeDBAppendBinaryBlobEquivalence :: Assertion
 test_closeDBAppendBinaryBlobEquivalence =
     apiEquivalenceImmDB (expectUserError isClosedDBError) $ \hasFS err -> do
-      db <- fst <$> openDB hasFS err ["test"] 0 (M.singleton 0 10) NoValidation
+      db <- fst <$> openDB_ hasFS err ["test"] 0 (M.singleton 0 10) NoValidation
       closeDB db
       appendBinaryBlob db 0 "foo"
   where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -1150,7 +1150,7 @@ prop_sequential :: Property
 prop_sequential = forAllCommands smUnused Nothing $ \cmds ->
     QCM.monadic (ioProperty . runSimIO) $ do
       (db, Nothing) <- QCM.run $
-        openDB hasFS EH.monadCatch dbFolder 0 (Map.singleton 0 firstEpochSize)
+        openDB_ hasFS EH.monadCatch dbFolder 0 (Map.singleton 0 firstEpochSize)
           NoValidation
       let sm' = sm hasFS db dbm mdb
       (hist, model, res) <- runCommands sm' cmds
@@ -1179,7 +1179,7 @@ prop_sequential_errors :: Property
 prop_sequential_errors = forAllCommands smUnused Nothing $ \cmds ->
     QCM.monadic (ioProperty . runSimErrorIO) $ do
       (db, Nothing) <- QCM.run $
-        openDB hasFS EH.monadCatch dbFolder 0 (Map.singleton 0 firstEpochSize)
+        openDB_ hasFS EH.monadCatch dbFolder 0 (Map.singleton 0 firstEpochSize)
           NoValidation
       let sm' = smErr hasFS db dbm mdb
       (hist, model, res) <- runCommands sm' cmds


### PR DESCRIPTION
corrects the Byron proxy, which previously would stop working after the
200th epoch.

This doesn't change anything about `ImmutableDB`, just gives a different
type for `openDB` and preserves the old one as `openDB_`.