### PR TITLE
Null clients

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -19,6 +19,10 @@ module Ouroboros.Network.NodeToClient (
 
   -- * Re-exports
   , AnyResponderApp (..)
+
+  -- * Re-exported clients
+  , chainSyncClientNull
+  , localTxSubmissionClientNull
   ) where
 
 import           Control.Concurrent.Async (Async)
@@ -38,6 +42,8 @@ import           Network.Mux.Types (ProtocolEnum(..), MiniProtocolLimits (..))
 import           Network.Mux.Interface
 
 import           Ouroboros.Network.Mux
+import           Ouroboros.Network.Protocol.ChainSync.Client (chainSyncClientNull)
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Client (localTxSubmissionClientNull)
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.Socket

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
@@ -22,7 +22,13 @@ module Ouroboros.Network.Protocol.ChainSync.Client (
 
       -- * Execution as a typed protocol
     , chainSyncClientPeer
+
+      -- * Null chain sync client
+    , chainSyncClientNull
     ) where
+
+import Control.Monad (forever)
+import Control.Monad.Class.MonadTimer
 
 import Network.TypedProtocol.Core
 import Ouroboros.Network.Protocol.ChainSync.Type
@@ -34,6 +40,10 @@ newtype ChainSyncClient header point m a = ChainSyncClient {
     runChainSyncClient :: m (ClientStIdle header point m a)
   }
 
+-- | A chain sync client which never sends any message.
+--
+chainSyncClientNull :: MonadTimer m => ChainSyncClient header point m a
+chainSyncClientNull = ChainSyncClient $ forever $ threadDelay 43200 {- one day in seconds -}
 
 -- | In the 'StIdle' protocol state, the server does not have agency and can choose to
 -- send a request next, or a find intersection message.

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Client.hs
@@ -23,7 +23,13 @@ module Ouroboros.Network.Protocol.LocalTxSubmission.Client (
 
     -- * Execution as a typed protocol
   , localTxSubmissionClientPeer
+
+      -- * Null local tx submission client
+    , localTxSubmissionClientNull
   ) where
+
+import           Control.Monad (forever)
+import           Control.Monad.Class.MonadTimer
 
 import           Network.TypedProtocol.Core
 
@@ -33,6 +39,12 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
 newtype LocalTxSubmissionClient tx reject m a = LocalTxSubmissionClient {
       runLocalTxSubmissionClient :: m (LocalTxClientStIdle tx reject m a)
     }
+
+-- | A local tx submission client which never sends any message.
+--
+localTxSubmissionClientNull :: MonadTimer m => LocalTxSubmissionClient tx reject m a
+localTxSubmissionClientNull =
+    LocalTxSubmissionClient $ forever $ threadDelay 43200 {- day in seconds -}
 
 -- | The client side of the local transaction submission protocol.
 --

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Examples.hs
@@ -30,7 +30,7 @@ localTxSubmissionClient
   => [tx]
   -> LocalTxSubmissionClient tx reject m [(tx, Maybe reject)]
 localTxSubmissionClient =
-    client []
+    LocalTxSubmissionClient . pure . client []
   where
     client acc [] =
       SendMsgDone (reverse acc)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
@@ -111,7 +111,7 @@ prop_connect :: (Tx -> Maybe Reject) -> [Tx] -> Bool
 prop_connect p txs =
     case runSimOrThrow
            (connect
-             (localTxSubmissionClientPeer $ pure $
+             (localTxSubmissionClientPeer $
               localTxSubmissionClient txs)
              (localTxSubmissionServerPeer $ pure $
               localTxSubmissionServer p)) of
@@ -142,7 +142,7 @@ prop_channel createChannels p txs =
       codec
       "client"
       "server"
-      (localTxSubmissionClientPeer $ pure $
+      (localTxSubmissionClientPeer $
        localTxSubmissionClient txs)
       (localTxSubmissionServerPeer $ pure $
        localTxSubmissionServer p)


### PR DESCRIPTION
* null chain sync client
* null local tx submission client

I converted local tx submission client types to the form we use in the other modules, where a top level type is a newtype wrapper, but I didn't used it in the other type to avoid unnecessary indirection.  I think this gives the right indication of what's the top level API and still avoids newtype boilerplate.