### PR TITLE
Protect against unintended file deletion

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -247,6 +247,7 @@ test-suite test-consensus
                     Test.Consensus.Mempool
                     Test.Consensus.Mempool.TestBlock
                     Test.Consensus.Mempool.TestTx
+                    Test.Consensus.Node
                     Test.Consensus.Protocol.PBFT
                     Test.Consensus.ResourceRegistry
                     Test.Dynamic.BFT

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -62,6 +62,7 @@ library
                        Ouroboros.Consensus.Mempool.Impl
                        Ouroboros.Consensus.Mempool.TxSeq
                        Ouroboros.Consensus.Node
+                       Ouroboros.Consensus.Node.DbMarker
                        Ouroboros.Consensus.Node.ProtocolInfo
                        Ouroboros.Consensus.Node.ProtocolInfo.Abstract
                        Ouroboros.Consensus.Node.ProtocolInfo.Byron

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -24,9 +24,6 @@ module Ouroboros.Consensus.Node
   , NodeArgs (..)
   , NodeKernel (..)
     -- * Internal helpers
-  , checkProtocolMagicId
-  , protocolMagicIdFile
-  , ChainDbCheckError (..)
   , initChainDB
   , mkNodeArgs
   , initNetwork
@@ -34,17 +31,12 @@ module Ouroboros.Consensus.Node
 
 import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Term as CBOR
-import qualified Codec.CBOR.Write as CBOR
 import           Control.Monad (forM, void)
-import           Control.Monad.Except
-import           Control.Tracer
+import           Control.Tracer (Tracer)
 import           Crypto.Random
 import           Data.ByteString.Lazy (ByteString)
-import qualified Data.ByteString.Lazy as Lazy
 import           Data.List (any)
 import           Data.Proxy (Proxy (..))
-import qualified Data.Set as Set
-import           Data.Text (Text)
 import           Data.Time.Clock (secondsToDiffTime)
 import           Network.Mux.Types (MuxTrace, WithMuxBearer)
 import           Network.Socket as Socket
@@ -52,9 +44,6 @@ import           Network.Socket as Socket
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
-
-import           Cardano.Binary (fromCBOR, toCBOR)
-import           Cardano.Crypto (ProtocolMagicId)
 
 import           Ouroboros.Network.Block
 import qualified Ouroboros.Network.Block as Block
@@ -70,6 +59,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.ChainSyncClient (ClockSkew (..))
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import           Ouroboros.Consensus.Mempool (GenTx, MempoolCapacity (..))
+import           Ouroboros.Consensus.Node.DbMarker
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Tracers
@@ -83,7 +73,6 @@ import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Storage.ChainDB (ChainDB, ChainDbArgs)
 import qualified Ouroboros.Storage.ChainDB as ChainDB
 import           Ouroboros.Storage.EpochInfo (newEpochInfo)
-import           Ouroboros.Storage.FS.API
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.FS.IO (ioHasFS)
 import           Ouroboros.Storage.ImmutableDB (ValidationPolicy (..))
@@ -117,11 +106,15 @@ run
   -> IO ()
 run tracers chainDbTracer rna dbPath pInfo
     customiseChainDbArgs customiseNodeArgs onNodeKernel = do
-    let mountPoint = MountPoint dbPath
-    either throwM return =<< checkProtocolMagicId
-      (ioHasFS mountPoint)
-      mountPoint
-      (nodeProtocolMagicId (Proxy @blk) cfg)
+    -- TODO: Enable once new index format lands.
+    if False then do
+      let mountPoint = MountPoint dbPath
+      either throwM return =<< checkDbMarker
+        (ioHasFS mountPoint)
+        mountPoint
+        (nodeProtocolMagicId (Proxy @blk) cfg)
+    else
+      return () -- Skipping check for now
     withRegistry $ \registry -> do
 
       chainDB <- initChainDB
@@ -167,115 +160,6 @@ run tracers chainDbTracer rna dbPath pInfo
     --
     -- For now, we hard-code it to Byron's 20 seconds.
     slotLength = slotLengthFromMillisec (20 * 1000)
-
-
--- | The database folder will contain folders for the ImmutableDB
--- (@immutable@), the VolatileDB (@volatile@), and the LedgerDB (@ledger@).
--- All three subdatabases can delete files from these folders, e.g., outdated
--- files or files that are deemed invalid.
---
--- For example, when starting a node that will connect to a testnet with a
--- database folder containing mainnet blocks, these blocks will be deemed
--- invalid and will be deleted. This would throw away a perfectly good chain,
--- possibly consisting of gigabytes of data that will have to be synched
--- again.
---
--- To protect us from unwanted deletion of valid files, we first check whether
--- we have been given the path to the right database folder. We do this by
--- reading the 'ProtocolMagicId' of the net from a file stored in the root of
--- the database folder. This file's name is defined in 'protocolMagicIdFile'.
---
--- * If the 'ProtocolMagicId' from the file matches that of the net, we have
---   the right database folder.
--- * If not, we are opening the wrong database folder and abort by throwing a
---   'ChainDbCheckError'.
--- * If there is no such file and the folder is empty, we create it and store
---   the net's 'ProtocolMagicId' in it.
--- * If there is no such file, but the folder is not empty, we throw a
---   'ChainDbCheckError', because we have likely been given the wrong path,
---   maybe to a folder containing user or system files. This includes the case
---   that the 'protocolMagicIdFile' has been deleted.
--- * If there is such a 'protocolMagicIdFile', but it could not be read or its
---   contents could not be parsed, we also throw a 'ChainDbCheckError'.
---
--- Note that an 'FsError' can also be thrown.
-checkProtocolMagicId
-  :: forall m h. MonadThrow m
-  => HasFS m h
-  -> MountPoint
-     -- ^ Database directory. Should be the mount point of the @HasFS@. Used
-     -- in error messages.
-  -> ProtocolMagicId
-  -> m (Either ChainDbCheckError ())
-checkProtocolMagicId hasFS mountPoint protocolMagicId = runExceptT $ do
-    lift $ createDirectoryIfMissing hasFS True root
-    fileExists <- lift $ doesFileExist hasFS pFile
-    if fileExists then do
-      actualProtocolMagicId <- readProtocolMagicIdFile
-      when (actualProtocolMagicId /= protocolMagicId) $
-        throwError $ ProtocolMagicIdMismatch
-          fullPath
-          actualProtocolMagicId
-          protocolMagicId
-    else do
-      isEmpty <- lift $ Set.null <$> listDirectory hasFS root
-      if isEmpty then
-        createProtocolMagicIdFile
-      else
-        throwError $ NoProtocolMagicIdAndNotEmpty fullPath
-  where
-    root     = mkFsPath []
-    pFile    = fsPathFromList [protocolMagicIdFile]
-    fullPath = fsToFilePath mountPoint pFile
-
-    readProtocolMagicIdFile :: ExceptT ChainDbCheckError m ProtocolMagicId
-    readProtocolMagicIdFile = ExceptT $
-      withFile hasFS pFile ReadMode $ \h -> do
-        res <- CBOR.deserialiseFromBytes fromCBOR <$> hGetAll hasFS h
-        case res of
-          Right (bl, a) | Lazy.null bl -> return $ Right a
-          _ -> return $ Left $ CorruptProtocolMagicId fullPath
-
-    createProtocolMagicIdFile :: ExceptT ChainDbCheckError m ()
-    createProtocolMagicIdFile = lift $
-      withFile hasFS pFile (AppendMode MustBeNew) $ \h ->
-        void $ hPutAll hasFS h $
-          CBOR.toLazyByteString (toCBOR protocolMagicId)
-
-protocolMagicIdFile :: Text
-protocolMagicIdFile = "protocolMagicId"
-
-data ChainDbCheckError =
-    -- | There was a 'protocolMagicIdFile' in the database folder, but it
-    -- contained a different 'ProtocolMagicId' than the expected one. This
-    -- indicates that this database folder corresponds to another net.
-    ProtocolMagicIdMismatch
-      FilePath         -- ^ The full path to the 'protocolMagicIdFile'
-      ProtocolMagicId  -- ^ Actual
-      ProtocolMagicId  -- ^ Expected
-
-    -- | The database folder contained no 'protocolMagicIdFile', but also
-    -- contained some files. Either the given folder is a non-database folder
-    -- or it is a database folder, but its 'protocolMagicIdFile' has been
-    -- deleted.
-  | NoProtocolMagicIdAndNotEmpty
-      FilePath         -- ^ The full path to the 'protocolMagicIdFile'
-
-    -- | The database folder contained a 'protocolMagicIdFile' that could not
-    -- be read. The file has been tampered with or it was corrupted somehow.
-  | CorruptProtocolMagicId
-      FilePath         -- ^ The full path to the 'protocolMagicIdFile'
-  deriving (Eq, Show)
-
-instance Exception ChainDbCheckError where
-  displayException e = case e of
-    ProtocolMagicIdMismatch f actual expected ->
-      "Wrong protocolMagicId in \"" <> f <> "\": " <> show actual <>
-      ", but expected: " <> show expected
-    NoProtocolMagicIdAndNotEmpty f ->
-      "Missing \"" <> f <> "\" but the folder was not empty"
-    CorruptProtocolMagicId f ->
-      "Corrupt or unreadable \"" <> f <> "\""
 
 initChainDB
   :: forall blk. RunNode blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/DbMarker.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/DbMarker.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Special file we store in the DB dir to avoid unintended deletions
+module Ouroboros.Consensus.Node.DbMarker (
+    DbMarkerError(..)
+  , checkDbMarker
+    -- * For the benefit of testing only
+  , dbMarkerFile
+  , dbMarkerContents
+  , dbMarkerParse
+  ) where
+
+import           Control.Monad (void)
+import           Control.Monad.Except
+import           Control.Monad.Trans.Class (lift)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BS.Char8
+import           Data.ByteString.Lazy (fromStrict, toStrict)
+import qualified Data.Set as Set
+import           Data.Text (Text)
+import           Data.Word
+import           Text.Read (readMaybe)
+
+import           Control.Monad.Class.MonadThrow
+
+import           Cardano.Crypto (ProtocolMagicId (..))
+
+import           Ouroboros.Storage.FS.API
+import           Ouroboros.Storage.FS.API.Types
+
+{-------------------------------------------------------------------------------
+  Check proper
+-------------------------------------------------------------------------------}
+
+-- | Check database marker
+--
+-- The database folder will contain folders for the ImmutableDB (@immutable@),
+-- the VolatileDB (@volatile@), and the LedgerDB (@ledger@). All three
+-- subdatabases can delete files from these folders, e.g., outdated files or
+-- files that are deemed invalid.
+--
+-- For example, when starting a node that will connect to a testnet with a
+-- database folder containing mainnet blocks, these blocks will be deemed
+-- invalid and will be deleted. This would throw away a perfectly good chain,
+-- possibly consisting of gigabytes of data that will have to be synched
+-- again.
+--
+-- To protect us from unwanted deletion of valid files, we first check whether
+-- we have been given the path to the right database folder. We do this by
+-- reading the 'ProtocolMagicId' of the net from a file stored in the root of
+-- the database folder. This file's name is defined in 'dbMarkerFile'.
+--
+-- * If the 'ProtocolMagicId' from the file matches that of the net, we have
+--   the right database folder.
+-- * If not, we are opening the wrong database folder and abort by throwing a
+--   'DbMarkerError'.
+-- * If there is no such file and the folder is empty, we create it and store
+--   the net's 'ProtocolMagicId' in it.
+-- * If there is no such file, but the folder is not empty, we throw a
+--   'DbMarkerError', because we have likely been given the wrong path,
+--   maybe to a folder containing user or system files. This includes the case
+--   that the 'dbMarkerFile' has been deleted.
+-- * If there is such a 'dbMarkerFile', but it could not be read or its
+--   contents could not be parsed, we also throw a 'DbMarkerError'.
+--
+-- Note that an 'FsError' can also be thrown.
+checkDbMarker
+  :: forall m h. MonadThrow m
+  => HasFS m h
+  -> MountPoint
+     -- ^ Database directory. Should be the mount point of the @HasFS@. Used
+     -- in error messages.
+  -> ProtocolMagicId
+  -> m (Either DbMarkerError ())
+checkDbMarker hasFS mountPoint protocolMagicId = runExceptT $ do
+    lift $ createDirectoryIfMissing hasFS True root
+    fileExists <- lift $ doesFileExist hasFS pFile
+    if fileExists then do
+      actualProtocolMagicId <- readProtocolMagicIdFile
+      when (actualProtocolMagicId /= protocolMagicId) $
+        throwError $ ProtocolMagicIdMismatch
+          fullPath
+          actualProtocolMagicId
+          protocolMagicId
+    else do
+      isEmpty <- lift $ Set.null <$> listDirectory hasFS root
+      if isEmpty then
+        createProtocolMagicIdFile
+      else
+        throwError $ NoDbMarkerAndNotEmpty fullPath
+  where
+    root     = mkFsPath []
+    pFile    = fsPathFromList [dbMarkerFile]
+    fullPath = fsToFilePath mountPoint pFile
+
+    readProtocolMagicIdFile :: ExceptT DbMarkerError m ProtocolMagicId
+    readProtocolMagicIdFile = ExceptT $
+      withFile hasFS pFile ReadMode $ \h -> do
+        bs <- toStrict <$> hGetAll hasFS h
+        runExceptT $ dbMarkerParse fullPath bs
+
+    createProtocolMagicIdFile :: ExceptT DbMarkerError m ()
+    createProtocolMagicIdFile = lift $
+      withFile hasFS pFile (AppendMode MustBeNew) $ \h ->
+        void $ hPutAll hasFS h $
+          fromStrict $ dbMarkerContents protocolMagicId
+
+{-------------------------------------------------------------------------------
+  Error
+-------------------------------------------------------------------------------}
+
+data DbMarkerError =
+    -- | There was a 'dbMarkerFile' in the database folder, but it
+    -- contained a different 'ProtocolMagicId' than the expected one. This
+    -- indicates that this database folder corresponds to another net.
+    ProtocolMagicIdMismatch
+      FilePath         -- ^ The full path to the 'dbMarkerFile'
+      ProtocolMagicId  -- ^ Actual
+      ProtocolMagicId  -- ^ Expected
+
+    -- | The database folder contained no 'dbMarkerFile', but also
+    -- contained some files. Either the given folder is a non-database folder
+    -- or it is a database folder, but its 'dbMarkerFile' has been
+    -- deleted.
+  | NoDbMarkerAndNotEmpty
+      FilePath         -- ^ The full path to the 'dbMarkerFile'
+
+    -- | The database folder contained a 'dbMarkerFile' that could not
+    -- be read. The file has been tampered with or it was corrupted somehow.
+  | CorruptDbMarker
+      FilePath         -- ^ The full path to the 'dbMarkerFile'
+  deriving (Eq, Show)
+
+instance Exception DbMarkerError where
+  displayException e = case e of
+    ProtocolMagicIdMismatch f actual expected ->
+      "Wrong protocolMagicId in \"" <> f <> "\": " <> show actual <>
+      ", but expected: " <> show expected
+    NoDbMarkerAndNotEmpty f ->
+      "Missing \"" <> f <> "\" but the folder was not empty"
+    CorruptDbMarker f ->
+      "Corrupt or unreadable \"" <> f <> "\""
+
+{-------------------------------------------------------------------------------
+  Configuration (filename, file format)
+-------------------------------------------------------------------------------}
+
+dbMarkerFile :: Text
+dbMarkerFile = "protocolMagicId"
+
+-- Contents of the DB marker file
+--
+-- We show the protocol magic ID as a human readable (decimal) number.
+--
+-- Type annotation on @pmid@ is here so that /if/ the type changes, this
+-- code will fail to build. This is important, because if we change the
+-- type, we must consider how this affects existing DB deployments.
+dbMarkerContents :: ProtocolMagicId -> ByteString
+dbMarkerContents (ProtocolMagicId (pmid :: Word32)) =
+    BS.Char8.pack $ show pmid
+
+-- | Parse contents of the DB marker file
+--
+-- Must be inverse to 'dbMarkerContents'
+dbMarkerParse :: Monad m
+              => FilePath
+              -> ByteString
+              -> ExceptT DbMarkerError m ProtocolMagicId
+dbMarkerParse fullPath bs =
+    case readMaybe (BS.Char8.unpack bs) of
+      Just pmid -> return     $ ProtocolMagicId pmid
+      Nothing   -> throwError $ CorruptDbMarker fullPath

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
@@ -15,6 +15,8 @@ import           Crypto.Random (MonadRandom)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Proxy (Proxy)
 
+import           Cardano.Crypto (ProtocolMagicId)
+
 import           Ouroboros.Network.Block (BlockNo, ChainHash (..), HeaderHash,
                      SlotNo)
 import           Ouroboros.Network.BlockFetch (SizeInBytes)
@@ -53,6 +55,9 @@ class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
   nodeNetworkMagic       :: Proxy blk
                          -> NodeConfig (BlockProtocol blk)
                          -> NetworkMagic
+  nodeProtocolMagicId    :: Proxy blk
+                         -> NodeConfig (BlockProtocol blk)
+                         -> ProtocolMagicId
 
   -- Encoders
   nodeEncodeBlock        :: NodeConfig (BlockProtocol blk) -> blk -> Encoding

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -47,11 +47,13 @@ instance RunNode ByronBlock where
                          $ SystemStart
                          . Genesis.gdStartTime
                          . extractGenesisData
-
   nodeNetworkMagic       = const
                          $ NetworkMagic
                          . Crypto.unProtocolMagicId
                          . Genesis.gdProtocolMagicId
+                         . extractGenesisData
+  nodeProtocolMagicId    = const
+                         $ Genesis.gdProtocolMagicId
                          . extractGenesisData
 
   nodeEncodeBlock        = const encodeByronBlock

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
@@ -10,6 +10,8 @@ import           Data.Time.Calendar (fromGregorian)
 import           Data.Time.Clock (UTCTime (..))
 import           Data.Typeable (Typeable)
 
+import           Cardano.Crypto (ProtocolMagicId (..))
+
 import           Ouroboros.Network.Magic (NetworkMagic (..))
 
 import           Ouroboros.Consensus.Block
@@ -18,7 +20,6 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Node.Run.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract (ChainState)
-
 
 {-------------------------------------------------------------------------------
   RunNode instance for the mock ledger
@@ -46,6 +47,8 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
       --  This doesn't matter much
       dummyDate = UTCTime (fromGregorian 2019 8 13) 0
   nodeNetworkMagic       = \_ _ -> NetworkMagic 0x0000ffff
+
+  nodeProtocolMagicId    = \_ _ -> ProtocolMagicId 0
 
   nodeEncodeBlock        = const encode
   nodeEncodeHeader       = const encode

--- a/ouroboros-consensus/test-consensus/Main.hs
+++ b/ouroboros-consensus/test-consensus/Main.hs
@@ -6,6 +6,7 @@ import qualified Test.Consensus.BlockchainTime (tests)
 import qualified Test.Consensus.ChainSyncClient (tests)
 import qualified Test.Consensus.Ledger.Byron (tests)
 import qualified Test.Consensus.Mempool (tests)
+import qualified Test.Consensus.Node (tests)
 import qualified Test.Consensus.Protocol.PBFT (tests)
 import qualified Test.Consensus.ResourceRegistry (tests)
 import qualified Test.Dynamic.BFT (tests)
@@ -25,6 +26,7 @@ tests =
   , Test.Consensus.ChainSyncClient.tests
   , Test.Consensus.Ledger.Byron.tests
   , Test.Consensus.Mempool.tests
+  , Test.Consensus.Node.tests
   , Test.Consensus.Protocol.PBFT.tests
   , Test.Consensus.ResourceRegistry.tests
   , Test.Dynamic.Util.Tests.tests

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Node.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Node.hs
@@ -2,18 +2,14 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Test.Consensus.Node (tests) where
 
-import qualified Codec.CBOR.Write as CBOR
 import           Data.Bifunctor (second)
-import           Data.ByteString (ByteString)
 import qualified Data.Map.Strict as Map
 
 import           Control.Monad.IOSim (runSimOrThrow)
 
-import           Cardano.Binary (toCBOR)
 import           Cardano.Crypto (ProtocolMagicId (..))
 
-import           Ouroboros.Consensus.Node (ChainDbCheckError (..),
-                     checkProtocolMagicId, protocolMagicIdFile)
+import           Ouroboros.Consensus.Node.DbMarker
 
 import           Ouroboros.Storage.FS.API.Types
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
@@ -28,7 +24,7 @@ import           Test.Util.FS.Sim.STM (runSimFS)
 
 tests :: TestTree
 tests = testGroup "Node"
-    [ testGroup "checkProtocolMagicId"
+    [ testGroup "checkDbMarker"
       [ testCase "match"        test_checkProtocolMagicId_match
       , testCase "mismatch"     test_checkProtocolMagicId_mismatch
       , testCase "empty folder" test_checkProtocolMagicId_empty_folder
@@ -39,7 +35,7 @@ tests = testGroup "Node"
     ]
 
 {-------------------------------------------------------------------------------
-  checkProtocolMagicId
+  checkDbMarker
 -------------------------------------------------------------------------------}
 
 expectedProtocolMagicId :: ProtocolMagicId
@@ -50,25 +46,22 @@ mountPoint = MountPoint "root"
 
 fullPath :: FilePath
 fullPath = fsToFilePath
-    mountPoint (fsPathFromList [protocolMagicIdFile])
+    mountPoint (fsPathFromList [dbMarkerFile])
 
-runCheck :: Files -> (Either ChainDbCheckError (), Files)
+runCheck :: Files -> (Either DbMarkerError (), Files)
 runCheck files = runSimOrThrow $ do
     fmap (second Mock.mockFiles) $
       runSimFS EH.monadCatch Mock.empty { Mock.mockFiles = files } $ \hasFS ->
-        checkProtocolMagicId hasFS mountPoint expectedProtocolMagicId
-
-protocolMagicIdToBS :: ProtocolMagicId -> ByteString
-protocolMagicIdToBS = CBOR.toStrictByteString . toCBOR
+        checkDbMarker hasFS mountPoint expectedProtocolMagicId
 
 test_checkProtocolMagicId_match :: Assertion
 test_checkProtocolMagicId_match = res @?= Right ()
   where
     fs = Folder $ Map.fromList
-      [ (protocolMagicIdFile, File $ protocolMagicIdToBS expectedProtocolMagicId)
-      , ("immutable",         Folder mempty)
-      , ("ledger",            Folder mempty)
-      , ("volatile",          Folder mempty)
+      [ (dbMarkerFile, File $ dbMarkerContents expectedProtocolMagicId)
+      , ("immutable",  Folder mempty)
+      , ("ledger",     Folder mempty)
+      , ("volatile",   Folder mempty)
       ]
     (res, _) = runCheck fs
 
@@ -76,10 +69,10 @@ test_checkProtocolMagicId_mismatch :: Assertion
 test_checkProtocolMagicId_mismatch = res @?= Left e
   where
     fs = Folder $ Map.fromList
-      [ (protocolMagicIdFile, File $ protocolMagicIdToBS actual)
-      , ("immutable",         Folder mempty)
-      , ("ledger",            Folder mempty)
-      , ("volatile",          Folder mempty)
+      [ (dbMarkerFile, File $ dbMarkerContents actual)
+      , ("immutable",  Folder mempty)
+      , ("ledger",     Folder mempty)
+      , ("volatile",   Folder mempty)
       ]
     (res, _) = runCheck fs
     actual = ProtocolMagicId 10
@@ -91,12 +84,12 @@ test_checkProtocolMagicId_mismatch = res @?= Left e
 test_checkProtocolMagicId_empty_folder :: Assertion
 test_checkProtocolMagicId_empty_folder = do
     res @?= Right ()
-    expectedFs' @?= fs'
+    fs' @?= expectedFs'
   where
     fs = Folder mempty
     (res, fs') = runCheck fs
     expectedFs' = Folder $ Map.fromList
-      [ (protocolMagicIdFile, File $ protocolMagicIdToBS expectedProtocolMagicId) ]
+      [ (dbMarkerFile, File $ dbMarkerContents expectedProtocolMagicId) ]
 
 test_checkProtocolMagicId_missing :: Assertion
 test_checkProtocolMagicId_missing = res @?= Left e
@@ -105,28 +98,28 @@ test_checkProtocolMagicId_missing = res @?= Left e
       [ ("passwords.txt", File "qwerty\n123456\n")
       ]
     (res, _) = runCheck fs
-    e = NoProtocolMagicIdAndNotEmpty fullPath
+    e = NoDbMarkerAndNotEmpty fullPath
 
 test_checkProtocolMagicId_corrupt :: Assertion
 test_checkProtocolMagicId_corrupt = res @?= Left e
   where
     fs = Folder $ Map.fromList
-      [ (protocolMagicIdFile, File "garbage")
-      , ("immutable",         Folder mempty)
-      , ("ledger",            Folder mempty)
-      , ("volatile",          Folder mempty)
+      [ (dbMarkerFile, File "garbage")
+      , ("immutable",  Folder mempty)
+      , ("ledger",     Folder mempty)
+      , ("volatile",   Folder mempty)
       ]
     (res, _) = runCheck fs
-    e = CorruptProtocolMagicId fullPath
+    e = CorruptDbMarker fullPath
 
 test_checkProtocolMagicId_empty :: Assertion
 test_checkProtocolMagicId_empty = res @?= Left e
   where
     fs = Folder $ Map.fromList
-      [ (protocolMagicIdFile, File "")
-      , ("immutable",         Folder mempty)
-      , ("ledger",            Folder mempty)
-      , ("volatile",          Folder mempty)
+      [ (dbMarkerFile, File "")
+      , ("immutable",  Folder mempty)
+      , ("ledger",     Folder mempty)
+      , ("volatile",   Folder mempty)
       ]
     (res, _) = runCheck fs
-    e = CorruptProtocolMagicId fullPath
+    e = CorruptDbMarker fullPath

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Node.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Node.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Test.Consensus.Node (tests) where
+
+import qualified Codec.CBOR.Write as CBOR
+import           Data.Bifunctor (second)
+import           Data.ByteString (ByteString)
+import qualified Data.Map.Strict as Map
+
+import           Control.Monad.IOSim (runSimOrThrow)
+
+import           Cardano.Binary (toCBOR)
+import           Cardano.Crypto (ProtocolMagicId (..))
+
+import           Ouroboros.Consensus.Node (ChainDbCheckError (..),
+                     checkProtocolMagicId, protocolMagicIdFile)
+
+import           Ouroboros.Storage.FS.API.Types
+import qualified Ouroboros.Storage.Util.ErrorHandling as EH
+
+import           Test.Tasty
+import           Test.Tasty.HUnit
+
+import           Test.Util.FS.Sim.FsTree (FsTree (..))
+import           Test.Util.FS.Sim.MockFS (Files)
+import qualified Test.Util.FS.Sim.MockFS as Mock
+import           Test.Util.FS.Sim.STM (runSimFS)
+
+tests :: TestTree
+tests = testGroup "Node"
+    [ testGroup "checkProtocolMagicId"
+      [ testCase "match"        test_checkProtocolMagicId_match
+      , testCase "mismatch"     test_checkProtocolMagicId_mismatch
+      , testCase "empty folder" test_checkProtocolMagicId_empty_folder
+      , testCase "missing"      test_checkProtocolMagicId_missing
+      , testCase "corrupt"      test_checkProtocolMagicId_corrupt
+      , testCase "empty"        test_checkProtocolMagicId_empty
+      ]
+    ]
+
+{-------------------------------------------------------------------------------
+  checkProtocolMagicId
+-------------------------------------------------------------------------------}
+
+expectedProtocolMagicId :: ProtocolMagicId
+expectedProtocolMagicId = ProtocolMagicId 1910
+
+mountPoint :: MountPoint
+mountPoint = MountPoint "root"
+
+fullPath :: FilePath
+fullPath = fsToFilePath
+    mountPoint (fsPathFromList [protocolMagicIdFile])
+
+runCheck :: Files -> (Either ChainDbCheckError (), Files)
+runCheck files = runSimOrThrow $ do
+    fmap (second Mock.mockFiles) $
+      runSimFS EH.monadCatch Mock.empty { Mock.mockFiles = files } $ \hasFS ->
+        checkProtocolMagicId hasFS mountPoint expectedProtocolMagicId
+
+protocolMagicIdToBS :: ProtocolMagicId -> ByteString
+protocolMagicIdToBS = CBOR.toStrictByteString . toCBOR
+
+test_checkProtocolMagicId_match :: Assertion
+test_checkProtocolMagicId_match = res @?= Right ()
+  where
+    fs = Folder $ Map.fromList
+      [ (protocolMagicIdFile, File $ protocolMagicIdToBS expectedProtocolMagicId)
+      , ("immutable",         Folder mempty)
+      , ("ledger",            Folder mempty)
+      , ("volatile",          Folder mempty)
+      ]
+    (res, _) = runCheck fs
+
+test_checkProtocolMagicId_mismatch :: Assertion
+test_checkProtocolMagicId_mismatch = res @?= Left e
+  where
+    fs = Folder $ Map.fromList
+      [ (protocolMagicIdFile, File $ protocolMagicIdToBS actual)
+      , ("immutable",         Folder mempty)
+      , ("ledger",            Folder mempty)
+      , ("volatile",          Folder mempty)
+      ]
+    (res, _) = runCheck fs
+    actual = ProtocolMagicId 10
+    e = ProtocolMagicIdMismatch
+      fullPath
+      actual
+      expectedProtocolMagicId
+
+test_checkProtocolMagicId_empty_folder :: Assertion
+test_checkProtocolMagicId_empty_folder = do
+    res @?= Right ()
+    expectedFs' @?= fs'
+  where
+    fs = Folder mempty
+    (res, fs') = runCheck fs
+    expectedFs' = Folder $ Map.fromList
+      [ (protocolMagicIdFile, File $ protocolMagicIdToBS expectedProtocolMagicId) ]
+
+test_checkProtocolMagicId_missing :: Assertion
+test_checkProtocolMagicId_missing = res @?= Left e
+  where
+    fs = Folder $ Map.fromList
+      [ ("passwords.txt", File "qwerty\n123456\n")
+      ]
+    (res, _) = runCheck fs
+    e = NoProtocolMagicIdAndNotEmpty fullPath
+
+test_checkProtocolMagicId_corrupt :: Assertion
+test_checkProtocolMagicId_corrupt = res @?= Left e
+  where
+    fs = Folder $ Map.fromList
+      [ (protocolMagicIdFile, File "garbage")
+      , ("immutable",         Folder mempty)
+      , ("ledger",            Folder mempty)
+      , ("volatile",          Folder mempty)
+      ]
+    (res, _) = runCheck fs
+    e = CorruptProtocolMagicId fullPath
+
+test_checkProtocolMagicId_empty :: Assertion
+test_checkProtocolMagicId_empty = res @?= Left e
+  where
+    fs = Folder $ Map.fromList
+      [ (protocolMagicIdFile, File "")
+      , ("immutable",         Folder mempty)
+      , ("ledger",            Folder mempty)
+      , ("volatile",          Folder mempty)
+      ]
+    (res, _) = runCheck fs
+    e = CorruptProtocolMagicId fullPath


### PR DESCRIPTION
Addresses #445. The ChainDB deletes invalid files on startup. When
accidentally pointing it to the database directory of another net (testnet vs.
mainnet), it would wipe out that directory, throwing away all blocks. To
protect the user against such accidents, we store the `ProtocolMagicId` in a
file in the database folder and check that upon startup.

See the docstring of `checkProtocolMagicId` for more details.