### PR TITLE
Assign correct FsErrorTypes

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
@@ -149,6 +149,7 @@ hGetExactly hasFS h n = go n []
               fsErrorType   = FsReachedEOF
             , fsErrorPath   = path
             , fsErrorString = "hGetExactly found eof before reading " ++ show n ++ " bytes"
+            , fsErrorNo     = Nothing
             , fsErrorStack  = callStack
             , fsLimitation  = False
             }

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
@@ -82,7 +82,4 @@ rethrowFsError fp action = do
       Right a  -> return a
   where
     handleError :: HasCallStack => IOError -> IO a
-    handleError ioErr =
-      case ioToFsError fp ioErr of
-        Left  unexpected -> E.throwIO unexpected
-        Right err        -> E.throwIO err
+    handleError ioErr = E.throwIO $ ioToFsError fp ioErr

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/MockFS.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/MockFS.hs
@@ -199,6 +199,7 @@ seekFilePtr err@ErrorHandling{..} MockFS{..} h seekMode o = do
             fsErrorType   = FsIllegalOperation
           , fsErrorPath   = closedFilePath
           , fsErrorString = "handle closed"
+          , fsErrorNo     = Nothing
           , fsErrorStack  = callStack
           , fsLimitation  = False
           }
@@ -234,6 +235,7 @@ seekFilePtr err@ErrorHandling{..} MockFS{..} h seekMode o = do
                          fsErrorType   = FsInvalidArgument
                        , fsErrorPath   = fp
                        , fsErrorString = "seek past EOF not supported"
+                       , fsErrorNo     = Nothing
                        , fsErrorStack  = callStack
                        , fsLimitation  = True
                        }
@@ -241,6 +243,7 @@ seekFilePtr err@ErrorHandling{..} MockFS{..} h seekMode o = do
                          fsErrorType   = FsInvalidArgument
                        , fsErrorPath   = fp
                        , fsErrorString = "seek in append mode not supported"
+                       , fsErrorNo     = Nothing
                        , fsErrorStack  = callStack
                        , fsLimitation  = True
                        }
@@ -248,6 +251,7 @@ seekFilePtr err@ErrorHandling{..} MockFS{..} h seekMode o = do
                          fsErrorType   = FsInvalidArgument
                        , fsErrorPath   = fp
                        , fsErrorString = "seek past beginning of file"
+                       , fsErrorNo     = Nothing
                        , fsErrorStack  = callStack
                        , fsLimitation  = False
                        }
@@ -324,6 +328,7 @@ withOpenHandleModify err@ErrorHandling{..} h f =
             fsErrorType   = FsIllegalOperation
           , fsErrorPath   = closedFilePath
           , fsErrorString = "handle closed"
+          , fsErrorNo     = Nothing
           , fsErrorStack  = callStack
           , fsLimitation  = False
           }
@@ -346,6 +351,7 @@ withOpenHandleRead err@ErrorHandling{..} h f =
             fsErrorType   = FsIllegalOperation
           , fsErrorPath   = closedFilePath
           , fsErrorString = "handle closed"
+          , fsErrorNo     = Nothing
           , fsErrorStack  = callStack
           , fsLimitation  = False
           }
@@ -371,6 +377,7 @@ checkFsTree' ErrorHandling{..} = go
             fsErrorType   = FsResourceInappropriateType
           , fsErrorPath   = fp
           , fsErrorString = "expected directory"
+          , fsErrorNo     = Nothing
           , fsErrorStack  = callStack
           , fsLimitation  = False
           }
@@ -379,6 +386,7 @@ checkFsTree' ErrorHandling{..} = go
             fsErrorType   = FsResourceInappropriateType
           , fsErrorPath   = fp
           , fsErrorString = "expected file"
+          , fsErrorNo     = Nothing
           , fsErrorStack  = callStack
           , fsLimitation  = False
           }
@@ -389,6 +397,7 @@ checkFsTree' ErrorHandling{..} = go
             fsErrorType   = FsResourceAlreadyExist
           , fsErrorPath   = fp
           , fsErrorString = "file exists"
+          , fsErrorNo     = Nothing
           , fsErrorStack  = callStack
           , fsLimitation  = False
           }
@@ -405,6 +414,7 @@ checkFsTree err@ErrorHandling{..} ma = do
                      fsErrorType   = FsResourceDoesNotExist
                    , fsErrorPath   = fp
                    , fsErrorString = "does not exist"
+                   , fsErrorNo     = Nothing
                    , fsErrorStack  = callStack
                    , fsLimitation  = False
                    }
@@ -419,6 +429,7 @@ checkDoesNotExist err@ErrorHandling{..} fs fp = do
                fsErrorType   = FsResourceAlreadyExist
              , fsErrorPath   = fp
              , fsErrorString = "already exists"
+             , fsErrorNo     = Nothing
              , fsErrorStack  = callStack
              , fsLimitation  = False
              }
@@ -457,6 +468,7 @@ hOpen err@ErrorHandling{..} fp openMode = do
         fsErrorType   = FsResourceInappropriateType
       , fsErrorPath   = fp
       , fsErrorString = "hOpen: directories not supported"
+      , fsErrorNo     = Nothing
       , fsErrorStack  = callStack
       , fsLimitation  = True
       }
@@ -469,6 +481,7 @@ hOpen err@ErrorHandling{..} fp openMode = do
             fsErrorType   = FsInvalidArgument
           , fsErrorPath   = fp
           , fsErrorString = "more than one concurrent writer not supported"
+          , fsErrorNo     = Nothing
           , fsErrorStack  = callStack
           , fsLimitation  = True
           }
@@ -528,6 +541,7 @@ hGetSome err@ErrorHandling{..} h n =
         fsErrorType   = FsInvalidArgument
       , fsErrorPath   = fp
       , fsErrorString = "cannot hGetSome in " <> mode <> " mode"
+      , fsErrorNo     = Nothing
       , fsErrorStack  = callStack
       , fsLimitation  = True
       }
@@ -554,6 +568,7 @@ hPutSome err@ErrorHandling{..} h toWrite =
                          fsErrorType   = FsInvalidArgument
                        , fsErrorPath   = fp
                        , fsErrorString = "handle is read-only"
+                       , fsErrorNo     = Nothing
                        , fsErrorStack  = callStack
                        , fsLimitation  = False
                        }
@@ -609,6 +624,7 @@ hTruncate err@ErrorHandling{..} h sz =
                       fsErrorType   = FsInvalidArgument
                     , fsErrorPath   = openFilePath
                     , fsErrorString = "truncate cannot make the file larger"
+                    , fsErrorNo     = Nothing
                     , fsErrorStack  = callStack
                     , fsLimitation  = True
                     }
@@ -617,6 +633,7 @@ hTruncate err@ErrorHandling{..} h sz =
                       fsErrorType   = FsInvalidArgument
                     , fsErrorPath   = openFilePath
                     , fsErrorString = "truncate only supported in append mode"
+                    , fsErrorNo     = Nothing
                     , fsErrorStack  = callStack
                     , fsLimitation  = True
                     }
@@ -659,6 +676,7 @@ createDirectoryIfMissing err@ErrorHandling{..} createParents dir = do
           fsErrorType   = FsResourceAlreadyExist
         , fsErrorPath   = dir
         , fsErrorString = "a file with that name already exists"
+        , fsErrorNo     = Nothing
         , fsErrorStack  = callStack
         , fsLimitation  = False
         }
@@ -717,6 +735,7 @@ removeFile err@ErrorHandling{..} fp = modifyMockFS err $ \fs -> case fp of
              fsErrorType   = FsIllegalOperation
            , fsErrorPath   = fp
            , fsErrorString = "cannot remove the root directory"
+           , fsErrorNo     = Nothing
            , fsErrorStack  = callStack
            , fsLimitation  = True
            }
@@ -725,6 +744,7 @@ removeFile err@ErrorHandling{..} fp = modifyMockFS err $ \fs -> case fp of
              fsErrorType   = FsIllegalOperation
            , fsErrorPath   = fp
            , fsErrorString = "cannot remove an open file"
+           , fsErrorNo     = Nothing
            , fsErrorStack  = callStack
            , fsLimitation  = True
            }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
@@ -69,11 +69,6 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 
 import           Test.Ouroboros.Storage.Util (Blob (..))
 
-
-
--- TODO what about FsUnexpectedException? Should we generate those too?
-
-
 {-------------------------------------------------------------------------------
   Streams
 -------------------------------------------------------------------------------}
@@ -369,7 +364,7 @@ genErrors genPartialWrites genSubstituteWithJunk = do
     _hOpen <- streamGen 1
       [ FsResourceDoesNotExist, FsResourceInappropriateType
       , FsResourceAlreadyInUse, FsResourceAlreadyExist
-      , FsInsufficientPermissions ]
+      , FsInsufficientPermissions, FsTooManyOpenFiles ]
     _hSeek      <- streamGen 3 [ FsReachedEOF ]
     _hGetSome   <- mkStreamGen 20 $ QC.frequency
       [ (1, return $ Left FsReachedEOF)
@@ -545,6 +540,7 @@ withErr ErrorHandling {..} errorsVar path action msg getter setter = do
         { fsErrorType   = errType
         , fsErrorPath   = path
         , fsErrorString = "simulated error: " <> msg
+        , fsErrorNo     = Nothing
         , fsErrorStack  = callStack
         , fsLimitation  = False
         }
@@ -583,6 +579,7 @@ hGetSome' ErrorHandling{..} fsVar errorsVar hGetSomeWrapped handle n = do
         { fsErrorType   = errType
         , fsErrorPath   = handleFsPath mockFS handle
         , fsErrorString = "simulated error: hGetSome"
+        , fsErrorNo     = Nothing
         , fsErrorStack  = callStack
         , fsLimitation  = False
         }
@@ -611,6 +608,7 @@ hPutSome' ErrorHandling{..} fsVar errorsVar hPutSomeWrapped handle bs = do
           , fsErrorString = "simulated error: hPutSome" <> case mbCorr of
               Nothing   -> ""
               Just corr -> " with corruption: " <> show corr
+          , fsErrorNo     = Nothing
           , fsErrorStack  = callStack
           , fsLimitation  = False
           }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -128,6 +128,7 @@ putBlockModel err cmdErr BlockInfo{..} bs = do
                       fsErrorType = fsErrT
                     , fsErrorPath = [currentFile]
                     , fsErrorString = ""
+                    , fsErrorNo    = Nothing
                     , fsErrorStack = EmptyCallStack
                     , fsLimitation = False
                 }
@@ -191,6 +192,7 @@ garbageCollectModel err cmdErr sl = do
                               fsErrorType = e
                             , fsErrorPath = [currentFile]
                             , fsErrorString = ""
+                            , fsErrorNo    = Nothing
                             , fsErrorStack = EmptyCallStack
                             , fsLimitation = False
                         }
@@ -202,6 +204,7 @@ garbageCollectModel err cmdErr sl = do
                               fsErrorType = e
                             , fsErrorPath = [currentFile]
                             , fsErrorString = ""
+                            , fsErrorNo    = Nothing
                             , fsErrorStack = EmptyCallStack
                             , fsLimitation = False
                         }


### PR DESCRIPTION
The `FsError` thrown when running out of file descriptors confusingly had
`FsDeviceFull` as its `FsErrorType`. This commit changes it to
`FsTooManyOpenFiles`.

The reason for it was that the underlying `IOError` had `ResourceExhausted` as
`IOErrorType` to which we assigned the `FsDeviceFull` `FsErrorType`. The
`ResourceExhausted` constructor is used for both the `EMFILE` `errno` (too
many open files) and `ENOSPC` (no space left on device).

To fix this, we make our own classification of `IOError`s based on the `errno`
first and falling back to the `IOErrorType` secondly. This allows us to assign
separate `FsErrorType`s to the two errors.

* Introduce the `FsTooManyOpenFiles` `FsErrorType` constructor.

* Remove the separate `FsUnexpectedException` and replace it with the
  `FsOther` constructor of `FsErrorType`.

* Add a `fsErrorNo :: Maybe Errno` to `FsError` so error messages show the
  precise `errno`, which will help with figuring out the true cause.