### PR TITLE
doc: Make network.pdf a Hydra build product

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -35,6 +35,10 @@ stdenv.mkDerivation {
      cd doc
      latexmk -view=pdf network;
   '';
-  installPhase = "install -Dt $out network.pdf";
+  installPhase = ''
+    install -Dt $out network.pdf
+    mkdir $out/nix-support
+    echo "doc-pdf $out/network.pdf" >> $out/nix-support/hydra-build-products
+  '';
 }
 


### PR DESCRIPTION
This change will make a link to `network.pdf` in Hydra.
