### PR TITLE
Changes needed to support cardano-node#63

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Run.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts        #-}
 {-# LANGUAGE FlexibleInstances       #-}
+{-# LANGUAGE MonoLocalBinds          #-}
 {-# LANGUAGE UndecidableInstances    #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 -- | Infrastructure required to run the demo
@@ -47,5 +48,5 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
          ) => RunDemo (SimpleBlock SimpleMockCrypto ext) where
   demoMockTx _ = SimpleGenTx
 
-instance ByronGiven => RunDemo (ByronBlockOrEBB ByronConfig) where
+instance RunNode (ByronBlockOrEBB ByronConfig) => RunDemo (ByronBlockOrEBB ByronConfig) where
   demoMockTx = Byron.elaborateTx

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -530,9 +530,12 @@ instance Condense (Header (ByronBlockOrEBB cfg)) where
   condense (ByronHeaderOrEBB (Right hdr)) = condense (ByronHeader hdr)
   condense (ByronHeaderOrEBB (Left bvd)) = condenseBVD bvd
 
+instance Condense CC.Block.HeaderHash where
+  condense = formatToString CC.Block.headerHashF
+
 instance Condense (ChainHash (ByronBlockOrEBB cfg)) where
   condense GenesisHash   = "genesis"
-  condense (BlockHash h) = show h
+  condense (BlockHash h) = condense h
 
 instance Condense (GenTx (ByronBlockOrEBB cfg)) where
     condense (ByronTx tx) =


### PR DESCRIPTION
- Add an orphan 'Condense' instance for 'HeaderHash'.
- Alter the instance declaration for RunDemo (ByronBlock). This is a bit
weird, but needed because we actually try to construct the instance on
the other side of a `Dict (RunNode ...)`, where we lost that instance's
constraints.