### PR TITLE
Concurrent reads

### DIFF
--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -36,6 +36,7 @@
           (hsPkgs.cardano-prelude)
           (hsPkgs.cardano-slotting)
           (hsPkgs.cborg)
+          (hsPkgs.concurrent-extra)
           (hsPkgs.containers)
           (hsPkgs.cryptonite)
           (hsPkgs.cs-blockchain)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -246,6 +246,7 @@ library
                        cardano-prelude,
                        cardano-slotting,
                        cborg             >=0.2.2 && <0.3,
+                       concurrent-extra,
                        containers        >=0.5   && <0.7,
                        cryptonite        >=0.25  && <0.26,
                        cs-blockchain,

--- a/ouroboros-consensus/src-unix/Ouroboros/Storage/IO.hs
+++ b/ouroboros-consensus/src-unix/Ouroboros/Storage/IO.hs
@@ -25,7 +25,7 @@ import           System.Posix (Fd)
 import qualified System.Posix as Posix
 
 -- Package 'unix' exports the same module.
-import "unix-bytestring" System.Posix.IO.ByteString (fdPreadBuf)
+import           "unix-bytestring" System.Posix.IO.ByteString (fdPreadBuf)
 
 import           Ouroboros.Storage.FS.API.Types (AllowExisting (..), FsError,
                      OpenMode (..), SeekMode (..), sameFsError)
@@ -79,7 +79,7 @@ open fp openMode = Posix.openFd fp posixOpenMode fileMode fileFlags
 
 -- | Writes the data pointed by the input 'Ptr Word8' into the input 'FHandle'.
 write :: FHandle -> Ptr Word8 -> Int64 -> IO Word32
-write h data' bytes = withOpenHandle "write" h $ \fd ->
+write h data' bytes = withExclOpenHandle "write" h $ \fd ->
     fromIntegral <$> Posix.fdWriteBuf fd data' (fromIntegral bytes)
 
 -- | Seek within the file.
@@ -89,23 +89,27 @@ write h data' bytes = withOpenHandle "write" h $ \fd ->
 -- We don't return the new offset since the behaviour of lseek is rather odd
 -- (e.g., the file pointer may not actually be moved until a subsequent write)
 seek :: FHandle -> SeekMode -> Int64 -> IO ()
-seek h seekMode offset = withOpenHandle "seek" h $ \fd ->
+seek h seekMode offset = withExclOpenHandle "seek" h $ \fd ->
     void $ Posix.fdSeek fd seekMode (fromIntegral offset)
 
 -- | Reads a given number of bytes from the input 'FHandle'.
+-- 'read' is not thread safe since it alters the file offset, that's why we use
+-- 'withExclOpenHandle' instead of 'withSharedOpenHandle'. Use 'pread' for
+-- thread safety.
 read :: FHandle -> Word64 -> IO ByteString
-read h bytes = withOpenHandle "read" h $ \fd ->
+read h bytes = withExclOpenHandle "read" h $ \fd ->
     Internal.createUptoN (fromIntegral bytes) $ \ptr ->
       fromIntegral <$> Posix.fdReadBuf fd ptr (fromIntegral bytes)
 
+-- | Thread safe version of 'read'.
 pread :: FHandle -> Word64 -> Word64 -> IO ByteString
-pread h bytes offset = withOpenHandle "pread" h $ \fd ->
-    Internal.createUptoN (fromIntegral bytes) $ \ptr ->
-      fromIntegral <$> fdPreadBuf fd ptr (fromIntegral bytes) (fromIntegral offset)
+pread h bytes offset = withSharedOpenHandle "pread" h $ \fd ->
+    Internal.createUptoN (fromIntegral bytes) $ \ptr -> fromIntegral <$>
+      fdPreadBuf fd ptr (fromIntegral bytes) (fromIntegral offset)
 
 -- | Truncates the file managed by the input 'FHandle' to the input size.
 truncate :: FHandle -> Word64 -> IO ()
-truncate h sz = withOpenHandle "truncate" h $ \fd ->
+truncate h sz = withExclOpenHandle "truncate" h $ \fd ->
     Posix.setFdSize fd (fromIntegral sz)
 
 -- | Close handle
@@ -116,11 +120,11 @@ close h = closeHandleOS h Posix.closeFd
 
 -- | File size of the given file pointer
 --
--- NOTE: This is not thread safe (changes made to the file in other threads
--- may affect this thread).
+-- NOTE: 'fileSize' is not thread safe in terms of other writes
+-- (changes made to the file in other threads may affect this thread).
 getSize :: FHandle -> IO Word64
-getSize h = withOpenHandle "getSize" h $ \fd ->
-     fromIntegral . Posix.fileSize <$> Posix.getFdStatus fd
+getSize h = withSharedOpenHandle "getSize" h $
+    fmap (fromIntegral . Posix.fileSize) . Posix.getFdStatus
 
 sameError :: FsError -> FsError -> Bool
 sameError = sameFsError

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -712,10 +712,15 @@ instance Exception ChainDbFailure where
       VolDbFailure e -> case e of
         VolDB.FileSystemError fse -> fsError fse
         VolDB.ParserError {}      -> corruption
+        VolDB.FileNotFound {}     -> internalViolation
       LgrDbFailure fse                    -> fsError fse
       ChainDbMissingBlock {}              -> corruption
     where
-      corruption = "The database got corrupted, please restart with validation mode enabled"
+      corruption =
+        "The database got corrupted, please restart with validation mode enabled"
+
+      internalViolation =
+        "Database violation found: could not find the file to read, please restart."
 
       -- The output will be a bit too detailed, but it will be quite clear.
       fsError :: FsError -> String

--- a/ouroboros-consensus/src/Ouroboros/Storage/FS/Handle.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/FS/Handle.hs
@@ -1,27 +1,30 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase    #-}
+{-# LANGUAGE TupleSections #-}
 
 -- | This is meant to be used for the implementation of HasFS
 -- instances and not directly by client code.
 module Ouroboros.Storage.FS.Handle (
       HandleOS (..)
+    , newHandleOS
+    , withSharedOpenHandle
+    , withExclOpenHandle
     , closeHandleOS
-    , withOpenHandle
-    , isHandleClosedException
     ) where
 
-import           Control.Concurrent.MVar
+import           Control.Concurrent.ReadWriteVar
 import           Control.Exception hiding (handle)
 import           System.IO.Error as IO
 
--- | File handlers for the IO instance for HasFS.
--- This is parametric on the os.
+-- | File handles for the IO instance for HasFS. This is parametric on the os.
 --
 -- The 'FilePath' is used to improve error messages.
--- The 'MVar' is used to implement 'close'.
+--
+-- The 'RWVar' is used to implement concurrent reads and sequential writes.
+--
 -- osHandle is Fd for unix and HANDLE for Windows.
 data HandleOS osHandle = HandleOS {
       filePath :: FilePath
-    , handle   :: MVar (Maybe osHandle)
+    , handle   :: RWVar (Maybe osHandle)
     }
 
 instance Eq (HandleOS a) where
@@ -30,36 +33,48 @@ instance Eq (HandleOS a) where
 instance Show (HandleOS a) where
   show h = "<Handle " ++ filePath h ++ ">"
 
--- | This is a no-op when the handle is already closed.
-closeHandleOS :: HandleOS osHandle -> (osHandle -> IO ()) -> IO ()
-closeHandleOS (HandleOS _ hVar) close =
-  modifyMVar hVar $ \case
-    Nothing -> return (Nothing, ())
-    Just h -> close h >> return (Nothing, ())
-
 {-------------------------------------------------------------------------------
-  Exceptions
+  Handle Access
 -------------------------------------------------------------------------------}
 
--- | This is meant to be used for the implementation of individual file system commands.
--- Using it for larger scopes woud not be correct, since we would not notice if the
--- handle is closed.
-withOpenHandle :: String -> HandleOS osHandle -> (osHandle -> IO a) -> IO a
-withOpenHandle label (HandleOS fp hVar) k =
-    withMVar hVar $ \case
-        Nothing -> throwIO (handleClosedException fp label)
-        Just fd -> k fd
+newHandleOS :: FilePath -> osHandle -> IO (HandleOS osHandle)
+newHandleOS path osHandle =
+    HandleOS path <$> new (Just osHandle)
+
+-- | This is meant to be used for the implementation of individual file system
+-- commands. Using it for larger scopes would not be correct, since we would not
+-- notice if the handle is closed.
+--
+-- Multiple shared access is allowed. Blocks only the exclusive access of other
+-- threads.
+withSharedOpenHandle :: String -> HandleOS osHandle -> (osHandle -> IO a) -> IO a
+withSharedOpenHandle label (HandleOS fp hVar) k =
+    with hVar $ \case
+      Nothing -> throwIO (handleClosedException fp label)
+      Just fd -> k fd
+
+-- | Only one exclusive access is allowed. Blocks any other shared or exclusive
+-- access.
+withExclOpenHandle :: String -> HandleOS osHandle -> (osHandle -> IO a) -> IO a
+withExclOpenHandle label (HandleOS fp hVar) k =
+    modify hVar $ \hndl -> case hndl of
+      Nothing -> throwIO (handleClosedException fp label)
+      Just fd -> (hndl,) <$> k fd
+
+-- | Like 'withExclOpenHandle' in terms of locking.
+-- This is a no-op when the handle is already closed.
+closeHandleOS :: HandleOS osHandle -> (osHandle -> IO ()) -> IO ()
+closeHandleOS (HandleOS _ hVar) close =
+    modify hVar $ \case
+      Nothing -> return (Nothing, ())
+      Just h  -> close h >> return (Nothing, ())
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary
+-------------------------------------------------------------------------------}
 
 handleClosedException :: FilePath -> String -> IOException
 handleClosedException fp label =
       flip IO.ioeSetErrorType IO.illegalOperationErrorType
     $ flip IO.ioeSetFileName fp
     $ userError (label ++ ": FHandle closed")
-
-{-------------------------------------------------------------------------------
-  Internal auxiliary
--------------------------------------------------------------------------------}
-
-isHandleClosedException :: IOException -> Bool
-isHandleClosedException ioErr =
-    IO.isUserErrorType (IO.ioeGetErrorType ioErr)

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Index.hs
@@ -13,6 +13,7 @@ module Ouroboros.Storage.VolatileDB.Index (
   , delete
   , toList
   , elems
+  , getHandle
   ) where
 
 import           Prelude hiding (lookup)
@@ -21,34 +22,40 @@ import           Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IM
 import           GHC.Generics (Generic)
 
-import           Cardano.Prelude (NoUnexpectedThunks(..))
-import           Ouroboros.Storage.VolatileDB.Types (FileId)
+import           Cardano.Prelude (NoUnexpectedThunks (..))
+
+import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.VolatileDB.FileInfo (FileInfo)
+import qualified Ouroboros.Storage.VolatileDB.FileInfo as FileInfo
+import           Ouroboros.Storage.VolatileDB.Types (FileId)
 
 -- For each file, we store the latest blockId, the number of blocks
 -- and a Map for its contents.
-newtype Index blockId = Index {unIndex :: IntMap (FileInfo blockId)}
+newtype Index blockId h = Index {unIndex :: IntMap (FileInfo blockId h)}
   deriving (Generic, NoUnexpectedThunks)
 
-modifyIndex :: (IntMap (FileInfo blockId) -> IntMap (FileInfo blockId))
-            -> Index blockId
-            -> Index blockId
+modifyIndex :: (IntMap (FileInfo blockId h) -> IntMap (FileInfo blockId h))
+            -> Index blockId h
+            -> Index blockId h
 modifyIndex mdf (Index mp) = Index (mdf mp)
 
-empty :: Index blockId
+empty :: Index blockId h
 empty = Index IM.empty
 
-lookup :: FileId -> Index blockId -> Maybe (FileInfo blockId)
-lookup path (Index mp) = IM.lookup path mp
+lookup :: FileId -> Index blockId h -> Maybe (FileInfo blockId h)
+lookup fileId (Index mp) = IM.lookup fileId mp
 
-insert :: FileId -> FileInfo blockId -> Index blockId -> Index blockId
-insert path info = modifyIndex (IM.insert path info)
+insert :: FileId -> FileInfo blockId h -> Index blockId h -> Index blockId h
+insert fileId info = modifyIndex (IM.insert fileId info)
 
-delete :: FileId -> Index blockId -> Index blockId
-delete path = modifyIndex (IM.delete path)
+delete :: FileId -> Index blockId h -> Index blockId h
+delete fileId = modifyIndex (IM.delete fileId)
 
-toList :: Index blockId -> [(FileId, FileInfo blockId)]
+toList :: Index blockId h -> [(FileId, FileInfo blockId h)]
 toList (Index mp) = IM.toList mp
 
-elems :: Index blockId -> [FileInfo blockId]
+elems :: Index blockId h -> [FileInfo blockId h]
 elems (Index mp) = IM.elems mp
+
+getHandle :: FileId -> Index blockId h -> Maybe (Handle h)
+getHandle fileId index = FileInfo.getHandle <$> lookup fileId index

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Types.hs
@@ -57,6 +57,7 @@ data UserError =
 data UnexpectedError =
       FileSystemError FsError
     | ParserError ParserError
+    | FileNotFound FsPath
     deriving (Show)
 
 instance Eq VolatileDBError where
@@ -144,7 +145,8 @@ data BlockInfo blockId = BlockInfo {
 
 -- | The internal information the db keeps for each block.
 data InternalBlockInfo blockId = InternalBlockInfo {
-      ibFile         :: !FsPath
+      ibFileId       :: !FileId
+    , ibFile         :: !FsPath
     , ibSlotOffset   :: !SlotOffset
     , ibBlockSize    :: !BlockSize
     , ibSlot         :: !SlotNo

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -16,6 +16,7 @@ module Ouroboros.Storage.VolatileDB.Util
     , fromEither
     , wrapFsError
     , tryVolDB
+    , fsToVolatileDBError
 
       -- * Map of Set utilities
     , insertMapSet
@@ -114,11 +115,12 @@ tryVolDB :: forall m a. Monad m
          -> m a -> m (Either VolatileDBError a)
 tryVolDB fsErr volDBErr = fmap squash . EH.try fsErr . EH.try volDBErr
   where
-    fromFS = UnexpectedError . FileSystemError
-
     squash :: Either FsError (Either VolatileDBError a)
            -> Either VolatileDBError a
-    squash = either (Left . fromFS) id
+    squash = either (Left . fsToVolatileDBError) id
+
+fsToVolatileDBError :: FsError -> VolatileDBError
+fsToVolatileDBError = UnexpectedError . FileSystemError
 
 {------------------------------------------------------------------------------
   Map of Set utilities

--- a/ouroboros-consensus/test-util/Test/Util/FS/Sim/MockFS.hs
+++ b/ouroboros-consensus/test-util/Test/Util/FS/Sim/MockFS.hs
@@ -193,7 +193,7 @@ seekFilePtr err@ErrorHandling{..} MockFS{..} (Handle h _) seekMode o = do
     case mockHandles M.! h of
       HandleClosed ClosedHandle{..} ->
         throwError FsError {
-            fsErrorType   = FsIllegalOperation
+            fsErrorType   = FsHandleClosed
           , fsErrorPath   = closedFilePath
           , fsErrorString = "handle closed"
           , fsErrorNo     = Nothing
@@ -322,7 +322,7 @@ withOpenHandleModify err@ErrorHandling{..} h f =
         second (second HandleOpen) <$> f fs hs
       HandleClosed ClosedHandle{..} ->
         throwError FsError {
-            fsErrorType   = FsIllegalOperation
+            fsErrorType   = FsHandleClosed
           , fsErrorPath   = closedFilePath
           , fsErrorString = "handle closed"
           , fsErrorNo     = Nothing
@@ -345,7 +345,7 @@ withOpenHandleRead err@ErrorHandling{..} h f =
         second HandleOpen <$> f fs hs
       HandleClosed ClosedHandle{..} ->
         throwError FsError {
-            fsErrorType   = FsIllegalOperation
+            fsErrorType   = FsHandleClosed
           , fsErrorPath   = closedFilePath
           , fsErrorString = "handle closed"
           , fsErrorNo     = Nothing


### PR DESCRIPTION
This pr keeps a single read handle per file of the VolatileDB, so that it reduces reopening for each read https://github.com/input-output-hk/ouroboros-network/issues/767. A new read handle opens when we parse a file of the db (during opening the db) or when a new file is created. 

It is important that these files are properly garbage collected, which is not trivial.
q-s-m tests caught some cases where open handles leak, which I fixed with exception-handling, but a more all-around solution should be given as part of https://github.com/input-output-hk/ouroboros-network/issues/649, maybe using `ResourceRegistry`.

`pread` is used to allow concurrent readers. `pread` (in unix) is given a read lock on the FS layer.
Also ImmutableDB now uses pread in some cases.

~First prs are also part of https://github.com/input-output-hk/ouroboros-network/pull/1160 and https://github.com/input-output-hk/ouroboros-network/pull/1164~

Last piece of https://github.com/input-output-hk/ouroboros-network/pull/1149