### PR TITLE
First version of the ledger DB

### DIFF
--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -111,6 +111,7 @@
             (hsPkgs.ouroboros-network)
             (hsPkgs.ouroboros-consensus)
             (hsPkgs.io-sim-classes)
+            (hsPkgs.io-sim)
             (hsPkgs.bifunctors)
             (hsPkgs.binary)
             (hsPkgs.bytestring)

--- a/ouroboros-consensus/demo-playground/Mock/TxSubmission.hs
+++ b/ouroboros-consensus/demo-playground/Mock/TxSubmission.hs
@@ -24,7 +24,8 @@ import           Ouroboros.Consensus.Crypto.Hash (ShortHash)
 import qualified Ouroboros.Consensus.Crypto.Hash as H
 import           Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Ledger.Mock as Mock
-import           Ouroboros.Consensus.Node (NodeId(..), NodeKernel (getExtLedgerState))
+import           Ouroboros.Consensus.Node (NodeId (..),
+                     NodeKernel (getExtLedgerState))
 import           Ouroboros.Consensus.Util.CBOR (Decoder (..), initDecoderIO)
 import           Ouroboros.Consensus.Util.Condense
 

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -83,6 +83,13 @@ library
                        Ouroboros.Storage.ImmutableDB.Index
                        Ouroboros.Storage.ImmutableDB.Types
                        Ouroboros.Storage.ImmutableDB.Util
+                       Ouroboros.Storage.IO
+                       Ouroboros.Storage.LedgerDB.Conf
+                       Ouroboros.Storage.LedgerDB.DiskPolicy
+                       Ouroboros.Storage.LedgerDB.InMemory
+                       Ouroboros.Storage.LedgerDB.MemPolicy
+                       Ouroboros.Storage.LedgerDB.Offsets
+                       Ouroboros.Storage.LedgerDB.OnDisk
                        Ouroboros.Storage.Util
                        Ouroboros.Storage.Util.ErrorHandling
                        Ouroboros.Storage.VolatileDB
@@ -90,7 +97,6 @@ library
                        Ouroboros.Storage.VolatileDB.Impl
                        Ouroboros.Storage.VolatileDB.Types
                        Ouroboros.Storage.VolatileDB.Util
-                       Ouroboros.Storage.IO
 
   default-language:    Haskell2010
   other-extensions:
@@ -270,7 +276,6 @@ test-suite test-storage
   main-is:          Main.hs
   other-modules:
                     Test.Ouroboros.Storage
-                    Test.Ouroboros.Storage.Util
                     Test.Ouroboros.Storage.FS
                     Test.Ouroboros.Storage.FS.Sim.Error
                     Test.Ouroboros.Storage.FS.StateMachine
@@ -279,6 +284,10 @@ test-suite test-storage
                     Test.Ouroboros.Storage.ImmutableDB.Model
                     Test.Ouroboros.Storage.ImmutableDB.StateMachine
                     Test.Ouroboros.Storage.ImmutableDB.TestBlock
+                    Test.Ouroboros.Storage.LedgerDB
+                    Test.Ouroboros.Storage.LedgerDB.InMemory
+                    Test.Ouroboros.Storage.LedgerDB.OnDisk
+                    Test.Ouroboros.Storage.Util
                     Test.Ouroboros.Storage.VolatileDB
                     Test.Ouroboros.Storage.VolatileDB.Model
                     Test.Ouroboros.Storage.VolatileDB.StateMachine
@@ -288,6 +297,7 @@ test-suite test-storage
                     ouroboros-network,
                     ouroboros-consensus,
                     io-sim-classes,
+                    io-sim,
 
                     bifunctors,
                     binary,

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -12,6 +12,7 @@ module Ouroboros.Consensus.Util (
   , foldlM'
   , repeatedly
   , repeatedlyM
+  , nTimes
   , chunks
   , byteStringChunks
   , lazyByteStringChunks
@@ -24,6 +25,9 @@ module Ouroboros.Consensus.Util (
   , allDisjoint
   , (.:)
   , (..:)
+  , takeLast
+  , dropLast
+  , mustBeRight
   ) where
 
 import qualified Data.ByteString as Strict
@@ -32,6 +36,7 @@ import           Data.Kind (Constraint)
 import           Data.List (foldl')
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.Void
 import           Data.Word (Word64)
 import           GHC.Stack
 
@@ -57,6 +62,13 @@ repeatedly = flip . foldl' . flip
 
 repeatedlyM :: Monad m => (a -> b -> m b) -> ([a] -> b -> m b)
 repeatedlyM = flip . foldlM' . flip
+
+nTimes :: forall a. (a -> a) -> Word64 -> (a -> a)
+nTimes f = go
+  where
+    go :: Word64 -> (a -> a)
+    go 0 x = x
+    go n x = go (n - 1) (f x)
 
 chunks :: Int -> [a] -> [[a]]
 chunks _ [] = []
@@ -132,3 +144,15 @@ allDisjoint = go Set.empty
 
 (..:) :: (d -> e) -> (a -> b -> c -> d) -> (a -> b -> c -> e)
 (f ..: g) a b c = f (g a b c)
+
+-- | Take the last @n@ elements
+takeLast :: Word64 -> [a] -> [a]
+takeLast n = reverse . take (fromIntegral n) . reverse
+
+-- | Drop the last @n@ elements
+dropLast :: Word64 -> [a] -> [a]
+dropLast n = reverse . drop (fromIntegral n) . reverse
+
+mustBeRight :: Either Void a -> a
+mustBeRight (Left  v) = absurd v
+mustBeRight (Right a) = a

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
@@ -108,6 +108,9 @@ data ReadIncrementalErr =
 
 -- | Read a file incrementally
 --
+-- NOTE: The 'MonadThrow' constraint is only needed for 'bracket'. This
+-- function does not actually throw anything.
+--
 -- NOTE: This uses a chunk size of roughly 32k. If we use this function to read
 -- small things this might not be ideal.
 --

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
@@ -53,6 +53,8 @@ data HasFS m h = HasFS {
   , hPut                     :: HasCallStack => h -> Builder -> m Word64
 
     -- | Truncate the file to the specified size
+    --
+    -- NOTE: Only supported in append mode.
   , hTruncate                :: HasCallStack => h -> Word64 -> m ()
 
     -- | Return current file size

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/Conf.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/Conf.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Ouroboros.Storage.LedgerDB.Conf (
+    LedgerDbConf(..)
+  , PrevApplied(..)
+    -- * Support for tests
+  , PureLedgerDbConf
+  , pureLedgerDbConf
+  ) where
+
+import           Data.Functor.Identity
+import           Data.Void
+
+import           Ouroboros.Consensus.Util ((.:))
+
+{-------------------------------------------------------------------------------
+  Callbacks required by the ledger DB
+-------------------------------------------------------------------------------}
+
+-- | Callbacks required by the ledger DB
+data LedgerDbConf m l r b e = LedgerDbConf {
+      -- | Get the genesis ledger
+      --
+      -- This is monadic because constructing the ledger state involves reading
+      -- configuration files etc. It is also rarely called.
+      ledgerDbGenesis :: m l
+
+      -- | Apply a block (passed by value)
+    , ledgerDbApply   :: PrevApplied -> b -> l -> Either e l
+
+      -- | Resolve a block
+      --
+      -- Resolving a block reference to the actual block lives in @m@ because
+      -- it might need to read the block from disk (and can therefore not be
+      -- done inside an STM transaction).
+      --
+      -- NOTE: The ledger DB will only ask the 'ChainDB' for blocks it knows
+      -- must exist. If the 'ChainDB' is unable to fulfill the request, data
+      -- corruption must have happened and the 'ChainStateDB' should trigger
+      -- validation mode.
+    , ledgerDbResolve :: r -> m b
+    }
+
+-- | Have we previously successfully applied this block to a ledger state?
+data PrevApplied =
+    -- | This block was previously applied
+    --
+    -- If we re-apply it to compute a new ledger state, expensive checks such as
+    -- the verification of cryptographic primitives can be skipped. Indeed,
+    -- a previously verified block /cannot/ result in a validation error.
+    PrevApplied
+
+    -- | Not previously applied
+    --
+    -- All checks must be performed
+  | NotPrevApplied
+
+{-------------------------------------------------------------------------------
+  Support for tests
+-------------------------------------------------------------------------------}
+
+-- | Ledger callbacks with no errors and where blocks are always passed by value
+type PureLedgerDbConf l b = LedgerDbConf Identity l b b Void
+
+pureLedgerDbConf :: l -> (b -> l -> l) -> PureLedgerDbConf l b
+pureLedgerDbConf l f = LedgerDbConf {
+      ledgerDbGenesis = Identity l
+    , ledgerDbResolve = Identity
+    , ledgerDbApply   = \_pa -> Right .: f
+    }

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
@@ -1,0 +1,67 @@
+module Ouroboros.Storage.LedgerDB.DiskPolicy (
+    DiskPolicy(..)
+  , defaultDiskPolicy
+  ) where
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadTimer
+
+import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+
+-- | On-disk policy
+--
+-- We only write ledger states that are older than @k@ blocks to disk (that is,
+-- snapshots that are guaranteed valid). The on-disk policy determines how often
+-- we write to disk and how many checkpoints we keep.
+data DiskPolicy m = DiskPolicy {
+      -- | How many snapshots do we want to keep on disk?
+      --
+      -- A higher number of on-disk snapshots is primarily a safe-guard against
+      -- disk corruption: it trades disk space for reliability.
+      --
+      -- Examples:
+      --
+      -- * @0@: Delete the snapshot immediately after writing.
+      --        Probably not a useful value :-D
+      -- * @1@: Delete the previous snapshot immediately after writing the next
+      --        Dangerous policy: if for some reason the deletion happens before
+      --        the new snapshot is written entirely to disk (we don't @fsync@),
+      --        we have no choice but to start at the genesis snapshot on the
+      --        next startup.
+      -- * @2@: Always keep 2 snapshots around. This means that when we write
+      --        the next snapshot, we delete the oldest one, leaving the middle
+      --        one available in case of truncation of the write. This is
+      --        probably a sane value in most circumstances.
+      onDiskNumSnapshots  :: Word
+
+      -- | How frequently do we want to write to disk?
+      --
+      -- Specified as an STM transaction that gives the delay (in microsec)
+      -- between writes, allowing the delay to be varied on the fly if needed.
+      --
+      -- Writing snapshots more often means we have less work to do when
+      -- opening the database, but at the cost of doing more IO while the node
+      -- is running.
+      --
+      -- A sensible value might be the time interval corresponding to @k@
+      -- blocks (12 hours), resulting in a gap between the most recent on disk
+      -- snapshot and the oldest in-memory snapshot between @k@ and @2k@ blocks.
+      --
+      -- NOTE: Specifying this as a time interval rather than in terms of number
+      -- of blocks means that during chain synchronization (where a node is
+      -- catching up with its neighbours) the frequency of writes /in terms of
+      -- blocks/ automatically goes down.
+    , onDiskWriteInterval :: STM m (Duration (Time m))
+    }
+
+-- | Default on-disk policy
+defaultDiskPolicy :: (MonadSTM m, MonadTime m)
+                  => SecurityParam     -- ^ Maximum rollback
+                  -> Duration (Time m) -- ^ Slot length
+                  -> STM m (DiskPolicy m)
+defaultDiskPolicy (SecurityParam k) slotLength = do
+    constantDelay <- newTVar (fromIntegral k * slotLength)
+    return DiskPolicy {
+        onDiskNumSnapshots  = 2
+      , onDiskWriteInterval = readTVar constantDelay
+      }

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -1,0 +1,492 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+
+module Ouroboros.Storage.LedgerDB.InMemory (
+     -- * Chain summary
+     Tip(..)
+   , tipIsGenesis
+   , ChainSummary(..)
+   , genesisChainSummary
+     -- * LedgerDB proper
+   , LedgerDB
+   , ledgerDbFromChain
+   , ledgerDbFromGenesis
+     -- ** Queries
+   , ledgerDbChainLength
+   , ledgerDbToList
+   , ledgerDbMaxRollback
+   , ledgerDbCurrent
+   , ledgerDbTip
+   , ledgerDbIsComplete
+   , ledgerDbIsSaturated
+   , ledgerDbTail
+     -- ** Updates
+   , BlockInfo(..)
+   , ledgerDbPush
+   , ledgerDbPushMany
+   , ledgerDbSwitch
+     -- * Rollback
+   , Suffix -- opaque
+   , toSuffix
+   , fromSuffix
+   , rollback
+   , rollbackMany
+     -- * Pure wrappers (primarily for property testing)
+   , ledgerDbComputeCurrent'
+   , ledgerDbPush'
+   , ledgerDbPushMany'
+   , ledgerDbSwitch'
+   , fromSuffix'
+     -- * Shape of the snapshots
+   , Shape(..)
+   , memPolicyShape
+   , snapshotsShape
+     -- * Demo
+   , demo
+   ) where
+
+import           Codec.Serialise (Serialise)
+import           Control.Monad.Except
+import           Data.Functor.Identity
+import           Data.Void
+import           Data.Word
+import           GHC.Generics (Generic)
+
+import           Ouroboros.Consensus.Util
+
+import           Ouroboros.Storage.LedgerDB.Conf
+import           Ouroboros.Storage.LedgerDB.MemPolicy
+import           Ouroboros.Storage.LedgerDB.Offsets
+
+{-------------------------------------------------------------------------------
+  Block info
+-------------------------------------------------------------------------------}
+
+data BlockInfo r b =
+    -- | Block passed by reference
+    BlockRef PrevApplied r
+
+    -- | Block passed by value
+    --
+    -- For convenience we also require the reference to this block
+  | BlockVal PrevApplied (r, b)
+
+{-------------------------------------------------------------------------------
+  Chain summary
+-------------------------------------------------------------------------------}
+
+-- | Tip of the chain
+data Tip r = Tip r | TipGen
+  deriving (Show, Eq, Generic)
+
+tipIsGenesis :: Tip r -> Bool
+tipIsGenesis TipGen  = True
+tipIsGenesis (Tip _) = False
+
+-- | Summary of the chain at a particular point in time
+data ChainSummary l r = ChainSummary {
+      -- | The tip of the chain
+      csTip    :: Tip r
+
+      -- | Length of the chain
+    , csLength :: Word64
+
+      -- | Ledger state
+    , csLedger :: l
+    }
+  deriving (Show, Eq, Generic)
+
+genesisChainSummary :: l -> ChainSummary l r
+genesisChainSummary l = ChainSummary TipGen 0 l
+
+{-------------------------------------------------------------------------------
+  LedgerDB proper
+-------------------------------------------------------------------------------}
+
+-- | Ledger snapshots
+--
+-- In addition to the ledger snapshots @l@ themselves we also store references
+-- @r@ to the blocks that led to those snapshots. This is important when we
+-- need to recompute the snapshots (in particular for rollback).
+data LedgerDB l r =
+    -- | Apply block @r@ and take a snapshot of the resulting ledger state @l@
+    Snap r l (LedgerDB l r)
+
+    -- | Apply block @r@ without taking a snapshot
+  | Skip r (LedgerDB l r)
+
+    -- | The tail of the chain that is outside the scope of the snapshots
+    --
+    -- We record a summary of the chain tail /at this point/ as well as the
+    -- missing snapshots, if any.
+  | Tail Missing (ChainSummary l r)
+  deriving (Show, Eq)
+
+-- | Are we still missing some snapshots?
+--
+-- This is represented as a list of skips:
+--
+-- * If the list is empty, all snapshots required by the policy are available.
+-- * If the list starts with @n@, the current oldest ledger state will become a
+--   snapshot after @n@ blocks have been applied.
+type Missing = [Word64]
+
+-- | Construct snapshots when we are in the genesis ledger state (no blocks)
+ledgerDbFromChain :: MemPolicy -> ChainSummary l r -> LedgerDB l r
+ledgerDbFromChain = Tail . memPolicyToSkips
+
+ledgerDbFromGenesis :: MemPolicy -> l -> LedgerDB l r
+ledgerDbFromGenesis policy = ledgerDbFromChain policy . genesisChainSummary
+
+{-------------------------------------------------------------------------------
+  Internal: derived functions in terms of 'BlockInfo'
+-------------------------------------------------------------------------------}
+
+-- | Block that we've seen before
+blockOld :: r -> BlockInfo r b
+blockOld = BlockRef PrevApplied
+
+blockRef :: BlockInfo r b -> r
+blockRef (BlockRef _ r)      = r
+blockRef (BlockVal _ (r, _)) = r
+
+applyBlock :: Monad m
+           => LedgerDbConf m l r b e
+           -> BlockInfo r b -> l -> m (Either e l)
+applyBlock LedgerDbConf{..} (BlockVal pa (_r, b)) l = do
+    return $ ledgerDbApply pa b l
+applyBlock LedgerDbConf{..} (BlockRef pa r) l = do
+    (\b -> ledgerDbApply pa b l) <$> ledgerDbResolve r
+
+snap :: BlockInfo r b -> l -> LedgerDB l r -> LedgerDB l r
+snap = Snap . blockRef
+
+skip :: BlockInfo r b -> LedgerDB l r -> LedgerDB l r
+skip = Skip . blockRef
+
+{-------------------------------------------------------------------------------
+  Queries
+-------------------------------------------------------------------------------}
+
+-- | Total length of the chain (in terms of number of blocks)
+ledgerDbChainLength :: LedgerDB l r -> Word64
+ledgerDbChainLength = go 0
+  where
+    go :: Word64 -> LedgerDB l r -> Word64
+    go !acc (Tail _ cs)   = acc + csLength cs
+    go !acc (Snap _ _ ss) = go (acc + 1) ss
+    go !acc (Skip _   ss) = go (acc + 1) ss
+
+-- | All snapshots along with their offsets from the tip of the chain
+ledgerDbToList :: LedgerDB l r -> Offsets l
+ledgerDbToList = offsetsFromPairs . go 0
+  where
+    go :: Word64 -> LedgerDB l r -> [(Word64, l)]
+    go offset (Snap _ l ss) = (offset, l) : go (offset + 1) ss
+    go offset (Skip _   ss) =               go (offset + 1) ss
+    go offset (Tail _ cs)   = [(offset, csLedger cs)]
+
+-- | How many blocks can be currently roll back?
+--
+-- If @ss@ is a 'LedgerDB' with @n@ blocks applied, we have
+--
+-- > ledgerDbMaxRollback ss == min (memPolicyMaxRollback policy) n
+ledgerDbMaxRollback :: LedgerDB l r -> Word64
+ledgerDbMaxRollback = last . offsetsDropValues . ledgerDbToList
+
+-- | Current snapshot, assuming mem policy specifies it must be recorded
+ledgerDbCurrent :: LedgerDB l r -> l
+ledgerDbCurrent (Snap _ l _) = l
+ledgerDbCurrent (Skip   _ _) = error "ledgerDbCurrent: not stored"
+ledgerDbCurrent (Tail _ cs)  = csLedger cs
+
+-- | Reference to the block at the tip of the chain
+--
+-- Returns 'Nothing' if genesis
+ledgerDbTip :: LedgerDB l r -> Tip r
+ledgerDbTip (Snap r _ _) = Tip r
+ledgerDbTip (Skip r   _) = Tip r
+ledgerDbTip (Tail _ cs)  = csTip cs
+
+-- | Is the ledger DB complete?
+--
+-- This is 'False' if the ledger DB is not saturated, /unless/ this is due to
+-- being close to genesis. In other words, the ledger DB is considered complete
+-- when it supports the maximum rollback required (if we are close to genesis
+-- the maximum required rollback can't go past genesis).
+ledgerDbIsComplete :: LedgerDB l r -> Bool
+ledgerDbIsComplete (Snap _ _ ss)   = ledgerDbIsComplete ss
+ledgerDbIsComplete (Skip _   ss)   = ledgerDbIsComplete ss
+ledgerDbIsComplete (Tail []    _)  = True
+ledgerDbIsComplete (Tail [0]   _)  = True
+ledgerDbIsComplete (Tail (_:_) cs) = tipIsGenesis (csTip cs)
+
+-- | Have all snapshots been filled?
+--
+-- TODO: Here and elsewhere it would be much nicer to avoid this @Tail [0]@
+-- special case. There is redundancy in the representation. We should
+-- reconsider this.
+ledgerDbIsSaturated :: LedgerDB l r -> Bool
+ledgerDbIsSaturated (Snap _ _ ss) = ledgerDbIsSaturated ss
+ledgerDbIsSaturated (Skip _   ss) = ledgerDbIsSaturated ss
+ledgerDbIsSaturated (Tail []  _)  = True
+ledgerDbIsSaturated (Tail [0] _)  = True
+ledgerDbIsSaturated (Tail _   _)  = False
+
+-- | The tail of the DB (oldest snapshot)
+ledgerDbTail :: LedgerDB l r -> ChainSummary l r
+ledgerDbTail (Snap _ _ ss) = ledgerDbTail ss
+ledgerDbTail (Skip _   ss) = ledgerDbTail ss
+ledgerDbTail (Tail _ cs)   = cs
+
+{-------------------------------------------------------------------------------
+  Updates
+-------------------------------------------------------------------------------}
+
+-- | Push a block
+ledgerDbPush :: forall m l r b e. Monad m
+             => LedgerDbConf m l r b e
+             -> BlockInfo r b
+             -> LedgerDB l r
+             -> m (Either e (LedgerDB l r))
+ledgerDbPush cfg = runExceptT .: go
+  where
+    app = ExceptT .: applyBlock cfg
+
+    go :: BlockInfo r b -> LedgerDB l r -> ExceptT e m (LedgerDB l r)
+    go b' (Snap r l ss) = snap b' <$> app b' l <*> go (blockOld r) ss
+    go b' (Skip r   ss) = skip b' <$>              go (blockOld r) ss
+    go b' (Tail os cs)
+      | []    <- os     = Tail [] <$> goCS b' cs
+      -- Create new snapshots when we need to
+      -- For the very last snapshot we use the 'End' constructor itself.
+      | [0]   <- os     = Tail [] <$> goCS b' cs
+      | 0:os' <- os     = snap b' <$> app b' l <*> pure (Tail      os'  cs)
+      | o:os' <- os     = skip b' <$>              pure (Tail (o-1:os') cs)
+      where
+        l = csLedger cs
+
+    goCS :: BlockInfo r b -> ChainSummary l r -> ExceptT e m (ChainSummary l r)
+    goCS b' ChainSummary{..} = do
+        csLedger' <- app b' csLedger
+        return ChainSummary{
+            csTip    = Tip (blockRef b')
+          , csLength = csLength + 1
+          , csLedger = csLedger'
+          }
+
+-- | Push a bunch of blocks (oldest first)
+ledgerDbPushMany :: Monad m
+                 => LedgerDbConf m l r b e
+                 -> [BlockInfo r b]
+                 -> LedgerDB l r
+                 -> m (Either e (LedgerDB l r))
+ledgerDbPushMany conf = runExceptT .: repeatedlyM (ExceptT .: ledgerDbPush conf)
+
+-- | Switch to a fork
+--
+-- PRE: Must have at least as many new blocks as we are rolling back.
+ledgerDbSwitch :: forall m l r b e. Monad m
+               => LedgerDbConf m l r b e
+               -> Word64              -- ^ How many blocks to roll back
+               -> [BlockInfo r b]   -- ^ New blocks to apply
+               -> LedgerDB l r
+               -> m (Either e (LedgerDB l r))
+ledgerDbSwitch cfg numRollbacks newBlocks ss =
+      fromSuffix cfg newBlocks
+    $ rollbackMany numRollbacks (toSuffix ss)
+
+{-------------------------------------------------------------------------------
+  Internal: implementation of rollback
+-------------------------------------------------------------------------------}
+
+-- | Suffix of 'LedgerDB' obtained by stripping some recent block
+data Suffix l r = Suffix {
+    -- | The remaining 'LedgerDB'
+    suffixRemaining :: LedgerDB l r
+
+    -- | The stuff we stripped off (old to new)
+  , suffixStripped  :: Stripped
+  }
+
+data Stripped =
+      -- | Nothing missing anymore; the prefix is complete
+      SNone
+
+      -- | Stripped off a 'Rec' constructor
+    | SSnap Stripped
+
+      -- | Stripped off a 'Skip' constructor
+    | SSkip Stripped
+
+-- | Trivial suffix (not actually stripping off any blocks)
+toSuffix :: LedgerDB l r -> Suffix l r
+toSuffix ss = Suffix { suffixRemaining = ss, suffixStripped = SNone }
+
+-- | Compute current snapshot
+--
+-- This will be O(1) /provided/ that we store the most recent snapshot
+-- (see also 'ledgerDbGetCurrent').
+ledgerDbComputeCurrent :: forall m l r b e. Monad m
+                       => LedgerDbConf m l r b e
+                       -> LedgerDB l r
+                       -> m (Either e l)
+ledgerDbComputeCurrent cfg = runExceptT . go
+  where
+    go :: LedgerDB l r -> ExceptT e m l
+    go (Snap _ l _)  = return l
+    go (Skip r   ss) = go ss >>= ExceptT . applyBlock cfg (blockOld r)
+    go (Tail _ cs)   = return (csLedger cs)
+
+fromSuffix :: forall m l r b e. Monad m
+           => LedgerDbConf m l r b e
+           -> [BlockInfo r b]
+           -> Suffix l r
+           -> m (Either e (LedgerDB l r))
+fromSuffix cfg = \bs suffix -> runExceptT $ do
+    -- Here we /must/ call 'ledgerDbComputeCurrent', not 'ledgerDbGetCurrent':
+    -- only if we are /very/ lucky would we roll back to a point where we happen
+    -- to store a snapshot.
+    l <- ExceptT $ ledgerDbComputeCurrent cfg (suffixRemaining suffix)
+    go bs suffix l
+  where
+    go :: [BlockInfo r b] -> Suffix l r -> l -> ExceptT e m (LedgerDB l r)
+    go bs     (Suffix ss SNone) _     = ExceptT $ ledgerDbPushMany cfg bs ss
+    go (b:bs) (Suffix ss (SSnap m)) l = do l' <- ExceptT $ applyBlock cfg b l
+                                           go bs (Suffix (snap b l' ss) m) l'
+    go (b:bs) (Suffix ss (SSkip m)) l = do l' <- ExceptT $ applyBlock cfg b l
+                                           go bs (Suffix (skip b ss) m) l'
+    go []     (Suffix _  (SSnap _)) _ = error "fromSuffix: too few blocks"
+    go []     (Suffix _  (SSkip _)) _ = error "fromSuffix: too few blocks"
+
+rollback :: Suffix l r -> Suffix l r
+rollback (Suffix (Snap _ _ ss) missing) = Suffix ss (SSnap missing)
+rollback (Suffix (Skip _   ss) missing) = Suffix ss (SSkip missing)
+rollback (Suffix (Tail _ _)    _) = error "rollback: cannot rollback past end"
+
+rollbackMany :: Word64 -> Suffix l r -> Suffix l r
+rollbackMany = nTimes rollback
+
+{-------------------------------------------------------------------------------
+  Pure variations (primarily for testing)
+-------------------------------------------------------------------------------}
+
+fromIdentity :: Identity (Either Void l) -> l
+fromIdentity = mustBeRight . runIdentity
+
+ledgerDbComputeCurrent' :: PureLedgerDbConf l b
+                        -> LedgerDB l b -> l
+ledgerDbComputeCurrent' f = fromIdentity . ledgerDbComputeCurrent f
+
+ledgerDbPush' :: PureLedgerDbConf l b
+              -> BlockInfo b b -> LedgerDB l b -> LedgerDB l b
+ledgerDbPush' f = fromIdentity .: ledgerDbPush f
+
+ledgerDbPushMany' :: PureLedgerDbConf l b
+                  -> [BlockInfo b b] -> LedgerDB l b -> LedgerDB l b
+ledgerDbPushMany' f = fromIdentity .: ledgerDbPushMany f
+
+ledgerDbSwitch' :: PureLedgerDbConf l b
+                -> Word64 -> [BlockInfo b b] -> LedgerDB l b -> LedgerDB l b
+ledgerDbSwitch' f n = fromIdentity .: ledgerDbSwitch f n
+
+fromSuffix' :: PureLedgerDbConf l b
+            -> [BlockInfo b b] -> Suffix l b -> LedgerDB l b
+fromSuffix' f = fromIdentity .: fromSuffix f
+
+{-------------------------------------------------------------------------------
+  Shape
+-------------------------------------------------------------------------------}
+
+-- | Shape of the snapshots
+--
+-- The shape of the snapshots tells us which snapshots are included and which
+-- aren't. This is used only for testing and stating invariants: both
+-- 'ledgerDbPush' and 'ledgerDbSwitch' must preserve this shape.
+data Shape = Included Shape | Excluded Shape | Nil
+  deriving (Show, Eq)
+
+-- | The shape that the policy dictates
+memPolicyShape :: MemPolicy -> Shape
+memPolicyShape = go 0 . offsetsDropValues . memPolicyToOffsets
+  where
+    go :: Word64 -> [Word64] -> Shape
+    go _   []     = Nil
+    go cur (o:os)
+      | cur == o  = Included $ go (cur + 1)    os
+      | otherwise = Excluded $ go (cur + 1) (o:os)
+
+-- | Compute the shape of the snapshots
+snapshotsShape :: LedgerDB l r -> Shape
+snapshotsShape (Snap _ _ ss) = Included (snapshotsShape ss)
+snapshotsShape (Skip  _  ss) = Excluded (snapshotsShape ss)
+snapshotsShape (Tail os _)   = go os
+  where
+    go :: Missing -> Shape
+    go []      = Included Nil
+    go [0]     = Included Nil
+    go (0:os') = Included $ go os'
+    go (o:os') = Excluded $ go (o-1:os')
+
+{-------------------------------------------------------------------------------
+  Serialisation
+
+  TODO: We shouldn't use the 'Generic' instances here
+-------------------------------------------------------------------------------}
+
+instance (Serialise r)              => Serialise (Tip r)
+instance (Serialise r, Serialise l) => Serialise (ChainSummary l r)
+
+{-------------------------------------------------------------------------------
+  Demo
+-------------------------------------------------------------------------------}
+
+type Branch     = Char
+newtype DemoLedger = DL (Branch, Int) deriving (Show)
+newtype DemoBlock  = DB (Branch, Int) deriving (Show)
+newtype DemoRef    = DR (Branch, Int) deriving (Show)
+newtype DemoErr    = DE (Int, Int)    deriving (Show)
+
+demoConf :: LedgerDbConf Identity DemoLedger DemoRef DemoBlock DemoErr
+demoConf = LedgerDbConf {
+      ledgerDbGenesis = Identity $ DL ('a', 0)
+    , ledgerDbApply   = \_prevApplied (DB r@(_, n)) (DL (_, l)) ->
+                          if n > l then Right $ DL r
+                                   else Left  $ DE (n, l)
+    , ledgerDbResolve = \(DR b) -> Identity (DB b)
+    }
+
+demoPolicy :: MemPolicy
+demoPolicy = memPolicyFromOffsets (offsetsWithoutValues [0, 2, 5])
+
+db0 :: LedgerDB DemoLedger DemoRef
+db0 = ledgerDbFromGenesis demoPolicy (DL ('a', 0))
+
+demo :: [LedgerDB DemoLedger DemoRef]
+demo = db0 : go 1 8 db0
+  where
+    go :: Int -> Int -> LedgerDB DemoLedger DemoRef -> [LedgerDB DemoLedger DemoRef]
+    go n m db =
+      if n > m then
+        let blockInfos = [ BlockVal NotPrevApplied (DR ('b', n-1), DB ('b', n-1))
+                         , BlockVal NotPrevApplied (DR ('b', n-0), DB ('b', n-0))
+                         ]
+            Identity (Right db') = ledgerDbSwitch demoConf 1 blockInfos db
+        in [db']
+      else
+        let blockInfo = BlockVal NotPrevApplied (DR ('a', n), DB ('a', n))
+            Identity (Right db') = ledgerDbPush demoConf blockInfo db
+        in db' : go (n + 1) m db'
+
+
+{-
+ledgerDbSwitch :: forall m l r b e. Monad m
+               => LedgerDbConf m l r b e
+               -> Word64              -- ^ How many blocks to roll back
+               -> [BlockInfo r b]   -- ^ New blocks to apply
+               -> LedgerDB l r
+               -> m (Either e (LedgerDB l r))
+-}

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/MemPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/MemPolicy.hs
@@ -1,0 +1,108 @@
+module Ouroboros.Storage.LedgerDB.MemPolicy (
+    MemPolicy -- opaque
+  , memPolicyVerify
+  , memPolicyValid
+  , memPolicyFromSkips
+  , memPolicyToSkips
+  , memPolicyFromOffsets
+  , memPolicyToOffsets
+  , memPolicyMaxRollback
+  , defaultMemPolicy
+  ) where
+
+import           Data.Either (isRight)
+import           Data.Word
+
+import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+
+import           Ouroboros.Storage.LedgerDB.Offsets
+
+{-------------------------------------------------------------------------------
+  Memory policy
+-------------------------------------------------------------------------------}
+
+-- | Memory policy
+newtype MemPolicy = MemPolicy {
+    -- | Internal representation
+    --
+    -- The memory policy is defined in terms of "how many blocks do I need to
+    -- see until my next snapshot?", starting with "how many blocks do I need to
+    -- see until I store the /first/ snapshot?".
+    --
+    -- For example, if we want to store snapshots at offsets 0, 2 and 5 from the
+    -- tip of the chain, the memory policy will be @[0, 1, 2]@:
+    --
+    -- >                        (tip)
+    -- >      5  (4) (3)  2  (1)  0
+    -- >     -----------------
+    -- >     l4  l5  l6  l7  l8  l9
+    -- >     ^^          ^^      ^^
+    -- >      \__________/\______/
+    -- >          2           1
+    --
+    -- Given sufficient number of blocks, we will store as many snapshots as
+    -- there are entries in the memory policy. A memory policy @[0, 0..]@ would
+    -- mean we keep absolutely all snapshots.
+    memPolicyToSkips :: [Word64]
+  }
+  deriving (Show, Eq)
+
+-- | Default in-memory policy
+--
+-- The in-memory policy specifies how many snapshots of the ledger state we
+-- must keep in memory. More in-memory snapshots means faster recovery from
+-- forks (which may be important for the short lived forks in Praos), but also
+-- means a larger memory footprint (although conceivably this is reduced through
+-- sharing). For the current ledger state a single copy of the ledger state is
+-- roughly 1.4 GB (though this can likely be shrunk by optimizing various data
+-- structures).
+--
+-- The policy for the snapshots in memory is independent from the policy for
+-- which snapshots we write to disk. Indeed, the most recent snapshot on disk
+-- may well be older than the oldest in-memory snapshot (in fact, this is
+-- likely). It cannot be the case of course that the most recent on disk
+-- snapshot is /newer/ than the oldest in-memory snapshot (this would mean if we
+-- reopen the ledger DB we would not be able to rollback sufficiently far).
+-- The distance between snapshots on disk and in memory is also unrelated.
+--
+-- TODO: Right now this just keeps the minimum: the most recent snapshot and
+-- one @k@ blocks back. Once we move to Praos we might want to keep an
+-- additional snapshot, say, 10 back, to be able to deal more efficiently with
+-- short-lived forks  (trading memory footprint for execution time).
+defaultMemPolicy :: SecurityParam -> MemPolicy
+defaultMemPolicy (SecurityParam k) =
+    memPolicyFromOffsets $ offsetsWithoutValues [0, k + 1]
+
+memPolicyVerify :: MemPolicy -> Either String ()
+memPolicyVerify (MemPolicy [])    = Left "MemPolicy should not be emty"
+memPolicyVerify (MemPolicy (0:_)) = Right ()
+memPolicyVerify (MemPolicy (_:_)) = Left "MemPolicy should start with 0"
+
+memPolicyValid :: MemPolicy -> Bool
+memPolicyValid = isRight . memPolicyVerify
+
+memPolicyFromSkips :: [Word64] -> MemPolicy
+memPolicyFromSkips = MemPolicy
+
+-- | Memory policy in terms of the offsets from the tip of the blockchain
+memPolicyToOffsets :: MemPolicy -> Offsets ()
+memPolicyToOffsets = offsetsWithoutValues . go 0 . memPolicyToSkips
+  where
+    go :: Word64 -> [Word64] -> [Word64]
+    go _         []     = []
+    go curOffset (0:ss) = curOffset : go (curOffset + 1) ss
+    go curOffset (s:ss) = go (curOffset + s) (0 : ss)
+
+memPolicyFromOffsets :: Offsets () -> MemPolicy
+memPolicyFromOffsets = MemPolicy . go 0 . offsetsDropValues
+  where
+    go :: Word64 -> [Word64] -> [Word64]
+    go _         []     = []
+    go curOffset (o:os) = o - curOffset : go (o + 1) os
+
+-- | Maxinum number of blocks we can roll back given the policy
+--
+-- Of course there is no guarantee that we can /actually/ roll back this far
+-- (if we are too close to genesis it might be less).
+memPolicyMaxRollback :: MemPolicy -> Word64
+memPolicyMaxRollback = last . offsetsDropValues . memPolicyToOffsets

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/Offsets.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/Offsets.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+
+module Ouroboros.Storage.LedgerDB.Offsets (
+    Offsets(..)
+  , offsetsFromPairs
+  , offsetsDropValues
+  , offsetsWithoutValues
+  ) where
+
+import           Data.Word
+import           GHC.Stack
+
+-- | List of @a@s paired with offsets
+--
+-- The offsets must be strictly and monotonically increasing.
+newtype Offsets a = Offsets { offsetsToPairs :: [(Word64, a)] }
+  deriving (Show, Eq, Functor)
+
+offsetsFromPairs :: forall a. HasCallStack => [(Word64, a)] -> Offsets a
+offsetsFromPairs pairs =
+    case pairs of
+      []          -> error validationErr
+      (o, a):rest -> Offsets $ (o, a) : validate o rest
+  where
+    validate :: Word64 -> [(Word64, a)] -> [(Word64, a)]
+    validate _    []            = []
+    validate prev ((o, a):rest)
+                    | prev < o  = (o, a) : validate o rest
+                    | otherwise = error validationErr
+
+    validationErr :: String
+    validationErr = "offsetsFromPairs: invalid " ++ show (map fst pairs)
+
+offsetsDropValues :: Offsets a -> [Word64]
+offsetsDropValues = map fst . offsetsToPairs
+
+offsetsWithoutValues :: [Word64] -> Offsets ()
+offsetsWithoutValues = offsetsFromPairs . map (, ())

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -1,0 +1,270 @@
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiWayIf                 #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TupleSections              #-}
+
+module Ouroboros.Storage.LedgerDB.OnDisk (
+    -- * Opening the database
+    initLedgerDB
+    -- ** Abstraction over the stream API
+  , NextBlock(..)
+  , StreamAPI(..)
+    -- * Write to disk
+  , takeSnapshot
+    -- * Low-level API (primarily exposed for testing)
+  , DiskSnapshot
+  , deleteSnapshot
+  , snapshotToPath
+  ) where
+
+import           Codec.Serialise (Serialise)
+import qualified Codec.Serialise as S
+import           Control.Monad.Except
+import qualified Data.List as List
+import           Data.Maybe (mapMaybe)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           GHC.Generics (Generic)
+import           GHC.Stack
+import           System.IO (IOMode (..))
+import           Text.Read (readMaybe)
+
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadThrow
+
+import           Ouroboros.Consensus.Util.CBOR
+
+import           Ouroboros.Storage.FS.API
+import           Ouroboros.Storage.FS.API.Types
+
+import           Ouroboros.Storage.LedgerDB.Conf
+import           Ouroboros.Storage.LedgerDB.InMemory
+import           Ouroboros.Storage.LedgerDB.MemPolicy
+
+{-------------------------------------------------------------------------------
+  Abstraction over the streaming API provided by the Chain DB
+-------------------------------------------------------------------------------}
+
+-- | Next block returned during streaming
+data NextBlock r b = NoMoreBlocks | NextBlock (r, b)
+
+-- | Abstraction over block streaming
+--
+-- In CPS form to enable the use of 'withXYZ' style iterator init functions.
+data StreamAPI m r b = StreamAPI {
+      -- | Start streaming after the specified block
+      streamAfter :: forall a.
+           Tip r
+        -- Current tip (exclusive lower bound point for streaming)
+
+        -> (Maybe (m (NextBlock r b)) -> m a)
+        -- Get the next block (by value)
+        --
+        -- 'Nothing' if the lower bound could not be found
+        -- (this can happen if the chain was truncated due to disk corruption
+        -- and this particular snapshot is now too recent)
+
+        -> m a
+    }
+
+-- | Stream all blocks
+streamAll :: forall m r b e a. Monad m
+          => StreamAPI m r b
+          -> Tip r                -- ^ Starting point for streaming
+          -> (Tip r -> e)         -- ^ Error when tip not found
+          -> a                    -- ^ Starting point when tip /is/ found
+          -> ((r, b) -> a -> m a) -- ^ Update function for each block
+          -> ExceptT e m a
+streamAll StreamAPI{..} tip notFound e f = ExceptT $
+    streamAfter tip $ \case
+      Nothing      -> return $ Left (notFound tip)
+      Just getNext -> do
+        let go :: a -> m a
+            go a = do mNext <- getNext
+                      case mNext of
+                        NoMoreBlocks -> return a
+                        NextBlock b  -> go =<< f b a
+        Right <$> go e
+
+{-------------------------------------------------------------------------------
+  Initialize the DB
+-------------------------------------------------------------------------------}
+
+-- | Initialize the ledger DB from the most recent snapshot on disk
+--
+-- If no such snapshot can be found, use the genesis ledger DB.
+--
+-- We do /not/ catch any exceptions thrown during streaming; should any be
+-- thrown, it is the responsibility of the 'ChainStateDB' to catch these
+-- and trigger (further) validation. We only discard snapshots if
+--
+-- * We cannot deserialise them, or
+-- * They are too close to the tip of the chain to give all snapshots required
+--   by the memory policy (the snapshot being /ahead/ of the chain is a
+--   special case of this).
+initLedgerDB :: forall m h l r b e. (
+                  MonadST    m
+                , MonadThrow m
+                , Serialise l
+                , Serialise r
+                )
+             => HasFS m h
+             -> MemPolicy
+             -> LedgerDbConf m l r b e
+             -> StreamAPI m r b
+             -> m (LedgerDB l r)
+initLedgerDB hasFS policy conf streamAPI = do
+    snapshots <- listSnapshots hasFS
+    tryNewestFirst snapshots
+  where
+    tryNewestFirst :: [DiskSnapshot] -> m (LedgerDB l r)
+    tryNewestFirst [] = do
+        -- We're out of snapshots. Start at genesis
+        initDb <- ledgerDbFromGenesis policy <$> ledgerDbGenesis conf
+        ml     <- runExceptT $ initStartingWith conf streamAPI initDb
+        case ml of
+          Left _  -> error "invariant violation: invalid current chain"
+          Right l -> return l
+    tryNewestFirst (s:ss) = do
+        -- If we fail to use this snapshot, delete it and try an older one
+        ml <- runExceptT $ initFromSnapshot hasFS policy conf streamAPI s
+        case ml of
+          Left _  -> deleteSnapshot hasFS s >> tryNewestFirst ss
+          Right l -> return l
+
+{-------------------------------------------------------------------------------
+  Internal: initialize using the given snapshot
+-------------------------------------------------------------------------------}
+
+data InitFailure r =
+    -- | We failed to deserialise the snapshot
+    --
+    -- This can happen due to data corruption in the ledger DB.
+    InitFailureRead ReadIncrementalErr
+
+    -- | This snapshot is too recent (ahead of the tip of the chain)
+  | InitFailureTooRecent (Tip r)
+
+    -- | Insufficient blocks applied to on-disk snapshot
+    --
+    -- We apply blocks to the on-disk snapshot to get back to a state where we
+    -- can support @k@ rollback. If a particular snapshot is too recent (due
+    -- to data loss in either the immutable DB or the volatile DB), we must
+    -- try an older snapshot instead.
+  | InitFailureIncomplete
+
+-- | Attempt to initialize the ledger DB from the given snapshot
+--
+-- If the chain DB or ledger layer reports an error, the whole thing is aborted
+-- and an error is returned. This should not throw any errors itself (ignoring
+-- unexpected exceptions such as asynchronous exceptions, of course).
+initFromSnapshot :: forall m h l r b e.
+                    (MonadST m, MonadThrow m, Serialise l, Serialise r)
+                 => HasFS m h
+                 -> MemPolicy
+                 -> LedgerDbConf m l r b e
+                 -> StreamAPI m r b
+                 -> DiskSnapshot
+                 -> ExceptT (InitFailure r) m (LedgerDB l r)
+initFromSnapshot hasFS policy conf streamAPI ss = do
+    initDb <- withExceptT InitFailureRead $
+                ledgerDbFromChain policy <$> readSnapshot hasFS ss
+    initStartingWith conf streamAPI initDb
+
+-- | Attempt to initialize the ledger DB starting from the given ledger DB
+initStartingWith :: forall m l r b e. Monad m
+                 => LedgerDbConf m l r b e
+                 -> StreamAPI m r b
+                 -> LedgerDB l r
+                 -> ExceptT (InitFailure r) m (LedgerDB l r)
+initStartingWith conf@LedgerDbConf{..} streamAPI initDb = do
+    applied <- streamAll streamAPI (ledgerDbTip initDb)
+                 InitFailureTooRecent
+                 initDb
+                 push
+    ExceptT $ return $ if ledgerDbIsComplete applied
+                         then Right applied
+                         else Left InitFailureIncomplete
+  where
+    push :: (r, b) -> LedgerDB l r -> m (LedgerDB l r)
+    push b db = mustBeValid <$> ledgerDbPush conf (BlockVal NotPrevApplied b) db
+
+    mustBeValid :: Either e (LedgerDB l r) -> LedgerDB l r
+    mustBeValid (Left _)   = error invalidChain
+    mustBeValid (Right db) = db
+
+    invalidChain :: String
+    invalidChain = concat [
+          "initStartingWith: "
+        , "invariant vaiolation: "
+        , "ChainDB selected invalid chain"
+        ]
+
+{-------------------------------------------------------------------------------
+  Write to disk
+-------------------------------------------------------------------------------}
+
+-- | Take a snapshot of the ledger DB
+--
+-- NOTE: This is a lower-level API that unconditionally takes a snapshot
+-- (i.e., independent from whether this snapshot corresponds to a state that
+-- is more than @k@ back).
+--
+-- TODO: Should we delete the file if an error occurs during writing?
+takeSnapshot :: (MonadThrow m, Serialise l, Serialise r)
+             => HasFS m h -> LedgerDB l r -> m DiskSnapshot
+takeSnapshot hasFS db = do
+    ss <- nextAvailable <$> listSnapshots hasFS
+    writeSnapshot hasFS ss (ledgerDbTail db)
+    return ss
+
+{-------------------------------------------------------------------------------
+  Internal: reading from disk
+-------------------------------------------------------------------------------}
+
+-- | On disk snapshots are numbered monotonically
+newtype DiskSnapshot = DiskSnapshot Int
+  deriving (Show, Eq, Ord, Generic)
+
+-- | Number of the next snapshot, given snapshots currently on disk
+nextAvailable :: [DiskSnapshot] -> DiskSnapshot
+nextAvailable [] = DiskSnapshot 1
+nextAvailable ss = let DiskSnapshot n = maximum ss in DiskSnapshot (n + 1)
+
+-- | Read snapshot from disk
+readSnapshot :: (MonadST m, MonadThrow m, Serialise l, Serialise r)
+             => HasFS m h
+             -> DiskSnapshot
+             -> ExceptT ReadIncrementalErr m (ChainSummary l r)
+readSnapshot hasFS = ExceptT . readIncremental hasFS . snapshotToPath
+
+-- | Write snapshot to disk
+writeSnapshot :: (MonadThrow m, Serialise l, Serialise r)
+              => HasFS m h -> DiskSnapshot -> ChainSummary l r -> m ()
+writeSnapshot hasFS@HasFS{..} ss cs = do
+    withFile hasFS (snapshotToPath ss) WriteMode $ \h ->
+      void $ hPut h (S.serialiseIncremental cs)
+
+-- | Delete snapshot from disk
+deleteSnapshot :: HasCallStack => HasFS m h -> DiskSnapshot -> m ()
+deleteSnapshot HasFS{..} = removeFile . snapshotToPath
+
+-- | List on-disk snapshots, most recent first
+listSnapshots :: Monad m => HasFS m h -> m [DiskSnapshot]
+listSnapshots HasFS{..} =
+    aux <$> listDirectory []
+  where
+    aux :: Set String -> [DiskSnapshot]
+    aux = List.sortBy (flip compare) . mapMaybe snapshotFromPath . Set.toList
+
+snapshotToPath :: DiskSnapshot -> FsPath
+snapshotToPath (DiskSnapshot ss) = [show ss]
+
+snapshotFromPath :: String -> Maybe DiskSnapshot
+snapshotFromPath = fmap DiskSnapshot . readMaybe

--- a/ouroboros-consensus/src/Ouroboros/Storage/Util/ErrorHandling.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Util/ErrorHandling.hs
@@ -16,6 +16,7 @@ module Ouroboros.Storage.Util.ErrorHandling (
   , exceptions
   , exceptT
   , monadCatch
+  , noErrors
   , embed
   , liftErrNewtype
   , liftErrReader
@@ -29,6 +30,7 @@ import qualified Control.Monad.Except as M
 import           Control.Monad.Reader (ReaderT (..), runReaderT)
 import           Control.Monad.State (StateT (..), runStateT)
 import           Data.Type.Coercion
+import           Data.Void
 
 import           Control.Monad.Class.MonadThrow (MonadCatch)
 import qualified Control.Monad.Class.MonadThrow as C
@@ -69,10 +71,18 @@ monadCatch = ErrorHandling {
     , catchError = C.catch
     }
 
+-- | Use standard IO exceptions
 exceptions :: Exception e => ErrorHandling e IO
 exceptions = ErrorHandling {
       throwError = E.throwIO
     , catchError = E.catch
+    }
+
+-- | Trivial 'ErrorHandling' for errors that cannot happen
+noErrors :: ErrorHandling Void m
+noErrors = ErrorHandling {
+      throwError = absurd
+    , catchError = const
     }
 
 -- | Embed one kind of error in another

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage.hs
@@ -2,10 +2,11 @@ module Test.Ouroboros.Storage
   ( tests
   ) where
 
-import GHC.Stack (HasCallStack)
+import           GHC.Stack (HasCallStack)
 
 import qualified Test.Ouroboros.Storage.FS as FS
 import qualified Test.Ouroboros.Storage.ImmutableDB as ImmutableDB
+import qualified Test.Ouroboros.Storage.LedgerDB as LedgerDB
 import qualified Test.Ouroboros.Storage.VolatileDB as VolatileDB
 import           Test.Tasty (TestTree, testGroup)
 
@@ -19,4 +20,5 @@ tests tmpDir = testGroup "Storage"
     [ FS.tests tmpDir
     , ImmutableDB.tests
     , VolatileDB.tests
+    , LedgerDB.tests
     ]

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB.hs
@@ -1,0 +1,14 @@
+module Test.Ouroboros.Storage.LedgerDB (
+    tests
+  ) where
+
+import           Test.Tasty
+
+import qualified Test.Ouroboros.Storage.LedgerDB.InMemory as InMemory
+import qualified Test.Ouroboros.Storage.LedgerDB.OnDisk as OnDisk
+
+tests :: TestTree
+tests = testGroup "LedgerDB" [
+      InMemory.tests
+    , OnDisk.tests
+    ]

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -1,0 +1,467 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Ouroboros.Storage.LedgerDB.InMemory (
+    tests
+  ) where
+
+import           Data.Word
+import           GHC.Stack
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+import           Ouroboros.Consensus.Util
+
+import           Ouroboros.Storage.LedgerDB.Conf
+import           Ouroboros.Storage.LedgerDB.InMemory
+import           Ouroboros.Storage.LedgerDB.MemPolicy
+import           Ouroboros.Storage.LedgerDB.Offsets
+
+tests :: TestTree
+tests = testGroup "InMemory" [
+      testGroup "MemPolicy" [
+          testProperty "invariant"     prop_memPolicy_invariant
+        , testProperty "fromToSkips"   prop_memPolicy_fromToSkips
+        , testProperty "toFromSkips"   prop_memPolicy_toFromSkips
+        , testProperty "fromToOffsets" prop_memPolicy_fromToOffsets
+        , testProperty "toFromOffsets" prop_memPolicy_toFromOffsets
+        ]
+    , testGroup "Genesis" [
+          testProperty "length"  prop_genesisLength
+        , testProperty "current" prop_genesisCurrent
+        ]
+    , testGroup "Push" [
+          testProperty "incrementsLength"       prop_pushIncrementsLength
+        , testProperty "preservesShape"         prop_pushPreservesShape
+        , testProperty "lengthMatchesNumBlocks" prop_lengthMatchesNumBlocks
+        , testProperty "shapeMatchesPolicy"     prop_shapeMatchesPolicy
+        , testProperty "matchesPolicy"          prop_pushMatchesPolicy
+        , testProperty "expectedLedger"         prop_pushExpectedLedger
+        ]
+    , testGroup "Rollback" [
+          testProperty "maxRollbackGenesisZero" prop_maxRollbackGenesisZero
+        , testProperty "ledgerDbMaxRollback"    prop_snapshotsMaxRollback
+        , testProperty "ledgerDbMaxRollbackSat" prop_snapshotsMaxRollbackSat
+        , testProperty "toFromSuffix"           prop_toFromSuffix
+        , testProperty "preservesShape"         prop_rollbackPreservesShape
+        , testProperty "switchSameChain"        prop_switchSameChain
+        , testProperty "switchExpectedLedger"   prop_switchExpectedLedger
+        ]
+    ]
+
+{-------------------------------------------------------------------------------
+  Memory policy
+-------------------------------------------------------------------------------}
+
+-- | Check the generator
+prop_memPolicy_invariant :: MemPolicy -> Property
+prop_memPolicy_invariant = (Right () ===) . memPolicyVerify
+
+prop_memPolicy_fromToSkips :: [Word64] -> Property
+prop_memPolicy_fromToSkips skips =
+    memPolicyToSkips (memPolicyFromSkips skips) === skips
+
+prop_memPolicy_toFromSkips :: MemPolicy -> Property
+prop_memPolicy_toFromSkips policy =
+    memPolicyFromSkips (memPolicyToSkips policy) === policy
+
+prop_memPolicy_fromToOffsets :: Offsets () -> Property
+prop_memPolicy_fromToOffsets offsets =
+    memPolicyToOffsets (memPolicyFromOffsets offsets) === offsets
+
+prop_memPolicy_toFromOffsets :: MemPolicy -> Property
+prop_memPolicy_toFromOffsets policy =
+    memPolicyFromOffsets (memPolicyToOffsets policy) === policy
+
+{-------------------------------------------------------------------------------
+  Genesis
+-------------------------------------------------------------------------------}
+
+prop_genesisCurrent :: MemPolicy -> Property
+prop_genesisCurrent policy =
+    ledgerDbCurrent genSnaps === initLedger
+  where
+    genSnaps = ledgerDbFromGenesis policy initLedger
+
+prop_genesisLength :: MemPolicy -> Property
+prop_genesisLength policy =
+   ledgerDbChainLength genSnaps === 0
+  where
+    genSnaps = ledgerDbFromGenesis policy initLedger
+
+{-------------------------------------------------------------------------------
+  Constructing snapshots
+-------------------------------------------------------------------------------}
+
+prop_pushIncrementsLength :: ChainSetup 'Unsaturated -> Property
+prop_pushIncrementsLength setup@ChainSetup{..} =
+    collect (saturation setup) $
+          ledgerDbChainLength (ledgerDbPush' callbacks blockInfo csPushed)
+      === ledgerDbChainLength csPushed + 1
+  where
+    blockInfo = BlockRef NotPrevApplied (Block maxBound 0)
+
+prop_lengthMatchesNumBlocks :: ChainSetup 'Unsaturated -> Property
+prop_lengthMatchesNumBlocks setup@ChainSetup{..} =
+    collect (saturation setup) $
+          ledgerDbChainLength csPushed
+      === csNumBlocks
+
+prop_shapeMatchesPolicy :: ChainSetup 'Unsaturated -> Property
+prop_shapeMatchesPolicy setup@ChainSetup{..} =
+    collect (saturation setup) $
+          snapshotsShape csPushed
+      === memPolicyShape csPolicy
+
+prop_pushPreservesShape :: ChainSetup 'Unsaturated -> Property
+prop_pushPreservesShape setup@ChainSetup{..} =
+    collect (saturation setup) $
+          snapshotsShape (ledgerDbPush' callbacks blockInfo csPushed)
+      === snapshotsShape csPushed
+  where
+    blockInfo = BlockRef NotPrevApplied (Block maxBound 0)
+
+prop_pushMatchesPolicy :: ChainSetup 'Saturated -> Property
+prop_pushMatchesPolicy setup@ChainSetup{..} =
+    conjoin [
+        saturation setup === Saturated
+      ,     (const () <$> ledgerDbToList csPushed)
+        === memPolicyToOffsets csPolicy
+      ]
+
+prop_pushExpectedLedger :: ChainSetup 'Unsaturated -> Property
+prop_pushExpectedLedger setup@ChainSetup{..} =
+    collect (saturation setup) $
+      conjoin [
+          l === applyMany (expectedChain o) initLedger
+        | (o, l) <- offsetsToPairs $ ledgerDbToList csPushed
+        ]
+  where
+    expectedChain :: Word64 -> [Block]
+    expectedChain o = take (fromIntegral (csNumBlocks - o)) csChain
+
+{-------------------------------------------------------------------------------
+  Rollback
+-------------------------------------------------------------------------------}
+
+prop_maxRollbackGenesisZero :: MemPolicy -> Property
+prop_maxRollbackGenesisZero policy =
+        ledgerDbMaxRollback (ledgerDbFromGenesis policy (Ledger []))
+    === 0
+
+prop_snapshotsMaxRollback :: ChainSetup 'Unsaturated -> Property
+prop_snapshotsMaxRollback setup@ChainSetup{..} =
+    collect (saturation setup) $
+          ledgerDbMaxRollback csPushed
+      === min (memPolicyMaxRollback csPolicy) csNumBlocks
+
+prop_snapshotsMaxRollbackSat :: ChainSetup 'Saturated -> Property
+prop_snapshotsMaxRollbackSat setup@ChainSetup{..} =
+    conjoin [
+        saturation setup === Saturated
+      , ledgerDbMaxRollback csPushed === memPolicyMaxRollback csPolicy
+      ]
+
+prop_toFromSuffix :: ChainSetup 'Unsaturated -> Property
+prop_toFromSuffix setup@ChainSetup{..} =
+    collect (saturation setup) $
+          fromSuffix' neverCalled [] (toSuffix csPushed)
+      === csPushed
+
+prop_rollbackPreservesShape :: SwitchSetup 'Unsaturated -> Property
+prop_rollbackPreservesShape setup@SwitchSetup{..} =
+    collect (saturation setup) $
+          snapshotsShape csPushed
+      === snapshotsShape ssSwitched
+  where
+    ChainSetup{..} = ssChainSetup
+
+prop_switchSameChain :: SwitchSetup 'Unsaturated -> Property
+prop_switchSameChain setup@SwitchSetup{..} =
+    collect (saturation setup) $
+          ledgerDbSwitch' callbacks ssNumRollback blockInfo csPushed
+      === csPushed
+  where
+    ChainSetup{..} = ssChainSetup
+    blockInfo      = map (BlockRef PrevApplied) ssRemoved
+
+prop_switchExpectedLedger :: SwitchSetup 'Unsaturated -> Property
+prop_switchExpectedLedger setup@SwitchSetup{..} =
+    collect (saturation setup) $
+      conjoin [
+          l === applyMany (expectedChain o) initLedger
+        | (o, l) <- offsetsToPairs $ ledgerDbToList ssSwitched
+        ]
+  where
+    ChainSetup{..} = ssChainSetup
+
+    expectedChain :: Word64 -> [Block]
+    expectedChain o = take (fromIntegral (ssNumBlocks - o)) ssChain
+
+{-------------------------------------------------------------------------------
+  Saturation
+-------------------------------------------------------------------------------}
+
+data Saturation =
+    -- | Saturated (all snapshots have been filled)
+    Saturated
+
+    -- | Unsaturated (not all snapshots may have been filled)
+  | Unsaturated
+  deriving (Show, Eq)
+
+class CheckSaturation (f :: Saturation -> *) where
+  saturation :: f s -> Saturation
+
+{-------------------------------------------------------------------------------
+  Test setup
+-------------------------------------------------------------------------------}
+
+data ChainSetup (s :: Saturation) = ChainSetup {
+      -- | Memory policy
+      csPolicy    :: MemPolicy
+
+      -- | Number of blocks applied
+    , csNumBlocks :: Word64
+
+      -- | Derived: genesis snapshots
+    , csGenSnaps  :: LedgerDB Ledger Block
+
+      -- | Derived: the actual blocks that got applied (old to new)
+    , csChain     :: [Block]
+
+      -- | Derived: the snapshots after all blocks were applied
+    , csPushed    :: LedgerDB Ledger Block
+    }
+  deriving (Show)
+
+instance CheckSaturation ChainSetup where
+  saturation ChainSetup{..}
+    | ledgerDbIsSaturated csPushed = Saturated
+    | otherwise                    = Unsaturated
+
+data SwitchSetup s = SwitchSetup {
+      -- | Chain setup
+      ssChainSetup  :: ChainSetup s
+
+      -- | Number of blocks to roll back
+    , ssNumRollback :: Word64
+
+      -- | Number of new blocks (to be applied after the rollback)
+    , ssNumNew      :: Word64
+
+      -- | Derived: number of blocks in the new chain
+    , ssNumBlocks   :: Word64
+
+      -- | Derived: the blocks that were removed
+    , ssRemoved     :: [Block]
+
+      -- | Derived: the new blocks themselves
+    , ssNewBlocks   :: [Block]
+
+      -- | Derived: the full chain after switching to this fork
+    , ssChain       :: [Block]
+
+      -- | Derived; the snapshots after the switch was performed
+    , ssSwitched    :: LedgerDB Ledger Block
+    }
+  deriving (Show)
+
+instance CheckSaturation SwitchSetup where
+  saturation = saturation . ssChainSetup
+
+mkTestSetup :: MemPolicy -> Word64 -> ChainSetup s
+mkTestSetup csPolicy csNumBlocks =
+    ChainSetup {..}
+  where
+    csGenSnaps = ledgerDbFromGenesis csPolicy initLedger
+    csChain    = mkChain csNumBlocks 0
+    blockInfo  = map (BlockRef NotPrevApplied) csChain
+    csPushed   = ledgerDbPushMany' callbacks blockInfo csGenSnaps
+
+mkRollbackSetup :: ChainSetup s -> Word64 -> Word64 -> SwitchSetup s
+mkRollbackSetup ssChainSetup ssNumRollback ssNumNew =
+    SwitchSetup {..}
+  where
+    ChainSetup{..} = ssChainSetup
+
+    ssNumBlocks = csNumBlocks - ssNumRollback + ssNumNew
+    ssRemoved   = takeLast ssNumRollback csChain
+    ssNewBlocks = drop (fromIntegral (csNumBlocks - ssNumRollback)) $
+                    mkChain ssNumBlocks 1
+    ssChain     = concat [
+                         take (fromIntegral (csNumBlocks - ssNumRollback)) csChain
+                       , ssNewBlocks
+                       ]
+    blockInfo   = map (BlockRef NotPrevApplied) ssNewBlocks
+    ssSwitched  = ledgerDbSwitch' callbacks ssNumRollback blockInfo csPushed
+
+instance Arbitrary (ChainSetup 'Unsaturated) where
+  arbitrary = sized $ \n -> do
+      policy    <- arbitrary
+      numBlocks <- choose (0, min (fromIntegral n) maxNumBlocks)
+      return $ mkTestSetup policy numBlocks
+
+  shrink ChainSetup{..} = concat [
+        [ mkTestSetup csPolicy' csNumBlocks
+        | csPolicy' <- shrink csPolicy
+        ]
+      , [ mkTestSetup csPolicy csNumBlocks'
+        | csNumBlocks' <- shrink csNumBlocks
+        ]
+      ]
+
+instance Arbitrary (ChainSetup 'Saturated) where
+  arbitrary = do
+      policy    <- arbitrary
+      let minNumBlocks = memPolicyMaxRollback policy
+      numBlocks <- choose (minNumBlocks, minNumBlocks * 2)
+      return $ mkTestSetup policy numBlocks
+
+  shrink ChainSetup{..} = concat [
+        -- If we shrink the policy, it can't be that we need /more/ blocks
+        [ mkTestSetup csPolicy' csNumBlocks
+        | csPolicy' <- shrink csPolicy
+        ]
+        -- Shrinking the number of blocks may make the snapshots unsaturated
+      , [ mkTestSetup csPolicy csNumBlocks'
+        | csNumBlocks' <- shrink csNumBlocks
+        , let minNumBlocks = memPolicyMaxRollback csPolicy
+        , csNumBlocks' >= minNumBlocks
+        ]
+      ]
+
+instance Arbitrary (ChainSetup s) => Arbitrary (SwitchSetup s) where
+  arbitrary = do
+      chainSetup  <- arbitrary
+      numRollback <- choose (0, ledgerDbMaxRollback (csPushed chainSetup))
+      numNew      <- choose (numRollback, 2 * numRollback)
+      return $ mkRollbackSetup chainSetup numRollback numNew
+
+  shrink SwitchSetup{..} = concat [
+        -- If we shrink the chain setup, we might restrict max rollback
+        [ mkRollbackSetup ssChainSetup' ssNumRollback ssNumNew
+        | ssChainSetup' <- shrink ssChainSetup
+        , ssNumRollback <= ledgerDbMaxRollback (csPushed ssChainSetup')
+        ]
+        -- Number of new blocks must be at least the rollback
+      , [ mkRollbackSetup ssChainSetup ssNumRollback ssNumNew'
+        | ssNumNew' <- shrink ssNumNew
+        , ssNumNew' >= ssNumRollback
+        ]
+        -- But rolling back less is always possible
+      , [ mkRollbackSetup ssChainSetup ssNumRollback' ssNumNew
+        | ssNumRollback' <- shrink ssNumRollback
+        ]
+      ]
+
+-- | Block
+--
+-- For the purposes of the tests of the ledger DB, we don't really care what's
+-- inside blocks; we simply mark blocks with their position in the chain and
+-- the number of the fork. For example,
+--
+-- > Block 2 0
+--
+-- is the second block in the chain, on fork 0.
+data Block = Block Word64 Word64
+  deriving (Show, Eq)
+
+mkChain :: Word64 -> Word64 -> [Block]
+mkChain numBlocks fork = [Block i fork | i <- [1 .. numBlocks]]
+
+-- | "Free" ledger
+--
+-- This ledger is free in that we don't interpret in any way the " blocks " that
+-- we apply, we merely record them.
+newtype Ledger = Ledger [Block]
+  deriving (Show, Eq)
+
+initLedger :: Ledger
+initLedger = Ledger []
+
+-- | Apply a block
+apply :: Block -> Ledger -> Ledger
+apply b (Ledger bs) = Ledger (b:bs)
+
+-- | Apply a list of blocks (old to new)
+applyMany :: [Block] -> Ledger -> Ledger
+applyMany = repeatedly apply
+
+callbacks :: PureLedgerDbConf Ledger Block
+callbacks = pureLedgerDbConf initLedger apply
+
+{-------------------------------------------------------------------------------
+  Orphan Arbitrary instances
+-------------------------------------------------------------------------------}
+
+instance Arbitrary a => Arbitrary (Offsets a) where
+  arbitrary = do
+      offsets <- arbitrary
+      offsetsFromPairs <$> go 0 (imposeLimits offsets)
+    where
+      imposeLimits :: [Word64] -> [Word64]
+      imposeLimits = take maxNumSnapshots . map (min maxSkip) . (0 :)
+
+      -- Make sure the list is strictly monotonically increasing
+      go :: Word64 -> [Word64] -> Gen [(Word64, a)]
+      go _ []     = return []
+      go p (o:os) = do a    <- arbitrary
+                       rest <- go (p + o + 1) os
+                       return (((p + o), a) : rest)
+
+  shrink = map offsetsFromPairs
+         . filter isValid
+         . shrink
+         . offsetsToPairs
+    where
+      isValid ((0, _):_) = True
+      isValid _otherwise = False
+
+instance Arbitrary MemPolicy where
+  arbitrary = oneof [
+        -- Sufficiently often return a small mempolicy to keep examples small
+        return $ defaultMemPolicy (SecurityParam 3)
+      , memPolicyFromSkips . imposeLimits <$> arbitrary
+      ]
+    where
+      imposeLimits :: [Word64] -> [Word64]
+      imposeLimits = take maxNumSnapshots . map (min maxSkip) . (0 :)
+
+  shrink = filter memPolicyValid
+         . map memPolicyFromSkips
+         . shrink
+         . memPolicyToSkips
+
+{-------------------------------------------------------------------------------
+  Testing constants
+-------------------------------------------------------------------------------}
+
+-- | Maximum number of snapshots we want to keep
+maxNumSnapshots :: Int
+maxNumSnapshots = 10
+
+-- | Maximum distance between the snapshots
+maxSkip :: Word64
+maxSkip = 100
+
+-- | Maximum number of blocks we want on a chain
+maxNumBlocks :: Word64
+maxNumBlocks = 1500
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+neverCalled :: HasCallStack => a
+neverCalled = error "this should not be called"

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -1,0 +1,920 @@
+{-# LANGUAGE DataKinds                 #-}
+{-# LANGUAGE DeriveAnyClass            #-}
+{-# LANGUAGE DeriveFoldable            #-}
+{-# LANGUAGE DeriveFunctor             #-}
+{-# LANGUAGE DeriveGeneric             #-}
+{-# LANGUAGE DeriveTraversable         #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE InstanceSigs              #-}
+{-# LANGUAGE KindSignatures            #-}
+{-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE StandaloneDeriving        #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE TypeOperators             #-}
+{-# LANGUAGE UndecidableInstances      #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Ouroboros.Storage.LedgerDB.OnDisk (
+    tests
+  , showLabelledExamples
+  ) where
+
+import           Prelude hiding (elem)
+
+import           Codec.Serialise (Serialise)
+import           Control.Monad.Except (Except, runExcept, throwError)
+import           Control.Monad.State (StateT (..))
+import qualified Control.Monad.State as State
+import           Data.Bifunctor (first)
+import           Data.Foldable (toList)
+import           Data.Functor.Classes
+import qualified Data.List as L
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromJust)
+import           Data.Proxy
+import           Data.TreeDiff (ToExpr (..))
+import           Data.Word
+import           GHC.Generics (Generic)
+import           System.IO (IOMode (..))
+import           System.Random (getStdRandom, randomR)
+
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+import           Test.QuickCheck (Gen)
+import qualified Test.QuickCheck as QC
+import qualified Test.QuickCheck.Monadic as QC
+import qualified Test.QuickCheck.Random as QC
+import           Test.StateMachine
+import qualified Test.StateMachine.Types as QSM
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Ouroboros.Consensus.Util
+import qualified Ouroboros.Consensus.Util.Classify as C
+
+import           Ouroboros.Storage.FS.API
+import qualified Ouroboros.Storage.FS.Sim.MockFS as MockFS
+import           Ouroboros.Storage.FS.Sim.STM
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+import           Ouroboros.Storage.LedgerDB.Conf
+import           Ouroboros.Storage.LedgerDB.InMemory
+import           Ouroboros.Storage.LedgerDB.MemPolicy
+import           Ouroboros.Storage.LedgerDB.Offsets
+import           Ouroboros.Storage.LedgerDB.OnDisk
+
+-- For the Arbitrary instance of 'MemPolicy'
+import           Test.Ouroboros.Storage.LedgerDB.InMemory ()
+
+{-------------------------------------------------------------------------------
+  Top-level tests
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "OnDisk" [
+      testProperty "LedgerSimple" $ prop_sequential (Proxy @'LedgerSimple)
+    ]
+
+{-------------------------------------------------------------------------------
+  Modelling the ledger
+-------------------------------------------------------------------------------}
+
+-- | Type level description of the ledger model
+data LedgerUnderTest = LedgerSimple
+
+class ( Show      (BlockRef  t)
+      , Ord       (BlockRef  t)
+      , Serialise (BlockRef  t)
+      , Show      (BlockVal  t)
+      , Eq        (BlockVal  t)
+      , ToExpr    (BlockVal  t)
+      , Eq        (LedgerSt  t)
+      , Show      (LedgerSt  t)
+      , Serialise (LedgerSt  t)
+      , ToExpr    (LedgerSt  t)
+      , Eq        (LedgerErr t)
+      , Show      (LedgerErr t)
+      ) => LUT (t :: LedgerUnderTest) where
+  data family LedgerSt  t :: *
+  type family LedgerErr t :: *
+  data family BlockVal  t :: *
+  type family BlockRef  t :: *
+
+  -- | Genesis value
+  ledgerGenesis :: LedgerSt t
+
+  -- | Apply ledger rules
+  ledgerApply   :: BlockVal t -> LedgerSt t -> Either (LedgerErr t) (LedgerSt t)
+
+  -- | Compute reference to a block
+  blockRef      :: BlockVal t -> BlockRef t
+
+  -- | Produce new block, given current ledger and tip
+  genBlock      :: LedgerSt t -> Gen (BlockVal t)
+
+refValPair :: LUT t => BlockVal t -> (BlockRef t, BlockVal t)
+refValPair b = (blockRef b, b)
+
+genBlocks :: LUT t => Word64 -> LedgerSt t -> Gen [BlockVal t]
+genBlocks 0 _ = return []
+genBlocks n l = do b <- genBlock l
+                   case ledgerApply b l of
+                     Left  _  -> error invalidBlock
+                     Right l' -> do
+                       bs <- genBlocks (n - 1) l'
+                       return (b:bs)
+  where
+    invalidBlock = "genBlocks: genBlock produced invalid block"
+
+type LedgerDbConf' m t = LedgerDbConf m (LedgerSt t) (BlockRef t) (BlockVal t) (LedgerErr t)
+type LedgerDB'       t = LedgerDB       (LedgerSt t) (BlockRef t)
+type StreamAPI'    m t = StreamAPI    m              (BlockRef t) (BlockVal t)
+type NextBlock'      t = NextBlock                   (BlockRef t) (BlockVal t)
+type BlockInfo'      t = BlockInfo                   (BlockRef t) (BlockVal t)
+type Tip'            t = Tip                         (BlockRef t)
+
+{-------------------------------------------------------------------------------
+  Simple instantiation of LUT
+-------------------------------------------------------------------------------}
+
+instance LUT 'LedgerSimple where
+  data LedgerSt 'LedgerSimple = SimpleLedger Int
+    deriving (Show, Eq, Generic, Serialise, ToExpr)
+
+  data BlockVal 'LedgerSimple = SimpleBlock Int
+    deriving (Show, Eq, Generic, Serialise, ToExpr)
+
+  type LedgerErr 'LedgerSimple = (Int, Int)
+  type BlockRef  'LedgerSimple = Int
+
+  ledgerGenesis :: LedgerSt 'LedgerSimple
+  ledgerGenesis = SimpleLedger 0
+
+  ledgerApply :: BlockVal 'LedgerSimple
+              -> LedgerSt 'LedgerSimple
+              -> Either (LedgerErr 'LedgerSimple) (LedgerSt 'LedgerSimple)
+  ledgerApply (SimpleBlock b) (SimpleLedger l) =
+      if b > l then Right (SimpleLedger b)
+               else Left (b, l)
+
+  blockRef :: BlockVal 'LedgerSimple -> BlockRef 'LedgerSimple
+  blockRef (SimpleBlock b) = b
+
+  genBlock :: LedgerSt 'LedgerSimple -> Gen (BlockVal 'LedgerSimple)
+  genBlock (SimpleLedger l) = return $ SimpleBlock (l + 1)
+
+{-------------------------------------------------------------------------------
+  Commands
+-------------------------------------------------------------------------------}
+
+data Corruption =
+    -- | Delete the snapshot entirely
+    Delete
+
+    -- | Truncate the file
+    --
+    -- This is just a simple way to cause a deserialisation error
+  | Truncate
+  deriving (Show, Eq, Generic, ToExpr)
+
+data Cmd (t :: LedgerUnderTest) ss =
+    -- | Get the current ledger state
+    Current
+
+    -- | Push a block
+  | Push (BlockVal t)
+
+    -- | Switch to a fork
+  | Switch Word64 [BlockVal t]
+
+    -- | Take a snapshot (write to disk)
+  | Snap
+
+    -- | Restore the DB from on-disk, then return it
+    --
+    -- We could avoid returning the ledger from 'Restore', instead relying on
+    -- 'Current' to do the check, but returning the ledger immediately means
+    -- we spot problems sooner and makes tagging easier.
+  | Restore
+
+    -- | Corrupt a previously taken snapshot
+  | Corrupt Corruption ss
+
+    -- | Corruption of the chain
+    --
+    -- Chain corruption, no matter what form, always results in truncation. We
+    -- model this as the number of blocks that got truncated from the end of the
+    -- chain.
+    --
+    -- NOTE: Since this is modelling /disk/ corruption, and it is the
+    -- responsibility of the 'ChainStateDB' to /notice/ disk corruption (by
+    -- catching the appropriate exceptions), the assume that the ledger state
+    -- will immediately be re-initialized after a 'Truncate' (which is precisely
+    -- what the 'ChainStateDB' would do, after first doing recovery on the
+    -- underlying 'ChainDB'). This is important because otherwise the model
+    -- would diverge from the real thing.
+    --
+    -- Since 'Drop' therefore implies a 'Restore', we return the new ledger.
+  | Drop Word64
+  deriving (Functor, Foldable, Traversable)
+
+data Success t ss =
+    Unit ()
+  | MaybeErr (Either (LedgerErr t) ())
+  | Ledger (LedgerSt t)
+  | Snapped ss
+  deriving (Functor, Foldable, Traversable)
+
+-- | Currently we don't have any error responses
+newtype Resp t ss = Resp (Success t ss)
+  deriving (Functor, Foldable, Traversable)
+
+deriving instance (LUT t, Show ss) => Show (Cmd t ss)
+deriving instance (LUT t, Eq   ss) => Eq   (Cmd t ss)
+
+deriving instance (LUT t, Show ss) => Show (Success t ss)
+deriving instance (LUT t, Eq   ss) => Eq   (Success t ss)
+
+deriving instance (LUT t, Show ss) => Show (Resp t ss)
+deriving instance (LUT t, Eq   ss) => Eq   (Resp t ss)
+
+{-------------------------------------------------------------------------------
+  Pure model
+-------------------------------------------------------------------------------}
+
+-- The mock ledger records the blocks and ledger values at each point
+type MockLedger t = [(BlockVal t, LedgerSt t)]
+
+-- | We simply enumerate snapshots
+--
+-- We only keep track of this to be able to give more meaningful statistics
+-- about generated tests. The mock implementation doesn't actually " take "
+-- any snapshots (instead it stores the legder state at each point).
+newtype MockSnap = MockSnap Int
+  deriving (Show, Eq, Ord, Generic, ToExpr)
+
+-- | Mock implementation
+--
+-- The mock implementation simply records the ledger at every point.
+-- We store the chain most recent first.
+data Mock t = Mock {
+      mockLedger :: MockLedger t
+    , mockSnaps  :: Map MockSnap SnapState
+    , mockNext   :: Int
+    }
+  deriving (Generic)
+
+deriving instance LUT t => Show   (Mock t)
+deriving instance LUT t => ToExpr (Mock t)
+
+data SnapState = SnapOk | SnapCorrupted Corruption
+  deriving (Show, Eq, Generic, ToExpr)
+
+mockInit :: Mock t
+mockInit = Mock [] Map.empty 1
+
+mockCurrent :: LUT t => Mock t -> LedgerSt t
+mockCurrent Mock{..} =
+    case mockLedger of
+      []       -> ledgerGenesis
+      (_, l):_ -> l
+
+mockChainLength :: Mock t -> Word64
+mockChainLength Mock{..} = fromIntegral (length mockLedger)
+
+mockRollback :: Word64 -> Mock t -> Mock t
+mockRollback n mock@Mock{..} = mock {
+      mockLedger = drop (fromIntegral n) mockLedger
+    }
+
+mockUpdateLedger :: StateT (MockLedger t) (Except (LedgerErr t)) a
+                 -> Mock t -> (Either (LedgerErr t) a, Mock t)
+mockUpdateLedger f mock =
+    case runExcept (runStateT f (mockLedger mock)) of
+      Left  err          -> (Left err, mock)
+      Right (a, ledger') -> (Right a, mock { mockLedger = ledger' })
+
+mockRecentSnap :: Mock t -> Maybe SnapState
+mockRecentSnap Mock{..} =
+    case Map.toDescList mockSnaps of
+      []        -> Nothing
+      (_, st):_ -> Just st
+
+{-------------------------------------------------------------------------------
+  Interpreter
+-------------------------------------------------------------------------------}
+
+runMock :: forall t. LUT t
+        => Cmd t MockSnap -> Mock t -> (Resp t MockSnap, Mock t)
+runMock = first Resp .: go
+  where
+    go :: Cmd t MockSnap -> Mock t -> (Success t MockSnap, Mock t)
+    go Current        = \mock -> (Ledger (cur (mockLedger mock)), mock)
+    go (Push b)       = first MaybeErr . mockUpdateLedger (push b)
+    go (Switch n bs)  = first MaybeErr . mockUpdateLedger (switch n bs)
+    go Restore        = go Current
+    go Snap           = \mock@Mock{..} -> (
+          Snapped (MockSnap mockNext)
+        , mock { mockNext  = mockNext + 1
+               , mockSnaps = Map.insert (MockSnap mockNext) SnapOk mockSnaps
+               }
+        )
+    go (Corrupt c ss) = \mock -> (
+          Unit ()
+        , mock { mockSnaps = Map.alter corrupt ss (mockSnaps mock) }
+        )
+      where
+        -- Deletion trumps corruption
+        corrupt :: Maybe SnapState -> Maybe SnapState
+        corrupt old = Just $
+          case (c, old) of
+            (_        , Nothing    )               -> SnapCorrupted c
+            (Delete   , _          )               -> SnapCorrupted Delete
+            (Truncate , Just SnapOk)               -> SnapCorrupted Truncate
+            (Truncate , (Just (SnapCorrupted c'))) -> SnapCorrupted c'
+    go (Drop n) = \mock@Mock{..} ->
+        go Restore $ mock { mockLedger = drop (fromIntegral n) mockLedger }
+
+    push :: BlockVal t -> StateT (MockLedger t) (Except (LedgerErr t)) ()
+    push b = do
+        ls <- State.get
+        case ledgerApply b (cur ls) of
+          Left  err -> throwError err
+          Right l'  -> State.put ((b, l'):ls)
+
+    switch :: Word64
+           -> [BlockVal t]
+           -> StateT (MockLedger t) (Except (LedgerErr t)) ()
+    switch n bs = do
+        State.modify $ drop (fromIntegral n)
+        mapM_ push bs
+
+    cur :: MockLedger t -> LedgerSt t
+    cur []         = ledgerGenesis
+    cur ((_, l):_) = l
+
+{-------------------------------------------------------------------------------
+  Standalone instantiation of the ledger DB
+-------------------------------------------------------------------------------}
+
+-- | Arguments required by 'StandaloneDB'
+data DbEnv m = forall fh. DbEnv {
+      dbHasFS     :: HasFS m fh
+    , dbMemPolicy :: MemPolicy
+    }
+
+-- | Standalone ledger DB
+--
+-- Under normal circumstances the ledger DB is maintained by the 'ChainStateDB',
+-- and supported by the 'ChainDB'. In order to test it stand-alone we need to
+-- mock these components.
+data StandaloneDB m t = DB {
+      -- | Arguments
+      dbEnv    :: DbEnv m
+
+      -- | Block storage
+      --
+      -- We can think of this as mocking the volatile DB. Blocks can be
+      -- added to this without updating the rest of the state.
+    , dbBlocks :: TVar m (Map (BlockRef t) (BlockVal t))
+
+      -- | Current chain and corresponding ledger state
+      --
+      -- We can think of this as mocking the ChainStateDB, which must keep
+      -- track of a current chain and keep the ledger DB in sync with it.
+      --
+      -- Invariant: all references @r@ here must be present in 'dbBlocks'.
+    , dbState  :: TVar m ([BlockRef t], LedgerDB (LedgerSt t) (BlockRef t))
+    }
+
+initStandaloneDB :: (MonadSTM m, LUT t) => DbEnv m -> m (StandaloneDB m t)
+initStandaloneDB dbEnv@DbEnv{..} = do
+    dbBlocks <- atomically $ newTVar Map.empty
+    dbState  <- atomically $ newTVar (initChain, initDB)
+    return DB{..}
+  where
+    initChain = []
+    initDB    = ledgerDbFromGenesis dbMemPolicy ledgerGenesis
+
+dbConf :: forall m t. (MonadSTM m, LUT t)
+       => StandaloneDB m t -> LedgerDbConf' m t
+dbConf DB{..} = LedgerDbConf {..}
+  where
+    ledgerDbGenesis = return ledgerGenesis
+    ledgerDbApply   = const  ledgerApply
+    ledgerDbResolve = \r -> atomically $ getBlock r <$> readTVar dbBlocks
+
+    getBlock :: BlockRef t -> Map (BlockRef t) (BlockVal t) -> BlockVal t
+    getBlock = Map.findWithDefault (error blockNotFound)
+
+    blockNotFound :: String
+    blockNotFound = concat [
+          "dbConf: "
+        , "invariant violation: "
+        , "block in dbChain not in dbBlocks, "
+        , "or LedgerDB not re-initialized after chain truncation"
+        ]
+
+dbStreamAPI :: forall m t. (MonadSTM m, LUT t)
+            => StandaloneDB m t -> StreamAPI' m t
+dbStreamAPI DB{..} = StreamAPI {..}
+  where
+    streamAfter :: Tip' t -> (Maybe (m (NextBlock' t)) -> m a) -> m a
+    streamAfter tip k = do
+        rs       <- atomically $ reverse . fst <$> readTVar dbState
+        toStream <- case tip of
+                      TipGen -> do atomically $ Just <$> newTVar rs
+                      Tip r  -> case dropWhile (/= r) rs of
+                                   []    -> return Nothing
+                                   _:rs' -> atomically $ Just <$> newTVar rs'
+        k (getNext <$> toStream)
+
+    getNext :: TVar m [BlockRef t] -> m (NextBlock' t)
+    getNext toStream = do
+        mr <- atomically $ do
+                rs <- readTVar toStream
+                case rs of
+                  []    -> return Nothing
+                  r:rs' -> writeTVar toStream rs' >> return (Just r)
+        case mr of
+          Nothing -> return NoMoreBlocks
+          Just r  -> do mb <- atomically $ Map.lookup r <$> readTVar dbBlocks
+                        case mb of
+                          Just b  -> return $ NextBlock (r, b)
+                          Nothing -> error blockNotFound
+
+    blockNotFound :: String
+    blockNotFound = concat [
+          "dbStreamAPI: "
+        , "invariant violation: "
+        , "block in dbChain not present in dbBlocks"
+        ]
+
+runDB :: forall m t.
+         (MonadSTM m, MonadThrow m, MonadST m, LUT t)
+      => StandaloneDB m t
+      -> Cmd t DiskSnapshot -> m (Resp t DiskSnapshot)
+runDB standalone@DB{..} cmd =
+    case dbEnv of
+      DbEnv{dbHasFS} -> Resp <$> go dbHasFS cmd
+  where
+    conf      = dbConf      standalone
+    streamAPI = dbStreamAPI standalone
+
+    go :: HasFS m fh -> Cmd t DiskSnapshot -> m (Success t DiskSnapshot)
+    go _ Current =
+        atomically $ (Ledger . ledgerDbCurrent . snd) <$> readTVar dbState
+    go _ (Push b) = do
+        atomically $ modifyTVar dbBlocks $
+          uncurry Map.insert (refValPair b)
+        upd (push b) $ ledgerDbPush conf (new b)
+    go _ (Switch n bs) = do
+        atomically $ modifyTVar dbBlocks $
+          repeatedly (uncurry Map.insert) (map refValPair bs)
+        upd (switch n bs) $ ledgerDbSwitch conf n (map new bs)
+    go hasFS Snap = do
+        (_, db) <- atomically $ readTVar dbState
+        Snapped <$> takeSnapshot hasFS db
+    go hasFS Restore = do
+        db <- initLedgerDB hasFS (dbMemPolicy dbEnv) conf streamAPI
+        atomically $ modifyTVar dbState (\(rs, _) -> (rs, db))
+        go hasFS Current
+    go hasFS (Corrupt c ss) =
+        EH.catchError (hasFsErr hasFS)
+          (case c of
+             Delete   -> Unit <$> deleteSnapshot   hasFS ss
+             Truncate -> Unit <$> truncateSnapshot hasFS ss)
+          (\_ -> return $ Unit()) -- ignore any errors during corruption
+    go hasFS (Drop n) = do
+        -- During recovery the ChainStateDB would ask the ChainDB to recover
+        -- and pick a new current chain; only once that is done would it
+        -- compute a new ledger state. During this process the ChainStateDB
+        -- would effectively be closed.
+        atomically $ do
+            (rs, _db) <- readTVar dbState
+            writeTVar dbState (drop (fromIntegral n) rs, error "ledger DB not initialized")
+        go hasFS Restore
+
+    push :: BlockVal t -> [BlockRef t] -> [BlockRef t]
+    push b = (blockRef b:)
+
+    switch :: Word64 -> [BlockVal t] -> [BlockRef t] -> [BlockRef t]
+    switch 0 bs = (reverse (map blockRef bs) ++)
+    switch n bs = switch 0 bs . drop (fromIntegral n)
+
+    new :: BlockVal t -> BlockInfo' t
+    new = BlockVal NotPrevApplied . refValPair
+
+    upd :: ([BlockRef t] -> [BlockRef t])
+        -> (LedgerDB' t -> m (Either (LedgerErr t) (LedgerDB' t)))
+        -> m (Success t DiskSnapshot)
+    upd f g = do
+        -- We cannot run the whole thing in a transaction, since computing the
+        -- new value of the ledger DB may require reading from the chain DB
+        (rs, db) <- atomically $ readTVar dbState
+        mDB'     <- g db
+        case mDB' of
+          Left  e   -> return $ MaybeErr (Left e)
+          Right db' -> do atomically $ writeTVar dbState (f rs, db')
+                          return $ MaybeErr (Right ())
+
+    truncateSnapshot :: HasFS m fh -> DiskSnapshot -> m ()
+    truncateSnapshot hasFS@HasFS{..} ss =
+        withFile hasFS (snapshotToPath ss) AppendMode $ \h ->
+          hTruncate h 0
+
+{-------------------------------------------------------------------------------
+  References
+-------------------------------------------------------------------------------}
+
+newtype At f r = At (f (Reference DiskSnapshot r))
+type    f :@ r = At f r
+
+deriving instance Show (f (Reference DiskSnapshot r)) => Show (At f r)
+
+{-------------------------------------------------------------------------------
+  Model
+-------------------------------------------------------------------------------}
+
+type SnapRefs r = [(Reference DiskSnapshot r, MockSnap)]
+
+(!) :: Eq r => [(r, a)] -> r -> a
+env ! r = fromJust (lookup r env)
+
+data Model t r = Model {
+    modelMock  :: Mock t
+  , modelSnaps :: SnapRefs r
+  }
+  deriving (Generic)
+
+deriving instance (Show1 r, LUT t) => Show (Model t r)
+
+initModel :: Model t r
+initModel = Model mockInit []
+
+toMock :: (Functor f, Eq1 r) => Model t r -> f :@ r -> f MockSnap
+toMock m (At fr) = (modelSnaps m !) <$> fr
+
+step :: (Eq1 r, LUT t) => Model t r -> Cmd t :@ r -> (Resp t MockSnap, Mock t)
+step m cmd = runMock (toMock m cmd) (modelMock m)
+
+{-------------------------------------------------------------------------------
+  Events
+-------------------------------------------------------------------------------}
+
+data Event t r = Event {
+      eventBefore   :: Model t    r
+    , eventCmd      :: Cmd   t :@ r
+    , eventResp     :: Resp  t :@ r
+    , eventAfter    :: Model t    r
+    , eventMockResp :: Resp  t MockSnap
+    }
+
+deriving instance (LUT t, Show1 r) => Show (Event t r)
+
+lockstep :: (Eq1 r, LUT t)
+         => Model t    r
+         -> Cmd   t :@ r
+         -> Resp  t :@ r
+         -> Event t    r
+lockstep m@(Model _ hs) cmd (At resp) = Event {
+      eventBefore   = m
+    , eventCmd      = cmd
+    , eventResp     = At resp
+    , eventAfter    = Model mock' (hs' <> hs) -- new references override old!
+    , eventMockResp = resp'
+    }
+  where
+    (resp', mock') = step m cmd
+    hs' = zip (toList resp) (toList resp')
+
+execCmd :: LUT t
+        => Model t Symbolic
+        -> QSM.Command (At (Cmd t)) (At (Resp t))
+        -> Event t Symbolic
+execCmd model (QSM.Command cmd resp _vars) = lockstep model cmd resp
+
+execCmds :: forall t. LUT t
+         => QSM.Commands (At (Cmd t)) (At (Resp t))
+         -> [Event t Symbolic]
+execCmds = \(QSM.Commands cs) -> go initModel cs
+  where
+    go :: Model t Symbolic
+       -> [QSM.Command (At (Cmd t)) (At (Resp t))]
+       -> [Event t Symbolic]
+    go _ []     = []
+    go m (c:cs) = e : go (eventAfter e) cs
+      where
+        e = execCmd m c
+
+{-------------------------------------------------------------------------------
+  Generator
+-------------------------------------------------------------------------------}
+
+generator :: forall t. LUT t
+          => MemPolicy -> Model t Symbolic -> Maybe (Gen (Cmd t :@ Symbolic))
+generator memPolicy (Model mock hs) = Just $ QC.oneof $ concat [
+      withoutRef
+    , withRef
+    ]
+  where
+    withoutRef :: [Gen (Cmd t :@ Symbolic)]
+    withoutRef = [
+          fmap At $ return Current
+        , fmap At $ Push <$> genBlock (mockCurrent mock)
+        , fmap At $ do
+            let maxRollback = minimum [
+                    mockChainLength mock
+                  , memPolicyMaxRollback memPolicy
+                  ]
+            numRollback  <- QC.choose (0, maxRollback)
+            numNewBlocks <- QC.choose (numRollback, numRollback + 2)
+            let afterRollback = mockRollback numRollback mock
+            Switch numRollback <$> genBlocks numNewBlocks (mockCurrent afterRollback)
+        , fmap At $ return Snap
+        , fmap At $ return Restore
+        , fmap At $ (Drop . fromIntegral) <$> QC.choose (0, mockChainLength mock)
+        ]
+
+    withRef :: [Gen (Cmd t :@ Symbolic)]
+    withRef = [
+          fmap At $ Corrupt <$> genCorruption <*> genSnapshot
+        ]
+
+    genCorruption :: Gen Corruption
+    genCorruption = QC.elements [Delete, Truncate]
+
+    genSnapshot :: Gen (Reference DiskSnapshot Symbolic)
+    genSnapshot = QC.elements (map fst hs)
+
+shrinker :: Model t Symbolic -> Cmd t :@ Symbolic -> [Cmd t :@ Symbolic]
+shrinker _ _ = []
+
+{-------------------------------------------------------------------------------
+  Additional type class instances required by QSM
+-------------------------------------------------------------------------------}
+
+instance CommandNames (At (Cmd t)) where
+  cmdName (At Current{}) = "Current"
+  cmdName (At Push{})    = "Push"
+  cmdName (At Switch{})  = "Switch"
+  cmdName (At Snap{})    = "Snap"
+  cmdName (At Restore{}) = "Restore"
+  cmdName (At Corrupt{}) = "Corrupt"
+  cmdName (At Drop{})    = "Drop"
+
+  cmdNames _ = [
+      "Current"
+    , "Push"
+    , "Switch"
+    , "Snap"
+    , "Restore"
+    , "Corrupt"
+    , "Drop"
+    ]
+
+instance Functor f => Rank2.Functor (At f) where
+  fmap = \f (At x) -> At $ fmap (lift f) x
+    where
+      lift :: (r x -> r' x) -> QSM.Reference x r -> QSM.Reference x r'
+      lift f (QSM.Reference x) = QSM.Reference (f x)
+
+instance Foldable f => Rank2.Foldable (At f) where
+  foldMap = \f (At x) -> foldMap (lift f) x
+    where
+      lift :: (r x -> m) -> QSM.Reference x r -> m
+      lift f (QSM.Reference x) = f x
+
+instance Traversable t => Rank2.Traversable (At t) where
+  traverse = \f (At x) -> At <$> traverse (lift f) x
+    where
+      lift :: Functor f
+           => (r x -> f (r' x)) -> QSM.Reference x r -> f (QSM.Reference x r')
+      lift f (QSM.Reference x) = QSM.Reference <$> f x
+
+instance LUT t => ToExpr (Model t Concrete)
+
+deriving instance ToExpr DiskSnapshot
+
+{-------------------------------------------------------------------------------
+  Final state machine
+-------------------------------------------------------------------------------}
+
+semantics :: (MonadSTM m, MonadThrow m, MonadST m, LUT t)
+          => StandaloneDB m t
+          -> Cmd t :@ Concrete -> m (Resp t :@ Concrete)
+semantics db (At cmd) = (At . fmap reference) <$> runDB db (concrete <$> cmd)
+
+transition :: (Eq1 r, LUT t)
+           => Model t    r
+           -> Cmd   t :@ r
+           -> Resp  t :@ r
+           -> Model t    r
+transition m cmd = eventAfter . lockstep m cmd
+
+postcondition :: LUT t
+              => Model t    Concrete
+              -> Cmd   t :@ Concrete
+              -> Resp  t :@ Concrete
+              -> Logic
+postcondition m cmd r = toMock (eventAfter e) r .== eventMockResp e
+  where
+    e = lockstep m cmd r
+
+precondition :: Model t Symbolic -> Cmd t :@ Symbolic -> Logic
+precondition (Model mock hs) (At c) =
+        forall (toList c) (`elem` map fst hs)
+    .&& validCmd c
+  where
+    validCmd :: Cmd t ss -> Logic
+    validCmd (Switch n _) = n .<= mockChainLength mock
+    validCmd _otherwise   = Top
+
+symbolicResp :: LUT t
+             => Model        t    Symbolic
+             -> Cmd          t :@ Symbolic
+             -> GenSym (Resp t :@ Symbolic)
+symbolicResp m c = At <$> traverse (const genSym) resp
+  where
+    (resp, _mock') = step m c
+
+sm :: (MonadSTM m, MonadThrow m, MonadST m, LUT t)
+   => MemPolicy
+   -> StandaloneDB m t
+   -> StateMachine (Model t) (At (Cmd t)) m (At (Resp t))
+sm memPolicy db = StateMachine {
+      initModel     = initModel
+    , transition    = transition
+    , precondition  = precondition
+    , postcondition = postcondition
+    , invariant     = Nothing
+    , generator     = generator memPolicy
+    , distribution  = Nothing
+    , shrinker      = shrinker
+    , semantics     = semantics db
+    , mock          = symbolicResp
+    }
+
+prop_sequential :: forall t. LUT t => Proxy t -> MemPolicy -> QC.Property
+prop_sequential p memPolicy =
+    QC.collect (tagMemPolicy memPolicy) $
+      forAllCommands (sm memPolicy (dbUnused p)) Nothing $ \cmds ->
+        QC.monadicIO (prop cmds)
+  where
+    k = memPolicyMaxRollback memPolicy
+
+    -- Ideally we'd like to use @SimM s@ instead of IO, but unfortunately
+    -- QSM requires monads that implement MonadIO.
+    prop :: QSM.Commands (At (Cmd t)) (At (Resp t))
+         -> QC.PropertyM IO ()
+    prop cmds = do
+      fs <- QC.run $ atomically $ newTVar MockFS.empty
+      let dbEnv :: DbEnv IO
+          dbEnv = DbEnv (simHasFS EH.exceptions fs) memPolicy
+      db <- QC.run $ initStandaloneDB dbEnv
+      let sm' = sm memPolicy db
+      (hist, _model, res) <- runCommands sm' cmds
+      prettyCommands sm' hist
+        $ QC.tabulate "Tags" (map show $ tagEvents k (execCmds cmds))
+        $ res QC.=== Ok
+
+dbUnused :: Proxy t -> StandaloneDB IO t
+dbUnused = error "DB unused during command generation"
+
+{-------------------------------------------------------------------------------
+  Labelling of the mem policy
+-------------------------------------------------------------------------------}
+
+data TagMemPolicy =
+     -- | Otherwise we record the maximum offset
+    MemPolicyMaxOffset (Range Word64)
+  deriving (Show)
+
+tagMemPolicy :: MemPolicy -> TagMemPolicy
+tagMemPolicy = go . offsetsDropValues . memPolicyToOffsets
+  where
+    go :: [Word64] -> TagMemPolicy
+    go os = MemPolicyMaxOffset $ range maxBound (maximum os)
+
+{-------------------------------------------------------------------------------
+  Event labelling
+
+  TODO: We need at least a label for restore-after-corruption
+-------------------------------------------------------------------------------}
+
+data Tag =
+    -- | Restore
+    --
+    -- We record the length of the chain at the time of the restore (to the
+    -- closest power of two) as well as the state of the most recent snapshot,
+    -- if any has been created.
+    --
+    -- We will look for the /maximum/ chain length in each case.
+    TagRestore (Maybe SnapState) (Range Word64)
+
+    -- | Tag rollback
+    --
+    -- We record the rollback length
+  | TagMaxRollback (Range Word64)
+
+    -- | Tag chain truncation
+    --
+    -- We record how many blocks were dropped
+  | TagMaxDrop (Range Word64)
+  deriving (Show, Eq)
+
+type EventPred t = C.Predicate (Event t Symbolic) Tag
+
+tagEvents :: forall t. Word64 -> [Event t Symbolic] -> [Tag]
+tagEvents k = C.classify [
+      tagMaxRollback
+    , tagMaxDrop
+    , tagRestore Nothing
+    , tagRestore (Just SnapOk)
+    , tagRestore (Just (SnapCorrupted Truncate))
+    , tagRestore (Just (SnapCorrupted Delete))
+    ]
+  where
+    tagMaxRollback :: EventPred t
+    tagMaxRollback =
+        fmap (TagMaxRollback . range k) $ C.maximum $ \ev ->
+          case eventCmd ev of
+            At (Switch n _) -> Just n
+            _otherwise      -> Nothing
+
+    tagMaxDrop :: EventPred t
+    tagMaxDrop =
+        fmap (TagMaxDrop . range k) $ C.maximum $ \ev ->
+          case eventCmd ev of
+            At (Drop n) -> Just n
+            _otherwise  -> Nothing
+
+    tagRestore :: Maybe SnapState -> EventPred t
+    tagRestore mST =
+        fmap (TagRestore mST . range k) $ C.maximum $ \ev ->
+          let mock = modelMock (eventBefore ev) in
+          case eventCmd ev of
+            At Restore | mockRecentSnap mock == mST -> Just (mockChainLength mock)
+            _otherwise                              -> Nothing
+
+{-------------------------------------------------------------------------------
+  Inspecting the labelling function
+-------------------------------------------------------------------------------}
+
+showLabelledExamples :: MemPolicy
+                     -> Maybe Int
+                     -> (Tag -> Bool) -- ^ Which tag are we interested in?
+                     -> IO ()
+showLabelledExamples memPolicy mReplay relevant = do
+    replaySeed <- case mReplay of
+                    Nothing   -> getStdRandom $ randomR (1, 999999)
+                    Just seed -> return seed
+
+    putStrLn $ "Using replaySeed " ++ show replaySeed
+
+    let args = QC.stdArgs {
+            QC.maxSuccess = 10000
+          , QC.replay     = Just (QC.mkQCGen replaySeed, 0)
+          }
+
+    QC.labelledExamplesWith args $
+      forAllCommands (sm memPolicy (dbUnused p)) Nothing $ \cmds ->
+        repeatedly QC.collect (filter relevant . tagEvents k . execCmds $ cmds) $
+          QC.property True
+  where
+    k = memPolicyMaxRollback memPolicy
+    p = Proxy @'LedgerSimple
+
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+data Range n = R_Eq n | R_Btwn (n, n) | R_Gt n | R_Gt_k
+  deriving (Show, Eq)
+
+range :: (Ord n, Show n, Num n) => n -> n -> Range n
+range k n
+  | n > k           = R_Gt_k
+  | n > limit       = R_Gt limit
+  | n `L.elem` vals = R_Eq n
+  | otherwise       =
+      case L.find (\(lo, hi) -> lo <= n && n <= hi) rngs of
+        Nothing  -> error $ "range: unable to classify " ++ show n
+        Just rng -> R_Btwn rng
+  where
+    vals  = [0, 1, 2, 3, 4]
+    rngs  = [(5, 10), (11, 20)]
+    limit = 20


### PR DESCRIPTION
This implements a first version of the ledger DB, and comes with detailed tests both of the in-memory structure (as normal QC properties) and stateful tests using q-s-m. The only thing that is still missing is the thread that interprets the DiskPolicy and writes a snapshot every so often, but this is a very simple component.

Some statistics about the tests run by q-s-m:

1M tests in about 400sec (little under 7mins). Some statistics:

* Maximum offset stored in the ledger (effectively "k"):

```
50.1794% MemPolicyMaxOffset (R_Eq 4)
43.4336% MemPolicyMaxOffset (R_Gt 20)
 2.6127% MemPolicyMaxOffset (R_Eq 0)
 1.5566% MemPolicyMaxOffset (R_Btwn (11,20))
 1.2661% MemPolicyMaxOffset (R_Btwn (5,10))
 0.3495% MemPolicyMaxOffset (R_Eq 2)
 0.3183% MemPolicyMaxOffset (R_Eq 1)
 0.2838% MemPolicyMaxOffset (R_Eq 3)
```

* Maximum rollback

```          
7.23303% TagMaxRollback (R_Eq 0)
5.11824% TagMaxRollback (R_Eq 1)
4.50081% TagMaxRollback (R_Eq 2)
3.93080% TagMaxRollback (R_Eq 3)
3.70661% TagMaxRollback (R_Eq 4)
2.15484% TagMaxRollback (R_Btwn (5,10))
0.14420% TagMaxRollback (R_Btwn (11,20))
0.00109% TagMaxRollback (R_Gt 20)
```

* Maximum truncation of the chain (modelling disk corruption in the chain DB)

```
5.38973% TagMaxDrop (R_Eq 0)
4.05861% TagMaxDrop (R_Eq 1)
3.98104% TagMaxDrop (R_Eq 2)
3.61544% TagMaxDrop (R_Eq 3)
3.53532% TagMaxDrop R_Gt_k
3.04372% TagMaxDrop (R_Btwn (5,10))
2.99611% TagMaxDrop (R_Eq 4)
0.19048% TagMaxDrop (R_Btwn (11,20))
0.00102% TagMaxDrop (R_Gt 20)
```

* Maximum length of the chain at the time of a call to restore, with no ledger snapshots present

```
6.98502% TagRestore Nothing (R_Eq 0)
3.13445% TagRestore Nothing (R_Eq 1)
2.07342% TagRestore Nothing (R_Eq 2)
1.17748% TagRestore Nothing (R_Eq 3)
0.66715% TagRestore Nothing (R_Eq 4)
0.52012% TagRestore Nothing R_Gt_k
0.40059% TagRestore Nothing (R_Btwn (5,10))
0.00958% TagRestore Nothing (R_Btwn (11,20))
0.00003% TagRestore Nothing (R_Gt 20)
```

* Maximum length of the chain at the time of a call to restore, with a snapshot present and not corrupted

```
3.89460% TagRestore (Just SnapOk) R_Gt_k
3.22074% TagRestore (Just SnapOk) (R_Btwn (5,10))
2.64964% TagRestore (Just SnapOk) (R_Eq 2)
2.55404% TagRestore (Just SnapOk) (R_Eq 3)
2.40333% TagRestore (Just SnapOk) (R_Eq 1)
2.30497% TagRestore (Just SnapOk) (R_Eq 4)
2.14656% TagRestore (Just SnapOk) (R_Eq 0)
0.42360% TagRestore (Just SnapOk) (R_Btwn (11,20))
0.00542% TagRestore (Just SnapOk) (R_Gt 20)
```

* Maximum length of the chain at the time of a call to restore, where the most recent snapshot had been deleted

```
1.11760% TagRestore (Just (SnapCorrupted Delete)) (R_Eq 2)
1.10973% TagRestore (Just (SnapCorrupted Delete)) (R_Eq 1)
0.96390% TagRestore (Just (SnapCorrupted Delete)) R_Gt_k
0.95742% TagRestore (Just (SnapCorrupted Delete)) (R_Eq 3)
0.94518% TagRestore (Just (SnapCorrupted Delete)) (R_Eq 0)
0.81608% TagRestore (Just (SnapCorrupted Delete)) (R_Btwn (5,10))
0.75651% TagRestore (Just (SnapCorrupted Delete)) (R_Eq 4)
0.07300% TagRestore (Just (SnapCorrupted Delete)) (R_Btwn (11,20))
0.00058% TagRestore (Just (SnapCorrupted Delete)) (R_Gt 20)
```

* Maximum length of the chain at the time of a call to restore, where the most recept snapshot had been truncated (and would therefore fail to parse)

```
0.86826% TagRestore (Just (SnapCorrupted Truncate)) (R_Eq 1)
0.85691% TagRestore (Just (SnapCorrupted Truncate)) (R_Eq 2)
0.78435% TagRestore (Just (SnapCorrupted Truncate)) (R_Eq 0)
0.71295% TagRestore (Just (SnapCorrupted Truncate)) (R_Eq 3)
0.68504% TagRestore (Just (SnapCorrupted Truncate)) R_Gt_k
0.58280% TagRestore (Just (SnapCorrupted Truncate)) (R_Btwn (5,10))
0.54582% TagRestore (Just (SnapCorrupted Truncate)) (R_Eq 4)
0.05153% TagRestore (Just (SnapCorrupted Truncate)) (R_Btwn (11,20))           
0.00048% TagRestore (Just (SnapCorrupted Truncate)) (R_Gt 20)
```
           
