### PR TITLE
Make `network-mux` independent of `typed-protocols`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -99,7 +99,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-shell
-  tag: 92e6b42167d1399971df788b691423222722c2f6
+  tag: 1c4d504b39c560da95abaab48122a5611ee1f46f
 
 source-repository-package
   type: git

--- a/network-mux/README.md
+++ b/network-mux/README.md
@@ -1,0 +1,24 @@
+# network-mux
+
+Multiplexing library.  It allows to run multiple network applications over
+a single bearer.  The muliplexer cuts messages in chunks of some maximal size
+and sends them over a bearer channel.  The current version of this library
+relies on reliable and ordered delivery of messages.  The muliplexer should run
+alongside with an incremental decoder.
+
+Example protocol with an incremental
+decoder is implemented in
+[Test.Mux.ReqResp](https://github.com/input-output-hk/ouroboros-network/blob/master/network-mux/test/Test/Mux/ReqResp.hs)
+for other examples of protocols see 'typed-protocols' or 'ouroboros-network'
+packages.
+
+## tests
+
+To run the test suite:
+```
+cabal new-run test-network-mux
+```
+or
+```
+nix-build -A nix-tools.tests.network-mux
+```

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -66,6 +66,7 @@ test-suite test-network-mux
                        Network.Mux.Bearer.Socket
 
                        Test.Mux
+                       Test.Mux.ReqResp
   default-language:    Haskell2010
   build-depends:       base,
                        typed-protocols,

--- a/network-mux/src/Network/Mux.hs
+++ b/network-mux/src/Network/Mux.hs
@@ -87,7 +87,7 @@ muxStart
        , MiniProtocolLimits ptcl
        )
     => peerid
-    -> MuxApplication appType peerid ptcl m BL.ByteString a b
+    -> MuxApplication appType peerid ptcl m a b
     -> MuxBearer ptcl m
     -> m ()
 muxStart peerid app bearer = do
@@ -188,7 +188,7 @@ muxChannel
     -> MiniProtocolId ptcl
     -> MiniProtocolMode
     -> TVar m Int
-    -> m (Channel m BL.ByteString)
+    -> m (Channel m)
 muxChannel pmss mid md cnt = do
     w <- newEmptyTMVarM
     return $ Channel { send = send (Wanton w)

--- a/network-mux/src/Network/Mux/Bearer/Pipe.hs
+++ b/network-mux/src/Network/Mux/Bearer/Pipe.hs
@@ -89,7 +89,7 @@ runMuxWithPipes
     :: ( Mx.ProtocolEnum ptcl, Ord ptcl, Enum ptcl, Bounded ptcl, Show ptcl
        , Mx.MiniProtocolLimits ptcl)
     => peerid
-    -> Mx.MuxApplication appType peerid ptcl IO BL.ByteString a b
+    -> Mx.MuxApplication appType peerid ptcl IO a b
     -> Handle -- ^ read handle
     -> Handle -- ^ write handle
     -> IO ()

--- a/network-mux/src/Network/Mux/Bearer/Queues.hs
+++ b/network-mux/src/Network/Mux/Bearer/Queues.hs
@@ -81,7 +81,7 @@ runMuxWithQueues
      , MonadMask m
      , MonadSay m
      , MonadSTM m
-     , MonadThrow m 
+     , MonadThrow m
      , MonadThrow (STM m)
      , MonadTime m
      , MonadTimer m
@@ -93,7 +93,7 @@ runMuxWithQueues
      , Mx.MiniProtocolLimits ptcl
      )
   => peerid
-  -> Mx.MuxApplication appType peerid ptcl m BL.ByteString a b
+  -> Mx.MuxApplication appType peerid ptcl m a b
   -> TBQueue m BL.ByteString
   -> TBQueue m BL.ByteString
   -> Word16

--- a/network-mux/src/Network/Mux/Interface.hs
+++ b/network-mux/src/Network/Mux/Interface.hs
@@ -19,10 +19,6 @@ module Network.Mux.Interface
   , MuxApplication (..)
   , initiatorApplication
   , responderApplication
-  , MuxPeer (..)
-  , runMuxPeer
-  , simpleMuxInitiatorApplication
-  , simpleMuxResponderApplication
   , ProtocolEnum (..)
   , MiniProtocolLimits (..)
   , TraceLabelPeer (..)
@@ -30,19 +26,7 @@ module Network.Mux.Interface
 
 import           Data.Void (Void)
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadThrow ( MonadCatch
-                                                , MonadThrow
-                                                )
-import           Control.Tracer (Tracer)
-
-import           Control.Exception (Exception)
-
-import           Network.TypedProtocol.Core
-import           Network.TypedProtocol.Codec
 import           Network.TypedProtocol.Channel
-import           Network.TypedProtocol.Driver
-import           Network.TypedProtocol.Pipelined
 
 import           Network.Mux.Types ( MiniProtocolLimits (..)
                                    , ProtocolEnum (..)
@@ -136,68 +120,3 @@ responderApplication
   -> (peerid -> ptcl -> Channel m bytes ->  m b)
 responderApplication (MuxResponderApplication app) = app
 responderApplication (MuxInitiatorAndResponderApplication _ app) = app
-
--- |
--- This type is only necessary to use the @'simpleMuxClient'@ and
--- @'simpleMuxServer'@ smart constructors.
-data MuxPeer peerid failure m bytes a where
-    MuxPeer :: Tracer m (TraceSendRecv ps peerid failure)
-            -> Codec ps failure m bytes
-            -> Peer ps pr st m a
-            -> MuxPeer peerid failure m bytes a
-
-    MuxPeerPipelined
-            :: Tracer m (TraceSendRecv ps peerid failure)
-            -> Codec ps failure m bytes
-            -> PeerPipelined ps pr st m a
-            -> MuxPeer peerid failure m bytes a
-
-
--- |
--- Run a @'MuxPeer'@ using either @'runPeer'@ or @'runPipelinedPeer'@.
---
-runMuxPeer
-  :: ( MonadThrow m
-     , MonadCatch m
-     , MonadAsync m
-     , Exception failure
-     )
-  => MuxPeer peerid failure m bytes a
-  -> peerid
-  -> Channel m bytes
-  -> m a
-runMuxPeer (MuxPeer tracer codec peer) peerid channel =
-    runPeer tracer codec peerid channel peer
-
-runMuxPeer (MuxPeerPipelined tracer codec peer) peerid channel =
-    runPipelinedPeer tracer codec peerid channel peer
-
-
--- |
--- Smart constructor for @'MuxInitiatorApplication'@.  It is a simple client, since
--- none of the applications requires resource handling to run in the monad @m@.
--- Each one is simply run either by @'runPeer'@ or @'runPipelinedPeer'@.
---
-simpleMuxInitiatorApplication
-  :: MonadThrow m
-  => MonadCatch m
-  => MonadAsync m
-  => Exception failure
-  => (ptcl -> MuxPeer peerid failure m bytes a)
-  -> MuxApplication InitiatorApp peerid ptcl m bytes a Void
-simpleMuxInitiatorApplication fn = MuxInitiatorApplication $ \peerid ptcl channel ->
-  runMuxPeer (fn ptcl) peerid channel
-
-
--- |
--- Smart constructor for @'MuxResponderApplicatin'@, similar to @'simpleMuxInitiator'@.
---
-simpleMuxResponderApplication
-  :: MonadThrow m
-  => MonadCatch m
-  => MonadAsync m
-  => Exception failure
-  => (ptcl -> MuxPeer peerid failure m bytes a)
-  -> MuxApplication ResponderApp peerid ptcl m bytes Void a
-simpleMuxResponderApplication fn = MuxResponderApplication $ \peerid ptcl channel ->
-  runMuxPeer (fn ptcl) peerid channel

--- a/network-mux/test/Test/Mux.hs
+++ b/network-mux/test/Test/Mux.hs
@@ -113,22 +113,6 @@ instance Mx.MiniProtocolLimits TestProtocolsSmall where
   maximumMessageSize ReqRespSmall  = smallMiniProtocolLimit
   maximumIngressQueue ReqRespSmall = smallMiniProtocolLimit
 
--- |
--- Allow to run a singly req-resp protocol.
---
-data TestProtocols3 = ReqResp4
-  deriving (Eq, Ord, Enum, Bounded, Show)
-
-instance Mx.ProtocolEnum TestProtocols3 where
-  fromProtocolEnum ReqResp4 = 4
-
-  toProtocolEnum 4 = Just ReqResp4
-  toProtocolEnum _ = Nothing
-
-instance Mx.MiniProtocolLimits TestProtocols3 where
-  maximumMessageSize ReqResp4  = defaultMiniProtocolLimit
-  maximumIngressQueue ReqResp4 = defaultMiniProtocolLimit
-
 newtype DummyPayload = DummyPayload {
       unDummyPayload :: BL.ByteString
     } deriving Eq
@@ -302,8 +286,12 @@ prop_mux_snd_recv request response = ioProperty $ do
     (verify, clientApp, serverApp) <- setupMiniReqRsp
                                         (return ()) endMpsVar request response
 
-    clientAsync <- async $ Mx.runMuxWithQueues "client" (Mx.MuxInitiatorApplication $ \_ ReqResp4 -> clientApp) client_w client_r sduLen Nothing
-    serverAsync <- async $ Mx.runMuxWithQueues "server" (Mx.MuxResponderApplication $ \_ ReqResp4 -> serverApp) server_w server_r sduLen Nothing
+    clientAsync <-
+      async $ Mx.runMuxWithQueues "client" (Mx.MuxInitiatorApplication
+        $ \_ ReqResp1 -> clientApp) client_w client_r sduLen Nothing
+    serverAsync <-
+      async $ Mx.runMuxWithQueues "server" (Mx.MuxResponderApplication
+        $ \_ ReqResp1 -> serverApp) server_w server_r sduLen Nothing
 
     r <- waitBoth clientAsync serverAsync
     case r of

--- a/network-mux/test/Test/Mux.hs
+++ b/network-mux/test/Test/Mux.hs
@@ -69,6 +69,10 @@ defaultMiniProtocolLimit = 3000000
 smallMiniProtocolLimit :: Int64
 smallMiniProtocolLimit = 16*1024
 
+--
+-- Various ProtocolEnum instances used in tests
+--
+
 data TestProtocols1 = ReqResp1
   deriving (Eq, Ord, Enum, Bounded, Show)
 
@@ -112,6 +116,10 @@ instance Mx.ProtocolEnum TestProtocolsSmall where
 instance Mx.MiniProtocolLimits TestProtocolsSmall where
   maximumMessageSize ReqRespSmall  = smallMiniProtocolLimit
   maximumIngressQueue ReqRespSmall = smallMiniProtocolLimit
+
+--
+-- Generators
+--
 
 newtype DummyPayload = DummyPayload {
       unDummyPayload :: BL.ByteString
@@ -263,6 +271,12 @@ instance Arbitrary Mx.MuxBearerState where
                           , Mx.Dying
                           , Mx.Dead
                           ]
+
+
+
+--
+-- QuickChekc Properties
+--
 
 
 -- | Verify that an initiator and a responder can send and receive messages

--- a/network-mux/test/Test/Mux/ReqResp.hs
+++ b/network-mux/test/Test/Mux/ReqResp.hs
@@ -1,0 +1,211 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes          #-}
+
+-- | A simple ReqResp protocol, togetether with an incremental decoder.  Mux is
+-- chopping messages into 'MuxSDU's of a fixed size, for that reasone the
+-- peer awaiting for messages needs an incremental decoder to assemple messages
+-- back.
+--
+module Test.Mux.ReqResp where
+
+import           Codec.CBOR.Decoding (Decoder)
+import qualified Codec.CBOR.Decoding as CBOR hiding (Done, Fail)
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Read as CBOR
+import           Codec.Serialise (Serialise (..), serialise)
+import           Control.Monad.ST
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString as BS
+
+import           Control.Monad.Class.MonadST
+import           Control.Tracer (Tracer, traceWith)
+
+import           Network.Mux.Channel
+
+-- | Protocol messages.
+--
+data MsgReqResp req resp =
+
+   -- | Client request.
+   --
+     MsgReq req
+
+   -- | Server response.
+   --
+   | MsgResp resp
+
+   -- | Client finishes the protocol exchange.
+   --
+   | MsgDone
+   deriving (Show, Eq, Ord)
+
+
+instance (Serialise req, Serialise resp) => Serialise (MsgReqResp req resp) where
+    encode (MsgReq req)   = CBOR.encodeListLen 2 <> CBOR.encodeWord 0 <> encode req
+    encode (MsgResp resp) = CBOR.encodeListLen 2 <> CBOR.encodeWord 1 <> encode resp
+    encode MsgDone        = CBOR.encodeListLen 1 <> CBOR.encodeWord 2
+
+    decode = do
+      len <- CBOR.decodeListLen
+      tag <- CBOR.decodeWord
+      case (len, tag) of
+        (2, 0) -> MsgReq  <$> decode
+        (2, 1) -> MsgResp <$> decode
+        (1, 2) -> pure MsgDone
+        _      -> fail $ "decode MsgReqResp: unknown tag " ++ show tag
+
+
+-- | A Client which requests 'req' data and receives 'resp'.
+--
+data ReqRespClient req resp m a where
+  SendMsgReq  :: req
+              -> (resp -> m (ReqRespClient req resp m a))
+              -> ReqRespClient req resp m a
+
+  SendMsgDone :: m a -> ReqRespClient req resp m a
+
+
+data TraceSendRecv msg
+  = TraceSend msg
+  | TraceRecv msg
+  | TraceFailure CBOR.DeserialiseFailure
+  deriving Show
+
+
+runDecoderWithChannel :: forall s m a.
+                         ( Monad m
+                         , MonadST m
+                         )
+                      => (forall b. ST s b -> m b)
+                      -> Channel m
+                      -> Maybe LBS.ByteString
+                      -> Decoder s a
+                      -> m (Either CBOR.DeserialiseFailure (a, Maybe LBS.ByteString))
+
+runDecoderWithChannel liftST Channel{recv} trailing decoder =
+    liftST (CBOR.deserialiseIncremental decoder) >>= go (LBS.toStrict <$> trailing)
+  where
+
+    go :: Maybe BS.ByteString
+       -> CBOR.IDecode s a
+       -> m (Either CBOR.DeserialiseFailure (a, Maybe LBS.ByteString))
+
+    go Nothing (CBOR.Partial k) =
+      recv >>= liftST . k . fmap LBS.toStrict >>= go Nothing
+    go (Just bs) (CBOR.Partial k)  =
+      liftST (k (Just bs)) >>= go Nothing
+    go _ (CBOR.Done trailing' _ a) | BS.null trailing'
+                                   = return (Right (a, Nothing))
+                                   | otherwise
+                                   = return (Right (a, Just $ LBS.fromStrict trailing'))
+    go _ (CBOR.Fail _ _ failure)   = return $ Left failure
+
+
+
+-- | Run a client using a byte 'Channel'.
+--
+runClient :: forall req resp m a.
+             ( Monad m
+             , MonadST m
+             , Serialise req
+             , Serialise resp
+             , Show req
+             , Show resp
+             )
+          => Tracer m (TraceSendRecv (MsgReqResp req resp))
+          -> Channel m
+          -> ReqRespClient req resp m a
+          -> m a
+
+runClient tracer channel@Channel {send} =
+    go Nothing
+  where
+    go :: Maybe LBS.ByteString
+       -> ReqRespClient req resp m a
+       -> m a
+    go trailing (SendMsgReq req mnext) = do
+      let msg :: MsgReqResp req resp
+          msg = MsgReq req
+      traceWith tracer (TraceSend msg)
+      send $ serialise msg
+
+      res <- withLiftST $ \liftST -> runDecoderWithChannel
+                                        liftST channel trailing decode
+
+      case res of
+        Left err -> do
+          traceWith tracer (TraceFailure err)
+          error $ "runClient: deserialise error: " ++ show err
+
+        Right (msg'@(MsgResp resp), trailing') -> do
+          traceWith tracer (TraceRecv msg')
+          mnext resp >>= go trailing'
+
+        Right (msg', _) -> error $ "runClient: wrong message " ++ show msg'
+
+    go _trailing (SendMsgDone ma) = do
+        let msg :: MsgReqResp req resp
+            msg = MsgDone
+        traceWith tracer (TraceSend msg)
+        send (serialise msg)
+        ma
+
+
+-- | Server which receives 'req' and responds with 'resp'.
+--
+data ReqRespServer req resp m a = ReqRespServer {
+    -- | The client sent us a ping message. We have no choices here, and
+    -- the response is nullary, all we have are local effects.
+    recvMsgReq  :: req -> m (resp, ReqRespServer req resp m a)
+
+    -- | The client terminated. Here we have a pure return value, but we
+    -- could have done another action in 'm' if we wanted to.
+  , recvMsgDone :: m a
+  }
+
+
+runServer :: forall req resp m a.
+             ( Monad m
+             , Serialise req
+             , Serialise resp
+             , Show req
+             , Show resp
+             , m ~ IO
+             )
+          => Tracer m (TraceSendRecv (MsgReqResp req resp))
+          -> Channel m
+          -> ReqRespServer req resp m a
+          -> m a
+
+runServer tracer channel@Channel {send} =
+    go Nothing
+  where
+    go :: Maybe LBS.ByteString
+       -> ReqRespServer req resp m a
+       -> m a
+    go trailing ReqRespServer {recvMsgReq, recvMsgDone} = do
+      res <- withLiftST $ \liftST -> runDecoderWithChannel
+                                        liftST channel trailing decode
+      case res of
+        Left err -> do
+          traceWith tracer (TraceFailure err)
+          error $ "runServer: deserialise error " ++ show err
+
+        Right (msg@(MsgReq req), trailing') -> do
+          traceWith tracer (TraceRecv msg)
+          (resp, server) <- recvMsgReq req
+          let msg' :: MsgReqResp req resp
+              msg' = MsgResp resp
+          traceWith tracer (TraceSend msg')
+          send $ serialise msg'
+          go trailing' server
+
+        Right (msg@MsgDone, _) -> do
+          traceWith tracer (TraceRecv msg)
+          recvMsgDone
+
+        Right (msg, _) -> do
+          traceWith tracer (TraceRecv msg)
+          error $ "runServer: unexpected message " ++ show msg

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -21,6 +21,7 @@
           (hsPkgs.io-sim-classes)
           (hsPkgs.bytestring)
           (hsPkgs.contra-tracer)
+          (hsPkgs.time)
           ];
         };
       tests = {
@@ -34,6 +35,7 @@
             (hsPkgs.QuickCheck)
             (hsPkgs.tasty)
             (hsPkgs.tasty-quickcheck)
+            (hsPkgs.time)
             ];
           };
         };

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -27,8 +27,8 @@ import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim (runSimOrThrow)
 
-import           Network.Mux.Channel
 import           Network.TypedProtocol.Driver
+import           Network.TypedProtocol.Channel
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -35,8 +35,8 @@ import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 
-import           Network.Mux.Channel
 import           Network.TypedProtocol.Codec (AnyMessage (..))
+import           Network.TypedProtocol.Channel
 
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain
@@ -177,7 +177,6 @@ createNetworkInterface chans nodeIds us
         -- if an exception is thrown to this thread, cancel all threads;
         (waitAnyCancel ts `onException` traverse_ cancel ts) >>= k . fst
     }
-
 
 -- | Setup fully-connected topology, where every node is both a producer
 -- and a consumer

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -44,7 +44,7 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
 import Ouroboros.Network.Point (WithOrigin (Origin))
 import Ouroboros.Network.Testing.ConcreteBlock
 import Ouroboros.Network.Socket
-import Network.Mux.Interface
+import Ouroboros.Network.Mux
 import Ouroboros.Network.NodeToNode
 
 import Network.TypedProtocol.Channel

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -35,6 +35,8 @@ import           Codec.Serialise (DeserialiseFailure)
 import qualified Codec.Serialise as CBOR
 import           Codec.SerialiseTerm
 
+import           Network.Mux
+
 import qualified Network.Socket as Socket
 
 import Ouroboros.Network.Block
@@ -116,7 +118,7 @@ defaultLocalSocketAddrPath :: FilePath
 defaultLocalSocketAddrPath =  "./demo-chain-sync.sock"
 
 defaultLocalSocketAddrInfo :: Socket.AddrInfo
-defaultLocalSocketAddrInfo = 
+defaultLocalSocketAddrInfo =
     mkLocalSocketAddrInfo defaultLocalSocketAddrPath
 
 rmIfExists :: FilePath -> IO ()
@@ -147,13 +149,12 @@ clientPingPong pipelined =
       (\(DictVersion codec) -> encodeTerm codec)
       (\(DictVersion codec) -> decodeTerm codec)
       (,)
-      (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) muxApplication)
+      (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) app)
       Nothing
       defaultLocalSocketAddrInfo
   where
-    muxApplication :: MuxApplication InitiatorApp (Socket.SockAddr, Socket.SockAddr) DemoProtocol0 IO LBS.ByteString () Void
-    muxApplication =
-      simpleMuxInitiatorApplication protocols
+    app :: OuroborosApplication InitiatorApp (Socket.SockAddr, Socket.SockAddr) DemoProtocol0 IO LBS.ByteString () Void
+    app = simpleInitiatorApplication protocols
 
     protocols :: DemoProtocol0 -> MuxPeer (Socket.SockAddr, Socket.SockAddr) DeserialiseFailure IO LBS.ByteString ()
     protocols PingPong0 | pipelined =
@@ -183,12 +184,11 @@ serverPingPong = do
       (\(DictVersion codec)-> decodeTerm codec)
       (,)
       (\(DictVersion _) -> acceptEq)
-      (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) muxApplication) $ \_ serverAsync ->
+      (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) app) $ \_ serverAsync ->
         wait serverAsync   -- block until async exception
   where
-    muxApplication :: MuxApplication ResponderApp (Socket.SockAddr, Socket.SockAddr) DemoProtocol0 IO LBS.ByteString Void ()
-    muxApplication =
-      simpleMuxResponderApplication protocols
+    app :: OuroborosApplication ResponderApp (Socket.SockAddr, Socket.SockAddr) DemoProtocol0 IO LBS.ByteString Void ()
+    app = simpleResponderApplication protocols
 
     protocols :: DemoProtocol0 -> MuxPeer (Socket.SockAddr, Socket.SockAddr) DeserialiseFailure IO LBS.ByteString ()
     protocols PingPong0 =
@@ -232,16 +232,12 @@ clientPingPong2 =
       (\(DictVersion codec) -> encodeTerm codec)
       (\(DictVersion codec) -> decodeTerm codec)
       (,)
-      (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) muxApplication)
+      (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) app)
       Nothing
       defaultLocalSocketAddrInfo
   where
-    muxApplication :: MuxApplication
-                        InitiatorApp
-                        (Socket.SockAddr, Socket.SockAddr)
-                        DemoProtocol1 IO LBS.ByteString () Void
-    muxApplication =
-      simpleMuxInitiatorApplication protocols
+    app :: OuroborosApplication InitiatorApp (Socket.SockAddr, Socket.SockAddr) DemoProtocol1 IO LBS.ByteString () Void
+    app = simpleInitiatorApplication protocols
 
     protocols :: DemoProtocol1 -> MuxPeer
                                     (Socket.SockAddr, Socket.SockAddr)
@@ -286,14 +282,11 @@ serverPingPong2 = do
       (\(DictVersion codec)-> decodeTerm codec)
       (,)
       (\(DictVersion _) -> acceptEq)
-      (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) muxApplication) $ \_ serverAsync ->
+      (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) app) $ \_ serverAsync ->
         wait serverAsync   -- block until async exception
   where
-    muxApplication :: MuxApplication ResponderApp
-                                     (Socket.SockAddr, Socket.SockAddr)
-                                     DemoProtocol1 IO LBS.ByteString Void ()
-    muxApplication =
-      simpleMuxResponderApplication protocols
+    app :: OuroborosApplication ResponderApp (Socket.SockAddr, Socket.SockAddr) DemoProtocol1 IO LBS.ByteString Void ()
+    app = simpleResponderApplication protocols
 
     protocols :: DemoProtocol1 -> MuxPeer (Socket.SockAddr, Socket.SockAddr)
                                            DeserialiseFailure IO LBS.ByteString ()
@@ -335,15 +328,12 @@ clientChainSync sockAddrs =
         (\(DictVersion codec) -> encodeTerm codec)
         (\(DictVersion codec) -> decodeTerm codec)
         (,)
-        (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) muxApplication)
+        (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) app)
         Nothing
         (mkLocalSocketAddrInfo sockAddr)
   where
-    muxApplication :: MuxApplication InitiatorApp
-                                     (Socket.SockAddr, Socket.SockAddr)
-                                     DemoProtocol2 IO LBS.ByteString () Void
-    muxApplication =
-      simpleMuxInitiatorApplication protocols
+    app :: OuroborosApplication InitiatorApp (Socket.SockAddr, Socket.SockAddr) DemoProtocol2 IO LBS.ByteString () Void
+    app = simpleInitiatorApplication protocols
 
     protocols :: DemoProtocol2 -> MuxPeer (Socket.SockAddr, Socket.SockAddr)
                                           DeserialiseFailure IO LBS.ByteString ()
@@ -364,16 +354,13 @@ serverChainSync sockAddr = do
       (\(DictVersion codec)-> decodeTerm codec)
       (,)
       (\(DictVersion _) -> acceptEq)
-      (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) muxApplication) $ \_ serverAsync ->
+      (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) app) $ \_ serverAsync ->
         wait serverAsync   -- block until async exception
   where
     prng = mkSMGen 0
 
-    muxApplication :: MuxApplication ResponderApp
-                                     (Socket.SockAddr, Socket.SockAddr)
-                                     DemoProtocol2 IO LBS.ByteString Void ()
-    muxApplication =
-      simpleMuxResponderApplication protocols
+    app :: OuroborosApplication ResponderApp (Socket.SockAddr, Socket.SockAddr) DemoProtocol2 IO LBS.ByteString Void ()
+    app = simpleResponderApplication protocols
 
     protocols :: DemoProtocol2 -> MuxPeer (Socket.SockAddr, Socket.SockAddr)
                                           DeserialiseFailure IO LBS.ByteString ()
@@ -413,11 +400,8 @@ clientBlockFetch sockAddrs = do
     candidateChainsVar <- newTVarIO Map.empty
     currentChainVar    <- newTVarIO genesisChainFragment
 
-    let muxApplication :: MuxApplication InitiatorApp
-                                         (Socket.SockAddr, Socket.SockAddr) 
-                                         DemoProtocol3 IO LBS.ByteString () Void
-        muxApplication =
-          MuxInitiatorApplication protocols
+    let app :: OuroborosApplication InitiatorApp (Socket.SockAddr, Socket.SockAddr) DemoProtocol3 IO LBS.ByteString () Void
+        app = OuroborosInitiatorApplication protocols
 
         protocols :: (Socket.SockAddr, Socket.SockAddr)
                   -> DemoProtocol3
@@ -512,7 +496,7 @@ clientBlockFetch sockAddrs = do
                           (\(DictVersion codec) -> encodeTerm codec)
                           (\(DictVersion codec) -> decodeTerm codec)
                           (,)
-                          (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) muxApplication)
+                          (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) app)
                           Nothing
                           (mkLocalSocketAddrInfo sockAddr)
                     | sockAddr <- sockAddrs ]
@@ -553,14 +537,13 @@ serverBlockFetch sockAddr = do
       (\(DictVersion codec)-> decodeTerm codec)
       (,)
       (\(DictVersion _) -> acceptEq)
-      (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) muxApplication) $ \_ serverAsync ->
+      (simpleSingletonVersions (0::Int) (NodeToNodeVersionData 0) (DictVersion nodeToNodeCodecCBORTerm) app) $ \_ serverAsync ->
         wait serverAsync   -- block until async exception
   where
     prng = mkSMGen 0
 
-    muxApplication :: MuxApplication ResponderApp (Socket.SockAddr, Socket.SockAddr) DemoProtocol3 IO LBS.ByteString Void ()
-    muxApplication =
-      simpleMuxResponderApplication protocols
+    app :: OuroborosApplication ResponderApp (Socket.SockAddr, Socket.SockAddr) DemoProtocol3 IO LBS.ByteString Void ()
+    app = simpleResponderApplication protocols
 
     protocols :: DemoProtocol3 -> MuxPeer (Socket.SockAddr, Socket.SockAddr)
                                           DeserialiseFailure IO LBS.ByteString ()
@@ -746,7 +729,7 @@ chainGenerator g =
 genBlockChain :: RandomGen g => g -> Maybe BlockHeader -> [Block]
 genBlockChain !g prevHeader =
     block : genBlockChain g'' (Just (blockHeader block))
-  where 
+  where
     block     = genBlock g' prevHeader
     (g', g'') = split g
 

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -47,6 +47,7 @@ library
                        Ouroboros.Network.BlockFetch.DeltaQ
                        Ouroboros.Network.BlockFetch.State
                        Ouroboros.Network.ChainFragment
+                       Ouroboros.Network.Channel
                        Ouroboros.Network.DeltaQ
                        Ouroboros.Network.Mux
                        Ouroboros.Network.NodeToNode
@@ -159,6 +160,7 @@ test-suite tests
                        Ouroboros.Network.Chain
                        Ouroboros.Network.ChainFragment
                        Ouroboros.Network.ChainProducerState
+                       Ouroboros.Network.Channel
                        Ouroboros.Network.DeltaQ
                        Ouroboros.Network.Mux
                        Ouroboros.Network.Node

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -48,6 +48,7 @@ library
                        Ouroboros.Network.BlockFetch.State
                        Ouroboros.Network.ChainFragment
                        Ouroboros.Network.DeltaQ
+                       Ouroboros.Network.Mux
                        Ouroboros.Network.NodeToNode
                        Ouroboros.Network.NodeToClient
                        Ouroboros.Network.Point
@@ -159,6 +160,7 @@ test-suite tests
                        Ouroboros.Network.ChainFragment
                        Ouroboros.Network.ChainProducerState
                        Ouroboros.Network.DeltaQ
+                       Ouroboros.Network.Mux
                        Ouroboros.Network.Node
                        Ouroboros.Network.NodeToNode
                        Ouroboros.Network.Point

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -40,10 +40,9 @@ import           Ouroboros.Network.Protocol.BlockFetch.Type
 import           Ouroboros.Network.Protocol.BlockFetch.Server
 import           Ouroboros.Network.Protocol.BlockFetch.Codec
 import           Network.TypedProtocol.Core
+import           Network.TypedProtocol.Channel
 import           Network.TypedProtocol.Pipelined
 import           Network.TypedProtocol.Driver
-
-import           Network.Mux.Channel
 
 import           Ouroboros.Network.DeltaQ
 import           Ouroboros.Network.BlockFetch.Client

--- a/ouroboros-network/src/Ouroboros/Network/Channel.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Channel.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | The integration point of 'Network.TypedProtocol.Channel' and
+-- 'Network.Mux.Channel'.
+--
+module Ouroboros.Network.Channel
+  ( fromChannel
+  , toChannel
+
+  , createPipeConnectedChannels
+  ) where
+
+import qualified Data.ByteString.Lazy as LBS
+
+import qualified Network.TypedProtocol.Channel as TP
+import qualified Network.Mux.Channel as Mx
+
+fromChannel :: Mx.Channel m
+            -> TP.Channel m LBS.ByteString
+fromChannel Mx.Channel { Mx.send, Mx.recv } = TP.Channel {
+    TP.send = send,
+    TP.recv = recv
+  }
+
+toChannel :: TP.Channel m LBS.ByteString
+          -> Mx.Channel m
+toChannel TP.Channel { TP.send, TP.recv } = Mx.Channel {
+    Mx.send = send,
+    Mx.recv = recv
+  }
+
+-- | Create a local pipe, with both ends in this process, and expose that as
+-- a pair of 'Channel's, one for each end.
+--
+-- This is primarily for testing purposes since it does not allow actual IPC.
+--
+createPipeConnectedChannels :: IO (TP.Channel IO LBS.ByteString,
+                                   TP.Channel IO LBS.ByteString)
+createPipeConnectedChannels =
+    (\(a, b) -> (fromChannel a, fromChannel b))
+    <$> Mx.createPipeConnectedChannels

--- a/ouroboros-network/src/Ouroboros/Network/Mux.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Mux.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs     #-}
+
+module Ouroboros.Network.Mux
+  ( module Network.Mux
+  , module Network.Mux.Interface
+  , MuxPeer (..)
+  , runMuxPeer
+  , simpleMuxInitiatorApplication
+  , simpleMuxResponderApplication
+  ) where
+
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadThrow
+import           Control.Exception (Exception)
+import           Control.Tracer (Tracer)
+import           Data.Void (Void)
+
+import           Network.TypedProtocol.Core
+import           Network.TypedProtocol.Codec
+import           Network.TypedProtocol.Channel
+import           Network.TypedProtocol.Driver
+import           Network.TypedProtocol.Pipelined
+
+import           Network.Mux.Interface
+import           Network.Mux
+
+-- |
+-- This type is only necessary to use the @'simpleMuxClient'@ and
+-- @'simpleMuxServer'@ smart constructors.
+--
+data MuxPeer peerid failure m bytes a where
+    MuxPeer :: Tracer m (TraceSendRecv ps peerid failure)
+            -> Codec ps failure m bytes
+            -> Peer ps pr st m a
+            -> MuxPeer peerid failure m bytes a
+
+    MuxPeerPipelined
+            :: Tracer m (TraceSendRecv ps peerid failure)
+            -> Codec ps failure m bytes
+            -> PeerPipelined ps pr st m a
+            -> MuxPeer peerid failure m bytes a
+
+
+-- |
+-- Run a @'MuxPeer'@ using either @'runPeer'@ or @'runPipelinedPeer'@.
+--
+runMuxPeer
+  :: ( MonadThrow m
+     , MonadCatch m
+     , MonadAsync m
+     , Exception failure
+     )
+  => MuxPeer peerid failure m bytes a
+  -> peerid
+  -> Channel m bytes
+  -> m a
+runMuxPeer (MuxPeer tracer codec peer) peerid channel =
+    runPeer tracer codec peerid channel peer
+
+runMuxPeer (MuxPeerPipelined tracer codec peer) peerid channel =
+    runPipelinedPeer tracer codec peerid channel peer
+
+
+-- |
+-- Smart constructor for @'MuxInitiatorApplication'@.  It is a simple client, since
+-- none of the applications requires resource handling to run in the monad @m@.
+-- Each one is simply run either by @'runPeer'@ or @'runPipelinedPeer'@.
+--
+simpleMuxInitiatorApplication
+  :: MonadThrow m
+  => MonadCatch m
+  => MonadAsync m
+  => Exception failure
+  => (ptcl -> MuxPeer peerid failure m bytes a)
+  -> MuxApplication InitiatorApp peerid ptcl m bytes a Void
+simpleMuxInitiatorApplication fn = MuxInitiatorApplication $ \peerid ptcl channel ->
+  runMuxPeer (fn ptcl) peerid channel
+
+
+-- |
+-- Smart constructor for @'MuxResponderApplicatin'@, similar to @'simpleMuxInitiator'@.
+--
+simpleMuxResponderApplication
+  :: MonadThrow m
+  => MonadCatch m
+  => MonadAsync m
+  => Exception failure
+  => (ptcl -> MuxPeer peerid failure m bytes a)
+  -> MuxApplication ResponderApp peerid ptcl m bytes Void a
+simpleMuxResponderApplication fn = MuxResponderApplication $ \peerid ptcl channel ->
+  runMuxPeer (fn ptcl) peerid channel

--- a/ouroboros-network/src/Ouroboros/Network/Mux.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Mux.hs
@@ -1,13 +1,16 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs     #-}
+{-# LANGUAGE DataKinds      #-}
+{-# LANGUAGE GADTs          #-}
+{-# LANGUAGE KindSignatures #-}
 
 module Ouroboros.Network.Mux
-  ( module Network.Mux
-  , module Network.Mux.Interface
+  ( AppType (..)
+  , OuroborosApplication (..)
   , MuxPeer (..)
   , runMuxPeer
-  , simpleMuxInitiatorApplication
-  , simpleMuxResponderApplication
+  , simpleInitiatorApplication
+  , simpleResponderApplication
+
+  , toApplication
   ) where
 
 import           Control.Monad.Class.MonadAsync
@@ -15,6 +18,7 @@ import           Control.Monad.Class.MonadThrow
 import           Control.Exception (Exception)
 import           Control.Tracer (Tracer)
 import           Data.Void (Void)
+import qualified Data.ByteString.Lazy as LBS
 
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Codec
@@ -23,7 +27,40 @@ import           Network.TypedProtocol.Driver
 import           Network.TypedProtocol.Pipelined
 
 import           Network.Mux.Interface
-import           Network.Mux
+
+import           Ouroboros.Network.Channel
+
+
+-- |  Like 'MuxApplication' but using a more polymorphic 'Channel' type.
+--
+data OuroborosApplication (appType :: AppType) peerid ptcl m bytes a b where
+     OuroborosInitiatorApplication
+       :: (peerid -> ptcl -> Channel m bytes -> m a)
+       -> OuroborosApplication InitiatorApp peerid ptcl m bytes a Void
+
+     OuroborosResponderApplication
+       :: (peerid -> ptcl -> Channel m bytes -> m a)
+       -> OuroborosApplication ResponderApp peerid ptcl m bytes Void a
+
+     OuroborosInitiatorAndResponderApplication
+       :: (peerid -> ptcl -> Channel m bytes -> m a)
+       -> (peerid -> ptcl -> Channel m bytes -> m b)
+       -> OuroborosApplication InitiatorAndResponderApp peerid ptcl m bytes a b
+
+
+toApplication :: OuroborosApplication appType peerid ptcl m LBS.ByteString a b
+              -> MuxApplication appType peerid ptcl m a b
+toApplication (OuroborosInitiatorApplication f) =
+    MuxInitiatorApplication
+      (\peerid ptcl channel -> f peerid ptcl (fromChannel channel))
+toApplication (OuroborosResponderApplication f) =
+    MuxResponderApplication
+      (\peerid ptcl channel -> f peerid ptcl (fromChannel channel))
+toApplication (OuroborosInitiatorAndResponderApplication f g) =
+    MuxInitiatorAndResponderApplication
+      (\peerid ptcl channel -> f peerid ptcl (fromChannel channel))
+      (\peerid ptcl channel -> g peerid ptcl (fromChannel channel))
+
 
 -- |
 -- This type is only necessary to use the @'simpleMuxClient'@ and
@@ -67,26 +104,26 @@ runMuxPeer (MuxPeerPipelined tracer codec peer) peerid channel =
 -- none of the applications requires resource handling to run in the monad @m@.
 -- Each one is simply run either by @'runPeer'@ or @'runPipelinedPeer'@.
 --
-simpleMuxInitiatorApplication
+simpleInitiatorApplication
   :: MonadThrow m
   => MonadCatch m
   => MonadAsync m
   => Exception failure
   => (ptcl -> MuxPeer peerid failure m bytes a)
-  -> MuxApplication InitiatorApp peerid ptcl m bytes a Void
-simpleMuxInitiatorApplication fn = MuxInitiatorApplication $ \peerid ptcl channel ->
+  -> OuroborosApplication InitiatorApp peerid ptcl m bytes a Void
+simpleInitiatorApplication fn = OuroborosInitiatorApplication $ \peerid ptcl channel ->
   runMuxPeer (fn ptcl) peerid channel
 
 
 -- |
 -- Smart constructor for @'MuxResponderApplicatin'@, similar to @'simpleMuxInitiator'@.
 --
-simpleMuxResponderApplication
+simpleResponderApplication
   :: MonadThrow m
   => MonadCatch m
   => MonadAsync m
   => Exception failure
   => (ptcl -> MuxPeer peerid failure m bytes a)
-  -> MuxApplication ResponderApp peerid ptcl m bytes Void a
-simpleMuxResponderApplication fn = MuxResponderApplication $ \peerid ptcl channel ->
+  -> OuroborosApplication ResponderApp peerid ptcl m bytes Void a
+simpleResponderApplication fn = OuroborosResponderApplication $ \peerid ptcl channel ->
   runMuxPeer (fn ptcl) peerid channel

--- a/ouroboros-network/src/Ouroboros/Network/Node.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Node.hs
@@ -25,10 +25,10 @@ import           Control.Monad.Class.MonadTimer
 import           Control.Tracer (nullTracer)
 
 import           Network.TypedProtocol.Core
+import           Network.TypedProtocol.Channel
 import           Network.TypedProtocol.Driver
 import           Network.TypedProtocol.Codec.Cbor
 
-import           Network.Mux.Channel
 import           Network.Mux.Time
 
 import           Ouroboros.Network.Block

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -18,7 +18,7 @@ module Ouroboros.Network.NodeToClient (
   , withServer
 
   -- * Re-exports
-  , AnyMuxResponderApp (..)
+  , AnyResponderApp (..)
   ) where
 
 import           Control.Concurrent.Async (Async)
@@ -37,6 +37,7 @@ import qualified Network.Socket as Socket
 import           Network.Mux.Types (ProtocolEnum(..), MiniProtocolLimits (..))
 import           Network.Mux.Interface
 
+import           Ouroboros.Network.Mux
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.Socket
@@ -109,7 +110,7 @@ connectTo
   -- ^ create peerid from local address and remote address
   -> Versions NodeToClientVersion
               DictVersion
-              (MuxApplication InitiatorApp peerid NodeToClientProtocols IO BL.ByteString a b)
+              (OuroborosApplication InitiatorApp peerid NodeToClientProtocols IO BL.ByteString a b)
   -> Maybe Socket.AddrInfo
   -> Socket.AddrInfo
   -> IO ()
@@ -127,7 +128,7 @@ withServer
   -- ^ create peerid from local address and remote address
   -> (forall vData. DictVersion vData -> vData -> vData -> Accept)
   -> Versions NodeToClientVersion DictVersion
-              (AnyMuxResponderApp peerid NodeToClientProtocols IO BL.ByteString)
+              (AnyResponderApp peerid NodeToClientProtocols IO BL.ByteString)
   -> (Async () -> IO t)
   -> IO t
 withServer tbl addr peeridFn acceptVersion versions k =

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -19,7 +19,7 @@ module Ouroboros.Network.NodeToNode (
   , withServer
 
   -- * Re-exports
-  , AnyMuxResponderApp (..)
+  , AnyResponderApp (..)
   ) where
 
 import           Control.Concurrent.Async (Async)
@@ -39,6 +39,7 @@ import qualified Network.Socket as Socket
 import           Network.Mux.Types (ProtocolEnum(..), MiniProtocolLimits (..))
 import           Network.Mux.Interface
 
+import           Ouroboros.Network.Mux
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.Socket
@@ -123,7 +124,7 @@ connectTo
   -- ^ create peerid from local address and remote address
   -> Versions NodeToNodeVersion
               DictVersion
-              (MuxApplication InitiatorApp peerid NodeToNodeProtocols IO BL.ByteString a b)
+              (OuroborosApplication InitiatorApp peerid NodeToNodeProtocols IO BL.ByteString a b)
   -> Maybe Socket.AddrInfo
   -> Socket.AddrInfo
   -> IO ()
@@ -140,7 +141,7 @@ withServer
   -> (Socket.SockAddr -> Socket.SockAddr -> peerid)
   -- ^ create peerid from local address and remote address
   -> (forall vData. DictVersion vData -> vData -> vData -> Accept)
-  -> Versions NodeToNodeVersion DictVersion (AnyMuxResponderApp peerid NodeToNodeProtocols IO BL.ByteString)
+  -> Versions NodeToNodeVersion DictVersion (AnyResponderApp peerid NodeToNodeProtocols IO BL.ByteString)
   -> (Async () -> IO t)
   -> IO t
 withServer tbl addr peeridFn acceptVersion versions k =

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -19,9 +19,10 @@ import           Control.Tracer (nullTracer)
 
 import           Network.TypedProtocol.Driver
 import           Network.TypedProtocol.Codec
+import           Network.TypedProtocol.Channel
 import           Network.TypedProtocol.Proofs
 
-import           Network.Mux.Channel
+import           Ouroboros.Network.Channel
 
 import           Ouroboros.Network.Block (StandardHash)
 import           Ouroboros.Network.Chain (Chain, Point)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -23,10 +23,11 @@ import           Control.Tracer (nullTracer)
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Network.TypedProtocol.Codec
+import           Network.TypedProtocol.Channel
 import           Network.TypedProtocol.Driver
 import           Network.TypedProtocol.Proofs (connect)
 
-import           Network.Mux.Channel
+import           Ouroboros.Network.Channel
 
 import           Ouroboros.Network.Chain (Point)
 import qualified Ouroboros.Network.Chain as Chain

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -27,9 +27,10 @@ import           Network.TypedProtocol.Codec
 import           Network.TypedProtocol.Channel
 import           Network.TypedProtocol.Driver
 import           Network.TypedProtocol.Proofs
-import           Network.Mux.Channel
 
 import           Test.Ouroboros.Network.Testing.Utils (splits2, splits3)
+
+import           Ouroboros.Network.Channel
 
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Codec

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
@@ -27,10 +27,11 @@ import qualified Codec.Serialise as Serialise (encode, decode)
 
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Driver
+import           Network.TypedProtocol.Channel
 import           Network.TypedProtocol.Proofs
 import           Network.TypedProtocol.Codec.Cbor hiding (prop_codec)
 
-import           Network.Mux.Channel
+import           Ouroboros.Network.Channel
 
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Client
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Codec

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Test.hs
@@ -29,10 +29,12 @@ import           Codec.Serialise (Serialise)
 import qualified Codec.Serialise as Serialise (encode, decode)
 
 import           Network.TypedProtocol.Core
+import           Network.TypedProtocol.Channel
 import           Network.TypedProtocol.Driver
 import           Network.TypedProtocol.Proofs
 import           Network.TypedProtocol.Codec.Cbor hiding (prop_codec)
-import           Network.Mux.Channel
+
+import           Ouroboros.Network.Channel
 
 import           Ouroboros.Network.Protocol.TxSubmission.Client
 import           Ouroboros.Network.Protocol.TxSubmission.Codec

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -40,8 +40,7 @@ import qualified Ouroboros.Network.Protocol.ChainSync.Codec    as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Examples as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Server   as ChainSync
 
-import qualified Network.Mux as Mx
-import qualified Network.Mux.Interface as Mx
+import qualified Ouroboros.Network.Mux as Mx
 import qualified Network.Mux.Bearer.Queues as Mx
 
 

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -40,8 +40,9 @@ import qualified Ouroboros.Network.Protocol.ChainSync.Codec    as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Examples as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Server   as ChainSync
 
-import qualified Ouroboros.Network.Mux as Mx
+import qualified Network.Mux.Types as Mx
 import qualified Network.Mux.Bearer.Queues as Mx
+import qualified Ouroboros.Network.Mux as Mx
 
 
 tests :: TestTree
@@ -99,7 +100,7 @@ demo chain0 updates delay = do
         consumerPeer = ChainSync.chainSyncClientPeer
                           (ChainSync.chainSyncClientExample consumerVar
                           (consumerClient done target consumerVar))
-        consumerApp = Mx.simpleMuxInitiatorApplication
+        consumerApp = Mx.simpleInitiatorApplication
                         (\ChainSyncPr ->
                             Mx.MuxPeer
                               nullTracer
@@ -108,15 +109,15 @@ demo chain0 updates delay = do
 
         producerPeer :: Peer (ChainSync.ChainSync block (Point block)) AsServer ChainSync.StIdle m ()
         producerPeer = ChainSync.chainSyncServerPeer (ChainSync.chainSyncServerExample () producerVar)
-        producerApp = Mx.simpleMuxResponderApplication
+        producerApp = Mx.simpleResponderApplication
                         (\ChainSyncPr ->
                             Mx.MuxPeer
                               nullTracer
                               (ChainSync.codecChainSync encode decode encode decode)
                               producerPeer)
 
-    clientAsync <- async $ Mx.runMuxWithQueues "consumer" consumerApp client_w client_r sduLen Nothing
-    serverAsync <- async $ Mx.runMuxWithQueues "producer" producerApp server_w server_r sduLen Nothing
+    clientAsync <- async $ Mx.runMuxWithQueues "consumer" (Mx.toApplication consumerApp) client_w client_r sduLen Nothing
+    serverAsync <- async $ Mx.runMuxWithQueues "producer" (Mx.toApplication producerApp) server_w server_r sduLen Nothing
 
     updateAid <- async $ sequence_
         [ do threadDelay delay -- X milliseconds, just to provide interest

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -24,8 +24,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 import           Control.Tracer (nullTracer)
 
-import qualified Network.Mux as Mx
-import qualified Network.Mux.Interface as Mx
+import qualified Ouroboros.Network.Mux as Mx
 import qualified Network.Mux.Bearer.Pipe as Mx
 
 import           Ouroboros.Network.Chain (Chain, ChainUpdate, Point)

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -39,8 +39,8 @@ import qualified Network.TypedProtocol.ReqResp.Examples as ReqResp
 import           Codec.SerialiseTerm
 import           Control.Tracer
 
-import qualified Network.Mux as Mx
-import           Network.Mux.Interface
+-- TODO: remove Mx prefixes
+import           Ouroboros.Network.Mux as Mx
 import qualified Network.Mux.Bearer.Socket as Mx
 
 import           Ouroboros.Network.Socket
@@ -208,7 +208,7 @@ prop_socket_send_recv initiatorAddr responderAddr f xs = do
 
     let -- Server Node; only req-resp server
         responderApp :: MuxApplication ResponderApp () TestProtocols2 IO BL.ByteString Void ()
-        responderApp = MuxResponderApplication $
+        responderApp = Mx.MuxResponderApplication $
           \peerid ReqRespPr channel -> do
             r <- runPeer nullTracer
                          ReqResp.codecReqResp

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -41,6 +41,7 @@ import           Control.Tracer
 
 -- TODO: remove Mx prefixes
 import           Ouroboros.Network.Mux as Mx
+import qualified Network.Mux as Mx
 import qualified Network.Mux.Bearer.Socket as Mx
 
 import           Ouroboros.Network.Socket
@@ -58,7 +59,6 @@ import           Ouroboros.Network.Protocol.Handshake.Version (simpleSingletonVe
 import           Ouroboros.Network.Testing.Serialise
 
 import           Test.ChainGenerators (TestBlockChainAndUpdates (..))
--- import           Test.Mux.ReqResp
 
 import           Test.QuickCheck
 import           Test.Tasty (DependencyType (..), TestTree, after, testGroup)
@@ -207,8 +207,8 @@ prop_socket_send_recv initiatorAddr responderAddr f xs = do
     siblingVar <- newTVarM 2
 
     let -- Server Node; only req-resp server
-        responderApp :: MuxApplication ResponderApp () TestProtocols2 IO BL.ByteString Void ()
-        responderApp = Mx.MuxResponderApplication $
+        responderApp :: OuroborosApplication Mx.ResponderApp () TestProtocols2 IO BL.ByteString Void ()
+        responderApp = OuroborosResponderApplication $
           \peerid ReqRespPr channel -> do
             r <- runPeer nullTracer
                          ReqResp.codecReqResp
@@ -219,8 +219,8 @@ prop_socket_send_recv initiatorAddr responderAddr f xs = do
             waitSibling siblingVar
 
         -- Client Node; only req-resp client
-        initiatorApp :: MuxApplication InitiatorApp () TestProtocols2 IO BL.ByteString () Void
-        initiatorApp = MuxInitiatorApplication $
+        initiatorApp :: OuroborosApplication Mx.InitiatorApp () TestProtocols2 IO BL.ByteString () Void
+        initiatorApp = OuroborosInitiatorApplication $
           \peerid ReqRespPr channel -> do
             r <- runPeer nullTracer
                          ReqResp.codecReqResp
@@ -269,8 +269,8 @@ prop_socket_recv_close f _ = ioProperty $ do
 
     sv   <- newEmptyTMVarM
 
-    let app :: MuxApplication ResponderApp () TestProtocols2 IO BL.ByteString Void ()
-        app = MuxResponderApplication $
+    let app :: OuroborosApplication ResponderApp () TestProtocols2 IO BL.ByteString Void ()
+        app = OuroborosResponderApplication $
           \peerid ReqRespPr channel -> do
             r <- runPeer nullTracer
                          ReqResp.codecReqResp
@@ -298,7 +298,7 @@ prop_socket_recv_close f _ = ioProperty $ do
                 $ \(sd',_) -> do
                   bearer <- Mx.socketAsMuxBearer sd'
                   Mx.muxBearerSetState bearer Mx.Connected
-                  Mx.muxStart () app bearer
+                  Mx.muxStart () (toApplication app) bearer
           )
           $ \muxAsync -> do
 
@@ -327,8 +327,8 @@ prop_socket_client_connect_error _ xs = ioProperty $ do
 
     cv <- newEmptyTMVarM
 
-    let app :: MuxApplication InitiatorApp (Socket.SockAddr, Socket.SockAddr) TestProtocols2 IO BL.ByteString () Void
-        app = MuxInitiatorApplication $
+    let app :: OuroborosApplication Mx.InitiatorApp (Socket.SockAddr, Socket.SockAddr) TestProtocols2 IO BL.ByteString () Void
+        app = OuroborosInitiatorApplication $
                 \peerid ReqRespPr channel -> do
                   _ <- runPeer nullTracer
                           ReqResp.codecReqResp
@@ -368,8 +368,8 @@ demo chain0 updates = do
     let Just expectedChain = Chain.applyChainUpdates updates chain0
         target = Chain.headPoint expectedChain
 
-        initiatorApp :: MuxApplication InitiatorApp (Socket.SockAddr, Socket.SockAddr) TestProtocols1 IO BL.ByteString () Void
-        initiatorApp = simpleMuxInitiatorApplication $
+        initiatorApp :: OuroborosApplication Mx.InitiatorApp (Socket.SockAddr, Socket.SockAddr) TestProtocols1 IO BL.ByteString () Void
+        initiatorApp = simpleInitiatorApplication $
           \ChainSyncPr ->
               MuxPeer nullTracer
                       (ChainSync.codecChainSync encode decode encode decode)
@@ -380,8 +380,8 @@ demo chain0 updates = do
         server :: ChainSync.ChainSyncServer block (Point block) IO ()
         server = ChainSync.chainSyncServerExample () producerVar
 
-        responderApp :: MuxApplication ResponderApp (Socket.SockAddr, Socket.SockAddr)TestProtocols1 IO BL.ByteString Void ()
-        responderApp = simpleMuxResponderApplication $
+        responderApp :: OuroborosApplication Mx.ResponderApp (Socket.SockAddr, Socket.SockAddr) TestProtocols1 IO BL.ByteString Void ()
+        responderApp = simpleResponderApplication $
           \ChainSyncPr ->
             MuxPeer nullTracer
                     (ChainSync.codecChainSync encode decode encode decode)

--- a/typed-protocols/typed-protocols.cabal
+++ b/typed-protocols/typed-protocols.cabal
@@ -48,7 +48,8 @@ library
   build-depends:     base,
                      io-sim-classes,
                      bytestring,
-                     contra-tracer
+                     contra-tracer,
+                     time
 
   hs-source-dirs:    src
   default-language:  Haskell2010
@@ -86,6 +87,7 @@ test-suite tests
                    , QuickCheck
                    , tasty
                    , tasty-quickcheck
+                   , time
   default-language:  Haskell2010
   ghc-options:       -rtsopts
                      -Wall


### PR DESCRIPTION
This PR makes `network-mux` indenependent of `typed-protocols`.  In tests it is using a simple implementation of `ReqResp` protocol without `typed-protocols`.  I initially thought it will be easier, but as a side effect it made quite explicit that `network-mux` depends on using an incremental decoder. (I am also fine with using typed-protocols in the tests, dropping one commit from this PR).

This has some consequences on `ouroboros-network`, suggestions for better names in `Ouroboros.Network.Mux` are welcome.   One suggestion I have is to move `Ouroboros.Network.Mux` as `Ouroboros.Network` (drop the `Mux` prefix in names), and possibly include more useful exports there e.g. (`Network.Mux.Interface`, `Ouroboros.Network.NodeToClient` and `Ouroboros.Network.NodeToNode`, and possible some other stuff). This could go into a separate PR though.