### PR TITLE
Widen network magics from Word16 to Word32

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -91,7 +91,7 @@ instance Serialise NodeToClientVersion where
 -- | Version data for NodeToClient protocol v1
 --
 newtype NodeToClientVersionData = NodeToClientVersionData
-  { networkMagic :: Word16 }
+  { networkMagic :: Word32 }
   deriving (Eq, Show, Typeable)
 
 nodeToClientCodecCBORTerm :: CodecCBORTerm Text NodeToClientVersionData

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -104,7 +104,7 @@ instance Serialise NodeToNodeVersion where
 -- | Version data for NodeToNode protocol v1
 --
 newtype NodeToNodeVersionData = NodeToNodeVersionData
-  { networkMagic :: Word16 }
+  { networkMagic :: Word32 }
   deriving (Eq, Show, Typeable)
 
 nodeToNodeCodecCBORTerm :: CodecCBORTerm Text NodeToNodeVersionData


### PR DESCRIPTION
cardano-ledger is using Word32 for network magic.
This just adds a single byte to handshake protocol messages.