### PR TITLE
Change how ledger DB is initialized

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/MemPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/MemPolicy.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 module Ouroboros.Storage.LedgerDB.MemPolicy (
     MemPolicy -- opaque
   , memPolicyVerify
@@ -12,6 +14,7 @@ module Ouroboros.Storage.LedgerDB.MemPolicy (
 
 import           Data.Either (isRight)
 import           Data.Word
+import           GHC.Generics (Generic)
 
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 
@@ -45,7 +48,7 @@ newtype MemPolicy = MemPolicy {
     -- mean we keep absolutely all snapshots.
     memPolicyToSkips :: [Word64]
   }
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 -- | Default in-memory policy
 --


### PR DESCRIPTION
In our original design for the Chain DB we had envisioned that we would _always_ support a roll back of up to `k` blocks. We had since changed our mind about that: if due to data loss we have fewer than `k` blocks available in the volatile DB, we would only support rollback to the tip of the immutable DB. On Friday I realized that there was still a remnant of the old decision decision present in the ledger DB. I changed that (that was easy), but updating the ledger DB tests to reflect this new design is a bit trickier.

q-s-m stats:

```
        LedgerSimple: OK (443.62s)
          +++ OK, passed 1000000 tests:
          50.1167% MemPolicyMaxOffset (R_Eq 4)
          45.7364% MemPolicyMaxOffset (R_Gt 20)
           2.5888% MemPolicyMaxOffset (R_Eq 0)
           0.5065% MemPolicyMaxOffset (R_Btwn (5,10))
           0.4239% MemPolicyMaxOffset (R_Btwn (11,20))
           0.2519% MemPolicyMaxOffset (R_Eq 2)
           0.2228% MemPolicyMaxOffset (R_Eq 1)
           0.1530% MemPolicyMaxOffset (R_Eq 3)
          
          Tags (3040312 in total):
           6.93153% TagMaxRollback (R_Eq 0)
           6.73543% TagRestore Nothing (R_Eq 0)
           5.12836% TagMaxDrop (R_Eq 0)
           4.89400% TagMaxRollback (R_Eq 1)
           4.39323% TagMaxRollback (R_Eq 2)
           3.87299% TagMaxDrop (R_Eq 1)
           3.83010% TagMaxRollback (R_Eq 3)
           3.80076% TagMaxDrop (R_Eq 2)
           3.56378% TagMaxRollback (R_Eq 4)
           3.54934% TagRestore (Just SnapOk) R_Gt_k
           3.49599% TagMaxDrop R_Gt_k
           3.48451% TagMaxDrop (R_Eq 3)
           3.04761% TagRestore Nothing (R_Eq 1)
           3.03281% TagMaxDrop (R_Btwn (5,10))
           2.97660% TagRestore (Just SnapOk) (R_Btwn (5,10))
           2.91408% TagMaxDrop (R_Eq 4)
           2.60013% TagRestore (Just SnapOk) (R_Eq 2)
           2.46133% TagRestore (Just SnapOk) (R_Eq 3)
           2.37101% TagRestore (Just SnapOk) (R_Eq 1)
           2.17932% TagRestore (Just SnapOk) (R_Eq 4)
           2.15435% TagMaxRollback (R_Btwn (5,10))
           2.14534% TagRestore (Just SnapOk) (R_Eq 0)
           2.01650% TagRestore Nothing (R_Eq 2)
           1.87379% TagRestore (Just (SnapCorrupted Delete)) R_Gt_k
           1.65450% TagRestore (Just (SnapCorrupted Delete)) (R_Eq 2)
           1.56497% TagRestore (Just (SnapCorrupted Delete)) (R_Eq 1)
           1.49886% TagRestore (Just (SnapCorrupted Delete)) (R_Eq 3)
           1.47251% TagRestore (Just (SnapCorrupted Delete)) (R_Btwn (5,10))
           1.29681% TagRestore (Just (SnapCorrupted Delete)) (R_Eq 0)
           1.25576% TagRestore (Just (SnapCorrupted Delete)) (R_Eq 4)
           1.13992% TagRestore Nothing (R_Eq 3)
           0.70309% TagRestore (Just (SnapCorrupted Truncate)) (R_Eq 1)
           0.69825% TagRestore (Just (SnapCorrupted Truncate)) (R_Eq 2)
           0.64668% TagRestore Nothing (R_Eq 4)
           0.61527% TagRestore (Just (SnapCorrupted Truncate)) R_Gt_k
           0.61145% TagRestore (Just (SnapCorrupted Truncate)) (R_Eq 0)
           0.57333% TagRestore (Just (SnapCorrupted Truncate)) (R_Eq 3)
           0.51271% TagRestore (Just (SnapCorrupted Truncate)) (R_Btwn (5,10))
           0.49186% TagRestore Nothing R_Gt_k
           0.46015% TagRestore (Just (SnapCorrupted Truncate)) (R_Eq 4)
           0.39654% TagRestore (Just SnapOk) (R_Btwn (11,20))
           0.37687% TagRestore Nothing (R_Btwn (5,10))
           0.19636% TagMaxDrop (R_Btwn (11,20))
           0.16035% TagRestore (Just (SnapCorrupted Delete)) (R_Btwn (11,20))
           0.14564% TagMaxRollback (R_Btwn (11,20))
           0.05628% TagRestore (Just (SnapCorrupted Truncate)) (R_Btwn (11,20))
           0.00921% TagRestore Nothing (R_Btwn (11,20))
           0.00487% TagRestore (Just SnapOk) (R_Gt 20)
           0.00201% TagRestore (Just (SnapCorrupted Delete)) (R_Gt 20)
           0.00135% TagMaxDrop (R_Gt 20)
           0.00105% TagMaxRollback (R_Gt 20)
           0.00049% TagRestore (Just (SnapCorrupted Truncate)) (R_Gt 20)
```