### PR TITLE
Add a cardano-base dependency on the slotting subdir

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -71,6 +71,12 @@ source-repository-package
 
 source-repository-package
   type: git
+  location: https://github.com/input-output-hk/cardano-base
+  tag: 80deee31f8d9422b8e090e55b17e1a714153180b
+  subdir: slotting
+
+source-repository-package
+  type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
   tag: b404d58efb9e372305073d4ee5a660a89bb435f4
   subdir: byron/semantics/executable-spec


### PR DESCRIPTION
Without it, the cabal build is broken.