### PR TITLE
on demand starting of mux mini-protocols & handler threads

### DIFF
--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -49,6 +49,7 @@ library
                        Network.Mux.Codec
                        Network.Mux.Egress
                        Network.Mux.Ingress
+                       Network.Mux.JobPool
                        Network.Mux.Time
                        Network.Mux.Types
                        Network.Mux.Trace
@@ -70,6 +71,7 @@ test-suite test-network-mux
                        Network.Mux.Codec
                        Network.Mux.Egress
                        Network.Mux.Ingress
+                       Network.Mux.JobPool
                        Network.Mux.Time
                        Network.Mux.Types
                        Network.Mux.Trace

--- a/network-mux/src/Network/Mux.hs
+++ b/network-mux/src/Network/Mux.hs
@@ -34,16 +34,17 @@ module Network.Mux (
     , WithMuxBearer (..)
     ) where
 
+import           Data.Int (Int64)
+import qualified Data.ByteString.Lazy as BL
+import           Data.Array
+import           Text.Printf
+
 import           Control.Monad
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
 import           Control.Tracer
-import           Data.Array
-import qualified Data.ByteString.Lazy as BL
-import           Data.Int (Int64)
 import           GHC.Stack
-import           Text.Printf
 
 import           Network.Mux.Channel
 import           Network.Mux.Egress  as Egress

--- a/network-mux/src/Network/Mux.hs
+++ b/network-mux/src/Network/Mux.hs
@@ -171,7 +171,7 @@ muxStart tracer (MuxApplication ptcls) bearer = do
                  ])
       where
         minpix = 0
-        maxpix = length ptcls' - 1
+        maxpix = fromIntegral (length ptcls' - 1)
 
         codes   = [ miniProtocolNum ptcl | (ptcl, _, _) <- ptcls' ]
         mincode = minimum codes

--- a/network-mux/src/Network/Mux.hs
+++ b/network-mux/src/Network/Mux.hs
@@ -314,6 +314,7 @@ monitor tracer jobpool
                        ++ "instance is initiator only")
                    callStack
 
+    checkNonEmptyBuf :: MiniProtocolDispatchInfo m -> STM m ()
     checkNonEmptyBuf (MiniProtocolDispatchInfo q _) = do
       buf <- readTVar q
       check (not (BL.null buf))

--- a/network-mux/src/Network/Mux/Egress.hs
+++ b/network-mux/src/Network/Mux/Egress.hs
@@ -141,7 +141,7 @@ newtype Wanton m = Wanton { want :: StrictTVar m BL.ByteString }
 mux :: MonadSTM m
     => StrictTVar m Int
     -> MuxState m
-    -> m ()
+    -> m void
 mux cnt muxstate@MuxState{egressQueue} =
     forever $ do
       TLSRDemand mpc md d <- atomically $ readTBQueue egressQueue

--- a/network-mux/src/Network/Mux/Ingress.hs
+++ b/network-mux/src/Network/Mux/Ingress.hs
@@ -102,8 +102,9 @@ data MiniProtocolDispatchInfo m =
 -- | demux runs as a single separate thread and reads complete 'MuxSDU's from
 -- the underlying Mux Bearer and forwards it to the matching ingress queue.
 demux :: (MonadSTM m, MonadThrow m, MonadThrow (STM m), HasCallStack)
-      => DemuxState m -> m ()
-demux DemuxState{dispatchTable, bearer} = forever $ do
+      => DemuxState m -> m void
+demux DemuxState{dispatchTable, bearer} =
+  forever $ do
     (sdu, _) <- Network.Mux.Types.read bearer
     -- say $ printf "demuxing sdu on mid %s mode %s lenght %d " (show $ msId sdu) (show $ msMode sdu)
     --             (BL.length $ msBlob sdu)

--- a/network-mux/src/Network/Mux/Ingress.hs
+++ b/network-mux/src/Network/Mux/Ingress.hs
@@ -93,8 +93,6 @@ data MiniProtocolDispatch m =
        !(Array (MiniProtocolIx, MiniProtocolMode)
                (MiniProtocolDispatchInfo m))
 
-type MiniProtocolIx = Int
-
 data MiniProtocolDispatchInfo m =
      MiniProtocolDispatchInfo
        !(StrictTVar m BL.ByteString)

--- a/network-mux/src/Network/Mux/JobPool.hs
+++ b/network-mux/src/Network/Mux/JobPool.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+
+module Network.Mux.JobPool (
+    JobPool,
+    Job(..),
+    withJobPool,
+    forkJob,
+    readSize,
+    collect
+  ) where
+
+import qualified Data.Map.Strict as Map
+import           Data.Map.Strict (Map)
+import           Data.Proxy (Proxy(..))
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadFork (MonadThread(..))
+import           Control.Monad.Class.MonadThrow
+import           Control.Exception (SomeException, SomeAsyncException(..))
+
+
+data JobPool m a = JobPool {
+       jobsVar         :: !(TVar m (Map (ThreadId m) (Async m ()))),
+       completionQueue :: !(TQueue m a)
+     }
+
+data Job m a = Job (m a) (SomeException -> a)
+
+withJobPool :: forall m a b.
+               (MonadAsync m, MonadThrow m)
+            => (JobPool m a -> m b) -> m b
+withJobPool =
+    bracket create close
+  where
+    create :: m (JobPool m a)
+    create =
+      atomically $
+        JobPool <$> newTVar Map.empty
+                <*> newTQueue
+
+    close :: JobPool m a -> m ()
+    close JobPool{jobsVar} = do
+      jobs <- atomically (readTVar jobsVar)
+      mapM_ cancel jobs
+
+forkJob :: forall m a.
+           (MonadAsync m, MonadMask m)
+        => JobPool m a
+        -> Job     m a
+        -> m ()
+forkJob JobPool{jobsVar, completionQueue} (Job action handler) =
+    mask $ \restore -> do
+      jobAsync <- async $ do
+        res <- handleJust notAsyncExceptions (return . handler) $
+                 restore action
+        tid <- myThreadId
+        atomically $ do
+          writeTQueue completionQueue res
+          modifyTVar' jobsVar (Map.delete tid)
+
+      let !tid = asyncThreadId (Proxy :: Proxy m) jobAsync
+      atomically $ modifyTVar' jobsVar (Map.insert tid jobAsync)
+  where
+    notAsyncExceptions :: SomeException -> Maybe SomeException
+    notAsyncExceptions e
+      | Just (SomeAsyncException _) <- fromException e
+                  = Nothing
+      | otherwise = Just e
+
+readSize :: MonadSTM m => JobPool m a -> STM m Int
+readSize JobPool{jobsVar} = Map.size <$> readTVar jobsVar
+
+collect :: MonadSTM m => JobPool m a -> STM m a
+collect JobPool{completionQueue} = readTQueue completionQueue
+

--- a/network-mux/src/Network/Mux/Trace.hs
+++ b/network-mux/src/Network/Mux/Trace.hs
@@ -49,9 +49,9 @@ data MuxErrorType = MuxUnknownMiniProtocol
                   | MuxIngressQueueOverRun
                   -- ^ thrown by 'demux' when violating 'maximumIngressQueue'
                   -- byte limit.
-                  | MuxControlProtocolError
-                  -- ^ thrown by 'muxControl' (mux control thread), when
-                  -- received a 'Muxcontrol' message on a mature 'MuxBearer'.
+                  | MuxInitiatorOnly
+                  -- ^ thrown when data arrives on a responder channel when the
+                  -- mux was set up as an 'InitiatorApp'.
                   |  MuxTooLargeMessage
                   -- ^ thrown by 'muxChannel' when violationg
                   -- 'maximumMessageSize' byte limit.

--- a/network-mux/src/Network/Mux/Trace.hs
+++ b/network-mux/src/Network/Mux/Trace.hs
@@ -131,8 +131,8 @@ data MuxTrace =
     | MuxTraceSendStart MuxSDU
     | MuxTraceSendEnd
     | MuxTraceState MuxBearerState
-    | MuxTraceCleanExit String
-    | MuxTraceExceptionExit SomeException String
+    | MuxTraceCleanExit MiniProtocolNum MiniProtocolMode
+    | MuxTraceExceptionExit MiniProtocolNum MiniProtocolMode SomeException
     | MuxTraceChannelRecvStart MiniProtocolNum
     | MuxTraceChannelRecvEnd MiniProtocolNum BL.ByteString
     | MuxTraceChannelSendStart MiniProtocolNum BL.ByteString
@@ -167,8 +167,8 @@ instance Show MuxTrace where
         (BL.length $ msBlob sdu)
     show MuxTraceSendEnd = printf "Bearer Send End"
     show (MuxTraceState new) = printf "State: %s" (show new)
-    show (MuxTraceCleanExit mp) = printf "Miniprotocol %s triggered clean exit" mp
-    show (MuxTraceExceptionExit e mp) = printf "Miniprotocol %s triggered exit with %s" mp (show e)
+    show (MuxTraceCleanExit mid dir) = printf "Miniprotocol %s %s terminated cleanly" (show mid) (show dir)
+    show (MuxTraceExceptionExit mid dir e) = printf "Miniprotocol %s %s terminated with exception %s" (show mid) (show dir) (show e)
     show (MuxTraceChannelRecvStart mid) = printf "Channel Receive Start on %s" (show mid)
     show (MuxTraceChannelRecvEnd mid blob) = printf "Channel Receive End on %s %d" (show mid)
         (BL.length blob)

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -16,6 +16,7 @@ module Network.Mux.Types (
     , MuxMiniProtocol (..)
     , RunMiniProtocol (..)
 
+    , MiniProtocolIx
     , MuxBearer (..)
     , muxBearerAsControlChannel
     , MuxSDU (..)
@@ -150,6 +151,10 @@ data RunMiniProtocol (appType :: AppType) m a b where
 --
 -- Mux internal types
 --
+
+-- | The index of a protocol in a MuxApplication, used for array indicies
+newtype MiniProtocolIx = MiniProtocolIx Int
+  deriving (Eq, Ord, Num, Enum, Ix, Show)
 
 data MiniProtocolMode = ModeInitiator | ModeResponder
   deriving (Eq, Ord, Ix, Enum, Bounded, Show)

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -138,8 +138,8 @@ data RunMiniProtocol (appType :: AppType) m a b where
   ResponderProtocolOnly
     -- Responder application; similarly to the @'MuxInitiatorApplication'@ but it
     -- will be run using @'ModeResponder'@.
-    :: (Channel m -> m a)
-    -> RunMiniProtocol ResponderApp m Void a
+    :: (Channel m -> m b)
+    -> RunMiniProtocol ResponderApp m Void b
 
   InitiatorAndResponderProtocol
     -- Initiator and server applications.

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -354,7 +354,7 @@ networkErrorPolicies = ErrorPolicies
                       MuxUnknownMiniProtocol  -> Just ourBug
                       MuxDecodeError          -> Just ourBug
                       MuxIngressQueueOverRun  -> Just ourBug
-                      MuxControlProtocolError -> Just ourBug
+                      MuxInitiatorOnly        -> Just ourBug
                       MuxTooLargeMessage      -> Just ourBug
 
                       -- in case of bearer closed / or IOException we suspend

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -442,7 +442,7 @@ remoteNetworkErrorPolicy = ErrorPolicies {
                         MuxUnknownMiniProtocol  -> Just theyBuggyOrEvil
                         MuxDecodeError          -> Just theyBuggyOrEvil
                         MuxIngressQueueOverRun  -> Just theyBuggyOrEvil
-                        MuxControlProtocolError -> Just theyBuggyOrEvil
+                        MuxInitiatorOnly        -> Just theyBuggyOrEvil
                         MuxTooLargeMessage      -> Just theyBuggyOrEvil
 
                         -- in case of bearer closed / or IOException we suspend


### PR DESCRIPTION
Work in progress on adjusting the mux to support starting mux mini-protocols on demand.

This is based on the ideas in #1349 but done on top of more recent mux refactoring & API changes, and taking a slightly different implementation & API approach. In particular we use fewer threads, by having the threads themselves start on demand, rather than having all threads start at the begning and blocking until they are needed.