### PR TITLE
Remove default-extensions from .cabal files

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -183,7 +183,6 @@ test-suite tests
                        Test.Pipe
                        Test.Socket
   default-language:    Haskell2010
-  default-extensions:  NamedFieldPuns
   build-depends:       base,
                        typed-protocols,
                        io-sim-classes,
@@ -242,7 +241,6 @@ test-suite test-cddl
                        Ouroboros.Network.Chain
                        Ouroboros.Network.Codec
   default-language:    Haskell2010
-  default-extensions:  NamedFieldPuns
   build-depends:       base,
                        bytestring,
                        cborg,

--- a/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TypeOperators       #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 
 module Test.Ouroboros.Network.Node where
 


### PR DESCRIPTION
They were not needed and it's not good practice.