### PR TITLE
Check for file handle leaks in the consensus tests

### DIFF
--- a/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
@@ -39,6 +39,7 @@ import qualified Cardano.Crypto as Crypto
 import qualified Test.Cardano.Chain.Genesis.Dummy as Dummy
 
 import           Test.Dynamic.General
+import           Test.Dynamic.Network (NodeOutput (..))
 import           Test.Dynamic.Util
 
 import           Test.Util.Orphans.Arbitrary ()
@@ -91,7 +92,7 @@ prop_simple_real_pbft_convergence k numCoreNodes numSlots seed =
             numCoreNodes numSlots seed
 
     finalChains :: [Chain (ByronBlockOrEBB ByronConfig)]
-    finalChains = map snd $ Map.elems $ testOutputNodes testOutput
+    finalChains = Map.elems $ nodeOutputFinalChain <$> testOutputNodes testOutput
 
     giveByron :: forall a. (ByronGiven => a) -> a
     giveByron a =


### PR DESCRIPTION
For each node in the test setup, we return a `NodeInfo` record which stores the mock file-systems the node used for its ChainDB. This record can later be extended with other functionality, e.g., a way to shut down the node, or other information about the node.

 We combine all useful output of a node in the new `NodeOutput` record (as soon as we have more than 2 values and we're writing `{fst,snd,thd}3`, it's a sign we have to switch to a record). In `prop_general` we check for file handle leaks.


