### PR TITLE
Replace Duration with concrete type DiffTime

### DIFF
--- a/io-sim-classes/io-sim-classes.cabal
+++ b/io-sim-classes/io-sim-classes.cabal
@@ -28,6 +28,7 @@ library
                        Control.Monad.Class.MonadST
                        Control.Monad.Class.MonadSTM
                        Control.Monad.Class.MonadThrow
+                       Control.Monad.Class.MonadTime
                        Control.Monad.Class.MonadTimer
   default-language:    Haskell2010
   other-extensions:    CPP

--- a/io-sim-classes/io-sim-classes.cabal
+++ b/io-sim-classes/io-sim-classes.cabal
@@ -41,10 +41,11 @@ library
                        ScopedTypeVariables
                        RankNTypes
   build-depends:       base  >=4.9 && <4.13,
+                       async >=2.1,
+                       bytestring,
                        mtl   >=2.2 && <2.3,
                        stm   >=2.4 && <2.6,
-                       async >=2.1,
-                       bytestring
+                       time  >=1.6 && <1.10
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts

--- a/io-sim-classes/src/Control/Monad/Class/MonadTime.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTime.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Control.Monad.Class.MonadTime (
+    MonadTime(..)
+  , TimeMeasure(..)
+
+    -- * Duration type
+  , Duration
+  , secondsDuration
+  , microsecondsDuration
+  , durationSeconds
+  , durationMicroseconds
+  , multiplyDuration
+  ) where
+
+import           Data.Int (Int64)
+import           Data.Word (Word64)
+import           Data.Fixed as Fixed (Fixed(MkFixed), Micro)
+
+
+-- | Time duration, with microsecond precision.
+--
+-- This is a vector in time so it can represent negative as well as positive
+-- durations. This is useful for measuring the time between two events.
+--
+-- Construct using 'fromIntegral' and 'fromRational' in units of seconds. Use
+-- 'microsecondsDuration' to create from microseconds.
+--
+-- Use 'Num' and 'Fractional' operations, and 'toRational', 'durationSeconds'
+-- and 'durationMicroseconds' to convert.
+--
+newtype Duration = Duration Fixed.Micro
+  deriving (Eq, Ord, Show, Num, Fractional)
+
+-- | A duration in seconds, with microsecond precision.
+durationSeconds :: Duration -> Fixed.Micro
+durationSeconds (Duration micro) = micro
+
+-- | A duration in microseconds.
+durationMicroseconds :: Duration -> Int64
+durationMicroseconds (Duration (MkFixed micro)) = fromIntegral micro
+
+-- | Make a duration given a value in seconds, with microsecond precision.
+secondsDuration :: Fixed.Micro -> Duration
+secondsDuration = Duration
+
+-- | Make a duration given a value in microseconds.
+microsecondsDuration :: Int64 -> Duration
+microsecondsDuration = Duration . MkFixed . fromIntegral
+
+multiplyDuration :: Real a => a -> Duration -> Duration
+multiplyDuration a (Duration d) = Duration (realToFrac a * d)
+
+
+-- | A type that represents points in time. The operations
+--
+class Ord t => TimeMeasure t where
+
+  -- | The time duration between two points in time (positive or negative).
+  diffTime  :: t -> t -> Duration
+
+  -- | Add a duration to a point in time, giving another time.
+  addTime   :: Duration -> t -> t
+
+  -- | The time epoch where points in time are measured relative to.
+  --
+  -- For example POSIX time is relative to 1970-01-01 00:00 UTC. For a
+  -- monotonic clock this would be an arbitrary point, not related to any
+  -- wall clock time.
+  --
+  zeroTime  :: t
+
+class (Monad m, TimeMeasure (Time m)) => MonadTime m where
+  type Time m :: *
+
+  getMonotonicTime :: m (Time m)
+
+
+--
+-- Instances for IO
+--
+
+-- | Time in a monotonic clock, with microsecond precision. The epoch for this
+-- clock is arbitrary and does not correspond to any wall clock or calendar.
+--
+newtype MonotonicTimeIO = MonotonicTimeIO Int64
+  deriving (Eq, Ord, Show)
+
+instance TimeMeasure MonotonicTimeIO where
+  diffTime (MonotonicTimeIO t) (MonotonicTimeIO t') =
+    microsecondsDuration (t - t')
+
+  addTime d (MonotonicTimeIO t) =
+    MonotonicTimeIO (t + durationMicroseconds d)
+
+  zeroTime = MonotonicTimeIO 0
+
+instance MonadTime IO where
+  type Time IO = MonotonicTimeIO
+  getMonotonicTime = fmap (MonotonicTimeIO . fromIntegral . (`div` 1000))
+                          getMonotonicNSec
+
+foreign import ccall unsafe "getMonotonicNSec"
+    getMonotonicNSec :: IO Word64
+

--- a/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
@@ -1,21 +1,9 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE DefaultSignatures          #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Control.Monad.Class.MonadTimer (
-    MonadTime(..)
-  , MonadTimer(..)
+    MonadTimer(..)
   , TimeoutState(..)
-  , TimeMeasure(..)
-
-    -- * Duration type
-  , Duration
-  , secondsDuration
-  , microsecondsDuration
-  , durationSeconds
-  , durationMicroseconds
-  , multiplyDuration
   ) where
 
 import qualified Control.Concurrent as IO
@@ -24,76 +12,18 @@ import qualified Control.Monad.STM as STM
 import           Control.Exception (assert)
 import           Data.Functor (void)
 import           Data.Int (Int64)
-import           Data.Word (Word64)
-import           Data.Fixed as Fixed (Fixed(MkFixed), Micro)
 
 import qualified GHC.Event as GHC (TimeoutKey, getSystemTimerManager,
                      registerTimeout, unregisterTimeout, updateTimeout)
 
 import           Control.Monad.Class.MonadFork (MonadFork(..))
 import           Control.Monad.Class.MonadSTM
-
--- | Time duration, with microsecond precision.
---
--- This is a vector in time so it can represent negative as well as positive
--- durations. This is useful for measuring the time between two events.
---
--- Construct using 'fromIntegral' and 'fromRational' in units of seconds. Use
--- 'microsecondsDuration' to create from microseconds.
---
--- Use 'Num' and 'Fractional' operations, and 'toRational', 'durationSeconds'
--- and 'durationMicroseconds' to convert.
---
-newtype Duration = Duration Fixed.Micro
-  deriving (Eq, Ord, Show, Num, Fractional)
-
--- | A duration in seconds, with microsecond precision.
-durationSeconds :: Duration -> Fixed.Micro
-durationSeconds (Duration micro) = micro
-
--- | A duration in microseconds.
-durationMicroseconds :: Duration -> Int64
-durationMicroseconds (Duration (MkFixed micro)) = fromIntegral micro
-
--- | Make a duration given a value in seconds, with microsecond precision.
-secondsDuration :: Fixed.Micro -> Duration
-secondsDuration = Duration
-
--- | Make a duration given a value in microseconds.
-microsecondsDuration :: Int64 -> Duration
-microsecondsDuration = Duration . MkFixed . fromIntegral
-
-multiplyDuration :: Real a => a -> Duration -> Duration
-multiplyDuration a (Duration d) = Duration (realToFrac a * d)
-
-
--- | A type that represents points in time. The operations
---
-class Ord t => TimeMeasure t where
-
-  -- | The time duration between two points in time (positive or negative).
-  diffTime  :: t -> t -> Duration
-
-  -- | Add a duration to a point in time, giving another time.
-  addTime   :: Duration -> t -> t
-
-  -- | The time epoch where points in time are measured relative to.
-  --
-  -- For example POSIX time is relative to 1970-01-01 00:00 UTC. For a
-  -- monotonic clock this would be an arbitrary point, not related to any
-  -- wall clock time.
-  --
-  zeroTime  :: t
-
-class (Monad m, TimeMeasure (Time m)) => MonadTime m where
-  type Time m :: *
-
-  getMonotonicTime :: m (Time m)
+import           Control.Monad.Class.MonadTime (Duration, durationMicroseconds)
 
 
 data TimeoutState = TimeoutPending | TimeoutFired | TimeoutCancelled
 
-class (MonadSTM m, MonadTime m) => MonadTimer m where
+class MonadSTM m => MonadTimer m where
   data Timeout m :: *
 
   -- | Create a new timeout which will fire at the given time duration in
@@ -159,32 +89,10 @@ class (MonadSTM m, MonadTime m) => MonadTimer m where
     _ <- fork $ atomically (awaitTimeout t >>= writeTVar v)
     return v
 
+
 --
 -- Instances for IO
 --
-
--- | Time in a monotonic clock, with microsecond precision. The epoch for this
--- clock is arbitrary and does not correspond to any wall clock or calendar.
---
-newtype MonotonicTimeIO = MonotonicTimeIO Int64
-  deriving (Eq, Ord, Show)
-
-instance TimeMeasure MonotonicTimeIO where
-  diffTime (MonotonicTimeIO t) (MonotonicTimeIO t') =
-    microsecondsDuration (t - t')
-
-  addTime d (MonotonicTimeIO t) =
-    MonotonicTimeIO (t + durationMicroseconds d)
-
-  zeroTime = MonotonicTimeIO 0
-
-instance MonadTime IO where
-  type Time IO = MonotonicTimeIO
-  getMonotonicTime = fmap (MonotonicTimeIO . fromIntegral . (`div` 1000))
-                          getMonotonicNSec
-
-foreign import ccall unsafe "getMonotonicNSec"
-    getMonotonicNSec :: IO Word64
 
 instance MonadTimer IO where
   data Timeout IO = TimeoutIO !(STM.TVar TimeoutState) !GHC.TimeoutKey

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -53,7 +53,8 @@ test-suite tests
                        io-sim-classes,
                        QuickCheck,
                        tasty,
-                       tasty-quickcheck
+                       tasty-quickcheck,
+                       time
 
   ghc-options:         -Wall
                        -fno-ignore-asserts

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -33,7 +33,7 @@ import           Data.OrdPSQ (OrdPSQ)
 import qualified Data.OrdPSQ as PSQ
 import qualified Data.List as List
 import           Data.Maybe (maybeToList)
-import           Data.Fixed (Micro)
+import           Data.Fixed (Pico)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -87,8 +87,8 @@ data SimA s a where
   LiftST       :: StrictST.ST s a -> (a -> SimA s b) -> SimA s b
 
   GetTime      :: (VTime -> SimA s b) -> SimA s b
-  NewTimeout   :: Duration -> (Timeout (SimM s) -> SimA s b) -> SimA s b
-  UpdateTimeout:: Timeout (SimM s) -> Duration -> SimA s b -> SimA s b
+  NewTimeout   :: DiffTime -> (Timeout (SimM s) -> SimA s b) -> SimA s b
+  UpdateTimeout:: Timeout (SimM s) -> DiffTime -> SimA s b -> SimA s b
   CancelTimeout:: Timeout (SimM s) -> SimA s b -> SimA s b
 
   Throw        :: SomeException -> SimA s a
@@ -180,13 +180,13 @@ instance Monad (STM s) where
 
     fail = MonadFail.fail
 
-newtype VTime = VTime Micro
+newtype VTime = VTime Pico
   deriving (Eq, Ord, Show)
 
 instance TimeMeasure VTime where
 
-  diffTime (VTime t) (VTime t') = secondsDuration (t-t')
-  addTime d (VTime t) = VTime (t + durationSeconds d)
+  diffTime (VTime t) (VTime t') = realToFrac (t-t')
+  addTime d (VTime t) = VTime (t + realToFrac d)
   zeroTime = VTime 0
 
 instance MonadFail (SimM s) where

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -63,6 +63,7 @@ import           Control.Monad.Class.MonadSTM hiding (STM, TVar)
 import qualified Control.Monad.Class.MonadSTM as MonadSTM
 import           Control.Monad.Class.MonadAsync hiding (Async)
 import qualified Control.Monad.Class.MonadAsync as MonadAsync
+import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 
 {-# ANN module "HLint: ignore Use readTVarIO" #-}

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -24,6 +24,7 @@ import           Test.Tasty.QuickCheck
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.IOSim

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -18,10 +18,11 @@
       "library" = {
         depends = [
           (hsPkgs.base)
-          (hsPkgs.mtl)
-          (hsPkgs.stm)
           (hsPkgs.async)
           (hsPkgs.bytestring)
+          (hsPkgs.mtl)
+          (hsPkgs.stm)
+          (hsPkgs.time)
           ];
         };
       };

--- a/nix/.stack.nix/io-sim.nix
+++ b/nix/.stack.nix/io-sim.nix
@@ -35,6 +35,7 @@
             (hsPkgs.QuickCheck)
             (hsPkgs.tasty)
             (hsPkgs.tasty-quickcheck)
+            (hsPkgs.time)
             ];
           };
         };

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -37,6 +37,7 @@
           (hsPkgs.serialise)
           (hsPkgs.stm)
           (hsPkgs.text)
+          (hsPkgs.time)
           ];
         };
       tests = {
@@ -66,6 +67,7 @@
             (hsPkgs.tasty)
             (hsPkgs.tasty-quickcheck)
             (hsPkgs.text)
+            (hsPkgs.time)
             ];
           };
         };

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -52,6 +52,7 @@ import           Data.Word (Word64)
 import           Control.Monad (void)
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 
 import           Ouroboros.Consensus.Util.STM

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -100,7 +100,7 @@ finalSlot (NumSlots n) = SlotNo (fromIntegral n)
 -- thread (otherwise the system will keep waiting).
 testBlockchainTime :: forall m. (MonadSTM m, MonadFork m, MonadTimer m)
                    => NumSlots           -- ^ Number of slots
-                   -> Duration (Time m)  -- ^ Slot duration
+                   -> Duration           -- ^ Slot duration
                    -> m (BlockchainTime m)
 testBlockchainTime (NumSlots numSlots) slotLen = do
     slotVar <- atomically $ newTVar firstSlot
@@ -193,7 +193,9 @@ fixedDiffToMicroseconds :: FixedDiffTime -> Int
 fixedDiffToMicroseconds (FixedDiffTime d) = round (d * 1_000_000)
 
 threadDelayByFixedDiff :: FixedDiffTime -> IO ()
-threadDelayByFixedDiff = threadDelay . fixedDiffToMicroseconds
+threadDelayByFixedDiff = threadDelay
+                       . microsecondsDuration . fromIntegral
+                       . fixedDiffToMicroseconds
 
 multFixedDiffTime :: Int -> FixedDiffTime -> FixedDiffTime
 multFixedDiffTime n (FixedDiffTime d) = FixedDiffTime (fromIntegral n * d)

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
@@ -4,7 +4,7 @@ module Ouroboros.Storage.LedgerDB.DiskPolicy (
   ) where
 
 import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadTimer
+import           Control.Monad.Class.MonadTime (Duration)
 
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 
@@ -55,7 +55,7 @@ data DiskPolicy m = DiskPolicy {
     }
 
 -- | Default on-disk policy
-defaultDiskPolicy :: (MonadSTM m, MonadTime m)
+defaultDiskPolicy :: MonadSTM m
                   => SecurityParam     -- ^ Maximum rollback
                   -> Duration          -- ^ Slot length
                   -> STM m (DiskPolicy m)

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
@@ -3,8 +3,8 @@ module Ouroboros.Storage.LedgerDB.DiskPolicy (
   , defaultDiskPolicy
   ) where
 
+import           Data.Time.Clock (DiffTime)
 import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadTime (Duration)
 
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 
@@ -51,13 +51,13 @@ data DiskPolicy m = DiskPolicy {
       -- of blocks means that during chain synchronization (where a node is
       -- catching up with its neighbours) the frequency of writes /in terms of
       -- blocks/ automatically goes down.
-    , onDiskWriteInterval :: STM m Duration
+    , onDiskWriteInterval :: STM m DiffTime
     }
 
 -- | Default on-disk policy
 defaultDiskPolicy :: MonadSTM m
                   => SecurityParam     -- ^ Maximum rollback
-                  -> Duration          -- ^ Slot length
+                  -> DiffTime          -- ^ Slot length
                   -> STM m (DiskPolicy m)
 defaultDiskPolicy (SecurityParam k) slotLength = do
     constantDelay <- newTVar (fromIntegral k * slotLength)

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
@@ -51,13 +51,13 @@ data DiskPolicy m = DiskPolicy {
       -- of blocks means that during chain synchronization (where a node is
       -- catching up with its neighbours) the frequency of writes /in terms of
       -- blocks/ automatically goes down.
-    , onDiskWriteInterval :: STM m (Duration (Time m))
+    , onDiskWriteInterval :: STM m Duration
     }
 
 -- | Default on-disk policy
 defaultDiskPolicy :: (MonadSTM m, MonadTime m)
                   => SecurityParam     -- ^ Maximum rollback
-                  -> Duration (Time m) -- ^ Slot length
+                  -> Duration          -- ^ Slot length
                   -> STM m (DiskPolicy m)
 defaultDiskPolicy (SecurityParam k) slotLength = do
     constantDelay <- newTVar (fromIntegral k * slotLength)

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -43,6 +43,7 @@ library
                        Ouroboros.Network.NodeToClient
                        Ouroboros.Network.Pipe
                        Ouroboros.Network.Socket
+                       Ouroboros.Network.Time
                        Ouroboros.Network.Testing.ConcreteBlock
                        Ouroboros.Network.Protocol.ChainSync.Client
                        Ouroboros.Network.Protocol.ChainSync.Codec
@@ -98,7 +99,8 @@ library
                        process           >=1.6 && <1.7,
                        serialise         >=0.2 && <0.3,
                        stm               >=2.4 && <2.6,
-                       text              >=1.2 && <1.3
+                       text              >=1.2 && <1.3,
+                       time              >=1.6 && <1.10
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
@@ -140,6 +142,7 @@ test-suite tests
                        Ouroboros.Network.Protocol.ReqResp.Codec
                        Ouroboros.Network.Protocol.ReqResp.Test
                        Ouroboros.Network.Socket
+                       Ouroboros.Network.Time
 
                        Test.Chain
                        Test.ChainGenerators
@@ -176,7 +179,8 @@ test-suite tests
                        serialise,
                        tasty,
                        tasty-quickcheck,
-                       text
+                       text,
+                       time
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors

--- a/ouroboros-network/src/Ouroboros/Network/Channel.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Channel.hs
@@ -19,6 +19,7 @@ module Ouroboros.Network.Channel
 import qualified Data.ByteString               as BS
 import qualified Data.ByteString.Lazy          as LBS
 import qualified Data.ByteString.Lazy.Internal as LBS (smallChunkSize)
+import           Data.Time.Clock (DiffTime)
 import qualified System.Process as IO (createPipe)
 import qualified System.IO      as IO
                    ( withFile, IOMode(..) )
@@ -26,7 +27,6 @@ import qualified Network.Socket            as Socket hiding (send, recv)
 import qualified Network.Socket.ByteString as Socket
 
 import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadTime (Duration)
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.Class.MonadSay
 
@@ -147,7 +147,7 @@ createSocketConnectedChannels family = do
 delayChannel :: ( MonadSTM m
                 , MonadTimer m
                 )
-             => Duration
+             => DiffTime
              -> Channel m a
              -> Channel m a
 delayChannel delay = channelEffect (\_ -> return ())

--- a/ouroboros-network/src/Ouroboros/Network/Channel.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Channel.hs
@@ -146,7 +146,7 @@ createSocketConnectedChannels family = do
 delayChannel :: ( MonadSTM m
                 , MonadTimer m
                 )
-             => Duration (Time m)
+             => Duration
              -> Channel m a
              -> Channel m a
 delayChannel delay = channelEffect (\_ -> return ())

--- a/ouroboros-network/src/Ouroboros/Network/Channel.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Channel.hs
@@ -26,6 +26,7 @@ import qualified Network.Socket            as Socket hiding (send, recv)
 import qualified Network.Socket.ByteString as Socket
 
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadTime (Duration)
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.Class.MonadSay
 

--- a/ouroboros-network/src/Ouroboros/Network/DeltaQ.hs
+++ b/ouroboros-network/src/Ouroboros/Network/DeltaQ.hs
@@ -34,7 +34,7 @@ module Ouroboros.Network.DeltaQ (
   ) where
 
 import           Data.Semigroup ((<>))
-import           Control.Monad.Class.MonadTimer (Duration)
+import           Control.Monad.Class.MonadTime (Duration)
 
 
 --

--- a/ouroboros-network/src/Ouroboros/Network/Mux.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Mux.hs
@@ -22,7 +22,7 @@ import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTimer
+import           Control.Monad.Class.MonadTime (Time)
 import           Data.Array
 import qualified Data.ByteString.Lazy as BL
 import           Data.Word

--- a/ouroboros-network/src/Ouroboros/Network/Mux/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Mux/Types.hs
@@ -30,7 +30,7 @@ import           Text.Printf
 
 import           Control.Exception (throw, ArrayException(IndexOutOfBounds))
 import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadTimer
+import           Control.Monad.Class.MonadTime
 import           Ouroboros.Network.Channel
 
 newtype RemoteClockModel = RemoteClockModel { unRemoteClockModel :: Word32 } deriving Eq

--- a/ouroboros-network/src/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Node.hs
@@ -117,8 +117,8 @@ createOneWaySubscriptionChannels
      ( MonadSTM m
      , MonadTimer m
      )
-  => Duration (Time m)
-  -> Duration (Time m)
+  => Duration
+  -> Duration
   -> m (NodeChannels m block, NodeChannels m block)
 createOneWaySubscriptionChannels trDelay1 trDelay2 = do
   (cr, rc) <- createConnectedChannels
@@ -141,8 +141,8 @@ createTwoWaySubscriptionChannels
      ( MonadSTM m
      , MonadTimer m
      )
-  => Duration (Time m)
-  -> Duration (Time m)
+  => Duration
+  -> Duration
   -> m (NodeChannels m block, NodeChannels m block)
 createTwoWaySubscriptionChannels trDelay1 trDelay2 = do
   r12 <- createOneWaySubscriptionChannels trDelay1 trDelay2
@@ -157,7 +157,7 @@ blockGenerator :: forall block m.
                   , MonadFork m
                   , MonadTimer m
                   )
-               => Duration (Time m)
+               => Duration
                -- ^ slot duration
                -> [block]
                -- ^ The list of blocks to generate in increasing slot order.
@@ -325,7 +325,7 @@ forkCoreKernel :: forall block m.
                   , MonadFork m
                   , MonadTimer m
                   )
-               => Duration (Time m)
+               => Duration
                -- ^ slot duration
                -> [block]
                -- ^ Blocks to produce (in order they should be produced)
@@ -379,7 +379,7 @@ coreNode :: forall m.
         , MonadSay m
         )
      => NodeId
-     -> Duration (Time m)
+     -> Duration
      -- ^ slot duration
      -> [Block]
      -> NodeChannels m Block

--- a/ouroboros-network/src/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Node.hs
@@ -21,7 +21,6 @@ import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 
 import           Network.TypedProtocol.Core
@@ -29,6 +28,7 @@ import           Network.TypedProtocol.Driver
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec
 
+import           Ouroboros.Network.Time
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (Chain (..), Point)
 import qualified Ouroboros.Network.Chain as Chain
@@ -118,8 +118,8 @@ createOneWaySubscriptionChannels
      ( MonadSTM m
      , MonadTimer m
      )
-  => Duration
-  -> Duration
+  => DiffTime
+  -> DiffTime
   -> m (NodeChannels m block, NodeChannels m block)
 createOneWaySubscriptionChannels trDelay1 trDelay2 = do
   (cr, rc) <- createConnectedChannels
@@ -142,8 +142,8 @@ createTwoWaySubscriptionChannels
      ( MonadSTM m
      , MonadTimer m
      )
-  => Duration
-  -> Duration
+  => DiffTime
+  -> DiffTime
   -> m (NodeChannels m block, NodeChannels m block)
 createTwoWaySubscriptionChannels trDelay1 trDelay2 = do
   r12 <- createOneWaySubscriptionChannels trDelay1 trDelay2
@@ -158,7 +158,7 @@ blockGenerator :: forall block m.
                   , MonadFork m
                   , MonadTimer m
                   )
-               => Duration
+               => DiffTime
                -- ^ slot duration
                -> [block]
                -- ^ The list of blocks to generate in increasing slot order.
@@ -326,7 +326,7 @@ forkCoreKernel :: forall block m.
                   , MonadFork m
                   , MonadTimer m
                   )
-               => Duration
+               => DiffTime
                -- ^ slot duration
                -> [block]
                -- ^ Blocks to produce (in order they should be produced)
@@ -380,7 +380,7 @@ coreNode :: forall m.
         , MonadSay m
         )
      => NodeId
-     -> Duration
+     -> DiffTime
      -- ^ slot duration
      -> [Block]
      -> NodeChannels m Block

--- a/ouroboros-network/src/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Node.hs
@@ -21,6 +21,7 @@ import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 
 import           Network.TypedProtocol.Core

--- a/ouroboros-network/src/Ouroboros/Network/Pipe.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Pipe.hs
@@ -16,7 +16,7 @@ import           GHC.Stack
 import           System.IO (Handle, hClose, hFlush)
 
 import qualified Ouroboros.Network.Mux as Mx
-
+import           Ouroboros.Network.Time
 
 import qualified Data.ByteString.Lazy as BL
 
@@ -46,11 +46,9 @@ writePipe :: (Mx.ProtocolEnum ptcl, Ord ptcl, Enum ptcl, Bounded ptcl)
           -> IO (Time IO)
 writePipe ctx sdu = do
     ts <- getMonotonicTime
-    let ts32 :: Word32
-               -- grab the low 32bits of the timestamp in microseconds
-        ts32 = fromIntegral (durationMicroseconds (ts `diffTime` zeroTime))
-    let sdu' = sdu { Mx.msTimestamp = Mx.RemoteClockModel ts32 }
-        buf = Mx.encodeMuxSDU sdu'
+    let ts32 = timestampMicrosecondsLow32Bits ts
+        sdu' = sdu { Mx.msTimestamp = Mx.RemoteClockModel ts32 }
+        buf  = Mx.encodeMuxSDU sdu'
     BL.hPut (pcWrite ctx) buf
     hFlush (pcWrite ctx)
     return ts

--- a/ouroboros-network/src/Ouroboros/Network/Pipe.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Pipe.hs
@@ -10,7 +10,7 @@ module Ouroboros.Network.Pipe (
 
 import           Control.Monad
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTimer
+import           Control.Monad.Class.MonadTime
 import           Data.Word
 import           GHC.Stack
 import           System.IO (Handle, hClose, hFlush)

--- a/ouroboros-network/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Socket.hs
@@ -14,7 +14,6 @@ import           Control.Monad
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTimer
-import           Data.Bits
 import qualified Data.ByteString.Lazy as BL
 import           Data.Int
 import           Data.Word
@@ -49,7 +48,10 @@ writeSocket :: Mx.ProtocolEnum ptcl => SocketCtx -> Mx.MuxSDU ptcl -> IO (Time I
 writeSocket ctx sdu = do
     --say "write"
     ts <- getMonotonicTime
-    let sdu' = sdu { Mx.msTimestamp = Mx.RemoteClockModel $ fromIntegral $ ts .&. 0xffffffff }
+    let ts32 :: Word32
+               -- grab the low 32bits of the timestamp in microseconds
+        ts32 = fromIntegral (durationMicroseconds (ts `diffTime` zeroTime))
+    let sdu' = sdu { Mx.msTimestamp = Mx.RemoteClockModel ts32 }
         buf = Mx.encodeMuxSDU sdu'
     --hexDump buf ""
     Socket.sendAll (scSocket ctx) buf

--- a/ouroboros-network/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Socket.hs
@@ -13,7 +13,7 @@ import           Control.Concurrent.Async
 import           Control.Monad
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTimer
+import           Control.Monad.Class.MonadTime
 import qualified Data.ByteString.Lazy as BL
 import           Data.Int
 import           Data.Word

--- a/ouroboros-network/src/Ouroboros/Network/Time.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Time.hs
@@ -1,0 +1,33 @@
+
+module Ouroboros.Network.Time (
+    -- * DiffTime
+    DiffTime,
+    diffTimeToMicroseconds,
+    microsecondsToDiffTime,
+
+    -- * TimeMeasure
+    TimeMeasure(..),
+    timestampMicrosecondsLow32Bits,
+  ) where
+
+import Data.Word (Word32)
+import Data.Time.Clock (DiffTime, diffTimeToPicoseconds, picosecondsToDiffTime)
+import Control.Monad.Class.MonadTime (TimeMeasure(..))
+
+diffTimeToMicroseconds :: DiffTime -> Integer
+diffTimeToMicroseconds = (`div` 1000000) . diffTimeToPicoseconds
+
+microsecondsToDiffTime :: Integer -> DiffTime
+microsecondsToDiffTime = picosecondsToDiffTime . (* 1000000)
+
+-- | This is a slightly pecluliar operation: it returns the number of
+-- microseconds since an arbitrary epoch, modulo 2^32. This number of
+-- microseconds wraps every ~35 minutes.
+--
+-- The purpose is to give a compact timestamp (compact to send over the wire)
+-- for measuring time differences on the order of seconds or less.
+--
+timestampMicrosecondsLow32Bits :: TimeMeasure t => t -> Word32
+timestampMicrosecondsLow32Bits ts =
+    fromIntegral (diffTimeToMicroseconds (ts `diffTime` zeroTime))
+

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -19,6 +19,7 @@ import           Text.Printf
 
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Network.TypedProtocol.Driver
 import           Network.TypedProtocol.ReqResp.Client
@@ -136,7 +137,7 @@ sduSizeMux :: (Monad m)
            -> m Word16
 sduSizeMux ctx = return $ sduSize ctx
 
-writeMux :: (MonadTimer m, MonadSTM m, Mx.ProtocolEnum ptcl)
+writeMux :: (MonadTime m, MonadSTM m, Mx.ProtocolEnum ptcl)
          => MuxSTMCtx ptcl m
          -> Mx.MuxSDU ptcl
          -> m (Time m)
@@ -146,7 +147,7 @@ writeMux ctx sdu = do
     atomically $ writeTBQueue (writeQueue ctx) buf
     return ts
 
-readMux :: (MonadTimer m, MonadSTM m, MonadThrow m, Mx.ProtocolEnum ptcl)
+readMux :: (MonadTime m, MonadSTM m, MonadThrow m, Mx.ProtocolEnum ptcl)
         => MuxSTMCtx ptcl m
         -> m (Mx.MuxSDU ptcl, Time m)
 readMux ctx = do

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -25,6 +25,7 @@ import           Network.TypedProtocol.Driver
 import           Network.TypedProtocol.ReqResp.Client
 import           Network.TypedProtocol.ReqResp.Server
 
+import           Ouroboros.Network.Time
 import           Ouroboros.Network.Channel
 import qualified Ouroboros.Network.Mux as Mx
 import           Ouroboros.Network.Protocol.ReqResp.Codec
@@ -143,7 +144,9 @@ writeMux :: (MonadTime m, MonadSTM m, Mx.ProtocolEnum ptcl)
          -> m (Time m)
 writeMux ctx sdu = do
     ts <- getMonotonicTime
-    let buf = Mx.encodeMuxSDU sdu -- XXX Timestamp isn't set
+    let ts32 = timestampMicrosecondsLow32Bits ts
+        sdu' = sdu { Mx.msTimestamp = Mx.RemoteClockModel ts32 }
+        buf  = Mx.encodeMuxSDU sdu'
     atomically $ writeTBQueue (writeQueue ctx) buf
     return ts
 

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -202,7 +202,7 @@ prop_mux_snd_recv request response = ioProperty $ do
 -- Stub for a mpdInitiator or mpdResponder that doesn't send or receive any data.
 dummyCallback :: (MonadTimer m) => Channel m BL.ByteString  -> m ()
 dummyCallback _ = forever $
-    threadDelay 1000000
+    threadDelay 1.0
 
 -- | Create a verification function, a MiniProtocolDescription for the client side and a
 -- MiniProtocolDescription for the server side for a RequestResponce protocol.

--- a/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
@@ -31,6 +31,7 @@ import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import qualified Control.Monad.IOSim as Sim
 
@@ -72,6 +73,7 @@ test_blockGenerator
   :: forall m.
      ( MonadSTM m
      , MonadFork m
+     , MonadTime m
      , MonadTimer m
      , Show (Time m)
      )
@@ -94,6 +96,7 @@ test_blockGenerator chain slotDuration = do
     experiment
       :: ( MonadSTM m
          , MonadFork m
+         , MonadTime m
          , MonadTimer m
          )
       => Duration
@@ -127,8 +130,8 @@ prop_blockGenerator_IO (TestBlockChain chain) (Positive slotDuration) =
 coreToRelaySim :: ( MonadSTM m
                   , MonadFork m
                   , MonadThrow m
-                  , MonadTimer m
                   , MonadSay m
+                  , MonadTime m
                   , MonadTimer m
                   )
                => Bool              -- ^ two way subscription
@@ -205,8 +208,8 @@ prop_coreToRelay (TestNodeSim chain slotDuration coreTrDelay relayTrDelay) =
 coreToRelaySim2 :: ( MonadSTM m
                    , MonadFork m
                    , MonadThrow m
-                   , MonadTimer m
                    , MonadSay m
+                   , MonadTime m
                    , MonadTimer m
                    )
                 => Chain Block
@@ -302,8 +305,8 @@ networkGraphSim :: forall m.
                   ( MonadSTM m
                   , MonadFork m
                   , MonadThrow m
-                  , MonadTimer m
                   , MonadSay m
+                  , MonadTime m
                   , MonadTimer m
                   )
                 => TestNetworkGraph

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -86,7 +86,7 @@ demo chain0 updates = do
     startPipe a_mps (hndRead2, hndWrite1)
 
     void $ fork $ sequence_
-        [ do threadDelay 10000 -- just to provide interest
+        [ do threadDelay 10e-3 -- 10 milliseconds, just to provide interest
              atomically $ do
                  p <- readTVar producerVar
                  let Just p' = CPS.applyChainUpdate update p
@@ -125,7 +125,7 @@ demo chain0 updates = do
        return ()
 
     dummyCallback _ = forever $
-        threadDelay 1000000
+        threadDelay 1.0
 
     producerRsp ::  TVar IO (CPS.ChainProducerState block)
                 -> Channel IO BL.ByteString -> IO ()

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -198,7 +198,7 @@ demo chain0 updates = do
     startInitiator a_mps a b
 
     void $ fork $ sequence_
-        [ do threadDelay 10000 -- just to provide interest
+        [ do threadDelay 10e-3 -- 10 milliseconds, just to provide interest
              atomically $ do
                  p <- readTVar producerVar
                  let Just p' = CPS.applyChainUpdate update p
@@ -240,7 +240,7 @@ demo chain0 updates = do
        return ()
 
     dummyCallback _ = forever $
-        threadDelay 1000000
+        threadDelay 1.0
 
     producerRsp ::  TVar IO (CPS.ChainProducerState block)
                 -> Channel IO BL.ByteString -> IO ()


### PR DESCRIPTION
And clean up a few of the somewhat dubious time calculations.

Keep a `zeroTime` value in the `TimeMeasure` class. The only use is in the mux where we use it in a slightly peculuiar operation: getting the low 32bits of the time as a timestamp with microsecond precision. This is of
course from an arbitrary time epoch. Any suggestions on making this more principled are welcome.