### PR TITLE
consensus: track EBBs in PBFT chain state

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/ChainState.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/ChainState.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
@@ -17,18 +18,19 @@ module Ouroboros.Consensus.Protocol.PBFT.ChainState (
     -- * Construction
   , empty
   , append
-  , appendMany
+  , appendEBB
   , rewind
     -- * Queries
   , countSignatures
   , countInWindow
   , countSignedBy
-  , lastSlot
+  , lastSignedSlot
     -- * Support for tests
-  , invariant
-  , toList
-  , fromList
+  , EbbMap (..)
   , PBftSigner(..)
+  , invariant
+  , fromList
+  , toList
     -- ** Serialization
   , encodePBftChainState
   , decodePBftChainState
@@ -39,6 +41,7 @@ import           Codec.Serialise.Decoding (Decoder)
 import qualified Codec.Serialise.Decoding as Serialise
 import           Codec.Serialise.Encoding (Encoding)
 import qualified Codec.Serialise.Encoding as Serialise
+import qualified Control.Exception as Exn
 import           Control.Monad.Except
 import qualified Data.Foldable as Foldable
 import           Data.Map.Strict (Map)
@@ -95,7 +98,7 @@ import           Ouroboros.Consensus.Util (repeatedly)
 -- not change the maximum rollback point).
 --
 -- This means that unless we are near genesis, we will at least have @n@
--- signatures in the history (after a maximum rollback of @k@), and under
+-- signatures in the history (even after a maximum rollback of @k@), and under
 -- normal circumstances (i.e., when not halfway a switch to a fork), @k+n@
 -- signatures.
 --
@@ -127,10 +130,41 @@ data PBftChainState c = PBftChainState {
       --
       -- We should have precisely @n@ signatures in the window, unless we are
       -- near genesis.
+      --
+      -- INVARIANT Empty if and only if we are exactly at genesis.
     , inWindow   :: !(StrictSeq (PBftSigner c))
 
       -- | Cached counts of the signatures in the window
     , counts     :: !(Map (PBftVerKeyHash c) Word64)
+
+      -- | Map from slots of relevant epoch boundary blocks (EBBs) to signed
+      -- slots
+      --
+      -- EBBs are not signed, so the 'preAnchor', 'postAnchor', 'preWindow',
+      -- and 'postWindow' fields are unaffected by EBBs. However, EBBs must
+      -- also be valid targets for 'rewind', so this field maps each slot that
+      -- contains an EBB to the preceding signed slot, /if/ that signed slot is
+      -- still a valid target for 'rewind'.
+      --
+      -- See INVARIANTs on 'EbbMap'.
+      --
+      -- INVARIANT For all @(ebbSlot, mSlot)@ in @'ebbs' (cs :: 'ChainState')@,
+      --
+      --  * @mSlot >= anchorSlot cs@; see 'pruneEBBsLT'
+      --
+      --  * @'At' ebbSlot <= tgt@ if @cs@ is the result of a 'rewind' to @tgt@;
+      --    see 'pruneEBBsGT'
+      --
+      --  * @and [ At s <= mSlot | s <- precedingSignedSlots ]@
+      --
+      --  * @'rewind' k n ('At' ebbSlot) cs = 'rewind' k n mSlot cs@
+      --
+      --   where
+      --
+      --  * @precedingSignedSlots = filter (< ebbSlot) signedSlots@
+      --
+      --  * @signedSlots = 'pbftSignerSlotNo' <$> ('preAnchor' <> 'postAnchor')@
+    , ebbs       :: !EbbMap
     }
   deriving (Generic)
 
@@ -175,9 +209,34 @@ invariant (SecurityParam k)
 
     unless (computeCounts inWindow == counts) $
       failure "Cached counts incorrect"
+
+    unless (allEbbs $ \_ mSlot -> mSlot >= anchorSlot st) $
+      failure "EBB mapped to slot before anchor"
+
+    unless (allEbbs $ \slot mSlot ->
+               let signedSlots          =
+                     fmap pbftSignerSlotNo $
+                     Foldable.toList $ preAnchor <> postAnchor
+                   precedingSignedSlots = filter (< slot) signedSlots
+               in all (\s -> At s <= mSlot) precedingSignedSlots
+           ) $
+      failure "EBB does not map to the preceding signature"
+
+    -- 'EbbMap''s "Key greater"
+    unless (allEbbs $ \slot mSlot -> At slot > mSlot) $
+      failure "EBB mapped to a simultaneous or future slot"
+
+    -- 'EbbMap''s "Non-descending"
+    unless (let nonDescending es = and $ zipWith (<=) es (tail es)
+            in nonDescending $ map snd $ Map.toAscList $ unEbbMap ebbs) $
+      failure $ "EBB mappings are not non-descending"
   where
     failure :: String -> Except String ()
     failure err = throwError $ err ++ ": " ++ show st
+
+    allEbbs p =
+      Map.null $
+      Map.filterWithKey (\slot mSlot -> not (p slot mSlot)) (unEbbMap ebbs)
 
 -- | The 'PBftChainState' tests don't rely on this flag but check the
 -- invariant manually. This flag is here so that the invariant checks could be
@@ -246,10 +305,24 @@ countSignedBy PBftChainState{..} gk = Map.findWithDefault 0 gk counts
 -- | The last (most recent) signed slot in the window
 --
 -- Returns 'Origin' if there are no signatures in the window (this will happen
--- near genesis only).
-lastSlot :: PBftChainState c -> WithOrigin SlotNo
-lastSlot PBftChainState{..} =
+-- exactly at genesis only).
+--
+-- Unaffected by EBBs, since they're not signed.
+lastSignedSlot :: PBftChainState c -> WithOrigin SlotNo
+lastSignedSlot PBftChainState{..} =
     case inWindow of
+      _ :|> signer -> At (pbftSignerSlotNo signer)
+      _otherwise   -> Origin
+
+-- | The anchor slot
+--
+-- Returns 'Origin' if there are no signatures in the window (this will happen
+-- exactly at genesis only).
+--
+-- Unaffected by EBBs, since they're not signed.
+anchorSlot :: PBftChainState c -> WithOrigin SlotNo
+anchorSlot PBftChainState{..} =
+    case preAnchor of
       _ :|> signer -> At (pbftSignerSlotNo signer)
       _otherwise   -> Origin
 
@@ -267,6 +340,7 @@ empty = PBftChainState {
     , preWindow  = Empty
     , inWindow   = Empty
     , counts     = Map.empty
+    , ebbs       = ebbsEmpty
     }
 
 -- | Append new signature
@@ -277,13 +351,16 @@ append :: forall c. PBftCrypto c
        -> WindowSize
        -> PBftSigner c
        -> PBftChainState c -> PBftChainState c
-append k n signer@(PBftSigner _ gk) PBftChainState{..} = assertInvariant k n $
+append k n signer@(PBftSigner _ gk) PBftChainState{..} =
+    assertInvariant k n $
+    pruneEBBsLT $
     PBftChainState {
         preAnchor  = preAnchor'
       , postAnchor = postAnchor'
       , preWindow  = preWindow'
       , inWindow   = inWindow'
       , counts     = updateCounts counts
+      , ebbs       = ebbs   -- NB this needs to be pruned
       }
   where
     (preAnchor', postAnchor') =
@@ -304,14 +381,6 @@ append k n signer@(PBftSigner _ gk) PBftChainState{..} = assertInvariant k n $
           , incrementKey gk
           )
 
--- | Append a bunch of blocks
-appendMany :: forall c. PBftCrypto c
-           => SecurityParam
-           -> WindowSize
-           -> [PBftSigner c] -- ^ Old to new
-           -> PBftChainState c -> PBftChainState c
-appendMany k n = repeatedly (append k n)
-
 -- | Rewind the state to the specified slot
 --
 -- This matches the semantics of 'rewindChainState' in 'OuroborosTag', in that
@@ -331,6 +400,19 @@ rewind :: forall c. PBftCrypto c
        -> WithOrigin SlotNo
        -> PBftChainState c -> Maybe (PBftChainState c)
 rewind k n mSlot cs@PBftChainState{..} =
+  case rewind_ k n mSlot cs of
+    Right mbCs' -> pruneEBBsGT mSlot <$> mbCs'
+    Left mSlot' ->
+      error $ "rewind: rollback to block not previously applied, "
+          ++ show (mSlot, mSlot', ebbs)
+
+-- | Internal worker for 'rewind'
+rewind_ :: forall c. PBftCrypto c
+       => SecurityParam
+       -> WindowSize
+       -> WithOrigin SlotNo
+       -> PBftChainState c -> Either SlotNo (Maybe (PBftChainState c))
+rewind_ k n mSlot cs@PBftChainState{..} =
     case mSlot of
       At slot ->
         -- We scan from the right, since block to roll back to likely at end
@@ -340,8 +422,8 @@ rewind k n mSlot cs@PBftChainState{..} =
           -- after that slot.
           (toDiscard, toKeep@(_ :|> x)) ->
             if slot == pbftSignerSlotNo x
-              then Just $ go toDiscard toKeep
-              else notPreviouslyApplied
+              then Right $ Just $ go toDiscard toKeep
+              else notFound slot
 
           -- The slot was not found post-anchor. If the slot matches the last
           -- slot pre-anchor, all is well, discarding everything post-anchor.
@@ -349,18 +431,10 @@ rewind k n mSlot cs@PBftChainState{..} =
           (toDiscard, Empty) ->
             case preAnchor of
               _ :|> x
-                | slot == pbftSignerSlotNo x -> Just $ go toDiscard Empty
+                | slot == pbftSignerSlotNo x -> Right $ Just $ go toDiscard Empty
                 | slot <  pbftSignerSlotNo x -> rollbackTooFar
-                | otherwise                  -> notPreviouslyApplied
-              Empty
-                -- In the current tests, slot 0 is always an EBB, which means
-                -- there is no record of it in the chain state. But we need to
-                -- be able to rewind to it.
-                --
-                -- TODO Eliminate this very specific adhoc case; see Issue
-                -- #1312.
-                | slot == 0 -> rewind k n Origin cs
-                | otherwise -> notPreviouslyApplied
+                | otherwise                  -> notFound slot
+              Empty                          -> notFound slot
 
       -- We can only roll back to origin if there are no signatures
       -- pre-anchor. Rolling back to origin would leave the chain empty. This
@@ -368,15 +442,18 @@ rewind k n mSlot cs@PBftChainState{..} =
       -- have more than @k@ blocks, the pre-anchor will not be empty.
       Origin ->
         case preAnchor of
-          Empty      -> Just $ go postAnchor Empty
+          Empty      -> Right $ Just $ go postAnchor Empty
           _otherwise -> rollbackTooFar
   where
-    notPreviouslyApplied :: forall x. x
-    notPreviouslyApplied =
-      error $ "rewind: rollback to block not previously applied"
+    -- If we didn't find a non-EBB, check if the slot was known to have an EBB.
+    -- If so, recur (just once, as long as 'ebbs' is well-formed).
+    notFound :: SlotNo -> Either SlotNo (Maybe (PBftChainState c))
+    notFound slot = case ebbsLookup slot ebbs of
+      Just mSlot' -> rewind_ k n mSlot' cs
+      Nothing     -> Left slot
 
-    rollbackTooFar :: Maybe x
-    rollbackTooFar = Nothing
+    rollbackTooFar :: Either x (Maybe y)
+    rollbackTooFar = Right Nothing
 
     -- Construct new state, given the remaining post-anchor signatures
     --
@@ -391,6 +468,7 @@ rewind k n mSlot cs@PBftChainState{..} =
         , preWindow  = preWindow'
         , inWindow   = inWindow'
         , counts     = computeCounts inWindow' -- for simplicity, just recount
+        , ebbs       = ebbs   -- NB this needs to be pruned
         }
       where
         -- Reconstruct the window
@@ -436,20 +514,24 @@ prune (SecurityParam n) (WindowSize k) (xs, ys) =
   Conversion
 -------------------------------------------------------------------------------}
 
-toList :: PBftChainState c -> (WithOrigin SlotNo, StrictSeq (PBftSigner c))
+toList :: PBftChainState c -> (WithOrigin SlotNo, StrictSeq (PBftSigner c), EbbMap)
 toList PBftChainState{..} = (
       case preAnchor of
         Empty   -> Origin
         _ :|> x -> At (pbftSignerSlotNo x)
     , preWindow <> inWindow
+    , ebbs
     )
 
 fromList :: PBftCrypto c
          => SecurityParam
          -> WindowSize
-         -> (WithOrigin SlotNo, StrictSeq (PBftSigner c))
+         -> (WithOrigin SlotNo, StrictSeq (PBftSigner c), EbbMap)
          -> PBftChainState c
-fromList k n (anchor, signers) = assertInvariant k n $ PBftChainState {..}
+fromList k n (anchor, signers, ebbs) =
+    assertInvariant k n $
+    pruneEBBsLT $
+    PBftChainState {..}
   where
     inPreAnchor :: PBftSigner c -> Bool
     inPreAnchor (PBftSigner slot _) = At slot <= anchor
@@ -462,25 +544,45 @@ fromList k n (anchor, signers) = assertInvariant k n $ PBftChainState {..}
   Serialization
 -------------------------------------------------------------------------------}
 
+serializationFormatVersion1 :: Word8
+serializationFormatVersion1 = 1
+  -- CHANGELOG
+  --
+  -- Version 0 is 2 fields, the anchor and the window. Note that it does not
+  -- have the version marker.
+  --
+  -- Version 1 has 4 fields, the version marker, anchor, window, and EbbMap.
+
 encodePBftChainState :: (PBftCrypto c, Serialise (PBftVerKeyHash c))
                      => PBftChainState c -> Encoding
-encodePBftChainState st = mconcat [
-      Serialise.encodeListLen 2
+encodePBftChainState st@PBftChainState{..} = mconcat [
+      Serialise.encodeListLen 4
+    , encode serializationFormatVersion1
     , encode (withOriginToMaybe anchor)
     , encode signers
+    , encode ebbs'
     ]
   where
-    (anchor, signers) = toList st
+    (anchor, signers, ebbs') = toList st
 
-decodePBftChainState :: (PBftCrypto c, Serialise (PBftVerKeyHash c))
+decodePBftChainState :: (PBftCrypto c, Serialise (PBftVerKeyHash c), HasCallStack)
                      => SecurityParam
                      -> WindowSize
                      -> Decoder s (PBftChainState c)
-decodePBftChainState k n = do
-      Serialise.decodeListLenOf 2
+decodePBftChainState k n = Serialise.decodeListLen >>= \case
+   2 -> do -- Version is 0
       anchor  <- withOriginFromMaybe <$> decode
       signers <- decode
-      return $ fromList k n (anchor, signers)
+      return $ fromList k n (anchor, signers, ebbsEmpty)
+   4 -> do -- Version is >0
+      v       <- decode
+      unless (v == serializationFormatVersion1) $ error $
+        "decode list length is 4, but version is not 1: " ++ show v
+      anchor  <- withOriginFromMaybe <$> decode
+      signers <- decode
+      ebbs'   <- decode
+      return $ fromList k n (anchor, signers, ebbs')
+   o -> error $ "unexpected list length: " <> show o
 
 instance Serialise (PBftVerKeyHash c) => Serialise (PBftSigner c) where
   encode = encode . toPair
@@ -490,3 +592,65 @@ instance Serialise (PBftVerKeyHash c) => Serialise (PBftSigner c) where
   decode = fromPair <$> decode
     where
       fromPair (slotNo, genesisKey) = PBftSigner slotNo genesisKey
+
+{-------------------------------------------------------------------------------
+  EBB Map
+-------------------------------------------------------------------------------}
+
+-- | Append an EBB
+--
+-- Its slot will be mapped to the 'lastSignedSlot'.
+appendEBB :: forall c. (PBftCrypto c, HasCallStack)
+          => SecurityParam
+          -> WindowSize
+          -> SlotNo
+          -> PBftChainState c -> PBftChainState c
+appendEBB k n newEbbSlot cs@PBftChainState{..} =
+    assertInvariant k n $
+    Exn.assert valid $
+    cs{ebbs = ebbsInsert newEbbSlot latestNonEbbSlot ebbs}
+  where
+    latestEbbSlot    = ebbsMax ebbs
+    latestNonEbbSlot = lastSignedSlot cs
+
+    valid = At newEbbSlot > max latestEbbSlot latestNonEbbSlot
+
+-- | Discard 'ebbs' mappings whose /value/ is before the anchor
+--
+-- Called by 'append', since 'ebbs' do not increase how far back the chain
+-- state can rewind.
+pruneEBBsLT :: PBftChainState c -> PBftChainState c
+pruneEBBsLT cs@PBftChainState{..} =
+  cs{ebbs = EbbMap $ Map.filter (>= anchorSlot cs) (unEbbMap ebbs)}
+
+-- | Discard 'ebbs' mappings whose /key/ is after the given slot
+--
+-- Called by 'rewind', since 'rewind'ing to a slot should forget the EBBs it
+-- precedes.
+pruneEBBsGT :: WithOrigin SlotNo -> PBftChainState c -> PBftChainState c
+pruneEBBsGT mSlot cs@PBftChainState{..} =
+  cs{ ebbs =
+        EbbMap $ Map.filterWithKey (\s _ -> At s <= mSlot) (unEbbMap ebbs)
+    }
+
+-- | A map from the slots containing an EBB to the preceding signed slot
+--
+-- INVARIANT Key greater: For all @(k, v)@, @At k > v@.
+--
+-- INVARIANT Non-descending: For all @(k1, v1)@ and @(k2, v2)@, @k1 < k2@
+-- implies @v1 <= v2@.
+newtype EbbMap = EbbMap {unEbbMap :: Map SlotNo (WithOrigin SlotNo)}
+  deriving stock (Generic, Show)
+  deriving newtype (Eq, Ord, NoUnexpectedThunks, Serialise)
+
+ebbsEmpty :: EbbMap
+ebbsEmpty = EbbMap Map.empty
+
+ebbsInsert :: SlotNo -> WithOrigin SlotNo -> EbbMap -> EbbMap
+ebbsInsert k v = EbbMap . Map.insert k v . unEbbMap
+
+ebbsMax :: EbbMap -> WithOrigin SlotNo
+ebbsMax = maybe Origin (At . fst) . Map.lookupMax . unEbbMap
+
+ebbsLookup :: SlotNo -> EbbMap -> Maybe (WithOrigin SlotNo)
+ebbsLookup k = Map.lookup k . unEbbMap

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/RealPBFT.hs
@@ -74,18 +74,14 @@ tests = testGroup "Dynamic chain generation"
               ]
             , nodeTopology = meshNodeTopology ncn
             }
-    , testProperty "worked around in PBFT.ChainState.rewind (see Issue #1312)" $
+    , testProperty "rewind to EBB supported as of Issue #1312, #1" $
       once $
       let ncn = NumCoreNodes 2 in
       -- When node 1 joins in slot 1, it leads with an empty chain and so
       -- forges the 0-EBB again. This causes it to report slot 0 as the found
       -- intersection point to node 0, which causes node 0 to \"rewind\" to
-      -- slot 0 (even though it's already there). That rewind fails since its
-      -- chain state is empty since EBBs don't affect the PBFT chain state.
-      --
-      -- But we currently have a workaround to handle this behavior for slot 0,
-      -- and we currently only ever forge the 0-EBB, not later ones, so this
-      -- test passes. TODO Issue #1312 will actually resolve the problem.
+      -- slot 0 (even though it's already there). That rewind fails if EBBs
+      -- don't affect the PBFT chain state, since its chain state is empty.
       prop_simple_real_pbft_convergence
         TestConfig { numCoreNodes = ncn
                    , numSlots     = NumSlots 2
@@ -93,6 +89,18 @@ tests = testGroup "Dynamic chain generation"
                    , nodeTopology = meshNodeTopology ncn
                    }
         Seed {getSeed = (15069526818753326002,9758937467355895013,16548925776947010688,13173070736975126721,13719483751339084974)}
+    , testProperty "rewind to EBB supported as of Issue #1312, #2" $
+      once $
+      let ncn = NumCoreNodes 2 in
+      -- Same as above, except node 0 gets to forge an actual block before node
+      -- 1 tells it to rewind to the EBB.
+      prop_simple_real_pbft_convergence
+        TestConfig { numCoreNodes = ncn
+                   , numSlots     = NumSlots 4
+                   , nodeJoinPlan = NodeJoinPlan (Map.fromList [(CoreNodeId 0,SlotNo {unSlotNo = 0}),(CoreNodeId 1,SlotNo {unSlotNo = 3})])
+                   , nodeTopology = meshNodeTopology ncn
+                   }
+        Seed {getSeed = (16817746570690588019,3284322327197424879,14951803542883145318,5227823917971823767,14093715642382269482)}
     , testProperty "simple Real PBFT convergence" $
         forAllShrink genRealPBFTTestConfig shrinkRealPBFTTestConfig $ \testConfig ->
         forAll arbitrary $ \seed ->

--- a/ouroboros-network/src/Ouroboros/Network/Point.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Point.hs
@@ -20,8 +20,11 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
+import           Codec.Serialise (Serialise (..))
+
 data WithOrigin t = Origin | At !t
-  deriving (Eq, Ord, Show, Generic, Functor, Foldable, Traversable, NoUnexpectedThunks)
+  deriving (Eq, Ord, Show, Generic, Functor, Foldable, Traversable,
+            NoUnexpectedThunks, Serialise)
 
 data Block slot hash = Block
   { blockPointSlot :: !slot


### PR DESCRIPTION
Closes #1312. Closes #925.

This is Option A on #1312: complicate the PBFT chain state to also track EBBs. This lets `rewind` target EBBs, which the CS client (unknowingly) needs it to do.

This is a Draft PR because:

  * This is not the option we were favoring, but I believed it would be useful to actually see it prototyped before dismissing it.
  * The diff does not extend the PBFT `ChainState` tests to test the new `ebbs` field.