### PR TITLE
Add Show constraints to RunDemo type class

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Ledger/Mock.hs
@@ -34,6 +34,7 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
            -- @-O0@ it is perfectly fine. ghc bug?!
          , SupportedBlock (SimpleBlock SimpleMockCrypto ext)
          , Condense ext
+         , Show ext
          , Typeable ext
          , Serialise ext
          , ForgeExt (BlockProtocol (SimpleBlock SimpleMockCrypto ext))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Run.hs
@@ -63,9 +63,11 @@ class ( ProtocolLedgerView blk
       , Condense (ChainHash blk)
       , Condense blk
       , Condense [blk]
+      , Show blk
       , ApplyTx blk
       , Show (ApplyTxErr blk)
       , Condense (GenTx blk)
+      , Show (GenTx blk)
       ) => RunDemo blk where
   demoForgeBlock         :: (HasNodeState (BlockProtocol blk) m, MonadRandom m)
                          => NodeConfig (BlockProtocol blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -525,6 +525,9 @@ instance Condense (GenTx (ByronBlock cfg)) where
       ", witness: " <> show (CC.UTxO.aTaWitness tx) <>
       ")"
 
+instance Show (GenTx (ByronBlock cfg)) where
+    show tx = condense tx
+
 {-------------------------------------------------------------------------------
   Serialisation
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -265,6 +265,9 @@ instance HasUtxo (GenTx (SimpleBlock p c)) where
 instance Condense (GenTx (SimpleBlock p c)) where
     condense (SimpleGenTx tx) = condense tx
 
+instance Show (GenTx (SimpleBlock p c)) where
+    show (SimpleGenTx tx) = condense tx
+
 {-------------------------------------------------------------------------------
   Crypto needed for simple blocks
 -------------------------------------------------------------------------------}


### PR DESCRIPTION
This for support of tracers used by ouroboros-network library.  We don't
have access to Condense type class there, and thus we only can use
Show constraints.

These instances are not used here in `ouroboros-consensus` but they will be useful in `cardano-node`.