### PR TITLE
Limit size of cddl test.

### DIFF
--- a/ouroboros-network/test/CDDL.hs
+++ b/ouroboros-network/test/CDDL.hs
@@ -66,7 +66,7 @@ main = defaultMain tests
 
 tests :: TestTree
 tests =
-  adjustOption (const $ QuickCheckMaxSize 20) $ testGroup "messages.cddl-spec"
+  adjustOption (const $ QuickCheckMaxSize 10) $ testGroup "messages.cddl-spec"
   [
 -- These tests call the CDDL-tool to parse an arbitray message.
 -- The parser of the CDDL-tool is slow (exponential runtime & space).


### PR DESCRIPTION
When used in parsing mode the external `cddl` tool has a high time and space complexity for some
test cases (a bug).
This PR limits the size of the test cases to `QuickCheckMaxSize 10`.
This makes is less likely to hit test cases with a run time longer than a view seconds (per testcase).