### PR TITLE
Move EpochNo and EpochInfo to cardano-slotting.

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -16,9 +16,8 @@ import           Control.Monad.Trans
 import           Crypto.Random
 import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
-import           Data.Hashable (Hashable)
-import           Data.HashPSQ (HashPSQ)
-import qualified Data.HashPSQ as PSQ
+import           Data.IntPSQ (IntPSQ)
+import qualified Data.IntPSQ as PSQ
 
 import           Control.Tracer (Tracer)
 
@@ -90,14 +89,11 @@ instance (NoUnexpectedThunks k, NoUnexpectedThunks v)
   whnfNoUnexpectedThunks ctxt = noUnexpectedThunksInKeysAndValues ctxt
                               . Bimap.toList
 
-instance ( NoUnexpectedThunks k
-         , NoUnexpectedThunks p
+instance ( NoUnexpectedThunks p
          , NoUnexpectedThunks v
-         , Hashable k
-         , Ord k
          , Ord p
-         ) => NoUnexpectedThunks (HashPSQ k p v) where
-  showTypeOf _ = "HashPSQ"
+         ) => NoUnexpectedThunks (IntPSQ p v) where
+  showTypeOf _ = "IntPSQ"
   whnfNoUnexpectedThunks ctxt = allNoUnexpectedThunks
                               . concatMap (\(k, p, v) ->
                                 [ noUnexpectedThunks ctxt k

--- a/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
@@ -20,34 +20,20 @@ module Ouroboros.Storage.Common (
   , BinaryInfo (..)
   ) where
 
-import           Cardano.Binary (ToCBOR (..))
 import           Codec.CBOR.Decoding (Decoder)
 import qualified Codec.CBOR.Decoding as Dec
 import           Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as Enc
 import           Codec.Serialise (Serialise (..))
-import           Data.Hashable (Hashable)
 import           Data.Word
 import           GHC.Generics
 
 import           Cardano.Prelude (NoUnexpectedThunks)
+import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..))
 
 import           Ouroboros.Network.Block (Point, genesisPoint)
 
 import           Ouroboros.Consensus.Util.Condense
-
-{-------------------------------------------------------------------------------
-  Epochs
--------------------------------------------------------------------------------}
-
--- | An epoch, i.e. the number of the epoch.
-newtype EpochNo = EpochNo { unEpochNo :: Word64 }
-  deriving stock (Eq, Ord, Show, Generic)
-  deriving newtype (Enum, Num, Serialise, ToCBOR, NoUnexpectedThunks, Hashable)
-
-newtype EpochSize = EpochSize { unEpochSize :: Word64 }
-  deriving stock (Eq, Ord, Show, Generic)
-  deriving newtype (Enum, Num, Real, Integral, NoUnexpectedThunks)
 
 {-------------------------------------------------------------------------------
   Indexing


### PR DESCRIPTION
We also chance the DB cache to use an IntPSQ rather than a HashPSQ.
The `EpochNo` type in cardano-slotting does not have a Hashable
instance, and we don't need one in this case.

Note that since we are using the EpochNo as an integer only as a key for
lookup, the Word64-Int64 conversion is fine on a 64-bit platform. On a
32 bit platform, we maybe have to worry in a few million years, unless
we use much smaller epochs.