### PR TITLE
update ouroboros-network/README.md for test-crypto relocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,6 @@ or with `nix`
 ```
 nix-build -A nix-tools.tests.ouroboros-consensus.test-consensus
 ```
-### Crypto test suite
-```
-cabal new-run pkg:ouroboros-consensus:test-crypto
-```
-or with `nix`
-```
-nix-build -A nix-tools.tests.ouroboros-consensus.test-crypto
-```
 ### Storage test suite
 ```
 cabal new-run pkg:ouroboros-consensus:test-storage


### PR DESCRIPTION
#684 relocated `test-crypto` to a different package. This removes a stale reference to it from the README.