### PR TITLE
Fix bug in cborEpochFileParser

### DIFF
--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
@@ -22,7 +22,7 @@ module Test.Ouroboros.Storage.ImmutableDB.TestBlock
   , tests
   ) where
 
-import           Codec.Serialise (Serialise)
+import           Codec.Serialise (Serialise, decode, serialiseIncremental)
 import           Control.Monad (forM, replicateM, void, when)
 import           Control.Monad.Class.MonadThrow
 
@@ -53,8 +53,11 @@ import           Ouroboros.Storage.FS.API.Types (FsPath)
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import           Ouroboros.Storage.FS.Sim.STM (runSimFS)
 import           Ouroboros.Storage.ImmutableDB.Types
-import           Ouroboros.Storage.ImmutableDB.Util (readAll)
+import           Ouroboros.Storage.ImmutableDB.Util (cborEpochFileParser,
+                     readAll)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+import           Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr)
 
 import           Test.Util.Orphans.Arbitrary ()
 
@@ -207,7 +210,7 @@ prop_testBlockEpochFileParser (TestBlocks mbEBB regularBlocks) = QCM.monadicIO $
     QSM.liftProperty (ebbHash === mbEBB)
     let (offsets', blocks') = unzip offsetsAndBlocks
         offsets = dropLast $ scanl (+) 0 $
-          map (const (fromIntegral testBlockSize)) blocks
+          map (const testBlockSize) blocks
     QSM.liftProperty (blocks  ===  blocks')
     QSM.liftProperty (offsets === offsets')
   where
@@ -230,6 +233,71 @@ prop_testBlockEpochFileParser (TestBlocks mbEBB regularBlocks) = QCM.monadicIO $
     runSimIO :: (HasFS IO Mock.Handle -> IO a) -> IO a
     runSimIO m = fst <$> runSimFS EH.exceptions Mock.empty m
 
+{-------------------------------------------------------------------------------
+  CBOR EpochFileParser
+-------------------------------------------------------------------------------}
+
+-- [readIncrementalOffsetsEBB bug]
+--
+-- There was a bug in 'readIncrementalOffsetsEBB' (used in the implementation
+-- of 'cborEpochFileParser') that caused it to prematurely stop the
+-- incremental deserialisation of blocks from a file. Whenever the 'Done' case
+-- (of 'IDecode') was reached with no leftover bytes, deserialisation was
+-- stopped incorrectly. In this case, deserialisation only has to stop when
+-- there are no more bytes in the file. The absence of leftover bytes in the
+-- 'Done' constructor was mistakenly interpreted to represent this. In
+-- reality, it means that no more bytes are left over in the /chunk/ that was
+-- read from the file, not that no more bytes are left over in the /file/ that
+-- is being read.
+--
+-- The test below tries to trigger this bug by using a chunk size equal to the
+-- size of the first block so that it can be deserialised with exactly all the
+-- bytes that have been read in one chunk (resulting in no leftover bytes).
+
+prop_testBlockCborEpochFileParser :: TestBlocks -> Property
+prop_testBlockCborEpochFileParser (TestBlocks mbEBB regularBlocks) = QCM.monadicIO $ do
+    (offsetsAndSizesAndBlocks, ebbHash, mbErr) <- QCM.run $ runSimIO $ \hasFS -> do
+      writeBlocks hasFS
+      readBlocks  hasFS
+    QSM.liftProperty (mbErr   === Nothing)
+    QSM.liftProperty (ebbHash === mbEBB)
+    let (offsets', sizesAndBlocks) = unzip offsetsAndSizesAndBlocks
+        blocks' = map snd sizesAndBlocks
+    QSM.liftProperty (blocks  === blocks')
+    QSM.liftProperty (offsets === offsets')
+  where
+    dropLast xs = zipWith const xs (drop 1 xs)
+    file = ["test"]
+
+    blocks = maybeToList mbEBB <> regularBlocks
+    blockSizes = map blockSize blocks
+    offsets = dropLast $ scanl (+) 0 blockSizes
+    chunkSize = case blockSizes of
+      []               -> 32
+      firstBlockSize:_ -> fromIntegral firstBlockSize
+
+    writeBlocks :: HasFS IO Mock.Handle -> IO ()
+    writeBlocks hasFS@HasFS{..} = do
+      let bld = foldMap serialiseIncremental blocks
+      withFile hasFS file AppendMode $ \eHnd -> void $ hPut eHnd bld
+
+    readBlocks :: HasFS IO Mock.Handle
+               -> IO ( [(SlotOffset, (Word64, TestBlock))]
+                     , Maybe TestBlock
+                     , Maybe ReadIncrementalErr)
+    readBlocks hasFS = runEpochFileParser
+      (cborEpochFileParser chunkSize hasFS decode extractEBB)
+      file
+
+    extractEBB :: TestBlock -> Maybe TestBlock
+    extractEBB b | testBlockIsEBB b = Just b
+                 | otherwise        = Nothing
+
+    blockSize :: TestBlock -> SlotOffset
+    blockSize = fromIntegral . BL.length . BS.toLazyByteString . serialiseIncremental
+
+    runSimIO :: (HasFS IO Mock.Handle -> IO a) -> IO a
+    runSimIO m = fst <$> runSimFS EH.exceptions Mock.empty m
 
 {-------------------------------------------------------------------------------
   Corruption
@@ -285,6 +353,7 @@ shrinkCorruptions =
 
 tests :: TestTree
 tests = testGroup "TestBlock"
-    [ testProperty "TestBlock Binary roundtrip" prop_TestBlock_Binary
-    , testProperty "testBlockEpochFileParser" prop_testBlockEpochFileParser
+    [ testProperty "TestBlock Binary roundtrip"   prop_TestBlock_Binary
+    , testProperty "testBlockEpochFileParser"     prop_testBlockEpochFileParser
+    , testProperty "testBlockCborEpochFileParser" prop_testBlockCborEpochFileParser
     ]


### PR DESCRIPTION
@avieth encountered a bug in the ImmutableDB (using the `ValidateAllEpochs`
policy) when storing blocks in it downloaded from mainnet using the
byron-proxy. Interrupting the download in the middle of the second epoch and
restarting it caused the ImmutableDB to remove the second epoch file and to
restart appending to the first epoch file, growing beyond its expected file
size. Cancelling again caused the same thing to happen, and the first epoch
file keeps on growing more and more each time.

The cause of this bug was in the `EpochFileParser`, which parses an epoch file
and tells which blocks start at which offsets. The `EpochFileParser` used in
this case was `cborEpochFileParser'`. For the first epoch file, it was
reporting that the last block ended at offset 9858352 instead of at offset
14788562 (without reporting an error). So the blocks after this offset were
invisible to the ImmutableDB, but were still in the epoch file, and were
appended again on each restart.

The reported incorrect final offset was due to a bug in
`readIncrementalOffsetsEBB` that caused it to prematurely stop the incremental
deserialisation of blocks from a file. Whenever the `Done` case (of `IDecode`)
was reached with no leftover bytes, deserialisation was stopped incorrectly.
In this case, deserialisation only has to stop when there are no more bytes in
the file. The absence of leftover bytes in the `Done` constructor was
mistakenly interpreted to represent this. In reality, it means that no more
bytes are left over in the _chunk_ that was read from the file, not that no
more bytes are left over in the _file_ that is being read.

This commit fixes the bug and adds a property test that triggers this exact
bug by using a chunk size that exactly matches the size of a block. Also add a
simple check in the ImmutableDB that verifies whether the final offset the
`EpochFileParser` reports (in the absence of an error) matches the size of the
epoch file. If this isn't the case, it must be a bug in the `EpochFileParser`,
which is something we can't recover from, as we're using it to
validate/recover (missing) index files.