### PR TITLE
Remove peerid plumbing in the mux layer

### DIFF
--- a/network-mux/src/Network/Mux.hs
+++ b/network-mux/src/Network/Mux.hs
@@ -89,7 +89,7 @@ import           Network.Mux.Trace
 -- 'Wanton'
 --
 muxStart
-    :: forall m appType peerid a b.
+    :: forall m appType a b.
        ( MonadAsync m
        , MonadSTM m
        , MonadThrow m
@@ -98,11 +98,10 @@ muxStart
        , Eq (Async m ())
        )
     => Tracer m MuxTrace
-    -> peerid
-    -> MuxApplication appType peerid m a b
+    -> MuxApplication appType m a b
     -> MuxBearer m
     -> m ()
-muxStart tracer peerid (MuxApplication ptcls) bearer = do
+muxStart tracer (MuxApplication ptcls) bearer = do
     ctlPtclInfo <- mkMiniProtocolInfo (MiniProtocolNum 0)
                                       (MiniProtocolLimits 0xffff 0xffff)
     appPtclInfo <- sequence [ mkMiniProtocolInfo (miniProtocolNum ptcl)
@@ -195,27 +194,27 @@ muxStart tracer peerid (MuxApplication ptcls) bearer = do
       -> Int64
       -> StrictTVar m BL.ByteString
       -> StrictTVar m BL.ByteString
-      -> RunMiniProtocol appType peerid m a b
+      -> RunMiniProtocol appType m a b
       -> [(m (), String)]
     mpsJob cnt tq mc msgMax initQ respQ run =
         case run of
           InitiatorProtocolOnly initiator ->
             [ ( do chan <- mkChannel ModeInitiator
-                   _    <- initiator peerid chan
+                   _    <- initiator chan
                    mpsJobExit cnt
               , show mc ++ " Initiator" )]
           ResponderProtocolOnly responder ->
             [ ( do chan <- mkChannel ModeResponder
-                   _    <- responder peerid chan
+                   _    <- responder chan
                    mpsJobExit cnt
               , show mc ++ " Responder" )]
           InitiatorAndResponderProtocol initiator responder ->
             [ ( do chan <- mkChannel ModeInitiator
-                   _    <- initiator peerid chan
+                   _    <- initiator chan
                    mpsJobExit cnt
               , show mc ++ " Initiator" )
             , ( do chan <- mkChannel ModeResponder
-                   _    <- responder peerid chan
+                   _    <- responder chan
                    mpsJobExit cnt
               , show mc ++ " Responder" )
             ]

--- a/network-mux/src/Network/Mux/Bearer/Pipe.hs
+++ b/network-mux/src/Network/Mux/Bearer/Pipe.hs
@@ -78,13 +78,12 @@ pipeAsMuxBearer tracer pcRead pcWrite = do
 
 runMuxWithPipes
     :: Tracer IO (Mx.WithMuxBearer String Mx.MuxTrace)
-    -> peerid
-    -> Mx.MuxApplication appType peerid IO a b
+    -> Mx.MuxApplication appType IO a b
     -> Handle -- ^ read handle
     -> Handle -- ^ write handle
     -> IO ()
-runMuxWithPipes tracer peerid app pcRead pcWrite = do
+runMuxWithPipes tracer app pcRead pcWrite = do
     let muxTracer = Mx.WithMuxBearer "Pipe" `contramap` tracer
         bearer    = pipeAsMuxBearer muxTracer pcRead pcWrite
-    Mx.muxStart muxTracer peerid app bearer
+    Mx.muxStart muxTracer app bearer
 

--- a/network-mux/src/Network/Mux/Bearer/Queues.hs
+++ b/network-mux/src/Network/Mux/Bearer/Queues.hs
@@ -87,17 +87,16 @@ runMuxWithQueues
      , Eq  (Async m ())
      )
   => Tracer m (Mx.WithMuxBearer String Mx.MuxTrace)
-  -> peerid
-  -> Mx.MuxApplication appType peerid m a b
+  -> Mx.MuxApplication appType m a b
   -> TBQueue m BL.ByteString
   -> TBQueue m BL.ByteString
   -> Word16
   -> Maybe (TBQueue m (Mx.MiniProtocolNum, Mx.MiniProtocolMode, Time))
   -> m (Maybe SomeException)
-runMuxWithQueues tracer peerid app wq rq mtu trace = do
+runMuxWithQueues tracer app wq rq mtu trace = do
     let muxTracer = Mx.WithMuxBearer "Queue" `contramap` tracer
         bearer    = queuesAsMuxBearer muxTracer wq rq mtu trace
-    res_e <- try $ Mx.muxStart muxTracer peerid app bearer
+    res_e <- try $ Mx.muxStart muxTracer app bearer
     case res_e of
          Left  e -> return (Just e)
          Right _ -> return Nothing

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -116,36 +116,36 @@ type family HasResponder (appType :: AppType) :: Bool where
 --   serving downstream peers using server side of each protocol and getting
 --   updates from upstream peers using client side of each of the protocols.
 --
-newtype MuxApplication (appType :: AppType) peerid m a b =
-        MuxApplication [MuxMiniProtocol appType peerid m a b]
+newtype MuxApplication (appType :: AppType) m a b =
+        MuxApplication [MuxMiniProtocol appType m a b]
 
-data MuxMiniProtocol (appType :: AppType) peerid m a b =
+data MuxMiniProtocol (appType :: AppType) m a b =
      MuxMiniProtocol {
        miniProtocolNum    :: !MiniProtocolNum,
        miniProtocolLimits :: !MiniProtocolLimits,
-       miniProtocolRun    :: !(RunMiniProtocol appType peerid m a b)
+       miniProtocolRun    :: !(RunMiniProtocol appType m a b)
      }
 
-data RunMiniProtocol (appType :: AppType) peerid m a b where
+data RunMiniProtocol (appType :: AppType) m a b where
   InitiatorProtocolOnly
     -- Initiator application; most simple application will be @'runPeer'@ or
     -- @'runPipelinedPeer'@ supplied with a codec and a @'Peer'@ for each
     -- @ptcl@.  But it allows to handle resources if just application of
     -- @'runPeer'@ is not enough.  It will be run as @'ModeInitiator'@.
-    :: (peerid -> Channel m -> m a)
-    -> RunMiniProtocol InitiatorApp peerid m a Void
+    :: (Channel m -> m a)
+    -> RunMiniProtocol InitiatorApp m a Void
 
   ResponderProtocolOnly
     -- Responder application; similarly to the @'MuxInitiatorApplication'@ but it
     -- will be run using @'ModeResponder'@.
-    :: (peerid -> Channel m -> m a)
-    -> RunMiniProtocol ResponderApp peerid m Void a
+    :: (Channel m -> m a)
+    -> RunMiniProtocol ResponderApp m Void a
 
   InitiatorAndResponderProtocol
     -- Initiator and server applications.
-    :: (peerid -> Channel m -> m a)
-    -> (peerid -> Channel m -> m b)
-    -> RunMiniProtocol InitiatorAndResponderApp peerid m a b
+    :: (Channel m -> m a)
+    -> (Channel m -> m b)
+    -> RunMiniProtocol InitiatorAndResponderApp m a b
 
 --
 -- Mux internal types

--- a/ouroboros-network/src/Ouroboros/Network/Mux.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Mux.hs
@@ -68,8 +68,9 @@ class MiniProtocolLimits ptcl where
 toApplication :: (Enum ptcl, Bounded ptcl,
                   ProtocolEnum ptcl, MiniProtocolLimits ptcl)
               => OuroborosApplication appType peerid ptcl m LBS.ByteString a b
+              -> peerid
               -> MuxApplication appType peerid m a b
-toApplication (OuroborosInitiatorApplication f) =
+toApplication (OuroborosInitiatorApplication f) peerid =
     MuxApplication
       [ MuxMiniProtocol {
           miniProtocolNum    = fromProtocolEnum ptcl,
@@ -79,11 +80,11 @@ toApplication (OuroborosInitiatorApplication f) =
                                },
           miniProtocolRun    =
             InitiatorProtocolOnly
-              (\peerid channel -> f peerid ptcl (fromChannel channel))
+              (\_peerid channel -> f peerid ptcl (fromChannel channel))
         }
       | ptcl <- [minBound..maxBound] ]
 
-toApplication (OuroborosResponderApplication f) =
+toApplication (OuroborosResponderApplication f) peerid =
     MuxApplication
       [ MuxMiniProtocol {
           miniProtocolNum    = fromProtocolEnum ptcl,
@@ -93,11 +94,11 @@ toApplication (OuroborosResponderApplication f) =
                                },
           miniProtocolRun    =
             ResponderProtocolOnly
-              (\peerid channel -> f peerid ptcl (fromChannel channel))
+              (\_peerid channel -> f peerid ptcl (fromChannel channel))
         }
       | ptcl <- [minBound..maxBound] ]
 
-toApplication (OuroborosInitiatorAndResponderApplication f g) =
+toApplication (OuroborosInitiatorAndResponderApplication f g) peerid =
     MuxApplication
       [ MuxMiniProtocol {
           miniProtocolNum    = fromProtocolEnum ptcl,
@@ -107,8 +108,8 @@ toApplication (OuroborosInitiatorAndResponderApplication f g) =
                                },
           miniProtocolRun    =
             InitiatorAndResponderProtocol
-              (\peerid channel -> f peerid ptcl (fromChannel channel))
-              (\peerid channel -> g peerid ptcl (fromChannel channel))
+              (\_peerid channel -> f peerid ptcl (fromChannel channel))
+              (\_peerid channel -> g peerid ptcl (fromChannel channel))
         }
       | ptcl <- [minBound..maxBound] ]
 

--- a/ouroboros-network/src/Ouroboros/Network/Mux.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Mux.hs
@@ -69,7 +69,7 @@ toApplication :: (Enum ptcl, Bounded ptcl,
                   ProtocolEnum ptcl, MiniProtocolLimits ptcl)
               => OuroborosApplication appType peerid ptcl m LBS.ByteString a b
               -> peerid
-              -> MuxApplication appType peerid m a b
+              -> MuxApplication appType m a b
 toApplication (OuroborosInitiatorApplication f) peerid =
     MuxApplication
       [ MuxMiniProtocol {
@@ -80,7 +80,7 @@ toApplication (OuroborosInitiatorApplication f) peerid =
                                },
           miniProtocolRun    =
             InitiatorProtocolOnly
-              (\_peerid channel -> f peerid ptcl (fromChannel channel))
+              (\channel -> f peerid ptcl (fromChannel channel))
         }
       | ptcl <- [minBound..maxBound] ]
 
@@ -94,7 +94,7 @@ toApplication (OuroborosResponderApplication f) peerid =
                                },
           miniProtocolRun    =
             ResponderProtocolOnly
-              (\_peerid channel -> f peerid ptcl (fromChannel channel))
+              (\channel -> f peerid ptcl (fromChannel channel))
         }
       | ptcl <- [minBound..maxBound] ]
 
@@ -108,8 +108,8 @@ toApplication (OuroborosInitiatorAndResponderApplication f g) peerid =
                                },
           miniProtocolRun    =
             InitiatorAndResponderProtocol
-              (\_peerid channel -> f peerid ptcl (fromChannel channel))
-              (\_peerid channel -> g peerid ptcl (fromChannel channel))
+              (\channel -> f peerid ptcl (fromChannel channel))
+              (\channel -> g peerid ptcl (fromChannel channel))
         }
       | ptcl <- [minBound..maxBound] ]
 

--- a/ouroboros-network/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Socket.hs
@@ -239,7 +239,7 @@ connectToNode' versionDataCodec NetworkConnectTracers {nctMuxTracer, nctHandshak
              throwIO err
          Right app -> do
              traceWith muxTracer $ Mx.MuxTraceHandshakeClientEnd (diffTime ts_end ts_start)
-             Mx.muxStart muxTracer connectionId (toApplication app connectionId) bearer
+             Mx.muxStart muxTracer (toApplication app connectionId) bearer
 
 
 -- |
@@ -315,7 +315,7 @@ beginConnection muxTracer handshakeTracer versionDataCodec acceptVersion fn t ad
             throwIO err
           Right app -> do
             traceWith muxTracer' $ Mx.MuxTraceHandshakeServerEnd
-            Mx.muxStart muxTracer' peerid (toApplication app peerid) bearer
+            Mx.muxStart muxTracer' (toApplication app peerid) bearer
       RejectConnection st' _peerid -> pure $ Server.Reject st'
 
 

--- a/ouroboros-network/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Socket.hs
@@ -239,7 +239,7 @@ connectToNode' versionDataCodec NetworkConnectTracers {nctMuxTracer, nctHandshak
              throwIO err
          Right app -> do
              traceWith muxTracer $ Mx.MuxTraceHandshakeClientEnd (diffTime ts_end ts_start)
-             Mx.muxStart muxTracer connectionId (toApplication app) bearer
+             Mx.muxStart muxTracer connectionId (toApplication app connectionId) bearer
 
 
 -- |
@@ -315,7 +315,7 @@ beginConnection muxTracer handshakeTracer versionDataCodec acceptVersion fn t ad
             throwIO err
           Right app -> do
             traceWith muxTracer' $ Mx.MuxTraceHandshakeServerEnd
-            Mx.muxStart muxTracer' peerid (toApplication app) bearer
+            Mx.muxStart muxTracer' peerid (toApplication app peerid) bearer
       RejectConnection st' _peerid -> pure $ Server.Reject st'
 
 

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -126,8 +126,8 @@ demo chain0 updates delay = do
                         (encodeTip encode) (decodeTip decode))
                         producerPeer)
 
-    clientAsync <- async $ Mx.runMuxWithQueues activeTracer "consumer" (Mx.toApplication consumerApp "consumer") client_w client_r sduLen Nothing
-    serverAsync <- async $ Mx.runMuxWithQueues activeTracer "producer" (Mx.toApplication producerApp "producer") server_w server_r sduLen Nothing
+    clientAsync <- async $ Mx.runMuxWithQueues activeTracer (Mx.toApplication consumerApp "consumer") client_w client_r sduLen Nothing
+    serverAsync <- async $ Mx.runMuxWithQueues activeTracer (Mx.toApplication producerApp "producer") server_w server_r sduLen Nothing
 
     updateAid <- async $ sequence_
         [ do

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -126,8 +126,8 @@ demo chain0 updates delay = do
                         (encodeTip encode) (decodeTip decode))
                         producerPeer)
 
-    clientAsync <- async $ Mx.runMuxWithQueues activeTracer "consumer" (Mx.toApplication consumerApp) client_w client_r sduLen Nothing
-    serverAsync <- async $ Mx.runMuxWithQueues activeTracer "producer" (Mx.toApplication producerApp) server_w server_r sduLen Nothing
+    clientAsync <- async $ Mx.runMuxWithQueues activeTracer "consumer" (Mx.toApplication consumerApp "consumer") client_w client_r sduLen Nothing
+    serverAsync <- async $ Mx.runMuxWithQueues activeTracer "producer" (Mx.toApplication producerApp "producer") server_w server_r sduLen Nothing
 
     updateAid <- async $ sequence_
         [ do

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -124,8 +124,8 @@ demo chain0 updates = do
                                               (encodeTip encode) (decodeTip decode))
                     (ChainSync.chainSyncServerPeer server)
 
-    _ <- async $ Mx.runMuxWithPipes activeTracer "producer" (toApplication producerApp "producer") hndRead1 hndWrite2
-    _ <- async $ Mx.runMuxWithPipes activeTracer "consumer" (toApplication consumerApp "consumer") hndRead2 hndWrite1
+    _ <- async $ Mx.runMuxWithPipes activeTracer (toApplication producerApp "producer") hndRead1 hndWrite2
+    _ <- async $ Mx.runMuxWithPipes activeTracer (toApplication consumerApp "consumer") hndRead2 hndWrite1
 
     void $ fork $ sequence_
         [ do threadDelay 10e-4 -- 1 milliseconds, just to provide interest

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -124,8 +124,8 @@ demo chain0 updates = do
                                               (encodeTip encode) (decodeTip decode))
                     (ChainSync.chainSyncServerPeer server)
 
-    _ <- async $ Mx.runMuxWithPipes activeTracer "producer" (toApplication producerApp) hndRead1 hndWrite2
-    _ <- async $ Mx.runMuxWithPipes activeTracer "consumer" (toApplication consumerApp) hndRead2 hndWrite1
+    _ <- async $ Mx.runMuxWithPipes activeTracer "producer" (toApplication producerApp "producer") hndRead1 hndWrite2
+    _ <- async $ Mx.runMuxWithPipes activeTracer "consumer" (toApplication consumerApp "consumer") hndRead2 hndWrite1
 
     void $ fork $ sequence_
         [ do threadDelay 10e-4 -- 1 milliseconds, just to provide interest

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -304,7 +304,7 @@ prop_socket_recv_close f _ = ioProperty $ do
              (\(sd',_) -> Socket.close sd') $ \(sd',_) -> do
                let bearer = Mx.socketAsMuxBearer nullTracer sd'
                Mx.traceMuxBearerState nullTracer Mx.Connected
-               Mx.muxStart nullTracer () (toApplication app) bearer
+               Mx.muxStart nullTracer () (toApplication app ()) bearer
           )
           $ \muxAsync -> do
 

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -304,7 +304,7 @@ prop_socket_recv_close f _ = ioProperty $ do
              (\(sd',_) -> Socket.close sd') $ \(sd',_) -> do
                let bearer = Mx.socketAsMuxBearer nullTracer sd'
                Mx.traceMuxBearerState nullTracer Mx.Connected
-               Mx.muxStart nullTracer () (toApplication app ()) bearer
+               Mx.muxStart nullTracer (toApplication app ()) bearer
           )
           $ \muxAsync -> do
 


### PR DESCRIPTION
The mux layer has never needed to know the peerid, since it only deals with a single connection to a single peer at once. It was only ever being passed around to satisfy plumbing requirements of either the
typed-protocols driver (which itself didn't really need to know, but that has now been resolved) or the OuroborosApplication layer (which is resolved in the first of the two patches).
