### PR TITLE
remove HasCallStack from iterator next impl

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -1038,7 +1038,7 @@ streamBinaryBlobsImpl dbEnv mbStart mbEnd = withOpenState dbEnv $ \hasFS st -> d
 
 
 iteratorNextImpl :: forall m hash.
-                    (HasCallStack, MonadSTM m, MonadCatch m, Eq hash)
+                    (MonadSTM m, MonadCatch m, Eq hash)
                  => ImmutableDBEnv m hash
                  -> IteratorHandle hash m
                  -> Bool  -- ^ Step the iterator after reading iff True


### PR DESCRIPTION
Keeping it there caused a memory leak: an application which repeatedly
pulls on an iterator will accumulate and retain the entire call stack.