### PR TITLE
Also use non-mesh topologies in test-consensus

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -265,6 +265,7 @@ test-suite test-consensus
                     Test.Dynamic.Util
                     Test.Dynamic.Util.Expectations
                     Test.Dynamic.Util.NodeJoinPlan
+                    Test.Dynamic.Util.NodeTopology
                     Test.Dynamic.Util.Tests
                     Test.Ouroboros
                     Test.Util.DepFn

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -184,7 +184,7 @@ prop_general k TestConfig{numSlots, nodeJoinPlan, nodeTopology} schedule
     tabulate "consensus expected" [show isConsensusExcepected] $
     tabulate "shortestLength" [show (rangeK k (shortestLength nodeChains))] $
     tabulate "floor(4 * lastJoinSlot / numSlots)" [show lastJoinSlot] $
-    tabulate "bottleneckSizeNodeTopology" [show (bottleneckSizeNodeTopology nodeTopology)] $
+    tabulate "minimumDegreeNodeTopology" [show (minimumDegreeNodeTopology nodeTopology)] $
     prop_all_common_prefix
         maxForkLength
         (Map.elems nodeChains) .&&.

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -24,6 +24,7 @@ import           Ouroboros.Consensus.Util.Random
 import           Test.Dynamic.General
 import           Test.Dynamic.Util
 import           Test.Dynamic.Util.NodeJoinPlan
+import           Test.Dynamic.Util.NodeTopology
 
 import           Test.Util.Orphans.Arbitrary ()
 
@@ -47,12 +48,16 @@ tests = testGroup "Dynamic chain generation"
             shrinkNodeJoinPlan $
         \nodeJoinPlan ->
         forAllShrink
+            (genNodeTopology numCoreNodes)
+            shrinkNodeTopology $
+        \nodeTopology ->
+        forAllShrink
             (genLeaderSchedule k numSlots numCoreNodes nodeJoinPlan)
             (shrinkLeaderSchedule numSlots) $
         \schedule ->
             prop_simple_leader_schedule_convergence
                 params
-                TestConfig{numCoreNodes, numSlots, nodeJoinPlan}
+                TestConfig{numCoreNodes, numSlots, nodeJoinPlan, nodeTopology}
                 schedule seed
 
 prop_simple_leader_schedule_convergence :: PraosParams

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -14,7 +14,7 @@
 
 -- | Setup network
 module Test.Dynamic.Network (
-    broadcastNetwork
+    runNodeNetwork
   , TracingConstraints
     -- * Tracers
   , MiniProtocolExpectedException (..)
@@ -90,13 +90,14 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 
 import           Test.Dynamic.TxGen
 import           Test.Dynamic.Util.NodeJoinPlan
+import           Test.Dynamic.Util.NodeTopology
 
--- | Setup fully-connected topology, where every node is both a producer
--- and a consumer, and joins according to the node join plan
+-- | Setup a network of core nodes, where each joins according to the node join
+-- plan and is interconnected according to the node topology
 --
 -- We run for the specified number of blocks, then return the final state of
 -- each node.
-broadcastNetwork :: forall m blk.
+runNodeNetwork :: forall m blk.
                     ( MonadAsync m
                     , MonadFork  m
                     , MonadMask  m
@@ -113,13 +114,16 @@ broadcastNetwork :: forall m blk.
                  -> TestBlockchainTime m
                  -> NumCoreNodes
                  -> NodeJoinPlan
+                 -> NodeTopology
                  -> (CoreNodeId -> ProtocolInfo blk)
                  -> ChaChaDRG
                  -> DiffTime
                  -> m (TestOutput blk)
-broadcastNetwork registry testBtime numCoreNodes nodeJoinPlan pInfo initRNG slotLen = do
+runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
+  pInfo initRNG slotLen = do
     -- This function is organized around the notion of a network of nodes as a
-    -- simple graph with no loops. The graph topology is fully-connected/mesh.
+    -- simple graph with no loops. The graph topology is determined by
+    -- @nodeTopology@.
     --
     -- Each graph node is a Ouroboros core node, with its own private threads
     -- managing the node's internal state. Some nodes join the network later
@@ -137,18 +141,17 @@ broadcastNetwork registry testBtime numCoreNodes nodeJoinPlan pInfo initRNG slot
       forM coreNodeIds $ \nid -> (,) nid <$> atomically newEmptyTMVar
 
     -- spawn threads for each undirected edge
-    let meshEdges =
-          [ (n1, n2) | n1 <- coreNodeIds, n2 <- coreNodeIds, n1 < n2 ]
-    forM_ meshEdges $ \edge -> do
+    let edges = edgesNodeTopology nodeTopology
+    forM_ edges $ \edge -> do
       void $ forkLinkedThread registry $ do
         undirectedEdge nullTracer nodeVars edge
 
     -- create nodes
-    let meshNodes =
+    let nodesByJoinSlot =
           List.sortOn fst $   -- sort non-descending by join slot
           map (\nv@(n, _) -> (joinSlotOf n, nv)) $
           Map.toList nodeVars
-    nodes <- forM meshNodes $ \(joinSlot, (coreNodeId, nodeVar)) -> do
+    nodes <- forM nodesByJoinSlot $ \(joinSlot, (coreNodeId, nodeVar)) -> do
       -- do not start the node before its joinSlot
       tooLate <- blockUntilSlot btime joinSlot
       when tooLate $ do

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -19,6 +19,7 @@ import           Ouroboros.Consensus.Util.Random
 import           Test.Dynamic.General
 import           Test.Dynamic.Util
 import           Test.Dynamic.Util.NodeJoinPlan
+import           Test.Dynamic.Util.NodeTopology
 
 import           Test.Util.Orphans.Arbitrary ()
 
@@ -44,10 +45,15 @@ tests = testGroup "Dynamic chain generation"
             (genNodeJoinPlan numCoreNodes numSlots)
             shrinkNodeJoinPlan $
         \nodeJoinPlan ->
+        forAllShrink
+            (genNodeTopology numCoreNodes)
+            shrinkNodeTopology $
+        \nodeTopology ->
             testPraos' TestConfig
               { numCoreNodes
               , numSlots
               , nodeJoinPlan
+              , nodeTopology
               }
                 seed
     ]
@@ -57,6 +63,7 @@ tests = testGroup "Dynamic chain generation"
       { numCoreNodes
       , numSlots
       , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
+      , nodeTopology = meshNodeTopology numCoreNodes
       }
 
     testPraos' :: TestConfig -> Seed -> Property

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
@@ -42,6 +42,7 @@ import           Test.Dynamic.General
 import           Test.Dynamic.Network (NodeOutput (..))
 import           Test.Dynamic.Util
 import           Test.Dynamic.Util.NodeJoinPlan
+import           Test.Dynamic.Util.NodeTopology
 
 import           Test.Util.Orphans.Arbitrary ()
 
@@ -59,14 +60,18 @@ tests = testGroup "Dynamic chain generation"
       -- See a related discussion at
       -- https://github.com/input-output-hk/ouroboros-network/pull/773#issuecomment-522192097
       testProperty "addressed by InvalidRollForward exception (PR #773)" $
+          let ncn = NumCoreNodes 3
+          in
           prop_simple_real_pbft_convergence TestConfig
-            { numCoreNodes = NumCoreNodes 3
+            { numCoreNodes = ncn
             , numSlots = NumSlots 24
             , nodeJoinPlan = NodeJoinPlan $ Map.fromList
               [ (CoreNodeId 0,SlotNo 0)
               , (CoreNodeId 1,SlotNo 20)
               , (CoreNodeId 2,SlotNo 22)
-              ]}
+              ]
+            , nodeTopology = meshNodeTopology ncn
+            }
     , testProperty "simple Real PBFT convergence" $
         prop_simple_real_pbft_convergence
     ]

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util/NodeTopology.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util/NodeTopology.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Dynamic.Util.NodeTopology
+  ( -- * Node Topology
+    NodeTopology (..)
+  , coreNodeIdNeighbors
+  , edgesNodeTopology
+  , genNodeTopology
+  , shrinkNodeTopology
+  , meshNodeTopology
+  , bottleneckSizeNodeTopology
+  ) where
+
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           GHC.Stack (HasCallStack)
+import           Test.QuickCheck
+
+import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract
+import           Ouroboros.Consensus.NodeId
+import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Consensus.Util.Orphans ()
+
+{-------------------------------------------------------------------------------
+  Node Topologies
+-------------------------------------------------------------------------------}
+
+-- | Which /lesser/ nodes each node connects to
+--
+-- INVARIANT: for each mapping @n -> ms@, @n > m@ for each @m@.
+--
+-- INVARIANT: each mapping is non-empty, except for @CoreNodeId 0@
+--
+-- INVARIANT: each mapping is sorted strictly ascending
+--
+-- INVARIANT: there is a mapping for each @CoreNodeId@ in the test, @0 .. n -
+-- 1@
+--
+newtype NodeTopology = NodeTopology (Map CoreNodeId [CoreNodeId])
+  deriving (Eq, Show)
+
+instance Condense NodeTopology where
+  condense top@(NodeTopology m)
+    | top == mesh = "meshNodeTopology (NumCoreNodes " ++ show (Map.size m) ++ ")"
+    | otherwise = condense
+      [ (fromCoreNodeId nid, map fromCoreNodeId nids)
+      | (nid, nids) <- Map.toAscList m ]
+    where
+      mesh = meshNodeTopology (NumCoreNodes (Map.size m))
+
+-- | Connect every pair of nodes
+--
+meshNodeTopology ::
+     NumCoreNodes
+     -- ^ PRECONDITION: non-negative
+  -> NodeTopology
+meshNodeTopology numCoreNodes =
+    NodeTopology $
+    Map.fromList $
+    [ (nid, enumCoreNodes (NumCoreNodes i))
+    | nid@(CoreNodeId i) <- enumCoreNodes numCoreNodes ]
+
+-- | Generate a 'NodeTopology' consistent with the given properties
+--
+genNodeTopology ::
+     HasCallStack
+  => NumCoreNodes
+     -- ^ PRECONDITION: non-negative
+  -> Gen NodeTopology
+genNodeTopology numCoreNodes@(NumCoreNodes n)
+  | n < 0 = error $ "Unsatisfiable parameters: "
+    ++ show numCoreNodes
+
+  | otherwise = do
+    let genNeighbors me@(CoreNodeId i) = case i of
+          0 -> pure (me, [])
+          _ ->
+            fmap ((,) me) $
+            flip suchThat (not . null) $
+            sublistOf (enumCoreNodes (NumCoreNodes i))
+
+    fmap (NodeTopology . Map.fromList) $
+      mapM genNeighbors (enumCoreNodes numCoreNodes)
+
+-- | Shrink a node topology
+--
+-- The new topologies must be usable with the same number of nodes and slots as
+-- the old topology
+--
+shrinkNodeTopology :: NodeTopology -> [NodeTopology]
+shrinkNodeTopology top@(NodeTopology m)
+    | top == mesh = []
+    | otherwise = [mesh]
+  where
+    mesh = meshNodeTopology (NumCoreNodes (Map.size m))
+    -- TODO more sophisticated shrinks. I anticipate that they'll need to use
+    -- 'Test.QuickCheck.Shrinking' or else risk very slow responses
+
+-- | Partial; @error@ for a node not in the plan
+--
+coreNodeIdNeighbors ::
+     HasCallStack
+  => NodeTopology -> CoreNodeId -> [CoreNodeId]
+coreNodeIdNeighbors (NodeTopology m) nid =
+    case hit of
+      Nothing      -> error $ "not found: " <> condense (nid, Map.toList m)
+      Just lessers -> lessers ++ greaters
+  where
+    (_, hit, greaters0) = Map.splitLookup nid m
+    greaters = Map.keys (Map.filter (nid `elem`) greaters0)
+
+-- | The edges in this topology
+edgesNodeTopology ::
+     HasCallStack
+  => NodeTopology -> [(CoreNodeId, CoreNodeId)]
+edgesNodeTopology (NodeTopology m) =
+    flip foldMap (Map.toList m) $ \(greater, lessers) ->
+       map (flip (,) greater) lessers
+
+-- | The neighbor count of the node with the fewest neighbors
+--
+bottleneckSizeNodeTopology :: HasCallStack => NodeTopology -> Int
+bottleneckSizeNodeTopology top@(NodeTopology m) =
+    check [ length (coreNodeIdNeighbors top nid) | nid <- Map.keys m ]
+  where
+    check = \case
+        []   -> error "empty topology"
+        x:xs -> foldl min x xs


### PR DESCRIPTION
This is a draft PR because I have plans to add `shrink`. Somewhat counter-intuitively, it will add missing edges to the topology.

Edit: I decided to leave the shrink as-is (only falls-back to full mesh), anything else risks combinatorial explosion. Fixes #228.