### PR TITLE
add export for TraceChainSyncServerEvent

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
@@ -8,7 +8,7 @@ module Ouroboros.Consensus.ChainSyncServer
   ( chainSyncHeadersServer
   , chainSyncBlocksServer
     -- * Trace events
-  , TraceChainSyncServerEvent
+  , TraceChainSyncServerEvent (..)
   ) where
 
 import           Control.Monad.Class.MonadSTM


### PR DESCRIPTION
export all constructuros for `TraceChainSyncServerEvent` so we can pattern match on them in cardano-node, for rendering the traced items.
