### PR TITLE
Allow error policy to fall through

### DIFF
--- a/ouroboros-network/test/Test/PeerState.hs
+++ b/ouroboros-network/test/Test/PeerState.hs
@@ -196,9 +196,9 @@ data ArbErrorPolicies = ArbErrorPolicies [ErrorPolicy] -- application error poli
 genErrorPolicy :: Gen (SuspendDecision DiffTime)
                -> Gen (ErrorPolicy)
 genErrorPolicy genCmd = oneof
-    [ (\cmd -> ErrorPolicy (\(_e :: ArithException) -> cmd)) <$> genCmd,
-      (\cmd -> ErrorPolicy (\(_e :: AsyncException) -> cmd)) <$> genCmd,
-      (\cmd -> ErrorPolicy (\(_e :: NonTermination) -> cmd)) <$> genCmd
+    [ (\cmd -> ErrorPolicy (\(_e :: ArithException) -> Just cmd)) <$> genCmd,
+      (\cmd -> ErrorPolicy (\(_e :: AsyncException) -> Just cmd)) <$> genCmd,
+      (\cmd -> ErrorPolicy (\(_e :: NonTermination) -> Just cmd)) <$> genCmd
     ]
 
 instance Arbitrary ArbErrorPolicies where


### PR DESCRIPTION
This makes it possible to deal with wrapped exceptions; for example:

```haskell
          -- Dispatch on nested exception
        , ErrorPolicy $ \(ExceptionInLinkedThread _ e) ->
            evalErrorPolicies e (epAppErrorPolicies consensusErrorPolicy)
```