### PR TITLE
Remove special case in chain sync client

### DIFF
--- a/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/General.hs
@@ -68,7 +68,8 @@ data TestConfig = TestConfig
 
 genTestConfig :: NumCoreNodes -> NumSlots -> Gen TestConfig
 genTestConfig numCoreNodes numSlots = do
-    nodeJoinPlan <- genNodeJoinPlan numCoreNodes numSlots
+    -- nodeJoinPlan <- genNodeJoinPlan numCoreNodes numSlots -- TODO #1257
+    let nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
     nodeTopology <- genNodeTopology numCoreNodes
     pure TestConfig{numCoreNodes, numSlots, nodeJoinPlan, nodeTopology}
 


### PR DESCRIPTION
The special case was incorrect (#1257).

This means however that we cannot deal with low-density chains. This
isn't a problem for the real chain, but it is a problem for the tests.
For now I've disabled testing with nodes joining late; we need to
reconsider this and have them join late but not so late that the chain
density goes too low.