### PR TITLE
Avoid need for subtyping

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -109,6 +109,7 @@ library
                        Ouroboros.Consensus.Protocol
                        Ouroboros.Consensus.Protocol.Abstract
                        Ouroboros.Consensus.Protocol.BFT
+                       Ouroboros.Consensus.Protocol.ExtConfig
                        Ouroboros.Consensus.Protocol.LeaderSchedule
                        Ouroboros.Consensus.Protocol.MockChainSel
                        Ouroboros.Consensus.Protocol.ModChainSel

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DefaultSignatures       #-}
 {-# LANGUAGE DeriveAnyClass          #-}
 {-# LANGUAGE DeriveGeneric           #-}
 {-# LANGUAGE FlexibleContexts        #-}
@@ -17,7 +18,7 @@ module Ouroboros.Consensus.Block (
   , headerPrevHash
   , headerPoint
     -- * Supported blocks
-  , SupportedBlock
+  , SupportedBlock(..)
     -- * EBBs
   , IsEBB (..)
   , toIsEBB
@@ -90,10 +91,19 @@ class ( GetHeader blk
       , HasHeader blk
       , HasHeader (Header blk)
       , OuroborosTag (BlockProtocol blk)
-      , CanValidate  (BlockProtocol blk) (Header blk)
-      , CanSelect    (BlockProtocol blk) (Header blk)
       , NoUnexpectedThunks (Header blk)
-      ) => SupportedBlock blk
+      ) => SupportedBlock blk where
+  validateView :: NodeConfig (BlockProtocol blk)
+               -> Header blk -> ValidateView (BlockProtocol blk)
+
+  selectView   :: NodeConfig (BlockProtocol blk)
+               -> Header blk -> SelectView   (BlockProtocol blk)
+
+  -- Default chain selection just looks at longest chains
+  default selectView :: SelectView (BlockProtocol blk) ~ BlockNo
+                     => NodeConfig (BlockProtocol blk)
+                     -> Header blk -> SelectView (BlockProtocol blk)
+  selectView _ = blockNo
 
 {-------------------------------------------------------------------------------
   EBBs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Block.hs
@@ -25,6 +25,8 @@ module Ouroboros.Consensus.Ledger.Byron.Block (
   , mkByronHeader
     -- * Auxiliary functions
   , countByronGenTxs
+  , byronHeaderIsEBB
+  , byronBlockIsEBB
     -- * Serialisation
   , encodeByronBlockWithInfo
   , encodeByronBlock
@@ -237,6 +239,16 @@ countByronGenTxs ByronBlock{..} = go byronBlockRaw
 
     payloadProposals :: CC.Update.APayload a -> [CC.Update.AProposal a]
     payloadProposals = maybeToList . CC.Update.payloadProposal
+
+byronHeaderIsEBB :: Header ByronBlock -> IsEBB
+byronHeaderIsEBB = go . byronHeaderRaw
+  where
+    go :: ABlockOrBoundaryHdr a -> IsEBB
+    go (ABOBBlockHdr    _) = IsNotEBB
+    go (ABOBBoundaryHdr _) = IsEBB
+
+byronBlockIsEBB :: ByronBlock -> IsEBB
+byronBlockIsEBB = byronHeaderIsEBB . getHeader
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/ContainsGenesis.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/ContainsGenesis.hs
@@ -9,7 +9,7 @@ import qualified Cardano.Chain.Genesis as CC.Genesis
 
 import           Ouroboros.Consensus.Ledger.Byron.Config
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Protocol.PBFT
+import           Ouroboros.Consensus.Protocol.ExtConfig
 
 class ConfigContainsGenesis cfg where
   getGenesisConfig :: cfg -> CC.Genesis.Config
@@ -18,5 +18,5 @@ instance ConfigContainsGenesis ByronConfig where
   getGenesisConfig = pbftGenesisConfig
 
 instance ConfigContainsGenesis cfg
-      => ConfigContainsGenesis (NodeConfig (PBft cfg c)) where
-  getGenesisConfig = getGenesisConfig . pbftExtConfig
+      => ConfigContainsGenesis (NodeConfig (ExtConfig p cfg)) where
+  getGenesisConfig = getGenesisConfig . extNodeConfig

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Ouroboros.Consensus.Ledger.Byron.Forge (
     forgeByronBlock
@@ -14,6 +15,7 @@ import           Control.Monad (void)
 import           Crypto.Random (MonadRandom)
 import           Data.ByteString (ByteString)
 import           Data.Coerce (coerce)
+import           Data.Proxy
 import           Data.Word (Word32)
 import           GHC.Stack
 
@@ -141,7 +143,10 @@ forgeRegularBlock
   -> m ByronBlock
 forgeRegularBlock cfg curSlot curNo extLedger txs isLeader = do
     ouroborosPayload <-
-      forgePBftFields cfg isLeader (reAnnotate $ Annotated toSign ())
+      forgePBftFields
+        (constructContextDSIGN (Proxy @PBftCardanoCrypto) (pbftExtConfig cfg))
+        isLeader
+        (reAnnotate $ Annotated toSign ())
     return $ forge ouroborosPayload
   where
     -- TODO: Might be sufficient to add 'ConfigContainsGenesis' constraint.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Forge.hs
@@ -43,6 +43,7 @@ import           Ouroboros.Consensus.Ledger.Byron.Mempool
 import           Ouroboros.Consensus.Ledger.Byron.PBFT
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.ExtConfig
 import           Ouroboros.Consensus.Protocol.PBFT
 
 forgeByronBlock
@@ -75,7 +76,7 @@ forgeEBB cfg curSlot curNo prevHash =
     protocolMagicId = CC.Genesis.configProtocolMagicId (getGenesisConfig cfg)
     ByronConfig { pbftGenesisHash
                 , pbftEpochSlots
-                } = pbftExtConfig cfg
+                } = extNodeConfig cfg
 
     prevHeaderHash :: Either CC.Genesis.GenesisHash CC.Block.HeaderHash
     prevHeaderHash = case prevHash of
@@ -144,7 +145,7 @@ forgeRegularBlock
 forgeRegularBlock cfg curSlot curNo extLedger txs isLeader = do
     ouroborosPayload <-
       forgePBftFields
-        (constructContextDSIGN (Proxy @PBftCardanoCrypto) (pbftExtConfig cfg))
+        (constructContextDSIGN (Proxy @PBftCardanoCrypto) (extNodeConfig cfg))
         isLeader
         (reAnnotate $ Annotated toSign ())
     return $ forge ouroborosPayload
@@ -155,7 +156,7 @@ forgeRegularBlock cfg curSlot curNo extLedger txs isLeader = do
       , pbftProtocolVersion
       , pbftSoftwareVersion
       , pbftProtocolMagic
-      } = pbftExtConfig cfg
+      } = extNodeConfig cfg
 
     blockPayloads :: BlockPayloads
     blockPayloads = foldr extendBlockPayloads initBlockPayloads txs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Integrity.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Integrity.hs
@@ -35,15 +35,15 @@ verifyBlockMatchesHeader hdr blk =
 -- This function will always return 'True' for an EBB.
 verifyHeaderSignature
   :: NodeConfig ByronConsensusProtocol -> Header ByronBlock -> Bool
-verifyHeaderSignature cfg@PBftNodeConfig { pbftExtConfig } hdr =
+verifyHeaderSignature cfg hdr =
     case validateView cfg hdr of
       PBftValidateBoundary{} ->
         -- EBB, no signature to check
         True
-      PBftValidateRegular _slot fields signed ->
-        let PBftFields { pbftIssuer, pbftGenKey, pbftSignature } = fields
+      PBftValidateRegular _slot fields signed contextDSIGN ->
+        let PBftFields { pbftIssuer, pbftSignature } = fields
         in isRight $ CC.Crypto.verifySignedDSIGN
-             (constructContextDSIGN cfg pbftExtConfig pbftGenKey)
+             contextDSIGN
              pbftIssuer
              signed
              pbftSignature

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Ledger.hs
@@ -67,6 +67,7 @@ import           Ouroboros.Consensus.Ledger.Byron.DelegationHistory
 import qualified Ouroboros.Consensus.Ledger.Byron.DelegationHistory as History
 import           Ouroboros.Consensus.Ledger.Byron.PBFT
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.ExtConfig
 import           Ouroboros.Consensus.Protocol.PBFT
 
 instance UpdateLedger ByronBlock where
@@ -146,8 +147,8 @@ instance ConfigContainsGenesis (LedgerConfig ByronBlock) where
   getGenesisConfig = unByronLedgerConfig
 
 instance ProtocolLedgerView ByronBlock where
-  ledgerConfigView PBftNodeConfig{..} = ByronLedgerConfig $
-      pbftGenesisConfig pbftExtConfig
+  ledgerConfigView ExtNodeConfig{..} = ByronLedgerConfig $
+      pbftGenesisConfig extNodeConfig
 
   protocolLedgerView _cfg =
         toPBftLedgerView
@@ -222,7 +223,7 @@ instance ProtocolLedgerView ByronBlock where
 
               in Aux.applyScheduledDelegations toApply dsNow
     where
-      SecurityParam k = pbftSecurityParam . pbftParams $ cfg
+      SecurityParam k = pbftSecurityParam . pbftParams $ extNodeConfigP cfg
 
       dsNow :: Delegation.Map
       dsNow = Aux.getDelegationMap ls

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
@@ -64,6 +64,7 @@ instance SupportedBlock ByronBlock where
                (blockSlot hdr)
                pbftFields
                (CC.recoverSignedBytes epochSlots regular)
+               (pbftExtConfig cfg, pbftGenKey pbftFields)
     where
       epochSlots = pbftEpochSlots (pbftExtConfig cfg)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/PBFT.hs
@@ -31,10 +31,11 @@ import           Ouroboros.Consensus.Ledger.Byron.Auxiliary
 import           Ouroboros.Consensus.Ledger.Byron.Block
 import           Ouroboros.Consensus.Ledger.Byron.Config
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.ExtConfig
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
 
-type ByronConsensusProtocol = PBft ByronConfig PBftCardanoCrypto
+type ByronConsensusProtocol = ExtConfig (PBft PBftCardanoCrypto) ByronConfig
 type instance BlockProtocol ByronBlock = ByronConsensusProtocol
 
 instance SupportedBlock ByronBlock where
@@ -64,10 +65,9 @@ instance SupportedBlock ByronBlock where
                (blockSlot hdr)
                pbftFields
                (CC.recoverSignedBytes epochSlots regular)
-               (pbftExtConfig cfg, pbftGenKey pbftFields)
+               (extNodeConfig cfg, pbftGenKey pbftFields)
     where
-      epochSlots = pbftEpochSlots (pbftExtConfig cfg)
-
+      epochSlots = pbftEpochSlots (extNodeConfig cfg)
 
   selectView _ hdr = (blockNo hdr, byronHeaderIsEBB hdr)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/ByronSpec/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/ByronSpec/Ledger.hs
@@ -59,6 +59,7 @@ instance UpdateLedger ByronSpecBlock where
   newtype LedgerConfig ByronSpecBlock = ByronSpecLedgerConfig {
         unByronSpecLedgerConfig :: ByronSpecGenesis
       }
+    deriving NoUnexpectedThunks via AllowThunk (LedgerConfig ByronSpecBlock)
 
   type LedgerError ByronSpecBlock = ByronSpecLedgerError
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual/Byron.hs
@@ -280,12 +280,11 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params mLeader =
     ProtocolInfo {
         pInfoConfig = ExtNodeConfig {
             extNodeConfig  = abstractConfig
-          , extNodeConfigP = PBftNodeConfig {
+          , extNodeConfigP = ExtNodeConfig concreteConfig PBftNodeConfig {
                 pbftParams    = params
               , pbftIsLeader  = case mLeader of
                                   Nothing  -> PBftIsNotALeader
                                   Just nid -> PBftIsALeader $ pbftIsLeader nid
-              , pbftExtConfig = concreteConfig
               }
           }
       , pInfoInitState =
@@ -319,7 +318,7 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params mLeader =
     concreteConfig :: ByronConfig
 
     abstractConfig = ByronSpecLedgerConfig abstractGenesis
-    concreteConfig = byronConfig
+    concreteConfig = mkByronConfig
                        concreteGenesis
                        protocolVersion
                        softwareVersion

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -93,10 +93,7 @@ data BlockPreviouslyApplied =
 -- way around. This means that in the spec delegation updates scheduled for
 -- slot @n@ are really only in effect at slot @n+1@.
 -- See <https://github.com/input-output-hk/cardano-ledger-specs/issues/1007>
-applyExtLedgerState :: ( UpdateLedger blk
-                       , ProtocolLedgerView blk
-                       , HasCallStack
-                       )
+applyExtLedgerState :: (ProtocolLedgerView blk, HasCallStack)
                     => BlockPreviouslyApplied
                     -> NodeConfig (BlockProtocol blk)
                     -> blk
@@ -119,7 +116,7 @@ applyExtLedgerState prevApplied cfg blk ExtLedgerState{..} = do
                               applyChainState
                                 cfg
                                 (protocolLedgerView cfg ledgerState')
-                                (getHeader blk)
+                                (validateView cfg (getHeader blk))
                                 ouroborosChainState
     return $ ExtLedgerState ledgerState' ouroborosChainState'
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/BFT.hs
@@ -68,16 +68,10 @@ _simpleBFtHeader = simpleHeader
   Evidence that SimpleBlock can support BFT
 -------------------------------------------------------------------------------}
 
+type instance Signed (SimpleBftHeader c c') = SignedSimpleBft c c'
+
 instance SignedHeader (SimpleBftHeader c c') where
-  type Signed (SimpleBftHeader c c') = SignedSimpleBft c c'
-
   headerSigned = SignedSimpleBft . simpleHeaderStd
-
-instance ( SimpleCrypto c
-         , BftCrypto c'
-         , Signable (BftDSIGN c') (SignedSimpleBft c c')
-         ) => HeaderSupportsBft c' (SimpleBftHeader c c') where
-  headerBftFields _ = simpleBftExt . simpleHeaderExt
 
 instance RunMockProtocol (Bft c') where
   mockProtocolMagicId  = const constructMockProtocolMagicId
@@ -105,7 +99,8 @@ instance ( SimpleCrypto c
 instance ( SimpleCrypto c
          , BftCrypto c'
          , Signable (BftDSIGN c') (SignedSimpleBft c c')
-         ) => SupportedBlock (SimpleBftBlock c c')
+         ) => SupportedBlock (SimpleBftBlock c c') where
+  validateView _ = bftValidateView (simpleBftExt . simpleHeaderExt)
 
 instance ( SimpleCrypto c
          , BftCrypto c'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
@@ -112,7 +112,7 @@ instance ( SimpleCrypto c
 instance ( SimpleCrypto c
          , Signable MockDSIGN (SignedSimplePBft c PBftMockCrypto)
          ) => SupportedBlock (SimplePBftBlock c PBftMockCrypto) where
-  validateView _     = pbftValidateRegular (simplePBftExt . simpleHeaderExt)
+  validateView _     = pbftValidateRegular () (simplePBftExt . simpleHeaderExt)
   selectView   _ hdr = (blockNo hdr, IsNotEBB)
 
 -- | The ledger view is constant for the mock instantiation of PBFT

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PBFT.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
@@ -17,6 +18,7 @@ module Ouroboros.Consensus.Ledger.Mock.Block.PBFT (
   ) where
 
 import           Codec.Serialise (Serialise (..))
+import           Data.Proxy
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 
@@ -98,10 +100,10 @@ instance ( SimpleCrypto c
          ) => RunMockBlock (PBft ext c') c (SimplePBftExt c c') where
   forgeExt cfg isLeader SimpleBlock{..} = do
       ext :: SimplePBftExt c c' <- fmap SimplePBftExt $
-        forgePBftFields cfg isLeader $
-          SignedSimplePBft {
-              signedSimplePBft = simpleHeaderStd
-            }
+        forgePBftFields
+          (constructContextDSIGN (Proxy @c') (pbftExtConfig cfg))
+          isLeader
+          SignedSimplePBft { signedSimplePBft = simpleHeaderStd }
       return SimpleBlock {
           simpleHeader = mkSimpleHeader encode simpleHeaderStd ext
         , simpleBody   = simpleBody

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/Praos.hs
@@ -33,6 +33,7 @@ import           Ouroboros.Consensus.Ledger.Mock.Address
 import           Ouroboros.Consensus.Ledger.Mock.Block
 import           Ouroboros.Consensus.Ledger.Mock.Run
 import           Ouroboros.Consensus.Ledger.Mock.Stake
+import           Ouroboros.Consensus.Protocol.ExtConfig
 import           Ouroboros.Consensus.Protocol.Praos
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util.Condense
@@ -68,7 +69,7 @@ data SignedSimplePraos c c' = SignedSimplePraos {
     }
 
 -- | See 'ProtocolLedgerView' instance for why we need the 'AddrDist'
-type instance BlockProtocol (SimplePraosBlock  c c') = Praos AddrDist c'
+type instance BlockProtocol (SimplePraosBlock  c c') = ExtConfig (Praos c') AddrDist
 type instance BlockProtocol (SimplePraosHeader c c') = BlockProtocol (SimplePraosBlock c c')
 
 -- | Sanity check that block and header type synonyms agree
@@ -87,7 +88,7 @@ instance PraosCrypto c' => SignedHeader (SimplePraosHeader c c') where
       , signedPraosFields = praosExtraFields (simplePraosExt simpleHeaderExt)
       }
 
-instance PraosCrypto c' => RunMockProtocol (Praos ext c') where
+instance PraosCrypto c' => RunMockProtocol (ExtConfig (Praos c') ext) where
   mockProtocolMagicId  = const constructMockProtocolMagicId
   mockEncodeChainState = const encode
   mockDecodeChainState = const decode
@@ -109,10 +110,10 @@ instance PraosCrypto c' => Serialise (BlockInfo c') where
 instance ( SimpleCrypto c
          , PraosCrypto c'
          , Signable (PraosKES c') (SignedSimplePraos c c')
-         ) => RunMockBlock (Praos ext c') c (SimplePraosExt c c') where
+         ) => RunMockBlock (ExtConfig (Praos c') ext) c (SimplePraosExt c c') where
   forgeExt cfg isLeader SimpleBlock{..} = do
       ext :: SimplePraosExt c c' <- fmap SimplePraosExt $
-        forgePraosFields cfg
+        forgePraosFields (extNodeConfigP cfg)
                          isLeader
                          $ \praosExtraFields ->
           SignedSimplePraos {
@@ -147,11 +148,11 @@ instance ( SimpleCrypto c
   ledgerConfigView _ =
       SimpleLedgerConfig
 
-  protocolLedgerView PraosNodeConfig{..} _ =
-      equalStakeDist praosExtConfig
+  protocolLedgerView ExtNodeConfig{..} _ =
+      equalStakeDist extNodeConfig
 
-  anachronisticProtocolLedgerView PraosNodeConfig{..} _ _ =
-      Right $ equalStakeDist praosExtConfig
+  anachronisticProtocolLedgerView ExtNodeConfig{..} _ _ =
+      Right $ equalStakeDist extNodeConfig
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/Praos.hs
@@ -79,19 +79,13 @@ _simplePraosHeader = simpleHeader
   Evidence that SimpleBlock can support BFT
 -------------------------------------------------------------------------------}
 
-instance PraosCrypto c' => SignedHeader (SimplePraosHeader c c') where
-  type Signed (SimplePraosHeader c c') = SignedSimplePraos c c'
+type instance Signed (SimplePraosHeader c c') = SignedSimplePraos c c'
 
+instance PraosCrypto c' => SignedHeader (SimplePraosHeader c c') where
   headerSigned SimpleHeader{..} = SignedSimplePraos {
         signedSimplePraos = simpleHeaderStd
       , signedPraosFields = praosExtraFields (simplePraosExt simpleHeaderExt)
       }
-
-instance ( SimpleCrypto c
-         , PraosCrypto c'
-         , Signable (PraosKES c') (SignedSimplePraos c c')
-         ) => HeaderSupportsPraos AddrDist c' (SimplePraosHeader c c') where
-  headerPraosFields _ = simplePraosExt . simpleHeaderExt
 
 instance PraosCrypto c' => RunMockProtocol (Praos ext c') where
   mockProtocolMagicId  = const constructMockProtocolMagicId
@@ -135,7 +129,8 @@ instance ( SimpleCrypto c
 instance ( SimpleCrypto c
          , PraosCrypto c'
          , Signable (PraosKES c') (SignedSimplePraos c c')
-         ) => SupportedBlock (SimpleBlock c (SimplePraosExt c c'))
+         ) => SupportedBlock (SimpleBlock c (SimplePraosExt c c')) where
+  validateView _ = praosValidateView (simplePraosExt . simpleHeaderExt)
 
 -- | Praos needs a ledger that can give it the "active stake distribution"
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PraosRule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PraosRule.hs
@@ -59,7 +59,7 @@ newtype SimplePraosRuleExt = SimplePraosRuleExt {
   deriving (Generic, Condense, Show, Eq, NoUnexpectedThunks)
 
 type instance BlockProtocol (SimplePraosRuleBlock c) =
-   WithLeaderSchedule (Praos () PraosCryptoUnused)
+   WithLeaderSchedule (Praos PraosCryptoUnused)
 
 -- | Sanity check that block and header type synonyms agree
 _simplePraosRuleHeader :: SimplePraosRuleBlock c -> SimplePraosRuleHeader c

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PraosRule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block/PraosRule.hs
@@ -86,7 +86,8 @@ instance SimpleCrypto c
       SimpleHeader{..} = simpleHeader
 
 instance SimpleCrypto c
-      => SupportedBlock (SimpleBlock c SimplePraosRuleExt)
+      => SupportedBlock (SimpleBlock c SimplePraosRuleExt) where
+  validateView _ _ = ()
 
 instance SimpleCrypto c
       => ProtocolLedgerView (SimplePraosRuleBlock c) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Byron.hs
@@ -11,7 +11,7 @@
 module Ouroboros.Consensus.Node.ProtocolInfo.Byron (
     protocolInfoByron
   , ByronConfig
-  , byronConfig
+  , mkByronConfig
   , PBftSignatureThreshold(..)
   , defaultPBftSignatureThreshold
     -- * Secrets
@@ -43,6 +43,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract
 import           Ouroboros.Consensus.NodeId (CoreNodeId)
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.ExtConfig
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
 
@@ -119,12 +120,11 @@ protocolInfoByron :: Genesis.Config
                   -> ProtocolInfo ByronBlock
 protocolInfoByron genesisConfig mSigThresh pVer sVer mLeader =
     ProtocolInfo {
-        pInfoConfig = PBftNodeConfig {
+        pInfoConfig = ExtNodeConfig byronConfig PBftNodeConfig {
             pbftParams    = byronPBftParams genesisConfig mSigThresh
           , pbftIsLeader  = case mLeader of
                               Nothing   -> PBftIsNotALeader
                               Just cred -> PBftIsALeader $ pbftLeaderOrNot cred
-          , pbftExtConfig = byronConfig genesisConfig pVer sVer
           }
       , pInfoInitLedger = ExtLedgerState {
             ledgerState         = initByronLedgerState genesisConfig Nothing
@@ -132,6 +132,8 @@ protocolInfoByron genesisConfig mSigThresh pVer sVer mLeader =
           }
       , pInfoInitState  = ()
       }
+  where
+    byronConfig = mkByronConfig genesisConfig pVer sVer
 
 byronPBftParams :: Genesis.Config -> Maybe PBftSignatureThreshold -> PBftParams
 byronPBftParams cfg threshold = PBftParams {
@@ -163,11 +165,11 @@ pbftLeaderOrNot (PBftLeaderCredentials sk cert nid) = PBftIsLeader {
     , pbftDlgCert    = cert
     }
 
-byronConfig :: Genesis.Config
-            -> Update.ProtocolVersion
-            -> Update.SoftwareVersion
-            -> ByronConfig
-byronConfig genesisConfig pVer sVer = ByronConfig {
+mkByronConfig :: Genesis.Config
+              -> Update.ProtocolVersion
+              -> Update.SoftwareVersion
+              -> ByronConfig
+mkByronConfig genesisConfig pVer sVer = ByronConfig {
       pbftGenesisConfig   = genesisConfig
     , pbftProtocolVersion = pVer
     , pbftSoftwareVersion = sVer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/PBFT.hs
@@ -14,6 +14,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
+import           Ouroboros.Consensus.Protocol.ExtConfig
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
 
@@ -23,7 +24,7 @@ protocolInfoMockPBFT :: PBftParams
                                                       PBftMockCrypto)
 protocolInfoMockPBFT params nid =
     ProtocolInfo {
-        pInfoConfig = PBftNodeConfig {
+        pInfoConfig = ExtNodeConfig ledgerView PBftNodeConfig {
             pbftParams   = params
           , pbftIsLeader = PBftIsALeader PBftIsLeader {
                 pbftCoreNodeId = nid
@@ -31,16 +32,18 @@ protocolInfoMockPBFT params nid =
                 -- For Mock PBFT, we use our key as the genesis key.
               , pbftDlgCert    = (verKey nid, verKey nid)
               }
-          , pbftExtConfig = PBftLedgerView $
-              Bimap.fromList [ (verKey n, verKey n)
-                             | n <- enumCoreNodes (pbftNumNodes params)
-                             ]
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          CS.empty
       , pInfoInitState  = ()
       }
   where
+    ledgerView :: PBftLedgerView PBftMockCrypto
+    ledgerView = PBftLedgerView $
+        Bimap.fromList [ (verKey n, verKey n)
+                       | n <- enumCoreNodes (pbftNumNodes params)
+                       ]
+
     signKey :: CoreNodeId -> SignKeyDSIGN MockDSIGN
     signKey (CoreNodeId n) = SignKeyMockDSIGN (fromIntegral n)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/Praos.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/Praos.hs
@@ -16,6 +16,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.Mock
 import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
+import           Ouroboros.Consensus.Protocol.ExtConfig
 import           Ouroboros.Consensus.Protocol.Praos
 
 protocolInfoPraos :: NumCoreNodes
@@ -25,14 +26,13 @@ protocolInfoPraos :: NumCoreNodes
                                                     PraosMockCrypto)
 protocolInfoPraos numCoreNodes nid params =
     ProtocolInfo {
-        pInfoConfig = PraosNodeConfig {
+        pInfoConfig = ExtNodeConfig addrDist PraosNodeConfig {
             praosParams       = params
           , praosNodeId       = CoreId nid
           , praosSignKeyVRF   = signKeyVRF nid
           , praosInitialEta   = 0
           , praosInitialStake = genesisStakeDist addrDist
           , praosVerKeys      = verKeys
-          , praosExtConfig    = addrDist
           }
       , pInfoInitLedger = ExtLedgerState {
             ledgerState         = genesisSimpleLedgerState addrDist

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/PraosRule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo/Mock/PraosRule.hs
@@ -35,7 +35,6 @@ protocolInfoPraosRule numCoreNodes
             , praosInitialEta   = 0
             , praosInitialStake = genesisStakeDist addrDist
             , praosVerKeys      = verKeys
-            , praosExtConfig    = ()
             }
         , lsNodeConfigNodeId   = nid
         }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Abstract.hs
@@ -11,6 +11,7 @@ module Ouroboros.Consensus.Node.Run.Abstract
 
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
+import           Codec.Serialise (Serialise)
 import           Crypto.Random (MonadRandom)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Proxy (Proxy)
@@ -40,6 +41,8 @@ class ( ProtocolLedgerView blk
       , ApplyTx blk
       , HasTxId (GenTx blk)
       , QueryLedger blk
+        -- TODO: Remove after reconsidering rewindChainState:
+      , Serialise (HeaderHash blk)
       ) => RunNode blk where
 
   nodeForgeBlock          :: (HasNodeState (BlockProtocol blk) m, MonadRandom m)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/Byron.hs
@@ -25,6 +25,7 @@ import           Ouroboros.Consensus.Ledger.Byron
 import qualified Ouroboros.Consensus.Ledger.Byron.Auxiliary as Aux
 import           Ouroboros.Consensus.Node.Run.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.ExtConfig
 import           Ouroboros.Consensus.Protocol.PBFT
 import           Ouroboros.Consensus.Util.IOLike
 
@@ -104,7 +105,8 @@ instance RunNode ByronBlock where
   nodeDecodeHeaderHash      = const decodeByronHeaderHash
   nodeDecodeLedgerState     = const decodeByronLedgerState
   nodeDecodeChainState      = \_proxy cfg ->
-                                 let k = pbftSecurityParam $ pbftParams cfg
+                                 let k = pbftSecurityParam $
+                                           pbftParams (extNodeConfigP cfg)
                                  in decodeByronChainState k
   nodeDecodeApplyTxError    = const decodeByronApplyTxError
   nodeDecodeQuery           = decodeByronQuery

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/DualByron.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run/DualByron.hs
@@ -103,8 +103,8 @@ instance RunNode DualByronBlock where
   nodeDecodeLedgerState   = const $ decodeDualLedgerState decodeByronLedgerState
   nodeDecodeApplyTxError  = const $ decodeDualGenTxErr    decodeByronApplyTxError
   nodeDecodeChainState    = \_proxy cfg ->
-                               let k = pbftSecurityParam $
-                                         pbftParams (extNodeConfigP cfg)
+                               let k = pbftSecurityParam . pbftParams $
+                                          extNodeConfigP (extNodeConfigP cfg)
                                in decodeByronChainState k
   nodeDecodeQuery         = error "DualByron.nodeDecodeQuery"
   nodeDecodeResult        = \case {}

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -29,6 +29,7 @@ module Ouroboros.Consensus.NodeNetwork (
   , localResponderNetworkApplication
   ) where
 
+import           Codec.Serialise (Serialise)
 import           Control.Monad (void)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Proxy (Proxy (..))
@@ -144,6 +145,7 @@ protocolHandlers
        , HasTxId (GenTx blk)
        , ProtocolLedgerView blk
        , QueryLedger blk
+       , Serialise (HeaderHash blk)
        )
     => NodeArgs   m peer blk  --TODO eliminate, merge relevant into NodeKernel
     -> NodeKernel m peer blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
@@ -32,6 +32,7 @@ import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.NodeId (CoreNodeId)
 import           Ouroboros.Consensus.Protocol.Abstract as X
 import           Ouroboros.Consensus.Protocol.BFT as X
+import           Ouroboros.Consensus.Protocol.ExtConfig as X
 import           Ouroboros.Consensus.Protocol.LeaderSchedule as X
 import           Ouroboros.Consensus.Protocol.PBFT as X
 import           Ouroboros.Consensus.Protocol.Praos as X
@@ -46,7 +47,7 @@ type ProtocolMockPraos      = Praos AddrDist PraosMockCrypto
 type ProtocolLeaderSchedule = WithLeaderSchedule (Praos () PraosCryptoUnused)
 type ProtocolMockPBFT       = PBft (PBftLedgerView PBftMockCrypto) PBftMockCrypto
 type ProtocolRealPBFT       = PBft ByronConfig PBftCardanoCrypto
-type ProtocolDualPBFT       = PBft DualByronConfig PBftCardanoCrypto
+type ProtocolDualPBFT       = ExtConfig ProtocolRealPBFT (LedgerConfig ByronSpecBlock)
 
 {-------------------------------------------------------------------------------
   Abstract over the various protocols

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
@@ -43,8 +43,8 @@ import           Ouroboros.Consensus.Util
 -------------------------------------------------------------------------------}
 
 type ProtocolMockBFT        = Bft BftMockCrypto
-type ProtocolMockPraos      = Praos AddrDist PraosMockCrypto
-type ProtocolLeaderSchedule = WithLeaderSchedule (Praos () PraosCryptoUnused)
+type ProtocolMockPraos      = ExtConfig PraosMockCrypto AddrDist
+type ProtocolLeaderSchedule = WithLeaderSchedule (Praos PraosCryptoUnused)
 type ProtocolMockPBFT       = PBft (PBftLedgerView PBftMockCrypto) PBftMockCrypto
 type ProtocolRealPBFT       = PBft ByronConfig PBftCardanoCrypto
 type ProtocolDualPBFT       = ExtConfig ProtocolRealPBFT (LedgerConfig ByronSpecBlock)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol.hs
@@ -45,8 +45,8 @@ import           Ouroboros.Consensus.Util
 type ProtocolMockBFT        = Bft BftMockCrypto
 type ProtocolMockPraos      = ExtConfig PraosMockCrypto AddrDist
 type ProtocolLeaderSchedule = WithLeaderSchedule (Praos PraosCryptoUnused)
-type ProtocolMockPBFT       = PBft (PBftLedgerView PBftMockCrypto) PBftMockCrypto
-type ProtocolRealPBFT       = PBft ByronConfig PBftCardanoCrypto
+type ProtocolMockPBFT       = ExtConfig (PBft PBftMockCrypto) (PBftLedgerView PBftMockCrypto)
+type ProtocolRealPBFT       = ExtConfig (PBft PBftCardanoCrypto) ByronConfig
 type ProtocolDualPBFT       = ExtConfig ProtocolRealPBFT (LedgerConfig ByronSpecBlock)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtConfig.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtConfig.hs
@@ -6,6 +6,8 @@
 
 module Ouroboros.Consensus.Protocol.ExtConfig (
     ExtConfig
+    -- * Type families
+  , NodeConfig(..)
   ) where
 
 import           Data.Typeable

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtConfig.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtConfig.hs
@@ -38,8 +38,8 @@ instance ( OuroborosTag p
   type IsLeader      (ExtConfig p ext) = IsLeader      p
   type LedgerView    (ExtConfig p ext) = LedgerView    p
   type ValidationErr (ExtConfig p ext) = ValidationErr p
-  type CanValidate   (ExtConfig p ext) = CanValidate   p
-  type CanSelect     (ExtConfig p ext) = CanSelect     p
+  type ValidateView  (ExtConfig p ext) = ValidateView  p
+  type SelectView    (ExtConfig p ext) = SelectView    p
 
   preferCandidate       ExtNodeConfig{..} = preferCandidate       extNodeConfigP
   compareCandidates     ExtNodeConfig{..} = compareCandidates     extNodeConfigP

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtConfig.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ExtConfig.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TypeFamilies      #-}
+
+module Ouroboros.Consensus.Protocol.ExtConfig (
+    ExtConfig
+  ) where
+
+import           Data.Typeable
+import           GHC.Generics (Generic)
+
+import           Cardano.Prelude (NoUnexpectedThunks (..))
+
+import           Ouroboros.Consensus.Protocol.Abstract
+
+data ExtConfig p ext
+
+data instance NodeConfig (ExtConfig p ext) = ExtNodeConfig {
+      extNodeConfig  :: ext
+    , extNodeConfigP :: NodeConfig p
+    }
+  deriving (Generic)
+
+instance ( NoUnexpectedThunks (NodeConfig p)
+         , NoUnexpectedThunks ext
+         )
+      => NoUnexpectedThunks (NodeConfig (ExtConfig p ext)) where
+  -- Use generic instance
+
+instance ( OuroborosTag p
+         , Typeable ext
+         , NoUnexpectedThunks ext
+         ) => OuroborosTag (ExtConfig p ext) where
+  type NodeState     (ExtConfig p ext) = NodeState     p
+  type ChainState    (ExtConfig p ext) = ChainState    p
+  type IsLeader      (ExtConfig p ext) = IsLeader      p
+  type LedgerView    (ExtConfig p ext) = LedgerView    p
+  type ValidationErr (ExtConfig p ext) = ValidationErr p
+  type CanValidate   (ExtConfig p ext) = CanValidate   p
+  type CanSelect     (ExtConfig p ext) = CanSelect     p
+
+  preferCandidate       ExtNodeConfig{..} = preferCandidate       extNodeConfigP
+  compareCandidates     ExtNodeConfig{..} = compareCandidates     extNodeConfigP
+  checkIsLeader         ExtNodeConfig{..} = checkIsLeader         extNodeConfigP
+  applyChainState       ExtNodeConfig{..} = applyChainState       extNodeConfigP
+  protocolSecurityParam ExtNodeConfig{..} = protocolSecurityParam extNodeConfigP
+  protocolSlotLengths   ExtNodeConfig{..} = protocolSlotLengths   extNodeConfigP
+  rewindChainState      ExtNodeConfig{..} = rewindChainState      extNodeConfigP

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -23,7 +23,6 @@ import           Ouroboros.Network.Block (SlotNo (..))
 
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), fromCoreNodeId)
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Util (Empty)
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 
 newtype LeaderSchedule = LeaderSchedule {getLeaderSchedule :: Map SlotNo [CoreNodeId]}
@@ -53,13 +52,13 @@ data instance NodeConfig (WithLeaderSchedule p) = WLSNodeConfig
   deriving (Generic)
 
 instance OuroborosTag p => OuroborosTag (WithLeaderSchedule p) where
-  type ChainState      (WithLeaderSchedule p) = ()
-  type NodeState       (WithLeaderSchedule p) = ()
-  type LedgerView      (WithLeaderSchedule p) = ()
-  type ValidationErr   (WithLeaderSchedule p) = ()
-  type IsLeader        (WithLeaderSchedule p) = ()
-  type CanValidate     (WithLeaderSchedule p) = Empty
-  type CanSelect       (WithLeaderSchedule p) = CanSelect p
+  type ChainState    (WithLeaderSchedule p) = ()
+  type NodeState     (WithLeaderSchedule p) = ()
+  type LedgerView    (WithLeaderSchedule p) = ()
+  type ValidationErr (WithLeaderSchedule p) = ()
+  type IsLeader      (WithLeaderSchedule p) = ()
+  type ValidateView  (WithLeaderSchedule p) = ()
+  type SelectView    (WithLeaderSchedule p) = SelectView p
 
   preferCandidate       WLSNodeConfig{..} = preferCandidate       lsNodeConfigP
   compareCandidates     WLSNodeConfig{..} = compareCandidates     lsNodeConfigP

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UndecidableInstances       #-}
 
 module Ouroboros.Consensus.Protocol.ModChainSel (
     ChainSelection (..)
@@ -17,7 +16,6 @@ module Ouroboros.Consensus.Protocol.ModChainSel (
   , NodeConfig (..)
   ) where
 
-import           Data.Kind
 import           Data.Proxy (Proxy (..))
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
@@ -28,12 +26,13 @@ import           Ouroboros.Consensus.Protocol.Abstract
 
 -- | Redefine the chain selection part of 'OuroborosTag'
 class OuroborosTag p => ChainSelection p s where
-  type family CanSelect' p :: * -> Constraint
+  type family SelectView' p :: *
 
-  preferCandidate'   :: CanSelect' p hdr
-                     => proxy s -> NodeConfig p -> hdr -> hdr -> Bool
-  compareCandidates' :: CanSelect' p hdr
-                     => proxy s -> NodeConfig p -> hdr -> hdr -> Ordering
+  preferCandidate'   :: proxy s
+                     -> NodeConfig p -> SelectView' p -> SelectView' p -> Bool
+
+  compareCandidates' :: proxy s
+                     -> NodeConfig p -> SelectView' p -> SelectView' p -> Ordering
 
 data ModChainSel p s
 
@@ -41,13 +40,13 @@ newtype instance NodeConfig (ModChainSel p s) = McsNodeConfig (NodeConfig p)
   deriving (Generic)
 
 instance (Typeable p, Typeable s, ChainSelection p s) => OuroborosTag (ModChainSel p s) where
-    type NodeState       (ModChainSel p s) = NodeState       p
-    type ChainState      (ModChainSel p s) = ChainState      p
-    type IsLeader        (ModChainSel p s) = IsLeader        p
-    type LedgerView      (ModChainSel p s) = LedgerView      p
-    type ValidationErr   (ModChainSel p s) = ValidationErr   p
-    type CanValidate     (ModChainSel p s) = CanValidate     p
-    type CanSelect       (ModChainSel p s) = CanSelect'      p
+    type NodeState     (ModChainSel p s) = NodeState     p
+    type ChainState    (ModChainSel p s) = ChainState    p
+    type IsLeader      (ModChainSel p s) = IsLeader      p
+    type LedgerView    (ModChainSel p s) = LedgerView    p
+    type ValidationErr (ModChainSel p s) = ValidationErr p
+    type ValidateView  (ModChainSel p s) = ValidateView  p
+    type SelectView    (ModChainSel p s) = SelectView'   p
 
     checkIsLeader         (McsNodeConfig cfg) = checkIsLeader         cfg
     applyChainState       (McsNodeConfig cfg) = applyChainState       cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Signed.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Signed.hs
@@ -2,8 +2,12 @@
 
 -- | Support for protocols that include a signature
 module Ouroboros.Consensus.Protocol.Signed (
-    SignedHeader(..)
+    Signed
+  , SignedHeader(..)
   ) where
+
+-- | The part of the header that is signed
+type family Signed hdr :: *
 
 -- | Header that contain a signed part
 --
@@ -13,8 +17,5 @@ module Ouroboros.Consensus.Protocol.Signed (
 -- download separately). Typically of course the header will contain a hash
 -- of the body, so the signature can include the body implicitly.
 class SignedHeader hdr where
-  -- | The part of the header that is signed
-  type family Signed hdr :: *
-
   -- | Extract the part of the header that the signature should be computed over
   headerSigned :: hdr -> Signed hdr

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool/TestBlock.hs
@@ -94,14 +94,12 @@ instance Measured Block.BlockMeasure TestBlock where
 
 type instance BlockProtocol TestBlock = Bft BftMockCrypto
 
+type instance Signed (Header TestBlock) = ()
 instance SignedHeader (Header TestBlock) where
-  type Signed (Header TestBlock) = ()
   headerSigned _ = notNeeded
 
-instance HeaderSupportsBft BftMockCrypto (Header TestBlock) where
-  headerBftFields = notNeeded
-
-instance SupportedBlock TestBlock
+instance SupportedBlock TestBlock where
+  validateView = notNeeded
 
 instance UpdateLedger TestBlock where
   data LedgerState TestBlock =

--- a/ouroboros-consensus/test-consensus/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/ThreadNet/DualPBFT.hs
@@ -47,6 +47,7 @@ import           Ouroboros.Consensus.Ledger.Dual.Byron
 import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Protocol.ExtConfig
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
 import           Ouroboros.Consensus.Protocol.PBFT
 
@@ -305,7 +306,7 @@ genTx cfg st = HH.choice [
     cfg' :: ByronSpecGenesis
     st'  :: Spec.State Spec.CHAIN
 
-    cfg' = unByronSpecLedgerConfig $ dualNodeConfigAux  cfg
+    cfg' = unByronSpecLedgerConfig $ extNodeConfig cfg
     st'  = byronSpecLedgerState    $ dualLedgerStateAux st
 
     bridge :: ByronSpecBridge

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -25,6 +25,7 @@ import           Control.Tracer
 import           Ouroboros.Network.MockChain.Chain (Chain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
+import           Ouroboros.Consensus.Block (getHeader)
 import           Ouroboros.Consensus.BlockchainTime.Mock
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
@@ -138,7 +139,9 @@ prop_addBlock_multiple_threads bpt =
 
     equallyPreferable :: Chain TestBlock -> Chain TestBlock -> Bool
     equallyPreferable chain1 chain2 =
-      compareAnchoredCandidates cfg (Chain.toAnchoredFragment chain1) (Chain.toAnchoredFragment chain2) == EQ
+      compareAnchoredCandidates cfg
+        (Chain.toAnchoredFragment (getHeader <$> chain1))
+        (Chain.toAnchoredFragment (getHeader <$> chain2)) == EQ
 
     cfg :: NodeConfig (BlockProtocol TestBlock)
     cfg = singleNodeTestConfig

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -33,7 +33,6 @@ import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
 openDB :: forall m blk. (
             IOLike m
           , ProtocolLedgerView blk
-          , CanSelect (BlockProtocol blk) blk
           , ModelSupportsBlock blk
           )
        => NodeConfig (BlockProtocol blk)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
@@ -16,6 +16,7 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (HasHeader (..), genesisPoint)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Abstract
 import qualified Ouroboros.Consensus.Util.AnchoredFragment as AF
 
@@ -70,7 +71,7 @@ prop_alwaysPickPreferredChain bt p =
     model   = addBlocks blocks
     current = M.currentChain model
 
-    curFragment = Chain.toAnchoredFragment current
+    curFragment = Chain.toAnchoredFragment (getHeader <$> current)
 
     SecurityParam k = protocolSecurityParam singleNodeTestConfig
 
@@ -78,7 +79,7 @@ prop_alwaysPickPreferredChain bt p =
         AF.preferAnchoredCandidate singleNodeTestConfig curFragment candFragment &&
         AF.forksAtMostKBlocks k curFragment candFragment
       where
-        candFragment = Chain.toAnchoredFragment candidate
+        candFragment = Chain.toAnchoredFragment (getHeader <$> candidate)
 
 -- TODO add properties about forks too
 prop_between_currentChain :: BlockTree -> Property


### PR DESCRIPTION
In 6a3cd479c88eeaa85364ef04ea96744b1ffef08d we described the need for subtyping, and the motivation for the elimination of the `ExtConfig` combinator. However, this led to some nastiness elsewhere, and the fact that we couldn't use this combinator never sat very well with me; it suggested our protocol combinators aren't as powerful as one might hope.

This PR makes a subtle change to `OuroborosTag` that avoids all of these problems. As a consequence, we can reintroduce the `ExtConfig` combinator, use it throughout, and remove the hacks that its absence required, most notably in the `DualBlock` combinator, which is now entirely independent of the underlying protocol.