### PR TITLE
Remove unused checktvarinvariant flag

### DIFF
--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -1,6 +1,6 @@
 { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = { checktvarinvariant = false; };
+    flags = {};
     package = {
       specVersion = "1.10";
       identifier = { name = "ouroboros-consensus"; version = "0.1.0.0"; };

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -17,11 +17,6 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/ouroboros-network
 
-flag checktvarinvariant
-  Description: Enable runtime checks on application state
-  Manual: True
-  Default: False
-
 library
   hs-source-dirs:      src
 


### PR DESCRIPTION
This flag is no longer used in `ouroboros-consensus.cabal`. Note that it is
still being used in `io-sim-classes.cabal`.