### PR TITLE
Byron mainnet converter and validator

### DIFF
--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -34,8 +34,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "4fab23bda24a119f4a4bc08f907caedde1d19b4f";
-      sha256 = "16p16h1l5qfwn1yc382pvr61xbm1fhias5r6g2lyn0wqsr9h2d0f";
+      rev = "ecbd65ed4790f1a15965128b4a88a7656d194fbf";
+      sha256 = "10grpvvkm3ldpbjwqi8nb1lcvciwp8akd6c6i10izppbmjr42338";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "4fab23bda24a119f4a4bc08f907caedde1d19b4f";
-      sha256 = "16p16h1l5qfwn1yc382pvr61xbm1fhias5r6g2lyn0wqsr9h2d0f";
+      rev = "ecbd65ed4790f1a15965128b4a88a7656d194fbf";
+      sha256 = "10grpvvkm3ldpbjwqi8nb1lcvciwp8akd6c6i10izppbmjr42338";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "4fab23bda24a119f4a4bc08f907caedde1d19b4f";
-      sha256 = "16p16h1l5qfwn1yc382pvr61xbm1fhias5r6g2lyn0wqsr9h2d0f";
+      rev = "ecbd65ed4790f1a15965128b4a88a7656d194fbf";
+      sha256 = "10grpvvkm3ldpbjwqi8nb1lcvciwp8akd6c6i10izppbmjr42338";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -116,8 +116,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "4fab23bda24a119f4a4bc08f907caedde1d19b4f";
-      sha256 = "16p16h1l5qfwn1yc382pvr61xbm1fhias5r6g2lyn0wqsr9h2d0f";
+      rev = "ecbd65ed4790f1a15965128b4a88a7656d194fbf";
+      sha256 = "10grpvvkm3ldpbjwqi8nb1lcvciwp8akd6c6i10izppbmjr42338";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -65,6 +65,7 @@
             (hsPkgs.cardano-ledger)
             (hsPkgs.containers)
             (hsPkgs.contra-tracer)
+            (hsPkgs.directory)
             (hsPkgs.mtl)
             (hsPkgs.optparse-applicative)
             (hsPkgs.optparse-generic)

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -55,6 +55,30 @@
           then [ (hsPkgs.Win32) ]
           else [ (hsPkgs.unix) ]);
         };
+      exes = {
+        "byron-db-converter" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.bytestring)
+            (hsPkgs.cardano-binary)
+            (hsPkgs.cardano-crypto-wrapper)
+            (hsPkgs.cardano-ledger)
+            (hsPkgs.containers)
+            (hsPkgs.contra-tracer)
+            (hsPkgs.mtl)
+            (hsPkgs.optparse-applicative)
+            (hsPkgs.optparse-generic)
+            (hsPkgs.ouroboros-consensus)
+            (hsPkgs.path)
+            (hsPkgs.path-io)
+            (hsPkgs.reflection)
+            (hsPkgs.resourcet)
+            (hsPkgs.streaming)
+            (hsPkgs.text)
+            (hsPkgs.time)
+            ];
+          };
+        };
       tests = {
         "test-consensus" = {
           depends = [

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -369,7 +369,6 @@ executable byron-db-converter
                      , cardano-binary
                      , cardano-crypto-wrapper
                      , cardano-ledger
-                     , cborg >= 0.2.2.0
                      , containers
                      , contra-tracer
                      , mtl

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -371,6 +371,7 @@ executable byron-db-converter
                      , cardano-ledger
                      , containers
                      , contra-tracer
+                     , directory
                      , mtl
                      , optparse-applicative
                      , optparse-generic

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -361,3 +361,26 @@ test-suite test-storage
 
   ghc-options:      -Wall
                     -fno-ignore-asserts
+
+executable byron-db-converter
+   hs-source-dirs:     tools/db-convert
+   build-depends:      base
+                     , bytestring
+                     , cardano-binary
+                     , cardano-crypto-wrapper
+                     , cardano-ledger
+                     , containers
+                     , contra-tracer
+                     , mtl
+                     , optparse-applicative
+                     , optparse-generic
+                     , ouroboros-consensus
+                     , path
+                     , path-io
+                     , reflection
+                     , resourcet
+                     , streaming
+                     , text
+                     , time
+   default-language:   Haskell2010
+   main-is:            Main.hs

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -369,6 +369,7 @@ executable byron-db-converter
                      , cardano-binary
                      , cardano-crypto-wrapper
                      , cardano-ledger
+                     , cborg >= 0.2.2.0
                      , containers
                      , contra-tracer
                      , mtl

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -384,3 +384,4 @@ executable byron-db-converter
                      , time
    default-language:   Haskell2010
    main-is:            Main.hs
+   ghc-options:        -Wall

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -34,7 +34,7 @@ import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling,
 
 import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
 import qualified Ouroboros.Storage.ChainDB.Impl.LgrDB as LgrDB
-import           Ouroboros.Storage.ChainDB.Impl.Types (TraceEvent(..))
+import           Ouroboros.Storage.ChainDB.Impl.Types (TraceEvent (..))
 import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
 
 {-------------------------------------------------------------------------------
@@ -140,7 +140,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , immValidation       = cdbValidation
         , immIsEBB            = cdbIsEBB
         , immHasFS            = cdbHasFSImmDb
-        , immDbTracer         = contramap TraceImmDBEvent cdbTracer
+        , immTracer           = contramap TraceImmDBEvent cdbTracer
         }
     , VolDB.VolDbArgs {
           volHasFS            = cdbHasFSVolDb

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -17,7 +17,7 @@ import           Data.Time.Clock (DiffTime, secondsToDiffTime)
 
 import           Control.Monad.Class.MonadSTM
 
-import           Control.Tracer (Tracer)
+import           Control.Tracer (Tracer, contramap)
 
 import           Ouroboros.Network.Block (HeaderHash, StandardHash)
 
@@ -34,7 +34,7 @@ import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling,
 
 import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
 import qualified Ouroboros.Storage.ChainDB.Impl.LgrDB as LgrDB
-import           Ouroboros.Storage.ChainDB.Impl.Types (TraceEvent)
+import           Ouroboros.Storage.ChainDB.Impl.Types (TraceEvent(..))
 import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
 
 {-------------------------------------------------------------------------------
@@ -140,6 +140,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , immValidation       = cdbValidation
         , immIsEBB            = cdbIsEBB
         , immHasFS            = cdbHasFSImmDb
+        , immDbTracer         = contramap TraceImmDBEvent cdbTracer
         }
     , VolDB.VolDbArgs {
           volHasFS            = cdbHasFSVolDb

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -113,7 +113,7 @@ data ImmDbArgs m blk = forall h. ImmDbArgs {
     , immValidation  :: ImmDB.ValidationPolicy
     , immIsEBB       :: blk -> Maybe (HeaderHash blk)
     , immHasFS       :: HasFS m h
-    , immDbTracer    :: Tracer m ImmDB.TraceEvent
+    , immTracer      :: Tracer m ImmDB.TraceEvent
     }
 
 -- | Default arguments when using the 'IO' monad
@@ -139,7 +139,7 @@ defaultArgs fp = ImmDbArgs{
     , immEpochSize   = error "no default for immEpochSize"
     , immValidation  = error "no default for immValidation"
     , immIsEBB       = error "no default for immIsEBB"
-    , immDbTracer    = nullTracer
+    , immTracer      = nullTracer
     }
 
 openDB :: (MonadSTM m, MonadST m, MonadCatch m, HasHeader blk)
@@ -155,7 +155,7 @@ openDB args@ImmDbArgs{..} = do
                immEpochInfo
                immValidation
                (epochFileParser args)
-               immDbTracer
+               immTracer
     return ImmDB
       { immDB        = immDB
       , decBlock     = immDecodeBlock

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -10,7 +10,6 @@
 -- | Thin wrapper around the ImmutableDB
 module Ouroboros.Storage.ChainDB.Impl.ImmDB (
     ImmDB -- Opaque
-  , ImmDB.TraceEvent
     -- * Initialization
   , ImmDbArgs(..)
   , defaultArgs
@@ -36,6 +35,9 @@ module Ouroboros.Storage.ChainDB.Impl.ImmDB (
   , iteratorHasNext
   , iteratorPeek
   , iteratorClose
+    -- * Tracing
+  , ImmDB.TraceEvent
+  , EpochFileError
     -- * Re-exports
   , Iterator
   , IteratorResult(..)
@@ -113,7 +115,7 @@ data ImmDbArgs m blk = forall h. ImmDbArgs {
     , immValidation  :: ImmDB.ValidationPolicy
     , immIsEBB       :: blk -> Maybe (HeaderHash blk)
     , immHasFS       :: HasFS m h
-    , immTracer      :: Tracer m ImmDB.TraceEvent
+    , immTracer      :: Tracer m (ImmDB.TraceEvent EpochFileError)
     }
 
 -- | Default arguments when using the 'IO' monad
@@ -491,7 +493,7 @@ parseIteratorResult db result =
 data EpochFileError =
     EpochErrRead Util.CBOR.ReadIncrementalErr
   | EpochErrUnexpectedEBB
-  deriving Show
+  deriving (Eq, Show)
 
 epochFileParser :: forall m blk. (MonadST m, MonadThrow m, HasHeader blk)
                 => ImmDbArgs m blk

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -294,6 +294,7 @@ data TraceEvent blk
   | TraceOpenEvent         (TraceOpenEvent         blk)
   | TraceIteratorEvent     (TraceIteratorEvent     blk)
   | TraceLedgerEvent       (TraceLedgerEvent       blk)
+  | TraceImmDBEvent        ImmDB.TraceEvent
   deriving (Generic)
 
 deriving instance

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -294,7 +294,7 @@ data TraceEvent blk
   | TraceOpenEvent         (TraceOpenEvent         blk)
   | TraceIteratorEvent     (TraceIteratorEvent     blk)
   | TraceLedgerEvent       (TraceLedgerEvent       blk)
-  | TraceImmDBEvent        ImmDB.TraceEvent
+  | TraceImmDBEvent        (ImmDB.TraceEvent ImmDB.EpochFileError)
   deriving (Generic)
 
 deriving instance

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -1536,7 +1536,6 @@ validate :: forall m hash h e.
 validate hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFileParser tracer = do
     filesInDBFolder <- listDirectory []
     let epochFiles = fst $ dbFilesOnDisk filesInDBFolder
-    traceWith tracer $ ValidatingEpochFiles epochFiles
     case Set.lookupMax epochFiles of
       Nothing              -> do
         -- Remove left-over index files

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -136,6 +136,7 @@
 -- unfilled.
 module Ouroboros.Storage.ImmutableDB.Impl
   ( openDB
+  , reconstructIndex
   ) where
 
 import           Prelude hiding (truncate)
@@ -149,6 +150,7 @@ import           Control.Monad.Class.MonadThrow (ExitCase (..),
                      MonadCatch (generalBracket), MonadThrow, finally)
 import           Control.Monad.State.Strict (StateT (..), get, lift, modify,
                      put, runStateT, state)
+import           Control.Tracer (Tracer, traceWith)
 
 import           Data.ByteString.Builder (Builder)
 import           Data.ByteString.Lazy (ByteString, toStrict)
@@ -184,13 +186,14 @@ import           Ouroboros.Storage.ImmutableDB.Util
 
 
 -- | The environment used by the immutable database.
-data ImmutableDBEnv m hash = forall h e. ImmutableDBEnv
+data ImmutableDBEnv m hash = forall h e. Show e => ImmutableDBEnv
     { _dbHasFS           :: !(HasFS m h)
     , _dbErr             :: !(ErrorHandling ImmutableDBError m)
     , _dbInternalState   :: !(TMVar m (Either (ClosedState m) (OpenState m hash h)))
     , _dbEpochFileParser :: !(EpochFileParser e hash m (Word64, SlotNo))
     , _dbHashDecoder     :: !(forall s . Decoder s hash)
     , _dbHashEncoder     :: !(hash -> Encoding)
+    , _dbTracer          :: !(Tracer m TraceEvent)
     }
 
 -- | Internal state when the database is open.
@@ -213,7 +216,6 @@ data OpenState m hash h = OpenState
     -- ^ The ID of the next iterator that will be created.
     }
 
-
 -- | Internal state when the database is closed. This contains data that
 -- should be restored when the database is reopened. Data not present here
 -- will be recovered when reopening.
@@ -223,20 +225,6 @@ data ClosedState m = ClosedState
     , _closedNextIteratorID :: !BaseIteratorID
     -- ^ See '_nextIteratorID'.
     }
-
-
--- | Variant of 'Tip' that uses 'EpochSlot' instead of 'EpochNo' or 'SlotNo'.
-data TipEpochSlot
-  = TipEpochSlotGenesis
-  | TipEpochSlot EpochSlot
-  deriving (Eq)
-
-instance Ord TipEpochSlot where
-  compare te1 te2 = case (te1, te2) of
-    (TipEpochSlotGenesis, TipEpochSlotGenesis) -> EQ
-    (TipEpochSlotGenesis, _)                   -> LT
-    (_,                   TipEpochSlotGenesis) -> GT
-    (TipEpochSlot es1,    TipEpochSlot es2)    -> compare es1 es2
 
 
 {------------------------------------------------------------------------------
@@ -268,7 +256,7 @@ instance Ord TipEpochSlot where
 --
 -- __Note__: To be used in conjunction with 'withDB'.
 openDB
-  :: (HasCallStack, MonadSTM m, MonadCatch m, Eq hash)
+  :: (HasCallStack, MonadSTM m, MonadCatch m, Eq hash, Show e)
   => (forall s . Decoder s hash)
   -> (hash -> Encoding)
   -> HasFS m h
@@ -276,6 +264,7 @@ openDB
   -> EpochInfo m
   -> ValidationPolicy
   -> EpochFileParser e hash m (Word64, SlotNo)
+  -> Tracer m TraceEvent
   -> m (ImmutableDB hash m)
 openDB = openDBImpl
 
@@ -301,7 +290,7 @@ mkDBRecord dbEnv = ImmutableDB
     }
 
 openDBImpl :: forall m h hash e.
-              (HasCallStack, MonadSTM m, MonadCatch m, Eq hash)
+              (HasCallStack, MonadSTM m, MonadCatch m, Eq hash, Show e)
            => (forall s . Decoder s hash)
            -> (hash -> Encoding)
            -> HasFS m h
@@ -309,14 +298,15 @@ openDBImpl :: forall m h hash e.
            -> EpochInfo m
            -> ValidationPolicy
            -> EpochFileParser e hash m (Word64, SlotNo)
+           -> Tracer m TraceEvent
            -> m (ImmutableDB hash m)
-openDBImpl hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFileParser = do
+openDBImpl hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFileParser tracer = do
     !ost  <- validateAndReopen hashDecoder hashEncoder hasFS err epochInfo
-      valPol epochFileParser initialIteratorID
+      valPol epochFileParser initialIteratorID tracer
 
     stVar <- atomically $ newTMVar (Right ost)
 
-    let dbEnv = ImmutableDBEnv hasFS err stVar epochFileParser hashDecoder hashEncoder
+    let dbEnv = ImmutableDBEnv hasFS err stVar epochFileParser hashDecoder hashEncoder tracer
         db    = mkDBRecord dbEnv
     return db
 
@@ -328,13 +318,16 @@ closeDBImpl ImmutableDBEnv {..} = do
     internalState <- atomically $ takeTMVar _dbInternalState
     case internalState of
       -- Already closed
-      Left  _ -> atomically $ putTMVar _dbInternalState internalState
+      Left  _ -> do
+        traceWith _dbTracer $ DBAlreadyClosed
+        atomically $ putTMVar _dbInternalState internalState
       Right OpenState {..} -> do
         let !closedState = closedStateFromInternalState internalState
         -- Close the database before doing the file-system operations so that
         -- in case these fail, we don't leave the database open.
         atomically $ putTMVar _dbInternalState (Left closedState)
         hClose _currentEpochWriteHandle
+        traceWith _dbTracer DBClosed
   where
     HasFS{..} = _dbHasFS
 
@@ -364,7 +357,7 @@ reopenImpl ImmutableDBEnv {..} valPol = do
 
             !ost  <- validateAndReopen _dbHashDecoder _dbHashEncoder _dbHasFS
               _dbErr _closedEpochInfo valPol _dbEpochFileParser
-              _closedNextIteratorID
+              _closedNextIteratorID _dbTracer
 
             atomically $ putTMVar _dbInternalState (Right ost)
   where
@@ -380,6 +373,8 @@ deleteAfterImpl dbEnv tip = modifyOpenState dbEnv $ \hasFS@HasFS{..} -> do
     st@OpenState {..} <- get
     currentEpochSlot <- lift $ tipToEpochSlot _epochInfo _currentTip
     newEpochSlot     <- lift $ tipToEpochSlot _epochInfo tip
+
+    lift . traceWith (_dbTracer dbEnv) $ DeletingAfter currentEpochSlot newEpochSlot
 
     case (currentEpochSlot, newEpochSlot) of
       -- If we're already at genesis we don't have to do anything
@@ -1203,7 +1198,7 @@ onException fsErr err onErr m =
 -- | Perform validation as per the 'ValidationPolicy' using 'validate' and
 -- create an 'OpenState' corresponding to its outcome.
 validateAndReopen :: forall m hash h e.
-                     (HasCallStack, MonadThrow m, Eq hash)
+                     (HasCallStack, MonadThrow m, Eq hash, Show e)
                   => (forall s . Decoder s hash)
                   -> (hash -> Encoding)
                   -> HasFS m h
@@ -1212,15 +1207,27 @@ validateAndReopen :: forall m hash h e.
                   -> ValidationPolicy
                   -> EpochFileParser e hash m (Word64, SlotNo)
                   -> BaseIteratorID
+                  -> Tracer m TraceEvent
                   -> m (OpenState m hash h)
-validateAndReopen hashDecoder hashEncoder hasFS err epochInfo valPol epochFileParser nextIteratorID = do
+validateAndReopen
+  hashDecoder
+  hashEncoder
+  hasFS
+  err
+  epochInfo
+  valPol
+  epochFileParser
+  nextIteratorID
+  tracer = do
     mbLastValidLocationAndIndex <-
-      validate hashDecoder hashEncoder hasFS err epochInfo valPol epochFileParser
+      validate hashDecoder hashEncoder hasFS err epochInfo valPol epochFileParser tracer
 
     case mbLastValidLocationAndIndex of
-      Nothing ->
+      Nothing -> do
+        traceWith tracer $ NoValidLastLocation
         mkOpenStateNewEpoch hasFS 0 epochInfo nextIteratorID TipGen
       Just (lastValidLocation, index) -> do
+        traceWith tracer $ ValidatedLastLocation
         tip <- epochSlotToTip epochInfo lastValidLocation
         let epoch = _epoch lastValidLocation
         mkOpenState hasFS epoch epochInfo nextIteratorID tip index
@@ -1513,7 +1520,7 @@ data ValidateResult hash
 --   but the last slot of each epoch is filled, we can reconstruct all index
 --   files from the epochs without needing any truncation.
 validate :: forall m hash h e.
-            (HasCallStack, MonadThrow m, Eq hash)
+            (HasCallStack, MonadThrow m, Eq hash, Show e)
          => (forall s . Decoder s hash)
          -> (hash -> Encoding)
          -> HasFS m h
@@ -1521,13 +1528,15 @@ validate :: forall m hash h e.
          -> EpochInfo m
          -> ValidationPolicy
          -> EpochFileParser e hash m (Word64, SlotNo)
+         -> Tracer m TraceEvent
          -> m (Maybe (EpochSlot, Index hash))
             -- ^ The 'EpochSlot' pointing at the last valid block or EBB on
             -- disk and the 'Index' of the corresponding epoch. 'Nothing' if
             -- the database is empty.
-validate hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFileParser = do
+validate hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFileParser tracer = do
     filesInDBFolder <- listDirectory []
     let epochFiles = fst $ dbFilesOnDisk filesInDBFolder
+    traceWith tracer $ ValidatingEpochFiles epochFiles
     case Set.lookupMax epochFiles of
       Nothing              -> do
         -- Remove left-over index files
@@ -1537,7 +1546,7 @@ validate hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFileP
 
       Just lastEpochOnDisk -> case valPol of
         ValidateMostRecentEpoch -> validateMostRecentEpoch lastEpochOnDisk
-        ValidateAllEpochs       -> validateAllEpochs       lastEpochOnDisk
+        ValidateAllEpochs       -> validateAllEpochs lastEpochOnDisk
   where
     -- | Validate the most recent (given) epoch using 'validateEpoch'.
     --
@@ -1612,17 +1621,20 @@ validate hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFileP
       where
         go lastValid epoch = do
           validateRes <- validateEpoch epoch
+
           let continueIfPossible lastValid'
                 | epoch == 0 = return lastValid'
                 | otherwise  = go lastValid' (epoch - 1)
           case validateRes of
             Missing -> do
+              traceWith tracer $ ValidatingEpochMissing epoch
               -- Remove all valid files that may come after it. Note that
               -- 'Invalid' guarantees that there is no epoch or index file for
               -- this epoch.
               removeFilesStartingFrom hasFS (succ epoch)
               continueIfPossible Nothing
             Incomplete index -> do
+              traceWith tracer $ ValidatingEpochIndexIncomplete epoch
               case firstFilledSlot index of
                 -- If the index is empty, remove the index and epoch file too
                 Nothing -> removeFilesStartingFrom hasFS epoch
@@ -1711,7 +1723,8 @@ validate hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFileP
           -- If there was an error parsing the epoch file, truncate it
           case mbErr of
             -- If there was an error parsing the epoch file, truncate it
-            Just _ ->
+            Just _err -> do
+              traceWith tracer $ ValidatingEpochErrorParsing (show _err)
               withFile hasFS epochFile (AppendMode AllowExisting) $ \eHnd ->
                 hTruncate eHnd (lastSlotOffset reconstructedIndex)
             -- If not, check that the last offset matches the epoch file size.
@@ -1791,7 +1804,9 @@ validate hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFileP
 
             -- No index file, either because it is missing or because the
             -- epoch was not finalised
-            | otherwise -> return $ Incomplete reconstructedIndex
+            | otherwise -> do
+              traceWith tracer ReconstructIndexLastSlotMissing
+              return $ Incomplete reconstructedIndex
 
 
 -- | Reconstruct an 'Index' from the given epoch file using the

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -1226,9 +1226,9 @@ validateAndReopen
         traceWith tracer $ NoValidLastLocation
         mkOpenStateNewEpoch hasFS 0 epochInfo nextIteratorID TipGen
       Just (lastValidLocation, index) -> do
-        traceWith tracer $ ValidatedLastLocation
         tip <- epochSlotToTip epochInfo lastValidLocation
         let epoch = _epoch lastValidLocation
+        traceWith tracer $ ValidatedLastLocation epoch tip
         mkOpenState hasFS epoch epochInfo nextIteratorID tip index
 
 -- | Create the internal open state based on an epoch with the given 'Index'.
@@ -1618,6 +1618,7 @@ validate hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFileP
     validateAllEpochs = go Nothing
       where
         go lastValid epoch = do
+          traceWith tracer $ ValidatingEpoch epoch
           validateRes <- validateEpoch epoch
 
           let continueIfPossible lastValid'

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -258,8 +258,9 @@ prettyUnexpectedError = \case
 
 data TraceEvent e
     = NoValidLastLocation
-    | ValidatedLastLocation
+    | ValidatedLastLocation EpochNo ImmTip
       -- Validation of previous DB
+    | ValidatingEpoch EpochNo
     | ValidatingEpochMissing EpochNo
     | ValidatingEpochErrorParsing e
     | ReconstructIndexLastSlotMissing

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -256,12 +256,12 @@ prettyUnexpectedError = \case
       "DeserialisationError (" <> displayException df <> "): " <>
       prettyCallStack cs
 
-data TraceEvent
+data TraceEvent e
     = NoValidLastLocation
     | ValidatedLastLocation
       -- Validation of previous DB
     | ValidatingEpochMissing EpochNo
-    | ValidatingEpochErrorParsing String
+    | ValidatingEpochErrorParsing e
     | ReconstructIndexLastSlotMissing
     | ValidatingEpochIndexIncomplete EpochNo
       -- Delete after

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -25,7 +25,6 @@ module Ouroboros.Storage.ImmutableDB.Types
 
 import           Codec.Serialise (DeserialiseFailure)
 import           Control.Exception (Exception (..))
-import qualified Data.Set as Set
 
 import           GHC.Generics (Generic)
 import           GHC.Stack (CallStack, prettyCallStack)
@@ -261,7 +260,6 @@ data TraceEvent
     = NoValidLastLocation
     | ValidatedLastLocation
       -- Validation of previous DB
-    | ValidatingEpochFiles (Set.Set EpochNo)
     | ValidatingEpochMissing EpochNo
     | ValidatingEpochErrorParsing String
     | ReconstructIndexLastSlotMissing

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -270,4 +270,4 @@ data TraceEvent e
       -- Closing the DB
     | DBAlreadyClosed
     | DBClosed
-  deriving (Eq, Show)
+  deriving (Eq, Generic, Show)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -93,6 +93,7 @@ import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import           Ouroboros.Storage.FS.Sim.STM (simHasFS)
 import           Ouroboros.Storage.ImmutableDB
                      (ValidationPolicy (ValidateAllEpochs))
+import qualified Ouroboros.Storage.ImmutableDB as ImmDB
 import           Ouroboros.Storage.LedgerDB.DiskPolicy (defaultDiskPolicy)
 import           Ouroboros.Storage.LedgerDB.MemPolicy (defaultMemPolicy)
 import qualified Ouroboros.Storage.LedgerDB.OnDisk as LedgerDB
@@ -874,6 +875,8 @@ deriving instance SOP.Generic         (TraceLedgerEvent blk)
 deriving instance SOP.HasDatatypeInfo (TraceLedgerEvent blk)
 deriving instance SOP.Generic         (LedgerDB.InitLog r)
 deriving instance SOP.HasDatatypeInfo (LedgerDB.InitLog r)
+deriving instance SOP.Generic         (ImmDB.TraceEvent e)
+deriving instance SOP.HasDatatypeInfo (ImmDB.TraceEvent e)
 
 -- TODO labelling
 
@@ -1124,6 +1127,7 @@ traceEventName = \case
     TraceLedgerEvent         ev    -> "Ledger."       <> case ev of
       InitLog                ev' -> constrName ev'
       _                          -> constrName ev
+    TraceImmDBEvent          ev    -> "ImmDB."        <> constrName ev
 
 mkArgs :: (MonadSTM m, MonadCatch m, MonadThrow (STM m))
        => NodeConfig (BlockProtocol Blk)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -10,7 +10,7 @@ module Test.Ouroboros.Storage.ImmutableDB (tests) where
 import qualified Codec.Serialise as S
 import           Control.Monad.Class.MonadSTM (MonadSTM)
 import           Control.Monad.Class.MonadThrow (MonadCatch)
-
+import           Control.Tracer (nullTracer)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           Data.Coerce (coerce)
@@ -87,7 +87,7 @@ openTestDB :: (HasCallStack, MonadSTM m, MonadCatch m)
            -> ErrorHandling ImmutableDBError m
            -> m (ImmutableDB Hash m)
 openTestDB hasFS err =
-    openDB S.decode S.encode hasFS err (fixedSizeEpochInfo fixedEpochSize) ValidateMostRecentEpoch parser
+    openDB S.decode S.encode hasFS err (fixedSizeEpochInfo fixedEpochSize) ValidateMostRecentEpoch parser nullTracer
   where
     parser = TestBlock.testBlockEpochFileParser' hasFS
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -25,6 +25,7 @@ import           Control.Monad.Class.MonadThrow (MonadCatch)
 import           Control.Monad.Except (ExceptT (..), runExceptT)
 import           Control.Monad.State.Strict (MonadState, State, evalState, gets,
                      modify, put, runState)
+import           Control.Tracer (nullTracer)
 import           Data.Functor.Identity
 
 import           Data.Bifunctor (first)
@@ -1081,9 +1082,9 @@ prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do
                   )
         test errorsVar hasFS = do
           let parser = testBlockEpochFileParser' hasFS
-          db <- QC.run $
-            openDB decode encode hasFS EH.monadCatch (fixedSizeEpochInfo fixedEpochSize) ValidateMostRecentEpoch
-              parser
+          db <- QC.run $ openDB decode encode hasFS EH.monadCatch
+                          (fixedSizeEpochInfo fixedEpochSize) ValidateMostRecentEpoch
+                          parser nullTracer
           let sm' = sm errorsVar hasFS db dbm mdb
           (hist, model, res) <- runCommands sm' cmds
           QC.run $ closeDB db >> reopen db ValidateAllEpochs

--- a/ouroboros-consensus/tools/db-convert/Main.hs
+++ b/ouroboros-consensus/tools/db-convert/Main.hs
@@ -1,0 +1,274 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-
+  Database conversion tool.
+-}
+module Main where
+
+import qualified Cardano.Binary as CB
+import qualified Cardano.Chain.Block as CC
+import qualified Cardano.Chain.Common as CC
+import qualified Cardano.Chain.Delegation.Validation.Scheduling as Scheduling
+import qualified Cardano.Chain.Epoch.File as CC
+import qualified Cardano.Chain.Genesis as CC.Genesis
+import Cardano.Chain.Slotting (EpochSlots (..))
+import qualified Cardano.Chain.Update as CC.Update
+import Cardano.Crypto
+  ( Hash
+  , RequiresNetworkMagic (..)
+  , decodeAbstractHash
+  , getAProtocolMagicId
+  )
+import Control.Exception (Exception, throwIO)
+import Control.Monad.Except (liftIO, runExceptT)
+import Control.Monad.Trans.Resource (runResourceT)
+import Control.Tracer (contramap, debugTracer, nullTracer)
+import Data.Bifunctor (first)
+import qualified Data.ByteString as BS
+import Data.Coerce (coerce)
+import Data.Foldable (for_)
+import Data.Reflection (give)
+import qualified Data.Sequence as Seq
+import qualified Data.Text as Text
+import Data.Time (UTCTime)
+import Data.Typeable (Typeable)
+import Data.Word (Word64)
+import qualified Options.Applicative as Options
+import qualified Options.Applicative.Types as Options
+import Options.Generic
+import qualified Ouroboros.Consensus.Ledger.Byron as Byron
+import Ouroboros.Consensus.Ledger.Byron (ByronBlockOrEBB)
+import Ouroboros.Consensus.Ledger.Byron.Config (ByronConfig (..))
+import Ouroboros.Consensus.Ledger.Extended
+  ( ExtLedgerState (..)
+  , ledgerState
+  , ouroborosChainState
+  )
+import Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+import Ouroboros.Consensus.Protocol.ExtNodeConfig (NodeConfig (..))
+import Ouroboros.Consensus.Protocol.PBFT (NodeConfig (..), PBftParams (..))
+import Ouroboros.Consensus.Protocol.WithEBBs (NodeConfig (..))
+import Ouroboros.Consensus.Util.Condense (condense)
+import Ouroboros.Consensus.Util.ThreadRegistry (withThreadRegistry)
+import qualified Ouroboros.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
+import Ouroboros.Storage.Common (EpochSize (..))
+import qualified Ouroboros.Storage.LedgerDB.DiskPolicy as LgrDB
+import qualified Ouroboros.Storage.LedgerDB.MemPolicy as LgrDB
+import Path
+import Path.IO
+import qualified Streaming.Prelude as S
+import qualified System.IO as IO
+
+instance ParseField (Path Abs Dir) where
+
+  readField =
+    parseAbsDir <$> Options.readerAsk >>= \case
+      Just p -> return p
+      Nothing -> Options.readerAbort Options.ShowHelpText
+
+instance ParseFields (Path Abs Dir)
+
+instance ParseRecord (Path Abs Dir) where
+
+  parseRecord = fmap getOnly parseRecord
+
+instance ParseField (Path Abs File) where
+
+  readField =
+    parseAbsFile <$> Options.readerAsk >>= \case
+      Just p -> return p
+      Nothing -> Options.readerAbort Options.ShowHelpText
+
+instance ParseFields (Path Abs File)
+
+instance ParseRecord (Path Abs File) where
+
+  parseRecord = fmap getOnly parseRecord
+
+instance ParseField UTCTime
+
+instance ParseFields UTCTime
+
+instance ParseRecord UTCTime where
+
+  parseRecord = fmap getOnly parseRecord
+
+instance ParseField (Hash CB.Raw) where
+
+  readField = Options.eitherReader (first Text.unpack . decodeAbstractHash . Text.pack)
+
+instance ParseFields (Hash CB.Raw)
+
+instance ParseRecord (Hash CB.Raw) where
+
+  parseRecord = fmap getOnly parseRecord
+
+data Args w
+  = Convert
+      { epochDir :: w ::: Path Abs Dir <?> "Path to the directory containing old epoch files"
+      , dbDir :: w ::: Path Abs Dir <?> "Path to the new database directory"
+      , epochSlots :: w ::: Word64 <?> "Slots per epoch"
+      }
+  | Validate
+      { dbDir :: w ::: Path Abs Dir <?> "Path to the new database directory"
+      , configFile :: w ::: Path Abs File <?> "Configuration file (e.g. mainnet-genesis.json)"
+      , systemStart :: w ::: Maybe UTCTime <?> "System start time"
+      , requiresNetworkMagic :: w ::: Bool <?> "Expecto patronum?"
+      , genesisHash :: w ::: Hash CB.Raw <?> "Expected genesis hash"
+      , verbose :: w ::: Bool <?> "Enable verbose logging"
+      }
+  deriving (Generic)
+
+instance ParseRecord (Args Wrapped)
+
+deriving instance Show (Args Unwrapped)
+
+data ValidationError
+  = MkConfigError CC.Genesis.ConfigurationError
+  | InitialChainStateError Scheduling.Error
+  deriving (Show, Typeable)
+
+instance Exception ValidationError
+
+main :: IO ()
+main = do
+  (cmd :: Args Unwrapped) <- unwrapRecord "Byron DB converter"
+  case cmd of
+    Convert {epochDir, dbDir, epochSlots} -> do
+      (_, files) <- listDir $ epochDir
+      let epochFiles = filter (\f -> fileExtension f == ".epoch") files
+      putStrLn $ "Writing to " ++ show dbDir
+      for_ epochFiles $ \f -> do
+        putStrLn $ "Converting file " ++ show f
+        convertEpochFile (EpochSlots epochSlots) f dbDir
+    Validate
+      { dbDir
+      , configFile
+      , requiresNetworkMagic
+      , genesisHash
+      , verbose
+      } -> do
+        econfig <-
+          runExceptT $
+            CC.Genesis.mkConfigFromFile
+              (if requiresNetworkMagic then RequiresMagic else RequiresNoMagic)
+              (toFilePath configFile)
+              genesisHash
+        case econfig of
+          Left err -> throwIO $ MkConfigError err
+          Right config -> validateChainDb dbDir config verbose
+
+convertEpochFile
+  :: EpochSlots
+  -> Path Abs File -- ^ Input
+  -> Path Abs Dir -- ^ Ouput directory
+  -> IO (Either CC.ParseError ())
+convertEpochFile es inFile outDir =
+  let inStream = CC.parseEpochFileWithBoundary es (toFilePath inFile)
+      dbDir = outDir </> [reldir|immutable|]
+      encode blk = case blk of
+        CC.ABOBBlock b -> CC.blockAnnotation b
+        CC.ABOBBoundary b -> CC.boundaryAnnotation b
+   in do
+        createDirIfMissing True dbDir
+        outFileName <-
+          parseRelFile $ "epoch-" <>
+            drop 2 (toFilePath (filename inFile))
+        outFile <- (dbDir </> outFileName) -<.> "dat"
+        IO.withFile (toFilePath outFile) IO.WriteMode $ \h ->
+          runResourceT $ runExceptT $ S.mapM_ (liftIO . BS.hPut h) . S.map encode $ inStream
+
+validateChainDb
+  :: forall blk. (blk ~ ByronBlockOrEBB ByronConfig)
+  => Path Abs Dir -- ^ DB directory
+  -> CC.Genesis.Config
+  -> Bool -- Verbose
+  -> IO ()
+validateChainDb dbDir cfg verbose =
+  do
+    initialCVS <- runExceptT $ CC.initialChainValidationState cfg
+    case initialCVS of
+      Left err -> throwIO $ InitialChainStateError err
+      Right cvs ->
+        withThreadRegistry $ \registry -> do
+          chaindb <- give protocolMagicId $ give epochSlots $ ChainDB.openDB $ args registry
+          blk <- ChainDB.getTipBlock chaindb
+          putStrLn $ "DB tip: " ++ condense blk
+          ChainDB.closeDB chaindb
+        where
+          initLedgerState = ExtLedgerState
+            { ledgerState = Byron.ByronEBBLedgerState $
+                Byron.ByronLedgerState cvs Seq.empty
+            , ouroborosChainState = Seq.empty
+            }
+          protocolMagicId = CB.unAnnotated . getAProtocolMagicId $ CC.Genesis.configProtocolMagic cfg
+          epochSlots = CC.Genesis.configEpochSlots cfg
+          securityParam = SecurityParam $ CC.unBlockCount k
+          k = CC.Genesis.configK cfg
+          args registry =
+            (ChainDB.defaultArgs @blk (toFilePath dbDir))
+              { ChainDB.cdbGenesis = return initLedgerState
+              , ChainDB.cdbDecodeBlock = Byron.decodeByronBlock protocolMagicId epochSlots
+              , ChainDB.cdbDecodeChainState = Byron.decodeByronChainState
+              , ChainDB.cdbDecodeHash = Byron.decodeByronHeaderHash
+              , ChainDB.cdbDecodeLedger = Byron.decodeByronLedgerState
+              , ChainDB.cdbEncodeBlock = Byron.encodeByronBlock protocolMagicId epochSlots
+              , ChainDB.cdbEncodeChainState = Byron.encodeByronChainState
+              , ChainDB.cdbEncodeHash = Byron.encodeByronHeaderHash
+              , ChainDB.cdbEncodeLedger = Byron.encodeByronLedgerState
+              , -- Policy
+              ChainDB.cdbValidation = ImmDB.ValidateAllEpochs
+              , ChainDB.cdbBlocksPerFile = 10
+              , ChainDB.cdbMemPolicy = LgrDB.defaultMemPolicy securityParam
+              , ChainDB.cdbDiskPolicy = LgrDB.defaultDiskPolicy securityParam 20000
+              , -- Integration
+              ChainDB.cdbNodeConfig = WithEBBNodeConfig $ EncNodeConfig
+                { encNodeConfigP = PBftNodeConfig
+                    { pbftParams = PBftParams
+                        { pbftSecurityParam = securityParam
+                        , pbftNumNodes = 7
+                        , pbftSignatureWindow = coerce k
+                        , pbftSignatureThreshold = 0.22
+                        }
+                    , pbftIsLeader = Nothing
+                    }
+                , encNodeConfigExt = ByronConfig
+                  { pbftProtocolMagic = CC.Genesis.configProtocolMagic cfg
+                  , pbftProtocolVersion = CC.Update.ProtocolVersion 1 0 0
+                  , pbftSoftwareVersion = CC.Update.SoftwareVersion
+                    (CC.Update.ApplicationName "Cardano SL")
+                    2
+                  , pbftGenesisConfig = cfg
+                  , pbftGenesisHash = CC.Genesis.configGenesisHash cfg
+                  , pbftEpochSlots = epochSlots
+                  , pbftGenesisDlg = CC.Genesis.gdHeavyDelegation . CC.Genesis.configGenesisData $ cfg
+                  , pbftSecrets = undefined
+                  }
+                }
+              , ChainDB.cdbEpochSize = const (return . EpochSize . unEpochSlots $ epochSlots)
+              , -- Misc
+              ChainDB.cdbTracer = if verbose
+              then
+                contramap
+                  ( give protocolMagicId $
+                    give epochSlots $
+                    show
+                  )
+                  debugTracer
+              else nullTracer
+              , ChainDB.cdbThreadRegistry = registry
+              , ChainDB.cdbGcDelay = 0
+              }

--- a/stack.yaml
+++ b/stack.yaml
@@ -26,7 +26,7 @@ extra-deps:
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 4fab23bda24a119f4a4bc08f907caedde1d19b4f
+    commit: ecbd65ed4790f1a15965128b4a88a7656d194fbf
     subdirs:
       - cardano-ledger
       - cardano-ledger/test


### PR DESCRIPTION
This PR adds a standalone mainnet converter and validator tool, along with adding some additional tracing to the immutable DB.

Example usage:

```
[nc@lorien:~/topos/iohk/ouroboros-network]$ ./ouroboros-consensus/.stack-work/dist/x86_64-linux-nix/Cabal-2.4.0.1/build/byron-db-converter/byron-db-converter c
onvert --epochDir /tmp/tmp.rquJ7pBVhW --dbDir $(mktemp -d) --epochSlots 21600
Writing to "/tmp/tmp.hIWEfz5t3r/"
Converting file "/tmp/tmp.rquJ7pBVhW/00000.epoch"
Converting file "/tmp/tmp.rquJ7pBVhW/00003.epoch"
Converting file "/tmp/tmp.rquJ7pBVhW/00007.epoch"
Converting file "/tmp/tmp.rquJ7pBVhW/00005.epoch"
Converting file "/tmp/tmp.rquJ7pBVhW/00009.epoch"
Converting file "/tmp/tmp.rquJ7pBVhW/00004.epoch"
Converting file "/tmp/tmp.rquJ7pBVhW/00006.epoch"
Converting file "/tmp/tmp.rquJ7pBVhW/00002.epoch"
Converting file "/tmp/tmp.rquJ7pBVhW/00001.epoch"
Converting file "/tmp/tmp.rquJ7pBVhW/00008.epoch"

[nc@lorien:~/topos/iohk/ouroboros-network]$ ./ouroboros-consensus/.stack-work/dist/x86_64-linux-nix/Cabal-2.4.0.1/build/byron-db-converter/byron-db-converter v
alidate --configFile $(pwd)/mainnet-genesis.json --genesisHash 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb --verbose --dbDir /tmp/tmp.hIWE
fz5t3r/
```