### PR TITLE
Introduce distinguished GenesisPoint :: Point

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/State.hs
@@ -18,8 +18,7 @@ import qualified Data.Set as Set
 import           Cardano.Crypto.Hash
 
 import           Ouroboros.Network.Block (ChainHash, HasHeader, Point (..),
-                     StandardHash)
-import           Ouroboros.Network.Chain (genesisPoint)
+                     pointHash, StandardHash)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Mock.Address
@@ -67,5 +66,5 @@ genesisMockState :: AddrDist -> MockState blk
 genesisMockState addrDist = MockState {
       mockUtxo      = genesisUtxo addrDist
     , mockConfirmed = Set.singleton (hash (genesisTx addrDist))
-    , mockTip       = genesisPoint
+    , mockTip       = GenesisPoint
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -354,7 +354,8 @@ forkBlockProduction IS{..} =
                         -> AnchoredFragment (Header blk)
                         -> (Point blk, BlockNo)
     prevPointAndBlockNo slot c = case c of
-        Empty _   -> (Chain.genesisPoint, Chain.genesisBlockNo)
+         --TODO: it's not clear that genesisBlockNo is meaningful
+        Empty _   -> (GenesisPoint, Chain.genesisBlockNo)
         c' :> hdr -> case blockSlot hdr `compare` slot of
           LT -> (headerPoint hdr, blockNo hdr)
           -- The block at the tip of our chain has a slot that lies in the
@@ -366,7 +367,8 @@ forkBlockProduction IS{..} =
              -> (headerPoint hdr', blockNo hdr')
              | otherwise
                -- If there is no block before it, so use genesis.
-             -> (Chain.genesisPoint, Chain.genesisBlockNo)
+               --TODO: it's not clear that genesisBlockNo is meaningful
+             -> (GenesisPoint, Chain.genesisBlockNo)
 
     runProtocol :: TVar m ChaChaDRG -> ProtocolM blk m a -> STM m a
     runProtocol varDRG = simOuroborosStateT varState

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -115,7 +115,7 @@ protocolHandlers
        , ApplyTx blk
        , ProtocolLedgerView blk
        , Condense (Header blk)
-       , Condense (ChainHash blk)
+       , Condense (HeaderHash blk)
        , Condense peer
        , Show (ApplyTxErr blk)  --TODO: consider using condense
        , Condense (GenTx blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -12,7 +12,7 @@ import           Cardano.Crypto.Hash (Hash)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (ChainHash, HasHeader, Point (..),
+import           Ouroboros.Network.Block (HeaderHash, HasHeader, Point (..),
                      SlotNo (..))
 import           Ouroboros.Network.Chain (Chain (..))
 
@@ -25,7 +25,8 @@ import           Ouroboros.Consensus.Util.Condense
 instance Condense SlotNo where
   condense (SlotNo n) = condense n
 
-instance Condense (ChainHash block) => Condense (Point block) where
+instance Condense (HeaderHash block) => Condense (Point block) where
+    condense GenesisPoint = "GenesisPoint"
     condense (Point ptSlot ptHash) =
       "(Point " <> condense ptSlot <> ", " <> condense ptHash <> ")"
 
@@ -33,7 +34,7 @@ instance Condense block => Condense (Chain block) where
     condense Genesis   = "Genesis"
     condense (cs :> b) = condense cs <> " :> " <> condense b
 
-instance (Condense block, HasHeader block, Condense (ChainHash block))
+instance (Condense block, HasHeader block, Condense (HeaderHash block))
     => Condense (AnchoredFragment block) where
     condense (AF.Empty pt) = "EmptyAnchor " <> condense pt
     condense (cs AF.:> b)  = condense cs <> " :> " <> condense b

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Model.hs
@@ -40,7 +40,7 @@ import           GHC.Stack (HasCallStack)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as Fragment
 import           Ouroboros.Network.Block (ChainHash (..), ChainUpdate (..),
-                     HasHeader, HeaderHash, Point)
+                     HasHeader, HeaderHash, Point(..))
 import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Network.Chain (Chain (..))
 import qualified Ouroboros.Network.Chain as Chain
@@ -89,7 +89,7 @@ tipBlock :: Model blk -> Maybe blk
 tipBlock = Chain.head . currentChain
 
 tipPoint :: HasHeader blk => Model blk -> Point blk
-tipPoint = maybe Chain.genesisPoint Block.blockPoint . tipBlock
+tipPoint = maybe GenesisPoint Block.blockPoint . tipBlock
 
 lastK :: HasHeader a
       => SecurityParam
@@ -177,7 +177,7 @@ iteratorNext itrId m =
 newReader :: HasHeader blk => Model blk -> (CPS.ReaderId, Model blk)
 newReader m = (rdrId, m { cps = cps' })
   where
-    (cps', rdrId) = CPS.initReader Chain.genesisPoint (cps m)
+    (cps', rdrId) = CPS.initReader GenesisPoint (cps m)
 
 readerInstruction :: forall blk. HasHeader blk
                   => CPS.ReaderId

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -804,7 +804,7 @@ mkTestFetchedBlockHeap points = do
 --
 
 genesisChainFragment :: AF.AnchoredFragment BlockHeader
-genesisChainFragment = AF.Empty (Point 0 GenesisHash)
+genesisChainFragment = AF.Empty GenesisPoint
 
 shiftAnchoredFragment :: HasHeader block
                       => Int

--- a/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
@@ -93,7 +93,7 @@ import qualified Ouroboros.Network.ChainFragment as CF
 -- The fact that it is an /exclusive/ bound is particularly convenient when
 -- dealing with Genesis. Genesis is the start of the chain, but not an actual
 -- block, so we cannot use it an inclusive bound. However, there /is/ a
--- 'Point' that refers to Genesis ('Chain.genesisPoint'), which can be used as
+-- 'Point' that refers to Genesis ('GenesisPoint'), which can be used as
 -- the anchor point, acting as an exclusive bound.
 --
 -- An 'AnchoredFragment' anchored at Genesis, can thus be converted to a
@@ -402,17 +402,17 @@ applyChainUpdates (u:us) c = applyChainUpdates us =<< applyChainUpdate u c
 
 -- | Convert a 'Chain' to an 'AnchoredFragment'.
 --
--- The anchor of the fragment will be 'Chain.genesisPoint'.
+-- The anchor of the fragment will be 'GenesisPoint'.
 fromChain :: HasHeader block => Chain block -> AnchoredFragment block
-fromChain = mkAnchoredFragment Chain.genesisPoint . CF.unvalidatedFromChain
+fromChain = mkAnchoredFragment GenesisPoint . CF.unvalidatedFromChain
 
 -- | Convert an 'AnchoredFragment' to a 'Chain'.
 --
--- The anchor of the fragment must be 'Chain.genesisPoint', otherwise
+-- The anchor of the fragment must be 'GenesisPoint', otherwise
 -- 'Nothing' is returned.
 toChain :: HasHeader block => AnchoredFragment block -> Maybe (Chain block)
 toChain af@(AnchoredFragment a _)
-    | a == Chain.genesisPoint
+    | a == GenesisPoint
     = Just $ Chain.fromNewestFirst $ toNewestFirst af
     | otherwise
     = Nothing
@@ -431,7 +431,7 @@ anchorNewest = go CF.Empty
     -- Walk back over the chain, building up a chain fragment until k = 0 or
     -- we encountered genesis, then anchor the built-up chain fragment
     go :: ChainFragment block -> Word64 -> Chain block -> AnchoredFragment block
-    go cf _ Chain.Genesis   = mkAnchoredFragment Chain.genesisPoint cf
+    go cf _ Chain.Genesis   = mkAnchoredFragment GenesisPoint cf
     go cf 0 (_  Chain.:> b) = mkAnchoredFragment (blockPoint b)     cf
     go cf n (ch Chain.:> b) = go (b CF.:< cf) (n - 1) ch
 

--- a/ouroboros-network/src/Ouroboros/Network/Chain.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Chain.hs
@@ -25,7 +25,6 @@ module Ouroboros.Network.Chain (
   -- * Chain construction and inspection
   -- ** Genesis
   genesis,
-  genesisPoint,
   genesisSlotNo,
 --  genesisHash, -- TODO: currently (temporarily) exported by HasHeader
   genesisBlockNo,
@@ -108,9 +107,6 @@ genesisSlotNo = SlotNo 0
 genesisBlockNo :: BlockNo
 genesisBlockNo = BlockNo 0
 
-genesisPoint :: Point block
-genesisPoint = Point genesisSlotNo GenesisHash
-
 valid :: HasHeader block => Chain block -> Bool
 valid Genesis  = True
 valid (c :> b) = valid c && validExtension c b
@@ -126,7 +122,7 @@ head Genesis  = Nothing
 head (_ :> b) = Just b
 
 headPoint :: HasHeader block => Chain block -> Point block
-headPoint Genesis  = genesisPoint
+headPoint Genesis  = GenesisPoint
 headPoint (_ :> b) = blockPoint b
 
 headSlot :: HasHeader block => Chain block -> SlotNo
@@ -179,7 +175,7 @@ addBlock b c = assert (validExtension c b) $
                c :> b
 
 pointOnChain :: HasHeader block => Point block -> Chain block -> Bool
-pointOnChain p Genesis        = p == genesisPoint
+pointOnChain p Genesis        = p == GenesisPoint
 pointOnChain p (c :> b)
   | pointSlot p >  blockSlot b = False
   | pointSlot p == blockSlot b = pointHash p == BlockHash (blockHash b)
@@ -188,7 +184,7 @@ pointOnChain p (c :> b)
 rollback :: HasHeader block => Point block -> Chain block -> Maybe (Chain block)
 rollback p (c :> b) | blockPoint b == p = Just (c :> b)
                     | otherwise         = rollback p c
-rollback p Genesis  | p == genesisPoint = Just Genesis
+rollback p Genesis  | p == GenesisPoint = Just Genesis
                     | otherwise         = Nothing
 
 successorBlock :: HasHeader block => Point block -> Chain block -> Maybe block
@@ -197,7 +193,7 @@ successorBlock p c0 = go c0
   where
     go (c :> b' :> b) | blockPoint b' == p = Just b
                       | otherwise          = go (c :> b')
-    go (Genesis :> b) | p == genesisPoint  = Just b
+    go (Genesis :> b) | p == GenesisPoint  = Just b
     go _ = error "successorBlock: point not on chain"
 
 selectChain

--- a/ouroboros-network/src/Ouroboros/Network/ChainProducerState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainProducerState.hs
@@ -3,8 +3,9 @@
 
 module Ouroboros.Network.ChainProducerState where
 
-import           Ouroboros.Network.Chain (Chain, ChainUpdate (..), HasHeader,
-                     Point (..), blockPoint, genesisPoint, pointOnChain)
+import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader,
+                     Point (..), pointSlot, blockPoint)
+import           Ouroboros.Network.Chain (Chain, pointOnChain)
 import qualified Ouroboros.Network.Chain as Chain
 
 import           Control.Exception (assert)
@@ -187,7 +188,7 @@ switchFork :: HasHeader block
 switchFork c (ChainProducerState c' rs) =
     ChainProducerState c (map update rs)
   where
-    ipoint = fromMaybe genesisPoint $ Chain.intersectChains c c'
+    ipoint = fromMaybe GenesisPoint $ Chain.intersectChains c c'
 
     update r@ReaderState{readerPoint} =
       if pointOnChain readerPoint c

--- a/ouroboros-network/src/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Node.hs
@@ -82,7 +82,7 @@ chainValidation :: forall block m. (HasHeader block, MonadSTM m)
                 -> TVar m (Maybe (Chain block))
                 -> m ()
 chainValidation peerChainVar candidateChainVar = do
-    st <- atomically (newTVar Chain.genesisPoint)
+    st <- atomically (newTVar GenesisPoint)
     forever (atomically (update st))
   where
     update :: TVar m (Point block) -> STM m ()
@@ -202,7 +202,7 @@ observeChainProducerState
   -> TVar m (ChainProducerState block)
   -> m ()
 observeChainProducerState nid probe cpsVar = do
-    st <- atomically (newTVar Chain.genesisPoint)
+    st <- atomically (newTVar GenesisPoint)
     forever (update st)
   where
     update :: TVar m (Point block) -> m ()

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
@@ -42,10 +42,10 @@ codecBlockFetch encodeBody encodeHeaderHash
     mkCodecCborLazyBS encode decode
  where
   encodePoint' :: Point block -> CBOR.Encoding
-  encodePoint' = Block.encodePoint $ Block.encodeChainHash encodeHeaderHash
+  encodePoint' = Block.encodePoint encodeHeaderHash
 
   decodePoint' :: forall s. CBOR.Decoder s (Point block)
-  decodePoint' = Block.decodePoint $ Block.decodeChainHash decodeHeaderHash
+  decodePoint' = Block.decodePoint decodeHeaderHash
 
   encode :: forall (pr :: PeerRole) st st'.
             PeerHasAgency pr st

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -23,8 +23,8 @@ import           Network.TypedProtocol.Proofs
 
 import           Network.Mux.Channel
 
-import           Ouroboros.Network.Block (StandardHash)
-import           Ouroboros.Network.Chain (Chain, Point)
+import           Ouroboros.Network.Block (StandardHash, Point(..))
+import           Ouroboros.Network.Chain (Chain)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.Testing.ConcreteBlock (Block)
 
@@ -361,7 +361,7 @@ pointsToRanges chain points =
           Nothing -> ChainRange x y : go (y : ys)
           Just x' -> ChainRange (Chain.blockPoint x') y : go (y : ys)
         else ChainRange x y : go (y : ys)
-    go [x] = [ChainRange Chain.genesisPoint x]
+    go [x] = [ChainRange GenesisPoint x]
     go []  = []
 
 -- | Compute list of received block bodies from a chain and points.

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Examples.hs
@@ -180,7 +180,7 @@ chainSyncServerExample recvMsgDoneClient chainvar = ChainSyncServer $
     newReader :: m ReaderId
     newReader = atomically $ do
       cps <- readTVar chainvar
-      let (cps', rid) = ChainProducerState.initReader Chain.genesisPoint cps
+      let (cps', rid) = ChainProducerState.initReader GenesisPoint cps
       writeTVar chainvar cps'
       return rid
 

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -226,7 +226,7 @@ mkAnchoredFragment anchorpoint anchorblockno =
 
 mkAnchoredFragmentSimple :: [BlockBody] -> AnchoredFragment Block
 mkAnchoredFragmentSimple =
-    mkAnchoredFragment (Point 0 GenesisHash) (BlockNo 0) . zip [1..]
+    mkAnchoredFragment GenesisPoint (BlockNo 0) . zip [1..]
 
 
 mkPartialBlock :: SlotNo -> BlockBody -> Block

--- a/ouroboros-network/test/Test/AnchoredFragment.hs
+++ b/ouroboros-network/test/Test/AnchoredFragment.hs
@@ -85,7 +85,7 @@ prop_length_Empty :: Bool
 prop_length_Empty =
     AF.length (Empty anchor :: AnchoredFragment Block) == 0
   where
-    anchor = Chain.genesisPoint
+    anchor = GenesisPoint
 
 prop_dropNewest_Empty :: TestBlockAnchoredFragment -> Bool
 prop_dropNewest_Empty (TestBlockAnchoredFragment chain) =
@@ -249,7 +249,7 @@ prop_toChain_fromChain (TestBlockChain ch) =
 prop_anchorNewest :: NonNegative Int -> TestBlockChain -> Property
 prop_anchorNewest (NonNegative n') (TestBlockChain ch) =
     AF.length af === min (Chain.length ch) (fromIntegral n) .&&.
-    take n1 (map blockPoint (Chain.toNewestFirst ch) ++ [Chain.genesisPoint]) ===
+    take n1 (map blockPoint (Chain.toNewestFirst ch) ++ [GenesisPoint]) ===
              map blockPoint (AF.toNewestFirst af)    ++ [AF.anchorPoint af]
   where
     af = AF.anchorNewest n ch

--- a/ouroboros-network/test/Test/Chain.hs
+++ b/ouroboros-network/test/Test/Chain.hs
@@ -14,8 +14,9 @@ import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Ouroboros.Network.Block (blockPrevHash)
-import           Ouroboros.Network.Chain (Chain (..), Point (..), genesisPoint)
+import           Ouroboros.Network.Block
+                   ( Point (..), pointSlot, pointHash, blockPrevHash )
+import           Ouroboros.Network.Chain (Chain (..))
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.Testing.Serialise (prop_serialise)
 
@@ -107,7 +108,7 @@ prop_lookupBySlot :: TestChainAndPoint -> Bool
 prop_lookupBySlot (TestChainAndPoint c p) =
   case Chain.lookupBySlot c (pointSlot p) of
     Just b  -> Chain.pointOnChain (Chain.blockPoint b) c
-    Nothing | p == genesisPoint -> True
+    Nothing | p == GenesisPoint -> True
             | otherwise         -> not (Chain.pointOnChain p c)
 
 prop_selectBlockRange :: TestChainAndRange -> Bool

--- a/ouroboros-network/test/Test/ChainGenerators.hs
+++ b/ouroboros-network/test/Test/ChainGenerators.hs
@@ -110,12 +110,12 @@ instance Arbitrary ConcreteHeaderHash where
 instance Arbitrary (Point BlockHeader) where
   arbitrary =
       -- Sometimes pick the genesis point
-      frequency [ (1, pure (Point (SlotNo 0) GenesisHash))
-                , (4, Point <$> arbitrary <*> (BlockHash <$> arbitrary)) ]
-  shrink (Point _ GenesisHash)   = []
-  shrink (Point s (BlockHash h)) =
-      Point (SlotNo 0) GenesisHash
-    : [ Point s' (BlockHash h') | (s', h') <- shrink (s, h), s > SlotNo 0 ]
+      frequency [ (1, pure GenesisPoint)
+                , (4, Point <$> arbitrary <*> arbitrary) ]
+  shrink GenesisPoint   = []
+  shrink (Point s h) =
+      GenesisPoint
+    : [ Point s' h' | (s', h') <- shrink (s, h), s > SlotNo 0 ]
 
 instance Arbitrary (Point Block) where
   arbitrary = (castPoint :: Point BlockHeader -> Point Block) <$> arbitrary
@@ -529,7 +529,7 @@ instance Arbitrary TestChainAndPoints where
           , (5, return Nothing)
           ]
         points = map Chain.blockPoint (Chain.chainToList chain)
-                  ++ [Chain.genesisPoint]
+                  ++ [GenesisPoint]
     points' <- catMaybes <$> mapM fn points
     return $ TestChainAndPoints chain points'
 

--- a/ouroboros-network/test/Test/ChainProducerState.hs
+++ b/ouroboros-network/test/Test/ChainProducerState.hs
@@ -15,8 +15,8 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Ouroboros.Network.Chain (Chain, ChainUpdate (..), Point (..),
-                     genesisPoint, headPoint, pointOnChain)
+import           Ouroboros.Network.Block (ChainUpdate (..), Point (..), pointSlot)
+import           Ouroboros.Network.Chain (Chain, headPoint, pointOnChain)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState
 import           Ouroboros.Network.Testing.ConcreteBlock (Block (..))
@@ -209,7 +209,7 @@ instance Arbitrary ChainProducerStateTest where
     rs <- fixupReaderStates <$> listOf1 (genReaderState n c)
     rid <- choose (0, length rs - 1)
     p <- if n == 0
-         then return genesisPoint
+         then return GenesisPoint
          else mkRollbackPoint c <$> choose (0, n)
     return (ChainProducerStateTest (ChainProducerState c rs) rid p)
 

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -137,7 +137,7 @@ prop_blockFetchStaticWithOverlap (TestChainFork _common fork1 fork2) =
                     (contramap TraceFetchDecision       dynamicTracer)
                     (contramap TraceFetchClientState    dynamicTracer)
                     (contramap TraceFetchClientSendRecv dynamicTracer)
-                    (AnchoredFragment.Empty Chain.genesisPoint) forks
+                    (AnchoredFragment.Empty GenesisPoint) forks
 
      in counterexample ("\nTrace:\n" ++ unlines (map show trace)) $
 
@@ -160,7 +160,7 @@ prop_blockFetchStaticWithOverlap (TestChainFork _common fork1 fork2) =
 
 chainToAnchoredFragment :: Chain.Chain Block -> AnchoredFragment Block
 chainToAnchoredFragment =
-    AnchoredFragment.fromNewestFirst Chain.genesisPoint
+    AnchoredFragment.fromNewestFirst GenesisPoint
   . Chain.chainToList
 
 -- TODO: move elsewhere and generalise


### PR DESCRIPTION
This is an alternative starting point for the same goal as #635. It is based on the complain in https://github.com/input-output-hk/ouroboros-network/pull/635#pullrequestreview-256044624 that there's too much all changing at once. This PR attempts to do just the first step, but one that's a lot less disruptive. The goal would be to then consider doing the second step of distinguishing a block point from a point that may also refer to the genesis point.

This patch does leave a couple TODOs where there are dubious uses of `genesisSlot` / `Slot 0` or `genesisBlockNo`.

This changes the Point type from this:
```
data Point block = Point {
       pointSlot :: SlotNo,
       pointHash :: ChainHash block
     }
```
which relies on:
```
data ChainHash b = GenesisHash | BlockHash (HeaderHash b)
```
To this:
```
data Point block = GenesisPoint | Point !SlotNo !(HeaderHash block)
```
Everything else in the patch is just knock-on changes.

The motivation is to avoid having to say that a genesis point has a slot
number. Nevertheless, to avoid excessive disruption, this patch keeps
the old field names as functions
```
pointSlot :: Point block -> SlotNo
pointHash :: Point block -> ChainHash block
```
which are defined for the GenesisPoint following the previous convention:
```
pointSlot GenesisPoint   = SlotNo 0
pointHash GenesisPoint   = GenesisHash
```
To abolish even talking about the slot number for the genesis point will require a further, more disruptive, change: distinguishing between a point that can only refer to a block, and a point that may also be the genesis point. This patch is a possible step towards that.