### PR TITLE
Simplify BlockchainTime module and users

### DIFF
--- a/ouroboros-consensus/demo-playground/CLI.hs
+++ b/ouroboros-consensus/demo-playground/CLI.hs
@@ -42,7 +42,7 @@ parseCLI = CLI
     <*> parseCommand
 
 parseSystemStart :: Parser SystemStart
-parseSystemStart = option (SystemStart . fixedFromUTC <$> auto) $ mconcat [
+parseSystemStart = option (SystemStart <$> auto) $ mconcat [
       long "system-start"
     , help "The start time of the system (e.g. \"2018-12-10 15:58:06\""
     ]

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -43,7 +43,6 @@ module Ouroboros.Consensus.BlockchainTime (
 
 import           Control.Monad
 import           Data.Fixed
-import           Data.Proxy
 import           Data.Time
 import           Data.Time.Clock (DiffTime)
 import           Data.Time.Clock.System
@@ -184,10 +183,10 @@ instance Show FixedDiffTime where
   show = show . fixedDiffToNominal
 
 fixedDiffFromNominal :: NominalDiffTime -> FixedDiffTime
-fixedDiffFromNominal = FixedDiffTime . doubleToFixed round . realToFrac
+fixedDiffFromNominal = FixedDiffTime . realToFrac
 
 fixedDiffToNominal :: FixedDiffTime -> NominalDiffTime
-fixedDiffToNominal = realToFrac . fixedToDouble . fixedDiffTime
+fixedDiffToNominal = realToFrac . fixedDiffTime
 
 threadDelayByFixedDiff :: FixedDiffTime -> IO ()
 threadDelayByFixedDiff = threadDelay
@@ -280,25 +279,3 @@ waitUntilNextSlotIO slotLen start = do
     threadDelayByFixedDiff delay
     return nextSlot
 
-{-------------------------------------------------------------------------------
-  Auxiliary
--------------------------------------------------------------------------------}
-
--- | Convert 'Double' to fixed precision
---
--- For precision 'E1', we have
---
--- >           1.000 1.010 1.040 1.049 1.050  1.051 1.090 1.100
--- > floor   | 1.0   1.0   1.0   1.0   1.0    1.0   1.0   1.1
--- > round   | 1.0   1.0   1.0   1.0   1.0(*) 1.1   1.1   1.1
--- > ceiling | 1.0   1.1   1.1   1.1   1.1    1.1   1.1   1.1
---
--- (*): See <https://en.wikipedia.org/wiki/IEEE_754#Rounding_rules>
-doubleToFixed :: forall a. HasResolution a
-              => (Double -> Integer) -- ^ Rounding policy
-              -> Double -> Fixed a
-doubleToFixed r d = MkFixed $ r (d * fromIntegral (resolution (Proxy @a)))
-
--- | Convert fixed precision number to 'Double'
-fixedToDouble :: HasResolution a => Fixed a -> Double
-fixedToDouble = realToFrac

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -17,8 +17,6 @@ module Ouroboros.Consensus.BlockchainTime (
   , realBlockchainTime
     -- * Time utilities
   , FixedUTC
-  , fixedFromUTC
-  , fixedToUTC
   , getCurrentFixedUTC
   , FixedDiffTime
   , fixedDiffFromNominal
@@ -142,18 +140,10 @@ realBlockchainTime slotLen start = do
 
 -- | Fixed precision UTC time (resolution: milliseconds)
 --
--- > fixedToUTC (fixedFromUTC t) == t
--- > fixedFromUTC (fixedToUTC t) == t
 type FixedUTC = UTCTime
 
-fixedFromUTC :: UTCTime -> FixedUTC
-fixedFromUTC = id
-
-fixedToUTC :: FixedUTC -> UTCTime
-fixedToUTC = id
-
 getCurrentFixedUTC :: IO FixedUTC
-getCurrentFixedUTC = fixedFromUTC <$> getCurrentTime
+getCurrentFixedUTC = getCurrentTime
 
 -- | Fixed precision time span (resolution: milliseconds)
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -19,8 +19,6 @@ module Ouroboros.Consensus.BlockchainTime (
   , FixedUTC
   , getCurrentFixedUTC
   , FixedDiffTime
-  , fixedDiffFromNominal
-  , fixedDiffToNominal
   , threadDelayByFixedDiff
   , multFixedDiffTime
   , diffFixedUTC
@@ -147,15 +145,7 @@ getCurrentFixedUTC = getCurrentTime
 
 -- | Fixed precision time span (resolution: milliseconds)
 --
--- > fixedToNominal (fixedFromNominal d) == d
--- > fixedFromNominal (fixedToNominal t) == t
 type FixedDiffTime = NominalDiffTime
-
-fixedDiffFromNominal :: NominalDiffTime -> FixedDiffTime
-fixedDiffFromNominal = id
-
-fixedDiffToNominal :: FixedDiffTime -> NominalDiffTime
-fixedDiffToNominal = id
 
 threadDelayByFixedDiff :: FixedDiffTime -> IO ()
 threadDelayByFixedDiff = threadDelay . realToFrac

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -142,7 +142,7 @@ realBlockchainTime slotLen start = do
 
 -- | Fixed precision UTC time (resolution: milliseconds)
 --
--- > fixedToUTC (fixedFromUTC t) ~= t
+-- > fixedToUTC (fixedFromUTC t) == t
 -- > fixedFromUTC (fixedToUTC t) == t
 newtype FixedUTC = FixedUTC { fixedSecondsSinceEpoch :: UTCTime }
   deriving (Eq, Ord)
@@ -161,7 +161,7 @@ getCurrentFixedUTC = fixedFromUTC <$> getCurrentTime
 
 -- | Fixed precision time span (resolution: milliseconds)
 --
--- > fixedToNominal (fixedFromNominal d) ~= d
+-- > fixedToNominal (fixedFromNominal d) == d
 -- > fixedFromNominal (fixedToNominal t) == t
 newtype FixedDiffTime = FixedDiffTime { fixedDiffTime :: NominalDiffTime }
   deriving (Eq, Ord, Num)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -17,9 +17,7 @@ module Ouroboros.Consensus.BlockchainTime (
   , realBlockchainTime
     -- * Time utilities
   , FixedUTC
-  , getCurrentFixedUTC
   , FixedDiffTime
-  , threadDelayByFixedDiff
     -- * Time to slots and back again
   , SlotLength(..)
   , slotLengthFromMillisec
@@ -137,15 +135,9 @@ realBlockchainTime slotLen start = do
 --
 type FixedUTC = UTCTime
 
-getCurrentFixedUTC :: IO FixedUTC
-getCurrentFixedUTC = getCurrentTime
-
 -- | Fixed precision time span (resolution: milliseconds)
 --
 type FixedDiffTime = NominalDiffTime
-
-threadDelayByFixedDiff :: FixedDiffTime -> IO ()
-threadDelayByFixedDiff = threadDelay . realToFrac
 
 {-------------------------------------------------------------------------------
   Time to slots and back again
@@ -217,13 +209,13 @@ timeUntilNextSlot slotLen start now =
 -- | Get current slot
 getCurrentSlotIO :: SlotLength -> SystemStart -> IO SlotNo
 getCurrentSlotIO slotLen start =
-    fst . slotAtTime slotLen start <$> getCurrentFixedUTC
+    fst . slotAtTime slotLen start <$> getCurrentTime
 
 -- | Wait until next slot, and return number of that slot
 waitUntilNextSlotIO :: SlotLength -> SystemStart -> IO SlotNo
 waitUntilNextSlotIO slotLen start = do
-    now <- getCurrentFixedUTC
+    now <- getCurrentTime
     let (delay, nextSlot) = timeUntilNextSlot slotLen start now
-    threadDelayByFixedDiff delay
+    threadDelay ((realToFrac :: NominalDiffTime -> DiffTime) delay)
     return nextSlot
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -16,11 +16,11 @@ module Ouroboros.Consensus.BlockchainTime (
     -- * Real blockchain time
   , realBlockchainTime
     -- * Time utilities
-  , FixedUTC(..)
+  , FixedUTC
   , fixedFromUTC
   , fixedToUTC
   , getCurrentFixedUTC
-  , FixedDiffTime(..)
+  , FixedDiffTime
   , fixedDiffFromNominal
   , fixedDiffToNominal
   , threadDelayByFixedDiff
@@ -144,14 +144,13 @@ realBlockchainTime slotLen start = do
 --
 -- > fixedToUTC (fixedFromUTC t) == t
 -- > fixedFromUTC (fixedToUTC t) == t
-newtype FixedUTC = FixedUTC { fixedSecondsSinceEpoch :: UTCTime }
-  deriving (Eq, Ord)
+type FixedUTC = UTCTime
 
-instance Show FixedUTC where
-  show = show . fixedToUTC
+fixedSecondsSinceEpoch :: FixedUTC -> UTCTime
+fixedSecondsSinceEpoch = id
 
 fixedFromUTC :: UTCTime -> FixedUTC
-fixedFromUTC = FixedUTC
+fixedFromUTC = id
 
 fixedToUTC :: FixedUTC -> UTCTime
 fixedToUTC = fixedSecondsSinceEpoch
@@ -163,14 +162,13 @@ getCurrentFixedUTC = fixedFromUTC <$> getCurrentTime
 --
 -- > fixedToNominal (fixedFromNominal d) == d
 -- > fixedFromNominal (fixedToNominal t) == t
-newtype FixedDiffTime = FixedDiffTime { fixedDiffTime :: NominalDiffTime }
-  deriving (Eq, Ord, Num)
+type FixedDiffTime = NominalDiffTime
 
-instance Show FixedDiffTime where
-  show = show . fixedDiffToNominal
+fixedDiffTime :: FixedDiffTime -> NominalDiffTime
+fixedDiffTime = id
 
 fixedDiffFromNominal :: NominalDiffTime -> FixedDiffTime
-fixedDiffFromNominal = FixedDiffTime
+fixedDiffFromNominal = id
 
 fixedDiffToNominal :: FixedDiffTime -> NominalDiffTime
 fixedDiffToNominal = fixedDiffTime
@@ -179,13 +177,13 @@ threadDelayByFixedDiff :: FixedDiffTime -> IO ()
 threadDelayByFixedDiff = threadDelay . realToFrac . fixedDiffTime
 
 multFixedDiffTime :: Int -> FixedDiffTime -> FixedDiffTime
-multFixedDiffTime n (FixedDiffTime d) = FixedDiffTime (fromIntegral n * d)
+multFixedDiffTime n d = fromIntegral n * d
 
 diffFixedUTC :: FixedUTC -> FixedUTC -> FixedDiffTime
-diffFixedUTC (FixedUTC t) (FixedUTC t') = FixedDiffTime (t `diffUTCTime` t')
+diffFixedUTC t t' = t `diffUTCTime` t'
 
 addFixedUTC :: FixedDiffTime -> FixedUTC -> FixedUTC
-addFixedUTC (FixedDiffTime d) (FixedUTC t) = FixedUTC (d `addUTCTime` t)
+addFixedUTC d t = d `addUTCTime` t
 
 {-------------------------------------------------------------------------------
   Time to slots and back again
@@ -196,7 +194,7 @@ newtype SlotLength = SlotLength { getSlotLength :: FixedDiffTime }
   deriving (Show)
 
 slotLengthFromMillisec :: Integer -> SlotLength
-slotLengthFromMillisec = SlotLength . FixedDiffTime . conv
+slotLengthFromMillisec = SlotLength . conv
   where
     -- Explicit type annotation here means that /if/ we change the precision,
     -- we are forced to reconsider this code.
@@ -238,7 +236,7 @@ slotAtTime (SlotLength d) (SystemStart start) now = conv $
     `divMod'` (fixedDiffTime d)
   where
     conv :: (Word64, NominalDiffTime) -> (SlotNo, FixedDiffTime)
-    conv (slot, time) = (SlotNo slot, FixedDiffTime time)
+    conv (slot, time) = (SlotNo slot, time)
 
 -- | Compute time until the next slot and the number of that next slot
 --

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
@@ -16,9 +16,7 @@ import           Test.Util.Orphans.Arbitrary (genLimitedSlotNo)
 
 tests :: TestTree
 tests = testGroup "BlockchainTime" [
-      testProperty "UTC_Fixed_UTC"         prop_UTC_Fixed_UTC
-    , testProperty "Nominal_Fixed_Nominal" prop_Nominal_Fixed_Nominal
-    , testProperty "Fixed_UTC_Fixed"       prop_Fixed_UTC_Fixed
+      testProperty "Nominal_Fixed_Nominal" prop_Nominal_Fixed_Nominal
     , testProperty "Fixed_Nominal_Fixed"   prop_Fixed_Nominal_Fixed
     , testProperty "startOfSlot"           prop_startOfSlot
     , testProperty "slotAtTime"            prop_slotAtTime
@@ -31,14 +29,6 @@ tests = testGroup "BlockchainTime" [
 {-------------------------------------------------------------------------------
   Roundtrip properties for time conversion functions
 -------------------------------------------------------------------------------}
-
--- > fixedToUTC (fixedFromUTC t) ~= t
-prop_UTC_Fixed_UTC :: UTCTime -> Property
-prop_UTC_Fixed_UTC t = fixedToUTC (fixedFromUTC t) === t
-
--- > fixedFromUTC (fixedToUTC t) == t
-prop_Fixed_UTC_Fixed :: FixedUTC -> Property
-prop_Fixed_UTC_Fixed t = fixedFromUTC (fixedToUTC t) === t
 
 -- > fixedToNominal (fixedFromNominal d) ~= d
 prop_Nominal_Fixed_Nominal :: NominalDiffTime -> Property

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
@@ -4,7 +4,7 @@
 module Test.Consensus.BlockchainTime (tests) where
 
 import           Data.Bifunctor
-import           Data.Time.Clock (getCurrentTime, addUTCTime)
+import           Data.Time.Clock
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -37,7 +37,7 @@ prop_startOfSlot slotLen start = forAll genLimitedSlotNo $ \ slot ->
 
 -- > now - slotLen < startOfSlot (fst (slotAtTime now)) <= now
 -- > 0 <= snd (slotAtTime now) < slotLen
-prop_slotAtTime :: SlotLength -> SystemStart -> FixedDiffTime -> Property
+prop_slotAtTime :: SlotLength -> SystemStart -> NominalDiffTime -> Property
 prop_slotAtTime slotLen start execTime =
       counterexample ("now:         " ++ show now)
     . counterexample ("currentSlot: " ++ show currentSlot)
@@ -54,7 +54,7 @@ prop_slotAtTime slotLen start execTime =
     slotLen'                 = getSlotLength slotLen
 
 -- > 0 < fst (timeUntilNextSlot now) <= slotLen
-prop_timeUntilNextSlot :: SlotLength -> SystemStart -> FixedDiffTime -> Property
+prop_timeUntilNextSlot :: SlotLength -> SystemStart -> NominalDiffTime -> Property
 prop_timeUntilNextSlot slotLen start execTime =
       counterexample ("now:      " ++ show now)
     . counterexample ("timeLeft: " ++ show timeLeft)
@@ -80,7 +80,7 @@ prop_timeFromStartOfSlot slotLen start = forAll genLimitedSlotNo $ \ slot ->
 
 -- > slotAtTime (now + fst (timeUntilNextSlot now)) == bimap (+1) (const 0) (slotAtTime now)
 -- > fst (slotAtTime (now + fst (timeUntilNextSlot now))) == snd (timeUntilNextSlot now)
-prop_slotAfterTime :: SlotLength -> SystemStart -> FixedDiffTime -> Property
+prop_slotAfterTime :: SlotLength -> SystemStart -> NominalDiffTime -> Property
 prop_slotAfterTime slotLen start execTime =
       counterexample ("now:        " ++ show now)
     . counterexample ("timeLeft:   " ++ show timeLeft)
@@ -103,7 +103,7 @@ data TestDelayIO = TestDelayIO {
       --
       -- Since we don't actually " start " the system in any way, we specify
       -- this as an offset _before_ the start of the test.
-      tdioStart'  :: FixedDiffTime
+      tdioStart'  :: NominalDiffTime
 
       -- | SlotNo length
       --
@@ -133,5 +133,5 @@ prop_delayNextSlot TestDelayIO{..} = withMaxSuccess 10 $ ioProperty $ do
     pickSystemStart :: IO SystemStart
     pickSystemStart = pick <$> getCurrentTime
       where
-        pick :: FixedUTC -> SystemStart
+        pick :: UTCTime -> SystemStart
         pick = SystemStart . addUTCTime (negate tdioStart')

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
@@ -4,7 +4,7 @@
 module Test.Consensus.BlockchainTime (tests) where
 
 import           Data.Bifunctor
-import           Data.Time.Clock (addUTCTime)
+import           Data.Time.Clock (getCurrentTime, addUTCTime)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -131,7 +131,7 @@ prop_delayNextSlot TestDelayIO{..} = withMaxSuccess 10 $ ioProperty $ do
     assertEqual "nextSlot"              nextSlot                slotAfterDelay
   where
     pickSystemStart :: IO SystemStart
-    pickSystemStart = pick <$> getCurrentFixedUTC
+    pickSystemStart = pick <$> getCurrentTime
       where
         pick :: FixedUTC -> SystemStart
         pick = SystemStart . addUTCTime (negate tdioStart')

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
@@ -34,16 +34,7 @@ tests = testGroup "BlockchainTime" [
 
 -- > fixedToUTC (fixedFromUTC t) ~= t
 prop_UTC_Fixed_UTC :: UTCTime -> Property
-prop_UTC_Fixed_UTC t =
-      counterexample ("t':  " ++ show t')
-    . counterexample ("t'': " ++ show t'')
-    $ realToFrac (diffUTCTime t t'') < maxError
-  where
-    t'  = fixedFromUTC t
-    t'' = fixedToUTC   t'
-
-    maxError :: Double
-    maxError = 0.001 -- millisecond resolution
+prop_UTC_Fixed_UTC t = fixedToUTC (fixedFromUTC t) === t
 
 -- > fixedFromUTC (fixedToUTC t) == t
 prop_Fixed_UTC_Fixed :: FixedUTC -> Property
@@ -51,16 +42,7 @@ prop_Fixed_UTC_Fixed t = fixedFromUTC (fixedToUTC t) === t
 
 -- > fixedToNominal (fixedFromNominal d) ~= d
 prop_Nominal_Fixed_Nominal :: NominalDiffTime -> Property
-prop_Nominal_Fixed_Nominal d =
-      counterexample ("t':  " ++ show d')
-    . counterexample ("t'': " ++ show d'')
-    $ realToFrac (d - d'') < maxError
-  where
-    d'  = fixedDiffFromNominal d
-    d'' = fixedDiffToNominal   d'
-
-    maxError :: Double
-    maxError = 0.001 -- millisecond resolution
+prop_Nominal_Fixed_Nominal t = fixedDiffToNominal (fixedDiffFromNominal t) === t
 
 -- > fixedFromNominal (fixedToNominal t) == t
 prop_Fixed_Nominal_Fixed :: FixedDiffTime -> Property

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime.hs
@@ -4,7 +4,6 @@
 module Test.Consensus.BlockchainTime (tests) where
 
 import           Data.Bifunctor
-import           Data.Time
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -16,27 +15,13 @@ import           Test.Util.Orphans.Arbitrary (genLimitedSlotNo)
 
 tests :: TestTree
 tests = testGroup "BlockchainTime" [
-      testProperty "Nominal_Fixed_Nominal" prop_Nominal_Fixed_Nominal
-    , testProperty "Fixed_Nominal_Fixed"   prop_Fixed_Nominal_Fixed
-    , testProperty "startOfSlot"           prop_startOfSlot
+      testProperty "startOfSlot"           prop_startOfSlot
     , testProperty "slotAtTime"            prop_slotAtTime
     , testProperty "timeUntilNextSlot"     prop_timeUntilNextSlot
     , testProperty "timeFromStartOfSlot"   prop_timeFromStartOfSlot
     , testProperty "slotAfterTime"         prop_slotAfterTime
     , testProperty "delayNextSlot"         prop_delayNextSlot
     ]
-
-{-------------------------------------------------------------------------------
-  Roundtrip properties for time conversion functions
--------------------------------------------------------------------------------}
-
--- > fixedToNominal (fixedFromNominal d) ~= d
-prop_Nominal_Fixed_Nominal :: NominalDiffTime -> Property
-prop_Nominal_Fixed_Nominal t = fixedDiffToNominal (fixedDiffFromNominal t) === t
-
--- > fixedFromNominal (fixedToNominal t) == t
-prop_Fixed_Nominal_Fixed :: FixedDiffTime -> Property
-prop_Fixed_Nominal_Fixed t = fixedDiffFromNominal (fixedDiffToNominal t) === t
 
 {-------------------------------------------------------------------------------
   Properties of the time utilities

--- a/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
@@ -178,4 +178,4 @@ secondsPerDay = 24 * 60 * 60
 --
 -- Everybody knows nothing happened before 2000-01-01 00:00:00
 dawnOfTime :: UTCTime
-dawnOfTime = read "2000-01-01 00:00:00"
+dawnOfTime = UTCTime (fromGregorian 2000 01 01) 0

--- a/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
@@ -61,7 +61,7 @@ instance Arbitrary UTCTime where
 instance Arbitrary SlotLength where
   arbitrary = slotLengthFromMillisec <$> choose (1, 20 * 1_000)
 
-deriving via FixedUTC        instance Arbitrary SystemStart
+deriving via UTCTime         instance Arbitrary SystemStart
 deriving via Positive Word64 instance Arbitrary SlotNo
 deriving via Word64          instance Arbitrary EpochNo
 deriving via Positive Word64 instance Arbitrary EpochSize

--- a/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
@@ -57,14 +57,6 @@ instance Arbitrary NominalDiffTime where
 instance Arbitrary UTCTime where
   arbitrary = (`addUTCTime` dawnOfTime) <$> arbitrary
 
--- | Defined in terms of instance for 'NominalDiffTime'
-instance Arbitrary FixedDiffTime where
-   arbitrary = fixedDiffFromNominal <$> arbitrary
-
--- | Defined in terms of instance for 'UTCTime'
-instance Arbitrary FixedUTC where
-  arbitrary = fixedFromUTC <$> arbitrary
-
 -- | Length between 0.001 and 20 seconds, millisecond granularity
 instance Arbitrary SlotLength where
   arbitrary = slotLengthFromMillisec <$> choose (1, 20 * 1_000)


### PR DESCRIPTION
It eliminates the `FixedUTC` and `FixedDiffTime` types and associated utils.

This is a careful step-by-step refactoring, preserving the tests.

~~Ignore the first 5 patches, which are part of PR #399. This can be rebased after that PR is merged.~~