### PR TITLE
Don't require Serialise instance for ChainState

### DIFF
--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -42,6 +42,7 @@
           (hsPkgs.filepath)
           (hsPkgs.fingertree)
           (hsPkgs.formatting)
+          (hsPkgs.hashable)
           (hsPkgs.memory)
           (hsPkgs.mmorph)
           (hsPkgs.mtl)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -54,6 +54,7 @@ library
                        Ouroboros.Consensus.Ledger.Mock.Block.Praos
                        Ouroboros.Consensus.Ledger.Mock.Block.PraosRule
                        Ouroboros.Consensus.Ledger.Mock.Forge
+                       Ouroboros.Consensus.Ledger.Mock.Run
                        Ouroboros.Consensus.Ledger.Mock.Stake
                        Ouroboros.Consensus.Ledger.Mock.State
                        Ouroboros.Consensus.Ledger.Mock.UTxO
@@ -222,6 +223,7 @@ library
                        filepath          >=1.4   && <1.5,
                        fingertree        >=0.1.4.2 && <0.2,
                        formatting        >=6.3   && <6.4,
+                       hashable,
                        memory,
                        mmorph            >=1.1   && <1.2,
                        mtl               >=2.2   && <2.3,

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
@@ -15,7 +15,6 @@ module Ouroboros.Consensus.Ledger.Byron.PBFT (
 
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
-import           Codec.Serialise (decode, encode)
 import           Data.ByteString (ByteString)
 
 import           Cardano.Binary (Annotated)
@@ -31,6 +30,7 @@ import           Ouroboros.Consensus.Ledger.Byron.Block
 import           Ouroboros.Consensus.Ledger.Byron.Config
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.PBFT
+import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
 
 type ByronConsensusProtocol = PBft ByronConfig PBftCardanoCrypto
 type instance BlockProtocol ByronBlock = ByronConsensusProtocol
@@ -71,7 +71,7 @@ fromPBftLedgerView :: PBftLedgerView PBftCardanoCrypto -> Delegation.Map
 fromPBftLedgerView = Delegation.Map . pbftDelegates
 
 encodeByronChainState :: ChainState (BlockProtocol ByronBlock) -> Encoding
-encodeByronChainState = encode
+encodeByronChainState = CS.encodePBftChainState
 
 decodeByronChainState :: Decoder s (ChainState (BlockProtocol ByronBlock))
-decodeByronChainState = decode
+decodeByronChainState = CS.decodePBftChainState

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/BFT.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Ouroboros.Consensus.Ledger.Mock.Block.BFT (
     SimpleBftBlock
   , SimpleBftHeader
@@ -25,7 +27,7 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Mock.Block
-import           Ouroboros.Consensus.Ledger.Mock.Forge
+import           Ouroboros.Consensus.Ledger.Mock.Run
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util.Condense
@@ -77,11 +79,16 @@ instance ( SimpleCrypto c
          ) => HeaderSupportsBft c' (SimpleBftHeader c c') where
   headerBftFields _ = simpleBftExt . simpleHeaderExt
 
+instance RunMockProtocol (Bft c') where
+  mockProtocolMagicId  = const constructMockProtocolMagicId
+  mockEncodeChainState = const encode
+  mockDecodeChainState = const decode
+
 instance ( SimpleCrypto c
          , BftCrypto c'
          , Signable (BftDSIGN c') (SignedSimpleBft c c')
          )
-      => ForgeExt (Bft c') c (SimpleBftExt c c') where
+      => RunMockBlock (Bft c') c (SimpleBftExt c c') where
   forgeExt cfg () SimpleBlock{..} = do
       ext :: SimpleBftExt c c' <- fmap SimpleBftExt $
         forgeBftFields cfg $

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PraosRule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PraosRule.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 -- | Test the Praos chain selection rule (with explicit leader schedule)
 module Ouroboros.Consensus.Ledger.Mock.Block.PraosRule (
     SimplePraosRuleBlock
@@ -25,7 +27,7 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Mock.Block
-import           Ouroboros.Consensus.Ledger.Mock.Forge
+import           Ouroboros.Consensus.Ledger.Mock.Run
 import           Ouroboros.Consensus.NodeId (CoreNodeId)
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
 import           Ouroboros.Consensus.Protocol.Praos
@@ -67,8 +69,13 @@ _simplePraosRuleHeader = simpleHeader
   Evidence that 'SimpleBlock' can support Praos with an explicit leader schedule
 -------------------------------------------------------------------------------}
 
+instance RunMockProtocol (WithLeaderSchedule p) where
+  mockProtocolMagicId  = const constructMockProtocolMagicId
+  mockEncodeChainState = const encode
+  mockDecodeChainState = const decode
+
 instance SimpleCrypto c
-      => ForgeExt (WithLeaderSchedule p) c SimplePraosRuleExt where
+      => RunMockBlock (WithLeaderSchedule p) c SimplePraosRuleExt where
   forgeExt cfg () SimpleBlock{..} = do
       let ext = SimplePraosRuleExt $ lsNodeConfigNodeId cfg
       return SimpleBlock {

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Forge.hs
@@ -3,10 +3,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 
-module Ouroboros.Consensus.Ledger.Mock.Forge (
-    forgeSimple
-  , ForgeExt(..)
-  ) where
+module Ouroboros.Consensus.Ledger.Mock.Forge (forgeSimple) where
 
 import           Codec.Serialise (Serialise (..), serialise)
 import           Crypto.Random (MonadRandom)
@@ -18,21 +15,14 @@ import           Cardano.Crypto.Hash
 import           Ouroboros.Network.Block (BlockNo, ChainHash, SlotNo)
 
 import           Ouroboros.Consensus.Ledger.Mock.Block
+import           Ouroboros.Consensus.Ledger.Mock.Run
 import           Ouroboros.Consensus.Protocol.Abstract
-
-class ForgeExt p c ext where
-  -- | Construct the protocol specific part of the block
-  forgeExt :: (HasNodeState p m, MonadRandom m)
-           => NodeConfig p
-           -> IsLeader p
-           -> SimpleBlock' c ext ()
-           -> m (SimpleBlock c ext)
 
 forgeSimple :: forall p c m ext.
                ( HasNodeState p m
                , MonadRandom m
                , SimpleCrypto c
-               , ForgeExt p c ext
+               , RunMockBlock p c ext
                )
             => NodeConfig p
             -> SlotNo                         -- ^ Current slot

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Run.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes            #-}
+
+module Ouroboros.Consensus.Ledger.Mock.Run (
+    RunMockProtocol(..)
+  , RunMockBlock(..)
+  , constructMockProtocolMagicId
+  ) where
+
+import           Codec.CBOR.Decoding (Decoder)
+import           Codec.CBOR.Encoding (Encoding)
+import           Crypto.Random (MonadRandom)
+import           Data.Hashable (hash)
+import           GHC.Stack
+
+import           Cardano.Crypto (ProtocolMagicId (..))
+
+import           Ouroboros.Consensus.Ledger.Mock.Block
+import           Ouroboros.Consensus.Protocol.Abstract
+
+-- | The part of 'RunMock' that depends only on @p@
+class RunMockProtocol p where
+  mockProtocolMagicId  ::           NodeConfig p -> ProtocolMagicId
+  mockEncodeChainState ::           NodeConfig p -> ChainState p -> Encoding
+  mockDecodeChainState :: forall s. NodeConfig p -> Decoder s (ChainState p)
+
+-- | Protocol specific functionality required to run consensus with mock blocks
+class RunMockProtocol p => RunMockBlock p c ext where
+  -- | Construct the protocol specific part of the block
+  --
+  -- This is used in 'forgeSimple', which takes care of the generic part of
+  -- the mock block.
+  forgeExt :: (HasNodeState p m, MonadRandom m)
+           => NodeConfig p
+           -> IsLeader p
+           -> SimpleBlock' c ext ()
+           -> m (SimpleBlock c ext)
+
+-- | Construct protocol magic ID depending on where in the code this is called
+--
+-- The sole purpose of this is to make sure that these mock protocols have
+-- different IDs from each other and from regular protocols.
+constructMockProtocolMagicId :: HasCallStack => ProtocolMagicId
+constructMockProtocolMagicId =
+    ProtocolMagicId $ fromIntegral $ hash (prettyCallStack callStack)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -46,13 +46,13 @@ import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Network.Block
 import qualified Ouroboros.Network.Block as Block
-import           Ouroboros.Network.Socket (ConnectionId)
 import           Ouroboros.Network.ErrorPolicy
 import           Ouroboros.Network.Magic
 import           Ouroboros.Network.NodeToClient as NodeToClient
 import           Ouroboros.Network.NodeToNode as NodeToNode
 import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
                      (pipelineDecisionLowHighMark)
+import           Ouroboros.Network.Socket (ConnectionId)
 
 import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.BlockchainTime
@@ -181,11 +181,11 @@ initChainDB tracer registry dbPath cfg initLedger slotLength
     mkArgs epochInfo = customiseArgs $ (ChainDB.defaultArgs dbPath)
       { ChainDB.cdbBlocksPerFile    = 1000
       , ChainDB.cdbDecodeBlock      = nodeDecodeBlock         cfg
-      , ChainDB.cdbDecodeChainState = nodeDecodeChainState    (Proxy @blk)
+      , ChainDB.cdbDecodeChainState = nodeDecodeChainState    (Proxy @blk) cfg
       , ChainDB.cdbDecodeHash       = nodeDecodeHeaderHash    (Proxy @blk)
       , ChainDB.cdbDecodeLedger     = nodeDecodeLedgerState   cfg
       , ChainDB.cdbEncodeBlock      = nodeEncodeBlockWithInfo cfg
-      , ChainDB.cdbEncodeChainState = nodeEncodeChainState    (Proxy @blk)
+      , ChainDB.cdbEncodeChainState = nodeEncodeChainState    (Proxy @blk) cfg
       , ChainDB.cdbEncodeHash       = nodeEncodeHeaderHash    (Proxy @blk)
       , ChainDB.cdbEncodeLedger     = nodeEncodeLedgerState   cfg
       , ChainDB.cdbEpochInfo        = epochInfo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/Praos.hs
@@ -6,13 +6,9 @@ module Ouroboros.Consensus.Node.ProtocolInfo.Mock.Praos (
     protocolInfoPraos
   ) where
 
-import           Codec.CBOR.Decoding (decodeListLenOf)
-import           Codec.CBOR.Encoding (encodeListLen)
-import           Codec.Serialise (Serialise (..))
 import           Data.IntMap (IntMap)
 import qualified Data.IntMap as IntMap
 
-import           Cardano.Binary (fromCBOR, toCBOR)
 import           Cardano.Crypto.KES
 import           Cardano.Crypto.VRF
 
@@ -55,17 +51,3 @@ protocolInfoPraos (NumCoreNodes numCoreNodes) (CoreNodeId nid) params =
     verKeys = IntMap.fromList [ (nd, (VerKeyMockKES nd, VerKeyMockVRF nd))
                               | nd <- [0 .. numCoreNodes - 1]
                               ]
-
-instance Serialise (BlockInfo PraosMockCrypto) where
-  encode BlockInfo {..} = mconcat
-    [ encodeListLen 3
-    , encode biSlot
-    , toCBOR biRho
-    , encode biStake
-    ]
-  decode = do
-    decodeListLenOf 3
-    biSlot  <- decode
-    biRho   <- fromCBOR
-    biStake <- decode
-    return BlockInfo {..}

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
@@ -71,7 +71,7 @@ class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
   nodeEncodeGenTxId       :: GenTxId blk -> Encoding
   nodeEncodeHeaderHash    :: Proxy blk -> HeaderHash blk -> Encoding
   nodeEncodeLedgerState   :: NodeConfig (BlockProtocol blk) -> LedgerState blk -> Encoding
-  nodeEncodeChainState    :: Proxy blk -> ChainState (BlockProtocol blk) -> Encoding
+  nodeEncodeChainState    :: Proxy blk -> NodeConfig (BlockProtocol blk) -> ChainState (BlockProtocol blk) -> Encoding
   nodeEncodeApplyTxError  :: Proxy blk -> ApplyTxErr blk -> Encoding
 
   -- Decoders
@@ -81,5 +81,5 @@ class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
   nodeDecodeGenTxId       :: forall s. Decoder s (GenTxId blk)
   nodeDecodeHeaderHash    :: forall s. Proxy blk -> Decoder s (HeaderHash blk)
   nodeDecodeLedgerState   :: forall s. NodeConfig (BlockProtocol blk) -> Decoder s (LedgerState blk)
-  nodeDecodeChainState    :: forall s. Proxy blk -> Decoder s (ChainState (BlockProtocol blk))
+  nodeDecodeChainState    :: forall s. Proxy blk -> NodeConfig (BlockProtocol blk) -> Decoder s (ChainState (BlockProtocol blk))
   nodeDecodeApplyTxError  :: forall s. Proxy blk -> Decoder s (ApplyTxErr blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -68,7 +68,7 @@ instance RunNode ByronBlock where
   nodeEncodeGenTxId       = encodeByronGenTxId
   nodeEncodeHeaderHash    = const encodeByronHeaderHash
   nodeEncodeLedgerState   = const encodeByronLedgerState
-  nodeEncodeChainState    = const encodeByronChainState
+  nodeEncodeChainState    = \_proxy _cfg -> encodeByronChainState
   nodeEncodeApplyTxError  = const encodeByronApplyTxError
 
   nodeDecodeBlock         = decodeByronBlock  . extractEpochSlots
@@ -77,7 +77,7 @@ instance RunNode ByronBlock where
   nodeDecodeGenTxId       = decodeByronGenTxId
   nodeDecodeHeaderHash    = const decodeByronHeaderHash
   nodeDecodeLedgerState   = const decodeByronLedgerState
-  nodeDecodeChainState    = const decodeByronChainState
+  nodeDecodeChainState    = \_proxy _cfg -> decodeByronChainState
   nodeDecodeApplyTxError  = const decodeByronApplyTxError
 
 extractGenesisData :: NodeConfig ByronConsensusProtocol -> Genesis.GenesisData

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
@@ -10,16 +10,14 @@ import           Data.Time.Calendar (fromGregorian)
 import           Data.Time.Clock (UTCTime (..))
 import           Data.Typeable (Typeable)
 
-import           Cardano.Crypto (ProtocolMagicId (..))
-
 import           Ouroboros.Network.Magic (NetworkMagic (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Mock
+import           Ouroboros.Consensus.Ledger.Mock.Run
 import           Ouroboros.Consensus.Node.Run.Abstract
-import           Ouroboros.Consensus.Protocol.Abstract (ChainState)
 
 {-------------------------------------------------------------------------------
   RunNode instance for the mock ledger
@@ -32,10 +30,9 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
          , SupportedBlock (SimpleBlock SimpleMockCrypto ext)
          , Typeable ext
          , Serialise ext
-         , ForgeExt (BlockProtocol (SimpleBlock SimpleMockCrypto ext))
-                    SimpleMockCrypto
-                    ext
-         , Serialise (ChainState (BlockProtocol (SimpleBlock SimpleMockCrypto ext)))
+         , RunMockBlock (BlockProtocol (SimpleBlock SimpleMockCrypto ext))
+                        SimpleMockCrypto
+                        ext
          ) => RunNode (SimpleBlock SimpleMockCrypto ext) where
   nodeForgeBlock          = forgeSimple
   nodeBlockMatchesHeader  = matchesSimpleHeader
@@ -48,9 +45,8 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
       dummyDate = UTCTime (fromGregorian 2019 8 13) 0
   nodeNetworkMagic        = \_ _ -> NetworkMagic 0x0000ffff
 
-  nodeProtocolMagicId     = \_ _ -> ProtocolMagicId 0
+  nodeProtocolMagicId     = const mockProtocolMagicId
   nodeHashInfo            = const simpleBlockHashInfo
-
 
   nodeEncodeBlockWithInfo = const simpleBlockBinaryInfo
   nodeEncodeHeader        = const encode
@@ -58,7 +54,7 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
   nodeEncodeGenTxId       =       encode
   nodeEncodeHeaderHash    = const encode
   nodeEncodeLedgerState   = const encode
-  nodeEncodeChainState    = const encode
+  nodeEncodeChainState    = const mockEncodeChainState
   nodeEncodeApplyTxError  = const encode
 
   nodeDecodeBlock         = const (const <$> decode)
@@ -67,5 +63,5 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
   nodeDecodeGenTxId       =       decode
   nodeDecodeHeaderHash    = const decode
   nodeDecodeLedgerState   = const decode
-  nodeDecodeChainState    = const decode
+  nodeDecodeChainState    = const mockDecodeChainState
   nodeDecodeApplyTxError  = const decode

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -242,12 +242,12 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
           cdbDecodeHash       = nodeDecodeHeaderHash (Proxy @blk)
         , cdbDecodeBlock      = nodeDecodeBlock cfg
         , cdbDecodeLedger     = nodeDecodeLedgerState cfg
-        , cdbDecodeChainState = nodeDecodeChainState (Proxy @blk)
+        , cdbDecodeChainState = nodeDecodeChainState (Proxy @blk) cfg
           -- Encoders
         , cdbEncodeBlock      = nodeEncodeBlockWithInfo cfg
         , cdbEncodeHash       = nodeEncodeHeaderHash (Proxy @blk)
         , cdbEncodeLedger     = nodeEncodeLedgerState cfg
-        , cdbEncodeChainState = nodeEncodeChainState (Proxy @blk)
+        , cdbEncodeChainState = nodeEncodeChainState (Proxy @blk) cfg
           -- Error handling
         , cdbErrImmDb         = EH.monadCatch
         , cdbErrVolDb         = EH.monadCatch


### PR DESCRIPTION
We already avoided this in the general setup, but still required it for
mock blocks. We need to avoid it altogether so that the encoding of the
PBFT chain state can depend on the configuration (required in the next
commit).