### PR TITLE
Don't hardcode the transaction size for mock blocks

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -276,12 +276,10 @@ instance (SimpleCrypto c, Typeable ext, SupportedBlock (SimpleBlock c ext))
   data GenTx (SimpleBlock c ext) = SimpleGenTx
     { simpleGenTx   :: !Mock.Tx
     , simpleGenTxId :: !Mock.TxId
-      -- ^ This field is lazy on purpose so that the TxId is computed on
-      -- demand.
     } deriving stock    (Generic)
       deriving anyclass (Serialise)
 
-  txSize _ = 2000  -- TODO #745
+  txSize = fromIntegral . Lazy.length . serialise
 
   type ApplyTxErr (SimpleBlock c ext) = MockError (SimpleBlock c ext)
 


### PR DESCRIPTION
Fixes #745 and #1479.

Also, remove an out of date comment.