### PR TITLE
consolidate the final chains property and fix revealed off-by-one in `genLeaderSchedule`

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -257,6 +257,7 @@ test-suite test-consensus
                     Test.Dynamic.TxGen
                     Test.Dynamic.Util
                     Test.Dynamic.Util.Expectations
+                    Test.Dynamic.Util.Tests
                     Test.Ouroboros
                     Test.Util.DepFn
                     Test.Util.HasCreator

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -256,6 +256,7 @@ test-suite test-consensus
                     Test.Dynamic.Praos
                     Test.Dynamic.TxGen
                     Test.Dynamic.Util
+                    Test.Dynamic.Util.Expectations
                     Test.Ouroboros
                     Test.Util.DepFn
                     Test.Util.HasCreator

--- a/ouroboros-consensus/test-consensus/Main.hs
+++ b/ouroboros-consensus/test-consensus/Main.hs
@@ -9,6 +9,7 @@ import qualified Test.Dynamic.BFT (tests)
 import qualified Test.Dynamic.LeaderSchedule (tests)
 import qualified Test.Dynamic.PBFT (tests)
 import qualified Test.Dynamic.Praos (tests)
+import qualified Test.Dynamic.Util.Tests (tests)
 
 main :: IO ()
 main = defaultMain tests
@@ -19,6 +20,7 @@ tests =
   [ Test.Consensus.BlockchainTime.tests
   , Test.Consensus.ChainSyncClient.tests
   , Test.Consensus.Mempool.tests
+  , Test.Dynamic.Util.Tests.tests
   , Test.Dynamic.BFT.tests
   , Test.Dynamic.LeaderSchedule.tests
   , Test.Dynamic.PBFT.tests

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -15,25 +15,20 @@ module Test.Dynamic.BFT (
     tests
   ) where
 
-import qualified Data.Map.Strict as Map
-
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
-import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Protocol
 import           Ouroboros.Consensus.Util.Random
-import           Ouroboros.Network.MockChain.Chain (Chain)
 
 import           Test.Dynamic.General
 import           Test.Dynamic.Util
 
 import           Test.Util.Orphans.Arbitrary ()
-import           Test.Util.Range
 
 tests :: TestTree
 tests = testGroup "Dynamic chain generation" [
@@ -49,17 +44,11 @@ prop_simple_bft_convergence :: SecurityParam
                             -> Seed
                             -> Property
 prop_simple_bft_convergence k numCoreNodes numSlots seed =
-    counterexample (show final') $
-    tabulate "shortestLength" [show (rangeK k (shortestLength final'))] $
-    allEqual (takeChainPrefix <$> Map.elems final')
+    prop_general k
+        (roundRobinLeaderSchedule numCoreNodes numSlots)
+        testOutput
   where
-    TestOutput{testOutputNodes = final} =
+    testOutput =
         runTestNetwork
             (\nid -> protocolInfo numCoreNodes nid (ProtocolMockBFT k))
             numCoreNodes numSlots seed
-
-    -- Without the 'NodeConfig's
-    final' = snd <$> final
-    takeChainPrefix :: Chain (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
-                    -> Chain (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
-    takeChainPrefix = id -- in BFT, chains should indeed all be equal.

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -1,16 +1,3 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
-
-{-# OPTIONS -fno-warn-orphans #-}
-
 module Test.Dynamic.BFT (
     tests
   ) where

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -11,25 +11,43 @@
 
 {-# OPTIONS_GHC -Wredundant-constraints #-}
 module Test.Dynamic.General (
-    runTestNetwork
+    prop_general
+  , runTestNetwork
     -- * Re-exports
   , TestOutput (..)
   ) where
 
+import qualified Data.Map as Map
+import           Test.QuickCheck
+
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.IOSim (runSimOrThrow)
+
+import           Ouroboros.Network.Block (HasHeader)
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.NodeId
+import           Ouroboros.Consensus.Protocol (LeaderSchedule (..))
+import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+
+import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.ThreadRegistry
 
 import           Test.Dynamic.Network
 import           Test.Dynamic.TxGen
+import           Test.Dynamic.Util
 
+import           Test.Util.Range
+
+-- | Execute a fully-connected network of nodes that all join immediately
+--
+-- Runs the network for the specified number of slots, and returns the
+-- resulting 'TestOutput'.
+--
 runTestNetwork ::
   forall blk.
      ( RunNode blk
@@ -55,3 +73,32 @@ runTestNetwork pInfo numCoreNodes numSlots seed =
   where
     slotLen :: DiffTime
     slotLen = 100000
+
+-- | The properties always required
+--
+-- Includes:
+--
+-- * The competitive chains at the end of the simulation respect the expected
+--   bound on fork length
+--
+prop_general ::
+     ( Condense blk
+     , Eq blk
+     , HasHeader blk
+     )
+  => SecurityParam
+  -> LeaderSchedule
+  -> TestOutput blk
+  -> Property
+prop_general k schedule
+  TestOutput{testOutputNodes} =
+    counterexample ("schedule: " <> condense schedule) $
+    counterexample ("nodeChains: " <> condense nodeChains) $
+    tabulate "shortestLength" [show (rangeK k (shortestLength nodeChains))] $
+    prop_all_common_prefix
+        maxForkLength
+        (Map.elems nodeChains)
+  where
+    NumBlocks maxForkLength = determineForkLength k schedule
+
+    nodeChains = snd <$> testOutputNodes

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -1,15 +1,7 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE KindSignatures        #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 module Test.Dynamic.General (
     prop_general
   , runTestNetwork

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -1,16 +1,4 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
-
-{-# OPTIONS -fno-warn-orphans #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Test.Dynamic.LeaderSchedule (
     tests

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -83,7 +83,7 @@ genLeaderSchedule k (NumSlots numSlots) (NumCoreNodes numCoreNodes) =
             , ( 1, pick 2)
             , ( 1, pick 3)
             ]
-        return $ LeaderSchedule $ Map.fromList $ zip [1..] leaders
+        return $ LeaderSchedule $ Map.fromList $ zip [0..] leaders
   where
     pick :: Int -> Gen [CoreNodeId]
     pick = go [0 .. numCoreNodes - 1]
@@ -99,7 +99,7 @@ genLeaderSchedule k (NumSlots numSlots) (NumCoreNodes numCoreNodes) =
 shrinkLeaderSchedule :: NumSlots -> LeaderSchedule -> [LeaderSchedule]
 shrinkLeaderSchedule (NumSlots numSlots) (LeaderSchedule m) =
     [ LeaderSchedule m'
-    | slot <- [1 .. fromIntegral numSlots]
+    | slot <- [0 .. fromIntegral numSlots - 1]
     , m'   <- reduceSlot slot m
     ]
   where

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
@@ -1,16 +1,3 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
-
-{-# OPTIONS -fno-warn-orphans #-}
-
 module Test.Dynamic.PBFT (
     tests
   ) where

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
@@ -15,7 +15,6 @@ module Test.Dynamic.PBFT (
     tests
   ) where
 
-import qualified Data.Map.Strict as Map
 import           Test.QuickCheck
 
 import           Test.Tasty
@@ -23,17 +22,14 @@ import           Test.Tasty.QuickCheck
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Demo
-import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Protocol
 import           Ouroboros.Consensus.Util.Random
-import           Ouroboros.Network.MockChain.Chain (Chain)
 
 import           Test.Dynamic.General
 import           Test.Dynamic.Util
 
 import           Test.Util.Orphans.Arbitrary ()
-import           Test.Util.Range
 
 tests :: TestTree
 tests = testGroup "Dynamic chain generation" [
@@ -50,21 +46,15 @@ prop_simple_pbft_convergence :: SecurityParam
                              -> Property
 prop_simple_pbft_convergence
   k numCoreNodes@(NumCoreNodes nn) numSlots seed =
-    counterexample (show final') $
-    tabulate "shortestLength" [show (rangeK k (shortestLength final'))] $
-    allEqual (takeChainPrefix <$> Map.elems final')
+    prop_general k
+        (roundRobinLeaderSchedule numCoreNodes numSlots)
+        testOutput
   where
     sigWin = fromIntegral $ nn * 10
     sigThd = (1.0 / fromIntegral nn) + 0.1
     params = PBftParams k (fromIntegral nn) sigWin sigThd
 
-    TestOutput{testOutputNodes = final} =
+    testOutput =
         runTestNetwork
             (\nid -> protocolInfo numCoreNodes nid (ProtocolMockPBFT params))
             numCoreNodes numSlots seed
-
-    -- Without the 'NodeConfig's
-    final' = snd <$> final
-    takeChainPrefix :: Chain (SimplePBftBlock SimpleMockCrypto PBftMockCrypto)
-                    -> Chain (SimplePBftBlock SimpleMockCrypto PBftMockCrypto)
-    takeChainPrefix = id -- in PBFT, chains should indeed all be equal.

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -74,10 +74,8 @@ prop_simple_praos_convergence
     counterexample (show final') $
     counterexample (tracesToDot final) $
     counterexample (condense schedule) $
-    counterexample (show longest) $
-    label ("longest crowded run " <> show crowded) $
     tabulate "shortestLength" [show (rangeK k (shortestLength final'))] $
-    if crowded > maxRollbacks k
+    if maxForkLength > maxRollbacks k
       then label "too crowded"     $ property True
       else label "not too crowded" $
                prop_all_common_prefix
@@ -92,5 +90,5 @@ prop_simple_praos_convergence
     -- Without the 'NodeConfig's
     final'   = snd <$> final
     schedule = leaderScheduleFromTrace numSlots final
-    longest  = longestCrowdedRun schedule
-    crowded  = crowdedRunLength longest
+
+    NumBlocks maxForkLength = determineForkLength k schedule

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -58,10 +58,9 @@ prop_simple_praos_convergence :: PraosParams
 prop_simple_praos_convergence
   params@PraosParams{praosSecurityParam = k} numCoreNodes numSlots seed =
     counterexample (tracesToDot testOutputNodes) $
-    if tooCrowded k schedule
-      then label "too crowded"     $ property True
-      else label "not too crowded" $
-               prop_general k schedule testOutput
+    label lbl $
+    counterexample lbl $
+    prop_general k schedule testOutput
   where
     testOutput@TestOutput{testOutputNodes} =
         runTestNetwork
@@ -69,3 +68,4 @@ prop_simple_praos_convergence
             numCoreNodes numSlots seed
 
     schedule = leaderScheduleFromTrace numSlots testOutputNodes
+    lbl = if tooCrowded k schedule then "too crowded" else "not too crowded"

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -1,16 +1,5 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
-
-{-# OPTIONS -fno-warn-orphans #-}
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Test.Dynamic.Praos (
     tests

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
@@ -5,18 +5,20 @@
 {-# LANGUAGE TypeFamilies        #-}
 
 module Test.Dynamic.Util (
+  -- * Chain properties
     allEqual
   , prop_all_common_prefix
   , shortestLength
-  , tracesToDot
+  -- * LeaderSchedule
   , leaderScheduleFromTrace
-  , CrowdedRun (..)
-  , crowdedRunLength
-  , longestCrowdedRun
+  , notTooCrowded
+  -- * GraphViz Dot
+  , tracesToDot
+  -- * Re-exports
+  , module Test.Dynamic.Util.Expectations
   ) where
 
 import           Data.Foldable (foldl')
-import           Data.Function (on)
 import           Data.Graph.Inductive.Graph
 import           Data.Graph.Inductive.PatriciaTree
 import           Data.GraphViz
@@ -38,7 +40,8 @@ import qualified Ouroboros.Network.MockChain.Chain as Chain
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.NodeId
-import           Ouroboros.Consensus.Protocol.Abstract (NodeConfig)
+import           Ouroboros.Consensus.Protocol.Abstract (NodeConfig,
+                     SecurityParam (..))
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
                      (LeaderSchedule (..))
 import           Ouroboros.Consensus.Util.Condense
@@ -46,6 +49,9 @@ import           Ouroboros.Consensus.Util.Orphans ()
 
 import           Test.Util.HasCreator
 import qualified Test.Util.MockChain as Chain
+
+import           Test.Dynamic.Util.Expectations (NumBlocks (..),
+                     determineForkLength)
 
 {-------------------------------------------------------------------------------
   Chain properties
@@ -240,6 +246,10 @@ tracesToDot traces = Text.unpack $ printDotGraph $ graphToDot quickParams graph
     graph :: Gr NodeLabel EdgeLabel
     graph = mkGraph ns es
 
+{-------------------------------------------------------------------------------
+  Leader Schedule
+-------------------------------------------------------------------------------}
+
 leaderScheduleFromTrace :: forall b. (HasCreator b, HasHeader b)
                         => NumSlots
                         -> Map NodeId (NodeConfig (BlockProtocol b), Chain b)
@@ -261,92 +271,7 @@ leaderScheduleFromTrace (NumSlots numSlots) = LeaderSchedule .
         | nid `elem` xs = xs
         | otherwise     = nid : xs
 
-{-------------------------------------------------------------------------------
-  Crowded Run - longest multi-leader section of a leader schedule
--------------------------------------------------------------------------------}
-
--- | Describes a sequence of slots in a leader schedule with slots with
--- more than one leader, possibly interrupted by slots without leader.
--- There can be no such sequence, but if there is, first slot and number of
--- multi-leader slots are given.
-newtype CrowdedRun = CrowdedRun (Maybe (SlotNo, Word64))
-    deriving (Show, Eq)
-
-crowdedRunLength :: CrowdedRun -> Word64
-crowdedRunLength (CrowdedRun m) = maybe 0 snd m
-
-instance Ord CrowdedRun where
-    compare = compare `on` crowdedRunLength
-
-noRun :: CrowdedRun
-noRun = CrowdedRun Nothing
-
-incCrowdedRun :: SlotNo -> CrowdedRun -> CrowdedRun
-incCrowdedRun slot (CrowdedRun Nothing)          = CrowdedRun (Just (slot, 1))
-incCrowdedRun _    (CrowdedRun (Just (slot, n))) = CrowdedRun (Just (slot, n + 1))
-
--- | The longest 'CrowdedRun' of a 'LeaderSchedule'. The tiebreaker favors
--- earlier runs. The \"length\" of a run is the number of slots in it that have
--- more than one leader. The run may also have slots with no leader in it, but
--- these don't make it longer. A run has no slots with exactly one leader.
---
--- Such a run can drive a network away from consensus. If its long enough, it
--- might even prevent consensus thereafter. The length of the run is defined as
--- a number of slots, but it is also interpreted as an upper bound on the
--- number of blocks that can differ among the competing chains' suffixes at the
--- end of the run. Thus, if the length of a run exceeds the security parameter
--- @k@, then that part of the leader schedule itself may be enough to prevent
--- the network from ever re-establishing consensus. The method of failure is as
--- follows.
---
--- * Assume the network is in consensus as of slot @s - 1@: all nodes have the
--- same current chain. Call that chain C.
---
--- * Let the slot @s@ have @N > 1@ leaders. Each leader forges a block that
--- fits onto C. It's most likely that each leader will add the block that it
--- forged to its own chain; a race condition between ChainSync/BlockFetch and
--- forging makes it possible, though less likely, that a leader would have
--- received another leader's new block before it forges its own. The @N@
--- leaders have thereby created (from 1 to) @N@ competing current chains D1 ..
--- DN amongst the network; each non-leader will adopt one of these new chains
--- because they're all longer than C. Thus the network is likely no longer in
--- consensus.
---
--- * If the slot @s + 1@ has exactly one leader, then the leader will forge a
--- block onto whichever of the @N@ chains it happens to have adopted. All
--- non-leaders will switch to this new chain E, because it is longer than each
--- of D1 .. DN. The network has reestablished consensus.
---
--- * If the slot @s + 1@ instead has @M > 1@ leaders, then the pattern from
--- slot @s@ will repeat, and the competing chains will grow by one block. Now
--- instead of the competing chains disagreeing on only the last block, they
--- could disagree on the last two blocks. (If all the @M@ leaders happened to
--- have adopted the same one of the @N@ chains from slot @s@, then all new
--- chains in slot @s + 1@ would again disagree on only the last block. But that
--- is the least common possibility.)
---
--- * If the slot @s + 1@ instead has no leader, then all nodes will retain
--- their chains. The network is still not in consensus.
---
--- Consider a run beginning with a slot @s@ that has multiple leaders, and the
--- subsequent slots include @q@ many slots with multiple leaders before the
--- next slot @s + i@ that has exactly one leader. If @q > k@, then the security
--- parameter @k@ might prevent the network from being able to reach consensus
--- at slot @s + i@ and beyond. Note that @i >= q@, because some of the
--- intervening slots may have no leader; leaderless slots increase the
--- \"duration\" (number of slots) of the run but not its \"length\" (number of
--- potentially-disagreed-upon blocks).
---
--- To be careful, this function assumes that any multi-leader slot will indeed
--- create multiple competing chains in the network as described above.
-longestCrowdedRun :: LeaderSchedule -> CrowdedRun
-longestCrowdedRun (LeaderSchedule m) = fst
-                                     $ foldl' go (noRun, noRun)
-                                     $ Map.toList
-                                     $ fmap length m
+notTooCrowded :: SecurityParam -> LeaderSchedule -> Bool
+notTooCrowded k schedule = maxForkLength <= maxRollbacks k
   where
-    go :: (CrowdedRun, CrowdedRun) -> (SlotNo, Int) -> (CrowdedRun, CrowdedRun)
-    go (x, y) (slot, n)
-        | n == 0    = (x, y)
-        | n == 1    = (x, noRun)
-        | otherwise = let y' = incCrowdedRun slot y in (max x y', y')
+    NumBlocks maxForkLength = determineForkLength k schedule

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util/Expectations.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util/Expectations.hs
@@ -14,6 +14,7 @@ import           Ouroboros.Consensus.Protocol.LeaderSchedule
                      (LeaderSchedule (..))
 
 newtype NumBlocks = NumBlocks Word64
+  deriving (Eq, Show)
 
 -- | Internal accumulator of 'determineForkLength'
 data Acc = Acc
@@ -27,8 +28,58 @@ data Acc = Acc
 -- | Compute a bound for the length of the final forks
 --
 -- At the end of the test, the nodes' final chains will share a common prefix
--- (\"intersection\"), though it may be empty. Each current chain is a fork off
--- that prefix. No fork will be longer than the result of this function.
+-- (\"intersection\"), though it may be empty. Each node's current chain is a
+-- fork off that prefix. No such fork will be longer than the result of this
+-- function.
+--
+-- ASSUMPTION: The network connectivity is such that any block forged in a slot
+-- will be fetched and possibly selected by every other node before the end of
+-- the slot.
+--
+-- *How 'LeaderSchedule' affects this function*
+--
+-- A round-robin 'LeaderSchedule' will always reach consensus, so the fork
+-- length will be @0@. For other 'LeaderSchedule's -- whether known /a priori/
+-- (see "Test.Dynamic.LeaderSchedule") or /a posteriori/ (see
+-- "Test.Dynamic.Praos") -- we often will not expect consensus. The key
+-- difference is that a round-robin schedule always has exactly one leader per
+-- slot. Arbitrary schedules instead may have 0 or multiple leaders.
+--
+-- A sequence of slots in which no slot has exactly one leader can drive a
+-- network away from consensus. This function bounds how far from consensus the
+-- network could be after the last simulated slot. It determines a conservative
+-- upper bound on the length of the contended suffix of the nodes' final
+-- chains. The bound may be less than, equal, or greater than @k@; regardless
+-- of which, it should be used to test the nodes' final chains.
+--
+-- If such a sequence is long enough, it might even prevent the network from
+-- every reaching consensus again: the nodes at the end of the sequence may
+-- have chains that disagree by more than @k@ blocks, thereby exceeding the
+-- security parameter @k@. In particular, if the bound determined by a
+-- 'LeaderSchedule' is greater than @k@, then no extension of that
+-- 'LeaderSchedule' can determine a lesser bound.
+--
+-- Multiple leaders create divergent chains as follows. Assume that every
+-- leader of @s + 1@ begins the slot with a chain of length @n@, and that no
+-- chain in the network has a greater length. Each leader forges a unique
+-- block. A race condition between ChainSync/BlockFetch and forging makes it
+-- possible, though relatively unlikely, that a leader would have received
+-- another leader's new block before it forges its own. In that case, the new
+-- leader will forged a block but then not select it, since it already selected
+-- the other leader's new block. This function assumes the \"worst-case\" in
+-- which both leaders make separate chains, thereby breaking consensus. Hence
+-- it computes an upper bound. Each leader thus selects a new @n+1@-length
+-- chain, and each non-leader will adopt one of them because they previously
+-- had a chain of length @<= n@. Thus the network is likely not in consensus at
+-- the end of a multi-leader slot.
+--
+-- The network will reestablish consensus at the end of a single-leader slot,
+-- because the leader creates the only chain of length @n+1@ and all other
+-- nodes thus select it.
+--
+-- In a slot with no leaders, all nodes will simply retain their current
+-- chains.
+--
 determineForkLength ::
      SecurityParam
   -> LeaderSchedule
@@ -56,16 +107,16 @@ determineForkLength k (LeaderSchedule m) =
 
             -- assume (common) worst-case: each leader creates a unique longer
             -- chain
-          | pullingAhead >  1              = (+ 1)
+          | numLeaders >  1                = (+ 1)
 
             -- the sole leader creates the sole longer chain, bringing the
             -- network into consensus
-          | pullingAhead == 1              = const 0
+          | numLeaders == 1                = const 0
 
             -- no leaders, so the longest chains are the same as in the
             -- previous slot
           | otherwise                      = id
 
-        -- how many leaders are making a new chain longer than any from the
-        -- previous slot
-        pullingAhead = length leaders
+        -- ASSUMPTION: each leader is making a unique new chain that is longer
+        -- than any from the previous slot
+        numLeaders = length leaders

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util/Expectations.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util/Expectations.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Test.Dynamic.Util.Expectations
+    ( NumBlocks (..)
+    , determineForkLength
+    ) where
+
+import           Data.Foldable (foldl')
+import qualified Data.Map.Strict as Map
+import           Data.Word (Word64)
+
+import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+import           Ouroboros.Consensus.Protocol.LeaderSchedule
+                     (LeaderSchedule (..))
+
+newtype NumBlocks = NumBlocks Word64
+
+-- | Internal accumulator of 'determineForkLength'
+data Acc = Acc
+  { maxForkLength  :: !Word64
+    -- ^ Upper bound on length of the longest fork in the network, excluding
+    -- the common prefix
+    --
+    -- Note that @0@ corresponds to /consensus/.
+  }
+
+-- | Compute a bound for the length of the final forks
+--
+-- At the end of the test, the nodes' final chains will share a common prefix
+-- (\"intersection\"), though it may be empty. Each current chain is a fork off
+-- that prefix. No fork will be longer than the result of this function.
+determineForkLength ::
+     SecurityParam
+  -> LeaderSchedule
+  -> NumBlocks
+determineForkLength k (LeaderSchedule m) =
+    prj $ foldl' step initial (Map.toAscList m)
+  where
+    prj Acc{maxForkLength} = NumBlocks maxForkLength
+
+    -- assume the network begins in consensus (eg all nodes start at Genesis)
+    initial = Acc
+      { maxForkLength = 0
+      }
+
+    -- this logic focuses on the new chains made in this slot that are longer
+    -- than the longest chains from the previous slot
+    step Acc{maxForkLength} (_slot, leaders) =
+        Acc
+          { maxForkLength = update maxForkLength
+          }
+      where
+        update
+            -- too late to reach consensus, so further diverge
+          | maxForkLength > maxRollbacks k = (+ 1)
+
+            -- assume (common) worst-case: each leader creates a unique longer
+            -- chain
+          | pullingAhead >  1              = (+ 1)
+
+            -- the sole leader creates the sole longer chain, bringing the
+            -- network into consensus
+          | pullingAhead == 1              = const 0
+
+            -- no leaders, so the longest chains are the same as in the
+            -- previous slot
+          | otherwise                      = id
+
+        -- how many leaders are making a new chain longer than any from the
+        -- previous slot
+        pullingAhead = length leaders

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util/Tests.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util/Tests.hs
@@ -1,0 +1,30 @@
+module Test.Dynamic.Util.Tests (
+    tests
+  ) where
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Ouroboros.Consensus.BlockchainTime (NumSlots (..))
+import           Ouroboros.Consensus.Demo (defaultSecurityParam)
+import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract
+                     (NumCoreNodes (..))
+import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+
+import           Test.Dynamic.Util
+
+import           Test.Util.Orphans.Arbitrary ()
+
+tests :: TestTree
+tests = testGroup "Test.Dynamic.Util.Tests" $
+    [ testProperty "0 = determineForkLength roundRobinLeaderSchedule" $
+          prop_roundRobin_forkLength defaultSecurityParam
+    ]
+
+-- | A round-robin schedule should reach consensus
+prop_roundRobin_forkLength ::
+    SecurityParam -> NumCoreNodes -> NumSlots -> Property
+prop_roundRobin_forkLength k numCoreNodes numSlots =
+  determineForkLength k schedule === NumBlocks 0
+  where
+    schedule = roundRobinLeaderSchedule numCoreNodes numSlots


### PR DESCRIPTION
Currently on `master`, `LeaderSchedule` and `Praos` use `prop_all_common_prefix` (unless the schedule is _too crowded_, then it discards/gives up) while BFT and PBFT use `allEqual`.

This PR consolidates all of that logic into a common property. This involves eliminating the `CrowdedRun` logic in favor of a more direct and general computation. Beyond the inherent simplification, this is in anticipation of #773: letting nodes join late generalizes the notion of _too crowded_ in such a way that will affect all the protocols.

Also, #827 should have included the `fix off-by-one bug in genLeaderSchedule` commit, but the related test wasn't failing until this PR. This is because the new property based on `determineForkLength` is more demanding than what was being used before.