### PR TITLE
ourobors-network: remove BlockSigner field.

### DIFF
--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -829,13 +829,9 @@ genBlockHeader g prevHeader body =
       headerPrevHash = maybe GenesisHash (BlockHash . headerHash) prevHeader,
       headerSlot     = maybe 1 (addSlotGap slotGap  . headerSlot) prevHeader,
       headerBlockNo  = maybe 1 (succ             . headerBlockNo) prevHeader,
-      headerSigner   = expectedBFTSigner (headerSlot header),
       headerBodyHash = hashBody body
     }
     (slotGap, _) = randomR (1,3) g
-
-    expectedBFTSigner :: SlotNo -> BlockSigner
-    expectedBFTSigner (SlotNo n) = BlockSigner (n `mod` 7)
 
     addSlotGap :: Int -> SlotNo -> SlotNo
     addSlotGap m (SlotNo n) = SlotNo (n + fromIntegral m)

--- a/ouroboros-network/test/Test/ChainGenerators.hs
+++ b/ouroboros-network/test/Test/ChainGenerators.hs
@@ -195,7 +195,6 @@ instance CoArbitrary Block
 instance CoArbitrary BlockHeader
 instance CoArbitrary SlotNo
 instance CoArbitrary BlockNo
-instance CoArbitrary BlockSigner
 instance CoArbitrary BodyHash
 instance CoArbitrary BlockBody
 instance CoArbitrary (ChainHash BlockHeader)

--- a/ouroboros-network/test/messages.cddl
+++ b/ouroboros-network/test/messages.cddl
@@ -122,11 +122,16 @@ refuseReasonRefused              = [2, versionNumber, tstr]
 ; The following encodings are used in the test code.
 
 block           = [blockHeader, blockBody]
-blockHeader     = [int, chainHash, word64, word64 , word64, int]
+
+blockHeader     = [headerHash, chainHash, headerSlot, headerBlockNo , headerBodyHash]
+headerHash      = int
 chainHash       = genesisHash / blockHash
 genesisHash     = []
 blockHash       = [int]
 blockBody       = tstr
+headerSlot      = word64
+headerBlockNo   = word64
+headerBodyHash  = int
 
 point           = origin / blockHeaderHash
 origin          = []


### PR DESCRIPTION
Remove `BlockSigner` from `Ouroboros.Network.Testing.ConcreteBlock.BlockHeader`
https://github.com/input-output-hk/ouroboros-network/issues/674