### PR TITLE
Fix broken master

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -164,8 +164,9 @@ mkImmDB :: ImmutableDB (HeaderHash blk) m
         -> (blk -> Encoding)
         -> EpochInfo m
         -> (blk -> Maybe (HeaderHash blk))
+        -> ErrorHandling ImmDB.ImmutableDBError m
         -> ImmDB m blk
-mkImmDB immDB decBlock encBlock immEpochInfo isEBB = ImmDB {..}
+mkImmDB immDB decBlock encBlock immEpochInfo isEBB err = ImmDB {..}
 
 {-------------------------------------------------------------------------------
   Getting and parsing blocks

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
@@ -411,7 +411,7 @@ implIteratorClose varItState itrId IteratorEnv{..} = do
       mbImmIt <- iteratorStateImmIt <$> readTVar varItState
       writeTVar varItState Closed
       return mbImmIt
-    mapM_ (ImmDB.iteratorClose cdbImmDB) mbImmIt
+    mapM_ (ImmDB.iteratorClose itImmDB) mbImmIt
 
 -- | Possible states of an iterator.
 --
@@ -569,8 +569,8 @@ implIteratorNext varItState IteratorEnv{..} =
                 -> InImmDBEnd blk
                 -> m (IteratorResult blk)
     nextInImmDB continueFrom immIt immEnd = do
-      immRes <- selectResult immEnd <$> ImmDB.iteratorNext    cdbImmDB immIt
-                                    <*> ImmDB.iteratorHasNext cdbImmDB immIt
+      immRes <- selectResult immEnd <$> ImmDB.iteratorNext    itImmDB immIt
+                                    <*> ImmDB.iteratorHasNext itImmDB immIt
       case immRes of
         NotDone blk -> do
           let continueFrom' = StreamFromExclusive (blockPoint blk)
@@ -605,8 +605,8 @@ implIteratorNext varItState IteratorEnv{..} =
                      -> NonEmpty (HeaderHash blk)
                      -> m (IteratorResult blk)
     nextInImmDBRetry mbContinueFrom immIt (hash NE.:| hashes) =
-      selectResult StreamAll <$> ImmDB.iteratorNext    cdbImmDB immIt
-                             <*> ImmDB.iteratorHasNext cdbImmDB immIt >>= \case
+      selectResult StreamAll <$> ImmDB.iteratorNext    itImmDB immIt
+                             <*> ImmDB.iteratorHasNext itImmDB immIt >>= \case
         NotDone blk | blockHash blk == hash -> do
           trace $ BlockWasCopiedToImmDB hash
           let continueFrom' = StreamFromExclusive (blockPoint blk)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
@@ -146,8 +146,10 @@ openDB args@VolDbArgs{..} = do
 mkVolDB :: VolatileDB (HeaderHash blk) m
         -> (forall s. Decoder s blk)
         -> (blk -> Encoding)
+        -> ErrorHandling (VolatileDBError (HeaderHash blk)) m
+        -> ThrowCantCatch (VolatileDBError (HeaderHash blk)) (STM m)
         -> VolDB m blk
-mkVolDB volDB decBlock encBlock = VolDB {..}
+mkVolDB volDB decBlock encBlock err errSTM = VolDB {..}
 
 {-------------------------------------------------------------------------------
   Wrappers

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -273,7 +273,7 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
       (_volDBModel, volDB) <- VolDB.openDBMock EH.throwSTM 1
       forM_ blocks $ \block ->
         VolDB.putBlock volDB (blockInfo block) (serialiseIncremental block)
-      return $ mkVolDB volDB decode encode
+      return $ mkVolDB volDB decode encode EH.monadCatch EH.throwSTM
 
     blockInfo :: TestBlock -> VolDB.BlockInfo (HeaderHash TestBlock)
     blockInfo tb = VolDB.BlockInfo
@@ -295,4 +295,5 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
         ImmDB.appendBinaryBlob immDB (blockSlot block)
                                (serialiseIncremental block)
       let epochInfo = fixedSizeEpochInfo epochSize
-      return $ mkImmDB immDB decode encode epochInfo (const Nothing)
+          isEBB     = const Nothing
+      return $ mkImmDB immDB decode encode epochInfo isEBB EH.monadCatch


### PR DESCRIPTION
PR #797 was recently merged, which no longer compiled after merging with
master because of PR #810.

CI did not signal this because there were no merge conflicts and it never
rebuilt PR #797 against the updated master.

To avoid this in the future, use `bors r+`, which first tries to build the
merged PR (as opposed to the unmerged PR branch) before actually pushing to
master.