### PR TITLE
Encoding & Decoding of ControlMessages

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Mux/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Mux/Types.hs
@@ -58,15 +58,11 @@ instance Serialise NetworkMagic where
 
 data Version = Version0 !NetworkMagic -- Plain NodeToNode
              | Version1 !NetworkMagic -- NodeToClient
-             deriving (Eq, Ord)
+             deriving (Eq, Ord, Show)
 
 versionMagic :: Version -> NetworkMagic
 versionMagic (Version0 nm) = nm
 versionMagic (Version1 nm) = nm
-
-instance Show Version where
-    show (Version0 m) = printf "Version 0 NetworkMagic %d" $ unNetworkMagic m
-    show (Version1 m) = printf "Version 1 NetworkMagic %d" $ unNetworkMagic m
 
 instance Serialise Version where
     encode (Version0 m) = CBOR.encodeListLen 2 <> CBOR.encodeWord 0 <> encode m

--- a/ouroboros-network/test/Test/Mux/Control.hs
+++ b/ouroboros-network/test/Test/Mux/Control.hs
@@ -51,8 +51,8 @@ instance Arbitrary ControlMsg where
 prop_mux_encode_decode :: ControlMsg
                        -> Property
 prop_mux_encode_decode msg =
-    let bs = toLazyByteString $ encodeCtrlMsg msg
-        res_e = deserialiseFromBytes decodeCtrlMsg bs in
+    let bs = toLazyByteString $ encode msg
+        res_e = deserialiseFromBytes decode bs in
     case res_e of
          Left  _   -> property False
          Right res -> return msg === res
@@ -141,7 +141,7 @@ data ArbitraryControlMsgFT = ArbitraryControlMsgFT (Maybe ControlMsg) CBOR.FlatT
 --
 instance Arbitrary ArbitraryControlMsgFT where
     arbitrary = oneof
-        [ (\x -> ArbitraryControlMsgFT (Just x) (CBOR.toFlatTerm $ encodeCtrlMsg x)) <$> arbitrary
+        [ (\x -> ArbitraryControlMsgFT (Just x) (CBOR.toFlatTerm $ encode x)) <$> arbitrary
         , msgInitReq <$> listOf arbitrary
         ,  msgInitRsp <$> arbitrary
         , invalidControlMsgTag
@@ -169,7 +169,7 @@ instance Arbitrary ArbitraryControlMsgFT where
         msgInitRsp (ArbitraryVersionFT (Just v) _) =
           ArbitraryControlMsgFT
             (Just (MsgInitRsp v))
-            (CBOR.toFlatTerm $ encodeCtrlMsg (MsgInitRsp v))
+            (CBOR.toFlatTerm $ encode (MsgInitRsp v))
         msgInitRsp (ArbitraryVersionFT Nothing ts) =
           ArbitraryControlMsgFT
             Nothing
@@ -195,6 +195,6 @@ instance Arbitrary ArbitraryControlMsgFT where
 --
 prop_decode_ControlMsg :: ArbitraryControlMsgFT -> Property
 prop_decode_ControlMsg (ArbitraryControlMsgFT msg t) =
-  case CBOR.fromFlatTerm decodeCtrlMsg t of
+  case CBOR.fromFlatTerm decode t of
     Left _     -> property $ maybe True (const False) msg
     Right msg' -> msg === Just msg'

--- a/ouroboros-network/test/Test/Mux/Control.hs
+++ b/ouroboros-network/test/Test/Mux/Control.hs
@@ -41,7 +41,7 @@ instance Arbitrary ControlMsg where
         vs <- arbitrary
         v  <- arbitrary
         f  <- arbitrary
-        elements [ MsgInitReq (M.fromList $ map (\a -> (Mx.versionToVersionNumber a, a)) vs)
+        elements [ MsgInitReq vs
                  , MsgInitRsp v
                  , MsgInitFail f]
 
@@ -81,7 +81,7 @@ prop_unknown_version_req version len validVersion = version > 1 && len > 0 && le
         res = deserialiseFromBytes decodeCtrlMsg blob in
     case res of
          Left _ -> property False
-         Right (_, MsgInitReq resVersions) -> M.elems resVersions === [validVersion]
+         Right (_, MsgInitReq resVersions) -> resVersions === [validVersion]
          Right _  -> property False
   where
     enc =

--- a/ouroboros-network/test/Test/Mux/Control.hs
+++ b/ouroboros-network/test/Test/Mux/Control.hs
@@ -1,15 +1,18 @@
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Mux.Control (
       tests) where
 
-import           Codec.CBOR.Encoding (Encoding, encodeListLen, encodeWord)
-import           Codec.CBOR.Read (DeserialiseFailure (..), deserialiseFromBytes)
+import           Codec.CBOR.Read (deserialiseFromBytes)
 import           Codec.CBOR.Write (toLazyByteString)
+import qualified Codec.CBOR.FlatTerm as CBOR
 import           Codec.Serialise (Serialise (..))
-import           Control.Exception
-import           Data.Foldable (foldl')
-import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Char8 as BSC
+import           Data.Maybe (mapMaybe)
+import qualified Data.Text as T
 import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
@@ -20,10 +23,11 @@ import           Ouroboros.Network.Mux.Control
 tests :: TestTree
 tests =
   testGroup "MuxControl"
-  [ testProperty "MuxControl encode/decode"       prop_mux_encode_decode
-  , testProperty "MuxControl unknown version rsp" prop_unknown_version_rsp
-  , testProperty "MuxControl unknown version req" prop_unknown_version_req
-  , testProperty "MuxControl unknown message"     prop_unknown_version_key
+  [ testProperty "MuxControl encode/decode"      prop_mux_encode_decode
+  , testProperty "MuxControl decoding"           prop_decode_ControlMsg
+  , testGroup "generators"
+     [ testProperty "ArbitraryFlatTerm is valid" prop_ArbitraryFlatTerm
+     ]
   ]
 
 instance Arbitrary Mx.NetworkMagic where
@@ -53,60 +57,144 @@ prop_mux_encode_decode msg =
          Left  _   -> property False
          Right res -> return msg === res
 
--- | Verify error handling for MsgInitRsp with an invalid version.
-prop_unknown_version_rsp :: Word
-                         -> Word
-                         -> Property
-prop_unknown_version_rsp version len = version > 1 && len > 0 && len < 0xffff ==>
-    let blob = toLazyByteString $ invalidControlMessage 1 version len
-    in case deserialiseFromBytes decodeCtrlMsg blob of
-      Left (DeserialiseFailure _ err)
-        -> err === ("unknown version " ++ show version)
+data ArbitraryVersionFT = ArbitraryVersionFT (Maybe Mx.Version) CBOR.FlatTerm
+    deriving Show
 
-      _ -> property False
+instance Arbitrary ArbitraryVersionFT where
 
--- | Verify that unknown versions are skipped in MsgInitReq messages.
-prop_unknown_version_req :: Word
-                         -> Word
-                         -> Mx.Version
-                         -> Property
-prop_unknown_version_req version len validVersion = version > 1 && len > 0 && len < 0xffff ==>
-    let blob = toLazyByteString enc
-        res = deserialiseFromBytes decodeCtrlMsg blob in
-    case res of
-         Left _ -> property False
-         Right (_, MsgInitReq resVersions) -> resVersions === [validVersion]
-         Right _  -> property False
+  arbitrary = oneof
+      [ (\v -> ArbitraryVersionFT (Just v) (CBOR.toFlatTerm $ encode v)) <$> arbitrary
+      , toArbitraryVersionFT . unArbitraryFlatTerm <$> resize 10 arbitrary
+      ]
+    where
+      toArbitraryVersionFT :: CBOR.FlatTerm -> ArbitraryVersionFT
+      toArbitraryVersionFT t = ArbitraryVersionFT (toVersion t) t
+
+      -- We allow to encode a version as a list of length >= 2 with two first
+      -- fields as integers, either encoded as `TkInt` or `TkInteger`.
+      toVersion (CBOR.TkListLen n : CBOR.TkInt x : CBOR.TkInt y : _) | n >= 2 && y >= 0 = case x of
+        0 -> Just (Mx.Version0 (Mx.NetworkMagic (fromIntegral y)))
+        1 -> Just (Mx.Version1 (Mx.NetworkMagic (fromIntegral y)))
+        _ -> Nothing
+      toVersion (CBOR.TkListLen n : CBOR.TkInt x : CBOR.TkInteger y : _) | n >= 2 && y >= 0 = case x of
+        0 -> Just (Mx.Version0 (Mx.NetworkMagic (fromIntegral y)))
+        1 -> Just (Mx.Version1 (Mx.NetworkMagic (fromIntegral y)))
+        _ -> Nothing
+      toVersion (CBOR.TkListLen n : CBOR.TkInteger x : CBOR.TkInt y : _) | n >= 2 && y >= 0 = case x of
+        0 -> Just (Mx.Version0 (Mx.NetworkMagic (fromIntegral y)))
+        1 -> Just (Mx.Version1 (Mx.NetworkMagic (fromIntegral y)))
+        _ -> Nothing
+      toVersion (CBOR.TkListLen n : CBOR.TkInteger x : CBOR.TkInteger y : _) | n >= 2 && y >= 0 = case x of
+        0 -> Just (Mx.Version0 (Mx.NetworkMagic (fromIntegral y)))
+        1 -> Just (Mx.Version1 (Mx.NetworkMagic (fromIntegral y)))
+        _ -> Nothing
+      toVersion _ = Nothing
+
+-- |
+-- Generate arbitrary valid @'CBOR.FlatTerm'@.  It needs to be resized so it
+-- does not loop to deep.
+--
+genArbitraryFlatTerm :: Gen CBOR.FlatTerm
+genArbitraryFlatTerm = sized $ \s ->
+  let s' = if s > 0 then pred s else 0
+  in oneof
+    [ (:[]) . CBOR.TkInt <$> arbitrary
+    , (:[]) . CBOR.TkInteger <$> arbitrary
+    , (\x  -> [CBOR.TkBytesBegin, CBOR.TkBytes x, CBOR.TkBreak]) . BSC.pack <$> arbitrary
+    , (\x  -> [CBOR.TkStringBegin, CBOR.TkString x, CBOR.TkBreak]) . T.pack <$>  arbitrary
+    , (\xs -> CBOR.TkListLen (fromIntegral $ length xs) : concat xs) <$> (resize s' $ listOf genArbitraryFlatTerm)
+    , (\xs -> CBOR.TkListBegin : concat xs ++ [CBOR.TkBreak]) <$> (resize s' $ listOf genArbitraryFlatTerm)
+    , (\xs -> CBOR.TkMapLen (fromIntegral $ length xs) : concat xs) <$> (resize s' $ listOf genArbitraryPairs)
+    , (\xs -> CBOR.TkMapBegin : concat xs ++ [CBOR.TkBreak]) <$> (resize s' $ listOf genArbitraryPairs)
+    , (:[]) . CBOR.TkBool <$> arbitrary
+    ,  return [CBOR.TkNull]
+    , (:[]) . CBOR.TkSimple <$> arbitrary
+    , (:[]) . CBOR.TkFloat16 <$> arbitrary
+    , (:[]) . CBOR.TkFloat32 <$> arbitrary
+    , (:[]) . CBOR.TkFloat64 <$> arbitrary
+    ]
   where
-    enc =
-        let term = BL.replicate (fromIntegral len) 0xa in
-        encodeListLen 2 <> encodeWord 0 <> encodeListLen 2
-        <> foldl' (\b v -> b <> encode v)
-            -- unknown (or bad) encoding of a Version
-            (encode term)
-            [validVersion]
+    genArbitraryPairs :: Gen CBOR.FlatTerm
+    genArbitraryPairs = sized $ \s  ->
+      let s' = if s > 0 then pred s else 0
+      in (\x y -> x ++ y)
+          <$> resize s' genArbitraryFlatTerm
+          <*> resize s' genArbitraryFlatTerm
 
--- | Verify error handling for ControlMsg with invalid key.
-prop_unknown_version_key :: Word
-                         -> Word
-                         -> Property
-prop_unknown_version_key key len = key > 2 && len > 0 && len < 0xffff ==> ioProperty $ do
-    let blob = toLazyByteString $ invalidControlMessage key 1 len
+data ArbitraryFlatTerm = ArbitraryFlatTerm { unArbitraryFlatTerm :: CBOR.FlatTerm }
+    deriving Show
 
-    res <- try $ return $! deserialiseFromBytes decodeCtrlMsg blob
-    case res of
-         Left e  ->
-             case fromException e of
-                  Just me -> return $ Mx.errorType me == Mx.MuxControlUnknownMessage
-                  Nothing -> return False
+instance Arbitrary ArbitraryFlatTerm where
+    arbitrary = resize 10 $ ArbitraryFlatTerm <$> genArbitraryFlatTerm
+    -- TODO shrink
 
-         Right _ -> return False
+prop_ArbitraryFlatTerm :: ArbitraryFlatTerm -> Bool
+prop_ArbitraryFlatTerm (ArbitraryFlatTerm t) = CBOR.validFlatTerm t
 
--- | Encode an invalid Muxcontrol message with the key 'k', version number 'v' and 'len' bytes
--- of '0xa' dummy payload.
-invalidControlMessage :: Word -> Word -> Word -> Encoding
-invalidControlMessage k v len =
-    let term = BL.replicate (fromIntegral len) 0xa in
-    encodeListLen 2 <> encodeWord k <> encodeListLen 2 <> encode v <> encode term
+data ArbitraryControlMsgFT = ArbitraryControlMsgFT (Maybe ControlMsg) CBOR.FlatTerm
+    deriving Show
 
+-- |
+-- The arbitrary instance which generates a @'ControlMessage@' encoding (and
+-- possible message from which it was generated).  All the generated CBOR terms
+-- are valid; the generator will include unknown encodings of @'Mx.Version'@.
+--
+instance Arbitrary ArbitraryControlMsgFT where
+    arbitrary = oneof
+        [ (\x -> ArbitraryControlMsgFT (Just x) (CBOR.toFlatTerm $ encodeCtrlMsg x)) <$> arbitrary
+        , msgInitReq <$> listOf arbitrary
+        ,  msgInitRsp <$> arbitrary
+        , invalidControlMsgTag
+        ]
+      where
+        -- |
+        -- Generate @'MsgInitReq'@ with a list of versions which includes unknown
+        -- terms.
+        msgInitReq :: [ArbitraryVersionFT] -> ArbitraryControlMsgFT
+        msgInitReq xs =
+          let ts :: CBOR.FlatTerm
+              ts = concatMap (\(ArbitraryVersionFT _ t) -> t) xs 
+              vs :: [Mx.Version]
+              vs = mapMaybe (\(ArbitraryVersionFT v _) -> v) xs
+          in ArbitraryControlMsgFT
+            (Just (MsgInitReq vs))
+            (CBOR.TkListLen 2
+              : CBOR.TkInt 0
+              : CBOR.TkListLen (fromIntegral $ length xs)
+              : ts)
 
+        -- |
+        -- Generate @'MsgInitRsp'@ which includes unknown term.
+        msgInitRsp :: ArbitraryVersionFT -> (ArbitraryControlMsgFT)
+        msgInitRsp (ArbitraryVersionFT (Just v) _) =
+          ArbitraryControlMsgFT
+            (Just (MsgInitRsp v))
+            (CBOR.toFlatTerm $ encodeCtrlMsg (MsgInitRsp v))
+        msgInitRsp (ArbitraryVersionFT Nothing ts) =
+          ArbitraryControlMsgFT
+            Nothing
+            (CBOR.TkListLen 2
+              : CBOR.TkInt 1
+              : ts)
+
+        -- |
+        -- Generate @'ControlMessage'@ with an unknown tag, which includes
+        -- unknown terms.
+        invalidControlMsgTag :: Gen (ArbitraryControlMsgFT)
+        invalidControlMsgTag = do
+          NonNegative x <- arbitrary
+          (xs :: [CBOR.FlatTerm]) <- listOf (unArbitraryFlatTerm <$> arbitrary)
+          return $ ArbitraryControlMsgFT Nothing
+            (CBOR.TkListLen (fromIntegral $ (length xs) + 1)
+              : CBOR.TkInt (x + 2)
+              : concat xs)
+
+-- |
+-- Check that we can decode all version that we know ignoring version's that
+-- are unkown.
+--
+prop_decode_ControlMsg :: ArbitraryControlMsgFT -> Property
+prop_decode_ControlMsg (ArbitraryControlMsgFT msg t) =
+  case CBOR.fromFlatTerm decodeCtrlMsg t of
+    Left _     -> property $ maybe True (const False) msg
+    Right msg' -> msg === Just msg'


### PR DESCRIPTION
I changed the encoding of `MsgInitReq` to use lists, and I added generators to test that we can decode all versions that we accept.