### PR TITLE
Windows compatiblity

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ErrorPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ErrorPolicy.hs
@@ -24,19 +24,12 @@ import           Ouroboros.Consensus.Node.ProtocolInfo.Byron
 import           Ouroboros.Consensus.Util.ResourceRegistry
                      (RegistryClosedException, ResourceRegistryThreadException)
 
-consensusErrorPolicy :: ErrorPolicies addr ()
+consensusErrorPolicy :: ErrorPolicies
 consensusErrorPolicy = ErrorPolicies {
       -- Exception raised during connect
       --
       -- This is entirely a network-side concern.
       epConErrorPolicies = []
-
-      -- What to do when the protocol exits cleanly
-      --
-      -- This never happens (we always throw an exception), so this function
-      -- should never be called; if for some reason it /does/, we make it
-      -- throw an exception.
-    , epReturnCallback = \_time _addr () -> ourBug
 
       -- Exception raised during interaction with the peer
       --

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -286,6 +286,10 @@ test-suite test-network
     build-depends:     Win32-network                 <0.2.0.0,
                        Win32           >= 2.5.4.1 && <2.9
 
+  if os(windows)
+    build-depends:     Win32-network                 <0.2.0.0,
+                       Win32           >= 2.5.4.1 && <2.9
+
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -78,6 +78,7 @@ library
                        Ouroboros.Network.Subscription
                        Ouroboros.Network.Subscription.Ip
                        Ouroboros.Network.Subscription.Dns
+                       Ouroboros.Network.Subscription.Client
                        Ouroboros.Network.Subscription.Subscriber
                        Ouroboros.Network.Subscription.PeerState
                        Ouroboros.Network.Subscription.Worker

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -130,10 +130,8 @@ data DiffusionApplications = DiffusionApplications {
                                           ())
       -- ^ NodeToClient responder applicaton (server role)
 
-    , daErrorPolicies :: ErrorPolicies SockAddr ()
+    , daErrorPolicies :: ErrorPolicies
       -- ^ error policies
-      --
-      -- TODO: one cannot use `forall a. ErrorPolicies SockAddr a`
     }
 
 runDataDiffusion
@@ -218,7 +216,7 @@ runDataDiffusion tracers
       , laUnix = Nothing
       }
 
-    remoteErrorPolicy, localErrorPolicy :: ErrorPolicies SockAddr ()
+    remoteErrorPolicy, localErrorPolicy :: ErrorPolicies
     remoteErrorPolicy = NodeToNode.remoteNetworkErrorPolicy <> daErrorPolicies
     localErrorPolicy  = NodeToNode.localNetworkErrorPolicy <> daErrorPolicies
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -225,7 +225,7 @@ withServer
   -> LocalAddress
   -> Versions NodeToClientVersion DictVersion
               (OuroborosApplication appType (ConnectionId LocalAddress) NodeToClientProtocols IO BL.ByteString a b)
-  -> ErrorPolicies LocalAddress ()
+  -> ErrorPolicies
   -> IO Void
 withServer sn tracers networkState addr versions errPolicies =
   withServerNode
@@ -258,7 +258,7 @@ withServer_V1
   -- ^ applications which has the reponder side, i.e.
   -- 'OuroborosResponderApplication' or
   -- 'OuroborosInitiatorAndResponderApplication'.
-  -> ErrorPolicies LocalAddress ()
+  -> ErrorPolicies
   -> IO Void
 withServer_V1 sn tracers networkState addr versionData application =
     withServer
@@ -363,7 +363,7 @@ ncSubscriptionWorker_V1
 --
 -- If a trusted node sends us a wrong data or 
 --
-networkErrorPolicies :: ErrorPolicies addr a
+networkErrorPolicies :: ErrorPolicies
 networkErrorPolicies = ErrorPolicies
     { epAppErrorPolicies = [
         -- Handshake client protocol error: we either did not recognise received
@@ -408,7 +408,6 @@ networkErrorPolicies = ErrorPolicies
         ErrorPolicy $ \(_ :: IOException) -> Just $
           SuspendPeer shortDelay shortDelay
       ]
-    , epReturnCallback = \_ _ _ -> ourBug
     }
   where
     ourBug :: SuspendDecision DiffTime

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -33,8 +33,9 @@ module Ouroboros.Network.NodeToNode (
   -- * Subscription Workers
   -- ** IP subscriptin worker
   , IPSubscriptionTarget (..)
-  , NetworkIPSubscriptionTracers (..)
-  , nullNetworkIPSubscriptionTracers
+  , NetworkIPSubscriptionTracers
+  , NetworkSubscriptionTracers (..)
+  , nullNetworkSubscriptionTracers
   , SubscriptionParams (..)
   , IPSubscriptionParams
   , ipSubscriptionWorker
@@ -294,25 +295,25 @@ ipSubscriptionWorker
     -> IO Void
 ipSubscriptionWorker
   sn
-  NetworkIPSubscriptionTracers
-    { nistSubscriptionTracer
-    , nistMuxTracer
-    , nistHandshakeTracer
-    , nistErrorPolicyTracer
+  NetworkSubscriptionTracers
+    { nsSubscriptionTracer
+    , nsMuxTracer
+    , nsHandshakeTracer
+    , nsErrorPolicyTracer
     }
   networkState
   subscriptionParams
   versions
     = Subscription.ipSubscriptionWorker
         sn
-        nistSubscriptionTracer
-        nistErrorPolicyTracer
+        nsSubscriptionTracer
+        nsErrorPolicyTracer
         networkState
         subscriptionParams
         (connectToNode'
           sn
           cborTermVersionDataCodec
-          (NetworkConnectTracers nistMuxTracer nistHandshakeTracer)
+          (NetworkConnectTracers nsMuxTracer nsHandshakeTracer)
           versions)
 
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -236,7 +236,7 @@ withServer
   -> NetworkMutableState Socket.SockAddr
   -> Socket.SockAddr
   -> Versions NodeToNodeVersion DictVersion (OuroborosApplication appType (ConnectionId Socket.SockAddr) NodeToNodeProtocols IO BL.ByteString a b)
-  -> ErrorPolicies Socket.SockAddr ()
+  -> ErrorPolicies
   -> IO Void
 withServer sn tracers networkState addr versions errPolicies =
   withServerNode
@@ -261,7 +261,7 @@ withServer_V1
   -> Socket.SockAddr
   -> NodeToNodeVersionData
   -> (OuroborosApplication appType (ConnectionId Socket.SockAddr) NodeToNodeProtocols IO BL.ByteString x y)
-  -> ErrorPolicies Socket.SockAddr ()
+  -> ErrorPolicies
   -> IO Void
 withServer_V1 sn tracers networkState addr versionData application =
     withServer
@@ -433,7 +433,7 @@ dnsSubscriptionWorker_V1
 -- | A minimal error policy for remote peers, which only handles exceptions
 -- raised by `ouroboros-network`.
 --
-remoteNetworkErrorPolicy :: ErrorPolicies Socket.SockAddr a
+remoteNetworkErrorPolicy :: ErrorPolicies
 remoteNetworkErrorPolicy = ErrorPolicies {
       epAppErrorPolicies = [
           -- Handshake client protocol error: we either did not recognise received
@@ -500,9 +500,7 @@ remoteNetworkErrorPolicy = ErrorPolicies {
       epConErrorPolicies = [
           ErrorPolicy $ \(_ :: IOException) -> Just $
             SuspendConsumer shortDelay
-        ],
-
-      epReturnCallback = \_ _ _ -> ourBug
+        ]
     }
   where
     theyBuggyOrEvil :: SuspendDecision DiffTime
@@ -510,9 +508,6 @@ remoteNetworkErrorPolicy = ErrorPolicies {
 
     misconfiguredPeer :: SuspendDecision DiffTime
     misconfiguredPeer = SuspendConsumer defaultDelay
-
-    ourBug :: SuspendDecision DiffTime
-    ourBug = Throw
 
     defaultDelay :: DiffTime
     defaultDelay = 200 -- seconds
@@ -528,7 +523,7 @@ remoteNetworkErrorPolicy = ErrorPolicies {
 -- killed and not penalised by this policy.  This allows to restart the local
 -- client without a delay.
 --
-localNetworkErrorPolicy :: ErrorPolicies Socket.SockAddr a
+localNetworkErrorPolicy :: ErrorPolicies
 localNetworkErrorPolicy = ErrorPolicies {
       epAppErrorPolicies = [
           -- exception thrown by `runDecoderWithByteLimit`
@@ -547,12 +542,7 @@ localNetworkErrorPolicy = ErrorPolicies {
         ],
 
       -- The node never connects to a local client
-      epConErrorPolicies = [],
-
-      epReturnCallback = \_ _ _ -> ourBug
+      epConErrorPolicies = []
     }
-  where
-    ourBug :: SuspendDecision DiffTime
-    ourBug = Throw
 
 type RemoteConnectionId = ConnectionId Socket.SockAddr

--- a/ouroboros-network/src/Ouroboros/Network/Snocket.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Snocket.hs
@@ -18,6 +18,7 @@ module Ouroboros.Network.Snocket
   , LocalSnocket
   , localSnocket
   , LocalAddress
+  , LocalFD
   , localAddressFromPath
   ) where
 
@@ -381,11 +382,13 @@ namedPipeSnocket iocp name = Snocket {
 -- | System dependent LocalSnocket type
 #if defined(mingw32_HOST_OS)
 type LocalSnocket = HANDLESnocket
+type LocalFD      = Win32.HANDLE
 
 localSnocket :: AssociateWithIOCP -> FilePath -> LocalSnocket
 localSnocket = namedPipeSnocket
 #else
 type LocalSnocket = SocketSnocket
+type LocalFD      = Socket
 
 localSnocket :: AssociateWithIOCP -> FilePath -> LocalSnocket
 localSnocket iocp _  = rawSocketSnocket iocp

--- a/ouroboros-network/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Socket.hs
@@ -489,7 +489,7 @@ runServerThread
     -> VersionDataCodec extra CBOR.Term
     -> (forall vData. extra vData -> vData -> vData -> Accept)
     -> Versions vNumber extra (OuroborosApplication appType (ConnectionId addr) ptcl IO BL.ByteString a b)
-    -> ErrorPolicies addr ()
+    -> ErrorPolicies
     -> IO Void
 runServerThread NetworkServerTracers { nstMuxTracer
                                      , nstHandshakeTracer
@@ -589,7 +589,7 @@ withServerNode
     -- ^ The mux application that will be run on each incoming connection from
     -- a given address.  Note that if @'MuxClientAndServerApplication'@ is
     -- returned, the connection will run a full duplex set of mini-protocols.
-    -> ErrorPolicies addr ()
+    -> ErrorPolicies
     -> (addr -> Async Void -> IO t)
     -- ^ callback which takes the @Async@ of the thread that is running the server.
     -- Note: the server thread will terminate when the callback returns or

--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Client.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- Subscription worker for client applications connecting with 'LocalSnocket'
+-- which is using either unix sockets or Windows' named pipes.
+--
+module Ouroboros.Network.Subscription.Client
+  ( ClientSubscriptionParams (..)
+  , clientSubscriptionWorker
+  ) where
+
+import           Control.Monad.Class.MonadTime
+import           Control.Tracer
+
+import           Data.Void (Void)
+import           Data.Functor.Identity (Identity (..))
+
+import           Ouroboros.Network.Snocket ( LocalAddress
+                                           , LocalSnocket
+                                           , LocalFD
+                                           )
+import           Ouroboros.Network.ErrorPolicy ( ErrorPolicies
+                                               , ErrorPolicyTrace
+                                               , WithAddr
+                                               , completeApplicationTx
+                                               )
+import           Ouroboros.Network.Socket (NetworkMutableState (..))
+import           Ouroboros.Network.Subscription.Ip (socketStateChangeTx, mainTx)
+import           Ouroboros.Network.Subscription.Worker
+import           Ouroboros.Network.Subscription.Subscriber
+
+
+data ClientSubscriptionParams a = ClientSubscriptionParams
+  { cspAddress                :: !LocalAddress
+  -- ^ unix socket or named pipe address
+  , cspConnectionAttemptDelay :: !(Maybe DiffTime)
+  -- ^ delay between connection attempts
+  , cspErrorPolicies          :: !ErrorPolicies
+  -- ^ error policies for subscription worker
+  }
+
+-- | Client subscription worker keeps subsribing to the 'LocalAddress' using
+-- either unix socket or named pipe.
+--
+clientSubscriptionWorker
+    :: LocalSnocket
+    -> Tracer IO (SubscriptionTrace LocalAddress)
+    -> Tracer IO (WithAddr LocalAddress ErrorPolicyTrace)
+    -> NetworkMutableState LocalAddress
+    -> ClientSubscriptionParams a
+    -> (LocalFD -> IO a)
+    -> IO Void
+clientSubscriptionWorker snocket
+                         tracer
+                         errorPolicyTracer
+                         NetworkMutableState { nmsConnectionTable, nmsPeerStates }
+                         ClientSubscriptionParams { cspAddress
+                                                  , cspConnectionAttemptDelay
+                                                  , cspErrorPolicies
+                                                  }
+                         k =
+    worker tracer
+           errorPolicyTracer
+           nmsConnectionTable
+           nmsPeerStates
+           snocket
+           WorkerCallbacks
+            { wcSocketStateChangeTx   = socketStateChangeTx
+            , wcCompleteApplicationTx = completeApplicationTx cspErrorPolicies
+            , wcMainTx                = mainTx
+            }
+           workerParams
+           k
+  where
+    workerParams = WorkerParams {
+        wpLocalAddresses         = Identity cspAddress,
+        wpSelectAddress          = \_ (Identity addr) -> Just addr,
+        wpConnectionAttemptDelay = const cspConnectionAttemptDelay,
+        wpSubscriptionTarget     = pure (constantSubscriptionTarget cspAddress),
+        wpValency                = 1
+      }

--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Dns.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Dns.hs
@@ -251,6 +251,7 @@ dnsSubscriptionWorker' snocket subTracer dnsTracer errorPolicyTracer
                                           (WithDomainName (dstDomain dst) `contramap` dnsTracer)
                                           resolver nmsPeerStates beforeConnectTx dst
                                     , wpValency = dstValency dst
+                                    , wpSelectAddress = selectSockAddr 
                                     }
                        spErrorPolicies
                        main

--- a/ouroboros-network/src/Ouroboros/Network/Subscription/Ip.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Subscription/Ip.hs
@@ -65,7 +65,7 @@ data SubscriptionParams a target = SubscriptionParams
   { spLocalAddresses         :: LocalAddresses Socket.SockAddr
   , spConnectionAttemptDelay :: Socket.SockAddr -> Maybe DiffTime
     -- ^ should return expected delay for the given address
-  , spErrorPolicies          :: ErrorPolicies Socket.SockAddr a
+  , spErrorPolicies          :: ErrorPolicies
   , spSubscriptionTarget     :: target
   }
 
@@ -181,7 +181,7 @@ subscriptionWorker
     -> Tracer IO (WithAddr Socket.SockAddr ErrorPolicyTrace)
     -> NetworkMutableState Socket.SockAddr
     -> WorkerParams IO Socket.SockAddr
-    -> ErrorPolicies Socket.SockAddr a
+    -> ErrorPolicies
     -> Main IO (PeerStates IO Socket.SockAddr) x
     -- ^ main callback
     -> (Socket.Socket -> IO a)

--- a/ouroboros-network/src/Ouroboros/Network/Tracers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Tracers.hs
@@ -1,6 +1,7 @@
 module Ouroboros.Network.Tracers
-  ( NetworkIPSubscriptionTracers (..)
-  , nullNetworkIPSubscriptionTracers
+  ( NetworkSubscriptionTracers (..)
+  , NetworkIPSubscriptionTracers
+  , nullNetworkSubscriptionTracers
   , NetworkDNSSubscriptionTracers (..)
   , nullNetworkDNSSubscriptionTracers
   ) where
@@ -20,29 +21,31 @@ import           Ouroboros.Network.Subscription.Dns
 
 -- | IP subscription tracers.
 --
-data NetworkIPSubscriptionTracers addr ptcl vNumber = NetworkIPSubscriptionTracers {
-      nistMuxTracer          :: Tracer IO (WithMuxBearer (ConnectionId addr) MuxTrace),
+data NetworkSubscriptionTracers withIPList addr ptcl vNumber = NetworkSubscriptionTracers {
+      nsMuxTracer          :: Tracer IO (WithMuxBearer (ConnectionId addr) MuxTrace),
       -- ^ low level mux-network tracer, which logs mux sdu (send and received)
       -- and other low level multiplexing events.
-      nistHandshakeTracer    :: Tracer IO (WithMuxBearer (ConnectionId addr)
+      nsHandshakeTracer    :: Tracer IO (WithMuxBearer (ConnectionId addr)
                                             (TraceSendRecv (Handshake vNumber CBOR.Term))),
       -- ^ handshake protocol tracer; it is important for analysing version
       -- negotation mismatches.
-      nistErrorPolicyTracer  :: Tracer IO (WithAddr addr ErrorPolicyTrace),
+      nsErrorPolicyTracer  :: Tracer IO (WithAddr addr ErrorPolicyTrace),
       -- ^ error policy tracer; must not be 'nullTracer', otherwise all the
       -- exceptions which are not matched by any error policy will be caught
       -- and not logged or rethrown.
-      nistSubscriptionTracer :: Tracer IO (WithIPList (SubscriptionTrace addr))
+      nsSubscriptionTracer :: Tracer IO (withIPList (SubscriptionTrace addr))
       -- ^ subscription tracers; it is infrequent it should not be 'nullTracer'
       -- by default.
     }
 
-nullNetworkIPSubscriptionTracers :: NetworkIPSubscriptionTracers addr ptcl vNumber
-nullNetworkIPSubscriptionTracers = NetworkIPSubscriptionTracers {
-      nistMuxTracer          = nullTracer,
-      nistHandshakeTracer    = nullTracer,
-      nistErrorPolicyTracer  = nullTracer,
-      nistSubscriptionTracer = nullTracer
+type NetworkIPSubscriptionTracers addr ptcl vNumber = NetworkSubscriptionTracers WithIPList addr ptcl vNumber
+
+nullNetworkSubscriptionTracers :: NetworkSubscriptionTracers withIPList addr ptcl vNumber
+nullNetworkSubscriptionTracers = NetworkSubscriptionTracers {
+      nsMuxTracer          = nullTracer,
+      nsHandshakeTracer    = nullTracer,
+      nsErrorPolicyTracer  = nullTracer,
+      nsSubscriptionTracer = nullTracer
     }
 
 -- | DNS subscription tracers.

--- a/ouroboros-network/test/Test/PeerState.hs
+++ b/ouroboros-network/test/Test/PeerState.hs
@@ -377,12 +377,12 @@ prop_subscriptionWorker
                      laIpv6 = Just localAddr,
                      laUnix = Nothing
                    },
+                 wpSelectAddress = \_ LocalAddresses {laIpv4, laIpv6} -> getFirst (First laIpv4 <> First laIpv6),
                  wpConnectionAttemptDelay = const Nothing,
                  wpSubscriptionTarget = 
                    pure $ ipSubscriptionTarget nullTracer peerStatesVar [remoteAddr],
                  wpValency = 1
                }
-             (\_ LocalAddresses {laIpv4, laIpv6} -> getFirst (First laIpv4 <> First laIpv6))
              (\sock -> app sock
                 `finally`
                 (void $ atomically $ tryPutTMVar doneVar ()))

--- a/ouroboros-network/test/Test/PeerState.hs
+++ b/ouroboros-network/test/Test/PeerState.hs
@@ -344,13 +344,12 @@ prop_subscriptionWorker
     -> Int -- local address
     -> Int -- remote address
     -> ArbValidPeerState IO
-    -> (Fun (ArbTime, Int, ()) (ArbSuspendDecision ArbDiffTime))
     -> ArbErrorPolicies
     -> (Blind (ArbApp Int))
     -> Property
 prop_subscriptionWorker
     sockType localAddr remoteAddr (ArbValidPeerState ps)
-    returnCallback (ArbErrorPolicies appErrPolicies conErrPolicies)
+    (ArbErrorPolicies appErrPolicies conErrPolicies)
     (Blind (ArbApp merr app))
   =
     tabulate "peer states & app errors" [printf "%-20s %s" (peerStateType ps) (exceptionType merr)] $
@@ -391,10 +390,7 @@ prop_subscriptionWorker
     completeTx = completeApplicationTx
        (ErrorPolicies
           appErrPolicies
-          conErrPolicies
-          (\t addr r -> fmap getArbDiffTime . getArbSuspendDecision $ case returnCallback of
-              Fn3 f -> f (ArbTime t) addr r
-              _     -> error "impossible happend"))
+          conErrPolicies)
 
     main :: StrictTMVar IO () -> Main IO (PeerStates IO Int) Bool
     main doneVar s = do

--- a/ouroboros-network/test/Test/Subscription.hs
+++ b/ouroboros-network/test/Test/Subscription.hs
@@ -725,6 +725,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
               (NetworkMutableState tbl peerStatesVar)
               WorkerParams {
                   wpLocalAddresses = LocalAddresses (Just localAddr) Nothing Nothing,
+                  wpSelectAddress  = selectSockAddr,
                   wpConnectionAttemptDelay = \_ -> Just minConnectionAttemptDelay,
                   wpSubscriptionTarget = pure $ listSubscriptionTarget [remoteAddr],
                   wpValency = 1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Run all the tests using `cabal`.  This is useful for runing tests on Windows.
+
+# Any arguments are passed to `cabal run` command.
+
+cabal run ${@} test-Win32-network && \
+cabal run ${@} test-protocols && \
+cabal run ${@} test-sim && \
+cabal run ${@} test-network-mux && \
+cabal run ${@} ntp-client-test && \
+cabal run ${@} test-typed-protocols-cbor && \
+cabal run ${@} test-network
+# consensus tests are disabled due to #1082
+# cabal run ${@} test-consensus && \
+# cabal run ${@} test-storage
+# cddl tests are disabled - one needs the cddl tool
+# cabal run ${@} cddl


### PR DESCRIPTION
This PR includes three things:
* simplifies `ErrorPolicies` by removing callback which classifies return values of error policies
* adds `clientSubscriptionWorker` which subscribes to a unix socket or named pipe on windows.  It is a simplified version of `ipSubscriptionWorker`.
* adds `./scripts/test.sh` - a script to run tests on widnows - all are green :tada: :sunglasses:

It depends on #1499 - which needs to be merge first, it addresses #1501.