### PR TITLE
Minor additions to `io-sim` and `io-sim-classes`

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
@@ -10,6 +10,7 @@ module Control.Monad.Class.MonadAsync
 
 import           Prelude hiding (read)
 
+import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 import           Control.Exception (SomeException)
@@ -21,12 +22,13 @@ class ( MonadSTM m
       , forall a. Ord (Async m a)
       ) => MonadAsync m where
 
-  {-# MINIMAL async, cancel, cancelWith, waitCatchSTM, pollSTM #-}
+  {-# MINIMAL async, asyncThreadId, cancel, cancelWith, waitCatchSTM, pollSTM #-}
 
   -- | An asynchronous action
   type Async m :: * -> *
 
   async                 :: m a -> m (Async m a)
+  asyncThreadId         :: proxy m -> Async m a -> ThreadId m
   withAsync             :: m a -> (Async m a -> m b) -> m b
 
   wait                  :: Async m a -> m a
@@ -226,6 +228,7 @@ instance MonadAsync IO where
   type Async IO = Async.Async
 
   async                 = Async.async
+  asyncThreadId         = \_proxy -> Async.asyncThreadId
   withAsync             = Async.withAsync
 
   wait                  = Async.wait
@@ -260,4 +263,3 @@ instance MonadAsync IO where
   race                  = Async.race
   race_                 = Async.race_
   concurrently          = Async.concurrently
-

--- a/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
@@ -20,6 +20,7 @@ import           Control.Concurrent.Async (AsyncCancelled(..))
 class ( MonadSTM m
       , forall a. Eq  (Async m a)
       , forall a. Ord (Async m a)
+      , Functor (Async m)
       ) => MonadAsync m where
 
   {-# MINIMAL async, asyncThreadId, cancel, cancelWith, waitCatchSTM, pollSTM #-}

--- a/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
@@ -23,8 +23,6 @@ import           Data.Typeable (Typeable)
 #if defined(__GLASGOW_HASKELL__) && !defined(mingw32_HOST_OS)
 import qualified GHC.Event as GHC (TimeoutKey, getSystemTimerManager,
                      registerTimeout, unregisterTimeout, updateTimeout)
-#else
-import           Control.Monad (when)
 #endif
 
 import           Control.Monad.Class.MonadFork (MonadFork(..))

--- a/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
@@ -1,18 +1,24 @@
 {-# LANGUAGE CPP                        #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE DefaultSignatures          #-}
 
 module Control.Monad.Class.MonadTimer (
     MonadTimer(..)
   , TimeoutState(..)
+  , timeoutAfter
   ) where
 
 import qualified Control.Concurrent as IO
 import qualified Control.Concurrent.STM.TVar as STM
+import           Control.Monad (when)
 import qualified Control.Monad.STM as STM
-import           Control.Exception (assert)
+import           Control.Exception (Exception(..), assert)
+import qualified Control.Exception as E
 import           Data.Functor (void)
 import           Data.Time.Clock (DiffTime, diffTimeToPicoseconds)
+import           Data.Typeable (Typeable)
 
 #if defined(__GLASGOW_HASKELL__) && !defined(mingw32_HOST_OS)
 import qualified GHC.Event as GHC (TimeoutKey, getSystemTimerManager,
@@ -23,11 +29,12 @@ import           Control.Monad (when)
 
 import           Control.Monad.Class.MonadFork (MonadFork(..))
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
 
 
 data TimeoutState = TimeoutPending | TimeoutFired | TimeoutCancelled
 
-class MonadSTM m => MonadTimer m where
+class (MonadSTM m, Eq (Timeout m)) => MonadTimer m where
   data Timeout m :: *
 
   -- | Create a new timeout which will fire at the given time duration in
@@ -99,6 +106,9 @@ class MonadSTM m => MonadTimer m where
 --
 
 #if defined(__GLASGOW_HASKELL__) && !defined(mingw32_HOST_OS)
+instance Eq (Timeout IO) where
+  TimeoutIO _ key == TimeoutIO _ key' = key == key'
+
 instance MonadTimer IO where
   data Timeout IO = TimeoutIO !(STM.TVar TimeoutState) !GHC.TimeoutKey
 
@@ -138,6 +148,9 @@ instance MonadTimer IO where
 
   registerDelay = STM.registerDelay . diffTimeToMicrosecondsAsInt
 #else
+instance Eq (Timeout IO) where
+  TimeoutIO _ cancelvar == TimeoutIO _ cancelvar' = cancelvar == cancelvar'
+
 instance MonadTimer IO where
   data Timeout IO = TimeoutIO !(STM.TVar (STM.TVar Bool)) !(STM.TVar Bool)
 
@@ -178,3 +191,37 @@ diffTimeToMicrosecondsAsInt d =
     assert (usec <= fromIntegral (maxBound :: Int)) $
     fromIntegral usec
 
+{-------------------------------------------------------------------------------
+  Timeout an action
+
+  This is based on the implementation in System.Timeout
+-------------------------------------------------------------------------------}
+
+data TimeoutException m = TimeoutException (Timeout m)
+
+instance Show (TimeoutException m) where
+  show _ = "<<timeout>>"
+
+instance Typeable m => Exception (TimeoutException m) where
+  toException   = E.asyncExceptionToException
+  fromException = E.asyncExceptionFromException
+
+-- | Generalization of 'System.Timeout.timeout' to 'MonadTimer'
+--
+-- NOTE: Like most of the timer API, this will only work with the threaded
+-- runtime. When using the non-threaded runtime, will fail with a runtime
+-- exception about a pattern match failure in "GHC.Event.Thread".
+timeoutAfter :: (MonadFork m, MonadTimer m, MonadMask m, Typeable m)
+             => DiffTime -> m a -> m (Maybe a)
+timeoutAfter d act = do
+    pid <- myThreadId
+    t   <- newTimeout d
+    handleJust
+      (\(TimeoutException t') -> if t' == t then Just () else Nothing)
+      (\_ -> return Nothing) $
+      bracket
+        (void $ forkWithUnmask $ \unmask -> unmask $ do
+            fired <- atomically $ awaitTimeout t
+            when fired $ throwTo pid (TimeoutException t))
+        (\() -> cancelTimeout t)
+        (\() -> Just <$> act)


### PR DESCRIPTION
* Add `asyncThreadId` to `MonadFork`
* Add `forkWithUnmask` to `MonadTimer`
* Implement derived `timeoutAfter`

Note that in order to correctly implement `timeoutAfter`, we need`Timeout`s to be comparable for equality; that was already the case, but we did not require it in `MonadTimer`; now we do.

Adding a few people as reviewer, not because it's all that tricky but because I don't know who's around. However, implementation of `forkWithUnmask` would benefit from a careful check. I _think_ it's probably okay, but not 100% sure.