### PR TITLE
Block forging improvements

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -176,6 +176,9 @@ data Mempool m blk idx = Mempool {
       -- to the mempool.
       addTxs        :: [GenTx blk] -> m [(GenTx blk, Maybe (ApplyTxErr blk))]
 
+      -- | Manually remove the given transactions from the mempool.
+    , removeTxs     :: [GenTxId blk] -> m ()
+
       -- | Sync the transactions in the mempool with the current ledger state
       --  of the 'ChainDB'.
       --
@@ -264,11 +267,25 @@ data TraceEventMempool blk
       -- from the Mempool.
       !Word
       -- ^ The total number of transactions now in the Mempool.
+  | TraceMempoolManuallyRemovedTxs
+      ![GenTxId blk]
+      -- ^ Transactions that have been manually removed from the Mempool.
+      ![GenTx blk]
+      -- ^ Previously valid transactions that are no longer valid because they
+      -- dependend on transactions that were manually removed from the
+      -- Mempool. These transactions have also been removed from the Mempool.
+      --
+      -- This list shares not transactions with the list of manually removed
+      -- transactions.
+      !Word
+      -- ^ The total number of transactions now in the Mempool.
 
 deriving instance ( Eq (GenTx blk)
+                  , Eq (GenTxId blk)
                   , Eq (ApplyTxErr blk)
                   ) => Eq (TraceEventMempool blk)
 
 deriving instance ( Show (GenTx blk)
+                  , Show (GenTxId blk)
                   , Show (ApplyTxErr blk)
                   ) => Show (TraceEventMempool blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -14,6 +14,7 @@ module Ouroboros.Consensus.Mempool.TxSeq (
   , lookupByTicketNo
   , splitAfterTicketNo
   , zeroTicketNo
+  , filterTxs
   ) where
 
 import           Data.FingerTree.Strict (StrictFingerTree)
@@ -165,3 +166,12 @@ fromTxSeq :: TxSeq tx -> [(tx, TicketNo)]
 fromTxSeq (TxSeq ftree) = fmap
   (\(TxTicket tx tn) -> (tx, tn))
   (Foldable.toList $ ftree)
+
+-- | \( O(n) \). Filter the 'TxSeq'.
+filterTxs :: (TxTicket tx -> Bool) -> TxSeq tx -> TxSeq tx
+filterTxs p (TxSeq ftree) =
+      TxSeq
+    . FingerTree.fromList
+    . filter p
+    . Foldable.toList
+    $ ftree

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -140,7 +140,7 @@ infixl 5 :>, :<
 {-# COMPLETE Empty, (:<) #-}
 
 
--- | \( O(\log(n) \). Look up a transaction in the sequence by its 'TicketNo'.
+-- | \( O(\log(n)) \). Look up a transaction in the sequence by its 'TicketNo'.
 --
 lookupByTicketNo :: TxSeq tx -> TicketNo -> Maybe tx
 lookupByTicketNo (TxSeq txs) n =
@@ -149,7 +149,7 @@ lookupByTicketNo (TxSeq txs) n =
       FingerTree.Position _ (TxTicket tx n') _ | n' == n -> Just tx
       _                                                  -> Nothing
 
--- | \( O(\log(n) \). Split the sequence of transactions into two parts
+-- | \( O(\log(n)) \). Split the sequence of transactions into two parts
 -- based on the given 'TicketNo'. The first part has transactions with tickets
 -- less than or equal to the given ticket, and the second part has transactions
 -- with tickets strictly greater than the given ticket.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -19,12 +19,14 @@ import           Ouroboros.Network.TxSubmission.Inbound
 import           Ouroboros.Network.TxSubmission.Outbound
                      (TraceTxSubmissionOutbound)
 
-import           Ouroboros.Consensus.Block (Header, SupportedBlock)
+import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Consensus.BlockFetchServer
                      (TraceBlockFetchServerEvent)
-import           Ouroboros.Consensus.ChainSyncClient (TraceChainSyncClientEvent)
+import           Ouroboros.Consensus.ChainSyncClient (InvalidBlockReason,
+                     TraceChainSyncClientEvent)
 import           Ouroboros.Consensus.ChainSyncServer (TraceChainSyncServerEvent)
-import           Ouroboros.Consensus.Ledger.Abstract (AnachronyFailure)
+import           Ouroboros.Consensus.Ledger.Abstract (AnachronyFailure,
+                     ProtocolLedgerView)
 import           Ouroboros.Consensus.Mempool.API (ApplyTxErr, GenTx, GenTxId,
                      TraceEventMempool)
 import           Ouroboros.Consensus.TxSubmission
@@ -73,7 +75,7 @@ showTracers :: ( Show blk
                , Show (ApplyTxErr blk)
                , Show (Header blk)
                , Show peer
-               , SupportedBlock blk
+               , ProtocolLedgerView blk
                )
             => Tracer m String -> Tracers m peer blk
 showTracers tr = Tracers
@@ -106,4 +108,18 @@ data TraceForgeEvent blk
   -- 'anachronisticProtocolLedgerView', although we expect this to be
   -- 'TooFarAhead', never 'TooFarBehind'.
   | TraceCouldNotForge SlotNo AnachronyFailure
+
+  -- | We adopted the block we produced
+  | TraceAdoptedBlock SlotNo blk
+
+  -- | We did not adopt the block we produced, but the block was valid. We
+  -- must have adopted a block that another leader of the same slot produced
+  -- before we got the chance of adopting our own block. This is very rare,
+  -- this warrants a warning.
+  | TraceDidntAdoptBlock SlotNo blk
+
+  -- | We forged a block that is invalid according to the ledger in the
+  -- ChainDB. This means there is an inconsistency between the mempool
+  -- validation and the ledger validation. This is a serious error!
+  | TraceForgedInvalidBlock SlotNo blk (InvalidBlockReason blk)
   deriving (Eq, Show)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -69,6 +69,7 @@ nullTracers = Tracers
 
 showTracers :: ( Show blk
                , Show (GenTx blk)
+               , Show (GenTxId blk)
                , Show (ApplyTxErr blk)
                , Show (Header blk)
                , Show peer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -348,12 +348,14 @@ forkBlockProduction IS{..} =
         NotLeader ->
           return ()
         ProducedBlock newBlock -> do
-          traceWith (forgeTracer tracers) $ TraceForgeEvent currentSlot newBlock
+          trace $ TraceForgeEvent currentSlot newBlock
           ChainDB.addBlock chainDB newBlock
         FailedToProduce err ->
-          traceWith (forgeTracer tracers) $ TraceCouldNotForge currentSlot err
+          trace $ TraceCouldNotForge currentSlot err
   where
     NodeCallbacks{..} = callbacks
+
+    trace = traceWith (forgeTracer tracers)
 
     -- Return the point and block number of the most recent block in the
     -- current chain with a slot < the given slot. These will either

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -101,6 +101,9 @@ data ChainDB m blk = ChainDB {
       -- to the current chain; even if the block is valid, it will not become
       -- part of the chain if there are other chains available that are
       -- preferred by the consensus algorithm (typically, longer chains).
+      --
+      -- This function triggers chain selection (if necessary) and terminates
+      -- after chain selection is done.
       addBlock           :: blk -> m ()
 
       -- | Get the current chain fragment

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -413,10 +413,12 @@ instance Arbitrary TestSetup where
     -- TODO we could shrink @testLedgerState@ too
     [ TestSetup { testLedgerState
                 , testInitialTxs = testInitialTxs'
-                , testMempoolCap = testMempoolCap'
+                , testMempoolCap = MempoolCapacity mpCap'
                 }
-    | testInitialTxs' <- shrinkList (const []) testInitialTxs,
-      testMempoolCap' <- map MempoolCapacity (shrinkIntegral mpCap) ]
+    | testInitialTxs' <- shrinkList (const []) testInitialTxs
+    , mpCap' <- shrinkIntegral mpCap
+    , mpCap' > 0
+    ]
 
 -- | Generate a number of valid and invalid transactions and apply the valid
 -- transactions to the given 'LedgerState'. The transactions along with a

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -60,6 +60,7 @@ tests = testGroup "Mempool"
   , testProperty "Rejected invalid txs are traced"         prop_Mempool_TraceRejectedTxs
   , testProperty "Removed invalid txs are traced"          prop_Mempool_TraceRemovedTxs
   , testProperty "idx consistency"                         prop_Mempool_idx_consistency
+  , testProperty "removeTxs"                               prop_Mempool_removeTxs
   ]
 
 {-------------------------------------------------------------------------------
@@ -127,6 +128,20 @@ prop_Mempool_InvalidTxsNeverAdded setup =
         | txInMempool <- txsInMempoolAfter
         , txInMempool `notElem` txsInMempoolBefore
         ]
+
+-- | After removing a transaction from the Mempool, it's actually gone.
+prop_Mempool_removeTxs :: TestSetupWithTxInMempool -> Property
+prop_Mempool_removeTxs (TestSetupWithTxInMempool testSetup tx) =
+    withTestMempool testSetup $ \TestMempool { mempool } -> do
+      let Mempool { removeTxs, getSnapshot } = mempool
+      removeTxs [txId txToRemove]
+      txsInMempoolAfter <- map fst . snapshotTxs <$> atomically getSnapshot
+      return $ counterexample
+        ("Transactions in the mempool after removing (" <>
+         show txToRemove <> "): " <> show txsInMempoolAfter)
+        (txToRemove `notElem` txsInMempoolAfter)
+  where
+    txToRemove = TestGenTx tx
 
 -- | When the mempool is at capacity, test that 'addTxs' blocks when
 -- attempting to add one more transaction and that it unblocks when there is
@@ -289,6 +304,8 @@ prop_Mempool_Capacity mcts = withTestMempool mctsTestSetup $
       TraceMempoolAddTxs      txs mpSz -> TraceMempoolAddTxs      (sort txs) mpSz
       TraceMempoolRemoveTxs   txs mpSz -> TraceMempoolRemoveTxs   (sort txs) mpSz
       TraceMempoolRejectedTxs txs mpSz -> TraceMempoolRejectedTxs (sort txs) mpSz
+      TraceMempoolManuallyRemovedTxs txIds txs mpSz ->
+        TraceMempoolManuallyRemovedTxs (sort txIds) (sort txs) mpSz
 
 -- | Test that all valid transactions added to a 'Mempool' via 'addTxs' are
 -- appropriately represented in the trace of events.
@@ -557,6 +574,29 @@ revalidate TestSetup { testLedgerState, testInitialTxs } =
       tx:txs' -> case runExcept (applyTxToLedger ledgerState tx) of
         Left _             -> go ledgerState  ((tx, False):revalidated) txs'
         Right ledgerState' -> go ledgerState' ((tx, True):revalidated)  txs'
+
+{-------------------------------------------------------------------------------
+  TestSetupWithTxInMempol: a mempool and a transaction that is in the mempool
+-------------------------------------------------------------------------------}
+
+-- | A 'TestSetup' along with a transaction that is in the Mempool.
+--
+-- > 'txInMempool' `elem` 'testInitialTxs' 'testSetup'
+data TestSetupWithTxInMempool = TestSetupWithTxInMempool TestSetup TestTx
+  deriving (Show)
+
+instance Arbitrary TestSetupWithTxInMempool where
+  arbitrary = do
+    TestSetupWithTxs { testSetup } <-
+      arbitrary `suchThat` (not . null . testInitialTxs . testSetup)
+    tx <- elements (testInitialTxs testSetup)
+    return $ TestSetupWithTxInMempool testSetup tx
+  shrink (TestSetupWithTxInMempool testSetup _tx) =
+    [ TestSetupWithTxInMempool testSetup tx'
+    | testSetup' <- shrink testSetup
+    , not . null . testInitialTxs $ testSetup'
+    , tx' <- testInitialTxs testSetup'
+    ]
 
 {-------------------------------------------------------------------------------
   TestMempool: a mempool with random contents

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -64,6 +64,7 @@ import qualified Ouroboros.Consensus.BlockFetchServer as BFServer
 import           Ouroboros.Consensus.ChainSyncClient (ClockSkew (..))
 import qualified Ouroboros.Consensus.ChainSyncClient as CSClient
 import           Ouroboros.Consensus.ChainSyncServer (Tip)
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Mempool
@@ -632,7 +633,7 @@ nullDebugTracer = nullTracer `asTypeOf` showTracing debugTracer
 nullDebugTracers ::
      ( Monad m
      , Show peer
-     , SupportedBlock blk
+     , ProtocolLedgerView blk
      , TracingConstraints blk
      )
   => Tracers m peer blk


### PR DESCRIPTION
~This builds further upon #1279 and thus includes it for now.~ *Update: merged*

Addresses #787: trace whether we adopted or block or not.

Addresses #1225: if we produced an invalid block, we remove all transactions
in it from the Mempool.

~Addresses #1150: handle clock skew when producing a new block~ *Update: this will be handled by the ChainDB in a separate PR*

It also includes some minor improvements/fixes that I made along the way.