### PR TITLE
ChainSync Client: trimming and refactoring 

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -283,6 +283,7 @@ test-suite test-consensus
                     Test.Util.TestBlock
                     Test.Util.QSM
                     Test.Util.SOP
+                    Test.Util.Tracer
   build-depends:    base,
                     cardano-binary,
                     cardano-crypto-class,

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -2,10 +2,12 @@
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DuplicateRecordFields      #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiWayIf                 #-}
 {-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeFamilies               #-}
@@ -17,8 +19,10 @@ module Ouroboros.Consensus.ChainSyncClient (
   , chainSyncClient
   , bracketChainSyncClient
   , ChainSyncClientException (..)
+  , ChainDbView (..)
   , ClockSkew (..)
-  , CandidateState (..)
+  , Our (..)
+  , Their (..)
     -- * Trace events
   , TraceChainSyncClientEvent (..)
   ) where
@@ -29,14 +33,12 @@ import           Control.Tracer
 import           Data.List (find)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (isJust)
 import           Data.Typeable (Typeable)
 import           Data.Void (Void)
 import           Data.Word (Word64)
-import           GHC.Generics (Generic)
 
 import           Control.Monad.Class.MonadThrow
-
-import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Network.TypedProtocol.Pipelined
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
@@ -70,16 +72,22 @@ newtype ClockSkew = ClockSkew { unClockSkew :: Word64 }
 type Consensus (client :: * -> * -> (* -> *) -> * -> *) blk tip m =
    client (Header blk) tip m Void
 
--- | The state of the candidate chain synched with an upstream node.
-data CandidateState blk = CandidateState
-    { candidateChain      :: !(AnchoredFragment (Header blk))
-    , candidateChainState :: !(ChainState (BlockProtocol blk))
-      -- ^ 'ChainState' corresponding to the tip (most recent block) of the
-      -- 'candidateChain'.
-    }
-  deriving (Generic)
+-- | Abstract over the ChainDB
+data ChainDbView m blk tip = ChainDbView
+  { getCurrentChain   :: STM m (AnchoredFragment (Header blk))
+  , getCurrentLedger  :: STM m (ExtLedgerState blk)
+  , getOurTip         :: STM m tip
+  , getIsInvalidBlock :: STM m (HeaderHash blk -> Bool, Fingerprint)
+  }
 
-deriving instance SupportedBlock blk => NoUnexpectedThunks (CandidateState blk)
+-- newtype wrappers to avoid confusing our tip with their tip.
+newtype Their a = Their { unTheir :: a }
+  deriving stock   (Eq)
+  deriving newtype (Show)
+
+newtype Our   a = Our   { unOur   :: a }
+  deriving stock   (Eq)
+  deriving newtype (Show)
 
 bracketChainSyncClient
     :: ( IOLike m
@@ -89,44 +97,120 @@ bracketChainSyncClient
        , Show tip
        )
     => Tracer m (TraceChainSyncClientEvent blk tip)
-    -> STM m (AnchoredFragment (Header blk))
-       -- ^ Get the current chain
-    -> STM m (ExtLedgerState blk)
-       -- ^ Get the current ledger state
-    -> STM m (HeaderHash blk -> Bool, Fingerprint)
-       -- ^ Get the invalid block checker
-    -> StrictTVar m (Map peer (StrictTVar m (CandidateState blk)))
+    -> ChainDbView m blk tip
+    -> StrictTVar m (Map peer (StrictTVar m (AnchoredFragment (Header blk))))
        -- ^ The candidate chains, we need the whole map because we
        -- (de)register nodes (@peer@).
     -> peer
-    -> (StrictTVar m (CandidateState blk) -> AnchoredFragment (Header blk) -> m a)
+    -> (    StrictTVar m (AnchoredFragment (Header blk))
+         -> m a
+       )
     -> m a
-bracketChainSyncClient tracer getCurrentChain getCurrentLedger
-                       getIsInvalidBlock varCandidates peer body =
+bracketChainSyncClient tracer ChainDbView { getIsInvalidBlock } varCandidates
+                       peer body =
     withRegistry $ \registry ->
-      bracket register unregister $ \(varCandidate, curChain) -> do
+      bracket register unregister $ \varCandidate -> do
         rejectInvalidBlocks
           tracer
           registry
           getIsInvalidBlock
           (readTVar varCandidate)
-        body varCandidate curChain
+        body varCandidate
   where
     register = do
-      (curChain, curChainState) <- atomically $ (,)
-        <$> getCurrentChain
-        <*> (ouroborosChainState <$> getCurrentLedger)
-      varCandidate <- uncheckedNewTVarM CandidateState
-        { candidateChain       = curChain
-        , candidateChainState  = curChainState
-        }
+      varCandidate <- uncheckedNewTVarM $ AF.Empty GenesisPoint
       atomically $ modifyTVar varCandidates $ Map.insert peer varCandidate
-      -- We use our current chain, which contains the last @k@ headers, as
-      -- the initial chain for the candidate.
-      return (varCandidate, curChain)
+      return varCandidate
 
     unregister _ = do
       atomically $ modifyTVar varCandidates $ Map.delete peer
+
+-- Our task: after connecting to an upstream node, try to maintain an
+-- up-to-date header-only fragment representing their chain. We maintain
+-- such candidate chains in a map with upstream nodes as keys.
+--
+-- The block fetch logic will use these candidate chains to download
+-- blocks from, prioritising certain candidate chains over others using
+-- the consensus protocol. Whenever such a block has been downloaded and
+-- added to the local 'ChainDB', the 'ChainDB' will perform chain
+-- selection.
+--
+-- We also validate the headers of a candidate chain by advancing the
+-- 'ChainState' with the headers, which returns an error when validation
+-- failed. Thus, in addition to the chain fragment of each candidate, we
+-- also store a 'ChainState' corresponding to the head of the candidate
+-- chain.
+--
+-- We must keep the candidate chain synchronised with the corresponding
+-- upstream chain. The upstream node's chain might roll forward or
+-- backwards, and they will inform us about this. When we get these
+-- messages, we will replicate these actions on our candidate chain.
+--
+-- INVARIANT:
+--
+-- >           our tip
+-- >             v
+-- >   /--* .... *
+-- >   |
+-- > --*
+-- >   |
+-- >   \--* .... *
+-- >        fragment tip
+--
+-- The distance from our tip to the intersection between our chain and the
+-- fragment maintained for the upstream node cannot exceed @k@ blocks. When
+-- this invariant cannot be maintained, the upstream node is on a fork that
+-- is too distant and we should disconnect.
+--
+-- TODO #423 rate-limit switching chains, otherwise we can't place blame (we
+-- don't know which candidate's chain included the point that was
+-- poisoned). E.g. two rollbacks per time slot -> make it configurable ->
+-- just a simple argument for now.
+--
+-- TODO #467 if the 'theirTip' that they sent us is on our chain, just
+-- switch to it.
+
+-- | State used when the intersection between the candidate and the current
+-- chain is unknown.
+data UnknownIntersectionState blk tip = UnknownIntersectionState
+  { ourFrag       :: !(AnchoredFragment (Header blk))
+    -- ^ A view of the current chain fragment. Note that this might be
+    -- temporarily out of date w.r.t. the actual current chain until we update
+    -- it again.
+    --
+    -- This fragment is used to select points from to find an intersection
+    -- with the candidate.
+    --
+    -- INVARIANT: 'ourFrag' contains @k@ headers, unless close to genesis.
+  , ourChainState :: !(ChainState (BlockProtocol blk))
+    -- ^ 'ChainState' corresponding to the tip (most recent block) of
+    -- 'ourFrag'.
+  , ourTip        :: !(Our tip)
+    -- ^ INVARIANT: must correspond to the tip of 'ourFrag'.
+  }
+
+-- | State used when the intersection between the candidate and the current
+-- chain is known.
+data KnownIntersectionState blk tip = KnownIntersectionState
+  { theirFrag       :: !(AnchoredFragment (Header blk))
+    -- ^ The candidate, the synched fragment of their chain.
+  , theirChainState :: !(ChainState (BlockProtocol blk))
+    -- ^ 'ChainState' corresponding to the tip (most recent block) of
+    -- 'theirFrag'.
+  , ourFrag         :: !(AnchoredFragment (Header blk))
+    -- ^ A view of the current chain fragment used to maintain the invariants
+    -- with. Note that this might be temporarily out of date w.r.t. the actual
+    -- current chain until we update it again.
+    --
+    -- INVARIANT: 'ourFrag' contains @k@ headers, unless close to genesis.
+    --
+    -- INVARIANT: 'theirFrag' and 'ourFrag' have the same anchor point. From
+    -- this follows that both fragments intersect. This also means that
+    -- 'theirFrag' forks off within the last @k@ headers/blocks of the
+    -- 'ourFrag'.
+  , ourTip          :: !(Our tip)
+    -- ^ INVARIANT: must correspond to the tip of 'ourFrag'.
+  }
 
 -- | Chain sync client
 --
@@ -144,225 +228,271 @@ chainSyncClient
     -> Tracer m (TraceChainSyncClientEvent blk tip)
     -> NodeConfig (BlockProtocol blk)
     -> BlockchainTime m
-    -> ClockSkew                                    -- ^ Maximum clock skew
-    -> STM m (ExtLedgerState blk)                   -- ^ Get the current ledger state
-    -> STM m (HeaderHash blk -> Bool, Fingerprint)  -- ^ Get the invalid block checker
-    -> STM m BlockNo                                -- ^ Get the BlockNo of our current tip
-    -> StrictTVar m (CandidateState blk)            -- ^ Our peer's state var
-    -> AnchoredFragment (Header blk)                -- ^ The current chain
+    -> ClockSkew   -- ^ Maximum clock skew
+    -> ChainDbView m blk tip
+    -> StrictTVar m (AnchoredFragment (Header blk))
     -> Consensus ChainSyncClientPipelined blk tip m
-chainSyncClient mkPipelineDecision0
-                 tipBlockNo
-                 tracer cfg btime (ClockSkew maxSkew)
-                 getCurrentLedger getIsInvalidBlock getTipBlockNo varCandidate =
-    \curChain -> ChainSyncClientPipelined (initialise curChain)
+chainSyncClient mkPipelineDecision0 getTipBlockNo tracer cfg btime
+                (ClockSkew maxSkew)
+                ChainDbView
+                { getCurrentChain
+                , getCurrentLedger
+                , getOurTip
+                , getIsInvalidBlock
+                }
+                varCandidate = ChainSyncClientPipelined initialise
   where
-    -- Our task: after connecting to an upstream node, try to maintain an
-    -- up-to-date header-only fragment representing their chain. We maintain
-    -- such candidate chains in a map with upstream nodes as keys.
-    --
-    -- The block fetch logic will use these candidate chains to download
-    -- blocks from, prioritising certain candidate chains over others using
-    -- the consensus protocol. Whenever such a block has been downloaded and
-    -- added to the local 'ChainDB', the 'ChainDB' will perform chain
-    -- selection.
-    --
-    -- We also validate the headers of a candidate chain by advancing the
-    -- 'ChainState' with the headers, which returns an error when validation
-    -- failed. Thus, in addition to the chain fragment of each candidate, we
-    -- also store a 'ChainState' corresponding to the head of the candidate
-    -- chain.
-    --
-    -- We must keep the candidate chain synchronised with the corresponding
-    -- upstream chain. The upstream node's chain might roll forward or
-    -- backwards, and they will inform us about this. When we get these
-    -- messages, we will replicate these actions on our candidate chain.
-    --
-    -- INVARIANT:
-    --
-    -- >           our tip
-    -- >             v
-    -- >   /--* .... *
-    -- >   |
-    -- > --*
-    -- >   |
-    -- >   \--* .... *
-    -- >        fragment tip
-    --
-    -- The distance from our tip to the intersection between our chain and the
-    -- fragment maintained for the upstream node cannot exceed @k@ blocks. When
-    -- this invariant cannot be maintained, the upstream node is on a fork that
-    -- is too distant and we should disconnect.
-    --
-    -- TODO #579 Simplification for now: we don't maintain the above invariant
-    -- yet. Additionally, we don't monitor our current chain in order to find
-    -- a better intersection point either.
-    --
-    -- TODO #465 Simplification for now: we don't trim candidate chains, so
-    -- they might grow indefinitely.
-    --
-    -- TODO #423 rate-limit switching chains, otherwise we can't place blame (we
-    -- don't know which candidate's chain included the point that was
-    -- poisoned). E.g. two rollbacks per time slot -> make it configurable ->
-    -- just a simple argument for now.
-    --
-    -- TODO #467 if the 'theirHead' that they sent us is on our chain, just
-    -- switch to it.
-    --
-    -- TODO split in two parts: one requiring only the @TVar@ for the
-    -- candidate instead of the whole map.
-    initialise :: AnchoredFragment (Header blk)
-               -> m (Consensus (ClientPipelinedStIdle Z) blk tip m)
-    initialise curChain = do
+    -- | Start ChainSync by looking for an intersection between our current
+    -- chain fragment and their chain.
+    initialise :: m (Consensus (ClientPipelinedStIdle Z) blk tip m)
+    initialise = atomically $ findIntersection (ForkTooDeep GenesisPoint)
+
+    -- | Try to find an intersection by sending points of our current chain to
+    -- the server, if any of them intersect with their chain, roll back our
+    -- chain to that point and start synching using that fragment. If none
+    -- intersect, disconnect by throwing the exception obtained by calling the
+    -- passed function.
+    findIntersection
+      :: (Our tip -> Their tip -> ChainSyncClientException blk tip)
+         -- ^ Exception to throw when no intersection is found.
+      -> STM m (Consensus (ClientPipelinedStIdle Z) blk tip m)
+    findIntersection mkEx = do
+      ourFrag       <- getCurrentChain
+      ourChainState <- ouroborosChainState <$> getCurrentLedger
+      ourTip        <- Our <$> getOurTip
       -- We select points from the last @k@ headers of our current chain. This
       -- means that if an intersection is found for one of these points, it
       -- was an intersection within the last @k@ blocks of our current chain.
       -- If not, we could never switch to this candidate chain anyway.
-      --
-      -- TODO #465 However, by the time we get a response about an
-      -- intersection, our chain might have changed already and it could be
-      -- that the intersection is now more than @k@ blocks in the past, which
-      -- means the candidate is no longer eligible after all.
-      let points = AF.selectPoints (map fromIntegral offsets) curChain
+      let maxOffset = fromIntegral (AF.length ourFrag)
+          points    = AF.selectPoints
+                        (map fromIntegral (offsets maxOffset))
+                        ourFrag
+          uis = UnknownIntersectionState
+            { ourFrag       = ourFrag
+            , ourChainState = ourChainState
+            , ourTip        = ourTip
+            }
       return $ SendMsgFindIntersect points $ ClientPipelinedStIntersect
-        { recvMsgIntersectFound    = intersectFound . castPoint
-        , recvMsgIntersectNotFound = intersectNotFound
+        { recvMsgIntersectFound    = \i theirTip' ->
+            intersectFound uis (castPoint i) (Their theirTip')
+        , recvMsgIntersectNotFound = \theirTip'   -> traceException $
+            atomically $ disconnect $ mkEx ourTip (Their theirTip')
         }
 
-    -- One of the points we sent intersected our chain. This intersection
+    -- | One of the points we sent intersected our chain. This intersection
     -- point will become the new tip of the candidate chain.
-    intersectFound :: Point blk  -- ^ Intersection
-                   -> tip        -- ^ Their head
+    intersectFound :: UnknownIntersectionState blk tip
+                   -> Point blk  -- ^ Intersection
+                   -> Their tip
                    -> m (Consensus (ClientPipelinedStIdle Z) blk tip m)
-    intersectFound intersection theirHead = traceException $ atomically $ do
+    intersectFound UnknownIntersectionState
+                   { ourFrag
+                   , ourChainState
+                   , ourTip = ourTip
+                   }
+                   intersection theirTip = do
+      traceWith tracer $ TraceFoundIntersection intersection ourTip theirTip
+      traceException $ atomically $ do
+        -- Roll back the current chain fragment to the @intersection@.
+        --
+        -- While the primitives in the ChainSync protocol are "roll back",
+        -- "roll forward (apply block)", etc. The /real/ primitive is "switch
+        -- to fork", which means that a roll back is always followed by
+        -- applying at least as many blocks that we rolled back.
+        --
+        -- This is important for 'rewindChainState', which can only roll back
+        -- up to @k@ blocks, /once/, i.e., we cannot keep rolling back the
+        -- same chain state multiple times, because that would mean that we
+        -- store the chain state for the /whole chain/, all the way to
+        -- genesis.
+        --
+        -- So the rewind below is fine when we are switching to a fork (i.e.
+        -- it is followed by rolling forward again), but we need some
+        -- guarantees that the ChainSync protocol /does/ in fact give us a
+        -- switch-to-fork instead of a true rollback.
+        (theirFrag, theirChainState) <-
+          case (,) <$> AF.rollback (castPoint intersection) ourFrag
+                   <*> rewindChainState cfg ourChainState (pointSlot intersection)
+          of
+            Just (c, d) -> return (c, d)
+            -- The @intersection@ is not on the candidate chain, even though
+            -- we sent only points from the candidate chain to find an
+            -- intersection with. The node must have sent us an invalid
+            -- intersection point.
+            Nothing     -> disconnect InvalidIntersection
+              { _intersection = intersection
+              , _ourTip       = ourTip
+              , _theirTip     = theirTip
+              }
+        writeTVar varCandidate theirFrag
+        let kis = KnownIntersectionState
+              { theirFrag       = theirFrag
+              , theirChainState = theirChainState
+              , ourFrag         = ourFrag
+              , ourTip          = ourTip
+              }
+        nextStep kis mkPipelineDecision0 Zero theirTip
 
-      CandidateState { candidateChain, candidateChainState } <- readTVar varCandidate
-      -- Roll back the candidate to the @intersection@.
-      --
-      -- While the primitives in the ChainSync protocol are "roll back", "roll
-      -- forward (apply block)", etc. The /real/ primitive is "switch to
-      -- fork", which means that a roll back is always followed by applying at
-      -- least as many blocks that we rolled back.
-      --
-      -- This is important for 'rewindChainState', which can only roll back up
-      -- to @k@ blocks, /once/, i.e., we cannot keep rolling back the same
-      -- chain state multiple times, because that would mean that we store the
-      -- chain state for the /whole chain/, all the way to genesis.
-      --
-      -- So the rewind below is fine when we are switching to a fork (i.e. it
-      -- is followed by rolling forward again), but we need some guarantees
-      -- that the ChainSync protocol /does/ in fact give us a switch-to-fork
-      -- instead of a true rollback.
-      (candidateChain', candidateChainState') <-
-        case (,) <$> AF.rollback (castPoint intersection) candidateChain
-                 <*> rewindChainState cfg candidateChainState (pointSlot intersection)
-        of
-          Just (c,d) -> return (c,d)
-          -- The @intersection@ is not on the candidate chain, even though we
-          -- sent only points from the candidate chain to find an intersection
-          -- with. The node must have sent us an invalid intersection point.
-          Nothing    -> disconnect $ InvalidIntersection intersection
+    -- | Look at the current chain fragment that may have been updated in the
+    -- background. Check whether the candidate fragment still intersects with
+    -- it. If so, update the 'KnownIntersectionState' and trim the candidate
+    -- fragment to the new current chain fragment's anchor point. If not,
+    -- return 'Nothing'.
+    intersectsWithCurrentChain
+      :: KnownIntersectionState blk tip
+      -> STM m (Maybe (KnownIntersectionState blk tip))
+    intersectsWithCurrentChain kis@KnownIntersectionState
+                               { theirFrag
+                               , ourFrag
+                               } = do
+      ourFrag' <- getCurrentChain
+      ourTip'  <- Our <$> getOurTip
+      if
+        | AF.headPoint ourFrag == AF.headPoint ourFrag' ->
+          -- Our current chain didn't change, and changes to their chain that
+          -- might affect the intersection point are handled elsewhere
+          -- ('rollBackward'), so we have nothing to do.
+          return $ Just kis
 
-      -- TODO make sure the header state is fully evaluated, otherwise we'd
-      -- hang on to the entire ledger state. This applies to everywhere we
-      -- update the header state.
-      writeTVar varCandidate CandidateState
-        { candidateChain      = candidateChain'
-        , candidateChainState = candidateChainState'
-        }
+        | isJust (AF.intersectionPoint ourFrag' theirFrag) ->
+          -- Our current chain changed, but it still intersects with candidate
+          -- fragment, so update the 'ourFrag' field and trim to the
+          -- candidate fragment to the same anchor point.
+          --
+          -- Note that this is the only place we need to trim. Headers on
+          -- their chain can only become unnecessary (eligible for trimming)
+          -- in two ways: 1. we adopted them, i.e., our chain changed (handled
+          -- in this function); 2. we will /never/ adopt them, which is
+          -- handled in the "no more intersection case".
+          case AF.splitAfterPoint theirFrag (AF.anchorPoint ourFrag') of
+           -- + Before the update to our fragment, both fragments were
+           --   anchored at the same anchor.
+           -- + We still have an intersection.
+           -- + The number of blocks after the intersection cannot have
+           --   shrunk, but could have increased.
+           -- + If it did increase, the anchor point will have shifted up.
+           -- + It can't have moved up past the intersection point (because
+           --   then there would be no intersection anymore).
+           -- + This means the new anchor point must be between the old anchor
+           --   point and the new intersection point.
+           -- + Since we know both the old anchor point and the new
+           --   intersection point exist on their fragment, the new anchor
+           --   point must also.
+           Nothing -> error
+             "anchor point must be on candidate fragment if they intersect"
+           Just (_, trimmedCandidateFrag) -> return $ Just kis
+             { ourFrag   = ourFrag'
+             , theirFrag = trimmedCandidateFrag
+             , ourTip    = ourTip'
+             }
 
-      ourHeadBlockNo <- getTipBlockNo
+        | otherwise ->
+          -- No more intersection with the current chain
+          return Nothing
 
-      return $ requestNext mkPipelineDecision0 Zero ourHeadBlockNo theirHead
-
-    -- If the intersection point is unchanged, this means that the best
-    -- intersection point was the initial assumption: genesis.
+    -- | Request the next message (roll forward or backward), unless our chain
+    -- has changed such that it no longer intersects with the candidate, in
+    -- which case we initiate the intersection finding part of the protocol.
     --
-    -- Note: currently, we only try to find an intersection at start-up. When
-    -- we later optimise this client to also find intersections after
-    -- start-up, this code will have to be adapted, as it assumes it is only
-    -- called at start-up.
-    intersectNotFound :: tip               -- Their head
-                      -> m (Consensus (ClientPipelinedStIdle Z) blk tip m)
-    intersectNotFound theirHead = traceException $ atomically $ do
-      curChainState <- ouroborosChainState <$> getCurrentLedger
+    -- Note that this is the only place we check whether our current chain has
+    -- changed.
+    nextStep :: KnownIntersectionState blk tip
+             -> MkPipelineDecision
+             -> Nat n
+             -> Their tip
+             -> STM m (Consensus (ClientPipelinedStIdle n) blk tip m)
+    nextStep kis mkPipelineDecision n theirTip =
+      intersectsWithCurrentChain kis >>= \case
+        Just kis' -> do
+          -- Our chain (tip) didn't change or if it did, it still intersects
+          -- with the candidate fragment, so we can continue requesting the
+          -- next block.
+          writeTVar varCandidate (theirFrag kis')
+          let candTipBlockNo = getTipBlockNo (unTheir theirTip)
+          return $ requestNext kis' mkPipelineDecision n theirTip candTipBlockNo
+        Nothing ->
+          -- Our chain (tip) has changed and it no longer intersects with the
+          -- candidate fragment, so we have to find a new intersection, but
+          -- first drain the pipe.
+          drainThePipe n $ findIntersection NoMoreIntersection
 
-      CandidateState { candidateChain } <- readTVar varCandidate
-      -- If the genesis point is within the bounds of the candidate fragment
-      -- (initially equal to our fragment), it means we (the client) are <=
-      -- @k@ blocks from genesis and we want to sync with this
-      -- server/candidate. If not, the server/candidate is on a fork that
-      -- forked off too far in the past so that we do not intersect with them
-      -- within the last @k@ blocks, so we don't want to sync with them.
-      unless (AF.withinFragmentBounds genesisPoint candidateChain) $
-        disconnect $ ForkTooDeep genesisPoint theirHead
+    -- | "Drain the pipe": collect and discard all in-flight responses and
+    -- finally execute the given action.
+    drainThePipe :: Nat n
+                 -> STM m (Consensus (ClientPipelinedStIdle Z) blk tip m)
+                    -- ^ Execute this when the pipe has been drained
+                 -> STM m (Consensus (ClientPipelinedStIdle n) blk tip m)
+    drainThePipe n0 m = go n0
+      where
+        go :: forall n. Nat n
+           -> STM m (Consensus (ClientPipelinedStIdle n) blk tip m)
+        go n = case n of
+          Zero    -> m
+          Succ n' -> return $ CollectResponse Nothing $ ClientStNext
+            { recvMsgRollForward  = \_hdr _tip -> atomically $ go n'
+            , recvMsgRollBackward = \_pt  _tip -> atomically $ go n'
+            }
 
-      -- Get the 'ChainState' at genesis.
-      let candidateChain' = Empty genesisPoint
-      candidateChainState' <- case rewindChainState cfg curChainState Origin of
-        Nothing -> disconnect $ ForkTooDeep genesisPoint theirHead
-        Just c  -> pure c
-
-      writeTVar varCandidate CandidateState
-        { candidateChain       = candidateChain'
-        , candidateChainState  = candidateChainState'
-        }
-
-      ourHeadBlockNo <- getTipBlockNo
-
-      return $ requestNext mkPipelineDecision0 Zero ourHeadBlockNo theirHead
-
-    requestNext :: MkPipelineDecision
+    requestNext :: KnownIntersectionState blk tip
+                -> MkPipelineDecision
                 -> Nat n
-                -> BlockNo  -- ^ Our head
-                -> tip      -- ^ Their head
+                -> Their tip
+                -> BlockNo
                 -> Consensus (ClientPipelinedStIdle n) blk tip m
-    requestNext mkPipelineDecision n ourHeadBlockNo theirHead =
+    requestNext kis mkPipelineDecision n theirTip candTipBlockNo =
         case (n, decision) of
-          (_zero, (Request, mkPipelineDecision')) ->
+          (Zero, (Request, mkPipelineDecision')) ->
             SendMsgRequestNext
-              (handleNext mkPipelineDecision' Zero)
-              (return $ handleNext mkPipelineDecision' Zero) -- when we have to wait
+              (handleNext kis mkPipelineDecision' Zero)
+              (return $ handleNext kis mkPipelineDecision' Zero) -- when we have to wait
           (_, (Pipeline, mkPipelineDecision')) ->
             SendMsgRequestNextPipelined
-              (requestNext mkPipelineDecision' (Succ n) ourHeadBlockNo theirHead)
+              (requestNext kis mkPipelineDecision' (Succ n) theirTip candTipBlockNo)
           (Succ n', (CollectOrPipeline, mkPipelineDecision')) ->
             CollectResponse
               (Just $ SendMsgRequestNextPipelined $
-                requestNext mkPipelineDecision' (Succ n) ourHeadBlockNo theirHead)
-              (handleNext mkPipelineDecision' n')
+                requestNext kis mkPipelineDecision' (Succ n) theirTip candTipBlockNo)
+              (handleNext kis mkPipelineDecision' n')
           (Succ n', (Collect, mkPipelineDecision')) ->
             CollectResponse
               Nothing
-              (handleNext mkPipelineDecision' n')
+              (handleNext kis mkPipelineDecision' n')
       where
-        theirHeadBlockNo = tipBlockNo theirHead
+        theirTipBlockNo = getTipBlockNo (unTheir theirTip)
         decision = runPipelineDecision
           mkPipelineDecision
           n
-          ourHeadBlockNo
-          theirHeadBlockNo
+          candTipBlockNo
+          theirTipBlockNo
 
-    handleNext :: MkPipelineDecision
+    handleNext :: KnownIntersectionState blk tip
+               -> MkPipelineDecision
                -> Nat n
                -> Consensus (ClientStNext n) blk tip m
-    handleNext mkPipelineDecision n = ClientStNext
-      { recvMsgRollForward  = \hdr theirHead -> do
+    handleNext kis mkPipelineDecision n = ClientStNext
+      { recvMsgRollForward  = \hdr theirTip -> do
           traceWith tracer $ TraceDownloadedHeader hdr
-          rollForward mkPipelineDecision n hdr theirHead
-      , recvMsgRollBackward = \intersection theirHead -> do
+          rollForward kis mkPipelineDecision n hdr (Their theirTip)
+      , recvMsgRollBackward = \intersection theirTip -> do
           let intersection' :: Point blk
               intersection' = castPoint intersection
           traceWith tracer $ TraceRolledBack intersection'
-          rollBackward mkPipelineDecision n intersection' theirHead
+          rollBackward kis mkPipelineDecision n intersection' (Their theirTip)
       }
 
-    rollForward :: MkPipelineDecision
+    rollForward :: KnownIntersectionState blk tip
+                -> MkPipelineDecision
                 -> Nat n
                 -> Header blk
-                -> tip
+                -> Their tip
                 -> m (Consensus (ClientPipelinedStIdle n) blk tip m)
-    rollForward mkPipelineDecision n hdr theirHead = traceException $ atomically $ do
+    rollForward kis@KnownIntersectionState
+                { theirChainState
+                , theirFrag
+                , ourTip
+                }
+                mkPipelineDecision n hdr theirTip = traceException $ atomically $ do
       -- Reject the block if invalid
       let hdrHash  = headerHash hdr
           hdrPoint = headerPoint hdr
@@ -375,20 +505,22 @@ chainSyncClient mkPipelineDecision0
       -- (anachronistic) ledger view. We read the latter as the first thing in
       -- the transaction, because we might have to retry the transaction if the
       -- ledger state is too far behind the upstream peer (see below).
+      --
+      -- NOTE: this doesn't need to be consistent with our current (possibly
+      -- outdated) view of our chain, i.e. 'ourFrag', we /only/ use
+      -- @curLedger@ to validate /their/ header, even in the special case
+      -- discussed below.
       curLedger <- ledgerState <$> getCurrentLedger
-      let ourTip :: Point blk
-          ourTip = ledgerTipPoint curLedger
-
       -- NOTE: Low density chains
       --
-      -- The ledger gives us an "anachronistic ledger view", which allows us to
-      -- validate headers within a certain range of slots, provided that we
-      -- maintain the invariant that the intersecton between our tip and the tip
-      -- of the peer fragment is within @k@ blocks from our tip (see detailed
-      -- description at 'anachronisticProtocolLedgerView'). This range is in
-      -- terms of /slots/, not blocks: this is important, because certain
-      -- transitions on the ledger happen at slot boundaries (for instance,
-      -- update proposals).
+      -- The ledger gives us an "anachronistic ledger view", which allows us
+      -- to validate headers within a certain range of slots, provided that we
+      -- maintain the invariant that the intersection between our tip and the
+      -- tip of the peer fragment is within @k@ blocks from our tip (see
+      -- detailed description at 'anachronisticProtocolLedgerView'). This
+      -- range is in terms of /slots/, not blocks: this is important, because
+      -- certain transitions on the ledger happen at slot boundaries (for
+      -- instance, update proposals).
       --
       -- Under normal circumstances this is fine, but it can be problematic in
       -- the case of low density chains. For example, we might get the header
@@ -417,7 +549,7 @@ chainSyncClient mkPipelineDecision0
       -- we will not be able to verify it and so we will not be able to switch
       -- to this fork.
       ledgerView <-
-        if headerPrevHash hdr == pointHash ourTip then
+        if headerPrevHash hdr == pointHash (ledgerTipPoint curLedger) then
           -- Special case mentioned above
           return $ protocolLedgerView cfg curLedger
         else
@@ -430,7 +562,11 @@ chainSyncClient mkPipelineDecision0
           case anachronisticProtocolLedgerView cfg curLedger (pointSlot hdrPoint) of
             -- unexpected alternative; see comment before this case expression
             Left TooFarBehind ->
-                disconnect $ InvalidRollForward hdrPoint theirHead ourTip
+                disconnect InvalidRollForward
+                  { _newPoint = hdrPoint
+                  , _ourTip   = ourTip
+                  , _theirTip = theirTip
+                  }
             Left TooFarAhead  -> retry
             Right view -> case view `SB.at` hdrSlot of
                 Nothing -> error "anachronisticProtocolLedgerView invariant violated"
@@ -443,43 +579,61 @@ chainSyncClient mkPipelineDecision0
       -- Check for clock skew
       wallclock <- getCurrentSlot btime
       when (fmap unSlotNo (pointSlot hdrPoint) > At (unSlotNo wallclock + maxSkew)) $
-        disconnect $ HeaderExceedsClockSkew hdrPoint wallclock
+        disconnect HeaderExceedsClockSkew
+          { _receivedHeader    = hdrPoint
+          , _currentWallSlotNo = wallclock
+          , _ourTip            = ourTip
+          , _theirTip          = theirTip
+          }
 
       -- Validate header
-      CandidateState {..} <- readTVar varCandidate
-
-      let expectPrevHash = castHash (AF.headHash candidateChain)
+      let expectPrevHash = castHash (AF.headHash theirFrag)
           actualPrevHash = headerPrevHash hdr
       when (actualPrevHash /= expectPrevHash) $
-        disconnect $ DoesntFit actualPrevHash expectPrevHash
+        disconnect DoesntFit
+          { _receivedPrevHash = actualPrevHash
+          , _expectedPrevHash = expectPrevHash
+          , _ourTip           = ourTip
+          , _theirTip         = theirTip
+          }
 
-      candidateChainState' <-
-        case runExcept $ applyChainState cfg ledgerView hdr candidateChainState of
-          Left vErr                  -> disconnect $ ChainError vErr
-          Right candidateChainState' -> return candidateChainState'
+      theirChainState' <-
+        case runExcept $ applyChainState cfg ledgerView hdr theirChainState of
+          Right theirChainState' -> return theirChainState'
+          Left vErr              -> disconnect ChainError
+            { _newPoint           = hdrPoint
+            , _chainValidationErr = vErr
+            , _ourTip             = ourTip
+            , _theirTip           = theirTip
+            }
 
-      writeTVar varCandidate CandidateState
-        { candidateChain      = candidateChain :> hdr
-        , candidateChainState = candidateChainState'
-        }
+      let theirFrag' = theirFrag :> hdr
+          kis' = kis
+            { theirFrag       = theirFrag'
+            , theirChainState = theirChainState'
+            }
+      writeTVar varCandidate theirFrag'
 
-      ourHeadBlockNo <- getTipBlockNo
+      nextStep kis' mkPipelineDecision n theirTip
 
-      return $ requestNext mkPipelineDecision n ourHeadBlockNo theirHead
-
-    rollBackward :: MkPipelineDecision
+    rollBackward :: KnownIntersectionState blk tip
+                 -> MkPipelineDecision
                  -> Nat n
                  -> Point blk
-                 -> tip
+                 -> Their tip
                  -> m (Consensus (ClientPipelinedStIdle n) blk tip m)
-    rollBackward mkPipelineDecision n intersection theirHead = traceException $ atomically $ do
-      CandidateState {..} <- readTVar varCandidate
-
-      (candidateChain', candidateChainState') <-
-        case (,) <$> AF.rollback (castPoint intersection) candidateChain
-                 <*> rewindChainState cfg candidateChainState (pointSlot intersection)
+    rollBackward kis@KnownIntersectionState
+                 { theirFrag
+                 , theirChainState
+                 , ourTip
+                 }
+                 mkPipelineDecision n intersection
+                 theirTip = traceException $ atomically $ do
+      (theirFrag', theirChainState') <-
+        case (,) <$> AF.rollback (castPoint intersection) theirFrag
+                 <*> rewindChainState cfg theirChainState (pointSlot intersection)
         of
-          Just (c,d)  -> return (c,d)
+          Just (c, d) -> return (c,d)
           -- Remember that we use our current chain fragment as the starting
           -- point for the candidate's chain. Our fragment contained @k@
           -- headers. At this point, the candidate fragment might have grown to
@@ -502,17 +656,19 @@ chainSyncClient mkPipelineDecision0
           -- forward @s@ new headers where @s >= r@.
           --
           -- Thus, @k - r + s >= k@.
-          Nothing              -> disconnect $
-            InvalidRollBack intersection theirHead
+          Nothing     -> disconnect InvalidRollBack
+            { _newPoint = intersection
+            , _ourTip   = ourTip
+            , _theirTip = theirTip
+            }
 
-      writeTVar varCandidate CandidateState
-        { candidateChain      = candidateChain'
-        , candidateChainState = candidateChainState'
-        }
+      let kis' = kis
+            { theirFrag       = theirFrag'
+            , theirChainState = theirChainState'
+            }
+      writeTVar varCandidate theirFrag'
 
-      ourHeadBlockNo <- getTipBlockNo
-
-      return $ requestNext mkPipelineDecision n ourHeadBlockNo theirHead
+      nextStep kis' mkPipelineDecision n theirTip
 
     -- | Disconnect from the upstream node by throwing the given exception.
     -- The cleanup is handled in 'bracketChainSyncClient'.
@@ -541,8 +697,14 @@ chainSyncClient mkPipelineDecision0
     -- For @k = 5@ (during testing), this evaluates to
     --
     -- > [0,1,2,3,5]
-    offsets :: [Word64]
-    offsets = [0] ++ takeWhile (< k) [fib n | n <- [2..]] ++ [k]
+    --
+    -- In case the fragment contains less than @k@ blocks, we use the length
+    -- of the fragment as @k@. This ensures that the oldest rollback point is
+    -- selected.
+    offsets :: Word64 -> [Word64]
+    offsets maxOffset = [0] ++ takeWhile (< l) [fib n | n <- [2..]] ++ [l]
+      where
+        l = k `min` maxOffset
 
     k :: Word64
     k = maxRollbacks $ protocolSecurityParam cfg
@@ -575,18 +737,18 @@ rejectInvalidBlocks
     -> ResourceRegistry m
     -> STM m (HeaderHash blk -> Bool, Fingerprint)
        -- ^ Get the invalid block checker
-    -> STM m (CandidateState blk)
+    -> STM m (AnchoredFragment (Header blk))
     -> m ()
-rejectInvalidBlocks tracer registry getIsInvalidBlock getCandidateState =
+rejectInvalidBlocks tracer registry getIsInvalidBlock getCandidate =
     onEachChange registry snd Nothing getIsInvalidBlock checkInvalid
   where
     checkInvalid :: (HeaderHash blk -> Bool, Fingerprint) -> m ()
     checkInvalid (isInvalidBlock, _) = do
-      candChain <- candidateChain <$> atomically getCandidateState
+      theirFrag <- atomically getCandidate
       -- The invalid block is likely to be a more recent block, so check from
       -- newest to oldest.
       mapM_ disconnect $
-        find (isInvalidBlock . headerHash) (AF.toNewestFirst candChain)
+        find (isInvalidBlock . headerHash) (AF.toNewestFirst theirFrag)
 
     disconnect :: Header blk -> m ()
     disconnect invalidHeader = do
@@ -603,50 +765,79 @@ data ChainSyncClientException blk tip =
       --
       -- I.e., the slot of the received header was > current slot (according
       -- to the wall time) + the max clock skew.
-      --
-      -- The first 'Point' argument is the point of the received header, the
-      -- second 'SlotId' argument is the current slot (by wall clock).
-      HeaderExceedsClockSkew (Point blk) SlotNo
+      HeaderExceedsClockSkew
+      { _receivedHeader    :: Point blk
+      , _currentWallSlotNo :: SlotNo
+      , _ourTip            :: Our   tip
+      , _theirTip          :: Their tip
+      }
 
       -- | The server we're connecting to forked more than @k@ blocks ago.
-      --
-      -- The first 'Point' is the intersection point with the server that was
-      -- too far in the past, the second 'Point' is the head of the server.
-    | ForkTooDeep (Point blk) tip
+    | ForkTooDeep
+      { _intersection :: Point blk
+      , _ourTip       :: Our   tip
+      , _theirTip     :: Their tip
+      }
 
       -- | The chain validation threw an error.
-    | ChainError (ValidationErr (BlockProtocol blk))
+    | ChainError
+      { _newPoint           :: Point blk
+      , _chainValidationErr :: ValidationErr (BlockProtocol blk)
+      , _ourTip             :: Our   tip
+      , _theirTip           :: Their tip
+      }
 
       -- | The upstream node rolled forward to a point too far in our past.
       -- This may happen if, during catch-up, our local node has moved too far
       -- ahead of the upstream node.
-      --
-      -- We store the requested point and head point from the upstream node as
-      -- well as the tip of our current ledger.
-    | InvalidRollForward (Point blk) tip (Point blk)
+    | InvalidRollForward
+      { _newPoint :: Point blk
+      , _ourTip   :: Our   tip
+      , _theirTip :: Their tip
+      }
 
       -- | The upstream node rolled back more than @k@ blocks.
-      --
-      -- We store the requested intersection point and head point from the
-      -- upstream node.
-    | InvalidRollBack (Point blk) tip
+    | InvalidRollBack
+      { _newPoint :: Point blk
+      , _ourTip   :: Our   tip
+      , _theirTip :: Their tip
+      }
 
       -- | We send the upstream node a bunch of points from a chain fragment and
       -- the upstream node responded with an intersection point that is not on
       -- our chain fragment, and thus not among the points we sent.
       --
       -- We store the intersection point the upstream node sent us.
-    | InvalidIntersection (Point blk)
+    | InvalidIntersection
+      { _intersection :: Point blk
+      , _ourTip       :: Our   tip
+      , _theirTip     :: Their tip
+      }
+
+      -- | Our chain changed such that it no longer intersects with the
+      -- candidate's fragment, and asking for a new intersection did not yield
+      -- one.
+    | NoMoreIntersection
+      { _ourTip   :: Our   tip
+      , _theirTip :: Their tip
+      }
 
       -- | The received header to roll forward doesn't fit onto the previous
       -- one.
       --
       -- The first 'ChainHash' is the previous hash of the received header and
       -- the second 'ChainHash' is that of the previous one.
-    | DoesntFit (ChainHash blk) (ChainHash blk)
+    | DoesntFit
+      { _receivedPrevHash :: ChainHash blk
+      , _expectedPrevHash :: ChainHash blk
+      , _ourTip           :: Our   tip
+      , _theirTip         :: Their tip
+      }
 
       -- | The upstream node's chain contained a block that we know is invalid.
-    | InvalidBlock (Point blk)
+    | InvalidBlock
+      { _invalidBlock :: Point blk
+      }
 
 deriving instance ( SupportedBlock blk
                   , Show tip
@@ -715,6 +906,9 @@ data TraceChainSyncClientEvent blk tip
     -- header.
   | TraceRolledBack (Point blk)
     -- ^ While following a candidate chain, we rolled back to the given point.
+  | TraceFoundIntersection (Point blk) (Our tip) (Their tip)
+    -- ^ We found an intersection between our chain fragment and the
+    -- candidate's chain.
   | TraceException (ChainSyncClientException blk tip)
     -- ^ An exception was thrown by the Chain Sync Client.
 

--- a/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
@@ -455,6 +455,13 @@ AnchoredFragment a1 c1 `isPrefixOf` AnchoredFragment a2 c2 =
 -- The given 'Point' may be the anchor point of the fragment, in which case
 -- the empty fragment with the given anchor point and the original fragment
 -- are returned.
+--
+-- POSTCONDITION: when @Just (before, after) = splitAfterPoint f pt@, then:
+-- * @anchorPoint before == anchorPoint f@
+-- * @headPoint   before == pt@
+-- * @anchorPoint after  == pt@
+-- * @headPoint   after  == headPoint f@
+-- * @join before after  == Just f@
 splitAfterPoint
    :: forall block1 block2.
       (HasHeader block1, HasHeader block2, HeaderHash block1 ~ HeaderHash block2)


### PR DESCRIPTION
* Implement the `docs/ChainSync.md` spec: watch our current chain and trim the
  candidates.

* Introduce `ChainDbView` to abstract over the ChainDB.

* Introduce `Their` and `Our` newtype wrappers to avoid confusing our tip with
  their tip.

* Only store the candidate fragments in the peer map, not the whole candidate
  state. Thread the state of the candidate through manually, without storing
  it in a `StrictTVar`. Split the state up in `NoIntersectionState` and
  `IntersectionState` to be more precise.

* Include our tip and their tip in the `ChainSyncClientException` and add
  field names.

* Fix bug in pipelining: we used our current chain's tip's block number
  instead of the candidate's tip's block number.

* Misc. improvements to the ChainSync client test.