### PR TITLE
Improve chain QC generators

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Node.hs
@@ -388,5 +388,11 @@ coreNode :: forall m.
      -> m (TVar m (ChainProducerState Block))
 coreNode nid slotDuration gchain chans = do
   cpsVar <- relayNode nid Genesis chans
-  forkCoreKernel slotDuration gchain (Concrete.fixupBlock . Chain.head) cpsVar
+  forkCoreKernel slotDuration gchain fixupBlock cpsVar
   return cpsVar
+  where
+    fixupBlock :: Chain Block -> Block -> Block
+    fixupBlock c =
+      Concrete.fixupBlock
+        (Chain.headHash c)
+        (Chain.headBlockNo c)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -36,9 +36,7 @@ import           Ouroboros.Network.Protocol.BlockFetch.Direct
 import           Ouroboros.Network.Protocol.BlockFetch.Examples
 import           Ouroboros.Network.Protocol.BlockFetch.Codec
 
-import           Test.ChainGenerators ( TestChainAndPoints (..)
-                                      , ArbitraryChainRange (..)
-                                      , ArbitraryBlockBody (..))
+import           Test.ChainGenerators ( TestChainAndPoints (..) )
 import           Test.Ouroboros.Network.Testing.Utils (splits2, splits3)
 
 import           Test.QuickCheck
@@ -302,11 +300,11 @@ prop_pipe_IO (TestChainAndPoints chain points) =
 instance Arbitrary (AnyMessageAndAgency (BlockFetch BlockHeader BlockBody)) where
   arbitrary = oneof
     [ AnyMessageAndAgency (ClientAgency TokIdle) <$>
-        MsgRequestRange <$> (getArbitraryChainRange <$> arbitrary)
+        MsgRequestRange <$> arbitrary
     , return $ AnyMessageAndAgency (ServerAgency TokBusy) MsgStartBatch
     , return $ AnyMessageAndAgency (ServerAgency TokBusy) MsgNoBlocks
     , AnyMessageAndAgency (ServerAgency TokStreaming) <$>
-        MsgBlock <$> getArbitraryBlockBody <$> arbitrary
+        MsgBlock <$> arbitrary
     , return $ AnyMessageAndAgency (ServerAgency TokStreaming) MsgBatchDone
     , return $ AnyMessageAndAgency (ClientAgency TokIdle) MsgClientDone
     ]

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -39,7 +39,7 @@ import Ouroboros.Network.Protocol.ChainSync.Codec
 import qualified Ouroboros.Network.Protocol.ChainSync.Examples as ChainSyncExamples
 
 import Ouroboros.Network.Testing.ConcreteBlock (Block (..), BlockHeader (..))
-import Test.ChainGenerators ( ArbitraryPoint (..), ArbitraryBlockHeader (..))
+import Test.ChainGenerators ()
 import Test.Ouroboros.Network.Testing.Utils (splits2, splits3)
 import Test.ChainProducerState (ChainProducerStateForkTest (..))
 
@@ -144,30 +144,30 @@ instance Arbitrary (AnyMessageAndAgency (ChainSync BlockHeader (Point BlockHeade
     , return $ AnyMessageAndAgency (ServerAgency (TokNext TokCanAwait)) MsgAwaitReply
 
     , AnyMessageAndAgency (ServerAgency (TokNext TokCanAwait))
-        <$> (MsgRollForward <$> (getArbitraryBlockHeader <$> arbitrary)
-        <*> (getArbitraryPoint <$> arbitrary))
+        <$> (MsgRollForward <$> arbitrary
+                            <*> arbitrary)
 
     , AnyMessageAndAgency (ServerAgency (TokNext TokMustReply))
-        <$> (MsgRollForward <$> (getArbitraryBlockHeader <$> arbitrary)
-        <*> (getArbitraryPoint <$> arbitrary))
+        <$> (MsgRollForward <$> arbitrary
+                            <*> arbitrary)
 
     , AnyMessageAndAgency (ServerAgency (TokNext TokCanAwait))
-        <$> (MsgRollBackward <$> (getArbitraryPoint <$> arbitrary)
-        <*> (getArbitraryPoint <$> arbitrary))
+        <$> (MsgRollBackward <$> arbitrary
+                             <*> arbitrary)
 
     , AnyMessageAndAgency (ServerAgency (TokNext TokMustReply))
-        <$> (MsgRollBackward <$> (getArbitraryPoint <$> arbitrary)
-        <*> (getArbitraryPoint <$> arbitrary))
+        <$> (MsgRollBackward <$> arbitrary
+                             <*> arbitrary)
 
     , AnyMessageAndAgency (ClientAgency TokIdle) . MsgFindIntersect
-        <$> (map getArbitraryPoint <$> arbitrary)
+        <$> arbitrary
 
     , AnyMessageAndAgency (ServerAgency TokIntersect)
-        <$> (MsgIntersectImproved <$> (getArbitraryPoint <$> arbitrary)
-        <*> (getArbitraryPoint <$> arbitrary))
+        <$> (MsgIntersectImproved <$> arbitrary
+                                  <*> arbitrary)
 
     , AnyMessageAndAgency (ServerAgency TokIntersect) . MsgIntersectUnchanged
-        <$> (getArbitraryPoint <$> arbitrary)
+        <$> arbitrary
 
     , return $ AnyMessageAndAgency (ClientAgency TokIdle) MsgDone
     ]

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -43,8 +43,8 @@ module Ouroboros.Network.Testing.ConcreteBlock (
   , fixupBlockHeader
   , fixupBlockHeader'
   , fixupChain
-  , fixupChainFragment
-  , fixupAnchoredFragment
+  , fixupChainFragmentFromGenesis
+  , fixupAnchoredFragmentFrom
   ) where
 
 import           Data.FingerTree (Measured(measure))
@@ -210,7 +210,7 @@ mkChainSimple = mkChain . zip [1..]
 -- @BlockNo 0@ and @GenesisHash@ in @prevHeaderHash@.
 mkChainFragment :: [(SlotNo, BlockBody)] -> ChainFragment Block
 mkChainFragment =
-    fixupChainFragment fixupBlock
+    fixupChainFragmentFromGenesis fixupBlock
   . map (uncurry mkPartialBlock)
   . reverse
 
@@ -222,7 +222,7 @@ mkAnchoredFragment :: Point Block
                    -> [(SlotNo, BlockBody)]
                    -> AnchoredFragment Block
 mkAnchoredFragment anchor =
-    fixupAnchoredFragment anchor fixupBlock
+    fixupAnchoredFragmentFrom anchor fixupBlock
   . map (uncurry mkPartialBlock)
   . reverse
 
@@ -332,18 +332,18 @@ fixupChain :: (Maybe b -> b -> b)
            -> [b] -> Chain b
 fixupChain = fixupBlocks (C.:>) C.Genesis
 
-fixupChainFragment :: HasHeader b
-                   => (Maybe b -> b -> b)
-                   -> [b] -> ChainFragment b
-fixupChainFragment =
+fixupChainFragmentFromGenesis :: HasHeader b
+                              => (Maybe b -> b -> b)
+                              -> [b] -> ChainFragment b
+fixupChainFragmentFromGenesis =
     fixupBlocks
       (CF.:>) CF.Empty
 
-fixupAnchoredFragment :: HasHeader b
-                      => Point b
-                      -> (Maybe b -> b -> b)
-                      -> [b] -> AnchoredFragment b
-fixupAnchoredFragment anchor =
+fixupAnchoredFragmentFrom :: HasHeader b
+                          => Point b
+                          -> (Maybe b -> b -> b)
+                          -> [b] -> AnchoredFragment b
+fixupAnchoredFragmentFrom anchor =
     fixupBlocks
       (AF.:>) (AF.Empty anchor)
 

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -170,7 +170,10 @@ instance HasHeader BlockHeader where
 
     -- | The header invariant is that the cached header hash is correct.
     --
-    blockInvariant = \b -> hashHeader b == headerHash b
+    blockInvariant b =
+        hashHeader b == headerHash b
+     && blockNo    b >  BlockNo 0  -- we reserve 0 for genesis
+     && blockSlot  b >  SlotNo  0  -- we reserve 0 for genesis
 
 instance HasHeader Block where
     type HeaderHash Block = ConcreteHeaderHash
@@ -183,8 +186,9 @@ instance HasHeader Block where
     -- | The block invariant is just that the actual block body hash matches the
     -- body hash listed in the header.
     --
-    blockInvariant Block { blockBody, blockHeader = BlockHeader {headerBodyHash} } =
-        headerBodyHash == hashBody blockBody
+    blockInvariant Block { blockBody, blockHeader } =
+        blockInvariant blockHeader
+     && headerBodyHash blockHeader == hashBody blockBody
 
 {-------------------------------------------------------------------------------
   Constructing sample chains

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -42,9 +42,11 @@ module Ouroboros.Network.Testing.ConcreteBlock (
   , fixupBlockHeader
   , fixupBlockAfterBlock
   , fixupChain
+  , fixupChainFragmentFrom
   , fixupChainFragmentFromGenesis
   , fixupChainFragmentFromSame
   , fixupAnchoredFragmentFrom
+  , fixupAnchoredFragmentFromSame
   ) where
 
 import           Data.FingerTree (Measured(measure))
@@ -333,6 +335,18 @@ fixupChain =
       (Just GenesisHash)
       (Just (BlockNo 0))
 
+
+fixupChainFragmentFrom :: HasHeader b
+                       => ChainHash b
+                       -> BlockNo
+                       -> (ChainHash b -> BlockNo -> b -> b)
+                       -> [b] -> ChainFragment b
+fixupChainFragmentFrom prevhash prevblockno =
+    fixupBlocks
+      (CF.:>) CF.Empty
+      (Just prevhash)
+      (Just prevblockno)
+
 fixupChainFragmentFromGenesis :: HasHeader b
                               => (ChainHash b -> BlockNo -> b -> b)
                               -> [b] -> ChainFragment b
@@ -360,6 +374,16 @@ fixupAnchoredFragmentFrom anchor =
       (AF.:>) (AF.Empty anchor)
       (Just (pointHash anchor))
       (Just (BlockNo 0))
+
+fixupAnchoredFragmentFromSame :: HasHeader b
+                              => Point b
+                              -> (ChainHash b -> BlockNo -> b -> b)
+                              -> [b] -> AnchoredFragment b
+fixupAnchoredFragmentFromSame anchor =
+    fixupBlocks
+      (AF.:>) (AF.Empty anchor)
+      (Just (pointHash anchor))  -- fixup the hash
+      Nothing                    -- but keep the first block number
 
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -24,19 +24,27 @@ main = defaultMain tests
 tests :: TestTree
 tests =
   testGroup "ouroboros-network"
-  [ Test.AnchoredFragment.tests
-  , Test.ChainGenerators.tests
+
+    -- data structures
+  [ Test.ChainGenerators.tests
   , Test.Chain.tests
   , Test.ChainFragment.tests
+  , Test.AnchoredFragment.tests
   , Test.ChainProducerState.tests
-  , Test.Mux.tests
-  , Test.Pipe.tests
-  , Test.Socket.tests
-  , Test.Ouroboros.Network.Node.tests
-  , Test.Ouroboros.Network.BlockFetch.tests
+
+    -- protocols
   , Ouroboros.Network.Protocol.ChainSync.Test.tests
   , Ouroboros.Network.Protocol.BlockFetch.Test.tests
   , Ouroboros.Network.Protocol.PingPong.Test.tests
   , Ouroboros.Network.Protocol.ReqResp.Test.tests
   , Ouroboros.Network.Protocol.Handshake.Test.tests
+
+    -- network logic
+  , Test.Mux.tests
+  , Test.Pipe.tests
+  , Test.Socket.tests
+  , Test.Ouroboros.Network.BlockFetch.tests
+
+    -- pseudo system-level
+  , Test.Ouroboros.Network.Node.tests
   ]

--- a/ouroboros-network/test/Test/AnchoredFragment.hs
+++ b/ouroboros-network/test/Test/AnchoredFragment.hs
@@ -29,7 +29,7 @@ import           Test.ChainFragment (TestBlockChainFragment (..),
                      TestChainFragmentAndPoint (..),
                      TestChainFragmentFork (..))
 import qualified Test.ChainFragment as CF
-import           Test.ChainGenerators (TestBlockChain (..), genPoint)
+import           Test.ChainGenerators (TestBlockChain (..))
 
 
 --
@@ -413,7 +413,7 @@ instance Arbitrary TestAnchoredFragmentAndPoint where
       , (if AF.null chain then 0 else 7,
          blockPoint <$> elements (AF.toNewestFirst chain))
       -- A few points off the chain!
-      , (1, genPoint)
+      , (1, arbitrary)
       ]
     return (TestAnchoredFragmentAndPoint_ taf point)
 

--- a/ouroboros-network/test/Test/AnchoredFragment.hs
+++ b/ouroboros-network/test/Test/AnchoredFragment.hs
@@ -18,7 +18,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 import           Text.Show.Functions ()
 
 import           Ouroboros.Network.AnchoredFragment
-                     (AnchoredFragment ((:>), Empty))
+                     (AnchoredFragment(..))
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block
 import qualified Ouroboros.Network.Chain as Chain
@@ -367,11 +367,14 @@ instance Arbitrary TestAddBlock where
     ]
 
 prop_arbitrary_TestAddBlock :: TestAddBlock -> Bool
-prop_arbitrary_TestAddBlock (TestAddBlock c b) = AF.valid (c :> b)
+prop_arbitrary_TestAddBlock (TestAddBlock c b) =
+    AF.valid c && AF.validExtension c b
 
 prop_shrink_TestAddBlock :: TestAddBlock -> Bool
 prop_shrink_TestAddBlock t =
-    and [ AF.valid (c :> b) | TestAddBlock c b <- shrink t ]
+    and [ AF.valid c && AF.validExtension c b
+        | TestAddBlock c b <- shrink t ]
+
 
 --
 -- Generator for chain and single point on the chain

--- a/ouroboros-network/test/Test/ChainFragment.hs
+++ b/ouroboros-network/test/Test/ChainFragment.hs
@@ -372,7 +372,7 @@ prop_toChain_fromChain (TestBlockChain c) =
 
 prop_fixupBlock' :: TestBlockChainFragment -> Bool
 prop_fixupBlock' (TestBlockChainFragment chain) =
-  fixupChainFragment fixupBlock' (CF.toNewestFirst chain) == chain
+  fixupChainFragmentFromGenesis fixupBlock' (CF.toNewestFirst chain) == chain
 
 --
 -- Generators for chains
@@ -400,7 +400,7 @@ instance Arbitrary TestBlockChainFragment where
         mkSlots = map toEnum . tail . scanl (+) 0
 
     shrink (TestBlockChainFragment c) =
-        [ TestBlockChainFragment (fixupChainFragment fixupBlock c')
+        [ TestBlockChainFragment (fixupChainFragmentFromGenesis fixupBlock c')
         | c' <- shrinkList (const []) (CF.toNewestFirst c) ]
 
 instance Arbitrary TestHeaderChainFragment where
@@ -410,7 +410,7 @@ instance Arbitrary TestHeaderChainFragment where
         return (TestHeaderChainFragment headerchain)
 
     shrink (TestHeaderChainFragment c) =
-        [ TestHeaderChainFragment (fixupChainFragment fixupBlockHeader c')
+        [ TestHeaderChainFragment (fixupChainFragmentFromGenesis fixupBlockHeader c')
         | c' <- shrinkList (const []) (CF.toNewestFirst c) ]
 
 prop_arbitrary_TestBlockChainFragment :: TestBlockChainFragment -> Property
@@ -721,23 +721,23 @@ instance Arbitrary TestChainFragmentFork where
         ex1 = extensionFragment l1 c1
         ex2 = extensionFragment l2 c2 in
     [ TestChainFragmentFork
-        (fixupChainFragment fixupBlock longestPrefix')
-        (fixupChainFragment fixupBlock shortestPrefix')
-        (fixupChainFragment fixupBlock (ex1 ++ longestPrefix'))
-        (fixupChainFragment fixupBlock (ex2 ++ shortestPrefix'))
+        (fixupChainFragmentFromGenesis fixupBlock longestPrefix')
+        (fixupChainFragmentFromGenesis fixupBlock shortestPrefix')
+        (fixupChainFragmentFromGenesis fixupBlock (ex1 ++ longestPrefix'))
+        (fixupChainFragmentFromGenesis fixupBlock (ex2 ++ shortestPrefix'))
     | longestPrefix' <- shrinkList (const []) (CF.toNewestFirst longestPrefix)
     , let shortestPrefix' = reverse $ drop toDrop $ reverse longestPrefix'
     ]
    -- shrink the first fork
    ++ [ TestChainFragmentFork l1 l2 c1' c2
       | ex1' <- shrinkList (const []) ex1
-      , let c1' = fixupChainFragment fixupBlock' (ex1' ++ CF.toNewestFirst l1)
+      , let c1' = fixupChainFragmentFromGenesis fixupBlock' (ex1' ++ CF.toNewestFirst l1)
       , isLongestCommonPrefix c1' c2
       ]
    -- shrink the second fork
    ++ [ TestChainFragmentFork l1 l2 c1 c2'
       | ex2' <- shrinkList (const []) ex2
-      , let c2' = fixupChainFragment fixupBlock' (ex2' ++ CF.toNewestFirst l2)
+      , let c2' = fixupChainFragmentFromGenesis fixupBlock' (ex2' ++ CF.toNewestFirst l2)
       , isLongestCommonPrefix c1 c2'
       ]
     where

--- a/ouroboros-network/test/Test/ChainFragment.hs
+++ b/ouroboros-network/test/Test/ChainFragment.hs
@@ -29,7 +29,7 @@ import           Text.Show.Functions ()
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (ChainUpdate (..), Point (..))
 import qualified Ouroboros.Network.Chain as Chain
-import           Ouroboros.Network.ChainFragment (ChainFragment ((:>), Empty))
+import           Ouroboros.Network.ChainFragment (ChainFragment(..))
 import qualified Ouroboros.Network.ChainFragment as CF
 import           Ouroboros.Network.Testing.ConcreteBlock
 import           Ouroboros.Network.Testing.Serialise (prop_serialise)
@@ -480,11 +480,12 @@ genAddBlock chain = do
 
 prop_arbitrary_TestAddBlock :: TestAddBlock -> Bool
 prop_arbitrary_TestAddBlock (TestAddBlock c b) =
-    CF.valid (c :> b)
+    CF.valid c && CF.validExtension c b
 
 prop_shrink_TestAddBlock :: TestAddBlock -> Bool
 prop_shrink_TestAddBlock t =
-    and [ CF.valid (c :> b) | TestAddBlock c b <- shrink t ]
+    and [ CF.valid c && CF.validExtension c b
+        | TestAddBlock c b <- shrink t ]
 
 --
 -- Generator for chain updates

--- a/ouroboros-network/test/Test/ChainFragment.hs
+++ b/ouroboros-network/test/Test/ChainFragment.hs
@@ -34,9 +34,9 @@ import qualified Ouroboros.Network.ChainFragment as CF
 import           Ouroboros.Network.Testing.ConcreteBlock
 import           Ouroboros.Network.Testing.Serialise (prop_serialise)
 import           Test.Chain ()
-import           Test.ChainGenerators (ArbitraryBlockBody (..),
-                     TestBlockChain (..), TestChainAndRange (..), addSlotGap,
-                     genNonNegative, genPoint, genSlotGap, mkPartialBlock)
+import           Test.ChainGenerators
+                   ( TestBlockChain (..), TestChainAndRange (..)
+                   , addSlotGap, genNonNegative, genSlotGap, mkPartialBlock)
 
 
 --
@@ -430,7 +430,7 @@ prop_shrink_TestHeaderChainFragment c =
 
 genBlockChainFragment :: Int -> Gen (ChainFragment Block)
 genBlockChainFragment n = do
-    bodies <- map getArbitraryBlockBody <$> vector n
+    bodies <- vector n
     slots  <- mkSlots <$> vectorOf n genSlotGap
     return (mkChainFragment (zip slots bodies))
   where
@@ -471,7 +471,7 @@ genAddBlock :: (HasHeader block, HeaderHash block ~ ConcreteHeaderHash)
             => ChainFragment block -> Gen Block
 genAddBlock chain = do
     slotGap <- genSlotGap
-    body    <- getArbitraryBlockBody <$> arbitrary
+    body    <- arbitrary
     let pb = mkPartialBlock (addSlotGap slotGap
                                         (fromMaybe (SlotNo 0) $ CF.headSlot chain))
                                         body
@@ -604,13 +604,13 @@ instance Arbitrary TestChainFragmentAndPoint where
       [ (2, return (CF.headPoint chain))
       , (8, mkRollbackPoint chain <$> choose (1, len - 1))
       -- or a few off the chain!
-      , (1, Just <$> genPoint)
+      , (1, Just <$> arbitrary)
       ]
     -- If 'mbPoint' yielded Nothing, just generate one off the chain fragment,
     -- as the chain fragment is probably empty anyway.
     point <- case mbPoint of
                Just p  -> return p
-               Nothing -> genPoint
+               Nothing -> arbitrary
     return (TestChainFragmentAndPoint chain point)
 
   shrink (TestChainFragmentAndPoint c p)

--- a/ouroboros-network/test/Test/ChainFragment.hs
+++ b/ouroboros-network/test/Test/ChainFragment.hs
@@ -47,6 +47,10 @@ tests = testGroup "ChainFragment"
       -- It's important we don't generate too many trivial test cases here
       -- so check the coverage to enforce it.
       checkCoverage prop_arbitrary_TestBlockChainFragment
+
+      -- All our shrinkers rely on fixupBlock, so lets test that first
+    , testProperty "fixupBlock"                              prop_fixupBlock
+
     , testProperty "shrink for TestBlockChainFragment"       prop_shrink_TestBlockChainFragment
 
     , testProperty "arbitrary for TestHeaderChainFragment"   prop_arbitrary_TestHeaderChainFragment
@@ -103,7 +107,6 @@ tests = testGroup "ChainFragment"
   , testProperty "(:<)"                                      prop_prepend
   , testProperty "fromChain/toChain"                         prop_fromChain_toChain
   , testProperty "toChain/fromChain"                         prop_toChain_fromChain
-  , testProperty "fixupBlockPrim"                            prop_fixupBlock
   ]
 
 --

--- a/ouroboros-network/test/Test/ChainGenerators.hs
+++ b/ouroboros-network/test/Test/ChainGenerators.hs
@@ -397,7 +397,7 @@ instance Arbitrary TestChainAndPoint where
     return (TestChainAndPoint chain point)
 
   shrink (TestChainAndPoint c p) =
-    [ TestChainAndPoint c' (fixupPoint c' p)
+    [ TestChainAndPoint c' (if p `Chain.pointOnChain` c then fixupPoint c' p else p)
     | TestBlockChain c' <- shrink (TestBlockChain c) ]
 
 genPointOnChain :: HasHeader block => Chain block -> Gen (Point block)
@@ -455,7 +455,10 @@ instance Arbitrary TestChainAndRange where
     return (TestChainAndRange chain point1 point2)
 
   shrink (TestChainAndRange c p1 p2) =
-    [ TestChainAndRange c' (fixupPoint c' p1) (fixupPoint c' p2)
+    [ TestChainAndRange
+        c'
+        (if p1 `Chain.pointOnChain` c then fixupPoint c' p1 else p1)
+        (if p2 `Chain.pointOnChain` c then fixupPoint c' p2 else p2)
     | TestBlockChain c' <- shrink (TestBlockChain c) ]
 
 genRangeOnChain :: HasHeader block

--- a/ouroboros-network/test/Test/ChainGenerators.hs
+++ b/ouroboros-network/test/Test/ChainGenerators.hs
@@ -211,7 +211,8 @@ instance Arbitrary TestAddBlock where
   shrink (TestAddBlock c b) =
     [ TestAddBlock c' b'
     | TestBlockChain c' <- shrink (TestBlockChain c)
-    , let b' = fixupBlock (Chain.head c') b
+    , let b' = fixupBlock (Chain.headHash c')
+                          (Chain.headBlockNo c') b
     ]
 
 genAddBlock :: (HasHeader block, HeaderHash block ~ ConcreteHeaderHash)
@@ -220,7 +221,8 @@ genAddBlock chain = do
     slotGap <- genSlotGap
     body    <- arbitrary
     let pb = mkPartialBlock (addSlotGap slotGap (Chain.headSlot chain)) body
-        b  = fixupBlock (Chain.head chain) pb
+        b  = fixupBlock (Chain.headHash chain)
+                        (Chain.headBlockNo chain) pb
     return b
 
 prop_arbitrary_TestAddBlock :: TestAddBlock -> Bool


### PR DESCRIPTION
A series of (hopefully-comprehensible) patches to improve the range of values the chain generators make, and to make the construction and generation code more comprehensible.

This should be ok to apply as is, so it doesn't bit-rot, but there's a couple follow-ups I'd like to add:

* [ ]  Improved docs for the construction and fixup functions
* [ ]  Also overhaul the `AnchoredFragment` generators so that they are more direct and less confusing. Perhaps the unachored fragment generators could be done in terms of the anchored ones, rather than the other way around.