### PR TITLE
Adjustments to PBFT ByronConfig

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Byron/Elaborate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Byron/Elaborate.hs
@@ -116,6 +116,8 @@ elaborateTx (WithEBBNodeConfig cfg) (Mock.Tx ins outs) =
     richmen =
         zip [0..] $
           CC.Genesis.gsRichSecrets $ pbftSecrets (encNodeConfigExt cfg)
+        --TODO: this is the only use of pbftSecrets, and it can be removed
+        --as soon as we no longer need tx elaboration.
 
     fromCompactTxInTxOutList :: [(CC.UTxO.CompactTxIn, CC.UTxO.CompactTxOut)]
                              -> [(CC.UTxO.TxIn, CC.UTxO.TxOut)]

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Config.hs
@@ -25,7 +25,14 @@ data ByronConfig = ByronConfig {
     , pbftGenesisConfig   :: CC.Genesis.Config
     , pbftGenesisHash     :: CC.Genesis.GenesisHash
     , pbftGenesisDlg      :: CC.Genesis.GenesisDelegation
+
+      -- | This is only needed by "Ouroboros.Consensus.Demo.Byron.Elaborate"
+      -- to elaborate from mock transactions to real ones. This obviously only
+      -- works for demos. This can be removed as soon as the elaboration is
+      -- removed (or moved into the tx submission tool for demos).
+      --
     , pbftSecrets         :: CC.Genesis.GeneratedSecrets
+      -- TODO: remove this ^^
     }
 
 type ByronExtNodeConfig = ExtNodeConfig ByronConfig (PBft PBftCardanoCrypto)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Config.hs
@@ -6,27 +6,19 @@ module Ouroboros.Consensus.Ledger.Byron.Config (
   , ByronEBBExtNodeConfig
   ) where
 
-import           Data.Bimap (Bimap)
-
 import qualified Cardano.Chain.Genesis as CC.Genesis
 import qualified Cardano.Chain.Slotting as CC.Slot
 import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Crypto as Crypto
 
 import           Ouroboros.Consensus.Ledger.Byron
-import           Ouroboros.Consensus.NodeId (CoreNodeId)
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
 import           Ouroboros.Consensus.Protocol.PBFT
 import           Ouroboros.Consensus.Protocol.WithEBBs
 
 -- | Extended configuration we need for Byron
 data ByronConfig = ByronConfig {
-      -- | Mapping from generic keys to core node IDs
-      --
-      -- The keys in this map are the verification keys of the core nodes - that
-      -- is, the delegates of the genesis keys.
-      pbftCoreNodes       :: Bimap Crypto.VerificationKey CoreNodeId
-    , pbftProtocolMagic   :: Crypto.ProtocolMagic
+      pbftProtocolMagic   :: Crypto.ProtocolMagic
     , pbftProtocolVersion :: CC.Update.ProtocolVersion
     , pbftSoftwareVersion :: CC.Update.SoftwareVersion
     , pbftEpochSlots      :: CC.Slot.EpochSlots

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
@@ -90,9 +90,9 @@ instance ( SimpleCrypto c
          ) => ForgeExt (ExtNodeConfig ext (PBft c'))
                        c
                        (SimplePBftExt c c') where
-  forgeExt cfg () SimpleBlock{..} = do
+  forgeExt _cfg isLeader SimpleBlock{..} = do
       ext :: SimplePBftExt c c' <- fmap SimplePBftExt $
-        forgePBftFields (encNodeConfigP cfg) encode $
+        forgePBftFields isLeader encode $
           SignedSimplePBft {
               signedSimplePBft = simpleHeaderStd
             }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
@@ -12,7 +12,6 @@ module Ouroboros.Consensus.Node.ProtocolInfo.Byron (
   ) where
 
 import           Control.Monad.Except
-import qualified Data.Bimap as Bimap
 import           Data.Coerce
 import           Data.Maybe (fromJust)
 import qualified Data.Sequence as Seq
@@ -62,11 +61,7 @@ protocolInfoByron (NumCoreNodes numCoreNodes) (CoreNodeId nid) params gc =
                 , pbftGenVerKey = VerKeyCardanoDSIGN (lookupGenKey nid)
                 }
           , encNodeConfigExt = ByronConfig {
-                pbftCoreNodes = Bimap.fromList [
-                    (fst (lookupKey n), CoreNodeId n)
-                    | n <- [0 .. numCoreNodes]
-                    ]
-              , pbftProtocolMagic   = Cardano.Genesis.configProtocolMagic gc
+                pbftProtocolMagic   = Cardano.Genesis.configProtocolMagic gc
               , pbftProtocolVersion = Cardano.Update.ProtocolVersion 1 0 0
               , pbftSoftwareVersion = Cardano.Update.SoftwareVersion (Cardano.Update.ApplicationName "Cardano Demo") 1
               , pbftGenesisConfig   = gc

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
@@ -26,7 +26,7 @@ import           Ouroboros.Consensus.Crypto.DSIGN.Cardano
 import           Ouroboros.Consensus.Ledger.Byron
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract
-import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
 import           Ouroboros.Consensus.Protocol.PBFT
 import           Ouroboros.Consensus.Protocol.WithEBBs
@@ -50,15 +50,18 @@ protocolInfoByron (NumCoreNodes numCoreNodes) (CoreNodeId nid) params gc =
     ProtocolInfo {
         pInfoConfig = WithEBBNodeConfig $ EncNodeConfig {
             encNodeConfigP = PBftNodeConfig {
-                  pbftParams  = params
+                  pbftParams   = params
                     { pbftNumNodes = fromIntegral numCoreNodes
                       -- Set the signature window to be short for the demo.
                     , pbftSignatureWindow = 7
                     }
-                , pbftNodeId  = CoreId nid
-                , pbftSignKey = SignKeyCardanoDSIGN (snd (lookupKey nid))
-                , pbftVerKey  = VerKeyCardanoDSIGN  (fst (lookupKey nid))
-                , pbftGenVerKey = VerKeyCardanoDSIGN (lookupGenKey nid)
+                  --TODO: also allow not being a BFT leader:
+                , pbftIsLeader = Just PBftIsLeader {
+                      pbftCoreNodeId = CoreNodeId nid
+                    , pbftSignKey    = SignKeyCardanoDSIGN (snd (lookupKey nid))
+                    , pbftVerKey     = VerKeyCardanoDSIGN  (fst (lookupKey nid))
+                    , pbftGenVerKey  = VerKeyCardanoDSIGN (lookupGenKey nid)
+                    }
                 }
           , encNodeConfigExt = ByronConfig {
                 pbftProtocolMagic   = Cardano.Genesis.configProtocolMagic gc

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
@@ -69,6 +69,9 @@ protocolInfoByron (NumCoreNodes numCoreNodes) (CoreNodeId nid) params gc =
               , pbftEpochSlots      = Cardano.Genesis.configEpochSlots gc
               , pbftGenesisDlg      = Cardano.Genesis.configHeavyDelegation gc
               , pbftSecrets         = Dummy.dummyGeneratedSecrets
+                --TODO: These "richmen" secrets ^^ are here to support demos
+                -- where we need to elaborate from mock transactions to real
+                -- ones. It should be removed when we can eliminate elaboration.
               }
           }
       , pInfoInitLedger = ExtLedgerState {

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/PBFT.hs
@@ -14,7 +14,7 @@ import           Cardano.Crypto.DSIGN
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract
-import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
 import           Ouroboros.Consensus.Protocol.PBFT
 
@@ -28,11 +28,13 @@ protocolInfoMockPBFT (NumCoreNodes numCoreNodes) (CoreNodeId nid) params =
         pInfoConfig = EncNodeConfig {
             encNodeConfigP = PBftNodeConfig {
                 pbftParams   = params {pbftNumNodes = fromIntegral numCoreNodes}
-              , pbftNodeId   = CoreId nid
-              , pbftSignKey  = SignKeyMockDSIGN nid
-              , pbftVerKey   = VerKeyMockDSIGN nid
-                -- For Mock PBFT, we use our key as the genesis key.
-              , pbftGenVerKey = VerKeyMockDSIGN nid
+              , pbftIsLeader = Just PBftIsLeader {
+                    pbftCoreNodeId = CoreNodeId nid
+                  , pbftSignKey    = SignKeyMockDSIGN nid
+                  , pbftVerKey     = VerKeyMockDSIGN nid
+                    -- For Mock PBFT, we use our key as the genesis key.
+                  , pbftGenVerKey  = VerKeyMockDSIGN nid
+                  }
               }
             , encNodeConfigExt = PBftLedgerView $
                 Bimap.fromList [ (VerKeyMockDSIGN n, VerKeyMockDSIGN n)


### PR DESCRIPTION
Three cleanups:

* remove a confusing and unused part of the `ByronConfig`
* add TODOs about things relevant only for the demo (that were confusing people)
* allow nodes to be not a BFT slot leader by making the leader credentials optional