### PR TITLE
fix #821: testBlockchainTime was creating on extra slot

### DIFF
--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -92,13 +92,12 @@ test_simple_protocol_convergence :: forall m c ext.
                                  -> m Property
 test_simple_protocol_convergence pInfo isValid numCoreNodes numSlots seed =
     fmap (isValid nodeIds) $ withThreadRegistry $ \registry -> do
-      btime <- testBlockchainTime registry numSlots slotLen
+      testBtime <- newTestBlockchainTime registry numSlots slotLen
       broadcastNetwork registry
-                       btime
+                       testBtime
                        numCoreNodes
                        pInfo
                        (seedToChaCha seed)
-                       numSlots
                        slotLen
   where
     nodeIds :: [NodeId]


### PR DESCRIPTION
The patch is simple and does what we discussed on #821. But it's a Draft PR at the moment because the `Praos` test consumes all my machine's memory.