### PR TITLE
Sync startup & shutdown between chain sync and block fetch clients

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
@@ -4,20 +4,20 @@
 
 module Control.Monad.Class.MonadAsync
   ( MonadAsync (..)
+  , AsyncCancelled(..)
   ) where
 
 import           Prelude hiding (read)
-
-import           Data.Proxy (Proxy)
 
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 import           Control.Exception (SomeException)
 import qualified Control.Concurrent.Async as Async
+import           Control.Concurrent.Async (AsyncCancelled(..))
 
 class MonadSTM m => MonadAsync m where
 
-  {-# MINIMAL async, cancel, isCancel, waitCatchSTM, pollSTM #-}
+  {-# MINIMAL async, cancel, waitCatchSTM, pollSTM #-}
 
   -- | An asynchronous action
   type Async m :: * -> *
@@ -30,7 +30,6 @@ class MonadSTM m => MonadAsync m where
   waitCatch             :: Async m a -> m (Either SomeException a)
   cancel                :: Async m a -> m ()
   uninterruptibleCancel :: Async m a -> m ()
-  isCancel              :: Proxy m -> SomeException -> Bool
 
   waitSTM               :: Async m a -> STM m a
   pollSTM               :: Async m a -> STM m (Maybe (Either SomeException a))
@@ -229,9 +228,6 @@ instance MonadAsync IO where
   waitCatch             = Async.waitCatch
   cancel                = Async.cancel
   uninterruptibleCancel = Async.uninterruptibleCancel
-  isCancel _ e
-    | Just Async.AsyncCancelled <- fromException e = True
-    | otherwise                                    = False
 
   waitSTM               = Async.waitSTM
   pollSTM               = Async.pollSTM

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -85,6 +85,7 @@
             (hsPkgs.stm)
             (hsPkgs.tasty)
             (hsPkgs.tasty-quickcheck)
+            (hsPkgs.tasty-hunit)
             (hsPkgs.text)
             (hsPkgs.time)
             ];

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -28,6 +28,7 @@ import           Control.Monad (void)
 import           Data.Void (Void)
 
 import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
@@ -207,6 +208,7 @@ muxResponderNetworkApplication NetworkApplication {..} =
 consensusNetworkApps
     :: forall m peer blk failure bytesCS bytesBF.
        ( MonadAsync m
+       , MonadFork m
        , MonadCatch m
        , Ord peer
        , Exception failure

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -236,6 +236,7 @@ test-suite tests
                        stm,
                        tasty,
                        tasty-quickcheck,
+                       tasty-hunit,
                        text,
                        time
 

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -90,6 +90,7 @@ module Ouroboros.Network.BlockFetch (
     FetchClientRegistry,
     newFetchClientRegistry,
     bracketFetchClient,
+    bracketSyncWithFetchClient,
 
     -- * Re-export types used by 'BlockFetchConsensusInterface'
     FetchMode (..),
@@ -114,7 +115,8 @@ import           Ouroboros.Network.BlockFetch.ClientRegistry
                    ( FetchClientPolicy(..)
                    , FetchClientRegistry, newFetchClientRegistry
                    , readFetchClientsStatus, readFetchClientsStateVars
-                   , bracketFetchClient, setFetchClientContext )
+                   , bracketFetchClient, bracketSyncWithFetchClient
+                   , setFetchClientContext )
 
 
 -- | The consensus layer functionality that the block fetch logic requires.

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientRegistry.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientRegistry.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 
 module Ouroboros.Network.BlockFetch.ClientRegistry (
     -- * Registry of block fetch clients
     FetchClientRegistry,
     newFetchClientRegistry,
     bracketFetchClient,
+    bracketSyncWithFetchClient,
     setFetchClientContext,
     FetchClientPolicy(..),
     readFetchClientsStatus,
@@ -20,6 +22,9 @@ import           Data.Map (Map)
 import           Control.Monad (unless)
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadFork
+                   ( MonadFork(ThreadId, myThreadId, throwTo) )
 import           Control.Exception (assert)
 import           Control.Tracer (Tracer, contramap)
 
@@ -41,36 +46,112 @@ data FetchClientRegistry peer header block m =
        (TMVar m (Tracer m (TraceLabelPeer peer (TraceFetchClientState header)),
                  FetchClientPolicy header block m))
        (TVar  m (Map peer (FetchClientStateVars m header)))
+       (TVar  m (Map peer (ThreadId m, TMVar m ())))
 
 newFetchClientRegistry :: MonadSTM m
                        => m (FetchClientRegistry peer header block m)
 newFetchClientRegistry = FetchClientRegistry <$> newEmptyTMVarM
                                              <*> newTVarM Map.empty
+                                             <*> newTVarM Map.empty
 
-bracketFetchClient :: (MonadThrow m, MonadSTM m, Ord peer)
+-- | This is needed to start a block fetch client. It provides the required
+-- 'FetchClientContext'. It registers and unregisters the fetch client on
+-- start and end.
+--
+-- It also manages synchronisation with the corresponding chain sync client.
+--
+bracketFetchClient :: forall m a peer header block.
+                      (MonadThrow m, MonadSTM m, MonadFork m, Ord peer)
                    => FetchClientRegistry peer header block m
                    -> peer
                    -> (FetchClientContext header block m -> m a)
                    -> m a
-bracketFetchClient (FetchClientRegistry ctxVar registry) peer =
-    bracket register unregister
+bracketFetchClient (FetchClientRegistry ctxVar
+                      fetchRegistry syncRegistry) peer action =
+    bracket register (uncurry unregister) (action . fst)
   where
-    register = atomically $ do
-      (tracer, policy) <- readTMVar ctxVar -- blocks until setFetchClientContext
-      stateVars <- newFetchClientStateVars
-      modifyTVar' registry $ \m ->
-        assert (peer `Map.notMember` m) $
-        Map.insert peer stateVars m
-      return FetchClientContext {
-        fetchClientCtxTracer    = contramap (TraceLabelPeer peer) tracer,
-        fetchClientCtxPolicy    = policy,
-        fetchClientCtxStateVars = stateVars
-      }
+    register :: m ( FetchClientContext header block m
+                  , (ThreadId m, TMVar m ()) )
+    register = do
+      ctx <- atomically $ do
+        -- blocks until setFetchClientContext is called
+        (tracer, policy) <- readTMVar ctxVar
+        stateVars <- newFetchClientStateVars
+        modifyTVar' fetchRegistry $ \m ->
+          assert (peer `Map.notMember` m) $
+          Map.insert peer stateVars m
+        return FetchClientContext {
+          fetchClientCtxTracer    = contramap (TraceLabelPeer peer) tracer,
+          fetchClientCtxPolicy    = policy,
+          fetchClientCtxStateVars = stateVars
+        }
+      -- Now wait for the sync client to start up:
+      syncclient <- atomically $ do
+        syncclients <- readTVar syncRegistry
+        case Map.lookup peer syncclients of
+          Nothing         -> retry
+          Just syncclient -> return syncclient
+      return (ctx, syncclient)
 
-    unregister FetchClientContext { fetchClientCtxStateVars = stateVars } =
-      atomically $ do
+    unregister :: FetchClientContext header block m
+               -> (ThreadId m, TMVar m ())
+               -> m ()
+    unregister FetchClientContext { fetchClientCtxStateVars = stateVars }
+               (tid, doneVar)  = do
+      -- Signal we are shutting down
+      atomically $
         writeTVar (fetchClientStatusVar stateVars) PeerFetchStatusShutdown
-        modifyTVar' registry $ \m ->
+      -- Kill the sync client if it is still running
+      throwTo tid AsyncCancelled
+      -- Wait for the sync client to terminate and finally unregister ourselves
+      atomically $ do
+        readTMVar doneVar
+        modifyTVar' fetchRegistry $ \m ->
+          assert (peer `Map.member` m) $
+          Map.delete peer m
+
+
+-- | The block fetch and chain sync clients for each peer need to synchronise
+-- their startup and shutdown. This bracket operation provides that
+-- synchronisation for the chain sync client.
+--
+-- This must be used for the chain sync client /outside/ of its own state
+-- registration and deregistration.
+--
+bracketSyncWithFetchClient :: forall m a peer header block.
+                              (MonadThrow m, MonadSTM m, MonadFork m, Ord peer)
+                           => FetchClientRegistry peer header block m
+                           -> peer
+                           -> m a
+                           -> m a
+bracketSyncWithFetchClient (FetchClientRegistry _ctxVar
+                              fetchRegistry syncRegistry) peer action = do
+    doneVar <- newEmptyTMVarM
+    bracket_ (register doneVar) (unregister doneVar) action
+  where
+    -- The goal here is that the block fetch client should be registered
+    -- before the sync client starts running.
+    --
+    -- On the shutdown side, the sync client should stop before the block fetch
+    -- is unregistered. This has to happen even if either client is terminated
+    -- abnormally or being cancelled (which of course can happen in any order).
+
+    register :: TMVar m () -> m ()
+    register doneVar = do
+      tid <- myThreadId
+      -- We wait for the fetch client to be registered, and register ourselves
+      atomically $ do
+        fetchclients <- readTVar fetchRegistry
+        check (peer `Map.member` fetchclients)
+        modifyTVar' syncRegistry $ \m ->
+          assert (peer `Map.notMember` m) $
+          Map.insert peer (tid, doneVar) m
+
+    unregister :: TMVar m () -> m ()
+    unregister doneVar =
+      atomically $ do
+        putTMVar doneVar ()
+        modifyTVar' syncRegistry $ \m ->
           assert (peer `Map.member` m) $
           Map.delete peer m
 
@@ -79,7 +160,7 @@ setFetchClientContext :: MonadSTM m
                       -> Tracer m (TraceLabelPeer peer (TraceFetchClientState header))
                       -> FetchClientPolicy header block m
                       -> m ()
-setFetchClientContext (FetchClientRegistry ctxVar _) tracer policy =
+setFetchClientContext (FetchClientRegistry ctxVar _ _) tracer policy =
     atomically $ do
       ok <- tryPutTMVar ctxVar (tracer, policy)
       unless ok $ fail "setFetchClientContext: called more than once"
@@ -90,7 +171,7 @@ setFetchClientContext (FetchClientRegistry ctxVar _) tracer policy =
 readFetchClientsStatus :: MonadSTM m
                        => FetchClientRegistry peer header block m
                        -> STM m (Map peer (PeerFetchStatus header))
-readFetchClientsStatus (FetchClientRegistry _ registry) =
+readFetchClientsStatus (FetchClientRegistry _ registry _) =
   readTVar registry >>= traverse (readTVar . fetchClientStatusVar)
 
 -- | A read-only 'STM' action to get the 'FetchClientStateVars' for all fetch
@@ -99,5 +180,5 @@ readFetchClientsStatus (FetchClientRegistry _ registry) =
 readFetchClientsStateVars :: MonadSTM m
                           => FetchClientRegistry peer header block m
                           -> STM m (Map peer (FetchClientStateVars m header))
-readFetchClientsStateVars (FetchClientRegistry _ registry) = readTVar registry
+readFetchClientsStateVars (FetchClientRegistry _ registry _) = readTVar registry
 


### PR DESCRIPTION
We concluded that the previous approach was a bit ad-hoc and messy.

This introduces a new mechanism to do the syncing, rips out the old one, and uses the new one.

As part of this we also pull out a `bracketChainSyncClient` which properly handles the register/unregister of the chain sync client. In particular it can always unregister on shutdown, normal or abnormal. This feature is however currently disabled because the chain sync client test currently relies on the chains never being unregistered. Once this is fixed then the unregister `FIXME` in `bracketChainSyncClient` can be easily resolved.