### PR TITLE
Add  Show (Header blk) constraint to RunDemo

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Run.hs
@@ -64,7 +64,13 @@ class ( ProtocolLedgerView blk
       , Condense (HeaderHash blk)
       , Condense blk
       , Condense [blk]
+      -- TODO: the show constraints are needed when using a tracer which logs
+      -- a mini-protocol messages, or the fetch client decisions, we should
+      -- rethink where the condense class lives so that we can provide
+      -- 'Condenese' instances for data structures defined in ouroboros-network
+      -- or provide them in the module where 'Condense' is defined.
       , Show blk
+      , Show (Header blk)
       , ApplyTx blk
       , Show (ApplyTxErr blk)
       , Condense (GenTx blk)


### PR DESCRIPTION
It would be better to provide Condense instances for data structures
defined in ouroboros-network, or move condense class to
ouroboros-network (or an independent package).  Either way we should be
able to remove the Show constraints and use Condense instead which give
better debugging experience.