### PR TITLE
Split SupportedHeader into CanSelect/CanValidate

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
@@ -90,7 +90,8 @@ class ( GetHeader blk
       , HasHeader blk
       , HasHeader (Header blk)
       , OuroborosTag (BlockProtocol blk)
-      , SupportedHeader (BlockProtocol blk) (Header blk)
+      , CanValidate  (BlockProtocol blk) (Header blk)
+      , CanSelect    (BlockProtocol blk) (Header blk)
       , NoUnexpectedThunks (Header blk)
       ) => SupportedBlock blk
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -119,12 +119,13 @@ data instance NodeConfig (Bft c) = BftNodeConfig {
   deriving (Generic)
 
 instance BftCrypto c => OuroborosTag (Bft c) where
-  type ValidationErr   (Bft c) = BftValidationErr
-  type SupportedHeader (Bft c) = HeaderSupportsBft c
-  type NodeState       (Bft c) = ()
-  type LedgerView      (Bft c) = ()
-  type IsLeader        (Bft c) = ()
-  type ChainState      (Bft c) = ()
+  type ValidationErr (Bft c) = BftValidationErr
+  type CanValidate   (Bft c) = HeaderSupportsBft c
+  type CanSelect     (Bft c) = HasHeader
+  type NodeState     (Bft c) = ()
+  type LedgerView    (Bft c) = ()
+  type IsLeader      (Bft c) = ()
+  type ChainState    (Bft c) = ()
 
   protocolSecurityParam = bftSecurityParam . bftParams
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -58,7 +58,8 @@ instance OuroborosTag p => OuroborosTag (WithLeaderSchedule p) where
   type LedgerView      (WithLeaderSchedule p) = ()
   type ValidationErr   (WithLeaderSchedule p) = ()
   type IsLeader        (WithLeaderSchedule p) = ()
-  type SupportedHeader (WithLeaderSchedule p) = Empty
+  type CanValidate     (WithLeaderSchedule p) = Empty
+  type CanSelect       (WithLeaderSchedule p) = CanSelect p
 
   preferCandidate       WLSNodeConfig{..} = preferCandidate       lsNodeConfigP
   compareCandidates     WLSNodeConfig{..} = compareCandidates     lsNodeConfigP

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/MockChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/MockChainSel.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 module Ouroboros.Consensus.Protocol.MockChainSel where
 
@@ -30,7 +30,11 @@ import           Ouroboros.Network.MockChain.Chain hiding (selectChain)
 -- somehow fail if the selected chain turns out to be invalid.)
 --
 -- Returns 'Nothing' if we stick with our current chain.
-selectChain :: forall p hdr l. (OuroborosTag p, HasHeader hdr)
+selectChain :: forall p hdr l. (
+                 OuroborosTag p
+               , HasHeader hdr
+               , CanSelect p hdr
+               )
             => NodeConfig p
             -> Chain hdr           -- ^ Our chain
             -> [(Chain hdr, l)]    -- ^ Upstream chains
@@ -51,7 +55,11 @@ selectChain cfg ours' candidates' =
       = error "impossible: fragment was anchored at genesis"
 
 -- | Chain selection on unvalidated chains
-selectUnvalidatedChain :: forall p hdr. (OuroborosTag p, HasHeader hdr)
+selectUnvalidatedChain :: forall p hdr. (
+                            OuroborosTag p
+                          , HasHeader hdr
+                          , CanSelect p hdr
+                          )
                        => NodeConfig p
                        -> Chain hdr
                        -> [Chain hdr]

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -17,6 +17,7 @@ module Ouroboros.Consensus.Protocol.ModChainSel (
   , NodeConfig (..)
   ) where
 
+import           Data.Kind
 import           Data.Proxy (Proxy (..))
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
@@ -24,18 +25,19 @@ import           GHC.Generics (Generic)
 import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
-import           Ouroboros.Network.Block (HasHeader)
 
 import           Ouroboros.Consensus.Protocol.Abstract
 
 class OuroborosTag p => ChainSelection p s where
-  preferCandidate' :: HasHeader b
+  type family CanSelect' p :: * -> Constraint
+
+  preferCandidate' :: CanSelect' p b
                    => proxy s
                    -> NodeConfig p
                    -> AnchoredFragment b      -- ^ Our chain
                    -> AnchoredFragment b      -- ^ Candidate
                    -> Bool
-  compareCandidates' :: HasHeader b
+  compareCandidates' :: CanSelect' p b
                      => proxy s
                      -> NodeConfig p
                      -> AnchoredFragment b -> AnchoredFragment b -> Ordering
@@ -51,7 +53,8 @@ instance (Typeable p, Typeable s, ChainSelection p s) => OuroborosTag (ModChainS
     type IsLeader        (ModChainSel p s) = IsLeader        p
     type LedgerView      (ModChainSel p s) = LedgerView      p
     type ValidationErr   (ModChainSel p s) = ValidationErr   p
-    type SupportedHeader (ModChainSel p s) = SupportedHeader p
+    type CanValidate     (ModChainSel p s) = CanValidate     p
+    type CanSelect       (ModChainSel p s) = CanSelect'      p
 
     checkIsLeader         (McsNodeConfig cfg) = checkIsLeader         cfg
     applyChainState       (McsNodeConfig cfg) = applyChainState       cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -206,9 +206,10 @@ instance ( PBftCrypto c
          , ConstructContextDSIGN cfg c
          )
       => OuroborosTag (PBft cfg c) where
-  type ValidationErr   (PBft cfg c) = PBftValidationErr c
-  type SupportedHeader (PBft cfg c) = HeaderSupportsPBft cfg c
-  type NodeState       (PBft cfg c) = ()
+  type ValidationErr (PBft cfg c) = PBftValidationErr c
+  type CanValidate   (PBft cfg c) = HeaderSupportsPBft cfg c
+  type CanSelect     (PBft cfg c) = HasHeader
+  type NodeState     (PBft cfg c) = ()
 
   -- | We require two things from the ledger state:
   --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -225,12 +225,13 @@ instance ( PraosCrypto c
          ) => OuroborosTag (Praos cfg c) where
   protocolSecurityParam = praosSecurityParam . praosParams
 
-  type NodeState       (Praos cfg c) = PraosNodeState c
-  type LedgerView      (Praos cfg c) = StakeDist
-  type IsLeader        (Praos cfg c) = PraosProof c
-  type ValidationErr   (Praos cfg c) = PraosValidationError c
-  type SupportedHeader (Praos cfg c) = HeaderSupportsPraos cfg c
-  type ChainState      (Praos cfg c) = [BlockInfo c]
+  type NodeState     (Praos cfg c) = PraosNodeState c
+  type LedgerView    (Praos cfg c) = StakeDist
+  type IsLeader      (Praos cfg c) = PraosProof c
+  type ValidationErr (Praos cfg c) = PraosValidationError c
+  type CanValidate   (Praos cfg c) = HeaderSupportsPraos cfg c
+  type CanSelect     (Praos cfg c) = HasHeader
+  type ChainState    (Praos cfg c) = [BlockInfo c]
 
   checkIsLeader cfg@PraosNodeConfig{..} slot _u cs =
     case praosNodeId of

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -28,7 +28,11 @@ import           Ouroboros.Storage.ChainDB.API
 import           Test.Ouroboros.Storage.ChainDB.Model (Model)
 import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
 
-openDB :: forall m blk. (IOLike m, ProtocolLedgerView blk)
+openDB :: forall m blk. (
+            IOLike m
+          , ProtocolLedgerView blk
+          , CanSelect (BlockProtocol blk) blk
+          )
        => NodeConfig (BlockProtocol blk)
        -> ExtLedgerState blk
        -> m (ChainDB m blk)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -186,6 +186,7 @@ data Success blk it rdr
 type TestConstraints blk =
   ( OuroborosTag   (BlockProtocol blk)
   , ProtocolLedgerView            blk
+  , CanSelect (BlockProtocol blk) blk
   , Eq (ChainState (BlockProtocol blk))
   , Eq (LedgerState               blk)
   , Eq                            blk
@@ -725,7 +726,10 @@ precondition Model {..} (At cmd) =
         Left  _ -> Bot
         Right _ -> Top
 
-equallyPreferable :: (OuroborosTag (BlockProtocol blk), HasHeader blk)
+equallyPreferable :: ( OuroborosTag (BlockProtocol blk)
+                     , HasHeader blk
+                     , CanSelect (BlockProtocol blk) blk
+                     )
                   => NodeConfig (BlockProtocol blk)
                   -> Chain blk -> Chain blk -> Bool
 equallyPreferable cfg chain1 chain2 =


### PR DESCRIPTION
I _think_ this now clears the last hurdle for the hard fork combinator (at least as far as the protocol is concerned, haven't looked at ledger integration yet).