### PR TITLE
Split Ouroboros.Consensus.NodeId out of Ouroboros.Consensus.Node

### DIFF
--- a/ouroboros-consensus/demo-playground/CLI.hs
+++ b/ouroboros-consensus/demo-playground/CLI.hs
@@ -27,7 +27,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Demo.Run
 import qualified Ouroboros.Consensus.Ledger.Mock as Mock
-import           Ouroboros.Consensus.Node (NodeId (..))
+import           Ouroboros.Consensus.NodeId (NodeId (..))
 import           Ouroboros.Consensus.Util
 
 import           Mock.TxSubmission (command', parseMockTx)

--- a/ouroboros-consensus/demo-playground/Mock/TxSubmission.hs
+++ b/ouroboros-consensus/demo-playground/Mock/TxSubmission.hs
@@ -27,7 +27,8 @@ import qualified Ouroboros.Consensus.Crypto.Hash as H
 import           Ouroboros.Consensus.Demo.Run
 import qualified Ouroboros.Consensus.Ledger.Mock as Mock
 import           Ouroboros.Consensus.Mempool
-import           Ouroboros.Consensus.Node (NodeId (..), NodeKernel (..))
+import           Ouroboros.Consensus.NodeId (NodeId (..))
+import           Ouroboros.Consensus.Node   (NodeKernel (..))
 import           Ouroboros.Consensus.Util.CBOR (Decoder (..), initDecoderIO)
 import           Ouroboros.Consensus.Util.Condense
 

--- a/ouroboros-consensus/demo-playground/NamedPipe.hs
+++ b/ouroboros-consensus/demo-playground/NamedPipe.hs
@@ -18,7 +18,7 @@ import           System.Posix.Files (createNamedPipe, otherReadMode,
                      otherWriteMode, ownerModes, unionFileModes)
 
 import           Ouroboros.Network.Channel (Channel, handlesAsChannel)
-import           Ouroboros.Consensus.Node (NodeId(..))
+import           Ouroboros.Consensus.NodeId (NodeId(..))
 
 
 data NodeMapping src tgt = src :==>: tgt

--- a/ouroboros-consensus/demo-playground/Run.hs
+++ b/ouroboros-consensus/demo-playground/Run.hs
@@ -34,6 +34,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.ChainSyncClient (ClockSkew (..))
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Demo.Run
+import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Node
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()

--- a/ouroboros-consensus/demo-playground/Topology.hs
+++ b/ouroboros-consensus/demo-playground/Topology.hs
@@ -12,7 +12,7 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import           Data.String.Conv (toS)
 
-import           Ouroboros.Consensus.Node (NodeId(..))
+import           Ouroboros.Consensus.NodeId (NodeId(..))
 
 -- | A data structure bundling together a node identifier and the path to
 -- the topology file.

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -82,6 +82,7 @@ library
                        Ouroboros.Consensus.Mempool.API
                        Ouroboros.Consensus.Mempool.Impl
                        Ouroboros.Consensus.Node
+                       Ouroboros.Consensus.NodeId
                        Ouroboros.Consensus.Protocol.Abstract
                        Ouroboros.Consensus.Protocol.BFT
                        Ouroboros.Consensus.Protocol.ExtNodeConfig

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo.hs
@@ -48,7 +48,7 @@ import           Ouroboros.Consensus.Demo.Ledger.Mock.PraosRule
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Ledger.Byron
 import           Ouroboros.Consensus.Ledger.Mock
-import           Ouroboros.Consensus.Node (CoreNodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/HasCreator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/HasCreator.hs
@@ -13,7 +13,7 @@ import           Data.Maybe (fromMaybe)
 import qualified Cardano.Chain.Block as CC.Block
 import qualified Cardano.Crypto as Cardano
 
-import           Ouroboros.Consensus.Node (CoreNodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 
 import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Demo.Ledger.Byron.Config

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Byron.hs
@@ -27,7 +27,7 @@ import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Ledger.Byron
 import           Ouroboros.Consensus.Ledger.Extended
-import           Ouroboros.Consensus.Node (CoreNodeId (..), NodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
 import           Ouroboros.Consensus.Protocol.PBFT
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Byron/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Byron/Config.hs
@@ -14,7 +14,7 @@ import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Crypto as Crypto
 
 import           Ouroboros.Consensus.Ledger.Byron
-import           Ouroboros.Consensus.Node (CoreNodeId)
+import           Ouroboros.Consensus.NodeId (CoreNodeId)
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
 import           Ouroboros.Consensus.Protocol.PBFT
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Mock/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Mock/BFT.hs
@@ -8,7 +8,7 @@ import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Mock
-import           Ouroboros.Consensus.Node (CoreNodeId (..), NodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Mock/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Mock/PBFT.hs
@@ -9,7 +9,7 @@ import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Mock
-import           Ouroboros.Consensus.Node (CoreNodeId (..), NodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
 import           Ouroboros.Consensus.Protocol.PBFT
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Mock/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Mock/Praos.hs
@@ -10,7 +10,7 @@ import           Ouroboros.Consensus.Crypto.VRF
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Mock
-import           Ouroboros.Consensus.Node (CoreNodeId (..), NodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
 import           Ouroboros.Consensus.Protocol.Praos
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Mock/PraosRule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Mock/PraosRule.hs
@@ -11,7 +11,7 @@ import           Ouroboros.Consensus.Crypto.VRF
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Mock
-import           Ouroboros.Consensus.Node (CoreNodeId (..), NodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
 import           Ouroboros.Consensus.Protocol.Praos
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Address.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Address.hs
@@ -7,7 +7,7 @@ module Ouroboros.Consensus.Ledger.Mock.Address (
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 
-import           Ouroboros.Consensus.Node (NodeId (..))
+import           Ouroboros.Consensus.NodeId (NodeId (..))
 
 -- | Mock address
 type Addr = String

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -59,6 +59,7 @@ import           Ouroboros.Consensus.Ledger.Mock.UTxO
 import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.Util ((.:))
 import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Consensus.Util.Orphans ()
 
 {-------------------------------------------------------------------------------
   Definition of a block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PraosRule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PraosRule.hs
@@ -24,7 +24,7 @@ import           Ouroboros.Consensus.Crypto.VRF
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Mock.Block
 import           Ouroboros.Consensus.Ledger.Mock.Forge
-import           Ouroboros.Consensus.Node (CoreNodeId)
+import           Ouroboros.Consensus.NodeId (CoreNodeId)
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
 import           Ouroboros.Consensus.Protocol.Praos
 import           Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Stake.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Stake.hs
@@ -20,7 +20,7 @@ import           Data.Maybe (mapMaybe)
 
 import           Ouroboros.Consensus.Ledger.Mock.Address
 import           Ouroboros.Consensus.Ledger.Mock.UTxO
-import           Ouroboros.Consensus.Node (NodeId (..))
+import           Ouroboros.Consensus.NodeId (NodeId (..))
 
 {-------------------------------------------------------------------------------
   Stakeholders

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -12,12 +12,8 @@
 {-# OPTIONS_GHC -Wredundant-constraints -Werror=missing-fields #-}
 
 module Ouroboros.Consensus.Node (
-    -- * Node IDs
-    NodeId (..)
-  , CoreNodeId (..)
-  , fromCoreNodeId
     -- * Node
-  , NodeKernel (..)
+    NodeKernel (..)
   , NodeCallbacks (..)
   , NodeComms (..)
   , NodeParams (..)
@@ -28,7 +24,6 @@ module Ouroboros.Consensus.Node (
   , Network.loggingChannel
   ) where
 
-import           Codec.Serialise (Serialise)
 import           Control.Monad (void)
 import           Crypto.Random (ChaChaDRG)
 import qualified Data.Foldable as Foldable
@@ -81,27 +76,6 @@ import           Ouroboros.Consensus.Util.ThreadRegistry
 import           Ouroboros.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Storage.ChainDB.API as ChainDB
 
-
-{-------------------------------------------------------------------------------
-  Node IDs
--------------------------------------------------------------------------------}
-
--- TODO: This was moved here from the network layer Node module. We should
--- review this and make sure it makes sense here.
-data NodeId = CoreId Int
-            | RelayId Int
-  deriving (Eq, Ord, Show)
-
-instance Condense NodeId where
-  condense (CoreId  i) = "c" ++ show i
-  condense (RelayId i) = "r" ++ show i
-
--- | Core node ID
-newtype CoreNodeId = CoreNodeId Int
-  deriving (Show, Eq, Ord, Condense, Serialise)
-
-fromCoreNodeId :: CoreNodeId -> NodeId
-fromCoreNodeId (CoreNodeId n) = CoreId n
 
 {-------------------------------------------------------------------------------
   Relay node

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeId.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeId.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Ouroboros.Consensus.NodeId (
+    -- * Node IDs
+    NodeId (..)
+  , CoreNodeId (..)
+  , fromCoreNodeId
+  ) where
+
+import           Codec.Serialise (Serialise)
+import           Ouroboros.Consensus.Util.Condense (Condense(..))
+
+
+{-------------------------------------------------------------------------------
+  Node IDs
+-------------------------------------------------------------------------------}
+
+-- TODO: It is not at all clear that this makes any sense anymore. The network
+-- layer does not use or provide node ids (it uses addresses).
+data NodeId = CoreId Int
+            | RelayId Int
+  deriving (Eq, Ord, Show)
+
+instance Condense NodeId where
+  condense (CoreId  i) = "c" ++ show i
+  condense (RelayId i) = "r" ++ show i
+
+-- | Core node ID
+newtype CoreNodeId = CoreNodeId Int
+  deriving (Show, Eq, Ord, Condense, Serialise)
+
+fromCoreNodeId :: CoreNodeId -> NodeId
+fromCoreNodeId (CoreNodeId n) = CoreId n
+

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -39,7 +39,7 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Consensus.Crypto.DSIGN.Class
 import           Ouroboros.Consensus.Crypto.DSIGN.Ed448 (Ed448DSIGN)
 import           Ouroboros.Consensus.Crypto.DSIGN.Mock (MockDSIGN)
-import           Ouroboros.Consensus.Node (NodeId (..))
+import           Ouroboros.Consensus.NodeId (NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -16,7 +16,7 @@ import qualified Data.Map.Strict as Map
 
 import           Ouroboros.Network.Block (SlotNo (..))
 
-import           Ouroboros.Consensus.Node (CoreNodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util (Empty)
 import           Ouroboros.Consensus.Util.Condense (Condense (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -46,7 +46,7 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Consensus.Crypto.DSIGN.Cardano
 import           Ouroboros.Consensus.Crypto.DSIGN.Class
 import           Ouroboros.Consensus.Crypto.DSIGN.Mock (MockDSIGN)
-import           Ouroboros.Consensus.Node (NodeId (..))
+import           Ouroboros.Consensus.NodeId (NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -56,7 +56,7 @@ import           Ouroboros.Consensus.Crypto.KES.Simple
 import           Ouroboros.Consensus.Crypto.VRF.Class
 import           Ouroboros.Consensus.Crypto.VRF.Mock (MockVRF)
 import           Ouroboros.Consensus.Crypto.VRF.Simple (SimpleVRF)
-import           Ouroboros.Consensus.Node (CoreNodeId (..), NodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util (Empty)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -49,8 +49,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.ChainSyncClient
 import           Ouroboros.Consensus.Crypto.DSIGN.Mock
 import           Ouroboros.Consensus.Ledger.Extended hiding (ledgerState)
-import           Ouroboros.Consensus.Node (CoreNodeId (..), NodeId (..),
-                     fromCoreNodeId)
+import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util (whenJust)

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -26,7 +26,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Ledger.Mock
-import           Ouroboros.Consensus.Node
+import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util.Random

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -33,7 +33,7 @@ import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Mock
-import           Ouroboros.Consensus.Node
+import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract (NodeConfig)
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -35,7 +35,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Ledger.Mock
-import           Ouroboros.Consensus.Node
+import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
 import           Ouroboros.Consensus.Protocol.Praos

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -44,6 +44,7 @@ import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Mock
+import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Node
 import           Ouroboros.Consensus.Protocol.Abstract (NodeConfig)
 import           Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
@@ -31,7 +31,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Ledger.Mock
-import           Ouroboros.Consensus.Node
+import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.PBFT
 import           Ouroboros.Consensus.Util.Random

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -37,7 +37,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Ledger.Mock
-import           Ouroboros.Consensus.Node (NodeId)
+import           Ouroboros.Consensus.NodeId (NodeId)
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.Praos
 import           Ouroboros.Consensus.Util.Chain (dropLastBlocks, lastSlot)

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
@@ -37,7 +37,7 @@ import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo.HasCreator
 import           Ouroboros.Consensus.Ledger.Abstract
-import           Ouroboros.Consensus.Node
+import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract (NodeConfig)
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
                      (LeaderSchedule (..))

--- a/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
@@ -52,11 +52,12 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Crypto.DSIGN
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
-import           Ouroboros.Consensus.Node (NodeId (..))
+import           Ouroboros.Consensus.NodeId (NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Consensus.Util.Orphans ()
 import qualified Ouroboros.Consensus.Util.SlotBounded as SB
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
The rest of `Ouroboros.Consensus.Node` does not need the `NodeId` and almost all modules that import `Ouroboros.Consensus.Node` only actually use the things from `Ouroboros.Consensus.NodeId`.

So since they're essentially completely independent then have them live in separate modules and that makes it much clearer which things actually depend on `Ouroboros.Consensus.Node`.

This patch touches a lot of files but it's just adjusting names of imports.