### PR TITLE
Restore the original Condense instance for SlotNo

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -157,7 +157,7 @@ instance Condense CC.UTxO.TxId where
   condense hash = "txid:" <> unpack (sformat shortHashF hash)
 
 instance Condense BlockNo where
-  condense (BlockNo n) = 'b' : show n
+  condense (BlockNo n) = show n
 
 instance Condense SlotNo where
-  condense (SlotNo n) = 's' : show n
+  condense (SlotNo n) = show n


### PR DESCRIPTION
This addresses #1105: cardano-node breaks because it is using `read` to parse
the `SlotNo` from a trace message, and the tracer is using our `Condense`
instance for `SlotNo`. I warned them that this may cause some accidental
breakage :)