### PR TITLE
Add subdirs for cardano-shell in stack.yaml

### DIFF
--- a/nix/.stack.nix/cardano-shell.nix
+++ b/nix/.stack.nix/cardano-shell.nix
@@ -43,13 +43,6 @@
             (hsPkgs.cardano-prelude)
             ];
           };
-        "daedalus-ipc" = {
-          depends = [
-            (hsPkgs.base)
-            (hsPkgs.cardano-shell)
-            (hsPkgs.cardano-prelude)
-            ];
-          };
         };
       tests = {
         "cardano-shell-test" = {
@@ -65,16 +58,14 @@
             (hsPkgs.tree-diff)
             (hsPkgs.hspec)
             ];
-          build-tools = [
-            (hsPkgs.buildPackages.cardano-shell or (pkgs.buildPackages.cardano-shell))
-            ];
           };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-shell";
-      rev = "812a36b8d6714cf76ca3576bdac903bedd88a72b";
-      sha256 = "0qqw8dx2bcbj0mbciyh0jja915li0yimc42a0bjpfp5v3cq5i7cn";
+      rev = "8b8437fa2c0cd7e0c1f0ee94ae1565dbcf5617d0";
+      sha256 = "18mq0cq5miy6ls60nfp7crh6l72qgdcvv4fsqfcwiv4sqwc5k3mg";
       });
+    postUnpack = "sourceRoot+=/cardano-shell; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -37,6 +37,7 @@
         cardano-crypto-test = ./cardano-crypto-test.nix;
         cardano-prelude = ./cardano-prelude.nix;
         cardano-prelude-test = ./cardano-prelude-test.nix;
+        cardano-shell = ./cardano-shell.nix;
         cardano-sl-x509 = ./cardano-sl-x509.nix;
         cardano-crypto = ./cardano-crypto.nix;
         };

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,6 +41,8 @@ extra-deps:
 
   - git: https://github.com/input-output-hk/cardano-shell
     commit: 8b8437fa2c0cd7e0c1f0ee94ae1565dbcf5617d0
+    subdirs:
+      - cardano-shell
 
   - git: https://github.com/input-output-hk/cardano-sl-x509
     commit: 43a036c5bbe68ca2e9cbe611eab7982e2348fe49


### PR DESCRIPTION
The `cardano-shell` package was recently moved in to a subdirectory in the repo. This needs to be reflected in `stack.yaml` (for stack users :smile:).