### PR TITLE
Simplify and specialise ouroboros-network interface

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -299,29 +299,25 @@ initNetwork registry nodeArgs kernel RunNetworkArgs{..} = do
     runLocalServer :: IO ()
     runLocalServer = do
       (connTable :: ConnectionTable IO Socket.SockAddr) <- newConnectionTable
-      case localResponderNetworkApplication networkApps of
-        AnyResponderApp application ->
-          NodeToClient.withServer_V1
-            connTable
-            rnaMyLocalAddr
-            rnaMkPeer
-            (\(DictVersion _) -> acceptEq)
-            nodeToClientVersionData
-            application
-            wait
+      NodeToClient.withServer_V1
+        connTable
+        rnaMyLocalAddr
+        rnaMkPeer
+        (\(DictVersion _) -> acceptEq)
+        nodeToClientVersionData
+        (localResponderNetworkApplication networkApps)
+        wait
 
     runPeerServer :: ConnectionTable IO Socket.SockAddr -> IO ()
     runPeerServer connTable =
-      case responderNetworkApplication networkApps of
-        AnyResponderApp application ->
-          NodeToNode.withServer_V1
-            connTable
-            rnaMyAddr
-            rnaMkPeer
-            (\(DictVersion _) -> acceptEq)
-            nodeToNodeVersionData
-            application
-            wait
+      NodeToNode.withServer_V1
+        connTable
+        rnaMyAddr
+        rnaMkPeer
+        (\(DictVersion _) -> acceptEq)
+        nodeToNodeVersionData
+        (responderNetworkApplication networkApps)
+        wait
 
     runIpSubscriptionWorker :: ConnectionTable IO Socket.SockAddr -> IO ()
     runIpSubscriptionWorker connTable = ipSubscriptionWorker_V1

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -42,7 +42,6 @@ import           Ouroboros.Network.Block
 import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Network.NodeToClient as NodeToClient
 import           Ouroboros.Network.NodeToNode as NodeToNode
-import           Ouroboros.Network.Socket
 
 import           Ouroboros.Network.Protocol.Handshake.Type
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -28,7 +28,6 @@ module Ouroboros.Consensus.Node
   , initNetwork
   ) where
 
-import           Codec.SerialiseTerm
 import           Control.Monad (forM, void)
 import           Control.Tracer
 import           Crypto.Random
@@ -38,18 +37,14 @@ import           Data.Time.Clock (secondsToDiffTime)
 import           Network.Socket as Socket
 
 import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadSTM
 
 import           Ouroboros.Network.Block
 import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Network.NodeToClient as NodeToClient
 import           Ouroboros.Network.NodeToNode as NodeToNode
 import           Ouroboros.Network.Socket
-import           Ouroboros.Network.Subscription.Dns
-import           Ouroboros.Network.Subscription.Ip
 
 import           Ouroboros.Network.Protocol.Handshake.Type
-import           Ouroboros.Network.Protocol.Handshake.Version
 
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.BlockchainTime
@@ -296,51 +291,43 @@ initNetwork registry nodeArgs kernel RunNetworkArgs{..} = do
       (protocolCodecs (getNodeConfig kernel))
       (protocolHandlers nodeArgs kernel)
 
-    networkAppNodeToNode :: Versions
-                              NodeToNodeVersion
-                              DictVersion
-                              (NetworkApps peer)
-    networkAppNodeToNode =
-      simpleSingletonVersions
-        NodeToNodeV_1
-        (NodeToNodeVersionData { networkMagic = 0 })
-        (DictVersion nodeToNodeCodecCBORTerm)
-        networkApps
-
-    networkAppNodeToClient :: Versions
-                                NodeToClientVersion
-                                DictVersion
-                                (NetworkApps peer)
-    networkAppNodeToClient =
-      simpleSingletonVersions
-        NodeToClientV_1
-        (NodeToClientVersionData { networkMagic = 0 })
-        (DictVersion nodeToClientCodecCBORTerm)
-        networkApps
+    -- TODO: network magics should be configurable, this gives an early fail if
+    -- one tries to run testnet vs mainnet.
+    nodeToNodeVersionData   = NodeToNodeVersionData { networkMagic   = 0 }
+    nodeToClientVersionData = NodeToClientVersionData { networkMagic = 0 }
 
     runLocalServer :: IO ()
     runLocalServer = do
-      connTable <- newConnectionTable
-      NodeToClient.withServer
-        connTable
-        rnaMyLocalAddr
-        rnaMkPeer
-        (\(DictVersion _) -> acceptEq)
-        (localResponderNetworkApplication <$> networkAppNodeToClient)
-        wait
+      (connTable :: ConnectionTable IO Socket.SockAddr) <- newConnectionTable
+      case localResponderNetworkApplication networkApps of
+        AnyResponderApp application ->
+          NodeToClient.withServer_V1
+            connTable
+            rnaMyLocalAddr
+            rnaMkPeer
+            (\(DictVersion _) -> acceptEq)
+            nodeToClientVersionData
+            application
+            wait
 
     runPeerServer :: ConnectionTable IO Socket.SockAddr -> IO ()
-    runPeerServer connTable = NodeToNode.withServer
-      connTable
-      rnaMyAddr
-      rnaMkPeer
-      (\(DictVersion _) -> acceptEq)
-      (responderNetworkApplication <$> networkAppNodeToNode)
-      wait
+    runPeerServer connTable =
+      case responderNetworkApplication networkApps of
+        AnyResponderApp application ->
+          NodeToNode.withServer_V1
+            connTable
+            rnaMyAddr
+            rnaMkPeer
+            (\(DictVersion _) -> acceptEq)
+            nodeToNodeVersionData
+            application
+            wait
 
     runIpSubscriptionWorker :: ConnectionTable IO Socket.SockAddr -> IO ()
-    runIpSubscriptionWorker connTable = ipSubscriptionWorker
+    runIpSubscriptionWorker connTable = ipSubscriptionWorker_V1
       rnaIpSubscriptionTracer
+      nullTracer -- TODO add hanshake protocol tracer to 'ProtocolTracers'
+      rnaMkPeer
       connTable
       -- the comments in dnsSbuscriptionWorker call apply
       (Just (Socket.SockAddrInet 0 0))
@@ -350,20 +337,17 @@ initNetwork registry nodeArgs kernel RunNetworkArgs{..} = do
         { ispIps     = rnaIpProducers
         , ispValency = length rnaIpProducers
         }
-      (\_ -> retry)
-      (connectToNode'
-        (\(DictVersion codec) -> encodeTerm codec)
-        (\(DictVersion codec) -> decodeTerm codec)
-        nullTracer
-        rnaMkPeer
-        (initiatorNetworkApplication <$> networkAppNodeToNode))
+      nodeToNodeVersionData
+      (initiatorNetworkApplication networkApps) 
 
     runDnsSubscriptionWorker :: ConnectionTable IO Socket.SockAddr
                              -> DnsSubscriptionTarget
                              -> IO ()
-    runDnsSubscriptionWorker connTable dnsProducer = dnsSubscriptionWorker
+    runDnsSubscriptionWorker connTable dnsProducer = dnsSubscriptionWorker_V1
       rnaDnsSubscriptionTracer
       rnaDnsResolverTracer
+      nullTracer -- TODO add hanshake protocol tracer to 'ProtocolTracers'
+      rnaMkPeer
       connTable
       -- IPv4 address
       --
@@ -376,10 +360,5 @@ initNetwork registry nodeArgs kernel RunNetworkArgs{..} = do
       (Just (Socket.SockAddrInet6 0 0 (0, 0, 0, 1) 0))
       (const Nothing)
       dnsProducer
-      (\_ -> retry)
-      (connectToNode'
-        (\(DictVersion codec) -> encodeTerm codec)
-        (\(DictVersion codec) -> decodeTerm codec)
-        nullTracer
-        rnaMkPeer
-        (initiatorNetworkApplication <$> networkAppNodeToNode))
+      nodeToNodeVersionData
+      (initiatorNetworkApplication networkApps)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -43,8 +43,6 @@ import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Network.NodeToClient as NodeToClient
 import           Ouroboros.Network.NodeToNode as NodeToNode
 
-import           Ouroboros.Network.Protocol.Handshake.Type
-
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.ChainSyncClient (ClockSkew (..))
@@ -302,7 +300,6 @@ initNetwork registry nodeArgs kernel RunNetworkArgs{..} = do
         connTable
         rnaMyLocalAddr
         rnaMkPeer
-        (\(DictVersion _) -> acceptEq)
         nodeToClientVersionData
         (localResponderNetworkApplication networkApps)
         wait
@@ -313,7 +310,6 @@ initNetwork registry nodeArgs kernel RunNetworkArgs{..} = do
         connTable
         rnaMyAddr
         rnaMkPeer
-        (\(DictVersion _) -> acceptEq)
         nodeToNodeVersionData
         (responderNetworkApplication networkApps)
         wait

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -373,9 +373,9 @@ initiatorNetworkApplication NetworkApplication {..} =
 --
 responderNetworkApplication
   :: NetworkApplication m peer bytes bytes bytes bytes bytes a
-  -> AnyResponderApp peer NodeToNodeProtocols m bytes
+  -> OuroborosApplication 'ResponderApp peer NodeToNodeProtocols m bytes Void a
 responderNetworkApplication NetworkApplication {..} =
-    AnyResponderApp $ OuroborosResponderApplication $ \them ptcl -> case ptcl of
+    OuroborosResponderApplication $ \them ptcl -> case ptcl of
       ChainSyncWithHeadersPtcl -> naChainSyncServer them
       BlockFetchPtcl           -> naBlockFetchServer them
       TxSubmissionPtcl         -> naTxSubmissionServer them
@@ -385,9 +385,9 @@ responderNetworkApplication NetworkApplication {..} =
 --
 localResponderNetworkApplication
   :: NetworkApplication m peer bytes bytes bytes bytes bytes a
-  -> AnyResponderApp peer NodeToClientProtocols m bytes
+  -> OuroborosApplication 'ResponderApp peer NodeToClientProtocols m bytes Void a
 localResponderNetworkApplication NetworkApplication {..} =
-    AnyResponderApp $ OuroborosResponderApplication $ \peer  ptcl -> case ptcl of
+    OuroborosResponderApplication $ \peer  ptcl -> case ptcl of
       ChainSyncWithBlocksPtcl -> naLocalChainSyncServer peer
       LocalTxSubmissionPtcl   -> naLocalTxSubmissionServer peer
 

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -180,7 +180,7 @@ pingPongClientCount n = SendMsgPing (pure (pingPongClientCount (n-1)))
 serverPingPong :: IO ()
 serverPingPong = do
     tbl <- newConnectionTable
-    withSimpleServerNode
+    withServerNode
       tbl
       defaultLocalSocketAddrInfo
       (\(DictVersion codec)-> encodeTerm codec)
@@ -279,7 +279,7 @@ pingPongClientPipelinedMax c =
 serverPingPong2 :: IO ()
 serverPingPong2 = do
     tbl <- newConnectionTable
-    withSimpleServerNode
+    withServerNode
       tbl
       defaultLocalSocketAddrInfo
       (\(DictVersion codec)-> encodeTerm codec)
@@ -352,7 +352,7 @@ clientChainSync sockAddrs =
 serverChainSync :: FilePath -> IO ()
 serverChainSync sockAddr = do
     tbl <- newConnectionTable
-    withSimpleServerNode
+    withServerNode
       tbl
       (mkLocalSocketAddrInfo sockAddr)
       (\(DictVersion codec)-> encodeTerm codec)
@@ -545,7 +545,7 @@ clientBlockFetch sockAddrs = do
 serverBlockFetch :: FilePath -> IO ()
 serverBlockFetch sockAddr = do
     tbl <- newConnectionTable
-    withSimpleServerNode
+    withServerNode
       tbl
       (mkLocalSocketAddrInfo sockAddr)
       (\(DictVersion codec)-> encodeTerm codec)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -199,7 +199,6 @@ withServer_V1
   -> Socket.AddrInfo
   -> (Socket.SockAddr -> Socket.SockAddr -> peerid)
   -- ^ create peerid from local address and remote address
-  -> (forall vData. DictVersion vData -> vData -> vData -> Accept)
   -> NodeToClientVersionData
   -- ^ Client version data sent during initial handshake protocol.  Client and
   -- server must agree on it.
@@ -209,9 +208,10 @@ withServer_V1
   -- 'OuroborosInitiatorAndResponderApplication'.
   -> (Async () -> IO t)
   -> IO t
-withServer_V1 tbl addr peeridFn acceptVersion versionData application =
+withServer_V1 tbl addr peeridFn versionData application =
     withServer
-      tbl addr peeridFn acceptVersion 
+      tbl addr peeridFn 
+      (\(DictVersion _) -> acceptEq)
       (simpleSingletonVersions
         NodeToClientV_1
         versionData

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -20,9 +20,6 @@ module Ouroboros.Network.NodeToClient (
   , withServer_V1
   , withServer
 
-  -- * Re-exports
-  , AnyResponderApp (..)
-
   -- * Re-exported clients
   , chainSyncClientNull
   , localTxSubmissionClientNull
@@ -172,13 +169,14 @@ connectTo_V1 tracer peeridFn versionData application =
 -- the protocols.
 --
 withServer
-  :: ConnectionTable IO Socket.SockAddr
+  :: HasResponder appType ~ True
+  => ConnectionTable IO Socket.SockAddr
   -> Socket.AddrInfo
   -> (Socket.SockAddr -> Socket.SockAddr -> peerid)
   -- ^ create peerid from local address and remote address
   -> (forall vData. DictVersion vData -> vData -> vData -> Accept)
   -> Versions NodeToClientVersion DictVersion
-              (AnyResponderApp peerid NodeToClientProtocols IO BL.ByteString)
+              (OuroborosApplication appType peerid NodeToClientProtocols IO BL.ByteString a b)
   -> (Async () -> IO t)
   -> IO t
 withServer tbl addr peeridFn acceptVersion versions k =
@@ -218,4 +216,4 @@ withServer_V1 tbl addr peeridFn acceptVersion versionData application =
         NodeToClientV_1
         versionData
         (DictVersion nodeToClientCodecCBORTerm)
-        (AnyResponderApp application))
+        application)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -227,14 +227,14 @@ withServer_V1
   -> Socket.AddrInfo
   -> (Socket.SockAddr -> Socket.SockAddr -> peerid)
   -- ^ create peerid from local address and remote address
-  -> (forall vData. DictVersion vData -> vData -> vData -> Accept)
   -> NodeToNodeVersionData
   -> (OuroborosApplication appType peerid NodeToNodeProtocols IO BL.ByteString x y)
   -> (Async () -> IO t)
   -> IO t
-withServer_V1 tbl addr peeridFn acceptVersion versionData application k =
+withServer_V1 tbl addr peeridFn versionData application k =
     withServer
-      tbl addr peeridFn acceptVersion
+      tbl addr peeridFn
+      (\(DictVersion _) -> acceptEq)
       (simpleSingletonVersions
           NodeToNodeV_1
           versionData

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -34,9 +34,6 @@ module Ouroboros.Network.NodeToNode (
   , dnsSubscriptionWorker_V1
   , DnsTrace (..)
   , WithDomainName (..)
-
-  -- * Re-exports
-  , AnyResponderApp (..)
   ) where
 
 import           Control.Concurrent.Async (Async)
@@ -194,12 +191,13 @@ connectTo_V1 tracer peeridFn versionData application localAddr remoteAddr =
 -- | A specialised version of @'Ouroboros.Network.Socket.withServerNode'@
 --
 withServer
-  :: ConnectionTable IO Socket.SockAddr
+  :: HasResponder appType ~ True
+  => ConnectionTable IO Socket.SockAddr
   -> Socket.AddrInfo
   -> (Socket.SockAddr -> Socket.SockAddr -> peerid)
   -- ^ create peerid from local address and remote address
   -> (forall vData. DictVersion vData -> vData -> vData -> Accept)
-  -> Versions NodeToNodeVersion DictVersion (AnyResponderApp peerid NodeToNodeProtocols IO BL.ByteString)
+  -> Versions NodeToNodeVersion DictVersion (OuroborosApplication appType peerid NodeToNodeProtocols IO BL.ByteString a b)
   -> (Async () -> IO t)
   -> IO t
 withServer tbl addr peeridFn acceptVersion versions k =
@@ -234,7 +232,7 @@ withServer_V1 tbl addr peeridFn acceptVersion versionData application k =
           NodeToNodeV_1
           versionData
           (DictVersion nodeToNodeCodecCBORTerm)
-          (AnyResponderApp application))
+          application)
       k
 
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -27,11 +27,13 @@ module Ouroboros.Network.NodeToNode (
   , ipSubscriptionWorker
   , ipSubscriptionWorker_V1
   , SubscriptionTrace (..)
+  , WithIPList (..)
   -- ** DNS subscription worker
   , DnsSubscriptionTarget (..)
   , dnsSubscriptionWorker
   , dnsSubscriptionWorker_V1
   , DnsTrace (..)
+  , WithDomainName (..)
 
   -- * Re-exports
   , AnyResponderApp (..)
@@ -63,7 +65,7 @@ import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.Socket
 import qualified Ouroboros.Network.Subscription.Ip as Subscription
 import           Ouroboros.Network.Subscription.Ip ( IPSubscriptionTarget (..)
-                                                   , WithIPList
+                                                   , WithIPList (..)
                                                    , SubscriptionTrace (..)
                                                    )
 import qualified Ouroboros.Network.Subscription.Dns as Subscription
@@ -243,7 +245,11 @@ ipSubscriptionWorker
     :: forall appType peerid void x y.
        (HasInitiator appType ~ True)
     => Tracer IO (WithIPList (SubscriptionTrace Socket.SockAddr))
-    -> Tracer IO (TraceSendRecv (Handshake NodeToNodeVersion CBOR.Term) peerid (DecoderFailureOrTooMuchInput DeserialiseFailure))
+    -> Tracer IO
+        (TraceSendRecv
+          (Handshake NodeToNodeVersion CBOR.Term)
+          peerid
+          (DecoderFailureOrTooMuchInput DeserialiseFailure))
     -> (Socket.SockAddr -> Socket.SockAddr -> peerid)
     -> ConnectionTable IO Socket.SockAddr
     -> Maybe Socket.SockAddr
@@ -342,7 +348,11 @@ dnsSubscriptionWorker
        HasInitiator appType ~ True
     => Tracer IO (WithDomainName (SubscriptionTrace Socket.SockAddr))
     -> Tracer IO (WithDomainName DnsTrace)
-    -> Tracer IO (TraceSendRecv (Handshake NodeToNodeVersion CBOR.Term) peerid (DecoderFailureOrTooMuchInput DeserialiseFailure))
+    -> Tracer IO
+        (TraceSendRecv
+          (Handshake NodeToNodeVersion CBOR.Term)
+          peerid
+          (DecoderFailureOrTooMuchInput DeserialiseFailure))
     -> (Socket.SockAddr -> Socket.SockAddr -> peerid)
     -> ConnectionTable IO Socket.SockAddr
     -> Maybe Socket.SockAddr

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -34,6 +34,10 @@ module Ouroboros.Network.NodeToNode (
   , dnsSubscriptionWorker_V1
   , DnsTrace (..)
   , WithDomainName (..)
+
+  -- * Re-exports
+  , ConnectionTable
+  , newConnectionTable
   ) where
 
 import           Control.Concurrent.Async (Async)
@@ -60,6 +64,9 @@ import           Ouroboros.Network.Mux
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.Socket
+import           Ouroboros.Network.Server.ConnectionTable ( ConnectionTable
+                                                          , newConnectionTable
+                                                          )
 import qualified Ouroboros.Network.Subscription.Ip as Subscription
 import           Ouroboros.Network.Subscription.Ip ( IPSubscriptionTarget (..)
                                                    , WithIPList (..)

--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Dns.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Dns.hs
@@ -198,7 +198,7 @@ dnsSubscriptionWorker'
     -> (Socket.SockAddr -> Maybe DiffTime)
     -> DnsSubscriptionTarget
     -> Main IO () t
-    -> (Socket.Socket -> IO t)
+    -> (Socket.Socket -> IO a)
     -> IO t
 dnsSubscriptionWorker' subTracer dnsTracer tbl resolver localIPv4 localIPv6
   connectionAttemptDelay dst main k = do
@@ -229,7 +229,7 @@ dnsSubscriptionWorker
     -> (Socket.SockAddr -> Maybe DiffTime)
     -> DnsSubscriptionTarget
     -> Main IO () t
-    -> (Socket.Socket -> IO t)
+    -> (Socket.Socket -> IO a)
     -> IO t
 dnsSubscriptionWorker subTracer dnsTracer tbl localIPv4 localIPv6 connectionAttemptDelay dst
   main k = do

--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Ip.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Ip.hs
@@ -9,7 +9,7 @@
 module Ouroboros.Network.Subscription.Ip
     ( ipSubscriptionWorker
     , subscriptionWorker
-    , SubscriptionTrace
+    , SubscriptionTrace (..)
     , IPSubscriptionTarget (..)
     , WithIPList (..)
     ) where

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -231,7 +231,7 @@ prop_socket_send_recv initiatorAddr responderAddr f xs = do
             waitSibling siblingVar
 
     res <-
-      withSimpleServerNode
+      withServerNode
         tbl
         responderAddr
         (\(DictVersion codec) -> encodeTerm codec)
@@ -392,7 +392,7 @@ demo chain0 updates = do
         codecChainSync = ChainSync.codecChainSync encode (fmap const decode)
                                                   encode             decode
 
-    withSimpleServerNode
+    withServerNode
       tbl
       producerAddress
       (\(DictVersion codec)-> encodeTerm codec)


### PR DESCRIPTION
* Expose function which are specific to `NdoeToNodeV_1` and `NodeToClientV_1`
* Remove `AnyResponderApp`
* Consolidate exports in `NodeToNode` and `NodeToClient` modules

WIth this patch all the api that consensus needs is contained in `NodeToClient` and `NodeToNode`.  I'd expect the same is true for other applications (wallet, explorer, chairman, etc.)