### PR TITLE
Re-enable late joins

### DIFF
--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -113,6 +113,7 @@
             (hsPkgs.ouroboros-consensus)
             (hsPkgs.io-sim-classes)
             (hsPkgs.io-sim)
+            (hsPkgs.binary-search)
             (hsPkgs.cborg)
             (hsPkgs.containers)
             (hsPkgs.contra-tracer)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -308,6 +308,7 @@ test-suite test-consensus
                     io-sim-classes,
                     io-sim,
 
+                    binary-search,
                     cborg,
                     containers,
                     contra-tracer,

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -287,6 +287,7 @@ test-suite test-consensus
                     Test.Util.QSM
                     Test.Util.Range
                     Test.Util.SOP
+                    Test.Util.Shrink
                     Test.Util.TestBlock
                     Test.Util.Tracer
   build-depends:    base,

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -268,6 +268,7 @@ test-suite test-consensus
                     Test.Dynamic.PBFT
                     Test.Dynamic.Praos
                     Test.Dynamic.RealPBFT
+                    Test.Dynamic.Ref.RealPBFT
                     Test.Dynamic.TxGen
                     Test.Dynamic.Util
                     Test.Dynamic.Util.Expectations

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -169,7 +169,7 @@ data PBftParams = PBftParams {
       -- parameter to the ambient security parameter @k@.
     , pbftSignatureThreshold :: !Double
     }
-  deriving (Generic, NoUnexpectedThunks)
+  deriving (Generic, NoUnexpectedThunks, Show)
 
 -- | If we are a core node (i.e. a block producing node) we know which core
 -- node we are, and we have the operational key pair and delegation certificate.

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
@@ -15,6 +15,7 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromJust)
 import           Data.Time (Day (..), UTCTime (..))
 
+import           Numeric.Search.Range (searchFromTo)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -39,11 +40,13 @@ import qualified Test.Cardano.Chain.Genesis.Dummy as Dummy
 
 import           Test.Dynamic.General
 import           Test.Dynamic.Network (NodeOutput (..))
+import qualified Test.Dynamic.Ref.RealPBFT as Ref
 import           Test.Dynamic.Util
 import           Test.Dynamic.Util.NodeJoinPlan
 import           Test.Dynamic.Util.NodeTopology
 
 import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Shrink (andId, dropId)
 
 tests :: TestTree
 tests = testGroup "Dynamic chain generation"
@@ -71,8 +74,9 @@ tests = testGroup "Dynamic chain generation"
               ]
             , nodeTopology = meshNodeTopology ncn
             }
-    , testProperty "simple Real PBFT convergence" $
-        prop_simple_real_pbft_convergence
+    , testProperty "simple Real PBFT convergence" $ \seed ->
+        forAllShrink genRealPBFTTestConfig shrinkRealPBFTTestConfig $ \testConfig ->
+        prop_simple_real_pbft_convergence testConfig seed
     ]
 
 prop_setup_coreNodeId ::
@@ -127,11 +131,11 @@ mkProtocolRealPBFT :: NumCoreNodes
                    -> Genesis.Config
                    -> Genesis.GeneratedSecrets
                    -> Protocol ByronBlock
-mkProtocolRealPBFT (NumCoreNodes n) (CoreNodeId i)
+mkProtocolRealPBFT numCoreNodes (CoreNodeId i)
                    genesisConfig genesisSecrets =
     ProtocolRealPBFT
       genesisConfig
-      (Just signatureThreshold)
+      (Just $ PBftSignatureThreshold pbftSignatureThreshold)
       (Update.ProtocolVersion 1 0 0)
       (Update.SoftwareVersion (Update.ApplicationName "Cardano Test") 2)
       (Just leaderCredentials)
@@ -143,8 +147,7 @@ mkProtocolRealPBFT (NumCoreNodes n) (CoreNodeId i)
           dlgKey
           dlgCert
 
-    signatureThreshold = PBftSignatureThreshold $
-      (1.0 / fromIntegral n) + 0.1
+    PBftParams{pbftSignatureThreshold} = realPBftParams numCoreNodes
 
     dlgKey :: Crypto.SigningKey
     dlgKey = fromJust $
@@ -159,15 +162,34 @@ mkProtocolRealPBFT (NumCoreNodes n) (CoreNodeId i)
            $ Genesis.gdHeavyDelegation
            $ Genesis.configGenesisData genesisConfig
 
+{-------------------------------------------------------------------------------
+  Generating the genesis configuration
+-------------------------------------------------------------------------------}
+
+realPBftParams :: NumCoreNodes -> PBftParams
+realPBftParams numCoreNodes = PBftParams
+  { pbftNumNodes           = n
+  , pbftSecurityParam      = SecurityParam k
+  , pbftSignatureThreshold = (1 / n) + (1 / k)
+    -- crucially: @floor (k * t) >= ceil (k / n)@
+  }
+    where
+      n :: Num a => a
+      n = fromIntegral x where NumCoreNodes x = numCoreNodes
+
+      k :: Num a => a
+      k = 10
 
 -- Instead of using 'Dummy.dummyConfig', which hard codes the number of rich
 -- men (= CoreNodes for us) to 4, we generate a dummy config with the given
 -- number of rich men.
 generateGenesisConfig :: NumCoreNodes -> (Genesis.Config, Genesis.GeneratedSecrets)
-generateGenesisConfig (NumCoreNodes n) =
+generateGenesisConfig numCoreNodes =
     either (error . show) id $ Genesis.generateGenesisConfig startTime spec
   where
     startTime = UTCTime (ModifiedJulianDay 0) 0
+    NumCoreNodes n = numCoreNodes
+    PBftParams{pbftSecurityParam} = realPBftParams numCoreNodes
 
     spec :: Genesis.GenesisSpec
     spec = Dummy.dummyGenesisSpec
@@ -177,4 +199,138 @@ generateGenesisConfig (NumCoreNodes n) =
               -- The nodes are the richmen
               { Genesis.tboRichmen = fromIntegral n }
         }
+      , Genesis.gsK = Common.BlockCount $ maxRollbacks pbftSecurityParam
       }
+
+{-------------------------------------------------------------------------------
+  Generating node join plans that ensure sufficiently dense chains
+-------------------------------------------------------------------------------}
+
+genSlot :: SlotNo -> SlotNo -> Gen SlotNo
+genSlot lo hi = SlotNo <$> choose (unSlotNo lo, unSlotNo hi)
+
+-- | As 'genNodeJoinPlan', but ensures an additional invariant
+--
+-- INVARIANT this 'NodeJoinPlan' ensures that -- under \"ideal circumstances\"
+-- -- the chain includes at least @k@ blocks within every @2k@-slot window.
+--
+-- Note that there is only one chain: at any slot onset, the net's fork only
+-- has one tine.
+--
+genRealPBFTNodeJoinPlan :: PBftParams -> NumSlots -> Gen NodeJoinPlan
+genRealPBFTNodeJoinPlan params numSlots@(NumSlots t)
+  | n < 0 || t < 1 = error $ "Cannot generate RealPBFT NodeJoinPlan: "
+    ++ show (params, numSlots)
+  | otherwise      = go (NodeJoinPlan Map.empty) Ref.emptyState
+  where
+    PBftParams{pbftNumNodes} = params
+    n                        = fromIntegral pbftNumNodes
+
+    lastSlot = SlotNo $ fromIntegral $ t - 1
+
+    go ::
+         NodeJoinPlan
+         -- ^ an /incomplete/ and /viable/ node join plan
+      -> Ref.State
+         -- ^ a state whose 'Ref.nextSlot' is <= the last join slot in given
+         -- plan (or 0 if the plan is empty)
+      -> Gen NodeJoinPlan
+    go nodeJoinPlan@(NodeJoinPlan m) st
+      | i == n    = pure $ NodeJoinPlan m
+      | otherwise = do
+            -- @True@ if this join slot for @nid@ is viable
+            --
+            -- /Viable/ means the desired chain density invariant remains
+            -- satisfiable, at the very least the nodes after @nid@ may need to
+            -- also join in this same slot.
+            --
+            -- Assuming @nodeJoinPlan@ is indeed viable and @st@ is indeed not
+            -- ahead of it, then we should be able to find a join slot for
+            -- @nid@ that is also viable: the viability of @nodeJoinPlan@ means
+            -- @nid@ can at least join \"immediately\" wrt to @nodeJoinPlan@.
+            --
+            -- The base case is that the empty join plan and empty state are
+            -- viable, which assumes that the invariant would be satisified if
+            -- all nodes join in slot 0. For uninterrupted round-robin, that
+            -- merely requires @n * floor (k * t) >= k@. (TODO Does that
+            -- *always* suffice?)
+        let check s' =
+                Ref.viable params lastSlot
+                    (NodeJoinPlan (Map.insert nid s' m))
+                    st
+            lo = Ref.nextSlot st
+
+            -- @check@ is downward-closed, but 'searchFromTo' requires
+            -- upward-closed, so we search in dualized range
+            inn = (maxBound -) . unSlotNo
+            out = SlotNo . (maxBound -)
+        s' <- case out <$> searchFromTo (check . out) (inn lastSlot) (inn lo) of
+            Just hi -> genSlot lo hi
+            Nothing -> error $
+                "Cannot find viable RealPBFT NodeJoinPlan: " ++
+                show (nodeJoinPlan, st)
+
+        let m'  = Map.insert nid s' m
+
+            -- optimization: avoid simulating from the same inputs multiple
+            -- times
+            --
+            -- We've decided that @nid@ joins in @s'@, so advance the state to
+            -- /just/ /before/ @s'@, since we might want @nid+1@ to also join
+            -- in @s'@.
+            --
+            -- NOTE @m@ is congruent to @m'@ for all slots prior to @s'@
+            st' = Ref.advanceUpTo params nodeJoinPlan st s'
+        go (NodeJoinPlan m') st'
+      where
+        -- the next node to be added to the incomplete join plan
+        nid = CoreNodeId i
+        i   = case fst <$> Map.lookupMax m of
+            Nothing             -> 0
+            Just (CoreNodeId h) -> succ h
+
+genRealPBFTTestConfig :: Gen TestConfig
+genRealPBFTTestConfig = do
+    numCoreNodes <- arbitrary
+    numSlots     <- arbitrary
+
+    let params = realPBftParams numCoreNodes
+    nodeJoinPlan <- genRealPBFTNodeJoinPlan params numSlots
+    nodeTopology <- genNodeTopology numCoreNodes
+
+    pure TestConfig
+      { nodeJoinPlan
+      , nodeTopology
+      , numCoreNodes
+      , numSlots
+      }
+
+shrinkRealPBFTTestConfig :: TestConfig -> [TestConfig]
+shrinkRealPBFTTestConfig  = shrinkTestConfigSlotsOnly
+  -- NOTE 'shrink' at type 'NodePlanJoin' never increases inter-join delays
+  --
+  -- and we're neither shrinking the security parameter nor /increasing/ the
+  -- number of slots, so the invariant established by 'genRealPBFTNodeJoinPlan'
+  -- will be preserved
+
+-- | Shrink, including the number of slots but not number of nodes
+--
+shrinkTestConfigSlotsOnly :: TestConfig -> [TestConfig]
+shrinkTestConfigSlotsOnly TestConfig
+  { numCoreNodes
+  , numSlots
+  , nodeJoinPlan
+  , nodeTopology
+  } =
+    dropId $
+    [ TestConfig
+        { nodeJoinPlan = p'
+        , nodeTopology = top'
+        , numCoreNodes
+        , numSlots     = t'
+        }
+    | t'            <- andId shrink numSlots
+    , let adjustedP  = truncateNodeJoinPlan nodeJoinPlan numCoreNodes (numSlots, t')
+    , p'            <- andId shrinkNodeJoinPlan adjustedP
+    , top'          <- andId shrinkNodeTopology nodeTopology
+    ]

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Ref/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Ref/RealPBFT.hs
@@ -1,0 +1,253 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | A reference simulator of the RealPBFT protocol under \"ideal
+-- circumstances\"
+--
+-- See 'step'.
+--
+module Test.Dynamic.Ref.RealPBFT (
+  Outcome (..),
+  State (..),
+  advanceUpTo,
+  emptyState,
+  nullState,
+  step,
+  viable,
+  ) where
+
+import           Data.Foldable (Foldable, foldl', toList)
+import qualified Data.Map as Map
+import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+
+import           Ouroboros.Network.Block (SlotNo (..))
+
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
+import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
+import           Ouroboros.Consensus.Protocol.PBFT (PBftParams (..))
+
+import           Test.Dynamic.Util.NodeJoinPlan
+
+oneK :: Num a => PBftParams -> a
+oneK PBftParams{pbftSecurityParam} =
+    fromIntegral (maxRollbacks pbftSecurityParam)
+
+twoK :: Num a => PBftParams -> a
+twoK PBftParams{pbftSecurityParam} =
+    2 * fromIntegral (maxRollbacks pbftSecurityParam)
+
+oneN :: Num a => PBftParams -> a
+oneN PBftParams{pbftNumNodes} = fromIntegral pbftNumNodes
+
+{-------------------------------------------------------------------------------
+  PBFT state
+-------------------------------------------------------------------------------}
+
+-- | Outcome of a node leading a slot
+--
+data Outcome
+
+  = Absent
+    -- ^ the leader hadn't yet joined
+
+  | Nominal
+    -- ^ the leader extended the networks' common chain with a valid block
+
+  | Unable
+    -- ^ the leader could not forge a valid block
+
+  | Wasted
+    -- ^ the leader forged a valid-but-irrelevant block, because it forged
+    -- before sufficiently synchronizing
+    --
+    -- As of commit 4eb23cfe \"Merge #1260\", this only happens if a node leads
+    -- in the slot it joins. In that slot, it forges before the mini protocols
+    -- are able to pull in any of the existing nodes' chain, and so it
+    -- re-forges the epoch 0 boundary block (EBB).
+
+  deriving (Eq, Show)
+
+-- | The state of the RealPBFT net
+--
+data State = State
+  { ids      :: !(Seq CoreNodeId)
+    -- ^ who forged each of the last @k@ blocks
+
+  , nomCount :: !NumNominals
+    -- ^ cache for optimization: number of 'Nominal's in 'outs'
+
+  , nextSlot :: !SlotNo
+
+  , outs     :: !(Seq Outcome)
+    -- ^ the outcome of each the last @2k@ slots
+  }
+
+newtype NumNominals = NumNominals Int
+
+emptyState :: State
+emptyState = State Seq.empty (NumNominals 0) 0 Seq.empty
+
+-- | There are no recorded forgings
+--
+nullState :: State -> Bool
+nullState State{ids} = Seq.null ids
+
+-- | Record the latest forging in the state
+--
+-- Should be followed by a call to 'extendOut'.
+--
+extendId :: PBftParams -> State -> CoreNodeId -> State
+extendId params st@State{ids} i = st
+  { ids      = snd $ prune (oneK params) $ ids Seq.|> i
+  }
+
+count :: (Eq a, Foldable t) => a -> t a -> Int
+count a bs = length [ () | b <- toList bs, a == b ]
+
+prune :: Int -> Seq a -> (Seq a, Seq a)
+prune lim x = Seq.splitAt excess x
+  where
+    excess = Seq.length x - fromIntegral lim
+
+-- | Record the latest outcome in the state
+--
+extendOut :: PBftParams -> State -> Outcome -> State
+extendOut params State{ids, nomCount, nextSlot, outs} out = State
+  { ids
+  , nomCount = nomCount'
+  , outs     = outs'
+  , nextSlot = succ nextSlot
+  }
+  where
+    (dropped, outs') = prune (twoK params) $ outs Seq.|> out
+
+    NumNominals nc = nomCount
+    nomCount'      = NumNominals $ nc
+      + (if Nominal == out then 1 else 0)
+      - count Nominal dropped
+
+-- | @True@ if the state would violate 'pbftSignatureThreshold'
+--
+tooMany :: PBftParams -> State -> CoreNodeId -> Bool
+tooMany params State{ids} i =
+    not $
+    Seq.length ids < k || count i ids <= most
+  where
+    PBftParams{pbftSignatureThreshold} = params
+
+    k :: forall a. Num a => a
+    k = oneK params
+
+    -- how many blocks in the latest k-blocks that a single core node is
+    -- allowed to have forged
+    most = floor $ k * pbftSignatureThreshold
+
+-- | @True@ if the state resulted from a sequence of @2k@ slots that had less
+-- than @k@ 'Nominal' outcomes
+--
+tooSparse :: PBftParams -> State -> Bool
+tooSparse params State{nomCount, outs} =
+    Seq.length outs - nc > oneK params
+  where
+    NumNominals nc = nomCount
+
+-- | @True@ if the state has a suffix of @n@ sequential 'Nominal' outcomes
+--
+-- Once this happens, by the assumption list on 'step', all remaining slots
+-- will be 'Nominal'.
+--
+saturated :: PBftParams -> State -> Bool
+saturated params State{outs} =
+    Seq.length outs >= oneN params && all (== Nominal) nouts
+  where
+    (_, nouts) = prune (oneN params) outs
+
+{-------------------------------------------------------------------------------
+  PBFT reference implementation
+-------------------------------------------------------------------------------}
+
+-- | Advance the state by one slot
+--
+-- ASSUMPTION Any new valid block is immediately selected by all nodes.
+--
+-- This assumption seems mild because of PBFT's fixed round-robin schedule; it
+-- primarily constrains the network topology, network outages, node restarts,
+-- clock skew, etc to be trivial. In other words, \"ideal circumstances\".
+--
+-- The assumption is useful in this reference implementation because it lets us
+-- maintain a single \"global\" 'State' common to all nodes.
+--
+step :: PBftParams -> NodeJoinPlan -> State -> State
+step params nodeJoinPlan st
+  | maybe True (s <) mbJ       = stuck Absent
+  | Just s == mbJ, not isFirst = stuck Wasted
+  | tooMany params st' i       = stuck Unable
+  | otherwise                  = extendOut params st' Nominal
+  where
+    s = nextSlot st
+
+    -- @s@'s scheduled leader
+    i = CoreNodeId $ fromIntegral $ unSlotNo s `mod` oneN params
+
+    -- when @i@ joins the network
+    mbJ = Map.lookup i m where NodeJoinPlan m = nodeJoinPlan
+
+    -- whether @i@ would be the first to lead
+    isFirst = nullState st
+
+    -- the state that @i@ would make
+    st' = extendId params st i
+
+    stuck o = extendOut params st o
+
+-- | Iterate 'step'
+--
+-- POST 'nextSlot' is @>=@ the given slot
+--
+advanceUpTo :: PBftParams -> NodeJoinPlan -> State -> SlotNo -> State
+advanceUpTo params nodeJoinPlan = go
+  where
+    go st s
+      | nextSlot st >= s = st
+      | otherwise        = go (step params nodeJoinPlan st) s
+
+{-------------------------------------------------------------------------------
+  Queries
+-------------------------------------------------------------------------------}
+
+-- | Finish an incomplete 'NodeJoinPlan': all remaining nodes join ASAP
+--
+-- Specifically, \"ASAP\" is either when the last already-scheduled node joins
+-- or \"now\" (the given 'SlotNo'), whichever is latest.
+--
+fillOut :: PBftParams -> NodeJoinPlan -> SlotNo -> NodeJoinPlan
+fillOut params (NodeJoinPlan m) s =
+    NodeJoinPlan $
+    foldl' (\acc i -> Map.insert i j acc) m $
+    CoreNodeId <$> [i0 .. iN]
+  where
+    iN       = oneN params - 1
+    j        = max s j0
+    (i0, j0) = case Map.lookupMax m of
+        Nothing                -> (0,      0)
+        Just (CoreNodeId h, x) -> (succ h, x)
+
+-- | @True@ if there will be no necessary violations of \"@k@-blocks in
+-- @2k@-slots\" assuming all remaining nodes join ASAP
+--
+-- PRE the given parameters and state are not @tooSparse params st@
+--
+viable :: PBftParams -> SlotNo -> NodeJoinPlan -> State -> Bool
+viable params lastSlot nodeJoinPlan st0 = go st0
+  where
+    nodeJoinPlan' = fillOut params nodeJoinPlan (nextSlot st0)
+
+    go st
+      | lastSlot < nextSlot st = True
+      | saturated params st    = True   -- an optimization
+      | tooSparse params st'   = False
+      | otherwise              = go st'
+      where
+        st' = step params nodeJoinPlan' st

--- a/ouroboros-consensus/test-util/Test/Util/Shrink.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Shrink.hs
@@ -1,0 +1,23 @@
+-- | Utility functions for defining @QuickCheck@'s 'Test.QuickCheck.shrink'
+--
+module Test.Util.Shrink (
+  andId,
+  dropId,
+  ) where
+
+{-------------------------------------------------------------------------------
+  Shrinking Helpers
+-------------------------------------------------------------------------------}
+
+-- | Drop the last element
+--
+-- If every source list in a comprehension uses 'andId', then the last element
+-- will be a copy of the initial input.
+--
+dropId :: [a] -> [a]
+dropId = init
+
+-- | Add the argument as the last element of the output
+--
+andId :: (a -> [a]) -> a -> [a]
+andId f x = f x ++ [x]


### PR DESCRIPTION
Closes #1283.

[Edit: I minimized the PR and it now only does the first "primary change".]

This PR makes three primary changes.

  * It adds an idealistic "reference simulator" for `RealPBFT` and relies on that to only generate node join plans for `RealPBFT` that ensure there will always be a single shared chain and it will have at least `k` blocks in each `2k`-slot window. Node join plans that could never satisfy that chain density property were the reason late joins were recently disabled.
  * That simulator requires eg `PBftParams`. So we add a field to `TestConfig` that has a type that depends on the protocol. This "dependent generation" avoids requiring eg `Data.Reflection.Given` for the `Arbitrary (TestConfig BlockRealPBFT)` instance.
  * It consolidates the test configuration for all of the protocols we test into the same module `*.TestConfig`. I initially did this just to avoid orphan `TestableBlock` instances, but I'm wondering if we should accept such orphans in this test code and un-consolidate the `TestableBlock` instances back to the protocol-specific modules. For the few protocols we currently have, this one module seems more convenient.

The `RealPBFT` reference simulator assumes "nominal behavior", which excludes network outages, node restarts, etc. PRs adding those will either have to extend the reference simulator or else introduce a separate property that does not assume chain density etc. We'll cross that bridge when we come to it.

Looking ahead, I think always having a generator and `Property` pair for the simple case (eg there is only ever one best chain in the network) will be helpful.

Having a protocol-dependent field in the `TestConfig` will also let us extend the generators to eg also vary the protocol parameters, such as `k`, the PBFT threshold, etc.