### PR TITLE
Rename Node to MockNode

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -163,7 +163,7 @@ test-suite tests
                        Ouroboros.Network.Channel
                        Ouroboros.Network.DeltaQ
                        Ouroboros.Network.Mux
-                       Ouroboros.Network.Node
+                       Ouroboros.Network.MockNode
                        Ouroboros.Network.NodeToNode
                        Ouroboros.Network.Point
                        Ouroboros.Network.Protocol.BlockFetch.Client
@@ -214,7 +214,7 @@ test-suite tests
                        Test.ChainProducerState
                        Test.Ouroboros.Network.Testing.Utils
                        Test.Ouroboros.Network.BlockFetch
-                       Test.Ouroboros.Network.Node
+                       Test.Ouroboros.Network.MockNode
                        Test.Mux
                        Test.Pipe
                        Test.Socket

--- a/ouroboros-network/src/Ouroboros/Network/MockNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/MockNode.hs
@@ -6,7 +6,15 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE PolyKinds           #-}
 
-module Ouroboros.Network.Node where
+-- | A mock (and naive) node implentation.  It only implements the @chain-sync@
+-- protocol using the 'Ouroboros.Network.MockChain.Chain' module.  The module
+-- is used to build tests on randomly generated graphs of nodes, see
+-- 'Test.Ouroboros.Network.MockNoder'.
+--
+-- A historical note: this was the very first node implemntation that pre-dates
+-- 'typed-protocols'.
+--
+module Ouroboros.Network.MockNode where
 
 import           Control.Exception (assert)
 import           Control.Monad

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -9,7 +9,7 @@ import qualified Test.ChainFragment (tests)
 import qualified Test.ChainProducerState (tests)
 import qualified Test.Pipe (tests)
 import qualified Test.Subscription (tests)
-import qualified Test.Ouroboros.Network.Node (tests)
+import qualified Test.Ouroboros.Network.MockNode (tests)
 import qualified Test.Ouroboros.Network.BlockFetch (tests)
 import qualified Ouroboros.Network.Protocol.ChainSync.Test (tests)
 import qualified Ouroboros.Network.Protocol.BlockFetch.Test (tests)
@@ -46,5 +46,5 @@ tests =
   , Test.Ouroboros.Network.BlockFetch.tests
 
     -- pseudo system-level
-  , Test.Ouroboros.Network.Node.tests
+  , Test.Ouroboros.Network.MockNode.tests
   ]

--- a/ouroboros-network/test/Test/Ouroboros/Network/MockNode.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/MockNode.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 
-module Test.Ouroboros.Network.Node where
+module Test.Ouroboros.Network.MockNode where
 
 import           Control.Monad (forM, forM_, replicateM, filterM, unless)
 import           Control.Monad.State (execStateT, lift, modify')
@@ -40,7 +40,7 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Network.Chain (Chain (..))
 import qualified Ouroboros.Network.Chain as Chain
 import           Ouroboros.Network.ChainProducerState (ChainProducerState (..))
-import           Ouroboros.Network.Node
+import           Ouroboros.Network.MockNode
 import           Ouroboros.Network.Testing.ConcreteBlock as ConcreteBlock
 
 import           Test.ChainGenerators (TestBlockChain (..))
@@ -48,7 +48,7 @@ import           Test.ChainGenerators (TestBlockChain (..))
 
 tests :: TestTree
 tests =
-  testGroup "Node"
+  testGroup "MockNode"
   [ testGroup "fixed graph topology"
     [ testProperty "core -> relay" prop_coreToRelay
     , testProperty "core -> relay -> relay" prop_coreToRelay2


### PR DESCRIPTION
Also add a commentary which indicates that this is a mock node
implementation, which is only used to test `chain-sync` protocol.