### PR TITLE
Remove obsolete turbohack that cleans up the demo's named pipes

### DIFF
--- a/demo-playground/cleanup-demo.sh
+++ b/demo-playground/cleanup-demo.sh
@@ -1,2 +1,0 @@
-rm -f upstream*
-rm -f downstream*

--- a/demo-playground/start-node.sh
+++ b/demo-playground/start-node.sh
@@ -1,13 +1,5 @@
 #!/usr/bin/env bash
 
-# Turbohack to clean up the resources.
-trap ctrl_c INT
-
-function ctrl_c() {
-  echo "Cleaning up named pipes..."
-  sh -c "./demo-playground/cleanup-demo.sh"
-}
-
 now=`date "+%Y-%m-%d 00:00:00"`
 
 set -x


### PR DESCRIPTION
The `ThreadRegistry` is now properly terminating the forked threads that run
the communication over the named pipes, so the "close" part of the `bracket`
in `withPipeChannel` is actually being executed. Hence the bash turbohack to
clean up the named pipes upon CTRL-C is no longer necessary.

Fixes #223.