### PR TITLE
tx submission logic

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -73,6 +73,9 @@ library
                        Ouroboros.Network.Protocol.LocalTxSubmission.Client
                        Ouroboros.Network.Protocol.LocalTxSubmission.Server
                        Ouroboros.Network.Protocol.LocalTxSubmission.Codec
+                       Ouroboros.Network.TxSubmission.Inbound
+                       Ouroboros.Network.TxSubmission.Outbound
+
   default-language:    Haskell2010
   other-extensions:    BangPatterns,
                        DataKinds,
@@ -184,6 +187,8 @@ test-suite tests
                        Ouroboros.Network.Protocol.LocalTxSubmission.Test
                        Ouroboros.Network.Socket
                        Ouroboros.Network.Server.Socket
+                       Ouroboros.Network.TxSubmission.Inbound
+                       Ouroboros.Network.TxSubmission.Outbound
 
                        Test.AnchoredFragment
                        Test.Chain

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Direct.hs
@@ -57,6 +57,7 @@ directPipelined (TxSubmissionServerPipelined server)
     directSender q (CollectPipelined (Just server') _) client =
       directSender q server' client
 
-    directSender (ConsQ c q) (CollectPipelined _ collect) client =
-      directSender q (collect c) client
+    directSender (ConsQ c q) (CollectPipelined _ collect) client = do
+      server' <- collect c
+      directSender q server' client
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Server.hs
@@ -84,9 +84,9 @@ data ServerStIdle (n :: N) txid tx m a where
   -- | Collect a pipelined result.
   --
   CollectPipelined
-    :: Maybe              (ServerStIdle (S n) txid tx m a)
-    -> (Collect txid tx -> ServerStIdle    n  txid tx m a) --TODO put in m
-    ->                     ServerStIdle (S n) txid tx m a
+    :: Maybe                 (ServerStIdle (S n) txid tx m a)
+    -> (Collect txid tx -> m (ServerStIdle    n  txid tx m a))
+    ->                        ServerStIdle (S n) txid tx m a
 
 
 -- | Transform a 'TxSubmissionServerPipelined' into a 'PeerPipelined'.
@@ -139,5 +139,5 @@ txSubmissionServerPeerPipelined (TxSubmissionServerPipelined server) =
     go (CollectPipelined mNone collect) =
       SenderCollect
         (fmap go mNone)
-        (go . collect)
+        (SenderEffect . fmap go . collect)
 

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Inbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Inbound.hs
@@ -1,0 +1,310 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE BangPatterns        #-}
+
+module Ouroboros.Network.TxSubmission.Inbound (
+    txSubmissionInbound,
+    TxSubmissionMempoolWriter(..),
+    TraceTxSubmissionInbound(..),
+    TxSubmissionProtocolError(..),
+  ) where
+
+import qualified Data.List.NonEmpty as NonEmpty
+import           Data.Word (Word16)
+import qualified Data.Set as Set
+import qualified Data.Map.Strict as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Sequence as Seq
+import           Data.Sequence (Seq)
+import           Data.Foldable (foldl')
+
+import           Control.Monad (unless)
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Exception (assert)
+import           Control.Tracer (Tracer)
+
+import           Network.TypedProtocol.Pipelined (N, Nat(..))
+
+import           Ouroboros.Network.Protocol.TxSubmission.Server
+
+
+
+-- | The consensus layer functionality that the inbound side of the tx
+-- submission logic requires.
+--
+-- This is provided to the tx submission logic by the consensus layer.
+--
+data TxSubmissionMempoolWriter txid tx idx m =
+     TxSubmissionMempoolWriter {
+
+       -- | Compute the transaction id from a transaction.
+       --
+       -- This is used in the protocol handler to verify a full transaction
+       -- matches a previously given transaction id.
+       --
+       txId :: tx -> txid,
+
+       -- | Supply a batch of transactions to the mempool. They are either
+       -- accepted or rejected individually, but in the order supplied.
+       --
+       mempoolAddTxs :: [tx] -> m ()
+       -- TODO: we will need the txids of the ones that were added successfully
+    }
+
+data TraceTxSubmissionInbound txid tx = TraceTxSubmissionInbound --TODO
+  deriving Show
+
+data TxSubmissionProtocolError =
+       ProtocolErrorTxNotRequested
+
+  deriving Show
+
+instance Exception TxSubmissionProtocolError where
+  displayException ProtocolErrorTxNotRequested =
+      "The peer replied with a transaction we did not ask for."
+
+
+-- | Information maintained internally in the 'txSubmissionInbound' server
+-- implementation.
+--
+data ServerState txid tx = ServerState {
+       -- | The number of transaction identifiers that we have requested but
+       -- which have not yet been replied to. We need to track this it keep
+       -- our requests within the limit on the number of unacknowledged txids.
+       --
+       requestedTxIdsInFlight :: Word16,
+
+       -- | Those transactions (by their identifier) that the client has told
+       -- us about, and which we have not yet acknowledged. This is kept in
+       -- the order in which the client gave them to us. This is the same order
+       -- in which we submit them to the mempool (or for this example, the final
+       -- result order). It is also the order we acknowledge in.
+       unacknowledgedTxIds :: Seq txid,
+
+       -- | Those transactions (by their identifier) that we can request. These
+       -- are a subset of the 'unacknowledgedTxIds' that we have not yet
+       -- requested. This is not ordered to illustrate the fact that we can
+       -- request txs out of order. We also remember the size.
+       availableTxids      :: Map txid TxSizeInBytes,
+
+       -- | Transactions we have successfully downloaded but have not yet added
+       -- to the mempool or acknowledged. This needed because we can request
+       -- transactions out of order but must use the original order when adding
+       -- to the mempool or acknowledging transactions.
+       --
+       bufferedTxs         :: Map txid (Maybe tx),
+
+       -- | The number of transactions we can acknowledge on our next request
+       -- for more transactions. The number here have already been removed from
+       -- 'unacknowledgedTxIds'.
+       --
+       numTxsToAcknowledge :: Word16
+     }
+  deriving Show
+
+initialServerState :: ServerState txid tx
+initialServerState = ServerState 0 Seq.empty Map.empty Map.empty 0
+
+
+txSubmissionInbound
+  :: forall txid tx idx m.
+     (Ord txid, Ord idx, MonadSTM m, MonadThrow m)
+  => Tracer m (TraceTxSubmissionInbound txid tx)
+  -> Word16         -- ^ Maximum number of unacknowledged txids allowed
+  -> TxSubmissionMempoolWriter txid tx idx m
+  -> TxSubmissionServerPipelined txid tx m ()
+txSubmissionInbound _tracer maxUnacked TxSubmissionMempoolWriter{..} =
+    TxSubmissionServerPipelined (serverIdle Zero initialServerState)
+  where
+    --TODO: replace these fixed limits by policies based on TxSizeInBytes
+    -- and delta-Q and the bandwidth/delay product.
+    -- These numbers are for demo purposes only, the throughput will be low.
+    maxTxIdsToRequest = 3 :: Word16
+    maxTxToRequest    = 2 :: Word16
+
+    serverIdle :: forall (n :: N).
+                  Nat n
+               -> ServerState txid tx
+               -> ServerStIdle n txid tx m ()
+    serverIdle Zero st
+        -- There are no replies in flight, but we do know some more txs we can
+        -- ask for, so lets ask for them and more txids.
+      | canRequestMoreTxs st
+      = serverReqTxs Zero st
+
+        -- There's no replies in flight, and we have no more txs we can ask for
+        -- so the only remaining thing to do is to ask for more txids. Since
+        -- this is the only thing to do now, we make this a blocking call.
+      | otherwise
+      , let numTxIdsToRequest = maxTxIdsToRequest `min` maxUnacked
+      = assert (requestedTxIdsInFlight st == 0
+             && Seq.null (unacknowledgedTxIds st)
+             && Map.null (availableTxids st)
+             && Map.null (bufferedTxs st)) $
+        SendMsgRequestTxIdsBlocking
+          (numTxsToAcknowledge st)
+          numTxIdsToRequest
+          ()                -- Our result if the client terminates the protocol
+          ( handleReply Zero st {
+              numTxsToAcknowledge    = 0,
+              requestedTxIdsInFlight = numTxIdsToRequest
+            }
+          . CollectTxIds numTxIdsToRequest
+          . NonEmpty.toList)
+
+    serverIdle (Succ n) st
+        -- We have replies in flight and we should eagerly collect them if
+        -- available, but there are transactions to request too so we should
+        -- not block waiting for replies.
+        --
+        -- Having requested more transactions, we opportunistically ask for
+        -- more txids in a non-blocking way. This is how we pipeline asking for
+        -- both txs and txids.
+        --
+        -- It's important not to pipeline more requests for txids when we have
+        -- no txs to ask for, since (with no other guard) this will put us into
+        -- a busy-polling loop.
+        --
+      | canRequestMoreTxs st
+      = CollectPipelined
+          (Just (serverReqTxs (Succ n) st))
+          (handleReply n st)
+
+        -- In this case there is nothing else to do so we block until we
+        -- collect a reply.
+      | otherwise
+      = CollectPipelined
+          Nothing
+          (handleReply n st)
+
+    canRequestMoreTxs :: ServerState k tx -> Bool
+    canRequestMoreTxs st =
+        not (Map.null (availableTxids st))
+
+    handleReply :: forall (n :: N).
+                   Nat n
+                -> ServerState txid tx
+                -> Collect txid tx
+                -> m (ServerStIdle n txid tx m ())
+    handleReply n st (CollectTxIds reqNo txids) =
+      -- Upon receiving a batch of new txids we extend our available set,
+      -- and extended the unacknowledged sequence.
+      return $ serverIdle n st {
+        requestedTxIdsInFlight = requestedTxIdsInFlight st - reqNo,
+        unacknowledgedTxIds    = unacknowledgedTxIds st
+                              <> Seq.fromList (map fst txids),
+        availableTxids         = availableTxids st
+                              <> Map.fromList txids
+      }
+
+    handleReply n st (CollectTxs txids txs) = do
+
+      -- To start with we have to verify that the txs they have sent us do
+      -- correspond to the txs we asked for. This is slightly complicated by
+      -- the fact that in general we get a subset of the txs that we asked for.
+      -- We should never get a tx we did not ask for. We take a strict approch
+      -- to this and check it.
+      --
+      let txsMap :: Map txid tx
+          txsMap = Map.fromList [ (txId tx, tx) | tx <- txs ]
+
+          txidsReceived  = Map.keysSet txsMap
+          txidsRequested = Set.fromList txids
+
+      unless (txidsReceived `Set.isSubsetOf` txidsRequested) $
+        throwM ProtocolErrorTxNotRequested
+
+          -- We can match up all the txids we requested, with those we received.
+      let txIdsRequestedWithTxsReceived :: Map txid (Maybe tx)
+          txIdsRequestedWithTxsReceived =
+              Map.map Just txsMap
+           <> Map.fromSet (const Nothing) txidsRequested
+
+          -- We still have to acknowledge the txids we were given. This
+          -- combined with the fact that we request txs out of order means our
+          -- bufferedTxs has to track all the txids we asked for, even though
+          -- not all have replies.
+          bufferedTxs' = bufferedTxs st <> txIdsRequestedWithTxsReceived
+
+          -- We have to update the unacknowledgedTxIds here eagerly and not
+          -- delay it to serverReqTxs, otherwise we could end up blocking in
+          -- serverIdle on more pipelined results rather than being able to
+          -- move on.
+
+          -- Check if having received more txs we can now confirm any (in
+          -- strict order in the unacknowledgedTxIds sequence).
+          (acknowledgedTxIds, unacknowledgedTxIds') =
+            Seq.spanl (`Map.member` bufferedTxs') (unacknowledgedTxIds st)
+
+          -- If so we can submit the acknowledged txs to our local mempool
+          txsReady = foldr (\txid r -> maybe r (:r) (bufferedTxs' Map.! txid))
+                           [] acknowledgedTxIds
+
+          -- And remove acknowledged txs from our buffer
+          bufferedTxs'' = foldl' (flip Map.delete)
+                                 bufferedTxs' acknowledgedTxIds
+
+      mempoolAddTxs txsReady
+
+      return $ serverIdle n st {
+        bufferedTxs         = bufferedTxs'',
+        unacknowledgedTxIds = unacknowledgedTxIds',
+        numTxsToAcknowledge = numTxsToAcknowledge st
+                            + fromIntegral (Seq.length acknowledgedTxIds)
+      }
+
+
+    serverReqTxs :: forall (n :: N).
+                    Nat n
+                 -> ServerState txid tx
+                 -> ServerStIdle n txid tx m ()
+    serverReqTxs n st =
+        SendMsgRequestTxsPipelined
+          (Map.keys txsToRequest)
+          (pure $ serverReqTxIds (Succ n) st {
+                    availableTxids = availableTxids'
+                  })
+      where
+        -- TODO: This implementation is deliberately naive, we pick in an
+        -- arbitrary order and up to a fixed limit. This is to illustrate
+        -- that we can request txs out of order. In the final version we will
+        -- try to pick in-order and only pick out of order when we have to.
+        -- We will also uses the size of txs in bytes as our limit for
+        -- upper and lower watermarks for pipelining. We'll also use the
+        -- amount in flight and delta-Q to estimate when we're in danger of
+        -- becomming idle, and need to request stalled txs.
+        --
+        (txsToRequest, availableTxids') =
+          Map.splitAt (fromIntegral maxTxToRequest) (availableTxids st)
+
+    serverReqTxIds :: forall (n :: N).
+                      Nat n
+                   -> ServerState txid tx
+                   -> ServerStIdle n txid tx m ()
+    serverReqTxIds n st
+      | numTxIdsToRequest > 0
+      = SendMsgRequestTxIdsPipelined
+          (numTxsToAcknowledge st)
+          numTxIdsToRequest
+          (do pure $ serverIdle (Succ n) st {
+                requestedTxIdsInFlight = requestedTxIdsInFlight st
+                                       + numTxIdsToRequest,
+                numTxsToAcknowledge    = 0
+              })
+
+      | otherwise
+      = serverIdle n st
+      where
+        -- This definition is justified by the fact that the
+        -- 'numTxsToAcknowledge' are not included in the 'unacknowledgedTxIds'.
+        numTxIdsToRequest =
+                (maxUnacked
+                  - fromIntegral (Seq.length (unacknowledgedTxIds st))
+                  - requestedTxIdsInFlight st)
+          `min` maxTxIdsToRequest
+

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
@@ -1,0 +1,221 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE BangPatterns        #-}
+
+module Ouroboros.Network.TxSubmission.Outbound (
+    txSubmissionOutbound,
+    TxSubmissionMempoolReader(..),
+    TraceTxSubmissionOutbound(..),
+    TxSubmissionProtocolError(..),
+  ) where
+
+import           Data.Word (Word16)
+import           Data.Maybe (isNothing, catMaybes)
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map.Strict as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Sequence as Seq
+import           Data.Sequence (Seq)
+import           Data.Foldable (foldl')
+import qualified Data.Foldable as Foldable
+
+import           Control.Monad (when, unless)
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Exception (Exception(..), assert)
+import           Control.Tracer (Tracer)
+
+import           Ouroboros.Network.Protocol.TxSubmission.Client
+
+
+-- | The consensus layer functionality that the outbound side of the tx
+-- submission logic requires.
+--
+-- This is provided to the tx submission logic by the consensus layer.
+--
+data TxSubmissionMempoolReader txid tx idx m =
+     TxSubmissionMempoolReader {
+
+       -- | In STM, grab a snapshot of the contents of the mempool. This allows
+       -- further pure queries on the snapshot.
+       --
+       mempoolGetSnapshot  :: STM m (MempoolSnapshot txid tx idx),
+
+       -- | 'mempoolTxIdsAfter' with 'mempoolZeroIdx' is expected to give all
+       -- txs currently in the mempool.
+       mempoolZeroIdx      :: idx
+    }
+
+-- | A pure snapshot of the contents of the mempool. It allows fetching
+-- information about transactions in the mempool, and fetching individual
+-- transactions.
+--
+-- This uses a transaction sequence number type for identifying transactions
+-- within the mempool sequence. The sequence number is local to this mempool,
+-- unlike the transaction hash. This allows us to ask for all transactions
+-- after a known sequence number, to get new transactions. It is also used to
+-- look up individual transactions.
+--
+-- Note that it is expected that 'mempoolLookupTx' will often return 'Nothing'
+-- even for tx sequence numbers returned in previous snapshots. This happens
+-- when the transaction has been removed from the mempool between snapshots.
+--
+data MempoolSnapshot txid tx idx =
+     MempoolSnapshot {
+       mempoolTxIdsAfter :: idx -> [(txid, idx, TxSizeInBytes)],
+       mempoolLookupTx   :: idx -> Maybe tx
+     }
+
+data TraceTxSubmissionOutbound txid tx = TraceTxSubmissionOutbound --TODO
+  deriving Show
+
+data TxSubmissionProtocolError =
+       ProtocolErrorAckedTooManyTxids
+     | ProtocolErrorRequestedNothing
+     | ProtocolErrorRequestedTooManyTxids Word16 Word16
+     | ProtocolErrorRequestBlocking
+     | ProtocolErrorRequestNonBlocking
+     | ProtocolErrorRequestedUnavailableTx
+  deriving Show
+
+instance Exception TxSubmissionProtocolError where
+  displayException ProtocolErrorAckedTooManyTxids =
+      "The peer tried to acknowledged more txids than are available to do so."
+
+  displayException (ProtocolErrorRequestedTooManyTxids reqNo maxUnacked) =
+      "The peer requested " ++ show reqNo ++ " txids which would put the "
+   ++ "total in flight over the limit of " ++ show maxUnacked
+
+  displayException ProtocolErrorRequestedNothing =
+      "The peer requested zero txids."
+
+  displayException ProtocolErrorRequestBlocking =
+      "The peer made a blocking request for more txids when there are still "
+   ++ "unacknowledged txids. It should have used a non-blocking request."
+
+  displayException ProtocolErrorRequestNonBlocking =
+      "The peer made a non-blocking request for more txids when there are "
+   ++ "no unacknowledged txids. It should have used a blocking request."
+
+  displayException ProtocolErrorRequestedUnavailableTx =
+      "The peer requested a transaction which is not available, either " 
+   ++ "because it was never available or because it was previously requested."
+
+
+txSubmissionOutbound
+  :: forall txid tx idx m.
+     (Ord txid, Ord idx, MonadSTM m, MonadThrow m)
+  => Tracer m (TraceTxSubmissionOutbound txid tx)
+  -> Word16         -- ^ Maximum number of unacknowledged txids allowed
+  -> TxSubmissionMempoolReader txid tx idx m
+  -> TxSubmissionClient txid tx m ()
+txSubmissionOutbound _tracer maxUnacked TxSubmissionMempoolReader{..} =
+    TxSubmissionClient (pure (client Seq.empty Map.empty mempoolZeroIdx))
+  where
+    client :: Seq txid -> Map txid idx -> idx -> ClientStIdle txid tx m ()
+    client !unackedSeq !unackedMap !lastIdx =
+        assert invariant
+        ClientStIdle { recvMsgRequestTxIds, recvMsgRequestTxs }
+      where
+        invariant =
+          Map.isSubmapOfBy
+            (\_ _ -> True)
+            unackedMap
+            (Map.fromList [ (x, ()) | x <- Foldable.toList unackedSeq ])
+
+        recvMsgRequestTxIds :: forall blocking.
+                               TokBlockingStyle blocking
+                            -> Word16
+                            -> Word16
+                            -> m (ClientStTxIds blocking txid tx m ())
+        recvMsgRequestTxIds blocking ackNo reqNo = do
+
+          when (ackNo > fromIntegral (Seq.length unackedSeq)) $
+            throwM ProtocolErrorAckedTooManyTxids
+
+          when (  fromIntegral (Seq.length unackedSeq)
+                - ackNo
+                + fromIntegral reqNo
+                > maxUnacked) $
+            throwM (ProtocolErrorRequestedTooManyTxids reqNo maxUnacked)
+
+          -- Update our tracking state to remove the number of txids that the
+          -- peer has acknowledged.
+          let !unackedSeq' = Seq.drop (fromIntegral ackNo) unackedSeq
+              !unackedMap' = foldl' (flip Map.delete) unackedMap
+                                    (Seq.take (fromIntegral ackNo) unackedSeq)
+
+          -- Grab info about any new txs after the last tx idx we've seen,
+          -- up to  the number that the peer has requested.
+          txs <- case blocking of
+            TokBlocking -> do
+              when (reqNo == 0) $
+                throwM ProtocolErrorRequestedNothing
+              unless (Seq.null unackedSeq') $
+                throwM ProtocolErrorRequestBlocking
+
+              atomically $ do
+                MempoolSnapshot{mempoolTxIdsAfter} <- mempoolGetSnapshot
+                let txs = mempoolTxIdsAfter lastIdx
+                -- but block until there are some
+                check (not (null txs))
+                return (take (fromIntegral reqNo) txs)
+
+            TokNonBlocking -> do
+              when (reqNo == 0 && ackNo == 0) $
+                throwM ProtocolErrorRequestedNothing
+              when (Seq.null unackedSeq') $
+                throwM ProtocolErrorRequestNonBlocking
+
+              atomically $ do
+                MempoolSnapshot{mempoolTxIdsAfter} <- mempoolGetSnapshot
+                let txs = mempoolTxIdsAfter lastIdx
+                return (take (fromIntegral reqNo) txs)
+
+          -- These txs should all be fresh
+          assert (all (\(_, idx, _) -> idx > lastIdx) txs) (return ())
+
+          -- Update our tracking state with any extra txs available.
+          let !unackedSeq'' = unackedSeq' <> Seq.fromList
+                                [ txid | (txid, _, _) <- txs ]
+              !unackedMap'' = unackedMap' <> Map.fromList
+                                [ (txid, idx) | (txid, idx, _) <- txs ]
+              !lastIdx'
+                | null txs  = lastIdx
+                | otherwise = idx where (_, idx, _) = last txs
+              txs'         :: [(txid, TxSizeInBytes)]
+              txs'          = [ (txid, size) | (txid, _, size) <- txs ]
+              client'       = client unackedSeq'' unackedMap'' lastIdx'
+
+          -- Our reply type is different in the blocking vs non-blocking cases
+          return $! case blocking of
+            TokNonBlocking -> SendMsgReplyTxIds (NonBlockingReply txs') client'
+            TokBlocking    -> SendMsgReplyTxIds (BlockingReply   txs'') client'
+              where
+                Just txs'' = NonEmpty.nonEmpty txs'
+                -- Assert txs is non-empty: we blocked until txs was non-null,
+                -- and we know reqNo > 0, hence take reqNo txs is non-null.
+
+
+        recvMsgRequestTxs :: [txid]
+                          -> m (ClientStTxs txid tx m ())
+        recvMsgRequestTxs txids = do
+          MempoolSnapshot{mempoolLookupTx} <- atomically mempoolGetSnapshot
+
+          let txidxs  = [ Map.lookup txid unackedMap | txid <- txids ]
+              txidxs' = catMaybes txidxs
+
+          when (any isNothing txidxs) $
+            throwM ProtocolErrorRequestedUnavailableTx
+
+          -- The 'mempoolLookupTx' will return nothing if the transaction is no
+          -- longer in the mempool. This is good. Neither the sending nor
+          -- receiving side wants to forward txs that are no longer of interest.
+          let txs          = catMaybes (map mempoolLookupTx txidxs')
+              !unackedMap' = foldl' (flip Map.delete) unackedMap txids
+              client'      = client unackedSeq unackedMap' lastIdx
+
+          return $ SendMsgReplyTxs txs client'
+


### PR DESCRIPTION
Add a first version of tx submission logic. This covers both the inbound and outbound sides.

These are abstracted over interfaces with the consensus, and are not yet integrated with the consensus. These interfaces should match up reasonably closely now with the mempool API changes in #678. So the subsequent integration should not be too hard now.

The inbound side is based closely on the example tx submission server and so takes a very simplistic approach. There are a number of steps to take to get to the design we want here, but this should work for now.

The full design will pipeline based on the delta-Q, and try to avoid fetching the same tx from multiple peers.