### PR TITLE
Instantiate node-to-node ChainSync with WithBlockSize (Header blk)

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveAnyClass          #-}
 {-# LANGUAGE DeriveGeneric           #-}
-{-# LANGUAGE DeriveTraversable       #-}
 {-# LANGUAGE FlexibleContexts        #-}
 {-# LANGUAGE FlexibleInstances       #-}
 {-# LANGUAGE MultiParamTypeClasses   #-}
@@ -19,8 +18,6 @@ module Ouroboros.Consensus.Block (
   , headerPoint
     -- * Supported blocks
   , SupportedBlock
-    -- * 'WithBlockSize'
-  , WithBlockSize (..)
     -- * EBBs
   , IsEBB (..)
   , toIsEBB
@@ -28,7 +25,6 @@ module Ouroboros.Consensus.Block (
   ) where
 
 import           Codec.Serialise (Serialise)
-import           Data.Word (Word32)
 import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
@@ -98,29 +94,6 @@ class ( GetHeader blk
       , CanSelect    (BlockProtocol blk) (Header blk)
       , NoUnexpectedThunks (Header blk)
       ) => SupportedBlock blk
-
-{-------------------------------------------------------------------------------
-  WithBlockSize
--------------------------------------------------------------------------------}
-
-data WithBlockSize a = WithBlockSize
-  { blockSize        :: !Word32
-  , withoutBlockSize :: !a
-  } deriving (Eq, Show, Generic, NoUnexpectedThunks, Functor, Foldable, Traversable)
-
-type instance HeaderHash (WithBlockSize a) = HeaderHash a
-
-instance Measured BlockMeasure a => Measured BlockMeasure (WithBlockSize a) where
-  measure = measure . withoutBlockSize
-
-instance StandardHash a => StandardHash (WithBlockSize a)
-
-instance HasHeader a => HasHeader (WithBlockSize a) where
-  blockHash      = blockHash . withoutBlockSize
-  blockPrevHash  = castHash . blockPrevHash . withoutBlockSize
-  blockSlot      = blockSlot . withoutBlockSize
-  blockNo        = blockNo . withoutBlockSize
-  blockInvariant = blockInvariant . withoutBlockSize
 
 {-------------------------------------------------------------------------------
   EBBs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Block.hs
@@ -32,6 +32,7 @@ module Ouroboros.Consensus.Ledger.Byron.Block (
   , encodeByronHeaderHash
   , decodeByronHeaderHash
   , byronAddHeaderEnvelope
+  , byronBlockSize
   ) where
 
 import           Data.Binary (Get, Put)
@@ -310,3 +311,11 @@ byronAddHeaderEnvelope
 byronAddHeaderEnvelope = mappend . \case
     IsEBB    -> "\130\NUL"
     IsNotEBB -> "\130\SOH"
+
+-- | Return the size of a block in bytes.
+--
+-- Cheap, as the annotation (serialisation) is kept in memory.
+byronBlockSize :: ByronBlock -> Word32
+byronBlockSize blk = fromIntegral $ Strict.length $ case byronBlockRaw blk of
+    CC.ABOBBoundary b -> CC.boundaryHeaderAnnotation $ CC.boundaryHeader b
+    CC.ABOBBlock    b -> CC.headerAnnotation         $ CC.blockHeader    b

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -40,6 +40,7 @@ import           Data.Time.Clock (secondsToDiffTime)
 
 import           Control.Monad.Class.MonadThrow
 
+import           Ouroboros.Network.Block (WithBlockSize (..))
 import           Ouroboros.Network.Diffusion
 import           Ouroboros.Network.Magic
 import           Ouroboros.Network.NodeToClient (DictVersion (..),
@@ -244,6 +245,7 @@ mkChainDbArgs tracer registry btime dbPath cfg initLedger
     , ChainDB.cdbAddHdrEnv        = nodeAddHeaderEnvelope   (Proxy @blk)
     , ChainDB.cdbDiskPolicy       = defaultDiskPolicy secParam
     , ChainDB.cdbIsEBB            = nodeIsEBB . getHeader
+    , ChainDB.cdbBlockSize        = nodeBlockSize
     , ChainDB.cdbCheckIntegrity   = nodeCheckIntegrity      cfg
     , ChainDB.cdbParamsLgrDB      = ledgerDbDefaultParams secParam
     , ChainDB.cdbNodeConfig       = cfg
@@ -275,8 +277,7 @@ mkNodeArgs registry cfg initState tracers btime chainDB isProducer = NodeArgs
     , btime
     , chainDB
     , blockProduction
-    , blockFetchSize      = nodeBlockFetchSize
-    , blockMatchesHeader  = nodeBlockMatchesHeader
+    , blockMatchesHeader  = nodeBlockMatchesHeader . withoutBlockSize
     , maxUnackTxs         = 100 -- TODO
     , maxBlockSize        = NoOverride
     , mempoolCap          = MempoolCapacityBytes 128_000 -- TODO

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
@@ -19,7 +19,6 @@ import           Data.Word (Word32)
 import           Cardano.Crypto (ProtocolMagicId)
 
 import           Ouroboros.Network.Block (BlockNo, HeaderHash, SlotNo)
-import           Ouroboros.Network.BlockFetch (SizeInBytes)
 import           Ouroboros.Network.Magic (NetworkMagic)
 
 import           Ouroboros.Consensus.Block
@@ -47,8 +46,8 @@ class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
                           -> m blk
 
   nodeBlockMatchesHeader  :: Header blk -> blk -> Bool
-  nodeBlockFetchSize      :: Header blk -> SizeInBytes
   nodeIsEBB               :: Header blk -> Maybe EpochNo
+  nodeBlockSize           :: blk -> Word32
   nodeEpochSize           :: Monad m
                           => Proxy blk
                           -> NodeConfig (BlockProtocol blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -35,7 +35,6 @@ import           Ouroboros.Storage.Common (EpochNo (..), EpochSize (..))
 instance RunNode ByronBlock where
   nodeForgeBlock            = forgeByronBlock
   nodeBlockMatchesHeader    = verifyBlockMatchesHeader
-  nodeBlockFetchSize        = const 2000 -- TODO #593
   nodeIsEBB                 = \hdr -> case byronHeaderRaw hdr of
     Aux.ABOBBlockHdr _       -> Nothing
     Aux.ABOBBoundaryHdr bhdr -> Just
@@ -43,6 +42,7 @@ instance RunNode ByronBlock where
                               . Cardano.Block.boundaryEpoch
                               $ bhdr
 
+  nodeBlockSize             = byronBlockSize
   -- The epoch size is fixed and can be derived from @k@ by the ledger
   -- ('kEpochSlots').
   nodeEpochSize             = \_proxy cfg _epochNo -> return

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Mock.hs
@@ -5,7 +5,8 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Ouroboros.Consensus.Node.Run.Mock () where
 
-import           Codec.Serialise (Serialise, decode, encode)
+import           Codec.Serialise (Serialise, decode, encode, serialise)
+import qualified Data.ByteString.Lazy as Lazy
 import           Data.Time.Calendar (fromGregorian)
 import           Data.Time.Clock (UTCTime (..))
 import           Data.Typeable (Typeable)
@@ -40,8 +41,8 @@ instance ( ProtocolLedgerView (SimpleBlock SimpleMockCrypto ext)
          ) => RunNode (SimpleBlock SimpleMockCrypto ext) where
   nodeForgeBlock            = forgeSimple
   nodeBlockMatchesHeader    = matchesSimpleHeader
-  nodeBlockFetchSize        = fromIntegral . simpleBlockSize . simpleHeaderStd
   nodeIsEBB                 = const Nothing
+  nodeBlockSize             = fromIntegral . Lazy.length . serialise
   nodeEpochSize             = \_ cfg _ -> return $
     EpochSize $ 10 * maxRollbacks (protocolSecurityParam cfg)
   nodeStartTime             = \_ _ -> SystemStart dummyDate

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -11,7 +11,7 @@ module Ouroboros.Consensus.Node.Tracers
 
 import           Control.Tracer (Tracer, nullTracer, showTracing)
 
-import           Ouroboros.Network.Block (Point, SlotNo)
+import           Ouroboros.Network.Block (Point, SlotNo, WithBlockSize)
 import           Ouroboros.Network.BlockFetch (FetchDecision,
                      TraceFetchClientState, TraceLabelPeer)
 import           Ouroboros.Network.TxSubmission.Inbound
@@ -39,10 +39,10 @@ import           Ouroboros.Consensus.TxSubmission
 
 data Tracers' peer blk f = Tracers
   { chainSyncClientTracer         :: f (TraceChainSyncClientEvent blk)
-  , chainSyncServerHeaderTracer   :: f (TraceChainSyncServerEvent blk (Header blk))
-  , chainSyncServerBlockTracer    :: f (TraceChainSyncServerEvent blk blk)
-  , blockFetchDecisionTracer      :: f [TraceLabelPeer peer (FetchDecision [Point (Header blk)])]
-  , blockFetchClientTracer        :: f (TraceLabelPeer peer (TraceFetchClientState (Header blk)))
+  , chainSyncServerHeaderTracer   :: f (TraceChainSyncServerEvent blk)
+  , chainSyncServerBlockTracer    :: f (TraceChainSyncServerEvent blk)
+  , blockFetchDecisionTracer      :: f [TraceLabelPeer peer (FetchDecision [Point (WithBlockSize (Header blk))])]
+  , blockFetchClientTracer        :: f (TraceLabelPeer peer (TraceFetchClientState (WithBlockSize (Header blk))))
   , blockFetchServerTracer        :: f (TraceBlockFetchServerEvent blk)
   , txInboundTracer               :: f (TraceTxSubmissionInbound  (GenTxId blk) (GenTx blk))
   , txOutboundTracer              :: f (TraceTxSubmissionOutbound (GenTxId blk) (GenTx blk))

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/API.hs
@@ -70,7 +70,7 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import           Ouroboros.Network.Block (BlockNo, pattern BlockPoint,
                      ChainUpdate, pattern GenesisPoint, HasHeader (..),
                      HeaderHash, MaxSlotNo, Point, Serialised (..), SlotNo,
-                     StandardHash, atSlot, genesisPoint)
+                     StandardHash, WithBlockSize, atSlot, genesisPoint)
 
 import           Ouroboros.Consensus.Block (GetHeader (..), IsEBB (..))
 import           Ouroboros.Consensus.Ledger.Abstract (ProtocolLedgerView)
@@ -153,7 +153,7 @@ data ChainDB m blk = ChainDB {
       --
       -- NOTE: A direct consequence of this guarantee is that the anchor of the
       -- fragment will move as the chain grows.
-    , getCurrentChain    :: STM m (AnchoredFragment (Header blk))
+    , getCurrentChain    :: STM m (AnchoredFragment (WithBlockSize (Header blk)))
 
       -- | Get current ledger
     , getCurrentLedger   :: STM m (ExtLedgerState blk)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -155,6 +155,7 @@ openDBInternal args launchBgTasks = do
                   , cdbKillBgThreads  = varKillBgThreads
                   , cdbEpochInfo      = Args.cdbEpochInfo args
                   , cdbIsEBB          = isJust . Args.cdbIsEBB args
+                  , cdbBlockSize      = Args.cdbBlockSize args
                   , cdbBlockchainTime = Args.cdbBlockchainTime args
                   , cdbFutureBlocks   = varFutureBlocks
                   }

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -15,6 +15,7 @@ import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Time.Clock (DiffTime, secondsToDiffTime)
+import           Data.Word (Word32)
 
 import           Control.Tracer (Tracer, contramap)
 
@@ -90,6 +91,7 @@ data ChainDbArgs m blk = forall h1 h2 h3. ChainDbArgs {
     , cdbEpochInfo        :: EpochInfo m
     , cdbHashInfo         :: HashInfo (HeaderHash blk)
     , cdbIsEBB            :: blk -> Maybe EpochNo
+    , cdbBlockSize        :: blk -> Word32
     , cdbCheckIntegrity   :: blk -> Bool
     , cdbGenesis          :: m (ExtLedgerState blk)
     , cdbBlockchainTime   :: BlockchainTime m
@@ -116,6 +118,7 @@ data ChainDbSpecificArgs m blk = ChainDbSpecificArgs {
     , cdbsGcDelay        :: DiffTime
     , cdbsBlockchainTime :: BlockchainTime m
     , cdbsEncodeHeader   :: Header blk -> Encoding
+    , cdbsBlockSize      :: blk -> Word32
     }
 
 -- | Default arguments
@@ -134,6 +137,7 @@ defaultSpecificArgs = ChainDbSpecificArgs{
     , cdbsRegistry       = error "no default for cdbsRegistry"
     , cdbsBlockchainTime = error "no default for cdbsBlockchainTime"
     , cdbsEncodeHeader   = error "no default for cdbsEncodeHeader"
+    , cdbsBlockSize      = error "no default for cdbsBlockSize"
     }
   where
     oneHour = secondsToDiffTime 60 * 60
@@ -211,6 +215,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , cdbsGcDelay         = cdbGcDelay
         , cdbsBlockchainTime  = cdbBlockchainTime
         , cdbsEncodeHeader    = cdbEncodeHeader
+        , cdbsBlockSize       = cdbBlockSize
         }
     )
 
@@ -257,6 +262,7 @@ toChainDbArgs ImmDB.ImmDbArgs{..}
     , cdbEpochInfo        = immEpochInfo
     , cdbHashInfo         = immHashInfo
     , cdbIsEBB            = immIsEBB
+    , cdbBlockSize        = cdbsBlockSize
     , cdbCheckIntegrity   = immCheckIntegrity
     , cdbGenesis          = lgrGenesis
     , cdbBlockchainTime   = cdbsBlockchainTime

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Query.hs
@@ -32,9 +32,9 @@ import           Control.Monad.Class.MonadThrow
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (BlockNo, ChainHash (..), HasHeader,
-                     HeaderHash, MaxSlotNo, Point, StandardHash, castPoint,
-                     genesisPoint, maxSlotNoFromWithOrigin, pointHash,
-                     pointSlot)
+                     HeaderHash, MaxSlotNo, Point, StandardHash,
+                     WithBlockSize (..), castPoint, genesisPoint,
+                     maxSlotNoFromWithOrigin, pointHash, pointSlot)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -75,7 +75,7 @@ getCurrentChain
      , OuroborosTag (BlockProtocol blk)
      )
   => ChainDbEnv m blk
-  -> STM m (AnchoredFragment (Header blk))
+  -> STM m (AnchoredFragment (WithBlockSize (Header blk)))
 getCurrentChain CDB{..} =
     AF.anchorNewest k <$> readTVar cdbChain
   where
@@ -107,7 +107,8 @@ getTipHeader
   => ChainDbEnv m blk
   -> m (Maybe (Header blk))
 getTipHeader CDB{..} = do
-    anchorOrHdr <- AF.head <$> atomically (readTVar cdbChain)
+    anchorOrHdr <- fmap withoutBlockSize . AF.head <$>
+      atomically (readTVar cdbChain)
     case anchorOrHdr of
       Right hdr
         -> return $ Just hdr

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -48,10 +48,9 @@ import           Streaming (Of, Stream)
 import           Cardano.Prelude (NoUnexpectedThunks (..),
                      UseIsNormalFormNamed (..))
 
-import           Ouroboros.Network.Block (SlotNo (..))
+import           Ouroboros.Network.Block (SlotNo (..), WithBlockSize (..))
 import           Ouroboros.Network.Point (WithOrigin)
 
-import           Ouroboros.Consensus.Block (WithBlockSize (..))
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API.Types (FsError, FsPath, prettyFsError,
                      sameFsError)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -51,6 +51,7 @@ import           Cardano.Prelude (NoUnexpectedThunks (..),
 import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.Point (WithOrigin)
 
+import           Ouroboros.Consensus.Block (WithBlockSize (..))
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.FS.API.Types (FsError, FsPath, prettyFsError,
                      sameFsError)
@@ -69,11 +70,6 @@ type ImmTipWithHash hash = Tip (WithHash hash BlockOrEBB)
 data WithHash hash a = WithHash
   { theHash    :: !hash
   , forgetHash :: !a
-  } deriving (Eq, Show, Generic, NoUnexpectedThunks, Functor, Foldable, Traversable)
-
-data WithBlockSize a = WithBlockSize
-  { blockSize        :: !Word32
-  , withoutBlockSize :: !a
   } deriving (Eq, Show, Generic, NoUnexpectedThunks, Functor, Foldable, Traversable)
 
 -- | How to get/put the header hash of a block and how many bytes it occupies

--- a/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
@@ -358,6 +358,7 @@ runThreadNetwork ThreadNetworkArgs
         , cdbEpochInfo        = epochInfo
         , cdbHashInfo         = nodeHashInfo (Proxy @blk)
         , cdbIsEBB            = nodeIsEBB . getHeader
+        , cdbBlockSize        = nodeBlockSize
         , cdbCheckIntegrity   = nodeCheckIntegrity cfg
         , cdbGenesis          = return initLedger
         , cdbBlockchainTime   = btime
@@ -439,8 +440,7 @@ runThreadNetwork ThreadNetworkArgs
             , btime
             , chainDB
             , blockProduction     = Just blockProduction
-            , blockFetchSize      = nodeBlockFetchSize
-            , blockMatchesHeader  = nodeBlockMatchesHeader
+            , blockMatchesHeader  = nodeBlockMatchesHeader . withoutBlockSize
             , maxUnackTxs         = 1000 -- TODO
             , maxBlockSize        = NoOverride
             , mempoolCap          = MempoolCapacityBytes 3000 -- TODO

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -8,7 +8,7 @@ module Test.Ouroboros.Storage.ChainDB.AddBlock
 
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
-import           Codec.Serialise (decode, encode)
+import           Codec.Serialise (decode, encode, serialise)
 import           Control.Exception (throw)
 import           Control.Monad (void)
 import qualified Data.ByteString.Lazy as Lazy
@@ -137,8 +137,10 @@ prop_addBlock_multiple_threads bpt =
         Model.empty initLedger
 
     equallyPreferable :: Chain TestBlock -> Chain TestBlock -> Bool
-    equallyPreferable chain1 chain2 =
-      compareAnchoredCandidates cfg (Chain.toAnchoredFragment chain1) (Chain.toAnchoredFragment chain2) == EQ
+    equallyPreferable chain1 chain2 = EQ ==
+      compareAnchoredCandidates cfg id
+        (Chain.toAnchoredFragment chain1)
+        (Chain.toAnchoredFragment chain2)
 
     cfg :: NodeConfig (BlockProtocol TestBlock)
     cfg = singleNodeTestConfig
@@ -270,6 +272,7 @@ mkArgs cfg initLedger tracer registry hashInfo
     , cdbEpochInfo        = fixedSizeEpochInfo fixedEpochSize
     , cdbHashInfo         = hashInfo
     , cdbIsEBB            = const Nothing
+    , cdbBlockSize        = fromIntegral . Lazy.length . serialise
     , cdbCheckIntegrity   = const True
     , cdbBlockchainTime   = fixedBlockchainTime maxBound
     , cdbGenesis          = return initLedger

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -120,7 +120,7 @@ openDB cfg initLedger btime = do
 
     return ChainDB {
         addBlock            = update_  . Model.addBlock cfg
-      , getCurrentChain     = querySTM $ Model.lastK k getHeader
+      , getCurrentChain     = querySTM $ Model.lastK k
       , getCurrentLedger    = querySTM $ Model.currentLedger
       , getPastLedger       = query    . Model.getPastLedger cfg
       , getBlockComponent   = queryE  .: Model.getBlockComponentByPoint

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
@@ -75,7 +75,7 @@ prop_alwaysPickPreferredChain bt p =
     SecurityParam k = protocolSecurityParam singleNodeTestConfig
 
     preferCandidate' candidate =
-        AF.preferAnchoredCandidate singleNodeTestConfig curFragment candFragment &&
+        AF.preferAnchoredCandidate singleNodeTestConfig id curFragment candFragment &&
         AF.forksAtMostKBlocks k curFragment candFragment
       where
         candFragment = Chain.toAnchoredFragment candidate

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -172,6 +172,9 @@ testHashInfo = HashInfo
 testBlockIsEBB :: TestBlock -> IsEBB
 testBlockIsEBB = thIsEBB . testHeader
 
+testBlockSize :: TestBlock -> Word32
+testBlockSize = fromIntegral . Lazy.length . serialise
+
 -- | Only works correctly if the epoch size is fixed
 testBlockEpochNoIfEBB :: EpochSize -> TestBlock -> Maybe EpochNo
 testBlockEpochNoIfEBB fixedEpochSize b = case testBlockIsEBB b of

--- a/ouroboros-network/src/Ouroboros/Network/DeltaQ.hs
+++ b/ouroboros-network/src/Ouroboros/Network/DeltaQ.hs
@@ -36,6 +36,7 @@ module Ouroboros.Network.DeltaQ (
 
 import           Data.Semigroup ((<>))
 import           Data.Time.Clock (DiffTime)
+import           Data.Word (Word32)
 
 
 --
@@ -194,7 +195,7 @@ ballisticGSV g s v = GSV g (\sz -> s * fromIntegral sz) v
 -- Basic calculations based on GSV
 --
 
-type SizeInBytes = Word
+type SizeInBytes = Word32
 
 -- | The 𝚫Q for when the leading edge of a transmission unit arrives at the
 -- destination. This is just the convolution of the /G/ and /V/ components.

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -30,7 +30,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 import           Network.TypedProtocol.Core
 
-import           Ouroboros.Network.Block (Tip(..), encodeTip, decodeTip)
+import           Ouroboros.Network.Block (Tip (..), decodeTip, encodeTip)
 import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate, Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 import qualified Ouroboros.Network.MockChain.ProducerState as CPS
@@ -113,6 +113,7 @@ demo chain0 updates delay = do
                         Mx.MuxPeer
                         nullTracer
                         (ChainSync.codecChainSync
+                        id                 id
                         encode (fmap const decode)
                         encode             decode
                         (encodeTip encode) (decodeTip decode))
@@ -125,6 +126,7 @@ demo chain0 updates delay = do
                         Mx.MuxPeer
                         nullTracer
                         (ChainSync.codecChainSync
+                        id                 id
                         encode (fmap const decode)
                         encode             decode
                         (encodeTip encode) (decodeTip decode))

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -28,7 +28,7 @@ import qualified Network.Mux.Bearer.Pipe as Mx
 import qualified Network.Mux.Types as Mx
 import           Ouroboros.Network.Mux
 
-import           Ouroboros.Network.Block (encodeTip, decodeTip)
+import           Ouroboros.Network.Block (decodeTip, encodeTip)
 import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate, Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 import qualified Ouroboros.Network.MockChain.ProducerState as CPS
@@ -109,7 +109,8 @@ demo chain0 updates = do
         consumerApp = simpleInitiatorApplication $
           \ChainSync ->
             MuxPeer nullTracer
-                    (ChainSync.codecChainSync encode             (fmap const decode)
+                    (ChainSync.codecChainSync id                 id
+                                              encode             (fmap const decode)
                                               encode             decode
                                               (encodeTip encode) (decodeTip decode))
                     (ChainSync.chainSyncClientPeer
@@ -123,7 +124,8 @@ demo chain0 updates = do
         producerApp = simpleResponderApplication $
           \ChainSync ->
             MuxPeer nullTracer
-                    (ChainSync.codecChainSync encode             (fmap const decode)
+                    (ChainSync.codecChainSync id                 id
+                                              encode             (fmap const decode)
                                               encode             decode
                                               (encodeTip encode) (decodeTip decode))
                     (ChainSync.chainSyncServerPeer server)

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -49,7 +49,7 @@ import           Ouroboros.Network.Mux as Mx
 
 import           Ouroboros.Network.Socket
 
-import           Ouroboros.Network.Block (Tip, encodeTip, decodeTip)
+import           Ouroboros.Network.Block (Tip, decodeTip, encodeTip)
 import           Ouroboros.Network.Magic
 import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate, Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
@@ -59,7 +59,8 @@ import qualified Ouroboros.Network.Protocol.ChainSync.Client as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Codec as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Examples as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Server as ChainSync
-import           Ouroboros.Network.Protocol.Handshake.Type (acceptEq, cborTermVersionDataCodec)
+import           Ouroboros.Network.Protocol.Handshake.Type (acceptEq,
+                     cborTermVersionDataCodec)
 import           Ouroboros.Network.Protocol.Handshake.Version
                      (simpleSingletonVersions)
 import           Ouroboros.Network.Testing.Serialise
@@ -403,7 +404,8 @@ demo chain0 updates = do
                     codecChainSync
                     (ChainSync.chainSyncServerPeer server)
 
-        codecChainSync = ChainSync.codecChainSync encode (fmap const decode)
+        codecChainSync = ChainSync.codecChainSync id                 id
+                                                  encode (fmap const decode)
                                                   encode             decode
                                                   (encodeTip encode) (decodeTip decode)
 


### PR DESCRIPTION
Closes #593.

* Modify the ChainSync codec.

* The current chain fragment of the ChainDB now stores `WithBlockSize (Header
  blk)` instead of `Header`.