### PR TITLE
rename MsgIntersectUnchanged to MsgIntersectNotFound

### DIFF
--- a/doc/network.tex
+++ b/doc/network.tex
@@ -1171,7 +1171,7 @@ application of the protocol determines the types of the requests and responses.
 \newcommand{\RollBackward}{\msg{RollBackward}}
 \newcommand{\FindIntersect}{\msg{FindIntersect}}
 \newcommand{\IntersectFound}{\msg{IntersectFound}}
-\newcommand{\IntersectUnchanged}{\msg{IntersectUnchanged}}
+\newcommand{\IntersectNotFound}{\msg{IntersectNotFound}}
 
 \subsection{Description}
 The chain synchronisation protocol is used by the block chain consumer
@@ -1211,7 +1211,7 @@ other node it communicates with.
   \draw (MustReply)    edge[right,bend right=80]     node{\RollBackward}          (Idle);
   \draw (Idle)         edge[right, bend right]    node{\FindIntersect}         (Intersect);
   \draw (Intersect)    edge[above, bend right=45]    node[below = 4mm]{\IntersectFound}     (Idle);
-  \draw (Intersect)    edge[above, bend right=80]    node[above = 4mm]{\IntersectUnchanged}    (Idle);
+  \draw (Intersect)    edge[above, bend right=80]    node[above = 4mm]{\IntersectNotFound}  (Idle);
   \draw (Idle)         edge[above]                node{\MsgDone}                  (Done);
 \end{tikzpicture}
 \caption{State machine of the chain sync protocol.}
@@ -1242,7 +1242,7 @@ The protocol uses the following messages:
       The producer replies with the first point of the request that is on his current chain.
       The consumer can decide whether to send more points.
       The message also tells the consumer about the head point of the producer.
-\item [\IntersectUnchanged{} {\boldmath $(point_{head})$}]
+\item [\IntersectNotFound{} {\boldmath $(point_{head})$}]
       The reply to the consumer that no intersection was found: none of the
       points the consumer supplied are on the producer chain.
       The message also tells the consumer about the head point of the producer.
@@ -1263,7 +1263,7 @@ The protocol uses the following messages:
   \MustReply & \RollForward        & $header$, $point_{head}$            & \Idle       \\ \hline
   \MustReply & \RollBackward       & $point_{old}$, $point_{head}$       & \Idle       \\ \hline
   \Intersect & \IntersectFound     & $point_{intersect}$, $point_{head}$ & \Idle       \\ \hline
-  \Intersect & \IntersectUnchanged & $point_{head}$                      & \Idle       \\ \hline
+  \Intersect & \IntersectNotFound  & $point_{head}$                      & \Idle       \\ \hline
 
 \end{tabular}
 
@@ -1378,7 +1378,7 @@ between the fork of the producer and the fork that is known to the consumer.
 
 To do so, the consumer sends a \FindIntersect{} message with a list of chain
 points which belong to its node chain.
-If the producer does not know any of the points it replies with \IntersectUnchanged.
+If the producer does not know any of the points it replies with \IntersectNotFound.
 Otherwise it replies with \IntersectFound{} and the best (i.e. the newest) of the points that it knows
 and also updates the $read~pointer$ accordingly.
 For efficiency, the consumer should use a binary search scheme to search for the longest common

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -230,8 +230,8 @@ chainSyncClient tracer cfg btime (ClockSkew maxSkew)
       return $ SendMsgFindIntersect (map castPoint points) $ ClientStIntersect
         { recvMsgIntersectFound  =
             ChainSyncClient .: intersectFound
-        , recvMsgIntersectUnchanged =
-            ChainSyncClient .  intersectUnchanged
+        , recvMsgIntersectNotFound =
+            ChainSyncClient .  intersectNotFound
         }
 
     -- One of the points we sent intersected our chain. This intersection
@@ -283,9 +283,9 @@ chainSyncClient tracer cfg btime (ClockSkew maxSkew)
     -- we later optimise this client to also find intersections after
     -- start-up, this code will have to be adapted, as it assumes it is only
     -- called at start-up.
-    intersectUnchanged :: Point blk
+    intersectNotFound :: Point blk
                        -> m (Consensus ClientStIdle blk m)
-    intersectUnchanged theirHead = atomically $ do
+    intersectNotFound theirHead = atomically $ do
       curChainState <- ouroborosChainState <$> getCurrentLedger
 
       CandidateState { candidateChain } <- readTVar varCandidate

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
@@ -111,7 +111,7 @@ chainSyncServerForReader _tracer chainDB rdr =
       tip     <- atomically $ ChainDB.getTipPoint chainDB
       return $ case changed of
         Just pt -> SendMsgIntersectFound    pt tip idle'
-        Nothing -> SendMsgIntersectUnchanged   tip idle'
+        Nothing -> SendMsgIntersectNotFound tip idle'
 
 {-------------------------------------------------------------------------------
   Trace events

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -656,7 +656,7 @@ chainSyncServer seed =
     intersectState :: [Block]
                    -> ServerStIntersect BlockHeader (Point BlockHeader) IO ()
     intersectState blocks =
-      SendMsgIntersectUnchanged
+      SendMsgIntersectNotFound
          -- pretend chain head is next one:
         (blockPoint (blockHeader (head blocks)))
         (ChainSyncServer (return (idleState blocks)))

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
@@ -93,8 +93,8 @@ data ClientStNext header point m a =
 --
 data ClientStIntersect header point m a =
      ClientStIntersect {
-       recvMsgIntersectFound     :: point -> point -> ChainSyncClient header point m a,
-       recvMsgIntersectUnchanged ::          point -> ChainSyncClient header point m a
+       recvMsgIntersectFound    :: point -> point -> ChainSyncClient header point m a,
+       recvMsgIntersectNotFound ::          point -> ChainSyncClient header point m a
      }
 
 
@@ -145,12 +145,12 @@ chainSyncClientPeer (ChainSyncClient mclient) =
           MsgIntersectFound pIntersect pHead ->
             chainSyncClientPeer (recvMsgIntersectFound pIntersect pHead)
 
-          MsgIntersectUnchanged pHead ->
-            chainSyncClientPeer (recvMsgIntersectUnchanged pHead)
+          MsgIntersectNotFound pHead ->
+            chainSyncClientPeer (recvMsgIntersectNotFound pHead)
       where
         ClientStIntersect {
           recvMsgIntersectFound,
-          recvMsgIntersectUnchanged
+          recvMsgIntersectNotFound
         } = stIntersect
 
     chainSyncClientPeer_ (SendMsgDone a) =

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
@@ -62,7 +62,7 @@ codecChainSync encodeHeader decodeHeader encodePoint decodePoint =
     encode (ServerAgency TokIntersect) (MsgIntersectFound p1 p2) =
       encodeListLen 3 <> encodeWord 5 <> encodePoint p1 <> encodePoint p2
 
-    encode (ServerAgency TokIntersect) (MsgIntersectUnchanged p) =
+    encode (ServerAgency TokIntersect) (MsgIntersectNotFound p) =
       encodeListLen 2 <> encodeWord 6 <> encodePoint p
 
     encode (ClientAgency TokIdle) MsgDone =
@@ -102,7 +102,7 @@ codecChainSync encodeHeader decodeHeader encodePoint decodePoint =
 
         (6, 2, ServerAgency TokIntersect) -> do
           p <- decodePoint
-          return (SomeMessage (MsgIntersectUnchanged p))
+          return (SomeMessage (MsgIntersectNotFound p))
 
         (7, 1, ClientAgency TokIdle) ->
           return (SomeMessage MsgDone)
@@ -155,7 +155,7 @@ codecChainSyncId = Codec encode decode
 
     (ServerAgency TokIntersect, Just (AnyMessage (MsgIntersectFound p1 p2))) -> return (DecodeDone (SomeMessage (MsgIntersectFound p1 p2)) Nothing)
 
-    (ServerAgency TokIntersect, Just (AnyMessage (MsgIntersectUnchanged p))) -> return (DecodeDone (SomeMessage (MsgIntersectUnchanged p)) Nothing)
+    (ServerAgency TokIntersect, Just (AnyMessage (MsgIntersectNotFound p))) -> return (DecodeDone (SomeMessage (MsgIntersectNotFound p)) Nothing)
 
     (ClientAgency TokIdle, Just (AnyMessage MsgDone)) -> return (DecodeDone (SomeMessage MsgDone) Nothing)
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
@@ -42,14 +42,14 @@ direct_  ServerStIdle{recvMsgRequestNext}
 direct_  ServerStIdle{recvMsgFindIntersect}
         (Client.SendMsgFindIntersect points
           ClientStIntersect{recvMsgIntersectFound,
-                            recvMsgIntersectUnchanged}) = do
+                            recvMsgIntersectNotFound}) = do
     sIntersect <- recvMsgFindIntersect points
     case sIntersect of
       SendMsgIntersectFound  pIntersect pHead server' ->
         direct server' (recvMsgIntersectFound pIntersect pHead)
 
-      SendMsgIntersectUnchanged            pHead server' ->
-        direct server' (recvMsgIntersectUnchanged pHead)
+      SendMsgIntersectNotFound            pHead server' ->
+        direct server' (recvMsgIntersectNotFound pHead)
 
 direct_ ServerStIdle{recvMsgDoneClient}
        (Client.SendMsgDone clientDone) = do

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Direct.hs
@@ -48,8 +48,8 @@ direct_  ServerStIdle{recvMsgFindIntersect}
       SendMsgIntersectFound  pIntersect pHead server' ->
         direct server' (recvMsgIntersectFound pIntersect pHead)
 
-      SendMsgIntersectNotFound            pHead server' ->
-        direct server' (recvMsgIntersectNotFound pHead)
+      SendMsgIntersectNotFound          pHead server' ->
+        direct server' (recvMsgIntersectNotFound         pHead)
 
 direct_ ServerStIdle{recvMsgDoneClient}
        (Client.SendMsgDone clientDone) = do

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Examples.hs
@@ -64,8 +64,8 @@ chainSyncClientExample chainvar client = ChainSyncClient $
       --  rejecting the server if there is no intersection in the last K blocks
       --
       ClientStIntersect {
-        recvMsgIntersectFound     = \_ _ -> ChainSyncClient (return (requestNext client')),
-        recvMsgIntersectUnchanged = \  _ -> ChainSyncClient (return (requestNext client'))
+        recvMsgIntersectFound    = \_ _ -> ChainSyncClient (return (requestNext client')),
+        recvMsgIntersectNotFound = \  _ -> ChainSyncClient (return (requestNext client'))
       }
 
     requestNext :: Client header m a -> ClientStIdle header (Point header) m a
@@ -175,7 +175,7 @@ chainSyncServerExample recvMsgDoneClient chainvar = ChainSyncServer $
       changed <- improveReadPoint r points
       case changed of
         (Just pt, tip) -> return $ SendMsgIntersectFound     pt tip (idle' r)
-        (Nothing, tip) -> return $ SendMsgIntersectUnchanged    tip (idle' r)
+        (Nothing, tip) -> return $ SendMsgIntersectNotFound     tip (idle' r)
 
     newReader :: m ReaderId
     newReader = atomically $ do

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Server.hs
@@ -83,7 +83,7 @@ data ServerStIntersect header point m a where
                             -> ChainSyncServer header point m a
                             -> ServerStIntersect header point m a
 
-  SendMsgIntersectUnchanged :: point
+  SendMsgIntersectNotFound  :: point
                             -> ChainSyncServer header point m a
                             -> ServerStIntersect header point m a
 
@@ -131,7 +131,7 @@ chainSyncServerPeer (ChainSyncServer mterm) = Effect $ mterm >>=
             (MsgIntersectFound pIntersect pHead)
             (chainSyncServerPeer next)
 
-    handleStIntersect (SendMsgIntersectUnchanged pHead next) =
+    handleStIntersect (SendMsgIntersectNotFound pHead next) =
       Yield (ServerAgency TokIntersect)
-            (MsgIntersectUnchanged pHead)
+            (MsgIntersectNotFound pHead)
             (chainSyncServerPeer next)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -179,15 +179,15 @@ instance (Show header, Show point) => Show (AnyMessageAndAgency (ChainSync heade
   show (AnyMessageAndAgency _ msg) = show msg
 
 instance (Eq header, Eq point) => Eq (AnyMessage (ChainSync header point)) where
-  AnyMessage MsgRequestNext               == AnyMessage MsgRequestNext               = True
-  AnyMessage MsgAwaitReply                == AnyMessage MsgAwaitReply                = True
-  AnyMessage (MsgRollForward h1 p1)       == AnyMessage (MsgRollForward h2 p2)       = h1 == h2 && p1 == p2
-  AnyMessage (MsgRollBackward p1 h1)      == AnyMessage (MsgRollBackward p2 h2)      = p1 == p2 && h1 == h2
-  AnyMessage (MsgFindIntersect ps1)       == AnyMessage (MsgFindIntersect ps2)       = ps1 == ps2
-  AnyMessage (MsgIntersectFound p1 h1)    == AnyMessage (MsgIntersectFound p2 h2)    = p1 == p2 && h1 == h2
-  AnyMessage (MsgIntersectNotFound h1)    == AnyMessage (MsgIntersectNotFound h2)    = h1 == h2
-  AnyMessage MsgDone                      == AnyMessage MsgDone                      = True
-  _                                       == _                                       = False
+  AnyMessage MsgRequestNext            == AnyMessage MsgRequestNext            = True
+  AnyMessage MsgAwaitReply             == AnyMessage MsgAwaitReply             = True
+  AnyMessage (MsgRollForward h1 p1)    == AnyMessage (MsgRollForward h2 p2)    = h1 == h2 && p1 == p2
+  AnyMessage (MsgRollBackward p1 h1)   == AnyMessage (MsgRollBackward p2 h2)   = p1 == p2 && h1 == h2
+  AnyMessage (MsgFindIntersect ps1)    == AnyMessage (MsgFindIntersect ps2)    = ps1 == ps2
+  AnyMessage (MsgIntersectFound p1 h1) == AnyMessage (MsgIntersectFound p2 h2) = p1 == p2 && h1 == h2
+  AnyMessage (MsgIntersectNotFound h1) == AnyMessage (MsgIntersectNotFound h2) = h1 == h2
+  AnyMessage MsgDone                   == AnyMessage MsgDone                   = True
+  _                                    == _                                    = False
 
 prop_codec_ChainSync
   :: AnyMessageAndAgency (ChainSync BlockHeader (Point BlockHeader))

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -169,7 +169,7 @@ instance Arbitrary (AnyMessageAndAgency (ChainSync BlockHeader (Point BlockHeade
         <$> (MsgIntersectFound <$> arbitrary
                                <*> arbitrary)
 
-    , AnyMessageAndAgency (ServerAgency TokIntersect) . MsgIntersectUnchanged
+    , AnyMessageAndAgency (ServerAgency TokIntersect) . MsgIntersectNotFound
         <$> arbitrary
 
     , return $ AnyMessageAndAgency (ClientAgency TokIdle) MsgDone
@@ -184,8 +184,8 @@ instance (Eq header, Eq point) => Eq (AnyMessage (ChainSync header point)) where
   AnyMessage (MsgRollForward h1 p1)       == AnyMessage (MsgRollForward h2 p2)       = h1 == h2 && p1 == p2
   AnyMessage (MsgRollBackward p1 h1)      == AnyMessage (MsgRollBackward p2 h2)      = p1 == p2 && h1 == h2
   AnyMessage (MsgFindIntersect ps1)       == AnyMessage (MsgFindIntersect ps2)       = ps1 == ps2
-  AnyMessage (MsgIntersectFound p1 h1)    == AnyMessage (MsgIntersectFound p2 h2) = p1 == p2 && h1 == h2
-  AnyMessage (MsgIntersectUnchanged h1)   == AnyMessage (MsgIntersectUnchanged h2)   = h1 == h2
+  AnyMessage (MsgIntersectFound p1 h1)    == AnyMessage (MsgIntersectFound p2 h2)    = p1 == p2 && h1 == h2
+  AnyMessage (MsgIntersectNotFound h1)    == AnyMessage (MsgIntersectNotFound h2)    = h1 == h2
   AnyMessage MsgDone                      == AnyMessage MsgDone                      = True
   _                                       == _                                       = False
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -109,9 +109,9 @@ instance Protocol (ChainSync header point) where
     --
     -- The message also tells the consumer about the head point of the producer.
     --
-    MsgIntersectUnchanged :: point
-                          -> Message (ChainSync header point)
-                                     StIntersect StIdle
+    MsgIntersectNotFound :: point
+                         -> Message (ChainSync header point)
+                                    StIntersect StIdle
 
     -- | Terminating messages
     --
@@ -151,7 +151,7 @@ instance (Show header, Show point) => Show (Message (ChainSync header point) fro
   show (MsgRollBackward p tip)      = "MsgRollBackward " ++ show p ++ " " ++ show tip
   show (MsgFindIntersect ps)        = "MsgFindIntersect " ++ show ps
   show (MsgIntersectFound p tip)    = "MsgIntersectFound " ++ show p ++ " " ++ show tip
-  show (MsgIntersectUnchanged p)    = "MsgIntersectUnchanged " ++ show p
+  show (MsgIntersectNotFound p)     = "MsgIntersectNotFound " ++ show p
   show MsgDone{}                    = "MsgDone"
 
 instance Show (ClientHasAgency (st :: ChainSync header point)) where

--- a/ouroboros-network/test/messages.cddl
+++ b/ouroboros-network/test/messages.cddl
@@ -20,7 +20,7 @@ chainSyncMessage
     / msgRollBackward
     / msgFindIntersect
     / msgIntersectFound
-    / msgIntersectUnchanged
+    / msgIntersectNotFound
     / chainSyncMsgDone
 
 ; these records use fixed length list encodings TODO: lookup CDDL syntax for that
@@ -30,8 +30,8 @@ msgRollForward         = [2, header, point]
 msgRollBackward        = [3, header, point]
 msgFindIntersect       = [4, points]
 msgIntersectFound      = [5, point, point]
-msgIntersectUnchanged  = [6, point]
-chainSyncMsgDone   = [7]
+msgIntersectNotFound   = [6, point]
+chainSyncMsgDone       = [7]
 
 points = [point]
 

--- a/ouroboros-network/wireshark-plugin/ouroboros_network.lua
+++ b/ouroboros-network/wireshark-plugin/ouroboros_network.lua
@@ -28,7 +28,7 @@ local chainsync_msg_codes = {
 	[3] = "MsgRollBackward",
 	[4] = "MsgFindIntersect",
 	[5] = "MsgIntersectFound",
-	[6] = "MsgIntersectUnchanged",
+	[6] = "MsgIntersectNotFound",
 	[7] = "MsgDone"
 }
 


### PR DESCRIPTION
Rename `MsgIntersectUnchanged` to `MsgIntersectNotFound`
including the identifiers that are derived from the message name,
documentation and wireshark-plugin.

https://github.com/input-output-hk/ouroboros-network/issues/849

This requires updates to cardano-node but only two lines