### PR TITLE
Relax the constraints on the block fetch codec

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -151,10 +151,10 @@ data ChainUpdate block = AddBlock block
   Serialisation
 -------------------------------------------------------------------------------}
 
-instance StandardHash b => Serialise (ChainHash b) where
+instance Serialise (HeaderHash b) => Serialise (ChainHash b) where
   -- use the Generic instance
 
-instance HasHeader block => Serialise (Point block) where
+instance Serialise (HeaderHash block) => Serialise (Point block) where
 
   encode Point { pointSlot = s, pointHash = h } =
       encodeListLen 2

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 
 module Ouroboros.Network.Protocol.BlockFetch.Codec where
@@ -21,7 +22,7 @@ import qualified Codec.Serialise.Class as CBOR
 import           Network.TypedProtocol.Codec
 import           Ouroboros.Network.Codec
 
-import           Ouroboros.Network.Block (HasHeader)
+import           Ouroboros.Network.Block (HeaderHash)
 import           Ouroboros.Network.Protocol.BlockFetch.Type
 
 codecBlockFetch
@@ -30,7 +31,7 @@ codecBlockFetch
      , MonadST m
      , Serialise header
      , Serialise body
-     , HasHeader header
+     , Serialise (HeaderHash header)
      )
   => Codec (BlockFetch header body) CBOR.DeserialiseFailure m ByteString
 codecBlockFetch = mkCodecCborLazyBS encode decode

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -11,8 +11,7 @@ module Ouroboros.Network.Protocol.BlockFetch.Type where
 
 import           Data.Void (Void)
 
-import           Ouroboros.Network.Block (StandardHash)
-import           Ouroboros.Network.Chain (Point)
+import           Ouroboros.Network.Block (StandardHash, Point)
 import           Network.TypedProtocol.Core (Protocol (..))
 
 -- | Range of headers


### PR DESCRIPTION
We don't need `HasHeader header`, just `Serialise (HeaderHash header)` since it's just for serialising the `Point header`.