### PR TITLE
Use orElse in default implementations of Async class methods

### DIFF
--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -1011,8 +1011,7 @@ execAtomically mytid = go [] [] []
     go :: [SomeTVar s]
        -> [SomeTVar s]
        -> [(Int, StmA s a)] -- list of checkpoints of written variables at the
-                            -- point of @OrElse@ and second argument of
-                            -- @OrElse@
+                            -- point of @OrElse@ and second argument of @OrElse@
        -> TVarId
        -> StmA s a -> ST s (StmTxResult s a)
     go read written orElses nextVid action = case action of


### PR DESCRIPTION
These are the implementations used in the async library. The only reason we were using low level ones before was because we didn't have the STM orElse combinator available.

We could also, if needed, use this to adjust the default async implementation to provide a Functor instance.