### PR TITLE
Removed subscriptionTracer from Tracers'

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -10,13 +10,10 @@ module Ouroboros.Consensus.Node.Tracers
   ) where
 
 import           Control.Tracer (Tracer, nullTracer, showTracing)
-import qualified Network.Socket as Socket
 
 import           Ouroboros.Network.Block (Point, SlotNo)
 import           Ouroboros.Network.BlockFetch (FetchDecision,
                      TraceFetchClientState, TraceLabelPeer)
-import           Ouroboros.Network.Subscription.Ip (SubscriptionTrace,
-                     WithIPList)
 import           Ouroboros.Network.TxSubmission.Inbound
                      (TraceTxSubmissionInbound)
 import           Ouroboros.Network.TxSubmission.Outbound
@@ -48,7 +45,6 @@ data Tracers' peer blk f = Tracers
   , localTxSubmissionServerTracer :: f (TraceLocalTxSubmissionServerEvent blk)
   , mempoolTracer                 :: f (TraceEventMempool blk)
   , forgeTracer                   :: f (TraceForgeEvent blk)
-  , subscriptionTracer            :: f (WithIPList (SubscriptionTrace Socket.SockAddr))
   }
 
 -- | A record of 'Tracer's for the node.
@@ -68,7 +64,6 @@ nullTracers = Tracers
   , localTxSubmissionServerTracer = nullTracer
   , mempoolTracer                 = nullTracer
   , forgeTracer                   = nullTracer
-  , subscriptionTracer            = nullTracer
   }
 
 showTracers :: ( Show blk
@@ -91,7 +86,6 @@ showTracers tr = Tracers
   , localTxSubmissionServerTracer = showTracing tr
   , mempoolTracer                 = showTracing tr
   , forgeTracer                   = showTracing tr
-  , subscriptionTracer            = showTracing tr
   }
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
This tracer is passed using `RunNetworkArgs` to `initNetwork`.