### PR TITLE
Lower default connection delay

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Worker.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Worker.hs
@@ -68,7 +68,7 @@ import           Ouroboros.Network.Subscription.Subscriber
 -- info.
 --
 defaultConnectionAttemptDelay :: DiffTime
-defaultConnectionAttemptDelay = 0.250 -- 250ms delay
+defaultConnectionAttemptDelay = 0.050 -- 50ms delay
 
 -- | Minimum time to wait between connection attempts.
 --


### PR DESCRIPTION
By lowering the default connection attempt delay there is a good chance
that a client will avoid peers not on the same continent.