### PR TITLE
ChainDB: improve tracing of LedgerDB and start-up

### DIFF
--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -26,6 +26,7 @@
           (hsPkgs.contra-tracer)
           (hsPkgs.cardano-ledger-test)
           (hsPkgs.base16-bytestring)
+          (hsPkgs.bifunctors)
           (hsPkgs.bimap)
           (hsPkgs.bytestring)
           (hsPkgs.cardano-binary)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -200,6 +200,7 @@ library
                        cardano-ledger-test,
 
                        base16-bytestring >=0.1   && <0.2,
+                       bifunctors,
                        bimap             >=0.3   && <0.5,
                        bytestring        >=0.10  && <0.11,
                        cardano-binary,

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -45,6 +45,9 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..))
 
+import           Ouroboros.Storage.Common (EpochNo)
+import           Ouroboros.Storage.EpochInfo (epochInfoEpoch)
+
 import           Ouroboros.Storage.ChainDB.API
 
 import           Ouroboros.Storage.ChainDB.Impl.Args (ChainDbArgs, defaultArgs)
@@ -148,6 +151,7 @@ openDBInternal args launchBgTasks = do
                   , cdbThreadRegistry = Args.cdbThreadRegistry args
                   , cdbGcDelay        = Args.cdbGcDelay        args
                   , cdbBgThreads      = varBgThreads
+                  , cdbEpochInfo      = Args.cdbEpochInfo      args
                   }
     h <- fmap CDBHandle $ atomically $ newTVar $ ChainDbOpen env
     let chainDB = ChainDB

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -162,6 +162,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , lgrMemPolicy        = cdbMemPolicy
         , lgrDiskPolicy       = cdbDiskPolicy
         , lgrGenesis          = cdbGenesis
+        , lgrTracer           = contramap TraceLedgerEvent cdbTracer
         }
     , ChainDbSpecificArgs {
           cdbsTracer          = cdbTracer

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -27,7 +27,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.ThreadRegistry (ThreadRegistry)
 
-import           Ouroboros.Storage.Common
+import           Ouroboros.Storage.EpochInfo (EpochInfo)
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling,
                      ThrowCantCatch)
@@ -73,7 +73,7 @@ data ChainDbArgs m blk = forall h1 h2 h3. ChainDbArgs {
 
       -- Integration
     , cdbNodeConfig       :: NodeConfig (BlockProtocol blk)
-    , cdbEpochSize        :: EpochNo -> m EpochSize
+    , cdbEpochInfo        :: EpochInfo m
     , cdbIsEBB            :: blk -> Maybe (HeaderHash blk)
     , cdbGenesis          :: m (ExtLedgerState blk)
 
@@ -136,7 +136,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , immEncodeHash       = cdbEncodeHash
         , immEncodeBlock      = cdbEncodeBlock
         , immErr              = cdbErrImmDb
-        , immEpochSize        = cdbEpochSize
+        , immEpochInfo        = cdbEpochInfo
         , immValidation       = cdbValidation
         , immIsEBB            = cdbIsEBB
         , immHasFS            = cdbHasFSImmDb
@@ -208,7 +208,7 @@ toChainDbArgs ImmDB.ImmDbArgs{..}
     , cdbDiskPolicy       = lgrDiskPolicy
       -- Integration
     , cdbNodeConfig       = lgrNodeConfig
-    , cdbEpochSize        = immEpochSize
+    , cdbEpochInfo        = immEpochInfo
     , cdbIsEBB            = immIsEBB
     , cdbGenesis          = lgrGenesis
       -- Misc

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
@@ -27,7 +27,7 @@ module Ouroboros.Storage.ChainDB.Impl.Background
   ) where
 
 import           Control.Exception (assert)
-import           Control.Monad (forM_, forever)
+import           Control.Monad (forM_, forever, void)
 import           Data.Bifunctor (first)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
@@ -337,12 +337,8 @@ updateLedgerSnapshots
   -> m ()
 updateLedgerSnapshots CDB{..} = do
     -- TODO avoid taking multiple snapshots corresponding to the same tip.
-    (snapshot, pt)   <- LgrDB.takeSnapshot  cdbLgrDB
-    trace $ TookSnapshot snapshot pt
-    deletedSnapshots <- LgrDB.trimSnapshots cdbLgrDB
-    forM_ deletedSnapshots $ trace . DeletedSnapshot
-  where
-    trace = traceWith (contramap TraceLedgerEvent cdbTracer)
+    void $ LgrDB.takeSnapshot  cdbLgrDB
+    void $ LgrDB.trimSnapshots cdbLgrDB
 
 -- | Execute 'updateLedgerSnapshots', wait 'onDiskWriteInterval', and repeat.
 updateLedgerSnapshotsRunner

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE PatternSynonyms           #-}
 {-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
@@ -18,6 +20,9 @@ module Ouroboros.Storage.ChainDB.Impl.LgrDB (
   , defaultArgs
   , openDB
   , reopen
+    -- * 'TraceReplayEvent' decorator
+  , TraceLedgerReplayEvent
+  , decorateReplayTracer
     -- * Wrappers
   , getCurrent
   , setCurrent
@@ -37,12 +42,15 @@ module Ouroboros.Storage.ChainDB.Impl.LgrDB (
   , DiskSnapshot
   , LedgerDB.SwitchResult (..)
   , LedgerDB.PushManyResult (..)
+  , TraceEvent (..)
+  , TraceReplayEvent (..)
   ) where
 
 import           Codec.Serialise.Decoding (Decoder)
 import           Codec.Serialise.Encoding (Encoding)
 import           Control.Monad.Except (runExcept)
 import           Data.Bifunctor (second)
+import           Data.Bitraversable (bitraverse)
 import           Data.Foldable (foldl')
 import           Data.Functor ((<&>))
 import           Data.Set (Set)
@@ -58,7 +66,8 @@ import           Control.Monad.Class.MonadThrow
 
 import           Control.Tracer
 
-import           Ouroboros.Network.Block (HasHeader (..), HeaderHash, Point,
+import           Ouroboros.Network.Block (pattern BlockPoint,
+                     pattern GenesisPoint, HasHeader (..), HeaderHash, Point,
                      SlotNo, StandardHash, blockPoint, castPoint)
 import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Network.Point (WithOrigin (At))
@@ -70,7 +79,7 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util ((.:))
 
 import           Ouroboros.Storage.Common
-import           Ouroboros.Storage.EpochInfo (EpochInfo (..))
+import           Ouroboros.Storage.EpochInfo
 import           Ouroboros.Storage.FS.API (HasFS (hasFsErr),
                      createDirectoryIfMissing)
 import           Ouroboros.Storage.FS.API.Types (FsError, MountPoint (..))
@@ -83,7 +92,8 @@ import           Ouroboros.Storage.LedgerDB.InMemory (Apply (..), RefOrVal (..))
 import qualified Ouroboros.Storage.LedgerDB.InMemory as LedgerDB
 import           Ouroboros.Storage.LedgerDB.MemPolicy (MemPolicy)
 import           Ouroboros.Storage.LedgerDB.OnDisk (DiskSnapshot,
-                     NextBlock (..), StreamAPI (..))
+                     NextBlock (..), StreamAPI (..), TraceEvent (..),
+                     TraceReplayEvent (..))
 import qualified Ouroboros.Storage.LedgerDB.OnDisk as LedgerDB
 
 import           Ouroboros.Storage.ChainDB.API (ChainDbFailure (..))
@@ -134,6 +144,7 @@ data LgrDbArgs m blk = forall h. LgrDbArgs {
     , lgrMemPolicy        :: MemPolicy
     , lgrDiskPolicy       :: DiskPolicy m
     , lgrGenesis          :: m (ExtLedgerState blk)
+    , lgrTracer           :: Tracer m (TraceEvent (Point blk))
     }
 
 -- | Default arguments
@@ -163,6 +174,7 @@ defaultArgs fp = LgrDbArgs {
     , lgrMemPolicy        = error "no default for lgrMemPolicy"
     , lgrDiskPolicy       = error "no default for lgrDiskPolicy"
     , lgrGenesis          = error "no default for lgrGenesis"
+    , lgrTracer           = nullTracer
     }
 
 -- | Open the ledger DB
@@ -174,6 +186,9 @@ openDB :: forall m blk.
           )
        => LgrDbArgs m blk
        -- ^ Stateless initializaton arguments
+       -> Tracer m (TraceReplayEvent (Point blk) () (Point blk))
+       -- ^ Used to trace the progress while replaying blocks against the
+       -- ledger.
        -> ImmDB m blk
        -- ^ Reference to the immutable DB
        --
@@ -186,11 +201,10 @@ openDB :: forall m blk.
        --
        -- The block may be in the immutable DB or in the volatile DB; the ledger
        -- DB does not know where the boundary is at any given point.
-       -> Tracer m (LedgerDB.InitLog (Point blk))
        -> m (LgrDB m blk)
-openDB args@LgrDbArgs{..} immDB getBlock tracer = do
+openDB args@LgrDbArgs{..} replayTracer immDB getBlock = do
     createDirectoryIfMissing lgrHasFS True []
-    db <- initFromDisk args lgrDbConf immDB tracer
+    db <- initFromDisk args replayTracer lgrDbConf immDB
     (varDB, varPrevApplied) <- atomically $
       (,) <$> newTVar db <*> newTVar Set.empty
     return LgrDB {
@@ -226,10 +240,10 @@ reopen :: ( MonadSTM   m
           )
        => LgrDB  m blk
        -> ImmDB  m blk
-       -> Tracer m (LedgerDB.InitLog (Point blk))
+       -> Tracer m (TraceReplayEvent (Point blk) () (Point blk))
        -> m ()
-reopen LgrDB{..} immDB tracer = do
-    db <- initFromDisk args conf immDB tracer
+reopen LgrDB{..} immDB replayTracer = do
+    db <- initFromDisk args replayTracer conf immDB
     atomically $ writeTVar varDB db
 
 initFromDisk :: ( MonadST    m
@@ -237,21 +251,61 @@ initFromDisk :: ( MonadST    m
                 , HasHeader blk
                 )
              => LgrDbArgs m blk
+             -> Tracer m (TraceReplayEvent (Point blk) () (Point blk))
              -> Conf      m blk
              -> ImmDB     m blk
-             -> Tracer    m (LedgerDB.InitLog (Point blk))
              -> m (LedgerDB blk)
-initFromDisk args@LgrDbArgs{..} lgrDbConf immDB tracer = wrapFailure args $ do
-    (initLog, db) <-
+initFromDisk args@LgrDbArgs{..} replayTracer lgrDbConf immDB = wrapFailure args $ do
+    (_initLog, db) <-
       LedgerDB.initLedgerDB
+        replayTracer
+        lgrTracer
         lgrHasFS
         (decodeExtLedgerState lgrDecodeLedger lgrDecodeChainState)
         (Block.decodePoint lgrDecodeHash)
         lgrMemPolicy
         lgrDbConf
         (streamAPI immDB)
-    traceWith tracer initLog
     return db
+
+{-------------------------------------------------------------------------------
+  TraceReplayEvent decorator
+-------------------------------------------------------------------------------}
+
+-- | 'TraceReplayEvent' instantiated with additional information.
+--
+-- The @replayTo@ parameter is instantiated with the 'Point' and 'EpochNo' of
+-- the tip of the ImmutableDB.
+--
+-- The @blockInfo@ parameter is instantiated with the 'EpochNo' of the block
+-- and the 'SlotNo' of the first slot in the epoch.
+type TraceLedgerReplayEvent blk =
+  TraceReplayEvent (Point blk) (Point blk, EpochNo) (EpochNo, SlotNo)
+
+decorateReplayTracer
+  :: forall m blk. Monad m
+  => EpochInfo m
+  -> Point blk
+     -- ^ Tip of the ImmutableDB
+  -> Tracer m (TraceLedgerReplayEvent blk)
+  -> m (Tracer m (TraceReplayEvent (Point blk) () (Point blk)))
+decorateReplayTracer epochInfo immDbTip tracer = do
+    (immDbTipEpoch, _) <- epochNoAndFirstSlot immDbTip
+    return $ Tracer $ \ev -> do
+      decoratedEv <- bitraverse
+        -- Fill in @replayTo@
+        (const $ return (immDbTip, immDbTipEpoch))
+        -- Fill in @blockInfo@
+        epochNoAndFirstSlot
+        ev
+      traceWith tracer decoratedEv
+  where
+    epochNoAndFirstSlot :: Point blk -> m (EpochNo, SlotNo)
+    epochNoAndFirstSlot GenesisPoint          = return (0, 0)
+    epochNoAndFirstSlot BlockPoint { atSlot } = do
+      epoch      <- epochInfoEpoch epochInfo atSlot
+      epochFirst <- epochInfoFirst epochInfo epoch
+      return (epoch, epochFirst)
 
 {-------------------------------------------------------------------------------
   Wrappers
@@ -284,6 +338,7 @@ takeSnapshot :: (MonadSTM m, MonadThrow m, StandardHash blk, Typeable blk)
 takeSnapshot lgrDB@LgrDB{ args = args@LgrDbArgs{..} } = wrapFailure args $ do
     ledgerDB <- atomically $ getCurrent lgrDB
     second tipToPoint <$> LedgerDB.takeSnapshot
+      lgrTracer
       lgrHasFS
       (encodeExtLedgerState lgrEncodeLedger lgrEncodeChainState)
       (Block.encodePoint lgrEncodeHash)
@@ -293,7 +348,7 @@ trimSnapshots :: (MonadThrow m, StandardHash blk, Typeable blk)
               => LgrDB m blk
               -> m [DiskSnapshot]
 trimSnapshots LgrDB{ args = args@LgrDbArgs{..} } = wrapFailure args $
-    LedgerDB.trimSnapshots lgrHasFS lgrDiskPolicy
+    LedgerDB.trimSnapshots lgrTracer lgrHasFS lgrDiskPolicy
 
 getDiskPolicy :: LgrDB m blk -> DiskPolicy m
 getDiskPolicy LgrDB{ args = LgrDbArgs{..} } = lgrDiskPolicy

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -70,6 +70,7 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util ((.:))
 
 import           Ouroboros.Storage.Common
+import           Ouroboros.Storage.EpochInfo (EpochInfo (..))
 import           Ouroboros.Storage.FS.API (HasFS (hasFsErr),
                      createDirectoryIfMissing)
 import           Ouroboros.Storage.FS.API.Types (FsError, MountPoint (..))

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -61,6 +61,9 @@ import           Ouroboros.Consensus.Protocol.Abstract (NodeConfig)
 import           Ouroboros.Consensus.Util.STM (Fingerprint)
 import           Ouroboros.Consensus.Util.ThreadRegistry (ThreadRegistry)
 
+import           Ouroboros.Storage.Common (EpochNo)
+import           Ouroboros.Storage.EpochInfo (EpochInfo)
+
 import           Ouroboros.Storage.ChainDB.API (ChainDbError (..), IteratorId,
                      ReaderId, StreamFrom, StreamTo, UnknownRange)
 
@@ -222,6 +225,7 @@ data ChainDbEnv m blk = CDB
     -- ImmutableDB and garbage collecting it from the VolatileDB
   , cdbBgThreads      :: TVar m [Async m ()]
     -- ^ The background threads.
+  , cdbEpochInfo      :: EpochInfo m
   }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -65,6 +65,7 @@ import           Ouroboros.Consensus.Util.ThreadRegistry
 
 import qualified Ouroboros.Storage.ChainDB as ChainDB
 import           Ouroboros.Storage.ChainDB.Impl (ChainDbArgs (..))
+import           Ouroboros.Storage.EpochInfo (newEpochInfo)
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import           Ouroboros.Storage.FS.Sim.STM (simHasFS)
 import qualified Ouroboros.Storage.ImmutableDB as ImmDB
@@ -249,6 +250,7 @@ broadcastNetwork registry testBtime numCoreNodes pInfo initRNG slotLen = do
         (,,) <$> newTVar Mock.empty
              <*> newTVar Mock.empty
              <*> newTVar Mock.empty
+      epochInfo <- newEpochInfo $ nodeEpochSize (Proxy @blk)
       return ChainDbArgs
         { -- Decoders
           cdbDecodeHash       = nodeDecodeHeaderHash (Proxy @blk)
@@ -275,7 +277,7 @@ broadcastNetwork registry testBtime numCoreNodes pInfo initRNG slotLen = do
         , cdbDiskPolicy       = LgrDB.defaultDiskPolicy (protocolSecurityParam cfg) slotLen
           -- Integration
         , cdbNodeConfig       = cfg
-        , cdbEpochSize        = nodeEpochSize (Proxy @blk)
+        , cdbEpochInfo        = epochInfo
         , cdbIsEBB            = \blk -> if nodeIsEBB blk
                                         then Just (blockHash blk)
                                         else Nothing

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -89,6 +89,7 @@ import qualified Ouroboros.Consensus.Util.ThreadRegistry as ThreadRegistry
 import           Ouroboros.Storage.ChainDB
 import qualified Ouroboros.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Storage.ChainDB.Model as Model
+import           Ouroboros.Storage.EpochInfo (fixedSizeEpochInfo)
 import           Ouroboros.Storage.FS.Sim.MockFS (MockFS)
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import           Ouroboros.Storage.FS.Sim.STM (simHasFS)
@@ -1172,7 +1173,7 @@ mkArgs cfg initLedger tracer registry
 
       -- Integration
     , cdbNodeConfig       = cfg
-    , cdbEpochSize        = const (return 10)
+    , cdbEpochInfo        = fixedSizeEpochInfo 10
     , cdbIsEBB            = const Nothing -- TODO
     , cdbGenesis          = return initLedger
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -875,10 +875,10 @@ deriving instance SOP.Generic         (TraceGCEvent blk)
 deriving instance SOP.HasDatatypeInfo (TraceGCEvent blk)
 deriving instance SOP.Generic         (TraceIteratorEvent blk)
 deriving instance SOP.HasDatatypeInfo (TraceIteratorEvent blk)
-deriving instance SOP.Generic         (TraceLedgerEvent blk)
-deriving instance SOP.HasDatatypeInfo (TraceLedgerEvent blk)
-deriving instance SOP.Generic         (LedgerDB.InitLog r)
-deriving instance SOP.HasDatatypeInfo (LedgerDB.InitLog r)
+deriving instance SOP.Generic         (LedgerDB.TraceEvent r)
+deriving instance SOP.HasDatatypeInfo (LedgerDB.TraceEvent r)
+deriving instance SOP.Generic         (LedgerDB.TraceReplayEvent r replayTo blockInfo)
+deriving instance SOP.HasDatatypeInfo (LedgerDB.TraceReplayEvent r replayTo blockInfo)
 deriving instance SOP.Generic         (ImmDB.TraceEvent e)
 deriving instance SOP.HasDatatypeInfo (ImmDB.TraceEvent e)
 
@@ -1128,9 +1128,8 @@ traceEventName = \case
     TraceOpenEvent           ev    -> "Open."         <> constrName ev
     TraceGCEvent             ev    -> "GC."           <> constrName ev
     TraceIteratorEvent       ev    -> "Iterator."     <> constrName ev
-    TraceLedgerEvent         ev    -> "Ledger."       <> case ev of
-      InitLog                ev' -> constrName ev'
-      _                          -> constrName ev
+    TraceLedgerEvent         ev    -> "Ledger."       <> constrName ev
+    TraceLedgerReplayEvent   ev    -> "LedgerReplay." <> constrName ev
     TraceImmDBEvent          ev    -> "ImmDB."        <> constrName ev
 
 mkArgs :: (MonadSTM m, MonadCatch m, MonadThrow (STM m))

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -49,6 +49,8 @@ import           Data.Word
 import           GHC.Generics (Generic)
 import           System.Random (getStdRandom, randomR)
 
+import           Control.Tracer (nullTracer)
+
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
@@ -639,9 +641,11 @@ runDB standalone@DB{..} cmd =
           fmap switchResultToEither . ledgerDbSwitch conf n (map new bs)
     go hasFS Snap = do
         (_, db) <- atomically $ readTVar dbState
-        Snapped <$> takeSnapshot hasFS S.encode S.encode db
+        Snapped <$> takeSnapshot nullTracer hasFS S.encode S.encode db
     go hasFS Restore = do
         (initLog, db) <- initLedgerDB
+                           nullTracer
+                           nullTracer
                            hasFS
                            S.decode
                            S.decode

--- a/ouroboros-consensus/tools/db-convert/Main.hs
+++ b/ouroboros-consensus/tools/db-convert/Main.hs
@@ -58,6 +58,7 @@ import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
 import Ouroboros.Storage.Common (EpochSize (..))
 import qualified Ouroboros.Storage.LedgerDB.DiskPolicy as LgrDB
 import qualified Ouroboros.Storage.LedgerDB.MemPolicy as LgrDB
+import Ouroboros.Storage.EpochInfo (fixedSizeEpochInfo)
 import Path
 import Path.IO (listDir, createDirIfMissing)
 import qualified Streaming.Prelude as S
@@ -202,7 +203,7 @@ validateChainDb dbDir cfg verbose =
         , ChainDB.cdbDiskPolicy = LgrDB.defaultDiskPolicy securityParam 20000
           -- Integration
         , ChainDB.cdbNodeConfig = pInfoConfig byronProtocolInfo
-        , ChainDB.cdbEpochSize = const (return . EpochSize . unEpochSlots $ epochSlots)
+        , ChainDB.cdbEpochInfo = fixedSizeEpochInfo . EpochSize . unEpochSlots $ epochSlots
         , ChainDB.cdbIsEBB = \blk -> case Byron.unByronBlockOrEBB blk of
           CC.ABOBBlock _ -> Nothing
           CC.ABOBBoundary ebb -> Just (CC.boundaryHashAnnotated ebb)


### PR DESCRIPTION
In particular, trace `ReplayedBlock` while initialising the ledger on
start-up. This process can take a while, certainly when there is no recent
snapshot of the LedgerDB, so we can inform the user of the progress by
tracing.