### PR TITLE
Fix use of FingerTree.search

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE PatternSynonyms       #-}
 
 module Ouroboros.Consensus.Mempool.TxSeq (
-    TicketNo
+    TicketNo(..)
   , TxTicket(..)
   , TxSeq(Empty, (:>), (:<))
   , appendTx
@@ -137,7 +137,7 @@ infixl 5 :>, :<
 lookupByTicketNo :: TxSeq tx -> TicketNo -> Maybe tx
 lookupByTicketNo (TxSeq txs) n =
     case FingerTree.search (\ml mr -> mMaxTicket ml >= n
-                                   && mMinTicket mr >= n) txs of
+                                   && mMinTicket mr >  n) txs of
       FingerTree.Position _ (TxTicket tx _) _ -> Just tx
       _                                       -> Nothing
 

--- a/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
@@ -421,7 +421,7 @@ lookupBySlotFT :: HasHeader block
                -> SlotNo
                -> FT.SearchResult BlockMeasure block
 lookupBySlotFT (ChainFragment t) s =
-    FT.search (\vl vr -> bmMaxSlot vl >= s && bmMinSlot vr >= s) t
+    FT.search (\vl vr -> bmMaxSlot vl >= s && bmMinSlot vr > s) t
 
 -- | \( O(\log(\min(i,n-i)) \). Find the oldest block in the chain fragment
 -- with a slot equal to the given slot.

--- a/ouroboros-network/test/Test/ChainFragment.hs
+++ b/ouroboros-network/test/Test/ChainFragment.hs
@@ -93,6 +93,7 @@ tests = testGroup "ChainFragment"
   , testProperty "rollback/head"                             prop_rollback_head
   , testProperty "successorBlock"                            prop_successorBlock
   , testProperty "lookupBySlot"                              prop_lookupBySlot
+  , testProperty "lookupBySlot2"                             prop_lookupBySlot2
   , testProperty "intersectChainFragments"                   prop_intersectChainFragments
   , testProperty "serialise chain"                           prop_serialise_chain
   , testProperty "slotOnChainFragment"                       prop_slotOnChainFragment
@@ -231,6 +232,14 @@ prop_lookupBySlot (TestChainFragmentAndPoint c p) =
     Just b  -> CF.slotOnChainFragment (blockSlot b) c
             && CF.blockSlot b == slot
     Nothing -> not (CF.slotOnChainFragment slot c)
+
+prop_lookupBySlot2 :: TestBlockChainFragment -> Bool
+prop_lookupBySlot2 (TestBlockChainFragment c) =
+  and [ case CF.lookupBySlot c slot of
+          Just b' -> b == b'
+          Nothing -> False
+      | b <- CF.toNewestFirst c
+      , let slot = pointSlot (blockPoint b) ]
 
 prop_intersectChainFragments :: TestChainFragmentFork -> Property
 prop_intersectChainFragments (TestChainFragmentFork origL1 origL2 c1 c2) =


### PR DESCRIPTION
The predicate needs to satisfy the properties given in the docs

http://hackage.haskell.org/package/fingertree-0.1.4.2/docs/Data-FingerTree.html#g:4

Fixed uses of search in TxSeq and in ChainFragment and added a test for TxSeq and added an additional test for ChainFragment. The ChainFragment test was not failing, but it's not clear to me yet why not.