### PR TITLE
Add tracing for the ledger DB size

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -108,13 +108,13 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 001ec3576ef3bda04cf5bcccdd9a00991835d1a7
+  tag: ad19158c7599bc5d50fe7cb0111a1488a139a381
   subdir: .
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 001ec3576ef3bda04cf5bcccdd9a00991835d1a7
+  tag: ad19158c7599bc5d50fe7cb0111a1488a139a381
   subdir: test
 
 source-repository-package

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "001ec3576ef3bda04cf5bcccdd9a00991835d1a7";
-      sha256 = "0v746pi0s1ib1bvvvlfkrw7n4p2qxqfrrlx4fg4dpk6fjp0raass";
+      rev = "ad19158c7599bc5d50fe7cb0111a1488a139a381";
+      sha256 = "172il8sw6ip84mfw1gvrrqm10vb3hccphj4v4jqyqdjxshmj1r8g";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -71,7 +71,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "001ec3576ef3bda04cf5bcccdd9a00991835d1a7";
-      sha256 = "0v746pi0s1ib1bvvvlfkrw7n4p2qxqfrrlx4fg4dpk6fjp0raass";
+      rev = "ad19158c7599bc5d50fe7cb0111a1488a139a381";
+      sha256 = "172il8sw6ip84mfw1gvrrqm10vb3hccphj4v4jqyqdjxshmj1r8g";
       });
     }

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -102,6 +102,7 @@ library
                        Ouroboros.Consensus.Util.Singletons
                        Ouroboros.Consensus.Util.SlotBounded
                        Ouroboros.Consensus.Util.STM
+                       Ouroboros.Consensus.Util.TraceSize
 
                        -- Storing things on disk
                        Ouroboros.Storage.Common

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/TraceSize.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/TraceSize.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Ouroboros.Consensus.Util.TraceSize (
+    -- * Generic
+    traceSize
+    -- * Ledger DB specific
+  , LedgerDbSize(..)
+  , traceLedgerDbSize
+  ) where
+
+import           Cardano.Prelude (CountFailure, computeHeapSize)
+import           Control.Monad (when)
+import           Control.Monad.IO.Class
+import           Control.Tracer
+import           Data.Word
+
+import           Ouroboros.Network.Block (Point (..), SlotNo (..))
+import           Ouroboros.Network.Point (Block (..), WithOrigin (..))
+
+import           Ouroboros.Storage.Common
+import           Ouroboros.Storage.LedgerDB.InMemory (LedgerDB)
+import qualified Ouroboros.Storage.LedgerDB.InMemory as LedgerDB
+
+{-------------------------------------------------------------------------------
+  Generic
+-------------------------------------------------------------------------------}
+
+-- | Generic helper to trace a value and its size
+traceSize :: MonadIO m
+          => Tracer m (a, Either CountFailure Word64)
+          -> Tracer m a
+traceSize (Tracer f) = Tracer $ \a -> do
+    sz <- liftIO $ computeHeapSize a
+    f (a, sz)
+
+{-------------------------------------------------------------------------------
+  Ledger DB specific
+-------------------------------------------------------------------------------}
+
+data LedgerDbSize blk = LedgerDbSize {
+      -- | The tip of the ledger DB
+      ledgerDbTip       :: Tip (Point blk)
+
+      -- | Size of the ledger at the tip of the DB
+    , ledgerDbSizeTip   :: Either CountFailure Word64
+
+      -- | Size of the entire (in-memory) ledger DB
+    , ledgerDbSizeTotal :: Either CountFailure Word64
+    }
+  deriving (Show)
+
+-- | Trace the size of the ledger
+--
+-- Only traces slots for which the predicate results true (genesis will be
+-- considered to be slot 0).
+traceLedgerDbSize :: MonadIO m
+                  => (Word64 -> Bool)
+                  -> Tracer m (LedgerDbSize blk)
+                  -> Tracer m (LedgerDB l (Point blk))
+traceLedgerDbSize p (Tracer f) = Tracer $ \(!db) -> do
+    let !ledger = LedgerDB.ledgerDbCurrent db
+        !tip    = LedgerDB.ledgerDbTip db
+
+    when (shouldTrace tip) $ do
+      sizeTip   <- liftIO $ computeHeapSize ledger
+      sizeTotal <- liftIO $ computeHeapSize db
+      f $ LedgerDbSize {
+              ledgerDbTip       = tip
+            , ledgerDbSizeTip   = sizeTip
+            , ledgerDbSizeTotal = sizeTotal
+            }
+  where
+    shouldTrace :: Tip (Point blk) -> Bool
+    shouldTrace TipGen               = p 0
+    shouldTrace (Tip (Point Origin)) = p 0
+    shouldTrace (Tip (Point (At b))) = p (unSlotNo (blockPointSlot b))

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -140,6 +140,7 @@ openDBInternal args launchBgTasks = do
                   , cdbNextReaderId   = varNextReaderId
                   , cdbCopyLock       = varCopyLock
                   , cdbTracer         = tracer
+                  , cdbTraceLedger    = Args.cdbTraceLedger args
                   , cdbRegistry       = Args.cdbRegistry args
                   , cdbGcDelay        = Args.cdbGcDelay args
                   , cdbBgThreads      = varBgThreads

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -79,6 +79,7 @@ data ChainDbArgs m blk = forall h1 h2 h3. ChainDbArgs {
 
       -- Misc
     , cdbTracer           :: Tracer m (TraceEvent blk)
+    , cdbTraceLedger      :: Tracer m (LgrDB.LedgerDB blk)
     , cdbRegistry         :: ResourceRegistry m
     , cdbGcDelay          :: DiffTime
     }
@@ -163,6 +164,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , lgrDiskPolicy       = cdbDiskPolicy
         , lgrGenesis          = cdbGenesis
         , lgrTracer           = contramap TraceLedgerEvent cdbTracer
+        , lgrTraceLedger      = cdbTraceLedger
         }
     , ChainDbSpecificArgs {
           cdbsTracer          = cdbTracer
@@ -214,6 +216,7 @@ toChainDbArgs ImmDB.ImmDbArgs{..}
     , cdbGenesis          = lgrGenesis
       -- Misc
     , cdbTracer           = cdbsTracer
+    , cdbTraceLedger      = lgrTraceLedger
     , cdbRegistry         = cdbsRegistry
     , cdbGcDelay          = cdbsGcDelay
     }

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
@@ -445,9 +445,11 @@ addBlock cdb@CDB{..} b = do
           -- The chain must be changed in the meantime such that our chain is
           -- no longer preferred.
           _ -> return (curChain, False)
-      trace $ if switched
-              then SwitchedToChain  curChain newChain
-              else ChainChangedInBg curChain newChain
+      if switched then do
+        trace $ SwitchedToChain curChain newChain
+        traceWith cdbTraceLedger newLedger
+      else do
+        trace $ ChainChangedInBg curChain newChain
 
     -- | Build a cache from the headers in the fragment.
     cacheHeaders :: AnchoredFragment (Header blk)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -156,6 +156,7 @@ data LgrDbArgs m blk = forall h. LgrDbArgs {
     , lgrDiskPolicy       :: DiskPolicy m
     , lgrGenesis          :: m (ExtLedgerState blk)
     , lgrTracer           :: Tracer m (TraceEvent (Point blk))
+    , lgrTraceLedger      :: Tracer m (LedgerDB blk)
     }
   deriving NoUnexpectedThunks via OnlyCheckIsWHNF "LgrDbArgs" (LgrDbArgs m blk)
 
@@ -187,6 +188,7 @@ defaultArgs fp = LgrDbArgs {
     , lgrDiskPolicy       = error "no default for lgrDiskPolicy"
     , lgrGenesis          = error "no default for lgrGenesis"
     , lgrTracer           = nullTracer
+    , lgrTraceLedger      = nullTracer
     }
 
 -- | Open the ledger DB

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -198,6 +198,7 @@ data ChainDbEnv m blk = CDB
     -- Note that 'copyToImmDB' can still be executed concurrently with all
     -- others functions, just not with itself.
   , cdbTracer         :: !(Tracer m (TraceEvent blk))
+  , cdbTraceLedger    :: !(Tracer m (LgrDB.LedgerDB blk))
   , cdbRegistry       :: !(ResourceRegistry m)
     -- ^ Resource registry that will be used to (re)start the background
     -- threads, see 'cdbBgThreads'.

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -277,6 +277,7 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
                   (ChainDB.AddedBlockToVolDB p bno IsNotEBB)
                   -> traceWith addTracer (p, bno)
               _   -> pure ()
+        , cdbTraceLedger      = nullTracer
         , cdbRegistry         = registry
         , cdbGcDelay          = 0
         }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -263,6 +263,7 @@ mkArgs cfg initLedger tracer registry
 
     -- Misc
     , cdbTracer           = tracer
+    , cdbTraceLedger      = nullTracer
     , cdbRegistry         = registry
     , cdbGcDelay          = 0
     }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -66,7 +66,7 @@ import           Ouroboros.Network.MockChain.ProducerState (ChainProducerState,
 import qualified Ouroboros.Network.MockChain.ProducerState as CPS
 import qualified Ouroboros.Network.Point as Point
 
-import           Ouroboros.Consensus.Block (getHeader, IsEBB (..))
+import           Ouroboros.Consensus.Block (IsEBB (..), getHeader)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.NodeId (NodeId (..))
@@ -1209,6 +1209,7 @@ mkArgs cfg initLedger tracer registry
 
     -- Misc
     , cdbTracer           = tracer
+    , cdbTraceLedger      = nullTracer
     , cdbRegistry         = registry
     , cdbGcDelay          = 0
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -47,7 +47,7 @@ extra-deps:
       - crypto/test
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 001ec3576ef3bda04cf5bcccdd9a00991835d1a7
+    commit: ad19158c7599bc5d50fe7cb0111a1488a139a381
     subdirs:
       - .
       - test


### PR DESCRIPTION
This provides both a generic tracing hook for the ledger DB, as well as a
particular tracer that can be used to trace the ledger DB's size.