### PR TITLE
Use `Data.ByteString.Char8.putStr` in MonadSay IO Instance

### DIFF
--- a/io-sim-classes/io-sim-classes.cabal
+++ b/io-sim-classes/io-sim-classes.cabal
@@ -42,7 +42,8 @@ library
   build-depends:       base  >=4.9 && <4.13,
                        mtl   >=2.2 && <2.3,
                        stm   >=2.4 && <2.6,
-                       async >=2.1
+                       async >=2.1,
+                       bytestring
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts

--- a/io-sim-classes/src/Control/Monad/Class/MonadSay.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSay.hs
@@ -1,12 +1,13 @@
 module Control.Monad.Class.MonadSay where
 
 import           Control.Monad.State
+import qualified Data.ByteString.Char8 as BSC
 
 class Monad m => MonadSay m where
   say :: String -> m ()
 
 instance MonadSay IO where
-  say = print
+  say = BSC.putStrLn . BSC.pack
 
 instance MonadSay m => MonadSay (StateT s m) where
   say = lift . say

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -16,7 +16,13 @@
       };
     components = {
       "library" = {
-        depends = [ (hsPkgs.base) (hsPkgs.mtl) (hsPkgs.stm) (hsPkgs.async) ];
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.mtl)
+          (hsPkgs.stm)
+          (hsPkgs.async)
+          (hsPkgs.bytestring)
+          ];
         };
       };
     } // rec { src = (pkgs.lib).mkDefault .././../io-sim-classes; }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -35,7 +35,6 @@
           (hsPkgs.pipes)
           (hsPkgs.process)
           (hsPkgs.serialise)
-          (hsPkgs.say)
           (hsPkgs.stm)
           (hsPkgs.text)
           ];

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -96,7 +96,6 @@ library
                        pipes             >=4.3 && <4.4,
                        process           >=1.6 && <1.7,
                        serialise         >=0.2 && <0.3,
-                       say,
                        stm               >=2.4 && <2.6,
                        text              >=1.2 && <1.3
 


### PR DESCRIPTION
MonadSay should be removed in favour of iohk-monitoring-framework.