### PR TITLE
Subscription fix

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Worker.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Worker.hs
@@ -452,6 +452,8 @@ subscriptionLoop
         Left (SomeException e) -> do
           traceWith tr $ SubscriptionTraceConnectException remoteAddr e
           atomically $ do
+            -- remove thread from active connections threads
+            modifyTVar' conThreads (Set.delete thread)
             (!s, m) <- readTVar sVar >>= completeApplicationTx (ConnectionError t remoteAddr e)
             writeTVar sVar s
             writeTQueue resQ (Act m)

--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Worker.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Worker.hs
@@ -403,19 +403,23 @@ subscriptionLoop
                       socket'
                       remoteAddr
                       localAddr
-                      (atomically $ do
-                        modifyTVar' conThreads (Set.insert thread)
-                        modifyTVar' threadsVar (Set.insert thread)
-                        readTVar sVar
-                          >>= socketStateChangeTx (CreatedSocket remoteAddr thread)
-                          >>= (writeTVar sVar $!))
-                      (atomically $ do
-                        -- The thread is removed from 'conThreads'
-                        -- inside 'connAction'.
-                        modifyTVar' threadsVar (Set.delete thread)
-                        readTVar sVar
-                          >>= socketStateChangeTx (ClosedSocket remoteAddr thread)
-                          >>= (writeTVar sVar $!))
+                      (do
+                        traceWith tr $ SubscriptionTraceAllocateSocket remoteAddr
+                        atomically $ do
+                          modifyTVar' conThreads (Set.insert thread)
+                          modifyTVar' threadsVar (Set.insert thread)
+                          readTVar sVar
+                            >>= socketStateChangeTx (CreatedSocket remoteAddr thread)
+                            >>= (writeTVar sVar $!))
+                      (do
+                        atomically $ do
+                          -- The thread is removed from 'conThreads'
+                          -- inside 'connAction'.
+                          modifyTVar' threadsVar (Set.delete thread)
+                          readTVar sVar
+                            >>= socketStateChangeTx (ClosedSocket remoteAddr thread)
+                            >>= (writeTVar sVar $!)
+                        traceWith tr $ SubscriptionTraceCloseSocket remoteAddr)
                       (connAction
                         thread conThreads valencyVar
                         remoteAddr)


### PR DESCRIPTION
This fixes the case when a `connect` fails and the subscription worker `innerLoop` is block on waiting on `conThreads`.  The problem was `conThreads` was not cleared when `connect` thrown an exception (only when it return without an error).