### PR TITLE
Add basic test for Chain Growth

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -16,7 +16,7 @@ import qualified Data.Map.Strict as Map
 
 import           Ouroboros.Network.Block (SlotNo (..))
 
-import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..), fromCoreNodeId)
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util (Empty)
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
@@ -25,9 +25,8 @@ newtype LeaderSchedule = LeaderSchedule {getLeaderSchedule :: Map SlotNo [CoreNo
     deriving (Show, Eq, Ord)
 
 instance Condense LeaderSchedule where
-    condense (LeaderSchedule m) = show
-                                $ map (\(s, ls) ->
-                                    (unSlotNo s, map (\(CoreNodeId nid) -> nid) ls))
+    condense (LeaderSchedule m) = condense
+                                $ map (\(s, ls) -> (s, map fromCoreNodeId ls))
                                 $ Map.toList m
 
 -- | Extension of protocol @p@ by a static leader schedule.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -36,6 +36,8 @@ import           Cardano.Crypto.KES (MockKES, NeverKES, SigKES,
                      pattern SignKeyMockKES, SignedKES (..), SimpleKES,
                      pattern VerKeyMockKES)
 
+import           Ouroboros.Network.Block (BlockNo (..), SlotNo (..))
+
 import           Ouroboros.Consensus.Util.HList (All, HList (..))
 import qualified Ouroboros.Consensus.Util.HList as HList
 
@@ -153,3 +155,9 @@ instance Condense (Hash h a) where
 
 instance Condense CC.UTxO.TxId where
   condense hash = "txid:" <> unpack (sformat shortHashF hash)
+
+instance Condense BlockNo where
+  condense (BlockNo n) = 'b' : show n
+
+instance Condense SlotNo where
+  condense (SlotNo n) = 's' : show n

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -17,8 +17,7 @@ import           Cardano.Prelude (NoUnexpectedThunks (..))
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (HasHeader, HeaderHash, Point (..),
-                     SlotNo (..))
+import           Ouroboros.Network.Block (HasHeader, HeaderHash, Point (..))
 import           Ouroboros.Network.MockChain.Chain (Chain (..))
 import           Ouroboros.Network.Point (WithOrigin (..), blockPointHash,
                      blockPointSlot)
@@ -28,9 +27,6 @@ import           Ouroboros.Consensus.Util.Condense
 {-------------------------------------------------------------------------------
   Condense
 -------------------------------------------------------------------------------}
-
-instance Condense SlotNo where
-  condense (SlotNo n) = condense n
 
 instance Condense (HeaderHash block) => Condense (Point block) where
     condense (Point Origin)        = "Origin"

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -199,8 +199,8 @@ prop_general k TestConfig{numSlots, nodeJoinPlan, nodeTopology} schedule
         (Map.elems nodeChains) .&&.
     prop_all_growth .&&.
     conjoin
-      [ fileHandleLeakCheck nid nodeInfo
-      | (nid, nodeInfo) <- Map.toList nodeInfos ]
+      [ fileHandleLeakCheck nid nodeDBs
+      | (nid, nodeDBs) <- Map.toList nodeOutputDBs ]
   where
     NumBlocks maxForkLength = determineForkLength k nodeJoinPlan schedule
 
@@ -238,17 +238,17 @@ prop_general k TestConfig{numSlots, nodeJoinPlan, nodeTopology} schedule
             in
             Just s == (snd <$> Map.lookupMin m)
 
-    nodeChains = nodeOutputFinalChain <$> testOutputNodes
-    nodeInfos  = nodeOutputNodeInfo   <$> testOutputNodes
+    nodeChains    = nodeOutputFinalChain <$> testOutputNodes
+    nodeOutputDBs = nodeOutputNodeDBs    <$> testOutputNodes
 
     isConsensusExcepected :: Bool
     isConsensusExcepected = consensusExpected k nodeJoinPlan schedule
 
-    fileHandleLeakCheck :: NodeId -> NodeInfo blk MockFS -> Property
-    fileHandleLeakCheck nid nodeInfo = conjoin
-        [ checkLeak "ImmutableDB" $ nodeInfoImmDbFs nodeInfo
-        , checkLeak "VolatileDB"  $ nodeInfoVolDbFs nodeInfo
-        , checkLeak "LedgerDB"    $ nodeInfoLgrDbFs nodeInfo
+    fileHandleLeakCheck :: NodeId -> NodeDBs blk MockFS -> Property
+    fileHandleLeakCheck nid nodeDBs = conjoin
+        [ checkLeak "ImmutableDB" $ nodeDBsImm nodeDBs
+        , checkLeak "VolatileDB"  $ nodeDBsVol nodeDBs
+        , checkLeak "LedgerDB"    $ nodeDBsLgr nodeDBs
         ]
       where
         checkLeak dbName fs = counterexample

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -182,7 +182,7 @@ prop_general ::
   -> TestOutput blk
   -> Property
 prop_general k TestConfig{numSlots, nodeJoinPlan, nodeTopology} schedule
-  TestOutput{testOutputNodes, testOutputSlotBlockNos} =
+  TestOutput{testOutputNodes, testOutputTipBlockNos} =
     counterexample ("nodeChains: " <> unlines ("" : map (\x -> "  " <> condense x) (Map.toList nodeChains))) $
     counterexample ("nodeJoinPlan: " <> condense nodeJoinPlan) $
     counterexample ("nodeTopology: " <> condense nodeTopology) $
@@ -312,4 +312,4 @@ prop_general k TestConfig{numSlots, nodeJoinPlan, nodeTopology} schedule
     slotNodeDepths =
         Map.toAscList $
         fmap Map.toAscList $
-        testOutputSlotBlockNos
+        testOutputTipBlockNos


### PR DESCRIPTION
This PR is "part one" for Issue #235.

It adds a `Property` that tests for Chain Growth modulo EBBs and late joins. In particular, it assumes there are no message delays, which is effectively true now and will be until Issue #229 and/or #230.

From https://eprint.iacr.org/2017/573/20171115:001835

> Chain Growth (CG); with parameters τ ∈ (0, 1], s ∈ N. Consider the chains C1, C2 possessed by two honest parties at the onset of two slots sl1, sl2 with sl2 at least s slots ahead of sl1. Then it holds that len(C2) − len(C1) ≥ τ · s. We call τ the speed coefficient.

We test with a deterministic variety of values for the `τ` and `s` parameters. Because our current test framework has a limited set of possible faults, we can test Chain Growth for all values of `s` that are greater than 0. Similarly, we're able to compute a `τ` value for any given interval of slots based on the leader schedule (roughly-- see relevant comments in diff). Once we add message delays (latencies, partitions, etc) these tests as-is will fail -- I'm still thinking about how to handle that, but I've decided to open this PR for now.