### PR TITLE
export subscription result codes

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription.hs
@@ -7,6 +7,8 @@ module Ouroboros.Network.Subscription
       -- * DNS Subscription Worker
     , dnsSubscriptionWorker
     , DnsSubscriptionTarget (..)
+    , ConnectResult (..)
+
 
       -- * Constants
     , defaultConnectionAttemptDelay

--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Worker.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Worker.hs
@@ -12,6 +12,7 @@ module Ouroboros.Network.Subscription.Worker
   ( SocketStateChange
   , SocketState (..)
   , CompleteApplication
+  , ConnectResult (..)
   , Result (..)
   , Main
   , StateVar


### PR DESCRIPTION
export of result codes in subscription such that these can be interpreted in cardano-node
(PR https://github.com/input-output-hk/cardano-node/pull/150)