### PR TITLE
 Transaction submission protocol (node-to-node)

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -65,6 +65,10 @@ library
                        Ouroboros.Network.Protocol.Handshake.Type
                        Ouroboros.Network.Protocol.Handshake.Codec
                        Ouroboros.Network.Protocol.Handshake.Version
+                       Ouroboros.Network.Protocol.TxSubmission.Type
+                       Ouroboros.Network.Protocol.TxSubmission.Client
+                       Ouroboros.Network.Protocol.TxSubmission.Server
+                       Ouroboros.Network.Protocol.TxSubmission.Codec
                        Ouroboros.Network.Protocol.LocalTxSubmission.Type
                        Ouroboros.Network.Protocol.LocalTxSubmission.Client
                        Ouroboros.Network.Protocol.LocalTxSubmission.Server
@@ -164,6 +168,13 @@ test-suite tests
                        Ouroboros.Network.Protocol.Handshake.Codec
                        Ouroboros.Network.Protocol.Handshake.Test
                        Ouroboros.Network.Protocol.Handshake.Version
+                       Ouroboros.Network.Protocol.TxSubmission.Client
+                       Ouroboros.Network.Protocol.TxSubmission.Codec
+                       Ouroboros.Network.Protocol.TxSubmission.Direct
+                       Ouroboros.Network.Protocol.TxSubmission.Examples
+                       Ouroboros.Network.Protocol.TxSubmission.Server
+                       Ouroboros.Network.Protocol.TxSubmission.Type
+                       Ouroboros.Network.Protocol.TxSubmission.Test
                        Ouroboros.Network.Protocol.LocalTxSubmission.Client
                        Ouroboros.Network.Protocol.LocalTxSubmission.Codec
                        Ouroboros.Network.Protocol.LocalTxSubmission.Direct

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Client.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes          #-}
+
+
+-- | A view of the transaction submission protocol from the point of view of
+-- the client.
+--
+-- This provides a view that uses less complex types and should be easier to
+-- use than the underlying typed protocol itself.
+--
+-- For execution, 'txSubmissionClientPeer' is provided for conversion
+-- into the typed protocol.
+--
+module Ouroboros.Network.Protocol.TxSubmission.Client (
+    -- * Protocol type for the client
+    -- | The protocol states from the point of view of the client.
+    TxSubmissionClient(..)
+  , ClientStIdle(..)
+  , ClientStTxIds(..)
+  , ClientStTxs(..)
+  , TxSizeInBytes
+  , TokBlockingStyle(..)
+  , BlockingReplyList(..)
+
+    -- * Execution as a typed protocol
+  , txSubmissionClientPeer
+  ) where
+
+import           Data.Word (Word16)
+
+import           Network.TypedProtocol.Core
+
+import           Ouroboros.Network.Protocol.TxSubmission.Type
+
+
+-- | The client side of the transaction submission protocol.
+--
+-- The peer in the client role submits transactions to the peer in the server
+-- role.
+--
+newtype TxSubmissionClient txid tx m a = TxSubmissionClient {
+    runTxSubmissionClient :: m (ClientStIdle txid tx m a)
+  }
+
+-- | In the 'StIdle' protocol state, the client does not have agency. Instead
+-- it is waiting for:
+--
+-- * a request for transaction ids (blocking or non-blocking)
+-- * a request for a given list of transactions
+-- * a termination message
+--
+-- It must be prepared to handle any of these.
+--
+data ClientStIdle txid tx m a = ClientStIdle {
+
+    recvMsgRequestTxIds      :: forall blocking.
+                                TokBlockingStyle blocking
+                             -> Word16
+                             -> Word16
+                             -> m (ClientStTxIds blocking txid tx m a),
+
+    recvMsgRequestTxs        :: [txid]
+                             -> m (ClientStTxs txid tx m a)
+  }
+
+data ClientStTxIds blocking txid tx m a where
+  SendMsgReplyTxIds :: BlockingReplyList blocking (txid, TxSizeInBytes)
+                    -> ClientStIdle           txid tx m a
+                    -> ClientStTxIds blocking txid tx m a
+
+  -- | In the blocking case, the client can terminate the protocol. This could
+  -- be used when the client knows there will be no more transactions to submit.
+  --
+  SendMsgDone       :: a -> ClientStTxIds StBlocking txid tx m a
+
+
+data ClientStTxs txid tx m a where
+  SendMsgReplyTxs   :: [tx]
+                    -> ClientStIdle txid tx m a
+                    -> ClientStTxs  txid tx m a
+
+
+-- | A non-pipelined 'Peer' representing the 'TxSubmissionClient'.
+--
+txSubmissionClientPeer :: forall txid tx m a. Monad m
+                       => TxSubmissionClient txid tx m a
+                       -> Peer (TxSubmission txid tx) AsClient StIdle m a
+txSubmissionClientPeer (TxSubmissionClient client) =
+    Effect $ go <$> client
+  where
+    go :: ClientStIdle txid tx m a
+       -> Peer (TxSubmission txid tx) AsClient StIdle m a
+    go ClientStIdle {recvMsgRequestTxIds, recvMsgRequestTxs} =
+      Await (ServerAgency TokIdle) $ \msg -> case msg of
+        MsgRequestTxIds blocking ackNo reqNo -> Effect $ do
+          reply <- recvMsgRequestTxIds blocking ackNo reqNo
+          case reply of
+            SendMsgReplyTxIds txids k ->
+              return $ Yield (ClientAgency (TokTxIds blocking))
+                             (MsgReplyTxIds txids)
+                             (go k)
+
+            SendMsgDone result ->
+              return $ Yield (ClientAgency (TokTxIds TokBlocking))
+                              MsgDone
+                             (Done TokDone result)
+
+        MsgRequestTxs txids -> Effect $ do
+          SendMsgReplyTxs txs k <- recvMsgRequestTxs txids
+          return $ Yield (ClientAgency TokTxs)
+                         (MsgReplyTxs txs)
+                         (go k)
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Codec.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+
+module Ouroboros.Network.Protocol.TxSubmission.Codec (
+    codecTxSubmission
+  ) where
+
+import           Control.Monad.Class.MonadST
+import qualified Data.List.NonEmpty as NonEmpty
+
+import           Data.ByteString.Lazy (ByteString)
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Read     as CBOR
+
+import           Network.TypedProtocol.Codec
+import           Network.TypedProtocol.Codec.Cbor
+
+import           Ouroboros.Network.Protocol.TxSubmission.Type
+
+
+codecTxSubmission
+  :: forall txid tx m.
+     MonadST m
+  => (txid -> CBOR.Encoding)
+  -> (forall s . CBOR.Decoder s txid)
+  -> (tx -> CBOR.Encoding)
+  -> (forall s . CBOR.Decoder s tx)
+  -> Codec (TxSubmission txid tx) CBOR.DeserialiseFailure m ByteString
+codecTxSubmission encodeTxId decodeTxId
+                  encodeTx   decodeTx =
+    mkCodecCborLazyBS encode decode
+  where
+    encode :: forall (pr :: PeerRole) st st'.
+              PeerHasAgency pr st
+           -> Message (TxSubmission txid tx) st st'
+           -> CBOR.Encoding
+    encode (ServerAgency TokIdle) (MsgRequestTxIds blocking ackNo reqNo) =
+        CBOR.encodeListLen 4
+     <> CBOR.encodeWord 0
+     <> CBOR.encodeBool (case blocking of
+                           TokBlocking    -> True
+                           TokNonBlocking -> False)
+     <> CBOR.encodeWord16 ackNo
+     <> CBOR.encodeWord16 reqNo
+
+    encode (ClientAgency (TokTxIds _)) (MsgReplyTxIds txids) =
+        CBOR.encodeListLen 2
+     <> CBOR.encodeWord 1
+     <> CBOR.encodeListLenIndef
+     <> foldr (\(txid, sz) r -> CBOR.encodeListLen 2
+                             <> encodeTxId txid
+                             <> CBOR.encodeWord32 sz
+                             <> r)
+              CBOR.encodeBreak
+              txids'
+      where
+        txids' :: [(txid, TxSizeInBytes)]
+        txids' = case txids of
+                   BlockingReply    xs -> NonEmpty.toList xs
+                   NonBlockingReply xs -> xs
+
+    encode (ServerAgency TokIdle) (MsgRequestTxs txids) =
+        CBOR.encodeListLen 2
+     <> CBOR.encodeWord 2
+     <> CBOR.encodeListLenIndef
+     <> foldr (\txid r -> encodeTxId txid <> r) CBOR.encodeBreak txids
+
+    encode (ClientAgency TokTxs)  (MsgReplyTxs txs) =
+        CBOR.encodeListLen 2
+     <> CBOR.encodeWord 3
+     <> CBOR.encodeListLenIndef
+     <> foldr (\txid r -> encodeTx txid <> r) CBOR.encodeBreak txs
+
+    encode (ClientAgency (TokTxIds TokBlocking)) MsgDone =
+        CBOR.encodeListLen 1
+     <> CBOR.encodeWord 4
+
+
+    decode :: forall (pr :: PeerRole) s (st :: TxSubmission txid tx).
+              PeerHasAgency pr st
+           -> CBOR.Decoder s (SomeMessage st)
+    decode stok = do
+      len <- CBOR.decodeListLen
+      key <- CBOR.decodeWord
+      case (stok, len, key) of
+
+        (ServerAgency TokIdle,       4, 0) -> do
+          blocking <- CBOR.decodeBool
+          ackNo    <- CBOR.decodeWord16
+          reqNo    <- CBOR.decodeWord16
+          return $! case blocking of
+            True  -> SomeMessage (MsgRequestTxIds TokBlocking    ackNo reqNo)
+            False -> SomeMessage (MsgRequestTxIds TokNonBlocking ackNo reqNo)
+
+        (ClientAgency (TokTxIds b),  2, 1) -> do
+          CBOR.decodeListLenIndef
+          txids <- CBOR.decodeSequenceLenIndef
+                     (flip (:)) [] reverse
+                     (do CBOR.decodeListLenOf 2
+                         txid <- decodeTxId
+                         sz   <- CBOR.decodeWord32
+                         return (txid, sz))
+          case (b, txids) of
+            (TokBlocking, t:ts) ->
+              return $
+                SomeMessage (MsgReplyTxIds (BlockingReply (t NonEmpty.:| ts)))
+
+            (TokNonBlocking, ts) ->
+              return $
+                SomeMessage (MsgReplyTxIds (NonBlockingReply ts))
+
+            (TokBlocking, []) ->
+              fail "codecTxSubmission: MsgReplyTxIds: empty list not permitted"
+
+
+        (ServerAgency TokIdle,       2, 2) -> do
+          CBOR.decodeListLenIndef
+          txids <- CBOR.decodeSequenceLenIndef (flip (:)) [] reverse decodeTxId
+          return (SomeMessage (MsgRequestTxs txids))
+
+        (ClientAgency TokTxs,     2, 3) -> do
+          CBOR.decodeListLenIndef
+          txids <- CBOR.decodeSequenceLenIndef (flip (:)) [] reverse decodeTx
+          return (SomeMessage (MsgReplyTxs txids))
+
+        (ClientAgency (TokTxIds TokBlocking), 1, 4) ->
+          return (SomeMessage MsgDone)
+
+        (ServerAgency TokIdle,    _, _) ->
+          fail "codecTxSubmission.Idle: unexpected key"
+        (ClientAgency TokTxIds{}, _, _) ->
+          fail "codecTxSubmission.TxIds: unexpected key"
+        (ClientAgency TokTxs,     _, _) ->
+          fail "codecTxSubmission.Tx: unexpected message key"
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Direct.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Network.Protocol.TxSubmission.Direct (
+    directPipelined
+  ) where
+
+import           Network.TypedProtocol.Pipelined
+import           Network.TypedProtocol.Proofs (Queue(..), enqueue)
+
+import           Ouroboros.Network.Protocol.TxSubmission.Client
+import           Ouroboros.Network.Protocol.TxSubmission.Server
+
+
+directPipelined
+  :: forall txid tx m a b.
+     Monad m
+  => TxSubmissionServerPipelined txid tx m a
+  -> TxSubmissionClient          txid tx m b
+  -> m (a, b)
+directPipelined (TxSubmissionServerPipelined server)
+                (TxSubmissionClient mclient) =
+    mclient >>= directSender EmptyQ server
+  where
+    directSender :: forall (n :: N).
+                    Queue        n (Collect txid tx)
+                 -> ServerStIdle n txid tx m a
+                 -> ClientStIdle   txid tx m b
+                 -> m (a, b)
+    directSender q (SendMsgRequestTxIdsBlocking ackNo reqNo a serverNext)
+                   ClientStIdle{recvMsgRequestTxIds} = do
+      reply <- recvMsgRequestTxIds TokBlocking ackNo reqNo
+      case reply of
+        SendMsgReplyTxIds (BlockingReply txids) client' -> do
+          server' <- serverNext txids
+          directSender q server' client'
+        SendMsgDone b ->
+          return (a, b)
+
+    directSender q (SendMsgRequestTxIdsPipelined ackNo reqNo serverNext)
+                   ClientStIdle{recvMsgRequestTxIds} = do
+      reply <- recvMsgRequestTxIds TokNonBlocking ackNo reqNo
+      case reply of
+        SendMsgReplyTxIds (NonBlockingReply txids) client' -> do
+          server' <- serverNext
+          directSender (enqueue (CollectTxIds reqNo txids) q) server' client'
+
+    directSender q (SendMsgRequestTxsPipelined txids serverNext)
+                   ClientStIdle{recvMsgRequestTxs} = do
+      server' <- serverNext
+      SendMsgReplyTxs txs client' <- recvMsgRequestTxs txids
+      directSender (enqueue (CollectTxs txids txs) q) server' client'
+
+    directSender q (CollectPipelined (Just server') _) client =
+      directSender q server' client
+
+    directSender (ConsQ c q) (CollectPipelined _ collect) client =
+      directSender q (collect c) client
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Examples.hs
@@ -1,0 +1,397 @@
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+
+module Ouroboros.Network.Protocol.TxSubmission.Examples (
+    txSubmissionClient,
+    txSubmissionServer,
+
+    TraceEventClient(..),
+    TraceEventServer(..),
+  ) where
+
+import qualified Data.List.NonEmpty as NonEmpty
+import           Data.List.NonEmpty (NonEmpty(..))
+import           Data.Word (Word16)
+import qualified Data.Map.Strict as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Sequence as Seq
+import           Data.Sequence (Seq)
+import           Data.Foldable as Foldable (foldr, foldl', toList)
+
+import           Control.Monad (when)
+import           Control.Exception (assert)
+import           Control.Tracer (Tracer, traceWith)
+
+import           Network.TypedProtocol.Pipelined (N, Nat(..))
+
+import           Ouroboros.Network.Protocol.TxSubmission.Client
+import           Ouroboros.Network.Protocol.TxSubmission.Server
+
+
+--
+-- Example client
+--
+
+data TraceEventClient txid tx =
+     EventRecvMsgRequestTxIds (Seq txid) (Map txid tx) [tx] Word16 Word16
+   | EventRecvMsgRequestTxs   (Seq txid) (Map txid tx) [tx] [txid]
+  deriving Show
+
+-- | An example @'TxSubmissionClient'@ which sends transactions from a fixed
+-- list of transactions.
+--
+-- It is intended to illustrate the protocol or for use in tests. The client
+-- enforces aspects of the protocol. It will fail with a protocol error if
+-- the peer asks for a transaction which is not in the unacknowledged set.
+-- The unacknowledged set is managed such that things are removed after having
+-- been requested. The net effect is that the peer can only ask for 
+-- * If a server will ask for
+-- the same transaction twice.
+--
+txSubmissionClient
+  :: forall txid tx m.
+     (Ord txid, Show txid, Monad m)
+  => Tracer m (TraceEventClient txid tx)
+  -> (tx -> txid)
+  -> (tx -> TxSizeInBytes)
+  -> Word16  -- ^ Maximum number of unacknowledged txids allowed
+  -> [tx]
+  -> TxSubmissionClient txid tx m ()
+txSubmissionClient tracer txId txSize maxUnacked =
+    TxSubmissionClient . pure . client Seq.empty Map.empty
+  where
+    client :: Seq txid -> Map txid tx -> [tx] -> ClientStIdle txid tx m ()
+    client !unackedSeq !unackedMap remainingTxs =
+        assert invariant
+        ClientStIdle { recvMsgRequestTxIds, recvMsgRequestTxs }
+      where
+        -- The entries in the unackedMap are a subset of those in the
+        -- unackedSeq. The sequence is all of them, whereas we remove
+        -- entries from the map once they are requested, to enforce
+        -- that each tx can be requested at most once.
+        invariant =
+          Map.isSubmapOfBy
+            (\_ _ -> True)
+            unackedMap
+            (Map.fromList [ (x, ()) | x <- Foldable.toList unackedSeq ])
+
+        recvMsgRequestTxIds :: forall blocking.
+                               TokBlockingStyle blocking
+                            -> Word16
+                            -> Word16
+                            -> m (ClientStTxIds blocking txid tx m ())
+        recvMsgRequestTxIds blocking ackNo reqNo = do
+          traceWith tracer (EventRecvMsgRequestTxIds unackedSeq unackedMap
+                                                     remainingTxs ackNo reqNo)
+          when (ackNo > fromIntegral (Seq.length unackedSeq)) $
+            fail $ "txSubmissionClientConst.recvMsgRequestTxIds: "
+                ++ "peer acknowledged more txids than possible"
+
+          when (  fromIntegral (Seq.length unackedSeq)
+                - ackNo
+                + fromIntegral reqNo
+                > maxUnacked) $
+            fail $ "txSubmissionClientConst.recvMsgRequestTxIds: "
+                ++ "peer requested more txids than permitted"
+
+          let unackedSeq' = Seq.drop (fromIntegral ackNo) unackedSeq
+              unackedMap' = foldl' (flip Map.delete) unackedMap
+                                   (Seq.take (fromIntegral ackNo) unackedSeq)
+
+          case blocking of
+            TokBlocking | not (Seq.null unackedSeq')
+              -> fail $ "txSubmissionClientConst.recvMsgRequestTxIds: "
+                     ++ "peer made a blocking request for more txids when "
+                     ++ "there are still unacknowledged txids."
+            _ -> return ()
+
+          -- This example is eager, it always provides as many as asked for,
+          -- up to the number remaining available.
+          let unackedExtra   = take (fromIntegral reqNo) remainingTxs
+              unackedSeq''   = unackedSeq'
+                            <> Seq.fromList (map txId unackedExtra)
+              unackedMap''   = unackedMap'
+                            <> Map.fromList [ (txId tx, tx)
+                                            | tx <- unackedExtra ]
+              remainingTxs'  = drop (fromIntegral reqNo) remainingTxs
+              txIdAndSize tx = (txId tx, txSize tx)
+
+          return $! case (blocking, unackedExtra) of
+            (TokBlocking, []) ->
+              SendMsgDone ()
+
+            (TokBlocking, tx:txs) ->
+              SendMsgReplyTxIds
+                (BlockingReply (fmap txIdAndSize (tx :| txs)))
+                (client unackedSeq'' unackedMap'' remainingTxs')
+
+            (TokNonBlocking, txs) ->
+              SendMsgReplyTxIds
+                (NonBlockingReply (map txIdAndSize txs))
+                (client unackedSeq'' unackedMap'' remainingTxs')
+
+        recvMsgRequestTxs :: [txid]
+                          -> m (ClientStTxs txid tx m ())
+        recvMsgRequestTxs txids = do
+          traceWith tracer (EventRecvMsgRequestTxs unackedSeq unackedMap
+                                                   remainingTxs txids)
+          case [ txid | txid <- txids, txid `Map.notMember` unackedMap ] of
+            [] -> pure (SendMsgReplyTxs txs client')
+              where
+                txs         = map (unackedMap Map.!) txids
+                client'     = client unackedSeq unackedMap' remainingTxs
+                unackedMap' = foldr Map.delete unackedMap txids
+                -- Here we remove from the map, while the seq stays unchanged.
+                -- This enforces that each tx can be requested at most once.
+
+            missing -> fail $ "txSubmissionClientConst.recvMsgRequestTxs: "
+                           ++ "requested missing TxIds: " ++ show missing
+
+
+--
+-- Example server
+--
+
+data TraceEventServer txid tx =
+     EventRequestTxIdsBlocking  (ServerState txid tx) Word16 Word16
+   | EventRequestTxIdsPipelined (ServerState txid tx) Word16 Word16
+   | EventRequestTxsPipelined   (ServerState txid tx) [txid]
+
+deriving instance (Show txid, Show tx) => Show (TraceEventServer txid tx)
+
+data ServerState txid tx = ServerState {
+       -- | The number of transaction identifiers that we have requested but
+       -- which have not yet been replied to. We need to track this it keep
+       -- our requests within the limit on the number of unacknowledged txids.
+       --
+       requestedTxIdsInFlight :: Word16,
+
+       -- | Those transactions (by their identifier) that the client has told
+       -- us about, and which we have not yet acknowledged. This is kept in
+       -- the order in which the client gave them to us. This is the same order
+       -- in which we submit them to the mempool (or for this example, the final
+       -- result order). It is also the order we acknowledge in.
+       unacknowledgedTxIds :: Seq txid,
+
+       -- | Those transactions (by their identifier) that we can request. These
+       -- are a subset of the 'unacknowledgedTxIds' that we have not yet
+       -- requested. This is not ordered to illustrate the fact that we can
+       -- request txs out of order. We also remember the sizes, though this
+       -- example does not make use of the size information.
+       availableTxids      :: Map txid TxSizeInBytes,
+
+       -- | Transactions we have successfully downloaded but have not yet added
+       -- to the mempool or acknowledged. This is needed because we request
+       -- transactions out of order but we must use the original order when
+       -- adding to the mempool or acknowledging transactions.
+       --
+       bufferedTxs         :: Map txid (Maybe tx),
+
+       -- | The number of transactions we can acknowledge on our next request
+       -- for more transactions. The number here have already been removed from
+       -- 'unacknowledgedTxIds'.
+       --
+       numTxsToAcknowledge :: Word16
+     }
+  deriving Show
+
+initialServerState :: ServerState txid tx
+initialServerState = ServerState 0 Seq.empty Map.empty Map.empty 0
+
+
+-- | An example transaction submission server.
+--
+-- It collects and returns all the transactions that the client submits. This
+-- is suitable for tests and using as a starting template for a full version.
+--
+-- Note that this example does not respect any overall byte limit on pipelining
+-- and does not make any delta-Q info to optimises the pipelining decisions.
+--
+txSubmissionServer
+  :: forall txid tx m.
+     (Ord txid, Show txid, Show tx, Monad m)
+  => Tracer m (TraceEventServer txid tx)
+  -> (tx -> txid)
+  -> Word16  -- ^ Maximum number of unacknowledged txids  
+  -> Word16  -- ^ Maximum number of txids to request in any one go
+  -> Word16  -- ^ Maximum number of txs to request in any one go
+  -> TxSubmissionServerPipelined txid tx m [tx]
+txSubmissionServer tracer txId maxUnacked maxTxIdsToRequest maxTxToRequest =
+    TxSubmissionServerPipelined (serverIdle [] Zero initialServerState)
+  where
+    serverIdle :: forall (n :: N).
+                  [tx]
+               -> Nat n
+               -> ServerState txid tx
+               -> ServerStIdle n txid tx m [tx]
+    serverIdle accum Zero st
+        -- There are no replies in flight, but we do know some more txs we can
+        -- ask for, so lets ask for them and more txids.
+      | canRequestMoreTxs st
+      = serverReqTxs accum Zero st
+
+        -- There's no replies in flight, and we have no more txs we can ask for
+        -- so the only remaining thing to do is to ask for more txids. Since
+        -- this is the only thing to do now, we make this a blocking call.
+      | otherwise
+      , let numTxIdsToRequest = maxTxIdsToRequest `min` maxUnacked
+      = assert (requestedTxIdsInFlight st == 0
+             && Seq.null (unacknowledgedTxIds st)
+             && Map.null (availableTxids st)
+             && Map.null (bufferedTxs st)) $
+        SendMsgRequestTxIdsBlocking
+          (numTxsToAcknowledge st)
+          numTxIdsToRequest
+          accum                      -- result if the client reports we're done
+          (\txids -> do
+              traceWith tracer (EventRequestTxIdsBlocking st (numTxsToAcknowledge st) numTxIdsToRequest)
+              return . handleReply accum Zero st {
+                         numTxsToAcknowledge    = 0,
+                         requestedTxIdsInFlight = numTxIdsToRequest
+                       }
+                     . CollectTxIds numTxIdsToRequest
+                     . NonEmpty.toList $ txids)
+
+    serverIdle accum (Succ n) st
+        -- We have replies in flight and we should eagerly collect them if
+        -- available, but there are transactions to request too so we should
+        -- not block waiting for replies.
+        --
+        -- Having requested more transactions, we opportunistically ask for
+        -- more txids in a non-blocking way. This is how we pipeline asking for
+        -- both txs and txids.
+        --
+        -- It's important not to pipeline more requests for txids when we have
+        -- no txs to ask for, since (with no other guard) this will put us into
+        -- a busy-polling loop.
+        --
+      | canRequestMoreTxs st
+      = CollectPipelined
+          (Just (serverReqTxs accum (Succ n) st))
+          (handleReply accum n st)
+
+        -- In this case there is nothing else to do so we block until we
+        -- collect a reply.
+      | otherwise
+      = CollectPipelined
+          Nothing
+          (handleReply accum n st)
+
+    canRequestMoreTxs :: ServerState k tx -> Bool
+    canRequestMoreTxs st =
+        not (Map.null (availableTxids st))
+
+    handleReply :: forall (n :: N).
+                   [tx]
+                -> Nat n
+                -> ServerState txid tx
+                -> Collect txid tx
+                -> ServerStIdle n txid tx m [tx]
+    handleReply accum n st (CollectTxIds reqNo txids) =
+      -- Upon receiving a batch of new txids we extend our available set,
+      -- and extended the unacknowledged sequence.
+      serverIdle accum n st {
+        requestedTxIdsInFlight = requestedTxIdsInFlight st - reqNo,
+        unacknowledgedTxIds    = unacknowledgedTxIds st
+                              <> Seq.fromList (map fst txids),
+        availableTxids         = availableTxids st
+                              <> Map.fromList txids
+      }
+
+    handleReply accum n st (CollectTxs txids txs) =
+      -- When we receive a batch of transactions, in general we get a subset of
+      -- those that we asked for, with the remainder now deemed unnecessary.
+      -- But we still have to acknowledge the txids we were given. This combined
+      -- with the fact that we request txs out of order means our bufferedTxs
+      -- has to track all the txids we asked for, even though not all have
+      -- replies.
+      --
+      -- We have to update the unacknowledgedTxIds here eagerly and not delay it
+      -- to serverReqTxs, otherwise we could end up blocking in serverIdle on
+      -- more pipelined results rather than being able to move on.
+      serverIdle accum' n st {
+        bufferedTxs         = bufferedTxs'',
+        unacknowledgedTxIds = unacknowledgedTxIds',
+        numTxsToAcknowledge = numTxsToAcknowledge st
+                            + fromIntegral (Seq.length acknowledgedTxIds)
+      }
+      where
+        txIdsRequestedWithTxsReceived :: [(txid, Maybe tx)]
+        txIdsRequestedWithTxsReceived =
+          [ (txid, mbTx)
+          | let txsMap :: Map txid tx
+                txsMap = Map.fromList [ (txId tx, tx) | tx <- txs ]
+          , txid <- txids
+          , let !mbTx = Map.lookup txid txsMap
+          ]
+
+        bufferedTxs'  = bufferedTxs st
+                     <> Map.fromList txIdsRequestedWithTxsReceived
+
+        -- Check if having received more txs we can now confirm any (in strict
+        -- order in the unacknowledgedTxIds sequence).
+        (acknowledgedTxIds, unacknowledgedTxIds') =
+          Seq.spanl (`Map.member` bufferedTxs') (unacknowledgedTxIds st)
+
+        -- If so we can add the acknowledged txs to our accumulating result
+        accum' = accum
+              ++ foldr (\txid r -> maybe r (:r) (bufferedTxs' Map.! txid)) []
+                       acknowledgedTxIds
+
+        -- And remove acknowledged txs from our buffer
+        bufferedTxs'' = foldl' (flip Map.delete) bufferedTxs' acknowledgedTxIds
+
+
+    serverReqTxs :: forall (n :: N).
+                    [tx]
+                 -> Nat n
+                 -> ServerState txid tx
+                 -> ServerStIdle n txid tx m [tx]
+    serverReqTxs accum n st =
+        SendMsgRequestTxsPipelined
+          (Map.keys txsToRequest)
+          (do traceWith tracer (EventRequestTxsPipelined st (Map.keys txsToRequest))
+              pure $ serverReqTxIds accum (Succ n) st {
+                availableTxids = availableTxids'
+              })
+      where
+        -- This implementation is deliberately naive, we pick in an arbitrary
+        -- order and up to a fixed limit. The real thing should take account of
+        -- the expected transaction sizes, to pipeline well and keep within
+        -- pipelining byte limits.
+        (txsToRequest, availableTxids') =
+          Map.splitAt (fromIntegral maxTxToRequest) (availableTxids st)
+
+    serverReqTxIds :: forall (n :: N).
+                      [tx]
+                   -> Nat n
+                   -> ServerState txid tx
+                   -> ServerStIdle n txid tx m [tx]
+    serverReqTxIds accum n st
+      | numTxIdsToRequest > 0
+      = SendMsgRequestTxIdsPipelined
+          (numTxsToAcknowledge st)
+          numTxIdsToRequest
+          (do traceWith tracer (EventRequestTxIdsPipelined st (numTxsToAcknowledge st) numTxIdsToRequest)
+              pure $ serverIdle accum (Succ n) st {
+                requestedTxIdsInFlight = requestedTxIdsInFlight st
+                                       + numTxIdsToRequest,
+                numTxsToAcknowledge    = 0
+              })
+
+      | otherwise
+      = serverIdle accum n st
+      where
+        -- This definition is justified by the fact that the
+        -- 'numTxsToAcknowledge' are not included in the 'unacknowledgedTxIds'.
+        numTxIdsToRequest =
+                (maxUnacked
+                  - fromIntegral (Seq.length (unacknowledgedTxIds st))
+                  - requestedTxIdsInFlight st)
+          `min` maxTxIdsToRequest
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Server.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | A view of the transaction submission protocol from the point of view of
+-- the server.
+--
+-- This provides a view that uses less complex types and should be easier to
+-- use than the underlying typed protocol itself.
+--
+-- For execution, a conversion into the typed protocol is provided.
+--
+module Ouroboros.Network.Protocol.TxSubmission.Server (
+    -- * Protocol type for the server
+    -- | The protocol states from the point of view of the server.
+    TxSubmissionServerPipelined (..)
+  , ServerStIdle(..)
+  , Collect(..)
+  , TxSizeInBytes
+
+    -- * Execution as a typed protocol
+  , txSubmissionServerPeerPipelined
+  ) where
+
+import           Data.Word (Word16)
+import           Data.List.NonEmpty (NonEmpty)
+
+import           Network.TypedProtocol.Core
+import           Network.TypedProtocol.Pipelined
+
+import           Ouroboros.Network.Protocol.TxSubmission.Type
+
+
+data TxSubmissionServerPipelined txid tx m a where
+  TxSubmissionServerPipelined
+    :: ServerStIdle              Z txid tx m a
+    -> TxSubmissionServerPipelined txid tx m a
+
+
+-- | This is the type of the pipelined results, collected by 'CollectPipelined'.
+-- This protocol can pipeline requests for transaction ids and transactions,
+-- so we use a sum of either for collecting the responses.
+--
+data Collect txid tx =
+       -- | The result of 'SendMsgRequestTxIdsPipelined'. It also carries
+       -- the number of txids originally requested.
+       CollectTxIds Word16 [(txid, TxSizeInBytes)]
+
+       -- | The result of 'SendMsgRequestTxsPipelined'. The actual reply only
+       -- contains the transactions sent, but this pairs them up with the
+       -- transactions requested. This is because the peer can determine that
+       -- some transactions are no longer needed.
+     | CollectTxs [txid] [tx]
+
+
+data ServerStIdle (n :: N) txid tx m a where
+
+  -- |
+  --
+  SendMsgRequestTxIdsBlocking
+    :: Word16                               -- ^ number of txids to acknowledge
+    -> Word16                               -- ^ number of txids to request
+    -> a                                    -- ^ Result if done
+    -> (NonEmpty (txid, TxSizeInBytes)
+        -> m (ServerStIdle Z txid tx m a))
+    -> ServerStIdle        Z txid tx m a
+
+  -- |
+  --
+  SendMsgRequestTxIdsPipelined
+    :: Word16
+    -> Word16
+    -> m (ServerStIdle (S n) txid tx m a)
+    -> ServerStIdle       n  txid tx m a
+
+  -- |
+  --
+  SendMsgRequestTxsPipelined
+    :: [txid]
+    -> m (ServerStIdle (S n) txid tx m a)
+    -> ServerStIdle       n  txid tx m a
+
+  -- | Collect a pipelined result.
+  --
+  CollectPipelined
+    :: Maybe              (ServerStIdle (S n) txid tx m a)
+    -> (Collect txid tx -> ServerStIdle    n  txid tx m a) --TODO put in m
+    ->                     ServerStIdle (S n) txid tx m a
+
+
+-- | Transform a 'TxSubmissionServerPipelined' into a 'PeerPipelined'.
+--
+txSubmissionServerPeerPipelined
+    :: forall txid tx m a.
+       Functor m
+    => TxSubmissionServerPipelined txid tx m a
+    -> PeerPipelined (TxSubmission txid tx) AsServer StIdle m a
+txSubmissionServerPeerPipelined (TxSubmissionServerPipelined server) =
+    PeerPipelined (go server)
+  where
+    go :: forall (n :: N).
+          ServerStIdle n txid tx m a
+       -> PeerSender (TxSubmission txid tx) AsServer StIdle
+                     n (Collect txid tx) m a
+
+    go (SendMsgRequestTxIdsBlocking ackNo reqNo kDone k) =
+      SenderYield
+        (ServerAgency TokIdle)
+        (MsgRequestTxIds TokBlocking ackNo reqNo) $
+      SenderAwait
+        (ClientAgency (TokTxIds TokBlocking)) $ \msg ->
+        case msg of
+          MsgDone ->
+            SenderDone TokDone kDone
+
+          MsgReplyTxIds (BlockingReply txids) ->
+            SenderEffect (go <$> k txids)
+
+    go (SendMsgRequestTxIdsPipelined ackNo reqNo k) =
+      SenderPipeline
+        (ServerAgency TokIdle)
+        (MsgRequestTxIds TokNonBlocking ackNo reqNo)
+        (ReceiverAwait (ClientAgency (TokTxIds TokNonBlocking)) $ \msg ->
+           case msg of
+             MsgReplyTxIds (NonBlockingReply txids) ->
+               ReceiverDone (CollectTxIds reqNo txids))
+        (SenderEffect (go <$> k))
+
+    go (SendMsgRequestTxsPipelined txids k) =
+      SenderPipeline
+        (ServerAgency TokIdle)
+        (MsgRequestTxs txids)
+        (ReceiverAwait (ClientAgency TokTxs) $ \msg ->
+           case msg of
+             MsgReplyTxs txs -> ReceiverDone (CollectTxs txids txs))
+        (SenderEffect (go <$> k))
+
+    go (CollectPipelined mNone collect) =
+      SenderCollect
+        (fmap go mNone)
+        (go . collect)
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Test.hs
@@ -1,0 +1,351 @@
+{-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE DataKinds                  #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ouroboros.Network.Protocol.TxSubmission.Test (
+    tests
+  ) where
+
+import           Data.List (nub)
+import qualified Data.List.NonEmpty as NonEmpty
+import           Data.Word (Word16)
+import           Data.ByteString.Lazy (ByteString)
+
+import           Control.Monad.ST (runST)
+import           Control.Monad.IOSim
+import           Control.Monad.Class.MonadAsync (MonadAsync)
+import           Control.Monad.Class.MonadST (MonadST)
+import           Control.Monad.Class.MonadThrow (MonadCatch)
+import           Control.Tracer (Tracer(..), nullTracer)
+
+import           Codec.Serialise (Serialise)
+import qualified Codec.Serialise as Serialise (encode, decode)
+
+import           Network.TypedProtocol.Core
+import           Network.TypedProtocol.Driver
+import           Network.TypedProtocol.Proofs
+import           Network.TypedProtocol.Codec.Cbor hiding (prop_codec)
+import           Network.Mux.Channel
+
+import           Ouroboros.Network.Protocol.TxSubmission.Client
+import           Ouroboros.Network.Protocol.TxSubmission.Codec
+import           Ouroboros.Network.Protocol.TxSubmission.Direct
+import           Ouroboros.Network.Protocol.TxSubmission.Examples
+import           Ouroboros.Network.Protocol.TxSubmission.Server
+import           Ouroboros.Network.Protocol.TxSubmission.Type
+
+import           Test.Ouroboros.Network.Testing.Utils (splits2, splits3)
+
+import           Test.QuickCheck as QC
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+
+--
+-- Test cases
+--
+
+tests :: TestTree
+tests =
+  testGroup "Ouroboros.Network.Protocol.TxSubmission"
+  [ testProperty "direct"              prop_direct
+  , testProperty "connect 1"           prop_connect1
+  , testProperty "connect 2"           prop_connect2
+  , testProperty "codec"               prop_codec
+  , testProperty "codec 2-splits"      prop_codec_splits2
+  , testProperty "codec 3-splits"    $ withMaxSuccess 30
+                                       prop_codec_splits3
+  , testProperty "channel ST"          prop_channel_ST
+  , testProperty "channel IO"          prop_channel_IO
+  , testProperty "pipe IO"             prop_pipe_IO
+  ]
+
+
+--
+-- Common types & clients and servers used in the tests in this module.
+--
+
+newtype Tx = Tx TxId
+  deriving (Eq, Show, Arbitrary, Serialise)
+
+txId :: Tx -> TxId
+txId (Tx txid) = txid
+
+newtype TxId = TxId Int
+  deriving (Eq, Ord, Show, Arbitrary, Serialise)
+
+type TestServer m = TxSubmissionServerPipelined TxId Tx m [Tx]
+type TestClient m = TxSubmissionClient          TxId Tx m ()
+
+testServer :: Monad m
+           => Tracer m (TraceEventServer TxId Tx)
+           -> TxSubmissionTestParams
+           -> TestServer m
+testServer tracer
+           TxSubmissionTestParams {
+             testMaxUnacked        = Positive (Small maxUnacked),
+             testMaxTxIdsToRequest = Positive (Small maxTxIdsToRequest),
+             testMaxTxToRequest    = Positive (Small maxTxToRequest)
+           } =
+    txSubmissionServer
+      tracer txId
+      maxUnacked maxTxIdsToRequest maxTxToRequest
+
+testClient :: Monad m
+           => Tracer m (TraceEventClient TxId Tx)
+           -> TxSubmissionTestParams
+           -> TestClient m
+testClient tracer            TxSubmissionTestParams {
+             testMaxUnacked   = Positive (Small maxUnacked),
+             testTransactions = DistinctList txs
+           } =
+    txSubmissionClient
+      tracer txId txSize
+      maxUnacked
+      txs
+  where
+    txSize _ = 500
+
+
+--
+-- Properties going directly, not via Peer.
+--
+
+-- | Run a simple tx-submission client and server, directly on the wrappers,
+-- without going via the 'Peer'.
+--
+prop_direct :: TxSubmissionTestParams -> Bool
+prop_direct params@TxSubmissionTestParams{testTransactions} =
+    runSimOrThrow
+      (directPipelined
+        (testServer nullTracer params)
+        (testClient nullTracer params))
+  ==
+    (fromDistinctList testTransactions, ())
+
+
+--
+-- Properties going via Peer, but without using a channel
+--
+
+-- | Run a simple tx-submission client and server, going via the 'Peer'
+-- representation, but without going via a channel.
+--
+-- This test converts the pipelined server peer to a non-pipelined peer
+-- before connecting it with the client.
+--
+prop_connect1 :: TxSubmissionTestParams -> Bool
+prop_connect1 params@TxSubmissionTestParams{testTransactions} =
+    case runSimOrThrow
+           (connect
+             (forgetPipelined $
+              txSubmissionServerPeerPipelined $
+              testServer nullTracer params)
+             (txSubmissionClientPeer $
+              testClient nullTracer params)) of
+
+      (txs', (), TerminalStates TokDone TokDone) ->
+        txs' == fromDistinctList testTransactions
+
+
+-- | Run a pipelined tx-submission client against a server, going via the
+-- 'Peer' representation, but without going via a channel.
+--
+-- This test uses the pipelined server, connected to the non-pipelined client.
+--
+prop_connect2 :: TxSubmissionTestParams -> [Bool] -> Bool
+prop_connect2 params@TxSubmissionTestParams{testTransactions}
+                      choices =
+    case runSimOrThrow
+           (connectPipelined choices
+             (txSubmissionServerPeerPipelined $
+              testServer nullTracer params)
+             (txSubmissionClientPeer $
+              testClient nullTracer params)) of
+
+      (txs', (), TerminalStates TokDone TokDone) ->
+        txs' == fromDistinctList testTransactions
+
+
+--
+-- Properties using a channel
+--
+
+-- | Run a simple tx-submission client and server using connected channels.
+--
+prop_channel :: (MonadAsync m, MonadCatch m, MonadST m)
+             => m (Channel m ByteString, Channel m ByteString)
+             -> TxSubmissionTestParams
+             -> m Bool
+prop_channel createChannels params@TxSubmissionTestParams{testTransactions} =
+
+    (\(txs', ()) -> txs' == fromDistinctList testTransactions) <$>
+
+    runConnectedPeersPipelined
+      createChannels
+      nullTracer
+      codec
+      (txSubmissionServerPeerPipelined $
+       testServer nullTracer params)
+      (txSubmissionClientPeer $
+       testClient nullTracer params)
+
+
+-- | Run 'prop_channel' in the simulation monad.
+--
+prop_channel_ST :: TxSubmissionTestParams
+                -> Bool
+prop_channel_ST params =
+    runSimOrThrow
+      (prop_channel createConnectedChannels params)
+
+
+-- | Run 'prop_channel' in the IO monad.
+--
+prop_channel_IO :: TxSubmissionTestParams -> Property
+prop_channel_IO params =
+    ioProperty (prop_channel createConnectedChannels params)
+
+
+-- | Run 'prop_channel' in the IO monad using local pipes.
+--
+prop_pipe_IO :: TxSubmissionTestParams -> Property
+prop_pipe_IO params =
+    ioProperty (prop_channel createPipeConnectedChannels params)
+
+
+--
+-- Codec properties
+--
+
+instance Arbitrary (AnyMessageAndAgency (TxSubmission TxId Tx)) where
+  arbitrary = oneof
+    [ AnyMessageAndAgency (ServerAgency TokIdle) <$>
+        (MsgRequestTxIds TokBlocking
+                     <$> arbitrary
+                     <*> arbitrary)
+
+    , AnyMessageAndAgency (ServerAgency TokIdle) <$>
+        (MsgRequestTxIds TokNonBlocking
+                     <$> arbitrary
+                     <*> arbitrary)
+
+    , AnyMessageAndAgency (ClientAgency (TokTxIds TokBlocking)) <$>
+        MsgReplyTxIds <$> (BlockingReply . NonEmpty.fromList
+                                         . QC.getNonEmpty
+                                       <$> arbitrary)
+
+    , AnyMessageAndAgency (ClientAgency (TokTxIds TokNonBlocking)) <$>
+        MsgReplyTxIds <$> (NonBlockingReply <$> arbitrary)
+
+    , AnyMessageAndAgency (ServerAgency TokIdle) <$>
+        MsgRequestTxs <$> arbitrary
+
+    , AnyMessageAndAgency (ClientAgency TokTxs) <$>
+        MsgReplyTxs <$> arbitrary
+
+    , AnyMessageAndAgency (ClientAgency (TokTxIds TokBlocking)) <$>
+        pure MsgDone
+    ]
+
+instance Show (AnyMessageAndAgency (TxSubmission TxId Tx)) where
+  show (AnyMessageAndAgency _ msg) = show msg
+
+instance (Eq txid, Eq tx) => Eq (AnyMessage (TxSubmission txid tx)) where
+
+  (==) (AnyMessage (MsgRequestTxIds TokBlocking ackNo  reqNo))
+       (AnyMessage (MsgRequestTxIds TokBlocking ackNo' reqNo')) =
+    (ackNo, reqNo) == (ackNo', reqNo')
+
+  (==) (AnyMessage (MsgRequestTxIds TokNonBlocking ackNo  reqNo))
+       (AnyMessage (MsgRequestTxIds TokNonBlocking ackNo' reqNo')) =
+    (ackNo, reqNo) == (ackNo', reqNo')
+
+  (==) (AnyMessage (MsgReplyTxIds (BlockingReply txids)))
+       (AnyMessage (MsgReplyTxIds (BlockingReply txids'))) =
+    txids == txids'
+
+  (==) (AnyMessage (MsgReplyTxIds (NonBlockingReply txids)))
+       (AnyMessage (MsgReplyTxIds (NonBlockingReply txids'))) =
+    txids == txids'
+
+  (==) (AnyMessage (MsgRequestTxs txids))
+       (AnyMessage (MsgRequestTxs txids')) = txids == txids'
+
+  (==) (AnyMessage (MsgReplyTxs txs))
+       (AnyMessage (MsgReplyTxs txs')) = txs == txs'
+
+  (==) (AnyMessage MsgDone)
+       (AnyMessage MsgDone) = True
+
+  _ == _ = False
+
+
+codec :: MonadST m
+       => Codec (TxSubmission TxId Tx)
+                DeserialiseFailure
+                m ByteString
+codec = codecTxSubmission
+          Serialise.encode Serialise.decode
+          Serialise.encode Serialise.decode
+
+-- | Check the codec round trip property.
+--
+prop_codec :: AnyMessageAndAgency (TxSubmission TxId Tx) -> Bool
+prop_codec msg =
+  runST (prop_codecM codec msg)
+
+-- | Check for data chunk boundary problems in the codec using 2 chunks.
+--
+prop_codec_splits2 :: AnyMessageAndAgency (TxSubmission TxId Tx) -> Bool
+prop_codec_splits2 msg =
+  runST (prop_codec_splitsM splits2 codec msg)
+
+-- | Check for data chunk boundary problems in the codec using 3 chunks.
+--
+prop_codec_splits3 :: AnyMessageAndAgency (TxSubmission TxId Tx) -> Bool
+prop_codec_splits3 msg =
+  runST (prop_codec_splitsM splits3 codec msg)
+
+
+--
+-- Local generators
+--
+
+data TxSubmissionTestParams =
+     TxSubmissionTestParams {
+       testMaxUnacked        :: Positive (Small Word16),
+       testMaxTxIdsToRequest :: Positive (Small Word16),
+       testMaxTxToRequest    :: Positive (Small Word16),
+       testTransactions      :: DistinctList Tx
+     }
+  deriving Show
+
+instance Arbitrary TxSubmissionTestParams where
+  arbitrary =
+    TxSubmissionTestParams <$> arbitrary
+                           <*> arbitrary
+                           <*> arbitrary
+                           <*> arbitrary
+
+  shrink (TxSubmissionTestParams a b c d) =
+    [ TxSubmissionTestParams a' b' c' d'
+    | (a', b', c', d') <- shrink (a, b, c, d) ]
+
+
+newtype DistinctList a = DistinctList { fromDistinctList :: [a] }
+  deriving Show
+
+instance (Eq a, Arbitrary a) => Arbitrary (DistinctList a) where
+  arbitrary = DistinctList . nub <$> arbitrary
+
+  shrink (DistinctList xs) =
+    [ DistinctList (nub xs') | xs' <- shrink xs ]
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
@@ -1,0 +1,253 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE EmptyCase          #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies       #-}
+
+-- | The type of the transaction submission protocol.
+--
+-- This is used to relay transactions between nodes.
+--
+module Ouroboros.Network.Protocol.TxSubmission.Type where
+
+import           Data.Word (Word16, Word32)
+import           Data.List.NonEmpty (NonEmpty)
+
+import           Network.TypedProtocol.Core
+
+-- | Transactions are typically not big, but in principle in future we could
+-- have ones over 64k large.
+--
+type TxSizeInBytes = Word32
+
+-- | The kind of the transaction-submission protocol, and the types of the
+-- states in the protocol state machine.
+--
+-- We describe this protocol using the label \"client\" for the peer that is
+-- submitting transactions, and \"server\" for the one receiving them. The
+-- protocol is however pull based, so it is typically the server that has
+-- agency in this protocol. This is the opposite of the chain sync and block
+-- fetch protocols, but that makes sense because the information flow is also
+-- reversed: submitting transactions rather than receiving headers and blocks.
+--
+-- Because these client\/server labels are somewhat confusing in this case, we
+-- sometimes clarify by using the terms inbound and outbound. This refers to
+-- whether transactions are flowing towards a peer or away, and thus indicates
+-- what role the peer is playing.
+--
+data TxSubmission txid tx where
+
+  -- | The server (inbound side) has agency; it can either terminate, ask for
+  -- transaction identifiers or ask for transactions.
+  --
+  -- There is no timeout in this state.
+  --
+  StIdle   :: TxSubmission txid tx
+
+  -- | The client (outbound side) has agency; it must reply with a
+  -- list of transaction identifiers that it wishes to submit.
+  --
+  -- There are two sub-states for this, for blocking and non-blocking cases.
+  --
+  StTxIds  :: StBlockingStyle -> TxSubmission txid tx
+
+  -- | The client (outbound side) has agency; it must reply with the list of
+  -- transactions.
+  --
+  StTxs    :: TxSubmission txid tx
+
+  -- | Nobody has agency; termination state.
+  --
+  StDone   :: TxSubmission txid tx
+
+
+data StBlockingStyle where
+
+  -- | In this sub-state the reply need not be prompt. There is no timeout.
+  --
+  StBlocking    :: StBlockingStyle
+  
+  -- | In this state the peer must reply. There is a timeout.
+  --
+  StNonBlocking :: StBlockingStyle
+
+
+-- | There are some constraints of the protocol that are not captured in the
+-- types of the messages, but are documented with the messages. Violation
+-- of these constraints is also a protocol error. The constraints are intended
+-- to ensure that implementations are able to work in bounded space.
+--
+instance Protocol (TxSubmission txid tx) where
+
+  -- | The messages in the transaction submission protocol.
+  --
+  -- In this protocol the consumer (inbound side, server role) always
+  -- initiates and the producer (outbound side, client role) replies.
+  -- This makes it a pull based protocol where the receiver manages the
+  -- control flow.
+  --
+  -- The protocol involves asking for transaction identifiers, and then
+  -- asking for transactions corresponding to the identifiers of interest.
+  --
+  -- There are two ways to ask for transaction identifiers, blocking and
+  -- non-blocking. They otherwise have the same semantics.
+  --
+  -- The protocol maintains a notional FIFO of \"outstanding\" transaction
+  -- identifiers that have been provided but not yet acknowledged. Only
+  -- transactions that are outstanding can be requested: they can be
+  -- requested in any order, but at most once. Transaction identifiers are
+  -- acknowledged in the same FIFO order they were provided in. The
+  -- acknowledgement is included in the same messages used to ask for more
+  -- transaction identifiers.
+  --
+  data Message (TxSubmission txid tx) from to where
+
+    -- | Request a non-empty list of transaction identifiers from the client,
+    -- and confirm a number of outstanding transaction identifiers.
+    --
+    -- With 'TokBlocking' this is a a blocking operation: the response will
+    -- always have at least one transaction identifier, and it does not expect
+    -- a prompt response: there is no timeout. This covers the case when there
+    -- is nothing else to do but wait. For example this covers leaf nodes that
+    -- rarely, if ever, create and submit a transaction.
+    --
+    -- With 'TokNonBlocking' this is a non-blocking operation: the response
+    -- may be an empty list and this does expect a prompt response. This
+    -- covers high throughput use cases where we wish to pipeline, by
+    -- interleaving requests for additional transaction identifiers with
+    -- requests for transactions, which requires these requests not block.
+    --
+    -- The request gives the maximum number of transaction identifiers that
+    -- can be accepted in the response. This must be greater than zero in the
+    -- 'TokBlocking' case. In the 'TokNonBlocking' case either the numbers
+    -- acknowledged or the number requested must be non-zero. In either case,
+    -- the number requested must not put the total outstanding over the fixed
+    -- protocol limit.
+    --
+    -- The request also gives the number of outstanding transaction
+    -- identifiers that can now be acknowledged. The actual transactions
+    -- to acknowledge are known to the peer based on the FIFO order in which
+    -- they were provided.
+    --
+    -- There is no choice about when to use the blocking case versus the
+    -- non-blocking case, it depends on whether there are any remaining
+    -- unacknowledged transactions (after taking into account the ones
+    -- acknowledged in this message):
+    --
+    -- * The blocking case must be used when there are zero remaining
+    --   unacknowledged transactions.
+    --
+    -- * The non-blocking case must be used when there are non-zero remaining
+    --   unacknowledged transactions.
+    --
+    MsgRequestTxIds
+      :: TokBlockingStyle blocking
+      -> Word16 -- ^ Acknowledge this number of outstanding txids
+      -> Word16 -- ^ Request up to this number of txids.
+      -> Message (TxSubmission txid tx) StIdle (StTxIds blocking)
+
+    -- | Reply with a list of transaction identifiers for available
+    -- transactions, along with the size of each transaction.
+    --
+    -- The list must not be longer than the maximum number requested.
+    --
+    -- In the 'StTxIds' 'StBlocking' state the list must be non-empty while
+    -- in the 'StTxIds' 'StNonBlocking' state the list may be empty.
+    --
+    -- These transactions are added to the notional FIFO of outstanding
+    -- transaction identifiers for the protocol.
+    --
+    -- The order in which these transaction identifiers are returned must be
+    -- the order in which they are submitted to the mempool, to preserve
+    -- dependent transactions.
+    --
+    MsgReplyTxIds
+      :: BlockingReplyList blocking (txid, TxSizeInBytes)
+      -> Message (TxSubmission txid tx) (StTxIds blocking) StIdle
+
+    -- | Request one or more transactions corresponding to the given
+    -- transaction identifiers.
+    --
+    -- While it is the responsibility of the replying peer to keep within
+    -- pipelining in-flight limits, the sender must also cooperate by keeping
+    -- the total requested across all in-flight requests within the limits.
+    --
+    -- It is an error to ask for transaction identifiers that were not
+    -- previously announced (via 'MsgReplyTxIds').
+    --
+    -- It is an error to ask for transaction identifiers that are not
+    -- outstanding or that were already asked for.
+    --
+    MsgRequestTxs
+      :: [txid]
+      -> Message (TxSubmission txid tx) StIdle StTxs
+
+    -- | Reply with the requested transactions, or implicitly discard.
+    --
+    -- Transactions can become invalid between the time the transaction
+    -- identifier was sent and the transaction being requested. Invalid
+    -- (including committed) transactions do not need to be sent.
+    --
+    -- Any transaction identifiers requested but not provided in this reply
+    -- should be considered as if this peer had never announced them. (Note
+    -- that this is no guarantee that the transaction is invalid, it may still
+    -- be valid and available from another peer).
+    --
+    MsgReplyTxs
+      :: [tx]
+      -> Message (TxSubmission txid tx) StTxs StIdle
+
+    -- | Termination message, initiated by the client when the server is
+    -- making a blocking call for more transaction identifiers.
+    --
+    MsgDone
+      :: Message (TxSubmission txid tx) (StTxIds StBlocking) StDone
+
+
+  data ClientHasAgency st where
+    TokTxIds  :: TokBlockingStyle b -> ClientHasAgency (StTxIds b)
+    TokTxs    :: ClientHasAgency StTxs
+
+  data ServerHasAgency st where
+    TokIdle   :: ServerHasAgency StIdle
+
+  data NobodyHasAgency st where
+    TokDone   :: NobodyHasAgency StDone
+
+  exclusionLemma_ClientAndServerHaveAgency tok TokIdle = case tok of {}
+
+  exclusionLemma_NobodyAndClientHaveAgency TokDone tok = case tok of {}
+
+  exclusionLemma_NobodyAndServerHaveAgency TokDone tok = case tok of {}
+
+
+-- | The value level equivalent of 'StBlockingStyle'.
+--
+-- This is also used in 'MsgRequestTxIds' where it is interpreted (and can be
+-- encoded) as a 'Bool' with 'True' for blocking, and 'False' for non-blocking.
+--
+data TokBlockingStyle (k :: StBlockingStyle) where
+  TokBlocking    :: TokBlockingStyle StBlocking
+  TokNonBlocking :: TokBlockingStyle StNonBlocking
+
+deriving instance Eq   (TokBlockingStyle b)
+deriving instance Show (TokBlockingStyle b)
+
+-- | We have requests for lists of things. In the blocking case the
+-- corresponding reply must be non-empty, whereas in the non-blocking case
+-- and empty reply is fine.
+--
+data BlockingReplyList (blocking :: StBlockingStyle) a where
+  BlockingReply    :: NonEmpty a  -> BlockingReplyList StBlocking    a
+  NonBlockingReply ::         [a] -> BlockingReplyList StNonBlocking a
+
+deriving instance Eq   a => Eq   (BlockingReplyList blocking a)
+deriving instance Show a => Show (BlockingReplyList blocking a)
+
+deriving instance (Eq txid, Eq tx) =>
+                  Eq (Message (TxSubmission txid tx) from to)
+
+deriving instance (Show txid, Show tx) =>
+                  Show (Message (TxSubmission txid tx) from to)
+

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -13,6 +13,7 @@ import qualified Test.Ouroboros.Network.BlockFetch (tests)
 import qualified Ouroboros.Network.Protocol.ChainSync.Test (tests)
 import qualified Ouroboros.Network.Protocol.BlockFetch.Test (tests)
 import qualified Ouroboros.Network.Protocol.Handshake.Test (tests)
+import qualified Ouroboros.Network.Protocol.TxSubmission.Test (tests)
 import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Test (tests)
 import qualified Test.Socket (tests)
 
@@ -34,6 +35,7 @@ tests =
   , Ouroboros.Network.Protocol.ChainSync.Test.tests
   , Ouroboros.Network.Protocol.BlockFetch.Test.tests
   , Ouroboros.Network.Protocol.LocalTxSubmission.Test.tests
+  , Ouroboros.Network.Protocol.TxSubmission.Test.tests
   , Ouroboros.Network.Protocol.Handshake.Test.tests
 
     -- network logic


### PR DESCRIPTION
This adds the node-to-node transaction submission protocol. This is based in part on a previous design implemented by Marcin.

The new version is designed for full pipelining (for performance) and to support what the higher level transaction relaying logic needs to do. In particular it will enable forwarding dependent transactions in
order. To do this without stalling we need to be able to request transactions out of order, but still limiting the amount of state that both peers need to track.

This patch inclues:

* types
* pipelined client
* server
* codec
* direct connect check
* example client & servers
* tests

~Also adds a local tx submission protocol for the node -> client case.~ (This was done in a spearate PR)

The higher level relaying logic remains to do.

This supersedes PR #329.