### PR TITLE
Add equivalent of System.Timeout.timeout to MonadTimer

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
@@ -142,10 +142,6 @@ instance MonadTimer IO where
           TimeoutCancelled -> return ()
       mgr <- GHC.getSystemTimerManager
       GHC.unregisterTimeout mgr key
-
-  threadDelay d = IO.threadDelay (diffTimeToMicrosecondsAsInt d)
-
-  registerDelay = STM.registerDelay . diffTimeToMicrosecondsAsInt
 #else
 instance Eq (Timeout IO) where
   TimeoutIO _ cancelvar == TimeoutIO _ cancelvar' = cancelvar == cancelvar'
@@ -175,11 +171,11 @@ instance MonadTimer IO where
     STM.atomically $ do
       fired <- STM.readTVar =<< STM.readTVar timeoutvarvar
       when (not fired) $ STM.writeTVar cancelvar True
+#endif
 
   threadDelay d = IO.threadDelay (diffTimeToMicrosecondsAsInt d)
 
   registerDelay = STM.registerDelay . diffTimeToMicrosecondsAsInt
-#endif
 
 diffTimeToMicrosecondsAsInt :: DiffTime -> Int
 diffTimeToMicrosecondsAsInt d =

--- a/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
@@ -7,34 +7,31 @@
 module Control.Monad.Class.MonadTimer (
     MonadTimer(..)
   , TimeoutState(..)
-  , timeoutAfter
   ) where
 
 import qualified Control.Concurrent as IO
 import qualified Control.Concurrent.STM.TVar as STM
-import           Control.Monad (when)
 import qualified Control.Monad.STM as STM
-import           Control.Exception (Exception(..), assert)
-import qualified Control.Exception as E
+import           Control.Exception (assert)
 import           Data.Functor (void)
 import           Data.Time.Clock (DiffTime, diffTimeToPicoseconds)
-import           Data.Typeable (Typeable)
 
 #if defined(__GLASGOW_HASKELL__) && !defined(mingw32_HOST_OS) && !defined(__GHCJS__)
 import qualified GHC.Event as GHC (TimeoutKey, getSystemTimerManager,
                      registerTimeout, unregisterTimeout, updateTimeout)
+#else
+import           Control.Monad (when)
 #endif
 
 import           Control.Monad.Class.MonadFork (MonadFork(..))
 import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadThrow
 
 import qualified System.Timeout as IO
 
 
 data TimeoutState = TimeoutPending | TimeoutFired | TimeoutCancelled
 
-class (MonadSTM m, Eq (Timeout m)) => MonadTimer m where
+class MonadSTM m => MonadTimer m where
   data Timeout m :: *
 
   -- | Create a new timeout which will fire at the given time duration in
@@ -109,9 +106,6 @@ class (MonadSTM m, Eq (Timeout m)) => MonadTimer m where
 
 
 #if defined(__GLASGOW_HASKELL__) && !defined(mingw32_HOST_OS) && !defined(__GHCJS__)
-instance Eq (Timeout IO) where
-  TimeoutIO _ key == TimeoutIO _ key' = key == key'
-
 instance MonadTimer IO where
   data Timeout IO = TimeoutIO !(STM.TVar TimeoutState) !GHC.TimeoutKey
 
@@ -147,9 +141,6 @@ instance MonadTimer IO where
       mgr <- GHC.getSystemTimerManager
       GHC.unregisterTimeout mgr key
 #else
-instance Eq (Timeout IO) where
-  TimeoutIO _ cancelvar == TimeoutIO _ cancelvar' = cancelvar == cancelvar'
-
 instance MonadTimer IO where
   data Timeout IO = TimeoutIO !(STM.TVar (STM.TVar Bool)) !(STM.TVar Bool)
 
@@ -192,38 +183,3 @@ diffTimeToMicrosecondsAsInt d =
     -- systems means 2^31 usec, which is only ~35 minutes.
     assert (usec <= fromIntegral (maxBound :: Int)) $
     fromIntegral usec
-
-{-------------------------------------------------------------------------------
-  Timeout an action
-
-  This is based on the implementation in System.Timeout
--------------------------------------------------------------------------------}
-
-data TimeoutException m = TimeoutException (Timeout m)
-
-instance Show (TimeoutException m) where
-  show _ = "<<timeout>>"
-
-instance Typeable m => Exception (TimeoutException m) where
-  toException   = E.asyncExceptionToException
-  fromException = E.asyncExceptionFromException
-
--- | Generalization of 'System.Timeout.timeout' to 'MonadTimer'
---
--- NOTE: Like most of the timer API, this will only work with the threaded
--- runtime. When using the non-threaded runtime, will fail with a runtime
--- exception about a pattern match failure in "GHC.Event.Thread".
-timeoutAfter :: (MonadFork m, MonadTimer m, MonadMask m, Typeable m)
-             => DiffTime -> m a -> m (Maybe a)
-timeoutAfter d act = do
-    pid <- myThreadId
-    t   <- newTimeout d
-    handleJust
-      (\(TimeoutException t') -> if t' == t then Just () else Nothing)
-      (\_ -> return Nothing) $
-      bracket
-        (void $ forkWithUnmask $ \unmask -> unmask $ do
-            fired <- atomically $ awaitTimeout t
-            when fired $ throwTo pid (TimeoutException t))
-        (\() -> cancelTimeout t)
-        (\() -> Just <$> act)

--- a/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTimer.hs
@@ -29,6 +29,8 @@ import           Control.Monad.Class.MonadFork (MonadFork(..))
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 
+import qualified System.Timeout as IO
+
 
 data TimeoutState = TimeoutPending | TimeoutFired | TimeoutCancelled
 
@@ -97,6 +99,8 @@ class (MonadSTM m, Eq (Timeout m)) => MonadTimer m where
     t <- newTimeout d
     _ <- fork $ atomically (awaitTimeout t >>= writeTVar v)
     return v
+
+  timeout :: DiffTime -> m a -> m (Maybe a)
 
 
 --
@@ -176,6 +180,9 @@ instance MonadTimer IO where
   threadDelay d = IO.threadDelay (diffTimeToMicrosecondsAsInt d)
 
   registerDelay = STM.registerDelay . diffTimeToMicrosecondsAsInt
+
+  timeout = IO.timeout . diffTimeToMicrosecondsAsInt
+
 
 diffTimeToMicrosecondsAsInt :: DiffTime -> Int
 diffTimeToMicrosecondsAsInt d =

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -380,9 +380,6 @@ setCurrentTime t = SimM $ \k -> SetWallTime t (k ())
 unshareClock :: SimM s ()
 unshareClock = SimM $ \k -> UnshareClock (k ())
 
-instance Eq (Timeout (SimM s)) where
-  Timeout _ key == Timeout _ key' = key == key'
-
 instance MonadTimer (SimM s) where
   data Timeout (SimM s) = Timeout !(TVar s TimeoutState) !TimeoutId
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -62,7 +62,7 @@ module Ouroboros.Consensus.Util.IOLike (
   , getCurrentTime
     -- *** MonadTimer
   , threadDelay
-  , timeoutAfter
+  , timeout
     -- *** Cardano prelude
   , NoUnexpectedThunks(..)
   ) where

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -349,7 +349,7 @@ runIO :: forall m. (IOLike m, Typeable m)
       => StrictTVar m [TestThread m]
       -> ResourceRegistry m
       -> Cmd (TestThread m) -> m (Resp (TestThread m))
-runIO alive reg cmd = catchEx $ timeoutAfter 1 $
+runIO alive reg cmd = catchEx $ timeout 1 $
     case cmd of
       Fork ->
         Spawned <$> newThread alive reg DontLink

--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Dns.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Dns.hs
@@ -22,7 +22,6 @@ module Ouroboros.Network.Subscription.Dns
     , WithDomainName (..)
     ) where
 
-import           Control.Monad (unless)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadSTM (LazyTVar)
 import qualified Control.Monad.Class.MonadSTM as Lazy
@@ -180,9 +179,9 @@ dnsResolve tracer resolver (DnsSubscriptionTarget domain _ _) = do
                   -}
                  timeoutVar <- registerDelay resolutionDelay
                  atomically $ do
-                     timeout <- Lazy.readTVar timeoutVar
+                     timedOut   <- Lazy.readTVar timeoutVar
                      gotIpv6Rsp <- Lazy.readTVar gotIpv6RspVar
-                     unless (timeout || gotIpv6Rsp) retry
+                     check (timedOut || gotIpv6Rsp)
 
                  -- XXX Addresses should be sorted here based on DeltaQueue.
                  atomically $ putTMVar rspsVar r


### PR DESCRIPTION
Add `timeout` to the `MonadTimer` class. The IO implementation uses `System.Timeout.timeout`.

The IO version is an optimised implementation on unix with the threaded RTS, so it's much better to use it than to have only a generic version. Provide a generic version for the simulator.

Remove the existing `timeoutAfter` and replace uses with new `timeout`.
