### PR TITLE
Improvements to block fetch concurrency/state management

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -49,11 +49,7 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..),
                      headSlot)
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.BlockFetch
-                     (BlockFetchConsensusInterface (..), FetchClientRegistry,
-                     blockFetchLogic, newFetchClientRegistry)
-import qualified Ouroboros.Network.BlockFetch.Client as BlockFetchClient
 import           Ouroboros.Network.BlockFetch.State (FetchMode (..))
-import           Ouroboros.Network.BlockFetch.Types (SizeInBytes)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.Protocol.BlockFetch.Server
                      (BlockFetchServer (..), blockFetchServerPeer)
@@ -528,7 +524,7 @@ initNetworkLayer _tracer registry NetworkRequires{..} = NetworkProvides {..}
       clientRegistered <- newEmptyTMVarM
 
       void $ forkLinked registry $ bfWithChan $ \chan ->
-        BlockFetchClient.bracketFetchClient nrFetchClientRegistry up $ \stateVars -> do
+        bracketFetchClient nrFetchClientRegistry up $ \stateVars -> do
           atomically $ putTMVar clientRegistered ()
           -- TODO make 10 a parameter. Or encapsulate the pipelining
           -- stuff

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -32,10 +32,10 @@ library
                        Ouroboros.Network.Block
                        Ouroboros.Network.BlockFetch
                        Ouroboros.Network.BlockFetch.Client
+                       Ouroboros.Network.BlockFetch.ClientState
                        Ouroboros.Network.BlockFetch.Decision
                        Ouroboros.Network.BlockFetch.DeltaQ
                        Ouroboros.Network.BlockFetch.State
-                       Ouroboros.Network.BlockFetch.Types
                        Ouroboros.Network.ChainFragment
                        Ouroboros.Network.Channel
                        Ouroboros.Network.Codec
@@ -128,11 +128,11 @@ test-suite tests
                        Ouroboros.Network.Block
                        Ouroboros.Network.BlockFetch
                        Ouroboros.Network.BlockFetch.Client
+                       Ouroboros.Network.BlockFetch.ClientState
                        Ouroboros.Network.BlockFetch.Decision
                        Ouroboros.Network.BlockFetch.DeltaQ
                        Ouroboros.Network.BlockFetch.Examples
                        Ouroboros.Network.BlockFetch.State
-                       Ouroboros.Network.BlockFetch.Types
                        Ouroboros.Network.Chain
                        Ouroboros.Network.ChainFragment
                        Ouroboros.Network.ChainProducerState

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -32,6 +32,7 @@ library
                        Ouroboros.Network.Block
                        Ouroboros.Network.BlockFetch
                        Ouroboros.Network.BlockFetch.Client
+                       Ouroboros.Network.BlockFetch.ClientRegistry
                        Ouroboros.Network.BlockFetch.ClientState
                        Ouroboros.Network.BlockFetch.Decision
                        Ouroboros.Network.BlockFetch.DeltaQ
@@ -128,6 +129,7 @@ test-suite tests
                        Ouroboros.Network.Block
                        Ouroboros.Network.BlockFetch
                        Ouroboros.Network.BlockFetch.Client
+                       Ouroboros.Network.BlockFetch.ClientRegistry
                        Ouroboros.Network.BlockFetch.ClientState
                        Ouroboros.Network.BlockFetch.Decision
                        Ouroboros.Network.BlockFetch.DeltaQ

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -100,8 +100,11 @@ import           Ouroboros.Network.DeltaQ
                    ( PeerGSV(..), ballisticGSV, degenerateDistribution
                    , SizeInBytes )
 
-import           Ouroboros.Network.BlockFetch.Client
 import           Ouroboros.Network.BlockFetch.State
+import           Ouroboros.Network.BlockFetch.ClientRegistry
+                   ( FetchClientRegistry, newFetchClientRegistry
+                   , readFetchClientsStatus, readFetchClientsStates
+                   , readFetchClientsReqVars )
 
 
 -- | The consensus layer functionality that the block fetch logic requires.

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -97,11 +97,11 @@ import           Control.Tracer (Tracer)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.DeltaQ
-                   ( PeerGSV(..), ballisticGSV, degenerateDistribution )
+                   ( PeerGSV(..), ballisticGSV, degenerateDistribution
+                   , SizeInBytes )
 
 import           Ouroboros.Network.BlockFetch.Client
 import           Ouroboros.Network.BlockFetch.State
-import           Ouroboros.Network.BlockFetch.Types
 
 
 -- | The consensus layer functionality that the block fetch logic requires.

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -103,8 +103,7 @@ import           Ouroboros.Network.DeltaQ
 import           Ouroboros.Network.BlockFetch.State
 import           Ouroboros.Network.BlockFetch.ClientRegistry
                    ( FetchClientRegistry, newFetchClientRegistry
-                   , readFetchClientsStatus, readFetchClientsStates
-                   , readFetchClientsReqVars )
+                   , readFetchClientsStatus, readFetchClientsStateVars )
 
 
 -- | The consensus layer functionality that the block fetch logic requires.
@@ -234,14 +233,13 @@ blockFetchLogic decisionTracer
     fetchNonTriggerVariables =
       FetchNonTriggerVariables {
         readStateFetchedBlocks = readFetchedBlocks,
-        readStatePeerStates    = readFetchClientsStates registry,
+        readStatePeerStateVars = readFetchClientsStateVars registry,
         readStatePeerGSVs      = readPeerGSVs,
-        readStatePeerReqVars   = readFetchClientsReqVars registry,
         readStateFetchMode     = readFetchMode
       }
 
     -- TODO: get this from elsewhere once we have DeltaQ info available
-    readPeerGSVs = Map.map (const dummyGSVs) <$> readFetchClientsStates registry
+    readPeerGSVs = Map.map (const dummyGSVs) <$> readFetchClientsStateVars registry
     -- roughly 10ms ping time and 1MBit/s bandwidth
     -- leads to ~2200 bytes in flight minimum
     dummyGSVs    = PeerGSV{outboundGSV, inboundGSV}

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -85,6 +85,11 @@ module Ouroboros.Network.BlockFetch (
     -- * The 'FetchClientRegistry'
     FetchClientRegistry,
     newFetchClientRegistry,
+    bracketFetchClient,
+
+    -- * Re-export types used by 'BlockFetchConsensusInterface'
+    FetchMode (..),
+    SizeInBytes,
   ) where
 
 import           Data.Map.Strict (Map)
@@ -103,7 +108,8 @@ import           Ouroboros.Network.DeltaQ
 import           Ouroboros.Network.BlockFetch.State
 import           Ouroboros.Network.BlockFetch.ClientRegistry
                    ( FetchClientRegistry, newFetchClientRegistry
-                   , readFetchClientsStatus, readFetchClientsStateVars )
+                   , readFetchClientsStatus, readFetchClientsStateVars
+                   , bracketFetchClient )
 
 
 -- | The consensus layer functionality that the block fetch logic requires.

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -32,7 +32,7 @@ import           Ouroboros.Network.BlockFetch.ClientState
                    ( FetchClientStateVars, PeerFetchStatus(..)
                    , PeerFetchInFlight(..)
                    , FetchRequest(..)
-                   , acceptFetchRequest
+                   , acknowledgeFetchRequest
                    , completeBlockDownload
                    , completeFetchBatch )
 import           Ouroboros.Network.BlockFetch.DeltaQ
@@ -58,11 +58,8 @@ data BlockFetchProtocolFailure =
 instance Exception BlockFetchProtocolFailure
 
 data TraceFetchClientEvent header =
-       AcceptedFetchRequest
+       AcknowledgedFetchRequest
          (FetchRequest header)
-         (PeerFetchInFlight header)
-          PeerFetchInFlightLimits
-         (PeerFetchStatus header)
      | CompletedBlockFetch
          (Point header)
          (PeerFetchInFlight header)
@@ -122,13 +119,9 @@ blockFetchClient tracer
       -- in-flight, and the tracking state that the fetch logic uses now
       -- reflects that.
       --
-      (request, _gsvs, inflight, inflightlimits, currentStatus) <-
-        acceptFetchRequest blockFetchSize stateVars
+      (request, _gsvs, inflightlimits) <- acknowledgeFetchRequest stateVars
 
-      traceWith tracer $ AcceptedFetchRequest
-                           request
-                           inflight inflightlimits
-                           currentStatus
+      traceWith tracer (AcknowledgedFetchRequest request)
 
       return $ senderActive outstanding inflightlimits
                             (fetchRequestFragments request)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -10,6 +10,7 @@ module Ouroboros.Network.BlockFetch.Client (
     blockFetchClient,
     FetchClientPolicy(..),
     TraceFetchClientEvent(..),
+    FetchClientStateVars,
 
     -- * Registry of block fetch clients
     FetchClientRegistry(..),
@@ -38,15 +39,15 @@ import           Ouroboros.Network.Protocol.BlockFetch.Type
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Pipelined
 
-import           Ouroboros.Network.BlockFetch.Types
+import           Ouroboros.Network.BlockFetch.ClientState
                    ( FetchClientStateVars(..), PeerFetchStatus(..)
                    , PeerFetchInFlight(..), initialPeerFetchInFlight
-                   , SizeInBytes
                    , FetchRequest(..)
                    , TFetchRequestVar
                    , newTFetchRequestVar, takeTFetchRequestVar )
 import           Ouroboros.Network.BlockFetch.DeltaQ
-                   ( PeerGSV(..), PeerFetchInFlightLimits(..)
+                   ( PeerGSV(..), SizeInBytes
+                   , PeerFetchInFlightLimits(..)
                    , calculatePeerFetchInFlightLimits )
 
 

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -34,8 +34,7 @@ import           Ouroboros.Network.BlockFetch.ClientState
                    , completeBlockDownload
                    , completeFetchBatch )
 import           Ouroboros.Network.BlockFetch.DeltaQ
-                   ( PeerGSV(..), SizeInBytes
-                   , PeerFetchInFlightLimits(..) )
+                   ( SizeInBytes, PeerFetchInFlightLimits(..) )
 
 
 -- TODO #468 extract this from BlockFetchConsensusInterface
@@ -79,7 +78,6 @@ blockFetchClient :: forall header block m.
                  => Tracer m (TraceFetchClientEvent header)
                  -> FetchClientPolicy header block m
                  -> FetchClientStateVars m header
-                 -> STM m PeerGSV
                  -> PeerPipelined (BlockFetch header block) AsClient BFIdle m ()
 blockFetchClient tracer
                  FetchClientPolicy {
@@ -87,8 +85,7 @@ blockFetchClient tracer
                    blockMatchesHeader,
                    addFetchedBlock
                  }
-                 stateVars
-                 readPeerGSVs =
+                 stateVars =
     PeerPipelined (senderAwait Zero)
   where
     senderIdle :: forall n.
@@ -123,8 +120,8 @@ blockFetchClient tracer
       -- in-flight, and the tracking state that the fetch logic uses now
       -- reflects that.
       --
-      (fragments, inflight, inflightlimits, currentStatus) <-
-        acceptFetchRequest blockFetchSize readPeerGSVs stateVars
+      (fragments, _gsvs, inflight, inflightlimits, currentStatus) <-
+        acceptFetchRequest blockFetchSize stateVars
 
       traceWith tracer $ AcceptedFetchRequest
                            (fmap blockPoint (FetchRequest fragments))

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -247,7 +247,7 @@ blockFetchClient tracer
             -- Update our in-flight stats and our current status
             (inflight, currentStatus) <-
               completeBlockDownload blockFetchSize inflightlimits
-                                    header headers' stateVars
+                                    header stateVars
 
             traceWith tracer $ CompletedBlockFetch
                                  (blockPoint header)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -11,19 +11,7 @@ module Ouroboros.Network.BlockFetch.Client (
     FetchClientPolicy(..),
     TraceFetchClientEvent(..),
     FetchClientStateVars,
-
-    -- * Registry of block fetch clients
-    FetchClientRegistry(..),
-    newFetchClientRegistry,
-    bracketFetchClient,
-    readFetchClientsStatus,
-    readFetchClientsStates,
-    readFetchClientsReqVars,
   ) where
-
-import qualified Data.Set as Set
-import qualified Data.Map as Map
-import           Data.Map (Map)
 
 import           Control.Monad (unless)
 import           Control.Monad.Class.MonadSTM
@@ -39,11 +27,9 @@ import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Pipelined
 
 import           Ouroboros.Network.BlockFetch.ClientState
-                   ( FetchClientStateVars(..), PeerFetchStatus(..)
-                   , PeerFetchInFlight(..), initialPeerFetchInFlight
+                   ( FetchClientStateVars, PeerFetchStatus(..)
+                   , PeerFetchInFlight(..)
                    , FetchRequest(..)
-                   , TFetchRequestVar
-                   , newTFetchRequestVar
                    , acceptFetchRequest
                    , completeBlockDownload
                    , completeFetchBatch )
@@ -272,76 +258,4 @@ blockFetchClient tracer
 
           (MsgBlock _, []) -> ReceiverEffect $
             throwM BlockFetchProtocolFailureTooManyBlocks
-
-
-
--- | A registry for the threads that are executing the client side of the
--- 'BlockFetch' protocol to communicate with our peers.
---
--- The registry contains the shared variables we use to communicate with these
--- threads, both to track their status and to provide instructions.
---
--- The threads add\/remove themselves to\/from this registry when they start up
--- and shut down.
---
-newtype FetchClientRegistry peer header m =
-        FetchClientRegistry (TVar m (Map peer (FetchClientStateVars header m)))
-
-newFetchClientRegistry :: MonadSTM m => m (FetchClientRegistry peer header m)
-newFetchClientRegistry = FetchClientRegistry <$> newTVarM Map.empty
-
-bracketFetchClient :: (MonadThrow m, MonadSTM m, Ord peer)
-                   => FetchClientRegistry peer header m
-                   -> peer
-                   -> (FetchClientStateVars header m -> m a)
-                   -> m a
-bracketFetchClient (FetchClientRegistry registry) peer =
-    bracket register unregister
-  where
-    register = atomically $ do
-      fetchClientInFlightVar <- newTVar initialPeerFetchInFlight
-      fetchClientStatusVar   <- newTVar (PeerFetchStatusReady Set.empty)
-      fetchClientRequestVar  <- newTFetchRequestVar
-      let stateVars = FetchClientStateVars {
-                        fetchClientStatusVar,
-                        fetchClientInFlightVar,
-                        fetchClientRequestVar
-                      }
-      modifyTVar' registry (Map.insert peer stateVars)
-      return stateVars
-
-    unregister FetchClientStateVars{fetchClientStatusVar} =
-      atomically $ do
-        writeTVar fetchClientStatusVar PeerFetchStatusShutdown
-        modifyTVar' registry (Map.delete peer)
-
--- | A read-only 'STM' action to get the current 'PeerFetchStatus' for all
--- fetch clients in the 'FetchClientRegistry'.
---
-readFetchClientsStatus :: MonadSTM m
-                       => FetchClientRegistry peer header m
-                       -> STM m (Map peer (PeerFetchStatus header))
-readFetchClientsStatus (FetchClientRegistry registry) =
-  readTVar registry >>= traverse (readTVar . fetchClientStatusVar)
-
--- | A read-only 'STM' action to get the current 'PeerFetchStatus' and
--- 'PeerFetchInFlight' for all fetch clients in the 'FetchClientRegistry'.
---
-readFetchClientsStates :: MonadSTM m
-                       => FetchClientRegistry peer header m
-                       -> STM m (Map peer (PeerFetchStatus   header,
-                                           PeerFetchInFlight header))
-readFetchClientsStates (FetchClientRegistry registry) =
-  readTVar registry >>=
-  traverse (\s -> (,) <$> readTVar (fetchClientStatusVar s)
-                      <*> readTVar (fetchClientInFlightVar s))
-
--- | A read-only 'STM' action to get the current 'TFetchRequestVar' for all
--- fetch clients in the 'FetchClientRegistry'.
---
-readFetchClientsReqVars :: MonadSTM m
-                        => FetchClientRegistry peer header m
-                        -> STM m (Map peer (TFetchRequestVar m header))
-readFetchClientsReqVars (FetchClientRegistry registry) =
-  readTVar registry >>= return . Map.map fetchClientRequestVar
 

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -79,7 +79,7 @@ blockFetchClient :: forall header block m.
                      HeaderHash header ~ HeaderHash block)
                  => Tracer m (TraceFetchClientEvent header)
                  -> FetchClientPolicy header block m
-                 -> FetchClientStateVars header m
+                 -> FetchClientStateVars m header
                  -> STM m PeerGSV
                  -> PeerPipelined (BlockFetch header block) AsClient BFIdle m ()
 blockFetchClient tracer

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientRegistry.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientRegistry.hs
@@ -10,8 +10,6 @@ module Ouroboros.Network.BlockFetch.ClientRegistry (
     bracketFetchClient,
     readFetchClientsStatus,
     readFetchClientsStateVars,
-    readFetchClientsStates,
-    readFetchClientsReqVars,
   ) where
 
 import qualified Data.Map as Map
@@ -73,25 +71,4 @@ readFetchClientsStateVars :: MonadSTM m
                           => FetchClientRegistry peer header m
                           -> STM m (Map peer (FetchClientStateVars m header))
 readFetchClientsStateVars (FetchClientRegistry registry) = readTVar registry
-
--- | A read-only 'STM' action to get the current 'PeerFetchStatus' and
--- 'PeerFetchInFlight' for all fetch clients in the 'FetchClientRegistry'.
---
-readFetchClientsStates :: MonadSTM m
-                       => FetchClientRegistry peer header m
-                       -> STM m (Map peer (PeerFetchStatus   header,
-                                           PeerFetchInFlight header))
-readFetchClientsStates (FetchClientRegistry registry) =
-  readTVar registry >>=
-  traverse (\s -> (,) <$> readTVar (fetchClientStatusVar s)
-                      <*> readTVar (fetchClientInFlightVar s))
-
--- | A read-only 'STM' action to get the current 'TFetchRequestVar' for all
--- fetch clients in the 'FetchClientRegistry'.
---
-readFetchClientsReqVars :: MonadSTM m
-                        => FetchClientRegistry peer header m
-                        -> STM m (Map peer (TFetchRequestVar m header))
-readFetchClientsReqVars (FetchClientRegistry registry) =
-  readTVar registry >>= return . Map.map fetchClientRequestVar
 

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientRegistry.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientRegistry.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE BangPatterns               #-}
+
+module Ouroboros.Network.BlockFetch.ClientRegistry (
+    -- * Registry of block fetch clients
+    FetchClientRegistry(..),
+    newFetchClientRegistry,
+    bracketFetchClient,
+    readFetchClientsStatus,
+    readFetchClientsStateVars,
+    readFetchClientsStates,
+    readFetchClientsReqVars,
+  ) where
+
+import qualified Data.Map as Map
+import           Data.Map (Map)
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+import           Ouroboros.Network.BlockFetch.ClientState
+
+
+
+-- | A registry for the threads that are executing the client side of the
+-- 'BlockFetch' protocol to communicate with our peers.
+--
+-- The registry contains the shared variables we use to communicate with these
+-- threads, both to track their status and to provide instructions.
+--
+-- The threads add\/remove themselves to\/from this registry when they start up
+-- and shut down.
+--
+newtype FetchClientRegistry peer header m =
+        FetchClientRegistry (TVar m (Map peer (FetchClientStateVars header m)))
+
+newFetchClientRegistry :: MonadSTM m => m (FetchClientRegistry peer header m)
+newFetchClientRegistry = FetchClientRegistry <$> newTVarM Map.empty
+
+bracketFetchClient :: (MonadThrow m, MonadSTM m, Ord peer)
+                   => FetchClientRegistry peer header m
+                   -> peer
+                   -> (FetchClientStateVars header m -> m a)
+                   -> m a
+bracketFetchClient (FetchClientRegistry registry) peer =
+    bracket register unregister
+  where
+    register = atomically $ do
+      stateVars <- newFetchClientStateVars
+      modifyTVar' registry (Map.insert peer stateVars)
+      return stateVars
+
+    unregister FetchClientStateVars{fetchClientStatusVar} =
+      atomically $ do
+        writeTVar fetchClientStatusVar PeerFetchStatusShutdown
+        modifyTVar' registry (Map.delete peer)
+
+-- | A read-only 'STM' action to get the current 'PeerFetchStatus' for all
+-- fetch clients in the 'FetchClientRegistry'.
+--
+readFetchClientsStatus :: MonadSTM m
+                       => FetchClientRegistry peer header m
+                       -> STM m (Map peer (PeerFetchStatus header))
+readFetchClientsStatus (FetchClientRegistry registry) =
+  readTVar registry >>= traverse (readTVar . fetchClientStatusVar)
+
+-- | A read-only 'STM' action to get the 'FetchClientStateVars' for all fetch
+-- clients in the 'FetchClientRegistry'.
+--
+readFetchClientsStateVars :: MonadSTM m
+                          => FetchClientRegistry peer header m
+                          -> STM m (Map peer (FetchClientStateVars header m))
+readFetchClientsStateVars (FetchClientRegistry registry) = readTVar registry
+
+-- | A read-only 'STM' action to get the current 'PeerFetchStatus' and
+-- 'PeerFetchInFlight' for all fetch clients in the 'FetchClientRegistry'.
+--
+readFetchClientsStates :: MonadSTM m
+                       => FetchClientRegistry peer header m
+                       -> STM m (Map peer (PeerFetchStatus   header,
+                                           PeerFetchInFlight header))
+readFetchClientsStates (FetchClientRegistry registry) =
+  readTVar registry >>=
+  traverse (\s -> (,) <$> readTVar (fetchClientStatusVar s)
+                      <*> readTVar (fetchClientInFlightVar s))
+
+-- | A read-only 'STM' action to get the current 'TFetchRequestVar' for all
+-- fetch clients in the 'FetchClientRegistry'.
+--
+readFetchClientsReqVars :: MonadSTM m
+                        => FetchClientRegistry peer header m
+                        -> STM m (Map peer (TFetchRequestVar m header))
+readFetchClientsReqVars (FetchClientRegistry registry) =
+  readTVar registry >>= return . Map.map fetchClientRequestVar
+

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientRegistry.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientRegistry.hs
@@ -34,7 +34,7 @@ import           Ouroboros.Network.BlockFetch.ClientState
 -- and shut down.
 --
 newtype FetchClientRegistry peer header m =
-        FetchClientRegistry (TVar m (Map peer (FetchClientStateVars header m)))
+        FetchClientRegistry (TVar m (Map peer (FetchClientStateVars m header)))
 
 newFetchClientRegistry :: MonadSTM m => m (FetchClientRegistry peer header m)
 newFetchClientRegistry = FetchClientRegistry <$> newTVarM Map.empty
@@ -42,7 +42,7 @@ newFetchClientRegistry = FetchClientRegistry <$> newTVarM Map.empty
 bracketFetchClient :: (MonadThrow m, MonadSTM m, Ord peer)
                    => FetchClientRegistry peer header m
                    -> peer
-                   -> (FetchClientStateVars header m -> m a)
+                   -> (FetchClientStateVars m header -> m a)
                    -> m a
 bracketFetchClient (FetchClientRegistry registry) peer =
     bracket register unregister
@@ -71,7 +71,7 @@ readFetchClientsStatus (FetchClientRegistry registry) =
 --
 readFetchClientsStateVars :: MonadSTM m
                           => FetchClientRegistry peer header m
-                          -> STM m (Map peer (FetchClientStateVars header m))
+                          -> STM m (Map peer (FetchClientStateVars m header))
 readFetchClientsStateVars (FetchClientRegistry registry) = readTVar registry
 
 -- | A read-only 'STM' action to get the current 'PeerFetchStatus' and

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -5,6 +5,7 @@
 
 module Ouroboros.Network.BlockFetch.ClientState (
     FetchClientStateVars(..),
+    newFetchClientStateVars,
     PeerFetchStatus(..),
     PeerFetchInFlight(..),
     initialPeerFetchInFlight,
@@ -68,6 +69,13 @@ data FetchClientStateVars header m =
        --
        fetchClientRequestVar  :: TFetchRequestVar m header
      }
+
+newFetchClientStateVars :: MonadSTM m => STM m (FetchClientStateVars header m)
+newFetchClientStateVars = do
+    fetchClientInFlightVar <- newTVar initialPeerFetchInFlight
+    fetchClientStatusVar   <- newTVar (PeerFetchStatusReady Set.empty)
+    fetchClientRequestVar  <- newTFetchRequestVar
+    return FetchClientStateVars {..}
 
 
 -- | The status of the block fetch communication with a peer. This is maintained

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -1,6 +1,5 @@
 
-module Ouroboros.Network.BlockFetch.Types (
-    SizeInBytes,
+module Ouroboros.Network.BlockFetch.ClientState (
     FetchClientStateVars(..),
     PeerFetchStatus(..),
     PeerFetchInFlight(..),

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -43,7 +43,7 @@ import           Ouroboros.Network.BlockFetch.DeltaQ
 -- decision making thread the status of things with that peer. And in the other
 -- direction one shared variable is for providing new fetch requests.
 --
-data FetchClientStateVars header m =
+data FetchClientStateVars m header =
      FetchClientStateVars {
 
        -- | The current status of communication with the peer. It is written
@@ -70,7 +70,7 @@ data FetchClientStateVars header m =
        fetchClientRequestVar  :: TFetchRequestVar m header
      }
 
-newFetchClientStateVars :: MonadSTM m => STM m (FetchClientStateVars header m)
+newFetchClientStateVars :: MonadSTM m => STM m (FetchClientStateVars m header)
 newFetchClientStateVars = do
     fetchClientInFlightVar <- newTVar initialPeerFetchInFlight
     fetchClientStatusVar   <- newTVar (PeerFetchStatusReady Set.empty)
@@ -184,7 +184,7 @@ setFetchRequest fetchClientRequestVar request =
 acceptFetchRequest :: (MonadSTM m, HasHeader header)
                    => (header -> SizeInBytes)
                    -> STM m PeerGSV
-                   -> FetchClientStateVars header m
+                   -> FetchClientStateVars m header
                    -> m ( [[header]]
                         , PeerFetchInFlight header
                         , PeerFetchInFlightLimits
@@ -235,7 +235,7 @@ completeBlockDownload :: (MonadSTM m, HasHeader header)
                       -> PeerFetchInFlightLimits
                       -> header
                       -> [header]
-                      -> FetchClientStateVars header m
+                      -> FetchClientStateVars m header
                       -> m (PeerFetchInFlight header, PeerFetchStatus header)
 
 completeBlockDownload blockFetchSize inFlightLimits header headers' FetchClientStateVars {..} =
@@ -281,7 +281,7 @@ completeBlockDownload blockFetchSize inFlightLimits header headers' FetchClientS
       return (inflight', currentStatus')
 
 completeFetchBatch :: MonadSTM m
-                   => FetchClientStateVars header m
+                   => FetchClientStateVars m header
                    -> m ()
 completeFetchBatch FetchClientStateVars {fetchClientInFlightVar} =
     atomically $ modifyTVar' fetchClientInFlightVar $ \inflight ->

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
@@ -701,10 +701,9 @@ selectBlocksUpToLimits blockFetchSize nreqs0 maxreqs nbytes0 maxbytes fragments 
     -- The case that we are already over our limits has to be checked earlier,
     -- outside of this function. From here on however we check for limits.
 
-    FetchRequest
-      [ assert (not (ChainFragment.null fragment)) $
-        ChainFragment.toOldestFirst fragment
-      | fragment <- goFrags nreqs0 nbytes0 fragments ]
+    let fragments' = goFrags nreqs0 nbytes0 fragments in
+    assert (all (not . ChainFragment.null) fragments') $
+    FetchRequest fragments'
   where
     goFrags _     _      []     = []
     goFrags nreqs nbytes (c:cs)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
@@ -33,14 +33,14 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Network.ChainFragment (ChainFragment(..))
 import qualified Ouroboros.Network.ChainFragment as ChainFragment
 
-import           Ouroboros.Network.BlockFetch.Types
+import           Ouroboros.Network.BlockFetch.ClientState
                    ( FetchRequest(..)
                    , PeerFetchInFlight(..)
                    , PeerFetchStatus(..)
-                   , SizeInBytes
                    )
 import           Ouroboros.Network.BlockFetch.DeltaQ
-                   ( PeerGSV(..), PeerFetchInFlightLimits(..)
+                   ( PeerGSV(..), SizeInBytes
+                   , PeerFetchInFlightLimits(..)
                    , calculatePeerFetchInFlightLimits )
 
 

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/DeltaQ.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/DeltaQ.hs
@@ -7,6 +7,7 @@ module Ouroboros.Network.BlockFetch.DeltaQ (
     Distribution,
     DeltaQ,
     PeerGSV(..),
+    SizeInBytes,
     estimateBlockFetchResponse,
     blockArrivalShedule,
     PeerFetchInFlightLimits(..),
@@ -17,7 +18,7 @@ import           Data.Fixed as Fixed (Pico)
 import           Control.Monad.Class.MonadTime
 
 import           Ouroboros.Network.DeltaQ
-import           Ouroboros.Network.BlockFetch.Types
+import           Ouroboros.Network.BlockFetch.ClientState
                    ( PeerFetchInFlight(..) )
 
 

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/DeltaQ.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/DeltaQ.hs
@@ -8,18 +8,16 @@ module Ouroboros.Network.BlockFetch.DeltaQ (
     DeltaQ,
     PeerGSV(..),
     SizeInBytes,
-    estimateBlockFetchResponse,
-    blockArrivalShedule,
     PeerFetchInFlightLimits(..),
     calculatePeerFetchInFlightLimits,
+--    estimateBlockFetchResponse,
+--    blockArrivalShedule,
   ) where
 
 import           Data.Fixed as Fixed (Pico)
 import           Control.Monad.Class.MonadTime
 
 import           Ouroboros.Network.DeltaQ
-import           Ouroboros.Network.BlockFetch.ClientState
-                   ( PeerFetchInFlight(..) )
 
 
 data PeerFetchInFlightLimits = PeerFetchInFlightLimits {
@@ -80,6 +78,7 @@ calculatePeerFetchInFlightLimits PeerGSV {
     inFlightBytesHighWatermark = inFlightBytesLowWatermark * 2
 
 
+{-
 estimateBlockFetchResponse :: PeerGSV
                            -> PeerFetchInFlight header
                            -> [SizeInBytes]
@@ -109,4 +108,4 @@ blockArrivalShedule gsvs
     reqSize = 100 -- not exact, but it's small
 
     cumulativeSumFrom n = tail . scanl (+) n
-
+-}

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -24,6 +24,7 @@ import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadTime
 import           Control.Tracer (Tracer, nullTracer)
+import           Control.Exception (assert)
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.ChainFragment (ChainFragment(..))
@@ -285,7 +286,9 @@ mockBlockFetchServer1 chain =
 
     receiveReq :: ChainRange header
                -> m (BlockFetchBlockSender header block m ())
-    receiveReq (ChainRange lpoint upoint) = do
+    receiveReq (ChainRange lpoint upoint) =
+      -- We can only assert this for tests, not for the real thing.
+      assert (pointSlot lpoint <= pointSlot upoint) $
       case ChainFragment.sliceRange chain
              (castPoint lpoint) (castPoint upoint) of
         Nothing     -> return $ SendMsgNoBlocks (return senderSide)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -8,6 +8,7 @@
 module Ouroboros.Network.BlockFetch.Examples (
     blockFetchExample1,
     mockBlockFetchServer1,
+    exampleFixedPeerGSVs,
   ) where
 
 import qualified Data.Map.Strict as Map
@@ -241,7 +242,6 @@ mockedBlockFetchClient1 clientStateTracer blockHeap clientStateVars =
       clientStateTracer
       (mockFetchClientPolicy1 blockHeap)
       clientStateVars
-      (return exampleFixedPeerGSVs)
 
 mockFetchClientPolicy1 :: TestFetchedBlockHeap m block
                        -> FetchClientPolicy header block m

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -171,7 +171,7 @@ runFetchClient :: (MonadCatch m, MonadAsync m, MonadST m, Ord peerid,
                 -> FetchClientRegistry peerid header m
                 -> peerid
                 -> Channel m LBS.ByteString
-                -> (  FetchClientStateVars header m
+                -> (  FetchClientStateVars m header
                    -> PeerPipelined (BlockFetch header block)
                                     AsClient BFIdle m a)
                 -> m a
@@ -199,7 +199,7 @@ runFetchClientAndServerAsync
                 -> Tracer m (TraceSendRecv (BlockFetch header block))
                 -> FetchClientRegistry peerid header m
                 -> peerid
-                -> (  FetchClientStateVars header m
+                -> (  FetchClientStateVars m header
                    -> PeerPipelined (BlockFetch header block)
                                     AsClient BFIdle m a)
                 -> BlockFetchServer header block m b
@@ -233,7 +233,7 @@ mockedBlockFetchClient1 :: (MonadSTM m, MonadTime m, MonadThrow m,
                             HeaderHash header ~ HeaderHash block)
                         => Tracer m (TraceFetchClientEvent header)
                         -> TestFetchedBlockHeap m block
-                        -> FetchClientStateVars header m
+                        -> FetchClientStateVars m header
                         -> PeerPipelined (BlockFetch header block)
                                          AsClient BFIdle m ()
 mockedBlockFetchClient1 clientStateTracer blockHeap clientStateVars =

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -40,6 +40,7 @@ import           Ouroboros.Network.Channel
 
 import           Ouroboros.Network.DeltaQ
 import           Ouroboros.Network.BlockFetch.Client
+import           Ouroboros.Network.BlockFetch.ClientRegistry
 import           Ouroboros.Network.BlockFetch.State
 import           Ouroboros.Network.BlockFetch
 

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -39,7 +39,6 @@ import           Network.TypedProtocol.Driver
 import           Ouroboros.Network.Channel
 
 import           Ouroboros.Network.DeltaQ
-import           Ouroboros.Network.BlockFetch.Types
 import           Ouroboros.Network.BlockFetch.Client
 import           Ouroboros.Network.BlockFetch.State
 import           Ouroboros.Network.BlockFetch

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
@@ -25,6 +25,7 @@ import           Control.Tracer (Tracer, traceWith)
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment(..))
 import qualified Ouroboros.Network.AnchoredFragment as AnchoredFragment
+import qualified Ouroboros.Network.ChainFragment    as ChainFragment
 
 import           Ouroboros.Network.BlockFetch.ClientState
                    ( FetchRequest(..)
@@ -140,7 +141,7 @@ fetchLogicIteration decisionTracer
       -- Flatten multiple fragments and trace points, not full headers
       [ blockPoint header
       | headers <- headerss
-      , header  <- headers ]
+      , header  <- ChainFragment.toOldestFirst headers ]
 
 -- | Do a bit of rearranging of data before calling 'fetchDecisions' to do the
 -- real work.

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
@@ -133,7 +133,7 @@ fetchLogicIteration decisionTracer
 
     return stateFingerprint'
   where
-    swizzleReqVar (d,(_,_,_,rq)) = (d,rq)
+    swizzleReqVar (d,(_,_,g,rq)) = (d,g,rq)
 
     fetchRequestPoints :: HasHeader hdr => FetchRequest hdr -> [Point hdr]
     fetchRequestPoints (FetchRequest headerss) =
@@ -194,12 +194,13 @@ fetchDecisionsForStateSnapshot
 --
 fetchLogicIterationAct :: MonadSTM m
                        => [(FetchDecision (FetchRequest header),
+                            PeerGSV,
                             FetchClientStateVars m header)]
                        -> m ()
 fetchLogicIterationAct decisions =
     sequence_
-      [ setFetchRequest stateVars request
-      | (Right request, stateVars) <- decisions ]
+      [ setFetchRequest stateVars request gsvs
+      | (Right request, gsvs, stateVars) <- decisions ]
 
 
 -- | STM actions to read various state variables that the fetch logic depends

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE FlexibleContexts           #-}
@@ -132,7 +133,7 @@ fetchLogicIteration decisionTracer
     -- Tell the fetch clients to act on our decisions
     statusUpdates <- fetchLogicIterationAct fetchDecisionPolicy
                                             (map swizzleReqVar decisions)
-    let stateFingerprint'' =
+    let !stateFingerprint'' =
           updateFetchStateFingerprintPeerStatus statusUpdates stateFingerprint'
 
     return stateFingerprint''
@@ -239,9 +240,9 @@ data FetchNonTriggerVariables peer header block m = FetchNonTriggerVariables {
 
 data FetchStateFingerprint peer header block =
      FetchStateFingerprint
-       (Maybe (Point block))
-       (Map peer (Point header))
-       (Map peer (PeerFetchStatus header))
+       !(Maybe (Point block))
+       !(Map peer (Point header))
+       !(Map peer (PeerFetchStatus header))
   deriving Eq
 
 initialFetchStateFingerprint :: FetchStateFingerprint peer header block
@@ -296,7 +297,7 @@ readStateVariables FetchTriggerVariables{..}
     fetchStatePeerStatus    <- readStatePeerStatus
 
     -- Construct the change detection fingerprint
-    let fetchStateFingerprint' =
+    let !fetchStateFingerprint' =
           FetchStateFingerprint
             (Just (castPoint (AnchoredFragment.headPoint fetchStateCurrentChain)))
             (Map.map AnchoredFragment.headPoint fetchStatePeerChains)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
@@ -31,7 +31,7 @@ import           Ouroboros.Network.BlockFetch.ClientState
                    , PeerFetchInFlight(..)
                    , PeerFetchStatus(..)
                    , TFetchRequestVar
-                   , writeTFetchRequestVar
+                   , setFetchRequest
                    )
 import           Ouroboros.Network.BlockFetch.Decision
                    ( fetchDecisions
@@ -201,7 +201,7 @@ fetchLogicIterationAct :: MonadSTM m
                        -> m ()
 fetchLogicIterationAct decisions =
     sequence_
-      [ atomically (writeTFetchRequestVar peerFetchRequestVar request)
+      [ setFetchRequest peerFetchRequestVar request
       | (Right request, peerFetchRequestVar) <- decisions ]
 
 

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
@@ -26,7 +26,7 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment(..))
 import qualified Ouroboros.Network.AnchoredFragment as AnchoredFragment
 
-import           Ouroboros.Network.BlockFetch.Types
+import           Ouroboros.Network.BlockFetch.ClientState
                    ( FetchRequest(..)
                    , PeerFetchInFlight(..)
                    , PeerFetchStatus(..)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -15,7 +15,7 @@ import           Ouroboros.Network.Block (StandardHash, Point)
 import           Network.TypedProtocol.Codec (AnyMessage (..))
 import           Network.TypedProtocol.Core (Protocol (..))
 
--- | Range of headers
+-- | Range of headers, defined by a lower and upper point, inclusive.
 --
 data ChainRange header = ChainRange !(Point header) !(Point header)
   deriving (Show, Eq, Ord)


### PR DESCRIPTION
The two most important patches here are the following two. The rest is refactoring, or tidying.
```
Change where block fetch in-flight stats are updated

This should fix a tricky concurrency bug in the interaction of the block
fetch decision logic thread and the block fetch client thread(s).
PReviously we would post a proposed request but not update the in-flight
stats until the request is accepted by the client thread. This would
allow a possible schedule where before a fetch request being updated
(with the same or better one) the client thread coule accept the
previous request, leading to the same fetch request being made twice.
This then led to subsequent incorrect in-flight stats and further bad
consequences.

Now we update the in-flight stats at the moment the fetch request is
posted. We can now enforce the invariant that (for a single fetch
client thread) requests for any block are posted at most once.

This paves the way to resolve another theoretical (but never observed)
schedule where if the decision logic thread is severely delayed that it
could entirely miss the completion of a block fetch request. This patch
does not resolve that issue, but doing so requires this step of moving
when the stats are updated.
```
```
Update the FetchStateFingerprint after adding fetch requests

This resolves two problems:
 1. the decision logic thread waking up unnecessarily
 2. the decision logic thread missing state changes

The latter is a correctness problem (though theoretical and nerver
observed in practice) while the former is a performance and cleanlyness
issue.

The basic issue is that the decision logic thread blocks until the state
changes, however when it does wake up and make a decision it changes the
very state that it observes. In particular it changes the status of the
block fetch client threads.

This means that every time it does an update it ends up doing another
follow-up check since it changed the state. But in that new state there
is never anything more to do, we did it all in the previous step.

And in the other direction, it's theoretically possible (with an extreme
thread schedule) for an entire block fetch request cycle to complete,
returning the state back to the original, before the decision thread
goes back to blocking on the state changes. This would mean that the
decision thread could miss the fact that that fetch client thread is
ready to do more requests.

Both problems are resolved by changing the state fingerprint that the
decision logic compares against when looking for state changes. We
update the state fingerprint to reflect the changes in fetch client
status that we cause by adding new block fetch requests.
```