### PR TITLE
Add a test which checks that codecs produce valid cbor encoding

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
@@ -46,7 +46,7 @@ codecBlockFetch encodeBlock     decodeBlock
          -> Message (BlockFetch block) st st'
          -> CBOR.Encoding
   encode (ClientAgency TokIdle) (MsgRequestRange (ChainRange from to)) =
-    CBOR.encodeListLen 2 <> CBOR.encodeWord 0 <> encodePoint from
+    CBOR.encodeListLen 3 <> CBOR.encodeWord 0 <> encodePoint from
                                               <> encodePoint to
   encode (ClientAgency TokIdle) MsgClientDone =
     CBOR.encodeListLen 1 <> CBOR.encodeWord 1

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -37,7 +37,7 @@ import           Ouroboros.Network.Protocol.BlockFetch.Examples
 import           Ouroboros.Network.Protocol.BlockFetch.Codec
 
 import           Test.ChainGenerators ( TestChainAndPoints (..) )
-import           Test.Ouroboros.Network.Testing.Utils (splits2, splits3)
+import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM, splits2, splits3)
 
 import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
@@ -63,6 +63,7 @@ tests =
   , testProperty "codec 2-splits"      prop_codec_splits2_BlockFetch
   , testProperty "codec 3-splits"    $ withMaxSuccess 30
                                        prop_codec_splits3_BlockFetch
+  , testProperty "codec cbor"          prop_codec_cbor_BlockFetch
   ]
 
 
@@ -350,6 +351,11 @@ prop_codec_splits3_BlockFetch
 prop_codec_splits3_BlockFetch msg =
   runST (prop_codec_splitsM splits3 codec msg)
 
+prop_codec_cbor_BlockFetch
+  :: AnyMessageAndAgency (BlockFetch Block)
+  -> Bool
+prop_codec_cbor_BlockFetch msg =
+  runST (prop_codec_cborM codec msg)
 
 --
 -- Auxilary functions

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -52,7 +52,7 @@ import           Ouroboros.Network.Testing.ConcreteBlock (Block (..),
                      BlockHeader (..))
 import           Test.ChainGenerators ()
 import           Test.ChainProducerState (ChainProducerStateForkTest (..))
-import           Test.Ouroboros.Network.Testing.Utils (splits2, splits3)
+import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM, splits2, splits3)
 
 import           Test.QuickCheck hiding (Result)
 import           Test.Tasty (TestTree, testGroup)
@@ -75,6 +75,7 @@ tests = testGroup "Ouroboros.Network.Protocol.ChainSyncProtocol"
   , testProperty "codec"          prop_codec_ChainSync
   , testProperty "codec 2-splits" prop_codec_splits2_ChainSync
   , testProperty "codec 3-splits" $ withMaxSuccess 30 prop_codec_splits3_ChainSync
+  , testProperty "codec cbor"     prop_codec_cbor
   , testProperty "demo ST" propChainSyncDemoST
   , testProperty "demo IO" propChainSyncDemoIO
   , testProperty "demoPipelinedMax ST" propChainSyncDemoPipelinedMaxST
@@ -399,6 +400,11 @@ prop_codec_splits3_ChainSync msg =
       splits3
       codec
       msg
+prop_codec_cbor
+  :: AnyMessageAndAgency (ChainSync BlockHeader (Point BlockHeader, BlockNo))
+  -> Bool
+prop_codec_cbor msg =
+    ST.runST (prop_codec_cborM codec msg)
 
 chainSyncDemo
   :: forall m.

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -28,7 +28,7 @@ import           Network.TypedProtocol.Channel
 import           Network.TypedProtocol.Driver
 import           Network.TypedProtocol.Proofs
 
-import           Test.Ouroboros.Network.Testing.Utils (splits2, splits3)
+import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM, splits2, splits3)
 
 import           Ouroboros.Network.Channel
 
@@ -59,6 +59,7 @@ tests =
   , testProperty "codec 2-splits"      prop_codec_splits2_Handshake
   , testProperty "codec 3-splits"    $ withMaxSuccess 30
                                        prop_codec_splits3_Handshake
+  , testProperty "codec cbor"          prop_codec_cbor
   , testGroup "Generators"
     [ testProperty "ArbitraryVersions" $
         checkCoverage prop_arbitrary_ArbitraryVersions
@@ -480,3 +481,9 @@ prop_codec_splits3_Handshake
   -> Bool
 prop_codec_splits3_Handshake msg =
   runST (prop_codec_splitsM splits3 codecHandshake msg)
+
+prop_codec_cbor
+  :: AnyMessageAndAgency (Handshake VersionNumber CBOR.Term)
+  -> Bool
+prop_codec_cbor msg =
+  runST (prop_codec_cborM codecHandshake msg)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
@@ -40,7 +40,7 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Examples
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Server
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
 
-import           Test.Ouroboros.Network.Testing.Utils (splits2, splits3)
+import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM, splits2, splits3)
 
 import           Text.Show.Functions ()
 import           Test.QuickCheck as QC
@@ -61,6 +61,7 @@ tests =
   , testProperty "codec 2-splits"      prop_codec_splits2
   , testProperty "codec 3-splits"    $ withMaxSuccess 30
                                        prop_codec_splits3
+  , testProperty "codec cbor"          prop_codec_cbor
   , testProperty "channel ST"          prop_channel_ST
   , testProperty "channel IO"          prop_channel_IO
   , testProperty "pipe IO"             prop_pipe_IO
@@ -240,3 +241,8 @@ prop_codec_splits3 :: AnyMessageAndAgency (LocalTxSubmission Tx Reject) -> Bool
 prop_codec_splits3 msg =
   runST (prop_codec_splitsM splits3 codec msg)
 
+prop_codec_cbor
+  :: AnyMessageAndAgency (LocalTxSubmission Tx Reject)
+  -> Bool
+prop_codec_cbor msg =
+  runST (prop_codec_cborM codec msg)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Test.hs
@@ -43,7 +43,7 @@ import           Ouroboros.Network.Protocol.TxSubmission.Examples
 import           Ouroboros.Network.Protocol.TxSubmission.Server
 import           Ouroboros.Network.Protocol.TxSubmission.Type
 
-import           Test.Ouroboros.Network.Testing.Utils (splits2, splits3)
+import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM, splits2, splits3)
 
 import           Test.QuickCheck as QC
 import           Test.Tasty (TestTree, testGroup)
@@ -64,6 +64,7 @@ tests =
   , testProperty "codec 2-splits"      prop_codec_splits2
   , testProperty "codec 3-splits"    $ withMaxSuccess 30
                                        prop_codec_splits3
+  , testProperty "codec cbor"          prop_codec_cbor
   , testProperty "channel ST"          prop_channel_ST
   , testProperty "channel IO"          prop_channel_IO
   , testProperty "pipe IO"             prop_pipe_IO
@@ -318,6 +319,11 @@ prop_codec_splits3 :: AnyMessageAndAgency (TxSubmission TxId Tx) -> Bool
 prop_codec_splits3 msg =
   runST (prop_codec_splitsM splits3 codec msg)
 
+prop_codec_cbor
+  :: AnyMessageAndAgency (TxSubmission TxId Tx)
+  -> Bool
+prop_codec_cbor msg =
+  runST (prop_codec_cborM codec msg)
 
 --
 -- Local generators

--- a/ouroboros-network/test/Test/Ouroboros/Network/Testing/Utils.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/Testing/Utils.hs
@@ -1,7 +1,12 @@
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE FlexibleContexts    #-}
 module Test.Ouroboros.Network.Testing.Utils where
 
 import qualified Data.ByteString.Lazy as LBS
+import qualified Codec.CBOR.Read      as CBOR
+import qualified Codec.CBOR.Term      as CBOR
 
+import           Network.TypedProtocol.Codec
 
 -- | Generate all 2-splits of a string.
 splits2 :: LBS.ByteString -> [[LBS.ByteString]]
@@ -13,3 +18,18 @@ splits3 bs =
     [ [a,b,c]
     | (a,bs') <- zip (LBS.inits bs)  (LBS.tails bs)
     , (b,c)   <- zip (LBS.inits bs') (LBS.tails bs') ]
+
+-- | Check that the codec produces a valid CBOR term
+-- that is decodeable by CBOR.decodeTerm.
+prop_codec_cborM
+  :: forall ps m.
+     ( Monad m
+     , Eq (AnyMessage ps)
+     )
+  => Codec ps CBOR.DeserialiseFailure m LBS.ByteString
+  -> AnyMessageAndAgency ps
+  -> m Bool
+prop_codec_cborM codec (AnyMessageAndAgency stok msg)
+    = case CBOR.deserialiseFromBytes CBOR.decodeTerm $ encode codec stok msg of
+        Left _err               -> return False
+        Right (leftover, _term) -> return $ LBS.null leftover


### PR DESCRIPTION
Add a test which checks that codecs produce valid cbor encoding.
This addresses #984.