### PR TITLE
Add a first draft of a LocalTxSubmission protocol

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -560,9 +560,7 @@ initNetworkLayer _tracer registry NetworkRequires{..} = NetworkProvides {..}
       void $ forkLinked registry $ bfWithChan $ \chan ->
         bracketFetchClient nrFetchClientRegistry up $ \clientCtx -> do
           atomically $ putTMVar clientRegistered ()
-          -- TODO make 10 a parameter. Or encapsulate the pipelining
-          -- stuff
-          runPipelinedPeer 10 nullTracer bfCodec chan $
+          runPipelinedPeer nullTracer bfCodec chan $
             nrBlockFetchClient clientCtx
 
       -- The block fetch logic thread in the background wants there to be a

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -152,7 +152,6 @@ clientPingPong pipelined =
     protocols :: DemoProtocol0 -> MuxPeer DeserialiseFailure IO ()
     protocols PingPong0 | pipelined =
       MuxPeerPipelined
-        10
         (contramap show stdoutTracer)
         codecPingPong
         (pingPongClientPeerPipelined (pingPongClientPipelinedMax 5))
@@ -412,7 +411,7 @@ clientBlockFetch sockAddrs = do
 
         protocols peerid BlockFetch3 channel =
           bracketFetchClient registry peerid $ \clientCtx ->
-            runPipelinedPeer 10
+            runPipelinedPeer
               nullTracer -- (contramap (show . TraceLabelPeer peerid) stdoutTracer)
               (codecBlockFetch CBOR.encode CBOR.encode CBOR.decode CBOR.decode)
               channel

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -76,6 +76,10 @@ library
                        Ouroboros.Network.Protocol.Handshake.Type
                        Ouroboros.Network.Protocol.Handshake.Codec
                        Ouroboros.Network.Protocol.Handshake.Version
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Type
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Client
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Server
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Codec
   default-language:    Haskell2010
   other-extensions:    BangPatterns,
                        DataKinds,
@@ -182,6 +186,13 @@ test-suite tests
                        Ouroboros.Network.Protocol.Handshake.Codec
                        Ouroboros.Network.Protocol.Handshake.Test
                        Ouroboros.Network.Protocol.Handshake.Version
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Client
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Codec
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Direct
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Examples
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Server
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Type
+                       Ouroboros.Network.Protocol.LocalTxSubmission.Test
                        Ouroboros.Network.Socket
                        Ouroboros.Network.Server.Socket
                        Ouroboros.Network.Time

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -192,7 +192,7 @@ runFetchClient :: (MonadCatch m, MonadAsync m, MonadST m, Ord peerid,
                 -> m a
 runFetchClient tracer registry peerid channel client =
     bracketFetchClient registry peerid $ \clientCtx ->
-      runPipelinedPeer 10 tracer codec channel $
+      runPipelinedPeer tracer codec channel $
         client clientCtx
   where
     codec = codecBlockFetch encode encode decode decode

--- a/ouroboros-network/src/Ouroboros/Network/Mux/Interface.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Mux/Interface.hs
@@ -36,7 +36,6 @@ module Ouroboros.Network.Mux.Interface
 
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Functor (void)
-import           Numeric.Natural (Natural)
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadThrow ( MonadCatch
@@ -150,8 +149,7 @@ data MuxPeer failure m a where
             -> MuxPeer failure m a
 
     MuxPeerPipelined
-            :: Natural
-            -> Tracer m (TraceSendRecv ps)
+            :: Tracer m (TraceSendRecv ps)
             -> Codec ps failure m ByteString
             -> PeerPipelined ps pr st m a
             -> MuxPeer failure m a
@@ -169,8 +167,12 @@ runMuxPeer
   => MuxPeer failure m a
   -> Channel m ByteString
   -> m a
-runMuxPeer (MuxPeer tracer codec peer) channel = runPeer tracer codec channel peer
-runMuxPeer (MuxPeerPipelined n tracer codec peer) channel = runPipelinedPeer n tracer codec channel peer
+runMuxPeer (MuxPeer tracer codec peer) channel =
+    runPeer tracer codec channel peer
+
+runMuxPeer (MuxPeerPipelined tracer codec peer) channel =
+    runPipelinedPeer tracer codec channel peer
+
 
 -- |
 -- Smart constructor for @'MuxInitiatorApplication'@.  It is a simple client, since

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -33,7 +33,7 @@ import           Ouroboros.Network.NodeToNode (DictVersion (..))
 -- make up the overall node-to-client protocol.
 --
 data NodeToClientProtocols = ChainSyncWithBlocks
-                          -- ClientRPC -- will probably need something like this
+                           | LocalTxSubmission
   deriving (Eq, Ord, Enum, Bounded, Show)
 
 -- | These are the actual wire format protocol numbers.
@@ -46,8 +46,10 @@ data NodeToClientProtocols = ChainSyncWithBlocks
 instance ProtocolEnum NodeToClientProtocols where
 
   fromProtocolEnum ChainSyncWithBlocks = 5
+  fromProtocolEnum LocalTxSubmission   = 6
 
   toProtocolEnum 5 = Just ChainSyncWithBlocks
+  toProtocolEnum 6 = Just LocalTxSubmission
   toProtocolEnum _ = Nothing
 
 -- |

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Client.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes          #-}
+
+
+-- | A view of the transaction submission protocol from the point of view of
+-- the client.
+--
+-- This provides a view that uses less complex types and should be easier to
+-- use than the underlying typed protocol itself.
+--
+-- For execution, 'localTxSubmissionClientPeer' is provided for conversion
+-- into the typed protocol.
+--
+module Ouroboros.Network.Protocol.LocalTxSubmission.Client (
+    -- * Protocol type for the client
+    -- | The protocol states from the point of view of the client.
+    LocalTxSubmissionClient(..)
+
+    -- * Execution as a typed protocol
+  , localTxSubmissionClientPeer
+  ) where
+
+import           Network.TypedProtocol.Core
+
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
+
+
+-- | The client side of the local transaction submission protocol.
+--
+-- The peer in the client role submits transactions to the peer in the server
+-- role.
+--
+data LocalTxSubmissionClient tx reject m a where
+
+     -- | The client submits a single transaction and waits a reply.
+     --
+     -- The server replies to inform the client that it has either accepted the
+     -- transaction or rejected it. In the rejection case a reason for the
+     -- rejection is included.
+     --
+     SendMsgSubmitTx
+       :: tx
+       -> (Maybe reject -> m (LocalTxSubmissionClient tx reject m a))
+       -> LocalTxSubmissionClient tx reject m a
+
+     -- | The client can terminate the protocol.
+     --
+     SendMsgDone
+       :: a -> LocalTxSubmissionClient tx reject m a
+
+
+-- | A non-pipelined 'Peer' representing the 'LocalTxSubmissionClient'.
+--
+localTxSubmissionClientPeer
+  :: forall tx reject m a. Monad m
+  => m (LocalTxSubmissionClient tx reject m a)
+  -> Peer (LocalTxSubmission tx reject) AsClient StIdle m a
+localTxSubmissionClientPeer client =
+    Effect $ go <$> client
+  where
+    go :: LocalTxSubmissionClient tx reject m a
+       -> Peer (LocalTxSubmission tx reject) AsClient StIdle m a
+    go (SendMsgSubmitTx tx k) =
+      Yield (ClientAgency TokIdle)
+            (MsgSubmitTx tx) $
+      Await (ServerAgency TokBusy) $ \msg -> case msg of
+        MsgAcceptTx        -> Effect (go <$> k Nothing)
+        MsgRejectTx reject -> Effect (go <$> k (Just reject))
+
+    go (SendMsgDone a) =
+      Yield (ClientAgency TokIdle)
+            MsgDone
+            (Done TokDone a)
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Codec.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+
+module Ouroboros.Network.Protocol.LocalTxSubmission.Codec (
+    codecLocalTxSubmission
+  ) where
+
+import           Control.Monad.Class.MonadST
+
+import           Data.ByteString.Lazy (ByteString)
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Read     as CBOR
+
+import           Ouroboros.Network.Codec
+
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
+
+
+codecLocalTxSubmission
+  :: forall tx reject m.
+     MonadST m
+  => (tx -> CBOR.Encoding)
+  -> (forall s . CBOR.Decoder s tx)
+  -> (reject -> CBOR.Encoding)
+  -> (forall s . CBOR.Decoder s reject)
+  -> Codec (LocalTxSubmission tx reject) CBOR.DeserialiseFailure m ByteString
+codecLocalTxSubmission encodeTx decodeTx encodeReject decodeReject =
+    mkCodecCborLazyBS encode decode
+  where
+    encode :: forall (pr :: PeerRole) st st'.
+              PeerHasAgency pr st
+           -> Message (LocalTxSubmission tx reject) st st'
+           -> CBOR.Encoding
+    encode (ClientAgency TokIdle) (MsgSubmitTx tx) =
+        CBOR.encodeListLen 2
+     <> CBOR.encodeWord 0
+     <> encodeTx tx
+
+    encode (ServerAgency TokBusy) MsgAcceptTx =
+        CBOR.encodeListLen 1
+     <> CBOR.encodeWord 1
+
+    encode (ServerAgency TokBusy) (MsgRejectTx reject) =
+        CBOR.encodeListLen 2
+     <> CBOR.encodeWord 2
+     <> encodeReject reject
+
+    encode (ClientAgency TokIdle) MsgDone =
+        CBOR.encodeListLen 1
+     <> CBOR.encodeWord 3
+
+
+    decode :: forall (pr :: PeerRole) s (st :: LocalTxSubmission tx reject).
+              PeerHasAgency pr st
+           -> CBOR.Decoder s (SomeMessage st)
+    decode stok = do
+      len <- CBOR.decodeListLen
+      key <- CBOR.decodeWord
+      case (stok, len, key) of
+        (ClientAgency TokIdle, 2, 0) -> do
+          tx <- decodeTx
+          return (SomeMessage (MsgSubmitTx tx))
+
+        (ServerAgency TokBusy, 1, 1) ->
+          return (SomeMessage MsgAcceptTx)
+
+        (ServerAgency TokBusy, 2, 2) -> do
+          reject <- decodeReject
+          return (SomeMessage (MsgRejectTx reject))
+
+        (ClientAgency TokIdle, 1, 3) ->
+          return (SomeMessage MsgDone)
+
+        (ClientAgency TokIdle, _, _) ->
+          fail "codecLocalTxSubmission.Idle: unexpected key"
+        (ServerAgency TokBusy, _, _) ->
+          fail "codecLocalTxSubmission.Busy: unexpected key"
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Direct.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Network.Protocol.LocalTxSubmission.Direct (
+    direct
+  ) where
+
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Client
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Server
+
+
+direct :: forall tx reject m a b.
+          Monad m
+       => LocalTxSubmissionClient tx reject m a
+       -> LocalTxSubmissionServer tx reject m b
+       -> m (a, b)
+direct (SendMsgSubmitTx tx k) LocalTxSubmissionServer{recvMsgSubmitTx} = do
+    (res, server') <- recvMsgSubmitTx tx
+    client' <- k res
+    direct client' server'
+
+direct (SendMsgDone a) LocalTxSubmissionServer{recvMsgDone = b} =
+    return (a,b)
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Examples.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+
+module Ouroboros.Network.Protocol.LocalTxSubmission.Examples (
+    localTxSubmissionClient,
+    localTxSubmissionServer,
+  ) where
+
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Client
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Server
+
+
+
+--
+-- Example client
+--
+
+-- | An example @'LocalTxSubmissionClient'@ which submits a fixed list of
+-- transactions. The result is those transactions annotated with whether they
+-- were accepted or rejected.
+--
+localTxSubmissionClient
+  :: forall tx reject m.
+     Applicative m
+  => [tx]
+  -> LocalTxSubmissionClient tx reject m [(tx, Maybe reject)]
+localTxSubmissionClient =
+    client []
+  where
+    client acc [] =
+      SendMsgDone (reverse acc)
+
+    client acc (tx:txs) =
+      SendMsgSubmitTx tx $ \mreject -> pure (client ((tx, mreject):acc) txs)
+
+
+--
+-- Example server
+--
+
+localTxSubmissionServer
+  :: forall tx reject m.
+     Applicative m
+  => (tx -> Maybe reject)
+  -> LocalTxSubmissionServer tx reject m [(tx, Maybe reject)]
+localTxSubmissionServer p =
+    server []
+  where
+    server acc = LocalTxSubmissionServer {
+      recvMsgSubmitTx = \tx ->
+        let mreject = p tx in
+        pure (mreject, server ((tx, mreject) : acc)),
+
+      recvMsgDone = reverse acc
+    }
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Server.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | A view of the local transaction submission protocol from the point of view
+-- of the server.
+--
+-- This provides a view that uses less complex types and should be easier to
+-- use than the underlying typed protocol itself.
+--
+-- For execution, a conversion into the typed protocol is provided.
+--
+module Ouroboros.Network.Protocol.LocalTxSubmission.Server (
+    -- * Protocol type for the server
+    -- | The protocol states from the point of view of the server.
+    LocalTxSubmissionServer (..)
+
+    -- * Execution as a typed protocol
+  , localTxSubmissionServerPeer
+  ) where
+
+import           Network.TypedProtocol.Core
+
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
+
+
+-- | The server side of the local transaction submission protocol.
+--
+-- The peer in the client role submits transactions to the peer in the server
+-- role.
+--
+data LocalTxSubmissionServer tx reject m a =
+     LocalTxSubmissionServer {
+
+       -- | The client has submited a single transaction and it expects a reply.
+       --
+       -- The server must reply to inform the client that it has either accepted
+       -- the transaction or rejected it. In the rejection case a reason for the
+       -- rejection is included.
+       --
+       recvMsgSubmitTx :: tx -> m ( Maybe reject
+                                  , LocalTxSubmissionServer tx reject m a ),
+
+       -- | The client can terminate the protocol.
+       --
+       recvMsgDone     :: a
+     }
+
+
+-- | A non-pipelined 'Peer' representing the 'LocalTxSubmissionServer'.
+--
+localTxSubmissionServerPeer
+  :: forall tx reject m a. Monad m
+  => m (LocalTxSubmissionServer tx reject m a)
+  -> Peer (LocalTxSubmission tx reject) AsServer StIdle m a
+localTxSubmissionServerPeer server =
+    Effect $ go <$> server
+  where
+    go :: LocalTxSubmissionServer tx reject m a
+       -> Peer (LocalTxSubmission tx reject) AsServer StIdle m a
+    go LocalTxSubmissionServer{recvMsgSubmitTx, recvMsgDone} =
+      Await (ClientAgency TokIdle) $ \msg -> case msg of
+        MsgSubmitTx tx -> Effect $ do
+          (mreject, k) <- recvMsgSubmitTx tx
+          return $
+            case mreject of
+              Nothing ->
+                Yield
+                  (ServerAgency TokBusy)
+                  MsgAcceptTx
+                  (go k)
+              Just reject ->
+                Yield
+                  (ServerAgency TokBusy)
+                  (MsgRejectTx reject)
+                  (go k)
+
+        MsgDone -> Done TokDone recvMsgDone
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
@@ -1,0 +1,238 @@
+{-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE DataKinds                  #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ouroboros.Network.Protocol.LocalTxSubmission.Test (
+    tests
+  ) where
+
+import           Data.ByteString.Lazy (ByteString)
+
+import           Control.Monad.ST (runST)
+import           Control.Monad.IOSim
+import           Control.Monad.Class.MonadAsync (MonadAsync)
+import           Control.Monad.Class.MonadST (MonadST)
+import           Control.Monad.Class.MonadThrow (MonadCatch)
+import           Control.Tracer (nullTracer)
+
+import           Codec.Serialise (Serialise)
+import qualified Codec.Serialise as Serialise (encode, decode)
+
+import           Network.TypedProtocol.Core
+import           Network.TypedProtocol.Driver
+import           Network.TypedProtocol.Proofs
+import           Ouroboros.Network.Channel
+import           Ouroboros.Network.Codec hiding (prop_codec)
+
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Client
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Codec
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Direct
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Examples
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Server
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
+
+import           Test.Ouroboros.Network.Testing.Utils (splits2, splits3)
+
+import           Text.Show.Functions ()
+import           Test.QuickCheck as QC
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+
+--
+-- Test cases
+--
+
+tests :: TestTree
+tests =
+  testGroup "Ouroboros.Network.Protocol.LocalTxSubmission"
+  [ testProperty "direct"              prop_direct
+  , testProperty "connect"             prop_connect
+  , testProperty "codec"               prop_codec
+  , testProperty "codec 2-splits"      prop_codec_splits2
+  , testProperty "codec 3-splits"    $ withMaxSuccess 30
+                                       prop_codec_splits3
+  , testProperty "channel ST"          prop_channel_ST
+  , testProperty "channel IO"          prop_channel_IO
+  , testProperty "pipe IO"             prop_pipe_IO
+  ]
+
+
+--
+-- Common types & clients and servers used in the tests in this module.
+--
+
+newtype Tx = Tx Int
+  deriving (Eq, Show, Arbitrary, CoArbitrary, Serialise)
+
+newtype Reject = Reject Int
+  deriving (Eq, Show, Arbitrary, Serialise)
+
+
+--
+-- Properties going directly, not via Peer.
+--
+
+-- | Run a simple tx-submission client and server, directly on the wrappers,
+-- without going via the 'Peer'.
+--
+prop_direct :: (Tx -> Maybe Reject) -> [Tx] -> Bool
+prop_direct p txs =
+    runSimOrThrow
+      (direct
+        (localTxSubmissionClient txs)
+        (localTxSubmissionServer p))
+  ==
+    (txs', txs')
+  where
+    txs' = [ (tx, p tx) | tx <- txs ]
+
+
+--
+-- Properties going via Peer, but without using a channel
+--
+
+-- | Run a simple tx-submission client and server, going via the 'Peer'
+-- representation, but without going via a channel.
+--
+-- This test converts the pipelined server peer to a non-pipelined peer
+-- before connecting it with the client.
+--
+prop_connect :: (Tx -> Maybe Reject) -> [Tx] -> Bool
+prop_connect p txs =
+    case runSimOrThrow
+           (connect
+             (localTxSubmissionClientPeer $ pure $
+              localTxSubmissionClient txs)
+             (localTxSubmissionServerPeer $ pure $
+              localTxSubmissionServer p)) of
+
+      (a, b, TerminalStates TokDone TokDone) ->
+        (a, b) == (txs', txs')
+  where
+    txs' = [ (tx, p tx) | tx <- txs ]
+
+
+--
+-- Properties using a channel
+--
+
+-- | Run a local tx-submission client and server using connected channels.
+--
+prop_channel :: (MonadAsync m, MonadCatch m, MonadST m)
+             => m (Channel m ByteString, Channel m ByteString)
+             -> (Tx -> Maybe Reject) -> [Tx]
+             -> m Bool
+prop_channel createChannels p txs =
+
+    ((txs', txs') ==) <$>
+
+    runConnectedPeers
+      createChannels
+      nullTracer
+      codec
+      (localTxSubmissionClientPeer $ pure $
+       localTxSubmissionClient txs)
+      (localTxSubmissionServerPeer $ pure $
+       localTxSubmissionServer p)
+  where
+    txs' = [ (tx, p tx) | tx <- txs ]
+
+
+-- | Run 'prop_channel' in the simulation monad.
+--
+prop_channel_ST :: (Tx -> Maybe Reject) -> [Tx] -> Bool
+prop_channel_ST p txs =
+    runSimOrThrow
+      (prop_channel createConnectedChannels p txs)
+
+
+-- | Run 'prop_channel' in the IO monad.
+--
+prop_channel_IO :: (Tx -> Maybe Reject) -> [Tx] -> Property
+prop_channel_IO p txs =
+    ioProperty (prop_channel createConnectedChannels p txs)
+
+
+-- | Run 'prop_channel' in the IO monad using local pipes.
+--
+prop_pipe_IO :: (Tx -> Maybe Reject) -> [Tx] -> Property
+prop_pipe_IO p txs =
+    ioProperty (prop_channel createPipeConnectedChannels p txs)
+
+
+--
+-- Codec properties
+--
+
+instance Arbitrary (AnyMessageAndAgency (LocalTxSubmission Tx Reject)) where
+  arbitrary = oneof
+    [ AnyMessageAndAgency (ClientAgency TokIdle) <$>
+        (MsgSubmitTx <$> arbitrary)
+
+    , AnyMessageAndAgency (ServerAgency TokBusy) <$>
+        pure MsgAcceptTx
+
+    , AnyMessageAndAgency (ServerAgency TokBusy) <$>
+        (MsgRejectTx <$> arbitrary)
+
+    , AnyMessageAndAgency (ClientAgency TokIdle) <$>
+        pure MsgDone
+    ]
+
+instance (Show tx, Show reject) =>
+          Show (AnyMessageAndAgency (LocalTxSubmission tx reject)) where
+  show (AnyMessageAndAgency _ msg) = show msg
+
+instance (Eq tx, Eq reject) =>
+          Eq (AnyMessage (LocalTxSubmission tx reject)) where
+
+  (==) (AnyMessage (MsgSubmitTx tx))
+       (AnyMessage (MsgSubmitTx tx')) = tx == tx'
+
+  (==) (AnyMessage MsgAcceptTx)
+       (AnyMessage MsgAcceptTx) = True
+
+  (==) (AnyMessage (MsgRejectTx rej))
+       (AnyMessage (MsgRejectTx rej')) = rej == rej'
+
+  (==) (AnyMessage MsgDone)
+       (AnyMessage MsgDone) = True
+
+  _ == _ = False
+
+
+codec :: MonadST m
+       => Codec (LocalTxSubmission Tx Reject)
+                DeserialiseFailure
+                m ByteString
+codec = codecLocalTxSubmission
+          Serialise.encode Serialise.decode
+          Serialise.encode Serialise.decode
+
+
+-- | Check the codec round trip property.
+--
+prop_codec :: AnyMessageAndAgency (LocalTxSubmission Tx Reject) -> Bool
+prop_codec msg =
+  runST (prop_codecM codec msg)
+
+-- | Check for data chunk boundary problems in the codec using 2 chunks.
+--
+prop_codec_splits2 :: AnyMessageAndAgency (LocalTxSubmission Tx Reject) -> Bool
+prop_codec_splits2 msg =
+  runST (prop_codec_splitsM splits2 codec msg)
+
+-- | Check for data chunk boundary problems in the codec using 3 chunks.
+--
+prop_codec_splits3 :: AnyMessageAndAgency (LocalTxSubmission Tx Reject) -> Bool
+prop_codec_splits3 msg =
+  runST (prop_codec_splitsM splits3 codec msg)
+

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Type.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE EmptyCase          #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies       #-}
+
+-- | The type of the local transaction submission protocol.
+--
+-- This is used by local clients (like wallets and CLI tools) to submit
+-- transactions to a local node.
+--
+module Ouroboros.Network.Protocol.LocalTxSubmission.Type where
+
+
+import           Network.TypedProtocol.Core
+
+
+-- | The kind of the local transaction-submission protocol, and the types of
+-- the states in the protocol state machine.
+--
+-- It is parametrised over the type of transactions and the type of reasons
+-- used when rejecting a transaction.
+--
+data LocalTxSubmission tx reject where
+
+  -- | The client has agency; it can submit a transaction or terminate.
+  --
+  -- There is no timeout in this state.
+  --
+  StIdle   :: LocalTxSubmission tx reject
+
+  -- | The server has agency; it must process the submitted transaction and
+  -- either accept or reject it (with a reason).
+  --
+  -- There is a timeout in this state. If the mempool is full and remains so
+  -- for a period then the transaction should be rejected with a suitable
+  -- temporary failure reason.
+  --
+  StBusy   :: LocalTxSubmission tx reject
+
+  -- | Nobody has agency. The terminal state.
+  --
+  StDone   :: LocalTxSubmission tx reject
+
+
+instance Protocol (LocalTxSubmission tx reject) where
+
+  -- | The messages in the transaction submission protocol.
+  --
+  -- In this protocol the client always initiates and the server replies.
+  -- This makes it a push based protocol where the client manages the
+  -- control flow. It is acceptable for this protocol to be push based
+  -- because this protocol is only for use between a node and local client.
+  --
+  -- The protocol is a very simple request\/response pattern: a single
+  -- transaction is submitted and it is either accepted or rejected.
+  -- The confirmation or rejection (with reason) is returned.
+  --
+  data Message (LocalTxSubmission tx reject) from to where
+
+    -- | The client submits a single transaction and waits a reply.
+    --
+    MsgSubmitTx
+      :: tx
+      -> Message (LocalTxSubmission tx reject) StIdle StBusy
+
+    -- | The server can reply to inform the client that it has accepted the
+    -- transaction.
+    --
+    MsgAcceptTx
+      :: Message (LocalTxSubmission tx reject) StBusy StIdle
+
+    -- | The server can reply to inform the client that it has rejected the
+    -- transaction. A reason for the rejection is included.
+    --
+    MsgRejectTx
+      :: reject
+      -> Message (LocalTxSubmission tx reject) StBusy StIdle
+
+    -- | The client can terminate the protocol.
+    --
+    MsgDone
+      :: Message (LocalTxSubmission tx reject) StIdle StDone
+
+
+  data ClientHasAgency st where
+    TokIdle  :: ClientHasAgency StIdle
+
+  data ServerHasAgency st where
+    TokBusy  :: ServerHasAgency StBusy
+
+  data NobodyHasAgency st where
+    TokDone  :: NobodyHasAgency StDone
+
+  exclusionLemma_ClientAndServerHaveAgency TokIdle tok = case tok of {}
+
+  exclusionLemma_NobodyAndClientHaveAgency TokDone tok = case tok of {}
+
+  exclusionLemma_NobodyAndServerHaveAgency TokDone tok = case tok of {}
+
+
+deriving instance (Eq tx, Eq reject) =>
+                   Eq (Message (LocalTxSubmission tx reject) from to)
+
+deriving instance (Show tx, Show reject) =>
+                   Show (Message (LocalTxSubmission tx reject) from to)
+

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -16,6 +16,7 @@ import qualified Ouroboros.Network.Protocol.BlockFetch.Test (tests)
 import qualified Ouroboros.Network.Protocol.PingPong.Test (tests)
 import qualified Ouroboros.Network.Protocol.ReqResp.Test (tests)
 import qualified Ouroboros.Network.Protocol.Handshake.Test (tests)
+import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Test (tests)
 import qualified Test.Socket (tests)
 
 main :: IO ()
@@ -33,10 +34,11 @@ tests =
   , Test.ChainProducerState.tests
 
     -- protocols
-  , Ouroboros.Network.Protocol.ChainSync.Test.tests
-  , Ouroboros.Network.Protocol.BlockFetch.Test.tests
   , Ouroboros.Network.Protocol.PingPong.Test.tests
   , Ouroboros.Network.Protocol.ReqResp.Test.tests
+  , Ouroboros.Network.Protocol.ChainSync.Test.tests
+  , Ouroboros.Network.Protocol.BlockFetch.Test.tests
+  , Ouroboros.Network.Protocol.LocalTxSubmission.Test.tests
   , Ouroboros.Network.Protocol.Handshake.Test.tests
 
     -- network logic


### PR DESCRIPTION
This is for the client -> node case, rather than the node -> node case. Because of that it can be much simpler. No pipelining is needed. It does not need the txid / tx split and the control flow can be client driven.

It also can return a result to say if the tx was accepted or rejected, and can give a reason for rejection (which would be an information leak in the node -> node case).

Also include a patch needed later for the full pipelined node -> node tx submission:

> Remove pipeline limit in pipelined peer driver
>
> The pipelined peer driver used a TBQueue for the queues for the outstanding pipelined reply handlers and results. Originally this was simply because our MonadSTM only had bounded queues and not unbounded
queues.
> 
> A blocking bounded queue is not a good choice since when the pipelining limit is reached then the peer can deadlock. The reasonable choices are to have a limit but to fail when that limit is reached, or to have no
limit.
>
> Since we are planning to impose pipelining limits in terms of bytes and not number of messages, then it is not useful to us to have a message based limit that we enforce. So this is why we remove the limit.
>
> The right solution is to have test properties that check that the bytes-in-flight limits are kept to.