### PR TITLE
sendRecvDebugTracer for miniprotocols

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -12,7 +12,6 @@ module Ouroboros.Network.Protocol.BlockFetch.Type where
 import           Data.Void (Void)
 
 import           Ouroboros.Network.Block (StandardHash, Point)
-import           Network.TypedProtocol.Codec (AnyMessage (..))
 import           Network.TypedProtocol.Core (Protocol (..))
 
 -- | Range of headers, defined by a lower and upper point, inclusive.
@@ -90,6 +89,3 @@ instance (StandardHash header, Show body) => Show (Message (BlockFetch header bo
   show MsgNoBlocks             = "MsgNoBlocks"
   show MsgBatchDone            = "MsgBatchDone"
   show MsgClientDone           = "MsgClientDone"
-
-instance (StandardHash header, Show body) => Show (AnyMessage (BlockFetch header body)) where
-  show (AnyMessage msg) = show msg

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -12,7 +12,6 @@
 module Ouroboros.Network.Protocol.ChainSync.Type where
 
 import Network.TypedProtocol.Core
-import Network.TypedProtocol.Codec (AnyMessage (..))
 
 
 -- | A kind to identify our protocol, and the types of the states in the state
@@ -154,6 +153,3 @@ instance (Show header, Show point) => Show (Message (ChainSync header point) fro
   show (MsgIntersectImproved p tip) = "MsgIntersectImproved " ++ show p ++ " " ++ show tip
   show (MsgIntersectUnchanged p)    = "MsgIntersectUnchanged " ++ show p
   show MsgDone{}                    = "MsgDone"
-
-instance (Show header, Show point) => Show (AnyMessage (ChainSync header point)) where
-  show (AnyMessage msg) = show msg

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -145,15 +145,15 @@ data TokNextKind (k :: StNextKind) where
   TokMustReply :: TokNextKind StMustReply
 
 
-instance Show (Message (ChainSync header point) from to) where
-  show MsgRequestNext          = "MsgRequestNext"
-  show MsgAwaitReply           = "MsgAwaitReply"
-  show MsgRollForward{}        = "MsgRollForward"
-  show MsgRollBackward{}       = "MsgRollBackward"
-  show MsgFindIntersect{}      = "MsgFindIntersect"
-  show MsgIntersectImproved{}  = "MsgIntersectImproved"
-  show MsgIntersectUnchanged{} = "MsgIntersectUnchanged"
-  show MsgDone{}               = "MsgDone"
+instance (Show header, Show point) => Show (Message (ChainSync header point) from to) where
+  show MsgRequestNext               = "MsgRequestNext"
+  show MsgAwaitReply                = "MsgAwaitReply"
+  show (MsgRollForward h tip)       = "MsgRollForward " ++ show h ++ " " ++ show tip
+  show (MsgRollBackward p tip)      = "MsgRollBackward " ++ show p ++ " " ++ show tip
+  show (MsgFindIntersect ps)        = "MsgFindIntersect " ++ show ps
+  show (MsgIntersectImproved p tip) = "MsgIntersectImproved " ++ show p ++ " " ++ show tip
+  show (MsgIntersectUnchanged p)    = "MsgIntersectUnchanged " ++ show p
+  show MsgDone{}                    = "MsgDone"
 
 instance (Show header, Show point) => Show (AnyMessage (ChainSync header point)) where
   show (AnyMessage msg) = show msg

--- a/typed-protocols/src/Network/TypedProtocol/Codec.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Codec.hs
@@ -7,6 +7,10 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE TypeInType                 #-}
+-- @UndecidableInstances@ extension is required for defining @Show@ instance of
+-- @'AnyMessage'@.
+{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE QuantifiedConstraints      #-}
 
 module Network.TypedProtocol.Codec (
     -- * Defining and using Codecs
@@ -195,6 +199,7 @@ data CodecFailure = CodecFailureOutOfInput
                   | CodecFailure String
   deriving (Eq, Show)
 
+-- safe instance with @UndecidableInstances@ in scope
 instance Exception CodecFailure
 
 
@@ -241,6 +246,10 @@ runDecoderPure runM decoder bs = runM (runDecoder bs =<< decoder)
 --
 data AnyMessage ps where
      AnyMessage :: Message ps st st' -> AnyMessage ps
+
+-- requires @UndecidableInstances@ and @QuantifiedConstraints@.
+instance (forall st st'. Show (Message ps st st')) => Show (AnyMessage ps) where
+    show (AnyMessage msg) = show msg
 
 -- | Used to hold the 'PeerHasAgency' state token and a corresponding 'Message'.
 --

--- a/typed-protocols/src/Network/TypedProtocol/Codec.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Codec.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE PolyKinds                  #-}

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -7,6 +7,9 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE EmptyCase #-}
+-- @UndecidableInstances@ extensions is required for defining @Show@ instance
+-- of @'TraceSendRecv'@.
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Drivers for running 'Peer's with a 'Codec' and a 'Channel'.
 --
@@ -44,7 +47,7 @@ import Network.TypedProtocol.Codec
 import Control.Monad.Class.MonadSTM
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadThrow
-import Control.Tracer (Tracer, traceWith)
+import Control.Tracer (Tracer (..), traceWith)
 
 import Numeric.Natural (Natural)
 
@@ -74,15 +77,19 @@ import Numeric.Natural (Natural)
 -- helpful utility for use in custom drives.
 --
 
-
---
--- Driver for normal peers
---
-
 -- | Structured 'Tracer' output for 'runPeer' and derivitives.
 --
 data TraceSendRecv ps = TraceSendMsg (AnyMessage ps)
                       | TraceRecvMsg (AnyMessage ps)
+
+-- requires @UndecidableInstances@ extension
+instance Show (AnyMessage ps) => Show (TraceSendRecv ps) where
+  show (TraceSendMsg msg) = "Send " ++ show msg
+  show (TraceRecvMsg msg) = "Recv " ++ show msg
+
+--
+-- Driver for normal peers
+--
 
 -- | Run a peer with the given channel via the given codec.
 --


### PR DESCRIPTION
This PR also adds show instance to `AnyMessage` using `QuantifiedConstraints`.  This way we get it for all mini-protocols at once.