### PR TITLE
Add NodeConfig to `blockPayload`

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -219,7 +219,7 @@ class (HasHeader b) => HasPreHeader b where
 -- blocks can be defined to have payloads for multiple protocols. This is
 -- important for protocol combinators.
 class HasPreHeader b => HasPayload p b where
-  blockPayload :: proxy p -> b -> Payload p (PreHeader b)
+  blockPayload :: NodeConfig p -> b -> Payload p (PreHeader b)
 
 {-------------------------------------------------------------------------------
   Chain selection

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -21,11 +21,10 @@ module Ouroboros.Consensus.Protocol.BFT (
   , Payload(..)
   ) where
 
-import           Codec.Serialise (Serialise(..))
+import           Codec.Serialise (Serialise (..))
 import           Control.Monad.Except
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Proxy
 import           Data.Typeable (Typeable)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
@@ -105,11 +104,11 @@ instance BftCrypto c => OuroborosTag (Bft c) where
     where
       BftParams{..}  = bftParams
 
-  applyChainState toEnc BftNodeConfig{..} _l b _cs = do
+  applyChainState toEnc cfg@BftNodeConfig{..} _l b _cs = do
       -- TODO: Should deal with unknown node IDs
       if verifySignedDSIGN toEnc (bftVerKeys Map.! expectedLeader)
                       (blockPreHeader b)
-                      (bftSignature (blockPayload (Proxy @(Bft c)) b))
+                      (bftSignature (blockPayload cfg b))
         then return ()
         else throwError BftInvalidSignature
     where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -23,13 +23,12 @@ module Ouroboros.Consensus.Protocol.PBFT (
   , Payload(..)
   ) where
 
-import           Codec.Serialise (Serialise(..))
-import qualified Codec.Serialise.Encoding as Enc
+import           Codec.Serialise (Serialise (..))
 import qualified Codec.Serialise.Decoding as Dec
+import qualified Codec.Serialise.Encoding as Enc
 import           Control.Monad.Except
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Proxy
 import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import           Data.Tuple (swap)
@@ -157,7 +156,7 @@ instance (PBftCrypto c, Typeable c) => OuroborosTag (PBft c) where
     where
       PBftParams{..}  = pbftParams
 
-  applyChainState toEnc PBftNodeConfig{..} (PBftLedgerView dms) b (signers, lastSlot) = do
+  applyChainState toEnc cfg@PBftNodeConfig{..} (PBftLedgerView dms) b (signers, lastSlot) = do
       -- Check that the issuer signature verifies, and that it's a delegate of a
       -- genesis key, and that genesis key hasn't voted too many times.
 
@@ -179,7 +178,7 @@ instance (PBftCrypto c, Typeable c) => OuroborosTag (PBft c) where
           return (signers', blockSlot b)
     where
       PBftParams{..}  = pbftParams
-      payload = blockPayload (Proxy @(PBft c)) b
+      payload = blockPayload cfg b
       winSize = fromIntegral pbftSignatureWindow
       wt = floor $ pbftSignatureThreshold * fromIntegral winSize
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -25,10 +25,10 @@ module Ouroboros.Consensus.Protocol.Praos (
   , Payload(..)
   ) where
 
-import           Codec.Serialise (Serialise(..))
-import qualified Codec.Serialise.Encoding as Enc
-import qualified Codec.Serialise.Decoding as Dec
 import           Codec.CBOR.Encoding (Encoding, encodeListLen)
+import           Codec.Serialise (Serialise (..))
+import qualified Codec.Serialise.Decoding as Dec
+import qualified Codec.Serialise.Encoding as Enc
 import           Control.Monad (unless)
 import           Control.Monad.Except (throwError)
 import           Data.IntMap.Strict (IntMap)
@@ -191,7 +191,7 @@ instance (Serialise (PraosExtraFields c), PraosCrypto c) => OuroborosTag (Praos 
               else Nothing
 
   applyChainState toEnc cfg@PraosNodeConfig{..} sd b cs = do
-    let PraosPayload{..} = blockPayload (Proxy :: Proxy (Praos c)) b
+    let PraosPayload{..} = blockPayload cfg b
         ph               = blockPreHeader b
         slot             = blockSlot b
         CoreNodeId nid   = praosCreator praosExtraFields


### PR DESCRIPTION
This can be ignored almost everywhere (though it may potentially be useful, as
it may provide access to stuff like protocol magic or what have you). It's
needed to to fix a bug in the chain sync client, which was assuming every block
was signed by the same node. This bug doesn't get caught on master since we
don't have proper validation in the chain sync client yet, but _is_ caught in
the ledger integration branch (it's the last failing test there).