### PR TITLE
More changes needed to support cardano-node#63

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -745,7 +745,8 @@ instance (ByronGiven, Typeable cfg, ConfigContainsGenesis cfg)
   -- newtype)
   data GenTx (ByronBlockOrEBB cfg) = ByronTx { unByronTx :: CC.UTxO.ATxAux ByteString }
 
-  data GenTxId (ByronBlockOrEBB cfg) = ByronTxId { unByronTxId :: CC.UTxO.TxId }
+  newtype GenTxId (ByronBlockOrEBB cfg) = ByronTxId { unByronTxId :: CC.UTxO.TxId }
+    deriving (Eq, Ord)
 
   computeGenTxId = ByronTxId . Crypto.hash . CC.UTxO.taTx . unByronTx
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -24,7 +24,7 @@ import           Ouroboros.Network.Protocol.TxSubmission.Type (TxSizeInBytes)
 
 import           Ouroboros.Consensus.Ledger.Abstract
 
-class UpdateLedger blk => ApplyTx blk where
+class (UpdateLedger blk, Ord (GenTxId blk)) => ApplyTx blk where
   -- | Generalized transaction
   --
   -- The mempool (and, accordingly, blocks) consist of "generalized

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -132,7 +132,6 @@ protocolHandlers
        , Condense (HeaderHash blk)
        , Condense peer
        , Show (ApplyTxErr blk)  --TODO: consider using condense
-       , Ord (GenTxId blk)
        , Condense (GenTx blk)
        )
     => NodeParams m peer blk  --TODO eliminate, merge relevant into NodeKernel


### PR DESCRIPTION
Require (and add) an `Ord` instance for `GenTxId`.