### PR TITLE
ChainDB: pass new block to ledger validation

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -145,6 +145,7 @@ library
                        Ouroboros.Storage.ChainDB.Impl
                        Ouroboros.Storage.ChainDB.Impl.Args
                        Ouroboros.Storage.ChainDB.Impl.Background
+                       Ouroboros.Storage.ChainDB.Impl.BlockCache
                        Ouroboros.Storage.ChainDB.Impl.BlockComponent
                        Ouroboros.Storage.ChainDB.Impl.ChainSel
                        Ouroboros.Storage.ChainDB.Impl.ImmDB

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
@@ -58,6 +58,7 @@ import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
+import qualified Ouroboros.Storage.ChainDB.Impl.BlockCache as BlockCache
 import           Ouroboros.Storage.ChainDB.Impl.ChainSel
                      (chainSelectionForBlock)
 import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
@@ -405,7 +406,7 @@ scheduledChainSelection cdb@CDB{..} curSlot = do
       -- which case, the ChainDB has to be (re)started, triggering a full
       -- chain selection, which would include these blocks. So there is no
       -- risk of "forgetting" to add a block.
-      mapM_ (chainSelectionForBlock cdb) hdrs
+      mapM_ (chainSelectionForBlock cdb BlockCache.empty) hdrs
 
 -- | Whenever the current slot changes, call 'scheduledChainSelection' for the
 -- (new) current slot.

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/BlockCache.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/BlockCache.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE FlexibleContexts #-}
+-- | Cache blocks in memory
+--
+-- Intended for qualified import.
+--
+-- > import           Ouroboros.Storage.ChainDB.Impl.BlockCache (BlockCache)
+-- > import qualified Ouroboros.Storage.ChainDB.Impl.BlockCache as BlockCache
+module Ouroboros.Storage.ChainDB.Impl.BlockCache
+  ( BlockCache -- opaque
+  , empty
+  , singleton
+  , cacheBlock
+  , lookup
+  , toHeaderOrBlock
+  ) where
+
+import           Prelude hiding (lookup)
+
+import           Data.Map (Map)
+import qualified Data.Map as Map
+
+import           Ouroboros.Network.Block (HasHeader (..), HeaderHash)
+
+import           Ouroboros.Consensus.Block (Header, headerHash)
+
+
+newtype BlockCache blk = BlockCache (Map (HeaderHash blk) blk)
+
+empty :: BlockCache blk
+empty = BlockCache Map.empty
+
+singleton :: HasHeader blk => blk -> BlockCache blk
+singleton blk = cacheBlock blk empty
+
+cacheBlock :: HasHeader blk => blk -> BlockCache blk -> BlockCache blk
+cacheBlock blk (BlockCache cache) = BlockCache (Map.insert (blockHash blk) blk cache)
+
+lookup :: HasHeader blk => HeaderHash blk -> BlockCache blk -> Maybe blk
+lookup hash (BlockCache cache) = Map.lookup hash cache
+
+toHeaderOrBlock
+  :: (HasHeader blk, HasHeader (Header blk))
+  => Header blk -> BlockCache blk -> Either (Header blk) blk
+toHeaderOrBlock hdr blockCache
+    | Just blk <- lookup (headerHash hdr) blockCache
+    = Right blk
+    | otherwise
+    = Left hdr

--- a/ouroboros-consensus/test-consensus/Test/Consensus/LocalStateQueryServer.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/LocalStateQueryServer.hs
@@ -43,6 +43,7 @@ import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util ((.:))
 import           Ouroboros.Consensus.Util.IOLike
 
+import qualified Ouroboros.Storage.ChainDB.Impl.BlockCache as BlockCache
 import qualified Ouroboros.Storage.ChainDB.Impl.LedgerCursor as LedgerCursor
 import           Ouroboros.Storage.ChainDB.Impl.LgrDB (LedgerDbParams (..),
                      LgrDB, LgrDbArgs (..), mkLgrDB)
@@ -181,7 +182,7 @@ initLgrDB k chain = do
     varDB          <- newTVarM genesisLedgerDB
     varPrevApplied <- newTVarM mempty
     let lgrDB = mkLgrDB conf varDB varPrevApplied args
-    LgrDB.validate lgrDB genesisLedgerDB 0
+    LgrDB.validate lgrDB genesisLedgerDB BlockCache.empty 0
       (map getHeader (Chain.toOldestFirst chain)) >>= \case
         LgrDB.MaximumRollbackExceeded {} ->
           error "rollback was 0"


### PR DESCRIPTION
In `ChainDB.addBlock`, we receive a new block and use it to try switch to a longer chain. This will require applying the block to the ledger, which requires reading the block from disk and parsing it again. This is right in the critical path of (bulk) chain sync.

Since we have the block in memory, we can avoid the redundant read and pass it to the validation code directly.

Note that when switching to a fork or when we can extend the new chain with more blocks after the new block, we'll still have to read blocks from disk in order to validate them, but not the new block.