### PR TITLE
consensus: make PBFT serialisation more general

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/ChainState.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/ChainState.hs
@@ -519,9 +519,12 @@ toList PBftChainState{..} = (
       case preAnchor of
         Empty   -> Origin
         _ :|> x -> At (pbftSignerSlotNo x)
-    , preWindow <> inWindow
+    , if aSize > wSize then preAnchor <> postAnchor else preWindow <> inWindow
     , ebbs
     )
+  where
+    wSize = size preWindow + size inWindow :: Word64
+    aSize = size preAnchor + size postAnchor
 
 fromList :: PBftCrypto c
          => SecurityParam


### PR DESCRIPTION
I'm unaware of any specification that N >= K; this module's Haddock only says "The window size itself is pretty much arbitrary and will be fixed by a particular blockchain specification (e.g., Byron)."

> Without this patch, deserialization would not round-trip unless the window size
> N were at least as large as the security parameter K. That s true in the
> current implementation, but it is not necessary in general.
