### PR TITLE
Test with infra-slot message latency

### DIFF
--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -124,6 +124,7 @@
             (hsPkgs.quickcheck-state-machine)
             (hsPkgs.random)
             (hsPkgs.serialise)
+            (hsPkgs.splitmix)
             (hsPkgs.tasty)
             (hsPkgs.tasty-hunit)
             (hsPkgs.tasty-quickcheck)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -268,6 +268,7 @@ test-suite test-consensus
                     Test.Util.Range
                     Test.Util.SOP
                     Test.Util.TestBlock
+                    Test.Util.Time
                     Test.Util.Tracer
   build-depends:    base,
                     base16-bytestring,

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -252,6 +252,7 @@ test-suite test-consensus
                     Test.Dynamic.TxGen
                     Test.Dynamic.Util
                     Test.Dynamic.Util.Expectations
+                    Test.Dynamic.Util.LivePipes
                     Test.Dynamic.Util.NodeJoinPlan
                     Test.Dynamic.Util.NodeTopology
                     Test.Dynamic.Util.Tests
@@ -300,6 +301,7 @@ test-suite test-consensus
                     quickcheck-state-machine,
                     random,
                     serialise,
+                    splitmix,
                     tasty,
                     tasty-hunit,
                     tasty-quickcheck,

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -66,6 +66,7 @@ import           Ouroboros.Consensus.Util.STM (Fingerprint (..),
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock
+import           Test.Util.Time (ioSimSecondsToDiffTime)
 import           Test.Util.Tracer (recordingTracerTVar)
 
 {-------------------------------------------------------------------------------
@@ -255,7 +256,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
     (ServerUpdates serverUpdates) startSyncingAt = withRegistry $ \registry -> do
 
     testBtime <- newTestBlockchainTime registry numSlots
-      (\_s -> threadDelay 100000)   -- io-sim "seconds"
+      (\_s -> threadDelay (ioSimSecondsToDiffTime 100000))
     let btime = testBlockchainTime testBtime
 
     -- Set up the client

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -254,7 +254,8 @@ runChainSync
 runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
     (ServerUpdates serverUpdates) startSyncingAt = withRegistry $ \registry -> do
 
-    testBtime <- newTestBlockchainTime registry numSlots slotDuration
+    testBtime <- newTestBlockchainTime registry numSlots
+      (\_s -> threadDelay 100000)   -- io-sim "seconds"
     let btime = testBlockchainTime testBtime
 
     -- Set up the client
@@ -387,9 +388,6 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
         )
   where
     k = maxRollbacks securityParam
-
-    slotDuration :: DiffTime
-    slotDuration = 100000
 
     nodeCfg :: CoreNodeId -> NodeConfig (Bft BftMockCrypto)
     nodeCfg coreNodeId = BftNodeConfig

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -146,7 +146,8 @@ runTestNetwork pInfo
   TestConfig{numCoreNodes, numSlots, nodeJoinPlan, nodeTopology}
   seed = runSimOrThrow $ do
     registry  <- unsafeNewRegistry
-    testBtime <- newTestBlockchainTime registry numSlots slotLen
+    testBtime <- newTestBlockchainTime registry numSlots
+      (\_s -> threadDelay slotLen)
     runNodeNetwork NodeNetworkArgs
       { nnaNodeJoinPlan    = nodeJoinPlan
       , nnaNodeTopology    = nodeTopology
@@ -159,7 +160,7 @@ runTestNetwork pInfo
       }
   where
     slotLen :: DiffTime
-    slotLen = 100000
+    slotLen = 100000   -- io-sim "seconds"
 
 {-------------------------------------------------------------------------------
   Test properties

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -147,15 +147,16 @@ runTestNetwork pInfo
   seed = runSimOrThrow $ do
     registry  <- unsafeNewRegistry
     testBtime <- newTestBlockchainTime registry numSlots slotLen
-    runNodeNetwork
-      registry
-      testBtime
-      numCoreNodes
-      nodeJoinPlan
-      nodeTopology
-      pInfo
-      (seedToChaCha seed)
-      slotLen
+    runNodeNetwork NodeNetworkArgs
+      { nnaNodeJoinPlan    = nodeJoinPlan
+      , nnaNodeTopology    = nodeTopology
+      , nnaNumCoreNodes    = numCoreNodes
+      , nnaProtocol        = pInfo
+      , nnaRegistry        = registry
+      , nnaSlotLen         = slotLen
+      , nnaTestBtime       = testBtime
+      , nnaTxSeed          = seedToChaCha seed
+      }
   where
     slotLen :: DiffTime
     slotLen = 100000

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -56,13 +56,21 @@ tests = testGroup "Dynamic chain generation"
             (genNodeTopology numCoreNodes)
             shrinkNodeTopology $
         \nodeTopology ->
+        forAllShrink genLatencySeed shrinkLatencySeed $
+        \latencySeed ->
         forAllShrink
             (genLeaderSchedule k numSlots numCoreNodes nodeJoinPlan)
             (shrinkLeaderSchedule numSlots) $
         \schedule ->
             prop_simple_leader_schedule_convergence
                 params
-                TestConfig{numCoreNodes, numSlots, nodeJoinPlan, nodeTopology}
+                TestConfig
+                  { numCoreNodes
+                  , numSlots
+                  , nodeJoinPlan
+                  , nodeTopology
+                  , latencySeed
+                  }
                 schedule seed
 
 prop_simple_leader_schedule_convergence :: PraosParams

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -203,10 +203,8 @@ runNodeNetwork NodeNetworkArgs
 
       return (coreNodeId, pInfoConfig (pInfo coreNodeId), node, readNodeInfo)
 
-    -- Wait some extra time after the end of the test block fetch and chain
-    -- sync to finish
+    -- Wait until the final slot ends
     testBlockchainTimeDone testBtime
-    threadDelay 2000   -- arbitrary "small" duration
 
     -- Close the 'ResourceRegistry': this shuts down the background threads of
     -- a node. This is important because we close the ChainDBs in

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -48,11 +48,14 @@ tests = testGroup "Dynamic chain generation"
             (genNodeTopology numCoreNodes)
             shrinkNodeTopology $
         \nodeTopology ->
+        forAllShrink genLatencySeed shrinkLatencySeed $
+        \latencySeed ->
             testPraos' TestConfig
               { numCoreNodes
               , numSlots
               , nodeJoinPlan
               , nodeTopology
+              , latencySeed
               }
                 seed
     ]
@@ -63,6 +66,7 @@ tests = testGroup "Dynamic chain generation"
       , numSlots
       , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
       , nodeTopology = meshNodeTopology numCoreNodes
+      , latencySeed  = noLatencySeed
       }
 
     testPraos' :: TestConfig -> Seed -> Property

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
@@ -70,6 +70,7 @@ tests = testGroup "Dynamic chain generation"
               , (CoreNodeId 2,SlotNo 22)
               ]
             , nodeTopology = meshNodeTopology ncn
+            , latencySeed  = noLatencySeed
             }
     , testProperty "simple Real PBFT convergence" $
         prop_simple_real_pbft_convergence

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util/LivePipes.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util/LivePipes.hs
@@ -1,0 +1,227 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE DeriveFoldable             #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE DeriveTraversable          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Dynamic.Util.LivePipes
+  ( -- * Latency configuration
+    LatencyInjection (..)
+  , MaxLatencies (..)
+  , -- * Live Pipes
+    LivePipes (..)
+  , LivePipesVar
+  , Pipe (..)
+  , PipeId (..)
+  , blockUntilQuiescent
+  , newLivePipe
+  , forgetLivePipeSTM
+  ) where
+
+import           Control.Monad (forM, forever, when, void)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Time.Clock (picosecondsToDiffTime)
+import           Data.Word (Word64)
+import           GHC.Stack
+import           System.Random.SplitMix (SMGen)
+import qualified System.Random.SplitMix as SM
+
+import qualified Control.Monad.Class.MonadSTM as Q
+import           Control.Monad.Class.MonadSTM.Strict
+
+import           Network.TypedProtocol.Channel
+
+import           Ouroboros.Consensus.Util.IOLike
+
+{-------------------------------------------------------------------------------
+  Latency Injection specification
+-------------------------------------------------------------------------------}
+
+data LatencyInjection a
+  = DoNotInjectLatencies
+    -- ^ Do not inject any latencies
+  | InjectLatencies a
+    -- ^ Inject actual latencies
+  | InjectTrivialLatencies
+    -- ^ Inject latencies of 0 duration, just to test affect on scheduler
+  deriving (Eq, Foldable, Functor, Show, Traversable)
+
+-- | The maximum possible latencies used by 'newLivePipe'
+--
+data MaxLatencies = MaxLatencies
+  { maxSendLatency :: !DiffTime
+    -- ^ Similar to the Serialisation latency of GSV, though see the NOTE on
+    -- 'newLivePipe' regarding back pressure
+    --
+  , maxVar1Latency :: !DiffTime
+    -- ^ Similar to the Variable latency of GSV, though the NOTE on
+    -- 'newLivePipe' regarding pipelining
+  }
+
+{-------------------------------------------------------------------------------
+  Live Pipes
+-------------------------------------------------------------------------------}
+
+-- | One half of a pair of connected 'Channel's: 'send' for one and 'recv' for
+-- the other
+--
+newtype Pipe m a = Pipe (Channel m a)
+
+-- | How many messages have been sent on this pipe but not yet received
+--
+newtype InFlightCount = InFlightCount Word64
+  deriving (Enum, Eq, Ord, Show)
+
+-- | How many times has a pipe been emptied
+--
+newtype EmptiedCount = EmptiedCount Word64
+  deriving (Enum, Eq, Ord, Show)
+
+newtype PipeId = PipeId Word64
+  deriving (Enum, Eq, Ord, Show)
+
+data LPMetaVars m = LPMetaVars
+  { lpmvCount    :: !(StrictTVar m EmptiedCount)
+  , lpmvInFlight :: !(StrictTVar m InFlightCount)
+  }
+
+-- | The set of live pipes
+--
+-- The primary use case is 'blockUntilQuiescent'.
+--
+data LivePipes a = LivePipes
+  { livePipes  :: !(Map PipeId a)
+  , nextPipeId :: !PipeId
+  }
+
+type LivePipesVar m = StrictTVar m (LivePipes (LPMetaVars m))
+
+-- | Block until all live pipes have been empty for at least the given duration
+--
+blockUntilQuiescent ::
+  forall m. IOLike m => LivePipesVar m -> DiffTime -> m ()
+blockUntilQuiescent livePipesVar dur = get >>= go
+  where
+    get :: m (Map PipeId EmptiedCount)
+    get = atomically $ do
+        LivePipes{livePipes} <- readTVar livePipesVar
+        forM livePipes $ \LPMetaVars{lpmvCount, lpmvInFlight} -> do
+            readTVar lpmvInFlight >>= check . (== InFlightCount 0)
+            readTVar lpmvCount
+
+    go sig1 = do
+        threadDelay dur
+        sig2 <- get
+        if sig1 == sig2 then pure () else go sig2
+
+-- | Create a new live pipe
+--
+-- This pipe supports multiple readers and/or multiple writers. It supports the
+-- 'Channel' assumptions: reliability, order preservation, etc. Each send
+-- blocks for a random amount (uniform) of time, and each message takes a
+-- random amount (uniform) of time to travel from the sender to the receiver.
+-- Moreover, each message only begins traveling once the previous arrives.
+--
+-- NOTE This mock \"physical layer\" carries one message at a time (hence the
+-- name 'maxVar1Latency'). Though it uses queues so that a (pipelined) sender
+-- is never blocked, there will be no _latency hiding_. In other words, the
+-- stream of Variable latency samples have _already_ taken into account any
+-- possible latency hiding.
+--
+-- NOTE Similarly, it is assumed that the Serialisation latency sufficiently
+-- subsumes _back pressure_, since otherwise sending never blocks the sender.
+--
+-- The motivation for including latencies in this mock network is to explore
+-- different permutations/ways to interleave concurrent events. While realistic
+-- latencies would exhibit (conditional) (temporal) correlations due to
+-- pipelining, back pressure, and so on, we assume that samplers crafted to
+-- accurately synthesize those correlations would explore fewer scheduling
+-- permutations.
+--
+newLivePipe ::
+  forall m a.
+     ( IOLike m
+     , HasCallStack
+     )
+  => MaxLatencies
+  -> LatencyInjection (StrictTVar m SMGen)
+  -> LivePipesVar m
+  -> m (PipeId, Pipe m a)
+newLivePipe MaxLatencies{maxVar1Latency, maxSendLatency} liSMG tvar = do
+    lpmvCount    <- uncheckedNewTVarM (EmptiedCount 0)
+    lpmvInFlight <- uncheckedNewTVarM (InFlightCount 0)
+    pid <- atomically $ do
+        LivePipes{nextPipeId, livePipes} <- readTVar tvar
+        writeTVar tvar LivePipes
+          { nextPipeId = succ nextPipeId
+          , livePipes  =
+                Map.insert nextPipeId
+                    LPMetaVars{lpmvCount, lpmvInFlight}
+                    livePipes
+          }
+        pure nextPipeId
+
+    -- create a thread that reliably and order-preservingly transports messages
+    -- down the pipe
+    inBuf     <- atomically Q.newTQueue
+    outBuf    <- atomically Q.newTQueue
+    liVar1SMG <- mapM split liSMG
+    void $ fork $ forever $ do
+        x <- atomically $ Q.readTQueue inBuf
+
+        mapM (genDelay maxVar1Latency) liVar1SMG >>= threadDelayLI
+
+        atomically $ Q.writeTQueue outBuf x
+
+    liSendSMG <- mapM split liSMG
+    let pipe = Pipe Channel
+          { send = \ !x -> do
+                atomically $ modifyTVar lpmvInFlight succ
+
+                mapM (genDelay maxSendLatency) liSendSMG >>= threadDelayLI
+
+                atomically $ Q.writeTQueue inBuf x
+          , recv = atomically $ do
+                x <- Q.readTQueue outBuf
+
+                n <- readTVar lpmvInFlight
+                when (InFlightCount 0 == n) $ error "impossible!"
+                when (InFlightCount 1 == n) $ modifyTVar lpmvCount succ
+                writeTVar lpmvInFlight (pred n)
+
+                pure $ Just x
+          }
+
+    pure (pid, pipe)
+  where
+    split :: StrictTVar m SMGen -> m (StrictTVar m SMGen)
+    split smgVar = atomically $ do
+        (smg1, smg') <- SM.splitSMGen <$> readTVar smgVar
+        writeTVar smgVar smg'
+        newTVar smg1
+
+    -- interpret 'LatencyInjection' via 'threadDelay'
+    threadDelayLI :: LatencyInjection DiffTime -> m ()
+    threadDelayLI = \case
+        DoNotInjectLatencies   -> pure ()
+        InjectTrivialLatencies -> threadDelay 0
+        InjectLatencies d      -> threadDelay d
+
+    -- generate a delay in the interval @[0, mx)@
+    genDelay :: DiffTime -> StrictTVar m SMGen -> m DiffTime
+    genDelay mx smgVar = atomically $ do
+        (i, smg') <- SM.nextInt <$> readTVar smgVar
+        writeTVar smgVar smg'
+        let denom = picosecondsToDiffTime 1000
+        let frac = toEnum (abs i `mod` 1000) / denom
+        pure $ mx * frac
+
+-- | Remove the identified pipe
+--
+forgetLivePipeSTM :: IOLike m => LivePipesVar m -> PipeId -> STM m ()
+forgetLivePipeSTM tvar pid = modifyTVar tvar $ \lp@LivePipes{livePipes} ->
+    lp{livePipes = Map.delete pid livePipes}

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Util/LivePipes.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Util/LivePipes.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 
 module Test.Dynamic.Util.LivePipes
   ( -- * Latency configuration
@@ -21,7 +21,7 @@ module Test.Dynamic.Util.LivePipes
   , forgetLivePipeSTM
   ) where
 
-import           Control.Monad (forM, forever, when, void)
+import           Control.Monad (forM, forever, void, when)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Time.Clock (picosecondsToDiffTime)
@@ -47,7 +47,7 @@ data LatencyInjection a
   | InjectLatencies a
     -- ^ Inject actual latencies
   | InjectTrivialLatencies
-    -- ^ Inject latencies of 0 duration, just to test affect on scheduler
+    -- ^ Inject latencies of 0 duration, just to test effect on scheduler
   deriving (Eq, Foldable, Functor, Show, Traversable)
 
 -- | The maximum possible latencies used by 'newLivePipe'

--- a/ouroboros-consensus/test-util/Test/Util/Time.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Time.hs
@@ -1,0 +1,14 @@
+module Test.Util.Time (
+  ioSimSecondsToDiffTime,
+  ) where
+
+import           Data.Time (DiffTime)
+
+-- | Map a number of seconds to a 'DiffTime' planned for use in an @io-sim@
+-- simulation context
+--
+-- The @io-sim@ layer can skip ahead through time, so this function tends to
+-- have arguments with extreme magnitude.
+--
+ioSimSecondsToDiffTime :: Integer -> DiffTime
+ioSimSecondsToDiffTime = fromInteger

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -353,7 +353,7 @@ tracePropertyClientStateSanity es =
         == fromIntegral peerFetchBytesInFlight
 
      && case status of
-          PeerFetchStatusReady _ -> True
+          PeerFetchStatusReady{} -> True
           PeerFetchStatusBusy    -> True
           _                      -> False -- not used in this test
 


### PR DESCRIPTION
This Draft PR is my first attempt at injecting networking latency into the `test-consensus` tests while simultaneously ensuring that every mini protocol message arrives in the same slot it was sent. The purpose is to permute the interleaving of various events without adding new difficult-to-predict mechanisms for Common Prefix violations.

This PR is partial progress towards Issue #229. This intermediate milestone is motivated by the test plan in (pending) PR #1128.