### PR TITLE
Support for `cabal new-build all`

### DIFF
--- a/byron-proxy/byron-proxy.cabal
+++ b/byron-proxy/byron-proxy.cabal
@@ -84,7 +84,8 @@ executable byron-proxy
                        random,
                        stm,
                        text,
-                       time
+                       time,
+                       type-operators == 0.1.0.4
   hs-source-dirs:      src/exec
   default-language:    Haskell2010
   -- -threaded is needed or else the diffusion layer will crash, due to a use

--- a/cabal.project
+++ b/cabal.project
@@ -4,6 +4,8 @@ packages: ./typed-protocols
           ./ouroboros-consensus
           ./io-sim
           ./io-sim-classes
+          ./byron-proxy
+          ./type-operators
 
 package typed-protocols
   tests: True
@@ -15,7 +17,27 @@ package ouroboros-network
   tests: True
 
 package ouroboros-consensus
-  tests: True
+  tests: False
+
+source-repository-package
+  type: git
+  location: https://github.com/avieth/network-transport
+  tag: 0b8f5a7bec389a4ffa653792cfd203c742a0857b
+
+--
+-- from network-transport-tcp-HEAD.nix
+--
+
+source-repository-package
+  type: git
+  location: https://github.com/avieth/network-transport-tcp
+  tag: da5e1544ead1d1b70ca4b7a54fc5f02b1a9a98c9
+
+source-repository-package
+  type: git
+  location: https://github.com/avieth/kademlia
+  tag: 38a0575bb303804461f4b6176ca38eba81adbd79
+
 
 source-repository-package
   type: git
@@ -62,6 +84,129 @@ source-repository-package
   location: https://github.com/well-typed/cborg
   tag: 80fbe0ee5e67a5622e2cb9eaa9d8594a2214322d
   subdir: cborg
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: util
+
+source-repository-package
+  type: git
+  location: https://github.com/avieth/haskell-hedgehog.git
+  tag: d965a9002b16b82a548da4c071b0eb0af8ed7838
+  subdir: hedgehog
+
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: infra
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: db
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: crypto
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: core
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: chain
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: binary
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: lib
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: networking
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: crypto/test
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: core/test
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: chain/test
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: binary/test
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: util/test
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-report-server.git
+  tag: 9b96874d0f234554a5779d98762cc0a6773a532a
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/rocksdb-haskell-ng.git
+  tag: 49f501a082d745f3b880677220a29cafaa181452
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/universum.git
+  tag: 7f1b2483f71cacdfd032fe447064d6e0a1df50fc
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/log-warper
+  tag: 16246d4fbf16da7984f2a4b6c42f2ed5098182e4
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: util
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl
+  tag: f96f3fe04719bd3b0cedc1bbaf80fa6927e937f3
+  subdir: networking
 
 package contra-tracer
   tests: False

--- a/cabal.project
+++ b/cabal.project
@@ -5,7 +5,6 @@ packages: ./typed-protocols
           ./io-sim
           ./io-sim-classes
           ./byron-proxy
-          ./type-operators
 
 package typed-protocols
   tests: True


### PR DESCRIPTION
Useful for building binaries with dwarf debug info for profiling and debugging.

Tests for `ouroboros-consensus` has been disabled due to dependency conflicts, which means that this PR should _not_ be merged.