### PR TITLE
Extend TraceSendRecv type

### DIFF
--- a/network-mux/src/Network/Mux/Interface.hs
+++ b/network-mux/src/Network/Mux/Interface.hs
@@ -132,13 +132,13 @@ responderApplication (MuxInitiatorAndResponderApplication _ app) = app
 -- This type is only necessary to use the @'simpleMuxClient'@ and
 -- @'simpleMuxServer'@ smart constructors.
 data MuxPeer failure m bytes a where
-    MuxPeer :: Tracer m (TraceSendRecv ps)
+    MuxPeer :: Tracer m (TraceSendRecv ps failure)
             -> Codec ps failure m bytes
             -> Peer ps pr st m a
             -> MuxPeer failure m bytes a
 
     MuxPeerPipelined
-            :: Tracer m (TraceSendRecv ps)
+            :: Tracer m (TraceSendRecv ps failure)
             -> Codec ps failure m bytes
             -> PeerPipelined ps pr st m a
             -> MuxPeer failure m bytes a

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -265,8 +265,8 @@ consensusNetworkApps
        , Ord peer
        , Exception failure
        )
-    => Tracer m (TraceSendRecv (ChainSync (Header blk) (Point blk)))
-    -> Tracer m (TraceSendRecv (BlockFetch blk))
+    => Tracer m (TraceSendRecv (ChainSync (Header blk) (Point blk)) failure)
+    -> Tracer m (TraceSendRecv (BlockFetch blk) failure)
     -> NodeKernel m peer blk
     -> ProtocolCodecs blk failure m bytesCS bytesBF bytesLCS bytesTX
     -> ProtocolHandlers m peer blk

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -17,6 +17,7 @@ import qualified Data.Set as Set
 import           Data.Set (Set)
 import qualified Data.ByteString.Lazy as LBS
 import           Codec.Serialise (Serialise(..))
+import           Codec.CBOR.Read (DeserialiseFailure)
 
 import           Control.Monad (forever)
 import           Control.Monad.Class.MonadSTM
@@ -75,7 +76,7 @@ blockFetchExample1 :: forall m.
                    -> Tracer m (TraceLabelPeer Int
                                  (TraceFetchClientState BlockHeader))
                    -> Tracer m (TraceLabelPeer Int
-                                 (TraceSendRecv (BlockFetch Block)))
+                                 (TraceSendRecv (BlockFetch Block) DeserialiseFailure))
                    -> AnchoredFragment Block   -- ^ Fixed current chain
                    -> [AnchoredFragment Block] -- ^ Fixed candidate chains
                    -> m ()
@@ -187,7 +188,7 @@ exampleFixedPeerGSVs =
 
 runFetchClient :: (MonadCatch m, MonadAsync m, MonadFork m, MonadST m,
                    Ord peerid, Serialise block, Serialise (HeaderHash block))
-                => Tracer m (TraceSendRecv (BlockFetch block))
+                => Tracer m (TraceSendRecv (BlockFetch block) DeserialiseFailure)
                 -> FetchClientRegistry peerid header block m
                 -> peerid
                 -> Channel m LBS.ByteString
@@ -204,7 +205,7 @@ runFetchClient tracer registry peerid channel client =
 runFetchServer :: (MonadThrow m, MonadST m,
                    Serialise block,
                    Serialise (HeaderHash block))
-                => Tracer m (TraceSendRecv (BlockFetch block))
+                => Tracer m (TraceSendRecv (BlockFetch block) DeserialiseFailure)
                 -> Channel m LBS.ByteString
                 -> BlockFetchServer block m a
                 -> m a
@@ -219,8 +220,8 @@ runFetchClientAndServerAsync
                    MonadST m, Ord peerid,
                    Serialise header, Serialise block,
                    Serialise (HeaderHash block))
-                => Tracer m (TraceSendRecv (BlockFetch block))
-                -> Tracer m (TraceSendRecv (BlockFetch block))
+                => Tracer m (TraceSendRecv (BlockFetch block) DeserialiseFailure)
+                -> Tracer m (TraceSendRecv (BlockFetch block) DeserialiseFailure)
                 -> FetchClientRegistry peerid header block m
                 -> peerid
                 -> (  FetchClientContext header block m

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -90,3 +90,10 @@ instance (Show block, StandardHash block)
   show MsgNoBlocks             = "MsgNoBlocks"
   show MsgBatchDone            = "MsgBatchDone"
   show MsgClientDone           = "MsgClientDone"
+
+instance Show (ClientHasAgency (st :: BlockFetch block)) where
+  show TokIdle = "TokIdle" 
+
+instance Show (ServerHasAgency (st :: BlockFetch block)) where
+  show TokBusy      = "TokBusy"
+  show TokStreaming = "TokStreaming"

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE EmptyCase         #-}
+{-# LANGUAGE PolyKinds         #-}
 
 -- | The type of the chain synchronisation protocol.
 --
@@ -153,3 +154,11 @@ instance (Show header, Show point) => Show (Message (ChainSync header point) fro
   show (MsgIntersectImproved p tip) = "MsgIntersectImproved " ++ show p ++ " " ++ show tip
   show (MsgIntersectUnchanged p)    = "MsgIntersectUnchanged " ++ show p
   show MsgDone{}                    = "MsgDone"
+
+instance Show (ClientHasAgency (st :: ChainSync header point)) where
+    show TokIdle = "TokIdle"
+
+instance Show (ServerHasAgency (st :: ChainSync header point)) where
+    show (TokNext TokCanAwait)  = "TokNext TokCanAwait"
+    show (TokNext TokMustReply) = "TokNext TokMustReply"
+    show TokIntersect           = "TokIntersect"

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE PolyKinds             #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
@@ -149,6 +150,12 @@ instance Protocol (Handshake vNumber vParams) where
 
 deriving instance (Show vNumber, Show vParams)
     => Show (Message (Handshake vNumber vParams) from to)
+
+instance Show (ClientHasAgency (st :: Handshake vNumber vParams)) where
+    show TokPropose = "TokPropose"
+
+instance Show (ServerHasAgency (st :: Handshake vNumber vParams)) where
+    show TokConfirm = "TokConfirm"
 
 encodeVersions
   :: forall vNumber extra r vParams.

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Type.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE EmptyCase          #-}
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE GADTs              #-}
+{-# LANGUAGE PolyKinds          #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies       #-}
 
@@ -106,3 +107,8 @@ deriving instance (Eq tx, Eq reject) =>
 deriving instance (Show tx, Show reject) =>
                    Show (Message (LocalTxSubmission tx reject) from to)
 
+instance Show (ClientHasAgency (st :: LocalTxSubmission tx reject)) where
+  show TokIdle = "TokIdle"
+
+instance Show (ServerHasAgency (st :: LocalTxSubmission tx reject)) where
+  show TokBusy = "TokBusy"

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE EmptyCase          #-}
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE GADTs              #-}
+{-# LANGUAGE PolyKinds          #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies       #-}
 
@@ -251,3 +252,10 @@ deriving instance (Eq txid, Eq tx) =>
 deriving instance (Show txid, Show tx) =>
                   Show (Message (TxSubmission txid tx) from to)
 
+instance Show (ClientHasAgency (st :: TxSubmission txid tx)) where
+  show (TokTxIds TokBlocking)    = "TokTxIds TokBlocking"
+  show (TokTxIds TokNonBlocking) = "TokTxIds TokNonBlocking"
+  show TokTxs                    = "TokTxs"
+
+instance Show (ServerHasAgency (st :: TxSubmission txid tx)) where
+  show TokIdle = "TokIdle"

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -12,6 +12,7 @@ import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck (testProperty)
 import           Test.ChainGenerators (TestChainFork(..))
 
+import           Codec.CBOR.Read (DeserialiseFailure)
 import           Data.List
 import qualified Data.Set as Set
 import           Data.Set (Set)
@@ -174,7 +175,7 @@ data Example1TraceEvent =
    | TraceFetchClientState    (TraceLabelPeer Int
                                 (TraceFetchClientState BlockHeader))
    | TraceFetchClientSendRecv (TraceLabelPeer Int
-                                (TraceSendRecv (BlockFetch Block)))
+                                (TraceSendRecv (BlockFetch Block) DeserialiseFailure))
 
 instance Show Example1TraceEvent where
   show (TraceFetchDecision       x) = "TraceFetchDecision " ++ show x

--- a/typed-protocols/src/Network/TypedProtocol/Core.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Core.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeInType #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 
 
 -- | This module defines the core of the typed protocol framework.
@@ -324,6 +325,12 @@ data PeerRole = AsClient | AsServer
 data PeerHasAgency (pr :: PeerRole) (st :: ps) where
   ClientAgency :: !(ClientHasAgency st) -> PeerHasAgency AsClient st
   ServerAgency :: !(ServerHasAgency st) -> PeerHasAgency AsServer st
+
+instance ( forall (st' :: ps). Show (ClientHasAgency st')
+         , forall (st' :: ps). Show (ServerHasAgency st')
+         ) => Show (PeerHasAgency pr (st :: ps)) where
+    show (ClientAgency stok) = "ClientAgency " ++ show stok
+    show (ServerAgency stok) = "ServerAgency " ++ show stok
 
 -- | A synonym for an state token in which \"our\" peer has agency. This is
 -- parametrised over the client or server roles. In either case the peer in

--- a/typed-protocols/src/Network/TypedProtocol/Driver/ByteLimit.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver/ByteLimit.hs
@@ -71,7 +71,7 @@ runPeerWithByteLimit
   -- ^ message size limit
   -> (bytes -> Int64)
   -- ^ byte size
-  -> Tracer m (TraceSendRecv ps)
+  -> Tracer m (TraceSendRecv ps (DecoderFailureOrTooMuchInput failure))
   -> Codec ps failure m bytes
   -> Channel m bytes
   -> Peer ps pr st m a
@@ -99,5 +99,6 @@ runPeerWithByteLimit limit byteLength tr Codec{encode, decode} channel@Channel{s
         Right (SomeMessage msg, trailing') -> do
           traceWith tr (TraceRecvMsg (AnyMessage msg))
           go trailing' (k msg)
-        Left failure ->
+        Left failure -> do
+          traceWith tr (TraceDecoderFailure stok failure)
           throwM failure

--- a/typed-protocols/src/Network/TypedProtocol/PingPong/Tests.hs
+++ b/typed-protocols/src/Network/TypedProtocol/PingPong/Tests.hs
@@ -270,7 +270,7 @@ prop_connect_pipelined5 choices (Positive omax) (NonNegative n) =
 -- | Run a non-pipelined client and server over a channel using a codec.
 --
 prop_channel :: (MonadSTM m, MonadAsync m, MonadCatch m)
-             => NonNegative Int -> Tracer m (TraceSendRecv PingPong) -> m Bool
+             => NonNegative Int -> Tracer m (TraceSendRecv PingPong CodecFailure) -> m Bool
 prop_channel (NonNegative n) tr = do
     ((), n') <- runConnectedPeers createConnectedChannels
                                   tr

--- a/typed-protocols/src/Network/TypedProtocol/PingPong/Type.hs
+++ b/typed-protocols/src/Network/TypedProtocol/PingPong/Type.hs
@@ -79,3 +79,8 @@ instance Protocol PingPong where
 
 deriving instance Show (Message PingPong from to)
 
+instance Show (ClientHasAgency (st :: PingPong)) where
+  show TokIdle = "TokIdle"
+
+instance Show (ServerHasAgency (st :: PingPong)) where
+  show TokBusy = "TokBusy"

--- a/typed-protocols/src/Network/TypedProtocol/ReqResp/Type.hs
+++ b/typed-protocols/src/Network/TypedProtocol/ReqResp/Type.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE PolyKinds #-}
 
 
 module Network.TypedProtocol.ReqResp.Type where
@@ -42,3 +43,9 @@ deriving instance (Show req, Show resp)
 
 deriving instance (Eq req, Eq resp)
                => Eq (Message (ReqResp req resp) from to)
+
+instance Show (ClientHasAgency (st :: ReqResp req resp)) where
+    show TokIdle = "TokIdle"
+
+instance Show (ServerHasAgency (st :: ReqResp req resp)) where
+    show TokBusy = "TokBusy"

--- a/typed-transitions/src/Protocol/PingPong/Type.hs
+++ b/typed-transitions/src/Protocol/PingPong/Type.hs
@@ -54,4 +54,3 @@ instance Show (PingPongMessage from to) where
   show MsgPing = "MsgPing"
   show MsgPong = "MsgPong"
   show MsgDone = "MsgDone"
-


### PR DESCRIPTION
Tracing decoding failures, using quantified constraints to capture the
state in the logs.  Also includes show instances for all
ouroboros-network protocols.

Fixes #715 