### PR TITLE
Immutable DB: Use Word64

### DIFF
--- a/byron-proxy/src/lib/Ouroboros/Byron/Proxy/DB.hs
+++ b/byron-proxy/src/lib/Ouroboros/Byron/Proxy/DB.hs
@@ -59,7 +59,7 @@ epochFileParser
   :: ( MonadST m, MonadThrow m )
   => CSL.SlotCount
   -> HasFS m h
-  -> Immutable.EpochFileParser ReadIncrementalErr CSL.HeaderHash m (Word, Immutable.SlotNo)
+  -> Immutable.EpochFileParser ReadIncrementalErr CSL.HeaderHash m (Word64, Immutable.SlotNo)
 epochFileParser epochSlots hasFS =
   fmap (\(w, block) -> (w, takeSlot block))
        (cborEpochFileParser' hasFS decoder hashOfEBB)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
@@ -145,14 +145,14 @@ readIncremental hasFS@HasFS{..} fp = withLiftST $ \liftST -> do
 
 -- | Read multiple @a@s incrementally from a file.
 --
--- Return the offset ('Word64') of the start of each @a@ and the size ('Word')
+-- Return the offset ('Word64') of the start of each @a@ and the size ('Word64')
 -- of each @a@. When deserialising fails, return all already deserialised @a@s
 -- and the error.
 readIncrementalOffsets :: forall m h a. (MonadST m, MonadThrow m)
                        => HasFS m h
                        -> (forall s . CBOR.Decoder s a)
                        -> FsPath
-                       -> m ([(Word64, (Word, a))], Maybe ReadIncrementalErr)
+                       -> m ([(Word64, (Word64, a))], Maybe ReadIncrementalErr)
                           -- ^ ((the offset of the start of @a@ in the file,
                           --     (the size of @a@ in bytes,
                           --      @a@ itself)),
@@ -163,11 +163,11 @@ readIncrementalOffsets hasFS@HasFS{..} decoder fp = withLiftST $ \liftST ->
   where
     go :: (forall x. ST s x -> m x)
        -> h
-       -> Word64                -- ^ Offset
-       -> [(Word64, (Word, a))] -- ^ Already deserialised (reverse order)
-       -> Maybe ByteString      -- ^ Unconsumed bytes from last time
+       -> Word64                  -- ^ Offset
+       -> [(Word64, (Word64, a))] -- ^ Already deserialised (reverse order)
+       -> Maybe ByteString        -- ^ Unconsumed bytes from last time
        -> S.IDecode s a
-       -> m ([(Word64, (Word, a))], Maybe ReadIncrementalErr)
+       -> m ([(Word64, (Word64, a))], Maybe ReadIncrementalErr)
     go liftST h offset deserialised mbUnconsumed dec = case dec of
       S.Partial k -> do
         -- First use the unconsumed bytes from a previous read before read
@@ -195,7 +195,7 @@ readIncrementalOffsets hasFS@HasFS{..} decoder fp = withLiftST $ \liftST ->
 
 -- | Read multiple @a@s incrementally from a file.
 --
--- Return the offset ('Word64') of the start of each @a@ and the size ('Word')
+-- Return the offset ('Word64') of the start of each @a@ and the size ('Word64')
 -- of each @a@. When deserialising fails, return all already deserialised @a@s
 -- and the error.
 --
@@ -209,7 +209,7 @@ readIncrementalOffsetsEBB :: forall m hash h a. (MonadST m, MonadThrow m)
                               -- ^ In case the given @a@ is an EBB, return its
                               -- @hash@.
                           -> FsPath
-                          -> m ([(Word64, (Word, a))],
+                          -> m ([(Word64, (Word64, a))],
                                 Maybe hash,
                                 Maybe ReadIncrementalErr)
                              -- ^ ((the offset of the start of @a@ in the file,
@@ -226,12 +226,12 @@ readIncrementalOffsetsEBB hasFS decoder getEBBHash fp = withLiftST $ \liftST ->
 
     go :: (forall x. ST s x -> m x)
        -> h
-       -> Word64                -- ^ Offset
-       -> [(Word64, (Word, a))] -- ^ Already deserialised (reverse order)
-       -> Maybe hash            -- ^ The hash of the EBB block
-       -> Maybe ByteString      -- ^ Unconsumed bytes from last time
+       -> Word64                  -- ^ Offset
+       -> [(Word64, (Word64, a))] -- ^ Already deserialised (reverse order)
+       -> Maybe hash              -- ^ The hash of the EBB block
+       -> Maybe ByteString        -- ^ Unconsumed bytes from last time
        -> S.IDecode s a
-       -> m ([(Word64, (Word, a))], Maybe hash, Maybe ReadIncrementalErr)
+       -> m ([(Word64, (Word64, a))], Maybe hash, Maybe ReadIncrementalErr)
     go liftST h offset deserialised mbEBBHash mbUnconsumed dec = case dec of
       S.Partial k -> do
         -- First use the unconsumed bytes from a previous read before read

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Util.hs
@@ -32,6 +32,7 @@ import qualified Data.ByteString.Builder as BS
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
+import           Data.Word
 
 import           GHC.Stack (HasCallStack, callStack, popCallStack)
 
@@ -187,14 +188,14 @@ validateIteratorRange err ces tip mbStart mbEnd = do
 -- slot is 0.
 --
 -- The output list will always have 0 as last element.
-reconstructSlotOffsets :: [(SlotOffset, (Word, RelativeSlot))]
+reconstructSlotOffsets :: [(SlotOffset, (Word64, RelativeSlot))]
                        -> NonEmpty SlotOffset
 reconstructSlotOffsets = go 0 [] 0
   where
     go :: SlotOffset
        -> [SlotOffset]
        -> RelativeSlot
-       -> [(SlotOffset, (Word, RelativeSlot))]
+       -> [(SlotOffset, (Word64, RelativeSlot))]
        -> NonEmpty SlotOffset
     go offsetAfterLast offsets expectedRelSlot ((offset, (len, relSlot)):olrs') =
       assert (offsetAfterLast == offset) $
@@ -260,7 +261,7 @@ cborEpochFileParser' :: forall m hash h a. (MonadST m, MonadThrow m)
                      -> (a -> Maybe hash)
                         -- ^ In case the given @a@ is an EBB, return its
                         -- @hash@.
-                     -> EpochFileParser ReadIncrementalErr hash m (Word, a)
+                     -> EpochFileParser ReadIncrementalErr hash m (Word64, a)
                         -- ^ The 'Word' is the size in bytes of the
                         -- corresponding @a@.
 cborEpochFileParser' hasFS decoder getEBBHash = EpochFileParser $

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
@@ -342,7 +342,7 @@ getIsMemberImpl VolatileDBEnv{..} = do
         Nothing -> EH.throwError _dbErr ClosedDBError
         Just st -> return (\bid -> Map.member bid (_currentRevMap st))
 
-getBlockIdsImpl :: forall m blockId. (MonadSTM m, Ord blockId)
+getBlockIdsImpl :: forall m blockId. (MonadSTM m)
                 => VolatileDBEnv m blockId
                 -> m [blockId]
 getBlockIdsImpl VolatileDBEnv{..} = do
@@ -368,8 +368,7 @@ getSuccessorsImpl VolatileDBEnv{..} blockId = do
 
 -- db first tries to fill files from _nextWriteFiles list.
 -- If none find it creates new ones.
-nextFile :: forall h m. MonadSTM m
-         => forall blockId. Ord blockId
+nextFile :: forall h m blockId. MonadSTM m
          => HasFS m h
          -> ErrorHandling (VolatileDBError blockId) m
          -> VolatileDBEnv m blockId

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -333,7 +333,7 @@ test_cborEpochFileParser = forM_ ["junk", ""] $ \junk -> runFS $ \hasFS -> do
     blocks :: [ByteString]
     blocks = map (snd . snd) offsetsAndSizesAndBlocks
 
-    offsetsAndSizesAndBlocks :: [(SlotOffset, (Word, ByteString))]
+    offsetsAndSizesAndBlocks :: [(SlotOffset, (Word64, ByteString))]
     offsetsAndSizesAndBlocks =
       [ (0, (4, "ebb"))
         -- Note that "ebb" is encoded as "Cebb", hence the size of 4

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
@@ -83,11 +83,11 @@ testBlockIsEBB TestEBB   {} = True
 
 -- | The binary representation of 'TestBlock' consists of repeating its 'SlotNo'
 -- @n@ times, where @n = 'testBlockSize'@.
-testBlockRepeat :: Word
+testBlockRepeat :: Word64
 testBlockRepeat = 9
 
 -- | The number of bytes the binary representation 'TestBlock' takes up.
-testBlockSize :: Word
+testBlockSize :: Word64
 testBlockSize = 8 + testBlockRepeat * 8
 
 -- | The encoding is as follows:
@@ -193,7 +193,7 @@ binaryEpochFileParser hasFS@HasFS{..} isEBB getHash = EpochFileParser $ \fsPath 
 -- | We use 'TestBlock' as the @hash@.
 testBlockEpochFileParser' :: MonadThrow m
                           => HasFS m h
-                          -> EpochFileParser String TestBlock m (Word, SlotNo)
+                          -> EpochFileParser String TestBlock m (Word64, SlotNo)
 testBlockEpochFileParser' hasFS = (\tb -> (testBlockSize, tbSlot tb)) <$>
     binaryEpochFileParser hasFS testBlockIsEBB id
 


### PR DESCRIPTION
Small PR to replace some uses of `Word` by `Word64` in the immutable DB.