### PR TITLE
LgrDB: correctly garbage collect previously applied points

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -424,7 +424,7 @@ streamAPI immDB = StreamAPI streamAfter
 -- previously applied points.
 garbageCollectPrevApplied :: IOLike m => LgrDB m blk -> SlotNo -> STM m ()
 garbageCollectPrevApplied LgrDB{..} slotNo = modifyTVar varPrevApplied $
-    Set.filter ((< (At slotNo)) . Block.pointSlot)
+    Set.dropWhileAntitone ((< (At slotNo)) . Block.pointSlot)
 
 {-------------------------------------------------------------------------------
   Error handling


### PR DESCRIPTION
In the LgrDB, we are remembering the points of all applied (validated) blocks in a `Set` so that when we need to reapply (revalidate) those blocks, we can use a cheaper validation (update the ledger), as we already know the block itself is valid.

When performing a garbage collection for slot number `s`, we remove all points older than `s` from the `Set`, as we will not be revalidating those blocks anymore (they're older than `k`).

At least, that is what I thought I was doing. In reality, I flipped the condition of `filter`, causing the `Set` to be empty at all times.

We now use the more efficient `Set.dropWhileAntitone` (O(log n) vs O(n)), which flips the condition to garbage collect the `Set`.