### PR TITLE
Byron proxy: one sqlite transaction per batch of blocks

### DIFF
--- a/byron-proxy/byron-proxy.cabal
+++ b/byron-proxy/byron-proxy.cabal
@@ -70,6 +70,7 @@ executable byron-proxy
                        directory,
                        iohk-monitoring,
                        lens,
+                       optparse-applicative,
                        ouroboros-consensus,
                        random,
                        stm,

--- a/default.nix
+++ b/default.nix
@@ -14,8 +14,8 @@ let
   # proxy will build.
   cardanoroot = nixpkgs.fetchgit {
     url = "https://github.com/input-output-hk/cardano-sl";
-    rev = "7b21cfd5f4e705b46ac30c504fefab6ca24298ba";
-    sha256 = "1xy7bqi3k32ps0cxbbxzhjw3vya0q65rl9h2rls05zg7mh7604nx";
+    rev = "0af82eb3de205c6a1a681e1c10b0b513d3e8eb2b";
+    sha256 = "13infd9j3g71pa40fw32300gadj4bnv0hyg5m83q716qscw5dr1j";
   };
   cardanopkgs = import ./nix/cardanopkgs.nix { inherit nixpkgs cardanoroot; };
 

--- a/default.nix
+++ b/default.nix
@@ -14,8 +14,8 @@ let
   # proxy will build.
   cardanoroot = nixpkgs.fetchgit {
     url = "https://github.com/input-output-hk/cardano-sl";
-    rev = "1c8b414f59016c360c0f0eb2ec9cef07c99063ef";
-    sha256 = "0dzd9gj3hvcymqwz17widyhxq366yr669pijmvsvys6ghgxc13nk";
+    rev = "7b21cfd5f4e705b46ac30c504fefab6ca24298ba";
+    sha256 = "1xy7bqi3k32ps0cxbbxzhjw3vya0q65rl9h2rls05zg7mh7604nx";
   };
   cardanopkgs = import ./nix/cardanopkgs.nix { inherit nixpkgs cardanoroot; };
 

--- a/nix/overrides.nix
+++ b/nix/overrides.nix
@@ -57,4 +57,5 @@
 
     /* One test case fails. Hopefully fix will come soon. */
     iohk-monitoring = dontCheck (self.callPackage ./iohk-monitoring-HEAD.nix {});
+
   }


### PR DESCRIPTION
- Change to the type of `Index` to admit expression of transactions.
- One sqlite transaction per batch of streamed blocks. This drastically improves download speed (previously it was one per block).
- Command line argument added to Byron proxy: `--index-path`, of the sqlite index.
- Byron proxy will terminate on keypress. This can and should be changed but for now it's good to have a way to stop normally, so that the databases don't become corrupted.
- Updated the nix infrastructure to allow for profiled builds.
- Use a revision of `cardano-sl` which supports proper shutdown, and includes a batch size argument for the diffusion layer (block streaming). https://github.com/input-output-hk/cardano-sl/pull/4095