### PR TITLE
Introduce some basic Mempool tests

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -225,6 +225,7 @@ test-suite test-consensus
   other-modules:
                     Test.Consensus.BlockchainTime
                     Test.Consensus.ChainSyncClient
+                    Test.Consensus.Mempool
                     Test.Dynamic.BFT
                     Test.Dynamic.General
                     Test.Dynamic.LeaderSchedule
@@ -237,6 +238,7 @@ test-suite test-consensus
                     Test.Util.Orphans.Arbitrary
                     Test.Util.Range
                     Test.Util.TestBlock
+                    Test.Util.TestTx
   build-depends:    base,
                     cardano-crypto-class,
                     typed-protocols,
@@ -297,6 +299,7 @@ test-suite test-storage
                     Test.Util.Range
                     Test.Util.RefEnv
                     Test.Util.TestBlock
+                    Test.Util.TestTx
   build-depends:    base,
                     cardano-crypto-class,
                     ouroboros-network,

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -31,7 +31,7 @@ newtype TicketNo = TicketNo Word64
 
 -- | The transaction ticket number from which our counter starts.
 zeroTicketNo :: TicketNo
-zeroTicketNo = TicketNo 1
+zeroTicketNo = TicketNo 0
 
 -- | We pair up transactions in the mempool with their ticket number.
 --
@@ -179,5 +179,5 @@ fromTxSeq (TxSeq ftree) = fmap
 --
 appendTx :: TxSeq tx -> tx -> TxSeq tx
 appendTx ts tx = case viewBack ts of
-  Nothing                           -> Empty :> TxTicket tx zeroTicketNo
+  Nothing                           -> Empty :> TxTicket tx (TicketNo 1)
   Just (_, TxTicket _ (TicketNo n)) -> ts    :> TxTicket tx (TicketNo (n + 1))

--- a/ouroboros-consensus/test-consensus/Main.hs
+++ b/ouroboros-consensus/test-consensus/Main.hs
@@ -4,6 +4,7 @@ import           Test.Tasty
 
 import qualified Test.Consensus.BlockchainTime (tests)
 import qualified Test.Consensus.ChainSyncClient (tests)
+import qualified Test.Consensus.Mempool (tests)
 import qualified Test.Dynamic.BFT (tests)
 import qualified Test.Dynamic.LeaderSchedule (tests)
 import qualified Test.Dynamic.PBFT (tests)
@@ -17,6 +18,7 @@ tests =
   testGroup "ouroboros-consensus"
   [ Test.Consensus.BlockchainTime.tests
   , Test.Consensus.ChainSyncClient.tests
+  , Test.Consensus.Mempool.tests
   , Test.Dynamic.BFT.tests
   , Test.Dynamic.LeaderSchedule.tests
   , Test.Dynamic.PBFT.tests

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -650,6 +650,7 @@ genChainUpdates securityParam n =
               , tbPrevHash = prevHash
               , tbNo       = succ (Chain.headBlockNo chain)
               , tbSlot     = slot
+              , tbTxs      = []
               }
         modify (addBlock b)
         return b

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE RankNTypes       #-}
+
+module Test.Consensus.Mempool (tests) where
+
+import           Test.QuickCheck (Property, Testable, classify, counterexample,
+                     tabulate, (===))
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Control.Monad.Class.MonadAsync (MonadAsync)
+import           Control.Monad.Class.MonadFork (MonadFork)
+import           Control.Monad.Class.MonadSTM (MonadSTM, STM, atomically)
+import           Control.Monad.Class.MonadThrow (MonadMask, MonadThrow)
+import           Control.Monad.IOSim (runSimOrThrow)
+
+import           Ouroboros.Consensus.Ledger.Abstract (ledgerConfigView)
+import           Ouroboros.Consensus.Mempool (Mempool (..),
+                     MempoolSnapshot (..), openMempool)
+import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo)
+import           Ouroboros.Consensus.Util.ThreadRegistry (withThreadRegistry)
+
+import           Ouroboros.Network.Chain (Chain (..))
+
+import           Ouroboros.Storage.ChainDB.API (ChainDB)
+import qualified Ouroboros.Storage.ChainDB.API as ChainDB
+import qualified Ouroboros.Storage.ChainDB.Mock as Mock
+
+import           Test.Util.TestBlock (GenTx (..), GenTxId (..), TestBlock,
+                     computeGenTxId, singleNodeTestConfig, testInitExtLedger)
+import           Test.Util.TestTx (TestTx (..))
+
+tests :: TestTree
+tests = testGroup "Mempool"
+  [ testProperty "getTxs == getTxsAfter zeroIdx"        prop_Mempool_getTxs_getTxsAfter
+  , testProperty "addedTxs == getTxs"                   prop_Mempool_addTxs_getTxs
+  , testProperty "Invalid transactions are never added" prop_Mempool_InvalidTxsNeverAdded
+  ]
+
+{-------------------------------------------------------------------------------
+  Mempool Implementation Properties
+-------------------------------------------------------------------------------}
+
+-- | Test that @getTxs == getTxsAfter zeroIdx@.
+prop_Mempool_getTxs_getTxsAfter :: Chain TestBlock
+                                -> [TestTx]
+                                -> Property
+prop_Mempool_getTxs_getTxsAfter bc txs =
+  testAddTxsWithMempoolAndSnapshot
+    bc
+    txs
+    (\Mempool{zeroIdx} MempoolSnapshot{getTxs, getTxsAfter} ->
+      getTxs === getTxsAfter zeroIdx)
+
+-- | Test that all valid transactions added to a 'Mempool' can be retrieved
+-- afterward.
+--
+-- n.b. In this test, we add a list of arbitrary transactions to an initially
+-- empty 'Mempool', retrieve all of the transactions from the 'Mempool', and
+-- assert that those transactions are /specifically/ equal to the /valid/
+-- transactions that we attempted to add (the invalid ones should have been
+-- dropped).
+prop_Mempool_addTxs_getTxs :: Chain TestBlock
+                           -> [TestTx]
+                           -> Property
+prop_Mempool_addTxs_getTxs bc txs =
+    testAddTxsWithMempoolAndSnapshot
+        bc
+        txs
+        (\_ MempoolSnapshot{getTxs} ->
+          filter (genTxIsValid . snd) (testTxsToGenTxPairs txs)
+              === dropThd getTxs)
+  where
+    dropThd :: [(a, b, c)] -> [(a, b)]
+    dropThd = map (\(a, b, _) -> (a, b))
+    --
+    genTxIsValid :: GenTx TestBlock -> Bool
+    genTxIsValid (TestGenTx (ValidTestTx _)) = True
+    genTxIsValid _                           = False
+
+-- | Test that invalid transactions can never be added to the 'Mempool'.
+--
+-- n.b. In this test, we add an arbitrary list of transactions to an initially
+-- empty 'Mempool', retrieve all of the transactions from the 'Mempool', and
+-- assert that none of those transactions are invalid.
+prop_Mempool_InvalidTxsNeverAdded :: Chain TestBlock
+                                  -> [TestTx]
+                                  -> Property
+prop_Mempool_InvalidTxsNeverAdded bc txs =
+    testAddTxsWithMempoolAndSnapshot
+        bc
+        txs
+        (\_ MempoolSnapshot{getTxs} ->
+          filter (\(_, tx, _) -> genTxIsInvalid tx) getTxs === [])
+  where
+    genTxIsInvalid :: GenTx TestBlock -> Bool
+    genTxIsInvalid (TestGenTx (InvalidTestTx _)) = True
+    genTxIsInvalid _                             = False
+
+{-------------------------------------------------------------------------------
+  Helpers
+-------------------------------------------------------------------------------}
+
+testTxsToGenTxPairs :: [TestTx] -> [(GenTxId TestBlock, GenTx TestBlock)]
+testTxsToGenTxPairs = map testTxToGenTxPair
+
+testTxToGenTxPair :: TestTx -> (GenTxId TestBlock, GenTx TestBlock)
+testTxToGenTxPair tx = (computeGenTxId genTx, genTx)
+  where
+    genTx = TestGenTx tx
+
+testAddTxsWithMempoolAndSnapshot
+  :: Testable prop
+  => Chain TestBlock
+  -> [TestTx]
+  -> (   forall m.
+         Mempool m TestBlock TicketNo
+      -> MempoolSnapshot (GenTxId TestBlock) (GenTx TestBlock) TicketNo
+      -> prop
+     )
+  -> Property
+testAddTxsWithMempoolAndSnapshot bc txs prop =
+  tabulate "Transactions" (map constrName txs) $
+  runSimOrThrow $
+  withOpenMempool bc $ \mempool -> do
+    let genTxs = testTxsToGenTxPairs txs
+        Mempool
+          { addTxs
+          , getSnapshot
+          } = mempool
+    invalidTxs <- addTxs genTxs
+    snapshot@MempoolSnapshot{getTxs} <- atomically getSnapshot
+    pure $
+      counterexampleMempoolInfo genTxs invalidTxs getTxs $
+      classifyMempoolSize getTxs $
+      prop mempool snapshot
+
+openDB :: forall m.
+          ( MonadSTM m
+          , MonadFork m
+          , MonadMask m
+          , MonadThrow m
+          , MonadThrow (STM m)
+          , MonadAsync m
+          )
+       => m (ChainDB m TestBlock)
+openDB = Mock.openDB singleNodeTestConfig testInitExtLedger
+
+withOpenMempool :: ( MonadSTM m
+                   , MonadFork m
+                   , MonadMask m
+                   , MonadThrow m
+                   , MonadThrow (STM m)
+                   , MonadAsync m
+                   )
+                => Chain TestBlock
+                -> (Mempool m TestBlock TicketNo -> m a)
+                -> m a
+withOpenMempool bc action = do
+  chainDb <- ChainDB.fromChain openDB bc
+  withThreadRegistry $ \registry -> do
+    let cfg = ledgerConfigView singleNodeTestConfig
+    action =<< openMempool registry chainDb cfg
+
+-- | Classify whether we're testing against an empty or non-empty 'Mempool' in
+-- each test case.
+classifyMempoolSize :: Testable prop => [a] -> prop -> Property
+classifyMempoolSize txs prop =
+  classify (null txs)         "empty Mempool"     $
+  classify (not . null $ txs) "non-empty Mempool" $
+  prop
+
+counterexampleMempoolInfo :: ( Show a
+                             , Show b
+                             , Show c
+                             , Testable prop
+                             )
+                          => [a]
+                          -> [b]
+                          -> [c]
+                          -> prop
+                          -> Property
+counterexampleMempoolInfo txsToAdd invalidTxs txsInMempool prop =
+  counterexample
+  ("Transactions to add: "         <> show txsToAdd   <> "\n" <>
+   "Invalid transactions: "        <> show invalidTxs <> "\n" <>
+   "Transactions in the Mempool: " <> show txsInMempool) $
+  prop
+
+-- TODO: Should be replaced by solution for issue #709.
+constrName :: Show a => a -> String
+constrName = head . words . show

--- a/ouroboros-consensus/test-util/Test/Util/TestTx.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestTx.hs
@@ -1,0 +1,49 @@
+module Test.Util.TestTx (
+    -- * Transactions
+    TestTxId
+  , TestTx (..)
+  ) where
+
+import           Data.Word (Word64)
+import           Test.QuickCheck (Arbitrary (..), oneof)
+
+{-------------------------------------------------------------------------------
+  Test infrastructure: test transaction
+-------------------------------------------------------------------------------}
+
+-- | A simple transaction identifier used in testing 'Mempool' support.
+newtype TestTxId = TestTxId Word64
+  deriving (Show, Eq, Ord)
+
+instance Arbitrary TestTxId where
+  arbitrary           = TestTxId <$> arbitrary
+  shrink (TestTxId w) = [TestTxId w' | w' <- shrink w]
+
+-- | A simple valid or invalid transaction used in testing 'Mempool' support.
+--
+-- Currently, in the tests for the basic 'Mempool' operations and properties,
+-- we don't really need to know much more about a transaction other than
+-- whether it is valid or invalid. At the moment, we're only testing properties
+-- surrounding a basic subset of 'Mempool' functionality: When attempting to
+-- add transactions to the 'Mempool', those which are valid are stored and
+-- those which are invalid are dropped.
+--
+-- TODO:
+-- This will most definitely need to be extended in order to test other
+-- situations. For example, situations in which known valid transactions
+-- (which are in the 'Mempool') can be dropped due to later becoming invalid
+-- with respect to the current ledger state. This can happen when either that
+-- transaction is already included on the chain or one of its inputs has
+-- already been spent with respect to the current ledger state.
+data TestTx = ValidTestTx !TestTxId
+            | InvalidTestTx !TestTxId
+  deriving (Show, Eq, Ord)
+
+instance Arbitrary TestTx where
+  arbitrary = oneof
+    [ ValidTestTx   <$> arbitrary
+    , InvalidTestTx <$> arbitrary
+    ]
+
+  shrink (ValidTestTx txid)   = [ValidTestTx txid'   | txid' <- shrink txid]
+  shrink (InvalidTestTx txid) = [InvalidTestTx txid' | txid' <- shrink txid]


### PR DESCRIPTION
This PR introduces some trivial `Mempool` tests which build off of the data types and functionality defined in `Test.Util.TestBlock`. 

Note that these tests will continue to be expanded upon and improved as I continue working on the `Mempool` functionality. For example, I'd like to introduce some tests for situations in which known valid transactions (which are in the 'Mempool') can be dropped due to later becoming invalid with respect to the current ledger state. This can happen when either that transaction is already included on the chain or one of its inputs has already been spent with respect to the current ledger state. 