### PR TITLE
Chain DB: catch and rewrap iterator exceptions

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -447,17 +447,13 @@ instance Eq (Reader m blk a) where
 
 -- | Database failure
 --
--- This exception wraps any kind of unexpected problem with the on-disk storage
--- of the chain. It is primarily for monitoring purposes:
+-- This exception wraps any kind of unexpected problem with the on-disk
+-- storage of the chain.
 --
--- * It should never be thrown outside the scope of the Chain DB; it is the
---   responsibility of the Chain DB itself to catch these exceptions and
---   trigger data recovery. The exception type is part of the public API because
---   these exceptions will be logged.
--- * The various constructors only serve to give more detailed information about
---   what went wrong, in case sysadmins want to investigate the disk failure.
---   The Chain DB itself does not differentiate; all disk failures are treated
---   equal and all trigger the same recovery procedure.
+-- The various constructors only serve to give more detailed information about
+-- what went wrong, in case sysadmins want to investigate the disk failure.
+-- The Chain DB itself does not differentiate; all disk failures are treated
+-- equal and all trigger the same recovery procedure.
 data ChainDbFailure blk =
     -- | A block in the immutable DB failed to parse
     ImmDbParseFailure (Either EpochNo SlotNo) CBOR.DeserialiseFailure
@@ -528,7 +524,7 @@ instance (StandardHash blk, Typeable blk) => Exception (ChainDbFailure blk)
   Exceptions
 -------------------------------------------------------------------------------}
 
--- | Database error.
+-- | Database error
 --
 -- Thrown upon incorrect use: invalid input.
 data ChainDbError blk =

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -31,8 +31,12 @@ module Ouroboros.Storage.ChainDB.Impl.ImmDB (
     -- * Wrappers
   , closeDB
   , reopen
+  , iteratorNext
+  , iteratorHasNext
+  , iteratorPeek
+  , iteratorClose
     -- * Re-exports
-  , Iterator(..)
+  , Iterator
   , IteratorResult(..)
   , ImmDB.ValidationPolicy(..)
   , ImmDB.ImmutableDBError
@@ -70,8 +74,8 @@ import           Ouroboros.Storage.EpochInfo (EpochInfo (..), newEpochInfo)
 import           Ouroboros.Storage.FS.API (HasFS, createDirectoryIfMissing)
 import           Ouroboros.Storage.FS.API.Types (MountPoint (..))
 import           Ouroboros.Storage.FS.IO (ioHasFS)
-import           Ouroboros.Storage.ImmutableDB (ImmutableDB, Iterator (..),
-                     IteratorResult (..))
+import           Ouroboros.Storage.ImmutableDB (ImmutableDB,
+                     Iterator (Iterator), IteratorResult (..))
 import qualified Ouroboros.Storage.ImmutableDB as ImmDB
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
@@ -293,22 +297,22 @@ streamBlocksFrom db from = withDB db $ \imm -> runExceptT $ case from of
     StreamFromExclusive pt@BlockPoint { atSlot = slot, withHash = hash } -> do
       checkFutureSlot pt
       it    <- stream imm (Just (slot, hash)) Nothing
-      itRes <- lift $ iteratorNext it
+      itRes <- lift $ iteratorNext db it
       if blockMatchesPoint itRes pt
         then return it
         else do
-          lift $ iteratorClose it
+          lift $ iteratorClose db it
           throwError $ MissingBlock pt
     StreamFromExclusive    GenesisPoint ->
       stream imm Nothing Nothing
     StreamFromInclusive pt@BlockPoint { atSlot = slot, withHash = hash } -> do
       checkFutureSlot pt
       it    <- stream imm (Just (slot, hash)) Nothing
-      itRes <- lift $ iteratorPeek it
+      itRes <- lift $ iteratorPeek db it
       if blockMatchesPoint itRes pt
         then return it
         else do
-          lift $ iteratorClose it
+          lift $ iteratorClose db it
           throwError $ MissingBlock pt
     StreamFromInclusive    GenesisPoint ->
       throwM $ NoGenesisBlock @blk
@@ -358,7 +362,7 @@ streamBlocksFromUnchecked  :: forall m blk.
 streamBlocksFromUnchecked db from = withDB db $ \imm -> case from of
     StreamFromExclusive BlockPoint { atSlot = slot, withHash = hash } -> do
       it    <- ImmDB.streamBinaryBlobs imm (Just (slot, hash)) Nothing
-      void $ iteratorNext it
+      void $ iteratorNext db it
       return $ parseIterator db it
     StreamFromExclusive    GenesisPoint ->
       stream imm Nothing Nothing
@@ -415,7 +419,7 @@ streamBlobsAfter db low = withDB db $ \imm -> do
         case low' of
           Nothing           -> return ()
           Just (slot, hash) -> do
-            skipped <- parseIteratorResult db =<< iteratorNext itr
+            skipped <- parseIteratorResult db =<< iteratorNext db itr
             case skipped of
               IteratorResult slot' blk ->
                   unless (hash == hash' && slot == slot') $
@@ -432,16 +436,16 @@ streamBlobsAfter db low = withDB db $ \imm -> do
                   throwM $ ImmDbUnexpectedIteratorExhausted low
 
 -- | Parse the bytestrings returned by an iterator as blocks.
-parseIterator :: (MonadThrow m, HasHeader blk)
+parseIterator :: (MonadCatch m, HasHeader blk)
               => ImmDB m blk
               -> Iterator (HeaderHash blk) m Lazy.ByteString
               -> Iterator (HeaderHash blk) m blk
 parseIterator db itr = Iterator {
-      iteratorNext    = parseIteratorResult db =<< iteratorNext itr
-    , iteratorPeek    = parseIteratorResult db =<< iteratorPeek itr
-    , iteratorHasNext = iteratorHasNext itr
-    , iteratorClose   = iteratorClose   itr
-    , iteratorID      = ImmDB.DerivedIteratorID $ iteratorID itr
+      iteratorNext    = parseIteratorResult db =<< iteratorNext db itr
+    , iteratorPeek    = parseIteratorResult db =<< iteratorPeek db itr
+    , iteratorHasNext = iteratorHasNext db itr
+    , iteratorClose   = iteratorClose   db itr
+    , iteratorID      = ImmDB.DerivedIteratorID $ ImmDB.iteratorID itr
     }
 
 parseIteratorResult :: (MonadThrow m, HasHeader blk)
@@ -579,3 +583,29 @@ reopen :: (MonadCatch m, HasHeader blk, HasCallStack)
        => ImmDB m blk -> m ()
 reopen db = withDB db $ \imm ->
     ImmDB.reopen imm ImmDB.ValidateMostRecentEpoch
+
+-- These wrappers ensure that we correctly rethrow exceptions using 'withDB'.
+
+iteratorNext :: (HasCallStack, MonadCatch m, HasHeader blk)
+             => ImmDB m blk
+             -> ImmDB.Iterator (HeaderHash blk) m a
+             -> m (ImmDB.IteratorResult (HeaderHash blk) a)
+iteratorNext db it = withDB db $ const $ ImmDB.iteratorNext it
+
+iteratorHasNext :: (HasCallStack, MonadCatch m, HasHeader blk)
+                => ImmDB m blk
+                -> ImmDB.Iterator (HeaderHash blk) m a
+                -> m Bool
+iteratorHasNext db it = withDB db $ const $ ImmDB.iteratorHasNext it
+
+iteratorPeek :: (HasCallStack, MonadCatch m, HasHeader blk)
+             => ImmDB m blk
+             -> ImmDB.Iterator (HeaderHash blk) m a
+             -> m (ImmDB.IteratorResult (HeaderHash blk) a)
+iteratorPeek db it = withDB db $ const $ ImmDB.iteratorPeek it
+
+iteratorClose :: (HasCallStack, MonadCatch m, HasHeader blk)
+              => ImmDB m blk
+              -> ImmDB.Iterator (HeaderHash blk) m a
+              -> m ()
+iteratorClose db it = withDB db $ const $ ImmDB.iteratorClose it

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -362,12 +362,12 @@ streamAPI immDB = StreamAPI streamAfter
         then k Nothing
         else bracket
           (ImmDB.streamBlocksAfter immDB (tipToPoint tip))
-          ImmDB.iteratorClose
+          (ImmDB.iteratorClose immDB)
           (k . Just . getNext)
 
     getNext :: ImmDB.Iterator (HeaderHash blk) m blk
             -> m (NextBlock (Point blk) blk)
-    getNext itr = ImmDB.iteratorNext itr <&> \case
+    getNext itr = ImmDB.iteratorNext immDB itr <&> \case
       ImmDB.IteratorExhausted    -> NoMoreBlocks
       ImmDB.IteratorResult _ blk -> NextBlock (Block.blockPoint blk, blk)
       ImmDB.IteratorEBB  _ _ blk -> NextBlock (Block.blockPoint blk, blk)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
@@ -195,7 +195,7 @@ makeNewBlockOrHeaderReader h readerId = Reader {..}
 
 close
   :: forall m blk.
-     ( MonadSTM m )
+     (MonadSTM m, MonadCatch m, HasHeader blk)
   => ReaderId
   -> ChainDbEnv m blk
   -> m ()
@@ -207,7 +207,7 @@ close readerId CDB{..} = do
       traverse readTVar mbReader
     -- If the ReaderId is not present in the map, the Reader must have been
     -- closed already.
-    mapM_ closeReaderState mbReaderState
+    mapM_ (closeReaderState cdbImmDB) mbReaderState
   where
     -- | Delete the entry corresponding to the given key from the map. If it
     -- existed, return it, otherwise, return 'Nothing'. The updated map is of
@@ -217,12 +217,13 @@ close readerId CDB{..} = do
 
 -- | Close the given 'ReaderState' by closing any 'ImmDB.Iterator' it might
 -- contain.
-closeReaderState :: Monad m => ReaderState m blk -> m ()
-closeReaderState = \case
+closeReaderState :: (MonadCatch m, HasHeader blk)
+                 => ImmDB.ImmDB m blk -> ReaderState m blk -> m ()
+closeReaderState immDB = \case
      ReaderInMem _         -> return ()
      -- IMPORTANT: the main reason we're closing readers: to close this open
      -- iterator, which contains a reference to a file handle.
-     ReaderInImmDB _ immIt -> ImmDB.iteratorClose immIt
+     ReaderInImmDB _ immIt -> ImmDB.iteratorClose immDB immIt
 
 
 type BlockOrHeader blk = Either (Header blk) blk
@@ -317,7 +318,7 @@ instructionHelper fromMaybeSTM fromPure CDB{..} varReader = do
     trace = traceWith (contramap TraceReaderEvent cdbTracer)
 
     nextBlock :: ImmDB.Iterator (HeaderHash blk) m blk -> m (Maybe blk)
-    nextBlock immIt = ImmDB.iteratorNext immIt <&> \case
+    nextBlock immIt = ImmDB.iteratorNext cdbImmDB immIt <&> \case
       ImmDB.IteratorResult _ blk -> Just blk
       ImmDB.IteratorEBB  _ _ blk -> Just blk
       ImmDB.IteratorExhausted    -> Nothing
@@ -480,7 +481,7 @@ switchFork ipoint newChain readerState =
 
 -- | Close all open 'Reader's.
 closeAllReaders
-  :: MonadSTM m
+  :: (MonadSTM m, MonadCatch m, HasHeader blk)
   => ChainDbEnv m blk
   -> m ()
 closeAllReaders CDB{..} = do
@@ -488,4 +489,4 @@ closeAllReaders CDB{..} = do
       readerStates <- readTVar cdbReaders >>= traverse readTVar . Map.elems
       writeTVar cdbReaders Map.empty
       return readerStates
-    mapM_ closeReaderState readerStates
+    mapM_ (closeReaderState cdbImmDB) readerStates

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
@@ -87,6 +87,8 @@ data VolDB m blk = VolDB {
       volDB    :: VolatileDB (HeaderHash blk) m
     , decBlock :: forall s. Decoder s blk
     , encBlock :: blk -> Encoding
+    , err      :: ErrorHandling (VolatileDBError (HeaderHash blk)) m
+    , errSTM   :: ThrowCantCatch (VolatileDBError (HeaderHash blk)) (STM m)
     }
 
 {-------------------------------------------------------------------------------
@@ -132,6 +134,8 @@ openDB args@VolDbArgs{..} = do
                volBlocksPerFile
     return VolDB
       { volDB    = volDB
+      , err      = volErr
+      , errSTM   = volErrSTM
       , decBlock = volDecodeBlock
       , encBlock = volEncodeBlock
       }
@@ -426,20 +430,20 @@ blockFileParser VolDbArgs{..} =
 
 -- | Wrap calls to the VolatileDB and rethrow exceptions that may indicate
 -- disk failure and should therefore trigger recovery
-withDB :: forall m blk x. (MonadCatch m, StandardHash blk, Typeable blk)
+withDB :: forall m blk x. (MonadThrow m, StandardHash blk, Typeable blk)
        => VolDB m blk
        -> (VolatileDB (HeaderHash blk) m -> m x)
        -> m x
-withDB VolDB{..} k = catch (k volDB) rethrow
+withDB VolDB{..} k = EH.catchError err (k volDB) rethrow
   where
     rethrow :: VolatileDBError (HeaderHash blk) -> m x
-    rethrow err = case wrap err of
-                    Just err' -> throwM err'
-                    Nothing   -> throwM err
+    rethrow e = case wrap e of
+                  Just e' -> throwM e'
+                  Nothing -> throwM e
 
     wrap :: VolatileDBError (HeaderHash blk) -> Maybe (ChainDbFailure blk)
-    wrap (VolDB.UnexpectedError err) = Just (VolDbFailure err)
-    wrap VolDB.UserError{}           = Nothing
+    wrap (VolDB.UnexpectedError e) = Just (VolDbFailure e)
+    wrap VolDB.UserError{}         = Nothing
 
 -- | STM actions, by definition, cannot access the disk and therefore we don't
 -- have to worry about catching exceptions here: any exceptions that may be


### PR DESCRIPTION
Properly catch exceptions encountered by ImmutableDB iterators (used by ChainDB iterators and readers) and rewrap them in `ChainDbFailure`.