### PR TITLE
allow closed parent in forkLinkedTransfer

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
@@ -119,6 +119,7 @@ onEachChange registry f mbInitB getA notify = do
 runWhenJust :: ( MonadMask  m
                , MonadFork  m
                , MonadAsync m
+               , HasCallStack
                )
             => ResourceRegistry m
             -> STM m (Maybe a)


### PR DESCRIPTION
While rebasing #773, I noticed that a `forkLinkedTransfer` call was no longer propagating exceptions. This patch seems to resolve that and also improves the available information when debugging.

My explanation: when a child is spawned with `forkLinkedTransfer`, its "clean-up" phase is built in several steps, from innermost/first to outermost/last.

  1. transfer its clean-ups to its parent (via a `finally` in `forkLinkedTransfer`)
  1. run its own cleanups (via `with` in `forkLinkedTransfer`)
  1. propagate any exceptions to its parent (via a `catch` in `forkLinked`)
  1. release itself from its parent registry (via a `finally` in `fork`)

If thread A spawns thread B via `forkLinkedTransfer` but then terminates and thus `close`s its registry _before_ thread B terminates, then the first/innermost step above fails via `error _ :: m a`. This spoils the correct behavior of the remaining steps.

That `error` arises because the `close` of A's registry first swaps in an `error` thunk for the cleanups in its `_registered` `TVar` and then invokes the cleanups. One of those cleanups will cancel thread B. This causes B's registry to attempt to transfer its own cleanups to A's registry, but the destination `TVar`'s contents has already been replaced by the `error` thunk, which is demanded, prematurely ending the normal shutdown.

This PR as-of-being-opened replaces the `error` thunk in the `TVar` by an inspectable tombstone. In all other cases, finding tombstone still causes a similar `error`, except in the `forkLinkedTransfer` `finally` in which it simply causes the transfer to be skipped: since the parent is already closed, the child should just run its cleanups as it naturally will in the subsequent second step above.

Note: PR #914 includes "TODO: consensus tests are failing with:", but it's unclear if that was resolved before the PR was merged. If not, then I think this PR will resolve that issue -- it's one of the ways it was manifesting while I debugged it on #773.