### PR TITLE
Rewrite PBftChainState

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Demo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Demo.hs
@@ -39,7 +39,6 @@ defaultDemoPBftParams :: PBftParams
 defaultDemoPBftParams = PBftParams {
       pbftSecurityParam      = defaultSecurityParam
     , pbftNumNodes           = nn
-    , pbftSignatureWindow    = fromIntegral $ nn * 10
     , pbftSignatureThreshold = (1.0 / fromIntegral nn) + 0.1
     }
   where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
@@ -132,7 +132,6 @@ protocolInfoByron genesisConfig@Genesis.Config {
                   , pbftNumNodes           = fromIntegral . Set.size
                                            . Genesis.unGenesisKeyHashes
                                            $ genesisKeyHashes
-                  , pbftSignatureWindow    = fromIntegral kParam
                   , pbftSignatureThreshold = unSignatureThreshold $
                       fromMaybe defaultPBftSignatureThreshold mSigThresh
                   }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -190,7 +190,12 @@ class ( Show (ChainState    p)
   -- and will yield 'Nothing'.
   rewindChainState :: NodeConfig p
                    -> ChainState p
-                   -> WithOrigin SlotNo -- ^ Slot to rewind to.
+                   -> WithOrigin SlotNo
+                   -- ^ Slot to rewind to
+                   --
+                   -- This should be the state at the /end/ of the specified
+                   -- slot (i.e., after the block in that slot, if any, has
+                   -- been applied).
                    -> Maybe (ChainState p)
 
 -- | Protocol security parameter
@@ -203,7 +208,7 @@ class ( Show (ChainState    p)
 -- NOTE: This talks about the number of /blocks/ we can roll back, not
 -- the number of /slots/.
 newtype SecurityParam = SecurityParam { maxRollbacks :: Word64 }
-  deriving (Eq)
+  deriving (Show, Eq)
 
 {-------------------------------------------------------------------------------
   State monad

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/ChainState.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/ChainState.hs
@@ -1,140 +1,320 @@
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
 -- | PBFT chain state
 --
 -- Intended for qualified import.
 module Ouroboros.Consensus.Protocol.PBFT.ChainState (
-    PBftChainState
+    PBftChainState(..)
+    -- * Construction
   , empty
-  , prune
-  , size
   , insert
+  , prune
   , rewind
-  , lastSlot
+    -- * Queries
+  , size
   , countSignedBy
-    -- * Primarily for tests
+  , lastSlot
+    -- * Support for tests
   , fromMap
   ) where
 
-import           Codec.Serialise (Serialise)
+import           Codec.Serialise (Serialise (..))
+import qualified Codec.Serialise.Decoding as Serialise
+import qualified Codec.Serialise.Encoding as Serialise
+import           Data.Foldable (toList)
 import           Data.List (sortOn)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Sequence (Seq)
+import           Data.Sequence (Seq ((:<|), (:|>)), (|>))
 import qualified Data.Sequence as Seq
+import           Data.Tuple (swap)
+import           Data.Word
 
 import           Ouroboros.Network.Block (SlotNo (..))
-import           Ouroboros.Network.Point (WithOrigin (..))
+import           Ouroboros.Network.Point (WithOrigin (..), withOriginFromMaybe,
+                     withOriginToMaybe)
 
 import           Ouroboros.Consensus.Protocol.PBFT.Crypto
+import           Ouroboros.Consensus.Util (nTimes, repeatedly)
 
--- | PBFT chain satte
---
--- The PBFT chain state consists of a map from genesis keys to the list of
--- blocks which they have issued.
-newtype PBftChainState c = PBftChainState (Map (PBftVerKeyHash c) (Seq SlotNo))
+{-------------------------------------------------------------------------------
+  Types
+-------------------------------------------------------------------------------}
 
--- | Construct chain state from a map
+-- | PBFT chain state
 --
--- Used for testing only.
-fromMap :: Map (PBftVerKeyHash c) (Seq SlotNo) -> PBftChainState c
-fromMap = PBftChainState
+-- The PBFT chain state records for the last @n@ slots who signed those slots
+-- (in terms of genesis keys). It is used to check that a single node has not
+-- signed more than a certain percentage threshold of the slots (that check
+-- is not implemented here, however).
+--
+-- The window size @n@ can be set pretty much arbitrarily. However, in order for
+-- the chain state to be able to roll back at least @k@ blocks, we must have
+-- that @n >= k@.
+--
+-- The performance of this code is not that important during normal node
+-- operation, as it will only be used when a new block comes in. However, it
+-- can potentially become a bottleneck during syncing.
+data PBftChainState c = PBftChainState {
+      -- | Anchor
+      --
+      -- The anchor is the slot number of the block before the first block
+      -- in the state.
+      --
+      -- Suppose we have a window size of 5 (i.e., we 'prune' the state with a
+      -- maximum size of 5). Then the state evolves as follows (G = genesis):
+      --
+      -- > anchor | max rollback | blocks
+      -- > --------------------------------------------
+      -- > G      | 0 (G)        | []
+      -- > G      | 1 (G)        | [B1]
+      -- > G      | 2 (G)        | [B1, B2]
+      -- > G      | 3 (G)        | [B1, B2, B3]
+      -- > G      | 4 (G)        | [B1, B2, B3, B4]
+      -- > G      | 4 (B1)       | [B1, B2, B3, B4, B5]
+      -- > S1     | 4 (B2)       | [B2, B3, B4, B5, B6]       (S1 slot of B1)
+      -- > S2     | 4 (B3)       | [B3, B4, B5, B6, B7]
+      --
+      -- The table above also shows the maximum rollback, as well as the oldest
+      -- block we should be able to roll back to, given @k=4@.
+      --
+      -- Note what happens when we set the window size to be /equal/ to @k@:
+      --
+      -- > anchor | max rollback | blocks
+      -- > ----------------------------------------
+      -- > G      | 0 (G)        | []
+      -- > G      | 1 (G)        | [B1]
+      -- > G      | 2 (G)        | [B1, B2]
+      -- > G      | 3 (G)        | [B1, B2, B3]
+      -- > G      | 4 (G)        | [B1, B2, B3, B4]
+      -- > S1     | 4 (B1)       | [B2, B3, B4, B5]
+      -- > S2     | 4 (B2)       | [B3, B4, B5, B6]
+      -- > S3     | 4 (B3)       | [B4, B5, B6, B7]
+      --
+      -- At this point the anchor becomes equal to the (slot number of) the
+      -- oldest block that we can roll back to.
+      anchor  :: WithOrigin SlotNo
+
+      -- | Sequence in increasing order of slots and corresponding genesis keys
+    , signers :: !(Seq (SlotNo, PBftVerKeyHash c))
+
+      -- | Count for each genesis key
+      --
+      -- Invariant:
+      --
+      -- > counts == fromSlots signers
+      --
+      -- We maintain it as an explicit value for improved performance.
+    , counts  :: !(Map (PBftVerKeyHash c) Int)
+    }
 
 deriving instance PBftCrypto c => Show (PBftChainState c)
 deriving instance PBftCrypto c => Eq   (PBftChainState c)
 
--- | Don't require PBftCrypto (we don't need the 'Given' constraint here)
-deriving instance ( Ord       (PBftVerKeyHash c)
-                  , Serialise (PBftVerKeyHash c)
-                  ) => Serialise (PBftChainState c)
-
-empty :: PBftChainState c
-empty = PBftChainState Map.empty
-
--- | Prune the chain state to the given size by dropping the signers in the
--- oldest slots.
-prune :: forall c. PBftCrypto c => Int -> PBftChainState c -> PBftChainState c
-prune toSize st@(PBftChainState cs) = PBftChainState $ go
-    cs
-    (sortOn snd . Map.toAscList . Map.mapMaybe (Seq.lookup 0) $ cs)
-    (max 0 $ size st - toSize)
-  where
-    go :: (Ord k, Ord v)
-       => Map k (Seq v)  -- ^ The chain state to prune
-       -> [(k, v)]       -- ^ Index: for each @k@ in the chain state, its
-                         -- oldest @v@ (slot).
-                         --
-                         -- INVARIANT: the @k@s in the chain state match the
-                         -- @k@s in the index.
-       -> Int            -- ^ How many elements left to drop
-       -> Map k (Seq v)
-    go fromCS idx toDrop = if toDrop <= 0 then fromCS else case idx of
-      [] -> fromCS
-      (gk,_):xs@((_,nextLowest):_) ->
-        let (newSeq, numDropped) = dropWhileL (< nextLowest) $ fromCS Map.! gk
-            newIdx = case newSeq of
-              x Seq.:<| _ -> sortOn snd $ (gk, x) : xs
-              _           -> xs
-        in go (Map.insert gk newSeq fromCS) newIdx (toDrop - numDropped)
-      -- Only one genesis key
-      (gk,_):[] ->
-        let newSeq = Seq.drop toDrop $ fromCS Map.! gk
-        in Map.insert gk newSeq fromCS
-
-size :: PBftChainState c -> Int
-size (PBftChainState cs) = sum $ Seq.length <$> Map.elems cs
-
--- | Insert a signatory into the chain state.
-insert
-  :: PBftCrypto c
-  => PBftVerKeyHash c
-  -> SlotNo
-  -> PBftChainState c
-  -> PBftChainState c
-insert gk s (PBftChainState cs) = PBftChainState $
-  Map.alter (\case
-      Just es -> Just $ es Seq.|> s
-      Nothing -> Just $ Seq.singleton s
-    ) gk cs
-
-rewind :: WithOrigin SlotNo -> PBftChainState c -> Maybe (PBftChainState c)
-rewind mSlot (PBftChainState cs) = PBftChainState <$> case mSlot of
-    Origin
-        -> Just Map.empty
-    At slot
-        | all Seq.null $ Map.elems oldCs
-        -> Nothing
-        | otherwise
-        -> Just oldCs
-      where
-        oldCs = Seq.takeWhileL (<= slot) <$> cs
-
--- We always include slot number 0 in case there are no signers yet.
-lastSlot :: PBftChainState c -> SlotNo
-lastSlot (PBftChainState cs) =
-        maximum
-     .  (SlotNo 0 :)
-     $  lastSlotOfSigner
-    <$> Map.elems cs
-  where
-    lastSlotOfSigner :: Seq SlotNo -> SlotNo
-    lastSlotOfSigner = \case
-      _ Seq.:|> s -> s
-      _           -> SlotNo 0
-
-countSignedBy :: PBftCrypto c => PBftChainState c -> PBftVerKeyHash c -> Int
-countSignedBy (PBftChainState cs) gk = maybe 0 Seq.length $ Map.lookup gk cs
-
 {-------------------------------------------------------------------------------
-  Internal auxiliary
+  Queries
 -------------------------------------------------------------------------------}
 
--- | Variant of 'dropWhileL' which also returns the number of elements dropped
-dropWhileL :: (a -> Bool) -> Seq a -> (Seq a, Int)
-dropWhileL f s = let res = Seq.dropWhileL f s in
-  (res, Seq.length s - Seq.length res)
+-- | Total number of signed slots
+--
+-- This is in terms of /blocks/, not slots.
+--
+-- Pruning limits the size:
+--
+-- > size (prune n st) <= n
+-- > size (prune n st) == n  if  size st >= n
+size :: PBftChainState c -> Int
+size = Seq.length . signers
+
+-- | The number of blocks signed by the specified genesis key
+countSignedBy :: PBftCrypto c => PBftChainState c -> PBftVerKeyHash c -> Int
+countSignedBy st gk = Map.findWithDefault 0 gk (counts st)
+
+-- | The last (most recent) signed slot in the window
+--
+-- Any new blocks should be in slots /after/ the 'lastSlot'.
+--
+-- Returns the anchor if empty.
+lastSlot :: PBftChainState c -> WithOrigin SlotNo
+lastSlot st =
+    case signers st of
+      _ :|> (slot, _) -> At slot
+      _otherwise      -> anchor st
+
+{-------------------------------------------------------------------------------
+  Construction
+-------------------------------------------------------------------------------}
+
+-- | Empty PBFT chain state
+--
+-- In other words, the PBFT chain state corresponding to genesis.
+empty :: PBftChainState c
+empty = PBftChainState {
+      anchor  = Origin
+    , signers = Seq.empty
+    , counts  = Map.empty
+    }
+
+-- | Insert new signed block into the state
+insert :: PBftCrypto c
+       => PBftVerKeyHash c -> SlotNo -> PBftChainState c -> PBftChainState c
+insert gk slot st = PBftChainState {
+      anchor  = anchor st -- anchor doesn't change because first block doesn't
+    , signers = signers st |> (slot, gk)
+    , counts  = incrementKey gk (counts st)
+    }
+
+-- | Internal: drop the oldest slot (if one exists)
+--
+-- Precondition: state is not empty.
+--
+-- (Used in 'prune', which establishes the precondition.)
+dropOldest :: PBftCrypto c => PBftChainState c -> PBftChainState c
+dropOldest st =
+    case signers st of
+      (slot, gk) :<| signers' ->
+        PBftChainState {
+            anchor  = At slot
+          , signers = signers'
+          , counts  = decrementKey gk (counts st)
+          }
+      _otherwise ->
+        error "dropOldest: empty PBftChainState"
+
+-- | Prune to the given maximum size
+prune :: forall c. PBftCrypto c => Int -> PBftChainState c -> PBftChainState c
+prune maxSize st
+  | size st > maxSize = nTimes dropOldest toDrop st
+  | otherwise         = st
+  where
+    toDrop :: Word64
+    toDrop = fromIntegral (size st - maxSize)
+
+-- | Rewind the state to the specified slot
+--
+-- This matches the semantics of 'rewindChainState' in 'OuroborosTag', in that
+-- this should be the state at the /end/ of the specified slot (i.e., after the
+-- block in that slot, if any, has been applied).
+--
+-- NOTE: It only makes sense to rewind to a slot containing a block that we have
+-- previously applied (the "genesis block" can be understood as having been
+-- implicitly applied). This will be implicitly assumed in the properies below.
+--
+-- = Properties
+--
+-- * Rewinding to the last applied block is an identity
+--
+--   > rewind (lastSlot st) st == Just st
+--
+-- * Rewinding to the same slot should be idempotent:
+--
+--   > rewind s st == Just st'  ==>  rewind s st' == Just st'
+--
+-- * Rewinding fails only if the slot is before the anchor
+--
+--   > rewind s st == Nothing  iff  s < anchor st
+--
+--   (See documentation of 'anchor' for motivation)
+--
+-- * If rewinding to a particular slot fails, rewinding to any slot prior to
+--   that will also fail
+--
+--   > rewind s st == Nothing, s' < s  ==>  rewind s' st == Nothing
+--
+-- * Rewinding to the anchor will leave the state empty
+--
+--   > size (rewind (anchor s) st) == 0
+--
+-- * But rewinding to a more recent block will not
+--
+--   > s > anchor st  ==>  size (rewind s st) > 0
+rewind :: PBftCrypto c
+       => WithOrigin SlotNo -> PBftChainState c -> Maybe (PBftChainState c)
+rewind slot st
+  | slot < anchor st = Nothing
+  | otherwise = Just $ PBftChainState {
+        anchor  = anchor st
+      , signers = keep
+      -- Typically we only drop a few blocks (and keep most), so updating
+      -- the counts based on what we drop will in most cases be faster than
+      -- recomputing it from the blocks we keep.
+      , counts  = repeatedly (decrementKey . snd) (toList discard) (counts st)
+      }
+  where
+    (keep, discard) = Seq.spanl (\(slot', _) -> At slot' <= slot) (signers st)
+
+{-------------------------------------------------------------------------------
+  Internal
+-------------------------------------------------------------------------------}
+
+fromSlots :: Ord gk => Seq (slot, gk) -> Map gk Int
+fromSlots slots = repeatedly (incrementKey . snd) (toList slots) Map.empty
+
+incrementKey :: Ord gk => gk -> Map gk Int -> Map gk Int
+incrementKey = Map.alter inc
+  where
+    inc :: Maybe Int -> Maybe Int
+    inc Nothing  = Just 1
+    inc (Just n) = Just (n + 1)
+
+decrementKey :: Ord gk => gk -> Map gk Int -> Map gk Int
+decrementKey = Map.alter dec
+  where
+    dec :: Maybe Int -> Maybe Int
+    dec Nothing  = error "decrementKey: key does not exist"
+    dec (Just 1) = Nothing
+    dec (Just n) = Just (n - 1)
+
+{-------------------------------------------------------------------------------
+  Support for tests
+-------------------------------------------------------------------------------}
+
+-- | Construct PBFT chain state from map listing signed slots per key
+fromMap :: forall c. PBftCrypto c
+        => WithOrigin SlotNo -- ^ Anchor
+        -> Map (PBftVerKeyHash c) [SlotNo]
+        -> PBftChainState c
+fromMap anchor perKey = PBftChainState {
+      anchor  = anchor
+    , signers = perSlot
+    , counts  = fromSlots perSlot
+    }
+  where
+    perSlot :: Seq (SlotNo, PBftVerKeyHash c)
+    perSlot = Seq.fromList
+            . sortOn fst
+            . map swap
+            . distrib
+            . Map.toList
+            $ perKey
+
+    distrib :: [(a, [b])] -> [(a, b)]
+    distrib = concatMap (\(a, bs) -> map (a,) bs)
+
+{-------------------------------------------------------------------------------
+  Serialization
+-------------------------------------------------------------------------------}
+
+-- | Don't require PBftCrypto (we don't need the 'Given' constraint here)
+instance ( Ord       (PBftVerKeyHash c)
+         , Serialise (PBftVerKeyHash c)
+         ) => Serialise (PBftChainState c) where
+  encode PBftChainState{..} = mconcat [
+        Serialise.encodeListLen 2
+      , encode (withOriginToMaybe anchor)
+      , encode signers
+      ]
+
+  decode = do
+      Serialise.decodeListLenOf 2
+      anchor  <- withOriginFromMaybe <$> decode
+      signers <- decode
+      let counts = fromSlots signers
+      return $ PBftChainState{..}

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
@@ -37,9 +37,8 @@ prop_simple_pbft_convergence
         (roundRobinLeaderSchedule numCoreNodes numSlots)
         testOutput
   where
-    sigWin = fromIntegral $ nn * 10
     sigThd = (1.0 / fromIntegral nn) + 0.1
-    params = PBftParams k (fromIntegral nn) sigWin sigThd
+    params = PBftParams k (fromIntegral nn) sigThd
 
     testOutput =
         runTestNetwork

--- a/ouroboros-network/src/Ouroboros/Network/Point.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Point.hs
@@ -9,6 +9,9 @@ module Ouroboros.Network.Point
   , origin
   , at
   , block
+  , fromWithOrigin
+  , withOriginToMaybe
+  , withOriginFromMaybe
   ) where
 
 import           GHC.Generics (Generic)
@@ -30,3 +33,15 @@ origin = Origin
 
 block :: slot -> hash -> WithOrigin (Block slot hash)
 block slot hash = at (Block slot hash)
+
+fromWithOrigin :: t -> WithOrigin t -> t
+fromWithOrigin t Origin = t
+fromWithOrigin _ (At t) = t
+
+withOriginToMaybe :: WithOrigin t -> Maybe t
+withOriginToMaybe Origin = Nothing
+withOriginToMaybe (At t) = Just t
+
+withOriginFromMaybe :: Maybe t -> WithOrigin t
+withOriginFromMaybe Nothing  = Origin
+withOriginFromMaybe (Just t) = At t


### PR DESCRIPTION
# Motivation

Profiling pointed to the `prune` function of the `PBftChainState` as taking up more than 50% of the node runtime, so I set about redesigning this datatype, and clarifying it as I went. The original was designed in a bit of a hurry in the lead-up to a demo. Details below.

# Status

This is almost done, but the tests are failing:

```
# cabal run test-consensus -- -p 'simple PBFT convergence' --quickcheck-replay=589684 2>&1 | friendly 
Up to date
ouroboros-consensus
  Dynamic chain generation
    simple PBFT convergence: FAIL (0.41s)
      *** Failed! Exception: 'FailureException ExceptionInLinkedThread "ThreadId 23" (
    ChainError (
      PBftExceededSignThreshold "(
        SecurityParam {maxRollbacks = 5}
      ,PBftChainState {
          anchor = Origin
        , signers = fromList [
            (SlotNo {unSlotNo = 0},VerKeyMockDSIGN 0)
          ,(SlotNo {unSlotNo = 0},VerKeyMockDSIGN 0)
          ,(SlotNo {unSlotNo = 1},VerKeyMockDSIGN 1)
          ,(SlotNo {unSlotNo = 2},VerKeyMockDSIGN 2)
          ,(SlotNo {unSlotNo = 3},VerKeyMockDSIGN 0)
        ]
        , counts = fromList [(VerKeyMockDSIGN 0,3),(VerKeyMockDSIGN 1,1),(VerKeyMockDSIGN 2,1)]
      }
    )" 5 3
  )
```

This is very strange though; the `signers` seems to suggest that node 0 is creating block 0 _twice_....? I don't understand where this is coming from. I've discussed this with @nfrisby and he's promised to take a look. If he can't find anything, I'll get back to this next week (but I have _very_ limited time next week unfortunately).

# Details

The internal representation of the PBftChainState is entirely different in this
PR. The new representation is hopefully easier to understand, and, perhaps
equally important, should be significantly faster. (Technically speaking the
two representations--nearly--isomorphic; the witness in one direction is
implemented in `fromMap`).

However, it is _not_ semantically the same. These functions are doing the
same thing:

* `size`
* `insert`
* `countSignedBy`

But `rewind` and `prune` (and `lastBlock`) do _not_. Details below.

# Rewinding

## Genesis

The existing implementing of `rewind` treats genesis special: we can _always_
roll back to the genesis point:

```haskell
rewind mSlot (PBftChainState cs) = PBftChainState <$> case mSlot of
    Origin
        -> Just Map.empty
```

It is perhaps debatable whether this is correct or not; however, the way we
use `rewindChainState` is that rewinding should fail if we don't want to roll
back past a certain amount. Formally, we should have that

```haskell
-- * If rewinding to a particular slot fails, rewinding to any slot prior to
--   that will also fail
--
--   > rewind s st == Nothing, s' < s  ==>  rewind s' st == Nothing
```

In particular, if we are connecting to an upstream node, and the intersection
of the chain of that upstream node and our own chain is past `k`, we should
not connect to that node; that's true even if that intersection happens to be
the genesis point.

## Failure to rewind

The existing `rewind` fails if it would leave the map empty. Consider this
evolution of the chain:

```haskell
-- > anchor | max rollback | blocks
-- > ----------------------------------------
-- > G      | 0 (G)        | []
-- > G      | 1 (G)        | [B1]
-- > G      | 2 (G)        | [B1, B2]
-- > G      | 3 (G)        | [B1, B2, B3]
-- > G      | 4 (G)        | [B1, B2, B3, B4]
-- > S1     | 4 (B1)       | [B2, B3, B4, B5]   (**)
-- > S2     | 4 (B2)       | [B3, B4, B5, B6]
-- > S3     | 4 (B3)       | [B4, B5, B6, B7]
```

and suppose we are on line `(**)`. The new implementation allows to rewind to
`S1` (leaving no blocks in the map); the old implementation would rule this out.
This means that in the new implementation the window size can be set to be
equal to `k` (as per the specs), but the old implementation would need the
window size to be `k+1`; but even if you did, you then _must_ treat genesis
special (because rewinding to genesis would leave the map empty). The new
definition in terms of an anchor makes this more principled.

# Pruning

The existing implementation of pruning is slow (took up more than 50% of a
time profile of the Byron proxy), which is what prompted this investigation.
However, it also contains a bug. Let's suppose the signers looks something like

```
[ (gk, s1), (gk, s2), (gk, s3), (gk', s4), (gk, s5), (gk', s6) ]
```

In the existing representation, this would be represented as

```
[ (gk  , [s1, s2, s3, s5])
, (gk' , [s4, s6])
]
```

And suppose we want to prune this to a maximum size of 5. Then in the case

```haskell
(gk,_):xs@((_,nextLowest):_) ->
  let (newSeq, numDropped) = dropWhileL (< nextLowest) $ fromCS Map.! gk
```

we will have `nextLowest = s5`, and therefore drop `s1, s2, s3` (but should
only drop `s1`).

# lastSlot

In the new version, `lastSlot` returns the anchor if the list is empty. I don't
think this is particularly important, but if we _do_ rewind and end up with an
empty state (this is now allowed, after all), then we should be able to apply
any block after the anchor, not after genesis.

# Usage of the PBFT chainstate (`applyChainState`)

The existing implementation of `applyChainState` starts with the original
`chainState` and first prunes it. Ideally, this should be a no-op (after all, we
prune the each new `ChainState` that we produce). It might not be a no-op in the
current version, because the two calls to `prune` in the existing version used
two _different_ window sizes: once `winSize`, and once `(winSize + 2*k)`. I
suspect this is a leftover from a older version of the chain state; `2*k` seems
try and map a limit in terms of blocks to a limit in terms of slots, but both
the existing version of the chain state as well as my rewrite are already in
terms of blocks, so I think this is not necessary. So I've removed the call to
`prune` on the input state, leaving on the call to `prune` on the new state
(and we do this `prune` _after_ inserting the new key).

Moreover, as per the spec, I've removed `pbftSignatureWindow` altogether, and
use `pbftSecurityParam` instead. Setting the window size to be equal to `k` (and
with the new implementation) means that we cannot rewind the state precisely
when we are trying to roll back too far.

Then, the window threshold check in `applyChainState` is currently done on the
_existing_ window, but for the _new_ key. In other words, if a particular key
signed one block too many in a window, we would not detect it until the _next_
block that this key tries to sign (indeed, we might not detect it at all if
there is a sufficient number of blocks signed by other keys in between). The
spec does it the other way around, so that's what I've done also.

