### PR TITLE
Minor decoupling in the consensus abstractions

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Ledger.hs
@@ -70,9 +70,6 @@ instance UpdateLedger ByronBlock where
       unByronLedgerConfig :: Gen.Config
     }
 
-  ledgerConfigView PBftNodeConfig{..} = ByronLedgerConfig $
-      pbftGenesisConfig pbftExtConfig
-
   applyChainTick cfg slotNo ByronLedgerState{..} =
       TickedLedgerState ByronLedgerState {
           byronDelegationHistory = byronDelegationHistory
@@ -105,6 +102,9 @@ instance ConfigContainsGenesis (LedgerConfig ByronBlock) where
   getGenesisConfig = unByronLedgerConfig
 
 instance ProtocolLedgerView ByronBlock where
+  ledgerConfigView PBftNodeConfig{..} = ByronLedgerConfig $
+      pbftGenesisConfig pbftExtConfig
+
   protocolLedgerView _cfg =
         toPBftLedgerView
       . Aux.getDelegationMap

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Mempool.hs
@@ -17,7 +17,7 @@
 module Ouroboros.Consensus.Ledger.Byron.Mempool (
     -- * Mempool integration
     GenTx(..)
-  , GenTxId(..)
+  , TxId(..)
     -- * Serialisation
   , encodeByronGenTx
   , decodeByronGenTx
@@ -81,18 +81,6 @@ instance ApplyTx ByronBlock where
     deriving (Eq, Generic)
     deriving NoUnexpectedThunks via UseIsNormalForm (GenTx ByronBlock)
 
-  data GenTxId ByronBlock
-    = ByronTxId             !Utxo.TxId
-    | ByronDlgId            !Delegation.CertificateId
-    | ByronUpdateProposalId !Update.UpId
-    | ByronUpdateVoteId     !Update.VoteId
-    deriving (Eq, Ord)
-
-  txId (ByronTx             i _) = ByronTxId             i
-  txId (ByronDlg            i _) = ByronDlgId            i
-  txId (ByronUpdateProposal i _) = ByronUpdateProposalId i
-  txId (ByronUpdateVote     i _) = ByronUpdateVoteId     i
-
   txSize tx =
         1 {- encodeListLen -}
       + 1 {- tag -}
@@ -122,6 +110,19 @@ instance ApplyTx ByronBlock where
         applyByronGenTx validationMode cfg tx st
     where
       validationMode = CC.ValidationMode CC.NoBlockValidation Utxo.NoTxValidation
+
+instance HasTxId (GenTx ByronBlock) where
+  data TxId (GenTx ByronBlock)
+    = ByronTxId             !Utxo.TxId
+    | ByronDlgId            !Delegation.CertificateId
+    | ByronUpdateProposalId !Update.UpId
+    | ByronUpdateVoteId     !Update.VoteId
+    deriving (Eq, Ord)
+
+  txId (ByronTx             i _) = ByronTxId             i
+  txId (ByronDlg            i _) = ByronDlgId            i
+  txId (ByronUpdateProposal i _) = ByronUpdateProposalId i
+  txId (ByronUpdateVote     i _) = ByronUpdateVoteId     i
 
 {-------------------------------------------------------------------------------
   Conversion to and from 'AMempoolPayload'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -242,7 +242,6 @@ instance (SimpleCrypto c, Typeable ext, SupportedBlock (SimpleBlock c ext))
       mustSucceed (Left  err) = error ("reapplyLedgerBlock: unexpected error: " <> show err)
       mustSucceed (Right st)  = st
   ledgerTipPoint (SimpleLedgerState st) = mockTip st
-  ledgerConfigView _ = SimpleLedgerConfig
 
 updateSimpleLedgerState :: (Monad m, SimpleCrypto c, Typeable ext)
                         => SimpleBlock c ext

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/BFT.hs
@@ -111,6 +111,7 @@ instance ( SimpleCrypto c
          , BftCrypto c'
          , Signable (BftDSIGN c') (SignedSimpleBft c c')
          ) => ProtocolLedgerView (SimpleBftBlock c c') where
+  ledgerConfigView _ = SimpleLedgerConfig
   protocolLedgerView _ _ = ()
   anachronisticProtocolLedgerView _ _ _ = Right ()
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
@@ -129,6 +129,8 @@ instance ( SimpleCrypto c
 instance ( SimpleCrypto c
          , Signable MockDSIGN (SignedSimplePBft c PBftMockCrypto)
          ) => ProtocolLedgerView (SimplePBftBlock c PBftMockCrypto) where
+  ledgerConfigView _ =
+      SimpleLedgerConfig
   protocolLedgerView PBftNodeConfig{..} _ls =
       pbftExtConfig
   anachronisticProtocolLedgerView PBftNodeConfig{..} _ _ =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/Praos.hs
@@ -149,6 +149,9 @@ instance ( SimpleCrypto c
          , PraosCrypto c'
          , Signable (PraosKES c') (SignedSimplePraos c c')
          ) => ProtocolLedgerView (SimplePraosBlock c c') where
+  ledgerConfigView _ =
+      SimpleLedgerConfig
+
   protocolLedgerView PraosNodeConfig{..} _ =
       equalStakeDist praosExtConfig
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PraosRule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PraosRule.hs
@@ -90,6 +90,7 @@ instance SimpleCrypto c
 
 instance SimpleCrypto c
       => ProtocolLedgerView (SimplePraosRuleBlock c) where
+  ledgerConfigView _ = SimpleLedgerConfig
   protocolLedgerView _ _ = ()
   anachronisticProtocolLedgerView _ _ _ = Right ()
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -10,6 +10,8 @@ module Ouroboros.Consensus.Mempool.API (
   , BlockSlot(..)
   , MempoolSnapshot(..)
   , ApplyTx(..)
+  , HasTxId(..)
+  , GenTxId
   , MempoolSize (..)
   , TraceEventMempool(..)
     -- * Re-exports
@@ -27,7 +29,6 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Util.IOLike
 
 class ( UpdateLedger blk
-      , Ord (GenTxId blk)
       , NoUnexpectedThunks (GenTx blk)
       ) => ApplyTx blk where
   -- | Generalized transaction
@@ -36,14 +37,6 @@ class ( UpdateLedger blk
   -- transactions"; this could be "proper" transactions (transferring funds) but
   -- also other kinds of things such as update proposals, delegations, etc.
   data family GenTx blk :: *
-
-  -- | A generalized transaction, 'GenTx', identifier.
-  data family GenTxId blk :: *
-
-  -- | Return the 'GenTxId' of a 'GenTx'.
-  --
-  -- Should be cheap as this will be called often.
-  txId :: GenTx blk -> GenTxId blk
 
   -- | Return the post-serialization size in bytes of a 'GenTx'.
   txSize :: GenTx blk -> TxSizeInBytes
@@ -83,6 +76,22 @@ class ( UpdateLedger blk
                      -> GenTx blk
                      -> TickedLedgerState blk
                      -> TickedLedgerState blk
+
+-- | Transactions with an identifier
+--
+-- The mempool will use these to locate transactions, so two different
+-- transactions should have different identifiers.
+class Ord (TxId tx) => HasTxId tx where
+  -- | A generalized transaction, 'GenTx', identifier.
+  data family TxId tx :: *
+
+  -- | Return the 'GenTxId' of a 'GenTx'.
+  --
+  -- Should be cheap as this will be called often.
+  txId :: tx -> TxId tx
+
+-- | Shorthand: ID of a generalized transaction
+type GenTxId blk = TxId (GenTx blk)
 
 -- | Mempool
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -52,7 +52,7 @@ import           Ouroboros.Consensus.Util.STM (onEachChange)
   Top-level API
 -------------------------------------------------------------------------------}
 
-openMempool :: (IOLike m, ApplyTx blk)
+openMempool :: (IOLike m, ApplyTx blk, HasTxId (GenTx blk))
             => ResourceRegistry m
             -> LedgerInterface m blk
             -> LedgerConfig blk
@@ -69,7 +69,7 @@ openMempool registry ledger cfg capacity tracer = do
 --
 -- Intended for testing purposes.
 openMempoolWithoutSyncThread
-  :: (IOLike m, ApplyTx blk)
+  :: (IOLike m, ApplyTx blk, HasTxId (GenTx blk))
   => LedgerInterface m blk
   -> LedgerConfig blk
   -> MempoolCapacityBytes
@@ -78,7 +78,7 @@ openMempoolWithoutSyncThread
 openMempoolWithoutSyncThread ledger cfg capacity tracer =
     mkMempool <$> initMempoolEnv ledger cfg capacity tracer
 
-mkMempool :: (IOLike m, ApplyTx blk)
+mkMempool :: (IOLike m, ApplyTx blk, HasTxId (GenTx blk))
           => MempoolEnv m blk -> Mempool m blk TicketNo
 mkMempool env = Mempool
     { addTxs         = implAddTxs         env []
@@ -382,7 +382,7 @@ implAddTxs mpEnv accum txs = assert (all txInvariant txs) $ do
                                   -- validated).
 
 implRemoveTxs
-  :: (IOLike m, ApplyTx blk)
+  :: (IOLike m, ApplyTx blk, HasTxId (GenTx blk))
   => MempoolEnv m blk
   -> [GenTxId blk]
   -> m ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
@@ -35,7 +35,10 @@ import           Ouroboros.Storage.ChainDB (ChainDB)
 import           Ouroboros.Storage.Common (EpochNo, EpochSize)
 import           Ouroboros.Storage.ImmutableDB (BinaryInfo (..), HashInfo)
 
-class (ProtocolLedgerView blk, ApplyTx blk) => RunNode blk where
+class ( ProtocolLedgerView blk
+      , ApplyTx blk
+      , HasTxId (GenTx blk)
+      ) => RunNode blk where
 
   nodeForgeBlock          :: (HasNodeState (BlockProtocol blk) m, MonadRandom m)
                           => NodeConfig (BlockProtocol blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -218,6 +218,7 @@ initInternalState
        , Ord peer
        , NoUnexpectedThunks peer
        , ApplyTx blk
+       , HasTxId (GenTx blk)
        )
     => NodeArgs m peer blk
     -> m (InternalState m peer blk)
@@ -520,7 +521,7 @@ newtype PRNG = PRNG ChaChaDRG
 -------------------------------------------------------------------------------}
 
 getMempoolReader
-  :: forall m blk. (IOLike m, ApplyTx blk)
+  :: forall m blk. (IOLike m, ApplyTx blk, HasTxId (GenTx blk))
   => Mempool m blk TicketNo
   -> TxSubmissionMempoolReader (GenTxId blk) (GenTx blk) TicketNo m
 getMempoolReader mempool = Outbound.TxSubmissionMempoolReader
@@ -541,7 +542,7 @@ getMempoolReader mempool = Outbound.TxSubmissionMempoolReader
         }
 
 getMempoolWriter
-  :: (Monad m, ApplyTx blk)
+  :: (Monad m, HasTxId (GenTx blk))
   => Mempool m blk TicketNo
   -> TxSubmissionMempoolWriter (GenTxId blk) (GenTx blk) TicketNo m
 getMempoolWriter mempool = Inbound.TxSubmissionMempoolWriter

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -133,6 +133,7 @@ protocolHandlers
     :: forall m blk peer.
        ( IOLike m
        , ApplyTx blk
+       , HasTxId (GenTx blk)
        , ProtocolLedgerView blk
        )
     => NodeArgs   m peer blk  --TODO eliminate, merge relevant into NodeKernel

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ChainSel.hs
@@ -804,7 +804,7 @@ data ChainAndLedger blk = ChainAndLedger
     -- ^ Ledger corresponding to '_chain'
   }
 
-mkChainAndLedger :: (HasHeader blk , UpdateLedger blk)
+mkChainAndLedger :: (HasHeader blk, UpdateLedger blk)
                  => AnchoredFragment (Header blk) -> LgrDB.LedgerDB blk
                  -> ChainAndLedger blk
 mkChainAndLedger c l =

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Ledger/Byron.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Ledger/Byron.hs
@@ -35,7 +35,7 @@ import           Ouroboros.Consensus.Block (BlockProtocol, Header)
 import           Ouroboros.Consensus.Ledger.Byron
 import           Ouroboros.Consensus.Ledger.Byron.Auxiliary
 import qualified Ouroboros.Consensus.Ledger.Byron.DelegationHistory as DH
-import           Ouroboros.Consensus.Mempool.API (ApplyTxErr)
+import           Ouroboros.Consensus.Mempool.API (ApplyTxErr, GenTxId)
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Protocol
 import           Ouroboros.Consensus.Protocol.Abstract (ChainState,
@@ -472,7 +472,7 @@ instance Arbitrary (GenTx ByronBlock) where
     fromMempoolPayload . reAnnotateUsing toCBOR fromCBOR <$>
     hedgehog (CC.genMempoolPayload protocolMagicId)
 
-instance Arbitrary (GenTxId ByronBlock) where
+instance Arbitrary (TxId (GenTx ByronBlock)) where
   arbitrary = oneof
       [ ByronTxId             <$> hedgehog CC.genTxId
       , ByronDlgId            <$> hedgehog genCertificateId

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -670,7 +670,7 @@ withTestMempool setup@TestSetup { testLedgerState, testInitialTxs, testMempoolCa
     classify (not (null testInitialTxs)) "non-empty Mempool" $
     runSimOrThrow setUpAndRun
   where
-    cfg = ledgerConfigView singleNodeTestConfig
+    cfg = LedgerConfig
 
     setUpAndRun :: forall m. IOLike m => m Property
     setUpAndRun = do

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool/TestBlock.hs
@@ -18,7 +18,7 @@ module Test.Consensus.Mempool.TestBlock
     -- * Test infrastructure: mempool support
   , TestTxError (..)
   , GenTx (..)
-  , GenTxId (..)
+  , TxId (..)
     -- * Re-exported
   , TestTx (..)
   , TestTxId (..)
@@ -41,7 +41,7 @@ import qualified Ouroboros.Network.Block as Block
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
-import           Ouroboros.Consensus.Mempool (ApplyTx (..))
+import           Ouroboros.Consensus.Mempool (ApplyTx (..), HasTxId (..))
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util.Condense
@@ -139,14 +139,6 @@ instance ApplyTx TestBlock where
     deriving stock (Show, Eq, Ord, Generic)
     deriving newtype (Condense)
 
-  newtype GenTxId TestBlock = TestGenTxId
-    { unTestGenTxId :: TestTxId
-    }
-    deriving stock (Show, Eq, Ord)
-    deriving newtype (Condense)
-
-  txId (TestGenTx tx) = TestGenTxId (testTxId tx)
-
   txSize _ = 2000 -- TODO #745
 
   type ApplyTxErr TestBlock = TestTxError
@@ -160,6 +152,15 @@ instance ApplyTx TestBlock where
   reapplyTxSameState cfg tx ledger = mustBeRight $ applyTx cfg tx ledger
     where
       mustBeRight = either (error "cannot fail") id . runExcept
+
+instance HasTxId (GenTx TestBlock) where
+  newtype TxId (GenTx TestBlock) = TestGenTxId
+    { unTestGenTxId :: TestTxId
+    }
+    deriving stock (Show, Eq, Ord)
+    deriving newtype (Condense)
+
+  txId (TestGenTx tx) = TestGenTxId (testTxId tx)
 
 instance NoUnexpectedThunks (GenTx TestBlock) where
   showTypeOf _ = "GenTx TestBlock"

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool/TestBlock.hs
@@ -115,7 +115,6 @@ instance UpdateLedger TestBlock where
   data LedgerConfig TestBlock = LedgerConfig
   type LedgerError  TestBlock = ()
 
-  ledgerConfigView _ = LedgerConfig
   applyChainTick _ _ = TickedLedgerState
 
   applyLedgerBlock   = notNeeded

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -326,8 +326,6 @@ instance UpdateLedger TestBlock where
   data LedgerConfig TestBlock = LedgerConfig
   type LedgerError  TestBlock = TestBlockError
 
-  ledgerConfigView _ = LedgerConfig
-
   applyChainTick _ _ = TickedLedgerState
 
   applyLedgerBlock _ tb@TestBlock{..} TestLedger{..}
@@ -344,6 +342,7 @@ instance UpdateLedger TestBlock where
   ledgerTipPoint = lastAppliedPoint
 
 instance ProtocolLedgerView TestBlock where
+  ledgerConfigView _ = LedgerConfig
   protocolLedgerView _ _ = ()
   anachronisticProtocolLedgerView _ _ _ = Right ()
 

--- a/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
@@ -280,8 +280,6 @@ instance UpdateLedger TestBlock where
   data LedgerConfig TestBlock = LedgerConfig
   type LedgerError  TestBlock = TestBlockError
 
-  ledgerConfigView _ = LedgerConfig
-
   applyChainTick _ _ = TickedLedgerState
 
   applyLedgerBlock _ tb@TestBlock{..} TestLedger{..}
@@ -298,6 +296,7 @@ instance UpdateLedger TestBlock where
   ledgerTipPoint = lastAppliedPoint
 
 instance ProtocolLedgerView TestBlock where
+  ledgerConfigView _ = LedgerConfig
   protocolLedgerView _ _ = ()
   anachronisticProtocolLedgerView _ _ _ = Right ()
 


### PR DESCRIPTION
In order to run the Byron dual ledger, we need to decouple consensus from ledger concerns. This was mostly already done, but there were two things stopping the integration:

* `UpdateLedger` unnecessarily required `SupportedBlock`. It really shouldn't refer to `NodeConfig` at all (since that is a consensus concern)
* `ApplyTx` required transactions to have an identifier, but those two concepts are orthogonal. This is now `HasTxId`.