### PR TITLE
Add applyChainTick and merge applyLedgerHeader/Block in consensus

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -39,26 +39,19 @@ class ( SupportedBlock blk
   ledgerConfigView :: NodeConfig (BlockProtocol blk)
                    -> LedgerConfig blk
 
-  -- | Apply a block header to the ledger state.
-  --
-  -- Used in 'applyExtLedgerState' to update the ledger state in 3 steps:
-  --
-  -- 1. 'applyLedgerHeader' updates the ledger with information from the header
-  -- 2. 'applyChainState' updates the the consensus-specific chain state
-  --    This gets passed the updated ledger from step (1) as an argument
-  -- 3. 'applyLedgerBlock' updates the ledger with information from the body
-  --
-  -- TODO: Explain why this ordering is correct and why we need the split;
-  -- (3) does not seem to rely on (2), and so we could do (1), (3), (2), and if
-  -- that is indeed possible, we could just combine (1) and (3) into a single
-  -- step..?
-  -- <https://github.com/input-output-hk/ouroboros-network/issues/596>
-  applyLedgerHeader :: LedgerConfig blk
-                    -> Header blk
-                    -> LedgerState blk
-                    -> Except (LedgerError blk) (LedgerState blk)
+  -- | Apply state transformations that might occur when encountering a new
+  --   block, but happen before full header and body processing. In the Byron
+  --   era this is used to perform epoch transitions on receipt of the first
+  --   block in the new epoch.
+  applyChainTick :: LedgerConfig blk
+                 -> SlotNo
+                 -> LedgerState blk
+                 -> Except (LedgerError blk) (LedgerState blk)
 
-  -- | Apply a block to the ledger state
+  -- | Apply a block to the ledger state.
+  --
+  --   TODO: Update <https://github.com/input-output-hk/ouroboros-network/issues/596>
+  --   with change to applyLedgerBlock
   applyLedgerBlock :: LedgerConfig blk
                    -> blk
                    -> LedgerState blk

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool/TestBlock.hs
@@ -113,9 +113,9 @@ instance UpdateLedger TestBlock where
 
   ledgerConfigView _ = LedgerConfig
 
-  applyLedgerBlock = notNeeded
+  applyChainTick _ _ = notNeeded
 
-  applyLedgerHeader _ _ = notNeeded
+  applyLedgerBlock = notNeeded
 
   ledgerTipPoint = tlLastApplied
 

--- a/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
@@ -240,6 +240,8 @@ instance UpdateLedger TestBlock where
 
   ledgerConfigView _ = LedgerConfig
 
+  applyChainTick _ _ = return
+
   applyLedgerBlock _ tb@TestBlock{..} TestLedger{..}
     | Block.blockPrevHash tb /= snd lastApplied
     = throwError $ InvalidHash (snd lastApplied) (Block.blockPrevHash tb)
@@ -247,8 +249,6 @@ instance UpdateLedger TestBlock where
     = throwError $ InvalidBlock
     | otherwise
     = return     $ TestLedger (Chain.blockPoint tb, BlockHash (Block.blockHash tb))
-
-  applyLedgerHeader _ _ = return
 
   ledgerTipPoint = fst . lastApplied
 


### PR DESCRIPTION
This PR introduces the `applyChainTick` entry point, which separates out functionality that should happen when moving to a new slot, but before block processing. In the Byron era this is used to perform epoch transitions in the first block of the new era. 

This separation is necessary for hard forking. When we see the first block of the new era post-fork, we need to finish up the epoch transition in the old era, apply a translation to the state, and then start processing the new blocks.

This should also resolve #596, as we now have a clearly ordering on the phases of processing. We apply the chain tick, then process the header and body together, then finally perform the update to the chain state.