### PR TITLE
ntp-client tests

### DIFF
--- a/nix/.stack.nix/ntp-client.nix
+++ b/nix/.stack.nix/ntp-client.nix
@@ -47,5 +47,18 @@
             ];
           };
         };
+      tests = {
+        "ntp-client-test" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.binary)
+            (hsPkgs.time)
+            (hsPkgs.time-units)
+            (hsPkgs.QuickCheck)
+            (hsPkgs.tasty)
+            (hsPkgs.tasty-quickcheck)
+            ];
+          };
+        };
       };
     } // rec { src = (pkgs.lib).mkDefault ../../././ntp-client; }

--- a/ntp-client/ntp-client.cabal
+++ b/ntp-client/ntp-client.cabal
@@ -37,7 +37,7 @@ Library
 
 -- Just for testing: to be removed later.
 Executable ntp-app
-  hs-source-dirs:       src, test
+  hs-source-dirs:       test, src
   main-is:              NtpApp.hs
   default-language:     Haskell2010
   ghc-options:          -Wall -Werror -fwarn-redundant-constraints
@@ -57,38 +57,24 @@ Executable ntp-app
                       , time
                       , time-units
                         
--- test-suite cardano-ntp-test
---  main-is:             Test.hs
---  other-modules:       Spec
---                       Test.NtpSpec
---  type:                exitcode-stdio-1.0
---  build-depends:       async
---                     , base >= 4.8 && < 5
---                     , binary
---                     , bytestring >= 0.10.8
---                     , cardano-sl-networking
---                     , cardano-sl-util
---                     , containers >= 0.5.7
---                     , hspec >= 2.1.10
---                     , hspec-core
---                     , lens >= 4.14
---                     , mtl >= 2.2.1
---                     , network-transport
---                     , network-transport-tcp
---                     , network-transport-inmemory
---                     , QuickCheck
---                     , random
---                     , serokell-util >= 0.1.2.3
---                     , stm
---                     , time-units
---  build-tool-depends: hspec-discover:hspec-discover
---  hs-source-dirs:      test
---  default-language:    Haskell2010
---  ghc-options:         -threaded
---                       -rtsopts
---                       -Wall
---                       -with-rtsopts=-N
---  default-extensions:  OverloadedStrings
---                     , DeriveDataTypeable
---                     , GeneralizedNewtypeDeriving
---                     , MonadFailDesugaring
+test-suite ntp-client-test
+  hs-source-dirs:     test, src
+  main-is:            Test.hs
+  type:               exitcode-stdio-1.0
+  other-modules:      Network.NTP.Packet
+  build-depends:        base
+                      , binary >= 0.8
+                      , time
+                      , time-units
+                      , QuickCheck
+                      , tasty
+                      , tasty-quickcheck
+  default-language:   Haskell2010
+  ghc-options:        -threaded
+                      -rtsopts
+                      -Wall
+                      -with-rtsopts=-N
+  default-extensions:  OverloadedStrings
+                     , DeriveDataTypeable
+                     , GeneralizedNewtypeDeriving
+                     , MonadFailDesugaring

--- a/ntp-client/test/Test.hs
+++ b/ntp-client/test/Test.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main
+    ( main
+    ) where
+
+import           Data.Binary (decodeOrFail, encode)
+import           Data.Time.Units (Microsecond, fromMicroseconds, toMicroseconds)
+import           Data.Word (Word32)
+
+import           Test.Tasty (TestTree, defaultMain, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+import           Test.QuickCheck (Arbitrary (..), Gen, Property, NonNegative(..) , arbitrary, choose, counterexample, sized, (.&&.), (===))
+
+import           Network.NTP.Packet (NtpOffset (..), NtpPacket (..), clockOffsetPure,
+                     ntpToRealMcs, realMcsToNtp)
+
+main :: IO ()
+main = defaultMain tests
+
+data NtpPacketWithOffset = NtpPacketWithOffset
+    { npoNtpPacket       :: NtpPacket
+    , npoOffset          :: NtpOffset
+    , npoDestinationTime :: Microsecond
+    }
+    deriving (Show)
+
+genMicro :: Gen Microsecond
+genMicro = fromMicroseconds <$> arbitrary
+
+genMicroNotBefore :: Microsecond -> Gen Microsecond
+genMicroNotBefore t = do
+    (NonNegative offset) <- arbitrary
+    return $ fromMicroseconds $ toMicroseconds t + offset
+
+
+newtype ArbitraryNtpPacket = ArbitraryNtpPacket NtpPacket
+    deriving (Show, Eq)
+
+instance Arbitrary ArbitraryNtpPacket where
+    arbitrary = do
+        ntpParams <- arbitrary
+        ntpPoll <- arbitrary
+        ntpOriginTime <- genMicro
+        ntpReceivedTime <- genMicroNotBefore ntpOriginTime
+        ntpTransmitTime <- genMicroNotBefore ntpReceivedTime
+        return $ ArbitraryNtpPacket $ NtpPacket {..}
+
+-- An arbitrary instance which generates a packet with a given offset, with
+-- ideal symmetric trip time.
+-- TODO: This use of `sized` looks strange.
+
+instance Arbitrary NtpPacketWithOffset where
+    arbitrary = sized $ \offset -> do
+        let drift :: Microsecond
+            drift = fromMicroseconds $ fromIntegral offset
+        ntpParams <- arbitrary
+        ntpPoll <- arbitrary
+        ntpOriginTime <- genMicro
+        tripTime <- genMicro
+        let ntpReceivedTime = ntpOriginTime + tripTime + drift
+        ntpTransmitTime <- genMicroNotBefore ntpReceivedTime
+        let npoDestinationTime = ntpTransmitTime + tripTime - drift
+        return $ NtpPacketWithOffset
+            { npoNtpPacket = NtpPacket {..}
+            , npoOffset = NtpOffset drift
+            , npoDestinationTime = npoDestinationTime
+            }
+
+data NtpTime = NtpTime Word32 Word32
+    deriving Show
+
+-- Generate arbitrary pairs of @'Word32'@.  The ntp fractions correspond to 232
+-- picoseconds (so 1msc correspond to @1000000 `div` 232 = 4310@).  Since we
+-- operate with micorseconds we generated them only up this resolution.
+instance Arbitrary NtpTime where
+    arbitrary = do
+        sec <- arbitrary
+        frac <- choose (1, (maxBound @Word32 `div` 1000000) * 232 -1)
+        return $ NtpTime sec $ frac * (1000000 `div` 232) - 1
+
+newtype NtpMicrosecond = NtpMicrosecond Microsecond
+    deriving Show
+
+-- Generate NtpMicrosecond which must be smaller than
+-- @'maxBound' \@Word32 - 2200898800@ (we substract 70 years in seconds).
+instance Arbitrary NtpMicrosecond where
+    arbitrary = (NtpMicrosecond . fromMicroseconds) <$> choose (0, endTime)
+       where endTime = (fromIntegral $ maxBound @Word32) - 2208988800
+
+tests:: TestTree
+tests =
+    testGroup "NTP packets"
+    [ testProperty "clockOffsetPure returns clock the offset"         prop_clockOffetPure
+    , testProperty "realMcsToNtp is the right nverse of ntpToRealMcs" prop_timeConvert1
+    , testProperty "realMcsToNtp is the left inverse of ntpToRealMcs" prop_timeConvert2
+    , testProperty "NtpPacket serialize-deserialze round-trip"        prop_NtpPacket_codec
+    ]
+
+prop_clockOffetPure :: NtpPacketWithOffset -> Property
+prop_clockOffetPure (NtpPacketWithOffset {..})
+    = npoOffset === clockOffsetPure npoNtpPacket npoDestinationTime
+
+prop_timeConvert1 :: NtpMicrosecond -> Property
+prop_timeConvert1 (NtpMicrosecond x)
+    = x === uncurry ntpToRealMcs (realMcsToNtp x)
+
+prop_timeConvert2 :: NtpTime -> Property
+prop_timeConvert2 (NtpTime sec frac)
+-- Each npt fraction unit correspond to 232 picoseconds, there are 4310 of them in a millisecond.
+    = let (sec', frac') = realMcsToNtp $ ntpToRealMcs sec frac
+      in sec === sec' .&&. frac `div` 4310 === frac' `div` 4310
+
+prop_NtpPacket_codec :: ArbitraryNtpPacket -> Property
+prop_NtpPacket_codec (ArbitraryNtpPacket ntpPacket)
+    = case decodeOrFail $ encode ntpPacket of
+        Left (_, _, err)     -> counterexample (show ntpPacket ++ " " ++ show err) False
+        Right (_, _, packet) -> ntpPacket === packet


### PR DESCRIPTION
Recover the old test cases for the cardano-sl repo.
Some changes where done:
* Replace `hspec` with `tasty`.
* Remove the use of `suchThat`.
* One use of `sized` was a little strange (comment added).
* Some small changes.
* run `./nix/regenerate.sh`
Not changed:
* There are many Magic constants in the generators
* Many of the tests are cover functions that will not be needed later.