### PR TITLE
Testing the CDDL-specification

### DIFF
--- a/doc/messages.cddl
+++ b/doc/messages.cddl
@@ -1,8 +1,8 @@
 ; The only purpose of allMessages is to have an entry point for testing all parts of the specification.
 ; ! allMessages is NOT a valid wire format !
 
-allMessages
-    = [0,chainSyncMessage]
+allMessages =
+      [0,chainSyncMessage]
     / [1,reqRespMessage]
     / [2,pingPongMessage]
     / [3,blockFetchMessage]
@@ -70,21 +70,26 @@ pingPongMsgDone = 2
 ; ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
 
 blockFetchMessage
-    = msgRequestRange
-    / msgStartBatch
-    / msgNoBlocks
-    / msgBlock
-    / msgBatchDone
-    / msgClientDone
+     = msgRequestRange
+     / msgClientDone
+     / msgStartBatch
+     / msgNoBlocks
+     / msgBlock
+     /msgBatchDone
 
-msgRequestRange = [0, point, point]
+msgRequestRange = [0, bfPoint, bfPoint]
 msgClientDone   = [1]
 msgStartBatch   = [2]
 msgNoBlocks     = [3]
-msgBlock        = [4, body]
+msgBlock        = [4, bfBody]
 msgBatchDone    = [5]
 
-body            = bytes .cbor any
+bfPoint           = [slotNo, chainHash]
+slotNo          = uint ; word64
+chainHash       = [0]  ; this is the representation of the GenesisHash
+
+bfBody         = tstr
+
 
 ; Transaction Submission Protocol
 ; reference implementation of the codec in

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -41,6 +41,23 @@
           (hsPkgs.time)
           ];
         };
+      exes = {
+        "test-cddl" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.bytestring)
+            (hsPkgs.cborg)
+            (hsPkgs.fingertree)
+            (hsPkgs.hashable)
+            (hsPkgs.process-extras)
+            (hsPkgs.serialise)
+            (hsPkgs.text)
+            (hsPkgs.io-sim-classes)
+            (hsPkgs.ouroboros-network-testing)
+            (hsPkgs.typed-protocols)
+            ];
+          };
+        };
       tests = {
         "tests" = {
           depends = [

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -202,3 +202,39 @@ test-suite tests
                        -fno-ignore-asserts
   if flag(ipv6)
     cpp-options:       -DOUROBOROS_NETWORK_IPV6
+
+executable test-cddl
+  hs-source-dirs:      test-cddl src
+  main-is:             Main.hs
+  other-modules:       Ouroboros.Network.Protocol.ChainSync.Codec
+                       Ouroboros.Network.Protocol.ChainSync.Type
+                       Ouroboros.Network.Block
+                       Ouroboros.Network.Chain
+                       Ouroboros.Network.ChainFragment
+                       Ouroboros.Network.Codec
+                       Ouroboros.Network.Protocol.BlockFetch.Codec
+                       Ouroboros.Network.Protocol.BlockFetch.Type
+                       Ouroboros.Network.Protocol.ChainSync.Codec
+                       Ouroboros.Network.Protocol.ChainSync.Type
+                       Ouroboros.Network.Protocol.PingPong.Codec
+                       Ouroboros.Network.Protocol.ReqResp.Codec
+                       Ouroboros.Network.Testing.ConcreteBlock
+                       Ouroboros.Network.Block
+                       Ouroboros.Network.Chain
+                       Ouroboros.Network.Codec
+  default-language:    Haskell2010
+  default-extensions:  NamedFieldPuns
+  build-depends:       base,
+                       bytestring,
+                       cborg,
+                       fingertree,
+                       hashable,
+                       process-extras,
+                       serialise,
+                       text,
+                       io-sim-classes,
+                       ouroboros-network-testing,
+                       typed-protocols
+  ghc-options:         -Wall
+                       -Wno-unticked-promoted-constructors
+                       -fno-ignore-asserts

--- a/ouroboros-network/test-cddl/Main.hs
+++ b/ouroboros-network/test-cddl/Main.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
+module Main
+where
+
+import System.Environment (getArgs)
+import System.Exit (ExitCode(..))
+import System.Process.ByteString.Lazy
+import Control.Monad
+import Control.Exception.Base (throw)
+import qualified Data.ByteString.Lazy as BS
+import Data.ByteString.Lazy (ByteString)
+import Data.ByteString.Lazy.Char8 as Char8 (putStrLn, unpack, lines)
+import qualified Codec.Serialise.Class as Serialise
+import Codec.CBOR.Decoding (decodeWord, decodeListLenOf, decodeBytes)
+import Codec.CBOR.Read
+
+import Ouroboros.Network.Protocol.ChainSync.Type as CS
+import Ouroboros.Network.Protocol.ChainSync.Codec (codecChainSync)
+import Network.TypedProtocol.ReqResp.Type as ReqResp
+import Ouroboros.Network.Protocol.ReqResp.Codec (codecReqResp)
+import Ouroboros.Network.Protocol.PingPong.Codec (codecPingPong)
+import Network.TypedProtocol.PingPong.Type as PingPong
+import Ouroboros.Network.Protocol.BlockFetch.Codec (codecBlockFetch)
+import Ouroboros.Network.Protocol.BlockFetch.Type as BlockFetch
+import Ouroboros.Network.Testing.ConcreteBlock
+
+import Network.TypedProtocol.Codec
+
+-- the concrete types used for the test
+type CS = ChainSync DummyBytes DummyBytes
+type RR = ReqResp DummyBytes DummyBytes
+type BF = BlockFetch BlockHeader BlockBody
+
+main :: IO ()
+main = getArgs >>= \case
+    [cddlCmd,diag2cborCmd,cddlSpec,rounds]
+        -> generateAndDecode cddlCmd diag2cborCmd cddlSpec (read rounds)
+    _ -> error "call with 4 arguments"
+
+test :: IO ()
+test = generateAndDecode "./cddl" "./diag2cbor.rb" "../doc/messages.cddl" 100
+
+generateAndDecode :: FilePath -> FilePath -> FilePath -> Int -> IO ()
+generateAndDecode cddlCmd diag2cborCmd cddlSpec rounds = do
+    diags <- generateCBORDiag cddlCmd cddlSpec rounds
+    forM_ diags $ \diag -> do
+        Char8.putStrLn diag
+        bytes <- diagToBytes diag2cborCmd diag
+        decodeMsg $ decodeTopTerm bytes
+
+generateCBORDiag :: FilePath -> FilePath -> Int -> IO [ByteString]
+generateCBORDiag cddlCmd cddlSpec rounds = do
+    result <- readProcessWithExitCode cddlCmd [cddlSpec, "generate", show rounds] BS.empty
+    case result of
+        (ExitFailure _, _, err) -> error $ Char8.unpack err
+        (ExitSuccess, diags, err) -> do
+            Char8.putStrLn err
+            return $ Char8.lines diags
+
+diagToBytes :: FilePath -> ByteString -> IO ByteString
+diagToBytes diag2cborCmd diag = do
+    result <- readProcessWithExitCode diag2cborCmd ["-"] diag
+    case result of
+        (ExitFailure _ , _, err) -> error $ Char8.unpack err
+        (ExitSuccess, bytes, _) -> return bytes
+
+decodeFile :: FilePath -> IO ()
+decodeFile f =
+    BS.readFile f >>= decodeMsg . decodeTopTerm
+
+data DummyBytes = DummyBytes
+instance Serialise.Serialise DummyBytes where
+    encode _ = error "encode Serialise DummyBytes"
+    decode = decodeBytes >> return DummyBytes
+
+type MonoCodec x = Codec x Codec.CBOR.Read.DeserialiseFailure IO ByteString
+
+-- | Split the ByteString into the tag-word and the rest.
+decodeTopTerm :: ByteString -> (Word, ByteString)
+decodeTopTerm input
+    = case deserialiseFromBytes (decodeListLenOf 2 >> decodeWord) input of
+        Right (bs,tag) -> (tag,bs)
+        Left err -> throw err
+
+-- Decode a message. Throw an error if the message is not decodeable.
+decodeMsg :: (Word, ByteString) -> IO ()
+decodeMsg (tag, input) = case tag of
+    0 -> tryParsers "chainSync"  chainSyncParsers
+    1 -> tryParsers "reqResp"    reqRespParsers
+    2 -> tryParsers "pingPong"   pingPongParsers
+    3 -> tryParsers "blockFetch" blockFetchParsers
+    4 -> return () -- "txSubmissionMessage" in branch
+    5 -> return () -- error "muxControlMessage" in branch
+    _ -> error "unkown tag"
+    where
+        tryParsers :: String -> [IO Bool] -> IO ()
+        tryParsers name [] = error $ "parse failed : " ++ name
+        tryParsers name (h:t) = h >>= \case
+            True -> return ()
+            False -> tryParsers name t
+
+        runCodec
+          :: IO (DecodeStep ByteString DeserialiseFailure IO (SomeMessage st))
+          -> ByteString
+          -> IO Bool
+        runCodec cont bs = cont >>= \case
+            DecodeDone _msg _rest -> error "runCodec: codec is DecodeDone"
+            DecodeFail _f -> error "runCodec: codec is DecodeFail"
+            DecodePartial next -> (next $ Just bs) >>= \case
+                DecodePartial _ -> return False
+                DecodeDone _msg rest -> case rest of
+                    Nothing -> return True
+                    Just _r  -> return False
+                DecodeFail _f -> return False
+
+        run :: forall ps (pr :: PeerRole) (st :: ps).
+                Codec ps DeserialiseFailure IO ByteString
+             -> PeerHasAgency pr st -> IO Bool
+        run codec state = runCodec ((decode codec) state) input
+
+        runCS = run (codecChainSync :: MonoCodec CS)
+        chainSyncParsers = [
+              runCS (ClientAgency CS.TokIdle)
+            , runCS (ServerAgency (CS.TokNext TokCanAwait))
+            , runCS (ClientAgency CS.TokIdle)
+            , runCS (ServerAgency CS.TokIntersect)
+            , runCS (ServerAgency CS.TokIntersect)
+            ]
+
+        runReqResp = run (codecReqResp :: MonoCodec RR)
+        reqRespParsers = [
+              runReqResp (ClientAgency ReqResp.TokIdle)
+            , runReqResp (ServerAgency ReqResp.TokBusy)
+            ]
+
+        runPingPong = run (codecPingPong :: MonoCodec PingPong)
+        pingPongParsers = [
+              runPingPong (ClientAgency PingPong.TokIdle)
+            , runPingPong (ServerAgency PingPong.TokBusy)
+            ]
+
+        runBlockFetch = run (codecBlockFetch :: MonoCodec BF)
+        blockFetchParsers = [
+              runBlockFetch (ClientAgency BlockFetch.TokIdle)
+            , runBlockFetch (ServerAgency BlockFetch.TokBusy)
+            , runBlockFetch (ServerAgency BlockFetch.TokStreaming)
+            ]


### PR DESCRIPTION
Test that every message according to the CDDL-spec
is also accepted by the codecs.
The executable `test-cddl` takes 4 arguments:
1) the path to the cddl command
2) the path to the diag2cbor.rb command
3) the path cddl-spec
4) number of iterations
Supported codecs are: ChainSync, ReqResp, PingPong and BlockFetch
TODO: add TxSubmission and MuxControl
TODO: also test the other direction