### PR TITLE
Remove `tip` argument to ChainSyncClient

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -12,14 +12,15 @@ module Ouroboros.Consensus.Node.Tracers
 import           Control.Tracer (Tracer, nullTracer, showTracing)
 import qualified Network.Socket as Socket
 
-import           Ouroboros.Network.Block (Point, SlotNo, Tip)
+import           Ouroboros.Network.Block (Point, SlotNo)
 import           Ouroboros.Network.BlockFetch (FetchDecision,
                      TraceFetchClientState, TraceLabelPeer)
+import           Ouroboros.Network.Subscription.Ip (SubscriptionTrace,
+                     WithIPList)
 import           Ouroboros.Network.TxSubmission.Inbound
                      (TraceTxSubmissionInbound)
 import           Ouroboros.Network.TxSubmission.Outbound
                      (TraceTxSubmissionOutbound)
-import           Ouroboros.Network.Subscription.Ip (SubscriptionTrace, WithIPList)
 
 import           Ouroboros.Consensus.Block (Header, SupportedBlock)
 import           Ouroboros.Consensus.BlockFetchServer
@@ -35,8 +36,8 @@ import           Ouroboros.Consensus.TxSubmission
   All tracers of a node bundled together
 -------------------------------------------------------------------------------}
 
-data Tracers' peer blk tip f = Tracers
-  { chainSyncClientTracer         :: f (TraceChainSyncClientEvent blk tip)
+data Tracers' peer blk f = Tracers
+  { chainSyncClientTracer         :: f (TraceChainSyncClientEvent blk)
   , chainSyncServerHeaderTracer   :: f (TraceChainSyncServerEvent blk (Header blk))
   , chainSyncServerBlockTracer    :: f (TraceChainSyncServerEvent blk blk)
   , blockFetchDecisionTracer      :: f [TraceLabelPeer peer (FetchDecision [Point (Header blk)])]
@@ -51,7 +52,7 @@ data Tracers' peer blk tip f = Tracers
   }
 
 -- | A record of 'Tracer's for the node.
-type Tracers m peer blk = Tracers' peer blk (Tip blk) (Tracer m)
+type Tracers m peer blk = Tracers' peer blk (Tracer m)
 
 -- | Use a 'nullTracer' for each of the 'Tracer's in 'Tracers'
 nullTracers :: Monad m => Tracers m peer blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -148,7 +148,6 @@ protocolHandlers NodeArgs {btime, maxClockSkew, tracers, maxUnackTxs, chainSyncP
       phChainSyncClient =
         chainSyncClient
           chainSyncPipelining
-          tipBlockNo
           (chainSyncClientTracer tracers)
           getNodeConfig
           btime
@@ -522,7 +521,7 @@ consensusNetworkApps kernel ProtocolTracers {..} ProtocolCodecs {..} ProtocolHan
         channel
         (localTxSubmissionServerPeer (pure phLocalTxSubmissionServer))
 
-chainDbView :: IOLike m => ChainDB m blk -> ChainDbView m blk (Tip blk)
+chainDbView :: IOLike m => ChainDB m blk -> ChainDbView m blk
 chainDbView chainDB = ChainDbView
   { getCurrentChain   = ChainDB.getCurrentChain       chainDB
   , getCurrentLedger  = ChainDB.getCurrentLedger      chainDB

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -345,7 +345,7 @@ newThread alive parentReg = \shouldLink -> do
               putMVar result ()
               error "crashing"
 
-runIO :: forall m. (IOLike m, Typeable m)
+runIO :: forall m. IOLike m
       => StrictTVar m [TestThread m]
       -> ResourceRegistry m
       -> Cmd (TestThread m) -> m (Resp (TestThread m))

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -707,7 +707,7 @@ type LimitedApp' m peer blk unused1 unused2 =
 -- | Non-fatal exceptions expected from the threads of a 'directedEdge'
 --
 data MiniProtocolExpectedException blk
-  = MPEEChainSyncClient (CSClient.ChainSyncClientException blk (Tip blk))
+  = MPEEChainSyncClient (CSClient.ChainSyncClientException blk)
     -- ^ see "Ouroboros.Consensus.ChainSyncClient"
     --
     -- NOTE: the second type in 'ChainSyncClientException' denotes the 'tip'.

--- a/ouroboros-network/src/Ouroboros/Network/MockNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/MockNode.hs
@@ -281,7 +281,7 @@ relayNode :: forall m block.
              )
           => NodeId
           -> Chain block
-          -> NodeChannels m block (ExampleTip block)
+          -> NodeChannels m block (Tip block)
           -> m (StrictTVar m (ChainProducerState block))
 relayNode nid initChain chans = do
   -- Mutable state
@@ -304,7 +304,7 @@ relayNode nid initChain chans = do
     -- state between producers than necessary (here are producers share chain
     -- state and all the reader states, while we could share just the chain).
     startConsumer :: Int
-                  -> Channel m (AnyMessage (ChainSync block (ExampleTip block)))
+                  -> Channel m (AnyMessage (ChainSync block (Tip block)))
                   -> m (StrictTVar m (Chain block))
     startConsumer cid channel = do
       chainVar <- atomically $ newTVar Genesis
@@ -316,9 +316,9 @@ relayNode nid initChain chans = do
                                    consumer
       return chainVar
 
-    startProducer :: Peer (ChainSync block (ExampleTip block)) AsServer StIdle m ()
+    startProducer :: Peer (ChainSync block (Tip block)) AsServer StIdle m ()
                   -> Int
-                  -> Channel m (AnyMessage (ChainSync block (ExampleTip block)))
+                  -> Channel m (AnyMessage (ChainSync block (Tip block)))
                   -> m ()
     startProducer producer pid channel =
       -- use 'void' because 'fork' only works with 'm ()'
@@ -398,7 +398,7 @@ coreNode :: forall m.
      -> DiffTime
      -- ^ slot duration
      -> [Block]
-     -> NodeChannels m Block (ExampleTip Block)
+     -> NodeChannels m Block (Tip Block)
      -> m (StrictTVar m (ChainProducerState Block))
 coreNode nid slotDuration gchain chans = do
   cpsVar <- relayNode nid Genesis chans

--- a/ouroboros-network/test/CDDL.hs
+++ b/ouroboros-network/test/CDDL.hs
@@ -29,7 +29,7 @@ import Codec.CBOR.Term as CBOR
 import Codec.CBOR.Read
 import Codec.CBOR.Write (toLazyByteString)
 
-import Ouroboros.Network.Block (BlockNo, HeaderHash, Point)
+import Ouroboros.Network.Block (HeaderHash, Point, Tip, encodeTip, decodeTip)
 import Ouroboros.Network.Testing.ConcreteBlock (BlockHeader (..), Block)
 
 import Ouroboros.Network.Protocol.ChainSync.Type as CS
@@ -82,7 +82,7 @@ tests =
 
 -- The concrete/monomorphic types used for the test.
 type MonoCodec x = Codec x Codec.CBOR.Read.DeserialiseFailure IO ByteString
-type CS = ChainSync BlockHeader (Point BlockHeader, BlockNo)
+type CS = ChainSync BlockHeader (Tip BlockHeader)
 type RR = ReqResp DummyBytes DummyBytes
 type BF = BlockFetch Block
 type HS = Handshake VersionNumber CBOR.Term
@@ -91,7 +91,7 @@ type TS = TxSubmission TxId Tx
 codecCS :: MonoCodec CS
 codecCS = codecChainSync Serialise.encode (fmap const Serialise.decode)
                          Serialise.encode (Serialise.decode :: CBOR.Decoder s (Point BlockHeader))
-                         Serialise.encode (Serialise.decode :: CBOR.Decoder s (Point BlockHeader, BlockNo))
+                         (encodeTip Serialise.encode) (decodeTip Serialise.decode)
 
 codecBF :: MonoCodec BF
 codecBF = codecBlockFetch Serialise.encode (fmap const Serialise.decode) Serialise.encode Serialise.decode

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -51,6 +51,7 @@ import           Ouroboros.Network.Mux as Mx
 
 import           Ouroboros.Network.Socket
 
+import           Ouroboros.Network.Block (Tip, encodeTip, decodeTip)
 import           Ouroboros.Network.Magic
 import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate, Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
@@ -58,7 +59,6 @@ import qualified Ouroboros.Network.MockChain.ProducerState as CPS
 import           Ouroboros.Network.NodeToNode
 import qualified Ouroboros.Network.Protocol.ChainSync.Client as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Codec as ChainSync
-import           Ouroboros.Network.Protocol.ChainSync.Examples (ExampleTip)
 import qualified Ouroboros.Network.Protocol.ChainSync.Examples as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Server as ChainSync
 import           Ouroboros.Network.Protocol.Handshake.Type (acceptEq)
@@ -401,7 +401,7 @@ demo chain0 updates = do
                         (ChainSync.chainSyncClientExample consumerVar
                         (consumerClient done target consumerVar)))
 
-        server :: ChainSync.ChainSyncServer block (ExampleTip block) IO ()
+        server :: ChainSync.ChainSyncServer block (Tip block) IO ()
         server = ChainSync.chainSyncServerExample () producerVar
 
         responderApp :: OuroborosApplication Mx.ResponderApp (Socket.SockAddr, Socket.SockAddr) TestProtocols1 IO BL.ByteString Void ()
@@ -413,7 +413,7 @@ demo chain0 updates = do
 
         codecChainSync = ChainSync.codecChainSync encode (fmap const decode)
                                                   encode             decode
-                                                  encode             decode
+                                                  (encodeTip encode) (decodeTip decode)
 
     withServerNode
       nullTracer
@@ -462,7 +462,7 @@ demo chain0 updates = do
     consumerClient :: StrictTMVar IO Bool
                    -> Point block
                    -> StrictTVar IO (Chain block)
-                   -> ChainSync.Client block (ExampleTip block) IO ()
+                   -> ChainSync.Client block (Tip block) IO ()
     consumerClient done target chain =
       ChainSync.Client
         { ChainSync.rollforward = \_ -> checkTip target chain >>= \b ->


### PR DESCRIPTION
This also removes ExampleTip (which was isomorphic to Tip).