### PR TITLE
ChainDB.ImmDB: fix bug in getBlockWithPoint

### DIFF
--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -118,6 +118,8 @@
           depends = [
             (hsPkgs.base)
             (hsPkgs.cardano-crypto-class)
+            (hsPkgs.cardano-ledger)
+            (hsPkgs.cardano-ledger-test)
             (hsPkgs.ouroboros-network)
             (hsPkgs.ouroboros-network-testing)
             (hsPkgs.ouroboros-consensus)
@@ -137,6 +139,7 @@
             (hsPkgs.QuickCheck)
             (hsPkgs.quickcheck-state-machine)
             (hsPkgs.random)
+            (hsPkgs.reflection)
             (hsPkgs.serialise)
             (hsPkgs.tasty)
             (hsPkgs.tasty-hunit)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -310,6 +310,7 @@ test-suite test-storage
                     Test.Ouroboros.Storage
                     Test.Ouroboros.Storage.ChainDB
                     Test.Ouroboros.Storage.ChainDB.AddBlock
+                    Test.Ouroboros.Storage.ChainDB.ImmDB
                     Test.Ouroboros.Storage.ChainDB.Iterator
                     Test.Ouroboros.Storage.ChainDB.Mock
                     Test.Ouroboros.Storage.ChainDB.Model
@@ -340,6 +341,8 @@ test-suite test-storage
                     Test.Util.Tracer
   build-depends:    base,
                     cardano-crypto-class,
+                    cardano-ledger,
+                    cardano-ledger-test,
                     ouroboros-network,
                     ouroboros-network-testing,
                     ouroboros-consensus,
@@ -360,6 +363,7 @@ test-suite test-storage
                     QuickCheck,
                     quickcheck-state-machine >=0.6.0,
                     random,
+                    reflection,
                     serialise,
                     tasty,
                     tasty-hunit,

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
@@ -5,6 +5,8 @@
 module Ouroboros.Consensus.Ledger.Byron.Forge (
     forgeBlock
   , forgeBlockOrEBB
+    -- * For testing purposes
+  , forgeGenesisEBB
   ) where
 
 import           Control.Monad (void)
@@ -50,22 +52,16 @@ forgeBlockOrEBB
   -> PBftIsLeader PBftCardanoCrypto    -- ^ Leader proof ('IsLeader')
   -> m (ByronBlockOrEBB ByronConfig)
 forgeBlockOrEBB cfg curSlot curNo prevHash txs isLeader = case prevHash of
-  GenesisHash -> forgeGenesisEBB cfg curSlot
+  GenesisHash -> return $ forgeGenesisEBB cfg curSlot
   BlockHash _ -> forgeBlock cfg curSlot curNo prevHash txs isLeader
 
 forgeGenesisEBB
-  :: forall m.
-     ( HasNodeState_ () m  -- @()@ is the @NodeState@ of PBFT
-     , MonadRandom m
-       -- TODO: This 'Given' constraint should not be needed (present in config)
-     , Given Crypto.ProtocolMagicId
-     )
+  :: Given Crypto.ProtocolMagicId
   => NodeConfig ByronEBBExtNodeConfig
   -> SlotNo
-  -> m (ByronBlockOrEBB ByronConfig)
-forgeGenesisEBB (WithEBBNodeConfig cfg) curSlot = do
-    return
-      . ByronBlockOrEBB
+  -> ByronBlockOrEBB ByronConfig
+forgeGenesisEBB (WithEBBNodeConfig cfg) curSlot =
+        ByronBlockOrEBB
       . CC.Block.ABOBBoundary
       . annotateBoundary given
       $ boundaryBlock

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB.hs
@@ -5,6 +5,7 @@ module Test.Ouroboros.Storage.ChainDB (
 import           Test.Tasty
 
 import qualified Test.Ouroboros.Storage.ChainDB.AddBlock as AddBlock
+import qualified Test.Ouroboros.Storage.ChainDB.ImmDB as ImmDB
 import qualified Test.Ouroboros.Storage.ChainDB.Iterator as Iterator
 import qualified Test.Ouroboros.Storage.ChainDB.Mock as Mock
 import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
@@ -13,6 +14,7 @@ import qualified Test.Ouroboros.Storage.ChainDB.StateMachine as StateMachine
 tests :: TestTree
 tests = testGroup "ChainDB" [
       AddBlock.tests
+    , ImmDB.tests
     , Iterator.tests
     , Model.tests
     , Mock.tests

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+module Test.Ouroboros.Storage.ChainDB.ImmDB
+  ( tests
+  ) where
+
+import           Data.Proxy (Proxy (..))
+import           Data.Reflection (give)
+
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.IOSim (runSimOrThrow)
+
+import           Control.Tracer (nullTracer)
+
+import qualified Cardano.Chain.Genesis as Genesis
+import qualified Cardano.Chain.Update as Update
+
+import           Ouroboros.Network.Block (SlotNo (..), blockHash, blockPoint)
+
+import           Ouroboros.Consensus.Block (BlockProtocol)
+import           Ouroboros.Consensus.Ledger.Byron (ByronBlockOrEBB, ByronGiven)
+import           Ouroboros.Consensus.Ledger.Byron.Config (ByronConfig)
+import           Ouroboros.Consensus.Ledger.Byron.Forge (forgeGenesisEBB)
+import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
+                     PBftSignatureThreshold (..), ProtocolInfo (..),
+                     protocolInfo)
+import           Ouroboros.Consensus.Node.Run (RunNode (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
+import           Ouroboros.Consensus.Protocol
+
+import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB, ImmDbArgs (..))
+import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
+import           Ouroboros.Storage.EpochInfo (newEpochInfo)
+import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
+import           Ouroboros.Storage.FS.Sim.STM (simHasFS)
+import           Ouroboros.Storage.ImmutableDB
+                     (ValidationPolicy (ValidateMostRecentEpoch))
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import qualified Test.Cardano.Chain.Genesis.Dummy as Dummy
+
+
+tests :: TestTree
+tests = testGroup "ImmDB"
+    [ testCase "getBlockWithPoint EBB at tip" test_getBlockWithPoint_EBB_at_tip
+    ]
+
+test_getBlockWithPoint_EBB_at_tip :: Assertion
+test_getBlockWithPoint_EBB_at_tip =
+    runSimOrThrow $ giveByron $ withImmDB $ \immDB -> do
+      ImmDB.appendBlock immDB ebb
+      mbEbb' <- ImmDB.getBlockWithPoint immDB (blockPoint ebb)
+      return $ mbEbb' @?= Just ebb
+  where
+    ebb = giveByron $ forgeGenesisEBB testCfg (SlotNo 0)
+
+withImmDB :: forall m blk a.
+             ( MonadCatch m
+             , MonadST    m
+             , MonadSTM   m
+             , ByronGiven
+             , blk ~ ByronBlockOrEBB ByronConfig
+             )
+          => (ImmDB m blk -> m a) -> m a
+withImmDB k = do
+    immDbFsVar <- atomically $ newTVar Mock.empty
+    epochInfo  <- newEpochInfo $ nodeEpochSize (Proxy @blk)
+    bracket (ImmDB.openDB (mkArgs immDbFsVar epochInfo)) ImmDB.closeDB k
+  where
+    mkArgs immDbFsVar epochInfo = ImmDbArgs
+      { immErr         = EH.monadCatch
+      , immHasFS       = simHasFS EH.monadCatch immDbFsVar
+      , immDecodeHash  = nodeDecodeHeaderHash (Proxy @blk)
+      , immDecodeBlock = nodeDecodeBlock testCfg
+      , immEncodeHash  = nodeEncodeHeaderHash (Proxy @blk)
+      , immEncodeBlock = nodeEncodeBlock testCfg
+      , immEpochInfo   = epochInfo
+      , immValidation  = ValidateMostRecentEpoch
+      , immIsEBB       = \blk -> if nodeIsEBB blk
+                                 then Just (blockHash blk)
+                                 else Nothing
+      , immTracer      = nullTracer
+      }
+
+testCfg :: NodeConfig (BlockProtocol (ByronBlockOrEBB ByronConfig))
+testCfg = pInfoConfig $ protocolInfo (NumCoreNodes 1) (CoreNodeId 0) prot
+  where
+    prot = ProtocolRealPBFT
+      Dummy.dummyConfig
+      (Just (PBftSignatureThreshold 0.5))
+      (Update.ProtocolVersion 1 0 0)
+      (Update.SoftwareVersion (Update.ApplicationName "Cardano Test") 2)
+      Nothing
+
+giveByron :: forall a. (ByronGiven => a) -> a
+giveByron a =
+  give (Genesis.gdProtocolMagicId Dummy.dummyGenesisData) $
+  give Dummy.dummyEpochSlots a


### PR DESCRIPTION
Calling `ImmDB.getBlockWithPoint` with a point that corresponds to the EBB at
the tip of the ImmutableDB results in a `ReadFutureSlotError` because we first
try to read the block at the slot, which is indeed in the future.

Nicolas Frisby discovered this bug in:
https://github.com/input-output-hk/ouroboros-network/pull/773#issuecomment-520550499

Fix this by first trying to read the EBB in this exceptional scenario.

Also add a unit test that triggers this rare case.