### PR TITLE
Introduce `IOLike` monad

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -278,6 +278,7 @@ test-suite test-consensus
                     Test.Util.MockChain
                     Test.Util.Orphans.Arbitrary
                     Test.Util.Orphans.NoUnexpectedThunks
+                    Test.Util.Orphans.IOLike
                     Test.Util.Range
                     Test.Util.TestBlock
                     Test.Util.QSM
@@ -354,6 +355,7 @@ test-suite test-storage
                     Test.Ouroboros.Storage.VolatileDB.StateMachine
                     Test.Ouroboros.Storage.VolatileDB.TestBlock
                     Test.Util.Orphans.Arbitrary
+                    Test.Util.Orphans.IOLike
                     Test.Util.Orphans.NoUnexpectedThunks
                     Test.Util.Range
                     Test.Util.RefEnv

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -92,6 +92,7 @@ library
                        Ouroboros.Consensus.Util.Classify
                        Ouroboros.Consensus.Util.Condense
                        Ouroboros.Consensus.Util.HList
+                       Ouroboros.Consensus.Util.IOLike
                        Ouroboros.Consensus.Util.MonadSTM.NormalForm
                        Ouroboros.Consensus.Util.Orphans
                        Ouroboros.Consensus.Util.Random

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchServer.hs
@@ -15,7 +15,6 @@ module Ouroboros.Consensus.BlockFetchServer
 
 import           Data.Typeable (Typeable)
 
-import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 import           Control.Tracer (Tracer)
 
@@ -25,6 +24,7 @@ import           Ouroboros.Network.Protocol.BlockFetch.Server
                      BlockFetchServer (..))
 import           Ouroboros.Network.Protocol.BlockFetch.Type (ChainRange (..))
 
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
 import           Ouroboros.Storage.ChainDB (ChainDB, IteratorResult (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchServer.hs
@@ -55,8 +55,7 @@ instance (Typeable blk, StandardHash blk)
 -- the 'ChainDB'.
 blockFetchServer
     :: forall m blk.
-       ( MonadSTM   m
-       , MonadThrow m
+       ( IOLike m
        , StandardHash blk
        , Typeable     blk
        )

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -42,14 +42,11 @@ import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           GHC.Stack
 
+import           Control.Monad.Class.MonadThrow
+
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork (MonadFork)
-import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTimer
-
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM
 import           Ouroboros.Network.Block (SlotNo (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -88,7 +88,7 @@ data BlockchainTime m = BlockchainTime {
 -- blocks as requested and then returns 'False'
 --
 blockUntilSlot ::
-     MonadSTM m
+     IOLike m
   => BlockchainTime m
   -> SlotNo
   -> m Bool
@@ -111,12 +111,7 @@ onSlot :: HasCallStack => BlockchainTime m -> SlotNo -> m () -> m ()
 onSlot = onSlot_
 
 -- | Default implementation of 'onSlot' (used internally only)
-defaultOnSlot :: forall m.
-                 ( MonadMask  m
-                 , MonadFork  m
-                 , MonadAsync m
-                 , HasCallStack
-                 )
+defaultOnSlot :: forall m. (IOLike m, HasCallStack)
               => ResourceRegistry m
               -> STM m SlotNo
               -> SlotNo
@@ -178,13 +173,7 @@ data TestBlockchainTime m = TestBlockchainTime
 -- appropriate for initialization code etc. In contrast, the argument to
 -- 'onSlotChange' is blocked at least until @SlotNo 0@ begins.
 newTestBlockchainTime
-    :: forall m. (
-           MonadAsync m
-         , MonadTimer m
-         , MonadMask  m
-         , MonadFork  m
-         , HasCallStack
-         )
+    :: forall m. (IOLike m, HasCallStack)
     => ResourceRegistry m
     -> NumSlots           -- ^ Number of slots
     -> DiffTime           -- ^ Slot duration

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -34,11 +34,9 @@ import           Data.Void (Void)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 
-import           Cardano.Prelude (NoUnexpectedThunks)
-
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadThrow
+
+import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Network.TypedProtocol.Pipelined
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
@@ -54,7 +52,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.SlotBounded as SB
 import           Ouroboros.Consensus.Util.STM (Fingerprint, onEachChange)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -144,9 +144,7 @@ data CandidateState blk = CandidateState
 deriving instance SupportedBlock blk => NoUnexpectedThunks (CandidateState blk)
 
 bracketChainSyncClient
-    :: ( MonadAsync m
-       , MonadFork  m
-       , MonadMask  m
+    :: ( IOLike m
        , Ord peer
        , SupportedBlock blk
        , Typeable tip
@@ -199,9 +197,7 @@ bracketChainSyncClient tracer getCurrentChain getCurrentLedger
 -- corresponding peer will never be chosen again.
 chainSyncClient
     :: forall m blk tip.
-       ( MonadSTM   m
-       , MonadCatch m
-       , MonadThrow (STM m)
+       ( IOLike m
        , ProtocolLedgerView blk
        , Exception (ChainSyncClientException blk tip)
        )
@@ -632,9 +628,7 @@ chainSyncClient mkPipelineDecision0
 -- of invalid blocks).
 rejectInvalidBlocks
     :: forall m blk tip.
-       ( MonadAsync m
-       , MonadFork  m
-       , MonadMask  m
+       ( IOLike m
        , SupportedBlock blk
        , Typeable tip
        , Show tip

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
@@ -32,7 +32,7 @@ import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 -- headers (and fetches blocks separately with the block fetch mini-protocol).
 --
 chainSyncHeadersServer
-    :: forall m blk. MonadSTM m
+    :: forall m blk. IOLike m
     => Tracer m (TraceChainSyncServerEvent blk (Header blk))
     -> ChainDB m blk
     -> ResourceRegistry m
@@ -49,7 +49,7 @@ chainSyncHeadersServer tracer chainDB registry =
 -- chains of full blocks (rather than a header \/ body split).
 --
 chainSyncBlocksServer
-    :: forall m blk. MonadSTM m
+    :: forall m blk. IOLike m
     => Tracer m (TraceChainSyncServerEvent blk blk)
     -> ChainDB m blk
     -> ResourceRegistry m
@@ -72,7 +72,7 @@ chainSyncBlocksServer tracer chainDB registry =
 --
 chainSyncServerForReader
     :: forall m blk b.
-       ( MonadSTM m
+       ( IOLike m
        , HeaderHash blk ~ HeaderHash b
        )
     => Tracer m (TraceChainSyncServerEvent blk b)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
@@ -13,7 +13,6 @@ module Ouroboros.Consensus.ChainSyncServer
   , TraceChainSyncServerEvent (..)
   ) where
 
-import           Control.Monad.Class.MonadSTM
 import           Control.Tracer
 
 import           Ouroboros.Network.Block (ChainUpdate (..), HeaderHash,
@@ -24,6 +23,7 @@ import           Ouroboros.Storage.ChainDB.API (ChainDB, Reader)
 import qualified Ouroboros.Storage.ChainDB.API as ChainDB
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
 -- | Chain Sync Server for block headers for a given a 'ChainDB'.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -18,11 +18,10 @@ import           Control.Monad.Except
 import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
 
-import           Control.Monad.Class.MonadSTM
-
 import           Ouroboros.Network.Protocol.TxSubmission.Type (TxSizeInBytes)
 
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Util.IOLike
 
 class (UpdateLedger blk, Ord (GenTxId blk)) => ApplyTx blk where
   -- | Generalized transaction

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -15,10 +15,7 @@ import           Control.Monad.Except
 import qualified Data.Foldable as Foldable
 import           Data.Word (Word64)
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadThrow
-
 import           Control.Tracer
 
 import           Ouroboros.Network.Block (ChainHash)
@@ -35,7 +32,7 @@ import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo, TxSeq (..),
                      splitAfterTicketNo, zeroTicketNo)
 import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Util (repeatedly)
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (onEachChange)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -15,7 +15,6 @@ import           Control.Monad.Except
 import qualified Data.Foldable as Foldable
 import           Data.Word (Word64)
 
-import           Control.Monad.Class.MonadThrow
 import           Control.Tracer
 
 import           Ouroboros.Network.Block (ChainHash)
@@ -40,11 +39,7 @@ import           Ouroboros.Consensus.Util.STM (onEachChange)
   Top-level API
 -------------------------------------------------------------------------------}
 
-openMempool :: ( MonadAsync m
-               , MonadFork  m
-               , MonadMask  m
-               , ApplyTx blk
-               )
+openMempool :: (IOLike m, ApplyTx blk)
             => ResourceRegistry m
             -> LedgerInterface m blk
             -> LedgerConfig blk
@@ -60,7 +55,7 @@ openMempool registry ledger cfg tracer = do
 --
 -- Intended for testing purposes.
 openMempoolWithoutSyncThread
-  :: (MonadAsync m, ApplyTx blk)
+  :: (IOLike m, ApplyTx blk)
   => LedgerInterface m blk
   -> LedgerConfig blk
   -> Tracer m (TraceEventMempool blk)
@@ -68,7 +63,7 @@ openMempoolWithoutSyncThread
 openMempoolWithoutSyncThread ledger cfg tracer =
     mkMempool <$> initMempoolEnv ledger cfg tracer
 
-mkMempool :: (MonadSTM m, ApplyTx blk)
+mkMempool :: (IOLike m, ApplyTx blk)
           => MempoolEnv m blk -> Mempool m blk TicketNo
 mkMempool env = Mempool
     { addTxs        = implAddTxs env
@@ -83,7 +78,7 @@ data LedgerInterface m blk = LedgerInterface
   }
 
 -- | Create a 'LedgerInterface' from a 'ChainDB'.
-chainDBLedgerInterface :: MonadSTM m => ChainDB m blk -> LedgerInterface m blk
+chainDBLedgerInterface :: IOLike m => ChainDB m blk -> LedgerInterface m blk
 chainDBLedgerInterface chainDB = LedgerInterface
     { getCurrentLedgerState = ledgerState <$> ChainDB.getCurrentLedger chainDB
     }
@@ -116,7 +111,7 @@ data MempoolEnv m blk = MempoolEnv {
 initInternalState :: InternalState blk
 initInternalState = IS TxSeq.Empty Block.GenesisHash zeroTicketNo
 
-initMempoolEnv :: MonadSTM m
+initMempoolEnv :: IOLike m
                => LedgerInterface m blk
                -> LedgerConfig blk
                -> Tracer m (TraceEventMempool blk)
@@ -132,11 +127,7 @@ initMempoolEnv ledgerInterface cfg tracer = do
 
 -- | Spawn a thread which syncs the 'Mempool' state whenever the 'LedgerState'
 -- changes.
-forkSyncStateOnTipPointChange :: ( MonadAsync m
-                                 , MonadFork m
-                                 , MonadMask m
-                                 , ApplyTx blk
-                                 )
+forkSyncStateOnTipPointChange :: (IOLike m, ApplyTx blk)
                               => ResourceRegistry m
                               -> MempoolEnv m blk
                               -> m ()
@@ -152,7 +143,7 @@ forkSyncStateOnTipPointChange registry menv =
   Mempool Implementation
 -------------------------------------------------------------------------------}
 
-implAddTxs :: forall m blk. (MonadSTM m, ApplyTx blk)
+implAddTxs :: forall m blk. (IOLike m, ApplyTx blk)
            => MempoolEnv m blk
            -> [GenTx blk]
            -> m [(GenTx blk, Maybe (ApplyTxErr blk))]
@@ -193,7 +184,7 @@ implAddTxs mpEnv@MempoolEnv{mpEnvStateVar, mpEnvLedgerCfg, mpEnvTracer} txs = do
         res { vrInvalid = [] }
 
 implWithSyncState
-  :: (MonadSTM m, ApplyTx blk)
+  :: (IOLike m, ApplyTx blk)
   => MempoolEnv m blk
   -> (MempoolSnapshot blk TicketNo -> STM m a)
   -> m a
@@ -220,7 +211,7 @@ implWithSyncState mpEnv@MempoolEnv{mpEnvTracer, mpEnvStateVar} f = do
       traceWith mpEnvTracer $ TraceMempoolRemoveTxs removed mempoolSize
     return res
 
-implGetSnapshot :: MonadSTM m
+implGetSnapshot :: IOLike m
                 => MempoolEnv m blk
                 -> STM m (MempoolSnapshot blk TicketNo)
 implGetSnapshot MempoolEnv{mpEnvStateVar} = do
@@ -232,7 +223,7 @@ implGetSnapshot MempoolEnv{mpEnvStateVar} = do
     }
 
 -- | Return the number of transactions in the Mempool.
-getMempoolSize :: MonadSTM m => MempoolEnv m blk -> STM m Word64
+getMempoolSize :: IOLike m => MempoolEnv m blk -> STM m Word64
 getMempoolSize MempoolEnv{mpEnvStateVar} =
     fromIntegral . Foldable.length . isTxs <$> readTVar mpEnvStateVar
 
@@ -364,7 +355,7 @@ extendVRNew cfg tx
                       }
 
 -- | Validate internal state
-validateIS :: forall m blk. (MonadSTM m, ApplyTx blk)
+validateIS :: forall m blk. (IOLike m, ApplyTx blk)
            => MempoolEnv m blk -> STM m (ValidationResult blk)
 validateIS MempoolEnv{mpEnvLedger, mpEnvLedgerCfg, mpEnvStateVar} =
     go <$> getCurrentLedgerState mpEnvLedger <*> readTVar mpEnvStateVar

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -36,10 +36,8 @@ import           Crypto.Random
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Proxy (Proxy (..))
 import           Data.Time.Clock (secondsToDiffTime)
+import           Network.Mux.Types (MuxTrace, WithMuxBearer)
 import           Network.Socket as Socket
-import           Network.Mux.Types (WithMuxBearer, MuxTrace)
-
-import           Control.Monad.Class.MonadAsync
 
 import           Ouroboros.Network.Block
 import qualified Ouroboros.Network.Block as Block
@@ -59,6 +57,7 @@ import           Ouroboros.Consensus.Node.Tracers
 import           Ouroboros.Consensus.NodeKernel
 import           Ouroboros.Consensus.NodeNetwork
 import           Ouroboros.Consensus.Protocol hiding (Protocol)
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.ResourceRegistry
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -28,8 +28,6 @@ import           Data.Map.Strict (Map)
 import           Data.Maybe (isNothing)
 import           Data.Word (Word16)
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork (MonadFork)
 import           Control.Monad.Class.MonadThrow
 import           Control.Tracer
 
@@ -58,7 +56,7 @@ import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo)
 import           Ouroboros.Consensus.Node.Tracers
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.ResourceRegistry

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -131,10 +131,7 @@ data ProtocolHandlers m peer blk = ProtocolHandlers {
 
 protocolHandlers
     :: forall m blk peer.
-       ( MonadSTM   m
-       , MonadThrow (STM m)
-       , MonadTime  m
-       , MonadCatch m
+       ( IOLike m
        , ApplyTx blk
        , ProtocolLedgerView blk
        )
@@ -209,7 +206,7 @@ data ProtocolCodecs blk failure m
 
 -- | The real codecs
 --
-protocolCodecs :: forall m blk. (MonadST m, RunNode blk)
+protocolCodecs :: forall m blk. (IOLike m, RunNode blk)
                => NodeConfig (BlockProtocol blk)
                -> ProtocolCodecs blk DeserialiseFailure m
                                  ByteString ByteString ByteString
@@ -391,9 +388,7 @@ localResponderNetworkApplication NetworkApplication {..} =
 --
 consensusNetworkApps
     :: forall m peer blk failure bytesCS bytesBF bytesTX bytesLCS bytesLTX.
-       ( MonadAsync m
-       , MonadFork m
-       , MonadMask m
+       ( IOLike m
        , Ord peer
        , Exception failure
        , SupportedBlock blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -33,19 +33,13 @@ import           Data.ByteString.Lazy (ByteString)
 import           Data.Proxy (Proxy (..))
 import           Data.Void (Void)
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTime
 import           Control.Tracer
 
 import           Network.Mux.Interface
 import           Network.TypedProtocol.Channel
 import           Network.TypedProtocol.Codec.Cbor hiding (decode, encode)
 import           Network.TypedProtocol.Driver
-import           Ouroboros.Network.NodeToClient
-import           Ouroboros.Network.NodeToNode
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
 import           Ouroboros.Network.Block
@@ -53,6 +47,8 @@ import           Ouroboros.Network.BlockFetch
 import           Ouroboros.Network.BlockFetch.Client (BlockFetchClient,
                      blockFetchClient)
 import           Ouroboros.Network.Mux
+import           Ouroboros.Network.NodeToClient
+import           Ouroboros.Network.NodeToNode
 import           Ouroboros.Network.Protocol.BlockFetch.Codec
 import           Ouroboros.Network.Protocol.BlockFetch.Server (BlockFetchServer,
                      blockFetchServerPeer)
@@ -82,7 +78,7 @@ import           Ouroboros.Consensus.Node.Tracers
 import           Ouroboros.Consensus.NodeKernel
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.TxSubmission
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.ResourceRegistry
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -38,8 +38,6 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Control.Monad.Class.MonadSay
-
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
 import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..))
 import           Ouroboros.Network.Point (WithOrigin)
@@ -238,7 +236,7 @@ instance HasNodeState_ s m => HasNodeState_ s (ChaChaT m) where
 -------------------------------------------------------------------------------}
 
 newtype NodeStateT_ s m a = NodeStateT { unNodeStateT :: StateT s m a }
-  deriving (Functor, Applicative, Monad, MonadTrans, MonadSay)
+  deriving (Functor, Applicative, Monad, MonadTrans)
 
 type NodeStateT p = NodeStateT_ (NodeState p)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
@@ -29,8 +29,6 @@ import qualified Data.ByteString.Lazy as LBS
 import           Data.IORef
 import           Data.Word (Word64)
 
-import           Control.Monad.Class.MonadThrow
-
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.FS.API
@@ -115,7 +113,7 @@ data ReadIncrementalErr =
 --
 -- NOTE: This currently expects the file to contain precisely one value; see also
 -- 'readIncrementalOffsets'.
-readIncremental :: forall m h a. (MonadST m, MonadThrow m)
+readIncremental :: forall m h a. IOLike m
                 => HasFS m h
                 -> (forall s . CBOR.Decoder s a)
                 -> FsPath
@@ -148,7 +146,7 @@ readIncremental hasFS@HasFS{..} decoder fp = withLiftST $ \liftST -> do
 -- Return the offset ('Word64') of the start of each @a@ and the size ('Word64')
 -- of each @a@. When deserialising fails, return all already deserialised @a@s
 -- and the error.
-readIncrementalOffsets :: forall m h a. (MonadST m, MonadThrow m)
+readIncrementalOffsets :: forall m h a. IOLike m
                        => HasFS m h
                        -> (forall s . CBOR.Decoder s (LBS.ByteString -> a))
                        -> FsPath

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
@@ -29,8 +29,9 @@ import qualified Data.ByteString.Lazy as LBS
 import           Data.IORef
 import           Data.Word (Word64)
 
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
+
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -1,13 +1,88 @@
+{-# LANGUAGE FlexibleContexts #-}
+
 module Ouroboros.Consensus.Util.IOLike (
-    module X
+    IOLike
+    -- * Re-exports
+    -- *** MonadThrow
+  , uninterruptibleCancel
+    -- *** MonadSTM
+  , STM
+  , atomically
+  , check
+  , retry
+    -- ** Queues (TODO: Should we have a strict queue?)
+  , TQueue
+  , newTQueue
+  , readTQueue
+  , writeTQueue
+    -- ** StrictTVar
+  , StrictTVar
+  , modifyTVar
+  , readTVar
+  , uncheckedNewTVarM
+  , updateTVar
+  , writeTVar
+    -- *** StrictTMVar
+  , StrictTMVar
+  , putTMVar
+  , readTMVar
+  , takeTMVar
+  , tryTakeTMVar
+  , swapTMVar
+  , uncheckedNewEmptyTMVarM
+  , uncheckedNewTMVarM
+    -- *** MonadFork
+  , ThreadId
+  , myThreadId
+  , fork -- TODO: Should we hide this?
+    -- *** MonadAsync
+  , Async
+  , async
+  , asyncThreadId
+  , linkTo
+  , wait
+  , waitAny
+  , waitBoth
+  , withAsync
+    -- *** MonadST
+  , withLiftST
+    -- *** MonadTime
+  , Time
+  , DiffTime
+  , addTime
+  , diffTime
+  , getMonotonicTime
+    -- *** MonadTimer
+  , threadDelay
+  , timeoutAfter
+    -- *** Cardano prelude
+  , NoUnexpectedThunks(..)
   ) where
 
-import           Cardano.Prelude as X (NoUnexpectedThunks (..))
+import           Cardano.Prelude (NoUnexpectedThunks (..))
 
-import           Control.Monad.Class.MonadAsync as X
-import           Control.Monad.Class.MonadFork as X
-import           Control.Monad.Class.MonadST as X
-import           Control.Monad.Class.MonadTime as X
-import           Control.Monad.Class.MonadTimer as X
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer
 
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm as X
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+
+{-------------------------------------------------------------------------------
+  IOLike
+-------------------------------------------------------------------------------}
+
+class ( MonadAsync m
+      , MonadFork  m
+      , MonadST    m
+      , MonadTime  m
+      , MonadTimer m
+      , MonadThrow m
+      , MonadCatch m
+      , MonadMask  m
+      , MonadThrow (STM m)
+      ) => IOLike m where
+
+instance IOLike IO

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -1,0 +1,13 @@
+module Ouroboros.Consensus.Util.IOLike (
+    module X
+  ) where
+
+import           Cardano.Prelude as X (NoUnexpectedThunks (..))
+
+import           Control.Monad.Class.MonadAsync as X
+import           Control.Monad.Class.MonadFork as X
+import           Control.Monad.Class.MonadST as X
+import           Control.Monad.Class.MonadTime as X
+import           Control.Monad.Class.MonadTimer as X
+
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 
 module Ouroboros.Consensus.Util.IOLike (
     IOLike
@@ -69,6 +70,7 @@ import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 
 import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.Orphans ()
 
 {-------------------------------------------------------------------------------
   IOLike
@@ -83,6 +85,8 @@ class ( MonadAsync m
       , MonadCatch m
       , MonadMask  m
       , MonadThrow (STM m)
+      , forall a. NoUnexpectedThunks (m a)
+      , forall a. NoUnexpectedThunks a => NoUnexpectedThunks (StrictTVar m a)
       ) => IOLike m where
 
 instance IOLike IO

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
@@ -14,9 +14,9 @@ import           System.IO.Unsafe (unsafePerformIO)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..), ThunkInfo (..))
 
-import           Control.Monad.Class.MonadSTM.Strict hiding (newEmptyTMVar,
-                     newEmptyTMVarM, newEmptyTMVarWithInvariantM, newTMVar,
-                     newTMVarM, newTMVarWithInvariantM, newTVar, newTVarM,
+import           Control.Monad.Class.MonadSTM.Strict hiding (newEmptyTMVarM,
+                     newEmptyTMVarWithInvariantM, newTMVar, newTMVarM,
+                     newTMVarWithInvariantM, newTVar, newTVarM,
                      newTVarWithInvariantM)
 import qualified Control.Monad.Class.MonadSTM.Strict as Strict
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Random.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Random.hs
@@ -26,8 +26,6 @@ import           Crypto.Random (ChaChaDRG, MonadPseudoRandom, MonadRandom (..),
 import           Data.List (genericLength)
 import           Data.Word (Word64)
 
---import ToBeReplaced
-
 {-------------------------------------------------------------------------------
   Producing values in MonadRandom
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Random.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Random.hs
@@ -26,7 +26,7 @@ import           Crypto.Random (ChaChaDRG, MonadPseudoRandom, MonadRandom (..),
 import           Data.List (genericLength)
 import           Data.Word (Word64)
 
-import           Control.Monad.Class.MonadSay
+--import ToBeReplaced
 
 {-------------------------------------------------------------------------------
   Producing values in MonadRandom
@@ -60,7 +60,7 @@ nullSeed = Seed (0,0,0,0,0)
 
 -- | Add DRNG to a monad stack
 newtype ChaChaT m a = ChaChaT { unChaChaT :: StateT ChaChaDRG m a }
-  deriving (Functor, Applicative, Monad, MonadTrans, MonadSay)
+  deriving (Functor, Applicative, Monad, MonadTrans)
 
 instance Monad m => MonadRandom (ChaChaT m) where
   getRandomBytes = ChaChaT . state . randomBytesGenerate

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -34,7 +34,7 @@ module Ouroboros.Consensus.Util.ResourceRegistry (
   ) where
 
 import           Control.Applicative ((<|>))
-import           Control.Exception (asyncExceptionFromException)
+import           Control.Exception (Exception, asyncExceptionFromException)
 import           Control.Monad
 import           Control.Monad.State
 import           Data.Bifunctor
@@ -49,14 +49,12 @@ import           Data.Tuple (swap)
 import           GHC.Generics (Generic)
 import           GHC.Stack
 
+import           Control.Monad.Class.MonadThrow
+
 import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..),
                      UseIsNormalForm (..), UseIsNormalFormNamed (..))
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadThrow
-
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 
 -- | Resource registry
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
@@ -24,16 +24,14 @@ import           Control.Monad.Reader
 import           Control.Monad.State
 import           Control.Monad.Writer
 
+import           Control.Monad.Class.MonadThrow
+
 import           Data.Void
 import           Data.Word (Word64)
 import           GHC.Stack
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork (MonadFork)
-import           Control.Monad.Class.MonadThrow
-
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.ResourceRegistry
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -38,8 +38,6 @@ import           Data.Function (on)
 import           Data.Typeable (Typeable)
 import           GHC.Stack
 
-import           Control.Monad.Class.MonadThrow
-
 import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
@@ -271,8 +269,7 @@ data ChainDB m blk = ChainDB {
   Support for tests
 -------------------------------------------------------------------------------}
 
-toChain :: forall m blk.
-           (HasCallStack, MonadMask m, HasHeader blk, MonadSTM m, MonadFork m)
+toChain :: forall m blk. (HasCallStack, IOLike m, HasHeader blk)
         => ChainDB m blk -> m (Chain blk)
 toChain chainDB = withRegistry $ \registry ->
     streamAll chainDB registry >>= maybe (return Genesis) (go Genesis)
@@ -396,7 +393,7 @@ validBounds from to = case from of
 --
 -- Note that this is not a 'Reader', so the stream will not include blocks
 -- that are added to the current chain after starting the stream.
-streamAll :: (MonadSTM m, StandardHash blk)
+streamAll :: (IOLike m, StandardHash blk)
           => ChainDB m blk
           -> ResourceRegistry m
           -> m (Maybe (Iterator m blk))

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -38,8 +38,6 @@ import           Data.Function (on)
 import           Data.Typeable (Typeable)
 import           GHC.Stack
 
-import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 
 import           Cardano.Prelude (NoUnexpectedThunks)
@@ -52,6 +50,7 @@ import           Ouroboros.Network.Block (BlockNo, pattern BlockPoint,
 
 import           Ouroboros.Consensus.Block (GetHeader (..))
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..))
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -27,13 +27,7 @@ module Ouroboros.Storage.ChainDB.Impl (
 import           Control.Monad (when)
 import qualified Data.Map.Strict as Map
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTime
-import           Control.Monad.Class.MonadTimer
-
 import           Control.Tracer
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -42,7 +36,7 @@ import           Ouroboros.Network.Block (blockNo, blockPoint, blockSlot,
 
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..))
 
 import           Ouroboros.Storage.Common (EpochNo)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -27,7 +27,6 @@ module Ouroboros.Storage.ChainDB.Impl (
 import           Control.Monad (when)
 import qualified Data.Map.Strict as Map
 
-import           Control.Monad.Class.MonadThrow
 import           Control.Tracer
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -62,31 +61,13 @@ import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
 -------------------------------------------------------------------------------}
 
 openDB
-  :: forall m blk.
-     ( MonadAsync m
-     , MonadFork  m
-     , MonadST    m
-     , MonadMask  m
-     , MonadTime  m
-     , MonadTimer m
-     , MonadThrow (STM m)
-     , ProtocolLedgerView blk
-     )
+  :: forall m blk. (IOLike m, ProtocolLedgerView blk)
   => ChainDbArgs m blk
   -> m (ChainDB m blk)
 openDB args = fst <$> openDBInternal args True
 
 openDBInternal
-  :: forall m blk.
-     ( MonadAsync m
-     , MonadFork  m
-     , MonadST    m
-     , MonadMask  m
-     , MonadTime  m
-     , MonadTimer m
-     , MonadThrow (STM m)
-     , ProtocolLedgerView blk
-     )
+  :: forall m blk. (IOLike m, ProtocolLedgerView blk)
   => ChainDbArgs m blk
   -> Bool -- ^ 'True' = Launch background tasks
   -> m (ChainDB m blk, Internal m blk)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -16,8 +16,6 @@ import           Codec.CBOR.Encoding (Encoding)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Time.Clock (DiffTime, secondsToDiffTime)
 
-import           Control.Monad.Class.MonadSTM
-
 import           Control.Tracer (Tracer, contramap)
 
 import           Ouroboros.Network.Block (HeaderHash, StandardHash)
@@ -26,6 +24,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
 import           Ouroboros.Storage.EpochInfo (EpochInfo)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
@@ -35,12 +35,7 @@ import           Data.Maybe (fromMaybe)
 import           Data.Typeable (Typeable)
 import           GHC.Stack (HasCallStack)
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTime
-import           Control.Monad.Class.MonadTimer
-
 import           Control.Tracer
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
@@ -52,7 +47,7 @@ import           Ouroboros.Network.Point (WithOrigin (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract (ProtocolLedgerView)
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
@@ -60,14 +60,7 @@ import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
 -------------------------------------------------------------------------------}
 
 launchBgTasks
-  :: forall m blk.
-     ( MonadAsync m
-     , MonadFork  m
-     , MonadMask  m
-     , MonadTime  m
-     , MonadTimer m
-     , ProtocolLedgerView blk
-     )
+  :: forall m blk. (IOLike m, ProtocolLedgerView blk)
   => ChainDbEnv m blk
   -> m ()
 launchBgTasks cdb@CDB{..} = do
@@ -109,8 +102,7 @@ launchBgTasks cdb@CDB{..} = do
 -- not with itself.
 copyToImmDB
   :: forall m blk.
-     ( MonadSTM   m
-     , MonadCatch m
+     ( IOLike m
      , OuroborosTag (BlockProtocol blk)
      , HasHeader blk
      , HasHeader (Header blk)
@@ -190,9 +182,7 @@ copyToImmDB CDB{..} = withCopyLock $ do
 -- recent block that was copied.
 copyToImmDBRunner
   :: forall m blk.
-     ( MonadSTM   m
-     , MonadCatch m
-     , MonadTime  m
+     ( IOLike m
      , OuroborosTag (BlockProtocol blk)
      , HasHeader blk
      , HasHeader (Header blk)
@@ -227,11 +217,7 @@ copyToImmDBRunner cdb@CDB{..} gcSchedule = forever $ do
 -- TODO will a long GC be a bottleneck? It will block any other calls to
 -- @putBlock@ and @getBlock@.
 garbageCollect
-  :: forall m blk.
-     ( MonadCatch m
-     , MonadSTM   m
-     , HasHeader blk
-     )
+  :: forall m blk. (IOLike m, HasHeader blk)
   => ChainDbEnv m blk
   -> SlotNo
   -> m ()
@@ -291,12 +277,11 @@ garbageCollect CDB{..} slotNo = do
 -- same.
 newtype GcSchedule m = GcSchedule (TQueue m (Time m, SlotNo))
 
-newGcSchedule :: MonadSTM m => m (GcSchedule m)
+newGcSchedule :: IOLike m => m (GcSchedule m)
 newGcSchedule = GcSchedule <$> atomically newTQueue
 
 scheduleGC
-  :: forall m blk.
-     (MonadSTM m, MonadTime m)
+  :: forall m blk. IOLike m
   => Tracer m (TraceGCEvent blk)
   -> SlotNo    -- ^ The slot to use for garbage collection
   -> DiffTime  -- ^ How long to wait until performing the GC
@@ -308,8 +293,7 @@ scheduleGC tracer slotNo delay (GcSchedule queue) = do
     traceWith tracer $ ScheduledGC slotNo delay
 
 gcScheduleRunner
-  :: forall m.
-     (MonadSTM m, MonadTime m, MonadTimer m)
+  :: forall m. IOLike m
   => GcSchedule m
   -> (SlotNo -> m ())  -- ^ GC function
   -> m ()
@@ -328,8 +312,7 @@ gcScheduleRunner (GcSchedule queue) runGc = forever $ do
 -- | Write a snapshot of the LedgerDB to disk and remove old snapshots
 -- (typically one) so that only 'onDiskNumSnapshots' snapshots are on disk.
 updateLedgerSnapshots
-  :: forall m blk.
-     (MonadSTM m, MonadThrow m, StandardHash blk, Typeable blk)
+  :: forall m blk. (IOLike m, StandardHash blk, Typeable blk)
   => ChainDbEnv m blk
   -> m ()
 updateLedgerSnapshots CDB{..} = do
@@ -339,8 +322,7 @@ updateLedgerSnapshots CDB{..} = do
 
 -- | Execute 'updateLedgerSnapshots', wait 'onDiskWriteInterval', and repeat.
 updateLedgerSnapshotsRunner
-  :: forall m blk.
-     (MonadTimer m, MonadThrow m, StandardHash blk, Typeable blk)
+  :: forall m blk. (IOLike m, StandardHash blk, Typeable blk)
   => ChainDbEnv m blk
   -> m ()
 updateLedgerSnapshotsRunner cdb@CDB{..} = loop

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
@@ -39,7 +39,6 @@ import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
 
 import           Control.Monad.Class.MonadThrow
-
 import           Control.Tracer (Tracer, contramap, traceWith)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
@@ -50,7 +49,7 @@ import           Ouroboros.Network.Block (BlockNo, HasHeader (..), HeaderHash,
 import           Ouroboros.Consensus.Block (BlockProtocol, GetHeader (..))
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.STM (Fingerprint)
 
 import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
@@ -69,11 +69,7 @@ import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
 --
 -- See "## Initialization" in ChainDB.md.
 initialChainSelection
-  :: forall m blk.
-     ( MonadCatch m
-     , MonadSTM   m
-     , ProtocolLedgerView blk
-     )
+  :: forall m blk. (IOLike m, ProtocolLedgerView blk)
   => ImmDB m blk
   -> VolDB m blk
   -> LgrDB m blk
@@ -188,8 +184,7 @@ initialChainSelection immDB volDB lgrDB tracer cfg varInvalid = do
 -- This cost is currently deemed acceptable.
 addBlock
   :: forall m blk.
-     ( MonadSTM   m
-     , MonadCatch m
+     ( IOLike m
      , HasHeader blk
      , ProtocolLedgerView blk
      , HasCallStack
@@ -515,7 +510,7 @@ getKnownHeaderThroughCache volDB hash = gets (Map.lookup hash) >>= \case
 -- PRECONDITION: the candidate suffixes must fit on the (given) current chain.
 chainSelection
   :: forall m blk.
-     ( MonadSTM m
+     ( IOLike m
      , ProtocolLedgerView blk
      , HasCallStack
      )
@@ -625,7 +620,7 @@ chainSelection lgrDB tracer cfg varInvalid
 -- Returns 'Nothing' if this candidate requires a rollback we cannot support.
 validateCandidate
   :: forall m blk.
-     ( MonadSTM m
+     ( IOLike m
      , ProtocolLedgerView blk
      , HasCallStack
      )

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -64,9 +64,6 @@ import           Data.Word
 import           GHC.Stack (HasCallStack)
 import           System.FilePath ((</>))
 
-import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Network.Block (pattern BlockPoint,
@@ -76,9 +73,9 @@ import           Ouroboros.Network.Block (pattern BlockPoint,
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import qualified Ouroboros.Consensus.Util.CBOR as Util.CBOR
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry,
                      allocate, unsafeRelease)
-
 
 import           Ouroboros.Storage.ChainDB.API (ChainDbError (..),
                      ChainDbFailure (..), StreamFrom (..), UnknownRange (..))

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -146,8 +146,7 @@ defaultArgs fp = ImmDbArgs{
     , immTracer      = nullTracer
     }
 
-openDB :: (MonadSTM m, MonadST m, MonadCatch m, HasHeader blk)
-       => ImmDbArgs m blk -> m (ImmDB m blk)
+openDB :: (IOLike m, HasHeader blk) => ImmDbArgs m blk -> m (ImmDB m blk)
 openDB args@ImmDbArgs{..} = do
     createDirectoryIfMissing immHasFS True (mkFsPath [])
     immDB <- ImmDB.openDB
@@ -350,7 +349,7 @@ appendBlock db@ImmDB{..} b = withDB db $ \imm -> case isEBB b of
 --
 -- When the returned iterator is closed, it will be 'release'd from the
 -- 'ResourceRegistry'.
-registeredStream :: (MonadMask m, MonadSTM m, MonadFork m, HasHeader blk)
+registeredStream :: (IOLike m, HasHeader blk)
                  => ImmDB m blk
                  -> ResourceRegistry m
                  -> Maybe (SlotNo, HeaderHash blk)
@@ -380,12 +379,7 @@ registeredStream db registry start end = do
 --
 -- When passed @'StreamFromInclusive' pt@ where @pt@ refers to Genesis, a
 -- 'NoGenesisBlock' exception will be thrown.
-streamBlocksFrom :: forall m blk.
-                   ( MonadMask m
-                   , MonadSTM  m
-                   , MonadFork m
-                   , HasHeader blk
-                   )
+streamBlocksFrom :: forall m blk. (IOLike m, HasHeader blk)
                  => ImmDB m blk
                  -> ResourceRegistry m
                  -> StreamFrom blk
@@ -450,12 +444,7 @@ streamBlocksFrom db registry from = runExceptT $ case from of
 --
 -- When passed @'StreamFromInclusive' pt@ where @pt@ refers to Genesis, a
 -- 'NoGenesisBlock' exception will be thrown.
-streamBlocksFromUnchecked  :: forall m blk.
-                              ( MonadMask m
-                              , MonadSTM  m
-                              , MonadFork m
-                              , HasHeader blk
-                              )
+streamBlocksFromUnchecked  :: forall m blk. (IOLike m, HasHeader blk)
                            => ImmDB m blk
                            -> ResourceRegistry m
                            -> StreamFrom blk
@@ -480,12 +469,7 @@ streamBlocksFromUnchecked db registry from = case from of
 -- See also 'streamBlobsAfter'.
 --
 -- PRECONDITION: the exclusive lower bound is part of the ImmutableDB.
-streamBlocksAfter :: forall m blk.
-                     ( MonadMask m
-                     , MonadSTM  m
-                     , MonadFork m
-                     , HasHeader blk
-                     )
+streamBlocksAfter :: forall m blk. (IOLike m, HasHeader blk)
                   => ImmDB m blk
                   -> ResourceRegistry m
                   -> Point blk -- ^ Exclusive lower bound
@@ -504,12 +488,7 @@ streamBlocksAfter db registry low =
 -- bound at all; if it doesn't, we pass the hash as the lower bound to the
 -- 'ImmutableDB' and then step the iterator one block to skip that first
 -- block.
-streamBlobsAfter :: forall m blk.
-                    ( MonadMask m
-                    , MonadSTM  m
-                    , MonadFork m
-                    , HasHeader blk
-                    )
+streamBlobsAfter :: forall m blk. (IOLike m, HasHeader blk)
                  => ImmDB m blk
                  -> ResourceRegistry m
                  -> Point blk -- ^ Exclusive lower bound
@@ -588,7 +567,7 @@ data EpochFileError =
   | EpochErrUnexpectedEBB
   deriving (Eq, Show)
 
-epochFileParser :: forall m blk. (MonadST m, MonadThrow m, HasHeader blk)
+epochFileParser :: forall m blk. (IOLike m, HasHeader blk)
                 => ImmDbArgs m blk
                 -> ImmDB.EpochFileParser
                      EpochFileError

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
@@ -25,9 +25,7 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           GHC.Stack (HasCallStack)
 
-import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadThrow
-
 import           Control.Tracer
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -36,7 +34,7 @@ import           Ouroboros.Network.Block (pattern BlockPoint,
                      atSlot, blockHash, blockPoint, castPoint, pointSlot,
                      withHash)
 
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
 import           Ouroboros.Storage.ChainDB.API (ChainDbError (..),

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -60,10 +60,7 @@ import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
 import           System.FilePath ((</>))
 
-import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
-
 import           Control.Tracer
 
 import           Ouroboros.Network.Block (pattern BlockPoint,
@@ -77,7 +74,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util ((.:))
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.Common

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
@@ -65,7 +65,7 @@ import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
 -- therefore, /must/ still be \"immutable\".
 getCurrentChain
   :: forall m blk.
-     ( MonadSTM m
+     ( IOLike m
      , HasHeader (Header blk)
      , OuroborosTag (BlockProtocol blk)
      )
@@ -76,16 +76,11 @@ getCurrentChain CDB{..} =
   where
     SecurityParam k = protocolSecurityParam cdbNodeConfig
 
-getCurrentLedger :: MonadSTM m => ChainDbEnv m blk -> STM m (ExtLedgerState blk)
+getCurrentLedger :: IOLike m => ChainDbEnv m blk -> STM m (ExtLedgerState blk)
 getCurrentLedger CDB{..} = LgrDB.getCurrentState cdbLgrDB
 
 getTipBlock
-  :: forall m blk.
-     ( MonadCatch m
-     , MonadSTM m
-     , HasHeader blk
-     , HasHeader (Header blk)
-     )
+  :: forall m blk. (IOLike m, HasHeader blk, HasHeader (Header blk))
   => ChainDbEnv m blk
   -> m (Maybe blk)
 getTipBlock cdb@CDB{..} = do
@@ -96,8 +91,7 @@ getTipBlock cdb@CDB{..} = do
 
 getTipHeader
   :: forall m blk.
-     ( MonadCatch m
-     , MonadSTM   m
+     ( IOLike m
      , GetHeader blk
      , HasHeader blk
      , HasHeader (Header blk)
@@ -127,13 +121,13 @@ getTipHeader CDB{..} = do
     anchorMustBeThere (Just blk) = Just (getHeader blk)
 
 getTipPoint
-  :: forall m blk. (MonadSTM m, HasHeader (Header blk))
+  :: forall m blk. (IOLike m, HasHeader (Header blk))
   => ChainDbEnv m blk -> STM m (Point blk)
 getTipPoint CDB{..} =
     (castPoint . AF.headPoint) <$> readTVar cdbChain
 
 getTipBlockNo
-  :: forall m blk. (MonadSTM m, HasHeader (Header blk))
+  :: forall m blk. (IOLike m, HasHeader (Header blk))
   => ChainDbEnv m blk -> STM m BlockNo
 getTipBlockNo CDB{..} = do
     mbTipBlockNo <- AF.headBlockNo <$> readTVar cdbChain
@@ -148,7 +142,7 @@ getBlock
 getBlock CDB{..} = getAnyBlock cdbImmDB cdbVolDB
 
 getIsFetched
-  :: forall m blk. MonadSTM m
+  :: forall m blk. IOLike m
   => ChainDbEnv m blk -> STM m (Point blk -> Bool)
 getIsFetched CDB{..} = basedOnHash <$> VolDB.getIsMember cdbVolDB
   where
@@ -162,12 +156,12 @@ getIsFetched CDB{..} = basedOnHash <$> VolDB.getIsMember cdbVolDB
           GenesisHash    -> False
 
 getIsInvalidBlock
-  :: forall m blk. (MonadSTM m, HasHeader blk)
+  :: forall m blk. (IOLike m, HasHeader blk)
   => ChainDbEnv m blk -> STM m (HeaderHash blk -> Bool, Fingerprint)
 getIsInvalidBlock CDB{..} = first (flip Map.member) <$> readTVar cdbInvalid
 
 getMaxSlotNo
-  :: forall m blk. (MonadSTM m, HasHeader (Header blk))
+  :: forall m blk. (IOLike m, HasHeader (Header blk))
   => ChainDbEnv m blk -> STM m MaxSlotNo
 getMaxSlotNo CDB{..} = do
     -- Note that we need to look at both the current chain and the VolatileDB

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
@@ -35,7 +35,7 @@ import           Ouroboros.Network.Block (BlockNo, ChainHash (..), HasHeader,
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.STM (Fingerprint)
 
 import           Ouroboros.Storage.ChainDB.API (ChainDbError (..),

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
@@ -20,9 +20,7 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (isJust)
 import           GHC.Stack (HasCallStack)
 
-import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadThrow
-
 import           Control.Tracer (contramap, traceWith)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
@@ -33,7 +31,7 @@ import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader,
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block (GetHeader (..), headerPoint)
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import           Ouroboros.Consensus.Util.STM (blockUntilJust)
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
@@ -42,7 +42,7 @@ import qualified Ouroboros.Storage.ChainDB.Impl.Reader as Reader
 import           Ouroboros.Storage.ChainDB.Impl.Types
 import qualified Ouroboros.Storage.ChainDB.Impl.VolDB as VolDB
 
-isOpen :: MonadSTM m => ChainDbHandle m blk -> STM m Bool
+isOpen :: IOLike m => ChainDbHandle m blk -> STM m Bool
 isOpen (CDBHandle varState) = readTVar varState <&> \case
     ChainDbReopening   -> False
     ChainDbClosed _env -> False
@@ -50,8 +50,7 @@ isOpen (CDBHandle varState) = readTVar varState <&> \case
 
 closeDB
   :: forall m blk.
-     ( MonadMask m
-     , MonadAsync m
+     ( IOLike m
      , HasHeader blk
      , HasHeader (Header blk)
      , HasCallStack
@@ -90,12 +89,7 @@ closeDB (CDBHandle varState) = do
 
 reopen
   :: forall m blk.
-     ( MonadAsync m
-     , MonadFork  m
-     , MonadMask  m
-     , MonadST    m
-     , MonadTime  m
-     , MonadTimer m
+     ( IOLike m
      , ProtocolLedgerView blk
      , HasCallStack
      )

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
@@ -16,13 +16,7 @@ import           Control.Monad (when)
 import           Data.Functor ((<&>))
 import           GHC.Stack (HasCallStack)
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTime
-import           Control.Monad.Class.MonadTimer
-
 import           Control.Tracer
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
@@ -33,7 +27,7 @@ import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util (whenJust)
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.Common (EpochNo)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -44,7 +44,6 @@ import           Data.Word
 import           GHC.Generics (Generic)
 
 import           Control.Monad.Class.MonadThrow
-
 import           Control.Tracer
 
 import           Cardano.Prelude (NoUnexpectedThunks)
@@ -58,7 +57,7 @@ import           Ouroboros.Consensus.Block (BlockProtocol, Header)
 import           Ouroboros.Consensus.Ledger.Abstract (ProtocolLedgerView)
 import           Ouroboros.Consensus.Ledger.Extended (ExtValidationError)
 import           Ouroboros.Consensus.Protocol.Abstract (NodeConfig)
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (Fingerprint)
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -78,12 +78,7 @@ newtype ChainDbHandle m blk = CDBHandle (StrictTVar m (ChainDbState m blk))
 
 -- | Check if the ChainDB is open, if so, executing the given function on the
 -- 'ChainDbEnv', otherwise, throw a 'CloseDBError'.
-getEnv :: forall m blk r.
-          ( MonadSTM   m
-          , MonadThrow m
-          , StandardHash blk
-          , Typeable     blk
-          )
+getEnv :: forall m blk r. (IOLike m, StandardHash blk, Typeable blk)
        => ChainDbHandle m blk
        -> (ChainDbEnv m blk -> m r)
        -> m r
@@ -94,24 +89,14 @@ getEnv (CDBHandle varState) f = atomically (readTVar varState) >>= \case
     ChainDbReopening   -> error "ChainDB used while reopening"
 
 -- | Variant 'of 'getEnv' for functions taking one argument.
-getEnv1 :: forall m blk a r.
-           ( MonadSTM   m
-           , MonadThrow m
-           , StandardHash blk
-           , Typeable     blk
-           )
+getEnv1 :: (IOLike m, StandardHash blk, Typeable blk)
         => ChainDbHandle m blk
         -> (ChainDbEnv m blk -> a -> m r)
         -> a -> m r
 getEnv1 h f a = getEnv h (\env -> f env a)
 
 -- | Variant 'of 'getEnv' for functions taking two arguments.
-getEnv2 :: forall m blk a b r.
-           ( MonadSTM   m
-           , MonadThrow m
-           , StandardHash blk
-           , Typeable     blk
-           )
+getEnv2 :: (IOLike m, StandardHash blk, Typeable blk)
         => ChainDbHandle m blk
         -> (ChainDbEnv m blk -> a -> b -> m r)
         -> a -> b -> m r
@@ -119,12 +104,7 @@ getEnv2 h f a b = getEnv h (\env -> f env a b)
 
 
 -- | Variant of 'getEnv' that works in 'STM'.
-getEnvSTM :: forall m blk r.
-             ( MonadSTM   m
-             , MonadThrow (STM m)
-             , StandardHash blk
-             , Typeable     blk
-             )
+getEnvSTM :: forall m blk r. (IOLike m, StandardHash blk, Typeable  blk)
           => ChainDbHandle m blk
           -> (ChainDbEnv m blk -> STM m r)
           -> STM m r

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
@@ -58,8 +58,6 @@ import           Data.Typeable (Typeable)
 import           GHC.Stack (HasCallStack)
 import           System.FilePath ((</>))
 
-import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Network.Block (pattern BlockPoint, ChainHash (..),
@@ -71,6 +69,7 @@ import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Consensus.Block (GetHeader, Header)
 import qualified Ouroboros.Consensus.Block as Block
 import qualified Ouroboros.Consensus.Util.CBOR as Util.CBOR
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.ChainDB.API (ChainDbError (..),
                      ChainDbFailure (..), StreamFrom (..), StreamTo (..))

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
@@ -125,8 +125,7 @@ defaultArgs fp = VolDbArgs {
     , volEncodeBlock   = error "no default for volEncodeBlock"
     }
 
-openDB :: (MonadCatch m, MonadSTM m, MonadST m, HasHeader blk)
-       => VolDbArgs m blk -> m (VolDB m blk)
+openDB :: (IOLike m, HasHeader blk) => VolDbArgs m blk -> m (VolDB m blk)
 openDB args@VolDbArgs{..} = do
     createDirectoryIfMissing volHasFS True (mkFsPath [])
     volDB <- VolDB.openDB
@@ -222,7 +221,7 @@ candidates succsOf b = mapMaybe NE.nonEmpty $ go (fromChainHash (pointHash b))
 
 -- | Variant of 'isReachable' that obtains its arguments in the same 'STM'
 -- transaction.
-isReachableSTM :: (MonadSTM m, HasHeader blk)
+isReachableSTM :: (IOLike m, HasHeader blk)
                => VolDB m blk
                -> STM m (Point blk) -- ^ The tip of the ImmutableDB (@I@).
                -> Point blk         -- ^ The point of the block (@B@) to check
@@ -335,11 +334,7 @@ computePath predecessor isMember from to = case to of
 -- transaction. Throws an 'InvalidIteratorRange' exception when the range is
 -- invalid (i.e., 'computePath' returned 'Nothing').
 computePathSTM
-  :: forall m blk.
-     ( MonadSTM m
-     , MonadThrow (STM m)
-     , HasHeader blk
-     )
+  :: forall m blk. (IOLike m, HasHeader blk)
   => VolDB m blk
   -> StreamFrom blk
   -> StreamTo   blk
@@ -428,7 +423,7 @@ getBlock db hash = do
   Auxiliary: parsing
 -------------------------------------------------------------------------------}
 
-blockFileParser :: forall m blk. (MonadST m, MonadThrow m, HasHeader blk)
+blockFileParser :: forall m blk. (IOLike m, HasHeader blk)
                 => VolDbArgs m blk
                 -> VolDB.Parser
                      Util.CBOR.ReadIncrementalErr

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
@@ -20,7 +20,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util ((..:))
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.STM (blockUntilJust)
 
 import           Ouroboros.Storage.ChainDB.API

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Mock.hs
@@ -27,12 +27,7 @@ import           Ouroboros.Storage.ChainDB.API
 import           Ouroboros.Storage.ChainDB.Model (Model)
 import qualified Ouroboros.Storage.ChainDB.Model as Model
 
-openDB :: forall m blk.
-          ( MonadSTM   m
-          , MonadThrow m
-          , MonadThrow (STM m)
-          , ProtocolLedgerView blk
-          )
+openDB :: forall m blk. (IOLike m, ProtocolLedgerView blk)
        => NodeConfig (BlockProtocol blk)
        -> ExtLedgerState blk
        -> m (ChainDB m blk)

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/API.hs
@@ -27,9 +27,9 @@ import           Data.Set (Set)
 import           Data.Word (Word64)
 import           GHC.Stack
 
-import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
-
 import           Control.Monad.Class.MonadThrow
+
+import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
 
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling,

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -13,8 +13,6 @@ module Ouroboros.Storage.ImmutableDB.API
   , module Ouroboros.Storage.ImmutableDB.Types
   ) where
 
-import           Control.Monad.Class.MonadThrow
-
 import           Cardano.Prelude (NoUnexpectedThunks (..), ThunkInfo (..))
 
 import           Data.ByteString.Builder (Builder)
@@ -25,6 +23,8 @@ import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 
 import           Pipes (Producer, lift, yield)
+
+import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.ImmutableDB.Types

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -151,8 +151,6 @@ import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
 import           Control.Exception (assert)
 import           Control.Monad (forM_, replicateM_, unless, when)
-import           Control.Monad.Class.MonadThrow (ExitCase (..),
-                     MonadCatch (generalBracket), MonadThrow, finally)
 import           Control.Monad.State.Strict (StateT (..), get, lift, modify,
                      put, runStateT, state)
 import           Control.Tracer (Tracer, traceWith)
@@ -174,8 +172,10 @@ import           Cardano.Prelude (NoUnexpectedThunks(..),
 
 import           GHC.Stack (HasCallStack, callStack)
 
+import           Control.Monad.Class.MonadThrow hiding (onException)
+
 import           Ouroboros.Consensus.Util (SomePair (..))
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.EpochInfo

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -275,7 +275,7 @@ data ClosedState m = ClosedState
 --
 -- __Note__: To be used in conjunction with 'withDB'.
 openDB
-  :: (HasCallStack, MonadSTM m, MonadCatch m, Eq hash)
+  :: (HasCallStack, IOLike m, Eq hash)
   => (forall s . Decoder s hash)
   -> (hash -> Encoding)
   -> HasFS m h
@@ -291,7 +291,7 @@ openDB = openDBImpl
   ImmutableDB Implementation
 ------------------------------------------------------------------------------}
 
-mkDBRecord :: (MonadSTM m, MonadCatch m, Eq hash)
+mkDBRecord :: (IOLike m, Eq hash)
            => ImmutableDBEnv m hash
            -> ImmutableDB hash m
 mkDBRecord dbEnv = ImmutableDB
@@ -309,7 +309,7 @@ mkDBRecord dbEnv = ImmutableDB
     }
 
 openDBImpl :: forall m h hash e.
-              (HasCallStack, MonadSTM m, MonadCatch m, Eq hash)
+              (HasCallStack, IOLike m, Eq hash)
            => (forall s . Decoder s hash)
            -> (hash -> Encoding)
            -> HasFS m h
@@ -330,7 +330,7 @@ openDBImpl hashDecoder hashEncoder hasFS@HasFS{..} err epochInfo valPol epochFil
     return db
 
 
-closeDBImpl :: (HasCallStack, MonadSTM m)
+closeDBImpl :: (HasCallStack, IOLike m)
             => ImmutableDBEnv m hash
             -> m ()
 closeDBImpl ImmutableDBEnv {..} = do
@@ -350,12 +350,12 @@ closeDBImpl ImmutableDBEnv {..} = do
   where
     HasFS{..} = _dbHasFS
 
-isOpenImpl :: MonadSTM m => ImmutableDBEnv m hash -> m Bool
+isOpenImpl :: IOLike m => ImmutableDBEnv m hash -> m Bool
 isOpenImpl ImmutableDBEnv {..} =
     dbIsOpen <$> atomically (readTMVar _dbInternalState)
 
 reopenImpl :: forall m hash.
-              (HasCallStack, MonadSTM m, MonadThrow m, Eq hash)
+              (HasCallStack, IOLike m, Eq hash)
            => ImmutableDBEnv m hash
            -> ValidationPolicy
            -> m ()
@@ -384,7 +384,7 @@ reopenImpl ImmutableDBEnv {..} valPol = do
 
 -- TODO close all iterators
 deleteAfterImpl :: forall m hash.
-                   (HasCallStack, MonadSTM m, MonadCatch m)
+                   (HasCallStack, IOLike m)
                 => ImmutableDBEnv m hash
                 -> ImmTip
                 -> m ()
@@ -485,7 +485,7 @@ deleteAfterImpl dbEnv@ImmutableDBEnv { _dbErr, _dbTracer } tip =
         truncateIndex relSlot =
             truncateToSlots (EpochSize (unRelativeSlot (succ relSlot)))
 
-getTipImpl :: (HasCallStack, MonadSTM m)
+getTipImpl :: (HasCallStack, IOLike m)
            => ImmutableDBEnv m hash
            -> m ImmTip
 getTipImpl dbEnv = do
@@ -493,7 +493,7 @@ getTipImpl dbEnv = do
     return _currentTip
 
 getBinaryBlobImpl
-  :: forall m hash. (HasCallStack, MonadSTM m, MonadCatch m)
+  :: forall m hash. (HasCallStack, IOLike m)
   => ImmutableDBEnv m hash
   -> SlotNo
   -> m (Maybe ByteString)
@@ -518,7 +518,7 @@ getBinaryBlobImpl dbEnv slot = withOpenState dbEnv $ \_dbHasFS st@OpenState{..} 
     ImmutableDBEnv { _dbErr } = dbEnv
 
 getEBBImpl
-  :: forall m hash. (HasCallStack, MonadSTM m, MonadCatch m)
+  :: forall m hash. (HasCallStack, IOLike m)
   => ImmutableDBEnv m hash
   -> EpochNo
   -> m (Maybe (hash, ByteString))
@@ -538,7 +538,7 @@ getEBBImpl dbEnv epoch = withOpenState dbEnv $ \_dbHasFS st@OpenState{..} -> do
 
 -- Preconditions: the given 'EpochSlot' is in the past.
 getEpochSlot
-  :: forall m hash h. (HasCallStack, MonadSTM m, MonadThrow m)
+  :: forall m hash h. (HasCallStack, IOLike m)
   => HasFS m h
   -> (forall s . Decoder s hash)
   -> OpenState m hash h
@@ -625,7 +625,7 @@ getEpochSlot _dbHasFS hashDecoder OpenState {..} _dbErr epochSlot = do
 
 
 appendBinaryBlobImpl :: forall m hash.
-                        (HasCallStack, MonadSTM m, MonadCatch m)
+                        (HasCallStack, IOLike m)
                      => ImmutableDBEnv m hash
                      -> SlotNo
                      -> Builder
@@ -695,7 +695,7 @@ appendBinaryBlobImpl dbEnv@ImmutableDBEnv{..} slot builder =
         , _currentTip = Tip (Right slot)
         }
 
-startNewEpoch :: (HasCallStack, MonadSTM m, MonadCatch m)
+startNewEpoch :: (HasCallStack, IOLike m)
               => (hash -> Encoding)
               -> HasFS m h
               -> StateT (OpenState m hash h) m ()
@@ -750,7 +750,7 @@ startNewEpoch hashEncoder hasFS@HasFS{..} = do
     put st
 
 appendEBBImpl :: forall m hash.
-                 (HasCallStack, MonadSTM m, MonadCatch m)
+                 (HasCallStack, IOLike m)
               => ImmutableDBEnv m hash
               -> EpochNo
               -> hash
@@ -868,7 +868,7 @@ data IteratorState hash h = IteratorState
   deriving (Generic, NoUnexpectedThunks)
 
 streamBinaryBlobsImpl :: forall m hash.
-                         (HasCallStack, MonadSTM m, MonadCatch m, Eq hash)
+                         (HasCallStack, IOLike m, Eq hash)
                       => ImmutableDBEnv m hash
                       -> Maybe (SlotNo, hash)
                       -- ^ When to start streaming (inclusive).
@@ -1069,7 +1069,7 @@ streamBinaryBlobsImpl dbEnv mbStart mbEnd = withOpenState dbEnv $ \hasFS st -> d
 
 
 iteratorNextImpl :: forall m hash.
-                    (MonadSTM m, MonadCatch m, Eq hash)
+                    (IOLike m, Eq hash)
                  => ImmutableDBEnv m hash
                  -> IteratorHandle hash m
                  -> Bool  -- ^ Step the iterator after reading iff True
@@ -1193,13 +1193,13 @@ iteratorNextImpl dbEnv it@IteratorHandle {_it_hasFS = hasFS :: HasFS m h, ..} st
                 , _it_epoch_index = index
                 }
 
-iteratorHasNextImpl :: (HasCallStack, MonadSTM m)
+iteratorHasNextImpl :: (HasCallStack, IOLike m)
                     => IteratorHandle hash m
                     -> m Bool
 iteratorHasNextImpl IteratorHandle { _it_state } =
     fmap isJust $ atomically $ readTVar _it_state
 
-iteratorCloseImpl :: (HasCallStack, MonadSTM m)
+iteratorCloseImpl :: (HasCallStack, IOLike m)
                   => IteratorHandle hash m
                   -> m ()
 iteratorCloseImpl IteratorHandle {..} = do
@@ -1330,7 +1330,7 @@ mkOpenStateNewEpoch HasFS{..} epoch epochInfo nextIteratorID tip = do
 -- instance for the /same/ type parameter @h@. Note that it would be impossible
 -- to use an existing 'HasFS' instance already in scope otherwise, since the
 -- @h@ parameters would not be known to match.
-getOpenState :: (HasCallStack, MonadSTM m)
+getOpenState :: (HasCallStack, IOLike m)
              => ImmutableDBEnv m hash
              -> m (SomePair (HasFS m) (OpenState m hash))
 getOpenState ImmutableDBEnv {..} = do
@@ -1355,7 +1355,7 @@ getOpenState ImmutableDBEnv {..} = do
 -- TODO(adn): we should really just use 'Control.Concurrent.MVar.MVar' rather
 -- than 'TMVar', but we currently don't have a simulator for code using
 -- @MVar@.
-modifyOpenState :: forall m hash r. (HasCallStack, MonadSTM m, MonadCatch m)
+modifyOpenState :: forall m hash r. (HasCallStack, IOLike m)
                 => ImmutableDBEnv m hash
                 -> (forall h. HasFS m h -> StateT (OpenState m hash h) m r)
                 -> m r
@@ -1417,7 +1417,7 @@ modifyOpenState ImmutableDBEnv {_dbHasFS = hasFS :: HasFS m h, ..} action = do
 -- In case an 'UnexpectedError' is thrown while the action is being run, the
 -- database is closed to prevent further appending to a database in a
 -- potentially inconsistent state.
-withOpenState :: forall m hash r. (HasCallStack, MonadSTM m, MonadCatch m)
+withOpenState :: forall m hash r. (HasCallStack, IOLike m)
               => ImmutableDBEnv m hash
               -> (forall h. HasFS m h -> OpenState m hash h -> m r)
               -> m r

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
@@ -38,7 +38,6 @@ import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
 import           Codec.CBOR.Write (toLazyByteString)
 import           Control.Exception (assert)
 import           Control.Monad (void, when)
-import           Control.Monad.Class.MonadThrow
 import           GHC.Generics (Generic)
 
 import           Data.Bifunctor (second)
@@ -50,7 +49,11 @@ import           Data.Word (Word64)
 
 import           GHC.Stack (HasCallStack, callStack)
 
+import           Control.Monad.Class.MonadThrow
+
 import           Cardano.Prelude (NoUnexpectedThunks (..))
+
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.FS.API (HasFS (..), hGetAll, hPut, hPutAll,
                      withFile)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Index.hs
@@ -53,8 +53,6 @@ import           Control.Monad.Class.MonadThrow
 
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 
-import           Ouroboros.Consensus.Util.IOLike
-
 import           Ouroboros.Storage.FS.API (HasFS (..), hGetAll, hPut, hPutAll,
                      withFile)
 import           Ouroboros.Storage.FS.API.Types (AllowExisting (..),

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
@@ -55,7 +55,7 @@ data DiskPolicy m = DiskPolicy {
     }
 
 -- | Default on-disk policy
-defaultDiskPolicy :: MonadSTM m
+defaultDiskPolicy :: IOLike m
                   => SecurityParam     -- ^ Maximum rollback
                   -> DiffTime          -- ^ Slot length
                   -> DiskPolicy m

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/DiskPolicy.hs
@@ -3,10 +3,10 @@ module Ouroboros.Storage.LedgerDB.DiskPolicy (
   , defaultDiskPolicy
   ) where
 
-import           Control.Monad.Class.MonadSTM
 import           Data.Time.Clock (DiffTime)
 
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+import           Ouroboros.Consensus.Util.IOLike
 
 -- | On-disk policy
 --

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -41,13 +41,13 @@ import           GHC.Generics (Generic)
 import           GHC.Stack
 import           Text.Read (readMaybe)
 
-import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadThrow
-
 import           Control.Tracer
+
+import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr,
                      readIncremental)
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -155,7 +155,7 @@ data InitLog r =
 -- /compute/ all subsequent ones. This is important, because the ledger states
 -- obtained in this way will (hopefully) share much of their memory footprint
 -- with their predecessors.
-initLedgerDB :: forall m h l r b e. (MonadST m, MonadThrow m, HasCallStack)
+initLedgerDB :: forall m h l r b e. (IOLike m, HasCallStack)
              => Tracer m (TraceReplayEvent r () r)
              -> Tracer m (TraceEvent r)
              -> HasFS m h
@@ -218,7 +218,7 @@ data InitFailure r =
 -- If the chain DB or ledger layer reports an error, the whole thing is aborted
 -- and an error is returned. This should not throw any errors itself (ignoring
 -- unexpected exceptions such as asynchronous exceptions, of course).
-initFromSnapshot :: forall m h l r b e. (MonadST m, MonadThrow m)
+initFromSnapshot :: forall m h l r b e. (IOLike m)
                  => Tracer m (TraceReplayEvent r () r)
                  -> HasFS m h
                  -> (forall s. Decoder s l)
@@ -315,7 +315,7 @@ nextAvailable [] = DiskSnapshot 1
 nextAvailable ss = let DiskSnapshot n = maximum ss in DiskSnapshot (n + 1)
 
 -- | Read snapshot from disk
-readSnapshot :: forall m l r h. (MonadST m, MonadThrow m)
+readSnapshot :: forall m l r h. (IOLike m)
              => HasFS m h
              -> (forall s. Decoder s l)
              -> (forall s. Decoder s r)

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
@@ -7,13 +7,14 @@ module Ouroboros.Storage.VolatileDB.API
   , module Ouroboros.Storage.VolatileDB.Types
   ) where
 
-import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadThrow
-
 import           Data.ByteString.Builder (Builder)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Set (Set)
 import           GHC.Stack (HasCallStack)
+
+import           Control.Monad.Class.MonadThrow
+
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.VolatileDB.Types
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
@@ -87,7 +87,6 @@ module Ouroboros.Storage.VolatileDB.Impl
     ) where
 
 import           Control.Monad
-import           Control.Monad.Class.MonadThrow
 import qualified Data.ByteString.Builder as BS
 import           Data.ByteString.Lazy (ByteString)
 import           Data.List (sortOn)
@@ -99,8 +98,10 @@ import qualified Data.Set as Set
 import           Data.Word (Word64)
 import           GHC.Stack
 
+import           Control.Monad.Class.MonadThrow
+
 import           Ouroboros.Consensus.Util (SomePair (..), safeMaximum)
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -6,7 +6,6 @@
 module Ouroboros.Storage.VolatileDB.Util where
 
 import           Control.Monad
-import           Control.Monad.Class.MonadThrow
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe)
@@ -16,8 +15,10 @@ import qualified Data.Text as T
 import           Data.Word (Word64)
 import           Text.Read (readMaybe)
 
+import           Control.Monad.Class.MonadThrow
+
 import           Ouroboros.Consensus.Util (safeMaximum, safeMaximumOn)
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -52,7 +52,7 @@ fromEither err = \case
     Left e -> EH.throwError err e
     Right a -> return a
 
-modifyTMVar :: (MonadSTM m, MonadCatch m)
+modifyTMVar :: IOLike m
             => StrictTMVar m a
             -> (a -> m (a,b))
             -> m b

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -22,13 +22,8 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork (MonadFork)
 import           Control.Monad.Class.MonadSay
-import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTime
-import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Network.TypedProtocol.Channel
@@ -61,7 +56,7 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.Condense
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..))
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -61,6 +61,7 @@ import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..))
 
 import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock
 
 {-------------------------------------------------------------------------------
@@ -201,14 +202,7 @@ newtype ServerUpdates =
 --
 -- Note that updates that are scheduled before the slot at which we start
 -- syncing help generate different chains to start syncing from.
-runChainSync :: forall m.
-       ( MonadAsync m
-       , MonadFork  m
-       , MonadMask  m
-       , MonadTimer m
-       , MonadThrow (STM m)
-       , MonadSay   m
-       )
+runChainSync :: forall m. (IOLike m, MonadSay m)
     => SecurityParam
     -> ClockSkew
     -> ClientUpdates

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -21,7 +21,6 @@ import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Control.Monad.Class.MonadAsync (MonadAsync)
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Control.Tracer (Tracer (..))
@@ -35,7 +34,7 @@ import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.Condense (condense)
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Test.Consensus.Mempool.TestBlock
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -30,10 +30,7 @@ import           Data.Typeable
 import qualified Generics.SOP as SOP
 import           GHC.Generics (Generic, Generic1)
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork hiding (fork)
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTimer
 
 import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
@@ -44,7 +41,7 @@ import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.Tasty hiding (after)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Test.Util.QSM

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -18,7 +18,6 @@ import qualified Data.Map as Map
 import           Data.Word (Word64)
 import           Test.QuickCheck
 
-import           Control.Monad.Class.MonadTime
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Ouroboros.Network.Block (HasHeader)
@@ -31,6 +30,7 @@ import           Ouroboros.Consensus.Protocol (LeaderSchedule (..))
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 
 import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.ResourceRegistry

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -45,6 +45,7 @@ import           Test.Dynamic.Util.NodeJoinPlan
 import           Test.Dynamic.Util.NodeTopology
 
 import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Orphans.IOLike ()
 import           Test.Util.Orphans.NoUnexpectedThunks ()
 import           Test.Util.Range
 

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -39,12 +39,7 @@ import           Data.Proxy (Proxy (..))
 import qualified Data.Typeable as Typeable
 import           GHC.Stack
 
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork (MonadFork)
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTime
-import           Control.Monad.Class.MonadTimer
 
 import           Network.TypedProtocol.Channel
 import           Network.TypedProtocol.Codec (AnyMessage (..))
@@ -77,7 +72,7 @@ import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.NodeKernel
 import           Ouroboros.Consensus.NodeNetwork
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.RedundantConstraints
 import           Ouroboros.Consensus.Util.ResourceRegistry

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -38,6 +38,7 @@ import qualified Ouroboros.Storage.FS.Sim.MockFS as Mock
 import           Test.Ouroboros.Storage.ChainDB.StateMachine (mkArgs)
 import           Test.Ouroboros.Storage.ChainDB.TestBlock
 
+import           Test.Util.Orphans.IOLike ()
 import           Test.Util.Orphans.NoUnexpectedThunks ()
 import           Test.Util.SOP
 
@@ -143,7 +144,7 @@ prop_addBlock_multiple_threads bpt =
   Auxiliary
 -------------------------------------------------------------------------------}
 
-mapConcurrently_ :: forall m a. MonadAsync m => (a -> m ()) -> [a] -> m ()
+mapConcurrently_ :: forall m a. IOLike m => (a -> m ()) -> [a] -> m ()
 mapConcurrently_ f = go
   where
     go :: [a] -> m ()

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -14,7 +14,6 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Control.Monad.Class.MonadAsync
 import           Control.Monad.IOSim
 
 import           Control.Tracer
@@ -27,7 +26,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util (chunks)
 import           Ouroboros.Consensus.Util.Condense (condense)
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.ChainDB (TraceAddBlockEvent (..), addBlock,

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -11,7 +11,6 @@ module Test.Ouroboros.Storage.ChainDB.ImmDB
 import           Data.Proxy (Proxy (..))
 import           Data.Reflection (give)
 
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.IOSim (runSimOrThrow)
 
@@ -32,7 +31,7 @@ import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
 import           Ouroboros.Consensus.Node.Run (RunNode (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB, ImmDbArgs (..))
 import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -45,6 +45,8 @@ import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
+import           Test.Util.Orphans.IOLike ()
+
 import qualified Test.Cardano.Chain.Genesis.Dummy as Dummy
 
 
@@ -63,9 +65,7 @@ test_getBlockWithPoint_EBB_at_tip =
     ebb = giveByron $ forgeGenesisEBB testCfg (SlotNo 0)
 
 withImmDB :: forall m blk a.
-             ( MonadCatch m
-             , MonadST    m
-             , MonadSTM   m
+             ( IOLike m
              , ByronGiven
              , blk ~ ByronBlockOrEBB ByronConfig
              )

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -25,7 +25,7 @@ import           Ouroboros.Network.MockChain.Chain (Chain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
 import           Ouroboros.Consensus.Util.Condense (condense)
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.ChainDB.API (Iterator (..), IteratorId (..),

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -16,7 +16,6 @@ import           Data.List (intercalate)
 import qualified Data.Map.Strict as Map
 import           Data.Word (Word64)
 
-import           Control.Monad.Class.MonadThrow
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Ouroboros.Network.Block (ChainHash (..), HasHeader (..),
@@ -43,6 +42,7 @@ import qualified Ouroboros.Storage.ImmutableDB as ImmDB
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import qualified Ouroboros.Storage.VolatileDB as VolDB
 
+import           Test.Util.Orphans.IOLike ()
 import           Test.Util.Tracer (recordingTracerTVar)
 
 import           Test.Ouroboros.Storage.ChainDB.TestBlock
@@ -246,11 +246,7 @@ runIterator setup from to = runSimOrThrow $ withRegistry $ \r -> do
 -------------------------------------------------------------------------------}
 
 initIteratorEnv
-  :: forall m.
-     ( MonadSTM   m
-     , MonadCatch m
-     , MonadThrow (STM m)
-     )
+  :: forall m. IOLike m
   => TestSetup
   -> Tracer m (TraceIteratorEvent TestBlock)
   -> m (IteratorEnv m TestBlock)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -8,15 +8,13 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim
 
 import           Ouroboros.Network.MockChain.Chain (Chain (..), ChainUpdate)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.ChainDB.API (ChainDB)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -21,6 +21,8 @@ import           Ouroboros.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Storage.ChainDB.API as ChainDB
 import qualified Ouroboros.Storage.ChainDB.Mock as Mock
 
+import           Test.Util.Orphans.IOLike ()
+
 import           Test.Ouroboros.Storage.ChainDB.TestBlock
 
 tests :: TestTree

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -204,7 +204,7 @@ deriving instance (TestConstraints blk, Eq   it, Eq   rdr)
 deriving instance (TestConstraints blk, Show it, Show rdr)
                => Show (Success blk it rdr)
 
-run :: forall m blk. (MonadSTM m, MonadAsync m)
+run :: forall m blk. (IOLike m)
     => ChainDB          m blk
     -> ChainDB.Internal m blk
     -> ResourceRegistry m
@@ -1158,7 +1158,7 @@ traceEventName = \case
     TraceLedgerReplayEvent   ev    -> "LedgerReplay." <> constrName ev
     TraceImmDBEvent          ev    -> "ImmDB."        <> constrName ev
 
-mkArgs :: (MonadSTM m, MonadCatch m, MonadThrow (STM m))
+mkArgs :: IOLike m
        => NodeConfig (BlockProtocol Blk)
        -> ExtLedgerState Blk
        -> Tracer m (TraceEvent Blk)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -52,9 +52,7 @@ import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadThrow
-
 import           Control.Tracer
 
 import           Cardano.Crypto.DSIGN.Mock
@@ -79,7 +77,7 @@ import           Ouroboros.Consensus.NodeId (NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util.Condense (condense)
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike hiding (fork)
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..))
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -8,8 +8,6 @@
 module Test.Ouroboros.Storage.ImmutableDB (tests) where
 
 import qualified Codec.Serialise as S
-import           Control.Monad.Class.MonadSTM (MonadSTM)
-import           Control.Monad.Class.MonadThrow (MonadCatch)
 import           Control.Tracer (nullTracer)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -18,6 +16,8 @@ import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import           Data.Maybe (maybeToList)
 import           Data.Word (Word64)
+
+import           Control.Monad.Class.MonadThrow hiding (try)
 
 import qualified Test.Ouroboros.Storage.ImmutableDB.CumulEpochSizes as CumulEpochSizes
 import qualified Test.Ouroboros.Storage.ImmutableDB.StateMachine as StateMachine
@@ -30,6 +30,8 @@ import           Test.QuickCheck.Monadic (monadicIO, run)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck (testProperty)
+
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.EpochInfo

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -17,8 +17,6 @@ import qualified Data.List.NonEmpty as NE
 import           Data.Maybe (maybeToList)
 import           Data.Word (Word64)
 
-import           Control.Monad.Class.MonadThrow hiding (try)
-
 import qualified Test.Ouroboros.Storage.ImmutableDB.CumulEpochSizes as CumulEpochSizes
 import qualified Test.Ouroboros.Storage.ImmutableDB.StateMachine as StateMachine
 import           Test.Ouroboros.Storage.ImmutableDB.TestBlock hiding (tests)
@@ -84,7 +82,7 @@ fixedEpochSize = 10
 type Hash = TestBlock
 
 -- Shorthand
-openTestDB :: (HasCallStack, MonadSTM m, MonadCatch m)
+openTestDB :: (HasCallStack, IOLike m)
            => HasFS m h
            -> ErrorHandling ImmutableDBError m
            -> m (ImmutableDB Hash m)
@@ -94,7 +92,7 @@ openTestDB hasFS err =
     parser = TestBlock.testBlockEpochFileParser' hasFS
 
 -- Shorthand
-withTestDB :: (HasCallStack, MonadSTM m, MonadCatch m)
+withTestDB :: (HasCallStack, IOLike m)
            => HasFS m h
            -> ErrorHandling ImmutableDBError m
            -> (ImmutableDB Hash m -> m a)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -8,9 +8,9 @@ import           Control.Monad.State (StateT, runStateT)
 import           Data.Proxy
 
 import           Control.Monad.Class.MonadThrow
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 
 import           Ouroboros.Consensus.Util ((..:), (.:))
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.Common (EpochNo, EpochSize)
 import           Ouroboros.Storage.ImmutableDB.API

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -21,8 +21,7 @@ import           Test.Ouroboros.Storage.ImmutableDB.Model
 
 type MockM hash = StateT (DBModel hash) (Except ImmutableDBError)
 
-openDBMock  :: forall m hash.
-               (MonadSTM m, MonadThrow (STM m), Eq hash)
+openDBMock  :: forall m hash. (IOLike m, Eq hash)
             => ErrorHandling ImmutableDBError m
             -> (EpochNo -> EpochSize)
             -> m (DBModel hash, ImmutableDB hash m)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -42,7 +42,7 @@ import           Data.TreeDiff.Class (ToExpr (..))
 import           Data.Typeable (Typeable)
 import           Data.Word (Word64)
 
-import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadThrow hiding (try)
 
 import qualified Generics.SOP as SOP
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -20,19 +20,17 @@ import           Prelude hiding (elem, notElem)
 
 import           Codec.Serialise (decode, encode)
 import           Control.Monad (forM_, when)
-import           Control.Monad.Class.MonadThrow (MonadCatch)
 import           Control.Monad.Except (ExceptT (..), runExceptT)
 import           Control.Monad.State.Strict (MonadState, State, evalState, gets,
                      modify, put, runState)
 import           Control.Tracer (nullTracer)
-import           Data.Functor.Identity
-
 import           Data.Bifunctor (first)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Coerce (Coercible, coerce)
 import           Data.Foldable (toList)
 import           Data.Function (on)
 import           Data.Functor.Classes (Eq1, Show1)
+import           Data.Functor.Identity
 import           Data.List (sortBy)
 import qualified Data.List.NonEmpty as NE
 import           Data.Map (Map)
@@ -43,6 +41,8 @@ import           Data.TreeDiff (Expr (App))
 import           Data.TreeDiff.Class (ToExpr (..))
 import           Data.Typeable (Typeable)
 import           Data.Word (Word64)
+
+import           Control.Monad.Class.MonadThrow
 
 import qualified Generics.SOP as SOP
 
@@ -64,7 +64,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 import           Text.Show.Pretty (ppShow)
 
 import qualified Ouroboros.Consensus.Util.Classify as C
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Network.Block (SlotNo (..))
 
@@ -78,7 +78,6 @@ import           Ouroboros.Storage.ImmutableDB
 import           Ouroboros.Storage.ImmutableDB.Layout
 import           Ouroboros.Storage.ImmutableDB.Util (renderFile, tryImmDB)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
-
 
 import           Test.Ouroboros.Storage.FS.Sim.Error (Errors, mkSimErrorHasFS,
                      withErrors)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
@@ -25,7 +25,6 @@ module Test.Ouroboros.Storage.ImmutableDB.TestBlock
 
 import           Codec.Serialise (Serialise)
 import           Control.Monad (forM, replicateM, void, when)
-import           Control.Monad.Class.MonadThrow
 
 import qualified Data.Binary as Bin
 import qualified Data.Binary.Get as Bin
@@ -41,11 +40,15 @@ import           Data.Word (Word64)
 
 import           GHC.Generics (Generic)
 
+import           Control.Monad.Class.MonadThrow
+
 import           Test.QuickCheck
 import qualified Test.QuickCheck.Monadic as QCM
 import qualified Test.StateMachine.Utils as QSM
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
+
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API (HasFS (..), hGetAll, hPut, withFile)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/TestBlock.hs
@@ -48,8 +48,6 @@ import qualified Test.StateMachine.Utils as QSM
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Ouroboros.Consensus.Util.IOLike
-
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API (HasFS (..), hGetAll, hPut, withFile)
 import           Ouroboros.Storage.FS.API.Types

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -49,10 +49,8 @@ import           Data.Word
 import           GHC.Generics (Generic)
 import           System.Random (getStdRandom, randomR)
 
-import           Control.Tracer (nullTracer)
-
-import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
+import           Control.Tracer (nullTracer)
 
 import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
@@ -67,7 +65,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 import           Ouroboros.Consensus.Util
 import qualified Ouroboros.Consensus.Util.Classify as C
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
@@ -6,7 +6,7 @@ module Test.Ouroboros.Storage.VolatileDB.Mock (openDBMock) where
 import           Control.Monad.State (StateT)
 
 import           Ouroboros.Consensus.Util ((.:))
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.STM (simStateT)
 
 import           Ouroboros.Storage.Util.ErrorHandling (ThrowCantCatch)
@@ -15,8 +15,7 @@ import           Ouroboros.Storage.VolatileDB.API
 
 import           Test.Ouroboros.Storage.VolatileDB.Model
 
-openDBMock  :: forall m blockId.
-               MonadSTM m
+openDBMock  :: forall m blockId. IOLike m
             => (Ord blockId)
             => ThrowCantCatch (VolatileDBError blockId) (STM m)
             -> Int

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -22,7 +22,6 @@ module Test.Ouroboros.Storage.VolatileDB.StateMachine
 
 import           Prelude hiding (elem)
 
-import           Control.Monad.Class.MonadThrow (MonadCatch)
 import           Control.Monad.Except
 import           Control.Monad.State
 import           Data.Bifunctor (bimap)
@@ -51,9 +50,11 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 import           Text.Show.Pretty (ppShow)
 
+import           Control.Monad.Class.MonadThrow hiding (try)
+
 import           Ouroboros.Consensus.Util (SomePair (..))
 import qualified Ouroboros.Consensus.Util.Classify as C
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/TestBlock.hs
@@ -7,8 +7,6 @@
 module Test.Ouroboros.Storage.VolatileDB.TestBlock where
 
 import           Control.Monad (forM)
-import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadThrow (MonadThrow)
 import qualified Data.Binary as Binary
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as BB
@@ -19,7 +17,11 @@ import           Data.Serialize
 import           Data.Word (Word64)
 import           Test.QuickCheck
 
+import           Control.Monad.Class.MonadThrow
+
 import           Ouroboros.Consensus.Util (SomePair (..))
+import           Ouroboros.Consensus.Util.IOLike
+
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API (HasFS (..), hGetExactly, hPut,
                      withFile)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/TestBlock.hs
@@ -143,7 +143,7 @@ corruptFile hasFS@HasFS{..} corr file = case corr of
         return $ fileSize /= newFileSize
 
 
-createFileImpl :: (MonadSTM m, MonadThrow m)
+createFileImpl :: IOLike m
                => HasFS m h
                -> Internal.VolatileDBEnv m blockId
                -> m ()

--- a/ouroboros-consensus/test-util/Test/Util/Orphans/IOLike.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Orphans/IOLike.hs
@@ -1,0 +1,7 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Test.Util.Orphans.IOLike () where
+
+import           Control.Monad.IOSim
+import           Ouroboros.Consensus.Util.IOLike
+
+instance IOLike (SimM s)

--- a/ouroboros-consensus/test-util/Test/Util/Orphans/IOLike.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Orphans/IOLike.hs
@@ -3,5 +3,6 @@ module Test.Util.Orphans.IOLike () where
 
 import           Control.Monad.IOSim
 import           Ouroboros.Consensus.Util.IOLike
+import           Test.Util.Orphans.NoUnexpectedThunks ()
 
 instance IOLike (SimM s)


### PR DESCRIPTION
This consists of two commits:

* The first introduces `Ouroboros.Consensus.Util.IOLike`, but simply re-exports all the `Control.Monad.Class.*` classes from there; the goal here is to simply re-route the imports, but not maky any real change.
* The second then _hides_ a lot of those classes, instead introducing `IOLike` as a new monad, and then updates the code accordingly. 