### PR TITLE
The NumCoreNodes param does not apply to all protocols

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -20,12 +20,18 @@ import           Ouroboros.Consensus.Protocol
 -------------------------------------------------------------------------------}
 
 -- | Data required to run the selected protocol
-protocolInfo :: NumCoreNodes
-             -> Protocol blk
-             -> ProtocolInfo blk
-protocolInfo nodes demoProtocol = case demoProtocol of
-    ProtocolMockBFT        nid params           -> protocolInfoBft       nodes nid params
-    ProtocolMockPraos      nid params           -> protocolInfoPraos     nodes nid params
-    ProtocolLeaderSchedule nid params schedule  -> protocolInfoPraosRule nodes nid params schedule
-    ProtocolMockPBFT       nid params           -> protocolInfoMockPBFT  nodes nid params
-    ProtocolRealPBFT       gc mthr prv swv mplc -> protocolInfoByron     gc mthr prv swv mplc
+protocolInfo :: Protocol blk -> ProtocolInfo blk
+protocolInfo (ProtocolMockBFT nodes nid params) =
+    protocolInfoBft nodes nid params
+
+protocolInfo (ProtocolMockPraos nodes nid params) =
+    protocolInfoPraos nodes nid params
+
+protocolInfo (ProtocolLeaderSchedule nodes nid params schedule) =
+    protocolInfoPraosRule nodes nid params schedule
+
+protocolInfo (ProtocolMockPBFT nodes nid params) =
+    protocolInfoMockPBFT nodes nid params
+
+protocolInfo (ProtocolRealPBFT gc mthr prv swv mplc) =
+    protocolInfoByron gc mthr prv swv mplc

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
@@ -20,6 +20,7 @@ import qualified Cardano.Chain.Update as Update
 
 import           Ouroboros.Consensus.Ledger.Byron
 import           Ouroboros.Consensus.Ledger.Mock
+import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract (NumCoreNodes)
 import           Ouroboros.Consensus.Node.ProtocolInfo.Byron
 import           Ouroboros.Consensus.Node.ProtocolInfo.Mock.PBFT ()
 import           Ouroboros.Consensus.Node.ProtocolInfo.Mock.Praos ()
@@ -50,26 +51,30 @@ type ProtocolRealPBFT       = PBft ByronConfig PBftCardanoCrypto
 data Protocol blk where
   -- | Run BFT against the mock ledger
   ProtocolMockBFT
-    :: CoreNodeId
+    :: NumCoreNodes
+    -> CoreNodeId
     -> SecurityParam
     -> Protocol (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
 
   -- | Run Praos against the mock ledger
   ProtocolMockPraos
-    :: CoreNodeId
+    :: NumCoreNodes
+    -> CoreNodeId
     -> PraosParams
     -> Protocol (SimplePraosBlock SimpleMockCrypto PraosMockCrypto)
 
   -- | Run Praos against the mock ledger but with an explicit leader schedule
   ProtocolLeaderSchedule
-    :: CoreNodeId
+    :: NumCoreNodes
+    -> CoreNodeId
     -> PraosParams
     -> LeaderSchedule
     -> Protocol (SimplePraosRuleBlock SimpleMockCrypto)
 
   -- | Run PBFT against the mock ledger
   ProtocolMockPBFT
-    :: CoreNodeId
+    :: NumCoreNodes
+    -> CoreNodeId
     -> PBftParams
     -> Protocol (SimplePBftBlock SimpleMockCrypto PBftMockCrypto)
 

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/BFT.hs
@@ -38,5 +38,5 @@ prop_simple_bft_convergence k
   where
     testOutput =
         runTestNetwork
-            (\nid -> protocolInfo numCoreNodes (ProtocolMockBFT nid k))
+            (\nid -> protocolInfo (ProtocolMockBFT numCoreNodes nid k))
             testConfig seed

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/LeaderSchedule.hs
@@ -78,8 +78,9 @@ prop_simple_leader_schedule_convergence
   where
     testOutput@TestOutput{testOutputNodes} =
         runTestNetwork
-            (\nid -> protocolInfo numCoreNodes
-                 (ProtocolLeaderSchedule nid params schedule))
+            (\nid -> protocolInfo
+                       (ProtocolLeaderSchedule numCoreNodes nid
+                                               params schedule))
             testConfig seed
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/PBFT.hs
@@ -44,5 +44,5 @@ prop_simple_pbft_convergence
 
     testOutput =
         runTestNetwork
-            (\nid -> protocolInfo numCoreNodes (ProtocolMockPBFT nid params))
+            (\nid -> protocolInfo (ProtocolMockPBFT numCoreNodes nid params))
             testConfig seed

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Praos.hs
@@ -94,5 +94,5 @@ prop_simple_praos_convergence
   where
     testOutput@TestOutput{testOutputNodes} =
         runTestNetwork
-            (\nid -> protocolInfo numCoreNodes (ProtocolMockPraos nid params))
+            (\nid -> protocolInfo (ProtocolMockPraos numCoreNodes nid params))
             testConfig seed

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
@@ -109,9 +109,9 @@ prop_simple_real_pbft_convergence
 
     testOutput =
         runTestNetwork
-            (\nid -> protocolInfo numCoreNodes
-                (mkProtocolRealPBFT numCoreNodes nid
-                                    genesisConfig genesisSecrets))
+            (\nid -> protocolInfo
+                       (mkProtocolRealPBFT numCoreNodes nid
+                                           genesisConfig genesisSecrets))
             testConfig seed
 
     finalChains :: [Chain ByronBlock]

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -22,8 +22,8 @@ import           Ouroboros.Network.Block (SlotNo (..), blockHash, blockPoint)
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.Ledger.Byron (ByronBlock)
 import           Ouroboros.Consensus.Ledger.Byron.Forge (forgeGenesisEBB)
-import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
-                     PBftSignatureThreshold (..), ProtocolInfo (..),
+import           Ouroboros.Consensus.Node.ProtocolInfo
+                     (PBftSignatureThreshold (..), ProtocolInfo (..),
                      protocolInfo)
 import           Ouroboros.Consensus.Node.Run (RunNode (..))
 import           Ouroboros.Consensus.Protocol
@@ -81,7 +81,7 @@ withImmDB k = do
       }
 
 testCfg :: NodeConfig (BlockProtocol ByronBlock)
-testCfg = pInfoConfig $ protocolInfo (NumCoreNodes 1) prot
+testCfg = pInfoConfig $ protocolInfo prot
   where
     prot = ProtocolRealPBFT
       Dummy.dummyConfig


### PR DESCRIPTION
In particular it does not apply to `RealPBFT`. So it should be per-protocol in the `Protocol` constructors and not passed to all protocols via `protocolInfo`.