### PR TITLE
support O_EXCL flag

### DIFF
--- a/ouroboros-consensus/src-win32/Ouroboros/Storage/IO.hs
+++ b/ouroboros-consensus/src-win32/Ouroboros/Storage/IO.hs
@@ -17,7 +17,7 @@ import           Data.ByteString
 import           Data.ByteString.Internal as Internal
 import           Data.Word (Word32, Word64, Word8)
 import           Foreign (Int64, Ptr)
-import           System.Win32
+import           System.Win32 hiding (setFilePointerEx)
 
 import           Ouroboros.Storage.FS.API.Types (AllowExisting (..),
                      OpenMode (..), SeekMode (..))

--- a/ouroboros-consensus/src-win32/Ouroboros/Storage/Seek.hsc
+++ b/ouroboros-consensus/src-win32/Ouroboros/Storage/Seek.hsc
@@ -9,7 +9,7 @@ module Ouroboros.Storage.Seek where
 #include <windows.h>
 
 import           System.Win32.Types
-import           System.Win32.File
+import           System.Win32.File (FilePtrDirection)
 import           Foreign (Ptr, alloca, peek)
 
 setFilePointerEx :: HANDLE -> LARGE_INTEGER -> FilePtrDirection -> IO LARGE_INTEGER

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
@@ -1,7 +1,7 @@
+{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE BangPatterns        #-}
 
 module Ouroboros.Consensus.Util.CBOR (
     -- * Incremental parsing in I/O
@@ -31,7 +31,6 @@ import           Data.ByteString.Builder.Extra (defaultChunkSize)
 import qualified Data.ByteString.Lazy as BSL
 import           Data.IORef
 import           Data.Word (Word64)
-import           System.IO (IOMode (..))
 
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -19,11 +19,13 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word
 import           Numeric.Natural
-import qualified System.IO as IO
 import           Text.Printf (printf)
 
 import           Ouroboros.Consensus.Util.HList (All, HList (..))
 import qualified Ouroboros.Consensus.Util.HList as HList
+
+import           Ouroboros.Storage.FS.API.Types (AllowExisting (..),
+                     OpenMode (..), SeekMode (..))
 
 -- | Condensed but human-readable output
 class Condense a where
@@ -93,16 +95,21 @@ instance (Condense a, Condense b, Condense c, Condense d, Condense e) => Condens
 instance (Condense k, Condense a) => Condense (Map k a) where
   condense = condense . Map.toList
 
-instance Condense IO.SeekMode where
-  condense IO.RelativeSeek = "r"
-  condense IO.AbsoluteSeek = "a"
-  condense IO.SeekFromEnd  = "e"
+instance Condense SeekMode where
+  condense RelativeSeek = "r"
+  condense AbsoluteSeek = "a"
+  condense SeekFromEnd  = "e"
 
-instance Condense IO.IOMode where
-  condense IO.ReadMode      = "r"
-  condense IO.WriteMode     = "w"
-  condense IO.ReadWriteMode = "rw"
-  condense IO.AppendMode    = "a"
+instance Condense AllowExisting where
+  condense AllowExisting = ""
+  condense MustBeNew     = "!"
+
+instance Condense OpenMode where
+    condense ReadMode           = "r"
+    condense (WriteMode     ex) = "w"  ++ condense ex
+    condense (ReadWriteMode ex) = "rw" ++ condense ex
+    condense (AppendMode    ex) = "a"  ++ condense ex
+
 
 instance Condense BS.Strict.ByteString where
   condense bs = show bs ++ "<" ++ show (BS.Strict.length bs) ++ "b>"

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
@@ -23,7 +23,6 @@ import           Data.Int (Int64)
 import           Data.Set (Set)
 import           Data.Word (Word64)
 import           GHC.Stack
-import           System.IO (IOMode, SeekMode)
 
 import           Control.Monad.Class.MonadThrow
 
@@ -42,7 +41,7 @@ data HasFS m h = HasFS {
     -- Operations of files
 
     -- | Open a file
-  , hOpen                    :: HasCallStack => FsPath -> IOMode -> m h
+  , hOpen                    :: HasCallStack => FsPath -> OpenMode -> m h
 
     -- | Close a file
   , hClose                   :: HasCallStack => h -> m ()
@@ -123,8 +122,8 @@ data HasFS m h = HasFS {
   }
 
 withFile :: (HasCallStack, MonadThrow m)
-         => HasFS m h -> FsPath -> IOMode -> (h -> m a) -> m a
-withFile HasFS{..} fp ioMode = bracket (hOpen fp ioMode) hClose
+         => HasFS m h -> FsPath -> OpenMode -> (h -> m a) -> m a
+withFile HasFS{..} fp openMode = bracket (hOpen fp openMode) hClose
 
 -- | Makes sure it reads all requested bytes.
 -- If eof is found before all bytes are read, it throws an exception.

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/API/Example.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/API/Example.hs
@@ -10,7 +10,6 @@ import           Control.Exception (try)
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.Set as Set
 import           GHC.Stack
-import qualified System.IO as IO
 
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Storage.FS.API
@@ -25,14 +24,14 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 
 example :: (HasCallStack, Monad m) => HasFS m h -> m [ByteString]
 example hasFS@HasFS{..} = do
-    h1 <- hOpen ["cardano.txt"] IO.ReadWriteMode
+    h1 <- hOpen ["cardano.txt"] (ReadWriteMode MustBeNew)
     _  <- hPut hasFS h1 "test"
-    _  <- hSeek h1 IO.AbsoluteSeek 0
+    _  <- hSeek h1 AbsoluteSeek 0
     r1 <- hGetExactly hasFS h1 4
     _  <- hPut hasFS h1 "ing"
-    h2 <- hOpen ["bar.txt"] IO.ReadWriteMode
+    h2 <- hOpen ["bar.txt"] (ReadWriteMode MustBeNew)
     _  <- hPut hasFS h2 "blockchain"
-    _  <- hSeek h2 IO.AbsoluteSeek 0
+    _  <- hSeek h2 AbsoluteSeek 0
     r2 <- hGetExactly hasFS h2 5
     _  <- listDirectory []
     _  <- listDirectory ["var"]

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/API/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/API/Types.hs
@@ -1,8 +1,13 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Ouroboros.Storage.FS.API.Types (
+    -- * Modes
+    OpenMode(..)
+  , AllowExisting(..)
+  , allowExisting
+  , SeekMode(..)
     -- * Paths
-    FsPath
+  , FsPath
   , MountPoint(..)
   , fsToFilePath
   , fsFromFilePath
@@ -22,7 +27,38 @@ import           Data.List (stripPrefix)
 import qualified GHC.IO.Exception as GHC
 import           GHC.Stack
 import           System.FilePath
+import           System.IO (SeekMode (..))
 import qualified System.IO.Error as IO
+
+
+{-------------------------------------------------------------------------------
+  Modes
+-------------------------------------------------------------------------------}
+
+-- | How to 'hOpen' a new file.
+data OpenMode
+  = ReadMode
+  | WriteMode     AllowExisting
+  | AppendMode    AllowExisting
+  | ReadWriteMode AllowExisting
+  deriving (Eq, Show)
+
+-- | When 'hOpen'ing a file:
+data AllowExisting
+  = AllowExisting
+    -- ^ The file may already exist. If it does, it is reopened. If it
+    -- doesn't, it is created.
+  | MustBeNew
+    -- ^ The file may not yet exist. If it does, an error
+    -- ('FsResourceAlreadyExist') is thrown.
+  deriving (Eq, Show)
+
+allowExisting :: OpenMode -> AllowExisting
+allowExisting openMode = case openMode of
+  ReadMode         -> AllowExisting
+  WriteMode     ex -> ex
+  AppendMode    ex -> ex
+  ReadWriteMode ex -> ex
 
 {-------------------------------------------------------------------------------
   Paths

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
@@ -33,10 +33,10 @@ ioHasFS mount = HasFS {
       -- TODO(adn) Might be useful to implement this properly by reading all
       -- the stuff available at the 'MountPoint'.
       dumpState = return "<dumpState@IO>"
-    , hOpen = \fp ioMode -> do
+    , hOpen = \fp openMode -> do
         let path = root fp
         osHandle <- rethrowFsError fp $
-            F.open path ioMode
+            F.open path openMode
         hVar <- newMVar $ Just osHandle
         return $ H.Handle fp path hVar
     , hClose = \h -> rethrowFsError (H.handlePath h) $

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -165,8 +165,6 @@ import           Data.Word
 
 import           GHC.Stack (HasCallStack, callStack)
 
-import           System.IO (IOMode (..), SeekMode (..))
-
 import           Ouroboros.Consensus.Util (SomePair (..))
 
 import           Ouroboros.Storage.Common
@@ -441,7 +439,7 @@ deleteAfterImpl dbEnv tip = modifyOpenState dbEnv $ \hasFS@HasFS{..} -> do
         go epoch index
           | Just relSlot <- lastFilledSlot index = do
             let truncatedIndex = truncateIndex relSlot index
-            withFile hasFS (renderFile "epoch" epoch) AppendMode $ \eHnd ->
+            withFile hasFS (renderFile "epoch" epoch) (AppendMode AllowExisting) $ \eHnd ->
               hTruncate eHnd (lastSlotOffset truncatedIndex)
             removeIndex epoch
             removeFilesStartingFrom hasFS (succ epoch)
@@ -1244,7 +1242,7 @@ mkOpenState HasFS{..} epoch epochInfo nextIteratorID tip index = do
     let epochFile     = renderFile "epoch" epoch
         epochOffsets  = indexToSlotOffsets index
 
-    eHnd <- hOpen epochFile AppendMode
+    eHnd <- hOpen epochFile (AppendMode AllowExisting)
 
     return OpenState
       { _currentEpoch            = epoch
@@ -1258,7 +1256,7 @@ mkOpenState HasFS{..} epoch epochInfo nextIteratorID tip index = do
 
 -- | Create the internal open state for a new empty epoch.
 --
--- Open the epoch file for appending.
+-- Create the epoch file for appending.
 mkOpenStateNewEpoch :: (HasCallStack, MonadThrow m)
                     => HasFS m h
                     -> EpochNo
@@ -1270,8 +1268,7 @@ mkOpenStateNewEpoch HasFS{..} epoch epochInfo nextIteratorID tip = do
     let epochFile    = renderFile "epoch" epoch
         epochOffsets = 0 NE.:| []
 
-    eHnd <- hOpen epochFile AppendMode
-    -- TODO Use new O_EXCL create when we expect it to be empty, see #292
+    eHnd <- hOpen epochFile (AppendMode MustBeNew)
 
     return OpenState
       { _currentEpoch            = epoch
@@ -1716,7 +1713,7 @@ validate hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFileP
           case mbErr of
             -- If there was an error parsing the epoch file, truncate it
             Just _ ->
-              withFile hasFS epochFile AppendMode $ \eHnd ->
+              withFile hasFS epochFile (AppendMode AllowExisting) $ \eHnd ->
                 hTruncate eHnd (lastSlotOffset reconstructedIndex)
             -- If not, check that the last offset matches the epoch file size.
             -- If it does not, it means the 'EpochFileParser' is incorrect. We

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -1627,7 +1627,10 @@ validate hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFileP
               removeFilesStartingFrom hasFS (succ epoch)
               continueIfPossible Nothing
             Incomplete index -> do
-              removeFilesStartingFrom hasFS (succ epoch)
+              case firstFilledSlot index of
+                -- If the index is empty, remove the index and epoch file too
+                Nothing -> removeFilesStartingFrom hasFS epoch
+                Just _  -> removeFilesStartingFrom hasFS (succ epoch)
               let lastValid' = lastFilledSlot index <&> \lastRelativeSlot ->
                     (EpochSlot epoch lastRelativeSlot, index)
               continueIfPossible lastValid'

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
@@ -49,9 +49,9 @@ import           Data.Word (Word64)
 
 import           GHC.Stack (HasCallStack, callStack)
 
-import           System.IO (IOMode (..))
-
 import           Ouroboros.Storage.FS.API (HasFS (..), hPut, hPutAll, withFile)
+import           Ouroboros.Storage.FS.API.Types (AllowExisting (..),
+                     OpenMode (..))
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.Util (decodeIndexEntryAt, encodeIndexEntry)
@@ -143,7 +143,7 @@ writeIndex :: (MonadThrow m)
            -> m ()
 writeIndex hashEncoder hasFS@HasFS{..} epoch (MkIndex offsets ebbHash) = do
     let indexFile = renderFile "index" epoch
-    withFile hasFS indexFile AppendMode $ \iHnd -> do
+    withFile hasFS indexFile (AppendMode AllowExisting) $ \iHnd -> do
       -- NOTE: open it in AppendMode and truncate it first, otherwise we might
       -- just overwrite part of the data stored in the index file.
       void $ hTruncate iHnd 0
@@ -162,7 +162,7 @@ writeSlotOffsets :: (MonadThrow m)
                  -> m ()
 writeSlotOffsets hashEncoder hasFS@HasFS{..} epoch sos ebbHash = do
     let indexFile = renderFile "index" epoch
-    withFile hasFS indexFile AppendMode $ \iHnd -> do
+    withFile hasFS indexFile (AppendMode AllowExisting) $ \iHnd -> do
       -- NOTE: open it in AppendMode and truncate it first, otherwise we might
       -- just overwrite part of the data stored in the index file.
       void $ hTruncate iHnd 0

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -35,7 +35,6 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           GHC.Generics (Generic)
 import           GHC.Stack
-import           System.IO (IOMode (..))
 import           Text.Read (readMaybe)
 
 import           Control.Monad.Class.MonadST
@@ -301,7 +300,7 @@ writeSnapshot :: forall m l r h. MonadThrow m
               -> (r -> Encoding)
               -> DiskSnapshot -> ChainSummary l r -> m ()
 writeSnapshot hasFS@HasFS{..} encLedger encRef ss cs = do
-    withFile hasFS (snapshotToPath ss) WriteMode $ \h ->
+    withFile hasFS (snapshotToPath ss) (WriteMode MustBeNew) $ \h ->
       void $ hPut hasFS h $ CBOR.toBuilder (encode cs)
   where
     encode :: ChainSummary l r -> Encoding

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS.hs
@@ -5,9 +5,6 @@ module Test.Ouroboros.Storage.FS
   ( tests
   ) where
 
-
-import qualified System.IO as IO
-
 import qualified Test.Ouroboros.Storage.FS.StateMachine as StateMachine
 import           Test.Ouroboros.Storage.Util
 import           Test.Tasty (TestTree, testGroup)
@@ -32,13 +29,13 @@ tests tmpDir = testGroup "HasFS"
 
 test_hOpenWriteInvalid :: Assertion
 test_hOpenWriteInvalid = apiEquivalenceFs (expectFsError FsInvalidArgument) $ \hasFS@HasFS{..} _err -> do
-    _  <- hOpen ["foo.txt"] IO.WriteMode
-    h2 <- hOpen ["foo.txt"] IO.ReadMode
+    _  <- hOpen ["foo.txt"] (WriteMode MustBeNew)
+    h2 <- hOpen ["foo.txt"] ReadMode
     hPut hasFS h2 "haskell-is-nice"
 
 test_example :: Assertion
 test_example = apiEquivalenceFs (expectFsResult (@?= ["test", "block"])) $ \hasFS@HasFS{..} _err -> do
     -- The example assumes the presence of some files and dirs.
     createDirectoryIfMissing True ["var", "tmp"]
-    withFile hasFS ["var", "tmp", "foo.txt"] IO.WriteMode $ \_ -> return ()
+    withFile hasFS ["var", "tmp", "foo.txt"] (WriteMode MustBeNew) $ \_ -> return ()
     FS.API.Example.example hasFS

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -21,8 +21,6 @@ import qualified Data.List.NonEmpty as NE
 import           Data.Maybe (isJust, isNothing, maybeToList)
 import           Data.Word (Word64)
 
-import qualified System.IO as IO
-
 import qualified Test.Ouroboros.Storage.ImmutableDB.CumulEpochSizes as CumulEpochSizes
 import qualified Test.Ouroboros.Storage.ImmutableDB.StateMachine as StateMachine
 import           Test.Ouroboros.Storage.ImmutableDB.TestBlock hiding (tests)
@@ -133,8 +131,8 @@ test_openDBEmptyIndexFileEquivalence :: Assertion
 test_openDBEmptyIndexFileEquivalence =
     apiEquivalenceImmDB (expectImmDBResult (@?= TipGen)) $ \hasFS@HasFS{..} err -> do
       -- Create an empty index file
-      h1 <- hOpen ["epoch-000.dat"] IO.WriteMode
-      h2 <- hOpen ["index-000.dat"] IO.WriteMode
+      h1 <- hOpen ["epoch-000.dat"] (WriteMode MustBeNew)
+      h2 <- hOpen ["index-000.dat"] (WriteMode MustBeNew)
       hClose h1
       hClose h2
 
@@ -348,7 +346,7 @@ test_cborEpochFileParser = forM_ ["junk", ""] $ \junk -> runFS $ \hasFS -> do
     -- Test once with junk at the end and once without
     let HasFS{..} = hasFS
 
-    withFile hasFS fp IO.AppendMode $ \h -> do
+    withFile hasFS fp (AppendMode MustBeNew) $ \h -> do
       forM_ blocks $ \block ->
         hPut hasFS h (S.serialiseIncremental block)
       void $ hPut hasFS h (BS.string8 junk)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
@@ -39,8 +39,6 @@ import           Data.Word (Word64)
 
 import           GHC.Generics (Generic)
 
-import           System.IO (IOMode (..))
-
 import           Test.QuickCheck
 import qualified Test.QuickCheck.Monadic as QCM
 import qualified Test.StateMachine.Utils as QSM
@@ -49,7 +47,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API (HasFS (..), hPut, withFile)
-import           Ouroboros.Storage.FS.API.Types (FsPath)
+import           Ouroboros.Storage.FS.API.Types
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import           Ouroboros.Storage.FS.Sim.STM (runSimFS)
 import           Ouroboros.Storage.ImmutableDB.Types
@@ -222,7 +220,8 @@ prop_testBlockEpochFileParser (TestBlocks mbEBB regularBlocks) = QCM.monadicIO $
     writeBlocks :: HasFS IO Mock.Handle -> IO ()
     writeBlocks hasFS@HasFS{..} = do
       let bld = foldMap testBlockToBuilder blocks
-      withFile hasFS file AppendMode $ \eHnd -> void $ hPut hasFS eHnd bld
+      withFile hasFS file (AppendMode MustBeNew) $ \eHnd ->
+        void $ hPut hasFS eHnd bld
 
     readBlocks :: HasFS IO Mock.Handle
                -> IO ([(SlotOffset, TestBlock)], Maybe TestBlock, Maybe String)
@@ -279,7 +278,8 @@ prop_testBlockCborEpochFileParser (TestBlocks mbEBB regularBlocks) = QCM.monadic
     writeBlocks :: HasFS IO Mock.Handle -> IO ()
     writeBlocks hasFS@HasFS{..} = do
       let bld = foldMap serialiseIncremental blocks
-      withFile hasFS file AppendMode $ \eHnd -> void $ hPut hasFS eHnd bld
+      withFile hasFS file (AppendMode MustBeNew) $ \eHnd ->
+        void $ hPut hasFS eHnd bld
 
     readBlocks :: HasFS IO Mock.Handle
                -> IO ( [(SlotOffset, (Word64, TestBlock))]
@@ -315,7 +315,7 @@ data FileCorruption
 corruptFile :: MonadThrow m => HasFS m h -> FileCorruption -> FsPath -> m Bool
 corruptFile hasFS@HasFS{..} fc file = case fc of
     DeleteFile              -> removeFile file $> True
-    DropLastBytes n         -> withFile hasFS file AppendMode $ \hnd -> do
+    DropLastBytes n         -> withFile hasFS file (AppendMode AllowExisting) $ \hnd -> do
       fileSize <- hGetSize hnd
       let newFileSize = if n >= fileSize then 0 else fileSize - n
       hTruncate hnd newFileSize

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -47,7 +47,6 @@ import           Data.TreeDiff (ToExpr (..))
 import           Data.Typeable (Typeable)
 import           Data.Word
 import           GHC.Generics (Generic)
-import           System.IO (IOMode (..))
 import           System.Random (getStdRandom, randomR)
 
 import           Control.Monad.Class.MonadST
@@ -70,6 +69,7 @@ import qualified Ouroboros.Consensus.Util.Classify as C
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API
+import           Ouroboros.Storage.FS.API.Types
 import qualified Ouroboros.Storage.FS.Sim.MockFS as MockFS
 import           Ouroboros.Storage.FS.Sim.STM
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
@@ -690,7 +690,7 @@ runDB standalone@DB{..} cmd =
 
     truncateSnapshot :: HasFS m fh -> DiskSnapshot -> m ()
     truncateSnapshot hasFS@HasFS{..} ss =
-        withFile hasFS (snapshotToPath ss) AppendMode $ \h ->
+        withFile hasFS (snapshotToPath ss) (AppendMode AllowExisting) $ \h ->
           hTruncate h 0
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -40,7 +40,6 @@ import qualified Data.Set as S
 import           Data.TreeDiff (ToExpr)
 import           GHC.Generics
 import           GHC.Stack
-import qualified System.IO as IO
 import           System.Random (getStdRandom, randomR)
 import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
@@ -56,7 +55,7 @@ import           Text.Show.Pretty (ppShow)
 import           Ouroboros.Consensus.Util (SomePair (..))
 import qualified Ouroboros.Consensus.Util.Classify as C
 import           Ouroboros.Storage.FS.API
-import           Ouroboros.Storage.FS.API (HasFS (..))
+import           Ouroboros.Storage.FS.API.Types
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import           Ouroboros.Storage.VolatileDB.API
@@ -489,7 +488,7 @@ semanticsRestCmd hasFS env db cmd = case cmd of
         return $ Unit ()
     CreateInvalidFile -> do
         closeDB db
-        withFile hasFS ["invalidFileName.dat"] IO.AppendMode $ \_hndl -> do
+        withFile hasFS ["invalidFileName.dat"] (AppendMode MustBeNew) $ \_hndl -> do
             return ()
         reOpenDB db
         return $ Unit ()


### PR DESCRIPTION
Issue https://github.com/input-output-hk/ouroboros-network/issues/292

- gives the option to open with O_EXCL flag for unix and CREATE_NEW for windows
- with these flags, open creates a new file or fails if it exists.
- q-s-m tests and MockFS extended.
- related tags provided (which are checked to occur)
- Enabling this flag on ReadMode throws a user exception. Unix manual state that 
```In general, the behavior of O_EXCL is undefined if it is used without O_CREAT.```