### PR TITLE
setup for #821 fix: cleanup slot-to-epoch conversions in Praos

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -66,6 +66,8 @@ import           Ouroboros.Consensus.Util.HList (HList (..))
 
 import           Ouroboros.Consensus.Ledger.Mock.Stake
 
+import           Ouroboros.Storage.Common (EpochNo (..))
+
 {-------------------------------------------------------------------------------
   Fields required by Praos in the header
 -------------------------------------------------------------------------------}
@@ -156,10 +158,6 @@ data PraosValidationError c =
     | PraosInsufficientStake Double Natural
 
 deriving instance PraosCrypto c => Show (PraosValidationError c)
-
--- TODO: This type definition belongs elsewhere.
-newtype EpochNo = EpochNo { unEpochNo :: Word64 }
-    deriving (Eq, Num, Ord, Serialise, ToCBOR)
 
 data BlockInfo c = BlockInfo
     { biSlot  :: SlotNo

--- a/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
@@ -17,6 +17,7 @@ module Ouroboros.Storage.Common (
   , decodeTip
   ) where
 
+import           Cardano.Binary (ToCBOR (..))
 import           Codec.CBOR.Decoding (Decoder)
 import qualified Codec.CBOR.Decoding as Dec
 import           Codec.CBOR.Encoding (Encoding)
@@ -33,7 +34,7 @@ import           Ouroboros.Network.Block (Point, genesisPoint)
 
 -- | An epoch, i.e. the number of the epoch.
 newtype EpochNo = EpochNo { unEpochNo :: Word64 }
-  deriving (Eq, Ord, Enum, Num, Show, Generic)
+  deriving (Eq, Ord, Enum, Num, Show, Generic, Serialise, ToCBOR)
 
 newtype EpochSize = EpochSize { unEpochSize :: Word64 }
   deriving (Eq, Ord, Enum, Num, Show, Generic, Real, Integral)


### PR DESCRIPTION
This PR requested at https://github.com/input-output-hk/ouroboros-network/pull/827#issuecomment-515337447

Summary: my anticipated explanation is that because of #821, this Praos code was written under the assumption that `SlotNo 1` was the first slot. From that perspective, the attempted fix for #821 (PR #827) reveals some "off-by-1" issues. This PR addresses those issues. The tests still pass, even without the fix for #821.