### PR TITLE
Move `NodeConfig` out of the `OuroborosTag` class

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -305,8 +305,7 @@ implAddTxs mpEnv accum txs = assert (all txInvariant txs) $ do
     -- possible, returning the last 'ValidationResult' and the remaining
     -- transactions which couldn't be added due to the mempool capacity being
     -- reached.
-    validateNew :: (IOLike m, ApplyTx blk)
-                => ValidationResult blk
+    validateNew :: ValidationResult blk
                 -> STM m (ValidationResult blk, [GenTx blk])
     validateNew res =
         let res' = res { vrInvalid = [] }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -14,6 +14,7 @@
 module Ouroboros.Consensus.Protocol.Abstract (
     -- * Abstract definition of the Ouroboros protocol
     OuroborosTag(..)
+  , NodeConfig
   , SecurityParam(..)
     -- * State monad for Ouroboros state
   , HasNodeState
@@ -47,6 +48,17 @@ import           Ouroboros.Consensus.Util.Random
 
 import           GHC.Stack
 
+-- | Static node configuration
+--
+-- Every method in the 'OuroborosTag' class takes the node configuration as a
+-- parameter, so having this as a data family rather than a type family resolves
+-- most ambiguity.
+--
+-- Defined out of the class so that protocols can define this type without
+-- having to define the entire protocol at the same time (or indeed in the same
+-- module).
+data family NodeConfig p :: *
+
 -- | The (open) universe of Ouroboros protocols
 --
 -- This class encodes the part that is independent from any particular
@@ -58,13 +70,6 @@ class ( Show (ChainState    p)
       , NoUnexpectedThunks (NodeState   p)
       , Typeable p -- so that p can appear in exceptions
       ) => OuroborosTag p where
-
-  -- | Static node configuration
-  --
-  -- Every method in this class takes the node configuration as a parameter,
-  -- so having this as a data family rather than a type family resolves most
-  -- ambiguity.
-  data family NodeConfig p :: *
 
   -- | State of the node required to run the protocol
   type family NodeState p :: *

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -107,16 +107,16 @@ data BftParams = BftParams {
     }
   deriving (Generic, NoUnexpectedThunks)
 
-instance BftCrypto c => OuroborosTag (Bft c) where
-  -- | (Static) node configuration
-  data NodeConfig (Bft c) = BftNodeConfig {
-        bftParams   :: !BftParams
-      , bftNodeId   :: !NodeId
-      , bftSignKey  :: !(SignKeyDSIGN (BftDSIGN c))
-      , bftVerKeys  :: !(Map NodeId (VerKeyDSIGN (BftDSIGN c)))
-      }
-    deriving (Generic)
+-- | (Static) node configuration
+data instance NodeConfig (Bft c) = BftNodeConfig {
+      bftParams  :: !BftParams
+    , bftNodeId  :: !NodeId
+    , bftSignKey :: !(SignKeyDSIGN (BftDSIGN c))
+    , bftVerKeys :: !(Map NodeId (VerKeyDSIGN (BftDSIGN c)))
+    }
+  deriving (Generic)
 
+instance BftCrypto c => OuroborosTag (Bft c) where
   type ValidationErr   (Bft c) = BftValidationErr
   type SupportedHeader (Bft c) = HeaderSupportsBft c
   type NodeState       (Bft c) = ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtNodeConfig.hs
@@ -28,6 +28,12 @@ import           Ouroboros.Consensus.Protocol.Abstract
 -- | Extension of protocol @p@ by additional static node configuration @cfg@.
 data ExtNodeConfig cfg p
 
+data instance NodeConfig (ExtNodeConfig cfg p) = EncNodeConfig {
+      encNodeConfigP   :: NodeConfig p
+    , encNodeConfigExt :: cfg
+    }
+  deriving (Generic)
+
 instance ( Typeable cfg
          , OuroborosTag p
          , NoUnexpectedThunks cfg
@@ -37,22 +43,12 @@ instance ( Typeable cfg
   -- Most types remain the same
   --
 
-  type ChainState      (ExtNodeConfig cfg p) = ChainState     p
-  type NodeState       (ExtNodeConfig cfg p) = NodeState      p
-  type LedgerView      (ExtNodeConfig cfg p) = LedgerView     p
-  type ValidationErr   (ExtNodeConfig cfg p) = ValidationErr  p
-  type IsLeader        (ExtNodeConfig cfg p) = IsLeader       p
+  type ChainState      (ExtNodeConfig cfg p) = ChainState      p
+  type NodeState       (ExtNodeConfig cfg p) = NodeState       p
+  type LedgerView      (ExtNodeConfig cfg p) = LedgerView      p
+  type ValidationErr   (ExtNodeConfig cfg p) = ValidationErr   p
+  type IsLeader        (ExtNodeConfig cfg p) = IsLeader        p
   type SupportedHeader (ExtNodeConfig cfg p) = SupportedHeader p
-
-  --
-  -- Only type that changes is the node config
-  --
-
-  data NodeConfig (ExtNodeConfig cfg p) = EncNodeConfig {
-        encNodeConfigP   :: NodeConfig p
-      , encNodeConfigExt :: cfg
-      }
-    deriving (Generic)
 
   --
   -- Propagate changes

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -45,21 +45,20 @@ instance Condense LeaderSchedule where
 -- | Extension of protocol @p@ by a static leader schedule.
 data WithLeaderSchedule p
 
-instance OuroborosTag p => OuroborosTag (WithLeaderSchedule p) where
+data instance NodeConfig (WithLeaderSchedule p) = WLSNodeConfig
+  { lsNodeConfigSchedule :: !LeaderSchedule
+  , lsNodeConfigP        :: !(NodeConfig p)
+  , lsNodeConfigNodeId   :: !CoreNodeId
+  }
+  deriving (Generic)
 
+instance OuroborosTag p => OuroborosTag (WithLeaderSchedule p) where
   type ChainState      (WithLeaderSchedule p) = ()
   type NodeState       (WithLeaderSchedule p) = ()
   type LedgerView      (WithLeaderSchedule p) = ()
   type ValidationErr   (WithLeaderSchedule p) = ()
   type IsLeader        (WithLeaderSchedule p) = ()
   type SupportedHeader (WithLeaderSchedule p) = Empty
-
-  data NodeConfig (WithLeaderSchedule p) = WLSNodeConfig
-    { lsNodeConfigSchedule :: !LeaderSchedule
-    , lsNodeConfigP        :: !(NodeConfig p)
-    , lsNodeConfigNodeId   :: !CoreNodeId
-    }
-    deriving (Generic)
 
   preferCandidate       WLSNodeConfig{..} = preferCandidate       lsNodeConfigP
   compareCandidates     WLSNodeConfig{..} = compareCandidates     lsNodeConfigP

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -42,15 +42,16 @@ class OuroborosTag p => ChainSelection p s where
 
 data ModChainSel p s
 
-instance (Typeable p, Typeable s, ChainSelection p s) => OuroborosTag (ModChainSel p s) where
+newtype instance NodeConfig (ModChainSel p s) = McsNodeConfig (NodeConfig p)
+  deriving (Generic)
 
-    newtype NodeConfig      (ModChainSel p s)    = McsNodeConfig (NodeConfig p) deriving (Generic)
-    type    NodeState       (ModChainSel p s)    = NodeState p
-    type    ChainState      (ModChainSel p s)    = ChainState p
-    type    IsLeader        (ModChainSel p s)    = IsLeader p
-    type    LedgerView      (ModChainSel p s)    = LedgerView p
-    type    ValidationErr   (ModChainSel p s)    = ValidationErr p
-    type    SupportedHeader (ModChainSel p s)    = SupportedHeader p
+instance (Typeable p, Typeable s, ChainSelection p s) => OuroborosTag (ModChainSel p s) where
+    type NodeState       (ModChainSel p s) = NodeState       p
+    type ChainState      (ModChainSel p s) = ChainState      p
+    type IsLeader        (ModChainSel p s) = IsLeader        p
+    type LedgerView      (ModChainSel p s) = LedgerView      p
+    type ValidationErr   (ModChainSel p s) = ValidationErr   p
+    type SupportedHeader (ModChainSel p s) = SupportedHeader p
 
     checkIsLeader         (McsNodeConfig cfg) = checkIsLeader         cfg
     applyChainState       (McsNodeConfig cfg) = applyChainState       cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -170,14 +170,14 @@ data PBftIsLeaderOrNot c
   | PBftIsNotALeader
   deriving (Generic, NoUnexpectedThunks)
 
-instance (PBftCrypto c, Typeable c) => OuroborosTag (PBft c) where
-  -- | (Static) node configuration
-  data NodeConfig (PBft c) = PBftNodeConfig {
-        pbftParams   :: !PBftParams
-      , pbftIsLeader :: !(PBftIsLeaderOrNot c)
-      }
-    deriving (Generic, NoUnexpectedThunks)
+-- | (Static) node configuration
+data instance NodeConfig (PBft c) = PBftNodeConfig {
+      pbftParams   :: !PBftParams
+    , pbftIsLeader :: !(PBftIsLeaderOrNot c)
+    }
+  deriving (Generic, NoUnexpectedThunks)
 
+instance (PBftCrypto c, Typeable c) => OuroborosTag (PBft c) where
   type ValidationErr   (PBft c) = PBftValidationErr c
   type SupportedHeader (PBft c) = HeaderSupportsPBft c
   type NodeState       (PBft c) = ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -205,17 +205,17 @@ newtype PraosNodeState c = PraosNodeState {
 instance PraosCrypto c => NoUnexpectedThunks (PraosNodeState c) where
   showTypeOf _ = show $ typeRep (Proxy @(PraosNodeState c))
 
-instance PraosCrypto c => OuroborosTag (Praos c) where
-  data NodeConfig (Praos c) = PraosNodeConfig
-    { praosParams        :: !PraosParams
-    , praosInitialEta    :: !Natural
-    , praosInitialStake  :: !StakeDist
-    , praosNodeId        :: !NodeId
-    , praosSignKeyVRF    :: !(SignKeyVRF (PraosVRF c))
-    , praosVerKeys       :: !(IntMap (VerKeyKES (PraosKES c), VerKeyVRF (PraosVRF c)))
-    }
-    deriving (Generic)
+data instance NodeConfig (Praos c) = PraosNodeConfig
+  { praosParams       :: !PraosParams
+  , praosInitialEta   :: !Natural
+  , praosInitialStake :: !StakeDist
+  , praosNodeId       :: !NodeId
+  , praosSignKeyVRF   :: !(SignKeyVRF (PraosVRF c))
+  , praosVerKeys      :: !(IntMap (VerKeyKES (PraosKES c), VerKeyVRF (PraosVRF c)))
+  }
+  deriving (Generic)
 
+instance PraosCrypto c => OuroborosTag (Praos c) where
   protocolSecurityParam = praosSecurityParam . praosParams
 
   type NodeState       (Praos c) = PraosNodeState c

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/WithEBBs.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/WithEBBs.hs
@@ -53,21 +53,22 @@ class ( HasHeader hoe
 -- This is entirely a legacy concern, and should go away after the Byron era.
 data WithEBBs p
 
+newtype instance NodeConfig (WithEBBs p) = WithEBBNodeConfig {
+      unWithEBBNodeConfig :: NodeConfig p
+    }
+  deriving (Generic)
+
 instance OuroborosTag p => OuroborosTag (WithEBBs p) where
   --
   -- Most types remain the same
   --
 
-  type ChainState      (WithEBBs p) = ChainStateWithEBBs p
-  type NodeState       (WithEBBs p) = NodeState      p
-  type LedgerView      (WithEBBs p) = LedgerView     p
-  type ValidationErr   (WithEBBs p) = ValidationErr  p
-  type IsLeader        (WithEBBs p) = IsLeader       p
-
+  type ChainState      (WithEBBs p) = ChainStateWithEBBs    p
+  type NodeState       (WithEBBs p) = NodeState             p
+  type LedgerView      (WithEBBs p) = LedgerView            p
+  type ValidationErr   (WithEBBs p) = ValidationErr         p
+  type IsLeader        (WithEBBs p) = IsLeader              p
   type SupportedHeader (WithEBBs p) = HeaderSupportsWithEBB p
-
-  newtype NodeConfig   (WithEBBs p) = WithEBBNodeConfig {unWithEBBNodeConfig :: NodeConfig p}
-    deriving (Generic)
 
   preferCandidate       (WithEBBNodeConfig cfg) = preferCandidate       cfg
   compareCandidates     (WithEBBNodeConfig cfg) = compareCandidates     cfg
@@ -134,8 +135,8 @@ data ChainStateWithEBBs p = UnsafeChainStateWithEBBs
 mkChainStateWithEBBs :: Maybe SlotNo -> ChainState p -> ChainStateWithEBBs p
 mkChainStateWithEBBs mSlot underlying =
     case mSlot of
-      Nothing    -> UnsafeChainStateWithEBBs Nothing     underlying
-      Just !slot -> UnsafeChainStateWithEBBs (Just slot) underlying
+      Nothing      -> UnsafeChainStateWithEBBs Nothing     underlying
+      Just (!slot) -> UnsafeChainStateWithEBBs (Just slot) underlying
 
 deriving instance OuroborosTag p => NoUnexpectedThunks (ChainStateWithEBBs p)
 deriving instance OuroborosTag p => Show (ChainStateWithEBBs p)


### PR DESCRIPTION
This makes it possible in protocols to define this independent from the
rest. Note that the other types in `OuroborasTag` are all type families,
not data families, and so can _already_ be defined independently.