### PR TITLE
Improve support for monad stacks

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
@@ -1,12 +1,14 @@
-{-# LANGUAGE DefaultSignatures         #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE QuantifiedConstraints     #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TypeApplications          #-}
-{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE DefaultSignatures     #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
 
 module Control.Monad.Class.MonadAsync
   ( MonadAsync (..)
+  , MonadAsyncSTM (..)
   , AsyncCancelled(..)
   , ExceptionInLinkedThread(..)
   , link
@@ -21,118 +23,38 @@ import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow
 
-import           Control.Monad (void)
+import           Control.Concurrent.Async (AsyncCancelled (..))
+import qualified Control.Concurrent.Async as Async
 import           Control.Exception (SomeException)
 import qualified Control.Exception as E
-import qualified Control.Concurrent.Async as Async
-import           Control.Concurrent.Async (AsyncCancelled(..))
+import           Control.Monad (void)
+import           Control.Monad.Reader
+import qualified Control.Monad.STM as STM
 import           Data.Proxy
 
-class ( MonadSTM m
-      , MonadThread m
-      , Functor (Async m)
-      ) => MonadAsync m where
+class (Functor async, MonadSTMTx stm) => MonadAsyncSTM async stm where
+  {-# MINIMAL waitCatchSTM, pollSTM #-}
 
-  {-# MINIMAL async, asyncThreadId, cancel, cancelWith, waitCatchSTM, pollSTM #-}
+  waitSTM      :: async a -> stm a
+  pollSTM      :: async a -> stm (Maybe (Either SomeException a))
+  waitCatchSTM :: async a -> stm (Either SomeException a)
 
-  -- | An asynchronous action
-  type Async m :: * -> *
+  default waitSTM :: MonadThrow stm => async a -> stm a
+  waitSTM action = waitCatchSTM action >>= either throwM return
 
-  async                 :: m a -> m (Async m a)
-  asyncThreadId         :: proxy m -> Async m a -> ThreadId m
-  withAsync             :: m a -> (Async m a -> m b) -> m b
-
-  wait                  :: Async m a -> m a
-  poll                  :: Async m a -> m (Maybe (Either SomeException a))
-  waitCatch             :: Async m a -> m (Either SomeException a)
-  cancel                :: Async m a -> m ()
-  cancelWith            :: Exception e => Async m a -> e -> m ()
-  uninterruptibleCancel :: Async m a -> m ()
-
-  waitSTM               :: Async m a -> STM m a
-  pollSTM               :: Async m a -> STM m (Maybe (Either SomeException a))
-  waitCatchSTM          :: Async m a -> STM m (Either SomeException a)
-
-  waitAny               :: [Async m a] -> m (Async m a, a)
-  waitAnyCatch          :: [Async m a] -> m (Async m a, Either SomeException a)
-  waitAnyCancel         :: [Async m a] -> m (Async m a, a)
-  waitAnyCatchCancel    :: [Async m a] -> m (Async m a, Either SomeException a)
-  waitEither            :: Async m a -> Async m b -> m (Either a b)
-
-  -- | Note, IO-based implementations should override the default
-  -- implementation. See the @async@ package implementation and comments.
-  -- <http://hackage.haskell.org/package/async-2.2.1/docs/src/Control.Concurrent.Async.html#waitEitherCatch>
-  waitEitherCatch       :: Async m a -> Async m b -> m (Either (Either SomeException a)
-                                                               (Either SomeException b))
-  waitEitherCancel      :: Async m a -> Async m b -> m (Either a b)
-  waitEitherCatchCancel :: Async m a -> Async m b -> m (Either (Either SomeException a)
-                                                               (Either SomeException b))
-  waitEither_           :: Async m a -> Async m b -> m ()
-  waitBoth              :: Async m a -> Async m b -> m (a, b)
-
-  waitAnySTM            :: [Async m a] -> STM m (Async m a, a)
-  waitAnyCatchSTM       :: [Async m a] -> STM m (Async m a, Either SomeException a)
-  waitEitherSTM         :: Async m a -> Async m b -> STM m (Either a b)
-  waitEitherSTM_        :: Async m a -> Async m b -> STM m ()
-  waitEitherCatchSTM    :: Async m a -> Async m b
-                        -> STM m (Either (Either SomeException a)
+  waitAnySTM            :: [async a] -> stm (async a, a)
+  waitAnyCatchSTM       :: [async a] -> stm (async a, Either SomeException a)
+  waitEitherSTM         :: async a -> async b -> stm (Either a b)
+  waitEitherSTM_        :: async a -> async b -> stm ()
+  waitEitherCatchSTM    :: async a -> async b
+                        -> stm (Either (Either SomeException a)
                                          (Either SomeException b))
-  waitBothSTM           :: Async m a -> Async m b -> STM m (a, b)
+  waitBothSTM           :: async a -> async b -> stm (a, b)
 
-  race                  :: m a -> m b -> m (Either a b)
-  race_                 :: m a -> m b -> m ()
-  concurrently          :: m a -> m b -> m (a,b)
-
-  -- default implementations
-  default withAsync     :: MonadMask m => m a -> (Async m a -> m b) -> m b
-  default uninterruptibleCancel
-                        :: MonadMask m => Async m a -> m ()
-  default waitSTM       :: MonadThrow (STM m) => Async m a -> STM m a
-  default waitAnyCancel         :: MonadThrow m => [Async m a] -> m (Async m a, a)
-  default waitAnyCatchCancel    :: MonadThrow m => [Async m a]
-                                -> m (Async m a, Either SomeException a)
-  default waitEitherCancel      :: MonadThrow m => Async m a -> Async m b
-                                -> m (Either a b)
-  default waitEitherCatchCancel :: MonadThrow m => Async m a -> Async m b
-                                -> m (Either (Either SomeException a)
-                                             (Either SomeException b))
-
-  default waitAnySTM     :: MonadThrow (STM m) => [Async m a] -> STM m (Async m a, a)
-  default waitEitherSTM  :: MonadThrow (STM m) => Async m a -> Async m b -> STM m (Either a b)
-  default waitEitherSTM_ :: MonadThrow (STM m) => Async m a -> Async m b -> STM m ()
-  default waitBothSTM    :: MonadThrow (STM m) => Async m a -> Async m b -> STM m (a, b)
-
-
-  withAsync action inner = mask $ \restore -> do
-                             a <- async (restore action)
-                             restore (inner a)
-                               `finally` uninterruptibleCancel a
-
-  wait      = atomically . waitSTM
-  poll      = atomically . pollSTM
-  waitCatch = atomically . waitCatchSTM
-
-  uninterruptibleCancel      = uninterruptibleMask_ . cancel
-  waitSTM action             = waitCatchSTM action >>= either throwM return
-
-  waitAny                    = atomically . waitAnySTM
-  waitAnyCatch               = atomically . waitAnyCatchSTM
-  waitEither      left right = atomically (waitEitherSTM left right)
-  waitEither_     left right = atomically (waitEitherSTM_ left right)
-  waitEitherCatch left right = atomically (waitEitherCatchSTM left right)
-  waitBoth        left right = atomically (waitBothSTM left right)
-
-  waitAnyCancel asyncs =
-    waitAny asyncs `finally` mapM_ cancel asyncs
-
-  waitAnyCatchCancel asyncs =
-    waitAnyCatch asyncs `finally` mapM_ cancel asyncs
-
-  waitEitherCancel left right =
-    waitEither left right `finally` (cancel left >> cancel right)
-
-  waitEitherCatchCancel left right =
-    waitEitherCatch left right `finally` (cancel left >> cancel right)
+  default waitAnySTM     :: MonadThrow stm => [async a] -> stm (async a, a)
+  default waitEitherSTM  :: MonadThrow stm => async a -> async b -> stm (Either a b)
+  default waitEitherSTM_ :: MonadThrow stm => async a -> async b -> stm ()
+  default waitBothSTM    :: MonadThrow stm => async a -> async b -> stm (a, b)
 
   waitAnySTM as =
     foldr orElse retry $
@@ -164,6 +86,91 @@ class ( MonadSTM m
       b <- waitSTM right
       return (a,b)
 
+class ( MonadSTM m
+      , MonadThread m
+      , MonadAsyncSTM (Async m) (STM m)
+      ) => MonadAsync m where
+
+  {-# MINIMAL async, asyncThreadId, cancel, cancelWith #-}
+
+  -- | An asynchronous action
+  type Async m :: * -> *
+
+  async                 :: m a -> m (Async m a)
+  asyncThreadId         :: Proxy m -> Async m a -> ThreadId m
+  withAsync             :: m a -> (Async m a -> m b) -> m b
+
+  wait                  :: Async m a -> m a
+  poll                  :: Async m a -> m (Maybe (Either SomeException a))
+  waitCatch             :: Async m a -> m (Either SomeException a)
+  cancel                :: Async m a -> m ()
+  cancelWith            :: Exception e => Async m a -> e -> m ()
+  uninterruptibleCancel :: Async m a -> m ()
+
+  waitAny               :: [Async m a] -> m (Async m a, a)
+  waitAnyCatch          :: [Async m a] -> m (Async m a, Either SomeException a)
+  waitAnyCancel         :: [Async m a] -> m (Async m a, a)
+  waitAnyCatchCancel    :: [Async m a] -> m (Async m a, Either SomeException a)
+  waitEither            :: Async m a -> Async m b -> m (Either a b)
+
+  -- | Note, IO-based implementations should override the default
+  -- implementation. See the @async@ package implementation and comments.
+  -- <http://hackage.haskell.org/package/async-2.2.1/docs/src/Control.Concurrent.Async.html#waitEitherCatch>
+  waitEitherCatch       :: Async m a -> Async m b -> m (Either (Either SomeException a)
+                                                               (Either SomeException b))
+  waitEitherCancel      :: Async m a -> Async m b -> m (Either a b)
+  waitEitherCatchCancel :: Async m a -> Async m b -> m (Either (Either SomeException a)
+                                                               (Either SomeException b))
+  waitEither_           :: Async m a -> Async m b -> m ()
+  waitBoth              :: Async m a -> Async m b -> m (a, b)
+
+  race                  :: m a -> m b -> m (Either a b)
+  race_                 :: m a -> m b -> m ()
+  concurrently          :: m a -> m b -> m (a,b)
+
+  -- default implementations
+  default withAsync     :: MonadMask m => m a -> (Async m a -> m b) -> m b
+  default uninterruptibleCancel
+                        :: MonadMask m => Async m a -> m ()
+  default waitAnyCancel         :: MonadThrow m => [Async m a] -> m (Async m a, a)
+  default waitAnyCatchCancel    :: MonadThrow m => [Async m a]
+                                -> m (Async m a, Either SomeException a)
+  default waitEitherCancel      :: MonadThrow m => Async m a -> Async m b
+                                -> m (Either a b)
+  default waitEitherCatchCancel :: MonadThrow m => Async m a -> Async m b
+                                -> m (Either (Either SomeException a)
+                                             (Either SomeException b))
+
+  withAsync action inner = mask $ \restore -> do
+                             a <- async (restore action)
+                             restore (inner a)
+                               `finally` uninterruptibleCancel a
+
+  wait      = atomically . waitSTM
+  poll      = atomically . pollSTM
+  waitCatch = atomically . waitCatchSTM
+
+  uninterruptibleCancel      = uninterruptibleMask_ . cancel
+
+  waitAny                    = atomically . waitAnySTM
+  waitAnyCatch               = atomically . waitAnyCatchSTM
+  waitEither      left right = atomically (waitEitherSTM left right)
+  waitEither_     left right = atomically (waitEitherSTM_ left right)
+  waitEitherCatch left right = atomically (waitEitherCatchSTM left right)
+  waitBoth        left right = atomically (waitBothSTM left right)
+
+  waitAnyCancel asyncs =
+    waitAny asyncs `finally` mapM_ cancel asyncs
+
+  waitAnyCatchCancel asyncs =
+    waitAnyCatch asyncs `finally` mapM_ cancel asyncs
+
+  waitEitherCancel left right =
+    waitEither left right `finally` (cancel left >> cancel right)
+
+  waitEitherCatchCancel left right =
+    waitEitherCatch left right `finally` (cancel left >> cancel right)
+
   race            left right = withAsync left  $ \a ->
                                withAsync right $ \b ->
                                  waitEither a b
@@ -180,6 +187,17 @@ class ( MonadSTM m
 -- Instance for IO uses the existing async library implementations
 --
 
+instance MonadAsyncSTM Async.Async STM.STM where
+  waitSTM            = Async.waitSTM
+  pollSTM            = Async.pollSTM
+  waitCatchSTM       = Async.waitCatchSTM
+  waitAnySTM         = Async.waitAnySTM
+  waitAnyCatchSTM    = Async.waitAnyCatchSTM
+  waitEitherSTM      = Async.waitEitherSTM
+  waitEitherSTM_     = Async.waitEitherSTM_
+  waitEitherCatchSTM = Async.waitEitherCatchSTM
+  waitBothSTM        = Async.waitBothSTM
+
 instance MonadAsync IO where
 
   type Async IO = Async.Async
@@ -195,10 +213,6 @@ instance MonadAsync IO where
   cancelWith            = Async.cancelWith
   uninterruptibleCancel = Async.uninterruptibleCancel
 
-  waitSTM               = Async.waitSTM
-  pollSTM               = Async.pollSTM
-  waitCatchSTM          = Async.waitCatchSTM
-
   waitAny               = Async.waitAny
   waitAnyCatch          = Async.waitAnyCatch
   waitAnyCancel         = Async.waitAnyCancel
@@ -210,16 +224,45 @@ instance MonadAsync IO where
   waitEither_           = Async.waitEither_
   waitBoth              = Async.waitBoth
 
-  waitAnySTM            = Async.waitAnySTM
-  waitAnyCatchSTM       = Async.waitAnyCatchSTM
-  waitEitherSTM         = Async.waitEitherSTM
-  waitEitherSTM_        = Async.waitEitherSTM_
-  waitEitherCatchSTM    = Async.waitEitherCatchSTM
-  waitBothSTM           = Async.waitBothSTM
-
   race                  = Async.race
   race_                 = Async.race_
   concurrently          = Async.concurrently
+
+--
+-- Lift to ReaderT
+--
+
+(.:) :: (c -> d) -> (a -> b -> c) -> (a -> b -> d)
+(f .: g) x y = f (g x y)
+
+instance MonadAsync m => MonadAsync (ReaderT r m) where
+  type Async (ReaderT r m) = Async m
+
+  asyncThreadId _ = asyncThreadId (Proxy @m)
+
+  async     (ReaderT ma)   = ReaderT $ \r -> async (ma r)
+  withAsync (ReaderT ma) f = ReaderT $ \r -> withAsync (ma r) $ \a -> runReaderT (f a) r
+
+  race         (ReaderT ma) (ReaderT mb) = ReaderT $ \r -> race         (ma r) (mb r)
+  race_        (ReaderT ma) (ReaderT mb) = ReaderT $ \r -> race_        (ma r) (mb r)
+  concurrently (ReaderT ma) (ReaderT mb) = ReaderT $ \r -> concurrently (ma r) (mb r)
+
+  wait                  = lift .  wait
+  poll                  = lift .  poll
+  waitCatch             = lift .  waitCatch
+  cancel                = lift .  cancel
+  uninterruptibleCancel = lift .  uninterruptibleCancel
+  cancelWith            = lift .: cancelWith
+  waitAny               = lift .  waitAny
+  waitAnyCatch          = lift .  waitAnyCatch
+  waitAnyCancel         = lift .  waitAnyCancel
+  waitAnyCatchCancel    = lift .  waitAnyCatchCancel
+  waitEither            = lift .: waitEither
+  waitEitherCatch       = lift .: waitEitherCatch
+  waitEitherCancel      = lift .: waitEitherCancel
+  waitEitherCatchCancel = lift .: waitEitherCatchCancel
+  waitEither_           = lift .: waitEither_
+  waitBoth              = lift .: waitBoth
 
 --
 -- Linking
@@ -275,7 +318,7 @@ linkToOnly tid shouldThrow a = do
       r <- waitCatch a
       case r of
         Left e | shouldThrow e -> throwTo tid (exceptionInLinkedThread e)
-        _otherwise -> return ()
+        _otherwise             -> return ()
   where
     exceptionInLinkedThread :: SomeException -> ExceptionInLinkedThread
     exceptionInLinkedThread =

--- a/io-sim-classes/src/Control/Monad/Class/MonadST.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadST.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE RankNTypes #-}
 module Control.Monad.Class.MonadST where
 
-import Control.Monad.ST (ST, stToIO)
+import           Control.Monad.Reader
+import           Control.Monad.ST (ST, stToIO)
 
 
 -- | This class is for abstracting over 'stToIO' which allows running 'ST'
@@ -29,3 +30,5 @@ instance MonadST IO where
 instance MonadST (ST s) where
   withLiftST = \f -> f id
 
+instance MonadST m => MonadST (ReaderT r m) where
+  withLiftST f = withLiftST $ \g -> f (lift . g)

--- a/io-sim-classes/src/Control/Monad/Class/MonadTime.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadTime.hs
@@ -8,10 +8,10 @@ module Control.Monad.Class.MonadTime (
   , UTCTime
   ) where
 
-import           Data.Word (Word64)
+import           Control.Monad.Reader
 import           Data.Time.Clock (DiffTime, UTCTime)
 import qualified Data.Time.Clock as Time
-
+import           Data.Word (Word64)
 
 -- | A point in time in a monotonic clock.
 --
@@ -59,3 +59,10 @@ instance MonadTime IO where
 foreign import ccall unsafe "getMonotonicNSec"
     getMonotonicNSec :: IO Word64
 
+--
+-- Instance for ReaderT
+--
+
+instance MonadTime m => MonadTime (ReaderT r m) where
+  getMonotonicTime = lift getMonotonicTime
+  getCurrentTime   = lift getCurrentTime

--- a/io-sim/test/Test/STM.hs
+++ b/io-sim/test/Test/STM.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE TypeOperators              #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
@@ -22,16 +22,16 @@
 --
 module Test.STM where
 
-import           Prelude hiding (exp)
-import           Data.Type.Equality
-import           Data.Maybe (fromMaybe, maybeToList)
-import qualified Data.Map.Strict as Map
 import           Data.Map.Strict (Map)
-import qualified Data.Set as Set
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe, maybeToList)
 import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Type.Equality
+import           Prelude hiding (exp)
 
-import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadSTM as STM
+import           Control.Monad.Class.MonadThrow
 
 import           Test.QuickCheck
 
@@ -490,12 +490,12 @@ snapshotExecValue (ExecValInt x)   = return (ImmValInt x)
 snapshotExecValue (ExecValVar v _) = fmap ImmValVar
                                           (snapshotExecValue =<< readTVar v)
 
-execAtomically :: (MonadSTM m, MonadThrow (STM m), MonadCatch m)
+execAtomically :: forall m t. (MonadSTM m, MonadThrow (STM m), MonadCatch m)
                => Term t -> m TxResult
 execAtomically t =
     toTxResult <$> try (atomically action')
   where
-    action  = snapshotExecValue =<< execTerm mempty t
+    action  = snapshotExecValue =<< execTerm (mempty :: ExecEnv m) t
 
     action' = fmap Just action `orElse` return Nothing
     -- We want to observe if the transaction would block. If we trust the STM
@@ -534,7 +534,7 @@ data GenEnv = GenEnv {
        envNames    :: TyTrie NameId,
 
        -- | For managing the fresh name supply
-       envNextName :: NameId 
+       envNextName :: NameId
      }
 
 data TyTrie a =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -494,9 +494,12 @@ forkBlockProduction maxBlockSizeOverride IS{..} BlockProduction{..} =
         noOverride       = nodeMaxBlockSize ledger - blockEncOverhead
 
     runProtocol :: StrictTVar m PRNG -> ProtocolM blk m a -> STM m a
-    runProtocol varDRG = simOuroborosStateT varState
-                       $ simChaChaT varDRG
-                       $ id
+    runProtocol varDRG = runSim sim
+      where
+        sim :: Sim (NodeStateT (BlockProtocol blk) (ChaChaT (STM m))) m
+        sim = simOuroborosStateT varState
+            $ simChaChaT         varDRG
+            $ simId
 
 -- | State of the pseudo-random number generator
 newtype PRNG = PRNG ChaChaDRG

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -31,6 +31,7 @@ module Ouroboros.Consensus.Util.IOLike (
   , diffTime
     -- *** MonadDelay
   , MonadTimer(..)
+  , MonadDelay(..)
     -- *** Cardano prelude
   , NoUnexpectedThunks(..)
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Reader.hs
@@ -378,14 +378,14 @@ instructionHelper registry varReader blockComponent encodeHeader fromMaybeSTM CD
 
 -- | 'readerInstruction' for when the reader is in the 'ReaderInMem' state.
 instructionSTM
-  :: forall m blk. (IOLike m, HasHeader (Header blk))
+  :: forall stm blk. (MonadSTMTx stm, HasHeader (Header blk))
   => ReaderRollState blk
      -- ^ The current 'ReaderRollState' of the reader
   -> AnchoredFragment (Header blk)
      -- ^ The current chain fragment
-  -> (ReaderRollState blk -> STM m ())
+  -> (ReaderRollState blk -> stm ())
      -- ^ How to save the updated 'ReaderRollState'
-  -> STM m (Maybe (ChainUpdate blk (Header blk)))
+  -> stm (Maybe (ChainUpdate blk (Header blk)))
 instructionSTM rollState curChain saveRollState =
     assert (invariant curChain) $ case rollState of
       RollForwardFrom pt ->

--- a/ouroboros-consensus/src/Ouroboros/Storage/Util/ErrorHandling.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/Util/ErrorHandling.hs
@@ -49,7 +49,6 @@ import           Data.Void
 
 import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..))
 
-import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadThrow (MonadCatch)
 import qualified Control.Monad.Class.MonadThrow as C
 
@@ -185,7 +184,7 @@ data ThrowCantCatch e m = ThrowCantCatch {
 throwCantCatch :: ErrorHandling e m -> ThrowCantCatch e m
 throwCantCatch ErrorHandling{..} = ThrowCantCatch throwError
 
-throwSTM :: (C.MonadThrow (STM m), Exception e) => ThrowCantCatch e (STM m)
+throwSTM :: (C.MonadThrow m, Exception e) => ThrowCantCatch e m
 throwSTM = ThrowCantCatch $ C.throwM
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/test-consensus/Test/ThreadNet/Network.hs
@@ -450,7 +450,8 @@ runThreadNetwork ThreadNetworkArgs
         varDRG <- uncheckedNewTVarM =<< produceDRG
         txs <- atomically $ do
           ledger <- ledgerState <$> getExtLedger
-          simChaChaT varDRG id $ testGenTxs numCoreNodes curSlotNo cfg ledger
+          runSim (simChaChaT varDRG simId) $
+            testGenTxs numCoreNodes curSlotNo cfg ledger
         void $ addTxs mempool txs
 
     forkEbbProducer :: HasCallStack
@@ -581,7 +582,8 @@ runThreadNetwork ThreadNetworkArgs
       let blockProduction :: BlockProduction m blk
           blockProduction = BlockProduction {
               produceBlock = nodeForgeBlock pInfoConfig
-            , produceDRG   = atomically $ simChaChaT varRNG id $ drgNew
+            , produceDRG   = atomically $
+                               runSim (simChaChaT varRNG simId) drgNew
             }
 
       let NodeInfo

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
@@ -7,7 +7,7 @@ import           Control.Monad.State (StateT)
 
 import           Ouroboros.Consensus.Util ((.:))
 import           Ouroboros.Consensus.Util.IOLike
-import           Ouroboros.Consensus.Util.STM (simStateT)
+import           Ouroboros.Consensus.Util.STM
 
 import           Ouroboros.Storage.Common (castBlockComponent)
 import           Ouroboros.Storage.Util.ErrorHandling (ThrowCantCatch)
@@ -52,4 +52,4 @@ openDBMock err maxNumPerFile = do
 
     wrapModel :: StrictTVar m (DBModel blockId)
               -> StateT (DBModel blockId) (STM m) a -> STM m a
-    wrapModel dbVar = simStateT dbVar $ id
+    wrapModel dbVar = runSim (simStateT dbVar $ simId)

--- a/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
@@ -311,7 +311,7 @@ mkTestFetchedBlockHeap :: (MonadSTM m, Ord (Point block))
                        => [Point block]
                        -> m (TestFetchedBlockHeap m block)
 mkTestFetchedBlockHeap points = do
-    v <- atomically (newTVar (Set.fromList points))
+    v <- newTVarM (Set.fromList points)
     return TestFetchedBlockHeap {
       getTestFetchedBlocks = readTVar v,
       addTestFetchedBlock  = \p _b -> atomically (modifyTVar v (Set.insert p))

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 {-# OPTIONS_GHC -Wno-orphans     #-}
 
@@ -27,7 +28,7 @@ import           Control.Tracer
 import qualified Network.Mux.Bearer.Pipe as Mx
 import           Ouroboros.Network.Mux
 
-import           Ouroboros.Network.Block (encodeTip, decodeTip)
+import           Ouroboros.Network.Block (decodeTip, encodeTip)
 import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate, Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 import qualified Ouroboros.Network.MockChain.ProducerState as CPS

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 {-# OPTIONS_GHC -Wno-orphans     #-}
 module Test.Socket (tests) where
@@ -43,13 +44,13 @@ import qualified Network.TypedProtocol.ReqResp.Codec.CBOR as ReqResp
 import           Control.Tracer
 
 -- TODO: remove Mx prefixes
-import qualified Network.Mux as Mx hiding (MiniProtocolLimits(..))
+import qualified Network.Mux as Mx hiding (MiniProtocolLimits (..))
 import qualified Network.Mux.Bearer.Socket as Mx
 import           Ouroboros.Network.Mux as Mx
 
 import           Ouroboros.Network.Socket
 
-import           Ouroboros.Network.Block (Tip, encodeTip, decodeTip)
+import           Ouroboros.Network.Block (Tip, decodeTip, encodeTip)
 import           Ouroboros.Network.Magic
 import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate, Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
@@ -59,7 +60,8 @@ import qualified Ouroboros.Network.Protocol.ChainSync.Client as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Codec as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Examples as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Server as ChainSync
-import           Ouroboros.Network.Protocol.Handshake.Type (acceptEq, cborTermVersionDataCodec)
+import           Ouroboros.Network.Protocol.Handshake.Type (acceptEq,
+                     cborTermVersionDataCodec)
 import           Ouroboros.Network.Protocol.Handshake.Version
                      (simpleSingletonVersions)
 import           Ouroboros.Network.Testing.Serialise

--- a/ouroboros-network/test/Test/Subscription.hs
+++ b/ouroboros-network/test/Test/Subscription.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
 
 
 {-# OPTIONS_GHC -Wno-orphans     #-}
@@ -54,16 +54,15 @@ import           Ouroboros.Network.Protocol.Handshake.Version (simpleSingletonVe
 
 import           Ouroboros.Network.Magic
 import           Ouroboros.Network.Mux
-import           Ouroboros.Network.NodeToNode hiding ( ipSubscriptionWorker
-                                                     , dnsSubscriptionWorker
-                                                     )
+import           Ouroboros.Network.NodeToNode hiding (dnsSubscriptionWorker,
+                     ipSubscriptionWorker)
 import           Ouroboros.Network.Socket
 import           Ouroboros.Network.Subscription
-import           Ouroboros.Network.Subscription.Ip
 import           Ouroboros.Network.Subscription.Dns
-import           Ouroboros.Network.Subscription.Worker (WorkerParams (..))
+import           Ouroboros.Network.Subscription.Ip
 import           Ouroboros.Network.Subscription.PeerState
 import           Ouroboros.Network.Subscription.Subscriber
+import           Ouroboros.Network.Subscription.Worker (WorkerParams (..))
 
 defaultMiniProtocolLimit :: Int64
 defaultMiniProtocolLimit = 3000000
@@ -595,10 +594,10 @@ prop_send_recv f xs first = ioProperty $ do
 
 
 data ReqRspCfg = ReqRspCfg {
-      rrcTag         :: !String
-    , rrcServerVar   :: !(StrictTMVar IO Int)
-    , rrcClientVar   :: !(StrictTMVar IO [Int])
-    , rrcSiblingVar  :: !(StrictTVar IO Int)
+      rrcTag        :: !String
+    , rrcServerVar  :: !(StrictTMVar IO Int)
+    , rrcClientVar  :: !(StrictTMVar IO [Int])
+    , rrcSiblingVar :: !(StrictTVar IO Int)
 }
 
 newReqRspCfg :: String -> StrictTVar IO Int -> IO ReqRspCfg
@@ -846,5 +845,3 @@ instance (Show a) => Show (WithTag a) where
 
 tagTrace :: String -> Tracer IO (WithTag a) -> Tracer IO a
 tagTrace tag tr = Tracer $ \s -> traceWith tr $ WithTag tag s
-
-


### PR DESCRIPTION
The main change in this commit is split in MonadSTM, which avoids the injectivity requirement, enabling GeneralizedNewtypeDeriving for MonadSTM. The remainder of the changes are related, and similarly
intended to faciliate the derivation of monad stacks.

Note that a similar change could be made to `MonadTimer`, but I didn't need it and so I've not done that yet.

With this PR, we can define something like

```haskell
newtype MockTime m a = MockTime (ReaderT () m a)
  deriving ( Functor
           , Applicative
           , Monad
           , MonadTrans
           , MonadThrow
           , MonadSTM
           , MonadDelay
           , MonadTime
           )
```

and have it Just Work (TM). (Of course, this particular definition isn't very useful, just a proof of concept.)