### PR TITLE
Fix broken network-mux test

### DIFF
--- a/network-mux/test/Test/Mux.hs
+++ b/network-mux/test/Test/Mux.hs
@@ -52,6 +52,7 @@ import           Network.TypedProtocol.ReqResp.Server
 import           Network.TypedProtocol.ReqResp.Codec.Cbor
 
 import qualified Network.Mux as Mx
+import qualified Network.Mux.Codec as Mx
 import qualified Network.Mux.Interface as Mx
 import qualified Network.Mux.Bearer.Queues as Mx
 


### PR DESCRIPTION
This should never have ended up on `master`, the PR that broken this should have been detected and rejected by CI.