### PR TITLE
byron proxy script generator helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ TAGS
 
 .stack-work/
 *.tix
+
+db-byron-proxy-*
+index-byron-proxy-*

--- a/default.nix
+++ b/default.nix
@@ -49,7 +49,8 @@ let
   byronProxyScripts = import ./nix/byron-proxy-scripts.nix {
     inherit commonLib oldCardanoSrc byronProxy;
   };
+  tests = import ./nix/nixos/tests { pkgs = commonLib.pkgs; };
 in {
-  inherit byronProxyScripts;
+  inherit byronProxyScripts tests;
   inherit (nixTools) nix-tools;
 }

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,4 @@
+{ ... }@args:
 #
 # The defaul.nix file. This will generate targets for all
 # buildables (see release.nix for nomenclature, excluding
@@ -5,7 +6,7 @@
 #
 # - nix build -f default.nix nix-tools.tests.io-sim # All `io-sim` tests
 # - nix build -f default.nix nix-tools.tests.ouroboros-consensus.test-consensus
-# 
+#
 # Generated targets include anything from stack.yaml (via
 # nix-tools:stack-to-nix and the nix/regenerate.sh script)
 # or cabal.project (via nix-tools:plan-to-nix), including all
@@ -19,30 +20,36 @@
 # Please run `nix/regenerate.sh` after modifying stack.yaml
 # or relevant part of cabal configuration files.
 # When switching to recent stackage or hackage package version,
-# you might also need to update the iohk-nix common lib. You 
+# you might also need to update the iohk-nix common lib. You
 # can do so by running the `nix/update-iohk-nix.sh` script.
-# 
+#
 # More information about iohk-nix and nix-tools is available at:
 # https://github.com/input-output-hk/iohk-nix/blob/master/docs/nix-toolification.org#for-a-stackage-project
 #
-
 
 # We will need to import the iohk-nix common lib, which includes
 # the nix-tools tooling.
 let
   commonLib = import ./nix/iohk-common.nix;
-in
+
 # This file needs to export a function that takes
 # the arguments it is passed and forwards them to
 # the default-nix template from iohk-nix. This is
 # important so that the release.nix file can properly
 # parameterize this file when targetting different
 # hosts.
-{ ... }@args:
-# We will instantiate the default-nix template with the
-# nix/pkgs.nix file...
-commonLib.nix-tools.default-nix ./nix/pkgs.nix args 
-# ... and add additional non-haskell packages we want to build on CI:
-// {
-  
+  nixTools = commonLib.nix-tools.default-nix ./nix/pkgs.nix args;
+  # TODO: remove when proxy and old cardano configs no
+  # longer required.
+  oldCardanoSrc = import ./nix/old-cardano.nix {
+    inherit commonLib;
+  };
+  byronProxy = nixTools.nix-tools.exes.byron-proxy;
+  # TODO: move scripts to cardano-shell at some point.
+  byronProxyScripts = import ./nix/byron-proxy-scripts.nix {
+    inherit commonLib oldCardanoSrc byronProxy;
+  };
+in {
+  inherit byronProxyScripts;
+  inherit (nixTools) nix-tools;
 }

--- a/nix/byron-proxy-scripts.nix
+++ b/nix/byron-proxy-scripts.nix
@@ -1,0 +1,29 @@
+{ commonLib
+, oldCardanoSrc
+, byronProxy
+, serverHost ? "127.0.0.1"
+, serverPort ? 7777
+}:
+
+let
+  pkgs = commonLib.pkgs;
+  oldCardano = import oldCardanoSrc {};
+  oldCardanoLib = import (oldCardanoSrc + "/lib.nix");
+  environments = oldCardanoLib.environments;
+  loggingConfig = ../byron-proxy/cfg/logging.yaml;
+  mkTopology = relay: pkgs.writeText "topology-file" ''
+    wallet:
+      relays: [[{ host: ${relay} }]]
+  '';
+  mkProxyScript = environment: let
+      envConfig = environments.${environment};
+    in pkgs.writeScript "byron-proxy-${environment}" ''
+    exec ${byronProxy}/bin/byron-proxy +RTS -T -RTS --database-path db-byron-proxy-${environment} --index-path index-byron-proxy-${environment} --configuration-file ${configuration}/lib/configuration.yaml --configuration-key ${envConfig.confKey} --server-host ${serverHost} --server-port ${builtins.toString serverPort} --topology ${mkTopology envConfig.relays} --logger-config ${loggingConfig}
+  '';
+  configuration = oldCardano.cardano-sl-config;
+
+in {
+  mainnet = mkProxyScript "mainnet";
+  staging = mkProxyScript "staging";
+  testnet = mkProxyScript "testnet";
+}

--- a/nix/nixos/byron-proxy.nix
+++ b/nix/nixos/byron-proxy.nix
@@ -1,0 +1,59 @@
+{ config, pkgs, lib, options, ... }:
+with lib;
+let
+  cfg = config.services.byron-proxy;
+  name = "byron-proxy";
+  stateDir = "/var/lib/byron-proxy";
+
+  byronProxyScripts = (import ../.. {}).byronProxyScripts;
+in {
+  options.services.byron-proxy = {
+    enable = mkEnableOption name;
+    environment = mkOption {
+      type = types.enum [ "mainnet" "staging" "testnet" ];
+      default = "mainnet";
+    };
+    serverPort = mkOption {
+      type = types.int;
+      default = 7777;
+    };
+    serverHost = mkOption {
+      type = types.string;
+      default = "127.0.0.1";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users = {
+      users.byron-proxy = {
+        description     = "byron-proxy";
+        group           = "byron-proxy";
+        home            = stateDir;
+        createHome      = true;
+      };
+      groups.byron-proxy = {};
+    };
+
+    networking.firewall = {
+      allowedTCPPorts = lib.optional (cfg.serverHost != "127.0.0.1") cfg.serverPort;
+    };
+
+    systemd.services.byron-proxy = {
+      description   = "byron proxy service";
+      after         = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      script = ''${byronProxyScripts.${cfg.environment}}'';
+      serviceConfig = {
+        User = "byron-proxy";
+        Group = "byron-proxy";
+        Restart = "always";
+        RestartSec = 30;
+        StartLimitInterval = 200;
+        StartLimitBurst = 5;
+        KillSignal = "SIGINT";
+        WorkingDirectory = stateDir;
+        PrivateTmp = true;
+      };
+    };
+  };
+}

--- a/nix/nixos/default.nix
+++ b/nix/nixos/default.nix
@@ -1,0 +1,3 @@
+{
+  imports = import ./module-list.nix;
+}

--- a/nix/nixos/module-list.nix
+++ b/nix/nixos/module-list.nix
@@ -1,0 +1,3 @@
+[
+  ./byron-proxy.nix
+]

--- a/nix/nixos/tests/byron-proxy.nix
+++ b/nix/nixos/tests/byron-proxy.nix
@@ -1,0 +1,23 @@
+{ pkgs, ... }:
+
+{
+  name = "byron-proxy-test";
+  nodes = {
+    machine = { config, pkgs, ... }: {
+      imports = [
+        (import ../.)
+      ];
+      services.byron-proxy = {
+        enable = true;
+        serverHost = "0.0.0.0";
+        serverPort = 7777;
+      };
+    };
+  };
+  testScript = ''
+    startAll
+    $machine->waitForUnit("byron-proxy.service");
+    $machine->waitForOpenPort(7777);
+  '';
+
+}

--- a/nix/nixos/tests/default.nix
+++ b/nix/nixos/tests/default.nix
@@ -1,0 +1,18 @@
+{ pkgs ? (import <nixpkgs> {}), supportedSystems ? [ "x86_64-linux" ] }:
+
+ with pkgs;
+with pkgs.lib;
+
+ let
+  forAllSystems = genAttrs supportedSystems;
+  importTest = fn: args: system: let
+    imported = import fn;
+    test = import (pkgs.path + "/nixos/tests/make-test.nix") imported;
+  in test ({
+    inherit system;
+  } // args);
+  callTest = fn: args: forAllSystems (system: hydraJob (importTest fn args system));
+in rec {
+  # TODO: tests of images
+  byronProxy = callTest ./byron-proxy.nix {};
+}

--- a/nix/old-cardano-sl-src.json
+++ b/nix/old-cardano-sl-src.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://github.com/input-output-hk/cardano-sl",
+  "rev": "24dcb24967cb97293f29ec886b0467be67edbcce",
+  "sha256": "1dw51f9iwq8ja7wap2b8pas4bqpkgr6mwfc20zc7183nc1bb1wf1",
+  "fetchSubmodules": false
+}

--- a/nix/old-cardano.nix
+++ b/nix/old-cardano.nix
@@ -1,0 +1,5 @@
+{ commonLib }:
+let
+  pkgs = commonLib.pkgs;
+  cfg = builtins.fromJSON (builtins.readFile ./old-cardano-sl-src.json);
+in pkgs.fetchgit cfg


### PR DESCRIPTION
I made these scripts to make it easier to launch byron proxy with the right configs for mainnet, staging and testnet. I do not think these should permanently live here, but for now, this makes it easier to test locally for devops/devs. This is the first step to integrating into iohk-ops to deploy a continuously running proxy and chain validator.

@angerman could use a confirmation that moving nix-tools into the let block doesn't break anything, although I assume if CI passes, it's probably fine.