### PR TITLE
Decouple PBFT from NodeConfig

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
@@ -60,7 +60,7 @@ instance HeaderSupportsPBft ByronConfig PBftCardanoCrypto (Header ByronBlock) wh
           , CC.recoverSignedBytes epochSlots hdr
           )
     where
-      epochSlots = pbftEpochSlots $ pbftExtConfig cfg
+      epochSlots = pbftEpochSlots cfg
 
 instance SupportedBlock ByronBlock
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/BFT.hs
@@ -70,7 +70,7 @@ _simpleBFtHeader = simpleHeader
 instance SignedHeader (SimpleBftHeader c c') where
   type Signed (SimpleBftHeader c c') = SignedSimpleBft c c'
 
-  headerSigned _ = SignedSimpleBft . simpleHeaderStd
+  headerSigned = SignedSimpleBft . simpleHeaderStd
 
 instance ( SimpleCrypto c
          , BftCrypto c'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
@@ -77,7 +77,7 @@ _simplePBftHeader = simpleHeader
 instance SignedHeader (SimplePBftHeader c c') where
   type Signed (SimplePBftHeader c c') = SignedSimplePBft c c'
 
-  headerSigned _ = SignedSimplePBft . simpleHeaderStd
+  headerSigned = SignedSimplePBft . simpleHeaderStd
 
 instance ( SimpleCrypto c
          , Signable MockDSIGN (SignedSimplePBft c PBftMockCrypto)
@@ -89,7 +89,7 @@ instance ( SimpleCrypto c
           Signed (SimplePBftHeader c PBftMockCrypto)
   headerPBftFields cfg hdr = Just (
         simplePBftExt (simpleHeaderExt hdr)
-      , headerSigned cfg hdr
+      , headerSigned hdr
       )
 
 instance ( SimpleCrypto c

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
@@ -87,7 +87,7 @@ instance ( SimpleCrypto c
                 (SimplePBftHeader c PBftMockCrypto) where
   type OptSigned (SimplePBftHeader c PBftMockCrypto) =
           Signed (SimplePBftHeader c PBftMockCrypto)
-  headerPBftFields cfg hdr = Just (
+  headerPBftFields _ hdr = Just (
         simplePBftExt (simpleHeaderExt hdr)
       , headerSigned hdr
       )

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/Praos.hs
@@ -79,7 +79,7 @@ _simplePraosHeader = simpleHeader
 instance PraosCrypto c' => SignedHeader (SimplePraosHeader c c') where
   type Signed (SimplePraosHeader c c') = SignedSimplePraos c c'
 
-  headerSigned _ SimpleHeader{..} = SignedSimplePraos {
+  headerSigned SimpleHeader{..} = SignedSimplePraos {
         signedSimplePraos = simpleHeaderStd
       , signedPraosFields = praosExtraFields (simplePraosExt simpleHeaderExt)
       }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -142,7 +142,7 @@ instance BftCrypto c => OuroborosTag (Bft c) where
       case verifySignedDSIGN
            ()
            (bftVerKeys Map.! expectedLeader)
-           (headerSigned cfg b)
+           (headerSigned b)
            bftSignature of
         Right () -> return ()
         Left err -> throwError $ BftInvalidSignature err

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -251,7 +251,7 @@ instance ( PraosCrypto c
   applyChainState cfg@PraosNodeConfig{..} sd b cs = do
     let PraosFields{..}      = headerPraosFields cfg b
         PraosExtraFields{..} = praosExtraFields
-        toSign               = headerSigned cfg b
+        toSign               = headerSigned b
         slot                 = blockSlot b
         CoreNodeId nid       = praosCreator
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Signed.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Signed.hs
@@ -5,9 +5,6 @@ module Ouroboros.Consensus.Protocol.Signed (
     SignedHeader(..)
   ) where
 
-import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Protocol.Abstract
-
 -- | Header that contain a signed part
 --
 -- This class enforces that signatures are computed over the header only
@@ -20,4 +17,4 @@ class SignedHeader hdr where
   type family Signed hdr :: *
 
   -- | Extract the part of the header that the signature should be computed over
-  headerSigned :: NodeConfig (BlockProtocol hdr) -> hdr -> Signed hdr
+  headerSigned :: hdr -> Signed hdr

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -245,7 +245,7 @@ type instance BlockProtocol TestBlock = Bft BftMockCrypto
 
 instance SignedHeader (Header TestBlock) where
   type Signed (Header TestBlock) = ()
-  headerSigned _ _ = ()
+  headerSigned _ = ()
 
 instance HeaderSupportsBft BftMockCrypto (Header TestBlock) where
   headerBftFields cfg hdr = BftFields {

--- a/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
@@ -211,7 +211,7 @@ type instance BlockProtocol TestBlock = Bft BftMockCrypto
 
 instance SignedHeader (Header TestBlock) where
   type Signed (Header TestBlock) = ()
-  headerSigned _ _ = ()
+  headerSigned _ = ()
 
 instance HeaderSupportsBft BftMockCrypto (Header TestBlock) where
   headerBftFields cfg (TestHeader tb) = BftFields {


### PR DESCRIPTION
This gives us a bit more freedom in chain selection.

This is really just two changes:

```haskell
class ( HasHeader hdr
      , Signable (PBftDSIGN c) (OptSigned hdr)
      , BlockProtocol hdr ~ PBft cfg c
      ) => HeaderSupportsPBft cfg c hdr where
  type family OptSigned hdr :: *
-  headerPBftFields :: NodeConfig (PBft cfg c)
-                   -> hdr -> Maybe (PBftFields c (OptSigned hdr), OptSigned hdr)
+  headerPBftFields :: cfg
+                   -> hdr
+                   -> Maybe (PBftFields c (OptSigned hdr), OptSigned hdr)
```

and

```haskell
class ConstructContextDSIGN cfg c where
-  constructContextDSIGN :: NodeConfig (PBft cfg c)
+  constructContextDSIGN :: proxy (PBft cfg c)
                        -> cfg
                        -> VerKeyDSIGN (PBftDSIGN c)
                        -> ContextDSIGN (PBftDSIGN c)
```

The rest is just dealing with the (mostly trivial) fallout.