### PR TITLE
refactor top-level test-consensus

### DIFF
--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -48,21 +48,18 @@ prop_simple_bft_convergence :: SecurityParam
                             -> NumSlots
                             -> Seed
                             -> Property
-prop_simple_bft_convergence k numCoreNodes =
-    prop_simple_protocol_convergence
-      (\nid -> protocolInfo numCoreNodes nid (ProtocolMockBFT k))
-      isValid
-      numCoreNodes
+prop_simple_bft_convergence k numCoreNodes numSlots seed =
+    counterexample (show final') $
+    tabulate "shortestLength" [show (rangeK k (shortestLength final'))] $
+    allEqual (takeChainPrefix <$> Map.elems final')
   where
-    isValid :: TestOutput (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
-            -> Property
-    isValid TestOutput{testOutputNodes = final} =
-        counterexample (show final') $
-        tabulate "shortestLength" [show (rangeK k (shortestLength final'))] $
-        allEqual (takeChainPrefix <$> Map.elems final')
-      where
-        -- Without the 'NodeConfig's
-        final' = snd <$> final
-        takeChainPrefix :: Chain (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
-                        -> Chain (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
-        takeChainPrefix = id -- in BFT, chains should indeed all be equal.
+    TestOutput{testOutputNodes = final} =
+        runTestNetwork
+            (\nid -> protocolInfo numCoreNodes nid (ProtocolMockBFT k))
+            numCoreNodes numSlots seed
+
+    -- Without the 'NodeConfig's
+    final' = snd <$> final
+    takeChainPrefix :: Chain (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
+                    -> Chain (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
+    takeChainPrefix = id -- in BFT, chains should indeed all be equal.

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -25,7 +25,6 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Node.ProtocolInfo
-import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Network.MockChain.Chain (Chain)
@@ -55,14 +54,12 @@ prop_simple_bft_convergence k numCoreNodes =
       isValid
       numCoreNodes
   where
-    isValid :: [NodeId]
-            -> TestOutput (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
+    isValid :: TestOutput (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
             -> Property
-    isValid nodeIds TestOutput{testOutputNodes = final} =
-          counterexample (show final')
-     $    tabulate "shortestLength" [show (rangeK k (shortestLength final'))]
-     $    Map.keys final === nodeIds
-     .&&. allEqual (takeChainPrefix <$> Map.elems final')
+    isValid TestOutput{testOutputNodes = final} =
+        counterexample (show final') $
+        tabulate "shortestLength" [show (rangeK k (shortestLength final'))] $
+        allEqual (takeChainPrefix <$> Map.elems final')
       where
         -- Without the 'NodeConfig's
         final' = snd <$> final

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -44,8 +44,7 @@ prop_simple_protocol_convergence :: forall blk.
                                    , TracingConstraints blk
                                    )
                                  => (CoreNodeId -> ProtocolInfo blk)
-                                 -> (   [NodeId]
-                                     -> TestOutput blk
+                                 -> (   TestOutput blk
                                      -> Property)
                                  -> NumCoreNodes
                                  -> NumSlots
@@ -69,15 +68,14 @@ test_simple_protocol_convergence :: forall m blk.
                                     , TracingConstraints blk
                                     )
                                  => (CoreNodeId -> ProtocolInfo blk)
-                                 -> (   [NodeId]
-                                     -> TestOutput blk
+                                 -> (   TestOutput blk
                                      -> Property)
                                  -> NumCoreNodes
                                  -> NumSlots
                                  -> Seed
                                  -> m Property
 test_simple_protocol_convergence pInfo isValid numCoreNodes numSlots seed =
-    fmap (isValid nodeIds) $ withThreadRegistry $ \registry -> do
+    fmap isValid $ withThreadRegistry $ \registry -> do
       testBtime <- newTestBlockchainTime registry numSlots slotLen
       broadcastNetwork registry
                        testBtime
@@ -86,8 +84,5 @@ test_simple_protocol_convergence pInfo isValid numCoreNodes numSlots seed =
                        (seedToChaCha seed)
                        slotLen
   where
-    nodeIds :: [NodeId]
-    nodeIds = map fromCoreNodeId $ enumCoreNodes numCoreNodes
-
     slotLen :: DiffTime
     slotLen = 100000

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -11,20 +11,12 @@
 
 {-# OPTIONS_GHC -Wredundant-constraints #-}
 module Test.Dynamic.General (
-    prop_simple_protocol_convergence
+    runTestNetwork
     -- * Re-exports
   , TestOutput (..)
   ) where
 
-import           Test.QuickCheck
-
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork (MonadFork)
-import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
-import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Ouroboros.Consensus.BlockchainTime
@@ -38,51 +30,28 @@ import           Ouroboros.Consensus.Util.ThreadRegistry
 import           Test.Dynamic.Network
 import           Test.Dynamic.TxGen
 
-prop_simple_protocol_convergence :: forall blk.
-                                   ( RunNode blk
-                                   , TxGen blk
-                                   , TracingConstraints blk
-                                   )
-                                 => (CoreNodeId -> ProtocolInfo blk)
-                                 -> (   TestOutput blk
-                                     -> Property)
-                                 -> NumCoreNodes
-                                 -> NumSlots
-                                 -> Seed
-                                 -> Property
-prop_simple_protocol_convergence pInfo isValid numCoreNodes numSlots seed =
+runTestNetwork ::
+  forall blk.
+     ( RunNode blk
+     , TxGen blk
+     , TracingConstraints blk
+     )
+  => (CoreNodeId -> ProtocolInfo blk)
+  -> NumCoreNodes
+  -> NumSlots
+  -> Seed
+  -> TestOutput blk
+runTestNetwork pInfo numCoreNodes numSlots seed =
     runSimOrThrow $
-      test_simple_protocol_convergence pInfo isValid numCoreNodes numSlots seed
-
--- Run protocol on the broadcast network, and check resulting chains on all nodes.
-test_simple_protocol_convergence :: forall m blk.
-                                    ( MonadAsync m
-                                    , MonadFork  m
-                                    , MonadMask  m
-                                    , MonadST    m
-                                    , MonadTime  m
-                                    , MonadTimer m
-                                    , MonadThrow (STM m)
-                                    , RunNode blk
-                                    , TxGen blk
-                                    , TracingConstraints blk
-                                    )
-                                 => (CoreNodeId -> ProtocolInfo blk)
-                                 -> (   TestOutput blk
-                                     -> Property)
-                                 -> NumCoreNodes
-                                 -> NumSlots
-                                 -> Seed
-                                 -> m Property
-test_simple_protocol_convergence pInfo isValid numCoreNodes numSlots seed =
-    fmap isValid $ withThreadRegistry $ \registry -> do
-      testBtime <- newTestBlockchainTime registry numSlots slotLen
-      broadcastNetwork registry
-                       testBtime
-                       numCoreNodes
-                       pInfo
-                       (seedToChaCha seed)
-                       slotLen
+        withThreadRegistry $ \registry -> do
+            testBtime <- newTestBlockchainTime registry numSlots slotLen
+            broadcastNetwork
+                registry
+                testBtime
+                numCoreNodes
+                pInfo
+                (seedToChaCha seed)
+                slotLen
   where
     slotLen :: DiffTime
     slotLen = 100000

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -35,9 +35,9 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.Random
 
 import           Test.Dynamic.General
-import           Test.Dynamic.Praos (prop_all_common_prefix)
 import           Test.Dynamic.Util
 
+import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Range
 
 tests :: TestTree

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -28,7 +28,6 @@ import           Ouroboros.Network.Block (SlotNo (..))
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
-import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol
@@ -45,48 +44,51 @@ tests :: TestTree
 tests = testGroup "Dynamic chain generation"
     [ testProperty
         "simple leader schedule convergence" $
-            prop_simple_leader_schedule_convergence
-                (NumSlots (fromIntegral numSlots))
-                (NumCoreNodes 3)
-                params
+            prop
     ]
   where
     params@PraosParams{..} = defaultDemoPraosParams
-    numSlots  = maxRollbacks praosSecurityParam * praosSlotsPerEpoch * numEpochs
+    numCoreNodes = NumCoreNodes 3
+    numSlots  = NumSlots $ fromEnum $
+        maxRollbacks praosSecurityParam * praosSlotsPerEpoch * numEpochs
     numEpochs = 3
 
-prop_simple_leader_schedule_convergence :: NumSlots
+    prop seed =
+        forAllShrink
+            (genLeaderSchedule numSlots numCoreNodes params)
+            (shrinkLeaderSchedule numSlots)
+            $ \schedule ->
+                prop_simple_leader_schedule_convergence
+                    params
+                    numCoreNodes numSlots schedule seed
+
+prop_simple_leader_schedule_convergence :: PraosParams
                                         -> NumCoreNodes
-                                        -> PraosParams
+                                        -> NumSlots
+                                        -> LeaderSchedule
                                         -> Seed
                                         -> Property
 prop_simple_leader_schedule_convergence
-  numSlots numCoreNodes params@PraosParams{praosSecurityParam = k} seed =
-    forAllShrink
-        (genLeaderSchedule numSlots numCoreNodes params)
-        (shrinkLeaderSchedule numSlots)
-        $ \schedule ->
-            let longest = longestCrowdedRun schedule
-            in    counterexample ("schedule: " <> condense schedule <> "\n" <> show longest)
-                $ label ("longest crowded run " <> show (crowdedRunLength longest))
-                $ prop_simple_protocol_convergence
-                    (\nid -> protocolInfo numCoreNodes nid (ProtocolLeaderSchedule params schedule))
-                    isValid
-                    numCoreNodes
-                    numSlots
-                    seed
+  params@PraosParams{praosSecurityParam = k}
+  numCoreNodes numSlots schedule seed =
+    counterexample ("schedule: " <> condense schedule <> "\n" <> show longest) $
+    label ("longest crowded run " <> show (crowdedRunLength longest)) $
+    counterexample (tracesToDot final) $
+    tabulate "shortestLength" [show (rangeK k (shortestLength final'))] $
+    prop_all_common_prefix
+        (maxRollbacks k)
+        (Map.elems final')
   where
-    isValid :: TestOutput (SimplePraosRuleBlock SimpleMockCrypto)
-            -> Property
-    isValid TestOutput{testOutputNodes = final} =
-       counterexample (tracesToDot final) $
-       tabulate "shortestLength" [show (rangeK k (shortestLength final'))] $
-       prop_all_common_prefix
-           (maxRollbacks k)
-           (Map.elems final')
-      where
-        -- Without the 'NodeConfig's
-        final' = snd <$> final
+    longest = longestCrowdedRun schedule
+
+    TestOutput{testOutputNodes = final} =
+        runTestNetwork
+            (\nid -> protocolInfo numCoreNodes nid
+                 (ProtocolLeaderSchedule params schedule))
+            numCoreNodes numSlots seed
+
+    -- Without the 'NodeConfig's
+    final' = snd <$> final
 
 {-------------------------------------------------------------------------------
   Dependent generation and shrinking of leader schedules

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
@@ -25,7 +25,6 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Node.ProtocolInfo
-import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Network.MockChain.Chain (Chain)
@@ -39,17 +38,17 @@ import           Test.Util.Range
 tests :: TestTree
 tests = testGroup "Dynamic chain generation" [
       testProperty "simple PBFT convergence" $
-        prop_simple_pbft_convergence sp
+        prop_simple_pbft_convergence k
     ]
   where
-    sp = defaultSecurityParam
+    k = defaultSecurityParam
 
 prop_simple_pbft_convergence :: SecurityParam
                              -> NumCoreNodes
                              -> NumSlots
                              -> Seed
                              -> Property
-prop_simple_pbft_convergence sp numCoreNodes@(NumCoreNodes nn) =
+prop_simple_pbft_convergence k numCoreNodes@(NumCoreNodes nn) =
     prop_simple_protocol_convergence
       (\nid -> protocolInfo numCoreNodes nid (ProtocolMockPBFT params))
       isValid
@@ -57,15 +56,14 @@ prop_simple_pbft_convergence sp numCoreNodes@(NumCoreNodes nn) =
   where
     sigWin = fromIntegral $ nn * 10
     sigThd = (1.0 / fromIntegral nn) + 0.1
-    params = PBftParams sp (fromIntegral nn) sigWin sigThd
-    isValid :: [NodeId]
-            -> TestOutput (SimplePBftBlock SimpleMockCrypto PBftMockCrypto)
+    params = PBftParams k (fromIntegral nn) sigWin sigThd
+
+    isValid :: TestOutput (SimplePBftBlock SimpleMockCrypto PBftMockCrypto)
             -> Property
-    isValid nodeIds TestOutput{testOutputNodes = final} =
-          counterexample (show final')
-     $    tabulate "shortestLength" [show (rangeK sp (shortestLength final'))]
-     $    Map.keys final === nodeIds
-     .&&. allEqual (takeChainPrefix <$> Map.elems final')
+    isValid TestOutput{testOutputNodes = final} =
+        counterexample (show final') $
+        tabulate "shortestLength" [show (rangeK k (shortestLength final'))] $
+        allEqual (takeChainPrefix <$> Map.elems final')
       where
         -- Without the 'NodeConfig's
         final' = snd <$> final


### PR DESCRIPTION
The commit diffs are each pretty small. All of these changes seem like simplifications to me. They became apparent during my work on #773 et al, so I broke them out here.

This is a behavior preserving refactor except:

  * I exchanged the order of some property arguments, which invalidates any recorded `quickcheck-replay` arguments.

  * The `streamline test-consensus predicates` commit drops the `Map.keys final === nodeIds` check. It was trivially satisfied by the test framework. If we want it back, it should be included in a general combinator, not occurring separately in various properties. (Note: my next PR will introduce such a general combinator used by all tests, so we can do it there if we prefer.)