### PR TITLE
release.nix: fix 'x86_65' typo in #885

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -80,7 +80,7 @@ in commonLib.nix-tools.release-nix {
     "nix-tools.tests.ouroboros-network.tests.x86_64-darwin"
     # 'Storage.HasFS.HasFS' test failing:
     "nix-tools.tests.ouroboros-consensus.test-storage.x86_64-darwin"
-    "nix-tools.tests.x86_65-pc-mingw32-ouroboros-consensus.test-storage.x86_64-linux"
+    "nix-tools.tests.x86_64-pc-mingw32-ouroboros-consensus.test-storage.x86_64-linux"
   ];
   # The required jobs that must pass for ci not to fail:
   required-name = "ouroboros-network-required-checks";


### PR DESCRIPTION
This commit fixes a `x86_65` typo from #885. This line is from master:

https://github.com/input-output-hk/ouroboros-network/blob/723d0ae621bfbc5b95b5813820badf90da22340f/release.nix#L83

I noticed the typo because that test is still failing on my #773 branch, even though I just rebased.