### PR TITLE
NTP-client : change API to use STM

### DIFF
--- a/ntp-client/src/Network/NTP/Trace.hs
+++ b/ntp-client/src/Network/NTP/Trace.hs
@@ -5,7 +5,6 @@ import           Data.Time.Units (Microsecond)
 
 data NtpTrace
     = NtpTraceStartNtpClient
-    | NtpTraceClientGetStatus
     | NtpTraceClientActNow
     | NtpTraceClientForceCheck
     | NtpTraceClientAbort


### PR DESCRIPTION
Change the API to use `ntpGetStatus  :: STM NtpStatus`.
This allows blocking and non-blocking queries of the NTP status.
