### PR TITLE
Test for unexpected message delays

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
@@ -16,6 +16,9 @@ module Ouroboros.Consensus.Block (
   , headerPoint
     -- * Supported blocks
   , SupportedBlock
+    -- * EBBs
+  , IsEBB (..)
+  , toIsEBB
   ) where
 
 import           Cardano.Prelude (NoUnexpectedThunks)
@@ -24,6 +27,7 @@ import           Data.FingerTree.Strict (Measured (..))
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.Condense
 
 {-------------------------------------------------------------------------------
   Link block to its header
@@ -81,3 +85,29 @@ class ( GetHeader blk
       , SupportedHeader (BlockProtocol blk) (Header blk)
       , NoUnexpectedThunks (Header blk)
       ) => SupportedBlock blk
+
+{-------------------------------------------------------------------------------
+  EBBs
+-------------------------------------------------------------------------------}
+
+-- | Whether a block is an Epoch Boundary Block (EBB)
+--
+-- See "Ouroboros.Storage.ImmutableDB.API" for a discussion of EBBs. Key
+-- idiosyncracies:
+--
+--  * An EBB carries no unique information.
+--
+--  * An EBB has the same 'BlockNo' as its predecessor.
+--
+--  * EBBs are vestigial. As of Shelley, nodes no longer forge EBBs: they are
+--    only a legacy/backwards-compatibility concern.
+data IsEBB
+  = IsEBB
+  | IsNotEBB
+  deriving (Eq, Show)
+
+instance Condense IsEBB where
+  condense = show
+
+toIsEBB :: Bool -> IsEBB
+toIsEBB b = if b then IsEBB else IsNotEBB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -30,6 +30,13 @@ newtype LeaderSchedule = LeaderSchedule {getLeaderSchedule :: Map SlotNo [CoreNo
     deriving stock    (Show, Eq, Ord, Generic)
     deriving anyclass (NoUnexpectedThunks)
 
+instance Semigroup LeaderSchedule where
+    LeaderSchedule l <> LeaderSchedule r =
+        LeaderSchedule $
+        Map.unionWith comb l r
+      where
+        comb ls rs = ls ++ filter (`notElem` ls) rs
+
 instance Condense LeaderSchedule where
     condense (LeaderSchedule m) = condense
                                 $ map (\(s, ls) -> (s, map fromCoreNodeId ls))

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -26,6 +26,7 @@ module Ouroboros.Storage.ChainDB.Impl (
 
 import           Control.Monad (when)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (isJust)
 
 import           Control.Tracer
 
@@ -143,6 +144,7 @@ openDBInternal args launchBgTasks = do
                   , cdbGcDelay        = Args.cdbGcDelay args
                   , cdbBgThreads      = varBgThreads
                   , cdbEpochInfo      = Args.cdbEpochInfo args
+                  , cdbIsEBB          = isJust . Args.cdbIsEBB args
                   }
     h <- fmap CDBHandle $ newTVarM $ ChainDbOpen env
     let chainDB = ChainDB

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
@@ -47,7 +47,8 @@ import           Ouroboros.Network.Block (BlockNo, HasHeader (..), HeaderHash,
                      Point, SlotNo, blockPoint, castPoint, pointHash)
 import           Ouroboros.Network.Point (WithOrigin)
 
-import           Ouroboros.Consensus.Block (BlockProtocol, GetHeader (..))
+import           Ouroboros.Consensus.Block (BlockProtocol, GetHeader (..),
+                     toIsEBB)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.IOLike
@@ -221,7 +222,7 @@ addBlock cdb@CDB{..} b = do
 
       -- Write the block to the VolatileDB in all other cases
       VolDB.putBlock cdbVolDB b
-      trace $ AddedBlockToVolDB (blockPoint b) (blockNo b) (cdbIsEBB b)
+      trace $ AddedBlockToVolDB (blockPoint b) (blockNo b) (toIsEBB (cdbIsEBB b))
 
       -- We need to get these after adding the block to the VolatileDB
       (isMember', succsOf, predecessor) <- atomically $

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
@@ -221,7 +221,7 @@ addBlock cdb@CDB{..} b = do
 
       -- Write the block to the VolatileDB in all other cases
       VolDB.putBlock cdbVolDB b
-      trace (AddedBlockToVolDB (blockPoint b))
+      trace $ AddedBlockToVolDB (blockPoint b) (blockNo b) (cdbIsEBB b)
 
       -- We need to get these after adding the block to the VolatileDB
       (isMember', succsOf, predecessor) <- atomically $

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -207,6 +207,7 @@ data ChainDbEnv m blk = CDB
   , cdbBgThreads      :: !(StrictTVar m [Thread m ()])
     -- ^ The background threads.
   , cdbEpochInfo      :: !(EpochInfo m)
+  , cdbIsEBB          :: !(blk -> Bool)
   } deriving (Generic)
 
 -- | We include @blk@ in 'showTypeOf' because it helps resolving type families
@@ -333,8 +334,10 @@ data TraceOpenEvent blk
 
 -- | Trace type for the various events that occur when adding a block.
 data TraceAddBlockEvent blk
-  = AddedBlockToVolDB    (Point blk)
+  = AddedBlockToVolDB    !(Point blk) !BlockNo !Bool
     -- ^ A block was added to the Volatile DB
+    --
+    -- its point, its block number, whether it's an EBB
 
   | TryAddToCurrentChain (Point blk)
     -- ^ The block fits onto the current chain, we'll try to use it to extend

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -53,7 +53,7 @@ import           Ouroboros.Network.Block (BlockNo, HasHeader, HeaderHash, Point,
                      SlotNo, StandardHash)
 import           Ouroboros.Network.Point (WithOrigin)
 
-import           Ouroboros.Consensus.Block (BlockProtocol, Header)
+import           Ouroboros.Consensus.Block (BlockProtocol, Header, IsEBB (..))
 import           Ouroboros.Consensus.Ledger.Abstract (ProtocolLedgerView)
 import           Ouroboros.Consensus.Ledger.Extended (ExtValidationError)
 import           Ouroboros.Consensus.Protocol.Abstract (NodeConfig)
@@ -334,10 +334,8 @@ data TraceOpenEvent blk
 
 -- | Trace type for the various events that occur when adding a block.
 data TraceAddBlockEvent blk
-  = AddedBlockToVolDB    !(Point blk) !BlockNo !Bool
+  = AddedBlockToVolDB    !(Point blk) !BlockNo !IsEBB
     -- ^ A block was added to the Volatile DB
-    --
-    -- its point, its block number, whether it's an EBB
 
   | TryAddToCurrentChain (Point blk)
     -- ^ The block fits onto the current chain, we'll try to use it to extend

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -34,7 +34,7 @@ prop_simple_bft_convergence k
   testConfig@TestConfig{numCoreNodes, numSlots} seed =
     prop_general k
         testConfig
-        (roundRobinLeaderSchedule numCoreNodes numSlots)
+        (Just $ roundRobinLeaderSchedule numCoreNodes numSlots)
         testOutput
   where
     testOutput =

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -69,7 +69,7 @@ prop_simple_leader_schedule_convergence
   params@PraosParams{praosSecurityParam = k}
   testConfig@TestConfig{numCoreNodes} schedule seed =
     counterexample (tracesToDot testOutputNodes) $
-    prop_general k testConfig schedule testOutput
+    prop_general k testConfig (Just schedule) testOutput
   where
     testOutput@TestOutput{testOutputNodes} =
         runTestNetwork

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -274,12 +274,12 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
         , cdbTracer           = Tracer $ \case
               ChainDB.TraceAddBlockEvent
                   (ChainDB.AddBlockValidation ChainDB.InvalidBlock
-                      { _invalidPoint = p }) ->
-                  traceWith invalidTracer p
+                      { _invalidPoint = p })
+                  -> traceWith invalidTracer p
               ChainDB.TraceAddBlockEvent
-                  (ChainDB.AddedBlockToVolDB p bno isEBB) ->
-                  when (not isEBB) $ traceWith addTracer (p, bno)
-              _                        -> pure ()
+                  (ChainDB.AddedBlockToVolDB p bno IsNotEBB)
+                  -> traceWith addTracer (p, bno)
+              _   -> pure ()
         , cdbRegistry         = registry
         , cdbGcDelay          = 0
         }

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
@@ -35,7 +35,7 @@ prop_simple_pbft_convergence
   k testConfig@TestConfig{numCoreNodes, numSlots} seed =
     prop_general k
         testConfig
-        (roundRobinLeaderSchedule numCoreNodes numSlots)
+        (Just $ roundRobinLeaderSchedule numCoreNodes numSlots)
         testOutput
   where
     NumCoreNodes nn = numCoreNodes

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -85,13 +85,11 @@ prop_simple_praos_convergence :: PraosParams
                               -> Property
 prop_simple_praos_convergence
   params@PraosParams{praosSecurityParam = k}
-  testConfig@TestConfig{numCoreNodes, numSlots} seed =
+  testConfig@TestConfig{numCoreNodes} seed =
     counterexample (tracesToDot testOutputNodes) $
-    prop_general k testConfig schedule testOutput
+    prop_general k testConfig Nothing testOutput
   where
     testOutput@TestOutput{testOutputNodes} =
         runTestNetwork
             (\nid -> protocolInfo numCoreNodes nid (ProtocolMockPraos params))
             testConfig seed
-
-    schedule = leaderScheduleFromTrace numSlots testOutputNodes

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
@@ -100,7 +100,7 @@ prop_simple_real_pbft_convergence
     giveByron $
     prop_general k
         testConfig
-        (roundRobinLeaderSchedule numCoreNodes numSlots)
+        (Just $ roundRobinLeaderSchedule numCoreNodes numSlots)
         testOutput
     .&&. not (all Chain.null finalChains)
   where

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
@@ -9,7 +9,6 @@ module Test.Dynamic.Util (
     prop_all_common_prefix
   , shortestLength
   -- * LeaderSchedule
-  , leaderScheduleFromTrace
   , roundRobinLeaderSchedule
   , consensusExpected
   -- * GraphViz Dot
@@ -223,33 +222,6 @@ tracesToDot traces = Text.unpack $ printDotGraph $ graphToDot quickParams graph
 {-------------------------------------------------------------------------------
   Leader Schedule
 -------------------------------------------------------------------------------}
-
-leaderScheduleFromTrace :: forall b. (HasCreator b, HasHeader b)
-                        => NumSlots
-                        -> Map NodeId (NodeOutput b)
-                        -> LeaderSchedule
-leaderScheduleFromTrace (NumSlots numSlots) = LeaderSchedule .
-    Map.foldl' addNodeOutput initial
-  where
-    initial :: Map SlotNo [CoreNodeId]
-    initial = Map.fromList [(slot, []) | slot <- [1 .. fromIntegral numSlots]]
-
-    addNodeOutput :: Map SlotNo [CoreNodeId]
-                  -> NodeOutput b
-                  -> Map SlotNo [CoreNodeId]
-    addNodeOutput m NodeOutput {nodeOutputCfg = nc, nodeOutputFinalChain = c} =
-      Chain.foldChain (step nc) m c
-
-    step :: NodeConfig (BlockProtocol b)
-         -> Map SlotNo [CoreNodeId]
-         -> b
-         -> Map SlotNo [CoreNodeId]
-    step nc m b = Map.adjust (insert $ getCreator nc b) (blockSlot b) m
-
-    insert :: CoreNodeId -> [CoreNodeId] -> [CoreNodeId]
-    insert nid xs
-        | nid `elem` xs = xs
-        | otherwise     = nid : xs
 
 consensusExpected ::
      SecurityParam

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util.hs
@@ -9,6 +9,7 @@ module Test.Dynamic.Util (
     prop_all_common_prefix
   , shortestLength
   -- * LeaderSchedule
+  , emptyLeaderSchedule
   , roundRobinLeaderSchedule
   , consensusExpected
   -- * GraphViz Dot
@@ -232,6 +233,13 @@ consensusExpected k nodeJoinPlan schedule =
     maxForkLength <= maxRollbacks k
   where
     NumBlocks maxForkLength = determineForkLength k nodeJoinPlan schedule
+
+emptyLeaderSchedule :: NumSlots -> LeaderSchedule
+emptyLeaderSchedule (NumSlots t) = LeaderSchedule $
+    Map.fromList $
+    [ (SlotNo (toEnum i), [])
+    | i <- [ 0 .. t - 1 ]
+    ]
 
 roundRobinLeaderSchedule :: NumCoreNodes -> NumSlots -> LeaderSchedule
 roundRobinLeaderSchedule (NumCoreNodes n) (NumSlots t) = LeaderSchedule $


### PR DESCRIPTION
This test confirms that our current test suite is not introducing any unexpected message delays, where _message delays_ is analogous to that from the paper https://eprint.iacr.org/2017/573/20171115:001835.

Issues #229 and #230 will cause this property to fail; they'll have to refine it somehow.