### PR TITLE
Trace a message when the blockchainTime starts in the future

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -112,6 +112,7 @@ run tracers chainDbTracer diffusionTracers diffusionArguments networkMagic dbPat
       lockDbMarkerFile registry dbPath
       btime <- realBlockchainTime
         registry
+        (blockchainTimeTracer tracers)
         slotLength
         (nodeStartTime (Proxy @blk) cfg)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -21,6 +21,7 @@ import           Ouroboros.Network.TxSubmission.Outbound
                      (TraceTxSubmissionOutbound)
 
 import           Ouroboros.Consensus.Block (Header)
+import           Ouroboros.Consensus.BlockchainTime (TraceBlockchainTimeEvent)
 import           Ouroboros.Consensus.BlockFetchServer
                      (TraceBlockFetchServerEvent)
 import           Ouroboros.Consensus.ChainSyncClient (InvalidBlockReason,
@@ -49,6 +50,7 @@ data Tracers' peer blk f = Tracers
   , localTxSubmissionServerTracer :: f (TraceLocalTxSubmissionServerEvent blk)
   , mempoolTracer                 :: f (TraceEventMempool blk)
   , forgeTracer                   :: f (TraceForgeEvent blk (GenTx blk))
+  , blockchainTimeTracer          :: f  TraceBlockchainTimeEvent
   }
 
 -- | A record of 'Tracer's for the node.
@@ -68,6 +70,7 @@ nullTracers = Tracers
   , localTxSubmissionServerTracer = nullTracer
   , mempoolTracer                 = nullTracer
   , forgeTracer                   = nullTracer
+  , blockchainTimeTracer          = nullTracer
   }
 
 showTracers :: ( Show blk
@@ -91,6 +94,7 @@ showTracers tr = Tracers
   , localTxSubmissionServerTracer = showTracing tr
   , mempoolTracer                 = showTracing tr
   , forgeTracer                   = showTracing tr
+  , blockchainTimeTracer          = showTracing tr
   }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/tools/db-convert/Main.hs
+++ b/ouroboros-consensus/tools/db-convert/Main.hs
@@ -165,6 +165,7 @@ validateChainDb dbDir genesisConfig onlyImmDB verbose =
     withRegistry $ \registry -> do
       btime <- realBlockchainTime
         registry
+        nullTracer
         slotLength
         (nodeStartTime (Proxy @ByronBlock) cfg)
       let chainDbArgs = mkChainDbArgs registry btime


### PR DESCRIPTION
When the start time of the blockchain time is in the future, we block until
that time has come. We now trace a message when this happens so that the user
knows what is going on.

A new 'blockchainTimeTracer' was added to accomplish this.