### PR TITLE
Pre-anchor signatures

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
@@ -73,5 +73,6 @@ fromPBftLedgerView = Delegation.Map . pbftDelegates
 encodeByronChainState :: ChainState (BlockProtocol ByronBlock) -> Encoding
 encodeByronChainState = CS.encodePBftChainState
 
-decodeByronChainState :: Decoder s (ChainState (BlockProtocol ByronBlock))
-decodeByronChainState = CS.decodePBftChainState
+decodeByronChainState :: SecurityParam
+                      -> Decoder s (ChainState (BlockProtocol ByronBlock))
+decodeByronChainState k = CS.decodePBftChainState k (pbftWindowSize k)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
@@ -98,7 +98,8 @@ instance (PBftCrypto c', Serialise (PBftVerKeyHash c'))
       => RunMockProtocol (PBft ext c') where
   mockProtocolMagicId  = const constructMockProtocolMagicId
   mockEncodeChainState = const CS.encodePBftChainState
-  mockDecodeChainState = const CS.decodePBftChainState
+  mockDecodeChainState = \cfg -> let k = pbftSecurityParam $ pbftParams cfg
+                                 in CS.decodePBftChainState k (pbftWindowSize k)
 
 instance ( SimpleCrypto c
          , PBftCrypto c'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -18,6 +18,7 @@ import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
 import           Ouroboros.Consensus.Ledger.Byron
 import           Ouroboros.Consensus.Node.Run.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.PBFT
 
 import           Ouroboros.Storage.Common (EpochNo (..), EpochSize (..))
 
@@ -77,7 +78,9 @@ instance RunNode ByronBlock where
   nodeDecodeGenTxId       = decodeByronGenTxId
   nodeDecodeHeaderHash    = const decodeByronHeaderHash
   nodeDecodeLedgerState   = const decodeByronLedgerState
-  nodeDecodeChainState    = \_proxy _cfg -> decodeByronChainState
+  nodeDecodeChainState    = \_proxy cfg ->
+                               let k = pbftSecurityParam $ pbftParams cfg
+                               in decodeByronChainState k
   nodeDecodeApplyTxError  = const decodeByronApplyTxError
 
 extractGenesisData :: NodeConfig ByronConsensusProtocol -> Genesis.GenesisData

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -184,9 +184,9 @@ class ( Show (ChainState    p)
   -- This function should attempt to rewind the chain state to the state at some
   -- given slot, or Origin to rewind to the state with no blocks.
   --
-  -- Implementers should take care that this function accurately reflects the
-  -- slot number, rather than the number of blocks, since naively the
-  -- 'ChainState' will be updated only on processing an actual block.
+  -- PRECONDITION: the slot to rewind to must correspond to the slot of a
+  -- header (or 'Origin') that was previously applied to the chain state using
+  -- 'applyChainState'.
   --
   -- Rewinding the chain state is intended to be used when switching to a
   -- fork, longer or equally long to the chain to which the current chain

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Protocol/PBFT.hs
@@ -1,89 +1,315 @@
-{-# LANGUAGE OverloadedLists #-}
-module Test.Consensus.Protocol.PBFT where
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Test.Consensus.Protocol.PBFT (
+    tests
+    -- * Used in the roundtrip tests
+  , TestChainState(..)
+  ) where
 
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import qualified Data.Sequence.Strict as Seq
+import           Data.Word
 
 import           Test.Tasty
-import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
 
 import           Cardano.Crypto.DSIGN
 
+import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.Point (WithOrigin (..))
 
+import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.PBFT.ChainState (PBftChainState)
 import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
 import           Ouroboros.Consensus.Protocol.PBFT.Crypto
+import           Ouroboros.Consensus.Util (dropLast, repeatedly, takeLast)
+
 
 {-------------------------------------------------------------------------------
   Top-level tests
 -------------------------------------------------------------------------------}
 
 tests :: TestTree
-tests = testGroup "PBFT"
-    [ testGroup "pruneChainState"
-      [ testProperty "pruneChainState/chainStateSize" prop_pruneChainState_chainStateSize
-      , testProperty "chainStateSize/pruneChainState" prop_chainStateSize_pruneChainState
-      , testCase     "pruneChainState 2"              test_pruneChainState
-      ]
+tests = testGroup "PBftChainState" [
+      testProperty "validGenerator"                   prop_validGenerator
+    , testProperty "appendPreservesInvariant"         prop_appendPreservesInvariant
+    , testProperty "rewindPreservesInvariant"         prop_rewindPreservesInvariant
+    , testProperty "rewindReappendId"                 prop_rewindReappendId
+    , testProperty "appendOldStatePreservesInvariant" prop_appendOldStatePreservesInvariant
+    , testProperty "appendOldStateRestoresPreWindow"  prop_appendOldStateRestoresPreWindow
     ]
 
 {-------------------------------------------------------------------------------
   Test setup
 -------------------------------------------------------------------------------}
 
-newtype TestChainState = TestChainState (PBftChainState PBftMockCrypto)
+data TestChainState = TestChainState {
+      testChainStateK         :: SecurityParam
+    , testChainStateN         :: CS.WindowSize
+    , testChainStateNumKeys   :: Int
+
+      -- | The generated chain state
+    , testChainState          :: PBftChainState PBftMockCrypto
+
+      -- | The corresponding chain state we would have deserialised before
+      -- #1307: this state does not include the @n@ pre-anchor signatures.
+    , testChainOldState       :: PBftChainState PBftMockCrypto
+
+      -- | The slots that were dropped (rollback before this chain state)
+    , testChainDropped        :: [CS.PBftSigner PBftMockCrypto]
+
+      -- | Possible next signers that can be added
+      --
+      -- INVARIANT: the length of this list will be @n + k@.
+    , testChainNextSigners    :: [CS.PBftSigner PBftMockCrypto]
+
+      -- | Possible next rollback
+    , testChainRollback       :: WithOrigin SlotNo
+
+      -- | The blocks that 'testChainRollback' would roll back
+    , testChainRollbackBlocks :: [CS.PBftSigner PBftMockCrypto]
+    }
   deriving (Show)
 
+-- | Generate chain state
+--
+-- We don't want to make too many assumptions here, so instead we model what
+-- happens on an actual chain: we have a bunch of slots, starting from genesis,
+-- signed by various keys, some slots are empty. We then compute the maximum
+-- rollback point (@k@ from the tip), and finally drop (d @<= k@) slots,
+-- and take the final @n + k - d@ slots.
+--
+-- Returns both the chain before rollback as well as the chain state.
+--
+-- NOTE: PBftChainState assumes @k >= 1@.
 instance Arbitrary TestChainState where
   arbitrary = do
-    -- The weights and ranges have been tweaked such that
-    -- 'prop_chainStateSize_pruneChainState' can do some pruning.
-    nbKs <- frequency
-      -- We want to test with no keys, but not too often
-      [ (1, return 0)
-      , (9, choose (1, 5))
-      ]
-    nbVs <- frequency
-      -- We want to test with no values, but not too often
-      [ (1, return 0)
-      -- We want to test with fewer values than keys, but not too often
-      , (1, choose (1, nbKs))
-      , (8, choose (nbKs, 200))
-      ]
-    return $ TestChainState . testState Origin $ Map.fromList
-      [ (k, vs)
-      | k <- [0..nbKs-1]
-      , let vs = [v | v <- [0..nbVs-1], v `mod` nbKs == k]
-      ]
+      k       <- choose (1, 4)
+      n       <- choose (1, 10)
+      numKeys <- choose (1, 4)
 
-testState :: WithOrigin Int -> Map Int [Int] -> PBftChainState PBftMockCrypto
-testState anchor =
-      CS.fromMap (fromIntegral <$> anchor)
-    . Map.mapKeys VerKeyMockDSIGN
-    . Map.map (fmap fromIntegral)
+      -- Pick number of slots
+      --
+      -- We don't try to be too clever here; we need to test the various edge
+      -- cases near genesis more carefully, but also want to test where we are
+      -- well past genesis
+      numSlots <- oneof [
+          choose (0, k)
+        , choose (0, n)
+        , choose (0, k + n)
+        , choose (0, 5 * (k + n))
+        ]
+
+      -- Generate all the signatures
+      slots <- generateSigners (genMockKey numKeys) numSlots Origin
+
+      -- Compute max rollback point
+      let anchor = case drop (fromIntegral k) (reverse slots) of
+                     []  -> Origin
+                     x:_ -> At (CS.pbftSignerSlotNo x)
+
+      -- Pick a number of blocks to drop
+      toDrop <- choose (0, k)
+      let signers = Seq.fromList $ takeLast (n + k - toDrop) (dropLast toDrop slots)
+          state   = CS.fromList
+                      (SecurityParam k)
+                      (CS.WindowSize n)
+                      (anchor, signers)
+
+      -- Compute the state that we would have deserialised before #1307: this
+      -- state does not include the @k@ extra signatures before the window.
+      let oldSigners = Seq.fromList $ takeLast (n - toDrop) (dropLast toDrop slots)
+          oldState = CS.fromList
+                      (SecurityParam k)
+                      (CS.WindowSize n)
+                      (anchor, oldSigners)
+
+      -- Create potential next @k@ signers to be added
+      let lastSlot = case signers of
+                       -- Can only be empty if near genesis, because @toDrop@ is
+                       -- at most @k@ and hence @signers@ must be at least @n@
+                       -- long, unless @slots@ is near genesis.
+                       Seq.Empty                   -> Origin
+                       _ Seq.:|> CS.PBftSigner s _ -> At s
+      nextSigners <- generateSigners (genMockKey numKeys) (n + k) lastSlot
+
+      -- Create potential rollback
+      numRollback <- oneof [
+          choose (0, k - toDrop) -- rollback that will succeed
+        , choose (0, numSlots)   -- rollback that might fail (too far)
+        ]
+      let rollback = case drop (fromIntegral (toDrop + numRollback)) (reverse slots) of
+                       []  -> Origin
+                       x:_ -> At (CS.pbftSignerSlotNo x)
+
+      return TestChainState {
+          testChainStateK         = SecurityParam k
+        , testChainStateN         = CS.WindowSize n
+        , testChainStateNumKeys   = numKeys
+        , testChainState          = state
+        , testChainOldState       = oldState
+        , testChainDropped        = takeLast toDrop slots
+        , testChainNextSigners    = nextSigners
+        , testChainRollback       = rollback
+        , testChainRollbackBlocks = takeLast numRollback (dropLast toDrop slots)
+        }
+
+generateSigners :: Gen (PBftVerKeyHash c)
+                -> Word64
+                -> WithOrigin SlotNo
+                -> Gen [CS.PBftSigner c]
+generateSigners genKey = go
+  where
+    go 0        _    = return []
+    go numSlots prev = do
+      slot :: SlotNo <- case prev of
+                          Origin ->
+                            SlotNo <$> choose (0, 3)
+                          At (SlotNo s) -> do
+                            skip <- choose (1, 3)
+                            return $ SlotNo (s + skip)
+      signer <- CS.PBftSigner slot <$> genKey
+      (signer :) <$> go (numSlots - 1) (At slot)
+
+genMockKey :: Int -> Gen (VerKeyDSIGN MockDSIGN)
+genMockKey numKeys = VerKeyMockDSIGN <$> choose (1, numKeys)
+
+{-------------------------------------------------------------------------------
+  Labelling
+-------------------------------------------------------------------------------}
+
+data ClassifyWindow =
+    WindowEmpty
+  | WindowNotFull
+  | WindowFull
+  deriving (Show)
+
+data ClassifyRollback =
+    RollbackImpossible
+  | RollbackLimited
+  | RollbackMaximum
+  deriving (Show)
+
+classifyWindow :: TestChainState -> ClassifyWindow
+classifyWindow TestChainState{..}
+  | size inWindow == (0 :: Int)                       = WindowEmpty
+  | size inWindow <  CS.getWindowSize testChainStateN = WindowNotFull
+  | otherwise                                         = WindowFull
+  where
+    CS.PBftChainState{..} = testChainState
+
+classifyRollback :: TestChainState -> ClassifyRollback
+classifyRollback TestChainState{..}
+  | size postAnchor == (0 :: Int)                   = RollbackImpossible
+  | size postAnchor <  maxRollbacks testChainStateK = RollbackLimited
+  | otherwise                                       = RollbackMaximum
+  where
+    CS.PBftChainState{..} = testChainState
 
 {-------------------------------------------------------------------------------
   Tests
 -------------------------------------------------------------------------------}
 
-prop_pruneChainState_chainStateSize :: TestChainState -> Property
-prop_pruneChainState_chainStateSize (TestChainState cs) =
-    CS.prune (CS.size cs) cs === cs
-
-prop_chainStateSize_pruneChainState :: Positive Int -> TestChainState -> Property
-prop_chainStateSize_pruneChainState (Positive n) (TestChainState cs)
-    | CS.size cs >= n
-    = label "pruned"
-    $ CS.size (CS.prune n cs) === n
-    | otherwise
-    = label "not pruned"
-    $ CS.size (CS.prune n cs) === CS.size cs
-
-test_pruneChainState :: Assertion
-test_pruneChainState =
-    CS.prune 2 cs @?= testState (At 4) (Map.fromList [(100, [5]), (101, [6])])
+-- Check that we are producing valid chain tests
+prop_validGenerator :: TestChainState -> Property
+prop_validGenerator st@TestChainState{..} =
+    collect (classifyWindow   st) $
+    collect (classifyRollback st) $
+    Right () === CS.invariant
+                   testChainStateK
+                   testChainStateN
+                   testChainState
+    .&&.
+    Right () === CS.invariant
+                   testChainStateK
+                   testChainStateN
+                   testChainOldState
+    .&&.
+    Seq.null (CS.preWindow testChainOldState)
   where
-    cs :: PBftChainState PBftMockCrypto
-    cs = testState Origin $ Map.fromList [(100, [1,2,5]), (101, [3, 4, 6])]
+    CS.PBftChainState{..} = testChainState
+
+prop_appendPreservesInvariant :: TestChainState -> Property
+prop_appendPreservesInvariant TestChainState{..} =
+    let state' = CS.append
+                   testChainStateK
+                   testChainStateN
+                   (head testChainNextSigners)
+                   testChainState
+    in Right () === CS.invariant
+                      testChainStateK
+                      testChainStateN
+                      state'
+
+prop_rewindPreservesInvariant :: TestChainState -> Property
+prop_rewindPreservesInvariant TestChainState{..} =
+    let rewound = CS.rewind
+                    testChainStateK
+                    testChainStateN
+                    testChainRollback
+                    testChainState
+    in case rewound of
+         Nothing     -> label "rollback too far in the past" True
+         Just state' -> label "rollback succeeded" $
+           Right () === CS.invariant
+                          testChainStateK
+                          testChainStateN
+                          state'
+
+-- | If we rewind and then reapply the same blocks, we should get back to
+-- our original test
+prop_rewindReappendId :: TestChainState -> Property
+prop_rewindReappendId TestChainState{..} =
+    let rewound = CS.rewind
+                    testChainStateK
+                    testChainStateN
+                    testChainRollback
+                    testChainState
+    in case rewound of
+         Nothing     -> label "rollback too far in the past" True
+         Just state' -> label "rollback succeeded" $
+           testChainState === CS.appendMany
+                                testChainStateK
+                                testChainStateN
+                                testChainRollbackBlocks
+                                state'
+
+-- This property holds for the old chain state too
+prop_appendOldStatePreservesInvariant :: TestChainState -> Property
+prop_appendOldStatePreservesInvariant TestChainState{..} =
+    let state' = CS.append
+                   testChainStateK
+                   testChainStateN
+                   (head testChainNextSigners)
+                   testChainOldState
+    in Right () === CS.invariant
+                      testChainStateK
+                      testChainStateN
+                      state'
+
+-- | After appending the missing signatures, we should have a 'CS.preWindow'
+-- of @k again.
+prop_appendOldStateRestoresPreWindow :: TestChainState -> Property
+prop_appendOldStateRestoresPreWindow TestChainState{..} =
+    let missing = fromIntegral
+                $ maxRollbacks       testChainStateK
+                + CS.getWindowSize   testChainStateN
+                - CS.countSignatures testChainOldState
+        state' = repeatedly
+                   (CS.append
+                     testChainStateK
+                     testChainStateN)
+                   (take missing testChainNextSigners)
+                   testChainOldState
+    in Right () === CS.invariant
+                      testChainStateK
+                      testChainStateN
+                      state'
+       .&&.
+       size (CS.preWindow state') === maxRollbacks testChainStateK
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+size :: Num b => Seq.StrictSeq a -> b
+size = fromIntegral . Seq.length

--- a/ouroboros-consensus/tools/db-convert/Main.hs
+++ b/ouroboros-consensus/tools/db-convert/Main.hs
@@ -198,7 +198,7 @@ validateChainDb dbDir cfg onlyImmDB verbose =
       (ChainDB.defaultArgs @ByronBlock (toFilePath dbDir))
         { ChainDB.cdbGenesis = return $ pInfoInitLedger byronProtocolInfo
         , ChainDB.cdbDecodeBlock = Byron.decodeByronBlock epochSlots
-        , ChainDB.cdbDecodeChainState = Byron.decodeByronChainState
+        , ChainDB.cdbDecodeChainState = Byron.decodeByronChainState securityParam
         , ChainDB.cdbDecodeHash = Byron.decodeByronHeaderHash
         , ChainDB.cdbDecodeLedger = Byron.decodeByronLedgerState
         , ChainDB.cdbEncodeBlock = Byron.encodeByronBlockWithInfo


### PR DESCRIPTION
This is yet another rewrite of the PBFT chain state, closing ticket #979.

Initially I had thought that this would be easy, and it was merely a case of storing a bunch of signatures before the anchor point. Conceptually that turns the state into a pair of lists, separated by the anchor. Unfortunately, this is not good enough. The fundamental problem is that we have _two_ split points: the first is the anchor point, but the second is the window size and, crucially, these two split points _must be allowed to vary independently_ (see diagrams in the code). 

We therefore track _two_ pairs of lists, which must be related in a well-defined way (see `invariant`). I have also completely replaced the tests for `PBftChainState` by proper property tests which verify that the two fundamental operations (`append` and `rewind`) preserve the invariant, and moreover, that rewnd-then-reappend is an identity operation. These property tests were instrumental in getting the redesign right. 