### PR TITLE
Use quiet for some data types' Show instance

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -60,6 +60,7 @@ library
                      , formatting        >=6.3   && <6.4
                      , memory
                      , mtl               >=2.2   && <2.3
+                     , quiet             >=0.2   && <0.3
                      , serialise         >=0.2   && <0.3
                      , text              >=1.2   && <1.3
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
@@ -41,6 +42,7 @@ import           Data.Proxy
 import           Data.Typeable
 import           Data.Word
 import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
 
 import           Cardano.Binary
 import           Cardano.Prelude (NoUnexpectedThunks (..))
@@ -68,9 +70,10 @@ import           Ouroboros.Consensus.Byron.Ledger.Orphans ()
 -------------------------------------------------------------------------------}
 
 newtype ByronHash = ByronHash { unByronHash :: CC.HeaderHash }
-  deriving stock   (Eq, Ord, Show, Generic)
+  deriving stock   (Eq, Ord, Generic)
   deriving newtype (ToCBOR, FromCBOR, Condense)
   deriving anyclass (NoUnexpectedThunks)
+  deriving (Show) via (Quiet ByronHash)
 
 mkByronHash :: CC.ABlockOrBoundaryHdr ByteString -> ByronHash
 mkByronHash = ByronHash . CC.abobHdrHash

--- a/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -55,6 +55,7 @@ library
                      , deepseq
                      , hashable
                      , mtl               >=2.2   && <2.3
+                     , quiet             >=0.2   && <0.3
                      , serialise         >=0.2   && <0.3
                      , time
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE EmptyCase                  #-}
 {-# LANGUAGE EmptyDataDeriving          #-}
 {-# LANGUAGE FlexibleContexts           #-}
@@ -74,6 +75,7 @@ import           Data.Proxy
 import           Data.Typeable
 import           Data.Word
 import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import           Cardano.Crypto.Hash hiding (castHash)
@@ -310,8 +312,9 @@ instance MockProtocolSpecific c ext
 newtype instance LedgerState (SimpleBlock c ext) = SimpleLedgerState {
       simpleLedgerState :: MockState (SimpleBlock c ext)
     }
-  deriving stock   (Generic, Show, Eq)
+  deriving stock   (Generic, Eq)
   deriving newtype (Serialise, NoUnexpectedThunks)
+  deriving (Show) via (Quiet (LedgerState (SimpleBlock c ext)))
 
 instance MockProtocolSpecific c ext => UpdateLedger (SimpleBlock c ext)
 

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -229,6 +229,7 @@ library
                      , mtl               >=2.2   && <2.3
                      , network           >=3.1   && <3.2
                      , psqueues          >=0.2.3 && <0.3
+                     , quiet             >=0.2   && <0.3
                      , serialise         >=0.2   && <0.3
                      , stm               >=2.5   && <2.6
                      , streaming
@@ -332,6 +333,7 @@ test-suite test-consensus
                      , mtl
                      , QuickCheck
                      , quickcheck-state-machine
+                     , quiet
                      , serialise
                      , tasty
                      , tasty-hunit

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Types.hs
@@ -22,6 +22,7 @@ module Ouroboros.Consensus.BlockchainTime.WallClock.Types (
 import           Data.Fixed
 import           Data.Time (NominalDiffTime, UTCTime)
 import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
 
 import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..),
                      UseIsNormalForm (..))
@@ -36,8 +37,9 @@ import           Control.Monad.Class.MonadTime (MonadTime (..))
 --
 -- Slots are counted from the system start.
 newtype SystemStart = SystemStart { getSystemStart :: UTCTime }
-  deriving (Eq, Show)
+  deriving (Eq, Generic)
   deriving NoUnexpectedThunks via UseIsNormalForm SystemStart
+  deriving (Show) via (Quiet SystemStart)
 
 -- | System time
 --
@@ -57,7 +59,8 @@ defaultSystemTime start = SystemTime start getCurrentTime
 
 -- | Slot length
 newtype SlotLength = SlotLength { getSlotLength :: NominalDiffTime }
-  deriving (Show, Eq, Generic, NoUnexpectedThunks)
+  deriving (Eq, Generic, NoUnexpectedThunks)
+  deriving (Show) via (Quiet SlotLength)
 
 -- | Constructor for 'SlotLength'
 mkSlotLength :: NominalDiffTime -> SlotLength

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config/SecurityParam.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config/SecurityParam.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Ouroboros.Consensus.Config.SecurityParam (
@@ -7,6 +8,7 @@ module Ouroboros.Consensus.Config.SecurityParam (
 
 import           Data.Word
 import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
@@ -20,4 +22,5 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 -- NOTE: This talks about the number of /blocks/ we can roll back, not
 -- the number of /slots/.
 newtype SecurityParam = SecurityParam { maxRollbacks :: Word64 }
-  deriving (Show, Eq, Generic, NoUnexpectedThunks)
+  deriving (Eq, Generic, NoUnexpectedThunks)
+  deriving (Show) via (Quiet SecurityParam)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards            #-}
@@ -19,6 +20,7 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy
 import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
@@ -41,8 +43,9 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
 newtype LeaderSchedule = LeaderSchedule {
         getLeaderSchedule :: Map SlotNo [CoreNodeId]
       }
-    deriving stock    (Show, Eq, Ord, Generic)
+    deriving stock    (Eq, Ord, Generic)
     deriving anyclass (NoUnexpectedThunks)
+    deriving (Show) via (Quiet LeaderSchedule)
 
 instance Semigroup LeaderSchedule where
     LeaderSchedule l <> LeaderSchedule r =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Random.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Random.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
@@ -30,6 +32,8 @@ import           Crypto.Random (ChaChaDRG, MonadPseudoRandom, MonadRandom (..),
                      drgNewTest, randomBytesGenerate, withDRG)
 import           Data.List (genericLength)
 import           Data.Word (Word64)
+import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
 
 import           Control.Monad.Class.MonadSTM
 
@@ -48,7 +52,8 @@ generateElement xs = do
 -------------------------------------------------------------------------------}
 
 newtype Seed = Seed {getSeed :: (Word64, Word64, Word64, Word64, Word64)}
-    deriving (Show, Eq, Ord, Serialise)
+    deriving (Eq, Generic, Ord, Serialise)
+    deriving (Show) via (Quiet Seed)
 
 withSeed :: Seed -> MonadPseudoRandom ChaChaDRG a -> a
 withSeed s = fst . withDRG (drgNewTest $ getSeed s)

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -143,6 +143,7 @@ library
                        iproute,
                        network           >=3.1 && <3.2,
                        psqueues          >=0.2.3 && <0.3,
+                       quiet             >=0.2   && <0.3,
                        serialise         >=0.2 && <0.3,
                        stm               >=2.4 && <2.6,
                        time              >=1.6 && <1.10

--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
@@ -79,6 +80,7 @@ import           Data.FingerTree.Strict (Measured)
 import           Data.Proxy (Proxy)
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
 
 -- TODO: it should be exported from 'Cardano.Prelude'
 import           Control.Tracer (contramap)
@@ -171,8 +173,9 @@ newtype Point block = Point
 
 deriving newtype instance StandardHash block => Eq   (Point block)
 deriving newtype instance StandardHash block => Ord  (Point block)
-deriving newtype instance StandardHash block => Show (Point block)
 deriving newtype instance (StandardHash block, Typeable block) => NoUnexpectedThunks (Point block)
+
+deriving via (Quiet (Point block)) instance (StandardHash block) => Show (Point block)
 
 pattern GenesisPoint :: Point block
 pattern GenesisPoint = Point Origin
@@ -438,7 +441,8 @@ instance Monoid BlockMeasure where
 -- putting them on the wire.
 newtype Serialised a = Serialised
   { unSerialised :: Lazy.ByteString }
-  deriving (Eq, Show)
+  deriving (Eq, Generic)
+  deriving (Show) via (Quiet (Serialised a))
 
 type instance HeaderHash (Serialised block) = HeaderHash block
 instance StandardHash block => StandardHash (Serialised block)

--- a/ouroboros-network/src/Ouroboros/Network/Magic.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Magic.hs
@@ -1,14 +1,16 @@
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Ouroboros.Network.Magic where
 
 import           Data.Word (Word32)
 import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
 -- | NetworkMagic is used to differentiate between different networks during the initial handshake.
 newtype NetworkMagic  = NetworkMagic { unNetworkMagic :: Word32 }
-  deriving (Show, Eq, Generic, NoUnexpectedThunks)
-
+  deriving (Eq, Generic, NoUnexpectedThunks)
+  deriving (Show) via (Quiet NetworkMagic)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -1,4 +1,5 @@
-
+{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE DerivingVia    #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Ouroboros.Network.NodeToClient.Version
@@ -12,6 +13,8 @@ import           Data.Bits (setBit, clearBit, testBit)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Typeable (Typeable)
+import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
 
 import qualified Codec.CBOR.Term as CBOR
 
@@ -61,7 +64,8 @@ nodeToClientVersionBit = 15
 --
 newtype NodeToClientVersionData = NodeToClientVersionData
   { networkMagic :: NetworkMagic }
-  deriving (Eq, Show, Typeable)
+  deriving (Eq, Generic, Typeable)
+  deriving (Show) via (Quiet NodeToClientVersionData)
 
 instance Acceptable NodeToClientVersionData where
     acceptableVersion local remote

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE DerivingVia    #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Ouroboros.Network.NodeToNode.Version
@@ -10,6 +12,8 @@ module Ouroboros.Network.NodeToNode.Version
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Typeable (Typeable)
+import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
 
 import qualified Codec.CBOR.Term as CBOR
 
@@ -41,7 +45,8 @@ nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
 --
 newtype NodeToNodeVersionData = NodeToNodeVersionData
   { networkMagic :: NetworkMagic }
-  deriving (Eq, Show, Typeable)
+  deriving (Eq, Generic, Typeable)
+  deriving (Show) via (Quiet NodeToNodeVersionData)
 
 instance Acceptable NodeToNodeVersionData where
     acceptableVersion local remote

--- a/ouroboros-network/src/Ouroboros/Network/Point.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Point.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingVia       #-}
 
 module Ouroboros.Network.Point
   ( WithOrigin (..)
@@ -17,6 +18,7 @@ module Ouroboros.Network.Point
   ) where
 
 import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 import           Cardano.Slotting.Slot
@@ -25,7 +27,8 @@ data Block slot hash = Block
   { blockPointSlot :: !slot
   , blockPointHash :: !hash
   }
-  deriving (Eq, Ord, Show, Generic, NoUnexpectedThunks)
+  deriving (Eq, Ord, Generic, NoUnexpectedThunks)
+  deriving (Show) via (Quiet (Block slot hash))
 
 block :: slot -> hash -> WithOrigin (Block slot hash)
 block slot hash = at (Block slot hash)


### PR DESCRIPTION
Edit: We changed our minds upstream: we're using https://hackage.haskell.org/package/quiet instead of the code I had added to `cardano-base`. So this PR now just uses `quiet`. The `extra-dep` `quiet-0.2` was already in our `stack.yaml`. My `cardano-base` PR will also add it to our LTS snapshot overlay.

I picked these types casually. Some I know will benefit the legibility of QC outputs on failure. Others were just anticipated to be nicer this way.

-----

Edit: The description below this line is still mostly right, but I took the advice of early comments and defined the generic function in `cardano-prelude`. This PR is now just using that functions in this repo.

-----

This commit adds a `generics-deriving`-based function that derives a `showsPrec` for record types that renders as if the fields were plain constructor arguments. This makes printed exceptions, traces, etc much more legible -- so much so that I've been repeatedly patching these instances manually whenever debugging the consensus tests. I decided to open this PR in case any of you agree it's worthwhile.

See the commit message for some more context.

I defined this function in `ouroboros-network` because that was the deepest package I wanted to use it in. It feels generic enough to be deeper, but I'm unsure where else that might be.