### PR TITLE
 Add human-readable displayException output for fatal exceptions

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ErrorPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ErrorPolicy.hs
@@ -60,11 +60,13 @@ consensusErrorPolicy = ErrorPolicies {
           -- them, we'd somehow have to distinguish between IO exceptions
           -- arising from disk I/O (shutdownNode) and those arising from
           -- network failures (SuspendConsumer).
-          ErrorPolicy $ \(_ :: VolatileDBError)  -> Just shutdownNode
+          ErrorPolicy $ \(_ :: DbMarkerError)    -> Just shutdownNode
         , ErrorPolicy $ \(_ :: ChainDbFailure)   -> Just shutdownNode
+          -- The three exceptions below will always be wrapped in a
+          -- 'ChainDbFailure', but we include them in the policy just in case.
+        , ErrorPolicy $ \(_ :: VolatileDBError)  -> Just shutdownNode
         , ErrorPolicy $ \(_ :: FsError)          -> Just shutdownNode
         , ErrorPolicy $ \(_ :: ImmutableDBError) -> Just shutdownNode
-        , ErrorPolicy $ \(_ :: DbMarkerError)    -> Just shutdownNode
 
           -- Node configuration failure
         , ErrorPolicy $ \(_ :: PBftLeaderCredentialsError) -> Just shutdownNode

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -20,7 +21,7 @@ module Ouroboros.Consensus.Node.ProtocolInfo.Byron (
   , plcCoreNodeId
   ) where
 
-import           Control.Exception (Exception)
+import           Control.Exception (Exception (..))
 import           Control.Monad.Except
 import           Data.Maybe
 import qualified Data.Set as Set
@@ -86,8 +87,12 @@ data PBftLeaderCredentialsError =
      | DelegationCertificateNotFromGenesisKey
   deriving (Eq, Show)
 
-instance Exception PBftLeaderCredentialsError
-
+instance Exception PBftLeaderCredentialsError where
+  displayException = \case
+    NodeSigningKeyDoesNotMatchDelegationCertificate ->
+      "The signing key does not match the delegation certificate"
+    DelegationCertificateNotFromGenesisKey ->
+      "Could not find a delegation certificate corresponding to the genesis key"
 
 {-------------------------------------------------------------------------------
   ProtocolInfo


### PR DESCRIPTION
When such exceptions shut down the node, the output of `displayException` (in
addition to the detailed output of `show`) will be shown to the user.