### PR TITLE
Remove redundant constraints

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -91,10 +91,11 @@ library
                        Ouroboros.Consensus.Util.HList
                        Ouroboros.Consensus.Util.Orphans
                        Ouroboros.Consensus.Util.Random
+                       Ouroboros.Consensus.Util.RedundantConstraints
                        Ouroboros.Consensus.Util.ResourceRegistry
-                       Ouroboros.Consensus.Util.STM
                        Ouroboros.Consensus.Util.Singletons
                        Ouroboros.Consensus.Util.SlotBounded
+                       Ouroboros.Consensus.Util.STM
 
                        -- Storing things on disk
                        Ouroboros.Storage.Common

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo/Run.hs
@@ -38,7 +38,6 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
            -- some of the tests loop, but only when compiled with @-O2@ ; with
            -- @-O0@ it is perfectly fine. ghc bug?!
          , SupportedBlock (SimpleBlock SimpleMockCrypto ext)
-         , Show ext
          , Typeable ext
          , Serialise ext
          , ForgeExt (BlockProtocol (SimpleBlock SimpleMockCrypto ext))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -368,8 +368,7 @@ instance Condense (ChainHash (SimpleBlock' c ext ext')) where
 instance ToCBOR SimpleBody where
   toCBOR = encode
 
-encodeSimpleHeader :: SimpleCrypto c
-                   => (ext' -> CBOR.Encoding)
+encodeSimpleHeader :: (ext' -> CBOR.Encoding)
                    -> Header (SimpleBlock' c ext ext')
                    -> CBOR.Encoding
 encodeSimpleHeader encodeExt SimpleHeader{..} =  mconcat [

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/BFT.hs
@@ -18,7 +18,7 @@ import           Codec.Serialise (Serialise (..))
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 
-import           Cardano.Binary (ToCBOR(..))
+import           Cardano.Binary (ToCBOR (..))
 import           Cardano.Crypto.DSIGN
 
 import           Ouroboros.Consensus.Block
@@ -66,7 +66,7 @@ _simpleBFtHeader = simpleHeader
   Evidence that SimpleBlock can support BFT
 -------------------------------------------------------------------------------}
 
-instance SimpleCrypto c => SignedHeader (SimpleBftHeader c c') where
+instance SignedHeader (SimpleBftHeader c c') where
   type Signed (SimpleBftHeader c c') = SignedSimpleBft c c'
 
   headerSigned = SignedSimpleBft . simpleHeaderStd

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
@@ -18,7 +18,7 @@ import           Codec.Serialise (Serialise (..))
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 
-import           Cardano.Binary (ToCBOR(..))
+import           Cardano.Binary (ToCBOR (..))
 import           Cardano.Crypto.DSIGN
 
 import           Ouroboros.Consensus.Block
@@ -74,7 +74,7 @@ _simplePBftHeader = simpleHeader
   Evidence that SimpleBlock can support PBFT
 -------------------------------------------------------------------------------}
 
-instance SimpleCrypto c => SignedHeader (SimplePBftHeader c c') where
+instance SignedHeader (SimplePBftHeader c c') where
   type Signed (SimplePBftHeader c c') = SignedSimplePBft c c'
 
   headerSigned = SignedSimplePBft . simpleHeaderStd

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/Praos.hs
@@ -19,7 +19,7 @@ import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.Serialise (Serialise (..))
 import           GHC.Generics (Generic)
 
-import           Cardano.Binary (FromCBOR(..), ToCBOR(..))
+import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import           Cardano.Crypto.KES
 
 import           Ouroboros.Consensus.Block
@@ -76,8 +76,7 @@ _simplePraosHeader = simpleHeader
   Evidence that SimpleBlock can support BFT
 -------------------------------------------------------------------------------}
 
-instance (SimpleCrypto c, PraosCrypto c')
-      => SignedHeader (SimplePraosHeader c c') where
+instance PraosCrypto c' => SignedHeader (SimplePraosHeader c c') where
   type Signed (SimplePraosHeader c c') = SignedSimplePraos c c'
 
   headerSigned SimpleHeader{..} = SignedSimplePraos {

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -44,9 +44,8 @@ import           Ouroboros.Consensus.Util.STM (onEachChange)
 -------------------------------------------------------------------------------}
 
 openMempool :: ( MonadAsync m
-               , MonadFork m
-               , MonadMask m
-               , MonadSTM m
+               , MonadFork  m
+               , MonadMask  m
                , ApplyTx blk
                )
             => ResourceRegistry m
@@ -64,12 +63,7 @@ openMempool registry ledger cfg tracer = do
 --
 -- Intended for testing purposes.
 openMempoolWithoutSyncThread
-  :: ( MonadAsync m
-     , MonadFork m
-     , MonadMask m
-     , MonadSTM m
-     , ApplyTx blk
-     )
+  :: (MonadAsync m, ApplyTx blk)
   => LedgerInterface m blk
   -> LedgerConfig blk
   -> Tracer m (TraceEventMempool blk)
@@ -229,9 +223,7 @@ implWithSyncState mpEnv@MempoolEnv{mpEnvTracer, mpEnvStateVar} f = do
       traceWith mpEnvTracer $ TraceMempoolRemoveTxs removed mempoolSize
     return res
 
-implGetSnapshot :: ( MonadSTM m
-                   , ApplyTx blk
-                   )
+implGetSnapshot :: MonadSTM m
                 => MempoolEnv m blk
                 -> STM m (MempoolSnapshot blk TicketNo)
 implGetSnapshot MempoolEnv{mpEnvStateVar} = do
@@ -251,20 +243,17 @@ getMempoolSize MempoolEnv{mpEnvStateVar} =
   MempoolSnapshot Implementation
 -------------------------------------------------------------------------------}
 
-implSnapshotGetTxs :: ApplyTx blk
-                   => InternalState blk
+implSnapshotGetTxs :: InternalState blk
                    -> [(GenTx blk, TicketNo)]
 implSnapshotGetTxs = (flip implSnapshotGetTxsAfter) zeroTicketNo
 
-implSnapshotGetTxsAfter :: ApplyTx blk
-                        => InternalState blk
+implSnapshotGetTxsAfter :: InternalState blk
                         -> TicketNo
                         -> [(GenTx blk, TicketNo)]
 implSnapshotGetTxsAfter IS{isTxs} tn =
     fromTxSeq $ snd $ splitAfterTicketNo isTxs tn
 
-implSnapshotGetTx :: ApplyTx blk
-                  => InternalState blk
+implSnapshotGetTx :: InternalState blk
                   -> TicketNo
                   -> Maybe (GenTx blk)
 implSnapshotGetTx IS{isTxs} tn = isTxs `lookupByTicketNo` tn

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -45,8 +45,8 @@ import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Network.NodeToClient as NodeToClient
 import           Ouroboros.Network.NodeToNode as NodeToNode
 import           Ouroboros.Network.Socket
-import           Ouroboros.Network.Subscription.Ip
 import           Ouroboros.Network.Subscription.Dns
+import           Ouroboros.Network.Subscription.Ip
 
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
@@ -191,7 +191,7 @@ initChainDB tracer registry dbPath cfg initLedger slotLength
       }
 
 mkNodeArgs
-  :: forall blk peer. (RunNode blk, Ord peer)
+  :: forall blk peer. RunNode blk
   => ResourceRegistry IO
   -> NodeConfig (BlockProtocol blk)
   -> NodeState  (BlockProtocol blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
@@ -27,7 +27,6 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
            -- some of the tests loop, but only when compiled with @-O2@ ; with
            -- @-O0@ it is perfectly fine. ghc bug?!
          , SupportedBlock (SimpleBlock SimpleMockCrypto ext)
-         , Show ext
          , Typeable ext
          , Serialise ext
          , ForgeExt (BlockProtocol (SimpleBlock SimpleMockCrypto ext))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -11,7 +11,7 @@ module Ouroboros.Consensus.Node.Tracers
 
 import           Control.Tracer (Tracer, nullTracer, showTracing)
 
-import           Ouroboros.Network.Block (HasHeader, Point, SlotNo)
+import           Ouroboros.Network.Block (Point, SlotNo)
 import           Ouroboros.Network.BlockFetch (FetchDecision,
                      TraceFetchClientState, TraceLabelPeer)
 import           Ouroboros.Network.TxSubmission.Inbound
@@ -64,9 +64,7 @@ nullTracers = Tracers
   , forgeTracer                   = nullTracer
   }
 
-showTracers :: ( Monad m
-               , HasHeader blk
-               , Show blk
+showTracers :: ( Show blk
                , Show (GenTx blk)
                , Show (Header blk)
                , Show peer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/TxSubmission.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/TxSubmission.hs
@@ -20,9 +20,7 @@ import           Ouroboros.Consensus.Mempool.API
 -- | Local transaction submission server, for adding txs to the 'Mempool'
 --
 localTxSubmissionServer
-  :: ( Monad m
-     , ApplyTx blk
-     )
+  :: Monad m
   => Tracer m (TraceLocalTxSubmissionServerEvent blk)
   -> Mempool m blk idx
   -> LocalTxSubmissionServer (GenTx blk) (ApplyTxErr blk) m ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/RedundantConstraints.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/RedundantConstraints.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
+
+module Ouroboros.Consensus.Util.RedundantConstraints (
+    keepRedundantConstraint
+  ) where
+
+-- | Can be used to silence individual "redundant constraint" warnings
+--
+-- > foo :: ConstraintUsefulForDebugging => ...
+-- > foo =
+-- >     ..
+-- >   where
+-- >     _ = keepRedundantConstraint (Proxy @ConstraintUsefulForDebugging))
+keepRedundantConstraint :: c => proxy c -> ()
+keepRedundantConstraint _ = ()

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -15,7 +15,6 @@ import           Data.Maybe (fromMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as T
-import           Data.Typeable
 import           Data.Word (Word64)
 import           Text.Read (readMaybe)
 
@@ -63,7 +62,7 @@ modifyTMVar m action =
             ExitCaseAbort                -> putTMVar m oldState
        ) action
 
-wrapFsError :: (Monad m, Show blockId, Typeable blockId)
+wrapFsError :: Monad m
             => ErrorHandling FsError                   m
             -> ErrorHandling (VolatileDBError blockId) m
             -> m a -> m a
@@ -98,7 +97,7 @@ sizeAndId (size, bInfo) = (size, bbid bInfo)
 -- This should be used whenever you want to run an action on the VolatileDB
 -- and catch the 'VolatileDBError' and the 'FsError' (wrapped in the former)
 -- it may thrown.
-tryVolDB :: forall m blockId a. (Monad m, Show blockId)
+tryVolDB :: forall m blockId a. Monad m
          => ErrorHandling FsError                   m
          -> ErrorHandling (VolatileDBError blockId) m
          -> m a -> m (Either (VolatileDBError blockId) a)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -22,9 +22,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
 import           Control.Monad.Class.MonadAsync (MonadAsync)
-import           Control.Monad.Class.MonadFork (MonadFork)
 import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadThrow (MonadMask)
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Control.Tracer (Tracer (..))
@@ -410,8 +408,7 @@ withTestMempool setup@TestSetup { testLedgerState, testInitialTxs } prop =
   where
     cfg = ledgerConfigView singleNodeTestConfig
 
-    setUpAndRun :: forall m. (MonadAsync m, MonadMask m, MonadFork m)
-                => m Property
+    setUpAndRun :: forall m. MonadAsync m => m Property
     setUpAndRun = do
 
       -- Set up the LedgerInterface

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -47,7 +47,6 @@ runTestNetwork ::
   forall blk.
      ( RunNode blk
      , TxGen blk
-     , TracingConstraints blk
      )
   => (CoreNodeId -> ProtocolInfo blk)
   -> NumCoreNodes

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -47,6 +47,7 @@ runTestNetwork ::
   forall blk.
      ( RunNode blk
      , TxGen blk
+     , TracingConstraints blk
      )
   => (CoreNodeId -> ProtocolInfo blk)
   -> NumCoreNodes

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -62,6 +62,7 @@ import           Ouroboros.Consensus.NodeKernel
 import           Ouroboros.Consensus.NodeNetwork
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Orphans ()
+import           Ouroboros.Consensus.Util.RedundantConstraints
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM
 
@@ -186,6 +187,7 @@ broadcastNetwork :: forall m blk.
                     , MonadThrow (STM m)
                     , RunNode blk
                     , TxGen blk
+                    , TracingConstraints blk
                     , HasCallStack
                     )
                  => ResourceRegistry m
@@ -217,6 +219,8 @@ broadcastNetwork registry testBtime numCoreNodes pInfo initRNG slotLen = do
 
     getTestOutput nodes
   where
+    _ = keepRedundantConstraint (Proxy @(TracingConstraints blk))
+
     btime = testBlockchainTime testBtime
 
     nodeIds :: [NodeId]

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -186,7 +186,6 @@ broadcastNetwork :: forall m blk.
                     , MonadThrow (STM m)
                     , RunNode blk
                     , TxGen blk
-                    , TracingConstraints blk
                     , HasCallStack
                     )
                  => ResourceRegistry m


### PR DESCRIPTION
There were quite a few redundant constraints, especially in the volatile
DB, and it was making it difficult to see which constraints were
redundant due to refactoring of the resource registry. This PR literally
does nothing but remove those redundant constraints.