### PR TITLE
Define constrName(s) once

### DIFF
--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -36,9 +36,9 @@ import qualified Ouroboros.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Storage.ChainDB.Model as Model
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 
-import           Test.Ouroboros.Storage.ChainDB.StateMachine (constrName,
-                     mkArgs)
+import           Test.Ouroboros.Storage.ChainDB.StateMachine (mkArgs)
 import           Test.Ouroboros.Storage.ChainDB.TestBlock
+import           Test.Ouroboros.Storage.Util (constrName)
 
 tests :: TestTree
 tests = testGroup "AddBlock"

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -19,7 +19,6 @@
 module Test.Ouroboros.Storage.ChainDB.StateMachine
   ( tests
   , mkArgs
-  , constrName
   ) where
 
 import           Prelude hiding (elem)
@@ -102,7 +101,7 @@ import qualified Ouroboros.Storage.LedgerDB.OnDisk as LedgerDB
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 
 import           Test.Ouroboros.Storage.ChainDB.TestBlock
-import           Test.Ouroboros.Storage.Util ((=:=))
+import           Test.Ouroboros.Storage.Util (constrName, constrNames, (=:=))
 
 import           Test.Util.RefEnv (RefEnv)
 import qualified Test.Util.RefEnv as RE
@@ -1264,28 +1263,3 @@ emptyRunCmdState = RunCmdState
   , _nextIteratorId = IteratorId 0
   , _nextReaderId   = 0
   }
-
-{-------------------------------------------------------------------------------
-  generics-sop auxiliary
--------------------------------------------------------------------------------}
-
-cmdConstrInfo :: SOP.HasDatatypeInfo a
-              => Proxy a
-              -> SOP.NP SOP.ConstructorInfo (SOP.Code a)
-cmdConstrInfo = SOP.constructorInfo . SOP.datatypeInfo
-
-constrName :: forall a. SOP.HasDatatypeInfo a => a -> String
-constrName a =
-    SOP.hcollapse $ SOP.hliftA2 go (cmdConstrInfo p) (SOP.unSOP (SOP.from a))
-  where
-    go :: SOP.ConstructorInfo b -> SOP.NP SOP.I b -> SOP.K String b
-    go nfo _ = SOP.K $ SOP.constructorName nfo
-
-    p = Proxy @a
-
-constrNames :: SOP.HasDatatypeInfo a => Proxy a -> [String]
-constrNames p =
-    SOP.hcollapse $ SOP.hmap go (cmdConstrInfo p)
-  where
-    go :: SOP.ConstructorInfo a -> SOP.K String a
-    go nfo = SOP.K $ SOP.constructorName nfo

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
@@ -75,7 +75,7 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import qualified Ouroboros.Consensus.Util.Classify as C
 import           Ouroboros.Consensus.Util.Condense
 
-import           Test.Ouroboros.Storage.Util (collects)
+import           Test.Ouroboros.Storage.Util (collects, constrName, constrNames)
 
 import           Test.Util.RefEnv (RefEnv)
 import qualified Test.Util.RefEnv as RE
@@ -1381,27 +1381,3 @@ instance Condense (cmd Symbolic) => Condense (QSM.Commands cmd resp) where
     where
       indent :: String -> String
       indent = ("  " ++)
-
-{-------------------------------------------------------------------------------
-  generics-sop auxiliary
--------------------------------------------------------------------------------}
-
-cmdConstrInfo :: Proxy (Cmd fp h)
-              -> SOP.NP SOP.ConstructorInfo (SOP.Code (Cmd fp h))
-cmdConstrInfo = SOP.constructorInfo . SOP.datatypeInfo
-
-constrName :: forall fp h. Cmd fp h -> String
-constrName a =
-    SOP.hcollapse $ SOP.hliftA2 go (cmdConstrInfo p) (SOP.unSOP (SOP.from a))
-  where
-    go :: SOP.ConstructorInfo a -> SOP.NP SOP.I a -> SOP.K String a
-    go nfo _ = SOP.K $ SOP.constructorName nfo
-
-    p = Proxy @(Cmd fp h)
-
-constrNames :: Proxy (Cmd fp h) -> [String]
-constrNames p =
-    SOP.hcollapse $ SOP.hmap go (cmdConstrInfo p)
-  where
-    go :: SOP.ConstructorInfo a -> SOP.K String a
-    go nfo = SOP.K $ SOP.constructorName nfo

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -84,7 +84,7 @@ import           Test.Ouroboros.Storage.FS.Sim.Error (Errors, mkSimErrorHasFS,
                      withErrors)
 import           Test.Ouroboros.Storage.ImmutableDB.Model
 import           Test.Ouroboros.Storage.ImmutableDB.TestBlock hiding (tests)
-import           Test.Ouroboros.Storage.Util (collects)
+import           Test.Ouroboros.Storage.Util (collects, constrName, constrNames)
 
 import           Test.Util.Orphans.Arbitrary (genSmallEpochNo, genSmallSlotNo)
 import           Test.Util.RefEnv (RefEnv)
@@ -1128,29 +1128,3 @@ dbUnused = error "semantics and DB used during command generation"
 
 hasFsUnused :: HasFS m h
 hasFsUnused = error "HasFS only used during execution"
-
--- TODO use condense?
-
-{-------------------------------------------------------------------------------
-  generics-sop auxiliary
--------------------------------------------------------------------------------}
-
-cmdConstrInfo :: Proxy (Cmd it)
-              -> SOP.NP SOP.ConstructorInfo (SOP.Code (Cmd it))
-cmdConstrInfo = SOP.constructorInfo . SOP.datatypeInfo
-
-constrName :: forall it. Cmd it -> String
-constrName a =
-    SOP.hcollapse $ SOP.hliftA2 go (cmdConstrInfo p) (SOP.unSOP (SOP.from a))
-  where
-    go :: SOP.ConstructorInfo a -> SOP.NP SOP.I a -> SOP.K String a
-    go nfo _ = SOP.K $ SOP.constructorName nfo
-
-    p = Proxy @(Cmd it)
-
-constrNames :: Proxy (Cmd it) -> [String]
-constrNames p =
-    SOP.hcollapse $ SOP.hmap go (cmdConstrInfo p)
-  where
-    go :: SOP.ConstructorInfo a -> SOP.K String a
-    go nfo = SOP.K $ SOP.constructorName nfo

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 module Test.Ouroboros.Storage.Util where
 -- TODO Move to Test.Util.Storage?
 
@@ -14,6 +15,8 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as LC8
 import           Data.String (IsString (..))
 import           Data.Typeable
+
+import qualified Generics.SOP as SOP
 
 import           System.Directory (getTemporaryDirectory)
 import           System.IO.Temp (withTempDirectory)
@@ -210,6 +213,31 @@ x =:= y =
     res = x == y
     interpret True  = " == "
     interpret False = " /= "
+
+{-------------------------------------------------------------------------------
+  generics-sop auxiliary
+-------------------------------------------------------------------------------}
+
+constrInfo :: SOP.HasDatatypeInfo a
+           => proxy a
+           -> SOP.NP SOP.ConstructorInfo (SOP.Code a)
+constrInfo = SOP.constructorInfo . SOP.datatypeInfo
+
+constrName :: forall a. SOP.HasDatatypeInfo a => a -> String
+constrName a =
+    SOP.hcollapse $ SOP.hliftA2 go (constrInfo p) (SOP.unSOP (SOP.from a))
+  where
+    go :: SOP.ConstructorInfo b -> SOP.NP SOP.I b -> SOP.K String b
+    go nfo _ = SOP.K $ SOP.constructorName nfo
+
+    p = Proxy @a
+
+constrNames :: SOP.HasDatatypeInfo a => proxy a -> [String]
+constrNames p =
+    SOP.hcollapse $ SOP.hmap go (constrInfo p)
+  where
+    go :: SOP.ConstructorInfo a -> SOP.K String a
+    go nfo = SOP.K $ SOP.constructorName nfo
 
 {------------------------------------------------------------------------------
   Blob


### PR DESCRIPTION
Closes #709.

We were defining `constrName` and `constrNames` every time we needed them,
instead of just once.

Use `proxy a` instead of `Proxy a`.