### PR TITLE
Clean up the exception handling in the peer drivers

### DIFF
--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -23,6 +23,7 @@ import           Test.QuickCheck
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim (runSimOrThrow)
 
@@ -53,6 +54,7 @@ prop_simple_protocol_convergence pInfo isValid numCoreNodes numSlots seed =
 test_simple_protocol_convergence :: forall m p.
                                     ( MonadSTM m
                                     , MonadFork m
+                                    , MonadThrow m
                                     , MonadSay m
                                     , MonadTimer m
                                     , DemoProtocolConstraints p

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -18,6 +18,7 @@ import qualified Data.Set as Set
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTimer
 
 import           Ouroboros.Network.Channel
@@ -48,6 +49,7 @@ import           Ouroboros.Consensus.Util.STM
 broadcastNetwork :: forall m p.
                     ( MonadSTM   m
                     , MonadFork  m
+                    , MonadThrow m
                     , MonadTimer m
                     , MonadSay   m
                     , DemoProtocolConstraints p

--- a/ouroboros-network/src/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Node.hs
@@ -19,6 +19,7 @@ import           GHC.Generics (Generic)
 
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTimer
 
@@ -285,6 +286,7 @@ forkRelayKernel upstream cpsVar = do
 relayNode :: forall m block.
              ( MonadSTM m
              , MonadFork m
+             , MonadThrow m
              , MonadSay m
              , HasHeader block
              , Show block
@@ -398,6 +400,7 @@ forkCoreKernel slotDuration gchain fixupBlock cpsVar = do
 coreNode :: forall m.
         ( MonadSTM m
         , MonadFork m
+        , MonadThrow m
         , MonadTimer m
         , MonadSay m
         )

--- a/ouroboros-network/src/Ouroboros/Network/Pipe.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Pipe.hs
@@ -13,7 +13,6 @@ import           Control.Monad
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadTimer
-import           Control.Exception (Exception(..))
 import           Data.Bits
 import qualified Data.Map.Strict as M
 import           Data.Word
@@ -31,7 +30,6 @@ import           Ouroboros.Network.Protocol.ChainSync.Server
 import           Ouroboros.Network.Serialise
 
 import           Ouroboros.Network.Channel
-import           Ouroboros.Network.Codec
 import           Network.TypedProtocol.Driver
 
 import qualified Data.ByteString.Lazy as BL
@@ -154,18 +152,13 @@ demo chain0 updates = do
         , points = \_ -> pure $ consumerClient target consChain
         }
 
-    throwOnUnexpected :: String -> Either DeserialiseFailure t -> IO t
-    throwOnUnexpected str (Left err) = fail $ str ++ " " ++ displayException err
-    throwOnUnexpected _   (Right t)  = pure t
-
     consumerInit :: TMVar IO Bool -> Point block -> TVar IO (Chain block)
                  -> Channel IO BL.ByteString -> IO ()
     consumerInit done_ target consChain channel = do
        let consumerPeer = chainSyncClientPeer (chainSyncClientExample consChain
                                                (consumerClient target consChain))
 
-       r <- runPeer codecChainSync channel consumerPeer
-       throwOnUnexpected "consumer" r
+       runPeer codecChainSync channel consumerPeer
        atomically $ putTMVar done_ True
 
        return ()
@@ -178,6 +171,5 @@ demo chain0 updates = do
     producerRsp prodChain channel = do
         let producerPeer = chainSyncServerPeer (chainSyncServerExample () prodChain)
 
-        r <- runPeer codecChainSync channel producerPeer
-        throwOnUnexpected "producer" r
+        runPeer codecChainSync channel producerPeer
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
@@ -30,6 +30,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTimer
 import qualified Control.Monad.IOSim as Sim
 
@@ -115,6 +116,7 @@ prop_blockGenerator_IO (TestBlockChain chain) (Positive slotDuration) =
 
 coreToRelaySim :: ( MonadSTM m
                   , MonadFork m
+                  , MonadThrow m
                   , MonadTimer m
                   , MonadSay m
                   , MonadTimer m
@@ -190,6 +192,7 @@ prop_coreToRelay (TestNodeSim chain slotDuration coreTrDelay relayTrDelay) =
 -- Node graph: c → r → r
 coreToRelaySim2 :: ( MonadSTM m
                    , MonadFork m
+                   , MonadThrow m
                    , MonadTimer m
                    , MonadSay m
                    , MonadTimer m
@@ -286,6 +289,7 @@ instance Arbitrary TestNetworkGraph where
 networkGraphSim :: forall m.
                   ( MonadSTM m
                   , MonadFork m
+                  , MonadThrow m
                   , MonadTimer m
                   , MonadSay m
                   , MonadTimer m

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/BlockFetch.hs
@@ -10,7 +10,6 @@ import           Control.Monad.ST (runST)
 import           Data.ByteString.Lazy (ByteString)
 
 import           Control.Monad.IOSim (runSimOrThrow)
-import           Control.Monad.Fail
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM (MonadSTM)
 import           Control.Monad.Class.MonadAsync (MonadAsync)
@@ -261,11 +260,11 @@ prop_connect_pipelined5 (TestChainAndPoints chain points)
 
 -- | Run a simple block-fetch client and server using connected channels.
 --
-prop_channel :: (MonadAsync m, MonadCatch m, MonadST m, MonadFail m)
+prop_channel :: (MonadAsync m, MonadCatch m, MonadST m)
              => m (Channel m ByteString, Channel m ByteString)
              -> Chain Block -> [Point Block] -> m Property
 prop_channel createChannels chain points = do
-    Right (bodies, ()) <-
+    (bodies, ()) <-
       runConnectedPeers
         createChannels codecBlockFetch
         (blockFetchClientPeer (testClient chain points))

--- a/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ChainSync.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Protocol/ChainSync.hs
@@ -16,6 +16,7 @@ import Data.ByteString.Lazy (ByteString)
 import Control.Monad.Class.MonadFork
 import Control.Monad.Class.MonadST
 import Control.Monad.Class.MonadSTM
+import Control.Monad.Class.MonadThrow
 
 import Control.Monad.IOSim (runSimOrThrow)
 
@@ -212,6 +213,7 @@ chainSyncDemo
      ( MonadST m
      , MonadSTM m
      , MonadFork m
+     , MonadThrow m
      )
   => Channel m ByteString
   -> Channel m ByteString

--- a/typed-protocols/src/Network/TypedProtocol/Codec.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Codec.hs
@@ -17,6 +17,7 @@ module Network.TypedProtocol.Codec (
   , WeHaveAgency
   , TheyHaveAgency
   , SomeMessage(..)
+  , CodecFailure(..)
     -- ** Incremental decoding
   , DecodeStep(..)
   , runDecoder
@@ -29,6 +30,8 @@ module Network.TypedProtocol.Codec (
   , prop_codec_splitsM
   , prop_codec_splits
   ) where
+
+import           Control.Exception (Exception)
 
 import           Network.TypedProtocol.Core
                    ( Protocol(..), PeerRole(..)
@@ -163,6 +166,17 @@ data DecodeStep bytes failure m a =
 --
 data SomeMessage (st :: ps) where
      SomeMessage :: Message ps st st' -> SomeMessage st
+
+
+-- | Each 'Codec' can use whatever @failure@ type is appropriate. This simple
+-- exception type is provided for use by simple codecs (e.g. \"identity\") when
+-- nothing more than a 'String' is needed. It is an instance of 'Exception'.
+--
+data CodecFailure = CodecFailureOutOfInput
+                  | CodecFailure String
+  deriving (Eq, Show)
+
+instance Exception CodecFailure
 
 
 --

--- a/typed-protocols/src/Network/TypedProtocol/PingPong/Codec.hs
+++ b/typed-protocols/src/Network/TypedProtocol/PingPong/Codec.hs
@@ -30,8 +30,11 @@ codecPingPong =
           (ServerAgency TokBusy, "pong") -> DecodeDone (SomeMessage MsgPong) trailing
           (ClientAgency TokIdle, "ping") -> DecodeDone (SomeMessage MsgPing) trailing
           (ClientAgency TokIdle, "done") -> DecodeDone (SomeMessage MsgDone) trailing
-          _                              -> DecodeFail failure
-            where failure = CodecFailure ("unexpected message: " ++ str)
+
+          (ServerAgency _      , _     ) -> DecodeFail failure
+            where failure = CodecFailure ("unexpected server message: " ++ str)
+          (ClientAgency _      , _     ) -> DecodeFail failure
+            where failure = CodecFailure ("unexpected client message: " ++ str)
 
 
 decodeTerminatedFrame :: forall m a.

--- a/typed-protocols/src/Network/TypedProtocol/PingPong/Tests.hs
+++ b/typed-protocols/src/Network/TypedProtocol/PingPong/Tests.hs
@@ -24,7 +24,6 @@ import Network.TypedProtocol.PingPong.Examples
 import Network.TypedProtocol.PingPong.Codec
 
 import Data.Functor.Identity (Identity (..))
-import Control.Monad.Fail
 import Control.Monad.Class.MonadSTM
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadThrow
@@ -269,11 +268,11 @@ prop_connect_pipelined5 choices (Positive omax) (NonNegative n) =
 
 -- | Run a non-pipelined client and server over a channel using a codec.
 --
-prop_channel :: (MonadSTM m, MonadAsync m, MonadCatch m, MonadFail m)
+prop_channel :: (MonadSTM m, MonadAsync m, MonadCatch m)
              => NonNegative Int -> m Bool
 prop_channel (NonNegative n) = do
-    Right ((), n') <- runConnectedPeers createConnectedChannels
-                                        codecPingPong client server
+    ((), n') <- runConnectedPeers createConnectedChannels
+                                  codecPingPong client server
     return (n' == n)
   where
     client = pingPongClientPeer (pingPongClientCount n)

--- a/typed-protocols/src/Network/TypedProtocol/ReqResp/Codec.hs
+++ b/typed-protocols/src/Network/TypedProtocol/ReqResp/Codec.hs
@@ -15,7 +15,7 @@ import           Text.Read (readMaybe)
 codecReqResp
   :: forall req resp m.
      (Monad m, Show req, Show resp, Read req, Read resp)
-  => Codec (ReqResp req resp) String m String
+  => Codec (ReqResp req resp) CodecFailure m String
 codecReqResp =
     Codec{encode, decode}
   where
@@ -28,7 +28,7 @@ codecReqResp =
 
     decode :: forall (pr :: PeerRole) st.
               PeerHasAgency pr st
-           -> m (DecodeStep String String m (SomeMessage st))
+           -> m (DecodeStep String CodecFailure m (SomeMessage st))
     decode stok =
       decodeTerminatedFrame '\n' $ \str trailing ->
         case (stok, break (==' ') str) of
@@ -40,5 +40,5 @@ codecReqResp =
           (ServerAgency TokBusy, ("MsgResp", str'))
              | Just resp <- readMaybe str'
             -> DecodeDone (SomeMessage (MsgResp resp)) trailing
-          _ -> DecodeFail ("unexpected message: " ++ str)
+          _ -> DecodeFail (CodecFailure ("unexpected message: " ++ str))
 

--- a/typed-protocols/src/Network/TypedProtocol/ReqResp/Codec.hs
+++ b/typed-protocols/src/Network/TypedProtocol/ReqResp/Codec.hs
@@ -40,5 +40,9 @@ codecReqResp =
           (ServerAgency TokBusy, ("MsgResp", str'))
              | Just resp <- readMaybe str'
             -> DecodeDone (SomeMessage (MsgResp resp)) trailing
-          _ -> DecodeFail (CodecFailure ("unexpected message: " ++ str))
+
+          (ServerAgency _      , _     ) -> DecodeFail failure
+            where failure = CodecFailure ("unexpected server message: " ++ str)
+          (ClientAgency _      , _     ) -> DecodeFail failure
+            where failure = CodecFailure ("unexpected client message: " ++ str)
 

--- a/typed-protocols/src/Network/TypedProtocol/ReqResp/Tests.hs
+++ b/typed-protocols/src/Network/TypedProtocol/ReqResp/Tests.hs
@@ -16,7 +16,6 @@ import Network.TypedProtocol.ReqResp.Server
 import Network.TypedProtocol.ReqResp.Codec
 import Network.TypedProtocol.ReqResp.Examples
 
-import Control.Monad.Fail
 import Control.Monad.Class.MonadSTM
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadThrow
@@ -145,12 +144,12 @@ prop_connectPipelined cs f xs =
 -- Properties using channels, codecs and drivers.
 --
 
-prop_channel :: (MonadSTM m, MonadAsync m, MonadCatch m, MonadFail m)
+prop_channel :: (MonadSTM m, MonadAsync m, MonadCatch m)
              => (Int -> Int -> (Int, Int)) -> [Int]
              -> m Bool
 prop_channel f xs = do
-    Right (c, s) <- runConnectedPeers createConnectedChannels
-                                      codecReqResp client server
+    (c, s) <- runConnectedPeers createConnectedChannels
+                                codecReqResp client server
     return ((s, c) == mapAccumL f 0 xs)
   where
     client = reqRespClientPeer (reqRespClientMap xs)


### PR DESCRIPTION
In particular the `runPeerPipelined` now throws and propagates codec failures as exceptions.

I decided it's a lot easier, simpler and more useful for the drivers to throw the codec failures than to return them as `runPeer` did originally.

Since `runPeer` was single threaded it was easy to return the codec error, but in all use sites we ended up throwing it anyway. And for `runPeerPipelined` which is inherently concurrent it's rather harder to return the codec failure and still get prompt termination. Using the async util `concurrently` it becomes trivial to propagate it.

Then fix all the use sites. Many become simpler. Many gain a `MonadThrow` constraint.