### PR TITLE
[#685] [#669] Return newly added transactions from addTxs and add Mempool tracing

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -1,13 +1,18 @@
+{-# LANGUAGE FlexibleContexts        #-}
+{-# LANGUAGE StandaloneDeriving      #-}
 {-# LANGUAGE TypeFamilies            #-}
+{-# LANGUAGE UndecidableInstances    #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 module Ouroboros.Consensus.Mempool.API (
     Mempool(..)
   , MempoolSnapshot(..)
   , ApplyTx(..)
+  , TraceEventMempool(..)
   ) where
 
 import           Control.Monad.Except
+import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
 
 import           Control.Monad.Class.MonadSTM
@@ -107,24 +112,32 @@ data Mempool m blk idx = Mempool {
       -- could exist within the mempool until they are revalidated and dropped
       -- from the mempool via a call to either 'addTxs' or 'syncState'.
       --
-      -- This function will return a list potentially consisting of a few
-      -- different kinds of transactions:
+      -- This function will return a list containing the following
+      -- transactions:
       --
       -- * Those transactions provided which were found to be valid, along
       --   with 'Nothing' for their accompanying @Maybe (ApplyTxErr blk)@
       --   values.
       -- * Those transactions provided which were found to be invalid, along
       --   with their accompanying validation errors.
-      -- * Invalid transactions, with respect to the current ledger state,
-      --   that were found in the mempool which have now been dropped, along
-      --   with their accompanying validation errors.
       --
-      -- In principle it is possible that such validation errors are transient;
-      -- for example, it is possible that a transaction is rejected because one
-      -- of its inputs is not /yet/ available in the UTxO (the transaction it
+      -- The order of this returned list is undefined.
+      --
+      -- Note that previously valid transaction that are now invalid with
+      -- respect to the current ledger state are dropped from the mempool, but
+      -- are not part of the returned list.
+      --
+      -- POSTCONDITION: given some ordering @txOrd@ on @'GenTx' blk@:
+      --
+      -- > addTxs inTxs >>= \outTxs ->
+      -- >   sortBy txOrd inTxs == sortBy txOrd (map fst outTxs)
+      --
+      -- In principle it is possible that validation errors are transient; for
+      -- example, it is possible that a transaction is rejected because one of
+      -- its inputs is not /yet/ available in the UTxO (the transaction it
       -- depends on is not yet in the chain, nor in the mempool). In practice
-      -- however it is likely that rejected transactions will still be rejected
-      -- later, and should just be dropped.
+      -- however it is likely that rejected transactions will still be
+      -- rejected later, and should just be dropped.
       --
       -- It is important to note one important special case of transactions
       -- being "invalid": a transaction will /also/ be considered invalid if
@@ -136,7 +149,7 @@ data Mempool m blk idx = Mempool {
       -- they have already been included. Distinguishing between these two
       -- cases can be done in theory, but it is expensive unless we have an
       -- index of transaction hashes that have been included on the blockchain.
-      addTxs :: [GenTx blk] -> m [(GenTx blk, Maybe (ApplyTxErr blk))]
+      addTxs      :: [GenTx blk] -> m [(GenTx blk, Maybe (ApplyTxErr blk))]
 
       -- | Sync the transactions in the mempool with the current ledger state
       --  of the 'ChainDB'.
@@ -146,13 +159,14 @@ data Mempool m blk idx = Mempool {
       -- invalid, with respect to the current ledger state, will be dropped
       -- from the mempool, whereas valid transactions will remain.
       --
-      -- Transactions which are now invalid, with respect to the current ledger
-      -- state, will be returned along with their associated validation errors.
+      -- We keep this in @m@ instead of @STM m@ to leave open the possibility
+      -- of persistence. Additionally, this makes it possible to trace the
+      -- removal of invalid transactions.
       --
       -- n.b. in our current implementation, when one opens a mempool, we
       -- spawn a thread which performs this action whenever the 'ChainDB' tip
       -- point changes.
-    , syncState :: STM m [(GenTx blk, ApplyTxErr blk)]
+    , syncState   :: m ()
 
       -- | Get a snapshot of the current mempool state. This allows for
       -- further pure queries on the snapshot.
@@ -191,3 +205,31 @@ data MempoolSnapshot txid tx idx = MempoolSnapshot {
     -- number, if it exists.
   , getTx :: idx -> Maybe (txid, tx)
   }
+
+-- | Events traced by the Mempool.
+data TraceEventMempool blk
+   = TraceMempoolAddTxs
+     { _txs          :: [GenTx blk]
+       -- ^ New, valid transaction were added to the Mempool.
+     , _txsInMempool :: Word64
+       -- ^ The total number of transactions now in the Mempool.
+     }
+
+   | TraceMempoolRejectedTxs
+     { _txs          :: [GenTx blk]
+       -- ^ New, invalid transaction were rejected and thus not added to the
+       -- Mempool.
+     , _txsInMempool :: Word64
+       -- ^ The total number of transactions now in the Mempool.
+     }
+   | TraceMempoolRemoveTxs
+     { _txs          :: [GenTx blk]
+       -- ^ Previously valid transactions that are no longer valid because of
+       -- changes in the ledger state. These transactions have been removed
+       -- from the Mempool.
+     , _txsInMempool :: Word64
+       -- ^ The total number of transactions now in the Mempool.
+     }
+
+deriving instance Eq   (GenTx blk) => Eq   (TraceEventMempool blk)
+deriving instance Show (GenTx blk) => Show (TraceEventMempool blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ViewPatterns          #-}
 {-# LANGUAGE PatternSynonyms       #-}
+{-# LANGUAGE ViewPatterns          #-}
 
 module Ouroboros.Consensus.Mempool.TxSeq (
     TicketNo(..)
@@ -13,10 +13,10 @@ module Ouroboros.Consensus.Mempool.TxSeq (
   , zeroTicketNo
   ) where
 
-import           Data.Word (Word64)
-import qualified Data.Foldable as Foldable
 import           Data.FingerTree (FingerTree)
 import qualified Data.FingerTree as FingerTree
+import qualified Data.Foldable as Foldable
+import           Data.Word (Word64)
 
 
 {-------------------------------------------------------------------------------
@@ -58,6 +58,7 @@ newtype TxSeq tx = TxSeq (FingerTree TxSeqMeasure (TxTicket tx))
 instance Foldable TxSeq where
   foldMap f (TxSeq txs) = Foldable.foldMap (f . (\(TxTicket tx _) -> tx)) txs
   null      (TxSeq txs) = Foldable.null txs
+  length    (TxSeq txs) = mSize $ FingerTree.measure txs
 
 -- | The 'FingerTree' relies on a \"measure\" for subsequences in the tree.
 -- A measure of the size of the subsequence allows for efficient sequence

--- a/ouroboros-consensus/src/Ouroboros/Consensus/TxSubmission.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/TxSubmission.hs
@@ -31,8 +31,7 @@ localTxSubmissionServer tracer Mempool{addTxs} =
     server = LocalTxSubmissionServer {
       recvMsgSubmitTx = \tx -> do
         traceWith tracer (condense tx)
-        let txid = computeGenTxId tx
-        res <- addTxs [(txid, tx)]
+        res <- addTxs [tx]
         -- The 'addTxs' action returns the failing ones, whereas the protocol
         -- returns a Maybe failure for a single tx, so we must convert here.
         case res of

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -130,7 +130,7 @@ testAddTxsWithMempoolAndSnapshot bc txs prop =
   tabulate "Transactions" (map constrName txs) $
   runSimOrThrow $
   withOpenMempool bc $ \mempool -> do
-    let genTxs = testTxsToGenTxPairs txs
+    let genTxs = map TestGenTx txs
         Mempool
           { addTxs
           , getSnapshot

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -4,7 +4,7 @@
 
 module Test.Consensus.Mempool (tests) where
 
-import           Data.List (foldl')
+import           Data.List (find, foldl', sort)
 
 import           Test.QuickCheck (Property, Testable, classify, counterexample,
                      tabulate, (===))
@@ -15,15 +15,17 @@ import           Control.Monad.Class.MonadAsync (MonadAsync)
 import           Control.Monad.Class.MonadFork (MonadFork)
 import           Control.Monad.Class.MonadSTM (MonadSTM, STM, atomically)
 import           Control.Monad.Class.MonadThrow (MonadMask, MonadThrow)
-import           Control.Monad.IOSim (runSimOrThrow)
+import           Control.Monad.IOSim (SimM, runSimOrThrow, runSimTrace,
+                     selectTraceEventsDynamic, traceM)
 
-import           Control.Tracer (nullTracer)
+import           Control.Tracer (Tracer (..), nullTracer)
 
 import           Data.Maybe (isJust)
+import           Data.Typeable (Typeable)
 
 import           Ouroboros.Consensus.Ledger.Abstract (ledgerConfigView)
 import           Ouroboros.Consensus.Mempool (Mempool (..),
-                     MempoolSnapshot (..), openMempool)
+                     MempoolSnapshot (..), TraceEventMempool (..), openMempool)
 import           Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Util.ThreadRegistry (withThreadRegistry)
 
@@ -46,6 +48,8 @@ tests = testGroup "Mempool"
   , testProperty "getTxs == getTxsAfter zeroIdx"        prop_Mempool_getTxs_getTxsAfter
   , testProperty "addedTxs == getTxs"                   prop_Mempool_addTxs_getTxs
   , testProperty "Invalid transactions are never added" prop_Mempool_InvalidTxsNeverAdded
+  , testProperty "Added valid transactions are traced"  prop_Mempool_TraceValidTxs
+  , testProperty "Rejected invalid txs are traced"      prop_Mempool_TraceRejectedTxs
   ]
 
 {-------------------------------------------------------------------------------
@@ -108,6 +112,60 @@ prop_Mempool_InvalidTxsNeverAdded bc txs =
     genTxIsInvalid (TestGenTx (InvalidTestTx _)) = True
     genTxIsInvalid _                             = False
 
+-- | Test that all valid transactions added to a 'Mempool' via 'addTxs' are
+-- appropriately represented in the trace of events.
+prop_Mempool_TraceValidTxs :: Chain TestBlock
+                           -> [TestTx]
+                           -> Property
+prop_Mempool_TraceValidTxs bc txs =
+    testAddTxsWithTrace bc txs traceProp
+  where
+    traceProp :: [GenTx TestBlock] -> [TraceEventMempool TestBlock] -> Property
+    traceProp genTxs es =
+        let addedTxs = maybe
+                (error "prop_Mempool_TraceValidTxs: No TraceMempoolAddTxs traces")
+                (\(TraceMempoolAddTxs ts _) -> ts)
+                (find isAddTxsEvent es)
+        in sort (filter genTxIsValid genTxs) === sort addedTxs
+    --
+    genTxIsValid :: GenTx TestBlock -> Bool
+    genTxIsValid (TestGenTx (ValidTestTx _)) = True
+    genTxIsValid _                           = False
+    --
+    isAddTxsEvent :: TraceEventMempool blk -> Bool
+    isAddTxsEvent (TraceMempoolAddTxs _ _) = True
+    isAddTxsEvent _                        = False
+
+-- | Test that all invalid rejected transactions returned from 'addTxs' are
+-- appropriately represented in the trace of events.
+prop_Mempool_TraceRejectedTxs :: Chain TestBlock
+                              -> [TestTx]
+                              -> Property
+prop_Mempool_TraceRejectedTxs bc txs =
+    testAddTxsWithTrace bc txs traceProp
+  where
+    traceProp :: [GenTx TestBlock] -> [TraceEventMempool TestBlock] -> Property
+    traceProp genTxs es =
+        let rejectedTxs = maybe
+                (error "prop_Mempool_TraceRejectedTxs: No TraceMempoolRejectedTxs traces")
+                (\(TraceMempoolRejectedTxs ts _) -> ts)
+                (find isRejectedTxsEvent es)
+        in sort (filter genTxIsInvalid genTxs) === sort rejectedTxs
+    --
+    genTxIsInvalid :: GenTx TestBlock -> Bool
+    genTxIsInvalid (TestGenTx (InvalidTestTx _)) = True
+    genTxIsInvalid _                             = False
+    --
+    isRejectedTxsEvent :: TraceEventMempool blk -> Bool
+    isRejectedTxsEvent (TraceMempoolRejectedTxs _ _) = True
+    isRejectedTxsEvent _                             = False
+
+-- TODO: Need to add a property which also tests 'TraceRemovedTxs' traces.
+--       However, the 'TestTx' implementation must be extended before we can
+--       do so as there is currently no way for 'ValidTestTx' transactions in
+--       the 'Mempool' to become invalid and, therefore, removed from the
+--       'Mempool'.
+
 {-------------------------------------------------------------------------------
   Helpers
 -------------------------------------------------------------------------------}
@@ -133,7 +191,7 @@ testAddTxsWithMempoolAndSnapshot
 testAddTxsWithMempoolAndSnapshot bc txs prop =
   tabulate "Transactions" (map constrName txs) $
   runSimOrThrow $
-  withOpenMempool bc $ \mempool -> do
+  withOpenMempool bc nullTracer $ \mempool -> do
     let genTxs = map TestGenTx txs
         Mempool
           { addTxs
@@ -146,6 +204,22 @@ testAddTxsWithMempoolAndSnapshot bc txs prop =
       counterexampleMempoolInfo genTxs invalidTxs getTxs $
       classifyMempoolSize getTxs $
       prop mempool snapshot
+
+testAddTxsWithTrace
+  :: Testable prop
+  => Chain TestBlock
+  -> [TestTx]
+  -> ([GenTx TestBlock] -> [TraceEventMempool TestBlock] -> prop)
+  -> Property
+testAddTxsWithTrace bc txs prop = do
+  let genTxs = map TestGenTx txs
+      trace  = selectTraceEventsDynamic $
+               runSimTrace $
+               withOpenMempool bc dynamicTracer $ \mempool -> do
+                 let Mempool{addTxs} = mempool
+                 addTxs genTxs
+  counterexample ("\nTrace:\n" ++ unlines (map show trace)) $
+    prop genTxs trace
 
 openDB :: forall m.
           ( MonadSTM m
@@ -166,13 +240,14 @@ withOpenMempool :: ( MonadSTM m
                    , MonadAsync m
                    )
                 => Chain TestBlock
+                -> Tracer m (TraceEventMempool TestBlock)
                 -> (Mempool m TestBlock TicketNo -> m a)
                 -> m a
-withOpenMempool bc action = do
+withOpenMempool bc tracer action = do
   chainDb <- ChainDB.fromChain openDB bc
   withThreadRegistry $ \registry -> do
     let cfg = ledgerConfigView singleNodeTestConfig
-    action =<< openMempool registry chainDb cfg nullTracer
+    action =<< openMempool registry chainDb cfg tracer
 
 -- | Classify whether we're testing against an empty or non-empty 'Mempool' in
 -- each test case.
@@ -203,8 +278,11 @@ counterexampleMempoolInfo txsToAdd invalidTxs txsInMempool prop =
 constrName :: Show a => a -> String
 constrName = head . words . show
 
+dynamicTracer :: Typeable a => Tracer (SimM s) a
+dynamicTracer = Tracer traceM
+
 {-------------------------------------------------------------------------------
-  TxSeq
+  TxSeq Properties
 -------------------------------------------------------------------------------}
 
 prop_TxSeq_lookupByTicketNo :: [Int] -> Bool
@@ -217,4 +295,3 @@ prop_TxSeq_lookupByTicketNo xs =
     txseq :: TxSeq Int
     txseq = foldl' (TxSeq.:>) TxSeq.Empty
                    (zipWith TxTicket xs (map TicketNo [0..]))
-

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -229,6 +229,7 @@ broadcastNetwork registry btime numCoreNodes pInfo initRNG numSlots = do
 
       let nodeParams = NodeParams
             { tracer             = nullTracer
+            , mempoolTracer      = nullTracer
             , threadRegistry     = registry
             , maxClockSkew       = ClockSkew 1
             , cfg                = pInfoConfig

--- a/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
@@ -228,7 +228,7 @@ newtype TestTxError = TestTxErrorInvalid TestTx
 instance ApplyTx TestBlock where
   newtype GenTx TestBlock = TestGenTx
     { testGenTx :: TestTx
-    } deriving (Show, Eq)
+    } deriving (Show, Eq, Ord)
 
   newtype GenTxId TestBlock = TestGenTxId
     { testGenTxId :: TestTxId


### PR DESCRIPTION
Closes #685 and #669.

addTxs should return both valid transactions which have been newly added to the Mempool, as well as all invalid transactions not added to or removed from the Mempool.