### PR TITLE
Byron block/header codec is CBOR-in-CBOR

### DIFF
--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -34,8 +34,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7";
-      sha256 = "1pp2i4w8074mlzmch3a7fdjiyqvjhimvbx9hv573dprwfh358l7j";
+      rev = "29902b163eb3dad1d6aed1e3efc08ee6258fa9e7";
+      sha256 = "0y0py7rgl4yly2cq0ls5hcgif2bk1a10js0d0grixpvnpwds4l12";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7";
-      sha256 = "1pp2i4w8074mlzmch3a7fdjiyqvjhimvbx9hv573dprwfh358l7j";
+      rev = "29902b163eb3dad1d6aed1e3efc08ee6258fa9e7";
+      sha256 = "0y0py7rgl4yly2cq0ls5hcgif2bk1a10js0d0grixpvnpwds4l12";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7";
-      sha256 = "1pp2i4w8074mlzmch3a7fdjiyqvjhimvbx9hv573dprwfh358l7j";
+      rev = "29902b163eb3dad1d6aed1e3efc08ee6258fa9e7";
+      sha256 = "0y0py7rgl4yly2cq0ls5hcgif2bk1a10js0d0grixpvnpwds4l12";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -115,8 +115,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7";
-      sha256 = "1pp2i4w8074mlzmch3a7fdjiyqvjhimvbx9hv573dprwfh358l7j";
+      rev = "29902b163eb3dad1d6aed1e3efc08ee6258fa9e7";
+      sha256 = "0y0py7rgl4yly2cq0ls5hcgif2bk1a10js0d0grixpvnpwds4l12";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -391,7 +391,13 @@ chainSyncClient tracer cfg btime (ClockSkew maxSkew)
           -- TODO: Chain sync Client: Reuse anachronistic ledger view? #581
           case anachronisticProtocolLedgerView cfg curLedger (pointSlot hdrPoint) of
             Nothing   -> retry
-            Just view -> return (SB.sbContent view)
+            Just view -> case view `SB.at` hdrSlot of
+                Nothing -> error "anachronisticProtocolLedgerView invariant violated"
+                Just lv -> return lv
+              where
+                hdrSlot = case pointSlot hdrPoint of
+                  Origin      -> SlotNo 0
+                  At thisSlot -> thisSlot
 
       -- Check for clock skew
       wallclock <- getCurrentSlot btime

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -391,13 +391,7 @@ chainSyncClient tracer cfg btime (ClockSkew maxSkew)
           -- TODO: Chain sync Client: Reuse anachronistic ledger view? #581
           case anachronisticProtocolLedgerView cfg curLedger (pointSlot hdrPoint) of
             Nothing   -> retry
-            Just view -> case view `SB.at` hdrSlot of
-                Nothing -> error "anachronisticProtocolLedgerView invariant violated"
-                Just lv -> return lv
-              where
-                hdrSlot = case pointSlot hdrPoint of
-                  Origin      -> SlotNo 0
-                  At thisSlot -> thisSlot
+            Just view -> return (SB.sbContent view)
 
       -- Check for clock skew
       wallclock <- getCurrentSlot btime

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -108,6 +108,7 @@ import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.SlotBounded (SlotBounded (..))
 import qualified Ouroboros.Consensus.Util.SlotBounded as SB
 
+
 {-------------------------------------------------------------------------------
   Byron blocks and headers
 -------------------------------------------------------------------------------}
@@ -895,15 +896,16 @@ instance (ByronGiven, Typeable cfg, ConfigContainsGenesis cfg)
         Nothing
           | slot >= At lvLB && slot <= At lvUB
           -> Just $ PBftLedgerView <$>
-             case Seq.takeWhileL
-                    (\sd -> At (convertSlot (V.Scheduling.sdSlot sd)) <= slot)
-                    dsScheduled of
+             case intermediateUpdates of
                 -- No updates to apply. So the current ledger state is valid
                 -- from the end of the last snapshot to the first scheduled
                 -- update.
                Seq.Empty              -> SB.bounded lb ub dsNow
-               toApply@(_ Seq.:|> la) ->
-                 SB.bounded lb (convertSlot . V.Scheduling.sdSlot $ la) $
+                -- Updates to apply. So we must apply them, and then the ledger
+                -- state is valid from the end of the last update until the next
+                -- scheduled update in the future.
+               toApply@(_ Seq.:|> la) -> 
+                 SB.bounded (convertSlot . V.Scheduling.sdSlot $ la) ub $
                  foldl'
                    (\acc x -> Bimap.insert (V.Scheduling.sdDelegator x)
                                            (V.Scheduling.sdDelegate x)
@@ -915,9 +917,13 @@ instance (ByronGiven, Typeable cfg, ConfigContainsGenesis cfg)
       lb = case ss of
         _ Seq.:|> s -> max lvLB (sbUpper s)
         Seq.Empty   -> lvLB
-      ub = case dsScheduled of
+      ub = case futureUpdates of
         s Seq.:<| _ -> min lvUB (convertSlot $ V.Scheduling.sdSlot s)
         Seq.Empty   -> lvUB
+      
+      (intermediateUpdates, futureUpdates) = Seq.spanl 
+                    (\sd -> At (convertSlot (V.Scheduling.sdSlot sd)) <= slot)
+                    dsScheduled
 
       SecurityParam paramK = pbftSecurityParam . pbftParams . encNodeConfigP $ cfg
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
@@ -73,13 +73,16 @@ forgeGenesisEBB (WithEBBNodeConfig cfg) curSlot = do
       . annotateBoundary given
       $ boundaryData
   where
-    boundaryData = CC.Block.BoundaryValidationData
+    boundaryData = CC.Block.ABoundaryBlock
                    boundaryLength
-                   (Left pbftGenesisHash)
-                   epoch
-                   (CC.Common.ChainDifficulty 0)
+                   boundaryHeader
+                   (CC.Block.ABoundaryBody ())
                    ()
-                   ()
+    boundaryHeader = CC.Block.ABoundaryHeader
+                     (Left pbftGenesisHash)
+                     epoch
+                     (CC.Common.ChainDifficulty 0)
+                     ()
     boundaryLength = 0 -- Since this is a demo and we ignore the length, set this
                        -- to 0
     ByronConfig { pbftGenesisHash

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -9,8 +9,6 @@ import           Data.Reflection (given)
 import qualified Cardano.Chain.Block as Cardano.Block
 import           Ouroboros.Consensus.Ledger.Byron
 import           Ouroboros.Consensus.Node.Run.Abstract
-import           Ouroboros.Consensus.Protocol.ExtNodeConfig
-import           Ouroboros.Consensus.Protocol.WithEBBs
 
 import           Ouroboros.Consensus.Ledger.Byron.Config
 import           Ouroboros.Consensus.Ledger.Byron.Forge
@@ -28,16 +26,16 @@ instance ByronGiven => RunNode (ByronBlockOrEBB ByronConfig) where
     Cardano.Block.ABOBBoundary _ -> True
   nodeEpochSize          = \_ _ -> return 21600 -- TODO #226
 
-  nodeEncodeBlock        = encodeByronBlock given . pbftEpochSlots . encNodeConfigExt . unWithEBBNodeConfig
-  nodeEncodeHeader       = encodeByronHeader given . pbftEpochSlots . encNodeConfigExt . unWithEBBNodeConfig
+  nodeEncodeBlock        = const encodeByronBlock
+  nodeEncodeHeader       = const encodeByronHeader
   nodeEncodeGenTx        = encodeByronGenTx
   nodeEncodeGenTxId      = encodeByronGenTxId
   nodeEncodeHeaderHash   = const encodeByronHeaderHash
   nodeEncodeLedgerState  = const encodeByronLedgerState
   nodeEncodeChainState   = const encodeByronChainState
 
-  nodeDecodeBlock        = decodeByronBlock given . pbftEpochSlots . encNodeConfigExt . unWithEBBNodeConfig 
-  nodeDecodeHeader       = decodeByronHeader given . pbftEpochSlots . encNodeConfigExt . unWithEBBNodeConfig 
+  nodeDecodeBlock        = const (decodeByronBlock given)
+  nodeDecodeHeader       = const (decodeByronHeader given)
   nodeDecodeGenTx        = decodeByronGenTx
   nodeDecodeGenTxId      = decodeByronGenTxId
   nodeDecodeHeaderHash   = const decodeByronHeaderHash

--- a/stack.yaml
+++ b/stack.yaml
@@ -26,7 +26,7 @@ extra-deps:
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 7d9fd48f4d8e4cd0658c7839a4d02c44d5706ac7
+    commit: 29902b163eb3dad1d6aed1e3efc08ee6258fa9e7
     subdirs:
       - cardano-ledger
       - cardano-ledger/test


### PR DESCRIPTION
This way, the `ByteString` annotations on Byron blocks and headers are
useful. Getting them by of re-annotate, which re-encodes the block/header
to get the annotation, doesn't work in general, because the decoder drops
information.

Makes use of an updated revision of cardano-ledger in which the boundary
validation data is factored into header/body.