### PR TITLE
QC utilities for working with SimM

### DIFF
--- a/nix/.stack.nix/ouroboros-network-testing.nix
+++ b/nix/.stack.nix/ouroboros-network-testing.nix
@@ -18,6 +18,7 @@
       "library" = {
         depends = [
           (hsPkgs.base)
+          (hsPkgs.io-sim)
           (hsPkgs.cborg)
           (hsPkgs.serialise)
           (hsPkgs.QuickCheck)

--- a/ouroboros-network-testing/ouroboros-network-testing.cabal
+++ b/ouroboros-network-testing/ouroboros-network-testing.cabal
@@ -3,7 +3,7 @@ version:             0.1.0.0
 synopsis:            Common modules used for testing in ouroboros-network and ouroboros-consensus
 license:             MIT
 license-file:        LICENSE
-author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts, Karl Knuttson 
+author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts, Karl Knuttson
 maintainer:
 copyright:           2018 IOHK
 category:            Network
@@ -22,6 +22,7 @@ library
   -- This has to be tidied up once the design becomes clear.
   exposed-modules:
                        Ouroboros.Network.Testing.Serialise
+                       Ouroboros.Network.Testing.QuickCheck
   default-language:    Haskell2010
   other-extensions:    BangPatterns,
                        DataKinds,
@@ -46,6 +47,7 @@ library
                        TypeFamilies,
                        TypeInType
   build-depends:       base              >=4.9 && <4.13,
+                       io-sim,
 
                        cborg             >=0.2.1 && <0.3,
                        serialise         >=0.2 && <0.3,

--- a/ouroboros-network-testing/src/Ouroboros/Network/Testing/QuickCheck.hs
+++ b/ouroboros-network-testing/src/Ouroboros/Network/Testing/QuickCheck.hs
@@ -20,7 +20,7 @@ runSimGen f = do
     Capture eval <- capture
     return $ runSimOrThrow (eval f)
 
--- | 'SimM; analogue of 'monadicST'
+-- | 'SimM' analogue of 'monadicST'
 --
 -- > monadicST  :: Testable a => (forall s. PropertyM (ST   s) a) -> Property
 -- > monadicSim :: Testable a => (forall s. PropertyM (SimM s) a) -> Property

--- a/ouroboros-network-testing/src/Ouroboros/Network/Testing/QuickCheck.hs
+++ b/ouroboros-network-testing/src/Ouroboros/Network/Testing/QuickCheck.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Ouroboros.Network.Testing.QuickCheck (
+    runSimGen
+  , monadicSim
+  ) where
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Gen.Unsafe (Capture (..), capture)
+import           Test.QuickCheck.Monadic
+
+import           Control.Monad.IOSim
+
+-- | 'SimM' analogue of 'runSTGen'
+--
+-- > runSTGen  :: (forall s. Gen (ST   s a)) -> Gen a
+-- > runSimGen :: (forall s. Gen (SimM s a)) -> Gen a
+runSimGen :: (forall s. Gen (SimM s a)) -> Gen a
+runSimGen f = do
+    Capture eval <- capture
+    return $ runSimOrThrow (eval f)
+
+-- | 'SimM; analogue of 'monadicST'
+--
+-- > monadicST  :: Testable a => (forall s. PropertyM (ST   s) a) -> Property
+-- > monadicSim :: Testable a => (forall s. PropertyM (SimM s) a) -> Property
+monadicSim :: Testable a => (forall s. PropertyM (SimM s) a) -> Property
+monadicSim m = property (runSimGen (monadic' m))


### PR DESCRIPTION
Some QuickCheck utilities to work with `SimM`, analogues of existing standard functions for working directly with `ST`. 