### PR TITLE
Remove 'applyChainTick'.

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -45,15 +45,6 @@ class ( SupportedBlock blk
   ledgerConfigView :: NodeConfig (BlockProtocol blk)
                    -> LedgerConfig blk
 
-  -- | Apply state transformations that might occur when encountering a new
-  --   block, but happen before full header and body processing. In the Byron
-  --   era this is used to perform epoch transitions on receipt of the first
-  --   block in the new epoch.
-  applyChainTick :: LedgerConfig blk
-                 -> SlotNo
-                 -> LedgerState blk
-                 -> Except (LedgerError blk) (LedgerState blk)
-
   -- | Apply a block to the ledger state.
   applyLedgerBlock :: LedgerConfig blk
                    -> blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -224,7 +224,6 @@ instance (SimpleCrypto c, Typeable ext, SupportedBlock (SimpleBlock c ext))
 
   type LedgerError (SimpleBlock c ext) = MockError (SimpleBlock c ext)
 
-  applyChainTick _ _ = return
   applyLedgerBlock _cfg = updateSimpleLedgerState
   reapplyLedgerBlock _cfg = (mustSucceed . runExcept) .: updateSimpleLedgerState
     where

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool/TestBlock.hs
@@ -117,8 +117,6 @@ instance UpdateLedger TestBlock where
 
   ledgerConfigView _ = LedgerConfig
 
-  applyChainTick _ _ = notNeeded
-
   applyLedgerBlock = notNeeded
 
   reapplyLedgerBlock = notNeeded

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -290,8 +290,6 @@ instance UpdateLedger TestBlock where
 
   ledgerConfigView _ = LedgerConfig
 
-  applyChainTick _ _ = return
-
   applyLedgerBlock _ tb@TestBlock{..} TestLedger{..}
     | blockPrevHash tb /= lastAppliedHash
     = throwError $ InvalidHash lastAppliedHash (blockPrevHash tb)

--- a/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
@@ -255,8 +255,6 @@ instance UpdateLedger TestBlock where
 
   ledgerConfigView _ = LedgerConfig
 
-  applyChainTick _ _ = return
-
   applyLedgerBlock _ tb@TestBlock{..} TestLedger{..}
     | Block.blockPrevHash tb /= lastAppliedHash
     = throwError $ InvalidHash lastAppliedHash (Block.blockPrevHash tb)


### PR DESCRIPTION
The initial motivation for 'applyChainTick' is that the ledger sequences
header application, protocol application and then body application. It's
necessary that header application happens _before_ protocol application.

However, the consensus code resolves this by simply applying the body
before the protocol code. As such, the need for a separate block tick is
removed.

Chain tick is now applied directly when we apply (any) block.