### PR TITLE
CodeNodeId is used by some but not all Protocol members

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -13,7 +13,6 @@ import           Ouroboros.Consensus.Node.ProtocolInfo.Mock.BFT as X
 import           Ouroboros.Consensus.Node.ProtocolInfo.Mock.PBFT as X
 import           Ouroboros.Consensus.Node.ProtocolInfo.Mock.Praos as X
 import           Ouroboros.Consensus.Node.ProtocolInfo.Mock.PraosRule as X
-import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol
 
 {-------------------------------------------------------------------------------
@@ -22,12 +21,11 @@ import           Ouroboros.Consensus.Protocol
 
 -- | Data required to run the selected protocol
 protocolInfo :: NumCoreNodes
-             -> CoreNodeId
              -> Protocol blk
              -> ProtocolInfo blk
-protocolInfo nodes nid demoProtocol = case demoProtocol of
-    ProtocolMockBFT        params               -> protocolInfoBft       nodes nid params
-    ProtocolMockPraos      params               -> protocolInfoPraos     nodes nid params
-    ProtocolLeaderSchedule params schedule      -> protocolInfoPraosRule nodes nid params schedule
-    ProtocolMockPBFT       params               -> protocolInfoMockPBFT  nodes nid params
+protocolInfo nodes demoProtocol = case demoProtocol of
+    ProtocolMockBFT        nid params           -> protocolInfoBft       nodes nid params
+    ProtocolMockPraos      nid params           -> protocolInfoPraos     nodes nid params
+    ProtocolLeaderSchedule nid params schedule  -> protocolInfoPraosRule nodes nid params schedule
+    ProtocolMockPBFT       nid params           -> protocolInfoMockPBFT  nodes nid params
     ProtocolRealPBFT       gc mthr prv swv mplc -> protocolInfoByron     gc mthr prv swv mplc

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
@@ -25,6 +25,7 @@ import           Ouroboros.Consensus.Node.ProtocolInfo.Byron
 import           Ouroboros.Consensus.Node.ProtocolInfo.Mock.PBFT ()
 import           Ouroboros.Consensus.Node.ProtocolInfo.Mock.Praos ()
 import           Ouroboros.Consensus.Node.Run
+import           Ouroboros.Consensus.NodeId (CoreNodeId)
 import           Ouroboros.Consensus.Protocol.Abstract as X
 import           Ouroboros.Consensus.Protocol.BFT as X
 import           Ouroboros.Consensus.Protocol.LeaderSchedule as X
@@ -50,23 +51,27 @@ type ProtocolRealPBFT       = PBft ByronConfig PBftCardanoCrypto
 data Protocol blk where
   -- | Run BFT against the mock ledger
   ProtocolMockBFT
-    :: SecurityParam
+    :: CoreNodeId
+    -> SecurityParam
     -> Protocol (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
 
   -- | Run Praos against the mock ledger
   ProtocolMockPraos
-    :: PraosParams
+    :: CoreNodeId
+    -> PraosParams
     -> Protocol (SimplePraosBlock SimpleMockCrypto PraosMockCrypto)
 
   -- | Run Praos against the mock ledger but with an explicit leader schedule
   ProtocolLeaderSchedule
-    :: PraosParams
+    :: CoreNodeId
+    -> PraosParams
     -> LeaderSchedule
     -> Protocol (SimplePraosRuleBlock SimpleMockCrypto)
 
   -- | Run PBFT against the mock ledger
   ProtocolMockPBFT
-    :: PBftParams
+    :: CoreNodeId
+    -> PBftParams
     -> Protocol (SimplePBftBlock SimpleMockCrypto PBftMockCrypto)
 
   -- | Run PBFT against the real ledger

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -38,5 +38,5 @@ prop_simple_bft_convergence k
   where
     testOutput =
         runTestNetwork
-            (\nid -> protocolInfo numCoreNodes nid (ProtocolMockBFT k))
+            (\nid -> protocolInfo numCoreNodes (ProtocolMockBFT nid k))
             testConfig seed

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -78,8 +78,8 @@ prop_simple_leader_schedule_convergence
   where
     testOutput@TestOutput{testOutputNodes} =
         runTestNetwork
-            (\nid -> protocolInfo numCoreNodes nid
-                 (ProtocolLeaderSchedule params schedule))
+            (\nid -> protocolInfo numCoreNodes
+                 (ProtocolLeaderSchedule nid params schedule))
             testConfig seed
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
@@ -44,5 +44,5 @@ prop_simple_pbft_convergence
 
     testOutput =
         runTestNetwork
-            (\nid -> protocolInfo numCoreNodes nid (ProtocolMockPBFT params))
+            (\nid -> protocolInfo numCoreNodes (ProtocolMockPBFT nid params))
             testConfig seed

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -94,5 +94,5 @@ prop_simple_praos_convergence
   where
     testOutput@TestOutput{testOutputNodes} =
         runTestNetwork
-            (\nid -> protocolInfo numCoreNodes nid (ProtocolMockPraos params))
+            (\nid -> protocolInfo numCoreNodes (ProtocolMockPraos nid params))
             testConfig seed

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
@@ -109,7 +109,7 @@ prop_simple_real_pbft_convergence
 
     testOutput =
         runTestNetwork
-            (\nid -> protocolInfo numCoreNodes nid
+            (\nid -> protocolInfo numCoreNodes
                 (mkProtocolRealPBFT numCoreNodes nid
                                     genesisConfig genesisSecrets))
             testConfig seed

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -26,7 +26,6 @@ import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
                      PBftSignatureThreshold (..), ProtocolInfo (..),
                      protocolInfo)
 import           Ouroboros.Consensus.Node.Run (RunNode (..))
-import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol
 import           Ouroboros.Consensus.Util.IOLike
 
@@ -86,7 +85,7 @@ withImmDB k = do
       }
 
 testCfg :: NodeConfig (BlockProtocol ByronBlockOrEBB)
-testCfg = pInfoConfig $ protocolInfo (NumCoreNodes 1) (CoreNodeId 0) prot
+testCfg = pInfoConfig $ protocolInfo (NumCoreNodes 1) prot
   where
     prot = ProtocolRealPBFT
       Dummy.dummyConfig


### PR DESCRIPTION
Change so that instead of `protocolInfo`taking the `CodeNodeId` as an agument for all protocols, the specific Protocol constructors that need one have one.

In particular RealPBFT does not need the `CodeNodeId` as an argument, and in the end the real Praos will not need it either.

This will help clarify the information dependencies in the node top level, so that the node id config or cli argument is clearly only used for the protocols that need it, and in particular not `--real-pbft`.

This will need a small update for the node, to only use the node id when constructing the protocol params, and not to require it for the real PBFT case.