### PR TITLE
Check ChainSyncClient for thunks

### DIFF
--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -1,6 +1,6 @@
 { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = {};
+    flags = { checktvarinvariant = false; };
     package = {
       specVersion = "1.10";
       identifier = { name = "ouroboros-consensus"; version = "0.1.0.0"; };

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -17,6 +17,11 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/ouroboros-network
 
+flag checktvarinvariant
+  Description: Enable runtime checks on application state
+  Manual: True
+  Default: False
+
 library
   hs-source-dirs:      src
 
@@ -245,6 +250,9 @@ library
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts
+
+  if flag(checktvarinvariant)
+    cpp-options: -DCHECK_TVAR_INVARIANT
 
 test-suite test-consensus
   type:             exitcode-stdio-1.0

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
@@ -7,6 +7,8 @@ module Ouroboros.Consensus.Util.MonadSTM.NormalForm (
   , uncheckedNewTVarM
   , uncheckedNewTMVarM
   , uncheckedNewEmptyTMVarM
+    -- * Low-level API
+  , unsafeNoThunks
   ) where
 
 import           GHC.Stack

--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
@@ -70,7 +72,8 @@ import qualified Ouroboros.Network.Point as Point (Block (..))
 
 -- | The 0-based index for the Ourboros time slot.
 newtype SlotNo = SlotNo { unSlotNo :: Word64 }
-  deriving (Show, Eq, Ord, Enum, Bounded, Num, Serialise, Generic, NoUnexpectedThunks)
+  deriving stock   (Show, Eq, Ord, Generic)
+  deriving newtype (Enum, Bounded, Num, Serialise, NoUnexpectedThunks)
 
 instance ToCBOR SlotNo where
   toCBOR = encode
@@ -79,7 +82,8 @@ instance ToCBOR SlotNo where
 -- BlockNo is <= SlotNo and is only equal at slot N if there is a block
 -- for every slot where N <= SlotNo.
 newtype BlockNo = BlockNo { unBlockNo :: Word64 }
-  deriving (Show, Eq, Ord, Enum, Bounded, Num, Serialise, Generic, NoUnexpectedThunks)
+  deriving stock   (Show, Eq, Ord, Generic)
+  deriving newtype (Enum, Bounded, Num, Serialise, NoUnexpectedThunks)
 
 genesisSlotNo :: SlotNo
 genesisSlotNo = SlotNo 0
@@ -162,10 +166,10 @@ newtype Point block = Point
     { getPoint :: WithOrigin (Point.Block SlotNo (HeaderHash block))
     }
 
-deriving instance StandardHash block => Eq   (Point block)
-deriving instance StandardHash block => Ord  (Point block)
-deriving instance StandardHash block => Show (Point block)
-deriving instance (StandardHash block, Typeable block) => NoUnexpectedThunks (Point block)
+deriving newtype instance StandardHash block => Eq   (Point block)
+deriving newtype instance StandardHash block => Ord  (Point block)
+deriving newtype instance StandardHash block => Show (Point block)
+deriving newtype instance (StandardHash block, Typeable block) => NoUnexpectedThunks (Point block)
 
 pattern GenesisPoint :: Point block
 pattern GenesisPoint = Point Origin
@@ -199,7 +203,7 @@ blockPoint b = Point (block (blockSlot b) (blockHash b))
 data Tip b = Tip
   { tipPoint   :: !(Point b)
   , tipBlockNo :: !BlockNo
-  } deriving (Eq, Show, Generic)
+  } deriving (Eq, Show, Generic, NoUnexpectedThunks)
 
 encodeTip :: (HeaderHash blk -> Encoding)
           -> (Tip        blk -> Encoding)

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -24,11 +24,10 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 import           Control.Tracer
 
-import           Ouroboros.Network.Mux
-import qualified Network.Mux.Types as Mx
 import qualified Network.Mux.Bearer.Pipe as Mx
+import qualified Network.Mux.Types as Mx
+import           Ouroboros.Network.Mux
 
-import           Ouroboros.Network.Block (BlockNo)
 import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate, Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 import qualified Ouroboros.Network.MockChain.ProducerState as CPS
@@ -116,7 +115,7 @@ demo chain0 updates = do
                       (ChainSync.chainSyncClientExample consumerVar
                       (consumerClient done target consumerVar)))
 
-        server :: ChainSyncServer block (Point block, BlockNo) IO ()
+        server :: ChainSyncServer block (ExampleTip block) IO ()
         server = ChainSync.chainSyncServerExample () producerVar
 
         producerApp ::OuroborosApplication ResponderApp String DemoProtocols IO BL.ByteString Void ()
@@ -152,7 +151,7 @@ demo chain0 updates = do
     consumerClient :: StrictTMVar IO Bool
                    -> Point block
                    -> StrictTVar IO (Chain block)
-                   -> ChainSync.Client block (Point block, BlockNo) IO ()
+                   -> ChainSync.Client block (ExampleTip block) IO ()
     consumerClient done target chain =
       ChainSync.Client
         { ChainSync.rollforward = \_ -> checkTip target chain >>= \b ->

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -20,10 +20,10 @@ import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTimer
 import qualified Data.ByteString.Lazy as BL
-import           Data.Time.Clock (UTCTime, getCurrentTime)
 import           Data.Functor ((<$))
 import           Data.Int (Int64)
 import           Data.List (mapAccumL)
+import           Data.Time.Clock (UTCTime, getCurrentTime)
 import           Data.Void (Void)
 import qualified Network.Socket as Socket
 import qualified Network.Socket.ByteString.Lazy as Socket (sendAll)
@@ -35,32 +35,33 @@ import           System.IO.Error
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Driver
 import qualified Network.TypedProtocol.ReqResp.Client as ReqResp
-import qualified Network.TypedProtocol.ReqResp.Server as ReqResp
-import qualified Network.TypedProtocol.ReqResp.Type as ReqResp
 import qualified Network.TypedProtocol.ReqResp.Codec.Cbor as ReqResp
 import qualified Network.TypedProtocol.ReqResp.Examples as ReqResp
+import qualified Network.TypedProtocol.ReqResp.Server as ReqResp
+import qualified Network.TypedProtocol.ReqResp.Type as ReqResp
 
 import           Codec.SerialiseTerm
 import           Control.Tracer
 
 -- TODO: remove Mx prefixes
-import           Ouroboros.Network.Mux as Mx
 import qualified Network.Mux as Mx
 import qualified Network.Mux.Bearer.Socket as Mx
+import           Ouroboros.Network.Mux as Mx
 
 import           Ouroboros.Network.Socket
 
-import           Ouroboros.Network.Block (BlockNo)
 import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate, Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 import qualified Ouroboros.Network.MockChain.ProducerState as CPS
 import           Ouroboros.Network.NodeToNode
 import qualified Ouroboros.Network.Protocol.ChainSync.Client as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Codec as ChainSync
+import           Ouroboros.Network.Protocol.ChainSync.Examples (ExampleTip)
 import qualified Ouroboros.Network.Protocol.ChainSync.Examples as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Server as ChainSync
 import           Ouroboros.Network.Protocol.Handshake.Type (acceptEq)
-import           Ouroboros.Network.Protocol.Handshake.Version (simpleSingletonVersions)
+import           Ouroboros.Network.Protocol.Handshake.Version
+                     (simpleSingletonVersions)
 import           Ouroboros.Network.Testing.Serialise
 
 import           Test.ChainGenerators (TestBlockChainAndUpdates (..))
@@ -68,8 +69,8 @@ import           Test.ChainGenerators (TestBlockChainAndUpdates (..))
 import           Test.QuickCheck
 import           Test.Tasty (DependencyType (..), TestTree, after, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
-import           Text.Show.Functions ()
 import           Text.Printf
+import           Text.Show.Functions ()
 
 {-
  - The travis build hosts does not support IPv6 so those test cases are hidden
@@ -393,7 +394,7 @@ demo chain0 updates = do
                         (ChainSync.chainSyncClientExample consumerVar
                         (consumerClient done target consumerVar)))
 
-        server :: ChainSync.ChainSyncServer block (Point block, BlockNo) IO ()
+        server :: ChainSync.ChainSyncServer block (ExampleTip block) IO ()
         server = ChainSync.chainSyncServerExample () producerVar
 
         responderApp :: OuroborosApplication Mx.ResponderApp (Socket.SockAddr, Socket.SockAddr) TestProtocols1 IO BL.ByteString Void ()
@@ -451,7 +452,7 @@ demo chain0 updates = do
     consumerClient :: StrictTMVar IO Bool
                    -> Point block
                    -> StrictTVar IO (Chain block)
-                   -> ChainSync.Client block (Point block, BlockNo) IO ()
+                   -> ChainSync.Client block (ExampleTip block) IO ()
     consumerClient done target chain =
       ChainSync.Client
         { ChainSync.rollforward = \_ -> checkTip target chain >>= \b ->
@@ -487,4 +488,3 @@ threadAndTimeTracer tr = Tracer $ \s -> do
     !now <- getCurrentTime
     !tid <- myThreadId
     traceWith tr $ WithThreadAndTime now tid s
-


### PR DESCRIPTION
The chain sync client stores a tip, but is polymorphic in that tip, and
if there are thunks in that tip, we might leak. For our tests we are
using the example server from the network layer, which is however not
polymorphic in its `tip` type, but uses a non-strict pair. This PR
replaces that with a strict `ExampleTip`, and pushes that through.
The `NoUnexpectedThunks` test for our chain sync tests now passes.

@coot , are you okay with the changes to the network examples here?