### PR TITLE
Changes required for integration with `cardano-chain`

### DIFF
--- a/ouroboros-consensus/demo-playground/Run.hs
+++ b/ouroboros-consensus/demo-playground/Run.hs
@@ -15,7 +15,6 @@ import qualified Data.Map.Strict as M
 import           Data.Maybe
 import           Data.Semigroup ((<>))
 
-import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (pointHash)
 import           Ouroboros.Network.Protocol.ChainSync.Codec
 
@@ -88,7 +87,7 @@ handleSimpleNode p CLI{..} (TopologyInfo myNodeId topologyFile) = do
                  callbacks = NodeCallbacks {
                      produceBlock = \proof l slot prevPoint prevBlockNo -> do
                         let curNo    = succ prevBlockNo
-                            prevHash = castHash (pointHash prevPoint)
+                            prevHash = pointHash prevPoint
 
                         -- Before generating a new block, look for incoming transactions.
                         -- If there are, check if the mempool is consistent and, if it is,

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/Hash/Class.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/Hash/Class.hs
@@ -11,6 +11,7 @@ module Ouroboros.Consensus.Crypto.Hash.Class
     , getHash
     , hash
     , fromHash
+    , emptyHash
     ) where
 
 import           Codec.Serialise (Serialise (..))
@@ -35,6 +36,9 @@ class HashAlgorithm h where
 
 newtype Hash h a = Hash {getHash :: ByteString}
     deriving (Eq, Ord, Generic)
+
+emptyHash :: Hash h a
+emptyHash = Hash mempty
 
 instance Condense (Hash h a) where
     condense = show

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -90,7 +90,7 @@ broadcastNetwork btime numCoreNodes pInfo initRNG numSlots = do
       let callbacks :: NodeCallbacks m (Block p)
           callbacks = NodeCallbacks {
               produceBlock = \proof l slot prevPoint prevNo -> do
-                let prevHash  = castHash (Chain.pointHash prevPoint)
+                let prevHash  = Chain.pointHash prevPoint
                     curNo     = succ prevNo
 
                 -- Produce some random transactions

--- a/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
@@ -202,7 +202,7 @@ headSlot :: HasHeader block => ChainFragment block -> Maybe Slot
 headSlot = fmap pointSlot . headPoint
 
 -- | \( O(1) \).
-headHash :: HasHeader block => ChainFragment block -> Maybe (Hash block)
+headHash :: HasHeader block => ChainFragment block -> Maybe (HeaderHash block)
 headHash = fmap pointHash . headPoint
 
 -- | \( O(1) \).

--- a/ouroboros-network/src/Ouroboros/Network/ChainProducerState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainProducerState.hs
@@ -1,8 +1,12 @@
-{-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Network.ChainProducerState where
 
+import           Ouroboros.Network.Block (HeaderHash)
 import           Ouroboros.Network.Chain (Chain, ChainUpdate (..), HasHeader,
                      Point (..), blockPoint, genesisPoint, pointOnChain)
 import qualified Ouroboros.Network.Chain as Chain
@@ -19,7 +23,9 @@ data ChainProducerState block = ChainProducerState {
        chainState   :: Chain block,
        chainReaders :: ReaderStates block
      }
-  deriving (Eq, Show)
+
+deriving instance (Eq   (HeaderHash block), Eq block)   => Eq   (ChainProducerState block)
+deriving instance (Show (HeaderHash block), Show block) => Show (ChainProducerState block)
 
 -- | Readers are represented here as a relation.
 --
@@ -75,7 +81,9 @@ data ReaderState block = ReaderState {
        -- | A unique tag per reader, to distinguish different readers.
        readerId    :: ReaderId
      }
-  deriving (Eq, Show)
+
+deriving instance Eq   (HeaderHash block) => Eq   (ReaderState block)
+deriving instance Show (HeaderHash block) => Show (ReaderState block)
 
 data ReaderNext = ReaderBackTo | ReaderForwardFrom
   deriving (Eq, Show)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -1,24 +1,31 @@
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE EmptyCase             #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE InstanceSigs          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds             #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE ExplicitForAll        #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
 module Ouroboros.Network.Protocol.BlockFetch.Type where
 
 import           Data.Void (Void)
 
-import           Ouroboros.Network.Block (StandardHash)
+import           Ouroboros.Network.Block (HeaderHash, StandardHash)
 import           Ouroboros.Network.Chain (Point)
 import           Network.TypedProtocol.Core (Protocol (..))
 
 -- | Range of headers
 --
 data ChainRange header = ChainRange !(Point header) !(Point header)
-  deriving (Show, Eq, Ord)
+
+deriving instance Eq   (HeaderHash header) => Eq   (ChainRange header)
+deriving instance Ord  (HeaderHash header) => Ord  (ChainRange header)
+deriving instance Show (HeaderHash header) => Show (ChainRange header)
 
 data BlockFetch header body where
   BFIdle      :: BlockFetch header body

--- a/ouroboros-network/test/Test/ChainGenerators.hs
+++ b/ouroboros-network/test/Test/ChainGenerators.hs
@@ -40,7 +40,7 @@ import qualified Data.List as L
 import           Data.Maybe (fromJust, catMaybes)
 
 import           Ouroboros.Network.Testing.ConcreteBlock
-import           Ouroboros.Network.Block (Slot (..), Hash (..) , HasHeader (..))
+import           Ouroboros.Network.Block (Slot (..), HasHeader (..))
 import           Ouroboros.Network.Chain (Chain (..), ChainUpdate (..), Point (..))
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.Protocol.BlockFetch.Type (ChainRange (..))
@@ -99,7 +99,7 @@ instance Arbitrary ArbitraryPoint where
   arbitrary = do
     slot <- Slot <$> arbitrary
     hash <- HeaderHash <$> arbitrary
-    return $ ArbitraryPoint $ Point slot (BlockHash hash)
+    return $ ArbitraryPoint $ Point slot hash
 
 newtype ArbitraryChainRange = ArbitraryChainRange {
     getArbitraryChainRange :: ChainRange BlockHeader
@@ -418,7 +418,7 @@ genPointOnChain chain =
     len = Chain.length chain
 
 genPoint :: Gen (Point Block)
-genPoint = (\s h -> Point (Slot s) (BlockHash (HeaderHash h))) <$> arbitrary <*> arbitrary
+genPoint = (\s h -> Point (Slot s) (HeaderHash h)) <$> arbitrary <*> arbitrary
 
 fixupPoint :: HasHeader block => Chain block -> Point block -> Point block
 fixupPoint c p =


### PR DESCRIPTION
The PR removed `Hash` type and instead added a `genesisHash :: HashHeader b`  field to the `HasHeader` instance.
The `HasHeader` class looks like this right now:
```
 class (StandardHash b, Measured BlockMeasure b) => HasHeader b where
   type HeaderHash b :: *

    blockHash      :: b -> HeaderHash b
    blockPrevHash  :: b -> HeaderHash b
    blockSlot      :: b -> Slot
    blockNo        :: b -> BlockNo

    -- |
    -- The hash of genesis block.  The @'Proxy'@ makes sense here, as we are
    -- computing a hash of something that is /not/ a block.
    --
    genesisHash    :: Proxy b -> HeaderHash b

    blockInvariant :: b -> Bool
```

@edsko please check the second commit if you are fine with it or suggest how would you like to fulfill the `HeaderHash` constraint.  Am I right, that if we'll make `HeaderHash` type family to be injective, then we wouldn't need the `Proxy` parameter in `genesisHash`?