### PR TITLE
Fix EBB-related bugs

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
@@ -216,8 +216,8 @@ copyToImmDBRunner cdb@CDB{..} gcSchedule = forever $ do
   Executing garbage collection
 -------------------------------------------------------------------------------}
 
--- | Trigger a garbage collection for blocks older or equal to the given
--- 'SlotNo' on the VolatileDB.
+-- | Trigger a garbage collection for blocks older than the given 'SlotNo' on
+-- the VolatileDB.
 --
 -- Also removes the corresponding cached "previously applied points" from the
 -- LedgerDB.
@@ -231,7 +231,7 @@ garbageCollect CDB{..} slotNo = do
     VolDB.garbageCollect cdbVolDB slotNo
     atomically $ do
       LgrDB.garbageCollectPrevApplied cdbLgrDB slotNo
-      modifyTVar cdbInvalid $ fmap $ Map.filter ((> slotNo) . snd)
+      modifyTVar cdbInvalid $ fmap $ Map.filter ((>= slotNo) . snd)
     traceWith cdbTracer $ TraceGCEvent $ PerformedGC slotNo
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -254,7 +254,7 @@ getBlockWithPoint db BlockPoint { withHash = hash, atSlot = slot } =
 
     -- | If there's an EBB at the tip of the ImmutableDB, return its 'SlotNo'.
     tipIsEBB :: m (Maybe SlotNo)
-    tipIsEBB = withDB db $ \imm -> ImmDB.getTip imm >>= \case
+    tipIsEBB = withDB db $ \imm -> fmap fst <$> ImmDB.getTip imm >>= \case
       Tip (ImmDB.EBB epochNo) -> Just <$> epochInfoFirst epochNo
       Tip (ImmDB.Block _)     -> return Nothing
       TipGen                  -> return Nothing
@@ -299,7 +299,7 @@ getBlockAtTip :: (MonadCatch m, HasCallStack)
               => ImmDB m blk -> m (Maybe blk)
 getBlockAtTip db = do
     immTip <- withDB db $ \imm -> ImmDB.getTip imm
-    case immTip of
+    case fst <$> immTip of
       TipGen                   -> return Nothing
       Tip (ImmDB.EBB epochNo)  -> Just <$> getKnownBlock db (Left epochNo)
       Tip (ImmDB.Block slotNo) -> Just <$> getKnownBlock db (Right slotNo)
@@ -316,7 +316,7 @@ getPointAtTip = fmap mbBlockToPoint . getBlockAtTip
 getSlotNoAtTip :: MonadCatch m => ImmDB m blk -> m (WithOrigin SlotNo)
 getSlotNoAtTip db = do
     immTip <- withDB db $ \imm -> ImmDB.getTip imm
-    case immTip of
+    case fst <$> immTip of
       TipGen                   -> return Origin
       Tip (ImmDB.EBB epochNo)  -> At <$> epochInfoFirst epochNo
       Tip (ImmDB.Block slotNo) -> return (At slotNo)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
@@ -268,8 +268,12 @@ newIterator itEnv@IteratorEnv{..} getItEnv registry from to = do
                 -- The end point == the tip of the ImmutableDB
              -> streamFromImmDB
              | otherwise
-                -- The end point /= the tip of the ImmutableDB
-             -> throwError $ ForkTooOld from
+                -- The end point /= the tip of the ImmutableDB. Either the
+                -- fork is too old, or the end point (or the tip of the
+                -- ImmutableDB) is an EBB. For example, the tip of the
+                -- ImmutableDB is an EBB and the end point is the regular
+                -- block after it.
+             -> findPathInVolDB
           -- The end point is > the tip of the ImmutableDB
           GT -> findPathInVolDB
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -419,11 +419,11 @@ streamAPI immDB = StreamAPI streamAfter
   Garbage collect points of previously applied blocks
 -------------------------------------------------------------------------------}
 
--- | Remove all points with a slot less than or equal to the given slot from
--- the set of previously applied points.
+-- | Remove all points with a slot older than the given slot from the set of
+-- previously applied points.
 garbageCollectPrevApplied :: IOLike m => LgrDB m blk -> SlotNo -> STM m ()
 garbageCollectPrevApplied LgrDB{..} slotNo = modifyTVar varPrevApplied $
-    Set.filter ((<= (At slotNo)) . Block.pointSlot)
+    Set.filter ((< (At slotNo)) . Block.pointSlot)
 
 {-------------------------------------------------------------------------------
   Error handling

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
 
 {-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Readers
@@ -27,7 +26,7 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader,
                      HeaderHash, Point, SlotNo, blockPoint, castPoint,
-                     genesisPoint, pointSlot)
+                     genesisPoint, pointHash, pointSlot)
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block (GetHeader (..), headerPoint)
@@ -445,8 +444,7 @@ forward registry CDB{..} varReader = \pts -> do
 -- PRECONDITION: the intersection point must be within the fragment bounds
 -- of the new chain
 switchFork
-  :: forall m blk.
-     HasHeader (Header blk)
+  :: forall m blk. (HasHeader blk, HasHeader (Header blk))
   => Point blk  -- ^ Intersection point between old and new chain
   -> AnchoredFragment (Header blk)  -- ^ The new chain
   -> ReaderState m blk -> ReaderState m blk
@@ -456,18 +454,47 @@ switchFork ipoint newChain readerState =
         -- If the reader is still reading from the ImmutableDB, switching to a
         -- fork won't affect it at all
         ReaderInImmDB {} -> readerState
-        ReaderInMem   rollState
-          | pointSlot (readerRollStatePoint rollState) > pointSlot ipoint
-            -- If the reader point is more recent than the intersection point,
-            -- we have to roll back the reader to the intersection point.
-          -> ReaderInMem $ RollBackTo ipoint
-          | otherwise
-            -- We can keep rolling forward. Note that this does not mean the
-            -- reader point is still on the current fragment, as headers older
-            -- than @k@ might have been moved from the fragment to the
-            -- ImmutableDB. This will be noticed when the next instruction is
-            -- requested; we'll switch to the 'ReaderInImmDB' state.
-          -> readerState
+        ReaderInMem   rollState ->
+            case pointSlot readerPoint `compare` pointSlot ipoint of
+              -- If the reader point is more recent than the intersection point,
+              -- we have to roll back the reader to the intersection point.
+              GT -> ReaderInMem $ RollBackTo ipoint
+
+              -- The reader point and the intersection point are in the same
+              -- slot. We have to be careful here, because one (or both) of them
+              -- could be an EBB.
+              EQ
+                | pointHash readerPoint == pointHash ipoint
+                  -- The same point, so no rollback needed.
+                -> readerState
+                | Just pointAfterRollStatePoint <- headerPoint <$>
+                    AF.successorBlock (castPoint readerPoint) newChain
+                , pointAfterRollStatePoint == ipoint
+                  -- The point after the reader point is the intersection
+                  -- point. It must be that the reader point is an EBB and
+                  -- that the intersection point is a regular block in the
+                  -- same slot. As the reader point is older than the
+                  -- intersection point, no rollback is needed.
+                -> readerState
+                | otherwise
+                  -- Either the intersection point is the EBB before the
+                  -- reader point (referring to the regular block in the same
+                  -- slot), in which case we need to roll back, as the
+                  -- intersection point is older than the reader point. Or,
+                  -- we're dealing with two blocks (could be two EBBs) in the
+                  -- same slot with a different hash, in which case we'll have
+                  -- to rollback to the intersection point.
+                -> ReaderInMem $ RollBackTo ipoint
+
+              -- The reader point is older than the intersection point, so we
+              -- can keep rolling forward. Note that this does not mean the
+              -- reader point is still on the current fragment, as headers older
+              -- than @k@ might have been moved from the fragment to the
+              -- ImmutableDB. This will be noticed when the next instruction is
+              -- requested; we'll switch to the 'ReaderInImmDB' state.
+              LT -> readerState
+          where
+            readerPoint = readerRollStatePoint rollState
 
 -- | Close all open 'Reader's.
 closeAllReaders :: IOLike m => ChainDbEnv m blk -> m ()

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -101,7 +101,7 @@ data ImmutableDB hash m = ImmutableDB
     --
     -- Throws a 'ClosedDBError' if the database is closed.
   , getTip
-      :: HasCallStack => m ImmTip
+      :: HasCallStack => m (ImmTipWithHash hash)
 
     -- | Get the block as a 'ByteString' and its header hash stored at the given
     -- 'SlotNo'.

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -386,10 +386,10 @@ deleteAfterImpl dbEnv@ImmutableDBEnv { _dbTracer } newTip =
 getTipImpl
   :: forall m hash. (HasCallStack, IOLike m)
   => ImmutableDBEnv m hash
-  -> m ImmTip
+  -> m (ImmTipWithHash hash)
 getTipImpl dbEnv = do
     SomePair _hasFS OpenState { _currentTip } <- getOpenState dbEnv
-    return (fst <$> _currentTip)
+    return _currentTip
 
 -- | Whether to read the whole block, its header, or the hash
 data GetWhat hash res where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -687,7 +687,7 @@ garbageCollectable secParam m@Model{..} b =
     onCurrentChain = Chain.pointOnChain (Block.blockPoint b) (currentChain m)
     -- Note: we don't use the block number but the slot number, as the
     -- VolatileDB's garbage collection is in terms of slot numbers.
-    olderThanImmutableSlotNo = At (Block.blockSlot b) <= immutableSlotNo secParam m
+    olderThanImmutableSlotNo = At (Block.blockSlot b) < immutableSlotNo secParam m
 
 -- Return 'True' when the model contains the block corresponding to the point
 -- and the block itself is eligible for garbage collection, i.e. the real

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1033,7 +1033,7 @@ genBlk :: BlockGen Blk m
 genBlk Model{..} = frequency
     [ (if empty then 0 else 1, genAlreadyInChain)
     , (5,                      genAppendToCurrentChain)
-    , (if empty then 0 else 3, genFitsOnSomewhere)
+    , (5,                      genFitsOnSomewhere)
     , (3,                      genGap)
     ]
   where
@@ -1097,9 +1097,10 @@ genBlk Model{..} = frequency
     -- Helper that generates a block that fits onto the given block.
     genFitsOn :: TestBlock -> Gen TestBlock
     genFitsOn b = frequency
-        -- If we generate too many EBBs, the density of the chain will be low.
         [ (4, do
-                slotNo <- chooseSlot (blockSlot b + 1) (blockSlot b + 3)
+                slotNo <- if fromIsEBB (testBlockIsEBB b)
+                  then chooseSlot (blockSlot b)     (blockSlot b + 2)
+                  else chooseSlot (blockSlot b + 1) (blockSlot b + 3)
                 body   <- genBody
                 return $ mkNextBlock b slotNo body)
         -- An EBB is never followed directly by another EBB, otherwise they

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -171,7 +171,7 @@ data Success it
   | Iter         (Either (WrongBoundError Hash) it)
   | IterResult   (IteratorResult Hash ByteString)
   | IterHasNext  Bool
-  | Tip          ImmTip
+  | Tip          (ImmTipWithHash Hash)
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
 -- | How to run a 'Corruption' command.
@@ -715,7 +715,7 @@ semantics errorsVar hasFS db internal (At cmdErr) =
         run (semanticsCorruption hasFS) its db internal cmd
 
       CmdErr (Just errors) cmd its -> do
-        tipBefore <- getTip db
+        tipBefore <- fmap fst <$> getTip db
         res       <- withErrors errorsVar errors $ try $
           run (semanticsCorruption hasFS) its db internal cmd
         case res of


### PR DESCRIPTION
Closes #1339.

After fixing the bug, I investigated why the ChainDB quickcheck-state-machine tests hadn't triggered it before. I discovered that no regular blocks in the same slot as an EBB were being generated. After fixing that, I discovered a few more EBB-related bugs.

To fix one of them, I pulled in parts of #1323 (which I will rebase after this branch is merged): a92f3f4 and 19fd306.