### PR TITLE
Don't use `Serialise` in codecs

### DIFF
--- a/byron-proxy/src/lib/Ouroboros/Byron/Proxy/ChainSync/Types.hs
+++ b/byron-proxy/src/lib/Ouroboros/Byron/Proxy/ChainSync/Types.hs
@@ -52,4 +52,4 @@ instance Serialise Point where
 codec
   :: (MonadST m)
   => Codec (ChainSync Block Point) CBOR.DeserialiseFailure m Lazy.ByteString
-codec = codecChainSync
+codec = codecChainSync encode encode decode decode

--- a/ouroboros-consensus/demo-playground/Run.hs
+++ b/ouroboros-consensus/demo-playground/Run.hs
@@ -7,7 +7,7 @@ module Run (
       runNode
     ) where
 
-import           Codec.Serialise (encode)
+import           Codec.Serialise (encode, decode)
 import qualified Control.Concurrent.Async as Async
 import           Control.Concurrent.STM
 import           Control.Monad
@@ -177,11 +177,11 @@ handleSimpleNode p CLI{..} (TopologyInfo myNodeId topologyFile) = do
         where
           direction = Upstream (producerNodeId :==>: myNodeId)
           nodeCommsCS = NodeComms {
-              ncCodec    = codecChainSync
+              ncCodec    = codecChainSync encode encode decode decode
             , ncWithChan = NamedPipe.withPipeChannel "chain-sync" direction
             }
           nodeCommsBF = NodeComms {
-              ncCodec    = codecBlockFetch
+              ncCodec    = codecBlockFetch encode encode decode decode
             , ncWithChan = NamedPipe.withPipeChannel "block-fetch" direction
             }
 
@@ -194,10 +194,10 @@ handleSimpleNode p CLI{..} (TopologyInfo myNodeId topologyFile) = do
         where
           direction = Downstream (myNodeId :==>: consumerNodeId)
           nodeCommsCS = NodeComms {
-              ncCodec    = codecChainSync
+              ncCodec    = codecChainSync encode encode decode decode
             , ncWithChan = NamedPipe.withPipeChannel "chain-sync" direction
             }
           nodeCommsBF = NodeComms {
-              ncCodec    = codecBlockFetch
+              ncCodec    = codecBlockFetch encode encode decode decode
             , ncWithChan = NamedPipe.withPipeChannel "block-fetch" direction
             }

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -17,7 +17,7 @@ import           Data.Map (Map)
 import qualified Data.Set as Set
 import           Data.Set (Set)
 import qualified Data.ByteString.Lazy as LBS
-import           Codec.Serialise (Serialise)
+import           Codec.Serialise (Serialise(..))
 
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadST
@@ -190,7 +190,7 @@ runFetchClient :: (MonadCatch m, MonadAsync m, MonadST m, Ord peerid,
                 -> m a
 runFetchClient tracer registry peerid channel client =
     bracketFetchClient registry peerid $ \stateVars ->
-      runPipelinedPeer 10 tracer codecBlockFetch channel (client stateVars)
+      runPipelinedPeer 10 tracer (codecBlockFetch encode encode decode decode) channel (client stateVars)
 
 runFetchServer :: (MonadThrow m, MonadST m,
                    Serialise header,
@@ -201,7 +201,7 @@ runFetchServer :: (MonadThrow m, MonadST m,
                 -> BlockFetchServer header block m a
                 -> m a
 runFetchServer tracer channel server =
-    runPeer tracer codecBlockFetch channel (blockFetchServerPeer server)
+    runPeer tracer (codecBlockFetch encode encode decode decode) channel (blockFetchServerPeer server)
 
 runFetchClientAndServerAsync
                :: (MonadCatch m, MonadAsync m, MonadST m, Ord peerid,
@@ -341,4 +341,3 @@ mkTestFetchedBlockHeap points = do
       getTestFetchedBlocks = readTVar v,
       addTestFetchedBlock  = \p _b -> atomically (modifyTVar' v (Set.insert p))
     }
-

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -8,6 +8,7 @@ module Ouroboros.Network.Protocol.BlockFetch.Test (tests) where
 
 import           Control.Monad.ST (runST)
 import           Data.ByteString.Lazy (ByteString)
+import qualified Codec.Serialise as S
 
 import           Control.Monad.IOSim (runSimOrThrow)
 import           Control.Monad.Class.MonadST (MonadST)
@@ -124,7 +125,7 @@ prop_direct (TestChainAndPoints chain points) =
 
 -- | Run a pipelined block-fetch client with a server, without going via 'Peer'.
 --
--- 
+--
 --
 prop_directPipelined1 :: TestChainAndPoints -> Bool
 prop_directPipelined1 (TestChainAndPoints chain points) =
@@ -267,7 +268,7 @@ prop_channel :: (MonadAsync m, MonadCatch m, MonadST m)
 prop_channel createChannels chain points = do
     (bodies, ()) <-
       runConnectedPeers
-        createChannels nullTracer codecBlockFetch
+        createChannels nullTracer (codecBlockFetch S.encode S.encode S.decode S.decode)
         (blockFetchClientPeer (testClient chain points))
         (blockFetchServerPeer (testServer chain))
     return $ reverse bodies === concat (receivedBlockBodies chain points)
@@ -327,19 +328,19 @@ prop_codec_BlockFetch
   :: AnyMessageAndAgency (BlockFetch BlockHeader BlockBody)
   -> Bool
 prop_codec_BlockFetch msg =
-  runST (prop_codecM codecBlockFetch msg)
+  runST (prop_codecM (codecBlockFetch S.encode S.encode S.decode S.decode) msg)
 
 prop_codec_splits2_BlockFetch
   :: AnyMessageAndAgency (BlockFetch BlockHeader BlockBody)
   -> Bool
 prop_codec_splits2_BlockFetch msg =
-  runST (prop_codec_splitsM splits2 codecBlockFetch msg)
+  runST (prop_codec_splitsM splits2 (codecBlockFetch S.encode S.encode S.decode S.decode) msg)
 
 prop_codec_splits3_BlockFetch
   :: AnyMessageAndAgency (BlockFetch BlockHeader BlockBody)
   -> Bool
 prop_codec_splits3_BlockFetch msg =
-  runST (prop_codec_splitsM splits3 codecBlockFetch msg)
+  runST (prop_codec_splitsM splits3 (codecBlockFetch S.encode S.encode S.decode S.decode) msg)
 
 
 --

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -6,7 +6,7 @@
 
 module Test.Pipe (tests) where
 
-import           Codec.Serialise (Serialise)
+import           Codec.Serialise (Serialise(..))
 import           Control.Monad
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
@@ -86,11 +86,11 @@ demo chain0 updates = do
         consumerPeer = ChainSync.chainSyncClientPeer
                           (ChainSync.chainSyncClientExample consumerVar
                           (consumerClient done target consumerVar))
-        consumerPeers Mxt.ChainSync1 = Mx.OnlyClient nullTracer ChainSync.codecChainSync consumerPeer
+        consumerPeers Mxt.ChainSync1 = Mx.OnlyClient nullTracer (ChainSync.codecChainSync encode encode decode decode) consumerPeer
 
         producerPeer :: Peer (ChainSync.ChainSync block (Point block)) AsServer ChainSync.StIdle IO ()
         producerPeer = ChainSync.chainSyncServerPeer (ChainSync.chainSyncServerExample () producerVar)
-        producerPeers Mxt.ChainSync1 = Mx.OnlyServer nullTracer ChainSync.codecChainSync producerPeer
+        producerPeers Mxt.ChainSync1 = Mx.OnlyServer nullTracer (ChainSync.codecChainSync encode encode decode decode) producerPeer
 
     _ <- async $ runNetworkNodeWithPipe producerPeers hndRead1 hndWrite2
     _ <- async $ runNetworkNodeWithPipe consumerPeers hndRead2 hndWrite1

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -282,7 +282,7 @@ demo chain0 updates = do
         consumerPeer = ChainSync.chainSyncClientPeer
                         (ChainSync.chainSyncClientExample consumerVar
                         (consumerClient done target consumerVar))
-        consumerPeers Mxt.ChainSync1 = OnlyClient nullTracer ChainSync.codecChainSync consumerPeer
+        consumerPeers Mxt.ChainSync1 = OnlyClient nullTracer (ChainSync.codecChainSync encode encode decode decode) consumerPeer
         consumerNet = NetworkInterface {
               nodeAddress = consumerAddress,
               protocols   = consumerPeers
@@ -290,7 +290,7 @@ demo chain0 updates = do
 
         producerPeer :: Peer (ChainSync.ChainSync block (Point block)) AsServer ChainSync.StIdle IO ()
         producerPeer = ChainSync.chainSyncServerPeer (ChainSync.chainSyncServerExample () producerVar)
-        producerPeers Mxt.ChainSync1 = OnlyServer nullTracer ChainSync.codecChainSync producerPeer
+        producerPeers Mxt.ChainSync1 = OnlyServer nullTracer (ChainSync.codecChainSync encode encode decode decode) producerPeer
         producerNet = NetworkInterface {
               nodeAddress = producerAddress,
               protocols   = producerPeers


### PR DESCRIPTION
Instead take explicit encoders and decoders. This will be needed for Byron since we don't _have_ those instances there (instead we have functions that require additional context).