### PR TITLE
Refactor runPeer

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -48,6 +48,7 @@ library
                        Ouroboros.Network.BlockFetch.State
                        Ouroboros.Network.ChainFragment
                        Ouroboros.Network.DeltaQ
+                       Ouroboros.Network.Driver
                        Ouroboros.Network.NodeToNode
                        Ouroboros.Network.NodeToClient
                        Ouroboros.Network.Point
@@ -157,6 +158,7 @@ test-suite tests
                        Ouroboros.Network.Chain
                        Ouroboros.Network.ChainFragment
                        Ouroboros.Network.ChainProducerState
+                       Ouroboros.Network.Driver
                        Ouroboros.Network.DeltaQ
                        Ouroboros.Network.Node
                        Ouroboros.Network.NodeToNode
@@ -206,6 +208,7 @@ test-suite tests
                        Test.ChainGenerators
                        Test.ChainFragment
                        Test.ChainProducerState
+                       Test.Driver
                        Test.Ouroboros.Network.Testing.Utils
                        Test.Ouroboros.Network.BlockFetch
                        Test.Ouroboros.Network.Node

--- a/ouroboros-network/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Socket.hs
@@ -50,8 +50,6 @@ import qualified Network.Socket as Socket hiding (recv)
 
 import           Control.Tracer (nullTracer)
 
-import           Network.TypedProtocol.Driver.ByteLimit
-
 import qualified Network.Mux as Mx
 import qualified Network.Mux.Types as Mx
 import           Network.Mux.Types (MuxBearer)
@@ -61,6 +59,8 @@ import qualified Network.Mux.Bearer.Socket as Mx
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.Protocol.Handshake.Codec
+import           Ouroboros.Network.Driver
+
 import qualified Ouroboros.Network.Server.Socket as Server
 
 

--- a/ouroboros-network/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Socket.hs
@@ -239,8 +239,7 @@ connectToNode' encodeData decodeData peeridFn versions sd = do
     bearer <- Mx.socketAsMuxBearer sd
     Mx.muxBearerSetState bearer Mx.Connected
     mapp <- runPeerWithByteLimit
-              maxTransmissionUnit
-              BL.length
+              (ByteLimit maxTransmissionUnit BL.length)
               nullTracer
               codecHandshake
               peerid
@@ -319,8 +318,7 @@ beginConnection encodeData decodeData acceptVersion fn addr st = do
         (bearer :: MuxBearer ptcl IO) <- Mx.socketAsMuxBearer sd
         Mx.muxBearerSetState bearer Mx.Connected
         mapp <- runPeerWithByteLimit
-                maxTransmissionUnit
-                BL.length
+                (ByteLimit maxTransmissionUnit BL.length)
                 nullTracer
                 codecHandshake
                 peerid

--- a/ouroboros-network/test/Test/Driver.hs
+++ b/ouroboros-network/test/Test/Driver.hs
@@ -1,0 +1,208 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module Test.Driver where
+
+import           Control.Monad (replicateM)
+import           Data.Int (Int64)
+import           Data.Functor (void)
+
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.IOSim
+import           Control.Tracer (nullTracer)
+
+import           Network.TypedProtocol.Core
+import           Network.TypedProtocol.Codec
+import           Network.TypedProtocol.Channel
+import           Network.TypedProtocol.Driver
+import           Network.TypedProtocol.Pipelined
+import           Network.TypedProtocol.ReqResp.Type
+import           Network.TypedProtocol.ReqResp.Codec
+import           Network.TypedProtocol.ReqResp.Client
+import           Network.TypedProtocol.ReqResp.Server
+import           Network.TypedProtocol.ReqResp.Examples
+
+import           Ouroboros.Network.Driver
+
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests =
+  testGroup "Ouroboros.Network.Driver"
+  [ testProperty "runPeerWithByteLimit ST"
+                                       prop_runPeerWithByteLimit_ST
+  , testProperty "runPeerWithByteLimit IO"
+                                       prop_runPeerWithByteLimit_IO
+  , testProperty "runPipelinedPeerWithByteLimit ST"
+                                       prop_runPipelinedPeerWithByteLimit_ST
+  , testProperty "runPipelinedPeerWithByteLimit IO"
+                                       prop_runPipelinedPeerWithByteLimit_IO
+  ]
+
+--
+-- runPeerWithByteLimit properties
+--
+
+-- |
+-- Run the server peer using @runPeerWithByteLimit@, which will receive requests
+-- with the given payloads.
+--
+prop_runPeerWithByteLimit
+  :: forall m. (MonadSTM m, MonadAsync m, MonadCatch m)
+  => Int64
+  -- ^ byte limit
+  -> [String]
+  -- ^ request payloads
+  -> m Bool
+prop_runPeerWithByteLimit limit reqPayloads = do
+      (c1, c2) <- createConnectedChannels
+
+      res <- try $
+        runPeerWithByteLimit (ByteLimit limit (fromIntegral . length)) nullTracer codecReqResp "receiver" c1 recvPeer
+          `concurrently`
+        void (runPeer nullTracer codecReqResp "sender" c2 sendPeer)
+
+      case res :: Either (DecoderFailureOrTooMuchInput CodecFailure) ([String], ()) of
+        Right _           -> pure $ not shouldFail
+        Left TooMuchInput -> pure $ shouldFail
+        Left _            -> pure $ False
+
+    where
+      sendPeer :: Peer (ReqResp String ()) AsClient StIdle m [()]
+      sendPeer = reqRespClientPeer $ reqRespClientMap reqPayloads
+
+      recvPeer :: Peer (ReqResp String ()) AsServer StIdle m [String]
+      recvPeer = reqRespServerPeer $ reqRespServerMapAccumL
+        (\acc req -> pure (req:acc, ()))
+        []
+
+      encoded :: [String]
+      encoded =
+        -- add @MsgDone@ which is always sent
+        (encode (codecReqResp @String @() @m) (ClientAgency TokIdle) MsgDone)
+        : map (encode (codecReqResp @String @() @m) (ClientAgency TokIdle) . MsgReq) reqPayloads
+
+      shouldFail :: Bool
+      shouldFail = any (> limit) $ map (fromIntegral . length) encoded
+
+data ReqRespPayloadWithLimit = ReqRespPayloadWithLimit Int64 String
+  deriving Show
+
+instance Arbitrary ReqRespPayloadWithLimit where
+    arbitrary = do
+      -- @MsgDone@ is encoded with 8 characters
+      limit <- (+7) . getSmall . getPositive <$> arbitrary
+      len <- frequency
+        -- close to the limit
+        [ (2, choose (max 0 (limit - 5), limit + 5))
+        -- below the limit
+        , (2, choose (0, limit))
+        -- above the limit
+        , (2, choose (limit, 10 * limit))
+        -- right at the limit
+        , (1, choose (limit, limit))
+        ]
+      ReqRespPayloadWithLimit limit <$> replicateM (fromIntegral len) arbitrary
+
+    shrink (ReqRespPayloadWithLimit l p) =
+      [ ReqRespPayloadWithLimit l' p
+      | l' <- shrink l
+      ]
+      ++
+      [ ReqRespPayloadWithLimit l p'
+      | p' <- shrink p
+      ]
+
+-- TODO: This test could be improved: it will not test the case in which
+-- @runDecoderWithByteLimit@ receives trailing bytes.
+--
+prop_runPeerWithByteLimit_ST
+  :: ReqRespPayloadWithLimit
+  -> Property
+prop_runPeerWithByteLimit_ST (ReqRespPayloadWithLimit limit payload) =
+      tabulate "Limit Boundaries" (labelExamples limit payload) $
+        runSimOrThrow (prop_runPeerWithByteLimit limit [payload])
+    where
+      labelExamples :: Int64 -> String -> [String]
+      labelExamples l p =
+        [ case length p `compare` fromIntegral l of
+            LT -> "BelowTheLimit"
+            EQ -> "AtTheLimit"
+            GT -> "AboveTheLimit"
+        ]
+        ++
+          if abs (length p - fromIntegral l) <= 5
+            then ["CloseToTheLimit"]
+            else []
+
+prop_runPeerWithByteLimit_IO
+  :: ReqRespPayloadWithLimit
+  -> Property
+prop_runPeerWithByteLimit_IO (ReqRespPayloadWithLimit limit payload) =
+  ioProperty (prop_runPeerWithByteLimit limit [payload])
+
+
+-- |
+-- Run the client peer using @runPipelinedPeerWithByteLimit@, which will receive
+-- requests with the given payloads (the server echoes the requests to the
+-- client).
+--
+prop_runPipelinedPeerWithByteLimit
+  :: forall m. (MonadSTM m, MonadAsync m, MonadCatch m)
+  => Int64
+  -- ^ byte limit
+  -> [String]
+  -- ^ request payloads
+  -> m Bool
+prop_runPipelinedPeerWithByteLimit limit reqPayloads = do
+      (c1, c2) <- createConnectedChannels
+
+      res <- try $
+        runPeer nullTracer codecReqResp "receiver" c1 recvPeer
+          `concurrently`
+        runPipelinedPeerWithByteLimit (ByteLimit limit (fromIntegral . length)) nullTracer codecReqResp "sender" c2 sendPeer
+
+      case res :: Either (DecoderFailureOrTooMuchInput CodecFailure) ((), [String]) of
+        Right _           -> pure $ not shouldFail
+        Left TooMuchInput -> pure $ shouldFail
+        Left _            -> pure $ False
+
+    where
+      sendPeer :: PeerPipelined (ReqResp String String) AsClient StIdle m [String]
+      sendPeer = reqRespClientPeerPipelined $ reqRespClientMapPipelined reqPayloads
+
+      recvPeer :: Peer (ReqResp String String) AsServer StIdle m ()
+      recvPeer = reqRespServerPeer $ reqRespServerMapAccumL
+        (\acc req -> pure (acc, req))
+        ()
+
+      encoded :: [String]
+      encoded =
+        map (encode (codecReqResp @String @String @m) (ServerAgency TokBusy) . MsgResp) reqPayloads
+
+      shouldFail :: Bool
+      shouldFail = any (> limit) $ map (fromIntegral . length) encoded
+
+
+prop_runPipelinedPeerWithByteLimit_ST
+  :: ReqRespPayloadWithLimit
+  -> Bool
+prop_runPipelinedPeerWithByteLimit_ST (ReqRespPayloadWithLimit limit payload) =
+      runSimOrThrow (prop_runPipelinedPeerWithByteLimit limit [payload])
+
+
+prop_runPipelinedPeerWithByteLimit_IO
+  :: ReqRespPayloadWithLimit
+  -> Property
+prop_runPipelinedPeerWithByteLimit_IO (ReqRespPayloadWithLimit limit payload) =
+      ioProperty (prop_runPipelinedPeerWithByteLimit limit [payload])
+

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -476,7 +476,6 @@ runDecoderWithChannel Channel{recv} = go
     go Nothing         (DecodePartial k) = recv >>= k        >>= go Nothing
     go (Just trailing) (DecodePartial k) = k (Just trailing) >>= go Nothing
 
-
 -- | Run two 'Peer's via a pair of connected 'Channel's and a common 'Codec'.
 --
 -- This is useful for tests and quick experiments.

--- a/typed-protocols/src/Network/TypedProtocol/Driver/ByteLimit.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver/ByteLimit.hs
@@ -9,6 +9,7 @@ module Network.TypedProtocol.Driver.ByteLimit
   ( runPeerWithByteLimit
   , ByteLimit (..)
   , DecoderFailureOrTooMuchInput (..)
+  , runDecoderWithByteLimit
   ) where
 
 import           Control.Exception

--- a/typed-protocols/src/Network/TypedProtocol/Driver/ByteLimit.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver/ByteLimit.hs
@@ -1,3 +1,4 @@
+
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE NamedFieldPuns      #-}
@@ -6,6 +7,7 @@
 
 module Network.TypedProtocol.Driver.ByteLimit
   ( runPeerWithByteLimit
+  , ByteLimit (..)
   , DecoderFailureOrTooMuchInput (..)
   ) where
 
@@ -13,7 +15,7 @@ import           Control.Exception
 import           Data.Int (Int64)
 
 import           Control.Monad.Class.MonadThrow (MonadThrow (..))
-import           Control.Tracer (Tracer, traceWith)
+import           Control.Tracer (Tracer)
 
 
 import           Network.TypedProtocol.Core
@@ -21,6 +23,11 @@ import           Network.TypedProtocol.Codec
 import           Network.TypedProtocol.Channel
 import           Network.TypedProtocol.Driver
 
+
+data ByteLimit bytes = ByteLimit {
+      byteLimit  :: !Int64,
+      byteLength :: !(bytes -> Int64)
+    }
 
 data DecoderFailureOrTooMuchInput failure
   = DecoderFailure !failure
@@ -31,15 +38,12 @@ instance Exception failure => Exception (DecoderFailureOrTooMuchInput failure)
 
 runDecoderWithByteLimit
     :: forall m bytes failure a. Monad m
-    => Int64
-    -- ^ message size limit
-    -> (bytes -> Int64)
-    -- ^ byte size
+    => ByteLimit bytes
     -> Channel m bytes
     -> Maybe bytes
     -> DecodeStep bytes failure m a
     -> m (Either (DecoderFailureOrTooMuchInput failure) (a, Maybe bytes))
-runDecoderWithByteLimit limit byteLength Channel{recv} mbytes = go 0 mbytes
+runDecoderWithByteLimit ByteLimit {byteLimit, byteLength} Channel{recv} mbytes = go 0 mbytes
     where
       go :: Int64
          -- ^ length of consumed input
@@ -47,10 +51,10 @@ runDecoderWithByteLimit limit byteLength Channel{recv} mbytes = go 0 mbytes
          -> DecodeStep bytes failure m a
          -> m (Either (DecoderFailureOrTooMuchInput failure) (a, Maybe bytes))
       -- we decoded the data, but we might be over the limit
-      go !l _  (DecodeDone x trailing) | l - maybe 0 byteLength trailing > limit = return (Left TooMuchInput)
+      go !l _  (DecodeDone x trailing) | l - maybe 0 byteLength trailing > byteLimit = return (Left TooMuchInput)
                                        | otherwise                       = return (Right (x, trailing))
       -- we run over the limit, return @TooMuchInput@ error
-      go !l _  _                       | l > limit = return (Left TooMuchInput)
+      go !l _  _                       | l > byteLimit = return (Left TooMuchInput)
       go !_ _  (DecodeFail failure)    = return (Left (DecoderFailure failure))
 
       go !l Nothing         (DecodePartial k) =
@@ -59,7 +63,6 @@ runDecoderWithByteLimit limit byteLength Channel{recv} mbytes = go 0 mbytes
       go !l (Just trailing) (DecodePartial k) =
         k (Just trailing) >>= go (l + byteLength trailing) Nothing
 
-
 -- |
 -- Like @'runPeer'@, but require that each inbound message is smaller than
 -- @limit@ bytes; if the limit is exceeded throw @'TooMuchInput'@ exception.
@@ -67,10 +70,7 @@ runDecoderWithByteLimit limit byteLength Channel{recv} mbytes = go 0 mbytes
 runPeerWithByteLimit
   :: forall ps (st :: ps) pr bytes peerid failure m a .
      (MonadThrow m, Exception failure)
-  => Int64
-  -- ^ message size limit
-  -> (bytes -> Int64)
-  -- ^ byte size
+  => ByteLimit bytes
   -> Tracer m (TraceSendRecv ps peerid (DecoderFailureOrTooMuchInput failure))
   -> Codec ps failure m bytes
   -> peerid
@@ -78,28 +78,5 @@ runPeerWithByteLimit
   -> Peer ps pr st m a
   -> m a
 
-runPeerWithByteLimit limit byteLength tr Codec{encode, decode} peerid channel@Channel{send} =
-    go Nothing
-  where
-    go :: forall st'.
-          Maybe bytes
-       -> Peer ps pr st' m a
-       -> m a
-    go trailing (Effect k) = k >>= go trailing
-    go _        (Done _ x) = return x
-
-    go trailing (Yield stok msg k) = do
-      traceWith tr (TraceSendMsg peerid (AnyMessage msg))
-      send (encode stok msg)
-      go trailing k
-
-    go trailing (Await stok k) = do
-      decoder <- decode stok
-      res <- runDecoderWithByteLimit limit byteLength channel trailing decoder
-      case res of
-        Right (SomeMessage msg, trailing') -> do
-          traceWith tr (TraceRecvMsg peerid (AnyMessage msg))
-          go trailing' (k msg)
-        Left failure -> do
-          traceWith tr (TraceDecoderFailure peerid stok failure)
-          throwM failure
+runPeerWithByteLimit limit tr codec peerid channel =
+  runPeerWith tr codec peerid channel (\_stok -> runDecoderWithByteLimit limit)

--- a/typed-protocols/src/Network/TypedProtocol/ReqResp/Tests.hs
+++ b/typed-protocols/src/Network/TypedProtocol/ReqResp/Tests.hs
@@ -11,6 +11,7 @@ module Network.TypedProtocol.ReqResp.Tests (tests) where
 
 import Network.TypedProtocol.Core
 import Network.TypedProtocol.Codec
+import Network.TypedProtocol.Pipelined
 import Network.TypedProtocol.Proofs
 import Network.TypedProtocol.Channel
 import Network.TypedProtocol.Driver
@@ -63,6 +64,10 @@ tests = testGroup "Network.TypedProtocol.ReqResp"
                                        prop_runPeerWithByteLimit_ST
   , testProperty "runPeerWithByteLimit IO"
                                        prop_runPeerWithByteLimit_IO
+  , testProperty "runPipelinedPeerWithByteLimit ST"
+                                       prop_runPipelinedPeerWithByteLimit_ST
+  , testProperty "runPipelinedPeerWithByteLimit IO"
+                                       prop_runPipelinedPeerWithByteLimit_IO
   ]
 
 
@@ -282,6 +287,63 @@ prop_runPeerWithByteLimit_IO
   -> Property
 prop_runPeerWithByteLimit_IO (ReqRespPayloadWithLimit limit payload) =
   ioProperty (prop_runPeerWithByteLimit limit [payload])
+
+
+-- |
+-- Run the client peer using @runPipelinedPeerWithByteLimit@, which will receive
+-- requests with the given payloads (the server echoes the requests to the
+-- client).
+--
+prop_runPipelinedPeerWithByteLimit
+  :: forall m. (MonadSTM m, MonadAsync m, MonadCatch m)
+  => Int64
+  -- ^ byte limit
+  -> [String]
+  -- ^ request payloads
+  -> m Bool
+prop_runPipelinedPeerWithByteLimit limit reqPayloads = do
+      (c1, c2) <- createConnectedChannels
+
+      res <- try $
+        runPeer nullTracer codecReqResp "receiver" c1 recvPeer
+          `concurrently`
+        runPipelinedPeerWith nullTracer codecReqResp "sender" c2 (\_ -> runDecoderWithByteLimit (ByteLimit limit (fromIntegral . length))) sendPeer
+
+      case res :: Either (DecoderFailureOrTooMuchInput CodecFailure) ((), [String]) of
+        Right _           -> pure $ not shouldFail
+        Left TooMuchInput -> pure $ shouldFail
+        Left _            -> pure $ False
+
+    where
+      sendPeer :: PeerPipelined (ReqResp String String) AsClient StIdle m [String]
+      sendPeer = reqRespClientPeerPipelined $ reqRespClientMapPipelined reqPayloads
+
+      recvPeer :: Peer (ReqResp String String) AsServer StIdle m ()
+      recvPeer = reqRespServerPeer $ reqRespServerMapAccumL
+        (\acc req -> pure (acc, req))
+        ()
+
+      encoded :: [String]
+      encoded =
+        map (encode (codecReqResp @String @String @m) (ServerAgency TokBusy) . MsgResp) reqPayloads
+
+      shouldFail :: Bool
+      shouldFail = any (> limit) $ map (fromIntegral . length) encoded
+
+
+prop_runPipelinedPeerWithByteLimit_ST
+  :: ReqRespPayloadWithLimit
+  -> Bool
+prop_runPipelinedPeerWithByteLimit_ST (ReqRespPayloadWithLimit limit payload) =
+      runSimOrThrow (prop_runPipelinedPeerWithByteLimit limit [payload])
+
+
+prop_runPipelinedPeerWithByteLimit_IO
+  :: ReqRespPayloadWithLimit
+  -> Property
+prop_runPipelinedPeerWithByteLimit_IO (ReqRespPayloadWithLimit limit payload) =
+      ioProperty (prop_runPipelinedPeerWithByteLimit limit [payload])
+
 
 --
 -- Codec properties

--- a/typed-protocols/src/Network/TypedProtocol/ReqResp/Tests.hs
+++ b/typed-protocols/src/Network/TypedProtocol/ReqResp/Tests.hs
@@ -200,7 +200,7 @@ prop_runPeerWithByteLimit limit reqPayloads = do
       (c1, c2) <- createConnectedChannels
 
       res <- try $
-        runPeerWithByteLimit limit (fromIntegral . length) nullTracer codecReqResp "receiver" c1 recvPeer
+        runPeerWithByteLimit (ByteLimit limit (fromIntegral . length)) nullTracer codecReqResp "receiver" c1 recvPeer
           `concurrently`
         void (runPeer nullTracer codecReqResp "sender" c2 sendPeer)
 

--- a/typed-protocols/src/Network/TypedProtocol/ReqResp/Tests.hs
+++ b/typed-protocols/src/Network/TypedProtocol/ReqResp/Tests.hs
@@ -11,11 +11,9 @@ module Network.TypedProtocol.ReqResp.Tests (tests) where
 
 import Network.TypedProtocol.Core
 import Network.TypedProtocol.Codec
-import Network.TypedProtocol.Pipelined
 import Network.TypedProtocol.Proofs
 import Network.TypedProtocol.Channel
 import Network.TypedProtocol.Driver
-import Network.TypedProtocol.Driver.ByteLimit
 
 import Network.TypedProtocol.ReqResp.Type
 import Network.TypedProtocol.ReqResp.Client
@@ -29,8 +27,6 @@ import Control.Monad.Class.MonadThrow
 import Control.Monad.IOSim (runSimOrThrow)
 import Control.Tracer (nullTracer)
 
-import Control.Monad (replicateM, void)
-import Data.Int (Int64)
 import Data.Functor.Identity (Identity (..))
 import Data.Tuple (swap)
 import Data.List (mapAccumL)
@@ -60,14 +56,6 @@ tests = testGroup "Network.TypedProtocol.ReqResp"
   , testProperty "codec 3-splits"      (withMaxSuccess 33
                                        prop_codec_splits3_ReqResp)
 
-  , testProperty "runPeerWithByteLimit ST"
-                                       prop_runPeerWithByteLimit_ST
-  , testProperty "runPeerWithByteLimit IO"
-                                       prop_runPeerWithByteLimit_IO
-  , testProperty "runPipelinedPeerWithByteLimit ST"
-                                       prop_runPipelinedPeerWithByteLimit_ST
-  , testProperty "runPipelinedPeerWithByteLimit IO"
-                                       prop_runPipelinedPeerWithByteLimit_IO
   ]
 
 
@@ -183,166 +171,6 @@ prop_channel_IO f xs =
 prop_channel_ST :: (Int -> Int -> (Int, Int)) -> [Int] -> Bool
 prop_channel_ST f xs =
     runSimOrThrow (prop_channel f xs)
-
-
---
--- runPeerWithByteLimit properties
---
-
-
--- |
--- Run the server peer using @runPeerWithByteLimit@, which will receive requests
--- with the given payloads.
---
-prop_runPeerWithByteLimit
-  :: forall m. (MonadSTM m, MonadAsync m, MonadCatch m)
-  => Int64
-  -- ^ byte limit
-  -> [String]
-  -- ^ request payloads
-  -> m Bool
-prop_runPeerWithByteLimit limit reqPayloads = do
-      (c1, c2) <- createConnectedChannels
-
-      res <- try $
-        runPeerWithByteLimit (ByteLimit limit (fromIntegral . length)) nullTracer codecReqResp "receiver" c1 recvPeer
-          `concurrently`
-        void (runPeer nullTracer codecReqResp "sender" c2 sendPeer)
-
-      case res :: Either (DecoderFailureOrTooMuchInput CodecFailure) ([String], ()) of
-        Right _           -> pure $ not shouldFail
-        Left TooMuchInput -> pure $ shouldFail
-        Left _            -> pure $ False
-
-    where
-      sendPeer :: Peer (ReqResp String ()) AsClient StIdle m [()]
-      sendPeer = reqRespClientPeer $ reqRespClientMap reqPayloads
-
-      recvPeer :: Peer (ReqResp String ()) AsServer StIdle m [String]
-      recvPeer = reqRespServerPeer $ reqRespServerMapAccumL
-        (\acc req -> pure (req:acc, ()))
-        []
-
-      encoded :: [String]
-      encoded =
-        -- add @MsgDone@ which is always sent
-        (encode (codecReqResp @String @() @m) (ClientAgency TokIdle) MsgDone)
-        : map (encode (codecReqResp @String @() @m) (ClientAgency TokIdle) . MsgReq) reqPayloads
-
-      shouldFail :: Bool
-      shouldFail = any (> limit) $ map (fromIntegral . length) encoded
-
-data ReqRespPayloadWithLimit = ReqRespPayloadWithLimit Int64 String
-  deriving Show
-
-instance Arbitrary ReqRespPayloadWithLimit where
-    arbitrary = do
-      -- @MsgDone@ is encoded with 8 characters
-      limit <- (+7) . getSmall . getPositive <$> arbitrary
-      len <- frequency
-        -- close to the limit
-        [ (2, choose (max 0 (limit - 5), limit + 5))
-        -- below the limit
-        , (2, choose (0, limit))
-        -- above the limit
-        , (2, choose (limit, 10 * limit))
-        -- right at the limit
-        , (1, choose (limit, limit))
-        ]
-      ReqRespPayloadWithLimit limit <$> replicateM (fromIntegral len) arbitrary
-
-    shrink (ReqRespPayloadWithLimit l p) =
-      [ ReqRespPayloadWithLimit l' p
-      | l' <- shrink l
-      ]
-      ++
-      [ ReqRespPayloadWithLimit l p'
-      | p' <- shrink p
-      ]
-
--- TODO: This test could be improved: it will not test the case in which
--- @runDecoderWithByteLimit@ receives trailing bytes.
---
-prop_runPeerWithByteLimit_ST
-  :: ReqRespPayloadWithLimit
-  -> Property
-prop_runPeerWithByteLimit_ST (ReqRespPayloadWithLimit limit payload) =
-      tabulate "Limit Boundaries" (labelExamples limit payload) $
-        runSimOrThrow (prop_runPeerWithByteLimit limit [payload])
-    where
-      labelExamples :: Int64 -> String -> [String]
-      labelExamples l p =
-        [ case length p `compare` fromIntegral l of
-            LT -> "BelowTheLimit"
-            EQ -> "AtTheLimit"
-            GT -> "AboveTheLimit"
-        ]
-        ++
-          if abs (length p - fromIntegral l) <= 5
-            then ["CloseToTheLimit"]
-            else []
-
-prop_runPeerWithByteLimit_IO
-  :: ReqRespPayloadWithLimit
-  -> Property
-prop_runPeerWithByteLimit_IO (ReqRespPayloadWithLimit limit payload) =
-  ioProperty (prop_runPeerWithByteLimit limit [payload])
-
-
--- |
--- Run the client peer using @runPipelinedPeerWithByteLimit@, which will receive
--- requests with the given payloads (the server echoes the requests to the
--- client).
---
-prop_runPipelinedPeerWithByteLimit
-  :: forall m. (MonadSTM m, MonadAsync m, MonadCatch m)
-  => Int64
-  -- ^ byte limit
-  -> [String]
-  -- ^ request payloads
-  -> m Bool
-prop_runPipelinedPeerWithByteLimit limit reqPayloads = do
-      (c1, c2) <- createConnectedChannels
-
-      res <- try $
-        runPeer nullTracer codecReqResp "receiver" c1 recvPeer
-          `concurrently`
-        runPipelinedPeerWith nullTracer codecReqResp "sender" c2 (\_ -> runDecoderWithByteLimit (ByteLimit limit (fromIntegral . length))) sendPeer
-
-      case res :: Either (DecoderFailureOrTooMuchInput CodecFailure) ((), [String]) of
-        Right _           -> pure $ not shouldFail
-        Left TooMuchInput -> pure $ shouldFail
-        Left _            -> pure $ False
-
-    where
-      sendPeer :: PeerPipelined (ReqResp String String) AsClient StIdle m [String]
-      sendPeer = reqRespClientPeerPipelined $ reqRespClientMapPipelined reqPayloads
-
-      recvPeer :: Peer (ReqResp String String) AsServer StIdle m ()
-      recvPeer = reqRespServerPeer $ reqRespServerMapAccumL
-        (\acc req -> pure (acc, req))
-        ()
-
-      encoded :: [String]
-      encoded =
-        map (encode (codecReqResp @String @String @m) (ServerAgency TokBusy) . MsgResp) reqPayloads
-
-      shouldFail :: Bool
-      shouldFail = any (> limit) $ map (fromIntegral . length) encoded
-
-
-prop_runPipelinedPeerWithByteLimit_ST
-  :: ReqRespPayloadWithLimit
-  -> Bool
-prop_runPipelinedPeerWithByteLimit_ST (ReqRespPayloadWithLimit limit payload) =
-      runSimOrThrow (prop_runPipelinedPeerWithByteLimit limit [payload])
-
-
-prop_runPipelinedPeerWithByteLimit_IO
-  :: ReqRespPayloadWithLimit
-  -> Property
-prop_runPipelinedPeerWithByteLimit_IO (ReqRespPayloadWithLimit limit payload) =
-      ioProperty (prop_runPipelinedPeerWithByteLimit limit [payload])
 
 
 --

--- a/typed-protocols/typed-protocols.cabal
+++ b/typed-protocols/typed-protocols.cabal
@@ -23,7 +23,6 @@ library
                    , Network.TypedProtocol.Channel
                    , Network.TypedProtocol.Codec
                    , Network.TypedProtocol.Driver
-                   , Network.TypedProtocol.Driver.ByteLimit
                    , Network.TypedProtocol.Proofs
 
                    , Network.TypedProtocol.PingPong.Type
@@ -63,7 +62,6 @@ test-suite tests
                    , Network.TypedProtocol.Codec
                    , Network.TypedProtocol.Core
                    , Network.TypedProtocol.Driver
-                   , Network.TypedProtocol.Driver.ByteLimit
                    , Network.TypedProtocol.PingPong.Client
                    , Network.TypedProtocol.PingPong.Codec
                    , Network.TypedProtocol.PingPong.Examples

--- a/typed-protocols/typed-protocols.cabal
+++ b/typed-protocols/typed-protocols.cabal
@@ -29,6 +29,7 @@ library
                    , Network.TypedProtocol.PingPong.Client
                    , Network.TypedProtocol.PingPong.Server
                    , Network.TypedProtocol.PingPong.Codec
+                   , Network.TypedProtocol.PingPong.Examples
 
                    , Network.TypedProtocol.ReqResp.Type
                    , Network.TypedProtocol.ReqResp.Client


### PR DESCRIPTION
The requested refactoring of `runPeer`.  There is now `driver` function which takes a callback which drives recieving of bytes and decoding; 

The `runDecoderWithChannel` can handle both cases: with and without byte limits.  Timeouts are not yet implemented, but it will be easy to add either a separate `runDecoderWithChannel` function or generalise it.