### PR TITLE
Add draft protocols LocalStateQuery and LocalTxMonitor

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -82,6 +82,8 @@ library
                        Ouroboros.Network.Protocol.Handshake.Type
                        Ouroboros.Network.Protocol.Handshake.Codec
                        Ouroboros.Network.Protocol.Handshake.Version
+                       Ouroboros.Network.Protocol.LocalStateQuery.Type
+                       Ouroboros.Network.Protocol.LocalTxMonitor.Type
                        Ouroboros.Network.Protocol.TxSubmission.Type
                        Ouroboros.Network.Protocol.TxSubmission.Client
                        Ouroboros.Network.Protocol.TxSubmission.Server

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Type.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE EmptyCase          #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE PolyKinds          #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies       #-}
+
+-- | The type of the local ledger state query protocol.
+--
+-- This is used by local clients (like wallets and CLI tools) to query the
+-- ledger state of a local node.
+--
+module Ouroboros.Network.Protocol.LocalStateQuery.Type where
+
+
+import Network.TypedProtocol.Core
+import Ouroboros.Network.Block (Point, StandardHash)
+
+
+-- | The kind of the local state query protocol, and the types of
+-- the states in the protocol state machine.
+--
+-- It is parametrised over the type of header (for points), the type of queries
+-- and query results.
+--
+data LocalStateQuery header query result where
+
+  -- | The client has agency. It can ask to acquire a state or terminate.
+  --
+  -- There is no timeout in this state.
+  --
+  StIdle :: LocalStateQuery header query result
+
+  -- | The server has agency. it must acquire the state at the requested point
+  -- or report a failure.
+  --
+  -- There is a timeout in this state.
+  --
+  StAcquiring :: LocalStateQuery header query result
+
+  -- | The client has agency. It can request queries against the current state,
+  -- or it can release the state.
+  --
+  StAcquired :: LocalStateQuery header query result
+
+  -- | The server has agency. It must respond with the query result.
+  --
+  StQuerying :: LocalStateQuery header query result
+
+  -- | Nobody has agency. The terminal state.
+  --
+  StDone   :: LocalStateQuery header query result
+
+
+instance Protocol (LocalStateQuery header query result) where
+
+  -- | The messages in the state query protocol.
+  --
+  -- The pattern of use is to 
+  --
+  data Message (LocalStateQuery header query result) from to where
+
+    -- | The client requests that the state as of a particular recent point on
+    -- the server's chain (within K of the tip) be made available to query,
+    -- and waits for confirmation or failure.
+    --
+    MsgAcquire
+      :: Point header
+      -> Message (LocalStateQuery header query result) StIdle StAcquiring
+
+    -- | The server can confirm that it has the state at the requested point.
+    --
+    MsgAcquired
+      :: Message (LocalStateQuery header query result) StAcquiring StAcquired
+
+    -- | The server can report that it cannot obtain the state for the
+    -- requested point.
+    --
+    MsgFailure
+      :: AcquireFailure
+      -> Message (LocalStateQuery header query result) StAcquiring StIdle
+
+    -- | The client can perform queries on the current acquired state.
+    --
+    MsgQuery
+      :: query
+      -> Message (LocalStateQuery header query result) StAcquired StQuerying
+
+    -- | The server must reply with the query results.
+    --
+    MsgResult
+      :: result
+      -> Message (LocalStateQuery header query result) StQuerying StAcquired
+
+    -- | The client can instruct the server to release the state. This lets
+    -- the server free resources.
+    --
+    MsgRelease
+      :: Message (LocalStateQuery header query result) StAcquired StIdle
+
+    -- | This is like 'MsgAcquire' but for when the client already has a
+    -- state. By moveing to another state directly without a 'MsgRelease' it
+    -- enables optimisations on the server side (e.g. moving to the state for
+    -- the immediate next block).
+    --
+    -- Note that failure to re-acquire is equivalent to 'MsgRelease',
+    -- rather than keeping the exiting acquired state.
+    --
+    MsgReAcquire
+      :: Point header
+      -> Message (LocalStateQuery header query result) StAcquired StAcquiring
+
+    -- | The client can terminate the protocol.
+    --
+    MsgDone
+      :: Message (LocalStateQuery header query result) StIdle StDone
+
+
+  data ClientHasAgency st where
+    TokIdle      :: ClientHasAgency StIdle
+    TokAcquired  :: ClientHasAgency StAcquired
+
+  data ServerHasAgency st where
+    TokAcquiring  :: ServerHasAgency StAcquiring
+    TokQuerying   :: ServerHasAgency StQuerying
+
+  data NobodyHasAgency st where
+    TokDone  :: NobodyHasAgency StDone
+
+  exclusionLemma_ClientAndServerHaveAgency TokIdle     tok = case tok of {}
+  exclusionLemma_ClientAndServerHaveAgency TokAcquired tok = case tok of {}
+
+  exclusionLemma_NobodyAndClientHaveAgency TokDone tok = case tok of {}
+
+  exclusionLemma_NobodyAndServerHaveAgency TokDone tok = case tok of {}
+
+
+data AcquireFailure = AcquireFailurePointTooOld
+                    | AcquireFailurePointNotOnChain
+  deriving (Eq, Enum, Show)
+
+deriving instance (StandardHash header, Show query, Show result) =>
+                   Show (Message (LocalStateQuery header query result) from to)
+
+instance Show (ClientHasAgency (st :: LocalStateQuery header query result)) where
+  show TokIdle     = "TokIdle"
+  show TokAcquired = "TokAcquired"
+
+instance Show (ServerHasAgency (st :: LocalStateQuery header query result)) where
+  show TokAcquiring = "TokAcquiring"
+  show TokQuerying  = "TokQuerying"

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxMonitor/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxMonitor/Type.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE EmptyCase          #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE PolyKinds          #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies       #-}
+
+-- | The type of the local transaction monitoring protocol.
+--
+-- This is used by local clients (like wallets, explorers and CLI tools) to
+-- monitor the transactions passing through the mempool of a local node.
+--
+module Ouroboros.Network.Protocol.LocalTxMonitor.Type where
+
+
+import           Network.TypedProtocol.Core
+
+
+-- | The kind of the local transaction monitoring protocol, and the types of
+-- the states in the protocol state machine.
+--
+-- It is parametrised over the type of transactions.
+--
+data LocalTxMonitor tx where
+
+  -- | The client has agency; it can request a transaction or terminate.
+  --
+  -- There is no timeout in this state.
+  --
+  StIdle   :: LocalTxMonitor tx
+
+  -- | The server has agency; it must (eventually) return the next transaction
+  -- that has not yet been sent to the client.
+  --
+  -- There is no timeout in this state.
+  --
+  StBusy   :: LocalTxMonitor tx
+
+  -- | Nobody has agency. The terminal state.
+  --
+  StDone   :: LocalTxMonitor tx
+
+
+instance Protocol (LocalTxMonitor tx) where
+
+  -- | The messages in the transaction monitoring protocol.
+  --
+  -- There is no guarantee or requirement that every transaction that enters
+  -- the mempool be sent, it need only be in the mempool at the time. So this
+  -- protocol can be used to monitor what is in the mempool but it cannot
+  -- guarantee to return everything that ever passed though the mempool. In
+  -- particular if the client is too slow then txs can be removed from the
+  -- mempool before the client requests them. This is reasonable semantics
+  -- since it is observationally equivalent to what can happen anyway: we can
+  -- \"miss\" a transaction even before the transaction makes it into the
+  -- node's mempool (since it can be removed from the mempool of a peer and
+  -- then not forwarded).
+  --
+  data Message (LocalTxMonitor tx) from to where
+
+    -- | The client requests a single transaction and waits a reply.
+    --
+    -- There is no timeout.
+    --
+    MsgRequestTx
+      :: Message (LocalTxMonitor tx) StIdle StBusy
+
+    -- | The server responds with a single transaction. This must be a
+    -- transaction that was not previously sent to the client.
+    --
+    -- There is no timeout. This can take an arbitrarily long time.
+    --
+    MsgReplyTx
+      :: tx
+      -> Message (LocalTxMonitor tx) StBusy StIdle
+
+    -- | The client can terminate the protocol.
+    --
+    MsgDone
+      :: Message (LocalTxMonitor tx) StIdle StDone
+
+
+  data ClientHasAgency st where
+    TokIdle  :: ClientHasAgency StIdle
+
+  data ServerHasAgency st where
+    TokBusy  :: ServerHasAgency StBusy
+
+  data NobodyHasAgency st where
+    TokDone  :: NobodyHasAgency StDone
+
+  exclusionLemma_ClientAndServerHaveAgency TokIdle tok = case tok of {}
+
+  exclusionLemma_NobodyAndClientHaveAgency TokDone tok = case tok of {}
+
+  exclusionLemma_NobodyAndServerHaveAgency TokDone tok = case tok of {}
+
+
+deriving instance Show tx => Show (Message (LocalTxMonitor tx) from to)
+
+instance Show (ClientHasAgency (st :: LocalTxMonitor tx)) where
+  show TokIdle = "TokIdle"
+
+instance Show (ServerHasAgency (st :: LocalTxMonitor tx)) where
+  show TokBusy = "TokBusy"


### PR DESCRIPTION
The LocalTxMonitor is for local client to see what transactions are flowing through the node's mempool. It's a simplified version of the transaction submission protocol.

The LocalStateQuery is for local clients to query the ledger state of the node. They can ask for the state at particular points in recent history, and then run one or more queries against that state. Unlike
queries against the volatile "current" state, this gives consistent results because we can grab an immutable state snapshot and run multiple queries against that.