### PR TITLE
ChainSyncServer: close the ChainDB.Reader when done

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
@@ -78,7 +78,7 @@ chainSyncServerForReader _tracer chainDB rdr =
       ServerStIdle {
         recvMsgRequestNext   = handleRequestNext,
         recvMsgFindIntersect = handleFindIntersect,
-        recvMsgDoneClient    = return ()
+        recvMsgDoneClient    = ChainDB.readerClose rdr
       }
 
     idle' :: ChainSyncServer b (Point blk) m ()


### PR DESCRIPTION
We were leaking the `ChainDB.Reader`, which (typically) holds onto a file
handle.