### PR TITLE
io-sim-classes additions and rearrangement

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
@@ -29,6 +29,7 @@ import           Control.Concurrent.Async (AsyncCancelled(..))
 import           Data.Proxy
 
 class ( MonadSTM m
+      , MonadThread m
       , forall a. Eq  (Async m a)
       , forall a. Ord (Async m a)
       , Functor (Async m)

--- a/io-sim-classes/src/Control/Monad/Class/MonadFork.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadFork.hs
@@ -10,7 +10,8 @@ module Control.Monad.Class.MonadFork
 
 import qualified Control.Concurrent as IO
 import qualified GHC.Conc.Sync as IO (labelThread)
-import           Control.Exception (Exception(..), SomeException)
+import           Control.Exception (Exception(..), SomeException,
+                                    AsyncException(ThreadKilled))
 import           Control.Monad.Reader
 import           System.IO (hFlush, hPutStrLn, stderr)
 import           System.IO.Unsafe (unsafePerformIO)
@@ -36,6 +37,9 @@ class MonadThread m => MonadFork m where
   forkWithUnmask :: ((forall a. m a -> m a) -> m ()) -> m (ThreadId m)
   throwTo        :: Exception e => ThreadId m -> e -> m ()
 
+  killThread     :: ThreadId m -> m ()
+  killThread tid = throwTo tid ThreadKilled
+
 
 instance MonadThread IO where
   type ThreadId IO = IO.ThreadId
@@ -56,6 +60,7 @@ instance MonadFork IO where
 
   forkWithUnmask = IO.forkIOWithUnmask
   throwTo        = IO.throwTo
+  killThread     = IO.killThread
 
 instance MonadThread m => MonadThread (ReaderT e m) where
   type ThreadId (ReaderT e m) = ThreadId m

--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE TypeFamilyDependencies #-}
 module Control.Monad.Class.MonadSTM
   ( MonadSTM (..)
-  , Tr
   , LazyTVar
   , LazyTMVar
 
@@ -56,8 +55,6 @@ import           Control.Monad.Reader
 import           GHC.Stack
 import           Numeric.Natural (Natural)
 
-{-# DEPRECATED Tr "Now simply called 'STM'" #-}
-type Tr m = STM m
 
 {-# DEPRECATED LazyTVar  "Renamed back to 'TVar'" #-}
 {-# DEPRECATED LazyTMVar "Renamed back to 'TMVar'" #-}

--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -88,6 +88,9 @@ class (Monad m, Monad (STM m)) => MonadSTM m where
   modifyTVar   :: TVar m a -> (a -> a) -> STM m ()
   modifyTVar  v f = readTVar v >>= writeTVar v . f
 
+  modifyTVar'  :: TVar m a -> (a -> a) -> STM m ()
+  modifyTVar' v f = readTVar v >>= \x -> writeTVar v $! f x
+
   check        :: Bool -> STM m ()
   check True = return ()
   check _    = retry
@@ -220,6 +223,7 @@ instance MonadSTM IO where
 
   newTVarM    = STM.newTVarIO
   modifyTVar  = STM.modifyTVar
+  modifyTVar' = STM.modifyTVar'
   check       = STM.check
 
   type TMVar IO = STM.TMVar

--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -6,6 +6,8 @@
 module Control.Monad.Class.MonadSTM
   ( MonadSTM (..)
   , Tr
+  , LazyTVar
+  , LazyTMVar
 
   -- * Helpers defined in terms of 'MonadSTM'
   , updateTVar
@@ -60,25 +62,30 @@ import           Numeric.Natural (Natural)
 {-# DEPRECATED Tr "Now simply called 'STM'" #-}
 type Tr m = STM m
 
+{-# DEPRECATED LazyTVar  "Renamed back to 'TVar'" #-}
+{-# DEPRECATED LazyTMVar "Renamed back to 'TMVar'" #-}
+type LazyTVar  m = TVar m
+type LazyTMVar m = TMVar m
+
 class (Monad m, Monad (STM m)) => MonadSTM m where
 
   -- STM transactions
   type STM  m = (n :: * -> *) | n -> m
   -- The STM primitives
-  type LazyTVar m :: * -> *
+  type TVar m :: * -> *
 
   atomically   :: HasCallStack => STM m a -> m a
-  newTVar      :: a -> STM m (LazyTVar m a)
-  readTVar     :: LazyTVar m a -> STM m a
-  writeTVar    :: LazyTVar m a -> a -> STM m ()
+  newTVar      :: a -> STM m (TVar m a)
+  readTVar     :: TVar m a -> STM m a
+  writeTVar    :: TVar m a -> a -> STM m ()
   retry        :: STM m a
   orElse       :: STM m a -> STM m a -> STM m a
 
   -- Helpful derived functions with default implementations
-  newTVarM     :: a -> m (LazyTVar m a)
+  newTVarM     :: a -> m (TVar m a)
   newTVarM     = atomically . newTVar
 
-  modifyTVar   :: LazyTVar m a -> (a -> a) -> STM m ()
+  modifyTVar   :: TVar m a -> (a -> a) -> STM m ()
   modifyTVar  v f = readTVar v >>= writeTVar v . f
 
   check        :: Bool -> STM m ()
@@ -86,19 +93,19 @@ class (Monad m, Monad (STM m)) => MonadSTM m where
   check _    = retry
 
   -- Additional derived STM APIs
-  type LazyTMVar m :: * -> *
-  newTMVar        :: a -> STM m (LazyTMVar m a)
-  newTMVarM       :: a -> m     (LazyTMVar m a)
-  newEmptyTMVar   ::      STM m (LazyTMVar m a)
-  newEmptyTMVarM  ::      m     (LazyTMVar m a)
-  takeTMVar       :: LazyTMVar m a      -> STM m a
-  tryTakeTMVar    :: LazyTMVar m a      -> STM m (Maybe a)
-  putTMVar        :: LazyTMVar m a -> a -> STM m ()
-  tryPutTMVar     :: LazyTMVar m a -> a -> STM m Bool
-  readTMVar       :: LazyTMVar m a      -> STM m a
-  tryReadTMVar    :: LazyTMVar m a      -> STM m (Maybe a)
-  swapTMVar       :: LazyTMVar m a -> a -> STM m a
-  isEmptyTMVar    :: LazyTMVar m a      -> STM m Bool
+  type TMVar m :: * -> *
+  newTMVar        :: a -> STM m (TMVar m a)
+  newTMVarM       :: a -> m     (TMVar m a)
+  newEmptyTMVar   ::      STM m (TMVar m a)
+  newEmptyTMVarM  ::      m     (TMVar m a)
+  takeTMVar       :: TMVar m a      -> STM m a
+  tryTakeTMVar    :: TMVar m a      -> STM m (Maybe a)
+  putTMVar        :: TMVar m a -> a -> STM m ()
+  tryPutTMVar     :: TMVar m a -> a -> STM m Bool
+  readTMVar       :: TMVar m a      -> STM m a
+  tryReadTMVar    :: TMVar m a      -> STM m (Maybe a)
+  swapTMVar       :: TMVar m a -> a -> STM m a
+  isEmptyTMVar    :: TMVar m a      -> STM m Bool
 
   type TQueue m  :: * -> *
   newTQueue      :: STM m (TQueue m a)
@@ -117,8 +124,8 @@ class (Monad m, Monad (STM m)) => MonadSTM m where
 
 instance MonadSTM m => MonadSTM (ReaderT e m) where
   type STM       (ReaderT e m) = ReaderT e (STM m)
-  type LazyTVar  (ReaderT e m) = LazyTVar m
-  type LazyTMVar (ReaderT e m) = LazyTMVar m
+  type TVar      (ReaderT e m) = TVar m
+  type TMVar     (ReaderT e m) = TMVar m
   type TQueue    (ReaderT e m) = TQueue m
   type TBQueue   (ReaderT e m) = TBQueue m
 
@@ -157,8 +164,8 @@ instance MonadSTM m => MonadSTM (ReaderT e m) where
 
 instance (Show e, MonadSTM m) => MonadSTM (ExceptT e m) where
   type STM       (ExceptT e m) = ExceptT e (STM m)
-  type LazyTVar  (ExceptT e m) = LazyTVar m
-  type LazyTMVar (ExceptT e m) = LazyTMVar m
+  type TVar      (ExceptT e m) = TVar m
+  type TMVar     (ExceptT e m) = TMVar m
   type TQueue    (ExceptT e m) = TQueue m
   type TBQueue   (ExceptT e m) = TBQueue m
 
@@ -201,8 +208,8 @@ instance (Show e, MonadSTM m) => MonadSTM (ExceptT e m) where
 --
 
 instance MonadSTM IO where
-  type STM      IO = STM.STM
-  type LazyTVar IO = STM.TVar
+  type STM  IO = STM.STM
+  type TVar IO = STM.TVar
 
   atomically  = wrapBlockedIndefinitely . STM.atomically
   newTVar     = STM.newTVar
@@ -215,7 +222,7 @@ instance MonadSTM IO where
   modifyTVar  = STM.modifyTVar
   check       = STM.check
 
-  type LazyTMVar IO = STM.TMVar
+  type TMVar IO = STM.TMVar
 
   newTMVar        = STM.newTMVar
   newTMVarM       = STM.newTMVarIO
@@ -273,7 +280,7 @@ wrapBlockedIndefinitely = handle (throwIO . BlockedIndefinitely callStack)
 -- Helpers defined in terms of MonadSTM
 --
 
-updateTVar :: MonadSTM m => LazyTVar m a -> (a -> (a, b)) -> STM m b
+updateTVar :: MonadSTM m => TVar m a -> (a -> (a, b)) -> STM m b
 updateTVar t f = do
     a <- readTVar t
     let (a', b) = f a
@@ -284,7 +291,7 @@ updateTVar t f = do
 -- Default TMVar implementation in terms of TVars (used by sim)
 --
 
-newtype TMVarDefault m a = TMVar (LazyTVar m (Maybe a))
+newtype TMVarDefault m a = TMVar (TVar m (Maybe a))
 
 newTMVarDefault :: MonadSTM m => a -> STM m (TMVarDefault m a)
 newTMVarDefault a = do
@@ -363,8 +370,8 @@ isEmptyTMVarDefault (TMVar t) = do
 -- Default TQueue implementation in terms of TVars (used by sim)
 --
 
-data TQueueDefault m a = TQueue !(LazyTVar m [a])
-                                !(LazyTVar m [a])
+data TQueueDefault m a = TQueue !(TVar m [a])
+                                !(TVar m [a])
 
 newTQueueDefault :: MonadSTM m => STM m (TQueueDefault m a)
 newTQueueDefault = do
@@ -412,10 +419,10 @@ isEmptyTQueueDefault (TQueue read write) = do
 --
 
 data TBQueueDefault m a = TBQueue
-  !(LazyTVar m Natural) -- read capacity
-  !(LazyTVar m [a])     -- elements waiting for read
-  !(LazyTVar m Natural) -- write capacity
-  !(LazyTVar m [a])     -- written elements
+  !(TVar m Natural) -- read capacity
+  !(TVar m [a])     -- elements waiting for read
+  !(TVar m Natural) -- write capacity
+  !(TVar m [a])     -- written elements
   !Natural
 
 newTBQueueDefault :: MonadSTM m => Natural -> STM m (TBQueueDefault m a)

--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -9,9 +9,6 @@ module Control.Monad.Class.MonadSTM
   , LazyTVar
   , LazyTMVar
 
-  -- * Helpers defined in terms of 'MonadSTM'
-  , updateTVar
-
   -- * Default 'TMVar' implementation
   , TMVarDefault (..)
   , newTMVarDefault
@@ -280,16 +277,6 @@ instance Exception BlockedIndefinitely where
 wrapBlockedIndefinitely :: HasCallStack => IO a -> IO a
 wrapBlockedIndefinitely = handle (throwIO . BlockedIndefinitely callStack)
 
---
--- Helpers defined in terms of MonadSTM
---
-
-updateTVar :: MonadSTM m => TVar m a -> (a -> (a, b)) -> STM m b
-updateTVar t f = do
-    a <- readTVar t
-    let (a', b) = f a
-    writeTVar t a'
-    return b
 
 --
 -- Default TMVar implementation in terms of TVars (used by sim)

--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM/Strict.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM/Strict.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE NamedFieldPuns        #-}
 module Control.Monad.Class.MonadSTM.Strict
   ( module X
+  , LazyTVar
+  , LazyTMVar
     -- * 'StrictTVar'
   , StrictTVar
   , toLazyTVar
@@ -32,7 +34,8 @@ module Control.Monad.Class.MonadSTM.Strict
   , checkInvariant
   ) where
 
-import           Control.Monad.Class.MonadSTM as X hiding (LazyTMVar, LazyTVar,
+import           Control.Monad.Class.MonadSTM as X hiding
+                    (TVar, TMVar, LazyTVar, LazyTMVar,
                      isEmptyTMVar, modifyTVar, newEmptyTMVar, newEmptyTMVarM,
                      newTMVar, newTMVarM, newTVar, newTVarM, putTMVar,
                      readTMVar, readTVar, swapTMVar, takeTMVar, tryPutTMVar,
@@ -41,20 +44,27 @@ import qualified Control.Monad.Class.MonadSTM as Lazy
 import           GHC.Stack
 
 {-------------------------------------------------------------------------------
+  Lazy TVar
+-------------------------------------------------------------------------------}
+
+type LazyTVar  m = Lazy.TVar m
+type LazyTMVar m = Lazy.TMVar m
+
+{-------------------------------------------------------------------------------
   Strict TVar
 -------------------------------------------------------------------------------}
 
 data StrictTVar m a = StrictTVar
    { invariant :: !(a -> Maybe String)
      -- ^ Invariant checked whenever updating the 'StrictTVar'.
-   , tvar      :: !(Lazy.LazyTVar m a)
+   , tvar      :: !(LazyTVar m a)
    }
 
 -- | Get the underlying @TVar@
 --
 -- Since we obviously cannot guarantee that updates to this 'LazyTVar' will be
 -- strict, this should be used with caution.
-toLazyTVar :: StrictTVar m a -> Lazy.LazyTVar m a
+toLazyTVar :: StrictTVar m a -> LazyTVar m a
 toLazyTVar StrictTVar { tvar } = tvar
 
 newTVar :: MonadSTM m => a -> STM m (StrictTVar m a)
@@ -98,7 +108,7 @@ updateTVar v f = do
 -- Does not support an invariant: if the invariant would not be satisfied,
 -- we would not be able to put a value into an empty TMVar, which would lead
 -- to very hard to debug bugs where code is blocked indefinitely.
-newtype StrictTMVar m a = StrictTMVar (Lazy.LazyTMVar m a)
+newtype StrictTMVar m a = StrictTMVar (LazyTMVar m a)
 
 newTMVar :: MonadSTM m => a -> STM m (StrictTMVar m a)
 newTMVar !a = StrictTMVar <$> Lazy.newTMVar a

--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM/Strict.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM/Strict.hs
@@ -39,7 +39,7 @@ import           Control.Monad.Class.MonadSTM as X hiding
                      isEmptyTMVar, modifyTVar, newEmptyTMVar, newEmptyTMVarM,
                      newTMVar, newTMVarM, newTVar, newTVarM, putTMVar,
                      readTMVar, readTVar, swapTMVar, takeTMVar, tryPutTMVar,
-                     tryReadTMVar, tryTakeTMVar, updateTVar, writeTVar)
+                     tryReadTMVar, tryTakeTMVar, writeTVar)
 import qualified Control.Monad.Class.MonadSTM as Lazy
 import           GHC.Stack
 

--- a/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
@@ -23,7 +23,7 @@ import qualified GHC.Event as GHC (TimeoutKey, getSystemTimerManager,
 import           Control.Monad (when)
 #endif
 
-import           Control.Monad.Class.MonadFork (MonadFork(..))
+import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSTM
 
 import qualified System.Timeout as IO

--- a/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
@@ -88,9 +88,9 @@ class MonadSTM m => MonadTimer m where
   threadDelay    :: DiffTime -> m ()
   threadDelay d   = void . atomically . awaitTimeout =<< newTimeout d
 
-  registerDelay :: DiffTime -> m (LazyTVar m Bool)
+  registerDelay :: DiffTime -> m (TVar m Bool)
 
-  default registerDelay :: MonadFork m => DiffTime -> m (LazyTVar m Bool)
+  default registerDelay :: MonadFork m => DiffTime -> m (TVar m Bool)
   registerDelay d = do
     v <- atomically $ newTVar False
     t <- newTimeout d

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -75,7 +75,7 @@ import qualified Control.Monad.Class.MonadFork as MonadFork
 import           Control.Monad.Class.MonadThrow as MonadThrow
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadST
-import           Control.Monad.Class.MonadSTM hiding (STM)
+import           Control.Monad.Class.MonadSTM hiding (STM, TVar)
 import qualified Control.Monad.Class.MonadSTM as MonadSTM
 import           Control.Monad.Class.MonadAsync hiding (Async)
 import qualified Control.Monad.Class.MonadAsync as MonadAsync
@@ -292,8 +292,8 @@ instance MonadFork (SimM s) where
 
 instance MonadSTM (SimM s) where
   type STM       (SimM s) = STM s
-  type LazyTVar  (SimM s) = TVar s
-  type LazyTMVar (SimM s) = TMVarDefault (SimM s)
+  type TVar      (SimM s) = TVar s
+  type TMVar     (SimM s) = TMVarDefault (SimM s)
   type TQueue    (SimM s) = TQueueDefault (SimM s)
   type TBQueue   (SimM s) = TBQueueDefault (SimM s)
 
@@ -331,7 +331,7 @@ instance MonadSTM (SimM s) where
   isEmptyTBQueue    = isEmptyTBQueueDefault
   isFullTBQueue     = isFullTBQueueDefault
 
-data Async s a = forall b. Async !ThreadId (b -> a) (LazyTMVar (SimM s) (Either SomeException b))
+data Async s a = forall b. Async !ThreadId (b -> a) (TMVar (SimM s) (Either SomeException b))
 
 instance Eq (Async s a) where
     Async tid _ _ == Async tid' _ _ = tid == tid'

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -279,12 +279,13 @@ unblock              a = SimM (SetMaskState Unmasked a)
 block                a = SimM (SetMaskState MaskedInterruptible a)
 blockUninterruptible a = SimM (SetMaskState MaskedUninterruptible a)
 
-instance MonadFork (SimM s) where
+instance MonadThread (SimM s) where
   type ThreadId (SimM s) = ThreadId
+  myThreadId       = SimM $ \k -> GetThreadId k
 
+instance MonadFork (SimM s) where
   fork task        = SimM $ \k -> Fork task k
   forkWithUnmask f = fork (f unblock)
-  myThreadId       = SimM $ \k -> GetThreadId k
   throwTo tid e    = SimM $ \k -> ThrowTo (toException e) tid (k ())
 
 instance MonadSTM (SimM s) where

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -843,6 +843,6 @@ runSimTraceSay :: (forall s. SimM s a) -> [String]
 runSimTraceSay action = selectTraceSay (runSimTrace action)
 
 selectTraceSay :: Trace a -> [String]
-selectTraceSay (Trace _ _ (EventSay msg) trace) = msg : selectTraceSay trace
-selectTraceSay (Trace _ _ _              trace) = selectTraceSay trace
-selectTraceSay  _                               = []
+selectTraceSay (Trace _ _ _ (EventSay msg) trace) = msg : selectTraceSay trace
+selectTraceSay (Trace _ _ _ _              trace) = selectTraceSay trace
+selectTraceSay  _                                 = []

--- a/io-sim/test/Test/STM.hs
+++ b/io-sim/test/Test/STM.hs
@@ -399,7 +399,7 @@ data ExecValue m (t :: Type) where
 
     ExecValUnit ::                           ExecValue m TyUnit
     ExecValInt  :: Int                    -> ExecValue m TyInt
-    ExecValVar  :: LazyTVar m (ExecValue m t) 
+    ExecValVar  :: TVar m (ExecValue m t)
                 -> TyRep t                -> ExecValue m (TyVar t)
 
 instance Show (ExecValue m t) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
@@ -54,13 +54,13 @@ import           Cardano.Prelude (NoUnexpectedThunks (..))
 data StrictMVar m a = StrictMVar
   { invariant :: !(a -> Maybe String)
     -- ^ Invariant checked whenever updating the 'StrictMVar'.
-  , tmvar     :: !(Lazy.LazyTMVar m a)
+  , tmvar     :: !(Lazy.TMVar m a)
     -- ^ The main TMVar supporting this 'StrictMVar'
-  , tvar      :: !(Lazy.LazyTVar m a)
+  , tvar      :: !(Lazy.TVar m a)
     -- ^ TVar for supporting 'readMVarSTM'
     --
-    -- This TVar is always kept up to date with the 'LazyTMVar', but holds on
-    -- the old value of the 'LazyTMVar' when it is empty. This is very useful
+    -- This TVar is always kept up to date with the 'Lazy.TMVar', but holds on
+    -- the old value of the 'Lazy.TMVar' when it is empty. This is very useful
     -- to support single writer/many reader scenarios.
     --
     -- NOTE: We should always update the 'tmvar' before the 'tvar' so that if

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientRegistry.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientRegistry.hs
@@ -25,7 +25,7 @@ import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-                   ( MonadFork(ThreadId, myThreadId, throwTo) )
+                   ( MonadThread(ThreadId, myThreadId), MonadFork(throwTo) )
 import           Control.Exception (assert)
 import           Control.Tracer (Tracer)
 

--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Dns.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Dns.hs
@@ -27,7 +27,7 @@ module Ouroboros.Network.Subscription.Dns
     ) where
 
 import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadSTM (LazyTVar)
+import           Control.Monad.Class.MonadSTM (TVar)
 import qualified Control.Monad.Class.MonadSTM as Lazy
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadSay
@@ -176,7 +176,7 @@ dnsResolve tracer resolver peerStatesVar beforeConnect (DnsSubscriptionTarget do
                  atomically $ Lazy.writeTVar gotIpv6RspVar True
                  return Nothing
 
-    resolveA :: LazyTVar m Bool -> StrictTMVar m [Socket.SockAddr] -> m (Maybe DNS.DNSError)
+    resolveA :: TVar m Bool -> StrictTMVar m [Socket.SockAddr] -> m (Maybe DNS.DNSError)
     resolveA gotIpv6RspVar rspsVar= do
         r_e <- lookupA resolver domain
         case r_e of

--- a/typed-protocols/src/Network/TypedProtocol/Channel.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Channel.hs
@@ -107,8 +107,8 @@ fixedInputChannel xs0 = do
 -- writing.
 --
 mvarsAsChannel :: MonadSTM m
-               => LazyTMVar m a
-               -> LazyTMVar m a
+               => TMVar m a
+               -> TMVar m a
                -> Channel m a 
 mvarsAsChannel bufferRead bufferWrite =
     Channel{send, recv}


### PR DESCRIPTION
Split `MonadThread` out of `MonadFork`, so `MonadThread` has `ThreadId` and `myThreadId` but not the `fork` or `throwTo` operations.

Also add `labelThread` to `MonadThread`. This is for naming threads in the trace output. In IO it uses the builtin labelThread that emits an entry to the ghc eventlog. In the sim the thread labels are reported in trace events along with the thread id.

Change `io-sim-classes` to follow upstream API names and behaviour
* Rename `LazyTVar` back to `TVar` and `LazyTMVar` back to `TMVar`
* Add `modifyTVar'`
* ~Move `StrictTVar` to `ouroboros-consensus` package~
* Remove fallback exception handler from `IO` instance for `MonadFork.fork`

Note that the last one is a behaviour change. The original behaviour requires use of
```
GHC.Conc.setUncaughtExceptionHandler :: (SomeException -> IO ()) -> IO ()
```
But this has the advantage of working for all threads in the program. This would need to be added to the node top level.