### PR TITLE
Drop unused deps in network lib

### DIFF
--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -26,19 +26,16 @@
           (hsPkgs.binary)
           (hsPkgs.bytestring)
           (hsPkgs.cborg)
-          (hsPkgs.clock)
           (hsPkgs.containers)
           (hsPkgs.fingertree)
-          (hsPkgs.hashable)
-          (hsPkgs.iohk-monitoring)
           (hsPkgs.mtl)
           (hsPkgs.network)
-          (hsPkgs.pipes)
           (hsPkgs.process)
           (hsPkgs.serialise)
           (hsPkgs.stm)
-          (hsPkgs.text)
           (hsPkgs.time)
+          (hsPkgs.hashable)
+          (hsPkgs.text)
           ];
         };
       tests = {

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -36,9 +36,7 @@ library
                        Ouroboros.Network.BlockFetch.DeltaQ
                        Ouroboros.Network.BlockFetch.State
                        Ouroboros.Network.BlockFetch.Types
-                       Ouroboros.Network.Chain
                        Ouroboros.Network.ChainFragment
-                       Ouroboros.Network.ChainProducerState
                        Ouroboros.Network.Channel
                        Ouroboros.Network.Codec
                        Ouroboros.Network.DeltaQ
@@ -51,7 +49,6 @@ library
                        Ouroboros.Network.Pipe
                        Ouroboros.Network.Socket
                        Ouroboros.Network.Time
-                       Ouroboros.Network.Testing.ConcreteBlock
                        Ouroboros.Network.Protocol.ChainSync.Client
                        Ouroboros.Network.Protocol.ChainSync.Codec
                        Ouroboros.Network.Protocol.ChainSync.Server
@@ -99,7 +96,6 @@ library
                        clock             >=0.7 && <0.8,
                        containers,
                        fingertree        >=0.1.4.2 && <0.2,
-                       hashable          >=1.2 && <1.3,
                        iohk-monitoring,
                        mtl               >=2.2 && <2.3,
                        network,
@@ -107,12 +103,20 @@ library
                        process           >=1.6 && <1.7,
                        serialise         >=0.2 && <0.3,
                        stm               >=2.4 && <2.6,
-                       text              >=1.2 && <1.3,
                        time              >=1.6 && <1.10
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts
+
+  -- Still in the lib for now as they're used in ouroboros-consensus.
+  -- They should be moved to the separate test lib if they're still needed.
+  exposed-modules:     Ouroboros.Network.Chain
+                       Ouroboros.Network.ChainProducerState
+                       Ouroboros.Network.Testing.ConcreteBlock
+  build-depends:       hashable          >=1.2 && <1.3,
+                       text              >=1.2 && <1.3
+
 
 test-suite tests
   type:                exitcode-stdio-1.0

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -46,8 +46,6 @@ library
                        Ouroboros.Network.Mux.Types
                        Ouroboros.Network.NodeToNode
                        Ouroboros.Network.NodeToClient
-                       Ouroboros.Network.Pipe
-                       Ouroboros.Network.Socket
                        Ouroboros.Network.Time
                        Ouroboros.Network.Protocol.ChainSync.Client
                        Ouroboros.Network.Protocol.ChainSync.Codec
@@ -55,7 +53,6 @@ library
                        Ouroboros.Network.Protocol.ChainSync.Type
                        Ouroboros.Network.Protocol.ChainSync.Examples
                        Ouroboros.Network.Protocol.PingPong.Codec
-                       Ouroboros.Network.Protocol.ReqResp.Codec
                        Ouroboros.Network.Protocol.BlockFetch.Type
                        Ouroboros.Network.Protocol.BlockFetch.Client
                        Ouroboros.Network.Protocol.BlockFetch.Server
@@ -93,13 +90,10 @@ library
                        binary            >=0.8 && <0.9,
                        bytestring        >=0.10 && <0.11,
                        cborg             >=0.2.1 && <0.3,
-                       clock             >=0.7 && <0.8,
                        containers,
                        fingertree        >=0.1.4.2 && <0.2,
-                       iohk-monitoring,
                        mtl               >=2.2 && <2.3,
                        network,
-                       pipes             >=4.3 && <4.4,
                        process           >=1.6 && <1.7,
                        serialise         >=0.2 && <0.3,
                        stm               >=2.4 && <2.6,

--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -28,20 +28,19 @@ import           Codec.CBOR.Decoding (decodeListLenOf)
 import           Codec.CBOR.Encoding (encodeListLen)
 import           Codec.Serialise (Serialise (..))
 import           Data.FingerTree (Measured)
-import           Data.Hashable
 import           Data.Typeable (Typeable)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 
 -- | The 0-based index for the Ourboros time slot.
 newtype SlotNo = SlotNo { unSlotNo :: Word64 }
-  deriving (Show, Eq, Ord, Hashable, Enum, Bounded, Num, Serialise, Generic)
+  deriving (Show, Eq, Ord, Enum, Bounded, Num, Serialise, Generic)
 
 -- | The 0-based index of the block in the blockchain.
 -- BlockNo is <= SlotNo and is only equal at slot N if there is a block
 -- for every slot where N <= SlotNo.
 newtype BlockNo = BlockNo { unBlockNo :: Word64 }
-  deriving (Show, Eq, Ord, Hashable, Enum, Bounded, Num, Serialise, Generic)
+  deriving (Show, Eq, Ord, Enum, Bounded, Num, Serialise, Generic)
 
 -- | Abstract over the shape of blocks (or indeed just block headers)
 class (StandardHash b, Measured BlockMeasure b, Typeable b) => HasHeader b where
@@ -96,16 +95,6 @@ deriving instance StandardHash block => Eq   (ChainHash block)
 deriving instance StandardHash block => Ord  (ChainHash block)
 deriving instance StandardHash block => Show (ChainHash block)
 
--- | 'Hashable' instance for 'Hash'
---
--- We don't insist that 'Hashable' in 'StandardHash' because 'Hashable' is
--- only used in the network layer /tests/.
---
--- This requires @UndecidableInstances@ because @Hashable (HeaderHash b)@
--- is no smaller than @Hashable (ChainHash b)@.
-instance Hashable (HeaderHash b) => Hashable (ChainHash b) where
- -- use generic instance
-
 castHash :: HeaderHash b ~ HeaderHash b' => ChainHash b -> ChainHash b'
 castHash GenesisHash   = GenesisHash
 castHash (BlockHash b) = BlockHash b
@@ -152,6 +141,7 @@ data ChainUpdate block = AddBlock block
   Serialisation
 -------------------------------------------------------------------------------}
 
+--TODO: these two instances require UndecidableInstances
 instance Serialise (HeaderHash b) => Serialise (ChainHash b) where
   -- use the Generic instance
 

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -1,8 +1,13 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+-- This module is for examples and tests (not the library) so orphans are ok
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Concrete block
 --
@@ -97,6 +102,19 @@ newtype BlockSigner = BlockSigner Word64
 --
 hashHeader :: BlockHeader -> ConcreteHeaderHash
 hashHeader (BlockHeader _ b c d e f) = HeaderHash (hash (b, c, d, e, f))
+
+deriving instance Hashable SlotNo
+deriving instance Hashable BlockNo
+
+-- | 'Hashable' instance for 'Hash'
+--
+-- We don't insist that 'Hashable' in 'StandardHash' because 'Hashable' is
+-- only used in the network layer /tests/.
+--
+-- This requires @UndecidableInstances@ because @Hashable (HeaderHash b)@
+-- is no smaller than @Hashable (ChainHash b)@.
+instance Hashable (HeaderHash b) => Hashable (ChainHash b)
+ -- use generic instance
 
 -- | The hash of all the information in a 'BlockHeader'.
 --


### PR DESCRIPTION
A few small patches to move modules that are only used by tests, and thereby drop several dependencies.