### PR TITLE
Rename Aux.hs to Auxiliary.hs as it broke Windows

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -34,7 +34,7 @@ library
                        Ouroboros.Consensus.Crypto.DSIGN.Cardano
                        Ouroboros.Consensus.Ledger.Abstract
                        Ouroboros.Consensus.Ledger.Byron
-                       Ouroboros.Consensus.Ledger.Byron.Aux
+                       Ouroboros.Consensus.Ledger.Byron.Auxiliary
                        Ouroboros.Consensus.Ledger.Byron.Block
                        Ouroboros.Consensus.Ledger.Byron.Config
                        Ouroboros.Consensus.Ledger.Byron.ContainsGenesis

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Auxiliary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Auxiliary.hs
@@ -16,7 +16,7 @@
 --
 -- NOTE: None of these definitions depend on @ouroboros-network@ or
 -- @ouroboros-consensus@ and could probably be moved to @cardano-ledger@.
-module Ouroboros.Consensus.Ledger.Byron.Aux (
+module Ouroboros.Consensus.Ledger.Byron.Auxiliary (
     -- * Extract info from genesis config
     allowedDelegators
   , boundaryBlockSlot

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Block.hs
@@ -61,7 +61,7 @@ import qualified Cardano.Crypto.Hashing as CC
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Ledger.Byron.Aux
+import           Ouroboros.Consensus.Ledger.Byron.Auxiliary
 import           Ouroboros.Consensus.Ledger.Byron.Conversions
 import           Ouroboros.Consensus.Ledger.Byron.Orphans ()
 import           Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
@@ -29,7 +29,7 @@ import           Cardano.Crypto.DSIGN
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Cardano
-import           Ouroboros.Consensus.Ledger.Byron.Aux
+import           Ouroboros.Consensus.Ledger.Byron.Auxiliary
 import           Ouroboros.Consensus.Ledger.Byron.Block
 import           Ouroboros.Consensus.Ledger.Byron.Config
 import           Ouroboros.Consensus.Ledger.Byron.ContainsGenesis

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Ledger.hs
@@ -44,7 +44,7 @@ import           Ouroboros.Network.Point (WithOrigin (..))
 import qualified Ouroboros.Network.Point as Point
 
 import           Ouroboros.Consensus.Ledger.Abstract
-import qualified Ouroboros.Consensus.Ledger.Byron.Aux as Aux
+import qualified Ouroboros.Consensus.Ledger.Byron.Auxiliary as Aux
 import           Ouroboros.Consensus.Ledger.Byron.Block
 import           Ouroboros.Consensus.Ledger.Byron.Config
 import           Ouroboros.Consensus.Ledger.Byron.ContainsGenesis

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Mempool.hs
@@ -57,7 +57,7 @@ import qualified Cardano.Chain.UTxO as Utxo
 import qualified Cardano.Chain.ValidationMode as CC
 
 import           Ouroboros.Consensus.Ledger.Abstract
-import           Ouroboros.Consensus.Ledger.Byron.Aux
+import           Ouroboros.Consensus.Ledger.Byron.Auxiliary
 import           Ouroboros.Consensus.Ledger.Byron.Block
 import           Ouroboros.Consensus.Ledger.Byron.Ledger
 import           Ouroboros.Consensus.Ledger.Byron.Orphans ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
@@ -25,7 +25,7 @@ import qualified Cardano.Chain.Delegation as Delegation
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Crypto.DSIGN.Cardano
-import           Ouroboros.Consensus.Ledger.Byron.Aux
+import           Ouroboros.Consensus.Ledger.Byron.Auxiliary
 import           Ouroboros.Consensus.Ledger.Byron.Block
 import           Ouroboros.Consensus.Ledger.Byron.Config
 import           Ouroboros.Consensus.Protocol.Abstract

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Ledger/Byron.hs
@@ -25,7 +25,7 @@ import           Ouroboros.Network.Block (HeaderHash)
 
 import           Ouroboros.Consensus.Block (Header)
 import           Ouroboros.Consensus.Ledger.Byron
-import           Ouroboros.Consensus.Ledger.Byron.Aux
+import           Ouroboros.Consensus.Ledger.Byron.Auxiliary
 import           Ouroboros.Consensus.Mempool.API (ApplyTxErr)
 import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
 


### PR DESCRIPTION
No files named "Aux" (even with an extension) are allowed on Windows.

See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file