### PR TITLE
Header/body split + storage layer integration

### DIFF
--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -11,6 +11,11 @@ category:            Testing
 build-type:          Simple
 cabal-version:       >=1.10
 
+flag asserts
+  description: Enable assertionss
+  manual:      False
+  default:     False
+
 source-repository head
   type:     git
   location: https://github.com/input-output-hk/ouroboros-network
@@ -38,7 +43,8 @@ library
                        psqueues          >=0.2 && <0.3
 
   ghc-options:         -Wall
-                       -fno-ignore-asserts
+  if flag(asserts)
+     ghc-options:      -fno-ignore-asserts
 
 test-suite tests
   type:                exitcode-stdio-1.0

--- a/nix/.stack.nix/io-sim.nix
+++ b/nix/.stack.nix/io-sim.nix
@@ -1,6 +1,6 @@
 { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = {};
+    flags = { asserts = false; };
     package = {
       specVersion = "1.10";
       identifier = { name = "io-sim"; version = "0.1.0.0"; };

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -48,6 +48,7 @@
         "demo-playground" = {
           depends = [
             (hsPkgs.base)
+            (hsPkgs.contra-tracer)
             (hsPkgs.ouroboros-network)
             (hsPkgs.ouroboros-consensus)
             (hsPkgs.io-sim-classes)
@@ -79,7 +80,9 @@
             (hsPkgs.ouroboros-consensus)
             (hsPkgs.io-sim-classes)
             (hsPkgs.io-sim)
+            (hsPkgs.bytestring)
             (hsPkgs.containers)
+            (hsPkgs.contra-tracer)
             (hsPkgs.cryptonite)
             (hsPkgs.fgl)
             (hsPkgs.graphviz)

--- a/ouroboros-consensus/demo-playground/Logging.hs
+++ b/ouroboros-consensus/demo-playground/Logging.hs
@@ -46,7 +46,7 @@ logChain :: Condense [b]
          -> Chain b
          -> IO ()
 logChain loggingQueue chain = do
-    let m = "Adopted chain: " <> condense (Chain.toOldestFirst chain)
+    let m = "Updated chain: " <> condense (Chain.toOldestFirst chain)
     atomically $ writeTBQueue loggingQueue $ LogEvent m
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/demo-playground/NamedPipe.hs
+++ b/ouroboros-consensus/demo-playground/NamedPipe.hs
@@ -30,10 +30,11 @@ data DataFlow =
 -- | Creates two pipes, one for reading, one for writing. The 'DataFlow' input
 -- type is there to make it easier to correctly specify the pipes so that
 -- correct communication can occur.
-withPipeChannel :: DataFlow
+withPipeChannel :: String  -- ^ Identifier used in the pipe name
+                -> DataFlow
                 -> (Channel IO ByteString -> IO a)
                 -> IO a
-withPipeChannel dataflow action = do
+withPipeChannel ident dataflow action = do
     let (readName, writeName) = mkNames
     bracket (do createNamedPipe readName  (unionFileModes ownerModes otherReadMode)
                     `catch` (\(_ :: SomeException) -> pure ())
@@ -59,13 +60,13 @@ withPipeChannel dataflow action = do
     mkNames = case dataflow of
         Downstream (source :==>: destination) ->
             let [src,tgt] = map dashify [source, destination]
-            in ( "upstream-"   <> src <> "-" <> tgt
-               , "downstream-" <> src <> "-" <> tgt
+            in ( "upstream-"   <> ident <> "-" <> src <> "-" <> tgt
+               , "downstream-" <> ident <> "-" <> src <> "-" <> tgt
                )
         Upstream   (source :==>: destination) ->
             let [src,tgt] = map dashify [source, destination]
-            in ( "downstream-" <> src <> "-" <> tgt
-               , "upstream-"   <> src <> "-" <> tgt
+            in ( "downstream-" <> ident <> "-" <> src <> "-" <> tgt
+               , "upstream-"   <> ident <> "-" <> src <> "-" <> tgt
                )
 
 -- | Given a 'NodeId', it dashifies it.

--- a/ouroboros-consensus/demo-playground/README.md
+++ b/ouroboros-consensus/demo-playground/README.md
@@ -33,7 +33,7 @@ You can chain transactions once you know the hash, which is printed after you
 submit the transaction:
 
 ```
-> ./demo-playground/submit-tx.sh 2 a 1000
+> ./demo-playground/submit-tx.sh -n 2 --address a --amount 1000
 Up to date
 The Id for this transaction is: 6f6e1118
 ```

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -25,6 +25,7 @@ library
 
   exposed-modules:
                        Ouroboros.Consensus.BlockchainTime
+                       Ouroboros.Consensus.BlockFetchClient
                        Ouroboros.Consensus.ChainSyncClient
                        Ouroboros.Consensus.ChainSyncServer
                        Ouroboros.Consensus.Crypto.DSIGN

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -25,6 +25,7 @@ library
 
   exposed-modules:
                        Ouroboros.Consensus.BlockchainTime
+                       Ouroboros.Consensus.ChainSyncServer
                        Ouroboros.Consensus.Crypto.DSIGN
                        Ouroboros.Consensus.Crypto.DSIGN.Class
                        Ouroboros.Consensus.Crypto.DSIGN.Ed448

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -56,6 +56,7 @@ library
                        Ouroboros.Consensus.Protocol.ExtNodeConfig
                        Ouroboros.Consensus.Protocol.ModChainSel
                        Ouroboros.Consensus.Util
+                       Ouroboros.Consensus.Util.AnchoredFragment
                        Ouroboros.Consensus.Util.CBOR
                        Ouroboros.Consensus.Util.Chain
                        Ouroboros.Consensus.Util.Classify

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -25,6 +25,7 @@ library
 
   exposed-modules:
                        Ouroboros.Consensus.BlockchainTime
+                       Ouroboros.Consensus.ChainSyncClient
                        Ouroboros.Consensus.ChainSyncServer
                        Ouroboros.Consensus.Crypto.DSIGN
                        Ouroboros.Consensus.Crypto.DSIGN.Class

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -193,6 +193,7 @@ executable demo-playground
                        Run
                        Topology
   build-depends:       base,
+                       contra-tracer,
                        ouroboros-network,
                        ouroboros-consensus,
                        io-sim-classes,
@@ -240,7 +241,9 @@ test-suite test-consensus
                     io-sim-classes,
                     io-sim,
 
+                    bytestring,
                     containers,
+                    contra-tracer,
                     cryptonite,
                     fgl,
                     graphviz,

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -26,6 +26,7 @@ library
   exposed-modules:
                        Ouroboros.Consensus.BlockchainTime
                        Ouroboros.Consensus.BlockFetchClient
+                       Ouroboros.Consensus.BlockFetchServer
                        Ouroboros.Consensus.ChainSyncClient
                        Ouroboros.Consensus.ChainSyncServer
                        Ouroboros.Consensus.Crypto.DSIGN

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchClient.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+module Ouroboros.Consensus.BlockFetchClient
+  ( BlockFetchClient
+  , blockFetchClient
+  ) where
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
+import           Control.Tracer
+
+import           Network.TypedProtocol.Pipelined (PeerPipelined)
+import           Ouroboros.Network.Codec
+
+import           Ouroboros.Network.Block
+import           Ouroboros.Network.BlockFetch
+                     (BlockFetchConsensusInterface (..))
+import           Ouroboros.Network.BlockFetch.Client (FetchClientPolicy (..))
+import qualified Ouroboros.Network.BlockFetch.Client as BlockFetchClient
+import           Ouroboros.Network.BlockFetch.Types (FetchClientStateVars)
+import           Ouroboros.Network.DeltaQ
+import           Ouroboros.Network.Protocol.BlockFetch.Type
+                     (BlockFetch (BFIdle))
+
+
+-- | The block fetch layer doesn't provide a readable type for the client yet,
+-- so define it ourselves for now.
+type BlockFetchClient hdr blk m a =
+  FetchClientStateVars hdr m ->
+  PeerPipelined (BlockFetch hdr blk) AsClient BFIdle m a
+
+-- | Block fetch client based on
+-- 'Ouroboros.Network.BlockFetch.Examples.mockedBlockFetchClient1', but using
+-- the 'ChainDB' (through the 'BlockFetchConsensusInterface').
+blockFetchClient
+    :: forall m up hdr blk.
+       (MonadSTM m, MonadTime m, MonadThrow m,
+        HasHeader blk, HasHeader hdr, HeaderHash hdr ~ HeaderHash blk)
+    => Tracer m String
+    -> BlockFetchConsensusInterface up hdr blk m
+    -> up -> BlockFetchClient hdr blk m ()
+blockFetchClient tracer blockFetchInterface _up clientStateVars =
+   -- TODO use @up@ in the tracer.
+    BlockFetchClient.blockFetchClient
+        (showTracing tracer)
+        policy
+        clientStateVars
+        -- TODO #469 replace with real GSV
+        (return exampleFixedPeerGSVs)
+  where
+    BlockFetchConsensusInterface
+      { blockFetchSize, blockMatchesHeader, addFetchedBlock } =
+        blockFetchInterface
+    -- TODO #468 the block fetch layer will eventually use the fields from the
+    -- 'BlockFetchConsensusInterface' to make a 'FetchClientPolicy'. So long
+    -- as this isn't done yet, let's do it ourselves.
+    policy = FetchClientPolicy
+      { blockFetchSize, blockMatchesHeader, addFetchedBlock }
+
+    -- | Roughly 10ms ping time and 1MBit\/s bandwidth, leads to ~2200 bytes
+    -- in flight minimum.
+    --
+    exampleFixedPeerGSVs :: PeerGSV
+    exampleFixedPeerGSVs = PeerGSV { outboundGSV, inboundGSV }
+      where
+        inboundGSV  = ballisticGSV 10e-3 10e-6 (degenerateDistribution 0)
+        outboundGSV = inboundGSV

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchServer.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+module Ouroboros.Consensus.BlockFetchServer
+  ( blockFetchServer
+  ) where
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Tracer (Tracer)
+
+import           Ouroboros.Network.Block (HeaderHash, castPoint)
+import           Ouroboros.Network.Protocol.BlockFetch.Server
+                     (BlockFetchBlockSender (..), BlockFetchSendBlocks (..),
+                     BlockFetchServer (..))
+import           Ouroboros.Network.Protocol.BlockFetch.Type (ChainRange (..))
+
+import           Ouroboros.Storage.ChainDB.API (ChainDB)
+import qualified Ouroboros.Storage.ChainDB.API as ChainDB
+
+
+-- | Block fetch server based on
+-- 'Ouroboros.Network.BlockFetch.Examples.mockBlockFetchServer1', but using
+-- the 'ChainDB'.
+blockFetchServer
+    :: forall m hdr blk.
+       (MonadSTM m, MonadThrow m, HeaderHash hdr ~ HeaderHash blk)
+    => Tracer m String
+    -> ChainDB m blk hdr
+    -> BlockFetchServer hdr blk m ()
+blockFetchServer _tracer chainDB = senderSide
+  where
+    senderSide :: BlockFetchServer hdr blk m ()
+    senderSide = BlockFetchServer receiveReq ()
+
+    receiveReq :: ChainRange hdr
+               -> m (BlockFetchBlockSender hdr blk m ())
+    receiveReq chainRange = withIter chainRange $ \it ->
+      -- When we got an iterator, it will stream at least one block since its
+      -- bounds are inclusive (when the bounds are invalid, we won't get an
+      -- iterator and we reply with 'SendMsgNoBlocks'), so we don't have to
+      -- check whether the iterator is empty (and reply with
+      -- 'SendMsgNoBlocks').
+      return $ SendMsgStartBatch $ sendBlocks it
+
+
+    sendBlocks :: ChainDB.Iterator m blk
+               -> m (BlockFetchSendBlocks hdr blk m ())
+    sendBlocks it = do
+      next <- ChainDB.iteratorNext it
+      return $ case next of
+        ChainDB.IteratorExhausted  -> SendMsgBatchDone (return senderSide)
+        ChainDB.IteratorResult blk -> SendMsgBlock blk (sendBlocks it)
+
+    withIter :: ChainRange hdr -> (ChainDB.Iterator m blk -> m a) -> m a
+    withIter (ChainRange start end) = bracket
+      -- TODO when streamBlocks throws an exception, we should return
+      -- SendMsgNoBlocks. Which exception will the ChainDB throw?
+        (ChainDB.streamBlocks
+          chainDB
+          (ChainDB.StreamFromInclusive (castPoint start))
+          (ChainDB.StreamToInclusive   (castPoint end)))
+        ChainDB.iteratorClose

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -1,0 +1,430 @@
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+module Ouroboros.Consensus.ChainSyncClient (
+    Consensus
+  , chainSyncClient
+  , ChainSyncClientException
+  , ClockSkew (..)
+  , CandidateState (..)
+  ) where
+
+import           Control.Monad
+import           Control.Monad.Except
+import           Control.Tracer
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe)
+import           Data.Typeable (Typeable)
+import           Data.Void (Void)
+import           Data.Word (Word64)
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block
+import           Ouroboros.Network.Chain (genesisBlockNo, genesisPoint)
+import           Ouroboros.Network.Protocol.ChainSync.Client
+
+import           Ouroboros.Consensus.BlockchainTime
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util.Orphans ()
+
+
+-- | Clock skew: the number of slots the chain of an upstream node may be
+-- ahead of the current slot (according to 'BlockchainTime').
+--
+-- E.g. a 'ClockSkew' value of @1@ means that a block produced by an upstream
+-- it may have a slot number that is 1 greater than the current slot.
+newtype ClockSkew = ClockSkew { unClockSkew :: Word64 }
+  deriving (Eq, Ord, Enum, Bounded, Show, Num)
+
+type Consensus (client :: * -> * -> (* -> *) -> * -> *) hdr m =
+   client hdr (Point hdr) m Void
+
+data ChainSyncClientException blk hdr =
+      -- | The header we received was for a slot too far in the future.
+      --
+      -- I.e., the slot of the received header was > current slot (according
+      -- to the wall time) + the max clock skew.
+      --
+      -- The first 'SlotNo' argument is the slot of the received header, the
+      -- second 'SlotNo' argument is the current slot.
+      TooFarInTheFuture SlotNo SlotNo
+
+      -- | The server we're connecting to forked more than @k@ blocks ago.
+      --
+      -- The first 'Point' is the intersection point with the server that was
+      -- too far in the past, the second 'Point' is the head of the server.
+    | ForkTooDeep (Point hdr) (Point hdr)
+
+      -- | The ledger threw an error.
+    | LedgerError (LedgerError blk)
+
+      -- | The upstream node rolled back more than @k@ blocks.
+      --
+      -- We store the requested intersection point and head point from the
+      -- upstream node.
+    | InvalidRollBack (Point hdr) (Point hdr)
+
+    -- | We send the upstream node a bunch of points from a chain fragment and
+    -- the upstream node responded with an intersection point that is not on
+    -- our chain fragment, and thus not among the points we sent.
+    --
+    -- We store the intersection piont the upstream node sent us.
+    | InvalidIntersection (Point hdr)
+
+
+deriving instance (StandardHash hdr, Show (LedgerError blk))
+    => Show (ChainSyncClientException blk hdr)
+
+instance (Typeable hdr, Typeable blk, StandardHash hdr, Show (LedgerError blk))
+    => Exception (ChainSyncClientException blk hdr)
+
+-- | The state of the candidate chain synched with an upstream node.
+data CandidateState blk hdr = CandidateState
+    { candidateChain       :: !(AnchoredFragment hdr)
+    , candidateHeaderState :: !(HeaderState blk)
+      -- ^ 'HeaderState' corresponding to the tip (most recent block) of the
+      -- 'candidateChain'.
+    }
+
+
+-- | Chain sync client
+--
+-- This never terminates. In case of a failure, a 'ChainSyncClientException'
+-- is thrown. The network layer classifies exception such that the
+-- corresponding peer will never be chosen again.
+chainSyncClient
+    :: forall m up blk hdr.
+       ( MonadSTM m
+       , MonadThrow (STM m)
+       , ProtocolLedgerView blk
+       , HasHeader hdr
+       , BlockProtocol hdr ~ BlockProtocol blk
+       , Ord up
+       )
+    => Tracer m String
+    -> NodeConfig (BlockProtocol hdr)
+    -> BlockchainTime m
+    -> ClockSkew                     -- ^ Maximum clock skew
+    -> STM m (AnchoredFragment hdr)  -- ^ Get the current chain
+    -> STM m (ExtLedgerState blk)    -- ^ Get the current ledger state
+    -> TVar m (Map up (TVar m (CandidateState blk hdr)))
+       -- ^ The candidate chains, we need the whole map because we
+       -- (de)register nodes (@up@).
+    -> up -> Consensus ChainSyncClient hdr m
+chainSyncClient _tracer cfg btime (ClockSkew maxSkew) getCurrentChain
+                getCurrentLedger varCandidates up =
+    ChainSyncClient initialise
+  where
+    -- Our task: after connecting to an upstream node, try to maintain an
+    -- up-to-date header-only fragment representing their chain. We maintain
+    -- such candidate chains in a map with upstream nodes as keys.
+    --
+    -- The block fetch logic will use these candidate chains to download
+    -- blocks from, prioritising certain candidate chains over others using
+    -- the consensus protocol. Whenever such a block has been downloaded and
+    -- added to the local 'ChainDB', the 'ChainDB' will perform chain
+    -- selection.
+    --
+    -- We also validate the headers of a candidate chain by advancing the
+    -- 'HeaderState' with the headers, which returns an error when validation
+    -- failed. Thus, in addition to the chain fragment of each candidate, we
+    -- also store a 'HeaderState' corresponding to the head of the candidate
+    -- chain.
+    --
+    -- We must keep the candidate chain synchronised with the corresponding
+    -- upstream chain. The upstream node's chain might roll forward or
+    -- backwards, and they will inform us about this. When we get these
+    -- messages, we will replicate these actions on our candidate chain.
+    --
+    -- TODO #465 Simplification for now: we don't monitor our current chain in
+    -- order to reject candidates that are no longer eligible (fork off more
+    -- than @k@ blocks in the past) or to find a better intersection point.
+    -- TODO #472 is this alright for the 'HeaderState', won't it get stale?
+    --
+    -- TODO #465 Simplification for now: we don't trim candidate chains, so
+    -- they might grow indefinitely.
+    --
+    -- TODO #466 the 'ChainDB' exposes through 'knownInvalidBlocks :: STM m
+    -- (Set (Point blk))' the invalid points. Whenever an upstream node has
+    -- such a block in its chain, we must disconnect from it with an
+    -- appropriate exception.
+    --
+    -- TODO #423 rate-limit switching chains, otherwise we can't place blame (we
+    -- don't know which candidate's chain included the point that was
+    -- poisoned). E.g. two rollbacks per time slot -> make it configurable ->
+    -- just a simple argument for now.
+    --
+    -- TODO #467 if the 'theirHead' that they sent us is on our chain, just
+    -- switch to it.
+    --
+    -- TODO split in two parts: one requiring only the @TVar@ for the
+    -- candidate instead of the whole map.
+    initialise :: m (Consensus ClientStIdle hdr m)
+    initialise = do
+      (curChain, varCandidate) <- atomically $ do
+        curChain  <- getCurrentChain
+        curLedger <- ledgerState <$> getCurrentLedger
+        -- We use our current chain, which contains the last @k@ headers, as
+        -- the initial chain for the candidate.
+        varCandidate <- newTVar CandidateState
+          { candidateChain       = curChain
+          , candidateHeaderState = getHeaderState curLedger 0
+          }
+        modifyTVar' varCandidates $ Map.insert up varCandidate
+        return (curChain, varCandidate)
+
+      -- We select points from the last @k@ headers of our current chain. This
+      -- means that if an intersection is found for one of these points, it
+      -- was an intersection within the last @k@ blocks of our current chain.
+      -- If not, we could never switch to this candidate chain anyway.
+      --
+      -- TODO #465 However, by the time we get a response about an
+      -- intersection, our chain might have changed already and it could be
+      -- that the intersection is now more than @k@ blocks in the past, which
+      -- means the candidate is no longer eligible after all.
+      let points = AF.selectPoints (map fromIntegral offsets) curChain
+
+      return $ SendMsgFindIntersect points $ ClientStIntersect
+        { recvMsgIntersectImproved  =
+            ChainSyncClient .: intersectImproved  varCandidate
+        , recvMsgIntersectUnchanged =
+            ChainSyncClient .  intersectUnchanged varCandidate
+        }
+
+    -- One of the points we sent intersected our chain
+    intersectImproved :: TVar m (CandidateState blk hdr)
+                      -> Point hdr -> Point hdr
+                      -> m (Consensus ClientStIdle hdr m)
+    intersectImproved varCandidate intersection _theirHead = atomically $ do
+      -- TODO #472
+      curLedger <- ledgerState <$> getCurrentLedger
+
+      CandidateState { candidateChain } <- readTVar varCandidate
+      -- Roll back the candidate to the @intersection@.
+      candidateChain' <- case AF.rollback intersection candidateChain of
+        Just c  -> return c
+        -- The @intersection@ is not on the candidate chain, even though we
+        -- sent only points from the candidate chain to find an intersection
+        -- with. The node must have sent us an invalid intersection point.
+        Nothing -> disconnect $ InvalidIntersection intersection
+
+      -- Get the HeaderState corresponding to point/block/header we rolled
+      -- back to.
+      let candidateHeaderState' =
+            getHeaderStateFor curLedger candidateChain candidateChain'
+
+      -- TODO make sure the header state is fully evaluated, otherwise we'd
+      -- hang on to the entire ledger state. This applies to everywhere we
+      -- update the header state.
+      writeTVar varCandidate CandidateState
+        { candidateChain       = candidateChain'
+        , candidateHeaderState = candidateHeaderState'
+        }
+      return $ requestNext varCandidate
+
+
+    -- If the intersection point is unchanged, this means that the best
+    -- intersection point was the initial assumption: genesis.
+    --
+    -- Note: currently, we only try to find an intersection at start-up. When
+    -- we later optimise this client to also find intersections after
+    -- start-up, this code will have to be adapted, as it assumes it is only
+    -- called at start-up.
+    intersectUnchanged :: TVar m (CandidateState blk hdr)
+                       -> Point hdr
+                       -> m (Consensus ClientStIdle hdr m)
+    intersectUnchanged varCandidate theirHead = atomically $ do
+      -- TODO #472
+      curLedger <- ledgerState <$> getCurrentLedger
+
+      CandidateState { candidateChain } <- readTVar varCandidate
+      -- If the genesis point is within the bounds of the candidate fragment
+      -- (initially equal to our fragment), it means we (the client) are <=
+      -- @k@ blocks from genesis and we want to sync with this
+      -- server/candidate. If not, the server/candidate is on a fork that
+      -- forked off too far in the past so that we do not intersect with them
+      -- within the last @k@ blocks, so we don't want to sync with them.
+      unless (AF.withinFragmentBounds genesisPoint candidateChain) $
+        disconnect $ ForkTooDeep genesisPoint theirHead
+
+      -- Get the 'HeaderState' at genesis (0).
+      let candidateChain' = Empty genesisPoint
+          candidateHeaderState' =
+            getHeaderStateFor curLedger candidateChain candidateChain'
+
+      writeTVar varCandidate CandidateState
+        { candidateChain       = candidateChain'
+        , candidateHeaderState = candidateHeaderState'
+        }
+      return $ requestNext varCandidate
+
+    requestNext :: TVar m (CandidateState blk hdr)
+                -> Consensus ClientStIdle hdr m
+    requestNext varCandidate = SendMsgRequestNext
+      (handleNext varCandidate)
+      (return (handleNext varCandidate)) -- when we have to wait
+
+    handleNext :: TVar m (CandidateState blk hdr)
+               -> Consensus ClientStNext hdr m
+    handleNext varCandidate = ClientStNext
+      { recvMsgRollForward  = ChainSyncClient .: rollForward  varCandidate
+      , recvMsgRollBackward = ChainSyncClient .: rollBackward varCandidate
+      }
+
+    rollForward :: TVar m (CandidateState blk hdr)
+                -> hdr -> Point hdr
+                -> m (Consensus ClientStIdle hdr m)
+    rollForward varCandidate hdr theirHead = atomically $ do
+      currentSlot <- getCurrentSlot btime
+      let theirSlot = AF.pointSlot theirHead
+
+      when (unSlotNo theirSlot > unSlotNo currentSlot + maxSkew) $
+        disconnect $ TooFarInTheFuture theirSlot currentSlot
+
+      -- TODO #472
+      curLedger <- ledgerState <$> getCurrentLedger
+
+      CandidateState {..} <- readTVar varCandidate
+
+      candidateHeaderState' <-
+        case runExcept $ advanceHeader curLedger hdr candidateHeaderState of
+          Left ledgerError            -> disconnect $ LedgerError ledgerError
+          Right candidateHeaderState' -> return candidateHeaderState'
+      writeTVar varCandidate CandidateState
+        { candidateChain       = candidateChain :> hdr
+        , candidateHeaderState = candidateHeaderState'
+        }
+      return $ requestNext varCandidate
+
+    rollBackward :: TVar m (CandidateState blk hdr)
+                 -> Point hdr -> Point hdr
+                 -> m (Consensus ClientStIdle hdr m)
+    rollBackward varCandidate intersection theirHead = atomically $ do
+      CandidateState {..} <- readTVar varCandidate
+      candidateChain' <- case AF.rollback intersection candidateChain of
+        Just candidateChain' -> return candidateChain'
+        -- TODO This is not correct, this limits their rollback to the point
+        -- where we started talking to them. It's entirely possible that we
+        -- don't have many of their blocks yet, and now they roll back more
+        -- than that number of blocks. Indeed, we might even just have one
+        -- block, and they might roll back two.
+        Nothing              -> disconnect $
+          InvalidRollBack intersection theirHead
+
+      -- TODO #472
+      curLedger <- ledgerState <$> getCurrentLedger
+
+      let candidateHeaderState' =
+            getHeaderStateFor curLedger candidateChain candidateChain'
+      writeTVar varCandidate CandidateState
+        { candidateChain       = candidateChain'
+        , candidateHeaderState = candidateHeaderState'
+        }
+      return $ requestNext varCandidate
+
+    -- | Disconnect from the upstream node by throwing the given exception and
+    -- removing its candidate from the map of candidates.
+    disconnect :: ChainSyncClientException blk hdr -> STM m a
+    disconnect ex = do
+      modifyTVar' varCandidates $ Map.delete up
+      throwM ex
+
+    -- | Get the 'HeaderState' for the head of the given chain.
+    getHeaderStateFor
+      :: LedgerState blk
+      -> AnchoredFragment hdr
+         -- ^ The ledger state corresponds to the head of this chain
+      -> AnchoredFragment hdr
+         -- ^ We want the ledger state for the head of this chain
+      -> HeaderState blk
+    getHeaderStateFor ledgerState ledgerChain wantedChain =
+        getHeaderState ledgerState rollBack
+      where
+        ledgerHeadBlockNo = mostRecentBlockNo ledgerChain
+        wantedHeadBlockNo = mostRecentBlockNo wantedChain
+        rollBack = unBlockNo ledgerHeadBlockNo - unBlockNo wantedHeadBlockNo
+
+    -- | Return the 'BlockNo' of the most recent header of the given chain,
+    -- the one at the tip. If the fragment is empty, it must be that we're
+    -- near genesis, so return 'genesisBlockNo' in that case.
+    mostRecentBlockNo :: AnchoredFragment hdr -> BlockNo
+    mostRecentBlockNo = fromMaybe genesisBlockNo . AF.headBlockNo
+
+    -- Recent offsets
+    --
+    -- These offsets are used to find an intersection point between our chain
+    -- and the upstream node's. We use the fibonacci sequence to try blocks
+    -- closer to our tip, and fewer blocks further down the chain. It is
+    -- important that this sequence constains at least a point @k@ back: if no
+    -- intersection can be found at most @k@ back, then this is not a peer
+    -- that we can sync with (since we will never roll back more than @k).
+    --
+    -- For @k = 2160@, this evaluates to
+    --
+    -- > [0,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2160]
+    --
+    -- For @k = 5@ (during testing), this evaluates to
+    --
+    -- > [0,1,2,3,5]
+    offsets :: [Word64]
+    offsets = [0] ++ takeWhile (< k) [fib n | n <- [2..]] ++ [k]
+
+    k :: Word64
+    k = maxRollbacks $ protocolSecurityParam cfg
+
+
+
+{-------------------------------------------------------------------------------
+  TODO #221: Implement genesis
+
+  Genesis in paper:
+
+    When we compare a candidate to our own chain, and that candidate forks off
+    more than k in the past, we compute the intersection point between that
+    candidate and our chain, select s slots from both chains, and compare the
+    number of blocks within those s slots. If the candidate has more blocks
+    in those s slots, we prefer the candidate, otherwise we stick with our own
+    chain.
+
+  Genesis as we will implement it:
+
+    * We decide we are in genesis mode if the head of our chain is more than
+      @k@ blocks behind the blockchain time. We will have to approximate this
+      as @k/f@ /slots/ behind the blockchain time time.
+    * In this situation, we must make sure we have a sufficient number of
+      upstream nodes "and collect chains from all of them"
+    * We still never consider chains that would require /us/ to rollback more
+      than k blocks.
+    * In order to compare two candidates, we compute the intersection point of
+      X of those two candidates and compare the density at point X.
+
+
+
+
+  Scribbled notes during meeting with Duncan:
+
+   geensis mode: compare clock to our chain
+   do we have enough peers?
+   still only interested in chains that don't fork more than k from our own chain
+
+     downloading headers from a /single/ node, download at least s headers
+     inform /other/ peers: "here is a point on our chain"
+     if all agree ("intersection imporved") -- all peers agree
+     avoid downloading tons of headers
+     /if/ there is a difference, get s headers from the peer who disagrees,
+       pick the denser one, and ignore the other
+       PROBLEM: what if the denser node has invalid block bodies??
+-------------------------------------------------------------------------------}

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+module Ouroboros.Consensus.ChainSyncServer
+  ( chainSyncServer
+  ) where
+
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Tracer
+
+import           Ouroboros.Network.Block (HeaderHash, Point (..), castPoint)
+import           Ouroboros.Network.Chain (ChainUpdate (..))
+import           Ouroboros.Network.Protocol.ChainSync.Server
+
+import           Ouroboros.Storage.ChainDB.API (ChainDB, Reader)
+import qualified Ouroboros.Storage.ChainDB.API as ChainDB
+
+
+-- | Chain Sync Server
+--
+-- This is a version of
+-- 'Ouroboros.Network.Protocol.ChainSync.Examples.chainSyncServerExample' that
+-- uses the 'ChainDB' instead of
+-- 'Ourboros.Network.ChainProducerState.ChainProducerState'.
+--
+-- All the hard work is done by the 'Reader's provided by the
+-- 'ChainDB'.
+chainSyncServer
+    :: forall m blk hdr.
+       (MonadSTM m, HeaderHash hdr ~ HeaderHash blk)
+    => Tracer m String
+    -> ChainDB m blk hdr
+    -> ChainSyncServer hdr (Point hdr) m ()
+chainSyncServer _tracer chainDB = ChainSyncServer $
+    idle <$> ChainDB.newReader chainDB
+  where
+    idle :: Reader m hdr -> ServerStIdle hdr (Point hdr) m ()
+    idle rdr =
+      ServerStIdle {
+        recvMsgRequestNext   = handleRequestNext rdr,
+        recvMsgFindIntersect = handleFindIntersect rdr,
+        recvMsgDoneClient    = return ()
+      }
+
+    idle' :: Reader m hdr -> ChainSyncServer hdr (Point hdr) m ()
+    idle' = ChainSyncServer . return . idle
+
+    handleRequestNext :: Reader m hdr
+                      -> m (Either (ServerStNext hdr (Point hdr) m ())
+                                (m (ServerStNext hdr (Point hdr) m ())))
+    handleRequestNext rdr = do
+      mupdate <- ChainDB.readerInstruction rdr
+      tip     <- atomically $ castPoint <$> ChainDB.getTipPoint chainDB
+      return $ case mupdate of
+        Just update -> Left  $ sendNext rdr tip update
+        Nothing     -> Right $ sendNext rdr tip <$> ChainDB.readerInstructionBlocking rdr
+                       -- Reader is at the head, have to block and wait for
+                       -- the producer's state to change.
+
+    sendNext :: Reader m hdr
+             -> Point hdr
+             -> ChainUpdate hdr
+             -> ServerStNext hdr (Point hdr) m ()
+    sendNext rdr tip update = case update of
+      AddBlock hdr -> SendMsgRollForward  hdr tip (idle' rdr)
+      RollBack pt  -> SendMsgRollBackward pt  tip (idle' rdr)
+
+    handleFindIntersect :: Reader m hdr
+                        -> [Point hdr]
+                        -> m (ServerStIntersect hdr (Point hdr) m ())
+    handleFindIntersect rdr points = do
+      -- TODO guard number of points
+      changed <- ChainDB.readerForward rdr points
+      tip     <- atomically $ castPoint <$> ChainDB.getTipPoint chainDB
+      return $ case changed of
+        Just pt -> SendMsgIntersectImproved  pt tip (idle' rdr)
+        Nothing -> SendMsgIntersectUnchanged    tip (idle' rdr)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo.hs
@@ -16,6 +16,7 @@ module Ouroboros.Consensus.Demo (
   , DemoPraos
   , DemoLeaderSchedule
   , Block
+  , Header
   , NumCoreNodes(..)
   , ProtocolInfo(..)
   , protocolInfo
@@ -37,8 +38,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 
-import           Ouroboros.Network.Block (SlotNo(..))
-import           Ouroboros.Network.Chain (Chain (..))
+import           Ouroboros.Network.Block (SlotNo (..))
 
 import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Crypto.DSIGN.Mock (verKeyIdFromSigned)
@@ -76,10 +76,13 @@ data DemoProtocol p where
 -- | Our 'Block' type stays the same.
 type Block p = SimpleBlock p SimpleBlockMockCrypto
 
--- | Data required to run the specified protocol
+-- | Our 'Header' type stays the same.
+type Header p = SimpleHeader p SimpleBlockMockCrypto
+
+-- | Data required to run the specified protocol.
 data ProtocolInfo p = ProtocolInfo {
         pInfoConfig     :: NodeConfig p
-      , pInfoInitChain  :: Chain (Block p)
+        -- | The ledger state at genesis
       , pInfoInitLedger :: ExtLedgerState (Block p)
       , pInfoInitState  :: NodeState p
       }
@@ -119,7 +122,6 @@ protocolInfo (DemoBFT securityParam) (NumCoreNodes numCoreNodes) (CoreNodeId nid
               | n <- [0 .. numCoreNodes - 1]
               ]
           }
-      , pInfoInitChain  = Genesis
       , pInfoInitLedger = ExtLedgerState (genesisLedgerState addrDist) ()
       , pInfoInitState  = ()
       }
@@ -140,7 +142,6 @@ protocolInfo (DemoPBFT params) (NumCoreNodes numCoreNodes) (CoreNodeId nid) =
             , encNodeConfigExt = PBftLedgerView
                 (Map.fromList [(VerKeyMockDSIGN n, VerKeyMockDSIGN n) | n <- [0 .. numCoreNodes - 1]])
           }
-      , pInfoInitChain  = Genesis
       , pInfoInitLedger = ExtLedgerState (genesisLedgerState addrDist) ( Seq.empty, SlotNo 0 )
       , pInfoInitState  = ()
       }
@@ -160,7 +161,6 @@ protocolInfo (DemoPraos params) (NumCoreNodes numCoreNodes) (CoreNodeId nid) =
               }
           , encNodeConfigExt = addrDist
           }
-      , pInfoInitChain  = Genesis
       , pInfoInitLedger = ExtLedgerState {
             ledgerState         = genesisLedgerState addrDist
           , ouroborosChainState = []
@@ -195,7 +195,6 @@ protocolInfo (DemoLeaderSchedule schedule params)
             }
         , lsNodeConfigNodeId   = CoreNodeId nid
         }
-    , pInfoInitChain  = Genesis
     , pInfoInitLedger = ExtLedgerState
         { ledgerState         = genesisLedgerState addrDist
         , ouroborosChainState = ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ConstraintKinds            #-}
-{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GADTs                      #-}
@@ -28,8 +27,8 @@ import           Codec.Serialise (Serialise)
 import           Data.Proxy (Proxy (..))
 import           Data.Typeable (Typeable)
 
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Ouroboros.Network.Block (HasHeader)
-import           Ouroboros.Network.Chain (Chain)
 
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Condense
@@ -39,14 +38,14 @@ class OuroborosTag p => ChainSelection p s where
   preferCandidate' :: HasHeader b
                    => proxy s
                    -> NodeConfig p
-                   -> Chain b      -- ^ Our chain
-                   -> Chain b      -- ^ Candidate
+                   -> AnchoredFragment b      -- ^ Our chain
+                   -> AnchoredFragment b      -- ^ Candidate
                    -> Bool
 
   compareCandidates' :: HasHeader b
                      => proxy s
                      -> NodeConfig p
-                     -> Chain b -> Chain b -> Ordering
+                     -> AnchoredFragment b -> AnchoredFragment b -> Ordering
 
 data ModChainSel p s
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -40,7 +40,6 @@ import           GHC.Generics (Generic)
 import           Numeric.Natural
 
 import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..))
-import qualified Ouroboros.Network.Chain as Chain
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Ed448 (Ed448DSIGN)
 import           Ouroboros.Consensus.Crypto.Hash.Class (HashAlgorithm (..),
@@ -56,9 +55,8 @@ import           Ouroboros.Consensus.Crypto.VRF.Simple (SimpleVRF)
 import           Ouroboros.Consensus.Node (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.Test
-import           Ouroboros.Consensus.Util.Chain (forksAtMostKBlocks)
+import qualified Ouroboros.Consensus.Util.AnchoredFragment as AF
 import           Ouroboros.Consensus.Util.Condense
-import           Ouroboros.Consensus.Util.HList (HList)
 import           Ouroboros.Consensus.Util.HList (HList (..))
 
 {-------------------------------------------------------------------------------
@@ -253,8 +251,8 @@ instance (Serialise (PraosExtraFields c), PraosCrypto c) => OuroborosTag (Praos 
   -- NOTE: We redefine `preferCandidate` but NOT `compareCandidates`
   -- NOTE: See note regarding clock skew.
   preferCandidate PraosNodeConfig{..} ours cand =
-      forksAtMostKBlocks k ours cand &&
-      Chain.length cand > Chain.length ours
+      AF.forksAtMostKBlocks k ours cand &&
+      AF.compareHeadBlockNo cand ours == GT
     where
       PraosParams{..} = praosParams
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -1,0 +1,53 @@
+-- | Utility functions on anchored fragments
+--
+-- Intended for qualified import
+-- > import qualified Ouroboros.Consensus.Util.AnchoredFragment as AF
+module Ouroboros.Consensus.Util.AnchoredFragment (
+    compareHeadBlockNo
+  , forksAtMostKBlocks
+  ) where
+
+import           Prelude hiding (length)
+
+import           Data.Function (on)
+import           Data.Word (Word64)
+
+import           Ouroboros.Network.AnchoredFragment
+
+{-------------------------------------------------------------------------------
+  Utility functions on anchored fragments
+-------------------------------------------------------------------------------}
+
+-- | Compare the 'headBlockNo', which is a measure of the length of the chain,
+-- of two anchored fragments.
+--
+-- A fragment with a head is always \"greater\" than one without. When both
+-- fragments have no head (i.e. are empty), they are 'EQ'.
+--
+-- Note that an EBB can share its @BlockNo@ with another regular block. If
+-- such an EBB is the head of one fragment and the regular block with the same
+-- @BlockNo@ is the head of the other fragment, then this function will say
+-- they are 'EQ', while in fact one fragment should be preferred over the
+-- other.
+--
+-- This is not a big deal as we won't be seeing new EBBs, so they will not be
+-- the head of a fragment very often anyway, only when catching up. As soon as
+-- a new block/header is added to the fragment, the right decision will be
+-- made again ('GT' or 'LT').
+compareHeadBlockNo
+  :: HasHeader b
+  => AnchoredFragment b
+  -> AnchoredFragment b
+  -> Ordering
+compareHeadBlockNo = compare `on` headBlockNo
+
+forksAtMostKBlocks
+  :: HasHeader b
+  => Word64              -- ^ How many blocks can it fork?
+  -> AnchoredFragment b  -- ^ Our chain.
+  -> AnchoredFragment b  -- ^ Their chain
+  -> Bool                -- ^ Indicates whether their chain forks at most the
+                         -- specified number of blocks.
+forksAtMostKBlocks k ours theirs = case ours `intersect` theirs of
+    Nothing                   -> False
+    Just (_, _, ourSuffix, _) -> fromIntegral (length ourSuffix) <= k

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Ouroboros.Consensus.Util.Orphans () where
 
@@ -5,7 +7,10 @@ import           Control.Monad.Identity
 import           Control.Monad.Trans
 import           Crypto.Random
 
-import           Ouroboros.Network.Block (SlotNo (..))
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (ChainHash, HasHeader, Point (..),
+                     SlotNo (..))
 import           Ouroboros.Network.Chain (Chain (..))
 
 import           Ouroboros.Consensus.Util.Condense
@@ -17,9 +22,18 @@ import           Ouroboros.Consensus.Util.Condense
 instance Condense SlotNo where
   condense (SlotNo n) = condense n
 
+instance Condense (ChainHash block) => Condense (Point block) where
+    condense (Point ptSlot ptHash) =
+      "(Point " <> condense ptSlot <> ", " <> condense ptHash <> ")"
+
 instance Condense block => Condense (Chain block) where
     condense Genesis   = "Genesis"
     condense (cs :> b) = condense cs <> " :> " <> condense b
+
+instance (Condense block, HasHeader block, Condense (ChainHash block))
+    => Condense (AnchoredFragment block) where
+    condense (AF.Empty pt) = "EmptyAnchor " <> condense pt
+    condense (cs AF.:> b)  = condense cs <> " :> " <> condense b
 
 {-------------------------------------------------------------------------------
   MonadRandom

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
@@ -21,11 +21,16 @@ import           Control.Monad.Reader
 import           Control.Monad.State
 import           Control.Monad.Writer
 
-import           Control.Monad.Class.MonadFork
+import           Data.Void (Void)
+
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadFork (MonadFork)
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Random
+import           Ouroboros.Consensus.Util.ThreadRegistry
 
 {-------------------------------------------------------------------------------
   Misc
@@ -42,11 +47,12 @@ blockUntilChanged f b getA = do
       else return (a, b')
 
 -- | Spawn a new thread that executes an action each time a TVar changes
-onEachChange :: forall m a b. (MonadSTM m, MonadFork m, Eq b)
-             => (a -> b) -> b -> STM m a -> (a -> m ()) -> m ()
-onEachChange f initB getA notify = void $ fork $ go initB
+onEachChange :: forall m a b. (MonadAsync m, MonadMask m, MonadFork m, Eq b)
+             => ThreadRegistry m
+             -> (a -> b) -> b -> STM m a -> (a -> m ()) -> m ()
+onEachChange registry f initB getA notify = void $ forkLinked registry $ go initB
   where
-    go :: b -> m ()
+    go :: b -> m Void
     go b = do
       (a, b') <- atomically $ blockUntilChanged f b getA
       notify a

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -32,11 +32,11 @@ import           Data.Typeable (Typeable)
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader (..),
                      SlotNo, StandardHash)
 import           Ouroboros.Network.Chain (Chain (..), Point (..))
 import qualified Ouroboros.Network.Chain as Chain
-import           Ouroboros.Network.ChainFragment (ChainFragment)
 import           Ouroboros.Network.ChainProducerState (ReaderId)
 
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -91,7 +91,7 @@ data ChainDB m blk hdr =
       --
       -- NOTE: A direct consequence of this guarantee is that the anchor of the
       -- fragment will move as the chain grows.
-    , getCurrentChain    :: STM m (ChainFragment hdr)
+    , getCurrentChain    :: STM m (AnchoredFragment hdr)
 
       -- | Get current ledger
     , getCurrentLedger   :: STM m (ExtLedgerState blk)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Model.hs
@@ -40,13 +40,13 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           GHC.Stack (HasCallStack)
 
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as Fragment
 import           Ouroboros.Network.Block (ChainHash (..), ChainUpdate (..),
                      HasHeader, HeaderHash, Point)
 import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Network.Chain (Chain)
 import qualified Ouroboros.Network.Chain as Chain
-import           Ouroboros.Network.ChainFragment (ChainFragment)
-import qualified Ouroboros.Network.ChainFragment as Fragment
 import qualified Ouroboros.Network.ChainProducerState as CPS
 
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -95,12 +95,11 @@ tipPoint = maybe Chain.genesisPoint Block.blockPoint . tipBlock
 
 lastK :: HasHeader a
       => SecurityParam
-      -> (blk -> a)  -- ^ Provided since `ChainFragment` is not a functor
+      -> (blk -> a)  -- ^ Provided since `AnchoredFragment` is not a functor
       -> Model blk
-      -> ChainFragment a
+      -> AnchoredFragment a
 lastK (SecurityParam k) f =
-      Fragment.takeNewest (fromIntegral k)
-    . Fragment.fromChain
+      Fragment.anchorNewest k
     . fmap f
     . currentChain
 

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -2,15 +2,10 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TupleSections         #-}
-{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
@@ -22,8 +17,8 @@ module Test.Dynamic.BFT (
 
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Test.QuickCheck
 
+import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -6,11 +6,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TupleSections         #-}
-{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
 module Test.Dynamic.General (
@@ -20,10 +16,13 @@ module Test.Dynamic.General (
 import           Data.Map.Strict (Map)
 import           Test.QuickCheck
 
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadFork (MonadFork)
 import           Control.Monad.Class.MonadSay
+import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim (runSimOrThrow)
 
@@ -34,6 +33,7 @@ import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Node
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random
+import           Ouroboros.Consensus.Util.ThreadRegistry
 
 import           Test.Dynamic.Network
 
@@ -52,11 +52,15 @@ prop_simple_protocol_convergence pInfo isValid numCoreNodes numSlots seed =
 
 -- Run protocol on the broadcast network, and check resulting chains on all nodes.
 test_simple_protocol_convergence :: forall m p.
-                                    ( MonadSTM m
-                                    , MonadFork m
-                                    , MonadThrow m
-                                    , MonadSay m
+                                    ( MonadAsync m
+                                    , MonadFork  m
+                                    , MonadMask  m
+                                    , MonadSay   m
+                                    , MonadST    m
+                                    , MonadSTM   m
+                                    , MonadTime  m
                                     , MonadTimer m
+                                    , MonadThrow (STM m)
                                     , DemoProtocolConstraints p
                                     )
                                  => (CoreNodeId -> ProtocolInfo p)
@@ -68,9 +72,10 @@ test_simple_protocol_convergence :: forall m p.
                                  -> Seed
                                  -> m Property
 test_simple_protocol_convergence pInfo isValid numCoreNodes numSlots seed =
-    fmap (isValid nodeIds) $ do
-      btime <- testBlockchainTime numSlots 100000
-      broadcastNetwork btime
+    fmap (isValid nodeIds) $ withThreadRegistry $ \registry -> do
+      btime <- testBlockchainTime registry numSlots 100000
+      broadcastNetwork registry
+                       btime
                        numCoreNodes
                        pInfo
                        (seedToChaCha seed)

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -86,7 +86,7 @@ prop_simple_leader_schedule_convergence numSlots numCoreNodes params seed =
      $    collect (shortestLength final)
      $    Map.keys final === nodeIds
      .&&. prop_all_common_prefix
-            (fromIntegral (maxRollbacks $ praosSecurityParam params))
+            (maxRollbacks $ praosSecurityParam params)
             (Map.elems final)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
@@ -58,7 +58,7 @@ allEqual (x : xs@(_:_)) =
                               <> show (unSlotNo t)
                               <> " and contains "
                               <> show (Chain.length d)
-                              <> "blocks): "
+                              <> " blocks): "
                               <> condense d
         (Just _, Nothing)  -> error "impossible case"
         (Just s, Just t)   ->    "intersection reaches slot "

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -16,6 +16,7 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import           Ouroboros.Consensus.Protocol.Abstract
+import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (HasHeader (..))
 import qualified Ouroboros.Storage.ChainDB.Model as M
 import           Test.Ouroboros.Storage.ChainDB.TestBlock
@@ -45,7 +46,7 @@ prop_getChain_addChain bc =
 prop_alwaysPickPreferredChain :: BlockTree -> Permutation -> Property
 prop_alwaysPickPreferredChain bt p =
     conjoin [
-        not $ preferCandidate testConfig current candidate
+        not $ preferCandidate testConfig (AF.fromChain current) (AF.fromChain candidate)
       | candidate <- treeToChains bt
       ]
   where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/TestBlock.hs
@@ -114,10 +114,17 @@ instance UpdateLedger TestBlock where
         }
     deriving (Show)
 
+  data HeaderState TestBlock = TestHeaderState
+
   applyLedgerState TestBlock{..} TestLedger{..} =
       if tbPrevHash == lastApplied
         then return     $ TestLedger (BlockHash tbHash)
         else throwError $ InvalidHash lastApplied tbPrevHash
+
+  getHeaderState _ _ = TestHeaderState
+
+  advanceHeader  _ _ _ = return TestHeaderState
+
 
 instance ProtocolLedgerView TestBlock where
   protocolLedgerView _ _ = ()

--- a/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
@@ -404,7 +404,7 @@ applyChainUpdates (u:us) c = applyChainUpdates us =<< applyChainUpdate u c
 --
 -- The anchor of the fragment will be 'Chain.genesisPoint'.
 fromChain :: HasHeader block => Chain block -> AnchoredFragment block
-fromChain = fromNewestFirst Chain.genesisPoint . Chain.toNewestFirst
+fromChain = mkAnchoredFragment Chain.genesisPoint . CF.unvalidatedFromChain
 
 -- | Convert an 'AnchoredFragment' to a 'Chain'.
 --

--- a/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
@@ -153,9 +153,14 @@ pattern (:>) :: HasHeader block
              => AnchoredFragment block -> block -> AnchoredFragment block
 pattern af' :> b <- (viewRight -> ConsR af' b)
   where
-    af@(AnchoredFragment a c) :> b =
-      assert (validExtension af b) $
-      AnchoredFragment a (c CF.:> b)
+    af@(AnchoredFragment a c) :> b = case c of
+      -- When the chain fragment is empty, validate to check whether the block
+      -- fits onto the anchor point.
+      CF.Empty -> assert (validExtension af b) $
+                  AnchoredFragment a (c CF.:> b)
+      -- Don't validate when we're just appending a block to the chain
+      -- fragment, as 'CF.:>' will already validate for us.
+      _        -> AnchoredFragment a (c CF.:> b)
 
 -- | Auxiliary data type to define the pattern synonym
 data ViewLeft block

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -113,16 +113,10 @@ data BlockFetchConsensusInterface peer header block m =
 
        -- | Read the K-suffixes of the candidate chains.
        --
-       -- They must be already validated and contain the last @K@ headers
-       -- (unless we're near the chain genesis of course).
-       --
-       -- Each candidate chain will be anchored within the bounds
-       -- ('AnchoredFragment.withinFragmentBounds') of the current chain
-       -- ('readCurrentChain'), which means that there will be an intersection
-       -- between the candidate chain and the current chain. In other words,
-       -- each candidate forks off within the last @K@ blocks of the current
-       -- chain (or less when we're near genesis).
-       --
+       -- Assumptions:
+       -- * They must be already validated.
+       -- * They may contain /fewer/ than @K@ blocks.
+       -- * Their anchor does not have to intersect with the current chain.
        readCandidateChains    :: STM m (Map peer (AnchoredFragment header)),
 
        -- | Read the K-suffix of the current chain.

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -130,7 +130,7 @@ data BlockFetchConsensusInterface peer header block m =
        -- This must contain info on the last @K@ blocks (unless we're near
        -- the chain genesis of course).
        --
-       readCurrentChain       :: STM m (AnchoredFragment block),
+       readCurrentChain       :: STM m (AnchoredFragment header),
 
        -- | Read the current fetch mode that the block fetch logic should use.
        --
@@ -160,7 +160,7 @@ data BlockFetchConsensusInterface peer header block m =
        -- with operational key certificates there are also cases where
        -- we would consider a chain of equal length to the current chain.
        --
-       plausibleCandidateChain :: AnchoredFragment block
+       plausibleCandidateChain :: AnchoredFragment header
                                -> AnchoredFragment header -> Bool,
 
        -- | Compare two candidate chains and return a preference ordering.
@@ -209,7 +209,7 @@ blockFetchLogic decisionTracer
       fetchTriggerVariables
       fetchNonTriggerVariables
   where
-    fetchDecisionPolicy :: FetchDecisionPolicy header block
+    fetchDecisionPolicy :: FetchDecisionPolicy header
     fetchDecisionPolicy =
       FetchDecisionPolicy {
         -- TODO: This is a protocol constant, but determined elsewhere.
@@ -225,7 +225,7 @@ blockFetchLogic decisionTracer
         blockFetchSize
       }
 
-    fetchTriggerVariables :: FetchTriggerVariables peer header block m
+    fetchTriggerVariables :: FetchTriggerVariables peer header m
     fetchTriggerVariables =
       FetchTriggerVariables {
         readStateCurrentChain    = readCurrentChain,

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -50,6 +50,7 @@ import           Ouroboros.Network.BlockFetch.DeltaQ
                    , calculatePeerFetchInFlightLimits )
 
 
+-- TODO #468 extract this from BlockFetchConsensusInterface
 data FetchClientPolicy header block m =
      FetchClientPolicy {
        blockFetchSize     :: header -> SizeInBytes,

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
@@ -44,13 +44,13 @@ import           Ouroboros.Network.BlockFetch.DeltaQ
                    , calculatePeerFetchInFlightLimits )
 
 
-data FetchDecisionPolicy header block = FetchDecisionPolicy {
+data FetchDecisionPolicy header = FetchDecisionPolicy {
        maxInFlightReqsPerPeer  :: Word,  -- A protocol constant.
 
        maxConcurrencyBulkSync  :: Word,
        maxConcurrencyDeadline  :: Word,
 
-       plausibleCandidateChain :: AnchoredFragment block
+       plausibleCandidateChain :: AnchoredFragment header
                                -> AnchoredFragment header -> Bool,
 
        compareCandidateChains  :: AnchoredFragment header
@@ -120,9 +120,9 @@ type CandidateFragments header = (ChainSuffix header, [ChainFragment header])
 fetchDecisions
   :: (HasHeader header, HasHeader block,
       HeaderHash header ~ HeaderHash block)
-  => FetchDecisionPolicy header block
+  => FetchDecisionPolicy header
   -> FetchMode
-  -> AnchoredFragment block
+  -> AnchoredFragment header
   -> (Point block -> Bool)
   -> [(AnchoredFragment header, PeerInfo header extra)]
   -> [(FetchDecision (FetchRequest header), PeerInfo header extra)]
@@ -559,7 +559,7 @@ obviously take that into account when considering later peer chains.
 
 fetchRequestDecisions
   :: HasHeader header
-  => FetchDecisionPolicy header block
+  => FetchDecisionPolicy header
   -> FetchMode
   -> [(FetchDecision [ChainFragment header], PeerFetchStatus header,
                                              PeerFetchInFlight header,
@@ -602,7 +602,7 @@ fetchRequestDecisions fetchDecisionPolicy fetchMode chains =
 
 fetchRequestDecision
   :: HasHeader header
-  => FetchDecisionPolicy header block
+  => FetchDecisionPolicy header
   -> FetchMode
   -> Word
   -> PeerFetchInFlightLimits

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -97,6 +97,9 @@ blockFetchExample1 decisionTracer clientStateTracer clientMsgTracer
   where
     serverMsgTracer = nullTracer
 
+    currentChainHeaders =
+      AnchoredFragment.mapAnchoredFragment blockHeader currentChain
+
     candidateChainHeaders =
       Map.fromList $ zip [1..] $
       map (AnchoredFragment.mapAnchoredFragment blockHeader) candidateChains
@@ -110,7 +113,7 @@ blockFetchExample1 decisionTracer clientStateTracer clientMsgTracer
     blockFetch registry blockHeap =
         blockFetchLogic
           decisionTracer
-          (sampleBlockFetchPolicy1 blockHeap currentChain candidateChainHeaders)
+          (sampleBlockFetchPolicy1 blockHeap currentChainHeaders candidateChainHeaders)
           registry
         >> return ()
 
@@ -129,7 +132,7 @@ blockFetchExample1 decisionTracer clientStateTracer clientMsgTracer
 
 sampleBlockFetchPolicy1 :: (MonadSTM m, HasHeader header, HasHeader block)
                         => TestFetchedBlockHeap m block
-                        -> AnchoredFragment block
+                        -> AnchoredFragment header
                         -> Map peer (AnchoredFragment header)
                         -> BlockFetchConsensusInterface peer header block m
 sampleBlockFetchPolicy1 blockHeap currentChain candidateChains =

--- a/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
@@ -71,6 +71,7 @@ module Ouroboros.Network.ChainFragment (
   -- * Conversion to/from Chain
   toChain,
   fromChain,
+  unvalidatedFromChain,
 
   -- * Helper functions
   prettyPrintChainFragment,
@@ -718,6 +719,12 @@ toChain = Chain.fromNewestFirst . toNewestFirst
 fromChain :: HasHeader block => Chain block -> ChainFragment block
 fromChain = fromNewestFirst . Chain.toNewestFirst
 
+-- | Variant of 'fromChain' that assumes a valid chain and will not validate
+-- the construct 'ChainFragment'.
+unvalidatedFromChain :: HasHeader block => Chain block -> ChainFragment block
+unvalidatedFromChain = unvalidatedFromNewestFirst . Chain.toNewestFirst
+  where
+    unvalidatedFromNewestFirst = ChainFragment . foldr (flip (FT.|>)) FT.empty
 
 --
 -- Serialisation

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -12,6 +12,7 @@ module Ouroboros.Network.Protocol.BlockFetch.Type where
 import           Data.Void (Void)
 
 import           Ouroboros.Network.Block (StandardHash, Point)
+import           Network.TypedProtocol.Codec (AnyMessage (..))
 import           Network.TypedProtocol.Core (Protocol (..))
 
 -- | Range of headers
@@ -89,3 +90,6 @@ instance (StandardHash header, Show body) => Show (Message (BlockFetch header bo
   show MsgNoBlocks             = "MsgNoBlocks"
   show MsgBatchDone            = "MsgBatchDone"
   show MsgClientDone           = "MsgClientDone"
+
+instance (StandardHash header, Show body) => Show (AnyMessage (BlockFetch header body)) where
+  show (AnyMessage msg) = show msg


### PR DESCRIPTION
Note that GitHub sorts commits by date, which - in this case - does not match
their actual order.

These are preparatory commits:

| Hash     | Commit                                                             |
|----------|--------------------------------------------------------------------|
| b4dc9a0e | `BlockFetch`: use headers for the current chain, not blocks        |
| a25c388e | `UpdateLedger`: add `HeaderState` and methods to obtain/advance it |
| 2ceed274 | Switch to `AnchoredFragment` in `OuroborosTag`                     |
| 530ae444 | Switch to `AnchoredFragment` in the `ChainDB`                      |
| 5038f986 | New `ChainSyncServer` based on the `ChainDB`                       |
| cc9133ba | New `ChainSyncClient`                                              |
| 2bea3309 | Add `BlockFetchClient`                                             |
| 824d570b | Add `BlockFetchServer`                                             |
| e0a0ee24 | Add `codecBlockFetchId`                                            |
| 132621a1 | Use the `ThreadRegistry` for `BlockchainTime`                      |
| 2df772ca | Add `headerBlockSize` to `SimplePreHeader`                         |

This is the main commit that rewrites `Ouroboros.Consensus.Node` and updates
the demo:

|     Hash | Commit                                        |
|----------|-----------------------------------------------|
| 9562c6c2 | Header/body split + storage layer integration |

The following commits bring down the `test-consensus` run-time from ~10
minutes to ~1 minute:

| Hash     | Commit                                                  |
|----------|---------------------------------------------------------|
| bc657908 | `AnchoredFragment`: don't validate twice                |
| 9a95889a | Cache the hash of the mock headers                      |
| 2c76ea11 | Add a fast variant of `fromChain` that doesn't validate |
| b99ce6c0 | Disable assertions in `IOSim`                           |
| fa406e3b | `ChainDB.Model`: more efficient chain construction      |

There are still a lot of TODOs, e.g., the `HeaderState` is currently just
(isomorphic to) unit, the `ChainSyncClient` is very basic and still has many
TODOs left in it. Tickets for some of these TODOs: #423, #465, #466, #467, #468, #469, #470, #472

Addressed by this PR: #243, #244, #245, #266.
