### PR TITLE
Minor cleanup of the imm DB, move some stuff to Common/

### DIFF
--- a/byron-proxy/src/lib/Ouroboros/Byron/Proxy/Index.hs
+++ b/byron-proxy/src/lib/Ouroboros/Byron/Proxy/Index.hs
@@ -18,7 +18,7 @@ import System.Directory (doesFileExist)
 import Pos.Chain.Block (HeaderHash)
 import Pos.Crypto.Hashing (AbstractHash (..))
 
-import Ouroboros.Storage.ImmutableDB.Types
+import Ouroboros.Storage.Common (EpochNo(..))
 
 -- | A point to read from the index. Looking up the tip gives its own hash,
 -- looking up anything by hash (could happen to be the tip) gives the hash

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -68,6 +68,7 @@ library
                        Ouroboros.Consensus.Util.STM
 
                        -- Storing things on disk
+                       Ouroboros.Storage.Common
                        Ouroboros.Storage.FS.API
                        Ouroboros.Storage.FS.API.Example
                        Ouroboros.Storage.FS.API.Types

--- a/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Ouroboros.Storage.Common (
+    -- * Epochs
+    EpochNo(..)
+  , EpochSize(..)
+    -- * File formats
+  , SlotOffset
+    -- * Indexing
+  , Tip(..)
+  , tipIsGenesis
+  ) where
+
+import           Codec.Serialise
+import           Data.Word
+import           GHC.Generics
+
+{-------------------------------------------------------------------------------
+  Epochs
+-------------------------------------------------------------------------------}
+
+-- | An epoch, i.e. the number of the epoch.
+newtype EpochNo = EpochNo { unEpochNo :: Word64 }
+  deriving (Eq, Ord, Enum, Num, Show, Generic)
+
+newtype EpochSize = EpochSize { unEpochSize :: Word64 }
+  deriving (Eq, Ord, Enum, Num, Show, Generic, Real, Integral)
+
+{-------------------------------------------------------------------------------
+  File formats
+-------------------------------------------------------------------------------}
+
+-- | The offset of a slot in an index file.
+type SlotOffset = Word64
+
+{-------------------------------------------------------------------------------
+  Indexing
+-------------------------------------------------------------------------------}
+
+-- | Tip of the chain
+data Tip r = Tip r | TipGen
+  deriving (Show, Eq, Generic)
+
+tipIsGenesis :: Tip r -> Bool
+tipIsGenesis TipGen  = True
+tipIsGenesis (Tip _) = False
+
+{-------------------------------------------------------------------------------
+  Serialization
+-------------------------------------------------------------------------------}
+
+instance (Serialise r) => Serialise (Tip r)
+  -- TODO: Don't use generic instance

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -23,6 +23,7 @@ import           GHC.Stack (HasCallStack)
 
 import           Pipes (Producer, lift, yield)
 
+import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.ImmutableDB.Types
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
 
@@ -102,7 +103,7 @@ data ImmutableDB hash m = ImmutableDB
     --
     -- Throws a 'ClosedDBError' if the database is closed.
   , deleteAfter
-      :: HasCallStack => Tip -> m ()
+      :: HasCallStack => ImmTip -> m ()
 
     -- | Return the tip of the database.
     --
@@ -111,7 +112,7 @@ data ImmutableDB hash m = ImmutableDB
     --
     -- Throws a 'ClosedDBError' if the database is closed.
   , getTip
-      :: HasCallStack => m Tip
+      :: HasCallStack => m ImmTip
 
     -- | Get the binary blob stored at the given 'SlotNo'.
     --

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
@@ -71,8 +71,7 @@ import           GHC.Generics (Generic)
 
 import           Ouroboros.Network.Block (SlotNo (..))
 
-import           Ouroboros.Storage.ImmutableDB.Types (EpochNo (..),
-                     EpochSize (EpochSize))
+import           Ouroboros.Storage.Common
 
 
 {------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
@@ -54,8 +54,8 @@ import           Ouroboros.Storage.FS.API (HasFS (..), withFile)
 import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes
                      (RelativeSlot (..))
 
-import           Ouroboros.Storage.ImmutableDB.Types (EpochNo, EpochSize,
-                     ImmutableDBError, SlotOffset,
+import           Ouroboros.Storage.Common
+import           Ouroboros.Storage.ImmutableDB.Types (ImmutableDBError,
                      UnexpectedError (DeserialisationError, InvalidFileError))
 import           Ouroboros.Storage.ImmutableDB.Util (readAll, renderFile,
                      throwUnexpectedError)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Util.hs
@@ -42,6 +42,7 @@ import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr (..),
                      readIncrementalOffsetsEBB)
 
+import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes (CumulEpochSizes,
@@ -148,7 +149,7 @@ validateIteratorRange
   :: Monad m
   => ErrorHandling ImmutableDBError m
   -> CumulEpochSizes
-  -> Tip
+  -> ImmTip
   -> Maybe (SlotNo, hash)  -- ^ range start (inclusive)
   -> Maybe (SlotNo, hash)  -- ^ range end (inclusive)
   -> m ()
@@ -168,9 +169,9 @@ validateIteratorRange err ces tip mbStart mbEnd = do
         throwUserError err $ ReadFutureSlotError end tip
   where
     isNewerThanTip slot = case tip of
-      TipGenesis           -> True
-      TipEBB     lastEpoch -> maybe True (slot >) $ CES.firstSlotOf ces lastEpoch
-      TipBlock   lastSlot  -> slot > lastSlot
+      TipGen                -> True
+      Tip (Left  lastEpoch) -> maybe True (slot >) $ CES.firstSlotOf ces lastEpoch
+      Tip (Right lastSlot)  -> slot > lastSlot
 
 
 -- | Given a list of increasing 'SlotOffset's together with the 'Word' (blob

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -57,6 +57,7 @@ import           GHC.Generics (Generic)
 
 import           Ouroboros.Consensus.Util
 
+import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.LedgerDB.Conf
 import           Ouroboros.Storage.LedgerDB.MemPolicy
 import           Ouroboros.Storage.LedgerDB.Offsets
@@ -77,14 +78,6 @@ data BlockInfo r b =
 {-------------------------------------------------------------------------------
   Chain summary
 -------------------------------------------------------------------------------}
-
--- | Tip of the chain
-data Tip r = Tip r | TipGen
-  deriving (Show, Eq, Generic)
-
-tipIsGenesis :: Tip r -> Bool
-tipIsGenesis TipGen  = True
-tipIsGenesis (Tip _) = False
 
 -- | Summary of the chain at a particular point in time
 data ChainSummary l r = ChainSummary {
@@ -437,7 +430,6 @@ snapshotsShape (Tail os _)   = go os
   TODO: We shouldn't use the 'Generic' instances here
 -------------------------------------------------------------------------------}
 
-instance (Serialise r)              => Serialise (Tip r)
 instance (Serialise r, Serialise l) => Serialise (ChainSummary l r)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -34,6 +34,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck (testProperty)
 
+import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.FS.Sim.FsTree (FsTree (..))
@@ -132,7 +133,7 @@ test_ReadFutureSlotErrorEquivalence =
 
 test_openDBEmptyIndexFileEquivalence :: Assertion
 test_openDBEmptyIndexFileEquivalence =
-    apiEquivalenceImmDB (expectImmDBResult (@?= TipGenesis)) $ \hasFS@HasFS{..} err -> do
+    apiEquivalenceImmDB (expectImmDBResult (@?= TipGen)) $ \hasFS@HasFS{..} err -> do
       -- Create an empty index file
       h1 <- hOpen ["epoch-000.dat"] IO.WriteMode
       h2 <- hOpen ["index-000.dat"] IO.WriteMode
@@ -143,7 +144,7 @@ test_openDBEmptyIndexFileEquivalence =
 
 test_reopenDBEquivalence :: Assertion
 test_reopenDBEquivalence =
-    apiEquivalenceImmDB (expectImmDBResult (@?= TipBlock 5)) $ \hasFS err -> do
+    apiEquivalenceImmDB (expectImmDBResult (@?= Tip (Right 5))) $ \hasFS err -> do
       withTestDB hasFS err $ \db ->
         appendBinaryBlob db 5 (testBlockToBuilder (TestBlock 5))
       withTestDB hasFS err $ \db ->

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/CumulEpochSizes.hs
@@ -11,10 +11,11 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 import           Ouroboros.Network.Block (SlotNo (..))
 
+import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes
-import           Ouroboros.Storage.ImmutableDB.Types
 
-import           Test.Util.Orphans.Arbitrary (genSmallEpochNo, genLimitedEpochSize)
+import           Test.Util.Orphans.Arbitrary (genLimitedEpochSize,
+                     genSmallEpochNo)
 
 
 instance Arbitrary CumulEpochSizes where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
@@ -47,6 +47,7 @@ import qualified Test.StateMachine.Utils as QSM
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
+import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API (HasFS (..), withFile)
 import           Ouroboros.Storage.FS.API.Types (FsPath)
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -260,7 +260,7 @@ knownLimitation model (At cmd) = case cmd of
     ReOpen -> Bot
     AskIfMember bids -> exists ((\b -> isLimitation (latestGarbaged $ dbModel model) (toSlot b)) <$> bids) Boolean
     where
-        isLimitation :: (Show slot, Ord slot) => Maybe slot -> slot -> Bool
+        isLimitation :: (Ord slot) => Maybe slot -> slot -> Bool
         isLimitation Nothing _sl       = False
         isLimitation (Just slot') slot = slot' >  slot
 

--- a/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
@@ -15,6 +15,8 @@ import           Data.Time
 import           Data.Word (Word64)
 import           Test.QuickCheck hiding (Fixed (..))
 
+import           Ouroboros.Network.Block (SlotNo (..))
+
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Crypto.DSIGN.Class (DSIGNAlgorithm (..))
 import           Ouroboros.Consensus.Crypto.Hash.Class (Hash,
@@ -25,8 +27,8 @@ import           Ouroboros.Consensus.Util.Random (Seed (..), withSeed)
 
 import           Ouroboros.Storage.ImmutableDB.CumulEpochSizes (EpochSlot (..),
                      RelativeSlot (..))
-import           Ouroboros.Storage.ImmutableDB.Types (EpochNo (..),
-                     EpochSize (..), SlotNo (..))
+import           Ouroboros.Storage.Common (EpochNo (..),
+                     EpochSize (..))
 
 
 minNumCoreNodes, minNumSlots :: Int


### PR DESCRIPTION
The imm DB was asking for an encoder of _maybe_ a hash, which was a bit confusing. It should be the responsibility of the imm DB itself to make the distinction between having an EBB and not, and choosing an appropriate encoding. This also moves some types to `Ouroboros.Storage.Common`, and unifies the `Tip` data structure used in the ledger DB and the immutable DB.

@avieth , the changes to the Byron proxy are merely to update it for these changes; I _think_ they are straight-forward, but let me know if I did something stupid.