### PR TITLE
Introduce `Consensus.MonadSTM.NormalForm`

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -92,6 +92,7 @@ library
                        Ouroboros.Consensus.Util.Classify
                        Ouroboros.Consensus.Util.Condense
                        Ouroboros.Consensus.Util.HList
+                       Ouroboros.Consensus.Util.MonadSTM.NormalForm
                        Ouroboros.Consensus.Util.Orphans
                        Ouroboros.Consensus.Util.Random
                        Ouroboros.Consensus.Util.RedundantConstraints

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -188,8 +188,8 @@ newTestBlockchainTime
     -> DiffTime           -- ^ Slot duration
     -> m (TestBlockchainTime m)
 newTestBlockchainTime registry (NumSlots numSlots) slotLen = do
-    slotVar <- atomically $ newTVar initVal
-    doneVar <- atomically $ newEmptyTMVar
+    slotVar <- newTVarM initVal
+    doneVar <- newEmptyTMVarM
 
     void $ forkLinkedThread registry $ loop slotVar doneVar
 
@@ -239,7 +239,7 @@ realBlockchainTime :: ResourceRegistry IO
                    -> IO (BlockchainTime IO)
 realBlockchainTime registry slotLen start = do
     first <- getCurrentSlotIO slotLen start
-    slot  <- atomically $ newTVar first
+    slot  <- newTVarM first
     void $ forkLinkedThread registry $ loop slot
     return BlockchainTime {
         getCurrentSlot = readTVar slot

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -41,10 +41,10 @@ import           GHC.Stack
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork (MonadFork)
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTimer
 
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM
 import           Ouroboros.Network.Block (SlotNo (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -188,8 +188,8 @@ newTestBlockchainTime
     -> DiffTime           -- ^ Slot duration
     -> m (TestBlockchainTime m)
 newTestBlockchainTime registry (NumSlots numSlots) slotLen = do
-    slotVar <- newTVarM initVal
-    doneVar <- newEmptyTMVarM
+    slotVar <- uncheckedNewTVarM initVal
+    doneVar <- uncheckedNewEmptyTMVarM
 
     void $ forkLinkedThread registry $ loop slotVar doneVar
 
@@ -239,7 +239,7 @@ realBlockchainTime :: ResourceRegistry IO
                    -> IO (BlockchainTime IO)
 realBlockchainTime registry slotLen start = do
     first <- getCurrentSlotIO slotLen start
-    slot  <- newTVarM first
+    slot  <- uncheckedNewTVarM first
     void $ forkLinkedThread registry $ loop slot
     return BlockchainTime {
         getCurrentSlot = readTVar slot

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -31,7 +31,6 @@ import           Data.Word (Word64)
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
@@ -46,6 +45,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.SlotBounded as SB
 import           Ouroboros.Consensus.Util.STM (Fingerprint, onEachChange)
@@ -83,7 +83,7 @@ data ChainSyncClientException blk tip =
 
       -- | The upstream node rolled forward to a point too far in our past.
       -- This may happen if, during catch-up, our local node has moved too far ahead of the upstream node.
-      -- 
+      --
       -- We store the requested point and head point from the upstream node as
       -- well as the tip of our current ledger.
     | InvalidRollForward (Point blk) tip (Point blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -167,7 +167,7 @@ bracketChainSyncClient tracer getCurrentChain getCurrentLedger
       (curChain, curChainState) <- atomically $ (,)
         <$> getCurrentChain
         <*> (ouroborosChainState <$> getCurrentLedger)
-      varCandidate <- newTVarM CandidateState
+      varCandidate <- uncheckedNewTVarM CandidateState
         { candidateChain       = curChain
         , candidateChainState  = curChainState
         }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -169,7 +169,7 @@ bracketChainSyncClient tracer getCurrentChain getCurrentLedger
         curChainState <- ouroborosChainState <$> getCurrentLedger
         -- We use our current chain, which contains the last @k@ headers, as
         -- the initial chain for the candidate.
-        varCandidate <- newTVar CandidateState
+        varCandidate <- uncheckedNewTVar CandidateState
           { candidateChain       = curChain
           , candidateChainState  = curChainState
           }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -125,7 +125,7 @@ initMempoolEnv :: MonadSTM m
                -> Tracer m (TraceEventMempool blk)
                -> m (MempoolEnv m blk)
 initMempoolEnv ledgerInterface cfg tracer = do
-    isVar <- atomically $ newTVar initInternalState
+    isVar <- newTVarM initInternalState
     return MempoolEnv
       { mpEnvLedger    = ledgerInterface
       , mpEnvLedgerCfg = cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -17,7 +17,6 @@ import           Data.Word (Word64)
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Control.Tracer
@@ -36,6 +35,7 @@ import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo, TxSeq (..),
                      splitAfterTicketNo, zeroTicketNo)
 import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Util (repeatedly)
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (onEachChange)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -125,7 +125,7 @@ initMempoolEnv :: MonadSTM m
                -> Tracer m (TraceEventMempool blk)
                -> m (MempoolEnv m blk)
 initMempoolEnv ledgerInterface cfg tracer = do
-    isVar <- newTVarM initInternalState
+    isVar <- uncheckedNewTVarM initInternalState
     return MempoolEnv
       { mpEnvLedger    = ledgerInterface
       , mpEnvLedgerCfg = cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -290,11 +290,10 @@ forkBlockProduction
     => InternalState m peer blk -> m ()
 forkBlockProduction IS{..} =
     onSlotChange btime $ \currentSlot -> do
-      drg  <- produceDRG
+      varDRG <- newTVarM =<< produceDRG
       -- See the docstring of 'withSyncState' for why we're using it instead
       -- of 'atomically'.
       mNewBlock <- withSyncState mempool $ \MempoolSnapshot{snapshotTxs} -> do
-        varDRG <- uncheckedNewTVar drg
         l@ExtLedgerState{..} <- ChainDB.getCurrentLedger chainDB
         mIsLeader            <- runProtocol varDRG $
                                    checkIsLeader

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -206,8 +206,8 @@ initInternalState
 initInternalState NodeArgs { tracers, chainDB, registry, cfg,
                              blockFetchSize, blockMatchesHeader, btime,
                              callbacks, initState } = do
-    varCandidates  <- newTVarM mempty
-    varState       <- newTVarM initState
+    varCandidates  <- uncheckedNewTVarM mempty
+    varState       <- uncheckedNewTVarM initState
     mempool        <- openMempool registry
                                   (chainDBLedgerInterface chainDB)
                                   (ledgerConfigView cfg)
@@ -290,7 +290,7 @@ forkBlockProduction
     => InternalState m peer blk -> m ()
 forkBlockProduction IS{..} =
     onSlotChange btime $ \currentSlot -> do
-      varDRG <- newTVarM =<< produceDRG
+      varDRG <- uncheckedNewTVarM =<< produceDRG
       -- See the docstring of 'withSyncState' for why we're using it instead
       -- of 'atomically'.
       mNewBlock <- withSyncState mempool $ \MempoolSnapshot{snapshotTxs} -> do

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -206,8 +206,8 @@ initInternalState
 initInternalState NodeArgs { tracers, chainDB, registry, cfg,
                              blockFetchSize, blockMatchesHeader, btime,
                              callbacks, initState } = do
-    varCandidates  <- atomically $ newTVar mempty
-    varState       <- atomically $ newTVar initState
+    varCandidates  <- newTVarM mempty
+    varState       <- newTVarM initState
     mempool        <- openMempool registry
                                   (chainDBLedgerInterface chainDB)
                                   (ledgerConfigView cfg)
@@ -294,7 +294,7 @@ forkBlockProduction IS{..} =
       -- See the docstring of 'withSyncState' for why we're using it instead
       -- of 'atomically'.
       mNewBlock <- withSyncState mempool $ \MempoolSnapshot{snapshotTxs} -> do
-        varDRG <- newTVar drg
+        varDRG <- uncheckedNewTVar drg
         l@ExtLedgerState{..} <- ChainDB.getCurrentLedger chainDB
         mIsLeader            <- runProtocol varDRG $
                                    checkIsLeader

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -30,7 +30,6 @@ import           Data.Word (Word16)
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork (MonadFork)
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Tracer
 
@@ -57,6 +56,7 @@ import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo)
 import           Ouroboros.Consensus.Node.Tracers
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.ResourceRegistry

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -38,7 +38,6 @@ import           Data.Void (Void)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Tracer
@@ -85,6 +84,7 @@ import           Ouroboros.Consensus.Node.Tracers
 import           Ouroboros.Consensus.NodeKernel
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.TxSubmission
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.ResourceRegistry
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
@@ -1,0 +1,5 @@
+module Ouroboros.Consensus.Util.MonadSTM.NormalForm (
+    module Control.Monad.Class.MonadSTM.Strict
+  ) where
+
+import           Control.Monad.Class.MonadSTM.Strict

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
@@ -1,5 +1,50 @@
 module Ouroboros.Consensus.Util.MonadSTM.NormalForm (
     module Control.Monad.Class.MonadSTM.Strict
+  , newTVarM
+  , newTMVarM
+  , newEmptyTMVarM
+    -- Temporary
+  , uncheckedNewTVar
+  , newTVarWithInvariantM
+  , newTMVarWithInvariantM
   ) where
 
-import           Control.Monad.Class.MonadSTM.Strict
+import           GHC.Stack
+
+import           Control.Monad.Class.MonadSTM.Strict hiding (newEmptyTMVar,
+                     newEmptyTMVarM, newEmptyTMVarWithInvariantM, newTMVar,
+                     newTMVarM, newTMVarWithInvariantM, newTVar, newTVarM,
+                     newTVarWithInvariantM)
+import qualified Control.Monad.Class.MonadSTM.Strict as Strict
+
+{-------------------------------------------------------------------------------
+  Wrap the variable constructors
+-------------------------------------------------------------------------------}
+
+newTVarM :: MonadSTM m => a -> m (StrictTVar m a)
+newTVarM = Strict.newTVarM
+
+newTMVarM :: MonadSTM m => a -> m (StrictTMVar m a)
+newTMVarM = Strict.newTMVarM
+
+newEmptyTMVarM :: MonadSTM m => m (StrictTMVar m a)
+newEmptyTMVarM = Strict.newEmptyTMVarM
+
+{-------------------------------------------------------------------------------
+  Deprecated
+-------------------------------------------------------------------------------}
+
+uncheckedNewTVar :: MonadSTM m => a -> STM m (StrictTVar m a)
+uncheckedNewTVar = Strict.newTVar
+
+newTVarWithInvariantM :: (MonadSTM m, HasCallStack)
+                      => (a -> Maybe String) -- ^ Invariant (expect 'Nothing')
+                      -> a
+                      -> m (StrictTVar m a)
+newTVarWithInvariantM = Strict.newTVarWithInvariantM
+
+newTMVarWithInvariantM :: (MonadSTM m, HasCallStack)
+                       => (a -> Maybe String)  -- ^ Invariant (expect 'Nothing')
+                       -> a
+                       -> m (StrictTMVar m a)
+newTMVarWithInvariantM = Strict.newTMVarWithInvariantM

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
@@ -4,7 +4,6 @@ module Ouroboros.Consensus.Util.MonadSTM.NormalForm (
   , newTMVarM
   , newEmptyTMVarM
     -- Temporary
-  , uncheckedNewTVar
   , newTVarWithInvariantM
   , newTMVarWithInvariantM
   ) where
@@ -33,9 +32,6 @@ newEmptyTMVarM = Strict.newEmptyTMVarM
 {-------------------------------------------------------------------------------
   Deprecated
 -------------------------------------------------------------------------------}
-
-uncheckedNewTVar :: MonadSTM m => a -> STM m (StrictTVar m a)
-uncheckedNewTVar = Strict.newTVar
 
 newTVarWithInvariantM :: (MonadSTM m, HasCallStack)
                       => (a -> Maybe String) -- ^ Invariant (expect 'Nothing')

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
@@ -1,8 +1,8 @@
 module Ouroboros.Consensus.Util.MonadSTM.NormalForm (
     module Control.Monad.Class.MonadSTM.Strict
-  , newTVarM
-  , newTMVarM
-  , newEmptyTMVarM
+  , uncheckedNewTVarM
+  , uncheckedNewTMVarM
+  , uncheckedNewEmptyTMVarM
     -- Temporary
   , newTVarWithInvariantM
   , newTMVarWithInvariantM
@@ -17,17 +17,19 @@ import           Control.Monad.Class.MonadSTM.Strict hiding (newEmptyTMVar,
 import qualified Control.Monad.Class.MonadSTM.Strict as Strict
 
 {-------------------------------------------------------------------------------
-  Wrap the variable constructors
+  Unchecked wrappers (where we don't check for thunks)
+
+  These will eventually be removed.
 -------------------------------------------------------------------------------}
 
-newTVarM :: MonadSTM m => a -> m (StrictTVar m a)
-newTVarM = Strict.newTVarM
+uncheckedNewTVarM :: MonadSTM m => a -> m (StrictTVar m a)
+uncheckedNewTVarM = Strict.newTVarM
 
-newTMVarM :: MonadSTM m => a -> m (StrictTMVar m a)
-newTMVarM = Strict.newTMVarM
+uncheckedNewTMVarM :: MonadSTM m => a -> m (StrictTMVar m a)
+uncheckedNewTMVarM = Strict.newTMVarM
 
-newEmptyTMVarM :: MonadSTM m => m (StrictTMVar m a)
-newEmptyTMVarM = Strict.newEmptyTMVarM
+uncheckedNewEmptyTMVarM :: MonadSTM m => m (StrictTMVar m a)
+uncheckedNewEmptyTMVarM = Strict.newEmptyTMVarM
 
 {-------------------------------------------------------------------------------
   Deprecated

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -46,8 +46,9 @@ import           GHC.Stack
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
+
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 -- | Resource registry
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -466,7 +466,7 @@ unsafeNewRegistry :: (MonadFork m, MonadSTM m, HasCallStack)
                   => m (ResourceRegistry m)
 unsafeNewRegistry = do
     context  <- captureContext
-    stateVar <- newTVarM initState
+    stateVar <- uncheckedNewTVarM initState
     return ResourceRegistry {
           registryContext = context
         , registryState   = stateVar

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -466,7 +466,7 @@ unsafeNewRegistry :: (MonadFork m, MonadSTM m, HasCallStack)
                   => m (ResourceRegistry m)
 unsafeNewRegistry = do
     context  <- captureContext
-    stateVar <- atomically $ newTVar initState
+    stateVar <- newTVarM initState
     return ResourceRegistry {
           registryContext = context
         , registryState   = stateVar

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
@@ -30,10 +30,10 @@ import           GHC.Stack
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork (MonadFork)
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.ResourceRegistry
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -127,7 +127,7 @@ openDBInternal args launchBgTasks = do
                             (Query.getAnyKnownBlock immDB volDB)
     traceWith tracer $ TraceOpenEvent OpenedLgrDB
 
-    varInvalid <- newTVarM (Map.empty, Fingerprint 0)
+    varInvalid <- uncheckedNewTVarM (Map.empty, Fingerprint 0)
 
     chainAndLedger <- ChainSel.initialChainSelection
       immDB
@@ -146,8 +146,8 @@ openDBInternal args launchBgTasks = do
     atomically $ LgrDB.setCurrent lgrDB ledger
     varChain          <- newTVarWithInvariantM  isNF chain
     varImmBlockNo     <- newTVarWithInvariantM  isNF immBlockNo
-    varIterators      <- newTVarM Map.empty
-    varReaders        <- newTVarM Map.empty
+    varIterators      <- uncheckedNewTVarM Map.empty
+    varReaders        <- uncheckedNewTVarM Map.empty
     varNextIteratorId <- newTVarWithInvariantM  isNF (IteratorId 0)
     varNextReaderId   <- newTVarWithInvariantM  isNF 0
     varCopyLock       <- newTMVarWithInvariantM isNF ()
@@ -171,7 +171,7 @@ openDBInternal args launchBgTasks = do
                   , cdbBgThreads      = varBgThreads
                   , cdbEpochInfo      = Args.cdbEpochInfo args
                   }
-    h <- fmap CDBHandle $ newTVarM $ ChainDbOpen env
+    h <- fmap CDBHandle $ uncheckedNewTVarM $ ChainDbOpen env
     let chainDB = ChainDB
           { addBlock           = getEnv1    h ChainSel.addBlock
           , getCurrentChain    = getEnvSTM  h Query.getCurrentChain

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -31,7 +31,6 @@ import qualified Data.Map.Strict as Map
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
@@ -46,6 +45,7 @@ import           Ouroboros.Network.Block (blockNo, blockPoint, blockSlot,
 
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..))
 
 import           Ouroboros.Storage.Common (EpochNo)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -144,14 +144,14 @@ openDBInternal args launchBgTasks = do
         immBlockNo = ChainSel.getImmBlockNo secParam chain immDbTipBlockNo
 
     atomically $ LgrDB.setCurrent lgrDB ledger
-    varChain          <- newTVarWithInvariantM  isNF chain
-    varImmBlockNo     <- newTVarWithInvariantM  isNF immBlockNo
-    varIterators      <- uncheckedNewTVarM Map.empty
-    varReaders        <- uncheckedNewTVarM Map.empty
-    varNextIteratorId <- newTVarWithInvariantM  isNF (IteratorId 0)
-    varNextReaderId   <- newTVarWithInvariantM  isNF 0
-    varCopyLock       <- newTMVarWithInvariantM isNF ()
-    varBgThreads      <- newTVarWithInvariantM  isNF []
+    varChain          <- uncheckedNewTVarM  chain
+    varImmBlockNo     <- uncheckedNewTVarM  immBlockNo
+    varIterators      <- uncheckedNewTVarM  Map.empty
+    varReaders        <- uncheckedNewTVarM  Map.empty
+    varNextIteratorId <- uncheckedNewTVarM  (IteratorId 0)
+    varNextReaderId   <- uncheckedNewTVarM  0
+    varCopyLock       <- uncheckedNewTMVarM ()
+    varBgThreads      <- uncheckedNewTVarM  []
 
     let env = CDB { cdbImmDB          = immDB
                   , cdbVolDB          = volDB
@@ -211,7 +211,3 @@ openDBInternal args launchBgTasks = do
 
     blockEpoch :: blk -> m EpochNo
     blockEpoch = epochInfoEpoch (Args.cdbEpochInfo args) . blockSlot
-
-    -- TODO (#969): Re-enable this and deal with the fallout.
-    isNF :: forall a. a -> Maybe String
-    isNF = const Nothing -- unsafePerformIO . isNormalForm

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
@@ -36,7 +36,6 @@ import           GHC.Stack (HasCallStack)
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
@@ -52,6 +51,7 @@ import           Ouroboros.Network.Point (WithOrigin (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract (ProtocolLedgerView)
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
@@ -38,7 +38,6 @@ import qualified Data.Set as Set
 import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
 
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Control.Tracer (Tracer, contramap, traceWith)
@@ -51,6 +50,7 @@ import           Ouroboros.Network.Block (BlockNo, HasHeader (..), HeaderHash,
 import           Ouroboros.Consensus.Block (BlockProtocol, GetHeader (..))
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.STM (Fingerprint)
 
 import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
@@ -380,7 +380,7 @@ newIterator itEnv@IteratorEnv{..} getItEnv registry from to = do
                  -> m (Iterator m blk)
     makeIterator register itState = do
       iteratorId <- makeNewIteratorId
-      varItState <- newTVarM itState
+      varItState <- uncheckedNewTVarM itState
       when register $ atomically $ modifyTVar itIterators $
         -- Note that we don't use 'itEnv' here, because that would mean that
         -- invoking the function only works when the database is open, which

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
@@ -26,7 +26,6 @@ import qualified Data.Map.Strict as Map
 import           GHC.Stack (HasCallStack)
 
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Control.Tracer
@@ -37,6 +36,7 @@ import           Ouroboros.Network.Block (pattern BlockPoint,
                      atSlot, blockHash, blockPoint, castPoint, pointSlot,
                      withHash)
 
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
 import           Ouroboros.Storage.ChainDB.API (ChainDbError (..),

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -208,8 +208,8 @@ openDB :: forall m blk.
 openDB args@LgrDbArgs{..} replayTracer immDB getBlock = do
     createDirectoryIfMissing lgrHasFS True []
     db <- initFromDisk args replayTracer lgrDbConf immDB
-    (varDB, varPrevApplied) <- atomically $
-      (,) <$> newTVar db <*> newTVar Set.empty
+    (varDB, varPrevApplied) <-
+      (,) <$> newTVarM db <*> newTVarM Set.empty
     return LgrDB {
         conf           = lgrDbConf
       , varDB          = varDB

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -62,7 +62,6 @@ import           System.FilePath ((</>))
 
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Control.Tracer
@@ -78,6 +77,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util ((.:))
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.Common

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -209,7 +209,7 @@ openDB args@LgrDbArgs{..} replayTracer immDB getBlock = do
     createDirectoryIfMissing lgrHasFS True []
     db <- initFromDisk args replayTracer lgrDbConf immDB
     (varDB, varPrevApplied) <-
-      (,) <$> newTVarM db <*> newTVarM Set.empty
+      (,) <$> uncheckedNewTVarM db <*> uncheckedNewTVarM Set.empty
     return LgrDB {
         conf           = lgrDbConf
       , varDB          = varDB

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
@@ -23,7 +23,6 @@ module Ouroboros.Storage.ChainDB.Impl.Query
 import           Data.Bifunctor (first)
 import qualified Data.Map.Strict as Map
 
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
@@ -35,6 +34,7 @@ import           Ouroboros.Network.Block (BlockNo, ChainHash (..), HasHeader,
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.STM (Fingerprint)
 
 import           Ouroboros.Storage.ChainDB.API (ChainDbError (..),

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
@@ -21,7 +21,6 @@ import           Data.Maybe (isJust)
 import           GHC.Stack (HasCallStack)
 
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Control.Tracer (contramap, traceWith)
@@ -34,6 +33,7 @@ import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader,
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block (GetHeader (..), headerPoint)
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import           Ouroboros.Consensus.Util.STM (blockUntilJust)
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
@@ -114,7 +114,7 @@ newReader cdb@CDB{..} h registry = do
         return $ ReaderInImmDB rollState immIt
 
     readerId  <- atomically $ updateTVar cdbNextReaderId $ \r -> (succ r, r)
-    varReader <- newTVarM readerState
+    varReader <- uncheckedNewTVarM readerState
     atomically $ modifyTVar cdbReaders $ Map.insert readerId varReader
     let reader = makeNewBlockOrHeaderReader h readerId registry
     traceWith cdbTracer $ TraceReaderEvent $ NewReader readerId

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
@@ -117,7 +117,7 @@ newReader cdb@CDB{..} h registry = do
       readerId <- readTVar cdbNextReaderId
       modifyTVar cdbNextReaderId succ
 
-      varReader <- newTVar readerState
+      varReader <- uncheckedNewTVar readerState
       modifyTVar cdbReaders (Map.insert readerId varReader)
       let reader = makeNewBlockOrHeaderReader h readerId registry
       return (reader, readerId)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
@@ -19,7 +19,6 @@ import           GHC.Stack (HasCallStack)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
@@ -34,6 +33,7 @@ import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util (whenJust)
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.Common (EpochNo)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -42,7 +42,6 @@ import           Data.Typeable (Typeable)
 import           Data.Word
 import           GHC.Generics (Generic)
 
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Control.Tracer
@@ -56,6 +55,7 @@ import           Ouroboros.Consensus.Block (BlockProtocol, Header)
 import           Ouroboros.Consensus.Ledger.Abstract (ProtocolLedgerView)
 import           Ouroboros.Consensus.Ledger.Extended (ExtValidationError)
 import           Ouroboros.Consensus.Protocol.Abstract (NodeConfig)
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (Fingerprint)
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
@@ -37,7 +37,7 @@ openDB :: forall m blk.
        -> ExtLedgerState blk
        -> m (ChainDB m blk)
 openDB cfg initLedger = do
-    db :: StrictTVar m (Model blk) <- atomically $ newTVar (Model.empty initLedger)
+    db :: StrictTVar m (Model blk) <- newTVarM (Model.empty initLedger)
 
     let querySTM :: (Model blk -> a) -> STM m a
         querySTM f = readTVar db >>= \m ->

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
@@ -10,7 +10,6 @@ module Ouroboros.Storage.ChainDB.Mock (
 import           Data.Bifunctor (first)
 import qualified Data.Map as Map
 
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Network.Block (ChainUpdate)
@@ -21,6 +20,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util ((..:))
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.STM (blockUntilJust)
 
 import           Ouroboros.Storage.ChainDB.API

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
@@ -37,7 +37,7 @@ openDB :: forall m blk.
        -> ExtLedgerState blk
        -> m (ChainDB m blk)
 openDB cfg initLedger = do
-    db :: StrictTVar m (Model blk) <- newTVarM (Model.empty initLedger)
+    db :: StrictTVar m (Model blk) <- uncheckedNewTVarM (Model.empty initLedger)
 
     let querySTM :: (Model blk -> a) -> STM m a
         querySTM f = readTVar db >>= \m ->

--- a/ouroboros-consensus/src/Ouroboros/Storage/EpochInfo/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/EpochInfo/Impl.hs
@@ -22,7 +22,7 @@ newEpochInfo :: forall m. MonadSTM m
              => (EpochNo -> m EpochSize) -> m (EpochInfo m)
 newEpochInfo getSize = do
     firstEpochSize <- getSize 0
-    cesVar         <- newTVarM $ CES.singleton firstEpochSize
+    cesVar         <- uncheckedNewTVarM $ CES.singleton firstEpochSize
     return EpochInfo {
         epochInfoSize  = wrap cesVar . CES.epochSize
       , epochInfoFirst = wrap cesVar . CES.firstSlotOf

--- a/ouroboros-consensus/src/Ouroboros/Storage/EpochInfo/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/EpochInfo/Impl.hs
@@ -22,7 +22,7 @@ newEpochInfo :: forall m. MonadSTM m
              => (EpochNo -> m EpochSize) -> m (EpochInfo m)
 newEpochInfo getSize = do
     firstEpochSize <- getSize 0
-    cesVar         <- atomically $ newTVar $ CES.singleton firstEpochSize
+    cesVar         <- newTVarM $ CES.singleton firstEpochSize
     return EpochInfo {
         epochInfoSize  = wrap cesVar . CES.epochSize
       , epochInfoFirst = wrap cesVar . CES.firstSlotOf

--- a/ouroboros-consensus/src/Ouroboros/Storage/EpochInfo/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/EpochInfo/Impl.hs
@@ -10,9 +10,9 @@ import           Control.Monad.Trans.State.Strict (runStateT)
 import           Data.List (maximumBy)
 import           Data.Ord (comparing)
 
-import           Control.Monad.Class.MonadSTM.Strict
-
 import           Ouroboros.Network.Block (SlotNo (..))
+
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.EpochInfo.API

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
@@ -34,7 +34,7 @@ runSimFS :: MonadSTM m
          -> (HasFS m HandleMock -> m a)
          -> m (a, MockFS)
 runSimFS err fs act = do
-    var <- atomically (newTVar fs)
+    var <- newTVarM fs
     a   <- act (simHasFS err var)
     fs' <- atomically (readTVar var)
     return (a, fs')

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
@@ -34,7 +34,7 @@ runSimFS :: MonadSTM m
          -> (HasFS m HandleMock -> m a)
          -> m (a, MockFS)
 runSimFS err fs act = do
-    var <- newTVarM fs
+    var <- uncheckedNewTVarM fs
     a   <- act (simHasFS err var)
     fs' <- atomically (readTVar var)
     return (a, fs')

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Sim/STM.hs
@@ -11,9 +11,8 @@ import           Control.Monad.Except
 import           Control.Monad.State
 import           Data.Proxy
 
-import           Control.Monad.Class.MonadSTM.Strict
-
 import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -145,7 +145,6 @@ import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
 import           Control.Exception (assert)
 import           Control.Monad (forM_, replicateM_, unless, when)
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow (ExitCase (..),
                      MonadCatch (generalBracket), MonadThrow, finally)
 import           Control.Monad.State.Strict (StateT (..), get, lift, modify,
@@ -166,6 +165,7 @@ import           Data.Word
 import           GHC.Stack (HasCallStack, callStack)
 
 import           Ouroboros.Consensus.Util (SomePair (..))
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.EpochInfo

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -304,7 +304,7 @@ openDBImpl hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFil
     !ost  <- validateAndReopen hashDecoder hashEncoder hasFS err epochInfo
       valPol epochFileParser initialIteratorID tracer
 
-    stVar <- atomically $ newTMVar (Right ost)
+    stVar <- newTMVarM (Right ost)
 
     let dbEnv = ImmutableDBEnv hasFS err stVar epochFileParser hashDecoder hashEncoder tracer
         db    = mkDBRecord dbEnv
@@ -999,7 +999,7 @@ streamBinaryBlobsImpl dbEnv mbStart mbEnd = withOpenState dbEnv $ \hasFS st -> d
               , _it_epoch_index  = index
               }
 
-        itState <- atomically $ newTVar mbIteratorState
+        itState <- newTVarM mbIteratorState
 
         let ith = IteratorHandle
               { _it_hasFS    = hasFS

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -304,7 +304,7 @@ openDBImpl hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFil
     !ost  <- validateAndReopen hashDecoder hashEncoder hasFS err epochInfo
       valPol epochFileParser initialIteratorID tracer
 
-    stVar <- newTMVarM (Right ost)
+    stVar <- uncheckedNewTMVarM (Right ost)
 
     let dbEnv = ImmutableDBEnv hasFS err stVar epochFileParser hashDecoder hashEncoder tracer
         db    = mkDBRecord dbEnv
@@ -999,7 +999,7 @@ streamBinaryBlobsImpl dbEnv mbStart mbEnd = withOpenState dbEnv $ \hasFS st -> d
               , _it_epoch_index  = index
               }
 
-        itState <- newTVarM mbIteratorState
+        itState <- uncheckedNewTVarM mbIteratorState
 
         let ith = IteratorHandle
               { _it_hasFS    = hasFS

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
@@ -87,7 +87,6 @@ module Ouroboros.Storage.VolatileDB.Impl
     ) where
 
 import           Control.Monad
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import qualified Data.ByteString.Builder as BS
 import           Data.ByteString.Lazy (ByteString)
@@ -101,6 +100,7 @@ import           Data.Word (Word64)
 import           GHC.Stack
 
 import           Ouroboros.Consensus.Util (SomePair (..))
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
@@ -184,7 +184,7 @@ openDBImpl hasFS@HasFS{..} err errSTM parser maxBlocksPerFile =
     then EH.throwError err $ UserError . InvalidArgumentsError $ "maxBlocksPerFile should be positive"
     else do
         st <- mkInternalStateDB hasFS err parser maxBlocksPerFile
-        stVar <- atomically $ newTMVar $ Just st
+        stVar <- newTMVarM $ Just st
         return $ VolatileDBEnv hasFS err errSTM stVar maxBlocksPerFile parser
 
 closeDBImpl :: MonadSTM m

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
@@ -184,7 +184,7 @@ openDBImpl hasFS@HasFS{..} err errSTM parser maxBlocksPerFile =
     then EH.throwError err $ UserError . InvalidArgumentsError $ "maxBlocksPerFile should be positive"
     else do
         st <- mkInternalStateDB hasFS err parser maxBlocksPerFile
-        stVar <- newTMVarM $ Just st
+        stVar <- uncheckedNewTMVarM $ Just st
         return $ VolatileDBEnv hasFS err errSTM stVar maxBlocksPerFile parser
 
 closeDBImpl :: MonadSTM m

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -6,7 +6,6 @@
 module Ouroboros.Storage.VolatileDB.Util where
 
 import           Control.Monad
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Data.List (maximumBy)
 import           Data.Map (Map)
@@ -17,6 +16,8 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 import           Data.Word (Word64)
 import           Text.Read (readMaybe)
+
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -227,14 +227,14 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
     let btime = testBlockchainTime testBtime
 
     -- Set up the client
-    varCandidates      <- newTVarM Map.empty
-    varClientState     <- newTVarM (Genesis, testInitExtLedger)
-    varClientException <- newTVarM Nothing
+    varCandidates      <- uncheckedNewTVarM Map.empty
+    varClientState     <- uncheckedNewTVarM (Genesis, testInitExtLedger)
+    varClientException <- uncheckedNewTVarM Nothing
     -- Candidates are removed from the candidates map when disconnecting, so
     -- we lose access to them. Therefore, store the candidate 'TVar's in a
     -- separate map too, one that isn't emptied. We can use this map to look
     -- at the final state of each candidate.
-    varFinalCandidates <- newTVarM Map.empty
+    varFinalCandidates <- uncheckedNewTVarM Map.empty
 
     let getCurrentChain :: STM m (AnchoredFragment TestBlock)
         getCurrentChain =
@@ -260,12 +260,12 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
                    getIsInvalidBlock
 
     -- Set up the server
-    varChainProducerState <- newTVarM $ initChainProducerState Genesis
+    varChainProducerState <- uncheckedNewTVarM $ initChainProducerState Genesis
     let server :: ChainSyncServer (Header TestBlock) (Point (Header TestBlock), BlockNo) m ()
         server = chainSyncServerExample () varChainProducerState
 
     -- Schedule updates of the client and server chains
-    varLastUpdate <- newTVarM 0
+    varLastUpdate <- uncheckedNewTVarM 0
     onSlotChange btime $ \slot -> do
       -- Stop updating the client and server chains when the chain sync client
       -- has thrown an exception, so that at the end, we can read the chains

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE GADTs               #-}
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -24,11 +24,10 @@ import           Test.Tasty.QuickCheck
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork (MonadFork)
-import           Control.Monad.Class.MonadSTM.Strict
+import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
-import           Control.Monad.Class.MonadSay
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Network.TypedProtocol.Channel
@@ -59,6 +58,7 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..))
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -412,13 +412,13 @@ withTestMempool setup@TestSetup { testLedgerState, testInitialTxs } prop =
     setUpAndRun = do
 
       -- Set up the LedgerInterface
-      varCurrentLedgerState <- newTVarM testLedgerState
+      varCurrentLedgerState <- uncheckedNewTVarM testLedgerState
       let ledgerInterface = LedgerInterface
             { getCurrentLedgerState = readTVar varCurrentLedgerState
             }
 
       -- Set up the Tracer
-      varEvents <- newTVarM []
+      varEvents <- uncheckedNewTVarM []
       -- TODO use SimM's dynamicTracer
       let tracer = Tracer $ \ev -> atomically $ modifyTVar varEvents (ev:)
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -412,13 +412,13 @@ withTestMempool setup@TestSetup { testLedgerState, testInitialTxs } prop =
     setUpAndRun = do
 
       -- Set up the LedgerInterface
-      varCurrentLedgerState <- atomically $ newTVar testLedgerState
+      varCurrentLedgerState <- newTVarM testLedgerState
       let ledgerInterface = LedgerInterface
             { getCurrentLedgerState = readTVar varCurrentLedgerState
             }
 
       -- Set up the Tracer
-      varEvents <- atomically $ newTVar []
+      varEvents <- newTVarM []
       -- TODO use SimM's dynamicTracer
       let tracer = Tracer $ \ev -> atomically $ modifyTVar varEvents (ev:)
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -22,7 +22,6 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
 import           Control.Monad.Class.MonadAsync (MonadAsync)
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Control.Tracer (Tracer (..))
@@ -36,6 +35,7 @@ import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.Condense (condense)
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 import           Test.Consensus.Mempool.TestBlock
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -32,7 +32,6 @@ import           GHC.Generics (Generic, Generic1)
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork hiding (fork)
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTimer
 
@@ -45,6 +44,7 @@ import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.Tasty hiding (after)
 import           Test.Tasty.QuickCheck (testProperty)
 
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Test.Util.QSM

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -283,7 +283,7 @@ data QueuedInstr m = forall a. QueuedInstr (ThreadInstr m a) (StrictTMVar m a)
 
 runInThread :: MonadSTM m => TestThread m -> ThreadInstr m a -> m a
 runInThread TestThread{..} instr = do
-    result <- atomically newEmptyTMVar
+    result <- newEmptyTMVarM
     atomically $ writeTQueue threadComms (QueuedInstr instr result)
     atomically $ takeTMVar result
 
@@ -305,7 +305,7 @@ newThread :: forall m. (MonadAsync m, MonadMask m, MonadFork m, MonadTimer m)
           -> m (TestThread m)
 newThread alive parentReg = \shouldLink -> do
     comms      <- atomically $ newTQueue
-    spawned    <- atomically $ newEmptyTMVar
+    spawned    <- newEmptyTMVarM
 
     thread <- forkThread parentReg $
                 withRegistry $ \childReg ->
@@ -593,7 +593,7 @@ prop_sequential = forAllCommands (sm unused unused) Nothing prop_sequential'
 
 prop_sequential' :: QSM.Commands (At IO Cmd) (At IO Resp) -> QC.Property
 prop_sequential' cmds = QC.monadicIO $ do
-    alive <- liftIO $ atomically $ newTVar []
+    alive <- liftIO $ newTVarM []
     reg   <- liftIO $ unsafeNewRegistry
     let sm' = sm alive reg
     (hist, _model, res) <- runCommands sm' cmds

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -283,7 +283,7 @@ data QueuedInstr m = forall a. QueuedInstr (ThreadInstr m a) (StrictTMVar m a)
 
 runInThread :: MonadSTM m => TestThread m -> ThreadInstr m a -> m a
 runInThread TestThread{..} instr = do
-    result <- newEmptyTMVarM
+    result <- uncheckedNewEmptyTMVarM
     atomically $ writeTQueue threadComms (QueuedInstr instr result)
     atomically $ takeTMVar result
 
@@ -305,7 +305,7 @@ newThread :: forall m. (MonadAsync m, MonadMask m, MonadFork m, MonadTimer m)
           -> m (TestThread m)
 newThread alive parentReg = \shouldLink -> do
     comms      <- atomically $ newTQueue
-    spawned    <- newEmptyTMVarM
+    spawned    <- uncheckedNewEmptyTMVarM
 
     thread <- forkThread parentReg $
                 withRegistry $ \childReg ->
@@ -593,7 +593,7 @@ prop_sequential = forAllCommands (sm unused unused) Nothing prop_sequential'
 
 prop_sequential' :: QSM.Commands (At IO Cmd) (At IO Resp) -> QC.Property
 prop_sequential' cmds = QC.monadicIO $ do
-    alive <- liftIO $ newTVarM []
+    alive <- liftIO $ uncheckedNewTVarM []
     reg   <- liftIO $ unsafeNewRegistry
     let sm' = sm alive reg
     (hist, _model, res) <- runCommands sm' cmds

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -137,11 +137,11 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
     -- node and server threads on the head node. These mini protocols begin as
     -- soon as both nodes have joined the network, according to @nodeJoinPlan@.
 
-    varRNG <- atomically $ newTVar initRNG
+    varRNG <- newTVarM initRNG
 
     -- allocate a TMVar for each node's network app
     nodeVars <- fmap Map.fromList $ do
-      forM coreNodeIds $ \nid -> (,) nid <$> atomically newEmptyTMVar
+      forM coreNodeIds $ \nid -> (,) nid <$> newEmptyTMVarM
 
     -- spawn threads for each undirected edge
     let edges = edgesNodeTopology nodeTopology
@@ -227,7 +227,7 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
         drg <- produceDRG
         txs <- atomically $ do
           ledger <- ledgerState <$> getExtLedger
-          varDRG <- newTVar drg
+          varDRG <- uncheckedNewTVar drg
           simChaChaT varDRG id $ testGenTxs numCoreNodes cfg ledger
         void $ addTxs mempool txs
 
@@ -305,8 +305,8 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
             }
 
       epochInfo <- newEpochInfo $ nodeEpochSize (Proxy @blk) pInfoConfig
-      fsVars@(immDbFsVar, volDbFsVar, lgrDbFsVar)  <- atomically $ (,,)
-        <$> newTVar Mock.empty <*> newTVar Mock.empty <*> newTVar Mock.empty
+      fsVars@(immDbFsVar, volDbFsVar, lgrDbFsVar)  <- (,,)
+        <$> newTVarM Mock.empty <*> newTVarM Mock.empty <*> newTVarM Mock.empty
       let args = mkArgs pInfoConfig pInfoInitLedger epochInfo fsVars
       chainDB <- ChainDB.openDB args
 

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -137,11 +137,11 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
     -- node and server threads on the head node. These mini protocols begin as
     -- soon as both nodes have joined the network, according to @nodeJoinPlan@.
 
-    varRNG <- newTVarM initRNG
+    varRNG <- uncheckedNewTVarM initRNG
 
     -- allocate a TMVar for each node's network app
     nodeVars <- fmap Map.fromList $ do
-      forM coreNodeIds $ \nid -> (,) nid <$> newEmptyTMVarM
+      forM coreNodeIds $ \nid -> (,) nid <$> uncheckedNewEmptyTMVarM
 
     -- spawn threads for each undirected edge
     let edges = edgesNodeTopology nodeTopology
@@ -224,7 +224,7 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
                -> m ()
     txProducer cfg produceDRG getExtLedger mempool =
       onSlotChange btime $ \_curSlotNo -> do
-        varDRG <- newTVarM =<< produceDRG
+        varDRG <- uncheckedNewTVarM =<< produceDRG
         txs <- atomically $ do
           ledger <- ledgerState <$> getExtLedger
           simChaChaT varDRG id $ testGenTxs numCoreNodes cfg ledger
@@ -305,7 +305,9 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
 
       epochInfo <- newEpochInfo $ nodeEpochSize (Proxy @blk) pInfoConfig
       fsVars@(immDbFsVar, volDbFsVar, lgrDbFsVar)  <- (,,)
-        <$> newTVarM Mock.empty <*> newTVarM Mock.empty <*> newTVarM Mock.empty
+        <$> uncheckedNewTVarM Mock.empty
+        <*> uncheckedNewTVarM Mock.empty
+        <*> uncheckedNewTVarM Mock.empty
       let args = mkArgs pInfoConfig pInfoInitLedger epochInfo fsVars
       chainDB <- ChainDB.openDB args
 

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -31,18 +31,17 @@ import qualified Control.Exception as Exn
 import           Control.Monad
 import           Control.Tracer
 import           Crypto.Random (ChaChaDRG, drgNew)
-import qualified Data.Typeable as Typeable
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy (Proxy (..))
+import qualified Data.Typeable as Typeable
 import           GHC.Stack
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork (MonadFork)
 import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
@@ -75,6 +74,7 @@ import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.NodeKernel
 import           Ouroboros.Consensus.NodeNetwork
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.RedundantConstraints
 import           Ouroboros.Consensus.Util.ResourceRegistry

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -224,10 +224,9 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
                -> m ()
     txProducer cfg produceDRG getExtLedger mempool =
       onSlotChange btime $ \_curSlotNo -> do
-        drg <- produceDRG
+        varDRG <- newTVarM =<< produceDRG
         txs <- atomically $ do
           ledger <- ledgerState <$> getExtLedger
-          varDRG <- uncheckedNewTVar drg
           simChaChaT varDRG id $ testGenTxs numCoreNodes cfg ledger
         void $ addTxs mempool txs
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -95,10 +95,10 @@ prop_addBlock_multiple_threads bpt =
     trace       :: [TraceAddBlockEvent TestBlock]
     (actualChain, trace) = run $ do
         -- Open the DB
-        fsVars <- atomically $ (,,)
-          <$> newTVar Mock.empty
-          <*> newTVar Mock.empty
-          <*> newTVar Mock.empty
+        fsVars <- (,,)
+          <$> newTVarM Mock.empty
+          <*> newTVarM Mock.empty
+          <*> newTVarM Mock.empty
         withRegistry $ \registry -> do
           let args = mkArgs cfg initLedger dynamicTracer registry fsVars
           db <- openDB args

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -15,7 +15,6 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.IOSim
 
 import           Control.Tracer
@@ -28,6 +27,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util (chunks)
 import           Ouroboros.Consensus.Util.Condense (condense)
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.ChainDB (TraceAddBlockEvent (..), addBlock,

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -96,9 +96,9 @@ prop_addBlock_multiple_threads bpt =
     (actualChain, trace) = run $ do
         -- Open the DB
         fsVars <- (,,)
-          <$> newTVarM Mock.empty
-          <*> newTVarM Mock.empty
-          <*> newTVarM Mock.empty
+          <$> uncheckedNewTVarM Mock.empty
+          <*> uncheckedNewTVarM Mock.empty
+          <*> uncheckedNewTVarM Mock.empty
         withRegistry $ \registry -> do
           let args = mkArgs cfg initLedger dynamicTracer registry fsVars
           db <- openDB args

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -72,7 +72,7 @@ withImmDB :: forall m blk a.
              )
           => (ImmDB m blk -> m a) -> m a
 withImmDB k = do
-    immDbFsVar <- newTVarM Mock.empty
+    immDbFsVar <- uncheckedNewTVarM Mock.empty
     epochInfo  <- newEpochInfo $ nodeEpochSize (Proxy @blk) testCfg
     bracket (ImmDB.openDB (mkArgs immDbFsVar epochInfo)) ImmDB.closeDB k
   where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -72,7 +72,7 @@ withImmDB :: forall m blk a.
              )
           => (ImmDB m blk -> m a) -> m a
 withImmDB k = do
-    immDbFsVar <- atomically $ newTVar Mock.empty
+    immDbFsVar <- newTVarM Mock.empty
     epochInfo  <- newEpochInfo $ nodeEpochSize (Proxy @blk) testCfg
     bracket (ImmDB.openDB (mkArgs immDbFsVar epochInfo)) ImmDB.closeDB k
   where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -12,7 +12,6 @@ import           Data.Proxy (Proxy (..))
 import           Data.Reflection (give)
 
 import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.IOSim (runSimOrThrow)
 
@@ -33,6 +32,7 @@ import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
 import           Ouroboros.Consensus.Node.Run (RunNode (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB, ImmDbArgs (..))
 import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -255,8 +255,8 @@ initIteratorEnv
   -> Tracer m (TraceIteratorEvent TestBlock)
   -> m (IteratorEnv m TestBlock)
 initIteratorEnv TestSetup { immutable, volatile } tracer = do
-    iters      <- atomically $ newTVar Map.empty
-    nextIterId <- atomically $ newTVar $ IteratorId 0
+    iters      <- newTVarM Map.empty
+    nextIterId <- newTVarM $ IteratorId 0
     volDB      <- openVolDB volatile
     immDB      <- openImmDB immutable
     return IteratorEnv

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -16,7 +16,6 @@ import           Data.List (intercalate)
 import qualified Data.Map.Strict as Map
 import           Data.Word (Word64)
 
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.IOSim (runSimOrThrow)
 
@@ -26,6 +25,7 @@ import           Ouroboros.Network.MockChain.Chain (Chain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
 import           Ouroboros.Consensus.Util.Condense (condense)
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.ChainDB.API (Iterator (..), IteratorId (..),

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -255,8 +255,8 @@ initIteratorEnv
   -> Tracer m (TraceIteratorEvent TestBlock)
   -> m (IteratorEnv m TestBlock)
 initIteratorEnv TestSetup { immutable, volatile } tracer = do
-    iters      <- newTVarM Map.empty
-    nextIterId <- newTVarM $ IteratorId 0
+    iters      <- uncheckedNewTVarM Map.empty
+    nextIterId <- uncheckedNewTVarM $ IteratorId 0
     volDB      <- openVolDB volatile
     immDB      <- openImmDB immutable
     return IteratorEnv

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -49,7 +49,7 @@ prop_reader bt p = runSimOrThrow test
     test = withRegistry $ \registry -> do
         db       <- openDB
         reader   <- ChainDB.newBlockReader db registry
-        chainVar <- newTVarM Genesis
+        chainVar <- uncheckedNewTVarM Genesis
 
         -- Fork a thread that applies all instructions from the reader
         _tid <- fork $ monitorReader chainVar reader

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -9,7 +9,6 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim
@@ -17,6 +16,7 @@ import           Control.Monad.IOSim
 import           Ouroboros.Network.MockChain.Chain (Chain (..), ChainUpdate)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.ChainDB.API (ChainDB)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -49,7 +49,7 @@ prop_reader bt p = runSimOrThrow test
     test = withRegistry $ \registry -> do
         db       <- openDB
         reader   <- ChainDB.newBlockReader db registry
-        chainVar <- atomically $ newTVar Genesis
+        chainVar <- newTVarM Genesis
 
         -- Fork a thread that applies all instructions from the reader
         _tid <- fork $ monitorReader chainVar reader

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1040,9 +1040,9 @@ prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do
       iteratorRegistry   <- QC.run unsafeNewRegistry
       (tracer, getTrace) <- QC.run recordingTracerIORef
       fsVars             <- QC.run $ (,,)
-        <$> newTVarM Mock.empty
-        <*> newTVarM Mock.empty
-        <*> newTVarM Mock.empty
+        <$> uncheckedNewTVarM Mock.empty
+        <*> uncheckedNewTVarM Mock.empty
+        <*> uncheckedNewTVarM Mock.empty
       let args = mkArgs testCfg testInitLedger tracer threadRegistry fsVars
       (db, internal)     <- QC.run $ openDBInternal args False
       let sm' = sm db internal iteratorRegistry genBlk testCfg testInitLedger
@@ -1226,9 +1226,9 @@ _mkBlk h = TestBlock
 _runCmds :: [Cmd Blk IteratorId ReaderId] -> IO [Resp Blk IteratorId ReaderId]
 _runCmds cmds = withRegistry $ \registry -> do
     fsVars <- (,,)
-      <$> newTVarM Mock.empty
-      <*> newTVarM Mock.empty
-      <*> newTVarM Mock.empty
+      <$> uncheckedNewTVarM Mock.empty
+      <*> uncheckedNewTVarM Mock.empty
+      <*> uncheckedNewTVarM Mock.empty
     let args = mkArgs
           testCfg
           testInitLedger

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1039,10 +1039,10 @@ prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do
       threadRegistry     <- QC.run unsafeNewRegistry
       iteratorRegistry   <- QC.run unsafeNewRegistry
       (tracer, getTrace) <- QC.run recordingTracerIORef
-      fsVars             <- QC.run $ atomically $ (,,)
-        <$> newTVar Mock.empty
-        <*> newTVar Mock.empty
-        <*> newTVar Mock.empty
+      fsVars             <- QC.run $ (,,)
+        <$> newTVarM Mock.empty
+        <*> newTVarM Mock.empty
+        <*> newTVarM Mock.empty
       let args = mkArgs testCfg testInitLedger tracer threadRegistry fsVars
       (db, internal)     <- QC.run $ openDBInternal args False
       let sm' = sm db internal iteratorRegistry genBlk testCfg testInitLedger
@@ -1225,10 +1225,10 @@ _mkBlk h = TestBlock
 -- | Debugging utility: run some commands against the real implementation.
 _runCmds :: [Cmd Blk IteratorId ReaderId] -> IO [Resp Blk IteratorId ReaderId]
 _runCmds cmds = withRegistry $ \registry -> do
-    fsVars <- atomically $ (,,)
-      <$> newTVar Mock.empty
-      <*> newTVar Mock.empty
-      <*> newTVar Mock.empty
+    fsVars <- (,,)
+      <$> newTVarM Mock.empty
+      <*> newTVarM Mock.empty
+      <*> newTVarM Mock.empty
     let args = mkArgs
           testCfg
           testInitLedger

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -53,7 +53,6 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
 import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Control.Tracer
@@ -79,6 +78,7 @@ import           Ouroboros.Consensus.NodeId (NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util.Condense (condense)
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..))
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
@@ -482,8 +482,8 @@ runSimErrorFS :: MonadSTM m
               -> (StrictTVar m Errors -> HasFS m HandleMock -> m a)
               -> m (a, MockFS)
 runSimErrorFS err mockFS errors action = do
-    fsVar     <- newTVarM mockFS
-    errorsVar <- newTVarM errors
+    fsVar     <- uncheckedNewTVarM mockFS
+    errorsVar <- uncheckedNewTVarM errors
     a         <- action errorsVar $ mkSimErrorHasFS err fsVar errorsVar
     fs'       <- atomically $ readTVar fsVar
     return (a, fs')

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
@@ -482,8 +482,8 @@ runSimErrorFS :: MonadSTM m
               -> (StrictTVar m Errors -> HasFS m HandleMock -> m a)
               -> m (a, MockFS)
 runSimErrorFS err mockFS errors action = do
-    fsVar     <- atomically $ newTVar mockFS
-    errorsVar <- atomically $ newTVar errors
+    fsVar     <- newTVarM mockFS
+    errorsVar <- newTVarM errors
     a         <- action errorsVar $ mkSimErrorHasFS err fsVar errorsVar
     fs'       <- atomically $ readTVar fsVar
     return (a, fs')

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/Sim/Error.hs
@@ -43,7 +43,6 @@ module Test.Ouroboros.Storage.FS.Sim.Error
 import           Prelude hiding (null)
 
 import           Control.Monad (replicateM, void)
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Except (runExceptT)
 
 import qualified Data.ByteString as BS
@@ -57,6 +56,7 @@ import           Test.QuickCheck (Arbitrary (..), Gen)
 import qualified Test.QuickCheck as QC
 
 import           Ouroboros.Consensus.Util (whenJust)
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Example (example)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -7,10 +7,10 @@ import           Control.Monad.Except (Except, runExcept)
 import           Control.Monad.State (StateT, runStateT)
 import           Data.Proxy
 
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Consensus.Util ((..:), (.:))
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 import           Ouroboros.Storage.Common (EpochNo, EpochSize)
 import           Ouroboros.Storage.ImmutableDB.API

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -27,7 +27,7 @@ openDBMock  :: forall m hash.
             -> (EpochNo -> EpochSize)
             -> m (DBModel hash, ImmutableDB hash m)
 openDBMock err epochSize = do
-    dbVar <- atomically $ newTVar dbModel
+    dbVar <- newTVarM dbModel
     return (dbModel, immDB dbVar)
   where
     db :: ImmutableDB hash (MockM hash)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -27,7 +27,7 @@ openDBMock  :: forall m hash.
             -> (EpochNo -> EpochSize)
             -> m (DBModel hash, ImmutableDB hash m)
 openDBMock err epochSize = do
-    dbVar <- newTVarM dbModel
+    dbVar <- uncheckedNewTVarM dbModel
     return (dbModel, immDB dbVar)
   where
     db :: ImmutableDB hash (MockM hash)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -1100,8 +1100,8 @@ prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do
 
           return (hist, res === Ok .&&. dbTip === modelTip .&&. validation)
 
-    fsVar     <- QC.run $ newTVarM Mock.empty
-    errorsVar <- QC.run $ newTVarM mempty
+    fsVar     <- QC.run $ uncheckedNewTVarM Mock.empty
+    errorsVar <- QC.run $ uncheckedNewTVarM mempty
     (hist, prop) <-
       test errorsVar (mkSimErrorHasFS EH.monadCatch fsVar errorsVar)
     prettyCommands smUnused hist

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -20,7 +20,6 @@ import           Prelude hiding (elem, notElem)
 
 import           Codec.Serialise (decode, encode)
 import           Control.Monad (forM_, when)
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow (MonadCatch)
 import           Control.Monad.Except (ExceptT (..), runExceptT)
 import           Control.Monad.State.Strict (MonadState, State, evalState, gets,
@@ -65,6 +64,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 import           Text.Show.Pretty (ppShow)
 
 import qualified Ouroboros.Consensus.Util.Classify as C
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 import           Ouroboros.Network.Block (SlotNo (..))
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -1100,8 +1100,8 @@ prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do
 
           return (hist, res === Ok .&&. dbTip === modelTip .&&. validation)
 
-    fsVar     <- QC.run $ atomically (newTVar Mock.empty)
-    errorsVar <- QC.run $ atomically (newTVar mempty)
+    fsVar     <- QC.run $ newTVarM Mock.empty
+    errorsVar <- QC.run $ newTVarM mempty
     (hist, prop) <-
       test errorsVar (mkSimErrorHasFS EH.monadCatch fsVar errorsVar)
     prettyCommands smUnused hist

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -52,7 +52,6 @@ import           System.Random (getStdRandom, randomR)
 import           Control.Tracer (nullTracer)
 
 import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 
 import           Test.QuickCheck (Gen)
@@ -68,6 +67,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 import           Ouroboros.Consensus.Util
 import qualified Ouroboros.Consensus.Util.Classify as C
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -543,8 +543,8 @@ data StandaloneDB m t = DB {
 
 initStandaloneDB :: (MonadSTM m, LUT t) => DbEnv m -> m (StandaloneDB m t)
 initStandaloneDB dbEnv@DbEnv{..} = do
-    dbBlocks <- atomically $ newTVar Map.empty
-    dbState  <- atomically $ newTVar (initChain, initDB)
+    dbBlocks <- newTVarM Map.empty
+    dbState  <- newTVarM (initChain, initDB)
     return DB{..}
   where
     initChain = []
@@ -589,7 +589,7 @@ dbStreamAPI DB{..} = StreamAPI {..}
         if unknownBlock tip rs
           then k Nothing
           else do
-            toStream <- atomically $ newTVar (blocksToStream tip rs)
+            toStream <- newTVarM (blocksToStream tip rs)
             k (Just (getNext toStream))
 
     -- Ignore requests to start streaming from blocks not on the current chain
@@ -983,7 +983,7 @@ propCmds :: LUT t
          -> QSM.Commands (At (Cmd t)) (At (Resp t))
          -> QC.PropertyM IO ()
 propCmds lgrDbParams cmds = do
-    fs <- QC.run $ atomically $ newTVar MockFS.empty
+    fs <- QC.run $ newTVarM MockFS.empty
     let dbEnv :: DbEnv IO
         dbEnv = DbEnv (simHasFS EH.exceptions fs) lgrDbParams
     db <- QC.run $ initStandaloneDB dbEnv

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -543,8 +543,8 @@ data StandaloneDB m t = DB {
 
 initStandaloneDB :: (MonadSTM m, LUT t) => DbEnv m -> m (StandaloneDB m t)
 initStandaloneDB dbEnv@DbEnv{..} = do
-    dbBlocks <- newTVarM Map.empty
-    dbState  <- newTVarM (initChain, initDB)
+    dbBlocks <- uncheckedNewTVarM Map.empty
+    dbState  <- uncheckedNewTVarM (initChain, initDB)
     return DB{..}
   where
     initChain = []
@@ -589,7 +589,7 @@ dbStreamAPI DB{..} = StreamAPI {..}
         if unknownBlock tip rs
           then k Nothing
           else do
-            toStream <- newTVarM (blocksToStream tip rs)
+            toStream <- uncheckedNewTVarM (blocksToStream tip rs)
             k (Just (getNext toStream))
 
     -- Ignore requests to start streaming from blocks not on the current chain
@@ -983,7 +983,7 @@ propCmds :: LUT t
          -> QSM.Commands (At (Cmd t)) (At (Resp t))
          -> QC.PropertyM IO ()
 propCmds lgrDbParams cmds = do
-    fs <- QC.run $ newTVarM MockFS.empty
+    fs <- QC.run $ uncheckedNewTVarM MockFS.empty
     let dbEnv :: DbEnv IO
         dbEnv = DbEnv (simHasFS EH.exceptions fs) lgrDbParams
     db <- QC.run $ initStandaloneDB dbEnv

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
@@ -22,7 +22,7 @@ openDBMock  :: forall m blockId.
             -> Int
             -> m (DBModel blockId, VolatileDB blockId m)
 openDBMock err maxNumPerFile = do
-    dbVar <- atomically $ newTVar dbModel
+    dbVar <- newTVarM dbModel
     return (dbModel, db dbVar)
   where
     dbModel = initDBModel maxNumPerFile

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
@@ -22,7 +22,7 @@ openDBMock  :: forall m blockId.
             -> Int
             -> m (DBModel blockId, VolatileDB blockId m)
 openDBMock err maxNumPerFile = do
-    dbVar <- newTVarM dbModel
+    dbVar <- uncheckedNewTVarM dbModel
     return (dbModel, db dbVar)
   where
     dbModel = initDBModel maxNumPerFile

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
@@ -4,12 +4,13 @@
 module Test.Ouroboros.Storage.VolatileDB.Mock (openDBMock) where
 
 import           Control.Monad.State (StateT)
-import           Control.Monad.Class.MonadSTM.Strict
 
 import           Ouroboros.Storage.Util.ErrorHandling (ThrowCantCatch)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import           Ouroboros.Storage.VolatileDB.API
+
 import           Ouroboros.Consensus.Util ((.:))
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.STM (simStateT)
 
 import           Test.Ouroboros.Storage.VolatileDB.Model

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -538,8 +538,8 @@ prop_sequential =
               (hist, _model, res) <- runCommands sm' cmds
               run $ closeDB db
               return (hist, res)
-        errorsVar <- run $ atomically (newTVar mempty)
-        fsVar <- run $ atomically (newTVar Mock.empty)
+        errorsVar <- run $ newTVarM mempty
+        fsVar <- run $ newTVarM Mock.empty
         (hist, res) <- test errorsVar (mkSimErrorHasFS EH.monadCatch fsVar errorsVar)
         let events = execCmds (initModel smUnused) cmds
         let myshow n = if n<5 then show n else if n < 20 then "5-19" else if n < 100 then "20-99" else ">=100"

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -538,8 +538,8 @@ prop_sequential =
               (hist, _model, res) <- runCommands sm' cmds
               run $ closeDB db
               return (hist, res)
-        errorsVar <- run $ newTVarM mempty
-        fsVar <- run $ newTVarM Mock.empty
+        errorsVar <- run $ uncheckedNewTVarM mempty
+        fsVar <- run $ uncheckedNewTVarM Mock.empty
         (hist, res) <- test errorsVar (mkSimErrorHasFS EH.monadCatch fsVar errorsVar)
         let events = execCmds (initModel smUnused) cmds
         let myshow n = if n<5 then show n else if n < 20 then "5-19" else if n < 100 then "20-99" else ">=100"

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -22,7 +22,6 @@ module Test.Ouroboros.Storage.VolatileDB.StateMachine
 
 import           Prelude hiding (elem)
 
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow (MonadCatch)
 import           Control.Monad.Except
 import           Control.Monad.State
@@ -54,6 +53,8 @@ import           Text.Show.Pretty (ppShow)
 
 import           Ouroboros.Consensus.Util (SomePair (..))
 import qualified Ouroboros.Consensus.Util.Classify as C
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types
 import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock

--- a/ouroboros-consensus/test-util/Test/Util/Tracer.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Tracer.hs
@@ -5,10 +5,9 @@ module Test.Util.Tracer
 
 import           Data.IORef
 
-import           Control.Monad.Class.MonadSTM.Strict
-
 import           Control.Tracer
 
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 -- | Create a 'Tracer' that stores all events in an 'IORef' that is atomically
 -- updated. The second return value lets you obtain the events recorded so far

--- a/ouroboros-consensus/test-util/Test/Util/Tracer.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Tracer.hs
@@ -22,7 +22,7 @@ recordingTracerIORef = newIORef [] >>= \ref -> return
 -- updated. The second return value lets you obtain the events recorded so far
 -- (from oldest to newest). Obtaining the events does not erase them.
 recordingTracerTVar :: MonadSTM m => m (Tracer m ev, m [ev])
-recordingTracerTVar = newTVarM [] >>= \ref -> return
+recordingTracerTVar = uncheckedNewTVarM [] >>= \ref -> return
     ( Tracer $ \ev -> atomically $ modifyTVar ref (ev:)
     , atomically $ reverse <$> readTVar ref
     )


### PR DESCRIPTION
This PR doesn't change very much, but merely paves the way for what is to come. The goal is to establish the interface in `MonadSTM.NormalForm`; however, I've done this in 5 separate commits, 4 of which are trivial; only the third needs more careful review (see commit messages for details).