### PR TITLE
Eliminate unnecessary type arguments for BlockFetch

### DIFF
--- a/byron-proxy/cabal.project
+++ b/byron-proxy/cabal.project
@@ -18,14 +18,29 @@ source-repository-package
   tag: cbe7ab32354f3838dc8c95c64109904c8f503347
   subdir: contra-tracer
 
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-shell
+  tag: 70944ad492aa49661ccf269434bf05a513cf4451
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-sl-x509
+  tag: e8bfc1294e088f90e5ae0b4aedbc82ee46ac5ee4
+
+source-repository-package
+  type: git
+  location: https://github.com/joelwilliamson/bimap
+  tag: 997fbb38b08dec14d225d064dac05b0a85f4ceae
+
 --
 -- from cardano-crypto-1.2.0.nix
 --
 
 source-repository-package
   type: git
-  location: https://github.com/avieth/cardano-crypto
-  tag: 784dbd11f213af58d70f1306399d941eb222abf8
+  location: https://github.com/input-output-hk/cardano-crypto
+  tag: 3c707936ba0a665375acf5bd240dc4b6eaa6c0bc
 
 --
 -- from cardano-report-server-0.5.10.nix
@@ -34,7 +49,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-report-server.git
-  tag: 9b96874d0f234554a5779d98762cc0a6773a532a
+  tag: 93f2246c54436e7f98cc363b4e0f8f1cb5e78717
 
 --
 -- from rocksdb-haskell-ng-0.0.0.nix
@@ -69,8 +84,8 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/avieth/haskell-hedgehog.git
-  tag: d965a9002b16b82a548da4c071b0eb0af8ed7838
+  location: https://github.com/hedgehogqa/haskell-hedgehog
+  tag: 2505055760d06ba6343f803783ed023fb0ed6c48
   subdir: hedgehog
 
 --
@@ -79,8 +94,8 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/avieth/network-transport
-  tag: 0b8f5a7bec389a4ffa653792cfd203c742a0857b
+  location: https://github.com/serokell/network-transport
+  tag: 018a50b9042c2115c3ec9c9fd5ca5f28737dd29c
 
 --
 -- from network-transport-tcp-HEAD.nix
@@ -89,7 +104,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/avieth/network-transport-tcp
-  tag: da5e1544ead1d1b70ca4b7a54fc5f02b1a9a98c9
+  tag: 2634e5e32178bb0456d800d133f8664321daa2ef
 
 --
 -- from kademlia-HEAD.nix
@@ -192,25 +207,25 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 2f33cbf9101dfee1cb488271ec96e210329eec96
+  tag: b676160954cea07d4378ccca870a61242bc188a2
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 595cfb5b20863fca869550423a4e27aab8e68aed
+  tag: 20afe954f847281665ada871c40943bf346f6cf5
   subdir: .
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 595cfb5b20863fca869550423a4e27aab8e68aed
+  tag: 20afe954f847281665ada871c40943bf346f6cf5
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: e1fb84b1a955b6e3e3e53d9022e8bc0f927417a2
+  tag: a136c4242b9c9f6124b811329bc8ccdfd86c514e
 
 source-repository-package
   type: git

--- a/cabal.project
+++ b/cabal.project
@@ -107,4 +107,6 @@ package contra-tracer
   tests: False
 
 constraints:
-  ip < 1.5
+  ip < 1.5,
+  ekg-prometheus-adapter >= 0.1.0.4,
+  hedgehog >= 1.0

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -124,7 +124,7 @@ data NodeKernel m up blk hdr = NodeKernel {
                        (Exception eCS, Exception eBF)
                     => up
                     -> NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
-                    -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
+                    -> NodeComms m (BlockFetch blk)            eBF bytesBF
                     -> m ()
 
       -- | Notify network layer of a new downstream node
@@ -134,7 +134,7 @@ data NodeKernel m up blk hdr = NodeKernel {
     , addDownstream :: forall eCS eBF bytesCS bytesBF.
                        (Exception eCS, Exception eBF)
                     => NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
-                    -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
+                    -> NodeComms m (BlockFetch blk)            eBF bytesBF
                     -> m ()
     }
 
@@ -305,7 +305,7 @@ initInternalState NodeParams {..} = do
           -- is passed to the blockFetchLogic.
           -- The message level tracer is passed to runPipelinedPeer.
 
-        nrBlockFetchServer :: BlockFetchServer hdr blk m ()
+        nrBlockFetchServer :: BlockFetchServer blk m ()
         nrBlockFetchServer =
           blockFetchServer (tracePrefix "BFServer" Nothing) chainDB
 
@@ -477,7 +477,7 @@ data NetworkRequires m up blk hdr = NetworkRequires {
     , nrBlockFetchClient    :: BlockFetchClient hdr blk m ()
 
       -- | Start a block fetch server server.
-    , nrBlockFetchServer    :: BlockFetchServer hdr blk m ()
+    , nrBlockFetchServer    :: BlockFetchServer blk m ()
 
       -- | The fetch client registry, used by the block fetch client.
     , nrFetchClientRegistry :: FetchClientRegistry up hdr blk m
@@ -506,7 +506,7 @@ data NetworkProvides m up blk hdr = NetworkProvides {
                       => up
                       -> NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
                          -- Communication for the Chain Sync protocol
-                      -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
+                      -> NodeComms m (BlockFetch blk) eBF bytesBF
                          -- Communication for the Block Fetch protocol
                       -> m ()
 
@@ -518,7 +518,7 @@ data NetworkProvides m up blk hdr = NetworkProvides {
                          (Exception eCS, Exception eBF)
                       => NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
                          -- Communication for the Chain Sync protocol
-                      -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
+                      -> NodeComms m (BlockFetch blk) eBF bytesBF
                          -- Communication for the Block Fetch protocol
                       -> m ()
     }
@@ -540,7 +540,7 @@ initNetworkLayer _tracer registry NetworkRequires{..} = NetworkProvides {..}
   where
     npAddDownstream :: (Exception eCS, Exception eBF)
                     => NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
-                    -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
+                    -> NodeComms m (BlockFetch blk)            eBF bytesBF
                     -> m ()
     npAddDownstream ncCS ncBF = do
       -- TODO use subregistry here?
@@ -556,7 +556,7 @@ initNetworkLayer _tracer registry NetworkRequires{..} = NetworkProvides {..}
     npAddUpstream :: (Exception eCS, Exception eBF)
                   => up
                   -> NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
-                  -> NodeComms m (BlockFetch hdr blk)        eBF bytesBF
+                  -> NodeComms m (BlockFetch blk)            eBF bytesBF
                   -> m ()
     npAddUpstream up ncCS ncBF = do
       -- TODO use subregistry here?

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -203,14 +203,14 @@ broadcastNetwork registry btime numCoreNodes pInfo initRNG numSlots = do
 type ChainSyncChannel m hdr = Channel m (AnyMessage (ChainSync hdr (Point hdr)))
 
 -- | Communication channel used for the Block Fetch protocol
-type BlockFetchChannel m blk hdr = Channel m (AnyMessage (BlockFetch hdr blk))
+type BlockFetchChannel m blk = Channel m (AnyMessage (BlockFetch blk))
 
 -- | The communication channels from and to each node
 data NodeChan m blk hdr = NodeChan
-  { chainSyncConsumer  :: ChainSyncChannel  m     hdr
-  , chainSyncProducer  :: ChainSyncChannel  m     hdr
-  , blockFetchConsumer :: BlockFetchChannel m blk hdr
-  , blockFetchProducer :: BlockFetchChannel m blk hdr
+  { chainSyncConsumer  :: ChainSyncChannel  m hdr
+  , chainSyncProducer  :: ChainSyncChannel  m hdr
+  , blockFetchConsumer :: BlockFetchChannel m blk
+  , blockFetchProducer :: BlockFetchChannel m blk
   }
 
 -- | All connections between all nodes

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Client.hs
@@ -16,51 +16,51 @@ import           Ouroboros.Network.Protocol.BlockFetch.Type
 -- | Block fetch client type for requesting ranges of blocks and handling
 -- responses.
 --
-newtype BlockFetchClient header block m a = BlockFetchClient {
-    runBlockFetchClient :: m (BlockFetchRequest header block m a)
+newtype BlockFetchClient block m a = BlockFetchClient {
+    runBlockFetchClient :: m (BlockFetchRequest block m a)
   }
 
-data BlockFetchRequest header block m a where
+data BlockFetchRequest block m a where
   -- | Request a chain range, supply handler for incoming blocks and
   -- a continuation.
   --
   SendMsgRequestRange
-    :: ChainRange header
-    -> BlockFetchResponse header block m a
-    -> BlockFetchClient   header block m a
-    -> BlockFetchRequest  header block m a
+    :: ChainRange block
+    -> BlockFetchResponse block m a
+    -> BlockFetchClient   block m a
+    -> BlockFetchRequest  block m a
 
   -- | Client terminating the block-fetch protocol.
   SendMsgClientDone
     :: a
-    -> BlockFetchRequest header block m a
+    -> BlockFetchRequest block m a
 
-data BlockFetchResponse header block m a = BlockFetchResponse {
-    handleStartBatch :: m (BlockFetchReceiver header block m),
+data BlockFetchResponse block m a = BlockFetchResponse {
+    handleStartBatch :: m (BlockFetchReceiver block m),
     handleNoBlocks   :: m ()
   }
 
 -- | Block are streamed and block receiver will handle each one when it comes,
 -- it also needs to handle errors send back from the server.
 --
-data BlockFetchReceiver header block m = BlockFetchReceiver {
-    handleBlock      :: block -> m (BlockFetchReceiver header block m),
+data BlockFetchReceiver block m = BlockFetchReceiver {
+    handleBlock      :: block -> m (BlockFetchReceiver block m),
     handleBatchDone  :: m ()
   }
 
 blockFetchClientPeer
-  :: forall header body m a.
-     ( StandardHash header
+  :: forall block m a.
+     ( StandardHash block
      , Monad m
      )
-  => BlockFetchClient header body m a
-  -> Peer (BlockFetch header body) AsClient BFIdle m a
+  => BlockFetchClient block m a
+  -> Peer (BlockFetch block) AsClient BFIdle m a
 blockFetchClientPeer (BlockFetchClient mclient) =
   Effect $ blockFetchRequestPeer <$> mclient
  where
   blockFetchRequestPeer
-    :: BlockFetchRequest header body m a
-    -> Peer (BlockFetch header body) AsClient BFIdle m a
+    :: BlockFetchRequest block m a
+    -> Peer (BlockFetch block) AsClient BFIdle m a
 
   blockFetchRequestPeer (SendMsgClientDone result) =
     Yield (ClientAgency TokIdle) MsgClientDone (Done TokDone result)
@@ -73,22 +73,22 @@ blockFetchClientPeer (BlockFetchClient mclient) =
 
 
   blockFetchResponsePeer
-    :: BlockFetchClient header body m a
-    -> BlockFetchResponse header body m a
-    -> Peer (BlockFetch header body) AsClient BFBusy m a
+    :: BlockFetchClient block m a
+    -> BlockFetchResponse block m a
+    -> Peer (BlockFetch block) AsClient BFBusy m a
   blockFetchResponsePeer next BlockFetchResponse{handleNoBlocks, handleStartBatch} =
     Await (ServerAgency TokBusy) $ \msg -> case msg of
       MsgStartBatch -> Effect $ blockReceiver next <$> handleStartBatch
       MsgNoBlocks   -> Effect $ handleNoBlocks >> (blockFetchRequestPeer <$> runBlockFetchClient next)
 
   blockReceiver
-    :: BlockFetchClient header body m a
-    -> BlockFetchReceiver header body m
-    -> Peer (BlockFetch header body) AsClient BFStreaming m a
+    :: BlockFetchClient block m a
+    -> BlockFetchReceiver block m
+    -> Peer (BlockFetch block) AsClient BFStreaming m a
   blockReceiver next BlockFetchReceiver{handleBlock, handleBatchDone} =
     Await (ServerAgency TokStreaming) $ \msg -> case msg of
-      MsgBlock body -> Effect $ blockReceiver next <$> handleBlock body
-      MsgBatchDone  -> Effect $ do
+      MsgBlock block -> Effect $ blockReceiver next <$> handleBlock block
+      MsgBatchDone   -> Effect $ do
         handleBatchDone
         blockFetchRequestPeer <$> runBlockFetchClient next
 
@@ -98,53 +98,53 @@ blockFetchClientPeer (BlockFetchClient mclient) =
 
 -- | A BlockFetch client designed for running the protcol in a pipelined way.
 --
-data BlockFetchClientPipelined header body m a where
+data BlockFetchClientPipelined block m a where
    -- | A 'BlockFetchSender', but starting with zero outstanding pipelined
    -- responses, and for any internal collect type @c@.
    BlockFetchClientPipelined
-     :: BlockFetchSender      Z c header body m a
-     -> BlockFetchClientPipelined header body m a
+     :: BlockFetchSender      Z c block m a
+     -> BlockFetchClientPipelined block m a
 
 -- | A 'BlockFetchSender' with @n@ outstanding stream of block bodies.
 --
-data BlockFetchSender n c header body m a where
+data BlockFetchSender n c block m a where
 
   -- | Send a `MsgRequestRange` but do not wait for response.  Supply a monadic
-  -- action which runs on each received body and which updates the internal
+  -- action which runs on each received block and which updates the internal
   -- received value @c@.  @c@ could be a Monoid, though it's more genral this
   -- way.
   --
   SendMsgRequestRangePipelined
-    :: ChainRange header
+    :: ChainRange block
     -> c
-    -> (Maybe body -> c -> m c)
-    -> BlockFetchSender (S n) c header body m a
-    -> BlockFetchSender    n  c header body m a
+    -> (Maybe block -> c -> m c)
+    -> BlockFetchSender (S n) c block m a
+    -> BlockFetchSender    n  c block m a
 
   -- | Collect the result of a previous pipelined receive action
   --
   CollectBlocksPipelined
-    :: Maybe (BlockFetchSender (S n) c header body m a)
-    -> (c ->  BlockFetchSender    n  c header body m a)
-    ->        BlockFetchSender (S n) c header body m a
+    :: Maybe (BlockFetchSender (S n) c block m a)
+    -> (c ->  BlockFetchSender    n  c block m a)
+    ->        BlockFetchSender (S n) c block m a
 
   -- | Termination of the block-fetch protocol.
   SendMsgDonePipelined
-    :: a -> BlockFetchSender Z c header body m a
+    :: a -> BlockFetchSender Z c block m a
 
 blockFetchClientPeerPipelined
-  :: forall header body m a.
+  :: forall block m a.
      Monad m
-  => BlockFetchClientPipelined header body m a
-  -> PeerPipelined (BlockFetch header body) AsClient BFIdle m a
+  => BlockFetchClientPipelined block m a
+  -> PeerPipelined (BlockFetch block) AsClient BFIdle m a
 blockFetchClientPeerPipelined (BlockFetchClientPipelined sender) =
   PeerPipelined (blockFetchClientPeerSender sender)
 
 blockFetchClientPeerSender
-  :: forall n header body c m a.
+  :: forall n block c m a.
      Monad m
-  => BlockFetchSender n c header body m a
-  -> PeerSender (BlockFetch header body) AsClient BFIdle n c m a
+  => BlockFetchSender n c block m a
+  -> PeerSender (BlockFetch block) AsClient BFIdle n c m a
 
 blockFetchClientPeerSender (SendMsgDonePipelined result) =
   -- Send `MsgClientDone` and complete the protocol
@@ -166,11 +166,11 @@ blockFetchClientPeerSender (SendMsgRequestRangePipelined range c0 receive next) 
  where
   receiveBlocks
     :: c
-    -> PeerReceiver (BlockFetch header body) AsClient BFStreaming BFIdle m c
+    -> PeerReceiver (BlockFetch block) AsClient BFStreaming BFIdle m c
   receiveBlocks c = ReceiverAwait (ServerAgency TokStreaming) $ \msg -> case msg of
     -- received a block, run an acction and compute the result
-    MsgBlock body -> ReceiverEffect $ do
-      c' <- receive (Just body) c
+    MsgBlock block -> ReceiverEffect $ do
+      c' <- receive (Just block) c
       return $ receiveBlocks c'
     MsgBatchDone  -> ReceiverDone c
 

--- a/ouroboros-network/test/Test/ChainFragment.hs
+++ b/ouroboros-network/test/Test/ChainFragment.hs
@@ -33,7 +33,8 @@ import           Ouroboros.Network.Testing.Serialise (prop_serialise)
 import           Test.Chain ()
 import           Test.ChainGenerators
                    ( TestBlockChain (..), TestChainAndRange (..)
-                   , addSlotGap, genNonNegative, genSlotGap, mkPartialBlock)
+                   , genNonNegative, genChainAnchor, mkPartialBlock
+                   , addSlotGap, genSlotGap)
 
 
 --
@@ -445,22 +446,6 @@ prop_shrink_TestBlockChainFragment c =
 prop_shrink_TestHeaderChainFragment :: TestHeaderChainFragment -> Bool
 prop_shrink_TestHeaderChainFragment c =
     and [ CF.valid c' | TestHeaderChainFragment c' <- shrink c ]
-
-
--- | A starting point for a chain fragment: either the 'genesisAnchor' or
--- an arbitrary point.
---
-genChainAnchor :: Gen (ChainHash Block, BlockNo, SlotNo)
-genChainAnchor = oneof [ pure genesisAnchor, genArbitraryChainAnchor ]
-
-genArbitraryChainAnchor :: Gen (ChainHash Block, BlockNo, SlotNo)
-genArbitraryChainAnchor =
-    (,,) <$> (BlockHash <$> arbitrary)
-         <*> arbitrary
-         <*> arbitrary
-
-genesisAnchor :: (ChainHash b, BlockNo, SlotNo)
-genesisAnchor = (GenesisHash, BlockNo 0, SlotNo 0)
 
 
 -- | The Ouroboros K paramater. This is also the maximum rollback length.

--- a/ouroboros-network/test/Test/ChainGenerators.hs
+++ b/ouroboros-network/test/Test/ChainGenerators.hs
@@ -124,7 +124,7 @@ instance Arbitrary (Point Block) where
          . shrink
          .     (castPoint :: Point Block -> Point BlockHeader)
 
-instance Arbitrary (ChainRange BlockHeader) where
+instance Arbitrary (ChainRange Block) where
   arbitrary = do
     low  <- arbitrary
     high <- arbitrary `suchThat` (\high -> pointSlot low <= pointSlot high)

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -160,7 +160,7 @@ data Example1TraceEvent =
    | TraceFetchClientState    (TraceLabelPeer Int
                                 (TraceFetchClientState BlockHeader))
    | TraceFetchClientSendRecv (TraceLabelPeer Int
-                                (TraceSendRecv (BlockFetch BlockHeader Block)))
+                                (TraceSendRecv (BlockFetch Block)))
 
 instance Show Example1TraceEvent where
   show (TraceFetchDecision       x) = "TraceFetchDecision " ++ show x

--- a/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
@@ -47,7 +47,6 @@ import           Ouroboros.Network.Testing.ConcreteBlock as ConcreteBlock
 import           Test.ChainGenerators
                   ( TestBlockChain (..)
                   , genNonNegative
-                  , genHeaderChain
                   )
 
 
@@ -447,13 +446,6 @@ genConnectedBidirectionalGraph = do
   g <- arbitraryAcyclicGraphSmall
   let g' = accum (++) g (assocs $ transposeG g)
   connectGraphG g'
-
--- | Generate a non-empty chain starting with this block header.
-genNonEmptyHeaderChain :: BlockHeader -> Gen (NonEmpty BlockHeader)
-genNonEmptyHeaderChain genesis = do
-  n <- genNonNegative
-  chain <- reverse . chainToList <$> genHeaderChain n
-  pure $ genesis NE.:| chain
 
 
 --

--- a/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Node.hs
@@ -16,8 +16,6 @@ import           Data.Fixed (Micro)
 import           Data.Functor (void)
 import           Data.Graph
 import           Data.List (foldl')
-import           Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (isNothing, listToMaybe)
@@ -38,16 +36,13 @@ import qualified Control.Monad.IOSim as Sim
 
 import           Ouroboros.Network.Time (microsecondsToDiffTime)
 import           Ouroboros.Network.Block
-import           Ouroboros.Network.Chain (Chain (..), chainToList)
+import           Ouroboros.Network.Chain (Chain (..))
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState (ChainProducerState (..))
 import           Ouroboros.Network.Node
 import           Ouroboros.Network.Testing.ConcreteBlock as ConcreteBlock
 
-import           Test.ChainGenerators
-                  ( TestBlockChain (..)
-                  , genNonNegative
-                  )
+import           Test.ChainGenerators (TestBlockChain (..))
 
 
 tests :: TestTree


### PR DESCRIPTION
Simplify BlockFetch type by eliminating header type arg

Previously we had `BlockFetch header block` but the `header` is in fact always just used for a `Point header`, which is really the same as a `Point block`, so the extra argument is unnecessary.

This type gets used in quite a few places, but it's a mechanical change everywhere.

This is a revised version of #559 without the change to `ChainSync` since that proved too disruptive.