### PR TITLE
Fix infinite loop in chain selection

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
@@ -615,7 +615,7 @@ validateCandidate lgrDB tracer cfg invalidPoints
         let lastValid  = castPoint $ LgrDB.currentPoint ledger'
             candidate' = fromMaybe
               (error "cannot rollback to point on fragment") $
-              AF.rollback lastValid candidate'
+              AF.rollback lastValid candidate
         let invalidPointsInCand = Set.fromList $ pointsStartingFrom pt
         atomically $ modifyTVar' invalidPoints (Set.union invalidPointsInCand)
         trace (InvalidBlock e pt)


### PR DESCRIPTION
When a candidate chain contains an invalid block, we take the valid prefix of
that candidate and continue chain selection using that candidate. In the
computation of that prefix, we were taking the prefix of the result of the
computation instead of the original candidate and boom, infinite loop...

We currently don't test with invalid blocks (on the list of TODOs!), so this
wasn't detected before. This infinite loop was discovered when running the
demo with `--real-pbft`, which can result in invalid blocks.