### PR TITLE
Make the slot duration part of RunNode

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
@@ -24,6 +24,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Byron
 import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.BlockchainTime (SlotLength)
 
 import           Ouroboros.Storage.Common (EpochNo, EpochSize)
 
@@ -43,10 +44,12 @@ class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
   nodeIsEBB              :: blk -> Bool
   nodeEpochSize          :: Monad m
                          => Proxy blk  -> EpochNo -> m EpochSize
+  nodeSlotDuration       :: Proxy blk
+                         -> NodeConfig (BlockProtocol blk)
+                         -> SlotLength
   nodeStartTime          :: Proxy blk
                          -> NodeConfig (BlockProtocol blk)
                          -> SystemStart
-
 
   -- Encoders
   nodeEncodeBlock        :: NodeConfig (BlockProtocol blk) -> blk -> Encoding

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -8,8 +8,9 @@ import           Data.Reflection (given)
 
 import qualified Cardano.Chain.Block as Cardano.Block
 import qualified Cardano.Chain.Genesis as Genesis
+import qualified Cardano.Chain.Update as PPrams
 
-import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
+import           Ouroboros.Consensus.BlockchainTime (SystemStart (..), slotLengthFromMillisec)
 import           Ouroboros.Consensus.Ledger.Byron
 import           Ouroboros.Consensus.Ledger.Byron.Config
 import           Ouroboros.Consensus.Ledger.Byron.Forge
@@ -29,6 +30,15 @@ instance ByronGiven => RunNode (ByronBlockOrEBB ByronConfig) where
     Cardano.Block.ABOBBlock _    -> False
     Cardano.Block.ABOBBoundary _ -> True
   nodeEpochSize          = \_ _ -> return 21600 -- TODO #226
+  nodeSlotDuration       = const
+                         $ slotLengthFromMillisec
+                         . fromIntegral
+                         . PPrams.ppSlotDuration
+                         . Genesis.gdProtocolParameters
+                         . Genesis.configGenesisData
+                         . pbftGenesisConfig
+                         . encNodeConfigExt
+                         . unWithEBBNodeConfig
 
   -- Extract it from the 'Genesis.Config'
   nodeStartTime          = const

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
@@ -11,7 +11,7 @@ import           Data.Time.Clock (UTCTime (..))
 import           Data.Typeable (Typeable)
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
+import           Ouroboros.Consensus.BlockchainTime (SystemStart (..), slotLengthFromMillisec)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Node.Run.Abstract
@@ -44,6 +44,7 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
     where
       --  This doesn't matter much
       dummyDate = UTCTime (fromGregorian 2019 8 13) 0
+  nodeSlotDuration       = \_ _ -> slotLengthFromMillisec 20000
 
   nodeEncodeBlock        = const encode
   nodeEncodeHeader       = const encode


### PR DESCRIPTION
When starting a node, the `nodeSlotDuration` method can be used to obtain the
slot duration.  For example, for real Byron blocks, it will extract the slot duration from the protocol parameters in the Genesis config. For mock blocks, it will just use a hard coded slot duration.
