### PR TITLE
Split the node network layer out of the node kernel

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -83,6 +83,7 @@ library
                        Ouroboros.Consensus.Mempool.Impl
                        Ouroboros.Consensus.Node
                        Ouroboros.Consensus.NodeId
+                       Ouroboros.Consensus.NodeNetwork
                        Ouroboros.Consensus.Protocol.Abstract
                        Ouroboros.Consensus.Protocol.BFT
                        Ouroboros.Consensus.Protocol.ExtNodeConfig

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -15,13 +15,9 @@ module Ouroboros.Consensus.Node (
     -- * Node
     NodeKernel (..)
   , NodeCallbacks (..)
-  , NodeComms (..)
   , NodeParams (..)
+  , TraceConstraints
   , nodeKernel
-    -- * Channels (re-exports from the network layer)
-  , Channel
-  , Network.createConnectedChannels
-  , Network.loggingChannel
   ) where
 
 import           Control.Monad (void)
@@ -29,39 +25,23 @@ import           Crypto.Random (ChaChaDRG)
 import qualified Data.Foldable as Foldable
 import           Data.Functor.Contravariant (contramap)
 import           Data.Map.Strict (Map)
-import           Data.Void (Void)
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork (MonadFork)
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTime
 import           Control.Tracer
-
-import           Network.TypedProtocol.Driver
-import           Ouroboros.Network.Channel as Network
-import           Ouroboros.Network.Codec
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..),
                      headSlot)
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.BlockFetch
-import           Ouroboros.Network.BlockFetch.Client (BlockFetchClient,
-                     blockFetchClient)
 import           Ouroboros.Network.BlockFetch.State (FetchMode (..))
 import qualified Ouroboros.Network.Chain as Chain
-import           Ouroboros.Network.Protocol.BlockFetch.Server
-                     (BlockFetchServer (..), blockFetchServerPeer)
-import           Ouroboros.Network.Protocol.BlockFetch.Type (BlockFetch)
-import           Ouroboros.Network.Protocol.ChainSync.Client
-import           Ouroboros.Network.Protocol.ChainSync.Server
-import           Ouroboros.Network.Protocol.ChainSync.Type
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
-import           Ouroboros.Consensus.BlockFetchServer
 import           Ouroboros.Consensus.ChainSyncClient
-import           Ouroboros.Consensus.ChainSyncServer
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Mempool
@@ -97,27 +77,6 @@ data NodeKernel m up blk = NodeKernel {
 
       -- | Read the current candidates
     , getNodeCandidates :: TVar m (Map up (TVar m (CandidateState blk)))
-
-      -- | Notify network layer of new upstream node
-      --
-      -- NOTE: Eventually it will be the responsibility of the network layer
-      -- itself to register and deregister peers.
-    , addUpstream   :: forall eCS eBF bytesCS bytesBF.
-                       (Exception eCS, Exception eBF)
-                    => up
-                    -> NodeComms m (ChainSync (Header blk) (Point blk)) eCS bytesCS
-                    -> NodeComms m (BlockFetch blk)                     eBF bytesBF
-                    -> m ()
-
-      -- | Notify network layer of a new downstream node
-      --
-      -- NOTE: Eventually it will be the responsibility of the network layer
-      -- itself to register and deregister peers.
-    , addDownstream :: forall eCS eBF bytesCS bytesBF.
-                       (Exception eCS, Exception eBF)
-                    => NodeComms m (ChainSync (Header blk) (Point blk)) eCS bytesCS
-                    -> NodeComms m (BlockFetch blk)                     eBF bytesBF
-                    -> m ()
     }
 
 -- | Monad that we run protocol specific functions in
@@ -171,8 +130,6 @@ nodeKernel
        ( MonadAsync m
        , MonadFork  m
        , MonadMask  m
-       , MonadTime  m
-       , MonadThrow (STM m)
        , ProtocolLedgerView blk
        , Ord up
        , TraceConstraints up blk
@@ -202,8 +159,6 @@ nodeKernel params@NodeParams { threadRegistry, cfg } = do
       , getNodeConfig = cfg
       , getFetchClientRegistry = fetchClientRegistry
       , getNodeCandidates      = varCandidates
-      , addUpstream   = npAddUpstream   (networkLayer st)
-      , addDownstream = npAddDownstream (networkLayer st)
       }
 
 {-------------------------------------------------------------------------------
@@ -223,7 +178,6 @@ data InternalState m up blk = IS {
     , threadRegistry      :: ThreadRegistry m
     , btime               :: BlockchainTime m
     , callbacks           :: NodeCallbacks m blk
-    , networkLayer        :: NetworkProvides m up blk
     , chainDB             :: ChainDB m blk (Header blk)
     , blockFetchInterface :: BlockFetchConsensusInterface up (Header blk) blk m
     , fetchClientRegistry :: FetchClientRegistry up (Header blk) blk m
@@ -236,10 +190,6 @@ data InternalState m up blk = IS {
 initInternalState
     :: forall m up blk.
        ( MonadAsync m
-       , MonadFork  m
-       , MonadMask  m
-       , MonadTime  m
-       , MonadThrow (STM m)
        , ProtocolLedgerView blk
        , Ord up
        , TraceConstraints up blk
@@ -262,42 +212,6 @@ initInternalState NodeParams {..} = do
         blockFetchInterface = initBlockFetchConsensusInterface
           (tracePrefix "ChainDB" Nothing)
           cfg chainDB getCandidates blockFetchSize blockMatchesHeader btime
-
-        nrChainSyncClient :: up -> Consensus ChainSyncClient blk m
-        nrChainSyncClient up = chainSyncClient
-          (tracePrefix "CSClient" (Just up))
-          cfg
-          btime
-          maxClockSkew
-          (ChainDB.getCurrentChain chainDB)
-          (ChainDB.getCurrentLedger chainDB)
-          varCandidates
-          up
-
-        nrChainSyncServer :: ChainSyncServer (Header blk) (Point blk) m ()
-        nrChainSyncServer =
-          chainSyncServer (tracePrefix "CSServer" Nothing) chainDB
-
-        nrBlockFetchClient :: BlockFetchClient (Header blk) blk m ()
-        nrBlockFetchClient = blockFetchClient
-          -- Note the tracer for the changes in the fetch client state
-          -- is passed to the blockFetchLogic.
-          -- The message level tracer is passed to runPipelinedPeer.
-
-        nrBlockFetchServer :: BlockFetchServer blk m ()
-        nrBlockFetchServer =
-          blockFetchServer (tracePrefix "BFServer" Nothing) chainDB
-
-        nrFetchClientRegistry = fetchClientRegistry
-
-        networkRequires :: NetworkRequires m up blk
-        networkRequires = NetworkRequires {..}
-
-        networkLayer :: NetworkProvides m up blk
-        networkLayer = initNetworkLayer
-          (contramap ("BlockFetch | " <>) tracer)
-          threadRegistry
-          networkRequires
 
     return IS {..}
   where
@@ -435,124 +349,3 @@ forkBlockProduction IS{..} =
                        $ simChaChaT varDRG
                        $ id
 
-{-------------------------------------------------------------------------------
-  New network layer
--------------------------------------------------------------------------------}
-
-data NetworkRequires m up blk = NetworkRequires {
-      -- | Start a chain sync client that communicates with the given upstream
-      -- node.
-      nrChainSyncClient     :: up -> ChainSyncClient (Header blk) (Point blk) m Void
-
-      -- | Start a chain sync server.
-    , nrChainSyncServer     :: ChainSyncServer (Header blk) (Point blk) m ()
-
-      -- | Start a block fetch client that communicates with the given
-      -- upstream node.
-    , nrBlockFetchClient    :: BlockFetchClient (Header blk) blk m ()
-
-      -- | Start a block fetch server server.
-    , nrBlockFetchServer    :: BlockFetchServer blk m ()
-
-      -- | The fetch client registry, used by the block fetch client.
-    , nrFetchClientRegistry :: FetchClientRegistry up (Header blk) blk m
-    }
-
--- | Required by the network layer to initiate comms to a new node
-data NodeComms m ps e bytes = NodeComms {
-      -- | Codec used for the protocol
-      ncCodec    :: Codec ps e m bytes
-
-      -- | Construct a channel to the node
-      --
-      -- This is in CPS style to allow for resource allocation.
-    , ncWithChan :: forall a. (Channel m bytes -> m a) -> m a
-    }
-
--- TODO something nicer than eCS, eBF, bytesCS, and bytesBF. Mux them over one
--- channel.
-data NetworkProvides m up blk = NetworkProvides {
-      -- | Notify network layer of new upstream node
-      --
-      -- NOTE: Eventually it will be the responsibility of the network layer
-      -- itself to register and deregister peers.
-      npAddUpstream   :: forall eCS eBF bytesCS bytesBF.
-                         (Exception eCS, Exception eBF)
-                      => up
-                      -> NodeComms m (ChainSync (Header blk) (Point blk)) eCS bytesCS
-                         -- Communication for the Chain Sync protocol
-                      -> NodeComms m (BlockFetch blk)                     eBF bytesBF
-                         -- Communication for the Block Fetch protocol
-                      -> m ()
-
-      -- | Notify network layer of a new downstream node
-      --
-      -- NOTE: Eventually it will be the responsibility of the network layer
-      -- itself to register and deregister peers.p
-    , npAddDownstream :: forall eCS eBF bytesCS bytesBF.
-                         (Exception eCS, Exception eBF)
-                      => NodeComms m (ChainSync (Header blk) (Point blk)) eCS bytesCS
-                         -- Communication for the Chain Sync protocol
-                      -> NodeComms m (BlockFetch blk)                     eBF bytesBF
-                         -- Communication for the Block Fetch protocol
-                      -> m ()
-    }
-
-initNetworkLayer
-    :: forall m up blk.
-       ( MonadSTM   m
-       , MonadAsync m
-       , MonadFork  m
-       , MonadCatch m
-       , MonadMask  m
-       , Ord up
-       )
-    => Tracer m String
-    -> ThreadRegistry m
-    -> NetworkRequires m up blk
-    -> NetworkProvides m up blk
-initNetworkLayer _tracer registry NetworkRequires{..} = NetworkProvides {..}
-  where
-    npAddDownstream :: (Exception eCS, Exception eBF)
-                    => NodeComms m (ChainSync (Header blk) (Point blk)) eCS bytesCS
-                    -> NodeComms m (BlockFetch blk)                     eBF bytesBF
-                    -> m ()
-    npAddDownstream ncCS ncBF = do
-      -- TODO use subregistry here?
-      let NodeComms csCodec csWithChan = ncCS
-          NodeComms bfCodec bfWithChan = ncBF
-      void $ forkLinked registry $ bfWithChan $ \chan ->
-        runPeer nullTracer bfCodec chan $
-          blockFetchServerPeer nrBlockFetchServer
-      void $ forkLinked registry $ csWithChan $ \chan ->
-        runPeer nullTracer csCodec chan $
-          chainSyncServerPeer nrChainSyncServer
-
-    npAddUpstream :: (Exception eCS, Exception eBF)
-                  => up
-                  -> NodeComms m (ChainSync (Header blk) (Point blk)) eCS bytesCS
-                  -> NodeComms m (BlockFetch blk)                     eBF bytesBF
-                  -> m ()
-    npAddUpstream up ncCS ncBF = do
-      -- TODO use subregistry here?
-      let NodeComms csCodec csWithChan = ncCS
-          NodeComms bfCodec bfWithChan = ncBF
-
-      clientRegistered <- newEmptyTMVarM
-
-      void $ forkLinked registry $ bfWithChan $ \chan ->
-        bracketFetchClient nrFetchClientRegistry up $ \clientCtx -> do
-          atomically $ putTMVar clientRegistered ()
-          runPipelinedPeer nullTracer bfCodec chan $
-            nrBlockFetchClient clientCtx
-
-      -- The block fetch logic thread in the background wants there to be a
-      -- block fetch client thread for each chain sync candidate it sees. So
-      -- start the chain sync client after the block fetch thread was
-      -- registered to make sure it never sees a chain sync candidate without
-      -- a corresponding block fetch client thread.
-      atomically $ takeTMVar clientRegistered
-
-      void $ forkNonTerminating registry $ csWithChan $ \chan ->
-        runPeer nullTracer csCodec chan $
-          chainSyncClientPeer (nrChainSyncClient up)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -1,0 +1,196 @@
+{-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DuplicateRecordFields      #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints -Werror=missing-fields #-}
+
+module Ouroboros.Consensus.NodeNetwork (
+    NetworkProvides(..)
+  , NodeComms(..)
+  , initNetworkLayer
+  ) where
+
+import           Control.Monad (void)
+import           Data.Functor.Contravariant (contramap)
+
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadFork (MonadFork)
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
+import           Control.Tracer
+
+import           Network.TypedProtocol.Driver
+import           Ouroboros.Network.Channel as Network
+import           Ouroboros.Network.Codec
+
+import           Ouroboros.Network.Block
+import           Ouroboros.Network.BlockFetch
+import           Ouroboros.Network.BlockFetch.Client (BlockFetchClient,
+                     blockFetchClient)
+import           Ouroboros.Network.Protocol.BlockFetch.Server
+                     (BlockFetchServer (..), blockFetchServerPeer)
+import           Ouroboros.Network.Protocol.BlockFetch.Type (BlockFetch)
+import           Ouroboros.Network.Protocol.ChainSync.Client
+import           Ouroboros.Network.Protocol.ChainSync.Server
+import           Ouroboros.Network.Protocol.ChainSync.Type
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.BlockFetchServer
+import           Ouroboros.Consensus.ChainSyncClient
+import           Ouroboros.Consensus.ChainSyncServer
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Consensus.Util.Orphans ()
+import           Ouroboros.Consensus.Util.ThreadRegistry
+
+import qualified Ouroboros.Storage.ChainDB.API as ChainDB
+
+import           Ouroboros.Consensus.Node
+
+
+{-------------------------------------------------------------------------------
+  Network layer
+-------------------------------------------------------------------------------}
+
+-- TODO something nicer than eCS, eBF, bytesCS, and bytesBF. Mux them over one
+-- channel.
+data NetworkProvides m up blk = NetworkProvides {
+      -- | Notify network layer of new upstream node
+      --
+      -- NOTE: Eventually it will be the responsibility of the network layer
+      -- itself to register and deregister peers.
+      addUpstream   :: forall eCS eBF bytesCS bytesBF.
+                       (Exception eCS, Exception eBF)
+                    => up
+                    -> NodeComms m (ChainSync (Header blk) (Point blk)) eCS bytesCS
+                       -- Communication for the Chain Sync protocol
+                    -> NodeComms m (BlockFetch blk)                     eBF bytesBF
+                       -- Communication for the Block Fetch protocol
+                    -> m ()
+
+      -- | Notify network layer of a new downstream node
+      --
+      -- NOTE: Eventually it will be the responsibility of the network layer
+      -- itself to register and deregister peers.p
+    , addDownstream :: forall eCS eBF bytesCS bytesBF.
+                       (Exception eCS, Exception eBF)
+                    => NodeComms m (ChainSync (Header blk) (Point blk)) eCS bytesCS
+                       -- Communication for the Chain Sync protocol
+                    -> NodeComms m (BlockFetch blk)                     eBF bytesBF
+                       -- Communication for the Block Fetch protocol
+                    -> m ()
+    }
+
+
+-- | Required by the network layer to initiate comms to a new node
+data NodeComms m ps e bytes = NodeComms {
+      -- | Codec used for the protocol
+      ncCodec    :: Codec ps e m bytes
+
+      -- | Construct a channel to the node
+      --
+      -- This is in CPS style to allow for resource allocation.
+    , ncWithChan :: forall a. (Channel m bytes -> m a) -> m a
+    }
+
+
+initNetworkLayer
+    :: forall m up blk.
+       ( MonadSTM   m
+       , MonadAsync m
+       , MonadFork  m
+       , MonadCatch m
+       , MonadMask  m
+       , MonadThrow (STM m)
+       , MonadTime  m
+       , Ord up
+       , ProtocolLedgerView blk
+       , TraceConstraints up blk
+       )
+    => NodeParams m up blk
+    -> NodeKernel m up blk
+    -> NetworkProvides m up blk
+initNetworkLayer NodeParams {..} NodeKernel{..} = NetworkProvides {..}
+  where
+    addDownstream :: (Exception eCS, Exception eBF)
+                  => NodeComms m (ChainSync (Header blk) (Point blk)) eCS bytesCS
+                  -> NodeComms m (BlockFetch blk)                     eBF bytesBF
+                  -> m ()
+    addDownstream ncCS ncBF = do
+      -- TODO use subregistry here?
+      let NodeComms csCodec csWithChan = ncCS
+          NodeComms bfCodec bfWithChan = ncBF
+      void $ forkLinked threadRegistry $ bfWithChan $ \chan ->
+        runPeer nullTracer bfCodec chan $
+          blockFetchServerPeer nrBlockFetchServer
+      void $ forkLinked threadRegistry $ csWithChan $ \chan ->
+        runPeer nullTracer csCodec chan $
+          chainSyncServerPeer nrChainSyncServer
+
+    addUpstream :: (Exception eCS, Exception eBF)
+                => up
+                -> NodeComms m (ChainSync (Header blk) (Point blk)) eCS bytesCS
+                -> NodeComms m (BlockFetch blk)                     eBF bytesBF
+                -> m ()
+    addUpstream up ncCS ncBF = do
+      -- TODO use subregistry here?
+      let NodeComms csCodec csWithChan = ncCS
+          NodeComms bfCodec bfWithChan = ncBF
+
+      clientRegistered <- newEmptyTMVarM
+
+      void $ forkLinked threadRegistry $ bfWithChan $ \chan ->
+        bracketFetchClient getFetchClientRegistry up $ \clientCtx -> do
+          atomically $ putTMVar clientRegistered ()
+          runPipelinedPeer nullTracer bfCodec chan $
+            nrBlockFetchClient clientCtx
+
+      -- The block fetch logic thread in the background wants there to be a
+      -- block fetch client thread for each chain sync candidate it sees. So
+      -- start the chain sync client after the block fetch thread was
+      -- registered to make sure it never sees a chain sync candidate without
+      -- a corresponding block fetch client thread.
+      atomically $ takeTMVar clientRegistered
+
+      void $ forkNonTerminating threadRegistry $ csWithChan $ \chan ->
+        runPeer nullTracer csCodec chan $
+          chainSyncClientPeer (nrChainSyncClient up)
+
+    nrChainSyncClient :: up -> Consensus ChainSyncClient blk m
+    nrChainSyncClient up = chainSyncClient
+      (tracePrefix "CSClient" (Just up))
+      cfg
+      btime
+      maxClockSkew
+      (ChainDB.getCurrentChain chainDB)
+      (ChainDB.getCurrentLedger chainDB)
+      getNodeCandidates
+      up
+
+    nrChainSyncServer :: ChainSyncServer (Header blk) (Point blk) m ()
+    nrChainSyncServer =
+      chainSyncServer (tracePrefix "CSServer" Nothing) chainDB
+
+    nrBlockFetchClient :: BlockFetchClient (Header blk) blk m ()
+    nrBlockFetchClient = blockFetchClient
+      -- Note the tracer for the changes in the fetch client state
+      -- is passed to the blockFetchLogic.
+      -- The message level tracer is passed to runPipelinedPeer.
+
+    nrBlockFetchServer :: BlockFetchServer blk m ()
+    nrBlockFetchServer =
+      blockFetchServer (tracePrefix "BFServer" Nothing) chainDB
+
+    tracePrefix :: String -> Maybe up -> Tracer m String
+    tracePrefix p mbUp =
+      let prefix = p <> maybe "" ((" " <>) . condense) mbUp <> " | "
+      in contramap (prefix <>) tracer
+

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -46,6 +46,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Node
+import           Ouroboros.Consensus.NodeNetwork
 import           Ouroboros.Consensus.Protocol.Abstract (NodeConfig)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -142,6 +143,7 @@ broadcastNetwork registry btime numCoreNodes pInfo initRNG numSlots = do
             }
 
       node <- nodeKernel nodeParams
+      let network = initNetworkLayer nodeParams node
 
       forM_ (filter (/= us) nodeIds) $ \them -> do
         let mkCommsDown :: Show bytes
@@ -162,10 +164,10 @@ broadcastNetwork registry btime numCoreNodes pInfo initRNG numSlots = do
                   loggingChannel (TalkingToProducer us them) $
                     getChan (chans Map.! them Map.! us)
               }
-        addDownstream node
+        addDownstream network
           (mkCommsDown chainSyncConsumer  codecChainSyncId)
           (mkCommsDown blockFetchConsumer codecBlockFetchId)
-        addUpstream node them
+        addUpstream network them
           (mkCommsUp   chainSyncProducer  codecChainSyncId)
           (mkCommsUp   blockFetchProducer codecBlockFetchId)
 


### PR DESCRIPTION
This should be a pure refactoring, with no changes. It takes the network interface initialisation out of the NodeKernel and moves it into its own layer which can be constructed from the NodeKernel.

This is another step in the direction of fully integrating the remaining network layer features (mux, version negotiation etc).