### PR TITLE
Do not require ouroboros-network in ouroboros-network:tests

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -105,17 +105,47 @@ library
 
 test-suite tests
   type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
+  hs-source-dirs:      test src
   main-is:             Main.hs
-  other-modules:       Test.Chain
+  other-modules:       Ouroboros.Network.Testing.ConcreteBlock
+                       Ouroboros.Network.Block
+                       Ouroboros.Network.Chain
+                       Ouroboros.Network.ChainFragment
+                       Ouroboros.Network.ChainProducerState
+                       Ouroboros.Network.Channel
+                       Ouroboros.Network.Codec
+                       Ouroboros.Network.Mux
+                       Ouroboros.Network.Mux.Egress
+                       Ouroboros.Network.Mux.Ingress
+                       Ouroboros.Network.Mux.Types
+                       Ouroboros.Network.Node
+                       Ouroboros.Network.Pipe
+                       Ouroboros.Network.Protocol.BlockFetch.Client
+                       Ouroboros.Network.Protocol.BlockFetch.Codec
+                       Ouroboros.Network.Protocol.BlockFetch.Direct
+                       Ouroboros.Network.Protocol.BlockFetch.Examples
+                       Ouroboros.Network.Protocol.BlockFetch.Server
+                       Ouroboros.Network.Protocol.BlockFetch.Type
+                       Ouroboros.Network.Protocol.BlockFetch.Test
+                       Ouroboros.Network.Protocol.ChainSync.Client
+                       Ouroboros.Network.Protocol.ChainSync.Codec
+                       Ouroboros.Network.Protocol.ChainSync.Direct
+                       Ouroboros.Network.Protocol.ChainSync.Examples
+                       Ouroboros.Network.Protocol.ChainSync.Server
+                       Ouroboros.Network.Protocol.ChainSync.Type
+                       Ouroboros.Network.Protocol.ChainSync.Test
+                       Ouroboros.Network.Protocol.PingPong.Codec
+                       Ouroboros.Network.Protocol.PingPong.Test
+                       Ouroboros.Network.Protocol.ReqResp.Codec
+                       Ouroboros.Network.Protocol.ReqResp.Test
+                       Ouroboros.Network.Serialise
+                       Ouroboros.Network.Socket
+
+                       Test.Chain
                        Test.ChainGenerators
                        Test.ChainFragment
                        Test.ChainProducerState
                        Test.Ouroboros.Network.Testing.Utils
-                       Test.Ouroboros.Network.Protocol.ChainSync
-                       Test.Ouroboros.Network.Protocol.PingPong
-                       Test.Ouroboros.Network.Protocol.ReqResp
-                       Test.Ouroboros.Network.Protocol.BlockFetch
                        Test.Ouroboros.Network.Node
                        Test.Mux
                        Test.Pipe
@@ -123,20 +153,22 @@ test-suite tests
   default-language:    Haskell2010
   default-extensions:  NamedFieldPuns
   build-depends:       base,
-                       ouroboros-network,
                        typed-protocols,
                        io-sim-classes,
                        io-sim            >=0.1 && < 0.2,
 
                        array,
                        async,
+                       binary,
                        bytestring,
                        cborg,
                        containers,
                        free,
                        fingertree,
                        free,
+                       hashable,
                        mtl,
+                       network,
                        pipes,
                        process,
                        QuickCheck,
@@ -146,4 +178,5 @@ test-suite tests
                        text
 
   ghc-options:         -Wall
+                       -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -4,7 +4,7 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Ouroboros.Network.Protocol.BlockFetch where
+module Ouroboros.Network.Protocol.BlockFetch.Test (tests) where
 
 import           Control.Monad.ST (runST)
 import           Data.ByteString.Lazy (ByteString)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -7,7 +7,7 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Ouroboros.Network.Protocol.ChainSync where
+module Ouroboros.Network.Protocol.ChainSync.Test (tests) where
 
 import Control.Monad (unless, void)
 import qualified Control.Monad.ST as ST

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/PingPong/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/PingPong/Test.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE FlexibleInstances   #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Ouroboros.Network.Protocol.PingPong (tests) where
+module Ouroboros.Network.Protocol.PingPong.Test (tests) where
 
 import           Control.Monad.ST (runST)
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ReqResp/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ReqResp/Test.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE FlexibleInstances   #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Ouroboros.Network.Protocol.ReqResp (tests) where
+module Ouroboros.Network.Protocol.ReqResp.Test (tests) where
 
 import           Control.Monad.ST (runST)
 

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -9,10 +9,10 @@ import qualified Test.ChainProducerState (tests)
 import qualified Test.Mux (tests)
 import qualified Test.Pipe (tests)
 import qualified Test.Ouroboros.Network.Node (tests)
-import qualified Test.Ouroboros.Network.Protocol.ChainSync (tests)
-import qualified Test.Ouroboros.Network.Protocol.BlockFetch (tests)
-import qualified Test.Ouroboros.Network.Protocol.PingPong (tests)
-import qualified Test.Ouroboros.Network.Protocol.ReqResp (tests)
+import qualified Ouroboros.Network.Protocol.ChainSync.Test (tests)
+import qualified Ouroboros.Network.Protocol.BlockFetch.Test (tests)
+import qualified Ouroboros.Network.Protocol.PingPong.Test (tests)
+import qualified Ouroboros.Network.Protocol.ReqResp.Test (tests)
 import qualified Test.Socket (tests)
 
 main :: IO ()
@@ -29,8 +29,8 @@ tests =
   , Test.Pipe.tests
   , Test.Socket.tests
   , Test.Ouroboros.Network.Node.tests
-  , Test.Ouroboros.Network.Protocol.ChainSync.tests
-  , Test.Ouroboros.Network.Protocol.BlockFetch.tests
-  , Test.Ouroboros.Network.Protocol.PingPong.tests
-  , Test.Ouroboros.Network.Protocol.ReqResp.tests
+  , Ouroboros.Network.Protocol.ChainSync.Test.tests
+  , Ouroboros.Network.Protocol.BlockFetch.Test.tests
+  , Ouroboros.Network.Protocol.PingPong.Test.tests
+  , Ouroboros.Network.Protocol.ReqResp.Test.tests
   ]


### PR DESCRIPTION
When working on tests it is easier when each module is picked directly,
this way one does not need to re-start ghci / ghcid sessions when
modifying a ouroboros-network library when working on tests.