### PR TITLE
[no-119 (iohk-monitoring)] Use basic-tracer for byron-proxy.

### DIFF
--- a/.stack-to-nix.cache
+++ b/.stack-to-nix.cache
@@ -66,3 +66,5 @@ https://github.com/input-output-hk/haskell-hedgehog e63fb354bfbad07f3befdd43b382
 https://github.com/input-output-hk/log-warper 16246d4fbf16da7984f2a4b6c42f2ed5098182e4 . 11vw6h3lshhwrjbxni6z0jr6w9x2x338rv6p2b4b0rgr650pv2a9 log-warper .stack.nix/log-warper.nix
 https://github.com/input-output-hk/iohk-monitoring-framework 6c9ff80285b29f9f92a03f7372c049bb77ace522 iohk-monitoring 1s6fnz959crbapvzabdlsl9wq70dyqdp5sdwl3b0mqdwpmdw7wwm iohk-monitoring .stack.nix/iohk-monitoring.nix
 https://github.com/input-output-hk/iohk-monitoring-framework 6c9ff80285b29f9f92a03f7372c049bb77ace522 basic-tracer 1s6fnz959crbapvzabdlsl9wq70dyqdp5sdwl3b0mqdwpmdw7wwm basic-tracer .stack.nix/basic-tracer.nix
+https://github.com/input-output-hk/iohk-monitoring-framework 0c31ff69e28b8a955a5147c03cd9471307b3f349 iohk-monitoring 0r9rscjary8d6lksafqkd4x18j8814hdwcxpxydzadix63kxsnjs iohk-monitoring .stack.nix/iohk-monitoring.nix
+https://github.com/input-output-hk/iohk-monitoring-framework 0c31ff69e28b8a955a5147c03cd9471307b3f349 basic-tracer 0r9rscjary8d6lksafqkd4x18j8814hdwcxpxydzadix63kxsnjs basic-tracer .stack.nix/basic-tracer.nix

--- a/.stack-to-nix.cache
+++ b/.stack-to-nix.cache
@@ -64,3 +64,5 @@ https://github.com/minad/writer-cps-transformers 971e29e0c77f5e47ad829f42ce465f2
 https://github.com/yihuang/log-warper 30642de93d32ee292b8a2e2172072d4a7e4553e2 . 0r4x3q258j4pvdxrahr9kv3shqyl6q9mkqh5z3sgb2gd95bpwgll log-warper .stack.nix/log-warper.nix
 https://github.com/input-output-hk/haskell-hedgehog e63fb354bfbad07f3befdd43b382c655944218be hedgehog 1p2yzlaiqj34pkk26cgg0dkvkm1zwjpgx1zk95md5xj0cijb34gj hedgehog .stack.nix/hedgehog.nix
 https://github.com/input-output-hk/log-warper 16246d4fbf16da7984f2a4b6c42f2ed5098182e4 . 11vw6h3lshhwrjbxni6z0jr6w9x2x338rv6p2b4b0rgr650pv2a9 log-warper .stack.nix/log-warper.nix
+https://github.com/input-output-hk/iohk-monitoring-framework 6c9ff80285b29f9f92a03f7372c049bb77ace522 iohk-monitoring 1s6fnz959crbapvzabdlsl9wq70dyqdp5sdwl3b0mqdwpmdw7wwm iohk-monitoring .stack.nix/iohk-monitoring.nix
+https://github.com/input-output-hk/iohk-monitoring-framework 6c9ff80285b29f9f92a03f7372c049bb77ace522 basic-tracer 1s6fnz959crbapvzabdlsl9wq70dyqdp5sdwl3b0mqdwpmdw7wwm basic-tracer .stack.nix/basic-tracer.nix

--- a/byron-proxy/byron-proxy.cabal
+++ b/byron-proxy/byron-proxy.cabal
@@ -61,6 +61,7 @@ executable byron-proxy
   -- other-extensions:
   build-depends:       base,
                        async,
+                       basic-tracer,
                        byron-proxy,
                        cardano-sl,
                        cardano-sl-binary,

--- a/byron-proxy/cabal.project
+++ b/byron-proxy/cabal.project
@@ -8,13 +8,13 @@ packages: byron-proxy.cabal
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 6c9ff80285b29f9f92a03f7372c049bb77ace522
+  tag: 0c31ff69e28b8a955a5147c03cd9471307b3f349
   subdir: iohk-monitoring
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 6c9ff80285b29f9f92a03f7372c049bb77ace522
+  tag: 0c31ff69e28b8a955a5147c03cd9471307b3f349
   subdir: basic-tracer
 
 --

--- a/byron-proxy/cabal.project
+++ b/byron-proxy/cabal.project
@@ -8,7 +8,14 @@ packages: byron-proxy.cabal
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 8456e488fd26e34f0d15c957965d6cc5c51427af
+  tag: 6c9ff80285b29f9f92a03f7372c049bb77ace522
+  subdir: iohk-monitoring
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/iohk-monitoring-framework
+  tag: 6c9ff80285b29f9f92a03f7372c049bb77ace522
+  subdir: basic-tracer
 
 --
 -- from cardano-crypto-1.2.0.nix

--- a/byron-proxy/src/exec/Main.hs
+++ b/byron-proxy/src/exec/Main.hs
@@ -149,23 +149,9 @@ convertSeverity sev = case sev of
   Wlog.Warning -> BM.Warning
   Wlog.Error   -> BM.Error
 
--- |
--- The iohk-monitoring-framework took the `Trace` type and renamed
--- it `Cardano.BM.BaseTrace.BaseTrace`. Then `Trace` is defined
--- to be `(TraceContext, BaseTrace m NamedLogItem)` where
--- `TraceContext` contains configuration stuff and a mysterious
--- `IO ()`.
---
--- The challenge: how to make the original `Trace` from this
--- thing, to give to the diffusion layer, in such a way that it
--- behaves as expected? What is the `TraceContext` for? Is it
--- needed? It seems all wrong: configuration for the `Trace`
--- should be kept _in its closure_ if need be rather than shown
--- up-front, and with a mention of `IO` to boot. Very poor
--- abstraction.
 convertTrace :: BM.Trace IO Text -> Trace IO (LogNamed (Wlog.Severity, Text))
 convertTrace trace = case trace of
-  (traceContext, Tracer (Op f)) -> Pos.Util.Trace.Trace $ Op $ \namedI -> do
+  Tracer (Op f) -> Pos.Util.Trace.Trace $ Op $ \namedI -> do
     tid <- pack . show <$> myThreadId
     now <- getCurrentTime
     let logName    = Text.intercalate (Text.pack ".") (Trace.lnName namedI)

--- a/nix/.stack-pkgs.nix
+++ b/nix/.stack-pkgs.nix
@@ -9,6 +9,7 @@
         "graphviz" = (((hackage.graphviz)."2999.20.0.3").revisions).default;
         "quickcheck-state-machine" = (((hackage.quickcheck-state-machine)."0.6.0").revisions).default;
         "transformers" = (((hackage.transformers)."0.5.5.0").revisions).default;
+        "libyaml" = (((hackage.libyaml)."0.1.0.0").revisions).default;
         "ekg-wai" = (((hackage.ekg-wai)."0.1.0.3").revisions).default;
         "pvss" = (((hackage.pvss)."0.2.0").revisions).default;
         "lrucache" = (((hackage.lrucache)."1.2.0.1").revisions).default;
@@ -39,6 +40,7 @@
         io-sim-classes = ./.stack.nix/io-sim-classes.nix;
         byron-proxy = ./.stack.nix/byron-proxy.nix;
         iohk-monitoring = ./.stack.nix/iohk-monitoring.nix;
+        basic-tracer = ./.stack.nix/basic-tracer.nix;
         writer-cps-mtl = ./.stack.nix/writer-cps-mtl.nix;
         writer-cps-transformers = ./.stack.nix/writer-cps-transformers.nix;
         canonical-json = ./.stack.nix/canonical-json.nix;

--- a/nix/.stack.nix/basic-tracer.nix
+++ b/nix/.stack.nix/basic-tracer.nix
@@ -1,0 +1,49 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "basic-tracer"; version = "0.1.0.0"; };
+      license = "MIT";
+      copyright = "2019 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "Neil Davies, Alexander Diemand, Andreas Triantafyllos";
+      homepage = "";
+      url = "";
+      synopsis = "tracing facility";
+      description = "";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.contravariant)
+          (hsPkgs.text)
+          ] ++ (if system.isWindows
+          then [ (hsPkgs.Win32) ]
+          else [ (hsPkgs.unix) ]);
+        };
+      tests = {
+        "tests" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.basic-tracer)
+            (hsPkgs.QuickCheck)
+            (hsPkgs.random)
+            (hsPkgs.tasty)
+            (hsPkgs.tasty-hunit)
+            (hsPkgs.tasty-quickcheck)
+            (hsPkgs.text)
+            ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/iohk-monitoring-framework";
+      rev = "6c9ff80285b29f9f92a03f7372c049bb77ace522";
+      sha256 = "1s6fnz959crbapvzabdlsl9wq70dyqdp5sdwl3b0mqdwpmdw7wwm";
+      });
+    postUnpack = "sourceRoot+=/basic-tracer; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/basic-tracer.nix
+++ b/nix/.stack.nix/basic-tracer.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "6c9ff80285b29f9f92a03f7372c049bb77ace522";
-      sha256 = "1s6fnz959crbapvzabdlsl9wq70dyqdp5sdwl3b0mqdwpmdw7wwm";
+      rev = "0c31ff69e28b8a955a5147c03cd9471307b3f349";
+      sha256 = "0r9rscjary8d6lksafqkd4x18j8814hdwcxpxydzadix63kxsnjs";
       });
     postUnpack = "sourceRoot+=/basic-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/byron-proxy.nix
+++ b/nix/.stack.nix/byron-proxy.nix
@@ -55,6 +55,7 @@
           depends = [
             (hsPkgs.base)
             (hsPkgs.async)
+            (hsPkgs.basic-tracer)
             (hsPkgs.byron-proxy)
             (hsPkgs.cardano-sl)
             (hsPkgs.cardano-sl-binary)

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -128,8 +128,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "6c9ff80285b29f9f92a03f7372c049bb77ace522";
-      sha256 = "1s6fnz959crbapvzabdlsl9wq70dyqdp5sdwl3b0mqdwpmdw7wwm";
+      rev = "0c31ff69e28b8a955a5147c03cd9471307b3f349";
+      sha256 = "0r9rscjary8d6lksafqkd4x18j8814hdwcxpxydzadix63kxsnjs";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -1,9 +1,15 @@
 { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = {};
+    flags = {
+      disable-aggregation = false;
+      disable-ekg = false;
+      disable-gui = false;
+      disable-monitoring = false;
+      disable-observables = false;
+      };
     package = {
       specVersion = "1.10";
-      identifier = { name = "iohk-monitoring"; version = "0.1.2.0"; };
+      identifier = { name = "iohk-monitoring"; version = "0.1.3.0"; };
       license = "MIT";
       copyright = "2018 IOHK";
       maintainer = "";
@@ -16,11 +22,13 @@
       };
     components = {
       "library" = {
-        depends = [
+        depends = (([
           (hsPkgs.base)
+          (hsPkgs.basic-tracer)
           (hsPkgs.aeson)
           (hsPkgs.array)
           (hsPkgs.async)
+          (hsPkgs.async-timer)
           (hsPkgs.attoparsec)
           (hsPkgs.auto-update)
           (hsPkgs.bytestring)
@@ -28,12 +36,11 @@
           (hsPkgs.containers)
           (hsPkgs.contravariant)
           (hsPkgs.directory)
-          (hsPkgs.ekg)
-          (hsPkgs.ekg-core)
           (hsPkgs.filepath)
           (hsPkgs.katip)
           (hsPkgs.lens)
           (hsPkgs.mtl)
+          (hsPkgs.safe)
           (hsPkgs.safe-exceptions)
           (hsPkgs.scientific)
           (hsPkgs.stm)
@@ -46,7 +53,10 @@
           (hsPkgs.vector)
           (hsPkgs.yaml)
           (hsPkgs.libyaml)
-          ] ++ (if system.isWindows
+          ] ++ (pkgs.lib).optionals (!flags.disable-ekg) [
+          (hsPkgs.ekg)
+          (hsPkgs.ekg-core)
+          ]) ++ (pkgs.lib).optional (!flags.disable-gui) (hsPkgs.threepenny-gui)) ++ (if system.isWindows
           then [ (hsPkgs.Win32) ]
           else [ (hsPkgs.unix) ]);
         };
@@ -82,6 +92,7 @@
         "tests" = {
           depends = [
             (hsPkgs.base)
+            (hsPkgs.basic-tracer)
             (hsPkgs.iohk-monitoring)
             (hsPkgs.aeson)
             (hsPkgs.array)
@@ -117,7 +128,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "8456e488fd26e34f0d15c957965d6cc5c51427af";
-      sha256 = "0d43rlpp543ig8chjpcd7nwwm5r1lxdyjras770yx1g26dxba340";
+      rev = "6c9ff80285b29f9f92a03f7372c049bb77ace522";
+      sha256 = "1s6fnz959crbapvzabdlsl9wq70dyqdp5sdwl3b0mqdwpmdw7wwm";
       });
+    postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,11 @@ extra-deps:
 - quickcheck-state-machine-0.6.0
 - transformers-0.5.5.0
 - git: https://github.com/input-output-hk/iohk-monitoring-framework
-  commit: 8456e488fd26e34f0d15c957965d6cc5c51427af
+  commit: 6c9ff80285b29f9f92a03f7372c049bb77ace522
+  subdirs:
+    - iohk-monitoring
+    - basic-tracer
+- libyaml-0.1.0.0
 
 # Cardano-sl dependencies:
 - ekg-wai-0.1.0.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@ extra-deps:
 - quickcheck-state-machine-0.6.0
 - transformers-0.5.5.0
 - git: https://github.com/input-output-hk/iohk-monitoring-framework
-  commit: 6c9ff80285b29f9f92a03f7372c049bb77ace522
+  commit: 0c31ff69e28b8a955a5147c03cd9471307b3f349
   subdirs:
     - iohk-monitoring
     - basic-tracer


### PR DESCRIPTION
Use an updated version of `iohk-monitoring` and the `basic-tracer` library.
Note: `TraceContext` is not yet removed from `iohk-monitoring`.