### PR TITLE
ChainDB implementation

### DIFF
--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -97,6 +97,7 @@
             (hsPkgs.bytestring)
             (hsPkgs.cereal)
             (hsPkgs.containers)
+            (hsPkgs.contra-tracer)
             (hsPkgs.directory)
             (hsPkgs.fingertree)
             (hsPkgs.generics-sop)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -91,6 +91,18 @@ library
                        Ouroboros.Storage.Common
                        Ouroboros.Storage.ChainDB
                        Ouroboros.Storage.ChainDB.API
+                       Ouroboros.Storage.ChainDB.Impl
+                       Ouroboros.Storage.ChainDB.Impl.Args
+                       Ouroboros.Storage.ChainDB.Impl.Background
+                       Ouroboros.Storage.ChainDB.Impl.ChainSel
+                       Ouroboros.Storage.ChainDB.Impl.ImmDB
+                       Ouroboros.Storage.ChainDB.Impl.Iterator
+                       Ouroboros.Storage.ChainDB.Impl.LgrDB
+                       Ouroboros.Storage.ChainDB.Impl.Query
+                       Ouroboros.Storage.ChainDB.Impl.Reader
+                       Ouroboros.Storage.ChainDB.Impl.Reopen
+                       Ouroboros.Storage.ChainDB.Impl.Types
+                       Ouroboros.Storage.ChainDB.Impl.VolDB
                        Ouroboros.Storage.ChainDB.Mock
                        Ouroboros.Storage.ChainDB.Model
                        Ouroboros.Storage.EpochInfo
@@ -313,6 +325,7 @@ test-suite test-storage
                     bytestring,
                     cereal,
                     containers,
+                    contra-tracer,
                     directory,
                     fingertree,
                     generics-sop,

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -289,6 +289,7 @@ test-suite test-storage
                     Test.Ouroboros.Storage.ChainDB
                     Test.Ouroboros.Storage.ChainDB.Mock
                     Test.Ouroboros.Storage.ChainDB.Model
+                    Test.Ouroboros.Storage.ChainDB.StateMachine
                     Test.Ouroboros.Storage.ChainDB.TestBlock
                     Test.Ouroboros.Storage.FS
                     Test.Ouroboros.Storage.FS.Sim.Error

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -287,6 +287,7 @@ test-suite test-storage
   other-modules:
                     Test.Ouroboros.Storage
                     Test.Ouroboros.Storage.ChainDB
+                    Test.Ouroboros.Storage.ChainDB.AddBlock
                     Test.Ouroboros.Storage.ChainDB.Mock
                     Test.Ouroboros.Storage.ChainDB.Model
                     Test.Ouroboros.Storage.ChainDB.StateMachine

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -26,6 +26,7 @@ import           Ouroboros.Consensus.Util.SlotBounded (SlotBounded)
 class ( SupportedBlock blk
       , Show (LedgerState blk)
       , Show (LedgerError blk)
+      , Eq   (LedgerState blk)
       ) => UpdateLedger blk where
   data family LedgerState blk :: *
   type family LedgerError blk :: *

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE RankNTypes         #-}
-{-# LANGUAGE RecordWildCards    #-}
-{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Ledger.Extended (
     -- * Extended ledger state
@@ -45,6 +47,9 @@ data ExtValidationError blk =
 
 deriving instance ProtocolLedgerView blk => Show (ExtLedgerState     blk)
 deriving instance ProtocolLedgerView blk => Show (ExtValidationError blk)
+
+deriving instance (ProtocolLedgerView blk, Eq (ChainState (BlockProtocol blk)))
+               => Eq (ExtLedgerState blk)
 
 applyExtLedgerState :: ( UpdateLedger blk
                        , ProtocolLedgerView blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -207,7 +207,7 @@ instance (SimpleCrypto c, Typeable ext, SupportedBlock (SimpleBlock c ext))
   newtype LedgerState (SimpleBlock c ext) = SimpleLedgerState {
         simpleLedgerState :: MockState (SimpleBlock c ext)
       }
-    deriving (Show)
+    deriving (Show, Eq)
 
   data LedgerConfig (SimpleBlock c ext) =
       SimpleLedgerConfig

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Stake.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Stake.hs
@@ -39,7 +39,7 @@ data StakeHolder =
 -------------------------------------------------------------------------------}
 
 newtype StakeDist = StakeDist { stakeDistToIntMap :: IntMap Rational }
-  deriving (Show)
+  deriving (Show, Eq)
 
 stakeWithDefault :: Rational -> Int -> StakeDist -> Rational
 stakeWithDefault d n = IntMap.findWithDefault d n . stakeDistToIntMap

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/State.hs
@@ -34,7 +34,7 @@ data MockState blk = MockState {
     , mockConfirmed :: Set TxId
     , mockTip       :: Point blk
     }
-  deriving (Show)
+  deriving (Show, Eq)
 
 data MockError blk =
     MockInvalidInputs InvalidInputs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -167,6 +167,7 @@ data BlockInfo c = BlockInfo
     }
 
 deriving instance PraosCrypto c => Show (BlockInfo c)
+deriving instance PraosCrypto c => Eq   (BlockInfo c)
 
 {-------------------------------------------------------------------------------
   Protocol proper

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ThreadRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ThreadRegistry.hs
@@ -15,6 +15,10 @@ module Ouroboros.Consensus.Util.ThreadRegistry
   , forkNonTerminating
   , withSubregistry
   , ExceptionInForkedThread (..)
+
+    -- * For contexts where a scoped 'withThreadRegistry' doesn't work
+  , new
+  , cancelAll
   ) where
 
 import           Control.Exception (asyncExceptionFromException,

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB.hs
@@ -1,5 +1,7 @@
 module Ouroboros.Storage.ChainDB (
     module Ouroboros.Storage.ChainDB.API
+  , module Ouroboros.Storage.ChainDB.Impl
   ) where
 
 import           Ouroboros.Storage.ChainDB.API
+import           Ouroboros.Storage.ChainDB.Impl

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE GADTs               #-}
+{-# LANGUAGE PatternSynonyms     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE PatternSynonyms     #-}
 
 module Ouroboros.Storage.ChainDB.API (
     -- * Main ChainDB API
@@ -39,9 +39,9 @@ import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
-import           Ouroboros.Network.Block (ChainUpdate, HasHeader (..),
-                     HeaderHash, SlotNo, StandardHash, pattern GenesisPoint,
-                     pattern BlockPoint, atSlot)
+import           Ouroboros.Network.Block (pattern BlockPoint, ChainUpdate,
+                     pattern GenesisPoint, HasHeader (..), HeaderHash, SlotNo,
+                     StandardHash, atSlot)
 import           Ouroboros.Network.Chain (Chain (..), Point (..), genesisPoint)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState (ReaderId)
@@ -335,16 +335,16 @@ validBounds from to = case from of
     _                              -> True
 
   StreamFromInclusive (BlockPoint { atSlot = sfrom }) -> case to of
-    StreamToInclusive GenesisPoint                    -> False
-    StreamToExclusive GenesisPoint                    -> False
-    StreamToInclusive (BlockPoint { atSlot = sto })   -> sfrom <= sto
-    StreamToExclusive (BlockPoint { atSlot = sto })   -> sfrom <  sto
+    StreamToInclusive GenesisPoint                  -> False
+    StreamToExclusive GenesisPoint                  -> False
+    StreamToInclusive (BlockPoint { atSlot = sto }) -> sfrom <= sto
+    StreamToExclusive (BlockPoint { atSlot = sto }) -> sfrom <  sto
 
   StreamFromExclusive (BlockPoint { atSlot = sfrom }) -> case to of
-    StreamToInclusive GenesisPoint                    -> False
-    StreamToExclusive GenesisPoint                    -> False
-    StreamToInclusive (BlockPoint { atSlot = sto })   -> sfrom <= sto
-    StreamToExclusive (BlockPoint { atSlot = sto })   -> sfrom <  sto
+    StreamToInclusive GenesisPoint                  -> False
+    StreamToExclusive GenesisPoint                  -> False
+    StreamToInclusive (BlockPoint { atSlot = sto }) -> sfrom <  sto
+    StreamToExclusive (BlockPoint { atSlot = sto }) -> sfrom <  sto
 
 -- | Stream all blocks from the current chain.
 --

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 module Ouroboros.Storage.ChainDB.API (
     -- * Main ChainDB API
@@ -308,6 +310,9 @@ data IteratorResult blk =
     -- the VolatileDB, but not added to the ImmutableDB.
     --
     -- This will only happen when streaming very old forks very slowly.
+
+deriving instance (Eq   blk, Eq   (HeaderHash blk)) => Eq   (IteratorResult blk)
+deriving instance (Show blk, Show (HeaderHash blk)) => Show (IteratorResult blk)
 
 data UnknownRange blk =
     -- | The block at the given point was not found in the ChainDB.

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -398,7 +398,7 @@ data Reader m blk a = Reader {
       -- | Blocking version of 'readerInstruction'
     , readerInstructionBlocking :: m (ChainUpdate blk a)
 
-      -- | Move the iterator forward
+      -- | Move the reader forward
       --
       -- Must be given a list of points in order of preference; the iterator
       -- will move forward to the first point on the list that is on the current
@@ -412,6 +412,14 @@ data Reader m blk a = Reader {
       -- Cannot live in @STM@ because the points specified might live in the
       -- immutable DB.
     , readerForward             :: [Point blk] -> m (Maybe (Point blk))
+
+      -- | Close the reader.
+      --
+      -- Idempotent.
+      --
+      -- After closing, all other operations on the reader will throw
+      -- 'ClosedReaderError'.
+    , readerClose               :: m ()
 
       -- | Per-database reader ID
       --
@@ -502,6 +510,12 @@ data ChainDbError blk =
     -- This will be thrown when performing any operation on the ChainDB except
     -- for 'isOpen' and 'closeDB'.
   | ClosedDBError
+
+    -- | The reader is closed.
+    --
+    -- This will be thrown when performing any operation on a closed readers,
+    -- except for 'readerClose'.
+  | ClosedReaderError ReaderId
 
     -- | When there is no chain/fork that satisfies the bounds passed to
     -- 'streamBlocks'.

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -1,0 +1,189 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+
+module Ouroboros.Storage.ChainDB.Impl (
+    -- * Initialization
+    ChainDbArgs(..)
+  , defaultArgs
+  , openDB
+    -- * Trace types
+  , TraceEvent (..)
+  , TraceAddBlockEvent (..)
+  , TraceReaderEvent (..)
+  , TraceCopyToImmDBEvent (..)
+  , TraceGCEvent (..)
+  , TraceValidationEvent (..)
+  , TraceInitChainSelEvent (..)
+  , TraceOpenEvent (..)
+  , TraceIteratorEvent (..)
+  , TraceLedgerEvent (..)
+  , ReasonInvalid (..)
+    -- * Internals for testing purposes
+  , openDBInternal
+  , Internal (..)
+  ) where
+
+import           Control.Monad (when)
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer
+
+import           Control.Tracer
+
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (blockNo, castPoint)
+import           Ouroboros.Network.Chain (genesisBlockNo)
+
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Protocol.Abstract
+
+import           Ouroboros.Storage.ChainDB.API
+
+import           Ouroboros.Storage.ChainDB.Impl.Args (ChainDbArgs, defaultArgs)
+import qualified Ouroboros.Storage.ChainDB.Impl.Args as Args
+import qualified Ouroboros.Storage.ChainDB.Impl.Background as Background
+import qualified Ouroboros.Storage.ChainDB.Impl.ChainSel as ChainSel
+import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
+import qualified Ouroboros.Storage.ChainDB.Impl.Iterator as Iterator
+import qualified Ouroboros.Storage.ChainDB.Impl.LgrDB as LgrDB
+import qualified Ouroboros.Storage.ChainDB.Impl.Query as Query
+import qualified Ouroboros.Storage.ChainDB.Impl.Reader as Reader
+import qualified Ouroboros.Storage.ChainDB.Impl.Reopen as Reopen
+import           Ouroboros.Storage.ChainDB.Impl.Types
+import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
+
+{-------------------------------------------------------------------------------
+  Initialization
+-------------------------------------------------------------------------------}
+
+openDB
+  :: forall m blk.
+     ( MonadAsync m
+     , MonadFork  m
+     , MonadST    m
+     , MonadMask  m
+     , MonadTime  m
+     , MonadTimer m
+     , MonadThrow (STM m)
+     , ProtocolLedgerView blk
+     )
+  => ChainDbArgs m blk
+  -> m (ChainDB m blk)
+openDB args = fst <$> openDBInternal args True
+
+openDBInternal
+  :: forall m blk.
+     ( MonadAsync m
+     , MonadFork  m
+     , MonadST    m
+     , MonadMask  m
+     , MonadTime  m
+     , MonadTimer m
+     , MonadThrow (STM m)
+     , ProtocolLedgerView blk
+     )
+  => ChainDbArgs m blk
+  -> Bool -- ^ 'True' = Launch background tasks
+  -> m (ChainDB m blk, Internal m blk)
+openDBInternal args launchBgTasks = do
+    immDB   <- ImmDB.openDB argsImmDb
+    volDB   <- VolDB.openDB argsVolDb
+    lgrDB   <- LgrDB.openDB argsLgrDb
+                            immDB
+                            (Query.getAnyKnownBlock immDB volDB)
+                            lgrTracer
+
+    varInvalid <- atomically $ newTVar Set.empty
+
+    chainAndLedger <- ChainSel.initialChainSelection
+      immDB
+      volDB
+      lgrDB
+      (Args.cdbTracer     args)
+      (Args.cdbNodeConfig args)
+      varInvalid
+
+    -- Get the actual BlockNo of the tip of the ImmutableDB. Note that this
+    -- might not end up being the \"immutable\" block(no), because the current
+    -- chain computed from the VolatileDB could be longer than @k@.
+    immDbBlockNo <- maybe genesisBlockNo blockNo <$> ImmDB.getBlockAtTip immDB
+
+    let chain      = ChainSel.clChain  chainAndLedger
+        ledger     = ChainSel.clLedger chainAndLedger
+        cfg        = Args.cdbNodeConfig args
+        secParam   = protocolSecurityParam cfg
+        immBlockNo = ChainSel.getImmBlockNo secParam chain immDbBlockNo
+
+    atomically $ LgrDB.setCurrent lgrDB ledger
+    varChain          <- atomically $ newTVar chain
+    varImmBlockNo     <- atomically $ newTVar immBlockNo
+    varIterators      <- atomically $ newTVar Map.empty
+    varReaders        <- atomically $ newTVar Map.empty
+    varNextIteratorId <- atomically $ newTVar $ IteratorId 0
+    varNextReaderId   <- atomically $ newTVar 0
+    varCopyLock       <- atomically $ newTMVar ()
+    varBgThreads      <- atomically $ newTVar []
+
+    let env = CDB { cdbImmDB          = immDB
+                  , cdbVolDB          = volDB
+                  , cdbLgrDB          = lgrDB
+                  , cdbChain          = varChain
+                  , cdbImmBlockNo     = varImmBlockNo
+                  , cdbIterators      = varIterators
+                  , cdbReaders        = varReaders
+                  , cdbNodeConfig     = cfg
+                  , cdbInvalid        = varInvalid
+                  , cdbNextIteratorId = varNextIteratorId
+                  , cdbNextReaderId   = varNextReaderId
+                  , cdbCopyLock       = varCopyLock
+                  , cdbTracer         = Args.cdbTracer         args
+                  , cdbThreadRegistry = Args.cdbThreadRegistry args
+                  , cdbGcDelay        = Args.cdbGcDelay        args
+                  , cdbBgThreads      = varBgThreads
+                  }
+    h <- fmap CDBHandle $ atomically $ newTVar $ ChainDbOpen env
+    let chainDB = ChainDB
+          { addBlock           = getEnv1    h ChainSel.addBlock
+          , getCurrentChain    = getEnvSTM  h Query.getCurrentChain
+          , getCurrentLedger   = getEnvSTM  h Query.getCurrentLedger
+          , getTipBlock        = getEnv     h Query.getTipBlock
+          , getTipHeader       = getEnv     h Query.getTipHeader
+          , getTipPoint        = getEnvSTM  h Query.getTipPoint
+          , getBlock           = getEnv1    h Query.getBlock
+          , getIsFetched       = getEnvSTM  h Query.getIsFetched
+          , streamBlocks       = Iterator.streamBlocks  h
+          , newHeaderReader    = Reader.newHeaderReader h
+          , newBlockReader     = Reader.newBlockReader  h
+          , knownInvalidBlocks = getEnvSTM  h Query.knownInvalidBlocks
+          , closeDB            = Reopen.closeDB h
+          , isOpen             = Reopen.isOpen  h
+          }
+        testing = Internal
+          { intReopen                = Reopen.reopen  h
+          , intCopyToImmDB           = getEnv  h Background.copyToImmDB
+          , intGarbageCollect        = getEnv1 h Background.garbageCollect
+          , intUpdateLedgerSnapshots = getEnv  h Background.updateLedgerSnapshots
+          , intBgThreads             = varBgThreads
+          }
+
+    traceWith (Args.cdbTracer args) $ TraceOpenEvent $ OpenedDB
+      { _immTip   = castPoint $ AF.anchorPoint chain
+      , _chainTip = castPoint $ AF.headPoint   chain
+      }
+
+    when launchBgTasks $ Background.launchBgTasks env
+
+    return (chainDB, testing)
+  where
+    (argsImmDb, argsVolDb, argsLgrDb, _) = Args.fromChainDbArgs args
+
+    lgrTracer = contramap (TraceLedgerEvent . InitLog) (Args.cdbTracer args)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -1,0 +1,217 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+module Ouroboros.Storage.ChainDB.Impl.Args
+  ( ChainDbArgs (..)
+  , ChainDbSpecificArgs (..)
+  , defaultArgs
+    -- * Internal
+  , fromChainDbArgs
+  ) where
+
+import           Codec.CBOR.Decoding (Decoder)
+import           Codec.CBOR.Encoding (Encoding)
+import           Data.Time.Clock (DiffTime, secondsToDiffTime)
+
+import           Control.Monad.Class.MonadSTM
+
+import           Control.Tracer (Tracer)
+
+import           Ouroboros.Network.Block (HeaderHash, StandardHash)
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.ThreadRegistry (ThreadRegistry)
+
+import           Ouroboros.Storage.Common
+import           Ouroboros.Storage.FS.API
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling,
+                     ThrowCantCatch)
+
+import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
+import qualified Ouroboros.Storage.ChainDB.Impl.LgrDB as LgrDB
+import           Ouroboros.Storage.ChainDB.Impl.Types (TraceEvent)
+import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
+
+{-------------------------------------------------------------------------------
+  Arguments
+-------------------------------------------------------------------------------}
+
+data ChainDbArgs m blk = forall h1 h2 h3. ChainDbArgs {
+
+      -- Decoders
+      cdbDecodeHash       :: forall s. Decoder s (HeaderHash blk)
+    , cdbDecodeBlock      :: forall s. Decoder s blk
+    , cdbDecodeLedger     :: forall s. Decoder s (LedgerState blk)
+    , cdbDecodeChainState :: forall s. Decoder s (ChainState (BlockProtocol blk))
+
+      -- Encoders
+    , cdbEncodeBlock      :: blk -> Encoding
+    , cdbEncodeHash       :: HeaderHash blk -> Encoding
+    , cdbEncodeLedger     :: LedgerState blk -> Encoding
+    , cdbEncodeChainState :: ChainState (BlockProtocol blk) -> Encoding
+
+      -- Error handling
+    , cdbErrImmDb         :: ErrorHandling ImmDB.ImmutableDBError m
+    , cdbErrVolDb         :: ErrorHandling (VolDB.VolatileDBError (HeaderHash blk)) m
+    , cdbErrVolDbSTM      :: ThrowCantCatch (VolDB.VolatileDBError (HeaderHash blk)) (STM m)
+
+      -- HasFS instances
+    , cdbHasFSImmDb       :: HasFS m h1
+    , cdbHasFSVolDb       :: HasFS m h2
+    , cdbHasFSLgrDB       :: HasFS m h3
+
+      -- Policy
+    , cdbValidation       :: ImmDB.ValidationPolicy
+    , cdbBlocksPerFile    :: Int
+    , cdbMemPolicy        :: LgrDB.MemPolicy
+    , cdbDiskPolicy       :: LgrDB.DiskPolicy m
+
+      -- Integration
+    , cdbNodeConfig       :: NodeConfig (BlockProtocol blk)
+    , cdbEpochSize        :: EpochNo -> m EpochSize
+    , cdbIsEBB            :: blk -> Maybe (HeaderHash blk)
+    , cdbGenesis          :: m (ExtLedgerState blk)
+
+      -- Misc
+    , cdbTracer         :: Tracer m (TraceEvent blk)
+    , cdbThreadRegistry :: ThreadRegistry m
+    , cdbGcDelay        :: DiffTime
+    }
+
+-- | Arguments specific to the ChainDB, not to the ImmutableDB, VolatileDB, or
+-- LedgerDB.
+data ChainDbSpecificArgs m blk = ChainDbSpecificArgs {
+      cdbsTracer         :: Tracer m (TraceEvent blk)
+    , cdbsThreadRegistry :: ThreadRegistry m
+    , cdbsGcDelay        :: DiffTime
+    }
+
+-- | Default arguments
+--
+-- The following fields must still be defined:
+--
+-- * 'cdbsTracer'
+-- * 'cdbsThreadRegistry'
+defaultSpecificArgs :: ChainDbSpecificArgs m blk
+defaultSpecificArgs = ChainDbSpecificArgs{
+      cdbsGcDelay        = oneHour
+      -- Fields without a default
+    , cdbsTracer         = error "no default for cdbsTracer"
+    , cdbsThreadRegistry = error "no default for cdbsThreadRegistry"
+    }
+  where
+    oneHour = secondsToDiffTime 60 * 60
+
+-- | Default arguments for use within IO
+--
+-- See 'ImmDB.defaultArgs', 'VolDB.defaultArgs', 'LgrDB.defaultArgs', and
+-- 'defaultSpecificArgs' for a list of which fields are not given a default
+-- and must therefore be set explicitly.
+defaultArgs :: StandardHash blk
+            => FilePath
+            -> ChainDbArgs IO blk
+defaultArgs fp = toChainDbArgs (ImmDB.defaultArgs fp)
+                               (VolDB.defaultArgs fp)
+                               (LgrDB.defaultArgs fp)
+                               defaultSpecificArgs
+
+
+-- | Internal: split 'ChainDbArgs' into 'ImmDbArgs', 'VolDbArgs, 'LgrDbArgs',
+-- and 'ChainDbSpecificArgs'.
+fromChainDbArgs :: ChainDbArgs m blk
+                -> ( ImmDB.ImmDbArgs     m blk
+                   , VolDB.VolDbArgs     m blk
+                   , LgrDB.LgrDbArgs     m blk
+                   , ChainDbSpecificArgs m blk
+                   )
+fromChainDbArgs ChainDbArgs{..} = (
+      ImmDB.ImmDbArgs {
+          immDecodeHash       = cdbDecodeHash
+        , immDecodeBlock      = cdbDecodeBlock
+        , immEncodeHash       = cdbEncodeHash
+        , immEncodeBlock      = cdbEncodeBlock
+        , immErr              = cdbErrImmDb
+        , immEpochSize        = cdbEpochSize
+        , immValidation       = cdbValidation
+        , immIsEBB            = cdbIsEBB
+        , immHasFS            = cdbHasFSImmDb
+        }
+    , VolDB.VolDbArgs {
+          volHasFS            = cdbHasFSVolDb
+        , volErr              = cdbErrVolDb
+        , volErrSTM           = cdbErrVolDbSTM
+        , volBlocksPerFile    = cdbBlocksPerFile
+        , volEncodeBlock      = cdbEncodeBlock
+        , volDecodeBlock      = cdbDecodeBlock
+        }
+    , LgrDB.LgrDbArgs {
+          lgrNodeConfig       = cdbNodeConfig
+        , lgrHasFS            = cdbHasFSLgrDB
+        , lgrDecodeLedger     = cdbDecodeLedger
+        , lgrDecodeChainState = cdbDecodeChainState
+        , lgrDecodeHash       = cdbDecodeHash
+        , lgrEncodeLedger     = cdbEncodeLedger
+        , lgrEncodeChainState = cdbEncodeChainState
+        , lgrEncodeHash       = cdbEncodeHash
+        , lgrMemPolicy        = cdbMemPolicy
+        , lgrDiskPolicy       = cdbDiskPolicy
+        , lgrGenesis          = cdbGenesis
+        }
+    , ChainDbSpecificArgs {
+          cdbsTracer          = cdbTracer
+        , cdbsThreadRegistry  = cdbThreadRegistry
+        , cdbsGcDelay         = cdbGcDelay
+        }
+    )
+
+-- | Internal: construct 'ChainDbArgs' from 'ImmDbArgs', 'VolDbArgs,
+-- 'LgrDbArgs', and 'ChainDbSpecificArgs'.
+--
+-- Useful in 'defaultArgs'
+toChainDbArgs :: ImmDB.ImmDbArgs     m blk
+              -> VolDB.VolDbArgs     m blk
+              -> LgrDB.LgrDbArgs     m blk
+              -> ChainDbSpecificArgs m blk
+              -> ChainDbArgs         m blk
+toChainDbArgs ImmDB.ImmDbArgs{..}
+              VolDB.VolDbArgs{..}
+              LgrDB.LgrDbArgs{..}
+              ChainDbSpecificArgs{..} = ChainDbArgs{
+      -- Decoders
+      cdbDecodeHash       = immDecodeHash
+    , cdbDecodeBlock      = immDecodeBlock
+    , cdbDecodeLedger     = lgrDecodeLedger
+    , cdbDecodeChainState = lgrDecodeChainState
+      -- Encoders
+    , cdbEncodeBlock      = immEncodeBlock
+    , cdbEncodeHash       = immEncodeHash
+    , cdbEncodeLedger     = lgrEncodeLedger
+    , cdbEncodeChainState = lgrEncodeChainState
+      -- Error handling
+    , cdbErrImmDb         = immErr
+    , cdbErrVolDb         = volErr
+    , cdbErrVolDbSTM      = volErrSTM
+      -- HasFS instances
+    , cdbHasFSImmDb       = immHasFS
+    , cdbHasFSVolDb       = volHasFS
+    , cdbHasFSLgrDB       = lgrHasFS
+      -- Policy
+    , cdbValidation       = immValidation
+    , cdbBlocksPerFile    = volBlocksPerFile
+    , cdbMemPolicy        = lgrMemPolicy
+    , cdbDiskPolicy       = lgrDiskPolicy
+      -- Integration
+    , cdbNodeConfig       = lgrNodeConfig
+    , cdbEpochSize        = immEpochSize
+    , cdbIsEBB            = immIsEBB
+    , cdbGenesis          = lgrGenesis
+      -- Misc
+    , cdbTracer           = cdbsTracer
+    , cdbThreadRegistry   = cdbsThreadRegistry
+    , cdbGcDelay          = cdbsGcDelay
+    }

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
@@ -1,0 +1,357 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+-- | Background tasks:
+--
+-- * Copying blocks from the VolatileDB to the ImmutableDB
+-- * Performing and scheduling garbage collections on the VolatileDB
+-- * Writing snapshots of the LedgerDB to disk and deleting old ones.
+module Ouroboros.Storage.ChainDB.Impl.Background
+  ( -- * Launch background tasks
+    launchBgTasks
+    -- * Copying blocks from the VolatileDB to the ImmutableDB
+  , copyToImmDB
+  , copyToImmDBRunner
+     -- * Executing garbage collection
+  , garbageCollect
+    -- * Scheduling garbage collections
+  , GcSchedule
+  , newGcSchedule
+  , scheduleGC
+  , gcScheduleRunner
+    -- * Taking and trimming ledger snapshots
+  , updateLedgerSnapshots
+  , updateLedgerSnapshotsRunner
+  ) where
+
+import           Control.Exception (assert)
+import           Control.Monad (forM_, forever)
+import           Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
+import           Data.Typeable (Typeable)
+import           GHC.Stack (HasCallStack)
+
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer
+
+import           Control.Tracer
+
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (ChainHash (..), HasHeader, Point,
+                     SlotNo, StandardHash, pointHash, pointSlot)
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Ledger.Abstract (ProtocolLedgerView)
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.ThreadRegistry (forkLinked)
+
+import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
+import qualified Ouroboros.Storage.ChainDB.Impl.LgrDB as LgrDB
+import           Ouroboros.Storage.ChainDB.Impl.Types
+import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
+
+{-------------------------------------------------------------------------------
+  Launch background tasks
+-------------------------------------------------------------------------------}
+
+launchBgTasks
+  :: forall m blk.
+     ( MonadAsync m
+     , MonadFork  m
+     , MonadMask  m
+     , MonadTime  m
+     , MonadTimer m
+     , ProtocolLedgerView blk
+     )
+  => ChainDbEnv m blk
+  -> m ()
+launchBgTasks cdb@CDB{..} = do
+    gcSchedule <- newGcSchedule
+    gcThread   <- launch $
+      gcScheduleRunner gcSchedule $ garbageCollect cdb
+    copyThread <- launch $
+      copyToImmDBRunner cdb gcSchedule
+    lgrSnapshotThread <- launch $
+      updateLedgerSnapshotsRunner cdb
+    atomically $ writeTVar cdbBgThreads
+      [gcThread, copyThread, lgrSnapshotThread]
+  where
+    launch = forkLinked cdbThreadRegistry
+
+{-------------------------------------------------------------------------------
+  Copying blocks from the VolatileDB to the ImmutableDB
+-------------------------------------------------------------------------------}
+
+-- | Copy the blocks older than @k@ from the VolatileDB to the ImmutableDB.
+--
+-- These headers of these blocks can be retrieved by dropping the @k@ most
+-- recent blocks from the fragment stored in 'cdbChain'.
+--
+-- The copied blocks are removed from the fragment stored in 'cdbChain'.
+--
+-- This function does not remove blocks from the VolatileDB.
+--
+-- The 'SlotNo' of the tip of the ImmutableDB after copying the blocks is
+-- returned. This can be used for a garbage collection on the VolatileDB.
+--
+-- NOTE: this function would not be safe when called multiple times
+-- concurrently. To enforce thread-safety, a lock is obtained at the start of
+-- this function and released at the end. So in practice, this function can be
+-- called multiple times concurrently, but the calls will be serialised.
+--
+-- NOTE: this function /can/ run concurrently with all other functions, just
+-- not with itself.
+copyToImmDB
+  :: forall m blk.
+     ( MonadSTM   m
+     , MonadCatch m
+     , OuroborosTag (BlockProtocol blk)
+     , HasHeader blk
+     , HasHeader (Header blk)
+     , HasCallStack
+     )
+  => ChainDbEnv m blk
+  -> m SlotNo
+copyToImmDB CDB{..} = withCopyLock $ do
+    toCopy <- atomically $ do
+      curChain <- readTVar cdbChain
+      let nbToCopy = max 0 (AF.length curChain - fromIntegral k)
+          toCopy :: [Point blk]
+          toCopy = map headerPoint
+                 $ AF.toOldestFirst
+                 $ AF.takeOldest nbToCopy curChain
+      return toCopy
+
+    if null toCopy
+      -- This can't happen in practice, as we're only called when the fragment
+      -- is longer than @k@. However, in the tests, we will be calling this
+      -- function manually, which means it might be called when there are no
+      -- blocks to copy.
+      then trace NoBlocksToCopyToImmDB
+      else forM_ toCopy $ \pt -> do
+        let hash = case pointHash pt of
+              BlockHash h -> h
+              -- There is no actual genesis block that can occur on a chain
+              GenesisHash -> error "genesis block on current chain"
+        -- This call is cheap
+        slotNoAtImmDBTip <- ImmDB.getSlotNoAtTip cdbImmDB
+        assert (pointSlot pt > slotNoAtImmDBTip) $ return ()
+        blk <- VolDB.getKnownBlock cdbVolDB hash
+        -- We're the only one modifying the ImmutableDB, so the tip cannot
+        -- have changed since we last checked it.
+        ImmDB.appendBlock cdbImmDB blk
+        -- TODO the invariant of 'cdbChain' is shortly violated between
+        -- these two lines: the tip was updated on the line above, but the
+        -- anchor point is only updated on the line below.
+        atomically $ removeFromChain pt
+        trace $ CopiedBlockToImmDB pt
+
+    -- Get the /possibly/ updated tip of the ImmDB
+    ImmDB.getSlotNoAtTip cdbImmDB
+  where
+    SecurityParam k = protocolSecurityParam cdbNodeConfig
+    trace = traceWith (contramap TraceCopyToImmDBEvent cdbTracer)
+
+    -- | Remove the header corresponding to the given point from the beginning
+    -- of the current chain fragment.
+    --
+    -- PRECONDITION: the header must be the first one (oldest) in the chain
+    removeFromChain :: Point blk -> STM m ()
+    removeFromChain pt = do
+      -- The chain might have been extended in the meantime.
+      curChain <- readTVar cdbChain
+      case curChain of
+        hdr :< curChain'
+          | headerPoint hdr == pt
+          -> writeTVar cdbChain curChain'
+        -- We're the only one removing things from 'curChain', so this cannot
+        -- happen if the precondition was satisfied.
+        _ -> error "header to remove not on the current chain"
+
+    withCopyLock :: forall a. HasCallStack => m a -> m a
+    withCopyLock = bracket_
+      (fmap mustBeUnlocked $ atomically $ tryTakeTMVar cdbCopyLock)
+      (atomically $ putTMVar  cdbCopyLock ())
+
+    mustBeUnlocked :: forall b. HasCallStack => Maybe b -> b
+    mustBeUnlocked = fromMaybe
+                   $ error "copyToImmDB running concurrently with itself"
+
+-- | Watches the current chain for changes. Whenever the chain is longer than
+-- @k@, then the headers older than @k@ are copied from the VolatileDB to the
+-- ImmutableDB (with 'copyToImmDB'). Afterwards, a garbage collection of the
+-- VolatileDB is scheduled using ('scheduleGC') for the 'SlotNo' of the most
+-- recent block that was copied.
+copyToImmDBRunner
+  :: forall m blk.
+     ( MonadSTM   m
+     , MonadCatch m
+     , MonadTime  m
+     , OuroborosTag (BlockProtocol blk)
+     , HasHeader blk
+     , HasHeader (Header blk)
+     )
+  => ChainDbEnv m blk
+  -> GcSchedule m
+  -> m ()
+copyToImmDBRunner cdb@CDB{..} gcSchedule = forever $ do
+    atomically $ do
+      curChain <- readTVar cdbChain
+      check $ fromIntegral (AF.length curChain) > k
+
+    slotNo <- copyToImmDB cdb
+    scheduleGC (contramap TraceGCEvent cdbTracer) slotNo cdbGcDelay gcSchedule
+  where
+    SecurityParam k = protocolSecurityParam cdbNodeConfig
+
+{-------------------------------------------------------------------------------
+  Executing garbage collection
+-------------------------------------------------------------------------------}
+
+-- | Trigger a garbage collection for blocks older or equal to the given
+-- 'SlotNo' on the VolatileDB.
+--
+-- Also removes the corresponding cached "previously applied points" from the
+-- LedgerDB.
+--
+-- This is thread-safe as the VolatileDB locks itself while performing a GC.
+--
+-- TODO will a long GC be a bottleneck? It will block any other calls to
+-- @putBlock@ and @getBlock@.
+garbageCollect
+  :: forall m blk.
+     ( MonadCatch m
+     , MonadSTM   m
+     , HasHeader blk
+     )
+  => ChainDbEnv m blk
+  -> SlotNo
+  -> m ()
+garbageCollect CDB{..} slotNo = do
+    VolDB.garbageCollect cdbVolDB slotNo
+    atomically $ do
+      LgrDB.garbageCollectPrevApplied cdbLgrDB slotNo
+      modifyTVar' cdbInvalid $ Set.filter ((<= slotNo) . pointSlot)
+    traceWith cdbTracer $ TraceGCEvent $ PerformedGC slotNo
+
+{-------------------------------------------------------------------------------
+  Scheduling garbage collections
+-------------------------------------------------------------------------------}
+
+-- | A scheduled garbage collections.
+--
+-- Represented as a queue.
+--
+-- The background thread will continuously try to pop the first element of the
+-- queue. Whenever it manages to pop a @('Time' m, 'SlotNo')@ off: it first
+-- waits until the 'Time' is passed (using 'threadDelay' with the given 'Time'
+-- minus the current 'Time') and then performs a garbage collection with the
+-- given 'SlotNo'.
+--
+-- The 'Time's in the queue should be monotonically increasing. A fictional
+-- example (with hh:mm:ss):
+--
+-- > [(16:01:12, SlotNo 1012), (16:04:38, SlotNo 1045), ..]
+--
+-- By using 'scheduleGC', monotonicity is practically guaranteed for standard
+-- usage. Theoretically, multiple concurrent calls to 'scheduleGC' might
+-- violate it, but this won't happen in practice, as it would mean that
+-- multiple calls to 'copyToImmDB' (which cannot run concurrent with itself)
+-- have finished very short after each other. Even then, the differences will
+-- be ignorable (<1s), and actually won't matter at all, as garbage collection
+-- timing doesn't have to be precise. In fact, it is exactly the goal to
+-- introduce a delay between copying blocks from the ImmutableDB to the
+-- VolatileDB and garbage-collecting them from the VolatileDB.
+--
+-- If a 'Time' @t@ in the queue /is/ earlier than the 'Time' @t'@ before it in
+-- the queue, then the GC scheduled for @t@ will simply be executed at @t'@.
+--
+-- All this combined means that a garbage collection scheduled at 'Time' @t@
+-- will be performed at @t@ /or/ later (but never earlier), with no hard
+-- guarantees about how much later.
+--
+-- How long will this queue be in practice?
+--
+-- If we say a block is produced every 20 seconds, then a new GC is scheduled
+-- every 20 seconds. Ignoring start-up, the queue will then be @delay / 20s@
+-- entries long. For example, if the delay is 1h, then the queue will be 180
+-- entries long, which is acceptable.
+--
+-- In Praos, the slot length decreases, but the number of blocks produced (per
+-- time) will remain the same as the density decreases too (more slots, but
+-- many of them empty), hence the queue queue length will also remain the
+-- same.
+newtype GcSchedule m = GcSchedule (TQueue m (Time m, SlotNo))
+
+newGcSchedule :: MonadSTM m => m (GcSchedule m)
+newGcSchedule = GcSchedule <$> atomically newTQueue
+
+scheduleGC
+  :: forall m blk.
+     (MonadSTM m, MonadTime m)
+  => Tracer m (TraceGCEvent blk)
+  -> SlotNo    -- ^ The slot to use for garbage collection
+  -> DiffTime  -- ^ How long to wait until performing the GC
+  -> GcSchedule m
+  -> m ()
+scheduleGC tracer slotNo delay (GcSchedule queue) = do
+    timeScheduledForGC <- addTime delay <$> getMonotonicTime
+    atomically $ writeTQueue queue (timeScheduledForGC, slotNo)
+    traceWith tracer $ ScheduledGC slotNo delay
+
+gcScheduleRunner
+  :: forall m.
+     (MonadSTM m, MonadTime m, MonadTimer m)
+  => GcSchedule m
+  -> (SlotNo -> m ())  -- ^ GC function
+  -> m ()
+gcScheduleRunner (GcSchedule queue) runGc = forever $ do
+    (timeScheduledForGC, slotNo) <- atomically $ readTQueue queue
+    currentTime <- getMonotonicTime
+    let toWait = max 0 (timeScheduledForGC `diffTime` currentTime)
+    threadDelay toWait
+    -- Garbage collection is called synchronously
+    runGc slotNo
+
+{-------------------------------------------------------------------------------
+  Taking and trimming ledger snapshots
+-------------------------------------------------------------------------------}
+
+-- | Write a snapshot of the LedgerDB to disk and remove old snapshots
+-- (typically one) so that only 'onDiskNumSnapshots' snapshots are on disk.
+updateLedgerSnapshots
+  :: forall m blk.
+     (MonadSTM m, MonadThrow m, StandardHash blk, Typeable blk)
+  => ChainDbEnv m blk
+  -> m ()
+updateLedgerSnapshots CDB{..} = do
+    -- TODO avoid taking multiple snapshots corresponding to the same tip.
+    (snapshot, pt)   <- LgrDB.takeSnapshot  cdbLgrDB
+    trace $ TookSnapshot snapshot pt
+    deletedSnapshots <- LgrDB.trimSnapshots cdbLgrDB
+    forM_ deletedSnapshots $ trace . DeletedSnapshot
+  where
+    trace = traceWith (contramap TraceLedgerEvent cdbTracer)
+
+-- | Execute 'updateLedgerSnapshots', wait 'onDiskWriteInterval', and repeat.
+updateLedgerSnapshotsRunner
+  :: forall m blk.
+     (MonadTimer m, MonadThrow m, StandardHash blk, Typeable blk)
+  => ChainDbEnv m blk
+  -> m ()
+updateLedgerSnapshotsRunner cdb@CDB{..} = loop
+  where
+    LgrDB.DiskPolicy{..} = LgrDB.getDiskPolicy cdbLgrDB
+
+    loop = updateLedgerSnapshots cdb >> waitInterval >> loop
+
+    waitInterval = do
+      interval <- atomically onDiskWriteInterval
+      threadDelay interval

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
@@ -1,0 +1,779 @@
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE MultiWayIf           #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+-- | Operations involving chain selection: the initial chain selection and
+-- adding a block.
+module Ouroboros.Storage.ChainDB.Impl.ChainSel
+  ( initialChainSelection
+  , addBlock
+    -- * Type for in-sync chain and ledger
+  , ChainAndLedger -- Opaque
+  , clChain
+  , clLedger
+    -- * Helpers
+  , getImmBlockNo
+  ) where
+
+import           Control.Exception (assert)
+import           Control.Monad (unless)
+import           Control.Monad.Except
+import           Control.Monad.Trans.State.Strict
+import           Data.Foldable (foldl')
+import           Data.Function (on)
+import           Data.List (sortBy)
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Maybe (fromMaybe, isJust, mapMaybe)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Word (Word64)
+import           GHC.Stack (HasCallStack)
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+import           Control.Tracer (Tracer, contramap, traceWith)
+
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (BlockNo, HasHeader (..), HeaderHash,
+                     Point, blockPoint, castPoint, pointHash)
+
+import           Ouroboros.Consensus.Block (BlockProtocol, GetHeader (..),
+                     headerPoint)
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Protocol.Abstract
+
+import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB)
+import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
+import           Ouroboros.Storage.ChainDB.Impl.LgrDB (LgrDB)
+import qualified Ouroboros.Storage.ChainDB.Impl.LgrDB as LgrDB
+import qualified Ouroboros.Storage.ChainDB.Impl.Query as Query
+import qualified Ouroboros.Storage.ChainDB.Impl.Reader as Reader
+import           Ouroboros.Storage.ChainDB.Impl.Types
+import           Ouroboros.Storage.ChainDB.Impl.VolDB (VolDB)
+import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
+
+
+-- | Perform the initial chain selection based on the tip of the ImmutableDB
+-- and the contents of the VolatileDB.
+--
+-- Returns the chosen validated chain and corresponding ledger.
+--
+-- See "## Initialization" in ChainDB.md.
+initialChainSelection
+  :: forall m blk.
+     ( MonadCatch m
+     , MonadSTM   m
+     , ProtocolLedgerView blk
+     )
+  => ImmDB m blk
+  -> VolDB m blk
+  -> LgrDB m blk
+  -> Tracer m (TraceEvent blk)
+  -> NodeConfig (BlockProtocol blk)
+  -> TVar m (Set (Point blk)) -- ^ 'cdbInvalid'
+  -> m (ChainAndLedger blk)
+initialChainSelection immDB volDB lgrDB tracer cfg invalidPoints = do
+    -- We follow the steps from section "## Initialization" in ChainDB.md
+
+    i :: Point blk <- ImmDB.getPointAtTip immDB
+    (succsOf, ledger) <- atomically $
+      (,) <$> VolDB.getSuccessors volDB
+          <*> LgrDB.getCurrent    lgrDB
+    chains <- constructChains i succsOf
+
+    -- We use the empty fragment anchored at @i@ as the current chain (and
+    -- ledger) and the default in case there is no better candidate.
+    let curChainAndLedger = mkChainAndLedger (Empty (castPoint i)) ledger
+
+    case NE.nonEmpty chains of
+      -- If there are no candidates, no chain selection is needed
+      Nothing      -> return curChainAndLedger
+      Just chains' -> fromMaybe curChainAndLedger <$>
+        chainSelection' curChainAndLedger chains'
+  where
+    -- | Use the VolatileDB to construct all chains starting from the tip of
+    -- the ImmutableDB.
+    constructChains :: Point blk -- ^ Tip of the ImmutableDB, @i@
+                    -> (Maybe (HeaderHash blk) -> Set (HeaderHash blk))
+                    -> m [AnchoredFragment (Header blk)]
+    constructChains i succsOf = flip evalStateT Map.empty $
+        mapM constructChain suffixesAfterI
+      where
+        suffixesAfterI :: [NonEmpty (HeaderHash blk)]
+        suffixesAfterI = VolDB.candidates succsOf i
+
+        constructChain :: NonEmpty (HeaderHash blk)
+                       -> StateT (Map (HeaderHash blk) (Header blk))
+                                 m
+                                 (AnchoredFragment (Header blk))
+        constructChain hashes =
+          AF.fromOldestFirst (castPoint i) <$>
+          mapM (getKnownHeaderThroughCache volDB) (NE.toList hashes)
+
+    -- | Perform chain selection (including validation) on the given
+    -- candidates.
+    --
+    -- PRECONDITION: all candidates are anchored at @i@.
+    --
+    -- PRECONDITION: all candidates must be preferred over the current chain.
+    chainSelection' :: HasCallStack
+                    => ChainAndLedger blk
+                       -- ^ The current chain and ledger, corresponding to
+                       -- @i@.
+                    -> NonEmpty (AnchoredFragment (Header blk))
+                       -- ^ Candidates anchored at @i@
+                    -> m (Maybe (ChainAndLedger blk))
+    chainSelection' curChainAndLedger@(ChainAndLedger curChain ledger) candidates =
+      assert (all ((LgrDB.currentPoint ledger ==) .
+                   castPoint . AF.anchorPoint)
+                  candidates) $
+      -- Since all these candidates are longer than the current chain, they
+      -- will be preferred over it. However, in the future, it might no longer
+      -- be that a longer chain always implies that 'preferCandidate' is true.
+      assert (all (preferCandidate cfg curChain) candidates) $
+      chainSelection
+        lgrDB
+        (contramap (TraceInitChainSelEvent . InitChainSelValidation) tracer)
+        cfg
+        invalidPoints
+        curChainAndLedger
+        (fmap (mkCandidateSuffix 0) candidates)
+
+-- | Add a block to the ChainDB.
+--
+-- This is the only operation that actually changes the ChainDB. It will add
+-- store the block on disk and trigger chain selection, possibly switching to
+-- a fork.
+--
+-- PRECONDITION: The slot number of the new block may not be too far in the
+-- future: @blockSlot b <= currentSlot + maxSkew@ where @b@ is the new block,
+-- @currentSlot@ is the current slot according to @BlockchainTime@ and
+-- @maxSkew@ is the maximum allowed @ClockSkew@. The chain sync client
+-- guarantees this.
+--
+-- = Constructing candidate fragments
+--
+-- The VolatileDB keeps a \"successors\" map in memory, telling us the hashes
+-- of the known successors of any block, but it does not keep /headers/ in
+-- memory, which are needed to construct candidate fargments. We try to reuse
+-- the headers from the current chain fragment where possible, but it will not
+-- contain all needed headers. This means that we will need to read some
+-- blocks from disk and extract their headers. Under normal circumstances this
+-- does not matter too much; although this will be done every time we add a
+-- block, the expected number of headers to read from disk is very small:
+--
+-- * None if we stay on the current chain and this is just the next block
+-- * A handful if we stay on the current chain and the block we just received
+--   was a missing block and we already received some of its successors
+-- * A handful if we switch to a short fork
+--
+-- This is expensive only
+--
+-- * on startup: in this case we need to read at least @k@ blocks from the
+--   VolatileDB, and possibly more if there are some other chains in the
+--   VolatileDB starting from the tip of the ImmutableDB
+-- * when we switch to a distant fork
+--
+-- This cost is currently deemed acceptable.
+addBlock
+  :: forall m blk.
+     ( MonadSTM   m
+     , MonadCatch m
+     , HasHeader blk
+     , ProtocolLedgerView blk
+     , HasCallStack
+     )
+  => ChainDbEnv m blk
+  -> blk
+  -> m ()
+addBlock cdb@CDB{..} b = do
+    (isMember, curChain, tipPoint, ledgerDB, invalid, immBlockNo) <-
+      atomically $ (,,,,,)
+        <$> VolDB.getIsMember     cdbVolDB
+        <*> Query.getCurrentChain cdb
+        <*> Query.getTipPoint     cdb
+        <*> LgrDB.getCurrent      cdbLgrDB
+        <*> readTVar              cdbInvalid
+        <*> readTVar              cdbImmBlockNo
+    let curChainAndLedger =
+          -- The current chain we're working with here is not longer than @k@
+          -- blocks (see 'getCurrentChain' and 'cdbChain'), which is easier to
+          -- reason about when doing chain selection, etc.
+          assert (fromIntegral (AF.length curChain) <= k) $
+          mkChainAndLedger curChain ledgerDB
+        -- See 'getCurrentChain'
+        i :: Point blk
+        i = castPoint $ AF.anchorPoint curChain
+
+    -- We follow the steps from section "## Adding a block" in ChainDB.md
+
+    -- ### Ignore
+    unless (blockNo b <= immBlockNo ||
+            isMember (blockHash b)  ||
+            Set.member (blockPoint b) invalid) $ do
+
+      -- Write the block to the VolatileDB in all other cases
+      VolDB.putBlock cdbVolDB b
+      trace (AddedBlockToVolDB (blockPoint b))
+
+      -- We need to get these after adding the block to the VolatileDB
+      (isMember', predecessor, succsOf) <- atomically $
+         (,,) <$> VolDB.getIsMember    cdbVolDB
+              <*> VolDB.getPredecessor cdbVolDB
+              <*> VolDB.getSuccessors  cdbVolDB
+
+      -- The block @b@ fits onto the end of our current chain
+      if | pointHash tipPoint == blockPrevHash b -> do
+           -- ### Add to current chain
+           trace (TryAddToCurrentChain (blockPoint b))
+           addToCurrentChain succsOf curChainAndLedger
+
+         | Just hashes <- VolDB.isReachable predecessor isMember'
+             i (blockPoint b) -> do
+           -- ### Switch to a fork
+           trace (TrySwitchToAFork (blockPoint b) hashes)
+           switchToAFork succsOf curChainAndLedger hashes
+
+         | otherwise ->
+           -- ### Store but don't change the current chain
+
+           -- We have already stored the block in the VolatileDB
+           trace (StoreButDontChange (blockPoint b))
+
+      -- Note that we may have extended the chain, but have not trimmed it to
+      -- @k@ blocks/headers. That is the job of the background thread, which
+      -- will first copy the blocks/headers to trim (from the end of the
+      -- fragment) from the VolatileDB to the ImmutableDB.
+
+  where
+    secParam@(SecurityParam k) = protocolSecurityParam cdbNodeConfig
+
+    trace :: TraceAddBlockEvent blk -> m ()
+    trace = traceWith (contramap TraceAddBlockEvent cdbTracer)
+
+    -- | PRECONDITION: the header @hdr@ (and block @b@) fit onto the end of
+    -- the current chain.
+    addToCurrentChain :: HasCallStack
+                      => (Maybe (HeaderHash blk) -> Set (HeaderHash blk))
+                      -> ChainAndLedger blk
+                         -- ^ The current chain and ledger
+                      -> m ()
+    addToCurrentChain succsOf curChainAndLedger@(ChainAndLedger curChain _) =
+        assert (AF.validExtension curChain hdr) $ do
+          let suffixesAfterB = VolDB.candidates succsOf (blockPoint b)
+
+          -- Fragments that are anchored at @curHead@, i.e. suffixes of the
+          -- current chain.
+          candidates <- case NE.nonEmpty suffixesAfterB of
+            -- If there are no suffixes after @b@, just use the suffix just
+            -- containing @b@ as the sole candidate.
+            Nothing              ->
+              return $ (AF.fromOldestFirst curHead [hdr]) NE.:| []
+            Just suffixesAfterB' ->
+              -- We can start with an empty cache, because we're only looking
+              -- up the headers /after/ b, so they won't be on the current
+              -- chain.
+              flip evalStateT Map.empty $ forM suffixesAfterB' $ \hashes -> do
+                hdrs <- mapM (getKnownHeaderThroughCache cdbVolDB) $
+                  NE.toList hashes
+                return $ AF.fromOldestFirst curHead (hdr : hdrs)
+
+          let candidateSuffixes = fmap (mkCandidateSuffix 0) candidates
+          -- Since all candidates are longer than the current chain, they will
+          -- /always/ be preferred over it.
+          assert (all (preferCandidate cdbNodeConfig curChain . _suffix)
+                      candidateSuffixes) $
+            chainSelection' curChainAndLedger candidateSuffixes >>= \case
+              Nothing                -> return ()
+              Just newChainAndLedger -> trySwitchTo newChainAndLedger
+      where
+        curHead = AF.headPoint curChain
+        hdr     = getHeader b
+
+    -- | We have found a path of hashes to the new block through the
+    -- VolatileDB. We try to extend this path by looking for forks that start
+    -- with the given block, then we do chain selection and /possibly/ try to
+    -- switch to a new fork.
+    switchToAFork :: HasCallStack
+                  => (Maybe (HeaderHash blk) -> Set (HeaderHash blk))
+                  -> ChainAndLedger blk
+                     -- ^ The current chain (anchored at @i@) and ledger
+                  -> NonEmpty (HeaderHash blk)
+                     -- ^ An uninterrupted path of hashes @(i,b]@.
+                  -> m ()
+    switchToAFork succsOf curChainAndLedger@(ChainAndLedger curChain _) hashes = do
+        let suffixesAfterB = VolDB.candidates succsOf (blockPoint b)
+            initCache      = Map.insert (blockHash b) hdr (cacheHeaders curChain)
+        -- Fragments that are anchored at @i@.
+        candidates <- flip evalStateT initCache $
+          case NE.nonEmpty suffixesAfterB of
+            -- If there are no suffixes after @b@, just use the fragment that
+            -- ends in @b@ as the sole candidate.
+            Nothing              -> (NE.:| []) <$> constructFork i hashes []
+            Just suffixesAfterB' -> mapM (constructFork i hashes . NE.toList)
+                                         suffixesAfterB'
+        let candidateSuffixes =
+                -- The suffixes all fork off from the current chain within @k@
+                -- blocks, so it satisfies the precondition of
+                -- 'preferCandidate'.
+                filter (preferCandidate cdbNodeConfig curChain . _suffix)
+              . mapMaybe (intersectCandidateSuffix curChain)
+              $ NE.toList candidates
+
+        case NE.nonEmpty candidateSuffixes of
+          -- No candidates preferred over the current chain
+          Nothing                 -> return ()
+          Just candidateSuffixes' ->
+            chainSelection' curChainAndLedger candidateSuffixes' >>= \case
+              Nothing                -> return ()
+              Just newChainAndLedger -> trySwitchTo newChainAndLedger
+      where
+        i   = castPoint $ anchorPoint curChain
+        hdr = getHeader b
+
+
+    -- | 'chainSelection' partially applied to the parameters from the
+    -- 'ChainDbEnv'.
+    chainSelection'
+      :: ChainAndLedger blk              -- ^ The current chain and ledger
+      -> NonEmpty (CandidateSuffix blk)  -- ^ Candidates
+      -> m (Maybe (ChainAndLedger blk))
+    chainSelection' = chainSelection
+      cdbLgrDB
+      (contramap (TraceAddBlockEvent . AddBlockValidation) cdbTracer)
+      cdbNodeConfig
+      cdbInvalid
+
+    -- | Try to swap the current (chain) fragment with the given candidate
+    -- fragment. The 'LgrDB.LedgerDB' is updated in the same transaction.
+    --
+    -- Note that the current chain might have changed in the meantime. We only
+    -- switch when the new chain is preferred over the current chain.
+    --
+    -- * Remember that we started with the @k@ most recent headers from the
+    --   current chain.
+    --
+    --   - In the common case, the candidate will be one block longer than
+    --     @k@, i.e. the new block that was appended to the current chain.
+    --   - In some cases, it might be a few blocks longer, because the new
+    --     block allowed us to append a few more blocks that we previously got
+    --     to the chain.
+    --   - In some cases, we have added one or more blocks to it, after
+    --     rolling a few back (less or equal to the number we added to it),
+    --     i.e. we switch to a short fork.
+    --   - In exceptional cases, it will be exactly @k@ long, when we switch
+    --     to a fork of the same length.
+    --   - In exceptional cases, it will be much longer than @k@, i.e. when we
+    --     have added a block that connects a much longer fork to the current
+    --     chain.
+    --
+    -- * The current chain might be longer than @k@ because the background
+    --   thread might not have written all blocks yet to the ImmutableDB.
+    --
+    -- If there's no concurrency, i.e., no concurrent calls to 'addBlock',
+    -- then it must be that current chain and the candidate chain intersect
+    -- within the last @k@ blocks (of the current chain).
+    --
+    -- If there is no such intersection, it must be that the current chain has
+    -- /concurrently/ changed so much that the fragment is no longer within
+    -- the last @k@ blocks of the current chain, and we are no longer
+    -- interested in this candidate anymore.
+    --
+    -- If there is an intersection, we compare the candidate fragment to the
+    -- current chain, and, if it is preferred, install it as the current
+    -- chain.
+    --
+    -- In case the current chain was changed in the background, it must either
+    -- have been done before we added our block to the VolatileDB or after. If
+    -- it was before, we know of the other block. If it was done after, they
+    -- must know of our block. In either case, somebody computed candidates
+    -- with knowledge of both blocks, so we're safe. See See "### Concurrency"
+    -- in ChainDB.md for more details.
+    trySwitchTo :: HasCallStack
+                => ChainAndLedger blk  -- ^ Chain and ledger to switch to
+                -> m ()
+    trySwitchTo (ChainAndLedger newChain newLedger) = do
+      (curChain, switched) <- atomically $ do
+        curChain <- readTVar cdbChain
+        case AF.intersect curChain newChain of
+          Just (curChainPrefix, _newChainPrefix, curChainSuffix, newChainSuffix)
+            | fromIntegral (AF.length curChainSuffix) <= k
+            , preferCandidate cdbNodeConfig curChain newChain
+            -> do
+              -- The current chain might still contain some old headers that
+              -- have not yet been written to the ImmutableDB. We must make
+              -- sure to prepend these headers to the new chain so that we
+              -- still know what the full chain is.
+              let newChain' = fromMaybe
+                    (error "postcondition of intersect violated") $
+                    AF.join curChainPrefix newChainSuffix
+              writeTVar cdbChain newChain'
+              LgrDB.setCurrent cdbLgrDB newLedger
+              -- Update 'cdbImmBlockNo'
+              modifyTVar' cdbImmBlockNo $ getImmBlockNo secParam newChain'
+
+              -- Update the readers
+              -- 'Reader.switchFork' needs to know the intersection point
+              -- (@ipoint@) between the old and the current chain.
+              let ipoint = castPoint $ AF.anchorPoint newChainSuffix
+              varReaders <- Map.elems <$> readTVar cdbReaders
+              forM_ varReaders $ \varReader -> modifyTVar' varReader $
+                Reader.switchFork ipoint newChain'
+
+              return (curChain, True)
+          -- The chain must be changed in the meantime such that our chain is
+          -- no longer preferred.
+          _ -> return (curChain, False)
+      trace $ if switched
+              then SwitchedToChain  curChain newChain
+              else ChainChangedInBg curChain newChain
+
+    -- | Build a cache from the headers in the fragment.
+    cacheHeaders :: AnchoredFragment (Header blk)
+                 -> Map (HeaderHash blk) (Header blk)
+    cacheHeaders =
+      foldl' (\m hdr -> Map.insert (blockHash hdr) hdr m) Map.empty .
+      AF.toNewestFirst
+
+    -- | We have a new block @b@ that doesn't fit onto the current chain, but
+    -- there is an unbroken path from the tip of the ImmutableDB (@i@ = the
+    -- anchor point of the current chain) to @b@. We also have a suffix @s@ of
+    -- hashes that starts after @b@.
+    --
+    -- We will try to construct a fragment @f@ for the fork such that:
+    -- * @f@ is anchored at @i@
+    -- * @f@ starts with the headers corresponding to the hashes of @(i,b]@
+    -- * The next header in @f@ is the header for @b@
+    -- * Finally, @f@ ends with the headers corresponding to the hashes
+    --   @(b,?]@ of the suffix @s@.
+    --
+    -- Note that we need to read the headers corresponding to the hashes
+    -- @(i,b]@ and @(b,?]@ from disk. It is likely that many of these headers
+    -- are actually on the current chain, so when possible, we reuse these
+    -- headers instead of reading them from disk.
+    constructFork
+      :: Point blk                  -- ^ Tip of ImmutableDB @i@
+      -> NonEmpty (HeaderHash blk)  -- ^ Hashes of @(i,b]@
+      -> [HeaderHash blk]           -- ^ Suffix @s@, hashes of @(b,?]@
+      -> StateT (Map (HeaderHash blk) (Header blk))
+                m
+                (AnchoredFragment (Header blk))
+         -- ^ Fork, anchored at @i@, contains (the header of) @b@ and ends
+         -- with the suffix @s@.
+    constructFork i hashes suffixHashes
+      = fmap (AF.fromOldestFirst (castPoint i))
+      $ mapM (getKnownHeaderThroughCache cdbVolDB)
+      $ NE.toList hashes <> suffixHashes
+
+
+-- | Check whether the header for the hash is in the cache, if not, get
+-- the corresponding header from the VolatileDB and store it in the cache.
+--
+-- PRECONDITION: the header (block) must exist in the VolatileDB.
+getKnownHeaderThroughCache
+  :: (MonadCatch m, HasHeader blk, GetHeader blk)
+  => VolDB m blk
+  -> HeaderHash blk
+  -> StateT (Map (HeaderHash blk) (Header blk)) m (Header blk)
+getKnownHeaderThroughCache volDB hash = gets (Map.lookup hash) >>= \case
+  Just hdr -> return hdr
+  Nothing  -> do
+    hdr <- lift $ VolDB.getKnownHeader volDB hash
+    modify (Map.insert hash hdr)
+    return hdr
+
+-- | Perform chain selection with the given candidates. If a validated
+-- candidate was chosen to replace the current chain, return it along with the
+-- corresponding ledger.
+--
+-- PRECONDITION: all candidates must be preferred over the current chain.
+--
+-- PRECONDITION: the candidate suffixes must fit on the (given) current chain.
+chainSelection
+  :: forall m blk.
+     ( MonadSTM m
+     , ProtocolLedgerView blk
+     , HasCallStack
+     )
+  => LgrDB m blk
+  -> Tracer m (TraceValidationEvent blk)
+  -> NodeConfig (BlockProtocol blk)
+  -> TVar m (Set (Point blk))  -- ^ The invalid points
+  -> ChainAndLedger blk              -- ^ The current chain and ledger
+  -> NonEmpty (CandidateSuffix blk)  -- ^ Candidates
+  -> m (Maybe (ChainAndLedger blk))
+     -- ^ The (valid) chain and corresponding LedgerDB that was selected, or
+     -- 'Nothing' if there is no valid chain preferred over the current
+     -- chain.
+chainSelection lgrDB tracer cfg invalidPoints
+               curChainAndLedger@(ChainAndLedger curChain _) candidates =
+  assert (all (isJust . fitCandidateSuffixOn curChain) candidates) $
+    go (sortCandidates (NE.toList candidates))
+  where
+    sortCandidates :: [CandidateSuffix blk] -> [CandidateSuffix blk]
+    sortCandidates =
+      sortBy (flip (compareCandidates cfg) `on` _suffix)
+
+    validate :: ChainAndLedger  blk  -- ^ Current chain and ledger
+             -> CandidateSuffix blk  -- ^ Candidate fragment
+             -> m (Maybe (ChainAndLedger blk))
+    validate = validateCandidate lgrDB tracer cfg invalidPoints
+
+    -- 1. Take the first candidate from the list of sorted candidates
+    -- 2. Validate it
+    --    - If it is invalid -> discard it and go to 1 with the rest of the
+    --      list.
+    --    - If it is valid and has the same tip -> return it
+    --    - If it is valid, but is a prefix of the original ->
+    --        add it to the list, sort it and go to 1. See the comment
+    --        [Ouroboros] below.
+    go :: [CandidateSuffix blk] -> m (Maybe (ChainAndLedger blk))
+    go []                                           = return Nothing
+    go (cand@(CandidateSuffix _ candSuffix):cands') =
+      validate curChainAndLedger cand >>= \case
+        Nothing ->
+          go cands'
+        Just newChainAndLedger@(ChainAndLedger candChain _)
+            | validatedHead == AF.headPoint candSuffix
+              -- Unchanged candidate
+            -> return $ Just newChainAndLedger
+            | otherwise
+              -- Prefix of the candidate because it contained invalid blocks
+              -- TODO spec says go back to candidate selection, see
+              -- [^whyGoBack], because now there might still be some
+              -- candidates that contain the same invalid block.
+            -> go (sortCandidates (candSuffix':cands'))
+          where
+            validatedHead = AF.headPoint candChain
+            candSuffix'   = rollbackCandidateSuffix
+              (castPoint validatedHead) cand
+    -- [Ouroboros]
+    --
+    -- Ouroboros says that when we are given an invalid chain by a peer, we
+    -- should reject that peer's chain. However, since we're throwing all
+    -- blocks together in the ChainDB, we can't tell which block or which
+    -- chain came from which peer, so we can't simply reject a peer's chain.
+    --
+    -- It might be that a good peer gave us a valid chain, but another peer
+    -- gave us an invalid block that fits onto the chain of the good peer. In
+    -- that case, we do still want to adopt the chain of the good peer, which
+    -- is a prefix of the chain that we constructed using all the blocks we
+    -- found in the VolatileDB, including the invalid block.
+    --
+    -- This is the reason why we still take valid prefixes of a invalid chains
+    -- into account during chain selection: they might correspond to the good
+    -- peer's valid chain.
+
+-- | Validate a candidate and return a 'ChainAndLedger' for it, i.e. a
+-- validated fragment along with a ledger corresponding to its tip (most
+-- recent block).
+--
+-- PRECONDITION: the candidate suffix must fit onto the given current chain.
+--
+-- If all blocks in the fragment are valid, then the fragment in the returned
+-- 'ChainAndLedger' is the same as the given candidate suffix fitted on top of
+-- the current chain ('fitCandidateSuffixOn').
+--
+-- If a block in the fragment is invalid, then the fragment in the returned
+-- 'ChainAndLedger' is a prefix of the given candidate fragment (upto the last
+-- valid block), if that fragment is still preferred ('preferCandidate') over
+-- the current chain, if not, 'Nothing' is returned.
+validateCandidate
+  :: forall m blk.
+     ( MonadSTM m
+     , ProtocolLedgerView blk
+     , HasCallStack
+     )
+  => LgrDB m blk
+  -> Tracer m (TraceValidationEvent blk)
+  -> NodeConfig (BlockProtocol blk)
+  -> TVar m (Set (Point blk))  -- ^ The invalid points
+  -> ChainAndLedger  blk       -- ^ Current chain and ledger
+  -> CandidateSuffix blk       -- ^ Candidate fragment
+  -> m (Maybe (ChainAndLedger blk))
+validateCandidate lgrDB tracer cfg invalidPoints
+                  (ChainAndLedger curChain curLedger) candSuffix =
+    LgrDB.validate lgrDB curLedger rollback newBlocks >>= \case
+      LgrDB.InvalidBlockInPrefix e pt -> do
+        let invalidPointsInCand = Set.fromList $ pointsStartingFrom pt
+        atomically $ modifyTVar' invalidPoints (Set.union invalidPointsInCand)
+        trace (InvalidBlock e pt)
+        trace (InvalidCandidate (_suffix candSuffix) InvalidBlockInPrefix)
+        return Nothing
+      LgrDB.PushSuffix (LgrDB.InvalidBlock e pt ledger') -> do
+        let lastValid  = castPoint $ LgrDB.currentPoint ledger'
+            candidate' = fromMaybe
+              (error "cannot rollback to point on fragment") $
+              AF.rollback lastValid candidate'
+        let invalidPointsInCand = Set.fromList $ pointsStartingFrom pt
+        atomically $ modifyTVar' invalidPoints (Set.union invalidPointsInCand)
+        trace (InvalidBlock e pt)
+
+        -- The candidate is now a prefix of the original candidate. We
+        -- already know the candidate is at least as long as the current
+        -- chain (otherwise, we'd be in the 'InvalidBlockInPrefix' case). We
+        -- always prefer longer chains, but the prefix of the candidate
+        -- might be exactly as long as the current chain, in which case we
+        -- must check again whether it is preferred over the current chain.
+        if preferCandidate cfg curChain candidate'
+          then do
+            trace (ValidCandidate (_suffix candSuffix))
+            return $ Just $ mkChainAndLedger candidate' ledger'
+          else do
+            trace (InvalidCandidate (_suffix candSuffix) InvalidBlockInSuffix)
+            return Nothing
+      LgrDB.PushSuffix (LgrDB.ValidBlocks ledger') -> do
+        trace (ValidCandidate (_suffix candSuffix))
+        return $ Just $ mkChainAndLedger candidate ledger'
+  where
+    trace = traceWith tracer
+    CandidateSuffix rollback suffix = candSuffix
+    newBlocks = AF.toOldestFirst suffix
+    candidate = fromMaybe
+      (error "candidate suffix doesn't fit on the current chain") $
+      fitCandidateSuffixOn curChain candSuffix
+
+    -- | Make a list of all the points after from the given point (inclusive)
+    -- in the candidate fragment.
+    --
+    -- PRECONDITON: the given point is on the candidate fragment.
+    pointsStartingFrom :: HasCallStack => Point blk -> [Point blk]
+    pointsStartingFrom pt = case AF.splitBeforePoint suffix pt of
+        Nothing                  -> error "point not on fragment"
+        Just (_, startingFromPt) ->
+          map headerPoint $ AF.toOldestFirst startingFromPt
+
+{-------------------------------------------------------------------------------
+  Auxiliary data types for 'cdbAddBlock'
+-------------------------------------------------------------------------------}
+
+-- | Auxiliary data type for 'cdbAddBlock' for a chain with a ledger that
+-- corresponds to it.
+--
+-- INVARIANT:
+-- > for (x :: ChainAndLedger blk),
+-- >   AF.headPoint (_chain x) == LgrDB.currentPoint (_ledger x)
+data ChainAndLedger blk = ChainAndLedger
+  { clChain  :: !(AnchoredFragment (Header blk))
+    -- ^ Chain fragment
+  , clLedger :: !(LgrDB.LedgerDB blk)
+    -- ^ Ledger corresponding to '_chain'
+  }
+
+mkChainAndLedger :: (HasHeader blk , UpdateLedger blk)
+                 => AnchoredFragment (Header blk) -> LgrDB.LedgerDB blk
+                 -> ChainAndLedger blk
+mkChainAndLedger c l =
+    assert (castPoint (AF.headPoint c) == LgrDB.currentPoint l) $
+    ChainAndLedger c l
+
+-- | Auxiliary data type for 'cdbAddBlock' for a candidate suffix.
+--
+-- INVARIANT: the length of the suffix must always be >= the rollback
+data CandidateSuffix blk = CandidateSuffix
+  { _rollback :: !Word64
+    -- ^ The number of headers to roll back the current chain
+  , _suffix   :: !(AnchoredFragment (Header blk))
+    -- ^ The new headers to add after rolling back the current chain.
+  }
+
+deriving instance (HasHeader blk, Eq (Header blk))
+               => Eq   (CandidateSuffix blk)
+deriving instance (HasHeader blk, Show (Header blk))
+               => Show (CandidateSuffix blk)
+
+mkCandidateSuffix :: HasHeader (Header blk)
+                  => Word64
+                  -> AnchoredFragment (Header blk)
+                  -> CandidateSuffix blk
+mkCandidateSuffix rollback suffix =
+    assert (fromIntegral (AF.length suffix) >= rollback) $
+    CandidateSuffix rollback suffix
+
+-- | Fit the candidate suffix on a chain after first rolling back the given
+-- chain.
+--
+-- If the given chain is the current chain on which the candidate is based, a
+-- 'Just' will be returned. The returned candidate fragment will have the same
+-- anchor point as the given chain.
+fitCandidateSuffixOn :: HasHeader (Header blk)
+                     => AnchoredFragment (Header blk)
+                     -> CandidateSuffix  blk
+                     -> Maybe (AnchoredFragment (Header blk))
+fitCandidateSuffixOn curChain (CandidateSuffix rollback suffix) =
+    AF.join (AF.dropNewest (fromIntegral rollback) curChain) suffix
+
+-- | Roll back the candidate suffix to the given point.
+--
+-- PRECONDITION: the given point must correspond to one of the new headers of
+-- the candidate suffix ('_suffix').
+--
+-- PRECONDITION: the length of the suffix rolled back to the given point must
+-- be >= the rollback ('_rollback').
+rollbackCandidateSuffix :: (HasHeader (Header blk), HasCallStack)
+                        => Point           blk
+                        -> CandidateSuffix blk
+                        -> CandidateSuffix blk
+rollbackCandidateSuffix pt (CandidateSuffix rollback suffix)
+    | Just suffix' <- AF.rollback (castPoint pt) suffix
+    = mkCandidateSuffix rollback suffix'
+    | otherwise
+    = error "rollback point not on the candidate suffix"
+
+-- | Calculate the candidate suffix of a fork of the current chain.
+--
+-- If the candidate fragment is shorter than the current chain, 'Nothing' is
+-- returned (this would violate the invariant of 'CandidateSuffix').
+--
+-- PRECONDITION: the candidate fragment must intersect with the current chain
+-- fragment.
+intersectCandidateSuffix
+  :: (HasHeader (Header blk), HasCallStack)
+  => AnchoredFragment (Header blk)          -- ^ Current chain
+  -> AnchoredFragment (Header blk)          -- ^ Candidate chain
+  -> Maybe (CandidateSuffix   blk)  -- ^ Candidate suffix
+intersectCandidateSuffix curChain candChain =
+  case AF.intersect curChain candChain of
+    Just (_curChainPrefix, _candPrefix, curChainSuffix, candSuffix)
+      -> let rollback = AF.length curChainSuffix
+         in if AF.length candSuffix >= rollback
+            then Just $ mkCandidateSuffix (fromIntegral rollback) candSuffix
+            else Nothing
+    -- Precondition violated.
+    _ -> error "candidate fragment doesn't intersect with current chain"
+
+
+{-------------------------------------------------------------------------------
+  Helpers
+-------------------------------------------------------------------------------}
+
+-- | Get the 'BlockNo' corresponding to the block @k@ blocks back in the given
+-- new chain, i.e. the most recent \"immutable\" block.
+--
+-- As the given chain might be shorter than @k@ (see 'cdbImmBlockNo' for why),
+-- the 'BlockNo' of the previous \"immutable\" block must be passed, since in
+-- that case, it will not change.
+--
+-- Also, when switching to a chain that is exactly as long as the current
+-- chain, there will be no header on the fragment @k@ blocks back, only the
+-- anchor point. In that case, the \"immutable\" block will also not change.
+getImmBlockNo
+  :: HasHeader (Header blk)
+  => SecurityParam
+  -> AnchoredFragment (Header blk)  -- ^ New chain
+  -> BlockNo  -- ^ 'BlockNo' of the previous \"immutable\" block
+  -> BlockNo
+getImmBlockNo (SecurityParam k) chain prevBlockNo =
+    fromMaybe prevBlockNo $
+    AF.headBlockNo $ AF.dropNewest (fromIntegral k) chain

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -1,0 +1,579 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE PatternSynonyms           #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TypeApplications          #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+-- | Thin wrapper around the ImmutableDB
+module Ouroboros.Storage.ChainDB.Impl.ImmDB (
+    ImmDB -- Opaque
+    -- * Initialization
+  , ImmDbArgs(..)
+  , defaultArgs
+  , openDB
+    -- * Getting and parsing blocks
+  , getBlockWithPoint
+  , getBlockAtTip
+  , getPointAtTip
+  , getSlotNoAtTip
+  , getKnownBlock
+  , getBlock
+  , getBlob
+    -- * Appending a block
+  , appendBlock
+    -- * Streaming
+  , streamBlocksFrom
+  , streamBlocksFromUnchecked
+  , streamBlocksAfter
+    -- * Wrappers
+  , closeDB
+  , reopen
+    -- * Re-exports
+  , Iterator(..)
+  , IteratorResult(..)
+  , ImmDB.ValidationPolicy(..)
+  , ImmDB.ImmutableDBError
+  ) where
+
+import           Codec.CBOR.Decoding (Decoder)
+import           Codec.CBOR.Encoding (Encoding)
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import           Control.Monad
+import           Control.Monad.Except
+import           Data.Bifunctor (first)
+import qualified Data.ByteString.Lazy as Lazy
+import           Data.Proxy
+import           Data.Word
+import           GHC.Stack (HasCallStack)
+import           System.FilePath ((</>))
+
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+import           Ouroboros.Network.Block (pattern BlockPoint, ChainHash (..),
+                     pattern GenesisPoint, HasHeader (..), HeaderHash, Point,
+                     SlotNo, atSlot, blockPoint, pointHash, pointSlot,
+                     withHash)
+import           Ouroboros.Network.Chain (genesisPoint, genesisSlotNo)
+
+import qualified Ouroboros.Consensus.Util.CBOR as Util.CBOR
+
+import           Ouroboros.Storage.ChainDB.API (ChainDbError (..),
+                     ChainDbFailure (..), StreamFrom (..), UnknownRange (..))
+import           Ouroboros.Storage.Common
+import           Ouroboros.Storage.EpochInfo (EpochInfo (..), newEpochInfo)
+import           Ouroboros.Storage.FS.API (HasFS, createDirectoryIfMissing)
+import           Ouroboros.Storage.FS.API.Types (MountPoint (..))
+import           Ouroboros.Storage.FS.IO (ioHasFS)
+import           Ouroboros.Storage.ImmutableDB (ImmutableDB, Iterator (..),
+                     IteratorResult (..))
+import qualified Ouroboros.Storage.ImmutableDB as ImmDB
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+-- | Thin wrapper around the ImmutableDB (opaque type)
+data ImmDB m blk = ImmDB {
+      immDB        :: ImmutableDB (HeaderHash blk) m
+    , decBlock     :: forall s. Decoder s blk
+    , encBlock     :: blk -> Encoding
+    , immEpochInfo :: EpochInfo m
+    , isEBB        :: blk -> Maybe (HeaderHash blk)
+    }
+
+{-------------------------------------------------------------------------------
+  Initialization
+-------------------------------------------------------------------------------}
+
+-- | Arguments to initialize the ImmutableDB
+--
+-- See also 'defaultArgs'.
+data ImmDbArgs m blk = forall h. ImmDbArgs {
+      immDecodeHash  :: forall s. Decoder s (HeaderHash blk)
+    , immDecodeBlock :: forall s. Decoder s blk
+    , immEncodeHash  :: HeaderHash blk -> Encoding
+    , immEncodeBlock :: blk -> Encoding
+    , immErr         :: ErrorHandling ImmDB.ImmutableDBError m
+    , immEpochSize   :: EpochNo -> m EpochSize
+    , immValidation  :: ImmDB.ValidationPolicy
+    , immIsEBB       :: blk -> Maybe (HeaderHash blk)
+    , immHasFS       :: HasFS m h
+    }
+
+-- | Default arguments when using the 'IO' monad
+--
+-- The following fields must still be defined:
+--
+-- * 'immDecodeHash'
+-- * 'immDecodeBlock'
+-- * 'immEncodeHash'
+-- * 'immEncodeBlock'
+-- * 'immEpochSize'
+-- * 'immValidation'
+-- * 'immIsEBB'
+defaultArgs :: FilePath -> ImmDbArgs IO blk
+defaultArgs fp = ImmDbArgs{
+      immErr   = EH.exceptions
+    , immHasFS = ioHasFS $ MountPoint (fp </> "immutable")
+      -- Fields without a default
+    , immDecodeHash  = error "no default for immDecodeHash"
+    , immDecodeBlock = error "no default for immDecodeBlock"
+    , immEncodeHash  = error "no default for immEncodeHash"
+    , immEncodeBlock = error "no default for immEncodeBlock"
+    , immEpochSize   = error "no default for immEpochSize"
+    , immValidation  = error "no default for immValidation"
+    , immIsEBB       = error "no default for immIsEBB"
+    }
+
+openDB :: (MonadSTM m, MonadST m, MonadCatch m, HasHeader blk)
+       => ImmDbArgs m blk -> m (ImmDB m blk)
+openDB args@ImmDbArgs{..} = do
+    createDirectoryIfMissing immHasFS True []
+    immEpochInfo <- newEpochInfo immEpochSize
+    immDB <- ImmDB.openDB
+               immDecodeHash
+               immEncodeHash
+               immHasFS
+               immErr
+               immEpochInfo
+               immValidation
+               (epochFileParser args)
+    return ImmDB
+      { immDB        = immDB
+      , decBlock     = immDecodeBlock
+      , encBlock     = immEncodeBlock
+      , immEpochInfo = immEpochInfo
+      , isEBB        = immIsEBB
+      }
+
+{-------------------------------------------------------------------------------
+  Getting and parsing blocks
+-------------------------------------------------------------------------------}
+
+-- | Return the block corresponding to the given point, if it is part of the
+-- ImmutableDB.
+--
+-- If we have a block at the slot of the point, but its hash differs, we
+-- return 'Nothing'.
+getBlockWithPoint :: forall m blk. (MonadCatch m, HasHeader blk, HasCallStack)
+                  => ImmDB m blk -> Point blk -> m (Maybe blk)
+getBlockWithPoint _  GenesisPoint   = throwM $ NoGenesisBlock @blk
+getBlockWithPoint db BlockPoint { withHash = hash, atSlot = slot } =
+    -- Unfortunately a point does not give us enough information to determine
+    -- whether this corresponds to a regular block or an EBB. We will
+    -- optimistically assume it refers to a regular block, and only when that
+    -- fails try to read the EBB instead. This means that
+    --
+    -- - If it is indeed a regular block performance is optimal
+    -- - If it is an EBB we would needlessly have read a regular block from
+    --   disk first, but EBBs are rare (1:20000 before the hard fork, and
+    --   non-existent after)
+    -- - If the block does not exist in the database at all, we'd have done two
+    --   reads before returning 'Nothing', but both of those reads are cheap
+    getBlockWithHash (Right slot) >>= \case
+      Just block -> return (Just block)
+      Nothing    -> do
+        epochNo <- epochInfoEpoch slot
+        getBlockWithHash (Left epochNo)
+  where
+    EpochInfo{..} = immEpochInfo db
+
+    -- Important: we check whether the block's hash matches the point's hash
+    getBlockWithHash epochOrSlot = getBlock db epochOrSlot >>= \case
+      Just block | blockHash block == hash -> return $ Just block
+      _                                    -> return $ Nothing
+
+getBlockAtTip :: (MonadCatch m, HasHeader blk, HasCallStack)
+              => ImmDB m blk -> m (Maybe blk)
+getBlockAtTip db = do
+    immTip <- withDB db $ \imm -> ImmDB.getTip imm
+    case immTip of
+      TipGen             -> return Nothing
+      Tip (Left epochNo) -> Just <$> getKnownBlock db (Left epochNo)
+      Tip (Right slotNo) -> Just <$> getKnownBlock db (Right slotNo)
+
+getPointAtTip :: forall m blk.
+                 (MonadCatch m, HasHeader blk, HasCallStack)
+              => ImmDB m blk -> m (Point blk)
+getPointAtTip = fmap mbBlockToPoint . getBlockAtTip
+  where
+    mbBlockToPoint :: Maybe blk -> Point blk
+    mbBlockToPoint Nothing    = genesisPoint
+    mbBlockToPoint (Just blk) = blockPoint blk
+
+getSlotNoAtTip :: (MonadCatch m, HasHeader blk)
+               => ImmDB m blk -> m SlotNo
+getSlotNoAtTip db = do
+    immTip <- withDB db $ \imm -> ImmDB.getTip imm
+    case immTip of
+      TipGen             -> return genesisSlotNo
+      Tip (Left epochNo) -> epochInfoFirst epochNo
+      Tip (Right slotNo) -> return slotNo
+  where
+    EpochInfo{..} = immEpochInfo db
+
+-- | Get known block from the ImmutableDB that we know should exist
+--
+-- If it does not exist, we are dealing with data corruption.
+getKnownBlock :: (MonadCatch m, HasHeader blk, HasCallStack)
+              => ImmDB m blk -> Either EpochNo SlotNo -> m blk
+getKnownBlock db epochOrSlot = do
+    mBlock <- mustExist epochOrSlot <$> getBlock db epochOrSlot
+    case mBlock of
+      Right b  -> return b
+      Left err -> throwM err
+
+-- | Get block from the ImmutableDB
+getBlock :: (MonadCatch m, HasHeader blk, HasCallStack)
+         => ImmDB m blk -> Either EpochNo SlotNo -> m (Maybe blk)
+getBlock db epochOrSlot = do
+    mBlob <- fmap (parse (decBlock db) epochOrSlot) <$> getBlob db epochOrSlot
+    case mBlob of
+      Nothing         -> return $ Nothing
+      Just (Right b)  -> return $ Just b
+      Just (Left err) -> throwM $ err
+
+getBlob :: (MonadCatch m, HasHeader blk, HasCallStack)
+        => ImmDB m blk -> Either EpochNo SlotNo -> m (Maybe Lazy.ByteString)
+getBlob db epochOrSlot = withDB db $ \imm ->
+    case epochOrSlot of
+      Left epochNo -> fmap snd <$> ImmDB.getEBB imm epochNo
+      Right slotNo -> ImmDB.getBinaryBlob imm slotNo
+
+{-------------------------------------------------------------------------------
+  Appending a block
+-------------------------------------------------------------------------------}
+
+-- | Appends the given block (as a regular block or EBB) to the ImmutableDB.
+--
+-- Does not check whether the block is in the past or not.
+appendBlock :: (MonadCatch m, HasHeader blk, HasCallStack)
+            => ImmDB m blk -> blk -> m ()
+appendBlock db@ImmDB{..} b = withDB db $ \imm -> case isEBB b of
+    Nothing   ->
+      ImmDB.appendBinaryBlob imm slotNo (CBOR.toBuilder (encBlock b))
+    Just hash -> do
+      epochNo <- epochInfoEpoch slotNo
+      ImmDB.appendEBB imm epochNo hash (CBOR.toBuilder (encBlock b))
+  where
+    slotNo = blockSlot b
+    EpochInfo{..} = immEpochInfo
+
+{-------------------------------------------------------------------------------
+  Streaming
+-------------------------------------------------------------------------------}
+
+-- | Stream blocks from the given 'StreamFrom'.
+--
+-- Checks whether the block at the lower bound has the right hash. If not,
+-- 'Nothing' is returned. This check comes at a cost, as to know the hash of a
+-- block, it first has be read from disk.
+--
+-- When the slot of the lower bound is greater than the slot at the tip in the
+-- ImmutableDB, we return 'MissingBlock' (instead of throwing a
+-- 'ReadFutureSlotError' or 'ReadFutureEBBError').
+--
+-- When passed @'StreamFromInclusive' pt@ where @pt@ refers to Genesis, a
+-- 'NoGenesisBlock' exception will be thrown.
+streamBlocksFrom :: forall m blk.
+                   ( MonadCatch m
+                   , HasHeader blk
+                   )
+                 => ImmDB m blk
+                 -> StreamFrom blk
+                 -> m (Either (UnknownRange blk)
+                              (ImmDB.Iterator (HeaderHash blk) m blk))
+streamBlocksFrom db from = withDB db $ \imm -> runExceptT $ case from of
+    StreamFromExclusive pt@BlockPoint { atSlot = slot, withHash = hash } -> do
+      checkFutureSlot pt
+      it    <- stream imm (Just (slot, hash)) Nothing
+      itRes <- lift $ iteratorNext it
+      if blockMatchesPoint itRes pt
+        then return it
+        else do
+          lift $ iteratorClose it
+          throwError $ MissingBlock pt
+    StreamFromExclusive    GenesisPoint ->
+      stream imm Nothing Nothing
+    StreamFromInclusive pt@BlockPoint { atSlot = slot, withHash = hash } -> do
+      checkFutureSlot pt
+      it    <- stream imm (Just (slot, hash)) Nothing
+      itRes <- lift $ iteratorPeek it
+      if blockMatchesPoint itRes pt
+        then return it
+        else do
+          lift $ iteratorClose it
+          throwError $ MissingBlock pt
+    StreamFromInclusive    GenesisPoint ->
+      throwM $ NoGenesisBlock @blk
+  where
+    -- | Check if the slot of the lower bound is <= the slot of the tip. If
+    -- not, throw a 'MissingBlock' error.
+    --
+    -- Note that between this check and the actual opening of the iterator, a
+    -- block may be appended to the ImmutableDB such that the requested slot
+    -- is no longer in the future, but we have returned 'MissingBlock'
+    -- nonetheless. This is fine, since the request to stream from the slot
+    -- was made earlier, at a moment where it still was in the future.
+    checkFutureSlot :: Point blk -> ExceptT (UnknownRange blk) m ()
+    checkFutureSlot pt = do
+      slotNoAtTip <- lift $ getSlotNoAtTip db
+      when (pointSlot pt > slotNoAtTip) $
+        throwError $ MissingBlock pt
+
+    stream imm start end = lift $ parseIterator db <$>
+      ImmDB.streamBinaryBlobs imm start end
+
+    -- | Check that the result of the iterator is a block that matches the
+    -- given point.
+    blockMatchesPoint :: ImmDB.IteratorResult (HeaderHash blk) blk
+                      -> Point blk
+                      -> Bool
+    blockMatchesPoint itRes pt = case itRes of
+      ImmDB.IteratorExhausted    -> False
+      ImmDB.IteratorResult _ blk -> blockPoint blk == pt
+      ImmDB.IteratorEBB  _ _ blk -> blockPoint blk == pt
+
+-- | Same as 'streamBlocksFrom', but without checking the hash of the lower
+-- bound.
+--
+-- There is still a cost when the lower bound is 'StreamFromExclusive': the
+-- block will be read from disk, but it won't be parsed.
+--
+-- When passed @'StreamFromInclusive' pt@ where @pt@ refers to Genesis, a
+-- 'NoGenesisBlock' exception will be thrown.
+streamBlocksFromUnchecked  :: forall m blk.
+                              ( MonadCatch m
+                              , HasHeader blk
+                              )
+                           => ImmDB m blk
+                           -> StreamFrom blk
+                           -> m (ImmDB.Iterator (HeaderHash blk) m blk)
+streamBlocksFromUnchecked db from = withDB db $ \imm -> case from of
+    StreamFromExclusive BlockPoint { atSlot = slot, withHash = hash } -> do
+      it    <- ImmDB.streamBinaryBlobs imm (Just (slot, hash)) Nothing
+      void $ iteratorNext it
+      return $ parseIterator db it
+    StreamFromExclusive    GenesisPoint ->
+      stream imm Nothing Nothing
+    StreamFromInclusive BlockPoint { atSlot = slot, withHash = hash } ->
+      stream imm (Just (slot, hash)) Nothing
+    StreamFromInclusive    GenesisPoint ->
+      throwM $ NoGenesisBlock @blk
+  where
+    stream imm start end = parseIterator db <$>
+      ImmDB.streamBinaryBlobs imm start end
+
+-- | Stream blocks after the given point
+--
+-- See also 'streamBlobsAfter'.
+--
+-- PRECONDITION: the exclusive lower bound is part of the ImmutableDB.
+streamBlocksAfter :: forall m blk. (MonadCatch m, HasHeader blk)
+                  => ImmDB m blk
+                  -> Point blk -- ^ Exclusive lower bound
+                  -> m (Iterator (HeaderHash blk) m blk)
+streamBlocksAfter db low = parseIterator db <$> streamBlobsAfter db low
+
+-- | Stream blobs after the given point
+--
+-- Our 'Point' based API and the 'SlotNo' + @hash@ based API of the
+-- 'ImmutableDB' have a slight impedance mismatch: the bounds offered by the
+-- 'ImmutableDB' are inclusive, /if specified/. We can't offer that here,
+-- since it does not make sense to stream /from/ (inclusive) the genesis
+-- block. Therefore we provide an /exclusive/ lower bound as a 'Point': if the
+-- 'Point' refers to the genesis block we don't give the 'ImmutableDB' a lower
+-- bound at all; if it doesn't, we pass the hash as the lower bound to the
+-- 'ImmutableDB' and then step the iterator one block to skip that first
+-- block.
+streamBlobsAfter :: forall m blk. (MonadCatch m, HasHeader blk)
+                 => ImmDB m blk
+                 -> Point blk -- ^ Exclusive lower bound
+                 -> m (Iterator (HeaderHash blk) m Lazy.ByteString)
+streamBlobsAfter db low = withDB db $ \imm -> do
+    itr   <- ImmDB.streamBinaryBlobs imm low' Nothing
+    skipAndCheck itr
+    return itr
+  where
+    low' :: Maybe (SlotNo, HeaderHash blk)
+    low' = case pointHash low of
+             GenesisHash -> Nothing
+             BlockHash h -> Just (pointSlot low, h)
+
+    -- Skip the first block (if any) to provide an /exclusive/ lower bound
+    --
+    -- Take advantage of the opportunity to also verify the hash (which the
+    -- ImmutableDB can't, since it cannot compute hashes)
+    skipAndCheck :: Iterator (HeaderHash blk) m Lazy.ByteString -> m ()
+    skipAndCheck itr =
+        case low' of
+          Nothing           -> return ()
+          Just (slot, hash) -> do
+            skipped <- parseIteratorResult db =<< iteratorNext itr
+            case skipped of
+              IteratorResult slot' blk ->
+                  unless (hash == hash' && slot == slot') $
+                    throwM $ ImmDbHashMismatch low hash hash'
+                where
+                  hash' = blockHash blk
+              IteratorEBB _epoch hash' _ebb ->
+                  -- We can't easily verify the slot, since all we have is the
+                  -- epoch number. We could do the conversion but it doesn't
+                  -- really matter: the hash uniquely determines the block.
+                  unless (hash == hash') $
+                    throwM $ ImmDbHashMismatch low hash hash'
+              IteratorExhausted ->
+                  throwM $ ImmDbUnexpectedIteratorExhausted low
+
+-- | Parse the bytestrings returned by an iterator as blocks.
+parseIterator :: (MonadThrow m, HasHeader blk)
+              => ImmDB m blk
+              -> Iterator (HeaderHash blk) m Lazy.ByteString
+              -> Iterator (HeaderHash blk) m blk
+parseIterator db itr = Iterator {
+      iteratorNext    = parseIteratorResult db =<< iteratorNext itr
+    , iteratorPeek    = parseIteratorResult db =<< iteratorPeek itr
+    , iteratorHasNext = iteratorHasNext itr
+    , iteratorClose   = iteratorClose   itr
+    , iteratorID      = ImmDB.DerivedIteratorID $ iteratorID itr
+    }
+
+parseIteratorResult :: (MonadThrow m, HasHeader blk)
+                    => ImmDB m blk
+                    -> IteratorResult (HeaderHash blk) Lazy.ByteString
+                    -> m (IteratorResult (HeaderHash blk) blk)
+parseIteratorResult db result =
+    case result of
+      IteratorExhausted ->
+        return IteratorExhausted
+      (IteratorResult slotNo bs) ->
+        case parse (decBlock db) (Right slotNo) bs of
+          Left  err -> throwM err
+          Right blk -> return $ IteratorResult slotNo blk
+      (IteratorEBB epochNo hash bs) ->
+        case parse (decBlock db) (Left epochNo) bs of
+          Left  err -> throwM err
+          Right blk -> return $ IteratorEBB epochNo hash blk
+
+{-------------------------------------------------------------------------------
+  Internal: parsing
+-------------------------------------------------------------------------------}
+
+data EpochFileError =
+    EpochErrRead Util.CBOR.ReadIncrementalErr
+  | EpochErrUnexpectedEBB
+
+epochFileParser :: forall m blk. (MonadST m, MonadThrow m, HasHeader blk)
+                => ImmDbArgs m blk
+                -> ImmDB.EpochFileParser
+                     EpochFileError
+                     (HeaderHash blk)
+                     m
+                     (Word64, SlotNo)
+epochFileParser ImmDbArgs{..} =
+    ImmDB.EpochFileParser $
+        fmap (processEpochs (Proxy @blk))
+      . Util.CBOR.readIncrementalOffsets immHasFS decoder'
+  where
+    -- It is important that we don't first parse all blocks, storing them all
+    -- in memory, and only /then/ extract the information we need.
+    decoder' :: forall s. Decoder s (SlotNo, Maybe (HeaderHash blk))
+    decoder' = (\b -> (blockSlot b, immIsEBB b)) <$> immDecodeBlock
+
+-- | Verify that there is at most one EBB in the epoch file and that it
+-- lives at the start of the file
+processEpochs :: forall blk.
+                 Proxy blk
+              -> ( [(Word64, (Word64, (SlotNo, Maybe (HeaderHash blk))))]
+                 , Maybe Util.CBOR.ReadIncrementalErr
+                 )
+              -> ( [(SlotOffset, (Word64, SlotNo))]
+                 , Maybe (HeaderHash blk)
+                 , Maybe EpochFileError
+                 )
+processEpochs _ = \(bs, mErr) ->
+    case bs of
+      []    -> ([], Nothing, EpochErrRead <$> mErr)
+      b:bs' -> let (bOff, (bSz, (bSlot, bEBB))) = b
+                   (slots, mErr') = go bs'
+               in ((bOff, (bSz, bSlot)) : slots, bEBB, earlierError mErr mErr')
+  where
+    -- Check that the rest of the blocks are not EBBs
+    go :: [(Word64, (Word64, (SlotNo, Maybe (HeaderHash blk))))]
+       -> ( [(SlotOffset, (Word64, SlotNo))]
+          , Maybe EpochFileError
+          )
+    go []     = ( [], Nothing )
+    go (b:bs) = let (bOff, (bSz, (bSlot, bEBB))) = b
+                in case bEBB of
+                     Just _  -> ( [], Just EpochErrUnexpectedEBB )
+                     Nothing -> first ((bOff, (bSz, bSlot)) :) $ go bs
+
+    -- Report the earlier error
+    --
+    -- The 'ReadIncrementalError' reported by the parser tells us that there
+    -- were blocks /after/ the ones that were returned that failed to parse.
+    -- If therefore /we/ find an error in those blocks that were returned, that
+    -- error happens /earlier/ in the file.
+    earlierError :: Maybe Util.CBOR.ReadIncrementalErr
+                 -> Maybe EpochFileError
+                 -> Maybe EpochFileError
+    earlierError _parserErr (Just ourErr) = Just ourErr
+    earlierError  parserErr Nothing       = EpochErrRead <$> parserErr
+
+{-------------------------------------------------------------------------------
+  Error handling
+-------------------------------------------------------------------------------}
+
+-- | Wrap calls to the ImmutableDB and rethrow exceptions that may indicate
+-- disk failure and should therefore trigger recovery
+withDB :: forall m blk x. (MonadCatch m, HasHeader blk)
+       => ImmDB m blk -> (ImmutableDB (HeaderHash blk) m -> m x) -> m x
+withDB ImmDB{..} k = catch (k immDB) rethrow
+  where
+    rethrow :: ImmDB.ImmutableDBError -> m x
+    rethrow err = case wrap err of
+                    Just err' -> throwM err'
+                    Nothing   -> throwM err
+
+    wrap :: ImmDB.ImmutableDBError -> Maybe (ChainDbFailure blk)
+    wrap (ImmDB.UnexpectedError err) = Just (ImmDbFailure err)
+    wrap ImmDB.UserError{}           = Nothing
+
+mustExist :: Either EpochNo SlotNo
+          -> Maybe blk
+          -> Either (ChainDbFailure blk) blk
+mustExist epochOrSlot Nothing  = Left  $ ImmDbMissingBlock epochOrSlot
+mustExist _           (Just b) = Right $ b
+
+parse :: forall blk.
+         (forall s. Decoder s blk)
+      -> Either EpochNo SlotNo
+      -> Lazy.ByteString
+      -> Either (ChainDbFailure blk) blk
+parse dec epochOrSlot =
+    aux . CBOR.deserialiseFromBytes dec
+  where
+    aux :: Either CBOR.DeserialiseFailure (Lazy.ByteString, blk)
+        -> Either (ChainDbFailure blk) blk
+    aux (Right (bs, b))
+      | Lazy.null bs = Right b
+      | otherwise    = Left $ ImmDbTrailingData epochOrSlot bs
+    aux (Left err)   = Left $ ImmDbParseFailure epochOrSlot err
+
+{-------------------------------------------------------------------------------
+  Wrappers
+-------------------------------------------------------------------------------}
+
+closeDB :: (MonadCatch m, HasHeader blk, HasCallStack)
+        => ImmDB m blk -> m ()
+closeDB db = withDB db ImmDB.closeDB
+
+reopen :: (MonadCatch m, HasHeader blk, HasCallStack)
+       => ImmDB m blk -> m ()
+reopen db = withDB db $ \imm ->
+    ImmDB.reopen imm ImmDB.ValidateMostRecentEpoch

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
@@ -1,0 +1,628 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+-- | Iterators
+module Ouroboros.Storage.ChainDB.Impl.Iterator
+  ( streamBlocks
+  , closeAllIterators
+  ) where
+
+import           Control.Monad (unless, when)
+import           Control.Monad.Except (ExceptT (..), lift, runExceptT,
+                     throwError)
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as Map
+import           GHC.Stack (HasCallStack)
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+import           Control.Tracer
+
+import           Ouroboros.Network.Block (HasHeader, HeaderHash, blockHash,
+                     blockPoint, pointSlot)
+
+import           Ouroboros.Storage.ChainDB.API (ChainDbError (..),
+                     Iterator (..), IteratorId (..), IteratorResult (..),
+                     StreamFrom (..), StreamTo (..), UnknownRange (..),
+                     validBounds)
+
+import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
+import           Ouroboros.Storage.ChainDB.Impl.Types
+import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
+
+-- | Stream blocks
+--
+-- = Start & end point
+--
+-- The start point can either be in the ImmutableDB (on our chain) or in the
+-- VolatileDB (on our chain or on a recent fork). We first check whether it is
+-- in the VolatileDB, if not, we check if it is in the ImmutableDB (see
+-- \"Garbage collection\" for why this order is important). Similarly for the
+-- end point.
+--
+-- If a bound can't be found in the ChainDB, an 'UnknownRange' error is
+-- returned.
+--
+-- When the bounds are nonsensical, e.g.,
+-- > StreamFromExclusive (Point { pointSlot = SlotNo 3 , .. }
+-- > StreamToInclusive   (Point { pointSlot = SlotNo 3 , .. }
+-- An 'InvalidIteratorRange' exception is thrown.
+--
+-- = Paths of blocks
+--
+-- To stream blocks from the ImmutableDB we can simply use the iterators
+-- offered by the ImmutableDB.
+--
+-- To stream blocks from the VolatileDB we have to construct a path of block
+-- hashes backwards through the VolatileDB, starting from the end point using
+-- 'getPredecessor' until we get to the start point, genesis, or we get to a
+-- block that is not in the VolatileDB. Then, for each hash in the path, we
+-- can ask the VolatileDB for the corresponding block.
+--
+-- If the path through the VolatileDB is incomplete, we will first have to
+-- stream blocks from the ImmutableDB and then switch to the path through the
+-- VolatileDB. We only allow the tip of the ImmutableDB to be the switchover
+-- point between the two DBs. In other words, the incomplete path through the
+-- VolatileDB must fit onto the tip of the ImmutableDB. This must be true at
+-- the time of initialising the iterator, but does not have to hold during the
+-- whole lifetime of the iterator. If it doesn't fit on it, it means the path
+-- forked off more than @k@ blocks in the past and blocks belonging to it are
+-- more likely to go missing because of garbage-collection (see the next
+-- paragraph). In that case, we return 'ForkTooOld'.
+--
+-- = Garbage collection
+--
+-- We have to be careful about the following: as our chain grows, blocks from
+-- our chain will be copied to the ImmutableDB in the background. After a
+-- while, old blocks will be garbage-collected from the VolatileDB. Blocks
+-- that were part of the current chain will be in the ImmutableDB, but blocks
+-- that only lived on forks will be gone forever.
+--
+-- This means that blocks that were part of the VolatileDB when the iterator
+-- was initialised might no longer be part of the VolatileDB when we come to
+-- the point that the iterator will try to read them. When this is noticed, we
+-- will try to open an iterator from the ImmutableDB to obtain the blocks that
+-- have moved over. However, this will only work if they were and are part of
+-- the current chain, otherwise they will have been deleted from the
+-- VolatileDB without being copied to the ImmutableDB.
+--
+-- This iterator is opened with an open upper bound and will be used to stream
+-- blocks until the path has been fully streamed, the iterator is exhausted,
+-- or a block doesn't match the expected hash. In the latter two cases, we
+-- switch back to the VolatileDB. If the block is missing from the VolatileDB,
+-- we will switch back to streaming from the ImmutableDB. If that fails, we
+-- switch back to the VolatileDB. To avoid eternally switching between the two
+-- DBs, we only switch back to the VolatileDB if the stream from the
+-- ImmutableDB has made progress, i.e. streamed at least one block with the
+-- expected hash. If no block was streamed from the ImmutableDB, not even the
+-- first one, we know for sure that that block isn't part of the VolatileDB
+-- (the reason we switch to the ImmutableDB) and isn't part of the ImmutableDB
+-- (no block was streamed). In that case, we return 'IteratorBlockGCed' and
+-- stop the stream.
+--
+-- Note that the open upper bound doesn't allow us to include blocks in the
+-- stream that are copied to the ImmutableDB after opening this iterator, as
+-- the bound of the iterator is fixed upon initialisation. These newly added
+-- blocks will be included in the stream because we will repeatedly open new
+-- ImmutableDB iterators (as long as we make progress).
+--
+-- = Bounds checking
+--
+-- The ImmutableDB is slot-based instead of point-based, which means that
+-- before we know whether a block in the ImmutableDB matches a given point, we
+-- must first read that block to obtain its hash, after which we can then
+-- verify whether it matches the hash of the point. This is important for the
+-- start and end bounds (both points) of a stream: we must first read the
+-- blocks corresponding to the bounds to be sure the range is valid. Note that
+-- these reads happen before the first call to 'iteratorNext' (which will
+-- trigger a second read of the first block).
+--
+-- Note that when streaming to an /exclusive/ bound, the block corresponding
+-- to that bound ('Point') must exist in the ChainDB.
+--
+-- = Costs
+--
+-- Opening an iterator has some costs:
+--
+-- * When blocks have to be streamed from the ImmutableDB: as discussed in
+--   \"Bounds checking\", the blocks corresponding to the bounds have to be
+--   read from disk.
+--
+-- * When blocks have to be streamed both from the ImmutableDB and the
+--   VolatileDB, the blocks corresponding to the two bound will have to be
+--   read upfront, as described in the previous bullet point. Since the tip of
+--   the ImmutableDB must be the switchover point between the two, it will be
+--   the upper bound.
+--
+-- In summary:
+--
+-- * Only streaming from the VolatileDB: 0 blocks read upfront.
+-- * Only streaming from the ImmutableDB: 2 blocks read upfront.
+-- * Streaming from both the ImmutableDB and the VolatileDB: 2 blocks read
+--   upfront.
+--
+-- Additionally, when we notice during streaming that a block is no longer in
+-- the VolatileDB, we try to see whether it can be streamed from the
+-- ImmutableDB instead. Opening such an iterator (with an exclusive bound) has
+-- the cost of reading (but not parsing) one extra block from disk, in
+-- addition to the block(s) we are actually interested in. This can happen
+-- multiple times. See #548.
+streamBlocks
+  :: forall m blk.
+     ( MonadCatch m
+     , MonadSTM   m
+     , MonadThrow (STM m)
+     , HasHeader blk
+     , HasCallStack
+     )
+  => ChainDbHandle m blk
+  -> StreamFrom      blk
+  -> StreamTo        blk
+  -> m (Either (UnknownRange blk) (Iterator m blk))
+streamBlocks h from to = getEnv h $ \cdb -> newIterator cdb h from to
+
+-- | See 'streamBlocks'.
+newIterator
+  :: forall m blk.
+     ( MonadCatch m
+     , MonadSTM   m
+     , MonadThrow (STM m)
+     , HasHeader blk
+     , HasCallStack
+     )
+  => ChainDbEnv    m blk
+  -> ChainDbHandle m blk
+     -- ^ We need the handle to pass it on to the 'Iterator', so that each
+     -- time a function is called on the 'Iterator', we check whether the
+     -- ChainDB is actually open.
+  -> StreamFrom      blk
+  -> StreamTo        blk
+  -> m (Either (UnknownRange blk) (Iterator m blk))
+newIterator cdb@CDB{..} h from to = do
+    unless (validBounds from to) $
+      throwM $ InvalidIteratorRange from to
+    res <- runExceptT start
+    case res of
+      Left e -> trace $ UnknownRangeRequested e
+      _      -> return ()
+    return res
+  where
+    tracer :: Tracer m (TraceIteratorEvent blk)
+    tracer = contramap TraceIteratorEvent cdbTracer
+
+    trace = traceWith tracer
+
+    start :: HasCallStack => ExceptT (UnknownRange blk) m (Iterator m blk)
+    start = do
+      path <- lift $ atomically $ VolDB.computePathSTM cdbVolDB from to
+      case path of
+        VolDB.NotInVolDB        _hash           -> streamFromImmDB
+        VolDB.PartiallyInVolDB  predHash hashes -> streamFromBoth predHash hashes
+        VolDB.CompletelyInVolDB hashes          -> case NE.nonEmpty hashes of
+          Just hashes' -> lift $ streamFromVolDB hashes'
+          Nothing      -> lift $ emptyIterator
+
+    streamFromVolDB :: NonEmpty (HeaderHash blk) -> m (Iterator m blk)
+    streamFromVolDB hashes = do
+      trace $ StreamFromVolDB from to (NE.toList hashes)
+      createIterator $ InVolDB from hashes
+
+    streamFromImmDB :: HasCallStack
+                    => ExceptT (UnknownRange blk) m (Iterator m blk)
+    streamFromImmDB = do
+      lift $ trace $ StreamFromImmDB from to
+      streamFromImmDBHelper True
+
+    streamFromImmDBHelper :: HasCallStack
+                          => Bool -- ^ Check the hash of the upper bound
+                          -> ExceptT (UnknownRange blk) m (Iterator m blk)
+    streamFromImmDBHelper checkUpperBound = do
+        -- First check whether the block in the ImmDB at the end bound has the
+        -- correct hash.
+        when checkUpperBound $ do
+          slotNoAtTip <- lift $ ImmDB.getSlotNoAtTip cdbImmDB
+          when (pointSlot endPoint > slotNoAtTip) $
+            throwError $ MissingBlock endPoint
+          lift (ImmDB.getBlockWithPoint cdbImmDB endPoint) >>= \case
+            Just _  -> return ()
+            Nothing -> throwError $ MissingBlock endPoint
+        -- 'ImmDB.streamBlocksFrom' will check the hash of the block at the
+        -- start bound.
+        immIt <- ExceptT $ ImmDB.streamBlocksFrom cdbImmDB from
+        lift $ createIterator $ InImmDB from immIt (StreamTo to)
+      where
+        endPoint = case to of
+          StreamToInclusive pt -> pt
+          StreamToExclusive pt -> pt
+
+    -- | If we have to stream from both the ImmutableDB and the VolatileDB, we
+    -- only allow the (current) tip of the ImmutableDB to be the switchover
+    -- point between the two DBs. If not, this would mean we have to stream a
+    -- fork that forks off more than @k@ blocks in the past, in which case the
+    -- risk of blocks going missing due to GC increases. So we refuse such a
+    -- stream.
+    streamFromBoth :: HasCallStack
+                   => HeaderHash blk
+                   -> [HeaderHash blk]
+                   -> ExceptT (UnknownRange blk) m (Iterator m blk)
+    streamFromBoth predHash hashes = do
+        lift $ trace $ StreamFromBoth from to hashes
+        lift (ImmDB.getBlockAtTip cdbImmDB) >>= \case
+          -- The ImmutableDB is empty
+          Nothing -> throwError $ ForkTooOld from
+          -- The incomplete path fits onto the tip of the ImmutableDB.
+          Just blk | blockHash blk == predHash -> case NE.nonEmpty hashes of
+            Just hashes' -> stream (blockPoint blk) hashes'
+            -- The path is actually empty, but the exclusive upper bound was
+            -- in the VolatileDB. Just stream from the ImmutableDB without
+            -- checking the upper bound (which might not be in the
+            -- ImmutableDB)
+            Nothing      -> streamFromImmDBHelper False
+          -- The incomplete path doesn't fit onto the tip of the ImmutableDB.
+          -- Note that since we have constructed the incomplete path through
+          -- the VolatileDB, blocks might have moved from the VolatileDB to
+          -- the ImmutableDB so that the tip of the ImmutableDB has changed.
+          -- Either the path used to fit onto the tip but the tip has changed,
+          -- or the path simply never fitted onto the tip.
+          Just blk -> case dropWhile (/= blockHash blk) hashes of
+            -- The current tip is not in the path, this means that the path
+            -- never fitted onto the tip of the ImmutableDB. We refuse this
+            -- stream.
+            []                    -> throwError $ ForkTooOld from
+            -- The current tip is in the path, with some hashes after it, this
+            -- means that some blocks in our path have moved from the
+            -- VolatileDB to the ImmutableDB. We can shift the switchover
+            -- point to the current tip.
+            _tipHash:hash:hashes' -> stream (blockPoint blk) (hash NE.:| hashes')
+            -- The current tip is the end of the path, this means we can
+            -- actually stream everything from just the ImmutableDB. No need
+            -- to check the hash at the upper bound again.
+            [_tipHash]            -> streamFromImmDBHelper False
+      where
+        stream pt hashes' = do
+          let immEnd = SwitchToVolDBFrom (StreamToInclusive pt) hashes'
+          immIt <- ExceptT $ ImmDB.streamBlocksFrom cdbImmDB from
+          lift $ createIterator $ InImmDB from immIt immEnd
+
+    makeIterator :: Bool  -- ^ Register the iterator in 'cdbIterators'?
+                 -> IteratorState m blk
+                 -> m (Iterator m blk)
+    makeIterator register itState = do
+      iteratorId <- makeNewIteratorId
+      varItState <- newTVarM itState
+      when register $ atomically $ modifyTVar' cdbIterators $
+        -- Note that we don't use 'getEnv' here, because that would mean that
+        -- invoking the function only works when the database is open, which
+        -- probably won't be the case.
+        Map.insert iteratorId (implIteratorClose varItState iteratorId cdb)
+      return Iterator {
+          iteratorNext  = getEnv h $ implIteratorNext  varItState
+        , iteratorClose = getEnv h $ implIteratorClose varItState iteratorId
+        , iteratorId    = iteratorId
+        }
+
+    emptyIterator :: m (Iterator m blk)
+    emptyIterator = makeIterator False Closed
+
+    -- | This is 'makeIterator' +  it in 'cdbIterators'.
+    createIterator :: IteratorState m blk -> m (Iterator m blk)
+    createIterator = makeIterator True
+
+    makeNewIteratorId :: m IteratorId
+    makeNewIteratorId = atomically $ do
+      newIteratorId <- readTVar cdbNextIteratorId
+      modifyTVar' cdbNextIteratorId succ
+      return newIteratorId
+
+-- | Close the iterator and remove it from the map of iterators
+-- ('cdbIterators').
+implIteratorClose
+  :: MonadSTM m
+  => TVar m (IteratorState m blk)
+  -> IteratorId
+  -> ChainDbEnv m blk
+  -> m ()
+implIteratorClose varItState itrId CDB{..} = do
+    mbImmIt <- atomically $ do
+      modifyTVar' cdbIterators (Map.delete itrId)
+      mbImmIt <- iteratorStateImmIt <$> readTVar varItState
+      writeTVar varItState Closed
+      return mbImmIt
+    mapM_ ImmDB.iteratorClose mbImmIt
+
+-- | Possible states of an iterator.
+--
+-- When streaming solely from the ImmutableDB ('InImmDB' where 'InImmDBEnd' is
+-- /not/ 'SwitchToVolDBFrom'): we will remain in this state until we are done,
+-- and end up in 'Closed'.
+--
+-- When streaming solely from the VolatileDB ('InVolDB'): when
+-- 'VolDB.getBlock' returns 'Nothing', i.e. the block is missing from the
+-- VolatileDB and might have moved to the ImmutableDB: we switch to the
+-- 'InImmDBRetry' state, unless we just come from that state, in that case,
+-- return 'IteratorBlockGCed' and close the iterator.
+--
+-- When streaming from the ImmutableDB with a planned switchover to the
+-- VolatileDB ('InImmDB' where 'InImmDBEnd' is 'SwitchToVolDBFrom') and we
+-- have reached the end of the ImmutableDB iterator (exhausted or upper bound
+-- is reached): we switch to the 'InVolDB' state.
+--
+-- In the 'InImmDBRetry' state, we distinguish two cases:
+--
+-- 1. We have just switched to it because a block was missing from the
+--    VolatileDB. We have an iterator that could stream this block from the
+--    ImmutableDB (if it was indeed moved to the ImmutableDB). If the streamed
+--    block matches the expected hash, we continue. If not, or if the iterator
+--    is immediately exhausted, then the block is missing and we return
+--    'IteratorBlockGCed' and close the iterator.
+--
+-- 2. We have successfully streamed one or more blocks from the ImmutableDB
+--    that were previously part of the VolatileDB. When we now encounter a
+--    block of which the hash does not match the expected hash or when the
+--    iterator is exhausted, we switch back to the 'InVolDB' state.
+--
+data IteratorState m blk
+  = InImmDB
+      (StreamFrom blk)
+      (ImmDB.Iterator (HeaderHash blk) m blk)
+      (InImmDBEnd blk)
+    -- ^ Streaming from the ImmutableDB.
+    --
+    -- Invariant: an ImmutableDB iterator opened using the 'StreamFrom'
+    -- parameter as lower bound will yield the same next block as the iterator
+    -- stored as parameter. There is one difference, which is exactly the
+    -- reason for keeping track of this 'StreamFrom': if the latter iterator
+    -- (the parameter) is exhausted and blocks have been appended to the end
+    -- of the ImmutableDB since it was originally opened, the new iterator can
+    -- include them in its stream.
+    --
+    -- Invariant: the iterator is not exhausted.
+  | InVolDB
+      (StreamFrom blk)
+      (NonEmpty (HeaderHash blk))
+    -- ^ Streaming from the VolatileDB.
+    --
+    -- The (non-empty) list of hashes is the path to follow through the
+    -- VolatileDB.
+    --
+    -- Invariant: if the blocks corresponding to the hashes have been moved to
+    -- the ImmutableDB, it should be possible to stream these blocks from the
+    -- ImmutableDB by starting an iterator using the 'StreamFrom' parameter.
+    -- Note that the hashes of these blocks still have to be checked against
+    -- the hashes in the path, because the blocks might not have been part of
+    -- the current chain, in which case they will not be in the ImmutableDB.
+  | InImmDBRetry
+      (StreamFrom blk)
+      (ImmDB.Iterator (HeaderHash blk) m blk)
+      (NonEmpty (HeaderHash blk))
+    -- ^ When streaming blocks (a list of hashes) from the VolatileDB, we
+    -- noticed a block was missing from the VolatileDB. It may have moved to
+    -- the ImmutableDB since we initialised the iterator (and built the path),
+    -- so we'll try if we can stream it from the ImmutableDB.
+    --
+    -- Invariants: invariants of 'InImmDB' + invariant of 'InVolDB'.
+
+  | Closed
+
+-- | Extract the ImmutableDB Iterator from the 'IteratorState'.
+iteratorStateImmIt :: IteratorState m blk
+                   -> Maybe (ImmDB.Iterator (HeaderHash blk) m blk)
+iteratorStateImmIt = \case
+    Closed                 -> Nothing
+    InImmDB      _ immIt _ -> Just immIt
+    InImmDBRetry _ immIt _ -> Just immIt
+    InVolDB {}             -> Nothing
+
+-- | Determines if/when to stop streaming from the ImmutableDB and what to do
+-- afterwards.
+data InImmDBEnd blk
+  = StreamAll
+    -- ^ Don't stop streaming until the iterator is exhausted.
+  | StreamTo          (StreamTo blk)
+    -- ^ Stream to the upper bound.
+  | SwitchToVolDBFrom (StreamTo blk)  (NonEmpty (HeaderHash blk))
+    -- ^ Stream to the upper bound. Afterwards, start streaming the path (the
+    -- second parameter) from the VolatileDB.
+
+implIteratorNext :: forall m blk.
+                    ( MonadCatch m
+                    , MonadSTM   m
+                    , HasHeader blk
+                    )
+                 => TVar m (IteratorState m blk)
+                 -> ChainDbEnv m blk
+                 -> m (IteratorResult blk)
+implIteratorNext varItState CDB{..} =
+    atomically (readTVar varItState) >>= \case
+      Closed ->
+        return IteratorExhausted
+      InImmDB continueAfter immIt immEnd ->
+        nextInImmDB continueAfter immIt immEnd
+      InImmDBRetry continueAfter immIt immHashes ->
+        nextInImmDBRetry (Just continueAfter) immIt immHashes
+      InVolDB continueAfter volHashes ->
+        nextInVolDB continueAfter volHashes
+  where
+    trace = traceWith (contramap TraceIteratorEvent cdbTracer)
+
+    -- | Read the next block while in the 'InVolDB' state.
+    nextInVolDB :: StreamFrom blk
+                   -- ^ In case the block corresponding to the first hash in
+                   -- the path is missing from the VolatileDB, we can use this
+                   -- lower bound to try to stream it from the ImmutableDB (if
+                   -- the block indeed has been moved there).
+                -> NonEmpty (HeaderHash blk)
+                -> m (IteratorResult blk)
+    nextInVolDB continueFrom (hash NE.:| hashes) =
+      VolDB.getBlock cdbVolDB hash >>= \case
+        -- Block is missing
+        Nothing -> do
+            trace $ BlockMissingFromVolDB hash
+            -- Try if we can stream a block from the ImmutableDB that was
+            -- previously in the VolatileDB. This will only work if the block
+            -- was part of the current chain, otherwise it will not have been
+            -- copied to the ImmutableDB.
+            --
+            -- This call cannot throw a 'ReadFutureSlotError' or a
+            -- 'ReadFutureEBBError' because if the block is missing, it /must/
+            -- have been garbage-collected, which means that its slot was
+            -- older than the slot of the tip of the ImmutableDB.
+            immIt <- ImmDB.streamBlocksFromUnchecked cdbImmDB continueFrom
+            nextInImmDBRetry Nothing immIt (hash NE.:| hashes)
+
+        -- Block is there
+        Just blk | Just hashes' <- NE.nonEmpty hashes -> do
+          let continueFrom' = StreamFromExclusive (blockPoint blk)
+          atomically $ writeTVar varItState (InVolDB continueFrom' hashes')
+          return $ IteratorResult blk
+        -- No more hashes, so we can stop
+        Just blk -> do
+          atomically $ writeTVar varItState Closed
+          return $ IteratorResult blk
+
+    -- | Read the next block while in the 'InImmDB' state.
+    nextInImmDB :: StreamFrom blk
+                -> ImmDB.Iterator (HeaderHash blk) m blk
+                -> InImmDBEnd blk
+                -> m (IteratorResult blk)
+    nextInImmDB continueFrom immIt immEnd = do
+      immRes <- selectResult immEnd <$> ImmDB.iteratorNext    immIt
+                                    <*> ImmDB.iteratorHasNext immIt
+      case immRes of
+        NotDone blk -> do
+          let continueFrom' = StreamFromExclusive (blockPoint blk)
+          atomically $ writeTVar varItState (InImmDB continueFrom' immIt immEnd)
+          return $ IteratorResult blk
+        -- True indicates that this is the last element in the stream
+        DoneAfter blk | SwitchToVolDBFrom _ hashes <- immEnd -> do
+          let continueFrom' = StreamFromExclusive (blockPoint blk)
+          atomically $ writeTVar varItState (InVolDB continueFrom' hashes)
+          return $ IteratorResult blk
+        DoneAfter blk -> do
+          atomically $ writeTVar varItState Closed
+          return $ IteratorResult blk
+        Done | SwitchToVolDBFrom _ hashes <- immEnd ->
+          nextInVolDB continueFrom hashes
+        Done -> do
+          -- No need to switch to the VolatileDB, so we can stop
+          atomically $ writeTVar varItState Closed
+          return IteratorExhausted
+
+    -- | Read the next block while in the 'InImmDBRetry' state.
+    --
+    -- We try to stream blocks that we suspect are now in the ImmutableDB
+    -- because they are no longer in the VolatileDB. We don't know this for
+    -- sure, so we must check whether they match the expected hashes.
+    nextInImmDBRetry :: Maybe (StreamFrom blk)
+                        -- ^ 'Nothing' iff the iterator was just opened and
+                        -- nothing has been streamed from it yet. This is used
+                        -- to avoid switching right back to the VolatileDB if
+                        -- we came from there.
+                     -> ImmDB.Iterator (HeaderHash blk) m blk
+                     -> NonEmpty (HeaderHash blk)
+                     -> m (IteratorResult blk)
+    nextInImmDBRetry mbContinueFrom immIt (hash NE.:| hashes) =
+      selectResult StreamAll <$> ImmDB.iteratorNext    immIt
+                             <*> ImmDB.iteratorHasNext immIt >>= \case
+        NotDone blk | blockHash blk == hash -> do
+          trace $ BlockWasCopiedToImmDB hash
+          let continueFrom' = StreamFromExclusive (blockPoint blk)
+          atomically $ writeTVar varItState $ case NE.nonEmpty hashes of
+            Nothing      -> Closed
+            Just hashes' -> InImmDBRetry continueFrom' immIt hashes'
+          return $ IteratorResult blk
+
+        DoneAfter blk | blockHash blk == hash -> do
+          trace $ BlockWasCopiedToImmDB hash
+          let continueFrom' = StreamFromExclusive (blockPoint blk)
+          case NE.nonEmpty hashes of
+            Nothing      -> atomically $ writeTVar varItState Closed
+            Just hashes' -> do
+              atomically $ writeTVar varItState $ InVolDB continueFrom' hashes'
+              trace SwitchBackToVolDB
+          return $ IteratorResult blk
+
+        -- Hash mismatch or 'Done'
+        _ -> case mbContinueFrom of
+          -- We just switched to this state and the iterator was just opened.
+          -- The block must be GC'ed, since we opened the iterator because it
+          -- was missing from the VolatileDB and now it is not in the
+          -- ImmutableDB either.
+          Nothing -> do
+            atomically $ writeTVar varItState Closed
+            trace $ BlockGCedFromVolDB hash
+            return $ IteratorBlockGCed hash
+
+          -- We have already streamed something from the iterator. We can try
+          -- looking in the VolatileDB again. If we hadn't streamed something
+          -- yet, switching to the VolatileDB would be pointless as we just
+          -- came from there.
+          Just continueFrom -> do
+            trace SwitchBackToVolDB
+            nextInVolDB continueFrom (hash NE.:| hashes)
+
+    -- | Return a 'Done' based on the 'InImmDBEnd'. See the documentation of
+    -- 'Done'. The 'Bool' argument should be the result of
+    -- 'ImmDB.iteratorHasNext' and indicates whether the iterator is able to
+    -- stream more blocks ('True') or whether it is exhausted ('False') after
+    -- returning the last result.
+    --
+    -- We're doing this because we're streaming from the ImmutableDB with an
+    -- open upper bound, because the ImmutableDB doesn't support streaming to
+    -- an exclusive upper bound.
+    selectResult :: InImmDBEnd blk
+                 -> ImmDB.IteratorResult (HeaderHash blk) blk
+                 -> Bool  -- ^ has the iterator a next element
+                 -> Done blk
+    selectResult immEnd itRes hasNext = case itRes of
+        ImmDB.IteratorResult _ blk -> select blk
+        ImmDB.IteratorEBB  _ _ blk -> select blk
+        ImmDB.IteratorExhausted    -> Done
+      where
+        select blk = case immEnd of
+          StreamAll
+            | hasNext             -> NotDone   blk
+            | otherwise           -> DoneAfter blk
+          StreamTo          to'   -> checkUpperBound blk to'
+          SwitchToVolDBFrom to' _ -> checkUpperBound blk to'
+        checkUpperBound blk = \case
+          StreamToExclusive pt
+            | pt == blockPoint blk -> Done
+            | hasNext              -> NotDone   blk
+            | otherwise            -> DoneAfter blk
+          StreamToInclusive pt
+            | pt == blockPoint blk -> DoneAfter blk
+            | hasNext              -> NotDone   blk
+            | otherwise            -> DoneAfter blk
+
+-- | Auxiliary data type used for 'selectResult' in 'implIteratorNext'.
+data Done blk
+  = Done
+    -- ^ We're done with the iterator, either it is exhausted or we reached
+    -- its upper bound.
+  | DoneAfter blk
+    -- ^ We're done with the iterator, but have to return this last block. We
+    -- must have reached its upper /inclusive/ bound.
+  | NotDone     blk
+    -- ^ We're not done yet with the iterator and have to return this block.
+    -- We know the iterator is not exhausted, but this does not mean that the
+    -- next block returned by it will be included in the stream as it might
+    -- correspond to the exclusive upper bound.
+
+
+-- | Close all open 'Iterator's.
+--
+-- This /can/ be called when the ChainDB is already closed.
+closeAllIterators
+  :: MonadSTM m
+  => ChainDbEnv m blk
+  -> m ()
+closeAllIterators CDB{..} = do
+    iteratorClosers <- atomically $ Map.elems <$> readTVar cdbIterators
+    -- Note that each closer removes its entry from the 'cdbIterators' map.
+    sequence_ iteratorClosers

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -1,0 +1,409 @@
+{-# LANGUAGE DataKinds                 #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE TypeFamilies              #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+-- | Thin wrapper around the LedgerDB
+module Ouroboros.Storage.ChainDB.Impl.LgrDB (
+    LgrDB -- opaque
+  , LedgerDB
+    -- * Initialization
+  , LgrDbArgs(..)
+  , defaultArgs
+  , openDB
+  , reopen
+    -- * Wrappers
+  , getCurrent
+  , setCurrent
+  , getCurrentState
+  , currentPoint
+  , takeSnapshot
+  , trimSnapshots
+  , getDiskPolicy
+    -- * Validation
+  , validate
+  , ValidateResult
+    -- * Garbage collect points of previously applied blocks
+  , garbageCollectPrevApplied
+    -- * Re-exports
+  , MemPolicy
+  , DiskPolicy (..)
+  , DiskSnapshot
+  , LedgerDB.SwitchResult (..)
+  , LedgerDB.PushManyResult (..)
+  ) where
+
+import           Codec.Serialise.Decoding (Decoder)
+import           Codec.Serialise.Encoding (Encoding)
+import           Control.Monad.Except (runExcept)
+import           Data.Bifunctor (second)
+import           Data.Foldable (foldl')
+import           Data.Functor ((<&>))
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Typeable (Typeable)
+import           Data.Word (Word64)
+import           GHC.Stack (HasCallStack)
+import           System.FilePath ((</>))
+
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+import           Control.Tracer
+
+import           Ouroboros.Network.Block (HasHeader (..), HeaderHash, Point,
+                     SlotNo, StandardHash, blockPoint, castPoint)
+import qualified Ouroboros.Network.Block as Block
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util ((.:))
+
+import           Ouroboros.Storage.Common
+import           Ouroboros.Storage.FS.API (HasFS (hasFsErr),
+                     createDirectoryIfMissing)
+import           Ouroboros.Storage.FS.API.Types (FsError, MountPoint (..))
+import           Ouroboros.Storage.FS.IO (ioHasFS)
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+import           Ouroboros.Storage.LedgerDB.Conf
+import           Ouroboros.Storage.LedgerDB.DiskPolicy (DiskPolicy (..))
+import           Ouroboros.Storage.LedgerDB.InMemory (Apply (..), RefOrVal (..))
+import qualified Ouroboros.Storage.LedgerDB.InMemory as LedgerDB
+import           Ouroboros.Storage.LedgerDB.MemPolicy (MemPolicy)
+import           Ouroboros.Storage.LedgerDB.OnDisk (DiskSnapshot,
+                     NextBlock (..), StreamAPI (..))
+import qualified Ouroboros.Storage.LedgerDB.OnDisk as LedgerDB
+
+import           Ouroboros.Storage.ChainDB.API (ChainDbFailure (..))
+import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB)
+import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
+
+-- | Thin wrapper around the ledger database
+data LgrDB m blk = LgrDB {
+      conf           :: Conf m blk
+    , varDB          :: TVar m (LedgerDB blk)
+      -- ^ INVARIANT: the tip of the 'LedgerDB' is always in sync with the tip
+      -- of the current chain of the ChainDB.
+    , varPrevApplied :: TVar m (Set (Point blk))
+      -- ^ INVARIANT: this set contains only points that are in the
+      -- VolatileDB.
+      --
+      -- The VolatileDB might contain invalid blocks, these will not be in
+      -- this set.
+      --
+      -- When a garbage-collection is performed on the VolatileDB, the points
+      -- of the blocks eligible for garbage-collection should be removed from
+      -- this set.
+    , args           :: LgrDbArgs m blk
+      -- ^ The arguments used to open the 'LgrDB'. Needed for 'reopen'ing the
+      -- 'LgrDB'.
+    }
+
+-- | Shorter synonym for the instantiated 'LedgerDB.LedgerDB'.
+type LedgerDB blk = LedgerDB.LedgerDB (ExtLedgerState blk) (Point blk)
+
+-- | Shorter synonym for the instantiated 'LedgerDbConf'.
+type Conf m blk =
+  LedgerDbConf m (ExtLedgerState blk) (Point blk) blk (ExtValidationError blk)
+
+{-------------------------------------------------------------------------------
+  Initialization
+-------------------------------------------------------------------------------}
+
+data LgrDbArgs m blk = forall h. LgrDbArgs {
+      lgrNodeConfig       :: NodeConfig (BlockProtocol blk)
+    , lgrHasFS            :: HasFS m h
+    , lgrDecodeLedger     :: forall s. Decoder s (LedgerState blk)
+    , lgrDecodeChainState :: forall s. Decoder s (ChainState (BlockProtocol blk))
+    , lgrDecodeHash       :: forall s. Decoder s (HeaderHash blk)
+    , lgrEncodeLedger     :: LedgerState blk                -> Encoding
+    , lgrEncodeChainState :: ChainState (BlockProtocol blk) -> Encoding
+    , lgrEncodeHash       :: HeaderHash blk                 -> Encoding
+    , lgrMemPolicy        :: MemPolicy
+    , lgrDiskPolicy       :: DiskPolicy m
+    , lgrGenesis          :: m (ExtLedgerState blk)
+    }
+
+-- | Default arguments
+--
+-- The following arguments must still be defined:
+--
+-- * 'lgrNodeConfig'
+-- * 'lgrDecodeLedger'
+-- * 'lgrDecodeChainState'
+-- * 'lgrDecodeHash'
+-- * 'lgrEncodeLedger'
+-- * 'lgrEncodeChainState'
+-- * 'lgrEncodeHash'
+-- * 'lgrMemPolicy'
+-- * 'lgrGenesis'
+defaultArgs :: FilePath -> LgrDbArgs IO blk
+defaultArgs fp = LgrDbArgs {
+      lgrHasFS            = ioHasFS $ MountPoint (fp </> "ledger")
+      -- Fields without a default
+    , lgrNodeConfig       = error "no default for lgrNodeConfig"
+    , lgrDecodeLedger     = error "no default for lgrDecodeLedger"
+    , lgrDecodeChainState = error "no default for lgrDecodeChainState"
+    , lgrDecodeHash       = error "no default for lgrDecodeHash"
+    , lgrEncodeLedger     = error "no default for lgrEncodeLedger"
+    , lgrEncodeChainState = error "no default for lgrEncodeChainState"
+    , lgrEncodeHash       = error "no default for lgrEncodeHash"
+    , lgrMemPolicy        = error "no default for lgrMemPolicy"
+    , lgrDiskPolicy       = error "no default for lgrDiskPolicy"
+    , lgrGenesis          = error "no default for lgrGenesis"
+    }
+
+-- | Open the ledger DB
+openDB :: forall m blk.
+          ( MonadSTM   m
+          , MonadST    m
+          , MonadCatch m
+          , ProtocolLedgerView blk
+          )
+       => LgrDbArgs m blk
+       -- ^ Stateless initializaton arguments
+       -> ImmDB m blk
+       -- ^ Reference to the immutable DB
+       --
+       -- After reading a snapshot from disk, the ledger DB will be brought
+       -- up to date with tip of the immutable DB. The corresponding ledger
+       -- state can then be used as the starting point for chain selection in
+       -- the ChainDB driver.
+       -> (Point blk -> m blk)
+       -- ^ Read a block from disk
+       --
+       -- The block may be in the immutable DB or in the volatile DB; the ledger
+       -- DB does not know where the boundary is at any given point.
+       -> Tracer m (LedgerDB.InitLog (Point blk))
+       -> m (LgrDB m blk)
+openDB args@LgrDbArgs{..} immDB getBlock tracer = do
+    createDirectoryIfMissing lgrHasFS True []
+    db <- initFromDisk args lgrDbConf immDB tracer
+    (varDB, varPrevApplied) <- atomically $
+      (,) <$> newTVar db <*> newTVar Set.empty
+    return LgrDB {
+        conf           = lgrDbConf
+      , varDB          = varDB
+      , varPrevApplied = varPrevApplied
+      , args           = args
+      }
+  where
+    apply :: blk
+          -> ExtLedgerState blk
+          -> Either (ExtValidationError blk) (ExtLedgerState blk)
+    apply = runExcept .: applyExtLedgerState lgrNodeConfig
+
+    reapply :: blk
+            -> ExtLedgerState blk
+            -> ExtLedgerState blk
+    reapply b l = case apply b l of  -- TODO skip some checks, see #440
+      Left  e  -> error $ "reapply failed: " <> show e
+      Right l' -> l'
+
+    lgrDbConf = LedgerDbConf {
+        ldbConfGenesis = lgrGenesis
+      , ldbConfApply   = apply
+      , ldbConfReapply = reapply
+      , ldbConfResolve = getBlock
+      }
+
+reopen :: ( MonadSTM   m
+          , MonadST    m
+          , MonadCatch m
+          , ProtocolLedgerView blk
+          )
+       => LgrDB  m blk
+       -> ImmDB  m blk
+       -> Tracer m (LedgerDB.InitLog (Point blk))
+       -> m ()
+reopen LgrDB{..} immDB tracer = do
+    db <- initFromDisk args conf immDB tracer
+    atomically $ writeTVar varDB db
+
+initFromDisk :: ( MonadST    m
+                , MonadCatch m
+                , HasHeader blk
+                )
+             => LgrDbArgs m blk
+             -> Conf      m blk
+             -> ImmDB     m blk
+             -> Tracer    m (LedgerDB.InitLog (Point blk))
+             -> m (LedgerDB blk)
+initFromDisk args@LgrDbArgs{..} lgrDbConf immDB tracer = wrapFailure args $ do
+    (initLog, db) <-
+      LedgerDB.initLedgerDB
+        lgrHasFS
+        (decodeExtLedgerState lgrDecodeLedger lgrDecodeChainState)
+        (Block.decodePoint lgrDecodeHash)
+        lgrMemPolicy
+        lgrDbConf
+        (streamAPI immDB)
+    traceWith tracer initLog
+    return db
+
+{-------------------------------------------------------------------------------
+  Wrappers
+-------------------------------------------------------------------------------}
+
+getCurrent :: MonadSTM m
+           => LgrDB m blk -> STM m (LedgerDB blk)
+getCurrent LgrDB{..} = readTVar varDB
+
+getCurrentState :: MonadSTM m
+                => LgrDB m blk -> STM m (ExtLedgerState blk)
+getCurrentState LgrDB{..} = LedgerDB.ledgerDbCurrent <$> readTVar varDB
+
+-- | PRECONDITION: The new 'LedgerDB' must be the result of calling either
+-- 'LedgerDB.ledgerDbSwitch' or 'LedgerDB.ledgerDbPushMany' on the current
+-- 'LedgerDB'.
+setCurrent :: MonadSTM m
+           => LgrDB m blk -> LedgerDB blk -> STM m ()
+setCurrent LgrDB{..} = writeTVar varDB
+
+currentPoint :: UpdateLedger blk
+             => LedgerDB blk -> Point blk
+currentPoint = ledgerTipPoint
+             . ledgerState
+             . LedgerDB.ledgerDbCurrent
+
+takeSnapshot :: (MonadSTM m, MonadThrow m, StandardHash blk, Typeable blk)
+             => LgrDB m blk
+             -> m (DiskSnapshot, Point blk)
+takeSnapshot lgrDB@LgrDB{ args = args@LgrDbArgs{..} } = wrapFailure args $ do
+    ledgerDB <- atomically $ getCurrent lgrDB
+    second tipToPoint <$> LedgerDB.takeSnapshot
+      lgrHasFS
+      (encodeExtLedgerState lgrEncodeLedger lgrEncodeChainState)
+      (Block.encodePoint lgrEncodeHash)
+      ledgerDB
+
+trimSnapshots :: (MonadThrow m, StandardHash blk, Typeable blk)
+              => LgrDB m blk
+              -> m [DiskSnapshot]
+trimSnapshots LgrDB{ args = args@LgrDbArgs{..} } = wrapFailure args $
+    LedgerDB.trimSnapshots lgrHasFS lgrDiskPolicy
+
+getDiskPolicy :: LgrDB m blk -> DiskPolicy m
+getDiskPolicy LgrDB{ args = LgrDbArgs{..} } = lgrDiskPolicy
+
+{-------------------------------------------------------------------------------
+  Validation
+-------------------------------------------------------------------------------}
+
+type ValidateResult blk =
+  LedgerDB.SwitchResult (ExtValidationError blk) (ExtLedgerState blk) (Point blk) 'False
+
+validate :: forall m blk.
+            ( MonadSTM m
+            , ProtocolLedgerView blk
+            , HasCallStack
+            )
+         => LgrDB m blk
+         -> LedgerDB blk
+            -- ^ This is used as the starting point for validation, not the one
+            -- in the 'LgrDB'.
+         -> Word64  -- ^ How many blocks to roll back
+         -> [Header blk]
+         -> m (ValidateResult blk)
+validate LgrDB{..} ledgerDB numRollbacks = \hdrs -> do
+    blocks <- toBlocks hdrs <$> atomically (readTVar varPrevApplied)
+    res <- LedgerDB.ledgerDbSwitch conf numRollbacks blocks ledgerDB
+    atomically $ modifyTVar' varPrevApplied $
+      addPoints (validBlockPoints res (map headerPoint hdrs))
+    return res
+  where
+    toBlocks :: [Header blk] -> Set (Point blk)
+             -> [(Apply 'False, RefOrVal (Point blk) blk)]
+    toBlocks hdrs prevApplied =
+      [ ( if Set.member (headerPoint hdr) prevApplied
+          then Reapply else Apply
+        , toRefOrVal (Left hdr) )
+      | hdr <- hdrs ]
+
+    -- | Based on the 'ValidateResult', return the hashes corresponding to
+    -- valid blocks.
+    validBlockPoints :: ValidateResult blk
+                     -> ([Point blk] -> [Point blk])
+    validBlockPoints = \case
+      LedgerDB.PushSuffix (LedgerDB.ValidBlocks _)              -> id
+      LedgerDB.PushSuffix (LedgerDB.InvalidBlock _ lastValid _) ->
+        takeWhile (/= lastValid)
+      LedgerDB.InvalidBlockInPrefix _ lastValid                 ->
+        takeWhile (/= lastValid)
+
+    addPoints :: [Point blk] -> Set (Point blk)
+              -> Set (Point blk)
+    addPoints hs set = foldl' (flip Set.insert) set hs
+
+{-------------------------------------------------------------------------------
+  Stream API to the immutable DB
+-------------------------------------------------------------------------------}
+
+streamAPI :: forall m blk. (MonadCatch m, HasHeader blk)
+          => ImmDB m blk -> StreamAPI m (Point blk) blk
+streamAPI immDB = StreamAPI streamAfter
+  where
+    streamAfter :: Tip (Point blk)
+                -> (Maybe (m (NextBlock (Point blk) blk)) -> m a)
+                -> m a
+    streamAfter tip k = do
+      slotNoAtTip <- ImmDB.getSlotNoAtTip immDB
+      if Block.pointSlot (tipToPoint tip) > slotNoAtTip
+        then k Nothing
+        else bracket
+          (ImmDB.streamBlocksAfter immDB (tipToPoint tip))
+          ImmDB.iteratorClose
+          (k . Just . getNext)
+
+    getNext :: ImmDB.Iterator (HeaderHash blk) m blk
+            -> m (NextBlock (Point blk) blk)
+    getNext itr = ImmDB.iteratorNext itr <&> \case
+      ImmDB.IteratorExhausted    -> NoMoreBlocks
+      ImmDB.IteratorResult _ blk -> NextBlock (Block.blockPoint blk, blk)
+      ImmDB.IteratorEBB  _ _ blk -> NextBlock (Block.blockPoint blk, blk)
+
+{-------------------------------------------------------------------------------
+  Garbage collect points of previously applied blocks
+-------------------------------------------------------------------------------}
+
+-- | Remove all points with a slot less than or equal to the given slot from
+-- the set of previously applied points.
+garbageCollectPrevApplied :: MonadSTM m
+                          => LgrDB m blk
+                          -> SlotNo
+                          -> STM m ()
+garbageCollectPrevApplied LgrDB{..} slotNo = modifyTVar' varPrevApplied $
+    Set.filter ((<= slotNo) . Block.pointSlot)
+
+{-------------------------------------------------------------------------------
+  Error handling
+-------------------------------------------------------------------------------}
+
+-- | Wrap exceptions that may indicate disk failure in a 'ChainDbFailure'
+-- exception using the 'LgrDbFailure' constructor.
+wrapFailure :: forall m blk x. (MonadThrow m, StandardHash blk, Typeable blk)
+            => LgrDbArgs m blk -> m x -> m x
+wrapFailure LgrDbArgs{ lgrHasFS = hasFS } k =
+    EH.catchError (hasFsErr hasFS) k rethrow
+  where
+    rethrow :: FsError -> m x
+    rethrow err = throwM $ LgrDbFailure @blk err
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+toRefOrVal :: (HasHeader blk, HasHeader (Header blk))
+           => Either (Header blk) blk -> RefOrVal (Point blk) blk
+toRefOrVal (Left  hdr) = Ref (castPoint (blockPoint hdr))
+toRefOrVal (Right blk) = Val (blockPoint blk) blk

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
@@ -1,0 +1,216 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+-- | Queries
+module Ouroboros.Storage.ChainDB.Impl.Query
+  ( -- * Queries
+    getCurrentChain
+  , getCurrentLedger
+  , getTipBlock
+  , getTipHeader
+  , getTipPoint
+  , getBlock
+  , getIsFetched
+  , knownInvalidBlocks
+    -- * Low-level queries
+  , getAnyKnownBlock
+  ) where
+
+import           Data.Set (Set)
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (ChainHash (..), HasHeader, HeaderHash,
+                     Point, castPoint, pointHash, pointSlot)
+import           Ouroboros.Network.Chain (genesisPoint)
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Protocol.Abstract
+
+import           Ouroboros.Storage.ChainDB.API (ChainDbError (..),
+                     ChainDbFailure (..))
+
+import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB)
+import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
+import qualified Ouroboros.Storage.ChainDB.Impl.LgrDB as LgrDB
+import           Ouroboros.Storage.ChainDB.Impl.Types
+import           Ouroboros.Storage.ChainDB.Impl.VolDB (VolDB)
+import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
+
+-- | Return the last @k@ headers.
+--
+-- While the in-memory fragment ('cdbChain') might temporarily be longer than
+-- @k@ (until the background thread has copied those blocks to the
+-- ImmutableDB), this function will never return a fragment longer than @k@.
+--
+-- The anchor point of the returned fragment will be the most recent
+-- \"immutable\" block, i.e. a block that cannot be rolled back. In
+-- ChainDB.md, we call this block @i@.
+--
+-- Note that the returned fragment may be shorter than @k@ in case the whole
+-- chain itself is shorter than @k@ or in case the VolatileDB was corrupted.
+-- In the latter case, we don't take blocks already in the ImmutableDB into
+-- account, as we know they /must/ have been \"immutable\" at some point, and,
+-- therefore, /must/ still be \"immutable\".
+getCurrentChain
+  :: forall m blk.
+     ( MonadSTM m
+     , HasHeader (Header blk)
+     , OuroborosTag (BlockProtocol blk)
+     )
+  => ChainDbEnv m blk
+  -> STM m (AnchoredFragment (Header blk))
+getCurrentChain CDB{..} =
+    AF.anchorNewest k <$> readTVar cdbChain
+  where
+    SecurityParam k = protocolSecurityParam cdbNodeConfig
+
+getCurrentLedger :: MonadSTM m => ChainDbEnv m blk -> STM m (ExtLedgerState blk)
+getCurrentLedger CDB{..} = LgrDB.getCurrentState cdbLgrDB
+
+getTipBlock
+  :: forall m blk.
+     ( MonadCatch m
+     , MonadSTM m
+     , HasHeader blk
+     , HasHeader (Header blk)
+     )
+  => ChainDbEnv m blk
+  -> m (Maybe blk)
+getTipBlock cdb@CDB{..} = do
+    tipPoint <- atomically $ getTipPoint cdb
+    if tipPoint == genesisPoint
+      then return Nothing
+      else Just <$> getAnyKnownBlock cdbImmDB cdbVolDB tipPoint
+
+getTipHeader
+  :: forall m blk.
+     ( MonadCatch m
+     , MonadSTM   m
+     , GetHeader blk
+     , HasHeader blk
+     , HasHeader (Header blk)
+     )
+  => ChainDbEnv m blk
+  -> m (Maybe (Header blk))
+getTipHeader CDB{..} = do
+    anchorOrHdr <- AF.head <$> atomically (readTVar cdbChain)
+    case anchorOrHdr of
+      Right hdr
+        -> return $ Just hdr
+      Left anchor
+        | anchor == genesisPoint
+        -> return Nothing
+        | otherwise
+          -- In this case, the fragment is empty but the anchor point is not
+          -- genesis. It must be that the VolatileDB got emptied and that our
+          -- current tip is now the tip of the ImmutableDB.
+
+          -- Note that we can't use 'getBlockAtTip' because a block might have
+          -- been appended to the ImmutableDB since we obtained 'anchorOrHdr'.
+        -> anchorMustBeThere <$>
+           ImmDB.getBlockWithPoint cdbImmDB (castPoint anchor)
+  where
+    anchorMustBeThere :: Maybe blk -> Maybe (Header blk)
+    anchorMustBeThere Nothing    = error "block at tip of ImmutableDB missing"
+    anchorMustBeThere (Just blk) = Just (getHeader blk)
+
+getTipPoint
+  :: forall m blk. (MonadSTM m, HasHeader (Header blk))
+  => ChainDbEnv m blk -> STM m (Point blk)
+getTipPoint CDB{..} =
+    (castPoint . AF.headPoint) <$> readTVar cdbChain
+
+getBlock
+  :: forall m blk. (MonadCatch m , HasHeader blk)
+  => ChainDbEnv m blk
+  -> Point blk -> m (Maybe blk)
+getBlock CDB{..} = getAnyBlock cdbImmDB cdbVolDB
+
+getIsFetched
+  :: forall m blk. MonadSTM m
+  => ChainDbEnv m blk -> STM m (Point blk -> Bool)
+getIsFetched CDB{..} = basedOnHash <$> VolDB.getIsMember cdbVolDB
+  where
+    -- The volatile DB indexes by hash only, not by points. However, it should
+    -- not be possible to have two points with the same hash but different
+    -- slot numbers.
+    basedOnHash :: (HeaderHash blk -> Bool) -> Point blk -> Bool
+    basedOnHash f p =
+        case pointHash p of
+          BlockHash hash -> f hash
+          GenesisHash    -> False
+
+knownInvalidBlocks :: MonadSTM m => ChainDbEnv m blk -> STM m (Set (Point blk))
+knownInvalidBlocks CDB{..} = readTVar cdbInvalid
+
+
+{-------------------------------------------------------------------------------
+  Unifying interface over the immutable DB and volatile DB, but independent
+  of the ledger DB. These functions therefore do not require the entire
+  Chain DB to have been initialized.
+-------------------------------------------------------------------------------}
+
+-- | Wrapper around 'getAnyBlock' for blocks we know should exist
+--
+-- If the block does not exist, this indicates disk failure.
+getAnyKnownBlock
+  :: forall m blk. (MonadCatch m, HasHeader blk)
+  => ImmDB m blk
+  -> VolDB m blk
+  -> Point blk
+  -> m blk
+getAnyKnownBlock immDB volDB p = do
+    mBlock <- mustExist p <$> getAnyBlock immDB volDB p
+    case mBlock of
+      Right b  -> return b
+      Left err -> throwM err
+
+-- | Get a block from either the immutable DB or volatile DB
+--
+-- Returns 'Nothing' if the block is unknown.
+-- Throws 'NoGenesisBlockException' if the 'Point' refers to the genesis block.
+getAnyBlock
+  :: forall m blk. (MonadCatch m, HasHeader blk)
+  => ImmDB m blk
+  -> VolDB m blk
+  -> Point blk
+  -> m (Maybe blk)
+getAnyBlock immDB volDB p = case pointHash p of
+    GenesisHash    -> throwM $ NoGenesisBlock @blk
+    BlockHash hash -> do
+      -- Note: to determine whether a block is in the ImmutableDB, we can look
+      -- at the slot of its tip, which we'll call @immTipSlot@. If the slot of
+      -- the requested point > @immTipSlot@, then the block will not be in the
+      -- ImmutableDB but in the VolatileDB. However, there is a race condition
+      -- here: if between the time we got @immTipSlot@ and the time we look up
+      -- the block in the VolatileDB the block was moved from the VolatileDB
+      -- to the ImmutableDB, and it was deleted from the VolatileDB, we won't
+      -- find the block, even though it is in the ChainDB.
+      --
+      -- Therefore, we first query the VolatileDB and if the block is not in
+      -- it, then we can get @immTipSlot@ and compare it to the slot of the
+      -- requested point. If the slot <= @immTipSlot@ it /must/ be in the
+      -- ImmutableDB (no race condition here).
+      mbVolBlock <- VolDB.getBlock volDB hash
+      case mbVolBlock of
+        Just block -> return $ Just block
+        Nothing    -> do
+          -- ImmDB will throw an exception if we ask for a block past the tip
+          immTipSlot <- ImmDB.getSlotNoAtTip immDB
+          if pointSlot p > immTipSlot
+            -- It's not supposed to be in the ImmutableDB and the VolatileDB
+            -- didn't contain it, so return 'Nothing'.
+            then return Nothing
+            else ImmDB.getBlockWithPoint immDB p
+
+mustExist :: Point blk -> Maybe blk -> Either (ChainDbFailure blk) blk
+mustExist p Nothing  = Left  $ ChainDbMissingBlock p
+mustExist _ (Just b) = Right $ b

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
@@ -1,0 +1,490 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+-- | Readers
+module Ouroboros.Storage.ChainDB.Impl.Reader
+  ( newHeaderReader
+  , newBlockReader
+  , switchFork
+  , closeAllReaders
+  ) where
+
+import           Control.Exception (assert)
+import           Control.Monad (when)
+import           Data.Functor ((<&>))
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Maybe (isJust, isNothing)
+import           GHC.Stack (HasCallStack)
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+import           Control.Tracer (contramap, traceWith)
+
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader,
+                     HeaderHash, Point, SlotNo, blockPoint, castPoint,
+                     pointSlot)
+import           Ouroboros.Network.Chain (genesisPoint)
+
+import           Ouroboros.Consensus.Block (GetHeader (..), headerPoint)
+import           Ouroboros.Consensus.Util.STM (blockUntilJust)
+
+import           Ouroboros.Storage.ChainDB.API (ChainDbError (..), Reader (..),
+                     ReaderId)
+
+import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
+import qualified Ouroboros.Storage.ChainDB.Impl.Query as Query
+import           Ouroboros.Storage.ChainDB.Impl.Types
+
+
+-- | Check if the ChainDB is open. If not, throw a 'ClosedDBError'. Next,
+-- check whether the reader with the given 'ReaderId' still exists. If not,
+-- throw a 'ClosedReaderError'.
+--
+-- Otherwise, execute the given function on the 'ChainDbEnv' and 'ReaderState'
+-- 'TVar'.
+getReader
+  :: forall m blk r.
+     ( MonadSTM m
+     , MonadThrow (STM m)
+     , HasHeader blk
+     )
+  => ChainDbHandle m blk
+  -> ReaderId
+  -> (ChainDbEnv m blk -> TVar m (ReaderState m blk) -> m r)
+  -> m r
+getReader (CDBHandle varState) readerId f = do
+    (env, varRdr) <- atomically $ readTVar varState >>= \case
+      ChainDbClosed _env -> throwM $ ClosedDBError @blk
+      -- See the docstring of 'ChainDbReopening'
+      ChainDbReopening   -> error "ChainDB used while reopening"
+      ChainDbOpen    env ->
+        Map.lookup readerId <$> readTVar (cdbReaders env) >>= \case
+          Nothing  -> throwM $ ClosedReaderError @blk readerId
+          Just varRdr -> return (env, varRdr)
+    f env varRdr
+
+-- | Variant 'of 'getReader' for functions taking one argument.
+getReader1
+  :: forall m blk a r.
+     ( MonadSTM m
+     , MonadThrow (STM m)
+     , HasHeader blk
+     )
+  => ChainDbHandle m blk
+  -> ReaderId
+  -> (ChainDbEnv m blk -> TVar m (ReaderState m blk) -> a -> m r)
+  -> a -> m r
+getReader1 h rdrId f a =
+    getReader h rdrId (\env varReader -> f env varReader a)
+
+newReader
+  :: forall m blk.
+     ( MonadSTM   m
+     , MonadCatch m
+     , MonadThrow (STM m)
+     , HasHeader blk
+     , HasHeader (Header blk)
+     )
+  => ChainDbEnv    m blk
+  -> ChainDbHandle m blk
+     -- ^ We need the handle to pass it on to the 'Reader', so that each time
+     -- a function is called on the 'Reader', we check whether the ChainDB is
+     -- actually open.
+  -> m (Reader m blk (BlockOrHeader blk))
+newReader cdb@CDB{..} h = do
+    tipPoint <- atomically $ Query.getTipPoint cdb
+    readerState <- if tipPoint == genesisPoint
+      then return $ ReaderInMem rollState
+      else do
+        -- TODO avoid opening an iterator immediately when creating a reader,
+        -- because the user will probably request an intersection with the
+        -- recent chain. OR should we not optimise for the best case?
+        immIt <- ImmDB.streamBlocksAfter cdbImmDB genesisPoint
+        return $ ReaderInImmDB rollState immIt
+
+    (reader, readerId) <- atomically $ do
+      readerId <- readTVar cdbNextReaderId
+      modifyTVar' cdbNextReaderId succ
+
+      varReader <- newTVar readerState
+      modifyTVar' cdbReaders (Map.insert readerId varReader)
+      let reader = makeNewBlockOrHeaderReader h readerId
+      return (reader, readerId)
+    traceWith cdbTracer $ TraceReaderEvent $ NewReader readerId
+    return reader
+  where
+    rollState = RollBackTo genesisPoint
+
+newHeaderReader
+  :: forall m blk.
+     ( MonadSTM   m
+     , MonadCatch m
+     , MonadThrow (STM m)
+     , GetHeader blk
+     , HasHeader blk
+     , HasHeader (Header blk)
+     )
+  => ChainDbHandle m blk
+  -> m (Reader m blk (Header blk))
+newHeaderReader h = getEnv h $ \cdb -> turnIntoHeaderReader <$> newReader cdb h
+  where
+    turnIntoHeaderReader :: Reader m blk (BlockOrHeader blk)
+                         -> Reader m blk (Header blk)
+    turnIntoHeaderReader Reader {..} = Reader
+      { readerInstruction         = fmap (fmap toHeader) <$> readerInstruction
+      , readerInstructionBlocking = fmap toHeader        <$> readerInstructionBlocking
+      , ..
+      }
+
+    toHeader :: BlockOrHeader blk -> Header blk
+    toHeader (Left  hdr) = hdr
+    toHeader (Right blk) = getHeader blk
+
+newBlockReader
+  :: forall m blk.
+     ( MonadSTM   m
+     , MonadCatch m
+     , MonadThrow (STM m)
+     , HasHeader blk
+     , HasHeader (Header blk)
+     )
+  => ChainDbHandle m blk
+  -> m (Reader m blk blk)
+newBlockReader h = getEnv h $ \cdb -> turnIntoBlockReader cdb <$> newReader cdb h
+  where
+    turnIntoBlockReader :: ChainDbEnv m blk
+                        -> Reader m blk (BlockOrHeader blk)
+                        -> Reader m blk blk
+    turnIntoBlockReader CDB{..} Reader {..} = Reader
+        { readerInstruction =
+            readerInstruction >>= traverse (traverse toBlock)
+        , readerInstructionBlocking =
+            readerInstructionBlocking >>= traverse toBlock
+        , ..
+        }
+      where
+        toBlock :: BlockOrHeader blk -> m blk
+        toBlock (Left  hdr) = Query.getAnyKnownBlock cdbImmDB cdbVolDB $ headerPoint hdr
+        toBlock (Right blk) = return blk
+
+makeNewBlockOrHeaderReader
+  :: forall m blk.
+     ( MonadSTM   m
+     , MonadCatch m
+     , MonadThrow (STM m)
+     , HasHeader blk
+     , HasHeader (Header blk)
+     )
+  => ChainDbHandle m blk
+  -> ReaderId
+  -> Reader m blk (BlockOrHeader blk)
+makeNewBlockOrHeaderReader h readerId = Reader {..}
+  where
+    readerInstruction         = getReader  h readerId $ instructionHelper id Just
+    readerInstructionBlocking = getReader  h readerId $ instructionHelper blockUntilJust id
+    readerForward             = getReader1 h readerId $ forward
+    readerClose               = getEnv     h          $ close readerId
+
+close
+  :: forall m blk.
+     ( MonadSTM m )
+  => ReaderId
+  -> ChainDbEnv m blk
+  -> m ()
+close readerId CDB{..} = do
+    mbReaderState <- atomically $ do
+      readers <- readTVar cdbReaders
+      let (mbReader, readers') = delete readerId readers
+      writeTVar cdbReaders readers'
+      traverse readTVar mbReader
+    -- If the ReaderId is not present in the map, the Reader must have been
+    -- closed already.
+    mapM_ closeReaderState mbReaderState
+  where
+    -- | Delete the entry corresponding to the given key from the map. If it
+    -- existed, return it, otherwise, return 'Nothing'. The updated map is of
+    -- course also returned.
+    delete :: forall k a. Ord k => k -> Map k a -> (Maybe a, Map k a)
+    delete = Map.updateLookupWithKey (\_ _ -> Nothing)
+
+-- | Close the given 'ReaderState' by closing any 'ImmDB.Iterator' it might
+-- contain.
+closeReaderState :: Monad m => ReaderState m blk -> m ()
+closeReaderState = \case
+     ReaderInMem _         -> return ()
+     -- IMPORTANT: the main reason we're closing readers: to close this open
+     -- iterator, which contains a reference to a file handle.
+     ReaderInImmDB _ immIt -> ImmDB.iteratorClose immIt
+
+
+type BlockOrHeader blk = Either (Header blk) blk
+
+-- | Helper for 'readerInstruction' and 'readerInstructionBlocking'.
+--
+-- The result type @r@ will be instantiated to:
+--
+-- * @Maybe (ChainUpdate blk (BlockOrHeader blk))@ in case of
+--   'readerInstruction'.
+-- * @ChainUpdate blk (BlockOrHeader blk)@ in case of
+--   'readerInstructionBlocking'.
+--
+-- The returned 'ChainUpdate' contain a 'BlockOrHeader' because depending on
+-- the state, we have to read the whole block anyway (in 'ReaderInImmDB') or
+-- only have the header in memory (in 'ReaderInMem'). The header or block
+-- reader can then perform the appropriate conversion or lookup itself. This
+-- way, we avoid having to read the same block twice or reading the whole
+-- block while we only needed its header.
+--
+-- When in the 'ReaderInImmDB' state, we never have to block, as we can just
+-- stream the next block from the ImmutableDB.
+--
+-- When in the 'ReaderInMem' state, we may have to block when we have reached
+-- the end of the current chain.
+instructionHelper
+  :: forall m blk r.
+     ( MonadSTM   m
+     , MonadCatch m
+     , HasHeader blk
+     , HasHeader (Header blk)
+     )
+  => (STM m (Maybe (ChainUpdate blk (BlockOrHeader blk))) -> STM m r)
+     -- ^ How to turn a transaction that may or may not result in a new
+     -- 'ChainUpdate' in one that returns the right return type: use
+     -- 'blockUntilJust' to block or 'id' to just return the @Maybe@.
+  -> (ChainUpdate blk (BlockOrHeader blk) -> r)
+     -- ^ How to turn a (pure) 'ChainUpdate' in the right return type: use
+     -- 'id' or 'Just'.
+  -> ChainDbEnv m blk
+  -> TVar m (ReaderState m blk)
+  -> m r
+instructionHelper fromMaybeSTM fromPure CDB{..} varReader = do
+    -- In one transaction: check in which state we are, if in the
+    -- @ReaderInMem@ state, just call 'instructionSTM', otherwise,
+    -- return the contents of the 'ReaderInImmDB' state.
+    inImmDBOrRes <- atomically $ do
+      curChain <- readTVar cdbChain
+      readTVar varReader >>= \case
+        -- Just return the contents of the state and end the transaction
+        ReaderInImmDB rollState immIt -> return $ Left (rollState, Just immIt)
+        ReaderInMem   rollState
+          | AF.withinFragmentBounds
+            (castPoint (readerRollStatePoint rollState)) curChain
+            -- The point is still in the current chain fragment
+          -> fmap Right $ fromMaybeSTM $ fmap (fmap Left) <$>
+               instructionSTM
+                 rollState
+                 curChain
+                 (writeTVar varReader . ReaderInMem)
+          | otherwise
+            -- The point is no longer on the fragment. Blocks must have moved
+            -- (off the fragment) to the ImmutableDB. Note that 'switchFork'
+            -- will try to keep the point on the fragment in case we switch to
+            -- a fork.
+          -> return $ Left (rollState, Nothing)
+    case inImmDBOrRes of
+      -- We were able to obtain the result inside the transaction as we were
+      -- in the 'ReaderInMem' state.
+      Right res               -> return res
+      -- We were in the 'ReaderInImmDB' state or we need to switch to it.
+      Left (rollState, mbImmIt) -> case rollState of
+        RollForwardFrom pt -> do
+          immIt <- case mbImmIt of
+            Just immIt -> return immIt
+            -- We were in the 'ReaderInMem' state but have to switch to the
+            -- 'ReaderInImmDB' state.
+            -- COST: the block at @pt@ is read.
+            Nothing    -> do
+              trace $ ReaderNoLongerInMem rollState
+              ImmDB.streamBlocksAfter cdbImmDB pt
+          rollForwardImmDB immIt pt
+        RollBackTo      pt -> do
+          when (isNothing mbImmIt) $
+            trace $ ReaderNoLongerInMem rollState
+          -- COST: the block at @pt@ is read.
+          immIt' <- ImmDB.streamBlocksAfter cdbImmDB pt
+          let readerState' = ReaderInImmDB (RollForwardFrom pt) immIt'
+          atomically $ writeTVar varReader readerState'
+          return $ fromPure $ RollBack pt
+  where
+    trace = traceWith (contramap TraceReaderEvent cdbTracer)
+
+    nextBlock :: ImmDB.Iterator (HeaderHash blk) m blk -> m (Maybe blk)
+    nextBlock immIt = ImmDB.iteratorNext immIt <&> \case
+      ImmDB.IteratorResult _ blk -> Just blk
+      ImmDB.IteratorEBB  _ _ blk -> Just blk
+      ImmDB.IteratorExhausted    -> Nothing
+
+    rollForwardImmDB :: ImmDB.Iterator (HeaderHash blk) m blk -> Point blk
+                     -> m r
+    rollForwardImmDB immIt pt = nextBlock immIt >>= \case
+      Just blk -> do
+        let pt'          = blockPoint blk
+            readerState' = ReaderInImmDB (RollForwardFrom pt') immIt
+        atomically $ writeTVar varReader readerState'
+        return $ fromPure $ AddBlock $ Right blk
+      Nothing  -> do
+        -- The iterator is exhausted: we've reached the end of the
+        -- ImmutableDB, or actually what was the end of the ImmutableDB at the
+        -- time of opening the iterator. We must now check whether that is
+        -- still the end (blocks might have been added to the ImmutableDB in
+        -- the meantime).
+        slotNoAtImmDBTip <- ImmDB.getSlotNoAtTip cdbImmDB
+        case pointSlot pt `compare` slotNoAtImmDBTip of
+          -- The ImmutableDB somehow rolled back
+          GT -> error "reader streamed beyond tip of the ImmutableDB"
+
+          -- The tip is still the same, so switch to the in-memory chain
+          EQ -> do
+            trace $ ReaderSwitchToMem pt slotNoAtImmDBTip
+            atomically $ fromMaybeSTM $ do
+              curChain <- readTVar cdbChain
+              fmap (fmap Left) <$> instructionSTM
+                (RollForwardFrom pt)
+                curChain
+                (writeTVar varReader . ReaderInMem)
+
+          -- The tip of the ImmutableDB has progressed since we opened the
+          -- iterator
+          LT -> do
+            trace $ ReaderNewImmIterator pt slotNoAtImmDBTip
+            -- COST: the block at @pt@ is read.
+            immIt' <- ImmDB.streamBlocksAfter cdbImmDB pt
+            -- Try again with the new iterator
+            rollForwardImmDB immIt' pt
+
+-- | 'readerInstruction' for when the reader is in the 'ReaderInMem' state.
+instructionSTM
+  :: forall m blk.
+     ( MonadSTM m
+     , HasHeader (Header blk)
+     )
+  => ReaderRollState blk
+     -- ^ The current 'ReaderRollState' of the reader
+  -> AnchoredFragment (Header blk)
+     -- ^ The current chain fragment
+  -> (ReaderRollState blk -> STM m ())
+     -- ^ How to save the updated 'ReaderRollState'
+  -> STM m (Maybe (ChainUpdate blk (Header blk)))
+instructionSTM rollState curChain saveRollState =
+    assert (invariant curChain) $ case rollState of
+      RollForwardFrom pt ->
+        case AF.successorBlock (castPoint pt) curChain of
+          -- There is no successor block because the reader is at the head
+          Nothing  -> return Nothing
+          Just hdr -> do
+            saveRollState $ RollForwardFrom $ headerPoint hdr
+            return $ Just $ AddBlock hdr
+      RollBackTo      pt -> do
+        saveRollState $ RollForwardFrom pt
+        return $ Just $ RollBack pt
+  where
+    invariant =
+      AF.withinFragmentBounds (castPoint (readerRollStatePoint rollState))
+
+forward
+  :: forall m blk.
+     ( MonadSTM   m
+     , MonadCatch m
+     , HasHeader blk
+     , HasHeader (Header blk)
+     , HasCallStack
+     )
+  => ChainDbEnv m blk
+  -> TVar m (ReaderState m blk)
+  -> [Point blk]
+  -> m (Maybe (Point blk))
+forward CDB{..} varReader = \pts -> do
+    -- The current state of the reader doesn't matter, the given @pts@ could
+    -- be in the current chain fragment or in the ImmutableDB.
+
+    -- NOTE: we don't use 'Query.getCurrentChain', which only returns the last
+    -- @k@ headers, because we want to see the headers that have not yet been
+    -- written to the ImmutableDB too.
+    curChain         <- atomically $ readTVar cdbChain
+    slotNoAtImmDBTip <- ImmDB.getSlotNoAtTip cdbImmDB
+    findFirstPointOnChain curChain slotNoAtImmDBTip pts
+  where
+    findFirstPointOnChain
+      :: HasCallStack
+      => AnchoredFragment (Header blk)
+      -> SlotNo
+      -> [Point blk]
+      -> m (Maybe (Point blk))
+    findFirstPointOnChain curChain slotNoAtImmDBTip = \case
+      []     -> return Nothing
+      pt:pts
+        | AF.withinFragmentBounds (castPoint pt) curChain
+        -> do
+          -- It's in the in-memory chain fragment
+          atomically $ writeTVar varReader $ ReaderInMem $ RollBackTo pt
+          return $ Just pt
+
+        | pointSlot pt > slotNoAtImmDBTip
+          -- The point is after the tip of the ImmutableDB, so don't look in
+          -- the ImmutableDB and skip the point.
+        -> findFirstPointOnChain curChain slotNoAtImmDBTip pts
+
+        | otherwise
+        -> do
+          inImmDB <- if pt == genesisPoint
+            then return True -- Genesis is always "in" the ImmutableDB
+            else isJust <$> ImmDB.getBlockWithPoint cdbImmDB pt
+          if inImmDB
+            then do
+              -- TODO combine block checking with opening the iterator to
+              -- avoid reading the same block twice
+              immIt <- ImmDB.streamBlocksAfter cdbImmDB pt
+              let readerState = ReaderInImmDB (RollBackTo pt) immIt
+              atomically $ writeTVar varReader readerState
+              return $ Just pt
+            else findFirstPointOnChain curChain slotNoAtImmDBTip pts
+
+-- | Update the given 'ReaderState' to account for switching the current
+-- chain to the given fork (which might just be an extension of the
+-- current chain).
+--
+-- PRECONDITION: the intersection point must be within the fragment bounds
+-- of the new chain
+switchFork
+  :: forall m blk.
+     HasHeader (Header blk)
+  => Point blk  -- ^ Intersection point between old and new chain
+  -> AnchoredFragment (Header blk)  -- ^ The new chain
+  -> ReaderState m blk -> ReaderState m blk
+switchFork ipoint newChain readerState =
+    assert (AF.withinFragmentBounds (castPoint ipoint) newChain) $
+      case readerState of
+        -- If the reader is still reading from the ImmutableDB, switching to a
+        -- fork won't affect it at all
+        ReaderInImmDB {} -> readerState
+        ReaderInMem   rollState
+          | pointSlot (currentPoint rollState) > pointSlot ipoint
+            -- If the reader point is more recent than the interseciton point,
+            -- we have to roll back the reader to the intersection point.
+          -> ReaderInMem $ RollBackTo ipoint
+          | otherwise
+            -- We can keep rolling forward.
+          -> assert (AF.withinFragmentBounds (currentPoint rollState) newChain)
+             readerState
+  where
+    currentPoint = castPoint . readerRollStatePoint
+
+-- | Close all open 'Reader's.
+closeAllReaders
+  :: MonadSTM m
+  => ChainDbEnv m blk
+  -> m ()
+closeAllReaders CDB{..} = do
+    readerStates <- atomically $ do
+      readerStates <- readTVar cdbReaders >>= traverse readTVar . Map.elems
+      writeTVar cdbReaders Map.empty
+      return readerStates
+    mapM_ closeReaderState readerStates

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+
+-- | Closing and reopening
+module Ouroboros.Storage.ChainDB.Impl.Reopen
+  ( isOpen
+  , closeDB
+  , reopen
+  ) where
+
+import           Control.Monad (when)
+import           Data.Functor ((<&>))
+import           GHC.Stack (HasCallStack)
+
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer
+
+import           Control.Tracer
+
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (HasHeader (..), castPoint)
+import           Ouroboros.Network.Chain (genesisBlockNo)
+
+import           Ouroboros.Consensus.Block (Header)
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util (whenJust)
+
+import qualified Ouroboros.Storage.ChainDB.Impl.Background as Background
+import           Ouroboros.Storage.ChainDB.Impl.ChainSel
+import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
+import qualified Ouroboros.Storage.ChainDB.Impl.Iterator as Iterator
+import qualified Ouroboros.Storage.ChainDB.Impl.LgrDB as LgrDB
+import qualified Ouroboros.Storage.ChainDB.Impl.Reader as Reader
+import           Ouroboros.Storage.ChainDB.Impl.Types
+import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
+
+isOpen :: MonadSTM m => ChainDbHandle m blk -> STM m Bool
+isOpen (CDBHandle varState) = readTVar varState <&> \case
+    ChainDbReopening   -> False
+    ChainDbClosed _env -> False
+    ChainDbOpen   _env -> True
+
+closeDB
+  :: forall m blk.
+     ( MonadCatch m
+     , MonadAsync m
+     , HasHeader blk
+     , HasHeader (Header blk)
+     , HasCallStack
+     )
+  => ChainDbHandle m blk -> m ()
+closeDB (CDBHandle varState) = do
+    mbOpenEnv <- atomically $ readTVar varState >>= \case
+      -- Wait until reopening the ChainDB finished
+      ChainDbReopening   -> retry
+      -- Idempotent
+      ChainDbClosed _env -> return Nothing
+      ChainDbOpen    env -> do
+        writeTVar varState $ ChainDbClosed env
+        return $ Just env
+
+    -- Only when the ChainDB was open
+    whenJust mbOpenEnv $ \cdb@CDB{..} -> do
+
+      Reader.closeAllReaders     cdb
+      Iterator.closeAllIterators cdb
+
+      bgThreads <- atomically $ readTVar cdbBgThreads
+      mapM_ cancel bgThreads
+
+      -- TODO Maybe write a 'LedgerDB' snapshot or wait until it is done.
+      -- See #367.
+      ImmDB.closeDB cdbImmDB
+      VolDB.closeDB cdbVolDB
+
+      chain <- atomically $ readTVar cdbChain
+
+      traceWith cdbTracer $ TraceOpenEvent $ ClosedDB
+        { _immTip   = castPoint $ AF.anchorPoint chain
+        , _chainTip = castPoint $ AF.headPoint chain
+        }
+
+reopen
+  :: forall m blk.
+     ( MonadAsync m
+     , MonadFork  m
+     , MonadMask  m
+     , MonadST    m
+     , MonadTime  m
+     , MonadTimer m
+     , ProtocolLedgerView blk
+     , HasCallStack
+     )
+  => ChainDbHandle m blk
+  -> Bool -- ^ 'True' = Launch background tasks
+  -> m ()
+reopen (CDBHandle varState) launchBgTasks = do
+    mbClosedEnv <- atomically $ readTVar varState >>= \case
+      -- Another call to 'cdbReopen' is in progress. Wait until it is
+      -- finished, then try reopening if it is still necessary.
+      ChainDbReopening  -> retry
+      -- No-op
+      ChainDbOpen  _env -> return Nothing
+      ChainDbClosed env -> do
+        writeTVar varState ChainDbReopening
+        return $ Just env
+
+    -- Only when the ChainDB was closed
+    whenJust mbClosedEnv $ \env@CDB{..} ->
+      -- When something goes wrong, reset the state to 'ChainDbClosed'
+      flip onException (atomically $ writeTVar varState $ ChainDbClosed env) $ do
+        -- TODO what will actually happen if an exception is thrown? What if
+        -- recovery is triggered?
+
+        ImmDB.reopen cdbImmDB
+        -- Note that we must reopen the VolatileDB before the LedgerDB, as the
+        -- latter may try to access the former: when we initially opened it,
+        -- we passed it @getAnyKnownBlock immDB volDB@, which will be called
+        -- during reopening.
+        VolDB.reopen cdbVolDB
+        let lgrTracer = contramap (TraceLedgerEvent . InitLog) cdbTracer
+        LgrDB.reopen cdbLgrDB cdbImmDB lgrTracer
+
+        chainAndLedger <- initialChainSelection
+           cdbImmDB
+           cdbVolDB
+           cdbLgrDB
+           cdbTracer
+           cdbNodeConfig
+           cdbInvalid
+
+        -- Get the actual BlockNo of the tip of the ImmutableDB. Note that
+        -- this might not end up being the \"immutable\" block(no), because
+        -- the current chain computed from the VolatileDB could be longer than
+        -- @k@.
+        immDbBlockNo <- maybe genesisBlockNo blockNo <$>
+          ImmDB.getBlockAtTip cdbImmDB
+
+        let chain      = clChain  chainAndLedger
+            ledger     = clLedger chainAndLedger
+            secParam   = protocolSecurityParam cdbNodeConfig
+            immBlockNo = getImmBlockNo secParam chain immDbBlockNo
+
+        atomically $ do
+          writeTVar cdbChain chain
+          LgrDB.setCurrent cdbLgrDB ledger
+          writeTVar cdbImmBlockNo immBlockNo
+          -- Change the state from 'ChainDbReopening' to 'ChainDbOpen'
+          writeTVar varState $ ChainDbOpen env
+        traceWith cdbTracer $ TraceOpenEvent $ ReopenedDB
+          { _immTip   = castPoint $ AF.anchorPoint chain
+          , _chainTip = castPoint $ AF.headPoint   chain
+          }
+
+        when launchBgTasks $ Background.launchBgTasks env

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
@@ -1,0 +1,486 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE PatternSynonyms           #-}
+{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE StandaloneDeriving        #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE UndecidableInstances      #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+-- | Thin wrapper around the VolatileDB
+module Ouroboros.Storage.ChainDB.Impl.VolDB (
+    VolDB -- Opaque
+    -- * Initialization
+  , VolDbArgs(..)
+  , defaultArgs
+  , openDB
+    -- * Candidates
+  , candidates
+  , isReachable
+  , isReachableSTM
+    -- * Paths
+  , Path(..)
+  , computePath
+  , computePathSTM
+    -- * Getting and parsing blocks
+  , getKnownHeader
+  , getKnownBlock
+  , getHeader
+  , getBlock
+    -- * Wrappers
+  , getIsMember
+  , getPredecessor
+  , getSuccessors
+  , putBlock
+  , closeDB
+  , reopen
+  , garbageCollect
+    -- * Re-exports
+  , VolatileDBError
+  ) where
+
+import           Codec.CBOR.Decoding (Decoder)
+import           Codec.CBOR.Encoding (Encoding)
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import qualified Data.ByteString.Lazy as Lazy
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import           Data.Maybe (mapMaybe)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Typeable (Typeable)
+import           GHC.Stack (HasCallStack)
+import           System.FilePath ((</>))
+
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+import           Ouroboros.Network.Block (pattern BlockPoint, ChainHash (..),
+                     pattern GenesisPoint, HasHeader (..), HeaderHash, Point,
+                     SlotNo, StandardHash, pointHash, withHash)
+import qualified Ouroboros.Network.Block as Block
+
+import           Ouroboros.Consensus.Block (GetHeader, Header)
+import qualified Ouroboros.Consensus.Block as Block
+import qualified Ouroboros.Consensus.Util.CBOR as Util.CBOR
+
+import           Ouroboros.Storage.ChainDB.API (ChainDbError (..),
+                     ChainDbFailure (..), StreamFrom (..), StreamTo (..))
+import           Ouroboros.Storage.FS.API (HasFS, createDirectoryIfMissing)
+import           Ouroboros.Storage.FS.API.Types (MountPoint (..))
+import           Ouroboros.Storage.FS.IO (ioHasFS)
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling,
+                     ThrowCantCatch)
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+import           Ouroboros.Storage.VolatileDB (VolatileDB, VolatileDBError)
+import qualified Ouroboros.Storage.VolatileDB as VolDB
+
+-- | Thin wrapper around the VolatileDB (opaque type)
+--
+-- The intention is that all interaction with the VolatileDB goes through this
+-- module.
+data VolDB m blk = VolDB {
+      volDB    :: VolatileDB (HeaderHash blk) m
+    , decBlock :: forall s. Decoder s blk
+    , encBlock :: blk -> Encoding
+    }
+
+{-------------------------------------------------------------------------------
+  Initialization
+-------------------------------------------------------------------------------}
+
+data VolDbArgs m blk = forall h. VolDbArgs {
+      volHasFS         :: HasFS m h
+    , volErr           :: ErrorHandling (VolatileDBError (HeaderHash blk)) m
+    , volErrSTM        :: ThrowCantCatch (VolatileDBError (HeaderHash blk)) (STM m)
+    , volBlocksPerFile :: Int
+    , volDecodeBlock   :: forall s. Decoder s blk
+    , volEncodeBlock   :: blk -> Encoding
+    }
+
+-- | Default arguments when using the 'IO' monad
+--
+-- The following fields must still be defined:
+--
+-- * 'volBlocksPerFile'
+-- * 'volDecodeBlock'
+-- * 'volEncodeBlock'
+defaultArgs :: StandardHash blk => FilePath -> VolDbArgs IO blk
+defaultArgs fp = VolDbArgs {
+      volErr    = EH.exceptions
+    , volErrSTM = EH.throwSTM
+    , volHasFS  = ioHasFS $ MountPoint (fp </> "volatile")
+      -- Fields without a default
+    , volBlocksPerFile = error "no default for volBlocksPerFile"
+    , volDecodeBlock   = error "no default for volDecodeBlock"
+    , volEncodeBlock   = error "no default for volEncodeBlock"
+    }
+
+openDB :: (MonadCatch m, MonadSTM m, MonadST m, HasHeader blk)
+       => VolDbArgs m blk -> m (VolDB m blk)
+openDB args@VolDbArgs{..} = do
+    createDirectoryIfMissing volHasFS True []
+    volDB <- VolDB.openDB
+               volHasFS
+               volErr
+               volErrSTM
+               (blockFileParser args)
+               volBlocksPerFile
+    return VolDB
+      { volDB    = volDB
+      , decBlock = volDecodeBlock
+      , encBlock = volEncodeBlock
+      }
+
+{-------------------------------------------------------------------------------
+  Wrappers
+-------------------------------------------------------------------------------}
+
+getIsMember :: VolDB m blk -> STM m (HeaderHash blk -> Bool)
+getIsMember db = withSTM db VolDB.getIsMember
+
+getPredecessor :: VolDB m blk
+               -> STM m (HeaderHash blk -> Maybe (HeaderHash blk))
+getPredecessor db = withSTM db VolDB.getPredecessor
+
+getSuccessors :: VolDB m blk
+              -> STM m (Maybe (HeaderHash blk) -> Set (HeaderHash blk))
+getSuccessors db = withSTM db VolDB.getSuccessors
+
+putBlock :: (MonadCatch m, HasHeader blk) => VolDB m blk -> blk -> m ()
+putBlock db@VolDB{..} b = withDB db $ \vol ->
+    VolDB.putBlock vol (extractInfo b) (CBOR.toBuilder (encBlock b))
+
+closeDB :: (MonadCatch m, HasHeader blk, HasCallStack)
+        => VolDB m blk -> m ()
+closeDB db = withDB db VolDB.closeDB
+
+reopen :: (MonadCatch m, HasHeader blk, HasCallStack)
+       => VolDB m blk -> m ()
+reopen db = withDB db VolDB.reOpenDB
+
+garbageCollect :: (MonadCatch m, HasHeader blk)
+               => VolDB m blk -> SlotNo -> m ()
+garbageCollect db slotNo = withDB db $ \vol ->
+    VolDB.garbageCollect vol slotNo
+
+{-------------------------------------------------------------------------------
+  Compute candidates
+-------------------------------------------------------------------------------}
+
+-- | Compute all candidates starting at the specified hash
+--
+-- PRECONDITION: the block to which the given point corresponds is part of the
+-- VolatileDB.
+--
+-- The first element in each list of hashes is the hash /after/ the specified
+-- hash. Thus, when building fragments from these lists of hashes, they
+-- fragments must be /anchored/ at the specified hash, but not contain it.
+--
+-- NOTE: it is possible that no candidates are found, but don't forget that
+-- the chain (fragment) ending with @B@ is also a potential candidate.
+candidates
+  :: forall blk.
+     (Maybe (HeaderHash blk) -> Set (HeaderHash blk)) -- ^ @getSuccessors@
+  -> Point blk                                        -- ^ @B@
+  -> [NonEmpty (HeaderHash blk)]
+     -- ^ Each element in the list is a list of hashes from which we can
+     -- construct a fragment anchored at the point @B@.
+candidates succsOf b = mapMaybe NE.nonEmpty $ go (fromChainHash (pointHash b))
+  where
+    go :: Maybe (HeaderHash blk) -> [[HeaderHash blk]]
+    go mbHash = case Set.toList $ succsOf mbHash of
+      []    -> [[]]
+      succs -> [ next : candidate
+               | next <- succs
+               , candidate <- go (Just next)
+               ]
+
+-- | Variant of 'isReachable' that obtains its arguments in the same 'STM'
+-- transaction.
+isReachableSTM :: (MonadSTM m, HasHeader blk)
+               => VolDB m blk
+               -> STM m (Point blk) -- ^ The tip of the ImmutableDB (@I@).
+               -> Point blk         -- ^ The point of the block (@B@) to check
+                                    -- the reachability of
+               -> STM m (Maybe (NonEmpty (HeaderHash blk)))
+isReachableSTM volDB getI b = do
+    (predecessor, isMember, i) <- withSTM volDB $ \db ->
+      (,,) <$> VolDB.getPredecessor db <*> VolDB.getIsMember db <*> getI
+    return $ isReachable predecessor isMember i b
+
+-- | Check whether the given point, corresponding to a block @B@, is reachable
+-- from the tip of the ImmutableDB (@I@) by chasing the predecessors.
+--
+-- Returns a path (of hashes) from @I@ (excluded) to @B@ (included).
+--
+-- PRECONDITION: @B ∈ V@, i.e. @B@ is part of the VolatileDB.
+--
+-- 'True' <=> for all transitive predecessors @B'@ of @B@ we have @B' ∈ V@ or
+-- @B' = I@.
+isReachable :: forall blk. (HasHeader blk, HasCallStack)
+            => (HeaderHash blk -> Maybe (HeaderHash blk))  -- ^ @getPredecessor@
+            -> (HeaderHash blk -> Bool)                    -- ^ @isMember@
+            -> Point blk                                   -- ^ @I@
+            -> Point blk                                   -- ^ @B@
+            -> Maybe (NonEmpty (HeaderHash blk))
+isReachable predecessor isMember i b =
+    case computePath predecessor isMember from to of
+      -- Bounds are not on the same fork
+      Nothing   -> Nothing
+      Just path -> case path of
+        CompletelyInVolDB hashes -> case NE.nonEmpty hashes of
+          Just hashes' -> Just hashes'
+          Nothing      ->
+            error "impossible: empty list of hashes with an inclusive bound"
+        PartiallyInVolDB  {}     -> Nothing
+        NotInVolDB        _      ->
+          error "impossible: block just added to VolatileDB missing"
+  where
+    from = StreamFromExclusive i
+    to   = StreamToInclusive   b
+
+{-------------------------------------------------------------------------------
+  Compute paths
+-------------------------------------------------------------------------------}
+
+-- | Construct a path backwards through the VolatileDB.
+--
+-- We walk backwards through the VolatileDB, constructing a 'Path' from the
+-- 'StreamTo' to the 'StreamFrom'.
+--
+-- If the range is invalid, 'Nothing' is returned.
+--
+-- See the documentation of 'Path'.
+computePath
+  :: forall blk. HasHeader blk
+  => (HeaderHash blk -> Maybe (HeaderHash blk)) -- ^ @getPredecessor@
+  -> (HeaderHash blk -> Bool)                   -- ^ @isMember@
+  -> StreamFrom blk
+  -> StreamTo   blk
+  -> Maybe (Path blk)
+computePath predecessor isMember from to = case to of
+    StreamToInclusive GenesisPoint
+      -> Nothing
+    StreamToExclusive GenesisPoint
+      -> Nothing
+    StreamToInclusive (BlockPoint { withHash = end })
+      | isMember end     -> case from of
+          -- Easier to handle this special case (@StreamFromInclusive start,
+          -- StreamToInclusive end, start == end@) here:
+          StreamFromInclusive (BlockPoint { withHash = start })
+            | start == end -> return $ CompletelyInVolDB [end]
+          _                -> go [end] end
+      | otherwise        -> return $ NotInVolDB end
+    StreamToExclusive (BlockPoint { withHash = end })
+      | isMember end     -> go [] end
+      | otherwise        -> return $ NotInVolDB end
+  where
+    -- Invariant: @isMember hash@ and @hash@ has been added to @acc@ (if
+    -- allowed by the bounds)
+    go :: [HeaderHash blk] -> HeaderHash blk -> Maybe (Path blk)
+    go acc hash = case predecessor hash of
+      -- Found genesis
+      Nothing -> case from of
+        StreamFromInclusive _
+          -> Nothing
+        StreamFromExclusive GenesisPoint
+          -> return $ CompletelyInVolDB acc
+        StreamFromExclusive (BlockPoint {})
+          -> Nothing
+
+      Just predHash
+        | isMember predHash -> case from of
+          StreamFromInclusive pt
+            | BlockHash predHash == Block.pointHash pt
+            -> return $ CompletelyInVolDB (predHash : acc)
+          StreamFromExclusive pt
+            | BlockHash predHash == Block.pointHash pt
+            -> return $ CompletelyInVolDB acc
+          -- Bound not yet reached, invariants both ok!
+          _ -> go (predHash : acc) predHash
+        -- Predecessor not in the VolatileDB
+        | StreamFromExclusive pt <- from
+        , BlockHash predHash == Block.pointHash pt
+          -- That's fine if we don't need to include it in the path.
+        -> return $ CompletelyInVolDB acc
+        | otherwise
+        -> return $ PartiallyInVolDB predHash acc
+
+-- | Variant of 'computePath' that obtains its arguments in the same 'STM'
+-- transaction. Throws an 'InvalidIteratorRange' exception when the range is
+-- invalid (i.e., 'computePath' returned 'Nothing').
+computePathSTM
+  :: forall m blk.
+     ( MonadSTM m
+     , MonadThrow (STM m)
+     , HasHeader blk
+     )
+  => VolDB m blk
+  -> StreamFrom blk
+  -> StreamTo   blk
+  -> STM m (Path blk)
+computePathSTM volDB from to = do
+    (predecessor, isMember) <- withSTM volDB $ \db ->
+      (,) <$> VolDB.getPredecessor db <*> VolDB.getIsMember db
+    case computePath predecessor isMember from to of
+      Just path -> return path
+      Nothing   -> throwM $ InvalidIteratorRange from to
+
+-- | A path through the VolatileDB from a 'StreamFrom' to a 'StreamTo'.
+--
+-- Invariant: the @ChainFragment@ (oldest first) constructed using the blocks
+-- corresponding to the hashes in the path will be valid, i.e. the blocks will
+-- fit onto each other.
+data Path blk
+  = NotInVolDB (HeaderHash blk)
+    -- ^ The @end@ point (@'StreamToInclusive' end@ or @'StreamToExclusive'
+    -- end@) was not part of the VolatileDB.
+  | CompletelyInVolDB [HeaderHash blk]
+    -- ^ A complete path, from start point to end point was constructed from
+    -- the VolatileDB. The list contains the hashes from oldest to newest.
+    --
+    -- * If the lower bound was @'StreamFromInclusive' pt@, then @pt@ will be
+    --   the first element of the list.
+    -- * If the lower bound was @'StreamFromExclusive' pt@, then the first
+    --   element of the list will correspond to the first block after @pt@.
+    --
+    -- * If the upper bound was @'StreamToInclusive' pt@, then @pt@ will be
+    --   the last element of the list.
+    -- * If the upper bound was @'StreamToExclusive' pt@, then the last
+    --   element of the list will correspond to the first block before @pt@.
+  | PartiallyInVolDB (HeaderHash blk) [HeaderHash blk]
+    -- ^ Only a partial path could be constructed from the VolatileDB. The
+    -- missing predecessor could still be in the ImmutableDB. The list
+    -- contains the hashes from oldest to newest.
+    --
+    -- * The first element in the list is the point for which no predecessor
+    --   is available in the VolatileDB. The block corresponding to the point
+    --   itself, /is/ available in the VolatileDB.
+    -- * The first argument is the hash of predecessor, the block that is not
+    --   available in the VolatileDB.
+    --
+    -- Note: if the lower bound is exclusive, the block corresponding to it
+    -- doesn't have to be part of the VolatileDB, it will result in a
+    -- 'StartToEnd'.
+    --
+    -- The same invariants hold for the upper bound as for 'StartToEnd'.
+
+deriving instance Show (HeaderHash blk) => Show (Path blk)
+
+{-------------------------------------------------------------------------------
+  Getting and parsing blocks
+-------------------------------------------------------------------------------}
+
+getKnownHeader :: (MonadCatch m, StandardHash blk, Typeable blk, GetHeader blk)
+               => VolDB m blk -> HeaderHash blk -> m (Header blk)
+getKnownHeader db@VolDB{..} hash =
+    Block.getHeader <$> getKnownBlock db hash
+
+getKnownBlock :: (MonadCatch m, StandardHash blk, Typeable blk)
+              => VolDB m blk -> HeaderHash blk -> m blk
+getKnownBlock db hash = do
+    mBlock <- mustExist hash <$> getBlock db hash
+    case mBlock of
+      Right b  -> return b
+      Left err -> throwM err
+
+getHeader :: (MonadCatch m, StandardHash blk, Typeable blk, GetHeader blk)
+               => VolDB m blk -> HeaderHash blk -> m (Maybe (Header blk))
+getHeader db@VolDB{..} hash =
+    fmap Block.getHeader <$> getBlock db hash
+
+getBlock :: (MonadCatch m, StandardHash blk, Typeable blk)
+         => VolDB m blk -> HeaderHash blk -> m (Maybe blk)
+getBlock db hash = do
+    mBlob <- withDB db $ \vol ->
+               fmap (parse (decBlock db) hash) <$> VolDB.getBlock vol hash
+    case mBlob of
+      Nothing         -> return $ Nothing
+      Just (Right b)  -> return $ Just b
+      Just (Left err) -> throwM $ err
+
+{-------------------------------------------------------------------------------
+  Auxiliary: parsing
+-------------------------------------------------------------------------------}
+
+blockFileParser :: forall m blk. (MonadST m, MonadThrow m, HasHeader blk)
+                => VolDbArgs m blk
+                -> VolDB.Parser
+                     Util.CBOR.ReadIncrementalErr
+                     m
+                     (HeaderHash blk)
+blockFileParser VolDbArgs{..} =
+    VolDB.Parser $ Util.CBOR.readIncrementalOffsets volHasFS decoder'
+  where
+    decoder' :: forall s. Decoder s (VolDB.BlockInfo (HeaderHash blk))
+    decoder' = extractInfo <$> volDecodeBlock
+
+{-------------------------------------------------------------------------------
+  Error handling
+-------------------------------------------------------------------------------}
+
+-- | Wrap calls to the VolatileDB and rethrow exceptions that may indicate
+-- disk failure and should therefore trigger recovery
+withDB :: forall m blk x. (MonadCatch m, StandardHash blk, Typeable blk)
+       => VolDB m blk
+       -> (VolatileDB (HeaderHash blk) m -> m x)
+       -> m x
+withDB VolDB{..} k = catch (k volDB) rethrow
+  where
+    rethrow :: VolatileDBError (HeaderHash blk) -> m x
+    rethrow err = case wrap err of
+                    Just err' -> throwM err'
+                    Nothing   -> throwM err
+
+    wrap :: VolatileDBError (HeaderHash blk) -> Maybe (ChainDbFailure blk)
+    wrap (VolDB.UnexpectedError err) = Just (VolDbFailure err)
+    wrap VolDB.UserError{}           = Nothing
+
+-- | STM actions, by definition, cannot access the disk and therefore we don't
+-- have to worry about catching exceptions here: any exceptions that may be
+-- thrown indicate bugs, either in the ChainDB or in the VolatileDB
+withSTM :: VolDB m blk
+        -> (VolatileDB (HeaderHash blk) m -> STM m x)
+        -> STM m x
+withSTM VolDB{..} k = k volDB
+
+mustExist :: HeaderHash blk
+          -> Maybe blk
+          -> Either (ChainDbFailure blk) blk
+mustExist hash Nothing  = Left  $ VolDbMissingBlock hash
+mustExist _    (Just b) = Right $ b
+
+parse :: forall blk.
+         (forall s. Decoder s blk)
+      -> HeaderHash blk
+      -> Lazy.ByteString
+      -> Either (ChainDbFailure blk) blk
+parse dec hash =
+    aux . CBOR.deserialiseFromBytes dec
+  where
+    aux :: Either CBOR.DeserialiseFailure (Lazy.ByteString, blk)
+        -> Either (ChainDbFailure blk) blk
+    aux (Right (bs, b))
+      | Lazy.null bs = Right b
+      | otherwise    = Left $ VolDbTrailingData hash bs
+    aux (Left err)   = Left $ VolDbParseFailure hash err
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+fromChainHash :: ChainHash blk -> Maybe (HeaderHash blk)
+fromChainHash GenesisHash      = Nothing
+fromChainHash (BlockHash hash) = Just hash
+
+extractInfo :: HasHeader blk => blk -> VolDB.BlockInfo (HeaderHash blk)
+extractInfo b = VolDB.BlockInfo {
+      bbid    = blockHash b
+    , bslot   = blockSlot b
+    , bpreBid = fromChainHash (blockPrevHash b)
+    }

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Model.hs
@@ -421,8 +421,11 @@ garbageCollectable secParam m@Model{..} b =
 
 -- Return 'True' when the model contains the block corresponding to the point
 -- and the block itself is eligible for garbage collection, i.e. the real
--- implementation might have garbage collected it. In all other cases, return
--- 'False'.
+-- implementation might have garbage collected it.
+--
+-- If the block is not in the model, return 'True', as it has likely been
+-- garbage-collected from the model too. Note that we cannot distinguish this
+-- case from a block that was never added to the model in the first place.
 garbageCollectablePoint :: forall blk. HasHeader blk
                         => SecurityParam -> Model blk -> Point blk -> Bool
 garbageCollectablePoint secParam m@Model{..} pt
@@ -430,7 +433,7 @@ garbageCollectablePoint secParam m@Model{..} pt
     , Just blk <- getBlock hash m
     = garbageCollectable secParam m blk
     | otherwise
-    = False
+    = True
 
 garbageCollect :: forall blk. HasHeader blk
                => SecurityParam -> Model blk -> Model blk

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Model.hs
@@ -1,6 +1,10 @@
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Model implementation of the chain DB
 --
@@ -48,6 +52,7 @@ import           Control.Monad.Except (runExcept)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, isJust, mapMaybe)
+import           GHC.Generics (Generic)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as Fragment
@@ -81,7 +86,14 @@ data Model blk = Model {
       -- ChainDB that wraps this model will throw a 'ClosedDBError' whenever
       -- it is used while closed.
     }
-  deriving (Show)
+  deriving (Generic)
+
+deriving instance
+  ( OuroborosTag (BlockProtocol blk)
+  , ProtocolLedgerView          blk
+  , Block.StandardHash          blk
+  , Show                        blk
+  ) => Show (Model blk)
 
 {-------------------------------------------------------------------------------
   Queries

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
@@ -3,8 +3,8 @@ module Ouroboros.Storage.LedgerDB.DiskPolicy (
   , defaultDiskPolicy
   ) where
 
-import           Data.Time.Clock (DiffTime)
 import           Control.Monad.Class.MonadSTM
+import           Data.Time.Clock (DiffTime)
 
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 
@@ -58,10 +58,8 @@ data DiskPolicy m = DiskPolicy {
 defaultDiskPolicy :: MonadSTM m
                   => SecurityParam     -- ^ Maximum rollback
                   -> DiffTime          -- ^ Slot length
-                  -> STM m (DiskPolicy m)
-defaultDiskPolicy (SecurityParam k) slotLength = do
-    constantDelay <- newTVar (fromIntegral k * slotLength)
-    return DiskPolicy {
-        onDiskNumSnapshots  = 2
-      , onDiskWriteInterval = readTVar constantDelay
-      }
+                  -> DiskPolicy m
+defaultDiskPolicy (SecurityParam k) slotLength = DiskPolicy {
+      onDiskNumSnapshots  = 2
+    , onDiskWriteInterval = return (fromIntegral k * slotLength)
+    }

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -125,7 +125,7 @@ data InitLog r =
     --
     -- NOTE: We should /only/ see this if data corrupted occurred.
   | InitFailure DiskSnapshot (InitFailure r) (InitLog r)
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 -- | Initialize the ledger DB from the most recent snapshot on disk
 --
@@ -198,7 +198,7 @@ data InitFailure r =
 
     -- | This snapshot is too recent (ahead of the tip of the chain)
   | InitFailureTooRecent (Tip r)
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 -- | Attempt to initialize the ledger DB from the given snapshot
 --

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB.hs
@@ -6,9 +6,11 @@ import           Test.Tasty
 
 import qualified Test.Ouroboros.Storage.ChainDB.Mock as Mock
 import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
+import qualified Test.Ouroboros.Storage.ChainDB.StateMachine as StateMachine
 
 tests :: TestTree
 tests = testGroup "ChainDB" [
       Model.tests
     , Mock.tests
+    , StateMachine.tests
     ]

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB.hs
@@ -4,13 +4,15 @@ module Test.Ouroboros.Storage.ChainDB (
 
 import           Test.Tasty
 
+import qualified Test.Ouroboros.Storage.ChainDB.AddBlock as AddBlock
 import qualified Test.Ouroboros.Storage.ChainDB.Mock as Mock
 import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
 import qualified Test.Ouroboros.Storage.ChainDB.StateMachine as StateMachine
 
 tests :: TestTree
 tests = testGroup "ChainDB" [
-      Model.tests
+      AddBlock.tests
+    , Model.tests
     , Mock.tests
     , StateMachine.tests
     ]

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Test.Ouroboros.Storage.ChainDB.AddBlock
+  ( tests
+  ) where
+
+import           Control.Exception (throw)
+import           Control.Monad (void)
+import           Data.List (permutations, transpose)
+
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.IOSim
+
+import           Control.Tracer
+
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Chain (Chain)
+
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util (chunks)
+import           Ouroboros.Consensus.Util.Condense (condense)
+import qualified Ouroboros.Consensus.Util.ThreadRegistry as ThreadRegistry
+
+import           Ouroboros.Storage.ChainDB (TraceAddBlockEvent (..), addBlock,
+                     closeDB, openDB, toChain)
+import qualified Ouroboros.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Storage.ChainDB.Model as Model
+
+import           Test.Ouroboros.Storage.ChainDB.StateMachine (constrName,
+                     mkArgs)
+import           Test.Ouroboros.Storage.ChainDB.TestBlock
+
+tests :: TestTree
+tests = testGroup "AddBlock"
+    [ testProperty "addBlock multiple threads" prop_addBlock_multiple_threads
+    ]
+
+
+-- | Add a bunch of blocks from multiple threads and check whether the
+-- resulting chain is correct.
+--
+-- Why not use the parallel state machine tests for this? If one thread adds a
+-- block that fits onto the current block and the other thread adds a
+-- different block that also fits onto the current block, then the outcome
+-- depends on scheduling: either outcome is fine, but they will be different.
+-- quickcheck-state-machine expects the outcome to be deterministic.
+--
+-- Hence this test: don't check whether the resulting chain is equal to the
+-- model chain, but check whether they are equally preferable (candidates). In
+-- fact, it is more complicated than that. Say @k = 2@ and we first add the
+-- following blocks in the given order: @A@, @B@, @C@, @A'@, @B'@, @C'@, @D'@,
+-- then the current chain will end with @C@, even though the fork ending with
+-- @D'@ would be longer. The reason is for this is that we would have to roll
+-- back more @k@ blocks to switch to this fork. Now imagine that the last four
+-- blocks in the list above get added before the first three, then the current
+-- chain would have ended with @D'@. So the order in which blocks are added
+-- really matters.
+--
+-- We take the following approach to check whether the resulting chain is
+-- correct:
+--
+-- * We take the list of blocks to add
+-- * For each permutation of this list:
+--   - We add all the blocks in the permuted list to the model
+--   - We check whether the current chain of the model is equally preferable
+--     to the resulting chain. If so, the test passes.
+-- * If none of the permutations result in an equally preferable chain, the
+--   test fails.
+--
+-- TODO test with multiple protocols
+-- TODO test with different thread schedulings for the simulator
+prop_addBlock_multiple_threads :: BlocksPerThread -> Property
+prop_addBlock_multiple_threads bpt =
+  -- TODO coverage checking
+    tabulate "Event" (map constrName trace) $
+    counterexample ("Actual chain: " <> condense actualChain) $
+    counterexample
+      "No interleaving of adding blocks found that results in the same chain" $
+    any (equallyPreferable actualChain) (map modelAddBlocks (permutations blks))
+  where
+    blks = blocks bpt
+
+    actualChain :: Chain TestBlock
+    trace       :: [TraceAddBlockEvent TestBlock]
+    (actualChain, trace) = run $ do
+        -- Open the DB
+        registry <- atomically ThreadRegistry.new
+        args     <- mkArgs cfg initLedger dynamicTracer registry
+        db       <- openDB args
+        -- Add blocks concurrently
+        mapConcurrently_ (mapM_ (addBlock db)) $ blocksPerThread bpt
+        -- Obtain the actual chain
+        chain <- toChain db
+        -- Close and cancel things
+        closeDB db
+        ThreadRegistry.cancelAll registry
+        return chain
+
+    -- The current chain after all the given blocks were added to a fresh
+    -- model.
+    modelAddBlocks :: [TestBlock] -> Chain TestBlock
+    modelAddBlocks = Model.currentChain . foldr (Model.addBlock cfg) initModel
+      where
+        initModel = Model.empty initLedger
+
+    equallyPreferable :: Chain TestBlock -> Chain TestBlock -> Bool
+    equallyPreferable chain1 chain2 =
+      compareCandidates cfg (AF.fromChain chain1) (AF.fromChain chain2) == EQ
+
+    cfg :: NodeConfig (BlockProtocol TestBlock)
+    cfg = singleNodeTestConfig
+
+    initLedger :: ExtLedgerState TestBlock
+    initLedger = testInitExtLedger
+
+    dynamicTracer :: Tracer (SimM s) (ChainDB.TraceEvent TestBlock)
+    dynamicTracer = Tracer $ \case
+      ChainDB.TraceAddBlockEvent ev -> traceM ev
+      _                             -> return ()
+
+    run :: (forall s. SimM s a) -> (a, [TraceAddBlockEvent TestBlock])
+    run m = (res, evs)
+      where
+      tr  = runSimTrace m
+      res = either throw id $ traceResult True tr
+      evs = selectTraceEventsDynamic tr
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+mapConcurrently_ :: forall m a. MonadAsync m => (a -> m ()) -> [a] -> m ()
+mapConcurrently_ f = go
+  where
+    go :: [a] -> m ()
+    go []     = return ()
+    go (x:xs) =
+      withAsync (f  x)  $ \y  ->
+      withAsync (go xs) $ \ys ->
+        void $ waitBoth y ys
+
+{-------------------------------------------------------------------------------
+  Generators
+-------------------------------------------------------------------------------}
+
+newtype Threads = Threads { unThreads :: Int }
+    deriving (Eq, Show)
+
+instance Arbitrary Threads where
+  arbitrary = Threads <$> choose (2, 10)
+  shrink (Threads n) = [Threads n' | n' <- [2..n-1]]
+
+
+data BlocksPerThread = BlocksPerThread
+  { _blockTree   :: !BlockTree
+  , _permutation :: !Permutation
+  , _threads     :: !Threads
+  }
+
+blocks :: BlocksPerThread -> [TestBlock]
+blocks BlocksPerThread{..} =
+    permute _permutation $ treeToBlocks _blockTree
+
+blocksPerThread :: BlocksPerThread -> [[TestBlock]]
+blocksPerThread bpt@BlocksPerThread{..} =
+    transpose $ chunks (unThreads _threads) $ blocks bpt
+
+instance Show BlocksPerThread where
+  show bpt = unlines $ zipWith
+    (\(i :: Int) blks -> "thread " <> show i <> ": " <> condense blks)
+    [0..]
+    (blocksPerThread bpt)
+
+instance Arbitrary BlocksPerThread where
+  arbitrary = BlocksPerThread
+     -- Limit the number of blocks to 10, because the number of interleavings
+     -- grows factorially.
+    <$> scale (min 10) arbitrary
+    <*> arbitrary
+    <*> arbitrary
+  shrink (BlocksPerThread bt p t) =
+    -- No need to shrink permutations
+    [BlocksPerThread bt  p t' | t'  <- shrink t]  <>
+    [BlocksPerThread bt' p t  | bt' <- shrink bt]

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1,0 +1,1184 @@
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DeriveTraversable    #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TupleSections        #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans -Wredundant-constraints #-}
+module Test.Ouroboros.Storage.ChainDB.StateMachine
+  ( tests
+  , mkArgs
+  , constrName
+  ) where
+
+import           Prelude hiding (elem)
+
+import           Codec.Serialise (decode, encode)
+import           Control.Monad (replicateM, unless)
+import           Control.Monad.State (StateT, evalStateT, get, lift, modify,
+                     put)
+import           Data.Bifoldable
+import           Data.Bifunctor
+import qualified Data.Bifunctor.TH as TH
+import           Data.Bitraversable
+import           Data.Functor.Classes (Eq1, Show1)
+import           Data.IORef
+import           Data.List (sortOn)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as Map
+import           Data.Ord (Down (..))
+import           Data.Proxy
+import           Data.TreeDiff (ToExpr)
+import           Data.Typeable
+import           Data.Word (Word64)
+import           GHC.Generics (Generic)
+
+import qualified Generics.SOP as SOP
+
+import           Test.QuickCheck
+import qualified Test.QuickCheck.Monadic as QC
+import           Test.StateMachine
+import qualified Test.StateMachine.Types as QSM
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+import           Control.Tracer
+
+import           Cardano.Crypto.DSIGN.Mock
+
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.Block (BlockNo (..), ChainHash (..),
+                     ChainUpdate, HasHeader, HeaderHash, Point, SlotNo (..),
+                     StandardHash)
+import qualified Ouroboros.Network.Block as Block
+import           Ouroboros.Network.Chain (Chain (..), genesisPoint)
+import qualified Ouroboros.Network.Chain as Chain
+import           Ouroboros.Network.ChainProducerState (ChainProducerState,
+                     ReaderNext, ReaderState)
+import qualified Ouroboros.Network.ChainProducerState as CPS
+import qualified Ouroboros.Network.Point as Point
+
+import           Ouroboros.Consensus.Block (getHeader)
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.NodeId (NodeId (..))
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.BFT
+import           Ouroboros.Consensus.Util.Condense (condense)
+import           Ouroboros.Consensus.Util.ThreadRegistry (ThreadRegistry,
+                     withThreadRegistry)
+import qualified Ouroboros.Consensus.Util.ThreadRegistry as ThreadRegistry
+
+import           Ouroboros.Storage.ChainDB
+import qualified Ouroboros.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Storage.ChainDB.Model as Model
+import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
+import           Ouroboros.Storage.FS.Sim.STM (simHasFS)
+import           Ouroboros.Storage.ImmutableDB
+                     (ValidationPolicy (ValidateAllEpochs))
+import           Ouroboros.Storage.LedgerDB.DiskPolicy (defaultDiskPolicy)
+import           Ouroboros.Storage.LedgerDB.MemPolicy (defaultMemPolicy)
+import qualified Ouroboros.Storage.LedgerDB.OnDisk as LedgerDB
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+import           Test.Ouroboros.Storage.ChainDB.TestBlock
+import           Test.Ouroboros.Storage.Util ((=:=))
+
+import           Test.Util.RefEnv (RefEnv)
+import qualified Test.Util.RefEnv as RE
+
+
+{-------------------------------------------------------------------------------
+  Abstract model
+-------------------------------------------------------------------------------}
+
+-- | Commands
+data Cmd blk it rdr
+  = AddBlock          blk
+  | GetCurrentChain
+  | GetCurrentLedger
+  | GetTipBlock
+  | GetTipHeader
+  | GetTipPoint
+  | GetBlock          (Point blk)
+  | GetGCedBlock      (Point blk)
+    -- ^ Only for blocks that may have been garbage collected.
+  | StreamBlocks      (StreamFrom blk) (StreamTo blk)
+  | IteratorNext      it
+  | IteratorClose     it
+  | NewBlockReader
+    -- ^ Subsumes 'newHeaderReader' as it will include the same code path.
+  | ReaderInstruction rdr
+    -- ^ 'readerInstructionBlocking' is excluded, as it requires multiple
+    -- threads. Its code path is pretty much the same as 'readerInstruction'
+    -- anyway.
+  | ReaderForward     rdr [Point blk]
+  | ReaderClose       rdr
+  | Close
+  | Reopen
+    -- Internal
+  | RunBgTasks
+  deriving (Generic, Show, Functor, Foldable, Traversable)
+
+-- TODO knownInvalidBlocks, see #625
+
+deriving instance SOP.Generic         (Cmd blk it rdr)
+deriving instance SOP.HasDatatypeInfo (Cmd blk it rdr)
+
+-- | Return type for successful database operations.
+data Success blk it rdr
+  = Unit          ()
+  | Chain         (AnchoredFragment (Header blk))
+  | Ledger        (ExtLedgerState blk)
+  | MbBlock       (Maybe blk)
+  | MbGCedBlock   (MaybeGCedBlock blk)
+  | MbHeader      (Maybe (Header blk))
+  | Point         (Point blk)
+  | UnknownRange  (UnknownRange blk)
+  | Iter          it
+  | IterResult    (IteratorResult blk)
+  | BlockReader   rdr
+  | MbChainUpdate (Maybe (ChainUpdate blk blk))
+  | MbPoint       (Maybe (Point blk))
+  deriving (Functor, Foldable, Traversable)
+
+type TestConstraints blk =
+  ( OuroborosTag   (BlockProtocol blk)
+  , ProtocolLedgerView            blk
+  , Eq (ChainState (BlockProtocol blk))
+  , Eq (LedgerState               blk)
+  , Eq                            blk
+  , Show                          blk
+  , HasHeader                     blk
+  , StandardHash                  blk
+  , Eq                    (Header blk)
+  , Show                  (Header blk)
+  )
+
+deriving instance (TestConstraints blk, Eq   it, Eq   rdr)
+               => Eq   (Success blk it rdr)
+deriving instance (TestConstraints blk, Show it, Show rdr)
+               => Show (Success blk it rdr)
+
+run :: forall m blk. (MonadSTM m, MonadAsync m)
+    => ChainDB          m blk
+    -> ChainDB.Internal m blk
+    ->    Cmd     blk (Iterator m blk) (Reader m blk blk)
+    -> m (Success blk (Iterator m blk) (Reader m blk blk))
+run ChainDB{..} ChainDB.Internal{..} = \case
+    AddBlock blk          -> Unit          <$> addBlock blk
+    GetCurrentChain       -> Chain         <$> atomically getCurrentChain
+    GetCurrentLedger      -> Ledger        <$> atomically getCurrentLedger
+    GetTipBlock           -> MbBlock       <$> getTipBlock
+    GetTipHeader          -> MbHeader      <$> getTipHeader
+    GetTipPoint           -> Point         <$> atomically getTipPoint
+    GetBlock pt           -> MbBlock       <$> getBlock pt
+    GetGCedBlock pt       -> mbGCedBlock   <$> getBlock pt
+    StreamBlocks from to  -> iter          <$> streamBlocks from to
+    IteratorNext  it      -> IterResult    <$> iteratorNext it
+    IteratorClose it      -> Unit          <$> iteratorClose it
+    NewBlockReader        -> BlockReader   <$> newBlockReader
+    ReaderInstruction rdr -> MbChainUpdate <$> readerInstruction rdr
+    ReaderForward rdr pts -> MbPoint       <$> readerForward rdr pts
+    ReaderClose rdr       -> Unit          <$> readerClose rdr
+    Close                 -> Unit          <$> closeDB
+    Reopen                -> Unit          <$> intReopen False
+    RunBgTasks            -> ignore        <$> runBgTasks
+  where
+    mbGCedBlock = MbGCedBlock . MaybeGCedBlock True
+    iter = either UnknownRange Iter
+    ignore _ = Unit ()
+
+    runBgTasks = do
+      slotNo <- intCopyToImmDB
+      intGarbageCollect slotNo
+      intUpdateLedgerSnapshots
+
+-- | Result type for 'getBlock'. Note that the real implementation of
+-- 'getBlock' is non-deterministic: if the requested block is older than @k@
+-- and not part of the current chain, it might have been garbage collected.
+--
+-- The first source of non-determinism is whether or not the background thread
+-- that performs garbage collection has been run yet. We disable this thread
+-- in the state machine tests and instead generate the 'CopyToImmDBAndGC'
+-- command that triggers the garbage collection explicitly. So this source of
+-- non-determinism is not a problem in the tests.
+--
+-- However, there is a second source of non-determinism: if a garbage
+-- collection has been performed and the block was eligible for collection, it
+-- might still not have been removed because it was part of a file that
+-- contained other blocks that cannot be garbage collected yet. So the block
+-- is still left in the VolatileDB. We do not try to imitate this behaviour,
+-- which would couple the test too tightly to the actual implementation.
+-- Instead, we accept this source of non-determinism and are more lenient when
+-- comparing the results of 'getBlock' when the block may have been garbage
+-- collected.
+--
+-- Equality of two 'MaybeGCedBlock' is determined as follows:
+-- * If both are produced by a model implementation: the @Maybe blk@s must be
+--   equal, as the these results are deterministic.
+-- * If at least one of them is produced by a real implementation: if either
+--   is 'Nothing', which means the block might have been garbage-collected,
+--   they are equal (even if the other is 'Just', which means it was not yet
+--   garbage-collected).
+-- * If both are 'Just's, then the blocks must be equal.
+--
+-- In practice, this equality is used when comparing the result of the real
+-- implementation with the result of the model implementation.
+data MaybeGCedBlock blk = MaybeGCedBlock
+  { real    :: Bool
+    -- ^ 'True':  result of calling 'getBlock' on the real implementation
+    -- ^ 'False': result of calling 'getBlock' on the model implementation
+  , mbBlock :: Maybe blk
+  } deriving (Show)
+
+instance Eq blk => Eq (MaybeGCedBlock blk) where
+  MaybeGCedBlock real1 mbBlock1 == MaybeGCedBlock real2 mbBlock2 =
+      case (real1, real2) of
+        (False, False) -> mbBlock1 == mbBlock2
+        (True,  _)     -> eqIfJust
+        (_,     True)  -> eqIfJust
+    where
+      eqIfJust = case (mbBlock1, mbBlock2) of
+        (Just b1, Just b2) -> b1 == b2
+        _                  -> True
+
+
+{-------------------------------------------------------------------------------
+  Instantiating the semantics
+-------------------------------------------------------------------------------}
+
+-- | Responses are either successful termination or an error.
+newtype Resp blk it rdr = Resp
+  { getResp :: Either (ChainDbError blk) (Success blk it rdr) }
+  deriving (Functor, Foldable, Traversable)
+
+deriving instance (TestConstraints blk, Show it, Show rdr)
+               => Show (Resp blk it rdr)
+
+instance (TestConstraints blk, Eq it, Eq rdr) => Eq (Resp blk it rdr) where
+  Resp (Left  e) == Resp (Left  e') = e == e'
+  Resp (Right a) == Resp (Right a') = a == a'
+  _              == _               = False
+
+-- We can't reuse 'run' because the 'ChainDB' API uses 'STM'. Instead, we call
+-- the model directly.
+runPure :: forall blk.
+           TestConstraints           blk
+        => NodeConfig (BlockProtocol blk)
+        -> Cmd                       blk   IteratorId ReaderId
+        -> DBModel                   blk
+        -> (Resp                     blk   IteratorId ReaderId, DBModel blk)
+runPure cfg = \case
+    AddBlock blk          -> ok  Unit          $ update_ (Model.addBlock cfg blk)
+    GetCurrentChain       -> ok  Chain         $ query   (Model.lastK k getHeader)
+    GetCurrentLedger      -> ok  Ledger        $ query    Model.currentLedger
+    GetTipBlock           -> ok  MbBlock       $ query    Model.tipBlock
+    GetTipHeader          -> ok  MbHeader      $ query   (fmap getHeader . Model.tipBlock)
+    GetTipPoint           -> ok  Point         $ query    Model.tipPoint
+    GetBlock pt           -> err MbBlock       $ query   (Model.getBlockByPoint pt)
+    GetGCedBlock pt       -> err mbGCedBlock   $ query   (Model.getBlockByPoint pt)
+    StreamBlocks from to  -> err iter          $ updateE (Model.streamBlocks k from to)
+    IteratorNext  it      -> ok  IterResult    $ update  (Model.iteratorNext  it)
+    IteratorClose it      -> ok  Unit          $ update_ (Model.iteratorClose it)
+    NewBlockReader        -> ok  BlockReader   $ update   Model.readBlocks
+    ReaderInstruction rdr -> err MbChainUpdate $ updateE (Model.readerInstruction rdr)
+    ReaderForward rdr pts -> err MbPoint       $ updateE (Model.readerForward rdr pts)
+    ReaderClose rdr       -> ok  Unit          $ update_ (Model.readerClose rdr)
+    -- TODO can this execute while closed?
+    RunBgTasks            -> ok  Unit          $ update_ (Model.garbageCollect k)
+    Close                 -> openOrClosed      $ update_  Model.closeDB
+    Reopen                -> openOrClosed      $ update_  Model.reopen
+  where
+    k = protocolSecurityParam cfg
+
+    iter = either UnknownRange Iter
+    mbGCedBlock = MbGCedBlock . MaybeGCedBlock False
+
+    query   f m = (f m, m)
+
+    update  f m = f m
+    update_ f m = ((), f m)
+    updateE f m = case f m of
+      Left  e       -> (Left e, m)
+      Right (a, m') -> (Right a, m')
+
+    -- Only executed when the ChainDB is open, otherwise a 'ClosedDBError' is
+    -- returned.
+    ok toSuccess f = err toSuccess (first Right . f)
+    err toSuccess f m
+      | Model.isOpen m
+      = first (Resp . fmap toSuccess) (f m)
+      | otherwise
+      = (Resp (Left ClosedDBError), m)
+
+    -- Executed whether the ChainDB is open or closed.
+    openOrClosed f = first (Resp . Right . Unit) . f
+
+runIO :: TestConstraints blk
+      => ChainDB          IO blk
+      -> ChainDB.Internal IO blk
+      ->     Cmd  blk (Iterator IO blk) (Reader IO blk blk)
+      -> IO (Resp blk (Iterator IO blk) (Reader IO blk blk))
+runIO db internal cmd = Resp <$> try (run db internal cmd)
+
+{-------------------------------------------------------------------------------
+  Collect arguments
+-------------------------------------------------------------------------------}
+
+-- | Collect all iterators created.
+iters :: Bitraversable t => t it rdr -> [it]
+iters = bifoldMap (:[]) (const [])
+
+-- | Collect all readers created.
+rdrs :: Bitraversable t => t it rdr -> [rdr]
+rdrs = bifoldMap (const []) (:[])
+
+{-------------------------------------------------------------------------------
+  Model
+-------------------------------------------------------------------------------}
+
+-- | Concrete or symbolic references to a real iterator
+type IterRef blk m r = Reference (Opaque (Iterator m blk)) r
+
+-- | Mapping between iterator references and mocked iterators
+type KnownIters blk m r = RefEnv (Opaque (Iterator m blk)) IteratorId r
+
+-- | Concrete or symbolic references to a real reader
+type ReaderRef blk m r = Reference (Opaque (Reader m blk blk)) r
+
+-- | Mapping between iterator references and mocked readers
+type KnownReaders blk m r = RefEnv (Opaque (Reader m blk blk)) ReaderId r
+
+type DBModel blk = Model.Model blk
+
+-- | Execution model
+data Model blk m r = Model
+  { dbModel      :: DBModel                           blk
+  , knownIters   :: KnownIters                        blk m r
+  , knownReaders :: KnownReaders                      blk m r
+  , modelConfig  :: Opaque (NodeConfig (BlockProtocol blk))
+  } deriving (Generic)
+
+deriving instance (TestConstraints blk, Show1 r) => Show (Model blk m r)
+
+-- | Initial model
+initModel :: NodeConfig (BlockProtocol blk)
+          -> ExtLedgerState blk
+          -> Model blk m r
+initModel cfg initLedger = Model
+  { dbModel      = Model.empty initLedger
+  , knownIters   = RE.empty
+  , knownReaders = RE.empty
+  , modelConfig  = QSM.Opaque cfg
+  }
+
+-- | Key property of the model is that we can go from real to mock responses
+toMock :: (Bifunctor (t blk), Eq1 r)
+       => Model blk m r -> At t blk m r -> t blk IteratorId ReaderId
+toMock Model {..} (At t) = bimap (knownIters RE.!) (knownReaders RE.!) t
+
+-- | Step the mock semantics
+--
+-- We cannot step the whole Model here (see 'event', below)
+step :: (TestConstraints blk, Eq1 r)
+     => Model  blk m r
+     -> At Cmd blk m r
+     -> (Resp  blk IteratorId ReaderId, DBModel blk)
+step model@Model { dbModel, modelConfig } cmd =
+    runPure (QSM.unOpaque modelConfig) (toMock model cmd) dbModel
+
+{-------------------------------------------------------------------------------
+  Wrapping in quickcheck-state-machine references
+-------------------------------------------------------------------------------}
+
+-- | Instantiate functor @t blk@ to
+-- @t blk ('IterRef' blk m r) ('ReaderRef' blk m r)@.
+--
+-- Needed because we need to (partially) apply @'At' t blk rdr m@ to @r@.
+newtype At t blk m r = At { unAt :: t blk (IterRef blk m r) (ReaderRef blk m r) }
+  deriving (Generic)
+
+-- | Don't print the 'At' constructor.
+instance Show (t blk (IterRef blk m r) (ReaderRef blk m r))
+      => Show (At t blk m r) where
+  show = show . unAt
+
+deriving instance (TestConstraints blk, Eq1 r) => Eq (At Resp blk m r)
+
+instance Bifunctor (t blk) => Rank2.Functor (At t blk m) where
+  fmap = \f (At x) -> At (bimap (app f) (app f) x)
+    where
+      app :: (r x -> r' x) -> QSM.Reference x r -> QSM.Reference x r'
+      app f (QSM.Reference x) = QSM.Reference (f x)
+
+instance Bifoldable (t blk) => Rank2.Foldable (At t blk m) where
+  foldMap = \f (At x) -> bifoldMap (app f) (app f) x
+    where
+      app :: (r x -> n) -> QSM.Reference x r -> n
+      app f (QSM.Reference x) = f x
+
+instance Bitraversable (t blk) => Rank2.Traversable (At t blk m) where
+  traverse = \f (At x) -> At <$> bitraverse (app f) (app f) x
+    where
+      app :: Functor f
+          => (r x -> f (r' x)) -> QSM.Reference x r -> f (QSM.Reference x r')
+      app f (QSM.Reference x) = QSM.Reference <$> f x
+
+{-------------------------------------------------------------------------------
+  Events
+-------------------------------------------------------------------------------}
+
+-- | An event records the model before and after a command along with the
+-- command itself, and a mocked version of the response.
+data Event blk m r = Event
+  { eventBefore   :: Model  blk m r
+  , eventCmd      :: At Cmd blk m r
+  , eventAfter    :: Model  blk m r
+  , eventMockResp :: Resp   blk     IteratorId ReaderId
+  }
+
+deriving instance (TestConstraints blk, Show1 r) => Show (Event blk m r)
+
+-- | Construct an event
+lockstep :: (TestConstraints blk, Eq1 r, Show1 r)
+         => Model     blk m r
+         -> At Cmd    blk m r
+         -> At Resp   blk m r
+         -> Event     blk m r
+lockstep model@Model {..} cmd (At resp) = Event
+    { eventBefore   = model
+    , eventCmd      = cmd
+    , eventAfter    = model'
+    , eventMockResp = mockResp
+    }
+  where
+    (mockResp, dbModel') = step model cmd
+    newIters   = RE.fromList $ zip (iters resp) (iters mockResp)
+    newReaders = RE.fromList $ zip (rdrs  resp) (rdrs  mockResp)
+    model' = case unAt cmd of
+      -- When closing the database, all open iterators and readers are closed
+      -- too, so forget them.
+      Close -> model
+        { dbModel      = dbModel'
+        , knownIters   = RE.empty
+        , knownReaders = RE.empty
+        }
+      _ -> model
+        { dbModel      = dbModel'
+        , knownIters   = knownIters `RE.union` newIters
+        , knownReaders = knownReaders `RE.union` newReaders
+        }
+
+
+{-------------------------------------------------------------------------------
+  Generator
+-------------------------------------------------------------------------------}
+
+type BlockGen blk m = Model blk m Symbolic -> Gen blk
+
+-- | Generate a 'Cmd'
+generator :: forall       blk m.
+             (HasHeader   blk, OuroborosTag (BlockProtocol blk))
+          => BlockGen     blk m
+          -> Model        blk m Symbolic
+          -> Gen (At Cmd  blk m Symbolic)
+generator genBlock m@Model {..} = At <$> frequency
+    [ (10, AddBlock <$> genBlock m)
+    , (10, return GetCurrentChain)
+    , (10, return GetCurrentLedger)
+    , (10, return GetTipBlock)
+      -- To check that we're on the right chain
+    , (10, return GetTipPoint)
+    , (10, genGetBlock)
+
+    -- Iterators
+    , (10, uncurry StreamBlocks <$> genBounds)
+    , (if null iterators then 0 else 20, genIteratorNext)
+      -- Use a lower frequency for closing, so that the chance increases that
+      -- we can stream multiple blocks from an iterator.
+    , (if null iterators then 0 else 2, genIteratorClose)
+
+    -- Readers
+    , (10, return NewBlockReader)
+    , (if null readers then 0 else 10, genReaderInstruction)
+    , (if null readers then 0 else 10, genReaderForward)
+      -- Use a lower frequency for closing, so that the chance increases that
+      -- we can read multiple blocks from a reader
+    , (if null readers then 0 else 2, genReaderClose)
+
+    , (10, return Close)
+    , (10, return Reopen)
+
+      -- Internal
+    , (10, return RunBgTasks)
+    ]
+    -- TODO adjust the frequencies after labelling
+  where
+    cfg :: NodeConfig (BlockProtocol blk)
+    cfg = unOpaque modelConfig
+
+    secParam :: SecurityParam
+    secParam = protocolSecurityParam cfg
+
+    iterators :: [Reference (Opaque (Iterator m blk)) Symbolic]
+    iterators = RE.keys knownIters
+
+    readers :: [Reference (Opaque (Reader m blk blk)) Symbolic]
+    readers = RE.keys knownReaders
+
+    genRandomPoint :: Gen (Point blk)
+    genRandomPoint = Block.blockPoint <$> genBlock m
+
+    pointsInDB :: [Point blk]
+    pointsInDB = Block.blockPoint <$> Map.elems (Model.blocks dbModel)
+
+    empty :: Bool
+    empty = null pointsInDB
+
+    genPoint :: Gen (Point blk)
+    genPoint = frequency
+      [ (1, return genesisPoint)
+      , (2, genRandomPoint)
+      , (if empty then 0 else 7, elements pointsInDB)
+      ]
+
+    genGetBlock :: Gen (Cmd blk it rdr)
+    genGetBlock = do
+      pt <- genPoint
+      return $ if Model.garbageCollectablePoint secParam dbModel pt
+        then GetGCedBlock pt
+        else GetBlock     pt
+
+
+    genBounds :: Gen (StreamFrom blk, StreamTo blk)
+    genBounds = frequency
+      [ (1, genRandomBounds)
+      , (if empty then 0 else 3, genExistingBounds)
+      ]
+
+    genRandomBounds :: Gen (StreamFrom blk, StreamTo blk)
+    genRandomBounds = (,)
+      <$> (genFromInEx <*> genPoint)
+      <*> (genToInEx   <*> genPoint)
+
+    genFromInEx :: Gen (Point blk -> StreamFrom blk)
+    genFromInEx = elements [StreamFromInclusive, StreamFromExclusive]
+
+    genToInEx :: Gen (Point blk -> StreamTo blk)
+    genToInEx = elements [StreamToInclusive, StreamToExclusive]
+
+    -- Generate bounds that correspond to existing blocks in the DB. Make sure
+    -- that the start bound is older than the end bound.
+    -- NOTE: this does not mean that these bounds are on the same chain.
+    genExistingBounds :: Gen (StreamFrom blk, StreamTo blk)
+    genExistingBounds = do
+      start <- elements pointsInDB
+      end   <- elements pointsInDB `suchThat` ((>= Block.pointSlot start) .
+                                               Block.pointSlot)
+      (,) <$> (genFromInEx <*> return start)
+          <*> (genToInEx   <*> return end)
+
+    genIteratorNext  = IteratorNext  <$> elements iterators
+    genIteratorClose = IteratorClose <$> elements iterators
+
+    genReaderInstruction = ReaderInstruction <$> elements readers
+    genReaderForward     = ReaderForward     <$> elements readers
+                                             <*> genReaderForwardPoints
+
+    genReaderForwardPoints :: Gen [Point blk]
+    genReaderForwardPoints = choose (1, 3) >>= \n ->
+      sortOn (Down . Block.pointSlot) <$> replicateM n genReaderForwardPoint
+
+    genReaderForwardPoint :: Gen (Point blk)
+    genReaderForwardPoint = genPoint
+
+    genReaderClose = ReaderClose <$> elements readers
+
+{-------------------------------------------------------------------------------
+  Shrinking
+-------------------------------------------------------------------------------}
+
+-- | Shrinker
+shrinker :: Model   blk m Symbolic
+         ->  At Cmd blk m Symbolic
+         -> [At Cmd blk m Symbolic]
+shrinker _ = const [] -- TODO
+
+{-------------------------------------------------------------------------------
+  The final state machine
+-------------------------------------------------------------------------------}
+
+-- | Mock a response
+--
+-- We do this by running the pure semantics and then generating mock
+-- references for any new handles.
+mock :: (TestConstraints blk, Typeable m)
+     => Model            blk m Symbolic
+     ->         At Cmd   blk m Symbolic
+     -> GenSym (At Resp  blk m Symbolic)
+mock model cmd = At <$> bitraverse (const genSym) (const genSym) resp
+  where
+    (resp, _dbm) = step model cmd
+
+precondition :: forall m blk. TestConstraints blk
+             => Model blk m Symbolic -> At Cmd blk m Symbolic -> Logic
+precondition Model {..} (At cmd) =
+   forall (iters cmd) (`elem` RE.keys knownIters)   .&&
+   forall (rdrs  cmd) (`elem` RE.keys knownReaders) .&&
+   case cmd of
+     -- Even though we ensure this in the generator, shrinking might change
+     -- it.
+     GetBlock     pt      -> Not $ garbageCollectable pt
+     GetGCedBlock pt      -> garbageCollectable pt
+
+     -- TODO The real implementation allows streaming blocks from the
+     -- VolatileDB that have no path to the current chain. The model
+     -- implementation disallows this, as it only allows streaming from one of
+     -- the possible forks, each starting at genesis. Temporarily only test
+     -- with iterators that the model allows. So we only test a subset of the
+     -- functionality, which does not include error paths.
+     StreamBlocks from to -> isValidIterator from to
+     -- Make sure we don't close (and reopen) when there are multiple equally
+     -- preferable forks in the ChainDB, because we might pick another one
+     -- than the current one when reopening, which would bring us out of sync
+     -- with the model.
+     Close                -> Not equallyPreferableFork
+     _                    -> Top
+  where
+    garbageCollectable :: Point blk -> Logic
+    garbageCollectable =
+      Boolean . Model.garbageCollectablePoint secParam dbModel
+
+    curChain :: Chain blk
+    curChain = Model.currentChain dbModel
+
+    forks :: [Chain blk]
+    forks = Model.chains $ Model.blocks dbModel
+
+    equallyPreferableFork :: Logic
+    equallyPreferableFork = exists forks $ \fork ->
+      Boolean (equallyPreferable cfg curChain fork) .&&
+      Chain.head curChain ./= Chain.head fork
+
+    cfg :: NodeConfig (BlockProtocol blk)
+    cfg = unOpaque modelConfig
+
+    secParam :: SecurityParam
+    secParam = protocolSecurityParam cfg
+
+    isValidIterator :: StreamFrom blk -> StreamTo blk -> Logic
+    isValidIterator from to =
+      case Model.between secParam from to dbModel of
+        Left  _ -> Bot
+        Right _ -> Top
+
+equallyPreferable :: (OuroborosTag (BlockProtocol blk), HasHeader blk)
+                  => NodeConfig (BlockProtocol blk)
+                  -> Chain blk -> Chain blk -> Bool
+equallyPreferable cfg chain1 chain2 =
+    compareCandidates cfg (AF.fromChain chain1) (AF.fromChain chain2) == EQ
+
+
+transition :: (TestConstraints blk, Show1 r, Eq1 r)
+           => Model   blk m r
+           -> At Cmd  blk m r
+           -> At Resp blk m r
+           -> Model   blk m r
+transition model cmd = eventAfter . lockstep model cmd
+
+postcondition :: TestConstraints blk
+              => Model   blk m Concrete
+              -> At Cmd  blk m Concrete
+              -> At Resp blk m Concrete
+              -> Logic
+postcondition model cmd resp =
+    (toMock (eventAfter ev) resp .== eventMockResp ev)
+    .// "real response didn't match model response"
+  where
+    ev = lockstep model cmd resp
+
+semantics :: forall blk. TestConstraints blk
+          => ChainDB IO blk
+          -> ChainDB.Internal IO blk
+          -> At Cmd blk IO Concrete
+          -> IO (At Resp blk IO Concrete)
+semantics db internal (At cmd) =
+    At . (bimap (QSM.reference . QSM.Opaque) (QSM.reference . QSM.Opaque)) <$>
+    runIO db internal (bimap QSM.opaque QSM.opaque cmd)
+
+-- | The state machine proper
+sm :: TestConstraints blk
+   => ChainDB          IO       blk
+   -> ChainDB.Internal IO       blk
+   -> BlockGen                  blk IO
+   -> NodeConfig (BlockProtocol blk)
+   -> ExtLedgerState            blk
+   -> StateMachine (Model       blk IO)
+                   (At Cmd      blk IO)
+                                    IO
+                   (At Resp     blk IO)
+sm db internal genBlock env initLedger = StateMachine
+  { initModel     = initModel env initLedger
+  , transition    = transition
+  , precondition  = precondition
+  , postcondition = postcondition
+  , generator     = Just . generator genBlock
+  , shrinker      = shrinker
+  , semantics     = semantics db internal
+  , mock          = mock
+  , invariant     = Nothing
+  , distribution  = Nothing
+  }
+
+{-------------------------------------------------------------------------------
+  Bitraversable instances
+-------------------------------------------------------------------------------}
+
+TH.deriveBifunctor     ''Cmd
+TH.deriveBifoldable    ''Cmd
+TH.deriveBitraversable ''Cmd
+
+TH.deriveBifunctor     ''Success
+TH.deriveBifoldable    ''Success
+TH.deriveBitraversable ''Success
+
+TH.deriveBifunctor     ''Resp
+TH.deriveBifoldable    ''Resp
+TH.deriveBitraversable ''Resp
+
+{-------------------------------------------------------------------------------
+  Required instances
+
+  The 'ToExpr' constraints come from "Data.TreeDiff".
+-------------------------------------------------------------------------------}
+
+instance CommandNames (At Cmd blk m) where
+  cmdName (At cmd) = constrName cmd
+  cmdNames (_ :: Proxy (At Cmd blk m r)) =
+    constrNames (Proxy @(Cmd blk () ()))
+
+deriving instance Generic ReaderNext
+deriving instance Generic IteratorId
+deriving instance Generic (Point blk)
+deriving instance Generic (Point.Block slot hash)
+deriving instance Generic (Chain blk)
+deriving instance Generic (ChainProducerState blk)
+deriving instance Generic (ReaderState blk)
+deriving instance Generic (ExtLedgerState blk)
+
+deriving instance ( ToExpr (ChainState (BlockProtocol blk))
+                  , ToExpr (LedgerState blk)
+                  )
+                 => ToExpr (ExtLedgerState blk)
+deriving instance ToExpr BlockNo
+deriving instance ToExpr SlotNo
+deriving instance ToExpr ReaderNext
+deriving instance ToExpr IteratorId
+deriving instance ToExpr blk  => ToExpr (Point.WithOrigin blk)
+deriving instance ToExpr hash => ToExpr (Point.Block SlotNo hash)
+deriving instance ToExpr (HeaderHash blk) => ToExpr (ChainHash blk)
+deriving instance ToExpr (HeaderHash blk) => ToExpr (Point blk)
+deriving instance ToExpr (HeaderHash blk) => ToExpr (ReaderState blk)
+deriving instance ToExpr blk => ToExpr (Chain blk)
+deriving instance ( ToExpr blk
+                  , ToExpr (HeaderHash blk)
+                  )
+                 => ToExpr (ChainProducerState blk)
+deriving instance ( ToExpr blk
+                  , ToExpr (HeaderHash blk)
+                  , ToExpr (ChainState (BlockProtocol blk))
+                  , ToExpr (LedgerState blk)
+                  )
+                 => ToExpr (DBModel blk)
+deriving instance ( ToExpr blk
+                  , ToExpr (HeaderHash blk)
+                  , ToExpr (ChainState (BlockProtocol blk))
+                  , ToExpr (LedgerState blk)
+                  )
+                 => ToExpr (Model blk IO Concrete)
+
+-- Blk specific instances
+
+deriving instance ToExpr TestHash
+deriving instance ToExpr Blk
+deriving instance ToExpr (LedgerState Blk)
+
+{-------------------------------------------------------------------------------
+  Labelling
+-------------------------------------------------------------------------------}
+
+deriving instance SOP.Generic         (TraceEvent blk)
+deriving instance SOP.HasDatatypeInfo (TraceEvent blk)
+deriving instance SOP.Generic         (TraceAddBlockEvent blk)
+deriving instance SOP.HasDatatypeInfo (TraceAddBlockEvent blk)
+deriving instance SOP.Generic         (TraceReaderEvent blk)
+deriving instance SOP.HasDatatypeInfo (TraceReaderEvent blk)
+deriving instance SOP.Generic         (TraceCopyToImmDBEvent blk)
+deriving instance SOP.HasDatatypeInfo (TraceCopyToImmDBEvent blk)
+deriving instance SOP.Generic         (TraceValidationEvent blk)
+deriving instance SOP.HasDatatypeInfo (TraceValidationEvent blk)
+deriving instance SOP.Generic         (TraceInitChainSelEvent blk)
+deriving instance SOP.HasDatatypeInfo (TraceInitChainSelEvent blk)
+deriving instance SOP.Generic         (TraceOpenEvent blk)
+deriving instance SOP.HasDatatypeInfo (TraceOpenEvent blk)
+deriving instance SOP.Generic         (TraceGCEvent blk)
+deriving instance SOP.HasDatatypeInfo (TraceGCEvent blk)
+deriving instance SOP.Generic         (TraceIteratorEvent blk)
+deriving instance SOP.HasDatatypeInfo (TraceIteratorEvent blk)
+deriving instance SOP.Generic         (TraceLedgerEvent blk)
+deriving instance SOP.HasDatatypeInfo (TraceLedgerEvent blk)
+deriving instance SOP.Generic         (LedgerDB.InitLog r)
+deriving instance SOP.HasDatatypeInfo (LedgerDB.InitLog r)
+
+-- TODO labelling
+
+{-------------------------------------------------------------------------------
+  Generator for TestBlock
+-------------------------------------------------------------------------------}
+
+type Blk = TestBlock
+
+genBlk :: BlockGen Blk m
+genBlk Model{..} = do
+    testHash@(TestHash h) <- genHash
+    let slot = 2 * fromIntegral (length h)
+    return $ TestBlock
+      { tbHash = testHash
+      , tbSlot = SlotNo slot
+      }
+  where
+    hashesInDB :: [TestHash]
+    hashesInDB = Map.keys (Model.blocks dbModel)
+
+    empty :: Bool
+    empty = null hashesInDB
+
+    -- If the maximum fork number is @n@, it means that only @n + 1@ different
+    -- forks may "fork off" after each block.
+    maxForkNo = 2
+
+    genForkNo :: Gen Word64
+    genForkNo = frequency
+      -- Give a slight preference to "not forking off"
+      [ (1, return 0)
+      , (1, choose (1, maxForkNo))
+      ]
+
+    genHash :: Gen TestHash
+    genHash = frequency
+        [ (1, genRandomHash)
+        , (5, genAppendToCurrentChain)
+        , (if empty then 0 else 3, genFitsOnSomewhere)
+        , (if empty then 0 else 3, genGapAfterExistingBlock)
+        ]
+
+    -- A random hash: random length and random fork numbers
+    genRandomHash :: Gen TestHash
+    genRandomHash = do
+        n <- frequency
+          [ (5, choose (1,  3))
+          , (4, choose (4,  6))
+          , (3, choose (7,  9))
+          , (2, choose (10, 12))
+          , (1, choose (12, 20))
+          ]
+        TestHash . NE.fromList <$> replicateM n genForkNo
+
+    -- A hash that fits onto the current chain, it may or may not fork off.
+    genAppendToCurrentChain :: Gen TestHash
+    genAppendToCurrentChain = do
+        forkNo <- genForkNo
+        return $ TestHash $ case Block.pointHash $ Model.tipPoint dbModel of
+          GenesisHash            ->         forkNo NE.:| []
+          BlockHash (TestHash h) -> NE.cons forkNo h
+
+    -- A hash that fits onto a block in the ChainDB. The block could be at the
+    -- tip of the chain and the hash might already be present in the ChainDB.
+    genFitsOnSomewhere :: Gen TestHash
+    genFitsOnSomewhere = do
+        TestHash hashInDB <- elements hashesInDB
+        forkNo <- genForkNo
+        return $ TestHash $ NE.cons forkNo hashInDB
+
+    -- A hash that doesn't fit onto a block in the ChainDB, but it creates a
+    -- gap of a couple of blocks between an existing block in the ChainDB
+    genGapAfterExistingBlock :: Gen TestHash
+    genGapAfterExistingBlock = do
+        TestHash hashInDB <- elements hashesInDB
+        gapSize <- choose (1, 2) -- TODO relate it to @k@?
+        forkNos <- replicateM gapSize genForkNo
+        return $ TestHash $ foldr NE.cons hashInDB forkNos
+
+{-------------------------------------------------------------------------------
+  Top-level tests
+-------------------------------------------------------------------------------}
+
+testCfg :: NodeConfig (BlockProtocol Blk)
+testCfg = BftNodeConfig
+    { bftParams   = BftParams { bftSecurityParam = k
+                              , bftNumNodes      = 1
+                              }
+    , bftNodeId   = CoreId 0
+    , bftSignKey  = SignKeyMockDSIGN 0
+    , bftVerKeys  = Map.singleton (CoreId 0) (VerKeyMockDSIGN 0)
+    }
+  where
+    k = SecurityParam 2
+
+testInitLedger :: ExtLedgerState Blk
+testInitLedger = testInitExtLedger
+
+dbUnused :: ChainDB blk m
+dbUnused = error "ChainDB used during command generation"
+
+internalUnused :: ChainDB.Internal blk m
+internalUnused = error "ChainDB.Internal used during command generation"
+
+smUnused :: StateMachine (Model Blk IO) (At Cmd Blk IO) IO (At Resp Blk IO)
+smUnused = sm dbUnused internalUnused genBlk testCfg testInitLedger
+
+recordTrace :: IO (Tracer IO ev, IO [ev])
+recordTrace = newIORef [] >>= \ref -> return
+    ( Tracer $ \ev -> atomicModifyIORef' ref $ \evs -> (ev:evs, ())
+    , reverse <$> readIORef ref
+    )
+
+prop_sequential :: Property
+prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do
+    (hist, prop) <- test cmds
+    -- TODO label tags
+    prettyCommands smUnused hist prop
+  where
+    test :: QSM.Commands (At Cmd Blk IO) (At Resp Blk IO)
+         -> QC.PropertyM IO
+            ( QSM.History (At Cmd Blk IO) (At Resp Blk IO)
+            , Property
+            )
+    test cmds = do
+      (tracer, getTrace) <- QC.run recordTrace
+      registry           <- QC.run $ atomically ThreadRegistry.new
+      args               <- QC.run $ mkArgs
+                                       testCfg
+                                       testInitLedger
+                                       tracer
+                                       registry
+      (db, internal)     <- QC.run $ openDBInternal args False
+      let sm' = sm db internal genBlk testCfg testInitLedger
+      (hist, model, res) <- runCommands sm' cmds
+      (realChain, realChain', trace) <- QC.run $ do
+        open <- atomically $ isOpen db
+        unless open $ intReopen internal False
+        realChain <- toChain db
+        trace <- getTrace
+        closeDB db
+        -- We already generate a command to test 'reopenDB', but since that
+        -- code path differs slightly from 'openDB', we test that code path
+        -- here too by simply opening the DB from scratch again and comparing
+        -- the resulting chain.
+        (db', _) <- openDBInternal args False
+        realChain' <- toChain db'
+        closeDB db'
+
+        ThreadRegistry.cancelAll registry
+        return (realChain, realChain', trace)
+      let modelChain = Model.currentChain $ dbModel model
+          prop =
+            counterexample ("Real  chain: " <> condense realChain)       $
+            counterexample ("Model chain: " <> condense modelChain)      $
+            counterexample ("TraceEvents: " <> unlines (map show trace)) $
+            tabulate "Chain length" [show (Chain.length realChain)]      $
+            tabulate "TraceEvents" (map traceEventName trace)            $
+            res === Ok               .&&.
+            realChain =:= modelChain .&&.
+            -- Another equally preferable fork may be selected when opening
+            -- the DB.
+            equallyPreferable (cdbNodeConfig args) realChain realChain'
+      return (hist, prop)
+
+traceEventName :: TraceEvent blk -> String
+traceEventName = \case
+    TraceAddBlockEvent       ev    -> "AddBlock."     <> case ev of
+      AddBlockValidation     ev' -> constrName ev'
+      _                          -> constrName ev
+    TraceReaderEvent         ev    -> "Reader."       <> constrName ev
+    TraceCopyToImmDBEvent    ev    -> "CopyToImmDB."  <> constrName ev
+    TraceInitChainSelEvent   ev    -> "InitChainSel." <> case ev of
+      InitChainSelValidation ev'   -> constrName ev'
+    TraceOpenEvent           ev    -> "Open."         <> constrName ev
+    TraceGCEvent             ev    -> "GC."           <> constrName ev
+    TraceIteratorEvent       ev    -> "Iterator."     <> constrName ev
+    TraceLedgerEvent         ev    -> "Ledger."       <> case ev of
+      InitLog                ev' -> constrName ev'
+      _                          -> constrName ev
+
+mkArgs :: (MonadSTM m, MonadCatch m, MonadThrow (STM m))
+       => NodeConfig (BlockProtocol Blk)
+       -> ExtLedgerState Blk
+       -> Tracer m (TraceEvent Blk)
+       -> ThreadRegistry m
+       -> m (ChainDbArgs m Blk)
+mkArgs cfg initLedger tracer registry = do
+    (immDbFsVar, volDbFsVar, lgrDbFsVar) <- atomically $
+      (,,) <$> newTVar Mock.empty
+           <*> newTVar Mock.empty
+           <*> newTVar Mock.empty
+    return ChainDbArgs
+      { -- Decoders
+        cdbDecodeHash       = decode
+      , cdbDecodeBlock      = decode
+      , cdbDecodeLedger     = decode
+      , cdbDecodeChainState = decode
+
+        -- Encoders
+      , cdbEncodeBlock      = encode
+      , cdbEncodeHash       = encode
+      , cdbEncodeLedger     = encode
+      , cdbEncodeChainState = encode
+
+        -- Error handling
+      , cdbErrImmDb         = EH.monadCatch
+      , cdbErrVolDb         = EH.monadCatch
+      , cdbErrVolDbSTM      = EH.throwSTM
+
+        -- HasFS instances
+      , cdbHasFSImmDb       = simHasFS EH.monadCatch immDbFsVar
+      , cdbHasFSVolDb       = simHasFS EH.monadCatch volDbFsVar
+      , cdbHasFSLgrDB       = simHasFS EH.monadCatch lgrDbFsVar
+
+        -- Policy
+      , cdbValidation       = ValidateAllEpochs
+      , cdbBlocksPerFile    = 4
+      , cdbMemPolicy        = defaultMemPolicy  (protocolSecurityParam cfg)
+      , cdbDiskPolicy       = defaultDiskPolicy (protocolSecurityParam cfg) 10000
+
+        -- Integration
+      , cdbNodeConfig       = cfg
+      , cdbEpochSize        = const (return 10)
+      , cdbIsEBB            = const Nothing -- TODO
+      , cdbGenesis          = return initLedger
+
+      -- Misc
+      , cdbTracer           = tracer
+      , cdbThreadRegistry   = registry
+      , cdbGcDelay          = 0
+      }
+
+tests :: TestTree
+tests = testGroup "ChainDB q-s-m"
+    [ testProperty "sequential" prop_sequential
+    ]
+
+{-------------------------------------------------------------------------------
+  Running commands directly
+-------------------------------------------------------------------------------}
+
+_mkBlk :: [Word64] -> TestBlock
+_mkBlk h = TestBlock
+    { tbHash = mkTestHash h
+    , tbSlot = SlotNo $ fromIntegral $ 2 * length h
+    }
+
+-- | Debugging utility: run some commands against the real implementation.
+_runCmds :: [Cmd Blk IteratorId ReaderId] -> IO [Resp Blk IteratorId ReaderId]
+_runCmds cmds = withThreadRegistry $ \registry -> do
+    args           <- mkArgs
+                        testCfg
+                        testInitLedger
+                        (showTracing stdoutTracer)
+                        registry
+    (db, internal) <- openDBInternal args False
+    evalStateT (mapM (go db internal) cmds) emptyRunCmdState
+  where
+    go :: ChainDB IO Blk -> ChainDB.Internal IO Blk
+       -> Cmd Blk IteratorId ReaderId
+       -> StateT RunCmdState
+                 IO
+                 (Resp Blk IteratorId ReaderId)
+    go db internal cmd = do
+      RunCmdState { _knownIters, _knownReaders} <- get
+      let cmd' = At $
+            bimap (revLookup _knownIters) (revLookup _knownReaders) cmd
+      resp <- lift $ unAt <$> semantics db internal cmd'
+      newIters <- RE.fromList <$>
+       mapM (\rdr -> (rdr, ) <$> newIteratorId) (iters resp)
+      newReaders <- RE.fromList <$>
+        mapM (\rdr -> (rdr, ) <$> newReaderId) (rdrs  resp)
+      let knownIters'   = _knownIters   `RE.union` newIters
+          knownReaders' = _knownReaders `RE.union` newReaders
+          resp'      = bimap (knownIters' RE.!) (knownReaders' RE.!) resp
+      modify $ \s ->
+        s { _knownIters = knownIters', _knownReaders = knownReaders' }
+      return resp'
+
+    revLookup :: Eq a => RefEnv k a r -> a -> Reference k r
+    revLookup env a = head $ RE.reverseLookup (== a) env
+
+    newIteratorId :: forall m. Monad m => StateT RunCmdState m IteratorId
+    newIteratorId = do
+      s@RunCmdState { _nextIteratorId } <- get
+      put (s { _nextIteratorId = succ _nextIteratorId })
+      return _nextIteratorId
+
+    newReaderId :: forall m. Monad m => StateT RunCmdState m ReaderId
+    newReaderId = do
+      s@RunCmdState { _nextReaderId } <- get
+      put (s { _nextReaderId = succ _nextReaderId })
+      return _nextReaderId
+
+data RunCmdState = RunCmdState
+  { _knownIters     :: KnownIters   Blk IO Concrete
+  , _knownReaders   :: KnownReaders Blk IO Concrete
+  , _nextIteratorId :: IteratorId
+  , _nextReaderId   :: ReaderId
+  }
+
+emptyRunCmdState :: RunCmdState
+emptyRunCmdState = RunCmdState
+  { _knownIters     = RE.empty
+  , _knownReaders   = RE.empty
+  , _nextIteratorId = IteratorId 0
+  , _nextReaderId   = 0
+  }
+
+{-------------------------------------------------------------------------------
+  generics-sop auxiliary
+-------------------------------------------------------------------------------}
+
+cmdConstrInfo :: SOP.HasDatatypeInfo a
+              => Proxy a
+              -> SOP.NP SOP.ConstructorInfo (SOP.Code a)
+cmdConstrInfo = SOP.constructorInfo . SOP.datatypeInfo
+
+constrName :: forall a. SOP.HasDatatypeInfo a => a -> String
+constrName a =
+    SOP.hcollapse $ SOP.hliftA2 go (cmdConstrInfo p) (SOP.unSOP (SOP.from a))
+  where
+    go :: SOP.ConstructorInfo b -> SOP.NP SOP.I b -> SOP.K String b
+    go nfo _ = SOP.K $ SOP.constructorName nfo
+
+    p = Proxy @a
+
+constrNames :: SOP.HasDatatypeInfo a => Proxy a -> [String]
+constrNames p =
+    SOP.hcollapse $ SOP.hmap go (cmdConstrInfo p)
+  where
+    go :: SOP.ConstructorInfo a -> SOP.K String a
+    go nfo = SOP.K $ SOP.constructorName nfo

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Test.Ouroboros.Storage.Util where
 -- TODO Move to Test.Util.Storage?
@@ -20,10 +19,11 @@ import           System.Directory (getTemporaryDirectory)
 import           System.IO.Temp (withTempDirectory)
 
 import           Test.QuickCheck (ASCIIString (..), Arbitrary (..), Property,
-                     collect, suchThat)
+                     collect, counterexample, suchThat)
 import           Test.Tasty.HUnit
 
 import           Ouroboros.Consensus.Util (repeatedly)
+import           Ouroboros.Consensus.Util.Condense (Condense, condense)
 
 import           Ouroboros.Storage.FS.API (HasFS (..))
 import           Ouroboros.Storage.FS.API.Types
@@ -201,7 +201,15 @@ tryFS = E.try
 collects :: Show a => [a] -> Property -> Property
 collects = repeatedly collect
 
-
+-- | Like '===', but uses 'Condense' instead of 'Show' when it fails.
+infix 4 =:=
+(=:=) :: (Eq a, Condense a) => a -> a -> Property
+x =:= y =
+    counterexample (condense x ++ interpret res ++ condense y) res
+  where
+    res = x == y
+    interpret True  = " == "
+    interpret False = " /= "
 
 {------------------------------------------------------------------------------
   Blob

--- a/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -45,6 +47,7 @@ import           Data.Maybe (fromMaybe)
 import           Data.Tree (Tree (..))
 import qualified Data.Tree as Tree
 import           Data.Word
+import           GHC.Generics (Generic)
 import qualified System.Random as R
 import           Test.QuickCheck
 
@@ -74,6 +77,7 @@ import           Test.Util.TestTx (TestTx (..), TestTxId)
 -------------------------------------------------------------------------------}
 
 newtype TestHash = TestHash Word64
+  deriving stock   (Generic)
   deriving newtype (Show, Eq, Ord, Serialise, Num, Condense)
 
 data TestBlock = TestBlock {
@@ -83,11 +87,12 @@ data TestBlock = TestBlock {
     , tbSlot     :: Block.SlotNo
     , tbTxs      :: [TestTx]
     }
-  deriving (Show, Eq)
+  deriving stock    (Show, Eq, Generic)
+  deriving anyclass (Serialise)
 
 instance GetHeader TestBlock where
   newtype Header TestBlock = TestHeader { testHeader :: TestBlock }
-    deriving (Show)
+    deriving (Eq, Show)
   getHeader = TestHeader
 
 type instance HeaderHash TestBlock = TestHash
@@ -175,7 +180,7 @@ instance UpdateLedger TestBlock where
           -- The ledger state simply consists of the last applied block
           lastApplied :: (Point TestBlock, ChainHash TestBlock)
         }
-    deriving (Show)
+    deriving (Show, Eq, Generic, Serialise)
 
   data LedgerConfig TestBlock = LedgerConfig
   type LedgerError  TestBlock = InvalidHash

--- a/ouroboros-consensus/test-util/Test/Util/TestTx.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestTx.hs
@@ -1,10 +1,16 @@
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Test.Util.TestTx (
     -- * Transactions
     TestTxId
   , TestTx (..)
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Data.Word (Word64)
+import           GHC.Generics (Generic)
 import           Test.QuickCheck (Arbitrary (..), oneof)
 
 {-------------------------------------------------------------------------------
@@ -13,7 +19,8 @@ import           Test.QuickCheck (Arbitrary (..), oneof)
 
 -- | A simple transaction identifier used in testing 'Mempool' support.
 newtype TestTxId = TestTxId Word64
-  deriving (Show, Eq, Ord)
+  deriving stock   (Show, Eq, Ord, Generic)
+  deriving newtype (Serialise)
 
 instance Arbitrary TestTxId where
   arbitrary           = TestTxId <$> arbitrary
@@ -37,7 +44,8 @@ instance Arbitrary TestTxId where
 -- already been spent with respect to the current ledger state.
 data TestTx = ValidTestTx !TestTxId
             | InvalidTestTx !TestTxId
-  deriving (Show, Eq, Ord)
+  deriving stock    (Show, Eq, Ord, Generic)
+  deriving anyclass (Serialise)
 
 instance Arbitrary TestTx where
   arbitrary = oneof


### PR DESCRIPTION
Remaining tasks:

- [ ] Test that EBBs are handled correctly by iterators, readers, `getBlock`, etc.
- [x] #367 Ledger DB: Thread for writing snapshots.
- [x] Allow readers to be closed to avoid leaking ImmDB iterators (which have open file handles).
- [ ] Avoid leaking the ImmDB iterators used by iterators and readers in case of exceptions, maybe we need something like `ResourceT`?
- [ ] Corruption/recovery
  - [ ] Close iterators
  - [ ] Close readers or roll them back to the new tip of the ChainDB
  *Currently, we just propagate any thrown exception, causing the ChainDB and the whole node itself to be shut down*
- [ ] Handle exceptions thrown in background tasks: what should happen? Is recovery triggered automatically (using `withDB`)? Do we need to restart these threads?
  *The exception shuts down the ChainDB and the whole node itself, see Corruption/recovery*
- [ ] Benchmark `addBlock`, optimise the fast path: adding a block that fits onto the current chain. Or don't we want to optimise for the best case?
- [ ] #627 Profile memory usage of chain selection (in particular long forks).
- [ ] Ignore invalid blocks when doing chain selection.
- [ ] #380 Audit memory footprint.
- [ ] #445 Protect against unintended file deletion.
- [ ] Handle clock changes.
- [ ] Testing
  - [ ] Labelling
  - [ ] Shrinking
  - [ ] #625 Test with invalid blocks
  - [ ] #653 Test with corruption
  - [ ] Test with invalid iterator bounds
  - [ ] Test with EBBs and check that they are handled correctly by iterators, readers, `getBlock`, etc.
  - [ ] Coverage checking
  - [ ] Switch the consensus tests over from the mock to the real implementation.
    *Tested locally*
  - [ ] Test the demo in cardano-node with the real implementation.
    *Tested locally*
- [ ] Adapt the byron-proxy to use the ChainDB instead of the ImmutableDB: check if it works, including aborting and restarting, and measure the performance.
