### PR TITLE
Add blockSize to ABlockOrBoundaryHdr

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Integrity.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Integrity.hs
@@ -61,9 +61,9 @@ verifyHeaderIntegrity cfg hdr =
     -- @CC.headerProtocolMagicId@ is the only field of a regular header that
     -- is not signed, so check it manually.
     case byronHeaderRaw hdr of
-        ABOBBlockHdr h    -> CC.headerProtocolMagicId h == protocolMagicId
+        ABOBBlockHdr    _ h -> CC.headerProtocolMagicId h == protocolMagicId
         -- EBB, we can't check it
-        ABOBBoundaryHdr _ -> True
+        ABOBBoundaryHdr _ _ -> True
   where
     protocolMagicId = CC.Genesis.configProtocolMagicId (getGenesisConfig cfg)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
@@ -40,8 +40,8 @@ instance HeaderSupportsPBft ByronConfig PBftCardanoCrypto (Header ByronBlock) wh
 
   headerPBftFields cfg ByronHeader{..} =
       case byronHeaderRaw of
-        ABOBBoundaryHdr _   -> Nothing
-        ABOBBlockHdr    hdr -> Just (
+        ABOBBoundaryHdr _ _   -> Nothing
+        ABOBBlockHdr    _ hdr -> Just (
             PBftFields {
               pbftIssuer    = VerKeyCardanoDSIGN
                             . Delegation.delegateVK

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
@@ -96,8 +96,9 @@ class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
   -- For example, a CBOR tag may have to be added in front.
   nodeAddHeaderEnvelope   :: Proxy blk
                           -> IsEBB
+                          -> Word32  -- ^ Block size
                           -> Lazy.ByteString -> Lazy.ByteString
-  nodeAddHeaderEnvelope _ _ = id  -- Default to no envelope
+  nodeAddHeaderEnvelope _ _ _ = id  -- Default to no envelope
 
 
   -- | This function is called when starting up the node, right after the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -35,13 +35,13 @@ import           Ouroboros.Storage.Common (EpochNo (..), EpochSize (..))
 instance RunNode ByronBlock where
   nodeForgeBlock            = forgeByronBlock
   nodeBlockMatchesHeader    = verifyBlockMatchesHeader
-  nodeBlockFetchSize        = const 2000 -- TODO #593
+  nodeBlockFetchSize        = byronBlockSizeFromHeader
   nodeIsEBB                 = \hdr -> case byronHeaderRaw hdr of
-    Aux.ABOBBlockHdr _       -> Nothing
-    Aux.ABOBBoundaryHdr bhdr -> Just
-                              . EpochNo
-                              . Cardano.Block.boundaryEpoch
-                              $ bhdr
+    Aux.ABOBBlockHdr    _ _    -> Nothing
+    Aux.ABOBBoundaryHdr _ bhdr -> Just
+                               . EpochNo
+                               . Cardano.Block.boundaryEpoch
+                               $ bhdr
 
   -- The epoch size is fixed and can be derived from @k@ by the ledger
   -- ('kEpochSlots').

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -15,6 +15,7 @@ import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Time.Clock (DiffTime, secondsToDiffTime)
+import           Data.Word (Word32)
 
 import           Control.Tracer (Tracer, contramap)
 
@@ -93,10 +94,12 @@ data ChainDbArgs m blk = forall h1 h2 h3. ChainDbArgs {
     , cdbCheckIntegrity   :: blk -> Bool
     , cdbGenesis          :: m (ExtLedgerState blk)
     , cdbBlockchainTime   :: BlockchainTime m
-    , cdbAddHdrEnv        :: IsEBB -> Lazy.ByteString -> Lazy.ByteString
+    , cdbAddHdrEnv        :: IsEBB -> Word32 -> Lazy.ByteString -> Lazy.ByteString
       -- ^ The header envelope will only be added after extracting the binary
       -- header from the binary block. Note that we never have to remove an
       -- envelope.
+      --
+      -- The 'Word32' is the size of the block.
     , cdbImmDbCacheConfig :: ImmDB.CacheConfig
 
       -- Misc

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -65,6 +65,7 @@ import           Control.Tracer (Tracer, nullTracer)
 import           Data.Bifunctor
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Functor (($>), (<&>))
+import           Data.Word (Word32)
 import           GHC.Stack
 import           System.FilePath ((</>))
 
@@ -111,7 +112,7 @@ data ImmDB m blk = ImmDB {
     , encBlock  :: !(blk -> BinaryInfo Encoding)
     , epochInfo :: !(EpochInfo m)
     , isEBB     :: !(Header blk -> Maybe EpochNo)
-    , addHdrEnv :: !(IsEBB -> Lazy.ByteString -> Lazy.ByteString)
+    , addHdrEnv :: !(IsEBB -> Word32 -> Lazy.ByteString -> Lazy.ByteString)
     , err       :: !(ErrorHandling ImmDB.ImmutableDBError m)
     }
 
@@ -153,7 +154,7 @@ data ImmDbArgs m blk = forall h. ImmDbArgs {
     , immValidation     :: ImmDB.ValidationPolicy
     , immIsEBB          :: Header blk -> Maybe EpochNo
     , immCheckIntegrity :: blk -> Bool
-    , immAddHdrEnv      :: IsEBB -> Lazy.ByteString -> Lazy.ByteString
+    , immAddHdrEnv      :: IsEBB -> Word32 -> Lazy.ByteString -> Lazy.ByteString
     , immHasFS          :: HasFS m h
     , immTracer         :: Tracer m (TraceEvent blk)
     , immCacheConfig    :: Index.CacheConfig
@@ -252,7 +253,7 @@ mkImmDB :: ImmutableDB (HeaderHash blk) m
         -> (blk -> BinaryInfo Encoding)
         -> EpochInfo m
         -> (Header blk -> Maybe EpochNo)
-        -> (IsEBB -> Lazy.ByteString -> Lazy.ByteString)
+        -> (IsEBB -> Word32 -> Lazy.ByteString -> Lazy.ByteString)
         -> ErrorHandling ImmDB.ImmutableDBError m
         -> ImmDB m blk
 mkImmDB immDB decHeader decBlock encBlock epochInfo isEBB addHdrEnv err = ImmDB {..}

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/VolDB.hs
@@ -60,6 +60,7 @@ import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Typeable (Typeable)
+import           Data.Word (Word32)
 import           GHC.Stack (HasCallStack)
 import           System.FilePath ((</>))
 
@@ -105,7 +106,7 @@ data VolDB m blk = VolDB {
       -- generics to derive the NoUnexpectedThunks instance.
     , encBlock  :: blk -> BinaryInfo Encoding
     , isEBB     :: blk -> IsEBB
-    , addHdrEnv :: !(IsEBB -> Lazy.ByteString -> Lazy.ByteString)
+    , addHdrEnv :: !(IsEBB -> Word32 -> Lazy.ByteString -> Lazy.ByteString)
     , err       :: ErrorHandling VolatileDBError m
     , errSTM    :: ThrowCantCatch VolatileDBError (STM m)
     }
@@ -137,7 +138,7 @@ data VolDbArgs m blk = forall h. VolDbArgs {
     , volDecodeBlock   :: forall s. Decoder s (Lazy.ByteString -> blk)
     , volEncodeBlock   :: blk -> BinaryInfo Encoding
     , volIsEBB         :: blk -> IsEBB
-    , volAddHdrEnv     :: IsEBB -> Lazy.ByteString -> Lazy.ByteString
+    , volAddHdrEnv     :: IsEBB -> Word32 -> Lazy.ByteString -> Lazy.ByteString
     }
 
 -- | Default arguments when using the 'IO' monad
@@ -190,7 +191,7 @@ mkVolDB :: VolatileDB (HeaderHash blk) m
         -> (forall s. Decoder s (Lazy.ByteString -> blk))
         -> (blk -> BinaryInfo Encoding)
         -> (blk -> IsEBB)
-        -> (IsEBB -> Lazy.ByteString -> Lazy.ByteString)
+        -> (IsEBB -> Word32 -> Lazy.ByteString -> Lazy.ByteString)
         -> ErrorHandling VolatileDBError m
         -> ThrowCantCatch VolatileDBError (STM m)
         -> VolDB m blk

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Ledger/Byron.hs
@@ -447,19 +447,22 @@ instance Arbitrary (Header ByronBlock) where
       ]
     where
       genHeader :: Gen (Header ByronBlock)
-      genHeader =
-        mkByronHeader epochSlots . ABOBBlockHdr .
-        reAnnotateUsing
-          (CC.Block.toCBORHeader epochSlots)
-          (CC.Block.fromCBORAHeader epochSlots) <$>
-        hedgehog (CC.genHeader protocolMagicId epochSlots)
+      genHeader = do
+        blockSize <- arbitrary
+        mkByronHeader epochSlots . ABOBBlockHdr blockSize .
+          reAnnotateUsing
+            (CC.Block.toCBORHeader epochSlots)
+            (CC.Block.fromCBORAHeader epochSlots) <$>
+          hedgehog (CC.genHeader protocolMagicId epochSlots)
+
       genBoundaryHeader :: Gen (Header ByronBlock)
-      genBoundaryHeader =
-        mkByronHeader epochSlots . ABOBBoundaryHdr .
-        reAnnotateUsing
-          (CC.Block.toCBORABoundaryHeader protocolMagicId)
-          CC.Block.fromCBORABoundaryHeader <$>
-        hedgehog CC.genBoundaryHeader
+      genBoundaryHeader = do
+        blockSize <- arbitrary
+        mkByronHeader epochSlots . ABOBBoundaryHdr blockSize .
+          reAnnotateUsing
+            (CC.Block.toCBORABoundaryHeader protocolMagicId)
+            CC.Block.fromCBORABoundaryHeader <$>
+          hedgehog CC.genBoundaryHeader
 
 instance Arbitrary ByronHash where
   arbitrary = ByronHash <$> hedgehog CC.genHeaderHash

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -273,7 +273,7 @@ mkArgs cfg initLedger tracer registry hashInfo
     , cdbCheckIntegrity   = const True
     , cdbBlockchainTime   = fixedBlockchainTime maxBound
     , cdbGenesis          = return initLedger
-    , cdbAddHdrEnv        = const id
+    , cdbAddHdrEnv        = \_ _ -> id
     , cdbImmDbCacheConfig = Index.CacheConfig 2 60
 
     -- Misc

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -18,6 +18,7 @@ import           Control.Tracer
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.List (intercalate)
 import qualified Data.Map.Strict as Map
+import           Data.Word (Word32)
 
 import           Control.Monad.IOSim (runSimOrThrow)
 
@@ -411,8 +412,8 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
     epochSize :: EpochSize
     epochSize = 10
 
-    addHdrEnv :: IsEBB -> Lazy.ByteString -> Lazy.ByteString
-    addHdrEnv = const id
+    addHdrEnv :: IsEBB -> Word32 -> Lazy.ByteString -> Lazy.ByteString
+    addHdrEnv _ _ = id
 
     -- | Open a mock ImmutableDB and add the given chain of blocks
     openImmDB :: Chain TestBlock -> m (ImmDB m TestBlock)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1463,7 +1463,7 @@ mkArgs cfg initLedger tracer registry varCurSlot
     , cdbCheckIntegrity   = testBlockIsValid
     , cdbGenesis          = return initLedger
     , cdbBlockchainTime   = settableBlockchainTime varCurSlot
-    , cdbAddHdrEnv        = const id
+    , cdbAddHdrEnv        = \_ _ -> id
     , cdbImmDbCacheConfig = Index.CacheConfig 2 60
 
     -- Misc

--- a/ouroboros-network/src/Ouroboros/Network/DeltaQ.hs
+++ b/ouroboros-network/src/Ouroboros/Network/DeltaQ.hs
@@ -36,6 +36,7 @@ module Ouroboros.Network.DeltaQ (
 
 import           Data.Semigroup ((<>))
 import           Data.Time.Clock (DiffTime)
+import           Data.Word (Word32)
 
 
 --
@@ -194,7 +195,7 @@ ballisticGSV g s v = GSV g (\sz -> s * fromIntegral sz) v
 -- Basic calculations based on GSV
 --
 
-type SizeInBytes = Word
+type SizeInBytes = Word32
 
 -- | The 𝚫Q for when the leading edge of a transmission unit arrives at the
 -- destination. This is just the convolution of the /G/ and /V/ components.


### PR DESCRIPTION
Closes #593.

We can extend the `ABlockOrBoundaryHdr` type with the block size, as this type does not have to binary-compatible (when sent across the network) with old nodes, only with new nodes.

When decoding a header extracted from the bytestring of an on-disk block, we use the header envelope to prepend the block size.