### PR TITLE
remove illegal MonadAsync super constraints

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
@@ -30,8 +30,6 @@ import           Data.Proxy
 
 class ( MonadSTM m
       , MonadThread m
-      , forall a. Eq  (Async m a)
-      , forall a. Ord (Async m a)
       , Functor (Async m)
       ) => MonadAsync m where
 


### PR DESCRIPTION
You cannot have type families in quantified constraints
https://gitlab.haskell.org/ghc/ghc/issues/17202#note_241130