### PR TITLE
Add parallel tests

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -212,3 +212,17 @@ source-repository-package
   location: https://github.com/input-output-hk/cardano-crypto/
   tag: 3c707936ba0a665375acf5bd240dc4b6eaa6c0bc
   --sha256: 0g8ln8k8wx4csdv92bz09pr7v9dp4lcyv1334b09c9rgwdwhqg1b
+
+source-repository-package
+  type: git
+  location: https://github.com/advancedtelematic/quickcheck-state-machine
+  tag: 41718e9b17e3151178ce27600f84ca1d9d852c65
+
+package contra-tracer
+  tests: False
+
+constraints:
+  ip < 1.5,
+  hedgehog >= 1.0,
+  bimap >= 0.4.0,
+  primitive < 0.7

--- a/ntp-client/ntp-client.cabal
+++ b/ntp-client/ntp-client.cabal
@@ -21,7 +21,9 @@ Library
                       , contra-tracer   >=0.1 && <0.2
                       , network         >= 3.1 && <3.2
                       , stm             >=2.4 && <2.6
+                      , these >= 0.8
                       , time            >=1.6 && <1.10
+                      , time-units
 
   hs-source-dirs:       src
   default-language:     Haskell2010

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -532,7 +532,7 @@ precondition (Model mock hs) (At c) =
     checkRef r =
         case lookup r hs of
           Nothing -> Bot
-          Just r' -> r' `elem` mockLiveThreads (threads mock)
+          Just r' -> r' `member` mockLiveThreads (threads mock)
 
 postcondition :: (IOLike m)
               => Model m      Concrete
@@ -563,10 +563,10 @@ sm alive reg = StateMachine {
     , postcondition = postcondition
     , invariant     = Nothing
     , generator     = generator
-    , distribution  = Nothing
     , shrinker      = shrinker
     , semantics     = semantics alive reg
     , mock          = symbolicResp
+    , cleanup       = noCleanup
     }
 
 prop_sequential :: QC.Property

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -860,8 +860,8 @@ mock model cmd = At <$> bitraverse (const genSym) (const genSym) resp
 precondition :: forall m blk. TestConstraints blk
              => Model blk m Symbolic -> At Cmd blk m Symbolic -> Logic
 precondition Model {..} (At cmd) =
-   forall (iters cmd) (`elem` RE.keys knownIters)   .&&
-   forall (rdrs  cmd) (`elem` RE.keys knownReaders) .&&
+   forall (iters cmd) (`member` RE.keys knownIters)   .&&
+   forall (rdrs  cmd) (`member` RE.keys knownReaders) .&&
    case cmd of
      -- Even though we ensure this in the generator, shrinking might change
      -- it.
@@ -1000,7 +1000,7 @@ sm db internal registry varCurSlot varNextId genBlock env initLedger = StateMach
   , semantics     = semantics db internal registry varCurSlot varNextId
   , mock          = mock
   , invariant     = Nothing
-  , distribution  = Nothing
+  , cleanup       = noCleanup
   }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
@@ -654,7 +654,7 @@ mock model cmd = At <$> bitraverse (const QSM.genSym) (const QSM.genSym) resp
 
 precondition :: Model Symbolic -> Cmd :@ Symbolic -> QSM.Logic
 precondition m@Model{..} (At cmd) =
-            QSM.forall (handles cmd) (`QSM.elem` RE.keys knownHandles)
+            QSM.forall (handles cmd) (`QSM.member` RE.keys knownHandles)
     QSM.:&& QSM.Boolean (Mock.numOpenHandles mockFS < maxNumOpenHandles)
     QSM.:&& QSM.Not (knownLimitation m (At cmd))
   where
@@ -698,7 +698,7 @@ sm mount = QSM.StateMachine {
              , semantics     = semantics mount
              , mock          = mock
              , invariant     = Nothing
-             , distribution  = Nothing
+             , cleanup       = QSM.noCleanup
              }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -51,7 +51,8 @@ import           Text.Show.Pretty (ppShow)
 import           Test.QuickCheck
 import qualified Test.QuickCheck.Monadic as QC
 import           Test.QuickCheck.Random (mkQCGen)
-import           Test.StateMachine
+import           Test.StateMachine hiding (showLabelledExamples,
+                     showLabelledExamples')
 import qualified Test.StateMachine.Sequential as QSM
 import qualified Test.StateMachine.Types as QSM
 import qualified Test.StateMachine.Types.Rank2 as Rank2
@@ -724,15 +725,15 @@ mock model cmdErr = At <$> traverse (const genSym) resp
 
 precondition :: Model m Symbolic -> At CmdErr m Symbolic -> Logic
 precondition Model {..} (At (CmdErr { _cmd = cmd })) =
-   forall (iters cmd) (`elem` RE.keys knownIters) .&&
+   forall (iters cmd) (`member` RE.keys knownIters) .&&
     case cmd of
       AppendBlock    _ _ b -> fitsOnTip b
       AppendEBB      _ _ b -> fitsOnTip b
-      DeleteAfter tip      -> tip `elem` NE.toList (tips dbModel)
+      DeleteAfter tip      -> tip `member` NE.toList (tips dbModel)
       Corruption corr ->
         forall
           (corruptionFiles (getCorruptions corr))
-          (`elem` getDBFiles dbModel)
+          (`member` getDBFiles dbModel)
       ReopenInThePast _ curSlot ->
         0 .<= curSlot .&& curSlot .<= lastSlot
       _ -> Top
@@ -855,7 +856,7 @@ sm env dbm = StateMachine
   , semantics     = semantics env
   , mock          = mock
   , invariant     = Nothing
-  , distribution  = Nothing
+  , cleanup       = noCleanup
   }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -54,7 +54,7 @@ import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
 import qualified Test.QuickCheck.Monadic as QC
 import qualified Test.QuickCheck.Random as QC
-import           Test.StateMachine
+import           Test.StateMachine hiding (showLabelledExamples)
 import qualified Test.StateMachine.Types as QSM
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.Tasty (TestTree, testGroup)
@@ -934,7 +934,7 @@ postcondition m cmd r = toMock (eventAfter e) r .== eventMockResp e
 
 precondition :: LUT t => Model t Symbolic -> Cmd t :@ Symbolic -> Logic
 precondition (Model mock hs) (At c) =
-        forall (toList c) (`elem` map fst hs)
+        forall (toList c) (`member` map fst hs)
     .&& validCmd c
   where
     -- Maximum rollback might decrease if shrinking removed blocks
@@ -961,10 +961,10 @@ sm lgrDbParams db = StateMachine {
     , postcondition = postcondition
     , invariant     = Nothing
     , generator     = generator lgrDbParams
-    , distribution  = Nothing
     , shrinker      = shrinker
     , semantics     = semantics db
     , mock          = symbolicResp
+    , cleanup       = noCleanup
     }
 
 prop_sequential :: LUT t => Proxy t -> LedgerDbParams -> QC.Property

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -13,7 +13,7 @@
 
 module Test.Ouroboros.Storage.VolatileDB.StateMachine
     ( tests
-    , showLabelledExamples
+    , printLabelledExamples
     ) where
 
 import           Prelude hiding (elem)
@@ -288,7 +288,7 @@ sm env dbm = StateMachine {
     , semantics     = semanticsImpl env
     , mock          = mockImpl
     , invariant     = Nothing
-    , distribution  = Nothing
+    , cleanup       = noCleanup
     }
 
 initModelImpl :: DBModel BlockId -> Model r
@@ -301,7 +301,7 @@ preconditionImpl :: Model Symbolic -> At CmdErr Symbolic -> Logic
 preconditionImpl Model{..} (At (CmdErr cmd mbErrors)) =
     compatibleWithError .&& case cmd of
       Corruption cors ->
-        forall (corruptionFiles cors) (`elem` getDBFiles dbModel)
+        forall (corruptionFiles cors) (`member` getDBFiles dbModel)
 
       -- When duplicating a block by appending it to some other file, make
       -- sure that both the file and the block exists, and that we're adding
@@ -800,15 +800,15 @@ execCmds model (Commands cs) = go model cs
     go _ []        = []
     go m (c : css) = let ev = execCmd m c in ev : go (eventAfter ev) css
 
-showLabelledExamples :: IO ()
-showLabelledExamples = showLabelledExamples' Nothing 1000
+printLabelledExamples :: IO ()
+printLabelledExamples = printLabelledExamples' Nothing 1000
 
-showLabelledExamples' :: Maybe Int
+printLabelledExamples' :: Maybe Int
                       -- ^ Seed
                       -> Int
                       -- ^ Number of tests to run to find examples
                       -> IO ()
-showLabelledExamples' mReplay numTests = do
+printLabelledExamples' mReplay numTests = do
     replaySeed <- case mReplay of
         Nothing   -> getStdRandom (randomR (1,999999))
         Just seed -> return seed

--- a/stack.yaml
+++ b/stack.yaml
@@ -74,17 +74,28 @@ extra-deps:
       - .
       - test
 
+  - git: https://github.com/advancedtelematic/quickcheck-state-machine
+    commit: 41718e9b17e3151178ce27600f84ca1d9d852c65
+    subdirs:
+      - .
+
   - bimap-0.4.0
   - binary-0.8.7.0
   - generic-monoid-0.1.0.0
   - graphviz-2999.20.0.3
   - hedgehog-quickcheck-0.1.1
-  - quickcheck-state-machine-0.6.0
   - splitmix-0.0.2
   - tasty-hedgehog-1.0.0.1
   - Unique-0.4.7.6
   - statistics-linreg-0.3
+<<<<<<< HEAD
   - network-3.1.0.1
+=======
+  - these-0.8
+  - assoc-1
+  - QuickCheck-2.13.2@sha256:ad4e5adbd1c9dc0221a44307b992cb040c515f31095182e47aa7e974bc461df1,6952
+  - markov-chain-usage-model-0.0.0@sha256:1afa95faeb9213c4d960a669190078b41b89169462b8edd910472980671ba8c0,2112
+>>>>>>> Use newer qsm version
 
   # Windows only
   - Win32-2.6.2.0


### PR DESCRIPTION
Builds on top of https://github.com/input-output-hk/ouroboros-network/pull/1180
Addresses https://github.com/input-output-hk/ouroboros-network/issues/1188
This pr adds paralle qsm tests for the VolatileDB.
It doesn't use the MockFS like sequential tests, but the real filesystem.
Only the basic api is supported for now: no simulated errors or corruptions.