### PR TITLE
Remove Ord instances for crypto keys

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -40,43 +40,43 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 565df9739781db7589c7220a9125ea46a615dd40
+  tag: 1121579803319f01612583fc445c50b0a0ce0424
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 565df9739781db7589c7220a9125ea46a615dd40
+  tag: 1121579803319f01612583fc445c50b0a0ce0424
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 565df9739781db7589c7220a9125ea46a615dd40
+  tag: 1121579803319f01612583fc445c50b0a0ce0424
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: d65ccecfc315b7b5447a8548e076d2ee106dbfca
+  tag: 98d818fb3d4e74dd8d9003e14d97733114d8ddc9
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: d65ccecfc315b7b5447a8548e076d2ee106dbfca
+  tag: 98d818fb3d4e74dd8d9003e14d97733114d8ddc9
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: d65ccecfc315b7b5447a8548e076d2ee106dbfca
+  tag: 98d818fb3d4e74dd8d9003e14d97733114d8ddc9
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: d65ccecfc315b7b5447a8548e076d2ee106dbfca
+  tag: 98d818fb3d4e74dd8d9003e14d97733114d8ddc9
   subdir: crypto/test
 
 source-repository-package

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "565df9739781db7589c7220a9125ea46a615dd40";
-      sha256 = "1my4zxxn1blp81sqn8vj2cqbv76zllv1scfjlirfivd6x8jl5xnz";
+      rev = "1121579803319f01612583fc445c50b0a0ce0424";
+      sha256 = "1yk4sk4id4acz568nx78bcgqpnsnx3hivcd65837j3vajc29rwvq";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "565df9739781db7589c7220a9125ea46a615dd40";
-      sha256 = "1my4zxxn1blp81sqn8vj2cqbv76zllv1scfjlirfivd6x8jl5xnz";
+      rev = "1121579803319f01612583fc445c50b0a0ce0424";
+      sha256 = "1yk4sk4id4acz568nx78bcgqpnsnx3hivcd65837j3vajc29rwvq";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -46,8 +46,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "565df9739781db7589c7220a9125ea46a615dd40";
-      sha256 = "1my4zxxn1blp81sqn8vj2cqbv76zllv1scfjlirfivd6x8jl5xnz";
+      rev = "1121579803319f01612583fc445c50b0a0ce0424";
+      sha256 = "1yk4sk4id4acz568nx78bcgqpnsnx3hivcd65837j3vajc29rwvq";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -34,8 +34,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "d65ccecfc315b7b5447a8548e076d2ee106dbfca";
-      sha256 = "1d9wa287n4p5nin5ricmpiar0wmbjn2nzc6dbhc4ak197w712j5f";
+      rev = "98d818fb3d4e74dd8d9003e14d97733114d8ddc9";
+      sha256 = "0vvznrkp26fd1r2nhrhw90ccf1z09s72jh4l170540d9l40y9ysq";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "d65ccecfc315b7b5447a8548e076d2ee106dbfca";
-      sha256 = "1d9wa287n4p5nin5ricmpiar0wmbjn2nzc6dbhc4ak197w712j5f";
+      rev = "98d818fb3d4e74dd8d9003e14d97733114d8ddc9";
+      sha256 = "0vvznrkp26fd1r2nhrhw90ccf1z09s72jh4l170540d9l40y9ysq";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "d65ccecfc315b7b5447a8548e076d2ee106dbfca";
-      sha256 = "1d9wa287n4p5nin5ricmpiar0wmbjn2nzc6dbhc4ak197w712j5f";
+      rev = "98d818fb3d4e74dd8d9003e14d97733114d8ddc9";
+      sha256 = "0vvznrkp26fd1r2nhrhw90ccf1z09s72jh4l170540d9l40y9ysq";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -115,8 +115,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "d65ccecfc315b7b5447a8548e076d2ee106dbfca";
-      sha256 = "1d9wa287n4p5nin5ricmpiar0wmbjn2nzc6dbhc4ak197w712j5f";
+      rev = "98d818fb3d4e74dd8d9003e14d97733114d8ddc9";
+      sha256 = "0vvznrkp26fd1r2nhrhw90ccf1z09s72jh4l170540d9l40y9ysq";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Cardano.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Crypto/DSIGN/Cardano.hs
@@ -30,7 +30,6 @@ import           Cardano.Crypto.DSIGN.Class
 import           Data.ByteString (ByteString)
 import           Data.Coerce (coerce)
 import           Data.Constraint
-import           Data.Function (on)
 import           Data.Proxy (Proxy (..))
 import           Data.Reflection (Given (..))
 import           GHC.Generics (Generic)
@@ -80,7 +79,7 @@ instance Given ProtocolMagicId => DSIGNAlgorithm CardanoDSIGN where
         deriving (Show, Eq, Generic)
 
     newtype SignKeyDSIGN CardanoDSIGN = SignKeyCardanoDSIGN SigningKey
-        deriving (Show, Eq, Generic)
+        deriving (Show, Generic)
 
     newtype SigDSIGN CardanoDSIGN = SigCardanoDSIGN (Signature CC.Block.ToSign)
         deriving (Show, Eq, Generic)
@@ -109,15 +108,6 @@ instance Given ProtocolMagicId => DSIGNAlgorithm CardanoDSIGN where
         if verifySignatureRaw vk (Crypto.signTag given (signTagFor a) <> recoverBytes a) $ coerce sig
           then Right ()
           else Left "Verification failed"
-
-instance Ord (VerKeyDSIGN CardanoDSIGN) where
-    compare = compare `on` show
-
-instance Ord (SignKeyDSIGN CardanoDSIGN) where
-    compare = compare `on` show
-
-instance Ord (SigDSIGN CardanoDSIGN) where
-    compare = compare `on` show
 
 instance Condense (SigDSIGN CardanoDSIGN) where
     condense (SigCardanoDSIGN s) = show s

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
@@ -52,7 +52,7 @@ data PBftLeaderCredentials = PBftLeaderCredentials {
       plcSignKey     :: Crypto.SigningKey
     , plcDlgCert     :: Delegation.Certificate
     , plcCodeNodeId  :: CoreNodeId
-    } deriving (Eq, Show)
+    } deriving Show
 
 -- | Make the 'PBftLeaderCredentials', with a couple sanity checks:
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -138,11 +138,9 @@ instance ToCBOR VRFType where
 
 deriving instance PraosCrypto c => Show (PraosExtraFields c)
 deriving instance PraosCrypto c => Eq   (PraosExtraFields c)
-deriving instance PraosCrypto c => Ord  (PraosExtraFields c)
 
 deriving instance PraosCrypto c => Show (PraosFields c toSign)
 deriving instance PraosCrypto c => Eq   (PraosFields c toSign)
-deriving instance PraosCrypto c => Ord  (PraosFields c toSign)
 
 data PraosProof c = PraosProof {
       praosProofRho  :: CertifiedVRF (PraosVRF c) (Natural, SlotNo, VRFType)

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,14 +19,14 @@ extra-deps:
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 565df9739781db7589c7220a9125ea46a615dd40
+    commit: 1121579803319f01612583fc445c50b0a0ce0424
     subdirs:
       - binary
       - binary/test
       - cardano-crypto-class
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: d65ccecfc315b7b5447a8548e076d2ee106dbfca
+    commit: 98d818fb3d4e74dd8d9003e14d97733114d8ddc9
     subdirs:
       - cardano-ledger
       - cardano-ledger/test


### PR DESCRIPTION
The pattern that our crypto libraries use is that they deliberately do not provide Ord instances for keys (verification or signing keys). Instead our crypto library encourage the use of comparisons on key hashes.

This patch removes Ord instances for keys and signatures. It removes Eq instances for signing keys. It keeps Eq instances for verification keys and signatures.

Update the ledger and cardano-prelude dependencies to use the crypto classes that also remove these instances and constraints.