### PR TITLE
Eliminate unnecessary type arguments for ChainSync and BlockFetch

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchClient.hs
@@ -31,7 +31,7 @@ import           Ouroboros.Consensus.Util.Condense
 -- so define it ourselves for now.
 type BlockFetchClient hdr blk m a =
   FetchClientStateVars m hdr ->
-  PeerPipelined (BlockFetch hdr blk) AsClient BFIdle m a
+  PeerPipelined (BlockFetch blk) AsClient BFIdle m a
 
 -- | Block fetch client based on
 -- 'Ouroboros.Network.BlockFetch.Examples.mockedBlockFetchClient1', but using

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -50,8 +50,8 @@ import           Ouroboros.Consensus.Util.Orphans ()
 newtype ClockSkew = ClockSkew { unClockSkew :: Word64 }
   deriving (Eq, Ord, Enum, Bounded, Show, Num)
 
-type Consensus (client :: * -> * -> (* -> *) -> * -> *) hdr m =
-   client hdr (Point hdr) m Void
+type Consensus (client :: * -> (* -> *) -> * -> *) hdr m =
+   client hdr m Void
 
 data ChainSyncClientException blk hdr =
       -- | The header we received was for a slot too far in the future.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
@@ -32,11 +32,11 @@ chainSyncServer
        (MonadSTM m, HeaderHash hdr ~ HeaderHash blk)
     => Tracer m String
     -> ChainDB m blk hdr
-    -> ChainSyncServer hdr (Point hdr) m ()
+    -> ChainSyncServer hdr m ()
 chainSyncServer _tracer chainDB = ChainSyncServer $
     idle <$> ChainDB.newReader chainDB
   where
-    idle :: Reader m hdr -> ServerStIdle hdr (Point hdr) m ()
+    idle :: Reader m hdr -> ServerStIdle hdr m ()
     idle rdr =
       ServerStIdle {
         recvMsgRequestNext   = handleRequestNext rdr,
@@ -44,12 +44,12 @@ chainSyncServer _tracer chainDB = ChainSyncServer $
         recvMsgDoneClient    = return ()
       }
 
-    idle' :: Reader m hdr -> ChainSyncServer hdr (Point hdr) m ()
+    idle' :: Reader m hdr -> ChainSyncServer hdr m ()
     idle' = ChainSyncServer . return . idle
 
     handleRequestNext :: Reader m hdr
-                      -> m (Either (ServerStNext hdr (Point hdr) m ())
-                                (m (ServerStNext hdr (Point hdr) m ())))
+                      -> m (Either (ServerStNext hdr m ())
+                                (m (ServerStNext hdr m ())))
     handleRequestNext rdr = do
       mupdate <- ChainDB.readerInstruction rdr
       tip     <- atomically $ castPoint <$> ChainDB.getTipPoint chainDB
@@ -62,14 +62,14 @@ chainSyncServer _tracer chainDB = ChainSyncServer $
     sendNext :: Reader m hdr
              -> Point hdr
              -> ChainUpdate hdr
-             -> ServerStNext hdr (Point hdr) m ()
+             -> ServerStNext hdr m ()
     sendNext rdr tip update = case update of
       AddBlock hdr -> SendMsgRollForward  hdr tip (idle' rdr)
       RollBack pt  -> SendMsgRollBackward pt  tip (idle' rdr)
 
     handleFindIntersect :: Reader m hdr
                         -> [Point hdr]
-                        -> m (ServerStIntersect hdr (Point hdr) m ())
+                        -> m (ServerStIntersect hdr m ())
     handleFindIntersect rdr points = do
       -- TODO guard number of points
       changed <- ChainDB.readerForward rdr points

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -118,7 +118,7 @@ data NodeKernel m up blk hdr = NodeKernel {
     , addUpstream   :: forall eCS eBF bytesCS bytesBF.
                        (Exception eCS, Exception eBF)
                     => up
-                    -> NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
+                    -> NodeComms m (ChainSync hdr) eCS bytesCS
                     -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
                     -> m ()
 
@@ -128,7 +128,7 @@ data NodeKernel m up blk hdr = NodeKernel {
       -- itself to register and deregister peers.
     , addDownstream :: forall eCS eBF bytesCS bytesBF.
                        (Exception eCS, Exception eBF)
-                    => NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
+                    => NodeComms m (ChainSync hdr) eCS bytesCS
                     -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
                     -> m ()
     }
@@ -284,7 +284,7 @@ initInternalState NodeParams {..} = do
           varCandidates
           up
 
-        nrChainSyncServer :: ChainSyncServer hdr (Point hdr) m ()
+        nrChainSyncServer :: ChainSyncServer hdr m ()
         nrChainSyncServer =
           chainSyncServer (tracePrefix "CSServer" Nothing) chainDB
 
@@ -450,10 +450,10 @@ forkBlockProduction IS{..} =
 data NetworkRequires m up blk hdr = NetworkRequires {
       -- | Start a chain sync client that communicates with the given upstream
       -- node.
-      nrChainSyncClient     :: up -> ChainSyncClient hdr (Point hdr) m Void
+      nrChainSyncClient     :: up -> ChainSyncClient hdr m Void
 
       -- | Start a chain sync server.
-    , nrChainSyncServer     :: ChainSyncServer hdr (Point hdr) m ()
+    , nrChainSyncServer     :: ChainSyncServer hdr m ()
 
       -- | Start a block fetch client that communicates with the given
       -- upstream node.
@@ -487,7 +487,7 @@ data NetworkProvides m up blk hdr = NetworkProvides {
       npAddUpstream   :: forall eCS eBF bytesCS bytesBF.
                          (Exception eCS, Exception eBF)
                       => up
-                      -> NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
+                      -> NodeComms m (ChainSync hdr) eCS bytesCS
                          -- Communication for the Chain Sync protocol
                       -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
                          -- Communication for the Block Fetch protocol
@@ -499,7 +499,7 @@ data NetworkProvides m up blk hdr = NetworkProvides {
       -- itself to register and deregister peers.p
     , npAddDownstream :: forall eCS eBF bytesCS bytesBF.
                          (Exception eCS, Exception eBF)
-                      => NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
+                      => NodeComms m (ChainSync hdr) eCS bytesCS
                          -- Communication for the Chain Sync protocol
                       -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
                          -- Communication for the Block Fetch protocol
@@ -522,7 +522,7 @@ initNetworkLayer
 initNetworkLayer _tracer registry NetworkRequires{..} = NetworkProvides {..}
   where
     npAddDownstream :: (Exception eCS, Exception eBF)
-                    => NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
+                    => NodeComms m (ChainSync hdr) eCS bytesCS
                     -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
                     -> m ()
     npAddDownstream ncCS ncBF = do
@@ -538,7 +538,7 @@ initNetworkLayer _tracer registry NetworkRequires{..} = NetworkProvides {..}
 
     npAddUpstream :: (Exception eCS, Exception eBF)
                   => up
-                  -> NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
+                  -> NodeComms m (ChainSync hdr) eCS bytesCS
                   -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
                   -> m ()
     npAddUpstream up ncCS ncBF = do

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -119,7 +119,7 @@ data NodeKernel m up blk hdr = NodeKernel {
                        (Exception eCS, Exception eBF)
                     => up
                     -> NodeComms m (ChainSync hdr) eCS bytesCS
-                    -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
+                    -> NodeComms m (BlockFetch blk) eBF bytesBF
                     -> m ()
 
       -- | Notify network layer of a new downstream node
@@ -129,7 +129,7 @@ data NodeKernel m up blk hdr = NodeKernel {
     , addDownstream :: forall eCS eBF bytesCS bytesBF.
                        (Exception eCS, Exception eBF)
                     => NodeComms m (ChainSync hdr) eCS bytesCS
-                    -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
+                    -> NodeComms m (BlockFetch blk) eBF bytesBF
                     -> m ()
     }
 
@@ -292,7 +292,7 @@ initInternalState NodeParams {..} = do
         nrBlockFetchClient up =
           blockFetchClient (tracePrefix "BFClient" (Just up)) blockFetchInterface up
 
-        nrBlockFetchServer :: BlockFetchServer hdr blk m ()
+        nrBlockFetchServer :: BlockFetchServer blk m ()
         nrBlockFetchServer =
           blockFetchServer (tracePrefix "BFServer" Nothing) chainDB
 
@@ -460,7 +460,7 @@ data NetworkRequires m up blk hdr = NetworkRequires {
     , nrBlockFetchClient    :: up -> BlockFetchClient hdr blk m ()
 
       -- | Start a block fetch server server.
-    , nrBlockFetchServer    :: BlockFetchServer hdr blk m ()
+    , nrBlockFetchServer    :: BlockFetchServer blk m ()
 
       -- | The fetch client registry, used by the block fetch client.
     , nrFetchClientRegistry :: FetchClientRegistry up hdr m
@@ -489,7 +489,7 @@ data NetworkProvides m up blk hdr = NetworkProvides {
                       => up
                       -> NodeComms m (ChainSync hdr) eCS bytesCS
                          -- Communication for the Chain Sync protocol
-                      -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
+                      -> NodeComms m (BlockFetch blk) eBF bytesBF
                          -- Communication for the Block Fetch protocol
                       -> m ()
 
@@ -501,7 +501,7 @@ data NetworkProvides m up blk hdr = NetworkProvides {
                          (Exception eCS, Exception eBF)
                       => NodeComms m (ChainSync hdr) eCS bytesCS
                          -- Communication for the Chain Sync protocol
-                      -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
+                      -> NodeComms m (BlockFetch blk) eBF bytesBF
                          -- Communication for the Block Fetch protocol
                       -> m ()
     }
@@ -523,7 +523,7 @@ initNetworkLayer _tracer registry NetworkRequires{..} = NetworkProvides {..}
   where
     npAddDownstream :: (Exception eCS, Exception eBF)
                     => NodeComms m (ChainSync hdr) eCS bytesCS
-                    -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
+                    -> NodeComms m (BlockFetch blk) eBF bytesBF
                     -> m ()
     npAddDownstream ncCS ncBF = do
       -- TODO use subregistry here?
@@ -539,7 +539,7 @@ initNetworkLayer _tracer registry NetworkRequires{..} = NetworkProvides {..}
     npAddUpstream :: (Exception eCS, Exception eBF)
                   => up
                   -> NodeComms m (ChainSync hdr) eCS bytesCS
-                  -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
+                  -> NodeComms m (BlockFetch blk) eBF bytesBF
                   -> m ()
     npAddUpstream up ncCS ncBF = do
       -- TODO use subregistry here?

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -198,7 +198,7 @@ broadcastNetwork registry btime numCoreNodes pInfo initRNG numSlots = do
 -------------------------------------------------------------------------------}
 
 -- | Communication channel used for the Chain Sync protocol
-type ChainSyncChannel m hdr = Channel m (AnyMessage (ChainSync hdr (Point hdr)))
+type ChainSyncChannel m hdr = Channel m (AnyMessage (ChainSync hdr))
 
 -- | Communication channel used for the Block Fetch protocol
 type BlockFetchChannel m blk hdr = Channel m (AnyMessage (BlockFetch hdr blk))

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -201,14 +201,14 @@ broadcastNetwork registry btime numCoreNodes pInfo initRNG numSlots = do
 type ChainSyncChannel m hdr = Channel m (AnyMessage (ChainSync hdr))
 
 -- | Communication channel used for the Block Fetch protocol
-type BlockFetchChannel m blk hdr = Channel m (AnyMessage (BlockFetch hdr blk))
+type BlockFetchChannel m blk = Channel m (AnyMessage (BlockFetch blk))
 
 -- | The communication channels from and to each node
 data NodeChan m blk hdr = NodeChan
-  { chainSyncConsumer  :: ChainSyncChannel  m     hdr
-  , chainSyncProducer  :: ChainSyncChannel  m     hdr
-  , blockFetchConsumer :: BlockFetchChannel m blk hdr
-  , blockFetchProducer :: BlockFetchChannel m blk hdr
+  { chainSyncConsumer  :: ChainSyncChannel  m hdr
+  , chainSyncProducer  :: ChainSyncChannel  m hdr
+  , blockFetchConsumer :: BlockFetchChannel m blk
+  , blockFetchProducer :: BlockFetchChannel m blk
   }
 
 -- | All connections between all nodes

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -70,7 +70,7 @@ blockFetchExample1 :: forall m. (MonadSTM m, MonadST m, MonadAsync m,
                    -> Tracer m (TraceLabelPeer Int
                                  (TraceFetchClientState BlockHeader))
                    -> Tracer m (TraceLabelPeer Int
-                                 (TraceSendRecv (BlockFetch BlockHeader Block)))
+                                 (TraceSendRecv (BlockFetch Block)))
                    -> AnchoredFragment Block   -- ^ Fixed current chain
                    -> [AnchoredFragment Block] -- ^ Fixed candidate chains
                    -> m ()
@@ -174,15 +174,14 @@ sampleBlockFetchPolicy1 blockHeap currentChain candidateChains =
 --
 
 runFetchClient :: (MonadCatch m, MonadAsync m, MonadST m, Ord peerid,
-                   Serialise header,
                    Serialise block,
-                   Serialise (HeaderHash header))
-                => Tracer m (TraceSendRecv (BlockFetch header block))
+                   Serialise (HeaderHash block))
+                => Tracer m (TraceSendRecv (BlockFetch block))
                 -> FetchClientRegistry peerid header m
                 -> peerid
                 -> Channel m LBS.ByteString
                 -> (  FetchClientStateVars m header
-                   -> PeerPipelined (BlockFetch header block)
+                   -> PeerPipelined (BlockFetch block)
                                     AsClient BFIdle m a)
                 -> m a
 runFetchClient tracer registry peerid channel client =
@@ -190,12 +189,11 @@ runFetchClient tracer registry peerid channel client =
       runPipelinedPeer 10 tracer (codecBlockFetch encode encode decode decode) channel (client stateVars)
 
 runFetchServer :: (MonadThrow m, MonadST m,
-                   Serialise header,
                    Serialise block,
-                   Serialise (HeaderHash header))
-                => Tracer m (TraceSendRecv (BlockFetch header block))
+                   Serialise (HeaderHash block))
+                => Tracer m (TraceSendRecv (BlockFetch block))
                 -> Channel m LBS.ByteString
-                -> BlockFetchServer header block m a
+                -> BlockFetchServer block m a
                 -> m a
 runFetchServer tracer channel server =
     runPeer tracer (codecBlockFetch encode encode decode decode) channel (blockFetchServerPeer server)
@@ -204,15 +202,15 @@ runFetchClientAndServerAsync
                :: (MonadCatch m, MonadAsync m, MonadST m, Ord peerid,
                    Serialise header,
                    Serialise block,
-                   Serialise (HeaderHash header))
-                => Tracer m (TraceSendRecv (BlockFetch header block))
-                -> Tracer m (TraceSendRecv (BlockFetch header block))
+                   Serialise (HeaderHash block))
+                => Tracer m (TraceSendRecv (BlockFetch block))
+                -> Tracer m (TraceSendRecv (BlockFetch block))
                 -> FetchClientRegistry peerid header m
                 -> peerid
                 -> (  FetchClientStateVars m header
-                   -> PeerPipelined (BlockFetch header block)
+                   -> PeerPipelined (BlockFetch block)
                                     AsClient BFIdle m a)
-                -> BlockFetchServer header block m b
+                -> BlockFetchServer block m b
                 -> m (Async m a, Async m b)
 runFetchClientAndServerAsync clientTracer serverTracer
                              registry peerid client server = do
@@ -244,7 +242,7 @@ mockedBlockFetchClient1 :: (MonadSTM m, MonadTime m, MonadThrow m,
                         => Tracer m (TraceFetchClientState header)
                         -> TestFetchedBlockHeap m block
                         -> FetchClientStateVars m header
-                        -> PeerPipelined (BlockFetch header block)
+                        -> PeerPipelined (BlockFetch block)
                                          AsClient BFIdle m ()
 mockedBlockFetchClient1 clientStateTracer blockHeap clientStateVars =
     blockFetchClient
@@ -281,30 +279,28 @@ exampleFixedPeerGSVs =
 -- It serves up ranges on a single given 'ChainFragment'. It does not simulate
 -- any delays, so is not suitable for timing-accurate simulations.
 --
-mockBlockFetchServer1 :: forall header block m.
-                        (MonadSTM m, HasHeader block,
-                         HeaderHash header ~ HeaderHash block)
+mockBlockFetchServer1 :: forall block m.
+                        (MonadSTM m, HasHeader block)
                       => ChainFragment block
-                      -> BlockFetchServer header block m ()
+                      -> BlockFetchServer block m ()
 mockBlockFetchServer1 chain =
     senderSide
   where
-    senderSide :: BlockFetchServer header block m ()
+    senderSide :: BlockFetchServer block m ()
     senderSide = BlockFetchServer receiveReq ()
 
-    receiveReq :: ChainRange header
-               -> m (BlockFetchBlockSender header block m ())
+    receiveReq :: ChainRange block
+               -> m (BlockFetchBlockSender block m ())
     receiveReq (ChainRange lpoint upoint) =
       -- We can only assert this for tests, not for the real thing.
       assert (pointSlot lpoint <= pointSlot upoint) $
-      case ChainFragment.sliceRange chain
-             (castPoint lpoint) (castPoint upoint) of
+      case ChainFragment.sliceRange chain lpoint upoint of
         Nothing     -> return $ SendMsgNoBlocks (return senderSide)
         Just chain' -> return $ SendMsgStartBatch (sendBlocks blocks)
           where blocks = ChainFragment.toOldestFirst chain'
 
 
-    sendBlocks :: [block] -> m (BlockFetchSendBlocks header block m ())
+    sendBlocks :: [block] -> m (BlockFetchSendBlocks block m ())
     sendBlocks []     = return $ SendMsgBatchDone (return senderSide)
     sendBlocks (b:bs) = return $ SendMsgBlock b (sendBlocks bs)
 

--- a/ouroboros-network/src/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Node.hs
@@ -98,10 +98,10 @@ chainValidation peerChainVar candidateChainVar = do
 -- | Simulated network channels for a given network node.
 --
 data NodeChannels m block = NodeChannels
-  { consumerChans :: [Channel m (AnyMessage (ChainSync block (Point block)))]
+  { consumerChans :: [Channel m (AnyMessage (ChainSync block))]
     -- ^ channels on which the node will play the consumer role:
     -- sending @consMsg@ and receiving @prodMsg@ messages.
-  , producerChans :: [Channel m (AnyMessage (ChainSync block (Point block)))]
+  , producerChans :: [Channel m (AnyMessage (ChainSync block))]
     -- ^ channels on which the node will play the producer role:
     -- sending @prodMsg@ and receiving @consMsg@ messages.
   }
@@ -293,7 +293,7 @@ relayNode nid initChain chans = do
     -- state between producers than necessary (here are producers share chain
     -- state and all the reader states, while we could share just the chain).
     startConsumer :: Int
-                  -> Channel m (AnyMessage (ChainSync block (Point block)))
+                  -> Channel m (AnyMessage (ChainSync block))
                   -> m (TVar m (Chain block))
     startConsumer cid channel = do
       chainVar <- atomically $ newTVar Genesis
@@ -301,9 +301,9 @@ relayNode nid initChain chans = do
       void $ fork $ void $ runPeer nullTracer codecChainSyncId (loggingChannel (ConsumerId nid cid) channel) consumer
       return chainVar
 
-    startProducer :: Peer (ChainSync block (Point block)) AsServer StIdle m ()
+    startProducer :: Peer (ChainSync block) AsServer StIdle m ()
                   -> Int
-                  -> Channel m (AnyMessage (ChainSync block (Point block)))
+                  -> Channel m (AnyMessage (ChainSync block))
                   -> m ()
     startProducer producer pid channel =
       -- use 'void' because 'fork' only works with 'm ()'

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Client.hs
@@ -16,51 +16,51 @@ import           Ouroboros.Network.Protocol.BlockFetch.Type
 -- | Block fetch client type for requesting ranges of blocks and handling
 -- responses.
 --
-newtype BlockFetchClient header block m a = BlockFetchClient {
-    runBlockFetchClient :: m (BlockFetchRequest header block m a)
+newtype BlockFetchClient block m a = BlockFetchClient {
+    runBlockFetchClient :: m (BlockFetchRequest block m a)
   }
 
-data BlockFetchRequest header block m a where
+data BlockFetchRequest block m a where
   -- | Request a chain range, supply handler for incoming blocks and
   -- a continuation.
   --
   SendMsgRequestRange
-    :: ChainRange header
-    -> BlockFetchResponse header block m a
-    -> BlockFetchClient   header block m a
-    -> BlockFetchRequest  header block m a
+    :: ChainRange block
+    -> BlockFetchResponse block m a
+    -> BlockFetchClient   block m a
+    -> BlockFetchRequest  block m a
 
   -- | Client terminating the block-fetch protocol.
   SendMsgClientDone
     :: a
-    -> BlockFetchRequest header block m a
+    -> BlockFetchRequest block m a
 
-data BlockFetchResponse header block m a = BlockFetchResponse {
-    handleStartBatch :: m (BlockFetchReceiver header block m),
+data BlockFetchResponse block m a = BlockFetchResponse {
+    handleStartBatch :: m (BlockFetchReceiver block m),
     handleNoBlocks   :: m ()
   }
 
 -- | Block are streamed and block receiver will handle each one when it comes,
 -- it also needs to handle errors send back from the server.
 --
-data BlockFetchReceiver header block m = BlockFetchReceiver {
-    handleBlock      :: block -> m (BlockFetchReceiver header block m),
+data BlockFetchReceiver block m = BlockFetchReceiver {
+    handleBlock      :: block -> m (BlockFetchReceiver block m),
     handleBatchDone  :: m ()
   }
 
 blockFetchClientPeer
-  :: forall header body m a.
-     ( StandardHash header
+  :: forall block m a.
+     ( StandardHash block
      , Monad m
      )
-  => BlockFetchClient header body m a
-  -> Peer (BlockFetch header body) AsClient BFIdle m a
+  => BlockFetchClient block m a
+  -> Peer (BlockFetch block) AsClient BFIdle m a
 blockFetchClientPeer (BlockFetchClient mclient) =
   Effect $ blockFetchRequestPeer <$> mclient
  where
   blockFetchRequestPeer
-    :: BlockFetchRequest header body m a
-    -> Peer (BlockFetch header body) AsClient BFIdle m a
+    :: BlockFetchRequest block m a
+    -> Peer (BlockFetch block) AsClient BFIdle m a
 
   blockFetchRequestPeer (SendMsgClientDone result) =
     Yield (ClientAgency TokIdle) MsgClientDone (Done TokDone result)
@@ -73,22 +73,22 @@ blockFetchClientPeer (BlockFetchClient mclient) =
 
 
   blockFetchResponsePeer
-    :: BlockFetchClient header body m a
-    -> BlockFetchResponse header body m a
-    -> Peer (BlockFetch header body) AsClient BFBusy m a
+    :: BlockFetchClient block m a
+    -> BlockFetchResponse block m a
+    -> Peer (BlockFetch block) AsClient BFBusy m a
   blockFetchResponsePeer next BlockFetchResponse{handleNoBlocks, handleStartBatch} =
     Await (ServerAgency TokBusy) $ \msg -> case msg of
       MsgStartBatch -> Effect $ blockReceiver next <$> handleStartBatch
       MsgNoBlocks   -> Effect $ handleNoBlocks >> (blockFetchRequestPeer <$> runBlockFetchClient next)
 
   blockReceiver
-    :: BlockFetchClient header body m a
-    -> BlockFetchReceiver header body m
-    -> Peer (BlockFetch header body) AsClient BFStreaming m a
+    :: BlockFetchClient block m a
+    -> BlockFetchReceiver block m
+    -> Peer (BlockFetch block) AsClient BFStreaming m a
   blockReceiver next BlockFetchReceiver{handleBlock, handleBatchDone} =
     Await (ServerAgency TokStreaming) $ \msg -> case msg of
-      MsgBlock body -> Effect $ blockReceiver next <$> handleBlock body
-      MsgBatchDone  -> Effect $ do
+      MsgBlock block -> Effect $ blockReceiver next <$> handleBlock block
+      MsgBatchDone   -> Effect $ do
         handleBatchDone
         blockFetchRequestPeer <$> runBlockFetchClient next
 
@@ -98,53 +98,53 @@ blockFetchClientPeer (BlockFetchClient mclient) =
 
 -- | A BlockFetch client designed for running the protcol in a pipelined way.
 --
-data BlockFetchClientPipelined header body m a where
+data BlockFetchClientPipelined block m a where
    -- | A 'BlockFetchSender', but starting with zero outstanding pipelined
    -- responses, and for any internal collect type @c@.
    BlockFetchClientPipelined
-     :: BlockFetchSender      Z c header body m a
-     -> BlockFetchClientPipelined header body m a
+     :: BlockFetchSender      Z c block m a
+     -> BlockFetchClientPipelined block m a
 
 -- | A 'BlockFetchSender' with @n@ outstanding stream of block bodies.
 --
-data BlockFetchSender n c header body m a where
+data BlockFetchSender n c block m a where
 
   -- | Send a `MsgRequestRange` but do not wait for response.  Supply a monadic
-  -- action which runs on each received body and which updates the internal
+  -- action which runs on each received block and which updates the internal
   -- received value @c@.  @c@ could be a Monoid, though it's more genral this
   -- way.
   --
   SendMsgRequestRangePipelined
-    :: ChainRange header
+    :: ChainRange block
     -> c
-    -> (Maybe body -> c -> m c)
-    -> BlockFetchSender (S n) c header body m a
-    -> BlockFetchSender    n  c header body m a
+    -> (Maybe block -> c -> m c)
+    -> BlockFetchSender (S n) c block m a
+    -> BlockFetchSender    n  c block m a
 
   -- | Collect the result of a previous pipelined receive action
   --
   CollectBlocksPipelined
-    :: Maybe (BlockFetchSender (S n) c header body m a)
-    -> (c ->  BlockFetchSender    n  c header body m a)
-    ->        BlockFetchSender (S n) c header body m a
+    :: Maybe (BlockFetchSender (S n) c block m a)
+    -> (c ->  BlockFetchSender    n  c block m a)
+    ->        BlockFetchSender (S n) c block m a
 
   -- | Termination of the block-fetch protocol.
   SendMsgDonePipelined
-    :: a -> BlockFetchSender Z c header body m a
+    :: a -> BlockFetchSender Z c block m a
 
 blockFetchClientPeerPipelined
-  :: forall header body m a.
+  :: forall block m a.
      Monad m
-  => BlockFetchClientPipelined header body m a
-  -> PeerPipelined (BlockFetch header body) AsClient BFIdle m a
+  => BlockFetchClientPipelined block m a
+  -> PeerPipelined (BlockFetch block) AsClient BFIdle m a
 blockFetchClientPeerPipelined (BlockFetchClientPipelined sender) =
   PeerPipelined (blockFetchClientPeerSender sender)
 
 blockFetchClientPeerSender
-  :: forall n header body c m a.
+  :: forall n block c m a.
      Monad m
-  => BlockFetchSender n c header body m a
-  -> PeerSender (BlockFetch header body) AsClient BFIdle n c m a
+  => BlockFetchSender n c block m a
+  -> PeerSender (BlockFetch block) AsClient BFIdle n c m a
 
 blockFetchClientPeerSender (SendMsgDonePipelined result) =
   -- Send `MsgClientDone` and complete the protocol
@@ -166,11 +166,11 @@ blockFetchClientPeerSender (SendMsgRequestRangePipelined range c0 receive next) 
  where
   receiveBlocks
     :: c
-    -> PeerReceiver (BlockFetch header body) AsClient BFStreaming BFIdle m c
+    -> PeerReceiver (BlockFetch block) AsClient BFStreaming BFIdle m c
   receiveBlocks c = ReceiverAwait (ServerAgency TokStreaming) $ \msg -> case msg of
     -- received a block, run an acction and compute the result
-    MsgBlock body -> ReceiverEffect $ do
-      c' <- receive (Just body) c
+    MsgBlock block -> ReceiverEffect $ do
+      c' <- receive (Just block) c
       return $ receiveBlocks c'
     MsgBatchDone  -> ReceiverDone c
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
@@ -10,8 +10,8 @@ import Ouroboros.Network.Protocol.ChainSync.Server as Server
 -- That's demonstrated here by constructing 'direct'.
 --
 direct :: Monad m
-       => ChainSyncServer header point m a
-       -> ChainSyncClient header point m b
+       => ChainSyncServer header m a
+       -> ChainSyncClient header m b
        -> m (a, b)
 direct (ChainSyncServer mserver) (ChainSyncClient mclient) = do
   server <- mserver
@@ -19,8 +19,8 @@ direct (ChainSyncServer mserver) (ChainSyncClient mclient) = do
   direct_ server client
 
 direct_ :: Monad m
-        => ServerStIdle header point m a
-        -> ClientStIdle header point m b
+        => ServerStIdle header m a
+        -> ClientStIdle header m b
         -> m (a, b)
 direct_  ServerStIdle{recvMsgRequestNext}
         (Client.SendMsgRequestNext stNext stAwait) = do

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -9,33 +9,43 @@
 -- Since we are using a typed protocol framework this is in some sense /the/
 -- definition of the protocol: what is allowed and what is not allowed.
 --
-module Ouroboros.Network.Protocol.ChainSync.Type where
+module Ouroboros.Network.Protocol.ChainSync.Type (
+    ChainSync(..),
+    Point,
+    StNextKind(..),
+    TokNextKind(..),
+    Message(..),
+    ClientHasAgency(..),
+    ServerHasAgency(..),
+    NobodyHasAgency(..),
+  ) where
 
 import Network.TypedProtocol.Core
+import Ouroboros.Network.Block (Point, StandardHash)
 
 
 -- | A kind to identify our protocol, and the types of the states in the state
 -- transition diagram of the protocol.
 --
-data ChainSync header point where
+data ChainSync header where
 
   -- | Both client and server are idle. The client can send a request and
   -- the server is waiting for a request.
-  StIdle      :: ChainSync header point
+  StIdle      :: ChainSync header
 
   -- | The client has sent a next update request. The client is now waiting
   -- for a response, and the server is busy getting ready to send a response.
   -- There are two possibilities here, since the server can send a reply
   -- immediately or it can send an initial await message followed later by
   -- the normal reply.
-  StNext      :: StNextKind -> ChainSync header point
+  StNext      :: StNextKind -> ChainSync header
 
   -- | The client has sent an intersection request. The client is now waiting
   -- for a response, and the server is busy getting ready to send a response.
-  StIntersect :: ChainSync header point
+  StIntersect :: ChainSync header
 
   -- | Both the client and server are in the terminal state. They're done.
-  StDone      :: ChainSync header point
+  StDone      :: ChainSync header
 
 -- | Sub-cases of the 'StNext' state. This is needed since the server can
 -- either send one reply back, or two.
@@ -47,42 +57,42 @@ data StNextKind where
   StMustReply :: StNextKind
 
 
-instance Protocol (ChainSync header point) where
+instance Protocol (ChainSync header) where
 
   -- | The messages in the chain sync protocol.
   --
   -- In this protocol the consumer always initiates things and the producer
   -- replies.
   --
-  data Message (ChainSync header point) from to where
+  data Message (ChainSync header) from to where
 
     -- | Request the next update from the producer. The response can be a roll
     -- forward, a roll back or wait.
     --
-    MsgRequestNext :: Message (ChainSync header point)
+    MsgRequestNext :: Message (ChainSync header)
                               StIdle (StNext StCanAwait)
 
     -- | Acknowledge the request but require the consumer to wait for the next
     -- update. This means that the consumer is synced with the producer, and
     -- the producer is waiting for its own chain state to change.
     --
-    MsgAwaitReply :: Message (ChainSync header point)
+    MsgAwaitReply :: Message (ChainSync header)
                              (StNext StCanAwait) (StNext StMustReply)
 
     -- | Tell the consumer to extend their chain with the given header.
     --
     -- The message also tells the consumer about the head point of the producer.
     --
-    MsgRollForward :: header -> point
-                   -> Message (ChainSync header point)
+    MsgRollForward :: header -> Point header
+                   -> Message (ChainSync header)
                               (StNext any) StIdle
 
     -- | Tell the consumer to roll back to a given point on their chain.
     --
     -- The message also tells the consumer about the head point of the producer.
     --
-    MsgRollBackward :: point -> point
-                    -> Message (ChainSync header point)
+    MsgRollBackward :: Point header -> Point header
+                    -> Message (ChainSync header)
                                (StNext any) StIdle
 
     -- | Ask the producer to try to find an improved intersection point between
@@ -90,8 +100,8 @@ instance Protocol (ChainSync header point) where
     -- points and it is up to the producer to find the first intersection point
     -- on its chain and send it back to the consumer.
     --
-    MsgFindIntersect :: [point]
-                     -> Message (ChainSync header point)
+    MsgFindIntersect :: [Point header]
+                     -> Message (ChainSync header)
                                 StIdle StIntersect
 
     -- | The reply to the consumer about an intersection found, but /only/ if this
@@ -100,8 +110,8 @@ instance Protocol (ChainSync header point) where
     --
     -- The message also tells the consumer about the head point of the producer.
     --
-    MsgIntersectImproved  :: point -> point
-                          -> Message (ChainSync header point)
+    MsgIntersectImproved  :: Point header -> Point header
+                          -> Message (ChainSync header)
                                      StIntersect StIdle
 
     -- | The reply to the consumer that no intersection was found: none of the
@@ -109,13 +119,13 @@ instance Protocol (ChainSync header point) where
     --
     -- The message also tells the consumer about the head point of the producer.
     --
-    MsgIntersectUnchanged :: point
-                          -> Message (ChainSync header point)
+    MsgIntersectUnchanged :: Point header
+                          -> Message (ChainSync header)
                                      StIntersect StIdle
 
     -- | Terminating messages
     --
-    MsgDone :: Message (ChainSync header point)
+    MsgDone :: Message (ChainSync header)
                        StIdle StDone
 
   -- | We have to explain to the framework what our states mean, in terms of
@@ -144,7 +154,8 @@ data TokNextKind (k :: StNextKind) where
   TokMustReply :: TokNextKind StMustReply
 
 
-instance (Show header, Show point) => Show (Message (ChainSync header point) from to) where
+instance (Show header, StandardHash header)
+      => Show (Message (ChainSync header) from to) where
   show MsgRequestNext               = "MsgRequestNext"
   show MsgAwaitReply                = "MsgAwaitReply"
   show (MsgRollForward h tip)       = "MsgRollForward " ++ show h ++ " " ++ show tip

--- a/ouroboros-network/test/Test/ChainFragment.hs
+++ b/ouroboros-network/test/Test/ChainFragment.hs
@@ -33,7 +33,8 @@ import           Ouroboros.Network.Testing.Serialise (prop_serialise)
 import           Test.Chain ()
 import           Test.ChainGenerators
                    ( TestBlockChain (..), TestChainAndRange (..)
-                   , addSlotGap, genNonNegative, genSlotGap, mkPartialBlock)
+                   , genNonNegative, genChainAnchor, mkPartialBlock
+                   , addSlotGap, genSlotGap)
 
 
 --
@@ -443,22 +444,6 @@ prop_shrink_TestBlockChainFragment c =
 prop_shrink_TestHeaderChainFragment :: TestHeaderChainFragment -> Bool
 prop_shrink_TestHeaderChainFragment c =
     and [ CF.valid c' | TestHeaderChainFragment c' <- shrink c ]
-
-
--- | A starting point for a chain fragment: either the 'genesisAnchor' or
--- an arbitrary point.
---
-genChainAnchor :: Gen (ChainHash Block, BlockNo, SlotNo)
-genChainAnchor = oneof [ pure genesisAnchor, genArbitraryChainAnchor ]
-
-genArbitraryChainAnchor :: Gen (ChainHash Block, BlockNo, SlotNo)
-genArbitraryChainAnchor =
-    (,,) <$> (BlockHash <$> arbitrary)
-         <*> arbitrary
-         <*> arbitrary
-
-genesisAnchor :: (ChainHash b, BlockNo, SlotNo)
-genesisAnchor = (GenesisHash, BlockNo 0, SlotNo 0)
 
 
 -- | The Ouroboros K paramater. This is also the maximum rollback length.

--- a/ouroboros-network/test/Test/ChainGenerators.hs
+++ b/ouroboros-network/test/Test/ChainGenerators.hs
@@ -124,7 +124,7 @@ instance Arbitrary (Point Block) where
          . shrink
          .     (castPoint :: Point Block -> Point BlockHeader)
 
-instance Arbitrary (ChainRange BlockHeader) where
+instance Arbitrary (ChainRange Block) where
   arbitrary = do
     low  <- arbitrary
     high <- arbitrary `suchThat` (\high -> pointSlot low <= pointSlot high)

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -770,7 +770,7 @@ demo chain0 updates delay = do
     let Just expectedChain = Chain.applyChainUpdates updates chain0
         target = Chain.headPoint expectedChain
 
-        consumerPeer :: Peer (ChainSync.ChainSync block (Point block)) AsClient ChainSync.StIdle m ()
+        consumerPeer :: Peer (ChainSync.ChainSync block) AsClient ChainSync.StIdle m ()
         consumerPeer = ChainSync.chainSyncClientPeer
                           (ChainSync.chainSyncClientExample consumerVar
                           (consumerClient done target consumerVar))
@@ -781,7 +781,7 @@ demo chain0 updates delay = do
                               (ChainSync.codecChainSync encode decode encode decode)
                               (consumerPeer))
 
-        producerPeer :: Peer (ChainSync.ChainSync block (Point block)) AsServer ChainSync.StIdle m ()
+        producerPeer :: Peer (ChainSync.ChainSync block) AsServer ChainSync.StIdle m ()
         producerPeer = ChainSync.chainSyncServerPeer (ChainSync.chainSyncServerExample () producerVar)
         producerApp = Mx.simpleMuxResponderApplication
                         (\ChainSync1 ->

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -160,7 +160,7 @@ data Example1TraceEvent =
    | TraceFetchClientState    (TraceLabelPeer Int
                                 (TraceFetchClientState BlockHeader))
    | TraceFetchClientSendRecv (TraceLabelPeer Int
-                                (TraceSendRecv (BlockFetch BlockHeader Block)))
+                                (TraceSendRecv (BlockFetch Block)))
 
 instance Show Example1TraceEvent where
   show (TraceFetchDecision       x) = "TraceFetchDecision " ++ show x

--- a/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
@@ -47,7 +47,6 @@ import           Ouroboros.Network.Testing.ConcreteBlock as ConcreteBlock
 import           Test.ChainGenerators
                   ( TestBlockChain (..)
                   , genNonNegative
-                  , genHeaderChain
                   )
 
 
@@ -447,13 +446,6 @@ genConnectedBidirectionalGraph = do
   g <- arbitraryAcyclicGraphSmall
   let g' = accum (++) g (assocs $ transposeG g)
   connectGraphG g'
-
--- | Generate a non-empty chain starting with this block header.
-genNonEmptyHeaderChain :: BlockHeader -> Gen (NonEmpty BlockHeader)
-genNonEmptyHeaderChain genesis = do
-  n <- genNonNegative
-  chain <- reverse . chainToList <$> genHeaderChain n
-  pure $ genesis NE.:| chain
 
 
 --

--- a/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
@@ -16,8 +16,6 @@ import           Data.Fixed (Micro)
 import           Data.Functor (void)
 import           Data.Graph
 import           Data.List (foldl')
-import           Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (isNothing, listToMaybe)
@@ -38,16 +36,13 @@ import qualified Control.Monad.IOSim as Sim
 
 import           Ouroboros.Network.Time (microsecondsToDiffTime)
 import           Ouroboros.Network.Block
-import           Ouroboros.Network.Chain (Chain (..), chainToList)
+import           Ouroboros.Network.Chain (Chain (..))
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState (ChainProducerState (..))
 import           Ouroboros.Network.Node
 import           Ouroboros.Network.Testing.ConcreteBlock as ConcreteBlock
 
-import           Test.ChainGenerators
-                  ( TestBlockChain (..)
-                  , genNonNegative
-                  )
+import           Test.ChainGenerators (TestBlockChain (..))
 
 
 tests :: TestTree


### PR DESCRIPTION
* Simplify `ChainSync` type by eliminating `point` type arg

Previously we had "ChainSync header point" but the point is in fact always a "Point header", so the extra argument is unnecessary.

* Simplify `BlockFetch` type by eliminating `header` type arg

Previously we had `BlockFetch header block` but the header is in fact always just used for a `Point header`, which is really the same as a `Point block`, so the extra argument is unnecessary.

Both get used quite a few places, but it's a mechanical change everywhere.