### PR TITLE
Check whether the state of the ChainDB is in normal form

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -212,6 +212,7 @@ library
                        constraints,
                        containers        >=0.5   && <0.7,
                        cryptonite        >=0.25  && <0.26,
+                       deepseq           >=1.4   && <1.5,
                        directory         >=1.3   && <1.4,
                        filepath          >=1.4   && <1.5,
                        fingertree        >=0.1.4.2 && <0.2,

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -89,6 +89,7 @@ library
                        Ouroboros.Consensus.Util.Condense
                        Ouroboros.Consensus.Util.HList
                        Ouroboros.Consensus.Util.Orphans
+                       Ouroboros.Consensus.Util.NormalForm
                        Ouroboros.Consensus.Util.Random
                        Ouroboros.Consensus.Util.STM
                        Ouroboros.Consensus.Util.Singletons

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -35,8 +35,8 @@ import           Ouroboros.Consensus.Util (repeatedlyM)
 --
 -- This is the combination of the ouroboros state and the ledger state proper.
 data ExtLedgerState blk = ExtLedgerState {
-      ledgerState         :: LedgerState blk
-    , ouroborosChainState :: ChainState (BlockProtocol blk)
+      ledgerState         :: !(LedgerState blk)
+    , ouroborosChainState :: !(ChainState (BlockProtocol blk))
     }
 
 data ExtValidationError blk =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeId.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeId.hs
@@ -8,7 +8,7 @@ module Ouroboros.Consensus.NodeId (
   ) where
 
 import           Codec.Serialise (Serialise)
-import           Ouroboros.Consensus.Util.Condense (Condense(..))
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
 
 
 {-------------------------------------------------------------------------------
@@ -17,8 +17,8 @@ import           Ouroboros.Consensus.Util.Condense (Condense(..))
 
 -- TODO: It is not at all clear that this makes any sense anymore. The network
 -- layer does not use or provide node ids (it uses addresses).
-data NodeId = CoreId Int
-            | RelayId Int
+data NodeId = CoreId !Int
+            | RelayId !Int
   deriving (Eq, Ord, Show)
 
 instance Condense NodeId where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -44,7 +44,7 @@ import           Ouroboros.Consensus.Util.Condense
 -------------------------------------------------------------------------------}
 
 data BftFields c toSign = BftFields {
-      bftSignature :: SignedDSIGN (BftDSIGN c) toSign
+      bftSignature :: !(SignedDSIGN (BftDSIGN c) toSign)
     }
 
 deriving instance BftCrypto c => Show (BftFields c toSIgn)
@@ -89,19 +89,19 @@ data BftParams = BftParams {
       --
       -- Although the protocol proper does not have such a security parameter,
       -- we insist on it.
-      bftSecurityParam :: SecurityParam
+      bftSecurityParam :: !SecurityParam
 
       -- | Number of core nodes
-    , bftNumNodes      :: Word64
+    , bftNumNodes      :: !Word64
     }
 
 instance BftCrypto c => OuroborosTag (Bft c) where
   -- | (Static) node configuration
   data NodeConfig (Bft c) = BftNodeConfig {
-        bftParams   :: BftParams
-      , bftNodeId   :: NodeId
-      , bftSignKey  :: SignKeyDSIGN (BftDSIGN c)
-      , bftVerKeys  :: Map NodeId (VerKeyDSIGN (BftDSIGN c))
+        bftParams   :: !BftParams
+      , bftNodeId   :: !NodeId
+      , bftSignKey  :: !(SignKeyDSIGN (BftDSIGN c))
+      , bftVerKeys  :: !(Map NodeId (VerKeyDSIGN (BftDSIGN c)))
       }
 
   type ValidationErr   (Bft c) = BftValidationErr

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/NormalForm.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/NormalForm.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+-- | Check whether a value is in normal form.
+--
+-- Intended for qualified import.
+--
+-- > import qualified Ouroboros.Consensus.Util.NormalForm as NF
+module Ouroboros.Consensus.Util.NormalForm
+  ( NormalForm (..)
+  , NFCheck
+  , checkResult
+  , checkMultiple
+    -- * Helpers
+  , standard
+  , tvar
+  , tvar'
+  , tmvar
+  , tmvar'
+  , tvarMap
+  , ignore
+  ) where
+
+import           Control.Monad.Except (ExceptT, lift, runExceptT, throwError)
+import           Data.Map.Strict (Map)
+import           GHC.Stack
+
+import           Control.Monad.Class.MonadSTM
+
+import qualified Cardano.Prelude as Cardano (isNormalForm)
+
+
+{-------------------------------------------------------------------------------
+  NormalForm class
+-------------------------------------------------------------------------------}
+
+-- TODO update documentation
+
+-- | Check whether a value of type @a@ is in normal form.
+--
+-- Use 'standard' (based on 'Cardano.isNormalForm') to implement instances.
+--
+-- We parameterise over @m@ and have @m Check@ as return type instead of
+-- simply @IO Bool@ (or @ExceptT String IO ()@) for the following reason:
+-- 'Cardano.isNormalForm' does not support 'TVar's and certainly not the
+-- 'TVar's we use that are parameterised over @m@. In order to check whether a
+-- 'TVar's is in normal form, we first have to read its contents, but since
+-- @m@ is abstract (and thus not 'IO'), this must happen in @m@.
+class NormalForm m a where
+  custom :: a -> m NFCheck
+
+{-------------------------------------------------------------------------------
+  Check
+-------------------------------------------------------------------------------}
+
+-- | The result of a 'isNormalForm' check, see 'NormalForm'.
+--
+-- Instead of returning @IO Bool@, we like to include an error message and
+-- make it composable, hence this newtype.
+newtype NFCheck = NFCheck { runNFCheck :: ExceptT CallStack IO () }
+
+-- | Return the result of a 'NFCheck'
+checkResult :: NFCheck -> IO (Either CallStack ())
+checkResult = runExceptT . runNFCheck
+
+instance Semigroup NFCheck where
+  NFCheck c1 <> NFCheck c2 = NFCheck (c1 *> c2)
+
+instance Monoid NFCheck where
+  mempty  = NFCheck $ return ()
+  mappend = (<>)
+
+-- | Combine multiple checks into one.
+checkMultiple :: Monad m => [m NFCheck] -> m NFCheck
+checkMultiple = fmap mconcat . sequence
+
+{-------------------------------------------------------------------------------
+  Helpers
+-------------------------------------------------------------------------------}
+
+-- | Use this for standard types, not for 'TVar's or 'TMVar's.
+standard :: (Monad m, HasCallStack) => a -> m NFCheck
+standard x = return $ NFCheck $ do
+    normal <- lift $ Cardano.isNormalForm $! x
+    if normal
+      then return ()
+      else throwError callStack
+
+-- | Use this helper for 'TVar's. The given function is used to check the
+-- value inside the 'TVar'.
+tvar :: (MonadSTM m, HasCallStack)
+     => TVar m a -> (a -> m NFCheck) -> m NFCheck
+tvar var f = do
+    contents <- atomically $ readTVar var
+    withFrozenCallStack $ f contents
+
+-- | Same as 'tvar', but uses 'standard' as the function.
+tvar' :: (MonadSTM m, HasCallStack) => TVar m a -> m NFCheck
+tvar' var = tvar var standard
+
+-- | Use this helper for 'TMVar's. The given function is used to check the
+-- value inside the 'TMVar'.
+--
+-- If the 'TMVar' is empty, the checks passes.
+tmvar :: (MonadSTM m, HasCallStack)
+      => TMVar m a -> (a -> m NFCheck) -> m NFCheck
+tmvar var f = do
+    contents <- atomically $ tryReadTMVar var
+    case contents of
+      Just x  -> withFrozenCallStack $ f x
+      Nothing -> return mempty
+
+-- | Same as 'tmvar', but uses 'standard' as the function.
+tmvar' :: (MonadSTM m, HasCallStack) => TMVar m a -> m NFCheck
+tmvar' var = tmvar var standard
+
+-- | Helper for a 'Map' containing 'TVar's, 'standard' is used to check the
+-- contents of the 'TVar's.
+tvarMap :: MonadSTM m => Map k (TVar m v) -> m NFCheck
+tvarMap _ = return mempty -- TODO
+
+-- | Ignore the given argument and assume it is always in normal form or that
+-- we simply don't care.
+ignore :: Monad m => a -> m NFCheck
+ignore _ = return mempty

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ThreadRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ThreadRegistry.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
 {-# OPTIONS_GHC -Wredundant-constraints #-}
 
@@ -34,6 +36,9 @@ import           Control.Monad.Class.MonadFork hiding (fork)
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow hiding (handle)
 
+import           Ouroboros.Consensus.Util.NormalForm (NormalForm)
+import qualified Ouroboros.Consensus.Util.NormalForm as NF
+
 {-------------------------------------------------------------------------------
   Public API
 -------------------------------------------------------------------------------}
@@ -49,6 +54,12 @@ data ThreadRegistry m = ThreadRegistry
     -- ^ The value to use for the next 'RegisteredID' that will be added to
     -- '_registered'.
   }
+
+instance MonadSTM m => NormalForm m (ThreadRegistry m) where
+  custom ThreadRegistry { _registered, _nextRegisteredID } = NF.checkMultiple
+    [ NF.tvar' _registered
+    , NF.tvar' _nextRegisteredID
+    ]
 
 -- | Create a new 'ThreadRegistry' and pass it to the supplied function.
 --

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds                 #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE FlexibleInstances         #-}
 {-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE MultiParamTypeClasses     #-}
 {-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
@@ -68,6 +70,8 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util ((.:))
+import           Ouroboros.Consensus.Util.NormalForm (NormalForm)
+import qualified Ouroboros.Consensus.Util.NormalForm as NF
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API (HasFS (hasFsErr),
@@ -109,6 +113,14 @@ data LgrDB m blk = LgrDB {
       -- ^ The arguments used to open the 'LgrDB'. Needed for 'reopen'ing the
       -- 'LgrDB'.
     }
+
+instance MonadSTM m => NormalForm m (LgrDB m blk) where
+  custom LgrDB{..} = NF.checkMultiple
+    [ NF.ignore conf -- A record of functions
+    , NF.ignore  varDB -- TODO NF.tvar'
+    , NF.tvar'  varPrevApplied
+    , NF.ignore args -- Static
+    ]
 
 -- | Shorter synonym for the instantiated 'LedgerDB.LedgerDB'.
 type LedgerDB blk = LedgerDB.LedgerDB (ExtLedgerState blk) (Point blk)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -148,10 +148,10 @@ data ChainDbState m blk
     -- 'ChainDB', it should /never/ be used.
 
 data ChainDbEnv m blk = CDB
-  { cdbImmDB          :: ImmDB m blk
-  , cdbVolDB          :: VolDB m blk
-  , cdbLgrDB          :: LgrDB m blk
-  , cdbChain          :: TVar m (AnchoredFragment (Header blk))
+  { cdbImmDB          :: !(ImmDB m blk)
+  , cdbVolDB          :: !(VolDB m blk)
+  , cdbLgrDB          :: !(LgrDB m blk)
+  , cdbChain          :: !(TVar m (AnchoredFragment (Header blk)))
     -- ^ Contains the current chain fragment.
     --
     -- INVARIANT: the anchor point of this fragment is the tip of the
@@ -164,7 +164,7 @@ data ChainDbEnv m blk = CDB
     -- Note that this fragment might also be /longer/ than @k@ headers,
     -- because the oldest blocks from the fragment might not yet have been
     -- copied from the VolatileDB to the ImmutableDB.
-  , cdbImmBlockNo     :: TVar m BlockNo
+  , cdbImmBlockNo     :: !(TVar m BlockNo)
     -- ^ The block number corresponding to the block @k@ blocks back. This is
     -- the most recent \"immutable\" block according to the protocol, i.e., a
     -- block that cannot be rolled back.
@@ -184,7 +184,7 @@ data ChainDbEnv m blk = CDB
     --
     -- Note that the \"immutable\" block will /never/ be /more/ than @k@
     -- blocks back, as opposed to the anchor point of 'cdbChain'.
-  , cdbIterators      :: TVar m (Map IteratorId (m ()))
+  , cdbIterators      :: !(TVar m (Map IteratorId (m ())))
     -- ^ The iterators.
     --
     -- This maps the 'IteratorId's of each open 'Iterator' to a function that,
@@ -192,14 +192,14 @@ data ChainDbEnv m blk = CDB
     -- ChainDB: the open file handles used by iterators can be closed, and the
     -- iterators themselves are closed so that it is impossible to use an
     -- iterator after closing the ChainDB itself.
-  , cdbReaders        :: TVar m (Map ReaderId (TVar m (ReaderState m blk)))
+  , cdbReaders        :: !(TVar m (Map ReaderId (TVar m (ReaderState m blk))))
     -- ^ The readers.
     --
     -- INVARIANT: the 'readerPoint' of each reader is 'withinFragmentBounds'
     -- of the current chain fragment (retrieved 'cdbGetCurrentChain', not by
     -- reading 'cdbChain' directly).
-  , cdbNodeConfig     :: NodeConfig (BlockProtocol blk)
-  , cdbInvalid        :: TVar m (Map (HeaderHash blk) SlotNo)
+  , cdbNodeConfig     :: !(NodeConfig (BlockProtocol blk))
+  , cdbInvalid        :: !(TVar m (Map (HeaderHash blk) SlotNo))
     -- ^ Hashes corresponding to invalid blocks. This is used to ignore these
     -- blocks during chain selection.
     --
@@ -208,22 +208,22 @@ data ChainDbEnv m blk = CDB
     -- older or equal to @s@ can be removed from this map.
     --
     -- TODO #730.
-  , cdbNextIteratorId :: TVar m IteratorId
-  , cdbNextReaderId   :: TVar m ReaderId
-  , cdbCopyLock       :: TMVar m ()
+  , cdbNextIteratorId :: !(TVar m IteratorId)
+  , cdbNextReaderId   :: !(TVar m ReaderId)
+  , cdbCopyLock       :: !(TMVar m ())
     -- ^ Lock used to ensure that 'copyToImmDB' is not executed more than
     -- once concurrentlycopyToImmDB.
     --
     -- Note that 'copyToImmDB' can still be executed concurrently with all
     -- others functions, just not with itself.
-  , cdbTracer         :: Tracer m (TraceEvent blk)
-  , cdbThreadRegistry :: ThreadRegistry m
+  , cdbTracer         :: !(Tracer m (TraceEvent blk))
+  , cdbThreadRegistry :: !(ThreadRegistry m)
     -- ^ Thread registry that will be used to (re)start the background
     -- threads, see 'cdbBgThreads'.
-  , cdbGcDelay        :: DiffTime
+  , cdbGcDelay        :: !DiffTime
     -- ^ How long to wait between copying a block from the VolatileDB to
     -- ImmutableDB and garbage collecting it from the VolatileDB
-  , cdbBgThreads      :: TVar m [Async m ()]
+  , cdbBgThreads      :: !(TVar m [Async m ()])
     -- ^ The background threads.
   }
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
@@ -51,7 +51,7 @@ type SlotOffset = Word64
 -------------------------------------------------------------------------------}
 
 -- | Tip of the chain
-data Tip r = Tip r | TipGen
+data Tip r = Tip !r | TipGen
   deriving (Show, Eq, Generic)
 
 tipIsGenesis :: Tip r -> Bool

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE RankNTypes    #-}
+{-# LANGUAGE DeriveFunctor         #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes            #-}
 module Ouroboros.Storage.ImmutableDB.API
   ( ImmutableDB (..)
   , withDB
@@ -23,6 +25,8 @@ import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 
 import           Pipes (Producer, lift, yield)
+
+import           Ouroboros.Consensus.Util.NormalForm (NFCheck, NormalForm (..))
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.ImmutableDB.Types
@@ -203,9 +207,15 @@ data ImmutableDB hash m = ImmutableDB
       -> m (Iterator hash m ByteString)
       -- TODO inclusive + exclusive bounds
 
+    -- | Internal: check whether the state is in normal form
+  , isNormalForm :: m NFCheck
+
     -- | Throw 'ImmutableDB' errors
   , immutableDBErr :: ErrorHandling ImmutableDBError m
   }
+
+instance NormalForm m (ImmutableDB hash m) where
+  custom = isNormalForm
 
 -- | An 'Iterator' is a handle which can be used to efficiently stream binary
 -- blobs. Slots not containing a blob and missing EBBs are skipped.

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
@@ -34,6 +34,7 @@ import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
 import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
 import           Codec.CBOR.Write (toLazyByteString)
+import           Control.DeepSeq (force)
 import           Control.Exception (assert)
 import           Control.Monad (void, when)
 import           Control.Monad.Class.MonadThrow
@@ -184,7 +185,7 @@ indexFromSlotOffsets = MkIndex . V.fromList . reverse . NE.toList
 indexToSlotOffsets :: Index hash -> NonEmpty SlotOffset
 indexToSlotOffsets (MkIndex offsets _)
   | Just sos <- NE.nonEmpty $ V.toList $ V.reverse offsets
-  = sos
+  = force sos
   | otherwise
   = 0 NE.:| []
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes       #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes            #-}
 module Ouroboros.Storage.VolatileDB.API
   ( VolatileDB(..)
   , withDB
@@ -15,6 +17,7 @@ import           Data.ByteString.Lazy (ByteString)
 import           Data.Set (Set)
 import           GHC.Stack (HasCallStack)
 
+import           Ouroboros.Consensus.Util.NormalForm (NFCheck, NormalForm (..))
 import           Ouroboros.Storage.VolatileDB.Types
 
 -- | Open the database using the given function, perform the given action
@@ -55,4 +58,9 @@ data VolatileDB blockId m = VolatileDB {
     , getPredecessor :: HasCallStack => STM m (blockId -> Maybe blockId)
     , garbageCollect :: HasCallStack => SlotNo -> m ()
     , getIsMember    :: HasCallStack => STM m (blockId -> Bool)
+      -- | Internal: check whether the state is in normal form
+    , isNormalForm   :: m NFCheck
 }
+
+instance NormalForm m (VolatileDB blockId m) where
+  custom = isNormalForm

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
@@ -13,7 +13,7 @@ module Ouroboros.Storage.VolatileDB.Types
     ) where
 
 import           Control.Exception (Exception (..))
-import           Data.Map (Map)
+import           Data.Map.Strict (Map)
 import           Data.Set (Set)
 import           Data.Typeable
 import           Data.Word (Word64)
@@ -100,23 +100,23 @@ newtype Parser e m blockId = Parser {
 
 -- This is the information a user has to provide for each new block.
 data BlockInfo blockId = BlockInfo {
-      bbid    :: blockId
-    , bslot   :: SlotNo
-    , bpreBid :: Maybe blockId
+      bbid    :: !blockId
+    , bslot   :: !SlotNo
+    , bpreBid :: !(Maybe blockId)
     } deriving Show
 
 -- The Internal information the db keeps for each block.
 data InternalBlockInfo blockId = InternalBlockInfo {
-      ibFile       :: String
-    , ibSlotOffset :: SlotOffset
-    , ibBlockSize  :: BlockSize
-    , ibSlot       :: SlotNo
-    , ibPreBid     :: Maybe blockId
+      ibFile       :: !String
+    , ibSlotOffset :: !SlotOffset
+    , ibBlockSize  :: !BlockSize
+    , ibSlot       :: !SlotNo
+    , ibPreBid     :: !(Maybe blockId)
     } deriving Show
 
 -- The Internal information the db keeps for each file.
 data FileInfo blockId = FileInfo {
-      fLatestSlot :: Maybe SlotNo
-    , fNBlocks    :: Int
-    , fContents   :: Map SlotOffset (BlockSize, blockId)
+      fLatestSlot :: !(Maybe SlotNo)
+    , fNBlocks    :: !Int
+    , fContents   :: !(Map SlotOffset (BlockSize, blockId))
     } deriving Show

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -35,7 +35,7 @@ import           Data.Bitraversable
 import           Data.Functor.Classes (Eq1, Show1)
 import           Data.List (sortOn)
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
 import           Data.Ord (Down (..))
 import           Data.Proxy
 import           Data.TreeDiff (ToExpr)

--- a/ouroboros-network/src/Ouroboros/Network/Point.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Point.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveFoldable    #-}
+{-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE DeriveTraversable #-}
 
@@ -11,9 +11,9 @@ module Ouroboros.Network.Point
   , block
   ) where
 
-import GHC.Generics (Generic)
+import           GHC.Generics (Generic)
 
-data WithOrigin t = Origin | At t
+data WithOrigin t = Origin | At !t
   deriving (Eq, Ord, Show, Generic, Functor, Foldable, Traversable)
 
 data Block slot hash = Block


### PR DESCRIPTION
Just sharing a potential approach.

I'm not happy with the need  to think about which functions from `NormalForm` to use: `tvar`, `tmvar`, `standard`, etc. We could use type class instances for this (so that we can simply use `custom`, which should then get renamed), but then we'll need to write a *lot* of instances (in most cases `standard` is enough).

I still have to update the mock databases.

There are still a bunch of things not in normal form, causing the test to fail. I have marked these with TODOs. We'll probably need more than a few bangs to fix them.