### PR TITLE
Rember the remaining bytestring chunks

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Codec.hs
@@ -137,10 +137,12 @@ convertCborDecoderLBS cborDecode liftST =
     -- and our choice here that consumes lazy bytestrings.
     go :: [BS.ByteString] -> CBOR.IDecode s a
        -> m (DecodeStep LBS.ByteString CBOR.DeserialiseFailure m a)
-    go _  (CBOR.Done  trailing _ x)
+    go [] (CBOR.Done  trailing _ x)
       | BS.null trailing    = return (DecodeDone x Nothing)
       | otherwise           = return (DecodeDone x (Just trailing'))
                                 where trailing' = LBS.fromStrict trailing
+    go cs (CBOR.Done  trailing _ x) = return (DecodeDone x (Just trailing'))
+                                where trailing' = LBS.fromChunks (trailing : cs)
     go _  (CBOR.Fail _ _ e) = return (DecodeFail e)
 
     -- We keep a bunch of chunks and supply the CBOR decoder with them


### PR DESCRIPTION
Remeber the remaining bytestring chunks after successfully parsing a
CBOR message. Previously only the remaining data in the current chunk
was saved.