### PR TITLE
Add handshake protocol to cddl tests

### DIFF
--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -94,6 +94,7 @@
             (hsPkgs.base)
             (hsPkgs.bytestring)
             (hsPkgs.cborg)
+            (hsPkgs.containers)
             (hsPkgs.fingertree)
             (hsPkgs.hashable)
             (hsPkgs.process-extras)

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -262,16 +262,21 @@ test-suite cddl
                        Ouroboros.Network.Protocol.BlockFetch.Type
                        Ouroboros.Network.Protocol.ChainSync.Codec
                        Ouroboros.Network.Protocol.ChainSync.Type
+                       Ouroboros.Network.Protocol.Handshake.Codec
+                       Ouroboros.Network.Protocol.Handshake.Type
+                       Ouroboros.Network.Protocol.Handshake.Version
                        Ouroboros.Network.Protocol.PingPong.Codec
                        Ouroboros.Network.Protocol.ReqResp.Codec
                        Ouroboros.Network.Testing.ConcreteBlock
                        Ouroboros.Network.Block
                        Ouroboros.Network.Chain
                        Ouroboros.Network.Codec
+                       Codec.SerialiseTerm
   default-language:    Haskell2010
   build-depends:       base,
                        bytestring,
                        cborg,
+                       containers,
                        fingertree,
                        hashable,
                        process-extras,

--- a/ouroboros-network/test/messages.cddl
+++ b/ouroboros-network/test/messages.cddl
@@ -7,7 +7,7 @@ allMessages =
     / [2,pingPongMessage]
     / [3,blockFetchMessage]
     / [4,txSubmissionMessage]
-    / [5,muxControlMessage]
+    / [5, handshakeMessage]
 
 ; Chain Sync Protocol
 ; reference implementation of the codec in
@@ -113,12 +113,48 @@ txSubmissionMsgDone = [4]
 txHash        = bytes .cbor any
 transaction   = bytes .cbor any
 
+; ToDo
 ; MuxControl Protocol
 ; reference implementation of the codec in
 ; ouroboros-network/src/Ouroboros/Network/Mux/Control.hs
+; muxControlMessage = msgInitReq / msgInitRsp / msgInitFail
+; msgInitReq  = [0]
+; msgInitRsp  = [1]
+; msgInitFail = [2]
+; Handshake Protocol
+; reference implementation of the codec in
+; ouroboros-network/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
 
-muxControlMessage = msgInitReq / msgInitRsp / msgInitFail
+versionNumber = uint .size 4
+handshakeMessage =
+       msgProposeVersions
+     / msgAcceptVersion
+     / msgRefuse
 
-msgInitReq  = [0] ; ToDo
-msgInitRsp  = [1]
-msgInitFail = [2]
+msgProposeVersions = [0 , versionTable]
+
+; CDDL is not expressive enough to describe the all possible values of proposeVersions.
+; proposeVersions is a tables that maps version numbers to version parameters.
+; The codec requires that the keys are unique and in ascending order.
+; This specification only enumerates version numbers from 1..4.
+
+params = any
+extraParams = any
+versionTable =
+    { ? 1 => params
+    , ? 2 => params
+    , ? 3 => params
+    , ? 4 => params
+    }
+
+msgAcceptVersion   = [1, versionNumber, extraParams]
+msgRefuse          = [2, refuseReason ]
+
+refuseReason
+    = refuseReasonVersionMismatch
+    / refuseReasonHandshakeDecodeError
+    / refuseReasonRefused
+
+refuseReasonVersionMismatch      = [0 , [ versionNumber] ]
+refuseReasonHandshakeDecodeError = [1 , versionNumber, tstr]
+refuseReasonRefused              = [2 , versionNumber, tstr]


### PR DESCRIPTION
This PR adds the handshake protocol to `messages.cddl` and the cddl tests.