### PR TITLE
Reshuffle  `Ouroboros.Network.Serialise`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,10 +1,14 @@
 packages: ./typed-protocols
+	  ./ouroboros-network-testing
           ./ouroboros-network
           ./ouroboros-consensus
           ./io-sim
           ./io-sim-classes
 
 package typed-protocols
+  tests: True
+
+package ouroboros-network-testing
   tests: True
 
 package ouroboros-network

--- a/ouroboros-consensus/demo-playground/Mock/Mempool.hs
+++ b/ouroboros-consensus/demo-playground/Mock/Mempool.hs
@@ -11,14 +11,13 @@ module Mock.Mempool (
   , consistent
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Control.Monad.Except
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Semigroup (Semigroup, (<>))
 import           Data.Set (Set)
 import qualified Data.Set as Set
-
-import           Ouroboros.Network.Serialise (Serialise)
 
 import           Ouroboros.Consensus.Crypto.Hash
 import           Ouroboros.Consensus.Ledger.Mock

--- a/ouroboros-consensus/demo-playground/Mock/TxSubmission.hs
+++ b/ouroboros-consensus/demo-playground/Mock/TxSubmission.hs
@@ -20,8 +20,6 @@ import qualified Data.Set as Set
 import           Options.Applicative
 import           System.IO (IOMode (..))
 
-import           Ouroboros.Network.Serialise ()
-
 import           Ouroboros.Consensus.Crypto.Hash (ShortHash)
 import qualified Ouroboros.Consensus.Crypto.Hash as H
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -245,11 +245,13 @@ test-suite test-crypto
                     Test.Util.Orphans.Arbitrary
                     Test.Util.QuickCheck
   build-depends:    base,
+                    ouroboros-network-testing,
                     ouroboros-network,
                     ouroboros-consensus,
 
                     bytestring,
                     QuickCheck,
+                    serialise,
                     tasty,
                     tasty-quickcheck,
                     time

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Class.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Class.hs
@@ -12,10 +12,9 @@ module Ouroboros.Consensus.Crypto.DSIGN.Class
     , verifySignedDSIGN
     ) where
 
+import           Codec.Serialise (Serialise (..))
 import           Crypto.Random (MonadRandom)
 import           GHC.Generics (Generic)
-
-import           Ouroboros.Network.Serialise
 
 import           Ouroboros.Consensus.Util.Condense
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Ed448.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Ed448.hs
@@ -9,13 +9,12 @@ module Ouroboros.Consensus.Crypto.DSIGN.Ed448
     ( Ed448DSIGN
     ) where
 
+import           Codec.Serialise (Serialise (..), serialise)
 import           Crypto.PubKey.Ed448
 import           Data.ByteArray (ByteArrayAccess)
 import           Data.ByteString.Lazy (toStrict)
 import           Data.Function (on)
 import           GHC.Generics (Generic)
-
-import           Ouroboros.Network.Serialise
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Class
 import           Ouroboros.Consensus.Crypto.Hash

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Mock.hs
@@ -11,9 +11,8 @@ module Ouroboros.Consensus.Crypto.DSIGN.Mock
     , verKeyIdFromSigned
     ) where
 
+import           Codec.Serialise (Serialise)
 import           GHC.Generics (Generic)
-
-import           Ouroboros.Network.Serialise
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Class
 import           Ouroboros.Consensus.Crypto.Hash

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/RSAPSS.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/RSAPSS.hs
@@ -10,6 +10,7 @@ module Ouroboros.Consensus.Crypto.DSIGN.RSAPSS
     ( RSAPSSDSIGN
     ) where
 
+import           Codec.Serialise (Serialise (..), serialise)
 import           Crypto.PubKey.RSA
 import           Crypto.PubKey.RSA.PSS
 import           Data.ByteString (unpack)
@@ -17,8 +18,6 @@ import           Data.ByteString.Lazy (toStrict)
 import           Data.Function (on)
 import           GHC.Generics (Generic)
 import           Text.Printf (printf)
-
-import           Ouroboros.Network.Serialise
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Class
 import           Ouroboros.Consensus.Crypto.Hash

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/Hash/Class.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/Hash/Class.hs
@@ -13,6 +13,9 @@ module Ouroboros.Consensus.Crypto.Hash.Class
     , fromHash
     ) where
 
+import           Codec.Serialise (Serialise (..))
+import           Codec.CBOR.Decoding (decodeBytes)
+import           Codec.CBOR.Write (toLazyByteString)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as SB
 import qualified Data.ByteString.Base16 as B16
@@ -25,7 +28,6 @@ import           GHC.Generics (Generic)
 import           Numeric.Natural
 
 import           Ouroboros.Consensus.Util.Condense
-import           Ouroboros.Network.Serialise
 
 class HashAlgorithm h where
     byteCount :: proxy h -> Natural

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/KES/Class.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/KES/Class.hs
@@ -13,10 +13,9 @@ module Ouroboros.Consensus.Crypto.KES.Class
     , verifySignedKES
     ) where
 
+import           Codec.Serialise (Serialise)
 import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
-
-import           Ouroboros.Network.Serialise
 
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Random

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/KES/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/KES/Mock.hs
@@ -11,10 +11,9 @@ module Ouroboros.Consensus.Crypto.KES.Mock
     , SignKeyKES(..)
     ) where
 
+import           Codec.Serialise (Serialise)
 import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
-
-import           Ouroboros.Network.Serialise (Serialise)
 
 import           Ouroboros.Consensus.Crypto.Hash
 import           Ouroboros.Consensus.Crypto.KES.Class

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/KES/Simple.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/KES/Simple.hs
@@ -11,12 +11,11 @@ module Ouroboros.Consensus.Crypto.KES.Simple
     ( SimpleKES
     ) where
 
+import           Codec.Serialise (Serialise)
 import           Control.Monad (replicateM)
 import           Data.Vector (Vector, fromList, (!?))
 import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
-
-import           Ouroboros.Network.Serialise (Serialise)
 
 import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Crypto.KES.Class

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/VRF/Class.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/VRF/Class.hs
@@ -13,11 +13,10 @@ module Ouroboros.Consensus.Crypto.VRF.Class
   , verifyCertified
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Crypto.Random (MonadRandom)
 import           GHC.Generics (Generic)
 import           Numeric.Natural
-
-import           Ouroboros.Network.Serialise
 
 class ( Show (VerKeyVRF v)
       , Ord (VerKeyVRF v)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/VRF/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/VRF/Mock.hs
@@ -10,6 +10,7 @@ module Ouroboros.Consensus.Crypto.VRF.Mock
   , SignKeyVRF (..)
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Data.Proxy (Proxy (..))
 import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
@@ -18,7 +19,6 @@ import           Ouroboros.Consensus.Crypto.Hash
 import           Ouroboros.Consensus.Crypto.VRF.Class
 import           Ouroboros.Consensus.Util.HList
 import           Ouroboros.Consensus.Util.Random
-import           Ouroboros.Network.Serialise
 
 data MockVRF
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/VRF/Simple.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/VRF/Simple.hs
@@ -19,11 +19,11 @@ import           Data.Function (on)
 import           Data.Proxy (Proxy (..))
 import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
+import           Codec.Serialise (Serialise (..))
 
 import           Ouroboros.Consensus.Crypto.Hash
 import           Ouroboros.Consensus.Crypto.VRF.Class
 import           Ouroboros.Consensus.Util.HList
-import           Ouroboros.Network.Serialise hiding ((<>))
 
 data SimpleVRF
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo.hs
@@ -27,6 +27,7 @@ module Ouroboros.Consensus.Demo (
   , HasCreator(..)
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Control.Monad.Except
 import           Data.Either (fromRight)
 import           Data.IntMap.Strict (IntMap)
@@ -35,7 +36,6 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
 import           Ouroboros.Network.Chain (Chain (..))
-import           Ouroboros.Network.Serialise (Serialise)
 
 import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Crypto.DSIGN.Mock (verKeyIdFromSigned)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -25,6 +25,7 @@ module Ouroboros.Consensus.Node (
   , Network.loggingChannel
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Control.Monad
 import           Control.Monad.Except
 import           Crypto.Random (ChaChaDRG)
@@ -49,7 +50,6 @@ import           Ouroboros.Network.Protocol.ChainSync.Client
 import           Ouroboros.Network.Protocol.ChainSync.Examples
 import           Ouroboros.Network.Protocol.ChainSync.Server
 import           Ouroboros.Network.Protocol.ChainSync.Type
-import           Ouroboros.Network.Serialise (Serialise)
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -29,6 +29,7 @@ module Ouroboros.Consensus.Protocol.Abstract (
   , evalNodeState
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Control.Monad.Except
 import           Control.Monad.State
 import           Crypto.Random (MonadRandom (..))
@@ -43,7 +44,6 @@ import           Control.Monad.Class.MonadSay
 import           Ouroboros.Network.Block (HasHeader (..), Slot)
 import           Ouroboros.Network.Chain (Chain (..))
 import qualified Ouroboros.Network.Chain as Chain
-import           Ouroboros.Network.Serialise (Serialise)
 
 import           Ouroboros.Consensus.Util.Chain (upToSlot)
 import           Ouroboros.Consensus.Util.Random

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -20,6 +20,7 @@ module Ouroboros.Consensus.Protocol.BFT (
   , Payload(..)
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Control.Monad.Except
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -27,7 +28,6 @@ import           Data.Proxy
 import           GHC.Generics (Generic)
 
 import           Ouroboros.Network.Block
-import           Ouroboros.Network.Serialise
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Class
 import           Ouroboros.Consensus.Crypto.DSIGN.Ed448 (Ed448DSIGN)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
@@ -16,9 +16,8 @@ module Ouroboros.Consensus.Protocol.ExtNodeConfig (
   , Payload(..)
   ) where
 
+import           Codec.Serialise (Serialise)
 import           GHC.Generics (Generic)
-
-import           Ouroboros.Network.Serialise
 
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -12,12 +12,12 @@ module Ouroboros.Consensus.Protocol.LeaderSchedule (
   , NodeConfig (..)
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           GHC.Generics (Generic)
 
 import           Ouroboros.Network.Block (Slot (..))
-import           Ouroboros.Network.Serialise (Serialise)
 
 import           Ouroboros.Consensus.Node (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -24,11 +24,11 @@ module Ouroboros.Consensus.Protocol.ModChainSel (
   , SupportedBlock
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Data.Proxy (Proxy (..))
 
 import           Ouroboros.Network.Block (HasHeader, Slot)
 import           Ouroboros.Network.Chain (Chain)
-import           Ouroboros.Network.Serialise
 
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -24,6 +24,8 @@ module Ouroboros.Consensus.Protocol.Praos (
   , Payload(..)
   ) where
 
+import           Codec.Serialise (Serialise, encode)
+import           Codec.CBOR.Encoding (Encoding)
 import           Control.Monad (unless)
 import           Control.Monad.Except (throwError)
 import           Data.IntMap.Strict (IntMap)
@@ -34,7 +36,6 @@ import           Numeric.Natural
 
 import           Ouroboros.Network.Block (HasHeader (..), Slot (..))
 import qualified Ouroboros.Network.Chain as Chain
-import           Ouroboros.Network.Serialise (Encoding, Serialise, encode)
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Ed448 (Ed448DSIGN)
 import           Ouroboros.Consensus.Crypto.Hash.Class (HashAlgorithm (..),

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Test.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Test.hs
@@ -18,9 +18,8 @@ module Ouroboros.Consensus.Protocol.Test (
   , Payload(..)
   ) where
 
+import           Codec.Serialise (Serialise)
 import           GHC.Generics (Generic)
-
-import           Ouroboros.Network.Serialise
 
 import           Ouroboros.Consensus.Node (NodeId)
 import           Ouroboros.Consensus.Protocol.Abstract

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Random.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Random.hs
@@ -19,6 +19,7 @@ module Ouroboros.Consensus.Util.Random (
     )
     where
 
+import           Codec.Serialise (Serialise)
 import           Control.Monad.State
 import           Crypto.Number.Generate (generateBetween)
 import           Crypto.Random (ChaChaDRG, MonadPseudoRandom, MonadRandom (..),
@@ -28,8 +29,6 @@ import           Data.List (genericLength)
 import           Data.Word (Word64)
 
 import           Control.Monad.Class.MonadSay
-
-import           Ouroboros.Network.Serialise (Serialise)
 
 {-------------------------------------------------------------------------------
   Producing values in MonadRandom

--- a/ouroboros-consensus/test-crypto/Test/Crypto/DSIGN.hs
+++ b/ouroboros-consensus/test-crypto/Test/Crypto/DSIGN.hs
@@ -10,13 +10,11 @@ import           Test.QuickCheck (Property, (==>))
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Ouroboros.Network.Serialise (prop_serialise)
-import           Ouroboros.Network.Serialise (Serialise)
-
 import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random (Seed, withSeed)
 
+import           Ouroboros.Network.Testing.Serialise (Serialise, prop_serialise)
 import           Test.Util.Orphans.Arbitrary ()
 
 --

--- a/ouroboros-consensus/test-crypto/Test/Crypto/Hash.hs
+++ b/ouroboros-consensus/test-crypto/Test/Crypto/Hash.hs
@@ -12,11 +12,10 @@ import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Ouroboros.Network.Serialise
-
 import           Ouroboros.Consensus.Crypto.Hash
 import           Ouroboros.Consensus.Util.Orphans ()
 
+import           Ouroboros.Network.Testing.Serialise
 import           Test.Util.Orphans.Arbitrary ()
 
 --

--- a/ouroboros-consensus/test-crypto/Test/Crypto/KES.hs
+++ b/ouroboros-consensus/test-crypto/Test/Crypto/KES.hs
@@ -15,12 +15,11 @@ import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Ouroboros.Network.Serialise (Serialise, prop_serialise)
-
 import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Crypto.KES
 import           Ouroboros.Consensus.Util.Random
 
+import           Ouroboros.Network.Testing.Serialise (Serialise, prop_serialise)
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.QuickCheck
 

--- a/ouroboros-consensus/test-crypto/Test/Crypto/VRF.hs
+++ b/ouroboros-consensus/test-crypto/Test/Crypto/VRF.hs
@@ -10,12 +10,11 @@ import           Test.QuickCheck (Property, counterexample, (==>))
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Ouroboros.Network.Serialise (Serialise, prop_serialise)
-
 import           Ouroboros.Consensus.Crypto.VRF
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random (Seed, withSeed)
 
+import           Ouroboros.Network.Testing.Serialise (Serialise, prop_serialise)
 import           Test.Util.Orphans.Arbitrary ()
 
 --

--- a/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
@@ -3,10 +3,9 @@
 
 module Test.Util.Orphans.Arbitrary () where
 
+import           Codec.Serialise (Serialise)
 import           Data.Time
 import           Test.QuickCheck hiding (Fixed (..))
-
-import           Ouroboros.Network.Serialise (Serialise)
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Crypto.DSIGN.Class (DSIGNAlgorithm (..))

--- a/ouroboros-network-testing/ChangeLog.md
+++ b/ouroboros-network-testing/ChangeLog.md
@@ -1,0 +1,5 @@
+# Revision history for ouroboros-network-testing
+
+## 0.1.0.0 -- 2019-03-07
+
+* Initial version

--- a/ouroboros-network-testing/LICENSE
+++ b/ouroboros-network-testing/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2018 IOHK
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to
+do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/ouroboros-network-testing/ouroboros-network-testing.cabal
+++ b/ouroboros-network-testing/ouroboros-network-testing.cabal
@@ -1,0 +1,56 @@
+name:                ouroboros-network-testing
+version:             0.1.0.0
+synopsis:            Common modules used for testing in ouroboros-network and ouroboros-consensus
+license:             MIT
+license-file:        LICENSE
+author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts, Karl Knuttson 
+maintainer:
+copyright:           2018 IOHK
+category:            Network
+build-type:          Simple
+extra-source-files:  ChangeLog.md
+cabal-version:       >=1.10
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+library
+  hs-source-dirs:      src
+
+  -- At this experiment/prototype stage everything is exposed.
+  -- This has to be tidied up once the design becomes clear.
+  exposed-modules:
+                       Ouroboros.Network.Testing.Serialise
+  default-language:    Haskell2010
+  other-extensions:    BangPatterns,
+                       DataKinds,
+                       EmptyCase,
+                       ExistentialQuantification,
+                       FlexibleContexts,
+                       FlexibleInstances,
+                       FunctionalDependencies,
+                       GADTs,
+                       GADTSyntax,
+                       GeneralizedNewtypeDeriving,
+                       MultiParamTypeClasses,
+                       NamedFieldPuns,
+                       OverloadedStrings,
+                       PolyKinds,
+                       RankNTypes,
+                       RecordWildCards,
+                       ScopedTypeVariables,
+                       TemplateHaskell,
+                       TupleSections,
+                       TypeApplications,
+                       TypeFamilies,
+                       TypeInType
+  build-depends:       base              >=4.9 && <4.13,
+
+                       cborg             >=0.2.1 && <0.3,
+                       serialise         >=0.2 && <0.3,
+                       QuickCheck
+
+  ghc-options:         -Wall
+                       -Wno-unticked-promoted-constructors
+                       -fno-ignore-asserts

--- a/ouroboros-network-testing/src/Ouroboros/Network/Testing/Serialise.hs
+++ b/ouroboros-network-testing/src/Ouroboros/Network/Testing/Serialise.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-module Ouroboros.Network.Serialise (
+module Ouroboros.Network.Testing.Serialise (
       -- * Class
       Serialise(..)
     , prop_serialise

--- a/ouroboros-network-testing/src/Ouroboros/Network/Testing/Serialise.hs
+++ b/ouroboros-network-testing/src/Ouroboros/Network/Testing/Serialise.hs
@@ -5,27 +5,12 @@ module Ouroboros.Network.Testing.Serialise (
     , prop_serialise
     , prop_serialise_valid
     , prop_serialise_roundtrip
-
-
-      -- * Re-exports
-    , module Codec.CBOR.Encoding
-    , module Codec.CBOR.Decoding
-    , (<>)
-    , serialise
-    , deserialise
-    , deserialiseOrFail
-    , toLazyByteString
     )
     where
 
-import           Codec.CBOR.Decoding hiding (DecodeAction (..), TokenType (..))
-import           Codec.CBOR.Encoding hiding (Encoding (..), Tokens (..))
-import           Codec.CBOR.Encoding (Encoding)
 import           Codec.CBOR.FlatTerm
 import           Codec.CBOR.Read (DeserialiseFailure (..))
-import           Codec.CBOR.Write (toLazyByteString)
 import           Codec.Serialise
-import           Codec.Serialise.Decoding (decodeBytes)
 import           Test.QuickCheck (Property, counterexample, property, (.&&.), (===))
 
 -- Class properties

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -41,7 +41,6 @@ library
                        Ouroboros.Network.NodeToNode
                        Ouroboros.Network.NodeToClient
                        Ouroboros.Network.Pipe
-                       Ouroboros.Network.Serialise
                        Ouroboros.Network.Socket
                        Ouroboros.Network.Testing.ConcreteBlock
                        Ouroboros.Network.Protocol.ChainSync.Client
@@ -99,9 +98,7 @@ library
                        serialise         >=0.2 && <0.3,
                        say,
                        stm               >=2.4 && <2.6,
-                       text              >=1.2 && <1.3,
-
-                       QuickCheck        >=2.12 && <2.13
+                       text              >=1.2 && <1.3
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
@@ -142,7 +139,6 @@ test-suite tests
                        Ouroboros.Network.Protocol.PingPong.Test
                        Ouroboros.Network.Protocol.ReqResp.Codec
                        Ouroboros.Network.Protocol.ReqResp.Test
-                       Ouroboros.Network.Serialise
                        Ouroboros.Network.Socket
 
                        Test.Chain
@@ -160,6 +156,7 @@ test-suite tests
                        typed-protocols,
                        io-sim-classes,
                        io-sim            >=0.1 && < 0.2,
+                       ouroboros-network-testing,
 
                        array,
                        async,

--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -23,8 +23,8 @@ module Ouroboros.Network.Block (
 import           Data.Hashable
 import           Data.FingerTree (Measured)
 import           GHC.Generics (Generic)
+import           Codec.Serialise (Serialise (..))
 
-import           Ouroboros.Network.Serialise
 
 -- | The Ouroboros time slot index for a block.
 newtype Slot = Slot { getSlot :: Word }

--- a/ouroboros-network/src/Ouroboros/Network/Chain.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Chain.hs
@@ -71,9 +71,11 @@ import           Prelude hiding (drop, head, length, null)
 
 import           Control.Exception (assert)
 import qualified Data.List as L
+import           Codec.Serialise (Serialise (..))
+import           Codec.CBOR.Encoding (encodeListLen)
+import           Codec.CBOR.Decoding (decodeListLen, decodeListLenOf)
 
 import           Ouroboros.Network.Block
-import           Ouroboros.Network.Serialise
 
 --
 -- Blockchain type

--- a/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
@@ -76,10 +76,12 @@ import qualified Data.FingerTree as FT
 import qualified Data.Foldable as Foldable
 import qualified Data.List as L
 import           Data.Maybe (isJust)
+import           Codec.Serialise (Serialise (..))
+import           Codec.CBOR.Encoding (encodeListLen)
+import           Codec.CBOR.Decoding (decodeListLen)
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (Point(..), blockPoint, ChainUpdate(..))
-import           Ouroboros.Network.Serialise
 
 --
 -- Blockchain fragment data type.

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -30,11 +30,21 @@ module Ouroboros.Network.Testing.ConcreteBlock (
 import           Data.FingerTree (Measured(measure))
 import           Data.Hashable
 import qualified Data.Text as Text
+import           Codec.Serialise (Serialise (..))
+import           Codec.CBOR.Encoding ( encodeListLen
+                                     , encodeInt
+                                     , encodeWord
+                                     , encodeString
+                                     )
+import           Codec.CBOR.Decoding ( decodeListLenOf
+                                     , decodeInt
+                                     , decodeWord
+                                     , decodeString
+                                     )
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain
 import qualified Ouroboros.Network.ChainFragment as CF
-import           Ouroboros.Network.Serialise
 
 {-------------------------------------------------------------------------------
   Concrete block shape used currently in the network layer

--- a/ouroboros-network/test/Test/Chain.hs
+++ b/ouroboros-network/test/Test/Chain.hs
@@ -17,7 +17,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 import           Ouroboros.Network.Block (blockPrevHash)
 import           Ouroboros.Network.Chain (Chain (..), Point (..), genesisPoint)
 import qualified Ouroboros.Network.Chain as Chain
-import           Ouroboros.Network.Serialise (prop_serialise)
+import           Ouroboros.Network.Testing.Serialise (prop_serialise)
 
 import           Test.ChainGenerators hiding (tests)
 

--- a/ouroboros-network/test/Test/ChainFragment.hs
+++ b/ouroboros-network/test/Test/ChainFragment.hs
@@ -35,7 +35,7 @@ import           Ouroboros.Network.Chain (ChainUpdate(..), Point(..))
 import           Ouroboros.Network.ChainFragment (ChainFragment,
                                                   pattern (:>), pattern Empty)
 import qualified Ouroboros.Network.ChainFragment as CF
-import           Ouroboros.Network.Serialise (prop_serialise)
+import           Ouroboros.Network.Testing.Serialise (prop_serialise)
 import           Ouroboros.Network.Testing.ConcreteBlock
 
 

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -5,6 +5,9 @@ module Test.Mux (
     , setupMiniReqRsp
     , tests) where
 
+import           Codec.Serialise (Serialise (..))
+import           Codec.CBOR.Encoding (encodeBytes)
+import           Codec.CBOR.Decoding (decodeBytes)
 import           Control.Monad
 import qualified Data.Binary.Put as Bin
 import qualified Data.ByteString.Lazy as BL
@@ -24,7 +27,6 @@ import           Network.TypedProtocol.ReqResp.Server
 import           Ouroboros.Network.Channel
 import qualified Ouroboros.Network.Mux as Mx
 import           Ouroboros.Network.Protocol.ReqResp.Codec
-import           Ouroboros.Network.Testing.Serialise
 
 tests :: TestTree
 tests =

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -24,7 +24,7 @@ import           Network.TypedProtocol.ReqResp.Server
 import           Ouroboros.Network.Channel
 import qualified Ouroboros.Network.Mux as Mx
 import           Ouroboros.Network.Protocol.ReqResp.Codec
-import           Ouroboros.Network.Serialise
+import           Ouroboros.Network.Testing.Serialise
 
 tests :: TestTree
 tests =

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Pipe (tests) where
 
+import           Codec.Serialise (Serialise)
 import           Control.Monad
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSTM
@@ -25,7 +26,6 @@ import           Ouroboros.Network.Protocol.ChainSync.Client
 import           Ouroboros.Network.Protocol.ChainSync.Codec
 import           Ouroboros.Network.Protocol.ChainSync.Examples
 import           Ouroboros.Network.Protocol.ChainSync.Server
-import           Ouroboros.Network.Testing.Serialise
 
 --
 -- The list of all tests

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -25,7 +25,7 @@ import           Ouroboros.Network.Protocol.ChainSync.Client
 import           Ouroboros.Network.Protocol.ChainSync.Codec
 import           Ouroboros.Network.Protocol.ChainSync.Examples
 import           Ouroboros.Network.Protocol.ChainSync.Server
-import           Ouroboros.Network.Serialise
+import           Ouroboros.Network.Testing.Serialise
 
 --
 -- The list of all tests

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -30,7 +30,7 @@ import           Ouroboros.Network.Protocol.ChainSync.Client
 import           Ouroboros.Network.Protocol.ChainSync.Codec
 import           Ouroboros.Network.Protocol.ChainSync.Examples
 import           Ouroboros.Network.Protocol.ChainSync.Server
-import           Ouroboros.Network.Serialise
+import           Ouroboros.Network.Testing.Serialise
 
 import           Test.ChainGenerators (TestBlockChainAndUpdates (..))
 import qualified Test.Mux as Mxt

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -40,12 +40,16 @@ let
       cleanSource (callCabal2nix "typed-protocols" ./typed-protocols { inherit io-sim io-sim-classes; })
     )))));
 
+    ouroboros-network-testing = doWerror(docNoSeprateOutput(doHaddock(doTest(doBench(
+      cleanSource (callCabal2nix "ouroboros-network-testing" ./ouroboros-network-testing { })
+    )))));
+
     ouroboros-network = doWerror(docNoSeprateOutput(doHaddock(doTest(doBench(
-      cleanSource (callCabal2nix "ouroboros-network" ./ouroboros-network { inherit io-sim io-sim-classes typed-protocols; })
+      cleanSource (callCabal2nix "ouroboros-network" ./ouroboros-network { inherit io-sim io-sim-classes typed-protocols ouroboros-network-testing; })
     )))));
 
     ouroboros-consensus = doWerror(docNoSeprateOutput(doHaddock(doTest(doBench(
-      cleanSource (callCabal2nix "ouroboros-consensus" ./ouroboros-consensus { inherit io-sim-classes io-sim typed-protocols ouroboros-network; })
+      cleanSource (callCabal2nix "ouroboros-consensus" ./ouroboros-consensus { inherit io-sim-classes io-sim typed-protocols ouroboros-network-testing ouroboros-network; })
     )))));
 
     byron-proxy = doWerror(docNoSeprateOutput(doHaddock(doTest(doBench(


### PR DESCRIPTION
Moved to a seprate package, since it is used in various test cases in `ouroboros-network` and `ouroboros-consensus`.  This PR removes `QuickCheck` dependency from `ouroboros-network` and `ouroboros-consensus`.

We can move even more to `ouroboros-network-testing`, e.g. the `Ouroboros.Network.Testing.ConcreteBlock`, but this will be done at a later stage.