### PR TITLE
ouroboros-network: Rename Hash to ChainHash

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock.hs
@@ -50,8 +50,7 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           GHC.Generics (Generic)
 
-import           Ouroboros.Network.Block hiding (Hash)
-import qualified Ouroboros.Network.Block as Network
+import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (Chain, toOldestFirst)
 
 import           Ouroboros.Consensus.Crypto.Hash.Class
@@ -197,7 +196,7 @@ deriving instance (SimpleBlockCrypto c, OuroborosTag p, Ord (Payload p (SimplePr
 -- (to wit, the pre header plus some ouroboros specific stuff but, crucially,
 -- without the signature itself).
 data SimplePreHeader p c = SimplePreHeader {
-      headerPrev     :: Network.Hash (SimpleHeader p c)
+      headerPrev     :: ChainHash (SimpleHeader p c)
     , headerSlot     :: SlotNo
     , headerBlockNo  :: BlockNo
     , headerBodyHash :: Hash (SimpleBlockHash c) SimpleBody
@@ -235,7 +234,7 @@ instance (SimpleBlockCrypto c, OuroborosTag p, Condense (Payload p (SimplePreHea
       , ")"
       ]
 
-condensedHash :: Show (HeaderHash b) => Network.Hash b -> String
+condensedHash :: Show (HeaderHash b) => ChainHash b -> String
 condensedHash GenesisHash     = "genesis"
 condensedHash (BlockHash hdr) = show hdr
 
@@ -262,7 +261,7 @@ instance (SimpleBlockCrypto c, OuroborosTag p, Serialise (Payload p (SimplePreHe
   blockHash      = blockHash . simpleHeader
   blockSlot      = blockSlot . simpleHeader
   blockNo        = blockNo   . simpleHeader
-  blockPrevHash  = Network.castHash . blockPrevHash . simpleHeader
+  blockPrevHash  = castHash . blockPrevHash . simpleHeader
 
   blockInvariant SimpleBlock{..} =
        blockInvariant simpleHeader
@@ -285,7 +284,7 @@ forgeBlock :: forall m p c.
            => NodeConfig p
            -> SlotNo                          -- ^ Current slot
            -> BlockNo                         -- ^ Current block number
-           -> Network.Hash (SimpleHeader p c) -- ^ Previous hash
+           -> ChainHash (SimpleHeader p c) -- ^ Previous hash
            -> Map (Hash ShortHash Tx) Tx      -- ^ Txs to add in the block
            -> IsLeader p
            -> m (SimpleBlock p c)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Chain.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Chain.hs
@@ -67,10 +67,10 @@ forksAtMostKBlocks k ours = go
         else go bs
 
     -- we can roll back at most k blocks
-    forkingPoints :: Set (Hash b)
+    forkingPoints :: Set (ChainHash b)
     forkingPoints = takeR (chainToSeq' ours) $ fromIntegral (k + 1)
 
-    chainToSeq' :: Chain b -> Seq (Hash b)
+    chainToSeq' :: Chain b -> Seq (ChainHash b)
     chainToSeq' c = GenesisHash :<| (BlockHash . blockHash <$> chainToSeq c)
 
     takeR :: Ord a => Seq a -> Int -> Set a

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
@@ -84,8 +84,8 @@ shortestLength = fromIntegral . minimum . map Chain.length . Map.elems
 data BlockInfo b = BlockInfo
     { biSlot     :: !SlotNo
     , biCreator  :: !(Maybe CoreNodeId)
-    , biHash     :: !(Hash b)
-    , biPrevious :: !(Maybe (Hash b))
+    , biHash     :: !(ChainHash b)
+    , biPrevious :: !(Maybe (ChainHash b))
     }
 
 genesisBlockInfo :: BlockInfo b
@@ -139,20 +139,20 @@ tracesToDot :: forall b. (HasHeader b, HasCreator b)
             -> String
 tracesToDot traces = Text.unpack $ printDotGraph $ graphToDot quickParams graph
   where
-    chainBlockInfos :: Chain b -> Map (Hash b) (BlockInfo b)
+    chainBlockInfos :: Chain b -> Map (ChainHash b) (BlockInfo b)
     chainBlockInfos = Chain.foldChain f (Map.singleton GenesisHash genesisBlockInfo)
       where
         f m b = let info = blockInfo b
                 in  Map.insert (biHash info) info m
 
-    blockInfos :: Map (Hash b) (BlockInfo b)
+    blockInfos :: Map (ChainHash b) (BlockInfo b)
     blockInfos = Map.unions $ map chainBlockInfos $ Map.elems traces
 
-    lastHash :: Chain b -> Hash b
+    lastHash :: Chain b -> ChainHash b
     lastHash Genesis  = GenesisHash
     lastHash (_ :> b) = BlockHash $ blockHash b
 
-    blockInfosAndBelievers :: Map (Hash b) (BlockInfo b, Set NodeId)
+    blockInfosAndBelievers :: Map (ChainHash b) (BlockInfo b, Set NodeId)
     blockInfosAndBelievers = Map.foldlWithKey f i traces
       where
         i = (\info -> (info, Set.empty)) <$> blockInfos
@@ -162,7 +162,7 @@ tracesToDot traces = Text.unpack $ printDotGraph $ graphToDot quickParams graph
             (lastHash chain)
             m
 
-    hashToId :: Map (Hash b) Node
+    hashToId :: Map (ChainHash b) Node
     hashToId = Map.fromList $ zip (Map.keys blockInfosAndBelievers) [0..]
 
     ns :: [LNode NodeLabel]

--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -14,7 +14,7 @@ module Ouroboros.Network.Block (
   , BlockNo(..)
   , HasHeader(..)
   , StandardHash
-  , Hash(..)
+  , ChainHash(..)
   , castHash
   , BlockMeasure(..)
   , blockMeasure
@@ -47,7 +47,7 @@ class (StandardHash b, Measured BlockMeasure b) => HasHeader b where
     type HeaderHash b :: *
 
     blockHash      :: b -> HeaderHash b
-    blockPrevHash  :: b -> Hash b
+    blockPrevHash  :: b -> ChainHash b
     blockSlot      :: b -> SlotNo
     blockNo        :: b -> BlockNo
 
@@ -62,7 +62,7 @@ blockMeasure b = BlockMeasure (blockSlot b) (blockSlot b) 1
 --
 -- Without this class we would need to write
 --
--- > deriving instance Eq (HeaderHash block) => Eq (Hash block)`
+-- > deriving instance Eq (HeaderHash block) => Eq (ChainHash block)`
 --
 -- That requires @UndecidableInstances@; not a problem by itself, but it also
 -- means that we can then not use @deriving Eq@ anywhere else for datatypes
@@ -82,12 +82,12 @@ class ( Eq        (HeaderHash b)
       , Serialise (HeaderHash b)
       ) => StandardHash b
 
-data Hash b = GenesisHash | BlockHash (HeaderHash b)
+data ChainHash b = GenesisHash | BlockHash (HeaderHash b)
   deriving (Generic)
 
-deriving instance StandardHash block => Eq   (Hash block)
-deriving instance StandardHash block => Ord  (Hash block)
-deriving instance StandardHash block => Show (Hash block)
+deriving instance StandardHash block => Eq   (ChainHash block)
+deriving instance StandardHash block => Ord  (ChainHash block)
+deriving instance StandardHash block => Show (ChainHash block)
 
 -- | 'Hashable' instance for 'Hash'
 --
@@ -95,11 +95,11 @@ deriving instance StandardHash block => Show (Hash block)
 -- only used in the network layer /tests/.
 --
 -- This requires @UndecidableInstances@ because @Hashable (HeaderHash b)@
--- is no smaller than @Hashable (Hash b)@.
-instance Hashable (HeaderHash b) => Hashable (Hash b) where
+-- is no smaller than @Hashable (ChainHash b)@.
+instance Hashable (HeaderHash b) => Hashable (ChainHash b) where
  -- use generic instance
 
-castHash :: HeaderHash b ~ HeaderHash b' => Hash b -> Hash b'
+castHash :: HeaderHash b ~ HeaderHash b' => ChainHash b -> ChainHash b'
 castHash GenesisHash   = GenesisHash
 castHash (BlockHash b) = BlockHash b
 
@@ -107,7 +107,7 @@ castHash (BlockHash b) = BlockHash b
   Serialisation
 -------------------------------------------------------------------------------}
 
-instance StandardHash b => Serialise (Hash b) where
+instance StandardHash b => Serialise (ChainHash b) where
   -- use the Generic instance
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-network/src/Ouroboros/Network/Chain.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Chain.hs
@@ -109,7 +109,7 @@ prettyPrintChain nl ppBlock = foldChain (\s b -> s ++ nl ++ "    " ++ ppBlock b)
 --
 data Point block = Point {
        pointSlot :: SlotNo,
-       pointHash :: Hash block
+       pointHash :: ChainHash block
      }
    deriving (Eq, Ord, Show)
 
@@ -153,7 +153,7 @@ headPoint (_ :> b) = blockPoint b
 headSlot :: HasHeader block => Chain block -> SlotNo
 headSlot = pointSlot . headPoint
 
-headHash :: HasHeader block => Chain block -> Hash block
+headHash :: HasHeader block => Chain block -> ChainHash block
 headHash = pointHash . headPoint
 
 headBlockNo :: HasHeader block => Chain block -> BlockNo

--- a/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
@@ -202,7 +202,7 @@ headSlot :: HasHeader block => ChainFragment block -> Maybe SlotNo
 headSlot = fmap pointSlot . headPoint
 
 -- | \( O(1) \).
-headHash :: HasHeader block => ChainFragment block -> Maybe (Hash block)
+headHash :: HasHeader block => ChainFragment block -> Maybe (ChainHash block)
 headHash = fmap pointHash . headPoint
 
 -- | \( O(1) \).

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -73,8 +73,8 @@ hashBody (BlockBody b) = BodyHash (hash b)
 --
 data BlockHeader = BlockHeader {
        headerHash     :: HeaderHash BlockHeader,  -- ^ The cached 'HeaderHash' of this header.
-       headerPrevHash :: Hash BlockHeader,        -- ^ The 'headerHash' of the previous block header
-       headerSlot     :: SlotNo,                    -- ^ The Ouroboros time slot index of this block
+       headerPrevHash :: ChainHash BlockHeader,   -- ^ The 'headerHash' of the previous block header
+       headerSlot     :: SlotNo,                  -- ^ The Ouroboros time slot index of this block
        headerBlockNo  :: BlockNo,                 -- ^ The block index from the Genesis
        headerSigner   :: BlockSigner,             -- ^ Who signed this block
        headerBodyHash :: BodyHash                 -- ^ The hash of the corresponding block body

--- a/ouroboros-network/test/Test/ChainGenerators.hs
+++ b/ouroboros-network/test/Test/ChainGenerators.hs
@@ -40,7 +40,7 @@ import qualified Data.List as L
 import           Data.Maybe (fromJust, catMaybes)
 
 import           Ouroboros.Network.Testing.ConcreteBlock
-import           Ouroboros.Network.Block (SlotNo (..), Hash (..) , HasHeader (..))
+import           Ouroboros.Network.Block (SlotNo (..), ChainHash (..) , HasHeader (..))
 import           Ouroboros.Network.Chain (Chain (..), ChainUpdate (..), Point (..))
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.Protocol.BlockFetch.Type (ChainRange (..))


### PR DESCRIPTION
The old name `Hash` was just a little too generic and clashes with too many other types during integration. The new name is also more descriptive.