### PR TITLE
Avoid ChainDB Iterator and Reader leaks with a ResourceRegistry

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -90,6 +90,7 @@ library
                        Ouroboros.Consensus.Util.HList
                        Ouroboros.Consensus.Util.Orphans
                        Ouroboros.Consensus.Util.Random
+                       Ouroboros.Consensus.Util.ResourceRegistry
                        Ouroboros.Consensus.Util.STM
                        Ouroboros.Consensus.Util.Singletons
                        Ouroboros.Consensus.Util.SlotBounded

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
@@ -20,6 +20,7 @@ import           Ouroboros.Storage.ChainDB.API (ChainDB, Reader)
 import qualified Ouroboros.Storage.ChainDB.API as ChainDB
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
 
 -- | Chain Sync Server for block headers for a given a 'ChainDB'.
@@ -31,10 +32,11 @@ chainSyncHeadersServer
     :: forall m blk. MonadSTM m
     => Tracer m (TraceChainSyncServerEvent blk)
     -> ChainDB m blk
+    -> ResourceRegistry m
     -> ChainSyncServer (Header blk) (Point blk) m ()
-chainSyncHeadersServer tracer chainDB =
+chainSyncHeadersServer tracer chainDB registry =
     ChainSyncServer $ do
-      rdr <- ChainDB.newHeaderReader chainDB
+      rdr <- ChainDB.newHeaderReader chainDB registry
       let ChainSyncServer server = chainSyncServerForReader tracer chainDB rdr
       server
 
@@ -47,10 +49,11 @@ chainSyncBlocksServer
     :: forall m blk. MonadSTM m
     => Tracer m (TraceChainSyncServerEvent blk)
     -> ChainDB m blk
+    -> ResourceRegistry m
     -> ChainSyncServer blk (Point blk) m ()
-chainSyncBlocksServer tracer chainDB =
+chainSyncBlocksServer tracer chainDB registry =
     ChainSyncServer $ do
-      rdr <- ChainDB.newBlockReader chainDB
+      rdr <- ChainDB.newBlockReader chainDB registry
       let ChainSyncServer server = chainSyncServerForReader tracer chainDB rdr
       server
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | A resource registry that allows registering clean-up actions that will be
+-- run when the resource registry is closed.
+--
+-- Inspired by @resource-simple@.
+module Ouroboros.Consensus.Util.ResourceRegistry
+  ( ResourceRegistry
+  , ResourceKey -- Abstract
+  , allocate
+  , release
+  , new
+  , close
+  , with
+    -- * For testing purposes
+  , nbCleanups
+  ) where
+
+import           Control.Monad (forM)
+import           Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IntMap
+import           Data.Maybe (catMaybes, listToMaybe)
+import           Data.Tuple (swap)
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+-- | A registry of resources with clean-up actions associated to them.
+data ResourceRegistry m = ResourceRegistry
+  { _registered :: !(TVar m (IntMap (m ())))
+    -- ^ The registered clean-up actions
+  , _nextKey    :: !(TVar m Int)
+    -- ^ The next value to use for the 'ResourceKey' of the next clean-up
+    -- action.
+  }
+
+-- | A key given after registering a clean-up action. This key can be used to
+-- 'unregister' it.
+newtype ResourceKey = ResourceKey Int
+
+-- | Register a clean-up action that will be run when the 'ResourceRegistry'
+-- is closed, unless it is 'unregister'ed before that happens.
+register :: MonadSTM m => ResourceRegistry m -> m () -> STM m ResourceKey
+register ResourceRegistry { _registered, _nextKey } cleanup = do
+    key <- readTVar _nextKey
+    writeTVar _nextKey $! succ key
+    modifyTVar' _registered $ IntMap.insertWith
+      (error $ "bug: key already registered: " <> show key)
+      key
+      cleanup
+    return $ ResourceKey key
+
+-- | Allocate a resource and register the corresponding clean-up action so
+-- that it will be run when the 'ResourceRegistry' is closed.
+--
+-- This deals with masking asynchronous exceptions.
+allocate :: (MonadSTM m, MonadMask m)
+         => ResourceRegistry m
+         -> m a         -- ^ Create resource
+         -> (a -> m ()) -- ^ Clean-up resource
+         -> m (ResourceKey, a)
+allocate registry create cleanup = mask $ \unmask -> do
+    resource <- unmask create
+    key      <- atomically $ register registry (cleanup resource)
+    return (key, resource)
+
+-- | Call a clean-up action and unregister it from the 'ResourceRegistry'.
+--
+-- Idempotent: noop when the clean-up action has already been unregistered.
+--
+-- Any exception thrown by the clean-up action is propagated.
+release :: forall m. MonadSTM m => ResourceRegistry m -> ResourceKey -> m ()
+release ResourceRegistry { _registered } (ResourceKey key) = do
+    mbCleanup <- atomically $ updateTVar' _registered $
+      swap . IntMap.updateLookupWithKey (\_ _ -> Nothing) key
+    sequence_ mbCleanup
+
+-- | Create new resource registry.
+new :: MonadSTM m => m (ResourceRegistry m)
+new = atomically $ do
+    _registered <- newTVar IntMap.empty
+    _nextKey    <- newTVar 1
+    return ResourceRegistry { _registered, _nextKey }
+
+-- | Close the resource registry. All registered clean-up actions are run with
+-- exceptions masked. Depending on the resources managed, this may or may not
+-- be time consuming.
+--
+-- In case one or more clean-up actions throw an exception, the remaining
+-- clean-up actions will be executed first, and one of the thrown exceptions
+-- will be rethrown (which one is undefined) at the end.
+--
+-- After closing a 'ResourceRegistry', it should no longer be used. This means
+-- that a 'ResourceRegistry' can only be closed once.
+close :: (MonadSTM m, MonadMask m) => ResourceRegistry m -> m ()
+close ResourceRegistry { _registered } = do
+    cleanups <- atomically $ do
+      cleanups <- IntMap.elems <$> readTVar _registered
+      writeTVar _registered $ error msg
+      return cleanups
+    mbEx <- fmap firstJust $ mask_ $ forM cleanups $ \cleanup ->
+      either (\(e :: SomeException) -> Just e) (const Nothing) <$> try cleanup
+    mapM_ throwM mbEx
+  where
+    msg = "ResourceRegistry used after closing"
+
+    firstJust :: forall a. [Maybe a] -> Maybe a
+    firstJust = listToMaybe . catMaybes
+
+-- | Bracketed variant.
+with :: (MonadSTM m, MonadMask m) => (ResourceRegistry m -> m a) -> m a
+with = bracket new close
+
+-- | Return the number of registered clean-up actions in the
+-- 'ResourceRegistry'.
+--
+-- Useful for testing purposes.
+nbCleanups :: MonadSTM m => ResourceRegistry m -> m Int
+nbCleanups ResourceRegistry { _registered } = atomically $
+    IntMap.size <$> readTVar _registered

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
@@ -340,6 +340,10 @@ instructionHelper registry fromMaybeSTM fromPure CDB{..} varReader = do
         atomically $ writeTVar varReader readerState'
         return $ fromPure $ AddBlock $ Right blk
       Nothing  -> do
+        -- Even though an iterator is automatically closed internally when
+        -- exhausted, we close it again (idempotent), but this time to
+        -- unregister the associated clean-up action.
+        ImmDB.iteratorClose cdbImmDB immIt
         -- The iterator is exhausted: we've reached the end of the
         -- ImmutableDB, or actually what was the end of the ImmutableDB at the
         -- time of opening the iterator. We must now check whether that is

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
@@ -20,7 +20,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Util ((..:), (.:))
+import           Ouroboros.Consensus.Util ((..:))
 import           Ouroboros.Consensus.Util.STM (blockUntilJust)
 
 import           Ouroboros.Storage.ChainDB.API
@@ -116,9 +116,9 @@ openDB cfg initLedger = do
       , getTipPoint         = querySTM $ Model.tipPoint
       , getIsFetched        = querySTM $ flip Model.hasBlockByPoint
       , getIsInvalidBlock   = querySTM $ (first (flip Map.member)) . Model.invalid
-      , streamBlocks        = updateE  .: (fmap (first (fmap iterator)) ..: Model.streamBlocks k)
-      , newBlockReader      = update   $ (first reader . Model.readBlocks)
-      , newHeaderReader     = update   $ (first (fmap getHeader . reader) . Model.readBlocks)
+      , streamBlocks        = updateE  ..: const (fmap (first (fmap iterator)) ..: Model.streamBlocks k)
+      , newBlockReader      = update   .   const (first reader . Model.readBlocks)
+      , newHeaderReader     = update   .   const (first (fmap getHeader . reader) . Model.readBlocks)
 
       , closeDB             = atomically $ modifyTVar' db Model.closeDB
       , isOpen              = Model.isOpen <$> readTVar db

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -371,7 +371,7 @@ newtype TestOutput blk = TestOutput
 getTestOutput ::
     forall m blk.
        ( MonadSTM m
-       , MonadThrow m
+       , MonadMask m
        , HasHeader blk
        )
     => [( CoreNodeId

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -26,6 +26,7 @@ import           Ouroboros.Network.MockChain.Chain (Chain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
 import           Ouroboros.Consensus.Util.Condense (condense)
+import qualified Ouroboros.Consensus.Util.ResourceRegistry as ResourceRegistry
 
 import           Ouroboros.Storage.ChainDB.API (Iterator (..), IteratorId (..),
                      IteratorResult (..), StreamFrom (..), StreamTo (..),
@@ -219,11 +220,11 @@ runIterator
   -> StreamFrom TestBlock
   -> StreamTo   TestBlock
   -> ([TraceIteratorEvent TestBlock], IterRes)
-runIterator setup from to = runSimOrThrow $ do
+runIterator setup from to = runSimOrThrow $ ResourceRegistry.with $ \r -> do
     (tracer, getTrace) <- recordingTracerTVar
     itEnv <- initIteratorEnv setup tracer
     res <- runExceptT $ do
-      it <- ExceptT $ newIterator itEnv ($ itEnv) from to
+      it <- ExceptT $ newIterator itEnv ($ itEnv) r from to
       lift $ consume it
     trace <- getTrace
     return (trace, res)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -17,6 +17,8 @@ import           Control.Monad.IOSim
 import           Ouroboros.Network.MockChain.Chain (Chain (..), ChainUpdate)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
+import qualified Ouroboros.Consensus.Util.ResourceRegistry as ResourceRegistry
+
 import           Ouroboros.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Storage.ChainDB.API as ChainDB
 import qualified Ouroboros.Storage.ChainDB.Mock as Mock
@@ -44,9 +46,9 @@ prop_reader bt p = runSimOrThrow test
     blocks = permute p $ treeToBlocks bt
 
     test :: forall s. SimM s Property
-    test = do
+    test = ResourceRegistry.with $ \registry -> do
         db       <- openDB
-        reader   <- ChainDB.newBlockReader db
+        reader   <- ChainDB.newBlockReader db registry
         chainVar <- atomically $ newTVar Genesis
 
         -- Fork a thread that applies all instructions from the reader


### PR DESCRIPTION
Closes #896.

To obtain a ChainDB iterator or reader, a `ResourceRegistry` must be passed.
That `ResourceRegistry` will be used to register all ImmutableDB iterators it
opens. These iterators hold on to file handles and are the ones we don't want
to leak when an exception is thrown.

The `ProtocolHandlers` that use ChainDB iterators (`BlockFetchServer`) and
readers (`ChainSyncServer`) now take a `ResourceRegistry` as an argument. When
the protocol thread starts, the registry is created and when the thread
terminates, because of normal termination or because an exception is thrown,
the registry is closed, running the clean-up of the registered resources.

At the end of the ChainDB q-s-m test, we check that no clean-up actions are
still registered after shutting down the ChainDB (which closes all open
iterators and readers).