### PR TITLE
Automatically pass tracer and policy to the fetch clients

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchClient.hs
@@ -8,22 +8,13 @@ module Ouroboros.Consensus.BlockFetchClient
   , blockFetchClient
   ) where
 
-import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTime
-import           Control.Tracer
-
 import           Network.TypedProtocol.Pipelined (PeerPipelined)
 import           Ouroboros.Network.Codec
 
-import           Ouroboros.Network.Block
-import qualified Ouroboros.Network.BlockFetch.Client as BlockFetchClient
-import           Ouroboros.Network.BlockFetch.ClientState
-                   ( FetchClientContext(..), FetchClientPolicy (..) )
+import           Ouroboros.Network.BlockFetch.Client
+                   (blockFetchClient, FetchClientContext)
 import           Ouroboros.Network.Protocol.BlockFetch.Type
-                     (BlockFetch (BFIdle))
-
-import           Ouroboros.Consensus.Util.Condense
+                   (BlockFetch (BFIdle))
 
 -- | The block fetch layer doesn't provide a readable type for the client yet,
 -- so define it ourselves for now.
@@ -31,33 +22,3 @@ type BlockFetchClient hdr blk m a =
   FetchClientContext hdr blk m ->
   PeerPipelined (BlockFetch hdr blk) AsClient BFIdle m a
 
--- | Block fetch client based on
--- 'Ouroboros.Network.BlockFetch.Examples.mockedBlockFetchClient1', but using
--- the 'ChainDB' (through the 'BlockFetchConsensusInterface').
-blockFetchClient
-    :: forall m up hdr blk.
-       (MonadSTM m, MonadTime m, MonadThrow m,
-        HasHeader blk, HasHeader hdr, HeaderHash hdr ~ HeaderHash blk,
-        Condense blk)
-    => Tracer m String
-    -> up -> BlockFetchClient hdr blk m ()
-blockFetchClient tracer _up clientCtx =
-   -- TODO trace and use @up@ in the output.
-    BlockFetchClient.blockFetchClient
-      clientCtx { fetchClientCtxPolicy = policy' }
-  where
-    -- TODO: The existing behaviour has been preserved here, but it doesn't
-    -- make much sense any more. What it is doing is adding a trace point onto
-    -- the call to the ChainDB.addBlock within the client policy, but is doing
-    -- it here rather than where the top level policy is set (where the actual
-    -- call to ChainDB.addBlock is).
-    --
-    -- Alternatively, the existing TraceFetchClientState tracer could be used
-    -- instead, since that already covers the download trace event.
-    --
-    policy     = fetchClientCtxPolicy clientCtx
-    policy'    = policy
-      { addFetchedBlock = \pt blk -> do
-          addFetchedBlock policy pt blk
-          traceWith tracer $ "Downloaded block: " <> condense blk
-      }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchClient.hs
@@ -17,11 +17,9 @@ import           Network.TypedProtocol.Pipelined (PeerPipelined)
 import           Ouroboros.Network.Codec
 
 import           Ouroboros.Network.Block
-import           Ouroboros.Network.BlockFetch
-                     (BlockFetchConsensusInterface (..))
-import           Ouroboros.Network.BlockFetch.Client (FetchClientPolicy (..))
 import qualified Ouroboros.Network.BlockFetch.Client as BlockFetchClient
-import           Ouroboros.Network.BlockFetch.ClientState (FetchClientStateVars)
+import           Ouroboros.Network.BlockFetch.ClientState
+                   ( FetchClientContext(..), FetchClientPolicy (..) )
 import           Ouroboros.Network.Protocol.BlockFetch.Type
                      (BlockFetch (BFIdle))
 
@@ -30,7 +28,7 @@ import           Ouroboros.Consensus.Util.Condense
 -- | The block fetch layer doesn't provide a readable type for the client yet,
 -- so define it ourselves for now.
 type BlockFetchClient hdr blk m a =
-  FetchClientStateVars m hdr ->
+  FetchClientContext hdr blk m ->
   PeerPipelined (BlockFetch hdr blk) AsClient BFIdle m a
 
 -- | Block fetch client based on
@@ -42,24 +40,24 @@ blockFetchClient
         HasHeader blk, HasHeader hdr, HeaderHash hdr ~ HeaderHash blk,
         Condense blk)
     => Tracer m String
-    -> BlockFetchConsensusInterface up hdr blk m
     -> up -> BlockFetchClient hdr blk m ()
-blockFetchClient tracer blockFetchInterface _up clientStateVars =
+blockFetchClient tracer _up clientCtx =
    -- TODO trace and use @up@ in the output.
     BlockFetchClient.blockFetchClient
-        nullTracer
-        policy
-        clientStateVars
+      clientCtx { fetchClientCtxPolicy = policy' }
   where
-    BlockFetchConsensusInterface
-      { blockFetchSize, blockMatchesHeader, addFetchedBlock } =
-        blockFetchInterface
-    -- TODO #468 the block fetch layer will eventually use the fields from the
-    -- 'BlockFetchConsensusInterface' to make a 'FetchClientPolicy'. So long
-    -- as this isn't done yet, let's do it ourselves.
-    policy = FetchClientPolicy
-      { blockFetchSize, blockMatchesHeader,
-        addFetchedBlock = \pt blk -> do
-          addFetchedBlock pt blk
+    -- TODO: The existing behaviour has been preserved here, but it doesn't
+    -- make much sense any more. What it is doing is adding a trace point onto
+    -- the call to the ChainDB.addBlock within the client policy, but is doing
+    -- it here rather than where the top level policy is set (where the actual
+    -- call to ChainDB.addBlock is).
+    --
+    -- Alternatively, the existing TraceFetchClientState tracer could be used
+    -- instead, since that already covers the download trace event.
+    --
+    policy     = fetchClientCtxPolicy clientCtx
+    policy'    = policy
+      { addFetchedBlock = \pt blk -> do
+          addFetchedBlock policy pt blk
           traceWith tracer $ "Downloaded block: " <> condense blk
       }

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE DeriveFunctor              #-}
 
 module Ouroboros.Network.BlockFetch.State (
     fetchLogicIterations,
@@ -39,6 +38,7 @@ import           Ouroboros.Network.BlockFetch.ClientState
                    , addNewFetchRequest
                    , readFetchClientState
                    , TraceFetchClientState(..)
+                   , TraceLabelPeer(..)
                    )
 import           Ouroboros.Network.BlockFetch.Decision
                    ( fetchDecisions
@@ -50,13 +50,6 @@ import           Ouroboros.Network.BlockFetch.Decision
                    )
 import           Ouroboros.Network.BlockFetch.DeltaQ
                    ( PeerGSV(..) )
-
-
--- | A peer label for use in 'Tracer's. This annotates tracer output as being
--- associated with a given peer identifier.
---
-data TraceLabelPeer peerid a = TraceLabelPeer peerid a
-  deriving (Eq, Functor, Show)
 
 
 fetchLogicIterations


### PR DESCRIPTION
The block fetch policy, and state tracer are passed into the top level block fetch logic, but some of the places these are needed are in the block fetch client code. Previously the block fetch client had to have these things passed in manually, duplicating what was already passed to the top level logic thread.

With this patch, these things are communicated automatically via the fetch client registry.

The consensus code is updated, and its tracer behaviour is adjusted in the second patch.

This fixes issue #468