### PR TITLE
Better Point type factoring, again

### DIFF
--- a/byron-proxy/src/exec/Logging.hs
+++ b/byron-proxy/src/exec/Logging.hs
@@ -81,6 +81,8 @@ defaultLoggerConfig = Monitoring.Representation
   , Monitoring.hasPrometheus   = Nothing
   , Monitoring.hasGUI          = Nothing
   , Monitoring.options         = mempty
+  , Monitoring.hasGraylog      = Nothing
+  , Monitoring.logOutput       = Nothing
   }
   where
   stdoutScribe = Monitoring.ScribeDefinition

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -143,7 +143,7 @@ chainSyncClient
        , MonadThrow (STM m)
        , ProtocolLedgerView blk
        , Condense (Header blk)
-       , Condense (ChainHash blk)
+       , Condense (HeaderHash blk)
        )
     => Tracer m String
     -> NodeConfig (BlockProtocol blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/State.hs
@@ -18,7 +18,7 @@ import qualified Data.Set as Set
 import           Cardano.Crypto.Hash
 
 import           Ouroboros.Network.Block (ChainHash, HasHeader, Point (..),
-                     StandardHash)
+                     StandardHash, pointHash)
 import           Ouroboros.Network.Chain (genesisPoint)
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -115,7 +115,7 @@ protocolHandlers
        , ApplyTx blk
        , ProtocolLedgerView blk
        , Condense (Header blk)
-       , Condense (ChainHash blk)
+       , Condense (HeaderHash blk)
        , Condense peer
        , Show (ApplyTxErr blk)  --TODO: consider using condense
        , Condense (GenTx blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -12,9 +12,11 @@ import           Cardano.Crypto.Hash (Hash)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (ChainHash, HasHeader, Point (..),
+import           Ouroboros.Network.Block (HasHeader, HeaderHash, Point (..),
                      SlotNo (..))
 import           Ouroboros.Network.Chain (Chain (..))
+import           Ouroboros.Network.Point (WithOrigin (..), blockPointHash,
+                     blockPointSlot)
 
 import           Ouroboros.Consensus.Util.Condense
 
@@ -25,15 +27,19 @@ import           Ouroboros.Consensus.Util.Condense
 instance Condense SlotNo where
   condense (SlotNo n) = condense n
 
-instance Condense (ChainHash block) => Condense (Point block) where
-    condense (Point ptSlot ptHash) =
+instance Condense (HeaderHash block) => Condense (Point block) where
+    condense (Point Origin)        = "Origin"
+    condense (Point (At blk)) =
       "(Point " <> condense ptSlot <> ", " <> condense ptHash <> ")"
+      where
+      ptSlot = blockPointSlot blk
+      ptHash = blockPointHash blk
 
 instance Condense block => Condense (Chain block) where
     condense Genesis   = "Genesis"
     condense (cs :> b) = condense cs <> " :> " <> condense b
 
-instance (Condense block, HasHeader block, Condense (ChainHash block))
+instance (Condense block, HasHeader block, Condense (HeaderHash block))
     => Condense (AnchoredFragment block) where
     condense (AF.Empty pt) = "EmptyAnchor " <> condense pt
     condense (cs AF.:> b)  = condense cs <> " :> " <> condense b

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Model.hs
@@ -90,13 +90,13 @@ hasBlock hash = isJust . getBlock hash
 getBlockByPoint :: HasHeader blk
                 => Point blk -> Model blk
                 -> Either (ChainDbError blk) (Maybe blk)
-getBlockByPoint pt = case Chain.pointHash pt of
+getBlockByPoint pt = case Block.pointHash pt of
     GenesisHash    -> const $ Left NoGenesisBlock
     BlockHash hash -> Right . getBlock hash
 
 hasBlockByPoint :: HasHeader blk
                 => Point blk -> Model blk -> Bool
-hasBlockByPoint pt = case Chain.pointHash pt of
+hasBlockByPoint pt = case Block.pointHash pt of
     GenesisHash    -> const False
     BlockHash hash -> hasBlock hash
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -40,6 +40,8 @@ import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState (chainState,
                      initChainProducerState)
 import qualified Ouroboros.Network.ChainProducerState as CPS
+import           Ouroboros.Network.Point (WithOrigin (..), blockPointHash,
+                     blockPointSlot)
 import           Ouroboros.Network.Protocol.ChainSync.Client
 import           Ouroboros.Network.Protocol.ChainSync.Codec (codecChainSyncId)
 import           Ouroboros.Network.Protocol.ChainSync.Examples
@@ -683,8 +685,12 @@ ppBlock TestBlock { tbSlot = SlotNo s, tbHash = h, tbPrevHash = p } =
       BlockHash hash -> show hash
 
 ppPoint :: Point TestBlock -> String
-ppPoint Point { pointSlot = SlotNo s, pointHash = h } =
+ppPoint (Point Origin)   = "Origin"
+ppPoint (Point (At blk)) =
     "(S:" <> show s <> "; H:" <> show h <> ")"
+  where
+    SlotNo s = blockPointSlot blk
+    h        = blockPointHash blk
 
 
 ppChain :: Chain TestBlock -> String

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -41,6 +41,7 @@ import Ouroboros.Network.Block
 import qualified Ouroboros.Network.Chain as Chain
 import qualified Ouroboros.Network.ChainFragment as CF
 import qualified Ouroboros.Network.AnchoredFragment as AF
+import Ouroboros.Network.Point (WithOrigin (Origin))
 import Ouroboros.Network.Testing.ConcreteBlock
 import Ouroboros.Network.Socket
 import Network.Mux.Interface
@@ -804,7 +805,7 @@ mkTestFetchedBlockHeap points = do
 --
 
 genesisChainFragment :: AF.AnchoredFragment BlockHeader
-genesisChainFragment = AF.Empty (Point 0 GenesisHash)
+genesisChainFragment = AF.Empty (Point Origin)
 
 shiftAnchoredFragment :: HasHeader block
                       => Int

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -49,6 +49,7 @@ library
                        Ouroboros.Network.DeltaQ
                        Ouroboros.Network.NodeToNode
                        Ouroboros.Network.NodeToClient
+                       Ouroboros.Network.Point
                        Ouroboros.Network.Server.Socket
                        Ouroboros.Network.Server.Version.CBOR
                        Ouroboros.Network.Server.Version.Protocol
@@ -153,6 +154,7 @@ test-suite tests
                        Ouroboros.Network.DeltaQ
                        Ouroboros.Network.Node
                        Ouroboros.Network.NodeToNode
+                       Ouroboros.Network.Point
                        Ouroboros.Network.Protocol.BlockFetch.Client
                        Ouroboros.Network.Protocol.BlockFetch.Codec
                        Ouroboros.Network.Protocol.BlockFetch.Direct
@@ -253,6 +255,7 @@ test-suite cddl
                        Ouroboros.Network.Block
                        Ouroboros.Network.Chain
                        Ouroboros.Network.ChainFragment
+                       Ouroboros.Network.Point
                        Ouroboros.Network.Protocol.BlockFetch.Codec
                        Ouroboros.Network.Protocol.BlockFetch.Type
                        Ouroboros.Network.Protocol.ChainSync.Codec

--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE PatternSynonyms            #-}
 
 -- | Abstract view over blocks
 --
@@ -32,6 +33,11 @@ module Ouroboros.Network.Block (
   , encodeChainHash
   , decodePoint
   , decodeChainHash
+
+  , pattern GenesisPoint
+  , pattern BlockPoint
+  , atSlot
+  , withHash
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)
@@ -128,6 +134,14 @@ newtype Point block = Point
 deriving instance StandardHash block => Eq   (Point block)
 deriving instance StandardHash block => Ord  (Point block)
 deriving instance StandardHash block => Show (Point block)
+
+pattern GenesisPoint :: Point block
+pattern GenesisPoint = Point Origin
+
+pattern BlockPoint :: SlotNo -> HeaderHash block -> Point block
+pattern BlockPoint { atSlot, withHash } = Point (At (Point.Block atSlot withHash))
+
+{-# COMPLETE GenesisPoint, BlockPoint #-}
 
 -- Should be
 -- pointSlot :: Point block -> WithOrigin SlotNo

--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -20,6 +20,8 @@ module Ouroboros.Network.Block (
   , ChainHash(..)
   , castHash
   , Point(..)
+  , pointSlot
+  , pointHash
   , castPoint
   , blockPoint
   , ChainUpdate(..)
@@ -41,6 +43,9 @@ import           Data.FingerTree (Measured)
 import           Data.Typeable (Typeable)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
+
+import           Ouroboros.Network.Point (WithOrigin (..), origin, block)
+import qualified Ouroboros.Network.Point as Point (Block (..))
 
 -- | The 0-based index for the Ourboros time slot.
 newtype SlotNo = SlotNo { unSlotNo :: Word64 }
@@ -114,21 +119,34 @@ castHash (BlockHash b) = BlockHash b
 -- as a check, or in some contexts it disambiguates blocks from different forks
 -- that were in the same slot.
 --
-data Point block = Point {
-       pointSlot :: SlotNo,
-       pointHash :: ChainHash block
-     }
-   deriving (Eq, Ord, Show)
+-- It's a newtype rather than a type synonym, because using a type synonym
+-- would lead to ambiguity, since HeaderHash is a non-injective type family.
+newtype Point block = Point
+    { getPoint :: WithOrigin (Point.Block SlotNo (HeaderHash block))
+    }
+
+deriving instance StandardHash block => Eq   (Point block)
+deriving instance StandardHash block => Ord  (Point block)
+deriving instance StandardHash block => Show (Point block)
+
+-- Should be
+-- pointSlot :: Point block -> WithOrigin SlotNo
+-- pointSlot (Point pt) = fmap Point.blockPointSlot pt
+pointSlot :: Point block -> SlotNo
+pointSlot (Point Origin)   = SlotNo 0
+pointSlot (Point (At blk)) = Point.blockPointSlot blk
+
+pointHash :: Point block -> ChainHash block
+pointHash (Point pt) = case pt of
+    Origin -> GenesisHash
+    At blk -> BlockHash (Point.blockPointHash blk)
 
 castPoint :: (HeaderHash a ~ HeaderHash b) => Point a -> Point b
-castPoint (Point a b) = Point a (castHash b)
+castPoint (Point Origin)                       = Point Origin
+castPoint (Point (At (Point.Block slot hash))) = Point (block slot hash)
 
 blockPoint :: HasHeader block => block -> Point block
-blockPoint b =
-    Point {
-      pointSlot = blockSlot b,
-      pointHash = BlockHash (blockHash b)
-    }
+blockPoint b = Point (block (blockSlot b) (blockHash b))
 
 {-------------------------------------------------------------------------------
   ChainUpdate type
@@ -172,19 +190,26 @@ decodeChainHash decodeHash = do
       1 -> BlockHash <$> decodeHash
       _ -> fail "decodeChainHash: invalid tag"
 
-encodePoint :: (ChainHash block -> Encoding)
-            -> (Point     block -> Encoding)
-encodePoint encodeHash Point { pointSlot = s, pointHash = h } =
-       Enc.encodeListLen 2
-    <> encode s
-    <> encodeHash h
+encodePoint :: (HeaderHash block -> Encoding)
+            -> (Point      block -> Encoding)
+encodePoint encodeHash (Point pt) = case pt of
+    Origin -> Enc.encodeListLen 0
+    At blk ->
+           Enc.encodeListLen 2
+        <> encode     (Point.blockPointSlot blk)
+        <> encodeHash (Point.blockPointHash blk)
 
-decodePoint :: (forall s. Decoder s (ChainHash block))
-            -> (forall s. Decoder s (Point     block))
+decodePoint :: (forall s. Decoder s (HeaderHash block))
+            -> (forall s. Decoder s (Point      block))
 decodePoint decodeHash = do
-      Dec.decodeListLenOf 2
-      Point <$> decode
-            <*> decodeHash
+    tag <- Dec.decodeListLen
+    case tag of
+      0 -> return (Point origin)
+      2 -> do
+        slot <- decode
+        hash <- decodeHash
+        return (Point (block slot hash))
+      _ -> fail "decodePoint: invalid tag"
 
 {-------------------------------------------------------------------------------
   Finger Tree Measure

--- a/ouroboros-network/src/Ouroboros/Network/Chain.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Chain.hs
@@ -78,6 +78,7 @@ import           Control.Exception (assert)
 import qualified Data.List as L
 
 import           Ouroboros.Network.Block
+import           Ouroboros.Network.Point (origin)
 
 --
 -- Blockchain type
@@ -109,7 +110,7 @@ genesisBlockNo :: BlockNo
 genesisBlockNo = BlockNo 0
 
 genesisPoint :: Point block
-genesisPoint = Point genesisSlotNo GenesisHash
+genesisPoint = Point origin
 
 valid :: HasHeader block => Chain block -> Bool
 valid Genesis  = True

--- a/ouroboros-network/src/Ouroboros/Network/ChainProducerState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainProducerState.hs
@@ -5,7 +5,7 @@
 
 module Ouroboros.Network.ChainProducerState where
 
-import           Ouroboros.Network.Block (castPoint)
+import           Ouroboros.Network.Block (castPoint, pointSlot)
 import           Ouroboros.Network.Chain (Chain, ChainUpdate (..), HasHeader,
                      HeaderHash, Point (..), blockPoint, genesisPoint,
                      pointOnChain)

--- a/ouroboros-network/src/Ouroboros/Network/Point.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Point.hs
@@ -1,0 +1,29 @@
+module Ouroboros.Network.Point
+  ( WithOrigin (..)
+  , Block (..)
+  , origin
+  , at
+  , block
+  ) where
+
+data WithOrigin t = Origin | At t
+  deriving (Eq, Ord, Show)
+
+instance Functor WithOrigin where
+  fmap _ Origin    = Origin
+  fmap f (At t) = At (f t)
+
+data Block slot hash = Block
+  { blockPointSlot :: !slot
+  , blockPointHash :: !hash
+  }
+  deriving (Eq, Ord, Show)
+
+at :: t -> WithOrigin t
+at = At
+
+origin :: WithOrigin t
+origin = Origin
+
+block :: slot -> hash -> WithOrigin (Block slot hash)
+block slot hash = at (Block slot hash)

--- a/ouroboros-network/src/Ouroboros/Network/Point.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Point.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE DeriveFunctor     #-}
+{-# LANGUAGE DeriveFoldable    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveTraversable #-}
+
 module Ouroboros.Network.Point
   ( WithOrigin (..)
   , Block (..)
@@ -6,12 +11,10 @@ module Ouroboros.Network.Point
   , block
   ) where
 
-data WithOrigin t = Origin | At t
-  deriving (Eq, Ord, Show)
+import GHC.Generics (Generic)
 
-instance Functor WithOrigin where
-  fmap _ Origin    = Origin
-  fmap f (At t) = At (f t)
+data WithOrigin t = Origin | At t
+  deriving (Eq, Ord, Show, Generic, Functor, Foldable, Traversable)
 
 data Block slot hash = Block
   { blockPointSlot :: !slot

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
@@ -42,10 +42,10 @@ codecBlockFetch encodeBody encodeHeaderHash
     mkCodecCborLazyBS encode decode
  where
   encodePoint' :: Point block -> CBOR.Encoding
-  encodePoint' = Block.encodePoint $ Block.encodeChainHash encodeHeaderHash
+  encodePoint' = Block.encodePoint encodeHeaderHash
 
   decodePoint' :: forall s. CBOR.Decoder s (Point block)
-  decodePoint' = Block.decodePoint $ Block.decodeChainHash decodeHeaderHash
+  decodePoint' = Block.decodePoint decodeHeaderHash
 
   encode :: forall (pr :: PeerRole) st st'.
             PeerHasAgency pr st

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -226,7 +226,7 @@ mkAnchoredFragment anchorpoint anchorblockno =
 
 mkAnchoredFragmentSimple :: [BlockBody] -> AnchoredFragment Block
 mkAnchoredFragmentSimple =
-    mkAnchoredFragment (Point 0 GenesisHash) (BlockNo 0) . zip [1..]
+    mkAnchoredFragment C.genesisPoint (BlockNo 0) . zip [1..]
 
 
 mkPartialBlock :: SlotNo -> BlockBody -> Block

--- a/ouroboros-network/test/Test/Chain.hs
+++ b/ouroboros-network/test/Test/Chain.hs
@@ -14,8 +14,8 @@ import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Ouroboros.Network.Block (blockPrevHash)
-import           Ouroboros.Network.Chain (Chain (..), Point (..), genesisPoint)
+import           Ouroboros.Network.Block (blockPrevHash, pointHash, pointSlot)
+import           Ouroboros.Network.Chain (Chain (..), genesisPoint)
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.Testing.Serialise (prop_serialise)
 

--- a/ouroboros-network/test/Test/ChainProducerState.hs
+++ b/ouroboros-network/test/Test/ChainProducerState.hs
@@ -16,6 +16,7 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
+import           Ouroboros.Network.Block (pointSlot)
 import           Ouroboros.Network.Chain (Chain, ChainUpdate (..), Point (..),
                      genesisPoint, headPoint, pointOnChain)
 import qualified Ouroboros.Network.Chain as Chain

--- a/ouroboros-network/test/messages.cddl
+++ b/ouroboros-network/test/messages.cddl
@@ -84,11 +84,9 @@ msgNoBlocks     = [3]
 msgBlock        = [4, bfBody]
 msgBatchDone    = [5]
 
-bfPoint         = [slotNo, chainHash]
+bfPoint         = origin / [slotNo, dummyBlockHash]
+origin          = []
 slotNo          = uint ; word64
-chainHash       = blockHash / genesisHash
-genesisHash     = []
-blockHash       = [dummyBlockHash]
 dummyBlockHash  = null
 bfBody          = bytes .cbor any
 


### PR DESCRIPTION
Intended to replace #635 and #690 .

It's factored into 2 commits that could be reviewed separately (the third one is a tiny unrelated fix to byron-proxy).

The first commit introduces the `Ouroboros.Network.Point` module and uses it throughout ouroboros-network, making it build and tests pass.

The second makes ouroboros-consensus build and tests pass.

This commit retains the mistake `pointHash :: Point block -> SlotNo` rather than fixing it to be `pointHash :: Point block -> WithOrigin SlotNo`. The origin point is given `SlotNo 0`. It's kept this way so that the pull request will remain short and people will be willing to review it.