### PR TITLE
Remove type arguments from error types

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -262,6 +262,7 @@ test-suite test-consensus
                     Test.Dynamic.Util.NodeJoinPlan
                     Test.Dynamic.Util.NodeTopology
                     Test.Dynamic.Util.Tests
+                    Test.Util.BlockchainTime
                     Test.Util.FS.Sim.FsTree
                     Test.Util.FS.Sim.MockFS
                     Test.Util.FS.Sim.STM

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockFetchServer.hs
@@ -1,10 +1,12 @@
-{-# LANGUAGE EmptyDataDeriving    #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes       #-}
+{-# LANGUAGE EmptyDataDeriving         #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE StandaloneDeriving        #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE UndecidableInstances      #-}
 module Ouroboros.Consensus.BlockFetchServer
   ( blockFetchServer
     -- * Trace events
@@ -30,7 +32,7 @@ import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import           Ouroboros.Storage.ChainDB (ChainDB, IteratorResult (..))
 import qualified Ouroboros.Storage.ChainDB as ChainDB
 
-data BlockFetchServerException blk =
+data BlockFetchServerException =
       -- | A block that was supposed to be included in a batch was garbage
       -- collected since we started the batch and can no longer be sent.
       --
@@ -43,12 +45,12 @@ data BlockFetchServerException blk =
       -- exception, as the block to stream from the old fork could have been
       -- garbage collected. However, the network protocol will have timed out
       -- long before this happens.
-      BlockGCed (HeaderHash blk)
+      forall blk. (Typeable blk, StandardHash blk) =>
+        BlockGCed (HeaderHash blk)
 
-deriving instance StandardHash blk => Show (BlockFetchServerException blk)
+deriving instance Show BlockFetchServerException
 
-instance (Typeable blk, StandardHash blk)
-      => Exception (BlockFetchServerException blk)
+instance Exception BlockFetchServerException
 
 -- | Block fetch server based on
 -- 'Ouroboros.Network.BlockFetch.Examples.mockBlockFetchServer1', but using

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -66,6 +66,7 @@ data family NodeConfig p :: *
 -- block representation.
 class ( Show (ChainState    p)
       , Show (ValidationErr p)
+      , Eq   (ValidationErr p)
       , NoUnexpectedThunks (NodeConfig  p)
       , NoUnexpectedThunks (ChainState  p)
       , NoUnexpectedThunks (NodeState   p)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -163,7 +163,7 @@ instance BftCrypto c => NoUnexpectedThunks (NodeConfig (Bft c))
 -------------------------------------------------------------------------------}
 
 data BftValidationErr = BftInvalidSignature String
-  deriving (Show)
+  deriving (Show, Eq)
 
 {-------------------------------------------------------------------------------
   Crypto models

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -327,7 +327,8 @@ data PBftValidationErr c
   | PBftExceededSignThreshold String Int Int
   | PBftInvalidSlot
 
-deriving instance (Show (PBftLedgerView c), PBftCrypto c) => Show (PBftValidationErr c)
+deriving instance PBftCrypto c => Show (PBftValidationErr c)
+deriving instance PBftCrypto c => Eq   (PBftValidationErr c)
 
 {-------------------------------------------------------------------------------
   Condense

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Praos.hs
@@ -33,7 +33,6 @@ module Ouroboros.Consensus.Protocol.Praos (
   ) where
 
 import           Cardano.Binary (ToCBOR (..))
-import           Codec.CBOR.Encoding (Encoding)
 import           Codec.Serialise (Serialise (..))
 import           Control.Monad (unless)
 import           Control.Monad.Except (throwError)
@@ -168,10 +167,11 @@ data PraosValidationError c =
       PraosInvalidSlot SlotNo SlotNo
     | PraosUnknownCoreId Int
     | PraosInvalidSig String (VerKeyKES (PraosKES c)) Natural (SigKES (PraosKES c))
-    | PraosInvalidCert (VerKeyVRF (PraosVRF c)) Encoding Natural (CertVRF (PraosVRF c))
+    | PraosInvalidCert (VerKeyVRF (PraosVRF c)) (Natural, SlotNo, VRFType) Natural (CertVRF (PraosVRF c))
     | PraosInsufficientStake Double Natural
 
 deriving instance PraosCrypto c => Show (PraosValidationError c)
+deriving instance PraosCrypto c => Eq   (PraosValidationError c)
 
 data BlockInfo c = BlockInfo
     { biSlot  :: !SlotNo
@@ -287,7 +287,7 @@ instance ( PraosCrypto c
     unless (verifyCertified () vkVRF rho' praosRho) $
         throwError $ PraosInvalidCert
             vkVRF
-            (toCBOR rho')
+            rho'
             (certifiedNatural praosRho)
             (certifiedProof praosRho)
 
@@ -295,7 +295,7 @@ instance ( PraosCrypto c
     unless (verifyCertified () vkVRF y' praosY) $
         throwError $ PraosInvalidCert
             vkVRF
-            (toCBOR y')
+            y'
             (certifiedNatural praosY)
             (certifiedProof praosY)
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -542,7 +542,7 @@ data ChainDbFailure blk =
     -- | The volatile DB throw an "unexpected error"
     --
     -- These are errors indicative of a disk failure (as opposed to API misuse)
-  | VolDbFailure (VolDB.UnexpectedError (HeaderHash blk))
+  | VolDbFailure VolDB.UnexpectedError
 
     -- | The ledger DB threw a file-system error
   | LgrDbFailure FsError

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -18,7 +18,7 @@ import           Data.Time.Clock (DiffTime, secondsToDiffTime)
 
 import           Control.Tracer (Tracer, contramap)
 
-import           Ouroboros.Network.Block (HeaderHash, StandardHash)
+import           Ouroboros.Network.Block (HeaderHash)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -57,8 +57,8 @@ data ChainDbArgs m blk = forall h1 h2 h3. ChainDbArgs {
 
       -- Error handling
     , cdbErrImmDb         :: ErrorHandling ImmDB.ImmutableDBError m
-    , cdbErrVolDb         :: ErrorHandling (VolDB.VolatileDBError (HeaderHash blk)) m
-    , cdbErrVolDbSTM      :: ThrowCantCatch (VolDB.VolatileDBError (HeaderHash blk)) (STM m)
+    , cdbErrVolDb         :: ErrorHandling VolDB.VolatileDBError m
+    , cdbErrVolDbSTM      :: ThrowCantCatch VolDB.VolatileDBError (STM m)
 
       -- HasFS instances
     , cdbHasFSImmDb       :: HasFS m h1
@@ -113,9 +113,7 @@ defaultSpecificArgs = ChainDbSpecificArgs{
 -- See 'ImmDB.defaultArgs', 'VolDB.defaultArgs', 'LgrDB.defaultArgs', and
 -- 'defaultSpecificArgs' for a list of which fields are not given a default
 -- and must therefore be set explicitly.
-defaultArgs :: StandardHash blk
-            => FilePath
-            -> ChainDbArgs IO blk
+defaultArgs :: FilePath -> ChainDbArgs IO blk
 defaultArgs fp = toChainDbArgs (ImmDB.defaultArgs fp)
                                (VolDB.defaultArgs fp)
                                (LgrDB.defaultArgs fp)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -206,7 +206,7 @@ mkImmDB immDB decBlock encBlock epochInfo isEBB err = ImmDB {..}
 -- 'ReadFutureSlotError' wrapped in a 'ImmDbFailure' is thrown.
 getBlockWithPoint :: forall m blk. (MonadCatch m, HasHeader blk, HasCallStack)
                   => ImmDB m blk -> Point blk -> m (Maybe blk)
-getBlockWithPoint _  GenesisPoint   = throwM $ NoGenesisBlock @blk
+getBlockWithPoint _  GenesisPoint   = throwM NoGenesisBlock
 getBlockWithPoint db BlockPoint { withHash = hash, atSlot = slot } =
     -- Unfortunately a point does not give us enough information to determine
     -- whether this corresponds to a regular block or an EBB. We will
@@ -421,8 +421,8 @@ streamBlocksFrom db registry from = runExceptT $ case from of
         else do
           lift $ iteratorClose db it
           throwError $ MissingBlock pt
-    StreamFromInclusive    GenesisPoint ->
-      throwM $ NoGenesisBlock @blk
+    StreamFromInclusive GenesisPoint ->
+      throwM NoGenesisBlock
   where
     -- | Check if the slot of the lower bound is <= the slot of the tip. If
     -- not, throw a 'MissingBlock' error.
@@ -473,8 +473,8 @@ streamBlocksFromUnchecked db registry from = case from of
       stream Nothing Nothing
     StreamFromInclusive BlockPoint { atSlot = slot, withHash = hash } ->
       stream (Just (slot, hash)) Nothing
-    StreamFromInclusive    GenesisPoint ->
-      throwM $ NoGenesisBlock @blk
+    StreamFromInclusive GenesisPoint ->
+      throwM NoGenesisBlock
   where
     stream start end = parseIterator db <$>
       registeredStream db registry start end

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -270,7 +270,7 @@ getBlockWithPoint db BlockPoint { withHash = hash, atSlot = slot } =
           | otherwise
           -> return $ Nothing
         Nothing -- EBB is missing
-          -> throwM $ ImmDbMissingBlock @blk (Left epochNo)
+          -> throwM $ ImmDbMissingBlock (Left epochNo)
 
     -- Important: we check whether the block's hash matches the point's hash
     getBlockWithHash :: Either EpochNo SlotNo -> m (Maybe blk)
@@ -278,7 +278,7 @@ getBlockWithPoint db BlockPoint { withHash = hash, atSlot = slot } =
       Just block | blockHash block == hash -> return $ Just block
       _                                    -> return $ Nothing
 
-getBlockAtTip :: (MonadCatch m, HasHeader blk, HasCallStack)
+getBlockAtTip :: (MonadCatch m, HasCallStack)
               => ImmDB m blk -> m (Maybe blk)
 getBlockAtTip db = do
     immTip <- withDB db $ \imm -> ImmDB.getTip imm
@@ -296,8 +296,7 @@ getPointAtTip = fmap mbBlockToPoint . getBlockAtTip
     mbBlockToPoint Nothing    = genesisPoint
     mbBlockToPoint (Just blk) = blockPoint blk
 
-getSlotNoAtTip :: (MonadCatch m, HasHeader blk)
-               => ImmDB m blk -> m (WithOrigin SlotNo)
+getSlotNoAtTip :: MonadCatch m => ImmDB m blk -> m (WithOrigin SlotNo)
 getSlotNoAtTip db = do
     immTip <- withDB db $ \imm -> ImmDB.getTip imm
     case immTip of
@@ -310,7 +309,7 @@ getSlotNoAtTip db = do
 -- | Get known block from the ImmutableDB that we know should exist
 --
 -- If it does not exist, we are dealing with data corruption.
-getKnownBlock :: (MonadCatch m, HasHeader blk, HasCallStack)
+getKnownBlock :: (MonadCatch m, HasCallStack)
               => ImmDB m blk -> Either EpochNo SlotNo -> m blk
 getKnownBlock db epochOrSlot = do
     mBlock <- mustExist epochOrSlot <$> getBlock db epochOrSlot
@@ -319,7 +318,7 @@ getKnownBlock db epochOrSlot = do
       Left err -> throwM err
 
 -- | Get block from the ImmutableDB
-getBlock :: (MonadCatch m, HasHeader blk, HasCallStack)
+getBlock :: (MonadCatch m, HasCallStack)
          => ImmDB m blk -> Either EpochNo SlotNo -> m (Maybe blk)
 getBlock db epochOrSlot = do
     mBlob <- fmap (parse (decBlock db) epochOrSlot) <$> getBlob db epochOrSlot
@@ -328,7 +327,7 @@ getBlock db epochOrSlot = do
       Just (Right b)  -> return $ Just b
       Just (Left err) -> throwM $ err
 
-getBlob :: (MonadCatch m, HasHeader blk, HasCallStack)
+getBlob :: (MonadCatch m, HasCallStack)
         => ImmDB m blk -> Either EpochNo SlotNo -> m (Maybe Lazy.ByteString)
 getBlob db epochOrSlot = withDB db $ \imm ->
     case epochOrSlot of
@@ -364,7 +363,7 @@ appendBlock db@ImmDB{..} b = withDB db $ \imm -> case isEBB b of
 --
 -- When the returned iterator is closed, it will be 'release'd from the
 -- 'ResourceRegistry'.
-registeredStream :: (IOLike m, HasHeader blk)
+registeredStream :: IOLike m
                  => ImmDB m blk
                  -> ResourceRegistry m
                  -> Maybe (SlotNo, HeaderHash blk)
@@ -459,7 +458,7 @@ streamBlocksFrom db registry from = runExceptT $ case from of
 --
 -- When passed @'StreamFromInclusive' pt@ where @pt@ refers to Genesis, a
 -- 'NoGenesisBlock' exception will be thrown.
-streamBlocksFromUnchecked  :: forall m blk. (IOLike m, HasHeader blk)
+streamBlocksFromUnchecked  :: forall m blk. IOLike m
                            => ImmDB m blk
                            -> ResourceRegistry m
                            -> StreamFrom blk
@@ -544,7 +543,7 @@ streamBlobsAfter db registry low = do
                   throwM $ ImmDbUnexpectedIteratorExhausted low
 
 -- | Parse the bytestrings returned by an iterator as blocks.
-parseIterator :: (MonadCatch m, HasHeader blk)
+parseIterator :: MonadCatch m
               => ImmDB m blk
               -> Iterator (HeaderHash blk) m Lazy.ByteString
               -> Iterator (HeaderHash blk) m blk
@@ -556,7 +555,7 @@ parseIterator db itr = Iterator {
     , iteratorID      = ImmDB.DerivedIteratorID $ ImmDB.iteratorID itr
     }
 
-parseIteratorResult :: (MonadThrow m, HasHeader blk)
+parseIteratorResult :: MonadThrow m
                     => ImmDB m blk
                     -> IteratorResult (HeaderHash blk) Lazy.ByteString
                     -> m (IteratorResult (HeaderHash blk) blk)
@@ -579,7 +578,7 @@ parseIteratorResult db result =
 
 -- | Wrap calls to the ImmutableDB and rethrow exceptions that may indicate
 -- disk failure and should therefore trigger recovery
-withDB :: forall m blk x. (MonadCatch m, HasHeader blk)
+withDB :: forall m blk x. MonadCatch m
        => ImmDB m blk -> (ImmutableDB (HeaderHash blk) m -> m x) -> m x
 withDB ImmDB{..} k = EH.catchError err (k immDB) rethrow
   where
@@ -588,13 +587,13 @@ withDB ImmDB{..} k = EH.catchError err (k immDB) rethrow
                     Just e' -> throwM e'
                     Nothing -> throwM e
 
-    wrap :: ImmDB.ImmutableDBError -> Maybe (ChainDbFailure blk)
+    wrap :: ImmDB.ImmutableDBError -> Maybe ChainDbFailure
     wrap (ImmDB.UnexpectedError e) = Just (ImmDbFailure e)
     wrap ImmDB.UserError{}         = Nothing
 
 mustExist :: Either EpochNo SlotNo
           -> Maybe blk
-          -> Either (ChainDbFailure blk) blk
+          -> Either ChainDbFailure blk
 mustExist epochOrSlot Nothing  = Left  $ ImmDbMissingBlock epochOrSlot
 mustExist _           (Just b) = Right $ b
 
@@ -602,13 +601,13 @@ parse :: forall blk.
          (forall s. Decoder s (Lazy.ByteString -> blk))
       -> Either EpochNo SlotNo
       -> Lazy.ByteString
-      -> Either (ChainDbFailure blk) blk
+      -> Either ChainDbFailure blk
 parse dec epochOrSlot bytes =
     aux (CBOR.deserialiseFromBytes dec bytes)
   where
     aux :: Either CBOR.DeserialiseFailure
                   (Lazy.ByteString, Lazy.ByteString -> blk)
-        -> Either (ChainDbFailure blk) blk
+        -> Either ChainDbFailure blk
     aux (Right (bs, blk))
       | Lazy.null bs = Right (blk bytes)
       | otherwise    = Left $ ImmDbTrailingData epochOrSlot bs
@@ -618,36 +617,34 @@ parse dec epochOrSlot bytes =
   Wrappers
 -------------------------------------------------------------------------------}
 
-closeDB :: (MonadCatch m, HasHeader blk, HasCallStack)
-        => ImmDB m blk -> m ()
+closeDB :: (MonadCatch m, HasCallStack) => ImmDB m blk -> m ()
 closeDB db = withDB db ImmDB.closeDB
 
-reopen :: (MonadCatch m, HasHeader blk, HasCallStack)
-       => ImmDB m blk -> m ()
+reopen :: (MonadCatch m, HasCallStack) => ImmDB m blk -> m ()
 reopen db = withDB db $ \imm ->
     ImmDB.reopen imm ImmDB.ValidateMostRecentEpoch
 
 -- These wrappers ensure that we correctly rethrow exceptions using 'withDB'.
 
-iteratorNext :: (HasCallStack, MonadCatch m, HasHeader blk)
+iteratorNext :: (HasCallStack, MonadCatch m)
              => ImmDB m blk
              -> ImmDB.Iterator (HeaderHash blk) m a
              -> m (ImmDB.IteratorResult (HeaderHash blk) a)
 iteratorNext db it = withDB db $ const $ ImmDB.iteratorNext it
 
-iteratorHasNext :: (HasCallStack, MonadCatch m, HasHeader blk)
+iteratorHasNext :: (HasCallStack, MonadCatch m)
                 => ImmDB m blk
                 -> ImmDB.Iterator (HeaderHash blk) m a
                 -> m Bool
 iteratorHasNext db it = withDB db $ const $ ImmDB.iteratorHasNext it
 
-iteratorPeek :: (HasCallStack, MonadCatch m, HasHeader blk)
+iteratorPeek :: (HasCallStack, MonadCatch m)
              => ImmDB m blk
              -> ImmDB.Iterator (HeaderHash blk) m a
              -> m (ImmDB.IteratorResult (HeaderHash blk) a)
 iteratorPeek db it = withDB db $ const $ ImmDB.iteratorPeek it
 
-iteratorClose :: (HasCallStack, MonadCatch m, HasHeader blk)
+iteratorClose :: (HasCallStack, MonadCatch m)
               => ImmDB m blk
               -> ImmDB.Iterator (HeaderHash blk) m a
               -> m ()

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
@@ -395,7 +395,7 @@ newIterator itEnv@IteratorEnv{..} getItEnv registry from to = do
 -- | Close the iterator and remove it from the map of iterators ('itIterators'
 -- and thus 'cdbIterators').
 implIteratorClose
-  :: (IOLike m, HasHeader blk)
+  :: IOLike m
   => StrictTVar m (IteratorState m blk)
   -> IteratorId
   -> IteratorEnv m blk

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
@@ -22,14 +22,16 @@ module Ouroboros.Storage.ChainDB.Impl.Query
   ) where
 
 import qualified Data.Map.Strict as Map
+import           Data.Typeable
 
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (BlockNo, ChainHash (..), HasHeader,
-                     HeaderHash, MaxSlotNo, Point, castPoint, genesisPoint,
-                     maxSlotNoFromWithOrigin, pointHash, pointSlot)
+                     HeaderHash, MaxSlotNo, Point, StandardHash, castPoint,
+                     genesisPoint, maxSlotNoFromWithOrigin, pointHash,
+                     pointSlot)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Extended
@@ -235,6 +237,7 @@ getAnyBlock immDB volDB p = case pointHash p of
             then return Nothing
             else ImmDB.getBlockWithPoint immDB p
 
-mustExist :: Point blk -> Maybe blk -> Either (ChainDbFailure blk) blk
+mustExist :: (Typeable blk, StandardHash blk)
+          => Point blk -> Maybe blk -> Either ChainDbFailure blk
 mustExist p Nothing  = Left  $ ChainDbMissingBlock p
 mustExist _ (Just b) = Right $ b

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
@@ -208,7 +208,7 @@ getAnyBlock
   -> Point blk
   -> m (Maybe blk)
 getAnyBlock immDB volDB p = case pointHash p of
-    GenesisHash    -> throwM $ NoGenesisBlock @blk
+    GenesisHash    -> throwM NoGenesisBlock
     BlockHash hash -> do
       -- Note: to determine whether a block is in the ImmutableDB, we can look
       -- at the slot of its tip, which we'll call @immTipSlot@. If the slot of

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
@@ -174,11 +174,7 @@ makeNewBlockOrHeaderReader h readerId registry = Reader {..}
     readerForward             = getReader1 h readerId $ forward           registry
     readerClose               = getEnv     h          $ close readerId
 
-close
-  :: forall m blk. (IOLike m, HasHeader blk)
-  => ReaderId
-  -> ChainDbEnv m blk
-  -> m ()
+close :: forall m blk. IOLike m => ReaderId -> ChainDbEnv m blk -> m ()
 close readerId CDB{..} = do
     mbReaderState <- atomically $ do
       readers <- readTVar cdbReaders
@@ -197,7 +193,7 @@ close readerId CDB{..} = do
 
 -- | Close the given 'ReaderState' by closing any 'ImmDB.Iterator' it might
 -- contain.
-closeReaderState :: (MonadCatch m, HasHeader blk)
+closeReaderState :: MonadCatch m
                  => ImmDB.ImmDB m blk -> ReaderState m blk -> m ()
 closeReaderState immDB = \case
      ReaderInMem _         -> return ()
@@ -474,10 +470,7 @@ switchFork ipoint newChain readerState =
           -> readerState
 
 -- | Close all open 'Reader's.
-closeAllReaders
-  :: (IOLike m, HasHeader blk)
-  => ChainDbEnv m blk
-  -> m ()
+closeAllReaders :: IOLike m => ChainDbEnv m blk -> m ()
 closeAllReaders CDB{..} = do
     readerStates <- atomically $ do
       readerStates <- readTVar cdbReaders >>= traverse readTVar . Map.elems

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
@@ -51,7 +51,6 @@ isOpen (CDBHandle varState) = readTVar varState <&> \case
 closeDB
   :: forall m blk.
      ( IOLike m
-     , HasHeader blk
      , HasHeader (Header blk)
      , HasCallStack
      )

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -18,6 +18,7 @@ import           Data.List (intercalate, span, unfoldr)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, isJust)
+import           Data.Typeable
 
 import           Test.QuickCheck
 import           Test.Tasty
@@ -106,11 +107,11 @@ prop_chainSync ChainSyncClientSetup {..} =
       Just (ForkTooDeep { _intersection = intersection })     ->
         label "ForkTooDeep" $
         counterexample ("ForkTooDeep intersection: " <> ppPoint intersection) $
-        not (AF.withinFragmentBounds intersection clientFragment)
+        not (withinFragmentBounds intersection clientFragment)
       Just (InvalidRollBack { _newPoint = intersection }) ->
         label "InvalidRollBack" $
         counterexample ("InvalidRollBack intersection: " <> ppPoint intersection) $
-        not (AF.withinFragmentBounds intersection synchedFragment)
+        not (withinFragmentBounds intersection synchedFragment)
       Just (NoMoreIntersection { _ourTip   = Our   (Tip ourHead   _)
                                , _theirTip = Their (Tip theirHead _)
                                }) ->
@@ -145,6 +146,18 @@ prop_chainSync ChainSyncClientSetup {..} =
       Just (_ourPrefix, _theirPrefix, ourSuffix, _theirSuffix) ->
         fromIntegral (AF.length ourSuffix) <= k
 
+-- | Generalization of 'AF.withinFragmentBounds' that returns false if the
+-- types don't line up
+--
+-- This kind of "dynamic type checking" is a bit ugly but is only necessary
+-- for the tests.
+withinFragmentBounds :: forall blk blk'. (HasHeader blk, Typeable blk')
+                     => Point blk -> AnchoredFragment blk' -> Bool
+withinFragmentBounds p af =
+    case eqT @blk @blk' of
+      Just Refl -> AF.withinFragmentBounds p af
+      Nothing   -> False
+
 -- | Check whether the anchored fragment is a suffix of the chain.
 isSuffixOf :: AnchoredFragment TestBlock -> Chain TestBlock -> Property
 isSuffixOf fragment chain =
@@ -167,9 +180,6 @@ clientId = CoreNodeId 0
 -- | Chain Sync Server
 serverId :: CoreNodeId
 serverId = CoreNodeId 1
-
--- | Terser notation
-type ChainSyncException = ChainSyncClientException TestBlock
 
 -- | Using slots as times, a schedule plans updates to a chain on certain
 -- slots.
@@ -247,7 +257,7 @@ runChainSync
     -> ServerUpdates
     -> SlotNo  -- ^ Start chain syncing at this slot.
     -> m (Chain TestBlock, Chain TestBlock,
-          AnchoredFragment TestBlock, Maybe ChainSyncException,
+          AnchoredFragment TestBlock, Maybe ChainSyncClientException,
           [TraceEvent])
        -- ^ (The final client chain, the final server chain, the synced
        --    candidate fragment, exception thrown by the chain sync client,
@@ -356,7 +366,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
                Map.insert serverId varCandidate
              runPipelinedPeer protocolTracer codecChainSyncId serverId clientChannel $
                chainSyncClientPeerPipelined $ client varCandidate
-        `catch` \(e :: ChainSyncException) -> do
+        `catch` \(e :: ChainSyncClientException) -> do
           -- TODO: Is this necessary? Wouldn't the Async's internal MVar do?
           atomically $ writeTVar varClientException (Just e)
           -- Rethrow, but it will be ignored anyway.
@@ -727,7 +737,7 @@ frequency' xs0 = lift (choose (1, tot)) >>= (`pick` xs0)
 ppBlock :: TestBlock -> String
 ppBlock = condense
 
-ppPoint :: Point TestBlock -> String
+ppPoint :: StandardHash blk => Point blk -> String
 ppPoint (Point Origin)   = "Origin"
 ppPoint (Point (At blk)) =
     "(S:" <> show s <> "; H:" <> show h <> ")"

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -63,6 +63,7 @@ import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..),
                      WithFingerprint (..))
 
+import           Test.Util.BlockchainTime
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -716,7 +716,7 @@ data MiniProtocolExpectedException blk
     -- exception.
   | MPEEBlockFetchClient BFClient.BlockFetchProtocolFailure
     -- ^ see "Ouroboros.Network.BlockFetch.Client"
-  | MPEEBlockFetchServer (BFServer.BlockFetchServerException blk)
+  | MPEEBlockFetchServer BFServer.BlockFetchServerException
     -- ^ see "Ouroboros.Consensus.BlockFetchServer"
   | MPEETxSubmissionClient TxOutbound.TxSubmissionProtocolError
     -- ^ see "Ouroboros.Network.TxSubmission.Outbound"

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -43,12 +43,12 @@ openDB cfg initLedger = do
         querySTM f = readTVar db >>= \m ->
           if Model.isOpen m
             then return (f m)
-            else throwM $ ClosedDBError @blk
+            else throwM ClosedDBError
 
         query :: (Model blk -> a) -> m a
         query = atomically . querySTM
 
-        queryE :: (Model blk -> Either (ChainDbError blk) a) -> m a
+        queryE :: (Model blk -> Either ChainDbError a) -> m a
         queryE f = query f >>= either throwM return
 
         updateSTM :: (Model blk -> (a, Model blk)) -> STM m a
@@ -57,9 +57,9 @@ openDB cfg initLedger = do
           if Model.isOpen m
             then let (a, m') = f m in writeTVar db m' >> return a
             else
-              throwM $ ClosedDBError @blk
+              throwM ClosedDBError
 
-        updateSTME :: (Model blk -> Either (ChainDbError blk) (a, Model blk))
+        updateSTME :: (Model blk -> Either ChainDbError (a, Model blk))
                    -> STM m a
         updateSTME f = do
             m <- readTVar db
@@ -68,12 +68,12 @@ openDB cfg initLedger = do
                 Left e        -> throwM e
                 Right (a, m') -> writeTVar db m' >> return a
               else
-                throwM $ ClosedDBError @blk
+                throwM ClosedDBError
 
         update :: (Model blk -> (a, Model blk)) -> m a
         update = atomically . updateSTM
 
-        updateE :: (Model blk -> Either (ChainDbError blk) (a, Model blk))
+        updateE :: (Model blk -> Either ChainDbError (a, Model blk))
                 -> m a
         updateE = atomically . updateSTME
 
@@ -102,7 +102,7 @@ openDB cfg initLedger = do
             }
           where
             readerInstruction' :: Model blk
-                               -> Either (ChainDbError blk)
+                               -> Either ChainDbError
                                          (Maybe (ChainUpdate blk blk), Model blk)
             readerInstruction' = Model.readerInstruction rdrId
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -125,7 +125,7 @@ hasBlock hash = isJust . getBlock hash
 
 getBlockByPoint :: HasHeader blk
                 => Point blk -> Model blk
-                -> Either (ChainDbError blk) (Maybe blk)
+                -> Either ChainDbError (Maybe blk)
 getBlockByPoint pt = case Block.pointHash pt of
     GenesisHash    -> const $ Left NoGenesisBlock
     BlockHash hash -> Right . getBlock hash
@@ -266,7 +266,7 @@ streamBlocks :: HasHeader blk
              => SecurityParam
              -> StreamFrom blk -> StreamTo blk
              -> Model blk
-             -> Either (ChainDbError blk)
+             -> Either ChainDbError
                        (Either (UnknownRange blk) IteratorId, Model blk)
 streamBlocks securityParam from to m = do
     unless (validBounds from to) $ Left (InvalidIteratorRange from to)
@@ -304,7 +304,7 @@ readerExists rdrId = CPS.readerExists rdrId . cps
 
 checkIfReaderExists :: CPS.ReaderId -> Model blk
                     -> a
-                    -> Either (ChainDbError blk) a
+                    -> Either ChainDbError a
 checkIfReaderExists rdrId m a
     | readerExists rdrId m
     = Right a
@@ -319,7 +319,7 @@ readBlocks m = (rdrId, m { cps = cps' })
 readerInstruction :: forall blk. HasHeader blk
                   => CPS.ReaderId
                   -> Model blk
-                  -> Either (ChainDbError blk)
+                  -> Either ChainDbError
                             (Maybe (ChainUpdate blk blk), Model blk)
 readerInstruction rdrId m = checkIfReaderExists rdrId m $
     rewrap $ CPS.readerInstruction rdrId (cps m)
@@ -333,7 +333,7 @@ readerForward :: HasHeader blk
               => CPS.ReaderId
               -> [Point blk]
               -> Model blk
-              -> Either (ChainDbError blk)
+              -> Either ChainDbError
                         (Maybe (Point blk), Model blk)
 readerForward rdrId points m = checkIfReaderExists rdrId m $
     case CPS.findFirstPoint points (cps m) of

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -297,7 +297,7 @@ instance Eq blk => Eq (MaybeGCedBlock blk) where
 
 -- | Responses are either successful termination or an error.
 newtype Resp blk it rdr = Resp
-  { getResp :: Either (ChainDbError blk) (Success blk it rdr) }
+  { getResp :: Either ChainDbError (Success blk it rdr) }
   deriving (Functor, Foldable, Traversable)
 
 deriving instance (TestConstraints blk, Show it, Show rdr)
@@ -364,8 +364,7 @@ runPure cfg = \case
     -- Executed whether the ChainDB is open or closed.
     openOrClosed f = first (Resp . Right . Unit) . f
 
-runIO :: TestConstraints blk
-      => ChainDB          IO blk
+runIO :: ChainDB          IO blk
       -> ChainDB.Internal IO blk
       -> ResourceRegistry IO
       ->     Cmd  blk (Iterator IO blk) (Reader IO blk blk)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
@@ -9,8 +9,6 @@ module Test.Ouroboros.Storage.Util where
 import           Control.Exception (Exception, SomeException)
 import qualified Control.Exception as E
 
-import           Data.Typeable
-
 import           System.Directory (getTemporaryDirectory)
 import           System.IO.Temp (withTempDirectory)
 
@@ -114,9 +112,8 @@ expectImmDBResult :: (a -> Assertion)
                   -> Assertion
 expectImmDBResult = expectResult prettyImmutableDBError
 
-expectVolDBResult :: (Show blockId)
-                  => (a -> Assertion)
-                  -> Either (VolatileDBError blockId) a
+expectVolDBResult :: (a -> Assertion)
+                  -> Either VolatileDBError a
                   -> Assertion
 expectVolDBResult = expectResult show
 
@@ -176,9 +173,9 @@ apiEquivalenceImmDB = apiEquivalence try prettyImmutableDBError sameImmutableDBE
   where
     try = tryImmDB EH.exceptions EH.exceptions
 
-apiEquivalenceVolDB :: (HasCallStack, Eq a, Show a, Show blockId, Typeable blockId, Eq blockId)
-                    => (Either (VolatileDBError blockId) a -> Assertion)
-                    -> (forall h. HasFS IO h -> ErrorHandling (VolatileDBError blockId) IO -> IO a)
+apiEquivalenceVolDB :: (HasCallStack, Eq a, Show a)
+                    => (Either VolatileDBError a -> Assertion)
+                    -> (forall h. HasFS IO h -> ErrorHandling VolatileDBError IO -> IO a)
                     -> Assertion
 apiEquivalenceVolDB = apiEquivalence try show sameVolatileDBError
   where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
@@ -17,7 +17,7 @@ import           Test.Ouroboros.Storage.VolatileDB.Model
 
 openDBMock  :: forall m blockId. IOLike m
             => (Ord blockId)
-            => ThrowCantCatch (VolatileDBError blockId) (STM m)
+            => ThrowCantCatch VolatileDBError (STM m)
             -> Int
             -> m (DBModel blockId, VolatileDB blockId m)
 openDBMock err maxNumPerFile = do
@@ -41,7 +41,7 @@ openDBMock err maxNumPerFile = do
         , getMaxSlotNo   = wrapModel  dbVar  $ getMaxSlotNoModel   err'
         }
 
-    err' :: ThrowCantCatch (VolatileDBError blockId)
+    err' :: ThrowCantCatch VolatileDBError
                            (StateT (DBModel blockId) (STM m))
     err' = EH.liftThrowT err
 

--- a/ouroboros-consensus/test-util/Test/Util/BlockchainTime.hs
+++ b/ouroboros-consensus/test-util/Test/Util/BlockchainTime.hs
@@ -1,0 +1,30 @@
+module Test.Util.BlockchainTime (
+    onSlot
+  , OnSlotException(..)
+  ) where
+
+import           Control.Exception (Exception)
+import           Control.Monad
+import           GHC.Stack
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+
+import           Ouroboros.Consensus.BlockchainTime
+import           Ouroboros.Consensus.Util.IOLike
+
+onSlot :: (HasCallStack, IOLike m) => BlockchainTime m -> SlotNo -> m () -> m ()
+onSlot btime slot k = do
+    startingSlot <- atomically $ getCurrentSlot btime
+    when (startingSlot >= slot) $
+      throwM $ OnSlotTooLate slot startingSlot
+    onSlotChange btime $ \slot' ->
+      when (slot == slot') k
+
+data OnSlotException =
+    -- | An action was scheduled via 'onSlot' for a slot in the past.
+    -- First slot is requested, second slot is current as of raising.
+    OnSlotTooLate SlotNo SlotNo
+  deriving (Eq, Show)
+
+instance Exception OnSlotException


### PR DESCRIPTION
NOTE:  "Remove `tip` argument to ChainSyncClient" is #1238.

This commit paves the way for consensus error policies. It removes type parameters from exception types, so that we cannot introduce bugs where we miss certain exceptions because due to (type) matching on exceptions of the wrong type (e.g., instantiated to header instead of block). 

It also removes `onSlot` from `BlockchainTime`. This was used only in tests, where it is easily replaced. 