### PR TITLE
Remove `Serialise` class from a bunch of places

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,10 @@ dist/
 *.swp
 *.swo
 *~
+*_flymake.hs
 result*
 tags
+TAGS
 
 .stack-work/
 *.tix

--- a/ouroboros-consensus/demo-playground/Run.hs
+++ b/ouroboros-consensus/demo-playground/Run.hs
@@ -6,6 +6,7 @@ module Run (
       runNode
     ) where
 
+import           Codec.Serialise (encode)
 import qualified Control.Concurrent.Async as Async
 import           Control.Concurrent.STM
 import           Control.Monad
@@ -112,6 +113,7 @@ handleSimpleNode p CLI{..} (TopologyInfo myNodeId topologyFile) = do
 
              btime  <- realBlockchainTime slotDuration systemStart
              kernel <- nodeKernel
+                         encode
                          pInfoConfig
                          pInfoInitState
                          btime

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Class.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Class.hs
@@ -10,24 +10,23 @@ module Ouroboros.Consensus.Crypto.DSIGN.Class
     , SignedDSIGN (..)
     , signedDSIGN
     , verifySignedDSIGN
+    , encodeSignedDSIGN
+    , decodeSignedDSIGN
     ) where
 
-import           Codec.Serialise (Serialise (..))
+import           Codec.Serialise.Encoding (Encoding)
+import           Codec.CBOR.Decoding (Decoder)
 import           Crypto.Random (MonadRandom)
 import           GHC.Generics (Generic)
-
 import           Ouroboros.Consensus.Util.Condense
 
 class ( Show (VerKeyDSIGN v)
       , Ord (VerKeyDSIGN v)
-      , Serialise (VerKeyDSIGN v)
       , Show (SignKeyDSIGN v)
       , Ord (SignKeyDSIGN v)
-      , Serialise (SignKeyDSIGN v)
       , Show (SigDSIGN v)
       , Condense (SigDSIGN v)
       , Ord (SigDSIGN v)
-      , Serialise (SigDSIGN v)
       )
       => DSIGNAlgorithm v where
 
@@ -35,10 +34,17 @@ class ( Show (VerKeyDSIGN v)
     data SignKeyDSIGN v :: *
     data SigDSIGN v :: *
 
+    encodeVerKeyDSIGN :: VerKeyDSIGN v -> Encoding
+    decodeVerKeyDSIGN :: Decoder s (VerKeyDSIGN v)
+    encodeSignKeyDSIGN :: SignKeyDSIGN v -> Encoding
+    decodeSignKeyDSIGN :: Decoder s (SignKeyDSIGN v)
+    encodeSigDSIGN :: SigDSIGN v -> Encoding
+    decodeSigDSIGN :: Decoder s (SigDSIGN v)
+
     genKeyDSIGN :: MonadRandom m => m (SignKeyDSIGN v)
     deriveVerKeyDSIGN :: SignKeyDSIGN v -> VerKeyDSIGN v
-    signDSIGN :: (MonadRandom m, Serialise a) => a -> SignKeyDSIGN v -> m (SigDSIGN v)
-    verifyDSIGN :: Serialise a => VerKeyDSIGN v -> a -> SigDSIGN v -> Bool
+    signDSIGN :: MonadRandom m => (a -> Encoding) -> a -> SignKeyDSIGN v -> m (SigDSIGN v)
+    verifyDSIGN :: (a -> Encoding) -> VerKeyDSIGN v -> a -> SigDSIGN v -> Bool
 
 newtype SignedDSIGN v a = SignedDSIGN (SigDSIGN v)
   deriving (Generic)
@@ -50,13 +56,16 @@ deriving instance DSIGNAlgorithm v => Ord  (SignedDSIGN v a)
 instance Condense (SigDSIGN v) => Condense (SignedDSIGN v a) where
     condense (SignedDSIGN sig) = condense sig
 
-instance DSIGNAlgorithm v => Serialise (SignedDSIGN v a) where
-  -- use Generic instance
-  --
-signedDSIGN :: (DSIGNAlgorithm v, MonadRandom m, Serialise a)
-            => a -> SignKeyDSIGN v -> m (SignedDSIGN v a)
-signedDSIGN a key = SignedDSIGN <$> signDSIGN a key
+signedDSIGN :: (DSIGNAlgorithm v, MonadRandom m)
+            => (a -> Encoding) -> a -> SignKeyDSIGN v -> m (SignedDSIGN v a)
+signedDSIGN encoder a key = SignedDSIGN <$> signDSIGN encoder a key
 
-verifySignedDSIGN :: (DSIGNAlgorithm v, Serialise a)
-                  => VerKeyDSIGN v -> a -> SignedDSIGN v a -> Bool
-verifySignedDSIGN key a (SignedDSIGN s) = verifyDSIGN key a s
+verifySignedDSIGN :: DSIGNAlgorithm v
+                  => (a -> Encoding) -> VerKeyDSIGN v -> a -> SignedDSIGN v a -> Bool
+verifySignedDSIGN encoder key a (SignedDSIGN s) = verifyDSIGN encoder key a s
+
+encodeSignedDSIGN :: DSIGNAlgorithm v => SignedDSIGN v a -> Encoding
+encodeSignedDSIGN (SignedDSIGN s) = encodeSigDSIGN s
+
+decodeSignedDSIGN :: DSIGNAlgorithm v => Decoder s (SignedDSIGN v a)
+decodeSignedDSIGN = SignedDSIGN <$> decodeSigDSIGN

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/Hash/Class.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/Hash/Class.hs
@@ -10,9 +10,11 @@ module Ouroboros.Consensus.Crypto.Hash.Class
     , Hash
     , getHash
     , hash
+    , hashWithSerialiser
     , fromHash
     ) where
 
+import           Codec.Serialise.Encoding (Encoding)
 import           Codec.CBOR.Decoding (decodeBytes)
 import           Codec.CBOR.Write (toLazyByteString)
 import           Codec.Serialise (Serialise (..))
@@ -59,7 +61,10 @@ instance HashAlgorithm h => Serialise (Hash h a) where
             else fail $ "expected " ++ show le ++ " byte(s), but got " ++ show la
 
 hash :: forall h a. (HashAlgorithm h, Serialise a) => a -> Hash h a
-hash = Hash . digest (Proxy :: Proxy h)  . LB.toStrict . toLazyByteString . encode
+hash = hashWithSerialiser encode
+
+hashWithSerialiser :: forall h a. HashAlgorithm h => (a -> Encoding) -> a -> Hash h a
+hashWithSerialiser toEnc = Hash . digest (Proxy :: Proxy h)  . LB.toStrict . toLazyByteString . toEnc
 
 fromHash :: Hash h a -> Natural
 fromHash = foldl' f 0 . SB.unpack . getHash

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/KES/Simple.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/KES/Simple.hs
@@ -11,9 +11,12 @@ module Ouroboros.Consensus.Crypto.KES.Simple
     ( SimpleKES
     ) where
 
-import           Codec.Serialise (Serialise)
+import           Codec.Serialise (Serialise(..))
+import qualified Codec.Serialise.Encoding as Enc
+import qualified Codec.Serialise.Decoding as Dec
 import           Control.Monad (replicateM)
 import           Data.Vector (Vector, fromList, (!?))
+import qualified Data.Vector as Vec
 import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
 
@@ -35,6 +38,14 @@ instance DSIGNAlgorithm d => KESAlgorithm (SimpleKES d) where
     newtype SigKES (SimpleKES d) = SigSimpleKES (SigDSIGN d)
         deriving Generic
 
+    encodeVerKeyKES = encode
+    encodeSignKeyKES = encode
+    encodeSigKES = encode
+
+    decodeSignKeyKES = decode
+    decodeVerKeyKES = decode
+    decodeSigKES = decode
+
     genKeyKES duration = do
         sks <- replicateM (fromIntegral duration) genKeyDSIGN
         let vks = map deriveVerKeyDSIGN sks
@@ -42,31 +53,64 @@ instance DSIGNAlgorithm d => KESAlgorithm (SimpleKES d) where
 
     deriveVerKeyKES (SignKeySimpleKES (vks, _)) = VerKeySimpleKES $ fromList vks
 
-    signKES j a (SignKeySimpleKES (vks, xs)) = case dropWhile (\(k, _) -> k < j) xs of
+    signKES toEnc j a (SignKeySimpleKES (vks, xs)) = case dropWhile (\(k, _) -> k < j) xs of
         []           -> return Nothing
         (_, sk) : ys -> do
-            sig <- signDSIGN a sk
+            sig <- signDSIGN toEnc a sk
             return $ Just (SigSimpleKES sig, SignKeySimpleKES (vks, ys))
 
-    verifyKES (VerKeySimpleKES vks) j a (SigSimpleKES sig) =
+    verifyKES toEnc (VerKeySimpleKES vks) j a (SigSimpleKES sig) =
         case vks !? fromIntegral j of
             Nothing -> False
-            Just vk -> verifyDSIGN vk a sig
+            Just vk -> verifyDSIGN toEnc vk a sig
 
 deriving instance DSIGNAlgorithm d => Show (VerKeyKES (SimpleKES d))
 deriving instance DSIGNAlgorithm d => Eq (VerKeyKES (SimpleKES d))
 deriving instance DSIGNAlgorithm d => Ord (VerKeyKES (SimpleKES d))
-deriving instance DSIGNAlgorithm d => Serialise (VerKeyKES (SimpleKES d))
+instance DSIGNAlgorithm d => Serialise (VerKeyKES (SimpleKES d)) where
+  encode (VerKeySimpleKES vvks) =
+       Enc.encodeListLen (fromIntegral $ Vec.length vvks)
+    <> Vec.foldl' (<>) mempty (fmap encodeVerKeyDSIGN vvks)
+  decode = VerKeySimpleKES <$> do
+    len <- Dec.decodeListLen
+    Vec.fromList <$> replicateM len decodeVerKeyDSIGN
 
 deriving instance DSIGNAlgorithm d => Show (SignKeyKES (SimpleKES d))
 deriving instance DSIGNAlgorithm d => Eq (SignKeyKES (SimpleKES d))
 deriving instance DSIGNAlgorithm d => Ord (SignKeyKES (SimpleKES d))
-deriving instance DSIGNAlgorithm d => Serialise (SignKeyKES (SimpleKES d))
+instance DSIGNAlgorithm d => Serialise (SignKeyKES (SimpleKES d)) where
+  encode (SignKeySimpleKES (vks, stuff)) =
+       Enc.encodeListLen 2
+    <> Enc.encodeListLen (fromIntegral $ length vks)
+    <> mconcat (fmap encodeVerKeyDSIGN vks)
+    <> Enc.encodeListLen (fromIntegral $ length stuff)
+    <> mconcat (fmap encodeStuff stuff)
+    where
+      encodeStuff (n, skd) =
+           Enc.encodeListLen 2
+        <> Enc.encodeWord (fromIntegral n)
+        <> encodeSignKeyDSIGN skd
+  decode = SignKeySimpleKES <$> do
+    Dec.decodeListLenOf 2
+    vksLen <- Dec.decodeListLen
+    vks <- replicateM vksLen decodeVerKeyDSIGN
+    stuffLen <- Dec.decodeListLen
+    stuff <- replicateM stuffLen decodeStuff
+    return (vks, stuff)
+    where
+      decodeStuff = do
+        Dec.decodeListLenOf 2
+        n <- fromIntegral <$> Dec.decodeWord
+        sks <- decodeSignKeyDSIGN
+        return (n, sks)
+
 
 deriving instance DSIGNAlgorithm d => Show (SigKES (SimpleKES d))
 deriving instance DSIGNAlgorithm d => Eq (SigKES (SimpleKES d))
 deriving instance DSIGNAlgorithm d => Ord (SigKES (SimpleKES d))
-deriving instance DSIGNAlgorithm d => Serialise (SigKES (SimpleKES d))
+instance DSIGNAlgorithm d => Serialise (SigKES (SimpleKES d)) where
+  encode (SigSimpleKES d) = encodeSigDSIGN d
+  decode = SigSimpleKES <$> decodeSigDSIGN
 
 instance Condense (SigDSIGN d) => Condense (SigKES (SimpleKES d)) where
     condense (SigSimpleKES sig) = condense sig

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock.hs
@@ -291,7 +291,7 @@ forgeBlock :: forall m p c.
            -> IsLeader p
            -> m (SimpleBlock p c)
 forgeBlock cfg curSlot curNo prevHash txs proof = do
-    ouroborosPayload <- mkPayload cfg proof preHeader
+    ouroborosPayload <- mkPayload encode cfg proof preHeader
     return $ SimpleBlock {
         simpleHeader = SimpleHeader preHeader ouroborosPayload
       , simpleBody   = body
@@ -373,7 +373,7 @@ instance (PBftCrypto c, SimpleBlockCrypto c')
   => ProtocolLedgerView (SimpleBlock (ExtNodeConfig (PBftLedgerView c) (PBft c)) c') where
   protocolLedgerView (EncNodeConfig _ pbftParams) _ls = pbftParams
 
-instance (PraosCrypto c, SimpleBlockCrypto c')
+instance ( PraosCrypto c, SimpleBlockCrypto c')
       => ProtocolLedgerView (SimpleBlock (ExtNodeConfig AddrDist (Praos c)) c') where
   protocolLedgerView (EncNodeConfig _ addrDist) (SimpleLedgerState u _) =
       relativeStakes $ totalStakes addrDist u

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -31,7 +31,7 @@ module Ouroboros.Consensus.Protocol.Abstract (
   , evalNodeState
   ) where
 
-import           Codec.Serialise (Serialise)
+import           Codec.Serialise.Encoding (Encoding)
 import           Control.Monad.Except
 import           Control.Monad.State
 import           Crypto.Random (MonadRandom (..))
@@ -99,8 +99,9 @@ class ( Show (ChainState    p)
   -- | Construct the ouroboros-specific payload of a block
   --
   -- Gets the proof that we are the leader and the preheader as arguments.
-  mkPayload :: (HasNodeState p m, MonadRandom m, Serialise ph)
-            => NodeConfig p
+  mkPayload :: (HasNodeState p m, MonadRandom m)
+            => (ph -> Encoding)
+            -> NodeConfig p
             -> IsLeader p
             -> ph
             -> m (Payload p ph)
@@ -135,7 +136,8 @@ class ( Show (ChainState    p)
 
   -- | Apply a block
   applyChainState :: SupportedBlock p b
-                  => NodeConfig p
+                  => (PreHeader b -> Encoding) -- Serialiser for the preheader
+                  -> NodeConfig p
                   -> LedgerView p -- /Updated/ ledger state
                   -> b
                   -> ChainState p -- /Previous/ Ouroboros state
@@ -156,7 +158,7 @@ class ( Show (ChainState    p)
 newtype SecurityParam = SecurityParam { maxRollbacks :: Word64 }
 
 -- | Extract the pre-header from a block
-class (HasHeader b, Serialise (PreHeader b)) => HasPreHeader b where
+class (HasHeader b) => HasPreHeader b where
   type family PreHeader b :: *
   blockPreHeader :: b -> PreHeader b
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
@@ -57,13 +57,13 @@ instance (Typeable cfg, OuroborosTag p) => OuroborosTag (ExtNodeConfig cfg p) wh
   -- Propagate changes
   --
 
-  mkPayload (EncNodeConfig cfg _) proof ph =
-      EncPayload <$> mkPayload cfg proof ph
+  mkPayload toEnc (EncNodeConfig cfg _) proof ph =
+      EncPayload <$> mkPayload toEnc cfg proof ph
 
   preferCandidate       (EncNodeConfig cfg _) = preferCandidate       cfg
   compareCandidates     (EncNodeConfig cfg _) = compareCandidates     cfg
   checkIsLeader         (EncNodeConfig cfg _) = checkIsLeader         cfg
-  applyChainState       (EncNodeConfig cfg _) = applyChainState       cfg
+  applyChainState toEnc (EncNodeConfig cfg _) = applyChainState toEnc cfg
   protocolSecurityParam (EncNodeConfig cfg _) = protocolSecurityParam cfg
 
 deriving instance Eq       (Payload p ph) => Eq       (Payload (ExtNodeConfig cfg p) ph)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -57,7 +57,7 @@ instance OuroborosTag p => OuroborosTag (WithLeaderSchedule p) where
     , lsNodeConfigNodeId   :: CoreNodeId
     }
 
-  mkPayload cfg () _ph = return $ WLSPayload $ lsNodeConfigNodeId cfg
+  mkPayload _ cfg () _ph = return $ WLSPayload $ lsNodeConfigNodeId cfg
 
   preferCandidate       WLSNodeConfig{..} = preferCandidate       lsNodeConfigP
   compareCandidates     WLSNodeConfig{..} = compareCandidates     lsNodeConfigP
@@ -70,7 +70,7 @@ instance OuroborosTag p => OuroborosTag (WithLeaderSchedule p) where
             | lsNodeConfigNodeId `elem` nids -> Just ()
             | otherwise                      -> Nothing
 
-  applyChainState _ _ _ _ = return ()
+  applyChainState _ _ _ _ _ = return ()
 
 deriving instance Eq   (Payload (WithLeaderSchedule p) ph)
 deriving instance Ord  (Payload (WithLeaderSchedule p) ph)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -62,10 +62,10 @@ instance (Typeable p, Typeable s, ChainSelection p s) => OuroborosTag (ModChainS
     type    ValidationErr  (ModChainSel p s)    = ValidationErr p
     type    SupportedBlock (ModChainSel p s)    = SupportedBlock p
 
-    mkPayload         (McsNodeConfig cfg) proof ph = McsPayload <$> mkPayload cfg proof ph
+    mkPayload toEnc        (McsNodeConfig cfg) proof ph = McsPayload <$> mkPayload toEnc cfg proof ph
 
     checkIsLeader         (McsNodeConfig cfg) = checkIsLeader         cfg
-    applyChainState       (McsNodeConfig cfg) = applyChainState       cfg
+    applyChainState toEnc (McsNodeConfig cfg) = applyChainState toEnc cfg
     protocolSecurityParam (McsNodeConfig cfg) = protocolSecurityParam cfg
 
     preferCandidate   (McsNodeConfig cfg) = preferCandidate'   (Proxy :: Proxy s) cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Test.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Test.hs
@@ -61,8 +61,8 @@ instance OuroborosTag p => OuroborosTag (TestProtocol p) where
   type ValidationErr   (TestProtocol p) = ValidationErr  p
   type SupportedBlock  (TestProtocol p) = SupportedBlock p
 
-  mkPayload (TestNodeConfig cfg _) (proof, stake) ph = do
-      standardPayload <- mkPayload cfg proof ph
+  mkPayload toEnc (TestNodeConfig cfg _) (proof, stake) ph = do
+      standardPayload <- mkPayload toEnc cfg proof ph
       return TestPayload {
           testPayloadP     = standardPayload
         , testPayloadStake = stake
@@ -76,7 +76,7 @@ instance OuroborosTag p => OuroborosTag (TestProtocol p) where
 
   preferCandidate       (TestNodeConfig cfg _) = preferCandidate       cfg
   compareCandidates     (TestNodeConfig cfg _) = compareCandidates     cfg
-  applyChainState       (TestNodeConfig cfg _) = applyChainState       cfg . fst
+  applyChainState toEnc (TestNodeConfig cfg _) = applyChainState toEnc cfg . fst
   protocolSecurityParam (TestNodeConfig cfg _) = protocolSecurityParam cfg
 
 deriving instance (OuroborosTag p, Show (Payload p ph)) => Show (Payload (TestProtocol p) ph)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Serialise.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Serialise.hs
@@ -3,14 +3,17 @@
 module Ouroboros.Consensus.Util.Serialise (
       encodeBA
     , decodeBA
+    , toBS
     ) where
 
+import qualified Codec.CBOR.Write as CBOR.Write
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
 import           Codec.Serialise (Serialise (..))
 import           Crypto.Error (CryptoFailable (..))
 import           Data.ByteArray (ByteArrayAccess, convert)
 import           Data.ByteString (ByteString)
+import           Data.ByteString.Lazy (toStrict)
 
 encodeBA :: ByteArrayAccess ba => ba -> Encoding
 encodeBA ba = let bs = convert ba :: ByteString in encode bs
@@ -21,3 +24,6 @@ decodeBA f = do
     case f bs of
         CryptoPassed a -> return a
         CryptoFailed e -> fail $ "decodeBA: " ++ show e
+
+toBS :: Encoding -> ByteString
+toBS = toStrict . CBOR.Write.toLazyByteString

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
@@ -9,6 +9,7 @@ module Ouroboros.Storage.ChainDB.Mock (
 import           Data.Bifunctor (first)
 import qualified Data.Set as Set
 
+import           Codec.CBOR.Encoding (Encoding)
 import           Control.Monad.Class.MonadSTM
 
 import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader (..),
@@ -31,11 +32,12 @@ openDB :: forall m blk hdr.
           , HeaderHash blk ~ HeaderHash hdr
           , ProtocolLedgerView blk
           )
-       => NodeConfig (BlockProtocol blk)
+       => (PreHeader blk -> Encoding)
+       -> NodeConfig (BlockProtocol blk)
        -> ExtLedgerState blk
        -> (blk -> hdr)
        -> m (ChainDB m blk hdr)
-openDB cfg initLedger blockHeader = do
+openDB toEnc cfg initLedger blockHeader = do
     db :: TVar m (Model blk) <- atomically $ newTVar (Model.empty initLedger)
 
     let query :: (Model blk -> a) -> STM m a
@@ -89,7 +91,7 @@ openDB cfg initLedger blockHeader = do
                 . Model.readerForward rdrId (map Block.castPoint ps)
 
     return ChainDB {
-        addBlock            = update_ . Model.addBlock cfg
+        addBlock            = update_ . Model.addBlock toEnc cfg
       , getCurrentChain     = query   $ Model.lastK k blockHeader
       , getCurrentLedger    = query   $ Model.currentLedger
       , getBlock            = query'  . Model.getBlockByPoint

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -8,6 +8,7 @@ module Test.Dynamic.Network (
     broadcastNetwork
   ) where
 
+import           Codec.Serialise (Serialise(encode))
 import           Control.Monad
 import           Crypto.Number.Generate (generateBetween)
 import           Crypto.Random (ChaChaDRG, drgNew)
@@ -107,6 +108,7 @@ broadcastNetwork btime numCoreNodes pInfo initRNG numSlots = do
             }
 
       node <- nodeKernel
+                encode
                 pInfoConfig
                 pInfoInitState
                 btime

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -2,6 +2,7 @@
 
 module Test.Ouroboros.Storage.ChainDB.Mock (tests) where
 
+import           Codec.Serialise (Serialise(encode))
 import           Control.Exception (Exception)
 import           Control.Monad
 import           Test.QuickCheck
@@ -84,4 +85,4 @@ instance Exception InvalidUpdate
 -------------------------------------------------------------------------------}
 
 openDB :: forall s. SimM s (ChainDB (SimM s) TestBlock TestBlock)
-openDB = Mock.openDB testConfig testInitExtLedger id
+openDB = Mock.openDB encode testConfig testInitExtLedger id

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -10,6 +10,7 @@ module Test.Ouroboros.Storage.ChainDB.Model (
     tests
   ) where
 
+import           Codec.Serialise (Serialise(encode))
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -28,18 +29,18 @@ tests = testGroup "Model" [
 
 prop_getBlock_addBlock :: BlockTree -> Permutation -> Property
 prop_getBlock_addBlock bt p =
-        M.getBlock (blockHash newBlock) (M.addBlock testConfig newBlock model)
+        M.getBlock (blockHash newBlock) (M.addBlock encode testConfig newBlock model)
     === Just newBlock
   where
     (newBlock:initBlocks) = permute p $ treeToBlocks bt
-    model = M.addBlocks testConfig initBlocks (M.empty testInitExtLedger)
+    model = M.addBlocks encode testConfig initBlocks (M.empty testInitExtLedger)
 
 prop_getChain_addChain :: BlockChain -> Property
 prop_getChain_addChain bc =
     blockChain bc === M.currentChain model
   where
     blocks = chainToBlocks bc
-    model  = M.addBlocks testConfig blocks (M.empty testInitExtLedger)
+    model  = M.addBlocks encode testConfig blocks (M.empty testInitExtLedger)
 
 prop_alwaysPickPreferredChain :: BlockTree -> Permutation -> Property
 prop_alwaysPickPreferredChain bt p =
@@ -49,5 +50,5 @@ prop_alwaysPickPreferredChain bt p =
       ]
   where
     blocks  = permute p $ treeToBlocks bt
-    model   = M.addBlocks testConfig blocks (M.empty testInitExtLedger)
+    model   = M.addBlocks encode testConfig blocks (M.empty testInitExtLedger)
     current = M.currentChain model

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/TestBlock.hs
@@ -29,7 +29,7 @@ module Test.Ouroboros.Storage.ChainDB.TestBlock (
   , permute
   ) where
 
-import           Codec.Serialise (Serialise)
+import           Codec.Serialise (Serialise(encode))
 import           Control.Monad.Except (throwError)
 import           Data.FingerTree (Measured (..))
 import           Data.Int
@@ -95,7 +95,7 @@ instance HasPreHeader TestBlock where
 
 instance HasPayload (Bft BftMockCrypto) TestBlock where
   blockPayload _ _ = BftPayload {
-        bftSignature = SignedDSIGN (mockSign () (SignKeyMockDSIGN 0))
+        bftSignature = SignedDSIGN (mockSign encode () (SignKeyMockDSIGN 0))
       }
 
 instance UpdateLedger TestBlock where

--- a/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Orphans/Arbitrary.hs
@@ -10,7 +10,7 @@ module Test.Util.Orphans.Arbitrary
     , genSmallSlotNo
     ) where
 
-import           Codec.Serialise (Serialise)
+import           Codec.Serialise (Serialise(..))
 import           Data.Time
 import           Data.Word (Word64)
 import           Test.QuickCheck hiding (Fixed (..))
@@ -134,7 +134,7 @@ instance DSIGNAlgorithm v => Arbitrary (SigDSIGN v) where
         a    <- arbitrary :: Gen Int
         sk   <- arbitrary
         seed <- arbitrary
-        return $ withSeed seed $ signDSIGN a sk
+        return $ withSeed seed $ signDSIGN encode a sk
 
     shrink = const []
 
@@ -156,7 +156,7 @@ instance VRFAlgorithm v => Arbitrary (CertVRF v) where
         a    <- arbitrary :: Gen Int
         sk   <- arbitrary
         seed <- arbitrary
-        return $ withSeed seed $ fmap snd $ evalVRF a sk
+        return $ withSeed seed $ fmap snd $ evalVRF encode a sk
 
     shrink = const []
 

--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -92,7 +92,6 @@ blockMeasure b = BlockMeasure (blockSlot b) (blockSlot b) 1
 class ( Eq        (HeaderHash b)
       , Ord       (HeaderHash b)
       , Show      (HeaderHash b)
-      , Serialise (HeaderHash b)
       , Typeable  (HeaderHash b)
       ) => StandardHash b
 

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 {-# OPTIONS_GHC -Wno-orphans     #-}
@@ -67,7 +68,7 @@ instance Mx.ProtocolEnum DemoProtocols where
 -- over a pipe with full message serialisation, framing etc.
 --
 demo :: forall block .
-        (Chain.HasHeader block, Serialise block, Eq block )
+        (Chain.HasHeader block, Serialise (Chain.HeaderHash block), Serialise block, Eq block )
      => Chain block -> [ChainUpdate block] -> IO Bool
 demo chain0 updates = do
 

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -220,12 +221,13 @@ prop_socket_client_connect_error _ xs = ioProperty $ do
       <- try $ withNetworkNode ni $ \nn ->
                  const False <$> withConnection (connect nn) clientAddr
 
-    -- XXX Disregarding the exact exception type 
+    -- XXX Disregarding the exact exception type
     pure $ either (const True) id res
 
 
 demo :: forall block .
-        (Chain.HasHeader block, Serialise block, Eq block, Show block )
+        ( Chain.HasHeader block, Serialise (Chain.HeaderHash block)
+        , Serialise block, Eq block, Show block )
      => Chain block -> [ChainUpdate block] -> IO Bool
 demo chain0 updates = do
     consumerAddress:_ <- Socket.getAddrInfo Nothing (Just "127.0.0.1") (Just "0")

--- a/stack.byron-proxy.yaml
+++ b/stack.byron-proxy.yaml
@@ -21,6 +21,24 @@ extra-deps:
     - iohk-monitoring
     - contra-tracer
 - libyaml-0.1.0.0
+- git: https://github.com/input-output-hk/cardano-base
+  commit: 2f33cbf9101dfee1cb488271ec96e210329eec96
+  subdirs:
+    - binary
+
+- git: https://github.com/input-output-hk/cardano-ledger
+  commit: 595cfb5b20863fca869550423a4e27aab8e68aed
+  subdirs:
+    - .
+    - crypto
+
+- git: https://github.com/input-output-hk/cardano-prelude
+  commit: e1fb84b1a955b6e3e3e53d9022e8bc0f927417a2
+- streaming-binary-0.3.0.1
+- git: https://github.com/well-typed/cborg
+  commit: 80fbe0ee5e67a5622e2cb9eaa9d8594a2214322d
+  subdirs:
+    - cborg
 
 # Cardano-sl dependencies:
 - ekg-wai-0.1.0.3
@@ -95,3 +113,11 @@ extra-deps:
     - util
     - util/test
     - networking
+nix:
+  packages:
+    - zlib
+    - openssl
+    - rocksdb
+    - lzma
+    - haskellPackages.happy
+    - haskellPackages.cpphs


### PR DESCRIPTION
We remove `Serialise` from a variety of places in the consensus layer, in order to allow integration with the ledger layer, which does not use `Serialise`.