### PR TITLE
Enable -Werror in all packages

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -32,7 +32,11 @@ let
         # This is similar to jailbreakCabal, however it
         # does not require any messing with cabal files.
         packages.katip.components.library.doExactConfig = true;
+        packages.typed-protocols.configureFlags = [ "--ghc-option=-Werror" ];
+        packages.io-sim.configureFlags = [ "--ghc-option=-Werror" ];
+        packages.io-sim-classes.configureFlags = [ "--ghc-option=-Werror" ];
         packages.ouroboros-network.configureFlags = [ "--ghc-option=-Werror" ];
+        packages.ouroboros-consensus.configureFlags = [ "--ghc-option=-Werror" ];
       }
     ];
   };


### PR DESCRIPTION
- `io-sim`
- `io-sim-classes`
- `typed-protocols`
- `ouroboros-consensus`

`ouroboros-network` allready builds with -Werror