### PR TITLE
Prep work for mempool tracing and tx submission

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -59,6 +59,7 @@ library
                        Ouroboros.Consensus.Mempool
                        Ouroboros.Consensus.Mempool.API
                        Ouroboros.Consensus.Mempool.Impl
+                       Ouroboros.Consensus.Mempool.TxSeq
                        Ouroboros.Consensus.Node
                        Ouroboros.Consensus.NodeId
                        Ouroboros.Consensus.NodeNetwork

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -18,6 +18,8 @@ module Ouroboros.Consensus.Ledger.Byron
   , ConfigContainsGenesis(..)
     -- * Mempool integration
   , GenTx (..)
+  , GenTxId (..)
+  , computeGenTxId
     -- * Ledger
   , LedgerState (..)
   , LedgerConfig (..)
@@ -399,6 +401,10 @@ instance (ByronGiven, Typeable cfg, ConfigContainsGenesis cfg)
   -- TODO #514: This is still missing the other cases (this shouldn't be a
   -- newtype)
   data GenTx (ByronBlock cfg) = ByronTx { unByronTx :: CC.UTxO.ATxAux ByteString }
+
+  data GenTxId (ByronBlock cfg) = ByronTxId { unByronTxId :: CC.UTxO.TxId }
+
+  computeGenTxId = ByronTxId . Crypto.hash . CC.UTxO.taTx . unByronTx
 
   type ApplyTxErr (ByronBlock cfg) = CC.UTxO.UTxOValidationError
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -30,6 +30,7 @@ module Ouroboros.Consensus.Ledger.Mock.Block (
   , genesisSimpleLedgerState
     -- * 'ApplyTx' (mempool support)
   , GenTx(..)
+  , GenTxId(..)
     -- * Crypto
   , SimpleCrypto
   , SimpleStandardCrypto
@@ -238,6 +239,11 @@ genesisSimpleLedgerState = SimpleLedgerState . genesisMockState
 instance (SimpleCrypto c, Typeable ext, SupportedBlock (SimpleBlock c ext))
       => ApplyTx (SimpleBlock c ext) where
   newtype GenTx   (SimpleBlock c ext) = SimpleGenTx { simpleGenTx :: Tx }
+
+  newtype GenTxId (SimpleBlock c ext) = SimpleGenTxId
+    { simpleGenTxId :: TxId
+    } deriving (Eq, Ord)
+
   type ApplyTxErr (SimpleBlock c ext) = MockError (SimpleBlock c ext)
 
   applyTx            = \_ -> updateSimpleLedgerState

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -31,6 +31,7 @@ module Ouroboros.Consensus.Ledger.Mock.Block (
     -- * 'ApplyTx' (mempool support)
   , GenTx(..)
   , GenTxId(..)
+  , computeGenTxId
     -- * Crypto
   , SimpleCrypto
   , SimpleStandardCrypto
@@ -243,6 +244,8 @@ instance (SimpleCrypto c, Typeable ext, SupportedBlock (SimpleBlock c ext))
   newtype GenTxId (SimpleBlock c ext) = SimpleGenTxId
     { simpleGenTxId :: TxId
     } deriving (Eq, Ord)
+
+  computeGenTxId = SimpleGenTxId . hash . simpleGenTx
 
   type ApplyTxErr (SimpleBlock c ext) = MockError (SimpleBlock c ext)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/State.hs
@@ -31,7 +31,7 @@ import           Ouroboros.Consensus.Ledger.Mock.UTxO
 
 data MockState blk = MockState {
       mockUtxo      :: Utxo
-    , mockConfirmed :: Set (Hash ShortHash Tx)
+    , mockConfirmed :: Set TxId
     , mockTip       :: Point blk
     }
   deriving (Show)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/UTxO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/UTxO.hs
@@ -9,6 +9,7 @@
 module Ouroboros.Consensus.Ledger.Mock.UTxO (
     -- * Basic definitions
     Tx(..)
+  , TxId
   , TxIn
   , TxOut
   , Addr
@@ -58,7 +59,8 @@ instance ToCBOR Tx where
 instance Condense Tx where
   condense (Tx ins outs) = condense (ins, outs)
 
-type TxIn  = (Hash ShortHash Tx, Int)
+type TxId  = Hash ShortHash Tx
+type TxIn  = (TxId, Int)
 type TxOut = (Addr, Int)
 type Utxo  = Map TxIn TxOut
 
@@ -72,7 +74,7 @@ newtype InvalidInputs = InvalidInputs (Set TxIn)
 class HasUtxo a where
   txIns      :: a -> Set TxIn
   txOuts     :: a -> Utxo
-  confirmed  :: a -> Set (Hash ShortHash Tx)
+  confirmed  :: a -> Set TxId
   updateUtxo :: Monad m => a -> Utxo -> ExceptT InvalidInputs m Utxo
 
 utxo :: (Monad m, HasUtxo a) => a -> ExceptT InvalidInputs m Utxo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -107,6 +107,11 @@ data Mempool m blk idx = Mempool {
       -- transaction/.
     , getTxs :: STM m (Seq (GenTx blk, idx))
 
+      -- | Get all transactions in the mempool, along with their associated
+      -- ticket numbers, which are associated with a ticket number greater
+      -- than the one provided.
+    , getTxsAfter :: idx -> STM m (Seq (GenTx blk, idx))
+
       -- | Get a specific transaction from the mempool by its ticket number,
       -- if it exists.
     , getTx :: idx -> STM m (Maybe (GenTx blk))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -21,6 +21,9 @@ class UpdateLedger blk => ApplyTx blk where
   -- also other kinds of things such as update proposals, delegations, etc.
   data family GenTx blk :: *
 
+  -- | A generalized transaction, 'GenTx', identifier.
+  data family GenTxId blk :: *
+
   -- | Updating the ledger with a single transaction may result in a different
   -- error type as when updating it with a block
   type family ApplyTxErr blk :: *
@@ -97,7 +100,7 @@ data Mempool m blk idx = Mempool {
       -- they have already been included. (Distinguishing between these two
       -- cases can be done in theory, but it is expensive unless we have an
       -- index of transaction hashes that have been included on the blockchain.)
-      addTxs :: [GenTx blk] -> m [(GenTx blk, ApplyTxErr blk)]
+      addTxs :: [(GenTxId blk, GenTx blk)] -> m [(GenTx blk, ApplyTxErr blk)]
 
       -- | Sync the transactions in the mempool with the ledger state of the
       -- 'ChainDB'. Invalid transactions will be returned along with the
@@ -113,16 +116,16 @@ data Mempool m blk idx = Mempool {
       -- valid (with respect to the ledger state) if this function is called
       -- immediately following a call to 'syncState', /within the same
       -- transaction/.
-    , getTxs :: STM m [(GenTx blk, idx)]
+    , getTxs :: STM m [(GenTxId blk, GenTx blk, idx)]
 
       -- | Get all transactions in the mempool, along with their associated
       -- ticket numbers, which are associated with a ticket number greater
       -- than the one provided.
-    , getTxsAfter :: idx -> STM m [(GenTx blk, idx)]
+    , getTxsAfter :: idx -> STM m [(GenTxId blk, GenTx blk, idx)]
 
       -- | Get a specific transaction from the mempool by its ticket number,
       -- if it exists.
-    , getTx :: idx -> STM m (Maybe (GenTx blk))
+    , getTx :: idx -> STM m (Maybe (GenTxId blk, GenTx blk))
 
       -- | Represents the initial value at which the transaction ticket number
       -- counter will start (i.e. the zeroth ticket number).

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -24,6 +24,9 @@ class UpdateLedger blk => ApplyTx blk where
   -- | A generalized transaction, 'GenTx', identifier.
   data family GenTxId blk :: *
 
+  -- | Given a 'GenTx', compute its 'GenTxId'.
+  computeGenTxId :: GenTx blk -> GenTxId blk
+
   -- | Updating the ledger with a single transaction may result in a different
   -- error type as when updating it with a block
   type family ApplyTxErr blk :: *

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -72,7 +72,7 @@ class UpdateLedger blk => ApplyTx blk where
 --   of transactions that fits in a block.
 -- * It supports wallets that submit dependent transactions (where later
 --   transaction depends on outputs from earlier ones).
-data Mempool m blk = Mempool {
+data Mempool m blk idx = Mempool {
       -- | Add a bunch of transactions (oldest to newest)
       --
       -- As long as we keep the mempool entirely in-memory this could live in
@@ -105,5 +105,5 @@ data Mempool m blk = Mempool {
       -- Guarantees that these transactions will be valid (when applied strictly
       -- in order) with respect to a call to 'getLedgerState' run /in the same
       -- transaction/.
-    , getTxs :: STM m (Seq (GenTx blk))
+    , getTxs :: STM m (Seq (GenTx blk, idx))
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -107,6 +107,10 @@ data Mempool m blk idx = Mempool {
       -- transaction/.
     , getTxs :: STM m (Seq (GenTx blk, idx))
 
+      -- | Get a specific transaction from the mempool by its ticket number,
+      -- if it exists.
+    , getTx :: idx -> STM m (Maybe (GenTx blk))
+
       -- | Represents the initial value at which the transaction ticket number
       -- counter will start (i.e. the zeroth ticket number).
     , zeroIdx :: idx

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -106,4 +106,8 @@ data Mempool m blk idx = Mempool {
       -- in order) with respect to a call to 'getLedgerState' run /in the same
       -- transaction/.
     , getTxs :: STM m (Seq (GenTx blk, idx))
+
+      -- | Represents the initial value at which the transaction ticket number
+      -- counter will start (i.e. the zeroth ticket number).
+    , zeroIdx :: idx
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -7,7 +7,6 @@ module Ouroboros.Consensus.Mempool.API (
   ) where
 
 import           Control.Monad.Except
-import           Data.Sequence (Seq)
 import           GHC.Stack (HasCallStack)
 
 import           Control.Monad.Class.MonadSTM
@@ -114,12 +113,12 @@ data Mempool m blk idx = Mempool {
       -- valid (with respect to the ledger state) if this function is called
       -- immediately following a call to 'syncState', /within the same
       -- transaction/.
-    , getTxs :: STM m (Seq (GenTx blk, idx))
+    , getTxs :: STM m [(GenTx blk, idx)]
 
       -- | Get all transactions in the mempool, along with their associated
       -- ticket numbers, which are associated with a ticket number greater
       -- than the one provided.
-    , getTxsAfter :: idx -> STM m (Seq (GenTx blk, idx))
+    , getTxsAfter :: idx -> STM m [(GenTx blk, idx)]
 
       -- | Get a specific transaction from the mempool by its ticket number,
       -- if it exists.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -100,10 +100,14 @@ data Mempool m blk idx = Mempool {
       -- index of transaction hashes that have been included on the blockchain.)
       addTxs :: [GenTx blk] -> m [(GenTx blk, ApplyTxErr blk)]
 
-      -- | Get all transactions in the mempool (oldest to newest)
+      -- | Get all transactions in the mempool along with their associated
+      -- ticket numbers (oldest to newest).
       --
-      -- Guarantees that these transactions will be valid (when applied strictly
-      -- in order) with respect to a call to 'getLedgerState' run /in the same
+      -- n.b. This function provides /no guarantee/ that the resulting
+      -- transactions will be valid with respect to the ledger state of the
+      -- 'ChainDB'. However, it is guaranteed that these transactions will be
+      -- valid (with respect to the ledger state) if this function is called
+      -- immediately following a call to 'syncState', /within the same
       -- transaction/.
     , getTxs :: STM m (Seq (GenTx blk, idx))
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -100,6 +100,11 @@ data Mempool m blk idx = Mempool {
       -- index of transaction hashes that have been included on the blockchain.)
       addTxs :: [GenTx blk] -> m [(GenTx blk, ApplyTxErr blk)]
 
+      -- | Sync the transactions in the mempool with the ledger state of the
+      -- 'ChainDB'. Invalid transactions will be returned along with the
+      -- validation error.
+    , syncState :: STM m [(GenTx blk, ApplyTxErr blk)]
+
       -- | Get all transactions in the mempool along with their associated
       -- ticket numbers (oldest to newest).
       --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -20,7 +20,8 @@ import           Ouroboros.Storage.ChainDB.API
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Mempool.API
-import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo, TxSeq (..), appendTx, fromTxSeq)
+import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo, TxSeq (..),
+                     appendTx, fromTxSeq, zeroTicketNo)
 import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Util (repeatedly)
 
@@ -35,8 +36,9 @@ openMempool :: (MonadSTM m, ApplyTx blk)
 openMempool chainDB cfg = do
     env <- initMempoolEnv chainDB cfg
     return Mempool {
-        addTxs = implAddTxs env
-      , getTxs = implGetTxs env
+        addTxs  = implAddTxs env
+      , getTxs  = implGetTxs env
+      , zeroIdx = zeroTicketNo
       }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -115,13 +115,13 @@ implSyncState mpEnv@MempoolEnv{mpEnvStateVar} = do
 
 implGetTxs :: (MonadSTM m, ApplyTx blk)
            => MempoolEnv m blk hdr
-           -> STM m (Seq (GenTx blk, TicketNo))
+           -> STM m [(GenTx blk, TicketNo)]
 implGetTxs = (flip implGetTxsAfter) zeroTicketNo
 
 implGetTxsAfter :: (MonadSTM m, ApplyTx blk)
                 => MempoolEnv m blk hdr
                 -> TicketNo
-                -> STM m (Seq (GenTx blk, TicketNo))
+                -> STM m [(GenTx blk, TicketNo)]
 implGetTxsAfter MempoolEnv{mpEnvStateVar} tn = do
   IS { isTxs } <- readTVar mpEnvStateVar
   pure $ fromTxSeq $ snd $ splitAfterTicketNo isTxs tn

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -1,0 +1,146 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ViewPatterns          #-}
+{-# LANGUAGE PatternSynonyms       #-}
+
+module Ouroboros.Consensus.Mempool.TxSeq (
+    TicketNo
+  , TxTicket(..)
+  , TxSeq(Empty, (:>), (:<))
+  , lookupByTicketNo
+  , splitAfterTicketNo
+  ) where
+
+import           Data.Word (Word64)
+import qualified Data.Foldable as Foldable
+import           Data.FingerTree (FingerTree)
+import qualified Data.FingerTree as FingerTree
+
+
+{-------------------------------------------------------------------------------
+  Mempool transaction sequence as a finger tree
+-------------------------------------------------------------------------------}
+
+-- | We allocate each transaction a (monotonically increasing) ticket number
+-- as it enters the mempool.
+--
+newtype TicketNo = TicketNo Word64
+  deriving (Eq, Ord, Bounded, Show)
+
+-- | We pair up transactions in the mempool with their ticket number.
+--
+data TxTicket tx = TxTicket !tx !TicketNo
+  deriving Show
+
+-- | The mempool is a sequence of transactions with their ticket numbers.
+-- Transactions are allocated monotonically increasing ticket numbers as they
+-- are appended to the mempool sequence. Transactions can be removed from any
+-- position, not just the front.
+--
+-- The sequence is thus ordered by the ticket numbers. We can use the ticket
+-- numbers as a compact representation for a \"reader\" location in the
+-- sequence. If a reader knows it has seen all txs with a lower ticket number
+-- then it is only interested in transactions with higher ticket numbers.
+--
+-- The mempool sequence is represented by a fingertree. We use a fingertree
+-- measure to allow not just normal sequence operations but also efficient
+-- splitting and indexing by the ticket number.
+--
+newtype TxSeq tx = TxSeq (FingerTree TxSeqMeasure (TxTicket tx))
+  deriving Show
+
+instance Foldable TxSeq where
+  foldMap f (TxSeq txs) = Foldable.foldMap (f . (\(TxTicket tx _) -> tx)) txs
+  null      (TxSeq txs) = Foldable.null txs
+
+-- | The 'FingerTree' relies on a \"measure\" for subsequences in the tree.
+-- A measure of the size of the subsequence allows for efficient sequence
+-- operations. Also measuing the min and max ticket number allows for efficient
+-- operations based on the ticket number (assuming the sequence is ordered by
+-- ticket number).
+--
+-- To use a 'FingerTree' with a 'TxSeqMeasure' we have to provide a way to
+-- measure individual elements of the sequence (i.e. 'TxTicket's), via a
+-- 'Measured' instance, and also a way to combine the measures, via a 'Monoid'
+-- instance.
+--
+data TxSeqMeasure = TxSeqMeasure {
+       mMinTicket :: !TicketNo,
+       mMaxTicket :: !TicketNo,
+       mSize      :: !Int
+     }
+  deriving Show
+
+instance FingerTree.Measured TxSeqMeasure (TxTicket tx) where
+  measure (TxTicket _ tno) = TxSeqMeasure tno tno 1
+
+instance Semigroup TxSeqMeasure where
+  vl <> vr = TxSeqMeasure
+               (mMinTicket vl `min` mMinTicket vr)
+               (mMaxTicket vl `max` mMaxTicket vr)
+               (mSize      vl   +   mSize      vr)
+
+instance Monoid TxSeqMeasure where
+  mempty  = TxSeqMeasure maxBound minBound 0
+  mappend = (<>)
+
+-- | A helper function for the ':>' pattern.
+--
+viewBack :: TxSeq tx -> Maybe (TxSeq tx, TxTicket tx)
+viewBack (TxSeq txs) = case FingerTree.viewr txs of
+                         FingerTree.EmptyR     -> Nothing
+                         txs' FingerTree.:> tx -> Just (TxSeq txs', tx)
+
+-- | A helper function for the ':<' pattern.
+--
+viewFront :: TxSeq tx -> Maybe (TxTicket tx, TxSeq tx)
+viewFront (TxSeq txs) = case FingerTree.viewl txs of
+                          FingerTree.EmptyL     -> Nothing
+                          tx FingerTree.:< txs' -> Just (tx, TxSeq txs')
+
+-- | An empty mempool sequence.
+--
+pattern Empty :: TxSeq tx
+pattern Empty <- (viewFront -> Nothing) where
+  Empty = TxSeq FingerTree.empty
+
+-- | \( O(1) \). Access or add a tx at the back of the mempool sequence.
+--
+-- New txs are always added at the back.
+--
+pattern (:>) :: TxSeq tx -> TxTicket tx -> TxSeq tx
+pattern txs :> tx <- (viewBack -> Just (txs, tx)) where
+  TxSeq txs :> tx = TxSeq (txs FingerTree.|> tx)  --TODO: assert ordered by ticket no
+
+-- | \( O(1) \). Access a tx at the front of the mempool sequence.
+--
+-- Note that we never add txs at the front. We access txs from front to back
+-- when forwarding txs to other peers, or when adding txs to blocks.
+--
+pattern (:<) :: TxTicket tx -> TxSeq tx -> TxSeq tx
+pattern tx :< txs <- (viewFront -> Just (tx, txs))
+
+infixl 5 :>, :<
+
+{-# COMPLETE Empty, (:>) #-}
+{-# COMPLETE Empty, (:<) #-}
+
+
+-- | \( O(\log(n) \). Look up a transaction in the sequence by its 'TicketNo'.
+--
+lookupByTicketNo :: TxSeq tx -> TicketNo -> Maybe tx
+lookupByTicketNo (TxSeq txs) n =
+    case FingerTree.search (\ml mr -> mMaxTicket ml >= n
+                                   && mMinTicket mr >= n) txs of
+      FingerTree.Position _ (TxTicket tx _) _ -> Just tx
+      _                                       -> Nothing
+
+-- | \( O(\log(n) \). Split the sequence of transactions into two parts
+-- based on the given 'TicketNo'. The first part has transactions with tickets
+-- less than or equal to the given ticket, and the second part has transactions
+-- with tickets strictly greater than the given ticket.
+--
+splitAfterTicketNo :: TxSeq tx -> TicketNo -> (TxSeq tx, TxSeq tx)
+splitAfterTicketNo (TxSeq txs) n =
+    case FingerTree.split (\m -> mMaxTicket m > n) txs of
+      (l, r) -> (TxSeq l, TxSeq r)
+

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -10,6 +10,7 @@ module Ouroboros.Consensus.Mempool.TxSeq (
   , fromTxSeq
   , lookupByTicketNo
   , splitAfterTicketNo
+  , zeroTicketNo
   ) where
 
 import           Data.Sequence (Seq)
@@ -29,6 +30,10 @@ import qualified Data.FingerTree as FingerTree
 --
 newtype TicketNo = TicketNo Word64
   deriving (Eq, Ord, Bounded, Show)
+
+-- | The transaction ticket number from which our counter starts.
+zeroTicketNo :: TicketNo
+zeroTicketNo = TicketNo 1
 
 -- | We pair up transactions in the mempool with their ticket number.
 --
@@ -160,5 +165,5 @@ fromTxSeq (TxSeq ftree) = fmap
 -- transaction's ticket number.
 appendTx :: TxSeq tx -> tx -> TxSeq tx
 appendTx ts tx = case viewBack ts of
-  Nothing                           -> Empty :> TxTicket tx (TicketNo 0)
+  Nothing                           -> Empty :> TxTicket tx zeroTicketNo
   Just (_, TxTicket _ (TicketNo n)) -> ts    :> TxTicket tx (TicketNo (n + 1))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -13,8 +13,6 @@ module Ouroboros.Consensus.Mempool.TxSeq (
   , zeroTicketNo
   ) where
 
-import           Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
 import           Data.Word (Word64)
 import qualified Data.Foldable as Foldable
 import           Data.FingerTree (FingerTree)
@@ -155,10 +153,10 @@ splitAfterTicketNo (TxSeq txs) n =
 
 -- | Convert a 'TxSeq' to the type which is expected to be returned from the
 -- 'Mempool' API.
-fromTxSeq :: TxSeq tx -> Seq (tx, TicketNo)
+fromTxSeq :: TxSeq tx -> [(tx, TicketNo)]
 fromTxSeq (TxSeq ftree) = fmap
   (\(TxTicket tx tn) -> (tx, tn))
-  (Seq.fromList . Foldable.toList $ ftree)
+  (Foldable.toList $ ftree)
 
 -- | Append a @tx@ to the back of a 'TxSeq'.
 -- n.b. This function also handles the incrementing of the newly added

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -161,6 +161,22 @@ fromTxSeq (TxSeq ftree) = fmap
 -- | Append a @tx@ to the back of a 'TxSeq'.
 -- n.b. This function also handles the incrementing of the newly added
 -- transaction's ticket number.
+--
+-- TODO FIXME:
+-- This does not work correctly in a couple scenarios:
+--   * If the mempool becomes empty during operation. In this case, the
+--     'TicketNo' counter would "reset" to 'zeroTicketNo'. Clients interacting
+--     with the mempool likely won't account for this.
+--
+--   * The transaction at the "back" of the mempool becomes invalid and is
+--     removed. In this case, the next transaction to be appended would take
+--     on the 'TicketNo' of the removed transaction (since this function only
+--     increments the 'TicketNo' associated with the transaction at the back
+--     of the mempool). Clients interacting with the mempool likely won't
+--     account for this.
+--
+-- Solution: Maintain a 'TicketNo' counter in the mempool implementation.
+--
 appendTx :: TxSeq tx -> tx -> TxSeq tx
 appendTx ts tx = case viewBack ts of
   Nothing                           -> Empty :> TxTicket tx zeroTicketNo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -193,6 +193,8 @@ data InternalState m peer blk = IS {
 initInternalState
     :: forall m peer blk.
        ( MonadAsync m
+       , MonadFork m
+       , MonadMask m
        , ProtocolLedgerView blk
        , Ord peer
        , TraceConstraints peer blk
@@ -203,7 +205,7 @@ initInternalState
 initInternalState NodeParams {..} = do
     varCandidates  <- atomically $ newTVar mempty
     varState       <- atomically $ newTVar initState
-    mempool        <- openMempool chainDB (ledgerConfigView cfg)
+    mempool        <- openMempool threadRegistry chainDB (ledgerConfigView cfg)
 
     fetchClientRegistry <- newFetchClientRegistry
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -309,6 +309,15 @@ forkBlockProduction IS{..} =
           Just proof -> do
             (prevPoint, prevNo) <- prevPointAndBlockNo currentSlot <$>
                                      ChainDB.getCurrentChain chainDB
+
+            -- In this circumstance, it is required that we call 'syncState'
+            -- before 'getTxs' within this 'STM' transaction since we need to
+            -- guarantee that the transactions returned from 'getTxs' are
+            -- valid with respect to the current ledger state of the
+            -- 'ChainDB'. Refer to the 'getTxs' documentation for more
+            -- information.
+            _invalidTxs         <- syncState mempool
+
             txs                 <- getTxs mempool
             newBlock            <- runProtocol varDRG $
                                      produceBlock

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -47,6 +47,7 @@ import           Ouroboros.Consensus.ChainSyncClient
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Mempool
+import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo)
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.Condense
@@ -69,7 +70,7 @@ data NodeKernel m peer blk = NodeKernel {
       getChainDB :: ChainDB m blk (Header blk)
 
       -- | The node's mempool
-    , getMempool :: Mempool m blk
+    , getMempool :: Mempool m blk TicketNo
 
       -- | The node's static configuration
     , getNodeConfig :: NodeConfig (BlockProtocol blk)
@@ -186,7 +187,7 @@ data InternalState m peer blk = IS {
     , varCandidates       :: TVar m (Map peer (TVar m (CandidateState blk)))
     , varState            :: TVar m (NodeState (BlockProtocol blk))
     , tracer              :: Tracer m String
-    , mempool             :: Mempool m blk
+    , mempool             :: Mempool m blk TicketNo
     }
 
 initInternalState
@@ -316,7 +317,7 @@ forkBlockProduction IS{..} =
                                        currentSlot
                                        (castPoint prevPoint)
                                        prevNo
-                                       (Foldable.toList txs)
+                                       (Foldable.toList . (fmap fst) $ txs)
             return $ Just newBlock
 
       whenJust mNewBlock $ \newBlock -> do

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -112,6 +112,7 @@ protocolHandlers
        , MonadThrow (STM m)
        , MonadTime  m
        , MonadThrow m
+       , ApplyTx blk
        , ProtocolLedgerView blk
        , Condense (Header blk)
        , Condense (ChainHash blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/TxSubmission.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/TxSubmission.hs
@@ -22,7 +22,7 @@ localTxSubmissionServer
      , Condense (GenTx blk)
      )
   => Tracer m String
-  -> Mempool m blk
+  -> Mempool m blk idx
   -> LocalTxSubmissionServer (GenTx blk) String m ()
 localTxSubmissionServer tracer Mempool{addTxs} =
     server

--- a/ouroboros-consensus/src/Ouroboros/Consensus/TxSubmission.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/TxSubmission.hs
@@ -27,7 +27,7 @@ localTxSubmissionServer
 localTxSubmissionServer tracer Mempool{addTxs} =
     server
   where
-    server = LocalTxSubmissionServer {
+    server = undefined {- LocalTxSubmissionServer {
       recvMsgSubmitTx = \tx -> do
         traceWith tracer (condense tx)
         res <- addTxs [tx]
@@ -38,5 +38,5 @@ localTxSubmissionServer tracer Mempool{addTxs} =
           _           -> return (Nothing,         server),
 
       recvMsgDone = ()
-    }
+    } -}
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/TxSubmission.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/TxSubmission.hs
@@ -19,6 +19,7 @@ import           Ouroboros.Consensus.Util.Condense
 localTxSubmissionServer
   :: ( Monad m
      , Show (ApplyTxErr blk) -- TODO: consider using condense
+     , ApplyTx blk
      , Condense (GenTx blk)
      )
   => Tracer m String
@@ -27,10 +28,11 @@ localTxSubmissionServer
 localTxSubmissionServer tracer Mempool{addTxs} =
     server
   where
-    server = undefined {- LocalTxSubmissionServer {
+    server = LocalTxSubmissionServer {
       recvMsgSubmitTx = \tx -> do
         traceWith tracer (condense tx)
-        res <- addTxs [tx]
+        let txid = computeGenTxId tx
+        res <- addTxs [(txid, tx)]
         -- The 'addTxs' action returns the failing ones, whereas the protocol
         -- returns a Maybe failure for a single tx, so we must convert here.
         case res of
@@ -38,5 +40,5 @@ localTxSubmissionServer tracer Mempool{addTxs} =
           _           -> return (Nothing,         server),
 
       recvMsgDone = ()
-    } -}
+    }
 


### PR DESCRIPTION
The main patch here adds a new representation for the mempool transaction sequence.
    
Instead of using a normal `Data.Sequence`, `TxSeq` is also a fingertree based sequence but with some extra capabilities.

The idea is that we assign a monotonically increasing ticket number to each transaction in the sequence. Ssince we only add txs at the back then the sequence is kept in order by ticket number.

We can then use these ticket numbers for identifying txs for lookup efficient later. We can also use them for readers to quickly determine which txs they have seen before and which are new. This works by the reader remembering the ticket number of the last tx it saw and using an efficient operation to split the sequence on a ticket number. All subsequent tickets are ones that are new.

This patch introduces the new representation but does not yet adapt the mempool implementation to use it.