### PR TITLE
implementation of STM orElse for the IO simulator

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
@@ -135,89 +135,35 @@ class ( MonadSTM m
   waitEitherCatchCancel left right =
     waitEitherCatch left right `finally` (cancel left >> cancel right)
 
-  -- Our MonadSTM does not cover orElse, so these all use low level versions
-  waitAnySTM []     = retry
-  waitAnySTM (a:as) = do
-    mr <- pollSTM a
-    case mr of
-      Nothing        -> waitAnySTM as
-      Just (Left  e) -> throwM e
-      Just (Right r) -> return (a, r)
-{-
+  waitAnySTM as =
     foldr orElse retry $
-      map (\a -> do r <- waitSTM a; return (a, r)) asyncs
--}
+      map (\a -> do r <- waitSTM a; return (a, r)) as
 
-  waitAnyCatchSTM []     = retry
-  waitAnyCatchSTM (a:as) = do
-    mr <- pollSTM a
-    case mr of
-      Nothing -> waitAnyCatchSTM as
-      Just r  -> return (a, r)
-{-
+  waitAnyCatchSTM as =
     foldr orElse retry $
-      map (\a -> do r <- waitCatchSTM a; return (a, r)) asyncs
--}
+      map (\a -> do r <- waitCatchSTM a; return (a, r)) as
 
-  waitEitherSTM left right = do
-    ml <- pollSTM left
-    mr <- pollSTM right
-    case (ml, mr) of
-      (Just (Left  e), _) -> throwM e
-      (Just (Right l), _) -> return (Left l)
-      (_, Just (Left  e)) -> throwM e
-      (_, Just (Right r)) -> return (Right r)
-      (Nothing,  Nothing) -> retry
-{-
+  waitEitherSTM left right =
     (Left  <$> waitSTM left)
       `orElse`
     (Right <$> waitSTM right)
--}
 
-
-  waitEitherSTM_ left right = do
-    ml <- pollSTM left
-    mr <- pollSTM right
-    case (ml, mr) of
-      (Just (Left  e), _) -> throwM e
-      (Just (Right _), _) -> return ()
-      (_, Just (Left  e)) -> throwM e
-      (_, Just (Right _)) -> return ()
-      (Nothing,  Nothing) -> retry
-{-
+  waitEitherSTM_ left right =
       (void $ waitSTM left)
         `orElse`
       (void $ waitSTM right)
--}
 
-  waitEitherCatchSTM left right = do
-    ml <- pollSTM left
-    mr <- pollSTM right
-    case (ml, mr) of
-      (Just l,  _      ) -> return (Left l)
-      (_,       Just r ) -> return (Right r)
-      (Nothing, Nothing) -> retry
-{-
+  waitEitherCatchSTM left right =
       (Left  <$> waitCatchSTM left)
         `orElse`
       (Right <$> waitCatchSTM right)
--}
 
   waitBothSTM left right = do
-    ml <- pollSTM left
-    mr <- pollSTM right
-    case (ml, mr) of
-      (Just (Left  e), _)              -> throwM e
-      (_,              Just (Left  e)) -> throwM e
-      (Just (Right l), Just (Right r)) -> return (l, r)
-      (_,  _)                          -> retry
-{-
       a <- waitSTM left
              `orElse`
            (waitSTM right >> retry)
       b <- waitSTM right
       return (a,b)
--}
 
   race            left right = withAsync left  $ \a ->
                                withAsync right $ \b ->

--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -72,7 +72,7 @@ class (Monad m, Monad (STM m)) => MonadSTM m where
   readTVar     :: LazyTVar m a -> STM m a
   writeTVar    :: LazyTVar m a -> a -> STM m ()
   retry        :: STM m a
---orElse       :: STM m a -> STM m a -> STM m a --TODO
+  orElse       :: STM m a -> STM m a -> STM m a
 
   -- Helpful derived functions with default implementations
   newTVarM     :: a -> m (LazyTVar m a)
@@ -127,6 +127,7 @@ instance MonadSTM m => MonadSTM (ReaderT e m) where
   readTVar         = lift . readTVar
   writeTVar t a    = lift $ writeTVar t a
   retry            = lift retry
+  orElse a b       = ReaderT $ \e -> runReaderT a e `orElse` runReaderT b e
 
   newTMVar         = lift . newTMVar
   newTMVarM        = lift . newTMVarM
@@ -166,6 +167,7 @@ instance (Show e, MonadSTM m) => MonadSTM (ExceptT e m) where
   readTVar               = lift . readTVar
   writeTVar t a          = lift $ writeTVar t a
   retry                  = lift retry
+  orElse a b             = ExceptT $ runExceptT a `orElse` runExceptT b
 
   newTMVar               = lift . newTMVar
   newTMVarM              = lift . newTMVarM
@@ -207,6 +209,7 @@ instance MonadSTM IO where
   readTVar    = STM.readTVar
   writeTVar   = STM.writeTVar
   retry       = STM.retry
+  orElse      = STM.orElse
 
   newTVarM    = STM.newTVarIO
   modifyTVar  = STM.modifyTVar

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -54,12 +54,14 @@ test-suite test-sim
   hs-source-dirs:      test
   main-is:             Main.hs
   other-modules:       Test.IOSim
+                       Test.STM
   default-language:    Haskell2010
   build-depends:       base,
                        array,
                        containers,
                        io-sim,
                        io-sim-classes,
+                       stm,
                        QuickCheck,
                        tasty,
                        tasty-quickcheck,

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -61,7 +61,6 @@ test-suite test-sim
                        containers,
                        io-sim,
                        io-sim-classes,
-                       stm,
                        QuickCheck,
                        tasty,
                        tasty-quickcheck,

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -313,7 +313,11 @@ prop_threadId_order_order_Sim n = runSimOrThrow $ test_threadId_order n
 prop_wakeup_order_ST :: Property
 prop_wakeup_order_ST = runSimOrThrow $ test_wakeup_order
 
--- It is not deterministic in IO
+-- This property is not actually deterministic in IO. Uncomment the following
+-- and try it! Arguably therefore, this property does not need to be true for
+-- the Sim either. Perhaps we should introduce random scheduling and abandon
+-- this property. In the meantime it's a helpful sanity check.
+
 --prop_wakeup_order_IO = ioProperty test_wakeup_order
 
 test_wakeup_order :: ( MonadFork m

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -78,6 +78,7 @@ tests =
     ]
   , testGroup "STM reference semantics"
     [ testProperty "Reference vs IO"    prop_stm_referenceIO
+    , testProperty "Reference vs Sim"   prop_stm_referenceSim
     ]
   ]
 
@@ -810,16 +811,19 @@ prop_stm_referenceIO t =
 -- | Compare the behaviour of the STM reference operational semantics with
 -- the behaviour of the IO simulator's STM implementation.
 --
---prop_stm_referenceSim :: SomeTerm -> Property
---prop_stm_referenceSim t =
---    runSimOrThrow (prop_stm_referenceM t)
+prop_stm_referenceSim :: SomeTerm -> Property
+prop_stm_referenceSim t =
+    runSimOrThrow (prop_stm_referenceM t)
+
+--TODO: would be nice to also have stronger tests here:
+-- * compare all the tvar values in the heap
+-- * compare the read and write sets
 
 -- | Compare the behaviour of the STM reference operational semantics with
 -- the behaviour of any 'MonadSTM' STM implementation.
 --
---prop_stm_referenceM :: (MonadSTM m, MonadThrow (STM m), MonadCatch m)
---                    => SomeTerm -> m Property
-prop_stm_referenceM :: SomeTerm -> IO Property
+prop_stm_referenceM :: (MonadSTM m, MonadThrow (STM m), MonadCatch m)
+                    => SomeTerm -> m Property
 prop_stm_referenceM (SomeTerm _tyrep t) = do
     let (r1, _heap) = evalAtomically t
     r2 <- execAtomically t

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -8,19 +8,16 @@ module Test.IOSim
     , arbitraryAcyclicGraph
     ) where
 
-import           Control.Monad
-import           Control.Exception
-                   ( ArithException(..) )
-import           System.IO.Error
 import           Data.Array
 import           Data.Fixed (Fixed (..), Micro)
 import           Data.Graph
 import           Data.List (sort)
 import           Data.Time.Clock (DiffTime, picosecondsToDiffTime)
 
-import           Test.QuickCheck
-import           Test.Tasty
-import           Test.Tasty.QuickCheck
+import           Control.Monad
+import           Control.Exception
+                   ( ArithException(..) )
+import           System.IO.Error (IOError, isUserError, ioeGetErrorString)
 
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSTM.Strict
@@ -29,9 +26,14 @@ import           Control.Monad.Class.MonadTimer
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.IOSim
 
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+
 tests :: TestTree
 tests =
-  testGroup "STM simulator"
+  testGroup "IO simulator"
   [ testProperty "read/write graph (IO)"   prop_stm_graph_io
   , testProperty "read/write graph (SimM)" (withMaxSuccess 1000 prop_stm_graph_sim)
   , testProperty "timers (SimM)"           (withMaxSuccess 1000 prop_timers_ST)

--- a/io-sim/test/Test/STM.hs
+++ b/io-sim/test/Test/STM.hs
@@ -495,13 +495,6 @@ data SomeExpr where
 deriving instance Show SomeTerm
 deriving instance Show SomeExpr
 
-{-
-instance Show SomeTerm where
-    show (SomeTerm _ t) = showTerm 0 t ""
-
-instance Show SomeExpr where
-    show (SomeExpr e) = showExpr 0 e ""
--}
 
 -- | The generator environment, used to keep track of what names are in scope
 -- in the terms and expressions we generate.
@@ -800,4 +793,3 @@ showTyRep _  TyRepUnit   = showString "()"
 showTyRep _  TyRepInt    = showString "Int"
 showTyRep p (TyRepVar t) = showParen (p > 10) $
                              showString "TVar " . showTyRep 11 t
-

--- a/io-sim/test/Test/STM.hs
+++ b/io-sim/test/Test/STM.hs
@@ -1,0 +1,808 @@
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE BangPatterns               #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+-- | A reference implementation of the STM operational semantics.
+--
+-- It is based on the paper /Composable Memory Transactions/, which gives the
+-- operational semantics of STM Haskell in Figures 2--4.
+--
+-- <https://research.microsoft.com/en-us/um/people/simonpj/papers/stm/stm.pdf>
+--
+module Test.STM where
+
+import           Prelude hiding (exp)
+import           Data.Type.Equality
+import           Data.Maybe (fromMaybe, maybeToList)
+import qualified Data.Map.Strict as Map
+import           Data.Map.Strict (Map)
+import qualified Data.Set as Set
+import           Data.Set (Set)
+
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadSTM as STM
+import qualified Control.Monad.STM as IOSTM
+
+import           Test.QuickCheck
+
+
+-- | The type level structure of types in our STM 'Term's. This is kept simple,
+-- just unit and ints as base types, and the type of STM variables.
+--
+data Type where
+    TyUnit :: Type
+    TyInt  :: Type
+    TyVar  :: Type -> Type
+
+
+-- | A value level representation of the types of STM 'Term's.
+--
+data TyRep (t :: Type) where
+    TyRepUnit ::            TyRep TyUnit
+    TyRepInt  ::            TyRep TyInt
+    TyRepVar  :: TyRep t -> TyRep (TyVar t)
+
+deriving instance Show (TyRep t)
+
+
+-- | Figure 2 in the paper gives the syntax of STM terms. It does not
+-- distinguish between STM action terms and other terms. We make such a
+-- distinction here because it makes the encoding and generation of terms
+-- easier, and the restriction is not fundamental for the STM semantics.
+--
+data Term (t :: Type) where
+
+    Return    :: Expr t -> Term t
+    Throw     :: Expr a -> Term t
+    Retry     :: Term t
+
+    ReadTVar  :: Name (TyVar t) -> Term t
+    WriteTVar :: Name (TyVar t) -> Expr t -> Term TyUnit
+    NewTVar   :: Expr t -> Term (TyVar t)
+
+    -- | This is the ordinary monad bind for STM terms.
+    Bind      :: Term a -> Name a -> Term t -> Term t
+    OrElse    :: Term t -> Term t -> Term t
+
+deriving instance Show (Term t)
+
+
+-- | Expressions that can appear within 'Term's.
+--
+data Expr (t :: Type) where
+
+    ExprUnit ::           Expr TyUnit
+    ExprInt  :: Int    -> Expr TyInt
+    ExprName :: Name t -> Expr t
+
+deriving instance Show (Expr t)
+
+
+-- | Normal form values that occur during evaluation.
+--
+data Value (t :: Type) where
+
+    ValUnit ::          Value TyUnit
+    ValInt  :: Int   -> Value TyInt
+    ValVar  :: Var t -> Value (TyVar t)
+
+deriving instance Show (Value t)
+
+
+-- | We have both names and STM variables, and it is important to keep the two
+-- concepts distinct. We need names because we have bind, and in particular the
+-- same name may end up referring to different variables during execution,
+-- depending on runtime conditions.
+--
+-- The bound variable scheme here is just a simple fresh name supply. The
+-- variable bindings are held in the 'Env'.
+--
+-- The names are typed and carry a representation of their type.
+--
+data Name (t :: Type) = Name !NameId (TyRep t)
+deriving instance Show (Name t)
+
+newtype NameId = NameId Int
+  deriving (Eq, Ord, Enum, Show)
+
+-- | An STM variable. The value is held in the 'Heap'. A simple fresh name
+-- supply scheme is used.
+--
+-- The variables are typed and carry a representation of their type.
+--
+data Var (t :: Type) = Var !VarId (TyRep t)
+deriving instance Show (Var t)
+
+newtype VarId = VarId Int
+  deriving (Eq, Ord, Enum, Show)
+
+
+
+--
+-- Type rep utils
+--
+
+eqTyRep :: TyRep a -> TyRep b -> Maybe (a :~: b)
+eqTyRep  TyRepUnit    TyRepUnit   = Just Refl
+eqTyRep  TyRepInt     TyRepInt    = Just Refl
+eqTyRep (TyRepVar a) (TyRepVar b) = case eqTyRep a b of
+                                      Nothing   -> Nothing
+                                      Just Refl -> Just Refl
+eqTyRep  _            _           = Nothing
+
+nameTyRep :: Name t -> TyRep t
+nameTyRep (Name _ tyrep) = tyrep
+
+varTyRep :: Var t -> TyRep t
+varTyRep (Var _ tyrep) = tyrep
+
+tyRepExpr :: Expr t -> TyRep t
+tyRepExpr (ExprName n) = nameTyRep n
+tyRepExpr  ExprUnit    = TyRepUnit
+tyRepExpr (ExprInt _)  = TyRepInt
+
+tyRepValue :: Value t -> TyRep t
+tyRepValue  ValUnit   = TyRepUnit
+tyRepValue (ValInt _) = TyRepInt
+tyRepValue (ValVar v) = TyRepVar (varTyRep v)
+
+
+--
+-- Evaluation environments
+--
+
+data SomeName where
+     SomeName :: Name t -> SomeName
+
+data SomeValue where
+     SomeValue :: Value t -> SomeValue
+
+deriving instance Show SomeName
+deriving instance Show SomeValue
+
+
+-- | The environment is a mapping of 'Name's to their values.
+--
+newtype Env = Env (Map NameId SomeValue)
+  deriving Show
+
+-- | Lookup a name in the environment. This dynamically checks the types.
+--
+lookupEnv :: Env -> Name t -> Value t
+lookupEnv (Env env) (Name name tyrep) =
+    fromMaybe (error "lookupEnv: no such var") $ do
+    SomeValue v <- Map.lookup name env
+    Refl        <- tyrep `eqTyRep` tyRepValue v
+    return v
+
+extendEnv :: Name t -> Value t -> Env -> Env
+extendEnv (Name name _tyrep) v (Env env) =
+    Env (Map.insert name (SomeValue v) env)
+
+
+--
+-- Heaps for mutable variable
+--
+
+data SomeVar where
+     SomeVar :: Var t -> SomeVar
+
+-- | The heap is a mapping of 'Var's to their current values.
+--
+newtype Heap = Heap (Map VarId SomeValue)
+  deriving (Show, Semigroup, Monoid)
+
+-- | The STM semantics uses two heaps, the other one is called the allocations.
+type Allocs = Heap
+
+
+readVar :: Heap -> Var t -> Value t
+readVar (Heap heap) (Var n tyrep) =
+    fromMaybe (error "readVar: no such var") $ do
+    SomeValue v <- Map.lookup n heap
+    Refl        <- tyrep `eqTyRep` tyRepValue v
+    return v
+
+writeVar :: Heap -> Var t -> Value t -> Heap
+writeVar (Heap heap) (Var n tyrep) v' =
+    fromMaybe (error "writeVar: no such var") $ do
+    SomeValue v <- Map.lookup n heap
+    Refl        <- tyrep `eqTyRep` tyRepValue v
+    let heap' = Heap (Map.insert n (SomeValue v') heap)
+    return heap'
+
+-- | Extend the heap and allocs with a fresh variable.
+extendHeap :: (Heap, Allocs) -> Value t -> (Var t, Heap, Allocs)
+extendHeap (Heap heap, Heap allocs) v =
+    (var, Heap heap', Heap allocs')
+  where
+    var     = Var n' (tyRepValue v)
+    heap'   = Map.insert n' (SomeValue v) heap
+    allocs' = Map.insert n' (SomeValue v) allocs
+    n'     :: VarId
+    n'      = case Map.maxViewWithKey heap of
+                Nothing          -> VarId 0
+                Just ((n, _), _) -> succ n
+
+
+--
+-- Top level results
+--
+
+-- | The overall result of an STM transaction.
+--
+-- This is used for both the reference evaluator 'evalAtomically' and the
+-- conversion into the implementation STM via 'execAtomically'.
+--
+data TxResult =
+       TxComitted ImmValue
+     | TxBlocked
+     | TxAborted  ImmValue
+  deriving (Eq, Show)
+
+-- | An immutable snapshot of a 'Value' where the current values of the mutable
+-- variables are captured and included.
+--
+data ImmValue where
+
+    ImmValUnit ::             ImmValue
+    ImmValInt  :: Int      -> ImmValue
+    ImmValVar  :: ImmValue -> ImmValue
+    -- ^ This means it was the value within in a mutable variable, but the
+    -- identity of the variable is forgotten.
+  deriving (Eq, Show)
+
+-- | In the execution in real STM transactions are aborted by throwing an
+-- exception.
+--
+instance Exception ImmValue
+
+
+
+--
+-- Evaluation
+--
+
+evalExpr :: Env -> Expr t -> Value t
+evalExpr  env  (ExprName n) = lookupEnv env n
+evalExpr _env   ExprUnit    = ValUnit
+evalExpr _env  (ExprInt n)  = ValInt n
+
+-- | The normal form for a 'Term' after execution.
+--
+data NfTerm (t :: Type) where
+
+    NfReturn :: Value t -> NfTerm t
+    NfThrow  :: Value a -> NfTerm t
+    NfRetry  ::            NfTerm t
+
+deriving instance Show (NfTerm t)
+
+
+-- | The STM transition rules. They reduce a 'Term' to a normal-form 'NfTerm'.
+--
+evalTerm :: Env -> Heap -> Allocs -> Term t -> (NfTerm t, Heap, Allocs)
+evalTerm !env !heap !allocs term = case term of
+
+    Return e -> (NfReturn e', heap, allocs)
+      where
+        e' = evalExpr env e
+
+    Throw  e -> (NfThrow e', heap, allocs)
+      where
+        e'  = evalExpr env e
+
+    Retry    -> (NfRetry,                   heap, allocs)
+
+    ReadTVar nvar -> (NfReturn (readVar heap var), heap,  allocs)
+      where
+        ValVar var = lookupEnv env nvar
+
+    WriteTVar nvar exp -> (NfReturn ValUnit, heap', allocs)
+      where
+        heap'             = writeVar heap var val
+        (ValVar var)      = lookupEnv env nvar
+        val               = evalExpr env exp
+
+    NewTVar exp ->
+      let val                   = evalExpr env exp
+          (var, heap', allocs') = extendHeap (heap, allocs) val
+      in (NfReturn (ValVar var), heap', allocs')
+
+    Bind t1 name t2 ->
+      let (nf1, heap', allocs') = evalTerm env heap allocs t1 in
+      case nf1 of
+        NfReturn v -> evalTerm env' heap' allocs' t2
+          where
+            env' = extendEnv name v env
+        NfThrow v  -> (NfThrow v, heap', allocs')
+        NfRetry    -> (NfRetry,   heap', allocs')
+
+    OrElse t1 t2 ->
+      let (nft1, heap', allocs') = evalTerm env heap allocs t1 in
+      case nft1 of
+        NfReturn v -> (NfReturn v, heap', allocs')
+        NfThrow  v -> (NfThrow  v, heap', allocs')
+        NfRetry    -> evalTerm env heap allocs t2
+
+-- | The top level rule for STM transitions (on closed terms).
+--
+evalAtomically :: Term t -> (TxResult, Heap)
+evalAtomically t =
+    let env                  = Env mempty
+        heap                 = mempty
+        allocs               = mempty
+        (t', heap', allocs') = evalTerm env heap allocs t in
+    case t' of
+      NfReturn v -> (TxComitted v', heap')            -- ARET
+                      where v' = snapshotValue heap' v
+
+      NfThrow  v -> (TxAborted  v', heap <> allocs')  -- ATHROW
+                      where v' = snapshotValue heap' v
+
+      NfRetry    -> (TxBlocked, heap)  -- heap unchanged for retry.
+
+-- | Capture an immutable snapshot of a value, given the current value of the
+-- mutable variable heap.
+--
+snapshotValue :: Heap -> Value t -> ImmValue
+snapshotValue _  ValUnit   = ImmValUnit
+snapshotValue _ (ValInt x) = ImmValInt x
+snapshotValue h (ValVar n) = ImmValVar (snapshotValue h (readVar h n))
+
+
+--
+-- Execution in an STM monad (real or sim)
+--
+
+data ExecValue m (t :: Type) where
+
+    ExecValUnit ::                           ExecValue m TyUnit
+    ExecValInt  :: Int                    -> ExecValue m TyInt
+    ExecValVar  :: LazyTVar m (ExecValue m t) 
+                -> TyRep t                -> ExecValue m (TyVar t)
+
+instance Show (ExecValue m t) where
+  show  ExecValUnit         = "ExecValUnit"
+  show (ExecValInt x)       = "ExecValInt " ++ show x
+  show (ExecValVar _ tyrep) = "ExecValVar (<tvar> :: " ++ show tyrep ++ ")"
+
+
+data SomeExecValue m where
+     SomeExecValue :: ExecValue m t -> SomeExecValue m
+
+deriving instance Show (SomeExecValue m)
+
+
+newtype ExecEnv m = ExecEnv (Map NameId (SomeExecValue m))
+  deriving (Semigroup, Monoid)
+
+tyRepExecValue :: ExecValue m t -> TyRep t
+tyRepExecValue  ExecValUnit         = TyRepUnit
+tyRepExecValue (ExecValInt _)       = TyRepInt
+tyRepExecValue (ExecValVar _ tyrep) = TyRepVar tyrep
+
+lookupExecEnv :: ExecEnv m -> Name t -> ExecValue m t
+lookupExecEnv (ExecEnv env) (Name name tyrep) =
+    fromMaybe (error "lookupExecEnv: no such var") $ do
+    SomeExecValue v <- Map.lookup name env
+    Refl            <- tyrep `eqTyRep` tyRepExecValue v
+    return v
+
+extendExecEnv :: Name t -> ExecValue m t -> ExecEnv m -> ExecEnv m
+extendExecEnv (Name name _tyrep) v (ExecEnv env) =
+    ExecEnv (Map.insert name (SomeExecValue v) env)
+
+
+-- | Execute an STM 'Term' in the 'STM' monad.
+--
+--execTerm :: (MonadSTM m, MonadThrow (STM m))
+--         => ExecEnv m
+--         -> Term t
+--         -> STM m (ExecValue m t)
+execTerm :: ExecEnv IO
+         -> Term t
+         -> STM IO (ExecValue IO t)
+execTerm env t =
+    case t of
+      Return e -> do
+        let e' = execExpr env e
+        return e'
+
+      Throw e -> do
+        let e' = execExpr env e
+        throwM =<< snapshotExecValue e'
+
+      Retry -> retry
+
+      ReadTVar n -> do
+        let tv = case lookupExecEnv env n of
+                   ExecValVar v _ -> v
+        readTVar tv
+
+      WriteTVar n e -> do
+        let tv = case lookupExecEnv env n of
+                   ExecValVar v _ -> v
+            e' = execExpr env e
+        writeTVar tv e'
+        return ExecValUnit
+
+      NewTVar e -> do
+        let e'    = execExpr env e
+            tyrep = tyRepExecValue e'
+        tv <- newTVar e'
+        return (ExecValVar tv tyrep)
+
+
+      Bind t1 n1 t2 -> do
+        v1 <- execTerm env t1
+        let env' = extendExecEnv n1 v1 env
+        execTerm env' t2
+
+      OrElse t1 t2 -> execTerm env t1
+             `IOSTM.orElse` execTerm env t2
+
+execExpr :: forall m t. ExecEnv m -> Expr t -> ExecValue m t
+execExpr _    ExprUnit    = ExecValUnit
+execExpr _   (ExprInt x)  = ExecValInt x
+execExpr env (ExprName n) = lookupExecEnv env n
+
+snapshotExecValue :: MonadSTM m => ExecValue m t -> STM m ImmValue
+snapshotExecValue  ExecValUnit     = return  ImmValUnit
+snapshotExecValue (ExecValInt x)   = return (ImmValInt x)
+snapshotExecValue (ExecValVar v _) = fmap ImmValVar
+                                          (snapshotExecValue =<< readTVar v)
+
+--execAtomically :: (MonadSTM m, MonadThrow (STM m), MonadCatch m)
+--               => Term t -> m TxResult
+execAtomically :: Term t -> IO TxResult
+execAtomically t =
+    toTxResult <$> try (atomically action')
+  where
+    action  = snapshotExecValue =<< execTerm mempty t
+             
+    action' = fmap Just action `IOSTM.orElse` return Nothing
+    -- We want to observe if the transaction would block. If we trust the STM
+    -- implementation then we can just use 'orElse' to observe the blocking.
+
+    toTxResult (Right (Just x)) = TxComitted x
+    toTxResult (Left e)         = TxAborted  e
+    toTxResult (Right Nothing)  = TxBlocked
+
+
+--
+-- QuickCheck generators
+--
+
+instance Arbitrary SomeTerm where
+  arbitrary = genSomeTerm emptyGenEnv
+
+  shrink (SomeTerm tyrep t) = [ SomeTerm tyrep t' | t' <- shrinkTerm t ]
+
+
+data SomeTerm where
+     SomeTerm :: TyRep t -> Term t -> SomeTerm
+
+data SomeExpr where
+     SomeExpr :: Expr t -> SomeExpr
+
+deriving instance Show SomeTerm
+deriving instance Show SomeExpr
+
+{-
+instance Show SomeTerm where
+    show (SomeTerm _ t) = showTerm 0 t ""
+
+instance Show SomeExpr where
+    show (SomeExpr e) = showExpr 0 e ""
+-}
+
+-- | The generator environment, used to keep track of what names are in scope
+-- in the terms and expressions we generate.
+--
+data GenEnv = GenEnv {
+       -- | The sets of names, grouped by type
+       envNames    :: TyTrie NameId,
+
+       -- | For managing the fresh name supply
+       envNextName :: NameId 
+     }
+
+data TyTrie a =
+     TyTrieEmpty
+   | TyTrieNode {
+       trieUnit :: [a],
+       trieInt  :: [a],
+       trieVar  :: TyTrie a
+     }
+  deriving Show
+
+lookupTyTrie :: TyTrie a -> TyRep t -> [a]
+lookupTyTrie TyTrieNode{trieUnit}  TyRepUnit       = trieUnit
+lookupTyTrie TyTrieNode{trieInt}   TyRepInt        = trieInt
+lookupTyTrie TyTrieNode{trieVar}  (TyRepVar tyrep) = lookupTyTrie trieVar tyrep
+lookupTyTrie _                     _               = []
+
+insertTyTrie :: TyTrie a -> TyRep t -> a -> TyTrie a
+insertTyTrie TyTrieEmpty tyrep x =
+    case tyrep of
+      TyRepUnit       -> TyTrieNode [x] [] TyTrieEmpty
+      TyRepInt        -> TyTrieNode [] [x] TyTrieEmpty
+      TyRepVar tyrep' -> TyTrieNode [] [] (insertTyTrie TyTrieEmpty tyrep' x)
+
+insertTyTrie node@TyTrieNode{trieUnit = us, trieInt = ns, trieVar} tyrep x =
+    case tyrep of
+      TyRepUnit       -> node { trieUnit = x : us }
+      TyRepInt        -> node { trieInt  = x : ns }
+      TyRepVar tyrep' -> node { trieVar  = insertTyTrie trieVar tyrep' x }
+
+emptyGenEnv :: GenEnv
+emptyGenEnv = GenEnv TyTrieEmpty (NameId 0)
+
+lookupNames :: GenEnv -> TyRep t -> Maybe [Name t]
+lookupNames GenEnv{envNames} tyrep =
+    case lookupTyTrie envNames tyrep of
+      [] -> Nothing
+      ns -> Just [ Name n tyrep | n <- ns ]
+
+freshName :: GenEnv -> TyRep t -> (Name t, GenEnv)
+freshName GenEnv {envNames, envNextName} tyrep =
+    (name, env')
+  where
+    name = Name envNextName tyrep
+    env' = GenEnv {
+             envNames    = insertTyTrie envNames tyrep envNextName,
+             envNextName = succ envNextName
+           }
+
+pickName :: GenEnv -> TyRep t -> Maybe (Gen (Name t))
+pickName env tyrep =
+    elements <$> lookupNames env tyrep
+
+data SomeVarName where
+     SomeVarName :: Name (TyVar t) -> SomeVarName
+deriving instance Show SomeVarName
+
+lookupVarNames :: GenEnv -> [SomeVarName]
+lookupVarNames GenEnv{envNames = TyTrieEmpty} = []
+lookupVarNames GenEnv{envNames = TyTrieNode{trieVar = trieVar0}} =
+    go 0 trieVar0
+  where
+    go :: Int -> TyTrie NameId -> [SomeVarName]
+    go _ TyTrieEmpty = []
+    go d TyTrieNode{trieUnit = us, trieInt = ns, trieVar} =
+         [ deep n TyRepUnit d | n <- us ]
+      ++ [ deep n TyRepInt  d | n <- ns ]
+      ++ go (succ d) trieVar
+
+deep :: NameId -> TyRep t -> Int -> SomeVarName
+deep nid tyrep 0 = SomeVarName (Name nid (TyRepVar tyrep))
+deep nid tyrep d = deep nid (TyRepVar tyrep) (pred d)
+
+
+-- | Generate a 'Term' of some type.
+--
+genSomeTerm :: GenEnv -> Gen SomeTerm
+genSomeTerm env =
+  oneof
+    [ SomeTerm          TyRepUnit
+        <$> genTerm env TyRepUnit
+    , SomeTerm          TyRepInt
+        <$> genTerm env TyRepInt
+    , SomeTerm          (TyRepVar TyRepInt)
+        <$> genTerm env (TyRepVar TyRepInt)
+    , SomeTerm          (TyRepVar (TyRepVar TyRepInt))
+        <$> genTerm env (TyRepVar (TyRepVar TyRepInt))
+      -- vars of vars is probably deep enough.
+    ]
+
+-- | Generate a 'Term' of a given type.
+--
+genTerm :: GenEnv -> TyRep t -> Gen (Term t)
+genTerm env tyrep =
+    sized $ \sz ->
+      if sz <= 1
+        then leafTerm
+        else frequency [ (1, leafTerm), (2, binTerm) ]
+  where
+    leafTerm =
+      frequency' $
+        [ (2, fmap Return <$> genExpr env tyrep)
+        , (1, Just ((\(SomeExpr e) -> Throw e) <$> genSomeExpr env))
+        , (1, Just (pure Retry))
+        , (3, do genvarname <- pickName env (TyRepVar tyrep)
+                 return (ReadTVar <$> genvarname))
+        , (3, case tyrep of
+                TyRepUnit ->
+                  case [ WriteTVar varname <$> genexpr
+                       | SomeVarName varname <- lookupVarNames env
+                       , let TyRepVar valtyrep = nameTyRep varname
+                       , genexpr <- maybeToList $ genExpr env valtyrep
+                       ]
+                  of [] -> Nothing
+                     ws -> Just (oneof ws)
+                TyRepVar vartyrep ->
+                  fmap NewTVar <$> genExpr env vartyrep
+                TyRepInt ->
+                  Nothing)
+        ]
+
+    binTerm = frequency [ (2, bindTerm), (1, orElseTerm)]
+
+    bindTerm =
+      sized $ \sz -> do
+        let sz1 = sz     `div` 3   -- 1/3
+            sz2 = sz * 2 `div` 3   -- 2/3
+            -- To right bias it a bit
+
+        SomeTerm t1ty t1 <- resize sz1 (genSomeTerm env)
+        let (name, env') = freshName env t1ty
+        t2 <- resize sz2 (genTerm env' tyrep)
+        return (Bind t1 name t2)
+
+    orElseTerm =
+      sized $ \sz -> resize (sz `div` 2) $
+        OrElse <$> genTerm env tyrep
+               <*> genTerm env tyrep
+
+genSomeExpr :: GenEnv -> Gen SomeExpr
+genSomeExpr env =
+    oneof'
+      [ fmap SomeExpr <$> genExpr env TyRepUnit
+      , fmap SomeExpr <$> genExpr env TyRepInt
+      , fmap SomeExpr <$> genExpr env (TyRepVar TyRepInt)
+      , fmap SomeExpr <$> genExpr env (TyRepVar (TyRepVar TyRepInt))
+      ]
+
+genExpr :: GenEnv -> TyRep t -> Maybe (Gen (Expr t))
+genExpr env tyrep@TyRepUnit =
+    Just $ oneof'
+      [ Just (pure ExprUnit)
+      , fmap ExprName <$> pickName env tyrep
+      ]
+genExpr env tyrep@TyRepInt  =
+    Just $ oneof'
+      [ Just (ExprInt <$> arbitrary)
+      , fmap ExprName <$> pickName env tyrep
+      ]
+genExpr env tyrep@TyRepVar{} =
+    fmap ExprName <$> pickName env tyrep
+
+
+elements' :: [Maybe a] -> Gen a
+elements' xs = elements [ g | Just g <- xs ]
+
+oneof' :: [Maybe (Gen a)] -> Gen a
+oneof' xs = oneof [ g | Just g <- xs ]
+
+frequency' :: [(Int, Maybe (Gen a))] -> Gen a
+frequency' xs = frequency [ (n, g) | (n, Just g) <- xs ]
+
+shrinkTerm :: Term t -> [Term t]
+shrinkTerm t =
+    case t of
+      Return e      -> [Return e' | e' <- shrinkExpr e]
+      Throw e       -> [Throw  e' | e' <- shrinkExpr e]
+      Retry         -> []
+      ReadTVar _    -> []
+
+      WriteTVar _ _ -> [Return ExprUnit] --TODO: there are other less drastic shrinks possible here
+
+      NewTVar e     -> [NewTVar e' | e' <- shrinkExpr e]
+
+      Bind t1 n t2  -> [ t2 | nameId n `Set.notMember` freeNamesTerm t2 ]
+                    ++ [ Bind t1' n t2  | t1' <- shrinkTerm t1 ]
+                    ++ [ Bind t1  n t2' | t2' <- shrinkTerm t2 ]
+
+      OrElse t1 t2  -> [t1, t2]
+                    ++ [ OrElse t1' t2  | t1' <- shrinkTerm t1 ]
+                    ++ [ OrElse t1  t2' | t2' <- shrinkTerm t2 ]
+
+shrinkExpr :: Expr t -> [Expr t]
+shrinkExpr  ExprUnit                        = []
+shrinkExpr (ExprInt n)                      = [ExprInt n' | n' <- shrink n]
+shrinkExpr (ExprName (Name _ TyRepUnit))    = [ExprUnit]
+shrinkExpr (ExprName (Name _ TyRepInt))     = [ExprInt 0]
+shrinkExpr (ExprName (Name _ (TyRepVar _))) = []
+
+freeNamesTerm :: Term t -> Set NameId
+freeNamesTerm (Return e)      = freeNamesExpr e
+freeNamesTerm (Throw  e)      = freeNamesExpr e
+freeNamesTerm  Retry          = Set.empty
+freeNamesTerm (ReadTVar  n)   = Set.singleton (nameId n)
+freeNamesTerm (WriteTVar n e) = Set.singleton (nameId n) <> freeNamesExpr e
+freeNamesTerm (NewTVar e)     = freeNamesExpr e
+freeNamesTerm (Bind t1 n t2)  = freeNamesTerm t1 <> Set.delete (nameId n)
+                                                               (freeNamesTerm t2)
+freeNamesTerm (OrElse t1 t2)  = freeNamesTerm t1 <> freeNamesTerm t2
+
+freeNamesExpr :: Expr t -> Set NameId
+freeNamesExpr  ExprUnit    = Set.empty
+freeNamesExpr (ExprInt _)  = Set.empty
+freeNamesExpr (ExprName n) = Set.singleton (nameId n)
+
+nameId :: Name t -> NameId
+nameId (Name nid _) = nid
+
+prop_genSomeTerm :: SomeTerm -> Property
+prop_genSomeTerm (SomeTerm tyrep term) =
+    tabulate "1. Term type"  [show tyrep] $
+    tabulate "2. Term size"  [show (sizeBucket (termSize term))] $
+    tabulate "3. Term depth" [show (termDepth term)] $
+    case evalAtomically term of
+      (!_val, !_heap') -> True
+  where
+    sizeBucket s = ((s-1) `div` 10 + 1) * 10
+
+
+termSize :: Term a -> Int
+termSize Return{}     = 1
+termSize Throw{}      = 1
+termSize Retry{}      = 1
+termSize ReadTVar{}   = 1
+termSize WriteTVar{}  = 1
+termSize NewTVar{}    = 1
+termSize (Bind a _ b) = 1 + termSize a + termSize b
+termSize (OrElse a b) = 1 + termSize a + termSize b
+
+termDepth :: Term a -> Int
+termDepth Return{}     = 1
+termDepth Throw{}      = 1
+termDepth Retry{}      = 1
+termDepth ReadTVar{}   = 1
+termDepth WriteTVar{}  = 1
+termDepth NewTVar{}    = 1
+termDepth (Bind a _ b) = 1 + max (termDepth a) (termDepth b)
+termDepth (OrElse a b) = 1 + max (termDepth a) (termDepth b)
+
+showTerm :: Int -> Term t -> ShowS
+showTerm p (Return e)      = showParen (p > 10) $
+                               showString "return " . showExpr 11 e
+showTerm p (Throw  e)      = showParen (p > 10) $
+                               showString "throwSTM " . showExpr 11 e
+showTerm _  Retry          = showString "retry"
+showTerm p (ReadTVar  n)   = showParen (p > 10) $
+                               showString "readTVar " . showName n
+showTerm p (WriteTVar n e) = showParen (p > 10) $
+                               showString "writeTVar " . showName n
+                                        . showChar ' ' . showExpr 11 e
+showTerm p (NewTVar e)     = showParen (p > 10) $
+                               showString "newTVar " . showExpr 11 e
+showTerm p (Bind t1 n t2)  = showParen (p > 1) $
+                               showTerm 2 t1 . showString " >>= \\"
+                             . showNameTyped n . showString " -> "
+                             . showTerm 1 t2
+showTerm p (OrElse t1 t2)  = showParen (p > 9) $
+                               showTerm 10 t1 . showString " `orElse` "
+                             . showTerm 10 t2
+
+showExpr :: Int -> Expr t -> ShowS
+showExpr _ ExprUnit     = showString "()"
+showExpr p (ExprInt n)  = showsPrec p n
+showExpr _ (ExprName n) = showName n
+
+showName :: Name t -> ShowS
+showName (Name (NameId nid) _) = showChar 'v' . shows nid
+
+showNameTyped :: Name t -> ShowS
+showNameTyped (Name (NameId nid) tyrep) =
+    showChar 'v' . shows nid
+  . showString " :: " . showTyRep 0 tyrep
+
+showTyRep :: Int -> TyRep t -> ShowS
+showTyRep _  TyRepUnit   = showString "()"
+showTyRep _  TyRepInt    = showString "Int"
+showTyRep p (TyRepVar t) = showParen (p > 10) $
+                             showString "TVar " . showTyRep 11 t
+


### PR DESCRIPTION
Implement `orElse` for the Sim, and add it to the `MonadSTM` class

Added a reference operational semantics for STM based on the original STM paper. Tests compare the reference semantics to GHC's IO STM implementation and to the simulator implementation.
