### PR TITLE
consensus: do not assume the anchor point is genesis in prevPointAndBlockNo

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -179,8 +179,7 @@ data TraceForgeEvent blk tx
   -- See also <https://github.com/input-output-hk/ouroboros-network/issues/1462>
   | TraceBlockFromFuture SlotNo SlotNo
 
-  -- | Leadership check failed: the tip of the ImmDB inhabits a slot /after/
-  -- the current slot
+  -- | Leadership check failed: the tip of the ImmDB inhabits the current slot
   --
   -- This might happen in two cases.
   --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -504,10 +504,10 @@ forkBlockProduction maxBlockSizeOverride IS{..} BlockProduction{..} =
 newtype PRNG = PRNG ChaChaDRG
   deriving NoUnexpectedThunks via UseIsNormalForm PRNG
 
--- | Data about a block's position in the chain
+-- | Context required to forge a block
 data BlockContext blk = BlockContext
   { bcBlockNo   :: !BlockNo
-    -- ^ the block number of the block
+    -- ^ the block number of the block to be forged
   , bcPrevPoint :: !(Point blk)
     -- ^ the point of /the predecessor of/ the block
     --
@@ -546,7 +546,7 @@ mkCurrentBlockContext
      -- If the fragment is 'Empty', then this is the block number of the
      -- tip of the ImmDB.
   -> Either (TraceForgeEvent blk (GenTx blk)) (BlockContext blk)
-     -- ^ the event is records the cause of the failure
+     -- ^ the event records the cause of the failure
 mkCurrentBlockContext currentSlot c bno = case c of
     Empty p   -- thus: bno and p both refer to the tip of the ImmDB
       | pointSlot p < At currentSlot


### PR DESCRIPTION
Fixes the first item in #1511.

Unfortunately I don't have a test case here, because the only repro I have only fails on my WIP branch for Issue 1489. On that branch, this commit does fix the repro.

I'm preparing an omnibus PR for 1489, but I thought I'd open this one too, since the fix seems clear in hindsight (unless I'm overlooking some invariant about the current chain here?) and it's in the library not just the test infrastructure.