### PR TITLE
make cddl test a required CI test

### DIFF
--- a/ouroboros-network/test/CDDL.hs
+++ b/ouroboros-network/test/CDDL.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
 module Main
 where
 
@@ -24,14 +25,14 @@ import Ouroboros.Network.Protocol.PingPong.Codec (codecPingPong)
 import Network.TypedProtocol.PingPong.Type as PingPong
 import Ouroboros.Network.Protocol.BlockFetch.Codec (codecBlockFetch)
 import Ouroboros.Network.Protocol.BlockFetch.Type as BlockFetch
-import Ouroboros.Network.Testing.ConcreteBlock
+import Ouroboros.Network.Block (HeaderHash)
 
 import Network.TypedProtocol.Codec
 
 -- the concrete types used for the test
 type CS = ChainSync DummyBytes DummyBytes
 type RR = ReqResp DummyBytes DummyBytes
-type BF = BlockFetch BlockHeader BlockBody
+type BF = BlockFetch DummyBytes
 
 main :: IO ()
 main = generateAndDecode "cddl" "diag2cbor.rb" "test/messages.cddl" 100
@@ -68,6 +69,7 @@ data DummyBytes = DummyBytes
 instance Serialise.Serialise DummyBytes where
     encode _ = error "encode Serialise DummyBytes"
     decode = decodeBytes >> return DummyBytes
+type instance HeaderHash DummyBytes = ()
 
 type MonoCodec x = Codec x Codec.CBOR.Read.DeserialiseFailure IO ByteString
 

--- a/ouroboros-network/test/messages.cddl
+++ b/ouroboros-network/test/messages.cddl
@@ -75,7 +75,7 @@ blockFetchMessage
      / msgStartBatch
      / msgNoBlocks
      / msgBlock
-     /msgBatchDone
+     / msgBatchDone
 
 msgRequestRange = [0, bfPoint, bfPoint]
 msgClientDone   = [1]
@@ -84,11 +84,13 @@ msgNoBlocks     = [3]
 msgBlock        = [4, bfBody]
 msgBatchDone    = [5]
 
-bfPoint           = [slotNo, chainHash]
+bfPoint         = [slotNo, chainHash]
 slotNo          = uint ; word64
-chainHash       = [0]  ; this is the representation of the GenesisHash
-
-bfBody         = tstr
+chainHash       = blockHash / genesisHash
+genesisHash     = []
+blockHash       = [dummyBlockHash]
+dummyBlockHash  = null
+bfBody          = bytes .cbor any
 
 
 ; Transaction Submission Protocol

--- a/release.nix
+++ b/release.nix
@@ -70,6 +70,7 @@ commonLib.pkgs.lib.mapAttrsRecursiveCond
     jobs.nix-tools.tests.ouroboros-consensus.test-crypto.x86_64-linux
     jobs.nix-tools.tests.ouroboros-consensus.test-storage.x86_64-linux
     jobs.nix-tools.tests.ouroboros-network.tests.x86_64-linux
+    jobs.nix-tools.tests.ouroboros-network.cddl.x86_64-linux
     jobs.nix-tools.tests.typed-protocols.tests.x86_64-linux
     jobs.nix-tools.tests.io-sim.tests.x86_64-linux
 


### PR DESCRIPTION
Make the CDDL tests a required CI test.
Update the CDDL tests to the latest version of BlockFetch.