### PR TITLE
Remove Mux close operation

### DIFF
--- a/network-mux/src/Network/Mux/Bearer/Pipe.hs
+++ b/network-mux/src/Network/Mux/Bearer/Pipe.hs
@@ -15,7 +15,7 @@ import           Control.Monad.Class.MonadTime
 import           Data.Word
 import qualified Data.ByteString.Lazy as BL
 import           GHC.Stack
-import           System.IO (Handle, hClose, hFlush)
+import           System.IO (Handle, hFlush)
 
 import qualified Network.Mux as Mx
 import           Network.Mux.Types (MuxBearer)
@@ -40,7 +40,6 @@ pipeAsMuxBearer pcRead pcWrite = do
       return $ Mx.MuxBearer {
           Mx.read = readPipe,
           Mx.write = writePipe,
-          Mx.close = closePipe,
           Mx.sduSize = sduSize,
           Mx.state = mxState
         }
@@ -76,11 +75,6 @@ pipeAsMuxBearer pcRead pcWrite = do
           BL.hPut pcWrite buf
           hFlush pcWrite
           return ts
-
-      closePipe :: IO ()
-      closePipe = do
-          hClose pcRead
-          hClose pcWrite
 
       sduSize :: IO Word16
       sduSize = return 32768

--- a/network-mux/src/Network/Mux/Bearer/Queues.hs
+++ b/network-mux/src/Network/Mux/Bearer/Queues.hs
@@ -41,7 +41,6 @@ queuesAsMuxBearer writeQueue readQueue sduSize traceQueue = do
       return $ Mx.MuxBearer {
           Mx.read    = readMux,
           Mx.write   = writeMux,
-          Mx.close   = return (),
           Mx.sduSize = sduSizeMux,
           Mx.state   = mxState
         }
@@ -100,7 +99,7 @@ runMuxWithQueues
   -> Maybe (TBQueue m (Mx.MiniProtocolId ptcl, Mx.MiniProtocolMode, Time m))
   -> m (Maybe SomeException)
 runMuxWithQueues peerid app wq rq mtu trace =
-    bracket (queuesAsMuxBearer wq rq mtu trace) Mx.close $ \bearer -> do
+    bracket (queuesAsMuxBearer wq rq mtu trace) (\_ -> pure ()) $ \bearer -> do
       res_e <- try $ Mx.muxStart peerid app bearer
       case res_e of
             Left  e -> return (Just e)

--- a/network-mux/src/Network/Mux/Bearer/Socket.hs
+++ b/network-mux/src/Network/Mux/Bearer/Socket.hs
@@ -48,7 +48,6 @@ socketAsMuxBearer sd = do
       return $ Mx.MuxBearer {
           Mx.read    = readSocket,
           Mx.write   = writeSocket,
-          Mx.close   = closeSocket,
           Mx.sduSize = sduSize,
           Mx.state   = mxState
         }
@@ -94,9 +93,6 @@ socketAsMuxBearer sd = do
           --hexDump buf ""
           Socket.sendAll sd buf
           return ts
-
-      closeSocket :: IO ()
-      closeSocket = Socket.close sd
 
       sduSize :: IO Word16
 #if defined(mingw32_HOST_OS)

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -218,8 +218,6 @@ data MuxBearer ptcl m = MuxBearer {
     , read    :: m (MuxSDU ptcl, Time m)
     -- | Return a suitable MuxSDU payload size.
     , sduSize :: m Word16
-    -- | Close underlying socket.
-    , close   :: m ()
     , state   :: TVar m MuxBearerState
     }
 


### PR DESCRIPTION
The mux close operation isn't used, and leaving it around means that it
could cause double closes if someone starts to use it in the future.