### PR TITLE
Reduce ChainDB memory usage

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -36,8 +36,8 @@ import           Ouroboros.Consensus.Util (repeatedlyM)
 --
 -- This is the combination of the ouroboros state and the ledger state proper.
 data ExtLedgerState blk = ExtLedgerState {
-      ledgerState         :: LedgerState blk
-    , ouroborosChainState :: ChainState (BlockProtocol blk)
+      ledgerState         :: !(LedgerState blk)
+    , ouroborosChainState :: !(ChainState (BlockProtocol blk))
     }
 
 data ExtValidationError blk =

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -330,7 +330,7 @@ getCurrentState LgrDB{..} = LedgerDB.ledgerDbCurrent <$> readTVar varDB
 -- 'LedgerDB'.
 setCurrent :: MonadSTM m
            => LgrDB m blk -> LedgerDB blk -> STM m ()
-setCurrent LgrDB{..} = writeTVar varDB
+setCurrent LgrDB{..} = writeTVar $! varDB
 
 currentPoint :: UpdateLedger blk
              => LedgerDB blk -> Point blk

--- a/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
@@ -53,7 +53,7 @@ type SlotOffset = Word64
 -------------------------------------------------------------------------------}
 
 -- | Tip of the chain
-data Tip r = Tip r | TipGen
+data Tip r = Tip !r | TipGen
   deriving (Show, Eq, Generic)
 
 instance Condense r => Condense (Tip r) where

--- a/ouroboros-network/src/Ouroboros/Network/Point.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Point.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveFoldable    #-}
+{-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE DeriveTraversable #-}
 
@@ -11,9 +11,9 @@ module Ouroboros.Network.Point
   , block
   ) where
 
-import GHC.Generics (Generic)
+import           GHC.Generics (Generic)
 
-data WithOrigin t = Origin | At t
+data WithOrigin t = Origin | At !t
   deriving (Eq, Ord, Show, Generic, Functor, Foldable, Traversable)
 
 data Block slot hash = Block


### PR DESCRIPTION
Before:
![byron-db-bench_before](https://user-images.githubusercontent.com/373460/63022785-ec01d300-bea3-11e9-800c-2afecb1cb642.png)
After:
![byron-db-bench_after](https://user-images.githubusercontent.com/373460/63022784-ec01d300-bea3-11e9-85bb-8c0fbc8183b7.png)

The profiled program adds the first 30,000 blocks from disk (so we add as fast we can read them) to the ChainDB.