### PR TITLE
Use the Mempool in the consensus tests

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -6,6 +6,7 @@ module Ouroboros.Consensus.Mempool.Impl (
     openMempool
   , LedgerInterface (..)
   , chainDBLedgerInterface
+  , TicketNo
     -- * For testing purposes
   , openMempoolWithoutSyncThread
   ) where


### PR DESCRIPTION
This finally enables testing of the node-to-node transaction submission protocol.