### PR TITLE
test-consensus: refactor PBft ChainState tests

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -288,6 +288,7 @@ test-suite test-consensus
                     Test.Util.Range
                     Test.Util.SOP
                     Test.Util.Shrink
+                    Test.Util.Split
                     Test.Util.TestBlock
                     Test.Util.Tracer
   build-depends:    base,

--- a/ouroboros-consensus/test-consensus/Main.hs
+++ b/ouroboros-consensus/test-consensus/Main.hs
@@ -17,6 +17,8 @@ import qualified Test.Dynamic.Praos (tests)
 import qualified Test.Dynamic.RealPBFT (tests)
 import qualified Test.Dynamic.Util.Tests (tests)
 
+import qualified Test.Util.Split (tests)
+
 main :: IO ()
 main = defaultMain tests
 
@@ -37,4 +39,5 @@ tests =
   , Test.Dynamic.PBFT.tests
   , Test.Dynamic.Praos.tests
   , Test.Dynamic.RealPBFT.tests
+  , Test.Util.Split.tests
   ]

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Protocol/PBFT.hs
@@ -1,17 +1,18 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ViewPatterns        #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 module Test.Consensus.Protocol.PBFT (
     tests
     -- * Used in the roundtrip tests
   , TestChainState(..)
   ) where
 
+import qualified Control.Exception as Exn
 import           Data.Coerce (coerce)
+import           Data.Functor ((<&>))
+import           Data.List (inits, tails)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (listToMaybe)
 import qualified Data.Sequence.Strict as Seq
 import           Data.Word
 
@@ -19,225 +20,318 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import           Cardano.Crypto.DSIGN
+import qualified Cardano.Prelude
 
 import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Protocol.PBFT.ChainState (EbbMap (..), PBftChainState)
+import           Ouroboros.Consensus.Protocol.PBFT.ChainState (EbbMap (..),
+                     PBftChainState)
 import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
 import           Ouroboros.Consensus.Protocol.PBFT.Crypto
-import           Ouroboros.Consensus.Util (dropLast, repeatedly, takeLast)
+import           Ouroboros.Consensus.Util (lastMaybe, repeatedly)
 
+import           Test.Util.Split (spanLeft, splitAtJust)
 
 {-------------------------------------------------------------------------------
   Top-level tests
 -------------------------------------------------------------------------------}
 
 tests :: TestTree
-tests = testGroup "PBftChainState" [
-      testProperty "validGenerator"                   prop_validGenerator
-    , testProperty "appendPreservesInvariant"         prop_appendPreservesInvariant
-    , testProperty "rewindPreservesInvariant"         prop_rewindPreservesInvariant
-    , testProperty "rewindReappendId"                 prop_rewindReappendId
-    , testProperty "appendOldStatePreservesInvariant" prop_appendOldStatePreservesInvariant
-    , testProperty "appendOldStateRestoresPreWindow"  prop_appendOldStateRestoresPreWindow
+tests = testGroup "PBftChainState" $
+    [ testProperty "validGenerator"
+               prop_validGenerator
+    , testProperty "directABb"
+               prop_directABb
+    , testProperty "appendIsMonoidAction"
+               prop_appendIsMonoidAction
+    , testProperty "appendPreservesInvariant"
+               prop_appendPreservesInvariant
+    , testProperty "rewindPreservesInvariant"
+               prop_rewindPreservesInvariant
+    , testProperty "rewindReappendId"
+               prop_rewindReappendId
+    , testProperty "appendOldStatePreservesInvariant"
+               prop_appendOldStatePreservesInvariant
+    , testProperty "appendOldStateRestoresPreWindow"
+               prop_appendOldStateRestoresPreWindow
     ]
 
 {-------------------------------------------------------------------------------
   Test setup
 -------------------------------------------------------------------------------}
 
+-- | A generated test scenario
+--
+-- We don't want to make too many assumptions here, so instead we model what
+-- happens on an actual chain: we build chain states by starting from genesis
+-- and iterating amongst the following actions.
+--
+--   * Append an actual block signed by a key, via 'CS.append'.
+--   * Append an epoch boundary block (EBB), via 'CS.appendEBB'.
+--   * Rewind the chain state to a previous slot, via 'CS.rewind'.
+--
+-- A rewind is expected to fail in two scenarios.
+--
+--   * When the slot is so far back that we would be discarding more than @k@
+--     signed blocks.
+--
+--   * When no block (neither actual nor EBB) was appended in that exact slot.
+--
+-- Rewinding to a slot @s2@ that only contained an EBB should behave similarly
+-- to rewinding to the latest /signed slot/ @s1 < s2@ or to 'Origin' if there
+-- isn't one. More specifically, it should discard the same signed blocks
+-- (those in slots @> s1@) but still retain information about the subsequent
+-- EBBs in slots in the inclusive range from @s1@ to @s2@.
+--
+-- NOTE: PBftChainState assumes @k >= 1@.
+--
+-- * 'testChainInputsA', 'testChainInputsB', and 'testChainInputsC':
+--
+-- We first generate three segments of 'Inputs'.
+--
+-- >                  B
+-- >              ---------
+-- >       A     /
+-- >   ---------<
+-- >             \
+-- >              -------------------
+-- >                       C
+--
+-- The slot of the first input of B will be greater than the slot of the last
+-- input of A. The segment B has @<= k@ signed blocks, since we intend to
+-- successfully rewind past it. The segment C has exactly @n + k@ signed
+-- blocks, since that's the most we'd need to append to ensure an incomplete
+-- window arising pre-#1307 will then be filled. The segment A has an
+-- effectively arbitrary number of signed blocks.
+--
+-- * 'testChainState':
+--
+-- The test properties themselves focus on the state @csABb@ defined by:
+--
+-- > csAB       = appendInputs (inA <> inB) empty
+-- > Just csABb = rewind (slotLatestInput (lastInput inA)) csAB
+--
+-- Segment A could be empty or have several times @k@ signed blocks interleaved
+-- with any number of EBBs. Segment B has @<= k@ signed blocks interleaved with
+-- any number of EBBs. Thus @csABb@, the result of appending both and the
+-- rewinding back to the end of A, should be a representative sample of the
+-- space of chain states.
+--
+-- * 'testChainOldState':
+--
+-- We also test that the state analogous to @csABb@ that would have arisen
+-- before PR #1307 is supported as an input to the current code as expected.
+-- (This exercises the legacy-support burden.)
+--
+-- In particular, appending a sufficient prefix of segment C will always
+-- restore the invariants that were not ensured before PR #1307.
+--
+-- * 'testChainRewind':
+--
+-- Since @csABb@ is fully representative of a realistic state, we will test an
+-- arbitrary rewind from it.
 data TestChainState = TestChainState {
-      testChainStateK         :: SecurityParam
-    , testChainStateN         :: CS.WindowSize
-    , testChainStateNumKeys   :: Int
+      testChainStateK        :: SecurityParam
+    , testChainStateN        :: CS.WindowSize
+    , testChainStateNumKeys  :: Int
 
-      -- | The generated chain state
-    , testChainState          :: PBftChainState PBftMockCrypto
+      -- | The segment A
+    , testChainInputsA       :: Inputs PBftMockCrypto
 
-      -- | The corresponding chain state we would have deserialised before
-      -- #1307: this state does not include the @n@ pre-anchor signatures.
-    , testChainOldState       :: PBftChainState PBftMockCrypto
-
-      -- | The slots that were kept (i.e., not rolled back to create
-      -- 'testChainState')
-    , testChainKeptInputs     :: Inputs PBftMockCrypto
-
-      -- | The slots that were dropped (rolled back to create 'testChainState')
-    , testChainDroppedInputs  :: Inputs PBftMockCrypto
-
-      -- | Possible next inputs that can be added to 'testChainState' and to
-      -- 'testChainOldState'
+      -- | The segment B
       --
-      -- INVARIANT: the length of this list will be @n + k@.
-    , testChainNextInputs     :: Inputs PBftMockCrypto
+      -- INVARIANT this segment has @<= k@ signed blocks
+    , testChainInputsB       :: Inputs PBftMockCrypto
 
-      -- | Possible next rollback from 'testChainState'
-    , testChainRollback       :: WithOrigin SlotNo
+      -- | The segment C
+      --
+      -- INVARIANT this segment has exactly @n + k@ signed blocks
+    , testChainInputsC       :: Inputs PBftMockCrypto
 
-      -- | The inputs that 'testChainRollback' would roll back
-    , testChainRollbackInputs :: Inputs PBftMockCrypto
+      -- | @csABb@
+    , testChainState         :: PBftChainState PBftMockCrypto
+
+      -- | The @csABb@ we would have deserialised before #1307: this state does
+      -- not include the @n@ pre-anchor signatures.
+    , testChainOldState      :: PBftChainState PBftMockCrypto
+
+      -- | The slot of some input within segment A
+    , testChainRewind        :: WithOrigin SlotNo
+
+      -- | The inputs in segment A occupying slots @> 'testChainRewind'@
+    , testChainRewoundInputs :: Inputs PBftMockCrypto
     }
   deriving (Show)
 
--- | Generate chain state
---
--- We don't want to make too many assumptions here, so instead we model what
--- happens on an actual chain: we have a bunch of slots, starting from genesis,
--- signed by various keys, some slots are empty. We then compute the maximum
--- rollback point (@k@ from the tip), and finally drop (d @<= k@) slots,
--- and take the final @n + k - d@ slots.
---
--- Returns both the chain before rollback as well as the chain state.
---
--- NOTE: PBftChainState assumes @k >= 1@.
 instance Arbitrary TestChainState where
-  arbitrary = do
-      k       <- choose (1, 4)
-      n       <- choose (1, 10)
-      numKeys <- choose (1, 4)
+  arbitrary = genTestChainState
 
-      -- Pick number of signed slots
-      --
-      -- We don't try to be too clever here; we need to test the various edge
-      -- cases near genesis more carefully, but also want to test where we are
-      -- well past genesis
-      numSigners <- oneof [
-          choose (0, k)
-        , choose (0, n)
-        , choose (0, k + n)
-        , choose (0, 5 * (k + n))
+genTestChainState :: Gen TestChainState
+genTestChainState = do
+    k       <- choose (1, 4)    -- security parameter
+    n       <- choose (1, 10)   -- PBFT window size
+    numKeys <- choose (1, 4)    -- number of core nodes
+
+    let paramK = SecurityParam k
+        paramN = CS.WindowSize n
+        genKey = genMockKey numKeys
+
+    -- Pick number of signed slots
+    --
+    -- We don't try to be too clever here; we need to test the various edge
+    -- cases near genesis more carefully, but also want to test where we are
+    -- well past genesis
+    numSignersAB <- oneof [
+        choose (0, k + 1)
+      , choose (0, n + 1)
+      , choose (0, k + n + 1)
+      , choose (0, 5 * (k + n))
+      ]
+
+    -- Divide those signers between the A and B segments
+    (numSignersA, numSignersB) <- do
+        -- since we plan to (successfully) rewind B, it cannot contain more
+        -- than k signers
+        numSignersB <- choose (0, min k numSignersAB)
+        pure (numSignersAB - numSignersB, numSignersB)
+
+    -- Generate all the inputs
+
+    (inA, inB, inC) <- do
+        inA <- generateInputs genKey numSignersA (LatestInput Nothing)
+
+        -- Segment B must not begin with the same slot that A ended with,
+        -- because rewinds can't split a slot and our tests focus on the result
+        -- of a rewind that can be undone by re-applying B.
+        let lastInputOfA' = LatestInput $ case unLatestInput $ toLastInput inA of
+                Nothing              -> Nothing
+                Just (InputSigner x) -> Just $ InputSigner x
+                Just (InputEBB x)    -> Just $ InputEBB $ tick x
+              where
+                tick (PBftEBB prev slot) = PBftEBB prev (succ slot)
+
+        inB <- generateInputs genKey numSignersB lastInputOfA'
+        inC <- generateInputs genKey (n + k)     (toLastInput inA)
+
+        pure (inA, inB, inC)
+
+    -- Calculate @csABb@ directly
+
+    -- The @anchor@ is the earliest slot to which we can rewind after appending
+    -- A and B; any earlier would violate the security parameter k.
+    let (mbPre, _) = splitAtSigner (numSignersAB .- k) $ inA <> inB
+        anchor = case mbPre of
+                   Nothing     -> Origin
+                   Just (_, x) -> At $ CS.pbftSignerSlotNo x
+
+    let newABb = fromInputs paramK paramN anchor
+                   (signatureInputs inps)
+                   (ebbInputs inps)
+          where
+            inps = snd $ splitAtSigner (numSignersA .- ((n + k) .- numSignersB)) inA
+
+        -- the state before PR #1307 didn't retain as many signatures and
+        -- didn't track EBBs at all
+        oldABb = fromInputs paramK paramN anchor
+                   (signatureInputs inps)
+                   mempty
+          where
+            inps = snd $ splitAtSigner (numSignersA .- (n .- numSignersB)) inA
+
+    -- Generate a second rewind that drops a suffix of A
+
+    numSignersSuffixA <- oneof [
+        choose (0, k .- numSignersB) -- rollback that will succeed
+      , choose (0, numSignersA) -- rollback that might fail (too far)
+      ]
+
+    let (mbAPrefix, inSuffixA) = splitAtSigner (numSignersA .- numSignersSuffixA) inA
+        -- if the rollback succeeds, its new window ends with this signed slot
+        signedTarget = case mbAPrefix of
+                         Nothing     -> Origin
+                         Just (_, x) -> At $ CS.pbftSignerSlotNo x
+
+    -- Pick a slot to rewind to
+    --
+    -- appending the @rewoundInputs@ will undo the rewind to @rewindSlot@
+    (rewindSlot, rewoundInputs) <- elements $
+        [ Exn.assert (unInputs inSuffixA == int <> tal) $
+          ( maybe signedTarget (At . slotInput) $ lastMaybe int
+          , Inputs tal
+          )
+        | (int, tal) <-
+            inits (unInputs inSuffixA) `zip` tails (unInputs inSuffixA)
+          -- this is ultimately picking a /slot/, so don't split between two
+          -- inputs that have the same slot
+        , case ( slotInput <$> lastMaybe int
+               , slotInput <$> Cardano.Prelude.head tal
+               ) of
+            (Just l, Just r) -> l /= r
+            _                -> True
         ]
 
-      let getFirstInputSlot = SlotNo <$> choose (0, 3)
+    pure TestChainState {
+        testChainStateK        = paramK
+      , testChainStateN        = paramN
+      , testChainStateNumKeys  = numKeys
+      , testChainState         = newABb
+      , testChainOldState      = oldABb
+      , testChainInputsA       = inA
+      , testChainInputsB       = inB
+      , testChainInputsC       = inC
+      , testChainRewind        = rewindSlot
+      , testChainRewoundInputs = rewoundInputs
+      }
 
-      -- Generate all the inputs
-      inputs <- getFirstInputSlot >>= generateInputs (genMockKey numKeys) numSigners . GenerateInputsState Origin
-
-      -- The chain state after appending all inputs to the empty chain state
-      let _X = appendInputs
-                 (SecurityParam k)
-                 (CS.WindowSize n)
-                 inputs
-                 CS.empty
-
-          -- The suffix of inputs we could \"undo\" from _X without violating k
-      let droppableInputs = takeLastSigners k inputs
-      let maxDrop = lengthInputs droppableInputs
-
-          -- The earliest slot to which we could rewind _X, as limited by k (it
-          -- is necessarily a signed slot)
-          anchor = case safeLastSigner (dropLastInputs maxDrop inputs) of
-                     Nothing -> Origin
-                     Just x  -> At (CS.pbftSignerSlotNo x)
-
-      -- Pick a number of inputs to drop; they'll include at most k signers
-      toDrop <- choose (0, maxDrop)
-
-      let (originalKept, originalDropped) = splitAtLastInputs toDrop inputs
-
-      -- Directly compute the state equivalent to rewinding _X enough to drop
-      -- @toDrop@ many inputs
-      let newInputs = dropLastInputs toDrop $ takeLastSigners (n + k) inputs
-          newState  = fromInputs
-                        (SecurityParam k)
-                        (CS.WindowSize n)
-                        (anchor, newInputs)
-
-      -- Directly compute the analogous state that we would have deserialised
-      -- before #1307: this state does not include the @k@ extra signatures
-      -- before the window.
-      let oldInputs = dropLastInputs toDrop $ takeLastSigners n inputs
-          oldState = fromInputs
-                      (SecurityParam k)
-                      (CS.WindowSize n)
-                      (anchor, oldInputs)
-
-      -- Create potential next @n + k@ signers to be added
-      resumeInputGenState <- case reverse $ unInputs $ originalKept of
-          []                   -> GenerateInputsState Origin <$> getFirstInputSlot
-          InputEBB prev slot:_ -> pure $ GenerateInputsState prev slot
-          InputSigner x:_      -> pure $ GenerateInputsState (At s) (succ s)
-            where
-              s = CS.pbftSignerSlotNo x
-      nextInputs <- generateInputs (genMockKey numKeys) (n + k) resumeInputGenState
-
-      -- Create potential rollback
-      toDrop2 <- oneof [
-          choose (0, maxDrop - toDrop) -- rollback that will succeed
-        , choose (0, lengthInputs inputs) -- rollback that might fail (too far)
-        ]
-
-      let rollback = case reverse $ slotInputs $ dropLastInputs toDrop2 originalKept of
-                       []     -> Origin
-                       slot:_ -> At slot
-
-      return TestChainState {
-          testChainStateK         = SecurityParam k
-        , testChainStateN         = CS.WindowSize n
-        , testChainStateNumKeys   = numKeys
-        , testChainState          = newState
-        , testChainOldState       = oldState
-        , testChainKeptInputs     = originalKept
-        , testChainDroppedInputs  = originalDropped
-        , testChainNextInputs     = nextInputs
-        , testChainRollback       = rollback
-        , testChainRollbackInputs =
-            dropWhileNotAfterInputs rollback $  -- If we rolled back to a slot
-                                                -- that had both an EBB and a
-                                                -- signer, then we must ensure
-                                                -- the signer is not in
-                                                -- testChainRollbackInputs
-            takeLastInputs toDrop2 originalKept
-        }
-
-data GenerateInputsState = GenerateInputsState !(WithOrigin SlotNo) !SlotNo
-     -- ^ (slot of latest signature, slot of next input)
-
--- | The output contains the specified number of 'InputSigner's and also some
--- additional 'InputEBB's
-generateInputs ::
-  forall c.
-     Gen (PBftVerKeyHash c)
-  -> Word64
-  -> GenerateInputsState
-  -> Gen (Inputs c)
-     -- ^ inputs, slot of latest signature, slot of next input
-generateInputs genKey = go
-  where
-    plus slot w = slot + SlotNo w
-    advance slot = plus slot <$> choose (0, 3)
-
-    go :: Word64 -> GenerateInputsState -> Gen (Inputs c)
-    go 0 _                               = return (Inputs [])
-    go n (GenerateInputsState prev slot) = do
-      let genEBB = do
-            pure
-              ( n
-              , prev
-                -- an EBB's successor may have the same slot
-              , advance (slot + 1)
-                -- an EBB never has the same slot as its predecessor
-              , InputEBB prev (slot + 1)
-              )
-          genSigner = do
-            key <- genKey
-            pure
-              ( n - 1
-              , At slot
-                -- an non-EBB's successor cannot have the same slot
-              , advance (slot + 1)
-                -- an non-EBB may have the same slot as its predecessor
-              , InputSigner (CS.PBftSigner slot key)
-              )
-
-      (n', prev', genSlot', inp) <- frequency [(1, genEBB), (9, genSigner)]
-      slot' <- genSlot'
-      (\inps -> (inp:) `coerce` inps) <$> go n' (GenerateInputsState prev' slot')
+{-------------------------------------------------------------------------------
+  Generating append inputs
+-------------------------------------------------------------------------------}
 
 genMockKey :: Int -> Gen (VerKeyDSIGN MockDSIGN)
 genMockKey numKeys = VerKeyMockDSIGN <$> choose (1, numKeys)
+
+-- | Generate a possibly empty sequence of 'InputEBB's and 'InputSigner's
+--
+-- POSTCONDITION The output contains exactly the specified number of
+-- 'InputSigner's.
+generateInputs
+  :: forall c.
+     Gen (PBftVerKeyHash c)
+  -> Word64
+  -> LatestInput c
+  -> Gen (Inputs c)
+generateInputs genKey = go []
+  where
+    go :: [Input c] -> Word64 -> LatestInput c -> Gen (Inputs c)
+    go acc n lastInput = do
+        inp <- frequency [(1, genEBB lastInput), (9, genSigner lastInput)]
+
+        let loop n' = go (coerce (inp:) acc) n' (LatestInput $ Just inp)
+        case inp of
+            InputEBB{}                -> loop n
+            InputSigner{} | 0 == n    -> pure $ Inputs $ reverse $ acc
+                          | otherwise -> loop $ n - 1
+
+    -- generate a slot >= the given slot
+    genSlot slot = choose (0, 3) <&> \w -> slot + SlotNo w
+
+    -- an EBB never has the same slot as its predecessor
+    genEBB lastInput = do
+      slot <- genSlot $ case unLatestInput lastInput of
+          Nothing  -> 0
+          Just inp -> succ $ slotInput inp
+      pure $ InputEBB $ PBftEBB (signedSlotLatestInput lastInput) slot
+
+    -- a signed slot can share the slot with an immediately preceding EBB
+    genSigner lastInput = do
+      slot <- genSlot $ case unLatestInput lastInput of
+          Nothing                -> 0
+          Just inp@InputEBB{}    -> slotInput inp
+          Just inp@InputSigner{} -> succ $ slotInput inp
+      key  <- genKey
+      pure $ InputSigner $ CS.PBftSigner slot key
 
 {-------------------------------------------------------------------------------
   Labelling
@@ -249,10 +343,16 @@ data ClassifyWindow =
   | WindowFull
   deriving (Show)
 
-data ClassifyRollback =
-    RollbackImpossible
-  | RollbackLimited
-  | RollbackMaximum
+data ClassifyRewind =
+    RewindImpossible
+  | RewindLimited
+  | RewindMaximum
+  deriving (Show)
+
+data ClassifyLastA =
+    EbbLastA
+  | OriginLastA
+  | SignedLastA
   deriving (Show)
 
 classifyWindow :: TestChainState -> ClassifyWindow
@@ -263,23 +363,31 @@ classifyWindow TestChainState{..}
   where
     CS.PBftChainState{..} = testChainState
 
-classifyRollback :: TestChainState -> ClassifyRollback
-classifyRollback TestChainState{..}
-  | size postAnchor == (0 :: Int)                   = RollbackImpossible
-  | size postAnchor <  maxRollbacks testChainStateK = RollbackLimited
-  | otherwise                                       = RollbackMaximum
+classifyRewind :: TestChainState -> ClassifyRewind
+classifyRewind TestChainState{..}
+  | size postAnchor == (0 :: Int)                   = RewindImpossible
+  | size postAnchor <  maxRollbacks testChainStateK = RewindLimited
+  | otherwise                                       = RewindMaximum
   where
     CS.PBftChainState{..} = testChainState
+
+classifyLastA :: TestChainState -> ClassifyLastA
+classifyLastA TestChainState{..} =
+  case unLatestInput $ toLastInput testChainInputsA of
+    Nothing            -> OriginLastA
+    Just InputEBB{}    -> EbbLastA
+    Just InputSigner{} -> SignedLastA
 
 {-------------------------------------------------------------------------------
   Tests
 -------------------------------------------------------------------------------}
 
--- Check that we are producing valid chain tests
+-- | Check that we are producing valid 'PBftChainState's
 prop_validGenerator :: TestChainState -> Property
 prop_validGenerator st@TestChainState{..} =
-    collect (classifyWindow   st) $
-    collect (classifyRollback st) $
+    collect (classifyWindow st) $
+    collect (classifyRewind st) $
+    collect (classifyLastA  st) $
     Right () === CS.invariant
                    testChainStateK
                    testChainStateN
@@ -294,24 +402,55 @@ prop_validGenerator st@TestChainState{..} =
   where
     CS.PBftChainState{..} = testChainState
 
+-- | Our direct calculation of @csABb@ matches the result of the corresponding
+-- appends and a rewind.
+prop_directABb :: TestChainState -> Property
+prop_directABb TestChainState{..} =
+    let k = testChainStateK
+        n = testChainStateN
+        state0 = CS.empty
+        state1 = appendInputs k n
+                   (testChainInputsA <> testChainInputsB)
+                   state0
+        mbState2 = CS.rewind k n
+                     (slotLatestInput $ toLastInput testChainInputsA)
+                     state1
+    in Just testChainState === mbState2
+
+-- | 'appendInputs' realizes 'Inputs' as a monoid action on chain states.
+prop_appendIsMonoidAction :: TestChainState -> Property
+prop_appendIsMonoidAction TestChainState{..} =
+    let act = appendInputs testChainStateK testChainStateN
+        inA = testChainInputsA
+        inB = testChainInputsB
+
+        fo = flip (.)
+
+        a1 = act $     inA  <>      inB
+        a2 =       act inA `fo` act inB
+    in
+      a1 CS.empty === a2 CS.empty
+      .&&.
+      act mempty CS.empty === CS.empty
+
+-- | Appending preserves the invariant.
 prop_appendPreservesInvariant :: TestChainState -> Property
 prop_appendPreservesInvariant TestChainState{..} =
-    let state' = CS.append
+    let state' = headInput testChainInputsC <&> \inp -> appendInput
                    testChainStateK
                    testChainStateN
-                   (headSigner testChainNextInputs)
+                   inp
                    testChainState
-    in Right () === CS.invariant
-                      testChainStateK
-                      testChainStateN
-                      state'
+    in (Just (Right ()) ===) $
+       CS.invariant testChainStateK testChainStateN <$> state'
 
+-- | Rewinding either fails or preserves the invariant.
 prop_rewindPreservesInvariant :: TestChainState -> Property
 prop_rewindPreservesInvariant TestChainState{..} =
     let rewound = CS.rewind
                     testChainStateK
                     testChainStateN
-                    testChainRollback
+                    testChainRewind
                     testChainState
     in case rewound of
          Nothing     -> label "rollback too far in the past" True
@@ -321,14 +460,14 @@ prop_rewindPreservesInvariant TestChainState{..} =
                           testChainStateN
                           state'
 
--- | If we rewind and then reapply the same blocks, we should get back to
--- our original test
+-- | If we successfully rewind a chain state to before a segment of inputs and
+-- then reapply those inputs, we should get that original chain state back.
 prop_rewindReappendId :: TestChainState -> Property
 prop_rewindReappendId TestChainState{..} =
     let rewound = CS.rewind
                     testChainStateK
                     testChainStateN
-                    testChainRollback
+                    testChainRewind
                     testChainState
     in case rewound of
          Nothing     -> label "rollback too far in the past" True
@@ -337,34 +476,43 @@ prop_rewindReappendId TestChainState{..} =
            testChainState === appendInputs
                                 testChainStateK
                                 testChainStateN
-                                testChainRollbackInputs
+                                testChainRewoundInputs
                                 state'
 
--- This property holds for the old chain state too
+-- | 'prop_appendPreservesInvariant' holds for the old chain state too
 prop_appendOldStatePreservesInvariant :: TestChainState -> Property
 prop_appendOldStatePreservesInvariant TestChainState{..} =
-    let state' = CS.append
+    let state' = headInput testChainInputsC <&> \inp -> appendInput
                    testChainStateK
                    testChainStateN
-                   (headSigner testChainNextInputs)
+                   inp
                    testChainOldState
-    in Right () === CS.invariant
-                      testChainStateK
-                      testChainStateN
-                      state'
+    in (Just (Right ()) ===) $
+       CS.invariant testChainStateK testChainStateN <$> state'
 
--- | After appending the missing signatures, we should have a 'CS.preWindow'
--- of @k@ again.
+-- | The old pre-#1307 state will have a 'CS.preWindow' of @k@ again once we
+-- add a sufficient number signed blocks (and any number of EBBs).
 prop_appendOldStateRestoresPreWindow :: TestChainState -> Property
 prop_appendOldStateRestoresPreWindow TestChainState{..} =
     let missing = fromIntegral
                 $ maxRollbacks       testChainStateK
                 + CS.getWindowSize   testChainStateN
                 - CS.countSignatures testChainOldState
+        inps = pre' <> post'
+          where
+            (mbPre, post) = splitAtSigner missing testChainInputsC
+
+            -- the prefix with @missing@-many signers
+            pre' = case mbPre of
+              Nothing       -> mempty
+              Just (pre, b) -> pre <> Inputs [InputSigner b]
+
+            -- the immediately subsequent EBBs
+            post' = Inputs $ map InputEBB $ fst $ spanEBBs post
         state' = appendInputs
                    testChainStateK
                    testChainStateN
-                   (takeSigners missing testChainNextInputs)
+                   inps
                    testChainOldState
     in Right () === CS.invariant
                       testChainStateK
@@ -377,111 +525,123 @@ prop_appendOldStateRestoresPreWindow TestChainState{..} =
   ChainState "Inputs"
 -------------------------------------------------------------------------------}
 
+data PBftEBB = PBftEBB
+  { pbftEbbPrev   :: !(WithOrigin SlotNo)
+    -- ^ the preceding signed slot
+  , pbftEbbSlotNo :: !SlotNo
+    -- ^ the EBB's own slot
+  }
+  deriving (Eq, Show)
+
 data Input c
-  = InputEBB !(WithOrigin SlotNo) !SlotNo
-    -- ^ the preceding signed slot, the EBB's slot
+  = InputEBB    !PBftEBB
   | InputSigner !(CS.PBftSigner c)
   deriving (Eq, Show)
 
 newtype Inputs c = Inputs {unInputs :: [Input c]}
-  deriving (Eq, Show)
+  deriving (Eq, Monoid, Semigroup, Show)
 
 signatureInputs :: Inputs c -> [CS.PBftSigner c]
-signatureInputs (Inputs inps) = [ signer | InputSigner signer <- inps ]
+signatureInputs (Inputs inps) = [ x | InputSigner x <- inps ]
 
-ebbInputs :: Inputs c -> [(WithOrigin SlotNo, SlotNo)]
-ebbInputs (Inputs inps) = [ (prev, slot) | InputEBB prev slot <- inps ]
+ebbInputs :: Inputs c -> [PBftEBB]
+ebbInputs (Inputs inps) = [ x | InputEBB x <- inps ]
 
 slotInput :: Input c -> SlotNo
 slotInput = \case
-  InputEBB _ slot -> slot
-  InputSigner   x -> CS.pbftSignerSlotNo x
+  InputEBB x    -> pbftEbbSlotNo x
+  InputSigner x -> CS.pbftSignerSlotNo x
 
-slotInputs :: Inputs c -> [SlotNo]
-slotInputs = map slotInput . unInputs
+headInput :: Inputs c -> Maybe (Input c)
+headInput = Cardano.Prelude.head . unInputs
 
-lengthInputs :: Num a => Inputs c -> a
-lengthInputs = fromIntegral . length . unInputs
-
-headSigner :: Inputs c -> CS.PBftSigner c
-headSigner = head . signatureInputs
-
-safeLastSigner :: Inputs c -> Maybe (CS.PBftSigner c)
-safeLastSigner = listToMaybe . reverse . signatureInputs
-
-appendInput ::
-     PBftCrypto c
+appendInput
+  :: PBftCrypto c
   => SecurityParam
   -> CS.WindowSize
   -> Input c
   -> CS.PBftChainState c -> CS.PBftChainState c
 appendInput k n = \case
-  InputEBB _ slot    -> CS.appendEBB k n slot
+  InputEBB ebb       -> CS.appendEBB k n (pbftEbbSlotNo ebb)
   InputSigner signer -> CS.append k n signer
 
-appendInputs ::
-     PBftCrypto c
+appendInputs
+  :: PBftCrypto c
   => SecurityParam
   -> CS.WindowSize
   -> Inputs c
   -> CS.PBftChainState c -> CS.PBftChainState c
 appendInputs k n = repeatedly (appendInput k n) . unInputs
 
--- | May include EBBs before the first signer and after the last signer
-takeSigners :: Word64 -> Inputs c -> Inputs c
-takeSigners = \n0 -> Inputs . go n0 . unInputs
+splitAtSigner :: Word64 -> Inputs c -> (Maybe (Inputs c, CS.PBftSigner c), Inputs c)
+splitAtSigner n (Inputs inps) =
+    coerce $ splitAtJust prjSigner n inps
   where
-    go !n = \case
-      [] -> []
-      inp:inps -> case inp of
-        InputEBB{}    -> inp : go n inps
-        InputSigner{}
-          | n == 0    -> []
-          | otherwise -> inp : go (n - 1) inps
+    prjSigner :: Input c -> Maybe (CS.PBftSigner c)
+    prjSigner = \case
+      InputEBB{}    -> Nothing
+      InputSigner x -> Just x
 
--- | May include EBBs after the last signer *BUT* *NOT* before the first signer
-takeLastSigners :: Word64 -> Inputs c -> Inputs c
-takeLastSigners = \n0 -> Inputs . reverse . go n0 . reverse . unInputs
+spanEBBs :: Inputs c -> ([PBftEBB], Inputs c)
+spanEBBs (Inputs inps0) =
+    (pre, post)
   where
-    go 0 = const []
-    go n = \case
-      []       -> []
-      inp:inps -> inp : go n' inps
-        where
-          n' = case inp of
-            InputEBB{}    -> n
-            InputSigner{} -> n - 1
+    (pre, mbPost) = spanLeft prj inps0
+      where
+        prj = \case
+          InputEBB x        -> Left x
+          inp@InputSigner{} -> Right inp
 
--- | Wrapper around 'CS.fromList' that also sets the 'ebbs' field
-fromInputs ::
-     PBftCrypto c
+    post = case mbPost of
+      Nothing          -> mempty
+      Just (inp, inps) -> Inputs $ inp : inps
+
+-- | Wrapper around 'CS.fromList'
+fromInputs
+  :: PBftCrypto c
   => SecurityParam
   -> CS.WindowSize
-  -> (WithOrigin SlotNo, Inputs c)
+  -> WithOrigin SlotNo
+  -> [CS.PBftSigner c]
+     -- ^ determines the window of signers
+  -> [PBftEBB]
+     -- ^ determines 'CS.ebbs'
   -> CS.PBftChainState c
-fromInputs k n (anchor, inputs) =
-    CS.fromList k n (anchor, Seq.fromList $ signatureInputs inputs, EbbMap m)
+fromInputs k n anchor signers ebbs =
+    CS.fromList k n (anchor, Seq.fromList signers, EbbMap m)
   where
-    m = Map.fromList [ (slot, mSlot) | (mSlot, slot) <- ebbInputs inputs ]
+    m = Map.fromList [ (slot, mSlot) | PBftEBB mSlot slot <- ebbs ]
 
-splitAtLastInputs :: Word64 -> Inputs c -> (Inputs c, Inputs c)
-splitAtLastInputs n (Inputs inps) = (Inputs l, Inputs r)
-  where
-    (l, r) = splitAt (length inps - fromIntegral n) inps
+{-------------------------------------------------------------------------------
+  "The previous input"
+-------------------------------------------------------------------------------}
 
-dropLastInputs :: Word64 -> Inputs c -> Inputs c
-dropLastInputs n = Inputs . dropLast (fromIntegral n) . unInputs
+-- | Summary of an 'Inputs' /that/ /begins/ /at/ 'Origin'
+newtype LatestInput c = LatestInput {unLatestInput :: Maybe (Input c)}
 
-dropWhileNotAfterInputs :: WithOrigin SlotNo -> Inputs c -> Inputs c
-dropWhileNotAfterInputs mSlot =
-  Inputs . dropWhile ((<= mSlot) . At . slotInput) . unInputs
+toLastInput :: Inputs c -> LatestInput c
+toLastInput = LatestInput . lastMaybe . unInputs
 
-takeLastInputs :: Word64 -> Inputs c -> Inputs c
-takeLastInputs n = Inputs . takeLast (fromIntegral n) . unInputs
+-- | The slot of the latest block
+slotLatestInput :: LatestInput c -> WithOrigin SlotNo
+slotLatestInput (LatestInput mbInp) = case mbInp of
+  Nothing  -> Origin
+  Just inp -> At $ slotInput inp
+
+-- | The slot of the latest /signed/ block
+signedSlotLatestInput :: LatestInput c -> WithOrigin SlotNo
+signedSlotLatestInput (LatestInput inp) = case inp of
+  Nothing              -> Origin
+  Just (InputEBB x)    -> pbftEbbPrev x
+  Just (InputSigner x) -> At $ CS.pbftSignerSlotNo x
 
 {-------------------------------------------------------------------------------
   Auxiliary
 -------------------------------------------------------------------------------}
+
+-- | <https://en.wikipedia.org/wiki/Monus>
+(.-) :: (Num a, Ord a) => a -> a -> a
+a .- b = if a > b then a - b else 0
 
 size :: Num b => Seq.StrictSeq a -> b
 size = fromIntegral . Seq.length

--- a/ouroboros-consensus/test-util/Test/Util/Split.hs
+++ b/ouroboros-consensus/test-util/Test/Util/Split.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Util.Split (
+    spanLeft,
+    spanLeft',
+    splitAtJust,
+    -- * Testing
+    prop_spanLeft,
+    prop_splitAtJust,
+    tests,
+  ) where
+
+import           Data.Bifunctor (first)
+import           Data.Either (isLeft, isRight)
+import           Data.Maybe (mapMaybe)
+import           Data.Word (Word64)
+import           GHC.Stack (HasCallStack)
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+{-------------------------------------------------------------------------------
+  spanLeft
+-------------------------------------------------------------------------------}
+
+-- | The returned @b@ is the first in the list.
+--
+-- INVARIANT The output data is a segmentation of the given list.
+spanLeft
+  :: forall x a b.
+     HasCallStack
+  => (x -> Either a b) -> [x] -> ([a], Maybe (b, [x]))
+spanLeft prj xs = (reverse acc, mbBxs)
+  where
+    (acc, mbBxs) = spanLeft' prj xs
+
+-- | As 'spanLeft', but the @[a]@ is reversed.
+spanLeft'
+  :: forall x a b.
+     HasCallStack
+  => (x -> Either a b) -> [x] -> ([a], Maybe (b, [x]))
+spanLeft' prj = go []
+  where
+    go acc = \case
+      []     -> (acc, Nothing)
+      x : xs -> case prj x of
+        Left a  -> go (a : acc) xs
+        Right b -> (acc, Just (b, xs))
+
+{-------------------------------------------------------------------------------
+  splitAtJust
+-------------------------------------------------------------------------------}
+
+-- | INVARIANT: The second is a function of the first.
+data Prj a b = Prj !a !b
+
+-- | The returned @b@ is either the @n@th @b@ or else the last in the given
+-- list.
+--
+-- INVARIANT The output data is a segmentation of the given list.
+splitAtJust
+  :: forall x b.
+     HasCallStack
+  => (x -> Maybe b) -> Word64 -> [x] -> (Maybe ([x], b), [x])
+splitAtJust prj = \n xs ->
+  if 0 == n then (Nothing, xs)
+  else case peel xs of
+    (pre, Just (xb, xs')) -> Just `first` go pre xb (n - 1) xs'
+    (_, Nothing)          -> (Nothing, xs)
+  where
+    peel :: [x] -> ([x], Maybe (Prj x b, [x]))
+    peel = spanLeft' prj'
+      where
+        prj' x = case prj x of
+          Nothing -> Left x
+          Just b  -> Right (Prj x b)
+
+    go pre (Prj x b) n xs
+      | 0 == n    = ((reverse pre, b), xs)
+      | otherwise = case peel xs of
+      (pre', Nothing       ) -> ((reverse pre, b), reverse pre')
+      (pre', Just (xb, xs')) -> go (pre' ++ x : pre) xb (n - 1) xs'
+
+{-------------------------------------------------------------------------------
+  Auxiliaries
+-------------------------------------------------------------------------------}
+
+wlength :: [a] -> Word64
+wlength = fromIntegral . length
+
+prjRight :: Either a b -> Maybe b
+prjRight = \case
+  Left{}  -> Nothing
+  Right x -> Just x
+
+{-------------------------------------------------------------------------------
+  Properties
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "Test.Util.Split" $
+    [ testProperty "prop_spanLeft"    prop_spanLeft
+    , testProperty "prop_splitAtJust" prop_splitAtJust
+    ]
+
+prop_spanLeft :: [Either Int Char] -> Property
+prop_spanLeft xs =
+    rebuild .&&.
+    count .&&.
+    tickIsReversed
+  where
+    result@(pre, mbPost) = spanLeft id xs
+
+    rebuild = counterexample "does not rebuild" $
+              counterexample (show result) $
+              actual === expected
+      where
+        expected = xs
+        actual   = case mbPost of
+          Nothing        -> map Left pre
+          Just (b, post) -> map Left pre ++ Right b : post
+
+    count = counterexample "wrong count" $
+            counterexample (show result) $
+            actual === expected
+      where
+        expected = length $ takeWhile isLeft xs
+        actual   = length pre
+
+    tickIsReversed = counterexample "is not reverse" $
+                     reverse pre === fst (spanLeft' id xs)
+
+prop_splitAtJust :: [Either Int Char] -> Word64 -> Property
+prop_splitAtJust xs rawN =
+    rebuild .&&.
+    count
+  where
+    prj = prjRight
+    lim = wlength $ mapMaybe prj xs
+    n = if 0 == lim then rawN else rawN `mod` (2 * lim)
+
+    result@(mbPre, post) = splitAtJust prj n xs
+
+    rebuild = counterexample "does not rebuild" $
+              counterexample (show result) $
+              actual === expected
+      where
+        expected = xs
+        actual   = case mbPre of
+          Nothing       -> post
+          Just (pre, b) -> pre ++ Right b : post
+
+    count = counterexample "wrong count" $
+            counterexample (show result) $
+            actual === expected
+      where
+        expected = min n (wlength $ filter isRight xs)
+        actual   = case mbPre of
+          Nothing       -> 0
+          Just (pre, _) -> succ (wlength $ filter isRight pre)


### PR DESCRIPTION
This is a follow-up to PR #1317. That added EBBs to the PBFT chain state and to the corresponding property tests. This PR is a more thorough update of those tests: it's clearer code and improves coverage some.

It's a pretty big diff. Several of the properties are essentially the same. The generator is also essentially the same, but it's more principled and better documented by the Haddock on the data type being generated. In particular, it almost exclusively relies on only two splitting functions (from the new `Test.Util.Split` module) instead of various takes, drops, filters, reverses, etc.