### PR TITLE
better Point type factoring

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
@@ -67,7 +67,7 @@ headerPrevHash :: HasHeader (Header blk) => Header blk -> ChainHash blk
 headerPrevHash = castHash . blockPrevHash
 
 headerPoint :: HasHeader (Header blk) => Header blk -> Point blk
-headerPoint = castPoint . blockPoint
+headerPoint = Point . blockPoint
 
 {-------------------------------------------------------------------------------
   Supported blocks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
@@ -98,8 +98,8 @@ chainSyncServerForReader _tracer chainDB rdr =
                        -- the producer's state to change.
 
     sendNext :: Point blk
-             -> ChainUpdate (Header blk)
-             -> ServerStNext (Header blk) (Point blk) m ()
+             -> ChainUpdate b
+             -> ServerStNext b (Point blk) m ()
     sendNext tip update = case update of
       AddBlock hdr -> SendMsgRollForward  hdr tip idle'
       RollBack pt  -> SendMsgRollBackward pt  tip idle'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Mock.hs
@@ -39,6 +39,7 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
          , ForgeExt (BlockProtocol (SimpleBlock SimpleMockCrypto ext))
                     SimpleMockCrypto
                     ext
+         , Eq ext
          ) => RunDemo (SimpleBlock  SimpleMockCrypto ext) where
   demoForgeBlock         = forgeSimple
   demoBlockMatchesHeader = matchesSimpleHeader

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Run.hs
@@ -60,12 +60,13 @@ class DemoHeaderHash hh where
 class ( ProtocolLedgerView blk
       , DemoHeaderHash (HeaderHash blk)
       , Condense (Header blk)
-      , Condense (ChainHash blk)
+      , Condense (HeaderHash blk)
       , Condense blk
       , Condense [blk]
       , ApplyTx blk
       , Show (ApplyTxErr blk)
       , Condense (GenTx blk)
+      , Eq (Header blk)
       ) => RunDemo blk where
   demoForgeBlock         :: (HasNodeState (BlockProtocol blk) m, MonadRandom m)
                          => NodeConfig (BlockProtocol blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -12,7 +12,7 @@ module Ouroboros.Consensus.Ledger.Abstract (
 
 import           Control.Monad.Except
 
-import           Ouroboros.Network.Block (Point, SlotNo)
+import           Ouroboros.Network.Block (Point, SlotNo, TPoint)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -114,5 +114,5 @@ class UpdateLedger blk => ProtocolLedgerView blk where
   anachronisticProtocolLedgerView
     :: NodeConfig (BlockProtocol blk)
     -> LedgerState blk
-    -> SlotNo -- ^ Slot for which you would like a ledger view
+    -> TPoint SlotNo -- ^ Slot for which you would like a ledger view
     -> Maybe (SlotBounded (LedgerView (BlockProtocol blk)))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -Wredundant-constraints #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Ouroboros.Consensus.Ledger.Byron
   ( -- * Byron blocks and headers
@@ -516,9 +517,8 @@ instance Condense (Header (ByronBlock cfg)) where
         . unByronHeader
         $ hdr
 
-instance Condense (ChainHash (ByronBlock cfg)) where
-  condense GenesisHash   = "genesis"
-  condense (BlockHash h) = show h
+instance Condense CC.Block.HeaderHash where
+  condense = show
 
 instance Condense (GenTx (ByronBlock cfg)) where
     condense (ByronTx tx) =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -319,9 +319,10 @@ instance Condense ext' => Condense (SimpleBlock' c ext ext') where
       SimpleStdHeader{..} = simpleHeaderStd
       SimpleBody{..}      = simpleBody
 
-instance Condense (ChainHash (SimpleBlock' c ext ext')) where
-  condense GenesisHash     = "genesis"
-  condense (BlockHash hdr) = show hdr
+instance Condense (ChainHash (SimpleBlock c ext)) where
+  condense GenesisHash   = "genesis"
+  -- uses the Condense (Hash a b) instance
+  condense (BlockHash h) = condense h
 
 {-------------------------------------------------------------------------------
   Serialise instances

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -247,7 +247,7 @@ extendsVR cfg prevApplied = repeatedly (extendVR cfg prevApplied)
 validateIS :: forall m blk hdr. (MonadSTM m, ApplyTx blk)
            => MempoolEnv m blk hdr -> STM m (ValidationResult blk)
 validateIS MempoolEnv{mpEnvChainDB, mpEnvLedgerCfg, mpEnvStateVar} =
-    go <$> (Block.pointHash <$> getTipPoint      mpEnvChainDB)
+    go <$> (getChainHash <$> getTipPoint      mpEnvChainDB)
        <*> (ledgerState     <$> getCurrentLedger mpEnvChainDB)
        <*> readTVar mpEnvStateVar
   where
@@ -259,3 +259,6 @@ validateIS MempoolEnv{mpEnvChainDB, mpEnvLedgerCfg, mpEnvStateVar} =
       | tip == isTip = initVR mpEnvLedgerCfg isTxs (tip, st)
       | otherwise    = extendsVR mpEnvLedgerCfg True (Foldable.toList isTxs) $
                          initVR mpEnvLedgerCfg TxSeq.Empty (tip, st)
+
+    getChainHash :: Block.Point blk -> ChainHash blk
+    getChainHash = Block.fromTPoint Block.GenesisHash (Block.BlockHash . Block.pointHash)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -202,7 +202,6 @@ initInternalState
        , Ord peer
        , TraceConstraints peer blk
        , ApplyTx blk
-       , Eq (Header blk)
        )
     => NodeParams m peer blk
     -> m (InternalState m peer blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -139,7 +139,6 @@ nodeKernel
        , TraceConstraints peer blk
        , ApplyTx blk
        , Eq (Header blk)
-       , Condense (HeaderHash blk)
        )
     => NodeParams m peer blk
     -> m (NodeKernel m peer blk)
@@ -175,7 +174,7 @@ nodeKernel params@NodeParams { threadRegistry, cfg } = do
 type TraceConstraints peer blk =
   ( Condense peer
   , Condense blk
-  , Condense (ChainHash blk)
+  , Condense (HeaderHash blk)
   , Condense (Header blk)
   )
 
@@ -204,7 +203,6 @@ initInternalState
        , TraceConstraints peer blk
        , ApplyTx blk
        , Eq (Header blk)
-       , Condense (HeaderHash blk)
        )
     => NodeParams m peer blk
     -> m (InternalState m peer blk)
@@ -277,10 +275,10 @@ initBlockFetchConsensusInterface tracer cfg chainDB getCandidates blockFetchSize
         then FetchModeDeadline
         else FetchModeBulkSync
 
-    readFetchedBlocks :: STM m (Point blk -> Bool)
+    readFetchedBlocks :: STM m (BlockPoint blk -> Bool)
     readFetchedBlocks = ChainDB.getIsFetched chainDB
 
-    addFetchedBlock :: Point blk -> blk -> m ()
+    addFetchedBlock :: BlockPoint blk -> blk -> m ()
     addFetchedBlock _pt blk = do
       ChainDB.addBlock chainDB blk
       traceWith tracer $ "Downloaded block: " <> condense blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -115,10 +115,11 @@ protocolHandlers
        , ApplyTx blk
        , ProtocolLedgerView blk
        , Condense (Header blk)
-       , Condense (ChainHash blk)
+       , Condense (HeaderHash blk)
        , Condense peer
        , Show (ApplyTxErr blk)  --TODO: consider using condense
        , Condense (GenTx blk)
+       , Eq (Header blk)
        )
     => NodeParams m peer blk  --TODO eliminate, merge relevant into NodeKernel
     -> NodeKernel m peer blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -44,7 +44,7 @@ import           Control.Monad.Class.MonadSay
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..))
+import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..), TPoint (..))
 import           Ouroboros.Network.Chain (Chain)
 
 import qualified Ouroboros.Consensus.Util.AnchoredFragment as AF
@@ -197,7 +197,7 @@ class ( Show (ChainState    p)
   -- and will yield 'Nothing'.
   rewindChainState :: NodeConfig p
                    -> ChainState p
-                   -> SlotNo -- ^ Slot to rewind to.
+                   -> TPoint SlotNo -- ^ Slot to rewind to.
                    -> Maybe (ChainState p)
 
 -- | Protocol security parameter

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -211,10 +211,11 @@ instance (PBftCrypto c, Typeable c) => OuroborosTag (PBft c) where
       takeR :: Integral i => i -> Seq a -> Seq a
       takeR (fromIntegral -> n) s = Seq.drop (Seq.length s - n - 1) s
 
-  rewindChainState _ cs slot = if slot == SlotNo 0 then Just Seq.empty else
-    case Seq.takeWhileL (\(_, s) -> s <= slot) cs of
-        _ Seq.:<| _ -> Just cs
-        _           -> Nothing
+  rewindChainState _ cs pslot = case pslot of
+    Origin     -> Just Seq.empty
+    Point slot -> case Seq.takeWhileL (\(_, s) -> s <= slot) cs of
+      _  Seq.:<| _ -> Just cs
+      _           -> Nothing
 
 {-------------------------------------------------------------------------------
   PBFT specific types

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -57,7 +57,7 @@ import           Cardano.Crypto.VRF.Class
 import           Cardano.Crypto.VRF.Mock (MockVRF)
 import           Cardano.Crypto.VRF.Simple (SimpleVRF)
 
-import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..))
+import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..), TPoint (..))
 
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -293,7 +293,7 @@ instance PraosCrypto c => OuroborosTag (Praos c) where
   -- filled; instead we roll back the the block just before it.
   rewindChainState PraosNodeConfig{..} cs rewindTo =
       -- This may drop us back to the empty list if we go back to genesis
-      Just $ dropWhile (\bi -> biSlot bi > rewindTo) cs
+      Just $ dropWhile (\bi -> Point (biSlot bi) > rewindTo) cs
 
   -- NOTE: We redefine `preferCandidate` but NOT `compareCandidates`
   -- NOTE: See note regarding clock skew.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -12,8 +12,8 @@ import           Cardano.Crypto.Hash (Hash)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (ChainHash, HasHeader, Point (..),
-                     SlotNo (..))
+import           Ouroboros.Network.Block (HeaderHash, HasHeader, SlotNo (..),
+                                          TBlockPoint (..), TPoint (..))
 import           Ouroboros.Network.Chain (Chain (..))
 
 import           Ouroboros.Consensus.Util.Condense
@@ -25,15 +25,18 @@ import           Ouroboros.Consensus.Util.Condense
 instance Condense SlotNo where
   condense (SlotNo n) = condense n
 
-instance Condense (ChainHash block) => Condense (Point block) where
-    condense (Point ptSlot ptHash) =
-      "(Point " <> condense ptSlot <> ", " <> condense ptHash <> ")"
+instance Condense t => Condense (TPoint t) where
+    condense Origin = "(Origin)"
+    condense (Point p) = "(Point " <> condense p <> ")"
+
+instance (Condense slot, Condense hash) => Condense (TBlockPoint slot hash) where
+  condense p = condense (pointSlot p) <> ", " <> condense (pointHash p)
 
 instance Condense block => Condense (Chain block) where
     condense Genesis   = "Genesis"
     condense (cs :> b) = condense cs <> " :> " <> condense b
 
-instance (Condense block, HasHeader block, Condense (ChainHash block))
+instance (Condense block, HasHeader block, Condense (HeaderHash block))
     => Condense (AnchoredFragment block) where
     condense (AF.Empty pt) = "EmptyAnchor " <> condense pt
     condense (cs AF.:> b)  = condense cs <> " :> " <> condense b

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/SlotBounded.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/SlotBounded.hs
@@ -8,12 +8,12 @@ module Ouroboros.Consensus.Util.SlotBounded (
   , at
   ) where
 
-import           Ouroboros.Network.Block (SlotNo)
+import           Ouroboros.Network.Block (SlotNo, TPoint (..))
 
--- | An item bounded to be valid within particular slots
+-- | An item bounded to be valid within particular slots (inclusive)
 data SlotBounded a = SlotBounded
-  { sbLower   :: !SlotNo
-  , sbUpper   :: !SlotNo
+  { sbLower   :: !(TPoint SlotNo)
+  , sbUpper   :: !(TPoint SlotNo)
   , sbContent :: !a
   } deriving (Eq, Functor, Show)
 
@@ -21,12 +21,12 @@ data SlotBounded a = SlotBounded
 --
 --   We choose not to validate that the slot bounds are reasonable here.
 bounded :: SlotNo -> SlotNo -> a -> SlotBounded a
-bounded = SlotBounded
+bounded l r = SlotBounded (Point l) (Point r)
 
 unbounded :: a -> SlotBounded a
-unbounded = SlotBounded minBound maxBound
+unbounded = SlotBounded Origin (Point maxBound)
 
-at :: SlotBounded a -> SlotNo -> Maybe a
+at :: SlotBounded a -> TPoint SlotNo -> Maybe a
 sb `at` slot =
   if (slot <= sbUpper sb && slot >= sbLower sb)
   then Just $ sbContent sb

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -35,7 +35,7 @@ import           Control.Monad.Class.MonadThrow
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader (..),
                      HeaderHash, SlotNo, StandardHash)
-import           Ouroboros.Network.Chain (Chain (..), Point (..))
+import           Ouroboros.Network.Chain (Chain (..), Point)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState (ReaderId)
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -35,7 +35,7 @@ import           Control.Monad.Class.MonadThrow
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader (..),
                      HeaderHash, SlotNo, StandardHash)
-import           Ouroboros.Network.Chain (Chain (..), Point)
+import           Ouroboros.Network.Chain (BlockPoint, Chain (..), Point)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState (ReaderId)
 
@@ -118,14 +118,14 @@ data ChainDB m blk hdr =
     , getTipPoint        :: STM m (Point blk)
 
       -- | Get block at the specified point (if it exists)
-    , getBlock           :: Point blk -> m (Maybe blk)
+    , getBlock           :: BlockPoint blk -> m (Maybe blk)
 
       -- | Return membership check function for recent blocks
       --
       -- This check is only reliable for blocks up to @k@ away from the tip.
       -- For blocks older than that the results should be regarded as
       -- non-deterministic.
-    , getIsFetched       :: STM m (Point blk -> Bool)
+    , getIsFetched       :: STM m (BlockPoint blk -> Bool)
 
       -- | Stream blocks
       --
@@ -176,13 +176,13 @@ data ChainDB m blk hdr =
     , newBlockReader     :: m (Reader m blk)
 
       -- | Known to be invalid blocks
-    , knownInvalidBlocks :: STM m (Set (Point blk))
+    , knownInvalidBlocks :: STM m (Set (BlockPoint blk))
 
       -- | Check if the specified point is on the current chain
       --
       -- This lives in @m@, not @STM m@, because if the point is not on the
       -- current chain fragment, it might have to query the immutable DB.
-    , pointOnChain       :: Point blk -> m Bool
+    , pointOnChain       :: BlockPoint blk -> m Bool
     }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
@@ -12,8 +12,7 @@ import qualified Data.Set as Set
 import           Control.Monad.Class.MonadSTM
 
 import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader (..),
-                     HeaderHash, Point (..))
-import qualified Ouroboros.Network.Block as Block
+                     HeaderHash, Point)
 import qualified Ouroboros.Network.ChainProducerState as CPS
 
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -97,9 +96,9 @@ openDB cfg initLedger blockHeader = do
             readerForward' :: [Point hdr]
                            -> Model blk
                            -> (Maybe (Point hdr), Model blk)
-            readerForward' ps =
-                  first (fmap Block.castPoint)
-                . Model.readerForward rdrId (map Block.castPoint ps)
+            readerForward' ps = Model.readerForward rdrId ps
+                --   first (fmap Block.castPoint)
+                -- . Model.readerForward rdrId (map Block.castPoint ps)
 
     return ChainDB {
         addBlock            = update_ . Model.addBlock cfg
@@ -120,5 +119,5 @@ openDB cfg initLedger blockHeader = do
     k = protocolSecurityParam cfg
 
     castUpdate :: ChainUpdate blk -> ChainUpdate hdr
-    castUpdate (RollBack p) = RollBack (Block.castPoint p)
+    castUpdate (RollBack p) = RollBack p
     castUpdate (AddBlock b) = AddBlock (blockHeader b)

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -46,6 +46,7 @@ prop_simple_protocol_convergence :: forall c ext.
                                    ( RunDemo (SimpleBlock c ext)
                                    , SimpleCrypto c
                                    , Show ext
+                                   , Eq ext
                                    , Typeable ext
                                    )
                                  => (CoreNodeId -> ProtocolInfo (SimpleBlock c ext))
@@ -75,6 +76,7 @@ test_simple_protocol_convergence :: forall m c ext.
                                     , RunDemo (SimpleBlock c ext)
                                     , SimpleCrypto c
                                     , Show ext
+                                    , Eq ext
                                     , Typeable ext
                                     )
                                  => (CoreNodeId -> ProtocolInfo (SimpleBlock c ext))

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -172,6 +172,7 @@ broadcastNetwork :: forall m c ext.
                     , RunDemo (SimpleBlock c ext)
                     , SimpleCrypto c
                     , Show ext
+                    , Eq ext
                     , Typeable ext
                     )
                  => ThreadRegistry m
@@ -210,7 +211,7 @@ broadcastNetwork registry btime numCoreNodes pInfo initRNG numSlots = do
                     curNo = succ prevNo
 
                 let prevHash :: ChainHash (SimpleBlock c ext)
-                    prevHash = castHash (pointHash prevPoint)
+                    prevHash = fromTPoint GenesisHash (BlockHash . pointHash) prevPoint
 
                 -- We ignore the transactions from the mempool (which will be
                 -- empty), and instead produce some random transactions

--- a/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
@@ -175,7 +175,7 @@ instance UpdateLedger TestBlock where
 
   applyLedgerBlock _ tb@TestBlock{..} TestLedger{..} =
       if tbPrevHash == snd lastApplied
-        then return     $ TestLedger (Chain.blockPoint tb, BlockHash tbHash)
+        then return     $ TestLedger (Chain.Point (Chain.blockPoint tb), BlockHash tbHash)
         else throwError $ InvalidHash (snd lastApplied) tbPrevHash
 
   applyLedgerHeader _ _ = return

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -202,7 +202,7 @@ data BlockFetchConsensusInterface peer header block m =
 -- This runs forever and should be shut down using mechanisms such as async.
 --
 blockFetchLogic :: forall peer header block m.
-                   (MonadSTM m, Ord peer,
+                   (MonadSTM m, Ord peer, Eq header,
                     HasHeader header, HasHeader block,
                     HeaderHash header ~ HeaderHash block)
                 => Tracer m [TraceLabelPeer peer (FetchDecision [Point header])]

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -156,12 +156,12 @@ data BlockFetchConsensusInterface peer header block m =
        readFetchMode          :: STM m FetchMode,
 
        -- | Recent, only within last K
-       readFetchedBlocks      :: STM m (Point block -> Bool),
+       readFetchedBlocks      :: STM m (BlockPoint block -> Bool),
 
        -- | This and 'readFetchedBlocks' are required to be linked. Upon
        -- successful completion of 'addFetchedBlock' it must be the case that
        -- 'readFetchedBlocks' reports the block.
-       addFetchedBlock        :: Point block -> block -> m (),
+       addFetchedBlock        :: BlockPoint block -> block -> m (),
 
        -- | Given the current chain, is the given chain plausible as a
        -- candidate chain. Classically for Ouroboros this would simply

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -229,7 +229,7 @@ blockFetchClient FetchClientContext {
             -- interleaving
 
             -- Add the block to the chain DB, notifying of any new chains.
-            addFetchedBlock (Point (blockPoint header)) block
+            addFetchedBlock (blockPoint header) block
 
             -- Note that we add the block to the chain DB /before/ updating our
             -- current status and in-flight stats. Otherwise blocks will

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -64,6 +64,7 @@ type BlockFetchClient header block m a =
 --
 blockFetchClient :: forall header block m.
                     (MonadSTM m, MonadTime m, MonadThrow m,
+                     Eq header,
                      HasHeader header, HasHeader block,
                      HeaderHash header ~ HeaderHash block)
                  => FetchClientContext header block m
@@ -148,8 +149,8 @@ blockFetchClient FetchClientContext {
 -}
         let range :: ChainRange block
             range = assert (not (ChainFragment.null fragment)) $
-                    ChainRange (castPoint (blockPoint lower))
-                               (castPoint (blockPoint upper))
+                    ChainRange (Point (blockPoint lower))
+                               (Point (blockPoint upper))
               where
                 Just lower = ChainFragment.last fragment
                 Just upper = ChainFragment.head fragment
@@ -213,7 +214,7 @@ blockFetchClient FetchClientContext {
             updateTimeout timeout (diffTime now )
 -}
 
-            unless (blockPoint header == castPoint (blockPoint block)) $
+            unless (blockPoint header == blockPoint block) $
               throwM BlockFetchProtocolFailureWrongBlock
 
             -- This is moderately expensive.
@@ -228,7 +229,7 @@ blockFetchClient FetchClientContext {
             -- interleaving
 
             -- Add the block to the chain DB, notifying of any new chains.
-            addFetchedBlock (castPoint (blockPoint header)) block
+            addFetchedBlock (Point (blockPoint header)) block
 
             -- Note that we add the block to the chain DB /before/ updating our
             -- current status and in-flight stats. Otherwise blocks will

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -33,7 +33,8 @@ import           Control.Monad.Class.MonadSTM
 import           Control.Exception (assert)
 import           Control.Tracer (Tracer, traceWith)
 
-import           Ouroboros.Network.Block (Point, TPoint (Point), blockPoint, HasHeader, HeaderHash)
+import           Ouroboros.Network.Block (BlockPoint, Point, TPoint (Point),
+                   blockPoint, HasHeader, HeaderHash)
 import qualified Ouroboros.Network.ChainFragment as CF
 import           Ouroboros.Network.ChainFragment (ChainFragment)
 import           Ouroboros.Network.BlockFetch.DeltaQ
@@ -59,7 +60,7 @@ data FetchClientPolicy header block m =
      FetchClientPolicy {
        blockFetchSize     :: header -> SizeInBytes,
        blockMatchesHeader :: header -> block -> Bool,
-       addFetchedBlock    :: Point block -> block -> m ()
+       addFetchedBlock    :: BlockPoint block -> block -> m ()
      }
 
 -- | A set of variables shared between the block fetch logic thread and each

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
@@ -127,7 +127,7 @@ fetchDecisions
   => FetchDecisionPolicy header
   -> FetchMode
   -> AnchoredFragment header
-  -> (Point block -> Bool)
+  -> (BlockPoint block -> Bool)
   -> [(AnchoredFragment header, PeerInfo header extra)]
   -> [(FetchDecision (FetchRequest header), PeerInfo header extra)]
 fetchDecisions fetchDecisionPolicy@FetchDecisionPolicy {
@@ -445,7 +445,7 @@ of individual blocks without their relationship to each other.
 filterNotAlreadyFetched
   :: forall header block peerinfo .
      (HasHeader header, HeaderHash header ~ HeaderHash block)
-  => (Point block -> Bool)
+  => (BlockPoint block -> Bool)
   -> [(FetchDecision (ChainSuffix        header), peerinfo)]
   -> [(FetchDecision (CandidateFragments header), peerinfo)]
 filterNotAlreadyFetched alreadyDownloaded chains =
@@ -461,7 +461,7 @@ filterNotAlreadyFetched alreadyDownloaded chains =
             return (candidate, fragments)
     ]
   where
-    notAlreadyFetched = not . alreadyDownloaded . Point . blockPoint
+    notAlreadyFetched = not . alreadyDownloaded . blockPoint
 
 
 filterNotAlreadyInFlightWithPeer

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
@@ -252,7 +252,7 @@ data FetchTriggerVariables peer header m = FetchTriggerVariables {
 -- necessary to re-evaluate when these variables change.
 --
 data FetchNonTriggerVariables peer header block m = FetchNonTriggerVariables {
-       readStateFetchedBlocks :: STM m (Point block -> Bool),
+       readStateFetchedBlocks :: STM m (BlockPoint block -> Bool),
        readStatePeerStateVars :: STM m (Map peer (FetchClientStateVars m header)),
        readStatePeerGSVs      :: STM m (Map peer PeerGSV),
        readStateFetchMode     :: STM m FetchMode
@@ -297,7 +297,7 @@ data FetchStateSnapshot peer header block m = FetchStateSnapshot {
                                             PeerFetchInFlight header,
                                             FetchClientStateVars m header),
        fetchStatePeerGSVs      :: Map peer PeerGSV,
-       fetchStateFetchedBlocks :: Point block -> Bool,
+       fetchStateFetchedBlocks :: BlockPoint block -> Bool,
        fetchStateFetchMode     :: FetchMode
      }
 

--- a/ouroboros-network/src/Ouroboros/Network/Chain.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Chain.hs
@@ -293,10 +293,10 @@ findFirstPoint
   :: HasHeader block
   => [Point block]
   -> Chain block
-  -> Point block
-findFirstPoint [] _     = Origin
+  -> Maybe (Point block)
+findFirstPoint [] _     = Nothing
 findFirstPoint (p:ps) c
-  | pointOnChain p c    = p
+  | pointOnChain p c    = Just p
   | otherwise           = findFirstPoint ps c
 
 intersectChains

--- a/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
@@ -260,8 +260,6 @@ validExtension' :: (HasHeader block, HasCallStack)
 validExtension' c bSucc
   | not (blockInvariant bSucc)
   = Left $ "blockInvariant failed for bSucc"
-  | blockSlot bSucc == SlotNo 0
-  = Left $ "blockSlot was 0"
   | otherwise
   = case head c of
       Nothing -> Right ()

--- a/ouroboros-network/src/Ouroboros/Network/ChainProducerState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainProducerState.hs
@@ -137,7 +137,7 @@ producerChain (ChainProducerState c _) = c
 findFirstPoint :: HasHeader block
                => [Point block]
                -> ChainProducerState block
-               -> Point block
+               -> Maybe (Point block)
 findFirstPoint ps = Chain.findFirstPoint ps . producerChain
 
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
@@ -19,6 +19,7 @@ import           Data.ByteString.Lazy (ByteString)
 import qualified Codec.CBOR.Encoding as CBOR (Encoding, encodeListLen, encodeWord)
 import qualified Codec.CBOR.Read     as CBOR
 import qualified Codec.CBOR.Decoding as CBOR (Decoder, decodeListLen, decodeWord)
+import qualified Codec.Serialise as Serialise (encode, decode)
 
 import           Network.TypedProtocol.Codec
 import           Network.TypedProtocol.Codec.Cbor
@@ -41,11 +42,12 @@ codecBlockFetch encodeBody encodeHeaderHash
                 decodeBody decodeHeaderHash =
     mkCodecCborLazyBS encode decode
  where
+  -- FIXME Serialise.encode is used for SlotNo. Should take that as a parameter.
   encodePoint' :: Point block -> CBOR.Encoding
-  encodePoint' = Block.encodePoint $ Block.encodeChainHash encodeHeaderHash
+  encodePoint' = Block.encodeTPoint (Block.encodeTBlockPoint Serialise.encode encodeHeaderHash)
 
   decodePoint' :: forall s. CBOR.Decoder s (Point block)
-  decodePoint' = Block.decodePoint $ Block.decodeChainHash decodeHeaderHash
+  decodePoint' = Block.decodeTPoint (Block.decodeTBlockPoint Serialise.decode decodeHeaderHash)
 
   encode :: forall (pr :: PeerRole) st st'.
             PeerHasAgency pr st

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -359,7 +359,7 @@ pointsToRanges chain points =
          -- otherwise `Chain.successorBlock` will error
         then case Chain.successorBlock x chain of
           Nothing -> ChainRange x y : go (y : ys)
-          Just x' -> ChainRange (Chain.blockPoint x') y : go (y : ys)
+          Just x' -> ChainRange (Chain.Point (Chain.blockPoint x')) y : go (y : ys)
         else ChainRange x y : go (y : ys)
     go [x] = [ChainRange Chain.genesisPoint x]
     go []  = []

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -7,17 +7,23 @@
 {-# LANGUAGE PolyKinds             #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE ExplicitForAll        #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE UndecidableInstances  #-}
 module Ouroboros.Network.Protocol.BlockFetch.Type where
 
 import           Data.Void (Void)
 
-import           Ouroboros.Network.Block (StandardHash, Point)
+import           Ouroboros.Network.Block (StandardHash, Point, HeaderHash)
 import           Network.TypedProtocol.Core (Protocol (..))
 
 -- | Range of blocks, defined by a lower and upper point, inclusive.
 --
 data ChainRange block = ChainRange !(Point block) !(Point block)
-  deriving (Show, Eq, Ord)
+
+deriving instance (Show (HeaderHash block)) => Show (ChainRange block)
+deriving instance (Eq (HeaderHash block)) => Eq (ChainRange block)
+deriving instance (Ord (HeaderHash block)) => Ord (ChainRange block)
 
 data BlockFetch block where
   BFIdle      :: BlockFetch block

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Examples.hs
@@ -189,11 +189,11 @@ chainSyncServerExample recvMsgDoneClient chainvar = ChainSyncServer $
       atomically $ do
         cps <- readTVar chainvar
         case ChainProducerState.findFirstPoint points cps of
-          Chain.Origin      -> pure (Nothing, Chain.headPoint (ChainProducerState.chainState cps))
-          Chain.Point ipoint -> do
-            let !cps' = ChainProducerState.updateReader rid (Chain.Point ipoint) cps
+          Nothing     -> pure (Nothing, Chain.headPoint (ChainProducerState.chainState cps))
+          Just ipoint -> do
+            let !cps' = ChainProducerState.updateReader rid ipoint cps
             writeTVar chainvar cps'
-            pure (Just (Chain.Point ipoint), Chain.headPoint (ChainProducerState.chainState cps'))
+            pure (Just ipoint, Chain.headPoint (ChainProducerState.chainState cps'))
 
     tryReadChainUpdate :: ReaderId -> m (Maybe (Point header, ChainUpdate header))
     tryReadChainUpdate rid =

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -79,7 +79,7 @@ testClient doneVar tip =
             return $ Left ()
           else return $ Right (testClient doneVar tip),
       ChainSyncExamples.rollforward = \block ->
-        if Chain.blockPoint block == tip
+        if Chain.Point (Chain.blockPoint block) == tip
           then do
             atomically $ writeTVar doneVar True
             return $ Left ()
@@ -140,7 +140,7 @@ propChainSyncConnectIO cps =
             void $  connect (chainSyncClientPeer cli) (chainSyncServerPeer ser)
         ) cps
 
-instance Arbitrary (AnyMessageAndAgency (ChainSync BlockHeader (Point BlockHeader))) where
+instance ( Arbitrary header, Arbitrary point ) => Arbitrary (AnyMessageAndAgency (ChainSync header point)) where
   arbitrary = oneof
     [ return $ AnyMessageAndAgency (ClientAgency TokIdle) MsgRequestNext
     , return $ AnyMessageAndAgency (ServerAgency (TokNext TokCanAwait)) MsgAwaitReply

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -226,7 +226,7 @@ mkAnchoredFragment anchorpoint anchorblockno =
 
 mkAnchoredFragmentSimple :: [BlockBody] -> AnchoredFragment Block
 mkAnchoredFragmentSimple =
-    mkAnchoredFragment (Point 0 GenesisHash) (BlockNo 0) . zip [1..]
+    mkAnchoredFragment Origin (BlockNo 0) . zip [1..]
 
 
 mkPartialBlock :: SlotNo -> BlockBody -> Block
@@ -368,7 +368,7 @@ fixupAnchoredFragmentFrom :: HasHeader b
 fixupAnchoredFragmentFrom anchorpoint anchorblockno =
     fixupBlocks
       (AF.:>) (AF.Empty anchorpoint)
-      (Just (pointHash anchorpoint))
+      (Just (chainHashFromPoint anchorpoint))
       (Just anchorblockno)
 
 fixupAnchoredFragmentFromSame :: HasHeader b
@@ -378,8 +378,8 @@ fixupAnchoredFragmentFromSame :: HasHeader b
 fixupAnchoredFragmentFromSame anchorpoint =
     fixupBlocks
       (AF.:>) (AF.Empty anchorpoint)
-      (Just (pointHash anchorpoint))  -- fixup the hash
-      Nothing                         -- but keep the first block number
+      (Just (chainHashFromPoint anchorpoint))  -- fixup the hash
+      Nothing                                  -- but keep the first block number
 
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-network/test/Test/ChainProducerState.hs
+++ b/ouroboros-network/test/Test/ChainProducerState.hs
@@ -15,7 +15,9 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Ouroboros.Network.Chain (Chain, ChainUpdate (..), Point (..),
+import           Ouroboros.Network.Block (Point, TPoint(..), TBlockPoint, SlotNo(..))
+import qualified Ouroboros.Network.Block as Block (pointSlot)
+import           Ouroboros.Network.Chain (Chain, ChainUpdate (..),
                      genesisPoint, headPoint, pointOnChain)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState
@@ -46,6 +48,11 @@ tests =
   , testProperty "switch fork" prop_switchFork
   ]
 
+-- This is dishonest (the Origin is not slot 0) but it will work for our
+-- purposes in this module.
+pointSlot :: TPoint (TBlockPoint SlotNo x) -> SlotNo
+pointSlot Origin = SlotNo 0
+pointSlot (Point bp) = Block.pointSlot bp
 
 --
 -- Properties

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -165,7 +165,7 @@ chainToAnchoredFragment =
 
 -- TODO: move elsewhere and generalise
 chainPoints :: AnchoredFragment Block -> [Point BlockHeader]
-chainPoints = map (castPoint . blockPoint)
+chainPoints = map (Point . blockPoint)
             . AnchoredFragment.toOldestFirst
 
 data Example1TraceEvent =
@@ -216,7 +216,7 @@ tracePropertyBlocksRequestedAndRecievedPerPeer fork1 fork2 es =
     requestedFetchPoints :: Map Int [Point BlockHeader]
     requestedFetchPoints =
       Map.fromListWith (flip (++))
-        [ (peer, map blockPoint (ChainFragment.toOldestFirst fragment))
+        [ (peer, map (Point . blockPoint) (ChainFragment.toOldestFirst fragment))
         | TraceFetchClientState
             (TraceLabelPeer peer
               (AddedFetchRequest
@@ -259,7 +259,7 @@ tracePropertyBlocksRequestedAndRecievedAllPeers fork1 fork2 es =
     requestedFetchPoints :: Set (Point BlockHeader)
     requestedFetchPoints =
       Set.fromList
-        [ blockPoint block
+        [ Point (blockPoint block)
         | TraceFetchClientState
             (TraceLabelPeer _
               (AddedFetchRequest
@@ -317,7 +317,7 @@ tracePropertyNoDuplicateBlocksBetweenPeers fork1 fork2 es =
               (AddedFetchRequest
                 (FetchRequest fragments) _ _ _)) <- es
         , fragment <- fragments
-        , let points = Set.fromList . map blockPoint
+        , let points = Set.fromList . map (Point . blockPoint)
                      . ChainFragment.toOldestFirst
         ]
 

--- a/ouroboros-network/test/messages.cddl
+++ b/ouroboros-network/test/messages.cddl
@@ -84,11 +84,10 @@ msgNoBlocks     = [3]
 msgBlock        = [4, bfBody]
 msgBatchDone    = [5]
 
-bfPoint         = [slotNo, chainHash]
+bfPoint         = origin / [[slotNo, blockHash]]
 slotNo          = uint ; word64
-chainHash       = blockHash / genesisHash
-genesisHash     = []
-blockHash       = [dummyBlockHash]
+origin          = []
+blockHash       = dummyBlockHash
 dummyBlockHash  = null
 bfBody          = bytes .cbor any
 


### PR DESCRIPTION
There is now a type for identifying actual blocks, called BlockPoint.
It's parameterized on the slot and hash, and specialized to use the
class/families variant, so that it's not forced upon the programmer.

Next, there is a Point functor which is just like Maybe; it adds the
Origin.

This way, we eliminate silly things like `Point 42 GenesisHash`. The
"genesis point" is now called Origin, and it has no slot number nor
header hash.

According to `Ouroboros.Network.Chain`, `headSlot Genesis = SlotNo 0`.
Also, valid chains have strictly increasing slot numbers. So in this
model, the first actual block has `SlotNo 1`. But that's contrary to the
`cardano-sl` implementation, which gives `SlotNo 0` to the first block.
In `ouroboros-consensus`, does any block have `SlotNo 0`?
`Point 0 (BlockHash hash)` is apparently nonsense too, for all `hash`.


Motivation for this change: I'm reworking the hash index in byron-proxy
so that it will be ready for use with the `ChainDB` (currently it is paired
with an `ImmutableDB`). This means the index must deal with forks.
The plan is to have it follow by way of the `newReader` interface. Naturally,
it will use `Point`s to deal with rollbacks. *I don't want to (nor should I have to)
write a program which knows how to rollback to the point at slot 42 with the
genesis hash. This makes no sense. With this patch, I won't have to.*

The patch only goes so far as to make `ouroboros-network` compile and its tests
pass. I will patch downstream packages only if this pull request is approved in
principle.