### PR TITLE
Exported subscription trace types

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Common.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Common.hs
@@ -13,6 +13,7 @@ module Ouroboros.Network.Subscription.Common
     , SubscriberError (..)
     , SubscriptionTrace
     , IPSubscriptionTarget (..)
+    , WithIPList
     ) where
 
 

--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Dns.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Dns.hs
@@ -17,6 +17,8 @@ module Ouroboros.Network.Subscription.Dns
     , dnsSubscriptionWorker
     , dnsResolve
     , resolutionDelay
+
+    , DnsTrace
     ) where
 
 import           Control.Monad (unless)


### PR DESCRIPTION
They are part of subscription API, and thus they should be exported.
Constractors are not exported since they should not be needed.