### PR TITLE
fix Windows bug

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -78,7 +78,6 @@ in commonLib.nix-tools.release-nix {
     "nix-tools.tests.ouroboros-network.test-network.x86_64-darwin"
     # 'Storage.HasFS.HasFS' test failing:
     "nix-tools.tests.ouroboros-consensus.test-storage.x86_64-darwin"
-    "nix-tools.tests.x86_64-pc-mingw32-ouroboros-consensus.test-storage.x86_64-linux"
   ];
   # The required jobs that must pass for ci not to fail:
   required-name = "ouroboros-network-required-checks";


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/ouroboros-network/issues/882

This unit test I wrote locally failed consistently before the fix:
```
test_Failure :: Assertion
test_Failure = apiEquivalenceFs (expectFsResult (@?= 1)) $ \hasFS@HasFS{..} _err -> do
  h1  <- hOpen (mkFsPath ["test_failure.txt"]) (WriteMode MustBeNew)
  hPut hasFS h1 "\NUL"
  hClose h1
  h2  <- hOpen (mkFsPath ["test_failure.txt"]) (ReadWriteMode AllowExisting)
  bytes <- hGetSome h2 1
  return $ BS.length bytes
```
