### PR TITLE
Generalize forgeBlock

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
@@ -31,12 +31,14 @@ import           Cardano.Crypto.DSIGN
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Crypto.DSIGN.Cardano
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Byron.Auxiliary
 import           Ouroboros.Consensus.Ledger.Byron.Block
 import           Ouroboros.Consensus.Ledger.Byron.Config
 import           Ouroboros.Consensus.Ledger.Byron.ContainsGenesis
 import           Ouroboros.Consensus.Ledger.Byron.Mempool
 import           Ouroboros.Consensus.Ledger.Byron.PBFT
+import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.PBFT
 
@@ -48,7 +50,7 @@ forgeByronBlock
   => NodeConfig ByronConsensusProtocol
   -> SlotNo                          -- ^ Current slot
   -> BlockNo                         -- ^ Current block number
-  -> ChainHash ByronBlock            -- ^ Previous hash
+  -> ExtLedgerState ByronBlock       -- ^ Ledger
   -> [GenTx ByronBlock]              -- ^ Txs to add in the block
   -> PBftIsLeader PBftCardanoCrypto  -- ^ Leader proof ('IsLeader')
   -> m ByronBlock
@@ -130,11 +132,11 @@ forgeRegularBlock
   => NodeConfig ByronConsensusProtocol
   -> SlotNo                            -- ^ Current slot
   -> BlockNo                           -- ^ Current block number
-  -> ChainHash ByronBlock              -- ^ Previous hash
+  -> ExtLedgerState ByronBlock         -- ^ Ledger
   -> [GenTx ByronBlock]                -- ^ Txs to add in the block
   -> PBftIsLeader PBftCardanoCrypto    -- ^ Leader proof ('IsLeader')
   -> m ByronBlock
-forgeRegularBlock cfg curSlot curNo prevHash txs isLeader = do
+forgeRegularBlock cfg curSlot curNo extLedger txs isLeader = do
     ouroborosPayload <-
       forgePBftFields cfg isLeader (reAnnotate $ Annotated toSign ())
     return $ forge ouroborosPayload
@@ -189,7 +191,7 @@ forgeRegularBlock cfg curSlot curNo prevHash txs isLeader = do
     proof = CC.Block.mkProof body
 
     prevHeaderHash :: CC.Block.HeaderHash
-    prevHeaderHash = case prevHash of
+    prevHeaderHash = case ledgerTipHash (ledgerState extLedger) of
       GenesisHash             -> error
         "the first block on the Byron chain must be an EBB"
       BlockHash (ByronHash h) -> h

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
@@ -18,8 +18,7 @@ import           Data.Word (Word32)
 
 import           Cardano.Crypto (ProtocolMagicId)
 
-import           Ouroboros.Network.Block (BlockNo, ChainHash (..), HeaderHash,
-                     SlotNo)
+import           Ouroboros.Network.Block (BlockNo, HeaderHash, SlotNo)
 import           Ouroboros.Network.BlockFetch (SizeInBytes)
 import           Ouroboros.Network.Magic (NetworkMagic)
 
@@ -27,6 +26,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime (SystemStart)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Byron
+import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.IOLike (IOLike)
@@ -39,10 +39,10 @@ class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
 
   nodeForgeBlock          :: (HasNodeState (BlockProtocol blk) m, MonadRandom m)
                           => NodeConfig (BlockProtocol blk)
-                          -> SlotNo         -- ^ Current slot
-                          -> BlockNo        -- ^ Current block number
-                          -> ChainHash blk  -- ^ Previous hash
-                          -> [GenTx blk]    -- ^ Txs to add in the block
+                          -> SlotNo              -- ^ Current slot
+                          -> BlockNo             -- ^ Current block number
+                          -> ExtLedgerState blk  -- ^ Current ledger
+                          -> [GenTx blk]         -- ^ Txs to add in the block
                           -> IsLeader (BlockProtocol blk)
                           -> m blk
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -111,7 +111,6 @@ data BlockProduction m blk = BlockProduction {
       produceBlock :: IsLeader (BlockProtocol blk) -- Proof we are leader
                    -> ExtLedgerState blk -- Current ledger state
                    -> SlotNo             -- Current slot
-                   -> Point blk          -- Previous point
                    -> BlockNo            -- Previous block number
                    -> [GenTx blk]        -- Contents of the mempool
                    -> ProtocolM blk m blk
@@ -394,7 +393,6 @@ forkBlockProduction maxBlockSizeOverride IS{..} BlockProduction{..} =
             proof
             extLedger
             currentSlot
-            prevPoint
             prevNo
             txs
         trace $ TraceForgedBlock

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -108,11 +108,11 @@ data BlockProduction m blk = BlockProduction {
       -- (also provided as an argument) and with each other (when applied in
       -- order). In principle /all/ of them could be included in the block (up
       -- to maximum block size).
-      produceBlock :: IsLeader (BlockProtocol blk) -- Proof we are leader
+      produceBlock :: SlotNo             -- Current slot
+                   -> BlockNo            -- Current block number
                    -> ExtLedgerState blk -- Current ledger state
-                   -> SlotNo             -- Current slot
-                   -> BlockNo            -- Previous block number
                    -> [GenTx blk]        -- Contents of the mempool
+                   -> IsLeader (BlockProtocol blk) -- Proof we are leader
                    -> ProtocolM blk m blk
 
       -- | Produce a random seed
@@ -390,11 +390,11 @@ forkBlockProduction maxBlockSizeOverride IS{..} BlockProduction{..} =
         -- Actually produce the block
         newBlock <- lift $ atomically $ runProtocol varDRG $
           produceBlock
-            proof
-            extLedger
             currentSlot
-            prevNo
+            (succ prevNo)
+            extLedger
             txs
+            proof
         trace $ TraceForgedBlock
                   currentSlot
                   newBlock

--- a/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
@@ -393,18 +393,8 @@ runThreadNetwork ThreadNetworkArgs
 
       let blockProduction :: BlockProduction m blk
           blockProduction = BlockProduction {
-              produceBlock = \proof extLedger slot prevNo txs -> do
-                let curNo :: BlockNo
-                    curNo = succ prevNo
-
-                nodeForgeBlock pInfoConfig
-                               slot
-                               curNo
-                               extLedger
-                               txs
-                               proof
-
-            , produceDRG      = atomically $ simChaChaT varRNG id $ drgNew
+              produceBlock = nodeForgeBlock pInfoConfig
+            , produceDRG   = atomically $ simChaChaT varRNG id $ drgNew
             }
 
       (nodeInfo, readNodeInfo) <- newNodeInfo

--- a/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
@@ -393,17 +393,14 @@ runThreadNetwork ThreadNetworkArgs
 
       let blockProduction :: BlockProduction m blk
           blockProduction = BlockProduction {
-              produceBlock = \proof _l slot prevPoint prevNo txs -> do
+              produceBlock = \proof extLedger slot prevNo txs -> do
                 let curNo :: BlockNo
                     curNo = succ prevNo
-
-                let prevHash :: ChainHash blk
-                    prevHash = castHash (pointHash prevPoint)
 
                 nodeForgeBlock pInfoConfig
                                slot
                                curNo
-                               prevHash
+                               extLedger
                                txs
                                proof
 


### PR DESCRIPTION
Make sure that block production gets the current ledger state as
argument, rather than just the previous block number.

Closes #1439.