### PR TITLE
Immutable DB: detect bitflips in epoch files

### DIFF
--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -50,6 +50,7 @@
           (hsPkgs.network)
           (hsPkgs.serialise)
           (hsPkgs.stm)
+          (hsPkgs.streaming)
           (hsPkgs.text)
           (hsPkgs.time)
           (hsPkgs.transformers)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -232,6 +232,7 @@ library
                        network,
                        serialise         >=0.2   && <0.3,
                        stm,
+                       streaming,
                        text              >=1.2   && <1.3,
                        time,
                        transformers,

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -41,6 +41,7 @@ library
                        Ouroboros.Consensus.Ledger.Byron.Conversions
                        Ouroboros.Consensus.Ledger.Byron.DelegationHistory
                        Ouroboros.Consensus.Ledger.Byron.Forge
+                       Ouroboros.Consensus.Ledger.Byron.Integrity
                        Ouroboros.Consensus.Ledger.Byron.Ledger
                        Ouroboros.Consensus.Ledger.Byron.Mempool
                        Ouroboros.Consensus.Ledger.Byron.Orphans

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron.hs
@@ -14,6 +14,7 @@ import           Ouroboros.Consensus.Ledger.Byron.ContainsGenesis as X
 import           Ouroboros.Consensus.Ledger.Byron.DelegationHistory as X
                      (DelegationHistory)
 import           Ouroboros.Consensus.Ledger.Byron.Forge as X
+import           Ouroboros.Consensus.Ledger.Byron.Integrity as X
 import           Ouroboros.Consensus.Ledger.Byron.Ledger as X
 import           Ouroboros.Consensus.Ledger.Byron.Mempool as X
 import           Ouroboros.Consensus.Ledger.Byron.PBFT as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Block.hs
@@ -21,7 +21,6 @@ module Ouroboros.Consensus.Ledger.Byron.Block (
     -- * Header
   , Header(..)
   , mkByronHeader
-  , byronBlockMatchesHeader
     -- * Serialisation
   , encodeByronBlockWithInfo
   , encodeByronBlock
@@ -169,11 +168,6 @@ mkByronHeader epochSlots hdr = ByronHeader {
     , byronHeaderSlotNo = fromByronSlotNo $ abobHdrSlotNo epochSlots hdr
     , byronHeaderHash   = mkByronHash hdr
     }
-
--- | Check if a block matches its header
-byronBlockMatchesHeader :: Header ByronBlock -> ByronBlock -> Bool
-byronBlockMatchesHeader hdr blk =
-    abobMatchesBody (byronHeaderRaw hdr) (byronBlockRaw blk)
 
 {-------------------------------------------------------------------------------
   HasHeader instances

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Integrity.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Integrity.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE NamedFieldPuns #-}
+module Ouroboros.Consensus.Ledger.Byron.Integrity
+  ( verifyBlockMatchesHeader
+  , verifyHeaderSignature
+  , verifyHeaderIntegrity
+  , verifyBlockIntegrity
+  ) where
+
+import           Data.Either (isRight)
+
+import qualified Cardano.Chain.Block as CC
+import qualified Cardano.Chain.Genesis as CC.Genesis
+import qualified Cardano.Crypto.DSIGN.Class as CC.Crypto
+
+import           Ouroboros.Consensus.Block (getHeader)
+
+import           Ouroboros.Consensus.Ledger.Byron.Auxiliary
+import           Ouroboros.Consensus.Ledger.Byron.Block
+import           Ouroboros.Consensus.Ledger.Byron.ContainsGenesis
+import           Ouroboros.Consensus.Ledger.Byron.PBFT
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.PBFT
+
+-- | Check if a block matches its header
+--
+-- Note that we cannot check this for an EBB, as the EBB header doesn't store
+-- a hash of the EBB body.
+verifyBlockMatchesHeader :: Header ByronBlock -> ByronBlock -> Bool
+verifyBlockMatchesHeader hdr blk =
+    abobMatchesBody (byronHeaderRaw hdr) (byronBlockRaw blk)
+
+-- | Verify whether a header matches its signature.
+--
+-- Note that we cannot check this for an EBB, as an EBB contains no signature.
+-- This function will always return 'True' for an EBB.
+verifyHeaderSignature
+  :: NodeConfig ByronConsensusProtocol -> Header ByronBlock -> Bool
+verifyHeaderSignature cfg@PBftNodeConfig { pbftExtConfig } hdr =
+    case headerPBftFields pbftExtConfig hdr of
+      -- EBB, no signature to check
+      Nothing -> True
+      Just (PBftFields { pbftIssuer, pbftGenKey, pbftSignature }, signed) ->
+        isRight $ CC.Crypto.verifySignedDSIGN
+          (constructContextDSIGN cfg pbftExtConfig pbftGenKey)
+          pbftIssuer
+          signed
+          pbftSignature
+
+-- | Verify whether a header is not corrupted.
+--
+-- The difference with 'verifyHeaderSignature' is that this function also
+-- checks the integrity of the 'CC.headerProtocolMagicId' field, which is the
+-- only field of a regular header that is not signed.
+--
+-- Note that we cannot check this for an EBB, as an EBB contains no signature.
+-- This function will always return 'True' for an EBB.
+verifyHeaderIntegrity
+  :: NodeConfig ByronConsensusProtocol -> Header ByronBlock -> Bool
+verifyHeaderIntegrity cfg hdr =
+    verifyHeaderSignature cfg hdr &&
+    -- @CC.headerProtocolMagicId@ is the only field of a regular header that
+    -- is not signed, so check it manually.
+    case byronHeaderRaw hdr of
+        ABOBBlockHdr h    -> CC.headerProtocolMagicId h == protocolMagicId
+        -- EBB, we can't check it
+        ABOBBoundaryHdr _ -> True
+  where
+    protocolMagicId = CC.Genesis.configProtocolMagicId (getGenesisConfig cfg)
+
+-- | Verifies whether the block is not corrupted by checking its signature and
+-- witnesses.
+--
+-- This function will always return 'True' for an EBB, as we cannot check
+-- anything for an EBB.
+verifyBlockIntegrity :: NodeConfig ByronConsensusProtocol -> ByronBlock -> Bool
+verifyBlockIntegrity cfg blk =
+    verifyHeaderIntegrity    cfg hdr &&
+    verifyBlockMatchesHeader     hdr blk
+  where
+    hdr = getHeader blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -227,6 +227,7 @@ initChainDB tracer registry btime dbPath cfg initLedger slotLength
       , ChainDB.cdbGenesis          = return initLedger
       , ChainDB.cdbDiskPolicy       = defaultDiskPolicy secParam slotDiffTime
       , ChainDB.cdbIsEBB            = nodeIsEBB
+      , ChainDB.cdbCheckIntegrity   = nodeCheckIntegrity      cfg
       , ChainDB.cdbParamsLgrDB      = ledgerDbDefaultParams secParam
       , ChainDB.cdbNodeConfig       = cfg
       , ChainDB.cdbRegistry         = registry

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
@@ -62,6 +62,18 @@ class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
   nodeHashInfo            :: Proxy blk
                           -> HashInfo (HeaderHash blk)
 
+  -- | Check the integrity of a block, i.e., that it has not been corrupted by
+  -- a bitflip.
+  --
+  -- Check this by, e.g., verifying whether the block has a valid signature
+  -- and that the hash of the body matches the body hash stores in the header.
+  --
+  -- This does not check the validity of the contents of the block, e.g.,
+  -- whether the transactions are valid w.r.t. the ledger, or whether it's
+  -- sent by a malicious node.
+  nodeCheckIntegrity      :: NodeConfig (BlockProtocol blk)
+                          -> blk -> Bool
+
   -- Encoders
   nodeEncodeBlockWithInfo :: NodeConfig (BlockProtocol blk) -> blk -> BinaryInfo Encoding
   nodeEncodeBlock         :: NodeConfig (BlockProtocol blk) -> blk -> Encoding

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -61,7 +61,7 @@ instance RunNode ByronBlock where
                           $ Genesis.gdProtocolMagicId
                           . extractGenesisData
   nodeHashInfo            = const byronHashInfo
-
+  nodeCheckIntegrity      = verifyBlockIntegrity
 
   nodeEncodeBlockWithInfo = const encodeByronBlockWithInfo
   nodeEncodeHeader        = const encodeByronHeader

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -28,7 +28,7 @@ import           Ouroboros.Storage.Common (EpochNo (..), EpochSize (..))
 
 instance RunNode ByronBlock where
   nodeForgeBlock          = forgeByronBlock
-  nodeBlockMatchesHeader  = byronBlockMatchesHeader
+  nodeBlockMatchesHeader  = verifyBlockMatchesHeader
   nodeBlockFetchSize      = const 2000 -- TODO #593
   nodeIsEBB               = \blk -> case byronBlockRaw blk of
     Cardano.Block.ABOBBlock _      -> Nothing

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
@@ -47,6 +47,7 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
 
   nodeProtocolMagicId     = const mockProtocolMagicId
   nodeHashInfo            = const simpleBlockHashInfo
+  nodeCheckIntegrity      = \_ _ -> True
 
   nodeEncodeBlockWithInfo = const simpleBlockBinaryInfo
   nodeEncodeHeader        = const encode

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -80,6 +80,7 @@ data ChainDbArgs m blk = forall h1 h2 h3. ChainDbArgs {
     , cdbEpochInfo        :: EpochInfo m
     , cdbHashInfo         :: HashInfo (HeaderHash blk)
     , cdbIsEBB            :: blk -> Maybe EpochNo
+    , cdbCheckIntegrity   :: blk -> Bool
     , cdbGenesis          :: m (ExtLedgerState blk)
     , cdbBlockchainTime   :: BlockchainTime m
 
@@ -147,6 +148,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , immHashInfo         = cdbHashInfo
         , immValidation       = cdbValidation
         , immIsEBB            = cdbIsEBB
+        , immCheckIntegrity   = cdbCheckIntegrity
         , immHasFS            = cdbHasFSImmDb
         , immTracer           = contramap TraceImmDBEvent cdbTracer
         }
@@ -222,6 +224,7 @@ toChainDbArgs ImmDB.ImmDbArgs{..}
     , cdbEpochInfo        = immEpochInfo
     , cdbHashInfo         = immHashInfo
     , cdbIsEBB            = immIsEBB
+    , cdbCheckIntegrity   = immCheckIntegrity
     , cdbGenesis          = lgrGenesis
     , cdbBlockchainTime   = cdbsBlockchainTime
       -- Misc

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -198,7 +198,7 @@ openDB ImmDbArgs{..} = do
   where
     parser = ImmDB.epochFileParser immHasFS immDecodeBlock immIsEBB
       -- TODO a more efficient to accomplish this?
-      (void . immEncodeBlock)
+      (void . immEncodeBlock) immCheckIntegrity
 
 
 -- | For testing purposes

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -107,8 +107,6 @@ import           GHC.Stack (HasCallStack)
 
 import           Control.Monad.Class.MonadThrow (finally)
 
-import           Ouroboros.Network.Point (WithOrigin)
-
 import           Ouroboros.Consensus.Block (IsEBB (..))
 import           Ouroboros.Consensus.Util (SomePair (..))
 import           Ouroboros.Consensus.Util.IOLike
@@ -167,7 +165,7 @@ openDB
   -> EpochInfo m
   -> HashInfo hash
   -> ValidationPolicy
-  -> EpochFileParser e m (Secondary.Entry hash, WithOrigin hash)
+  -> EpochFileParser e m (Secondary.Entry hash) hash
   -> Tracer m (TraceEvent e hash)
   -> m (ImmutableDB hash m)
 openDB hasFS err epochInfo hashInfo valPol parser tracer =
@@ -223,7 +221,7 @@ openDBInternal
   -> EpochInfo m
   -> HashInfo hash
   -> ValidationPolicy
-  -> EpochFileParser e m (Secondary.Entry hash, WithOrigin hash)
+  -> EpochFileParser e m (Secondary.Entry hash) hash
   -> Tracer m (TraceEvent e hash)
   -> m (ImmutableDB hash m, Internal hash m)
 openDBInternal hasFS@HasFS{..} err epochInfo hashInfo valPol parser tracer = do

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/State.hs
@@ -33,8 +33,6 @@ import           Cardano.Prelude (NoUnexpectedThunks (..))
 
 import           Control.Monad.Class.MonadThrow hiding (onException)
 
-import           Ouroboros.Network.Point (WithOrigin)
-
 import           Ouroboros.Consensus.Util (SomePair (..))
 import           Ouroboros.Consensus.Util.IOLike
 
@@ -63,7 +61,7 @@ data ImmutableDBEnv m hash = forall h e. ImmutableDBEnv
     { _dbHasFS           :: !(HasFS m h)
     , _dbErr             :: !(ErrorHandling ImmutableDBError m)
     , _dbInternalState   :: !(StrictMVar m (InternalState hash h))
-    , _dbEpochFileParser :: !(EpochFileParser e m (Secondary.Entry hash, WithOrigin hash))
+    , _dbEpochFileParser :: !(EpochFileParser e m (Secondary.Entry hash) hash)
     , _dbEpochInfo       :: !(EpochInfo m)
     , _dbHashInfo        :: !(HashInfo hash)
     , _dbTracer          :: !(Tracer m (TraceEvent e hash))

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
@@ -16,6 +16,7 @@ import           Control.Exception (assert)
 import           Control.Monad (unless, when)
 import           Control.Monad.Except (ExceptT, lift, runExceptT, throwError)
 import           Control.Tracer (Tracer, traceWith)
+import           Data.Coerce (coerce)
 import           Data.Functor (($>))
 import           Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
@@ -51,7 +52,7 @@ data ValidateEnv m hash h e = ValidateEnv
   , err       :: !(ErrorHandling ImmutableDBError m)
   , epochInfo :: !(EpochInfo m)
   , hashInfo  :: !(HashInfo hash)
-  , parser    :: !(EpochFileParser e m (Secondary.Entry hash, WithOrigin hash))
+  , parser    :: !(EpochFileParser e m (Secondary.Entry hash) hash)
   , tracer    :: !(Tracer m (TraceEvent e hash))
   }
 
@@ -216,6 +217,13 @@ data ShouldBeFinalised
 --   block of which its previous hash does not match the hash of the previous
 --   block.
 --
+-- * For each block, the 'EpochFileParser' checks whether the checksum (and
+--   other fields) from the secondary index file match the ones retrieved from
+--   the actual block. If they do, the block has not been corrupted. If they
+--   don't match or if the secondary index file is missing or corrupt, we have
+--   to do the expensive integrity check of the block itself to determine
+--   whether it is corrupt or not.
+--
 -- * This function checks whether the first block in the epoch fits onto the
 --   last block of the previous epoch by checking the hashes. If they do not
 --   fit, this epoch is truncated and @()@ is thrown.
@@ -227,17 +235,6 @@ data ShouldBeFinalised
 -- * All but the most recent epoch in the database should be finalised, i.e.
 --   padded to the size of the epoch.
 --
--- TODO currently, we focus on detecting partial writes, not on detecting all
--- kinds of corruptions, i.e. bitflips. In reality, the likeliness of a
--- bitflip happening in an epoch file is much larger than one happening in a
--- secondary index file. So when the checksums don't match, it will probably
--- be because the block is corrupt, not because the checksum got corrupted in
--- the secondary index file. We currently assume the epoch file is correct and
--- overwrite the secondary index file with the new checksum.
---
--- In the future, we will be able to check the integrity of a block on its own
--- so we can determine whether the block or the checksum got corrupted. See
--- #1253.
 validateEpoch
   :: forall m hash h e. (IOLike m, Eq hash, HasCallStack)
   => ValidateEnv m hash h e
@@ -259,27 +256,42 @@ validateEpoch
      -- would notice it doesn't fit anymore, and then throw.
 validateEpoch ValidateEnv{..} shouldBeFinalised epoch mbPrevHash = do
     trace $ ValidatingEpoch epoch
-    --  Parse the epoch file, return a list of 'Secondary.Entry's with one for
-    --  each block in the file. If the parser returns a deserialisation error,
-    --  truncate the epoch file. Don't truncate the database just yet, because
-    --  the deserialisation error may be due to some extra random bytes that
-    --  shouldn't have been there in the first place.
     epochFileExists <- lift $ doesFileExist epochFile
     unless epochFileExists $ do
       trace $ MissingEpochFile epoch
       throwError ()
 
+    -- Read the entries from the secondary index file, if it exists.
+    secondaryIndexFileExists  <- lift $ doesFileExist secondaryIndexFile
+    entriesFromSecondaryIndex <- lift $ if secondaryIndexFileExists
+      then EH.try errLoad
+        (Secondary.readAllEntries hasFS err hashInfo 0 epoch (const False) IsEBB) >>= \case
+          Left _                -> do
+            traceWith tracer $ InvalidSecondaryIndex epoch
+            return []
+          Right entriesFromFile -> return $ fixupEBB entriesFromFile
+      else do
+        traceWith tracer $ MissingSecondaryIndex epoch
+        return []
+
+    -- Parse the epoch file using the checksums from the secondary index file
+    -- as input. If the checksums match, the parser doesn't have to do the
+    -- expensive integrity check of a block.
+    let expectedChecksums =
+          map (Secondary.checksum . fst) entriesFromSecondaryIndex
     (entriesWithPrevHashes, mbErr) <- lift $
-        runEpochFileParser parser epochFile $ \stream ->
+        runEpochFileParser parser epochFile expectedChecksums $ \stream ->
           (\(es :> mbErr) -> (es, mbErr)) <$> S.toList stream
 
+    -- Check whether the first block of this epoch fits onto the last block of
+    -- the previous epoch.
     case entriesWithPrevHashes of
       (_, actualPrevHash) : _
         | Just expectedPrevHash <- mbPrevHash
         , expectedPrevHash /= actualPrevHash
           -- The previous hash of the first block in the epoch does not match
           -- the hash of the last block of the previous epoch. There must be a
-          -- gap. This epoch should be truncated
+          -- gap. This epoch should be truncated.
         -> do
           trace $ EpochFileDoesntFit expectedPrevHash actualPrevHash
           throwError ()
@@ -287,48 +299,21 @@ validateEpoch ValidateEnv{..} shouldBeFinalised epoch mbPrevHash = do
 
     lift $ do
 
+      -- If the parser returneds a deserialisation error, truncate the epoch
+      -- file. Don't truncate the database just yet, because the
+      -- deserialisation error may be due to some extra random bytes that
+      -- shouldn't have been there in the first place.
       whenJust mbErr $ \(parseErr, endOfLastValidBlock) -> do
-        -- If there was an error parsing the epoch file, truncate it
         traceWith tracer $ InvalidEpochFile epoch parseErr
         withFile hasFS epochFile (AppendMode AllowExisting) $ \eHnd ->
           hTruncate eHnd endOfLastValidBlock
 
-      -- Read the secondary index file, if it is missing, parsing fails, or it
-      -- does not match the 'Secondary.Entry's from the epoch file, overwrite
-      -- it using those (truncate first).
+      -- If the secondary index file is missing, parsing it failed, or it does
+      -- not match the entries from the epoch file, overwrite it using those
+      -- (truncate first).
       let entries = map fst entriesWithPrevHashes
-          isEBB
-            | entry:_ <- entries, EBB _ <- Secondary.blockOrEBB entry
-            = IsEBB
-            | otherwise
-            = IsNotEBB
-
-      secondaryIndexFileExists  <- doesFileExist secondaryIndexFile
-      secondaryIndexFileMatches <- if secondaryIndexFileExists
-        then EH.try errLoad
-          (Secondary.readAllEntries hasFS err hashInfo 0 epoch (const False) isEBB) >>= \case
-            Left _                -> do
-              traceWith tracer $ InvalidSecondaryIndex epoch
-              return False
-            -- TODO what if a hash or a checksum doesn't match? Who's speaking
-            -- the truth? If the checksums match, then the hash of the epoch
-            -- file is the right one. If the checksums don't match, we'd have
-            -- to check the signature and whether the body of the block
-            -- matches the body hash in the header to know which checksum is
-            -- correct. If the signature check and so on pass, then the
-            -- checksum of the block is correct, not the checksum in the
-            -- secondary index entry. If they don't, the the block is corrupt
-            -- and we should truncate it.
-            --
-            -- CURRENT APPROACH: we assume the contents of the epoch file are
-            -- correct (however unrealistic that may be, as the chance of a
-            -- bit flip in an epoch file is much greater than in an index
-            -- file). We will do the right thing in the future.
-            Right entriesFromFile -> return $ map fst entriesFromFile == entries
-        else do
-          traceWith tracer $ MissingSecondaryIndex epoch
-          return False
-      unless secondaryIndexFileMatches $ do
+      when (map fst entriesFromSecondaryIndex /= entries ||
+            not secondaryIndexFileExists) $ do
         traceWith tracer $ RewriteSecondaryIndex epoch
         Secondary.writeAllEntries hasFS hashInfo epoch entries
 
@@ -375,6 +360,49 @@ validateEpoch ValidateEnv{..} shouldBeFinalised epoch mbPrevHash = do
       (\case
         UnexpectedError (e@InvalidFileError {}) -> Just e
         _ -> Nothing) err
+
+    -- | When reading the entries from the secondary index file, we need to
+    -- pass in a value of type 'IsEBB' so we know whether the first entry
+    -- corresponds to an EBB or a regular block. We need this information to
+    -- correctly interpret the deserialised 'Word64' as a 'BlockOrEBB': if
+    -- it's an EBB, it's the 'EpochNo' ('Word64'), if it's a regular block,
+    -- it's a 'SlotNo' ('Word64').
+    --
+    -- However, at the point we are reading the secondary index file, we don't
+    -- yet know whether the first block will be an EBB or a regular block. We
+    -- will find that out when we read the actual block from the epoch file.
+    --
+    -- Fortunately, we can make a /very/ good guess: if the 'Word64' of the
+    -- 'BlockOrEBB' matches the epoch number, it is almost certainly an EBB,
+    -- as the slot numbers increase @10k@ times faster than epoch numbers.
+    -- Property: for every epoch @e > 0@, for all slot numbers @s@ in epoch
+    -- @e@ we have @s > e@. The only exception is epoch 0, which contains a
+    -- slot number 0. From this follows that it's an EBB if and only if the
+    -- 'Word64' matches the epoch number.
+    --
+    -- E.g., the first slot number in epoch 1 will be 21600 if @k = 2160@. We
+    -- could only make the wrong guess in the first very first epoch, i.e.,
+    -- epoch 0, as the first slot number is also 0. However, we know that the
+    -- real blockchain starts with an EBB, so even in that case we're fine.
+    --
+    -- If the epoch size were 1, then we would make the wrong guess for each
+    -- epoch that contains an EBB, which is a rather unrealistic scenario.
+    --
+    -- Note that even making the wrong guess is not a problem. The (CRC)
+    -- checksums are the only thing we extract from the secondary index file.
+    -- These are passed to the 'EpochFileParser'. We then reconstruct the
+    -- secondary index using the output of the 'EpochFileParser'. If that
+    -- output doesn't match the parsed secondary index file, we will overwrite
+    -- the secondary index file.
+    --
+    -- So the only thing that wouldn't go according to plan is that we will
+    -- needlessly overwrite the secondary index file.
+    fixupEBB :: [(Secondary.Entry hash, a)] -> [(Secondary.Entry hash, a)]
+    fixupEBB = \case
+      (entry@Secondary.Entry { blockOrEBB = EBB epoch' }, a):rest
+        | epoch' /= epoch
+        -> (entry { Secondary.blockOrEBB = Block (coerce epoch') }, a):rest
+      entries -> entries
 
 -- | Reconstruct a 'PrimaryIndex' based on a list of 'Secondary.Entry's.
 reconstructPrimaryIndex

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Parser.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Parser.hs
@@ -48,9 +48,17 @@ data EpochFileError hash =
   | EpochErrHashMismatch
       (WithOrigin hash)  -- ^ The hash of the previous block
       (WithOrigin hash)  -- ^ The previous hash of the block
+
+    -- | The integrity verification of the block with the given hash and
+    -- 'BlockOrEBB' number returned 'False', indicating that the block got
+    -- corrupted.
+  | EpochErrCorrupt hash BlockOrEBB
   deriving (Eq, Show)
 
-type BlockInfo hash = BinaryInfo (hash, WithOrigin hash, CRC, BlockOrEBB)
+-- | Type used internally in 'epochFileParser'': 'BinaryInfo' + the block
+-- hash, the previous hash, the CRC, 'BlockOrEBB', and whether the block is
+-- not corrupted ('False' = corrupted).
+type BlockInfo hash = BinaryInfo (hash, WithOrigin hash, CRC, BlockOrEBB, Bool)
 
 epochFileParser'
   :: forall m blk hash h. (IOLike m, Eq hash)
@@ -61,13 +69,15 @@ epochFileParser'
   -> (forall s. Decoder s (BL.ByteString -> blk))
   -> (blk -> Maybe EpochNo)    -- ^ If an EBB, return the epoch number
   -> (blk -> BinaryInfo ())
+  -> (blk -> Bool)             -- ^ Check integrity of the block. 'False' =
+                               -- corrupt.
   -> EpochFileParser
        (EpochFileError hash)
        m
        (Secondary.Entry hash, WithOrigin hash)
-epochFileParser' getSlotNo getHash getPrevHash
-                 hasFS decodeBlock isEBB getBinaryInfo = EpochFileParser $
-      fmap (checkIfHashesLineUp . first (fmap extractEntry))
+epochFileParser' getSlotNo getHash getPrevHash hasFS decodeBlock isEBB
+                 getBinaryInfo isNotCorrupt = EpochFileParser $
+      fmap (checkIfHashesLineUp . first (fmap extractEntry) . stopAtCorruption)
     . Util.CBOR.readIncrementalOffsets hasFS decoder
   where
     decoder :: forall s. Decoder s (BL.ByteString -> BlockInfo hash)
@@ -79,23 +89,41 @@ epochFileParser' getSlotNo getHash getPrevHash
     extractBlockInfo :: (BL.ByteString -> blk)
                      -> (BL.ByteString -> BlockInfo hash)
     extractBlockInfo f bs =
-        getBinaryInfo blk $> (hash, prevHash, crc, blockOrEBB)
+        getBinaryInfo blk $> (hash, prevHash, crc, blockOrEBB, notCorrupted)
       where
-        !blk        = f bs
-        !hash       = getHash blk
-        !prevHash   = getPrevHash blk
-        !crc        = computeCRC bs
-        !blockOrEBB = case isEBB blk of
+        !blk          = f bs
+        !hash         = getHash blk
+        !prevHash     = getPrevHash blk
+        !crc          = computeCRC bs
+        !blockOrEBB   = case isEBB blk of
           Just epoch -> EBB epoch
           Nothing    -> Block (getSlotNo blk)
+        !notCorrupted = isNotCorrupt blk
+
+    -- TODO two traversals with an accumulator now + in
+    -- 'readIncrementalOffsets' as well.
+    stopAtCorruption
+      :: ([(Word64, (Word64, BlockInfo hash))],
+          Maybe (Util.CBOR.ReadIncrementalErr, Word64))
+      -> ([(Word64, (Word64, BlockInfo hash))],
+          Maybe (EpochFileError hash, Word64))
+    stopAtCorruption (xs, mbErr) = go [] xs
+      where
+        go acc = \case
+          [] -> (reverse acc, first EpochErrRead <$> mbErr)
+          x@(offset, (_, BinaryInfo (hash, _, _, blockOrEBB, notCorrupted) _ _)):xs'
+            | notCorrupted
+            -> go (x:acc) xs'
+            | otherwise  -- The block is corrupt
+            -> (reverse acc, Just (EpochErrCorrupt hash blockOrEBB, offset))
 
     checkIfHashesLineUp
       :: ([(Secondary.Entry hash, WithOrigin hash)],
-          Maybe (Util.CBOR.ReadIncrementalErr, Word64))
+          Maybe (EpochFileError hash, Word64))
       -> ([(Secondary.Entry hash, WithOrigin hash)],
           Maybe (EpochFileError hash, Word64))
     checkIfHashesLineUp (es, mbErr) = case es of
-        []               -> ([], first EpochErrRead <$> mbErr)
+        []               -> ([], mbErr)
         e@(entry, _):es' -> go (At (Secondary.headerHash entry)) [e] es'
       where
         go hashOfPrevBlock acc =
@@ -103,7 +131,7 @@ epochFileParser' getSlotNo getHash getPrevHash
           -- block in @acc@ (the most recently checked one).
           assert (hashOfPrevBlock ==
                   At (Secondary.headerHash (fst (head acc)))) $ \case
-          [] -> (reverse acc, first EpochErrRead <$> mbErr)
+          [] -> (reverse acc, mbErr)
           e@(entry, prevHash):es'
             | prevHash == hashOfPrevBlock
             -> go (At (Secondary.headerHash entry)) (e:acc) es'
@@ -118,7 +146,7 @@ epochFileParser' getSlotNo getHash getPrevHash
     extractEntry (offset, (_size, blockInfo)) = (entry, prevHash)
       where
         BinaryInfo
-          { binaryBlob = (headerHash, prevHash, checksum, blockOrEBB)
+          { binaryBlob = (headerHash, prevHash, checksum, blockOrEBB, _notCorrupted)
           , headerOffset
           , headerSize
           } = blockInfo
@@ -138,6 +166,8 @@ epochFileParser
   -> (forall s. Decoder s (BL.ByteString -> blk))
   -> (blk -> Maybe EpochNo)  -- ^ If an EBB, return the epoch number
   -> (blk -> BinaryInfo ())
+  -> (blk -> Bool)           -- ^ Check integrity of the block. 'False' =
+                             -- corrupt.
   -> EpochFileParser
        (EpochFileError (HeaderHash blk))
        m

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -269,6 +269,7 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
         , cdbEpochInfo        = epochInfo
         , cdbHashInfo         = nodeHashInfo (Proxy @blk)
         , cdbIsEBB            = nodeIsEBB
+        , cdbCheckIntegrity   = nodeCheckIntegrity cfg
         , cdbGenesis          = return initLedger
         , cdbBlockchainTime   = btime
         -- Misc

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -267,6 +267,7 @@ mkArgs cfg initLedger tracer registry hashInfo
     , cdbEpochInfo        = fixedSizeEpochInfo fixedEpochSize
     , cdbHashInfo         = hashInfo
     , cdbIsEBB            = const Nothing
+    , cdbCheckIntegrity   = const True
     , cdbBlockchainTime   = fixedBlockchainTime maxBound
     , cdbGenesis          = return initLedger
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -66,17 +66,18 @@ withImmDB k = do
     bracket (ImmDB.openDB (mkArgs immDbFsVar epochInfo)) ImmDB.closeDB k
   where
     mkArgs immDbFsVar epochInfo = ImmDbArgs
-      { immErr         = EH.monadCatch
-      , immHasFS       = simHasFS EH.monadCatch immDbFsVar
-      , immDecodeHash  = nodeDecodeHeaderHash (Proxy @ByronBlock)
-      , immDecodeBlock = nodeDecodeBlock testCfg
-      , immEncodeHash  = nodeEncodeHeaderHash (Proxy @ByronBlock)
-      , immEncodeBlock = nodeEncodeBlockWithInfo testCfg
-      , immEpochInfo   = epochInfo
-      , immHashInfo    = nodeHashInfo (Proxy @ByronBlock)
-      , immValidation  = ValidateMostRecentEpoch
-      , immIsEBB       = nodeIsEBB
-      , immTracer      = nullTracer
+      { immErr            = EH.monadCatch
+      , immHasFS          = simHasFS EH.monadCatch immDbFsVar
+      , immDecodeHash     = nodeDecodeHeaderHash (Proxy @ByronBlock)
+      , immDecodeBlock    = nodeDecodeBlock testCfg
+      , immEncodeHash     = nodeEncodeHeaderHash (Proxy @ByronBlock)
+      , immEncodeBlock    = nodeEncodeBlockWithInfo testCfg
+      , immEpochInfo      = epochInfo
+      , immHashInfo       = nodeHashInfo (Proxy @ByronBlock)
+      , immValidation     = ValidateMostRecentEpoch
+      , immIsEBB          = nodeIsEBB
+      , immCheckIntegrity = nodeCheckIntegrity testCfg
+      , immTracer         = nullTracer
       }
 
 testCfg :: NodeConfig (BlockProtocol ByronBlock)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1355,6 +1355,7 @@ mkArgs cfg initLedger tracer registry varCurSlot
     , cdbEpochInfo        = fixedSizeEpochInfo fixedEpochSize
     , cdbHashInfo         = testHashInfo
     , cdbIsEBB            = testBlockEpochNoIfEBB fixedEpochSize
+    , cdbCheckIntegrity   = testBlockIsValid
     , cdbGenesis          = return initLedger
     , cdbBlockchainTime   = settableBlockchainTime varCurSlot
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -71,6 +71,7 @@ openTestDB hasFS err = openDB
     nullTracer
   where
     parser = epochFileParser hasFS (const <$> S.decode) isEBB getBinaryInfo
+      testBlockIsValid
     isEBB  = testBlockEpochNoIfEBB fixedEpochSize
     getBinaryInfo = void . testBlockToBinaryInfo
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -1246,7 +1246,8 @@ prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do
                   , Property
                   )
         test fsVar errorsVar hasFS = do
-          let parser = epochFileParser hasFS (const <$> decode) isEBB getBinaryInfo
+          let parser = epochFileParser hasFS (const <$> decode) isEBB
+                getBinaryInfo testBlockIsValid
           (tracer, getTrace) <- QC.run recordingTracerIORef
           (db, internal) <- QC.run $ openDBInternal hasFS EH.monadCatch
             (fixedSizeEpochInfo fixedEpochSize) testHashInfo

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -26,6 +26,7 @@ import qualified Data.ByteString.Lazy as Lazy
 import           Data.FingerTree.Strict (Measured (..))
 import           Data.Functor (($>))
 import           Data.Hashable
+import           Data.Int (Int64)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
@@ -56,7 +57,8 @@ import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 
 import           Ouroboros.Storage.Common (EpochNo (..), EpochSize (..))
-import           Ouroboros.Storage.FS.API (HasFS (..), withFile)
+import           Ouroboros.Storage.FS.API (HasFS (..), hGetExactly, hPutAll,
+                     hSeek, withFile)
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.ImmutableDB.Types (BinaryInfo (..),
                      HashInfo (..))
@@ -377,6 +379,9 @@ data FileCorruption
   = DeleteFile
   | DropLastBytes Word64
     -- ^ Drop the last @n@ bytes of a file.
+  | Corrupt Word64
+    -- ^ Corrupt the file by adding 1 to the byte at the given location
+    -- (modulo the file size).
   deriving (Show, Eq)
 
 -- | Returns 'True' when something was actually corrupted. For example, when
@@ -389,15 +394,31 @@ corruptFile hasFS@HasFS{..} fc file = case fc of
       let newFileSize = if n >= fileSize then 0 else fileSize - n
       hTruncate hnd newFileSize
       return $ fileSize /= newFileSize
+    Corrupt n               -> withFile hasFS file (ReadWriteMode AllowExisting) $ \hnd -> do
+      fileSize <- hGetSize hnd
+      if fileSize == 0 then
+        return False
+      else do
+        let offset :: Int64
+            offset = fromIntegral $ n `mod` fileSize
+        hSeek hnd AbsoluteSeek offset
+        bs <- hGetExactly hasFS hnd 1
+        hSeek hnd RelativeSeek (-1)
+        _ <- hPutAll hasFS hnd (Lazy.map (+ 1) bs)
+        return True
+
 
 instance Arbitrary FileCorruption where
   arbitrary = frequency
     [ (1, return DeleteFile)
     , (1, DropLastBytes . getSmall . getPositive <$> arbitrary)
+    , (1, Corrupt . getSmall . getPositive <$> arbitrary)
     ]
   shrink DeleteFile         = []
   shrink (DropLastBytes n)  =
     DropLastBytes . getSmall . getPositive <$> shrink (Positive (Small n))
+  shrink (Corrupt n) =
+    Corrupt . getSmall . getPositive <$> shrink (Positive (Small n))
 
 -- | Multiple corruptions
 type Corruptions = NonEmpty (FileCorruption, FsPath)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -177,6 +177,13 @@ testBlockEpochNoIfEBB fixedEpochSize b = case testBlockIsEBB b of
     IsEBB    -> Just $
       EpochNo (unSlotNo (blockSlot b) `div` unEpochSize fixedEpochSize)
 
+-- | Check whether the header matches its hash and whether the body matches
+-- its hash.
+testBlockIsValid :: TestBlock -> Bool
+testBlockIsValid (TestBlock hdr body) =
+  thHash     hdr == hashHeader hdr &&
+  thBodyHash hdr == hashBody   body
+
 testBlockToBuilder :: TestBlock -> Builder
 testBlockToBuilder = CBOR.toBuilder . encode
 

--- a/ouroboros-consensus/tools/db-analyse/Main.hs
+++ b/ouroboros-consensus/tools/db-analyse/Main.hs
@@ -254,6 +254,7 @@ openImmDB fp cfg epochInfo = openDB args
         , immEncodeHash     = nodeEncodeHeaderHash    (Proxy @ByronBlock)
         , immEncodeBlock    = nodeEncodeBlockWithInfo cfg
         , immEpochInfo      = epochInfo
+        , immHashInfo       = nodeHashInfo            (Proxy @ByronBlock)
         , immValidation     = ValidateMostRecentEpoch
         , immIsEBB          = nodeIsEBB
         , immCheckIntegrity = nodeCheckIntegrity      cfg


### PR DESCRIPTION
Addresses #290 and #1253.

Previously, we could only detect corruptions that cause deserialisation to fail, but not arbitrary bitflips. This PR fixes that.

* Add the ability to check whether a block got corrupted (= "integrity check") by checking its signature, body hash, etc. This works for all Byron blocks (see the property tests), except for those idiotic EBBs, which don't contain a signature or hash!

* Refactor the recovery to use streams (from http://hackage.haskell.org/package/streaming), making the code easier (IMO) and also making it easier to avoid having to keep all blocks from an epoch in memory.

* Use the CRC from the (secondary) index file to avoid the expensive the integrity check. Doing the integrity check for each block in https://github.com/input-output-hk/cardano-mainnet-mirror takes almost 4 min on my machine, using the CRC takes 1 min.

* Along the way, I fixed `db-convert` and `db-analyse` tools such that they they're less likely to break again in the future.