### PR TITLE
Byron proxy works with new ImmutableDB indexing scheme

### DIFF
--- a/byron-proxy/byron-proxy.cabal
+++ b/byron-proxy/byron-proxy.cabal
@@ -14,7 +14,8 @@ extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
 
 library
-  exposed-modules:     Ouroboros.Byron.Proxy.Types,
+  exposed-modules:     Ouroboros.Byron.Proxy.DB,
+                       Ouroboros.Byron.Proxy.Types,
                        Ouroboros.Byron.Proxy.Index
   -- other-modules:
   -- other-extensions:
@@ -29,6 +30,7 @@ library
                        cardano-sl-db,
                        cardano-sl-infra,
                        cardano-sl-util,
+                       cborg,
                        conduit,
                        containers,
                        cryptonite,
@@ -42,6 +44,7 @@ library
                        ouroboros-consensus,
                        ouroboros-network,
                        random,
+                       resourcet,
                        sqlite-simple,
                        stm,
                        tagged,
@@ -66,9 +69,11 @@ executable byron-proxy
                        cardano-sl-db,
                        cardano-sl-infra,
                        cardano-sl-util,
+                       cborg,
                        containers,
                        directory,
                        iohk-monitoring,
+                       io-sim-classes,
                        lens,
                        optparse-applicative,
                        ouroboros-consensus,

--- a/byron-proxy/src/lib/Ouroboros/Byron/Proxy/DB.hs
+++ b/byron-proxy/src/lib/Ouroboros/Byron/Proxy/DB.hs
@@ -1,0 +1,495 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GADTSyntax #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Byron.Proxy.DB where
+
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Write as CBOR
+
+import Control.Exception (Exception, bracket)
+import Control.Lens ((^.))
+import qualified Control.Lens as Lens (to)
+import Control.Monad (unless)
+import Control.Monad.Class.MonadST (MonadST)
+import Control.Monad.Class.MonadThrow (MonadThrow)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Resource (ResourceT, runResourceT)
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as Lazy (ByteString, fromStrict, null)
+import Data.ByteString.Builder (Builder)
+import Data.Conduit (ConduitT)
+import qualified Data.Conduit as Conduit
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
+import Data.Text (Text)
+
+import qualified Pos.Binary as CSL (decode, deserialize', serialize')
+import qualified Pos.Chain.Block as CSL
+import qualified Pos.Core.Slotting as CSL
+
+import Ouroboros.Byron.Proxy.Index (Index, IndexWrite)
+import qualified Ouroboros.Byron.Proxy.Index as Index
+import Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr)
+import Ouroboros.Storage.ImmutableDB.API (ImmutableDB, Epoch (..), Slot (..))
+import qualified Ouroboros.Storage.ImmutableDB.API as Immutable
+import Ouroboros.Storage.ImmutableDB.Util (cborEpochFileParser')
+import Ouroboros.Storage.FS.API (HasFS)
+
+-- Combines an `ImmutableDB` and an `Index` into a system for appending and
+-- reading cardano-sl `Block`s, with special care for epoch-boundary-blocks
+-- (EBBs) and the genesis block, which are packed alongside the first block of
+-- an epoch (if it exists).
+--
+-- Slots in the immutable DB are filled with tagged serialized blocks. There
+-- are 3 possibilities:
+--   - An EBB
+--   - A main block
+--   - An EBB followed by a main block.
+-- This is expressed by the `Block` type in this module.
+--
+-- Since there is at most one append per slot in the `ImmutableDB`, the
+-- EBBs cannot be written immediately, because the next block may also be
+-- for that slot. The DB abstraction here takes care of this, holding the
+-- most-recently-appended EBB in memory until the next block is appended, at
+-- which point that EBB is appended to the proper spot, possibly alongside
+-- the next block if it's for the first slot of that epoch.
+--
+-- The DB does not allow for concurrent writes, but does admit concurrent
+-- reads (alongside other reads and alongside writes).
+--
+-- For reading, the unwritten EBB, if there is one, will not be given by the
+-- conduit. It will be given only after it has been put into the ImmutableDB.
+-- It will, however, be given as the tip by `readTip`. There is therefore
+-- always a tip-of-chain, even if the actual on-disk database is empty.
+--
+-- Serialized blocks are read in a streaming style, by giving a start point,
+-- which is either a header hash (to support Byron style) or a slot (the new
+-- style). Conduit is used because the cardano-sl library also uses it. To
+-- make it work with the `ImmutableDB` iterator API, we have to use the
+-- `ResourceT` thing. Hopefully it all works out.
+
+-- | The type which is written to a slot in the ImmutableDB. It can be a block,
+-- an EBB, or both (EBBs do not necessarily take a whole slot).
+data Block ebb blk where
+  EBB   :: ebb -> Block ebb blk
+  Block :: blk -> Block ebb blk
+  Both  :: ebb -> blk -> Block ebb blk
+
+-- | Use an 8-bit word tag to discriminate between the 3 constructors of
+-- `Block`. If it's `Both`, the EBB encoding is appended after the block.
+--
+-- TODO do we need to use CBOR lists, or is this ok?
+encode
+  :: (ebb -> CBOR.Encoding)
+  -> (blk -> CBOR.Encoding)
+  -> (Block ebb blk -> CBOR.Encoding)
+encode encEbb encBlk block = case block of
+  EBB   ebb     -> CBOR.encodeWord8 0 <> encEbb ebb
+  Block blk     -> CBOR.encodeWord8 1 <> encBlk blk
+  Both  ebb blk -> CBOR.encodeWord8 2 <> encEbb ebb <> encBlk blk
+
+decode
+  :: CBOR.Decoder s ebb
+  -> CBOR.Decoder s blk
+  -> CBOR.Decoder s (Block ebb blk)
+decode decEbb decBlk = do
+  tag <- CBOR.decodeWord8
+  case tag of
+    0 -> EBB   <$> decEbb
+    1 -> Block <$> decBlk
+    2 -> Both  <$> decEbb <*> decBlk
+    _ -> fail "expected 8-bit word tag"
+
+-- | Run a Decoder and fail if it does not consume all of the input bytes.
+decodeFull
+  :: (forall s . CBOR.Decoder s t)
+  -> Lazy.ByteString
+  -> Either CBOR.DeserialiseFailure t
+decodeFull decoder lbs = case CBOR.deserialiseFromBytesWithSize decoder lbs of
+  Left failure -> Left failure
+  Right (bs, offset, t) ->
+    if Lazy.null bs
+    then Right t
+    else Left (CBOR.DeserialiseFailure offset "decodeFull: did not consume all input")
+
+-- | Decode a `Block ByteString ByteString`. The `ByteString`(s) are encoded
+-- genesis or main blocks.
+decodeSerialisedBlock
+  :: Lazy.ByteString
+  -> Either CBOR.DeserialiseFailure (Block ByteString ByteString)
+decodeSerialisedBlock = decodeFull decoder
+  where
+  decoder :: CBOR.Decoder s (Block ByteString ByteString)
+  decoder = decode CBOR.decodeBytes CBOR.decodeBytes
+
+-- | Encode a `Block ByteString ByteString` where the bytes are serialized
+-- genesis or main blocks.
+encodeSerialisedBlock :: Block ByteString ByteString -> Builder
+encodeSerialisedBlock = CBOR.toBuilder . encoding
+  where
+  encoding = encode CBOR.encodeBytes CBOR.encodeBytes
+
+-- | Parser for opening the `ImmutableDB`. It uses a CBOR decoder which decodes
+-- a `Block` and returns its `Slot`, which is `epoch * epochSlots` in
+-- case it's a genesis/EBB.
+--
+-- It does not check consistency of genesis/EBBs: that if they appear alongside
+-- a main block, the main block is for slot 0 of the same epoch as the EBB
+epochFileParser
+  :: ( MonadST m, MonadThrow m )
+  => CSL.SlotCount
+  -> HasFS m h
+  -> Immutable.EpochFileParser ReadIncrementalErr m (Word, Immutable.Slot)
+epochFileParser epochSlots hasFS = cborEpochFileParser' hasFS decoder
+  where
+  decoder :: forall s . CBOR.Decoder s Immutable.Slot
+  decoder = do
+    -- Each piece is a DB.Block, with the encoded GenesisBlock (EBB) or
+    -- MainBlock in it. This decoder reads the whole thing, then decodes
+    -- those bytes to determine the slot.
+    blkBytes <- decode CBOR.decodeBytes CBOR.decodeBytes
+    -- Make a cardano-sl `Block` from the `Block` by favouring the main block,
+    -- if it's there.
+    blk :: CSL.Block <- case blkBytes of
+      EBB   bs    -> Left  <$> CSL.deserialize' bs
+      Block bs    -> Right <$> CSL.deserialize' bs
+      Both  _  bs -> Right <$> CSL.deserialize' bs
+    pure (blockHeaderSlot epochSlots (CSL.getBlockHeader blk))
+
+-- | Identifies a block in the DB: by slot or by header hash.
+data Point where
+  ByHash :: CSL.HeaderHash -> Point
+  BySlot :: Slot           -> Point
+
+-- | Unified database interface which supports lookup by hash or by slot.
+data DB m = DB
+  { -- | Append 0 or more blocks within the continuation.
+    appendBlocks :: forall t . (DBAppend m -> m t) -> m t
+    -- | Stream serialized blocks from a given point.
+    -- Using `BySlot` for a slot which is divisible by the epoch size will
+    -- begin at an EBB.
+  , readFrom     :: Point -> ConduitT () ByteString m ()
+  , readTip      :: m CSL.Block
+  }
+
+data DBAppend m = DBAppend
+  { appendBlock :: CSL.Block -> m ()
+  }
+
+data UnwrittenEBB where
+  NoUnwrittenEBB :: UnwrittenEBB
+  -- | The serialised EBB is held along with the epoch in which it lives (0
+  -- for genesis)
+  -- Its serialisation is stored in order to save on potential re-serialisations
+  -- from reads.
+  -- We also need the hash so that we can put it into the index when the time
+  -- comes.
+  --
+  -- But, we also need the `GenesisBlock` itself in order to support `readTip`.
+  -- TODO knock out the `Epoch`, since it's cheaply derived from the
+  -- `CSL.GenesisBlock`
+  UnwrittenEBB
+    :: !CSL.HeaderHash
+    -> !Epoch
+    -> !ByteString
+    -> !CSL.GenesisBlock
+    -> UnwrittenEBB
+
+data DBError where
+  IndexInconsistent :: Text -> DBError
+  MalformedBlock    :: CBOR.DeserialiseFailure -> DBError
+  deriving (Show)
+
+instance Exception DBError
+
+withDB
+  :: (forall x . DBError -> IO x)
+  -> CSL.GenesisBlock
+  -- ^ The actual genesis block (not an EBB). Used in case the ImmtuableDB
+  -- is empty (iff the Index is empty), in which case it will be written to
+  -- slot 0 on the first append of a later block.
+  -> CSL.SlotCount
+  -- ^ Must know how many slots are in an epoch, and this must be constant for
+  -- all epochs for which there are blocks in the DB.
+  -> Index IO
+  -> ImmutableDB IO
+  -> (DB IO -> IO t)
+  -> IO t
+withDB err genesis epochSlots idx idb = bracket
+  (openDB err genesis epochSlots idx idb)
+  (const (pure ()))
+
+openDB
+  :: (forall x . DBError -> IO x)
+  -> CSL.GenesisBlock
+  -> CSL.SlotCount
+  -> Index IO
+  -> ImmutableDB IO
+  -> IO (DB IO)
+openDB err genesis epochSlots idx idb = do
+  dbTip <- Index.indexRead idx Index.Tip
+  -- The genesis block is the unwritten EBB only if the database is empty.
+  -- If we put it as the unwritten EBB and it weren't empty, it would be
+  -- written at the first write and we'd get an inconsistent database.
+  let unwrittenEBB = case dbTip of
+        Just _  -> NoUnwrittenEBB
+        Nothing -> UnwrittenEBB (CSL.headerHash genesis)
+                                (ebbEpoch genesis)
+                                (CSL.serialize' genesis)
+                                genesis
+  unwrittenEBBRef <- newIORef unwrittenEBB
+  pure $ DB
+    { appendBlocks = \k -> appendBlocksImpl err epochSlots unwrittenEBBRef idx idb k
+    , readFrom     = readFromImpl err epochSlots unwrittenEBBRef idx idb
+    , readTip      = readTipImpl err epochSlots unwrittenEBBRef idx idb
+    }
+
+appendBlocksImpl
+  :: (forall x . DBError -> IO x)
+  -> CSL.SlotCount
+  -> IORef UnwrittenEBB
+  -> Index IO
+  -> ImmutableDB IO
+  -> (DBAppend IO -> IO t)
+  -> IO t
+appendBlocksImpl err epochSlots unwrittenEBBRef idx idb k =
+  Index.indexWrite idx $ \iwrite ->
+    k (dbAppendImpl err epochSlots unwrittenEBBRef iwrite idb)
+
+-- | Append one block. This is the most complicated part.
+dbAppendImpl
+  :: (forall x . DBError -> IO x)
+  -> CSL.SlotCount
+  -> IORef UnwrittenEBB
+  -> IndexWrite IO
+  -> ImmutableDB IO
+  -> DBAppend IO
+dbAppendImpl err epochSlots unwrittenEBBRef iwrite idb = DBAppend $ \cslBlock -> case cslBlock of
+  -- It's an EBB: we _always_ put it into the unwritten EBB IORef. If something
+  -- is already there, we'll commit it to the index and immutable DB.
+  -- No consistency check is done; we leave that to the immutable DB.
+  Left ebb -> do
+    prevUnwrittenEBB <- atomicModifyIORef' unwrittenEBBRef $ \it ->
+      let hh = CSL.headerHash ebb
+          epoch = ebbEpoch ebb
+          bytes = CSL.serialize' ebb
+      in  (UnwrittenEBB hh epoch bytes ebb, it)
+    case prevUnwrittenEBB of
+      -- There was nothing before, so we're done. Next write will see that
+      -- there's an unwritten EBB and write it.
+      NoUnwrittenEBB -> pure ()
+      -- Very rare and weird case: we get 2 EBBs in a row.
+      UnwrittenEBB hh epoch bytes _ -> do
+        Index.updateTip iwrite hh epoch Index.EBBSlot
+        -- The slot in the immutable DB for EBBs is the same as the slot for
+        -- the first block of this epoch.
+        let slot = fromIntegral (epochSlots * fromIntegral epoch)
+        Immutable.appendBinaryBlob idb slot (encodeSerialisedBlock (EBB bytes))
+  Right mainBlk -> do
+    prevUnwrittenEBB <- atomicModifyIORef' unwrittenEBBRef $ \it ->
+      (NoUnwrittenEBB, it)
+    case prevUnwrittenEBB of
+      NoUnwrittenEBB -> do
+        let hh = CSL.headerHash mainBlk
+            (epoch, Slot wslot) = blockEpochAndSlot mainBlk
+            bytes = CSL.serialize' mainBlk
+            -- wslot is relative to epoch; for the ImmutableDB we need relative
+            -- to genesis
+            slot = Slot (fromIntegral epoch * fromIntegral epochSlots + wslot)
+        Index.updateTip iwrite hh epoch (Index.RealSlot wslot)
+        Immutable.appendBinaryBlob idb slot (encodeSerialisedBlock (Block bytes))
+      UnwrittenEBB hh epoch bytes _ -> do
+        let hh' = CSL.headerHash mainBlk
+            (epoch', Slot wslot) = blockEpochAndSlot mainBlk
+            bytes' = CSL.serialize' mainBlk
+            -- wslot is relative to epoch; for the ImmutableDB we need relative
+            -- to genesis
+            slot = Slot (fromIntegral epoch' * fromIntegral epochSlots + wslot)
+        Index.updateTip iwrite hh  epoch  Index.EBBSlot
+        Index.updateTip iwrite hh' epoch' (Index.RealSlot wslot)
+        Immutable.appendBinaryBlob idb slot (encodeSerialisedBlock (Both bytes bytes'))
+
+-- | Stream from a given point, using the index to determine the start point
+-- in case the `Point` is a header hash.
+readFromImpl
+  :: (forall x . DBError -> IO x)
+  -> CSL.SlotCount
+  -> IORef UnwrittenEBB
+  -> Index IO
+  -> ImmutableDB IO
+  -> Point
+  -> ConduitT () ByteString IO ()
+readFromImpl err epochSlots unwrittenEBBRef idx idb point = do
+  -- First, check whether the point is for the unwritten tip.
+  -- TODO is it right to do this though? We do it for `readTipImpl`.
+  -- If we read it here, surely we should also check it at the end of
+  -- streaming. But we can't read at the end of the stream, because there's a
+  -- possibility we miss a block. Between the final read of the stream and the
+  -- read of the unwritten tip, a block and then an EBB could be written, and
+  -- the intermediate block would be missed.
+  unwrittenEBB <- lift $ readIORef unwrittenEBBRef
+  case (unwrittenEBB, point) of
+    -- If the point is a slot corresponding to the EBB then we'll yield it
+    -- and stop.
+    (UnwrittenEBB _ (Epoch epoch) bs _, BySlot slot) ->
+      if slot == fromIntegral (epochSlots * fromIntegral epoch)
+      then Conduit.yield bs
+      else streamFromSlot False slot
+    (_, BySlot slot) -> streamFromSlot False slot
+    (_, ByHash hh)   -> streamFromHash hh
+  where
+
+  -- Use an `ImmutableDB` iterator to stream serialised blocks. The
+  -- iterator must be bracketed, so we have to use a `ResourceT`.
+  -- Surely there is a better way?
+  streamWithIterator
+    :: Bool -- ^ True means skip the EBB if the iterator is at a block that
+            -- includes an EBB and a main block. Also set to False on recursive
+            -- calls.
+    -> Immutable.Iterator IO
+    -> ConduitT () ByteString (ResourceT IO) ()
+  streamWithIterator skipEbb iter = do
+    next <- lift . lift $ Immutable.iteratorNext iter
+    case next of
+      Immutable.IteratorExhausted -> pure ()
+      -- Must decode the `Block` wrapper.
+      -- The bytes could be an EBB and main block packed together.
+      Immutable.IteratorResult _ bytes -> case decodeSerialisedBlock (Lazy.fromStrict bytes) of
+        Left cborError -> lift . lift $ err $ MalformedBlock cborError
+        Right (EBB bytes) -> do
+          Conduit.yield bytes
+          streamWithIterator False iter
+        Right (Block bytes) -> do
+          Conduit.yield bytes
+          streamWithIterator False iter
+        Right (Both bytesEbb bytesBlock) -> do
+          unless skipEbb (Conduit.yield bytesEbb)
+          Conduit.yield bytesBlock
+          streamWithIterator False iter
+
+  streamFromSlot :: Bool -> Slot -> ConduitT () ByteString IO ()
+  streamFromSlot skipEbb sl = Conduit.transPipe runResourceT $ Conduit.bracketP
+    (Immutable.streamBinaryBlobs idb (Just sl) Nothing)
+    Immutable.iteratorClose
+    (streamWithIterator skipEbb)
+
+  -- Streaming from a hash is done by finding the `Slot` of the start point
+  -- then using `streamFromSlot`.
+  -- NB: we don't even need the forward links in the sqlite database.
+  streamFromHash :: CSL.HeaderHash -> ConduitT () ByteString IO ()
+  streamFromHash hh = do
+    idxItem <- lift $ Index.indexRead idx (Index.ByHash hh)
+    case idxItem of
+      -- If the hash is not in the database, it's not an error, we just give an
+      -- empty stream.
+      Nothing -> pure ()
+      -- If the hash is in the database, we now know the slot, but we must take
+      -- care in case it's 0 modulo the slots per epoch: if it's not for an
+      -- EBB (relative slot 0) then we have to ensure that `streamFromHash`
+      -- does not yield the EBB which also lives at that slot. That's what
+      -- the `Bool` parameter is for.
+      Just (_, epoch, indexSlot) -> streamFromSlot
+        (not (isEbbSlot indexSlot))
+        (indexToSlot epochSlots epoch indexSlot)
+
+readTipImpl
+  :: (forall x . DBError -> IO x)
+  -> CSL.SlotCount
+  -> IORef UnwrittenEBB
+  -> Index IO
+  -> ImmutableDB IO
+  -> IO CSL.Block
+readTipImpl err epochSlots unwrittenEBBRef idx idb = do
+  unwritten <- readIORef unwrittenEBBRef
+  case unwritten of
+    UnwrittenEBB _ _ _ ebb -> pure (Left ebb)
+    NoUnwrittenEBB -> Index.indexRead idx Index.Tip >>= \mTip -> case mTip of
+      -- If this happens, it's a bug in this module.
+      Nothing -> error "readTipImpl: empty index and no unwritten tip"
+      -- The index gives an EpochSlot, from which we can determine the actual
+      -- slot by
+      --   epoch * epochSlots + (relativeSlot `mod` epochSlots)
+      -- since EBBs have epochSlots as their relativeSlot, we get 0 for these
+      -- and for the first main block.
+      Just (_, epoch, indexSlot) -> do
+        mBs <- Immutable.getBinaryBlob idb (indexToSlot epochSlots epoch indexSlot)
+        case mBs of
+          Nothing -> err $ IndexInconsistent "missing tip"
+          -- `epochSlots` and the relative slot from the index tells us whether
+          -- we're looking for an EBB or a main block.
+          Just bytes -> case decodeSerialisedBlock (Lazy.fromStrict bytes) of
+            Left cborError -> err (MalformedBlock cborError)
+            Right block -> case (isEbbSlot indexSlot, block) of
+              (True,  Block _)    -> err $ IndexInconsistent "missing EBB"
+              (False, EBB _)      -> err $ IndexInconsistent "missing main block"
+              (True,  Both ebbBytes _) -> case decodeFull CSL.decode (Lazy.fromStrict ebbBytes) of
+                Left cborError -> err $ MalformedBlock cborError
+                Right ebb       -> pure $ Left ebb
+              (False, Both _ blkBytes) -> case decodeFull CSL.decode (Lazy.fromStrict blkBytes) of
+                Left cborError -> err $ MalformedBlock cborError
+                Right blk      -> pure $ Right blk
+              (True,  EBB ebbBytes)    -> case decodeFull CSL.decode (Lazy.fromStrict ebbBytes) of
+                Left cborError -> err $ MalformedBlock cborError
+                Right ebb      -> pure $ Left ebb
+              (False, Block blkBytes)  -> case decodeFull CSL.decode (Lazy.fromStrict blkBytes) of
+                Left cborError -> err $ MalformedBlock cborError
+                Right blk      -> pure $ Right blk
+
+-- | The `Epoch` of an EBB.
+ebbEpoch :: CSL.GenesisBlock -> Epoch
+ebbEpoch ebb = ebb ^.
+    CSL.gbHeader
+  . CSL.gbhConsensus
+  . CSL.gcdEpoch
+  . Lens.to (Epoch . fromIntegral . CSL.getEpochIndex)
+
+blockEpochAndSlot :: CSL.MainBlock -> (Epoch, Slot)
+blockEpochAndSlot blk = blk ^.
+    CSL.gbHeader
+  . CSL.gbhConsensus
+  . CSL.mcdSlot
+  . Lens.to (\sl ->
+      ( Epoch (fromIntegral (CSL.getEpochIndex (CSL.siEpoch sl)))
+      , Slot  (fromIntegral (CSL.getSlotIndex  (CSL.siSlot  sl)))
+      )
+    )
+
+-- | The slot number relative to genesis of a block header.
+-- EBBs get `epoch * slots_in_epoch`, so they share a slot with the first block
+-- of that epoch. This includes the actual genesis block (at 0).
+blockHeaderSlot :: CSL.SlotCount -> CSL.BlockHeader -> Slot
+blockHeaderSlot epochSlots blkHeader = case blkHeader of
+  CSL.BlockHeaderMain mBlkHeader -> mBlkHeader ^.
+      CSL.gbhConsensus
+    . CSL.mcdSlot
+    -- FlatSlotId ~ Word64
+    -- so we `fromIntegral` it (hopefully it fits!)
+    . Lens.to (fromIntegral . CSL.flattenSlotId epochSlots)
+  CSL.BlockHeaderGenesis gBlkHeader -> gBlkHeader ^.
+      CSL.gbhConsensus
+    . CSL.gcdEpoch
+    . Lens.to CSL.getEpochIndex
+    . Lens.to (ebbSlot . fromIntegral)
+  where
+  ebbSlot = \ei -> ei * fromIntegral epochSlots
+
+-- | True if the `EpochSlot` is for an EBB (or genesis).
+isEbbSlot :: Index.IndexSlot -> Bool
+isEbbSlot idxSlot = case idxSlot of
+  Index.EBBSlot    -> True
+  Index.RealSlot _ -> False
+
+-- | Put the EBBs for epoch `n` at the same slot (relative to genesis) as the
+-- first block of epoch `n`.
+indexToSlot :: CSL.SlotCount -> Epoch -> Index.IndexSlot -> Slot
+indexToSlot epochSlots (Epoch epoch) idxSlot = Slot sl
+  where
+  sl = (fromIntegral epochSlots * epoch) + relative
+  relative :: Word
+  relative = case idxSlot of
+    Index.EBBSlot    -> 0
+    Index.RealSlot w -> w

--- a/byron-proxy/src/lib/Ouroboros/Byron/Proxy/Index.hs
+++ b/byron-proxy/src/lib/Ouroboros/Byron/Proxy/Index.hs
@@ -4,58 +4,40 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
+-- TODO move to Ouroboros.Byron.DB.Index
 module Ouroboros.Byron.Proxy.Index where
 
-import Control.Exception (Exception)
-import Control.Monad.Trans.Class (lift)
-import Crypto.Hash (Digest, HashAlgorithm, digestFromByteString)
+import Control.Exception (Exception, throwIO)
+import Crypto.Hash (digestFromByteString)
 import Data.ByteString (ByteString)
 import Data.ByteArray (convert)
-import Data.Conduit (ConduitT, yield)
-import Database.SQLite.Simple (Connection, Only (..), Query)
+import Database.SQLite.Simple (Connection, Query)
 import qualified Database.SQLite.Simple as Sql
 import System.Directory (doesFileExist)
 
 import Pos.Chain.Block (HeaderHash)
 import Pos.Crypto.Hashing (AbstractHash (..))
-import Pos.DB.Class (Serialized (..), SerializedBlock)
 
-import Ouroboros.Storage.ImmutableDB.API (ImmutableDB)
-import Ouroboros.Storage.ImmutableDB.CumulEpochSizes (EpochSlot(..),
-                                                      RelativeSlot(..))
-import qualified Ouroboros.Storage.ImmutableDB.API as ImmutableDB
 import Ouroboros.Storage.ImmutableDB.Types
-import Ouroboros.Byron.Proxy.Types
-
--- cardano-sl crypto apparently gives no way to get an AbstractHash from
--- a ByteString without re-hashing it. We'll use `digestFromByteString` from
--- cryptonite and trust that it's the right size.
-digestFromByteString_partial :: HashAlgorithm a => ByteString -> Digest a
-digestFromByteString_partial bs =
-  let Just digest = digestFromByteString bs in digest
 
 -- | A point to read from the index. Looking up the tip gives its own hash,
 -- looking up anything by hash (could happen to be the tip) gives the hash
 -- of its child (nothing iff it's the tip).
 data IndexPoint next where
-  Tip    :: IndexPoint OwnHash
-  ByHash :: HeaderHash -> IndexPoint ChildHash
-
-newtype OwnHash = OwnHash
-  { getOwnHash :: HeaderHash
-  }
-
-newtype ChildHash = ChildHash
-  { getChildHash :: Maybe HeaderHash
-  }
+  Tip    :: IndexPoint HeaderHash
+  ByHash :: HeaderHash -> IndexPoint ()
 
 data Index m = Index
-  { indexRead  :: forall d . IndexPoint d -> m (Maybe (d, EpochSlot))
+  { indexRead  :: forall d . IndexPoint d -> m (Maybe (d, Epoch, IndexSlot))
   , indexWrite :: forall t . (IndexWrite m -> m t) -> m t
   }
 
+data IndexSlot where
+  RealSlot :: Word -> IndexSlot
+  EBBSlot  :: IndexSlot
+
 data IndexWrite m = IndexWrite
-  { updateTip :: HeaderHash -> EpochSlot -> m ()
+  { updateTip :: HeaderHash -> Epoch -> IndexSlot -> m ()
   }
 
 -- TODO Move SQlite implemention into a separate module.
@@ -66,8 +48,8 @@ data IndexWrite m = IndexWrite
 sqliteIndex :: Connection -> Index IO
 sqliteIndex conn = Index
   { indexRead = \ip -> case ip of
-      Tip -> (fmap . fmap) (\(a, b) -> (OwnHash a, b)) (getTip conn)
-      ByHash hh -> (fmap . fmap) (\(a, b) -> (ChildHash a, b)) (getHash conn hh)
+      Tip -> getTip conn
+      ByHash hh -> getHash conn hh
   , indexWrite = \k -> Sql.withTransaction conn (k (IndexWrite (setTip conn)))
   }
 
@@ -75,6 +57,11 @@ sqliteIndex conn = Index
 data OpenDB where
   New      :: OpenDB
   Existing :: OpenDB
+
+-- TODO
+-- should implement a feature to reconstruct/repair the index using an
+-- `ImmutableDB`: iterate from the start and insert an entry for each thing.
+-- Would write that in Ouroboros.Byron.Proxy.DB though, I think.
 
 -- | Use an SQLite database connection.
 withDB :: OpenDB -> FilePath -> (Index IO -> IO t) -> IO t
@@ -93,63 +80,33 @@ withDB_ fp k = doesFileExist fp >>= \b -> case b of
   True  -> withDB Existing fp k
   False -> withDB New      fp k
 
--- | An index on an ImmutableDB is enough to get a ByronBlockSource, but we
--- assume that the index and DB are kept in-sync.
--- Also assumes of course that the DB blobs are valid encoded blocks.
--- Must give a `SerializedBlock` for the genesis, which is used when the
--- index (and therefore immutable DB) are empty.
-byronBlockSource
-  :: forall m .
-     ( Monad m )
-    -- TODO proper error type.
-  => (forall x . IndexInconsistent -> m x)
-  -> SerializedBlock
-  -> Index m
-  -> ImmutableDB m
-  -> ByronBlockSource m
-byronBlockSource err genesis idx db = ByronBlockSource
-  { bbsStream = streamFrom
-  , bbsTip    = indexRead idx Tip >>= \mTip -> case mTip of
-      Nothing -> pure genesis
-      Just (_, es) -> ImmutableDB.getBinaryBlob db (error "TODO") >>= \mBs -> case mBs of
-        Nothing -> err TipNotInDatabase
-        Just bs -> pure $ Serialized bs
-  }
-  where
-  streamFrom :: HeaderHash -> ConduitT () SerializedBlock m ()
-  streamFrom hh = lift (indexRead idx (ByHash hh)) >>= \mPoint -> case mPoint of
-    -- No problem. The stream is over.
-    Nothing -> pure ()
-    -- Got an entry. Use the EpochSlot to look up in the database, and the
-    -- child hash to continue the stream (if Just).
-    Just (ChildHash mChild, es) -> lift (ImmutableDB.getBinaryBlob db (error "TODO")) >>= \mBs -> case mBs of
-      Nothing -> lift $ err $ PointNotInDatabase hh es
-      Just bs -> do
-        yield (Serialized bs)
-        case mChild of
-          Nothing -> pure ()
-          Just hh' -> streamFrom hh'
+data IndexInternallyInconsistent where
+  -- | The `Int` is less than -1
+  InvalidRelativeSlot :: HeaderHash -> Int -> IndexInternallyInconsistent
+  -- | The header hash for the tip is not the right size.
+  InvalidHash :: ByteString -> IndexInternallyInconsistent
 
-data IndexInconsistent where
-  TipNotInDatabase   :: IndexInconsistent
-  PointNotInDatabase :: HeaderHash -> EpochSlot -> IndexInconsistent
+deriving instance Show IndexInternallyInconsistent
+instance Exception IndexInternallyInconsistent
 
-deriving instance Show IndexInconsistent
-instance Exception IndexInconsistent
-
--- | The index is a relation:
+-- | The index is the relation:
 --
--- +------------+------------+-------+------+
--- | HeaderHash | HeaderHash | Epoch | Slot |
--- +------------+------------+-------+------+
--- | ByteString | ByteString | Word  | Word |
--- +------------+------------+-------+------+
+-- +------------+-------+------+
+-- | HeaderHash | Epoch | Slot |
+-- +------------+-------+------+
+-- | ByteString | Word  | Int  |
+-- +------------+--------------+
 --
--- HeaderHash primary key, forward link foreign key into the same table but
--- is nullable (for the tip), epoch and relative slot unique in the table
+-- HeaderHash primary key, epoch and relative slot unique in the table
 -- (as a pair) and there's an index on this pair.
 --
--- We use INTEGER for epoch and slot, but the DB stuff uses Word.
+-- Epoch boundary blocks get slot number -1, thereby packing them in-between
+-- the last block of the prior epoch, and the first block of the next epoch.
+--
+-- Forward links aren't necessary, since we can tell what the next block is
+-- by using the order on epoch, slot.
+--
+-- We use the sqlite INTEGER for epoch and slot, but the DB stuff uses Word.
 -- INTEGER can be as big as 8 bytes, which may not fit into a Word depending
 -- on implementation. But since we're the only ones writing to this database,
 -- and we only put in Words, it should be ok.
@@ -158,10 +115,8 @@ sql_create_table :: Query
 sql_create_table =
   "CREATE TABLE block_index\n\
   \  ( header_hash       BLOB NOT NULL PRIMARY KEY\n\
-  \  , child_header_hash BLOB\n\
   \  , epoch             INTEGER NOT NULL\n\
   \  , slot              INTEGER NOT NULL\n\
-  \  , FOREIGN KEY(child_header_hash) REFERENCES block_index(header_hash)\n\
   \  , UNIQUE (epoch, slot)\n\
   \  );"
 
@@ -181,60 +136,53 @@ sql_get_tip =
   "SELECT header_hash, epoch, slot FROM block_index\
   \ ORDER BY epoch DESC, slot DESC LIMIT 1;"
 
-getTip :: Sql.Connection -> IO (Maybe (HeaderHash, EpochSlot))
+getTip :: Sql.Connection -> IO (Maybe (HeaderHash, Epoch, IndexSlot))
 getTip conn = do
-   rows :: [(ByteString, Word, Word)] <- Sql.query_ conn sql_get_tip
+   rows :: [(ByteString, Word, Int)] <- Sql.query_ conn sql_get_tip
    case rows of
      [] -> pure Nothing
-     ((hhBlob, epoch, slot) : _) ->
-       let hh = AbstractHash $ digestFromByteString_partial hhBlob
-           es = EpochSlot (Epoch epoch) (RelativeSlot slot)
-       in  pure $ Just (hh, es)
+     ((hhBlob, epoch, slotInt) : _) -> do
+       hh <- case digestFromByteString hhBlob of
+         Just hh -> pure (AbstractHash hh)
+         Nothing -> throwIO $ InvalidHash hhBlob
+       slot <-
+         if slotInt == -1
+         then pure EBBSlot
+         else if slotInt >= 0
+         then pure (RealSlot (fromIntegral slotInt))
+         else throwIO $ InvalidRelativeSlot hh slotInt
+       pure $ Just (hh, Epoch epoch, slot)
 
 sql_get_hash :: Query
 sql_get_hash =
-  "SELECT child_header_hash, epoch, slot FROM block_index\
+  "SELECT epoch, slot FROM block_index\
   \ WHERE header_hash = ?;"
 
-getHash :: Sql.Connection -> HeaderHash -> IO (Maybe (Maybe HeaderHash, EpochSlot))
-getHash conn (AbstractHash digest) = do
-  rows :: [(Maybe ByteString, Word, Word)]
+getHash :: Sql.Connection -> HeaderHash -> IO (Maybe ((), Epoch, IndexSlot))
+getHash conn hh@(AbstractHash digest) = do
+  rows :: [(Word, Int)]
     <- Sql.query conn sql_get_hash (Sql.Only (convert digest :: ByteString))
   case rows of
     [] -> pure Nothing
-    ((hhChildBlob, epoch, slot) : _) ->
-      let hh = fmap (AbstractHash . digestFromByteString_partial) hhChildBlob
-          es = EpochSlot (Epoch epoch) (RelativeSlot slot)
-      in  pure $ Just (hh, es)
+    ((epoch, slotInt) : _) -> do
+      slot <-
+        if slotInt == -1
+        then pure EBBSlot
+        else if slotInt >= 0
+        then pure (RealSlot (fromIntegral slotInt))
+        else throwIO $ InvalidRelativeSlot hh slotInt
+      pure $ Just ((), Epoch epoch, slot)
 
 sql_insert :: Query
-sql_insert = "INSERT INTO block_index VALUES (?, NULL, ?, ?);"
+sql_insert = "INSERT INTO block_index VALUES (?, ?, ?);"
 
-sql_update :: Query
-sql_update = "UPDATE block_index SET child_header_hash = ? WHERE header_hash = ?;"
-
-sql_get_tip_hash :: Query
-sql_get_tip_hash =
-  "SELECT header_hash FROM block_index\
-  \ ORDER BY epoch DESC, slot DESC LIMIT 1;"
-
-setTipTx :: Sql.Connection -> HeaderHash -> EpochSlot -> IO ()
-setTipTx conn hh es = Sql.withTransaction conn $ setTip conn hh es
-
-setTip :: Sql.Connection -> HeaderHash -> EpochSlot -> IO ()
-setTip conn (AbstractHash digest) (EpochSlot (Epoch epoch) rslot) = do
-  -- Get the current tip.
-  mTip :: [Only ByteString] <- Sql.query_ conn sql_get_tip_hash
-  case mTip of
-    -- No tip in the database (it's empty). Just one statement to do.
-    [] -> do
-      Sql.execute conn sql_insert (hashBytes, epoch, slot)
-    (Only oldTipHashBytes : _) -> do
-      -- Insert the new tip.
-      Sql.execute conn sql_insert (hashBytes, epoch, slot)
-      -- Update the old tip child pointer.
-      Sql.execute conn sql_update (hashBytes, oldTipHashBytes)
+setTip :: Sql.Connection -> HeaderHash -> Epoch -> IndexSlot -> IO ()
+setTip conn (AbstractHash digest) (Epoch epoch) slot = do
+  Sql.execute conn sql_insert (hashBytes, epoch, slotInt)
   where
+  slotInt :: Int
+  slotInt = case slot of
+    EBBSlot       -> -1
+    RealSlot word -> fromIntegral word
   hashBytes :: ByteString
   hashBytes = convert digest
-  RelativeSlot slot = rslot

--- a/default.nix
+++ b/default.nix
@@ -14,8 +14,8 @@ let
   # proxy will build.
   cardanoroot = nixpkgs.fetchgit {
     url = "https://github.com/input-output-hk/cardano-sl";
-    rev = "0af82eb3de205c6a1a681e1c10b0b513d3e8eb2b";
-    sha256 = "13infd9j3g71pa40fw32300gadj4bnv0hyg5m83q716qscw5dr1j";
+    rev = "d09d265e6f78621b2520f4b2b98d177c8695c138";
+    sha256 = "0dr75q5gqyhwvbb53rpq7lsjxp7nm97rkd4l78vdi9br49hhrbch";
   };
   cardanopkgs = import ./nix/cardanopkgs.nix { inherit nixpkgs cardanoroot; };
 

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -296,6 +296,7 @@ test-suite test-storage
                     QuickCheck,
                     quickcheck-state-machine >=0.6.0,
                     random,
+                    serialise,
                     stm,
                     tasty,
                     tasty-hunit,

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
@@ -13,6 +13,7 @@ module Ouroboros.Consensus.Util.CBOR (
     -- * HasFS interaction
   , ReadIncrementalErr(..)
   , readIncremental
+  , readIncrementalOffsets
   ) where
 
 import qualified Codec.CBOR.Read as CBOR
@@ -25,6 +26,7 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           Data.ByteString.Builder.Extra (defaultChunkSize)
 import           Data.IORef
+import           Data.Word (Word64)
 import           System.IO (IOMode (..))
 
 import           Control.Monad.Class.MonadST
@@ -100,6 +102,7 @@ data ReadIncrementalErr =
 
     -- | Deserialisation was successful, but there was additional data
   | TrailingBytes ByteString
+  deriving (Eq, Show)
 
 -- | Read a file incrementally
 --
@@ -130,6 +133,57 @@ readIncremental hasFS@HasFS{..} fp = withLiftST $ \liftST -> do
                    else Left $ TrailingBytes leftover
     go _ _ (S.Fail _ _ err) =
         return $ Left $ ReadFailed err
+
+    checkEmpty :: ByteString -> Maybe ByteString
+    checkEmpty bs | BS.null bs = Nothing
+                  | otherwise  = Just bs
+
+-- | Read multiple @a@s incrementally from a file.
+--
+-- Return the offset ('Word64') of the start of each @a@ and the size ('Word')
+-- of each @a@. When deserialising fails, return all already deserialised @a@s
+-- and the error.
+--
+-- To be used by 'Ouroboros.Storage.ImmutableDB.Util.cborEpochFileParser''.
+readIncrementalOffsets :: forall m h a. (Serialise a, MonadST m, MonadThrow m)
+                       => HasFS m h
+                       -> FsPath
+                       -> m ([(Word64, (Word, a))], Maybe ReadIncrementalErr)
+                          -- ^ ((the offset of the start of @a@ in the file,
+                          --     (the size of @a@ in bytes,
+                          --      @a@ itself)),
+                          --     error encountered during deserialisation)
+readIncrementalOffsets hasFS@HasFS{..} fp = withLiftST $ \liftST ->
+    withFile hasFS fp ReadMode $ \h ->
+      go liftST h 0 [] Nothing =<< liftST S.deserialiseIncremental
+  where
+    go :: (forall x. ST s x -> m x)
+       -> h
+       -> Word64                -- ^ Offset
+       -> [(Word64, (Word, a))] -- ^ Already deserialised (reverse order)
+       -> Maybe ByteString      -- ^ Unconsumed bytes from last time
+       -> S.IDecode s a
+       -> m ([(Word64, (Word, a))], Maybe ReadIncrementalErr)
+    go liftST h offset deserialised mbUnconsumed dec = case dec of
+      S.Partial k -> do
+        -- First use the unconsumed bytes from a previous read before read
+        -- some more bytes from the file.
+        bs   <- case mbUnconsumed of
+          Just unconsumed -> return unconsumed
+          Nothing         -> hGet h defaultChunkSize
+        dec' <- liftST $ k (checkEmpty bs)
+        go liftST h offset deserialised Nothing dec'
+
+      S.Done leftover size a -> do
+        let nextOffset    = offset + fromIntegral size
+            deserialised' = (offset, (fromIntegral size, a)) : deserialised
+        case checkEmpty leftover of
+          Nothing         -> return (reverse deserialised', Nothing)
+          -- Some more bytes, so try to read the next @a@.
+          Just unconsumed -> liftST S.deserialiseIncremental >>=
+            go liftST h nextOffset deserialised' (Just unconsumed)
+
+      S.Fail _ _ err -> return (reverse deserialised, Just (ReadFailed err))
 
     checkEmpty :: ByteString -> Maybe ByteString
     checkEmpty bs | BS.null bs = Nothing

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -71,8 +71,9 @@ extractTruncateFrom e = case e of
 --
 -- The parsing may include validation of the contents of the epoch file.
 --
--- The returned 'SlotOffset's are from __first to last__ and __strictly__
--- monotonically increasing. The first 'SlotOffset' must be 0.
+-- The 'SlotOffset' is the offset (in bytes) of the start of the corresponding
+-- @t@ (block). The returned 'SlotOffset's are from __first to last__ and
+-- __strictly__ monotonically increasing. The first 'SlotOffset' must be 0.
 --
 -- We assume the output of 'EpochFileParser' to be correct, we will not
 -- validate it.

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Util.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TupleSections     #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 module Ouroboros.Storage.ImmutableDB.Util
   ( renderFile
   , handleUser
@@ -13,13 +14,22 @@ module Ouroboros.Storage.ImmutableDB.Util
   , readAll
   , hGetRightSize
   , validateIteratorRange
+  , reconstructSlotOffsets
+  , indexBackfill
+  , cborEpochFileParser'
   ) where
 
+import           Codec.Serialise (Serialise)
+import           Control.Exception (assert)
 import           Control.Monad (when)
+import           Control.Monad.Class.MonadST (MonadST)
+import           Control.Monad.Class.MonadThrow (MonadThrow)
 
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BS
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 
 import           GHC.Stack (HasCallStack, callStack, popCallStack)
@@ -28,9 +38,13 @@ import           Text.Printf (printf)
 import           Text.Read (readMaybe)
 
 import           Ouroboros.Consensus.Util (whenJust)
+import           Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr (..),
+                     readIncrementalOffsets)
 
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types
+import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes
+                     (RelativeSlot (..))
 import           Ouroboros.Storage.ImmutableDB.Types
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
@@ -143,3 +157,88 @@ validateIteratorRange err next mbStart mbEnd = do
       -- Check that the end is not >= the next expected slot
       when (end >= next) $
         throwUserError err $ ReadFutureSlotError end next
+
+-- | Given a list of increasing 'SlotOffset's together with the 'Word' (blob
+-- size) and 'RelativeSlot' corresponding to the offset, reconstruct a
+-- non-empty list of (decreasing) slot offsets.
+--
+-- The input list (typically returned by 'EpochFileParser') is assumed to be
+-- valid: __strictly__ monotonically increasing offsets as well as
+-- __strictly__ monotonically increasing relative slots.
+--
+-- The 'RelativeSlot's are used to detect empty/unfilled slots that will
+-- result in repeated offsets in the output, indicating that the size of the
+-- slot is 0.
+--
+-- The output list will always have 0 as last element.
+reconstructSlotOffsets :: [(SlotOffset, (Word, RelativeSlot))]
+                       -> NonEmpty SlotOffset
+reconstructSlotOffsets = go 0 [] 0
+  where
+    go :: SlotOffset
+       -> [SlotOffset]
+       -> RelativeSlot
+       -> [(SlotOffset, (Word, RelativeSlot))]
+       -> NonEmpty SlotOffset
+    go offsetAfterLast offsets expectedRelSlot ((offset, (len, relSlot)):olrs') =
+      assert (offsetAfterLast == offset) $
+      assert (relSlot >= expectedRelSlot) $
+      let backfill = indexBackfill relSlot expectedRelSlot offset
+      in go (offset + fromIntegral len) (offset : backfill <> offsets)
+            (succ relSlot) olrs'
+    go offsetAfterLast offsets _lastRelSlot [] = offsetAfterLast NE.:| offsets
+
+
+-- | Return the slots to backfill the index file with.
+--
+-- A situation may arise in which we \"skip\" some relative slots, and we
+-- write into the DB, for example, every other relative slot. In this case, we
+-- need to backfill the index file with offsets for the skipped relative
+-- slots. Similarly, before we start a new epoch, we must backfill the index
+-- file of the current epoch file to indicate that it is finalised.
+--
+-- For example, say we have written \"a\" to relative slot 0 and \"bravo\" to
+-- relative slot 1. We have the following index file:
+--
+-- > slot:     0   1   2
+-- >         ┌───┬───┬───┐
+-- > offset: │ 0 │ 1 │ 6 │
+-- >         └───┴───┴───┘
+--
+-- Now we want to store \"haskell\" in relative slot 4, skipping 2 and 3. We
+-- first have to backfill the index by repeating the last offset for the two
+-- missing slots:
+--
+-- > slot:     0   1   2   3   4
+-- >         ┌───┬───┬───┬───┬───┐
+-- > offset: │ 0 │ 1 │ 6 │ 6 │ 6 │
+-- >         └───┴───┴───┴───┴───┘
+--
+-- After backfilling (writing the offset 6 twice), we can write the next
+-- offset:
+--
+-- > slot:     0   1   2   3   4   5
+-- >         ┌───┬───┬───┬───┬───┬───┐
+-- > offset: │ 0 │ 1 │ 6 │ 6 │ 6 │ 13│
+-- >         └───┴───┴───┴───┴───┴───┘
+--
+-- For the example above, the output of this funciton would thus be: @[6, 6]@.
+--
+indexBackfill :: RelativeSlot  -- ^ The slot to write to (>= next expected slot)
+              -> RelativeSlot  -- ^ The next expected slot to write to
+              -> SlotOffset    -- ^ The last 'SlotOffset' written to
+              -> [SlotOffset]
+indexBackfill (RelativeSlot slot) (RelativeSlot nextExpected) lastOffset =
+    replicate gap lastOffset
+  where
+    gap = fromIntegral $ slot - nextExpected
+
+
+-- | CBOR-based 'EpochFileParser' that can be used with
+-- 'Ouroboros.Storage.ImmutableDB.Impl.openDB'.
+cborEpochFileParser' :: forall m h a. (Serialise a, MonadST m, MonadThrow m)
+                     => HasFS m h
+                     -> EpochFileParser ReadIncrementalErr m (Word, a)
+                        -- ^ The 'Word' is the size in bytes of the
+                        -- corresponding @a@.
+cborEpochFileParser' hasFS = EpochFileParser (readIncrementalOffsets hasFS)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -4,6 +4,8 @@
 {-# OPTIONS_GHC -Wno-orphans   #-}
 module Test.Ouroboros.Storage.ImmutableDB (tests) where
 
+import qualified Codec.Serialise as S
+import           Control.Monad (forM_, void)
 import           Control.Monad.Class.MonadSTM (MonadSTM)
 import           Control.Monad.Class.MonadThrow (MonadCatch)
 
@@ -12,7 +14,7 @@ import qualified Data.ByteString as BS
 import           Data.Coerce (coerce)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import           Data.Maybe (isNothing, maybeToList)
+import           Data.Maybe (isJust, isNothing, maybeToList)
 import           Data.Word (Word64)
 
 import qualified System.IO as IO
@@ -40,6 +42,8 @@ import           Ouroboros.Storage.ImmutableDB
 import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes
                      (RelativeSlot (..))
 import           Ouroboros.Storage.ImmutableDB.Index
+import           Ouroboros.Storage.ImmutableDB.Util (cborEpochFileParser',
+                     reconstructSlotOffsets)
 import           Ouroboros.Storage.Util (decodeIndexEntryAt)
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
@@ -63,6 +67,9 @@ tests = testGroup "ImmutableDB"
       , testProperty "writeIndex/loadIndex roundtrip" prop_writeIndex_loadIndex
       , testProperty "writeSlotOffsets/loadIndex/indexToSlotOffsets roundtrip" prop_writeSlotOffsets_loadIndex_indexToSlotOffsets
       ]
+    , testCase     "reconstructSlotOffsets" test_reconstructSlotOffsets
+    , testCase     "reconstructSlotOffsets empty slots" test_reconstructSlotOffsets_empty_slots
+    , testCase     "cborEpochFileParser" test_cborEpochFileParser
     , TestBlock.tests
     , StateMachine.tests
     , CumulEpochSizes.tests
@@ -264,3 +271,57 @@ prop_writeSlotOffsets_loadIndex_indexToSlotOffsets (SlotOffsets offsets) =
         case r of
           Left  e      -> fail (prettyFsError e)
           Right (p, _) -> return p
+
+
+{------------------------------------------------------------------------------
+  reconstructSlotOffsets
+------------------------------------------------------------------------------}
+
+test_reconstructSlotOffsets :: Assertion
+test_reconstructSlotOffsets = reconstructSlotOffsets input @?= output
+  where
+    input  = [(0, (10, 0)), (10, (10, 1)), (20, (5, 2)), (25, (10, 3))]
+    output = NE.fromList [35, 25, 20, 10, 0]
+
+
+test_reconstructSlotOffsets_empty_slots :: Assertion
+test_reconstructSlotOffsets_empty_slots = reconstructSlotOffsets input @?= output
+  where
+    input  = [(0, (10, 2)), (10, (10, 4))]
+    output = NE.fromList [20, 10, 10, 0, 0, 0]
+
+
+
+{------------------------------------------------------------------------------
+  cborEpochFileParser
+------------------------------------------------------------------------------}
+
+test_cborEpochFileParser :: Assertion
+test_cborEpochFileParser = fmap fst $ Sim.runSimFS err Mock.empty $ \hasFS -> do
+    let HasFS{..} = hasFS
+
+    withFile hasFS fp IO.AppendMode $ \h -> do
+      forM_ blocks $ \block ->
+        hPut h (S.serialiseIncremental block)
+      void $ hPut h "trailingjunk"
+
+    (offsetsAndSizesAndBlocks', mbErr) <-
+      runEpochFileParser (cborEpochFileParser' hasFS) fp
+
+    offsetsAndSizesAndBlocks' @?= offsetsAndSizesAndBlocks
+    assertBool "Expected an error" (isJust mbErr)
+  where
+    blocks :: [ByteString]
+    blocks = map (snd . snd) offsetsAndSizesAndBlocks
+
+    offsetsAndSizesAndBlocks :: [(SlotOffset, (Word, ByteString))]
+    offsetsAndSizesAndBlocks =
+      [ (0, (4, "foo"))
+        -- Note that a "foo" is encoded as "Cfoo", hence the size of 4
+      , (4, (4, "bar"))
+      , (8, (4, "baz"))
+      ]
+
+    fp = ["test"]
+
+    err = EH.exceptions

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -306,7 +306,7 @@ test_cborEpochFileParser = fmap fst $ Sim.runSimFS err Mock.empty $ \hasFS -> do
       void $ hPut h "trailingjunk"
 
     (offsetsAndSizesAndBlocks', mbErr) <-
-      runEpochFileParser (cborEpochFileParser' hasFS) fp
+      runEpochFileParser (cborEpochFileParser' hasFS S.decode) fp
 
     offsetsAndSizesAndBlocks' @?= offsetsAndSizesAndBlocks
     assertBool "Expected an error" (isJust mbErr)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -278,7 +278,7 @@ findEpochDropLastBytesRollBackPoint n epoch dbm
     | otherwise
     = RollBackToEpochSlot (epochSlots !! lastValidFilledSlotIndex validBytes)
   where
-    totalBytes = fromIntegral $ testBlockSize * length epochSlots
+    totalBytes = fromIntegral testBlockSize * fromIntegral (length epochSlots)
     validBytes :: Word64
     validBytes
       | n >= totalBytes
@@ -286,8 +286,9 @@ findEpochDropLastBytesRollBackPoint n epoch dbm
       | otherwise
       = totalBytes - n
     epochSlots = epochSlotsInEpoch dbm epoch
+    lastValidFilledSlotIndex :: Word64 -> Int
     lastValidFilledSlotIndex offset =
-      (fromIntegral offset `quot` testBlockSize) - 1
+      (fromIntegral offset `quot` fromIntegral testBlockSize) - 1
 
 findEpochCorruptionRollBackPoint :: FileCorruption -> Epoch -> DBModel
                                  -> RollBackPoint

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
@@ -1,14 +1,15 @@
-{-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RecordWildCards  #-}
-{-# LANGUAGE TupleSections    #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 -- | Block used for the state machine tests
 module Test.Ouroboros.Storage.ImmutableDB.TestBlock
   ( TestBlock(..)
   , testBlockRepeat
   , testBlockSize
   , testBlockToBuilder
-  , testBlockEpochFileParser
+  , binaryEpochFileParser
   , testBlockEpochFileParser'
 
   , FileCorruption(..)
@@ -66,11 +67,11 @@ instance Arbitrary TestBlock where
 
 -- | The binary representation of 'TestBlock' consists of repeating its 'Slot'
 -- @n@ times, where @n = 'testBlockSize'@.
-testBlockRepeat :: Int
+testBlockRepeat :: Word
 testBlockRepeat = 10
 
 -- | The number of bytes the binary representation 'TestBlock' takes up.
-testBlockSize :: Int
+testBlockSize :: Word
 testBlockSize = testBlockRepeat * 8
 
 -- | The encoding of TestBlock @x@ is the encoding of @x@ as a 'Word',
@@ -84,9 +85,9 @@ testBlockSize = testBlockRepeat * 8
 -- depends on this encoding of 'TestBlock'.
 instance Bin.Binary TestBlock where
     put (TestBlock (Slot slot)) =
-      mconcat $ replicate testBlockRepeat (Bin.put slot)
+      mconcat $ replicate (fromIntegral testBlockRepeat) (Bin.put slot)
     get = do
-      (w:ws) <- replicateM testBlockRepeat Bin.get
+      (w:ws) <- replicateM (fromIntegral testBlockRepeat) Bin.get
       when (any (/= w) ws) $
         fail "Corrupt TestBlock"
       return $ TestBlock (Slot w)
@@ -107,10 +108,11 @@ testBlockToBuilder = BS.lazyByteString . Bin.encode
   EpochFileParser
 -------------------------------------------------------------------------------}
 
-testBlockEpochFileParser :: MonadThrow m
-                         => HasFS m h
-                         -> EpochFileParser String m TestBlock
-testBlockEpochFileParser hasFS@HasFS{..} = EpochFileParser $ \fsPath ->
+
+binaryEpochFileParser :: forall b m h. (MonadThrow m, Bin.Binary b)
+                      => HasFS m h
+                      -> EpochFileParser String m b
+binaryEpochFileParser hasFS@HasFS{..} = EpochFileParser $ \fsPath ->
     withFile hasFS fsPath ReadMode $ \eHnd -> do
       bytesInFile <- hGetSize eHnd
       parse (fromIntegral bytesInFile) 0 [] . BS.toLazyByteString <$>
@@ -118,25 +120,25 @@ testBlockEpochFileParser hasFS@HasFS{..} = EpochFileParser $ \fsPath ->
   where
     parse :: SlotOffset
           -> SlotOffset
-          -> [(SlotOffset, TestBlock)]
+          -> [(SlotOffset, b)]
           -> BL.ByteString
-          -> ([(SlotOffset, TestBlock)], Maybe String)
+          -> ([(SlotOffset, b)], Maybe String)
     parse bytesInFile offset parsed bs
       | offset >= bytesInFile
       = (reverse parsed, Nothing)
       | otherwise
       = case Bin.decodeOrFail bs of
           Left (_, _, e) -> (reverse parsed, Just e)
-          Right (remaining, bytesConsumed, testBlock) ->
+          Right (remaining, bytesConsumed, b) ->
             let newOffset = offset + fromIntegral bytesConsumed
-                newParsed = (offset, testBlock) : parsed
+                newParsed = (offset, b) : parsed
             in parse bytesInFile newOffset newParsed remaining
 
 testBlockEpochFileParser' :: MonadThrow m
                           => HasFS m h
-                          -> EpochFileParser String m (Int, Slot)
+                          -> EpochFileParser String m (Word, Slot)
 testBlockEpochFileParser' hasFS = (\tb -> (testBlockSize, tbSlot tb)) <$>
-    testBlockEpochFileParser hasFS
+    binaryEpochFileParser hasFS
 
 
 prop_testBlockEpochFileParser :: TestBlocks -> Property
@@ -161,7 +163,7 @@ prop_testBlockEpochFileParser (TestBlocks blocks) = QCM.monadicIO $ do
 
     readBlocks :: HasFS IO Mock.Handle
                -> IO ([(SlotOffset, TestBlock)], Maybe String)
-    readBlocks hasFS = runEpochFileParser (testBlockEpochFileParser hasFS) file
+    readBlocks hasFS = runEpochFileParser (binaryEpochFileParser hasFS) file
 
     runSimIO :: (HasFS IO Mock.Handle -> IO a) -> IO a
     runSimIO m = fst <$> runSimFS EH.exceptions Mock.empty m


### PR DESCRIPTION
Note the merge target: `mrBliss/slot-immutabledb`.

- There's a Byron proxy `DB` type, which admits reads by point or by hash. This is used to support the Byron proxy logic layer, and is used by the executable to save downloaded blocks.
- The sqlite index changes: no more child hash forward link as it's not needed, and the relative slot of EBBs is -1.
- EBBs are packed in the 0th slot of their epoch alongside the main block for that slot if there is one.