### PR TITLE
Remove obsolete readIncrementalOffsetsEBB and cborEpochFileParser

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -15,7 +14,6 @@ module Ouroboros.Consensus.Util.CBOR (
   , ReadIncrementalErr(..)
   , readIncremental
   , readIncrementalOffsets
-  , readIncrementalOffsetsEBB
   ) where
 
 import qualified Codec.CBOR.Decoding as CBOR (Decoder)
@@ -26,7 +24,6 @@ import           Control.Monad.ST
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           Data.ByteString.Builder.Extra (defaultChunkSize)
-import qualified Data.ByteString.Lazy as BSL
 import           Data.IORef
 import           Data.Word (Word64)
 
@@ -148,8 +145,6 @@ readIncremental hasFS@HasFS{..} decoder fp = withLiftST $ \liftST -> do
 -- Return the offset ('Word64') of the start of each @a@ and the size ('Word64')
 -- of each @a@. When deserialising fails, return all already deserialised @a@s
 -- and the error.
---
--- TODO parameterise over 'defaultChunkSize'
 readIncrementalOffsets :: forall m h a. (MonadST m, MonadThrow m)
                        => HasFS m h
                        -> (forall s . CBOR.Decoder s a)
@@ -204,92 +199,3 @@ readIncrementalOffsets hasFS@HasFS{..} decoder fp = withLiftST $ \liftST ->
     checkEmpty bs | BS.null bs = Nothing
                   | otherwise  = Just bs
 
--- | Read multiple @a@s incrementally from a file.
---
--- Return the offset ('Word64') of the start of each @a@ and the size ('Word64')
--- of each @a@. When deserialising fails, return all already deserialised @a@s
--- and the error.
---
--- TODO remove this function once we have removed
--- 'Ouroboros.Storage.ImmutableDB.Util.cborEpochFileParser'', the ChainDB will
--- extract the EBB hash for us.
-readIncrementalOffsetsEBB :: forall m hash h a. (MonadST m, MonadThrow m)
-                          => Word64 -- ^ Chunk size when reading bytes
-                          -> HasFS m h
-                          -> (forall s . CBOR.Decoder s a)
-                          -> (BSL.ByteString -> a -> Maybe hash)
-                              -- ^ In case the given @a@ is an EBB, return its
-                              -- @hash@. You also get the bytes from which it
-                              -- was decoded.
-                          -> FsPath
-                          -> m ([(Word64, (Word64, a))],
-                                Maybe hash,
-                                Maybe ReadIncrementalErr)
-                             -- ^ ((the offset of the start of @a@ in the file,
-                             --     (the size of @a@ in bytes,
-                             --      @a@ itself)),
-                             --     the hash of the EBB, if present
-                             --     error encountered during deserialisation)
-readIncrementalOffsetsEBB chunkSize hasFS decoder getEBBHash fp = withLiftST $ \liftST ->
-    withFile hasFS fp ReadMode $ \h -> do
-      fileSize <- hGetSize h
-      if fileSize == 0
-        -- If the file is empty, we will immediately get "end of input"
-        then return ([], Nothing, Nothing)
-        else liftST (CBOR.deserialiseIncremental decoder) >>=
-             go liftST h 0 [] Nothing Nothing [] fileSize
-  where
-    HasFS{..} = hasFS
-
-    -- The incremental decoder is run in such a way that the bytes fed to it
-    -- are retained and then used (in case of `Done`) to convert the
-    -- `ByteSpan` annotation into a `ByteString` annotation.
-    go :: (forall x. ST s x -> m x)
-       -> h
-       -> Word64                  -- ^ Offset
-       -> [(Word64, (Word64, a))] -- ^ Already deserialised (reverse order)
-       -> Maybe hash              -- ^ The hash of the EBB block
-       -> Maybe ByteString        -- ^ Unconsumed bytes from last time
-       -> [ByteString]            -- ^ Bytes fed to the decoder so far, reverse.
-       -> Word64                  -- ^ Total file size
-       -> CBOR.IDecode s a
-       -> m ([(Word64, (Word64, a))], Maybe hash, Maybe ReadIncrementalErr)
-    go liftST h !offset !deserialised !mbEBBHash !mbUnconsumed !consumed fileSize dec = case dec of
-      CBOR.Partial k -> case mbUnconsumed of
-        Just bs -> do
-          dec' <- liftST $ k (Just bs)
-          go liftST h offset deserialised mbEBBHash Nothing (bs : consumed) fileSize dec'
-        Nothing -> do
-          bs <- hGetSome h chunkSize
-          -- Use `checkEmpty` to give `Nothing`, an indication of end of stream.
-          -- NB: we don't do that for the other case `Just bs`, because lack of
-          -- unconsumed does _not_ imply end of stream.
-          dec' <- liftST $ k (checkEmpty bs)
-          go liftST h offset deserialised mbEBBHash Nothing (bs : consumed) fileSize dec'
-
-      CBOR.Done leftover size a -> do
-        let nextOffset    = offset + fromIntegral size
-            deserialised' = (offset, (fromIntegral size, a)) : deserialised
-            consumedBytes = BSL.take size (BSL.fromChunks (reverse consumed))
-            -- The EBB can only occur at the start of the file
-            mbEBBHash'    | offset == 0 = getEBBHash consumedBytes a
-                          | otherwise   = mbEBBHash
-        case checkEmpty leftover of
-          Nothing
-            | nextOffset == fileSize
-              -- We're at the end of the file, so stop
-            -> return (reverse deserialised', mbEBBHash', Nothing)
-          -- Otherwise, there are some left-over bytes or we know there are
-          -- still some more bytes in the file to read, so try to read the
-          -- next @a@.
-          mbLeftover -> do
-            dec' <- liftST $ CBOR.deserialiseIncremental decoder
-            go liftST h nextOffset deserialised' mbEBBHash' mbLeftover []
-               fileSize dec'
-
-      CBOR.Fail _ _ err -> return
-        (reverse deserialised, mbEBBHash, Just (ReadFailed err))
-
-    checkEmpty :: ByteString -> Maybe ByteString
-    checkEmpty bs | BS.null bs = Nothing
-                  | otherwise  = Just bs


### PR DESCRIPTION
The ChainDB now takes care of handling EBBs, see `Ouroboros.Storage.ChainDB.Impl.ImmDB.epochFileParser`.