### PR TITLE
Increase the length of server error message

### DIFF
--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -353,6 +353,6 @@ instance Show ptcl => Show (MuxTrace ptcl) where
     show MuxTraceHandshakeEnd = "Handshake end"
     show (MuxTraceHandshakeClientError e) =
          -- Client Error can include an error string from the peer which could be very large.
-        printf "Handshake Client Error %s" (take 64 $ show e)
+        printf "Handshake Client Error %s" (take 256 $ show e)
     show (MuxTraceHandshakeServerError e) = printf "Handshake Server Error %s" (show e)
 


### PR DESCRIPTION
Increase the maximum length of the error message from the server that is
displayed by the client incase of a handshake error. 64 characters
wasn't enough to show a network magic missmatch.