### PR TITLE
Also strengthen the PBFT check in Test.ThreadNet.Ref.RealPBFT

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -333,7 +333,6 @@ pbftWindowSize (SecurityParam k) = CS.WindowSize k
 -- | Does the number of blocks signed by this key exceed the threshold?
 --
 -- Returns @Just@ the number of blocks signed if exceeded.
--- Returns 'Nothing' if not 'shouldCheckThreshold'
 exceedsThreshold :: PBftCrypto c
                  => PBftWindowParams
                  -> PBftChainState c -> PBftVerKeyHash c -> Maybe Word64

--- a/ouroboros-consensus/test-consensus/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/ThreadNet/RealPBFT.hs
@@ -535,7 +535,7 @@ genRealPBFTNodeJoinPlan params numSlots@(NumSlots t)
             Just hi -> genSlot lo hi
             Nothing -> error $
                 "Cannot find viable RealPBFT NodeJoinPlan: " ++
-                show (nodeJoinPlan, st)
+                show (params, numSlots, nodeJoinPlan, st)
 
         let m'  = Map.insert nid s' m
 

--- a/ouroboros-consensus/test-consensus/Test/ThreadNet/Ref/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/ThreadNet/Ref/RealPBFT.hs
@@ -142,12 +142,8 @@ extendOutcome params State{forgers, nomCount, nextSlot, outs} out = State
 --
 tooMany :: PBftParams -> State -> Bool
 tooMany params st@State{forgers} =
-    not $
-    Seq.length forgers < k || count i forgers <= pbftLimit params
+    count i forgers > pbftLimit params
   where
-    k :: forall a. Num a => a
-    k = oneK params
-
     i = nextLeader params st
 
 -- | How many blocks in the latest @k@-blocks that a single core node is


### PR DESCRIPTION
Fixes #1484.

This PR makes the same change to the abstract `RealPBFT` implementation used to generate sufficient join plans as were made to the actual PBFT implementation in PR #1480.

I'm not sure of the exact details, but my suspicion is that we were never generating a test case in which `n > k`. We had a `SecurityParam` consensus yielding either 5 or 10 in `RealPBFT` cases, and we had `arbitrary :: NumCoreNodes` of 2-5. But on Edsko's dual ledger branch, we had e.g. `k = 4` and `n = 5`. In that regime and with the "weaker" PBFT check, the viability of a partial node join plan's next slot is indeed non-monotonic.

But with PR 1480 and this PR, the viability is again monotonic, even in the `k < n` regime.