### PR TITLE
Turn nodeInitChainDB into a field of NodeArgs

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -268,6 +268,7 @@ mkNodeArgs registry cfg initState tracers btime chainDB isProducer = NodeArgs
     , initState
     , btime
     , chainDB
+    , initChainDB         = nodeInitChainDB
     , blockProduction
     , blockFetchSize      = nodeBlockFetchSize
     , blockMatchesHeader  = nodeBlockMatchesHeader

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -157,6 +157,7 @@ data NodeArgs m peer blk = NodeArgs {
     , initState           :: NodeState (BlockProtocol blk)
     , btime               :: BlockchainTime m
     , chainDB             :: ChainDB m blk
+    , initChainDB         :: NodeConfig (BlockProtocol blk) -> ChainDB m blk -> m ()
     , blockFetchSize      :: Header blk -> SizeInBytes
     , blockProduction     :: Maybe (BlockProduction m blk)
     , blockMatchesHeader  :: Header blk -> blk -> Bool
@@ -176,9 +177,9 @@ initNodeKernel
     => NodeArgs m peer blk
     -> m (NodeKernel m peer blk)
 initNodeKernel args@NodeArgs { registry, cfg, tracers, maxBlockSize
-                             , blockProduction, chainDB } = do
+                             , blockProduction, chainDB, initChainDB } = do
 
-    nodeInitChainDB cfg chainDB
+    initChainDB cfg chainDB
 
     st <- initInternalState args
 

--- a/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
@@ -619,6 +619,7 @@ runThreadNetwork ThreadNetworkArgs
             , initState           = pInfoInitState
             , btime
             , chainDB
+            , initChainDB         = nodeInitChainDB
             , blockProduction     = Just blockProduction
             , blockFetchSize      = nodeBlockFetchSize
             , blockMatchesHeader  = nodeBlockMatchesHeader


### PR DESCRIPTION
Prerequisite for fixing https://github.com/input-output-hk/cardano-byron-proxy/issues/87

For an alternative approach and more details, see https://github.com/input-output-hk/cardano-byron-proxy/pull/90