### PR TITLE
Work around a strange space leak in PBFT.ChainState

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
@@ -231,7 +231,7 @@ garbageCollect CDB{..} slotNo = do
     VolDB.garbageCollect cdbVolDB slotNo
     atomically $ do
       LgrDB.garbageCollectPrevApplied cdbLgrDB slotNo
-      modifyTVar cdbInvalid $ fmap $ Map.filter ((>= slotNo) . snd)
+      modifyTVar cdbInvalid $ fmap $ Map.filter ((>= slotNo) . invalidBlockSlotNo)
     traceWith cdbTracer $ TraceGCEvent $ PerformedGC slotNo
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
@@ -190,7 +190,7 @@ addBlock cdb@CDB{..} b = do
         trace $ IgnoreBlockOlderThanK (blockPoint b)
       | isMember (blockHash b) ->
         trace $ IgnoreBlockAlreadyInVolDB (blockPoint b)
-      | Just (reason, _) <- Map.lookup (blockHash b) invalid ->
+      | Just (InvalidBlockInfo reason _) <- Map.lookup (blockHash b) invalid ->
         trace $ IgnoreInvalidBlock (blockPoint b) reason
 
       --- ### Store but schedule chain selection
@@ -302,7 +302,7 @@ chainSelectionForBlock cdb@CDB{..} hdr = do
         trace $ IgnoreBlockOlderThanK p
 
       -- We might have validated the block in the meantime
-      | Just (reason, _) <- Map.lookup (headerHash hdr) invalid ->
+      | Just (InvalidBlockInfo reason _) <- Map.lookup (headerHash hdr) invalid ->
         trace $ IgnoreInvalidBlock p reason
 
       -- The block @b@ fits onto the end of our current chain
@@ -778,9 +778,11 @@ validateCandidate lgrDB tracer cfg varInvalid
       BlockPoint slot hash -> case AF.splitAfterPoint suffix pt of
         Nothing           -> error "point not on fragment"
         Just (_, afterPt) ->
-          Map.insert hash (ValidationError e, slot) $ Map.fromList
-            [ (blockHash hdr, (InChainAfterInvalidBlock pt e, blockSlot hdr))
+          Map.insert hash (InvalidBlockInfo (ValidationError e) slot) $
+          Map.fromList
+            [ (blockHash hdr, InvalidBlockInfo reason (blockSlot hdr))
             | hdr <- AF.toOldestFirst afterPt
+            , let reason = InChainAfterInvalidBlock pt e
             ]
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
@@ -160,7 +160,7 @@ getIsInvalidBlock
   => ChainDbEnv m blk
   -> STM m (WithFingerprint (HeaderHash blk -> Maybe (InvalidBlockReason blk)))
 getIsInvalidBlock CDB{..} =
-  fmap (fmap (fmap fst) . flip Map.lookup) <$> readTVar cdbInvalid
+  fmap (fmap (fmap invalidBlockReason) . flip Map.lookup) <$> readTVar cdbInvalid
 
 getMaxSlotNo
   :: forall m blk. (IOLike m, HasHeader (Header blk))

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -26,6 +26,7 @@ module Ouroboros.Storage.ChainDB.Impl.Types (
   , readerRollStatePoint
     -- * Invalid blocks
   , InvalidBlocks
+  , InvalidBlockInfo (..)
     -- * Trace types
   , TraceEvent (..)
   , TraceAddBlockEvent (..)
@@ -294,12 +295,16 @@ readerRollStatePoint (RollForwardFrom pt) = pt
 
 -- | Hashes corresponding to invalid blocks. This is used to ignore these
 -- blocks during chain selection.
---
--- In addition to the reason why a block is invalid, the slot number of
--- the block is stored, so that whenever a garbage collection is performed
--- on the VolatileDB for some slot @s@, the hashes older or equal to @s@
--- can be removed from this map.
-type InvalidBlocks blk = Map (HeaderHash blk) (InvalidBlockReason blk, SlotNo)
+type InvalidBlocks blk = Map (HeaderHash blk) (InvalidBlockInfo blk)
+
+-- | In addition to the reason why a block is invalid, the slot number of the
+-- block is stored, so that whenever a garbage collection is performed on the
+-- VolatileDB for some slot @s@, the hashes older or equal to @s@ can be
+-- removed from this map.
+data InvalidBlockInfo blk = InvalidBlockInfo
+  { invalidBlockReason :: !(InvalidBlockReason blk)
+  , invalidBlockSlotNo :: !SlotNo
+  } deriving (Eq, Show, Generic, NoUnexpectedThunks)
 
 {-------------------------------------------------------------------------------
   Trace types

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Iterator.hs
@@ -132,8 +132,8 @@ streamImpl
                (Iterator hash m ByteString))
 streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
     withOpenState dbEnv $ \hasFS OpenState{..} -> runExceptT $ do
-      lift $ validateIteratorRange _dbErr _dbEpochInfo (fst <$> _currentTip)
-        mbStart mbEnd
+      lift $ validateIteratorRange _dbErr _dbEpochInfo
+        (forgetHash <$> _currentTip) mbStart mbEnd
 
       -- TODO cache index files: we might open the same primary and secondary
       -- indices to validate the end bound as for the start bound
@@ -144,8 +144,8 @@ streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
           -- would have thrown a 'ReadFutureSlotError'.
           assert (isNothing mbStart && isNothing mbEnd) $ lift mkEmptyIterator
         Tip tip -> do
-          (endEpochSlot, endHash)  <- fillInEndBound   hasFS tip mbEnd
-          (secondaryOffset, start) <- fillInStartBound hasFS     mbStart
+          WithHash endHash endEpochSlot <- fillInEndBound   hasFS tip mbEnd
+          (secondaryOffset, start)      <- fillInStartBound hasFS     mbStart
 
           lift $ do
             -- 'validateIteratorRange' will catch nearly all invalid ranges,
@@ -155,7 +155,7 @@ streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
             -- regular block, as both have the same slot number, we need to
             -- look at the hashes. 'validateIteratorRange' doesn't have enough
             -- information to do that.
-            let (startEpochSlot, _startHash) = start
+            let WithHash _startHash startEpochSlot = start
             when (startEpochSlot > endEpochSlot) $ do
               startSlot <- epochInfoAbsolute _dbEpochInfo startEpochSlot
               endSlot   <- epochInfoAbsolute _dbEpochInfo endEpochSlot
@@ -193,9 +193,9 @@ streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
     fillInEndBound
       :: HasCallStack
       => HasFS m h
-      -> (BlockOrEBB, hash)    -- ^ Current tip
-      -> Maybe (SlotNo, hash)  -- ^ End bound
-      -> ExceptT (WrongBoundError hash) m (EpochSlot, hash)
+      -> WithHash hash BlockOrEBB  -- ^ Current tip
+      -> Maybe (SlotNo, hash)      -- ^ End bound
+      -> ExceptT (WrongBoundError hash) m (WithHash hash EpochSlot)
     fillInEndBound hasFS currentTip = \case
       -- End bound given, check whether it corresponds to a regular block or
       -- an EBB. Convert the 'SlotNo' to an 'EpochSlot' accordingly.
@@ -203,12 +203,9 @@ streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
 
       -- No end bound given, use the current tip, but convert the 'BlockOrEBB'
       -- to an 'EpochSlot'.
-      Nothing  -> lift $ flip overFst currentTip $ \case
+      Nothing  -> lift $ forM currentTip $ \case
         EBB epoch      -> return (EpochSlot epoch 0)
         Block lastSlot -> epochInfoBlockRelative _dbEpochInfo lastSlot
-
-    overFst :: forall a b c f. Functor f => (a -> f c) -> (a, b) -> f (c, b)
-    overFst f (a, b) = (, b) <$> f a
 
     -- | Fill in the start bound: if 'Nothing', use the first block in the
     -- database. Otherwise, check whether the bound exists in the database and
@@ -221,7 +218,9 @@ streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
       :: HasCallStack
       => HasFS m h
       -> Maybe (SlotNo, hash)  -- ^ Start bound
-      -> ExceptT (WrongBoundError hash) m (SecondaryOffset, (EpochSlot, hash))
+      -> ExceptT (WrongBoundError hash)
+                  m
+                  (SecondaryOffset, WithHash hash EpochSlot)
     fillInStartBound hasFS = \case
       -- Start bound given, check whether it corresponds to a regular block or
       -- an EBB. Convert the 'SlotNo' to an 'EpochSlot' accordingly.
@@ -241,7 +240,7 @@ streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
                   (Secondary.Entry { headerHash }, _) <-
                     Secondary.readEntry hasFS _dbErr _dbHashInfo epoch isEBB
                       secondaryOffset
-                  return (secondaryOffset, (EpochSlot epoch relSlot, headerHash))
+                  return (secondaryOffset, WithHash headerHash epochSlot)
                 where
                   -- The first entry in the secondary index file (i.e. the
                   -- first filled slot in the primary index) always starts at
@@ -249,6 +248,7 @@ streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
                   secondaryOffset = 0
                   isEBB | relSlot == 0 = IsEBB
                         | otherwise    = IsNotEBB
+                  epochSlot = EpochSlot epoch relSlot
 
     -- | Check whether the given bound exists in the ImmutableDB, otherwise a
     -- 'WrongBoundError' is returned. The 'SecondaryOffset' and 'EpochSlot'
@@ -265,7 +265,9 @@ streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
       :: HasCallStack
       => HasFS m h
       -> (SlotNo, hash)  -- ^ Bound
-      -> ExceptT (WrongBoundError hash) m (SecondaryOffset, (EpochSlot, hash))
+      -> ExceptT (WrongBoundError hash)
+                 m
+                 (SecondaryOffset, WithHash hash EpochSlot)
     checkBound hasFS (slot, hash) = do
         epochSlot@(EpochSlot epoch relSlot) <- lift $
           epochInfoBlockRelative _dbEpochInfo slot
@@ -310,7 +312,7 @@ streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
 
         -- Use the secondary index entry to determine whether the slot + hash
         -- correspond to an EBB or a regular block.
-        return $ (secondaryOffset,) $ (, hash) $
+        return $ (secondaryOffset,) $ WithHash hash $
           case Secondary.blockOrEBB entry of
             Block _ -> epochSlot
             EBB   _ -> EpochSlot epoch 0

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
@@ -9,6 +9,7 @@ module Ouroboros.Storage.ImmutableDB.Types
   ( SlotNo (..)
   , ImmTip
   , ImmTipWithHash
+  , WithHash (..)
   , BlockOrEBB (..)
   , HashInfo (..)
   , BinaryInfo (..)
@@ -35,10 +36,10 @@ module Ouroboros.Storage.ImmutableDB.Types
 
 import           Control.Exception (Exception (..))
 import           Data.Binary (Get, Put)
+import           Data.List.NonEmpty (NonEmpty)
 import           Data.Word
 import           GHC.Generics (Generic)
 import           GHC.Stack (CallStack, prettyCallStack)
-import           Data.List.NonEmpty (NonEmpty)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..),
                      UseIsNormalFormNamed (..))
@@ -59,7 +60,12 @@ data BlockOrEBB
 type ImmTip = Tip BlockOrEBB
 
 -- TODO let this replace 'ImmTip' and integrate @hash@ in 'BlockOrEBB'?
-type ImmTipWithHash hash = Tip (BlockOrEBB, hash)
+type ImmTipWithHash hash = Tip (WithHash hash BlockOrEBB)
+
+data WithHash hash a = WithHash
+  { theHash    :: !hash
+  , forgetHash :: !a
+  } deriving (Eq, Show, Generic, NoUnexpectedThunks, Functor, Foldable, Traversable)
 
 -- | How to get/put the header hash of a block and how many bytes it occupies
 -- on-disk.

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -715,7 +715,7 @@ semantics errorsVar hasFS db internal (At cmdErr) =
         run (semanticsCorruption hasFS) its db internal cmd
 
       CmdErr (Just errors) cmd its -> do
-        tipBefore <- fmap fst <$> getTip db
+        tipBefore <- fmap forgetHash <$> getTip db
         res       <- withErrors errorsVar errors $ try $
           run (semanticsCorruption hasFS) its db internal cmd
         case res of
@@ -1174,6 +1174,7 @@ instance ToExpr TestHeader
 instance ToExpr TestBody
 instance ToExpr TestBlock
 instance ToExpr ImmDB.BlockOrEBB
+instance (ToExpr a, ToExpr hash) => ToExpr (ImmDB.WithHash hash a)
 instance ToExpr r => ToExpr (C.Tip r)
 instance ToExpr b => ToExpr (BinaryInfo b)
 instance ToExpr (DBModel Hash)


### PR DESCRIPTION
Includes a workaround for #1356.

Additionally, squash all thunks introduced in the last month(s), so that the tests pass again when the `checktvarinvariant` flag is enabled for the `io-sim-classes` package. This boils down to replacing tuples with records with strict fields and forcing the elements of non-empty list to WHNF.