### PR TITLE
Shell.nix, almost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist/
 *.swp
 *.swo
 *~
+\#*
 *_flymake.hs
 result*
 **/tags

--- a/shell.nix
+++ b/shell.nix
@@ -4,14 +4,14 @@ let
   default = import ./default.nix {};
 in
 default.nix-tools._raw.shellFor {
-  packages    = p: map (x: p."${x}") [
-    "io-sim"
-    "io-sim-classes"
-    "ouroboros-consensus"
-    "ouroboros-network"
-    "typed-transitions"
+  packages    = ps: with ps; [
+    io-sim
+    io-sim-classes
+    ouroboros-consensus
+    ouroboros-network
+    typed-transitions
   ];
-  withHoogle  = withHoogle;
+  inherit withHoogle;
   buildInputs = with default.nix-tools._raw; [
     cabal-install.components.exes.cabal
   ];

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,6 @@ let
 in
 default.nix-tools._raw.shellFor {
   packages    = p: map (x: p."${x}") [
-    "cabal-install"
     "io-sim"
     "io-sim-classes"
     "ouroboros-consensus"
@@ -13,4 +12,7 @@ default.nix-tools._raw.shellFor {
     "typed-transitions"
   ];
   withHoogle  = withHoogle;
+  buildInputs = with default.nix-tools._raw; [
+    cabal-install.components.exes.cabal
+  ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ withHoogle ? true
+}:
+let
+  default = import ./default.nix {};
+in
+default.nix-tools._raw.shellFor {
+  packages    = p: map (x: p."${x}") [
+    "cabal-install"
+    "io-sim"
+    "io-sim-classes"
+    "ouroboros-consensus"
+    "ouroboros-network"
+    "typed-transitions"
+  ];
+  withHoogle  = withHoogle;
+}


### PR DESCRIPTION
This _almost_ brings back `nix-shell` that can build/run `demo-playground`.

The only blocker is the need to remove the source package definitions in the Cabal project file, which is caused by this Cabal issue: https://github.com/haskell/cabal/issues/6049#issuecomment-502113697