### PR TITLE
Add ability to get past ledger states

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -605,7 +605,7 @@ data ChainDbFailure =
     --
     -- Same as 'ImmDbMissingBlock', but we only know the 'Point' of the block.
   | forall blk. (Typeable blk, StandardHash blk) =>
-      ImmDbMissingBlockPoint (Point blk)
+      ImmDbMissingBlockPoint (Point blk) CallStack
 
     -- | We requested an iterator that was immediately exhausted
     --

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -605,7 +605,7 @@ data ChainDbFailure =
     --
     -- Same as 'ImmDbMissingBlock', but we only know the 'Point' of the block.
   | forall blk. (Typeable blk, StandardHash blk) =>
-      ImmDbMissingBlockPoint (Point blk) CallStack
+      ImmDbMissingBlockPoint (Point blk) (UnknownRange blk) CallStack
 
     -- | We requested an iterator that was immediately exhausted
     --

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -149,6 +149,16 @@ data ChainDB m blk = ChainDB {
       -- | Get current ledger
     , getCurrentLedger   :: STM m (ExtLedgerState blk)
 
+      -- | Get past ledger
+      --
+      -- This cannot live in STM, because the ledger DB does not store all
+      -- ledger snapshots, and so getting a past ledger DB may involve reading
+      -- from disk.
+      --
+      -- Requests for ledger states for points not on the current chain, or for
+      -- points older than @k@, will return 'Nothing'.
+    , getPastLedger      :: Point blk -> m (Maybe (ExtLedgerState blk))
+
       -- | Get block at the tip of the chain, if one exists
       --
       -- Returns 'Nothing' if the database is empty.

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -605,7 +605,10 @@ data ChainDbFailure =
     --
     -- Same as 'ImmDbMissingBlock', but we only know the 'Point' of the block.
   | forall blk. (Typeable blk, StandardHash blk) =>
-      ImmDbMissingBlockPoint (Point blk) (UnknownRange blk) CallStack
+      ImmDbMissingBlockPoint
+        (Point blk)
+        (ImmDB.WrongBoundError (HeaderHash blk))
+        CallStack
 
     -- | We requested an iterator that was immediately exhausted
     --

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -165,6 +165,7 @@ openDBInternal args launchBgTasks = do
           { addBlock           = getEnv1    h ChainSel.addBlock
           , getCurrentChain    = getEnvSTM  h Query.getCurrentChain
           , getCurrentLedger   = getEnvSTM  h Query.getCurrentLedger
+          , getPastLedger      = getEnv1    h Query.getPastLedger
           , getTipBlock        = getEnv     h Query.getTipBlock
           , getTipHeader       = getEnv     h Query.getTipHeader
           , getTipPoint        = getEnvSTM  h Query.getTipPoint

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -22,6 +22,7 @@ module Ouroboros.Storage.ChainDB.Impl (
     -- * Internals for testing purposes
   , openDBInternal
   , Internal (..)
+  , intReopen
   ) where
 
 import           Control.Monad (when)
@@ -179,7 +180,7 @@ openDBInternal args launchBgTasks = do
           , isOpen             = Reopen.isOpen  h
           }
         testing = Internal
-          { intReopen                  = Reopen.reopen  h
+          { intReopen_                 = Reopen.reopen  h
           , intCopyToImmDB             = getEnv  h Background.copyToImmDB
           , intGarbageCollect          = getEnv1 h Background.garbageCollect
           , intUpdateLedgerSnapshots   = getEnv  h Background.updateLedgerSnapshots

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -70,7 +70,7 @@ import           Control.Tracer (Tracer, nullTracer)
 import           Data.Bifunctor (second)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Functor (($>), (<&>))
-import           GHC.Stack (HasCallStack)
+import           GHC.Stack
 import           System.FilePath ((</>))
 
 import           Cardano.Prelude (allNoUnexpectedThunks)
@@ -648,7 +648,7 @@ stream db registry blockOrHeader from to = runExceptT $ do
 -- PRECONDITION: the exclusive lower bound is part of the ImmutableDB, if not,
 -- 'ImmDbMissingBlockPoint' is thrown.
 streamAfter
-  :: forall m blk b. (IOLike m, HasHeader blk)
+  :: forall m blk b. (IOLike m, HasHeader blk, HasCallStack)
   => ImmDB m blk
   -> ResourceRegistry m
   -> BlockOrHeader blk b
@@ -656,7 +656,7 @@ streamAfter
   -> m (Iterator (HeaderHash blk) m (Deserialisable m blk b))
 streamAfter db registry blockOrHeader low =
     registeredStream db registry blockOrHeader low' Nothing >>= \case
-      Left  _   -> throwM $ ImmDbMissingBlockPoint low
+      Left  _   -> throwM $ ImmDbMissingBlockPoint low callStack
       Right itr -> do
         case low of
           GenesisPoint           -> return ()

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -656,7 +656,7 @@ streamAfter
   -> m (Iterator (HeaderHash blk) m (Deserialisable m blk b))
 streamAfter db registry blockOrHeader low =
     registeredStream db registry blockOrHeader low' Nothing >>= \case
-      Left  _   -> throwM $ ImmDbMissingBlockPoint low callStack
+      Left  err -> throwM $ ImmDbMissingBlockPoint low err callStack
       Right itr -> do
         case low of
           GenesisPoint           -> return ()

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -31,6 +31,7 @@ module Ouroboros.Storage.ChainDB.Impl.LgrDB (
   , getCurrent
   , setCurrent
   , getCurrentState
+  , getPastState
   , currentPoint
   , takeSnapshot
   , trimSnapshots
@@ -318,6 +319,11 @@ getCurrent LgrDB{..} = readTVar varDB
 
 getCurrentState :: IOLike m => LgrDB m blk -> STM m (ExtLedgerState blk)
 getCurrentState LgrDB{..} = LedgerDB.ledgerDbCurrent <$> readTVar varDB
+
+getPastState :: (IOLike m, UpdateLedger blk)
+             => LgrDB m blk -> Point blk -> m (Maybe (ExtLedgerState blk))
+getPastState LgrDB{..} p = LedgerDB.ledgerDbPast conf (tipFromPoint p)
+                       =<< atomically (readTVar varDB)
 
 -- | PRECONDITION: The new 'LedgerDB' must be the result of calling either
 -- 'LedgerDB.ledgerDbSwitch' or 'LedgerDB.ledgerDbPushMany' on the current

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -242,7 +242,7 @@ openDB args@LgrDbArgs{..} replayTracer immDB getBlock = do
       , ldbConfResolve = getBlock
       }
 
-reopen :: (IOLike m, ProtocolLedgerView blk)
+reopen :: (IOLike m, ProtocolLedgerView blk, HasCallStack)
        => LgrDB  m blk
        -> ImmDB  m blk
        -> Tracer m (TraceReplayEvent (Point blk) () (Point blk))
@@ -251,7 +251,7 @@ reopen LgrDB{..} immDB replayTracer = do
     db <- initFromDisk args replayTracer conf immDB
     atomically $ writeTVar varDB db
 
-initFromDisk :: (IOLike m, HasHeader blk)
+initFromDisk :: (IOLike m, HasHeader blk, HasCallStack)
              => LgrDbArgs m blk
              -> Tracer m (TraceReplayEvent (Point blk) () (Point blk))
              -> Conf      m blk
@@ -398,7 +398,8 @@ streamAPI :: forall m blk. (IOLike m, HasHeader blk)
           => ImmDB m blk -> StreamAPI m (Point blk) blk
 streamAPI immDB = StreamAPI streamAfter
   where
-    streamAfter :: Tip (Point blk)
+    streamAfter :: HasCallStack
+                => Tip (Point blk)
                 -> (Maybe (m (NextBlock (Point blk) blk)) -> m a)
                 -> m a
     streamAfter tip k = do

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/LgrDB.hs
@@ -406,9 +406,13 @@ streamAPI immDB = StreamAPI streamAfter
       slotNoAtTip <- ImmDB.getSlotNoAtTip immDB
       if Block.pointSlot (tipToPoint tip) > slotNoAtTip
         then k Nothing
-        else withRegistry $ \registry ->
-          ImmDB.streamAfter immDB registry Block (tipToPoint tip) >>=
-            k . Just . getNext . ImmDB.deserialiseIterator immDB
+        else withRegistry $ \registry -> do
+          mItr <- ImmDB.streamAfter immDB registry Block (tipToPoint tip)
+          case mItr of
+            Left _err ->
+              k Nothing
+            Right itr ->
+              k . Just . getNext . ImmDB.deserialiseIterator immDB $ itr
 
     getNext :: ImmDB.Iterator (HeaderHash blk) m blk
             -> m (NextBlock (Point blk) blk)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
@@ -8,6 +8,7 @@ module Ouroboros.Storage.ChainDB.Impl.Query
   ( -- * Queries
     getCurrentChain
   , getCurrentLedger
+  , getPastLedger
   , getTipBlock
   , getTipHeader
   , getTipPoint
@@ -34,6 +35,7 @@ import           Ouroboros.Network.Block (BlockNo, ChainHash (..), HasHeader,
                      pointSlot)
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.IOLike
@@ -80,6 +82,10 @@ getCurrentChain CDB{..} =
 
 getCurrentLedger :: IOLike m => ChainDbEnv m blk -> STM m (ExtLedgerState blk)
 getCurrentLedger CDB{..} = LgrDB.getCurrentState cdbLgrDB
+
+getPastLedger :: (IOLike m, UpdateLedger blk)
+              => ChainDbEnv m blk -> Point blk -> m (Maybe (ExtLedgerState blk))
+getPastLedger CDB{..} = LgrDB.getPastState cdbLgrDB
 
 getTipBlock
   :: forall m blk. (IOLike m, HasHeader blk, HasHeader (Header blk))

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
@@ -274,13 +274,13 @@ instructionHelper registry encodeHeader blockOrHeader fromMaybeSTM CDB{..} varRe
             -- 'ReaderInImmDB' state.
             Nothing    -> do
               trace $ ReaderNoLongerInMem rollState
-              ImmDB.streamAfter cdbImmDB registry blockOrHeader pt
+              ImmDB.streamAfterKnownBlock cdbImmDB registry blockOrHeader pt
           rollForwardImmDB immIt pt
         RollBackTo      pt -> do
           case mbImmIt of
             Just immIt -> ImmDB.iteratorClose cdbImmDB immIt
             Nothing    -> trace $ ReaderNoLongerInMem rollState
-          immIt' <- ImmDB.streamAfter cdbImmDB registry blockOrHeader pt
+          immIt' <- ImmDB.streamAfterKnownBlock cdbImmDB registry blockOrHeader pt
           let readerState' = ReaderInImmDB (RollForwardFrom pt) immIt'
           atomically $ writeTVar varReader readerState'
           return $ pure $ RollBack pt
@@ -358,7 +358,7 @@ instructionHelper registry encodeHeader blockOrHeader fromMaybeSTM CDB{..} varRe
           --    opened the iterator.
           _  -> do
             trace $ ReaderNewImmIterator pt slotNoAtImmDBTip
-            immIt' <- ImmDB.streamAfter cdbImmDB registry blockOrHeader pt
+            immIt' <- ImmDB.streamAfterKnownBlock cdbImmDB registry blockOrHeader pt
             -- Try again with the new iterator
             rollForwardImmDB immIt' pt
 
@@ -434,7 +434,7 @@ forward registry blockOrHeader CDB{..} varReader = \pts -> do
             else ImmDB.hasBlock cdbImmDB pt
           if inImmDB
             then do
-              immIt <- ImmDB.streamAfter cdbImmDB registry blockOrHeader pt
+              immIt <- ImmDB.streamAfterKnownBlock cdbImmDB registry blockOrHeader pt
               updateState $ ReaderInImmDB (RollBackTo pt) immIt
               return $ Just pt
             else findFirstPointOnChain curChain slotNoAtImmDBTip pts

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE TypeApplications     #-}
@@ -20,6 +21,7 @@ module Ouroboros.Storage.ChainDB.Impl.Types (
   , ChainDbEnv (..)
     -- * Exposed internals for testing purposes
   , Internal (..)
+  , intReopen
     -- * Reader-related
   , ReaderState (..)
   , ReaderRollState (..)
@@ -237,7 +239,7 @@ instance (IOLike m, ProtocolLedgerView blk)
 -------------------------------------------------------------------------------}
 
 data Internal m blk = Internal
-  { intReopen                  :: Bool -> m ()
+  { intReopen_                 :: HasCallStack => Bool -> m ()
     -- ^ Reopen a closed ChainDB.
     --
     -- A no-op if the ChainDB is still open.
@@ -262,6 +264,10 @@ data Internal m blk = Internal
   , intKillBgThreads           :: StrictTVar m (m ())
       -- ^ A handle to kill the background threads.
   }
+
+-- | Wrapper around 'intReopen_' to guarantee HasCallStack
+intReopen :: HasCallStack => Internal m blk -> Bool -> m ()
+intReopen = intReopen_
 
 {-------------------------------------------------------------------------------
   Reader-related

--- a/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
@@ -13,6 +13,7 @@ module Ouroboros.Storage.Common (
   , Tip(..)
   , tipIsGenesis
   , tipToPoint
+  , tipFromPoint
     -- * Serialisation
   , encodeTip
   , decodeTip
@@ -32,7 +33,8 @@ import           GHC.Generics
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block (Point, genesisPoint)
+import           Ouroboros.Network.Block (Point (..), genesisPoint)
+import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Util.Condense
 
@@ -76,6 +78,14 @@ tipIsGenesis (Tip _) = False
 tipToPoint :: Tip (Point blk) -> Point blk
 tipToPoint TipGen  = genesisPoint
 tipToPoint (Tip p) = p
+
+-- | Tip from a point
+--
+-- NOTE: We really shouldn't instantate 'Tip' with 'Point'; see
+-- <https://github.com/input-output-hk/ouroboros-network/issues/1155>
+tipFromPoint :: Point blk -> Tip (Point blk)
+tipFromPoint (Point Origin) = TipGen
+tipFromPoint p              = Tip p
 
 {-------------------------------------------------------------------------------
   Serialization

--- a/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -73,8 +73,8 @@ data NextBlock r b = NoMoreBlocks | NextBlock (r, b)
 -- In CPS form to enable the use of 'withXYZ' style iterator init functions.
 data StreamAPI m r b = StreamAPI {
       -- | Start streaming after the specified block
-      streamAfter :: forall a.
-           Tip r
+      streamAfter :: forall a. HasCallStack
+        => Tip r
         -- Reference to the block corresponding to the snapshot we found
         -- (or 'TipGen' if we didn't find any)
 
@@ -89,7 +89,7 @@ data StreamAPI m r b = StreamAPI {
     }
 
 -- | Stream all blocks
-streamAll :: forall m r b e a. Monad m
+streamAll :: forall m r b e a. (Monad m, HasCallStack)
           => StreamAPI m r b
           -> Tip r                -- ^ Starting point for streaming
           -> (Tip r -> e)         -- ^ Error when tip not found
@@ -218,7 +218,7 @@ data InitFailure r =
 -- If the chain DB or ledger layer reports an error, the whole thing is aborted
 -- and an error is returned. This should not throw any errors itself (ignoring
 -- unexpected exceptions such as asynchronous exceptions, of course).
-initFromSnapshot :: forall m h l r b e. (IOLike m)
+initFromSnapshot :: forall m h l r b e. (IOLike m, HasCallStack)
                  => Tracer m (TraceReplayEvent r () r)
                  -> HasFS m h
                  -> (forall s. Decoder s l)
@@ -236,7 +236,7 @@ initFromSnapshot tracer hasFS decLedger decRef params conf streamAPI ss = do
     return (csTip initSS, initDB)
 
 -- | Attempt to initialize the ledger DB starting from the given ledger DB
-initStartingWith :: forall m l r b e. Monad m
+initStartingWith :: forall m l r b e. (Monad m, HasCallStack)
                  => Tracer m (TraceReplayEvent r () r)
                  -> LedgerDbConf m l r b e
                  -> StreamAPI m r b

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -121,6 +121,7 @@ openDB cfg initLedger btime = do
         addBlock            = update_  . Model.addBlock cfg
       , getCurrentChain     = querySTM $ Model.lastK k getHeader
       , getCurrentLedger    = querySTM $ Model.currentLedger
+      , getPastLedger       = query    . Model.getPastLedger cfg
       , getBlock            = queryE   . Model.getBlockByPoint
       , getTipBlock         = query    $ Model.tipBlock
       , getTipHeader        = query    $ (fmap getHeader . Model.tipBlock)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -90,7 +90,7 @@ import           Ouroboros.Storage.ImmutableDB
 import qualified Ouroboros.Storage.ImmutableDB as ImmDB
 import qualified Ouroboros.Storage.ImmutableDB.Impl.Index as Index
 import           Ouroboros.Storage.LedgerDB.DiskPolicy (defaultDiskPolicy)
-import           Ouroboros.Storage.LedgerDB.InMemory (ledgerDbDefaultParams)
+import           Ouroboros.Storage.LedgerDB.InMemory (LedgerDbParams (..))
 import qualified Ouroboros.Storage.LedgerDB.OnDisk as LedgerDB
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 
@@ -1359,7 +1359,12 @@ mkArgs cfg initLedger tracer registry varCurSlot
       -- Policy
     , cdbValidation       = ValidateAllEpochs
     , cdbBlocksPerFile    = 4
-    , cdbParamsLgrDB      = ledgerDbDefaultParams (protocolSecurityParam cfg)
+    , cdbParamsLgrDB      = LedgerDbParams {
+                                -- Pick a small value for 'ledgerDbSnapEvery',
+                                -- so that maximum supported rollback is limited
+                                ledgerDbSnapEvery     = 2
+                              , ledgerDbSecurityParam = protocolSecurityParam cfg
+                              }
     , cdbDiskPolicy       = defaultDiskPolicy (protocolSecurityParam cfg)
 
       -- Integration


### PR DESCRIPTION
This also fixes a regression in the tests where non-saturated chains (fewer than `k` blocks) were ruled out; fortunately, this was a regression in the tests only, not in the code. Running 1M tests on the in-memory ledger DB:

```
# cabal run test-storage -- -p InMemory --quickcheck-tests=1000000
Up to date
ouroboros-storage
  Storage
    LedgerDB
      InMemory
        Serialisation
          ChainSummary:           OK (5.80s)
            +++ OK, passed 1000000 tests.
        Genesis
          length:                 OK (1.21s)
            +++ OK, passed 1000000 tests.
          current:                OK (1.21s)
            +++ OK, passed 1000000 tests.
        Push
          incrementsLength:       OK (2.26s)
            +++ OK, passed 1000000 tests (64.0082% saturated).
          lengthMatchesNumBlocks: OK (2.08s)
            +++ OK, passed 1000000 tests (63.9868% saturated).
          matchesPolicy:          OK (2.38s)
            +++ OK, passed 1000000 tests (63.9719% saturated).
          expectedLedger:         OK (3.02s)
            +++ OK, passed 1000000 tests (63.9387% saturated).
          pastLedger:             OK (3.76s)
            +++ OK, passed 1000000 tests:
            96.4751% within reach
            63.9570% saturated
        Rollback
          maxRollbackGenesisZero: OK (1.26s)
            +++ OK, passed 1000000 tests.
          ledgerDbMaxRollback:    OK (2.83s)
            +++ OK, passed 1000000 tests (63.9984% saturated).
          switchSameChain:        OK (3.35s)
            +++ OK, passed 1000000 tests (63.9431% saturated).
          switchMatchesPolicy:    OK (3.84s)
            +++ OK, passed 1000000 tests (64.0446% saturated).
          switchExpectedLedger:   OK (4.99s)
            +++ OK, passed 1000000 tests (64.0571% saturated).
          pastAfterSwitch:        OK (5.34s)
            +++ OK, passed 1000000 tests:
            92.9097% within reach
            63.9944% saturated
```

All 14 tests passed (43.35s)

Closes #1440.