### PR TITLE
Simplify MonadTime and add wall clock time

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadTime.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTime.hs
@@ -5,10 +5,11 @@ module Control.Monad.Class.MonadTime (
   , diffTime
   , addTime
   , DiffTime
+  , UTCTime
   ) where
 
 import           Data.Word (Word64)
-import           Data.Time.Clock (DiffTime)
+import           Data.Time.Clock (DiffTime, UTCTime)
 import qualified Data.Time.Clock as Time
 
 
@@ -37,11 +38,14 @@ class Monad m => MonadTime m where
   --
   getMonotonicTime :: m Time
 
+  -- | Wall clock time.
+  --
+  getCurrentTime   :: m UTCTime
+
 
 --
 -- Instances for IO
 --
-
 
 instance MonadTime IO where
   getMonotonicTime =
@@ -49,6 +53,8 @@ instance MonadTime IO where
     where
       conv :: Word64 -> Time
       conv = Time . Time.picosecondsToDiffTime . (* 1000) . toInteger
+
+  getCurrentTime = Time.getCurrentTime
 
 foreign import ccall unsafe "getMonotonicNSec"
     getMonotonicNSec :: IO Word64

--- a/io-sim-classes/src/Control/Monad/Class/MonadTime.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTime.hs
@@ -1,10 +1,9 @@
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Control.Monad.Class.MonadTime (
     MonadTime(..)
-  , TimeMeasure(..)
+  , Time(..)
+  , diffTime
+  , addTime
   , DiffTime
   ) where
 
@@ -13,46 +12,43 @@ import           Data.Time.Clock (DiffTime)
 import qualified Data.Time.Clock as Time
 
 
--- | A type that represents points in time.
+-- | A point in time in a monotonic clock.
 --
-class Ord t => TimeMeasure t where
+-- The epoch for this clock is arbitrary and does not correspond to any wall
+-- clock or calendar, and is /not guaranteed/ to be the same epoch across
+-- program runs. It is represented as the 'DiffTime' from this arbitrary epoch.
+--
+newtype Time = Time DiffTime
+  deriving (Eq, Ord, Show)
 
-  -- | The time duration between two points in time (positive or negative).
-  diffTime  :: t -> t -> DiffTime
+-- | The time duration between two points in time (positive or negative).
+diffTime :: Time -> Time -> DiffTime
+diffTime (Time t) (Time t') = t - t'
 
-  -- | Add a duration to a point in time, giving another time.
-  addTime   :: DiffTime -> t -> t
+-- | Add a duration to a point in time, giving another time.
+addTime :: DiffTime -> Time -> Time
+addTime d (Time t) = Time (d + t)
 
-  -- | The time epoch where points in time are measured relative to.
+
+class Monad m => MonadTime m where
+
+  -- | Time in a monotonic clock, with high precision. The epoch for this
+  -- clock is arbitrary and does not correspond to any wall clock or calendar.
   --
-  -- For example POSIX time is relative to 1970-01-01 00:00 UTC. For a
-  -- monotonic clock this would be an arbitrary point, not related to any
-  -- wall clock time.
-  --
-  zeroTime  :: t
-
-class (Monad m, TimeMeasure (Time m)) => MonadTime m where
-  type Time m :: *
-
-  getMonotonicTime :: m (Time m)
+  getMonotonicTime :: m Time
 
 
 --
 -- Instances for IO
 --
 
--- | Time in a monotonic clock, with high precision. The epoch for this
--- clock is arbitrary and does not correspond to any wall clock or calendar.
---
-instance TimeMeasure DiffTime where
-  diffTime t t' = t - t'
-  addTime  d t  = d + t
-  zeroTime      = 0
 
 instance MonadTime IO where
-  type Time IO = DiffTime
-  getMonotonicTime = fmap (Time.picosecondsToDiffTime . (* 1000) . toInteger)
-                          getMonotonicNSec
+  getMonotonicTime =
+      fmap conv getMonotonicNSec
+    where
+      conv :: Word64 -> Time
+      conv = Time . Time.picosecondsToDiffTime . (* 1000) . toInteger
 
 foreign import ccall unsafe "getMonotonicNSec"
     getMonotonicNSec :: IO Word64

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -42,7 +42,8 @@ library
                        io-sim-classes    >=0.1 && <0.2,
                        exceptions        >=0.10,
                        containers,
-                       psqueues          >=0.2 && <0.3
+                       psqueues          >=0.2 && <0.3,
+                       time              >=1.6 && <1.10
 
   ghc-options:         -Wall
   if flag(asserts)

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -22,6 +22,9 @@ module Control.Monad.IOSim (
   runSimTraceST,
   liftST,
   traceM,
+  -- * Simulation time
+  setCurrentTime,
+  unshareClock,
   -- * Simulation trace
   Trace(..),
   TraceEvent(..),
@@ -46,6 +49,9 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           Data.Typeable (Typeable)
 import           Data.Dynamic (Dynamic, toDyn, fromDynamic)
+import           Data.Time
+                   ( DiffTime, NominalDiffTime, UTCTime(..)
+                   , diffUTCTime, addUTCTime, fromGregorian )
 
 import           Control.Monad (mapM_)
 import           Control.Exception
@@ -92,7 +98,11 @@ data SimA s a where
 
   LiftST       :: StrictST.ST s a -> (a -> SimA s b) -> SimA s b
 
-  GetTime      :: (Time -> SimA s b) -> SimA s b
+  GetMonoTime  :: (Time    -> SimA s b) -> SimA s b
+  GetWallTime  :: (UTCTime -> SimA s b) -> SimA s b
+  SetWallTime  ::  UTCTime -> SimA s b  -> SimA s b
+  UnshareClock :: SimA s b -> SimA s b
+
   NewTimeout   :: DiffTime -> (Timeout (SimM s) -> SimA s b) -> SimA s b
   UpdateTimeout:: Timeout (SimM s) -> DiffTime -> SimA s b -> SimA s b
   CancelTimeout:: Timeout (SimM s) -> SimA s b -> SimA s b
@@ -348,7 +358,21 @@ liftST action = SimM $ \k -> LiftST action k
 
 instance MonadTime (SimM s) where
 
-  getMonotonicTime = SimM $ \k -> GetTime k
+  getMonotonicTime = SimM $ \k -> GetMonoTime k
+  getCurrentTime   = SimM $ \k -> GetWallTime k
+
+-- | Set the current wall clock time for the thread's clock domain.
+--
+setCurrentTime :: UTCTime -> SimM s ()
+setCurrentTime t = SimM $ \k -> SetWallTime t (k ())
+
+-- | Put the thread into a new wall clock domain, not shared with the parent
+-- thread. Changing the wall clock time in the new clock domain will not affect
+-- the other clock of other threads. All threads forked by this thread from
+-- this point onwards will share the new clock domain.
+--
+unshareClock :: SimM s ()
+unshareClock = SimM $ \k -> UnshareClock (k ())
 
 instance Eq (Timeout (SimM s)) where
   Timeout _ key == Timeout _ key' = key == key'
@@ -376,7 +400,8 @@ data Thread s a = Thread {
     threadBlocked :: !Bool,
     threadMasking :: !MaskingState,
     -- other threads blocked in a ThrowTo to us because we are or were masked
-    threadThrowTo :: ![(SomeException, ThreadId)]
+    threadThrowTo :: ![(SomeException, ThreadId)],
+    threadClockId :: !ClockId
   }
 
 -- We hide the type @b@ here, so it's useful to bundle these two parts
@@ -403,6 +428,7 @@ data ControlStack s b a where
 newtype ThreadId  = ThreadId  Int deriving (Eq, Ord, Enum, Show)
 newtype TVarId    = TVarId    Int deriving (Eq, Ord, Enum, Show)
 newtype TimeoutId = TimeoutId Int deriving (Eq, Ord, Enum, Show)
+newtype ClockId   = ClockId   Int deriving (Eq, Ord, Enum, Show)
 
 data Trace a = Trace !Time !ThreadId !TraceEvent (Trace a)
              | TraceMainReturn    !Time a             ![ThreadId]
@@ -543,7 +569,8 @@ runSimTraceST mainAction = schedule mainThread initialState
         threadControl = ThreadControl (runSimM mainAction) MainFrame,
         threadBlocked = False,
         threadMasking = Unmasked,
-        threadThrowTo = []
+        threadThrowTo = [],
+        threadClockId = ClockId 0
       }
 
 data SimState s a = SimState {
@@ -553,6 +580,7 @@ data SimState s a = SimState {
        threads  :: !(Map ThreadId (Thread s a)),
        curTime  :: !Time,
        timers   :: !(OrdPSQ TimeoutId Time (TVar s TimeoutState)),
+       clocks   :: !(Map ClockId UTCTime),
        nextTid  :: !ThreadId,   -- ^ next unused 'ThreadId'
        nextVid  :: !TVarId,     -- ^ next unused 'TVarId'
        nextTmid :: !TimeoutId   -- ^ next unused 'TimeoutId'
@@ -565,24 +593,35 @@ initialState =
       threads  = Map.empty,
       curTime  = Time 0,
       timers   = PSQ.empty,
+      clocks   = Map.singleton (ClockId 0) epoch1970,
       nextTid  = ThreadId 1,
       nextVid  = TVarId 0,
       nextTmid = TimeoutId 0
     }
+  where
+    epoch1970 = UTCTime (fromGregorian 1970 1 1) 0
 
 invariant :: Maybe (Thread s a) -> SimState s a -> Bool
 
-invariant (Just running) simstate@SimState{runqueue,threads} =
+invariant (Just running) simstate@SimState{runqueue,threads,clocks} =
     not (threadBlocked running)
  && threadId running `Map.notMember` threads
  && threadId running `List.notElem` runqueue
+ && threadClockId running `Map.member` clocks
  && invariant Nothing simstate
 
-invariant Nothing SimState{runqueue,threads} =
+invariant Nothing SimState{runqueue,threads,clocks} =
     all (`Map.member` threads) runqueue
  && and [ threadBlocked t == (threadId t `notElem` runqueue)
         | t <- Map.elems threads ]
  && runqueue == List.nub runqueue
+ && and [ threadClockId t `Map.member` clocks
+        | t <- Map.elems threads ]
+
+-- | Interpret the simulation monotonic time as a 'NominalDiffTime' since
+-- the start.
+timeSiceEpoch :: Time -> NominalDiffTime
+timeSiceEpoch (Time t) = fromRational (toRational t)
 
 
 schedule :: Thread s a -> SimState s a -> ST s (Trace a)
@@ -595,6 +634,7 @@ schedule thread@Thread{
            runqueue,
            threads,
            timers,
+           clocks,
            nextTid, nextVid, nextTmid,
            curTime  = time
          } =
@@ -667,9 +707,34 @@ schedule thread@Thread{
       let thread' = thread { threadControl = ThreadControl (k x) ctl }
       schedule thread' simstate
 
-    GetTime k -> do
+    GetMonoTime k -> do
       let thread' = thread { threadControl = ThreadControl (k time) ctl }
       schedule thread' simstate
+
+    GetWallTime k -> do
+      let clockid  = threadClockId thread
+          clockoff = clocks Map.! clockid
+          walltime = timeSiceEpoch time `addUTCTime` clockoff
+          thread'  = thread { threadControl = ThreadControl (k walltime) ctl }
+      schedule thread' simstate
+
+    SetWallTime walltime' k -> do
+      let clockid   = threadClockId thread
+          clockoff  = clocks Map.! clockid
+          walltime  = timeSiceEpoch time `addUTCTime` clockoff
+          clockoff' = addUTCTime (diffUTCTime walltime' walltime) clockoff
+          thread'   = thread { threadControl = ThreadControl k ctl }
+          simstate' = simstate { clocks = Map.insert clockid clockoff' clocks }
+      schedule thread' simstate'
+
+    UnshareClock k -> do
+      let clockid   = threadClockId thread
+          clockoff  = clocks Map.! clockid
+          clockid'  = (toEnum . fromEnum) tid -- reuse the thread id
+          thread'   = thread { threadControl = ThreadControl k ctl
+                             , threadClockId = clockid' }
+          simstate' = simstate { clocks = Map.insert clockid' clockoff clocks }
+      schedule thread' simstate'
 
     NewTimeout d k -> do
       tvar <- execNewTVar nextVid TimeoutPending
@@ -707,7 +772,8 @@ schedule thread@Thread{
                                                             ForkFrame
                             , threadBlocked = False
                             , threadMasking = threadMasking thread
-                            , threadThrowTo = [] }
+                            , threadThrowTo = []
+                            , threadClockId = threadClockId thread }
           threads' = Map.insert tid' thread'' threads
       trace <- schedule thread' simstate { runqueue = runqueue ++ [tid']
                                          , threads  = threads'
@@ -1151,11 +1217,11 @@ ordNub = go Set.empty
 -- Examples
 --
 {-
-example0 :: (MonadSay m, MonadTimer m, MonadSTM m) => m ()
+example0 :: (MonadSay m, MonadTimer m, MonadFork m, MonadSTM m) => m ()
 example0 = do
   say "starting"
   t <- atomically (newTVar (0 :: Int))
-  fork $ threadDelay 2 >> do
+  _ <- fork $ threadDelay 2 >> do
     say "timer fired!"
     atomically $
       writeTVar t 1
@@ -1168,11 +1234,11 @@ example1 :: SimM s ()
 example1 = do
   say "starting"
   chan <- atomically (newTVar ([] :: [Int]))
-  fork $ forever $ do
+  _ <- fork $ forever $ do
     atomically $ do
       x <- readTVar chan
       writeTVar chan (1:x)
-  fork $ forever $ do
+  _ <- fork $ forever $ do
     atomically $ do
       x <- readTVar chan
       writeTVar chan (2:x)
@@ -1185,18 +1251,18 @@ example1 = do
     say $ show x
 
 -- the trace should contain "1" followed by "2"
-example2 :: (MonadSay m, MonadSTM m) => m ()
+example2 :: (MonadSay m, MonadFork m, MonadSTM m) => m ()
 example2 = do
   say "starting"
   v <- atomically $ newTVar Nothing
-  fork $ do
+  _ <- fork $ do
     atomically $ do
       x <- readTVar v
       case x of
         Nothing -> retry
         Just _  -> return ()
     say "1"
-  fork $ do
+  _ <- fork $ do
     atomically $ do
       x <- readTVar v
       case x of
@@ -1204,4 +1270,48 @@ example2 = do
         Just _  -> return ()
     say "2"
   atomically $ writeTVar v (Just ())
+
+example3 :: SimM s ()
+example3 = do
+  say "starting"
+  threadDelay 1
+  mt1 <- getMonotonicTime
+  ct1 <- getCurrentTime
+  say (show (mt1, ct1))
+
+  setCurrentTime (UTCTime (fromGregorian 2000 1 1) 0)
+  ct1' <- getCurrentTime
+  say (show ct1')
+
+  threadDelay 1
+  mt2 <- getMonotonicTime
+  ct2 <- getCurrentTime
+  say (show (mt2, ct2))
+
+example4 :: SimM s ()
+example4 = do
+
+  say "starting"
+  setCurrentTime (UTCTime (fromGregorian 2000 1 1) 0)
+  do t <- (,) <$> getMonotonicTime <*> getCurrentTime
+     say $ "start: " ++ show t
+
+  v <- atomically (newTVar (0 :: Int))
+  _ <- fork $ do
+    unshareClock
+    setCurrentTime (UTCTime (fromGregorian 2011 11 11) 11)
+    do t <- (,) <$> getMonotonicTime <*> getCurrentTime
+       say $ "unshared: " ++ show t
+
+    atomically $
+      writeTVar v 1
+
+  atomically $ do
+    x <- readTVar v
+    unless (x == 1) retry
+
+  do t <- (,) <$> getMonotonicTime <*> getCurrentTime
+     say $ "end: " ++ show t
+
+  say "main done"
 -}

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -25,7 +25,6 @@ import           Test.Tasty.QuickCheck
 import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
-import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.IOSim
@@ -191,7 +190,6 @@ test_timers :: forall m.
                ( MonadFork m
                , MonadSTM m
                , MonadTimer m
-               , Show (Time m)
                )
             => [DiffTime]
             -> m Property

--- a/network-mux/src/Network/Mux/Bearer/Pipe.hs
+++ b/network-mux/src/Network/Mux/Bearer/Pipe.hs
@@ -47,7 +47,7 @@ pipeAsMuxBearer tracer pcRead pcWrite = do
         }
     where
       readPipe :: (HasCallStack)
-               => IO (Mx.MuxSDU ptcl, Time IO)
+               => IO (Mx.MuxSDU ptcl, Time)
       readPipe = do
           traceWith tracer $ Mx.MuxTraceRecvHeaderStart
           hbuf <- recvLen' pcRead 8 []
@@ -75,7 +75,7 @@ pipeAsMuxBearer tracer pcRead pcWrite = do
                   recvLen' pd (l - fromIntegral (BL.length buf)) (buf : bufs)
 
       writePipe :: Mx.MuxSDU ptcl
-                -> IO (Time IO)
+                -> IO Time
       writePipe sdu = do
           ts <- getMonotonicTime
           let ts32 = Mx.timestampMicrosecondsLow32Bits ts

--- a/network-mux/src/Network/Mux/Bearer/Queues.hs
+++ b/network-mux/src/Network/Mux/Bearer/Queues.hs
@@ -37,7 +37,7 @@ queuesAsMuxBearer
   -> TBQueue m BL.ByteString
   -> TBQueue m BL.ByteString
   -> Word16
-  -> Maybe (TBQueue m (Mx.MiniProtocolId ptcl, Mx.MiniProtocolMode, Time m))
+  -> Maybe (TBQueue m (Mx.MiniProtocolId ptcl, Mx.MiniProtocolMode, Time))
   -> m (MuxBearer ptcl m)
 queuesAsMuxBearer tracer writeQueue readQueue sduSize traceQueue = do
       mxState <- atomically $ newTVar Mx.Larval
@@ -48,7 +48,7 @@ queuesAsMuxBearer tracer writeQueue readQueue sduSize traceQueue = do
           Mx.state   = mxState
         }
     where
-      readMux :: m (Mx.MuxSDU ptcl, Time m)
+      readMux :: m (Mx.MuxSDU ptcl, Time)
       readMux = do
           traceWith tracer $ Mx.MuxTraceRecvHeaderStart
           buf <- atomically $ readTBQueue readQueue
@@ -69,7 +69,7 @@ queuesAsMuxBearer tracer writeQueue readQueue sduSize traceQueue = do
                   return (header {Mx.msBlob = payload}, ts)
 
       writeMux :: Mx.MuxSDU ptcl
-               -> m (Time m)
+               -> m Time
       writeMux sdu = do
           ts <- getMonotonicTime
           let ts32 = Mx.timestampMicrosecondsLow32Bits ts
@@ -107,7 +107,7 @@ runMuxWithQueues
   -> TBQueue m BL.ByteString
   -> TBQueue m BL.ByteString
   -> Word16
-  -> Maybe (TBQueue m (Mx.MiniProtocolId ptcl, Mx.MiniProtocolMode, Time m))
+  -> Maybe (TBQueue m (Mx.MiniProtocolId ptcl, Mx.MiniProtocolMode, Time))
   -> m (Maybe SomeException)
 runMuxWithQueues tracer peerid app wq rq mtu trace =
     let muxTracer = Mx.WithMuxBearer "Queue" `contramap` tracer in

--- a/network-mux/src/Network/Mux/Bearer/Socket.hs
+++ b/network-mux/src/Network/Mux/Bearer/Socket.hs
@@ -54,7 +54,7 @@ socketAsMuxBearer tracer sd = do
           Mx.state   = mxState
         }
     where
-      readSocket :: (HasCallStack) => IO (Mx.MuxSDU ptcl, Time IO)
+      readSocket :: (HasCallStack) => IO (Mx.MuxSDU ptcl, Time)
       readSocket = do
           traceWith tracer $ Mx.MuxTraceRecvHeaderStart
           hbuf <- recvLen' True 8 []
@@ -92,7 +92,7 @@ socketAsMuxBearer tracer sd = do
                   traceWith tracer $ Mx.MuxTraceRecvEnd buf
                   recvLen' False (l - fromIntegral (BL.length buf)) (buf : bufs)
 
-      writeSocket :: Mx.MuxSDU ptcl -> IO (Time IO)
+      writeSocket :: Mx.MuxSDU ptcl -> IO Time
       writeSocket sdu = do
           --say "write"
           ts <- getMonotonicTime

--- a/network-mux/src/Network/Mux/Time.hs
+++ b/network-mux/src/Network/Mux/Time.hs
@@ -5,14 +5,13 @@ module Network.Mux.Time (
     diffTimeToMicroseconds,
     microsecondsToDiffTime,
 
-    -- * TimeMeasure
-    TimeMeasure(..),
+    -- * Compact timestamp
     timestampMicrosecondsLow32Bits,
   ) where
 
 import Data.Word (Word32)
 import Data.Time.Clock (DiffTime, diffTimeToPicoseconds, picosecondsToDiffTime)
-import Control.Monad.Class.MonadTime (TimeMeasure(..))
+import Control.Monad.Class.MonadTime (Time(..))
 
 diffTimeToMicroseconds :: DiffTime -> Integer
 diffTimeToMicroseconds = (`div` 1000000) . diffTimeToPicoseconds
@@ -27,7 +26,7 @@ microsecondsToDiffTime = picosecondsToDiffTime . (* 1000000)
 -- The purpose is to give a compact timestamp (compact to send over the wire)
 -- for measuring time differences on the order of seconds or less.
 --
-timestampMicrosecondsLow32Bits :: TimeMeasure t => t -> Word32
-timestampMicrosecondsLow32Bits ts =
-    fromIntegral (diffTimeToMicroseconds (ts `diffTime` zeroTime))
+timestampMicrosecondsLow32Bits :: Time -> Word32
+timestampMicrosecondsLow32Bits (Time ts) =
+    fromIntegral (diffTimeToMicroseconds ts)
 

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -215,9 +215,9 @@ data MuxBearerState = Larval
 --
 data MuxBearer ptcl m = MuxBearer {
     -- | Timestamp and send MuxSDU.
-      write   :: MuxSDU ptcl -> m (Time m)
+      write   :: MuxSDU ptcl -> m Time
     -- | Read a MuxSDU
-    , read    :: m (MuxSDU ptcl, Time m)
+    , read    :: m (MuxSDU ptcl, Time)
     -- | Return a suitable MuxSDU payload size.
     , sduSize :: m Word16
     , state   :: StrictTVar m MuxBearerState

--- a/nix/.stack.nix/io-sim.nix
+++ b/nix/.stack.nix/io-sim.nix
@@ -22,6 +22,7 @@
           (hsPkgs.exceptions)
           (hsPkgs.containers)
           (hsPkgs.psqueues)
+          (hsPkgs.time)
           ];
         };
       tests = {

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -58,6 +58,8 @@ module Ouroboros.Consensus.Util.IOLike (
   , addTime
   , diffTime
   , getMonotonicTime
+  , UTCTime
+  , getCurrentTime
     -- *** MonadTimer
   , threadDelay
   , timeoutAfter

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
@@ -236,7 +236,7 @@ garbageCollect CDB{..} slotNo = do
 -- Represented as a queue.
 --
 -- The background thread will continuously try to pop the first element of the
--- queue. Whenever it manages to pop a @('Time' m, 'SlotNo')@ off: it first
+-- queue. Whenever it manages to pop a @('Time', 'SlotNo')@ off: it first
 -- waits until the 'Time' is passed (using 'threadDelay' with the given 'Time'
 -- minus the current 'Time') and then performs a garbage collection with the
 -- given 'SlotNo'.
@@ -274,7 +274,7 @@ garbageCollect CDB{..} slotNo = do
 -- time) will remain the same as the density decreases too (more slots, but
 -- many of them empty), hence the queue queue length will also remain the
 -- same.
-newtype GcSchedule m = GcSchedule (TQueue m (Time m, SlotNo))
+newtype GcSchedule m = GcSchedule (TQueue m (Time, SlotNo))
 
 newGcSchedule :: IOLike m => m (GcSchedule m)
 newGcSchedule = GcSchedule <$> atomically newTQueue

--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Worker.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Worker.hs
@@ -83,34 +83,34 @@ ipRetryDelay = 10 -- 10s delay
 -- | Result of the connection thread.  It's either result of an application, or
 -- an exception thrown by it.
 --
-data Result m addr r where
+data Result addr r where
      ApplicationResult
-       :: !(Time m)
+       :: !Time
        -> !addr
        -> !r
-       -> Result m addr r
+       -> Result addr r
 
      Connected
-       :: !(Time m)
+       :: !Time
        -> !addr
-       -> Result m addr r
+       -> Result addr r
 
      ConnectionError
        :: Exception e
-       => !(Time m)
+       => !Time
        -> !addr
        -> !e
-       -> Result m addr r
+       -> Result addr r
 
      ApplicationError
        :: Exception e
-       => !(Time m)
+       => !Time
        -> !addr
        -> !e
-       -> Result m addr r
+       -> Result addr r
 
 data ResOrAct m addr r =
-     Res !(Result m addr r)
+     Res !(Result addr r)
    | Act (m ())
 
 -- | Result queue.  The spawned threads will keep writing to it, while the main
@@ -151,7 +151,7 @@ type SocketStateChange m s addr = SocketState m addr -> s -> STM m s
 
 -- | Complete a connection, which receive application result (or exception).
 --
-type CompleteApplication m s addr r = Result m addr r -> s -> STM m (s, m ())
+type CompleteApplication m s addr r = Result addr r -> s -> STM m (s, m ())
 
 -- | Given current state 'retry' too keep the subscription worker going.
 -- When this transaction returns, all the threads spawned by the worker will be

--- a/ouroboros-network/test/Test/Ouroboros/Network/MockNode.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/MockNode.hs
@@ -69,7 +69,6 @@ test_blockGenerator
      , MonadFork m
      , MonadTime m
      , MonadTimer m
-     , Show (Time m)
      )
   => Chain Block
   -> DiffTime
@@ -78,12 +77,12 @@ test_blockGenerator chain slotDuration = do
     startTime <- getMonotonicTime
     isValid startTime <$> withProbe (experiment slotDuration)
   where
-    isValid :: Time m -> [(Time m, Block)] -> Property
+    isValid :: Time -> [(Time, Block)] -> Property
     isValid startTime = foldl'
         (\r (t, b) -> r .&&. t === slotTime (blockSlot b))
         (property True)
       where
-        slotTime :: SlotNo -> Time m
+        slotTime :: SlotNo -> Time
         slotTime s = (realToFrac (unSlotNo s) * slotDuration) `addTime` startTime
 
     experiment
@@ -93,7 +92,7 @@ test_blockGenerator chain slotDuration = do
          , MonadTimer m
          )
       => DiffTime
-      -> Probe m (Time m, Block)
+      -> Probe m (Time, Block)
       -> m ()
     experiment slotDur p = do
       getBlock <- blockGenerator slotDur (Chain.toOldestFirst chain)

--- a/ouroboros-network/test/Test/Subscription.hs
+++ b/ouroboros-network/test/Test/Subscription.hs
@@ -29,7 +29,6 @@ import           Data.Int
 import qualified Data.IP as IP
 import           Data.List as L
 import qualified Data.Map as M
-import           Data.Time.Clock
 import           Data.Void (Void)
 import           Data.Word
 import qualified Network.DNS as DNS


### PR DESCRIPTION
### Simplify `MonadTime` by using `DiffTime`

The `getMonotonicTime` does not need to use different types for time in different monads. It is fine to use `DiffTime` for both IO and the simulator.

### Add `getCurrentTime :: m UTCTime` to `MonadTime` and sim

This gives us two clocks, a monotonic clock and a wall clock. In IO the wall clock is the normal `getCurrentTime` from the time package.

In the simulator there is a new notion of clock domain. Each clock domain has a current wall clock time in `UTCTime`. Each thread belongs to a clock domain.

In the simulator only, the wall clock time can also be set. This does not affect the monotonic clock.

In the simulator only, a thread can put itself into a new clock domain which is not shared with other existing threads. This is intended to allow simulation of code running on different hosts that each have their own local wall clocks that are not necessarily synchronised.

This is intended to be used for testing the consensus implementation when there is clock skew between nodes.

