### PR TITLE
lazy miniprotocols

### DIFF
--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -103,5 +103,6 @@ test-suite test-network-mux
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts
+                       -threaded
   if flag(ipv6)
     cpp-options:       -DOUROBOROS_NETWORK_IPV6

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -370,10 +370,10 @@ data MuxTrace ptcl =
     | forall e. Exception e => MuxTraceHandshakeServerError e
     | MuxTraceBrooderResponderBrood (MiniProtocolId ptcl)
     | MuxTraceBrooderResponderHatch (MiniProtocolId ptcl)
-    | MuxTraceBrooderResponderDone (MiniProtocolId ptcl)
+    | MuxTraceBrooderResponderDone (MiniProtocolId ptcl) Int64
     | MuxTraceBrooderInitiatorBrood (MiniProtocolId ptcl)
     | MuxTraceBrooderInitiatorHatch (MiniProtocolId ptcl)
-    | MuxTraceBrooderInitiatorDone (MiniProtocolId ptcl)
+    | MuxTraceBrooderInitiatorDone (MiniProtocolId ptcl) Int64
 
 instance Show ptcl => Show (MuxTrace ptcl) where
     show MuxTraceRecvHeaderStart = printf "Bearer Receive Header Start"
@@ -416,8 +416,8 @@ instance Show ptcl => Show (MuxTrace ptcl) where
     show (MuxTraceHandshakeServerError e) = printf "Handshake Server Error %s" (show e)
     show (MuxTraceBrooderResponderBrood mid) = printf "Responder Brood on %s" (show mid)
     show (MuxTraceBrooderResponderHatch mid) = printf "Responder Hatch on %s" (show mid)
-    show (MuxTraceBrooderResponderDone mid) = printf "Responder Done on %s" (show mid)
+    show (MuxTraceBrooderResponderDone mid len) = printf "Responder Done on %s %d bytes left" (show mid) len
     show (MuxTraceBrooderInitiatorBrood mid) = printf "Initiator Brood on %s" (show mid)
     show (MuxTraceBrooderInitiatorHatch mid) = printf "Initiator Hatch on %s" (show mid)
-    show (MuxTraceBrooderInitiatorDone mid) = printf "Initiator Done on %s" (show mid)
+    show (MuxTraceBrooderInitiatorDone mid len) = printf "Initiator Done on %s  %d bytes left" (show mid) len
 

--- a/network-mux/test/Test/Mux/ReqResp.hs
+++ b/network-mux/test/Test/Mux/ReqResp.hs
@@ -117,14 +117,14 @@ runClient :: forall req resp m a.
           => Tracer m (TraceSendRecv (MsgReqResp req resp))
           -> Channel m
           -> ReqRespClient req resp m a
-          -> m a
+          -> m (a, Maybe LBS.ByteString)
 
 runClient tracer channel@Channel {send} =
     go Nothing
   where
     go :: Maybe LBS.ByteString
        -> ReqRespClient req resp m a
-       -> m a
+       -> m (a, Maybe LBS.ByteString)
     go trailing (SendMsgReq req mnext) = do
       let msg :: MsgReqResp req resp
           msg = MsgReq req
@@ -145,12 +145,13 @@ runClient tracer channel@Channel {send} =
 
         Right (msg', _) -> error $ "runClient: wrong message " ++ show msg'
 
-    go _trailing (SendMsgDone ma) = do
+    go trailing (SendMsgDone ma) = do
         let msg :: MsgReqResp req resp
             msg = MsgDone
         traceWith tracer (TraceSend msg)
         send (serialise msg)
-        ma
+        a <- ma
+        return (a, trailing)
 
 
 -- | Server which receives 'req' and responds with 'resp'.
@@ -177,14 +178,14 @@ runServer :: forall req resp m a.
           => Tracer m (TraceSendRecv (MsgReqResp req resp))
           -> Channel m
           -> ReqRespServer req resp m a
-          -> m a
+          -> m (a, Maybe LBS.ByteString)
 
 runServer tracer channel@Channel {send} =
     go Nothing
   where
     go :: Maybe LBS.ByteString
        -> ReqRespServer req resp m a
-       -> m a
+       -> m (a, Maybe LBS.ByteString)
     go trailing ReqRespServer {recvMsgReq, recvMsgDone} = do
       res <- withLiftST $ \liftST -> runDecoderWithChannel
                                         liftST channel trailing decode
@@ -202,9 +203,10 @@ runServer tracer channel@Channel {send} =
           send $ serialise msg'
           go trailing' server
 
-        Right (msg@MsgDone, _) -> do
+        Right (msg@MsgDone, trailing') -> do
           traceWith tracer (TraceRecv msg)
-          recvMsgDone
+          x <- recvMsgDone
+          return (x, trailing')
 
         Right (msg, _) -> do
           traceWith tracer (TraceRecv msg)

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -504,20 +504,20 @@ directedEdgeInner (node1, LimitedApp app1) (node2, LimitedApp app2) = do
             LimitedApp' m NodeId blk unused1 unused2
          -> NodeId
          -> Channel m msg
-         -> m ())
+         -> m ((), Maybe msg))
         -- ^ client action to run on node1
       -> (forall unused1 unused2.
             LimitedApp' m NodeId blk unused1 unused2
          -> NodeId
          -> Channel m msg
-         -> m ())
+         -> m ((), Maybe msg))
          -- ^ server action to run on node2
       -> m (m (), m ())
     miniProtocol client server = do
        (chan, dualChan) <- createConnectedChannels
        pure
-         ( client app1 (fromCoreNodeId node2) chan
-         , server app2 (fromCoreNodeId node1) dualChan
+         ( fst <$> client app1 (fromCoreNodeId node2) chan
+         , fst <$> server app2 (fromCoreNodeId node1) dualChan
          )
 
     wrapMPEE ::

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -487,10 +487,10 @@ clientBlockFetch sockAddrs = do
         protocols :: ConnectionId
                   -> DemoProtocol3
                   -> Channel IO LBS.ByteString
-                  -> IO ()
+                  -> IO ((), Maybe LBS.ByteString)
         protocols peerid ChainSync3 channel =
           bracket register unregister $ \chainVar ->
-          runPeer
+          runPeer'
             nullTracer -- (contramap (show . TraceLabelPeer peerid) stdoutTracer)
             codecChainSync
             peerid
@@ -509,7 +509,7 @@ clientBlockFetch sockAddrs = do
 
         protocols peerid BlockFetch3 channel =
           bracketFetchClient registry peerid $ \clientCtx ->
-            runPipelinedPeer
+            runPipelinedPeer'
               nullTracer -- (contramap (show . TraceLabelPeer peerid) stdoutTracer)
               codecBlockFetch
               peerid

--- a/typed-protocols/src/Network/TypedProtocol/Driver.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Driver.hs
@@ -8,12 +8,14 @@ module Network.TypedProtocol.Driver (
 
   -- * Normal peers
   runPeer,
+  runPeer',
   runPeerWithDriver,
   TraceSendRecv(..),
   runPeerWithLimits,
 
   -- * Pipelined peers
   runPipelinedPeer,
+  runPipelinedPeer',
   runPipelinedPeerWithDriver,
   runPipelinedPeerWithLimits,
 


### PR DESCRIPTION
Start responder side of miniprotocols on demand.
Let users decide when to start (and restart) the initiator side of a
miniprotocol.

Implements #1318 