### PR TITLE
ChainDB: take a ledger DB snapshot when shutting down

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
@@ -76,8 +76,9 @@ closeDB (CDBHandle varState) = do
       bgThreads <- atomically $ readTVar cdbBgThreads
       mapM_ cancelThread bgThreads
 
-      -- TODO Maybe write a 'LedgerDB' snapshot or wait until it is done.
-      -- See #367.
+      -- Write a 'LedgerDB' snapshot so that we don't have to replay too many
+      -- blocks when restarting
+      Background.updateLedgerSnapshots cdb
       ImmDB.closeDB cdbImmDB
       VolDB.closeDB cdbVolDB
 


### PR DESCRIPTION
Closes #1387.
 
When stopping a node that is in the middle of syncing, there would otherwise be no recent ledger DB snapshot, which means that a ton of blocks have to be replayed against an older ledger DB snapshot or the initial ledger at genesis. Such replays could take multiple minutes.