### PR TITLE
fix some MockChain problems regarding BlockNo

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/MockChain/Chain.hs
+++ b/ouroboros-network/src/Ouroboros/Network/MockChain/Chain.hs
@@ -123,9 +123,9 @@ validExtension c b = blockInvariant b
                   -- An EBB has the same SlotNo as the block after it, hence
                   -- the loose inequality.
                   && headSlot c <= At (blockSlot b)
-                  -- The empty chain has block number 0, but this is also the block
-                  -- number of the genesis block.
-                  && (headBlockNo c == 0 || succ (headBlockNo c) == blockNo b)
+                  -- The block number must be non-strictly increasing. An EBB
+                  -- has the same block number as its parent.
+                  && headBlockNo c <= blockNo b
 
 head :: Chain b -> Maybe b
 head Genesis  = Nothing
@@ -232,7 +232,9 @@ selectChain
   -> Chain block
   -> Chain block
 selectChain c1 c2 =
-  if headBlockNo c1 >= headBlockNo c2
+  -- Cannot use headBlockNo, because the block number could be less than the
+  -- length (it is non-striclty increasing).
+  if length c1 >= length c2
     then c1
     else c2
 

--- a/ouroboros-network/src/Ouroboros/Network/MockChain/Chain.hs
+++ b/ouroboros-network/src/Ouroboros/Network/MockChain/Chain.hs
@@ -232,9 +232,11 @@ selectChain
   -> Chain block
   -> Chain block
 selectChain c1 c2 =
-  -- Cannot use headBlockNo, because the block number could be less than the
-  -- length (it is non-striclty increasing).
-  if length c1 >= length c2
+  -- NB: it's not true in general that headBlockNo c = length c, since the
+  -- block number is non-strictly increasing. A chain c2 can be shorter in
+  -- _length_ i.e. number of blocks than c1, but still have a higher block
+  -- number than c1.
+  if headBlockNo c1 >= headBlockNo c2
     then c1
     else c2
 

--- a/ouroboros-network/src/Ouroboros/Network/MockChain/Chain.hs
+++ b/ouroboros-network/src/Ouroboros/Network/MockChain/Chain.hs
@@ -124,8 +124,9 @@ validExtension c b = blockInvariant b
                   -- the loose inequality.
                   && headSlot c <= At (blockSlot b)
                   -- The block number must be non-strictly increasing. An EBB
-                  -- has the same block number as its parent.
-                  && headBlockNo c <= blockNo b
+                  -- has the same block number as its parent. It can increase
+                  -- by at most one.
+                  && (headBlockNo c == blockNo b || succ (headBlockNo c) == blockNo b)
 
 head :: Chain b -> Maybe b
 head Genesis  = Nothing


### PR DESCRIPTION
Block numbers are not strictly increasing, because an EBB has the same block number as its parent (or 0 for the first one).