### PR TITLE
Use fewer test cases when testing the RealPBFT setup

### DIFF
--- a/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
@@ -47,7 +47,8 @@ import           Test.Util.Orphans.Arbitrary ()
 
 tests :: TestTree
 tests = testGroup "Dynamic chain generation"
-    [ testProperty "check Real PBFT setup" $
+    [ localOption (QuickCheckTests 10) $   -- each takes about 0.5 seconds!
+      testProperty "check Real PBFT setup" $
         \numCoreNodes ->
           forAll (elements (enumCoreNodes numCoreNodes)) $ \coreNodeId ->
           prop_setup_coreNodeId numCoreNodes coreNodeId


### PR DESCRIPTION
PR #916 added a simple property that merely tests the setup for the genuine `RealPBFT` test. This PR fixes its number of tests at 10, since the test is somewhat minor, and it seems disproportionately slow: taking about ~1min to run on my machine.