### PR TITLE
Move Byron orphans to separate module

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -39,6 +39,7 @@ library
                        Ouroboros.Consensus.Ledger.Byron
                        Ouroboros.Consensus.Ledger.Byron.Config
                        Ouroboros.Consensus.Ledger.Byron.Forge
+                       Ouroboros.Consensus.Ledger.Byron.Orphans
                        Ouroboros.Consensus.Ledger.Extended
                        Ouroboros.Consensus.Ledger.Mock
                        Ouroboros.Consensus.Ledger.Mock.Address

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -14,8 +14,6 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints -Wno-orphans #-}
-
 module Ouroboros.Consensus.Ledger.Byron
   ( -- * Byron blocks and headers
     ByronBlock (..)
@@ -64,7 +62,7 @@ import           Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Write as CBOR
-import           Codec.Serialise (Serialise, decode, encode)
+import           Codec.Serialise (decode, encode)
 import           Control.Monad.Except
 import           Control.Monad.Trans.Reader (runReaderT)
 import           Data.Bifunctor (bimap)
@@ -106,6 +104,7 @@ import qualified Ouroboros.Network.Point as Point (block, origin)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Crypto.DSIGN.Cardano
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Byron.Orphans ()
 import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.ExtNodeConfig
@@ -626,14 +625,6 @@ instance Show (GenTxId (ByronBlockOrEBB cfg)) where
 {-------------------------------------------------------------------------------
   Serialisation
 -------------------------------------------------------------------------------}
-
-instance Serialise CC.Block.ChainValidationState where
-  encode = toCBOR
-  decode = fromCBOR
-
-instance Serialise CC.Common.KeyHash where
-  encode = toCBOR
-  decode = fromCBOR
 
 -- | Encode a block. A legacy Byron node (cardano-sl) would successfully
 -- decode a block from these.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Orphans.hs
@@ -1,0 +1,20 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Ouroboros.Consensus.Ledger.Byron.Orphans () where
+
+import           Codec.Serialise (Serialise, decode, encode)
+
+import           Cardano.Binary (fromCBOR, toCBOR)
+import qualified Cardano.Chain.Block as CC.Block
+import qualified Cardano.Chain.Common as CC.Common
+
+{-------------------------------------------------------------------------------
+  Serialise
+-------------------------------------------------------------------------------}
+
+instance Serialise CC.Block.ChainValidationState where
+  encode = toCBOR
+  decode = fromCBOR
+
+instance Serialise CC.Common.KeyHash where
+  encode = toCBOR
+  decode = fromCBOR


### PR DESCRIPTION
I've been trying to get rid of these orphans by introducing some
newtypes, but it's hard to do. We might revisit this later, but for now
at least this makes these orphans a bit more visible.

(The only other remaining orphans we now have are in tests and in mock
protocols.)