### PR TITLE
cleanup exceptions and move some api calls in STM

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -42,15 +42,16 @@ module Control.Monad.Class.MonadSTM
 
 import           Prelude hiding (read)
 
-import qualified Control.Monad.STM as STM
-import qualified Control.Concurrent.STM.TVar as STM
+import qualified Control.Concurrent.STM.TBQueue as STM
 import qualified Control.Concurrent.STM.TMVar as STM
 import qualified Control.Concurrent.STM.TQueue as STM
-import qualified Control.Concurrent.STM.TBQueue as STM
+import qualified Control.Concurrent.STM.TVar as STM
+import qualified Control.Monad.STM as STM
 
 import           Control.Exception
 import           Control.Monad.Except
 import           Control.Monad.Reader
+import           Control.Monad.State
 import           GHC.Stack
 import           Numeric.Natural (Natural)
 
@@ -125,6 +126,45 @@ instance MonadSTM m => MonadSTM (ReaderT e m) where
   type TBQueue (ReaderT e m) = TBQueue m
 
   atomically (ReaderT t) = ReaderT $ \e -> atomically (t e)
+  newTVar          = lift . newTVar
+  readTVar         = lift . readTVar
+  writeTVar t a    = lift $ writeTVar t a
+  retry            = lift retry
+
+  newTMVar         = lift . newTMVar
+  newTMVarM        = lift . newTMVarM
+  newEmptyTMVar    = lift newEmptyTMVar
+  newEmptyTMVarM   = lift newEmptyTMVarM
+  takeTMVar        = lift . takeTMVar
+  tryTakeTMVar     = lift . tryTakeTMVar
+  putTMVar   t a   = lift $ putTMVar t a
+  tryPutTMVar t a  = lift $ tryPutTMVar t a
+  readTMVar        = lift . readTMVar
+  tryReadTMVar     = lift . tryReadTMVar
+  swapTMVar t a    = lift $ swapTMVar t a
+  isEmptyTMVar     = lift . isEmptyTMVar
+
+  newTQueue        = lift $ newTQueue
+  readTQueue       = lift . readTQueue
+  tryReadTQueue    = lift . tryReadTQueue
+  writeTQueue q a  = lift $ writeTQueue q a
+  isEmptyTQueue    = lift . isEmptyTQueue
+
+  newTBQueue       = lift . newTBQueue
+  readTBQueue      = lift . readTBQueue
+  tryReadTBQueue   = lift . tryReadTBQueue
+  writeTBQueue q a = lift $ writeTBQueue q a
+  isEmptyTBQueue   = lift . isEmptyTBQueue
+  isFullTBQueue    = lift . isFullTBQueue
+
+instance MonadSTM m => MonadSTM (StateT s m) where
+  type STM (StateT s m) = StateT s (STM m)
+  type TVar (StateT s m)  = TVar m
+  type TMVar (StateT s m) = TMVar m
+  type TQueue (StateT s m)  = TQueue m
+  type TBQueue (StateT s m) = TBQueue m
+
+  atomically (StateT t) = StateT $ \e -> atomically (t e)
   newTVar          = lift . newTVar
   readTVar         = lift . readTVar
   writeTVar t a    = lift $ writeTVar t a

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
@@ -7,6 +7,7 @@ module Ouroboros.Storage.VolatileDB.API
   , module Ouroboros.Storage.VolatileDB.Types
   ) where
 
+import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 
 import           Data.ByteString (ByteString)
@@ -36,5 +37,5 @@ data VolatileDB blockId m = VolatileDB {
     , getBlockIds    :: HasCallStack => m [blockId]
     , getSuccessors  :: HasCallStack => m (Maybe blockId -> Set blockId)
     , garbageCollect :: HasCallStack => SlotNo -> m ()
-    , getIsMember    :: HasCallStack => m (blockId -> Bool)
+    , getIsMember    :: HasCallStack => STM m (Maybe (blockId -> Bool))
 }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
@@ -189,10 +189,10 @@ tryFS :: IO a -> IO (Either FsError a)
 tryFS = E.try
 
 tryImmDB :: MonadCatch m => m a -> m (Either ImmutableDBError a)
-tryImmDB = tryDB (UnexpectedError . Immutable.FileSystemError)
+tryImmDB = tryDB (Immutable.UnexpectedError . Immutable.FileSystemError)
 
 tryVolDB :: (Show blockId, Typeable blockId, MonadCatch m) => m a -> m (Either (VolatileDBError blockId) a)
-tryVolDB = tryDB Volatile.FileSystemError
+tryVolDB = tryDB (Volatile.UnexpectedError . Volatile.FileSystemError)
 
 tryDB :: forall e a m. (Exception e, MonadCatch m) => (FsError -> e) -> m a -> m (Either e a)
 tryDB fromFS = fmap squash . C.try . C.try

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB.hs
@@ -32,7 +32,7 @@ tests = testGroup "VolatileDB"
 prop_VolatileInvalidArg :: HasCallStack => Property
 prop_VolatileInvalidArg = monadicIO $ do
     let fExpected = \case
-            Left (InvalidArgumentsError _str) -> return ()
+            Left (UserError (InvalidArgumentsError _str)) -> return ()
             somethingElse -> fail $ "IO returned " <> show somethingElse <> " instead of InvalidArgumentsError"
     run $ apiEquivalenceVolDB fExpected (\hasFS err -> do
             _ <- Internal.openDBFull hasFS err (myParser hasFS err) 0


### PR DESCRIPTION
related issue https://github.com/input-output-hk/ouroboros-network/issues/428
This pr:
- cleans up exceptions in volatile db (all FsErrors are now wrapped as VolatileDBErrors and VolatileDBErrors are split between UserError and UnexpectedError.
- makes `getIsMember` live in `STM m`  instead of `m`.

Unfortunately I had an issue with last bullet and this pr is not yet 100% (however it works properly). The issue is that for the Model `m` is State, so I had to define MonadSTM instance for State. MonadSTM for StateT was easily defined, however defining full MonadSTM for Identity does not make much sense. What I did was I used another Monad, called MockIdentity, with similar definition as Identity. Then, I defined only `type STM` and `atomically` in the MonadSTM definition of MockIdentity. These 2 definitions are the only ones needed to make the tests work properly.

I also tries using SimA, but I haven't managed to make it work yet.