### PR TITLE
Prepare for integration with cardano-chain code base

### DIFF
--- a/byron-proxy/src/exec/Main.hs
+++ b/byron-proxy/src/exec/Main.hs
@@ -265,7 +265,7 @@ main = withCompileInfo $ do
           -- configuration, and we assume it will never change.
           epochSlots :: SlotCount
           epochSlots = configEpochSlots genesisConfig
-          getEpochSize :: Immutable.Epoch -> IO Immutable.EpochSize
+          getEpochSize :: Immutable.EpochNo -> IO Immutable.EpochSize
           -- FIXME the 'fromIntegral' casts from 'Word64' to 'Word'.
           -- For sufficiently high k, on certain machines, there could be an
           -- overflow.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock.hs
@@ -198,7 +198,7 @@ deriving instance (SimpleBlockCrypto c, OuroborosTag p, Ord (Payload p (SimplePr
 -- without the signature itself).
 data SimplePreHeader p c = SimplePreHeader {
       headerPrev     :: Network.Hash (SimpleHeader p c)
-    , headerSlot     :: Slot
+    , headerSlot     :: SlotNo
     , headerBlockNo  :: BlockNo
     , headerBodyHash :: Hash (SimpleBlockHash c) SimpleBody
     }
@@ -229,7 +229,7 @@ instance (SimpleBlockCrypto c, OuroborosTag p, Condense (Payload p (SimplePreHea
       , ","
       , condense pl
       , ","
-      , condense (getSlot $ blockSlot hdr)
+      , condense (unSlotNo $ blockSlot hdr)
       , ","
       , condense txs
       , ")"
@@ -283,7 +283,7 @@ forgeBlock :: forall m p c.
               , Serialise (Payload p (SimplePreHeader p c))
               )
            => NodeConfig p
-           -> Slot                            -- ^ Current slot
+           -> SlotNo                          -- ^ Current slot
            -> BlockNo                         -- ^ Current block number
            -> Network.Hash (SimpleHeader p c) -- ^ Previous hash
            -> Map (Hash ShortHash Tx) Tx      -- ^ Txs to add in the block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -25,6 +25,7 @@ import           Control.Monad.Except
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy
+import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 
 import           Ouroboros.Network.Block
@@ -60,7 +61,7 @@ data BftParams = BftParams {
       bftSecurityParam :: SecurityParam
 
       -- | Number of core nodes
-    , bftNumNodes      :: Word
+    , bftNumNodes      :: Word64
     }
 
 instance BftCrypto c => OuroborosTag (Bft c) where
@@ -93,7 +94,7 @@ instance BftCrypto c => OuroborosTag (Bft c) where
           bftSignature = signature
         }
 
-  checkIsLeader BftNodeConfig{..} (Slot n) _l _cs = do
+  checkIsLeader BftNodeConfig{..} (SlotNo n) _l _cs = do
       return $ case bftNodeId of
                  RelayId _ -> Nothing -- relays are never leaders
                  CoreId  i -> if n `mod` bftNumNodes == fromIntegral i
@@ -111,7 +112,7 @@ instance BftCrypto c => OuroborosTag (Bft c) where
         else throwError BftInvalidSignature
     where
       BftParams{..}  = bftParams
-      Slot n         = blockSlot b
+      SlotNo n       = blockSlot b
       expectedLeader = CoreId $ fromIntegral (n `mod` bftNumNodes)
 
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Genesis.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Genesis.hs
@@ -9,13 +9,14 @@ module Ouroboros.Consensus.Protocol.Genesis (
   ) where
 
 import           Numeric.Natural (Natural)
+import           Data.Word (Word64)
 
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
 import           Ouroboros.Consensus.Protocol.ModChainSel
 import           Ouroboros.Consensus.Util.Chain (forksAtMostKBlocks,
                      intersectionSlot, upToSlot)
-import           Ouroboros.Network.Block (Slot (..))
+import           Ouroboros.Network.Block (SlotNo (..))
 import qualified Ouroboros.Network.Chain as Chain
 
 type Genesis p = ModChainSel (ExtNodeConfig Natural p) (GenesisChainSelection p)
@@ -28,8 +29,8 @@ instance OuroborosTag p => ChainSelection (ExtNodeConfig Natural p) (GenesisChai
         | forksAtMostKBlocks k ours' theirs' = preferCandidate encNodeConfigP slot ours theirs
         | otherwise                          =
             let sl    = case intersectionSlot ours' theirs' of
-                            Nothing -> Slot s
-                            Just j  -> Slot $ s + getSlot j
+                            Nothing -> SlotNo s
+                            Just j  -> SlotNo $ s + unSlotNo j
                 ours''   = upToSlot sl ours'
                 theirs'' = upToSlot sl theirs'
             in if Chain.length theirs'' > Chain.length ours''
@@ -41,10 +42,10 @@ instance OuroborosTag p => ChainSelection (ExtNodeConfig Natural p) (GenesisChai
         ours'   = clip ours
         theirs' = clip theirs
 
-        k :: Word
+        k :: Word64
         k = maxRollbacks $ protocolSecurityParam encNodeConfigP
 
-        s :: Word
+        s :: Word64
         s = fromIntegral encNodeConfigExt
 
     compareCandidates' = error "TODO"

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -17,19 +17,19 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           GHC.Generics (Generic)
 
-import           Ouroboros.Network.Block (Slot (..))
+import           Ouroboros.Network.Block (SlotNo (..))
 
 import           Ouroboros.Consensus.Node (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 
-newtype LeaderSchedule = LeaderSchedule {getLeaderSchedule :: Map Slot [CoreNodeId]}
+newtype LeaderSchedule = LeaderSchedule {getLeaderSchedule :: Map SlotNo [CoreNodeId]}
     deriving (Show, Eq, Ord)
 
 instance Condense LeaderSchedule where
     condense (LeaderSchedule m) = show
                                 $ map (\(s, ls) ->
-                                    (getSlot s, map (\(CoreNodeId nid) -> nid) ls))
+                                    (unSlotNo s, map (\(CoreNodeId nid) -> nid) ls))
                                 $ Map.toList m
 
 -- | Extension of protocol @p@ by a static leader schedule.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -27,7 +27,7 @@ module Ouroboros.Consensus.Protocol.ModChainSel (
 import           Codec.Serialise (Serialise)
 import           Data.Proxy (Proxy (..))
 
-import           Ouroboros.Network.Block (HasHeader, Slot)
+import           Ouroboros.Network.Block (HasHeader, SlotNo)
 import           Ouroboros.Network.Chain (Chain)
 
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -38,7 +38,7 @@ class OuroborosTag p => ChainSelection p s where
   preferCandidate' :: (Eq b, HasHeader b)
                    => proxy s
                    -> NodeConfig p
-                   -> Slot         -- ^ Present slot
+                   -> SlotNo       -- ^ Present slot
                    -> Chain b      -- ^ Our chain
                    -> Chain b      -- ^ Candidate
                    -> Maybe (Chain b)
@@ -46,7 +46,7 @@ class OuroborosTag p => ChainSelection p s where
   compareCandidates' :: (Eq b, HasHeader b)
                      => proxy s
                      -> NodeConfig p
-                     -> Slot         -- ^ Present slot
+                     -> SlotNo       -- ^ Present slot
                      -> Chain b -> Chain b -> Ordering
 
 data ModChainSel p s

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -32,6 +32,7 @@ import           Data.Kind (Constraint)
 import           Data.List (foldl')
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.Word (Word64)
 import           GHC.Stack
 
 data Dict (a :: Constraint) where
@@ -111,7 +112,7 @@ lastMaybe [x]    = Just x
 lastMaybe (_:xs) = lastMaybe xs
 
 -- | Fast Fibonacci computation, using Binet's formula
-fib :: Word -> Word
+fib :: Word64 -> Word64
 fib n = round $ phi ** fromIntegral n / sq5
   where
     sq5, phi :: Double

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Chain.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Chain.hs
@@ -17,6 +17,7 @@ import           Data.Foldable (foldl')
 import           Data.Sequence (Seq (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.Word (Word64)
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain
@@ -25,7 +26,7 @@ import           Ouroboros.Network.Chain
   Utility functions on chains
 -------------------------------------------------------------------------------}
 
-lastSlot :: HasHeader b => Chain b -> Maybe Slot
+lastSlot :: HasHeader b => Chain b -> Maybe SlotNo
 lastSlot Genesis  = Nothing
 lastSlot (_ :> b) = Just $ blockSlot b
 
@@ -39,7 +40,7 @@ commonPrefix c d = chainFromSeq $ go (chainToSeq c) (chainToSeq d)
         | x == y             = x :<| go xs ys
         | otherwise          = Empty
 
-upToSlot :: HasHeader b => Slot -> Chain b -> Chain b
+upToSlot :: HasHeader b => SlotNo -> Chain b -> Chain b
 upToSlot slot = go
   where
     go Genesis = Genesis
@@ -54,7 +55,7 @@ dropLastBlocks i bs@(cs :> _)
     | otherwise = dropLastBlocks (i - 1) cs
 
 forksAtMostKBlocks :: forall b. HasHeader b
-                   => Word     -- ^ How many blocks can it fork?
+                   => Word64   -- ^ How many blocks can it fork?
                    -> Chain b  -- ^ Our chain.
                    -> Chain b  -- ^ Their chain.
                    -> Bool     -- ^ Indicates whether their chain forks at most the specified number of blocks.
@@ -78,7 +79,7 @@ forksAtMostKBlocks k ours = go
         | l <= 0       = Set.empty
         | otherwise    = Set.insert x $ takeR xs $ l - 1
 
-intersectionSlot :: (Eq b, HasHeader b) => Chain b -> Chain b -> Maybe Slot
+intersectionSlot :: (Eq b, HasHeader b) => Chain b -> Chain b -> Maybe SlotNo
 intersectionSlot c d = lastSlot $ commonPrefix c d
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -5,7 +5,7 @@ import           Control.Monad.Identity
 import           Control.Monad.Trans
 import           Crypto.Random
 
-import           Ouroboros.Network.Block (Slot (..))
+import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.Chain (Chain (..))
 
 import           Ouroboros.Consensus.Util.Condense
@@ -14,8 +14,8 @@ import           Ouroboros.Consensus.Util.Condense
   Condense
 -------------------------------------------------------------------------------}
 
-instance Condense Slot where
-  condense (Slot n) = condense n
+instance Condense SlotNo where
+  condense (SlotNo n) = condense n
 
 instance Condense block => Condense (Chain block) where
     condense Genesis   = "Genesis"

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
@@ -48,7 +48,7 @@ import           Ouroboros.Consensus.Util (lastMaybe)
 import           Ouroboros.Storage.FS.API (HasFS (..), withFile)
 import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes
                      (RelativeSlot (..))
-import           Ouroboros.Storage.ImmutableDB.Types (Epoch, EpochSize,
+import           Ouroboros.Storage.ImmutableDB.Types (EpochNo, EpochSize,
                      SlotOffset)
 import           Ouroboros.Storage.ImmutableDB.Util (readAll, renderFile)
 import           Ouroboros.Storage.Util (decodeIndexEntryAt, encodeIndexEntry)
@@ -78,7 +78,7 @@ indexEntrySizeBytes = 8
 -- 'ByteString'@.
 loadIndex :: (HasCallStack, MonadThrow m)
           => HasFS m h
-          -> Epoch
+          -> EpochNo
           -> m (Index, Maybe ByteString)
 loadIndex hasFS epoch = do
     let indexFile = renderFile "index" epoch
@@ -101,7 +101,7 @@ loadIndex hasFS epoch = do
 -- > index === index' .&&. isNothing mbJunk
 writeIndex :: MonadThrow m
            => HasFS m h
-           -> Epoch
+           -> EpochNo
            -> Index
            -> m ()
 writeIndex hasFS@HasFS{..} epoch (MkIndex offsets) = do
@@ -126,7 +126,7 @@ writeIndex hasFS@HasFS{..} epoch (MkIndex offsets) = do
 -- > indexToSlotOffsets index === offsets
 writeSlotOffsets :: MonadThrow m
                  => HasFS m h
-                 -> Epoch
+                 -> EpochNo
                  -> NonEmpty SlotOffset
                  -> m ()
 writeSlotOffsets hasFS@HasFS{..} epoch sos = do

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Util.hs
@@ -55,8 +55,8 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 ------------------------------------------------------------------------------}
 
 
-renderFile :: String -> Epoch -> FsPath
-renderFile fileType (Epoch epoch) = [printf "%s-%03d.dat" fileType epoch]
+renderFile :: String -> EpochNo -> FsPath
+renderFile fileType (EpochNo epoch) = [printf "%s-%03d.dat" fileType epoch]
 
 handleUser :: HasCallStack
            => ErrorHandling ImmutableDBError m
@@ -87,9 +87,9 @@ throwUnexpectedError = throwError . handleUnexpected
 -- Just ("epoch", 1)
 -- > parseDBFile "index-012.dat"
 -- Just ("index", 12)
-parseDBFile :: String -> Maybe (String, Epoch)
+parseDBFile :: String -> Maybe (String, EpochNo)
 parseDBFile s = case T.splitOn "-" . fst . T.breakOn "." . T.pack $ s of
-    [prefix, n] -> (T.unpack prefix,) . Epoch <$> readMaybe (T.unpack n)
+    [prefix, n] -> (T.unpack prefix,) . EpochNo <$> readMaybe (T.unpack n)
     _           -> Nothing
 
 -- | Read all the data from the given file handle 64kB at a time.
@@ -138,9 +138,9 @@ hGetRightSize HasFS{..} hnd size file = do
 validateIteratorRange
   :: Monad m
   => ErrorHandling ImmutableDBError m
-  -> Slot        -- ^ Next expected write
-  -> Maybe Slot  -- ^ range start (inclusive)
-  -> Maybe Slot  -- ^ range end (inclusive)
+  -> SlotNo        -- ^ Next expected write
+  -> Maybe SlotNo  -- ^ range start (inclusive)
+  -> Maybe SlotNo  -- ^ range end (inclusive)
   -> m ()
 validateIteratorRange err next mbStart mbEnd = do
     case (mbStart, mbEnd) of

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
@@ -33,6 +33,6 @@ data VolatileDB blockId m = VolatileDB {
     , reOpenDB       :: HasCallStack => m ()
     , getBlock       :: HasCallStack => blockId -> m (Maybe ByteString)
     , putBlock       :: HasCallStack => blockId -> Builder -> m ()
-    , garbageCollect :: HasCallStack => Slot -> m ()
+    , garbageCollect :: HasCallStack => SlotNo -> m ()
     , getIsMember    :: HasCallStack => m (blockId -> Bool)
 }

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
@@ -25,7 +25,7 @@ type Fd = Int
 
 -- For each file, we store the latest blockId, the number of blocks
 -- and a Map for its contents.
-type Index blockId = Map String (Maybe Slot, Int, Map Int64 (Int, blockId))
+type Index blockId = Map String (Maybe SlotNo, Int, Map Int64 (Int, blockId))
 
 -- For each blockId, we store the file we can find the block, the offset and its size
 -- in bytes.

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
@@ -71,7 +71,7 @@ prop_Fixed_Nominal_Fixed t = fixedDiffFromNominal (fixedDiffToNominal t) === t
 -------------------------------------------------------------------------------}
 
 -- > slotAtTime (startOfSlot slot)) == (slot, 0)
-prop_startOfSlot :: SlotLength -> SystemStart -> Slot -> Property
+prop_startOfSlot :: SlotLength -> SystemStart -> SlotNo -> Property
 prop_startOfSlot slotLen start slot =
       counterexample ("slotStart: " ++ show slotStart)
     $ slotAtTime slotLen start slotStart === (slot, 0)
@@ -114,7 +114,7 @@ prop_timeUntilNextSlot slotLen start execTime =
              | otherwise                         = "in the middle"
 
 -- > timeUntilNextSlot (startOfSlot slot) == (slotLen, slot + 1)
-prop_timeFromStartOfSlot :: SlotLength -> SystemStart -> Slot -> Property
+prop_timeFromStartOfSlot :: SlotLength -> SystemStart -> SlotNo -> Property
 prop_timeFromStartOfSlot slotLen start slot =
       counterexample ("slotStart: " ++ show slotStart)
     $ timeUntilNextSlot slotLen start slotStart ===
@@ -149,7 +149,7 @@ data TestDelayIO = TestDelayIO {
       -- this as an offset _before_ the start of the test.
       tdioStart'  :: FixedDiffTime
 
-      -- | Slot length
+      -- | SlotNo length
       --
       -- Since this test is run in IO, we will keep the slot length short.
     , tdioSlotLen :: SlotLength

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
@@ -12,7 +12,7 @@ import           Test.Tasty.QuickCheck
 
 import           Ouroboros.Consensus.BlockchainTime
 
-import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Orphans.Arbitrary (genLimitedSlotNo)
 
 tests :: TestTree
 tests = testGroup "BlockchainTime" [
@@ -71,12 +71,11 @@ prop_Fixed_Nominal_Fixed t = fixedDiffFromNominal (fixedDiffToNominal t) === t
 -------------------------------------------------------------------------------}
 
 -- > slotAtTime (startOfSlot slot)) == (slot, 0)
-prop_startOfSlot :: SlotLength -> SystemStart -> SlotNo -> Property
-prop_startOfSlot slotLen start slot =
-      counterexample ("slotStart: " ++ show slotStart)
-    $ slotAtTime slotLen start slotStart === (slot, 0)
-  where
-    slotStart = startOfSlot slotLen start slot
+prop_startOfSlot :: SlotLength -> SystemStart -> Property
+prop_startOfSlot slotLen start = forAll genLimitedSlotNo $ \ slot ->
+    let slotStart = startOfSlot slotLen start slot in
+    counterexample ("slotStart: " ++ show slotStart)
+        $ slotAtTime slotLen start slotStart === (slot, 0)
 
 -- > now - slotLen < startOfSlot (fst (slotAtTime now)) <= now
 -- > 0 <= snd (slotAtTime now) < slotLen
@@ -114,13 +113,12 @@ prop_timeUntilNextSlot slotLen start execTime =
              | otherwise                         = "in the middle"
 
 -- > timeUntilNextSlot (startOfSlot slot) == (slotLen, slot + 1)
-prop_timeFromStartOfSlot :: SlotLength -> SystemStart -> SlotNo -> Property
-prop_timeFromStartOfSlot slotLen start slot =
-      counterexample ("slotStart: " ++ show slotStart)
-    $ timeUntilNextSlot slotLen start slotStart ===
-      (getSlotLength slotLen, slot + 1)
-  where
-    slotStart = startOfSlot slotLen start slot
+prop_timeFromStartOfSlot :: SlotLength -> SystemStart -> Property
+prop_timeFromStartOfSlot slotLen start = forAll genLimitedSlotNo $ \ slot ->
+    let slotStart = startOfSlot slotLen start slot in
+    counterexample ("slotStart: " ++ show slotStart)
+      $ timeUntilNextSlot slotLen start slotStart ===
+        (getSlotLength slotLen, slot + 1)
 
 -- > slotAtTime (now + fst (timeUntilNextSlot now)) == bimap (+1) (const 0) (slotAtTime now)
 -- > fst (slotAtTime (now + fst (timeUntilNextSlot now))) == snd (timeUntilNextSlot now)

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -28,7 +28,7 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Ouroboros.Network.Block (Slot (..))
+import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.Chain (Chain)
 
 import           Ouroboros.Consensus.BlockchainTime
@@ -129,7 +129,7 @@ shrinkLeaderSchedule (NumSlots numSlots) (LeaderSchedule m) =
     , m'   <- reduceSlot slot m
     ]
   where
-    reduceSlot :: Slot -> Map Slot [CoreNodeId] -> [Map Slot [CoreNodeId]]
+    reduceSlot :: SlotNo -> Map SlotNo [CoreNodeId] -> [Map SlotNo [CoreNodeId]]
     reduceSlot s m' = [Map.insert s xs m' | xs <- reduceList $ m' Map.! s]
 
     reduceList :: [a] -> [[a]]

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -23,6 +23,7 @@ module Test.Dynamic.Praos (
 
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Word (Word64)
 import           Test.QuickCheck
 
 import           Test.Tasty
@@ -109,12 +110,12 @@ prop_simple_praos_convergence params numCoreNodes numSlots =
                             (Map.elems final)
 
 prop_all_common_prefix :: (HasHeader b, Condense b, Eq b)
-                       => Word -> [Chain b] -> Property
+                       => Word64 -> [Chain b] -> Property
 prop_all_common_prefix _ []     = property True
 prop_all_common_prefix l (c:cs) = conjoin [prop_common_prefix l c d | d <- cs]
 
 prop_common_prefix :: forall b. (HasHeader b, Condense b, Eq b)
-                   => Word -> Chain b -> Chain b -> Property
+                   => Word64 -> Chain b -> Chain b -> Property
 prop_common_prefix l x y = go x y .&&. go y x
   where
     go c d =
@@ -144,5 +145,5 @@ prop_common_prefix l x y = go x y .&&. go y x
                   <> case lastSlot c of
                         Nothing -> ")"
                         Just s  ->    ", last slot "
-                                   <> show (getSlot s)
+                                   <> show (unSlotNo s)
                                    <> ")"

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
@@ -24,6 +24,7 @@ import           Data.Maybe (catMaybes)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text.Lazy as Text
+import           Data.Word (Word64)
 import           Numeric.Natural (Natural)
 import           Test.QuickCheck
 
@@ -54,18 +55,18 @@ allEqual (x : xs@(_:_)) =
     g c d = case (Chain.lastSlot c, Chain.lastSlot d) of
         (Nothing, Nothing) -> error "impossible case"
         (Nothing, Just t)  ->    "empty intersection of non-empty chains (one reaches slot "
-                              <> show (getSlot t)
+                              <> show (unSlotNo t)
                               <> " and contains "
                               <> show (Chain.length d)
                               <> "blocks): "
                               <> condense d
         (Just _, Nothing)  -> error "impossible case"
         (Just s, Just t)   ->    "intersection reaches slot "
-                              <> show (getSlot s)
+                              <> show (unSlotNo s)
                               <> " and has length "
                               <> show (Chain.length c)
                               <> ", but at least one chain reaches slot "
-                              <> show (getSlot t)
+                              <> show (unSlotNo t)
                               <> " and has length "
                               <> show (Chain.length d)
                               <> ": "
@@ -81,7 +82,7 @@ shortestLength = fromIntegral . minimum . map Chain.length . Map.elems
 -------------------------------------------------------------------------------}
 
 data BlockInfo b = BlockInfo
-    { biSlot     :: !Slot
+    { biSlot     :: !SlotNo
     , biCreator  :: !(Maybe CoreNodeId)
     , biHash     :: !(Hash b)
     , biPrevious :: !(Maybe (Hash b))
@@ -104,14 +105,14 @@ blockInfo b = BlockInfo
     }
 
 data NodeLabel = NodeLabel
-    { nlSlot      :: Slot
+    { nlSlot      :: SlotNo
     , nlCreator   :: Maybe CoreNodeId
     , nlBelievers :: Set NodeId
     }
 
 instance Labellable NodeLabel where
     toLabelValue NodeLabel{..} = StrLabel $ Text.pack $
-           show (getSlot nlSlot)
+           show (unSlotNo nlSlot)
         <> " "
         <> maybe "" (showNodeId . fromCoreNodeId) nlCreator
         <> showNodeIds nlBelievers
@@ -193,10 +194,10 @@ leaderScheduleFromTrace :: forall b. (HasCreator b, HasHeader b)
 leaderScheduleFromTrace (NumSlots numSlots) =
     LeaderSchedule . Map.foldl' (Chain.foldChain step) initial
   where
-    initial :: Map Slot [CoreNodeId]
+    initial :: Map SlotNo [CoreNodeId]
     initial = Map.fromList [(slot, []) | slot <- [1 .. fromIntegral numSlots]]
 
-    step :: Map Slot [CoreNodeId] -> b -> Map Slot [CoreNodeId]
+    step :: Map SlotNo [CoreNodeId] -> b -> Map SlotNo [CoreNodeId]
     step m b = Map.adjust (insert $ getCreator b) (blockSlot b) m
 
     insert :: CoreNodeId -> [CoreNodeId] -> [CoreNodeId]
@@ -212,10 +213,10 @@ leaderScheduleFromTrace (NumSlots numSlots) =
 -- more than one leader, possibly interrupted by slots without leader.
 -- There can be no such sequence, but if there is, first slot and number of
 -- multi-leader slots are given.
-newtype CrowdedRun = CrowdedRun (Maybe (Slot, Word))
+newtype CrowdedRun = CrowdedRun (Maybe (SlotNo, Word64))
     deriving (Show, Eq)
 
-crowdedRunLength :: CrowdedRun -> Word
+crowdedRunLength :: CrowdedRun -> Word64
 crowdedRunLength (CrowdedRun m) = maybe 0 snd m
 
 instance Ord CrowdedRun where
@@ -224,7 +225,7 @@ instance Ord CrowdedRun where
 noRun :: CrowdedRun
 noRun = CrowdedRun Nothing
 
-incCrowdedRun :: Slot -> CrowdedRun -> CrowdedRun
+incCrowdedRun :: SlotNo -> CrowdedRun -> CrowdedRun
 incCrowdedRun slot (CrowdedRun Nothing)          = CrowdedRun (Just (slot, 1))
 incCrowdedRun _    (CrowdedRun (Just (slot, n))) = CrowdedRun (Just (slot, n + 1))
 
@@ -234,7 +235,7 @@ longestCrowdedRun (LeaderSchedule m) = fst
                                      $ Map.toList
                                      $ fmap length m
   where
-    go :: (CrowdedRun, CrowdedRun) -> (Slot, Int) -> (CrowdedRun, CrowdedRun)
+    go :: (CrowdedRun, CrowdedRun) -> (SlotNo, Int) -> (CrowdedRun, CrowdedRun)
     go (x, y) (slot, n)
         | n == 0    = (x, y)
         | n == 1    = (x, noRun)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -79,7 +79,7 @@ tests = testGroup "ImmutableDB"
 fixedEpochSize :: EpochSize
 fixedEpochSize = 10
 
-fixedGetEpochSize :: Monad m => Epoch -> m EpochSize
+fixedGetEpochSize :: Monad m => EpochNo -> m EpochSize
 fixedGetEpochSize _ = return fixedEpochSize
 
 
@@ -87,7 +87,7 @@ fixedGetEpochSize _ = return fixedEpochSize
 openTestDB :: (HasCallStack, MonadSTM m, MonadCatch m)
            => HasFS m h
            -> ErrorHandling ImmutableDBError m
-           -> m (ImmutableDB m, Maybe Slot)
+           -> m (ImmutableDB m, Maybe SlotNo)
 openTestDB hasFS err =
     openDB hasFS err fixedGetEpochSize ValidateMostRecentEpoch parser
   where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
--- | Data structure to convert between 'Slot's and 'EpochSlot's.
+-- | Data structure to convert between 'SlotNo's and 'EpochSlot's.
 module Test.Ouroboros.Storage.ImmutableDB.CumulEpochSizes ( tests ) where
 
 import qualified Data.Foldable as Foldable
@@ -9,7 +9,7 @@ import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Ouroboros.Network.Block (Slot (..))
+import           Ouroboros.Network.Block (SlotNo (..))
 
 import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes
 import           Ouroboros.Storage.ImmutableDB.Types
@@ -26,15 +26,15 @@ instance Arbitrary CumulEpochSizes where
     , es' <- shrink es
     ]
 
-chooseSlot :: Slot -> Slot -> Gen Slot
-chooseSlot (Slot start) (Slot end) = Slot <$> choose (start, end)
+chooseSlot :: SlotNo -> SlotNo -> Gen SlotNo
+chooseSlot (SlotNo start) (SlotNo end) = SlotNo <$> choose (start, end)
 
 prop_ces_roundtrip :: CumulEpochSizes -> Property
 prop_ces_roundtrip ces = fromNonEmpty (NE.fromList (toList ces)) === ces
 
-prop_epochSize :: CumulEpochSizes -> Epoch -> Property
+prop_epochSize :: CumulEpochSizes -> EpochNo -> Property
 prop_epochSize ces epoch =
-    epochSize ces epoch === toList ces !? fromIntegral epoch
+    epochSize ces epoch === toList ces !? fromIntegral (unEpochNo epoch)
   where
     xs !? i
       | 0 <= i, i < Foldable.length xs = Just (xs !! i)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
@@ -14,15 +14,15 @@ import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes
 import           Ouroboros.Storage.ImmutableDB.Types
 
-import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Orphans.Arbitrary (genSmallEpochNo, genLimitedEpochSize)
 
 
 instance Arbitrary CumulEpochSizes where
   arbitrary =
-    fromNonEmpty . NE.fromList . fmap getPositive . getNonEmpty <$> arbitrary
+    fromNonEmpty . NE.fromList . getNonEmpty . NonEmpty <$> listOf1 genLimitedEpochSize
   shrink ces =
-    [ fromNonEmpty . NE.fromList . fmap getPositive . getNonEmpty $ es'
-    | let es = NonEmpty . fmap Positive $ toList ces
+    [ fromNonEmpty . NE.fromList . getNonEmpty $ es'
+    | let es = NonEmpty $ toList ces
     , es' <- shrink es
     ]
 
@@ -32,8 +32,9 @@ chooseSlot (SlotNo start) (SlotNo end) = SlotNo <$> choose (start, end)
 prop_ces_roundtrip :: CumulEpochSizes -> Property
 prop_ces_roundtrip ces = fromNonEmpty (NE.fromList (toList ces)) === ces
 
-prop_epochSize :: CumulEpochSizes -> EpochNo -> Property
-prop_epochSize ces epoch =
+prop_epochSize :: CumulEpochSizes -> Property
+prop_epochSize ces =
+    forAll genSmallEpochNo $ \ epoch ->
     epochSize ces epoch === toList ces !? fromIntegral (unEpochNo epoch)
   where
     xs !? i

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -372,11 +372,11 @@ appendBinaryBlobModel err getEpochSize slot bld = do
       throwUserError err $ AppendToSlotInThePastError slot dbmNextSlot
 
     let blob = BL.toStrict $ BS.toLazyByteString bld
-        toPad = unSlotNo (slot - dbmNextSlot)
+        toPad = fromIntegral $ unSlotNo (slot - dbmNextSlot)
 
     -- TODO snoc list?
     put dbm
-      { dbmChain           = dbmChain ++ replicate (fromIntegral toPad) Nothing ++ [Just blob]
+      { dbmChain           = dbmChain ++ replicate toPad Nothing ++ [Just blob]
       , dbmNextSlot        = slot + 1
       , dbmCumulEpochSizes = addMissingEpochSizes dbmCumulEpochSizes
       }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -35,7 +35,7 @@ import           GHC.Stack (HasCallStack, withFrozenCallStack)
 
 import           Ouroboros.Consensus.Util (lastMaybe)
 
-import           Ouroboros.Network.Block (Slot (..))
+import           Ouroboros.Network.Block (SlotNo (..))
 
 import           Ouroboros.Storage.FS.API.Types (FsPath)
 import           Ouroboros.Storage.ImmutableDB.API
@@ -51,7 +51,7 @@ import           Test.Ouroboros.Storage.ImmutableDB.TestBlock
 data DBModel = DBModel
   { dbmChain           :: [Maybe ByteString]
     -- ^ 'Nothing' when a slot is empty
-  , dbmNextSlot        :: Slot
+  , dbmNextSlot        :: SlotNo
     -- ^ The number of the next available slot
   , dbmCumulEpochSizes :: CumulEpochSizes
   , dbmIterators       :: Map IteratorID IteratorModel
@@ -69,7 +69,7 @@ initDBModel firstEpochSize = DBModel
   }
 
 dbmBlobs :: HasCallStack => DBModel -> Map EpochSlot ByteString
-dbmBlobs dbm@DBModel {..} = foldr add Map.empty (zip (map Slot [0..]) dbmChain)
+dbmBlobs dbm@DBModel {..} = foldr add Map.empty (zip (map SlotNo [0..]) dbmChain)
   where
     add (_,    Nothing)   = id
     add (slot, Just blob) = Map.insert (slotToEpochSlot dbm slot) blob
@@ -77,11 +77,11 @@ dbmBlobs dbm@DBModel {..} = foldr add Map.empty (zip (map Slot [0..]) dbmChain)
 
 -- | Model for an 'Iterator'.
 --
--- The first 'Slot' = return the next filled slot (doesn't have to exist) >=
--- this 'Slot'. The second 'Slot': last filled slot to return (inclusive).
+-- The first 'SlotNo' = return the next filled slot (doesn't have to exist) >=
+-- this 'SlotNo'. The second 'SlotNo': last filled slot to return (inclusive).
 --
 -- An iterator is open iff its is present in 'dbmIterators'
-newtype IteratorModel = IteratorModel (Slot, Slot)
+newtype IteratorModel = IteratorModel (SlotNo, SlotNo)
   deriving (Show, Eq, Generic)
 
 
@@ -93,7 +93,7 @@ newtype IteratorModel = IteratorModel (Slot, Slot)
 
 openDBModel :: MonadState DBModel m
             => ErrorHandling ImmutableDBError m
-            -> (Epoch -> EpochSize)
+            -> (EpochNo -> EpochSize)
             -> (DBModel, ImmutableDB m)
 openDBModel err getEpochSize = (dbModel, db)
   where
@@ -119,21 +119,21 @@ impossible msg = withFrozenCallStack (error ("Impossible: " ++ msg))
 mustBeJust :: HasCallStack => String -> Maybe a -> a
 mustBeJust msg = fromMaybe (impossible msg)
 
-lookupEpochSize :: HasCallStack => DBModel -> Epoch -> EpochSize
+lookupEpochSize :: HasCallStack => DBModel -> EpochNo -> EpochSize
 lookupEpochSize DBModel {..} epoch =
     mustBeJust msg $ CES.epochSize dbmCumulEpochSizes epoch
   where
     msg = "epoch (" <> show epoch <> ") size unknown (" <>
           show dbmCumulEpochSizes <> ")"
 
-epochSlotToSlot :: HasCallStack => DBModel -> EpochSlot -> Slot
+epochSlotToSlot :: HasCallStack => DBModel -> EpochSlot -> SlotNo
 epochSlotToSlot DBModel {..} epochSlot =
     mustBeJust msg $ CES.epochSlotToSlot dbmCumulEpochSizes epochSlot
   where
     msg = "epochSlot (" <> show epochSlot <>
           ") could not be converted to a slot"
 
-slotToEpochSlot :: HasCallStack => DBModel -> Slot -> EpochSlot
+slotToEpochSlot :: HasCallStack => DBModel -> SlotNo -> EpochSlot
 slotToEpochSlot DBModel {..} slot =
     mustBeJust msg $ CES.slotToEpochSlot dbmCumulEpochSizes slot
   where
@@ -141,20 +141,20 @@ slotToEpochSlot DBModel {..} slot =
           ") could not be converted to an epochSlot (" <>
           show dbmCumulEpochSizes <> ")"
 
-lookupBySlot :: HasCallStack => Slot -> [Maybe b] -> Maybe b
-lookupBySlot (Slot i) = go i
+lookupBySlot :: HasCallStack => SlotNo -> [Maybe b] -> Maybe b
+lookupBySlot (SlotNo i) = go i
   where
     go 0 (blob:_)  = blob
     go n (_:blobs) = go (n - 1) blobs
     go _ []        = error "lookupBySlot: index out of bounds"
 
-getLastBlobLocation :: DBModel -> Maybe Slot
+getLastBlobLocation :: DBModel -> Maybe SlotNo
 getLastBlobLocation DBModel {..} =
     lastMaybe $ zipWith const [0..] $ dropWhileEnd isNothing dbmChain
 
--- | Rolls back the chain to the given 'Slot', i.e. the given 'Slot' will be
+-- | Rolls back the chain to the given 'SlotNo', i.e. the given 'SlotNo' will be
 -- the new head of the chain.
-rollBackToSlot :: HasCallStack => Slot -> DBModel -> DBModel
+rollBackToSlot :: HasCallStack => SlotNo -> DBModel -> DBModel
 rollBackToSlot slot dbm@DBModel {..} =
     dbm { dbmChain           = rolledBackChain
         , dbmNextSlot        = newNextSlot
@@ -166,9 +166,9 @@ rollBackToSlot slot dbm@DBModel {..} =
     rolledBackChain = map snd $ takeWhile ((<= slot) . fst) $ zip [0..] dbmChain
     newNextSlot = fromIntegral $ length rolledBackChain
 
--- | Rolls back the chain to the start of the given 'Epoch'. The next epoch
--- slot will be the first of the given 'Epoch'.
-rollBackToEpochStart :: HasCallStack => Epoch -> DBModel -> DBModel
+-- | Rolls back the chain to the start of the given 'EpochNo'. The next epoch
+-- slot will be the first of the given 'EpochNo'.
+rollBackToEpochStart :: HasCallStack => EpochNo -> DBModel -> DBModel
 rollBackToEpochStart epoch dbm@DBModel {..} =
     dbm { dbmChain           = rolledBackChain
         , dbmNextSlot        = newNextSlot
@@ -189,16 +189,16 @@ rollBackToEpochSlot :: HasCallStack => EpochSlot -> DBModel -> DBModel
 rollBackToEpochSlot epochSlot dbm =
     rollBackToSlot (epochSlotToSlot dbm epochSlot) dbm
 
--- | Return the filled 'EpochSlot's of the given 'Epoch' stored in the model.
-epochSlotsInEpoch :: HasCallStack => DBModel -> Epoch -> [EpochSlot]
+-- | Return the filled 'EpochSlot's of the given 'EpochNo' stored in the model.
+epochSlotsInEpoch :: HasCallStack => DBModel -> EpochNo -> [EpochSlot]
 epochSlotsInEpoch dbm epoch =
     filter ((== epoch) . _epoch) $
     map fst $
     Map.toAscList $ dbmBlobs dbm
 
--- | Return the filled 'EpochSlot's before, in, and after the given 'Epoch'.
+-- | Return the filled 'EpochSlot's before, in, and after the given 'EpochNo'.
 filledEpochSlots :: HasCallStack
-                 => DBModel -> Epoch -> ([EpochSlot], [EpochSlot], [EpochSlot])
+                 => DBModel -> EpochNo -> ([EpochSlot], [EpochSlot], [EpochSlot])
 filledEpochSlots dbm epoch = (lt, eq, gt)
   where
     increasingEpochSlots = map fst $ Map.toAscList $ dbmBlobs dbm
@@ -228,8 +228,8 @@ simulateCorruptions corrs dbm = rollBack rbp dbm
 data RollBackPoint
   = DontRollBack
     -- ^ No roll back needed.
-  | RollBackToEpochStart Epoch
-    -- ^ Roll back to the start of the 'Epoch', removing all relative slots
+  | RollBackToEpochStart EpochNo
+    -- ^ Roll back to the start of the 'EpochNo', removing all relative slots
     -- of the epoch.
   | RollBackToEpochSlot  EpochSlot
     -- ^ Roll back to the 'EpochSlot', keeping it as the last relative slot.
@@ -264,7 +264,7 @@ findCorruptionRollBackPoint corr file dbm =
       Just ("index", epoch) -> findIndexCorruptionRollBackPoint corr epoch dbm
       _                     -> error "Invalid file to corrupt"
 
-findEpochDropLastBytesRollBackPoint :: Word64 -> Epoch -> DBModel
+findEpochDropLastBytesRollBackPoint :: Word64 -> EpochNo -> DBModel
                                     -> RollBackPoint
 findEpochDropLastBytesRollBackPoint n epoch dbm
     | null epochSlots
@@ -290,21 +290,21 @@ findEpochDropLastBytesRollBackPoint n epoch dbm
     lastValidFilledSlotIndex offset =
       (fromIntegral offset `quot` fromIntegral testBlockSize) - 1
 
-findEpochCorruptionRollBackPoint :: FileCorruption -> Epoch -> DBModel
+findEpochCorruptionRollBackPoint :: FileCorruption -> EpochNo -> DBModel
                                  -> RollBackPoint
 findEpochCorruptionRollBackPoint corr epoch dbm = case corr of
     DeleteFile      -> rollbackToLastFilledSlotBefore epoch dbm
 
     DropLastBytes n -> findEpochDropLastBytesRollBackPoint n epoch dbm
 
-rollbackToLastFilledSlotBefore :: Epoch -> DBModel -> RollBackPoint
+rollbackToLastFilledSlotBefore :: EpochNo -> DBModel -> RollBackPoint
 rollbackToLastFilledSlotBefore epoch dbm = case lastMaybe beforeEpoch of
     Just lastFilledSlotBefore -> RollBackToEpochSlot lastFilledSlotBefore
     Nothing                   -> RollBackToEpochStart 0
   where
     (beforeEpoch, _, _) = filledEpochSlots dbm epoch
 
-findIndexCorruptionRollBackPoint :: FileCorruption -> Epoch -> DBModel
+findIndexCorruptionRollBackPoint :: FileCorruption -> EpochNo -> DBModel
                                  -> RollBackPoint
 findIndexCorruptionRollBackPoint _corr epoch dbm
     | Just lastFilledSlotOfEpoch     <- lastMaybe inEpoch
@@ -329,7 +329,7 @@ findIndexCorruptionRollBackPoint _corr epoch dbm
 ------------------------------------------------------------------------------}
 
 reopenModel :: MonadState DBModel m
-            => Maybe TruncateFrom -> m (Maybe Slot)
+            => Maybe TruncateFrom -> m (Maybe SlotNo)
 reopenModel Nothing                    = gets getLastBlobLocation
 reopenModel (Just (TruncateFrom 0))    = do
     modify $ rollBackToEpochStart 0
@@ -344,12 +344,12 @@ reopenModel (Just (TruncateFrom slot)) = do
     return lastBlobLocation
 
 getNextSlotModel :: (HasCallStack, MonadState DBModel m)
-                 => m Slot
+                 => m SlotNo
 getNextSlotModel = gets dbmNextSlot
 
 getBinaryBlobModel :: (HasCallStack, MonadState DBModel m)
                    => ErrorHandling ImmutableDBError m
-                   -> Slot
+                   -> SlotNo
                    -> m (Maybe ByteString)
 getBinaryBlobModel err slot = do
     DBModel {..} <- get
@@ -361,8 +361,8 @@ getBinaryBlobModel err slot = do
 
 appendBinaryBlobModel :: (HasCallStack, MonadState DBModel m)
                       => ErrorHandling ImmutableDBError m
-                      -> (Epoch -> EpochSize)
-                      -> Slot
+                      -> (EpochNo -> EpochSize)
+                      -> SlotNo
                       -> Builder
                       -> m ()
 appendBinaryBlobModel err getEpochSize slot bld = do
@@ -372,11 +372,11 @@ appendBinaryBlobModel err getEpochSize slot bld = do
       throwUserError err $ AppendToSlotInThePastError slot dbmNextSlot
 
     let blob = BL.toStrict $ BS.toLazyByteString bld
-        toPad = fromIntegral (slot - dbmNextSlot)
+        toPad = unSlotNo (slot - dbmNextSlot)
 
     -- TODO snoc list?
     put dbm
-      { dbmChain           = dbmChain ++ replicate toPad Nothing ++ [Just blob]
+      { dbmChain           = dbmChain ++ replicate (fromIntegral toPad) Nothing ++ [Just blob]
       , dbmNextSlot        = slot + 1
       , dbmCumulEpochSizes = addMissingEpochSizes dbmCumulEpochSizes
       }
@@ -390,8 +390,8 @@ appendBinaryBlobModel err getEpochSize slot bld = do
 
 streamBinaryBlobsModel :: (HasCallStack, MonadState DBModel m)
                        => ErrorHandling ImmutableDBError m
-                       -> Maybe Slot
-                       -> Maybe Slot
+                       -> Maybe SlotNo
+                       -> Maybe SlotNo
                        -> m (Iterator m)
 streamBinaryBlobsModel err mbStart mbEnd = do
     dbm@DBModel {..} <- get

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -81,7 +81,7 @@ import           Test.Ouroboros.Storage.ImmutableDB.Model
 import           Test.Ouroboros.Storage.ImmutableDB.TestBlock hiding (tests)
 import           Test.Ouroboros.Storage.Util (collects, tryImmDB)
 
-import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Orphans.Arbitrary (genSmallSlotNo)
 import           Test.Util.RefEnv (RefEnv)
 import qualified Test.Util.RefEnv as RE
 
@@ -388,14 +388,14 @@ generateCmd Model {..} = At <$> frequency
     [ (1, GetBinaryBlob <$> frequency
             [ (if empty then 0 else 10, genSlotInThePast)
             , (1,  genSlotInTheFuture)
-            , (1,  arbitrary) ])
+            , (1,  genSmallSlotNo) ])
     , (3, do
-            slot <- arbitrary -- TODO can create many empty epochs
+            slot <- genSmallSlotNo -- TODO can create many empty epochs
             return $ AppendBinaryBlob slot (TestBlock slot))
     , (1, frequency
             -- An iterator with a random and likely invalid range,
-            [ (1, StreamBinaryBlobs <$> (Just <$> arbitrary)
-                                    <*> (Just <$> arbitrary))
+            [ (1, StreamBinaryBlobs <$> (Just <$> genSmallSlotNo)
+                                    <*> (Just <$> genSmallSlotNo))
             -- An iterator that is more likely to be valid.
             , (if empty then 0 else 2, do
                     start <- genSlotInThePast

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
@@ -23,6 +23,7 @@ import qualified Data.Map.Strict as M
 import           Data.Serialize
 import           Data.String (IsString (..))
 import           Data.Typeable
+import           Data.Word (Word64)
 
 import           System.Directory (getTemporaryDirectory)
 import qualified System.IO as IO
@@ -45,7 +46,7 @@ import           Ouroboros.Storage.ImmutableDB (ImmutableDBError (..),
 import qualified Ouroboros.Storage.ImmutableDB as Immutable
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
-import           Ouroboros.Storage.VolatileDB (Parser (..), Slot (..),
+import           Ouroboros.Storage.VolatileDB (Parser (..), SlotNo (..),
                      VolatileDBError (..), sameVolatileDBError)
 import qualified Ouroboros.Storage.VolatileDB as Volatile
 
@@ -255,9 +256,9 @@ blobFromBS = MkBlob . BS.byteString
 instance IsString Blob where
     fromString = blobFromBS . C8.pack
 
-type MyBlockId = Word
+type MyBlockId = Word64
 
-type Block = (Word, Int)
+type Block = (Word64, Int)
 
 toBinary :: MyBlockId -> BL.ByteString
 toBinary = Binary.encode . toBlock
@@ -265,8 +266,8 @@ toBinary = Binary.encode . toBlock
 fromBinary :: BL.ByteString -> MyBlockId
 fromBinary = fromBlock . Binary.decode
 
-toSlot :: MyBlockId -> Slot
-toSlot = Slot
+toSlot :: MyBlockId -> SlotNo
+toSlot = SlotNo
 
 toBlock :: MyBlockId -> Block
 toBlock bid = (bid, 0)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -25,7 +25,7 @@ import           Ouroboros.Storage.VolatileDB.API
 data DBModel blockId = DBModel {
       open           :: Bool
     , mp             :: Map blockId ByteString
-    , latestGarbaged :: Maybe Slot
+    , latestGarbaged :: Maybe SlotNo
     } deriving (Show)
 
 initDBModel :: DBModel blockId
@@ -91,7 +91,7 @@ putBlockModel err sl bs = do
 
 garbageCollectModel :: MonadState (DBModel blockId) m
                     => ErrorHandling (VolatileDBError blockId) m
-                    -> Slot
+                    -> SlotNo
                     -> m ()
 garbageCollectModel err sl = do
     dbm@DBModel {..} <- get

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -95,8 +95,8 @@ instance Show (Model r) where
 deriving instance Show (ModelShow r)
 deriving instance Generic (DBModel MyBlockId)
 deriving instance Generic (ModelShow r)
-deriving instance Generic Slot
-deriving instance ToExpr Slot
+deriving instance Generic SlotNo
+deriving instance ToExpr SlotNo
 deriving instance ToExpr (DBModel MyBlockId)
 deriving instance ToExpr (ModelShow r)
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -95,7 +95,6 @@ instance Show (Model r) where
 deriving instance Show (ModelShow r)
 deriving instance Generic (DBModel MyBlockId)
 deriving instance Generic (ModelShow r)
-deriving instance Generic SlotNo
 deriving instance ToExpr SlotNo
 deriving instance ToExpr (DBModel MyBlockId)
 deriving instance ToExpr (ModelShow r)

--- a/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
@@ -7,6 +7,7 @@ module Test.Util.Orphans.Arbitrary () where
 
 import           Codec.Serialise (Serialise)
 import           Data.Time
+import           Data.Word (Word64)
 import           Test.QuickCheck hiding (Fixed (..))
 
 import           Ouroboros.Consensus.BlockchainTime
@@ -19,8 +20,8 @@ import           Ouroboros.Consensus.Util.Random (Seed (..), withSeed)
 
 import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes (EpochSlot (..),
                      RelativeSlot (..))
-import           Ouroboros.Storage.ImmutableDB.Types (Epoch (..),
-                     EpochSize (..), Slot (..))
+import           Ouroboros.Storage.ImmutableDB.Types (EpochNo (..),
+                     EpochSize (..), SlotNo (..))
 
 
 minNumCoreNodes, minNumSlots :: Int
@@ -61,11 +62,11 @@ instance Arbitrary FixedUTC where
 instance Arbitrary SlotLength where
   arbitrary = slotLengthFromMillisec <$> choose (1, 20 * 1_000)
 
-deriving via FixedUTC      instance Arbitrary SystemStart
-deriving via Positive Word instance Arbitrary Slot
-deriving via Word          instance Arbitrary Epoch
-deriving via Positive Word instance Arbitrary EpochSize
-deriving via Word          instance Arbitrary RelativeSlot
+deriving via FixedUTC        instance Arbitrary SystemStart
+deriving via Positive Word64 instance Arbitrary SlotNo
+deriving via Word64          instance Arbitrary EpochNo
+deriving via Positive Word64 instance Arbitrary EpochSize
+deriving via Word64          instance Arbitrary RelativeSlot
 
 instance Arbitrary EpochSlot where
   arbitrary = EpochSlot <$> arbitrary <*> arbitrary

--- a/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
@@ -81,7 +81,7 @@ instance Arbitrary Seed where
     arbitrary = do  (\w1 w2 w3 w4 w5 -> Seed (w1, w2, w3, w4, w5))
                 <$> gen <*> gen <*> gen <*> gen <*> gen
       where
-        gen = getLarge <$> arbitrary
+        gen = arbitraryBoundedIntegral
 
     shrink = const []
 

--- a/ouroboros-network/src/Ouroboros/Network/Chain.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Chain.hs
@@ -25,7 +25,7 @@ module Ouroboros.Network.Chain (
   -- ** Genesis
   genesis,
   genesisPoint,
-  genesisSlot,
+  genesisSlotNo,
 --  genesisHash, -- TODO: currently (temporarily) exported by HasHeader
   genesisBlockNo,
 
@@ -101,14 +101,14 @@ prettyPrintChain nl ppBlock = foldChain (\s b -> s ++ nl ++ "    " ++ ppBlock b)
 -- Points on blockchains
 --
 
--- | A point on the chain is identified by its 'Slot' and 'HeaderHash'.
+-- | A point on the chain is identified by its 'SlotNo' and 'HeaderHash'.
 --
--- The 'Slot' tells us where to look and the 'HeaderHash' either simply serves
+-- The 'SlotNo' tells us where to look and the 'HeaderHash' either simply serves
 -- as a check, or in some contexts it disambiguates blocks from different forks
 -- that were in the same slot.
 --
 data Point block = Point {
-       pointSlot :: Slot,
+       pointSlot :: SlotNo,
        pointHash :: Hash block
      }
    deriving (Eq, Ord, Show)
@@ -123,14 +123,14 @@ blockPoint b =
 genesis :: Chain b
 genesis = Genesis
 
-genesisSlot :: Slot
-genesisSlot = Slot 0
+genesisSlotNo :: SlotNo
+genesisSlotNo = SlotNo 0
 
 genesisBlockNo :: BlockNo
 genesisBlockNo = BlockNo 0
 
 genesisPoint :: Point block
-genesisPoint = Point genesisSlot GenesisHash
+genesisPoint = Point genesisSlotNo GenesisHash
 
 valid :: HasHeader block => Chain block -> Bool
 valid Genesis  = True
@@ -150,7 +150,7 @@ headPoint :: HasHeader block => Chain block -> Point block
 headPoint Genesis  = genesisPoint
 headPoint (_ :> b) = blockPoint b
 
-headSlot :: HasHeader block => Chain block -> Slot
+headSlot :: HasHeader block => Chain block -> SlotNo
 headSlot = pointSlot . headPoint
 
 headHash :: HasHeader block => Chain block -> Hash block
@@ -228,7 +228,7 @@ selectChain c1 c2 =
 lookupBySlot
   :: HasHeader block
   => Chain block
-  -> Slot
+  -> SlotNo
   -> Maybe block
 lookupBySlot Genesis _slot = Nothing
 lookupBySlot (c :> b) slot | blockSlot b == slot = Just b

--- a/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
@@ -99,7 +99,7 @@ import           Ouroboros.Network.Chain (Point(..), blockPoint, ChainUpdate(..)
 -- since @minBound \@Word == 0@.
 --
 -- A fragment is represented by a finger tree for efficient searching based on
--- the 'Slot' (or 'Point') of a block.
+-- the 'SlotNo' (or 'Point') of a block.
 newtype ChainFragment block = ChainFragment (FingerTree BlockMeasure block)
   deriving (Show, Eq)
 
@@ -183,7 +183,7 @@ isValidSuccessorOf bSucc b =
 validExtension ::  HasHeader block => ChainFragment block -> block -> Bool
 validExtension c bSucc =
     blockInvariant bSucc
- && blockSlot bSucc /= Slot 0
+ && blockSlot bSucc /= SlotNo 0
  && case head c of
       Nothing -> True
       Just b  -> bSucc `isValidSuccessorOf` b
@@ -198,7 +198,7 @@ headPoint :: HasHeader block => ChainFragment block -> Maybe (Point block)
 headPoint = fmap blockPoint . head
 
 -- | \( O(1) \).
-headSlot :: HasHeader block => ChainFragment block -> Maybe Slot
+headSlot :: HasHeader block => ChainFragment block -> Maybe SlotNo
 headSlot = fmap pointSlot . headPoint
 
 -- | \( O(1) \).
@@ -278,7 +278,7 @@ rollback p c = fst <$> splitAfterPoint c p
 -- returns a 'FT.SearchResult'.
 lookupBySlotFT :: HasHeader block
                => ChainFragment block
-               -> Slot
+               -> SlotNo
                -> FT.SearchResult BlockMeasure block
 lookupBySlotFT (ChainFragment t) s =
     FT.search (\vl vr -> bmMaxSlot vl >= s && bmMinSlot vr >= s) t
@@ -287,7 +287,7 @@ lookupBySlotFT (ChainFragment t) s =
 -- with a slot equal to the given slot.
 lookupBySlot :: HasHeader block
              => ChainFragment block
-             -> Slot
+             -> SlotNo
              -> Maybe block
 lookupBySlot c s = case lookupBySlotFT c s of
   FT.Position _ b _ | blockSlot b == s -> Just b
@@ -367,7 +367,7 @@ successorBlock p c = case lookupBySlotFT c (pointSlot p) of
 -- (newest/rightmost) block on the first returned chain.
 splitAfterSlot :: HasHeader block
                => ChainFragment block
-               -> Slot
+               -> SlotNo
                -> (ChainFragment block, ChainFragment block)
 splitAfterSlot (ChainFragment t) s = (ChainFragment l, ChainFragment r)
   where
@@ -402,7 +402,7 @@ findFirstPoint
 findFirstPoint ps c = L.find (`pointOnChainFragment` c) ps
 
 -- | \( O(\log(\min(i,n-i)) \).
-slotOnChainFragment :: HasHeader block => Slot -> ChainFragment block -> Bool
+slotOnChainFragment :: HasHeader block => SlotNo -> ChainFragment block -> Bool
 slotOnChainFragment slot c = isJust (lookupBySlot c slot)
 
 -- | \( O(n) \). Specification of 'slotOnChainFragment'.
@@ -411,7 +411,7 @@ slotOnChainFragment slot c = isJust (lookupBySlot c slot)
 --
 -- This function is used to verify whether 'slotOnChainFragment' behaves as
 -- expected.
-slotOnChainFragmentSpec :: HasHeader block => Slot -> ChainFragment block -> Bool
+slotOnChainFragmentSpec :: HasHeader block => SlotNo -> ChainFragment block -> Bool
 slotOnChainFragmentSpec slot = go
   where
     -- Recursively search the fingertree from the right

--- a/ouroboros-network/src/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Node.hs
@@ -176,12 +176,12 @@ blockGenerator slotDuration chain = do
   void $ fork $ go var Nothing chain
   return (readTBQueue var)
  where
-  go :: TBQueue m (Maybe block) -> Maybe Slot -> [block] -> m ()
+  go :: TBQueue m (Maybe block) -> Maybe SlotNo -> [block] -> m ()
   go var _ [] = do
     atomically (writeTBQueue var Nothing)
   go var mslot (b : bs) = do
     let slot  = blockSlot b
-        delay = getSlot slot - maybe 0 getSlot mslot
+        delay = unSlotNo slot - maybe 0 unSlotNo mslot
     threadDelay (slotDuration * fromIntegral delay)
     atomically (writeTBQueue var (Just b))
     go var (Just slot) bs

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -30,15 +30,16 @@ module Ouroboros.Network.Testing.ConcreteBlock (
 import           Data.FingerTree (Measured(measure))
 import           Data.Hashable
 import qualified Data.Text as Text
+import           Data.Word (Word64)
 import           Codec.Serialise (Serialise (..))
 import           Codec.CBOR.Encoding ( encodeListLen
                                      , encodeInt
-                                     , encodeWord
+                                     , encodeWord64
                                      , encodeString
                                      )
 import           Codec.CBOR.Decoding ( decodeListLenOf
                                      , decodeInt
-                                     , decodeWord
+                                     , decodeWord64
                                      , decodeString
                                      )
 
@@ -73,7 +74,7 @@ hashBody (BlockBody b) = BodyHash (hash b)
 data BlockHeader = BlockHeader {
        headerHash     :: HeaderHash BlockHeader,  -- ^ The cached 'HeaderHash' of this header.
        headerPrevHash :: Hash BlockHeader,        -- ^ The 'headerHash' of the previous block header
-       headerSlot     :: Slot,                    -- ^ The Ouroboros time slot index of this block
+       headerSlot     :: SlotNo,                    -- ^ The Ouroboros time slot index of this block
        headerBlockNo  :: BlockNo,                 -- ^ The block index from the Genesis
        headerSigner   :: BlockSigner,             -- ^ Who signed this block
        headerBodyHash :: BodyHash                 -- ^ The hash of the corresponding block body
@@ -88,7 +89,7 @@ data BlockHeader = BlockHeader {
 --
 -- TODO: This can probably go, the network layer does not need to worry
 -- about signatures.
-newtype BlockSigner = BlockSigner Word
+newtype BlockSigner = BlockSigner Word64
   deriving (Show, Eq, Ord, Hashable)
 
 -- | Compute the 'HeaderHash' of the 'BlockHeader'.
@@ -234,7 +235,7 @@ instance Serialise BlockHeader where
   encode BlockHeader {
          headerHash     = headerHash,
          headerPrevHash = headerPrevHash,
-         headerSlot     = Slot headerSlot,
+         headerSlot     = SlotNo headerSlot,
          headerBlockNo  = BlockNo headerBlockNo,
          headerSigner   = BlockSigner headerSigner,
          headerBodyHash = BodyHash headerBodyHash
@@ -242,18 +243,18 @@ instance Serialise BlockHeader where
       encodeListLen 6
    <> encode     headerHash
    <> encode     headerPrevHash
-   <> encodeWord headerSlot
-   <> encodeWord headerBlockNo
-   <> encodeWord headerSigner
+   <> encodeWord64 headerSlot
+   <> encodeWord64 headerBlockNo
+   <> encodeWord64 headerSigner
    <> encodeInt  headerBodyHash
 
   decode = do
       decodeListLenOf 6
       BlockHeader <$> decode
                   <*> decode
-                  <*> (Slot <$> decodeWord)
-                  <*> (BlockNo <$> decodeWord)
-                  <*> (BlockSigner <$> decodeWord)
+                  <*> (SlotNo <$> decodeWord64)
+                  <*> (BlockNo <$> decodeWord64)
+                  <*> (BlockSigner <$> decodeWord64)
                   <*> (BodyHash <$> decodeInt)
 
 instance Serialise BlockBody where

--- a/ouroboros-network/test/Test/ChainFragment.hs
+++ b/ouroboros-network/test/Test/ChainFragment.hs
@@ -227,7 +227,7 @@ prop_splitAfterSlot_slots (TestChainFragmentAndPoint c p) =
     let (l, r) = CF.splitAfterSlot c (pointSlot p)
     in all (<= pointSlot p) (slots l) && all (>  pointSlot p) (slots r)
   where
-    slots :: ChainFragment Block -> [Slot]
+    slots :: ChainFragment Block -> [SlotNo]
     slots = map blockSlot . CF.toOldestFirst
 
 prop_splitAfterPoint_join :: TestChainFragmentAndPoint -> Property
@@ -254,14 +254,14 @@ prop_splitAfterPoint_slots (TestChainFragmentAndPoint c p) =
                 && all (>  pointSlot p) (slots r)
     Nothing     -> not (CF.pointOnChainFragment p c)
   where
-    slots :: ChainFragment Block -> [Slot]
+    slots :: ChainFragment Block -> [SlotNo]
     slots = map blockSlot . CF.toOldestFirst
 
 prop_foldChainFragment :: TestBlockChainFragment -> Property
 prop_foldChainFragment (TestBlockChainFragment c) =
     CF.foldChainFragment f [] c === CF.foldChainFragmentSpec f [] c
   where
-    f l block = getSlot (blockSlot block) : l
+    f l block = unSlotNo (blockSlot block) : l
 
 prop_lookupByIndexFromEnd :: TestChainFragmentAndIndex -> Property
 prop_lookupByIndexFromEnd (TestChainFragmentAndIndex c i) =
@@ -335,10 +335,10 @@ genBlockChainFragment n = do
     slots  <- mkSlots <$> vectorOf n genSlotGap
     return (mkChainFragment slots bodies)
   where
-    mkSlots :: [Int] -> [Slot]
+    mkSlots :: [Int] -> [SlotNo]
     mkSlots = map toEnum . tail . scanl (+) 0
 
-    mkChainFragment :: [Slot] -> [BlockBody] -> ChainFragment Block
+    mkChainFragment :: [SlotNo] -> [BlockBody] -> ChainFragment Block
     mkChainFragment slots bodies =
         fromListFixupBlocks
       . reverse
@@ -396,7 +396,7 @@ genAddBlock chain = do
     slotGap <- genSlotGap
     body    <- getArbitraryBlockBody <$> arbitrary
     let pb = mkPartialBlock (addSlotGap slotGap
-                                        (fromMaybe (Slot 0) $ CF.headSlot chain))
+                                        (fromMaybe (SlotNo 0) $ CF.headSlot chain))
                                         body
         b  = fixupBlockCF chain pb
     return b

--- a/ouroboros-network/test/Test/ChainGenerators.hs
+++ b/ouroboros-network/test/Test/ChainGenerators.hs
@@ -13,7 +13,7 @@ module Test.ChainGenerators
     -- These generators are used to test various scenarios that require
     -- a chain: e.g. appending a block to chain, arbitrary updates
     -- (rollforwards \/ backwards), chain forks.
-  , TestAddBlock (..) 
+  , TestAddBlock (..)
   , TestBlockChainAndUpdates (..)
   , TestBlockChain (..)
   , TestHeaderChain (..)
@@ -40,7 +40,7 @@ import qualified Data.List as L
 import           Data.Maybe (fromJust, catMaybes)
 
 import           Ouroboros.Network.Testing.ConcreteBlock
-import           Ouroboros.Network.Block (Slot (..), Hash (..) , HasHeader (..))
+import           Ouroboros.Network.Block (SlotNo (..), Hash (..) , HasHeader (..))
 import           Ouroboros.Network.Chain (Chain (..), ChainUpdate (..), Point (..))
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.Protocol.BlockFetch.Type (ChainRange (..))
@@ -97,7 +97,7 @@ newtype ArbitraryPoint = ArbitraryPoint {
 
 instance Arbitrary ArbitraryPoint where
   arbitrary = do
-    slot <- Slot <$> arbitrary
+    slot <- SlotNo <$> arbitrary
     hash <- HeaderHash <$> arbitrary
     return $ ArbitraryPoint $ Point slot (BlockHash hash)
 
@@ -140,10 +140,10 @@ genBlockChain n = do
     slots  <- mkSlots <$> vectorOf n genSlotGap
     return (mkChain slots bodies)
   where
-    mkSlots :: [Int] -> [Slot]
+    mkSlots :: [Int] -> [SlotNo]
     mkSlots = map toEnum . tail . scanl (+) 0
 
-    mkChain :: [Slot] -> [BlockBody] -> Chain Block
+    mkChain :: [SlotNo] -> [BlockBody] -> Chain Block
     mkChain slots bodies =
         fromListFixupBlocks
       . reverse
@@ -152,13 +152,13 @@ genBlockChain n = do
 genSlotGap :: Gen Int
 genSlotGap = frequency [(25, pure 1), (5, pure 2), (1, pure 3)]
 
-addSlotGap :: Int -> Slot -> Slot
-addSlotGap g (Slot n) = Slot (n + fromIntegral g)
+addSlotGap :: Int -> SlotNo -> SlotNo
+addSlotGap g (SlotNo n) = SlotNo (n + fromIntegral g)
 
 genHeaderChain :: Int -> Gen (Chain BlockHeader)
 genHeaderChain = fmap (fmap blockHeader) . genBlockChain
 
-mkPartialBlock :: Slot -> BlockBody -> Block
+mkPartialBlock :: SlotNo -> BlockBody -> Block
 mkPartialBlock sl body =
     Block {
       blockHeader = BlockHeader {
@@ -174,8 +174,8 @@ mkPartialBlock sl body =
   where
     partialField n = error ("mkPartialBlock: you didn't fill in field " ++ n)
 
-    expectedBFTSigner :: Slot -> BlockSigner
-    expectedBFTSigner (Slot n) = BlockSigner (n `mod` 7)
+    expectedBFTSigner :: SlotNo -> BlockSigner
+    expectedBFTSigner (SlotNo n) = BlockSigner (n `mod` 7)
 
 
 -- | To help with chain construction and shrinking it's handy to recalculate
@@ -418,7 +418,7 @@ genPointOnChain chain =
     len = Chain.length chain
 
 genPoint :: Gen (Point Block)
-genPoint = (\s h -> Point (Slot s) (BlockHash (HeaderHash h))) <$> arbitrary <*> arbitrary
+genPoint = (\s h -> Point (SlotNo s) (BlockHash (HeaderHash h))) <$> arbitrary <*> arbitrary
 
 fixupPoint :: HasHeader block => Chain block -> Point block -> Point block
 fixupPoint c p =

--- a/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
@@ -82,7 +82,7 @@ test_blockGenerator chain slotDuration = isValid <$> withProbe (experiment slotD
   where
     isValid :: [(Time m, Block)] -> Property
     isValid = foldl'
-        (\r (t, b) -> r .&&. t === fromStart ((fromIntegral . getSlot . blockSlot $ b) `mult` slotDuration))
+        (\r (t, b) -> r .&&. t === fromStart ((fromIntegral . unSlotNo . blockSlot $ b) `mult` slotDuration))
         (property True)
 
     experiment


### PR DESCRIPTION
Changes include:
* Rename `Slot` to `SlotNo` and `Epoch` to `EpochNo` to match `BlockNo`.
* Switch from `Word` to `Word64` (chain uses `Word64` nearly everywhere).
* Regularize `newtype` field accessor names (for type `X` use `unX`).
* Remove derived `Real` and `Integral` instances which can easily be misused.