### PR TITLE
Simplify ChainSync type by eliminating 'point' type arg

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -51,8 +51,8 @@ import           Ouroboros.Consensus.Util.SlotBounded as SB
 newtype ClockSkew = ClockSkew { unClockSkew :: Word64 }
   deriving (Eq, Ord, Enum, Bounded, Show, Num)
 
-type Consensus (client :: * -> * -> (* -> *) -> * -> *) hdr m =
-   client hdr (Point hdr) m Void
+type Consensus (client :: * -> (* -> *) -> * -> *) hdr m =
+   client hdr m Void
 
 data ChainSyncClientException hdr =
       -- | The header we received was for a slot too far in the future.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
@@ -32,11 +32,11 @@ chainSyncServer
        (MonadSTM m, HeaderHash hdr ~ HeaderHash blk)
     => Tracer m String
     -> ChainDB m blk hdr
-    -> ChainSyncServer hdr (Point hdr) m ()
+    -> ChainSyncServer hdr m ()
 chainSyncServer _tracer chainDB = ChainSyncServer $
     idle <$> ChainDB.newReader chainDB
   where
-    idle :: Reader m hdr -> ServerStIdle hdr (Point hdr) m ()
+    idle :: Reader m hdr -> ServerStIdle hdr m ()
     idle rdr =
       ServerStIdle {
         recvMsgRequestNext   = handleRequestNext rdr,
@@ -44,12 +44,12 @@ chainSyncServer _tracer chainDB = ChainSyncServer $
         recvMsgDoneClient    = return ()
       }
 
-    idle' :: Reader m hdr -> ChainSyncServer hdr (Point hdr) m ()
+    idle' :: Reader m hdr -> ChainSyncServer hdr m ()
     idle' = ChainSyncServer . return . idle
 
     handleRequestNext :: Reader m hdr
-                      -> m (Either (ServerStNext hdr (Point hdr) m ())
-                                (m (ServerStNext hdr (Point hdr) m ())))
+                      -> m (Either (ServerStNext hdr m ())
+                                (m (ServerStNext hdr m ())))
     handleRequestNext rdr = do
       mupdate <- ChainDB.readerInstruction rdr
       tip     <- atomically $ castPoint <$> ChainDB.getTipPoint chainDB
@@ -62,14 +62,14 @@ chainSyncServer _tracer chainDB = ChainSyncServer $
     sendNext :: Reader m hdr
              -> Point hdr
              -> ChainUpdate hdr
-             -> ServerStNext hdr (Point hdr) m ()
+             -> ServerStNext hdr m ()
     sendNext rdr tip update = case update of
       AddBlock hdr -> SendMsgRollForward  hdr tip (idle' rdr)
       RollBack pt  -> SendMsgRollBackward pt  tip (idle' rdr)
 
     handleFindIntersect :: Reader m hdr
                         -> [Point hdr]
-                        -> m (ServerStIntersect hdr (Point hdr) m ())
+                        -> m (ServerStIntersect hdr m ())
     handleFindIntersect rdr points = do
       -- TODO guard number of points
       changed <- ChainDB.readerForward rdr points

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -123,8 +123,8 @@ data NodeKernel m up blk hdr = NodeKernel {
     , addUpstream   :: forall eCS eBF bytesCS bytesBF.
                        (Exception eCS, Exception eBF)
                     => up
-                    -> NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
-                    -> NodeComms m (BlockFetch blk)            eBF bytesBF
+                    -> NodeComms m (ChainSync hdr)  eCS bytesCS
+                    -> NodeComms m (BlockFetch blk) eBF bytesBF
                     -> m ()
 
       -- | Notify network layer of a new downstream node
@@ -133,8 +133,8 @@ data NodeKernel m up blk hdr = NodeKernel {
       -- itself to register and deregister peers.
     , addDownstream :: forall eCS eBF bytesCS bytesBF.
                        (Exception eCS, Exception eBF)
-                    => NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
-                    -> NodeComms m (BlockFetch blk)            eBF bytesBF
+                    => NodeComms m (ChainSync hdr)  eCS bytesCS
+                    -> NodeComms m (BlockFetch blk) eBF bytesBF
                     -> m ()
     }
 
@@ -295,7 +295,7 @@ initInternalState NodeParams {..} = do
           varCandidates
           up
 
-        nrChainSyncServer :: ChainSyncServer hdr (Point hdr) m ()
+        nrChainSyncServer :: ChainSyncServer hdr m ()
         nrChainSyncServer =
           chainSyncServer (tracePrefix "CSServer" Nothing) chainDB
 
@@ -467,10 +467,10 @@ forkBlockProduction IS{..} =
 data NetworkRequires m up blk hdr = NetworkRequires {
       -- | Start a chain sync client that communicates with the given upstream
       -- node.
-      nrChainSyncClient     :: up -> ChainSyncClient hdr (Point hdr) m Void
+      nrChainSyncClient     :: up -> ChainSyncClient hdr m Void
 
       -- | Start a chain sync server.
-    , nrChainSyncServer     :: ChainSyncServer hdr (Point hdr) m ()
+    , nrChainSyncServer     :: ChainSyncServer hdr m ()
 
       -- | Start a block fetch client that communicates with the given
       -- upstream node.
@@ -504,7 +504,7 @@ data NetworkProvides m up blk hdr = NetworkProvides {
       npAddUpstream   :: forall eCS eBF bytesCS bytesBF.
                          (Exception eCS, Exception eBF)
                       => up
-                      -> NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
+                      -> NodeComms m (ChainSync hdr) eCS bytesCS
                          -- Communication for the Chain Sync protocol
                       -> NodeComms m (BlockFetch blk) eBF bytesBF
                          -- Communication for the Block Fetch protocol
@@ -516,7 +516,7 @@ data NetworkProvides m up blk hdr = NetworkProvides {
       -- itself to register and deregister peers.p
     , npAddDownstream :: forall eCS eBF bytesCS bytesBF.
                          (Exception eCS, Exception eBF)
-                      => NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
+                      => NodeComms m (ChainSync hdr) eCS bytesCS
                          -- Communication for the Chain Sync protocol
                       -> NodeComms m (BlockFetch blk) eBF bytesBF
                          -- Communication for the Block Fetch protocol
@@ -539,8 +539,8 @@ initNetworkLayer
 initNetworkLayer _tracer registry NetworkRequires{..} = NetworkProvides {..}
   where
     npAddDownstream :: (Exception eCS, Exception eBF)
-                    => NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
-                    -> NodeComms m (BlockFetch blk)            eBF bytesBF
+                    => NodeComms m (ChainSync hdr)  eCS bytesCS
+                    -> NodeComms m (BlockFetch blk) eBF bytesBF
                     -> m ()
     npAddDownstream ncCS ncBF = do
       -- TODO use subregistry here?
@@ -555,8 +555,8 @@ initNetworkLayer _tracer registry NetworkRequires{..} = NetworkProvides {..}
 
     npAddUpstream :: (Exception eCS, Exception eBF)
                   => up
-                  -> NodeComms m (ChainSync hdr (Point hdr)) eCS bytesCS
-                  -> NodeComms m (BlockFetch blk)            eBF bytesBF
+                  -> NodeComms m (ChainSync hdr)  eCS bytesCS
+                  -> NodeComms m (BlockFetch blk) eBF bytesBF
                   -> m ()
     npAddUpstream up ncCS ncBF = do
       -- TODO use subregistry here?

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -200,7 +200,7 @@ broadcastNetwork registry btime numCoreNodes pInfo initRNG numSlots = do
 -------------------------------------------------------------------------------}
 
 -- | Communication channel used for the Chain Sync protocol
-type ChainSyncChannel m hdr = Channel m (AnyMessage (ChainSync hdr (Point hdr)))
+type ChainSyncChannel m hdr = Channel m (AnyMessage (ChainSync hdr))
 
 -- | Communication channel used for the Block Fetch protocol
 type BlockFetchChannel m blk = Channel m (AnyMessage (BlockFetch blk))

--- a/ouroboros-network/src/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Node.hs
@@ -98,10 +98,10 @@ chainValidation peerChainVar candidateChainVar = do
 -- | Simulated network channels for a given network node.
 --
 data NodeChannels m block = NodeChannels
-  { consumerChans :: [Channel m (AnyMessage (ChainSync block (Point block)))]
+  { consumerChans :: [Channel m (AnyMessage (ChainSync block))]
     -- ^ channels on which the node will play the consumer role:
     -- sending @consMsg@ and receiving @prodMsg@ messages.
-  , producerChans :: [Channel m (AnyMessage (ChainSync block (Point block)))]
+  , producerChans :: [Channel m (AnyMessage (ChainSync block))]
     -- ^ channels on which the node will play the producer role:
     -- sending @prodMsg@ and receiving @consMsg@ messages.
   }
@@ -293,7 +293,7 @@ relayNode nid initChain chans = do
     -- state between producers than necessary (here are producers share chain
     -- state and all the reader states, while we could share just the chain).
     startConsumer :: Int
-                  -> Channel m (AnyMessage (ChainSync block (Point block)))
+                  -> Channel m (AnyMessage (ChainSync block))
                   -> m (TVar m (Chain block))
     startConsumer cid channel = do
       chainVar <- atomically $ newTVar Genesis
@@ -301,9 +301,9 @@ relayNode nid initChain chans = do
       void $ fork $ void $ runPeer nullTracer codecChainSyncId (loggingChannel (ConsumerId nid cid) channel) consumer
       return chainVar
 
-    startProducer :: Peer (ChainSync block (Point block)) AsServer StIdle m ()
+    startProducer :: Peer (ChainSync block) AsServer StIdle m ()
                   -> Int
-                  -> Channel m (AnyMessage (ChainSync block (Point block)))
+                  -> Channel m (AnyMessage (ChainSync block))
                   -> m ()
     startProducer producer pid channel =
       -- use 'void' because 'fork' only works with 'm ()'

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
@@ -10,8 +10,8 @@ import Ouroboros.Network.Protocol.ChainSync.Server as Server
 -- That's demonstrated here by constructing 'direct'.
 --
 direct :: Monad m
-       => ChainSyncServer header point m a
-       -> ChainSyncClient header point m b
+       => ChainSyncServer header m a
+       -> ChainSyncClient header m b
        -> m (a, b)
 direct (ChainSyncServer mserver) (ChainSyncClient mclient) = do
   server <- mserver
@@ -19,8 +19,8 @@ direct (ChainSyncServer mserver) (ChainSyncClient mclient) = do
   direct_ server client
 
 direct_ :: Monad m
-        => ServerStIdle header point m a
-        -> ClientStIdle header point m b
+        => ServerStIdle header m a
+        -> ClientStIdle header m b
         -> m (a, b)
 direct_  ServerStIdle{recvMsgRequestNext}
         (Client.SendMsgRequestNext stNext stAwait) = do

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -9,33 +9,43 @@
 -- Since we are using a typed protocol framework this is in some sense /the/
 -- definition of the protocol: what is allowed and what is not allowed.
 --
-module Ouroboros.Network.Protocol.ChainSync.Type where
+module Ouroboros.Network.Protocol.ChainSync.Type (
+    ChainSync(..),
+    Point,
+    StNextKind(..),
+    TokNextKind(..),
+    Message(..),
+    ClientHasAgency(..),
+    ServerHasAgency(..),
+    NobodyHasAgency(..),
+  ) where
 
 import Network.TypedProtocol.Core
+import Ouroboros.Network.Block (Point, StandardHash)
 
 
 -- | A kind to identify our protocol, and the types of the states in the state
 -- transition diagram of the protocol.
 --
-data ChainSync header point where
+data ChainSync header where
 
   -- | Both client and server are idle. The client can send a request and
   -- the server is waiting for a request.
-  StIdle      :: ChainSync header point
+  StIdle      :: ChainSync header
 
   -- | The client has sent a next update request. The client is now waiting
   -- for a response, and the server is busy getting ready to send a response.
   -- There are two possibilities here, since the server can send a reply
   -- immediately or it can send an initial await message followed later by
   -- the normal reply.
-  StNext      :: StNextKind -> ChainSync header point
+  StNext      :: StNextKind -> ChainSync header
 
   -- | The client has sent an intersection request. The client is now waiting
   -- for a response, and the server is busy getting ready to send a response.
-  StIntersect :: ChainSync header point
+  StIntersect :: ChainSync header
 
   -- | Both the client and server are in the terminal state. They're done.
-  StDone      :: ChainSync header point
+  StDone      :: ChainSync header
 
 -- | Sub-cases of the 'StNext' state. This is needed since the server can
 -- either send one reply back, or two.
@@ -47,42 +57,42 @@ data StNextKind where
   StMustReply :: StNextKind
 
 
-instance Protocol (ChainSync header point) where
+instance Protocol (ChainSync header) where
 
   -- | The messages in the chain sync protocol.
   --
   -- In this protocol the consumer always initiates things and the producer
   -- replies.
   --
-  data Message (ChainSync header point) from to where
+  data Message (ChainSync header) from to where
 
     -- | Request the next update from the producer. The response can be a roll
     -- forward, a roll back or wait.
     --
-    MsgRequestNext :: Message (ChainSync header point)
+    MsgRequestNext :: Message (ChainSync header)
                               StIdle (StNext StCanAwait)
 
     -- | Acknowledge the request but require the consumer to wait for the next
     -- update. This means that the consumer is synced with the producer, and
     -- the producer is waiting for its own chain state to change.
     --
-    MsgAwaitReply :: Message (ChainSync header point)
+    MsgAwaitReply :: Message (ChainSync header)
                              (StNext StCanAwait) (StNext StMustReply)
 
     -- | Tell the consumer to extend their chain with the given header.
     --
     -- The message also tells the consumer about the head point of the producer.
     --
-    MsgRollForward :: header -> point
-                   -> Message (ChainSync header point)
+    MsgRollForward :: header -> Point header
+                   -> Message (ChainSync header)
                               (StNext any) StIdle
 
     -- | Tell the consumer to roll back to a given point on their chain.
     --
     -- The message also tells the consumer about the head point of the producer.
     --
-    MsgRollBackward :: point -> point
-                    -> Message (ChainSync header point)
+    MsgRollBackward :: Point header -> Point header
+                    -> Message (ChainSync header)
                                (StNext any) StIdle
 
     -- | Ask the producer to try to find an improved intersection point between
@@ -90,8 +100,8 @@ instance Protocol (ChainSync header point) where
     -- points and it is up to the producer to find the first intersection point
     -- on its chain and send it back to the consumer.
     --
-    MsgFindIntersect :: [point]
-                     -> Message (ChainSync header point)
+    MsgFindIntersect :: [Point header]
+                     -> Message (ChainSync header)
                                 StIdle StIntersect
 
     -- | The reply to the consumer about an intersection found, but /only/ if this
@@ -100,8 +110,8 @@ instance Protocol (ChainSync header point) where
     --
     -- The message also tells the consumer about the head point of the producer.
     --
-    MsgIntersectImproved  :: point -> point
-                          -> Message (ChainSync header point)
+    MsgIntersectImproved  :: Point header -> Point header
+                          -> Message (ChainSync header)
                                      StIntersect StIdle
 
     -- | The reply to the consumer that no intersection was found: none of the
@@ -109,13 +119,13 @@ instance Protocol (ChainSync header point) where
     --
     -- The message also tells the consumer about the head point of the producer.
     --
-    MsgIntersectUnchanged :: point
-                          -> Message (ChainSync header point)
+    MsgIntersectUnchanged :: Point header
+                          -> Message (ChainSync header)
                                      StIntersect StIdle
 
     -- | Terminating messages
     --
-    MsgDone :: Message (ChainSync header point)
+    MsgDone :: Message (ChainSync header)
                        StIdle StDone
 
   -- | We have to explain to the framework what our states mean, in terms of
@@ -144,7 +154,8 @@ data TokNextKind (k :: StNextKind) where
   TokMustReply :: TokNextKind StMustReply
 
 
-instance (Show header, Show point) => Show (Message (ChainSync header point) from to) where
+instance (Show header, StandardHash header)
+      => Show (Message (ChainSync header) from to) where
   show MsgRequestNext               = "MsgRequestNext"
   show MsgAwaitReply                = "MsgAwaitReply"
   show (MsgRollForward h tip)       = "MsgRollForward " ++ show h ++ " " ++ show tip

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -770,7 +770,7 @@ demo chain0 updates delay = do
     let Just expectedChain = Chain.applyChainUpdates updates chain0
         target = Chain.headPoint expectedChain
 
-        consumerPeer :: Peer (ChainSync.ChainSync block (Point block)) AsClient ChainSync.StIdle m ()
+        consumerPeer :: Peer (ChainSync.ChainSync block) AsClient ChainSync.StIdle m ()
         consumerPeer = ChainSync.chainSyncClientPeer
                           (ChainSync.chainSyncClientExample consumerVar
                           (consumerClient done target consumerVar))
@@ -781,7 +781,7 @@ demo chain0 updates delay = do
                               (ChainSync.codecChainSync encode decode encode decode)
                               (consumerPeer))
 
-        producerPeer :: Peer (ChainSync.ChainSync block (Point block)) AsServer ChainSync.StIdle m ()
+        producerPeer :: Peer (ChainSync.ChainSync block) AsServer ChainSync.StIdle m ()
         producerPeer = ChainSync.chainSyncServerPeer (ChainSync.chainSyncServerExample () producerVar)
         producerApp = Mx.simpleMuxResponderApplication
                         (\ChainSync1 ->


### PR DESCRIPTION
Previously we had "ChainSync header point" but the point is in fact always a "Point header", so the extra argument is unnecessary.

This gets used quite a few places, but it's a mechanical change everywhere.

This should not be merged until we resolve the conflict with the byron proxy, or until we retire the byron proxy. See comments in this thread: https://github.com/input-output-hk/ouroboros-network/pull/559#issuecomment-496144486