### PR TITLE
Bump cborg version to 0.2.2.0 (in line with stack)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -106,18 +106,6 @@ source-repository-package
   location: https://github.com/input-output-hk/cardano-sl-x509
   tag: ec96c64c665b741c17b4e38f611315bae9b0b054
 
-source-repository-package
-  type: git
-  location: https://github.com/well-typed/cborg
-  tag: 992b730ca6fd9c1da191bfecb2b67cabf31b54ad
-  subdir: cborg
-
-source-repository-package
-  type: git
-  location: http://github.com/well-typed/canonical-json
-  tag: ddfe3593b80b5ceb88842bb7a6f2268df75d2c2f
-
-
 package contra-tracer
   tests: False
 

--- a/cabal.project
+++ b/cabal.project
@@ -109,7 +109,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/well-typed/cborg
-  tag: 80fbe0ee5e67a5622e2cb9eaa9d8594a2214322d
+  tag: 992b730ca6fd9c1da191bfecb2b67cabf31b54ad
   subdir: cborg
 
 source-repository-package

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -207,7 +207,7 @@ library
                        cardano-crypto-wrapper,
                        cardano-ledger,
                        cardano-prelude,
-                       cborg             >=0.2.1 && <0.3,
+                       cborg             >=0.2.2 && <0.3,
                        constraints,
                        containers        >=0.5   && <0.7,
                        cryptonite        >=0.25  && <0.26,


### PR DESCRIPTION
`ouroboros-consensus` doesn't build otherwise.