### PR TITLE
Add de/encode for ApplyTxErr to RunNode

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -58,25 +58,25 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 4fab23bda24a119f4a4bc08f907caedde1d19b4f
+  tag: ecbd65ed4790f1a15965128b4a88a7656d194fbf
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 4fab23bda24a119f4a4bc08f907caedde1d19b4f
+  tag: ecbd65ed4790f1a15965128b4a88a7656d194fbf
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 4fab23bda24a119f4a4bc08f907caedde1d19b4f
+  tag: ecbd65ed4790f1a15965128b4a88a7656d194fbf
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 4fab23bda24a119f4a4bc08f907caedde1d19b4f
+  tag: ecbd65ed4790f1a15965128b4a88a7656d194fbf
   subdir: crypto/test
 
 source-repository-package

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -34,8 +34,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "4fab23bda24a119f4a4bc08f907caedde1d19b4f";
-      sha256 = "16p16h1l5qfwn1yc382pvr61xbm1fhias5r6g2lyn0wqsr9h2d0f";
+      rev = "ecbd65ed4790f1a15965128b4a88a7656d194fbf";
+      sha256 = "10grpvvkm3ldpbjwqi8nb1lcvciwp8akd6c6i10izppbmjr42338";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "4fab23bda24a119f4a4bc08f907caedde1d19b4f";
-      sha256 = "16p16h1l5qfwn1yc382pvr61xbm1fhias5r6g2lyn0wqsr9h2d0f";
+      rev = "ecbd65ed4790f1a15965128b4a88a7656d194fbf";
+      sha256 = "10grpvvkm3ldpbjwqi8nb1lcvciwp8akd6c6i10izppbmjr42338";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "4fab23bda24a119f4a4bc08f907caedde1d19b4f";
-      sha256 = "16p16h1l5qfwn1yc382pvr61xbm1fhias5r6g2lyn0wqsr9h2d0f";
+      rev = "ecbd65ed4790f1a15965128b4a88a7656d194fbf";
+      sha256 = "10grpvvkm3ldpbjwqi8nb1lcvciwp8akd6c6i10izppbmjr42338";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -116,8 +116,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "4fab23bda24a119f4a4bc08f907caedde1d19b4f";
-      sha256 = "16p16h1l5qfwn1yc382pvr61xbm1fhias5r6g2lyn0wqsr9h2d0f";
+      rev = "ecbd65ed4790f1a15965128b4a88a7656d194fbf";
+      sha256 = "10grpvvkm3ldpbjwqi8nb1lcvciwp8akd6c6i10izppbmjr42338";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/State.hs
@@ -46,8 +46,10 @@ deriving instance Serialise (HeaderHash blk) => Serialise (MockState blk)
 data MockError blk =
     MockInvalidInputs InvalidInputs
   | MockInvalidHash (ChainHash blk) (ChainHash blk)
+  deriving (Generic)
 
 deriving instance StandardHash blk => Show (MockError blk)
+deriving instance Serialise (HeaderHash blk) => Serialise (MockError blk)
 
 updateMockState :: ( Monad m
                   , GetHeader blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/UTxO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/UTxO.hs
@@ -65,7 +65,9 @@ type Utxo  = Map TxIn TxOut
 -------------------------------------------------------------------------------}
 
 newtype InvalidInputs = InvalidInputs (Set TxIn)
-  deriving newtype (Show, Condense)
+  deriving stock    (Generic)
+  deriving newtype  (Show, Condense)
+  deriving anyclass (Serialise)
 
 class HasUtxo a where
   txIns      :: a -> Set TxIn

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
@@ -51,7 +51,7 @@ class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
   nodeEncodeHeaderHash   :: Proxy blk -> HeaderHash blk -> Encoding
   nodeEncodeLedgerState  :: NodeConfig (BlockProtocol blk) -> LedgerState blk -> Encoding
   nodeEncodeChainState   :: Proxy blk -> ChainState (BlockProtocol blk) -> Encoding
-
+  nodeEncodeApplyTxError :: Proxy blk -> ApplyTxErr blk -> Encoding
 
   -- Decoders
   nodeDecodeHeader       :: forall s. NodeConfig (BlockProtocol blk) -> Decoder s (Header blk)
@@ -61,3 +61,4 @@ class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
   nodeDecodeHeaderHash   :: forall s. Proxy blk -> Decoder s (HeaderHash blk)
   nodeDecodeLedgerState  :: forall s. NodeConfig (BlockProtocol blk) -> Decoder s (LedgerState blk)
   nodeDecodeChainState   :: forall s. Proxy blk -> Decoder s (ChainState (BlockProtocol blk))
+  nodeDecodeApplyTxError :: forall s. Proxy blk -> Decoder s (ApplyTxErr blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -33,6 +33,7 @@ instance ByronGiven => RunNode (ByronBlockOrEBB ByronConfig) where
   nodeEncodeHeaderHash   = const encodeByronHeaderHash
   nodeEncodeLedgerState  = const encodeByronLedgerState
   nodeEncodeChainState   = const encodeByronChainState
+  nodeEncodeApplyTxError = const encodeByronApplyTxError
 
   nodeDecodeBlock        = const (decodeByronBlock given)
   nodeDecodeHeader       = const (decodeByronHeader given)
@@ -41,3 +42,4 @@ instance ByronGiven => RunNode (ByronBlockOrEBB ByronConfig) where
   nodeDecodeHeaderHash   = const decodeByronHeaderHash
   nodeDecodeLedgerState  = const decodeByronLedgerState
   nodeDecodeChainState   = const decodeByronChainState
+  nodeDecodeApplyTxError = const decodeByronApplyTxError

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
@@ -45,6 +45,7 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
   nodeEncodeHeaderHash   = const encode
   nodeEncodeLedgerState  = const encode
   nodeEncodeChainState   = const encode
+  nodeEncodeApplyTxError = const encode
 
   nodeDecodeBlock        = const decode
   nodeDecodeHeader       = const decode
@@ -53,3 +54,4 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
   nodeDecodeHeaderHash   = const decode
   nodeDecodeLedgerState  = const decode
   nodeDecodeChainState   = const decode
+  nodeDecodeApplyTxError = const decode

--- a/stack.yaml
+++ b/stack.yaml
@@ -26,7 +26,7 @@ extra-deps:
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 4fab23bda24a119f4a4bc08f907caedde1d19b4f
+    commit: ecbd65ed4790f1a15965128b4a88a7656d194fbf
     subdirs:
       - cardano-ledger
       - cardano-ledger/test


### PR DESCRIPTION
In #864 (8d8d45ae7c98a1e9ebe2067da3a7f3500d8f2e94) I changed the
`LocalTxSubmission` protocol failure from `String` to `ApplyTxErr blk`, but
without providing a de/encoder for `ApplyTxErr blk`, which breaks
`cardano-node` and `cardano-byron-proxy`. This commit rectifies this by adding
a de/encoder to `RunDemo`.