### PR TITLE
Cache the GenTxId in GenTx so that querying it is cheap

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Byron/Elaborate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Byron/Elaborate.hs
@@ -45,7 +45,7 @@ elaborateTx :: HasCallStack
             => NodeConfig ByronEBBExtNodeConfig
             -> Mock.Tx -> GenTx (ByronBlockOrEBB cfg)
 elaborateTx (WithEBBNodeConfig cfg) (Mock.Tx ins outs) =
-    ByronTx $ CC.UTxO.ATxAux (annotate tx) (annotate witness)
+    mkByronTx $ CC.UTxO.ATxAux (annotate tx) (annotate witness)
   where
     annotate x = reAnnotate $ Annotated x ()
     -- mockInp and mockOut in [0 .. 3] (index of rich actor)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Run.hs
@@ -46,7 +46,7 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
                     ext
          , Serialise (ChainState (BlockProtocol (SimpleBlock SimpleMockCrypto ext)))
          ) => RunDemo (SimpleBlock SimpleMockCrypto ext) where
-  demoMockTx _ = SimpleGenTx
+  demoMockTx _ = mkSimpleGenTx
 
 instance RunNode (ByronBlockOrEBB ByronConfig) => RunDemo (ByronBlockOrEBB ByronConfig) where
   demoMockTx = Byron.elaborateTx

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -747,7 +747,7 @@ instance (ByronGiven, Typeable cfg, ConfigContainsGenesis cfg)
   newtype GenTxId (ByronBlockOrEBB cfg) = ByronTxId { unByronTxId :: CC.UTxO.TxId }
     deriving (Eq, Ord)
 
-  computeGenTxId = ByronTxId . Crypto.hash . CC.UTxO.taTx . unByronTx
+  txId = ByronTxId . Crypto.hash . CC.UTxO.taTx . unByronTx
 
   txSize (ByronTx atxaux) = fromIntegral txByteSize
     where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -21,7 +21,6 @@ module Ouroboros.Consensus.Ledger.Byron
     -- * Mempool integration
   , GenTx (..)
   , GenTxId (..)
-  , computeGenTxId
     -- * Ledger
   , LedgerState (..)
   , LedgerConfig (..)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
@@ -117,7 +117,7 @@ forgeBlock (WithEBBNodeConfig cfg) curSlot curNo prevHash txs () = do
       } = encNodeConfigExt cfg
 
     txPayload :: CC.UTxO.TxPayload
-    txPayload = CC.UTxO.mkTxPayload (map (void . unByronTx) txs)
+    txPayload = CC.UTxO.mkTxPayload (map (void . byronTx) txs)
 
     body :: CC.Block.Body
     body = CC.Block.ABody {

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -1,11 +1,12 @@
+{-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
@@ -31,6 +32,7 @@ module Ouroboros.Consensus.Ledger.Mock.Block (
     -- * 'ApplyTx' (mempool support)
   , GenTx(..)
   , GenTxId(..)
+  , mkSimpleGenTx
     -- * Crypto
   , SimpleCrypto
   , SimpleStandardCrypto
@@ -78,7 +80,8 @@ data SimpleBlock' c ext ext' = SimpleBlock {
       simpleHeader :: Header (SimpleBlock' c ext ext')
     , simpleBody   :: SimpleBody
     }
-  deriving (Generic, Show, Eq)
+  deriving stock    (Generic, Show, Eq)
+  deriving anyclass (Serialise)
 
 instance GetHeader (SimpleBlock' c ext ext') where
   data Header (SimpleBlock' c ext ext') = SimpleHeader {
@@ -111,12 +114,14 @@ data SimpleStdHeader c ext = SimpleStdHeader {
     , simpleBodyHash  :: Hash (SimpleHash c) SimpleBody
     , simpleBlockSize :: Word64
     }
-  deriving (Generic, Show, Eq)
+  deriving stock    (Generic, Show, Eq)
+  deriving anyclass (Serialise)
 
 data SimpleBody = SimpleBody {
       simpleTxs :: [Tx]
     }
-  deriving (Generic, Show, Eq)
+  deriving stock    (Generic, Show, Eq)
+  deriving anyclass (Serialise)
 
 {-------------------------------------------------------------------------------
   Working with 'SimpleBlock'
@@ -206,7 +211,8 @@ instance (SimpleCrypto c, Typeable ext, SupportedBlock (SimpleBlock c ext))
   newtype LedgerState (SimpleBlock c ext) = SimpleLedgerState {
         simpleLedgerState :: MockState (SimpleBlock c ext)
       }
-    deriving (Generic, Show, Eq)
+    deriving stock   (Generic, Show, Eq)
+    deriving newtype (Serialise)
 
   data LedgerConfig (SimpleBlock c ext) =
       SimpleLedgerConfig
@@ -238,13 +244,20 @@ genesisSimpleLedgerState = SimpleLedgerState . genesisMockState
 
 instance (SimpleCrypto c, Typeable ext, SupportedBlock (SimpleBlock c ext))
       => ApplyTx (SimpleBlock c ext) where
-  newtype GenTx   (SimpleBlock c ext) = SimpleGenTx { simpleGenTx :: Tx }
+  data GenTx (SimpleBlock c ext) = SimpleGenTx
+    { simpleGenTx   :: Tx
+    , simpleGenTxId :: TxId
+      -- ^ This field is lazy on purpose so that the TxId is computed on
+      -- demand.
+    } deriving stock    (Generic)
+      deriving anyclass (Serialise)
 
   newtype GenTxId (SimpleBlock c ext) = SimpleGenTxId
-    { simpleGenTxId :: TxId
-    } deriving (Show, Eq, Ord)
+    { unSimpleGenTxId :: TxId
+    } deriving stock   (Generic)
+      deriving newtype (Show, Eq, Ord, Serialise)
 
-  txId = SimpleGenTxId . hash . simpleGenTx
+  txId = SimpleGenTxId . simpleGenTxId
 
   txSize _ = 2000  -- TODO #745
 
@@ -264,10 +277,16 @@ instance HasUtxo (GenTx (SimpleBlock p c)) where
   updateUtxo = updateUtxo . simpleGenTx
 
 instance Condense (GenTx (SimpleBlock p c)) where
-    condense (SimpleGenTx tx) = condense tx
+    condense = condense . simpleGenTx
 
 instance Show (GenTx (SimpleBlock p c)) where
-    show (SimpleGenTx tx) = condense tx
+    show = show . simpleGenTx
+
+mkSimpleGenTx :: Tx -> GenTx (SimpleBlock c ext)
+mkSimpleGenTx tx = SimpleGenTx
+    { simpleGenTx   = tx
+    , simpleGenTxId = hash tx
+    }
 
 {-------------------------------------------------------------------------------
   Crypto needed for simple blocks
@@ -331,14 +350,8 @@ instance Condense (ChainHash (SimpleBlock' c ext ext')) where
   Serialise instances
 -------------------------------------------------------------------------------}
 
-instance (SimpleCrypto c, Serialise ext') => Serialise (SimpleBlock' c ext ext')
-instance (SimpleCrypto c) => Serialise (SimpleStdHeader c ext)
-instance Serialise SimpleBody
-deriving instance Serialise (GenTx (SimpleBlock p c))
-deriving instance Serialise (GenTxId (SimpleBlock p c))
 instance ToCBOR SimpleBody where
   toCBOR = encode
-deriving instance Serialise (LedgerState (SimpleBlock c ext))
 
 encodeSimpleHeader :: SimpleCrypto c
                    => (ext' -> CBOR.Encoding)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -244,7 +244,7 @@ instance (SimpleCrypto c, Typeable ext, SupportedBlock (SimpleBlock c ext))
     { simpleGenTxId :: TxId
     } deriving (Show, Eq, Ord)
 
-  computeGenTxId = SimpleGenTxId . hash . simpleGenTx
+  txId = SimpleGenTxId . hash . simpleGenTx
 
   txSize _ = 2000  -- TODO #745
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -31,7 +31,6 @@ module Ouroboros.Consensus.Ledger.Mock.Block (
     -- * 'ApplyTx' (mempool support)
   , GenTx(..)
   , GenTxId(..)
-  , computeGenTxId
     -- * Crypto
   , SimpleCrypto
   , SimpleStandardCrypto

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -35,10 +35,10 @@ class (UpdateLedger blk, Ord (GenTxId blk)) => ApplyTx blk where
   -- | A generalized transaction, 'GenTx', identifier.
   data family GenTxId blk :: *
 
-  -- | Given a 'GenTx', compute its 'GenTxId'.
+  -- | Return the 'GenTxId' of a 'GenTx'.
   --
   -- Should be cheap as this will be called often.
-  computeGenTxId :: GenTx blk -> GenTxId blk
+  txId :: GenTx blk -> GenTxId blk
 
   -- | Return the post-serialization size in bytes of a 'GenTx'.
   txSize :: GenTx blk -> TxSizeInBytes

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -43,8 +43,10 @@ import           Ouroboros.Network.BlockFetch
 import           Ouroboros.Network.BlockFetch.State (FetchMode (..))
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.TxSubmission.Inbound
-import           Ouroboros.Network.TxSubmission.Outbound hiding
-                     (MempoolSnapshot)
+                     (TraceTxSubmissionInbound, TxSubmissionMempoolWriter)
+import qualified Ouroboros.Network.TxSubmission.Inbound as Inbound
+import           Ouroboros.Network.TxSubmission.Outbound
+                     (TraceTxSubmissionOutbound, TxSubmissionMempoolReader)
 import qualified Ouroboros.Network.TxSubmission.Outbound as Outbound
 
 import           Ouroboros.Consensus.Block
@@ -391,7 +393,7 @@ getMempoolReader
      (MonadSTM m, ApplyTx blk)
   => Mempool m blk TicketNo
   -> TxSubmissionMempoolReader (GenTxId blk) (GenTx blk) TicketNo m
-getMempoolReader mempool = TxSubmissionMempoolReader
+getMempoolReader mempool = Outbound.TxSubmissionMempoolReader
     { mempoolZeroIdx     = zeroIdx mempool
     , mempoolGetSnapshot = convertSnapshot <$> getSnapshot mempool
     }
@@ -402,7 +404,7 @@ getMempoolReader mempool = TxSubmissionMempoolReader
     convertSnapshot MempoolSnapshot{snapshotTxsAfter, snapshotLookupTx} =
       Outbound.MempoolSnapshot
         { mempoolTxIdsAfter = \idx ->
-            [ (computeGenTxId tx, idx', txSize tx)
+            [ (txId tx, idx', txSize tx)
             | (tx, idx') <- snapshotTxsAfter idx
             ]
         , mempoolLookupTx   = snapshotLookupTx
@@ -412,9 +414,9 @@ getMempoolWriter
   :: (Monad m, ApplyTx blk)
   => Mempool m blk TicketNo
   -> TxSubmissionMempoolWriter (GenTxId blk) (GenTx blk) TicketNo m
-getMempoolWriter mempool = TxSubmissionMempoolWriter
-    { txId          = computeGenTxId
+getMempoolWriter mempool = Inbound.TxSubmissionMempoolWriter
+    { Inbound.txId          = txId
     , mempoolAddTxs = \txs ->
-        map (computeGenTxId . fst) . filter (isNothing . snd) <$>
+        map (txId . fst) . filter (isNothing . snd) <$>
         addTxs mempool txs
     }

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -26,7 +26,7 @@ import           Data.Typeable (Typeable)
 import qualified Ouroboros.Network.Chain as Chain
 
 import           Ouroboros.Consensus.Ledger.Abstract (ledgerConfigView)
-import           Ouroboros.Consensus.Mempool (Mempool (..),
+import           Ouroboros.Consensus.Mempool (ApplyTx (..), Mempool (..),
                      MempoolSnapshot (..), TraceEventMempool (..), openMempool)
 import           Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Util.ThreadRegistry (withThreadRegistry)
@@ -36,8 +36,8 @@ import qualified Ouroboros.Storage.ChainDB.API as ChainDB
 import qualified Ouroboros.Storage.ChainDB.Mock as Mock
 
 import           Test.Util.TestBlock (BlockChain, GenTx (..), GenTxId (..),
-                     TestBlock, chainToBlocks, computeGenTxId,
-                     singleNodeTestConfig, testInitExtLedger)
+                     TestBlock, chainToBlocks, singleNodeTestConfig,
+                     testInitExtLedger)
 import           Test.Util.TestTx (TestTx (..))
 
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -85,7 +85,7 @@ prop_Mempool_addTxs_getTxs bc txs =
         txs
         (\_ MempoolSnapshot{snapshotTxs} ->
           filter (genTxIsValid . snd) (testTxsToGenTxPairs txs)
-              === map (\(tx, _) -> (computeGenTxId tx, tx)) snapshotTxs)
+              === map (\(tx, _) -> (txId tx, tx)) snapshotTxs)
   where
     genTxIsValid :: GenTx TestBlock -> Bool
     genTxIsValid (TestGenTx (ValidTestTx _)) = True
@@ -172,7 +172,7 @@ testTxsToGenTxPairs :: [TestTx] -> [(GenTxId TestBlock, GenTx TestBlock)]
 testTxsToGenTxPairs = map testTxToGenTxPair
 
 testTxToGenTxPair :: TestTx -> (GenTxId TestBlock, GenTx TestBlock)
-testTxToGenTxPair tx = (computeGenTxId genTx, genTx)
+testTxToGenTxPair tx = (txId genTx, genTx)
   where
     genTx = TestGenTx tx
 

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -245,7 +245,7 @@ broadcastNetwork registry btime numCoreNodes pInfo initRNG numSlots slotLen = do
                                slot
                                curNo
                                prevHash
-                               (map SimpleGenTx txs)
+                               (map mkSimpleGenTx txs)
                                proof
 
             , produceDRG      = atomically $ simChaChaT varRNG id $ drgNew

--- a/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
@@ -293,8 +293,8 @@ instance ApplyTx TestBlock where
     { testGenTxId :: TestTxId
     } deriving (Show, Eq, Ord)
 
-  computeGenTxId (TestGenTx (ValidTestTx txid))   = TestGenTxId txid
-  computeGenTxId (TestGenTx (InvalidTestTx txid)) = TestGenTxId txid
+  txId (TestGenTx (ValidTestTx   txid)) = TestGenTxId txid
+  txId (TestGenTx (InvalidTestTx txid)) = TestGenTxId txid
 
   txSize _ = 2000 -- TODO #745
 

--- a/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
@@ -36,7 +36,6 @@ module Test.Util.TestBlock (
   , GenTx (..)
   , GenTxId (..)
   , ApplyTxErr
-  , computeGenTxId
     -- * Support for tests
   , Permutation(..)
   , permute


### PR DESCRIPTION
Closes #780.

The docstring of `txId` says it should be cheap to get the `GenTxId` of a
`GenTx`. This was not the case as the transaction was being hashed each time,
both for Mock and Byron blocks. Solve this by caching the hash.