### PR TITLE
Handle multiple blocks with the same SlotNo in chain-like data types

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/MockChain/ProducerState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/MockChain/ProducerState.hs
@@ -4,9 +4,10 @@
 
 module Ouroboros.Network.MockChain.ProducerState where
 
-import           Ouroboros.Network.Block (castPoint, genesisPoint, pointSlot)
-import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate (..), HasHeader,
-                     HeaderHash, Point (..), blockPoint, pointOnChain)
+import           Ouroboros.Network.Block (castPoint, genesisPoint)
+import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate (..),
+                     HasHeader, HeaderHash, Point (..), blockPoint,
+                     pointOnChain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
 import           Control.Exception (assert)
@@ -236,8 +237,8 @@ rollback p (ChainProducerState c rs nrid) = do
     return $ ChainProducerState c' (rollbackReader <$> rs) nrid
   where
     rollbackReader r@ReaderState { readerPoint = p' }
-      | pointSlot p' > pointSlot p
-      = r { readerPoint = (castPoint p), readerNext = ReaderBackTo }
+      | Chain.pointIsAfter p' (castPoint p) c
+      = r { readerPoint = castPoint p, readerNext = ReaderBackTo }
       | otherwise
       = r
 

--- a/ouroboros-network/src/Ouroboros/Network/MockNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/MockNode.hs
@@ -378,15 +378,10 @@ forkCoreKernel slotDuration gchain fixupBlock cpsVar = do
     addBlock :: Chain block -> block -> Chain block
     addBlock c b =
       case At (blockSlot b) `compare` Chain.headSlot c of
-        -- the block is OK
-        GT -> let r = Chain.addBlock (fixupBlock c b) c in
-              assert (Chain.valid r) r
-        -- the slot @s@ is already taken; replace the previous block
-        EQ -> let c' = Chain.drop 1 c
-                  b' = fixupBlock c' b
-                  r  = Chain.addBlock b' c'
-              in assert (Chain.valid r) r
         LT -> error "blockGenerator invariant vaiolation: generated block is for slot in the past"
+        -- the block is OK (slot number _can_ be equal).
+        _ -> let r = Chain.addBlock (fixupBlock c b) c in
+              assert (Chain.valid r) r
 
 -- | Core node simulation.  Given a chain it will generate a @block@ at its
 -- slot time (i.e. @slotDuration * blockSlot block@).  When the node finds out

--- a/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Testing/ConcreteBlock.hs
@@ -67,10 +67,10 @@ import           GHC.Generics (Generic)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block
-import           Ouroboros.Network.MockChain.Chain (Chain)
-import qualified Ouroboros.Network.MockChain.Chain as C
 import           Ouroboros.Network.ChainFragment (ChainFragment)
 import qualified Ouroboros.Network.ChainFragment as CF
+import           Ouroboros.Network.MockChain.Chain (Chain)
+import qualified Ouroboros.Network.MockChain.Chain as C
 
 {-------------------------------------------------------------------------------
   Concrete block shape used currently in the network layer
@@ -172,7 +172,6 @@ instance HasHeader BlockHeader where
     blockInvariant b =
         hashHeader b == headerHash b
      && blockNo    b >  BlockNo 0  -- we reserve 0 for genesis
-     && blockSlot  b >  SlotNo  0  -- we reserve 0 for genesis
 
 instance HasHeader Block where
     blockHash      =            headerHash     . blockHeader

--- a/ouroboros-network/test/Test/ChainProducerState.hs
+++ b/ouroboros-network/test/Test/ChainProducerState.hs
@@ -17,9 +17,9 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Ouroboros.Network.Block (pointSlot, genesisPoint)
-import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate (..), Point (..),
-                     headPoint, pointOnChain)
+import           Ouroboros.Network.Block (HasHeader, genesisPoint, pointSlot)
+import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate (..),
+                     Point (..), headPoint, pointOnChain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 import           Ouroboros.Network.MockChain.ProducerState
 import           Ouroboros.Network.Testing.ConcreteBlock (Block (..))
@@ -154,14 +154,15 @@ prop_switchFork (ChainProducerStateForkTest cps f) =
         (uncurry readerInv)
         (zip (readerStates cps) (readerStates cps'))
   where
-    readerInv :: ReaderState block -> ReaderState block -> Bool
+    readerInv :: HasHeader block
+              => ReaderState block -> ReaderState block -> Bool
     readerInv r r'
       -- points only move backward
        = pointSlot (readerPoint r') <= pointSlot (readerPoint r)
       -- if reader's point moves back, `readerNext` is changed to `ReaderBackTo`
       && ((pointSlot (readerPoint r') < pointSlot (readerPoint r)) `implies` (readerNext r' == ReaderBackTo))
       -- if reader's point is not changed, also next instruction is not changed
-      && ((pointSlot (readerPoint r') == pointSlot (readerPoint r)) `implies` (readerNext r' == readerNext r))
+      && ((readerPoint r' == readerPoint r) `implies` (readerNext r' == readerNext r))
 
     implies :: Bool -> Bool -> Bool
     implies a b = not a || b


### PR DESCRIPTION
Closes #816: don't assume that the blocks in a
`Chain`/`ChainFragment`/`AnchoredFragment` have strictly increasing `SlotNo`s,
as EBBs have the same `SlotNo` as the block after them.

* Add gap size 0 in the chain generators so that blocks with the same `SlotNo`
  as the one before it are generated.
* Remove slot-based functionality from the API or hide it. For example, remove
  `ChainFragment.splitAfterSlot`, since it would have to return a list of
  splits. Hide `ChainFragment.lookupBySlot` and change its return type from
  `Maybe block` to `[block]`.
* Adapt the point-based variants accordingly: `ChainFragment.splitAfterPoint`
  will try multiple splits until the block with the right hash is found. This
  has an additional cost of *O(s)* where *s* is the number of blocks with the
  same `SlotNo`.