### PR TITLE
Properly shut down a node, its DBs, and its threads

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl.hs
@@ -8,6 +8,7 @@ module Ouroboros.Storage.ChainDB.Impl (
     ChainDbArgs(..)
   , defaultArgs
   , withDB
+  , openDB
     -- * Trace types
   , TraceEvent (..)
   , TraceAddBlockEvent (..)
@@ -73,6 +74,12 @@ withDB
   -> (ChainDB m blk -> m a)
   -> m a
 withDB args = bracket (fst <$> openDBInternal args True) closeDB
+
+openDB
+  :: forall m blk. (IOLike m, ProtocolLedgerView blk)
+  => ChainDbArgs m blk
+  -> m (ChainDB m blk)
+openDB args = fst <$> openDBInternal args True
 
 openDBInternal
   :: forall m blk. (IOLike m, ProtocolLedgerView blk)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl.hs
@@ -112,8 +112,7 @@ import           Control.Monad.Class.MonadThrow (bracket, bracketOnError,
 import           Ouroboros.Consensus.Block (IsEBB (..))
 import           Ouroboros.Consensus.Util (SomePair (..))
 import           Ouroboros.Consensus.Util.IOLike
-import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry,
-                     releaseAll)
+import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.EpochInfo
@@ -278,17 +277,18 @@ closeDBImpl
   :: forall m hash. (HasCallStack, IOLike m)
   => ImmutableDBEnv m hash
   -> m ()
-closeDBImpl ImmutableDBEnv {..} = releaseAll _dbRegistry `finally` do
+closeDBImpl ImmutableDBEnv {..} = do
     internalState <- takeMVar _dbInternalState
     case internalState of
       -- Already closed
       DbClosed -> do
         putMVar _dbInternalState internalState
         traceWith _dbTracer $ DBAlreadyClosed
-      DbOpen OpenState {..} -> do
+      DbOpen openState@OpenState {..} -> do
         -- Close the database before doing the file-system operations so that
         -- in case these fail, we don't leave the database open.
         putMVar _dbInternalState DbClosed
+        cleanUpOpenState _dbHasFS openState
         traceWith _dbTracer DBClosed
   where
     HasFS{..} = _dbHasFS
@@ -343,16 +343,16 @@ deleteAfterImpl dbEnv@ImmutableDBEnv { _dbTracer } newTip =
     when (newTipEpochSlot < currentTipEpochSlot) $ do
       !ost <- lift $ do
         traceWith _dbTracer $ DeletingAfter newTip
-        -- Release the open handles and terminate the running threads, as we
-        -- might have to remove files that are currently opened.
-        releaseAll _dbRegistry
+        -- Release the open handles, as we might have to remove files that are
+        -- currently opened.
+        cleanUpOpenState hasFS st
         newTipWithHash <- truncateTo hasFS st newTipEpochSlot
         let (newEpoch, allowExisting) = case newTipEpochSlot of
               TipGen                  -> (0, MustBeNew)
               Tip (EpochSlot epoch _) -> (epoch, AllowExisting)
         -- Reset the index, as it can contain stale information. Also restarts
         -- the background thread expiring unused past epochs.
-        Index.reset _index newEpoch
+        Index.restart _index newEpoch
         mkOpenState _dbRegistry hasFS _dbErr _index newEpoch newTipWithHash
           allowExisting
       put ost
@@ -440,7 +440,7 @@ getBlockComponentImpl dbEnv blockComponent slot =
       getEpochSlot _dbHasFS _dbErr _dbEpochInfo _index curEpochInfo
         blockComponent epochSlot
   where
-    ImmutableDBEnv { _dbEpochInfo, _dbErr, _dbHashInfo } = dbEnv
+    ImmutableDBEnv { _dbEpochInfo, _dbErr } = dbEnv
 
 getEBBComponentImpl
   :: forall m hash b. (HasCallStack, IOLike m)
@@ -462,7 +462,7 @@ getEBBComponentImpl dbEnv blockComponent epoch =
       getEpochSlot _dbHasFS _dbErr _dbEpochInfo _index curEpochInfo
         blockComponent (EpochSlot epoch 0)
   where
-    ImmutableDBEnv { _dbEpochInfo, _dbErr, _dbHashInfo } = dbEnv
+    ImmutableDBEnv { _dbEpochInfo, _dbErr } = dbEnv
 
 extractBlockComponent
   :: forall m h hash b. (HasCallStack, IOLike m)
@@ -604,7 +604,7 @@ getBlockOrEBBComponentImpl dbEnv blockComponent slot hash =
             extractBlockComponent _dbHasFS _dbErr _dbEpochInfo epoch curEpochInfo
               (entry, blockSize) blockComponent
   where
-    ImmutableDBEnv { _dbEpochInfo, _dbErr, _dbHashInfo } = dbEnv
+    ImmutableDBEnv { _dbEpochInfo, _dbErr } = dbEnv
 
 -- | Get the block component corresponding to the given 'EpochSlot'.
 --
@@ -661,10 +661,10 @@ appendBlockImpl dbEnv slot headerHash binaryInfo =
         throwUserError _dbErr $
           AppendToSlotInThePastError slot (forgetHash <$> _currentTip)
 
-      appendEpochSlot _dbRegistry _dbHasFS _dbErr _dbEpochInfo _index
-        epochSlot (Block slot) headerHash binaryInfo
+      appendEpochSlot _dbRegistry _dbHasFS _dbErr _dbEpochInfo _index epochSlot
+        (Block slot) headerHash binaryInfo
   where
-    ImmutableDBEnv { _dbEpochInfo, _dbErr, _dbHashInfo, _dbRegistry } = dbEnv
+    ImmutableDBEnv { _dbEpochInfo, _dbErr, _dbRegistry } = dbEnv
 
 appendEBBImpl
   :: forall m hash. (HasCallStack, IOLike m)
@@ -692,7 +692,7 @@ appendEBBImpl dbEnv epoch headerHash binaryInfo =
       appendEpochSlot _dbRegistry _dbHasFS _dbErr _dbEpochInfo _index
         (EpochSlot epoch 0) (EBB epoch) headerHash binaryInfo
   where
-    ImmutableDBEnv { _dbEpochInfo, _dbErr, _dbHashInfo, _dbRegistry } = dbEnv
+    ImmutableDBEnv { _dbEpochInfo, _dbErr, _dbRegistry } = dbEnv
 
 appendEpochSlot
   :: forall m h hash. (HasCallStack, IOLike m)
@@ -810,7 +810,7 @@ startNewEpoch registry hasFS@HasFS{..} err index epochInfo = do
 
     lift $
       Index.appendOffsets index _currentPrimaryHandle backfillOffsets
-      `finally` closeOpenStateHandles hasFS st
+      `finally` cleanUpOpenState hasFS st
 
     st' <- lift $ mkOpenState registry hasFS err index (succ _currentEpoch)
       _currentTip MustBeNew

--- a/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE BangPatterns              #-}
-{-# LANGUAGE ConstraintKinds           #-}
-{-# LANGUAGE DataKinds                 #-}
-{-# LANGUAGE DeriveAnyClass            #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE GADTs                     #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE NamedFieldPuns            #-}
-{-# LANGUAGE RankNTypes                #-}
-{-# LANGUAGE RecordWildCards           #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TypeApplications          #-}
-{-# LANGUAGE TypeFamilies              #-}
-{-# LANGUAGE UndecidableInstances      #-}
+{-# LANGUAGE BangPatterns         #-}
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Setup network
 module Test.ThreadNet.Network (
@@ -93,8 +93,8 @@ import           Ouroboros.Consensus.Util.STM
 import qualified Ouroboros.Storage.ChainDB as ChainDB
 import           Ouroboros.Storage.ChainDB.Impl (ChainDbArgs (..))
 import           Ouroboros.Storage.Common (EpochNo (..))
-import           Ouroboros.Storage.EpochInfo (EpochInfo, epochInfoFirst,
-                     epochInfoEpoch, newEpochInfo)
+import           Ouroboros.Storage.EpochInfo (EpochInfo, epochInfoEpoch,
+                     epochInfoFirst, newEpochInfo)
 import qualified Ouroboros.Storage.ImmutableDB as ImmDB
 import qualified Ouroboros.Storage.ImmutableDB.Impl.Index as Index
 import qualified Ouroboros.Storage.LedgerDB.DiskPolicy as LgrDB
@@ -426,9 +426,6 @@ runThreadNetwork ThreadNetworkArgs
             let chainDB = getChainDB kernel
             finalChain <- ChainDB.toChain chainDB
 
-            -- TODO workaround Issue 1470
-            releaseAll nodeRegistry
-
             pure (again, finalChain)
 
           atomically $ writeTVar vertexStatusVar $ VDown finalChain
@@ -596,8 +593,8 @@ runThreadNetwork ThreadNetworkArgs
                 s <- atomically $ getCurrentSlot btime
                 traceWith (nodeEventsAdds nodeInfoEvents) (s, p, bno))
             nodeInfoDBs
-          openChainDB _ = fmap fst $ ChainDB.openDBInternal chainDbArgs True
-      chainDB <- fmap snd $ allocate registry openChainDB ChainDB.closeDB
+      chainDB <- snd <$>
+        allocate registry (const (ChainDB.openDB chainDbArgs)) ChainDB.closeDB
 
       -- We have a thread (see below) that forges EBBs for tests that involve
       -- them. This variable holds the slot of the next EBB to be forged.


### PR DESCRIPTION
Fixes #1470.

* Don't use `releaseAll` or `unsafeReleaseAll` in the ImmutableDB, as that   will terminate all background threads, not just the resources using the   ImmutableDB. Instead, use `Index.close` to shut down the background thread.

* Start and close the ChainDB using the `ResourceRegistry` instead of using   `withChainDB`, this makes sure that resources are released in the right   order. Previously, the ChainDB was being closed before the background   threads using it were terminated, resulting in `ClosedDBError`s.