### PR TITLE
Resurrect nix shell

### DIFF
--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "ef6ad17ef38834b43cd9686b53ec5d49b776fff2",
-  "date": "2019-04-09T12:09:39+08:00",
-  "sha256": "0abpfb5ydf90rcq2anqc28v3xwhf4162wzf22fgkb9kx4ynm0949",
+  "rev": "c21c67a8d551259f5a7a9f8ecd88ff994697a2bb",
+  "date": "2019-05-17T23:38:11+03:00",
+  "sha256": "0l2qrrpxpmn9wyfpbd9rgjxyj3s0w4096vlndv6ji3yyjrrfa5cy",
   "fetchSubmodules": false
 }

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,6 @@ let
 in
 default.nix-tools._raw.shellFor {
   packages    = p: map (x: p."${x}") [
-    "cabal-install"
     "io-sim"
     "io-sim-classes"
     "ouroboros-consensus"
@@ -13,4 +12,7 @@ default.nix-tools._raw.shellFor {
     "typed-transitions"
   ];
   withHoogle  = withHoogle;
+  buildInputs = with default.nix-tools._raw; [
+    cabal-install.components.exes.cabal
+  ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ withHoogle ? true
+}:
+let
+  default = import ./default.nix {};
+in
+default.nix-tools._raw.shellFor {
+  packages    = p: map (x: p."${x}") [
+    "cabal-install"
+    "io-sim"
+    "io-sim-classes"
+    "ouroboros-consensus"
+    "ouroboros-network"
+    "typed-transitions"
+  ];
+  withHoogle  = withHoogle;
+}


### PR DESCRIPTION
This provides a nix-shell based on the new `shellFor` functionality of `haskell.nix`.

Note, that since the `shellFor` functionality wasn't yet merged, this is a DO-NOT-MERGE(-yet) PR for preview.

You can `nix-shell` and `cabal build`, though.