### PR TITLE
ntp-client: Add time-units package as a dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -133,6 +133,11 @@ source-repository-package
   location: https://github.com/input-output-hk/cardano-crypto
   tag: 4590efa638397e952a51a8994b5543e4ea3c1ecd
 
+source-repository-package
+  type: git
+  location: https://github.com/acw/time-units
+  tag: 187c41725258b8881c527745b2c63cc5db880056
+
 package contra-tracer
   tests: False
 
@@ -140,4 +145,5 @@ constraints:
   ip < 1.5,
   hedgehog >= 1.0,
   bimap >= 0.4.0,
-  primitive < 0.7
+  primitive < 0.7,
+  time-units == 1.0.0

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -11,7 +11,6 @@
         "hedgehog-quickcheck" = (((hackage.hedgehog-quickcheck)."0.1.1").revisions).default;
         "quickcheck-state-machine" = (((hackage.quickcheck-state-machine)."0.6.0").revisions).default;
         "splitmix" = (((hackage.splitmix)."0.0.2").revisions).default;
-        "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
         "tasty-hedgehog" = (((hackage.tasty-hedgehog)."1.0.0.1").revisions).default;
         "Unique" = (((hackage.Unique)."0.4.7.6").revisions).default;
         "statistics-linreg" = (((hackage.statistics-linreg)."0.3").revisions).default;
@@ -48,6 +47,7 @@
         cardano-crypto-test = ./cardano-crypto-test.nix;
         cardano-prelude = ./cardano-prelude.nix;
         cardano-prelude-test = ./cardano-prelude-test.nix;
+        time-units = ./time-units.nix;
         cardano-crypto = ./cardano-crypto.nix;
         };
       compiler.version = "8.6.5";

--- a/nix/.stack.nix/time-units.nix
+++ b/nix/.stack.nix/time-units.nix
@@ -1,0 +1,24 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "1.6";
+      identifier = { name = "time-units"; version = "1.0.0"; };
+      license = "BSD-3-Clause";
+      copyright = "";
+      maintainer = "Adam Wick <awick@uhusre.com>";
+      author = "Adam Wick <awick@uhsure.com>";
+      homepage = "http://github.com/acw/time-units";
+      url = "";
+      synopsis = "A basic library for defining units of time as types.";
+      description = "In many cases, it is useful (either for error checking or documentation\nreasons) to define input and output types as having a particular unit of\ntime. In addition, by creating a type class defining type units, this\nlibrary should make it easier to separate the units of time the developer\nwants to think in versus the units of time the library author wants to\nthink in.";
+      buildType = "Simple";
+      };
+    components = { "library" = { depends = [ (hsPkgs.base) ]; }; };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/acw/time-units";
+      rev = "187c41725258b8881c527745b2c63cc5db880056";
+      sha256 = "0qyhnzkb4cjqxa3k5clkx035hdplm5jij7dycxlhy1vr2ydgi4ib";
+      });
+    }

--- a/stack.yaml
+++ b/stack.yaml
@@ -53,6 +53,11 @@ extra-deps:
       - .
       - test
 
+  - git: https://github.com/acw/time-units
+    commit: 187c41725258b8881c527745b2c63cc5db880056
+    subdirs:
+      - .
+
   - bimap-0.4.0
   - binary-0.8.7.0
   - generic-monoid-0.1.0.0
@@ -60,7 +65,6 @@ extra-deps:
   - hedgehog-quickcheck-0.1.1
   - quickcheck-state-machine-0.6.0
   - splitmix-0.0.2
-  - time-units-1.0.0
   - tasty-hedgehog-1.0.0.1
   - Unique-0.4.7.6
   - statistics-linreg-0.3


### PR DESCRIPTION
For some reason the build cannot find the package on hackage.
As a work-around this add the package from its github repo.