### PR TITLE
Immutable DB: misc improvements

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -219,80 +219,17 @@ mkImmDB immDB decBlock encBlock epochInfo isEBB err = ImmDB {..}
 --
 -- If the point corresponds to some slot in the future, a
 -- 'ReadFutureSlotError' wrapped in a 'ImmDbFailure' is thrown.
-getBlockWithPoint :: forall m blk. (MonadCatch m, HasHeader blk, HasCallStack)
+getBlockWithPoint :: forall m blk. (MonadCatch m, HasCallStack)
                   => ImmDB m blk -> Point blk -> m (Maybe blk)
 getBlockWithPoint _  GenesisPoint = throwM NoGenesisBlock
 getBlockWithPoint db BlockPoint { withHash = hash, atSlot = slot } =
-    -- Unfortunately a point does not give us enough information to determine
-    -- whether this corresponds to a regular block or an EBB. We will
-    -- optimistically assume it refers to a regular block, and only when that
-    -- fails try to read the EBB instead. This means that
-    --
-    -- - If it is indeed a regular block performance is optimal
-    -- - If it is an EBB we would needlessly have read a regular block from
-    --   disk first, but EBBs are rare (1:20000 before the hard fork, and
-    --   non-existent after)
-    -- - If the block does not exist in the database at all, we'd have done two
-    --   reads before returning 'Nothing', but both of those reads are cheap
-    --
-    -- Note that there is one exceptional scenario: the point refers to the
-    -- EBB at the ImmutableDB's tip. This means that the regular block with
-    -- the same slot number as the EBB hasn't been added to the ImmutableDB
-    -- yet. If we first try to read the regular block at that slot, we would
-    -- get a 'ReadFutureSlotError' because we're trying to read a block in the
-    -- future. If we first read the EBB at that slot (the corresponding epoch,
-    -- in fact), then we won't get the 'ReadFutureSlotError'.
-    tipIsEBB >>= \case
-      Just tipSlot
-        | tipSlot == slot
-          -- There is an EBB at @slot@
-        -> getEBB
-      _ -> getBlockThenEBB
-  where
-    EpochInfo{..} = epochInfo db
-
-    -- | If there's an EBB at the tip of the ImmutableDB, return its 'SlotNo'.
-    tipIsEBB :: m (Maybe SlotNo)
-    tipIsEBB = withDB db $ \imm -> fmap fst <$> ImmDB.getTip imm >>= \case
-      Tip (ImmDB.EBB epochNo) -> Just <$> epochInfoFirst epochNo
-      Tip (ImmDB.Block _)     -> return Nothing
-      TipGen                  -> return Nothing
-
-    -- TODO do this more efficiently in the ImmutableDB
-    -- | First try to read the block at the slot, if the block's hash doesn't
-    -- match the expect hash, try reading the EBB at that slot.
-    getBlockThenEBB :: m (Maybe blk)
-    getBlockThenEBB = getBlockWithHash (Right slot) >>= \case
-      Just block -> return (Just block)
-      Nothing    -> do
-        epochNo <- epochInfoEpoch slot
-        ebbSlot <- epochInfoFirst epochNo
-        -- The point can only refer to an EBB if its slot refers to the first
-        -- slot of the epoch
-        if slot == ebbSlot
-          then getBlockWithHash (Left epochNo)
-          else return Nothing
-
-    -- | Try to read the EBB at the slot, if the EBB's hash doesn't match the
-    -- expect hash, return 'Nothing'.
-    --
-    -- PRECONDITION: there is an EBB at @slot@
-    getEBB :: m (Maybe blk)
-    getEBB = epochInfoEpoch slot >>= \epochNo ->
-      getBlock db (Left epochNo) >>= \case
-        Just block
-          | blockHash block == hash
-          -> return $ Just block
-          | otherwise
-          -> return $ Nothing
-        Nothing -- EBB is missing
-          -> throwM $ ImmDbMissingBlock (Left epochNo)
-
-    -- Important: we check whether the block's hash matches the point's hash
-    getBlockWithHash :: Either EpochNo SlotNo -> m (Maybe blk)
-    getBlockWithHash epochOrSlot = getBlock db epochOrSlot >>= \case
-      Just block | blockHash block == hash -> return $ Just block
-      _                                    -> return $ Nothing
+    withDB db $ \imm -> do
+      mBlob <- fmap (uncurry (parse (decBlock db))) <$>
+        ImmDB.getBlockOrEBB imm slot hash
+      case mBlob of
+        Nothing         -> return $ Nothing
+        Just (Right b)  -> return $ Just b
+        Just (Left err) -> throwM $ err
 
 getBlockAtTip :: (MonadCatch m, HasCallStack)
               => ImmDB m blk -> m (Maybe blk)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
@@ -93,7 +93,6 @@ getTipHeader
   :: forall m blk.
      ( IOLike m
      , GetHeader blk
-     , HasHeader blk
      , HasHeader (Header blk)
      )
   => ChainDbEnv m blk

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -115,11 +115,11 @@ data ImmutableDB hash m = ImmutableDB
   , getBlock
       :: HasCallStack => SlotNo -> m (Maybe (hash, ByteString))
 
-    -- | TODO
+    -- | Variant of 'getBlock' that only reads the header.
   , getBlockHeader
       :: HasCallStack => SlotNo -> m (Maybe (hash, ByteString))
 
-    -- | TODO
+    -- | Variant of 'getBlock' that only reads the hash.
   , getBlockHash
       :: HasCallStack => SlotNo -> m (Maybe hash)
 
@@ -134,11 +134,11 @@ data ImmutableDB hash m = ImmutableDB
   , getEBB
       :: HasCallStack => EpochNo -> m (Maybe (hash, ByteString))
 
-    -- | TODO
+    -- | Variant of 'getEBB' that only reads the header.
   , getEBBHeader
       :: HasCallStack => EpochNo -> m (Maybe (hash, ByteString))
 
-    -- | TODO
+    -- | Variant of 'getEBB' that only returns the hash.
   , getEBBHash
       :: HasCallStack => EpochNo -> m (Maybe hash)
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -142,6 +142,27 @@ data ImmutableDB hash m = ImmutableDB
   , getEBBHash
       :: HasCallStack => EpochNo -> m (Maybe hash)
 
+    -- | Get the block or EBB at the given slot with the given hash.
+    --
+    -- Also return 'EpochNo' in case of an EBB or the given 'SlotNo' in case
+    -- of a regular block.
+    --
+    -- If the slot is empty, 'Nothing' is returned. If the slot is not empty,
+    -- but the block (and or the EBB) in it doesn't have the given hash,
+    -- 'Nothing' is also returned.
+    --
+    -- Throws a 'ReadFutureSlotError' if the requested slot is in the future.
+    --
+    -- Throws a 'ClosedDBError' if the database is closed.
+  , getBlockOrEBB
+      :: HasCallStack
+      => SlotNo -> hash -> m (Maybe (Either EpochNo SlotNo, ByteString))
+
+    -- | Variant of 'getBlockOrEBB' that only returns the header.
+  , getBlockOrEBBHeader
+      :: HasCallStack
+      => SlotNo -> hash -> m (Maybe (Either EpochNo SlotNo, ByteString))
+
     -- | Appends a block at the given slot.
     --
     -- Throws an 'AppendToSlotInThePastError' if the given slot is <= the

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -37,21 +37,23 @@ openDBMock err epochSize = do
 
     immDB :: StrictTVar m (DBModel hash) -> ImmutableDB hash m
     immDB dbVar = ImmutableDB
-        { closeDB           = wrap  $   closeDB       db
-        , isOpen            = wrap  $   isOpen        db
-        , reopen            = wrap  .   reopen        db
-        , getTip            = wrap  $   getTip        db
-        , getBlock          = wrap  .   getBlock      db
-        , getBlockHeader    = wrap  .   getBlock      db
-        , getBlockHash      = wrap  .   getBlockHash  db
-        , getEBB            = wrap  .   getEBB        db
-        , getEBBHeader      = wrap  .   getEBBHeader  db
-        , getEBBHash        = wrap  .   getEBBHash    db
-        , appendBlock       = wrap  ..: appendBlock   db
-        , appendEBB         = wrap  ..: appendEBB     db
-        , streamBlocks      = wrapI .:  streamBlocks  db
-        , streamHeaders     = wrapI .:  streamHeaders db
-        , immutableDBErr    = err
+        { closeDB             = wrap  $   closeDB             db
+        , isOpen              = wrap  $   isOpen              db
+        , reopen              = wrap  .   reopen              db
+        , getTip              = wrap  $   getTip              db
+        , getBlock            = wrap  .   getBlock            db
+        , getBlockHeader      = wrap  .   getBlock            db
+        , getBlockHash        = wrap  .   getBlockHash        db
+        , getEBB              = wrap  .   getEBB              db
+        , getEBBHeader        = wrap  .   getEBBHeader        db
+        , getEBBHash          = wrap  .   getEBBHash          db
+        , getBlockOrEBB       = wrap  .:  getBlockOrEBB       db
+        , getBlockOrEBBHeader = wrap  .:  getBlockOrEBBHeader db
+        , appendBlock         = wrap  ..: appendBlock         db
+        , appendEBB           = wrap  ..: appendEBB           db
+        , streamBlocks        = wrapI .:  streamBlocks        db
+        , streamHeaders       = wrapI .:  streamHeaders       db
+        , immutableDBErr      = err
         }
       where
         wrap  = wrapModel dbVar

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -429,7 +429,7 @@ generateCmd Model {..} = At <$> frequency
     [ -- Block
       (1, elements [GetBlock, GetBlockHeader, GetBlockHash] <*> genGetBlockSlot)
       -- EBB
-    , (1, elements [GetEBB, GetEBBHeader, GetEBBHash] <*> genEpoch)
+    , (1, elements [GetEBB, GetEBBHeader, GetEBBHash] <*> genGetEBB)
     , (3, do
             let mbPrevBlock = dbmTipBlock dbModel
             slotNo  <- frequency
@@ -524,10 +524,11 @@ generateCmd Model {..} = At <$> frequency
       , (1,  genSlotInTheFuture)
       , (1,  genSmallSlotNo) ]
 
-    genEpoch :: Gen EpochNo
-    genEpoch = frequency
-      [ (if empty then 0 else 10, chooseEpoch (0, currentEpoch))
-      , (1, chooseEpoch (0, 5)) ]
+    genGetEBB :: Gen EpochNo
+    genGetEBB = frequency
+      [ (if noEBBs then 0 else 5, elements $ Map.keys dbmEBBs)
+      , (1, chooseEpoch (0, 5))
+      ]
 
     chooseWord64 :: Coercible a Word64 => (a, a) -> Gen a
     chooseWord64 (start, end) = coerce $ choose @Word64 (coerce start, coerce end)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -111,23 +111,25 @@ import           Test.Ouroboros.Storage.Util (collects)
 -- Where @m@ can be 'PureM', 'RealM', or 'RealErrM', and @r@ can be 'Symbolic'
 -- or 'Concrete'.
 data Cmd it
-  = GetBlock          SlotNo
-  | GetBlockHeader    SlotNo
-  | GetBlockHash      SlotNo
-  | GetEBB            EpochNo
-  | GetEBBHeader      EpochNo
-  | GetEBBHash        EpochNo
-  | AppendBlock       SlotNo  Hash TestBlock
-  | AppendEBB         EpochNo Hash TestBlock
-  | StreamBlocks      (Maybe (SlotNo, Hash)) (Maybe (SlotNo, Hash))
-  | StreamHeaders     (Maybe (SlotNo, Hash)) (Maybe (SlotNo, Hash))
-  | IteratorNext      it
-  | IteratorPeek      it
-  | IteratorHasNext   it
-  | IteratorClose     it
-  | Reopen            ValidationPolicy
-  | DeleteAfter       ImmTip
-  | Corruption        Corruption
+  = GetBlock            SlotNo
+  | GetBlockHeader      SlotNo
+  | GetBlockHash        SlotNo
+  | GetEBB              EpochNo
+  | GetEBBHeader        EpochNo
+  | GetEBBHash          EpochNo
+  | GetBlockOrEBB       SlotNo  Hash
+  | GetBlockOrEBBHeader SlotNo  Hash
+  | AppendBlock         SlotNo  Hash TestBlock
+  | AppendEBB           EpochNo Hash TestBlock
+  | StreamBlocks        (Maybe (SlotNo, Hash)) (Maybe (SlotNo, Hash))
+  | StreamHeaders       (Maybe (SlotNo, Hash)) (Maybe (SlotNo, Hash))
+  | IteratorNext        it
+  | IteratorPeek        it
+  | IteratorHasNext     it
+  | IteratorClose       it
+  | Reopen              ValidationPolicy
+  | DeleteAfter         ImmTip
+  | Corruption          Corruption
   deriving (Generic, Show, Functor, Foldable, Traversable)
 
 deriving instance SOP.Generic         (Cmd it)
@@ -160,18 +162,20 @@ type Hash = TestHeaderHash
 
 -- | Return type for successful database operations.
 data Success it
-  = Unit         ()
-  | Block        (Maybe (Hash, ByteString))
-  | EBB          (Maybe (Hash, ByteString))
-  | BlockHeader  (Maybe (Hash, ByteString))
-  | EBBHeader    (Maybe (Hash, ByteString))
-  | BlockHash    (Maybe Hash)
-  | EBBHash      (Maybe Hash)
-  | EpochNo      EpochNo
-  | Iter         (Either (WrongBoundError Hash) it)
-  | IterResult   (IteratorResult Hash ByteString)
-  | IterHasNext  Bool
-  | Tip          (ImmTipWithHash Hash)
+  = Unit             ()
+  | Block            (Maybe (Hash, ByteString))
+  | EBB              (Maybe (Hash, ByteString))
+  | BlockHeader      (Maybe (Hash, ByteString))
+  | EBBHeader        (Maybe (Hash, ByteString))
+  | BlockHash        (Maybe Hash)
+  | EBBHash          (Maybe Hash)
+  | BlockOrEBB       (Maybe (Either EpochNo SlotNo, ByteString))
+  | BlockOrEBBHeader (Maybe (Either EpochNo SlotNo, ByteString))
+  | EpochNo          EpochNo
+  | Iter             (Either (WrongBoundError Hash) it)
+  | IterResult       (IteratorResult Hash ByteString)
+  | IterHasNext      Bool
+  | Tip              (ImmTipWithHash Hash)
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
 -- | How to run a 'Corruption' command.
@@ -190,29 +194,31 @@ run :: (HasCallStack, Monad m)
     -> Cmd (Iterator Hash m ByteString)
     -> m (Success (Iterator Hash m ByteString))
 run runCorruption its db internal cmd = case cmd of
-  GetBlock          s   -> Block       <$> getBlock       db s
-  GetEBB            e   -> EBB         <$> getEBB         db e
-  GetBlockHeader    s   -> BlockHeader <$> getBlockHeader db s
-  GetEBBHeader      e   -> EBBHeader   <$> getEBBHeader   db e
-  GetBlockHash      s   -> BlockHash   <$> getBlockHash   db s
-  GetEBBHash        e   -> EBBHash     <$> getEBBHash     db e
-  AppendBlock     s h b -> Unit        <$> appendBlock    db s h (toBuilder <$> testBlockToBinaryInfo b)
-  AppendEBB       e h b -> Unit        <$> appendEBB      db e h (toBuilder <$> testBlockToBinaryInfo b)
-  StreamBlocks    s e   -> Iter        <$> streamBlocks   db s e
-  StreamHeaders   s e   -> Iter        <$> streamHeaders  db s e
-  IteratorNext    it    -> IterResult  <$> iteratorNext    it
-  IteratorPeek    it    -> IterResult  <$> iteratorPeek    it
-  IteratorHasNext it    -> IterHasNext <$> iteratorHasNext it
-  IteratorClose   it    -> Unit        <$> iteratorClose   it
-  DeleteAfter tip       -> do
+  GetBlock            s     -> Block            <$> getBlock            db s
+  GetEBB              e     -> EBB              <$> getEBB              db e
+  GetBlockHeader      s     -> BlockHeader      <$> getBlockHeader      db s
+  GetEBBHeader        e     -> EBBHeader        <$> getEBBHeader        db e
+  GetBlockHash        s     -> BlockHash        <$> getBlockHash        db s
+  GetEBBHash          e     -> EBBHash          <$> getEBBHash          db e
+  GetBlockOrEBB       s h   -> BlockOrEBB       <$> getBlockOrEBB       db s h
+  GetBlockOrEBBHeader s h   -> BlockOrEBBHeader <$> getBlockOrEBBHeader db s h
+  AppendBlock         s h b -> Unit             <$> appendBlock         db s h (toBuilder <$> testBlockToBinaryInfo b)
+  AppendEBB           e h b -> Unit             <$> appendEBB           db e h (toBuilder <$> testBlockToBinaryInfo b)
+  StreamBlocks        s e   -> Iter             <$> streamBlocks        db s e
+  StreamHeaders       s e   -> Iter             <$> streamHeaders       db s e
+  IteratorNext        it    -> IterResult       <$> iteratorNext        it
+  IteratorPeek        it    -> IterResult       <$> iteratorPeek        it
+  IteratorHasNext     it    -> IterHasNext      <$> iteratorHasNext     it
+  IteratorClose       it    -> Unit             <$> iteratorClose       it
+  DeleteAfter tip           -> do
     mapM_ iteratorClose its
     Unit <$> deleteAfter internal tip
-  Reopen valPol         -> do
+  Reopen valPol             -> do
     mapM_ iteratorClose its
     closeDB db
     reopen db valPol
     Tip <$> getTip db
-  Corruption corr       -> do
+  Corruption corr           -> do
     mapM_ iteratorClose its
     runCorruption db internal corr
 
@@ -430,6 +436,7 @@ generateCmd Model {..} = At <$> frequency
       (1, elements [GetBlock, GetBlockHeader, GetBlockHash] <*> genGetBlockSlot)
       -- EBB
     , (1, elements [GetEBB, GetEBBHeader, GetEBBHash] <*> genGetEBB)
+    , (1, (uncurry <$> elements [GetBlockOrEBB, GetBlockOrEBBHeader]) <*> genSlotAndHash)
     , (3, do
             let mbPrevBlock = dbmTipBlock dbModel
             slotNo  <- frequency
@@ -545,6 +552,15 @@ generateCmd Model {..} = At <$> frequency
     genSlotInTheFuture :: Gen SlotNo
     genSlotInTheFuture = chooseSlot (succ lastSlot, maxBound)
 
+    genSlotAndHash :: Gen (SlotNo, Hash)
+    genSlotAndHash = frequency
+      [ (if noBlocks then 0 else 5,
+         (\b -> (blockSlot b, blockHash b)) <$> genBlockInThePast)
+      , (if noEBBs then 0 else 5,
+         (\b -> (blockSlot b, blockHash b)) <$> genEBBInThePast)
+      , (1, genRandomBound)
+      ]
+
     -- Generates random hashes, will seldomly correspond to real blocks. Used
     -- to test error handling.
     genRandomBound :: Gen (SlotNo, Hash)
@@ -616,6 +632,8 @@ shrinkCmd Model {..} (At cmd) = fmap At $ case cmd of
       [GetBlockHash slot' | slot' <- shrink slot]
     GetEBBHash epoch                  ->
       [GetEBBHash epoch' | epoch' <- shrink epoch]
+    GetBlockOrEBB _slot _hash         -> []
+    GetBlockOrEBBHeader _slot _hash   -> []
     IteratorNext    {}                -> []
     IteratorPeek    {}                -> []
     IteratorHasNext {}                -> []


### PR DESCRIPTION
Now that #1244 is merged, we can take advantage of the ImmutableDB being aware of hashes.

Previously, we often had to read and parse the whole block from the ImmutableDB to know its hash. For example, when reading the block from the ImmutableDB corresponding to some `Point`, we first have to read and parse the block to check whether the block in that slot has the hash of the point. It's even worse when the slot can contain an EBB: we first read the block in that slot and when its hash doesn't match, we read the EBB of the epoch and check its hash, uggh.

This check can be done much more efficiently in the ImmutableDB itself, where can check the index file(s) to see whether we have the block with right slot *and* hash, without having to parse the block first.

This PR contains some other improvements: add missing docstrings & tweak a test generator.