### PR TITLE
Make the StartTime part of RunNode

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
@@ -19,6 +19,7 @@ import           Ouroboros.Network.Block (BlockNo, ChainHash (..), HeaderHash,
 import           Ouroboros.Network.BlockFetch (SizeInBytes)
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.BlockchainTime (SystemStart)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Byron
 import           Ouroboros.Consensus.Mempool
@@ -42,6 +43,10 @@ class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
   nodeIsEBB              :: blk -> Bool
   nodeEpochSize          :: Monad m
                          => Proxy blk  -> EpochNo -> m EpochSize
+  nodeStartTime          :: Proxy blk
+                         -> NodeConfig (BlockProtocol blk)
+                         -> SystemStart
+
 
   -- Encoders
   nodeEncodeBlock        :: NodeConfig (BlockProtocol blk) -> blk -> Encoding

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -7,11 +7,15 @@ module Ouroboros.Consensus.Node.Run.Byron () where
 import           Data.Reflection (given)
 
 import qualified Cardano.Chain.Block as Cardano.Block
-import           Ouroboros.Consensus.Ledger.Byron
-import           Ouroboros.Consensus.Node.Run.Abstract
+import qualified Cardano.Chain.Genesis as Genesis
 
+import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
+import           Ouroboros.Consensus.Ledger.Byron
 import           Ouroboros.Consensus.Ledger.Byron.Config
 import           Ouroboros.Consensus.Ledger.Byron.Forge
+import           Ouroboros.Consensus.Node.Run.Abstract
+import           Ouroboros.Consensus.Protocol.ExtNodeConfig
+import           Ouroboros.Consensus.Protocol.WithEBBs
 
 {-------------------------------------------------------------------------------
   RunNode instance
@@ -25,6 +29,15 @@ instance ByronGiven => RunNode (ByronBlockOrEBB ByronConfig) where
     Cardano.Block.ABOBBlock _    -> False
     Cardano.Block.ABOBBoundary _ -> True
   nodeEpochSize          = \_ _ -> return 21600 -- TODO #226
+
+  -- Extract it from the 'Genesis.Config'
+  nodeStartTime          = const
+                         $ SystemStart
+                         . Genesis.gdStartTime
+                         . Genesis.configGenesisData
+                         . pbftGenesisConfig
+                         . encNodeConfigExt
+                         . unWithEBBNodeConfig
 
   nodeEncodeBlock        = const encodeByronBlock
   nodeEncodeHeader       = const encodeByronHeader

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
@@ -6,9 +6,12 @@
 module Ouroboros.Consensus.Node.Run.Mock () where
 
 import           Codec.Serialise (Serialise, decode, encode)
+import           Data.Time.Calendar (fromGregorian)
+import           Data.Time.Clock (UTCTime (..))
 import           Data.Typeable (Typeable)
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Node.Run.Abstract
@@ -37,6 +40,10 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
   nodeBlockFetchSize     = fromIntegral . simpleBlockSize . simpleHeaderStd
   nodeIsEBB              = const False
   nodeEpochSize          = \_ _ -> return 21600
+  nodeStartTime          = \_ _ -> SystemStart dummyDate
+    where
+      --  This doesn't matter much
+      dummyDate = UTCTime (fromGregorian 2019 8 13) 0
 
   nodeEncodeBlock        = const encode
   nodeEncodeHeader       = const encode


### PR DESCRIPTION
When starting a node, the `nodeStartTime` method can be used to obtain the
start time. This method will return the right time for each block type, and
thus protocol. For example, for real Byron blocks, it will extract it from the
Genesis config. For mock blocks, it will just use some hard-coded dummy date,
since the start time is not important for mock blocks.