### PR TITLE
nix-shell, almost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist/
 *.swp
 *.swo
 *~
+\#*
 *_flymake.hs
 result*
 **/tags

--- a/default.nix
+++ b/default.nix
@@ -54,27 +54,7 @@ let
   documents = import ./doc/default.nix {inherit commonLib; };
 in {
   inherit scripts tests;
-  inherit (nixTools) nix-tools;
+  inherit (nixTools) nix-tools shell;
   network-pdf-wip = documents.network-pdf-wip;
   network-pdf = documents.network-pdf;
-
-  shell = nixTools.nix-tools.shellFor {
-    inherit withHoogle;
-    packages = pkgs: with pkgs; [
-      io-sim
-      io-sim-classes
-      ouroboros-consensus
-      ouroboros-network
-      typed-transitions
-    ];
-    buildInputs = with nixTools.nix-tools._raw; [
-      cabal-install.components.exes.cabal
-      commonLib.stack-hpc-coveralls
-    ] ++ (with commonLib.pkgs; [
-      git
-      pkgconfig
-      stack
-      systemd
-    ]);
-  };
 }

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,6 @@
-{ customConfig ? {}, ... }:
+{ customConfig ? {}
+, withHoogle ? true
+, ... }:
 #
 # The default.nix file. This will generate targets for all
 # buildables (see release.nix for nomenclature, excluding
@@ -55,4 +57,24 @@ in {
   inherit (nixTools) nix-tools;
   network-pdf-wip = documents.network-pdf-wip;
   network-pdf = documents.network-pdf;
+
+  shell = nixTools.nix-tools.shellFor {
+    inherit withHoogle;
+    packages = pkgs: with pkgs; [
+      io-sim
+      io-sim-classes
+      ouroboros-consensus
+      ouroboros-network
+      typed-transitions
+    ];
+    buildInputs = with nixTools.nix-tools._raw; [
+      cabal-install.components.exes.cabal
+      commonLib.stack-hpc-coveralls
+    ] ++ (with commonLib.pkgs; [
+      git
+      pkgconfig
+      stack
+      systemd
+    ]);
+  };
 }

--- a/nix/nix-tools.nix
+++ b/nix/nix-tools.nix
@@ -1,6 +1,27 @@
-{ ... }@args:
+{ withHoogle ? true
+, ... }@args:
 
 let
   commonLib = import ./iohk-common.nix;
-
-in commonLib.nix-tools.default-nix ./pkgs.nix args
+  pkgs      = commonLib.nix-tools.default-nix ./pkgs.nix args;
+in pkgs // {
+  shell = pkgs.nix-tools.shellFor {
+    inherit withHoogle;
+    packages = pkgs: with pkgs; [
+      io-sim
+      io-sim-classes
+      ouroboros-consensus
+      ouroboros-network
+      typed-transitions
+    ];
+    buildInputs = with pkgs.nix-tools._raw; [
+      cabal-install.components.exes.cabal
+      commonLib.stack-hpc-coveralls
+    ] ++ (with commonLib.pkgs; [
+      git
+      pkgconfig
+      stack
+      systemd
+    ]);
+  };
+}

--- a/release.nix
+++ b/release.nix
@@ -67,6 +67,7 @@ commonLib.pkgs.lib.mapAttrsRecursiveCond
     network-pdf-wip = default.network-pdf-wip;
     network-pdf = default.network-pdf;
   };
+  builds-on-supported-systems = [ "shell" ];
   required-targets = jobs: [
     # targets are specified using above nomenclature:
     jobs.nix-tools.tests.ouroboros-consensus.test-consensus.x86_64-linux

--- a/shell.nix
+++ b/shell.nix
@@ -4,14 +4,14 @@ let
   default = import ./default.nix {};
 in
 default.nix-tools._raw.shellFor {
-  packages    = p: map (x: p."${x}") [
-    "io-sim"
-    "io-sim-classes"
-    "ouroboros-consensus"
-    "ouroboros-network"
-    "typed-transitions"
+  packages    = ps: with ps; [
+    io-sim
+    io-sim-classes
+    ouroboros-consensus
+    ouroboros-network
+    typed-transitions
   ];
-  withHoogle  = withHoogle;
+  inherit withHoogle;
   buildInputs = with default.nix-tools._raw; [
     cabal-install.components.exes.cabal
   ];

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,18 @@
+{ withHoogle ? true
+}:
+let
+  default = import ./default.nix {};
+in
+default.nix-tools._raw.shellFor {
+  packages    = p: map (x: p."${x}") [
+    "io-sim"
+    "io-sim-classes"
+    "ouroboros-consensus"
+    "ouroboros-network"
+    "typed-transitions"
+  ];
+  withHoogle  = withHoogle;
+  buildInputs = with default.nix-tools._raw; [
+    cabal-install.components.exes.cabal
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,18 +1,3 @@
 { withHoogle ? true
 }:
-let
-  default = import ./default.nix {};
-in
-default.nix-tools._raw.shellFor {
-  packages    = ps: with ps; [
-    io-sim
-    io-sim-classes
-    ouroboros-consensus
-    ouroboros-network
-    typed-transitions
-  ];
-  inherit withHoogle;
-  buildInputs = with default.nix-tools._raw; [
-    cabal-install.components.exes.cabal
-  ];
-}
+(import ./default.nix { inherit withHoogle; }).shell


### PR DESCRIPTION
Updated version of https://github.com/input-output-hk/ouroboros-network/pull/645

This _almost_ brings back `nix-shell` that can build/run `demo-playground`.

The only blocker is the need to remove the source package definitions in the Cabal project file, which is caused by this Cabal issue: https://github.com/haskell/cabal/issues/6049#issuecomment-502113697