### PR TITLE
Concurrent readers

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -241,6 +241,7 @@ library
      build-depends:       Win32
   else
      build-depends:       unix
+                        , unix-bytestring
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -214,6 +214,7 @@ library
                        cardano-ledger,
                        cardano-prelude,
                        cborg             >=0.2.2 && <0.3,
+                       concurrent-extra,
                        constraints,
                        containers        >=0.5   && <0.7,
                        cryptonite        >=0.25  && <0.26,

--- a/ouroboros-consensus/src-unix/Ouroboros/Storage/IO.hs
+++ b/ouroboros-consensus/src-unix/Ouroboros/Storage/IO.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE PackageImports #-}
+
 module Ouroboros.Storage.IO (
       FHandle
     , open
     , truncate
     , seek
     , read
+    , pread
     , write
     , close
     , getSize
@@ -20,6 +23,9 @@ import           Data.Word (Word32, Word64, Word8)
 import           Foreign (Ptr)
 import           System.Posix (Fd)
 import qualified System.Posix as Posix
+
+-- Package 'unix' has a same module.
+import "unix-bytestring" System.Posix.IO.ByteString (fdPreadBuf)
 
 import           Ouroboros.Storage.FS.API.Types (AllowExisting (..), FsError,
                      OpenMode (..), SeekMode (..), sameFsError)
@@ -91,6 +97,11 @@ read :: FHandle -> Word64 -> IO ByteString
 read h bytes = withOpenHandle "read" h $ \fd ->
     Internal.createUptoN (fromIntegral bytes) $ \ptr ->
       fromIntegral <$> Posix.fdReadBuf fd ptr (fromIntegral bytes)
+
+pread :: FHandle -> Word64 -> Int64 -> IO ByteString
+pread h bytes offset = withOpenHandle "read" h $ \fd ->
+    Internal.createUptoN (fromIntegral bytes) $ \ptr ->
+      fromIntegral <$> fdPreadBuf fd ptr (fromIntegral bytes) (fromIntegral offset)
 
 -- | Truncates the file managed by the input 'FHandle' to the input size.
 truncate :: FHandle -> Word64 -> IO ()

--- a/ouroboros-consensus/src-win32/Ouroboros/Storage/IO.hs
+++ b/ouroboros-consensus/src-win32/Ouroboros/Storage/IO.hs
@@ -51,10 +51,10 @@ open filename openMode = do
     return h
   where
     (isAppend, accessMode, creationDisposition) = case openMode of
-      ReadMode         -> (False, gENERIC_READ,                  oPEN_EXISTING)
-      AppendMode    ex -> (True,                   gENERIC_WRITE, createNew ex)
-      WriteMode     ex -> (True,  gENERIC_READ .|. gENERIC_WRITE, createNew ex)
-      ReadWriteMode ex -> (True,  gENERIC_READ .|. gENERIC_WRITE, createNew ex)
+      ReadMode         -> (False, gENERIC_READ,                   oPEN_EXISTING)
+      AppendMode    ex -> (True,                    gENERIC_WRITE, createNew ex)
+      WriteMode     ex -> (False,  gENERIC_READ .|. gENERIC_WRITE, createNew ex)
+      ReadWriteMode ex -> (False,  gENERIC_READ .|. gENERIC_WRITE, createNew ex)
     createNew AllowExisting = oPEN_ALWAYS
     createNew MustBeNew     = cREATE_NEW
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Handle.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Handle.hs
@@ -1,27 +1,30 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase    #-}
+{-# LANGUAGE TupleSections #-}
 
 -- | This is meant to be used for the implementation of HasFS
 -- instances and not directly by client code.
 module Ouroboros.Storage.FS.Handle (
       HandleOS (..)
+    , newHandleOS
+    , readOpenHandle
+    , writeOpenHandle
     , closeHandleOS
-    , withOpenHandle
-    , isHandleClosedException
     ) where
 
-import           Control.Concurrent.MVar
+import           Control.Concurrent.ReadWriteVar
 import           Control.Exception hiding (handle)
 import           System.IO.Error as IO
 
--- | File handlers for the IO instance for HasFS.
--- This is parametric on the os.
+-- | File handles for the IO instance for HasFS. This is parametric on the os.
 --
 -- The 'FilePath' is used to improve error messages.
--- The 'MVar' is used to implement 'close'.
+--
+-- The 'RWVar' is used to implement concurrent reads and sequential writes.
+--
 -- osHandle is Fd for unix and HANDLE for Windows.
 data HandleOS osHandle = HandleOS {
       filePath :: FilePath
-    , handle   :: MVar (Maybe osHandle)
+    , handle   :: RWVar (Maybe osHandle)
     }
 
 instance Eq (HandleOS a) where
@@ -30,36 +33,50 @@ instance Eq (HandleOS a) where
 instance Show (HandleOS a) where
   show h = "<Handle " ++ filePath h ++ ">"
 
--- | This is a no-op when the handle is already closed.
-closeHandleOS :: HandleOS osHandle -> (osHandle -> IO ()) -> IO ()
-closeHandleOS (HandleOS _ hVar) close =
-  modifyMVar hVar $ \case
-    Nothing -> return (Nothing, ())
-    Just h -> close h >> return (Nothing, ())
-
 {-------------------------------------------------------------------------------
-  Exceptions
+  Handle Access
 -------------------------------------------------------------------------------}
 
--- | This is meant to be used for the implementation of individual file system commands.
--- Using it for larger scopes woud not be correct, since we would not notice if the
--- handle is closed.
-withOpenHandle :: String -> HandleOS osHandle -> (osHandle -> IO a) -> IO a
-withOpenHandle label (HandleOS fp hVar) k =
-    withMVar hVar $ \case
-        Nothing -> throwIO (handleClosedException fp label)
-        Just fd -> k fd
+newHandleOS :: FilePath -> osHandle -> IO (HandleOS osHandle)
+newHandleOS path osHandle =
+    HandleOS path <$> new (Just osHandle)
+
+-- | This is meant to be used for the implementation of individual file system
+-- commands. Using it for larger scopes would not be correct, since we would not
+-- notice if the handle is closed.
+--
+-- Multiple threads can have concurrent access to the open handle using this
+-- combinator. However threads which try to write or close the handle block,
+-- while there is an ongoing reader. Also readers blocks if some other thread
+-- write or clolse.
+readOpenHandle :: String -> HandleOS osHandle -> (osHandle -> IO a) -> IO a
+readOpenHandle label (HandleOS fp hVar) k =
+    with hVar $ \case
+      Nothing -> throwIO (handleClosedException fp label)
+      Just fd -> k fd
+
+-- | Only one writer is allown. Writers block if there are any readers. Readers
+-- block if there is any writer.
+writeOpenHandle :: String -> HandleOS osHandle -> (osHandle -> IO a) -> IO a
+writeOpenHandle label (HandleOS fp hVar) k =
+    modify hVar $ \hndl -> case hndl of
+      Nothing -> throwIO (handleClosedException fp label)
+      Just fd -> (hndl,) <$> k fd
+
+-- | Like 'writeOpenHandle' in terms of locking.
+-- This is a no-op when the handle is already closed.
+closeHandleOS :: HandleOS osHandle -> (osHandle -> IO ()) -> IO ()
+closeHandleOS (HandleOS _ hVar) close =
+    modify hVar $ \case
+      Nothing -> return (Nothing, ())
+      Just h  -> close h >> return (Nothing, ())
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary
+-------------------------------------------------------------------------------}
 
 handleClosedException :: FilePath -> String -> IOException
 handleClosedException fp label =
       flip IO.ioeSetErrorType IO.illegalOperationErrorType
     $ flip IO.ioeSetFileName fp
     $ userError (label ++ ": FHandle closed")
-
-{-------------------------------------------------------------------------------
-  Internal auxiliary
--------------------------------------------------------------------------------}
-
-isHandleClosedException :: IOException -> Bool
-isHandleClosedException ioErr =
-    IO.isUserErrorType (IO.ioeGetErrorType ioErr)

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/IO.hs
@@ -45,6 +45,8 @@ ioHasFS mount = HasFS {
         F.seek h mode o
     , hGetSome = \(Handle h fp) n -> rethrowFsError fp $
         F.read h (fromIntegral n)
+    , hGetSomeAt = \(Handle h fp) n o -> rethrowFsError fp $
+        F.pread h (fromIntegral n) o
     , hTruncate = \(Handle h fp) sz -> rethrowFsError fp $
         F.truncate h sz
     , hGetSize = \(Handle h fp) -> rethrowFsError fp $

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
@@ -9,6 +9,7 @@ module Ouroboros.Storage.VolatileDB.API
   , module Ouroboros.Storage.VolatileDB.Types
   ) where
 
+import           Control.Monad.Class.MonadThrow
 import           Data.ByteString.Builder (Builder)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Set (Set)
@@ -16,12 +17,8 @@ import           GHC.Stack (HasCallStack)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..))
 
-import           Control.Monad.Class.MonadThrow
-
-import           Ouroboros.Network.Point (WithOrigin)
-
 import           Ouroboros.Consensus.Util.IOLike
-
+import           Ouroboros.Network.Point (WithOrigin)
 import           Ouroboros.Storage.VolatileDB.Types
 
 -- | Open the database using the given function, perform the given action

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
@@ -9,7 +9,6 @@ module Ouroboros.Storage.VolatileDB.API
   , module Ouroboros.Storage.VolatileDB.Types
   ) where
 
-import           Control.Monad.Class.MonadThrow
 import           Data.ByteString.Builder (Builder)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Set (Set)
@@ -17,8 +16,12 @@ import           GHC.Stack (HasCallStack)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..))
 
-import           Ouroboros.Consensus.Util.IOLike
+import           Control.Monad.Class.MonadThrow
+
 import           Ouroboros.Network.Point (WithOrigin)
+
+import           Ouroboros.Consensus.Util.IOLike
+
 import           Ouroboros.Storage.VolatileDB.Types
 
 -- | Open the database using the given function, perform the given action

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/FileInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/FileInfo.hs
@@ -132,10 +132,10 @@ sizeAndId (size, bInfo) = FileSlotInfo size (bbid bInfo)
 lastSlotInfo :: forall blockId.
                 Map SlotOffset (Word64, BlockInfo blockId)
              -> Maybe (blockId, SlotNo)
-lastSlotInfo mp = f <$> safeMaximumOn getSlot (Map.elems mp)
+lastSlotInfo mp = getBlockId <$> safeMaximumOn getSlotNo (Map.elems mp)
   where
-    f :: (SlotOffset, BlockInfo blockId) -> (blockId, SlotNo)
-    f (_, bInfo) = (bbid bInfo, bslot bInfo)
+    getBlockId :: (SlotOffset, BlockInfo blockId) -> (blockId, SlotNo)
+    getBlockId (_, bInfo) = (bbid bInfo, bslot bInfo)
 
-    getSlot :: (SlotOffset, BlockInfo blockId) -> SlotNo
-    getSlot (_, bInfo) = bslot bInfo
+    getSlotNo :: (SlotOffset, BlockInfo blockId) -> SlotNo
+    getSlotNo (_, bInfo) = bslot bInfo

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/FileInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/FileInfo.hs
@@ -8,11 +8,12 @@
 -- Intended for qualified import.
 module Ouroboros.Storage.VolatileDB.FileInfo (
     FileInfo     -- opaque
-  , FileSlotInfo(..) -- TODO: opaque
+  , FileSlotInfo -- opaque
     -- * Construction
   , empty
   , addSlot
   , fromParsedInfo
+  , mkFileSlotInfo
     -- * Queries
   , canGC
   , blockIds
@@ -91,6 +92,9 @@ fromParsedInfo parsed =
     parsed'  = Map.fromList parsed
     nBlocks  = Map.size parsed'
     contents = Map.map sizeAndId parsed'
+
+mkFileSlotInfo :: BlockSize -> blockId -> FileSlotInfo blockId
+mkFileSlotInfo = FileSlotInfo
 
 {-------------------------------------------------------------------------------
   Queries

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/FileInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/FileInfo.hs
@@ -20,6 +20,7 @@ module Ouroboros.Storage.VolatileDB.FileInfo (
   , isFull
   , maxSlot
   , maxSlotInFiles
+  , getHandle
   ) where
 
 import           Data.Map.Strict (Map)
@@ -35,19 +36,22 @@ import           Ouroboros.Network.Block (MaxSlotNo (..), SlotNo,
 
 import           Ouroboros.Consensus.Util
 
+import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.VolatileDB.Types
 import           Ouroboros.Storage.VolatileDB.Util
+
 
 {-------------------------------------------------------------------------------
   Types
 -------------------------------------------------------------------------------}
 
 -- The Internal information the db keeps for each file.
-data FileInfo blockId = MkFileInfo {
+data FileInfo blockId h = MkFileInfo {
       fLatestSlot :: !MaxSlotNo
     , fNBlocks    :: !Int
     , fContents   :: !(Map SlotOffset (FileSlotInfo blockId))
+    , fReadHandle :: !(Handle h)
     } deriving (Show, Generic, NoUnexpectedThunks)
 
 -- | Information about a slot in a file
@@ -60,22 +64,24 @@ data FileSlotInfo blockId = FileSlotInfo {
   Construction
 -------------------------------------------------------------------------------}
 
-empty :: FileInfo blockId
-empty = MkFileInfo {
+empty :: Handle h -> FileInfo blockId h
+empty hndl = MkFileInfo {
       fLatestSlot = NoMaxSlotNo
     , fNBlocks    = 0
     , fContents   = Map.empty
+    , fReadHandle = hndl
     }
 
--- | Add slot to a file
+-- | Adds slot to a file.
 addSlot :: SlotNo
         -> SlotOffset
         -> FileSlotInfo blockId
-        -> FileInfo blockId -> FileInfo blockId
-addSlot slotNo slotOffset slotInfo MkFileInfo{..} = MkFileInfo {
+        -> FileInfo blockId h -> FileInfo blockId h
+addSlot slotNo slotOffset slotInfo fileInfo@MkFileInfo{..} = fileInfo {
       fLatestSlot = updateSlotNoBlockId fLatestSlot [slotNo]
     , fNBlocks    = fNBlocks + 1
     , fContents   = Map.insert slotOffset slotInfo fContents
+    , fReadHandle = fReadHandle
     }
 
 -- | Construct 'FileInfo' from the parser result
@@ -83,11 +89,12 @@ addSlot slotNo slotOffset slotInfo MkFileInfo{..} = MkFileInfo {
 -- Additionally returns information about the last 'SlotOffset' in the file,
 -- unless the file is empty.
 fromParsedInfo :: ParsedInfo blockId
-               -> (FileInfo blockId, Maybe (blockId, SlotNo))
-fromParsedInfo parsed =
+               -> Handle h
+               -> (FileInfo blockId h, Maybe (blockId, SlotNo))
+fromParsedInfo parsed hndl =
     case lastSlotInfo parsed' of
-      Nothing     -> (MkFileInfo NoMaxSlotNo   nBlocks contents, Nothing)
-      Just (b, s) -> (MkFileInfo (MaxSlotNo s) nBlocks contents, Just (b, s))
+      Nothing     -> (MkFileInfo NoMaxSlotNo   nBlocks contents hndl, Nothing)
+      Just (b, s) -> (MkFileInfo (MaxSlotNo s) nBlocks contents hndl, Just (b, s))
   where
     parsed'  = Map.fromList parsed
     nBlocks  = Map.size parsed'
@@ -101,27 +108,30 @@ mkFileSlotInfo = FileSlotInfo
 -------------------------------------------------------------------------------}
 
 -- | Check if this file can be GCed
-canGC :: FileInfo blockId -> SlotNo -> Bool
+canGC :: FileInfo blockId h -> SlotNo -> Bool
 canGC MkFileInfo{..} slot =
     case fLatestSlot of
       NoMaxSlotNo      -> True
       MaxSlotNo latest -> latest < slot
 
 -- | All block IDs in this file
-blockIds :: FileInfo blockId -> [blockId]
+blockIds :: FileInfo blockId h -> [blockId]
 blockIds MkFileInfo{..} = fsBlockId <$> Map.elems fContents
 
 -- | Has this file reached its maximum size?
-isFull :: Int -> FileInfo blockId -> Bool
+isFull :: Int -> FileInfo blockId h -> Bool
 isFull maxNumBlocks MkFileInfo{..} = fNBlocks >= fromIntegral maxNumBlocks
 
-maxSlot :: FileInfo blockId -> MaxSlotNo
+maxSlot :: FileInfo blockId h -> MaxSlotNo
 maxSlot = fLatestSlot
 
-maxSlotInFiles :: [FileInfo blockId] -> MaxSlotNo
+maxSlotInFiles :: [FileInfo blockId h] -> MaxSlotNo
 maxSlotInFiles = maxSlotNoFromMaybe
                . safeMaximum
                . mapMaybe (maxSlotNoToMaybe . maxSlot)
+
+getHandle :: FileInfo blockId h -> Handle h
+getHandle = fReadHandle
 
 {-------------------------------------------------------------------------------
   Internal auxiliary

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
@@ -592,7 +592,10 @@ mkInternalState hasFS@HasFS{..} err parser n files =
     go currentMap currentRevMap succMap maxSlot lessThanN ((fd, file):rest) = do
         (blocks, mErr) <- parse parser file
         hndlRead <- hOpen file ReadMode
-        updateAndGo blocks hndlRead mErr
+        -- TODO: We can use @ResourceRegistry@ for a  better way to handle
+        -- recourses. In particular the approach here may allow open handles leaks
+        -- in case of async-exceptions.
+        updateAndGo blocks hndlRead mErr `onException` hClose hndlRead
       where
         -- | Updates the state and call 'go' for the rest of the files.
         updateAndGo :: [(SlotOffset, (BlockSize, BlockInfo blockId))]

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
@@ -262,10 +262,9 @@ getBlockImpl env@VolatileDBEnv{..} slot =
             Nothing ->
               -- All files should be open.
               throwError _dbErr $ UnexpectedError $ FileNotFound ibFile
-            Just hndl -> do
+            Just hndl ->
               -- TODO: use pread when available.
-              _ <- hSeek hndl AbsoluteSeek (fromIntegral ibSlotOffset)
-              hGetExactly hasFS hndl ibBlockSize
+              hGetExactlyAt hasFS hndl ibBlockSize (fromIntegral ibSlotOffset)
           return $ Just bs
 
 -- | This function follows the approach:

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Impl.hs
@@ -9,9 +9,9 @@
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE TupleSections             #-}
--- Volatile on-disk database of binary blobs
+-- | Volatile on-disk database of binary blobs
 --
--- Logic
+-- = Logic
 --
 -- The db is a key-value store of binary blocks and is parametric
 -- on the key of blocks, named blockId. The only constraints are that one must
@@ -33,7 +33,7 @@
 -- depend on the number of blocks we insert on each file, as well as the order
 -- of insertion, so it's not deterministic on blocks themselves.
 --
--- Errors
+-- = Errors
 --
 -- On any exception or error the db closes and its Internal State is lost,
 -- inluding in memory indexes. We try to make sure that even on errors the
@@ -55,12 +55,12 @@
 -- are safe. You can safely use HasFs calls in modifyState or wrapFsError
 -- actions.
 --
--- Concurrency
+-- = Concurrency
 --
 -- The same db should only be opened once
 -- Multiple threads can share the same db as concurency if fully supported.
 --
--- FS Layout:
+-- = FS Layout:
 --
 -- On disk represantation is as follows:
 --
@@ -87,8 +87,8 @@ module Ouroboros.Storage.VolatileDB.Impl
       -- * tests only
     , VolatileDBEnv(..)
     , InternalState(..)
+    , OpenOrClosed(..)
     , filePath
-    , getInternalState
     , openDBFull
     ) where
 
@@ -109,7 +109,7 @@ import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Network.Point (WithOrigin)
 
-import           Ouroboros.Consensus.Util (SomePair (..), safeMaximumOn)
+import           Ouroboros.Consensus.Util (safeMaximumOn)
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.FS.API
@@ -148,21 +148,23 @@ volatileDbIsOpen VolatileDbClosed   = False
 
 data InternalState blockId h = InternalState
     { _currentWriteHandle :: !(Handle h)
-    -- ^ The unique open file we append blocks.
+      -- ^ The unique open file we append blocks.
     , _currentWritePath   :: !FsPath
-    -- ^ The path of the file above.
+      -- ^ The path of the file above.
+    , _currentWriteId     :: !FileId
+      -- ^ The 'FileId' of the same file.
     , _currentWriteOffset :: !Word64
-    -- ^ The 'WriteHandle' for the same file.
+      -- ^ The offset of the same file.
     , _nextNewFileId      :: !Int
-    -- ^ The next file name Id.
+      -- ^ The next file name Id.
     , _currentMap         :: !(Index blockId)
-    -- ^ The content of each file.
+      -- ^ The contents of each file.
     , _currentRevMap      :: !(ReverseIndex blockId)
-    -- ^ Where to find each block from slot.
+      -- ^ Where to find each block based on its slot number.
     , _currentSuccMap     :: !(SuccessorsIndex blockId)
-    -- ^ successors for each block.
+      -- ^ The successors for each block.
     , _currentMaxSlotNo   :: !MaxSlotNo
-    -- ^ Highest ever stored SlotNo
+      -- ^ Highest ever stored SlotNo.
     }
   deriving (Generic, NoUnexpectedThunks)
 
@@ -189,27 +191,25 @@ openDBFull :: (HasCallStack, IOLike m, Ord blockId, NoUnexpectedThunks blockId)
 openDBFull hasFS err errSTM parser maxBlocksPerFile = do
     env <- openDBImpl hasFS err errSTM parser maxBlocksPerFile
     return $ (, env) VolatileDB {
-          closeDB        = closeDBImpl  env
-        , isOpenDB       = isOpenDBImpl env
-        , reOpenDB       = reOpenDBImpl env
-        , getBlock       = getBlockImpl env
-        , putBlock       = putBlockImpl env
-        , garbageCollect = garbageCollectImpl env
-        , getIsMember    = getIsMemberImpl env
-        , getBlockIds    = getBlockIdsImpl env
-        , getSuccessors  = getSuccessorsImpl env
-        , getPredecessor = getPredecessorImpl env
-        , getMaxSlotNo   = getMaxSlotNoImpl env
-        }
+        closeDB        = closeDBImpl  env
+      , isOpenDB       = isOpenDBImpl env
+      , reOpenDB       = reOpenDBImpl env
+      , getBlock       = getBlockImpl env
+      , putBlock       = putBlockImpl env
+      , garbageCollect = garbageCollectImpl env
+      , getIsMember    = getIsMemberImpl env
+      , getBlockIds    = getBlockIdsImpl env
+      , getSuccessors  = getSuccessorsImpl env
+      , getPredecessor = getPredecessorImpl env
+      , getMaxSlotNo   = getMaxSlotNoImpl env
+      }
 
--- | NOTE: After opening the db once, the same @maxBlocksPerFile@ must be
--- provided for all next opens.
 openDBImpl :: (HasCallStack, IOLike m, Ord blockId, NoUnexpectedThunks blockId)
            => HasFS m h
            -> ErrorHandling (VolatileDBError blockId) m
            -> ThrowCantCatch (VolatileDBError blockId) (STM m)
            -> Parser e m blockId
-           -> Int
+           -> Int -- ^ @maxBlocksPerFile@
            -> m (VolatileDBEnv m blockId)
 openDBImpl hasFS@HasFS{..} err errSTM parser maxBlocksPerFile =
     if maxBlocksPerFile <= 0
@@ -226,9 +226,9 @@ closeDBImpl :: IOLike m
 closeDBImpl VolatileDBEnv{..} = do
     mbInternalState <- swapMVar _dbInternalState VolatileDbClosed
     case mbInternalState of
-        VolatileDbClosed -> return ()
-        VolatileDbOpen InternalState{..} ->
-            wrapFsError hasFsErr _dbErr $ hClose _currentWriteHandle
+      VolatileDbClosed -> return ()
+      VolatileDbOpen InternalState{..} ->
+        wrapFsError hasFsErr _dbErr $ hClose _currentWriteHandle
   where
     HasFS{..} = _dbHasFS
 
@@ -239,17 +239,17 @@ isOpenDBImpl VolatileDBEnv{..} = do
     mSt <- readMVar _dbInternalState
     return $ volatileDbIsOpen mSt
 
--- | Preconditions: closeDB . reOpenDB is a no-op. This is achieved because
--- when we reOpen we always append onto the latest created file.
+-- | Property: @'closeDB' >> 'reOpenDB'@ is a no-op. This is true because
+-- 'reOpenDB` will always append to the last created file.
 reOpenDBImpl :: (HasCallStack, IOLike m, Ord blockId)
              => VolatileDBEnv m blockId
              -> m ()
 reOpenDBImpl VolatileDBEnv{..} =
     modifyMVar _dbInternalState $ \mbSt -> case mbSt of
-        VolatileDbOpen st -> return (VolatileDbOpen st, ())
-        VolatileDbClosed -> do
-            st <- mkInternalStateDB _dbHasFS _dbErr _parser _maxBlocksPerFile
-            return (VolatileDbOpen st, ())
+      VolatileDbOpen st -> return (VolatileDbOpen st, ())
+      VolatileDbClosed -> do
+        st <- mkInternalStateDB _dbHasFS _dbErr _parser _maxBlocksPerFile
+        return (VolatileDbOpen st, ())
 
 getBlockImpl :: (IOLike m, Ord blockId)
              => VolatileDBEnv m blockId
@@ -257,25 +257,28 @@ getBlockImpl :: (IOLike m, Ord blockId)
              -> m (Maybe ByteString)
 getBlockImpl env@VolatileDBEnv{..} slot =
     modifyState env $ \hasFS@HasFS{..} st@InternalState{..} ->
-        case Map.lookup slot _currentRevMap of
-            Nothing -> return (st, Nothing)
-            Just InternalBlockInfo {..} ->  do
-                bs <- withFile hasFS ibFile ReadMode $ \hndl -> do
-                        _ <- hSeek hndl AbsoluteSeek (fromIntegral ibSlotOffset)
-                        hGetExactly hasFS hndl (fromIntegral ibBlockSize)
-                return (st, Just bs)
+      case Map.lookup slot _currentRevMap of
+        Nothing -> return (st, Nothing)
+        Just InternalBlockInfo {..} ->  do
+          bs <- withFile hasFS ibFile ReadMode $ \hndl -> do
+                  _ <- hSeek hndl AbsoluteSeek (fromIntegral ibSlotOffset)
+                  hGetExactly hasFS hndl (fromIntegral ibBlockSize)
+          return (st, Just bs)
 
 -- | This function follows the approach:
 -- (1) hPut bytes to the file
 -- (2) if full hClose the write file
 -- (3)         hOpen a new write file
 -- (4) update the Internal State.
+--
 -- If there is an error after (1) or after (2) we should make sure that when
--- we reopen a db from scratch, it can succesfully recover if it does not
+-- we reopen a db from scratch, it can successfully recover if it does not
 -- find an empty file to write and all other files are full.
--- We should also make sure that the fs can be recovered if we get an
+--
+-- We should also make sure that the db can recover if we get an
 -- exception/error at any moment and that we are left with an empty Internal
 -- State.
+--
 -- We should be careful about not leaking open fds when we open a new file,
 -- since this can affect garbage collection of files.
 putBlockImpl :: forall m blockId. (IOLike m, Ord blockId)
@@ -283,56 +286,55 @@ putBlockImpl :: forall m blockId. (IOLike m, Ord blockId)
              -> BlockInfo blockId
              -> BS.Builder
              -> m ()
-putBlockImpl env@VolatileDBEnv{..} binfo@BlockInfo{..} builder =
-  modifyState env $ \hasFS@HasFS{..} st@InternalState{..} ->
-    if Map.member bbid _currentRevMap
-    then return (st, ()) -- putting an existing block is a no-op.
-    else do
+putBlockImpl env@VolatileDBEnv{..} BlockInfo{..} builder =
+    modifyState env $ \hasFS@HasFS{..} st@InternalState{..} ->
+      if Map.member bbid _currentRevMap
+      then return (st, ()) -- putting an existing block is a no-op.
+      else do
         bytesWritten <- hPut hasFS _currentWriteHandle builder
-        putBlockImpl' env binfo hasFS st bytesWritten
-
-putBlockImpl' :: forall m blockId h. (IOLike m, Ord blockId)
-              => VolatileDBEnv m blockId
-              -> BlockInfo blockId
-              -> HasFS m h
-              -> InternalState blockId h
-              -> Word64
-              -> m (InternalState blockId h, ())
-putBlockImpl' env BlockInfo{..} hasFS@HasFS{..} st@InternalState{..} bytesWritten =
-    if not (FileInfo.isFull (_maxBlocksPerFile env) fileInfo')
-    then return (st', ())
-    else (,()) <$> nextFile hasFS (_dbErr env) env st'
-    where
+        updateStateAfterWrite hasFS st bytesWritten
+  where
+    updateStateAfterWrite :: forall h.
+                             HasFS m h
+                          -> InternalState blockId h
+                          -> Word64
+                          -> m (InternalState blockId h, ())
+    updateStateAfterWrite hasFS@HasFS{..} st@InternalState{..} bytesWritten =
+        if FileInfo.isFull _maxBlocksPerFile fileInfo'
+        then (,()) <$> nextFile hasFS _dbErr env st'
+        else return (st', ())
+      where
         fileInfo = fromMaybe
-            (error $ "Volatile db invariant violation:"
-                  ++ "Current write file not found in Index.")
-            (Index.lookup _currentWritePath _currentMap)
+            (error $ "VolatileDB invariant violation:"
+                    ++ "Current write file not found in Index.")
+            (Index.lookup _currentWriteId _currentMap)
         fileInfo' = FileInfo.addSlot bslot _currentWriteOffset
             (FileInfo.mkFileSlotInfo (fromIntegral bytesWritten) bbid) fileInfo
-        mp = Index.insert _currentWritePath fileInfo' _currentMap
+        currentMap' = Index.insert _currentWriteId fileInfo' _currentMap
         internalBlockInfo' = InternalBlockInfo {
-              ibFile       = _currentWritePath
-            , ibSlotOffset = _currentWriteOffset
-            , ibBlockSize  = bytesWritten
-            , ibSlot       = bslot
-            , ibPreBid     = bpreBid
-        }
-        revMp = Map.insert bbid internalBlockInfo' _currentRevMap
+            ibFile       = _currentWritePath
+          , ibSlotOffset = _currentWriteOffset
+          , ibBlockSize  = bytesWritten
+          , ibSlot       = bslot
+          , ibPreBid     = bpreBid
+          }
+        currentRevMap' = Map.insert bbid internalBlockInfo' _currentRevMap
         st' = st {
-              _currentWriteOffset = _currentWriteOffset + fromIntegral bytesWritten
-            , _currentMap       = mp
-            , _currentRevMap    = revMp
-            , _currentSuccMap   = insertMapSet _currentSuccMap (bbid, bpreBid)
-            , _currentMaxSlotNo = _currentMaxSlotNo `max` MaxSlotNo bslot
-        }
+            _currentWriteOffset = _currentWriteOffset + fromIntegral bytesWritten
+          , _currentMap         = currentMap'
+          , _currentRevMap      = currentRevMap'
+          , _currentSuccMap     = insertMapSet _currentSuccMap (bbid, bpreBid)
+          , _currentMaxSlotNo   = _currentMaxSlotNo `max` MaxSlotNo bslot
+          }
 
--- The approach we follow here is to try to garbage collect each file.
+-- | The approach we follow here is to try to garbage collect each file.
 -- For each file we update the fs and then we update the Internal State.
 -- If some fs update fails, we are left with an empty Internal State and a
 -- subset of the deleted files in fs. Any unexpected failure (power loss,
 -- other exceptions) has the same results, since the Internal State will
 -- be empty on re-opening. This is ok only if any fs updates leave the fs
 -- in a consistent state every moment.
+--
 -- This approach works since we always close the Database in case of errors,
 -- but we should rethink it if this changes in the future.
 garbageCollectImpl :: forall m blockId. (IOLike m, Ord blockId)
@@ -341,16 +343,17 @@ garbageCollectImpl :: forall m blockId. (IOLike m, Ord blockId)
                    -> m ()
 garbageCollectImpl env@VolatileDBEnv{..} slot =
     modifyState env $ \hasFS st -> do
-        st' <- foldM (tryCollectFile hasFS env slot) st
-                (sortOn (unsafeParseFd . fst) $ Index.toList (_currentMap st))
-        return (st', ())
+      st' <- foldM (tryCollectFile hasFS env slot) st
+              (sortOn fst $ Index.toList (_currentMap st))
+      return (st', ())
 
--- For the given file, we check if it should be garbage collected.
--- At the same time we return the updated InternalState.
+-- | For the given file, we check if it should be garbage collected and
+-- return the updated InternalState.
+--
 -- Important note here is that, every call should leave the fs in a
--- consistent state, without depending on other calls.
--- This is achieved so far, since fs calls are reduced to
--- removeFile and truncate 0.
+-- consistent state, without depending on other calls. This is achieved
+-- so far, since fs calls are reduced to removeFile and truncate 0.
+--
 -- This may throw an FsError.
 tryCollectFile :: forall m h blockId
                .  (MonadThrow m, Ord blockId)
@@ -358,65 +361,60 @@ tryCollectFile :: forall m h blockId
                -> VolatileDBEnv m blockId
                -> SlotNo
                -> InternalState blockId h
-               -> (FsPath, FileInfo blockId)
+               -> (FileId, FileInfo blockId)
                -> m (InternalState blockId h)
-tryCollectFile hasFS@HasFS{..} env slot st@InternalState{..} (file, fileInfo) =
+tryCollectFile hasFS@HasFS{..} env slot st@InternalState{..} (fileId, fileInfo) =
     if  | not canGC     -> return st
         | not isCurrent -> do
-            removeFile file
-            return st { _currentMap = Index.delete file _currentMap
-                      , _currentRevMap = rv'
-                      , _currentSuccMap = succMap'
-                      }
+            removeFile $ filePath fileId
+            return st {
+                _currentMap = Index.delete fileId _currentMap
+              , _currentRevMap = currentRevMap'
+              , _currentSuccMap = succMap'
+              }
         | isCurrentNew  -> return st
-        | True          -> do
+        | otherwise     -> do
+            -- TODO: Rething if we want to reopen after
+            -- <https://github.com/input-output-hk/ouroboros-network/issues/767>
             st' <- reOpenFile hasFS (_dbErr env) env st
-            return st' { _currentRevMap = rv'
-                       , _currentSuccMap = succMap'
-                       }
-    where
-        canGC        = FileInfo.canGC fileInfo slot
-        isCurrent    = file == _currentWritePath
-        isCurrentNew = _currentWriteOffset == 0
-        bids         = FileInfo.blockIds fileInfo
-        rv'          = Map.withoutKeys _currentRevMap (Set.fromList bids)
-        deletedPairs =
-            mapMaybe (\b -> (b,) . ibPreBid <$> Map.lookup b _currentRevMap) bids
-        succMap'     = foldl deleteMapSet _currentSuccMap deletedPairs
-
-getInternalState :: forall m blockId. IOLike m
-                 => VolatileDBEnv m blockId
-                 -> m (SomePair (HasFS m) (InternalState blockId))
-getInternalState VolatileDBEnv{..} = do
-    mSt <- readMVar _dbInternalState
-    case mSt of
-        VolatileDbClosed  -> EH.throwError _dbErr $ UserError ClosedDBError
-        VolatileDbOpen st -> return $ SomePair _dbHasFS st
+            return st' {
+                _currentRevMap  = currentRevMap'
+              , _currentSuccMap = succMap'
+              }
+  where
+    canGC          = FileInfo.canGC fileInfo slot
+    isCurrent      = fileId == _currentWriteId
+    isCurrentNew   = _currentWriteOffset == 0
+    bids           = FileInfo.blockIds fileInfo
+    currentRevMap' = Map.withoutKeys _currentRevMap (Set.fromList bids)
+    deletedPairs   =
+        mapMaybe (\b -> (b,) . ibPreBid <$> Map.lookup b _currentRevMap) bids
+    succMap'       = foldl deleteMapSet _currentSuccMap deletedPairs
 
 getIsMemberImpl :: forall m blockId. (IOLike m, Ord blockId)
                 => VolatileDBEnv m blockId
                 -> STM m (blockId -> Bool)
-getIsMemberImpl env =
-    getterStm env $ \st bid -> Map.member bid (_currentRevMap st)
+getIsMemberImpl =
+    getterSTM $ \st bid -> Map.member bid (_currentRevMap st)
 
 getBlockIdsImpl :: forall m blockId. (IOLike m)
                 => VolatileDBEnv m blockId
                 -> m [blockId]
-getBlockIdsImpl env@VolatileDBEnv{..} =
-    getter env $ Map.keys . _currentRevMap
+getBlockIdsImpl =
+    getter $ Map.keys . _currentRevMap
 
 getSuccessorsImpl :: forall m blockId. (IOLike m, Ord blockId)
                   => VolatileDBEnv m blockId
                   -> STM m (WithOrigin blockId -> Set blockId)
-getSuccessorsImpl env =
-    getterStm env $ \st blockId ->
-        fromMaybe Set.empty (Map.lookup blockId (_currentSuccMap st))
+getSuccessorsImpl =
+    getterSTM $ \st blockId ->
+      fromMaybe Set.empty (Map.lookup blockId (_currentSuccMap st))
 
 getPredecessorImpl :: forall m blockId. (IOLike m, Ord blockId, HasCallStack)
                    => VolatileDBEnv m blockId
                    -> STM m (blockId -> WithOrigin blockId)
-getPredecessorImpl env =
-    getterStm env $ \st blockId ->
+getPredecessorImpl =
+    getterSTM $ \st blockId ->
         maybe (error msg) ibPreBid (Map.lookup blockId (_currentRevMap st))
   where
     msg = "precondition violated: block not member of the VolatileDB"
@@ -424,14 +422,14 @@ getPredecessorImpl env =
 getMaxSlotNoImpl :: forall m blockId. IOLike m
                  => VolatileDBEnv m blockId
                  -> STM m MaxSlotNo
-getMaxSlotNoImpl env =
-    getterStm env _currentMaxSlotNo
+getMaxSlotNoImpl =
+    getterSTM _currentMaxSlotNo
 
 {------------------------------------------------------------------------------
   Internal functions
 ------------------------------------------------------------------------------}
 
--- A new file is created.
+-- | Creates a new file and updates the 'InternalState' accordingly.
 -- This may throw an FsError.
 nextFile :: forall h m blockId. IOLike m
          => HasFS m h
@@ -439,19 +437,22 @@ nextFile :: forall h m blockId. IOLike m
          -> VolatileDBEnv m blockId
          -> InternalState blockId h
          -> m (InternalState blockId h)
-nextFile HasFS{..} _err VolatileDBEnv{..} st = do
-    hClose $ _currentWriteHandle st
+nextFile HasFS{..} _err VolatileDBEnv{..} st@InternalState{..} = do
+    hClose _currentWriteHandle
     hndl <- hOpen file (AppendMode MustBeNew)
-    return $ st {
-          _currentWriteHandle = hndl
-        , _currentWritePath   = file
-        , _currentWriteOffset = 0
-        , _nextNewFileId      = _nextNewFileId st + 1
-        , _currentMap = Index.insert file FileInfo.empty (_currentMap st)
-    }
-    where
-        file = filePath $ _nextNewFileId st
+    return st {
+        _currentWriteHandle = hndl
+      , _currentWritePath   = file
+      , _currentWriteId     = _nextNewFileId
+      , _currentWriteOffset = 0
+      , _currentMap         = Index.insert _nextNewFileId FileInfo.empty
+                                _currentMap
+      , _nextNewFileId      = _nextNewFileId + 1
+      }
+  where
+    file = filePath _nextNewFileId
 
+-- | Truncate a file to 0 and update its state accordingly.
 -- This may throw an FsError.
 reOpenFile :: forall m h blockId
            .  (MonadThrow m)
@@ -465,10 +466,11 @@ reOpenFile HasFS{..} _err VolatileDBEnv{..} st@InternalState{..} = do
     -- However the file is open on Append Only, so it should automatically go
     -- to the end before each write.
    hTruncate _currentWriteHandle 0
-   return $ st {
-         _currentMap = Index.insert _currentWritePath FileInfo.empty _currentMap
-       , _currentWriteOffset = 0
-    }
+   return st {
+        _currentMap = Index.insert
+            _currentWriteId FileInfo.empty _currentMap
+      , _currentWriteOffset = 0
+      }
 
 mkInternalStateDB :: (HasCallStack, MonadThrow m, MonadCatch m, Ord blockId)
                   => HasFS m h
@@ -479,131 +481,130 @@ mkInternalStateDB :: (HasCallStack, MonadThrow m, MonadCatch m, Ord blockId)
 mkInternalStateDB hasFS@HasFS{..} err parser maxBlocksPerFile =
   wrapFsError hasFsErr err $ do
     createDirectoryIfMissing True dir
-    allFiles <- Set.map toFsPath <$> listDirectory dir
-    mkInternalState hasFS err parser maxBlocksPerFile allFiles
+    allFiles <- map toFsPath . Set.toList <$> listDirectory dir
+    filesWithIds <- fromEither err $ parseAllFds allFiles
+    mkInternalState hasFS err parser maxBlocksPerFile filesWithIds
   where
     dir = mkFsPath []
 
     toFsPath :: String -> FsPath
     toFsPath file = mkFsPath [file]
 
--- | This function may create a new
-mkInternalState :: forall blockId m h e. (HasCallStack, MonadCatch m, Ord blockId)
-                => HasFS m h
-                -> ErrorHandling (VolatileDBError blockId) m
-                -> Parser e m blockId
-                -> Int
-                -> Set FsPath
-                -> m (InternalState blockId h)
+-- | Makes the 'InternalState' by parsing all files.
+--
+-- This function may create a new file to append new blocks or use an existing
+-- one.
+mkInternalState
+  :: forall blockId m h e. (HasCallStack, MonadCatch m, Ord blockId)
+  => HasFS m h
+  -> ErrorHandling (VolatileDBError blockId) m
+  -> Parser e m blockId
+  -> Int
+  -> [(FileId, FsPath)]
+  -> m (InternalState blockId h)
 mkInternalState hasFS err parser n files =
-  wrapFsError (hasFsErr hasFS) err $ do
-    lastFd <- findLastFdM err files
-    mkInternalState' hasFS err parser n files lastFd
+    wrapFsError (hasFsErr hasFS) err $
+      go Index.empty Map.empty Map.empty Nothing [] files
+  where
+    lastFile = safeMaximumOn fst files
+    newFileInfo mp newIndex =
+      ( filePath newIndex
+      , newIndex
+      , newIndex + 1
+      , Index.insert newIndex FileInfo.empty mp
+      , 0 )
 
-mkInternalState' :: forall blockId m h e. (HasCallStack, MonadCatch m, Ord blockId)
-                 => HasFS m h
-                 -> ErrorHandling (VolatileDBError blockId) m
-                 -> Parser e m blockId
-                 -> Int
-                 -> Set FsPath
-                 -> Maybe FileId
-                 -> m (InternalState blockId h)
-mkInternalState' hasFS err parser n files lastFd =
-    go Index.empty Map.empty Map.empty Nothing [] (Set.toList files)
-    where
-        newFileInfo mp newIndex =
-            ( newFile
-            , newIndex + (1 :: Int)
-            , Index.insert newFile FileInfo.empty mp
-            , 0 )
-            where
-                newFile = filePath newIndex
+    errorMsg = unwords
+        [ "VolatileDB invariant violation:"
+        , "The impossible happened!"
+        , "A file was found with less than "
+        , show n
+        , " blocks, but there are no files in db!"]
 
-        errorMsg = concat
-            [ "Volatile db invariant violation:"
-            , "A file was found with less than "
-            , show n
-            , " blocks, but there are no files parsed."]
+    truncateOnError Nothing _ _ = return ()
+    truncateOnError (Just _) file offset =
+        -- The handle of the parser is closed at this point. We need
+        -- to reOpen the file in 'AppendMode' now (parser opens with
+        -- 'ReadMode').
+        --
+        -- Note that no file is open at this point, so we can safely
+        -- open with 'AppendMode' any file, without the fear of opening
+        -- multiple concurrent writers, which is not allowed.
+        --
+        withFile hasFS file (AppendMode AllowExisting) $ \hndl ->
+            hTruncate hasFS hndl (fromIntegral offset)
 
-        truncateOnError Nothing _ _ = return ()
-        truncateOnError (Just _) file offset =
-            -- the handle of the parser is closed at this point. We need
-            -- to reOpen the file in AppendMode now (parser opens with
-            -- ReadMode).
-            --
-            -- Note that no file is open at this point, so we can safely
-            -- open with AppendMode any file, without the fear of opening
-            -- multiple concurrent writers, which is not allowed.
-            --
-            withFile hasFS file (AppendMode AllowExisting) $ \hndl ->
-                hTruncate hasFS hndl (fromIntegral offset)
-
-        go :: Index blockId
-           -> ReverseIndex blockId
-           -> SuccessorsIndex blockId
-           -> Maybe (blockId, SlotNo)
-           -> [(FileId, FsPath, FileSize)] -- Info of files with < n blocks.
-           -> [FsPath]
-           -> m (InternalState blockId h)
-        go mp revMp succMp maxSlot haveLessThanN (file : restFiles) = do
+    -- | For each file in the db, this function parses, updates the
+    -- internal state and calls itself for the rest of the files.
+    go :: Index blockId
+       -> ReverseIndex blockId
+       -> SuccessorsIndex blockId
+       -> Maybe (blockId, SlotNo)
+       -> [(FileId, FsPath, FileSize)] -- ^ Info of files with < n blocks.
+       -> [(FileId, FsPath)]
+       -> m (InternalState blockId h)
+    go currentMap currentRevMap succMp _maxSlot lessThanN [] = do
+        hndl <- hOpen hasFS fileToWrite (AppendMode AllowExisting)
+        return $ InternalState {
+            _currentWriteHandle = hndl
+          , _currentWritePath   = fileToWrite
+          , _currentWriteId     = fdToWrite
+          , _currentWriteOffset = offset'
+          , _nextNewFileId      = nextNewFileId'
+          , _currentMap         = currentMap'
+          , _currentRevMap      = currentRevMap
+          , _currentSuccMap     = succMp
+          , _currentMaxSlotNo   = FileInfo.maxSlotInFiles
+                                    (Index.elems currentMap')
+          }
+      where
+        (fileToWrite, fdToWrite, nextNewFileId', currentMap', offset') =
+          case (safeMaximumOn (\(fileId,_,_) -> fileId) lessThanN, lastFile) of
+            (Nothing, _) -> newFileInfo currentMap $ case lastFile of
+              Just (lastFd, _) -> lastFd + 1
+              Nothing          -> 0
+            (_, Nothing) -> error errorMsg
+            (Just (writeFd, wrFile, size), Just (lastFd, _)) | writeFd == lastFd->
+              -- If the file with biggest index is non-empty,
+              -- then this is the file we're looking for.
+              (wrFile, writeFd, lastFd + 1, currentMap, size)
+            (_, Just (lastFd,_)) ->
+              -- If it's not the last file, we just ignore it and
+              -- open a new one.
+              newFileInfo currentMap $ lastFd + 1
+    go currentMap currentRevMap succMap maxSlot lessThanN ((fd, file):rest) = do
             (blocks, mErr) <- parse parser file
-            updateAndGo mp revMp succMp maxSlot haveLessThanN file restFiles blocks mErr
-        go mp revMp succMp _maxSlot haveLessThanN [] = do
-            hndl <- hOpen hasFS fileToWrite (AppendMode AllowExisting)
-            return $ InternalState {
-                  _currentWriteHandle = hndl
-                , _currentWritePath   = fileToWrite
-                , _currentWriteOffset = offset'
-                , _nextNewFileId      = nextNewFileId'
-                , _currentMap         = mp'
-                , _currentRevMap      = revMp
-                , _currentSuccMap     = succMp
-                , _currentMaxSlotNo   = FileInfo.maxSlotInFiles (Index.elems mp')
-            }
-            where
-                (fileToWrite, nextNewFileId', mp', offset') =
-                    case (safeMaximumOn (\(a,_,_) -> a) haveLessThanN, lastFd) of
-                        (Nothing, _) -> newFileInfo mp $ case lastFd of
-                            Just lst -> lst + 1
-                            Nothing -> 0
-                        (_, Nothing) -> error errorMsg
-                        (Just (fd, wrfile, size), Just lst) | fd == lst->
-                            -- if the file with biggest index is non-empty,
-                            -- then this is the file we're looking for.
-                            (wrfile, lst + 1, mp, size)
-                        (_, Just lst) ->
-                            -- If it's not the last file, we just ignore it and
-                            -- open a new one.
-                            newFileInfo mp $ lst + 1
-
-        updateAndGo mp revMp succMp maxSlot haveLessThanN file restFiles blocks mErr = do
+            updateAndGo blocks mErr
+      where
+        -- | Updates the state and call 'go' for the rest of the files.
+        updateAndGo :: [(SlotOffset, (BlockSize, BlockInfo blockId))]
+                    -> Maybe e
+                    -> m (InternalState blockId h)
+        updateAndGo blocks mErr = do
             truncateOnError mErr file offset
-            newRevMp <- fromEither err $ reverseMap file revMp fileMp
-            go newMp newRevMp newSuccMp newMaxSlot newHaveLessThanN restFiles
-            where
-                offset = case reverse blocks of
-                    [] -> 0
-                    (slotOffset, (blockSize,_)) : _ ->
-                        -- The file offset is given by the offset of the last
-                        -- block plus its size.
-                        slotOffset + blockSize
-                fileMp = Map.fromList blocks
-                (fileInfo, maxSlotOfFile) = FileInfo.fromParsedInfo blocks
-                newMp = Index.insert file fileInfo mp
-                newMaxSlot = maxSlotList $ catMaybes [maxSlot, maxSlotOfFile]
-                -- For each block we need to update the succesor Map of its
-                -- predecesor.
-                newSuccMp = foldr
-                    (\(_,(_, blockInfo)) succMp' ->
-                        insertMapSet succMp' (bbid blockInfo, bpreBid blockInfo))
-                        succMp
-                        blocks
-                -- unsafe here is reasonable because we have already checked
-                -- that all filenames parse.
-                fd = unsafeParseFd file
-                newHaveLessThanN = if FileInfo.isFull n fileInfo
-                    then haveLessThanN
-                    else (fd, file, offset) : haveLessThanN
+            newRevMp <- fromEither err $ reverseMap file currentRevMap fileMp
+            go newMp newRevMp newSuccMp newMaxSlot newHaveLessThanN rest
+          where
+            offset = case reverse blocks of
+              [] -> 0
+              (slotOffset, (blockSize,_)) : _ ->
+                -- The file offset is given by the offset of the last
+                -- block plus its size.
+                slotOffset + blockSize
+            fileMp = Map.fromList blocks
+            (fileInfo, maxSlotOfFile) = FileInfo.fromParsedInfo blocks
+            newMp = Index.insert fd fileInfo currentMap
+            newMaxSlot = maxSlotList $ catMaybes [maxSlot, maxSlotOfFile]
+            -- For each block we need to update the succesor Map of its
+            -- predecesor.
+            newSuccMp = foldr
+              (\(_,(_, blockInfo)) succMap' ->
+                  insertMapSet succMap' (bbid blockInfo, bpreBid blockInfo))
+                  succMap
+                  blocks
+            newHaveLessThanN = if FileInfo.isFull n fileInfo
+              then lessThanN
+              else (fd, file, offset) : lessThanN
 
 -- | NOTE: This is safe in terms of throwing FsErrors.
 modifyState :: forall blockId m r. (HasCallStack, IOLike m)
@@ -626,20 +627,21 @@ modifyState VolatileDBEnv{_dbHasFS = hasFS :: HasFS m h, ..} action = do
     open :: m (OpenOrClosed blockId h)
     open = takeMVar _dbInternalState
 
-    close :: OpenOrClosed blockId h
-          -> ExitCase (Either (VolatileDBError blockId) (InternalState blockId h, r))
-          -> m ()
+    close
+      :: OpenOrClosed blockId h
+      -> ExitCase (Either (VolatileDBError blockId) (InternalState blockId h, r))
+      -> m ()
     close mst ec = case ec of
-      -- Restore the original state in case of an abort
+      -- Restore the original state in case of an abort.
       ExitCaseAbort         -> putMVar _dbInternalState mst
       -- In case of an exception, close the DB for safety.
       ExitCaseException _ex -> do
         putMVar _dbInternalState VolatileDbClosed
         closeOpenHandle mst
-      -- In case of success, update to the newest state
+      -- In case of success, update to the newest state.
       ExitCaseSuccess (Right (newState, _)) ->
         putMVar _dbInternalState (VolatileDbOpen newState)
-      -- In case of an error (not an exception), close the DB for safety
+      -- In case of an error (not an exception), close the DB for safety.
       ExitCaseSuccess (Left _) -> do
         putMVar _dbInternalState VolatileDbClosed
         closeOpenHandle mst
@@ -653,50 +655,45 @@ modifyState VolatileDBEnv{_dbHasFS = hasFS :: HasFS m h, ..} action = do
     closeOpenHandle :: OpenOrClosed blockId h -> m ()
     closeOpenHandle VolatileDbClosed                    = return ()
     closeOpenHandle (VolatileDbOpen InternalState {..}) =
-        wrapFsError hasFsErr _dbErr $ hClose _currentWriteHandle
+      wrapFsError hasFsErr _dbErr $ hClose _currentWriteHandle
 
+-- | Gets part of the 'InternalState', without modifying it.
 getter :: IOLike m
-       => VolatileDBEnv m blockId
-       -> (forall h. InternalState blockId h -> a)
+       => (forall h. InternalState blockId h -> a)
+       -> VolatileDBEnv m blockId
        -> m a
-getter VolatileDBEnv{..} fromSt = do
+getter fromSt VolatileDBEnv{..} = do
     mSt <- readMVar _dbInternalState
     case mSt of
-        VolatileDbClosed  -> EH.throwError _dbErr $ UserError ClosedDBError
-        VolatileDbOpen st -> return $ fromSt st
+      VolatileDbClosed  -> EH.throwError _dbErr $ UserError ClosedDBError
+      VolatileDbOpen st -> return $ fromSt st
 
-getterStm :: forall m blockId a. IOLike m
-          => VolatileDBEnv m blockId
-          -> (forall h. InternalState blockId h -> a)
+-- | Gets part of the 'InternalState' in 'STM'.
+getterSTM :: forall m blockId a. IOLike m
+          => (forall h. InternalState blockId h -> a)
+          -> VolatileDBEnv m blockId
           -> STM m a
-getterStm VolatileDBEnv{..} fromSt = do
+getterSTM fromSt VolatileDBEnv{..} = do
     mSt <- readMVarSTM _dbInternalState
     case mSt of
-        VolatileDbClosed  -> EH.throwError' _dbErrSTM $ UserError ClosedDBError
-        VolatileDbOpen st -> return $ fromSt st
+      VolatileDbClosed  -> EH.throwError' _dbErrSTM $ UserError ClosedDBError
+      VolatileDbOpen st -> return $ fromSt st
 
-reverseMap :: forall blockId
-           .  Ord blockId
+-- | For each block found in a parsed file, we insert its 'InternalBlockInfo'.
+-- If the block is already found in the 'ReverseIndex' or is dublicated in the
+-- same file, we abort and return an error.
+reverseMap :: forall blockId. Ord blockId
            => FsPath
            -> ReverseIndex blockId
            -> Map SlotOffset (BlockSize, BlockInfo blockId)
            -> Either (VolatileDBError blockId) (ReverseIndex blockId)
-reverseMap file revMp mp = foldM go revMp (Map.toList mp)
-    where
-        go :: ReverseIndex blockId
-           -> (SlotOffset, (BlockSize, BlockInfo blockId))
-           -> Either (VolatileDBError blockId) (ReverseIndex blockId)
-        go rv (offset, (size, BlockInfo {..})) = case Map.lookup bbid rv of
-            Nothing -> Right $ Map.insert
-                bbid (InternalBlockInfo file offset size bslot bpreBid) rv
-            Just blockInfo -> Left $ UnexpectedError . ParserError
-                $ DuplicatedSlot bbid file (ibFile blockInfo)
-
--- | Throws an error if one of the given file names does not parse.
-findLastFdM :: forall m blockId. Monad m
-            => ErrorHandling (VolatileDBError blockId) m
-            -> Set FsPath
-            -> m (Maybe FileId)
-findLastFdM err files = case findLastFd files of
-    Left e  -> EH.throwError err e
-    Right r -> return r
+reverseMap file revMap mp = foldM go revMap (Map.toList mp)
+  where
+    go :: ReverseIndex blockId
+       -> (SlotOffset, (BlockSize, BlockInfo blockId))
+       -> Either (VolatileDBError blockId) (ReverseIndex blockId)
+    go rv (offset, (size, BlockInfo {..})) = case Map.lookup bbid rv of
+      Nothing -> Right $ Map.insert
+        bbid (InternalBlockInfo file offset size bslot bpreBid) rv
+      Just blockInfo -> Left $ UnexpectedError . ParserError
+        $ DuplicatedSlot bbid file (ibFile blockInfo)

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Index.hs
@@ -1,12 +1,52 @@
+{-# LANGUAGE DeriveAnyClass            #-}
+{-# LANGUAGE DeriveGeneric             #-}
+
 module Ouroboros.Storage.VolatileDB.Index (
-    Index -- TODO: Make opaque newtype
+    Index -- opaque
+
+  -- public api. To be used as qualified.
+  , empty
+  , lookup
+  , insert
+  , delete
+  , toList
+  , elems
   ) where
 
-import           Data.Map.Strict (Map)
+import           Prelude hiding (lookup)
 
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           GHC.Generics (Generic)
+
+import           Cardano.Prelude (NoUnexpectedThunks(..))
 import           Ouroboros.Storage.FS.API.Types (FsPath)
-import           Ouroboros.Storage.VolatileDB.FileInfo
+import           Ouroboros.Storage.VolatileDB.FileInfo (FileInfo)
 
 -- For each file, we store the latest blockId, the number of blocks
 -- and a Map for its contents.
-type Index blockId = Map FsPath (FileInfo blockId)
+newtype Index blockId = Index {unIndex :: Map FsPath (FileInfo blockId)}
+  deriving (Generic, NoUnexpectedThunks)
+
+modifyIndex :: (Map FsPath (FileInfo blockId) -> Map FsPath (FileInfo blockId))
+            -> Index blockId
+            -> Index blockId
+modifyIndex mdf (Index mp) = Index (mdf mp)
+
+empty :: Index blockId
+empty = Index Map.empty
+
+lookup :: FsPath -> Index blockId -> Maybe (FileInfo blockId)
+lookup path (Index mp) = Map.lookup path mp
+
+insert :: FsPath -> FileInfo blockId -> Index blockId -> Index blockId
+insert path info = modifyIndex (Map.insert path info)
+
+delete :: FsPath -> Index blockId -> Index blockId
+delete path = modifyIndex (Map.delete path)
+
+toList :: Index blockId -> [(FsPath, FileInfo blockId)]
+toList (Index mp) = Map.toList mp
+
+elems :: Index blockId -> [FileInfo blockId]
+elems index = snd <$> toList index

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Index.hs
@@ -1,10 +1,12 @@
-{-# LANGUAGE DeriveAnyClass            #-}
-{-# LANGUAGE DeriveGeneric             #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
 
+-- | VolatileDB Index
+--
+-- Intended for qualified import
+-- > import qualified Ouroboros.Storage.VolatileDB.Index as Index
 module Ouroboros.Storage.VolatileDB.Index (
     Index -- opaque
-
-  -- public api. To be used as qualified.
   , empty
   , lookup
   , insert
@@ -15,38 +17,38 @@ module Ouroboros.Storage.VolatileDB.Index (
 
 import           Prelude hiding (lookup)
 
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import           Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IM
 import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks(..))
-import           Ouroboros.Storage.FS.API.Types (FsPath)
+import           Ouroboros.Storage.VolatileDB.Types (FileId)
 import           Ouroboros.Storage.VolatileDB.FileInfo (FileInfo)
 
 -- For each file, we store the latest blockId, the number of blocks
 -- and a Map for its contents.
-newtype Index blockId = Index {unIndex :: Map FsPath (FileInfo blockId)}
+newtype Index blockId = Index {unIndex :: IntMap (FileInfo blockId)}
   deriving (Generic, NoUnexpectedThunks)
 
-modifyIndex :: (Map FsPath (FileInfo blockId) -> Map FsPath (FileInfo blockId))
+modifyIndex :: (IntMap (FileInfo blockId) -> IntMap (FileInfo blockId))
             -> Index blockId
             -> Index blockId
 modifyIndex mdf (Index mp) = Index (mdf mp)
 
 empty :: Index blockId
-empty = Index Map.empty
+empty = Index IM.empty
 
-lookup :: FsPath -> Index blockId -> Maybe (FileInfo blockId)
-lookup path (Index mp) = Map.lookup path mp
+lookup :: FileId -> Index blockId -> Maybe (FileInfo blockId)
+lookup path (Index mp) = IM.lookup path mp
 
-insert :: FsPath -> FileInfo blockId -> Index blockId -> Index blockId
-insert path info = modifyIndex (Map.insert path info)
+insert :: FileId -> FileInfo blockId -> Index blockId -> Index blockId
+insert path info = modifyIndex (IM.insert path info)
 
-delete :: FsPath -> Index blockId -> Index blockId
-delete path = modifyIndex (Map.delete path)
+delete :: FileId -> Index blockId -> Index blockId
+delete path = modifyIndex (IM.delete path)
 
-toList :: Index blockId -> [(FsPath, FileInfo blockId)]
-toList (Index mp) = Map.toList mp
+toList :: Index blockId -> [(FileId, FileInfo blockId)]
+toList (Index mp) = IM.toList mp
 
 elems :: Index blockId -> [FileInfo blockId]
-elems index = snd <$> toList index
+elems (Index mp) = IM.elems mp

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Index.hs
@@ -27,28 +27,28 @@ import           Ouroboros.Storage.VolatileDB.FileInfo (FileInfo)
 
 -- For each file, we store the latest blockId, the number of blocks
 -- and a Map for its contents.
-newtype Index blockId = Index {unIndex :: IntMap (FileInfo blockId)}
+newtype Index blockId h = Index {unIndex :: IntMap (FileInfo blockId h)}
   deriving (Generic, NoUnexpectedThunks)
 
-modifyIndex :: (IntMap (FileInfo blockId) -> IntMap (FileInfo blockId))
-            -> Index blockId
-            -> Index blockId
+modifyIndex :: (IntMap (FileInfo blockId h) -> IntMap (FileInfo blockId h))
+            -> Index blockId h
+            -> Index blockId h
 modifyIndex mdf (Index mp) = Index (mdf mp)
 
-empty :: Index blockId
+empty :: Index blockId h
 empty = Index IM.empty
 
-lookup :: FileId -> Index blockId -> Maybe (FileInfo blockId)
+lookup :: FileId -> Index blockId h -> Maybe (FileInfo blockId h)
 lookup path (Index mp) = IM.lookup path mp
 
-insert :: FileId -> FileInfo blockId -> Index blockId -> Index blockId
+insert :: FileId -> FileInfo blockId h -> Index blockId h -> Index blockId h
 insert path info = modifyIndex (IM.insert path info)
 
-delete :: FileId -> Index blockId -> Index blockId
+delete :: FileId -> Index blockId h -> Index blockId h
 delete path = modifyIndex (IM.delete path)
 
-toList :: Index blockId -> [(FileId, FileInfo blockId)]
+toList :: Index blockId h -> [(FileId, FileInfo blockId h)]
 toList (Index mp) = IM.toList mp
 
-elems :: Index blockId -> [FileInfo blockId]
+elems :: Index blockId h -> [FileInfo blockId h]
 elems (Index mp) = IM.elems mp

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
@@ -71,14 +71,20 @@ data ParserError blockId =
 instance Eq blockId => Eq (ParserError blockId) where
     (==) = sameParseError
 
-sameVolatileDBError :: Eq blockId => VolatileDBError blockId -> VolatileDBError blockId -> Bool
+sameVolatileDBError :: Eq blockId
+                    => VolatileDBError blockId
+                    -> VolatileDBError blockId
+                    -> Bool
 sameVolatileDBError e1 e2 = case (e1, e2) of
     (UserError ue1, UserError ue2)             -> ue1 == ue2
     (UnexpectedError ue1, UnexpectedError ue2) -> sameUnexpectedError ue1 ue2
     _                                          -> False
 
 -- TODO: Why is this not comparing the arguments to 'DuplicatedSlot'?
-sameUnexpectedError :: Eq blockId => UnexpectedError blockId -> UnexpectedError blockId -> Bool
+sameUnexpectedError :: Eq blockId
+                    => UnexpectedError blockId
+                    -> UnexpectedError blockId
+                    -> Bool
 sameUnexpectedError e1 e2 = case (e1, e2) of
     (FileSystemError fs1, FileSystemError fs2) -> sameFsError fs1 fs2
     (ParserError p1, ParserError p2)           -> p1 == p2

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
@@ -1,10 +1,7 @@
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Ouroboros.Storage.VolatileDB.Types
     (
@@ -22,8 +19,8 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Point (WithOrigin)
 import           Ouroboros.Network.Block hiding (Tip, decodeTip, encodeTip)
+import           Ouroboros.Network.Point (WithOrigin)
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API.Types
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
@@ -52,6 +52,7 @@ data UserError =
 data UnexpectedError blockId =
       FileSystemError FsError
     | ParserError (ParserError blockId)
+    | FileNotFound FsPath
     deriving (Show)
 
 instance Eq blockId => Eq (VolatileDBError blockId) where
@@ -116,7 +117,8 @@ data BlockInfo blockId = BlockInfo {
 
 -- The Internal information the db keeps for each block.
 data InternalBlockInfo blockId = InternalBlockInfo {
-      ibFile       :: !FsPath
+      ibFileId     :: !FileId
+    , ibFile       :: !FsPath
     , ibSlotOffset :: !SlotOffset
     , ibBlockSize  :: !BlockSize
     , ibSlot       :: !SlotNo

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -44,7 +44,7 @@ parseFd = parseFilename <=< lastMaybe . fsPathToList
 
 unsafeParseFd :: FsPath -> FileId
 unsafeParseFd file = fromMaybe
-    (error $ "could not parse filename " <> show file <> " of index")
+    (error $ "could not parse filename " <> show file)
     (parseFd file)
 
 fromEither :: Monad m
@@ -78,7 +78,7 @@ wrapFsError fsErr volDBErr action =
 findLastFd :: forall blockId.
               Set FsPath
            -> Either (VolatileDBError blockId) (Maybe FileId)
-findLastFd files = foldM go Nothing files
+findLastFd= foldM go Nothing
     where
         maxMaybe :: Ord a => Maybe a -> a -> a
         maxMaybe ma a = case ma of

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -57,15 +57,24 @@ import           Test.Ouroboros.Storage.VolatileDB.TestBlock (Corruptions,
                      FileCorruption (..), binarySize)
 
 data DBModel blockId = DBModel {
-      blocksPerFile  :: Int  -- how many blocks each file has (should follow the real Impl)
-    , parseError     :: Maybe (ParserError blockId) -- an error which indicates the parser will return an error.
-    , open           :: Bool -- is the db open.
-    , mp             :: Map blockId ByteString -- superset of blocks in db. Some of them may be gced already.
-    , latestGarbaged :: Maybe SlotNo -- last gced slot.
-    , index          :: Map FsPath (MaxSlotNo, Int, [(blockId, WithOrigin blockId)]) -- what each file contains in the real impl.
-    , currentFile    :: FsPath -- the current open file. If the db is empty this is the next it wil write.
-    , nextFId        :: FileId -- the next file id.
-    , maxSlotNo      :: MaxSlotNo -- highest ever stored SlotNo
+      blocksPerFile  :: Int
+    -- ^ how many blocks each file has (should follow the real Impl)
+    , parseError     :: Maybe (ParserError blockId)
+    -- ^ an error which indicates the parser will return an error.
+    , open           :: Bool
+    -- ^ is the db open.
+    , mp             :: Map blockId ByteString
+    -- ^ superset of blocks in db. Some of them may be gced already.
+    , latestGarbaged :: Maybe SlotNo
+    -- ^ last gced slot.
+    , index          :: Map FsPath (MaxSlotNo, Int, [(blockId, WithOrigin blockId)])
+    -- ^ what each file contains in the real impl.
+    , currentFile    :: FsPath
+    -- ^ the current open file. If the db is empty this is the next it wil write.
+    , nextFId        :: FileId
+    -- ^ the next file id.
+    , maxSlotNo      :: MaxSlotNo
+    -- ^ highest ever stored SlotNo
     } deriving Show
 
 initDBModel ::Int -> DBModel blockId

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -49,7 +49,7 @@ import           Ouroboros.Storage.Util.ErrorHandling (ThrowCantCatch)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import           Ouroboros.Storage.VolatileDB.API
 import qualified Ouroboros.Storage.VolatileDB.Impl as Internal
-import           Ouroboros.Storage.VolatileDB.Util
+import           Ouroboros.Storage.VolatileDB.Util hiding (maxMaybe)
 
 import           Test.Util.FS.Sim.Error
 
@@ -70,7 +70,8 @@ data DBModel blockId = DBModel {
     , index          :: Map FsPath (MaxSlotNo, Int, [(blockId, WithOrigin blockId)])
       -- ^ What each file contains in the Impl.
     , currentFile    :: FsPath
-      -- ^ The current open file. If the db is closed, this is the next it should write to.
+      -- ^ The current open file. If the db is closed, this is the next file it
+      -- should write to.
     , nextFId        :: FileId
       -- ^ The next file id.
     , maxSlotNo      :: MaxSlotNo

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -58,23 +58,23 @@ import           Test.Ouroboros.Storage.VolatileDB.TestBlock (Corruptions,
 
 data DBModel blockId = DBModel {
       blocksPerFile  :: Int
-    -- ^ how many blocks each file has (should follow the real Impl)
+      -- ^ How many blocks each file has (should follow the real Impl).
     , parseError     :: Maybe (ParserError blockId)
-    -- ^ an error which indicates the parser will return an error.
+      -- ^ An error indicates a broken db and that parsing will fail.
     , open           :: Bool
-    -- ^ is the db open.
+      -- ^ Indicates if the db is open.
     , mp             :: Map blockId ByteString
-    -- ^ superset of blocks in db. Some of them may be gced already.
+      -- ^ Superset of blocks in db. Some of them may be gced already.
     , latestGarbaged :: Maybe SlotNo
-    -- ^ last gced slot.
+      -- ^ Last gced slot.
     , index          :: Map FsPath (MaxSlotNo, Int, [(blockId, WithOrigin blockId)])
-    -- ^ what each file contains in the real impl.
+      -- ^ What each file contains in the Impl.
     , currentFile    :: FsPath
-    -- ^ the current open file. If the db is empty this is the next it wil write.
+      -- ^ The current open file. If the db is closed, this is the next it should write to.
     , nextFId        :: FileId
-    -- ^ the next file id.
+      -- ^ The next file id.
     , maxSlotNo      :: MaxSlotNo
-    -- ^ highest ever stored SlotNo
+      -- ^ Highest ever stored SlotNo.
     } deriving Show
 
 initDBModel ::Int -> DBModel blockId

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -513,7 +513,7 @@ semanticsRestCmd hasFS env db cmd = case cmd of
         return $ Unit ()
     DuplicateBlock _file  bid preBid -> do
         let specialEnc = toBinary (bid, preBid)
-        SomePair stHasFS st <- Internal.getInternalState env
+        SomePair stHasFS st <- getInternalState env
         let hndl = Internal._currentWriteHandle st
         _ <- hPut stHasFS hndl (BL.lazyByteString specialEnc)
         closeDB db

--- a/ouroboros-consensus/test-util/Test/Util/FS/Sim/Error.hs
+++ b/ouroboros-consensus/test-util/Test/Util/FS/Sim/Error.hs
@@ -45,6 +45,7 @@ import           Control.Monad (replicateM, void)
 import qualified Data.ByteString as BS
 import           Data.List (dropWhileEnd, intercalate)
 import           Data.Maybe (catMaybes, isNothing)
+import           Data.Int
 import           Data.Word (Word64)
 
 import           GHC.Stack (HasCallStack, callStack)
@@ -232,6 +233,7 @@ data Errors = Errors
   , _hClose                   :: ErrorStream
   , _hSeek                    :: ErrorStream
   , _hGetSome                 :: ErrorStreamGetSome
+  , _hGetSomeAt               :: ErrorStreamGetSome
   , _hPutSome                 :: ErrorStreamPutSome
   , _hTruncate                :: ErrorStream
   , _hGetSize                 :: ErrorStream
@@ -252,6 +254,7 @@ allNull Errors {..} = null _dumpState
                    && null _hClose
                    && null _hSeek
                    && null _hGetSome
+                   && null _hGetSomeAt
                    && null _hPutSome
                    && null _hTruncate
                    && null _hGetSize
@@ -281,6 +284,7 @@ instance Show Errors where
         , s "_hClose"                   _hClose
         , s "_hSeek"                    _hSeek
         , s "_hGetSome"                 _hGetSome
+        , s "_hGetSomeAt"               _hGetSomeAt
         , s "_hPutSome"                 _hPutSome
         , s "_hTruncate"                _hTruncate
         , s "_hGetSize"                 _hGetSize
@@ -299,6 +303,7 @@ instance Semigroup Errors where
       , _hClose                   = combine _hClose
       , _hSeek                    = combine _hSeek
       , _hGetSome                 = combine _hGetSome
+      , _hGetSomeAt               = combine _hGetSomeAt
       , _hPutSome                 = combine _hPutSome
       , _hTruncate                = combine _hTruncate
       , _hGetSize                 = combine _hGetSize
@@ -326,6 +331,7 @@ simpleErrors es = Errors
     , _hClose                   = es
     , _hSeek                    = es
     , _hGetSome                 =  Left                <$> es
+    , _hGetSomeAt               =  Left                <$> es
     , _hPutSome                 = (Left . (, Nothing)) <$> es
     , _hTruncate                = es
     , _hGetSize                 = es
@@ -363,6 +369,9 @@ genErrors genPartialWrites genSubstituteWithJunk = do
     _hGetSome   <- mkStreamGen 20 $ QC.frequency
       [ (1, return $ Left FsReachedEOF)
       , (3, Right <$> arbitrary) ]
+    _hGetSomeAt <- mkStreamGen 20 $ QC.frequency
+      [ (1, return $ Left FsReachedEOF)
+      , (3, Right <$> arbitrary) ]
     _hPutSome   <- mkStreamGen 5 $ QC.frequency
       [ (1, Left . (FsDeviceFull, ) <$> QC.frequency
             [ (2, return Nothing)
@@ -395,6 +404,7 @@ instance Arbitrary Errors where
       , (\s' -> err { _hClose = s' })                   <$> dropLast _hClose
       , (\s' -> err { _hSeek = s' })                    <$> dropLast _hSeek
       , (\s' -> err { _hGetSome = s' })                 <$> dropLast _hGetSome
+      , (\s' -> err { _hGetSomeAt = s' })               <$> dropLast _hGetSomeAt
       , (\s' -> err { _hPutSome = s' })                 <$> dropLast _hPutSome
       , (\s' -> err { _hTruncate = s' })                <$> dropLast _hTruncate
       , (\s' -> err { _hGetSize = s' })                 <$> dropLast _hGetSize
@@ -438,6 +448,7 @@ mkSimErrorHasFS err fsVar errorsVar =
             withErr' err errorsVar h (hSeek h m n) "hSeek"
             _hSeek (\e es -> es { _hSeek = e })
         , hGetSome   = hGetSome' err errorsVar hGetSome
+        , hGetSomeAt = hGetSomeAt' err errorsVar hGetSomeAt
         , hPutSome   = hPutSome' err errorsVar hPutSome
         , hTruncate  = \h w ->
             withErr' err errorsVar h (hTruncate h w) "hTruncate"
@@ -574,6 +585,26 @@ hGetSome' ErrorHandling{..} errorsVar hGetSomeWrapped handle n = do
         }
       Just (Right partial) ->
         hGetSomeWrapped handle (hGetSomePartial partial n)
+
+-- | In the thread safe version of hGetSome, we simulate exactly the same errors.
+hGetSomeAt' :: (MonadSTM m, HasCallStack)
+            => ErrorHandling FsError m
+            -> StrictTVar m Errors
+            -> (Handle HandleMock -> Word64 -> Int64 -> m BS.ByteString)  -- ^ Wrapped 'hGetSome'
+            -> Handle HandleMock -> Word64 -> Int64 -> m BS.ByteString
+hGetSomeAt' ErrorHandling{..} errorsVar hGetSomeAtWrapped handle n offset = do
+    next errorsVar _hGetSomeAt (\e es -> es { _hGetSomeAt = e }) >>= \case
+      Nothing             -> hGetSomeAtWrapped handle n offset
+      Just (Left errType) -> throwError FsError
+        { fsErrorType   = errType
+        , fsErrorPath   = handlePath handle
+        , fsErrorString = "simulated error: hGetSomeAt"
+        , fsErrorNo     = Nothing
+        , fsErrorStack  = callStack
+        , fsLimitation  = False
+        }
+      Just (Right partial) ->
+        hGetSomeAtWrapped handle (hGetSomePartial partial n) offset
 
 -- | Execute the wrapped 'hPutSome', throw an error and apply possible
 -- corruption to the blob to write, or simulate a partial write, depending on

--- a/ouroboros-consensus/test-util/Test/Util/FS/Sim/Pure.hs
+++ b/ouroboros-consensus/test-util/Test/Util/FS/Sim/Pure.hs
@@ -43,6 +43,7 @@ pureHasFS err = HasFS {
     , hClose                   = Mock.hClose                   err'
     , hSeek                    = Mock.hSeek                    err'
     , hGetSome                 = Mock.hGetSome                 err'
+    , hGetSomeAt               = Mock.hGetSomeAt               err'
     , hPutSome                 = Mock.hPutSome                 err'
     , hTruncate                = Mock.hTruncate                err'
     , hGetSize                 = Mock.hGetSize                 err'

--- a/ouroboros-consensus/test-util/Test/Util/FS/Sim/STM.hs
+++ b/ouroboros-consensus/test-util/Test/Util/FS/Sim/STM.hs
@@ -51,6 +51,7 @@ simHasFS err var = HasFS {
     , hClose                   = sim  .  Mock.hClose                   err'
     , hSeek                    = sim ..: Mock.hSeek                    err'
     , hGetSome                 = sim  .: Mock.hGetSome                 err'
+    , hGetSomeAt               = sim ..: Mock.hGetSomeAt               err'
     , hPutSome                 = sim  .: Mock.hPutSome                 err'
     , hTruncate                = sim  .: Mock.hTruncate                err'
     , hGetSize                 = sim  .  Mock.hGetSize                 err'


### PR DESCRIPTION
This pr addresses a number of issues:
- Keeps open a ReadMode handle for each file in the VolatileDB, so that reading threads don't reopen their own. https://github.com/input-output-hk/ouroboros-network/issues/767
- Use pread syscall to fix the race condition on the file offset. pread is also implemented in Windows (in a hacky way) and related q-s-m tests are added. https://github.com/input-output-hk/ouroboros-network/issues/1140
- read/write locks are used. This allows to maximize read parallelism and take full advantage of the above feautures.
- A Windows related bug is fixed, which failed on ci https://github.com/input-output-hk/ouroboros-network/issues/882

For the read/write locks, I didn't use `readMVarSTM` as discussed, but `RWVar` from concurrent-extras. What I actually want is not write lock, but exclusive locks (when there is a writer, no reader should be allown). If I understand correctly, `StrictMVar` is not designed for this case.

I think ChainDB has some parallel tests, but this pr needs more testing, since VolatileDB lacks parallel q-s-m tests.

Finally this is built on top of https://github.com/input-output-hk/ouroboros-network/pull/1137 and will need rebasing when it is merged.
