### PR TITLE
StaticKeyMaterialByronPbft:  encapsulate the local key material necessary to run RealPBFT

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -46,6 +46,8 @@ module Ouroboros.Consensus.Ledger.Byron
   , pattern ByronHeaderOrEBB
   , unByronHeaderOrEBB
   , annotateBoundary
+    -- * Secrets
+  , StaticKeyMaterialByronPbft (..)
   ) where
 
 import           Codec.CBOR.Decoding (Decoder, decodeListLenOf)
@@ -164,6 +166,15 @@ instance (ByronGiven, Typeable cfg) => Measured BlockMeasure (ByronBlock cfg) wh
   measure = blockMeasure
 
 instance StandardHash (ByronBlock cfg)
+
+{-------------------------------------------------------------------------------
+  Key material
+-------------------------------------------------------------------------------}
+
+data StaticKeyMaterialByronPbft = StaticKeyMaterialByronPbft {
+      skmbpSignKey     :: Crypto.SigningKey
+    , skmbpDlgCert     :: CC.Delegation.Certificate
+    }
 
 {-------------------------------------------------------------------------------
   Ledger

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -46,8 +46,6 @@ module Ouroboros.Consensus.Ledger.Byron
   , pattern ByronHeaderOrEBB
   , unByronHeaderOrEBB
   , annotateBoundary
-    -- * Secrets
-  , StaticKeyMaterialByronPbft (..)
   ) where
 
 import           Codec.CBOR.Decoding (Decoder, decodeListLenOf)
@@ -166,15 +164,6 @@ instance (ByronGiven, Typeable cfg) => Measured BlockMeasure (ByronBlock cfg) wh
   measure = blockMeasure
 
 instance StandardHash (ByronBlock cfg)
-
-{-------------------------------------------------------------------------------
-  Key material
--------------------------------------------------------------------------------}
-
-data StaticKeyMaterialByronPbft = StaticKeyMaterialByronPbft {
-      skmbpSignKey     :: Crypto.SigningKey
-    , skmbpDlgCert     :: CC.Delegation.Certificate
-    }
 
 {-------------------------------------------------------------------------------
   Ledger

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -30,4 +30,4 @@ protocolInfo nodes nid demoProtocol = case demoProtocol of
     ProtocolMockPraos      params          -> protocolInfoPraos     nodes nid params
     ProtocolLeaderSchedule params schedule -> protocolInfoPraosRule nodes nid params schedule
     ProtocolMockPBFT       params          -> protocolInfoMockPBFT  nodes nid params
-    ProtocolRealPBFT       params gc       -> protocolInfoByron     nodes nid params gc
+    ProtocolRealPBFT       params gc skmbp -> protocolInfoByron     nodes nid params gc skmbp

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -30,4 +30,4 @@ protocolInfo nodes nid demoProtocol = case demoProtocol of
     ProtocolMockPraos      params          -> protocolInfoPraos     nodes nid params
     ProtocolLeaderSchedule params schedule -> protocolInfoPraosRule nodes nid params schedule
     ProtocolMockPBFT       params          -> protocolInfoMockPBFT  nodes nid params
-    ProtocolRealPBFT       params gc skmbp -> protocolInfoByron     nodes nid params gc skmbp
+    ProtocolRealPBFT       params gc mplc  -> protocolInfoByron     nodes nid params gc mplc

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
@@ -9,15 +9,16 @@
 module Ouroboros.Consensus.Node.ProtocolInfo.Byron (
     protocolInfoByron
   , ByronConfig
+    -- * Secrets
+  , PbftLeaderCredentials (..)
   ) where
 
 import           Control.Monad.Except
 import           Data.Coerce
-import           Data.Maybe (fromJust)
 import qualified Data.Sequence as Seq
 
 import qualified Cardano.Chain.Block as Cardano.Block
-import qualified Cardano.Chain.Common as Cardano.Common
+import qualified Cardano.Chain.Delegation as Cardano.Delegation
 import qualified Cardano.Chain.Genesis as Cardano.Genesis
 import qualified Cardano.Chain.Update as Cardano.Update
 import qualified Cardano.Crypto as Cardano
@@ -36,6 +37,15 @@ import           Ouroboros.Consensus.Ledger.Byron.Config
 import qualified Test.Cardano.Chain.Genesis.Dummy as Dummy
 
 {-------------------------------------------------------------------------------
+  Credentials
+-------------------------------------------------------------------------------}
+
+data PbftLeaderCredentials = PbftLeaderCredentials {
+      plcSignKey     :: Cardano.SigningKey
+    , plcDlgCert     :: Cardano.Delegation.Certificate
+    }
+
+{-------------------------------------------------------------------------------
   ProtocolInfo
 -------------------------------------------------------------------------------}
 
@@ -45,9 +55,9 @@ protocolInfoByron :: NumCoreNodes
                   -> CoreNodeId
                   -> PBftParams
                   -> Cardano.Genesis.Config
-                  -> StaticKeyMaterialByronPbft
+                  -> PbftLeaderCredentials
                   -> ProtocolInfo (ByronBlockOrEBB ByronConfig)
-protocolInfoByron (NumCoreNodes numCoreNodes) (CoreNodeId nid) params gc (StaticKeyMaterialByronPbft sk dlg) =
+protocolInfoByron (NumCoreNodes numCoreNodes) (CoreNodeId nid) params gc (PbftLeaderCredentials sk dlg) =
     ProtocolInfo {
         pInfoConfig = WithEBBNodeConfig $ EncNodeConfig {
             encNodeConfigP = PBftNodeConfig {

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
@@ -62,14 +62,19 @@ protocolInfoByron (NumCoreNodes numCoreNodes) nid params gc mLeader =
         pInfoConfig = WithEBBNodeConfig $ EncNodeConfig {
             encNodeConfigP = PBftNodeConfig {
                   pbftParams   = params
-                    { pbftNumNodes = fromIntegral numCoreNodes
+                    { -- TODO (Duncan): compute (from numGenesisKeys)
+                      pbftNumNodes = fromIntegral numCoreNodes
                       -- Set the signature window to be short for the demo.
+                      -- TODO: Is it always 'k'?
                     , pbftSignatureWindow = 7
+                      -- TODO: make pbftSignatureThreshold default to a value computed from pbftNumNodes,
+                      --       but configurable?
                     }
                 , pbftIsLeader = proofOfCredentials nid <$> mLeader
                 }
           , encNodeConfigExt = ByronConfig {
                 pbftProtocolMagic   = Cardano.Genesis.configProtocolMagic gc
+                -- TODO (Duncan): get versions from external config
               , pbftProtocolVersion = Cardano.Update.ProtocolVersion 1 0 0
               , pbftSoftwareVersion = Cardano.Update.SoftwareVersion (Cardano.Update.ApplicationName "Cardano Demo") 1
               , pbftGenesisConfig   = gc
@@ -95,7 +100,7 @@ protocolInfoByron (NumCoreNodes numCoreNodes) nid params gc mLeader =
     proofOfCredentials :: CoreNodeId -> PbftLeaderCredentials -> PBftIsLeader PBftCardanoCrypto
     proofOfCredentials nid' (PbftLeaderCredentials sk dlg) =
       PBftIsLeader
-      { pbftCoreNodeId = nid'
+      { pbftCoreNodeId = nid' -- TODO (Duncan): compute this based on the genesis verification key
       , pbftSignKey    = SignKeyCardanoDSIGN sk
       , pbftVerKey     = VerKeyCardanoDSIGN (Cardano.toVerification sk)
       , pbftGenVerKey  = VerKeyCardanoDSIGN (Cardano.Delegation.issuerVK dlg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
@@ -24,6 +24,7 @@ import qualified Cardano.Crypto as Cardano
 import           Ouroboros.Consensus.Ledger.Byron
 import           Ouroboros.Consensus.Ledger.Byron.Config
 import           Ouroboros.Consensus.Ledger.Mock
+import           Ouroboros.Consensus.Node.ProtocolInfo.Byron
 import           Ouroboros.Consensus.Node.ProtocolInfo.Mock.PBFT ()
 import           Ouroboros.Consensus.Node.ProtocolInfo.Mock.Praos ()
 import           Ouroboros.Consensus.Node.Run
@@ -79,7 +80,7 @@ data Protocol blk where
   ProtocolRealPBFT
     :: PBftParams
     -> Cardano.Genesis.Config
-    -> StaticKeyMaterialByronPbft
+    -> PbftLeaderCredentials
     -> Protocol (ByronBlockOrEBB ByronConfig)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
@@ -80,7 +80,7 @@ data Protocol blk where
   ProtocolRealPBFT
     :: PBftParams
     -> Cardano.Genesis.Config
-    -> PbftLeaderCredentials
+    -> Maybe PbftLeaderCredentials
     -> Protocol (ByronBlockOrEBB ByronConfig)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
@@ -79,6 +79,7 @@ data Protocol blk where
   ProtocolRealPBFT
     :: PBftParams
     -> Cardano.Genesis.Config
+    -> StaticKeyMaterialByronPbft
     -> Protocol (ByronBlockOrEBB ByronConfig)
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
The name is specifically including `Pbft`, because Byron Classic
also required a VSS keypair, which the PBFT variant does not.

Alternatively, this type could have been placed in the PBFT protocol,
under a different name, but it would have been even more unappropriately
over-specific there.

Ideal(-istic)ally, the notion of a per-protocol/block/ledger type
for node-specific key material could have been appropriately indexed
by the protocol/block types, but as yet there's no clear picture
of tradeoffs involved, since there's just a single "real" implementation
so far.
