### PR TITLE
Simplify PBftCrypto instances

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -37,19 +37,19 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 64bb761664c9ca8a52a0023dc1a92c9b5b884497
+  tag: 8c6869e63dca15e8fd7e455e65bda1295f2bbfb8
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 64bb761664c9ca8a52a0023dc1a92c9b5b884497
+  tag: 8c6869e63dca15e8fd7e455e65bda1295f2bbfb8
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 64bb761664c9ca8a52a0023dc1a92c9b5b884497
+  tag: 8c6869e63dca15e8fd7e455e65bda1295f2bbfb8
   subdir: cardano-crypto-class
 
 source-repository-package

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -38,8 +38,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "64bb761664c9ca8a52a0023dc1a92c9b5b884497";
-      sha256 = "1cqmyr4q5jpalxffzqr5clafr0zz7mzi3k57nxf0d519kilwhfdc";
+      rev = "8c6869e63dca15e8fd7e455e65bda1295f2bbfb8";
+      sha256 = "0ghnymbpivw4y3pihsmcnxyprpyl7pnz39w7pcpc43cgkfwyz8zj";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "64bb761664c9ca8a52a0023dc1a92c9b5b884497";
-      sha256 = "1cqmyr4q5jpalxffzqr5clafr0zz7mzi3k57nxf0d519kilwhfdc";
+      rev = "8c6869e63dca15e8fd7e455e65bda1295f2bbfb8";
+      sha256 = "0ghnymbpivw4y3pihsmcnxyprpyl7pnz39w7pcpc43cgkfwyz8zj";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -48,8 +48,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "64bb761664c9ca8a52a0023dc1a92c9b5b884497";
-      sha256 = "1cqmyr4q5jpalxffzqr5clafr0zz7mzi3k57nxf0d519kilwhfdc";
+      rev = "8c6869e63dca15e8fd7e455e65bda1295f2bbfb8";
+      sha256 = "0ghnymbpivw4y3pihsmcnxyprpyl7pnz39w7pcpc43cgkfwyz8zj";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -33,7 +33,6 @@
           (hsPkgs.cardano-ledger)
           (hsPkgs.cardano-prelude)
           (hsPkgs.cborg)
-          (hsPkgs.constraints)
           (hsPkgs.containers)
           (hsPkgs.cryptonite)
           (hsPkgs.deepseq)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -204,7 +204,6 @@ library
                        cardano-ledger,
                        cardano-prelude,
                        cborg             >=0.2.2 && <0.3,
-                       constraints,
                        containers        >=0.5   && <0.7,
                        cryptonite        >=0.25  && <0.26,
                        deepseq,

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Config.hs
@@ -4,6 +4,7 @@
 
 module Ouroboros.Consensus.Ledger.Byron.Config (
     ByronConfig(..)
+  , pbftProtocolMagicId
   ) where
 
 import           GHC.Generics (Generic)
@@ -25,3 +26,6 @@ data ByronConfig = ByronConfig {
     , pbftGenesisHash     :: !CC.Genesis.GenesisHash
     }
   deriving (Generic, NoUnexpectedThunks)
+
+pbftProtocolMagicId :: ByronConfig -> Crypto.ProtocolMagicId
+pbftProtocolMagicId = Crypto.getProtocolMagicId . pbftProtocolMagic

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
@@ -133,7 +133,7 @@ forgeBlock (WithEBBNodeConfig cfg) curSlot curNo prevHash txs isLeader = do
     ouroborosPayload <-
       give (VerKeyCardanoDSIGN headerGenesisKey) $
       give protocolMagicId $
-      forgePBftFields isLeader (reAnnotate $ Annotated toSign ())
+      forgePBftFields cfg isLeader (reAnnotate $ Annotated toSign ())
     return $ forge ouroborosPayload
   where
     -- TODO: Might be sufficient to add 'ConfigContainsGenesis' constraint.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
@@ -86,10 +86,11 @@ instance ( SimpleCrypto c
 instance ( SimpleCrypto c
          , PBftCrypto c'
          , Signable (PBftDSIGN c') (SignedSimplePBft c c')
+         , ConstructContextDSIGN ext c'
          ) => ForgeExt (PBft ext c') c (SimplePBftExt c c') where
-  forgeExt _cfg isLeader SimpleBlock{..} = do
+  forgeExt cfg isLeader SimpleBlock{..} = do
       ext :: SimplePBftExt c c' <- fmap SimplePBftExt $
-        forgePBftFields isLeader $
+        forgePBftFields cfg isLeader $
           SignedSimplePBft {
               signedSimplePBft = simpleHeaderStd
             }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -75,7 +75,7 @@ forgeBftFields :: ( MonadRandom m
                -> toSign
                -> m (BftFields c toSign)
 forgeBftFields BftNodeConfig{..} toSign = do
-      signature <- signedDSIGN toSign bftSignKey
+      signature <- signedDSIGN () toSign bftSignKey
       return $ BftFields {
           bftSignature = signature
         }
@@ -138,6 +138,7 @@ instance BftCrypto c => OuroborosTag (Bft c) where
   applyChainState cfg@BftNodeConfig{..} _l b _cs = do
       -- TODO: Should deal with unknown node IDs
       case verifySignedDSIGN
+           ()
            (bftVerKeys Map.! expectedLeader)
            (headerSigned b)
            bftSignature of
@@ -170,6 +171,7 @@ class ( Typeable c
       , DSIGNAlgorithm (BftDSIGN c)
       , Condense (SigDSIGN (BftDSIGN c))
       , NoUnexpectedThunks (SigDSIGN (BftDSIGN c))
+      , ContextDSIGN (BftDSIGN c) ~ ()
       ) => BftCrypto c where
   type family BftDSIGN c :: *
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/Crypto.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/Crypto.hs
@@ -12,111 +12,59 @@ module Ouroboros.Consensus.Protocol.PBFT.Crypto (
   , PBftCardanoCrypto
   ) where
 
-import           Data.Constraint
-import           Data.Reflection (Given, give)
 import           Data.Typeable
 
-import           Cardano.Binary (Decoded)
 import qualified Cardano.Chain.Common as CC.Common
 import qualified Cardano.Chain.Delegation as CC.Delegation
-import           Cardano.Crypto (ProtocolMagicId)
 import           Cardano.Crypto.DSIGN.Class
 import           Cardano.Crypto.DSIGN.Mock (MockDSIGN)
 import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Cardano
-import           Ouroboros.Consensus.Ledger.Byron.Orphans ()
-import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util.Condense
 
 -- | Crypto primitives required by BFT
+--
+-- Cardano stores a map of stakeholder IDs rather than the verification key
+-- directly. We make this family injective for convenience - whilst it's
+-- _possible_ that there could be non-injective instances, the chances of there
+-- being more than the two instances here are basically non-existent.
 class ( Typeable c
       , DSIGNAlgorithm (PBftDSIGN c)
       , Condense (SigDSIGN (PBftDSIGN c))
       , Show (PBftVerKeyHash c)
-      , Ord (PBftVerKeyHash c)
-      , Eq (PBftVerKeyHash c)
+      , Ord  (PBftVerKeyHash c)
+      , Eq   (PBftVerKeyHash c)
       , Show (PBftVerKeyHash c)
       , NoUnexpectedThunks (PBftVerKeyHash c)
       , NoUnexpectedThunks (PBftDelegationCert c)
       ) => PBftCrypto c where
-  type family PBftDSIGN c :: *
-
+  type family PBftDSIGN          c :: *
   type family PBftDelegationCert c = (d :: *) | d -> c
+  type family PBftVerKeyHash     c = (d :: *) | d -> c
 
   dlgCertGenVerKey :: PBftDelegationCert c -> VerKeyDSIGN (PBftDSIGN c)
   dlgCertDlgVerKey :: PBftDelegationCert c -> VerKeyDSIGN (PBftDSIGN c)
-
-  -- Cardano stores a map of stakeholder IDs rather than the verification key
-  -- directly. We make this family injective for convenience - whilst it's
-  -- _possible_ that there could be non-injective instances, the chances of there
-  -- being more than the two instances here are basically non-existent.
-  type family PBftVerKeyHash c = (d :: *) | d -> c
-
-  type family PBftSigningConstraints c hdr :: Constraint
-
-  hashVerKey :: VerKeyDSIGN (PBftDSIGN c) -> PBftVerKeyHash c
-
-  -- Abstracted version of `verifySignedDSIGN`
-  --
-  -- Since our signing constraints differ, we abstract this here such that we can
-  -- correctly assemble the constraints in the real crypto case. See the
-  -- documentation in Crypto/DSIGN/Cardano for more details.
-  verifyPBftSigned :: forall hdr proxy. (PBftSigningConstraints c hdr)
-                   => proxy (c, hdr)
-                   -> VerKeyDSIGN (PBftDSIGN c) -- Genesis key - only used in the real impl
-                   -> VerKeyDSIGN (PBftDSIGN c)
-                   -> Signed hdr
-                   -> SignedDSIGN (PBftDSIGN c) (Signed hdr) -> Either String ()
+  hashVerKey       :: VerKeyDSIGN (PBftDSIGN c) -> PBftVerKeyHash c
 
 data PBftMockCrypto
 
 instance PBftCrypto PBftMockCrypto where
-  type PBftDSIGN      PBftMockCrypto = MockDSIGN
-
+  type PBftDSIGN          PBftMockCrypto = MockDSIGN
   type PBftDelegationCert PBftMockCrypto = (VerKeyDSIGN MockDSIGN, VerKeyDSIGN MockDSIGN)
+  type PBftVerKeyHash     PBftMockCrypto = VerKeyDSIGN MockDSIGN
 
   dlgCertGenVerKey = fst
   dlgCertDlgVerKey = snd
-
-  type PBftVerKeyHash PBftMockCrypto = VerKeyDSIGN MockDSIGN
-
-  type PBftSigningConstraints PBftMockCrypto hdr = Signable MockDSIGN (Signed hdr)
-
-  hashVerKey = id
-
-  verifyPBftSigned _ _ = verifySignedDSIGN
+  hashVerKey       = id
 
 data PBftCardanoCrypto
 
-instance (Given ProtocolMagicId) => PBftCrypto PBftCardanoCrypto where
-  type PBftDSIGN PBftCardanoCrypto      = CardanoDSIGN
-
+instance PBftCrypto PBftCardanoCrypto where
+  type PBftDSIGN          PBftCardanoCrypto = CardanoDSIGN
   type PBftDelegationCert PBftCardanoCrypto = CC.Delegation.Certificate
+  type PBftVerKeyHash     PBftCardanoCrypto = CC.Common.KeyHash
 
   dlgCertGenVerKey = VerKeyCardanoDSIGN . CC.Delegation.issuerVK
   dlgCertDlgVerKey = VerKeyCardanoDSIGN . CC.Delegation.delegateVK
-
-  type PBftVerKeyHash PBftCardanoCrypto = CC.Common.KeyHash
-
-  type PBftSigningConstraints PBftCardanoCrypto hdr
-    = ( Decoded (Signed hdr)
-      , Given (VerKeyDSIGN CardanoDSIGN) :=> HasSignTag (Signed hdr)
-      )
-
   hashVerKey (VerKeyCardanoDSIGN pk) = CC.Common.hashKey pk
-
-  -- This uses some hackery from the 'constraints' package to assemble a
-  -- `HasSignTag` constraint from a `Given` constraint and a reified instance of
-  -- the instance head/body relationship between the two.
-  --
-  -- See
-  -- https://hackage.haskell.org/package/constraints-0.10.1/docs/Data-Constraint.html#v:-92--92-
-  -- for details.
-  verifyPBftSigned (_ :: proxy (PBftCardanoCrypto, hdr)) gkVerKey issuer hSig sig
-    = give gkVerKey $
-      (verifySignedDSIGN
-        issuer
-        hSig
-        sig \\
-        (ins :: Given (VerKeyDSIGN CardanoDSIGN) :- HasSignTag (Signed hdr) ))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE PolyKinds           #-}
@@ -37,15 +38,18 @@ module Ouroboros.Consensus.Util (
 
 import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Lazy as Lazy
-import           Data.Constraint
 import           Data.Function (on)
 import           Data.Functor.Identity
+import           Data.Kind
 import           Data.List (foldl', maximumBy)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Void
 import           Data.Word (Word64)
 import           GHC.Stack
+
+data Dict :: Constraint -> * where
+  Dict :: a => Dict a
 
 class Empty a
 instance Empty a

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@ extra-deps:
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 64bb761664c9ca8a52a0023dc1a92c9b5b884497
+    commit: 8c6869e63dca15e8fd7e455e65bda1295f2bbfb8
     subdirs:
       - binary
       - binary/test


### PR DESCRIPTION
The existing instances had to jump through a lot of hoops, because the crypto classes did not allow for context. I changed that in https://github.com/input-output-hk/cardano-base/pull/54, which allowed to significantly simplify the PBft code.

We no longer depend on `constraints` now.

Side note: I ran the tests with the no-thunks checks enabled (as I hadn't disabled that yet..) and they still pass, which is good to know.