### PR TITLE
Validate mainnet in CI

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -41,9 +41,11 @@ let
 # hosts.
   nixTools = import ./nix/nix-tools.nix {};
   documents = import ./doc/default.nix {inherit commonLib; };
+  validate-mainnet-test = import ./nix/validate-mainnet.nix
+    {pkgs = commonLib.pkgs; byron-db-converter = nixTools.nix-tools.exes.ouroboros-consensus; };
 in {
   inherit (nixTools) nix-tools shell;
   network-pdf-wip = documents.network-pdf-wip;
   network-pdf = documents.network-pdf;
-  tests = {};
+  tests = { inherit validate-mainnet-test; };
 }

--- a/nix/validate-mainnet.nix
+++ b/nix/validate-mainnet.nix
@@ -1,0 +1,37 @@
+{ pkgs
+, byron-db-converter
+}:
+
+let
+  cardano-mainnet-config = pkgs.fetchurl {
+    url = https://raw.githubusercontent.com/input-output-hk/cardano-node/master/mainnet-genesis.json;
+    sha256 = "1ahkdhqh07096law629r1d5jf6jz795rcw6c4vpgdi5j6ysb6a2g";
+  };
+  cardano-mainnet-mirror = pkgs.fetchFromGitHub {
+    owner = "input-output-hk";
+    repo = "cardano-mainnet-mirror";
+    rev = "a31ac7534ec855b715b9a6bb6a06861ee94935d9";
+    sha256 = "1z51ak4f7klz5pv2kjgaj5jv6agn2aph2n172hjssmn8x1q2bdys";
+  };
+  mainnet-converted = pkgs.runCommand "convert-mainnet"
+    { buildInputs = [byron-db-converter ]; }
+    ''
+    ${byron-db-converter}/bin/byron-db-converter convert \
+      --epochDir ${cardano-mainnet-mirror}/epochs \
+      --dbDir $out \
+      --epochSlots 21600
+    '';
+  validate-mainnet-immdb = pkgs.runCommand "validate-mainnet-immdb"
+    { buildInputs = [ byron-db-converter ]; }
+    ''
+    mkdir $out
+    cp -r ${mainnet-converted}/* $out
+    chmod -R u+rw,g+rw,a+x $out/*
+    ${byron-db-converter}/bin/byron-db-converter validate \
+      --configFile ${cardano-mainnet-config} \
+      --genesisHash 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb \
+      --dbDir $out \
+      --onlyImmDB
+    '';
+in
+  { inherit validate-mainnet-immdb; }

--- a/nix/validate-mainnet.nix
+++ b/nix/validate-mainnet.nix
@@ -4,7 +4,7 @@
 
 let
   cardano-mainnet-config = pkgs.fetchurl {
-    url = https://raw.githubusercontent.com/input-output-hk/cardano-node/master/mainnet-genesis.json;
+    url = https://raw.githubusercontent.com/input-output-hk/cardano-node/114ee7f3b1cb55d384f928552c6b0871d4ca27ff/configuration/mainnet-genesis.json;
     sha256 = "1ahkdhqh07096law629r1d5jf6jz795rcw6c4vpgdi5j6ysb6a2g";
   };
   cardano-mainnet-mirror = pkgs.fetchFromGitHub {

--- a/ouroboros-consensus/tools/db-convert/Main.hs
+++ b/ouroboros-consensus/tools/db-convert/Main.hs
@@ -51,6 +51,7 @@ import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 import           Ouroboros.Consensus.Util.Condense (condense)
 import qualified Ouroboros.Consensus.Util.ResourceRegistry as ResourceRegistry
 import qualified Ouroboros.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Storage.ChainDB.Impl.Args as Args
 import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
 import           Ouroboros.Storage.Common (EpochSize (..))
 import           Ouroboros.Storage.EpochInfo (fixedSizeEpochInfo)
@@ -93,6 +94,7 @@ data Args w
       , requiresNetworkMagic :: w ::: Bool <?> "Expecto patronum?"
       , genesisHash :: w ::: Hash CB.Raw <?> "Expected genesis hash"
       , verbose :: w ::: Bool <?> "Enable verbose logging"
+      , onlyImmDB :: w ::: Bool <?> "Validate only the immutable DB (e.g. do not do ledger validation)"
       }
   deriving (Generic)
 
@@ -124,6 +126,7 @@ main = do
       , requiresNetworkMagic
       , genesisHash
       , verbose
+      , onlyImmDB
       } -> do
         dbDir' <- parseAbsDir =<< canonicalizePath dbDir
         econfig <-
@@ -134,7 +137,7 @@ main = do
               genesisHash
         case econfig of
           Left err     -> throwIO $ MkConfigError err
-          Right config -> validateChainDb dbDir' config verbose
+          Right config -> validateChainDb dbDir' config onlyImmDB verbose
 
 convertEpochFile
   :: EpochSlots
@@ -159,14 +162,22 @@ validateChainDb
   :: forall blk. (blk ~ ByronBlockOrEBB ByronConfig)
   => Path Abs Dir -- ^ DB directory
   -> CC.Genesis.Config
+  -> Bool -- Immutable DB only?
   -> Bool -- Verbose
   -> IO ()
-validateChainDb dbDir cfg verbose =
-  ResourceRegistry.with $ \registry -> do
-    chaindb <- give protocolMagicId $ give epochSlots $ ChainDB.openDB $ args registry
-    blk <- ChainDB.getTipBlock chaindb
-    putStrLn $ "DB tip: " ++ condense blk
-    ChainDB.closeDB chaindb
+validateChainDb dbDir cfg onlyImmDB verbose =
+  ResourceRegistry.with $ \registry -> if onlyImmDB
+    then give protocolMagicId $ give epochSlots $ do
+      let (immDBArgs, _, _, _) = Args.fromChainDbArgs $ args registry
+      immDB <- ImmDB.openDB immDBArgs
+      immDbTipBlock <- ImmDB.getBlockAtTip immDB
+      putStrLn $ "DB tip: " ++ condense immDbTipBlock
+      ImmDB.closeDB immDB
+    else do
+      chaindb <- give protocolMagicId $ give epochSlots $ ChainDB.openDB $ args registry
+      blk <- ChainDB.getTipBlock chaindb
+      putStrLn $ "DB tip: " ++ condense blk
+      ChainDB.closeDB chaindb
   where
     byronProtocolInfo =
       protocolInfoByron


### PR DESCRIPTION
This adds a test to convert and validate the mainnet mirror during CI.

It additionally fixes a bug which is currently stopping mainnet from validating.

We only do the immutable DB validation, rather than full ledger validation, since ledger validation takes a few hours for all of mainnet.