### PR TITLE
Move PBftChainState to its own module

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -79,6 +79,8 @@ library
                        Ouroboros.Consensus.Protocol.MockChainSel
                        Ouroboros.Consensus.Protocol.ModChainSel
                        Ouroboros.Consensus.Protocol.PBFT
+                       Ouroboros.Consensus.Protocol.PBFT.ChainState
+                       Ouroboros.Consensus.Protocol.PBFT.Crypto
                        Ouroboros.Consensus.Protocol.Praos
                        Ouroboros.Consensus.Protocol.Signed
                        Ouroboros.Consensus.Protocol.WithEBBs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
@@ -22,13 +22,12 @@ module Ouroboros.Consensus.Node.ProtocolInfo.Byron (
 
 import           Control.Exception (Exception)
 import           Control.Monad.Except
-import qualified Data.Map.Strict as Map
+import           Data.Maybe
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
-import           Data.Maybe
 
 import qualified Cardano.Chain.Block as Block
-import           Cardano.Chain.Common (BlockCount(..))
+import           Cardano.Chain.Common (BlockCount (..))
 import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Update as Update
@@ -42,6 +41,7 @@ import           Ouroboros.Consensus.NodeId (CoreNodeId)
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
 import           Ouroboros.Consensus.Protocol.PBFT
+import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
 import           Ouroboros.Consensus.Protocol.WithEBBs
 
 import           Ouroboros.Consensus.Ledger.Byron.Config
@@ -53,9 +53,9 @@ import qualified Test.Cardano.Chain.Genesis.Dummy as Dummy
 -------------------------------------------------------------------------------}
 
 data PBftLeaderCredentials = PBftLeaderCredentials {
-      plcSignKey     :: Crypto.SigningKey
-    , plcDlgCert     :: Delegation.Certificate
-    , plcCoreNodeId  :: CoreNodeId
+      plcSignKey    :: Crypto.SigningKey
+    , plcDlgCert    :: Delegation.Certificate
+    , plcCoreNodeId :: CoreNodeId
     } deriving Show
 
 -- | Make the 'PBftLeaderCredentials', with a couple sanity checks:
@@ -164,7 +164,7 @@ protocolInfoByron genesisConfig@Genesis.Config {
                 blsCurrent   = initState
               , blsSnapshots = Seq.empty
               }
-          , ouroborosChainState = initChainStateWithEBBs Map.empty
+          , ouroborosChainState = initChainStateWithEBBs CS.empty
           }
       , pInfoInitState  = ()
       }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/PBFT.hs
@@ -7,7 +7,6 @@ module Ouroboros.Consensus.Node.ProtocolInfo.Mock.PBFT (
 
 import           Codec.Serialise (Serialise (..))
 import qualified Data.Bimap as Bimap
-import qualified Data.Map.Strict as Map
 
 import           Cardano.Crypto.DSIGN
 
@@ -17,6 +16,7 @@ import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
 import           Ouroboros.Consensus.Protocol.PBFT
+import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
 
 protocolInfoMockPBFT :: NumCoreNodes
                      -> CoreNodeId
@@ -41,7 +41,7 @@ protocolInfoMockPBFT (NumCoreNodes numCoreNodes) (CoreNodeId nid) params =
                                ]
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
-                                         Map.empty
+                                         CS.empty
       , pInfoInitState  = ()
       }
   where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -27,41 +27,30 @@ module Ouroboros.Consensus.Protocol.PBFT (
   , HeaderSupportsPBft(..)
     -- * Type instances
   , NodeConfig(..)
-    -- * Exposed for testing purposes
-  , pruneChainState
-  , chainStateSize
   ) where
 
 import           Control.Monad.Except
 import           Crypto.Random (MonadRandom)
 import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
-import           Data.Constraint
-import           Data.List (sortOn)
-import           Data.Reflection (Given (..), give)
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import           Data.Reflection (give)
 import qualified Data.Set as Set
-import           Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
-import           Data.Typeable (Proxy(..), Typeable)
+import           Data.Typeable (Proxy (..), Typeable)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 
-import           Cardano.Binary (Decoded)
 import qualified Cardano.Chain.Common as CC.Common
-import qualified Cardano.Chain.Delegation as CC.Delegation
 import qualified Cardano.Chain.Genesis as CC.Genesis
-import           Cardano.Crypto (ProtocolMagicId)
 import           Cardano.Crypto.DSIGN.Class
-import           Cardano.Crypto.DSIGN.Mock (MockDSIGN)
 
-import           Ouroboros.Network.Block
-import           Ouroboros.Network.Point (WithOrigin (..))
+import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..))
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Cardano
-import           Ouroboros.Consensus.NodeId (CoreNodeId(..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.PBFT.ChainState (PBftChainState)
+import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
+import           Ouroboros.Consensus.Protocol.PBFT.Crypto
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util.Condense
 
@@ -169,13 +158,8 @@ instance (PBftCrypto c, Typeable c) => OuroborosTag (PBft c) where
   --   - Protocol parameters, for the signature window and threshold.
   --   - The delegation map.
   type LedgerView     (PBft c) = PBftLedgerView c
-
-  type IsLeader       (PBft c) = PBftIsLeader c
-
-  -- | Chain state consists of a map from genesis keys to the list of blocks
-  -- which they have issued.
-  type ChainState     (PBft c) =
-    Map (PBftVerKeyHash c) (Seq SlotNo)
+  type IsLeader       (PBft c) = PBftIsLeader   c
+  type ChainState     (PBft c) = PBftChainState c
 
   protocolSecurityParam = pbftSecurityParam . pbftParams
 
@@ -205,15 +189,8 @@ instance (PBftCrypto c, Typeable c) => OuroborosTag (PBft c) where
         Right () -> return ()
         Left err -> throwError $ PBftInvalidSignature err
 
-      -- We always include slot number 0 in case there are no signers yet.
-      let signers = pruneChainState winSize chainState
-          lastSlotOfSigner = \case
-            _ Seq.:|> s -> s
-            _           -> SlotNo 0
-          lastSlot =  maximum
-                   .  (SlotNo 0 :)
-                   $  lastSlotOfSigner
-                  <$> Map.elems signers
+      let signers  = CS.prune winSize chainState
+          lastSlot = CS.lastSlot signers
 
       -- FIXME confirm that non-strict inequality is ok in general.
       -- It's here because EBBs have the same slot as the first block of their
@@ -224,11 +201,11 @@ instance (PBftCrypto c, Typeable c) => OuroborosTag (PBft c) where
       case Bimap.lookupR (hashVerKey pbftIssuer) dms of
         Nothing -> throwError $ PBftNotGenesisDelegate (hashVerKey pbftIssuer) lv
         Just gk -> do
-          let totalSigners = chainStateSize signers
-              gkSigners = maybe 0 Seq.length $ Map.lookup gk signers
+          let totalSigners = CS.size          signers
+              gkSigners    = CS.countSignedBy signers gk
           when (totalSigners >= winSize && gkSigners > wt)
             $ throwError (PBftExceededSignThreshold totalSigners gkSigners)
-          return $! insertSigner gk (blockSlot b) $ pruneChainState (winSize + 2*k) chainState
+          return $! CS.insert gk (blockSlot b) $ CS.prune (winSize + 2*k) chainState
     where
       PBftParams{..} = pbftParams
       PBftFields{..} = headerPBftFields cfg b
@@ -236,67 +213,7 @@ instance (PBftCrypto c, Typeable c) => OuroborosTag (PBft c) where
       SecurityParam (fromIntegral -> k) = pbftSecurityParam
       wt = floor $ pbftSignatureThreshold * fromIntegral winSize
 
-  rewindChainState _ cs mSlot = case mSlot of
-    Origin
-        -> Just Map.empty
-    At slot
-        | all Seq.null $ Map.elems oldCs
-        -> Nothing
-        | otherwise
-        -> Just oldCs
-      where
-        oldCs = Seq.takeWhileL (<= slot) <$> cs
-
--- | Prune the chain state to the given size by dropping the signers in the
--- oldest slots.
-pruneChainState :: forall k v. (Ord k, Ord v)
-                => Int -> Map k (Seq v) -> Map k (Seq v)
-pruneChainState toSize cs = go
-    cs
-    (sortOn snd . Map.toAscList . Map.mapMaybe (Seq.lookup 0) $ cs)
-    (max 0 $ chainStateSize cs - toSize)
-  where
-    go :: Map k (Seq v)  -- ^ The chain state to prune
-       -> [(k, v)]       -- ^ Index: for each @k@ in the chain state, its
-                         -- oldest @v@ (slot).
-                         --
-                         -- INVARIANT: the @k@s in the chain state match the
-                         -- @k@s in the index.
-       -> Int            -- ^ How many elements left to drop
-       -> Map k (Seq v)
-    go fromCS idx toDrop = if toDrop <= 0 then fromCS else case idx of
-      [] -> fromCS
-      (gk,_):xs@((_,nextLowest):_) ->
-        let (newSeq, numDropped) = dropWhileL (< nextLowest) $ fromCS Map.! gk
-            newIdx = case newSeq of
-              x Seq.:<| _ -> sortOn snd $ (gk, x) : xs
-              _           -> xs
-        in go (Map.insert gk newSeq fromCS) newIdx (toDrop - numDropped)
-      -- Only one genesis key
-      (gk,_):[] ->
-        let newSeq = Seq.drop toDrop $ fromCS Map.! gk
-        in Map.insert gk newSeq fromCS
-
-chainStateSize :: Map k (Seq v) -> Int
-chainStateSize cs = sum $ Seq.length <$> Map.elems cs
-
--- | Variant of 'dropWhileL' which also returns the number of elements dropped
-dropWhileL :: (a -> Bool) -> Seq a -> (Seq a, Int)
-dropWhileL f s = let res = Seq.dropWhileL f s in
-  (res, Seq.length s - Seq.length res)
-
--- | Insert a signatory into the chain state.
-insertSigner
-  :: PBftCrypto c
-  => PBftVerKeyHash c
-  -> SlotNo
-  -> ChainState (PBft c)
-  -> ChainState (PBft c)
-insertSigner gk s =
-  Map.alter (\case
-      Just es -> Just $ es Seq.|> s
-      Nothing -> Just $ Seq.singleton s
-    ) gk
+  rewindChainState _ cs mSlot = CS.rewind mSlot cs
 
 {-------------------------------------------------------------------------------
   PBFT node order
@@ -337,100 +254,6 @@ data PBftValidationErr c
   | PBftInvalidSlot
 
 deriving instance (Show (PBftLedgerView c), PBftCrypto c) => Show (PBftValidationErr c)
-
-{-------------------------------------------------------------------------------
-  Crypto models
--------------------------------------------------------------------------------}
-
--- | Crypto primitives required by BFT
-class ( Typeable c
-      , DSIGNAlgorithm (PBftDSIGN c)
-      , Condense (SigDSIGN (PBftDSIGN c))
-      , Show (PBftVerKeyHash c)
-      , Ord (PBftVerKeyHash c)
-      , Eq (PBftVerKeyHash c)
-      , Show (PBftVerKeyHash c)
-      ) => PBftCrypto c where
-  type family PBftDSIGN c :: *
-
-  type family PBftDelegationCert c = (d :: *) | d -> c
-
-  dlgCertGenVerKey :: PBftDelegationCert c -> VerKeyDSIGN (PBftDSIGN c)
-  dlgCertDlgVerKey :: PBftDelegationCert c -> VerKeyDSIGN (PBftDSIGN c)
-
-  -- Cardano stores a map of stakeholder IDs rather than the verification key
-  -- directly. We make this family injective for convenience - whilst it's
-  -- _possible_ that there could be non-injective instances, the chances of there
-  -- being more than the two instances here are basically non-existent.
-  type family PBftVerKeyHash c = (d :: *) | d -> c
-
-  type family PBftSigningConstraints c hdr :: Constraint
-
-  hashVerKey :: VerKeyDSIGN (PBftDSIGN c) -> PBftVerKeyHash c
-
-  -- Abstracted version of `verifySignedDSIGN`
-  --
-  -- Since our signing constraints differ, we abstract this here such that we can
-  -- correctly assemble the constraints in the real crypto case. See the
-  -- documentation in Crypto/DSIGN/Cardano for more details.
-  verifyPBftSigned :: forall hdr proxy. (PBftSigningConstraints c hdr)
-                   => proxy (c, hdr)
-                   -> VerKeyDSIGN (PBftDSIGN c) -- Genesis key - only used in the real impl
-                   -> VerKeyDSIGN (PBftDSIGN c)
-                   -> Signed hdr
-                   -> SignedDSIGN (PBftDSIGN c) (Signed hdr) -> Either String ()
-
-data PBftMockCrypto
-
-instance PBftCrypto PBftMockCrypto where
-  type PBftDSIGN      PBftMockCrypto = MockDSIGN
-
-  type PBftDelegationCert PBftMockCrypto = (VerKeyDSIGN MockDSIGN, VerKeyDSIGN MockDSIGN)
-
-  dlgCertGenVerKey = fst
-  dlgCertDlgVerKey = snd
-
-  type PBftVerKeyHash PBftMockCrypto = VerKeyDSIGN MockDSIGN
-
-  type PBftSigningConstraints PBftMockCrypto hdr = Signable MockDSIGN (Signed hdr)
-
-  hashVerKey = id
-
-  verifyPBftSigned _ _ = verifySignedDSIGN
-
-data PBftCardanoCrypto
-
-instance (Given ProtocolMagicId) => PBftCrypto PBftCardanoCrypto where
-  type PBftDSIGN PBftCardanoCrypto      = CardanoDSIGN
-
-  type PBftDelegationCert PBftCardanoCrypto = CC.Delegation.Certificate
-
-  dlgCertGenVerKey = VerKeyCardanoDSIGN . CC.Delegation.issuerVK
-  dlgCertDlgVerKey = VerKeyCardanoDSIGN . CC.Delegation.delegateVK
-
-  type PBftVerKeyHash PBftCardanoCrypto = CC.Common.KeyHash
-
-  type PBftSigningConstraints PBftCardanoCrypto hdr
-    = ( Decoded (Signed hdr)
-      , Given (VerKeyDSIGN CardanoDSIGN) :=> HasSignTag (Signed hdr)
-      )
-
-  hashVerKey (VerKeyCardanoDSIGN pk) = CC.Common.hashKey pk
-
-  -- This uses some hackery from the 'constraints' package to assemble a
-  -- `HasSignTag` constraint from a `Given` constraint and a reified instance of
-  -- the instance head/body relationship between the two.
-  --
-  -- See
-  -- https://hackage.haskell.org/package/constraints-0.10.1/docs/Data-Constraint.html#v:-92--92-
-  -- for details.
-  verifyPBftSigned (_ :: proxy (PBftCardanoCrypto, hdr)) gkVerKey issuer hSig sig
-    = give gkVerKey $
-      (verifySignedDSIGN
-        issuer
-        hSig
-        sig \\
-        (ins :: Given (VerKeyDSIGN CardanoDSIGN) :- HasSignTag (Signed hdr) ))
 
 {-------------------------------------------------------------------------------
   Condense

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/ChainState.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/ChainState.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+-- | PBFT chain state
+--
+-- Intended for qualified import.
+module Ouroboros.Consensus.Protocol.PBFT.ChainState (
+    PBftChainState
+  , empty
+  , prune
+  , size
+  , insert
+  , rewind
+  , lastSlot
+  , countSignedBy
+    -- * Primarily for tests
+  , fromMap
+  ) where
+
+import           Codec.Serialise (Serialise)
+import           Data.List (sortOn)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+
+import           Ouroboros.Network.Block (SlotNo (..))
+import           Ouroboros.Network.Point (WithOrigin (..))
+
+import           Ouroboros.Consensus.Protocol.PBFT.Crypto
+
+-- | PBFT chain satte
+--
+-- The PBFT chain state consists of a map from genesis keys to the list of
+-- blocks which they have issued.
+newtype PBftChainState c = PBftChainState (Map (PBftVerKeyHash c) (Seq SlotNo))
+
+-- | Construct chain state from a map
+--
+-- Used for testing only.
+fromMap :: Map (PBftVerKeyHash c) (Seq SlotNo) -> PBftChainState c
+fromMap = PBftChainState
+
+deriving instance PBftCrypto c => Show (PBftChainState c)
+deriving instance PBftCrypto c => Eq   (PBftChainState c)
+
+-- | Don't require PBftCrypto (we don't need the 'Given' constraint here)
+deriving instance ( Ord       (PBftVerKeyHash c)
+                  , Serialise (PBftVerKeyHash c)
+                  ) => Serialise (PBftChainState c)
+
+empty :: PBftChainState c
+empty = PBftChainState Map.empty
+
+-- | Prune the chain state to the given size by dropping the signers in the
+-- oldest slots.
+prune :: forall c. PBftCrypto c => Int -> PBftChainState c -> PBftChainState c
+prune toSize st@(PBftChainState cs) = PBftChainState $ go
+    cs
+    (sortOn snd . Map.toAscList . Map.mapMaybe (Seq.lookup 0) $ cs)
+    (max 0 $ size st - toSize)
+  where
+    go :: (Ord k, Ord v)
+       => Map k (Seq v)  -- ^ The chain state to prune
+       -> [(k, v)]       -- ^ Index: for each @k@ in the chain state, its
+                         -- oldest @v@ (slot).
+                         --
+                         -- INVARIANT: the @k@s in the chain state match the
+                         -- @k@s in the index.
+       -> Int            -- ^ How many elements left to drop
+       -> Map k (Seq v)
+    go fromCS idx toDrop = if toDrop <= 0 then fromCS else case idx of
+      [] -> fromCS
+      (gk,_):xs@((_,nextLowest):_) ->
+        let (newSeq, numDropped) = dropWhileL (< nextLowest) $ fromCS Map.! gk
+            newIdx = case newSeq of
+              x Seq.:<| _ -> sortOn snd $ (gk, x) : xs
+              _           -> xs
+        in go (Map.insert gk newSeq fromCS) newIdx (toDrop - numDropped)
+      -- Only one genesis key
+      (gk,_):[] ->
+        let newSeq = Seq.drop toDrop $ fromCS Map.! gk
+        in Map.insert gk newSeq fromCS
+
+size :: PBftChainState c -> Int
+size (PBftChainState cs) = sum $ Seq.length <$> Map.elems cs
+
+-- | Insert a signatory into the chain state.
+insert
+  :: PBftCrypto c
+  => PBftVerKeyHash c
+  -> SlotNo
+  -> PBftChainState c
+  -> PBftChainState c
+insert gk s (PBftChainState cs) = PBftChainState $
+  Map.alter (\case
+      Just es -> Just $ es Seq.|> s
+      Nothing -> Just $ Seq.singleton s
+    ) gk cs
+
+rewind :: WithOrigin SlotNo -> PBftChainState c -> Maybe (PBftChainState c)
+rewind mSlot (PBftChainState cs) = PBftChainState <$> case mSlot of
+    Origin
+        -> Just Map.empty
+    At slot
+        | all Seq.null $ Map.elems oldCs
+        -> Nothing
+        | otherwise
+        -> Just oldCs
+      where
+        oldCs = Seq.takeWhileL (<= slot) <$> cs
+
+-- We always include slot number 0 in case there are no signers yet.
+lastSlot :: PBftChainState c -> SlotNo
+lastSlot (PBftChainState cs) =
+        maximum
+     .  (SlotNo 0 :)
+     $  lastSlotOfSigner
+    <$> Map.elems cs
+  where
+    lastSlotOfSigner :: Seq SlotNo -> SlotNo
+    lastSlotOfSigner = \case
+      _ Seq.:|> s -> s
+      _           -> SlotNo 0
+
+countSignedBy :: PBftCrypto c => PBftChainState c -> PBftVerKeyHash c -> Int
+countSignedBy (PBftChainState cs) gk = maybe 0 Seq.length $ Map.lookup gk cs
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary
+-------------------------------------------------------------------------------}
+
+-- | Variant of 'dropWhileL' which also returns the number of elements dropped
+dropWhileL :: (a -> Bool) -> Seq a -> (Seq a, Int)
+dropWhileL f s = let res = Seq.dropWhileL f s in
+  (res, Seq.length s - Seq.length res)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/Crypto.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/Crypto.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE KindSignatures         #-}
+{-# LANGUAGE ScopedTypeVariables    #-}
+{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators          #-}
+{-# LANGUAGE UndecidableInstances   #-}
+
+module Ouroboros.Consensus.Protocol.PBFT.Crypto (
+    PBftCrypto(..)
+  , PBftMockCrypto
+  , PBftCardanoCrypto
+  ) where
+
+import           Data.Constraint
+import           Data.Reflection (Given (..), give)
+import           Data.Typeable
+
+import           Cardano.Binary (Decoded)
+import qualified Cardano.Chain.Common as CC.Common
+import qualified Cardano.Chain.Delegation as CC.Delegation
+import           Cardano.Crypto (ProtocolMagicId)
+import           Cardano.Crypto.DSIGN.Class
+import           Cardano.Crypto.DSIGN.Mock (MockDSIGN)
+
+import           Ouroboros.Consensus.Crypto.DSIGN.Cardano
+import           Ouroboros.Consensus.Protocol.Signed
+import           Ouroboros.Consensus.Util.Condense
+
+-- | Crypto primitives required by BFT
+class ( Typeable c
+      , DSIGNAlgorithm (PBftDSIGN c)
+      , Condense (SigDSIGN (PBftDSIGN c))
+      , Show (PBftVerKeyHash c)
+      , Ord (PBftVerKeyHash c)
+      , Eq (PBftVerKeyHash c)
+      , Show (PBftVerKeyHash c)
+      ) => PBftCrypto c where
+  type family PBftDSIGN c :: *
+
+  type family PBftDelegationCert c = (d :: *) | d -> c
+
+  dlgCertGenVerKey :: PBftDelegationCert c -> VerKeyDSIGN (PBftDSIGN c)
+  dlgCertDlgVerKey :: PBftDelegationCert c -> VerKeyDSIGN (PBftDSIGN c)
+
+  -- Cardano stores a map of stakeholder IDs rather than the verification key
+  -- directly. We make this family injective for convenience - whilst it's
+  -- _possible_ that there could be non-injective instances, the chances of there
+  -- being more than the two instances here are basically non-existent.
+  type family PBftVerKeyHash c = (d :: *) | d -> c
+
+  type family PBftSigningConstraints c hdr :: Constraint
+
+  hashVerKey :: VerKeyDSIGN (PBftDSIGN c) -> PBftVerKeyHash c
+
+  -- Abstracted version of `verifySignedDSIGN`
+  --
+  -- Since our signing constraints differ, we abstract this here such that we can
+  -- correctly assemble the constraints in the real crypto case. See the
+  -- documentation in Crypto/DSIGN/Cardano for more details.
+  verifyPBftSigned :: forall hdr proxy. (PBftSigningConstraints c hdr)
+                   => proxy (c, hdr)
+                   -> VerKeyDSIGN (PBftDSIGN c) -- Genesis key - only used in the real impl
+                   -> VerKeyDSIGN (PBftDSIGN c)
+                   -> Signed hdr
+                   -> SignedDSIGN (PBftDSIGN c) (Signed hdr) -> Either String ()
+
+data PBftMockCrypto
+
+instance PBftCrypto PBftMockCrypto where
+  type PBftDSIGN      PBftMockCrypto = MockDSIGN
+
+  type PBftDelegationCert PBftMockCrypto = (VerKeyDSIGN MockDSIGN, VerKeyDSIGN MockDSIGN)
+
+  dlgCertGenVerKey = fst
+  dlgCertDlgVerKey = snd
+
+  type PBftVerKeyHash PBftMockCrypto = VerKeyDSIGN MockDSIGN
+
+  type PBftSigningConstraints PBftMockCrypto hdr = Signable MockDSIGN (Signed hdr)
+
+  hashVerKey = id
+
+  verifyPBftSigned _ _ = verifySignedDSIGN
+
+data PBftCardanoCrypto
+
+instance (Given ProtocolMagicId) => PBftCrypto PBftCardanoCrypto where
+  type PBftDSIGN PBftCardanoCrypto      = CardanoDSIGN
+
+  type PBftDelegationCert PBftCardanoCrypto = CC.Delegation.Certificate
+
+  dlgCertGenVerKey = VerKeyCardanoDSIGN . CC.Delegation.issuerVK
+  dlgCertDlgVerKey = VerKeyCardanoDSIGN . CC.Delegation.delegateVK
+
+  type PBftVerKeyHash PBftCardanoCrypto = CC.Common.KeyHash
+
+  type PBftSigningConstraints PBftCardanoCrypto hdr
+    = ( Decoded (Signed hdr)
+      , Given (VerKeyDSIGN CardanoDSIGN) :=> HasSignTag (Signed hdr)
+      )
+
+  hashVerKey (VerKeyCardanoDSIGN pk) = CC.Common.hashKey pk
+
+  -- This uses some hackery from the 'constraints' package to assemble a
+  -- `HasSignTag` constraint from a `Given` constraint and a reified instance of
+  -- the instance head/body relationship between the two.
+  --
+  -- See
+  -- https://hackage.haskell.org/package/constraints-0.10.1/docs/Data-Constraint.html#v:-92--92-
+  -- for details.
+  verifyPBftSigned (_ :: proxy (PBftCardanoCrypto, hdr)) gkVerKey issuer hSig sig
+    = give gkVerKey $
+      (verifySignedDSIGN
+        issuer
+        hSig
+        sig \\
+        (ins :: Given (VerKeyDSIGN CardanoDSIGN) :- HasSignTag (Signed hdr) ))


### PR DESCRIPTION
This PR is a refactoring only, and makes no semantic changes. It moves the PBFT chain state to its own module, so that we can more precisely delineate what it's API is. This paves the way for changing this data structure (if possible) without changing its API; this is necessary, because profiling suggests that `prune` is taking up more than 50% of the total runtime of the Byron proxy :-o 

I will start looking at changing this data structure next. 