### PR TITLE
Demonstration of Trace usage

### DIFF
--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -69,7 +69,6 @@
             (hsPkgs.tasty-quickcheck)
             (hsPkgs.text)
             (hsPkgs.time)
-            (hsPkgs.unordered-containers)
             ];
           };
         "cddl" = {

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -44,8 +44,10 @@
             (hsPkgs.typed-protocols)
             (hsPkgs.io-sim-classes)
             (hsPkgs.io-sim)
+            (hsPkgs.iohk-monitoring)
             (hsPkgs.ouroboros-network-testing)
             (hsPkgs.contra-tracer)
+            (hsPkgs.aeson)
             (hsPkgs.array)
             (hsPkgs.async)
             (hsPkgs.binary)
@@ -67,6 +69,7 @@
             (hsPkgs.tasty-quickcheck)
             (hsPkgs.text)
             (hsPkgs.time)
+            (hsPkgs.unordered-containers)
             ];
           };
         "cddl" = {

--- a/ouroboros-network/cfg/test-logging.yaml
+++ b/ouroboros-network/cfg/test-logging.yaml
@@ -1,0 +1,40 @@
+# global filter; messages must have at least this severity to pass:
+minSeverity: Debug
+
+# these backends are initialized:
+setupBackends:
+  - KatipBK
+
+# if not indicated otherwise, then messages are passed to these backends:
+defaultBackends:
+  - KatipBK
+
+# if wanted, the GUI is listening on this port:
+# hasGUI: 18321
+
+# if wanted, the EKG interface is listening on this port:
+# hasEKG: 12789
+
+# if wanted, the Prometheus interface is using this port:
+# hasPrometheus: 12799
+
+# here we set up outputs of logging in 'katip':
+setupScribes:
+  - scKind: StdoutSK
+    scFormat: ScJson
+    scName: stdout
+
+# if not indicated otherwise, then log output is directed to this:
+defaultScribes:
+  - - StdoutSK
+    - stdout
+
+# more options which can be passed as key-value pairs:
+options:
+  cfokey:
+    value: "blockFetch-0.0.0"
+  mapSubtrace:
+    '#messagecounters.switchboard':
+      subtrace: NoTrace
+    '#messagecounters.ekgview':
+      subtrace: NoTrace

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -226,8 +226,7 @@ test-suite tests
                        tasty,
                        tasty-quickcheck,
                        text,
-                       time,
-                       unordered-containers
+                       time
 
 
   ghc-options:         -Wall

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -190,6 +190,7 @@ test-suite tests
                        Test.ChainProducerState
                        Test.Ouroboros.Network.Testing.Utils
                        Test.Ouroboros.Network.BlockFetch
+                       Test.Ouroboros.Network.BlockFetch.Orphans
                        Test.Ouroboros.Network.Node
                        Test.Mux
                        Test.Mux.ReqResp
@@ -200,9 +201,11 @@ test-suite tests
                        typed-protocols,
                        io-sim-classes,
                        io-sim            >=0.1 && < 0.2,
+                       iohk-monitoring,
                        ouroboros-network-testing,
                        contra-tracer,
 
+                       aeson,
                        array,
                        async,
                        binary,
@@ -223,7 +226,9 @@ test-suite tests
                        tasty,
                        tasty-quickcheck,
                        text,
-                       time
+                       time,
+                       unordered-containers
+
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors

--- a/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
@@ -5,8 +5,7 @@
 
 module Ouroboros.Network.ChainFragment (
   -- * ChainFragment type and fundamental operations
-  ChainFragment(Empty, (:>), (:<)),
-  ChainFragment(..),
+  ChainFragment(.., Empty, (:>), (:<)),
   valid,
   validExtension,
   isValidSuccessorOf,

--- a/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
@@ -6,6 +6,7 @@
 module Ouroboros.Network.ChainFragment (
   -- * ChainFragment type and fundamental operations
   ChainFragment(Empty, (:>), (:<)),
+  ChainFragment(..),
   valid,
   validExtension,
   isValidSuccessorOf,

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -117,7 +117,7 @@ prop_blockFetchStaticNoOverlap (TestChainFork common fork1 fork2) =
 blockFetchStaticNoOverlapIO :: TestChainFork -> Property
 blockFetchStaticNoOverlapIO (TestChainFork common fork1 fork2) =
     ioProperty $ do
-        let configFile = "ouroboros-network/cfg/test-logging.yaml"
+        let configFile = "cfg/test-logging.yaml"
         trace :: Tracer IO (LogObject Example1TraceEvent)
             <- setupTrace (Left configFile) $ pack "block-fetch"
         -- add names to the three tracers

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch/Orphans.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch/Orphans.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE UndecidableInstances  #-}
+{-# OPTIONS_GHC -fno-warn-orphans  #-}
+
+module Test.Ouroboros.Network.BlockFetch.Orphans () where
+
+import           GHC.Generics (Generic)
+import           Data.Aeson
+import           Data.FingerTree
+
+import           Ouroboros.Network.Block
+import           Ouroboros.Network.BlockFetch
+import           Ouroboros.Network.BlockFetch.ClientState
+import           Ouroboros.Network.BlockFetch.Decision (FetchDecline (..), FetchMode (..))
+import           Ouroboros.Network.BlockFetch.DeltaQ
+import           Ouroboros.Network.ChainFragment
+import           Ouroboros.Network.Protocol.BlockFetch.Type
+import           Ouroboros.Network.Testing.ConcreteBlock
+import           Network.TypedProtocol.Codec
+import           Network.TypedProtocol.Driver
+
+deriving instance ToJSON ConcreteHeaderHash
+deriving instance ToJSON (ChainHash BlockHeader)
+
+deriving instance ToJSON SlotNo
+
+deriving instance Generic (Point BlockHeader)
+deriving instance ToJSON (Point BlockHeader)
+
+
+deriving instance Generic FetchMode
+deriving instance ToJSON FetchMode
+deriving instance Generic FetchDecline
+deriving instance ToJSON FetchDecline
+
+
+deriving instance Generic (TraceLabelPeer Int (FetchDecision [Point BlockHeader]))
+deriving instance ToJSON (TraceLabelPeer Int (FetchDecision [Point BlockHeader]))
+
+
+
+instance ToJSON (FingerTree BlockMeasure BlockHeader) where
+    toJSON _ = Null -- maybe as a list
+deriving instance Generic (ChainFragment BlockHeader)
+deriving instance ToJSON (ChainFragment BlockHeader)
+deriving instance Generic (FetchRequest BlockHeader)
+deriving instance ToJSON (FetchRequest BlockHeader)
+
+deriving instance Generic (PeerFetchInFlight BlockHeader)
+deriving instance ToJSON (PeerFetchInFlight BlockHeader)
+
+deriving instance Generic (PeerFetchStatus BlockHeader)
+deriving instance ToJSON (PeerFetchStatus BlockHeader)
+
+deriving instance Generic PeerFetchInFlightLimits
+deriving instance ToJSON PeerFetchInFlightLimits
+
+deriving instance Generic (TraceFetchClientState BlockHeader)
+deriving instance ToJSON (TraceFetchClientState BlockHeader)
+
+deriving instance Generic (TraceLabelPeer Int (TraceFetchClientState BlockHeader))
+deriving instance ToJSON (TraceLabelPeer Int (TraceFetchClientState BlockHeader))
+
+
+
+instance ToJSON (Message (BlockFetch BlockHeader Block) st st') where
+    toJSON (MsgRequestRange _range) = String "MsgRequestRange" -- ++ toJSON range
+    toJSON MsgStartBatch           = String "MsgStartBatch"
+    toJSON (MsgBlock _block)        = String "MsgBlock " -- ++ toJSON block
+    toJSON MsgNoBlocks             = String "MsgNoBlocks"
+    toJSON MsgBatchDone            = String "MsgBatchDone"
+    toJSON MsgClientDone           = String "MsgClientDone"
+
+instance (forall st st'. ToJSON (Message ps st st')) => ToJSON (AnyMessage ps) where
+    toJSON (AnyMessage msg) = toJSON msg
+
+deriving instance Generic (TraceSendRecv (BlockFetch BlockHeader Block))
+deriving instance ToJSON (TraceSendRecv (BlockFetch BlockHeader Block))
+
+deriving instance Generic (TraceLabelPeer Int (TraceSendRecv (BlockFetch BlockHeader Block)))
+deriving instance ToJSON (TraceLabelPeer Int (TraceSendRecv (BlockFetch BlockHeader Block)))


### PR DESCRIPTION
It is not supposed to be merged.
It is just a demonstration of how we can use the `Trace` of `iohk-monitoring`.

Run the test with:
`cabal new-run pkg:ouroboros-network:tests -- -p '$3 == "static chains without overlap IO"'`
