### PR TITLE
Optimise chain serving

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -49,13 +49,13 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 7099318744ddd10b76e50eae73f005efd2c7195c
+  tag: 00487726c4bc21b4744e59d913334ebfeac7d68e
   subdir: .
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 7099318744ddd10b76e50eae73f005efd2c7195c
+  tag: 00487726c4bc21b4744e59d913334ebfeac7d68e
   subdir: test
 
 source-repository-package

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "7099318744ddd10b76e50eae73f005efd2c7195c";
-      sha256 = "04k3jm27bcbmskrxidyhg6ryb587prl8gayxik8mhv9zi81d36qw";
+      rev = "00487726c4bc21b4744e59d913334ebfeac7d68e";
+      sha256 = "0v4fcq5kdd2r5dgwys8kv46ff33qp756n26ycxrca10wq14zkwm5";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -74,7 +74,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "7099318744ddd10b76e50eae73f005efd2c7195c";
-      sha256 = "04k3jm27bcbmskrxidyhg6ryb587prl8gayxik8mhv9zi81d36qw";
+      rev = "00487726c4bc21b4744e59d913334ebfeac7d68e";
+      sha256 = "0v4fcq5kdd2r5dgwys8kv46ff33qp756n26ycxrca10wq14zkwm5";
       });
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -49,6 +49,7 @@
           (hsPkgs.mmorph)
           (hsPkgs.mtl)
           (hsPkgs.network)
+          (hsPkgs.psqueues)
           (hsPkgs.serialise)
           (hsPkgs.stm)
           (hsPkgs.streaming)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -144,6 +144,7 @@ library
                        Ouroboros.Storage.ImmutableDB.API
                        Ouroboros.Storage.ImmutableDB.Impl
                        Ouroboros.Storage.ImmutableDB.Impl.Index
+                       Ouroboros.Storage.ImmutableDB.Impl.Index.Cache
                        Ouroboros.Storage.ImmutableDB.Impl.Index.Primary
                        Ouroboros.Storage.ImmutableDB.Impl.Index.Secondary
                        Ouroboros.Storage.ImmutableDB.Impl.Iterator
@@ -236,6 +237,7 @@ library
                        mmorph            >=1.1   && <1.2,
                        mtl               >=2.2   && <2.3,
                        network,
+                       psqueues          >=0.2.3 && <0.3,
                        serialise         >=0.2   && <0.3,
                        stm,
                        streaming,

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -143,6 +143,7 @@ library
                        Ouroboros.Storage.ImmutableDB
                        Ouroboros.Storage.ImmutableDB.API
                        Ouroboros.Storage.ImmutableDB.Impl
+                       Ouroboros.Storage.ImmutableDB.Impl.Index
                        Ouroboros.Storage.ImmutableDB.Impl.Index.Primary
                        Ouroboros.Storage.ImmutableDB.Impl.Index.Secondary
                        Ouroboros.Storage.ImmutableDB.Impl.Iterator

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -38,6 +38,8 @@ module Ouroboros.Consensus.Util.IOLike (
   , uncheckedNewEmptyMVar
   , uncheckedNewMVar
   , updateMVar
+  , updateMVar_
+  , modifyMVar
     -- *** MonadFork
   , ThreadId
   , myThreadId

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
@@ -150,7 +150,7 @@ swapMVar StrictMVar { tmvar, tvar, invariant } !a = do
 isEmptyMVar :: MonadSTM m => StrictMVar m a -> m Bool
 isEmptyMVar StrictMVar { tmvar } = atomically $ Lazy.isEmptyTMVar tmvar
 
-updateMVar :: MonadSTM m => StrictMVar m a -> (a -> (a, b)) -> m b
+updateMVar :: (MonadSTM m, HasCallStack) => StrictMVar m a -> (a -> (a, b)) -> m b
 updateMVar StrictMVar { tmvar, tvar, invariant } f = do
     (a', b) <- atomically $ do
         a <- Lazy.takeTMVar tmvar

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE TupleSections     #-}
 
 module Ouroboros.Consensus.Util.MonadSTM.StrictMVar (
     StrictMVar(..) -- constructors exported for benefit of tests
@@ -18,6 +19,8 @@ module Ouroboros.Consensus.Util.MonadSTM.StrictMVar (
   , swapMVar
   , isEmptyMVar
   , updateMVar
+  , updateMVar_
+  , modifyMVar
   ) where
 
 import           Control.Concurrent.STM (readTVarIO)
@@ -25,6 +28,8 @@ import           Control.Monad (when)
 import           Control.Monad.Class.MonadSTM (MonadSTM (..))
 import qualified Control.Monad.Class.MonadSTM as Lazy
 import           Control.Monad.Class.MonadSTM.Strict (checkInvariant)
+import           Control.Monad.Class.MonadThrow (ExitCase (..), MonadCatch,
+                     generalBracket)
 import           GHC.Stack
 
 import           Cardano.Prelude (NoUnexpectedThunks (..))
@@ -159,6 +164,20 @@ updateMVar StrictMVar { tmvar, tvar, invariant } f = do
         Lazy.writeTVar tvar a'
         return (a', b)
     checkInvariant (invariant a') $ return b
+
+updateMVar_ :: (MonadSTM m, HasCallStack) => StrictMVar m a -> (a -> a) -> m ()
+updateMVar_ var f = updateMVar var ((, ()) . f)
+
+modifyMVar :: (MonadSTM m, MonadCatch m, HasCallStack)
+           => StrictMVar m a -> (a -> m (a, b)) -> m b
+modifyMVar var action =
+    snd . fst <$> generalBracket (takeMVar var) putBack action
+  where
+    putBack a ec = case ec of
+      ExitCaseSuccess (a', _) -> putMVar var a'
+      ExitCaseException _ex   -> putMVar var a
+      ExitCaseAbort           -> putMVar var a
+
 
 {-------------------------------------------------------------------------------
   NoUnexpectedThunks

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -307,7 +307,10 @@ data Deserialisable m blk b = Deserialisable
    { serialised         :: !(Serialised b)
    , deserialisableSlot :: !SlotNo
    , deserialisableHash :: !(HeaderHash blk)
-   , deserialise        :: !(m b)
+   , deserialise        :: m b
+     -- ^ No need for a bang as it is a monadic computation. Moreover, with a
+     -- bang, we might accidentally force deserialisation, as that is
+     -- typically a pure computation that only needs @m@ to throw an error.
    }
 
 deserialisablePoint :: Deserialisable m blk b -> Point blk

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -41,6 +41,8 @@ import           Ouroboros.Consensus.BlockchainTime (getCurrentSlot)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry,
+                     withRegistry)
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..),
                      WithFingerprint (..))
 
@@ -71,16 +73,17 @@ withDB
   => ChainDbArgs m blk
   -> (ChainDB m blk -> m a)
   -> m a
-withDB args k =
-    bracket (fst <$> openDBInternal args True) closeDB k
+withDB args k = withRegistry $ \registry ->
+    bracket (fst <$> openDBInternal registry args True) closeDB k
 
 openDBInternal
   :: forall m blk. (IOLike m, ProtocolLedgerView blk)
-  => ChainDbArgs m blk
+  => ResourceRegistry m  -- ^ Resource registry for the ImmutableDB
+  -> ChainDbArgs m blk
   -> Bool -- ^ 'True' = Launch background tasks
   -> m (ChainDB m blk, Internal m blk)
-openDBInternal args launchBgTasks = do
-    immDB <- ImmDB.openDB argsImmDb
+openDBInternal immRegistry args launchBgTasks = do
+    immDB <- ImmDB.openDB immRegistry argsImmDb
     -- In order to figure out the 'BlockNo' and 'Point' at the tip of the
     -- ImmutableDB, we need to read the header at the tip of the ImmutableDB.
     immDbTipHeader <- ImmDB.getBlockOrHeaderAtTip immDB Header

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -97,6 +97,7 @@ data ChainDbArgs m blk = forall h1 h2 h3. ChainDbArgs {
       -- ^ The header envelope will only be added after extracting the binary
       -- header from the binary block. Note that we never have to remove an
       -- envelope.
+    , cdbImmDbCacheConfig :: ImmDB.CacheConfig
 
       -- Misc
     , cdbTracer           :: Tracer m (TraceEvent blk)
@@ -171,6 +172,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , immHasFS            = cdbHasFSImmDb
         , immTracer           = contramap TraceImmDBEvent cdbTracer
         , immAddHdrEnv        = cdbAddHdrEnv
+        , immCacheConfig      = cdbImmDbCacheConfig
         }
     , VolDB.VolDbArgs {
           volHasFS            = cdbHasFSVolDb
@@ -256,6 +258,7 @@ toChainDbArgs ImmDB.ImmDbArgs{..}
     , cdbGenesis          = lgrGenesis
     , cdbBlockchainTime   = cdbsBlockchainTime
     , cdbAddHdrEnv        = immAddHdrEnv
+    , cdbImmDbCacheConfig = immCacheConfig
       -- Misc
     , cdbTracer           = cdbsTracer
     , cdbTraceLedger      = lgrTraceLedger

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -30,7 +30,7 @@ module Ouroboros.Storage.ChainDB.Impl.ImmDB (
     -- * Appending a block
   , appendBlock
     -- * Streaming
-  , streamFrom
+  , stream
   , streamAfter
   , deserialiseIterator
   , deserialisableIterator
@@ -68,6 +68,7 @@ import           Control.Tracer (Tracer, nullTracer)
 import           Data.Bifunctor (second)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Functor ((<&>))
+import           Data.Functor (($>))
 import           GHC.Stack (HasCallStack)
 import           System.FilePath ((</>))
 
@@ -75,9 +76,10 @@ import           Cardano.Prelude (allNoUnexpectedThunks)
 
 import           Control.Monad.Class.MonadThrow
 
-import           Ouroboros.Network.Block (pattern BlockPoint,
+import           Ouroboros.Network.Block (pattern BlockPoint, ChainHash (..),
                      pattern GenesisPoint, HasHeader (..), HeaderHash, Point,
-                     Serialised (..), SlotNo, atSlot, pointSlot, withHash)
+                     Serialised (..), SlotNo, atSlot, pointHash, pointSlot,
+                     withHash)
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block (Header, IsEBB (..))
@@ -88,7 +90,8 @@ import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry,
 
 import           Ouroboros.Storage.ChainDB.API (BlockOrHeader (..),
                      ChainDbError (..), ChainDbFailure (..),
-                     Deserialisable (..), StreamFrom (..), UnknownRange (..))
+                     Deserialisable (..), StreamFrom (..), StreamTo (..),
+                     UnknownRange (..))
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.EpochInfo (EpochInfo (..))
 import           Ouroboros.Storage.FS.API (HasFS, createDirectoryIfMissing)
@@ -482,7 +485,7 @@ registeredStream :: forall m blk b. IOLike m
                               (ImmDB.Iterator (HeaderHash blk) m Lazy.ByteString))
 registeredStream db@ImmDB { addHdrEnv } registry blockOrHeader start end = do
     errOrKeyAndIt <- allocateEither registry
-      (\_key -> withDB db $ \imm -> stream imm)
+      (\_key -> withDB db $ \imm -> go imm)
       (iteratorClose db)
     return $ case errOrKeyAndIt of
       Left e          -> Left (toUnknownRange e)
@@ -494,7 +497,7 @@ registeredStream db@ImmDB { addHdrEnv } registry blockOrHeader start end = do
       -- in the chain DB itself (throw ClosedDBError exception).
       Right (key, it) -> Right it { ImmDB.iteratorClose = unsafeRelease key }
   where
-    stream imm = case blockOrHeader of
+    go imm = case blockOrHeader of
       Block  -> ImmDB.streamBlocks  imm start end
       Header -> ImmDB.streamHeaders imm start end <&>
         fmap (traverseIterator db (traverseIteratorResult db addHdrEnvelope))
@@ -526,57 +529,94 @@ registeredStream db@ImmDB { addHdrEnv } registry blockOrHeader start end = do
       ImmDB.EmptySlotError slot     -> slot
       ImmDB.WrongHashError slot _ _ -> slot
 
--- | Stream headers/blocks from the given 'StreamFrom'.
---
--- Checks whether the block at the lower bound has the right hash. If not,
--- 'Nothing' is returned.
---
--- When the slot of the lower bound is greater than the slot at the tip in the
--- ImmutableDB, we return 'MissingBlock' (instead of throwing a
--- 'ReadFutureSlotError' or 'ReadFutureEBBError').
+-- | Stream headers/blocks from the given 'StreamFrom' to the given
+-- 'StreamTo'.
 --
 -- When passed @'StreamFromInclusive' pt@ where @pt@ refers to Genesis, a
 -- 'NoGenesisBlock' exception will be thrown.
-streamFrom
-  :: forall m blk b. IOLike m
+stream
+  :: forall m blk b. (IOLike m, HasHeader blk)
   => ImmDB m blk
   -> ResourceRegistry m
   -> BlockOrHeader blk b
   -> StreamFrom blk
+  -> StreamTo   blk
   -> m (Either (UnknownRange blk)
                (ImmDB.Iterator (HeaderHash blk) m (Deserialisable m blk b)))
-streamFrom db registry blockOrHeader from = runExceptT $ case from of
-    StreamFromExclusive pt@BlockPoint { atSlot = slot, withHash = hash } -> do
-      checkFutureSlot pt
-      it <- stream (Just (slot, hash)) Nothing
-      -- Skip the first block, as the bound is exclusive
-      void $ lift $ iteratorNext db it
-      return it
-    StreamFromExclusive    GenesisPoint ->
-      stream Nothing Nothing
-    StreamFromInclusive pt@BlockPoint { atSlot = slot, withHash = hash } -> do
-      checkFutureSlot pt
-      stream (Just (slot, hash)) Nothing
-    StreamFromInclusive GenesisPoint ->
-      throwM NoGenesisBlock
-  where
-    -- | Check if the slot of the lower bound is <= the slot of the tip. If
-    -- not, throw a 'MissingBlock' error.
+stream db registry blockOrHeader from to = runExceptT $ do
+    -- Also check if the slot of the bound is <= the slot of the tip. If not,
+    -- throw a 'MissingBlock' error.
     --
     -- Note that between this check and the actual opening of the iterator, a
     -- block may be appended to the ImmutableDB such that the requested slot
     -- is no longer in the future, but we have returned 'MissingBlock'
     -- nonetheless. This is fine, since the request to stream from the slot
     -- was made earlier, at a moment where it still was in the future.
-    checkFutureSlot :: Point blk -> ExceptT (UnknownRange blk) m ()
-    checkFutureSlot pt = do
-      slotNoAtTip <- lift $ getSlotNoAtTip db
-      when (pointSlot pt > slotNoAtTip) $
-        throwError $ MissingBlock pt
+    slotNoAtTip <- lift $ getSlotNoAtTip db
 
-    stream start end = ExceptT $
-      fmap (deserialisableIterator db blockOrHeader) <$>
+    end <- case to of
+      StreamToExclusive pt@BlockPoint { atSlot = slot, withHash = hash } -> do
+        when (pointSlot pt > slotNoAtTip) $ throwError $ MissingBlock pt
+        return $ Just (slot, hash)
+      StreamToExclusive GenesisPoint ->
+        throwM NoGenesisBlock
+      StreamToInclusive pt@BlockPoint { atSlot = slot, withHash = hash } -> do
+        when (pointSlot pt > slotNoAtTip) $ throwError $ MissingBlock pt
+        return $ Just (slot, hash)
+      StreamToInclusive GenesisPoint ->
+        throwM NoGenesisBlock
+
+    case from of
+      StreamFromExclusive pt@BlockPoint { atSlot = slot, withHash = hash } -> do
+        when (pointSlot pt > slotNoAtTip) $ throwError $ MissingBlock pt
+        it <- openRegisteredStream (Just (slot, hash)) end
+        -- Skip the first block, as the bound is exclusive
+        void $ lift $ iteratorNext db it
+        return it
+      StreamFromExclusive    GenesisPoint ->
+        openRegisteredStream Nothing end
+      StreamFromInclusive pt@BlockPoint { atSlot = slot, withHash = hash } -> do
+        when (pointSlot pt > slotNoAtTip) $ throwError $ MissingBlock pt
+        openRegisteredStream (Just (slot, hash)) end
+      StreamFromInclusive GenesisPoint ->
+        throwM NoGenesisBlock
+  where
+    openRegisteredStream start end = ExceptT $
+      fmap (deserialisableIterator db blockOrHeader . stopAt to) <$>
       registeredStream db registry blockOrHeader start end
+
+    -- | The ImmutableDB doesn't support an exclusive end bound, so we stop
+    -- the iterator when it reaches its exclusive end bound.
+    stopAt :: StreamTo blk
+           -> ImmDB.Iterator (HeaderHash blk) m a
+           -> ImmDB.Iterator (HeaderHash blk) m a
+    stopAt = \case
+      StreamToInclusive _  -> id
+      StreamToExclusive pt -> \it -> it
+          { ImmDB.iteratorNext    = ignoreExclusiveBound <$> ImmDB.iteratorNext it
+          , ImmDB.iteratorPeek    = ignoreExclusiveBound <$> ImmDB.iteratorPeek it
+            -- NOTE: this means 'iteratorHasNext' is more expensive when
+            -- streaming to an exclusive end bound, as the block is read.
+          , ImmDB.iteratorHasNext = ImmDB.iteratorPeek it >>= \case
+              ImmDB.IteratorExhausted -> return False
+              ImmDB.IteratorResult _slotNo hash _
+                | isEnd hash
+                -> ImmDB.iteratorClose it $> False
+              ImmDB.IteratorEBB _epochNo hash _
+                | isEnd hash
+                -> ImmDB.iteratorClose it $> False
+              _ -> return True
+          }
+        where
+          isEnd hash = pointHash pt == BlockHash hash
+          ignoreExclusiveBound = \case
+            ImmDB.IteratorResult _slotNo  hash _
+              | isEnd hash
+              -> ImmDB.IteratorExhausted
+            ImmDB.IteratorEBB    _epochNo hash _
+              | isEnd hash
+              -> ImmDB.IteratorExhausted
+            itRes -> itRes
 
 -- | Stream headers/blocks after the given point
 --

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Iterator.hs
@@ -25,6 +25,7 @@ import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (isJust)
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
@@ -659,8 +660,8 @@ implIteratorNext registry varItState IteratorEnv{..} =
     selectResult :: ImmDB.Iterator (HeaderHash blk) m (Deserialisable m blk blk)
                  -> m (Done (Deserialisable m blk blk))
     selectResult immIt = do
-        itRes   <- ImmDB.iteratorNext    itImmDB immIt
-        hasNext <- ImmDB.iteratorHasNext itImmDB immIt
+        itRes   <-            ImmDB.iteratorNext    itImmDB immIt
+        hasNext <- isJust <$> ImmDB.iteratorHasNext itImmDB immIt
         case itRes of
           ImmDB.IteratorResult _ _ blk -> select blk hasNext
           ImmDB.IteratorEBB    _ _ blk -> select blk hasNext

--- a/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
@@ -26,6 +26,7 @@ import qualified Codec.CBOR.Decoding as Dec
 import           Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as Enc
 import           Codec.Serialise (Serialise (..))
+import           Data.Hashable (Hashable)
 import           Data.Word
 import           GHC.Generics
 
@@ -42,7 +43,7 @@ import           Ouroboros.Consensus.Util.Condense
 -- | An epoch, i.e. the number of the epoch.
 newtype EpochNo = EpochNo { unEpochNo :: Word64 }
   deriving stock (Eq, Ord, Show, Generic)
-  deriving newtype (Enum, Num, Serialise, ToCBOR, NoUnexpectedThunks)
+  deriving newtype (Enum, Num, Serialise, ToCBOR, NoUnexpectedThunks, Hashable)
 
 newtype EpochSize = EpochSize { unEpochSize :: Word64 }
   deriving stock (Eq, Ord, Show, Generic)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -277,11 +277,11 @@ data Iterator hash m a = Iterator
     -- Throws a 'ClosedDBError' if the database is closed.
   , iteratorPeek    :: HasCallStack => m (IteratorResult hash a)
 
-    -- | Return 'True' if there is a next blob to return. Return 'False' if
-    -- not.
+    -- | Return the epoch number (in case of an EBB) or slot number and hash
+    -- of the next blob, if there is a next. Return 'Nothing' if not.
     --
     -- This operation is idempotent.
-  , iteratorHasNext :: HasCallStack => m Bool
+  , iteratorHasNext :: HasCallStack => m (Maybe (Either EpochNo SlotNo, hash))
 
     -- | Dispose of the 'Iterator' by closing any open handles.
     --

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE RankNTypes        #-}
 module Ouroboros.Storage.ImmutableDB.API
   ( ImmutableDB (..)
-  , withDB
   , Iterator (..)
   , IteratorResult (..)
   , iteratorToList
@@ -23,22 +22,9 @@ import           Data.Function (on)
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 
-import           Control.Monad.Class.MonadThrow
-
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.ImmutableDB.Types
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
-
--- | Open the database using the given function, perform the given action
--- using the database. Close the database using its 'closeDB' function
--- afterwards.
-withDB :: (HasCallStack, MonadThrow m)
-       => m (ImmutableDB hash m)
-          -- ^ How to open the database
-       -> (ImmutableDB hash m -> m a)
-          -- ^ Action to perform using the database
-       -> m a
-withDB openDB = bracket openDB closeDB
 
 -- | API for the 'ImmutableDB'.
 --

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DerivingVia         #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+module Ouroboros.Storage.ImmutableDB.Impl.Index
+  ( -- * Index
+    Index (..)
+  , readOffset
+  , readEntry
+    -- * File-backed index
+  , fileBackedIndex
+  ) where
+
+import           Data.Functor.Identity (Identity (..))
+import           Data.Word (Word64)
+import           GHC.Stack (HasCallStack)
+
+import           Control.Monad.Class.MonadThrow
+
+import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..))
+
+import           Ouroboros.Consensus.Block (IsEBB)
+
+import           Ouroboros.Storage.Common (EpochNo)
+import           Ouroboros.Storage.FS.API (HasFS)
+import           Ouroboros.Storage.FS.API.Types (AllowExisting, Handle)
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
+
+import           Ouroboros.Storage.ImmutableDB.Impl.Index.Primary
+                     (SecondaryOffset)
+import qualified Ouroboros.Storage.ImmutableDB.Impl.Index.Primary as Primary
+import           Ouroboros.Storage.ImmutableDB.Impl.Index.Secondary (BlockSize)
+import qualified Ouroboros.Storage.ImmutableDB.Impl.Index.Secondary as Secondary
+import           Ouroboros.Storage.ImmutableDB.Layout (RelativeSlot)
+import           Ouroboros.Storage.ImmutableDB.Types (HashInfo,
+                     ImmutableDBError, WithBlockSize (..))
+
+{------------------------------------------------------------------------------
+  Index
+------------------------------------------------------------------------------}
+
+-- | Bundle the operations on the primary and secondary index that touch the
+-- files. This allows us to easily introduce an intermediary caching layer.
+data Index m hash h = Index
+  { -- | See 'Primary.readOffsets'
+    readOffsets
+      :: forall t. (HasCallStack, Traversable t)
+      => EpochNo
+      -> t RelativeSlot
+      -> m (t (Maybe SecondaryOffset))
+
+    -- |  See 'Primary.readFirstFilledSlot'
+  , readFirstFilledSlot
+      :: HasCallStack
+      => EpochNo
+      -> m (Maybe RelativeSlot)
+
+    -- | See 'Primary.open'
+  , openPrimaryIndex
+      :: HasCallStack
+      => EpochNo
+      -> AllowExisting
+      -> m (Handle h)
+
+    -- | See 'Primary.appendOffsets'
+  , appendOffsets
+      :: forall f. (HasCallStack, Foldable f)
+      => Handle h
+      -> f SecondaryOffset
+      -> m ()
+
+    -- | See 'Secondary.readEntries'
+  , readEntries
+      :: forall t. (HasCallStack, Traversable t)
+      => EpochNo
+      -> t (IsEBB, SecondaryOffset)
+      -> m (t (Secondary.Entry hash, BlockSize))
+
+    -- | See 'Secondary.readAllEntries'
+  , readAllEntries
+      :: HasCallStack
+      => SecondaryOffset
+      -> EpochNo
+      -> (Secondary.Entry hash -> Bool)
+      -> Word64
+      -> IsEBB
+      -> m [WithBlockSize (Secondary.Entry hash)]
+
+    -- | See 'Secondary.appendEntry'
+  , appendEntry
+      :: HasCallStack
+      => EpochNo
+      -> Handle h
+      -> WithBlockSize (Secondary.Entry hash)
+      -> m Word64
+
+    -- | Reset the index, drop all cached information.
+    --
+    -- To be called when the index files were manipulated without using
+    -- 'Index'. Any cached information could have become stale.
+    --
+    -- NOTE: this will only used in the testsuite, when we need to truncate.
+  , reset
+      :: HasCallStack
+      => EpochNo  --  The (new) current epoch
+      -> m ()
+  }
+  deriving NoUnexpectedThunks via OnlyCheckIsWHNF "Index" (Index m hash h)
+
+-- | See 'Primary.readOffset'.
+readOffset
+  :: Functor m
+  => Index m hash h
+  -> EpochNo
+  -> RelativeSlot
+  -> m (Maybe SecondaryOffset)
+readOffset index epoch slot = runIdentity <$>
+    readOffsets index epoch (Identity slot)
+
+-- | See 'Secondary.readEntry'.
+readEntry
+  :: Functor m
+  => Index m hash h
+  -> EpochNo
+  -> IsEBB
+  -> SecondaryOffset
+  -> m (Secondary.Entry hash, BlockSize)
+readEntry index epoch isEBB slotOffset = runIdentity <$>
+    readEntries index epoch (Identity (isEBB, slotOffset))
+
+{------------------------------------------------------------------------------
+  File-backed index
+------------------------------------------------------------------------------}
+
+fileBackedIndex
+  :: forall m hash h. MonadThrow m
+  => HasFS m h
+  -> ErrorHandling ImmutableDBError m
+  -> HashInfo hash
+  -> Index m hash h
+fileBackedIndex hasFS err hashInfo = Index
+    { readOffsets         = Primary.readOffsets         hasFS err
+    , readFirstFilledSlot = Primary.readFirstFilledSlot hasFS err
+    , openPrimaryIndex    = Primary.open                hasFS
+    , appendOffsets       = Primary.appendOffsets       hasFS
+    , readEntries         = Secondary.readEntries       hasFS err hashInfo
+    , readAllEntries      = Secondary.readAllEntries    hasFS err hashInfo
+    , appendEntry         = \_epoch h (WithBlockSize _ entry) ->
+                            Secondary.appendEntry       hasFS     hashInfo h entry
+      -- Nothing to reset, as nothing is cached
+    , reset              = \_newCurEpoch -> return ()
+    }

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index/Cache.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index/Cache.hs
@@ -1,0 +1,791 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DuplicateRecordFields      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiWayIf                 #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+{-# OPTIONS_GHC -Wredundant-constraints #-}
+module Ouroboros.Storage.ImmutableDB.Impl.Index.Cache
+  ( -- * Environment
+    CacheEnv
+  , newEnv
+  , CacheConfig (..)
+  , checkInvariants
+    -- * Background thread
+  , expireUnusedEpochs
+    -- * Operations
+  , reset
+    -- ** On the primary index
+  , readOffsets
+  , readFirstFilledSlot
+  , openPrimaryIndex
+  , appendOffsets
+    -- ** On the secondary index
+  , readEntries
+  , readAllEntries
+  , appendEntry
+  ) where
+
+import           Control.Exception (assert)
+import           Control.Monad (forM, forM_, forever, mplus, unless, void, when)
+import           Control.Monad.Except (throwError)
+import           Control.Tracer (Tracer, traceWith)
+import           Data.Foldable (toList)
+import           Data.Functor ((<&>))
+import           Data.HashPSQ (HashPSQ)
+import qualified Data.HashPSQ as PSQ
+import           Data.Maybe (fromMaybe)
+import           Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as Seq
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import           Data.Void (Void)
+import           Data.Word (Word32, Word64)
+import           GHC.Generics (Generic)
+import           GHC.Stack (HasCallStack, callStack)
+
+import           Control.Monad.Class.MonadThrow (bracketOnError)
+import           Control.Monad.Class.MonadTime (Time (..))
+
+import           Cardano.Prelude (NoUnexpectedThunks (..), forceElemsToWHNF)
+
+import           Ouroboros.Consensus.Block (IsEBB (..))
+import           Ouroboros.Consensus.Util (whenJust)
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.MonadSTM.NormalForm (tryPutMVar,
+                     unsafeNoThunks)
+import qualified Ouroboros.Consensus.Util.MonadSTM.StrictMVar as Strict
+import           Ouroboros.Consensus.Util.ResourceRegistry
+
+import           Ouroboros.Storage.Common (EpochNo (..))
+import           Ouroboros.Storage.FS.API (HasFS (..), withFile)
+import           Ouroboros.Storage.FS.API.Types (AllowExisting (..), Handle,
+                     OpenMode (ReadMode))
+import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
+
+import           Ouroboros.Storage.ImmutableDB.Impl.Index.Primary (PrimaryIndex,
+                     SecondaryOffset)
+import qualified Ouroboros.Storage.ImmutableDB.Impl.Index.Primary as Primary
+import           Ouroboros.Storage.ImmutableDB.Impl.Index.Secondary
+                     (BlockSize (..))
+import qualified Ouroboros.Storage.ImmutableDB.Impl.Index.Secondary as Secondary
+import           Ouroboros.Storage.ImmutableDB.Impl.Util (onException,
+                     renderFile, throwUnexpectedError)
+import           Ouroboros.Storage.ImmutableDB.Layout (RelativeSlot (..))
+import           Ouroboros.Storage.ImmutableDB.Types (HashInfo (..),
+                     ImmutableDBError, TraceCacheEvent (..),
+                     UnexpectedError (..), WithBlockSize (..))
+
+-- TODO property and/or q-s-m tests comparing with 'fileBackedIndex'
+
+{------------------------------------------------------------------------------
+  Environment
+------------------------------------------------------------------------------}
+
+data CacheConfig = CacheConfig
+  { pastEpochsToCache :: Word32
+    -- ^ Maximum number of past epochs to cache, excluding the current epoch.
+    --
+    -- NOTE: must be > 0
+  , expireUnusedAfter :: DiffTime
+    -- ^ Expire past epochs that haven't been used for 'expireUnusedAfter'
+    -- from the cache, regardless the number of past epochs in the cache.
+  }
+  deriving (Eq, Show)
+
+-- | Short-hand we use internally
+type Entry hash = WithBlockSize (Secondary.Entry hash)
+
+-- | The cached primary and secondary indices of the current epoch.
+--
+-- We use sequences (as opposed to vectors) to allow for efficient appending
+-- in addition to (reasonably) efficient indexing.
+data CurrentEpochInfo hash = CurrentEpochInfo
+  { currentEpochOffsets :: !(StrictSeq SecondaryOffset)
+  , currentEpochEntries :: !(StrictSeq (Entry hash))
+  }
+  deriving (Generic, NoUnexpectedThunks, Show)
+
+emptyCurrentEpochInfo :: CurrentEpochInfo hash
+emptyCurrentEpochInfo = CurrentEpochInfo (Seq.singleton 0) Seq.empty
+
+-- | Convert a 'CurrentEpochInfo' to a 'PastEpochInfo'
+--
+-- TODO don't bother with the conversion? Use vectors for past epochs at start
+-- up. Epochs that become past epochs because we advance to new epochs, we can
+-- just leave in memory as seqs?
+toPastEpochInfo :: CurrentEpochInfo hash -> PastEpochInfo hash
+toPastEpochInfo CurrentEpochInfo { currentEpochOffsets, currentEpochEntries } =
+    PastEpochInfo
+      { pastEpochOffsets =
+          fromMaybe (error "invalid current epoch") $
+          Primary.mk (toList currentEpochOffsets)
+      , pastEpochEntries =
+          -- TODO optimise this
+          Vector.fromList $ toList currentEpochEntries
+      }
+
+-- | The cached primary and secondary indices of an epoch in the past.
+--
+-- We use vectors to allow for efficient indexing. We don't need to append to
+-- them, as they are in the past and thus immutable.
+data PastEpochInfo hash = PastEpochInfo
+  { pastEpochOffsets :: !PrimaryIndex
+  , pastEpochEntries :: !(Vector (Entry hash))
+  }
+  deriving (Generic, NoUnexpectedThunks)
+
+-- | The last time a cached past epoch was accessed.
+--
+-- We care about the ordering /and/ the absolute times so we can also evict
+-- epochs when they haven't been used for @x@ seconds or minutes.
+newtype LastUsed = LastUsed Time
+  deriving newtype (Eq, Ord, Show, NoUnexpectedThunks)
+
+-- | The data stored in the cache.
+data Cached hash = Cached
+  { currentEpoch     :: !EpochNo
+    -- ^ The current epoch of the ImmutableDB, i.e., the epoch we're still
+    -- appending entries too.
+  , currentEpochInfo :: !(CurrentEpochInfo hash)
+    -- ^ We always cache the current epoch.
+    --
+    -- When clients are in sync with our chain, they will only request blocks
+    -- from the current epoch, so it is worth optimising this case.
+    -- Additionally, by appending to the current epoch through the cache, we
+    -- are sure the current epoch info is never stale.
+  , pastEpochsInfo   :: !(HashPSQ EpochNo LastUsed (PastEpochInfo hash))
+    -- ^ Cached epochs from the past.
+    --
+    -- A LRU-cache (least recently used). Whenever a we get a cache hit
+    -- ('getEpochInfo') for a past epoch, we change its 'LastUsed' priority to
+    -- the current time. When the cache is full, see 'pastEpochsToCache', we
+    -- will remove the epoch with the lowest priority, i.e. the least recently
+    -- used past epoch.
+    --
+    -- INVARIANT: all past epochs are < 'currentEpoch'
+    --
+    -- INVARIANT: @'PSQ.size' 'pastEpochsInfo' <= 'pastEpochsToCache'@
+  , nbPastEpochs     :: !Word32
+    -- ^ Cached size of 'pastEpochsInfo', as a 'HashPSQ' only provides a \(
+    -- O(n) \) 'PSQ.size' operation.
+    --
+    -- INVARIANT: 'nbPastEpochs' == @'PSQ.size' 'pastEpochsInfo'@
+  }
+  deriving (Generic, NoUnexpectedThunks)
+
+checkInvariants
+  :: Word32  -- ^ Maximum number of past epochs to cache
+  -> Cached hash
+  -> Maybe String
+checkInvariants pastEpochsToCache Cached {..} = either Just (const Nothing) $ do
+    forM_ (PSQ.keys pastEpochsInfo) $ \pastEpoch ->
+      unless (pastEpoch < currentEpoch) $
+        throwError $
+          "past epoch (" <> show pastEpoch <> ") >= current epoch (" <>
+          show currentEpoch <> ")"
+
+    unless (PSQ.size pastEpochsInfo <= fromIntegral pastEpochsToCache) $
+      throwError $
+        "PSQ.size pastEpochsInfo (" <> show (PSQ.size pastEpochsInfo) <>
+        ") > pastEpochsToCache (" <> show pastEpochsToCache <> ")"
+
+    unless (nbPastEpochs == fromIntegral (PSQ.size pastEpochsInfo)) $
+      throwError $
+        "nbPastEpochs (" <> show nbPastEpochs <>
+        ") /= PSQ.size pastEpochsInfo (" <> show (PSQ.size pastEpochsInfo) <>
+        ")"
+
+-- | Store the 'PastEpochInfo' for the given 'EpochNo' in 'Cached'.
+--
+-- Uses the 'LastUsed' as the priority.
+--
+-- NOTE: does not trim the cache.
+--
+-- PRECONDITION: the given 'EpochNo' is < the 'currentEpoch'.
+addPastEpochInfo
+  :: EpochNo
+  -> LastUsed
+  -> PastEpochInfo hash
+  -> Cached hash
+  -> Cached hash
+addPastEpochInfo epoch lastUsed pastEpochInfo cached =
+    assert (epoch < currentEpoch cached) $
+    -- NOTE: in case of multiple concurrent cache misses of the same epoch,
+    -- we might add the same past epoch multiple times to the cache. This
+    -- means the following cannot be a precondition:
+    -- assert (not (PSQ.member epoch pastEpochsInfo)) $
+    cached
+      { pastEpochsInfo = PSQ.insert epoch lastUsed pastEpochInfo pastEpochsInfo
+      , nbPastEpochs   = succ nbPastEpochs
+      }
+  where
+    Cached { pastEpochsInfo, nbPastEpochs } = cached
+
+-- | Remove the least recently used past epoch from the cache when 'Cached'
+-- contains more epochs than the given maximum.
+--
+-- PRECONDITION: 'nbPastEpochs' + 1 <= given maximum. In other words, 'Cached'
+-- contains at most one epoch too many. We ensure this by calling this
+-- function directly after adding a past epoch to 'Cached'.
+--
+-- If a past epoch was evicted, its epoch number is returned.
+evictIfNecessary
+  :: Word32  -- ^ Maximum number of past epochs to cache
+  -> Cached hash
+  -> (Cached hash, Maybe EpochNo)
+evictIfNecessary maxNbPastEpochs cached
+    | nbPastEpochs > maxNbPastEpochs
+    = assert (nbPastEpochs == maxNbPastEpochs + 1) $
+      case PSQ.minView pastEpochsInfo of
+        Nothing                                 -> error
+          "nbPastEpochs > maxNbPastEpochs but pastEpochsInfo was empty"
+        Just (epochNo, _p, _v, pastEpochsInfo') -> (cached', Just epochNo)
+          where
+            cached' = cached
+              { nbPastEpochs   = maxNbPastEpochs
+              , pastEpochsInfo = pastEpochsInfo'
+              }
+    | otherwise
+    = (cached, Nothing)
+  where
+    Cached { nbPastEpochs, pastEpochsInfo } = cached
+-- NOTE: we must inline 'evictIfNecessary' otherwise we get unexplained thunks
+-- in 'Cached' and thus a space leak. Alternatively, we could disable the
+-- @-fstrictness@ optimisation (enabled by default for -O1).
+{-# INLINE evictIfNecessary #-}
+
+lookupPastEpochInfo
+  :: EpochNo
+  -> LastUsed
+  -> Cached hash
+  -> Maybe (PastEpochInfo hash, Cached hash)
+lookupPastEpochInfo epoch lastUsed cached@Cached { pastEpochsInfo } =
+    case PSQ.alter lookupAndUpdateLastUsed epoch pastEpochsInfo of
+      (Nothing, _) -> Nothing
+      (Just pastEpochInfo, pastEpochsInfo') -> Just (pastEpochInfo, cached')
+        where
+          cached' = cached { pastEpochsInfo = pastEpochsInfo' }
+  where
+    lookupAndUpdateLastUsed
+      :: Maybe (LastUsed, PastEpochInfo hash)
+      -> (Maybe (PastEpochInfo hash), Maybe (LastUsed, PastEpochInfo hash))
+    lookupAndUpdateLastUsed = \case
+      Nothing                -> (Nothing, Nothing)
+      Just (_lastUsed, info) -> (Just info, Just (lastUsed, info))
+
+openEpoch
+  :: EpochNo
+  -> LastUsed
+  -> CurrentEpochInfo hash
+  -> Cached hash
+  -> Cached hash
+openEpoch epoch lastUsed newCurrentEpochInfo cached
+    | currentEpoch == epoch
+    = cached
+        { currentEpochInfo = newCurrentEpochInfo }
+
+    | currentEpoch + 1 == epoch
+    = Cached
+        { currentEpoch     = epoch
+        , currentEpochInfo = newCurrentEpochInfo
+          -- We use 'lastUsed' for the current epoch that has now become a
+          -- "past" epoch, which means that that epoch is most recently used
+          -- one. When clients are roughly in sync with us, when we switch to a
+          -- new epoch, they might still request blocks from the previous one.
+          -- So to avoid throwing away that cached information, we give it the
+          -- highest priority.
+        , pastEpochsInfo   = PSQ.insert currentEpoch lastUsed
+            (toPastEpochInfo currentEpochInfo) pastEpochsInfo
+        , nbPastEpochs     = succ nbPastEpochs
+        }
+
+    | otherwise
+    = error $ "Going from epoch " <> show currentEpoch <> " to " <> show epoch
+  where
+    Cached
+      { currentEpoch, currentEpochInfo, pastEpochsInfo, nbPastEpochs
+      } = cached
+
+emptyCached
+  :: EpochNo -- ^ The current epoch
+  -> CurrentEpochInfo hash
+  -> Cached hash
+emptyCached currentEpoch currentEpochInfo = Cached
+    { currentEpoch
+    , currentEpochInfo
+    , pastEpochsInfo = PSQ.empty
+    , nbPastEpochs   = 0
+    }
+
+-- | Environment used by functions operating on the cached index.
+data CacheEnv m hash h = CacheEnv
+  { hasFS       :: HasFS m h
+  , err         :: ErrorHandling ImmutableDBError m
+  , hashInfo    :: HashInfo hash
+  , registry    :: ResourceRegistry m
+  , tracer      :: Tracer m TraceCacheEvent
+  , cacheVar    :: StrictMVar m (Cached hash)
+  , cacheConfig :: CacheConfig
+  }
+
+-- | Creates a new 'CacheEnv' and launches a background thread that expires
+-- unused past epochs ('expireUnusedEpochs').
+--
+-- PRECONDITION: 'pastEpochsToCache' (in 'CacheConfig') > 0
+newEnv
+  :: (HasCallStack, IOLike m, NoUnexpectedThunks hash)
+  => HasFS m h
+  -> ErrorHandling ImmutableDBError m
+  -> HashInfo hash
+  -> ResourceRegistry m
+  -> Tracer m TraceCacheEvent
+  -> CacheConfig
+  -> EpochNo  -- ^ Current epoch
+  -> m (CacheEnv m hash h)
+newEnv hasFS err hashInfo registry tracer cacheConfig epoch = do
+    when (pastEpochsToCache == 0) $
+      error "pastEpochsToCache must be > 0"
+
+    currentEpochInfo <- loadCurrentEpochInfo hasFS err hashInfo epoch
+    cacheVar <- newMVarWithInvariants $ emptyCached epoch currentEpochInfo
+    let cacheEnv = CacheEnv {..}
+    void $ forkLinkedThread registry $ expireUnusedEpochs cacheEnv
+    return cacheEnv
+  where
+    CacheConfig { pastEpochsToCache } = cacheConfig
+
+    -- When checking invariants, check both our invariants and for thunks.
+    -- Note that this is only done when the corresponding flag is enabled.
+    newMVarWithInvariants =
+      Strict.newMVarWithInvariant $ \cached ->
+        checkInvariants pastEpochsToCache cached
+        `mplus`
+        unsafeNoThunks cached
+
+{------------------------------------------------------------------------------
+  Background thread
+------------------------------------------------------------------------------}
+
+-- | Intended to run as a background thread.
+--
+-- Will expire past epochs that haven't been used for 'expireUnusedAfter' from
+-- the cache.
+expireUnusedEpochs
+  :: (HasCallStack, IOLike m)
+  => CacheEnv m hash h
+  -> m Void
+expireUnusedEpochs CacheEnv { cacheVar, cacheConfig, tracer } =
+    forever $ do
+      now <- getMonotonicTime
+      mbTraceMsg <- updateMVar cacheVar $ garbageCollect now
+      mapM_ (traceWith tracer) mbTraceMsg
+      threadDelay expireUnusedAfter
+  where
+    CacheConfig { expireUnusedAfter } = cacheConfig
+
+    -- | Remove the least recently used past epoch from 'Cached' /if/ it
+    -- hasn't been used for 'expireUnusedAfter', otherwise the original
+    -- 'Cached' is returned.
+    --
+    -- In case a 'TracePastEpochsExpired' event should be traced, it is
+    -- returned as a 'Just'.
+    garbageCollect
+      :: Time
+      -> Cached hash
+      -> (Cached hash, Maybe TraceCacheEvent)
+    garbageCollect now cached@Cached { pastEpochsInfo, nbPastEpochs } =
+        case expiredPastEpochs of
+          [] -> (cached,  Nothing)
+          _  -> (cached', Just traceMsg)
+      where
+        -- Every past epoch last used before (or at) this time, must be
+        -- expired.
+        expiredLastUsedTime :: LastUsed
+        expiredLastUsedTime = LastUsed $
+          Time (now `diffTime` Time expireUnusedAfter)
+
+        (expiredPastEpochs, pastEpochsInfo') =
+          PSQ.atMostView expiredLastUsedTime pastEpochsInfo
+
+        nbPastEpochs' = nbPastEpochs - fromIntegral (length expiredPastEpochs)
+
+        cached' = cached
+          { pastEpochsInfo = pastEpochsInfo'
+          , nbPastEpochs   = nbPastEpochs'
+          }
+
+        !traceMsg = TracePastEpochsExpired
+          -- Force this list, otherwise the traced message holds onto to the
+          -- past epoch indices.
+          (forceElemsToWHNF [epoch | (epoch, _, _) <- expiredPastEpochs])
+          nbPastEpochs'
+
+{------------------------------------------------------------------------------
+  Reading indices
+------------------------------------------------------------------------------}
+
+readPrimaryIndex
+  :: (HasCallStack, IOLike m)
+  => HasFS m h
+  -> ErrorHandling ImmutableDBError m
+  -> EpochNo
+  -> m (PrimaryIndex, IsEBB)
+     -- ^ The primary index and whether it starts with an EBB or not
+readPrimaryIndex hasFS err epoch = do
+    primaryIndex <- Primary.load hasFS err epoch
+    let firstIsEBB
+          | Primary.containsSlot primaryIndex 0
+          , Primary.isFilledSlot primaryIndex 0
+          = IsEBB
+          | otherwise
+          = IsNotEBB
+    return (primaryIndex, firstIsEBB)
+
+readSecondaryIndex
+  :: (HasCallStack, IOLike m)
+  => HasFS m h
+  -> ErrorHandling ImmutableDBError m
+  -> HashInfo hash
+  -> EpochNo
+  -> IsEBB
+  -> m [Entry hash]
+readSecondaryIndex hasFS@HasFS { hGetSize } err hashInfo epoch firstIsEBB = do
+    !epochFileSize <- withFile hasFS epochFile ReadMode hGetSize
+    Secondary.readAllEntries hasFS err hashInfo secondaryOffset
+      epoch stopCondition epochFileSize firstIsEBB
+  where
+    epochFile = renderFile "epoch" epoch
+    -- Read from the start
+    secondaryOffset = 0
+    -- Don't stop until the end
+    stopCondition = const False
+
+loadCurrentEpochInfo
+  :: (HasCallStack, IOLike m)
+  => HasFS m h
+  -> ErrorHandling ImmutableDBError m
+  -> HashInfo hash
+  -> EpochNo
+  -> m (CurrentEpochInfo hash)
+loadCurrentEpochInfo hasFS err hashInfo epoch = do
+    -- We're assuming that when the primary index file exists, the secondary
+    -- index file will also exist
+    epochExists <- doesFileExist hasFS primaryIndexFile
+    if epochExists then do
+      (primaryIndex, firstIsEBB) <- readPrimaryIndex hasFS err epoch
+      entries <- readSecondaryIndex hasFS err hashInfo epoch firstIsEBB
+      return CurrentEpochInfo
+        { currentEpochOffsets =
+          -- TODO optimise this
+            Seq.fromList . Primary.toSecondaryOffsets $ primaryIndex
+        , currentEpochEntries = Seq.fromList entries
+        }
+    else
+      return emptyCurrentEpochInfo
+  where
+    primaryIndexFile = renderFile "primary" epoch
+
+loadPastEpochInfo
+  :: (HasCallStack, IOLike m)
+  => HasFS m h
+  -> ErrorHandling ImmutableDBError m
+  -> HashInfo hash
+  -> EpochNo
+  -> m (PastEpochInfo hash)
+loadPastEpochInfo hasFS err hashInfo epoch = do
+    (primaryIndex, firstIsEBB) <- readPrimaryIndex hasFS err epoch
+    entries <- readSecondaryIndex hasFS err hashInfo epoch firstIsEBB
+    return PastEpochInfo
+      { pastEpochOffsets = primaryIndex
+      , pastEpochEntries = Vector.fromList $ forceElemsToWHNF entries
+      }
+
+getEpochInfo
+  :: (HasCallStack, IOLike m)
+  => CacheEnv m hash h
+  -> EpochNo
+  -> m (Either (CurrentEpochInfo hash) (PastEpochInfo hash))
+getEpochInfo cacheEnv epoch = do
+    lastUsed <- LastUsed <$> getMonotonicTime
+    -- Make sure we don't leave an empty MVar in case of an exception.
+    mbCacheHit <- bracketOnError (takeMVar cacheVar) (tryPutMVar cacheVar) $
+      \cached@Cached { currentEpoch, currentEpochInfo, nbPastEpochs } -> if
+        | epoch == currentEpoch -> do
+          -- Cache hit for the current epoch
+          putMVar cacheVar cached
+          traceWith tracer $ TraceCurrentEpochHit epoch nbPastEpochs
+          return $ Just $ Left currentEpochInfo
+        | Just (pastEpochInfo, cached') <- lookupPastEpochInfo epoch lastUsed cached -> do
+          -- Cache hit for an epoch in the past
+          putMVar cacheVar cached'
+          traceWith tracer $ TracePastEpochHit epoch nbPastEpochs
+          return $ Just $ Right pastEpochInfo
+        | otherwise -> do
+          -- Cache miss for an epoch in the past. We don't want to hold on to
+          -- the 'cacheVar' MVar, blocking all other access to the cace, while
+          -- we're reading things from disk, so put it back now and update the
+          -- cache afterwards.
+          putMVar cacheVar cached
+          traceWith tracer $ TracePastEpochMiss epoch nbPastEpochs
+          return Nothing
+    case mbCacheHit of
+      Just hit -> return hit
+      Nothing  -> do
+        -- Cache miss, load both entire indices for the epoch from disk.
+        pastEpochInfo <- loadPastEpochInfo hasFS err hashInfo epoch
+        -- Loading the epoch might have taken some time, so obtain the time
+        -- again.
+        lastUsed' <- LastUsed <$> getMonotonicTime
+        mbEvicted <- updateMVar cacheVar $
+          evictIfNecessary pastEpochsToCache .
+          addPastEpochInfo epoch lastUsed' pastEpochInfo
+        whenJust mbEvicted $ \evicted ->
+          -- If we had to evict, we are at 'pastEpochsToCache'
+          traceWith tracer $ TracePastEpochEvict evicted pastEpochsToCache
+        return $ Right pastEpochInfo
+  where
+    CacheEnv { hasFS, err, hashInfo, cacheVar, cacheConfig, tracer } = cacheEnv
+    CacheConfig { pastEpochsToCache } = cacheConfig
+
+{------------------------------------------------------------------------------
+  Operations
+------------------------------------------------------------------------------}
+
+-- | Empties the cache and restarts the background expiration thread.
+--
+-- PRECONDITION: the background thread expiring unused past epochs must have
+-- been terminated.
+reset
+  :: IOLike m
+  => CacheEnv m hash h
+  -> EpochNo  -- ^ The new current epoch
+  -> m ()
+reset cacheEnv@CacheEnv { hasFS, err, hashInfo, registry, cacheVar } epoch = do
+    currentEpochInfo <- loadCurrentEpochInfo hasFS err hashInfo epoch
+    void $ swapMVar cacheVar $ emptyCached epoch currentEpochInfo
+    void $ forkLinkedThread registry $ expireUnusedEpochs cacheEnv
+
+{------------------------------------------------------------------------------
+  On the primary index
+------------------------------------------------------------------------------}
+
+readOffsets
+  :: (HasCallStack, Traversable t, IOLike m)
+  => CacheEnv m hash h
+  -> EpochNo
+  -> t RelativeSlot
+  -> m (t (Maybe SecondaryOffset))
+readOffsets cacheEnv epoch relSlots =
+    getEpochInfo cacheEnv epoch <&> \case
+      Left CurrentEpochInfo { currentEpochOffsets } ->
+        getOffsetFromSecondaryOffsets currentEpochOffsets <$> relSlots
+      Right PastEpochInfo { pastEpochOffsets } ->
+        getOffsetFromPrimaryIndex pastEpochOffsets <$> relSlots
+  where
+    getOffsetFromSecondaryOffsets
+      :: StrictSeq SecondaryOffset
+      -> RelativeSlot
+      -> Maybe SecondaryOffset
+    getOffsetFromSecondaryOffsets offsets (RelativeSlot s) =
+      case Seq.splitAt (fromIntegral s + 1) offsets of
+        (_ Seq.:|> offset, offsetAfter Seq.:<| _)
+          | offset /= offsetAfter
+            -- The slot is not empty
+          -> Just offset
+        _ -> Nothing
+
+    getOffsetFromPrimaryIndex
+      :: PrimaryIndex
+      -> RelativeSlot
+      -> Maybe SecondaryOffset
+    getOffsetFromPrimaryIndex index relSlot
+      | Primary.containsSlot  index relSlot
+      , Primary.isFilledSlot  index relSlot
+      = Just $ Primary.offsetOfSlot index relSlot
+      | otherwise
+      = Nothing
+
+readFirstFilledSlot
+  :: (HasCallStack, IOLike m)
+  => CacheEnv m hash h
+  -> EpochNo
+  -> m (Maybe RelativeSlot)
+readFirstFilledSlot cacheEnv epoch =
+    getEpochInfo cacheEnv epoch <&> \case
+      Left CurrentEpochInfo { currentEpochOffsets } ->
+        firstFilledSlotInSeq currentEpochOffsets
+      Right PastEpochInfo { pastEpochOffsets } ->
+        Primary.firstFilledSlot pastEpochOffsets
+  where
+    firstFilledSlotInSeq :: StrictSeq SecondaryOffset -> Maybe RelativeSlot
+    firstFilledSlotInSeq = fmap indexToRelativeSlot . Seq.findIndexL (/= 0)
+      where
+        indexToRelativeSlot :: Int -> RelativeSlot
+        indexToRelativeSlot = RelativeSlot . fromIntegral . pred
+
+-- | This is called when a new epoch is started, which means we need to update
+-- 'Cached' to reflect this.
+openPrimaryIndex
+  :: (HasCallStack, IOLike m)
+  => CacheEnv m hash h
+  -> EpochNo
+  -> AllowExisting
+  -> m (Handle h)
+openPrimaryIndex cacheEnv epoch allowExisting = do
+    lastUsed <- LastUsed <$> getMonotonicTime
+    pHnd <- Primary.open hasFS epoch allowExisting
+    -- Don't leak the handle in case of an exception
+    onException hasFsErr err (hClose pHnd) $ do
+      newCurrentEpochInfo <- case allowExisting of
+        MustBeNew     -> return emptyCurrentEpochInfo
+        AllowExisting -> loadCurrentEpochInfo hasFS err hashInfo epoch
+      mbEvicted <- updateMVar cacheVar $
+        evictIfNecessary pastEpochsToCache .
+        openEpoch epoch lastUsed newCurrentEpochInfo
+      whenJust mbEvicted $ \evicted ->
+        -- If we had to evict, we are at 'pastEpochsToCache'
+        traceWith tracer $ TracePastEpochEvict evicted pastEpochsToCache
+      return pHnd
+  where
+    CacheEnv { hasFS, err, hashInfo, cacheVar, cacheConfig, tracer } = cacheEnv
+    HasFS { hClose, hasFsErr } = hasFS
+    CacheConfig { pastEpochsToCache } = cacheConfig
+
+appendOffsets
+  :: (HasCallStack, Foldable f, IOLike m)
+  => CacheEnv m hash h
+  -> Handle h
+  -> f SecondaryOffset
+  -> m ()
+appendOffsets CacheEnv { hasFS, cacheVar } pHnd offsets = do
+    Primary.appendOffsets hasFS pHnd offsets
+    updateMVar_ cacheVar addCurrentEpochOffsets
+  where
+    -- Lenses would be nice here
+    addCurrentEpochOffsets :: Cached hash -> Cached hash
+    addCurrentEpochOffsets cached@Cached { currentEpochInfo } = cached
+      { currentEpochInfo = currentEpochInfo
+        { currentEpochOffsets = currentEpochOffsets currentEpochInfo <>
+                                Seq.fromList (toList offsets)
+        }
+      }
+
+{------------------------------------------------------------------------------
+  On the secondary index
+------------------------------------------------------------------------------}
+
+readEntries
+  :: forall m hash h t. (HasCallStack, Traversable t, IOLike m)
+  => CacheEnv m hash h
+  -> EpochNo
+  -> t (IsEBB, SecondaryOffset)
+  -> m (t (Secondary.Entry hash, BlockSize))
+readEntries cacheEnv@CacheEnv { err, hashInfo } epoch toRead =
+    getEpochInfo cacheEnv epoch >>= \case
+      Left CurrentEpochInfo { currentEpochEntries } ->
+        forM toRead $ \(_isEBB, secondaryOffset) ->
+          case currentEpochEntries Seq.!? indexForOffset secondaryOffset of
+            Just (WithBlockSize size entry) -> return (entry, BlockSize size)
+            Nothing                         -> noEntry secondaryOffset
+      Right PastEpochInfo { pastEpochEntries } ->
+        forM toRead $ \(_isEBB, secondaryOffset) ->
+          case pastEpochEntries Vector.!? indexForOffset secondaryOffset of
+            Just (WithBlockSize size entry) -> return (entry, BlockSize size)
+            Nothing                         -> noEntry secondaryOffset
+  where
+    indexForOffset :: SecondaryOffset -> Int
+    indexForOffset secondaryOffset = fromIntegral $
+      secondaryOffset `div` Secondary.entrySize (hashSize hashInfo)
+
+    -- There was no entry in the secondary index for the given
+    -- 'SecondaryOffset'. Either the secondary index is incomplete, /or/, the
+    -- primary index from which we read the 'SecondaryOffset' got corrupted.
+    -- We don't know which of the two things happened, but the former is more
+    -- likely, so we mention that file in the error message.
+    noEntry :: SecondaryOffset -> m a
+    noEntry secondaryOffset = throwUnexpectedError err $ InvalidFileError
+      (renderFile "secondary" epoch)
+      ("no entry missing for " <> show secondaryOffset)
+      callStack
+
+readAllEntries
+  :: (HasCallStack, IOLike m)
+  => CacheEnv m hash h
+  -> SecondaryOffset
+  -> EpochNo
+  -> (Secondary.Entry hash -> Bool)
+  -> Word64
+  -> IsEBB
+  -> m [WithBlockSize (Secondary.Entry hash)]
+readAllEntries cacheEnv@CacheEnv { hashInfo } secondaryOffset epoch stopCondition
+               _epochFileSize _firstIsEBB =
+    getEpochInfo cacheEnv epoch <&> \case
+      Left CurrentEpochInfo { currentEpochEntries } ->
+        takeUntil (stopCondition . withoutBlockSize) $
+        toList $ Seq.drop toDrop currentEpochEntries
+      Right PastEpochInfo { pastEpochEntries } ->
+        takeUntil (stopCondition . withoutBlockSize) $
+        toList $ Vector.drop toDrop pastEpochEntries
+  where
+    toDrop :: Int
+    toDrop = fromIntegral $
+      secondaryOffset `div` Secondary.entrySize (hashSize hashInfo)
+
+appendEntry
+  :: forall m hash h. (HasCallStack, IOLike m)
+  => CacheEnv m hash h
+  -> EpochNo
+  -> Handle h
+  -> Entry hash
+  -> m Word64
+appendEntry CacheEnv { hasFS, hashInfo, cacheVar } epoch sHnd entry = do
+    nbBytes <- Secondary.appendEntry hasFS hashInfo sHnd (withoutBlockSize entry)
+    updateMVar_ cacheVar addCurrentEpochEntry
+    return nbBytes
+  where
+    -- Lenses would be nice here
+    addCurrentEpochEntry :: Cached hash -> Cached hash
+    addCurrentEpochEntry cached@Cached { currentEpoch, currentEpochInfo }
+      | currentEpoch /= epoch
+      = error $
+          "Appending to epoch " <> show epoch <>
+          " while the index is still in " <> show currentEpoch
+      | otherwise
+      = cached
+          { currentEpochInfo = currentEpochInfo
+            { currentEpochEntries =
+                currentEpochEntries currentEpochInfo Seq.|> entry
+            }
+          }
+
+{------------------------------------------------------------------------------
+  Helpers
+------------------------------------------------------------------------------}
+
+-- | Take items until the condition is true. If the condition is true for an
+-- item, include that item as the last item in the returned list. If the
+-- condition was never true, the original list is returned.
+--
+-- > takeUntil (== 3) [1,2,3,4]
+-- [1,2,3]
+-- > takeUntil (== 2) [0,1,0]
+-- [0,1,0]
+-- > takeUntil (== 2) [2,2,3]
+-- [2]
+takeUntil :: (a -> Bool) -> [a] -> [a]
+takeUntil p = \case
+  []
+    -> []
+  x:xs
+    | p x
+    -> [x]
+    | otherwise
+    -> x:takeUntil p xs

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index/Primary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index/Primary.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Primary Index

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index/Primary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index/Primary.hs
@@ -302,7 +302,7 @@ load hasFS err epoch =
 -- > primaryIndex === primaryIndex'
 --
 write
-  :: MonadThrow m
+  :: (HasCallStack, MonadThrow m)
   => HasFS m h
   -> EpochNo
   -> PrimaryIndex
@@ -333,7 +333,7 @@ truncateToSlot slot primary@(MkPrimaryIndex offsets)
 -- | On-disk variant of 'truncateToSlot'. The truncation is done without
 -- reading the primary index from disk.
 truncateToSlotFS
-  :: MonadThrow m
+  :: (HasCallStack, MonadThrow m)
   => HasFS m h
   -> EpochNo
   -> RelativeSlot
@@ -353,7 +353,7 @@ truncateToSlotFS hasFS@HasFS { hTruncate, hGetSize } epoch (RelativeSlot slot) =
 -- POSTCONDITION: the last slot of the primary index file will be filled,
 -- unless the index itself is empty.
 unfinalise
-  :: MonadThrow m
+  :: (HasCallStack, MonadThrow m)
   => HasFS m h
   -> ErrorHandling ImmutableDBError m
   -> EpochNo
@@ -394,7 +394,7 @@ open hasFS@HasFS { hOpen, hClose, hasFsErr } epoch allowExisting = do
 -- | Append the given 'SecondaryOffset' to the end of the file (passed as a
 -- handle).
 appendOffsets
-  :: (Monad m, Foldable f)
+  :: (Monad m, Foldable f, HasCallStack)
   => HasFS m h
   -> Handle h
   -> f SecondaryOffset

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index/Secondary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index/Secondary.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 module Ouroboros.Storage.ImmutableDB.Impl.Index.Secondary
   ( Entry (..)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index/Secondary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index/Secondary.hs
@@ -280,12 +280,12 @@ readAllEntries hasFS err HashInfo { getHash } secondaryOffset epoch stopAfter
 appendEntry
   :: forall m hash h. (HasCallStack, MonadThrow m)
   => HasFS m h
-  -> Handle h
   -> HashInfo hash
+  -> Handle h
   -> Entry hash
   -> m Word64
      -- ^ The number of bytes written
-appendEntry hasFS sHnd HashInfo { putHash, hashSize } entry = do
+appendEntry hasFS HashInfo { putHash, hashSize } sHnd entry = do
     bytesWritten <- hPut hasFS sHnd $ Put.execPut $ putEntry putHash entry
     return $
       assert (bytesWritten == fromIntegral (entrySize hashSize)) bytesWritten
@@ -319,7 +319,7 @@ writeAllEntries hasFS hashInfo epoch entries =
       -- First truncate the file, otherwise we might leave some old contents
       -- at the end if the new contents are smaller than the previous contents
       hTruncate sHnd 0
-      mapM_ (appendEntry hasFS sHnd hashInfo) entries
+      mapM_ (appendEntry hasFS hashInfo sHnd) entries
   where
     secondaryIndexFile  = renderFile "secondary" epoch
     HasFS { hTruncate } = hasFS

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Iterator.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE OverloadedStrings         #-}
 {-# LANGUAGE QuantifiedConstraints     #-}
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/State.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE OverloadedStrings         #-}
 {-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE RecordWildCards           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/State.hs
@@ -67,6 +67,7 @@ data ImmutableDBEnv m hash = forall h e. ImmutableDBEnv
     , _dbHashInfo        :: !(HashInfo hash)
     , _dbTracer          :: !(Tracer m (TraceEvent e hash))
     , _dbRegistry        :: !(ResourceRegistry m)
+    , _dbCacheConfig     :: !Index.CacheConfig
     }
 
 data InternalState m hash h =

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Util.hs
@@ -31,9 +31,9 @@ import qualified Data.Binary.Get as Get
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.Text (Text)
 import qualified Data.Text as T
 import           GHC.Stack (HasCallStack, callStack, popCallStack)
-import           Text.Printf (printf)
 import           Text.Read (readMaybe)
 
 import           Ouroboros.Consensus.Util (whenJust)
@@ -58,8 +58,10 @@ import           Ouroboros.Storage.ImmutableDB.Types
 data Two a = Two a a
   deriving (Functor, Foldable, Traversable)
 
-renderFile :: String -> EpochNo -> FsPath
-renderFile fileType (EpochNo epoch) = mkFsPath [printf "%05d.%s" epoch fileType]
+renderFile :: Text -> EpochNo -> FsPath
+renderFile fileType (EpochNo epoch) = fsPathFromList [name]
+  where
+    name = T.justifyRight 5 '0' (T.pack (show epoch)) <> "." <> fileType
 
 handleUser :: HasCallStack
            => ErrorHandling ImmutableDBError m

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
@@ -77,10 +77,10 @@ validateAndReopen validateEnv valPol nextIteratorID = do
     case tip of
       TipGen -> assert (epoch == 0) $ do
         traceWith tracer NoValidLastLocation
-        mkOpenState hasFS err index epoch nextIteratorID TipGen MustBeNew
+        mkOpenState registry hasFS err index epoch nextIteratorID TipGen MustBeNew
       _     -> do
         traceWith tracer $ ValidatedLastLocation epoch (forgetHash <$> tip)
-        mkOpenState hasFS err index epoch nextIteratorID tip    AllowExisting
+        mkOpenState registry hasFS err index epoch nextIteratorID tip    AllowExisting
   where
     ValidateEnv { hasFS, err, hashInfo, tracer } = validateEnv
     index = fileBackedIndex hasFS err hashInfo

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
@@ -30,6 +30,7 @@ import           Ouroboros.Network.Point (WithOrigin (..))
 import           Ouroboros.Consensus.Block (IsEBB (..))
 import           Ouroboros.Consensus.Util (lastMaybe, whenJust)
 import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.EpochInfo
@@ -60,6 +61,7 @@ data ValidateEnv m hash h e = ValidateEnv
   , hashInfo  :: !(HashInfo hash)
   , parser    :: !(EpochFileParser e m (Secondary.Entry hash) hash)
   , tracer    :: !(Tracer m (TraceEvent e hash))
+  , registry  :: !(ResourceRegistry m)
   }
 
 -- | Perform validation as per the 'ValidationPolicy' using 'validate' and

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE MultiWayIf          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
@@ -75,10 +75,10 @@ validateAndReopen validateEnv valPol nextIteratorID = do
     case tip of
       TipGen -> assert (epoch == 0) $ do
         traceWith tracer NoValidLastLocation
-        mkOpenState hasFS index epoch nextIteratorID TipGen MustBeNew
+        mkOpenState hasFS err index epoch nextIteratorID TipGen MustBeNew
       _     -> do
         traceWith tracer $ ValidatedLastLocation epoch (forgetHash <$> tip)
-        mkOpenState hasFS index epoch nextIteratorID tip    AllowExisting
+        mkOpenState hasFS err index epoch nextIteratorID tip    AllowExisting
   where
     ValidateEnv { hasFS, err, hashInfo, tracer } = validateEnv
     index = fileBackedIndex hasFS err hashInfo

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -30,6 +30,7 @@ module Ouroboros.Storage.ImmutableDB.Types
   , sameUnexpectedError
   , prettyUnexpectedError
   , TraceEvent(..)
+  , TraceCacheEvent(..)
     -- * Current EBB
   , CurrentEBB(..)
   , hasCurrentEBB
@@ -321,6 +322,11 @@ prettyUnexpectedError = \case
       " but got " <> show actual <>
       prettyCallStack cs
 
+
+{------------------------------------------------------------------------------
+  Tracing
+------------------------------------------------------------------------------}
+
 data TraceEvent e hash
     = NoValidLastLocation
     | ValidatedLastLocation EpochNo ImmTip
@@ -342,6 +348,22 @@ data TraceEvent e hash
       -- Closing the DB
     | DBAlreadyClosed
     | DBClosed
+      -- Events traced by the index cache
+    | TraceCacheEvent !TraceCacheEvent
+  deriving (Eq, Generic, Show)
+
+-- | The argument with type 'Word32' is the number of past epoch currently in
+-- the cache.
+data TraceCacheEvent
+    = TraceCurrentEpochHit   !EpochNo   !Word32
+    | TracePastEpochHit      !EpochNo   !Word32
+    | TracePastEpochMiss     !EpochNo   !Word32
+    | TracePastEpochEvict    !EpochNo   !Word32
+      -- ^ The least recently used past epoch was evicted because the cache
+      -- was full.
+    | TracePastEpochsExpired ![EpochNo] !Word32
+      -- ^ Past epochs were expired from the cache because they haven't been
+      -- used for a while.
   deriving (Eq, Generic, Show)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -11,6 +11,7 @@ module Ouroboros.Storage.ImmutableDB.Types
   , ImmTip
   , ImmTipWithHash
   , WithHash (..)
+  , WithBlockSize (..)
   , BlockOrEBB (..)
   , HashInfo (..)
   , BinaryInfo (..)
@@ -67,6 +68,11 @@ type ImmTipWithHash hash = Tip (WithHash hash BlockOrEBB)
 data WithHash hash a = WithHash
   { theHash    :: !hash
   , forgetHash :: !a
+  } deriving (Eq, Show, Generic, NoUnexpectedThunks, Functor, Foldable, Traversable)
+
+data WithBlockSize a = WithBlockSize
+  { blockSize        :: !Word32
+  , withoutBlockSize :: !a
   } deriving (Eq, Show, Generic, NoUnexpectedThunks, Functor, Foldable, Traversable)
 
 -- | How to get/put the header hash of a block and how many bytes it occupies

--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -14,7 +14,6 @@ module Ouroboros.Storage.VolatileDB.Util
 
       -- * Exception handling
     , fromEither
-    , modifyMVar
     , wrapFsError
     , tryVolDB
 
@@ -37,13 +36,10 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import           Text.Read (readMaybe)
 
-import           Control.Monad.Class.MonadThrow
-
 import           Ouroboros.Network.Point (WithOrigin)
 
 import           Ouroboros.Consensus.Util (lastMaybe, safeMaximum,
                      safeMaximumOn)
-import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling (..))
@@ -97,18 +93,6 @@ fromEither :: Monad m
 fromEither err = \case
     Left e -> EH.throwError err e
     Right a -> return a
-
-modifyMVar :: IOLike m
-           => StrictMVar m a
-           -> (a -> m (a,b))
-           -> m b
-modifyMVar m action =
-    snd . fst <$> generalBracket (takeMVar m)
-       (\oldState ec -> case ec of
-            ExitCaseSuccess (newState,_) -> putMVar m newState
-            ExitCaseException _ex        -> putMVar m oldState
-            ExitCaseAbort                -> putMVar m oldState
-       ) action
 
 wrapFsError :: Monad m
             => ErrorHandling FsError         m

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -88,6 +88,7 @@ import qualified Ouroboros.Storage.ChainDB as ChainDB
 import           Ouroboros.Storage.ChainDB.Impl (ChainDbArgs (..))
 import           Ouroboros.Storage.EpochInfo (EpochInfo, newEpochInfo)
 import qualified Ouroboros.Storage.ImmutableDB as ImmDB
+import qualified Ouroboros.Storage.ImmutableDB.Impl.Index as Index
 import qualified Ouroboros.Storage.LedgerDB.DiskPolicy as LgrDB
 import qualified Ouroboros.Storage.LedgerDB.InMemory as LgrDB
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
@@ -276,6 +277,7 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
         , cdbGenesis          = return initLedger
         , cdbBlockchainTime   = btime
         , cdbAddHdrEnv        = nodeAddHeaderEnvelope (Proxy @blk)
+        , cdbImmDbCacheConfig = Index.CacheConfig 2 60
         -- Misc
         , cdbTracer           = Tracer $ \case
               ChainDB.TraceAddBlockEvent

--- a/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/Dynamic/Network.hs
@@ -327,13 +327,14 @@ runNodeNetwork registry testBtime numCoreNodes nodeJoinPlan nodeTopology
             } = nodeInfo
 
       epochInfo <- newEpochInfo $ nodeEpochSize (Proxy @blk) pInfoConfig
-      chainDB <- ChainDB.openDB $ mkArgs
-          pInfoConfig pInfoInitLedger epochInfo
-          (nodeEventsInvalids nodeInfoEvents)
-          (Tracer $ \(p, bno) -> do
-              s <- atomically $ getCurrentSlot btime
-              traceWith (nodeEventsAdds nodeInfoEvents) (s, p, bno))
-          nodeInfoDBs
+      let chainDbArgs = mkArgs
+            pInfoConfig pInfoInitLedger epochInfo
+            (nodeEventsInvalids nodeInfoEvents)
+            (Tracer $ \(p, bno) -> do
+                s <- atomically $ getCurrentSlot btime
+                traceWith (nodeEventsAdds nodeInfoEvents) (s, p, bno))
+            nodeInfoDBs
+      (chainDB, _) <- ChainDB.openDBInternal chainDbArgs True
 
       let nodeArgs = NodeArgs
             { tracers             = nullDebugTracers

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -36,8 +36,7 @@ import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.ChainDB (ChainDbArgs (..),
-                     TraceAddBlockEvent (..), addBlock, closeDB, openDB,
-                     toChain)
+                     TraceAddBlockEvent (..), addBlock, toChain, withDB)
 import qualified Ouroboros.Storage.ChainDB as ChainDB
 import           Ouroboros.Storage.Common (EpochSize (..))
 import           Ouroboros.Storage.EpochInfo (fixedSizeEpochInfo)
@@ -120,14 +119,11 @@ prop_addBlock_multiple_threads bpt =
           <*> uncheckedNewTVarM Mock.empty
         withRegistry $ \registry -> do
           let args = mkArgs cfg initLedger dynamicTracer registry hashInfo fsVars
-          db <- openDB args
-          -- Add blocks concurrently
-          mapConcurrently_ (mapM_ (addBlock db)) $ blocksPerThread bpt
-          -- Obtain the actual chain
-          chain <- toChain db
-          -- Close
-          closeDB db
-          return chain
+          withDB args $ \db -> do
+            -- Add blocks concurrently
+            mapConcurrently_ (mapM_ (addBlock db)) $ blocksPerThread bpt
+            -- Obtain the actual chain
+            toChain db
 
     -- The current chain after all the given blocks were added to a fresh
     -- model.

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -42,6 +42,7 @@ import           Ouroboros.Storage.Common (EpochSize (..))
 import           Ouroboros.Storage.EpochInfo (fixedSizeEpochInfo)
 import           Ouroboros.Storage.ImmutableDB (BinaryInfo (..), HashInfo (..),
                      ValidationPolicy (ValidateAllEpochs))
+import qualified Ouroboros.Storage.ImmutableDB.Impl.Index as Index
 import           Ouroboros.Storage.LedgerDB.DiskPolicy (defaultDiskPolicy)
 import           Ouroboros.Storage.LedgerDB.InMemory (ledgerDbDefaultParams)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
@@ -273,6 +274,7 @@ mkArgs cfg initLedger tracer registry hashInfo
     , cdbBlockchainTime   = fixedBlockchainTime maxBound
     , cdbGenesis          = return initLedger
     , cdbAddHdrEnv        = const id
+    , cdbImmDbCacheConfig = Index.CacheConfig 2 60
 
     -- Misc
     , cdbTracer           = tracer

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -10,7 +10,6 @@ module Test.Ouroboros.Storage.ChainDB.ImmDB
 
 import           Data.Proxy (Proxy (..))
 
-import           Control.Monad.Class.MonadThrow
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Control.Tracer (nullTracer)
@@ -64,13 +63,13 @@ withImmDB :: IOLike m => (ImmDB m ByronBlock -> m a) -> m a
 withImmDB k = do
     immDbFsVar <- uncheckedNewTVarM Mock.empty
     epochInfo  <- newEpochInfo $ nodeEpochSize (Proxy @ByronBlock) testCfg
-    bracket (ImmDB.openDB (mkArgs immDbFsVar epochInfo)) ImmDB.closeDB k
+    ImmDB.withImmDB (mkArgs immDbFsVar epochInfo) k
   where
     mkArgs immDbFsVar epochInfo = ImmDbArgs
       { immErr            = EH.monadCatch
       , immHasFS          = simHasFS EH.monadCatch immDbFsVar
       , immDecodeHash     = nodeDecodeHeaderHash (Proxy @ByronBlock)
-      , immDecodeHeader = nodeDecodeHeader testCfg
+      , immDecodeHeader   = nodeDecodeHeader testCfg
       , immDecodeBlock    = nodeDecodeBlock testCfg
       , immEncodeHash     = nodeEncodeHeaderHash (Proxy @ByronBlock)
       , immEncodeBlock    = nodeEncodeBlockWithInfo testCfg

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -80,6 +80,7 @@ withImmDB k = do
       , immCheckIntegrity = nodeCheckIntegrity testCfg
       , immAddHdrEnv      = nodeAddHeaderEnvelope (Proxy @ByronBlock)
       , immTracer         = nullTracer
+      , immCacheConfig    = ImmDB.CacheConfig 2 60
       }
 
 testCfg :: NodeConfig (BlockProtocol ByronBlock)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -87,6 +87,7 @@ import           Ouroboros.Storage.EpochInfo (fixedSizeEpochInfo)
 import           Ouroboros.Storage.ImmutableDB
                      (ValidationPolicy (ValidateAllEpochs))
 import qualified Ouroboros.Storage.ImmutableDB as ImmDB
+import qualified Ouroboros.Storage.ImmutableDB.Impl.Index as Index
 import           Ouroboros.Storage.LedgerDB.DiskPolicy (defaultDiskPolicy)
 import           Ouroboros.Storage.LedgerDB.InMemory (ledgerDbDefaultParams)
 import qualified Ouroboros.Storage.LedgerDB.OnDisk as LedgerDB
@@ -1371,6 +1372,7 @@ mkArgs cfg initLedger tracer registry varCurSlot
     , cdbGenesis          = return initLedger
     , cdbBlockchainTime   = settableBlockchainTime varCurSlot
     , cdbAddHdrEnv        = const id
+    , cdbImmDbCacheConfig = Index.CacheConfig 2 60
 
     -- Misc
     , cdbTracer           = tracer

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1187,6 +1187,7 @@ prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do
     test cmds = do
       threadRegistry     <- QC.run unsafeNewRegistry
       iteratorRegistry   <- QC.run unsafeNewRegistry
+      immRegistry        <- QC.run unsafeNewRegistry
       (tracer, getTrace) <- QC.run recordingTracerIORef
       varCurSlot         <- QC.run $ uncheckedNewTVarM 0
       fsVars             <- QC.run $ (,,)
@@ -1194,7 +1195,7 @@ prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do
         <*> uncheckedNewTVarM Mock.empty
         <*> uncheckedNewTVarM Mock.empty
       let args = mkArgs testCfg testInitExtLedger tracer threadRegistry varCurSlot fsVars
-      (db, internal)     <- QC.run $ openDBInternal args False
+      (db, internal)     <- QC.run $ openDBInternal immRegistry args False
       let sm' = sm db internal iteratorRegistry varCurSlot genBlk testCfg testInitExtLedger
       (hist, model, res) <- runCommands sm' cmds
       (realChain, realChain', trace, fses, remainingCleanups) <- QC.run $ do
@@ -1212,10 +1213,11 @@ prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do
         -- code path differs slightly from 'openDB', we test that code path
         -- here too by simply opening the DB from scratch again and comparing
         -- the resulting chain.
-        (db', _) <- openDBInternal args False
+        (db', _) <- openDBInternal immRegistry args False
         realChain' <- toChain db'
         closeDB db'
 
+        closeRegistry immRegistry
         closeRegistry threadRegistry
 
         -- 'closeDB' should have closed all open 'Reader's and 'Iterator's,
@@ -1388,7 +1390,7 @@ tests = testGroup "ChainDB q-s-m"
 
 -- | Debugging utility: run some commands against the real implementation.
 _runCmds :: [Cmd Blk IteratorId ReaderId] -> IO [Resp Blk IteratorId ReaderId]
-_runCmds cmds = withRegistry $ \registry -> do
+_runCmds cmds = withRegistry $ \registry -> withRegistry $ \immRegistry -> do
     varCurSlot <- uncheckedNewTVarM 0
     fsVars <- (,,)
       <$> uncheckedNewTVarM Mock.empty
@@ -1401,7 +1403,7 @@ _runCmds cmds = withRegistry $ \registry -> do
           registry
           varCurSlot
           fsVars
-    (db, internal) <- openDBInternal args False
+    (db, internal) <- openDBInternal immRegistry args False
     evalStateT (mapM (go db internal registry varCurSlot) cmds) emptyRunCmdState
   where
     go :: ChainDB IO Blk -> ChainDB.Internal IO Blk

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -26,6 +26,7 @@ import           Ouroboros.Storage.FS.API.Types
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
 
 import           Ouroboros.Storage.ImmutableDB
+import qualified Ouroboros.Storage.ImmutableDB.Impl.Index as Index
 import           Ouroboros.Storage.ImmutableDB.Impl.Index.Primary (PrimaryIndex)
 import qualified Ouroboros.Storage.ImmutableDB.Impl.Index.Primary as Primary
 import           Ouroboros.Storage.ImmutableDB.Impl.Validation
@@ -74,6 +75,7 @@ openTestDB registry hasFS err = fst <$> openDBInternal
     ValidateMostRecentEpoch
     parser
     nullTracer
+    (Index.CacheConfig 2 60)
   where
     parser = epochFileParser hasFS (const <$> S.decode) isEBB getBinaryInfo
       testBlockIsValid

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -764,12 +764,13 @@ iteratorPeekModel itID = do
 
 iteratorHasNextModel :: MonadState (DBModel hash) m
                      => IteratorID
-                     -> m Bool
+                     -> m (Maybe (Either EpochNo SlotNo, hash))
 iteratorHasNextModel itID = do
     next <- iteratorPeekModel itID
     return $ case next of
-      IteratorExhausted -> False
-      _                 -> True
+      IteratorExhausted           -> Nothing
+      IteratorEBB    epoch hash _ -> Just (Left epoch, hash)
+      IteratorResult slot  hash _ -> Just (Right slot, hash)
 
 iteratorCloseModel :: MonadState (DBModel hash) m
                    => IteratorID -> m ()

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -174,7 +174,7 @@ data Success it
   | EpochNo          EpochNo
   | Iter             (Either (WrongBoundError Hash) it)
   | IterResult       (IteratorResult Hash ByteString)
-  | IterHasNext      Bool
+  | IterHasNext      (Maybe (Either EpochNo SlotNo, Hash))
   | Tip              (ImmTipWithHash Hash)
   deriving (Eq, Show, Functor, Foldable, Traversable)
 

--- a/ouroboros-consensus/tools/db-analyse/Main.hs
+++ b/ouroboros-consensus/tools/db-analyse/Main.hs
@@ -36,7 +36,7 @@ import           Ouroboros.Consensus.Protocol.Abstract (NodeConfig)
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.ChainDB.API (BlockOrHeader (..),
-                     StreamFrom (..))
+                     StreamFrom (..), StreamTo (..))
 import           Ouroboros.Storage.ChainDB.Impl.ImmDB
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.EpochInfo
@@ -150,7 +150,10 @@ processAll :: ImmDB IO ByronBlock
            -> (Either EpochNo SlotNo -> ByronBlock -> IO ())
            -> IO ()
 processAll immDB rr callback = do
-    Right itr <- streamFrom immDB rr Block $ StreamFromExclusive genesisPoint
+    tipPoint <- getPointAtTip immDB
+    Right itr <- stream immDB rr Block
+      (StreamFromExclusive genesisPoint)
+      (StreamToInclusive tipPoint)
     go (deserialiseIterator immDB itr)
   where
     go :: Iterator ByronHash IO ByronBlock -> IO ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/7099318744ddd10b76e50eae73f005efd2c7195c/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/00487726c4bc21b4744e59d913334ebfeac7d68e/snapshot.yaml
 
 packages:
   - ./typed-transitions
@@ -49,7 +49,7 @@ extra-deps:
       - crypto/test
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 7099318744ddd10b76e50eae73f005efd2c7195c
+    commit: 00487726c4bc21b4744e59d913334ebfeac7d68e
     subdirs:
       - .
       - test


### PR DESCRIPTION
This PR drastically reduces the CPU usage while serving headers and blocks.

I went over the profiling report and optimised what I could.

The main improvement comes from the following:

> [In `ChainDB.Iterator`] we were only passing a start bound to an `ImmutableDB.Iterator`, never an end bound. We would close the iterator manually. This was fine with the old database format, as an iterator would only load a small index in memory. Now with the new database format, the whole secondary index of the epoch is loaded into memory, even if only a few blocks from it needed to be streamed.

This means that for each incoming BlockFetch request, regardless its size (in practice, the requested batches typically only contain 1 or 2 blocks), we read and parsed all secondary index entries starting from the first block to the end of the epoch (so on average, 21600/2 entries!), instead of just the necessary secondary index entries for the requested batch.

We now apply a proper end bound and also *cache the indices in memory*.

The end result is that when a "client" is syncing at 100% CPU, the "server" is only uses a few % CPU.
