### PR TITLE
Binary streaming of blocks to the BlockFetch server

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -138,7 +138,7 @@ run tracers chainDbTracer diffusionTracers diffusionArguments networkMagic dbPat
       onNodeKernel registry nodeKernel
       let networkApps :: NetworkApplication
                            IO ConnectionId
-                           ByteString ByteString ByteString ByteString ByteString
+                           ByteString ByteString ByteString ByteString ByteString ByteString
                            ()
           networkApps = consensusNetworkApps
             nodeKernel

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE DataKinds     #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingVia   #-}
-{-# LANGUAGE RankNTypes    #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingVia       #-}
+{-# LANGUAGE RankNTypes        #-}
 module Ouroboros.Storage.ImmutableDB.API
   ( ImmutableDB (..)
   , withDB
@@ -301,7 +301,7 @@ data IteratorResult hash a
   = IteratorExhausted
   | IteratorResult    SlotNo  hash a
   | IteratorEBB       EpochNo hash a
-  deriving (Show, Eq, Generic, Functor)
+  deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 -- | Consume an 'Iterator' by stepping until it is exhausted. A list of all
 -- the 'IteratorResult's (excluding the final 'IteratorExhausted') produced by

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/API.hs
@@ -39,7 +39,7 @@ data VolatileDB blockId m = VolatileDB {
       closeDB        :: HasCallStack => m ()
     , isOpenDB       :: HasCallStack => m Bool
     , reOpenDB       :: HasCallStack => m ()
-    , getBlock       :: HasCallStack => blockId -> m (Maybe ByteString)
+    , getBlock       :: HasCallStack => blockId -> m (Maybe (SlotNo, ByteString))
     , putBlock       :: HasCallStack => BlockInfo blockId -> Builder -> m ()
     , getBlockIds    :: HasCallStack => m [blockId]
       -- | Return a function that returns the successors of the block with the

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -30,7 +30,7 @@ import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.ChainDB.API (Iterator (..), IteratorId (..),
                      IteratorResult (..), StreamFrom (..), StreamTo (..),
-                     UnknownRange)
+                     UnknownRange, deserialiseIterator)
 import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB, getPointAtTip,
                      mkImmDB)
 import           Ouroboros.Storage.ChainDB.Impl.Iterator (IteratorEnv (..),
@@ -226,7 +226,7 @@ runIterator setup from to = runSimOrThrow $ withRegistry $ \r -> do
     itEnv <- initIteratorEnv setup tracer
     res <- runExceptT $ do
       it <- ExceptT $ newIterator itEnv ($ itEnv) r from to
-      lift $ consume it
+      lift $ consume (deserialiseIterator it)
     trace <- getTrace
     return (trace, res)
   where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -83,10 +83,10 @@ openDB cfg initLedger btime = do
         update_ :: (Model blk -> Model blk) -> m ()
         update_ f = update (\m -> ((), f m))
 
-        iterator :: IteratorId -> Iterator m blk
+        iterator :: IteratorId -> Iterator m (Deserialisable m blk)
         iterator itrId = Iterator {
-              iteratorNext  = update  $ Model.iteratorNext  itrId
-            , iteratorClose = update_ $ Model.iteratorClose itrId
+              iteratorNext  = update  $ Model.iteratorNextDeserialised itrId
+            , iteratorClose = update_ $ Model.iteratorClose            itrId
             , iteratorId    = itrId
             }
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -262,7 +262,7 @@ run ChainDB{..} internal@ChainDB.Internal{..} registry varCurSlot = \case
   where
     mbGCedBlock = MbGCedBlock . MaybeGCedBlock True
     iterResultGCed = IterResultGCed . IteratorResultGCed True
-    iter = either UnknownRange Iter
+    iter = either UnknownRange (Iter . deserialiseIterator)
     ignore _ = Unit ()
 
     advanceAndAdd newCurSlot blk = do

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -78,7 +78,7 @@ type (:@) t r = At t r
 
 data Success
   = Unit     ()
-  | Blob     (Maybe ByteString)
+  | Blob     (Maybe (SlotNo, ByteString))
   | Blocks   [BlockId]
   | Bl       Bool
   | IsMember [Bool] -- We compare two functions based on their results on a list of inputs.

--- a/ouroboros-consensus/tools/db-analyse/Main.hs
+++ b/ouroboros-consensus/tools/db-analyse/Main.hs
@@ -142,7 +142,7 @@ processAll :: ImmDB IO ByronBlock
            -> IO ()
 processAll immDB rr callback = do
     Right itr <- streamBlocksFrom immDB rr $ StreamFromExclusive genesisPoint
-    go itr
+    go (deserialiseIterator immDB itr)
   where
     go :: Iterator ByronHash IO ByronBlock -> IO ()
     go itr = do

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -51,14 +51,14 @@ instance Protocol (BlockFetch block) where
     MsgClientDone
       :: Message (BlockFetch block) BFIdle BFDone
 
-  data ClientHasAgency ps where
+  data ClientHasAgency st where
     TokIdle :: ClientHasAgency BFIdle
 
-  data ServerHasAgency ps where
+  data ServerHasAgency st where
     TokBusy      :: ServerHasAgency BFBusy
     TokStreaming :: ServerHasAgency BFStreaming
 
-  data NobodyHasAgency ps where
+  data NobodyHasAgency st where
     TokDone :: NobodyHasAgency BFDone
 
   exclusionLemma_ClientAndServerHaveAgency


### PR DESCRIPTION
To serve blocks to other peers via the BlockFetch server, we read them from
disk, deserialise them, and then serialise them again when they are sent over
the network. To avoid this needless (de)serialisation, make the ChainDB able
to stream binary blocks without deserialising them.

* Add `Serialised blk` to `Ouroboros.Network.Block`, which just wraps the
  serialised bytes of a block.

* Add `Deserialisable m blk` to the `ChainDB`, which consists of `Serialised
  blk`, `SlotNo`, `HeaderHash blk`, and `m blk`. Use this internally as well:
  functions that need to deserialise the block are implemented in terms of
  functions that return a 'Deserialisable`.

* Let the VolatileDB return the `SlotNo` of a block too, as it is needed to
  construct a `SerialisedBlock`.

* TODO I have temporarily switched consensus protocol tests over to the new
  asymmetric codec that serialised. Previously, and in the future, they should
  use `AnyMessage` to avoid (de)serialisation altogether.