### PR TITLE
Use record type for output of protocol tests

### DIFF
--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -15,7 +15,6 @@ module Test.Dynamic.BFT (
     tests
   ) where
 
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 
 import           Test.QuickCheck
@@ -57,12 +56,11 @@ prop_simple_bft_convergence k numCoreNodes =
       numCoreNodes
   where
     isValid :: [NodeId]
-            -> Map NodeId ( NodeConfig ProtocolMockBFT
-                          , Chain (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
-                          )
+            -> TestOutput (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
             -> Property
-    isValid nodeIds final = counterexample (show final') $
-          tabulate "shortestLength" [show (rangeK k (shortestLength final'))]
+    isValid nodeIds TestOutput{testOutputNodes = final} =
+          counterexample (show final')
+     $    tabulate "shortestLength" [show (rangeK k (shortestLength final'))]
      $    Map.keys final === nodeIds
      .&&. allEqual (takeChainPrefix <$> Map.elems final')
       where

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -12,9 +12,10 @@
 {-# OPTIONS_GHC -Wredundant-constraints #-}
 module Test.Dynamic.General (
     prop_simple_protocol_convergence
+    -- * Re-exports
+  , TestOutput (..)
   ) where
 
-import           Data.Map.Strict (Map)
 import           Test.QuickCheck
 
 import           Control.Monad.Class.MonadAsync
@@ -26,14 +27,10 @@ import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim (runSimOrThrow)
 
-import           Ouroboros.Network.MockChain.Chain
-
 import           Ouroboros.Consensus.BlockchainTime
-import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.NodeId
-import           Ouroboros.Consensus.Protocol (NodeConfig)
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.ThreadRegistry
@@ -48,9 +45,7 @@ prop_simple_protocol_convergence :: forall blk.
                                    )
                                  => (CoreNodeId -> ProtocolInfo blk)
                                  -> (   [NodeId]
-                                     -> Map NodeId ( NodeConfig (BlockProtocol blk)
-                                                   , Chain blk
-                                                   )
+                                     -> TestOutput blk
                                      -> Property)
                                  -> NumCoreNodes
                                  -> NumSlots
@@ -75,9 +70,7 @@ test_simple_protocol_convergence :: forall m blk.
                                     )
                                  => (CoreNodeId -> ProtocolInfo blk)
                                  -> (   [NodeId]
-                                     -> Map NodeId ( NodeConfig (BlockProtocol blk)
-                                                   , Chain blk
-                                                   )
+                                     -> TestOutput blk
                                      -> Property)
                                  -> NumCoreNodes
                                  -> NumSlots

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -25,7 +25,6 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import           Ouroboros.Network.Block (SlotNo (..))
-import           Ouroboros.Network.MockChain.Chain (Chain)
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
@@ -77,11 +76,9 @@ prop_simple_leader_schedule_convergence numSlots numCoreNodes params seed =
                     seed
   where
     isValid :: [NodeId]
-            -> Map NodeId ( NodeConfig ProtocolLeaderSchedule
-                          , Chain (SimplePraosRuleBlock SimpleMockCrypto)
-                          )
+            -> TestOutput (SimplePraosRuleBlock SimpleMockCrypto)
             -> Property
-    isValid nodeIds final =
+    isValid nodeIds TestOutput{testOutputNodes = final} =
             counterexample (tracesToDot final)
        $    tabulate "shortestLength"
             [show (rangeK (praosSecurityParam params) (shortestLength final'))]

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
@@ -15,7 +15,6 @@ module Test.Dynamic.PBFT (
     tests
   ) where
 
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Test.QuickCheck
 
@@ -60,12 +59,11 @@ prop_simple_pbft_convergence sp numCoreNodes@(NumCoreNodes nn) =
     sigThd = (1.0 / fromIntegral nn) + 0.1
     params = PBftParams sp (fromIntegral nn) sigWin sigThd
     isValid :: [NodeId]
-            -> Map NodeId ( NodeConfig ProtocolMockPBFT
-                          , Chain (SimplePBftBlock SimpleMockCrypto PBftMockCrypto)
-                          )
+            -> TestOutput (SimplePBftBlock SimpleMockCrypto PBftMockCrypto)
             -> Property
-    isValid nodeIds final = counterexample (show final') $
-          tabulate "shortestLength" [show (rangeK sp (shortestLength final'))]
+    isValid nodeIds TestOutput{testOutputNodes = final} =
+          counterexample (show final')
+     $    tabulate "shortestLength" [show (rangeK sp (shortestLength final'))]
      $    Map.keys final === nodeIds
      .&&. allEqual (takeChainPrefix <$> Map.elems final')
       where

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -17,7 +17,6 @@ module Test.Dynamic.Praos (
   , prop_all_common_prefix
   ) where
 
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Word (Word64)
 import           Test.QuickCheck
@@ -89,11 +88,9 @@ prop_simple_praos_convergence params numCoreNodes numSlots =
     PraosParams{..} = params
 
     isValid :: [NodeId]
-            -> Map NodeId ( NodeConfig ProtocolMockPraos
-                          , Chain (SimplePraosBlock SimpleMockCrypto PraosMockCrypto)
-                          )
+            -> TestOutput (SimplePraosBlock SimpleMockCrypto PraosMockCrypto)
             -> Property
-    isValid nodeIds final
+    isValid nodeIds TestOutput{testOutputNodes = final}
        = counterexample (show final')
        $ counterexample (tracesToDot final)
        $ counterexample (condense schedule)


### PR DESCRIPTION
`broadcastNetwork` currently just returns a map. In tickets #231 etc and related debugging/investigations, I've wanted programmatic access to more information from the run.

This PR is a general refinement that simplifies the types within each per-protocol family member's test code and makes it easier to add information to the general test framework.