### PR TITLE
fix memory leak in mux egress loop

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Mux/Egress.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Mux/Egress.hs
@@ -138,10 +138,12 @@ mux :: (MonadSTM m)
      => TVar m Int
      -> PerMuxSharedState ptcl m
      -> m ()
-mux cnt pmss = do
+mux cnt pmss = go
+  where
+  go = do
     w <- atomically $ readTBQueue $ tsrQueue pmss
     case w of
-         TLSRDemand mid md d -> processSingleWanton pmss mid md d cnt >> mux cnt pmss
+         TLSRDemand mid md d -> processSingleWanton pmss mid md d cnt >> go
 
 -- | Pull a `maxSDU`s worth of data out out the `Wanton` - if there is
 -- data remaining requeue the `TranslocationServiceRequest` (this


### PR DESCRIPTION
Changes `mux` to the "worker/wrapper" style. This eliminates a space leak that was observed in a byron-proxy chain sync server.

The heap profile by closure description claimed that `mux` was retaining bytestrings or similar (ARR_WORDS), partial applications (PAP), and a compiler generated name `<Ouroboros.Network.Mux.Egress.sat_s1e9f>` in proportion. So I guessed it had something to do with monadic looping and laziness. I don't actually understand why this fixes it, or why ARR_WORDS were being retained.