### PR TITLE
Introduce `Handle` abstraction for `HasFS`

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
@@ -24,8 +24,8 @@ import           Control.Monad
 import           Control.Monad.ST
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
 import           Data.ByteString.Builder.Extra (defaultChunkSize)
+import qualified Data.ByteString.Lazy as LBS
 import           Data.IORef
 import           Data.Word (Word64)
 
@@ -124,7 +124,7 @@ readIncremental hasFS@HasFS{..} decoder fp = withLiftST $ \liftST -> do
       go liftST h =<< liftST (CBOR.deserialiseIncremental decoder)
   where
     go :: (forall x. ST s x -> m x)
-       -> h
+       -> Handle h
        -> CBOR.IDecode s a
        -> m (Either ReadIncrementalErr a)
     go liftST h (CBOR.Partial k) = do
@@ -166,7 +166,7 @@ readIncrementalOffsets hasFS@HasFS{..} decoder fp = withLiftST $ \liftST ->
              go liftST h 0 [] Nothing [] fileSize
   where
     go :: (forall x. ST s x -> m x)
-       -> h
+       -> Handle h
        -> Word64                  -- ^ Offset
        -> [(Word64, (Word64, a))] -- ^ Already deserialised (reverse order)
        -> Maybe ByteString        -- ^ Unconsumed bytes from last time
@@ -218,4 +218,3 @@ readIncrementalOffsets hasFS@HasFS{..} decoder fp = withLiftST $ \liftST ->
     checkEmpty :: ByteString -> Maybe ByteString
     checkEmpty bs | BS.null bs = Nothing
                   | otherwise  = Just bs
-

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -27,20 +27,17 @@ import           Text.Printf (printf)
 import qualified Cardano.Chain.UTxO as CC.UTxO
 
 import           Cardano.Crypto (shortHashF)
-import           Cardano.Crypto.DSIGN
-                   (SigDSIGN, SignedDSIGN(..), Ed448DSIGN,
-                    pattern SigEd448DSIGN, MockDSIGN, pattern SigMockDSIGN)
+import           Cardano.Crypto.DSIGN (Ed448DSIGN, MockDSIGN, SigDSIGN,
+                     pattern SigEd448DSIGN, pattern SigMockDSIGN,
+                     SignedDSIGN (..))
 import           Cardano.Crypto.Hash (Hash)
-import           Cardano.Crypto.KES
-                   (SigKES, SignedKES(..), MockKES, pattern SigMockKES,
-                    pattern SignKeyMockKES, pattern VerKeyMockKES, NeverKES,
-                    SimpleKES, pattern SigSimpleKES)
+import           Cardano.Crypto.KES (MockKES, NeverKES, SigKES,
+                     pattern SigMockKES, pattern SigSimpleKES,
+                     pattern SignKeyMockKES, SignedKES (..), SimpleKES,
+                     pattern VerKeyMockKES)
 
 import           Ouroboros.Consensus.Util.HList (All, HList (..))
 import qualified Ouroboros.Consensus.Util.HList as HList
-
-import           Ouroboros.Storage.FS.API.Types (AllowExisting (..),
-                     OpenMode (..), SeekMode (..))
 
 -- | Condensed but human-readable output
 class Condense a where
@@ -116,22 +113,6 @@ instance (Condense a, Condense b, Condense c, Condense d, Condense e) => Condens
 
 instance (Condense k, Condense a) => Condense (Map k a) where
   condense = condense . Map.toList
-
-instance Condense SeekMode where
-  condense RelativeSeek = "r"
-  condense AbsoluteSeek = "a"
-  condense SeekFromEnd  = "e"
-
-instance Condense AllowExisting where
-  condense AllowExisting = ""
-  condense MustBeNew     = "!"
-
-instance Condense OpenMode where
-    condense ReadMode           = "r"
-    condense (WriteMode     ex) = "w"  ++ condense ex
-    condense (ReadWriteMode ex) = "rw" ++ condense ex
-    condense (AppendMode    ex) = "a"  ++ condense ex
-
 
 instance Condense BS.Strict.ByteString where
   condense bs = show bs ++ "<" ++ show (BS.Strict.length bs) ++ "b>"

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
@@ -38,18 +38,18 @@ ioHasFS mount = HasFS {
         osHandle <- rethrowFsError fp $
             F.open path openMode
         hVar <- newMVar $ Just osHandle
-        return $ H.Handle fp path hVar
-    , hClose = \h -> rethrowFsError (H.handlePath h) $
+        return $ Handle (H.HandleOS path hVar) fp
+    , hClose = \(Handle h fp) -> rethrowFsError fp $
         F.close h
-    , hSeek = \h mode o -> rethrowFsError (H.handlePath h) $
+    , hSeek = \(Handle h fp) mode o -> rethrowFsError fp $
         F.seek h mode o
-    , hGetSome = \h n -> rethrowFsError (H.handlePath h) $
+    , hGetSome = \(Handle h fp) n -> rethrowFsError fp $
         F.read h (fromIntegral n)
-    , hTruncate = \h sz -> rethrowFsError (H.handlePath h) $
+    , hTruncate = \(Handle h fp) sz -> rethrowFsError fp $
         F.truncate h sz
-    , hGetSize = \h -> rethrowFsError (H.handlePath h) $
+    , hGetSize = \(Handle h fp) -> rethrowFsError fp $
         F.getSize h
-    , hPutSome = \h bs -> rethrowFsError (H.handlePath h) $ do
+    , hPutSome = \(Handle h fp) bs -> rethrowFsError fp $ do
         BS.unsafeUseAsCStringLen bs $ \(ptr, len) ->
             fromIntegral <$> F.write h (castPtr ptr) (fromIntegral len)
     , createDirectory = \fp -> rethrowFsError fp $
@@ -64,7 +64,6 @@ ioHasFS mount = HasFS {
         Dir.createDirectoryIfMissing createParent (root fp)
     , removeFile = \fp -> rethrowFsError fp $
         Dir.removeFile (root fp)
-    , handlePath = return . H.handlePath
     , hasFsErr = EH.exceptions
     }
   where

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/Pure.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/Pure.hs
@@ -33,7 +33,7 @@ runPureSimFS :: PureSimFS m a -> MockFS -> m (a, MockFS)
 runPureSimFS = runStateT . unPureSimFS
 
 pureHasFS :: forall m. Monad m
-          => ErrorHandling FsError m -> HasFS (PureSimFS m) Mock.Handle
+          => ErrorHandling FsError m -> HasFS (PureSimFS m) Mock.HandleMock
 pureHasFS err = HasFS {
       dumpState                = Mock.dumpState
     , hOpen                    = Mock.hOpen                    err'
@@ -49,7 +49,6 @@ pureHasFS err = HasFS {
     , doesDirectoryExist       = Mock.doesDirectoryExist       err'
     , doesFileExist            = Mock.doesFileExist            err'
     , removeFile               = Mock.removeFile               err'
-    , handlePath               = gets . flip Mock.handleFsPath
     , hasFsErr                 = err'
     }
   where

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
@@ -17,7 +17,7 @@ import           Ouroboros.Consensus.Util
 
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types
-import           Ouroboros.Storage.FS.Sim.MockFS (MockFS)
+import           Ouroboros.Storage.FS.Sim.MockFS (HandleMock, MockFS)
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
@@ -32,7 +32,7 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 runSimFS :: MonadSTM m
          => ErrorHandling FsError m
          -> MockFS
-         -> (HasFS m Mock.Handle -> m a)
+         -> (HasFS m HandleMock -> m a)
          -> m (a, MockFS)
 runSimFS err fs act = do
     var <- atomically (newTVar fs)
@@ -44,7 +44,7 @@ runSimFS err fs act = do
 simHasFS :: forall m. MonadSTM m
          => ErrorHandling FsError m
          -> StrictTVar m MockFS
-         -> HasFS m Mock.Handle
+         -> HasFS m HandleMock
 simHasFS err var = HasFS {
       dumpState                = sim     Mock.dumpState
     , hOpen                    = sim  .: Mock.hOpen                    err'
@@ -60,7 +60,6 @@ simHasFS err var = HasFS {
     , doesDirectoryExist       = sim  .  Mock.doesDirectoryExist       err'
     , doesFileExist            = sim  .  Mock.doesFileExist            err'
     , removeFile               = sim  .  Mock.removeFile               err'
-    , handlePath               = sim  .  gets . flip Mock.handleFsPath
     , hasFsErr                 = err
     }
   where

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -200,7 +200,7 @@ data ImmutableDBEnv m hash = forall h e. ImmutableDBEnv
 data OpenState m hash h = OpenState
     { _currentEpoch            :: !EpochNo
     -- ^ The current 'EpochNo' the immutable store is writing to.
-    , _currentEpochWriteHandle :: !h
+    , _currentEpochWriteHandle :: !(Handle h)
     -- ^ The write handle for the current epoch file.
     , _currentEpochOffsets     :: !(NonEmpty SlotOffset)
     -- ^ The offsets to which blobs have been written in the current epoch
@@ -823,7 +823,7 @@ data IteratorState hash h = IteratorState
     --
     -- __Invariant 4__: '_it_epoch_handle' points to where @next@ can be read
     -- from.
-  , _it_epoch_handle :: !h
+  , _it_epoch_handle :: !(Handle h)
     -- ^ A handle to the epoch file corresponding with '_it_next'.
   , _it_epoch_index  :: Index hash
     -- ^ We load the index file for the epoch we are currently iterating over

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
@@ -124,7 +124,7 @@ data VolatileDBEnv m blockId = forall h e. VolatileDBEnv {
     }
 
 data InternalState blockId h = InternalState {
-      _currentWriteHandle :: !h -- The unique open file we append blocks.
+      _currentWriteHandle :: !(Handle h) -- The unique open file we append blocks.
     , _currentWritePath   :: !String -- The path of the file above.
     , _currentWriteOffset :: !Word64 -- The 'WriteHandle' for the same file.
     , _nextWriteFiles     :: ![(String, Word)] -- The path and the size of the next files to write

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -37,7 +37,7 @@ import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.FS.Sim.FsTree (FsTree (..))
 import qualified Ouroboros.Storage.FS.Sim.FsTree as FS
-import           Ouroboros.Storage.FS.Sim.MockFS (MockFS)
+import           Ouroboros.Storage.FS.Sim.MockFS (HandleMock, MockFS)
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import qualified Ouroboros.Storage.FS.Sim.STM as Sim
 import           Ouroboros.Storage.ImmutableDB
@@ -285,7 +285,7 @@ prop_writeIndex_loadIndex index =
       index' <- loadIndex S.decode hasFS EH.exceptions epoch epochSize
       return $ index === index'
 
-    runS :: (HasFS IO Mock.Handle -> IO Property) -> IO Property
+    runS :: (HasFS IO HandleMock -> IO Property) -> IO Property
     runS m = do
         r <- tryFS (Sim.runSimFS EH.exceptions Mock.empty m)
         case r of
@@ -309,7 +309,7 @@ prop_writeSlotOffsets_loadIndex_indexToSlotOffsets slotOffsets@(SlotOffsets offs
       index :: Index TestHash <- loadIndex S.decode hasFS EH.exceptions epoch epochSize
       return $ indexToSlotOffsets index === offsets
 
-    runS :: (HasFS IO Mock.Handle -> IO Property) -> IO Property
+    runS :: (HasFS IO HandleMock -> IO Property) -> IO Property
     runS m = do
         r <- tryFS (Sim.runSimFS EH.exceptions Mock.empty m)
         case r of

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
@@ -48,6 +48,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API (HasFS (..), hGetAll, hPut, withFile)
 import           Ouroboros.Storage.FS.API.Types
+import           Ouroboros.Storage.FS.Sim.MockFS (HandleMock)
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import           Ouroboros.Storage.FS.Sim.STM (runSimFS)
 import           Ouroboros.Storage.ImmutableDB.Types
@@ -212,19 +213,19 @@ prop_testBlockEpochFileParser (TestBlocks mbEBB regularBlocks) = QCM.monadicIO $
 
     blocks = maybeToList mbEBB <> regularBlocks
 
-    writeBlocks :: HasFS IO Mock.Handle -> IO ()
+    writeBlocks :: HasFS IO HandleMock -> IO ()
     writeBlocks hasFS@HasFS{..} = do
       let bld = foldMap testBlockToBuilder blocks
       withFile hasFS file (AppendMode MustBeNew) $ \eHnd ->
         void $ hPut hasFS eHnd bld
 
-    readBlocks :: HasFS IO Mock.Handle
+    readBlocks :: HasFS IO HandleMock
                -> IO ([(SlotOffset, TestBlock)], Maybe TestBlock, Maybe String)
     readBlocks hasFS = runEpochFileParser
       (binaryEpochFileParser hasFS testBlockIsEBB id)
       file
 
-    runSimIO :: (HasFS IO Mock.Handle -> IO a) -> IO a
+    runSimIO :: (HasFS IO HandleMock -> IO a) -> IO a
     runSimIO m = fst <$> runSimFS EH.exceptions Mock.empty m
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
@@ -29,7 +29,7 @@ import           Ouroboros.Consensus.Util.Condense (Condense, condense)
 import           Ouroboros.Storage.FS.API (HasFS (..))
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.FS.IO (ioHasFS)
-import           Ouroboros.Storage.FS.Sim.MockFS (MockFS)
+import           Ouroboros.Storage.FS.Sim.MockFS (HandleMock, MockFS)
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import qualified Ouroboros.Storage.FS.Sim.STM as Sim
 import           Ouroboros.Storage.ImmutableDB (ImmutableDBError (..),
@@ -50,7 +50,7 @@ import           Ouroboros.Storage.VolatileDB.Util (tryVolDB)
 withMockFS :: Exception e
            => (forall x. IO x -> IO (Either e x))
            -> (Either e (a, MockFS) -> Assertion)
-           -> (HasFS IO Mock.Handle -> ErrorHandling e IO -> IO a)
+           -> (HasFS IO HandleMock -> ErrorHandling e IO -> IO a)
            -> Assertion
 withMockFS tryE assertion sim = do
     r <- tryE $ Sim.runSimFS EH.exceptions Mock.empty (flip sim EH.exceptions)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/TestBlock.hs
@@ -73,7 +73,7 @@ parseImpl hasFS@HasFS{..} path =
       fileSize <- hGetSize hndl
       go hndl [] 0 fileSize
   where
-    go :: h
+    go :: Handle h
        -> [(SlotOffset, (BlockSize, BlockInfo BlockId))]
        -> Word64  -- ^ Offset where we will read from next
        -> Word64  -- ^ File size, i.e. the max offset


### PR DESCRIPTION
This will give us a type that we can provide some instances for,
avoiding the need to propagate up constraints on `h`.