### PR TITLE
Add protocolSlotLength

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -18,6 +18,8 @@ module Ouroboros.Consensus.BlockchainTime (
   , realBlockchainTime
     -- * Time to slots and back again
   , SlotLength(..)
+  , slotLengthFromSec
+  , slotLengthToSec
   , slotLengthFromMillisec
   , slotLengthToMillisec
   , SystemStart(..)
@@ -43,9 +45,11 @@ import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTimer
 
+import           Ouroboros.Network.Block (SlotNo (..))
+
+import           Ouroboros.Consensus.Protocol.Abstract (SlotLength (..))
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM
-import           Ouroboros.Network.Block (SlotNo (..))
 
 {-------------------------------------------------------------------------------
   Abstract definition
@@ -235,9 +239,11 @@ realBlockchainTime registry slotLen start = do
   Time to slots and back again
 -------------------------------------------------------------------------------}
 
--- | Slot length
-newtype SlotLength = SlotLength { getSlotLength :: NominalDiffTime }
-  deriving (Show)
+slotLengthFromSec :: Integer -> SlotLength
+slotLengthFromSec = slotLengthFromMillisec . (* 1000)
+
+slotLengthToSec :: SlotLength -> Integer
+slotLengthToSec = (`div` 1000) . slotLengthToMillisec
 
 slotLengthFromMillisec :: Integer -> SlotLength
 slotLengthFromMillisec = SlotLength . conv

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo.hs
@@ -14,6 +14,7 @@ import           Data.Reflection (give)
 
 import qualified Cardano.Chain.Genesis as Cardano.Genesis
 
+import           Ouroboros.Consensus.BlockchainTime (slotLengthFromSec)
 import           Ouroboros.Consensus.Demo.Run
 import           Ouroboros.Consensus.Protocol
 import           Ouroboros.Consensus.Util
@@ -31,6 +32,7 @@ defaultDemoPraosParams :: PraosParams
 defaultDemoPraosParams = PraosParams {
       praosSecurityParam = defaultSecurityParam
     , praosSlotsPerEpoch = 3
+    , praosSlotLength    = slotLengthFromSec 2
     , praosLeaderF       = 0.5
     , praosLifetimeKES   = 1000000
     }
@@ -39,6 +41,7 @@ defaultDemoPBftParams :: PBftParams
 defaultDemoPBftParams = PBftParams {
       pbftSecurityParam      = defaultSecurityParam
     , pbftNumNodes           = nn
+    , pbftSlotLength         = slotLengthFromSec 2
     , pbftSignatureWindow    = fromIntegral $ nn * 10
     , pbftSignatureThreshold = (1.0 / fromIntegral nn) + 0.1
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PraosRule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PraosRule.hs
@@ -83,8 +83,8 @@ instance SimpleCrypto c
 
 instance SimpleCrypto c
       => ProtocolLedgerView (SimplePraosRuleBlock c) where
-  protocolLedgerView _ _ = ()
-  anachronisticProtocolLedgerView _ _ _ = Just $ SB.unbounded ()
+  protocolLedgerView _ _ = error "TODO"
+  anachronisticProtocolLedgerView _ _ _ = Just $ SB.unbounded $ error "TODO"
 
 {-------------------------------------------------------------------------------
   We don't need crypto for this protocol

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -45,8 +45,8 @@ import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Network.NodeToClient as NodeToClient
 import           Ouroboros.Network.NodeToNode as NodeToNode
 import           Ouroboros.Network.Socket
-import           Ouroboros.Network.Subscription.Ip
 import           Ouroboros.Network.Subscription.Dns
+import           Ouroboros.Network.Subscription.Ip
 
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
@@ -54,7 +54,8 @@ import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.ChainSyncClient (ClockSkew (..))
-import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
+import           Ouroboros.Consensus.Ledger.Abstract (protocolLedgerView)
+import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
 import           Ouroboros.Consensus.Mempool.API (GenTx)
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
@@ -136,11 +137,9 @@ run tracers chainDbTracer rna dbPath pInfo
       , pInfoInitState  = initState
       } = pInfo
 
-    -- TODO this will depend on the protocol and can change when a hard-fork
-    -- happens, see #921 and #282.
-    --
-    -- For now, we hard-code it to Byron's 20 seconds.
-    slotLength = slotLengthFromMillisec (20 * 1000)
+    slotLength = protocolSlotLength cfg
+               $ protocolLedgerView cfg
+               $ ledgerState        initLedger
 
 initChainDB
   :: forall blk. RunNode blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
@@ -23,17 +23,18 @@ module Ouroboros.Consensus.Node.ProtocolInfo.Byron (
 import           Control.Exception (Exception)
 import           Control.Monad.Except
 import qualified Data.Map.Strict as Map
+import           Data.Maybe
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
-import           Data.Maybe
 
 import qualified Cardano.Chain.Block as Block
-import           Cardano.Chain.Common (BlockCount(..))
+import           Cardano.Chain.Common (BlockCount (..))
 import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Crypto as Crypto
 
+import           Ouroboros.Consensus.BlockchainTime (slotLengthFromMillisec)
 import           Ouroboros.Consensus.Crypto.DSIGN.Cardano
 import           Ouroboros.Consensus.Ledger.Byron hiding (genesisConfig)
 import           Ouroboros.Consensus.Ledger.Extended
@@ -53,9 +54,9 @@ import qualified Test.Cardano.Chain.Genesis.Dummy as Dummy
 -------------------------------------------------------------------------------}
 
 data PBftLeaderCredentials = PBftLeaderCredentials {
-      plcSignKey     :: Crypto.SigningKey
-    , plcDlgCert     :: Delegation.Certificate
-    , plcCoreNodeId  :: CoreNodeId
+      plcSignKey    :: Crypto.SigningKey
+    , plcDlgCert    :: Delegation.Certificate
+    , plcCoreNodeId :: CoreNodeId
     } deriving Show
 
 -- | Make the 'PBftLeaderCredentials', with a couple sanity checks:
@@ -132,6 +133,11 @@ protocolInfoByron genesisConfig@Genesis.Config {
                   , pbftNumNodes           = fromIntegral . Set.size
                                            . Genesis.unGenesisKeyHashes
                                            $ genesisKeyHashes
+                  , pbftSlotLength         = slotLengthFromMillisec
+                                           . fromIntegral
+                                           . Update.ppSlotDuration
+                                           . Genesis.configProtocolParameters
+                                           $ genesisConfig
                   , pbftSignatureWindow    = fromIntegral kParam
                   , pbftSignatureThreshold = unSignatureThreshold $
                       fromMaybe defaultPBftSignatureThreshold mSigThresh

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/BFT.hs
@@ -6,6 +6,7 @@ import qualified Data.Map as Map
 
 import           Cardano.Crypto.DSIGN
 
+import           Ouroboros.Consensus.BlockchainTime (slotLengthFromSec)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract
@@ -23,6 +24,7 @@ protocolInfoBft (NumCoreNodes numCoreNodes) (CoreNodeId nid) securityParam =
             bftParams   = BftParams {
                               bftNumNodes      = fromIntegral numCoreNodes
                             , bftSecurityParam = securityParam
+                            , bftSlotLength    = slotLengthFromSec 20
                             }
           , bftNodeId   = CoreId nid
           , bftSignKey  = SignKeyMockDSIGN nid

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -93,6 +93,9 @@ data BftParams = BftParams {
 
       -- | Number of core nodes
     , bftNumNodes      :: Word64
+
+      -- | Slot length
+    , bftSlotLength    :: SlotLength
     }
 
 instance BftCrypto c => OuroborosTag (Bft c) where
@@ -112,6 +115,8 @@ instance BftCrypto c => OuroborosTag (Bft c) where
   type ChainState      (Bft c) = ()
 
   protocolSecurityParam = bftSecurityParam . bftParams
+
+  protocolSlotLength cfg _ledgerView = bftSlotLength $ bftParams cfg
 
   checkIsLeader BftNodeConfig{..} (SlotNo n) _l _cs = do
       return $ case bftNodeId of

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
@@ -56,6 +56,7 @@ instance (Typeable cfg, OuroborosTag p) => OuroborosTag (ExtNodeConfig cfg p) wh
   applyChainState       (EncNodeConfig cfg _) = applyChainState       cfg
   rewindChainState      (EncNodeConfig cfg _) = rewindChainState      cfg
   protocolSecurityParam (EncNodeConfig cfg _) = protocolSecurityParam cfg
+  protocolSlotLength    (EncNodeConfig cfg _) = protocolSlotLength    cfg
 
 mapExtNodeConfig :: (a -> b)
                  -> NodeConfig (ExtNodeConfig a p)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -1,9 +1,7 @@
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 module Ouroboros.Consensus.Protocol.LeaderSchedule (
     LeaderSchedule (..)
@@ -37,7 +35,7 @@ instance OuroborosTag p => OuroborosTag (WithLeaderSchedule p) where
 
   type ChainState      (WithLeaderSchedule p) = ()
   type NodeState       (WithLeaderSchedule p) = ()
-  type LedgerView      (WithLeaderSchedule p) = ()
+  type LedgerView      (WithLeaderSchedule p) = LedgerView p
   type ValidationErr   (WithLeaderSchedule p) = ()
   type IsLeader        (WithLeaderSchedule p) = ()
   type SupportedHeader (WithLeaderSchedule p) = Empty
@@ -51,6 +49,7 @@ instance OuroborosTag p => OuroborosTag (WithLeaderSchedule p) where
   preferCandidate       WLSNodeConfig{..} = preferCandidate       lsNodeConfigP
   compareCandidates     WLSNodeConfig{..} = compareCandidates     lsNodeConfigP
   protocolSecurityParam WLSNodeConfig{..} = protocolSecurityParam lsNodeConfigP
+  protocolSlotLength    WLSNodeConfig{..} = protocolSlotLength    lsNodeConfigP
 
   checkIsLeader WLSNodeConfig{..} slot _ _ = return $
     case Map.lookup slot $ getLeaderSchedule lsNodeConfigSchedule of

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -52,6 +52,7 @@ instance (Typeable p, Typeable s, ChainSelection p s) => OuroborosTag (ModChainS
     applyChainState       (McsNodeConfig cfg) = applyChainState       cfg
     rewindChainState      (McsNodeConfig cfg) = rewindChainState      cfg
     protocolSecurityParam (McsNodeConfig cfg) = protocolSecurityParam cfg
+    protocolSlotLength    (McsNodeConfig cfg) = protocolSlotLength    cfg
 
     preferCandidate   (McsNodeConfig cfg) = preferCandidate'   (Proxy :: Proxy s) cfg
     compareCandidates (McsNodeConfig cfg) = compareCandidates' (Proxy :: Proxy s) cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -38,13 +38,13 @@ import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
 import           Data.Constraint
 import           Data.List (sortOn)
-import           Data.Reflection (Given (..), give)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
+import           Data.Reflection (Given (..), give)
 import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
-import           Data.Typeable (Proxy(..), Typeable)
+import qualified Data.Set as Set
+import           Data.Typeable (Proxy (..), Typeable)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 
@@ -60,7 +60,7 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Cardano
-import           Ouroboros.Consensus.NodeId (CoreNodeId(..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util.Condense
@@ -133,6 +133,9 @@ data PBftParams = PBftParams {
       -- | Number of core nodes
     , pbftNumNodes           :: Word64
 
+      -- | Slot length
+    , pbftSlotLength         :: SlotLength
+
       -- TODO These will ultimately be protocol parameters, but at the moment such
       -- parameters are missing in the ledger.
 
@@ -178,6 +181,8 @@ instance (PBftCrypto c, Typeable c) => OuroborosTag (PBft c) where
     Map (PBftVerKeyHash c) (Seq SlotNo)
 
   protocolSecurityParam = pbftSecurityParam . pbftParams
+
+  protocolSlotLength cfg _ledgerView = pbftSlotLength $ pbftParams cfg
 
   checkIsLeader PBftNodeConfig{pbftIsLeader, pbftParams} (SlotNo n) _l _cs =
       case pbftIsLeader of

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -179,6 +179,7 @@ data PraosParams = PraosParams {
     , praosSecurityParam :: SecurityParam
     , praosSlotsPerEpoch :: Word64
     , praosLifetimeKES   :: Natural
+    , praosSlotLength    :: SlotLength
     }
 
 instance PraosCrypto c => OuroborosTag (Praos c) where
@@ -192,6 +193,8 @@ instance PraosCrypto c => OuroborosTag (Praos c) where
     }
 
   protocolSecurityParam = praosSecurityParam . praosParams
+
+  protocolSlotLength cfg _ledgerView = praosSlotLength $ praosParams cfg
 
   type NodeState       (Praos c) = SignKeyKES (PraosKES c)
   type LedgerView      (Praos c) = StakeDist

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/WithEBBs.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/WithEBBs.hs
@@ -1,11 +1,10 @@
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UndecidableInstances       #-}
-{-# LANGUAGE UndecidableSuperClasses    #-}
-{-# LANGUAGE ViewPatterns               #-}
+{-# LANGUAGE FlexibleContexts        #-}
+{-# LANGUAGE MultiParamTypeClasses   #-}
+{-# LANGUAGE ScopedTypeVariables     #-}
+{-# LANGUAGE TypeApplications        #-}
+{-# LANGUAGE TypeFamilies            #-}
+{-# LANGUAGE UndecidableInstances    #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 module Ouroboros.Consensus.Protocol.WithEBBs
   ( WithEBBs
@@ -14,7 +13,7 @@ module Ouroboros.Consensus.Protocol.WithEBBs
   )
 where
 
-import Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.Abstract
 
 class ( SupportedHeader p (HeaderOfBlock hoe)
       ) => HeaderSupportsWithEBB p hoe where
@@ -51,10 +50,11 @@ instance (OuroborosTag p) => OuroborosTag (WithEBBs p) where
   checkIsLeader         (WithEBBNodeConfig cfg) = checkIsLeader         cfg
   rewindChainState      (WithEBBNodeConfig cfg) = rewindChainState      cfg
   protocolSecurityParam (WithEBBNodeConfig cfg) = protocolSecurityParam cfg
+  protocolSlotLength    (WithEBBNodeConfig cfg) = protocolSlotLength cfg
 
   applyChainState (WithEBBNodeConfig cfg) lv b cs = case
     eitherHeaderOrEbb cfg b of
       Right hdr -> applyChainState @p cfg lv hdr cs
       -- Currently the hash chain is maintained in the ledger state, so we just
       -- ignore the EBB for protocol concerns.
-      Left _ -> return cs
+      Left _    -> return cs

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -342,6 +342,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
       { bftParams   = BftParams
         { bftSecurityParam = securityParam
         , bftNumNodes      = 2
+        , bftSlotLength    = slotLengthFromSec 20
         }
       , bftNodeId   = fromCoreNodeId coreNodeId
       , bftSignKey  = SignKeyMockDSIGN 0

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
@@ -39,7 +39,13 @@ prop_simple_pbft_convergence
   where
     sigWin = fromIntegral $ nn * 10
     sigThd = (1.0 / fromIntegral nn) + 0.1
-    params = PBftParams k (fromIntegral nn) sigWin sigThd
+    params = PBftParams
+      { pbftSecurityParam      = k
+      , pbftNumNodes           = fromIntegral nn
+      , pbftSlotLength         = slotLengthFromSec 20
+      , pbftSignatureWindow    = sigWin
+      , pbftSignatureThreshold = sigThd
+      }
 
     testOutput =
         runTestNetwork

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -74,6 +74,7 @@ import qualified Ouroboros.Network.MockChain.ProducerState as CPS
 import qualified Ouroboros.Network.Point as Point
 
 import           Ouroboros.Consensus.Block (getHeader)
+import           Ouroboros.Consensus.BlockchainTime (slotLengthFromSec)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.NodeId (NodeId (..))
@@ -997,6 +998,7 @@ testCfg :: NodeConfig (BlockProtocol Blk)
 testCfg = BftNodeConfig
     { bftParams   = BftParams { bftSecurityParam = k
                               , bftNumNodes      = 1
+                              , bftSlotLength    = slotLengthFromSec 20
                               }
     , bftNodeId   = CoreId 0
     , bftSignKey  = SignKeyMockDSIGN 0

--- a/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
@@ -62,6 +62,7 @@ import           Ouroboros.Network.MockChain.Chain (Chain (..), Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.BlockchainTime (slotLengthFromSec)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.NodeId (NodeId (..))
@@ -273,6 +274,7 @@ singleNodeTestConfig :: NodeConfig (Bft BftMockCrypto)
 singleNodeTestConfig = BftNodeConfig {
       bftParams   = BftParams { bftSecurityParam = k
                               , bftNumNodes      = 1
+                              , bftSlotLength    = slotLengthFromSec 20
                               }
     , bftNodeId   = CoreId 0
     , bftSignKey  = SignKeyMockDSIGN 0


### PR DESCRIPTION
The `SlotLength` is not a general parameter, but specific to a protocol. For
example, for Byron, it can be derived from the Genesis Config, which is stored
inside the `NodeConfig`. The future `HardFork` protocol combinator can
determine which `SlotLength` to use based on the `LedgerView`.