### PR TITLE
Remove `FsHandle` type family and `SimFS` monad

### DIFF
--- a/byron-proxy/src/exec/Main.hs
+++ b/byron-proxy/src/exec/Main.hs
@@ -174,7 +174,7 @@ blockHeaderIndex epochSlots blkHeader = EpochSlot epoch relativeSlot
       . Lens.to (\x -> x - 1)
     BlockHeaderMain mBlkHeader -> mBlkHeader ^.
         gbhConsensus
-      . mcdSlot 
+      . mcdSlot
       . Lens.to siEpoch
       . Lens.to getEpochIndex
       . Lens.to fromIntegral
@@ -298,7 +298,7 @@ main = withCompileInfo $ do
           dbFilePath = maybe ["db-byron-adapter"] pure (dbPath cArgs)
           fsMountPoint :: MountPoint
           fsMountPoint = MountPoint ""
-          fs :: HasFS IO
+          fs :: HasFS IO HandleIO
           fs = ioHasFS fsMountPoint
           errorHandling :: ErrorHandling ImmutableDBError IO
           errorHandling = ErrorHandling

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -150,8 +150,7 @@ library
                        text              >=1.2   && <1.3,
                        time,
                        transformers,
-                       vector            >=0.12  && <0.13,
-                       unliftio-core     >=0.1.1 && <0.2
+                       vector            >=0.12  && <0.13
 
   if os(windows)
      build-depends:       Win32
@@ -304,8 +303,7 @@ test-suite test-storage
                     tasty-quickcheck,
                     temporary,
                     transformers,
-                    tree-diff,
-                    unliftio-core
+                    tree-diff
 
   ghc-options:      -Wall
                     -fno-ignore-asserts

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -8,6 +8,7 @@
 module Ouroboros.Consensus.Util (
     Dict(..)
   , Some(..)
+  , SomePair(..)
   , foldlM'
   , repeatedly
   , repeatedlyM
@@ -36,6 +37,10 @@ data Dict (a :: Constraint) where
 
 data Some (f :: k -> *) where
     Some :: f a -> Some f
+
+-- | Pair of functors instantiated to the /same/ existential
+data SomePair (f :: k -> *) (g :: k -> *) where
+    SomePair :: f a -> g a -> SomePair f g
 
 foldlM' :: forall m a b. Monad m => (b -> a -> m b) -> b -> [a] -> m b
 foldlM' f = go

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -22,6 +22,8 @@ module Ouroboros.Consensus.Util (
   , lastMaybe
   , fib
   , allDisjoint
+  , (.:)
+  , (..:)
   ) where
 
 import qualified Data.ByteString as Strict
@@ -123,3 +125,9 @@ allDisjoint = go Set.empty
     go :: Set a -> [Set a] -> Bool
     go _   []       = True
     go acc (xs:xss) = Set.disjoint acc xs && go (Set.union acc xs) xss
+
+(.:) :: (c -> d) -> (a -> b -> c) -> (a -> b -> d)
+(f .: g) a b = f (g a b)
+
+(..:) :: (d -> e) -> (a -> b -> c -> d) -> (a -> b -> c -> e)
+(f ..: g) a b c = f (g a b c)

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
@@ -5,8 +5,6 @@
 -- | An abstract view over the filesystem.
 module Ouroboros.Storage.FS.API (
       HasFS(..)
-    , FsHandle
-    , Buffer
     , withFile
     ) where
 
@@ -26,20 +24,17 @@ import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
  Typeclass which abstracts over the filesystem
 ------------------------------------------------------------------------------}
 
-type family FsHandle (m :: * -> *) :: *
-data family Buffer   (m :: * -> *) :: *
-
-data HasFS m = HasFS {
-    newBuffer :: Int -> m (Buffer m)
-  , dumpState :: m String
+data HasFS m h = HasFS {
+    -- | Debugging: human-readable description of file system state
+    dumpState                :: m String
 
     -- Operations of files
 
     -- | Open a file
-  , hOpen      :: HasCallStack => FsPath -> IOMode -> m (FsHandle m)
+  , hOpen                    :: HasCallStack => FsPath -> IOMode -> m h
 
     -- | Close a file
-  , hClose     :: HasCallStack => FsHandle m -> m ()
+  , hClose                   :: HasCallStack => h -> m ()
 
     -- | Seek handle
     --
@@ -49,25 +44,22 @@ data HasFS m = HasFS {
     -- Unlike the Posix @lseek@, 'hSeek' does not return the new seek position
     -- because the value returned by Posix is rather strange and unreliable
     -- and we don't want to emulate it's behaviour.
-  , hSeek      :: HasCallStack => FsHandle m -> SeekMode -> Int64 -> m ()
+  , hSeek                    :: HasCallStack => h -> SeekMode -> Int64 -> m ()
 
     -- | Try to read @n@ bytes from a handle
-  , hGet       :: HasCallStack => FsHandle m -> Int -> m ByteString
+  , hGet                     :: HasCallStack => h -> Int -> m ByteString
 
     -- | Write to a handle
-  , hPut       :: HasCallStack => FsHandle m -> Builder -> m Word64
-
-    -- | Write to a handle using the given buffer (see 'newBuffer')
-  , hPutBuffer :: HasCallStack => FsHandle m -> Buffer m -> Builder -> m Word64
+  , hPut                     :: HasCallStack => h -> Builder -> m Word64
 
     -- | Truncate the file to the specified size
-  , hTruncate  :: HasCallStack => FsHandle m -> Word64 -> m ()
+  , hTruncate                :: HasCallStack => h -> Word64 -> m ()
 
     -- | Return current file size
     --
     -- NOTE: This is not thread safe (changes made to the file in other threads
     -- may affect this thread).
-  , hGetSize   :: HasCallStack => FsHandle m -> m Word64
+  , hGetSize                 :: HasCallStack => h -> m Word64
 
     -- Operations of directories
 
@@ -92,9 +84,9 @@ data HasFS m = HasFS {
   , removeFile               :: HasCallStack => FsPath -> m ()
 
     -- | Error handling
-  , hasFsErr :: ErrorHandling FsError m
+  , hasFsErr                 :: ErrorHandling FsError m
   }
 
 withFile :: (HasCallStack, MonadMask m)
-         => HasFS m -> FsPath -> IOMode -> (FsHandle m -> m a) -> m a
+         => HasFS m h -> FsPath -> IOMode -> (h -> m a) -> m a
 withFile HasFS{..} fp ioMode = bracket (hOpen fp ioMode) hClose

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE RankNTypes      #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TypeFamilies    #-}
 
 -- | An abstract view over the filesystem.
 module Ouroboros.Storage.FS.API (

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/API/Example.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/API/Example.hs
@@ -52,10 +52,10 @@ example HasFS{..} = do
 
 exampleSimFS :: IO ()
 exampleSimFS = do
-    mRes <- try $ runSimFS demo Mock.example
+    mRes <- try demo
     case mRes of
       Left  err      -> putStrLn (prettyFsError err)
       Right (bs, fs) -> putStrLn (Mock.pretty fs) >> print bs
   where
-    demo :: SimFS IO [ByteString]
-    demo = example (simHasFS EH.exceptions)
+    demo :: IO ([ByteString], Mock.MockFS)
+    demo = runSimFS EH.exceptions Mock.example example

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/API/Example.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/API/Example.hs
@@ -23,7 +23,7 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
   Example program that can run in any monad with file system support
 -------------------------------------------------------------------------------}
 
-example :: (HasCallStack, Monad m) => HasFS m -> m [ByteString]
+example :: (HasCallStack, Monad m) => HasFS m h -> m [ByteString]
 example HasFS{..} = do
     h1 <- hOpen ["cardano.txt"] IO.ReadWriteMode
     _  <- hPut h1 "test"

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
@@ -6,7 +6,8 @@
 -- | IO implementation of the 'HasFS' class
 module Ouroboros.Storage.FS.IO (
     -- * IO implementation & monad
-      ioHasFS
+      HandleIO(..)
+    , ioHasFS
     ) where
 
 import qualified Control.Exception as E
@@ -29,30 +30,33 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
   I/O implementation of HasFS
 -------------------------------------------------------------------------------}
 
-type instance FsHandle IO = (FsPath, F.FHandle)
-data instance Buffer   IO = BufferIO !(ForeignPtr Word8) !Int
+-- | File handlers for the IO instance for HasFS
+--
+-- We store the path the handle points to for better error messages
+data HandleIO = HandleIO {
+      handlePath :: FsPath
+    , handleIO   :: F.FHandle
+    }
+  deriving (Eq)
 
-ioHasFS :: MountPoint -> HasFS IO
+ioHasFS :: MountPoint -> HasFS IO HandleIO
 ioHasFS mount = HasFS {
       -- TODO(adn) Might be useful to implement this properly by reading all
       -- the stuff available at the 'MountPoint'.
       dumpState = return "<dumpState@IO>"
-    , newBuffer = newBufferIO
     , hOpen = \fp ioMode -> rethrowFsError fp $
-        (fp, ) <$> F.open (root fp) ioMode
-    , hClose = \(fp, h) -> rethrowFsError fp $
+        HandleIO fp <$> F.open (root fp) ioMode
+    , hClose = \(HandleIO fp h) -> rethrowFsError fp $
         F.close h
-    , hSeek = \(fp, h) mode o -> rethrowFsError fp $
+    , hSeek = \(HandleIO fp h) mode o -> rethrowFsError fp $
         F.seek h mode o
-    , hGet = \(fp, h) n -> rethrowFsError fp $
+    , hGet = \(HandleIO fp h) n -> rethrowFsError fp $
         F.read h n
-    , hTruncate = \(fp, h) sz -> rethrowFsError fp $
+    , hTruncate = \(HandleIO fp h) sz -> rethrowFsError fp $
         F.truncate h sz
-    , hPutBuffer = \(fp, h) buf bldr -> rethrowFsError fp $
-        hPutBufferIO h buf bldr
-    , hGetSize = \(fp, h) -> rethrowFsError fp $
+    , hGetSize = \(HandleIO fp h) -> rethrowFsError fp $
         F.getSize h
-    , hPut = \(fp, h) builder -> rethrowFsError fp $ do
+    , hPut = \(HandleIO fp h) builder -> rethrowFsError fp $ do
         buf0 <- newBufferIO BS.defaultChunkSize
         hPutBufferIO h buf0 builder
     , createDirectory = \fp -> rethrowFsError fp $
@@ -93,25 +97,27 @@ rethrowFsError fp action = do
   Auxiliary: buffers
 -------------------------------------------------------------------------------}
 
-bufferSize :: Buffer IO -> Int
+data BufferIO = BufferIO !(ForeignPtr Word8) !Int
+
+bufferSize :: BufferIO -> Int
 bufferSize (BufferIO _fptr len) = len
 
-newBufferIO :: Int -> IO (Buffer IO)
+newBufferIO :: Int -> IO BufferIO
 newBufferIO len = do
     fptr <- mallocPlainForeignPtrBytes len
     return $! BufferIO fptr len
 
-withBuffer :: Buffer IO
+withBuffer :: BufferIO
            -> (Ptr Word8 -> Int -> IO a)
            -> IO a
 withBuffer (BufferIO fptr len) action =
     withForeignPtr fptr $ \ptr -> action ptr len
 
-hPutBufferIO :: F.FHandle -> Buffer IO -> Builder -> IO Word64
+hPutBufferIO :: F.FHandle -> BufferIO -> Builder -> IO Word64
 hPutBufferIO hnd buf0 = go 0 buf0 . BS.runBuilder
   where
     go :: Word64
-       -> Buffer IO
+       -> BufferIO
        -> BS.BufferWriter
        -> IO Word64
     go !bytesWritten buf write = do

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE TypeFamilies      #-}
 
 -- | IO implementation of the 'HasFS' class
 module Ouroboros.Storage.FS.IO (

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/Pure.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
 
 module Ouroboros.Storage.FS.Sim.Pure (
     PureSimFS -- opaque

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/Pure.hs
@@ -30,23 +30,18 @@ newtype PureSimFS m a = PureSimFS { unPureSimFS :: StateT MockFS m a }
            , MonadState MockFS
            )
 
-type instance FsHandle (PureSimFS m) = Mock.Handle
-data instance Buffer   (PureSimFS m) = MockBufferUnused
-
 runPureSimFS :: PureSimFS m a -> MockFS -> m (a, MockFS)
 runPureSimFS = runStateT . unPureSimFS
 
 pureHasFS :: forall m. Monad m
-          => ErrorHandling FsError m -> HasFS (PureSimFS m)
+          => ErrorHandling FsError m -> HasFS (PureSimFS m) Mock.Handle
 pureHasFS err = HasFS {
-      dumpState = Mock.dumpState
-    , newBuffer                = \_ -> return MockBufferUnused
+      dumpState                = Mock.dumpState
     , hOpen                    = Mock.hOpen                    err'
     , hClose                   = Mock.hClose                   err'
     , hSeek                    = Mock.hSeek                    err'
     , hGet                     = Mock.hGet                     err'
     , hPut                     = Mock.hPut                     err'
-    , hPutBuffer               = Mock.hPutBuffer               err'
     , hTruncate                = Mock.hTruncate                err'
     , hGetSize                 = Mock.hGetSize                 err'
     , createDirectory          = Mock.createDirectory          err'

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
@@ -1,11 +1,5 @@
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 -- | 'HasFS' instance using 'MockFS' stored in an STM variable
 module Ouroboros.Storage.FS.Sim.STM (
@@ -31,7 +25,7 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
   The simulation-related types
 ------------------------------------------------------------------------------}
 
---- | Runs a 'SimFs' computation provided an initial 'MockFS', producing a
+--- | Runs a computation provided an initial 'MockFS', producing a
 --- result, the final state of the filesystem and a sequence of actions occurred
 --- in the filesystem.
 runSimFS :: MonadSTM m

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -1,8 +1,10 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE BangPatterns              #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TupleSections             #-}
 -- | Immutable on-disk database of binary blobs
 --
 -- = Logical format
@@ -214,6 +216,8 @@ import           GHC.Stack (HasCallStack, callStack)
 
 import           System.IO (IOMode (..), SeekMode (..))
 
+import           Ouroboros.Consensus.Util (SomePair (..))
+
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.Util
@@ -230,16 +234,18 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 
 
 -- | The environment used by the immutable database.
-data ImmutableDBEnv m = ImmutableDBEnv
-    { _dbInternalState :: !(TMVar m (Either ClosedState (OpenState m)))
+data ImmutableDBEnv m = forall h. ImmutableDBEnv
+    { _dbHasFS         :: !(HasFS m h)
+    , _dbErr           :: !(ErrorHandling ImmutableDBError m)
+    , _dbInternalState :: !(TMVar m (Either ClosedState (OpenState h)))
     , _dbFolder        :: !FsPath
     }
 
 -- | Internal state when the database is open.
-data OpenState m = OpenState
+data OpenState h = OpenState
     { _currentEpoch             :: !Epoch
     -- ^ The current 'Epoch' the immutable store is writing into.
-    , _currentEpochWriteHandle  :: !(FsHandle m)
+    , _currentEpochWriteHandle  :: !h
     -- ^ The write handle for the current epoch file.
     , _currentEpochOffsets      :: NonEmpty SlotOffset
     -- ^ The offsets to which blobs have been written in the current epoch
@@ -296,7 +302,7 @@ data ClosedState = ClosedState
 --
 -- __Note__: To be used in conjunction with 'withDB'.
 openDB :: (HasCallStack, MonadSTM m, MonadMask m)
-       => HasFS m
+       => HasFS m h
        -> ErrorHandling ImmutableDBError m
        -> FsPath -> Epoch -> Map Epoch EpochSize -> RecoveryPolicy e m
        -> m (ImmutableDB m, Maybe EpochSlot)
@@ -304,14 +310,14 @@ openDB hasFS err dbFolder epoch epochSizes recPol = do
     (dbEnv, lastBlobLocation) <-
       openDBImpl hasFS err dbFolder epoch epochSizes recPol
     return $ (, lastBlobLocation) $ ImmutableDB
-      { closeDB           = closeDBImpl           hasFS     dbEnv
-      , isOpen            = isOpenImpl                      dbEnv
-      , reopen            = reopenImpl            hasFS err dbEnv
-      , getNextEpochSlot  = getNextEpochSlotImpl        err dbEnv
-      , getBinaryBlob     = getBinaryBlobImpl     hasFS err dbEnv
-      , appendBinaryBlob  = appendBinaryBlobImpl  hasFS err dbEnv
-      , startNewEpoch     = startNewEpochImpl     hasFS err dbEnv
-      , streamBinaryBlobs = streamBinaryBlobsImpl hasFS err dbEnv
+      { closeDB           = closeDBImpl           dbEnv
+      , isOpen            = isOpenImpl            dbEnv
+      , reopen            = reopenImpl            dbEnv
+      , getNextEpochSlot  = getNextEpochSlotImpl  dbEnv
+      , getBinaryBlob     = getBinaryBlobImpl     dbEnv
+      , appendBinaryBlob  = appendBinaryBlobImpl  dbEnv
+      , startNewEpoch     = startNewEpochImpl     dbEnv
+      , streamBinaryBlobs = streamBinaryBlobsImpl dbEnv
       , immutableDBErr    = err
       }
 
@@ -319,7 +325,7 @@ openDB hasFS err dbFolder epoch epochSizes recPol = do
 --
 -- The file(s) in question are not checked, they might be empty or invalid.
 lastEpochOnDisk :: (HasCallStack, Monad m)
-                => HasFS m
+                => HasFS m h
                 -> FsPath
                 -> m (Maybe Epoch)
 lastEpochOnDisk HasFS{..} dbFolder = do
@@ -337,7 +343,7 @@ lastEpochOnDisk HasFS{..} dbFolder = do
 --
 -- Combination of 'openDB' and 'lastEpochOnDisk'.
 openLastEpoch :: (HasCallStack, MonadSTM m, MonadMask m)
-              => HasFS m
+              => HasFS m h
               -> ErrorHandling ImmutableDBError m
               -> FsPath -> Map Epoch EpochSize -> RecoveryPolicy e m
               -> m (ImmutableDB m, Maybe EpochSlot)
@@ -349,8 +355,8 @@ openLastEpoch hasFS err dbFolder epochSizes recPol = do
   ImmutableDB Implementation
 ------------------------------------------------------------------------------}
 
-openDBImpl :: forall m e. (HasCallStack, MonadSTM m, MonadMask m)
-           => HasFS m
+openDBImpl :: forall m h e. (HasCallStack, MonadSTM m, MonadMask m)
+           => HasFS m h
            -> ErrorHandling ImmutableDBError m
            -> FsPath
            -> Epoch
@@ -366,7 +372,7 @@ openDBImpl hasFS@HasFS{..} err dbFolder epoch epochSizes recPol = do
     st <- mkOpenState hasFS err dbFolder epochToOpen epochSizes initialIteratorId
 
     stVar <- atomically $ newTMVar (Right st)
-    let dbEnv = ImmutableDBEnv stVar dbFolder
+    let dbEnv = ImmutableDBEnv hasFS err stVar dbFolder
     case mbLastBlobLocation of
       Just lastBlobLocation -> return (dbEnv, lastBlobLocation)
       Nothing               -> (dbEnv,) <$> lastBlobInDB hasFS err st dbFolder
@@ -384,10 +390,9 @@ openDBImpl hasFS@HasFS{..} err dbFolder epoch epochSizes recPol = do
       (map (Just . fst) (Map.toAscList epochSizes) ++ repeat Nothing)
 
 closeDBImpl :: (HasCallStack, MonadSTM m, MonadMask m)
-            => HasFS m
-            -> ImmutableDBEnv m
+            => ImmutableDBEnv m
             -> m ()
-closeDBImpl hasFS@HasFS{..} ImmutableDBEnv {..} = do
+closeDBImpl ImmutableDBEnv {..} = do
     internalState <- atomically $ takeTMVar _dbInternalState
     case internalState of
       -- Already closed
@@ -399,7 +404,9 @@ closeDBImpl hasFS@HasFS{..} ImmutableDBEnv {..} = do
         atomically $ putTMVar _dbInternalState (Left closedState)
         hClose _currentEpochWriteHandle
         -- Also write an index file of the current (possible incomplete) epoch
-        writeSlotOffsets hasFS _dbFolder _currentEpoch _currentEpochOffsets
+        writeSlotOffsets _dbHasFS _dbFolder _currentEpoch _currentEpochOffsets
+  where
+    HasFS{..} = _dbHasFS
 
 isOpenImpl :: MonadSTM m => ImmutableDBEnv m -> m Bool
 isOpenImpl ImmutableDBEnv {..} =
@@ -408,12 +415,10 @@ isOpenImpl ImmutableDBEnv {..} =
 
 -- Note that recovery will stop when an 'FsError' is thrown, as usual.
 reopenImpl :: forall m e. (HasCallStack, MonadSTM m, MonadMask m)
-           => HasFS m
-           -> ErrorHandling ImmutableDBError m
-           -> ImmutableDBEnv m
+           => ImmutableDBEnv m
            -> RecoveryPolicy e m
            -> m LastBlobLocation
-reopenImpl hasFS@HasFS{..} err@ErrorHandling{..} ImmutableDBEnv{..} recPol = do
+reopenImpl ImmutableDBEnv{..} recPol = do
     internalState <- atomically $ takeTMVar _dbInternalState
     (openState, mbLastBlobLocation) <- case internalState of
       -- When still open,
@@ -426,59 +431,59 @@ reopenImpl hasFS@HasFS{..} err@ErrorHandling{..} ImmutableDBEnv{..} recPol = do
           -- Important: put back the state when the recovery policy threw an
           -- error, otherwise we have an empty TMVar.
           onException
-            (recovery hasFS err _dbFolder _closedLastEpoch _closedEpochSizes recPol)
+            (recovery _dbHasFS _dbErr _dbFolder _closedLastEpoch _closedEpochSizes recPol)
             (atomically $ putTMVar _dbInternalState internalState)
 
         -- TODO the index file is opened again by 'mkOpenState' after we have
         -- already opened it in 'recovery'. Should we avoid try to avoid this?
-        newOpenState <- mkOpenState hasFS err _dbFolder epochToReopen
+        newOpenState <- mkOpenState _dbHasFS _dbErr _dbFolder epochToReopen
                           _closedEpochSizes _closedNextIteratorID
         atomically $ putTMVar _dbInternalState (Right newOpenState)
         return (newOpenState, mbLastBlobLocation)
     case mbLastBlobLocation of
       Just lastBlobLocation -> return lastBlobLocation
-      Nothing               -> lastBlobInDB hasFS err openState _dbFolder
+      Nothing               -> lastBlobInDB _dbHasFS _dbErr openState _dbFolder
   where
+    HasFS{..}         = _dbHasFS
+    ErrorHandling{..} = _dbErr
+
     -- On both ImmutableDBError and on FsError
     onException m onErr =
-      EH.onException hasFsErr (EH.onException err m onErr) onErr
+      EH.onException hasFsErr (EH.onException _dbErr m onErr) onErr
 
 
 getNextEpochSlotImpl :: (HasCallStack, MonadSTM m)
-                     => ErrorHandling ImmutableDBError m
-                     -> ImmutableDBEnv m
+                     => ImmutableDBEnv m
                      -> m EpochSlot
-getNextEpochSlotImpl err dbEnv@ImmutableDBEnv {..} = do
-    OpenState {..} <- getOpenState err dbEnv
+getNextEpochSlotImpl dbEnv@ImmutableDBEnv {..} = do
+    SomePair _hasFS OpenState {..} <- getOpenState dbEnv
     return $ EpochSlot _currentEpoch _nextExpectedRelativeSlot
 
 getBinaryBlobImpl
   :: forall m. (HasCallStack, MonadSTM m, MonadMask m)
-  => HasFS m
-  -> ErrorHandling ImmutableDBError m
-  -> ImmutableDBEnv m
+  => ImmutableDBEnv m
   -> EpochSlot
   -> m (Maybe ByteString)
-getBinaryBlobImpl hasFS@HasFS{..} err dbEnv@ImmutableDBEnv {..} readEpochSlot = do
+getBinaryBlobImpl dbEnv@ImmutableDBEnv {..} readEpochSlot = do
     let EpochSlot epoch relativeSlot = readEpochSlot
-    OpenState {..} <- getOpenState err dbEnv
+    SomePair _hasFS OpenState {..} <- getOpenState dbEnv
 
     -- Check if the requested slot is not in the future.
     let nextExpectedEpochSlot =
           EpochSlot _currentEpoch _nextExpectedRelativeSlot
     when (readEpochSlot >= nextExpectedEpochSlot) $
-      throwUserError err $ ReadFutureSlotError
-                             readEpochSlot
-                             nextExpectedEpochSlot
+      throwUserError _dbErr $ ReadFutureSlotError
+                                readEpochSlot
+                                nextExpectedEpochSlot
 
     -- Check if the requested slot within the epoch, i.e. it may not be
     -- greater than or equal to the epoch size.
-    epochSize <- lookupEpochSize err epoch _epochSizes
+    epochSize <- lookupEpochSize _dbErr epoch _epochSizes
     when (getRelativeSlot relativeSlot >= epochSize) $
-      throwUserError err $ SlotGreaterThanEpochSizeError
-                             relativeSlot
-                             epoch
-                             epochSize
+      throwUserError _dbErr $ SlotGreaterThanEpochSizeError
+                                relativeSlot
+                                epoch
+                                epochSize
 
     let epochFile = _dbFolder <> renderFile "epoch" epoch
         indexFile = _dbFolder <> renderFile "index" epoch
@@ -495,7 +500,7 @@ getBinaryBlobImpl hasFS@HasFS{..} err dbEnv@ImmutableDBEnv {..} readEpochSlot = 
             lastSlot = _nextExpectedRelativeSlot - 1
 
       -- Otherwise, the offsets will have to be read from an index file
-      False -> withFile hasFS indexFile ReadMode $ \iHnd -> do
+      False -> withFile _dbHasFS indexFile ReadMode $ \iHnd -> do
         -- Grab the offset in bytes of the requested slot.
         let indexSeekPosition = fromIntegral (getRelativeSlot relativeSlot)
                               * fromIntegral indexEntrySizeBytes
@@ -505,7 +510,7 @@ getBinaryBlobImpl hasFS@HasFS{..} err dbEnv@ImmutableDBEnv {..} readEpochSlot = 
         -- Note the use of hGetRightSize: we must get enough bytes from the
         -- index file, otherwise 'decodeIndexEntry' (and its variant) would
         -- fail.
-        bytes <- hGetRightSize hasFS iHnd nbBytesToGet indexFile
+        bytes <- hGetRightSize _dbHasFS iHnd nbBytesToGet indexFile
         let !start = decodeIndexEntry   bytes
             !end   = decodeIndexEntryAt indexEntrySizeBytes bytes
         return (start, end - start)
@@ -519,37 +524,37 @@ getBinaryBlobImpl hasFS@HasFS{..} err dbEnv@ImmutableDBEnv {..} readEpochSlot = 
     -- implementations of the 'HasFS' API guarantee this too).
     case blobSize of
       0 -> return Nothing
-      _ -> withFile hasFS epochFile ReadMode $ \eHnd -> do
+      _ -> withFile _dbHasFS epochFile ReadMode $ \eHnd -> do
         -- Seek in the epoch file
         hSeek eHnd AbsoluteSeek (fromIntegral blobOffset)
-        Just <$> hGetRightSize hasFS eHnd (fromIntegral blobSize) epochFile
+        Just <$> hGetRightSize _dbHasFS eHnd (fromIntegral blobSize) epochFile
+  where
+    HasFS{..} = _dbHasFS
 
 appendBinaryBlobImpl :: (HasCallStack, MonadSTM m, MonadMask m)
-                     => HasFS m
-                     -> ErrorHandling ImmutableDBError m
-                     -> ImmutableDBEnv m
+                     => ImmutableDBEnv m
                      -> RelativeSlot
                      -> BS.Builder
                      -> m ()
-appendBinaryBlobImpl hasFS@HasFS{..} err dbEnv relativeSlot builder =
-    modifyOpenState hasFS err dbEnv $ \st@OpenState {..} -> do
+appendBinaryBlobImpl dbEnv@ImmutableDBEnv{..} relativeSlot builder =
+    modifyOpenState dbEnv $ \HasFS{..} st@OpenState {..} -> do
       let eHnd = _currentEpochWriteHandle
 
       -- Check that the slot is >= the expected next slot and thus not in the
       -- past.
       when (relativeSlot < _nextExpectedRelativeSlot) $
-        throwUserError err $ AppendToSlotInThePastError
-                               relativeSlot
-                               _nextExpectedRelativeSlot
+        throwUserError _dbErr $ AppendToSlotInThePastError
+                                  relativeSlot
+                                  _nextExpectedRelativeSlot
 
       -- Check if the requested slot within the epoch, i.e. it may not be
       -- greater than or equal to the epoch size.
-      epochSize <- lookupEpochSize err _currentEpoch _epochSizes
+      epochSize <- lookupEpochSize _dbErr _currentEpoch _epochSizes
       when (getRelativeSlot relativeSlot >= epochSize) $
-        throwUserError err $ SlotGreaterThanEpochSizeError
-                               relativeSlot
-                               _currentEpoch
-                               epochSize
+        throwUserError _dbErr $ SlotGreaterThanEpochSizeError
+                                  relativeSlot
+                                  _currentEpoch
+                                  epochSize
 
       -- If necessary, backfill the index file for any slot we missed.
       let lastEpochOffset = NE.head _currentEpochOffsets
@@ -572,12 +577,10 @@ appendBinaryBlobImpl hasFS@HasFS{..} err dbEnv relativeSlot builder =
                  }, ())
 
 startNewEpochImpl :: (HasCallStack, MonadSTM m, MonadMask m)
-                  => HasFS m
-                  -> ErrorHandling ImmutableDBError m
-                  -> ImmutableDBEnv m
+                  => ImmutableDBEnv m
                   -> EpochSize
                   -> m Epoch
-startNewEpochImpl hasFS@HasFS{..} err dbEnv newEpochSize = modifyOpenState hasFS err dbEnv $ \st -> do
+startNewEpochImpl dbEnv@ImmutableDBEnv{..} newEpochSize = modifyOpenState dbEnv $ \hasFS@HasFS{..} st -> do
     let OpenState {..} = st
 
     -- We can close the epoch file
@@ -586,7 +589,7 @@ startNewEpochImpl hasFS@HasFS{..} err dbEnv newEpochSize = modifyOpenState hasFS
     -- Find out the size of the epoch, so we can pad the _currentEpochOffsets
     -- to match the size before writing them to the index file. When looking
     -- at the index file, it will then be clear that the epoch is finalised.
-    epochSize <- lookupEpochSize err _currentEpoch _epochSizes
+    epochSize <- lookupEpochSize _dbErr _currentEpoch _epochSizes
 
     -- Calculate what to pad the file with
     let lastEpochOffset = NE.head _currentEpochOffsets
@@ -601,14 +604,14 @@ startNewEpochImpl hasFS@HasFS{..} err dbEnv newEpochSize = modifyOpenState hasFS
         allOffsets = foldr NE.cons _currentEpochOffsets backfillOffsets
 
     -- Now write the offsets to the index file to disk
-    writeSlotOffsets hasFS (_dbFolder dbEnv) _currentEpoch allOffsets
+    writeSlotOffsets hasFS _dbFolder _currentEpoch allOffsets
 
     let newEpoch      = succ _currentEpoch
         newEpochSizes = Map.insert newEpoch newEpochSize _epochSizes
     newState <- mkOpenState
                   hasFS
-                  err
-                  (_dbFolder dbEnv)
+                  _dbErr
+                  _dbFolder
                   newEpoch
                   newEpochSizes
                   _nextIteratorID
@@ -619,18 +622,18 @@ startNewEpochImpl hasFS@HasFS{..} err dbEnv newEpochSize = modifyOpenState hasFS
 ------------------------------------------------------------------------------}
 
 -- | Internal handle to an iterator
-data IteratorHandle m = IteratorHandle
-  { _it_state :: !(TVar m (Maybe (IteratorState m)))
+data IteratorHandle m = forall h. IteratorHandle
+  { _it_hasFS :: !(HasFS m h)
+    -- ^ Bundled HasFS instance allows to hide type parameters
+  , _it_state :: !(TVar m (Maybe (IteratorState h)))
     -- ^ The state of the iterator. If it is 'Nothing', the iterator is
     -- exhausted and closed.
   , _it_end   :: !EpochSlot
     -- ^ The end of the iterator: the last 'EpochSlot' it should return.
   }
 
-data IteratorState m = IteratorState
-  { _it_hasFS        :: !(HasFS m)
-    -- ^ Bundled HasFS instance allows to hide type parameters
-  , _it_next         :: !EpochSlot
+data IteratorState h = IteratorState
+  { _it_next         :: !EpochSlot
     -- ^ The location of the next binary blob to read.
     --
     -- TODO check invariants with code/assertions + check them in the tests
@@ -648,7 +651,7 @@ data IteratorState m = IteratorState
     --
     -- __Invariant 4__: '_it_epoch_handle' points to where @next@ can be read
     -- from.
-  , _it_epoch_handle :: !(FsHandle m)
+  , _it_epoch_handle :: !h
     -- ^ A handle to the epoch file corresponding with '_it_next'.
   , _it_epoch_index  :: Index
     -- ^ We load the index file for the epoch we are currently iterating over
@@ -657,19 +660,17 @@ data IteratorState m = IteratorState
 
 streamBinaryBlobsImpl :: forall m
                        . (HasCallStack, MonadSTM m, MonadMask m)
-                      => HasFS m
-                      -> ErrorHandling ImmutableDBError m
-                      -> ImmutableDBEnv m
+                      => ImmutableDBEnv m
                       -> Maybe EpochSlot  -- ^ When to start streaming (inclusive).
                       -> Maybe EpochSlot  -- ^ When to stop streaming (inclusive).
                       -> m (Iterator m)
-streamBinaryBlobsImpl hasFS@HasFS{..} err dbEnv@ImmutableDBEnv {..} mbStart mbEnd = do
-    OpenState {..} <- getOpenState err dbEnv
+streamBinaryBlobsImpl dbEnv@ImmutableDBEnv {..} mbStart mbEnd = do
+    SomePair _hasFS OpenState {..} <- getOpenState dbEnv
     let nextExpectedEpochSlot =
           EpochSlot _currentEpoch _nextExpectedRelativeSlot
 
-    validateIteratorRange err nextExpectedEpochSlot
-      (\epoch -> lookupEpochSize err epoch _epochSizes) mbStart mbEnd
+    validateIteratorRange _dbErr nextExpectedEpochSlot
+      (\epoch -> lookupEpochSize _dbErr epoch _epochSizes) mbStart mbEnd
 
     -- If the database is empty, just return an empty iterator (directly
     -- exhausted)
@@ -681,7 +682,7 @@ streamBinaryBlobsImpl hasFS@HasFS{..} err dbEnv@ImmutableDBEnv {..} mbStart mbEn
       lastAppendedSlot <- case nextExpectedEpochSlot of
         -- EpochSlot 0 0 is already handled before, so we can ignore it.
         EpochSlot epoch 0 -> do
-          epochSize <- lookupEpochSize err (epoch - 1) _epochSizes
+          epochSize <- lookupEpochSize _dbErr (epoch - 1) _epochSizes
           return $ EpochSlot (epoch - 1) (fromIntegral epochSize - 1)
         EpochSlot epoch relSlot ->
           return $ EpochSlot epoch (pred relSlot)
@@ -695,9 +696,9 @@ streamBinaryBlobsImpl hasFS@HasFS{..} err dbEnv@ImmutableDBEnv {..} mbStart mbEn
             = return $ indexFromSlotOffsets _currentEpochOffsets
             | otherwise
             = do
-              index <- loadIndex' hasFS err _dbFolder epoch
+              index <- loadIndex' _dbHasFS _dbErr _dbFolder epoch
               unless (isValidIndex index) $
-                throwUnexpectedError err $
+                throwUnexpectedError _dbErr $
                   InvalidFileError
                     (_dbFolder <> renderFile "index" epoch)
                     callStack
@@ -752,8 +753,7 @@ streamBinaryBlobsImpl hasFS@HasFS{..} err dbEnv@ImmutableDBEnv {..} mbStart mbEn
           hSeek eHnd AbsoluteSeek (fromIntegral (offsetOfSlot index nextSlot))
 
           return $ Just IteratorState
-            { _it_hasFS = hasFS
-            , _it_next = next
+            { _it_next = next
             , _it_epoch_handle = eHnd
             , _it_epoch_index = index
             }
@@ -761,22 +761,25 @@ streamBinaryBlobsImpl hasFS@HasFS{..} err dbEnv@ImmutableDBEnv {..} mbStart mbEn
       itState <- atomically $ newTVar mbIteratorState
 
       let ith = IteratorHandle
-            { _it_state = itState
+            { _it_hasFS = _dbHasFS
+            , _it_state = itState
             , _it_end   = end
             }
       -- Safely increment '_nextIteratorID' in the 'OpenState'.
-      modifyOpenState hasFS err dbEnv $ \st@OpenState {..} ->
+      modifyOpenState dbEnv $ \_hasFS st@OpenState {..} ->
         let it = Iterator
-              { iteratorNext  = iteratorNextImpl  hasFS err dbEnv ith
-              , iteratorClose = iteratorCloseImpl hasFS           ith
+              { iteratorNext  = iteratorNextImpl  dbEnv ith
+              , iteratorClose = iteratorCloseImpl       ith
               , iteratorID    = _nextIteratorID
               }
             st' = st { _nextIteratorID = succ _nextIteratorID }
         in return (st', it)
   where
+    HasFS{..} = _dbHasFS
+
     mkEmptyIterator :: m (Iterator m)
     mkEmptyIterator =
-      modifyOpenState hasFS err dbEnv $ \st@OpenState {..} ->
+      modifyOpenState dbEnv $ \_hasFS st@OpenState {..} ->
         let it = Iterator
               { iteratorNext  = return IteratorExhausted
               , iteratorClose = return ()
@@ -786,12 +789,10 @@ streamBinaryBlobsImpl hasFS@HasFS{..} err dbEnv@ImmutableDBEnv {..} mbStart mbEn
         in return (st', it)
 
 iteratorNextImpl :: forall m. (HasCallStack, MonadSTM m, MonadMask m)
-                 => HasFS m
-                 -> ErrorHandling ImmutableDBError m
-                 -> ImmutableDBEnv m
+                 => ImmutableDBEnv m
                  -> IteratorHandle m
                  -> m IteratorResult
-iteratorNextImpl hasFS@HasFS{..} err dbEnv it@IteratorHandle {..} = do
+iteratorNextImpl dbEnv it@IteratorHandle {_it_hasFS = hasFS :: HasFS m h, ..} = do
     -- The idea is that if the state is not Nothing, then '_it_next' is always
     -- ready to be read. After reading it with 'readNext', 'stepIterator' will
     -- advance the iterator to the next valid epoch slot.
@@ -807,7 +808,9 @@ iteratorNextImpl hasFS@HasFS{..} err dbEnv it@IteratorHandle {..} = do
         stepIterator iteratorState
         return $ IteratorResult (_it_next iteratorState) blob
   where
-    readNext :: IteratorState m -> m ByteString
+    HasFS{..} = hasFS
+
+    readNext :: IteratorState h -> m ByteString
     readNext IteratorState { _it_epoch_handle = eHnd
                            , _it_next = EpochSlot epoch slot
                            , _it_epoch_index = index } = do
@@ -822,7 +825,7 @@ iteratorNextImpl hasFS@HasFS{..} err dbEnv it@IteratorHandle {..} = do
     -- Move the iterator to the next position that can be read from, advancing
     -- epochs if necessary. If no next position can be found, the iterator is
     -- closed.
-    stepIterator :: IteratorState m -> m ()
+    stepIterator :: IteratorState h -> m ()
     stepIterator its@IteratorState { _it_epoch_handle = eHnd
                                    , _it_next = EpochSlot epoch currentSlot
                                    , _it_epoch_index = index } =
@@ -835,37 +838,37 @@ iteratorNextImpl hasFS@HasFS{..} err dbEnv it@IteratorHandle {..} = do
              -- Invariant 3 is OK (thanks to nextFilledSlot), Invariant 4 is
              -- OK (readNext moved the handle + nextFilledSlot).
           | otherwise
-          -> iteratorCloseImpl hasFS it
+          -> iteratorCloseImpl it
           where
             next = EpochSlot epoch nextSlot
 
         -- Epoch exhausted, open the next epoch
         Nothing -> do
           hClose eHnd
-          st <- getOpenState err dbEnv
+          SomePair _hasFS st <- getOpenState dbEnv
           openNextNonEmptyEpoch (epoch + 1) st
 
     -- Start opening epochs (starting from the given epoch number) until we
     -- encounter a non-empty one, then update the iterator state accordingly.
     -- If no non-empty epoch can be found, the iterator is closed.
-    openNextNonEmptyEpoch :: Epoch -> OpenState m -> m ()
+    openNextNonEmptyEpoch :: Epoch -> OpenState h' -> m ()
     openNextNonEmptyEpoch epoch st@OpenState {..}
       | epoch > _epoch _it_end
-      = iteratorCloseImpl hasFS it
+      = iteratorCloseImpl it
       | otherwise = do
         -- Thanks to the guard we know that epoch <= _epoch _it_end. We also
         -- know that _epoch _it_end is <= _currentEpoch, so we know that epoch
         -- <= _currentEpoch.
         index <- case epoch == _currentEpoch of
           True  -> return $ indexFromSlotOffsets _currentEpochOffsets
-          False -> loadIndex' hasFS err (_dbFolder dbEnv) epoch
+          False -> loadIndex' hasFS (_dbErr dbEnv) (_dbFolder dbEnv) epoch
 
         case firstFilledSlot index of
           -- Empty epoch -> try the next one
           Nothing -> openNextNonEmptyEpoch (epoch + 1) st
           Just slot
             -- Slot is after the end -> stop
-            | EpochSlot epoch slot > _it_end -> iteratorCloseImpl hasFS it
+            | EpochSlot epoch slot > _it_end -> iteratorCloseImpl it
             | otherwise -> do
               let epochFile = _dbFolder dbEnv <> renderFile "epoch" epoch
               eHnd <- hOpen epochFile ReadMode
@@ -876,17 +879,15 @@ iteratorNextImpl hasFS@HasFS{..} err dbEnv it@IteratorHandle {..} = do
               -- Invariant 3 is OK (thanks to firstFilledSlot), Invariant 4 is
               -- OK.
               atomically $ writeTVar _it_state $ Just IteratorState
-                { _it_hasFS = hasFS
-                , _it_next = EpochSlot epoch slot
+                { _it_next = EpochSlot epoch slot
                 , _it_epoch_handle = eHnd
                 , _it_epoch_index = index
                 }
 
 iteratorCloseImpl :: (HasCallStack, MonadSTM m)
-                  => HasFS m
-                  -> IteratorHandle m
+                  => IteratorHandle m
                   -> m ()
-iteratorCloseImpl HasFS{..} IteratorHandle {..} = do
+iteratorCloseImpl IteratorHandle {..} = do
     mbIteratorState <- atomically $ readTVar _it_state
     case mbIteratorState of
       -- Already closed
@@ -897,6 +898,8 @@ iteratorCloseImpl HasFS{..} IteratorHandle {..} = do
         -- invalid state.
         atomically $ writeTVar _it_state Nothing
         hClose _it_epoch_handle
+  where
+    HasFS{..} = _it_hasFS
 
 {------------------------------------------------------------------------------
   Internal functions
@@ -912,13 +915,13 @@ iteratorCloseImpl HasFS{..} IteratorHandle {..} = do
 -- 'InvalidFileError' is thrown. If the size of the epoch file does not match
 -- the last offset in the index file, an 'InvalidFileError' is thrown.
 mkOpenState :: (HasCallStack, MonadMask m)
-            => HasFS m
+            => HasFS m h
             -> ErrorHandling ImmutableDBError m
             -> FsPath
             -> Epoch
             -> Map Epoch EpochSize
             -> IteratorID
-            -> m (OpenState m)
+            -> m (OpenState h)
 mkOpenState hasFS@HasFS{..} err dbFolder epoch epochSizes nextIteratorID = do
     let epochFile = dbFolder <> renderFile "epoch" epoch
         indexFile = dbFolder <> renderFile "index" epoch
@@ -977,14 +980,13 @@ mkOpenState hasFS@HasFS{..} err dbFolder epoch epochSizes nextIteratorID = do
 -- | Get the 'OpenState' of the given database, throw a 'ClosedDBError' in
 -- case it is closed.
 getOpenState :: (HasCallStack, MonadSTM m)
-             => ErrorHandling ImmutableDBError m
-             -> ImmutableDBEnv m
-             -> m (OpenState m)
-getOpenState err ImmutableDBEnv {..} = do
+             => ImmutableDBEnv m
+             -> m (SomePair (HasFS m) OpenState)
+getOpenState ImmutableDBEnv {..} = do
     internalState <- atomically (readTMVar _dbInternalState)
     case internalState of
-       Left  _         -> throwUserError err ClosedDBError
-       Right openState -> return openState
+       Left  _         -> throwUserError _dbErr ClosedDBError
+       Right openState -> return (SomePair _dbHasFS openState)
 
 -- | Modify the internal state of an open database.
 --
@@ -1001,26 +1003,27 @@ getOpenState err ImmutableDBEnv {..} = do
 -- TODO(adn): we should really just use 'MVar' rather than 'TMVar', but we
 -- currently don't have a simulator for code using 'MVar'.
 modifyOpenState :: forall m r. (HasCallStack, MonadSTM m, MonadMask m)
-                => HasFS m
-                -> ErrorHandling ImmutableDBError m
-                -> ImmutableDBEnv m
-                -> (OpenState m -> m (OpenState m, r))
+                => ImmutableDBEnv m
+                -> (forall h. HasFS m h -> OpenState h -> m (OpenState h, r))
                 -> m r
-modifyOpenState HasFS{..} err@ErrorHandling{..} ImmutableDBEnv {..} action = do
-    (mr, ()) <- generalBracket open close (EH.try err . mutation)
+modifyOpenState ImmutableDBEnv {_dbHasFS = hasFS :: HasFS m h, ..} action = do
+    (mr, ()) <- generalBracket open close (EH.try _dbErr . mutation)
     case mr of
       Left  e      -> throwError e
       Right (_, r) -> return r
   where
+    HasFS{..}         = hasFS
+    ErrorHandling{..} = _dbErr
+
     -- We use @m (Either e a)@ instead of @EitherT e m a@ for 'generalBracket'
     -- so that 'close' knows which error is thrown (@Either e (s, r)@ vs. @(s,
     -- r)@).
 
-    open :: m (Either ClosedState (OpenState m))
+    open :: m (Either ClosedState (OpenState h))
     open = atomically $ takeTMVar _dbInternalState
 
-    close :: Either ClosedState (OpenState m)
-          -> ExitCase (Either ImmutableDBError (OpenState m, r))
+    close :: Either ClosedState (OpenState h)
+          -> ExitCase (Either ImmutableDBError (OpenState h, r))
           -> m ()
     close st ec = case ec of
       -- Restore the original state in case of an abort
@@ -1045,13 +1048,13 @@ modifyOpenState HasFS{..} err@ErrorHandling{..} ImmutableDBEnv {..} action = do
         atomically $ putTMVar _dbInternalState st
 
     mutation :: HasCallStack
-             => Either ClosedState (OpenState m)
-             -> m (OpenState m, r)
-    mutation (Left _)    = throwUserError err ClosedDBError
-    mutation (Right ost) = action ost
+             => Either ClosedState (OpenState h)
+             -> m (OpenState h, r)
+    mutation (Left _)    = throwUserError _dbErr ClosedDBError
+    mutation (Right ost) = action hasFS ost
 
     -- TODO what if this fails?
-    closeOpenHandles :: Either ClosedState (OpenState m) -> m ()
+    closeOpenHandles :: Either ClosedState (OpenState h) -> m ()
     closeOpenHandles (Left _)               = return ()
     closeOpenHandles (Right OpenState {..}) = hClose _currentEpochWriteHandle
 
@@ -1078,10 +1081,10 @@ type LastBlobLocation = Maybe EpochSlot
 --
 -- When the current epoch is still empty, opens the index of the previous
 -- epoch until a filled slot is found.
-lastBlobInDB :: forall m. (HasCallStack, MonadMask m)
-             => HasFS m
+lastBlobInDB :: forall m h. (HasCallStack, MonadMask m)
+             => HasFS m h
              -> ErrorHandling ImmutableDBError m
-             -> OpenState m
+             -> OpenState h
              -> FsPath
              -> m LastBlobLocation
 lastBlobInDB hasFS@HasFS{..} err OpenState{..} dbFolder
@@ -1159,8 +1162,8 @@ checkIndices reconstructedIndex indexFromFile epochSize
 --
 -- Precondition: the size for each epoch <= the epoch to reopen must be
 -- present in the map of epoch sizes.
-recovery :: forall m e. (HasCallStack, MonadMask m)
-         => HasFS m
+recovery :: forall m h e. (HasCallStack, MonadMask m)
+         => HasFS m h
          -> ErrorHandling ImmutableDBError m
          -> FsPath -> Epoch -> Map Epoch EpochSize
          -> RecoveryPolicy e m
@@ -1405,7 +1408,7 @@ reconstructSlotOffsets = go 0 [] 0
 -- | Variant of 'loadIndex' that throws an 'InvalidFileError' when 'loadIndex'
 -- signalled that there was some invalid trailing data.
 loadIndex' :: (HasCallStack, MonadMask m)
-           => HasFS m
+           => HasFS m h
            -> ErrorHandling ImmutableDBError m
            -> FsPath
            -> Epoch

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -979,6 +979,13 @@ mkOpenState hasFS@HasFS{..} err dbFolder epoch epochSizes nextIteratorID = do
 
 -- | Get the 'OpenState' of the given database, throw a 'ClosedDBError' in
 -- case it is closed.
+--
+-- NOTE: Since the 'OpenState' is parameterized over a type parameter @h@ of
+-- handles, which is not visible from the type of the @ImmutableDBEnv@,
+-- we return a @SomePair@ here that returns the open state along with a 'HasFS'
+-- instance for the /same/ type parameter @h@. Note that it would be impossible
+-- to use an existing 'HasFS' instance already in scope otherwise, since the
+-- @h@ parameters would not be known to match.
 getOpenState :: (HasCallStack, MonadSTM m)
              => ImmutableDBEnv m
              -> m (SomePair (HasFS m) OpenState)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
@@ -80,7 +80,7 @@ indexExpectedFileSize (MkIndex offsets) = V.length offsets * indexEntrySizeBytes
 -- Returns trailing invalid data that could not be read as @'Maybe'
 -- 'ByteString'@.
 loadIndex :: (HasCallStack, MonadMask m)
-          => HasFS m
+          => HasFS m h
           -> FsPath
           -> Epoch
           -> m (Index, Maybe ByteString)
@@ -104,7 +104,7 @@ loadIndex hasFS dbFolder epoch = do
 --
 -- > index === index' .&&. isNothing mbJunk
 writeIndex :: MonadMask m
-           => HasFS m
+           => HasFS m h
            -> FsPath
            -> Epoch
            -> Index
@@ -130,7 +130,7 @@ writeIndex hasFS@HasFS{..} dbFolder epoch (MkIndex offsets) = do
 --
 -- > indexToSlotOffsets index === offsets
 writeSlotOffsets :: MonadMask m
-                 => HasFS m
+                 => HasFS m h
                  -> FsPath
                  -> Epoch
                  -> NonEmpty SlotOffset

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Util.hs
@@ -73,7 +73,7 @@ parseDBFile s = case T.splitOn "-" . fst . T.breakOn "." . T.pack $ s of
 -- | Read all the data from the given file handle 64kB at a time.
 --
 -- TODO move to Ouroboros.Storage.FS.Class?
-readAll :: Monad m => HasFS m -> FsHandle m -> m BS.Builder
+readAll :: Monad m => HasFS m h -> h -> m BS.Builder
 readAll HasFS{..} hnd = go mempty
   where
     bufferSize = 64 * 1024
@@ -89,8 +89,8 @@ readAll HasFS{..} hnd = go mempty
 --
 -- TODO move to Ouroboros.Storage.FS.Class?
 hGetRightSize :: (HasCallStack, Monad m)
-              => HasFS m
-              -> FsHandle m
+              => HasFS m h
+              -> h
               -> Int     -- ^ The number of bytes to read.
               -> FsPath  -- ^ The file corresponding with the handle, used for
                          -- error reporting

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 
@@ -65,17 +66,19 @@ sameVolatileDBError e1 e2 = case (e1, e2) of
     (InvalidArgumentsError _, InvalidArgumentsError _) -> True
     _ -> False
 
-sameParseError :: Eq blockId => ParserError blockId -> ParserError blockId -> Bool
+-- TODO: Why is this not comparing the arguments to 'DuplicatedSlot'?
+sameParseError :: ParserError blockId -> ParserError blockId -> Bool
 sameParseError e1 e2 = case (e1, e2) of
-    (DuplicatedSlot _, DuplicatedSlot _) -> True
+    (DuplicatedSlot _, DuplicatedSlot _)               -> True
     (SlotsPerFileError _ _ _, SlotsPerFileError _ _ _) -> True
-    (InvalidFilename str1, InvalidFilename str2) -> str1 == str2
-    (DecodeFailed _ _, DecodeFailed _ _) -> True
-    _ -> False
+    (InvalidFilename str1, InvalidFilename str2)       -> str1 == str2
+    (DecodeFailed _ _, DecodeFailed _ _)               -> True
+    _                                                  -> False
 
 -- TODO(kde) unify/move/replace
 newtype Parser m blockId = Parser {
-    parse       :: HasFS m
+    parse       :: forall h.
+                   HasFS m h
                 -> ErrorHandling (VolatileDBError blockId) m
                 -> [String]
                 -> m (Int64, Map Int64 (Int, blockId))

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
@@ -150,13 +150,13 @@ data Success fp h =
   deriving (Eq, Show, Functor, Foldable)
 
 -- | Successful semantics
-run :: forall m. Monad m
-    => HasFS m
-    -> Cmd FsPath (FsHandle m)
-    -> m (Success FsPath (FsHandle m))
+run :: forall m h. Monad m
+    => HasFS m h
+    -> Cmd FsPath h
+    -> m (Success FsPath h)
 run HasFS{..} = go
   where
-    go :: Cmd FsPath (FsHandle m) -> m (Success FsPath (FsHandle m))
+    go :: Cmd FsPath h -> m (Success FsPath h)
     go (Open pe mode) =
         case mode of
           IO.ReadMode -> withPE pe (\_ -> RHandle) $ \fp -> hOpen fp mode
@@ -176,9 +176,9 @@ run HasFS{..} = go
     go (RemoveFile         pe  ) = withPE pe (const Unit)    $ removeFile
 
     withPE :: PathExpr FsPath
-           -> (FsPath -> a -> Success FsPath (FsHandle m))
+           -> (FsPath -> a -> Success FsPath h)
            -> (FsPath -> m a)
-           -> m (Success FsPath (FsHandle m))
+           -> m (Success FsPath h)
     withPE pe r f = let fp = evalPathExpr pe in r fp <$> f fp
 
 {-------------------------------------------------------------------------------
@@ -204,7 +204,7 @@ runPure cmd mockFS =
     aux (Left e)             = (Resp (Left e), mockFS)
     aux (Right (r, mockFS')) = (Resp (Right r), mockFS')
 
-runIO :: MountPoint -> Cmd FsPath (FsHandle IO) -> IO (Resp FsPath (FsHandle IO))
+runIO :: MountPoint -> Cmd FsPath HandleIO -> IO (Resp FsPath HandleIO)
 runIO mount cmd = Resp <$> E.try (run (ioHasFS mount) cmd)
 
 {-------------------------------------------------------------------------------
@@ -241,10 +241,10 @@ handles = bifoldMap (const []) (:[])
 type PathRef = QSM.Reference FsPath
 
 -- | Concrete or symbolic reference to an IO file handle
-type HandleRef = QSM.Reference (QSM.Opaque (FsHandle IO))
+type HandleRef = QSM.Reference (QSM.Opaque HandleIO)
 
 -- | Mapping between real IO file handles and mock file handles
-type KnownHandles = RefEnv (QSM.Opaque (FsHandle IO)) Mock.Handle
+type KnownHandles = RefEnv (QSM.Opaque HandleIO) Mock.Handle
 
 -- | Mapping between path references and paths
 type KnownPaths = RefEnv FsPath FsPath
@@ -865,7 +865,7 @@ prop_sequential tmpDir =
 
       -- | Close all open handles and delete the temp directory
       liftIO $ do
-        forM_ (RE.keys (knownHandles model)) $ F.close . snd . QSM.opaque
+        forM_ (RE.keys (knownHandles model)) $ F.close . handleIO . QSM.opaque
         removeDirectoryRecursive tstTmpDir
 
       QSM.prettyCommands sm' hist

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -21,15 +21,15 @@ import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import           Data.Map (Map)
 import qualified Data.Map.Strict as M
-import           Data.Maybe (fromMaybe, maybeToList, isNothing)
+import           Data.Maybe (fromMaybe, isNothing, maybeToList)
 import           Data.Word (Word64)
 
 import qualified System.IO as IO
 
-import           Test.Ouroboros.Storage.ImmutableDB.Sim (demoScript)
-import qualified Test.Ouroboros.Storage.ImmutableDB.TestBlock as TestBlock
-import qualified Test.Ouroboros.Storage.ImmutableDB.StateMachine as StateMachine
 import qualified Test.Ouroboros.Storage.ImmutableDB.CumulEpochSizes as CumulEpochSizes
+import           Test.Ouroboros.Storage.ImmutableDB.Sim (demoScript)
+import qualified Test.Ouroboros.Storage.ImmutableDB.StateMachine as StateMachine
+import qualified Test.Ouroboros.Storage.ImmutableDB.TestBlock as TestBlock
 import           Test.Ouroboros.Storage.Util
 import           Test.QuickCheck
 import           Test.QuickCheck.Monadic (monadicIO, pick, run)
@@ -87,7 +87,7 @@ tests = testGroup "ImmutableDB"
 
 -- Shorthand
 withTestDB :: (HasCallStack, MonadSTM m, MonadMask m)
-           => HasFS m
+           => HasFS m h
            -> ErrorHandling ImmutableDBError m
            -> Map Epoch EpochSize
            -> (ImmutableDB m -> m a)
@@ -570,7 +570,7 @@ prop_writeIndex_loadIndex index =
       (index', mbJunk) <- loadIndex hasFS dbFolder epoch
       return $ index === index' .&&. isNothing mbJunk
 
-    hasFS :: HasFS (SimFS IO)
+    hasFS :: HasFS (SimFS IO) Mock.Handle
     hasFS = Sim.simHasFS EH.exceptions
 
     runS :: SimFS IO Property -> IO Property
@@ -593,7 +593,7 @@ prop_writeSlotOffsets_loadIndex_indexToSlotOffsets (SlotOffsets offsets) =
       (index, mbJunk) <- loadIndex hasFS dbFolder epoch
       return $ indexToSlotOffsets index === offsets .&&. isNothing mbJunk
 
-    hasFS :: HasFS (SimFS IO)
+    hasFS :: HasFS (SimFS IO) Mock.Handle
     hasFS = Sim.simHasFS EH.exceptions
 
     runS :: SimFS IO Property -> IO Property

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -7,7 +7,7 @@ module Test.Ouroboros.Storage.ImmutableDB (tests) where
 
 import           Control.Monad (void)
 import           Control.Monad.Catch (MonadMask)
-import           Control.Monad.Class.MonadSTM (MonadSTM)
+import           Control.Monad.Class.MonadSTM
 
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -43,7 +43,6 @@ import           Ouroboros.Storage.FS.Sim.FsTree (FsTree (..))
 import qualified Ouroboros.Storage.FS.Sim.FsTree as FS
 import           Ouroboros.Storage.FS.Sim.MockFS (MockFS)
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
-import           Ouroboros.Storage.FS.Sim.STM (SimFS)
 import qualified Ouroboros.Storage.FS.Sim.STM as Sim
 import           Ouroboros.Storage.ImmutableDB
 import           Ouroboros.Storage.ImmutableDB.Index
@@ -96,11 +95,11 @@ withTestDB hasFS err epochSizes f =
     withDB (openDB hasFS err ["test"] 0 epochSizes NoValidation) (\db _ -> f db)
 
 withSimTestDB :: Map Epoch EpochSize
-              -> (ImmutableDB (SimFS IO) -> SimFS IO a)
-              -> SimFS IO a
-withSimTestDB = withTestDB
-                  (Sim.simHasFS     EH.exceptions)
-                  (Sim.liftErrSimFS EH.exceptions)
+              -> (ImmutableDB IO -> IO a)
+              -> IO a
+withSimTestDB epochSizes f = do
+    fsVar <- atomically $ newTVar Mock.empty
+    withTestDB (Sim.simHasFS EH.exceptions fsVar) EH.exceptions epochSizes f
 
 {------------------------------------------------------------------------------
   Builder
@@ -155,7 +154,7 @@ instance Arbitrary AppendAndGet where
 prop_appendAndGet :: AppendAndGet -> Property
 prop_appendAndGet (AppendAndGet append get) = label labelToApply $
     monadicIO $ do
-      r <- run $ tryImmDB $ Sim.runSimFS script Mock.empty
+      r <- run $ tryImmDB script
       assertion r
   where
     script = withSimTestDB (M.singleton 0 epochSize) $ \db -> do
@@ -198,22 +197,22 @@ prop_appendAndGet (AppendAndGet append get) = label labelToApply $
       | get == firstAppend
       = ("get the first blob from the first epoch",
          \case
-            Right (Just b, _) | b == "first" -> return ()
+            Right (Just b) | b == "first" -> return ()
             r -> fail ("Expected Just \"first\", got: " ++ show r))
       | get == secondAppend
       = ("get the second blob from the second epoch",
          \case
-            Right (Just b, _) | b == "second" -> return ()
+            Right (Just b) | b == "second" -> return ()
             r -> fail ("Expected Just \"second\", got: " ++ show r))
       | get == EpochSlot 1 append
       = ("get the append blob from the second epoch",
          \case
-            Right (Just b, _) | b == "haskell" -> return ()
+            Right (Just b) | b == "haskell" -> return ()
             r -> fail ("Expected Just \"haskell\", got: " ++ show r))
       | otherwise
       = ("get a missing slot from an epoch",
          \case
-            Right (Nothing, _) -> return ()
+            Right Nothing -> return ()
             r -> fail ("Expected Nothing, got: " ++ show r))
 
 test_appendAndGet :: Assertion
@@ -509,7 +508,7 @@ prop_iterator IteratorContentsAndRange {..} = monadicIO $ do
         script        = withSimTestDB (M.singleton 0 fixedEpochSize) $ \db -> do
                           executeDBActions db _dbActions
                           withIterator db (Just _start) (Just _end) iteratorToList
-    r <- run $ tryImmDB $ Sim.runSimFS script Mock.empty
+    r <- run $ tryImmDB script
     case r of
       Left (UserError (SlotGreaterThanEpochSizeError {}) _)
         |  getRelativeSlot (_relativeSlot _start) >= fixedEpochSize
@@ -522,7 +521,7 @@ prop_iterator IteratorContentsAndRange {..} = monadicIO $ do
         | _start > lastAppended || _end > lastAppended
         -> return ()
       Left e -> fail $ prettyImmutableDBError e
-      Right (actualBlobs, _) | actualBlobs /= expectedBlobs
+      Right actualBlobs | actualBlobs /= expectedBlobs
         -> fail ("Expected: " <> show expectedBlobs <> " but got: " <>
                  show actualBlobs)
       Right _ -> return ()
@@ -564,18 +563,15 @@ prop_writeIndex_loadIndex index =
     dbFolder = []
     epoch = 0
 
-    prop :: SimFS IO Property
-    prop = do
+    prop :: HasFS IO h -> IO Property
+    prop hasFS = do
       writeIndex hasFS dbFolder epoch index
       (index', mbJunk) <- loadIndex hasFS dbFolder epoch
       return $ index === index' .&&. isNothing mbJunk
 
-    hasFS :: HasFS (SimFS IO) Mock.Handle
-    hasFS = Sim.simHasFS EH.exceptions
-
-    runS :: SimFS IO Property -> IO Property
+    runS :: (HasFS IO Mock.Handle -> IO Property) -> IO Property
     runS m = do
-        r <- tryFS (Sim.runSimFS m Mock.empty)
+        r <- tryFS (Sim.runSimFS EH.exceptions Mock.empty m)
         case r of
           Left  e      -> fail (prettyFsError e)
           Right (p, _) -> return p
@@ -587,18 +583,15 @@ prop_writeSlotOffsets_loadIndex_indexToSlotOffsets (SlotOffsets offsets) =
     dbFolder = []
     epoch = 0
 
-    prop :: SimFS IO Property
-    prop = do
+    prop :: HasFS IO h -> IO Property
+    prop hasFS = do
       writeSlotOffsets hasFS dbFolder epoch offsets
       (index, mbJunk) <- loadIndex hasFS dbFolder epoch
       return $ indexToSlotOffsets index === offsets .&&. isNothing mbJunk
 
-    hasFS :: HasFS (SimFS IO) Mock.Handle
-    hasFS = Sim.simHasFS EH.exceptions
-
-    runS :: SimFS IO Property -> IO Property
+    runS :: (HasFS IO Mock.Handle -> IO Property) -> IO Property
     runS m = do
-        r <- tryFS (Sim.runSimFS m Mock.empty)
+        r <- tryFS (Sim.runSimFS EH.exceptions Mock.empty m)
         case r of
           Left  e      -> fail (prettyFsError e)
           Right (p, _) -> return p

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
@@ -20,7 +20,7 @@ module Test.Ouroboros.Storage.ImmutableDB.TestBlock
   , tests
   ) where
 
-import           Control.Monad (void, when, replicateM, forM)
+import           Control.Monad (forM, replicateM, void, when)
 import           Control.Monad.Catch (MonadMask)
 
 import qualified Data.Binary as Bin
@@ -33,7 +33,7 @@ import           Data.Word (Word64)
 
 import           GHC.Generics (Generic)
 
-import           System.IO (IOMode(..))
+import           System.IO (IOMode (..))
 
 import           Test.QuickCheck
 import qualified Test.QuickCheck.Monadic as QCM
@@ -41,7 +41,7 @@ import qualified Test.StateMachine.Utils as QSM
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Ouroboros.Storage.FS.API (HasFS(..), withFile)
+import           Ouroboros.Storage.FS.API (HasFS (..), withFile)
 import           Ouroboros.Storage.FS.API.Types (FsPath)
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import           Ouroboros.Storage.FS.Sim.STM (SimFS, runSimFS, simHasFS)
@@ -108,7 +108,7 @@ testBlockToBuilder = BS.lazyByteString . Bin.encode
 -------------------------------------------------------------------------------}
 
 testBlockEpochFileParser :: MonadMask m
-                         => HasFS m
+                         => HasFS m h
                          -> EpochFileParser String m TestBlock
 testBlockEpochFileParser hasFS@HasFS{..} = EpochFileParser $ \fsPath ->
     withFile hasFS fsPath ReadMode $ \eHnd -> do
@@ -133,7 +133,7 @@ testBlockEpochFileParser hasFS@HasFS{..} = EpochFileParser $ \fsPath ->
             in parse bytesInFile newOffset newParsed remaining
 
 testBlockEpochFileParser' :: MonadMask m
-                          => HasFS m
+                          => HasFS m h
                           -> EpochFileParser String m (Int, RelativeSlot)
 testBlockEpochFileParser' hasFS = (\tb -> (testBlockSize, tbRelativeSlot tb)) <$>
     testBlockEpochFileParser hasFS
@@ -176,7 +176,7 @@ data FileCorruption
 
 -- | Returns 'True' when something was actually corrupted. For example, when
 -- drop the last bytes of an empty file, we don't actually corrupt it.
-corruptFile :: MonadMask m => HasFS m -> FileCorruption -> FsPath -> m Bool
+corruptFile :: MonadMask m => HasFS m h -> FileCorruption -> FsPath -> m Bool
 corruptFile hasFS@HasFS{..} fc file = case fc of
     DeleteFile              -> removeFile file $> True
     DropLastBytes n         -> withFile hasFS file AppendMode $ \hnd -> do

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -18,9 +18,9 @@ import           Data.ByteString.Lazy (toStrict)
 import           Data.Map (Map)
 import qualified Data.Map as Map
 
-import           Ouroboros.Storage.VolatileDB.API
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+import           Ouroboros.Storage.VolatileDB.API
 
 data DBModel blockId = DBModel {
       open           :: Bool
@@ -36,7 +36,7 @@ initDBModel = DBModel {
 }
 
 openDBModel :: MonadState (DBModel blockId) m
-            => (Ord blockId, Show blockId)
+            => (Ord blockId)
             => ErrorHandling (VolatileDBError blockId) m
             -> (DBModel blockId, VolatileDB blockId m)
 openDBModel err = (dbModel, db)
@@ -66,7 +66,7 @@ reOpenModel = do
     dbm <- get
     put $ dbm {open = True}
 
-getBlockModel :: forall m blockId. (MonadState (DBModel blockId) m, Ord blockId, Show blockId)
+getBlockModel :: forall m blockId. (MonadState (DBModel blockId) m, Ord blockId)
               => ErrorHandling (VolatileDBError blockId) m
               -> blockId
               -> m (Maybe ByteString)
@@ -89,7 +89,6 @@ putBlockModel err sl bs = do
         Just _bs -> return ()
 
 garbageCollectModel :: MonadState (DBModel blockId) m
-                    => Ord blockId
                     => ErrorHandling (VolatileDBError blockId) m
                     -> Slot
                     -> m ()
@@ -99,5 +98,5 @@ garbageCollectModel err sl = do
     else put dbm {latestGarbaged = Just $ maxMaybe latestGarbaged sl}
 
 maxMaybe :: Ord slot => Maybe slot -> slot -> slot
-maxMaybe Nothing sl = sl
+maxMaybe Nothing sl    = sl
 maxMaybe (Just sl') sl = max sl' sl

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -1,18 +1,18 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DeriveTraversable    #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE FlexibleInstances    #-}
-{-# LANGUAGE GADTs                #-}
-{-# LANGUAGE KindSignatures       #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE RecordWildCards      #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DeriveTraversable   #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Test.Ouroboros.Storage.VolatileDB.StateMachine (tests) where
@@ -29,8 +29,8 @@ import           Data.Functor.Classes
 import           Data.Kind (Type)
 import           Data.TreeDiff (ToExpr)
 import           Data.TreeDiff.Class
-import           GHC.Stack
 import           GHC.Generics
+import           GHC.Stack
 import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
 import           Test.StateMachine
@@ -41,9 +41,9 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import           Ouroboros.Storage.FS.Sim.STM
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import           Ouroboros.Storage.VolatileDB.API
 import           Ouroboros.Storage.VolatileDB.Impl (openDB)
-import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import           Test.Ouroboros.Storage.Util
 import           Test.Ouroboros.Storage.VolatileDB.Model
 
@@ -99,19 +99,19 @@ instance ToExpr (Model r) where
 
 instance CommandNames (At Cmd) where
     cmdName (At cmd) = case cmd of
-        GetBlock _ -> "GetBlock"
-        PutBlock _ -> "PutBlock"
+        GetBlock _       -> "GetBlock"
+        PutBlock _       -> "PutBlock"
         GarbageCollect _ -> "GarbageCollect"
-        IsOpen -> "IsOpen"
-        Close -> "Close"
-        ReOpen -> "ReOpen"
+        IsOpen           -> "IsOpen"
+        Close            -> "Close"
+        ReOpen           -> "ReOpen"
     cmdNames _ = ["not", "suported", "yet"]
 
 data Model (r :: Type -> Type) = Model
-  { dbModel     :: DBModel MyBlockId
+  { dbModel :: DBModel MyBlockId
     -- ^ A model of the database, used as state for the 'HasImmutableDB'
     -- instance of 'ModelDB'.
-  , mockDB      :: ModelDBPure
+  , mockDB  :: ModelDBPure
     -- ^ A handle to the mocked database.
   } deriving (Generic)
 
@@ -135,8 +135,8 @@ data Event r = Event
   , eventMockResp :: Resp
   } deriving (Show)
 
-lockstep :: forall r. (Show1 r, Eq1 r)
-         => Model   r
+lockstep :: forall r.
+            Model   r
          -> At Cmd  r
          -> At Resp r
          -> Event   r
@@ -151,10 +151,10 @@ lockstep model@Model {..} (At cmd) (At _resp) = Event
     model' = model {dbModel = dbModel'}
 
 -- | Key property of the model is that we can go from real to mock responses
-toMock :: Eq1 r => Model r -> At t r -> t
+toMock :: Model r -> At t r -> t
 toMock _ (At t) = t
 
-step :: Eq1 r => Model r -> At Cmd r -> (Resp, DBModel MyBlockId)
+step :: Model r -> At Cmd r -> (Resp, DBModel MyBlockId)
 step model@Model{..} cmd = runPure dbModel mockDB (toMock model cmd)
 
 runPure :: DBModel MyBlockId
@@ -197,7 +197,7 @@ initModelImpl dbm vdm = Model {
     , mockDB = vdm
     }
 
-transitionImpl :: (Show1 r, Eq1 r) => Model r -> At Cmd r -> At Resp r -> Model r
+transitionImpl :: Model r -> At Cmd r -> At Resp r -> Model r
 transitionImpl model cmd = eventAfter . lockstep model cmd
 
 preconditionImpl :: Model Symbolic -> At Cmd Symbolic -> Logic
@@ -243,7 +243,7 @@ knownLimitation model (At cmd) = case cmd of
     ReOpen -> Bot
     where
         isLimitation :: (Show slot, Ord slot) => Maybe slot -> slot -> Logic
-        isLimitation Nothing _sl = Bot
+        isLimitation Nothing _sl       = Bot
         isLimitation (Just slot') slot = slot' .>  slot
 
 mkDBModel :: MonadState (DBModel MyBlockId) m => (DBModel MyBlockId, VolatileDB MyBlockId (ExceptT (VolatileDBError MyBlockId) m))


### PR DESCRIPTION
This is really just preparation for being able to get rid of `exceptions`, but it's a useful refactoring in its own right; these were remnants of the days where we had a monad-oriented approach rather than a record-based approach.