### PR TITLE
bugfix in `TxSeq.lookupByTicketNo`

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -139,8 +139,8 @@ lookupByTicketNo :: TxSeq tx -> TicketNo -> Maybe tx
 lookupByTicketNo (TxSeq txs) n =
     case FingerTree.search (\ml mr -> mMaxTicket ml >= n
                                    && mMinTicket mr >  n) txs of
-      FingerTree.Position _ (TxTicket tx _) _ -> Just tx
-      _                                       -> Nothing
+      FingerTree.Position _ (TxTicket tx n') _ | n' == n -> Just tx
+      _                                                  -> Nothing
 
 -- | \( O(\log(n) \). Split the sequence of transactions into two parts
 -- based on the given 'TicketNo'. The first part has transactions with tickets


### PR DESCRIPTION
For example, looking up `2` in the sequence `[0,1,3]` was erroneously returning `3`.

Regarding distribution of the new test, I'm seeing

```
      lookupByTicketNo sound:                             OK
        +++ OK, passed 100 tests:
        86% miss
        14% hit
```

which seems lopsided. Would be happy to receive refinements to the generator/property.