### PR TITLE
[CAD-402] Adding changes to the trace events we need and removing time from them

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -305,16 +305,12 @@ data TraceEventMempool blk
       -- ^ New, valid transaction were added to the Mempool.
       !MempoolSize
       -- ^ The current size of the Mempool.
-      !Time
-      -- ^ The time at which the transactions were added.
   | TraceMempoolRejectedTxs
       ![(GenTx blk, ApplyTxErr blk)]
       -- ^ New, invalid transaction were rejected and thus not added to the
       -- Mempool.
       !MempoolSize
       -- ^ The current size of the Mempool.
-      !Time
-      -- ^ The time at which the transactions were rejected.
   | TraceMempoolRemoveTxs
       ![GenTx blk]
       -- ^ Previously valid transactions that are no longer valid because of
@@ -322,8 +318,6 @@ data TraceEventMempool blk
       -- from the Mempool.
       !MempoolSize
       -- ^ The current size of the Mempool.
-      !Time
-      -- ^ The time at which the transactions were removed.
   | TraceMempoolManuallyRemovedTxs
       ![GenTxId blk]
       -- ^ Transactions that have been manually removed from the Mempool.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -285,13 +285,9 @@ implAddTxs mpEnv accum txs = assert (all txInvariant txs) $ do
 
     let ValidationResult { vrNewValid = accepted } = vr
 
-    -- We record the time at which the transactions were added to the mempool
-    -- so we can use it in our performance measurements.
-    time <- getMonotonicTime
-
-    traceBatch TraceMempoolRemoveTxs   mempoolSize (map fst removed) time
-    traceBatch TraceMempoolAddTxs      mempoolSize accepted          time
-    traceBatch TraceMempoolRejectedTxs mempoolSize rejected          time
+    traceBatch TraceMempoolRemoveTxs   mempoolSize (map fst removed)
+    traceBatch TraceMempoolAddTxs      mempoolSize accepted
+    traceBatch TraceMempoolRejectedTxs mempoolSize rejected
 
     case unvalidated of
       -- All of the provided transactions have been validated.
@@ -307,9 +303,9 @@ implAddTxs mpEnv accum txs = assert (all txInvariant txs) $ do
       , mpEnvCapacity = MempoolCapacityBytes mempoolCap
       } = mpEnv
 
-    traceBatch mkEv size batch time
+    traceBatch mkEv size batch
       | null batch = return ()
-      | otherwise  = traceWith mpEnvTracer (mkEv batch size time)
+      | otherwise  = traceWith mpEnvTracer (mkEv batch size)
 
     mkRes acc accepted rejected =
          [(tx, Just err) | (tx, err) <- rejected]
@@ -453,8 +449,7 @@ implWithSyncState mpEnv@MempoolEnv{mpEnvTracer, mpEnvStateVar} blockSlot f = do
       res         <- f snapshot
       return (map fst vrInvalid, mempoolSize, res)
     unless (null removed) $ do
-      time <- getMonotonicTime
-      traceWith mpEnvTracer $ TraceMempoolRemoveTxs removed mempoolSize time
+      traceWith mpEnvTracer $ TraceMempoolRemoveTxs removed mempoolSize
     return res
 
 implGetSnapshot :: IOLike m

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -9,7 +9,6 @@ module Ouroboros.Consensus.Node.Tracers
   , TraceForgeEvent (..)
   ) where
 
-import           Control.Monad.Class.MonadTime (Time)
 import           Control.Tracer (Tracer, nullTracer, showTracing)
 
 import           Ouroboros.Network.Block (Point, SlotNo)
@@ -119,8 +118,8 @@ data TraceForgeEvent blk tx
   | TraceCouldNotForge SlotNo AnachronyFailure
 
   -- | We adopted the block we produced, we also trace the transactions
-  -- and the time the block with the transactions was adopted.
-  | TraceAdoptedBlock SlotNo blk [tx] Time
+  -- that were adopted.
+  | TraceAdoptedBlock SlotNo blk [tx]
 
   -- | We did not adopt the block we produced, but the block was valid. We
   -- must have adopted a block that another leader of the same slot produced

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -368,11 +368,7 @@ forkBlockProduction maxBlockBodySize IS{..} BlockProduction{..} =
           -- Check whether we adopted our block
           curTip <- atomically $ ChainDB.getTipPoint chainDB
           if curTip == blockPoint newBlock then do
-            -- We measure the time directly.
-            -- We could also measure it when collecting the trace events, but this
-            -- is much more precise.
-            time <- getMonotonicTime
-            trace $ TraceAdoptedBlock currentSlot newBlock txs time
+            trace $ TraceAdoptedBlock currentSlot newBlock txs
           else do
             isInvalid <- atomically $
               ($ blockHash newBlock) . forgetFingerprint <$>
@@ -392,6 +388,7 @@ forkBlockProduction maxBlockBodySize IS{..} BlockProduction{..} =
                 -- process.
                 removeTxs mempool (map txId txs)
   where
+    trace :: TraceForgeEvent blk (GenTx blk) -> m ()
     trace = traceWith (forgeTracer tracers)
 
     -- Return the point and block number of the most recent block in the


### PR DESCRIPTION
https://jira.iohk.io/browse/CAD-402

Let me just copy the description from there:
```
The current issue (https://jira.iohk.io/browse/CAD-314) was measuring too much.

We need to start the micro benchmarking from small and precise steps, the opposite that I started with.

A good initial microbenchmark would be the time it takes for the block to be forged during the slot the leader is producing a block.
```