### PR TITLE
test-consensus: re-enable RealPBFT tests

### DIFF
--- a/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
@@ -66,8 +66,7 @@ tests = testGroup "Dynamic chain generation"
               , (CoreNodeId 1,SlotNo 20)
               , (CoreNodeId 2,SlotNo 22)
               ]}
-    , localOption (QuickCheckTests 0) $
-      testProperty "simple Real PBFT convergence" $
+    , testProperty "simple Real PBFT convergence" $
         prop_simple_real_pbft_convergence
     ]
 


### PR DESCRIPTION
I must have got confused during a rebase of #773 and disabled the RealPBFT tests. This PR re-enables them.