### PR TITLE
Use BlockComponent in the Storage API

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -129,6 +129,7 @@ library
                        Ouroboros.Storage.ChainDB.Impl
                        Ouroboros.Storage.ChainDB.Impl.Args
                        Ouroboros.Storage.ChainDB.Impl.Background
+                       Ouroboros.Storage.ChainDB.Impl.BlockComponent
                        Ouroboros.Storage.ChainDB.Impl.ChainSel
                        Ouroboros.Storage.ChainDB.Impl.ImmDB
                        Ouroboros.Storage.ChainDB.Impl.Iterator

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -413,6 +413,7 @@ test-suite test-storage
                     Test.Util.SOP
                     Test.Util.TestBlock
                     Test.Util.Tracer
+                    Test.Util.WithEq
   build-depends:    base,
                     cardano-crypto-class,
                     cardano-ledger,

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -51,7 +51,7 @@ import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
                      (pipelineDecisionLowHighMark)
 import           Ouroboros.Network.Socket (ConnectionId)
 
-import           Ouroboros.Consensus.Block (BlockProtocol, getHeader)
+import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.ChainSyncClient (ClockSkew (..))
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
@@ -243,7 +243,7 @@ mkChainDbArgs tracer registry btime dbPath cfg initLedger
     , ChainDB.cdbGenesis          = return initLedger
     , ChainDB.cdbAddHdrEnv        = nodeAddHeaderEnvelope   (Proxy @blk)
     , ChainDB.cdbDiskPolicy       = defaultDiskPolicy secParam
-    , ChainDB.cdbIsEBB            = nodeIsEBB . getHeader
+    , ChainDB.cdbIsEBB            = nodeIsEBB
     , ChainDB.cdbCheckIntegrity   = nodeCheckIntegrity      cfg
     , ChainDB.cdbParamsLgrDB      = ledgerDbDefaultParams secParam
     , ChainDB.cdbNodeConfig       = cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -28,6 +28,7 @@ module Ouroboros.Consensus.Util (
   , allDisjoint
   , (.:)
   , (..:)
+  , (...:)
   , takeLast
   , dropLast
   , mustBeRight
@@ -163,6 +164,9 @@ allDisjoint = go Set.empty
 
 (..:) :: (d -> e) -> (a -> b -> c -> d) -> (a -> b -> c -> e)
 (f ..: g) a b c = f (g a b c)
+
+(...:) :: (e -> f) -> (a -> b -> c -> d -> e) -> (a -> b -> c -> d -> f)
+(f ...: g) a b c d = f (g a b c d)
 
 -- | Take the last @n@ elements
 takeLast :: Word64 -> [a] -> [a]

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -1,12 +1,14 @@
-{-# LANGUAGE AllowAmbiguousTypes        #-}
 {-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeApplications           #-}
@@ -16,11 +18,17 @@
 module Ouroboros.Storage.ChainDB.API (
     -- * Main ChainDB API
     ChainDB(..)
-    -- * Block or header
-  , BlockOrHeader(..)
-    -- * Deserialisable block/header
-  , Deserialisable(..)
-  , deserialisablePoint
+    -- * Useful utilities
+  , getBlock
+  , streamBlocks
+  , newBlockReader
+    -- * Serialised block/header with its point
+  , SerialisedWithPoint(..)
+  , getSerialisedBlockWithPoint
+  , getSerialisedHeaderWithPoint
+  , getPoint
+    -- * BlockComponent
+  , BlockComponent(..)
     -- * Support for tests
   , toChain
   , fromChain
@@ -30,9 +38,8 @@ module Ouroboros.Storage.ChainDB.API (
   , Iterator(..)
   , IteratorId(..)
   , IteratorResult(..)
+  , traverseIterator
   , UnknownRange(..)
-  , deserialiseIterator
-  , deserialiseIteratorResult
   , validBounds
   , streamAll
     -- * Invalid block reason
@@ -40,9 +47,11 @@ module Ouroboros.Storage.ChainDB.API (
     -- * Readers
   , Reader(..)
   , ReaderId
-  , deserialiseReader
+  , traverseReader
     -- * Recovery
   , ChainDbFailure(..)
+  , BlockRef(..)
+  , IsEBB(..)
     -- * Exceptions
   , ChainDbError(..)
   ) where
@@ -60,10 +69,10 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Ouroboros.Network.Block (BlockNo, pattern BlockPoint,
                      ChainUpdate, pattern GenesisPoint, HasHeader (..),
-                     HeaderHash, MaxSlotNo, Point, Serialised, SlotNo,
+                     HeaderHash, MaxSlotNo, Point, Serialised (..), SlotNo,
                      StandardHash, atSlot, genesisPoint)
 
-import           Ouroboros.Consensus.Block (GetHeader (..))
+import           Ouroboros.Consensus.Block (GetHeader (..), IsEBB (..))
 import           Ouroboros.Consensus.Ledger.Abstract (ProtocolLedgerView)
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Util.IOLike
@@ -71,7 +80,7 @@ import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (WithFingerprint)
 
 import           Ouroboros.Storage.Common
-import           Ouroboros.Storage.FS.API.Types (FsError)
+import           Ouroboros.Storage.FS.API.Types (FsError, sameFsError)
 import qualified Ouroboros.Storage.ImmutableDB as ImmDB
 import qualified Ouroboros.Storage.VolatileDB as VolDB
 
@@ -185,8 +194,10 @@ data ChainDB m blk = ChainDB {
       -- Will return 'genesisBlockNo' if the database is empty.
     , getTipBlockNo      :: STM m BlockNo
 
-      -- | Get block at the specified point (if it exists)
-    , getBlock           :: Point blk -> m (Maybe blk)
+      -- | Get the given component(s) of the block at the specified point. If
+      -- there is no block at the given point, 'Nothing' is returned.
+    , getBlockComponent  :: forall b. BlockComponent (ChainDB m blk) b
+                         -> Point blk -> m (Maybe b)
 
       -- | Return membership check function for recent blocks
       --
@@ -238,10 +249,12 @@ data ChainDB m blk = ChainDB {
       --
       -- To stream all blocks from the current chain, use 'streamAll', as it
       -- correctly handles an empty ChainDB.
-    , streamBlocks
-        :: ResourceRegistry m
+    , stream
+        :: forall b.
+           ResourceRegistry m
+        -> BlockComponent (ChainDB m blk) b
         -> StreamFrom blk -> StreamTo blk
-        -> m (Either (UnknownRange blk) (Iterator m (Deserialisable m blk blk)))
+        -> m (Either (UnknownRange blk) (Iterator m blk b))
 
       -- | Chain reader
       --
@@ -255,18 +268,17 @@ data ChainDB m blk = ChainDB {
       -- This is intended for use by chain consumers to /reliably/ follow a
       -- chain, desipite the chain being volatile.
       --
-      -- Examples of users include the server side of the chain sync
-      -- mini-protocol for the node-to-node protocol.
+      -- Examples of users:
+      -- * The server side of the chain sync mini-protocol for the
+      --   node-to-node protocol using headers and the block size.
+      -- * The server side of the chain sync mini-protocol for the
+      --   node-to-client protocol using blocks.
       --
-    , newHeaderReader    :: ResourceRegistry m -> m (Reader m blk (Deserialisable m blk (Header blk)))
-
-      -- | This is the same as the reader 'newHeaderReader' but it provides a
-      -- reader for /whole blocks/ rather than headers.
-      --
-      -- Examples of users include the server side of the chain sync
-      -- mini-protocol for the node-to-client protocol.
-      --
-    , newBlockReader     :: ResourceRegistry m -> m (Reader m blk (Deserialisable m blk blk))
+    , newReader
+        :: forall b.
+           ResourceRegistry m
+        -> BlockComponent (ChainDB m blk) b
+        -> m (Reader m blk b)
 
       -- | Function to check whether a block is known to be invalid.
       --
@@ -297,37 +309,72 @@ data ChainDB m blk = ChainDB {
     , isOpen             :: STM m Bool
     }
 
-{-------------------------------------------------------------------------------
-  Block or header
--------------------------------------------------------------------------------}
-
--- | Either a block (@blk@) or a header (@'Header' blk@). Both have the same
--- @HeaderHash blk@.
-data BlockOrHeader blk b where
-  Block  :: BlockOrHeader blk blk
-  Header :: BlockOrHeader blk (Header blk)
+instance DB (ChainDB m blk) where
+  -- Returning a block or header requires parsing. In case of failure, a
+  -- 'ChainDbFailure' exception is thrown
+  type DBBlock      (ChainDB m blk) = m blk
+  type DBHeader     (ChainDB m blk) = m (Header blk)
+  type DBHeaderHash (ChainDB m blk) = HeaderHash blk
 
 {-------------------------------------------------------------------------------
-  Deserialisable block/header
+  Useful utilities
 -------------------------------------------------------------------------------}
 
--- | A @'Serialised' b@ together with its slot, hash, and a monadic function
--- to deserialise it. The @b@ will be @blk@ or @'Header' blk@.
-data Deserialisable m blk b = Deserialisable
-   { serialised         :: !(Serialised b)
-   , deserialisableSlot :: !SlotNo
-   , deserialisableHash :: !(HeaderHash blk)
-   , deserialise        :: m b
-     -- ^ No need for a bang as it is a monadic computation. Moreover, with a
-     -- bang, we might accidentally force deserialisation, as that is
-     -- typically a pure computation that only needs @m@ to throw an error.
+-- These are all variants of ChainDB methods instantiated to a specific
+-- BlockComponent.
+
+-- | Get block at the specified point (if it exists).
+getBlock :: Monad m => ChainDB m blk -> Point blk -> m (Maybe blk)
+getBlock ChainDB { getBlockComponent } pt =
+    sequence =<< getBlockComponent GetBlock pt
+
+streamBlocks
+  :: Monad m
+  => ChainDB m blk
+  -> ResourceRegistry m
+  -> StreamFrom blk
+  -> StreamTo blk
+  -> m (Either (UnknownRange blk) (Iterator m blk blk))
+streamBlocks ChainDB { stream } rr from to =
+    fmap (traverseIterator id) <$> stream rr GetBlock from to
+
+newBlockReader
+  :: Monad m
+  => ChainDB m blk
+  -> ResourceRegistry m
+  -> m (Reader m blk blk)
+newBlockReader ChainDB { newReader } rr =
+    traverseReader id <$> newReader rr GetBlock
+
+{-------------------------------------------------------------------------------
+  Serialised block/header with its point
+-------------------------------------------------------------------------------}
+
+-- | A @'Serialised' b@ together with its 'Point'.
+--
+-- The 'Point' is needed because we often need to know the hash, slot, or
+-- point itself of the block or header in question, and we don't want to
+-- deserialise the block to obtain it.
+data SerialisedWithPoint blk b = SerialisedWithPoint
+   { serialised :: !(Serialised b)
+   , point      :: !(Point blk)
    }
 
-deserialisablePoint :: Deserialisable m blk b -> Point blk
-deserialisablePoint d = BlockPoint (deserialisableSlot d) (deserialisableHash d)
+type instance HeaderHash (SerialisedWithPoint blk b) = HeaderHash blk
+instance StandardHash blk => StandardHash (SerialisedWithPoint blk b)
 
-type instance HeaderHash (Deserialisable m blk b) = HeaderHash blk
-instance StandardHash blk => StandardHash (Deserialisable m blk b)
+getPoint :: BlockComponent (ChainDB m blk) (Point blk)
+getPoint = BlockPoint <$> GetSlot <*> GetHash
+
+getSerialisedBlockWithPoint
+  :: BlockComponent (ChainDB m blk) (SerialisedWithPoint blk blk)
+getSerialisedBlockWithPoint =
+    SerialisedWithPoint <$> (Serialised <$> GetRawBlock) <*> getPoint
+
+getSerialisedHeaderWithPoint
+  :: BlockComponent (ChainDB m blk) (SerialisedWithPoint blk (Header blk))
+getSerialisedHeaderWithPoint =
+    SerialisedWithPoint <$> (Serialised <$> GetRawHeader) <*> getPoint
 
 {-------------------------------------------------------------------------------
   Support for tests
@@ -338,7 +385,7 @@ toChain :: forall m blk. (HasCallStack, IOLike m, HasHeader blk)
 toChain chainDB = withRegistry $ \registry ->
     streamAll chainDB registry >>= maybe (return Genesis) (go Genesis)
   where
-    go :: Chain blk -> Iterator m blk -> m (Chain blk)
+    go :: Chain blk -> Iterator m blk blk -> m (Chain blk)
     go chain it = do
       next <- iteratorNext it
       case next of
@@ -374,19 +421,21 @@ data StreamTo blk =
   | StreamToExclusive !(Point blk)
   deriving (Show, Eq, Generic, NoUnexpectedThunks)
 
-data Iterator m blk = Iterator {
-      iteratorNext  :: m (IteratorResult blk)
+data Iterator m blk b = Iterator {
+      iteratorNext  :: m (IteratorResult blk b)
     , iteratorClose :: m ()
     , iteratorId    :: IteratorId
-    }
+    } deriving (Functor, Foldable, Traversable)
 
--- | Deserialise the results of an iterator that yields serialised blocks.
-deserialiseIterator
-  :: Monad m => Iterator m (Deserialisable m blk blk) -> Iterator m blk
-deserialiseIterator it = Iterator
-    { iteratorNext  = iteratorNext  it >>= deserialiseIteratorResult
-    , iteratorClose = iteratorClose it
-    , iteratorId    = iteratorId    it
+-- | Variant of 'traverse' instantiated to @'Iterator' m blk@ that executes
+-- the monadic function when calling 'iteratorNext'.
+traverseIterator
+  :: Monad m
+  => (b -> m b')
+  -> Iterator m blk b
+  -> Iterator m blk b'
+traverseIterator f it = it {
+      iteratorNext = iteratorNext it >>= traverse f
     }
 
 -- | Equality instance for iterators
@@ -396,34 +445,27 @@ deserialiseIterator it = Iterator
 -- NOTE: Iterators created by /different instances of the DB/ may end up with
 -- the same ID. This should not matter in practice since there should not /be/
 -- more than one DB, but it should nonetheless be noted.
-instance Eq (Iterator m blk) where
+instance Eq (Iterator m blk b) where
   (==) = (==) `on` iteratorId
 
 newtype IteratorId = IteratorId Int
   deriving stock (Show)
   deriving newtype (Eq, Ord, Enum, NoUnexpectedThunks)
 
-data IteratorResult blk =
+data IteratorResult blk b =
     IteratorExhausted
-  | IteratorResult blk
+  | IteratorResult b
   | IteratorBlockGCed (HeaderHash blk)
     -- ^ The block that was supposed to be streamed was garbage-collected from
     -- the VolatileDB, but not added to the ImmutableDB.
     --
     -- This will only happen when streaming very old forks very slowly.
+  deriving (Functor, Foldable, Traversable)
 
-deriving instance (Eq   blk, Eq   (HeaderHash blk)) => Eq   (IteratorResult blk)
-deriving instance (Show blk, Show (HeaderHash blk)) => Show (IteratorResult blk)
-
--- | Deserialise the 'IteratorResult' of an iterator that yields serialised
--- blocks.
-deserialiseIteratorResult
-  :: Monad m
-  => IteratorResult (Deserialisable m blk blk) -> m (IteratorResult blk)
-deserialiseIteratorResult = \case
-    IteratorExhausted      -> return $ IteratorExhausted
-    IteratorBlockGCed hash -> return $ IteratorBlockGCed hash
-    IteratorResult    blk  -> IteratorResult <$> deserialise blk
+deriving instance (Eq   blk, Eq   b, Eq   (HeaderHash blk))
+               => Eq   (IteratorResult blk b)
+deriving instance (Show blk, Show b, Show (HeaderHash blk))
+               => Show (IteratorResult blk b)
 
 data UnknownRange blk =
     -- | The block at the given point was not found in the ChainDB.
@@ -480,7 +522,7 @@ validBounds from to = case from of
 streamAll :: (IOLike m, StandardHash blk)
           => ChainDB m blk
           -> ResourceRegistry m
-          -> m (Maybe (Iterator m blk))
+          -> m (Maybe (Iterator m blk blk))
 streamAll chainDB registry = do
     tip <- atomically $ getTipPoint chainDB
     if tip == genesisPoint
@@ -496,7 +538,7 @@ streamAll chainDB registry = do
           -- changed significantly between getting the tip and asking for the
           -- stream.
           Left  e  -> error (show e)
-          Right it -> return $ Just $ deserialiseIterator it
+          Right it -> return $ Just it
 
 {-------------------------------------------------------------------------------
   Invalid block reason
@@ -572,13 +614,17 @@ data Reader m blk a = Reader {
 instance Eq (Reader m blk a) where
   (==) = (==) `on` readerId
 
--- | Deserialise the results of a reader that yields serialised blocks or
--- headers.
-deserialiseReader
-  :: Monad m => Reader m blk (Deserialisable m blk b) -> Reader m blk b
-deserialiseReader rdr = Reader
-    { readerInstruction         = readerInstruction         rdr >>= traverse (traverse deserialise)
-    , readerInstructionBlocking = readerInstructionBlocking rdr >>= traverse deserialise
+-- | Variant of 'traverse' instantiated to @'Reader' m blk@ that executes the
+-- monadic function when calling 'readerInstruction' and
+-- 'readerInstructionBlocking'.
+traverseReader
+  :: Monad m
+  => (b -> m b')
+  -> Reader m blk b
+  -> Reader m blk b'
+traverseReader f rdr = Reader
+    { readerInstruction         = readerInstruction         rdr >>= traverse (traverse f)
+    , readerInstructionBlocking = readerInstructionBlocking rdr >>= traverse f
     , readerForward             = readerForward             rdr
     , readerClose               = readerClose               rdr
     , readerId                  = readerId                  rdr
@@ -587,6 +633,12 @@ deserialiseReader rdr = Reader
 {-------------------------------------------------------------------------------
   Recovery
 -------------------------------------------------------------------------------}
+
+-- | Reference to a block used in 'ChainDbFailure'.
+data BlockRef blk = BlockRef
+  { blockRefPoint :: !(Point blk)
+  , blockRefIsEBB :: !IsEBB
+  } deriving (Eq, Show)
 
 -- | Database failure
 --
@@ -599,10 +651,12 @@ deserialiseReader rdr = Reader
 -- equal and all trigger the same recovery procedure.
 data ChainDbFailure =
     -- | A block in the immutable DB failed to parse
-    ImmDbParseFailure (Either EpochNo SlotNo) CBOR.DeserialiseFailure
+    forall blk. (Typeable blk, StandardHash blk) =>
+      ImmDbParseFailure (BlockRef blk) CBOR.DeserialiseFailure
 
     -- | When parsing a block from the immutable DB we got some trailing data
-  | ImmDbTrailingData (Either EpochNo SlotNo) Lazy.ByteString
+  | forall blk. (Typeable blk, StandardHash blk) =>
+      ImmDbTrailingData (BlockRef blk) Lazy.ByteString
 
     -- | Block missing from the immutable DB
     --
@@ -637,11 +691,11 @@ data ChainDbFailure =
 
     -- | A block in the volatile DB failed to parse
   | forall blk. (Typeable blk, StandardHash blk) =>
-      VolDbParseFailure (HeaderHash blk) CBOR.DeserialiseFailure
+      VolDbParseFailure (BlockRef blk) CBOR.DeserialiseFailure
 
     -- | When parsing a block from the volatile DB, we got some trailing data
   | forall blk. (Typeable blk, StandardHash blk) =>
-      VolDbTrailingData (HeaderHash blk) Lazy.ByteString
+      VolDbTrailingData (BlockRef blk) Lazy.ByteString
 
     -- | Block missing from the volatile DB
     --
@@ -649,7 +703,7 @@ data ChainDbFailure =
     -- in the DB (for example, because its hash exists in the volatile DB's
     -- successor index) nonetheless was not found
   | forall blk. (Typeable blk, StandardHash blk) =>
-      VolDbMissingBlock (HeaderHash blk)
+      VolDbMissingBlock (Proxy blk) (HeaderHash blk)
 
     -- | The volatile DB throw an "unexpected error"
     --
@@ -694,6 +748,67 @@ instance Exception ChainDbFailure where
       -- The output will be a bit too detailed, but it will be quite clear.
       fsError :: FsError -> String
       fsError = displayException
+
+instance Eq ChainDbFailure where
+  ImmDbParseFailure (a1 :: BlockRef blk) b1 == ImmDbParseFailure (a2 :: BlockRef blk') b2 =
+    case eqT @blk @blk' of
+      Nothing   -> False
+      Just Refl -> a1 == a2 && b1 == b2
+  ImmDbParseFailure {} == _ = False
+
+  ImmDbTrailingData (a1 :: BlockRef blk) b1 == ImmDbTrailingData (a2 :: BlockRef blk') b2 =
+    case eqT @blk @blk' of
+      Nothing   -> False
+      Just Refl -> a1 == a2 && b1 == b2
+  ImmDbTrailingData {} == _ = False
+
+  ImmDbMissingBlock a1 == ImmDbMissingBlock a2 = a1 == a2
+  ImmDbMissingBlock {} == _ = False
+
+  ImmDbMissingBlockPoint (a1 :: Point blk) b1 _cs1 == ImmDbMissingBlockPoint (a2 :: Point blk') b2 _cs2 =
+    case eqT @blk @blk' of
+      Nothing   -> False
+      Just Refl -> a1 == a2 && b1 == b2
+  ImmDbMissingBlockPoint {} == _ = False
+
+  ImmDbUnexpectedIteratorExhausted (a1 :: Point blk) == ImmDbUnexpectedIteratorExhausted (a2 :: Point blk') =
+    case eqT @blk @blk' of
+      Nothing   -> False
+      Just Refl -> a1 == a2
+  ImmDbUnexpectedIteratorExhausted {} == _ = False
+
+  ImmDbFailure a1 == ImmDbFailure a2 = ImmDB.sameUnexpectedError a1 a2
+  ImmDbFailure {} == _               = False
+
+  VolDbParseFailure (a1 :: BlockRef blk) b1 == VolDbParseFailure (a2 :: BlockRef blk') b2 =
+    case eqT @blk @blk' of
+      Nothing   -> False
+      Just Refl -> a1 == a2 && b1 == b2
+  VolDbParseFailure {} == _ = False
+
+  VolDbTrailingData (a1 :: BlockRef blk) b1 == VolDbTrailingData (a2 :: BlockRef blk') b2 =
+    case eqT @blk @blk' of
+      Nothing   -> False
+      Just Refl -> a1 == a2 && b1 == b2
+  VolDbTrailingData {} == _ = False
+
+  VolDbMissingBlock (Proxy :: Proxy blk) a1 == VolDbMissingBlock (Proxy :: Proxy blk') a2 =
+    case eqT @blk @blk' of
+      Nothing   -> False
+      Just Refl -> a1 == a2
+  VolDbMissingBlock {} == _ = False
+
+  VolDbFailure a1 == VolDbFailure a2 = VolDB.sameUnexpectedError a1 a2
+  VolDbFailure {} == _               = False
+
+  LgrDbFailure a1 == LgrDbFailure a2 = sameFsError a1 a2
+  LgrDbFailure {} == _               = False
+
+  ChainDbMissingBlock (a1 :: Point blk) == ChainDbMissingBlock (a2 :: Point blk') =
+    case eqT @blk @blk' of
+      Nothing   -> False
+      Just Refl -> a1 == a2
+  ChainDbMissingBlock {} == _ = False
 
 {-------------------------------------------------------------------------------
   Exceptions

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -126,37 +126,37 @@ openDBInternal args launchBgTasks = do
         immBlockNo = ChainSel.getImmBlockNo secParam chain immDbTipBlockNo
 
     atomically $ LgrDB.setCurrent lgrDB ledger
-    varChain          <- newTVarM chain
-    varImmBlockNo     <- newTVarM immBlockNo
-    varIterators      <- newTVarM Map.empty
-    varReaders        <- newTVarM Map.empty
-    varNextIteratorId <- newTVarM (IteratorId 0)
-    varNextReaderId   <- newTVarM 0
-    varCopyLock       <- newMVar  ()
-    varKillBgThreads  <- newTVarM $ return ()
-    varFutureBlocks   <- newTVarM Map.empty
+    varChain           <- newTVarM chain
+    varImmBlockNo      <- newTVarM immBlockNo
+    varIterators       <- newTVarM Map.empty
+    varReaders         <- newTVarM Map.empty
+    varNextIteratorKey <- newTVarM (IteratorKey 0)
+    varNextReaderKey   <- newTVarM (ReaderKey   0)
+    varCopyLock        <- newMVar  ()
+    varKillBgThreads   <- newTVarM $ return ()
+    varFutureBlocks    <- newTVarM Map.empty
 
-    let env = CDB { cdbImmDB          = immDB
-                  , cdbVolDB          = volDB
-                  , cdbLgrDB          = lgrDB
-                  , cdbChain          = varChain
-                  , cdbImmBlockNo     = varImmBlockNo
-                  , cdbIterators      = varIterators
-                  , cdbReaders        = varReaders
-                  , cdbNodeConfig     = cfg
-                  , cdbInvalid        = varInvalid
-                  , cdbNextIteratorId = varNextIteratorId
-                  , cdbNextReaderId   = varNextReaderId
-                  , cdbCopyLock       = varCopyLock
-                  , cdbTracer         = tracer
-                  , cdbTraceLedger    = Args.cdbTraceLedger args
-                  , cdbRegistry       = Args.cdbRegistry args
-                  , cdbGcDelay        = Args.cdbGcDelay args
-                  , cdbKillBgThreads  = varKillBgThreads
-                  , cdbEpochInfo      = Args.cdbEpochInfo args
-                  , cdbIsEBB          = toIsEBB . isJust . Args.cdbIsEBB args
-                  , cdbBlockchainTime = Args.cdbBlockchainTime args
-                  , cdbFutureBlocks   = varFutureBlocks
+    let env = CDB { cdbImmDB           = immDB
+                  , cdbVolDB           = volDB
+                  , cdbLgrDB           = lgrDB
+                  , cdbChain           = varChain
+                  , cdbImmBlockNo      = varImmBlockNo
+                  , cdbIterators       = varIterators
+                  , cdbReaders         = varReaders
+                  , cdbNodeConfig      = cfg
+                  , cdbInvalid         = varInvalid
+                  , cdbNextIteratorKey = varNextIteratorKey
+                  , cdbNextReaderKey   = varNextReaderKey
+                  , cdbCopyLock        = varCopyLock
+                  , cdbTracer          = tracer
+                  , cdbTraceLedger     = Args.cdbTraceLedger args
+                  , cdbRegistry        = Args.cdbRegistry args
+                  , cdbGcDelay         = Args.cdbGcDelay args
+                  , cdbKillBgThreads   = varKillBgThreads
+                  , cdbEpochInfo       = Args.cdbEpochInfo args
+                  , cdbIsEBB           = toIsEBB . isJust . Args.cdbIsEBB args
+                  , cdbBlockchainTime  = Args.cdbBlockchainTime args
+                  , cdbFutureBlocks    = varFutureBlocks
                   }
     h <- fmap CDBHandle $ newTVarM $ ChainDbOpen env
     let chainDB = ChainDB

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -37,7 +37,7 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (HasHeader (..), castPoint,
                      genesisBlockNo, genesisPoint)
 
-import           Ouroboros.Consensus.Block (headerPoint)
+import           Ouroboros.Consensus.Block (headerPoint, toIsEBB)
 import           Ouroboros.Consensus.BlockchainTime (getCurrentSlot)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -83,7 +83,7 @@ openDBInternal args launchBgTasks = do
     immDB <- ImmDB.openDB argsImmDb
     -- In order to figure out the 'BlockNo' and 'Point' at the tip of the
     -- ImmutableDB, we need to read the header at the tip of the ImmutableDB.
-    immDbTipHeader <- ImmDB.getBlockOrHeaderAtTip immDB Header
+    immDbTipHeader <- sequence =<< ImmDB.getBlockComponentAtTip immDB GetHeader
     -- Note that 'immDbTipBlockNo' might not end up being the \"immutable\"
     -- block(no), because the current chain computed from the VolatileDB could
     -- be longer than @k@.
@@ -129,8 +129,7 @@ openDBInternal args launchBgTasks = do
     varChain          <- newTVarM chain
     varImmBlockNo     <- newTVarM immBlockNo
     varIterators      <- newTVarM Map.empty
-    varBlockReaders   <- newTVarM Map.empty
-    varHeaderReaders  <- newTVarM Map.empty
+    varReaders        <- newTVarM Map.empty
     varNextIteratorId <- newTVarM (IteratorId 0)
     varNextReaderId   <- newTVarM 0
     varCopyLock       <- newMVar  ()
@@ -143,8 +142,7 @@ openDBInternal args launchBgTasks = do
                   , cdbChain          = varChain
                   , cdbImmBlockNo     = varImmBlockNo
                   , cdbIterators      = varIterators
-                  , cdbBlockReaders   = varBlockReaders
-                  , cdbHeaderReaders  = varHeaderReaders
+                  , cdbReaders        = varReaders
                   , cdbNodeConfig     = cfg
                   , cdbInvalid        = varInvalid
                   , cdbNextIteratorId = varNextIteratorId
@@ -156,7 +154,7 @@ openDBInternal args launchBgTasks = do
                   , cdbGcDelay        = Args.cdbGcDelay args
                   , cdbKillBgThreads  = varKillBgThreads
                   , cdbEpochInfo      = Args.cdbEpochInfo args
-                  , cdbIsEBB          = isJust . Args.cdbIsEBB args
+                  , cdbIsEBB          = toIsEBB . isJust . Args.cdbIsEBB args
                   , cdbBlockchainTime = Args.cdbBlockchainTime args
                   , cdbFutureBlocks   = varFutureBlocks
                   }
@@ -170,12 +168,11 @@ openDBInternal args launchBgTasks = do
           , getTipHeader       = getEnv     h Query.getTipHeader
           , getTipPoint        = getEnvSTM  h Query.getTipPoint
           , getTipBlockNo      = getEnvSTM  h Query.getTipBlockNo
-          , getBlock           = getEnv1    h Query.getBlock
+          , getBlockComponent  = getEnv2    h Query.getBlockComponent
           , getIsFetched       = getEnvSTM  h Query.getIsFetched
           , getMaxSlotNo       = getEnvSTM  h Query.getMaxSlotNo
-          , streamBlocks       = Iterator.streamBlocks  h
-          , newHeaderReader    = Reader.newReader h (Args.cdbEncodeHeader args) Header
-          , newBlockReader     = Reader.newReader h (Args.cdbEncodeHeader args) Block
+          , stream             = Iterator.stream  h
+          , newReader          = Reader.newReader h (Args.cdbEncodeHeader args)
           , getIsInvalidBlock  = getEnvSTM  h Query.getIsInvalidBlock
           , closeDB            = Reopen.closeDB h
           , isOpen             = Reopen.isOpen  h

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -89,7 +89,7 @@ data ChainDbArgs m blk = forall h1 h2 h3. ChainDbArgs {
     , cdbNodeConfig       :: NodeConfig (BlockProtocol blk)
     , cdbEpochInfo        :: EpochInfo m
     , cdbHashInfo         :: HashInfo (HeaderHash blk)
-    , cdbIsEBB            :: blk -> Maybe EpochNo
+    , cdbIsEBB            :: Header blk -> Maybe EpochNo
     , cdbCheckIntegrity   :: blk -> Bool
     , cdbGenesis          :: m (ExtLedgerState blk)
     , cdbBlockchainTime   :: BlockchainTime m
@@ -152,7 +152,8 @@ defaultArgs fp = toChainDbArgs (ImmDB.defaultArgs fp)
 
 -- | Internal: split 'ChainDbArgs' into 'ImmDbArgs', 'VolDbArgs, 'LgrDbArgs',
 -- and 'ChainDbSpecificArgs'.
-fromChainDbArgs :: ChainDbArgs m blk
+fromChainDbArgs :: GetHeader blk
+                => ChainDbArgs m blk
                 -> ( ImmDB.ImmDbArgs     m blk
                    , VolDB.VolDbArgs     m blk
                    , LgrDB.LgrDbArgs     m blk
@@ -186,7 +187,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , volDecodeBlock      = cdbDecodeBlock
         , volEncodeBlock      = cdbEncodeBlock
         , volAddHdrEnv        = cdbAddHdrEnv
-        , volIsEBB            = \blk -> case cdbIsEBB blk of
+        , volIsEBB            = \blk -> case cdbIsEBB (getHeader blk) of
                                           Nothing -> IsNotEBB
                                           Just _  -> IsEBB
         }

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Background.hs
@@ -115,6 +115,7 @@ copyToImmDB
      ( IOLike m
      , OuroborosTag (BlockProtocol blk)
      , HasHeader blk
+     , GetHeader blk
      , HasHeader (Header blk)
      , HasCallStack
      )
@@ -195,6 +196,7 @@ copyToImmDBRunner
      ( IOLike m
      , OuroborosTag (BlockProtocol blk)
      , HasHeader blk
+     , GetHeader blk
      , HasHeader (Header blk)
      )
   => ChainDbEnv m blk

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/BlockComponent.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/BlockComponent.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Ouroboros.Storage.ChainDB.Impl.BlockComponent
+  ( BlockComponent (..)
+  , translateToRawDB
+  , Parser
+  , BlockOrHeader (..)
+  ) where
+
+import qualified Data.ByteString.Lazy as Lazy
+
+import           Ouroboros.Network.Block (pattern BlockPoint, HeaderHash,
+                     SlotNo)
+
+import           Ouroboros.Consensus.Block (GetHeader (..), IsEBB (..))
+
+import           Ouroboros.Storage.ChainDB.API (BlockRef (..), ChainDB)
+import           Ouroboros.Storage.Common
+
+-- | Translate a ChainDB 'BlockComponent' into a 'BlockComponent' known by the
+-- ImmutableDB and the VolatileDB.
+translateToRawDB
+  :: forall m blk b db. DBHeaderHash db ~ HeaderHash blk
+  => (forall b'. Parser m blk b')
+  -> (IsEBB -> Lazy.ByteString -> Lazy.ByteString)
+     -- ^ Add header envelope
+  -> BlockComponent (ChainDB m blk) b
+  -> BlockComponent db b
+translateToRawDB parse addHdrEnv = \case
+    GetBlock ->
+      parse Block <$> getBlockRef <*> GetRawBlock
+    GetRawBlock   -> GetRawBlock
+    GetHeader ->
+      (\isEBB blockRef bs -> parse Header blockRef (addHdrEnv isEBB bs)) <$>
+      GetIsEBB <*> getBlockRef <*> GetRawHeader
+    GetRawHeader  -> addHdrEnv <$> GetIsEBB <*> GetRawHeader
+    GetHash       -> GetHash
+    GetSlot       -> GetSlot
+    GetIsEBB      -> GetIsEBB
+    GetBlockSize  -> GetBlockSize
+    GetHeaderSize -> GetHeaderSize
+    GetPure a     -> GetPure a
+    GetApply f bc -> GetApply
+      (translateToRawDB parse addHdrEnv f)
+      (translateToRawDB parse addHdrEnv bc)
+
+-- | Block or header parser
+type Parser m blk b =
+     BlockOrHeader blk b
+  -> BlockRef blk
+  -> Lazy.ByteString
+  -> m b
+
+-- | Either a block (@blk@) or a header (@'Header' blk@). Both have the same
+-- @HeaderHash blk@.
+data BlockOrHeader blk b where
+  Block  :: BlockOrHeader blk blk
+  Header :: BlockOrHeader blk (Header blk)
+
+getBlockRef :: DBHeaderHash db ~ HeaderHash blk
+            => BlockComponent db (BlockRef blk)
+getBlockRef = mkBlockRef <$> GetSlot <*> GetHash <*> GetIsEBB
+  where
+    mkBlockRef :: SlotNo -> HeaderHash blk -> IsEBB -> BlockRef blk
+    mkBlockRef slot hash = BlockRef (BlockPoint slot hash)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
@@ -17,9 +17,9 @@ import           Codec.CBOR.Encoding (Encoding)
 import           Codec.CBOR.Write (toLazyByteString)
 import           Control.Exception (assert)
 import           Control.Monad (sequence_)
+import qualified Data.ByteString.Lazy as Lazy
 import           Data.Functor ((<&>))
 import           Data.Functor.Identity (Identity (..))
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           GHC.Stack (HasCallStack, callStack)
 
@@ -29,8 +29,8 @@ import           Control.Tracer (contramap, traceWith)
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader,
-                     HeaderHash, Point, Serialised (..), SlotNo, blockSlot,
-                     castPoint, genesisPoint, pointHash, pointSlot)
+                     HeaderHash, Point, SlotNo, blockSlot, castPoint,
+                     genesisPoint, pointHash, pointSlot)
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block (GetHeader (..), headerHash,
@@ -39,10 +39,9 @@ import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 import           Ouroboros.Consensus.Util.STM (blockUntilJust)
 
-import           Ouroboros.Storage.ChainDB.API (BlockOrHeader (..),
-                     ChainDbError (..), Deserialisable (..), Reader (..),
-                     ReaderId, deserialisablePoint)
-
+import           Ouroboros.Storage.ChainDB.API (BlockComponent (..), ChainDB,
+                     ChainDbError (..), Reader (..), ReaderId, getPoint)
+import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB)
 import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
 import qualified Ouroboros.Storage.ChainDB.Impl.Query as Query
 import           Ouroboros.Storage.ChainDB.Impl.Types
@@ -51,56 +50,36 @@ import           Ouroboros.Storage.ChainDB.Impl.Types
   Accessing the environment
 -------------------------------------------------------------------------------}
 
-getReadersVar
-  :: ChainDbEnv m blk
-  -> BlockOrHeader blk b
-  -> StrictTVar m (Map ReaderId (StrictTVar m (ReaderState m blk b)))
-getReadersVar env = \case
-    Block  -> cdbBlockReaders  env
-    Header -> cdbHeaderReaders env
-
-getReaderVar
-  :: IOLike m
-  => ChainDbEnv m blk
-  -> BlockOrHeader blk b
-  -> ReaderId
-  -> STM m (Maybe (StrictTVar m (ReaderState m blk b)))
-getReaderVar env blockOrHeader readerId =
-  fmap (Map.lookup readerId) $ readTVar $ getReadersVar env blockOrHeader
-
 -- | Check if the ChainDB is open. If not, throw a 'ClosedDBError'. Next,
 -- check whether the reader with the given 'ReaderId' still exists. If not,
 -- throw a 'ClosedReaderError'.
 --
--- Otherwise, execute the given function on the 'ChainDbEnv' and 'ReaderState'
--- 'StrictTVar'.
+-- Otherwise, execute the given function on the 'ChainDbEnv'.
 getReader
-  :: forall m blk b r. (IOLike m, HasCallStack)
+  :: forall m blk r. (IOLike m, HasCallStack)
   => ChainDbHandle m blk
   -> ReaderId
-  -> BlockOrHeader blk b
-  -> (ChainDbEnv m blk -> StrictTVar m (ReaderState m blk b) -> m r)
+  -> (ChainDbEnv m blk -> m r)
   -> m r
-getReader (CDBHandle varState) readerId blockOrHeader f = do
-    (env, varRdr) <- atomically $ readTVar varState >>= \case
+getReader (CDBHandle varState) readerId f = do
+    env <- atomically $ readTVar varState >>= \case
       ChainDbClosed _env -> throwM $ ClosedDBError callStack
-      -- See the docstring of 'ChainDbReopening'
       ChainDbReopening   -> error "ChainDB used while reopening"
-      ChainDbOpen    env -> getReaderVar env blockOrHeader readerId >>= \case
-        Nothing     -> throwM $ ClosedReaderError readerId
-        Just varRdr -> return (env, varRdr)
-    f env varRdr
+      ChainDbOpen env    -> do
+        readerOpen <- Map.member readerId <$> readTVar (cdbReaders env)
+        if readerOpen
+          then return env
+          else throwM $ ClosedReaderError readerId
+    f env
 
 -- | Variant 'of 'getReader' for functions taking one argument.
 getReader1
-  :: forall m blk b a r. IOLike m
+  :: forall m blk a r. IOLike m
   => ChainDbHandle m blk
   -> ReaderId
-  -> BlockOrHeader blk b
-  -> (ChainDbEnv m blk -> StrictTVar m (ReaderState m blk b) -> a -> m r)
+  -> (ChainDbEnv m blk -> a -> m r)
   -> a -> m r
-getReader1 h rdrId blockOrHeader f a =
-    getReader h rdrId blockOrHeader (\env varReader -> f env varReader a)
+getReader1 h readerId f a = getReader h readerId (\env -> f env a)
 
 {-------------------------------------------------------------------------------
   Reader
@@ -111,75 +90,93 @@ newReader
      ( IOLike m
      , HasHeader blk
      , HasHeader (Header blk)
-     , HeaderHash blk ~ HeaderHash b
      )
   => ChainDbHandle m blk
   -> (Header blk -> Encoding)
      -- ^ Needed to serialise a deserialised header that we already had in
      -- memory.
-  -> BlockOrHeader blk b
   -> ResourceRegistry m
-  -> m (Reader m blk (Deserialisable m blk b))
-newReader h encodeHeader blockOrHeader registry = getEnv h $ \cdb@CDB{..} -> do
+  -> BlockComponent (ChainDB m blk) b
+  -> m (Reader m blk b)
+newReader h encodeHeader registry blockComponent = getEnv h $ \CDB{..} -> do
+    -- The following operations don't need to be done in a single transaction
     readerId  <- atomically $ updateTVar cdbNextReaderId $ \r -> (succ r, r)
     varReader <- newTVarM ReaderInit
-    let readersVar = getReadersVar cdb blockOrHeader
-    atomically $ modifyTVar readersVar $ Map.insert readerId varReader
-    let reader = makeNewReader h encodeHeader readerId blockOrHeader registry
+    let readerHandle = mkReaderHandle cdbImmDB varReader
+    atomically $ modifyTVar cdbReaders $ Map.insert readerId readerHandle
+    let reader = makeNewReader h encodeHeader readerId varReader registry
+          blockComponent
     traceWith cdbTracer $ TraceReaderEvent $ NewReader readerId
     return reader
+  where
+    mkReaderHandle
+      :: ImmDB m blk
+      -> StrictTVar m (ReaderState m blk b)
+      -> ReaderHandle m blk
+    mkReaderHandle cdbImmDB varReader = ReaderHandle
+      { rhClose      = do
+          -- This is only called by 'closeAllReaders'. We just release the
+          -- resources. We don't check whether the Reader is still open.
+          -- We don't have to remove the reader from the 'cdbReaders',
+          -- 'closeAllReaders' will empty that map already.
+          readerState <- atomically $ readTVar varReader
+          closeReaderState cdbImmDB readerState
+      , rhSwitchFork = \ipoint newChain -> modifyTVar varReader $
+          switchFork ipoint newChain
+      }
 
 makeNewReader
   :: forall m blk b.
      ( IOLike m
      , HasHeader blk
      , HasHeader (Header blk)
-     , HeaderHash blk ~ HeaderHash b
      )
   => ChainDbHandle m blk
   -> (Header blk -> Encoding)
   -> ReaderId
-  -> BlockOrHeader blk b
+  -> StrictTVar m (ReaderState m blk b)
   -> ResourceRegistry m
-  -> Reader m blk (Deserialisable m blk b)
-makeNewReader h encodeHeader readerId blockOrHeader registry = Reader {..}
+  -> BlockComponent (ChainDB m blk) b
+  -> Reader m blk b
+makeNewReader h encodeHeader readerId varReader registry blockComponent = Reader {..}
   where
-    readerInstruction :: m (Maybe (ChainUpdate blk (Deserialisable m blk b)))
-    readerInstruction = getReader h readerId blockOrHeader $
-      instructionHelper registry encodeHeader blockOrHeader id
+    readerInstruction :: m (Maybe (ChainUpdate blk b))
+    readerInstruction = getReader h readerId $
+      instructionHelper registry varReader blockComponent encodeHeader id
 
-    readerInstructionBlocking :: m (ChainUpdate blk (Deserialisable m blk b))
+    readerInstructionBlocking :: m (ChainUpdate blk b)
     readerInstructionBlocking = fmap runIdentity $
-      getReader h readerId blockOrHeader $
-      instructionHelper registry encodeHeader blockOrHeader (fmap Identity . blockUntilJust)
+      getReader h readerId $
+      instructionHelper registry varReader blockComponent encodeHeader
+        (fmap Identity . blockUntilJust)
 
     readerForward :: [Point blk] -> m (Maybe (Point blk))
-    readerForward = getReader1 h readerId blockOrHeader $
-      forward registry blockOrHeader
+    readerForward = getReader1 h readerId $
+      forward registry varReader blockComponent
 
     readerClose :: m ()
-    readerClose = getEnv h $ close blockOrHeader readerId
+    readerClose = getEnv h $ close readerId varReader
 
+-- | Implementation of 'readerClose'.
+--
+-- To be called using 'getEnv' to make sure the ChainDB is still open.
+--
+-- Idempotent: the reader doesn't have to be open.
+--
+-- Unlike 'closeAllReaders', this is meant to be called by the user of the
+-- ChainDB.Reader.
 close
   :: forall m blk b. IOLike m
-  => BlockOrHeader blk b -> ReaderId -> ChainDbEnv m blk -> m ()
-close blockOrHeader readerId cdb@CDB { cdbImmDB } = do
-    mbReaderState <- atomically $ do
-      readers <- readTVar varReaders
-      let (mbReader, readers') = delete readerId readers
-      writeTVar varReaders readers'
-      traverse readTVar mbReader
+  => ReaderId
+  -> StrictTVar m (ReaderState m blk b)
+  -> ChainDbEnv m blk
+  -> m ()
+close readerId varReader CDB { cdbReaders, cdbImmDB } = do
     -- If the ReaderId is not present in the map, the Reader must have been
     -- closed already.
-    mapM_ (closeReaderState cdbImmDB) mbReaderState
-  where
-    varReaders = getReadersVar cdb blockOrHeader
-
-    -- | Delete the entry corresponding to the given key from the map. If it
-    -- existed, return it, otherwise, return 'Nothing'. The updated map is of
-    -- course also returned.
-    delete :: forall k a. Ord k => k -> Map k a -> (Maybe a, Map k a)
-    delete = Map.updateLookupWithKey (\_ _ -> Nothing)
+    atomically $ modifyTVar cdbReaders $ Map.delete readerId
+    readerState <- atomically $ readTVar varReader
+    closeReaderState cdbImmDB readerState
 
 -- | Close the given 'ReaderState' by closing any 'ImmDB.Iterator' it might
 -- contain.
@@ -200,8 +197,7 @@ closeReaderState immDB = \case
 -- * 'Maybe' in case of 'readerInstruction'.
 -- * 'Identity' in case of 'readerInstructionBlocking'.
 --
--- The returned 'ChainUpdate' contains a 'b', which can either be a @blk@ or a
--- @'Header' blk@.
+-- The returned 'ChainUpdate' contains a 'b', as defined by 'BlockComponent'.
 --
 -- When in the 'ReaderInImmDB' state, we never have to block, as we can just
 -- stream the next block/header from the ImmutableDB.
@@ -213,12 +209,12 @@ instructionHelper
      ( IOLike m
      , HasHeader blk
      , HasHeader (Header blk)
-     , HeaderHash blk ~ HeaderHash b
      , Traversable f, Applicative f
      )
   => ResourceRegistry m
+  -> StrictTVar m (ReaderState m blk b)
+  -> BlockComponent (ChainDB m blk) b
   -> (Header blk -> Encoding)
-  -> BlockOrHeader blk b
   -> (    STM m (Maybe (ChainUpdate blk (Header blk)))
        -> STM m (f     (ChainUpdate blk (Header blk))))
      -- ^ How to turn a transaction that may or may not result in a new
@@ -226,9 +222,8 @@ instructionHelper
      -- Identity . 'blockUntilJust'@ to block or 'id' to just return the
      -- @Maybe@.
   -> ChainDbEnv m blk
-  -> StrictTVar m (ReaderState m blk b)
-  -> m (f (ChainUpdate blk (Deserialisable m blk b)))
-instructionHelper registry encodeHeader blockOrHeader fromMaybeSTM CDB{..} varReader = do
+  -> m (f (ChainUpdate blk b))
+instructionHelper registry varReader blockComponent encodeHeader fromMaybeSTM CDB{..} = do
     -- In one transaction: check in which state we are, if in the
     -- @ReaderInMem@ state, just call 'instructionSTM', otherwise,
     -- return the contents of the 'ReaderInImmDB' state.
@@ -259,12 +254,9 @@ instructionHelper registry encodeHeader blockOrHeader fromMaybeSTM CDB{..} varRe
           -> return $ Left (rollState, Nothing)
     case inImmDBOrRes of
       -- We were able to obtain the result inside the transaction as we were
-      -- in the 'ReaderInMem' state.
-      Right fupdate -> case blockOrHeader of
-        -- We only got the header, so we have to read the whole block if
-        -- that's requested.
-        Block  -> traverse (traverse toDeserialisableBlock)  fupdate
-        Header -> traverse (traverse toDeserialisableHeader) fupdate
+      -- in the 'ReaderInMem' state. We only got a header, which we must first
+      -- convert to the right block component.
+      Right fupdate -> headerUpdateToBlockComponentUpdate fupdate
       -- We were in the 'ReaderInImmDB' state or we need to switch to it.
       Left (rollState, mbImmIt) -> case rollState of
         RollForwardFrom pt -> do
@@ -274,48 +266,71 @@ instructionHelper registry encodeHeader blockOrHeader fromMaybeSTM CDB{..} varRe
             -- 'ReaderInImmDB' state.
             Nothing    -> do
               trace $ ReaderNoLongerInMem rollState
-              ImmDB.streamAfterKnownBlock cdbImmDB registry blockOrHeader pt
+              ImmDB.streamAfterKnownBlock cdbImmDB registry
+                ((,) <$> getPoint <*> blockComponent) pt
           rollForwardImmDB immIt pt
         RollBackTo      pt -> do
           case mbImmIt of
             Just immIt -> ImmDB.iteratorClose cdbImmDB immIt
             Nothing    -> trace $ ReaderNoLongerInMem rollState
-          immIt' <- ImmDB.streamAfterKnownBlock cdbImmDB registry blockOrHeader pt
+          immIt' <- ImmDB.streamAfterKnownBlock cdbImmDB registry
+            ((,) <$> getPoint <*> blockComponent) pt
           let readerState' = ReaderInImmDB (RollForwardFrom pt) immIt'
           atomically $ writeTVar varReader readerState'
           return $ pure $ RollBack pt
   where
     trace = traceWith (contramap TraceReaderEvent cdbTracer)
 
-    toDeserialisableHeader :: Header blk -> m (Deserialisable m blk (Header blk))
-    toDeserialisableHeader hdr = return Deserialisable
-      { serialised         = Serialised $ toLazyByteString (encodeHeader hdr)
-      , deserialisableSlot = blockSlot hdr
-      , deserialisableHash = headerHash hdr
-      , deserialise        = return hdr
-      }
+    headerUpdateToBlockComponentUpdate
+      :: f (ChainUpdate blk (Header blk)) -> m (f (ChainUpdate blk b))
+    headerUpdateToBlockComponentUpdate =
+      traverse (traverse (`getBlockComponentFromHeader` blockComponent))
 
-    toDeserialisableBlock :: Header blk -> m (Deserialisable m blk blk)
-    toDeserialisableBlock hdr = Query.getAnyKnownDeserialisableBlockOrHeader
-      cdbImmDB cdbVolDB Block (headerPoint hdr)
+    -- | We only got the header for the in-memory chain fragment, so depending
+    -- on the 'BlockComponent' that's requested, we might have to read the
+    -- whole block.
+    getBlockComponentFromHeader
+      :: forall b'. Header blk -> BlockComponent (ChainDB m blk) b' -> m b'
+    getBlockComponentFromHeader hdr = \case
+        GetBlock      -> getBlockComponent GetBlock
+        GetRawBlock   -> getBlockComponent GetRawBlock
+        GetHeader     -> return $ return hdr
+        GetRawHeader  -> return $ toLazyByteString $ encodeHeader hdr
+        GetHash       -> return $ headerHash hdr
+        GetSlot       -> return $ blockSlot hdr
+        GetIsEBB      -> return $ cdbIsEBB hdr
+        GetBlockSize  -> getBlockComponent GetBlockSize
+        -- We could look up the header size in the index of the VolatileDB,
+        -- but getting the serialisation is cheap because we keep the
+        -- serialisation in memory as an annotation, and the following way is
+        -- less stateful
+        GetHeaderSize -> return $
+          fromIntegral $ Lazy.length $ toLazyByteString $ encodeHeader hdr
+        GetPure a     -> return a
+        GetApply f bc ->
+          getBlockComponentFromHeader hdr f <*>
+          getBlockComponentFromHeader hdr bc
+      where
+        -- | Use the 'ImmDB' and 'VolDB' to read the 'BlockComponent' from
+        -- disk (or memory).
+        getBlockComponent :: forall c. BlockComponent (ChainDB m blk) c -> m c
+        getBlockComponent bc =
+          Query.getAnyKnownBlockComponent cdbImmDB cdbVolDB bc (headerPoint hdr)
 
     next
-      :: ImmDB.Iterator (HeaderHash blk) m (Deserialisable m blk b)
-      -> m (Maybe (Deserialisable m blk b))
+      :: ImmDB.Iterator (HeaderHash blk) m (Point blk, b)
+      -> m (Maybe (Point blk, b))
     next immIt = ImmDB.iteratorNext cdbImmDB immIt <&> \case
-      ImmDB.IteratorResult _ _ b -> Just b
-      ImmDB.IteratorEBB    _ _ b -> Just b
-      ImmDB.IteratorExhausted    -> Nothing
+      ImmDB.IteratorResult  b -> Just b
+      ImmDB.IteratorExhausted -> Nothing
 
     rollForwardImmDB
-      :: ImmDB.Iterator (HeaderHash blk) m (Deserialisable m blk b)
+      :: ImmDB.Iterator (HeaderHash blk) m (Point blk, b)
       -> Point blk
-      -> m (f (ChainUpdate blk (Deserialisable m blk b)))
+      -> m (f (ChainUpdate blk b))
     rollForwardImmDB immIt pt = next immIt >>= \case
-      Just b -> do
-        let pt' :: Point blk
-            pt' = castPoint (deserialisablePoint b)
-            readerState' = ReaderInImmDB (RollForwardFrom pt') immIt
+      Just (pt', b) -> do
+        let readerState' = ReaderInImmDB (RollForwardFrom pt') immIt
         atomically $ writeTVar varReader readerState'
         return $ pure $ AddBlock b
       Nothing  -> do
@@ -344,9 +359,9 @@ instructionHelper registry encodeHeader blockOrHeader fromMaybeSTM CDB{..} varRe
                 (RollForwardFrom pt)
                 curChain
                 (writeTVar varReader . ReaderInMem)
-            case blockOrHeader of
-              Header -> traverse (traverse toDeserialisableHeader) fupdate
-              Block  -> traverse (traverse toDeserialisableBlock)  fupdate
+            -- We only got the header, we must first convert it to the right
+            -- block component.
+            headerUpdateToBlockComponentUpdate fupdate
 
           -- Two possibilities:
           --
@@ -358,7 +373,8 @@ instructionHelper registry encodeHeader blockOrHeader fromMaybeSTM CDB{..} varRe
           --    opened the iterator.
           _  -> do
             trace $ ReaderNewImmIterator pt slotNoAtImmDBTip
-            immIt' <- ImmDB.streamAfterKnownBlock cdbImmDB registry blockOrHeader pt
+            immIt' <- ImmDB.streamAfterKnownBlock cdbImmDB registry
+              ((,) <$> getPoint <*> blockComponent) pt
             -- Try again with the new iterator
             rollForwardImmDB immIt' pt
 
@@ -396,12 +412,12 @@ forward
      , HasHeader (Header blk)
      )
   => ResourceRegistry m
-  -> BlockOrHeader blk b
-  -> ChainDbEnv m blk
   -> StrictTVar m (ReaderState m blk b)
+  -> BlockComponent (ChainDB m blk) b
+  -> ChainDbEnv m blk
   -> [Point blk]
   -> m (Maybe (Point blk))
-forward registry blockOrHeader CDB{..} varReader = \pts -> do
+forward registry varReader blockComponent CDB{..} = \pts -> do
     -- The current state of the reader doesn't matter, the given @pts@ could
     -- be in the current chain fragment or in the ImmutableDB.
 
@@ -434,7 +450,8 @@ forward registry blockOrHeader CDB{..} varReader = \pts -> do
             else ImmDB.hasBlock cdbImmDB pt
           if inImmDB
             then do
-              immIt <- ImmDB.streamAfterKnownBlock cdbImmDB registry blockOrHeader pt
+              immIt <- ImmDB.streamAfterKnownBlock cdbImmDB registry
+                ((,) <$> getPoint <*> blockComponent) pt
               updateState $ ReaderInImmDB (RollBackTo pt) immIt
               return $ Just pt
             else findFirstPointOnChain curChain slotNoAtImmDBTip pts
@@ -518,11 +535,8 @@ switchFork ipoint newChain readerState =
 -- | Close all open block and header 'Reader's.
 closeAllReaders :: IOLike m => ChainDbEnv m blk -> m ()
 closeAllReaders CDB{..} = do
-    (blockReaderStates, headerReaderStates) <- atomically $ do
-      blockReaderStates  <- readTVar cdbBlockReaders  >>= traverse readTVar . Map.elems
-      headerReaderStates <- readTVar cdbHeaderReaders >>= traverse readTVar . Map.elems
-      writeTVar cdbBlockReaders  Map.empty
-      writeTVar cdbHeaderReaders Map.empty
-      return (blockReaderStates, headerReaderStates)
-    mapM_ (closeReaderState cdbImmDB) blockReaderStates
-    mapM_ (closeReaderState cdbImmDB) headerReaderStates
+    readerHandles <- atomically $ do
+      readerHandles  <- Map.elems <$> readTVar cdbReaders
+      writeTVar cdbReaders  Map.empty
+      return readerHandles
+    mapM_ rhClose readerHandles

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reopen.hs
@@ -33,7 +33,7 @@ import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Storage.Common (EpochNo)
 import           Ouroboros.Storage.EpochInfo (epochInfoEpoch)
 
-import           Ouroboros.Storage.ChainDB.API (BlockOrHeader (..))
+import           Ouroboros.Storage.ChainDB.API (BlockComponent (..))
 import qualified Ouroboros.Storage.ChainDB.Impl.Background as Background
 import           Ouroboros.Storage.ChainDB.Impl.ChainSel
 import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
@@ -121,7 +121,7 @@ reopen (CDBHandle varState) launchBgTasks = do
         ImmDB.reopen cdbImmDB
         -- In order to figure out the 'BlockNo' and 'Point' at the tip of the
         -- ImmutableDB, we need to read the header at the tip of the ImmutableDB.
-        immDbTipHeader <- ImmDB.getBlockOrHeaderAtTip cdbImmDB Header
+        immDbTipHeader <- sequence =<< ImmDB.getBlockComponentAtTip cdbImmDB GetHeader
         -- Note that 'immDbTipBlockNo' might not end up being the \"immutable\"
         -- block(no), because the current chain computed from the VolatileDB could
         -- be longer than @k@.

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Types.hs
@@ -1,14 +1,15 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DeriveAnyClass       #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE DerivingVia          #-}
-{-# LANGUAGE FlexibleContexts     #-}
-{-# LANGUAGE LambdaCase           #-}
-{-# LANGUAGE RankNTypes           #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
-{-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 {-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Types used throughout the implementation: handle, state, environment,
@@ -24,7 +25,10 @@ module Ouroboros.Storage.ChainDB.Impl.Types (
     -- * Exposed internals for testing purposes
   , Internal (..)
   , intReopen
+    -- * Iterator-related
+  , IteratorKey (..)
     -- * Reader-related
+  , ReaderKey (..)
   , ReaderHandle (..)
   , ReaderState (..)
   , ReaderRollState (..)
@@ -75,8 +79,7 @@ import           Ouroboros.Storage.Common (EpochNo)
 import           Ouroboros.Storage.EpochInfo (EpochInfo)
 
 import           Ouroboros.Storage.ChainDB.API (ChainDbError (..),
-                     InvalidBlockReason, IteratorId, ReaderId, StreamFrom,
-                     StreamTo, UnknownRange)
+                     InvalidBlockReason, StreamFrom, StreamTo, UnknownRange)
 
 import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB)
 import qualified Ouroboros.Storage.ChainDB.Impl.ImmDB as ImmDB
@@ -139,10 +142,10 @@ data ChainDbState m blk
   deriving (Generic, NoUnexpectedThunks)
 
 data ChainDbEnv m blk = CDB
-  { cdbImmDB          :: !(ImmDB m blk)
-  , cdbVolDB          :: !(VolDB m blk)
-  , cdbLgrDB          :: !(LgrDB m blk)
-  , cdbChain          :: !(StrictTVar m (AnchoredFragment (Header blk)))
+  { cdbImmDB           :: !(ImmDB m blk)
+  , cdbVolDB           :: !(VolDB m blk)
+  , cdbLgrDB           :: !(LgrDB m blk)
+  , cdbChain           :: !(StrictTVar m (AnchoredFragment (Header blk)))
     -- ^ Contains the current chain fragment.
     --
     -- INVARIANT: the anchor point of this fragment is the tip of the
@@ -155,7 +158,7 @@ data ChainDbEnv m blk = CDB
     -- Note that this fragment might also be /longer/ than @k@ headers,
     -- because the oldest blocks from the fragment might not yet have been
     -- copied from the VolatileDB to the ImmutableDB.
-  , cdbImmBlockNo     :: !(StrictTVar m BlockNo)
+  , cdbImmBlockNo      :: !(StrictTVar m BlockNo)
     -- ^ The block number corresponding to the block @k@ blocks back. This is
     -- the most recent \"immutable\" block according to the protocol, i.e., a
     -- block that cannot be rolled back.
@@ -175,50 +178,50 @@ data ChainDbEnv m blk = CDB
     --
     -- Note that the \"immutable\" block will /never/ be /more/ than @k@
     -- blocks back, as opposed to the anchor point of 'cdbChain'.
-  , cdbIterators      :: !(StrictTVar m (Map IteratorId (m ())))
+  , cdbIterators       :: !(StrictTVar m (Map IteratorKey (m ())))
     -- ^ The iterators.
     --
-    -- This maps the 'IteratorId's of each open 'Iterator' to a function that,
-    -- when called, closes the iterator. This is used when closing the
+    -- This maps the 'IteratorKey's of each open 'Iterator' to a function
+    -- that, when called, closes the iterator. This is used when closing the
     -- ChainDB: the open file handles used by iterators can be closed, and the
     -- iterators themselves are closed so that it is impossible to use an
     -- iterator after closing the ChainDB itself.
-  , cdbReaders        :: !(StrictTVar m (Map ReaderId (ReaderHandle m blk)))
+  , cdbReaders         :: !(StrictTVar m (Map ReaderKey (ReaderHandle m blk)))
     -- ^ The readers.
     --
-    -- A reader is open iff its 'ReaderId' is this 'Map'.
+    -- A reader is open iff its 'ReaderKey' is this 'Map'.
     --
     -- INVARIANT: the 'readerPoint' of each reader is 'withinFragmentBounds'
     -- of the current chain fragment (retrieved 'cdbGetCurrentChain', not by
     -- reading 'cdbChain' directly).
-  , cdbNodeConfig     :: !(NodeConfig (BlockProtocol blk))
-  , cdbInvalid        :: !(StrictTVar m (WithFingerprint (InvalidBlocks blk)))
+  , cdbNodeConfig      :: !(NodeConfig (BlockProtocol blk))
+  , cdbInvalid         :: !(StrictTVar m (WithFingerprint (InvalidBlocks blk)))
     -- ^ See the docstring of 'InvalidBlocks'.
     --
     -- The 'Fingerprint' changes every time a hash is added to the map, but
     -- not when hashes are garbage-collected from the map.
-  , cdbNextIteratorId :: !(StrictTVar m IteratorId)
-  , cdbNextReaderId   :: !(StrictTVar m ReaderId)
-  , cdbCopyLock       :: !(StrictMVar m ())
+  , cdbNextIteratorKey :: !(StrictTVar m IteratorKey)
+  , cdbNextReaderKey   :: !(StrictTVar m ReaderKey)
+  , cdbCopyLock        :: !(StrictMVar m ())
     -- ^ Lock used to ensure that 'copyToImmDB' is not executed more than
     -- once concurrently.
     --
     -- Note that 'copyToImmDB' can still be executed concurrently with all
     -- others functions, just not with itself.
-  , cdbTracer         :: !(Tracer m (TraceEvent blk))
-  , cdbTraceLedger    :: !(Tracer m (LgrDB.LedgerDB blk))
-  , cdbRegistry       :: !(ResourceRegistry m)
+  , cdbTracer          :: !(Tracer m (TraceEvent blk))
+  , cdbTraceLedger     :: !(Tracer m (LgrDB.LedgerDB blk))
+  , cdbRegistry        :: !(ResourceRegistry m)
     -- ^ Resource registry that will be used to (re)start the background
     -- threads, see 'cdbBgThreads'.
-  , cdbGcDelay        :: !DiffTime
+  , cdbGcDelay         :: !DiffTime
     -- ^ How long to wait between copying a block from the VolatileDB to
     -- ImmutableDB and garbage collecting it from the VolatileDB
-  , cdbKillBgThreads  :: !(StrictTVar m (m ()))
+  , cdbKillBgThreads   :: !(StrictTVar m (m ()))
     -- ^ A handle to kill the background threads.
-  , cdbEpochInfo      :: !(EpochInfo m)
-  , cdbIsEBB          :: !(Header blk -> IsEBB)
-  , cdbBlockchainTime :: !(BlockchainTime m)
-  , cdbFutureBlocks   :: !(StrictTVar m (Map SlotNo (NonEmpty (Header blk))))
+  , cdbEpochInfo       :: !(EpochInfo m)
+  , cdbIsEBB           :: !(Header blk -> IsEBB)
+  , cdbBlockchainTime  :: !(BlockchainTime m)
+  , cdbFutureBlocks    :: !(StrictTVar m (Map SlotNo (NonEmpty (Header blk))))
     -- ^ Scheduled chain selections for blocks with a slot in the future.
     --
     -- When a block with slot @s@, which is > the current slot is added, we
@@ -272,6 +275,20 @@ intReopen :: HasCallStack => Internal m blk -> Bool -> m ()
 intReopen = intReopen_
 
 {-------------------------------------------------------------------------------
+  Iterator-related
+-------------------------------------------------------------------------------}
+
+-- | We use this internally to track iterators in a map ('cdbIterators') in
+-- the ChainDB state so that we can remove them from the map when the iterator
+-- is closed.
+--
+-- We store them in the map so that the ChainDB can close all open iterators
+-- when it is closed itself.
+newtype IteratorKey = IteratorKey Word
+  deriving stock   (Show)
+  deriving newtype (Eq, Ord, Enum, NoUnexpectedThunks)
+
+{-------------------------------------------------------------------------------
   Reader-related
 -------------------------------------------------------------------------------}
 
@@ -279,6 +296,17 @@ intReopen = intReopen_
 -- depends on them, 'ChainDbEnv.cdbTracer' depends on 'TraceEvent', and most
 -- modules depend on 'ChainDbEnv'. Also, 'ChainDbEnv.cdbReaders' depends on
 -- 'ReaderState'.
+
+-- | We use this internally to track reader in a map ('cdbReaders') in the
+-- ChainDB state so that we can remove them from the map when the reader is
+-- closed.
+--
+-- We store them in the map so that the ChainDB can close all open readers
+-- when it is closed itself and to update the readers in case we switch to a
+-- different chain.
+newtype ReaderKey = ReaderKey Word
+  deriving stock   (Show)
+  deriving newtype (Eq, Ord, Enum, NoUnexpectedThunks)
 
 -- | Internal handle to a 'Reader' without an explicit @b@ (@blk@, @'Header'
 -- blk@, etc.) parameter so 'Reader's with different' @b@s can be stored
@@ -534,7 +562,7 @@ deriving instance
 
 
 data TraceReaderEvent blk
-  = NewReader ReaderId
+  = NewReader
     -- ^ A new reader was created.
 
   | ReaderNoLongerInMem (ReaderRollState blk)

--- a/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Common.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DeriveTraversable          #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE GADTs             #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 module Ouroboros.Storage.Common (
     -- * Epochs
@@ -19,6 +21,10 @@ module Ouroboros.Storage.Common (
   , decodeTip
     -- * BinaryInfo
   , BinaryInfo (..)
+    -- * BlockComponent
+  , DB (..)
+  , BlockComponent (..)
+  , castBlockComponent
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)
@@ -26,15 +32,17 @@ import qualified Codec.CBOR.Decoding as Dec
 import           Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as Enc
 import           Codec.Serialise (Serialise (..))
+import           Data.ByteString.Lazy (ByteString)
 import           Data.Word
 import           GHC.Generics
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..))
 
-import           Ouroboros.Network.Block (Point (..), genesisPoint)
+import           Ouroboros.Network.Block (Point (..), SlotNo, genesisPoint)
 import           Ouroboros.Network.Point (WithOrigin (..))
 
+import           Ouroboros.Consensus.Block (IsEBB)
 import           Ouroboros.Consensus.Util.Condense
 
 {-------------------------------------------------------------------------------
@@ -113,4 +121,65 @@ data BinaryInfo blob = BinaryInfo
     -- In the future, i.e. Shelley, we might want to extend this to include a
     -- field to tell where the transaction body ends and where the transaction
     -- witnesses begin so we can only extract the transaction body.
-  } deriving (Show, Generic, Functor)
+  } deriving (Eq, Show, Generic, Functor)
+
+
+{-------------------------------------------------------------------------------
+  BlockComponent
+-------------------------------------------------------------------------------}
+
+-- | The type of a block, header, and header hash of a database. Used by
+-- 'BlockComponent'.
+class DB db where
+  type DBBlock      db
+  type DBHeader     db
+  type DBHeaderHash db
+
+-- | Which component of the block to read from a database: the whole block,
+-- its header, its hash, the block size, ..., or combinations thereof.
+--
+-- NOTE: when requesting multiple components, we will not optimise/cache them.
+data BlockComponent db a where
+  GetBlock      :: BlockComponent db (DBBlock db)
+  GetRawBlock   :: BlockComponent db ByteString
+  GetHeader     :: BlockComponent db (DBHeader db)
+  GetRawHeader  :: BlockComponent db ByteString
+  GetHash       :: BlockComponent db (DBHeaderHash db)
+  GetSlot       :: BlockComponent db SlotNo
+  GetIsEBB      :: BlockComponent db IsEBB
+  GetBlockSize  :: BlockComponent db Word32
+  GetHeaderSize :: BlockComponent db Word16
+  GetPure       :: a
+                -> BlockComponent db a
+  GetApply      :: BlockComponent db (a -> b)
+                -> BlockComponent db a
+                -> BlockComponent db b
+
+instance Functor (BlockComponent db) where
+  fmap f = (GetPure f <*>)
+
+instance Applicative (BlockComponent db) where
+  pure  = GetPure
+  (<*>) = GetApply
+
+-- | Cast one 'BlockComponent' to another when all associated types of the two
+-- databases match.
+castBlockComponent
+  :: ( DBBlock      db1 ~ DBBlock      db2
+     , DBHeader     db1 ~ DBHeader     db2
+     , DBHeaderHash db1 ~ DBHeaderHash db2
+     )
+  => BlockComponent db1 b
+  -> BlockComponent db2 b
+castBlockComponent = \case
+    GetBlock      -> GetBlock
+    GetRawBlock   -> GetRawBlock
+    GetHeader     -> GetHeader
+    GetRawHeader  -> GetRawHeader
+    GetHash       -> GetHash
+    GetSlot       -> GetSlot
+    GetIsEBB      -> GetIsEBB
+    GetBlockSize  -> GetBlockSize
+    GetHeaderSize -> GetHeaderSize
+    GetPure a     -> GetPure a
+    GetApply f bc -> GetApply (castBlockComponent f) (castBlockComponent bc)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -3,10 +3,12 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE TypeFamilies      #-}
 module Ouroboros.Storage.ImmutableDB.API
   ( ImmutableDB (..)
   , Iterator (..)
   , IteratorResult (..)
+  , traverseIterator
   , iteratorToList
 
   , module Ouroboros.Storage.ImmutableDB.Types
@@ -16,7 +18,6 @@ import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..),
                      ThunkInfo (..))
 
 import           Data.ByteString.Builder (Builder)
-import           Data.ByteString.Lazy (ByteString)
 import           Data.Function (on)
 
 import           GHC.Generics (Generic)
@@ -89,8 +90,7 @@ data ImmutableDB hash m = ImmutableDB
   , getTip
       :: HasCallStack => m (ImmTipWithHash hash)
 
-    -- | Get the block as a 'ByteString' and its header hash stored at the given
-    -- 'SlotNo'.
+    -- | Get the block component of the block at the given 'SlotNo'.
     --
     -- Returns 'Nothing' if no blob was stored at the given slot.
     --
@@ -98,37 +98,24 @@ data ImmutableDB hash m = ImmutableDB
     -- i.e > the result of 'getTip'.
     --
     -- Throws a 'ClosedDBError' if the database is closed.
-  , getBlock
-      :: HasCallStack => SlotNo -> m (Maybe (hash, ByteString))
+  , getBlockComponent
+      :: forall b. HasCallStack
+      => BlockComponent (ImmutableDB hash m) b -> SlotNo -> m (Maybe b)
 
-    -- | Variant of 'getBlock' that only reads the header.
-  , getBlockHeader
-      :: HasCallStack => SlotNo -> m (Maybe (hash, ByteString))
-
-    -- | Variant of 'getBlock' that only reads the hash.
-  , getBlockHash
-      :: HasCallStack => SlotNo -> m (Maybe hash)
-
-    -- | Get the EBB (Epoch Boundary Block) as a 'ByteString' and its header
-    -- hash of the given epoch.
+    -- | Get the block component of the EBB (Epoch Boundary Block) of the
+    -- given epoch.
     --
     -- Returns 'Nothing' if no EEB was stored for the given epoch.
     --
     -- Throws a 'ReadFutureEBBError' if the requested EBB is in the future.
     --
     -- Throws a 'ClosedDBError' if the database is closed.
-  , getEBB
-      :: HasCallStack => EpochNo -> m (Maybe (hash, ByteString))
+  , getEBBComponent
+      :: forall b. HasCallStack
+      => BlockComponent (ImmutableDB hash m) b -> EpochNo -> m (Maybe b)
 
-    -- | Variant of 'getEBB' that only reads the header.
-  , getEBBHeader
-      :: HasCallStack => EpochNo -> m (Maybe (hash, ByteString))
-
-    -- | Variant of 'getEBB' that only returns the hash.
-  , getEBBHash
-      :: HasCallStack => EpochNo -> m (Maybe hash)
-
-    -- | Get the block or EBB at the given slot with the given hash.
+    -- | Get the block component of the block or EBB at the given slot with
+    -- the given hash.
     --
     -- Also return 'EpochNo' in case of an EBB or the given 'SlotNo' in case
     -- of a regular block.
@@ -140,14 +127,9 @@ data ImmutableDB hash m = ImmutableDB
     -- Throws a 'ReadFutureSlotError' if the requested slot is in the future.
     --
     -- Throws a 'ClosedDBError' if the database is closed.
-  , getBlockOrEBB
-      :: HasCallStack
-      => SlotNo -> hash -> m (Maybe (Either EpochNo SlotNo, ByteString))
-
-    -- | Variant of 'getBlockOrEBB' that only returns the header.
-  , getBlockOrEBBHeader
-      :: HasCallStack
-      => SlotNo -> hash -> m (Maybe (Either EpochNo SlotNo, ByteString))
+  , getBlockOrEBBComponent
+      :: forall b. HasCallStack
+      => BlockComponent (ImmutableDB hash m) b -> SlotNo -> hash -> m (Maybe b)
 
     -- | Appends a block at the given slot.
     --
@@ -214,26 +196,25 @@ data ImmutableDB hash m = ImmutableDB
     --
     -- The iterator is automatically closed when exhausted, and can be
     -- prematurely closed with 'iteratorClose'.
-  , streamBlocks
-      :: HasCallStack
-      => Maybe (SlotNo, hash)
+  , stream
+      :: forall b. HasCallStack
+      => BlockComponent (ImmutableDB hash m) b
+      -> Maybe (SlotNo, hash)
       -> Maybe (SlotNo, hash)
       -> m (Either (WrongBoundError hash)
-                   (Iterator hash m ByteString))
-
-    -- | Same as 'streamBlocks', but only the headers are streamed, not the
-    -- whole blocks.
-  , streamHeaders
-      :: HasCallStack
-      => Maybe (SlotNo, hash)
-      -> Maybe (SlotNo, hash)
-      -> m (Either (WrongBoundError hash)
-                   (Iterator hash m ByteString))
+                   (Iterator hash m b))
 
     -- | Throw 'ImmutableDB' errors
   , immutableDBErr :: ErrorHandling ImmutableDBError m
   }
   deriving NoUnexpectedThunks via OnlyCheckIsWHNF "ImmutableDB" (ImmutableDB hash m)
+
+instance DB (ImmutableDB hash m) where
+  -- The ImmutableDB doesn't have the ability to parse blocks and headers, it
+  -- only returns raw blocks and headers.
+  type DBBlock      (ImmutableDB hash m) = ()
+  type DBHeader     (ImmutableDB hash m) = ()
+  type DBHeaderHash (ImmutableDB hash m) = hash
 
 -- | An 'Iterator' is a handle which can be used to efficiently stream binary
 -- blobs. Slots not containing a blob and missing EBBs are skipped.
@@ -251,7 +232,7 @@ data Iterator hash m a = Iterator
     -- The iterator is automatically closed when exhausted
     -- ('IteratorExhausted'), and can be prematurely closed with
     -- 'iteratorClose'.
-    iteratorNext    :: HasCallStack => m (IteratorResult hash a)
+    iteratorNext    :: HasCallStack => m (IteratorResult a)
 
     -- | Read the blob the 'Iterator' is currently pointing.
     --
@@ -261,7 +242,7 @@ data Iterator hash m a = Iterator
     -- be returned.
     --
     -- Throws a 'ClosedDBError' if the database is closed.
-  , iteratorPeek    :: HasCallStack => m (IteratorResult hash a)
+  , iteratorPeek    :: HasCallStack => m (IteratorResult a)
 
     -- | Return the epoch number (in case of an EBB) or slot number and hash
     -- of the next blob, if there is a next. Return 'Nothing' if not.
@@ -296,6 +277,21 @@ instance Functor m => Functor (Iterator hash m) where
       , iteratorID      = DerivedIteratorID $ iteratorID itr
       }
 
+-- | Variant of 'traverse' instantiated to @'Iterator' hash m@ that executes
+-- the monadic function when calling 'iteratorNext' and 'iteratorPeek'.
+traverseIterator
+  :: Monad m
+  => (a -> m b)
+  -> Iterator hash m a
+  -> Iterator hash m b
+traverseIterator f itr = Iterator{
+      iteratorNext    = iteratorNext itr >>= traverse f
+    , iteratorPeek    = iteratorPeek itr >>= traverse f
+    , iteratorHasNext = iteratorHasNext itr
+    , iteratorClose   = iteratorClose itr
+    , iteratorID      = DerivedIteratorID $ iteratorID itr
+    }
+
 -- | Equality based on 'iteratorID'
 instance Eq (Iterator hash m a) where
   (==) = (==) `on` iteratorID
@@ -304,17 +300,16 @@ instance Ord (Iterator hash m a) where
   compare = compare `on` iteratorID
 
 -- | The result of stepping an 'Iterator'.
-data IteratorResult hash a
+data IteratorResult a
   = IteratorExhausted
-  | IteratorResult    SlotNo  hash a
-  | IteratorEBB       EpochNo hash a
+  | IteratorResult a
   deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 -- | Consume an 'Iterator' by stepping until it is exhausted. A list of all
 -- the 'IteratorResult's (excluding the final 'IteratorExhausted') produced by
 -- the 'Iterator' is returned.
 iteratorToList :: (HasCallStack, Monad m)
-               => Iterator hash m a -> m [IteratorResult hash a]
+               => Iterator hash m a -> m [IteratorResult a]
 iteratorToList it = go
   where
     go = do

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -309,11 +309,11 @@ data IteratorResult a
 -- the 'IteratorResult's (excluding the final 'IteratorExhausted') produced by
 -- the 'Iterator' is returned.
 iteratorToList :: (HasCallStack, Monad m)
-               => Iterator hash m a -> m [IteratorResult a]
-iteratorToList it = go
+               => Iterator hash m a -> m [a]
+iteratorToList it = go []
   where
-    go = do
+    go acc = do
       next <- iteratorNext it
       case next of
-        IteratorExhausted -> return []
-        _                 -> (next:) <$> go
+        IteratorExhausted  -> return $ reverse acc
+        IteratorResult res -> go (res:acc)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
 
 {-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Immutable on-disk database of binary blobs
@@ -95,6 +94,7 @@ module Ouroboros.Storage.ImmutableDB.Impl
 
 import           Prelude hiding (truncate)
 
+import           Control.Exception (assert)
 import           Control.Monad (replicateM_, when)
 import           Control.Monad.Except (runExceptT)
 import           Control.Monad.State.Strict (StateT (..), get, lift, modify,
@@ -102,12 +102,12 @@ import           Control.Monad.State.Strict (StateT (..), get, lift, modify,
 import           Control.Tracer (Tracer, traceWith)
 
 import           Data.ByteString.Builder (Builder)
-import           Data.ByteString.Lazy (ByteString)
 import           Data.Functor (($>), (<&>))
 
 import           GHC.Stack (HasCallStack)
 
-import           Control.Monad.Class.MonadThrow (bracket, bracketOnError, finally)
+import           Control.Monad.Class.MonadThrow (bracket, bracketOnError,
+                     finally)
 
 import           Ouroboros.Consensus.Block (IsEBB (..))
 import           Ouroboros.Consensus.Util (SomePair (..))
@@ -210,23 +210,17 @@ data Internal hash m = Internal
 mkDBRecord :: (IOLike m, Eq hash, NoUnexpectedThunks hash)
            => ImmutableDBEnv m hash -> ImmutableDB hash m
 mkDBRecord dbEnv = ImmutableDB
-    { closeDB             = closeDBImpl       dbEnv
-    , isOpen              = isOpenImpl        dbEnv
-    , reopen              = reopenImpl        dbEnv
-    , getTip              = getTipImpl        dbEnv
-    , getBlock            = getBlockImpl      dbEnv GetBlock
-    , getBlockHeader      = getBlockImpl      dbEnv GetHeader
-    , getBlockHash        = getBlockImpl      dbEnv GetHash
-    , getEBB              = getEBBImpl        dbEnv GetBlock
-    , getEBBHeader        = getEBBImpl        dbEnv GetHeader
-    , getEBBHash          = getEBBImpl        dbEnv GetHash
-    , getBlockOrEBB       = getBlockOrEBBImpl dbEnv GetBlock
-    , getBlockOrEBBHeader = getBlockOrEBBImpl dbEnv GetHeader
-    , appendBlock         = appendBlockImpl   dbEnv
-    , appendEBB           = appendEBBImpl     dbEnv
-    , streamBlocks        = streamImpl        dbEnv Blocks
-    , streamHeaders       = streamImpl        dbEnv Headers
-    , immutableDBErr      = _dbErr            dbEnv
+    { closeDB                = closeDBImpl                dbEnv
+    , isOpen                 = isOpenImpl                 dbEnv
+    , reopen                 = reopenImpl                 dbEnv
+    , getTip                 = getTipImpl                 dbEnv
+    , getBlockComponent      = getBlockComponentImpl      dbEnv
+    , getEBBComponent        = getEBBComponentImpl        dbEnv
+    , getBlockOrEBBComponent = getBlockOrEBBComponentImpl dbEnv
+    , appendBlock            = appendBlockImpl            dbEnv
+    , appendEBB              = appendEBBImpl              dbEnv
+    , stream                 = streamImpl                 dbEnv
+    , immutableDBErr         = _dbErr                     dbEnv
     }
 
 -- | For testing purposes:
@@ -420,19 +414,13 @@ getTipImpl dbEnv = do
     SomePair _hasFS OpenState { _currentTip } <- getOpenState dbEnv
     return _currentTip
 
--- | Whether to read the whole block, its header, or the hash
-data BlockComponent hash res where
-  GetBlock  :: BlockComponent hash (hash, ByteString)
-  GetHeader :: BlockComponent hash (hash, ByteString)
-  GetHash   :: BlockComponent hash hash
-
-getBlockImpl
-  :: forall m hash res. (HasCallStack, IOLike m)
+getBlockComponentImpl
+  :: forall m hash b. (HasCallStack, IOLike m)
   => ImmutableDBEnv m hash
-  -> BlockComponent hash res
+  -> BlockComponent (ImmutableDB hash m) b
   -> SlotNo
-  -> m (Maybe res)
-getBlockImpl dbEnv blockComponent slot =
+  -> m (Maybe b)
+getBlockComponentImpl dbEnv blockComponent slot =
     withOpenState dbEnv $ \_dbHasFS OpenState{..} -> do
       inTheFuture <- case forgetHash <$> _currentTip of
         TipGen                 -> return $ True
@@ -450,17 +438,18 @@ getBlockImpl dbEnv blockComponent slot =
 
       let curEpochInfo = CurrentEpochInfo _currentEpoch _currentEpochOffset
       epochSlot <- epochInfoBlockRelative _dbEpochInfo slot
-      getEpochSlot _dbHasFS _dbErr _index curEpochInfo blockComponent epochSlot
+      getEpochSlot _dbHasFS _dbErr _dbEpochInfo _index curEpochInfo
+        blockComponent epochSlot
   where
     ImmutableDBEnv { _dbEpochInfo, _dbErr, _dbHashInfo } = dbEnv
 
-getEBBImpl
-  :: forall m hash res. (HasCallStack, IOLike m)
+getEBBComponentImpl
+  :: forall m hash b. (HasCallStack, IOLike m)
   => ImmutableDBEnv m hash
-  -> BlockComponent hash res
+  -> BlockComponent (ImmutableDB hash m) b
   -> EpochNo
-  -> m (Maybe res)
-getEBBImpl dbEnv blockComponent epoch =
+  -> m (Maybe b)
+getEBBComponentImpl dbEnv blockComponent epoch =
     withOpenState dbEnv $ \_dbHasFS OpenState{..} -> do
       let inTheFuture = case forgetHash <$> _currentTip of
             TipGen        -> True
@@ -471,22 +460,54 @@ getEBBImpl dbEnv blockComponent epoch =
         throwUserError _dbErr $ ReadFutureEBBError epoch _currentEpoch
 
       let curEpochInfo = CurrentEpochInfo _currentEpoch _currentEpochOffset
-      getEpochSlot _dbHasFS _dbErr _index curEpochInfo blockComponent
-        (EpochSlot epoch 0)
+      getEpochSlot _dbHasFS _dbErr _dbEpochInfo _index curEpochInfo
+        blockComponent (EpochSlot epoch 0)
   where
     ImmutableDBEnv { _dbEpochInfo, _dbErr, _dbHashInfo } = dbEnv
 
-getBlockComponent
-  :: forall m h hash res. (HasCallStack, IOLike m)
+extractBlockComponent
+  :: forall m h hash b. (HasCallStack, IOLike m)
   => HasFS m h
   -> ErrorHandling ImmutableDBError m
+  -> EpochInfo m
   -> EpochNo
   -> CurrentEpochInfo
   -> (Secondary.Entry hash, BlockSize)
-  -> BlockComponent hash res
-  -> m res
-getBlockComponent hasFS err epoch curEpochInfo (entry, blockSize) = \case
+  -> BlockComponent (ImmutableDB hash m) b
+  -> m b
+extractBlockComponent hasFS err epochInfo epoch curEpochInfo (entry, blockSize) = \case
     GetHash  -> return headerHash
+    GetSlot  -> case blockOrEBB of
+      Block slot  -> return slot
+      EBB  epoch' -> assert (epoch' == epoch) $ epochInfoFirst epochInfo epoch'
+
+    GetIsEBB -> return $ case blockOrEBB of
+      Block _ -> IsNotEBB
+      EBB   _ -> IsEBB
+
+    GetBlockSize -> case blockSize of
+      Secondary.BlockSize size
+        -> return size
+      -- See the 'GetBlock' case for more info about 'Secondary.LastEntry'.
+      Secondary.LastEntry
+        | epoch == curEpoch
+        -> return $ fromIntegral $ curEpochOffset - blockOffset
+        | otherwise
+        -> do
+          -- With cached indices, we'll never hit this case.
+          offsetAfterLastBlock <- withFile hasFS epochFile ReadMode $ \eHnd ->
+            hGetSize hasFS eHnd
+          return $ fromIntegral $ offsetAfterLastBlock - unBlockOffset blockOffset
+
+    GetHeaderSize -> return $ fromIntegral $ unHeaderSize headerSize
+
+    GetPure a -> return a
+
+    GetApply f bc ->
+      extractBlockComponent hasFS err epochInfo epoch curEpochInfo
+        (entry, blockSize) f <*>
+      extractBlockComponent hasFS err epochInfo epoch curEpochInfo
+        (entry, blockSize) bc
 
     -- In case the requested epoch is the current epoch, we will be reading
     -- from the epoch file while we're also writing to it. Are we guaranteed
@@ -496,7 +517,7 @@ getBlockComponent hasFS err epoch curEpochInfo (entry, blockSize) = \case
     -- file handles ("Ouroboros.Storage.IO") so we're safe (other
     -- implementations of the 'HasFS' API guarantee this too).
 
-    GetBlock -> do
+    GetRawBlock -> do
       -- Get the whole block
       let offset = AbsOffset $ unBlockOffset blockOffset
       (bl, checksum') <- withFile hasFS epochFile ReadMode $ \eHnd ->
@@ -529,9 +550,9 @@ getBlockComponent hasFS err epoch curEpochInfo (entry, blockSize) = \case
           Secondary.BlockSize size
             -> hGetExactlyAtCRC hasFS eHnd (fromIntegral size) offset
       checkChecksum err epochFile blockOrEBB checksum checksum'
-      return (headerHash, bl)
+      return bl
 
-    GetHeader -> fmap (headerHash,) $
+    GetRawHeader ->
         -- Get just the header
         withFile hasFS epochFile ReadMode $ \eHnd ->
           -- We cannot check the checksum in this case, as we're not reading
@@ -542,6 +563,8 @@ getBlockComponent hasFS err epoch curEpochInfo (entry, blockSize) = \case
         offset = AbsOffset $
           unBlockOffset blockOffset +
           fromIntegral (unHeaderOffset headerOffset)
+    GetBlock  -> return ()
+    GetHeader -> return ()
   where
     Secondary.Entry
       { blockOffset, headerOffset, headerSize, headerHash, checksum
@@ -550,14 +573,14 @@ getBlockComponent hasFS err epoch curEpochInfo (entry, blockSize) = \case
     CurrentEpochInfo curEpoch curEpochOffset = curEpochInfo
     epochFile = renderFile "epoch" epoch
 
-getBlockOrEBBImpl
-  :: forall m hash. (HasCallStack, IOLike m, Eq hash)
+getBlockOrEBBComponentImpl
+  :: forall m hash b. (HasCallStack, IOLike m, Eq hash)
   => ImmutableDBEnv m hash
-  -> BlockComponent hash (hash, ByteString)
+  -> BlockComponent (ImmutableDB hash m) b
   -> SlotNo
   -> hash
-  -> m (Maybe (Either EpochNo SlotNo, ByteString))
-getBlockOrEBBImpl dbEnv blockComponent slot hash =
+  -> m (Maybe b)
+getBlockOrEBBComponentImpl dbEnv blockComponent slot hash =
     withOpenState dbEnv $ \_dbHasFS OpenState{..} -> do
 
       inTheFuture <- case forgetHash <$> _currentTip of
@@ -577,30 +600,27 @@ getBlockOrEBBImpl dbEnv blockComponent slot hash =
       case errOrRes of
         Left _ ->
           return Nothing
-        Right (EpochSlot epoch relSlot, (entry, blockSize), _secondaryOffset) ->
-            Just . (epochOrSlot, ) . snd <$>
-              getBlockComponent _dbHasFS _dbErr epoch curEpochInfo
-                (entry, blockSize) blockComponent
-          where
-            epochOrSlot | relSlot == 0 = Left epoch
-                        | otherwise    = Right slot
+        Right (EpochSlot epoch _, (entry, blockSize), _secondaryOffset) ->
+          Just <$>
+            extractBlockComponent _dbHasFS _dbErr _dbEpochInfo epoch curEpochInfo
+              (entry, blockSize) blockComponent
   where
     ImmutableDBEnv { _dbEpochInfo, _dbErr, _dbHashInfo } = dbEnv
 
--- | Get the block, header, or hash (depending on 'BlockComponent') corresponding to
--- the given 'EpochSlot'.
+-- | Get the block component corresponding to the given 'EpochSlot'.
 --
 -- Preconditions: the given 'EpochSlot' is in the past.
 getEpochSlot
-  :: forall m h hash res. (HasCallStack, IOLike m)
+  :: forall m h hash b. (HasCallStack, IOLike m)
   => HasFS m h
   -> ErrorHandling ImmutableDBError m
+  -> EpochInfo m
   -> Index m hash h
   -> CurrentEpochInfo
-  -> BlockComponent hash res
+  -> BlockComponent (ImmutableDB hash m) b
   -> EpochSlot
-  -> m (Maybe res)
-getEpochSlot hasFS err index curEpochInfo blockComponent epochSlot =
+  -> m (Maybe b)
+getEpochSlot hasFS err epochInfo index curEpochInfo blockComponent epochSlot =
     -- Check the primary index first
     Index.readOffset index epoch relativeSlot >>= \case
       -- Empty slot
@@ -611,8 +631,8 @@ getEpochSlot hasFS err index curEpochInfo blockComponent epochSlot =
         -- TODO only read the hash in case of 'GetHash'?
         (entry, blockSize) <- Index.readEntry index epoch isEBB secondaryOffset
         Just <$>
-          getBlockComponent hasFS err epoch curEpochInfo (entry, blockSize)
-            blockComponent
+          extractBlockComponent hasFS err epochInfo epoch curEpochInfo
+            (entry, blockSize) blockComponent
   where
     EpochSlot epoch relativeSlot = epochSlot
     isEBB | relativeSlot == 0    = IsEBB

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Iterator.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass            #-}
 {-# LANGUAGE DeriveGeneric             #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs                     #-}
 {-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE NamedFieldPuns            #-}
 {-# LANGUAGE OverloadedStrings         #-}
@@ -13,7 +14,6 @@
 module Ouroboros.Storage.ImmutableDB.Impl.Iterator
   ( streamImpl
   , getSlotInfo
-  , BlocksOrHeaders (..)
   , CurrentEpochInfo (..)
   ) where
 
@@ -109,9 +109,6 @@ data IteratorState hash h = IteratorState
   }
   deriving (Generic, NoUnexpectedThunks)
 
--- | Used by 'streamImpl' to choose between streaming blocks or headers.
-data BlocksOrHeaders = Blocks | Headers
-
 -- | Auxiliary data type that combines the '_currentEpoch' and
 -- '_currentEpochOffset' fields from 'OpenState'. This is used to avoid
 -- passing the whole state around, and moreover, it avoids issues with
@@ -119,22 +116,19 @@ data BlocksOrHeaders = Blocks | Headers
 data CurrentEpochInfo = CurrentEpochInfo !EpochNo !BlockOffset
 
 streamImpl
-  :: forall m hash. (HasCallStack, IOLike m, Eq hash, NoUnexpectedThunks hash)
+  :: forall m hash b. (HasCallStack, IOLike m, Eq hash, NoUnexpectedThunks hash)
   => ImmutableDBEnv m hash
-  -> BlocksOrHeaders
+  -> BlockComponent (ImmutableDB hash m) b
   -> Maybe (SlotNo, hash)
      -- ^ When to start streaming (inclusive).
   -> Maybe (SlotNo, hash)
      -- ^ When to stop streaming (inclusive).
   -> m (Either (WrongBoundError hash)
-               (Iterator hash m ByteString))
-streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
+               (Iterator hash m b))
+streamImpl dbEnv blockComponent mbStart mbEnd =
     withOpenState dbEnv $ \hasFS OpenState{..} -> runExceptT $ do
       lift $ validateIteratorRange _dbErr _dbEpochInfo
         (forgetHash <$> _currentTip) mbStart mbEnd
-
-      -- TODO cache index files: we might open the same primary and secondary
-      -- indices to validate the end bound as for the start bound
 
       case _currentTip of
         TipGen ->
@@ -256,13 +250,13 @@ streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
 
     -- TODO we're calling 'modifyOpenState' from within 'withOpenState', ok?
     withNewIteratorID
-      :: (IteratorID -> Iterator hash m ByteString)
-      -> m (Iterator hash m ByteString)
+      :: (IteratorID -> Iterator hash m b)
+      -> m (Iterator hash m b)
     withNewIteratorID mkIter = modifyOpenState dbEnv $ \_hasFS ->
       state $ \st@OpenState { _nextIteratorID = itID } ->
         (mkIter (BaseIteratorID itID), st { _nextIteratorID = succ itID })
 
-    mkEmptyIterator :: m (Iterator hash m ByteString)
+    mkEmptyIterator :: m (Iterator hash m b)
     mkEmptyIterator = withNewIteratorID $ \itID -> Iterator
       { iteratorNext    = return IteratorExhausted
       , iteratorPeek    = return IteratorExhausted
@@ -271,10 +265,10 @@ streamImpl dbEnv blocksOrHeaders mbStart mbEnd =
       , iteratorID      = itID
       }
 
-    mkIterator :: IteratorHandle hash m -> m (Iterator hash m ByteString)
+    mkIterator :: IteratorHandle hash m -> m (Iterator hash m b)
     mkIterator ith = withNewIteratorID $ \itID -> Iterator
-      { iteratorNext    = iteratorNextImpl dbEnv ith blocksOrHeaders True
-      , iteratorPeek    = iteratorNextImpl dbEnv ith blocksOrHeaders False
+      { iteratorNext    = iteratorNextImpl dbEnv ith blockComponent True
+      , iteratorPeek    = iteratorNextImpl dbEnv ith blockComponent False
       , iteratorHasNext = iteratorHasNextImpl    ith
       , iteratorClose   = iteratorCloseImpl      ith
       , iteratorID      = itID
@@ -353,16 +347,16 @@ getSlotInfo epochInfo index (slot, hash) = do
     return (epochSlot', (entry, blockSize), secondaryOffset)
 
 iteratorNextImpl
-  :: forall m hash. (IOLike m, Eq hash)
+  :: forall m hash b. (IOLike m, Eq hash)
   => ImmutableDBEnv m hash
   -> IteratorHandle hash m
-  -> BlocksOrHeaders
+  -> BlockComponent (ImmutableDB hash m) b
   -> Bool  -- ^ Step the iterator after reading iff True
-  -> m (IteratorResult hash ByteString)
+  -> m (IteratorResult b)
 iteratorNextImpl dbEnv it@IteratorHandle
                          { itHasFS = hasFS :: HasFS m h
                          , itIndex = index :: Index m hash h
-                         , .. } blocksOrHeaders step = do
+                         , .. } blockComponent step = do
     -- The idea is that if the state is not 'IteratorStateExhausted, then the
     -- head of 'itEpochEntries' is always ready to be read. After reading it
     -- with 'readNextBlock' or 'readNextHeader', 'stepIterator' will advance
@@ -372,21 +366,51 @@ iteratorNextImpl dbEnv it@IteratorHandle
       IteratorStateExhausted -> return IteratorExhausted
       IteratorStateOpen iteratorState@IteratorState{..} ->
         withOpenState dbEnv $ \_ st -> do
-          let entryWithBlockSize@(WithBlockSize _ entry) = NE.head itEpochEntries
-              hash = Secondary.headerHash entry
-              curEpochInfo = CurrentEpochInfo
+          let curEpochInfo = CurrentEpochInfo
                 (_currentEpoch       st)
                 (_currentEpochOffset st)
-          blob <- case blocksOrHeaders of
-            Blocks  -> readNextBlock  itEpochHandle entryWithBlockSize itEpoch
-            Headers -> readNextHeader itEpochHandle entry
+              entry = NE.head itEpochEntries
+          b <- getBlockComponent itEpochHandle itEpoch entry blockComponent
           when step $ stepIterator curEpochInfo iteratorState
-          return $ case Secondary.blockOrEBB entry of
-            Block slot  -> IteratorResult slot  hash blob
-            EBB   epoch -> IteratorEBB    epoch hash blob
+          return $ IteratorResult b
   where
     ImmutableDBEnv { _dbErr, _dbEpochInfo, _dbHashInfo } = dbEnv
     HasFS { hClose } = hasFS
+
+    getBlockComponent
+      :: Handle h
+      -> EpochNo
+      -> WithBlockSize (Secondary.Entry hash)
+      -> BlockComponent (ImmutableDB hash m) b'
+      -> m b'
+    getBlockComponent itEpochHandle itEpoch entryWithBlockSize = \case
+        GetHash         -> return headerHash
+        GetSlot         -> case blockOrEBB of
+          Block slot  -> return slot
+          EBB  epoch' -> assert (epoch' == itEpoch) $
+            epochInfoFirst _dbEpochInfo epoch'
+        GetIsEBB        -> return $ case blockOrEBB of
+          Block _ -> IsNotEBB
+          EBB   _ -> IsEBB
+        GetBlockSize    -> return blockSize
+        GetHeaderSize   ->
+          return $ fromIntegral $ Secondary.unHeaderSize headerSize
+        GetRawBlock     ->
+          readNextBlock  itEpochHandle entryWithBlockSize itEpoch
+        GetRawHeader    ->
+          readNextHeader itEpochHandle entry
+        GetBlock        ->
+          return ()
+        GetHeader       ->
+          return ()
+        GetPure a       ->
+          return a
+        GetApply f bc   ->
+          getBlockComponent itEpochHandle itEpoch entryWithBlockSize f <*>
+          getBlockComponent itEpochHandle itEpoch entryWithBlockSize bc
+      where
+        WithBlockSize blockSize entry = entryWithBlockSize
+        Secondary.Entry { headerHash, headerSize, blockOrEBB } = entry
 
     -- | We don't rely on the position of the handle, we always use
     -- 'hGetExactlyAtCRC', i.e. @pread@ for reading from a given offset.

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
@@ -72,18 +72,17 @@ validateAndReopen
   :: forall m hash h e. (IOLike m, Eq hash, NoUnexpectedThunks hash, HasCallStack)
   => ValidateEnv m hash h e
   -> ValidationPolicy
-  -> BaseIteratorID
   -> m (OpenState m hash h)
-validateAndReopen validateEnv valPol nextIteratorID = do
+validateAndReopen validateEnv valPol = do
     (epoch, tip) <- validate validateEnv valPol
     index        <- cachedIndex hasFS err hashInfo registry cacheTracer cacheConfig epoch
     case tip of
       TipGen -> assert (epoch == 0) $ do
         traceWith tracer NoValidLastLocation
-        mkOpenState registry hasFS err index epoch nextIteratorID TipGen MustBeNew
+        mkOpenState registry hasFS err index epoch TipGen MustBeNew
       _     -> do
         traceWith tracer $ ValidatedLastLocation epoch (forgetHash <$> tip)
-        mkOpenState registry hasFS err index epoch nextIteratorID tip    AllowExisting
+        mkOpenState registry hasFS err index epoch tip    AllowExisting
   where
     ValidateEnv { hasFS, err, hashInfo, tracer, registry, cacheConfig } = validateEnv
     cacheTracer = contramap TraceCacheEvent tracer

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -1,11 +1,10 @@
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DeriveTraversable          #-}
-{-# LANGUAGE DerivingVia                #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingVia       #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE RankNTypes        #-}
 module Ouroboros.Storage.ImmutableDB.Types
   ( SlotNo (..)
   , ImmTip
@@ -17,9 +16,6 @@ module Ouroboros.Storage.ImmutableDB.Types
   , BinaryInfo (..)
   , EpochFileParser (..)
   , ValidationPolicy (..)
-  , BaseIteratorID
-  , IteratorID(..)
-  , initialIteratorID
   , WrongBoundError (..)
   , ImmutableDBError (..)
   , sameImmutableDBError
@@ -157,20 +153,6 @@ data ValidationPolicy
     -- /open/ will throw a 'MissingFileError' or an 'InvalidFileError' in case
     -- of a missing or invalid epoch file, or an invalid index file.
   deriving (Show, Eq, Generic)
-
--- | ID of an iterator that is not derived from another iterator
-newtype BaseIteratorID = MkBaseIteratorID Int
-  deriving stock    (Show, Generic)
-  deriving newtype  (Eq, Ord, Enum)
-  deriving anyclass (NoUnexpectedThunks)
-
--- | A unique identifier for an iterator.
-data IteratorID = BaseIteratorID BaseIteratorID | DerivedIteratorID IteratorID
-  deriving (Show, Eq, Ord, Generic)
-
--- | Initial identifier number, use 'succ' to generate the next one.
-initialIteratorID :: BaseIteratorID
-initialIteratorID = MkBaseIteratorID 0
 
 -- | Returned by 'streamBlocks' and 'streamHeaders' when a bound is wrong.
 --

--- a/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
@@ -538,7 +538,7 @@ runThreadNetwork ThreadNetworkArgs
         , cdbNodeConfig       = cfg
         , cdbEpochInfo        = epochInfo
         , cdbHashInfo         = nodeHashInfo (Proxy @blk)
-        , cdbIsEBB            = nodeIsEBB . getHeader
+        , cdbIsEBB            = nodeIsEBB
         , cdbCheckIntegrity   = nodeCheckIntegrity cfg
         , cdbGenesis          = return initLedger
         , cdbBlockchainTime   = btime

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -417,7 +417,7 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
     -- | Open a mock ImmutableDB and add the given chain of blocks
     openImmDB :: Chain TestBlock -> m (ImmDB m TestBlock)
     openImmDB chain = do
-        (_immDBModel, immDB) <- ImmDB.openDBMock EH.monadCatch (const epochSize)
+        (_immDBModel, immDB) <- ImmDB.openDBMock EH.monadCatch epochSize
         forM_ (Chain.toOldestFirst chain) $ \block -> case isEBB (getHeader block) of
           Nothing -> ImmDB.appendBlock immDB
             (blockSlot block) (blockHash block)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -33,13 +33,13 @@ import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Storage.ChainDB.API (BlockComponent (..),
-                     Iterator (..), IteratorId (..), IteratorResult (..),
-                     StreamFrom (..), StreamTo (..), UnknownRange,
-                     UnknownRange (..), traverseIterator)
+                     Iterator (..), IteratorResult (..), StreamFrom (..),
+                     StreamTo (..), UnknownRange (..), traverseIterator)
 import           Ouroboros.Storage.ChainDB.Impl.ImmDB (ImmDB, mkImmDB)
 import           Ouroboros.Storage.ChainDB.Impl.Iterator (IteratorEnv (..),
                      newIterator)
-import           Ouroboros.Storage.ChainDB.Impl.Types (TraceIteratorEvent (..))
+import           Ouroboros.Storage.ChainDB.Impl.Types (IteratorKey (..),
+                     TraceIteratorEvent (..))
 import           Ouroboros.Storage.ChainDB.Impl.VolDB (VolDB, mkVolDB)
 import           Ouroboros.Storage.Common (BinaryInfo (..), EpochSize)
 import           Ouroboros.Storage.EpochInfo (fixedSizeEpochInfo)
@@ -372,16 +372,16 @@ initIteratorEnv
   -> Tracer m (TraceIteratorEvent TestBlock)
   -> m (IteratorEnv m TestBlock)
 initIteratorEnv TestSetup { immutable, volatile } tracer = do
-    iters      <- uncheckedNewTVarM Map.empty
-    nextIterId <- uncheckedNewTVarM $ IteratorId 0
-    volDB      <- openVolDB volatile
-    immDB      <- openImmDB immutable
+    iters       <- uncheckedNewTVarM Map.empty
+    nextIterKey <- uncheckedNewTVarM $ IteratorKey 0
+    volDB       <- openVolDB volatile
+    immDB       <- openImmDB immutable
     return IteratorEnv
-      { itImmDB          = immDB
-      , itVolDB          = volDB
-      , itIterators      = iters
-      , itNextIteratorId = nextIterId
-      , itTracer         = tracer
+      { itImmDB           = immDB
+      , itVolDB           = volDB
+      , itIterators       = iters
+      , itNextIteratorKey = nextIterKey
+      , itTracer          = tracer
       }
   where
     -- | Open a mock VolatileDB and add the given blocks

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -21,19 +21,21 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Util ((..:))
+import           Ouroboros.Consensus.Util ((...:), (.:))
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.STM (blockUntilJust)
 
 import           Ouroboros.Storage.ChainDB.API
 
-import           Test.Ouroboros.Storage.ChainDB.Model (Model)
+import           Test.Ouroboros.Storage.ChainDB.Model (Model,
+                     ModelSupportsBlock)
 import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
 
 openDB :: forall m blk. (
             IOLike m
           , ProtocolLedgerView blk
           , CanSelect (BlockProtocol blk) blk
+          , ModelSupportsBlock blk
           )
        => NodeConfig (BlockProtocol blk)
        -> ExtLedgerState blk
@@ -85,18 +87,18 @@ openDB cfg initLedger btime = do
         update_ :: (Model blk -> Model blk) -> m ()
         update_ f = update (\m -> ((), f m))
 
-        iterator :: IteratorId -> Iterator m (Deserialisable m blk blk)
-        iterator itrId = Iterator {
-              iteratorNext  = update  $ Model.iteratorNextDeserialised itrId
-            , iteratorClose = update_ $ Model.iteratorClose            itrId
+        iterator :: BlockComponent (ChainDB m blk) b -> IteratorId -> Iterator m blk b
+        iterator blockComponent itrId = Iterator {
+              iteratorNext  = update $ Model.iteratorNext itrId blockComponent
+            , iteratorClose = update_ $ Model.iteratorClose itrId
             , iteratorId    = itrId
             }
 
         reader :: forall b.
-                  (blk -> b)
+                  BlockComponent (ChainDB m blk) b
                -> CPS.ReaderId
                -> Reader m blk b
-        reader toB rdrId = Reader {
+        reader blockComponent rdrId = Reader {
               readerInstruction =
                 updateE readerInstruction'
             , readerInstructionBlocking = atomically $
@@ -113,7 +115,7 @@ openDB cfg initLedger btime = do
               :: Model blk
               -> Either ChainDbError
                         (Maybe (ChainUpdate blk b), Model blk)
-            readerInstruction' = Model.readerInstruction toB rdrId
+            readerInstruction' = Model.readerInstruction rdrId blockComponent
 
     void $ onSlotChange btime $ update_ . Model.advanceCurSlot cfg
 
@@ -122,7 +124,7 @@ openDB cfg initLedger btime = do
       , getCurrentChain     = querySTM $ Model.lastK k getHeader
       , getCurrentLedger    = querySTM $ Model.currentLedger
       , getPastLedger       = query    . Model.getPastLedger cfg
-      , getBlock            = queryE   . Model.getBlockByPoint
+      , getBlockComponent   = queryE  .: Model.getBlockComponentByPoint
       , getTipBlock         = query    $ Model.tipBlock
       , getTipHeader        = query    $ (fmap getHeader . Model.tipBlock)
       , getTipPoint         = querySTM $ Model.tipPoint
@@ -130,10 +132,8 @@ openDB cfg initLedger btime = do
       , getIsFetched        = querySTM $ flip Model.hasBlockByPoint
       , getIsInvalidBlock   = querySTM $ (fmap (fmap (fmap fst) . flip Map.lookup)) . Model.invalid
       , getMaxSlotNo        = querySTM $ Model.maxSlotNo
-      , streamBlocks        = updateE  ..: const (fmap (first (fmap iterator)) ..: Model.streamBlocks k)
-      , newBlockReader      = update   .   const (first (reader Model.toDeserialisable) . Model.readBlocks)
-      , newHeaderReader     = update   .   const (first (reader (Model.toDeserialisable . getHeader)) . Model.readBlocks)
-
+      , stream              = updateE ...: const (\bc from to -> fmap (first (fmap (iterator bc))) . Model.stream k from to)
+      , newReader           = update   .:  const (\bc -> (first (reader bc) . Model.newReader))
       , closeDB             = atomically $ modifyTVar db Model.closeDB
       , isOpen              = Model.isOpen <$> readTVar db
       }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -14,7 +14,6 @@ import           GHC.Stack (callStack)
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Network.Block (ChainUpdate)
-import qualified Ouroboros.Network.MockChain.ProducerState as CPS
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
@@ -27,8 +26,8 @@ import           Ouroboros.Consensus.Util.STM (blockUntilJust)
 
 import           Ouroboros.Storage.ChainDB.API
 
-import           Test.Ouroboros.Storage.ChainDB.Model (Model,
-                     ModelSupportsBlock)
+import           Test.Ouroboros.Storage.ChainDB.Model (IteratorId, Model,
+                     ModelSupportsBlock, ReaderId)
 import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
 
 openDB :: forall m blk. (
@@ -91,12 +90,11 @@ openDB cfg initLedger btime = do
         iterator blockComponent itrId = Iterator {
               iteratorNext  = update $ Model.iteratorNext itrId blockComponent
             , iteratorClose = update_ $ Model.iteratorClose itrId
-            , iteratorId    = itrId
             }
 
         reader :: forall b.
                   BlockComponent (ChainDB m blk) b
-               -> CPS.ReaderId
+               -> ReaderId
                -> Reader m blk b
         reader blockComponent rdrId = Reader {
               readerInstruction =
@@ -107,8 +105,6 @@ openDB cfg initLedger btime = do
                 updateE $ Model.readerForward rdrId ps
             , readerClose =
                 update_ $ Model.readerClose rdrId
-            , readerId =
-                rdrId
             }
           where
             readerInstruction'

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock/Test.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock/Test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Ouroboros.Storage.ChainDB.Mock.Test (tests) where
 
@@ -14,6 +15,7 @@ import           Control.Monad.IOSim
 import           Ouroboros.Network.MockChain.Chain (Chain (..), ChainUpdate)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
+import           Ouroboros.Consensus.Block (IsEBB (..))
 import           Ouroboros.Consensus.BlockchainTime.Mock
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
@@ -25,6 +27,7 @@ import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock
 
 import qualified Test.Ouroboros.Storage.ChainDB.Mock as Mock
+import           Test.Ouroboros.Storage.ChainDB.Model (ModelSupportsBlock (..))
 
 tests :: TestTree
 tests = testGroup "Mock" [
@@ -49,7 +52,7 @@ prop_reader bt p = runSimOrThrow test
     test :: forall s. SimM s Property
     test = withRegistry $ \registry -> do
         db       <- openDB
-        reader   <- ChainDB.deserialiseReader <$> ChainDB.newBlockReader db registry
+        reader   <- ChainDB.newBlockReader db registry
         chainVar <- uncheckedNewTVarM Genesis
 
         -- Fork a thread that applies all instructions from the reader
@@ -92,3 +95,10 @@ openDB = Mock.openDB
     testInitExtLedger
     -- We don't care about time or future here
     (fixedBlockchainTime maxBound)
+
+{-------------------------------------------------------------------------------
+  Orphan instances
+-------------------------------------------------------------------------------}
+
+instance ModelSupportsBlock TestBlock where
+  isEBB = const IsNotEBB

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -15,6 +15,8 @@
 -- Intended for qualified import
 module Test.Ouroboros.Storage.ChainDB.Model (
     Model -- opaque
+  , IteratorId
+  , CPS.ReaderId
     -- * Construction
   , empty
   , addBlock
@@ -101,8 +103,10 @@ import           Ouroboros.Consensus.Util.STM (Fingerprint (..),
 
 import           Ouroboros.Storage.ChainDB.API (BlockComponent (..), ChainDB,
                      ChainDbError (..), InvalidBlockReason (..),
-                     IteratorId (..), IteratorResult (..), StreamFrom (..),
-                     StreamTo (..), UnknownRange (..), validBounds)
+                     IteratorResult (..), StreamFrom (..), StreamTo (..),
+                     UnknownRange (..), validBounds)
+
+type IteratorId = Int
 
 -- | Model of the chain DB
 data Model blk = Model {
@@ -418,7 +422,7 @@ stream securityParam from to m = do
         })
   where
     itrId :: IteratorId
-    itrId = IteratorId (Map.size (iterators m)) -- we never delete iterators
+    itrId = Map.size (iterators m) -- we never delete iterators
 
 iteratorNext
   :: forall m blk b. (ModelSupportsBlock blk, Monad m)
@@ -474,7 +478,7 @@ checkIfReaderExists rdrId m a
     | readerExists rdrId m
     = Right a
     | otherwise
-    = Left $ ClosedReaderError rdrId
+    = Left ClosedReaderError
 
 newReader :: HasHeader blk => Model blk -> (CPS.ReaderId, Model blk)
 newReader m = (rdrId, m { cps = cps' })

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE TupleSections        #-}
+{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,6 +29,7 @@ module Test.Ouroboros.Storage.ChainDB.Model (
   , tipBlockNo
   , getBlock
   , getBlockByPoint
+  , getBlockComponentByPoint
   , hasBlock
   , hasBlockByPoint
   , immutableBlockNo
@@ -36,15 +38,16 @@ module Test.Ouroboros.Storage.ChainDB.Model (
   , invalid
   , getPastLedger
     -- * Iterators
-  , streamBlocks
+  , stream
   , iteratorNext
-  , iteratorNextDeserialised
   , iteratorClose
     -- * Readers
-  , readBlocks
+  , newReader
   , readerInstruction
   , readerForward
   , readerClose
+    -- * ModelSupportsBlock
+  , ModelSupportsBlock (..)
     -- * Exported for testing purposes
   , between
   , blocks
@@ -57,14 +60,15 @@ module Test.Ouroboros.Storage.ChainDB.Model (
   , closeDB
   , reopen
   , advanceCurSlot
-  , toDeserialisable
   , chains
   ) where
 
+import           Codec.Serialise (Serialise, serialise)
 import           Control.Monad (unless)
 import           Control.Monad.Except (runExcept)
-import           Data.Bifunctor (first)
+import qualified Data.ByteString.Lazy as Lazy
 import           Data.Function (on)
+import           Data.Functor.Identity (Identity (..))
 import           Data.List (sortBy)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
@@ -77,14 +81,15 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as Fragment
 import           Ouroboros.Network.Block (BlockNo, pattern BlockPoint,
                      ChainHash (..), pattern GenesisPoint, HasHeader,
-                     HeaderHash, MaxSlotNo (..), Point, Serialised (..),
-                     SlotNo)
+                     HeaderHash, MaxSlotNo (..), Point, SlotNo)
 import qualified Ouroboros.Network.Block as Block
 import           Ouroboros.Network.MockChain.Chain (Chain (..), ChainUpdate)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 import qualified Ouroboros.Network.MockChain.ProducerState as CPS
 import           Ouroboros.Network.Point (WithOrigin (..))
 
+import           Ouroboros.Consensus.Block (GetHeader (getHeader), Header,
+                     IsEBB (..))
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -94,8 +99,8 @@ import qualified Ouroboros.Consensus.Util.AnchoredFragment as Fragment
 import           Ouroboros.Consensus.Util.STM (Fingerprint (..),
                      WithFingerprint (..))
 
-import           Ouroboros.Storage.ChainDB.API (ChainDbError (..),
-                     Deserialisable (..), InvalidBlockReason (..),
+import           Ouroboros.Storage.ChainDB.API (BlockComponent (..), ChainDB,
+                     ChainDbError (..), InvalidBlockReason (..),
                      IteratorId (..), IteratorResult (..), StreamFrom (..),
                      StreamTo (..), UnknownRange (..), validBounds)
 
@@ -173,6 +178,14 @@ getBlockByPoint :: HasHeader blk
 getBlockByPoint pt = case Block.pointHash pt of
     GenesisHash    -> const $ Left NoGenesisBlock
     BlockHash hash -> Right . getBlock hash
+
+getBlockComponentByPoint
+  :: forall m blk b. (ModelSupportsBlock blk, Monad m)
+  => BlockComponent (ChainDB m blk) b
+  -> Point blk -> Model blk
+  -> Either ChainDbError (Maybe b)
+getBlockComponentByPoint blockComponent pt m =
+    fmap (`getBlockComponent` blockComponent) <$> getBlockByPoint pt m
 
 hasBlockByPoint :: HasHeader blk
                 => Point blk -> Model blk -> Bool
@@ -389,13 +402,14 @@ addBlocks cfg = repeatedly (addBlock cfg)
   Iterators
 -------------------------------------------------------------------------------}
 
-streamBlocks :: HasHeader blk
-             => SecurityParam
-             -> StreamFrom blk -> StreamTo blk
-             -> Model blk
-             -> Either ChainDbError
-                       (Either (UnknownRange blk) IteratorId, Model blk)
-streamBlocks securityParam from to m = do
+stream
+  :: HasHeader blk
+  => SecurityParam
+  -> StreamFrom blk -> StreamTo blk
+  -> Model blk
+  -> Either ChainDbError
+            (Either (UnknownRange blk) IteratorId, Model blk)
+stream securityParam from to m = do
     unless (validBounds from to) $ Left (InvalidIteratorRange from to)
     case between securityParam from to m of
       Left  e    -> return (Left e,      m)
@@ -406,39 +420,40 @@ streamBlocks securityParam from to m = do
     itrId :: IteratorId
     itrId = IteratorId (Map.size (iterators m)) -- we never delete iterators
 
-iteratorNext :: IteratorId -> Model blk -> (IteratorResult blk, Model blk)
-iteratorNext itrId m =
+iteratorNext
+  :: forall m blk b. (ModelSupportsBlock blk, Monad m)
+  => IteratorId
+  -> BlockComponent (ChainDB m blk) b
+  -> Model blk
+  -> (IteratorResult blk b, Model blk)
+iteratorNext itrId blockComponent m =
     case Map.lookup itrId (iterators m) of
       Just []     -> ( IteratorExhausted
                      , m
                      )
-      Just (b:bs) -> ( IteratorResult b
+      Just (b:bs) -> ( IteratorResult $ getBlockComponent b blockComponent
                      , m { iterators = Map.insert itrId bs (iterators m) }
                      )
       Nothing      -> error "iteratorNext: unknown iterator ID"
 
-iteratorNextDeserialised
-  :: forall m blk. (Monad m, HasHeader blk)
-  => IteratorId -> Model blk
-  -> (IteratorResult (Deserialisable m blk blk), Model blk)
-iteratorNextDeserialised itrId m =
-    first convert $ iteratorNext itrId m
-  where
-    convert :: IteratorResult blk -> IteratorResult (Deserialisable m blk blk)
-    convert = \case
-      IteratorExhausted      -> IteratorExhausted
-      IteratorResult blk     -> IteratorResult (toDeserialisable blk)
-      IteratorBlockGCed hash -> IteratorBlockGCed hash
+getBlockComponent
+  :: (ModelSupportsBlock blk, Monad m)
+  => blk -> BlockComponent (ChainDB m blk) b -> b
+getBlockComponent blk = \case
+    GetBlock      -> return blk
+    GetRawBlock   -> serialise blk
 
-toDeserialisable
-  :: (Monad m, HasHeader b, HeaderHash blk ~ HeaderHash b)
-  => b -> Deserialisable m blk b
-toDeserialisable b = Deserialisable
-  { serialised         = Serialised mempty -- Currently unused
-  , deserialisableSlot = Block.blockSlot b
-  , deserialisableHash = Block.blockHash b
-  , deserialise        = return b
-  }
+    GetHeader     -> return $ getHeader blk
+    GetRawHeader  -> serialise $ getHeader blk
+
+    GetHash       -> Block.blockHash blk
+    GetSlot       -> Block.blockSlot blk
+    GetIsEBB      -> isEBB (getHeader blk)
+    GetBlockSize  -> fromIntegral $ Lazy.length $ serialise blk
+    GetHeaderSize -> fromIntegral $ Lazy.length $ serialise $ getHeader blk
+
+    GetPure a     -> a
+    GetApply f bc -> getBlockComponent blk f $ getBlockComponent blk bc
 
 -- We never delete iterators such that we can use the size of the map as the
 -- next iterator id.
@@ -461,21 +476,24 @@ checkIfReaderExists rdrId m a
     | otherwise
     = Left $ ClosedReaderError rdrId
 
-readBlocks :: HasHeader blk => Model blk -> (CPS.ReaderId, Model blk)
-readBlocks m = (rdrId, m { cps = cps' })
+newReader :: HasHeader blk => Model blk -> (CPS.ReaderId, Model blk)
+newReader m = (rdrId, m { cps = cps' })
   where
     (cps', rdrId) = CPS.initReader Block.genesisPoint (cps m)
 
 readerInstruction
-  :: forall blk b. HasHeader blk
-  => (blk -> b)
-  -> CPS.ReaderId
+  :: forall m blk b. (ModelSupportsBlock blk, Monad m)
+  => CPS.ReaderId
+  -> BlockComponent (ChainDB m blk) b
   -> Model blk
   -> Either ChainDbError
             (Maybe (ChainUpdate blk b), Model blk)
-readerInstruction toB rdrId m = checkIfReaderExists rdrId m $
+readerInstruction rdrId blockComponent m = checkIfReaderExists rdrId m $
     rewrap $ CPS.readerInstruction rdrId (cps m)
   where
+    toB :: blk -> b
+    toB blk = getBlockComponent blk blockComponent
+
     rewrap
       :: Maybe (ChainUpdate blk blk, CPS.ChainProducerState blk)
       -> (Maybe (ChainUpdate blk b), Model blk)
@@ -503,6 +521,24 @@ readerClose rdrId m
     = m { cps = CPS.deleteReader rdrId (cps m) }
     | otherwise
     = m
+
+{-------------------------------------------------------------------------------
+  ModelSupportsBlock
+-------------------------------------------------------------------------------}
+
+-- | Functionality the block needs to support so that it can be used in the
+-- 'Model'.
+--
+-- The real ChainDB takes these as function arguments. For convenience (we
+-- don't want to pass around an environment throughout the model and the state
+-- machine tests), we bundle them in a testing-only type class.
+class ( HasHeader blk
+      , GetHeader blk
+      , HasHeader (Header blk)
+      , Serialise blk
+      , Serialise (Header blk)
+      ) => ModelSupportsBlock blk where
+  isEBB :: Header blk -> IsEBB
 
 {-------------------------------------------------------------------------------
   Internal auxiliary
@@ -749,13 +785,13 @@ garbageCollectablePoint secParam m@Model{..} pt
 -- eligible for garbage collection, i.e. the real implementation might have
 -- garbage collected it.
 garbageCollectableIteratorNext
-  :: forall blk. HasHeader blk
+  :: forall blk. ModelSupportsBlock blk
   => SecurityParam -> Model blk -> IteratorId -> Bool
 garbageCollectableIteratorNext secParam m itId =
-    case fst (iteratorNext itId m) of
-      IteratorExhausted    -> True -- TODO
-      IteratorBlockGCed {} -> error "model doesn't return IteratorBlockGCed"
-      IteratorResult blk   -> garbageCollectable secParam m blk
+    case fst (iteratorNext @Identity itId GetBlock m) of
+      IteratorExhausted             -> True -- TODO
+      IteratorBlockGCed {}          -> error "model doesn't return IteratorBlockGCed"
+      IteratorResult (Identity blk) -> garbageCollectable secParam m blk
 
 garbageCollect :: forall blk. HasHeader blk
                => SecurityParam -> Model blk -> Model blk

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -16,6 +16,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck (testProperty)
 
+import           Ouroboros.Consensus.Block (getHeader)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
@@ -79,7 +80,7 @@ openTestDB registry hasFS err = fst <$> openDBInternal
   where
     parser = epochFileParser hasFS (const <$> S.decode) isEBB getBinaryInfo
       testBlockIsValid
-    isEBB  = testBlockEpochNoIfEBB fixedEpochSize
+    isEBB  = testHeaderEpochNoIfEBB fixedEpochSize . getHeader
     getBinaryInfo = void . testBlockToBinaryInfo
 
 -- Shorthand
@@ -99,7 +100,7 @@ test_ReadFutureSlotErrorEquivalence :: HasCallStack => Assertion
 test_ReadFutureSlotErrorEquivalence =
     apiEquivalenceImmDB (expectUserError isReadFutureSlotError) $ \hasFS err ->
       withTestDB hasFS err $ \db -> do
-        _ <- getBlock db 0
+        _ <- getBlockComponent db GetBlock 0
         return ()
   where
     isReadFutureSlotError ReadFutureSlotError {} = True

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -46,14 +46,13 @@ openDBMock err epochSize = do
         }
       where
         iterator :: BlockComponent (ImmutableDB hash m) b
-                 -> IteratorID
+                 -> IteratorId
                  -> Iterator hash m b
-        iterator blockComponent itID = Iterator
-          { iteratorNext    = update  $ iteratorNextModel    itID blockComponent
-          , iteratorPeek    = query   $ iteratorPeekModel    itID blockComponent
-          , iteratorHasNext = query   $ iteratorHasNextModel itID
-          , iteratorClose   = update_ $ iteratorCloseModel   itID
-          , iteratorID      = itID
+        iterator blockComponent itId = Iterator
+          { iteratorNext    = update  $ iteratorNextModel    itId blockComponent
+          , iteratorPeek    = query   $ iteratorPeekModel    itId blockComponent
+          , iteratorHasNext = query   $ iteratorHasNextModel itId
+          , iteratorClose   = update_ $ iteratorCloseModel   itId
           }
 
         update_ :: (DBModel hash -> DBModel hash) -> m ()

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -12,7 +12,8 @@ import           Control.Monad.Class.MonadThrow
 import           Ouroboros.Consensus.Util ((..:), (.:))
 import           Ouroboros.Consensus.Util.IOLike
 
-import           Ouroboros.Storage.Common (EpochNo, EpochSize)
+import           Ouroboros.Storage.Common (EpochNo, EpochSize,
+                     castBlockComponent)
 import           Ouroboros.Storage.ImmutableDB.API
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
@@ -37,23 +38,17 @@ openDBMock err epochSize = do
 
     immDB :: StrictTVar m (DBModel hash) -> ImmutableDB hash m
     immDB dbVar = ImmutableDB
-        { closeDB             = wrap  $   closeDB             db
-        , isOpen              = wrap  $   isOpen              db
-        , reopen              = wrap  .   reopen              db
-        , getTip              = wrap  $   getTip              db
-        , getBlock            = wrap  .   getBlock            db
-        , getBlockHeader      = wrap  .   getBlock            db
-        , getBlockHash        = wrap  .   getBlockHash        db
-        , getEBB              = wrap  .   getEBB              db
-        , getEBBHeader        = wrap  .   getEBBHeader        db
-        , getEBBHash          = wrap  .   getEBBHash          db
-        , getBlockOrEBB       = wrap  .:  getBlockOrEBB       db
-        , getBlockOrEBBHeader = wrap  .:  getBlockOrEBBHeader db
-        , appendBlock         = wrap  ..: appendBlock         db
-        , appendEBB           = wrap  ..: appendEBB           db
-        , streamBlocks        = wrapI .:  streamBlocks        db
-        , streamHeaders       = wrapI .:  streamHeaders       db
-        , immutableDBErr      = err
+        { closeDB                = wrap  $    closeDB                db
+        , isOpen                 = wrap  $    isOpen                 db
+        , reopen                 = wrap  .    reopen                 db
+        , getTip                 = wrap  $    getTip                 db
+        , getBlockComponent      = wrap  .:  (getBlockComponent      db . castBlockComponent)
+        , getEBBComponent        = wrap  .:  (getEBBComponent        db . castBlockComponent)
+        , getBlockOrEBBComponent = wrap  ..: (getBlockOrEBBComponent db . castBlockComponent)
+        , appendBlock            = wrap  ..:  appendBlock            db
+        , appendEBB              = wrap  ..:  appendEBB              db
+        , stream                 = wrapI ..: (stream                 db . castBlockComponent)
+        , immutableDBErr         = err
         }
       where
         wrap  = wrapModel dbVar

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -1,80 +1,87 @@
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
 module Test.Ouroboros.Storage.ImmutableDB.Mock (openDBMock) where
 
-import           Control.Monad.Except (Except, runExcept)
-import           Control.Monad.State (StateT, runStateT)
-import           Data.Proxy
+import           Control.Monad (void)
+import           Data.Bifunctor (first)
+import           Data.Tuple (swap)
 
 import           Control.Monad.Class.MonadThrow
 
 import           Ouroboros.Consensus.Util ((..:), (.:))
 import           Ouroboros.Consensus.Util.IOLike
 
-import           Ouroboros.Storage.Common (EpochNo, EpochSize,
-                     castBlockComponent)
+import           Ouroboros.Storage.Common (BlockComponent, EpochSize)
 import           Ouroboros.Storage.ImmutableDB.API
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 
 import           Test.Ouroboros.Storage.ImmutableDB.Model
 
-type MockM hash = StateT (DBModel hash) (Except ImmutableDBError)
 
 openDBMock  :: forall m hash. (IOLike m, Eq hash)
             => ErrorHandling ImmutableDBError m
-            -> (EpochNo -> EpochSize)
+            -> EpochSize
             -> m (DBModel hash, ImmutableDB hash m)
 openDBMock err epochSize = do
     dbVar <- uncheckedNewTVarM dbModel
     return (dbModel, immDB dbVar)
   where
-    db :: ImmutableDB hash (MockM hash)
-    (dbModel, db, _internal) = openDBModel err' epochSize
-
-    err' :: ErrorHandling ImmutableDBError (MockM hash)
-    err' = EH.liftErrState (Proxy @(DBModel hash)) EH.exceptT
+    dbModel = initDBModel epochSize
 
     immDB :: StrictTVar m (DBModel hash) -> ImmutableDB hash m
     immDB dbVar = ImmutableDB
-        { closeDB                = wrap  $    closeDB                db
-        , isOpen                 = wrap  $    isOpen                 db
-        , reopen                 = wrap  .    reopen                 db
-        , getTip                 = wrap  $    getTip                 db
-        , getBlockComponent      = wrap  .:  (getBlockComponent      db . castBlockComponent)
-        , getEBBComponent        = wrap  .:  (getEBBComponent        db . castBlockComponent)
-        , getBlockOrEBBComponent = wrap  ..: (getBlockOrEBBComponent db . castBlockComponent)
-        , appendBlock            = wrap  ..:  appendBlock            db
-        , appendEBB              = wrap  ..:  appendEBB              db
-        , stream                 = wrapI ..: (stream                 db . castBlockComponent)
+        { closeDB                = return ()
+        , isOpen                 = return True
+        , reopen                 = \_valPol -> void $ update reopenModel
+        , getTip                 = query      $ getTipModel
+        , getBlockComponent      = queryE    .: getBlockComponentModel
+        , getEBBComponent        = queryE    .: getEBBComponentModel
+        , getBlockOrEBBComponent = queryE   ..: getBlockOrEBBComponentModel
+        , appendBlock            = updateE_ ..: appendBlockModel
+        , appendEBB              = updateE_ ..: appendEBBModel
+        , stream                 = updateEE ..: \bc s e -> fmap (fmap (first (iterator bc))) . streamModel s e
         , immutableDBErr         = err
         }
       where
-        wrap  = wrapModel dbVar
-        wrapI = wrapModel dbVar . fmap (wrapIter dbVar)
+        iterator :: BlockComponent (ImmutableDB hash m) b
+                 -> IteratorID
+                 -> Iterator hash m b
+        iterator blockComponent itID = Iterator
+          { iteratorNext    = update  $ iteratorNextModel    itID blockComponent
+          , iteratorPeek    = query   $ iteratorPeekModel    itID blockComponent
+          , iteratorHasNext = query   $ iteratorHasNextModel itID
+          , iteratorClose   = update_ $ iteratorCloseModel   itID
+          , iteratorID      = itID
+          }
 
-    wrapModel :: forall a. StrictTVar m (DBModel hash)
-              -> MockM hash a -> m a
-    wrapModel dbVar m = atomically $ do
-        st <- readTVar dbVar
-        case runExcept (runStateT m st) of
-          Left e           -> throwM e
-          Right (res, st') -> do
-            writeTVar dbVar st'
-            return res
+        update_ :: (DBModel hash -> DBModel hash) -> m ()
+        update_ f = atomically $ modifyTVar dbVar f
 
-    wrapIter :: forall a.
-                StrictTVar m (DBModel hash)
-             -> Either (WrongBoundError hash) (Iterator hash (MockM hash) a)
-             -> Either (WrongBoundError hash) (Iterator hash m a)
-    wrapIter _dbVar (Left e)   = Left e
-    wrapIter  dbVar (Right it) = Right Iterator
-        { iteratorNext    = wrap $ iteratorNext    it
-        , iteratorPeek    = wrap $ iteratorPeek    it
-        , iteratorHasNext = wrap $ iteratorHasNext it
-        , iteratorClose   = wrap $ iteratorClose   it
-        , iteratorID      = iteratorID it
-        }
-      where
-        wrap = wrapModel dbVar
+        update :: (DBModel hash -> (a, DBModel hash)) -> m a
+        update f = atomically $ updateTVar dbVar (swap . f)
+
+        updateE_ :: (DBModel hash -> Either ImmutableDBError (DBModel hash)) -> m ()
+        updateE_ f = atomically $ do
+          db <- readTVar dbVar
+          case f db of
+            Left  e   -> throwM e
+            Right db' -> writeTVar dbVar db'
+
+        updateEE :: (DBModel hash -> Either ImmutableDBError (Either e (a, DBModel hash)))
+                 -> m (Either e a)
+        updateEE f = atomically $ do
+          db <- readTVar dbVar
+          case f db of
+            Left  e                -> throwM e
+            Right (Left e)         -> return (Left e)
+            Right (Right (a, db')) -> writeTVar dbVar db' >> return (Right a)
+
+        query :: (DBModel hash -> a) -> m a
+        query f = fmap f $ atomically $ readTVar dbVar
+
+        queryE :: (DBModel hash -> Either ImmutableDBError a) -> m a
+        queryE f = query f >>= \case
+          Left  e -> EH.throwError err e
+          Right a -> return a

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -173,11 +173,11 @@ testBlockIsEBB :: TestBlock -> IsEBB
 testBlockIsEBB = thIsEBB . testHeader
 
 -- | Only works correctly if the epoch size is fixed
-testBlockEpochNoIfEBB :: EpochSize -> TestBlock -> Maybe EpochNo
-testBlockEpochNoIfEBB fixedEpochSize b = case testBlockIsEBB b of
+testHeaderEpochNoIfEBB :: EpochSize -> Header TestBlock -> Maybe EpochNo
+testHeaderEpochNoIfEBB fixedEpochSize (TestHeader' hdr) = case thIsEBB hdr of
     IsNotEBB -> Nothing
     IsEBB    -> Just $
-      EpochNo (unSlotNo (blockSlot b) `div` unEpochSize fixedEpochSize)
+      EpochNo (unSlotNo (thSlotNo hdr) `div` unEpochSize fixedEpochSize)
 
 -- | Check whether the header matches its hash and whether the body matches
 -- its hash.

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
@@ -9,6 +9,7 @@ import           Ouroboros.Consensus.Util ((.:))
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.STM (simStateT)
 
+import           Ouroboros.Storage.Common (castBlockComponent)
 import           Ouroboros.Storage.Util.ErrorHandling (ThrowCantCatch)
 import qualified Ouroboros.Storage.Util.ErrorHandling as EH
 import           Ouroboros.Storage.VolatileDB.API
@@ -28,18 +29,17 @@ openDBMock err maxNumPerFile = do
 
     db :: StrictTVar m (DBModel blockId) -> VolatileDB blockId m
     db dbVar = VolatileDB {
-          closeDB        = wrapModel' dbVar  $ closeModel
-        , isOpenDB       = wrapModel' dbVar  $ isOpenModel
-        , reOpenDB       = wrapModel' dbVar  $ reOpenModel         err'
-        , getBlock       = wrapModel' dbVar  . getBlockModel       err'
-        , getHeader      = wrapModel' dbVar  . getHeaderModel      err'
-        , putBlock       = wrapModel' dbVar .: putBlockModel       err' Nothing
-        , garbageCollect = wrapModel' dbVar  . garbageCollectModel err' Nothing
-        , getIsMember    = wrapModel  dbVar  $ getIsMemberModel    err'
-        , getBlockIds    = wrapModel' dbVar  $ getBlockIdsModel    err'
-        , getSuccessors  = wrapModel  dbVar  $ getSuccessorsModel  err'
-        , getPredecessor = wrapModel  dbVar  $ getPredecessorModel err'
-        , getMaxSlotNo   = wrapModel  dbVar  $ getMaxSlotNoModel   err'
+          closeDB           = wrapModel' dbVar  $  closeModel
+        , isOpenDB          = wrapModel' dbVar  $  isOpenModel
+        , reOpenDB          = wrapModel' dbVar  $  reOpenModel            err'
+        , getBlockComponent = wrapModel' dbVar .: (getBlockComponentModel err' . castBlockComponent)
+        , putBlock          = wrapModel' dbVar .:  putBlockModel          err' Nothing
+        , garbageCollect    = wrapModel' dbVar  .  garbageCollectModel    err' Nothing
+        , getIsMember       = wrapModel  dbVar  $  getIsMemberModel       err'
+        , getBlockIds       = wrapModel' dbVar  $  getBlockIdsModel       err'
+        , getSuccessors     = wrapModel  dbVar  $  getSuccessorsModel     err'
+        , getPredecessor    = wrapModel  dbVar  $  getPredecessorModel    err'
+        , getMaxSlotNo      = wrapModel  dbVar  $  getMaxSlotNoModel      err'
         }
 
     err' :: ThrowCantCatch VolatileDBError

--- a/ouroboros-consensus/test-util/Test/Util/WithEq.hs
+++ b/ouroboros-consensus/test-util/Test/Util/WithEq.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Test.Util.WithEq
+  ( WithEq (..)
+  , Id (..)
+  ) where
+
+import           Data.Function (on)
+import           GHC.Generics (Generic)
+
+newtype Id = Id Word
+  deriving stock   (Show, Generic)
+  deriving newtype (Eq, Ord, Enum, Bounded, Num)
+
+-- | Use this type to add an `Eq` instance for types that don't have one or
+-- for which one doesn't make sense, but an `Eq` instance is needed for
+-- testing purposes.
+--
+-- E.g., `ImmutableDB.Iterator` needs an `Eq` instance in the q-s-m tests
+data WithEq a = WithEq
+    { getId    :: Id
+    , unWithEq :: a
+    }
+  deriving (Show, Generic)
+
+instance Eq (WithEq a) where
+  (==) = (==) `on` getId


### PR DESCRIPTION
Closes #1372.

We have the ChainDB, ImmutableDB, and VolatileDB, that each provide operations to get a block or a header. The ImmutableDB also provides Iterators that can stream block or headers, and operations to get the hash of a block or EBB. The ChainDB provides Readers that can stream blocks or headers, and Iterators that can stream blocks (but not headers). In #1271 and #1331, we changed the ChainDB to return and stream `Deserialisable` blocks or headers. In the end, we had many variants of each operation, returning either headers, blocks, hashes, and/or `Deserialisable` variants thereof. Many variants were missing.

Moreover, to implement #593 (instantiate Chain Sync Client with header and block size), we should have the ability to let a Reader return the header *and* the block size, which would mean adding yet another variant or changing header everywhere to header *and* block size.

In this commit, we unify all such operations using the `BlockComponent` concept. All operations that could work for both block or headers work are now generalised to any `BlockComponent` *or combination thereof*.

We have the following `BlockComponent` type:

```haskell
data BlockComponent db a where
  GetBlock      :: BlockComponent db (DBBlock db)
  GetRawBlock   :: BlockComponent db ByteString
  GetHeader     :: BlockComponent db (DBHeader db)
  GetRawHeader  :: BlockComponent db ByteString
  GetHash       :: BlockComponent db (DBHeaderHash db)
  GetSlot       :: BlockComponent db SlotNo
  GetIsEBB      :: BlockComponent db IsEBB
  GetBlockSize  :: BlockComponent db Word32
  GetHeaderSize :: BlockComponent db Word16
  GetPure       :: a
                -> BlockComponent db a
  GetApply      :: BlockComponent db (a -> b)
                -> BlockComponent db a
```

This is a GADT so that the constructors determine the return type `a`. The `GetPure` and `GetApply` constructors allow this type to be a `Functor` and `Applicative`.

For example, to request a block from the ImmutableDB, one can now use `getBlockComponent GetBlock` instead of `getBlock`. Moreover, to request the header, slot, and block size, one can use `(,,) <*> GetHeader <*> GetSlot <*> GetBlockSize`. To request the `Point`, one can use `BlockPoint <$> GetSlot <*> GetHash`, and so on.

The three different databases each implement the following new type class:

```haskell
class DB db where
  type DBBlock     db
  type DBHeader    db
  type DBHeaderHash db
```

The ImmutableDB and VolatileDB don't support parsed blocks, only raw blocks, and thus have: `DBBlock (ImmutableDB hash m) = ()` and so on. The ChainDB, on the other hand, supports them and has `DBBlock (ChainDB m blk) = m blk`. Note the `m` there, indicating that parsing a block is monadic, as it can result in throwing parse failure exception.

The `Deserialisable` type was removed in favour of `SerialisedWithPoint`, which does not have an `m` parameter and thus no field to deserialise the block. This functionality is redundant anyway, now that there is `GetBlock`.