### PR TITLE
Add explicit support for EBBs to the ImmutableDB

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RankNTypes    #-}
 module Ouroboros.Storage.ImmutableDB.API
-  ( ImmutableDB(..)
+  ( ImmutableDB (..)
   , withDB
-  , Iterator(..)
+  , Iterator (..)
   , withIterator
-  , IteratorResult(..)
+  , IteratorResult (..)
   , iteratorToList
   , blobProducer
 
@@ -17,6 +18,7 @@ import           Data.ByteString (ByteString)
 import           Data.ByteString.Builder (Builder)
 import           Data.Function (on)
 
+import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 
 import           Pipes (Producer, lift, yield)
@@ -27,17 +29,13 @@ import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
 -- | Open the database using the given function, perform the given action
 -- using the database. Close the database using its 'closeDB' function
 -- afterwards.
---
--- The second return value of the database opener (and the second argument of
--- the action), is the last slot at which a blob is stored in the database or
--- 'Nothing' in case the database is empty.
 withDB :: (HasCallStack, MonadThrow m)
-       => m (ImmutableDB m, Maybe Slot)
+       => m (ImmutableDB hash m)
           -- ^ How to open the database
-       -> (ImmutableDB m -> Maybe Slot -> m a)
+       -> (ImmutableDB hash m -> m a)
           -- ^ Action to perform using the database
        -> m a
-withDB openDB action = bracket openDB (\(db, _) -> closeDB db) (uncurry action)
+withDB openDB = bracket openDB closeDB
 
 -- | API for the 'ImmutableDB'.
 --
@@ -45,21 +43,27 @@ withDB openDB action = bracket openDB (\(db, _) -> closeDB db) (uncurry action)
 -- chain.
 --
 -- The database is append-only, so you cannot append a blob to a slot in the
--- past, nor can you remove a blob. You can, however, skip slots, e.g., append
--- to slot 0 and then to slot 5, but afterwards, you can no longer append to
--- slots 1-4. You can only store at most one blob in each slot. It is not
--- allowed to store an empty blob in a slot (we would need a way to
--- distinguish an empty blob from an empty slot).
---
--- To find out the next slot that can be appended to, use 'getNextSlot'.
+-- past. You can, however, skip slots, e.g., append to slot 0 and then to slot
+-- 5, but afterwards, you can no longer append to slots 1-4. You can only
+-- store at most one blob in each slot. It is not allowed to store an empty
+-- blob in a slot (we would need a way to distinguish an empty blob from an
+-- empty slot).
 --
 -- The blob stored in a slot can be queried with 'getBinaryBlob'. Blobs can be
 -- efficiently streamed using 'Iterator's, see 'streamBinaryBlobs'.
 --
+-- An Epoch Boundary Block (EBB) can be appended to the start of each epoch
+-- using 'appendEBB'.
+--
+-- The 'Tip' of the database can be queried with 'getTip'. This tip will
+-- always point to a filled slot or an EBB that is present.
+--
+-- It is possible to delete blobs from the database using 'deleteAfter'.
+--
 -- The database can be explicitly closed, but can also be automatically closed
 -- in case of an 'Ouroboros.Storage.ImmutableDB.Types.UnexpectedError'. Use
 -- 'reopen' to reopen the database.
-data ImmutableDB m = ImmutableDB
+data ImmutableDB hash m = ImmutableDB
   { -- | Close the database.
     --
     -- Idempotent.
@@ -75,52 +79,65 @@ data ImmutableDB m = ImmutableDB
       :: HasCallStack => m Bool
 
     -- | When the database was closed, manually or because of an
-    -- 'Ouroboros.Storage.ImmutableDB.Types.UnexpectedError' during a write
+    -- 'Ouroboros.Storage.ImmutableDB.Types.UnexpectedError' during an
     -- operation, recover using the given 'ValidationPolicy' and reopen it at
     -- the most recent epoch.
     --
-    -- Returns the 'Slot' at which the last valid blob is stored in the
-    -- reopened database or 'Nothing' in case of an empty database.
+    -- During validation, the database will be truncated to the last valid
+    -- block or EBB stored in it. The tip of the database will never point to
+    -- an unfilled slot or missing EBB.
     --
-    -- Optionally truncate the database to the given slot ('TruncateFrom')
-    -- before reopening it.
-    --
-    -- When validation fails, an error will be thrown. Use
-    -- 'extractTruncateFrom' to try to extract a 'TruncateFrom' from the
-    -- error. When one could be extracted, use it to reopen the database
-    -- again, it should now succeed unless more file-system errors are thrown.
-    -- Note that this will truncate the database to some slot in the past.
-    --
-    -- The database is always truncated to its last filled slot. An open
-    -- database can never be opened at some empty slot.
-    --
-    -- When the database is still open, this is basically a no-op, unless a
-    -- 'TruncateFrom' is given.
+    -- Throws an 'OpenDBError' if the database is open.
   , reopen
-      :: HasCallStack
-      => ValidationPolicy -> Maybe TruncateFrom -> m (Maybe Slot)
+      :: HasCallStack => ValidationPolicy -> m ()
 
-    -- | Return the next free 'Slot'.
+    -- | Delete everything in the database after 'Tip'.
+    --
+    -- Trailing empty slots are also deleted so that the new tip of the
+    -- database points at a filled slot (or EBB). If the given tip is not
+    -- before the current tip, but newer, then nothing will be deleted.
+    --
+    -- Consequently, the result of calling 'getTip' after this call completed
+    -- will return a tip <= the given tip.
     --
     -- Throws a 'ClosedDBError' if the database is closed.
-  , getNextSlot
-      :: HasCallStack => m Slot
+  , deleteAfter
+      :: HasCallStack => Tip -> m ()
+
+    -- | Return the tip of the database.
+    --
+    -- The tip of the database will never point to an unfilled slot or missing
+    -- EBB.
+    --
+    -- Throws a 'ClosedDBError' if the database is closed.
+  , getTip
+      :: HasCallStack => m Tip
 
     -- | Get the binary blob stored at the given 'Slot'.
     --
     -- Returns 'Nothing' if no blob was stored at the given slot.
     --
     -- Throws a 'ReadFutureSlotError' if the requested slot is in the future,
-    -- i.e @>= 'getNextSlot'@.
+    -- i.e > the result of 'getTip'.
     --
     -- Throws a 'ClosedDBError' if the database is closed.
   , getBinaryBlob
       :: HasCallStack => Slot -> m (Maybe ByteString)
 
+    -- | Get the EBB (Epoch Boundary Block) and its hash of the given epoch.
+    --
+    -- Returns 'Nothing' if no EEB was stored for the given epoch.
+    --
+    -- Throws a 'ReadFutureEBBError' if the requested EBB is in the future.
+    --
+    -- Throws a 'ClosedDBError' if the database is closed.
+  , getEBB
+      :: HasCallStack => Epoch -> m (Maybe (hash, ByteString))
+
     -- | Appends a binary blob at the given slot.
     --
-    -- Throws an 'AppendToSlotInThePastError' if the given slot is before the
-    -- one returned by 'getNextSlot'.
+    -- Throws an 'AppendToSlotInThePastError' if the given slot is <= the
+    -- result of 'getTip'.
     --
     -- Throws a 'ClosedDBError' if the database is closed.
     --
@@ -128,12 +145,35 @@ data ImmutableDB m = ImmutableDB
   , appendBinaryBlob
       :: HasCallStack => Slot -> Builder -> m ()
 
+    -- | Appends a binary blob as the EBB of the given epoch.
+    --
+    -- The EEB can only be added before regular blobs are appended to the
+    -- current epoch.
+    --
+    -- Throws an 'AppendToEBBInThePastError' if the given epoch is before the
+    -- current or if the blobs have already been appended to the current
+    -- epoch.
+    --
+    -- Throws a 'ClosedDBError' if the database is closed.
+    --
+    -- TODO the given binary blob may not be empty.
+  , appendEBB
+      :: HasCallStack => Epoch -> hash -> Builder -> m ()
+
     -- | Return an 'Iterator' to efficiently stream binary blocks out of the
     -- database.
     --
     -- Optionally, a start position (first argument) and/or a stop position
     -- (second argument) can be given that will be used to determine from
     -- which 'Slot' streaming will start and/or stop (both inclusive bounds).
+    --
+    -- The @hash@ argument is used to distinguish the EBB from the regular
+    -- block stored at the same slot. Note that the database only stores the
+    -- hash of the EBB explicitly, so if the given hash matches the EBB's, we
+    -- know the bound refers to the EBB. If it doesn't match, we assume it
+    -- matches the regular block's hash, but we don't verify this. In order to
+    -- to verify this, we would either have to store the hash of each block,
+    -- or parse the contents of the block.
     --
     -- When no start position is given, streaming wil start from the first
     -- blob in the database. When no stop position is given, streaming will
@@ -147,23 +187,27 @@ data ImmutableDB m = ImmutableDB
     -- Throws an 'InvalidIteratorRangeError' if the start of the range is
     -- greater than the end of the range.
     --
-    -- Throws a 'ReadFutureSlotError' if the start or end 'EpochSlot' are in
-    -- the future.
+    -- Throws a 'ReadFutureSlotError' if the start or end 'Slot' are in the
+    -- future.
     --
     -- Throws a 'ClosedDBError' if the database is closed.
     --
     -- The iterator is automatically closed when exhausted, and can be
     -- prematurely closed with 'iteratorClose'.
   , streamBinaryBlobs
-      :: HasCallStack => Maybe Slot -> Maybe Slot -> m (Iterator m)
+      :: HasCallStack
+      => Maybe (Slot, hash)
+      -> Maybe (Slot, hash)
+      -> m (Iterator hash m)
+      -- TODO inclusive + exclusive bounds
 
     -- | Throw 'ImmutableDB' errors
   , immutableDBErr :: ErrorHandling ImmutableDBError m
   }
 
 -- | An 'Iterator' is a handle which can be used to efficiently stream binary
--- blobs. Slots not containing a blob are skipped.
-data Iterator m = Iterator
+-- blobs. Slots not containing a blob and missing EBBs are skipped.
+data Iterator hash m = Iterator
   { -- | Steps an 'Iterator' yielding an 'IteratorResult'.
     --
     -- Throws a 'ClosedDBError' if the database is closed.
@@ -174,7 +218,7 @@ data Iterator m = Iterator
     -- The iterator is automatically closed when exhausted
     -- ('IteratorExhausted'), and can be prematurely closed with
     -- 'iteratorClose'.
-    iteratorNext  :: HasCallStack => m IteratorResult
+    iteratorNext  :: HasCallStack => m (IteratorResult hash)
 
     -- | Dispose of the 'Iterator' by closing any open handles.
     --
@@ -189,55 +233,59 @@ data Iterator m = Iterator
   , iteratorID    :: IteratorID
   }
 
--- | Create an iterator from the given 'ImmutableDB' using 'streamBinaryBlobs'
--- and the given @start@ and @end@ @Maybe 'Slot'@s. Perform the given action
--- using the iterator, and close the iterator using its 'iteratorClose'
--- function, in case of success or when an exception was thrown.
+-- | Create an iterator from the given 'ImmutableDB' using
+-- 'streamBinaryBlobs'. Perform the given action using the iterator, and close
+-- the iterator using its 'iteratorClose' function, in case of success or when
+-- an exception was thrown.
 withIterator :: (HasCallStack, MonadThrow m)
-             => ImmutableDB m
-                -- ^ The database
-             -> Maybe Slot -- ^ Start streaming from here (inclusive)
-             -> Maybe Slot -- ^ End streaming here (inclusive)
-             -> (Iterator m -> m a)
-                -- ^ Action to perform using the iterator
+             => ImmutableDB hash m        -- ^ The database
+             -> Maybe (Slot, hash)        -- ^ Start streaming from here
+             -> Maybe (Slot, hash)        -- ^ End streaming here
+             -> (Iterator hash m -> m a)  -- ^ Action to perform on the iterator
              -> m a
 withIterator db start end =
     bracket (streamBinaryBlobs db start end) iteratorClose
 
 
 -- | Equality based on 'iteratorID'
-instance Eq (Iterator m) where
+instance Eq (Iterator hash m) where
   (==) = (==) `on` iteratorID
 
 -- | The result of stepping an 'Iterator'.
-data IteratorResult
+data IteratorResult hash
   = IteratorExhausted
-  | IteratorResult Slot ByteString
-  deriving (Show, Eq)
+  | IteratorResult    Slot       ByteString
+  | IteratorEBB       Epoch hash ByteString
+  deriving (Show, Eq, Generic)
 
 -- | Consume an 'Iterator' by stepping until it is exhausted. A list of all
--- the blobs produced by the 'Iterator' is returned.
-iteratorToList :: (HasCallStack, Monad m) => Iterator m -> m [ByteString]
+-- the 'IteratorResult's (excluding the final 'IteratorExhausted') produced by
+-- the 'Iterator' is returned.
+iteratorToList :: (HasCallStack, Monad m)
+               => Iterator hash m -> m [IteratorResult hash]
 iteratorToList it = go
   where
     go = do
       next <- iteratorNext it
       case next of
-        IteratorResult _ x -> (x:) <$> go
-        IteratorExhausted  -> return []
+        IteratorExhausted -> return []
+        _                 -> (next:) <$> go
 
 -- | A 'Producer' that streams binary blobs from the database in the given
 -- range.
 blobProducer :: (Monad m, HasCallStack)
-             => ImmutableDB m
-             -> Maybe Slot   -- ^ When to start streaming (inclusive).
-             -> Maybe Slot   -- ^ When to stop streaming (inclusive).
-             -> Producer (Slot, ByteString) m ()
+             => ImmutableDB hash m
+             -> Maybe (Slot, hash)   -- ^ When to start streaming (inclusive).
+             -> Maybe (Slot, hash)   -- ^ When to stop streaming (inclusive).
+             -> Producer (Either (Slot, ByteString)
+                                 (Epoch, hash, ByteString))
+                         m ()
 blobProducer db start end = do
     it <- lift $ streamBinaryBlobs db start end
     let loop = do
           res <- lift $ iteratorNext it
           case res of
-              IteratorExhausted        -> lift $ iteratorClose it
-              IteratorResult slot blob -> yield (slot, blob) *> loop
+            IteratorExhausted           -> lift $ iteratorClose it
+            IteratorResult    slot blob -> yield (Left  (slot,  blob))       *> loop
+            IteratorEBB epoch hash blob -> yield (Right (epoch, hash, blob)) *> loop
     loop

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
@@ -2,6 +2,30 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 -- | Conversion between 'Slot's and 'EpochSlot's.
+--
+-- The chain consists of 'Slot's. Each 'Slot' may be occupied by at most one
+-- block. In the 'ImmutableDB', we don't store the chain in one big file, but
+-- group blocks per 'Epoch', which are then written to an epoch file. Within
+-- each 'Epoch', the blocks are given 'RelativeSlot's. The combination of an
+-- 'Epoch' and a 'RelativeSlot' is an 'EpochSlot'. The 'ImmutableDB' will need
+-- to be able to convert 'Slot's to 'EpochSlot's and vice versa.
+--
+-- Additionally, each epoch may store an Epoch Boundary Block (EBB). This EBB
+-- logically lives between the last slot of an epoch and the first slot of the
+-- next epoch. In the 'ImmutableDB', these are stored at the beginning of each
+-- epoch file, namely at relative slot 0.
+--
+-- For example:
+--
+-- > Epochs:         <──────── 0 ────────> <────── 1 ──────>
+-- > Epoch size:               4                   3
+-- >                 ┌───┬───┬───┬───┬───┐ ┌───┬───┬───┬───┐
+-- >                 │   │   │   │   │   │ │   │   │   │   │
+-- >                 └───┴───┴───┴───┴───┘ └───┴───┴───┴───┘
+-- > 'RelativeSlot':   0   1   2   3   4     0   1   2   3
+-- > 'Slot':          EBB  0   1   2   3    EBB  4   5   6
+--
+-- Note that the epoch size does not include the (optional) EBB.
 module Ouroboros.Storage.ImmutableDB.CumulEpochSizes
   ( -- * RelativeSlot & EpochSlot
     RelativeSlot(..)
@@ -21,6 +45,7 @@ module Ouroboros.Storage.ImmutableDB.CumulEpochSizes
   , rollBackToEpoch
   , slotToEpochSlot
   , epochSlotToSlot
+  , firstSlotOf
 
     -- * StateT-based helpers
   , getNewEpochSizesUntilM
@@ -30,7 +55,8 @@ module Ouroboros.Storage.ImmutableDB.CumulEpochSizes
   ) where
 
 import           Control.Exception (assert)
-import           Control.Monad.State (StateT (StateT), get, lift, modify, put)
+import           Control.Monad.State.Strict (StateT (StateT), get, lift, modify,
+                     put)
 
 import           Data.Coerce (coerce)
 import qualified Data.Foldable as Foldable
@@ -43,7 +69,7 @@ import           GHC.Generics (Generic)
 
 import           Ouroboros.Network.Block (Slot (..))
 
-import           Ouroboros.Storage.ImmutableDB.Types (Epoch,
+import           Ouroboros.Storage.ImmutableDB.Types (Epoch (Epoch),
                      EpochSize (EpochSize))
 
 
@@ -56,8 +82,11 @@ newtype RelativeSlot = RelativeSlot { getRelativeSlot :: Word }
   deriving (Eq, Ord, Enum, Num, Show, Generic, Real, Integral)
 
 -- | Return the last relative slot within the given epoch size.
+--
+-- Relative slot 0 is reserved for the EBB and regular relative slots start at
+-- 0, so the last relative slot is equal to the epoch size.
 lastRelativeSlot :: EpochSize -> RelativeSlot
-lastRelativeSlot (EpochSize sz) = RelativeSlot (pred sz)
+lastRelativeSlot (EpochSize sz) = RelativeSlot sz
 
 -- | The combination of an 'Epoch' and a 'RelativeSlot' within the epoch.
 data EpochSlot = EpochSlot
@@ -66,7 +95,7 @@ data EpochSlot = EpochSlot
   } deriving (Eq, Ord, Generic)
 
 instance Show EpochSlot where
-  show (EpochSlot e (RelativeSlot s)) = show (e, s)
+  show (EpochSlot (Epoch e) (RelativeSlot s)) = show (e, s)
 
 
 {------------------------------------------------------------------------------
@@ -151,27 +180,21 @@ rollBackToEpoch (CES ces) epoch = CES $ Seq.take (succ (fromIntegral epoch)) ces
 -- > epochs:              0    1    2    3     4
 -- > epoch sizes:       [100, 150, 200, 200, 2160]
 -- > cumul epoch sizes: [100, 250, 450, 650, 2810]
--- > slot: 260 -> epoch slot: (2, 10)
+-- > slot: 260 -> epoch slot: (2, 11)
 slotToEpochSlot :: CumulEpochSizes -> Slot -> Maybe EpochSlot
-slotToEpochSlot (CES ces) slot = case ces of
-    _ :|> origLastEs
-      | slot' < origLastEs
-      -> case Seq.dropWhileR (> slot') ces of
-           ces'@(_ :|> lastEs) -> Just $ EpochSlot
-             { _epoch        = fromIntegral (Seq.length ces')
-             , _relativeSlot = coerce (slot' - lastEs)
-             }
-           Empty -> Just $ EpochSlot
-             { _epoch        = 0
-             , _relativeSlot = coerce slot
-             }
-      | origLastEs == slot'
-        -- If the slot == the size of the last epoch, return (epoch + 1, 0).
-      -> Just $ EpochSlot
-           { _epoch        = fromIntegral (Seq.length ces)
-           , _relativeSlot = 0
-           }
-    _ -> Nothing
+slotToEpochSlot (CES ces) slot
+    | _ :|> origLastEs <- ces
+    , slot' < origLastEs
+    = case Seq.dropWhileR (> slot') ces of
+        ces'@(_ :|> lastEs) -> Just $ EpochSlot
+          { _epoch        = fromIntegral (Seq.length ces')
+          , _relativeSlot = succ (coerce (slot' - lastEs))
+          }
+        Empty -> Just $ EpochSlot
+          { _epoch        = 0
+          , _relativeSlot = succ (coerce slot)
+          }
+    | otherwise = Nothing
   where
     slot' :: EpochSize
     slot' = coerce slot
@@ -183,26 +206,41 @@ slotToEpochSlot (CES ces) slot = case ces of
 -- > epochs:              0    1    2    3     4
 -- > epoch sizes:       [100, 150, 200, 200, 2160]
 -- > cumul epoch sizes: [100, 250, 450, 650, 2810]
--- > epoch slot: (2, 10) -> slot: 260
+-- > epoch slot: (2, 11) -> slot: 260
+--
+-- If the 'EpochSlot' has 'RelativeSlot' 0, i.e. it refers to an EBB, then the
+-- first slot of that epoch will be returned.
 epochSlotToSlot :: CumulEpochSizes -> EpochSlot -> Maybe Slot
-epochSlotToSlot (CES ces) (EpochSlot epoch relSlot)
-    | relSlot == 0
-    , fromIntegral epoch == Seq.length ces
+epochSlotToSlot (CES ces) (EpochSlot epoch relSlot) =
+    case Seq.splitAt (fromIntegral epoch) ces of
+      (_ :|> before, at :<| _)
+        | relSlot' < at - before
+        -> Just $ coerce (before + relSlot')
+      (Empty, at :<| _)
+        | relSlot' < at
+        -> Just $ coerce relSlot'
+      _ -> Nothing
+  where
+    relSlot' :: EpochSize
+    relSlot' | relSlot == 0 = 0
+             | otherwise    = coerce relSlot - 1
+             -- RelativeSlot 0 and 1 will point to the same Slot
+
+
+-- | Return the first 'Slot' of the given 'Epoch' if the 'Epoch' is stored in
+-- the 'CumulEpochSizes'.
+firstSlotOf :: CumulEpochSizes -> Epoch -> Maybe Slot
+firstSlotOf (CES ces) epoch
+    | fromIntegral epoch == Seq.length ces
     , _ :|> lastEs <- ces
-      -- Handle EpochSlot n 0 where n = the last epoch + 1
     = Just $ coerce lastEs
     | otherwise
     = case Seq.splitAt (fromIntegral epoch) ces of
-        (_ :|> before, at :<| _)
-          | relSlot' < at - before
-          -> Just $ coerce (before + relSlot')
-        (Empty, at :<| _)
-          | relSlot' < at
-          -> Just $ coerce relSlot
+        (_ :|> before, _ :<| _)
+          -> Just $ coerce before
+        (Empty, _ :<| _)
+          -> Just 0
         _ -> Nothing
-  where
-    relSlot' :: EpochSize
-    relSlot' = coerce relSlot
 
 
 {------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE BangPatterns              #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE MultiWayIf                #-}
 {-# LANGUAGE NamedFieldPuns            #-}
 {-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 
+{-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Immutable on-disk database of binary blobs
 --
 -- = Internal format
@@ -27,17 +29,17 @@
 -- For example:
 --
 -- > Epochs:         <──────── 0 ────────> <────── 1 ──────>
--- > Epoch size:               5                   4
+-- > Epoch size:               4                   3
 -- >                 ┌───┬───┬───┬───┬───┐ ┌───┬───┬───┬───┐
 -- >                 │   │   │   │   │   │ │   │   │   │   │
 -- >                 └───┴───┴───┴───┴───┘ └───┴───┴───┴───┘
 -- > 'RelativeSlot':   0   1   2   3   4     0   1   2   3
--- > 'Slot':           0   1   2   3   4     5   6   7   8
+-- > 'Slot':          EBB  0   1   2   3    EBB  4   5   6
 --
 -- = Errors
 --
 -- Whenever an 'Ouroboros.Storage.ImmutableDB.Types.UnexpectedError' is thrown
--- during a write operation, e.g., 'appendBinaryBlob', the database will be
+-- during an operation, e.g., 'appendBinaryBlob', the database will be
 -- automatically closed because we can not guarantee a consistent state in the
 -- face of file system errors. See the 'reopen' operation and the paragraph
 -- below about reopening the database for more information.
@@ -46,7 +48,8 @@
 --
 -- The database can be closed and reopened. In case the database was closed
 -- because of an unexpected error, the same database can be reopened again
--- with 'reopen' using a 'ValidationPolicy'.
+-- with 'reopen' using a 'ValidationPolicy', which will truncate invalid data
+-- from the database until a valid prefix is recovered.
 --
 -- = Concurrency
 --
@@ -74,36 +77,38 @@
 --   * An \"epoch file\" that stores the actual binary blobs. But nothing
 --     more, so nothing is stored for empty slots.
 --
---   * An \"index file\" that stores the offsets of the binary blobs. These
---     are used to efficiently seek within the epoch file. Index files are
---     only written for \"finalised\" epochs, i.e. an epoch that can no longer
---     be appended to because a new epoch was started.
+--   * An \"index file\" that stores the offsets of the binary blobs and the
+--     hash of the EBB. These are used to efficiently seek within the epoch
+--     file. Index files are only written for \"finalised\" epochs, i.e. an
+--     epoch that can no longer be appended to because a new epoch was
+--     started.
 --
 -- == Index file layout
 --
 -- The index file has the following layout:
 --
--- > ┌────────┬────────┬────────┬┄┄┄┄┄
--- > │offset 0│offset 1│offset 2│ ...
--- > └────────┴────────┴────────┴┄┄┄┄┄
+-- > ┌────────┬────────┬────────┬┄┄┄┄┄┬────────┐
+-- > │offset 0│offset 1│offset 2│ ... │EBB hash│
+-- > └────────┴────────┴────────┴┄┄┄┄┄┴────────┘
 --
 -- Where each @offset i@ is the offset in the epoch file where relative slot
--- @i@ starts. Each @offset i@ is a 'Data.World.Word64' (8 bytes).
+-- @i@ starts. Each @offset i@ is a 'Data.Word.Word64' (8 bytes).
 --
--- For example, say we have written \"a\" to relative slot 0, \"bravo\" to
--- relative slot 1, and \"haskell\" to slot 4. We get the following index file
--- (the row @offset@ is what is stored in the index file):
+-- For example, say we have written \"a\" to relative slot 0 (the EBB),
+-- \"bravo\" to relative slot 1, and \"haskell\" to slot 4. We get the
+-- following index file (the row @offset@ is what is stored in the index
+-- file) (the hash of the EBB was omitted):
 --
--- > slot:     0   1   2   3   4
--- >         ┌───┬───┬───┬───┬───┬────┐
--- > offset: │ 0 │ 1 │ 6 │ 6 │ 6 │ 13 │
--- >         └───┴───┴───┴───┴───┴────┘
+-- > relative slot:   0   1   2   3   4
+-- >                ┌───┬───┬───┬───┬───┬────┐
+-- > offset:        │ 0 │ 1 │ 6 │ 6 │ 6 │ 13 │
+-- >                └───┴───┴───┴───┴───┴────┘
 --
--- Note that the last slot we appended to was the 5th slot, the slot with
--- index 4, but there are 6 offsets in the index. In other words, the index
--- contains @slots + 1@ entries (or @lastSlot + 2@). The last offset is the
--- offset for the next slot that can be appended to and can also be used to
--- find out the size of the last binary blob.
+-- Note that the last (relative) slot we appended to was the 5th slot, the
+-- slot with index 4, but there are 6 offsets in the index. In other words,
+-- the index contains @slots + 1@ entries (or @lastSlot + 2@). The last offset
+-- is the offset for the next slot that can be appended to and can also be
+-- used to find out the size of the last binary blob.
 --
 -- When skipping slots (and thus creating unfilled slots) while appending, the
 -- index is /backfilled/ to indicate that some slots are unfilled. The last
@@ -114,44 +119,44 @@
 -- to the start of the epoch file.
 --
 -- When a new epoch file is started, the index of the current epoch will be
--- padded to @epochSize + 1@ offsets to record that the slots after the last
--- slot that was appended to are empty.
+-- padded to @epochSize + 2@ (1 extra for the EBB and 1 extra for the final
+-- offset) offsets to record that the slots after the last slot that was
+-- appended to are empty.
 --
 -- For example, continuing with the index above, assuming the @epochSize@ is
--- 7, after starting a new epoch, the index file will be padded to the
+-- 6, after starting a new epoch, the index file will be padded to the
 -- following:
 --
--- > slot:     0   1   2   3   4    5    6    7
--- >         ┌───┬───┬───┬───┬───┬────┬────┬────┐
--- > offset: │ 0 │ 1 │ 6 │ 6 │ 6 │ 13 │ 13 │ 13 │
--- >         └───┴───┴───┴───┴───┴────┴────┴────┘
+-- > relative slot:   0   1   2   3   4    5    6
+-- >                ┌───┬───┬───┬───┬───┬────┬────┬────┐
+-- > offset:        │ 0 │ 1 │ 6 │ 6 │ 6 │ 13 │ 13 │ 13 │
+-- >                └───┴───┴───┴───┴───┴────┴────┴────┘
 --
 -- The last offset was repeated twice to indicate that slots 5 and 6 were
 -- unfilled.
---
--- When closing the database, the index is not padded, because the database
--- may be reopened on the same epoch to continue appending to it.
 module Ouroboros.Storage.ImmutableDB.Impl
   ( openDB
   ) where
 
 import           Prelude hiding (truncate)
 
-import           Control.Monad (forM, forM_, replicateM_, unless, void, when)
+import           Codec.Serialise (Serialise, deserialiseOrFail)
+import           Control.Exception (assert)
+import           Control.Monad (forM_, replicateM_, when)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
 import           Control.Monad.Class.MonadThrow (ExitCase (..),
                      MonadCatch (generalBracket), MonadThrow)
-import           Control.Monad.State (StateT (..), execStateT, get, lift,
+import           Control.Monad.State.Strict (StateT (..), execStateT, get, lift,
                      modify, put, runStateT, state)
+
 import           Data.ByteString (ByteString)
 import           Data.ByteString.Builder (Builder)
-import           Data.Coerce (coerce)
+import qualified Data.ByteString.Builder as BS
 import           Data.Either (isRight)
-import           Data.Foldable (minimumBy)
-import           Data.Function (on)
+import           Data.Functor (($>), (<&>))
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import           Data.Maybe (fromMaybe, isJust, maybe)
+import           Data.Maybe (fromMaybe, isJust)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 
@@ -159,18 +164,17 @@ import           GHC.Stack (HasCallStack, callStack)
 
 import           System.IO (IOMode (..), SeekMode (..))
 
-import           Ouroboros.Consensus.Util (SomePair (..), whenJust)
+import           Ouroboros.Consensus.Util (SomePair (..))
 
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types
-import           Ouroboros.Storage.Util
-
 import           Ouroboros.Storage.ImmutableDB.API hiding (getEpochSize)
 import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes (CumulEpochSizes,
                      EpochSlot (..), RelativeSlot (..))
 import qualified Ouroboros.Storage.ImmutableDB.CumulEpochSizes as CES
 import           Ouroboros.Storage.ImmutableDB.Index
 import           Ouroboros.Storage.ImmutableDB.Util
+import           Ouroboros.Storage.Util
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 
@@ -180,15 +184,15 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 
 
 -- | The environment used by the immutable database.
-data ImmutableDBEnv m = forall h e. ImmutableDBEnv
+data ImmutableDBEnv m hash = forall h e. ImmutableDBEnv
     { _dbHasFS           :: !(HasFS m h)
     , _dbErr             :: !(ErrorHandling ImmutableDBError m)
-    , _dbInternalState   :: !(TMVar m (Either (ClosedState m) (OpenState m h)))
-    , _dbEpochFileParser :: !(EpochFileParser e m (Word, Slot))
+    , _dbInternalState   :: !(TMVar m (Either (ClosedState m) (OpenState m hash h)))
+    , _dbEpochFileParser :: !(EpochFileParser e hash m (Word, Slot))
     }
 
 -- | Internal state when the database is open.
-data OpenState m h = OpenState
+data OpenState m hash h = OpenState
     { _currentEpoch            :: !Epoch
     -- ^ The current 'Epoch' the immutable store is writing to.
     , _currentEpochWriteHandle :: !h
@@ -196,8 +200,11 @@ data OpenState m h = OpenState
     , _currentEpochOffsets     :: !(NonEmpty SlotOffset)
     -- ^ The offsets to which blobs have been written in the current epoch
     -- file, stored from last to first.
-    , _nextExpectedSlot        :: !Slot
-    -- ^ The next slot that we can append data to in the epoch file.
+    , _currentEBBHash          :: !(Maybe hash)
+    -- ^ The hash of the EBB of the current epoch that must be appended to the
+    -- index file when finalising the current epoch.
+    , _currentTip              :: !Tip
+    -- ^ The current tip of the database.
     , _getEpochSize            :: !(Epoch -> m EpochSize)
     -- ^ Function to get the size of an epoch.
     , _cumulEpochSizes         :: !CumulEpochSizes
@@ -220,6 +227,21 @@ data ClosedState m = ClosedState
     -- ^ See '_nextIteratorID'.
     }
 
+
+-- | Variant of 'Tip' that uses 'EpochSlot' instead of 'Epoch' or 'Slot'.
+data TipEpochSlot
+  = TipEpochSlotGenesis
+  | TipEpochSlot EpochSlot
+  deriving (Eq)
+
+instance Ord TipEpochSlot where
+  compare te1 te2 = case (te1, te2) of
+    (TipEpochSlotGenesis, TipEpochSlotGenesis) -> EQ
+    (TipEpochSlotGenesis, _)                   -> LT
+    (_,                   TipEpochSlotGenesis) -> GT
+    (TipEpochSlot es1,    TipEpochSlot es2)    -> compare es1 es2
+
+
 {------------------------------------------------------------------------------
   ImmutableDB API
 ------------------------------------------------------------------------------}
@@ -227,14 +249,13 @@ data ClosedState m = ClosedState
 -- | Open the database, creating it from scratch if necessary or reopening an
 -- existing one using the given 'ValidationPolicy'.
 --
--- In addition to the database, the 'Slot' of the last blob stored in it is
--- returned, or 'Nothing' in case the database is empty.
---
 -- A function that can be used to look up the size of an epoch must be passed.
 -- This function must:
 --
--- * For each epoch, return a strictly positive epoch size,
+-- * For each epoch, return a strictly positive (> 0) epoch size,
 -- * Always return the same epoch size for the same given epoch.
+--
+-- The results of this function will be cached.
 --
 -- See 'ValidationPolicy' for more details on the different validation
 -- policies.
@@ -242,63 +263,67 @@ data ClosedState m = ClosedState
 -- An 'EpochFileParser' must be passed in order to reconstruct indices from
 -- epoch files. The 'Word' that the 'EpochFileParser' must return for each
 -- 'Slot' is the size (in bytes) occupied by the (non-empty) block
--- corresponding to the 'Slot'. We only need to know the size of the blocks to
--- know the offset of the end of the last block, so we can know where to
--- truncate the file to in case of invalid trailing data. For all other
--- blocks, we can derive this from the offset of the next block, but there is
--- of course no block after the last one.
+-- corresponding to the 'Slot'. The only reason we need to know the size of
+-- the blocks is to compute the offset of the end of the last block, so we can
+-- know where to truncate the file to in case of invalid trailing data. For
+-- all other blocks, we can derive this from the offset of the next block, but
+-- there is of course no block after the last one.
 --
 -- __Note__: To be used in conjunction with 'withDB'.
-openDB :: (HasCallStack, MonadSTM m, MonadCatch m)
+openDB :: (HasCallStack, MonadSTM m, MonadCatch m, Serialise hash, Eq hash)
        => HasFS m h
        -> ErrorHandling ImmutableDBError m
        -> (Epoch -> m EpochSize)
        -> ValidationPolicy
-       -> EpochFileParser e m (Word, Slot)
-       -> m (ImmutableDB m, Maybe Slot)
+       -> EpochFileParser e hash m (Word, Slot)
+       -> m (ImmutableDB hash m)
 openDB = openDBImpl
 
 {------------------------------------------------------------------------------
   ImmutableDB Implementation
 ------------------------------------------------------------------------------}
 
-mkDBRecord :: (MonadSTM m, MonadCatch m)
-           => ImmutableDBEnv m
-           -> ImmutableDB m
+mkDBRecord :: (MonadSTM m, MonadCatch m, Serialise hash, Eq hash)
+           => ImmutableDBEnv m hash
+           -> ImmutableDB hash m
 mkDBRecord dbEnv = ImmutableDB
     { closeDB           = closeDBImpl           dbEnv
     , isOpen            = isOpenImpl            dbEnv
     , reopen            = reopenImpl            dbEnv
-    , getNextSlot       = getNextSlotImpl       dbEnv
+    , deleteAfter       = deleteAfterImpl       dbEnv
+    , getTip            = getTipImpl            dbEnv
     , getBinaryBlob     = getBinaryBlobImpl     dbEnv
+    , getEBB            = getEBBImpl            dbEnv
     , appendBinaryBlob  = appendBinaryBlobImpl  dbEnv
+    , appendEBB         = appendEBBImpl         dbEnv
     , streamBinaryBlobs = streamBinaryBlobsImpl dbEnv
     , immutableDBErr    = _dbErr dbEnv
     }
 
-openDBImpl :: forall m h e. (HasCallStack, MonadSTM m, MonadCatch m)
+openDBImpl :: forall m h hash e.
+              (HasCallStack, MonadSTM m, MonadCatch m, Serialise hash, Eq hash)
            => HasFS m h
            -> ErrorHandling ImmutableDBError m
            -> (Epoch -> m EpochSize)
            -> ValidationPolicy
-           -> EpochFileParser e m (Word, Slot)
-           -> m (ImmutableDB m, Maybe Slot)
+           -> EpochFileParser e hash m (Word, Slot)
+           -> m (ImmutableDB hash m)
 openDBImpl hasFS@HasFS{..} err getEpochSize valPol epochFileParser = do
     firstEpochSize <- getEpochSize 0
     let ces0 = CES.singleton firstEpochSize
 
-    (st, lastBlobLocation) <- validateAndReopen hasFS err getEpochSize valPol
-      epochFileParser ces0 initialIteratorId
+    !ost  <- validateAndReopen hasFS err getEpochSize valPol epochFileParser
+      ces0 initialIteratorID
 
-    stVar <- atomically $ newTMVar (Right st)
+    stVar <- atomically $ newTMVar (Right ost)
 
     let dbEnv = ImmutableDBEnv hasFS err stVar epochFileParser
         db    = mkDBRecord dbEnv
-        ces1  = _cumulEpochSizes st
-    return (db, epochSlotInThePastToSlot ces1 <$> lastBlobLocation)
+    return db
+
 
 closeDBImpl :: (HasCallStack, MonadSTM m)
-            => ImmutableDBEnv m
+            => ImmutableDBEnv m hash
             -> m ()
 closeDBImpl ImmutableDBEnv {..} = do
     internalState <- atomically $ takeTMVar _dbInternalState
@@ -314,127 +339,241 @@ closeDBImpl ImmutableDBEnv {..} = do
   where
     HasFS{..} = _dbHasFS
 
-isOpenImpl :: MonadSTM m => ImmutableDBEnv m -> m Bool
+isOpenImpl :: MonadSTM m => ImmutableDBEnv m hash -> m Bool
 isOpenImpl ImmutableDBEnv {..} =
     isRight <$> atomically (readTMVar _dbInternalState)
 
--- Note that 'validate' will stop when an 'FsError' is thrown, as usual.
-reopenImpl :: (HasCallStack, MonadSTM m, MonadThrow m)
-           => ImmutableDBEnv m
+reopenImpl :: forall m hash.
+              (HasCallStack, MonadSTM m, MonadThrow m, Eq hash, Serialise hash)
+           => ImmutableDBEnv m hash
            -> ValidationPolicy
-           -> Maybe TruncateFrom
-           -> m (Maybe Slot)
-reopenImpl dbEnv@ImmutableDBEnv {..} valPol mbTruncateFrom = do
+           -> m ()
+reopenImpl ImmutableDBEnv {..} valPol = do
     internalState <- atomically $ takeTMVar _dbInternalState
     case internalState of
       -- When still open,
-      Right ost
-          -- but we have to truncate, so first close the database, then reopen
-          -- it again so we end up in the last case
-        | Just _ <- mbTruncateFrom
-        -> do
-          let !closedState = closedStateFromInternalState internalState
-          -- Close the database before doing the file-system operations so
-          -- that in case these fail, we don't leave the database open.
-          atomically $ putTMVar _dbInternalState (Left closedState)
-          hClose (_currentEpochWriteHandle ost)
-          reopenImpl dbEnv valPol mbTruncateFrom
+      Right _ -> do
+        atomically $ putTMVar _dbInternalState internalState
+        throwUserError _dbErr OpenDBError
 
-          -- no need to truncate, so basically a no-op
-        | otherwise
-        -> do
-          -- Put the state back and do nothing
-          atomically $ putTMVar _dbInternalState internalState
-          lastBlobLocation <- lastBlobInDB _dbHasFS _dbErr ost
-          let ces = _cumulEpochSizes ost
-          return $ epochSlotInThePastToSlot ces <$> lastBlobLocation
-
-      -- Closed, do all the work
+      -- Closed, so we can try to reopen
       Left ClosedState {..} ->
         -- Important: put back the state when an error is thrown, otherwise we
         -- have an empty TMVar.
         onException hasFsErr _dbErr
           (atomically $ putTMVar _dbInternalState internalState) $ do
 
-            -- Truncate if requested. First convert the @'TruncateFrom'
-            -- 'Slot'@ to an 'EpochSlot'.
-            ces' <- case mbTruncateFrom of
-              Nothing                  -> return _closedCumulEpochSizes
-              Just (TruncateFrom slot) ->
-                flip execStateT _closedCumulEpochSizes $ do
-                  epochSlot <- CES.getNewEpochSizesUntilM
-                    (`CES.slotToEpochSlot` slot) _closedGetEpochSize
-                  truncate _dbHasFS _dbEpochFileParser _closedGetEpochSize
-                    epochSlot
+            !ost  <- validateAndReopen _dbHasFS _dbErr _closedGetEpochSize
+              valPol _dbEpochFileParser _closedCumulEpochSizes
+              _closedNextIteratorID
 
-            (!newOpenState, lastBlobLocation) <- validateAndReopen _dbHasFS
-              _dbErr _closedGetEpochSize valPol _dbEpochFileParser
-              ces' _closedNextIteratorID
-
-            atomically $ putTMVar _dbInternalState (Right newOpenState)
-
-            return $ epochSlotInThePastToSlot ces' <$> lastBlobLocation
+            atomically $ putTMVar _dbInternalState (Right ost)
   where
-    HasFS{..}         = _dbHasFS
-    ErrorHandling{..} = _dbErr
+    HasFS{..} = _dbHasFS
 
+-- TODO close all iterators
+deleteAfterImpl :: forall m hash.
+                   (HasCallStack, MonadSTM m, MonadCatch m, Serialise hash)
+                => ImmutableDBEnv m hash
+                -> Tip
+                -> m ()
+deleteAfterImpl dbEnv tip = modifyOpenState dbEnv $ \hasFS@HasFS{..} -> do
+    st@OpenState { _cumulEpochSizes = ces, ..} <- get
 
--- | Execute some error handler when an 'ImmutableDBError' or an 'FsError' is
--- thrown while executing an action.
-onException :: Monad m
-            => ErrorHandling FsError m
-            -> ErrorHandling ImmutableDBError m
-            -> m b  -- ^ What to do when an error is thrown
-            -> m a  -- ^ The action to execute
-            -> m a
-onException fsErr err onErr m =
-    EH.onException fsErr (EH.onException err m onErr) onErr
+    case (currentEpochSlot ces _currentTip, mbNewEpochSlot ces) of
+      -- If we're already at genesis we don't have to do anything
+      (TipEpochSlotGenesis, _)      -> return ()
+      -- Nothing means that the new tip refers to a slot in the future, so
+      -- we don't have to do anything either
+      (_, Nothing)                  -> return ()
+      (TipEpochSlot cur, Just new)
+        -- No truncation needed either
+        | new >= TipEpochSlot cur   -> return ()
+        | otherwise                 -> do
+          -- Close the current epoch file, as we might have to remove it
+          lift $ hClose _currentEpochWriteHandle
+          mbNewTipAndIndex <- lift $ truncateToTipLEQ hasFS st new
+          !ost <- lift $ case mbNewTipAndIndex of
+            Nothing -> mkOpenStateNewEpoch hasFS 0 _getEpochSize
+              ces _nextIteratorID TipGenesis
+            Just (epochSlot@(EpochSlot epoch _), index) -> do
+              let newTip = epochSlotInThePastToTip ces epochSlot
+              mkOpenState hasFS epoch _getEpochSize ces
+                _nextIteratorID newTip index
+          put ost
+  where
+    ImmutableDBEnv { _dbErr } = dbEnv
 
-getNextSlotImpl :: (HasCallStack, MonadSTM m)
-                => ImmutableDBEnv m
-                -> m Slot
-getNextSlotImpl dbEnv = do
-    SomePair _hasFS OpenState {..} <- getOpenState dbEnv
-    return _nextExpectedSlot
+    -- | The current tip as a 'TipEpochSlot'
+    currentEpochSlot :: CumulEpochSizes -> Tip -> TipEpochSlot
+    currentEpochSlot ces currentTip = case currentTip of
+      TipGenesis    -> TipEpochSlotGenesis
+      TipEBB epoch  -> TipEpochSlot $ EpochSlot epoch 0
+      TipBlock slot -> TipEpochSlot $ slotInThePastToEpochSlot ces slot
+
+    -- | The given tip as a 'TipEpochSlot'. 'Nothing' in case it refers to a
+    -- slot in the future. Note that the returned 'TipEpochSlot' may still
+    -- refer to a future EBB.
+    mbNewEpochSlot :: CumulEpochSizes -> Maybe TipEpochSlot
+    mbNewEpochSlot ces = case tip of
+      TipGenesis    -> Just $ TipEpochSlotGenesis
+      TipEBB epoch  -> Just $ TipEpochSlot (EpochSlot epoch 0)
+      -- If 'CES.slotToEpochSlot', returns 'Nothing', it means that the slot
+      -- is in the future. In that case we don't have to delete anything
+      -- anyway. So don't bother with gettting the epoch sizes needed to
+      -- convert it to an EpochSlot.
+      TipBlock slot -> TipEpochSlot <$> CES.slotToEpochSlot ces slot
+
+    -- | Truncate to the last valid (filled slot or EBB) tip <= the given tip.
+    truncateToTipLEQ :: HasFS m h
+                     -> OpenState m hash h
+                     -> TipEpochSlot
+                        -- ^ The returned epoch slot will be the last valid
+                        -- tip <= this tip.
+                     -> m (Maybe (EpochSlot, Index hash))
+                        -- ^ 'Nothing': no valid tip found, we have truncated
+                        -- to genesis. Otherwise, we have truncated so that
+                        -- the tip is at the given Epoch slot, and the index
+                        -- of the epoch is returned.
+    truncateToTipLEQ hasFS@HasFS{..} OpenState{..} = \case
+        TipEpochSlotGenesis -> removeFilesStartingFrom hasFS 0 $> Nothing
+        TipEpochSlot (EpochSlot epoch relSlot) -> do
+          index <- truncateIndex relSlot <$> openIndex epoch
+          go epoch index
+      where
+        ces = _cumulEpochSizes
+
+        -- | Look for the last filled relative slot in the given epoch (the
+        -- index of the epoch is the second argument). When found, return it
+        -- and the index that has the relative slot as its last slot. Removes
+        -- the files corresponding to later epochs and the index file of the
+        -- index. Even when the epoch is complete, i.e., the last slot is
+        -- filled, will its index file be removed, since the epoch will be
+        -- reopened as the current epoch.
+        go :: Epoch -> Index hash -> m (Maybe (EpochSlot, Index hash))
+        go epoch index
+          | Just relSlot <- lastFilledSlot index = do
+            let truncatedIndex = truncateIndex relSlot index
+            withFile hasFS (renderFile "epoch" epoch) AppendMode $ \eHnd ->
+              hTruncate eHnd (lastSlotOffset truncatedIndex)
+            removeIndex epoch
+            removeFilesStartingFrom hasFS (succ epoch)
+            return $ Just (EpochSlot epoch relSlot, truncatedIndex)
+          | epoch == 0
+            -- We come to the first epoch, without finding any empty filled
+            -- slots or EBBs, so remove all files
+          = removeFilesStartingFrom hasFS 0 $> Nothing
+          | otherwise
+          = let epoch' = epoch - 1 in openIndex epoch' >>= go epoch'
+
+        -- | Helper function to open the index file of an epoch.
+        openIndex :: Epoch -> m (Index hash)
+        openIndex epoch
+          | epoch == _currentEpoch
+          = return $ indexFromSlotOffsets _currentEpochOffsets _currentEBBHash
+          | otherwise
+          = loadIndex hasFS _dbErr epoch (succ (epochSizeInThePast ces epoch))
+
+        -- | Remove the index file of the given epoch, if it exists.
+        removeIndex :: Epoch -> m ()
+        removeIndex epoch = do
+            indexFileExists <- doesFileExist indexFile
+            when indexFileExists $ removeFile indexFile
+          where
+            indexFile = renderFile "index" epoch
+
+        -- | Truncate the index so that the given relative slot is the last
+        -- relative slot in the index.
+        truncateIndex :: RelativeSlot -> Index hash -> Index hash
+        truncateIndex relSlot = truncateToSlots (fromIntegral (succ relSlot))
+
+getTipImpl :: (HasCallStack, MonadSTM m)
+           => ImmutableDBEnv m hash
+           -> m Tip
+getTipImpl dbEnv = do
+    SomePair _hasFS OpenState { _currentTip } <- getOpenState dbEnv
+    return _currentTip
 
 getBinaryBlobImpl
-  :: forall m. (HasCallStack, MonadSTM m, MonadThrow m)
-  => ImmutableDBEnv m
+  :: forall m hash. (HasCallStack, MonadSTM m, MonadCatch m, Serialise hash)
+  => ImmutableDBEnv m hash
   -> Slot
   -> m (Maybe ByteString)
-getBinaryBlobImpl dbEnv@ImmutableDBEnv {..} slot = do
-    SomePair _hasFS OpenState {..} <- getOpenState dbEnv
-    -- TODO what if a failed update closes the db while we're in the middle of
-    -- this?
+getBinaryBlobImpl dbEnv slot = withOpenState dbEnv $ \_dbHasFS st@OpenState{..} -> do
+    let inTheFuture = case _currentTip of
+          TipGenesis          -> True
+          TipBlock lastSlot'  -> slot > lastSlot'
+          -- The slot (that pointing to a regular block) corresponding to this
+          -- EBB will be empty, as the EBB is the last thing in the database.
+          -- So if @slot@ is equal to this slot, it is also refering to the
+          -- future.
+          TipEBB lastEBBEpoch -> slot >= ebbSlot
+            where
+              ebbSlot = epochSlotInThePastToSlot _cumulEpochSizes
+                (EpochSlot lastEBBEpoch 0)
 
-    when (slot >= _nextExpectedSlot) $
-      throwUserError _dbErr $ ReadFutureSlotError slot _nextExpectedSlot
+    when inTheFuture $
+      throwUserError _dbErr $ ReadFutureSlotError slot _currentTip
 
-    let EpochSlot epoch relativeSlot =
-          slotInThePastToEpochSlot _cumulEpochSizes slot
-        epochFile = renderFile "epoch" epoch
+    let epochSlot = slotInThePastToEpochSlot _cumulEpochSizes slot
+    snd <$> getEpochSlot _dbHasFS st _dbErr epochSlot
+  where
+    ImmutableDBEnv { _dbErr } = dbEnv
+
+getEBBImpl
+  :: forall m hash. (HasCallStack, MonadSTM m, MonadCatch m, Serialise hash)
+  => ImmutableDBEnv m hash
+  -> Epoch
+  -> m (Maybe (hash, ByteString))
+getEBBImpl dbEnv epoch = withOpenState dbEnv $ \_dbHasFS st@OpenState{..} -> do
+    let inTheFuture = case _currentTip of
+          TipGenesis -> True
+          TipBlock _ -> epoch > _currentEpoch
+          TipEBB _   -> epoch > _currentEpoch
+
+    when inTheFuture $
+      throwUserError _dbErr $ ReadFutureEBBError epoch _currentEpoch
+
+    (mbEBBHash, mbBlob) <- getEpochSlot _dbHasFS st _dbErr (EpochSlot epoch 0)
+    return $ (,) <$> mbEBBHash <*> mbBlob
+  where
+    ImmutableDBEnv { _dbErr } = dbEnv
+
+-- Preconditions: the given 'EpochSlot' is in the past.
+getEpochSlot
+  :: forall m hash h. (HasCallStack, MonadSTM m, MonadThrow m, Serialise hash)
+  => HasFS m h
+  -> OpenState m hash h
+  -> ErrorHandling ImmutableDBError m
+  -> EpochSlot
+  -> m (Maybe hash, Maybe ByteString)
+getEpochSlot _dbHasFS OpenState {..} _dbErr epochSlot = do
+    let epochFile = renderFile "epoch" epoch
         indexFile = renderFile "index" epoch
 
-    (blobOffset, blobSize) <- case epoch == _currentEpoch of
+    (blobOffset, blobSize, mbEBBHash) <- case epoch == _currentEpoch of
       -- If the requested epoch is the current epoch, the offsets are still in
       -- memory
-      True ->
+      True -> assert (lastRelativeSlot >= relativeSlot) $
         case NE.drop toDrop _currentEpochOffsets of
-            (offsetAfter:offset:_) -> return (offset, offsetAfter - offset)
-            _ -> error "impossible: _currentEpochOffsets out of sync"
+            (offsetAfter:offset:_) ->
+              return (offset, offsetAfter - offset, _currentEBBHash)
+            [_] ->
+              -- We requested the EBB, but no EBB has been written yet.
+              return $ assert (relativeSlot == 0) (0, 0, Nothing)
+            [] -> error "impossible: _currentEpochOffsets out of sync"
           where
-            EpochSlot _ lastRelSlot =
-              slotInThePastToEpochSlot _cumulEpochSizes (_nextExpectedSlot - 1)
-            -- The subtraction above cannot underflow thanks to the @slot >=
-            -- _nextExpectedSlot@ check in the beginning.
-            toDrop = fromEnum (lastRelSlot - relativeSlot)
-            -- Similary for this subtraction
+            -- The substraction below cannot underflow, in other words:
+            -- @lastRelativeSlot >= relativeSlot@. This is guaranteed by the
+            -- precondition.
+            toDrop = fromEnum (lastRelativeSlot - relativeSlot)
 
       -- Otherwise, the offsets will have to be read from an index file
       False -> withFile _dbHasFS indexFile ReadMode $ \iHnd -> do
         -- Grab the offset in bytes of the requested slot.
-        let indexSeekPosition = fromIntegral (getRelativeSlot relativeSlot)
-                              * fromIntegral indexEntrySizeBytes
+        let indexSeekPosition =
+              (fromIntegral (getRelativeSlot relativeSlot)) *
+              fromIntegral indexEntrySizeBytes
         hSeek iHnd AbsoluteSeek indexSeekPosition
         -- Compute the offset on disk and the blob size.
         let nbBytesToGet = indexEntrySizeBytes * 2
@@ -444,7 +583,17 @@ getBinaryBlobImpl dbEnv@ImmutableDBEnv {..} slot = do
         bytes <- hGetRightSize _dbHasFS iHnd nbBytesToGet indexFile
         let !start = decodeIndexEntry   bytes
             !end   = decodeIndexEntryAt indexEntrySizeBytes bytes
-        return (start, end - start)
+
+        mbEBBHash <- if relativeSlot == 0 && end > start
+          then do
+            -- Seek till after the offsets so we can read the hash
+            let epochSize  = epochSizeInThePast _cumulEpochSizes epoch
+                hashOffset = (fromIntegral epochSize + 2) * indexEntrySizeBytes
+            hSeek iHnd AbsoluteSeek (fromIntegral hashOffset)
+            deserialiseHash =<< readAll _dbHasFS iHnd
+          else return Nothing
+
+        return (start, end - start, mbEBBHash)
 
     -- In case the requested is still the current epoch, we will be reading
     -- from the epoch file while we're also writing to it. Are we guaranteed
@@ -453,50 +602,80 @@ getBinaryBlobImpl dbEnv@ImmutableDBEnv {..} slot = do
     -- buffering. However, the 'HasFS' implementation we're using uses POSIX
     -- file handles ("Ouroboros.Storage.IO") so we're safe (other
     -- implementations of the 'HasFS' API guarantee this too).
-    case blobSize of
+    mbBlob <- case blobSize of
       0 -> return Nothing
       _ -> withFile _dbHasFS epochFile ReadMode $ \eHnd -> do
         -- Seek in the epoch file
         hSeek eHnd AbsoluteSeek (fromIntegral blobOffset)
         Just <$> hGetRightSize _dbHasFS eHnd (fromIntegral blobSize) epochFile
-  where
-    HasFS{..} = _dbHasFS
 
-appendBinaryBlobImpl :: forall m. (HasCallStack, MonadSTM m, MonadCatch m)
-                     => ImmutableDBEnv m
+    return (mbEBBHash, mbBlob)
+  where
+    HasFS{..}                    = _dbHasFS
+    EpochSlot epoch relativeSlot = epochSlot
+
+    lastRelativeSlot = case _currentTip of
+      TipEBB _      -> 0
+      TipGenesis    -> error "Postcondition violated: EpochSlot must be in the past"
+      TipBlock slot -> _relativeSlot $ slotInThePastToEpochSlot _cumulEpochSizes slot
+
+    deserialiseHash :: HasCallStack => Builder -> m (Maybe hash)
+    deserialiseHash bld = case deserialiseOrFail (BS.toLazyByteString bld) of
+      Right hash -> return hash
+      Left df    -> throwUnexpectedError _dbErr $
+        DeserialisationError df callStack
+
+
+appendBinaryBlobImpl :: forall m hash.
+                        (HasCallStack, MonadSTM m, MonadCatch m, Serialise hash)
+                     => ImmutableDBEnv m hash
                      -> Slot
                      -> Builder
                      -> m ()
 appendBinaryBlobImpl dbEnv@ImmutableDBEnv{..} slot builder =
     modifyOpenState dbEnv $ \hasFS@HasFS{..} -> do
-      OpenState { _currentEpoch, _nextExpectedSlot } <- get
 
-      -- Check that the slot is >= the expected next slot and thus not in the
-      -- past.
-      when (slot < _nextExpectedSlot) $ lift $ throwUserError _dbErr $
-        AppendToSlotInThePastError slot _nextExpectedSlot
+      EpochSlot epoch relSlot <- zoomCumul $ CES.slotToEpochSlotM slot
+
+      OpenState { _currentEpoch, _currentTip } <- get
+
+      -- Check that we're not appending to the past
+      let inThePast = case _currentTip of
+            TipBlock lastSlot'  -> slot  <= lastSlot'
+            TipEBB lastEBBEpoch -> epoch <  lastEBBEpoch
+            TipGenesis          -> False
+
+      when inThePast $ lift $ throwUserError _dbErr $
+        AppendToSlotInThePastError slot _currentTip
 
       -- If the slot is in an epoch > the current one, we have to finalise the
       -- current one and start a new epoch file, possibly skipping some
       -- epochs.
-      EpochSlot epoch relSlot <- zoomCumul $ CES.slotToEpochSlotM slot
-      -- The operation above can update the _cumulEpochSizes
       when (epoch > _currentEpoch) $ do
         let newEpochsToStart :: Int
             newEpochsToStart = fromIntegral $ epoch - _currentEpoch
-        -- Start as many new epochs as needed. Pass the updated state
-        -- around.
+        -- Start as many new epochs as needed.
         replicateM_ newEpochsToStart (startNewEpoch hasFS)
+
+      let initialEpoch = _currentEpoch
 
       -- We may have updated the state with 'startNewEpoch', so get the
       -- (possibly) updated state.
       OpenState {..} <- get
       -- If necessary, backfill for any slots we skipped in the current epoch
-      nextExpectedRelSlot <- zoomCumul $ CES.slotToRelativeSlotM _nextExpectedSlot
-      -- The operation above can update the _cumulEpochSizes
-      let lastEpochOffset = NE.head _currentEpochOffsets
-          backfillOffsets = indexBackfill relSlot nextExpectedRelSlot
-                                          lastEpochOffset
+      let nextFreeRelSlot
+            -- If we had to start a new epoch, we start with slot 0. Note that
+            -- in this case the _currentTip will refer to something in an
+            -- epoch before _currentEpoch.
+            | epoch > initialEpoch = 0
+            | otherwise             = case _currentTip of
+              TipEBB {}          -> 1
+              TipGenesis         -> 0
+              TipBlock lastSlot' -> succ . _relativeSlot $
+                slotInThePastToEpochSlot _cumulEpochSizes lastSlot'
+          lastEpochOffset = NE.head _currentEpochOffsets
+          backfillOffsets =
+            indexBackfill relSlot nextFreeRelSlot lastEpochOffset
 
       -- Append to the end of the epoch file.
       bytesWritten <- lift $ onException hasFsErr _dbErr
@@ -514,12 +693,12 @@ appendBinaryBlobImpl dbEnv@ImmutableDBEnv{..} slot builder =
       modify $ \st -> st
         { _currentEpochOffsets =
             (newOffset NE.:| backfillOffsets) <> _currentEpochOffsets
-        , _nextExpectedSlot = slot + 1
+        , _currentTip = TipBlock slot
         }
 
-startNewEpoch :: (HasCallStack, MonadSTM m, MonadCatch m)
+startNewEpoch :: (HasCallStack, MonadSTM m, MonadCatch m, Serialise hash)
               => HasFS m h
-              -> StateT (OpenState m h) m ()
+              -> StateT (OpenState m hash h) m ()
 startNewEpoch hasFS@HasFS{..} = do
     OpenState {..} <- get
     -- We can close the epoch file
@@ -532,37 +711,98 @@ startNewEpoch hasFS@HasFS{..} = do
     epochSize <- zoomCumul $ CES.getEpochSizeM _currentEpoch
 
     -- Calculate what to pad the file with
-    EpochSlot epoch nextExpectedRelSlot <- zoomCumul $
-      CES.slotToEpochSlotM _nextExpectedSlot
+    let nextFreeRelSlot
+          | null (NE.tail _currentEpochOffsets)
+            -- We have to take care when starting multiple new epochs in a
+            -- row. In the first call the tip will be in the current epoch,
+            -- but in subsequent calls, the tip will still be in an epoch in
+            -- the past, not the '_currentEpoch'. In that case, we can't use
+            -- the relative slot of the tip, since it will point to a relative
+            -- slot in a past epoch. So when the current epoch is empty
+            -- (detected by looking at the offsets), we use relative slot 0 to
+            -- calculate how much to pad.
+          = 0
+          | otherwise
+          = case _currentTip of
+              TipEBB {}          -> 1
+              TipGenesis         -> 0
+              TipBlock lastSlot' -> succ . _relativeSlot $
+                slotInThePastToEpochSlot _cumulEpochSizes lastSlot'
 
     -- The above calls may have modified the _cumulEpochSizes, so get it
     -- again.
     OpenState {..} <- get
     let lastEpochOffset = NE.head _currentEpochOffsets
-        -- An index file of n slots has n + 1 offsets, so pretend we need to
-        -- backfill to slot n
-        lastRelSlot = succ $ CES.lastRelativeSlot epochSize
-        backfillOffsets
-          | 0 <- nextExpectedRelSlot, epoch /= _currentEpoch
-            -- Edge case: last slot of the epoch is filled, so the next
-            -- expected relative slot actually refers to slot 0 of the next
-            -- epoch. No backfill needed
-          = []
-          | otherwise
-          = indexBackfill lastRelSlot nextExpectedRelSlot lastEpochOffset
-
+        -- The last relative slot in the file
+        lastRelSlot     = CES.lastRelativeSlot epochSize
+        backfillOffsets =
+          indexBackfill (succ lastRelSlot) nextFreeRelSlot lastEpochOffset
         -- Prepend the backfillOffsets to the current offsets to get a
         -- non-empty list of all the offsets. Note that this list is stored in
         -- reverse order.
         allOffsets = foldr NE.cons _currentEpochOffsets backfillOffsets
 
-    -- Now write the offsets to the index file to disk
-    lift $ writeSlotOffsets hasFS _currentEpoch allOffsets
+    -- Now write the offsets and the EBB hash to the index file
+    lift $ writeSlotOffsets hasFS _currentEpoch allOffsets _currentEBBHash
 
     st <- lift $ mkOpenStateNewEpoch hasFS (succ _currentEpoch) _getEpochSize
-      _cumulEpochSizes _nextIteratorID
+      _cumulEpochSizes _nextIteratorID _currentTip
 
     put st
+
+appendEBBImpl :: forall m hash.
+                 (HasCallStack, MonadSTM m, MonadCatch m, Serialise hash)
+              => ImmutableDBEnv m hash
+              -> Epoch
+              -> hash
+              -> Builder
+              -> m ()
+appendEBBImpl dbEnv@ImmutableDBEnv{..} epoch hash builder =
+    modifyOpenState dbEnv $ \hasFS@HasFS{..} -> do
+      OpenState { _currentEpoch, _currentTip, _currentEBBHash } <- get
+
+      -- Check that we're not appending to the past
+      let inThePast = case _currentTip of
+            -- There is already a block in this epoch, so the EBB can no
+            -- longer be appended in this epoch
+            TipBlock _ -> epoch <= _currentEpoch
+            -- There is already an EBB in this epoch
+            TipEBB _   -> epoch <= _currentEpoch
+            TipGenesis -> False
+
+      when inThePast $ lift $ throwUserError _dbErr $
+        AppendToEBBInThePastError epoch _currentEpoch
+
+      -- It must be that epoch > _currentEpoch or epoch == _currentEpoch == 0.
+      -- In the former case, one or more new epochs must be started.
+      let newEpochsToStart :: Int
+          newEpochsToStart = fromIntegral $ epoch - _currentEpoch
+      -- Start as many new epochs as needed.
+      replicateM_ newEpochsToStart (startNewEpoch hasFS)
+
+      -- We may have updated the state with 'startNewEpoch', so get the
+      -- (possibly) updated state.
+      OpenState {..} <- get
+
+      -- Append to the epoch file.
+      bytesWritten <- lift $ onException hasFsErr _dbErr
+        (hClose _currentEpochWriteHandle)
+        (hPut _currentEpochWriteHandle builder)
+        -- In 'modifyOpenState': when an exception occurs, we close the handle
+        -- if there is one in the initial open state. However, we might have
+        -- opened a new one when we called 'startNewEpoch', and this handle
+        -- will be different from the one in the initial state, so
+        -- 'modifyOpenState' cannot close it in case of an exception. So take
+        -- care of it here.
+
+      -- The EBB is always the first blob in the file
+      let newOffset = bytesWritten
+
+      modify $ \st -> st
+        { _currentEpochOffsets = newOffset NE.<| _currentEpochOffsets
+        , _currentEBBHash      = Just hash
+        , _currentTip          = TipEBB epoch
+        }
 
 {------------------------------------------------------------------------------
   ImmutableDB Iterator Implementation
@@ -570,17 +810,21 @@ startNewEpoch hasFS@HasFS{..} = do
 
 
 -- | Internal handle to an iterator
-data IteratorHandle m = forall h. IteratorHandle
-  { _it_hasFS :: !(HasFS m h)
+data IteratorHandle hash m = forall h. IteratorHandle
+  { _it_hasFS    :: !(HasFS m h)
     -- ^ Bundled HasFS instance allows to hide type parameters
-  , _it_state :: !(TVar m (Maybe (IteratorState h)))
+  , _it_state    :: !(TVar m (Maybe (IteratorState hash h)))
     -- ^ The state of the iterator. If it is 'Nothing', the iterator is
     -- exhausted and/or closed.
-  , _it_end   :: !EpochSlot
+  , _it_end      :: !EpochSlot
     -- ^ The end of the iterator: the last 'EpochSlot' it should return.
+  , _it_end_hash :: !(Maybe hash)
+    -- ^ The @hash@ of the last block the iterator should return. 'Nothing'
+    -- when no @hash@ was specified, then only '_it_end' will be used to
+    -- determine when to stop streaming.
   }
 
-data IteratorState h = IteratorState
+data IteratorState hash h = IteratorState
   { _it_next         :: !EpochSlot
     -- ^ The location of the next binary blob to read.
     --
@@ -601,79 +845,153 @@ data IteratorState h = IteratorState
     -- from.
   , _it_epoch_handle :: !h
     -- ^ A handle to the epoch file corresponding with '_it_next'.
-  , _it_epoch_index  :: Index
+  , _it_epoch_index  :: Index hash
     -- ^ We load the index file for the epoch we are currently iterating over
     -- in-memory, as it's going to be small anyway (usually ~150kb).
   }
 
-streamBinaryBlobsImpl :: forall m
-                       . (HasCallStack, MonadSTM m, MonadCatch m)
-                      => ImmutableDBEnv m
-                      -> Maybe Slot  -- ^ When to start streaming (inclusive).
-                      -> Maybe Slot  -- ^ When to stop streaming (inclusive).
-                      -> m (Iterator m)
-streamBinaryBlobsImpl dbEnv@ImmutableDBEnv {..} mbStart mbEnd = do
-    SomePair hasFS st@OpenState {..} <- getOpenState dbEnv
-    let ces = _cumulEpochSizes
+streamBinaryBlobsImpl :: forall m hash.
+                         (HasCallStack, MonadSTM m, MonadCatch m,
+                          Serialise hash, Eq hash)
+                      => ImmutableDBEnv m hash
+                      -> Maybe (Slot, hash)  -- ^ When to start streaming (inclusive).
+                      -> Maybe (Slot, hash)  -- ^ When to stop streaming (inclusive).
+                      -> m (Iterator hash m)
+streamBinaryBlobsImpl dbEnv mbStart mbEnd = withOpenState dbEnv $ \hasFS st -> do
+    let ImmutableDBEnv { _dbErr }               = dbEnv
+        HasFS {..}                              = hasFS
+        OpenState { _cumulEpochSizes = ces, ..} = st
 
-    validateIteratorRange _dbErr _nextExpectedSlot mbStart mbEnd
+    validateIteratorRange _dbErr ces _currentTip mbStart mbEnd
 
-    mbLastBlob <- lastBlobInDB hasFS _dbErr st
-    case mbLastBlob of
+    let emptyOrEndBound = case _currentTip of
+          TipGenesis -> Nothing
+          TipEBB epoch
+            | Just (endSlot, endHash) <- mbEnd
+            -> let endEpochSlot = slotInThePastToEpochSlot ces endSlot
+               in Just (endEpochSlot, Just endHash)
+            | otherwise
+            -> Just (EpochSlot epoch 0, Nothing)
+          TipBlock lastSlot'
+            | Just (endSlot, endHash) <- mbEnd
+            -> let endEpochSlot = slotInThePastToEpochSlot ces endSlot
+               in Just (endEpochSlot, Just endHash)
+            | otherwise
+            -> let endEpochSlot = slotInThePastToEpochSlot ces lastSlot'
+               in Just (endEpochSlot, Nothing)
+
+    case emptyOrEndBound of
       -- The database is empty, just return an empty iterator (directly
       -- exhausted)
-      Nothing       -> mkEmptyIterator
-      Just lastBlob -> do
-        -- Fill in missing bounds
-        let start@(EpochSlot startEpoch startSlot) =
-              maybe (EpochSlot 0 0) (slotInThePastToEpochSlot ces) mbStart
-            end = maybe lastBlob (slotInThePastToEpochSlot ces) mbEnd
+      Nothing -> mkEmptyIterator
+      Just (end, mbEndHash) -> do
+        -- Fill in missing start bound
+        let (start@(EpochSlot startEpoch startRelSlot), mbStartHash)
+              | Just (startSlot, startHash) <- mbStart
+              = case slotInThePastToEpochSlot ces startSlot of
+                  -- Include the EBB by setting the start relative slot to 0
+                  EpochSlot epoch 1 -> (EpochSlot epoch 0, Just startHash)
+                  epochSlot         -> (epochSlot,         Just startHash)
+              | otherwise
+              = (EpochSlot 0 0, Nothing)
 
         -- Helper function to open the index file of an epoch.
         let openIndex epoch
               | epoch == _currentEpoch
               = return $ indexFromSlotOffsets _currentEpochOffsets
+                  _currentEBBHash
               | otherwise
-              = loadIndex' hasFS _dbErr epoch
+              = loadIndex hasFS _dbErr epoch
+                  (succ (epochSizeInThePast ces epoch))
 
         startIndex <- openIndex startEpoch
 
-        -- Check if the index slot is filled, otherwise find the next filled
-        -- one. If there is none in this epoch, open the next epoch until you
-        -- find one. If we didn't find a filled slot before reaching 'end',
-        -- return Nothing.
-        mbIndexAndNext <- case containsSlot startIndex startSlot &&
-                               isFilledSlot startIndex startSlot of
-          -- The above 'containsSlot' condition is needed because we do not know
-          -- whether the index has the right size.
-          True  -> return $ Just (startIndex, start)
-          False -> case nextFilledSlot startIndex startSlot of
-            Just slot
+        -- True: use @start@ as the first 'EpochSlot' to start streaming from.
+        --
+        -- False: start searching after @start@ for an 'EpochSlot' to start
+        -- streaming from.
+        let useStartOtherwiseSearch :: Bool
+            useStartOtherwiseSearch
+              | containsSlot startIndex startRelSlot
+                -- The above 'containsSlot' condition is needed because we do
+                -- not know whether the index has the right size, which is a
+                -- precondition for 'isFilledSlot'.
+              , isFilledSlot startIndex startRelSlot
+              = case startRelSlot of
+                  -- If the startSlot refers to the first relative slot (0) of
+                  -- the epoch and the hash doesn't match the EBB hash, then
+                  -- skip the EBB and start from the block after it
+                  0 | Just startHash <- mbStartHash
+                      -- If slot 0 is filled, there must be an EBB hash
+                    , let ebbHash = fromMaybe (error "missing EBB hash") $
+                            getEBBHash startIndex
+                    , ebbHash /= startHash
+                    -> False
+                    | otherwise
+                      -- The startSlot refers to the first relative slot (0),
+                      -- but either no start hash was defined or it matched
+                      -- that of the EBB, so start from the EBB.
+                    -> True
+                  -- The startSlot refers to a filled relative slot other than
+                  -- the first (0), so start from that relative slot. We don't
+                  -- care about hashes, as only the EBB in relative slot 0 has
+                  -- a hash.
+                  _ -> True
+              | otherwise
+                -- The slot was not filled, so indicate that we should search
+                -- for a filled after it
+              = False
+
+        -- If we can't start from @start@, find the next filled 'EpochSlot' to
+        -- start from. If there is none in this epoch, open the next epoch
+        -- until you find one. If we didn't find a filled slot before reaching
+        -- @end@, return Nothing.
+        mbIndexAndNext <- if useStartOtherwiseSearch
+          then return $ Just (startIndex, start)
+          else case nextFilledSlot startIndex startRelSlot of
+            -- We no longer case about the start hash, as we are starting at a
+            -- later slot anyway. We don't care for end hash either, as we're
+            -- still in the same epoch so there can be no more EBB that we
+            -- would have to check the hash of.
+            Just relSlot
               -- There is a filled slot, but we've gone too far
-              | EpochSlot startEpoch slot > end -> return Nothing
+              | EpochSlot startEpoch relSlot > end
+              -> return Nothing
               -- There is a filled slot after startSlot in this epoch
-              | otherwise -> return $ Just (startIndex, EpochSlot startEpoch slot)
+              | otherwise
+              -> return $ Just (startIndex, EpochSlot startEpoch relSlot)
             -- No filled slot in the start epoch, open the next
             Nothing -> lookInLaterEpochs (startEpoch + 1)
               where
                 lookInLaterEpochs epoch
-                  -- Because we have checked that end is valid, this check is
-                  -- enough to guarantee that we will never open an epoch in
-                  -- the future
+                  -- Because we have checked that @end@ is valid, this check
+                  -- is enough to guarantee that we will never open the index
+                  -- of a future epoch, i.e. try to open a non-existing index
+                  -- file.
                   | epoch > _epoch end = return Nothing
                   | otherwise = do
                     index <- openIndex epoch
                     case firstFilledSlot index of
-                      Just slot
+                      Just relSlot
                         -- We've gone too far
-                        | EpochSlot epoch slot > end -> return Nothing
-                        | otherwise -> return $ Just (index, EpochSlot epoch slot)
+                        | EpochSlot epoch relSlot > end
+                        -> return Nothing
+                        | otherwise
+                        -- This @relSlot@ might refer to the first relative
+                        -- slot (0) of an epoch, so it might refer to an EBB.
+                        -- However, we don't have to check the EBB hash, as
+                        -- the EBB must be included in the stream whether the
+                        -- hash matches or not, because the EBB comes before
+                        -- the block stored at the same 'Slot'. When advancing
+                        -- the iterator, we will check whether we should stop
+                        -- after the EBB or include the next block.
+                        -> return $ Just (index, EpochSlot epoch relSlot)
                       Nothing -> lookInLaterEpochs (epoch + 1)
 
         mbIteratorState <- case mbIndexAndNext of
           -- No filled slot found, so just create a closed iterator
           Nothing -> return Nothing
-          Just (index, next@(EpochSlot nextEpoch nextSlot)) -> do
+          Just (index, next@(EpochSlot nextEpoch nextRelSlot)) -> do
             -- Invariant 1 = OK by the search above for a filled slot
 
             eHnd <- hOpen (renderFile "epoch" nextEpoch) ReadMode
@@ -682,23 +1000,24 @@ streamBinaryBlobsImpl dbEnv@ImmutableDBEnv {..} mbStart mbEnd = do
             -- Invariant 3 = OK by the search above for a filled slot
 
             -- Position the epoch handle at the right place. Invariant 4 = OK
-            let offset = fromIntegral (offsetOfSlot index nextSlot)
+            let offset = fromIntegral (offsetOfSlot index nextRelSlot)
             -- Close the handle if the seek fails
             onException hasFsErr _dbErr (hClose eHnd) $
               hSeek eHnd AbsoluteSeek offset
 
             return $ Just IteratorState
-              { _it_next = next
+              { _it_next         = next
               , _it_epoch_handle = eHnd
-              , _it_epoch_index = index
+              , _it_epoch_index  = index
               }
 
         itState <- atomically $ newTVar mbIteratorState
 
         let ith = IteratorHandle
-              { _it_hasFS = _dbHasFS
-              , _it_state = itState
-              , _it_end   = end
+              { _it_hasFS    = hasFS
+              , _it_state    = itState
+              , _it_end      = end
+              , _it_end_hash = mbEndHash
               }
         -- Safely increment '_nextIteratorID' in the 'OpenState'.
         modifyOpenState dbEnv $ \_hasFS -> state $ \st'@OpenState {..} ->
@@ -709,9 +1028,7 @@ streamBinaryBlobsImpl dbEnv@ImmutableDBEnv {..} mbStart mbEnd = do
                 }
           in (it, st' { _nextIteratorID = succ _nextIteratorID })
   where
-    HasFS{..} = _dbHasFS
-
-    mkEmptyIterator :: m (Iterator m)
+    mkEmptyIterator :: m (Iterator hash m)
     mkEmptyIterator =
       modifyOpenState dbEnv $ \_hasFS -> state $ \st@OpenState {..} ->
         let it = Iterator
@@ -722,10 +1039,12 @@ streamBinaryBlobsImpl dbEnv@ImmutableDBEnv {..} mbStart mbEnd = do
         in (it, st { _nextIteratorID = succ _nextIteratorID })
 
 
-iteratorNextImpl :: forall m. (HasCallStack, MonadSTM m, MonadThrow m)
-                 => ImmutableDBEnv m
-                 -> IteratorHandle m
-                 -> m IteratorResult
+iteratorNextImpl :: forall m hash.
+                    (HasCallStack, MonadSTM m, MonadCatch m, Serialise hash,
+                     Eq hash)
+                 => ImmutableDBEnv m hash
+                 -> IteratorHandle hash m
+                 -> m (IteratorResult hash)
 iteratorNextImpl dbEnv it@IteratorHandle {_it_hasFS = hasFS :: HasFS m h, ..} = do
     -- The idea is that if the state is not Nothing, then '_it_next' is always
     -- ready to be read. After reading it with 'readNext', 'stepIterator' will
@@ -735,24 +1054,44 @@ iteratorNextImpl dbEnv it@IteratorHandle {_it_hasFS = hasFS :: HasFS m h, ..} = 
       -- Iterator already closed
       Nothing -> return IteratorExhausted
       -- Valid @next@ thanks to Invariant 1, so go ahead and read it
-      Just iteratorState -> do
-        blob <- readNext iteratorState
-        -- Advance the iterator before return the read blob, so it has a valid
-        -- @next@ to read the next time.
-        stepIterator iteratorState
-        SomePair _hasFS st <- getOpenState dbEnv
+      Just iteratorState@IteratorState{..} -> withOpenState dbEnv $ \_ st -> do
         let ces = _cumulEpochSizes st
-            slot = epochSlotInThePastToSlot ces (_it_next iteratorState)
-        return $ IteratorResult slot blob
+            slot = epochSlotInThePastToSlot ces _it_next
+        blob <- readNext iteratorState
+        case _it_next of
+          -- It's an EBB
+          EpochSlot epoch 0
+            | let ebbHash = fromMaybe (error "missing EBB hash") $
+                    getEBBHash _it_epoch_index
+            -> do
+              case (_it_end, _it_end_hash) of
+                -- Special case: if the thing we are returning is an EBB and
+                -- its 'EpochSlot' matches '_it_end' and its EBB hash matches
+                -- '_it_end_hash', then we must stop after this EBB. Note that
+                -- the '_it_end' will refer to relative slot 1, even though
+                -- the EBB is stored at relative slot 0, because at the time
+                -- we calculate '_it_end"", we don't know yet whether to stop
+                -- at the EBB or the block stored in the same slot (after the
+                -- EBB).
+                (EpochSlot endEpoch 1, Just endHash)
+                  | epoch == endEpoch, endHash == ebbHash
+                  -> iteratorCloseImpl it
+                _ -> stepIterator st iteratorState
+              return $ IteratorEBB epoch ebbHash blob
+          _ -> do
+            -- Advance the iterator before returning the read blob, so it has
+            -- a valid @next@ to read the next time.
+            stepIterator st iteratorState
+            return $ IteratorResult slot blob
   where
     HasFS{..} = hasFS
 
-    readNext :: IteratorState h -> m ByteString
+    readNext :: IteratorState hash h -> m ByteString
     readNext IteratorState { _it_epoch_handle = eHnd
-                           , _it_next = EpochSlot epoch slot
+                           , _it_next = EpochSlot epoch relSlot
                            , _it_epoch_index = index } = do
       -- Grab the blob size from the cached index
-      let blobSize = sizeOfSlot index slot
+      let blobSize = sizeOfSlot index relSlot
 
       -- Read from the epoch file. No need for seeking: as we are streaming,
       -- we are already positioned at the correct place (Invariant 4).
@@ -762,14 +1101,17 @@ iteratorNextImpl dbEnv it@IteratorHandle {_it_hasFS = hasFS :: HasFS m h, ..} = 
     -- Move the iterator to the next position that can be read from, advancing
     -- epochs if necessary. If no next position can be found, the iterator is
     -- closed.
-    stepIterator :: IteratorState h -> m ()
-    stepIterator its@IteratorState { _it_epoch_handle = eHnd
-                                   , _it_next = EpochSlot epoch currentSlot
-                                   , _it_epoch_index = index } =
-      case nextFilledSlot index currentSlot of
+    stepIterator :: OpenState m hash h' -> IteratorState hash h -> m ()
+    stepIterator st its@IteratorState { _it_epoch_handle = eHnd
+                                      , _it_next = EpochSlot epoch currentRelSlot
+                                      , _it_epoch_index = index } =
+      case nextFilledSlot index currentRelSlot of
         -- We're still in the same epoch
-        Just nextSlot
+        Just nextRelSlot
           | next <= _it_end
+            -- We don't have to look at the end hash, because the next filled
+            -- slot can never refer to an EBB (only stored at slot 0), and
+            -- only when looking at an EBB can we check the hash.
           -> atomically $ writeTVar _it_state $ Just its { _it_next = next }
              -- Invariant 1 is OK (see condition), Invariant 2 is unchanged,
              -- Invariant 3 is OK (thanks to nextFilledSlot), Invariant 4 is
@@ -777,18 +1119,17 @@ iteratorNextImpl dbEnv it@IteratorHandle {_it_hasFS = hasFS :: HasFS m h, ..} = 
           | otherwise
           -> iteratorCloseImpl it
           where
-            next = EpochSlot epoch nextSlot
+            next = EpochSlot epoch nextRelSlot
 
         -- Epoch exhausted, open the next epoch
         Nothing -> do
           hClose eHnd
-          SomePair _hasFS st <- getOpenState dbEnv
           openNextNonEmptyEpoch (epoch + 1) st
 
     -- Start opening epochs (starting from the given epoch number) until we
     -- encounter a non-empty one, then update the iterator state accordingly.
     -- If no non-empty epoch can be found, the iterator is closed.
-    openNextNonEmptyEpoch :: Epoch -> OpenState m h' -> m ()
+    openNextNonEmptyEpoch :: Epoch -> OpenState m hash h' -> m ()
     openNextNonEmptyEpoch epoch st@OpenState {..}
       | epoch > _epoch _it_end
       = iteratorCloseImpl it
@@ -797,15 +1138,17 @@ iteratorNextImpl dbEnv it@IteratorHandle {_it_hasFS = hasFS :: HasFS m h, ..} = 
         -- know that _epoch _it_end is <= _currentEpoch, so we know that epoch
         -- <= _currentEpoch.
         index <- case epoch == _currentEpoch of
-          True  -> return $ indexFromSlotOffsets _currentEpochOffsets
-          False -> loadIndex' hasFS (_dbErr dbEnv) epoch
+          False -> loadIndex hasFS (_dbErr dbEnv) epoch
+            (succ (epochSizeInThePast _cumulEpochSizes epoch))
+          True  -> return $
+            indexFromSlotOffsets _currentEpochOffsets _currentEBBHash
 
         case firstFilledSlot index of
           -- Empty epoch -> try the next one
           Nothing -> openNextNonEmptyEpoch (epoch + 1) st
-          Just slot
+          Just relSlot
             -- Slot is after the end -> stop
-            | EpochSlot epoch slot > _it_end -> iteratorCloseImpl it
+            | EpochSlot epoch relSlot > _it_end -> iteratorCloseImpl it
             | otherwise -> do
               let epochFile = renderFile "epoch" epoch
               eHnd <- hOpen epochFile ReadMode
@@ -816,13 +1159,13 @@ iteratorNextImpl dbEnv it@IteratorHandle {_it_hasFS = hasFS :: HasFS m h, ..} = 
               -- Invariant 3 is OK (thanks to firstFilledSlot), Invariant 4 is
               -- OK.
               atomically $ writeTVar _it_state $ Just IteratorState
-                { _it_next = EpochSlot epoch slot
+                { _it_next = EpochSlot epoch relSlot
                 , _it_epoch_handle = eHnd
                 , _it_epoch_index = index
                 }
 
 iteratorCloseImpl :: (HasCallStack, MonadSTM m)
-                  => IteratorHandle m
+                  => IteratorHandle hash m
                   -> m ()
 iteratorCloseImpl IteratorHandle {..} = do
     mbIteratorState <- atomically $ readTVar _it_state
@@ -842,82 +1185,41 @@ iteratorCloseImpl IteratorHandle {..} = do
   Internal functions
 ------------------------------------------------------------------------------}
 
--- | Perform validation as per the 'ValidationPolicy' using 'validate',
--- truncate to the last filled slot in the database if necessary, create an
--- 'OpenState' corresponding to the epoch to reopen, and also return the
--- location of the last filled slot in the database, or 'Nothing' when empty.
-validateAndReopen :: (HasCallStack, MonadThrow m)
+-- | Execute some error handler when an 'ImmutableDBError' or an 'FsError' is
+-- thrown while executing an action.
+onException :: Monad m
+            => ErrorHandling FsError m
+            -> ErrorHandling ImmutableDBError m
+            -> m b  -- ^ What to do when an error is thrown
+            -> m a  -- ^ The action to execute
+            -> m a
+onException fsErr err onErr m =
+    EH.onException fsErr (EH.onException err m onErr) onErr
+
+-- | Perform validation as per the 'ValidationPolicy' using 'validate' and
+-- create an 'OpenState' corresponding to its outcome.
+validateAndReopen :: forall m hash h e.
+                     (HasCallStack, MonadThrow m, Eq hash, Serialise hash)
                   => HasFS m h
                   -> ErrorHandling ImmutableDBError m
                   -> (Epoch -> m EpochSize)
                   -> ValidationPolicy
-                  -> EpochFileParser e m (Word, Slot)
+                  -> EpochFileParser e hash m (Word, Slot)
                   -> CumulEpochSizes
                   -> IteratorID
-                  -> m (OpenState m h, Maybe EpochSlot)
+                  -> m (OpenState m hash h)
 validateAndReopen hasFS err getEpochSize valPol epochFileParser ces nextIteratorID = do
-    ((mbLastEpochAndIndex, mbLastBlobLocation), ces') <-
+    (mbLastValidLocationAndIndex, ces') <-
       flip runStateT ces $
       validate hasFS err getEpochSize valPol epochFileParser
 
-    -- If we get to this point, validation didn't throw an error and all files
-    -- on disk must be valid. The only things we have to deal with are:
-    -- + The last epoch(s) on disk might not contain slots or might end with
-    --   some empty slots. We must truncate to the last filled slot in the
-    --   database.
-    -- + If only the most recent epoch was validated, 'validate' will
-    --   not return an index file
-    --
-    -- Note: if the last epoch on disk is not finalised, it will not have an
-    -- index file. However, 'validate' has returned its reconstructed index.
-
-    case mbLastEpochAndIndex of
-      -- The database is empty, open a fresh state
-      Nothing -> do
-        ost <- mkOpenStateNewEpoch hasFS 0 getEpochSize ces' nextIteratorID
-        return (ost, Nothing)
-
-      Just (lastEpochOnDisk, index) -> do
-
-        -- Figure out the lastBlobLocation if we don't already know it
-        lastBlobLocation <- case mbLastBlobLocation of
-          Just lastBlobLocation
-            -> return lastBlobLocation
-          Nothing
-            | 0 <- lastEpochOnDisk
-              -- If we didn't find a blob in epoch 0, there are none
-            -> return Nothing
-            | otherwise
-            -> lastBlobOnDisk hasFS err (lastEpochOnDisk - 1)
-
-        -- Truncate to the last filled slot
-        ost <- case lastBlobLocation of
-          -- We already handled the case of an empty database, so in this
-          -- case, the database is not empty, but doesn't contain a blob. So
-          -- it only contains empty slots. Truncate it completely.
-          Nothing
-            -> do
-              truncateFromEpoch hasFS 0
-              mkOpenStateNewEpoch hasFS 0 getEpochSize ces' nextIteratorID
-
-          Just (EpochSlot epoch relSlot)
-            | epoch   == lastEpochOnDisk
-            , relSlot == lastSlot index
-              -- No truncation needed
-            -> mkOpenState hasFS epoch getEpochSize ces' nextIteratorID index
-
-            | otherwise
-              -- Truncation needed
-            -> do
-              let indexOrEpochFileParser
-                    | epoch == lastEpochOnDisk = Left index
-                    | otherwise                = Right epochFileParser
-              (index', ces'') <- flip runStateT ces' $
-                truncateFromEpochSlot hasFS indexOrEpochFileParser getEpochSize
-                  (EpochSlot epoch (succ relSlot))
-              mkOpenState hasFS epoch getEpochSize ces'' nextIteratorID index'
-
-        return (ost, lastBlobLocation)
+    case mbLastValidLocationAndIndex of
+      Nothing ->
+        mkOpenStateNewEpoch hasFS 0 getEpochSize ces' nextIteratorID TipGenesis
+      Just (lastValidLocation, index) -> do
+        let tip   = epochSlotInThePastToTip ces' lastValidLocation
+            epoch = _epoch lastValidLocation
+        mkOpenState hasFS epoch getEpochSize ces' nextIteratorID tip index
 
 -- | Create the internal open state based on an epoch with the given 'Index'.
 --
@@ -928,20 +1230,15 @@ mkOpenState :: (HasCallStack, MonadThrow m)
             -> (Epoch -> m EpochSize)
             -> CumulEpochSizes
             -> IteratorID
-            -> Index
-            -> m (OpenState m h)
-mkOpenState HasFS{..} epoch getEpochSize ces nextIteratorID index = do
-    let epochFile    = renderFile "epoch" epoch
-        epochOffsets = indexToSlotOffsets index
+            -> Tip
+            -> Index hash
+            -> m (OpenState m hash h)
+mkOpenState HasFS{..} epoch getEpochSize ces nextIteratorID tip index = do
+    let epochFile     = renderFile "epoch" epoch
+        epochOffsets  = indexToSlotOffsets index
 
-    -- Add missing epoch sizes to ces'
-    (epochStartSlot, ces') <- flip runStateT ces $ CES.getNewEpochSizesUntilM
-      (`CES.epochSlotToSlot` EpochSlot epoch 0) getEpochSize
-
-    -- Use the offsets from the index file (if there was one) to determine the
-    -- next relative slot to write to.
-    let nextExpectedRelSlot = fromIntegral (length epochOffsets - 1)
-        nextExpectedSlot    = epochStartSlot + nextExpectedRelSlot
+    -- Add missing epoch sizes
+    ces' <- execStateT (CES.getEpochSizeM epoch getEpochSize) ces
 
     eHnd <- hOpen epochFile AppendMode
 
@@ -949,7 +1246,8 @@ mkOpenState HasFS{..} epoch getEpochSize ces nextIteratorID index = do
       { _currentEpoch            = epoch
       , _currentEpochWriteHandle = eHnd
       , _currentEpochOffsets     = epochOffsets
-      , _nextExpectedSlot        = nextExpectedSlot
+      , _currentEBBHash          = getEBBHash index
+      , _currentTip              = tip
       , _getEpochSize            = getEpochSize
       , _cumulEpochSizes         = ces'
       , _nextIteratorID          = nextIteratorID
@@ -964,14 +1262,14 @@ mkOpenStateNewEpoch :: (HasCallStack, MonadThrow m)
                     -> (Epoch -> m EpochSize)
                     -> CumulEpochSizes
                     -> IteratorID
-                    -> m (OpenState m h)
-mkOpenStateNewEpoch HasFS{..} epoch getEpochSize ces nextIteratorID = do
+                    -> Tip
+                    -> m (OpenState m hash h)
+mkOpenStateNewEpoch HasFS{..} epoch getEpochSize ces nextIteratorID tip = do
     let epochFile    = renderFile "epoch" epoch
         epochOffsets = 0 NE.:| []
 
-    -- Add missing epoch sizes to ces'
-    (epochStartSlot, ces') <- flip runStateT ces $ CES.getNewEpochSizesUntilM
-      (`CES.epochSlotToSlot` EpochSlot epoch 0) getEpochSize
+    -- Add missing epoch sizes
+    ces' <- execStateT (CES.getEpochSizeM epoch getEpochSize) ces
 
     eHnd <- hOpen epochFile AppendMode
     -- TODO Use new O_EXCL create when we expect it to be empty, see #292
@@ -980,12 +1278,12 @@ mkOpenStateNewEpoch HasFS{..} epoch getEpochSize ces nextIteratorID = do
       { _currentEpoch            = epoch
       , _currentEpochWriteHandle = eHnd
       , _currentEpochOffsets     = epochOffsets
-      , _nextExpectedSlot        = epochStartSlot
+      , _currentEBBHash          = Nothing
+      , _currentTip              = tip
       , _getEpochSize            = getEpochSize
       , _cumulEpochSizes         = ces'
       , _nextIteratorID          = nextIteratorID
       }
-
 
 -- | Get the 'OpenState' of the given database, throw a 'ClosedDBError' in
 -- case it is closed.
@@ -997,8 +1295,8 @@ mkOpenStateNewEpoch HasFS{..} epoch getEpochSize ces nextIteratorID = do
 -- to use an existing 'HasFS' instance already in scope otherwise, since the
 -- @h@ parameters would not be known to match.
 getOpenState :: (HasCallStack, MonadSTM m)
-             => ImmutableDBEnv m
-             -> m (SomePair (HasFS m) (OpenState m))
+             => ImmutableDBEnv m hash
+             -> m (SomePair (HasFS m) (OpenState m hash))
 getOpenState ImmutableDBEnv {..} = do
     internalState <- atomically (readTMVar _dbInternalState)
     case internalState of
@@ -1009,7 +1307,7 @@ getOpenState ImmutableDBEnv {..} = do
 --
 -- In case the database is closed, a 'ClosedDBError' is thrown.
 --
--- In case a 'FileSystemError' is thrown, the database is closed to prevent
+-- In case an 'UnexpectedError' is thrown, the database is closed to prevent
 -- further appending to a database in a potentially inconsistent state.
 --
 -- __Note__: This /takes/ the 'TMVar', /then/ runs the action (which might be
@@ -1021,9 +1319,9 @@ getOpenState ImmutableDBEnv {..} = do
 -- TODO(adn): we should really just use 'Control.Concurrent.MVar.MVar' rather
 -- than 'TMVar', but we currently don't have a simulator for code using
 -- @MVar@.
-modifyOpenState :: forall m r. (HasCallStack, MonadSTM m, MonadCatch m)
-                => ImmutableDBEnv m
-                -> (forall h. HasFS m h -> StateT (OpenState m h) m r)
+modifyOpenState :: forall m hash r. (HasCallStack, MonadSTM m, MonadCatch m)
+                => ImmutableDBEnv m hash
+                -> (forall h. HasFS m h -> StateT (OpenState m hash h) m r)
                 -> m r
 modifyOpenState ImmutableDBEnv {_dbHasFS = hasFS :: HasFS m h, ..} action = do
     (mr, ()) <- generalBracket open close (EH.try _dbErr . mutation)
@@ -1038,11 +1336,11 @@ modifyOpenState ImmutableDBEnv {_dbHasFS = hasFS :: HasFS m h, ..} action = do
     -- so that 'close' knows which error is thrown (@Either e (s, r)@ vs. @(s,
     -- r)@).
 
-    open :: m (Either (ClosedState m) (OpenState m h))
+    open :: m (Either (ClosedState m) (OpenState m hash h))
     open = atomically $ takeTMVar _dbInternalState
 
-    close :: Either (ClosedState m) (OpenState m h)
-          -> ExitCase (Either ImmutableDBError (r, OpenState m h))
+    close :: Either (ClosedState m) (OpenState m hash h)
+          -> ExitCase (Either ImmutableDBError (r, OpenState m hash h))
           -> m ()
     close !st ec = case ec of
       -- Restore the original state in case of an abort
@@ -1067,19 +1365,83 @@ modifyOpenState ImmutableDBEnv {_dbHasFS = hasFS :: HasFS m h, ..} action = do
         atomically $ putTMVar _dbInternalState st
 
     mutation :: HasCallStack
-             => Either (ClosedState m) (OpenState m h)
-             -> m (r, OpenState m h)
+             => Either (ClosedState m) (OpenState m hash h)
+             -> m (r, OpenState m hash h)
     mutation (Left _)    = throwUserError _dbErr ClosedDBError
     mutation (Right ost) = runStateT (action hasFS) ost
 
     -- TODO what if this fails?
-    closeOpenHandles :: Either (ClosedState m) (OpenState m h) -> m ()
+    closeOpenHandles :: Either (ClosedState m) (OpenState m hash h) -> m ()
+    closeOpenHandles (Left _)               = return ()
+    closeOpenHandles (Right OpenState {..}) = hClose _currentEpochWriteHandle
+
+-- | Perform an action that accesses the internal state of an open database.
+--
+-- In case the database is closed, a 'ClosedDBError' is thrown.
+--
+-- In case an 'UnexpectedError' is thrown while the action is being run, the
+-- database is closed to prevent further appending to a database in a
+-- potentially inconsistent state.
+withOpenState :: forall m hash r. (HasCallStack, MonadSTM m, MonadCatch m)
+              => ImmutableDBEnv m hash
+              -> (forall h. HasFS m h -> OpenState m hash h -> m r)
+              -> m r
+withOpenState ImmutableDBEnv {_dbHasFS = hasFS :: HasFS m h, ..} action = do
+    (mr, ()) <- generalBracket open (const close) (EH.try _dbErr . access)
+    case mr of
+      Left  e -> throwError e
+      Right r -> return r
+  where
+    HasFS{..}         = hasFS
+    ErrorHandling{..} = _dbErr
+
+    open :: m (Either (ClosedState m) (OpenState m hash h))
+    open = atomically $ readTMVar _dbInternalState
+
+    -- close doesn't take the state that @open@ returned, because the state
+    -- may have been updated by someone else since we got it (remember we're
+    -- using 'readTMVar' here, 'takeTMVar'). So we need to get the most recent
+    -- state anyway.
+    close :: ExitCase (Either ImmutableDBError r)
+          -> m ()
+    close ec = case ec of
+      ExitCaseAbort         -> return ()
+      -- In case of an exception, most likely at the HasFS layer, close the DB
+      -- for safety.
+      ExitCaseException _ex -> do
+        st <- atomically $ do
+          st <- takeTMVar _dbInternalState
+          let !cst = closedStateFromInternalState st
+          putTMVar _dbInternalState (Left cst)
+          return st
+        closeOpenHandles st
+      ExitCaseSuccess (Right _) -> return ()
+      -- In case of an ImmutableDBError, close when unexpected
+      ExitCaseSuccess (Left (UnexpectedError {})) -> do
+        -- We need to get the most recent state because it might have changed
+        -- behind our back
+        st <- atomically $ do
+          st <- takeTMVar _dbInternalState
+          let !cst = closedStateFromInternalState st
+          putTMVar _dbInternalState (Left cst)
+          return st
+        closeOpenHandles st
+      ExitCaseSuccess (Left (UserError {})) -> return ()
+
+    access :: HasCallStack
+           => Either (ClosedState m) (OpenState m hash h)
+           -> m r
+    access (Left _)    = throwUserError _dbErr ClosedDBError
+    access (Right ost) = action hasFS ost
+
+    -- TODO what if this fails?
+    closeOpenHandles :: Either (ClosedState m) (OpenState m hash h) -> m ()
     closeOpenHandles (Left _)               = return ()
     closeOpenHandles (Right OpenState {..}) = hClose _currentEpochWriteHandle
 
 
 -- | Create a 'ClosedState' from an internal state, open or closed.
-closedStateFromInternalState :: Either (ClosedState m) (OpenState m h)
+closedStateFromInternalState :: Either (ClosedState m) (OpenState m hash h)
                              -> ClosedState m
 closedStateFromInternalState (Left cst) = cst
 closedStateFromInternalState (Right OpenState {..}) = ClosedState
@@ -1095,7 +1457,7 @@ zoomCumul :: Monad m
           => (    (Epoch -> m EpochSize)
                -> StateT CumulEpochSizes m a
              )
-          -> StateT (OpenState m h) m a
+          -> StateT (OpenState m hash h) m a
 zoomCumul m = do
     OpenState { _cumulEpochSizes = ces, _getEpochSize } <- get
     (a, ces') <- lift $ runStateT (m _getEpochSize) ces
@@ -1110,61 +1472,37 @@ zoomCumul m = do
 epochSlotInThePastToSlot :: HasCallStack
                          => CumulEpochSizes -> EpochSlot -> Slot
 epochSlotInThePastToSlot ces epochSlot = fromMaybe
-  (error "Could not convert EpochSlot to Slot") $
+  (error ("Could not convert EpochSlot to Slot: " <> show epochSlot)) $
   CES.epochSlotToSlot ces epochSlot
 
 -- | Convert a 'Slot' in the past (<= the next slot to write to) using an up
 -- to date 'CumulEpochSizes' to an 'EpochSlot'.
 --
---This conversion may not fail, as the 'Slot' must be in the past, and all
+-- This conversion may not fail, as the 'Slot' must be in the past, and all
 -- past epoch sizes are known.
 slotInThePastToEpochSlot :: HasCallStack
                          => CumulEpochSizes -> Slot -> EpochSlot
 slotInThePastToEpochSlot ces slot = fromMaybe
-  (error "Could not convert Slot to EpochSlot") $
+  (error ("Could not convert Slot to EpochSlot: " <> show slot)) $
   CES.slotToEpochSlot ces slot
 
--- | Return the 'EpochSlot' corresponding to the last blob stored in the
--- database. When the database is empty, 'Nothing' is returned.
+-- | Look up the 'EpochSize' of an 'Epoch' using an up to date
+-- 'CumulEpochSizes'.
 --
--- When the current epoch is still empty, the indices of previous epochs are
--- opened until a filled slot is found.
-lastBlobInDB :: forall m h. (HasCallStack, MonadThrow m)
-             => HasFS m h
-             -> ErrorHandling ImmutableDBError m
-             -> OpenState m h
-             -> m (Maybe EpochSlot)
-lastBlobInDB hasFS err OpenState {..}
-    | Just relSlot <- lastFilledSlot (indexFromSlotOffsets _currentEpochOffsets)
-      -- TODO low priority (seldomly called): this can be done more
-      -- efficiently without converting to an Index.
-    = return $ Just $ EpochSlot _currentEpoch relSlot
-    | 0 <- _currentEpoch
-      -- If in epoch 0 and the in-memory offsets told us there is no blob,
-      -- don't look at the disk, also because there are no indices on disk.
-    = return Nothing
-    | otherwise
-    = lastBlobOnDisk hasFS err (_currentEpoch - 1)
+-- This conversion may not fail, as the 'Epoch' must be in the past (or
+-- current), and all past epoch sizes are known.
+epochSizeInThePast :: HasCallStack
+                   => CumulEpochSizes -> Epoch -> EpochSize
+epochSizeInThePast ces epoch = fromMaybe
+  (error ("Unknown epoch size: " <> show epoch)) $ CES.epochSize ces epoch
 
+-- | Convert and 'EpochSlot' to an epoch in case it refers to an EBB or to a
+-- slot otherwise.
+epochSlotInThePastToTip :: CumulEpochSizes -> EpochSlot -> Tip
+epochSlotInThePastToTip _   (EpochSlot epoch 0) = TipEBB epoch
+epochSlotInThePastToTip ces epochSlot           = TipBlock $
+    epochSlotInThePastToSlot ces epochSlot
 
--- | Open index files looking for the last filled slot, starting from the
--- given epoch and going to previous epochs.
---
--- Assumes index files are present and valid.
-lastBlobOnDisk :: (HasCallStack, MonadThrow m)
-               => HasFS m h
-               -> ErrorHandling ImmutableDBError m
-               -> Epoch
-               -> m (Maybe EpochSlot)
-lastBlobOnDisk hasFS err = go
-  where
-    go epoch = do
-      index <- loadIndex' hasFS err epoch
-      case lastFilledSlot index of
-        Just relSlot -> return $ Just $ EpochSlot epoch relSlot
-        Nothing
-          | 0 <- epoch -> return Nothing
-          | otherwise  -> go (epoch - 1)
 
 -- | Go through all files, making two sets: the set of epoch-xxx.dat
 -- files, and the set of index-xxx.dat files, discarding all others.
@@ -1175,87 +1513,6 @@ dbFilesOnDisk = foldr categorise mempty
       Just ("epoch", n) -> (Set.insert n epochFiles, indexFiles)
       Just ("index", n) -> (epochFiles, Set.insert n indexFiles)
       _                 -> fs
-
--- | The location of the last blob stored in the database. 'Nothing' in case
--- the database stores no blobs, i.e. is empty.
---
--- This type synonyms is meant for internal used, mainly to avoid @'Maybe'
--- ('Maybe' 'Slot')@.
-type LastBlobLocation = Maybe EpochSlot
-
--- | Truncate to the given 'EpochSlot'.
---
--- May leave an unfilled slot as the last slot, it is up to the caller to
--- choose the right 'TruncateFrom' so that the last slot in the database is
--- filled.
---
--- Assumes everything stored on disk before the truncation point is valid. If
--- the index is missing of the epoch to truncate in, the 'EpochFileParser'
--- will be used. If it is present, it must at least be valid up to the slot to
--- truncate to. The remainder of the index file may be invalid. The contents
--- of an epoch after the truncation point are allowed to be invalid.
-truncate :: (HasCallStack, MonadThrow m)
-         => HasFS m h
-         -> EpochFileParser e m (Word, Slot)
-         -> (Epoch -> m EpochSize)
-         -> EpochSlot
-         -> StateT CumulEpochSizes m ()
-truncate hasFS epochFileParser getEpochSize epochSlot = case epochSlot of
-    EpochSlot epoch 0 -> lift $ truncateFromEpoch hasFS epoch
-    _                 -> void $
-      truncateFromEpochSlot hasFS (Right epochFileParser) getEpochSize
-        epochSlot
-
--- | Truncate everything starting from the given epoch (inclusive).
---
--- Doesn't read any index files.
-truncateFromEpoch :: (HasCallStack, MonadThrow m)
-                  => HasFS m h
-                  -> Epoch
-                  -> m ()
-truncateFromEpoch = removeFilesStartingFrom
-
--- | Truncate from the given 'EpochSlot' (inclusive).
---
--- In order to truncate to some relative slot, we need to know the right
--- offset of it. Either we get it from an in-memory 'Index' that corresponds
--- to the epoch, or we try to load the index from disk. However, if the epoch
--- is unfinalised, it will not have an index file, so in that case,
--- reconstruct it using the 'EpochFileParser'.
---
--- Return the truncated index of the epoch.
---
--- The index file is deleted from disk, as we only want complete index files
--- on disk.
-truncateFromEpochSlot :: (HasCallStack, MonadThrow m)
-                      => HasFS m h
-                      -> Either Index (EpochFileParser e m (Word, Slot))
-                      -> (Epoch -> m EpochSize)
-                      -> EpochSlot
-                      -> StateT CumulEpochSizes m Index
-truncateFromEpochSlot hasFS@HasFS{..} indexOrEpochFileParser getEpochSize epochSlot = do
-    let EpochSlot epoch relSlot = epochSlot
-    lift $ removeFilesStartingFrom hasFS (succ epoch)
-    let indexFile = renderFile "index" epoch
-        epochFile = renderFile "epoch" epoch
-    indexFileExists <- lift $ doesFileExist indexFile
-    -- Remove an index file that might be laying around
-    when indexFileExists $ lift $ removeFile indexFile
-
-    index <- case indexOrEpochFileParser of
-      Left  index           -> return index
-      Right epochFileParser ->
-        -- TODO we could try reading the index file if it exists and accept it
-        -- when it is complete
-        fst <$> reconstructIndex epochFile epochFileParser getEpochSize
-    let truncatedIndexSize :: EpochSize
-        truncatedIndexSize = coerce relSlot
-        truncatedIndex     = truncateToSlots truncatedIndexSize index
-    -- Truncate the epoch file
-    lift $ withFile hasFS epochFile AppendMode $ \eHnd ->
-      hTruncate eHnd (lastSlotOffset truncatedIndex)
-    return truncatedIndex
-
 
 -- | Remove all epoch and index starting from the given epoch (included).
 removeFilesStartingFrom :: (HasCallStack, Monad m)
@@ -1270,14 +1527,36 @@ removeFilesStartingFrom HasFS{..} epoch = do
     forM_ (takeWhile (>= epoch) (Set.toDescList indexFiles)) $ \i ->
       removeFile (renderFile "index" i)
 
+-- | Internal data type used as the result of @validateEpoch@.
+data ValidateResult hash
+  = Missing
+    -- ^ The epoch file is missing. The epoch and index files corresponding to
+    -- the epoch are guaranteed to be no longer on disk.
+  | Complete   (Index hash)
+    -- ^ There is a valid epoch file and a valid index file on disk (this may
+    -- be the result of recovery). The index is complete, i.e. finalised,
+    -- according to the index or because the last slot of the epoch was
+    -- filled.
+    --
+    -- The index may end with an empty slot.
+  | Incomplete (Index hash)
+    -- ^ There is a valid epoch file on disk. There is no index file on disk
+    -- (this may have been removed during recovery). The index is incomplete.
+    --
+    -- Either the index ends with a filled slot or it is empty.
+
+
 -- | Execute the 'ValidationPolicy'.
+--
+-- * Invalid or missing files will cause truncation. Later epoch and index
+--   files are removed. Trailing empty slots are truncated so that the tip of
+--   the database will always point to a valid block or EBB.
 --
 -- * Epoch files are the main source of truth. Index files can be
 --   reconstructed from the epoch files using the 'EpochFileParser'.
 --
 -- * Only complete index files (with the same number of slots as the epoch
---   size) are valid. An error will be thrown when an incomplete or invalid
---   index file is encountered.
+--   size) are valid.
 --
 -- * The last, unfinalised epoch will not have an index file. We do our best
 --   to only reconstruct its index once.
@@ -1286,294 +1565,304 @@ removeFilesStartingFrom HasFS{..} epoch = do
 --   files. Reconstructed indices are unaware of empty trailing slots. Special
 --   case: when the last slot of an epoch is filled, the reconstructed index
 --   gives us all the information we need, because there can't be any trailing
---   empty slots that only the index file could now about. In this case, we
---   overwrite the index file if it is missing or invalid without throwing an
---   error. This means that if all index files are missing, but the last slot
---   of each epoch is filled, we can reconstruct all index files from the
---   epochs without needing any truncation or throwing an error.
---
--- * An error will be thrown for the \"earliest\" invalid slot in the
---   database. A 'TruncateFrom' can be extracted from the error using
---   'extractTruncateFrom', and can be used to truncate the database (using
---   'reopen') so that all invalid\/missing files are removed or truncated,
---   and that the remaining contents of the database are valid. So the error
---   is thrown that requires the most truncation to fix, so that a single
---   truncation (and validation) is enough to bring the database back in a
---   valid state.
-validate :: forall m h e. (HasCallStack, MonadThrow m)
+--   empty slots that only the index file could know about. In this case, we
+--   overwrite the index file if it is missing or invalid instead of
+--   truncating the database. This means that if all index files are missing,
+--   but the last slot of each epoch is filled, we can reconstruct all index
+--   files from the epochs without needing any truncation.
+validate :: forall m hash h e.
+            (HasCallStack, MonadThrow m, Eq hash, Serialise hash)
          => HasFS m h
          -> ErrorHandling ImmutableDBError m
          -> (Epoch -> m EpochSize)
          -> ValidationPolicy
-         -> EpochFileParser e m (Word, Slot)
-         -> StateT CumulEpochSizes m ( Maybe (Epoch, Index)
-                                     , Maybe LastBlobLocation
-                                     )
-            -- ^ The last epoch on disk and its index (or 'Nothing' when there
-            -- is no epoch on disk), and the last block location if we know it
-            -- ('Nothing' if we don't know it).
+         -> EpochFileParser e hash m (Word, Slot)
+         -> StateT CumulEpochSizes m (Maybe (EpochSlot, Index hash))
+            -- ^ The 'EpochSlot' pointing at the last valid block or EBB on
+            -- disk and the 'Index' of the corresponding epoch. 'Nothing' if
+            -- the database is empty.
 validate hasFS@HasFS{..} err getEpochSize valPol epochFileParser = do
     filesInDBFolder <- lift $ listDirectory []
-    let epochFiles        = fst $ dbFilesOnDisk filesInDBFolder
-        mbLastEpochOnDisk = Set.lookupMax epochFiles
-    case mbLastEpochOnDisk of
-      Nothing -> do
-        -- Throw an error for left-over index files
-        errorOnIndexFileFrom 0
-        return (Nothing, Just Nothing)
+    let epochFiles = fst $ dbFilesOnDisk filesInDBFolder
+    case Set.lookupMax epochFiles of
+      Nothing              -> do
+        -- Remove left-over index files
+        lift $ removeFilesStartingFrom hasFS 0
+        -- TODO calls listDirectory again
+        return Nothing
 
       Just lastEpochOnDisk -> case valPol of
-
-        ValidateMostRecentEpoch -> do
-          (index, lastBlobLocation) <- validateEpochs lastEpochOnDisk []
-          -- If there are index files for epochs after the last epoch file on
-          -- disk, then some epoch file(s) must be missing.
-          errorOnIndexFileFrom (succ lastEpochOnDisk)
-          return ( Just (lastEpochOnDisk, index)
-               -- When we found the lastBlobLocation, return it. If we didn't
-               -- find it, don't say the 'LastBlobLocation' is Nothing (=
-               -- empty database), because we didn't look at previous epochs.
-               -- Just say we don't know the 'LastBlobLocation'
-                 , maybe Nothing (Just . Just) lastBlobLocation
-                 )
-
-        ValidateAllEpochs -> do
-          (index, lastBlobLocation) <- validateEpochs 0 [1..lastEpochOnDisk]
-          errorOnIndexFileFrom (succ lastEpochOnDisk)
-          return ( Just (lastEpochOnDisk, index)
-                   -- We looked at all epochs, so we know the last blob
-                   -- location.
-                 , Just lastBlobLocation
-                 )
+        ValidateMostRecentEpoch -> validateMostRecentEpoch lastEpochOnDisk
+        ValidateAllEpochs       -> validateAllEpochs       lastEpochOnDisk
   where
-    -- | Validate all the given epochs using 'validateEpoch'. Return the index
-    -- of the last epoch in the list (or the given epoch if the list is
-    -- empty). Also returns the location of the last known blob, which is not
-    -- necessarily in the last epoch.
+    -- | Validate the most recent (given) epoch using 'validateEpoch'.
     --
-    -- When this functions returns without throwing an error, all the given
-    -- epochs are valid.
-    validateEpochs :: HasCallStack
-                   => Epoch
-                   -> [Epoch]
-                   -> StateT CumulEpochSizes m (Index, LastBlobLocation)
-    validateEpochs epoch epochs = do
-        index <- validateEpoch epoch (null epochs)
-        let lastBlobLocation = EpochSlot epoch <$> lastFilledSlot index
-        go index lastBlobLocation epochs
+    -- Starts from the given epoch, if that is invalid or empty, it is
+    -- truncated and the epoch before it is validated, and so on.
+    --
+    -- validation stops as soon as we have found a valid non-empty epoch.
+    --
+    -- The location of the last valid block or EBB, along with the index of
+    -- the corresponding epoch, is returned.
+    --
+    -- All data after the last valid block or EBB is truncated.
+    validateMostRecentEpoch :: HasCallStack
+                            => Epoch
+                            -> StateT CumulEpochSizes m (Maybe (EpochSlot, Index hash))
+    validateMostRecentEpoch = go
       where
-        go index lastBlobLocation [] = return (index, lastBlobLocation)
-        go _     lastBlobLocation (epoch':epochs') = do
-          index' <- validateEpoch epoch' (null epochs')
-          let lastBlobLocation'
-                | Just relSlot <- lastFilledSlot index'
-                = Just $ EpochSlot epoch' relSlot
-                | otherwise
-                = lastBlobLocation
-          go index' lastBlobLocation' epochs'
+        go epoch = do
+          validateRes <- validateEpoch epoch
+          let continueIfPossible | epoch == 0 = return Nothing
+                                 | otherwise  = go (epoch - 1)
+          case validateRes of
+            Missing
+              -> continueIfPossible
+            Incomplete index
+              | Just lastRelativeSlot <- lastFilledSlot index
+              -> return $ Just (EpochSlot epoch lastRelativeSlot, index)
+              | otherwise
+              -> do
+                lift $ removeFile (renderFile "epoch" epoch)
+                continueIfPossible
+            Complete index
+              | Just lastRelativeSlot <- lastFilledSlot index
+              -> do
+                index' <- if
+                  | lastSlot index == lastRelativeSlot -> return index
+                    -- If the index contains empty trailing slots, truncate
+                    -- them.
+                  | otherwise                          -> do
+                    -- As the epoch will no longer be complete, remove the
+                    -- index file.
+                    lift $ removeFile (renderFile "index" epoch)
+                    let newIndexSize = fromIntegral lastRelativeSlot + 1
+                    return $ truncateToSlots newIndexSize index
+                return $ Just (EpochSlot epoch lastRelativeSlot, index')
+              | otherwise
+              -> do
+                lift $ removeFile (renderFile "epoch" epoch)
+                lift $ removeFile (renderFile "index" epoch)
+                continueIfPossible
+
+    -- | Validate all the epochs using @validateEpoch@, starting from the most
+    -- recent (given) epoch.
+    --
+    -- Starts from the given epoch, if that is invalid or empty, it is
+    -- truncated and the epoch before it is validated, and so on.
+    --
+    -- When a valid non-empty epoch is encountered, the location of the last
+    -- valid block or EBB in it is remembered, but validation continues until
+    -- all epochs are validated. Epoch 0 will be the last epoch to validate.
+    --
+    -- The location of the last valid block or EBB that was remembered, along
+    -- with the index of the corresponding epoch, is returned. All data before
+    -- this location will have been validated.
+    --
+    -- All data after the last valid block or EBB is truncated.
+    validateAllEpochs :: HasCallStack
+                      => Epoch
+                      -> StateT CumulEpochSizes m (Maybe (EpochSlot, Index hash))
+    validateAllEpochs = go Nothing
+      where
+        go lastValid epoch = do
+          validateRes <- validateEpoch epoch
+          let continueIfPossible lastValid'
+                | epoch == 0 = return lastValid'
+                | otherwise  = go lastValid' (epoch - 1)
+          case validateRes of
+            Missing -> do
+              -- Remove all valid files that may come after it. Note that
+              -- 'Invalid' guarantees that there is no epoch or index file for
+              -- this epoch.
+              lift $ removeFilesStartingFrom hasFS (succ epoch)
+              continueIfPossible Nothing
+            Incomplete index -> do
+              lift $ removeFilesStartingFrom hasFS (succ epoch)
+              let lastValid' = lastFilledSlot index <&> \lastRelativeSlot ->
+                    (EpochSlot epoch lastRelativeSlot, index)
+              continueIfPossible lastValid'
+            Complete index
+              | Just _ <- lastValid
+                -- If we have a valid epoch after this epoch to start at (and
+                -- all epochs in between are also valid), just continue
+                -- validating.
+              -> continueIfPossible lastValid
+              | Just lastRelativeSlot <- lastFilledSlot index
+                -- If there are no valid epochs after this one, and this one
+                -- is not empty, use it as lastValid
+              -> do
+                index' <- if
+                  | lastSlot index == lastRelativeSlot -> return index
+                    -- If the index contains empty trailing slots, truncate
+                    -- them.
+                  | otherwise                          -> do
+                    -- As the epoch will no longer be complete, remove the
+                    -- index file.
+                    lift $ removeFile (renderFile "index" epoch)
+                    let newIndexSize = fromIntegral lastRelativeSlot + 1
+                    return $ truncateToSlots newIndexSize index
+                continueIfPossible $ Just (EpochSlot epoch lastRelativeSlot, index')
+              | otherwise
+                -- If there are no valid epochs after this one, and this one
+                -- is empty, we can't use it as lastValid, so remove it and
+                -- continue.
+              -> do
+                lift $ removeFile (renderFile "epoch" epoch)
+                lift $ removeFile (renderFile "index" epoch)
+                continueIfPossible Nothing
 
     -- | Validates the epoch and index file of the given epoch.
     --
     -- Reconstructs the index by parsing the epoch file. If there remains
-    -- unparsed data, the epoch file is invalid.
+    -- unparsed data, the epoch file is truncated.
     --
-    -- Reads the index from the index file. If there remains unparsed data,
-    -- the index file is invalid.
+    -- If there is no epoch file, the result will be 'Missing'. An empty epoch
+    -- file will result in 'Incomplete'.
     --
-    -- If the reconstructed index and the index from the index file don't
-    -- match, we blame it on the index file and report an error.
+    -- Reads the index from the index file.
+    --
+    -- The epoch is 'Complete' when the index file is valid (remember that we
+    -- only write index files for complete epochs).
+    --
+    -- Special case: if the last slot of the epoch is filled, the epoch is
+    -- 'Complete' without there having to be a valid index file. As the index
+    -- file wouldn't be able to give us more information than the
+    -- reconstructed index already gives us, e.g., trailing empty slots. The
+    -- index file will be overwritten with the reconstructed index when
+    -- invalid or missing.
+    --
+    -- An invalid index file is deleted when the epoch is 'Incomplete'.
     --
     -- Note that an index file can tell us more than the reconstructed index,
     -- i.e. the presence of trailing empty slots, which we will accept as the
     -- truth.
-    --
-    -- Special case: if the last slot of the epoch is filled, the index file
-    -- won't tell us any more than the reconstructed index, so overwrite it
-    -- when missing or invalid and don't report an error.
-    --
-    -- Important: throw the error that requires the \"earliest\" or the most
-    -- truncation.
     validateEpoch :: HasCallStack
                   => Epoch
-                  -> Bool  -- ^ This epoch is the last epoch on disk
-                  -> StateT CumulEpochSizes m Index
-    validateEpoch epoch isLastEpoch = do
+                  -> StateT CumulEpochSizes m (ValidateResult hash)
+    validateEpoch epoch = do
       epochSize <- CES.getEpochSizeM epoch getEpochSize
 
-      ces <- get
-      -- Local helper function to create a 'TruncateFrom'
-      let mkTruncateFrom :: EpochSlot -> TruncateFrom
-          mkTruncateFrom epochSlot =
-            TruncateFrom (epochSlotInThePastToSlot ces epochSlot)
-          truncateFromEpochStart   = mkTruncateFrom (EpochSlot epoch 0)
+      let indexSize = succ epochSize  -- One extra slot for the EBB
+          indexFile = renderFile "index" epoch
+          epochFile = renderFile "epoch" epoch
 
-      let epochFile = renderFile "epoch" epoch
       epochFileExists <- lift $ doesFileExist epochFile
-      unless epochFileExists $ lift $ throwUnexpectedError err $
-        MissingFileError epochFile truncateFromEpochStart callStack
+      indexFileExists <- lift $ doesFileExist indexFile
+      if not epochFileExists
+        then do
+          when indexFileExists $ lift $ removeFile indexFile
+          return Missing
+        else do
 
-      -- Read the epoch file and reconstruct an index from it.
-      (reconstructedIndex, mbErr) <- reconstructIndex epochFile epochFileParser
-        getEpochSize
+          -- Read the epoch file and reconstruct an index from it.
+          (reconstructedIndex, mbErr) <- reconstructIndex epochFile
+            epochFileParser getEpochSize
 
-      -- In the following block we collect all errors (in the state) so we can
-      -- decide afterwards which error we should throw, i.e. the error which
-      -- requires the most truncation.
-      (index, errors) <- lift $ flip runStateT [] $ do
-            -- Local helper to add an error
-        let addError trunc e = modify ((trunc, e):)
+          -- If there was an error parsing the epoch file, truncate it
+          when (isJust mbErr) $ lift $
+            withFile hasFS epochFile AppendMode $ \eHnd ->
+              hTruncate eHnd (lastSlotOffset reconstructedIndex)
 
-        -- Truncation point based on the last valid blob in the epoch file
-        let truncLastValidBlobInEpoch
-              | Just relSlot <- lastFilledSlot reconstructedIndex
-              = mkTruncateFrom (EpochSlot epoch (succ relSlot))
-              | otherwise
-              = truncateFromEpochStart
+          -- If the last slot of the epoch is filled, we don't need an index
+          -- file. We can reconstruct it and don't have to throw an error.
+          let lastSlotFilled = indexSlots reconstructedIndex == indexSize
+              -- Handle only InvalidFileError and DeserialisationError
+              loadErr :: ErrorHandling UnexpectedError m
+              loadErr = EH.embed UnexpectedError
+                (\case
+                  UnexpectedError (e@InvalidFileError {})     -> Just e
+                  UnexpectedError (e@DeserialisationError {}) -> Just e
+                  _ -> Nothing) err
 
-        whenJust mbErr $ const $ addError truncLastValidBlobInEpoch $
-          InvalidFileError epochFile truncLastValidBlobInEpoch callStack
+          if
+            | lastSlotFilled -> do
+              -- If the last slot of the epoch is filled, we know all we need
+              -- to know from the reconstructed index, as there can't be any
+              -- trailing empty slots that the reconstructed index will be
+              -- unaware of. Write the reconstructed index to disk if needed.
+              overwrite <- if indexFileExists
+                then do
+                  indexFromFileOrError <- lift $ EH.try loadErr $
+                    loadIndex hasFS err epoch indexSize
+                  case indexFromFileOrError of
+                    Left _              -> return True
+                    Right indexFromFile ->
+                      return $ indexFromFile /= reconstructedIndex
+                else return True
+              when overwrite $
+                -- TODO log
+                lift $ writeIndex hasFS epoch reconstructedIndex
+              return $ Complete reconstructedIndex
 
-        -- If the last slot of the epoch is filled, we don't need an index
-        -- file. We can reconstruct it and don't have to throw an error.
-        let lastSlotFilled = indexSlots reconstructedIndex == epochSize
+            | indexFileExists -> do
+              indexFromFileOrError <- lift $ EH.try loadErr $
+                loadIndex hasFS err epoch indexSize
+              case indexFromFileOrError of
+                Left _              -> return $ Incomplete reconstructedIndex
+                Right indexFromFile
+                  | reconstructedIndex `isPrefixOf` indexFromFile -> do
+                    -- A reconstructed index knows nothing about trailing
+                    -- empty slots whereas an index from an index file may be
+                    -- aware of trailing empty slots in the epoch.
+                    --
+                    -- If the index from the index file pads the end of the
+                    -- reconstructed index with empty slots so that the epoch
+                    -- is full, we accept it, otherwise it is incomplete and
+                    -- thus invalid.
+                    --
+                    -- We don't want an index that ends with empty slots
+                    -- unless it is a finalised epoch, as such an index cannot
+                    -- be the result of regular operations.
+                    let extendedIndex = extendWithTrailingUnfilledSlotsFrom
+                          reconstructedIndex indexFromFile
+                    if indexSlots extendedIndex /= indexSize ||
+                       indexSlots indexFromFile > indexSlots extendedIndex
+                      then do
+                        lift $ removeFile indexFile
+                        return $ Incomplete reconstructedIndex
+                      else return $ Complete extendedIndex
 
-        let indexFile = renderFile "index" epoch
-        indexFileExists <- lift $ doesFileExist indexFile
-        if
-            -- If the last slot of the epoch is filled, we know all we need to
-            -- know from the reconstructed index, as there can't be any
-            -- trailing empty slots that the reconstructed index will be
-            -- unaware of. Write the reconstructed index to disk if needed.
-          | lastSlotFilled -> do
-            overwrite <- if indexFileExists
-              then do
-                (indexFromFile, mbJunk) <- lift $ loadIndex hasFS epoch
-                return $ indexFromFile /= reconstructedIndex || isJust mbJunk
-              else return True
-            when overwrite $
-              -- TODO log
-              lift $ writeIndex hasFS epoch reconstructedIndex
-            return reconstructedIndex
+                  | otherwise -> do
+                    -- No prefix: the index file is invalid
+                    lift $ removeFile indexFile
+                    return $ Incomplete reconstructedIndex
 
-          | indexFileExists -> do
-            (indexFromFile, mbJunk) <- lift $ loadIndex hasFS epoch
-            if | reconstructedIndex `isPrefixOf` indexFromFile -> do
-                 -- A reconstructed index knows nothing about trailing empty
-                 -- slots whereas an index from an index file may be aware of
-                 -- trailing empty slots in the epoch.
-                 --
-                 -- If the index from the index file pads the end of the
-                 -- reconstructed index with empty slots so that the epoch is
-                 -- full, we accept it, otherwise it is incomplete and thus
-                 -- invalid.
-                 --
-                 -- We don't want an index that ends with empty slots unless
-                 -- it is a finalised epoch, as such an index cannot be the
-                 -- result of regular operations.
-                 let extendedIndex = extendWithTrailingUnfilledSlotsFrom
-                       reconstructedIndex indexFromFile
-                 if indexSlots extendedIndex /= epochSize ||
-                    indexSlots indexFromFile > indexSlots extendedIndex
-                   then do
-                     addError truncLastValidBlobInEpoch $
-                       InvalidFileError indexFile truncLastValidBlobInEpoch
-                         callStack
-                     lift $ removeFile indexFile
-                     return reconstructedIndex
-                   else do
-                     -- The index file was correct. Unless it contained some
-                     -- junk at the end.
-                     whenJust mbJunk $ const $ lift $
-                       -- TODO log
-                       writeIndex hasFS epoch extendedIndex
-                     return extendedIndex
-
-               | otherwise -> do
-                 -- No prefix: the index file is invalid
-                 addError truncLastValidBlobInEpoch $
-                   InvalidFileError indexFile truncLastValidBlobInEpoch
-                     callStack
-                 -- The index file must be removed, because truncating to the
-                 -- last blob in the epoch might not truncate enough of the
-                 -- invalid index file.
-                 lift $ removeFile indexFile
-                 return reconstructedIndex
-
-            -- When we're validating the last epoch on disk, there will be no
-            -- index on disk, just use the reconstructed index. There is also
-            -- no need to write an index file, as only complete epochs should
-            -- have an index file.
-          | isLastEpoch -> return reconstructedIndex
-
-            -- No index file while there should be one
-          | otherwise -> do
-            addError truncLastValidBlobInEpoch $
-              MissingFileError indexFile truncLastValidBlobInEpoch
-                callStack
-            return reconstructedIndex
-
-      -- We're now out of the block that collects all the errors in the state
-      case errors of
-        [] -> return index
-        _  -> lift $ throwBestError errors
-
-    -- | Throw the error from the list with the minimal 'TruncateFrom' or none
-    -- if the list is empty.
-    --
-    -- Precondition: the list must be non-empty
-    throwBestError :: [(TruncateFrom, UnexpectedError)] -> m a
-    throwBestError es = throwUnexpectedError err bestError
-      where
-        (_, bestError) = minimumBy (compare `on` fst) es
-
-    -- | Throw a 'MissingFileError' if there is an index file on disk that
-    -- corresponds to an epoch equal or greater than the given one. The index
-    -- files on disk are given in the form of a 'Set' of epochs, as returned
-    -- by 'dbFilesOnDisk'.
-    --
-    -- Important: the error will refer to the smallest epoch equal or greater
-    -- than the given epoch, so that truncating from this epoch will solve the
-    -- problem.
-    errorOnIndexFileFrom :: HasCallStack
-                         => Epoch -> StateT CumulEpochSizes m ()
-    errorOnIndexFileFrom epoch = do
-      filesInDBFolder <- lift $ listDirectory []
-      let indexFiles = snd $ dbFilesOnDisk filesInDBFolder
-      whenJust (Set.lookupGE epoch indexFiles) $ \firstIndexFrom -> do
-        epochStartSlot <- CES.getNewEpochSizesUntilM
-          (`CES.epochSlotToSlot` EpochSlot epoch 0) getEpochSize
-        let trunc = TruncateFrom epochStartSlot
-
-        lift $ throwUnexpectedError err $ MissingFileError
-          (renderFile "epoch" firstIndexFrom) trunc callStack
+            -- No index file, either because it is missing or because the
+            -- epoch was not finalised
+            | otherwise -> return $ Incomplete reconstructedIndex
 
 
 -- | Reconstruct an 'Index' from the given epoch file using the
 -- 'EpochFileParser'.
 --
 -- Also returns the error returned by the 'EpochFileParser'.
-reconstructIndex :: (HasCallStack, MonadThrow m)
+reconstructIndex :: forall m e hash. MonadThrow m
                  => FsPath
-                 -> EpochFileParser e m (Word, Slot)
+                 -> EpochFileParser e hash m (Word, Slot)
                  -> (Epoch -> m EpochSize)
-                 -> StateT CumulEpochSizes m (Index, Maybe e)
+                 -> StateT CumulEpochSizes m (Index hash, Maybe e)
 reconstructIndex epochFile epochFileParser getEpochSize = do
-    (offsetsAndSizesAndSlots, mbErr) <- lift $
+    (offsetsAndSizesAndSlots, ebbHash, mbErr) <- lift $
       runEpochFileParser epochFileParser epochFile
-    offsetsAndSizesAndRelSlots <-
-      forM offsetsAndSizesAndSlots $ \(offset, (size, slot)) -> do
-        relSlot <- CES.slotToRelativeSlotM slot getEpochSize
-        return (offset, (size, relSlot))
-    let slotOffsets = reconstructSlotOffsets offsetsAndSizesAndRelSlots
-        index       = indexFromSlotOffsets slotOffsets
-    return (index, mbErr)
+    offsetsAndSizesAndRelSlots <- case offsetsAndSizesAndSlots of
+      [] -> return []
+      (offset0, (size0, _slot0)) : offsetsAndSizesAndSlots'
+        | Just _ <- ebbHash
+          -- If there is an EBB, then the first entry in the list must
+          -- correspond to the EBB
+        -> ((offset0, (size0, 0)) :) <$> slotsToRelSlots offsetsAndSizesAndSlots'
+        | otherwise
+        -> slotsToRelSlots offsetsAndSizesAndSlots
 
--- | Variant of 'loadIndex' that ignores any junk returned by 'loadIndex' (the
--- second return value).
-loadIndex' :: (HasCallStack, MonadThrow m)
-           => HasFS m h
-           -> ErrorHandling ImmutableDBError m
-           -> Epoch
-           -> m Index
-loadIndex' hasFS _err epoch = fst <$> loadIndex hasFS epoch
-    -- TODO throw an error when there is junk or the index is invalid?
+    let slotOffsets = reconstructSlotOffsets offsetsAndSizesAndRelSlots
+        index       = indexFromSlotOffsets slotOffsets ebbHash
+    return (index, mbErr)
+  where
+    slotsToRelSlots :: [(SlotOffset, (Word, Slot))]
+                    -> StateT CumulEpochSizes
+                              m
+                              [(SlotOffset, (Word, RelativeSlot))]
+    slotsToRelSlots = mapM $ \(offset, (size, slot)) -> do
+      relSlot <- CES.slotToRelativeSlotM slot getEpochSize
+      return (offset, (size, relSlot))

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -3,26 +3,27 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 module Ouroboros.Storage.ImmutableDB.Types
-  ( Slot(..)
-  , Epoch(..)
-  , EpochSize(..)
+  ( Slot (..)
+  , Epoch (..)
+  , EpochSize (..)
   , SlotOffset
-  , TruncateFrom(..)
-  , extractTruncateFrom
-  , EpochFileParser(..)
-  , ValidationPolicy(..)
+  , Tip (..)
+  , TruncateTo (..)
+  , EpochFileParser (..)
+  , ValidationPolicy (..)
   , IteratorID
-  , initialIteratorId
-  , ImmutableDBError(..)
+  , initialIteratorID
+  , ImmutableDBError (..)
   , sameImmutableDBError
   , prettyImmutableDBError
-  , UserError(..)
+  , UserError (..)
   , prettyUserError
-  , UnexpectedError(..)
+  , UnexpectedError (..)
   , sameUnexpectedError
   , prettyUnexpectedError
   ) where
 
+import           Codec.Serialise (DeserialiseFailure)
 import           Control.Exception (Exception (..))
 
 import           Data.Word (Word, Word64)
@@ -46,26 +47,24 @@ newtype EpochSize = EpochSize { getEpochSize :: Word }
 -- | The offset of a slot in an index file.
 type SlotOffset = Word64
 
--- | Truncate the database starting from the 'Slot' (inclusive). In other
--- words, all slots >= the given slot will be removed.
-newtype TruncateFrom = TruncateFrom { getTruncateFrom :: Slot }
-  deriving (Eq, Ord, Show, Generic)
-
--- | Try to extract a 'TruncateFrom' from a 'ImmutableDBError'.
+-- | The tip of the 'Ouroboros.Storage.ImmutableDB.API.ImmutableDB'.
+-- TODO unify with Edsko's Tip:
 --
--- When validation detects a missing or corrupt file, a 'InvalidFileError' or
--- 'MissingFileError' is thrown. Both contain a 'TruncateFrom' that can be
--- used to truncate the database to its last valid slot. Pass the
--- 'TruncateFrom' to 'Ouroboros.Storage.ImmutableDB.API.reopen' to truncate
--- and reopen.
-extractTruncateFrom :: ImmutableDBError -> Maybe TruncateFrom
-extractTruncateFrom e = case e of
-    UserError {}       -> Nothing
-    UnexpectedError ue -> case ue of
-      FileSystemError {}         -> Nothing
-      InvalidFileError _ trunc _ -> Just trunc
-      MissingFileError _ trunc _ -> Just trunc
-    -- TODO let validation only throw 'UnexpectedError'?
+-- data Tip r = Tip r | TipGen
+data Tip
+  = TipGenesis
+    -- ^ The database is empty
+  | TipEBB     Epoch
+    -- ^ The last thing in the database is the EBB of this 'Epoch'.
+  | TipBlock   Slot
+    -- ^ The last thing in the database is the block at this 'Slot'.
+  deriving (Eq, Show, Generic)
+
+-- | Truncate the database to some 'Tip'. This means that everything in the
+-- database that comes after the 'Tip' will be removed, excluding the EBB or
+-- block the 'Tip' points to.
+newtype TruncateTo = TruncateTo { getTruncateTo :: Tip }
+  deriving (Eq, Show, Generic)
 
 -- | Parse the contents of an epoch file.
 --
@@ -75,13 +74,16 @@ extractTruncateFrom e = case e of
 -- @t@ (block). The returned 'SlotOffset's are from __first to last__ and
 -- __strictly__ monotonically increasing. The first 'SlotOffset' must be 0.
 --
+-- The @Maybe hash@ is the hash of the EBB, if present. The EBB itself should
+-- be the first entry in the list, if present.
+--
 -- We assume the output of 'EpochFileParser' to be correct, we will not
 -- validate it.
 --
 -- An error may be returned in the form of @'Maybe' e@. The 'SlotOffset's may
 -- be accompanied with other data of type @t@.
-newtype EpochFileParser e m t = EpochFileParser
-  { runEpochFileParser :: FsPath -> m ([(SlotOffset, t)], Maybe e) }
+newtype EpochFileParser e hash m t = EpochFileParser
+  { runEpochFileParser :: FsPath -> m ([(SlotOffset, t)], Maybe hash, Maybe e) }
   deriving (Functor)
 
 -- | The validation policy used when (re)opening an
@@ -126,8 +128,8 @@ newtype IteratorID = IteratorID { getIteratorID :: Int }
   deriving (Show, Eq, Ord, Enum, Generic)
 
 -- | Initial identifier number, use 'succ' to generate the next one.
-initialIteratorId :: IteratorID
-initialIteratorId = IteratorID 0
+initialIteratorID :: IteratorID
+initialIteratorID = IteratorID 0
 
 -- | Errors that might arise when working with this database.
 data ImmutableDBError
@@ -161,25 +163,33 @@ prettyImmutableDBError = \case
     UnexpectedError ue    -> prettyUnexpectedError ue
 
 data UserError
-  = AppendToSlotInThePastError Slot Slot
+  = AppendToSlotInThePastError Slot Tip
     -- ^ When trying to append a new binary blob, the input slot was in the
-    -- past, i.e. less than the next expected slot.
+    -- past, i.e. before or equal to the tip of the database.
+  | AppendToEBBInThePastError Epoch Epoch
+    -- ^ When trying to append a new EBB, the input epoch was in the past,
+    -- i.e. less than the current epoch or blobs have already been appended to
+    -- the current epoch.
     --
-    -- The first parameter is the input slot and the second parameter is the
-    -- next slot available for appending.
-  | ReadFutureSlotError Slot Slot
-    -- ^ When trying to read a slot, the slot was not yet occupied, either
-    -- because it's too far in the future or because it is in the process of
-    -- being written.
+    -- The first parameter is the input epoch and the second parameter is the
+    -- current epoch.
+  | ReadFutureSlotError Slot Tip
+    -- ^ When trying to read a slot, the slot was not yet occupied, because
+    -- it's too far in the future, i.e. it is after the tip of the database.
+  | ReadFutureEBBError Epoch Epoch
+    -- ^ When trying to read an EBB, the requested epoch was in the future.
     --
-    -- The first parameter is the requested slot and the second parameter is
-    -- the next slot that will be appended to, and thus the slot marking the
-    -- future.
+    -- The first parameter is the requested epoch and the second parameter is
+    -- the current epoch.
   | InvalidIteratorRangeError Slot Slot
     -- ^ When the chosen iterator range was invalid, i.e. the @start@ (first
     -- parameter) came after the @end@ (second parameter).
   | ClosedDBError
-    -- ^ When performing an operation on a closed DB.
+    -- ^ When performing an operation on a closed DB that is only allowed when
+    -- the database is open.
+  | OpenDBError
+    -- ^ When performing an operation on an open DB that is only allowed when
+    -- the database is closed.
   deriving (Eq, Show, Generic)
 
 
@@ -187,47 +197,61 @@ data UserError
 -- its callstack.
 prettyUserError :: UserError -> String
 prettyUserError = \case
-    AppendToSlotInThePastError is es ->
+    AppendToSlotInThePastError is tip ->
       "AppendToSlotInThePastError (input slot was " <> show is <>
-      ", expected was " <> show es <> ")"
-    ReadFutureSlotError requested futureSlot ->
+      ", tip is " <> show tip <> ")"
+    AppendToEBBInThePastError ie ce ->
+      "AppendToEBBInThePastError (input epoch was " <> show ie <>
+      ", current epoch is " <> show ce <> ")"
+    ReadFutureSlotError requested tip ->
       "ReadFutureSlotError (requested was " <> show requested <>
-      ", the future starts at " <> show futureSlot <> ")"
+      ", tip is " <> show tip <> ")"
+    ReadFutureEBBError re ce ->
+      "ReadFutureEBBError (requested was " <> show re <>
+      ", the current epoch is " <> show ce <> ")"
     InvalidIteratorRangeError start end ->
       "InvalidIteratorRangeError (start was " <> show start <> " end was " <>
       show end <> ")"
     ClosedDBError -> "ClosedDBError"
+    OpenDBError   -> "OpenDBError"
 
 
 data UnexpectedError
   = FileSystemError FsError -- An FsError already stores the callstack
     -- ^ An IO operation on the file-system threw an error.
-  | InvalidFileError FsPath TruncateFrom CallStack
+  | InvalidFileError FsPath CallStack
     -- ^ When loading an epoch or index file, its contents did not pass
     -- validation.
-  | MissingFileError FsPath TruncateFrom CallStack
+  | MissingFileError FsPath CallStack
     -- ^ A missing epoch or index file.
+  | DeserialisationError DeserialiseFailure CallStack
+    -- ^ Deserialisation ('Codec.Serialise.Serialise') went wrong.
   deriving (Show, Generic)
 
 -- | Check if two 'Ouroboros.Storage.ImmutableDB.Types.UnexpectedError's are
 -- equal while ignoring their 'CallStack's.
 sameUnexpectedError :: UnexpectedError -> UnexpectedError -> Bool
 sameUnexpectedError ue1 ue2 = case (ue1, ue2) of
-    (FileSystemError fse1,     FileSystemError fse2)     -> sameFsError fse1 fse2
-    (FileSystemError {},       _)                        -> False
-    (InvalidFileError p1 t1 _, InvalidFileError p2 t2 _) -> p1 == p2 && t1 == t2
-    (InvalidFileError {},      _)                        -> False
-    (MissingFileError p1 t1 _, MissingFileError p2 t2 _) -> p1 == p2 && t1 == t2
-    (MissingFileError {},      _)                        -> False
+    (FileSystemError fse1,       FileSystemError fse2)       -> sameFsError fse1 fse2
+    (FileSystemError {},         _)                          -> False
+    (InvalidFileError p1 _,      InvalidFileError p2 _)      -> p1 == p2
+    (InvalidFileError {},        _)                          -> False
+    (MissingFileError p1 _,      MissingFileError p2 _)      -> p1 == p2
+    (MissingFileError {},        _)                          -> False
+    (DeserialisationError df1 _, DeserialisationError df2 _) -> df1 == df2
+    (DeserialisationError {},    _)                          -> False
 
 -- | Pretty-print an 'Ouroboros.Storage.ImmutableDB.Types.UnexpectedError',
 -- including its callstack.
 prettyUnexpectedError :: UnexpectedError -> String
 prettyUnexpectedError = \case
     FileSystemError fse -> prettyFsError fse
-    InvalidFileError path trunc cs ->
-      "InvalidFileError (" <> show path <> ", " <> show trunc <> "): " <>
+    InvalidFileError path cs ->
+      "InvalidFileError (" <> show path <> "): " <>
       prettyCallStack cs
-    MissingFileError path trunc cs ->
-      "MissingFileError (" <> show path <> ", " <> show trunc <> "): " <>
+    MissingFileError path cs ->
+      "MissingFileError (" <> show path <> "): " <>
+      prettyCallStack cs
+    DeserialisationError df cs ->
+      "DeserialisationError (" <> displayException df <> "): " <>
       prettyCallStack cs

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Util.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
-{-# LANGUAGE RankNTypes          #-}
 module Ouroboros.Storage.ImmutableDB.Util
   ( renderFile
   , handleUser
@@ -44,8 +44,9 @@ import           Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr (..),
 
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types
-import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes
-                     (RelativeSlot (..))
+import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes (CumulEpochSizes,
+                     RelativeSlot (..))
+import qualified Ouroboros.Storage.ImmutableDB.CumulEpochSizes as CES
 import           Ouroboros.Storage.ImmutableDB.Types
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
@@ -134,30 +135,43 @@ hGetRightSize HasFS{..} hnd size file = do
 
 -- | Check whether the given iterator range is valid.
 --
+-- \"Valid\" means:
+--
+-- * The start slot <= the end slot
+-- * The start slot is <= the tip
+-- * The end slot is <= the tip
+--
+-- The @hash@ is ignored.
+--
 -- See 'Ouroboros.Storage.ImmutableDB.API.streamBinaryBlobs'.
 validateIteratorRange
   :: Monad m
   => ErrorHandling ImmutableDBError m
-  -> Slot        -- ^ Next expected write
-  -> Maybe Slot  -- ^ range start (inclusive)
-  -> Maybe Slot  -- ^ range end (inclusive)
+  -> CumulEpochSizes
+  -> Tip
+  -> Maybe (Slot, hash)  -- ^ range start (inclusive)
+  -> Maybe (Slot, hash)  -- ^ range end (inclusive)
   -> m ()
-validateIteratorRange err next mbStart mbEnd = do
+validateIteratorRange err ces tip mbStart mbEnd = do
     case (mbStart, mbEnd) of
-      (Just start, Just end) ->
+      (Just (start, _), Just (end, _)) ->
         when (start > end) $
           throwUserError err $ InvalidIteratorRangeError start end
       _ -> return ()
 
-    whenJust mbStart $ \start ->
-      -- Check that the start is not >= the next expected slot
-      when (start >= next) $
-        throwUserError err $ ReadFutureSlotError start next
+    whenJust mbStart $ \(start, _) ->
+      when (isNewerThanTip start) $
+        throwUserError err $ ReadFutureSlotError start tip
 
-    whenJust mbEnd $ \end ->
-      -- Check that the end is not >= the next expected slot
-      when (end >= next) $
-        throwUserError err $ ReadFutureSlotError end next
+    whenJust mbEnd $ \(end, _) ->
+      when (isNewerThanTip end) $
+        throwUserError err $ ReadFutureSlotError end tip
+  where
+    isNewerThanTip slot = case tip of
+      TipGenesis           -> True
+      TipEBB     lastEpoch -> maybe True (slot >) $ CES.firstSlotOf ces lastEpoch
+      TipBlock   lastSlot  -> slot > lastSlot
+
 
 -- | Given a list of increasing 'SlotOffset's together with the 'Word' (blob
 -- size) and 'RelativeSlot' corresponding to the offset, reconstruct a
@@ -237,11 +251,14 @@ indexBackfill (RelativeSlot slot) (RelativeSlot nextExpected) lastOffset =
 
 -- | CBOR-based 'EpochFileParser' that can be used with
 -- 'Ouroboros.Storage.ImmutableDB.Impl.openDB'.
-cborEpochFileParser' :: forall m h a. (MonadST m, MonadThrow m)
+cborEpochFileParser' :: forall m hash h a. (MonadST m, MonadThrow m)
                      => HasFS m h
                      -> (forall s . CBOR.Decoder s a)
-                     -> EpochFileParser ReadIncrementalErr m (Word, a)
+                     -> (a -> Maybe hash)
+                        -- ^ In case the given @a@ is an EBB, return its
+                        -- @hash@.
+                     -> EpochFileParser ReadIncrementalErr hash m (Word, a)
                         -- ^ The 'Word' is the size in bytes of the
                         -- corresponding @a@.
-cborEpochFileParser' hasFS decoder = EpochFileParser $
-    readIncrementalOffsets hasFS decoder
+cborEpochFileParser' hasFS decoder getEBBHash = EpochFileParser $
+    readIncrementalOffsets hasFS decoder getEBBHash

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
@@ -45,7 +45,7 @@ prop_slotToEpochSlot_epochSlotToSlot ces =
     forAllShrink genValidSlot shrink $ \slot ->
       (slotToEpochSlot ces slot >>= epochSlotToSlot ces) === Just slot
   where
-    genValidSlot = chooseSlot 0 (maxSlot ces + 1)
+    genValidSlot = chooseSlot 0 (maxSlot ces)
 
 prop_epochSlotToSlot_invalid :: CumulEpochSizes -> Property
 prop_epochSlotToSlot_invalid ces =
@@ -57,7 +57,7 @@ prop_epochSlotToSlot_invalid ces =
       filter isInvalid (shrink epochSlot)
     isInvalid (EpochSlot epoch relSlot)
       | Just sz <- epochSize ces epoch
-      = relSlot >= fromIntegral sz
+      = relSlot > fromIntegral sz
       | otherwise
       = False
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -1,7 +1,10 @@
-{-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RecordWildCards  #-}
-{-# LANGUAGE TupleSections    #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+
 -- | Model for the 'ImmutableDB' based on a chain.
 --
 -- The chain is just a list of slots that can be unfilled (@Nothing@) or
@@ -12,22 +15,24 @@ module Test.Ouroboros.Storage.ImmutableDB.Model
   , initDBModel
   , IteratorModel
   , openDBModel
-  , getLastBlobLocation
   , simulateCorruptions
-  , slotToEpochSlot
+  , rollBackToTip
   ) where
 
 import           Control.Monad (when)
-import           Control.Monad.State (MonadState, get, gets, modify, put)
+import           Control.Monad.State.Strict (MonadState, execState, get, gets,
+                     modify, put, runState)
 
 import           Data.ByteString (ByteString)
 import           Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as BS
 import qualified Data.ByteString.Lazy as BL
-import           Data.List (dropWhileEnd)
+import           Data.Function ((&))
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 import           Data.Map (Map)
 import qualified Data.Map as Map
-import           Data.Maybe (fromMaybe, isNothing, listToMaybe, mapMaybe)
+import           Data.Maybe (fromMaybe)
 import           Data.Word (Word64)
 
 import           GHC.Generics (Generic)
@@ -47,64 +52,75 @@ import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
 
 import           Test.Ouroboros.Storage.ImmutableDB.TestBlock
 
-
-data DBModel = DBModel
+data DBModel hash = DBModel
   { dbmChain           :: [Maybe ByteString]
     -- ^ 'Nothing' when a slot is empty
-  , dbmNextSlot        :: Slot
-    -- ^ The number of the next available slot
+  , dbmTip             :: Tip
+  , dbmEBBs            :: Map Epoch (hash, ByteString)
+    -- ^ The EBB for each 'Epoch'
   , dbmCumulEpochSizes :: CumulEpochSizes
-  , dbmIterators       :: Map IteratorID IteratorModel
+  , dbmIterators       :: Map IteratorID (IteratorModel hash)
   , dbmNextIterator    :: IteratorID
   } deriving (Show, Generic)
 
 initDBModel :: EpochSize -- ^ The size of the first epoch
-            -> DBModel
+            -> DBModel hash
 initDBModel firstEpochSize = DBModel
   { dbmChain           = []
-  , dbmNextSlot        = 0
+  , dbmTip             = TipGenesis
+  , dbmEBBs            = Map.empty
   , dbmCumulEpochSizes = CES.singleton firstEpochSize
   , dbmIterators       = Map.empty
-  , dbmNextIterator    = initialIteratorId
+  , dbmNextIterator    = initialIteratorID
   }
 
-dbmBlobs :: HasCallStack => DBModel -> Map EpochSlot ByteString
-dbmBlobs dbm@DBModel {..} = foldr add Map.empty (zip (map Slot [0..]) dbmChain)
+dbmBlobs :: HasCallStack
+         => DBModel hash
+         -> Map (EpochSlot, Slot) (Either (hash, ByteString) ByteString)
+dbmBlobs dbm@DBModel {..} = foldr add ebbs (zip (map Slot [0..]) dbmChain)
   where
     add (_,    Nothing)   = id
-    add (slot, Just blob) = Map.insert (slotToEpochSlot dbm slot) blob
+    add (slot, Just blob) =
+      Map.insert (slotToEpochSlot dbm slot, slot) (Right blob)
 
+    ebbs = dbmEBBs
+         & Map.map Left
+         & Map.mapKeysMonotonic (`EpochSlot` 0)
+         & Map.mapKeysMonotonic (\epochSlot ->
+             (epochSlot, epochSlotToSlot dbm epochSlot))
 
 -- | Model for an 'Iterator'.
 --
--- The first 'Slot' = return the next filled slot (doesn't have to exist) >=
--- this 'Slot'. The second 'Slot': last filled slot to return (inclusive).
+-- An iterator is open iff its is present in 'dbmIterators'.
 --
--- An iterator is open iff its is present in 'dbmIterators'
-newtype IteratorModel = IteratorModel (Slot, Slot)
+-- The model of an iterator is just the list of 'IteratorResult's it streams
+-- over. Advancing the iterator will yield the first one and should drop it
+-- from the model.
+newtype IteratorModel hash = IteratorModel [IteratorResult hash]
   deriving (Show, Eq, Generic)
-
-
 
 
 {------------------------------------------------------------------------------
   ImmutableDB API
 ------------------------------------------------------------------------------}
 
-openDBModel :: MonadState DBModel m
+openDBModel :: (MonadState (DBModel hash) m, Eq hash)
             => ErrorHandling ImmutableDBError m
             -> (Epoch -> EpochSize)
-            -> (DBModel, ImmutableDB m)
+            -> (DBModel hash, ImmutableDB hash m)
 openDBModel err getEpochSize = (dbModel, db)
   where
     dbModel = initDBModel (getEpochSize 0)
     db = ImmutableDB
       { closeDB           = return ()
       , isOpen            = return True
-      , reopen            = const reopenModel -- No recovery
-      , getNextSlot       = getNextSlotModel
+      , reopen            = \_ -> return ()
+      , deleteAfter       = deleteAfterModel
+      , getTip            = getTipModel
       , getBinaryBlob     = getBinaryBlobModel     err
+      , getEBB            = getEBBModel            err
       , appendBinaryBlob  = appendBinaryBlobModel  err getEpochSize
+      , appendEBB         = appendEBBModel         err getEpochSize
       , streamBinaryBlobs = streamBinaryBlobsModel err
       , immutableDBErr    = err
       }
@@ -119,21 +135,21 @@ impossible msg = withFrozenCallStack (error ("Impossible: " ++ msg))
 mustBeJust :: HasCallStack => String -> Maybe a -> a
 mustBeJust msg = fromMaybe (impossible msg)
 
-lookupEpochSize :: HasCallStack => DBModel -> Epoch -> EpochSize
+lookupEpochSize :: HasCallStack => DBModel hash -> Epoch -> EpochSize
 lookupEpochSize DBModel {..} epoch =
     mustBeJust msg $ CES.epochSize dbmCumulEpochSizes epoch
   where
     msg = "epoch (" <> show epoch <> ") size unknown (" <>
           show dbmCumulEpochSizes <> ")"
 
-epochSlotToSlot :: HasCallStack => DBModel -> EpochSlot -> Slot
+epochSlotToSlot :: HasCallStack => DBModel hash -> EpochSlot -> Slot
 epochSlotToSlot DBModel {..} epochSlot =
     mustBeJust msg $ CES.epochSlotToSlot dbmCumulEpochSizes epochSlot
   where
     msg = "epochSlot (" <> show epochSlot <>
           ") could not be converted to a slot"
 
-slotToEpochSlot :: HasCallStack => DBModel -> Slot -> EpochSlot
+slotToEpochSlot :: HasCallStack => DBModel hash -> Slot -> EpochSlot
 slotToEpochSlot DBModel {..} slot =
     mustBeJust msg $ CES.slotToEpochSlot dbmCumulEpochSizes slot
   where
@@ -148,62 +164,92 @@ lookupBySlot (Slot i) = go i
     go n (_:blobs) = go (n - 1) blobs
     go _ []        = error "lookupBySlot: index out of bounds"
 
-getLastBlobLocation :: DBModel -> Maybe Slot
-getLastBlobLocation DBModel {..} =
-    lastMaybe $ zipWith const [0..] $ dropWhileEnd isNothing dbmChain
+-- | Rolls back the chain so that the given 'Tip' is the new tip.
+--
+-- The user is responsible for giving a valid 'Tip', i.e. a tip that points to
+-- a filled slot or an existing EBB (Genesis is always valid). This function
+-- will not truncate to the last filled slot or EBB itself.
+rollBackToTip :: HasCallStack => Tip -> DBModel hash -> DBModel hash
+rollBackToTip tip dbm@DBModel {..} = case tip of
+    TipGenesis    -> (initDBModel firstEpochSize)
+        { dbmNextIterator = dbmNextIterator }
+      where
+        firstEpochSize = lookupEpochSize dbm 0
 
--- | Rolls back the chain to the given 'Slot', i.e. the given 'Slot' will be
--- the new head of the chain.
-rollBackToSlot :: HasCallStack => Slot -> DBModel -> DBModel
-rollBackToSlot slot dbm@DBModel {..} =
-    dbm { dbmChain           = rolledBackChain
-        , dbmNextSlot        = newNextSlot
-        , dbmCumulEpochSizes = dbmCumulEpochSizes'
-        }
-  where
-    dbmCumulEpochSizes' = CES.rollBackToEpoch dbmCumulEpochSizes epoch
-    EpochSlot epoch _ = slotToEpochSlot dbm slot
-    rolledBackChain = map snd $ takeWhile ((<= slot) . fst) $ zip [0..] dbmChain
-    newNextSlot = fromIntegral $ length rolledBackChain
-
--- | Rolls back the chain to the start of the given 'Epoch'. The next epoch
--- slot will be the first of the given 'Epoch'.
-rollBackToEpochStart :: HasCallStack => Epoch -> DBModel -> DBModel
-rollBackToEpochStart epoch dbm@DBModel {..} =
-    dbm { dbmChain           = rolledBackChain
-        , dbmNextSlot        = newNextSlot
+    TipEBB epoch
+      | epoch > CES.lastEpoch dbmCumulEpochSizes -> dbm
+      | otherwise                                -> dbm
+        { dbmChain           = rolledBackChain
+        , dbmEBBs            = ebbsUpToEpoch epoch
+        , dbmTip             = tip
         , dbmCumulEpochSizes = CES.rollBackToEpoch dbmCumulEpochSizes epoch
         }
-  where
-    -- All slots >= @slot@ should be removed from the end of the chain
-    slot = epochSlotToSlot dbm (EpochSlot epoch 0)
-    rolledBackChain =
-      map snd $
-      takeWhile ((< slot) . fst) $
-      zip [0..] dbmChain
-    newNextSlot = fromIntegral $ length rolledBackChain
+      where
+        firstSlotAfter  = epochSlotToSlot dbm (EpochSlot epoch 1)
+        rolledBackChain = dbmChain
+                        & zip [0..]
+                        & takeWhile ((< firstSlotAfter) . fst)
+                        & map snd
 
--- | Rolls back the chain to the slot that corresponds to the given
--- 'EpochSlot'.
-rollBackToEpochSlot :: HasCallStack => EpochSlot -> DBModel -> DBModel
-rollBackToEpochSlot epochSlot dbm =
-    rollBackToSlot (epochSlotToSlot dbm epochSlot) dbm
+    TipBlock slot
+      | slot >= fromIntegral (length dbmChain) -> dbm
+      | otherwise                              -> dbm
+        { dbmChain           = rolledBackChain
+        , dbmEBBs            = ebbsUpToEpoch epoch
+        , dbmTip             = tip
+        , dbmCumulEpochSizes = CES.rollBackToEpoch dbmCumulEpochSizes epoch
+        }
+      where
+        EpochSlot epoch _ = slotToEpochSlot dbm slot
+        rolledBackChain   = dbmChain
+                          & zip [0..]
+                          & takeWhile ((<= slot) . fst)
+                          & map snd
+  where
+    ebbsUpToEpoch epoch =
+      Map.filterWithKey (\ebbEpoch _ -> ebbEpoch <= epoch) dbmEBBs
 
 -- | Return the filled 'EpochSlot's of the given 'Epoch' stored in the model.
-epochSlotsInEpoch :: HasCallStack => DBModel -> Epoch -> [EpochSlot]
+epochSlotsInEpoch :: HasCallStack => DBModel hash -> Epoch -> [EpochSlot]
 epochSlotsInEpoch dbm epoch =
     filter ((== epoch) . _epoch) $
-    map fst $
+    map (fst . fst) $
     Map.toAscList $ dbmBlobs dbm
 
--- | Return the filled 'EpochSlot's before, in, and after the given 'Epoch'.
+-- | Return the filled 'EpochSlot's (including EBBs) before, in, and after the
+-- given 'Epoch'.
 filledEpochSlots :: HasCallStack
-                 => DBModel -> Epoch -> ([EpochSlot], [EpochSlot], [EpochSlot])
+                 => DBModel hash
+                 -> Epoch
+                 -> ([EpochSlot], [EpochSlot], [EpochSlot])
 filledEpochSlots dbm epoch = (lt, eq, gt)
   where
-    increasingEpochSlots = map fst $ Map.toAscList $ dbmBlobs dbm
+    increasingEpochSlots = map (fst . fst) $ Map.toAscList $ dbmBlobs dbm
     (lt, geq) = span ((< epoch)      . _epoch) increasingEpochSlots
     (eq, gt)  = span ((< succ epoch) . _epoch) geq
+
+
+-- | List all 'Tip's that point to a filled slot or an existing EBB in the
+-- model, including 'TipGenesis'. The tips will be sorted from old to recent.
+tips :: DBModel hash -> NonEmpty Tip
+tips dbm = TipGenesis NE.:| tipsAfter dbm TipGenesis
+
+-- | List all 'Tip's that point to a filled slot or an existing EBB in the
+-- model that are after the given 'Tip'. The tips will be sorted from old to
+-- recent.
+tipsAfter :: DBModel hash -> Tip -> [Tip]
+tipsAfter dbm tip = map toTip $ dropWhile isBeforeTip blobLocations
+  where
+    blobLocations :: [(EpochSlot, Slot)]
+    blobLocations = Map.keys $ dbmBlobs dbm
+    isBeforeTip :: (EpochSlot, Slot) -> Bool
+    isBeforeTip (epochSlot, slot) = case tip of
+      TipGenesis     -> False
+      TipEBB epoch   -> epochSlot < EpochSlot epoch 0
+      TipBlock slot' -> slot      < slot'
+    toTip :: (EpochSlot, Slot) -> Tip
+    toTip (EpochSlot epoch 0, _)    = TipEBB epoch
+    toTip (_                , slot) = TipBlock slot
 
 
 {------------------------------------------------------------------------------
@@ -218,7 +264,7 @@ filledEpochSlots dbm epoch = (lt, eq, gt)
 --
 -- The 'FsPath's must correspond to index or epoch files that a real database,
 -- which is in sync with the given model, would have created on disk.
-simulateCorruptions :: Corruptions -> DBModel -> DBModel
+simulateCorruptions :: Corruptions -> DBModel hash -> DBModel hash
 simulateCorruptions corrs dbm = rollBack rbp dbm
   where
     -- Take the minimal 'RollBackPoint', which is the earliest.
@@ -228,35 +274,33 @@ simulateCorruptions corrs dbm = rollBack rbp dbm
 data RollBackPoint
   = DontRollBack
     -- ^ No roll back needed.
-  | RollBackToEpochStart Epoch
-    -- ^ Roll back to the start of the 'Epoch', removing all relative slots
-    -- of the epoch.
-  | RollBackToEpochSlot  EpochSlot
+  | RollBackToGenesis
+    -- ^ Roll back to genesis, removing all slots.
+  | RollBackToEpochSlot EpochSlot
     -- ^ Roll back to the 'EpochSlot', keeping it as the last relative slot.
   deriving (Eq, Show, Generic)
 
 -- | The earlier 'RollBackPoint' < the later 'RollBackPoint'.
 instance Ord RollBackPoint where
   compare r1 r2 = case (r1, r2) of
-    (DontRollBack, DontRollBack) -> EQ
-    (_,            DontRollBack) -> LT
-    (DontRollBack, _)            -> GT
-    (RollBackToEpochStart e1, RollBackToEpochStart e2) -> compare e1 e2
-    (RollBackToEpochStart e1, RollBackToEpochSlot (EpochSlot e2 _))
-      | e1 <= e2  -> LT
-      | otherwise -> GT
-    (RollBackToEpochSlot (EpochSlot e1 _), RollBackToEpochStart e2)
-      | e1 < e2   -> LT
-      | otherwise -> GT
+    (RollBackToGenesis, RollBackToGenesis)             -> EQ
+    (RollBackToGenesis, _)                             -> LT
+    (_, RollBackToGenesis)                             -> GT
+    (DontRollBack, DontRollBack)                       -> EQ
+    (_,            DontRollBack)                       -> LT
+    (DontRollBack, _)                                  -> GT
     (RollBackToEpochSlot es1, RollBackToEpochSlot es2) -> compare es1 es2
 
-rollBack :: RollBackPoint -> DBModel -> DBModel
-rollBack rbp = case rbp of
-    DontRollBack                   -> id
-    RollBackToEpochStart epoch     -> rollBackToEpochStart epoch
-    RollBackToEpochSlot  epochSlot -> rollBackToEpochSlot  epochSlot
+rollBack :: RollBackPoint -> DBModel hash -> DBModel hash
+rollBack rbp dbm = case rbp of
+    DontRollBack                            ->                               dbm
+    RollBackToGenesis                       -> rollBackToTip TipGenesis      dbm
+    RollBackToEpochSlot (EpochSlot epoch 0) -> rollBackToTip (TipEBB epoch)  dbm
+    RollBackToEpochSlot epochSlot           -> rollBackToTip (TipBlock slot) dbm
+      where
+        slot = epochSlotToSlot dbm epochSlot
 
-findCorruptionRollBackPoint :: FileCorruption -> FsPath -> DBModel
+findCorruptionRollBackPoint :: FileCorruption -> FsPath -> DBModel hash
                             -> RollBackPoint
 findCorruptionRollBackPoint corr file dbm =
     case lastMaybe file >>= parseDBFile of
@@ -264,7 +308,7 @@ findCorruptionRollBackPoint corr file dbm =
       Just ("index", epoch) -> findIndexCorruptionRollBackPoint corr epoch dbm
       _                     -> error "Invalid file to corrupt"
 
-findEpochDropLastBytesRollBackPoint :: Word64 -> Epoch -> DBModel
+findEpochDropLastBytesRollBackPoint :: Word64 -> Epoch -> DBModel hash
                                     -> RollBackPoint
 findEpochDropLastBytesRollBackPoint n epoch dbm
     | null epochSlots
@@ -290,21 +334,20 @@ findEpochDropLastBytesRollBackPoint n epoch dbm
     lastValidFilledSlotIndex offset =
       (fromIntegral offset `quot` fromIntegral testBlockSize) - 1
 
-findEpochCorruptionRollBackPoint :: FileCorruption -> Epoch -> DBModel
+findEpochCorruptionRollBackPoint :: FileCorruption -> Epoch -> DBModel hash
                                  -> RollBackPoint
 findEpochCorruptionRollBackPoint corr epoch dbm = case corr of
     DeleteFile      -> rollbackToLastFilledSlotBefore epoch dbm
-
     DropLastBytes n -> findEpochDropLastBytesRollBackPoint n epoch dbm
 
-rollbackToLastFilledSlotBefore :: Epoch -> DBModel -> RollBackPoint
+rollbackToLastFilledSlotBefore :: Epoch -> DBModel hash -> RollBackPoint
 rollbackToLastFilledSlotBefore epoch dbm = case lastMaybe beforeEpoch of
     Just lastFilledSlotBefore -> RollBackToEpochSlot lastFilledSlotBefore
-    Nothing                   -> RollBackToEpochStart 0
+    Nothing                   -> RollBackToGenesis
   where
     (beforeEpoch, _, _) = filledEpochSlots dbm epoch
 
-findIndexCorruptionRollBackPoint :: FileCorruption -> Epoch -> DBModel
+findIndexCorruptionRollBackPoint :: FileCorruption -> Epoch -> DBModel hash
                                  -> RollBackPoint
 findIndexCorruptionRollBackPoint _corr epoch dbm
     | Just lastFilledSlotOfEpoch     <- lastMaybe inEpoch
@@ -317,7 +360,7 @@ findIndexCorruptionRollBackPoint _corr epoch dbm
     | Just lastFilledSlotBeforeEpoch <- lastMaybe beforeEpoch
     = RollBackToEpochSlot lastFilledSlotBeforeEpoch
     | otherwise  -- there are no filled slots, roll back to genesis
-    = RollBackToEpochStart 0
+    = RollBackToGenesis
   where
     (beforeEpoch, inEpoch, _afterEpoch) = filledEpochSlots dbm epoch
     isLastSlotOfEpoch (EpochSlot epoch' relSlot) =
@@ -328,38 +371,53 @@ findIndexCorruptionRollBackPoint _corr epoch dbm
   ImmutableDB Implementation
 ------------------------------------------------------------------------------}
 
-reopenModel :: MonadState DBModel m
-            => Maybe TruncateFrom -> m (Maybe Slot)
-reopenModel Nothing                    = gets getLastBlobLocation
-reopenModel (Just (TruncateFrom 0))    = do
-    modify $ rollBackToEpochStart 0
-    return Nothing
-reopenModel (Just (TruncateFrom slot)) = do
-    modify $ rollBackToSlot (slot - 1)
-    lastBlobLocation <- gets getLastBlobLocation
-    -- Truncate empty trailing slots
-    modify $ case lastBlobLocation of
-      Nothing             -> rollBackToEpochStart 0
-      Just lastFilledSlot -> rollBackToSlot lastFilledSlot
-    return lastBlobLocation
+getTipModel :: MonadState (DBModel hash) m => m Tip
+getTipModel = gets dbmTip
 
-getNextSlotModel :: (HasCallStack, MonadState DBModel m)
-                 => m Slot
-getNextSlotModel = gets dbmNextSlot
+deleteAfterModel :: (HasCallStack, MonadState (DBModel hash) m) => Tip -> m ()
+deleteAfterModel tip =
+    -- First roll back to the given tip (which is not guaranteed to be
+    -- valid/exist!), then roll back to the last valid remaining tip.
+    modify $ rollBackToLastValidTip . rollBackToTip tip
+  where
+    rollBackToLastValidTip dbm = rollBackToTip (NE.last (tips dbm)) dbm
 
-getBinaryBlobModel :: (HasCallStack, MonadState DBModel m)
+getBinaryBlobModel :: (HasCallStack, MonadState (DBModel hash) m)
                    => ErrorHandling ImmutableDBError m
                    -> Slot
                    -> m (Maybe ByteString)
 getBinaryBlobModel err slot = do
     DBModel {..} <- get
-    when (slot >= dbmNextSlot) $ throwUserError err $
-      ReadFutureSlotError slot dbmNextSlot
+
+    -- Check that the slot is not in the future
+    let inTheFuture = case dbmTip of
+          TipGenesis        -> True
+          TipBlock lastSlot -> slot > lastSlot
+          TipEBB _          -> slot >= fromIntegral (length dbmChain)
+
+    when inTheFuture $
+      throwUserError err $ ReadFutureSlotError slot dbmTip
 
     return $ lookupBySlot slot dbmChain
 
+getEBBModel :: (HasCallStack, MonadState (DBModel hash) m)
+            => ErrorHandling ImmutableDBError m
+            -> Epoch
+            -> m (Maybe (hash, ByteString))
+getEBBModel err epoch = do
+    DBModel {..} <- get
+    let currentEpoch = CES.lastEpoch dbmCumulEpochSizes
+        inTheFuture  = case dbmTip of
+          TipGenesis -> True
+          TipBlock _ -> epoch > currentEpoch
+          TipEBB _   -> epoch > currentEpoch
 
-appendBinaryBlobModel :: (HasCallStack, MonadState DBModel m)
+    when inTheFuture $
+      throwUserError err $ ReadFutureEBBError epoch currentEpoch
+
+    return $ Map.lookup epoch dbmEBBs
+
+appendBinaryBlobModel :: (HasCallStack, MonadState (DBModel hash) m)
                       => ErrorHandling ImmutableDBError m
                       -> (Epoch -> EpochSize)
                       -> Slot
@@ -368,88 +426,170 @@ appendBinaryBlobModel :: (HasCallStack, MonadState DBModel m)
 appendBinaryBlobModel err getEpochSize slot bld = do
     dbm@DBModel {..} <- get
 
-    when (slot < dbmNextSlot) $
-      throwUserError err $ AppendToSlotInThePastError slot dbmNextSlot
+    -- Check that we're not appending to the past
+    let inThePast = case dbmTip of
+          TipBlock lastSlot -> slot <= lastSlot
+          TipEBB _          -> slot < fromIntegral (length dbmChain)
+          TipGenesis        -> False
 
-    let blob = BL.toStrict $ BS.toLazyByteString bld
-        toPad = fromIntegral (slot - dbmNextSlot)
+    when inThePast $
+      throwUserError err $ AppendToSlotInThePastError slot dbmTip
+
+    let blob  = BL.toStrict $ BS.toLazyByteString bld
+        toPad = fromIntegral slot - length dbmChain
+        ces'  = addMissingEpochSizes dbmCumulEpochSizes
 
     -- TODO snoc list?
     put dbm
       { dbmChain           = dbmChain ++ replicate toPad Nothing ++ [Just blob]
-      , dbmNextSlot        = slot + 1
-      , dbmCumulEpochSizes = addMissingEpochSizes dbmCumulEpochSizes
+      , dbmTip             = TipBlock slot
+      , dbmCumulEpochSizes = ces'
       }
   where
-    addMissingEpochSizes ces
-      | slot <= CES.maxSlot ces
-      = ces
-      | otherwise
-      = addMissingEpochSizes
-      $ CES.snoc ces (getEpochSize (succ (CES.lastEpoch ces)))
+    -- | Add 'EpochSize's to 'CumulEpochSizes' until the 'CES.maxSlot' is
+    -- greater or equal to the 'Slot'.
+    addMissingEpochSizes :: CumulEpochSizes -> CumulEpochSizes
+    addMissingEpochSizes = execState $
+       CES.getNewEpochSizesUntilM done (return . getEpochSize)
+      where
+        done :: CumulEpochSizes -> Maybe ()
+        done ces | slot <= CES.maxSlot ces = Just ()
+                 | otherwise               = Nothing
 
-streamBinaryBlobsModel :: (HasCallStack, MonadState DBModel m)
+
+appendEBBModel :: (HasCallStack, MonadState (DBModel hash) m)
+               => ErrorHandling ImmutableDBError m
+               -> (Epoch -> EpochSize)
+               -> Epoch
+               -> hash
+               -> Builder
+               -> m ()
+appendEBBModel err getEpochSize epoch hash bld = do
+    dbm@DBModel {..} <- get
+    let currentEpoch = CES.lastEpoch dbmCumulEpochSizes
+
+    -- Check that we're not appending to the past
+    let inThePast = case dbmTip of
+          -- There is already a block in this epoch, so the EBB can no
+          -- longer be appended in this epoch
+          TipBlock _ -> epoch <= currentEpoch
+          -- There is already an EBB in this epoch
+          TipEBB _   -> epoch <= currentEpoch
+          TipGenesis -> False
+
+    when inThePast $
+      throwUserError err $ AppendToEBBInThePastError epoch currentEpoch
+
+    let blob            = BL.toStrict $ BS.toLazyByteString bld
+        ebbEpochSlot    = EpochSlot epoch 0
+        (ebbSlot, ces') = addMissingEpochSizes ebbEpochSlot dbmCumulEpochSizes
+        toPad           = fromIntegral ebbSlot - length dbmChain
+
+    put dbm
+      { dbmChain           = dbmChain ++ replicate toPad Nothing
+      , dbmTip             = TipEBB epoch
+      , dbmCumulEpochSizes = ces'
+      , dbmEBBs            = Map.insert epoch (hash, blob) dbmEBBs
+      }
+  where
+    addMissingEpochSizes :: EpochSlot -> CumulEpochSizes
+                         -> (Slot, CumulEpochSizes)
+    addMissingEpochSizes epochSlot = runState $ CES.getNewEpochSizesUntilM
+      (`CES.epochSlotToSlot` epochSlot)
+      (return . getEpochSize)
+
+
+streamBinaryBlobsModel :: forall m hash.
+                          (HasCallStack, MonadState (DBModel hash) m, Eq hash)
                        => ErrorHandling ImmutableDBError m
-                       -> Maybe Slot
-                       -> Maybe Slot
-                       -> m (Iterator m)
+                       -> Maybe (Slot, hash)
+                       -> Maybe (Slot, hash)
+                       -> m (Iterator hash m)
 streamBinaryBlobsModel err mbStart mbEnd = do
     dbm@DBModel {..} <- get
-    validateIteratorRange err dbmNextSlot mbStart mbEnd
 
-    case length $ dropWhileEnd isNothing dbmChain of
-      -- Empty database, return an empty iterator
-      0 -> do
-        put dbm { dbmNextIterator = succ dbmNextIterator }
-        return Iterator
-          { iteratorNext  = return IteratorExhausted
-          , iteratorClose = return ()
-          , iteratorID    = dbmNextIterator
-          }
-      n -> do
-        let currentSlot = fromIntegral n - 1
-            start = fromMaybe 0           mbStart
-            end   = fromMaybe currentSlot mbEnd
-            itm   = IteratorModel (start, end)
-            itID  = dbmNextIterator
-        put dbm
-          { dbmNextIterator = succ dbmNextIterator
-          , dbmIterators    = Map.insert dbmNextIterator itm dbmIterators
-          }
-        return Iterator
-          { iteratorNext  = iteratorNextModel  itID
-          , iteratorClose = iteratorCloseModel itID
-          , iteratorID    = itID
-          }
+    validateIteratorRange err dbmCumulEpochSizes dbmTip mbStart mbEnd
 
+    let results = iteratorResults dbm
+        itm     = IteratorModel results
+        itID    = dbmNextIterator
+    put dbm
+      { dbmNextIterator = succ dbmNextIterator
+      , dbmIterators    = Map.insert dbmNextIterator itm dbmIterators
+      }
+    return Iterator
+      { iteratorNext  = iteratorNextModel  itID
+      , iteratorClose = iteratorCloseModel itID
+      , iteratorID    = itID
+      }
+  where
+    iteratorResults dbm@DBModel {..} =
+        map snd $ takeUntilEnd $ dropUntilStart $
+        map toIteratorResult $ Map.toAscList $ dbmBlobs dbm
+      where
+        toIteratorResult (k@(EpochSlot epoch _, slot), v) = case v of
+          Left (hash, blob) -> (k, IteratorEBB epoch hash blob)
+          Right blob        -> (k, IteratorResult slot blob)
 
-iteratorNextModel :: (HasCallStack, MonadState DBModel m)
+        dropUntilStart = case mbStart of
+          Nothing                -> id
+          Just (startSlot, hash) -> dropWhile $ \((_, slot), res) -> if
+            | slot < startSlot   -> True
+            | slot == startSlot  -> case res of
+              -- If an EBB is stored in the slot, we'll encounter the EBB
+              -- before we'd encounter a block at the same slot. If the hash
+              -- is that of the EBB, stop dropping because we want to include
+              -- it in the results.
+              IteratorEBB _ hash' _ | hash' == hash -> False
+              -- If the hash doesn't match that of the EBB, it must be the
+              -- hash of the block (which we can't verify!). Drop the EBB
+              -- because we should start at the next block.
+                                    | otherwise     -> True
+              -- If the slot is that of a regular block, stop dropping and
+              -- include the block in the results, regardless the hash.
+              _ -> False
+            | otherwise -> False
+        takeUntilEnd = case mbEnd of
+            Nothing              -> id
+            Just (endSlot, hash) -> go
+              where
+                go [] = []
+                go (x@((_, slot), res):xs)
+                  | slot < endSlot  = x : go xs
+                  | slot == endSlot = case res of
+                    -- If an EBB is stored in the slot, we'll encounter the
+                    -- EBB before we'd encounter a block at the same slot. If
+                    -- the hash is that of the EBB, we want to include it and
+                    -- stop.
+                    IteratorEBB _ hash' _ | hash' == hash -> [x]
+                    -- If the hash doesn't match that of the EBB, it must be
+                    -- the hash of the next block at the same slot (which we
+                    -- can't verify!), so include the EBB and continue so we
+                    -- can include the next block.
+                                          | otherwise     -> x : go xs
+                    -- If the slot is that of a regular block, include it and
+                    -- stop. It can't be that the hash was of the EBB because,
+                    -- then we would have already stopped.
+                    _ -> [x]
+                  | otherwise = []
+
+iteratorNextModel :: MonadState (DBModel hash) m
                   => IteratorID
-                  -> m IteratorResult
+                  -> m (IteratorResult hash)
 iteratorNextModel itID = do
     dbm@DBModel {..} <- get
     case Map.lookup itID dbmIterators of
-      Nothing -> return IteratorExhausted
-      Just (IteratorModel (minNext, end)) -> do
-        let mbBlob = listToMaybe
-                   $ takeWhile ((<= end) . fst)
-                   $ dropWhile ((< minNext) . fst)
-                   $ mapMaybe (\(slot, mbBlob') -> (slot,) <$> mbBlob')
-                   $ zip [0..] dbmChain
-        case mbBlob of
-          Nothing -> do
-            iteratorCloseModel itID
-            return IteratorExhausted
-          Just (next, blob) -> do
-            if next > end
-              then iteratorCloseModel itID
-              else
-                let next' = succ next
-                    itm'  = IteratorModel (next', end)
-                in put dbm { dbmIterators = Map.insert itID itm' dbmIterators }
-            return $ IteratorResult next blob
+      Nothing                         -> return IteratorExhausted
+      Just (IteratorModel [])         -> do
+        iteratorCloseModel itID
+        return IteratorExhausted
+      Just (IteratorModel (res:ress)) -> do
+        put dbm
+          { dbmIterators = Map.insert itID (IteratorModel ress) dbmIterators
+          }
+        return res
 
-iteratorCloseModel :: MonadState DBModel m
+iteratorCloseModel :: MonadState (DBModel hash) m
                    => IteratorID -> m ()
 iteratorCloseModel itID = modify $ \dbm@DBModel {..} ->
     dbm { dbmIterators = Map.delete itID dbmIterators }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveTraversable    #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE RecordWildCards      #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE StandaloneDeriving   #-}
@@ -17,25 +18,24 @@ module Test.Ouroboros.Storage.ImmutableDB.StateMachine
 
 import           Prelude hiding (elem, notElem)
 
-import           Control.Monad (forM_)
+import           Control.Monad (forM_, when)
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Except (ExceptT (..), runExceptT)
-import           Control.Monad.State (MonadState, State, StateT, evalStateT,
-                     get, gets, lift, modify, put, runState)
+import           Control.Monad.State.Strict (MonadState, State, evalState, gets,
+                     modify, put, runState)
 
 import           Data.Bifunctor (first)
 import           Data.ByteString (ByteString)
-import           Data.Coerce (coerce)
+import           Data.Coerce (Coercible, coerce)
 import           Data.Foldable (toList)
 import           Data.Function (on)
-import           Data.Functor (($>))
 import           Data.Functor.Classes (Eq1, Show1)
 import           Data.List (sortBy)
 import qualified Data.List.NonEmpty as NE
 import           Data.Map (Map)
 import qualified Data.Map as Map
-import           Data.Maybe (listToMaybe)
+import           Data.Maybe (listToMaybe, mapMaybe)
 import           Data.Proxy (Proxy (..))
 import           Data.TreeDiff (Expr (App))
 import           Data.TreeDiff.Class (ToExpr (..))
@@ -101,11 +101,14 @@ import qualified Test.Util.RefEnv as RE
 -- or 'Concrete'.
 data Cmd it
   = GetBinaryBlob     Slot
-  | AppendBinaryBlob  Slot TestBlock
-  | StreamBinaryBlobs (Maybe Slot) (Maybe Slot)
+  | GetEBB            Epoch
+  | AppendBinaryBlob  Slot       TestBlock
+  | AppendEBB         Epoch Hash TestBlock
+  | StreamBinaryBlobs (Maybe (Slot, Hash)) (Maybe (Slot, Hash))
   | IteratorNext      it
   | IteratorClose     it
-  | Reopen            ValidationPolicy (Maybe TruncateFrom)
+  | Reopen            ValidationPolicy
+  | DeleteAfter       Tip
   | Corruption        Corruption
   deriving (Generic, Show, Functor, Foldable, Traversable)
 
@@ -144,34 +147,45 @@ instance Show it => Show (CmdErr it) where
         Nothing  -> "Cmd "
         Just err -> "Cmd " <> show err <> " "
 
+-- | Just use the 'TestBlock' itself as the hash so we can easily see of which
+-- block it is the hash.
+type Hash = TestBlock
+
 -- | Return type for successful database operations.
 data Success it
   = Unit         ()
   | Blob         (Maybe ByteString)
+  | EBB          (Maybe (Hash, ByteString))
   | Epoch        Epoch
   | Iter         it
-  | IterResult   IteratorResult
-  | LastBlob     (Maybe Slot)
+  | IterResult   (IteratorResult Hash)
+  | Tip          Tip
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
 -- | Run the command against the given database.
 run :: (HasCallStack, Monad m)
-    => (ImmutableDB m -> Corruption -> m (Success (Iterator m)))
+    => (ImmutableDB Hash m -> Corruption -> m (Success (Iterator Hash m)))
        -- ^ How to run a 'Corruption' command.
-    -> [Iterator m]
-    -> ImmutableDB m
-    -> Cmd (Iterator m)
-    -> m (Success (Iterator m))
+    -> [Iterator Hash m]
+    -> ImmutableDB Hash m
+    -> Cmd (Iterator Hash m)
+    -> m (Success (Iterator Hash m))
 run runCorruption its db cmd = case cmd of
   GetBinaryBlob     s   -> Blob       <$> getBinaryBlob db s
+  GetEBB            e   -> EBB        <$> getEBB db e
   AppendBinaryBlob  s b -> Unit       <$> appendBinaryBlob db s (testBlockToBuilder b)
+  AppendEBB       e h b -> Unit       <$> appendEBB db e h (testBlockToBuilder b)
   StreamBinaryBlobs s e -> Iter       <$> streamBinaryBlobs db s e
   IteratorNext  it      -> IterResult <$> iteratorNext it
   IteratorClose it      -> Unit       <$> iteratorClose it
-  Reopen valPol mbTrunc -> do
+  DeleteAfter tip       -> do
+    mapM_ iteratorClose its
+    Unit <$> deleteAfter db tip
+  Reopen valPol         -> do
     mapM_ iteratorClose its
     closeDB db
-    LastBlob <$> reopen db valPol mbTrunc
+    reopen db valPol
+    Tip <$> getTip db
   Corruption corr       -> do
     mapM_ iteratorClose its
     runCorruption db corr
@@ -204,16 +218,16 @@ instance Show it => Show (Resp it) where
           prettyImmutableDBError (UnexpectedError ue)
 
 -- | The monad used to run pure model/mock implementation of the database.
-type PureM = ExceptT ImmutableDBError (State DBModel)
+type PureM = ExceptT ImmutableDBError (State (DBModel Hash))
 
 -- | The type of the pure model/mock implementation of the database.
-type ModelDBPure = ImmutableDB PureM
+type ModelDBPure = ImmutableDB Hash PureM
 
 -- | Run a command against the pure model
-runPure :: DBModel
+runPure :: DBModel Hash
         -> ModelDBPure
-        -> CmdErr (Iterator PureM)
-        -> (Resp (Iterator PureM), DBModel)
+        -> CmdErr (Iterator Hash PureM)
+        -> (Resp (Iterator Hash PureM), DBModel Hash)
 runPure dbm mdb (CmdErr mbErrors cmd its) =
     first Resp $ flip runState dbm $ do
       resp <- runExceptT $ run runCorruption its mdb cmd
@@ -228,16 +242,25 @@ runPure dbm mdb (CmdErr mbErrors cmd its) =
         -- have to close the iterators, as the truncation during the reopening
         -- of the database will erase any changes.
         (Just _, _) -> do
-          -- Note that we reset the state to the initial state (@dbm@), as we
-          -- don't want the result of executing the @cmd@ successfully.
-          modify $ const dbm { dbmIterators = mempty }
-          gets (Right . LastBlob . getLastBlobLocation)
+          -- We ignore the updated dbm (in the StateT), because we have to
+          -- roll back to the state before executing cmd.
+          --
+          -- As the implementation closes all iterators, we do the same.
+          put $ dbm { dbmIterators = mempty }
+          -- The only exception is the DeleteAfter cmd, in which case we have
+          -- to roll back to the requested tip.
+          case cmd of
+            DeleteAfter tip ->
+              fmap (either (error . prettyImmutableDBError) id) $
+              runExceptT $ deleteAfter mdb tip
+            _               -> return ()
+          gets (Right . Tip . dbmTip)
   where
     runCorruption :: ModelDBPure -> Corruption
-                  -> PureM (Success (Iterator PureM))
+                  -> PureM (Success (Iterator Hash PureM))
     runCorruption _ (MkCorruption corrs) = do
       modify $ simulateCorruptions corrs
-      gets (LastBlob . getLastBlobLocation)
+      gets (Tip . dbmTip)
 
 {-------------------------------------------------------------------------------
   Collect arguments
@@ -253,14 +276,14 @@ iters = toList
 -------------------------------------------------------------------------------}
 
 -- | Concrete or symbolic references to a real (or model) iterator
-type IterRef m = Reference (Opaque (Iterator m))
+type IterRef m = Reference (Opaque (Iterator Hash m))
 
 -- | Mapping between iterator references and mocked iterators
-type KnownIters m = RefEnv (Opaque (Iterator m)) (Iterator PureM)
+type KnownIters m = RefEnv (Opaque (Iterator Hash m)) (Iterator Hash PureM)
 
 -- | Execution model
 data Model m r = Model
-  { dbModel    :: DBModel
+  { dbModel    :: DBModel Hash
     -- ^ A model of the database, used as state for the 'HasImmutableDB'
     -- instance of 'ModelDB'.
   , mockDB     :: ModelDBPure
@@ -270,19 +293,19 @@ data Model m r = Model
   } deriving (Show, Generic)
 
 -- | Initial model
-initModel :: DBModel -> ModelDBPure -> Model m r
+initModel :: DBModel Hash -> ModelDBPure -> Model m r
 initModel dbModel mockDB = Model
     { knownIters  = RE.empty
     , ..
     }
 
 -- | Key property of the model is that we can go from real to mock responses
-toMock :: (Functor t, Eq1 r) => Model m r -> At t m r -> t (Iterator PureM)
+toMock :: (Functor t, Eq1 r) => Model m r -> At t m r -> t (Iterator Hash PureM)
 toMock Model {..} (At t) = fmap (knownIters RE.!) t
 
 -- | Step the mock semantics
 step :: Eq1 r
-     => Model m r -> At CmdErr m r -> (Resp (Iterator PureM), DBModel)
+     => Model m r -> At CmdErr m r -> (Resp (Iterator Hash PureM), DBModel Hash)
 step model@Model{..} cmdErr = runPure dbModel mockDB (toMock model cmdErr)
 
 
@@ -326,13 +349,13 @@ data Event m r = Event
   { eventBefore   :: Model     m r
   , eventCmdErr   :: At CmdErr m r
   , eventAfter    :: Model     m r
-  , eventMockResp :: Resp (Iterator PureM)
+  , eventMockResp :: Resp (Iterator Hash PureM)
   } deriving (Show)
 
 eventCmd :: Event m r -> At Cmd m r
 eventCmd = At . _cmd . unAt . eventCmdErr
 
-eventMockCmd :: Eq1 r => Event m r -> Cmd (Iterator PureM)
+eventMockCmd :: Eq1 r => Event m r -> Cmd (Iterator Hash PureM)
 eventMockCmd ev@Event {..} = toMock eventBefore (eventCmd ev)
 
 
@@ -364,21 +387,21 @@ lockstep model@Model {..} cmdErr (At resp) = Event
 generator :: Model m Symbolic -> Gen (At CmdErr m Symbolic)
 generator m@Model {..} = do
     _cmd    <- unAt <$> generateCmd m
-    _cmdErr <- if noErrorFor _cmd
-       then return Nothing
-       else frequency
+    _cmdErr <- if errorFor _cmd
+       then frequency
           -- We want to make some progress
           [ (4, return Nothing)
           , (1, Just <$> arbitrary)
           ]
+       else return Nothing
     let _cmdIters = RE.keys knownIters
     return $ At CmdErr {..}
   where
     -- Don't simulate an error during corruption, because we don't want an
     -- error to happen while we corrupt a file.
-    noErrorFor Corruption {} = True
-    noErrorFor Reopen {}     = True
-    noErrorFor _             = False
+    errorFor Corruption {} = False
+    errorFor Reopen {}     = False
+    errorFor _             = True
     -- TODO simulate errors during recovery?
 
 
@@ -387,51 +410,87 @@ generateCmd :: Model m Symbolic -> Gen (At Cmd m Symbolic)
 generateCmd Model {..} = At <$> frequency
     [ (1, GetBinaryBlob <$> frequency
             [ (if empty then 0 else 10, genSlotInThePast)
-            , (1,  genSlotInTheFuture)
-            , (1,  arbitrary) ])
+            , (1, genSlotInTheFuture)
+            , (1, arbitrary) ])
+    , (1, GetEBB <$> arbitrary)
     , (3, do
             slot <- arbitrary -- TODO can create many empty epochs
             return $ AppendBinaryBlob slot (TestBlock slot))
-    , (1, frequency
+    , (1, do
+            epoch <- frequency
+              [ (1, arbitrary)
+              , (3, chooseWord (currentEpoch, currentEpoch + 5))
+              ]
+            return $ AppendEBB epoch (TestEBB 0) (TestEBB 0))
+    , (0, frequency
             -- An iterator with a random and likely invalid range,
             [ (1, StreamBinaryBlobs <$> (Just <$> arbitrary)
                                     <*> (Just <$> arbitrary))
-            -- An iterator that is more likely to be valid.
+            -- A valid iterator
             , (if empty then 0 else 2, do
-                    start <- genSlotInThePast
-                    end   <- genSlotInThePast `suchThat` (>= start)
-                    return $ StreamBinaryBlobs (Just start) (Just end))
-            -- Same as above, but with possible empty bounds
-            , (if empty then 0 else 2, do
-                    start <- genSlotInThePast
-                    end   <- genSlotInThePast `suchThat` (>= start)
-                    mbStart <- elements [Nothing, Just start]
-                    mbEnd   <- elements [Nothing, Just end]
-                    return $ StreamBinaryBlobs mbStart mbEnd)
+                 start <- genBound
+                 let startSlot = maybe 0 fst start
+                 end  <- genBound `suchThat` \case
+                     -- NOTE: say @start@ refers to the only block in the DB,
+                     -- which is the EBB of the current epoch, then there is
+                     -- no regular block >= @start@, only the EBB itself (=
+                     -- @start@). So we must make sure that we can generate a
+                     -- slot that refers to this EBB for @end@, otherwise we
+                     -- may end up in an infinite loop if we're only
+                     -- generating slots referring to regular blocks.
+                     Nothing           -> True
+                     Just (endSlot, _) -> endSlot >= startSlot
+
+                 return $ StreamBinaryBlobs start end)
             ])
       -- Only if there are iterators can we generate commands that manipulate
       -- them.
-    , (if Map.null dbmIterators then 0 else 4,
-       do
+    , (if Map.null dbmIterators then 0 else 4, do
          iter <- elements $ RE.keys knownIters
          frequency [ (4, return $ IteratorNext  iter)
                    , (1, return $ IteratorClose iter) ])
+    , (1, Reopen <$> genValPol)
+
+    , (1, DeleteAfter <$> genTip)
+
       -- Only if there are files on disk can we generate commands that corrupt
       -- them.
-    , (1, Reopen <$> genValPol <*> genMbTrunc)
-
     , (if null dbFiles then 0 else 2, Corruption <$> genCorruption)
     ]
   where
     DBModel {..} = dbModel
 
-    empty = dbmNextSlot == 0
+    currentEpoch = CES.lastEpoch dbmCumulEpochSizes
+
+    lastSlot :: Slot
+    lastSlot = fromIntegral $ length dbmChain
+
+    empty = dbmTip == TipGenesis
+
+    noEBBs = Map.null dbmEBBs
+
+    chooseWord :: Coercible a Word => (a, a) -> Gen a
+    chooseWord (start, end) = coerce $ choose @Word (coerce start, coerce end)
 
     genSlotInThePast
       | empty     = discard
-      | otherwise = coerce $ choose @Word (0, coerce dbmNextSlot - 1)
+      | otherwise = chooseWord (0, lastSlot)
 
-    genSlotInTheFuture = coerce $ choose @Word (coerce dbmNextSlot, maxBound)
+    genEBBSlotInThePast :: Gen Slot
+    genEBBSlotInThePast
+      | noEBBs
+      = discard
+      | otherwise
+      = elements $ mapMaybe (CES.firstSlotOf dbmCumulEpochSizes)
+      $ Map.keys dbmEBBs
+
+    genSlotInTheFuture = chooseWord (succ lastSlot, maxBound)
+
+    genBound = frequency
+      [ (1, return Nothing)
+      , (1, (\slot -> Just (slot, TestBlock slot)) <$> genSlotInThePast)
+      , (1, (\slot -> Just (slot, TestEBB slot))   <$> genEBBSlotInThePast)
+      ]
 
     genCorruption = MkCorruption <$> generateCorruptions (NE.fromList dbFiles)
 
@@ -439,20 +498,16 @@ generateCmd Model {..} = At <$> frequency
 
     genValPol = elements [ValidateMostRecentEpoch, ValidateAllEpochs]
 
-    -- TODO generate slots in the future?
-    genMbTrunc
-      | empty
-      = return Nothing
-      | otherwise
-      = frequency
-        [ (1, return Nothing)
-        , (4, Just . TruncateFrom <$> genSlotInThePast)
-        ]
+    genTip = frequency
+      [ (1, return TipGenesis)
+      , (2, TipBlock <$> chooseWord (0, lastSlot + 3))
+      , (2, TipEBB   <$> chooseWord (0, currentEpoch + 3))
+      ]
 
 -- | Return the files that the database with the given model would have
 -- created. For each epoch an index and epoch file, except for the last epoch:
 -- only an epoch but no index file.
-getDBFiles :: DBModel -> [FsPath]
+getDBFiles :: DBModel Hash -> [FsPath]
 getDBFiles DBModel {..}
     | null dbmChain
     = []
@@ -484,36 +539,69 @@ shrinker m@Model {..} (At (CmdErr mbErrors cmd _)) = fmap At $
 -- | Shrink a 'Cmd'.
 shrinkCmd :: Model m Symbolic -> At Cmd m Symbolic -> [At Cmd m Symbolic]
 shrinkCmd Model {..} (At cmd) = fmap At $ case cmd of
-    AppendBinaryBlob slot _ ->
+    AppendBinaryBlob slot _         ->
       [ AppendBinaryBlob slot' (TestBlock slot')
       | slot' <- shrink slot ]
+    AppendEBB epoch hash ebb        ->
+      [ AppendEBB epoch  (TestEBB slot') (TestEBB slot')
+      | let TestEBB slot = ebb
+      , slot' <- shrink slot ] ++
+      [ AppendEBB epoch' hash ebb
+      | epoch' <- shrink epoch ]
     StreamBinaryBlobs mbStart mbEnd ->
       [ StreamBinaryBlobs mbStart' mbEnd
-      | mbStart' <- shrinkMbSlot mbStart] ++
+      | mbStart' <- shrinkMbBound mbStart] ++
       [ StreamBinaryBlobs mbStart  mbEnd'
-      | mbEnd'   <- shrinkMbSlot mbEnd]
-    GetBinaryBlob slot ->
+      | mbEnd'   <- shrinkMbBound mbEnd]
+    GetBinaryBlob slot              ->
       [GetBinaryBlob slot' | slot' <- shrink slot]
-    IteratorNext  {} -> []
-    IteratorClose {} -> []
-    Reopen valPol mbTruncateFrom ->
-      [ Reopen valPol' mbTruncateFrom
-      | valPol' <- shrinkValPol valPol ] ++
-      [ Reopen valPol  mbTruncateFrom'
-      | mbTruncateFrom' <- shrinkMbTruncateFrom mbTruncateFrom ]
-    Corruption corr ->
+    GetEBB epoch                    ->
+      [GetEBB epoch' | epoch' <- shrink epoch]
+    IteratorNext  {}                -> []
+    IteratorClose {}                -> []
+    DeleteAfter tip                 ->
+      [DeleteAfter tip' | tip' <- shrinkTip tip]
+    Reopen {}                       -> []
+    Corruption corr                 ->
       [Corruption corr' | corr' <- shrinkCorruption corr]
   where
-    shrinkMbSlot :: Maybe Slot -> [Maybe Slot]
-    shrinkMbSlot Nothing  = []
-    shrinkMbSlot (Just s) = Nothing : map Just (shrink s)
+    DBModel {..} = dbModel
+
+    currentEpoch = CES.lastEpoch dbmCumulEpochSizes
+
+    lastSlot :: Slot
+    lastSlot = fromIntegral $ length dbmChain
+
+    shrinkMbBound :: Maybe (Slot, Hash) -> [Maybe (Slot, Hash)]
+    shrinkMbBound Nothing  = []
+    shrinkMbBound (Just (s, TestBlock _)) = Nothing :
+      [ Just (s', TestBlock s') | s' <- shrink s ]
+    shrinkMbBound (Just (s, TestEBB _)) = Nothing :
+      [ Just (s', TestEBB s')
+      | s' <- takeWhile (< s)  ebbSlots]
+    ebbSlots = mapMaybe (CES.firstSlotOf dbmCumulEpochSizes) $ Map.keys dbmEBBs
+
     shrinkCorruption (MkCorruption corrs) =
       [ MkCorruption corrs'
       | corrs' <- shrinkCorruptions corrs]
-    shrinkValPol ValidateAllEpochs = [ValidateMostRecentEpoch]
-    shrinkValPol _                 = []
-    shrinkMbTruncateFrom Nothing  = []
-    shrinkMbTruncateFrom (Just _) = [Nothing]
+
+    -- Return tips that are closer to the current tip. If the tip is after the
+    -- current tip, return the tips between the current tip and the tip. If
+    -- the tip is before the current tip, return the tips between the tip and
+    -- the current tip.
+    --
+    -- For simplicity, we only shrink to TipEBBs if the tip is an TipEBB,
+    -- similarly for TipBlock. Otherwise we have to check whether a TipEBB is
+    -- before or after a TipBlock.
+    shrinkTip TipGenesis =
+      map TipBlock [0..lastSlot] ++ map TipEBB [0..currentEpoch]
+    shrinkTip (TipBlock slot)
+      | slot > lastSlot = map TipBlock [lastSlot..slot - 1]
+      | otherwise       = map TipBlock [slot + 1..lastSlot]
+    shrinkTip (TipEBB epoch)
+      | epoch > currentEpoch = map TipEBB [currentEpoch..epoch - 1]
+      | otherwise            = map TipEBB [epoch + 1..currentEpoch]
+
 
 {-------------------------------------------------------------------------------
   The final state machine
@@ -538,8 +626,6 @@ precondition Model {..} (At (CmdErr { _cmd = cmd })) =
     case cmd of
       Corruption corr ->
         forall (corruptionFiles corr) (`elem` getDBFiles dbModel)
-      Reopen _ (Just (TruncateFrom slot)) ->
-        slot .< dbmNextSlot dbModel
       _ -> Top
   where
     corruptionFiles (MkCorruption corrs) = map snd $ NE.toList corrs
@@ -559,7 +645,7 @@ postcondition model cmdErr resp =
 
 semantics :: TVar IO Errors
           -> HasFS IO h
-          -> ImmutableDB IO
+          -> ImmutableDB Hash IO
           -> At CmdErr IO Concrete
           -> IO (At Resp IO Concrete)
 semantics errorsVar hasFS db (At cmdErr) =
@@ -569,8 +655,8 @@ semantics errorsVar hasFS db (At cmdErr) =
         run (semanticsCorruption hasFS) its db cmd
 
       CmdErr (Just errors) cmd its -> do
-        nextSlot <- getNextSlot db
-        res      <- withErrors errorsVar errors $ tryImmDB $
+        tipBefore <- getTip db
+        res       <- withErrors errorsVar errors $ tryImmDB $
           run (semanticsCorruption hasFS) its db cmd
         case res of
           -- If the command resulted in a 'UserError', we didn't even get the
@@ -578,7 +664,11 @@ semantics errorsVar hasFS db (At cmdErr) =
           Left (UserError {})       -> return res
 
           -- We encountered a simulated error
-          Left (UnexpectedError {}) -> truncateAndReopen nextSlot its
+          Left (UnexpectedError {}) -> do
+            open <- isOpen db
+            when open $
+              fail "Database still open while it should have been closed"
+            truncateAndReopen cmd its tipBefore
 
           -- TODO track somewhere which/how many errors were *actually* thrown
 
@@ -586,52 +676,43 @@ semantics errorsVar hasFS db (At cmdErr) =
           -- happened if the error was thrown, so that we stay in sync with
           -- the model.
           Right suc                 ->
-            truncateAndReopen nextSlot (its <> iters suc)
+            truncateAndReopen cmd (its <> iters suc) tipBefore
             -- Note that we might have created an iterator, make sure to close
             -- it as well
   where
-    truncateAndReopen fromSlot its = tryImmDB $ do
+    truncateAndReopen cmd its tipBefore = tryImmDB $ do
       -- Close all open iterators as we will perform truncation
       mapM_ iteratorClose its
       -- Close the database in case no errors occurred and it wasn't
       -- closed already. This is idempotent anyway.
       closeDB db
-
-      -- TODO validate the database and check that if reopen succeeds, it
-      -- happened at some point in the right interval
-
-      -- Reopen the database, but truncate it to the point right before
-      -- the error
-      let trunc = Just (TruncateFrom fromSlot)
-      LastBlob <$> reopen db ValidateMostRecentEpoch trunc
+      reopen db ValidateAllEpochs
+      deleteAfter db tipBefore
+      -- If the cmd deleted things, we must do it here to have a deterministic
+      -- outcome and to stay in sync with the model. If no error was thrown,
+      -- these things will have been deleted. If an error was thrown, they
+      -- might not have been deleted or only part of them.
+      case cmd of
+        DeleteAfter tip -> deleteAfter db tip
+        _               -> return ()
+      Tip <$> getTip db
 
 semanticsCorruption :: MonadCatch m
                     => HasFS m h
-                    -> ImmutableDB m
+                    -> ImmutableDB Hash m
                     -> Corruption
-                    -> m (Success (Iterator m))
+                    -> m (Success (Iterator Hash m))
 semanticsCorruption hasFS db (MkCorruption corrs) = do
     closeDB db
     forM_ corrs $ \(corr, file) -> corruptFile hasFS corr file
-
-    -- Record the error thrown using the 'ValidateAllEpochs' policy
-    validateRes     <- tryImmDB $ reopen db ValidateAllEpochs Nothing
-    validationError <- case validateRes of
-          Left e  -> return $ Just e
-          -- Close the DB again, otherwise the next reopen is a no-op.
-          Right _ -> closeDB db $> Nothing
-
-    -- Now try to restore to the last valid epoch slot using the recovery
-    -- strategy suggested by the error.
-    let mbTruncateFrom = validationError >>= extractTruncateFrom
-
-    LastBlob <$> reopen db ValidateAllEpochs mbTruncateFrom
+    reopen db ValidateAllEpochs
+    Tip <$> getTip db
 
 -- | The state machine proper
 sm :: TVar IO Errors
    -> HasFS IO h
-   -> ImmutableDB IO
-   -> DBModel
+   -> ImmutableDB Hash IO
+   -> DBModel Hash
    -> ModelDBPure
    -> StateMachine (Model IO) (At CmdErr IO) IO (At Resp IO)
 sm errorsVar hasFS db dbm mdb = StateMachine
@@ -652,33 +733,22 @@ sm errorsVar hasFS db dbm mdb = StateMachine
 -------------------------------------------------------------------------------}
 
 validate :: forall m. Monad m
-         => Model m Concrete -> ImmutableDB m
-         -> m ()
-validate Model {..} db = flip evalStateT dbModel $ do
-    itDB    <- runDB    $ streamBinaryBlobs db     Nothing Nothing
-    itModel <- runModel $ streamBinaryBlobs mockDB Nothing Nothing
-    let loop = do
-          dbRes    <- runDB    $ iteratorNext itDB
-          modelRes <- runModel $ iteratorNext itModel
-          case (dbRes, modelRes) of
-            (IteratorExhausted, IteratorExhausted)
-              -> return ()
-            (IteratorResult {}, IteratorResult {})
-              | dbRes == modelRes
-              -> loop
-            _ -> fail $ "Mismatch between database (" <> show dbRes <>
-                        ") and model (" <> show modelRes <> ")"
-    loop
+         => Model m Concrete -> ImmutableDB Hash m
+         -> QC.PropertyM m Property
+validate Model {..} realDB = do
+    dbContents    <- QC.run   $ getDBContents realDB
+    modelContents <- runModel $ getDBContents mockDB
+    -- This message is clearer than the one produced by (===)
+    let msg = "Mismatch between database (" <> show dbContents <>
+              ") and model (" <> show modelContents <> ")"
+    return $ counterexample msg (dbContents == modelContents)
   where
-    runDB :: m a -> StateT DBModel m a
-    runDB = lift
+    getDBContents db = streamBinaryBlobs db Nothing Nothing >>= iteratorToList
 
-    runModel :: PureM a -> StateT DBModel m a
-    runModel m = do
-      s <- get
-      case runState (runExceptT m) s of
-        (Left e,  _)  -> fail $ prettyImmutableDBError e
-        (Right a, s') -> put s' >> return a
+    runModel :: PureM a -> QC.PropertyM m a
+    runModel m = case evalState (runExceptT m) dbModel of
+      Left e  -> fail $ prettyImmutableDBError e
+      Right a -> return a
 
 {-------------------------------------------------------------------------------
   Labelling
@@ -699,13 +769,19 @@ data Tag
 
   | TagIteratorWithoutBounds
 
+  | TagTruncation
+
   | TagCorruption
 
   | TagErrorDuringAppendBinaryBlob
 
+  | TagErrorDuringAppendEBB
+
   | TagErrorDuringStartNewEpoch
 
   | TagErrorDuringGetBinaryBlob
+
+  | TagErrorDuringGetEBB
 
   | TagErrorDuringStreamBinaryBlobs
 
@@ -721,7 +797,7 @@ type EventPred m = C.Predicate (Event m Symbolic) Tag
 
 -- | Convenience combinator for creating classifiers for successful commands
 successful :: (    Event m Symbolic
-                -> Success (Iterator PureM)
+                -> Success (Iterator Hash PureM)
                 -> Either Tag (EventPred m)
               )
            -> EventPred m
@@ -740,7 +816,7 @@ failed f = C.predicate $ \ev -> case eventMockResp ev of
     Resp (Right _) -> Right $ failed f
 
 -- | Convenience combinator for creating classifiers for commands failed with
--- a 'UserError'
+-- a @UserError@.
 failedUserError :: (    Event m Symbolic
                      -> UserError
                      -> Either Tag (EventPred m)
@@ -773,11 +849,20 @@ tag = C.classify
     , tagIteratorStreamedNBlobs Map.empty
     , tagIteratorWithoutBounds
     , tagCorruption
-    , tagErrorDuringAppendBinaryBlob
-    , tagErrorDuringGetBinaryBlob
-    , tagErrorDuringStreamBinaryBlobs
-    , tagErrorDuringIteratorNext
-    , tagErrorDuringIteratorClose
+    , tagErrorDuring TagErrorDuringAppendBinaryBlob $ \case
+      { At (AppendBinaryBlob {}) -> True; _ -> False }
+    , tagErrorDuring TagErrorDuringAppendEBB $ \case
+      { At (AppendEBB {}) -> True; _ -> False }
+    , tagErrorDuring TagErrorDuringGetBinaryBlob $ \case
+      { At (GetBinaryBlob {}) -> True; _ -> False }
+    , tagErrorDuring TagErrorDuringGetEBB $ \case
+      { At (GetEBB {}) -> True; _ -> False }
+    , tagErrorDuring TagErrorDuringStreamBinaryBlobs $ \case
+      { At (StreamBinaryBlobs {}) -> True ; _ -> False }
+    , tagErrorDuring TagErrorDuringIteratorNext $ \case
+      { At (IteratorNext {}) -> True; _ -> False }
+    , tagErrorDuring TagErrorDuringIteratorClose $ \case
+       { At (IteratorClose {}) -> True; _ -> False }
     ]
   where
     tagGetBinaryBlobJust :: EventPred m
@@ -807,7 +892,7 @@ tag = C.classify
       InvalidIteratorRangeError {} -> Left TagInvalidIteratorRangeError
       _                            -> Right tagInvalidIteratorRangeError
 
-    tagIteratorStreamedNBlobs :: Map (Iterator PureM) Int
+    tagIteratorStreamedNBlobs :: Map (Iterator Hash PureM) Int
                               -> EventPred m
     tagIteratorStreamedNBlobs blobsStreamed = C.Predicate
       { C.predApply = \ev -> case eventMockResp ev of
@@ -837,30 +922,9 @@ tag = C.classify
       , C.predFinish = Nothing
       }
 
-    tagErrorDuringAppendBinaryBlob :: EventPred m
-    tagErrorDuringAppendBinaryBlob = simulatedError $ \ev -> case eventCmd ev of
-      At (AppendBinaryBlob {}) -> Left TagErrorDuringAppendBinaryBlob
-      _                        -> Right tagErrorDuringAppendBinaryBlob
-
-    tagErrorDuringGetBinaryBlob :: EventPred m
-    tagErrorDuringGetBinaryBlob = simulatedError $ \ev -> case eventCmd ev of
-      At (GetBinaryBlob {}) -> Left TagErrorDuringGetBinaryBlob
-      _                     -> Right tagErrorDuringGetBinaryBlob
-
-    tagErrorDuringStreamBinaryBlobs :: EventPred m
-    tagErrorDuringStreamBinaryBlobs = simulatedError $ \ev -> case eventCmd ev of
-      At (StreamBinaryBlobs {}) -> Left TagErrorDuringStreamBinaryBlobs
-      _                         -> Right tagErrorDuringStreamBinaryBlobs
-
-    tagErrorDuringIteratorNext :: EventPred m
-    tagErrorDuringIteratorNext = simulatedError $ \ev -> case eventCmd ev of
-      At (IteratorNext {}) -> Left TagErrorDuringIteratorNext
-      _                    -> Right tagErrorDuringIteratorNext
-
-    tagErrorDuringIteratorClose :: EventPred m
-    tagErrorDuringIteratorClose = simulatedError $ \ev -> case eventCmd ev of
-      At (IteratorClose {}) -> Left TagErrorDuringIteratorClose
-      _                     -> Right tagErrorDuringIteratorClose
+    tagErrorDuring :: Tag -> (At Cmd m Symbolic -> Bool) -> EventPred m
+    tagErrorDuring t isErr = simulatedError $ \ev ->
+      if isErr (eventCmd ev) then Left t else Right $ tagErrorDuring t isErr
 
 
 -- | Step the model using a 'QSM.Command' (i.e., a command associated with
@@ -898,7 +962,7 @@ instance CommandNames (At CmdErr m) where
   cmdNames (_ :: Proxy (At CmdErr m r)) =
     constrNames (Proxy @(Cmd (IterRef m r)))
 
-instance Show (Iterator PureM) where
+instance Show (Iterator Hash PureM) where
   show it = "<iterator " <> show (iteratorID it) <> ">"
 
 instance Show ModelDBPure where
@@ -913,8 +977,11 @@ instance ToExpr EpochSlot
 instance ToExpr RelativeSlot
 instance ToExpr IteratorID
 instance ToExpr CumulEpochSizes
-instance ToExpr IteratorModel
-instance ToExpr DBModel
+instance ToExpr (IteratorResult Hash)
+instance ToExpr (IteratorModel Hash)
+instance ToExpr TestBlock
+instance ToExpr Tip
+instance ToExpr (DBModel Hash)
 
 instance ToExpr FsError where
   toExpr fsError = App (show fsError) []
@@ -922,13 +989,13 @@ instance ToExpr FsError where
 instance ToExpr ModelDBPure where
   toExpr db = App (show db) []
 
-instance ToExpr (Iterator PureM) where
+instance ToExpr (Iterator Hash PureM) where
   toExpr it = App (show it) []
 
 instance ToExpr (Model m Concrete)
 
 -- Orphan instance to store 'Iterator's in a 'Map'.
-instance Ord (Iterator m) where
+instance Ord (Iterator Hash m) where
   compare = compare `on` iteratorID
 
 {-------------------------------------------------------------------------------
@@ -944,7 +1011,7 @@ showLabelledExamples'
   -- ^ Number of tests to run to find examples
   -> (Tag -> Bool)
   -- ^ Tag filter (can be @const True@)
-  -> (   DBModel
+  -> (   DBModel Hash
       -> ModelDBPure
       -> StateMachine (Model m) (At CmdErr m) m (At Resp m)
      )
@@ -974,48 +1041,43 @@ prop_sequential :: Property
 prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do
     let test :: TVar IO Errors -> HasFS IO h -> QC.PropertyM IO (
                     QSM.History (At CmdErr IO) (At Resp IO)
-                  , Reason
-                  , Maybe Slot
-                  , Maybe Slot
+                  , Property
                   )
         test errorsVar hasFS = do
           let parser = testBlockEpochFileParser' hasFS
-          (db, Nothing) <- QC.run $
+          db <- QC.run $
             openDB hasFS EH.monadCatch fixedGetEpochSize ValidateMostRecentEpoch
               parser
           let sm' = sm errorsVar hasFS db dbm mdb
           (hist, model, res) <- runCommands sm' cmds
-          lastBlobLocation <- QC.run $ do
+          QC.run $ closeDB db >> reopen db ValidateAllEpochs
+          validation <- validate model db
+          dbTip <- QC.run $ do
+            dbTip <- getTip db
             closeDB db
-            lastBlobLocation <- reopen db ValidateAllEpochs Nothing
-            validate model db
-            closeDB db
-            return lastBlobLocation
+            return dbTip
 
-          let lastBlobLocationModel = getLastBlobLocation $ dbModel model
+          let modelTip = dbmTip $ dbModel model
+          QC.monitor $ counterexample ("dbTip:    " <> show dbTip)
+          QC.monitor $ counterexample ("modelTip: " <> show modelTip)
 
-          QC.monitor $ counterexample ("lastBlobLocation: "      <> show lastBlobLocation)
-          QC.monitor $ counterexample ("lastBlobLocationModel: " <> show lastBlobLocationModel)
-
-          return (hist, res, lastBlobLocationModel, lastBlobLocation)
+          return (hist, res === Ok .&&. dbTip === modelTip .&&. validation)
 
     fsVar     <- QC.run $ atomically (newTVar Mock.empty)
     errorsVar <- QC.run $ atomically (newTVar mempty)
-    (hist, res, lastBlobLocationModel, lastBlobLocation) <-
+    (hist, prop) <-
       test errorsVar (mkSimErrorHasFS EH.monadCatch fsVar errorsVar)
     prettyCommands smUnused hist
       $ tabulate "Tags" (map show $ tag (execCmds (QSM.initModel smUnused) cmds))
-      $ res === Ok .&&. lastBlobLocationModel === lastBlobLocation
+      $ prop
   where
     (dbm, mdb) = mkDBModel
     smUnused   = sm (error "errorsVar unused") hasFsUnused dbUnused dbm mdb
-
 
 tests :: TestTree
 tests = testGroup "ImmutableDB q-s-m"
     [ testProperty "sequential" prop_sequential
     ]
-
 
 fixedEpochSize :: EpochSize
 fixedEpochSize = 10
@@ -1023,11 +1085,11 @@ fixedEpochSize = 10
 fixedGetEpochSize :: Monad m => Epoch -> m EpochSize
 fixedGetEpochSize _ = return fixedEpochSize
 
-mkDBModel :: MonadState DBModel m
-          => (DBModel, ImmutableDB (ExceptT ImmutableDBError m))
+mkDBModel :: MonadState (DBModel Hash) m
+          => (DBModel Hash, ImmutableDB Hash (ExceptT ImmutableDBError m))
 mkDBModel = openDBModel EH.exceptT (const fixedEpochSize)
 
-dbUnused :: ImmutableDB m
+dbUnused :: ImmutableDB Hash m
 dbUnused = error "semantics and DB used during command generation"
 
 hasFsUnused :: HasFS m h

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
@@ -21,15 +22,19 @@ module Test.Ouroboros.Storage.ImmutableDB.TestBlock
   , tests
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Control.Monad (forM, replicateM, void, when)
 import           Control.Monad.Class.MonadThrow
 
 import qualified Data.Binary as Bin
+import qualified Data.Binary.Get as Bin
+import qualified Data.Binary.Put as Bin
 import qualified Data.ByteString.Builder as BS
 import qualified Data.ByteString.Lazy as BL
 import           Data.Functor (($>))
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
+import           Data.Maybe (isJust, maybeToList)
 import           Data.Word (Word64)
 
 import           GHC.Generics (Generic)
@@ -50,32 +55,45 @@ import           Ouroboros.Storage.ImmutableDB.Types
 import           Ouroboros.Storage.ImmutableDB.Util (readAll)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 
+import           Test.Util.Orphans.Arbitrary ()
 
 {-------------------------------------------------------------------------------
   TestBlock
 -------------------------------------------------------------------------------}
 
 
-newtype TestBlock = TestBlock { tbSlot :: Slot }
-    deriving (Generic, Eq, Ord)
+data TestBlock
+  = TestBlock { tbSlot :: Slot }
+  | TestEBB   { tbSlot :: Slot }
+  deriving (Generic, Eq, Ord)
 
 instance Show TestBlock where
-    show = show . getSlot . tbSlot
+    show (TestBlock slot) = "(TestBlock " <> show (getSlot slot) <> ")"
+    show (TestEBB   slot) = "(TestEBB "   <> show (getSlot slot) <> ")"
 
+-- | Only generates 'TestBlock's, no 'TestEBB's.
 instance Arbitrary TestBlock where
-    arbitrary = TestBlock . Slot <$> arbitrary
+  arbitrary = TestBlock <$> arbitrary
+  shrink    = genericShrink
+
+testBlockIsEBB :: TestBlock -> Bool
+testBlockIsEBB TestBlock {} = False
+testBlockIsEBB TestEBB   {} = True
 
 -- | The binary representation of 'TestBlock' consists of repeating its 'Slot'
 -- @n@ times, where @n = 'testBlockSize'@.
 testBlockRepeat :: Word
-testBlockRepeat = 10
+testBlockRepeat = 9
 
 -- | The number of bytes the binary representation 'TestBlock' takes up.
 testBlockSize :: Word
-testBlockSize = testBlockRepeat * 8
+testBlockSize = 8 + testBlockRepeat * 8
 
--- | The encoding of TestBlock @x@ is the encoding of @x@ as a 'Word',
--- repeated 10 times. This means that:
+-- | The encoding is as follows:
+--
+-- First a tag, either the bytestring @"bbbbbbbb"@ for a 'TestBlock' or the
+-- bytestring @"ebbebbeb"@ for a 'TestEBB'. Then the encoding of the @slot@ as
+-- a 'Word', repeated 9 times. This means that:
 --
 -- * We know the size of each block (no delimiters needed)
 -- * We know the slot of the block
@@ -84,69 +102,108 @@ testBlockSize = testBlockRepeat * 8
 -- __NOTE__: 'Test.Ouroboros.Storage.ImmutableDB.Model.simulateCorruptions'
 -- depends on this encoding of 'TestBlock'.
 instance Bin.Binary TestBlock where
-    put (TestBlock (Slot slot)) =
-      mconcat $ replicate (fromIntegral testBlockRepeat) (Bin.put slot)
+    put testBlock =
+        tag <> mconcat (replicate (fromIntegral testBlockRepeat) (Bin.put slot))
+      where
+        slot = getSlot (tbSlot testBlock)
+        tag  = Bin.putByteString $ case testBlock of
+          TestBlock {} -> "bbbbbbbb"
+          TestEBB   {} -> "ebbebbeb"
     get = do
+      tag <- Bin.getByteString 8
+      let constr = case tag of
+            "bbbbbbbb" -> TestBlock
+            "ebbebbeb" -> TestEBB
+            _          -> fail ("Unknown tag: " <> show tag)
       (w:ws) <- replicateM (fromIntegral testBlockRepeat) Bin.get
       when (any (/= w) ws) $
         fail "Corrupt TestBlock"
-      return $ TestBlock (Slot w)
+      return $ constr (Slot w)
 
-newtype TestBlocks = TestBlocks [TestBlock]
+-- | The list contains regular @TestBlock@s ordered by their slot.
+-- The @Maybe TestBlock@ is an optional @TestEBB@.
+data TestBlocks = TestBlocks (Maybe TestBlock) [TestBlock]
     deriving (Show)
 
 instance Arbitrary TestBlocks where
-    arbitrary = TestBlocks <$> orderedList
-    shrink (TestBlocks testBlocks) =
-      TestBlocks <$> shrinkList (const []) testBlocks
+    arbitrary = do
+      regularBlocks <- orderedList
+      mbEBB           <- frequency
+        [ (2, return Nothing)
+        , (1, Just . TestEBB <$> arbitrary)
+        ]
+      return $ TestBlocks mbEBB regularBlocks
+
+    shrink (TestBlocks mbEBB testBlocks) =
+      -- If there is an EBB, also return a list without it
+      (if isJust mbEBB then (TestBlocks Nothing testBlocks :) else id)
+      (TestBlocks mbEBB <$> shrinkList (const []) testBlocks)
 
 testBlockToBuilder :: TestBlock -> BS.Builder
 testBlockToBuilder = BS.lazyByteString . Bin.encode
 
+prop_TestBlock_Binary :: Slot -> Property
+prop_TestBlock_Binary slot =
+    Bin.decode (Bin.encode testBlock) === testBlock .&&.
+    Bin.decode (Bin.encode testEBB)   === testEBB
+  where
+    testBlock = TestBlock slot
+    testEBB   = TestEBB   slot
+
+instance Serialise TestBlock
 
 {-------------------------------------------------------------------------------
   EpochFileParser
 -------------------------------------------------------------------------------}
 
 
-binaryEpochFileParser :: forall b m h. (MonadThrow m, Bin.Binary b)
+-- The EBB can only occur at offset 0
+binaryEpochFileParser :: forall b m hash h. (MonadThrow m, Bin.Binary b)
                       => HasFS m h
-                      -> EpochFileParser String m b
-binaryEpochFileParser hasFS@HasFS{..} = EpochFileParser $ \fsPath ->
+                      -> (b -> Bool)  -- ^ Is the block an EBB?
+                      -> (b -> hash)
+                      -> EpochFileParser String hash m b
+binaryEpochFileParser hasFS@HasFS{..} isEBB getHash = EpochFileParser $ \fsPath ->
     withFile hasFS fsPath ReadMode $ \eHnd -> do
       bytesInFile <- hGetSize eHnd
-      parse (fromIntegral bytesInFile) 0 [] . BS.toLazyByteString <$>
+      parse bytesInFile 0 [] Nothing . BS.toLazyByteString <$>
         readAll hasFS eHnd
   where
     parse :: SlotOffset
           -> SlotOffset
           -> [(SlotOffset, b)]
+          -> Maybe hash
           -> BL.ByteString
-          -> ([(SlotOffset, b)], Maybe String)
-    parse bytesInFile offset parsed bs
+          -> ([(SlotOffset, b)], Maybe hash, Maybe String)
+    parse bytesInFile offset parsed ebbHash bs
       | offset >= bytesInFile
-      = (reverse parsed, Nothing)
+      = (reverse parsed, ebbHash, Nothing)
       | otherwise
       = case Bin.decodeOrFail bs of
-          Left (_, _, e) -> (reverse parsed, Just e)
+          Left (_, _, e) -> (reverse parsed, ebbHash, Just e)
           Right (remaining, bytesConsumed, b) ->
             let newOffset = offset + fromIntegral bytesConsumed
                 newParsed = (offset, b) : parsed
-            in parse bytesInFile newOffset newParsed remaining
+                ebbHash'
+                  | offset == 0, isEBB b = Just (getHash b)
+                  | otherwise            = ebbHash
+            in parse bytesInFile newOffset newParsed ebbHash' remaining
 
+-- | We use 'TestBlock' as the @hash@.
 testBlockEpochFileParser' :: MonadThrow m
                           => HasFS m h
-                          -> EpochFileParser String m (Word, Slot)
+                          -> EpochFileParser String TestBlock m (Word, Slot)
 testBlockEpochFileParser' hasFS = (\tb -> (testBlockSize, tbSlot tb)) <$>
-    binaryEpochFileParser hasFS
+    binaryEpochFileParser hasFS testBlockIsEBB id
 
 
 prop_testBlockEpochFileParser :: TestBlocks -> Property
-prop_testBlockEpochFileParser (TestBlocks blocks) = QCM.monadicIO $ do
-    (offsetsAndBlocks, mbErr) <- QCM.run $ runSimIO $ \hasFS -> do
+prop_testBlockEpochFileParser (TestBlocks mbEBB regularBlocks) = QCM.monadicIO $ do
+    (offsetsAndBlocks, ebbHash, mbErr) <- QCM.run $ runSimIO $ \hasFS -> do
       writeBlocks hasFS
       readBlocks  hasFS
-    QSM.liftProperty (mbErr === Nothing)
+    QSM.liftProperty (mbErr   === Nothing)
+    QSM.liftProperty (ebbHash === mbEBB)
     let (offsets', blocks') = unzip offsetsAndBlocks
         offsets = dropLast $ scanl (+) 0 $
           map (const (fromIntegral testBlockSize)) blocks
@@ -156,14 +213,18 @@ prop_testBlockEpochFileParser (TestBlocks blocks) = QCM.monadicIO $ do
     dropLast xs = zipWith const xs (drop 1 xs)
     file = ["test"]
 
+    blocks = maybeToList mbEBB <> regularBlocks
+
     writeBlocks :: HasFS IO Mock.Handle -> IO ()
     writeBlocks hasFS@HasFS{..} = do
       let bld = foldMap testBlockToBuilder blocks
       withFile hasFS file AppendMode $ \eHnd -> void $ hPut eHnd bld
 
     readBlocks :: HasFS IO Mock.Handle
-               -> IO ([(SlotOffset, TestBlock)], Maybe String)
-    readBlocks hasFS = runEpochFileParser (binaryEpochFileParser hasFS) file
+               -> IO ([(SlotOffset, TestBlock)], Maybe TestBlock, Maybe String)
+    readBlocks hasFS = runEpochFileParser
+      (binaryEpochFileParser hasFS testBlockIsEBB id)
+      file
 
     runSimIO :: (HasFS IO Mock.Handle -> IO a) -> IO a
     runSimIO m = fst <$> runSimFS EH.exceptions Mock.empty m
@@ -223,5 +284,6 @@ shrinkCorruptions =
 
 tests :: TestTree
 tests = testGroup "TestBlock"
-    [ testProperty "testBlockEpochFileParser" prop_testBlockEpochFileParser
+    [ testProperty "TestBlock Binary roundtrip" prop_TestBlock_Binary
+    , testProperty "testBlockEpochFileParser" prop_testBlockEpochFileParser
     ]


### PR DESCRIPTION
Addresses #349:

* The EBB is stored at the beginning of each epoch. Internally, `RelativeSlot`
  0 is now reserved for the EBB.

* Add the new operations `appendEBB` and `getEBB` to the `ImmutableDB`. EBBs
  are identified by their epoch. In addition to the contents of the
  EBB (`Builder`), its `hash` must also be passed when appending it (and will
  be returned when getting it).

* Iterator bounds are now `Maybe (Slot, hash)` where, just as before,
  `Nothing` means "from the start"/"until the end". A higher layer can
  instantiate the `hash` type such that this bound is isomorphic to
  `Maybe (Point block)`.

* The `hash` of the EBB is now also stored in the index file (at the end, so
  we're not bound by the size of the hash). This hash is used when determining
  the bounds for streaming blocks: should we stop before/after the EBB or the
  regular block at this slot? As we don't have the hash of the regular
  block (we don't want to store all hashes nor deserialise blocks to get their
  hash), we assume that when a hash doesn't match the EBB's hash, it will
  match the regular block's hash. We parameterise over the `hash` type (type
  parameter of `ImmutableDB`) so that it can be instantiated by a higher
  layer, instead of pulling in the `HasHeader` constraint on blobs (which are
  currently `ByteString`/`Builder`s).

* The `EpochFileParser` now also returns the hash of the EBB, if there was
  one (`Maybe hash`). The CBOR parser has been updated to take a function `a
  -> Maybe hash`.

* `IteratorResult` now has an `IteratorEBB :: Epoch -> hash -> ByteString ->
  IteratorResult` constructor for EBBs, which are included when streaming.

* Replace `getNextSlot` with `getTip`, using the new `Tip` type. Having access
  to the tip is much more useful than knowing what the next empty slot is. The
  next empty slot doesn't tell you whether the last thing in the database is
  an EBB or a regular block, whereas the tip will tell you whether the last
  thing in the database is an EBB or a regular block (or genesis in case of an
  empty database). Internally, we also track the tip instead of the next slot,
  which required some changes, but made things simpler.

* (Re)opening the database no longer returns the location of the last valid
  blob, as you can now simply use the new `getTip` operation.

* Validation no longer throws an error saying where the user should truncate
  to. Instead, it will perform truncation itself and will no longer throw an
  error. This cuts out an extra step: the only thing the user could do with
  the error was revalidate with the explicit truncation point extracted from
  the error.

* Add the `deleteAfter` operation to the `ImmutableDB` for explicitly
  truncating the (open, not closed!) database. This operation will be used by
  a higher layer during recovery: when the `VolatileDB` has been truncated and
  the `ImmutableDB`'s tip is no longer older than `k`, it should also be
  truncated so that its tip is older than `k` again.

* The getters in the implementation of the `ImmutableDB` now use
  `withOpenState`, which will close the database when an unexpected error was
  thrown. When an unexpected error, e.g., an invalid file error, is thrown,
  the database can no longer function correctly anyway, and should be
  validated again (using `reopen`). Previously, only write operations closed
  the database when an unexpected error was thrown (`modifyOpenState`).

* Add the `DeserialisationError` constructor to `UnexpectedError`: for when
  deserialising the hash of the EBB failed.

* Add the `OpenDBError` constructor to `UserError`: for when the user tries to
  reopen an open database. Previously, reopening an open database would be a
  no-op. The user typically wants to reopen the database in order to validate
  it, so a no-op instead of performing validation is not very nice. The user
  can use `isOpen` to check whether the database is open or closed.

TODO the byron-proxy should be updated.