### PR TITLE
Add `link` to `MonadAsync`

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
@@ -23,6 +23,7 @@ import           Control.Monad.Class.MonadThrow
 
 import           Control.Monad (void)
 import           Control.Exception (SomeException)
+import qualified Control.Exception as E
 import qualified Control.Concurrent.Async as Async
 import           Control.Concurrent.Async (AsyncCancelled(..))
 import           Data.Proxy
@@ -299,7 +300,9 @@ instance Show ExceptionInLinkedThread where
       showString " " .
       showsPrec 11 e
 
-instance Exception ExceptionInLinkedThread
+instance Exception ExceptionInLinkedThread where
+  fromException = E.asyncExceptionFromException
+  toException = E.asyncExceptionToException
 
 linkTo :: (MonadAsync m, MonadFork m, MonadMask m)
        => ThreadId m -> Async m a -> m ()


### PR DESCRIPTION
This adds linking-a-la-async to the `MonadAsync` interface, although it's slightly more general, in that we allow linking to any thread. This is required for the refactoring of the `ResourceRegistry`, and has been tested as part of that also. 