### PR TITLE
Abstract over blk instead of SimpleBlock in the consensus tests

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -254,6 +254,7 @@ test-suite test-consensus
                     Test.Dynamic.Network
                     Test.Dynamic.PBFT
                     Test.Dynamic.Praos
+                    Test.Dynamic.TxGen
                     Test.Dynamic.Util
                     Test.Ouroboros
                     Test.Util.DepFn

--- a/ouroboros-consensus/src/Ouroboros/Consensus/TxSubmission.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/TxSubmission.hs
@@ -21,12 +21,11 @@ import           Ouroboros.Consensus.Mempool.API
 --
 localTxSubmissionServer
   :: ( Monad m
-     , Show (ApplyTxErr blk)
      , ApplyTx blk
      )
   => Tracer m (TraceLocalTxSubmissionServerEvent blk)
   -> Mempool m blk idx
-  -> LocalTxSubmissionServer (GenTx blk) String m ()
+  -> LocalTxSubmissionServer (GenTx blk) (ApplyTxErr blk) m ()
 localTxSubmissionServer tracer Mempool{addTxs} =
     server
   where
@@ -35,7 +34,7 @@ localTxSubmissionServer tracer Mempool{addTxs} =
         traceWith tracer $ TraceReceivedTx tx
         res <- addTxs [tx]
         case res of
-          [(_tx, mbErr)] -> return (show <$> mbErr, server)
+          [(_tx, mbErr)] -> return (mbErr, server)
           -- The output list of addTxs has the same length as the input list.
           _              -> error "addTxs: unexpected result"
 

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/TxGen.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/TxGen.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | Transaction generator for testing
+module Test.Dynamic.TxGen
+  ( TxGen (..)
+  , testGenTxs
+  ) where
+
+import           Control.Monad (replicateM)
+import           Crypto.Number.Generate (generateBetween)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import           GHC.Stack (HasCallStack)
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Mock hiding (utxo)
+import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.Random
+
+{-------------------------------------------------------------------------------
+  TxGen class
+-------------------------------------------------------------------------------}
+
+class TxGen blk where
+  -- | Generate a transaction, valid or invalid, that can be submitted to a
+  -- node's Mempool.
+  testGenTx :: MonadRandom m
+            => NumCoreNodes
+            -> NodeConfig (BlockProtocol blk)
+            -> LedgerState blk
+            -> m (GenTx blk)
+
+-- | Generate multiple transactions using 'testGenTx'.
+testGenTxs :: (MonadRandom m, TxGen blk)
+           => NumCoreNodes
+           -> NodeConfig (BlockProtocol blk)
+           -> LedgerState blk
+           -> m [GenTx blk]
+testGenTxs numCoreNodes cfg ledger = do
+    -- Currently 0 to 1 txs
+    n <- generateBetween 0 1
+    replicateM (fromIntegral n) $ testGenTx numCoreNodes cfg ledger
+
+{-------------------------------------------------------------------------------
+  TxGen SimpleBlock
+-------------------------------------------------------------------------------}
+
+instance TxGen (SimpleBlock SimpleMockCrypto ext) where
+  testGenTx (NumCoreNodes n) _ ledgerState =
+      mkSimpleGenTx <$> genSimpleTx addrs utxo
+    where
+      addrs :: [Addr]
+      addrs = Map.keys $ mkAddrDist n
+
+      utxo :: Utxo
+      utxo = mockUtxo $ simpleLedgerState ledgerState
+
+genSimpleTx :: forall m. MonadRandom m => [Addr] -> Utxo -> m Tx
+genSimpleTx addrs u = do
+    let senders = Set.toList . Set.fromList . map fst . Map.elems $ u -- people with funds
+    sender    <- genElt senders
+    recipient <- genElt $ filter (/= sender) addrs
+    let assets  = filter (\(_, (a, _)) -> a == sender) $ Map.toList u
+        fortune = sum [c | (_, (_, c)) <- assets]
+        ins     = Set.fromList $ map fst assets
+    amount <- fromIntegral <$> generateBetween 1 (fromIntegral fortune)
+    let outRecipient = (recipient, amount)
+        outs         = if amount == fortune
+            then [outRecipient]
+            else [outRecipient, (sender, fortune - amount)]
+    return $ Tx ins outs
+  where
+    genElt :: HasCallStack => [a] -> m a
+    genElt xs = do
+        m <- generateElement xs
+        case m of
+            Nothing -> error "expected non-empty list"
+            Just x  -> return x


### PR DESCRIPTION
This is laying the ground work for testing with real Byron blocks.

Since we no longer know we're dealing with `SimpleBlock`s, we can't generate
transactions directly. We solve this by introducing the `TxGen` type class to
generate transactions. An instance for `SimpleBlock` is provided.

Remove the `loggingChannel` and all its `Show`/`Condense` constraints, we can
use `Tracer`s for that.