### PR TITLE
consensus: assert SignKey/VerKey correspondence in forgePBftFields

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -34,6 +34,7 @@ module Ouroboros.Consensus.Protocol.PBFT (
   ) where
 
 import           Codec.Serialise (Serialise (..))
+import qualified Control.Exception as Exn
 import           Control.Monad.Except
 import           Crypto.Random (MonadRandom)
 import           Data.Bimap (Bimap)
@@ -108,7 +109,7 @@ forgePBftFields :: ( MonadRandom m
                 -> m (PBftFields c toSign)
 forgePBftFields cfg PBftIsLeader{..} toSign = do
     signature <- signedDSIGN ctxtDSIGN toSign pbftSignKey
-    return $ PBftFields {
+    return $ Exn.assert (issuer == deriveVerKeyDSIGN pbftSignKey) $ PBftFields {
         pbftIssuer    = issuer
       , pbftGenKey    = genKey
       , pbftSignature = signature


### PR DESCRIPTION
This `assert`ion would have saved me time when I was debugging my prototype implementation
of #1202, so I thought to propose it here. I'm unsure if this PR is complete as-is: If we `assert` here, should we also `assert` in Praos, eg?