### PR TITLE
Introduce `getSnapshotFor` in the mempool

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -218,7 +218,17 @@ data Mempool m blk idx = Mempool {
 
       -- | Get a snapshot of the current mempool state. This allows for
       -- further pure queries on the snapshot.
+      --
+      -- This doesn't look at the ledger state at all.
     , getSnapshot   :: STM m (MempoolSnapshot blk idx)
+
+      -- | Get a snapshot of the mempool state that is valid with respect to
+      -- the given ledger state
+      --
+      -- This does not update the state of the mempool.
+    , getSnapshotFor :: BlockSlot
+                     -> LedgerState blk
+                     -> STM m (MempoolSnapshot blk idx)
 
       -- | Represents the initial value at which the transaction ticket number
       -- counter will start (i.e. the zeroth ticket number).

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -191,19 +191,6 @@ data Mempool m blk idx = Mempool {
       -- invalid with respect to the current ledger state, will be dropped
       -- from the mempool, whereas valid transactions will remain.
       --
-      -- The given function will be applied to a snapshot of the mempool that
-      -- is in sync with the current ledger state. This function will be
-      -- executed in the same 'STM' transaction that performs the
-      -- synchronisation. The main use case for this is a function that
-      -- produces a block containing the valid transactions in the mempool
-      -- snapshot.
-      --
-      -- Using this approach, we avoid the following race condition: the
-      -- current ledger state changes while we're producing a block, which
-      -- means that some of the transactions in the new block might no longer
-      -- be valid with respect to the current ledger state. Consequently, we
-      -- produce an invalid block, wasting our leadership slot.
-      --
       -- We keep this in @m@ instead of @STM m@ to leave open the possibility
       -- of persistence. Additionally, this makes it possible to trace the
       -- removal of invalid transactions.
@@ -211,10 +198,7 @@ data Mempool m blk idx = Mempool {
       -- n.b. in our current implementation, when one opens a mempool, we
       -- spawn a thread which performs this action whenever the 'ChainDB' tip
       -- point changes.
-    , withSyncState :: forall a.
-                       BlockSlot
-                    -> (MempoolSnapshot blk idx -> STM m a)
-                    -> m a
+    , syncWithLedger :: m (MempoolSnapshot blk idx)
 
       -- | Get a snapshot of the current mempool state. This allows for
       -- further pure queries on the snapshot.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -81,11 +81,12 @@ openMempoolWithoutSyncThread ledger cfg capacity tracer =
 mkMempool :: (IOLike m, ApplyTx blk)
           => MempoolEnv m blk -> Mempool m blk TicketNo
 mkMempool env = Mempool
-    { addTxs        = implAddTxs env []
-    , removeTxs     = implRemoveTxs env
-    , withSyncState = implWithSyncState env
-    , getSnapshot   = implGetSnapshot env
-    , zeroIdx       = zeroTicketNo
+    { addTxs         = implAddTxs         env []
+    , removeTxs      = implRemoveTxs      env
+    , withSyncState  = implWithSyncState  env
+    , getSnapshot    = implGetSnapshot    env
+    , getSnapshotFor = implGetSnapshotFor env
+    , zeroIdx        = zeroTicketNo
     }
 
 -- | Abstract interface needed to run a Mempool.
@@ -244,12 +245,8 @@ implAddTxs mpEnv accum txs = assert (all txInvariant txs) $ do
       IS{isTip = initialISTip} <- readTVar mpEnvStateVar
 
       -- First sync the state, which might remove some transactions
-      syncRes@ValidationResult
-        { vrBefore
-        , vrValid
-        , vrInvalid = removed
-        , vrLastTicketNo
-        } <- validateIS mpEnv TxsForUnknownBlock
+      syncRes <- validateIS mpEnv TxsForUnknownBlock
+      let removed = vrInvalid syncRes
 
       -- Determine whether the tip was updated after a call to 'validateIS'
       --
@@ -262,16 +259,13 @@ implAddTxs mpEnv accum txs = assert (all txInvariant txs) $ do
       -- about losing any changes in the event that we have to 'retry' this
       -- STM transaction. So we should continue by validating the provided new
       -- transactions.
-      if initialISTip /= vrBefore
+      if initialISTip /= vrBefore syncRes
         then do
           -- The tip changed.
           -- Because 'validateNew' can 'retry', we'll commit this STM
           -- transaction here to ensure that we don't lose any of the changes
           -- brought about by 'validateIS' thus far.
-          writeTVar mpEnvStateVar IS { isTxs          = vrValid
-                                     , isTip          = vrBefore
-                                     , isLastTicketNo = vrLastTicketNo
-                                     }
+          writeTVar mpEnvStateVar $ internalStateFromVR syncRes
           mempoolSize <- getMempoolSize mpEnv
           pure (syncRes, removed, [], txs, mempoolSize)
         else do
@@ -283,7 +277,7 @@ implAddTxs mpEnv accum txs = assert (all txInvariant txs) $ do
           mempoolSize       <- getMempoolSize mpEnv
           pure (vr, removed, vrInvalid vr, unvalidated, mempoolSize)
 
-    let ValidationResult { vrNewValid = accepted } = vr
+    let accepted = vrNewValid vr
 
     traceBatch TraceMempoolRemoveTxs   mempoolSize (map fst removed)
     traceBatch TraceMempoolAddTxs      mempoolSize accepted
@@ -403,21 +397,11 @@ implRemoveTxs mpEnv@MempoolEnv{mpEnvTracer, mpEnvStateVar} txIds = do
             (\TxTicket { txTicketTx } -> txId txTicketTx `notElem` toRemove)
             isTxs
         }
-      -- TODO some duplication with 'implWithSyncState'
-      ValidationResult
-        { vrBefore
-        , vrValid
-        , vrInvalid
-        , vrLastTicketNo
-        } <- validateIS mpEnv TxsForUnknownBlock
-      writeTVar mpEnvStateVar IS
-        { isTxs          = vrValid
-        , isTip          = vrBefore
-        , isLastTicketNo = vrLastTicketNo
-        }
+      vr <- validateIS mpEnv TxsForUnknownBlock
+      writeTVar mpEnvStateVar $ internalStateFromVR vr
       -- The size of the mempool /after/ manually removing the transactions.
       mempoolSize <- getMempoolSize mpEnv
-      return (map fst vrInvalid, mempoolSize)
+      return (map fst (vrInvalid vr), mempoolSize)
     unless (null txIds) $
       traceWith mpEnvTracer $
         TraceMempoolManuallyRemovedTxs txIds removed mempoolSize
@@ -432,22 +416,13 @@ implWithSyncState
   -> m a
 implWithSyncState mpEnv@MempoolEnv{mpEnvTracer, mpEnvStateVar} blockSlot f = do
     (removed, mempoolSize, res) <- atomically $ do
-      ValidationResult
-        { vrBefore
-        , vrValid
-        , vrInvalid
-        , vrLastTicketNo
-        } <- validateIS mpEnv blockSlot
-      writeTVar mpEnvStateVar IS
-        { isTxs          = vrValid
-        , isTip          = vrBefore
-        , isLastTicketNo = vrLastTicketNo
-        }
+      vr <- validateIS mpEnv blockSlot
+      writeTVar mpEnvStateVar (internalStateFromVR vr)
       -- The size of the mempool /after/ removing invalid transactions.
       mempoolSize <- getMempoolSize mpEnv
       snapshot    <- implGetSnapshot mpEnv
       res         <- f snapshot
-      return (map fst vrInvalid, mempoolSize, res)
+      return (map fst (vrInvalid vr), mempoolSize, res)
     unless (null removed) $ do
       traceWith mpEnvTracer $ TraceMempoolRemoveTxs removed mempoolSize
     return res
@@ -455,15 +430,23 @@ implWithSyncState mpEnv@MempoolEnv{mpEnvTracer, mpEnvStateVar} blockSlot f = do
 implGetSnapshot :: (IOLike m, ApplyTx blk)
                 => MempoolEnv m blk
                 -> STM m (MempoolSnapshot blk TicketNo)
-implGetSnapshot MempoolEnv{mpEnvStateVar} = do
-  is <- readTVar mpEnvStateVar
-  pure MempoolSnapshot
-    { snapshotTxs         = implSnapshotGetTxs         is
-    , snapshotTxsAfter    = implSnapshotGetTxsAfter    is
-    , snapshotTxsForSize  = implSnapshotGetTxsForSize  is
-    , snapshotLookupTx    = implSnapshotGetTx          is
-    , snapshotMempoolSize = implSnapshotGetMempoolSize is
-    }
+implGetSnapshot MempoolEnv{mpEnvStateVar} =
+    implSnapshotFromIS <$> readTVar mpEnvStateVar
+
+implGetSnapshotFor :: forall m blk. (IOLike m, ApplyTx blk)
+                   => MempoolEnv m blk
+                   -> BlockSlot
+                   -> LedgerState blk
+                   -> STM m (MempoolSnapshot blk TicketNo)
+implGetSnapshotFor MempoolEnv{mpEnvStateVar, mpEnvLedgerCfg}
+                   blockSlot ledger =
+    updatedSnapshot <$> readTVar mpEnvStateVar
+  where
+    updatedSnapshot :: InternalState blk -> MempoolSnapshot blk TicketNo
+    updatedSnapshot =
+          implSnapshotFromIS
+        . internalStateFromVR
+        . validateStateFor mpEnvLedgerCfg blockSlot ledger
 
 -- | Return the number of transactions in the Mempool paired with their total
 -- size in bytes.
@@ -484,6 +467,16 @@ txsToMempoolSize = foldMap toMempoolSize
 {-------------------------------------------------------------------------------
   MempoolSnapshot Implementation
 -------------------------------------------------------------------------------}
+
+implSnapshotFromIS :: ApplyTx blk
+                   => InternalState blk -> MempoolSnapshot blk TicketNo
+implSnapshotFromIS is = MempoolSnapshot {
+      snapshotTxs         = implSnapshotGetTxs         is
+    , snapshotTxsAfter    = implSnapshotGetTxsAfter    is
+    , snapshotTxsForSize  = implSnapshotGetTxsForSize  is
+    , snapshotLookupTx    = implSnapshotGetTx          is
+    , snapshotMempoolSize = implSnapshotGetMempoolSize is
+    }
 
 implSnapshotGetTxs :: InternalState blk
                    -> [(GenTx blk, TicketNo)]
@@ -549,6 +542,19 @@ data ValidationResult blk = ValidationResult {
     -- be affected.
   , vrLastTicketNo :: TicketNo
   }
+
+-- | Construct internal state from 'ValidationResult'
+--
+-- Discards information about invalid and newly valid transactions
+internalStateFromVR :: ValidationResult blk -> InternalState blk
+internalStateFromVR ValidationResult { vrBefore
+                                     , vrValid
+                                     , vrLastTicketNo
+                                     } = IS {
+      isTxs          = vrValid
+    , isTip          = vrBefore
+    , isLastTicketNo = vrLastTicketNo
+    }
 
 -- | Initialize 'ValidationResult' from a ledger state and a list of
 -- transactions /known/ to be valid in that ledger state
@@ -622,32 +628,39 @@ extendVRNew cfg tx
 
 -- | Validate internal state
 validateIS :: forall m blk. (IOLike m, ApplyTx blk)
-           => MempoolEnv m blk -> BlockSlot -> STM m (ValidationResult blk)
+           => MempoolEnv m blk
+           -> BlockSlot
+           -> STM m (ValidationResult blk)
 validateIS MempoolEnv{mpEnvLedger, mpEnvLedgerCfg, mpEnvStateVar} blockSlot =
-    go <$> getCurrentLedgerState mpEnvLedger
-       <*> readTVar mpEnvStateVar
-  where
-    go :: LedgerState      blk
-       -> InternalState    blk
-       -> ValidationResult blk
-    go st IS{isTxs, isTip, isLastTicketNo}
-        | ledgerTipHash (getTickedLedgerState st') == isTip
-        = initVR mpEnvLedgerCfg isTxs st' isLastTicketNo
-        | otherwise
-        = repeatedly (extendVRPrevApplied mpEnvLedgerCfg) (fromTxSeq isTxs)
-        $ initVR mpEnvLedgerCfg TxSeq.Empty st' isLastTicketNo
-      where
-        st' :: TickedLedgerState blk
-        st' = applyChainTick mpEnvLedgerCfg slot st
+    validateStateFor mpEnvLedgerCfg blockSlot
+      <$> getCurrentLedgerState mpEnvLedger
+      <*> readTVar mpEnvStateVar
 
-        -- If we don't yet know the slot number, optimistically assume that they
-        -- will be included in a block in the next available slot
-        slot :: SlotNo
-        slot = case blockSlot of
-                 TxsForBlockInSlot s -> s
-                 TxsForUnknownBlock  ->
-                   case ledgerTipSlot st of
-                     -- TODO: 'genesisSlotNo' is badly named. This is the slot
-                     -- number of the first real block.
-                     Origin -> Block.genesisSlotNo
-                     At s   -> succ s
+-- | Validate internal state given specific ledger
+validateStateFor :: forall blk. ApplyTx blk
+                 => LedgerConfig     blk
+                 -> BlockSlot
+                 -> LedgerState      blk
+                 -> InternalState    blk
+                 -> ValidationResult blk
+validateStateFor cfg blockSlot st IS{isTxs, isTip, isLastTicketNo}
+  | ledgerTipHash (getTickedLedgerState st') == isTip
+  = initVR cfg isTxs st' isLastTicketNo
+  | otherwise
+  = repeatedly (extendVRPrevApplied cfg) (fromTxSeq isTxs)
+  $ initVR cfg TxSeq.Empty st' isLastTicketNo
+  where
+    st' :: TickedLedgerState blk
+    st' = applyChainTick cfg slot st
+
+    -- If we don't yet know the slot number, optimistically assume that they
+    -- will be included in a block in the next available slot
+    slot :: SlotNo
+    slot = case blockSlot of
+             TxsForBlockInSlot s -> s
+             TxsForUnknownBlock  ->
+               case ledgerTipSlot st of
+                 -- TODO: 'genesisSlotNo' is badly named. This is the slot
+                 -- number of the first real block.
+                 Origin -> Block.genesisSlotNo
+                 At s   -> succ s

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -10,6 +10,7 @@ module Test.Consensus.Mempool (tests) where
 
 import           Control.Exception (assert)
 import           Control.Monad (foldM, forM, forM_, unless, void)
+import           Control.Monad.Class.MonadTime (Time (..))
 import           Control.Monad.Except (Except, runExcept)
 import           Control.Monad.State (State, evalState, get, modify)
 import           Data.List (find, foldl', isSuffixOf, nub, sort)
@@ -272,7 +273,7 @@ prop_Mempool_Capacity mcts = withTestMempool mctsTestSetup $
     updateLedger env testMempool txs = do
       let TestMempool{ mempool, addTxsToLedger } = testMempool
           MempoolCapTestEnv{ mctEnvRemovedTxs }  = env
-          Mempool{ getSnapshot, withSyncState }  = mempool
+          Mempool{ getSnapshot, syncWithLedger } = mempool
 
       envRemoved <- atomically (readTVar mctEnvRemovedTxs)
       assert (envRemoved <= length txs) $
@@ -291,7 +292,7 @@ prop_Mempool_Capacity mcts = withTestMempool mctsTestSetup $
           -- Sync the mempool with the ledger.
           -- Now all of the transactions in the mempool should have been
           -- removed.
-          withSyncState TxsForUnknownBlock (const (return ()))
+          void $ syncWithLedger
 
           -- Indicate that we've removed the transactions from the mempool.
           atomically $ do
@@ -366,7 +367,7 @@ prop_Mempool_TraceRemovedTxs :: TestSetup -> Property
 prop_Mempool_TraceRemovedTxs setup =
     withTestMempool setup $ \testMempool -> do
       let TestMempool { mempool, getTraceEvents, addTxsToLedger } = testMempool
-          Mempool { getSnapshot, withSyncState } = mempool
+          Mempool { getSnapshot, syncWithLedger } = mempool
       MempoolSnapshot { snapshotTxs } <- atomically getSnapshot
       -- We add all the transactions in the mempool to the ledger.
       let txsInMempool = map fst snapshotTxs
@@ -374,7 +375,7 @@ prop_Mempool_TraceRemovedTxs setup =
 
       -- Sync the mempool with the ledger. Now all of the transactions in the
       -- mempool should have been removed.
-      withSyncState TxsForUnknownBlock (const (return ()))
+      void $ syncWithLedger
 
       evs  <- getTraceEvents
       -- Also check that 'addTxsToLedger' never resulted in an error.
@@ -1092,7 +1093,7 @@ executeAction testMempool action = case action of
     RemoveTx tx -> do
       void $ atomically $ addTxsToLedger [tx]
       -- Synchronise the Mempool with the updated chain
-      withSyncState TxsForUnknownBlock $ \_snapshot -> return ()
+      void $ syncWithLedger
       expectTraceEvent $ \case
         TraceMempoolRemoveTxs [TestGenTx tx'] _
           | tx == tx'
@@ -1105,7 +1106,7 @@ executeAction testMempool action = case action of
       , getTraceEvents
       , addTxsToLedger
       } = testMempool
-    Mempool { addTxs, withSyncState } = mempool
+    Mempool { addTxs, syncWithLedger } = mempool
 
     expectTraceEvent :: (TraceEventMempool TestBlock -> Property) -> m Property
     expectTraceEvent checker = do
@@ -1118,12 +1119,12 @@ executeAction testMempool action = case action of
 
 currentTicketAssignment :: IOLike m
                         => Mempool m TestBlock TicketNo -> m TicketAssignment
-currentTicketAssignment Mempool { withSyncState } =
-    withSyncState TxsForUnknownBlock $ \MempoolSnapshot { snapshotTxs } ->
-      return $ Map.fromList
-        [ (ticketNo, testTxId (unTestGenTx tx))
-        | (tx, ticketNo) <- snapshotTxs
-        ]
+currentTicketAssignment Mempool { syncWithLedger } = do
+    MempoolSnapshot { snapshotTxs } <- syncWithLedger
+    return $ Map.fromList
+      [ (ticketNo, testTxId (unTestGenTx tx))
+      | (tx, ticketNo) <- snapshotTxs
+      ]
 
 instance Arbitrary Actions where
   arbitrary = sized $ \n -> do

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -10,7 +10,6 @@ module Test.Consensus.Mempool (tests) where
 
 import           Control.Exception (assert)
 import           Control.Monad (foldM, forM, forM_, unless, void)
-import           Control.Monad.Class.MonadTime (Time (..))
 import           Control.Monad.Except (Except, runExcept)
 import           Control.Monad.State (State, evalState, get, modify)
 import           Data.List (find, foldl', isSuffixOf, nub, sort)


### PR DESCRIPTION
This also enables us to simplify the mempool API, replacing `withSyncState` with simply `syncWIthLedger`. 

Closes #1438.