### PR TITLE
Lower maxConcurrencyBulkSync to 1

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -195,6 +195,7 @@ initNodeKernel args@NodeArgs { registry, cfg, tracers, maxBlockSize
         (blockFetchClientTracer   tracers)
         blockFetchInterface
         fetchClientRegistry
+        blockFetchConfiguration
 
     return NodeKernel
       { getChainDB             = chainDB
@@ -203,6 +204,13 @@ initNodeKernel args@NodeArgs { registry, cfg, tracers, maxBlockSize
       , getFetchClientRegistry = fetchClientRegistry
       , getNodeCandidates      = varCandidates
       , getTracers             = tracers
+      }
+
+  where
+    blockFetchConfiguration :: BlockFetchConfiguration
+    blockFetchConfiguration = BlockFetchConfiguration
+      { bfcMaxConcurrencyBulkSync = 1 -- Set to 1 for now, see #1526
+      , bfcMaxConcurrencyDeadline = 1
       }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -536,6 +536,7 @@ clientBlockFetch sockAddrs = do
                       (contramap show stdoutTracer) -- state tracer
                       blockFetchPolicy
                       registry
+                      (BlockFetchConfiguration 1 1)
                  >> return ()
 
     chainAsync <- async (chainSelection Map.empty)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -246,7 +246,7 @@ blockFetchLogic decisionTracer clientStateTracer
         maxInFlightReqsPerPeer   = 10,
 
         -- TODO: These should be determined by external local node config.
-        maxConcurrencyBulkSync   = 2,
+        maxConcurrencyBulkSync   = 1,
         maxConcurrencyDeadline   = 1,
 
         plausibleCandidateChain,

--- a/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
@@ -126,6 +126,7 @@ blockFetchExample1 decisionTracer clientStateTracer clientMsgTracer
           decisionTracer clientStateTracer
           (sampleBlockFetchPolicy1 blockHeap currentChainHeaders candidateChainHeaders)
           registry
+          (BlockFetchConfiguration 2 1)
         >> return ()
 
     driver :: TestFetchedBlockHeap m Block -> m ()


### PR DESCRIPTION
Concurrent bulk downloads are currently very costly.
Dissable them for now.
Part of a workaround for https://github.com/input-output-hk/cardano-node/issues/488