### PR TITLE
Simplify the run{Pipelined}Peer driver tracing

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -288,13 +288,13 @@ protocolCodecsId = ProtocolCodecs {
 type ProtocolTracers m peer blk failure = ProtocolTracers' peer blk failure (Tracer m)
 
 data ProtocolTracers' peer blk failure f = ProtocolTracers {
-    ptChainSyncTracer            :: f (TraceSendRecv (ChainSync (Header blk) (Tip blk))               peer failure)
-  , ptChainSyncSerialisedTracer  :: f (TraceSendRecv (ChainSync (Serialised (Header blk)) (Tip blk))  peer failure)
-  , ptBlockFetchTracer           :: f (TraceSendRecv (BlockFetch blk)                                 peer failure)
-  , ptBlockFetchSerialisedTracer :: f (TraceSendRecv (BlockFetch (Serialised blk))                    peer failure)
-  , ptTxSubmissionTracer         :: f (TraceSendRecv (TxSubmission (GenTxId blk) (GenTx blk))         peer failure)
-  , ptLocalChainSyncTracer       :: f (TraceSendRecv (ChainSync (Serialised blk) (Tip blk))           peer failure)
-  , ptLocalTxSubmissionTracer    :: f (TraceSendRecv (LocalTxSubmission (GenTx blk) (ApplyTxErr blk)) peer failure)
+    ptChainSyncTracer            :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (Header blk) (Tip blk))))
+  , ptChainSyncSerialisedTracer  :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (Serialised (Header blk)) (Tip blk))))
+  , ptBlockFetchTracer           :: f (TraceLabelPeer peer (TraceSendRecv (BlockFetch blk)))
+  , ptBlockFetchSerialisedTracer :: f (TraceLabelPeer peer (TraceSendRecv (BlockFetch (Serialised blk))))
+  , ptTxSubmissionTracer         :: f (TraceLabelPeer peer (TraceSendRecv (TxSubmission (GenTxId blk) (GenTx blk))))
+  , ptLocalChainSyncTracer       :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (Serialised blk) (Tip blk))))
+  , ptLocalTxSubmissionTracer    :: f (TraceLabelPeer peer (TraceSendRecv (LocalTxSubmission (GenTx blk) (ApplyTxErr blk))))
   }
 
 -- | Use a 'nullTracer' for each protocol.
@@ -310,9 +310,8 @@ nullProtocolTracers = ProtocolTracers {
   }
 
 showProtocolTracers :: ( Show blk
-                       , Show (Header blk)
                        , Show peer
-                       , Show failure
+                       , Show (Header blk)
                        , Show (GenTx blk)
                        , Show (GenTxId blk)
                        , Show (ApplyTxErr blk)
@@ -450,9 +449,8 @@ consensusNetworkApps kernel ProtocolTracers {..} ProtocolCodecs {..} ProtocolHan
           (getNodeCandidates kernel)
           them $ \varCandidate->
         runPipelinedPeer
-          ptChainSyncTracer
+          (contramap (TraceLabelPeer them) ptChainSyncTracer)
           pcChainSyncCodec
-          them
           channel
           $ chainSyncClientPeerPipelined
           $ phChainSyncClient varCandidate
@@ -463,9 +461,8 @@ consensusNetworkApps kernel ProtocolTracers {..} ProtocolCodecs {..} ProtocolHan
       -> m ()
     naChainSyncServer them channel = withRegistry $ \registry ->
       runPeer
-        ptChainSyncSerialisedTracer
+        (contramap (TraceLabelPeer them) ptChainSyncSerialisedTracer)
         pcChainSyncCodecSerialised
-        them
         channel
         $ chainSyncServerPeer
         $ phChainSyncServer registry
@@ -477,9 +474,8 @@ consensusNetworkApps kernel ProtocolTracers {..} ProtocolCodecs {..} ProtocolHan
     naBlockFetchClient them channel =
       bracketFetchClient (getFetchClientRegistry kernel) them $ \clientCtx ->
         runPipelinedPeer
-          ptBlockFetchTracer
+          (contramap (TraceLabelPeer them) ptBlockFetchTracer)
           pcBlockFetchCodec
-          them
           channel
           $ phBlockFetchClient clientCtx
 
@@ -489,9 +485,8 @@ consensusNetworkApps kernel ProtocolTracers {..} ProtocolCodecs {..} ProtocolHan
       -> m ()
     naBlockFetchServer them channel = withRegistry $ \registry ->
       runPeer
-        ptBlockFetchSerialisedTracer
+        (contramap (TraceLabelPeer them) ptBlockFetchSerialisedTracer)
         pcBlockFetchCodecSerialised
-        them
         channel
         $ blockFetchServerPeer
         $ phBlockFetchServer registry
@@ -502,9 +497,8 @@ consensusNetworkApps kernel ProtocolTracers {..} ProtocolCodecs {..} ProtocolHan
       -> m ()
     naTxSubmissionClient them channel =
       runPeer
-        ptTxSubmissionTracer
+        (contramap (TraceLabelPeer them) ptTxSubmissionTracer)
         pcTxSubmissionCodec
-        them
         channel
         (txSubmissionClientPeer phTxSubmissionClient)
 
@@ -514,9 +508,8 @@ consensusNetworkApps kernel ProtocolTracers {..} ProtocolCodecs {..} ProtocolHan
       -> m ()
     naTxSubmissionServer them channel =
       runPipelinedPeer
-        ptTxSubmissionTracer
+        (contramap (TraceLabelPeer them) ptTxSubmissionTracer)
         pcTxSubmissionCodec
-        them
         channel
         (txSubmissionServerPeerPipelined phTxSubmissionServer)
 
@@ -526,9 +519,8 @@ consensusNetworkApps kernel ProtocolTracers {..} ProtocolCodecs {..} ProtocolHan
       -> m ()
     naLocalChainSyncServer them channel = withRegistry $ \registry ->
       runPeer
-        ptLocalChainSyncTracer
+        (contramap (TraceLabelPeer them) ptLocalChainSyncTracer)
         pcLocalChainSyncCodec
-        them
         channel
         $ chainSyncServerPeer
         $ phLocalChainSyncServer registry
@@ -539,9 +531,8 @@ consensusNetworkApps kernel ProtocolTracers {..} ProtocolCodecs {..} ProtocolHan
       -> m ()
     naLocalTxSubmissionServer them channel =
       runPeer
-        ptLocalTxSubmissionTracer
+        (contramap (TraceLabelPeer them) ptLocalTxSubmissionTracer)
         pcLocalTxSubmissionCodec
-        them
         channel
         (localTxSubmissionServerPeer (pure phLocalTxSubmissionServer))
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -28,7 +28,6 @@ import           Control.Monad.Class.MonadThrow
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Network.TypedProtocol.Channel
-import           Network.TypedProtocol.Codec (CodecFailure)
 import           Network.TypedProtocol.Driver
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
@@ -223,9 +222,7 @@ newtype ServerUpdates =
 
 type TraceEvent = (SlotNo, Either
   (TraceChainSyncClientEvent TestBlock)
-  (TraceSendRecv (ChainSync (Header TestBlock) (Tip TestBlock))
-                 CoreNodeId
-                 CodecFailure))
+  (TraceSendRecv (ChainSync (Header TestBlock) (Tip TestBlock))))
 
 -- | We have a client and a server chain that both start at genesis. At
 -- certain slots, we apply updates to both of these chains to simulate changes
@@ -365,7 +362,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
            serverId $ \varCandidate -> do
              atomically $ modifyTVar varFinalCandidates $
                Map.insert serverId varCandidate
-             runPipelinedPeer protocolTracer codecChainSyncId serverId clientChannel $
+             runPipelinedPeer protocolTracer codecChainSyncId clientChannel $
                chainSyncClientPeerPipelined $ client varCandidate
         `catch` \(e :: ChainSyncClientException) -> do
           -- TODO: Is this necessary? Wouldn't the Async's internal MVar do?
@@ -373,7 +370,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
           -- Rethrow, but it will be ignored anyway.
           throwM e
       void $ forkLinkedThread registry $
-        runPeer nullTracer codecChainSyncId clientId serverChannel
+        runPeer nullTracer codecChainSyncId serverChannel
                 (chainSyncServerPeer server)
 
     testBlockchainTimeDone testBtime

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -158,8 +158,7 @@ clientPingPong pipelined =
                                 IO LBS.ByteString () Void
     app = simpleInitiatorApplication protocols
 
-    protocols :: DemoProtocol0 -> MuxPeer ConnectionId
-                                          DeserialiseFailure
+    protocols :: DemoProtocol0 -> MuxPeer DeserialiseFailure
                                           IO LBS.ByteString ()
     protocols PingPong0 | pipelined =
       MuxPeerPipelined
@@ -199,8 +198,7 @@ serverPingPong = do
                                 IO LBS.ByteString Void ()
     app = simpleResponderApplication protocols
 
-    protocols :: DemoProtocol0 -> MuxPeer ConnectionId
-                                          DeserialiseFailure
+    protocols :: DemoProtocol0 -> MuxPeer DeserialiseFailure
                                           IO LBS.ByteString ()
     protocols PingPong0 =
       MuxPeer
@@ -249,8 +247,7 @@ clientPingPong2 =
                                 IO LBS.ByteString () Void
     app = simpleInitiatorApplication protocols
 
-    protocols :: DemoProtocol1 -> MuxPeer ConnectionId
-                                          DeserialiseFailure
+    protocols :: DemoProtocol1 -> MuxPeer DeserialiseFailure
                                           IO LBS.ByteString ()
     protocols PingPong1 =
       MuxPeer
@@ -303,8 +300,7 @@ serverPingPong2 = do
                                 IO LBS.ByteString Void ()
     app = simpleResponderApplication protocols
 
-    protocols :: DemoProtocol1 -> MuxPeer ConnectionId
-                                          DeserialiseFailure
+    protocols :: DemoProtocol1 -> MuxPeer DeserialiseFailure
                                           IO LBS.ByteString ()
     protocols PingPong1 =
       MuxPeer
@@ -350,8 +346,7 @@ clientChainSync sockAddrs =
                                 IO LBS.ByteString () Void
     app = simpleInitiatorApplication protocols
 
-    protocols :: DemoProtocol2 -> MuxPeer ConnectionId
-                                          DeserialiseFailure
+    protocols :: DemoProtocol2 -> MuxPeer DeserialiseFailure
                                           IO LBS.ByteString ()
     protocols ChainSync2 =
       MuxPeer
@@ -383,8 +378,7 @@ serverChainSync sockAddr = do
                                 IO LBS.ByteString Void ()
     app = simpleResponderApplication protocols
 
-    protocols :: DemoProtocol2 -> MuxPeer ConnectionId
-                                          DeserialiseFailure
+    protocols :: DemoProtocol2 -> MuxPeer DeserialiseFailure
                                           IO LBS.ByteString ()
     protocols ChainSync2 =
       MuxPeer
@@ -446,7 +440,6 @@ clientBlockFetch sockAddrs = do
           runPeer
             nullTracer -- (contramap (show . TraceLabelPeer peerid) stdoutTracer)
             codecChainSync
-            peerid
             channel
             (ChainSync.chainSyncClientPeer
               (chainSyncClient' syncTracer currentChainVar chainVar))
@@ -465,7 +458,6 @@ clientBlockFetch sockAddrs = do
             runPipelinedPeer
               nullTracer -- (contramap (show . TraceLabelPeer peerid) stdoutTracer)
               codecBlockFetch
-              peerid
               channel
               (blockFetchClient clientCtx)
 
@@ -587,8 +579,7 @@ serverBlockFetch sockAddr = do
                                 IO LBS.ByteString Void ()
     app = simpleResponderApplication protocols
 
-    protocols :: DemoProtocol3 -> MuxPeer ConnectionId
-                                          DeserialiseFailure
+    protocols :: DemoProtocol3 -> MuxPeer DeserialiseFailure
                                           IO LBS.ByteString ()
     protocols ChainSync3 =
       MuxPeer

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -18,14 +18,12 @@ module Ouroboros.Network.Diffusion
 
 import qualified Control.Concurrent.Async as Async
 import           Control.Tracer (Tracer)
-import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Term as CBOR
 import           Data.Functor (void)
 import           Data.Void (Void)
 import           Data.ByteString.Lazy (ByteString)
 
 import           Network.TypedProtocol.Driver (TraceSendRecv (..))
-import           Network.TypedProtocol.Driver.ByteLimit (DecoderFailureOrTooMuchInput (..))
 import           Network.Mux (MuxTrace (..), WithMuxBearer (..))
 import           Network.Socket (SockAddr, AddrInfo)
 import qualified Network.Socket as Socket
@@ -65,15 +63,11 @@ data DiffusionTracers = DiffusionTracers {
       -- ^ Mux tracer
     , dtMuxLocalTracer        :: Tracer IO (WithMuxBearer ConnectionId MuxTrace)
       -- ^ Mux tracer for local clients
-    , dtHandshakeTracer       :: Tracer IO (TraceSendRecv
-                                              (Handshake NodeToNodeVersion CBOR.Term)
-                                              ConnectionId
-                                              (DecoderFailureOrTooMuchInput CBOR.DeserialiseFailure))
+    , dtHandshakeTracer       :: Tracer IO (WithMuxBearer ConnectionId
+                                             (TraceSendRecv (Handshake NodeToNodeVersion CBOR.Term)))
       -- ^ Handshake protocol tracer
-    , dtHandshakeLocalTracer  :: Tracer IO (TraceSendRecv
-                                              (Handshake NodeToClientVersion CBOR.Term)
-                                              ConnectionId
-                                              (DecoderFailureOrTooMuchInput CBOR.DeserialiseFailure))
+    , dtHandshakeLocalTracer  :: Tracer IO (WithMuxBearer ConnectionId
+                                             (TraceSendRecv (Handshake NodeToClientVersion CBOR.Term)))
       -- ^ Handshake protocol tracer for local clients
     , dtErrorPolicyTracer     :: Tracer IO (WithAddr SockAddr ErrorPolicyTrace)
     }

--- a/ouroboros-network/src/Ouroboros/Network/MockNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/MockNode.hs
@@ -283,7 +283,7 @@ relayNode :: forall m block.
           -> Chain block
           -> NodeChannels m block (Tip block)
           -> m (StrictTVar m (ChainProducerState block))
-relayNode nid initChain chans = do
+relayNode _nid initChain chans = do
   -- Mutable state
   -- 1. input chains
   upstream <- zipWithM startConsumer [0..] (consumerChans chans)
@@ -306,12 +306,11 @@ relayNode nid initChain chans = do
     startConsumer :: Int
                   -> Channel m (AnyMessage (ChainSync block (Tip block)))
                   -> m (StrictTVar m (Chain block))
-    startConsumer cid channel = do
+    startConsumer _cid channel = do
       chainVar <- atomically $ newTVar Genesis
       let consumer = chainSyncClientPeer (chainSyncClientExample chainVar pureClient)
       void $ fork $ void $ runPeer nullTracer
                                    codecChainSyncId
-                                   (ConsumerId nid cid)
                                    channel
                                    consumer
       return chainVar
@@ -320,13 +319,12 @@ relayNode nid initChain chans = do
                   -> Int
                   -> Channel m (AnyMessage (ChainSync block (Tip block)))
                   -> m ()
-    startProducer producer pid channel =
+    startProducer producer _pid channel =
       -- use 'void' because 'fork' only works with 'm ()'
       -- No sense throwing on Unexpected right? since fork will just squelch
       -- it. FIXME: use async...
       void $ fork $ void $ runPeer nullTracer
                                    codecChainSyncId
-                                   (ProducerId nid pid)
                                    channel
                                    producer
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -280,7 +280,6 @@ prop_channel createChannels chain points = do
       runConnectedPeers
         createChannels nullTracer
         codec
-        "client" "server"
         (blockFetchClientPeer (testClient chain points))
         (blockFetchServerPeer (testServer chain))
     return $ reverse bodies === concat (receivedBlockBodies chain points)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -535,8 +535,8 @@ chainSyncDemo clientChan serverChan (ChainProducerStateForkTest cps chain) = do
       client :: ChainSyncClient Block (Tip Block) m ()
       client = ChainSyncExamples.chainSyncClientExample chainVar (testClient doneVar (Chain.headPoint pchain))
 
-  void $ fork (void $ runPeer nullTracer codec "server" serverChan (chainSyncServerPeer server))
-  void $ fork (void $ runPeer nullTracer codec "client" clientChan (chainSyncClientPeer client))
+  void $ fork (void $ runPeer nullTracer codec serverChan (chainSyncServerPeer server))
+  void $ fork (void $ runPeer nullTracer codec clientChan (chainSyncClientPeer client))
 
   atomically $ do
     done <- readTVar doneVar
@@ -603,8 +603,8 @@ chainSyncDemoPipelined clientChan serverChan mkClient (ChainProducerStateForkTes
       client :: ChainSyncClientPipelined Block (Tip Block) m ()
       client = mkClient chainVar (testClient doneVar (Chain.headPoint pchain))
 
-  void $ fork (void $ runPeer nullTracer codec "server" serverChan (chainSyncServerPeer server))
-  void $ fork (void $ runPipelinedPeer nullTracer codec "client" clientChan (chainSyncClientPeerPipelined client))
+  void $ fork (void $ runPeer nullTracer codec serverChan (chainSyncServerPeer server))
+  void $ fork (void $ runPipelinedPeer nullTracer codec clientChan (chainSyncClientPeerPipelined client))
 
   atomically $ do
     done <- readTVar doneVar

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -375,8 +375,6 @@ prop_channel createChannels clientVersions serverVersions =
     (clientRes', serverRes') <-
       runConnectedPeers
         createChannels nullTracer codecHandshake
-        "client"
-        "server"
         (handshakeClientPeer
           cborTermVersionDataCodec
           clientVersions)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
@@ -143,8 +143,6 @@ prop_channel createChannels p txs =
       createChannels
       nullTracer
       codec
-      "client"
-      "server"
       (localTxSubmissionClientPeer $
        localTxSubmissionClient txs)
       (localTxSubmissionServerPeer $ pure $

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Test.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Test.hs
@@ -197,8 +197,6 @@ prop_channel createChannels params@TxSubmissionTestParams{testTransactions} =
       createChannels
       nullTracer
       codec
-      "client"
-      "producer"
       (txSubmissionServerPeerPipelined $
        testServer nullTracer params)
       (txSubmissionClientPeer $

--- a/ouroboros-network/src/Ouroboros/Network/Tracers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Tracers.hs
@@ -7,13 +7,11 @@ module Ouroboros.Network.Tracers
 
 import           Control.Tracer (Tracer, nullTracer)
 import qualified Codec.CBOR.Term as CBOR
-import           Codec.Serialise (DeserialiseFailure)
 
 import           Network.Socket (SockAddr)
 import           Network.Mux.Trace
 
 import           Network.TypedProtocol.Driver (TraceSendRecv)
-import           Network.TypedProtocol.Driver.ByteLimit
 
 import           Ouroboros.Network.ErrorPolicy
 import           Ouroboros.Network.Protocol.Handshake.Type
@@ -27,9 +25,8 @@ data NetworkIPSubscriptionTracers ptcl vNumber = NetworkIPSubscriptionTracers {
       nistMuxTracer          :: Tracer IO (WithMuxBearer ConnectionId MuxTrace),
       -- ^ low level mux-network tracer, which logs mux sdu (send and received)
       -- and other low level multiplexing events.
-      nistHandshakeTracer    :: Tracer IO (TraceSendRecv (Handshake vNumber CBOR.Term)
-                                                         ConnectionId
-                                                         (DecoderFailureOrTooMuchInput DeserialiseFailure)),
+      nistHandshakeTracer    :: Tracer IO (WithMuxBearer ConnectionId
+                                            (TraceSendRecv (Handshake vNumber CBOR.Term))),
       -- ^ handshake protocol tracer; it is important for analysing version
       -- negotation mismatches.
       nistErrorPolicyTracer  :: Tracer IO (WithAddr SockAddr ErrorPolicyTrace),
@@ -55,9 +52,8 @@ data NetworkDNSSubscriptionTracers ptcl vNumber peerid = NetworkDNSSubscriptionT
       ndstMuxTracer          :: Tracer IO (WithMuxBearer peerid MuxTrace),
       -- ^ low level mux-network tracer, which logs mux sdu (send and received)
       -- and other low level multiplexing events.
-      ndstHandshakeTracer    :: Tracer IO (TraceSendRecv (Handshake vNumber CBOR.Term)
-                                                       peerid
-                                                       (DecoderFailureOrTooMuchInput DeserialiseFailure)),
+      ndstHandshakeTracer    :: Tracer IO (WithMuxBearer peerid
+                                            (TraceSendRecv (Handshake vNumber CBOR.Term))),
       -- ^ handshake protocol tracer; it is important for analysing version
       -- negotation mismatches.
       ndstErrorPolicyTracer  :: Tracer IO (WithAddr SockAddr ErrorPolicyTrace),

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -12,7 +12,6 @@ import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck (testProperty)
 import           Test.ChainGenerators (TestChainFork(..))
 
-import           Codec.CBOR.Read (DeserialiseFailure)
 import           Data.List
 import qualified Data.Set as Set
 import           Data.Set (Set)
@@ -187,7 +186,8 @@ data Example1TraceEvent =
                                 (FetchDecision [Point BlockHeader])]
    | TraceFetchClientState    (TraceLabelPeer Int
                                 (TraceFetchClientState BlockHeader))
-   | TraceFetchClientSendRecv (TraceSendRecv (BlockFetch Block) Int DeserialiseFailure)
+   | TraceFetchClientSendRecv (TraceLabelPeer Int
+                                (TraceSendRecv (BlockFetch Block)))
 
 instance Show Example1TraceEvent where
   show (TraceFetchDecision       x) = "TraceFetchDecision " ++ show x

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -214,10 +214,9 @@ prop_socket_send_recv initiatorAddr responderAddr f xs = do
     let -- Server Node; only req-resp server
         responderApp :: OuroborosApplication Mx.ResponderApp ConnectionId TestProtocols2 IO BL.ByteString Void ()
         responderApp = OuroborosResponderApplication $
-          \peerid ReqRespPr channel -> do
+          \_peerid ReqRespPr channel -> do
             r <- runPeer nullTracer
                          ReqResp.codecReqResp
-                         peerid
                          channel
                          (ReqResp.reqRespServerPeer (ReqResp.reqRespServerMapAccumL (\a -> pure . f a) 0))
             atomically $ putTMVar sv r
@@ -226,10 +225,9 @@ prop_socket_send_recv initiatorAddr responderAddr f xs = do
         -- Client Node; only req-resp client
         initiatorApp :: OuroborosApplication Mx.InitiatorApp ConnectionId TestProtocols2 IO BL.ByteString () Void
         initiatorApp = OuroborosInitiatorApplication $
-          \peerid ReqRespPr channel -> do
+          \_peerid ReqRespPr channel -> do
             r <- runPeer nullTracer
                          ReqResp.codecReqResp
-                         peerid
                          channel
                          (ReqResp.reqRespClientPeer (ReqResp.reqRespClientMap xs))
             atomically $ putTMVar cv r
@@ -282,10 +280,9 @@ prop_socket_recv_close f _ = ioProperty $ do
 
     let app :: OuroborosApplication ResponderApp () TestProtocols2 IO BL.ByteString Void ()
         app = OuroborosResponderApplication $
-          \peerid ReqRespPr channel -> do
+          \_peerid ReqRespPr channel -> do
             r <- runPeer nullTracer
                          ReqResp.codecReqResp
-                         peerid
                          channel
                          (ReqResp.reqRespServerPeer (ReqResp.reqRespServerMapAccumL (\a -> pure . f a) 0))
             atomically $ putTMVar sv r
@@ -338,10 +335,9 @@ prop_socket_client_connect_error _ xs = ioProperty $ do
 
     let app :: OuroborosApplication Mx.InitiatorApp ConnectionId TestProtocols2 IO BL.ByteString () Void
         app = OuroborosInitiatorApplication $
-                \peerid ReqRespPr channel -> do
+                \_peerid ReqRespPr channel -> do
                   _ <- runPeer nullTracer
                           ReqResp.codecReqResp
-                          peerid
                           channel
                           (ReqResp.reqRespClientPeer (ReqResp.reqRespClientMap xs)
                                   :: Peer (ReqResp.ReqResp Int Int) AsClient ReqResp.StIdle IO [Int])

--- a/ouroboros-network/test/Test/Subscription.hs
+++ b/ouroboros-network/test/Test/Subscription.hs
@@ -526,10 +526,9 @@ prop_send_recv f xs first = ioProperty $ do
     let -- Server Node; only req-resp server
         responderApp :: OuroborosApplication ResponderApp ConnectionId TestProtocols2 IO BL.ByteString Void ()
         responderApp = OuroborosResponderApplication $
-          \peerid ReqRespPr channel -> do
+          \_peerid ReqRespPr channel -> do
             r <- runPeer (tagTrace "Responder" activeTracer)
                          ReqResp.codecReqResp
-                         peerid
                          channel
                          (ReqResp.reqRespServerPeer (ReqResp.reqRespServerMapAccumL (\a -> pure . f a) 0))
             atomically $ putTMVar sv r
@@ -538,10 +537,9 @@ prop_send_recv f xs first = ioProperty $ do
         -- Client Node; only req-resp client
         initiatorApp :: OuroborosApplication InitiatorApp ConnectionId TestProtocols2 IO BL.ByteString () Void
         initiatorApp = OuroborosInitiatorApplication $
-          \peerid ReqRespPr channel -> do
+          \_peerid ReqRespPr channel -> do
             r <- runPeer (tagTrace "Initiator" activeTracer)
                          ReqResp.codecReqResp
-                         peerid
                          channel
                          (ReqResp.reqRespClientPeer (ReqResp.reqRespClientMap xs))
             atomically $ putTMVar cv r
@@ -656,10 +654,9 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ do
     appX :: ReqRspCfg -> OuroborosApplication InitiatorAndResponderApp ConnectionId TestProtocols2 IO BL.ByteString () ()
     appX ReqRspCfg {rrcTag, rrcServerVar, rrcClientVar, rrcSiblingVar} = OuroborosInitiatorAndResponderApplication
             -- Initiator
-            (\peerid ReqRespPr channel -> do
+            (\_peerid ReqRespPr channel -> do
              r <- runPeer (tagTrace (rrcTag ++ " Initiator") activeTracer)
                          ReqResp.codecReqResp
-                         peerid
                          channel
                          (ReqResp.reqRespClientPeer (ReqResp.reqRespClientMap xs))
              atomically $ putTMVar rrcClientVar r
@@ -667,10 +664,9 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ do
              waitSiblingSub rrcSiblingVar
             )
             -- Responder
-            (\peerid ReqRespPr channel -> do
+            (\_peerid ReqRespPr channel -> do
              r <- runPeer (tagTrace (rrcTag ++ " Responder") activeTracer)
                          ReqResp.codecReqResp
-                         peerid
                          channel
                          (ReqResp.reqRespServerPeer (ReqResp.reqRespServerMapAccumL
                            (\a -> pure . f a) 0))

--- a/typed-protocols/src/Network/TypedProtocol/PingPong/Tests.hs
+++ b/typed-protocols/src/Network/TypedProtocol/PingPong/Tests.hs
@@ -270,11 +270,13 @@ prop_connect_pipelined5 choices (Positive omax) (NonNegative n) =
 -- | Run a non-pipelined client and server over a channel using a codec.
 --
 prop_channel :: (MonadSTM m, MonadAsync m, MonadCatch m)
-             => NonNegative Int -> Tracer m (TraceSendRecv PingPong String CodecFailure) -> m Bool
+             => NonNegative Int
+             -> Tracer m (PeerRole, TraceSendRecv PingPong)
+             -> m Bool
 prop_channel (NonNegative n) tr = do
     ((), n') <- runConnectedPeers createConnectedChannels
                                   tr
-                                  codecPingPong "client" "server" client server
+                                  codecPingPong client server
     return (n' == n)
   where
     client = pingPongClientPeer (pingPongClientCount n)

--- a/typed-protocols/src/Network/TypedProtocol/ReqResp/Tests.hs
+++ b/typed-protocols/src/Network/TypedProtocol/ReqResp/Tests.hs
@@ -164,7 +164,7 @@ prop_channel :: (MonadSTM m, MonadAsync m, MonadCatch m)
 prop_channel f xs = do
     (c, s) <- runConnectedPeers createConnectedChannels
                                 nullTracer
-                                codecReqResp "client" "server" client server
+                                codecReqResp client server
     return ((s, c) == mapAccumL f 0 xs)
   where
     client = reqRespClientPeer (reqRespClientMap xs)
@@ -200,9 +200,9 @@ prop_runPeerWithByteLimit limit reqPayloads = do
       (c1, c2) <- createConnectedChannels
 
       res <- try $
-        runPeerWithByteLimit limit (fromIntegral . length) nullTracer codecReqResp "receiver" c1 recvPeer
+        runPeerWithByteLimit limit (fromIntegral . length) nullTracer codecReqResp c1 recvPeer
           `concurrently`
-        void (runPeer nullTracer codecReqResp "sender" c2 sendPeer)
+        void (runPeer nullTracer codecReqResp c2 sendPeer)
 
       case res :: Either (DecoderFailureOrTooMuchInput CodecFailure) ([String], ()) of
         Right _           -> pure $ not shouldFail


### PR DESCRIPTION
The TraceSendRecv type used in the runPeer tracer was doing too much.

It was being used for logging exceptions, but the mechanism for reporting exceptions is that they are thrown, and they should be logged where they are handled.

It was also being used for reporting the peerid. This is a misunderstanding of the contravariant Tracer abstraction. The point with the contravariance is that context can be passed in, in the Tracer. So
there is no need to pass in extra context at the site where the events are traced. Only things that are special to the site of the event need to be included, as everything else can be passed into the tracer itself.

In particular, the peer that we are talking to is not special to runPeer, since it is only talking to one peer. So this is just context info. The right place to insert the contramap to annotate the trace with
the peer (or WithMuxBearer as the code calls it) is where there is a transition from there being multiple peers to a single peer, e.g. in server code after accepting a connection, or in connectTo on the outbound side.

Update users of runPeer, removing places where the peerid is passed in only because runPeer demanded it. In some places, add TraceLabelPeer or WithMuxBearer to existing tracers, so that they do include the peer id.