### PR TITLE
VolatileDB: fix memory leak

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/VolatileDB/Util.hs
@@ -159,8 +159,15 @@ alterfDelete :: Ord blockId
              -> Maybe (Set blockId)
              -> Maybe (Set blockId)
 alterfDelete successor mSet = case mSet of
-    Nothing  -> Nothing
-    Just set -> Just $ Set.delete successor set
+    Nothing
+        -> Nothing
+    Just set
+        | Set.null set'
+        -> Nothing
+        | otherwise
+        -> Just set'
+      where
+        set' = Set.delete successor set
 
 deleteMapSet :: Ord blockId
              => SuccessorsIndex blockId


### PR DESCRIPTION
The VolatileDB maintains a number of in-memory indices among which:

    type SuccessorsIndex blockId = Map (WithOrigin blockId) (Set blockId)

During garbage collection, this index was not being culled correctly: when the last `blockId` was removed from a `Set`, the empty `Set` was kept in the `Map` instead of removing the entry altogether.