### PR TITLE
do not rollback ledger db when n = 0

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -550,6 +550,7 @@ rollback :: forall m l r b e. Monad m
          => LedgerDbConf m l r b e
          -> Word64 -> LedgerDB l r -> m (Maybe (LedgerDB l r))
 rollback cfg n db@LedgerDB{..}
+  | n == 0        = return $ Just db
   | numToKeep < 0 = return Nothing
   | otherwise     = do
       current' <- uncurry computeCurrent $ reapply blocks'


### PR DESCRIPTION
Previously, thousands of blocks would be reapplied on every addBlock:
the num to rollback is 0, but rollback would still reapply them.

I don't know whether this patch makes anything incorrect, but it seems
sensible, and makes block download WAY faster.