### PR TITLE
Centralise the chain sync and block fetch codec schemas

### DIFF
--- a/ouroboros-consensus/demo-playground/Run.hs
+++ b/ouroboros-consensus/demo-playground/Run.hs
@@ -169,17 +169,17 @@ handleSimpleNode p CLI{..} (TopologyInfo myNodeId topologyFile) = do
           direction = Upstream (producerNodeId :==>: myNodeId)
           nodeCommsCS = NodeComms {
               ncCodec    = codecChainSync
-                             (demoEncodeHeader     pInfoConfig)
-                             (demoDecodeHeader     pInfoConfig)
-                             (encodePoint'         pInfo)
-                             (decodePoint'         pInfo)
+                             (      demoEncodeHeader pInfoConfig)
+                             (\_ -> demoDecodeHeader pInfoConfig)
+                             (encodePoint'           pInfo)
+                             (decodePoint'           pInfo)
             , ncWithChan = NamedPipe.withPipeChannel "chain-sync" direction
             }
           nodeCommsBF = NodeComms {
               ncCodec    = codecBlockFetch
-                             (demoEncodeBlock pInfoConfig)
+                             (      demoEncodeBlock pInfoConfig)
+                             (\_ -> demoDecodeBlock pInfoConfig)
                              demoEncodeHeaderHash
-                             (demoDecodeBlock pInfoConfig)
                              demoDecodeHeaderHash
             , ncWithChan = NamedPipe.withPipeChannel "block-fetch" direction
             }
@@ -194,17 +194,17 @@ handleSimpleNode p CLI{..} (TopologyInfo myNodeId topologyFile) = do
           direction = Downstream (myNodeId :==>: consumerNodeId)
           nodeCommsCS = NodeComms {
               ncCodec    = codecChainSync
-                             (demoEncodeHeader     pInfoConfig)
-                             (demoDecodeHeader     pInfoConfig)
-                             (encodePoint'         pInfo)
-                             (decodePoint'         pInfo)
+                             (      demoEncodeHeader pInfoConfig)
+                             (\_ -> demoDecodeHeader pInfoConfig)
+                             (encodePoint'           pInfo)
+                             (decodePoint'           pInfo)
             , ncWithChan = NamedPipe.withPipeChannel "chain-sync" direction
             }
           nodeCommsBF = NodeComms {
               ncCodec    = codecBlockFetch
-                             (demoEncodeBlock pInfoConfig)
+                             (      demoEncodeBlock pInfoConfig)
+                             (\_ -> demoDecodeBlock pInfoConfig)
                              demoEncodeHeaderHash
-                             (demoDecodeBlock pInfoConfig)
                              demoDecodeHeaderHash
             , ncWithChan = NamedPipe.withPipeChannel "block-fetch" direction
             }

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -16,7 +16,8 @@ import           Data.Map (Map)
 import qualified Data.Set as Set
 import           Data.Set (Set)
 import qualified Data.ByteString.Lazy as LBS
-import           Codec.Serialise (Serialise(..))
+import qualified Codec.Serialise as S (Serialise(encode, decode))
+import           Codec.Serialise      (Serialise)
 
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadST
@@ -195,7 +196,7 @@ runFetchClient tracer registry peerid channel client =
       runPipelinedPeer 10 tracer codec channel $
         client clientCtx
   where
-    codec = codecBlockFetch encode encode decode decode
+    codec = codecBlockFetch S.encode (const S.decode) S.encode S.decode
 
 runFetchServer :: (MonadThrow m, MonadST m,
                    Serialise block,
@@ -208,7 +209,7 @@ runFetchServer tracer channel server =
     runPeer tracer codec channel $
       blockFetchServerPeer server
   where
-    codec = codecBlockFetch encode encode decode decode
+    codec = codecBlockFetch S.encode (const S.decode) S.encode S.decode
 
 runFetchClientAndServerAsync
                :: (MonadCatch m, MonadAsync m, MonadST m, Ord peerid,

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
@@ -12,13 +12,16 @@ module Ouroboros.Network.Protocol.BlockFetch.Codec
   , codecBlockFetchId
   ) where
 
+import           Control.Monad (when)
 import           Control.Monad.Class.MonadST
 
-import           Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString      as BS
+import qualified Data.ByteString.Lazy as LBS
 
-import qualified Codec.CBOR.Encoding as CBOR (Encoding, encodeListLen, encodeWord)
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Read     as CBOR
-import qualified Codec.CBOR.Decoding as CBOR (Decoder, decodeListLen, decodeWord)
+import qualified Codec.CBOR.Write    as CBOR
 
 import           Network.TypedProtocol.Codec
 import           Ouroboros.Network.Codec
@@ -33,34 +36,30 @@ codecBlockFetch
      , MonadST m
      )
   => (block            -> CBOR.Encoding)
+  -> (forall s. BS.ByteString
+             -> CBOR.Decoder s block)
   -> (HeaderHash block -> CBOR.Encoding)
-  -> (forall s. CBOR.Decoder s block)
   -> (forall s. CBOR.Decoder s (HeaderHash block))
-  -> Codec (BlockFetch block) CBOR.DeserialiseFailure m ByteString
-codecBlockFetch encodeBody encodeHeaderHash
-                decodeBody decodeHeaderHash =
+  -> Codec (BlockFetch block) CBOR.DeserialiseFailure m LBS.ByteString
+codecBlockFetch encodeBlock     decodeBlock
+                encodeBlockHash decodeBlockHash =
     mkCodecCborLazyBS encode decode
  where
-  encodePoint' :: Point block -> CBOR.Encoding
-  encodePoint' = Block.encodePoint $ Block.encodeChainHash encodeHeaderHash
-
-  decodePoint' :: forall s. CBOR.Decoder s (Point block)
-  decodePoint' = Block.decodePoint $ Block.decodeChainHash decodeHeaderHash
-
   encode :: forall (pr :: PeerRole) st st'.
             PeerHasAgency pr st
          -> Message (BlockFetch block) st st'
          -> CBOR.Encoding
   encode (ClientAgency TokIdle) (MsgRequestRange (ChainRange from to)) =
-    CBOR.encodeListLen 2 <> CBOR.encodeWord 0 <> encodePoint' from <> encodePoint' to
+    CBOR.encodeListLen 2 <> CBOR.encodeWord 0 <> encodePoint from
+                                              <> encodePoint to
   encode (ClientAgency TokIdle) MsgClientDone =
     CBOR.encodeListLen 1 <> CBOR.encodeWord 1
   encode (ServerAgency TokBusy) MsgStartBatch =
     CBOR.encodeListLen 1 <> CBOR.encodeWord 2
   encode (ServerAgency TokBusy) MsgNoBlocks =
     CBOR.encodeListLen 1 <> CBOR.encodeWord 3
-  encode (ServerAgency TokStreaming) (MsgBlock body) =
-    CBOR.encodeListLen 2 <> CBOR.encodeWord 4 <> encodeBody body
+  encode (ServerAgency TokStreaming) (MsgBlock block) =
+    CBOR.encodeListLen 2 <> CBOR.encodeWord 4 <> encodeBlockWrapped block
   encode (ServerAgency TokStreaming) MsgBatchDone =
     CBOR.encodeListLen 1 <> CBOR.encodeWord 5
 
@@ -72,19 +71,43 @@ codecBlockFetch encodeBody encodeHeaderHash
     key <- CBOR.decodeWord
     case (stok, key) of
       (ClientAgency TokIdle, 0) -> do
-        from <- decodePoint'
-        to   <- decodePoint'
+        from <- decodePoint
+        to   <- decodePoint
         return $ SomeMessage $ MsgRequestRange (ChainRange from to)
       (ClientAgency TokIdle, 1) -> return $ SomeMessage MsgClientDone
       (ServerAgency TokBusy, 2) -> return $ SomeMessage MsgStartBatch
       (ServerAgency TokBusy, 3) -> return $ SomeMessage MsgNoBlocks
-      (ServerAgency TokStreaming, 4) -> SomeMessage . MsgBlock <$> decodeBody
+      (ServerAgency TokStreaming, 4) -> SomeMessage . MsgBlock
+                                          <$> decodeBlockWrapped
       (ServerAgency TokStreaming, 5) -> return $ SomeMessage MsgBatchDone
 
       -- TODO proper exceptions
       (ClientAgency TokIdle, _)      -> fail "codecBlockFetch.Idle: unexpected key"
       (ServerAgency TokBusy, _)      -> fail "codecBlockFetch.Busy: unexpected key"
       (ServerAgency TokStreaming, _) -> fail "codecBlockFetch.Streaming: unexpected key"
+
+  encodePoint :: Point block -> CBOR.Encoding
+  encodePoint = Block.encodePoint $ Block.encodeChainHash encodeBlockHash
+
+  decodePoint :: forall s. CBOR.Decoder s (Point block)
+  decodePoint = Block.decodePoint $ Block.decodeChainHash decodeBlockHash
+
+  encodeBlockWrapped :: block -> CBOR.Encoding
+  encodeBlockWrapped block =
+      CBOR.encodeTag 24
+   <> CBOR.encodeBytes (CBOR.toStrictByteString (encodeBlock block))
+
+  decodeBlockWrapped :: forall s. CBOR.Decoder s block
+  decodeBlockWrapped = do
+    tag <- CBOR.decodeTag
+    when (tag /= 24) $ fail "expected tag 24 (CBOR-in-CBOR)"
+    payload <- CBOR.decodeBytes
+    case CBOR.deserialiseFromBytes (decodeBlock payload)
+                                   (LBS.fromStrict payload) of
+      Left (CBOR.DeserialiseFailure _ reason) -> fail reason
+      Right (trailing, block)
+        | not (LBS.null trailing) -> fail "trailing bytes in CBOR-in-CBOR"
+        | otherwise               -> return block
 
 
 codecBlockFetchId

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -263,7 +263,7 @@ prop_channel :: (MonadAsync m, MonadCatch m, MonadST m)
 prop_channel createChannels chain points = do
     (bodies, ()) <-
       runConnectedPeers
-        createChannels nullTracer (codecBlockFetch S.encode S.encode S.decode S.decode)
+        createChannels nullTracer codec
         (blockFetchClientPeer (testClient chain points))
         (blockFetchServerPeer (testServer chain))
     return $ reverse bodies === concat (receivedBlockBodies chain points)
@@ -294,6 +294,13 @@ prop_pipe_IO (TestChainAndPoints chain points) =
 -- Codec properties
 --
 
+codec :: MonadST m
+      => Codec (BlockFetch Block)
+               S.DeserialiseFailure
+               m ByteString
+codec = codecBlockFetch S.encode (const S.decode)
+                        S.encode        S.decode
+
 instance Arbitrary (AnyMessageAndAgency (BlockFetch Block)) where
   arbitrary = oneof
     [ AnyMessageAndAgency (ClientAgency TokIdle) <$>
@@ -323,19 +330,19 @@ prop_codec_BlockFetch
   :: AnyMessageAndAgency (BlockFetch Block)
   -> Bool
 prop_codec_BlockFetch msg =
-  runST (prop_codecM (codecBlockFetch S.encode S.encode S.decode S.decode) msg)
+  runST (prop_codecM codec msg)
 
 prop_codec_splits2_BlockFetch
   :: AnyMessageAndAgency (BlockFetch Block)
   -> Bool
 prop_codec_splits2_BlockFetch msg =
-  runST (prop_codec_splitsM splits2 (codecBlockFetch S.encode S.encode S.decode S.decode) msg)
+  runST (prop_codec_splitsM splits2 codec msg)
 
 prop_codec_splits3_BlockFetch
   :: AnyMessageAndAgency (BlockFetch Block)
   -> Bool
 prop_codec_splits3_BlockFetch msg =
-  runST (prop_codec_splitsM splits3 (codecBlockFetch S.encode S.encode S.decode S.decode) msg)
+  runST (prop_codec_splitsM splits3 codec msg)
 
 
 --

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
@@ -11,35 +11,41 @@ module Ouroboros.Network.Protocol.ChainSync.Codec
   , codecChainSyncId
   ) where
 
+import           Control.Monad (when)
 import           Control.Monad.Class.MonadST
 
 import           Network.TypedProtocol.Codec
 import           Ouroboros.Network.Codec
 import           Ouroboros.Network.Protocol.ChainSync.Type
 
+import qualified Data.ByteString      as BS
+import qualified Data.ByteString.Lazy as LBS
 
 import qualified Codec.CBOR.Encoding as CBOR
-import qualified Codec.CBOR.Read     as CBOR
 import qualified Codec.CBOR.Decoding as CBOR
+import           Codec.CBOR.Encoding (encodeListLen, encodeWord)
+import           Codec.CBOR.Decoding (decodeListLen, decodeWord)
+import qualified Codec.CBOR.Read     as CBOR
+import qualified Codec.CBOR.Write    as CBOR
 
-import Data.ByteString.Lazy (ByteString)
-import Codec.CBOR.Encoding (encodeListLen, encodeWord)
-import Codec.CBOR.Decoding (decodeListLen, decodeWord)
 
 -- | The main CBOR 'Codec' for the 'ChainSync' protocol.
 --
 codecChainSync :: forall header point m.
                   (MonadST m)
                => (header -> CBOR.Encoding)
-               -> (forall s . CBOR.Decoder s header)
+               -> (forall s . BS.ByteString
+                           -> CBOR.Decoder s header)
                -> (point -> CBOR.Encoding)
                -> (forall s . CBOR.Decoder s point)
                -> Codec (ChainSync header point)
-                        CBOR.DeserialiseFailure m ByteString
+                        CBOR.DeserialiseFailure m LBS.ByteString
 codecChainSync encodeHeader decodeHeader encodePoint decodePoint =
     mkCodecCborLazyBS encode decode
   where
-    encode :: forall (pr :: PeerRole) (st :: ChainSync header point) (st' :: ChainSync header point).
+    encode :: forall (pr  :: PeerRole) 
+                     (st  :: ChainSync header point)
+                     (st' :: ChainSync header point).
               PeerHasAgency pr st
            -> Message (ChainSync header point) st st'
            -> CBOR.Encoding
@@ -51,7 +57,7 @@ codecChainSync encodeHeader decodeHeader encodePoint decodePoint =
       encodeListLen 1 <> encodeWord 1
 
     encode (ServerAgency TokNext{}) (MsgRollForward h p) =
-      encodeListLen 3 <> encodeWord 2 <> encodeHeader h <> encodePoint p
+      encodeListLen 3 <> encodeWord 2 <> encodeHeaderWrapped h <> encodePoint p
 
     encode (ServerAgency TokNext{}) (MsgRollBackward p1 p2) =
       encodeListLen 3 <> encodeWord 3 <> encodePoint p1 <> encodePoint p2
@@ -82,7 +88,7 @@ codecChainSync encodeHeader decodeHeader encodePoint decodePoint =
           return (SomeMessage MsgAwaitReply)
 
         (2, 3, ServerAgency (TokNext _)) -> do
-          h <- decodeHeader
+          h <- decodeHeaderWrapped
           p <- decodePoint
           return (SomeMessage (MsgRollForward h p))
 
@@ -108,6 +114,24 @@ codecChainSync encodeHeader decodeHeader encodePoint decodePoint =
           return (SomeMessage MsgDone)
 
         _ -> fail ("codecChainSync: unexpected key " ++ show (key, len))
+
+    encodeHeaderWrapped :: header -> CBOR.Encoding
+    encodeHeaderWrapped header =
+        CBOR.encodeTag 24
+     <> CBOR.encodeBytes (CBOR.toStrictByteString (encodeHeader header))
+
+    decodeHeaderWrapped :: forall s. CBOR.Decoder s header
+    decodeHeaderWrapped = do
+      tag <- CBOR.decodeTag
+      when (tag /= 24) $ fail "expected tag 24 (CBOR-in-CBOR)"
+      payload <- CBOR.decodeBytes
+      case CBOR.deserialiseFromBytes (decodeHeader payload)
+                                     (LBS.fromStrict payload) of
+        Left (CBOR.DeserialiseFailure _ reason) -> fail reason
+        Right (trailing, header)
+          | not (LBS.null trailing) -> fail "trailing bytes in CBOR-in-CBOR"
+          | otherwise               -> return header
+
 
 encodeList :: (a -> CBOR.Encoding) -> [a] -> CBOR.Encoding
 encodeList _   [] = CBOR.encodeListLen 0

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -778,7 +778,8 @@ demo chain0 updates delay = do
                         (\ChainSync1 ->
                             Mx.MuxPeer
                               nullTracer
-                              (ChainSync.codecChainSync encode decode encode decode)
+                              (ChainSync.codecChainSync encode (const decode)
+                                                        encode        decode)
                               (consumerPeer))
 
         producerPeer :: Peer (ChainSync.ChainSync block (Point block)) AsServer ChainSync.StIdle m ()
@@ -787,7 +788,8 @@ demo chain0 updates delay = do
                         (\ChainSync1 ->
                             Mx.MuxPeer
                               nullTracer
-                              (ChainSync.codecChainSync encode decode encode decode)
+                              (ChainSync.codecChainSync encode (const decode)
+                                                        encode        decode)
                               producerPeer)
 
     clientAsync <- startMuxSTM consumerApp client_w client_r sduLen Nothing

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -102,7 +102,7 @@ demo chain0 updates = do
         consumerApp = Mx.simpleMuxInitiatorApplication $
           \Mxt.ChainSync1 ->
             Mx.MuxPeer nullTracer
-                       (ChainSync.codecChainSync encode decode encode decode)
+                       codec
                        (ChainSync.chainSyncClientPeer
                           (ChainSync.chainSyncClientExample consumerVar
                             (consumerClient done target consumerVar)))
@@ -111,9 +111,12 @@ demo chain0 updates = do
         producerApp = Mx.simpleMuxResponderApplication $
           \Mxt.ChainSync1 ->
             Mx.MuxPeer nullTracer
-                       (ChainSync.codecChainSync encode decode encode decode)
+                       codec
                        (ChainSync.chainSyncServerPeer
                          (ChainSync.chainSyncServerExample () producerVar))
+
+        codec = ChainSync.codecChainSync encode (const decode)
+                                         encode        decode
 
     _ <- async $ runNetworkNodeWithPipe producerApp hndRead1 hndWrite2
     _ <- async $ runNetworkNodeWithPipe consumerApp hndRead2 hndWrite1

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -302,7 +302,7 @@ demo chain0 updates = do
         initiatorApp = simpleMuxInitiatorApplication $
           \Mxt.ChainSync1 ->
               MuxPeer nullTracer
-                      (ChainSync.codecChainSync encode decode encode decode)
+                      codecChainSync
                       (ChainSync.chainSyncClientPeer
                         (ChainSync.chainSyncClientExample consumerVar
                         (consumerClient done target consumerVar)))
@@ -311,8 +311,11 @@ demo chain0 updates = do
         responderApp = simpleMuxResponderApplication $
           \Mxt.ChainSync1 ->
             MuxPeer nullTracer
-                    (ChainSync.codecChainSync encode decode encode decode)
+                    codecChainSync
                     (ChainSync.chainSyncServerPeer (ChainSync.chainSyncServerExample () producerVar))
+
+        codecChainSync = ChainSync.codecChainSync encode (const decode)
+                                         encode        decode
 
     withSimpleServerNode
       producerAddress


### PR DESCRIPTION
Adjust the chain sync and block fetch codec formats slightly. Put the header and block types into a CBOR bytestring wrapper. This has a number of advantages:

* It makes it straightforward to pass on the data without decoding it, or delay decodoing.
* It allows a single CDDL spec, for many instantiations to different header and block types.
* It allows decoders access to the raw input bytes, without any further wrapper. This is needed for decoding the cardano-ledger headers and blocks where we need to annotate with the original bytes for verification purposes.
* This has to be done anyway for cardano-ledger, which is a change in CBOR schema. This just centralises that so the schema can be specified in one place.