### PR TITLE
Add: Fix pbft signature checking

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -296,6 +296,9 @@ instance (ByronGiven, Typeable cfg)
                       . CC.Block.delegationCertificate
                       . CC.Block.headerSignature
                       $ hdr
+      , pbftGenKey    = VerKeyCardanoDSIGN
+                      . CC.Block.headerIssuer
+                      $ hdr
       , pbftSignature = SignedDSIGN
                       . SigCardanoDSIGN
                       . CC.Block.signature

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
@@ -123,10 +123,12 @@ instance ( SimpleCrypto c
 instance PBftCrypto c' => Serialise (SimplePBftExt c c') where
   encode (SimplePBftExt PBftFields{..}) = mconcat [
         encodeVerKeyDSIGN pbftIssuer
+      , encodeVerKeyDSIGN pbftGenKey
       , encodeSignedDSIGN pbftSignature
       ]
   decode = do
       pbftIssuer    <- decodeVerKeyDSIGN
+      pbftGenKey    <- decodeVerKeyDSIGN
       pbftSignature <- decodeSignedDSIGN
       return $ SimplePBftExt PBftFields{..}
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -60,6 +60,7 @@ import           Ouroboros.Consensus.Util.Condense
 
 data PBftFields c toSign = PBftFields {
       pbftIssuer    :: VerKeyDSIGN (PBftDSIGN c)
+    , pbftGenKey    :: VerKeyDSIGN (PBftDSIGN c)
     , pbftSignature :: SignedDSIGN (PBftDSIGN c) toSign
     }
   deriving (Generic)
@@ -85,6 +86,7 @@ forgePBftFields PBftNodeConfig{..} encodeToSign toSign = do
     signature <- signedDSIGN encodeToSign toSign pbftSignKey
     return $ PBftFields {
         pbftIssuer    = pbftVerKey
+      , pbftGenKey    = pbftGenVerKey
       , pbftSignature = signature
       }
 
@@ -177,7 +179,7 @@ instance (PBftCrypto c, Typeable c) => OuroborosTag (PBft c) where
       let proxy = Identity b
       case verifyPBftSigned
              (Proxy :: Proxy (c, hdr))
-             pbftGenVerKey
+             pbftGenKey
              (encodeSigned proxy)
              pbftIssuer
              (headerSigned b)


### PR DESCRIPTION
Need to verify the block signature against the genesis key found in the block header.