### PR TITLE
Generalise mux over the set of protocol ids

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -33,6 +33,8 @@ library
                        Ouroboros.Network.Mux.Ingress
                        Ouroboros.Network.Mux.Types
                        Ouroboros.Network.Node
+                       Ouroboros.Network.NodeToNode
+                       Ouroboros.Network.NodeToClient
                        Ouroboros.Network.Pipe
                        Ouroboros.Network.Serialise
                        Ouroboros.Network.Socket

--- a/ouroboros-network/src/Ouroboros/Network/Mux/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Mux/Types.hs
@@ -4,8 +4,9 @@
 
 module Ouroboros.Network.Mux.Types (
       MiniProtocolDescription (..)
-    , MiniProtocolDescriptions (..)
+    , MiniProtocolDescriptions
     , MiniProtocolDispatch (..)
+    , ProtocolEnum (..)
     , MiniProtocolId (..)
     , MiniProtocolMode (..)
     , MuxSDU (..)
@@ -16,21 +17,95 @@ module Ouroboros.Network.Mux.Types (
     ) where
 
 import qualified Data.ByteString.Lazy as BL
-import qualified Data.Map.Strict as M
 import           Data.Word
+import           Data.Ix (Ix(..))
+import           Data.Array
 
+import           Control.Exception (throw, ArrayException(IndexOutOfBounds))
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTimer
 import           Ouroboros.Network.Channel
 
 newtype RemoteClockModel = RemoteClockModel { unRemoteClockModel :: Word32 }
 
-data MiniProtocolId = Muxcontrol
-                    | DeltaQ
-                    | ChainSync
-                    | BlockFetch
-                    | TxSubmission
+--
+-- Mini-protocol numbers
+--
+
+-- | The wire format includes the protocol numbers, and it's vital that these
+-- are stable. They are not necessarily dense however, as new ones are added
+-- and some old ones retired. So we use a dedicated class for this rather than
+-- reusing 'Enum'. This also covers unrecognised protocol numbers on the
+-- decoding side.
+--
+class ProtocolEnum ptcl where
+
+    fromProtocolEnum :: ptcl -> Word16
+    toProtocolEnum   :: Word16 -> Maybe ptcl
+
+
+-- | The Ids of mini-protocols that the mux manages. This is expected to be
+-- used with custom bounded enumerations that list all the mini-protocols in
+-- that instance of the overall muxed protocol.
+--
+-- It is necessary to have 'Ord', 'Enum' and 'Bounded' instances. For example:
+--
+-- > data NodeToClient = ChainSyncWithBlocks
+-- >                   | ClientRPC
+-- >   deriving (Eq, Ord, Enum, Bounded, Show)
+--
+data MiniProtocolId ptcl = Muxcontrol
+                         | DeltaQ
+                         | AppProtocolId ptcl
                     deriving (Eq, Ord, Show)
+
+-- | Shift the inner enumeration up by two, to account for the two mux built-in
+-- mini-protocols. This determines the final wire format for the protocol
+-- numbers.
+--
+instance ProtocolEnum ptcl => ProtocolEnum (MiniProtocolId ptcl) where
+  fromProtocolEnum Muxcontrol           = 0
+  fromProtocolEnum DeltaQ               = 1
+  fromProtocolEnum (AppProtocolId ptcl) = fromProtocolEnum ptcl
+
+  toProtocolEnum 0 = Just Muxcontrol
+  toProtocolEnum 1 = Just DeltaQ
+  toProtocolEnum n = AppProtocolId <$> toProtocolEnum n
+
+-- | Shift the inner enumeration up by two, to account for the two mux built-in
+-- mini-protocols. This instance is never used for the wire format, just for
+-- internal purposes such as dispatch tables.
+--
+instance Enum ptcl => Enum (MiniProtocolId ptcl) where
+  fromEnum Muxcontrol          = 0
+  fromEnum DeltaQ              = 1
+  fromEnum (AppProtocolId pid) = 2 + fromEnum pid
+
+  toEnum 0 = Muxcontrol
+  toEnum 1 = DeltaQ
+  toEnum n = AppProtocolId (toEnum (n-2))
+
+-- | We will be indexing arrays by the mini-protocol id, so need @Ix@.
+--
+instance (Ord ptcl, Enum ptcl) => Ix (MiniProtocolId ptcl) where
+  range   (from, to)       = enumFromTo from to
+  inRange (from, to) x     = x >= from && x <= to
+  index   (from, to) x
+    | inRange (from, to) x = fromEnum x - fromEnum from
+    | otherwise            = throw (IndexOutOfBounds msg)
+       where msg = "not inRange " ++ show (fromEnum from, fromEnum to)
+                           ++ " " ++ show (fromEnum x)
+
+-- | Need bounds to be able to construct arrays of mini-protocols.
+--
+instance Bounded ptcl => Bounded (MiniProtocolId ptcl) where
+  minBound = Muxcontrol
+  maxBound = AppProtocolId maxBound
+
+
+--
+-- Mini-protocol descriptions
+--
 
 {- | The 'MiniProtocolDescription' is used to provide
  two functions which will consume and produce messages
@@ -40,25 +115,32 @@ data MiniProtocolId = Muxcontrol
  any of them exit the underlying Mux Bearer will be torn down
  along with all other miniprotocols.
  -}
-data MiniProtocolDescription m = MiniProtocolDescription {
+data MiniProtocolDescription ptcl m = MiniProtocolDescription {
     -- | The 'MiniProtocolId' described.
-      mpdId        :: MiniProtocolId
+      mpdId        :: MiniProtocolId ptcl
     -- | Initiator function, consumes and produces messages related to the initiator side.
     , mpdInitiator :: Channel m BL.ByteString -> m ()
     -- | Responder function, consumes and produces messages related to the responder side.
     , mpdResponder :: Channel m BL.ByteString -> m ()
     }
 
-newtype MiniProtocolDescriptions m = MiniProtocolDescriptions (M.Map MiniProtocolId (MiniProtocolDescription m))
+type MiniProtocolDescriptions ptcl m = ptcl -> MiniProtocolDescription ptcl m
 
-newtype MiniProtocolDispatch m = MiniProtocolDispatch (M.Map (MiniProtocolId, MiniProtocolMode)
-                                                             (TBQueue m BL.ByteString))
 
-data MiniProtocolMode = ModeInitiator | ModeResponder deriving (Eq, Ord, Show)
+--
+-- Mux internal types
+--
 
-data MuxSDU = MuxSDU {
+newtype MiniProtocolDispatch ptcl m =
+        MiniProtocolDispatch (Array (MiniProtocolId ptcl, MiniProtocolMode)
+                                    (TBQueue m BL.ByteString))
+
+data MiniProtocolMode = ModeInitiator | ModeResponder
+  deriving (Eq, Ord, Ix, Enum, Bounded, Show)
+
+data MuxSDU ptcl = MuxSDU {
       msTimestamp :: !RemoteClockModel
-    , msId        :: !MiniProtocolId
+    , msId        :: !(MiniProtocolId ptcl)
     , msMode      :: !MiniProtocolMode
     , msLength    :: !Word16
     , msBlob      :: !BL.ByteString
@@ -69,8 +151,8 @@ data MuxSDU = MuxSDU {
 --  arbitrary (yet bounded) size. This multiplexing layer is
 --  responsible for the segmentation of concrete representation into
 --  appropriate SDU's for onward transmission.
-data TranslocationServiceRequest m
-  = TLSRDemand MiniProtocolId MiniProtocolMode (Wanton m)
+data TranslocationServiceRequest ptcl m
+  = TLSRDemand (MiniProtocolId ptcl) MiniProtocolMode (Wanton m)
 
 -- | A Wanton represent the concrete data to be translocated, note that the
 --  TMVar becoming empty indicates -- that the last fragment of the data has
@@ -81,15 +163,15 @@ newtype Wanton m = Wanton { want :: TMVar m BL.ByteString }
 -- de-multiplexing details (for despatch of incoming mesages to mini
 -- protocols) and for dispatching incoming SDUs.  This is shared
 -- between the muxIngress and the bearerIngress processes.
-data PerMuxSharedState m = PerMuxSS {
+data PerMuxSharedState ptcl m = PerMuxSS {
   -- | Ingress dispatch table, fixed and known at instantiation.
-    dispatchTable :: MiniProtocolDispatch m
+    dispatchTable :: MiniProtocolDispatch ptcl m
   -- | Egress queue, shared by all miniprotocols
-  , tsrQueue      :: TBQueue m (TranslocationServiceRequest m)
+  , tsrQueue      :: TBQueue m (TranslocationServiceRequest ptcl m)
   -- | Timestamp and send MuxSDU
-  , write         :: MuxSDU -> m (Time m)
+  , write         :: MuxSDU ptcl -> m (Time m)
   -- | Read a MuxSDU
-  , read          :: m (MuxSDU, Time m)
+  , read          :: m (MuxSDU ptcl, Time m)
   -- | Return a suitable MuxSDU payload size
   , sduSize       :: m Word16
   }

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -13,7 +13,7 @@ import Ouroboros.Network.Mux.Types (ProtocolEnum(..))
 -- make up the overall node-to-client protocol.
 --
 data NodeToClientProtocols = ChainSyncWithBlocks
-                        -- | ClientRPC  -- TODO
+                          -- ClientRPC -- will probably need something like this
   deriving (Eq, Ord, Enum, Bounded, Show)
 
 -- | These are the actual wire format protocol numbers.

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -1,0 +1,32 @@
+
+-- | This is the starting point for a module that will bring together the
+-- overall node to client protocol, as a collection of mini-protocols.
+--
+module Ouroboros.Network.NodeToClient (
+  NodeToClientProtocols(..)
+  ) where
+
+import Ouroboros.Network.Mux.Types (ProtocolEnum(..))
+
+
+-- | An index type used with the mux to enumerate all the mini-protocols that
+-- make up the overall node-to-client protocol.
+--
+data NodeToClientProtocols = ChainSyncWithBlocks
+                        -- | ClientRPC  -- TODO
+  deriving (Eq, Ord, Enum, Bounded, Show)
+
+-- | These are the actual wire format protocol numbers.
+--
+-- These are chosen to not overlap with the node to node protocol numbers.
+-- This is not essential for correctness, but is helpful to allow a single
+-- shared implementation of tools that can analyse both protocols, e.g.
+-- wireshark plugins.
+--
+instance ProtocolEnum NodeToClientProtocols where
+
+  fromProtocolEnum ChainSyncWithBlocks = 5
+
+  toProtocolEnum 5 = Just ChainSyncWithBlocks
+  toProtocolEnum _ = Nothing
+

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -1,0 +1,45 @@
+
+-- | This is the starting point for a module that will bring together the
+-- overall node to node protocol, as a collection of mini-protocols.
+--
+module Ouroboros.Network.NodeToNode (
+  NodeToNodeProtocols(..)
+  ) where
+
+import Ouroboros.Network.Mux.Types (ProtocolEnum(..))
+
+
+-- | An index type used with the mux to enumerate all the mini-protocols that
+-- make up the overall node-to-node protocol.
+--
+data NodeToNodeProtocols = ChainSyncWithHeaders
+                         | BlockFetch
+                         | TxSubmission
+  deriving (Eq, Ord, Enum, Bounded, Show)
+
+-- These protocol numbers end up in the wire format so it is vital that they
+-- are stable, even as they are upgraded. So we use custom Enum instances here.
+-- This allows us to retire old versions and add new, which may leave some
+-- holes in the numbering space.
+
+-- | These are the actual wire format protocol numbers.
+--
+-- The application specific protocol numbers start from 2 because of the two
+-- mux built-in protocols.
+--
+-- These are chosen to not overlap with the node to client protocol numbers.
+-- This is not essential for correctness, but is helpful to allow a single
+-- shared implementation of tools that can analyse both protocols, e.g.
+-- wireshark plugins.
+--
+instance ProtocolEnum NodeToNodeProtocols where
+
+  fromProtocolEnum ChainSyncWithHeaders = 2
+  fromProtocolEnum BlockFetch           = 3
+  fromProtocolEnum TxSubmission         = 4
+
+  toProtocolEnum 2 = Just ChainSyncWithHeaders
+  toProtocolEnum 3 = Just BlockFetch
+  toProtocolEnum 4 = Just TxSubmission
+  toProtocolEnum _ = Nothing
+


### PR DESCRIPTION
Here for comment initially. Needs to be rebased now that #311 was merged. Should be easy to fix up.

We will need to instantiate the mux with different sets of mini-protocols for the node-to-node vs the node-to-client protocols.

The approach we take is a simple trick using custom bounded enumerations. This makes use of the Ix type, arrays and functions covering the whole range of the enumeration.

This also eliminates some of the Data.Map lookup error conditions.

Also update the Pipe and Socket demos to use this.