### PR TITLE
Block Fetch optimisations

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -272,6 +272,9 @@ initBlockFetchConsensusInterface cfg chainDB getCandidates blockFetchSize
     addFetchedBlock :: Point blk -> blk -> m ()
     addFetchedBlock _pt = ChainDB.addBlock chainDB
 
+    readFetchedMaxSlotNo :: STM m MaxSlotNo
+    readFetchedMaxSlotNo = ChainDB.getMaxSlotNo chainDB
+
     plausibleCandidateChain :: AnchoredFragment (Header blk)
                             -> AnchoredFragment (Header blk)
                             -> Bool

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -1,11 +1,8 @@
- {-# LANGUAGE BangPatterns          #-}
- {-# LANGUAGE ConstraintKinds       #-}
- {-# LANGUAGE FlexibleInstances     #-}
- {-# LANGUAGE GADTs                 #-}
- {-# LANGUAGE MultiParamTypeClasses #-}
- {-# LANGUAGE PolyKinds             #-}
- {-# LANGUAGE ScopedTypeVariables   #-}
- {-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Miscellaneous utilities
 module Ouroboros.Consensus.Util (
@@ -33,13 +30,17 @@ module Ouroboros.Consensus.Util (
   , takeLast
   , dropLast
   , mustBeRight
+  , safeMaximum
+  , safeMaximumBy
+  , safeMaximumOn
   ) where
 
 import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Constraint
+import           Data.Function (on)
 import           Data.Functor.Identity
-import           Data.List (foldl')
+import           Data.List (foldl', maximumBy)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Void
@@ -168,3 +169,13 @@ dropLast n = reverse . drop (fromIntegral n) . reverse
 mustBeRight :: Either Void a -> a
 mustBeRight (Left  v) = absurd v
 mustBeRight (Right a) = a
+
+safeMaximum :: Ord a => [a] -> Maybe a
+safeMaximum = safeMaximumBy compare
+
+safeMaximumBy :: (a -> a -> Ordering) -> [a] -> Maybe a
+safeMaximumBy _cmp [] = Nothing
+safeMaximumBy cmp ls  = Just $ maximumBy cmp ls
+
+safeMaximumOn :: Ord b => (a -> b) -> [a] -> Maybe a
+safeMaximumOn f = safeMaximumBy (compare `on` f)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -45,8 +45,8 @@ import           Control.Monad.Class.MonadThrow
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Ouroboros.Network.Block (BlockNo, pattern BlockPoint,
                      ChainUpdate, pattern GenesisPoint, HasHeader (..),
-                     HeaderHash, Point, SlotNo, StandardHash, atSlot,
-                     genesisPoint)
+                     HeaderHash, MaxSlotNo, Point, SlotNo, StandardHash,
+                     atSlot, genesisPoint)
 
 import           Ouroboros.Consensus.Block (GetHeader (..))
 import           Ouroboros.Consensus.Ledger.Extended
@@ -164,6 +164,13 @@ data ChainDB m blk = ChainDB {
       -- For blocks older than that the results should be regarded as
       -- non-deterministic.
     , getIsFetched       :: STM m (Point blk -> Bool)
+
+      -- | Get the highest slot number stored in the ChainDB.
+      --
+      -- Note that the corresponding block doesn't have to be part of the
+      -- current chain, it could be part of some fork, or even be a
+      -- disconnected block.
+    , getMaxSlotNo       :: STM m MaxSlotNo
 
       -- | Stream blocks
       --

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -182,6 +182,7 @@ openDBInternal args launchBgTasks = do
           , getTipBlockNo      = getEnvSTM  h Query.getTipBlockNo
           , getBlock           = getEnv1    h Query.getBlock
           , getIsFetched       = getEnvSTM  h Query.getIsFetched
+          , getMaxSlotNo       = getEnvSTM  h Query.getMaxSlotNo
           , streamBlocks       = Iterator.streamBlocks  h
           , newHeaderReader    = Reader.newHeaderReader h
           , newBlockReader     = Reader.newBlockReader  h

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
@@ -33,6 +33,7 @@ module Ouroboros.Storage.ChainDB.Impl.VolDB (
   , getIsMember
   , getPredecessor
   , getSuccessors
+  , getMaxSlotNo
   , putBlock
   , closeDB
   , reopen
@@ -62,8 +63,9 @@ import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Network.Block (pattern BlockPoint, ChainHash (..),
-                     pattern GenesisPoint, HasHeader (..), HeaderHash, Point,
-                     SlotNo, StandardHash, pointHash, withHash)
+                     pattern GenesisPoint, HasHeader (..), HeaderHash,
+                     MaxSlotNo, Point, SlotNo, StandardHash, pointHash,
+                     withHash)
 import qualified Ouroboros.Network.Block as Block
 
 import           Ouroboros.Consensus.Block (GetHeader, Header)
@@ -165,6 +167,10 @@ getPredecessor db = withSTM db VolDB.getPredecessor
 getSuccessors :: VolDB m blk
               -> STM m (Maybe (HeaderHash blk) -> Set (HeaderHash blk))
 getSuccessors db = withSTM db VolDB.getSuccessors
+
+getMaxSlotNo :: VolDB m blk
+             -> STM m MaxSlotNo
+getMaxSlotNo db = withSTM db VolDB.getMaxSlotNo
 
 putBlock :: (MonadCatch m, HasHeader blk) => VolDB m blk -> blk -> m ()
 putBlock db@VolDB{..} b = withDB db $ \vol ->

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
@@ -117,6 +117,7 @@ openDB cfg initLedger = do
       , getTipBlockNo       = querySTM $ Model.tipBlockNo
       , getIsFetched        = querySTM $ flip Model.hasBlockByPoint
       , getIsInvalidBlock   = querySTM $ (first (flip Map.member)) . Model.invalid
+      , getMaxSlotNo        = querySTM $ Model.maxSlotNo
       , streamBlocks        = updateE  ..: const (fmap (first (fmap iterator)) ..: Model.streamBlocks k)
       , newBlockReader      = update   .   const (first reader . Model.readBlocks)
       , newHeaderReader     = update   .   const (first (fmap getHeader . reader) . Model.readBlocks)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Model.hs
@@ -28,6 +28,7 @@ module Ouroboros.Storage.ChainDB.Model (
   , hasBlock
   , hasBlockByPoint
   , immutableBlockNo
+  , maxSlotNo
   , isOpen
   , invalid
     -- * Iterators
@@ -66,7 +67,7 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as Fragment
 import           Ouroboros.Network.Block (BlockNo, pattern BlockPoint,
                      ChainHash (..), pattern GenesisPoint, HasHeader,
-                     HeaderHash, Point, SlotNo)
+                     HeaderHash, MaxSlotNo, Point, SlotNo, maxSlotNoFromMaybe)
 import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Network.MockChain.Chain (Chain (..), ChainUpdate)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
@@ -76,7 +77,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.MockChainSel
-import           Ouroboros.Consensus.Util (repeatedly)
+import           Ouroboros.Consensus.Util (repeatedly, safeMaximum)
 import qualified Ouroboros.Consensus.Util.AnchoredFragment as Fragment
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..))
 
@@ -164,6 +165,13 @@ immutableBlockNo (SecurityParam k) =
         Chain.headBlockNo
       . Chain.drop (fromIntegral k)
       . currentChain
+
+maxSlotNo :: HasHeader blk => Model blk -> MaxSlotNo
+maxSlotNo = maxSlotNoFromMaybe
+          . safeMaximum
+          . map Block.blockSlot
+          . Map.elems
+          . blocks
 
 {-------------------------------------------------------------------------------
   Construction

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
@@ -55,4 +55,6 @@ data VolatileDB blockId m = VolatileDB {
     , getPredecessor :: HasCallStack => STM m (blockId -> Maybe blockId)
     , garbageCollect :: HasCallStack => SlotNo -> m ()
     , getIsMember    :: HasCallStack => STM m (blockId -> Bool)
+      -- | Return the highest slot number ever stored by the VolatileDB.
+    , getMaxSlotNo   :: HasCallStack => STM m MaxSlotNo
 }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
@@ -39,6 +39,7 @@ openDBMock err maxNumPerFile = do
         , getBlockIds    = wrapModel' dbVar  $ getBlockIdsModel    err'
         , getSuccessors  = wrapModel  dbVar  $ getSuccessorsModel  err'
         , getPredecessor = wrapModel  dbVar  $ getPredecessorModel err'
+        , getMaxSlotNo   = wrapModel  dbVar  $ getMaxSlotNoModel   err'
         }
 
     err' :: ThrowCantCatch (VolatileDBError blockId)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -87,16 +87,24 @@ data Success
   deriving Show
 
 instance Eq Success where
-    Unit () == Unit () = True
-    Blob mbs == Blob mbs' = mbs == mbs'
-    Blocks ls == Blocks ls' = S.fromList ls == S.fromList ls'
-    Bl bl == Bl bl' = bl == bl'
-    IsMember ls == IsMember ls' = ls == ls'
+    Unit ()          == Unit ()          = True
+    Unit _           == _                = False
+    Blob mbs         == Blob mbs'        = mbs == mbs'
+    Blob _           == _                = False
+    Blocks ls        == Blocks ls'       = S.fromList ls == S.fromList ls'
+    Blocks _         == _                = False
+    Bl bl            == Bl bl'           = bl == bl'
+    Bl _             == _                = False
+    IsMember ls      == IsMember ls'     = ls == ls'
+    IsMember _       == _                = False
     SimulatedError _ == SimulatedError _ = True
-    Successors st1 == Successors st2 = st1 == st2
-    Predecessor p1 == Predecessor p2 = p1 == p2
-    MaxSlot ms1 == MaxSlot ms2 = ms1 == ms2
-    _ == _ = False
+    SimulatedError _ == _                = False
+    Successors st1   == Successors st2   = st1 == st2
+    Successors _     == _                = False
+    Predecessor p1   == Predecessor p2   = p1 == p2
+    Predecessor _    == _                = False
+    MaxSlot ms1      == MaxSlot ms2      = ms1 == ms2
+    MaxSlot _        == _                = False
 
 
 newtype Resp = Resp {getResp :: Either (VolatileDBError BlockId) Success}

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -467,6 +467,10 @@ clientBlockFetch sockAddrs = do
               readFetchMode          = return FetchModeBulkSync,
               readFetchedBlocks      = (\h p -> castPoint p `Set.member` h) <$>
                                          getTestFetchedBlocks blockHeap,
+              readFetchedMaxSlotNo   = foldl' max NoMaxSlotNo .
+                                       map (maxSlotNoFromWithOrigin . pointSlot) .
+                                       Set.elems <$>
+                                       getTestFetchedBlocks blockHeap,
               addFetchedBlock        = \p b -> addTestFetchedBlock blockHeap
                                          (castPoint p) (blockHeader b),
 
@@ -840,8 +844,8 @@ doloremIpsum =
 -- The interface is enough to use in examples and tests.
 --
 data TestFetchedBlockHeap m block = TestFetchedBlockHeap {
-       getTestFetchedBlocks  :: STM (Set (Point block)),
-       addTestFetchedBlock   :: Point block -> block -> m ()
+       getTestFetchedBlocks :: STM (Set (Point block)),
+       addTestFetchedBlock  :: Point block -> block -> m ()
      }
 
 -- | Make a 'TestFetchedBlockHeap' using a simple in-memory 'Map', stored in an

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -163,6 +163,15 @@ data BlockFetchConsensusInterface peer header block m =
        -- 'readFetchedBlocks' reports the block.
        addFetchedBlock        :: Point block -> block -> m (),
 
+       -- | The highest stored/downloaded slot number.
+       --
+       -- This is used to optimise the filtering of fragments in the block
+       -- fetch logic: when removing already downloaded blocks from a
+       -- fragment, the filtering (with a linear cost) is stopped as soon as a
+       -- block has a slot number higher than this slot number, as it cannot
+       -- have been downloaded anyway.
+       readFetchedMaxSlotNo    :: STM m MaxSlotNo,
+
        -- | Given the current chain, is the given chain plausible as a
        -- candidate chain. Classically for Ouroboros this would simply
        -- check if the candidate is strictly longer, but for Ouroboros
@@ -256,10 +265,11 @@ blockFetchLogic decisionTracer clientStateTracer
     fetchNonTriggerVariables :: FetchNonTriggerVariables peer header block m
     fetchNonTriggerVariables =
       FetchNonTriggerVariables {
-        readStateFetchedBlocks = readFetchedBlocks,
-        readStatePeerStateVars = readFetchClientsStateVars registry,
-        readStatePeerGSVs      = readPeerGSVs,
-        readStateFetchMode     = readFetchMode
+        readStateFetchedBlocks    = readFetchedBlocks,
+        readStatePeerStateVars    = readFetchClientsStateVars registry,
+        readStatePeerGSVs         = readPeerGSVs,
+        readStateFetchMode        = readFetchMode,
+        readStateFetchedMaxSlotNo = readFetchedMaxSlotNo
       }
 
     -- TODO: get this from elsewhere once we have DeltaQ info available

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Examples.hs
@@ -11,6 +11,7 @@ module Ouroboros.Network.BlockFetch.Examples (
     exampleFixedPeerGSVs,
   ) where
 
+import           Data.List (foldl')
 import qualified Data.Map.Strict as Map
 import           Data.Map (Map)
 import qualified Data.Set as Set
@@ -152,6 +153,10 @@ sampleBlockFetchPolicy1 blockHeap currentChain candidateChains =
       readFetchMode          = return FetchModeBulkSync,
       readFetchedBlocks      = flip Set.member <$>
                                  getTestFetchedBlocks blockHeap,
+      readFetchedMaxSlotNo   = foldl' max NoMaxSlotNo .
+                               map (maxSlotNoFromWithOrigin . pointSlot) .
+                               Set.elems <$>
+                               getTestFetchedBlocks blockHeap,
       addFetchedBlock        = addTestFetchedBlock blockHeap,
 
       plausibleCandidateChain,


### PR DESCRIPTION
See the separate commits for more details.

Without these optimisations, enabling pipelining for the ChainSync client (#1033) actually slows it down! This is because the ChainSync client quickly downloads all headers it can (2k), after which the Block Fetch logic has to deal with much larger candidate fragments. It performs multiple filtering passes each time, each of which is linear in the fragment size. The main optimisation in this PR cuts down the filtering work that is required. 