### PR TITLE
Correctly derive the epoch size instead of hardcoding it to 21600

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
@@ -42,7 +42,9 @@ class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
   nodeBlockFetchSize     :: Header blk -> SizeInBytes
   nodeIsEBB              :: blk -> Bool
   nodeEpochSize          :: Monad m
-                         => Proxy blk  -> EpochNo -> m EpochSize
+                         => Proxy blk
+                         -> NodeConfig (BlockProtocol blk)
+                         -> EpochNo -> m EpochSize
   nodeStartTime          :: Proxy blk
                          -> NodeConfig (BlockProtocol blk)
                          -> SystemStart

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
@@ -39,7 +39,7 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
   nodeBlockMatchesHeader = matchesSimpleHeader
   nodeBlockFetchSize     = fromIntegral . simpleBlockSize . simpleHeaderStd
   nodeIsEBB              = const False
-  nodeEpochSize          = \_ _ -> return 21600
+  nodeEpochSize          = \_ _ _ -> return 100
   nodeStartTime          = \_ _ -> SystemStart dummyDate
     where
       --  This doesn't matter much

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -326,7 +326,7 @@ broadcastNetwork registry testBtime numCoreNodes pInfo initRNG slotLen = do
             , produceDRG      = atomically $ simChaChaT varRNG id $ drgNew
             }
 
-      epochInfo <- newEpochInfo $ nodeEpochSize (Proxy @blk)
+      epochInfo <- newEpochInfo $ nodeEpochSize (Proxy @blk) pInfoConfig
       fsVars@(immDbFsVar, volDbFsVar, lgrDbFsVar)  <- atomically $ (,,)
         <$> newTVar Mock.empty <*> newTVar Mock.empty <*> newTVar Mock.empty
       let args = mkArgs pInfoConfig pInfoInitLedger epochInfo fsVars

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -73,7 +73,7 @@ withImmDB :: forall m blk a.
           => (ImmDB m blk -> m a) -> m a
 withImmDB k = do
     immDbFsVar <- atomically $ newTVar Mock.empty
-    epochInfo  <- newEpochInfo $ nodeEpochSize (Proxy @blk)
+    epochInfo  <- newEpochInfo $ nodeEpochSize (Proxy @blk) testCfg
     bracket (ImmDB.openDB (mkArgs immDbFsVar epochInfo)) ImmDB.closeDB k
   where
     mkArgs immDbFsVar epochInfo = ImmDbArgs


### PR DESCRIPTION
For Byron, we now use `kEpochSlots :: BlockCount -> EpochSlots` (basically `* 10`) to derive the epoch size from `k`, which is extracted from the genesis config. In order to have access to the genesis config,  nodeEpochSize` now takes the `NodeConfig` as argument.