### PR TITLE
Fix cabal.project after PBFT integration

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -29,5 +29,39 @@ source-repository-package
   subdir:   contra-tracer
   tag: b656651fd3c357860d8136598b223b048c195eae
 
-package basic-tracer
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-base
+  tag: 2f33cbf9101dfee1cb488271ec96e210329eec96
+  subdir: binary
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger
+  tag: 595cfb5b20863fca869550423a4e27aab8e68aed
+  subdir: .
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger
+  tag: 595cfb5b20863fca869550423a4e27aab8e68aed
+  subdir: crypto
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-prelude
+  tag: e1fb84b1a955b6e3e3e53d9022e8bc0f927417a2
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-crypto
+  tag: 3c707936ba0a665375acf5bd240dc4b6eaa6c0bc
+
+source-repository-package
+  type: git
+  location: https://github.com/well-typed/cborg
+  tag: 80fbe0ee5e67a5622e2cb9eaa9d8594a2214322d
+  subdir: cborg
+
+package contra-tracer
   tests: False


### PR DESCRIPTION
After #409 was merged the repo was no longer buildable with `cabal new-build`. This fixes that, though it would be good if we could somehow keep these things in sync.