### PR TITLE
Conditional compilation of WIP and relase version of network-pdf

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -49,9 +49,10 @@ let
     inherit customConfig;
   };
   tests = import ./nix/nixos/tests { inherit (commonLib) pkgs; };
-  network-pdf = import ./doc/default.nix {inherit commonLib; };
+  network-pdf-wip = import ./doc/default.nix {inherit commonLib; isRelease=false; };
+  network-pdf     = import ./doc/default.nix {inherit commonLib; isRelease=true; };
 in {
   inherit scripts tests;
   inherit (nixTools) nix-tools;
-  inherit network-pdf;
+  inherit network-pdf network-pdf-wip;
 }

--- a/default.nix
+++ b/default.nix
@@ -49,10 +49,10 @@ let
     inherit customConfig;
   };
   tests = import ./nix/nixos/tests { inherit (commonLib) pkgs; };
-  network-pdf-wip = import ./doc/default.nix {inherit commonLib; isRelease=false; };
-  network-pdf     = import ./doc/default.nix {inherit commonLib; isRelease=true; };
+  documents = import ./doc/default.nix {inherit commonLib; };
 in {
   inherit scripts tests;
   inherit (nixTools) nix-tools;
-  inherit network-pdf network-pdf-wip;
+  network-pdf-wip = documents.network-pdf-wip;
+  network-pdf = documents.network-pdf;
 }

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,4 +1,4 @@
-# See `./latexmkrc` for latexmk configuration
+# See `./latexmkrc` and `~/.latexmkrc` for latexmk configuration
 LATEX	= latexmk
 PVC	= -pvc
 

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -3,7 +3,6 @@
   pkgs ? commonLib.pkgs,
   stdenv ? pkgs.stdenv,
   texlive ? pkgs.texlive,
-  isRelease ? false
 }:
 
 let
@@ -23,24 +22,28 @@ let
     bibtex biblatex
     latexmk;
   };
+  document = isRelease: stdenv.mkDerivation {
+    name = if isRelease then "network-pdf" else "network-pdf-wip";
+    buildInputs = [ tex pkgs.cddl ];
+    # this is a hack :
+    # network.tex includes ../ouroboros-network/test/messages.cddl .
+    # Therefor the src also includes the parrent directory.
+    src = pkgs.lib.sourceFilesBySuffices ../. [ ".tex" ".bib" ".pdf" ".cddl"];
+    buildPhase = ''
+       # run cddl to catch syntax errors in messages.cddl
+       cddl ouroboros-network/test/messages.cddl generate 1
+       cd doc
+       ${if isRelease then "echo >.isRelease" else "rm -f .isRelease"}
+       latexmk -view=pdf network;
+    '';
+    installPhase = ''
+      install -Dt $out network.pdf
+      mkdir $out/nix-support
+      echo "doc-pdf network $out/network.pdf" >> $out/nix-support/hydra-build-products
+    '';
+  };
 in
-stdenv.mkDerivation {
-  name = if isRelease then "network-pdf" else "network-pdf-wip";
-  buildInputs = [ tex pkgs.cddl ];
-  # this is a hack :
-  # network.tex includes ../ouroboros-network/test/messages.cddl .
-  # Therefor the src also includes the parrent directory.
-  src = pkgs.lib.sourceFilesBySuffices ../. [ ".tex" ".bib" ".pdf" ".cddl"];
-  buildPhase = ''
-     # run cddl to catch syntax errors in messages.cddl
-     cddl ouroboros-network/test/messages.cddl generate 1
-     cd doc
-     ${if isRelease then "echo >.isRelease" else "rm -f .isRelease"}
-     latexmk -view=pdf network;
-  '';
-  installPhase = ''
-    install -Dt $out network.pdf
-    mkdir $out/nix-support
-    echo "doc-pdf network $out/network.pdf" >> $out/nix-support/hydra-build-products
-  '';
+{
+  network-pdf = document true;
+  network-pdf-wip = document false;
 }

--- a/doc/network.tex
+++ b/doc/network.tex
@@ -1,4 +1,7 @@
 \documentclass{report}
+\usepackage{etoolbox}
+\newbool{isRelease}
+\IfFileExists{.isRelease}{\booltrue{isRelease}}{\boolfalse{isRelease}}
 \usepackage[margin=2.5cm]{geometry}
 \usepackage{amsmath, amssymb, stmaryrd, latexsym, amsthm, mathtools}
 \usepackage{mathpazo, times}
@@ -8,8 +11,10 @@
 \usepackage{natbib}
 % \usepackage{parskip} % very ugly with lemmas, invariants, etc without intervening text
 
-\usepackage{todonotes}
-% \usepackage[disable]{todonotes}
+\ifbool{isRelease}
+    {\usepackage[disable]{todonotes}}
+    {\usepackage{todonotes}}
+
 \usepackage{slashed}
 \usepackage{tikz}
 \usetikzlibrary{automata, positioning, arrows}
@@ -62,13 +67,20 @@
 \newcommand{\subtractdom}{\mathbin{\slashed{\restrictdom}}}
 \newcommand{\restrictrange}{\rhd}
 
-% add reference to the relevant Haskell source (as comment)
-%\newcommand{\hsref}[1]{}  should be hidden in the final document
-\newcommand{\hsref}[1]{}
-%\newcommand{\hsref}[1]{\href{https://github.com/input-output-hk/ouroboros-network/blob/master/#1}{\emph{Haskell source: #1}}}
-%\newcommand{\wip}[1]{\color{magenta}{#1}\color{black}}
-\newcommand{\wip}[1]{}
-\newcommand{\hide}[1]{}
+\ifbool{isRelease}
+       {
+         \newcommand{\hsref}[1]{}
+         \newcommand{\wip}[1]{}
+         \newcommand{\hide}[1]{}
+       }
+       {
+         \newcommand{\hsref}[1]
+                    {\href{https://github.com/input-output-hk/ouroboros-network/blob/master/#1}
+                      {\emph{Haskell source: #1}}}
+         \newcommand{\wip}[1]{\color{magenta}{#1}\color{black}}
+         \newcommand{\hide}[1]{}
+       }
+
 \newcommand{\trans}[1]{\texttt{#1}}
 \newcommand{\state}[1]{\texttt{#1}}
 \newcommand{\msg}[1]{\texttt{#1}}

--- a/release.nix
+++ b/release.nix
@@ -62,6 +62,7 @@ commonLib.pkgs.lib.mapAttrsRecursiveCond
   required-name = "ouroboros-network-required-checks";
   extraBuilds = {
     tests = default.tests;
+    network-pdf-wip = default.network-pdf-wip;
     network-pdf = default.network-pdf;
   };
   required-targets = jobs: [


### PR DESCRIPTION
This PR introduces conditional building of the network documentation.
The tex file checks for a file `.isRelease`
```
If `.isRelease` exists then
        hide all todo-notes, parts that are wrapped in `\hide{..}`
        and the references to the sourcecode
    else
        show todo-notes and call the derivation to `network-pdf-wip`
```
NIx takes care of the `.isRelease` file and by default builds two derivations:
`network-pdf` -> the release version that is linked on the wiki.
`network-pdf-wip` -> the work-in-progress version
```
