### PR TITLE
Update consensus to do pipelining

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -29,6 +29,7 @@ library
                        Ouroboros.Consensus.Block
                        Ouroboros.Consensus.BlockFetchServer
                        Ouroboros.Consensus.BlockchainTime
+                       Ouroboros.Consensus.ChainSync
                        Ouroboros.Consensus.ChainSyncClient
                        Ouroboros.Consensus.ChainSyncServer
                        Ouroboros.Consensus.Crypto.DSIGN.Cardano

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSync.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSync.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | Shared by the ChainSync server and client
+module Ouroboros.Consensus.ChainSync
+  ( Tip (..)
+  , encodeTip
+  , decodeTip
+  ) where
+
+import           Codec.CBOR.Decoding (Decoder, decodeListLenOf)
+import           Codec.CBOR.Encoding (Encoding, encodeListLen)
+import           Codec.Serialise (decode, encode)
+
+import           GHC.Generics (Generic)
+
+import           Ouroboros.Network.Block (BlockNo, HeaderHash, Point,
+                     decodePoint, encodePoint)
+
+-- | Used to advertise the tip of the server
+data Tip b = Tip
+  { tipPoint   :: !(Point b)
+  , tipBlockNo :: !BlockNo
+  } deriving (Eq, Show, Generic)
+
+encodeTip :: (HeaderHash blk -> Encoding)
+          -> (Tip        blk -> Encoding)
+encodeTip encodeHeaderHash Tip { tipPoint, tipBlockNo } = mconcat
+    [ encodeListLen 2
+    , encodePoint encodeHeaderHash tipPoint
+    , encode                       tipBlockNo
+    ]
+
+decodeTip :: (forall s. Decoder s (HeaderHash blk))
+          -> (forall s. Decoder s (Tip        blk))
+decodeTip decodeHeaderHash = do
+  decodeListLenOf 2
+  tipPoint    <- decodePoint decodeHeaderHash
+  tipBlockNo  <- decode
+  return Tip { tipPoint, tipBlockNo }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -197,28 +197,6 @@ chainSyncClient
        , ProtocolLedgerView blk
        , Exception (ChainSyncClientException blk tip)
        )
-    => (tip -> BlockNo)
-    -> Tracer m (TraceChainSyncClientEvent blk tip)
-    -> NodeConfig (BlockProtocol blk)
-    -> BlockchainTime m
-    -> ClockSkew                                    -- ^ Maximum clock skew
-    -> STM m (ExtLedgerState blk)                   -- ^ Get the current ledger state
-    -> STM m (HeaderHash blk -> Bool, Fingerprint)  -- ^ Get the invalid block checker
-    -> STM m BlockNo                                -- ^ Get the BlockNo of our current tip
-    -> StrictTVar m (CandidateState blk)            -- ^ Our peer's state var
-    -> AnchoredFragment (Header blk)                -- ^ The current chain
-    -> Consensus ChainSyncClientPipelined blk tip m
-chainSyncClient = chainSyncClient_ $ pipelineDecisionLowHighMark 200 300
-
--- | Generalization of 'chainSyncClient_' over pipelining decision
-chainSyncClient_
-    :: forall m blk tip.
-       ( MonadSTM   m
-       , MonadCatch m
-       , MonadThrow (STM m)
-       , ProtocolLedgerView blk
-       , Exception (ChainSyncClientException blk tip)
-       )
     => MkPipelineDecision
     -> (tip -> BlockNo)
     -> Tracer m (TraceChainSyncClientEvent blk tip)
@@ -231,7 +209,7 @@ chainSyncClient_
     -> StrictTVar m (CandidateState blk)            -- ^ Our peer's state var
     -> AnchoredFragment (Header blk)                -- ^ The current chain
     -> Consensus ChainSyncClientPipelined blk tip m
-chainSyncClient_ mkPipelineDecision0
+chainSyncClient mkPipelineDecision0
                  tipBlockNo
                  tracer cfg btime (ClockSkew maxSkew)
                  getCurrentLedger getIsInvalidBlock getTipBlockNo varCandidate =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -28,6 +28,8 @@ module Ouroboros.Consensus.Node
   , initNetwork
   ) where
 
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Term as CBOR
 import           Control.Monad (forM, void)
 import           Control.Tracer
 import           Crypto.Random
@@ -35,8 +37,6 @@ import           Data.ByteString.Lazy (ByteString)
 import           Data.Proxy (Proxy (..))
 import           Data.Time.Clock (secondsToDiffTime)
 import           Network.Socket as Socket
-import qualified Codec.CBOR.Term as CBOR
-import qualified Codec.CBOR.Read as CBOR
 
 import           Control.Monad.Class.MonadAsync
 
@@ -44,6 +44,8 @@ import           Ouroboros.Network.Block
 import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Network.NodeToClient as NodeToClient
 import           Ouroboros.Network.NodeToNode as NodeToNode
+import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
+                     (pipelineDecisionLowHighMark)
 
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.BlockchainTime
@@ -201,9 +203,10 @@ mkNodeArgs registry cfg initState tracers btime chainDB = NodeArgs
     , btime
     , chainDB
     , callbacks
-    , blockFetchSize     = nodeBlockFetchSize
-    , blockMatchesHeader = nodeBlockMatchesHeader
-    , maxUnackTxs        = 100 -- TODO
+    , blockFetchSize      = nodeBlockFetchSize
+    , blockMatchesHeader  = nodeBlockMatchesHeader
+    , maxUnackTxs         = 100 -- TODO
+    , chainSyncPipelining = pipelineDecisionLowHighMark 200 300 -- TODO
     }
   where
     callbacks = NodeCallbacks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -22,6 +22,7 @@ import           Ouroboros.Network.TxSubmission.Outbound
 import           Ouroboros.Consensus.Block (Header, SupportedBlock)
 import           Ouroboros.Consensus.BlockFetchServer
                      (TraceBlockFetchServerEvent)
+import           Ouroboros.Consensus.ChainSync (Tip)
 import           Ouroboros.Consensus.ChainSyncClient (TraceChainSyncClientEvent)
 import           Ouroboros.Consensus.ChainSyncServer (TraceChainSyncServerEvent)
 import           Ouroboros.Consensus.Mempool.API (ApplyTxErr, GenTx, GenTxId,
@@ -35,8 +36,8 @@ import           Ouroboros.Consensus.TxSubmission
 
 data Tracers' peer blk tip f = Tracers
   { chainSyncClientTracer         :: f (TraceChainSyncClientEvent blk tip)
-  , chainSyncServerHeaderTracer   :: f (TraceChainSyncServerEvent (Header blk))
-  , chainSyncServerBlockTracer    :: f (TraceChainSyncServerEvent blk)
+  , chainSyncServerHeaderTracer   :: f (TraceChainSyncServerEvent blk (Header blk))
+  , chainSyncServerBlockTracer    :: f (TraceChainSyncServerEvent blk blk)
   , blockFetchDecisionTracer      :: f [TraceLabelPeer peer (FetchDecision [Point (Header blk)])]
   , blockFetchClientTracer        :: f (TraceLabelPeer peer (TraceFetchClientState (Header blk)))
   , blockFetchServerTracer        :: f (TraceBlockFetchServerEvent blk)
@@ -48,7 +49,7 @@ data Tracers' peer blk tip f = Tracers
   }
 
 -- | A record of 'Tracer's for the node.
-type Tracers m peer blk = Tracers' peer blk (Point (Header blk)) (Tracer m)
+type Tracers m peer blk = Tracers' peer blk (Tip blk) (Tracer m)
 
 -- | Use a 'nullTracer' for each of the 'Tracer's in 'Tracers'
 nullTracers :: Monad m => Tracers m peer blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -39,6 +39,8 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Network.BlockFetch
 import           Ouroboros.Network.BlockFetch.State (FetchMode (..))
 import           Ouroboros.Network.Point (WithOrigin (..))
+import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
+                     (MkPipelineDecision)
 import           Ouroboros.Network.TxSubmission.Inbound
                      (TxSubmissionMempoolWriter)
 import qualified Ouroboros.Network.TxSubmission.Inbound as Inbound
@@ -125,17 +127,18 @@ data NodeCallbacks m blk = NodeCallbacks {
 
 -- | Arguments required when initializing a node
 data NodeArgs m peer blk = NodeArgs {
-      tracers            :: Tracers m peer blk
-    , registry           :: ResourceRegistry m
-    , maxClockSkew       :: ClockSkew
-    , cfg                :: NodeConfig (BlockProtocol blk)
-    , initState          :: NodeState (BlockProtocol blk)
-    , btime              :: BlockchainTime m
-    , chainDB            :: ChainDB m blk
-    , callbacks          :: NodeCallbacks m blk
-    , blockFetchSize     :: Header blk -> SizeInBytes
-    , blockMatchesHeader :: Header blk -> blk -> Bool
-    , maxUnackTxs        :: Word16
+      tracers             :: Tracers m peer blk
+    , registry            :: ResourceRegistry m
+    , maxClockSkew        :: ClockSkew
+    , cfg                 :: NodeConfig (BlockProtocol blk)
+    , initState           :: NodeState (BlockProtocol blk)
+    , btime               :: BlockchainTime m
+    , chainDB             :: ChainDB m blk
+    , callbacks           :: NodeCallbacks m blk
+    , blockFetchSize      :: Header blk -> SizeInBytes
+    , blockMatchesHeader  :: Header blk -> blk -> Bool
+    , maxUnackTxs         :: Word16
+    , chainSyncPipelining :: MkPipelineDecision
     }
 
 initNodeKernel

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -146,7 +146,7 @@ protocolHandlers
     => NodeArgs   m peer blk  --TODO eliminate, merge relevant into NodeKernel
     -> NodeKernel m peer blk
     -> ProtocolHandlers m peer blk
-protocolHandlers NodeArgs {btime, maxClockSkew, tracers, maxUnackTxs}
+protocolHandlers NodeArgs {btime, maxClockSkew, tracers, maxUnackTxs, chainSyncPipelining}
                  NodeKernel {getChainDB, getMempool, getNodeConfig} =
     --TODO: bundle needed NodeArgs into the NodeKernel
     -- so we do not have to pass it separately
@@ -155,6 +155,7 @@ protocolHandlers NodeArgs {btime, maxClockSkew, tracers, maxUnackTxs}
     ProtocolHandlers {
       phChainSyncClient =
         chainSyncClient
+          chainSyncPipelining
           tipBlockNo
           (chainSyncClientTracer tracers)
           getNodeConfig

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -28,8 +28,6 @@ module Ouroboros.Consensus.NodeNetwork (
   , localResponderNetworkApplication
   ) where
 
-import           Codec.CBOR.Decoding (Decoder)
-import           Codec.CBOR.Encoding (Encoding)
 import           Control.Monad (void)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Proxy (Proxy (..))
@@ -44,7 +42,7 @@ import           Control.Tracer
 
 import           Network.Mux.Interface
 import           Network.TypedProtocol.Channel
-import           Network.TypedProtocol.Codec.Cbor
+import           Network.TypedProtocol.Codec.Cbor hiding (decode, encode)
 import           Network.TypedProtocol.Driver
 import           Ouroboros.Network.NodeToClient
 import           Ouroboros.Network.NodeToNode
@@ -75,6 +73,7 @@ import           Ouroboros.Network.TxSubmission.Outbound
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockFetchServer
+import           Ouroboros.Consensus.ChainSync
 import           Ouroboros.Consensus.ChainSyncClient
 import           Ouroboros.Consensus.ChainSyncServer
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -101,7 +100,7 @@ data ProtocolHandlers m peer blk = ProtocolHandlers {
       phChainSyncClient
         :: StrictTVar m (CandidateState blk)
         -> AnchoredFragment (Header blk)
-        -> ChainSyncClientPipelined (Header blk) (Point (Header blk)) m Void
+        -> ChainSyncClientPipelined (Header blk) (Tip blk) m Void
         -- TODO: we should consider either bundling these context paramaters
         -- into a record, or extending the protocol handler representation
         -- to support bracket-style initialisation so that we could have the
@@ -109,7 +108,7 @@ data ProtocolHandlers m peer blk = ProtocolHandlers {
 
     , phChainSyncServer
         :: ResourceRegistry m
-        -> ChainSyncServer (Header blk) (Point (Header blk)) m ()
+        -> ChainSyncServer (Header blk) (Tip blk) m ()
 
     -- TODO block fetch client does not have GADT view of the handlers.
     , phBlockFetchClient
@@ -129,7 +128,7 @@ data ProtocolHandlers m peer blk = ProtocolHandlers {
 
     , phLocalChainSyncServer
         :: ResourceRegistry m
-        -> ChainSyncServer blk (Point blk) m ()
+        -> ChainSyncServer blk (Tip blk) m ()
 
     , phLocalTxSubmissionServer
         :: LocalTxSubmissionServer (GenTx blk) (ApplyTxErr blk) m ()
@@ -156,13 +155,14 @@ protocolHandlers NodeArgs {btime, maxClockSkew, tracers, maxUnackTxs}
     ProtocolHandlers {
       phChainSyncClient =
         chainSyncClient
-          pointSlot
+          tipBlockNo
           (chainSyncClientTracer tracers)
           getNodeConfig
           btime
           maxClockSkew
           (ChainDB.getCurrentLedger  getChainDB)
           (ChainDB.getIsInvalidBlock getChainDB)
+          (ChainDB.getTipBlockNo     getChainDB)
     , phChainSyncServer =
         chainSyncHeadersServer
           (chainSyncServerHeaderTracer tracers)
@@ -199,13 +199,13 @@ protocolHandlers NodeArgs {btime, maxClockSkew, tracers, maxUnackTxs}
 data ProtocolCodecs blk failure m
                     bytesCS bytesBF bytesTX
                     bytesLCS bytesLTX = ProtocolCodecs {
-    pcChainSyncCodec         :: Codec (ChainSync (Header blk) (Point (Header blk)))
+    pcChainSyncCodec         :: Codec (ChainSync (Header blk) (Tip blk))
                                       failure m bytesCS
   , pcBlockFetchCodec        :: Codec (BlockFetch blk)
                                       failure m bytesBF
   , pcTxSubmissionCodec      :: Codec (TxSubmission (GenTxId blk) (GenTx blk))
                                       failure m bytesTX
-  , pcLocalChainSyncCodec    :: Codec (ChainSync blk (Point blk))
+  , pcLocalChainSyncCodec    :: Codec (ChainSync blk (Tip blk))
                                       failure m bytesLCS
   , pcLocalTxSubmissionCodec :: Codec (LocalTxSubmission (GenTx blk) (ApplyTxErr blk))
                                       failure m bytesLTX
@@ -223,10 +223,10 @@ protocolCodecs cfg = ProtocolCodecs {
         codecChainSync
           (nodeEncodeHeader cfg)
           (nodeDecodeHeader cfg)
-           encodeHdrPoint
-           decodeHdrPoint
-           encodeHdrPoint
-           decodeHdrPoint
+          (encodePoint (nodeEncodeHeaderHash (Proxy @blk)))
+          (decodePoint (nodeDecodeHeaderHash (Proxy @blk)))
+          (encodeTip   (nodeEncodeHeaderHash (Proxy @blk)))
+          (decodeTip   (nodeDecodeHeaderHash (Proxy @blk)))
 
     , pcBlockFetchCodec =
         codecBlockFetch
@@ -246,10 +246,10 @@ protocolCodecs cfg = ProtocolCodecs {
         codecChainSync
           (nodeEncodeBlock cfg)
           (nodeDecodeBlock cfg)
-           encodeBlkPoint
-           decodeBlkPoint
-           encodeBlkPoint
-           decodeBlkPoint
+          (encodePoint (nodeEncodeHeaderHash (Proxy @blk)))
+          (decodePoint (nodeDecodeHeaderHash (Proxy @blk)))
+          (encodeTip   (nodeEncodeHeaderHash (Proxy @blk)))
+          (decodeTip   (nodeDecodeHeaderHash (Proxy @blk)))
 
     , pcLocalTxSubmissionCodec =
         codecLocalTxSubmission
@@ -258,28 +258,15 @@ protocolCodecs cfg = ProtocolCodecs {
           (nodeEncodeApplyTxError (Proxy @blk))
           (nodeDecodeApplyTxError (Proxy @blk))
     }
-  where
-    encodeHdrPoint ::  Point (Header blk) -> Encoding
-    encodeHdrPoint = encodePoint (nodeEncodeHeaderHash (Proxy @blk))
-
-    decodeHdrPoint :: forall s. Decoder s (Point (Header blk))
-    decodeHdrPoint = decodePoint (nodeDecodeHeaderHash (Proxy @blk))
-
-    encodeBlkPoint ::  Point blk -> Encoding
-    encodeBlkPoint = encodePoint (nodeEncodeHeaderHash (Proxy @blk))
-
-    decodeBlkPoint :: forall s. Decoder s (Point blk)
-    decodeBlkPoint = decodePoint (nodeDecodeHeaderHash (Proxy @blk))
-
 
 -- | Id codecs used in tests.
 --
 protocolCodecsId :: Monad m
                  => ProtocolCodecs blk CodecFailure m
-                      (AnyMessage (ChainSync (Header blk) (Point (Header blk))))
+                      (AnyMessage (ChainSync (Header blk) (Tip blk)))
                       (AnyMessage (BlockFetch blk))
                       (AnyMessage (TxSubmission (GenTxId blk) (GenTx blk)))
-                      (AnyMessage (ChainSync blk (Point blk)))
+                      (AnyMessage (ChainSync blk (Tip blk)))
                       (AnyMessage (LocalTxSubmission (GenTx blk) (ApplyTxErr blk)))
 protocolCodecsId = ProtocolCodecs {
       pcChainSyncCodec         = codecChainSyncId
@@ -293,10 +280,10 @@ protocolCodecsId = ProtocolCodecs {
 type ProtocolTracers m peer blk failure = ProtocolTracers' peer blk failure (Tracer m)
 
 data ProtocolTracers' peer blk failure f = ProtocolTracers {
-    ptChainSyncTracer         :: f (TraceSendRecv (ChainSync (Header blk) (Point (Header blk)))          peer failure)
+    ptChainSyncTracer         :: f (TraceSendRecv (ChainSync (Header blk) (Tip blk))               peer failure)
   , ptBlockFetchTracer        :: f (TraceSendRecv (BlockFetch blk)                                 peer failure)
   , ptTxSubmissionTracer      :: f (TraceSendRecv (TxSubmission (GenTxId blk) (GenTx blk))         peer failure)
-  , ptLocalChainSyncTracer    :: f (TraceSendRecv (ChainSync blk (Point blk))                   peer failure)
+  , ptLocalChainSyncTracer    :: f (TraceSendRecv (ChainSync blk (Tip blk))                        peer failure)
   , ptLocalTxSubmissionTracer :: f (TraceSendRecv (LocalTxSubmission (GenTx blk) (ApplyTxErr blk)) peer failure)
   }
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -156,6 +156,7 @@ protocolHandlers NodeArgs {btime, maxClockSkew, tracers, maxUnackTxs}
     ProtocolHandlers {
       phChainSyncClient =
         chainSyncClient
+          pointSlot
           (chainSyncClientTracer tracers)
           getNodeConfig
           btime

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -253,6 +253,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
                     tip
                     m
         client = chainSyncClient
+                   (pointSlot . fst)
                    (Tracer $ say . show)
                    (nodeCfg clientId)
                    btime

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -152,7 +152,8 @@ serverId :: CoreNodeId
 serverId = CoreNodeId 1
 
 -- | Terser notation
-type ChainSyncException tip = ChainSyncClientException TestBlock tip
+type ChainSyncException =
+  ChainSyncClientException TestBlock (Point TestBlock, BlockNo)
 
 -- | Using slots as times, a schedule plans updates to a chain on certain
 -- slots.
@@ -203,14 +204,13 @@ newtype ServerUpdates =
 --
 -- Note that updates that are scheduled before the slot at which we start
 -- syncing help generate different chains to start syncing from.
-runChainSync :: forall m tip.
+runChainSync :: forall m.
        ( MonadAsync m
        , MonadFork  m
        , MonadMask  m
        , MonadTimer m
        , MonadThrow (STM m)
        , MonadSay   m
-       , tip ~ (Point (Header TestBlock), BlockNo)
        )
     => SecurityParam
     -> ClockSkew
@@ -218,7 +218,7 @@ runChainSync :: forall m tip.
     -> ServerUpdates
     -> SlotNo  -- ^ Start chain syncing at this slot.
     -> m (Chain TestBlock, Chain TestBlock,
-          AnchoredFragment TestBlock, Maybe (ChainSyncException tip))
+          AnchoredFragment TestBlock, Maybe ChainSyncException)
        -- ^ (The final client chain, the final server chain, the synced
        --    candidate fragment, exception thrown by the chain sync client)
 runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
@@ -245,25 +245,28 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
         getLedgerState  = snd <$> readTVar varClientState
         getIsInvalidBlock :: STM m (HeaderHash TestBlock -> Bool, Fingerprint)
         getIsInvalidBlock = return (const False, Fingerprint 0)
+        getTipBlockNo :: STM m BlockNo
+        getTipBlockNo = Chain.headBlockNo . fst <$> readTVar varClientState
 
         client :: StrictTVar m (CandidateState TestBlock)
                -> AnchoredFragment (Header TestBlock)
                -> Consensus ChainSyncClientPipelined
                     TestBlock
-                    tip
+                    (Point TestBlock, BlockNo)
                     m
         client = chainSyncClient
-                   (pointSlot . fst)
+                   snd
                    (Tracer $ say . show)
                    (nodeCfg clientId)
                    btime
                    maxClockSkew
                    getLedgerState
                    getIsInvalidBlock
+                   getTipBlockNo
 
     -- Set up the server
     varChainProducerState <- uncheckedNewTVarM $ initChainProducerState Genesis
-    let server :: ChainSyncServer (Header TestBlock) (Point (Header TestBlock), BlockNo) m ()
+    let server :: ChainSyncServer (Header TestBlock) (Point TestBlock, BlockNo) m ()
         server = chainSyncServerExample () varChainProducerState
 
     -- Schedule updates of the client and server chains
@@ -304,12 +307,14 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
           check (lastUpdate == startSyncingAt)
 
       (clientChannel, serverChannel) <- createConnectedChannels
+      let tracer :: Tracer m (TraceChainSyncClientEvent TestBlock (Point TestBlock, BlockNo))
+          tracer = nullTracer
       -- Don't link the thread (which will cause the exception to be rethrown
       -- in the main thread), just catch the exception and store it, because
       -- we want a "regular ending".
       void $ forkThread registry $
         bracketChainSyncClient
-           nullTracer
+           tracer
            (AF.mapAnchoredFragment coerce <$> getCurrentChain)
            getLedgerState
            getIsInvalidBlock
@@ -319,7 +324,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
                Map.insert serverId varCandidate
              runPipelinedPeer nullTracer codecChainSyncId serverId clientChannel
                     (chainSyncClientPeerPipelined (client varCandidate curChain))
-        `catch` \(e :: ChainSyncException tip) -> do
+        `catch` \(e :: ChainSyncException) -> do
           -- TODO: Is this necessary? Wouldn't the Async's internal MVar do?
           atomically $ writeTVar varClientException (Just e)
           -- Rethrow, but it will be ignored anyway.

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -47,6 +47,8 @@ import           Ouroboros.Network.Point (WithOrigin (..), blockPointHash,
 import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
 import           Ouroboros.Network.Protocol.ChainSync.Codec (codecChainSyncId)
 import           Ouroboros.Network.Protocol.ChainSync.Examples
+import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
+                     (pipelineDecisionLowHighMark)
 import           Ouroboros.Network.Protocol.ChainSync.Server
 
 import           Cardano.Crypto.DSIGN.Mock
@@ -255,6 +257,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
                     (Point TestBlock, BlockNo)
                     m
         client = chainSyncClient
+                   (pipelineDecisionLowHighMark 10 20)
                    snd
                    (Tracer $ say . show)
                    (nodeCfg clientId)

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -64,6 +64,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import qualified Ouroboros.Consensus.BlockFetchServer as BFServer
 import           Ouroboros.Consensus.ChainSyncClient (ClockSkew (..))
 import qualified Ouroboros.Consensus.ChainSyncClient as CSClient
+import           Ouroboros.Consensus.ChainSyncServer (Tip)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Mempool
@@ -578,7 +579,7 @@ data LimitedApp m peer blk =
 -- Used internal to this module, essentially as an abbreviatiation.
 type LimitedApp' m peer blk unused1 unused2 =
     NetworkApplication m peer
-        (AnyMessage (ChainSync (Header blk) (Point (Header blk))))
+        (AnyMessage (ChainSync (Header blk) (Tip blk)))
         (AnyMessage (BlockFetch blk))
         (AnyMessage (TxSubmission (GenTxId blk) (GenTx blk)))
         unused1 -- the local node-to-client channel types
@@ -592,7 +593,7 @@ type LimitedApp' m peer blk unused1 unused2 =
 -- | Non-fatal exceptions expected from the threads of a 'directedEdge'
 --
 data MiniProtocolExpectedException blk
-  = MPEEChainSyncClient (CSClient.ChainSyncClientException blk (Point (Header blk)))
+  = MPEEChainSyncClient (CSClient.ChainSyncClientException blk (Tip blk))
     -- ^ see "Ouroboros.Consensus.ChainSyncClient"
     --
     -- NOTE: the second type in 'ChainSyncClientException' denotes the 'tip'.

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -54,6 +54,8 @@ import           Ouroboros.Network.MockChain.Chain
 
 import qualified Ouroboros.Network.BlockFetch.Client as BFClient
 import           Ouroboros.Network.Protocol.BlockFetch.Type
+import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
+                     (pipelineDecisionLowHighMark)
 import           Ouroboros.Network.Protocol.ChainSync.Type
 import           Ouroboros.Network.Protocol.TxSubmission.Type
 import qualified Ouroboros.Network.TxSubmission.Inbound as TxInbound
@@ -313,17 +315,18 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
       chainDB <- ChainDB.openDB args
 
       let nodeArgs = NodeArgs
-            { tracers            = nullTracers
-            , registry           = registry
-            , maxClockSkew       = ClockSkew 1
-            , cfg                = pInfoConfig
-            , initState          = pInfoInitState
+            { tracers             = nullTracers
+            , registry            = registry
+            , maxClockSkew        = ClockSkew 1
+            , cfg                 = pInfoConfig
+            , initState           = pInfoInitState
             , btime
             , chainDB
             , callbacks
-            , blockFetchSize     = nodeBlockFetchSize
-            , blockMatchesHeader = nodeBlockMatchesHeader
-            , maxUnackTxs        = 1000 -- TODO
+            , blockFetchSize      = nodeBlockFetchSize
+            , blockMatchesHeader  = nodeBlockMatchesHeader
+            , maxUnackTxs         = 1000 -- TODO
+            , chainSyncPipelining = pipelineDecisionLowHighMark 2 4
             }
 
       nodeKernel <- initNodeKernel nodeArgs

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -71,6 +71,7 @@ library
                        Ouroboros.Network.Protocol.ChainSync.Type
                        Ouroboros.Network.Protocol.ChainSync.Examples
                        Ouroboros.Network.Protocol.ChainSync.ExamplesPipelined
+                       Ouroboros.Network.Protocol.ChainSync.PipelineDecision
                        Ouroboros.Network.Protocol.BlockFetch.Type
                        Ouroboros.Network.Protocol.BlockFetch.Client
                        Ouroboros.Network.Protocol.BlockFetch.Server
@@ -185,6 +186,7 @@ test-suite test-network
                        Ouroboros.Network.Protocol.ChainSync.DirectPipelined
                        Ouroboros.Network.Protocol.ChainSync.Examples
                        Ouroboros.Network.Protocol.ChainSync.ExamplesPipelined
+                       Ouroboros.Network.Protocol.ChainSync.PipelineDecision
                        Ouroboros.Network.Protocol.ChainSync.Server
                        Ouroboros.Network.Protocol.ChainSync.Type
                        Ouroboros.Network.Protocol.ChainSync.Test
@@ -300,6 +302,7 @@ test-suite cddl
                        Ouroboros.Network.Protocol.ChainSync.DirectPipelined
                        Ouroboros.Network.Protocol.ChainSync.Examples
                        Ouroboros.Network.Protocol.ChainSync.ExamplesPipelined
+                       Ouroboros.Network.Protocol.ChainSync.PipelineDecision
                        Ouroboros.Network.Protocol.ChainSync.Server
                        Ouroboros.Network.Protocol.ChainSync.Test
                        Ouroboros.Network.Protocol.ChainSync.Type

--- a/ouroboros-network/src/Ouroboros/Network/Point.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Point.hs
@@ -10,6 +10,7 @@ module Ouroboros.Network.Point
   , at
   , block
   , fromWithOrigin
+  , withOrigin
   , withOriginToMaybe
   , withOriginFromMaybe
   ) where
@@ -37,6 +38,10 @@ block slot hash = at (Block slot hash)
 fromWithOrigin :: t -> WithOrigin t -> t
 fromWithOrigin t Origin = t
 fromWithOrigin _ (At t) = t
+
+withOrigin :: b -> (t -> b) -> WithOrigin t -> b
+withOrigin a _ Origin = a
+withOrigin _ f (At t) = f t
 
 withOriginToMaybe :: WithOrigin t -> Maybe t
 withOriginToMaybe Origin = Nothing

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
@@ -10,8 +10,10 @@ module Ouroboros.Network.Protocol.ChainSync.ExamplesPipelined
     , Tip
     , chainSyncClientPipelinedMax
     , chainSyncClientPipelinedMin
+    , chainSyncClientPipelinedLowHigh
     ) where
 
+import           Control.Exception (assert)
 import           Control.Monad.Class.MonadSTM.Strict
 
 import           Network.TypedProtocol.Pipelined
@@ -27,8 +29,8 @@ import           Ouroboros.Network.Protocol.ChainSync.Examples (Client (..))
 -- | Pipeline decision: we can do either one of these:
 --
 -- * non-pipelined request
--- * pipline a request
--- * collect or pipline, but only when there are pipelined requests
+-- * pipeline a request
+-- * collect or pipeline, but only when there are pipelined requests
 -- * collect, as above, only when tere are pipelined requests
 --
 -- There might be other useful pipelining scenarios: collect a given number of
@@ -41,7 +43,7 @@ data PipelineDecision n where
     Collect           :: PipelineDecision (S n)
 
 
--- | Make pipeline decision gets the following arguments:
+-- | The callback gets the following arguments:
 --
 -- * how many requests are not yet collected (in flight or
 --   already queued)
@@ -54,10 +56,33 @@ data PipelineDecision n where
 -- 'MsgRollBackward' which rollbacks one block and makes client's tip and
 -- server's tip differ.
 --
--- In this module we implement two pipelining strategies: 'pipelineDecisionMax'
--- and 'pipelineDecisionMin'.
+-- In this module we implement three pipelining strategies:
 --
-type MkPipelineDecision n = Nat n -> BlockNo -> BlockNo -> PipelineDecision n
+-- * 'pipelineDecisionMax'
+-- * 'pipelineDecisionMin'
+-- * 'pipelineDecisionLowHighMark'
+--
+data MkPipelineDecision where
+     MkPipelineDecision
+       :: (forall n. Nat n
+                  -> BlockNo
+                  -> BlockNo
+                  -> (PipelineDecision n, MkPipelineDecision))
+       -> MkPipelineDecision
+
+runPipelineDecision
+    :: MkPipelineDecision
+    -> Nat n -> BlockNo -> BlockNo
+    -> (PipelineDecision n, MkPipelineDecision)
+runPipelineDecision (MkPipelineDecision f) n clientTipBlockNo serverTipBlockNo =
+    f n clientTipBlockNo serverTipBlockNo
+
+
+constantPipelineDecision
+   :: (forall n. Nat n -> BlockNo -> BlockNo -> PipelineDecision n)
+   -> MkPipelineDecision
+constantPipelineDecision f = MkPipelineDecision
+  $ \n clientTipBlockNo serverTipBlockNo -> (f n clientTipBlockNo serverTipBlockNo, constantPipelineDecision f)
 
 
 -- | Present maximal pipelining of at most @omax@ requests.  Collect responses
@@ -79,7 +104,7 @@ type MkPipelineDecision n = Nat n -> BlockNo -> BlockNo -> PipelineDecision n
 --    Collect
 -- @
 --
-pipelineDecisionMax :: Int -> MkPipelineDecision n
+pipelineDecisionMax :: Int -> Nat n -> BlockNo -> BlockNo -> PipelineDecision n
 pipelineDecisionMax omax n cliTipBlockNo srvTipBlockNo =
     case n of
       Zero   -- We are at most one block away from the server's tip.
@@ -116,7 +141,8 @@ pipelineDecisionMax omax n cliTipBlockNo srvTipBlockNo =
 -- | Present minimum pipelining of at most @omax@ requests, collect responses
 -- eagerly.
 --
-pipelineDecisionMin :: Int -> MkPipelineDecision n
+
+pipelineDecisionMin :: Int -> Nat n -> BlockNo -> BlockNo -> PipelineDecision n
 pipelineDecisionMin omax n cliTipBlockNo srvTipBlockNo =
     case n of
       Zero   -- We are at most one block away from the server's tip.
@@ -144,6 +170,64 @@ pipelineDecisionMin omax n cliTipBlockNo srvTipBlockNo =
     omax' = fromIntegral omax
 
 
+-- | Pipelinging strategy which pipelines up to highMark requests; if the number
+-- of pipelined messages exeeds the high mark it collects messages until there
+-- are at most lowMark outstanding requests.
+--
+pipelineDecisionLowHighMark :: Int -> Int -> MkPipelineDecision
+pipelineDecisionLowHighMark lowMark highMark =
+    assert (lowMark <= highMark) goLow
+  where
+    goZero :: Nat Z -> BlockNo -> BlockNo -> (PipelineDecision Z, MkPipelineDecision)
+    goZero Zero clientTipBlockNo serverTipBlockNo
+      | clientTipBlockNo + 1 == serverTipBlockNo
+      = (Request, goLow)
+
+      | otherwise
+      = (Pipeline, goLow)
+
+    -- mutually recursive pipeline decision strategies; we start with `goLow`,
+    -- when we go above the high mark, switch to `goHigh`, switch back to
+    -- `gotLow` when we go below low mark.
+    goLow, goHigh  :: MkPipelineDecision
+
+    goLow = MkPipelineDecision $
+      \n clientTipBlockNo serverTipBlockNo ->
+        case n of
+          Zero   -> goZero n clientTipBlockNo serverTipBlockNo
+
+          Succ{} | clientTipBlockNo + n' >= serverTipBlockNo
+                 -> (Collect, goLow)
+
+                 | n' >= highMark'
+                 -> (Collect, goHigh)
+
+                 | otherwise
+                 -> (CollectOrPipeline, goLow)
+            where
+              n' :: BlockNo
+              n' = fromIntegral (int n)
+
+    goHigh = MkPipelineDecision $
+      \n clientTipBlockNo serverTipBlockNo ->
+      case n of
+        Zero   -> goZero n clientTipBlockNo serverTipBlockNo  
+
+        Succ{} -> 
+            if n' > lowMark'
+              then (Collect,           goHigh)
+              else (CollectOrPipeline, goLow)
+          where
+            n' :: BlockNo
+            n' = fromIntegral (int n)
+
+    lowMark' :: BlockNo
+    lowMark' = fromIntegral lowMark
+
+    highMark' :: BlockNo
+    highMark' = fromIntegral highMark
+
+
 -- | Type which represents tip of server's chain.
 --
 type Tip header = (Point header, BlockNo)
@@ -155,11 +239,11 @@ chainSyncClientPipelined
          ( HasHeader header
          , MonadSTM m
          )
-      => (forall n. MkPipelineDecision n)
+      => MkPipelineDecision
       -> StrictTVar m (Chain header)
       -> Client header (Tip header) m a
       -> ChainSyncClientPipelined header (Tip header) m a
-chainSyncClientPipelined pipelineDecision chainvar =
+chainSyncClientPipelined mkPipelineDecision0 chainvar =
     ChainSyncClientPipelined . fmap initialise . getChainPoints
   where
     initialise :: ([Point header], Client header (Tip header) m a)
@@ -171,14 +255,15 @@ chainSyncClientPipelined pipelineDecision chainvar =
       ClientPipelinedStIntersect {
         recvMsgIntersectFound    = \_ srvTip -> do
           cliTipBlockNo <- Chain.headBlockNo <$> atomically (readTVar chainvar)
-          pure $ go Zero cliTipBlockNo srvTip client,
+          pure $ go mkPipelineDecision0 Zero cliTipBlockNo srvTip client,
         recvMsgIntersectNotFound = \  srvTip -> do
           cliTipBlockNo <- Chain.headBlockNo <$> atomically (readTVar chainvar)
-          pure $ go Zero cliTipBlockNo srvTip client
+          pure $ go mkPipelineDecision0 Zero cliTipBlockNo srvTip client
       }
 
-    -- Drive pipelining by using @pipelineDecision@ callback.
-    go :: Nat n
+    -- Drive pipelining by using @mkPipelineDecision@ callback.
+    go :: MkPipelineDecision
+       -> Nat n
        -> BlockNo
        -- ^ our head
        -> Tip header
@@ -186,9 +271,9 @@ chainSyncClientPipelined pipelineDecision chainvar =
        -> Client header (Tip header) m a
        -> ClientPipelinedStIdle n header (Tip header) m a
 
-    go n cliTipBlockNo srvTip@(_, srvTipBlockNo) client@Client {rollforward, rollbackward} =
-      case (n, pipelineDecision n cliTipBlockNo srvTipBlockNo) of
-        (_Zero, Request) ->
+    go mkPipelineDecision n cliTipBlockNo srvTip@(_, srvTipBlockNo) client@Client {rollforward, rollbackward} =
+      case (n, runPipelineDecision mkPipelineDecision n cliTipBlockNo srvTipBlockNo) of
+        (_Zero, (Request, mkPipelineDecision')) ->
           SendMsgRequestNext
               clientStNext
               -- We received 'MsgAwaitReplay' and we get a chance to run
@@ -202,42 +287,42 @@ chainSyncClientPipelined pipelineDecision chainvar =
                     choice <- rollforward srvHeader
                     pure $ case choice of
                       Left a        -> SendMsgDone a
-                      Right client' -> go n (blockNo srvHeader) srvTip' client',
+                      Right client' -> go mkPipelineDecision' n (blockNo srvHeader) srvTip' client',
                   recvMsgRollBackward = \pRollback srvTip' -> do
                     cliTipBlockNo' <- rollback pRollback
                     choice <- rollbackward pRollback srvTip'
                     pure $ case choice of
                       Left a        -> SendMsgDone a
-                      Right client' -> go n cliTipBlockNo' srvTip' client'
+                      Right client' -> go mkPipelineDecision' n cliTipBlockNo' srvTip' client'
                 }
 
-        (_, Pipeline) ->
+        (_, (Pipeline, mkPipelineDecision')) ->
           SendMsgRequestNextPipelined
-            (go (Succ n) cliTipBlockNo srvTip client)
+            (go mkPipelineDecision' (Succ n) cliTipBlockNo srvTip client)
 
-        (Succ n', CollectOrPipeline) ->
+        (Succ n', (CollectOrPipeline, mkPipelineDecision')) ->
           CollectResponse
             -- if there is no message we pipeline next one; it is important we
             -- do not directly loop here, but send something; otherwise we
             -- would just build a busy loop polling the driver's receiving
             -- queue.
-            (Just $ SendMsgRequestNextPipelined $ go (Succ n) cliTipBlockNo srvTip client)
+            (Just $ SendMsgRequestNextPipelined $ go mkPipelineDecision' (Succ n) cliTipBlockNo srvTip client)
             ClientStNext {
                 recvMsgRollForward = \srvHeader srvTip' -> do
                   addBlock srvHeader
                   choice <- rollforward srvHeader
                   pure $ case choice of
-                    Left a         -> collectAndDone n' a
-                    Right client' -> go n' (blockNo srvHeader) srvTip' client',
+                    Left a        -> collectAndDone n' a
+                    Right client' -> go mkPipelineDecision' n' (blockNo srvHeader) srvTip' client',
                 recvMsgRollBackward = \pRollback srvTip' -> do
                   cliTipBlockNo' <- rollback pRollback
                   choice <- rollbackward pRollback srvTip'
                   pure $ case choice of
-                    Left a         -> collectAndDone n' a
-                    Right client' -> go n' cliTipBlockNo' srvTip' client'
+                    Left a        -> collectAndDone n' a
+                    Right client' -> go mkPipelineDecision' n' cliTipBlockNo' srvTip' client'
               }
 
-        (Succ n', Collect) ->
+        (Succ n', (Collect, mkPipelineDecision')) ->
           CollectResponse
             Nothing
             ClientStNext {
@@ -245,14 +330,14 @@ chainSyncClientPipelined pipelineDecision chainvar =
                   addBlock srvHeader
                   choice <- rollforward srvHeader
                   pure $ case choice of
-                    Left a         -> collectAndDone n' a
-                    Right client' -> go n' (blockNo srvHeader) srvTip' client',
+                    Left a        -> collectAndDone n' a
+                    Right client' -> go mkPipelineDecision' n' (blockNo srvHeader) srvTip' client',
                 recvMsgRollBackward = \pRollback srvTip' -> do
                   cliTipBlockNo' <- rollback pRollback
                   choice <- rollbackward pRollback srvTip'
                   pure $ case choice of
-                    Left a         -> collectAndDone n' a
-                    Right client' -> go n' cliTipBlockNo' srvTip' client'
+                    Left a        -> collectAndDone n' a
+                    Right client' -> go mkPipelineDecision' n' cliTipBlockNo' srvTip' client'
               }
 
 
@@ -370,9 +455,9 @@ chainSyncClientPipelinedMax
       -> StrictTVar m (Chain header)
       -> Client header (Tip header) m a
       -> ChainSyncClientPipelined header (Tip header) m a
-chainSyncClientPipelinedMax omax = chainSyncClientPipelined (pipelineDecisionMax omax)
+chainSyncClientPipelinedMax omax = chainSyncClientPipelined (constantPipelineDecision $ pipelineDecisionMax omax)
 
--- | A pipelined chain-sycn client that piplines at most @omax@ requests and
+-- | A pipelined chain-sycn client that pipelines at most @omax@ requests and
 -- always tries to collect any replies as soon as they are available.   This
 -- keeps pipelineing to bare minimum, and gives maximum choice to the
 -- environment (drivers).
@@ -423,4 +508,19 @@ chainSyncClientPipelinedMin
       -> StrictTVar m (Chain header)
       -> Client header (Tip header) m a
       -> ChainSyncClientPipelined header (Tip header) m a
-chainSyncClientPipelinedMin omax = chainSyncClientPipelined (pipelineDecisionMin omax)
+chainSyncClientPipelinedMin omax = chainSyncClientPipelined (constantPipelineDecision $ pipelineDecisionMin omax)
+
+
+chainSyncClientPipelinedLowHigh
+      :: forall header m a.
+         ( HasHeader header
+         , MonadSTM m
+         )
+      => Int
+      -- ^ low mark
+      -> Int
+      -- ^ high mark
+      -> StrictTVar m (Chain header)
+      -> Client header (Tip header) m a
+      -> ChainSyncClientPipelined header (Tip header) m a
+chainSyncClientPipelinedLowHigh lowMark highMark = chainSyncClientPipelined (pipelineDecisionLowHighMark lowMark highMark)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
@@ -100,7 +100,7 @@ pipelineDecisionMax omax n cliTipBlockNo srvTipBlockNo =
              -- this causes @n'@ to drop and we will pipeline next message.
              -- This assures that when we aproach the end of the chain we will
              -- collect all outstanding requests without pipelining a request
-             | cliTipBlockNo + omax' >= srvTipBlockNo || n' >= omax'
+             | cliTipBlockNo + n' >= srvTipBlockNo || n' >= omax'
              -> Collect
 
              | otherwise
@@ -131,7 +131,7 @@ pipelineDecisionMin omax n cliTipBlockNo srvTipBlockNo =
       Succ{} -- We pipelined some requests and we are now synchronised or we
              -- exceeded pipelineing limit, and thus we should await for
              -- a response.
-             | cliTipBlockNo + omax' >= srvTipBlockNo || n' >= omax'
+             | cliTipBlockNo + n' >= srvTipBlockNo || n' >= omax'
              -> Collect
 
              | otherwise

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/PipelineDecision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/PipelineDecision.hs
@@ -127,7 +127,7 @@ pipelineDecisionMax omax n cliTipBlockNo srvTipBlockNo =
              -> Pipeline
   where
     n' :: BlockNo
-    n' = fromIntegral (int n)
+    n' = fromIntegral (natToInt n)
 
     omax' :: BlockNo
     omax' = fromIntegral omax
@@ -158,7 +158,7 @@ pipelineDecisionMin omax n cliTipBlockNo srvTipBlockNo =
              -> CollectOrPipeline
   where
     n' :: BlockNo
-    n' = fromIntegral (int n)
+    n' = fromIntegral (natToInt n)
 
     omax' :: BlockNo
     omax' = fromIntegral omax
@@ -200,7 +200,7 @@ pipelineDecisionLowHighMark lowMark highMark =
                  -> (CollectOrPipeline, goLow)
             where
               n' :: BlockNo
-              n' = fromIntegral (int n)
+              n' = fromIntegral (natToInt n)
 
     goHigh = MkPipelineDecision $
       \n clientTipBlockNo serverTipBlockNo ->
@@ -213,15 +213,10 @@ pipelineDecisionLowHighMark lowMark highMark =
               else (CollectOrPipeline, goLow)
           where
             n' :: BlockNo
-            n' = fromIntegral (int n)
+            n' = fromIntegral (natToInt n)
 
     lowMark' :: BlockNo
     lowMark' = fromIntegral lowMark
 
     highMark' :: BlockNo
     highMark' = fromIntegral highMark
-
--- this isn't supposed to be efficient, it's just for the example
-int :: Nat n -> Int
-int Zero     = 0
-int (Succ n) = succ (int n)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/PipelineDecision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/PipelineDecision.hs
@@ -1,0 +1,227 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Network.Protocol.ChainSync.PipelineDecision
+    ( PipelineDecision(..)
+    , MkPipelineDecision(..)
+    , runPipelineDecision
+    , constantPipelineDecision
+    , pipelineDecisionMax
+    , pipelineDecisionMin
+    , pipelineDecisionLowHighMark
+    ) where
+
+import           Control.Exception (assert)
+
+import           Network.TypedProtocol.Pipelined
+
+import           Ouroboros.Network.Block (BlockNo)
+
+-- | Pipeline decision: we can do either one of these:
+--
+-- * non-pipelined request
+-- * pipeline a request
+-- * collect or pipeline, but only when there are pipelined requests
+-- * collect, as above, only when tere are pipelined requests
+--
+-- There might be other useful pipelining scenarios: collect a given number of
+-- requests (whihc als can be used to collect all outstanding requests).
+--
+data PipelineDecision n where
+    Request           :: PipelineDecision Z
+    Pipeline          :: PipelineDecision n
+    CollectOrPipeline :: PipelineDecision (S n)
+    Collect           :: PipelineDecision (S n)
+
+
+-- | The callback gets the following arguments:
+--
+-- * how many requests are not yet collected (in flight or
+--   already queued)
+-- * block nubmer of client's tip
+-- * block nubmer of server's tip
+--
+-- Client' tip block number and server' tip block number can only be equal
+-- (from client's perspective) when both client's and server's tip headers
+-- agree.  If they would not agree (server forked), then the server sends
+-- 'MsgRollBackward' which rollbacks one block and makes client's tip and
+-- server's tip differ.
+--
+-- In this module we implement three pipelining strategies:
+--
+-- * 'pipelineDecisionMax'
+-- * 'pipelineDecisionMin'
+-- * 'pipelineDecisionLowHighMark'
+--
+data MkPipelineDecision where
+     MkPipelineDecision
+       :: (forall n. Nat n
+                  -> BlockNo
+                  -> BlockNo
+                  -> (PipelineDecision n, MkPipelineDecision))
+       -> MkPipelineDecision
+
+runPipelineDecision
+    :: MkPipelineDecision
+    -> Nat n -> BlockNo -> BlockNo
+    -> (PipelineDecision n, MkPipelineDecision)
+runPipelineDecision (MkPipelineDecision f) n clientTipBlockNo serverTipBlockNo =
+    f n clientTipBlockNo serverTipBlockNo
+
+
+constantPipelineDecision
+   :: (forall n. Nat n -> BlockNo -> BlockNo -> PipelineDecision n)
+   -> MkPipelineDecision
+constantPipelineDecision f = MkPipelineDecision
+  $ \n clientTipBlockNo serverTipBlockNo -> (f n clientTipBlockNo serverTipBlockNo, constantPipelineDecision f)
+
+
+-- | Present maximal pipelining of at most @omax@ requests.  Collect responses
+-- either when we are at the same block number as the server or when we sent
+-- more than @omax@ requests.
+--
+-- If @omax = 3@ this pipelining strategy will generate a sequence:
+-- @
+--    Pipeline
+--    Pipeline
+--    Pipeline
+--    Collect
+--    Pipeline
+--    Collect
+--    ....
+--    Pipeline
+--    Collect
+--    Collect
+--    Collect
+-- @
+--
+pipelineDecisionMax :: Int -> Nat n -> BlockNo -> BlockNo -> PipelineDecision n
+pipelineDecisionMax omax n cliTipBlockNo srvTipBlockNo =
+    case n of
+      Zero   -- We are at most one block away from the server's tip.
+             -- We use equality so that this does not triggered when we are
+             -- ahead of the producer, and it wil send us 'MsgRollBackward'.
+             | cliTipBlockNo + 1 == srvTipBlockNo
+             -> Request
+
+             | otherwise
+             -> Pipeline
+
+      Succ{} -- We pipelined some requests and we are now synchronised or we
+             -- exceeded pipelineing limit, and thus we should await for
+             -- a response.
+             --
+             -- Note: we add @omax'@ to avoid a deadlock in tests.  This
+             -- pielineing strategy collects at this stage a single result,
+             -- this causes @n'@ to drop and we will pipeline next message.
+             -- This assures that when we aproach the end of the chain we will
+             -- collect all outstanding requests without pipelining a request
+             | cliTipBlockNo + n' >= srvTipBlockNo || n' >= omax'
+             -> Collect
+
+             | otherwise
+             -> Pipeline
+  where
+    n' :: BlockNo
+    n' = fromIntegral (int n)
+
+    omax' :: BlockNo
+    omax' = fromIntegral omax
+
+
+-- | Present minimum pipelining of at most @omax@ requests, collect responses
+-- eagerly.
+--
+
+pipelineDecisionMin :: Int -> Nat n -> BlockNo -> BlockNo -> PipelineDecision n
+pipelineDecisionMin omax n cliTipBlockNo srvTipBlockNo =
+    case n of
+      Zero   -- We are at most one block away from the server's tip.
+             -- We use equality so that this does not triggered when we are
+             -- ahead of the producer, and it wil send us 'MsgRollBackward'.
+             | cliTipBlockNo + 1 == srvTipBlockNo
+             -> Request
+
+             | otherwise
+             -> Pipeline
+
+      Succ{} -- We pipelined some requests and we are now synchronised or we
+             -- exceeded pipelineing limit, and thus we should await for
+             -- a response.
+             | cliTipBlockNo + n' >= srvTipBlockNo || n' >= omax'
+             -> Collect
+
+             | otherwise
+             -> CollectOrPipeline
+  where
+    n' :: BlockNo
+    n' = fromIntegral (int n)
+
+    omax' :: BlockNo
+    omax' = fromIntegral omax
+
+
+-- | Pipelinging strategy which pipelines up to highMark requests; if the number
+-- of pipelined messages exeeds the high mark it collects messages until there
+-- are at most lowMark outstanding requests.
+--
+pipelineDecisionLowHighMark :: Int -> Int -> MkPipelineDecision
+pipelineDecisionLowHighMark lowMark highMark =
+    assert (lowMark <= highMark) goLow
+  where
+    goZero :: Nat Z -> BlockNo -> BlockNo -> (PipelineDecision Z, MkPipelineDecision)
+    goZero Zero clientTipBlockNo serverTipBlockNo
+      | clientTipBlockNo + 1 == serverTipBlockNo
+      = (Request, goLow)
+
+      | otherwise
+      = (Pipeline, goLow)
+
+    -- mutually recursive pipeline decision strategies; we start with `goLow`,
+    -- when we go above the high mark, switch to `goHigh`, switch back to
+    -- `gotLow` when we go below low mark.
+    goLow, goHigh  :: MkPipelineDecision
+
+    goLow = MkPipelineDecision $
+      \n clientTipBlockNo serverTipBlockNo ->
+        case n of
+          Zero   -> goZero n clientTipBlockNo serverTipBlockNo
+
+          Succ{} | clientTipBlockNo + n' >= serverTipBlockNo
+                 -> (Collect, goLow)
+
+                 | n' >= highMark'
+                 -> (Collect, goHigh)
+
+                 | otherwise
+                 -> (CollectOrPipeline, goLow)
+            where
+              n' :: BlockNo
+              n' = fromIntegral (int n)
+
+    goHigh = MkPipelineDecision $
+      \n clientTipBlockNo serverTipBlockNo ->
+      case n of
+        Zero   -> goZero n clientTipBlockNo serverTipBlockNo
+
+        Succ{} ->
+            if n' > lowMark'
+              then (Collect,           goHigh)
+              else (CollectOrPipeline, goLow)
+          where
+            n' :: BlockNo
+            n' = fromIntegral (int n)
+
+    lowMark' :: BlockNo
+    lowMark' = fromIntegral lowMark
+
+    highMark' :: BlockNo
+    highMark' = fromIntegral highMark
+
+-- this isn't supposed to be efficient, it's just for the example
+int :: Nat n -> Int
+int Zero     = 0
+int (Succ n) = succ (int n)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -78,10 +78,12 @@ tests = testGroup "Ouroboros.Network.Protocol.ChainSyncProtocol"
   , testProperty "codec cbor"     prop_codec_cbor
   , testProperty "demo ST" propChainSyncDemoST
   , testProperty "demo IO" propChainSyncDemoIO
-  , testProperty "demoPipelinedMax ST" propChainSyncDemoPipelinedMaxST
-  , testProperty "demoPipelinedMax IO" propChainSyncDemoPipelinedMaxIO
-  , testProperty "demoPipelinedMin ST" propChainSyncDemoPipelinedMinST
-  , testProperty "demoPipelinedMin IO" propChainSyncDemoPipelinedMinIO
+  , testProperty "demoPipelinedMax ST"     propChainSyncDemoPipelinedMaxST
+  , testProperty "demoPipelinedMax IO"     propChainSyncDemoPipelinedMaxIO
+  , testProperty "demoPipelinedMin ST"     propChainSyncDemoPipelinedMinST
+  , testProperty "demoPipelinedMin IO"     propChainSyncDemoPipelinedMinIO
+  , testProperty "demoPipelinedLowHigh ST" propChainSyncDemoPipelinedLowHighST
+  , testProperty "demoPipelinedLowHigh IO" propChainSyncDemoPipelinedLowHighIO
   , testProperty "demoPipelinedMin IO (buffered)"
                                        propChainSyncDemoPipelinedMinBufferedIO
   , testProperty "demo IO" propChainSyncDemoIO
@@ -556,6 +558,38 @@ propChainSyncDemoPipelinedMinIO cps (Positive omax) =
       clientChan serverChan
       (ChainSyncExamples.chainSyncClientPipelinedMin omax)
       cps
+
+propChainSyncDemoPipelinedLowHighST
+  :: ChainProducerStateForkTest
+  -> Positive Int
+  -> Positive Int
+  -> Property
+propChainSyncDemoPipelinedLowHighST cps (Positive x) (Positive y) =
+    runSimOrThrow $ do
+      (clientChan, serverChan) <- createPipelineTestChannels (fromIntegral highMark)
+      chainSyncDemoPipelined
+        clientChan serverChan
+        (ChainSyncExamples.chainSyncClientPipelinedLowHigh lowMark highMark)
+        cps
+  where
+    lowMark = min x y
+    highMark = max x y
+
+propChainSyncDemoPipelinedLowHighIO
+  :: ChainProducerStateForkTest
+  -> Positive Int
+  -> Positive Int
+  -> Property
+propChainSyncDemoPipelinedLowHighIO cps (Positive x) (Positive y) =
+    ioProperty $ do
+      (clientChan, serverChan) <- createPipelineTestChannels (fromIntegral highMark)
+      chainSyncDemoPipelined
+        clientChan serverChan
+        (ChainSyncExamples.chainSyncClientPipelinedLowHigh lowMark highMark)
+        cps
+  where
+    lowMark = min x y
+    highMark = max x y
 
 propChainSyncDemoPipelinedMinBufferedIO
   :: ChainProducerStateForkTest


### PR DESCRIPTION
This builds on #1027.

**NOTE:** this changes the instantiation of the ChainSync protocol: the `tip` parameter is now instantiated with the new `Tip blk` type (see `Ouroboros.Consensus.ChainSync`) instead of `Point blk`. The cardano-node and -byron-proxy will have to be updated. 