### PR TITLE
Have rewindChainState @WithEBBs skip EBBs that precede only genesis

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
@@ -164,7 +164,7 @@ protocolInfoByron genesisConfig@Genesis.Config {
                 blsCurrent   = initState
               , blsSnapshots = Seq.empty
               }
-          , ouroborosChainState = Map.empty
+          , ouroborosChainState = initChainStateWithEBBs Map.empty
           }
       , pInfoInitState  = ()
       }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -55,7 +55,7 @@ instance ByronGiven => RunNode (ByronBlockOrEBB ByronConfig) where
   nodeEncodeGenTxId      = encodeByronGenTxId
   nodeEncodeHeaderHash   = const encodeByronHeaderHash
   nodeEncodeLedgerState  = const encodeByronLedgerState
-  nodeEncodeChainState   = const encodeByronChainState
+  nodeEncodeChainState   = const (encodeChainStateWithEBBs encodeByronChainState)
   nodeEncodeApplyTxError = const encodeByronApplyTxError
 
   nodeDecodeBlock        = const (decodeByronBlock given)
@@ -64,7 +64,7 @@ instance ByronGiven => RunNode (ByronBlockOrEBB ByronConfig) where
   nodeDecodeGenTxId      = decodeByronGenTxId
   nodeDecodeHeaderHash   = const decodeByronHeaderHash
   nodeDecodeLedgerState  = const decodeByronLedgerState
-  nodeDecodeChainState   = const decodeByronChainState
+  nodeDecodeChainState   = const (decodeChainStateWithEBBs decodeByronChainState)
   nodeDecodeApplyTxError = const decodeByronApplyTxError
 
 extractGenesisData :: NodeConfig (WithEBBs (ExtNodeConfig ByronConfig p))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/WithEBBs.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/WithEBBs.hs
@@ -1,22 +1,35 @@
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UndecidableInstances       #-}
-{-# LANGUAGE UndecidableSuperClasses    #-}
-{-# LANGUAGE ViewPatterns               #-}
+{-# LANGUAGE FlexibleContexts        #-}
+{-# LANGUAGE MultiParamTypeClasses   #-}
+{-# LANGUAGE ScopedTypeVariables     #-}
+{-# LANGUAGE StandaloneDeriving      #-}
+{-# LANGUAGE TypeApplications        #-}
+{-# LANGUAGE TypeFamilies            #-}
+{-# LANGUAGE UndecidableInstances    #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 module Ouroboros.Consensus.Protocol.WithEBBs
   ( WithEBBs
   , HeaderSupportsWithEBB(..)
   , NodeConfig(..)
+  -- * ChainStateWithEBBs
+  , ChainStateWithEBBs   -- opaque
+  , decodeChainStateWithEBBs
+  , encodeChainStateWithEBBs
+  , initChainStateWithEBBs
   )
 where
 
-import Ouroboros.Consensus.Protocol.Abstract
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.Serialise as CBOR
 
-class ( SupportedHeader p (HeaderOfBlock hoe)
+import           Ouroboros.Network.Block (HasHeader (..), SlotNo)
+import           Ouroboros.Network.Point (WithOrigin (..))
+
+import           Ouroboros.Consensus.Protocol.Abstract
+
+class ( HasHeader hoe
+      , SupportedHeader p (HeaderOfBlock hoe)
       ) => HeaderSupportsWithEBB p hoe where
 
   type HeaderOfBlock hoe :: *
@@ -36,7 +49,7 @@ instance (OuroborosTag p) => OuroborosTag (WithEBBs p) where
   -- Most types remain the same
   --
 
-  type ChainState      (WithEBBs p) = ChainState     p
+  type ChainState      (WithEBBs p) = ChainStateWithEBBs p
   type NodeState       (WithEBBs p) = NodeState      p
   type LedgerView      (WithEBBs p) = LedgerView     p
   type ValidationErr   (WithEBBs p) = ValidationErr  p
@@ -48,13 +61,84 @@ instance (OuroborosTag p) => OuroborosTag (WithEBBs p) where
 
   preferCandidate       (WithEBBNodeConfig cfg) = preferCandidate       cfg
   compareCandidates     (WithEBBNodeConfig cfg) = compareCandidates     cfg
-  checkIsLeader         (WithEBBNodeConfig cfg) = checkIsLeader         cfg
-  rewindChainState      (WithEBBNodeConfig cfg) = rewindChainState      cfg
   protocolSecurityParam (WithEBBNodeConfig cfg) = protocolSecurityParam cfg
 
   applyChainState (WithEBBNodeConfig cfg) lv b cs = case
     eitherHeaderOrEbb cfg b of
-      Right hdr -> applyChainState @p cfg lv hdr cs
+      Right hdr ->
+          wrap <$> applyChainState @p cfg lv hdr (underlyingChainState cs)
+        where
+          wrap x = ChainStateWithEBBs
+            { firstNonEBBSlot      = Just $ case firstNonEBBSlot cs of
+                Just s  -> s
+                Nothing -> blockSlot b
+            , underlyingChainState = x
+            }
       -- Currently the hash chain is maintained in the ledger state, so we just
       -- ignore the EBB for protocol concerns.
       Left _ -> return cs
+
+  checkIsLeader (WithEBBNodeConfig cfg) slot lv cs =
+    checkIsLeader cfg slot lv (underlyingChainState cs)
+
+  rewindChainState (WithEBBNodeConfig cfg) cs mSlot =
+      wrap <$> rewindChainState cfg (underlyingChainState cs) mSlot'
+    where
+      effectivelyRewindingToOrigin = case mSlot of
+        At slot -> case firstNonEBBSlot cs of
+          Just s  -> slot < s
+          Nothing -> True
+        Origin  -> True
+
+      (mSlot', firstNonEBBSlot')
+         | effectivelyRewindingToOrigin = (Origin, Nothing)
+         | otherwise                    = (mSlot, firstNonEBBSlot cs)
+
+      wrap x = ChainStateWithEBBs
+        { firstNonEBBSlot      = firstNonEBBSlot'
+        , underlyingChainState = x
+        }
+
+-- | A wrapper around @'ChainState' p@ with extra bookeeping data
+--
+-- The bookkeeping data is used to avoid the #925 corner case. The @WithEBBs@
+-- 'applyChainState' crucially does not pass EBBs to the underlying protocol.
+-- Because the underlying 'applyChainState' never receives EBBs, the underlying
+-- 'rewindChainstate' may in general fail when rewinding to an EBB's slot. In
+-- #925 specifically, the underlying @PBFT@ was failing to rewind to a slot 0
+-- EBB with genesis predecessor because @PBFT@'s @rewindChainState@ refuses to
+-- return an empty chain state unless 'Origin' was specified directly.
+--
+data ChainStateWithEBBs p = ChainStateWithEBBs
+  { firstNonEBBSlot      :: !(Maybe SlotNo)
+    -- ^ earliest slot incorporated into 'underlyingChainState' that is not an
+    -- EBB
+  , underlyingChainState :: !(ChainState p)
+  }
+
+deriving instance Show (ChainState p) => Show (ChainStateWithEBBs p)
+
+-- | Create a 'ChainStateWithEBBs' from a 'ChainState' that does not include
+-- any non-EBB blocks.
+--
+initChainStateWithEBBs :: ChainState p -> ChainStateWithEBBs p
+initChainStateWithEBBs x = ChainStateWithEBBs
+  { firstNonEBBSlot      = Nothing
+  , underlyingChainState = x
+  }
+
+encodeChainStateWithEBBs ::
+    (ChainState p -> CBOR.Encoding)
+  -> ChainStateWithEBBs p
+  -> CBOR.Encoding
+encodeChainStateWithEBBs f (ChainStateWithEBBs x0 x1) =
+  CBOR.encodeListLen 2
+  <> CBOR.encode x0
+  <> f x1
+
+decodeChainStateWithEBBs ::
+     CBOR.Decoder s (ChainState p)
+  -> CBOR.Decoder s (ChainStateWithEBBs p)
+decodeChainStateWithEBBs f = do
+  CBOR.decodeListLenOf 2
+  ChainStateWithEBBs <$> CBOR.decode <*> f

--- a/ouroboros-consensus/tools/db-convert/Main.hs
+++ b/ouroboros-consensus/tools/db-convert/Main.hs
@@ -48,6 +48,7 @@ import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract (pInfoConfig,
                      pInfoInitLedger)
 import           Ouroboros.Consensus.Node.ProtocolInfo.Byron
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+import qualified Ouroboros.Consensus.Protocol.WithEBBs as WithEBBs
 import           Ouroboros.Consensus.Util.Condense (condense)
 import qualified Ouroboros.Consensus.Util.ResourceRegistry as ResourceRegistry
 import qualified Ouroboros.Storage.ChainDB as ChainDB
@@ -203,11 +204,11 @@ validateChainDb dbDir cfg onlyImmDB verbose =
       (ChainDB.defaultArgs @blk (toFilePath dbDir))
         { ChainDB.cdbGenesis = return $ pInfoInitLedger byronProtocolInfo
         , ChainDB.cdbDecodeBlock = Byron.decodeByronBlock epochSlots
-        , ChainDB.cdbDecodeChainState = Byron.decodeByronChainState
+        , ChainDB.cdbDecodeChainState = WithEBBs.decodeChainStateWithEBBs Byron.decodeByronChainState
         , ChainDB.cdbDecodeHash = Byron.decodeByronHeaderHash
         , ChainDB.cdbDecodeLedger = Byron.decodeByronLedgerState
         , ChainDB.cdbEncodeBlock = Byron.encodeByronBlock
-        , ChainDB.cdbEncodeChainState = Byron.encodeByronChainState
+        , ChainDB.cdbEncodeChainState = WithEBBs.encodeChainStateWithEBBs Byron.encodeByronChainState
         , ChainDB.cdbEncodeHash = Byron.encodeByronHeaderHash
         , ChainDB.cdbEncodeLedger = Byron.encodeByronLedgerState
           -- Policy


### PR DESCRIPTION
This is my first attempt at #925. It prevents the test failure on my work-in-progress branch for #773 (supplanting 1943df1a), but I'm unsure how best to write a standalone test against `origin/master`. I thought to maybe put one in `Test.Consensus.ChainSyncClient`, but that uses `TestBlock`, so doesn't involve EBBs.

Should we write a test case to `Test.Consensus.ChainSyncClient` that uses `ByronBlockOrEBB`, requiring all the boilerplate demonstrated in `RealPBFT` (which is where #773 revealed this issue)? Or is there a more economical way?

cc: @mrBliss