### PR TITLE
Fix space leak in the LedgerDB and the Byron LedgerState

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -180,9 +180,9 @@ instance (ByronGiven, Typeable cfg, ConfigContainsGenesis cfg)
      => UpdateLedger (ByronBlock cfg) where
 
   data LedgerState (ByronBlock cfg) = ByronLedgerState
-      { blsCurrent :: CC.Block.ChainValidationState
+      { blsCurrent :: !CC.Block.ChainValidationState
         -- | Slot-bounded snapshots of the chain state
-      , blsSnapshots :: Seq.Seq (SlotBounded CC.Block.ChainValidationState)
+      , blsSnapshots :: !(Seq.Seq (SlotBounded CC.Block.ChainValidationState))
       }
     deriving (Eq, Show)
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -129,13 +129,13 @@ ref (Val r _) = r
 -- | Summary of the chain at a particular point in time
 data ChainSummary l r = ChainSummary {
       -- | The tip of the chain
-      csTip    :: Tip r
+      csTip    :: !(Tip r)
 
       -- | Length of the chain
-    , csLength :: Word64
+    , csLength :: !Word64
 
       -- | Ledger state
-    , csLedger :: l
+    , csLedger :: !l
     }
   deriving (Show, Eq, Generic)
 
@@ -160,16 +160,16 @@ genesisChainSummary l = ChainSummary TipGen 0 l
 -- * as well as one at offset @k@ (so that we can roll back at most @k@ blocks)
 data LedgerDB l r =
     -- | Apply block @r@ and take a snapshot of the resulting ledger state @l@
-    Snap r l (LedgerDB l r)
+    Snap !r !l !(LedgerDB l r)
 
     -- | Apply block @r@ without taking a snapshot
-  | Skip r (LedgerDB l r)
+  | Skip !r !(LedgerDB l r)
 
     -- | The tail of the chain that is outside the scope of the snapshots
     --
     -- We record a summary of the chain tail /at this point/ as well as the
     -- missing snapshots, if any.
-  | Tail Missing (ChainSummary l r)
+  | Tail !Missing !(ChainSummary l r)
   deriving (Show, Eq)
 
 -- | Are we still missing some snapshots?


### PR DESCRIPTION
While running the cardano-byron-proxy, I noticed that the memory usage was
growing. Heap profiling revealed that the ledger was using the most memory. By
adding bangs to logical places in the `LedgerDB`, which stores snapshots of
the ledger state in memory and the `Byron` `LedgerState` record, the memory
usage reduced significantly. This is a first step towards #380.

I have measured the memory usage of cardano-byron-proxy using htop, after
downloading and validating 40.000 blocks.

Before: ~1500 MiB and growing
After:   ~523 MiB and steady, still ~523 MiB after 50.000 blocks.