### PR TITLE
ImmutableDB.Iterator: allocate handles in the ResourceRegistry

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -17,6 +17,7 @@ module Ouroboros.Consensus.Util.ResourceRegistry (
   , withRegistry
   , registryThread
     -- * Allocating and releasing regular resources
+  , ResourceKey
   , allocate
   , allocateEither
   , release
@@ -342,6 +343,7 @@ data RegistryStatus =
 --
 -- Resource keys are tied to a particular registry.
 data ResourceKey m = ResourceKey !(ResourceRegistry m) !ResourceId
+  deriving (Generic, NoUnexpectedThunks)
 
 -- | Resource ID
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -843,7 +843,7 @@ ensureKnownThread :: forall m. IOLike m
 ensureKnownThread rr context = do
     isKnown <- checkIsKnown
     unless isKnown $
-      throwM $ ResourceRegistryUsedFromUnknownThread {
+      throwM $ ResourceRegistryUsedFromUntrackedThread {
                    resourceRegistryCreatedIn = registryContext rr
                  , resourceRegistryUsedIn    = context
                  }
@@ -856,13 +856,14 @@ ensureKnownThread rr context = do
           KnownThreads ts <- registryThreads <$> readTVar (registryState rr)
           return $ contextThreadId context `Set.member` ts
 
--- | Registry used from unknown threads
+-- | Registry used from untracked threads
 --
 -- If this exception is raised, it indicates a bug in the caller.
 data ResourceRegistryThreadException =
-    -- | If the registry is used from an unknown thread, we cannot do proper
-    -- reference counting
-    forall m. IOLike m => ResourceRegistryUsedFromUnknownThread {
+    -- | If the registry is used from an untracked thread, we cannot do proper
+    -- reference counting. The following threads are /tracked/: the thread
+    -- that spawned the registry and all threads spawned by the registry.
+    forall m. IOLike m => ResourceRegistryUsedFromUntrackedThread {
           -- | Information about the context in which the registry was created
           resourceRegistryCreatedIn :: !(Context m)
 

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/API.hs
@@ -22,6 +22,8 @@ import           Data.ByteString.Builder (Builder)
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 
+import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
+
 import           Ouroboros.Storage.Common
 import           Ouroboros.Storage.ImmutableDB.Types
 import           Ouroboros.Storage.Util.ErrorHandling (ErrorHandling)
@@ -197,7 +199,8 @@ data ImmutableDB hash m = ImmutableDB
     -- prematurely closed with 'iteratorClose'.
   , stream
       :: forall b. HasCallStack
-      => BlockComponent (ImmutableDB hash m) b
+      => ResourceRegistry m
+      -> BlockComponent (ImmutableDB hash m) b
       -> Maybe (SlotNo, hash)
       -> Maybe (SlotNo, hash)
       -> m (Either (WrongBoundError hash)

--- a/ouroboros-consensus/test-consensus/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/ThreadNet/RealPBFT.hs
@@ -169,6 +169,35 @@ tests = testGroup "RealPBFT" $
             , slotLengths  = defaultSlotLengths
             , initSeed     = Seed (11044330969750026700,14522662956180538128,9026549867550077426,3049168255170604478,643621447671665184)
             }
+    , testProperty "ImmutableDB is leaking file handles, #1543" $
+          -- The failure was: c0 leaks one ImmDB file handle (for path
+          -- @00000.epoch@, read only, offset at 0).
+          --
+          -- The test case seems somewhat fragile, since the 'slotLengths'
+          -- value seems to matter!
+          once $
+          let ncn5 = NumCoreNodes 5 in
+          prop_simple_real_pbft_convergence NoEBBs (SecurityParam 2) TestConfig
+            { numCoreNodes = ncn5
+            -- Still fails if I increase numSlots.
+            , numSlots     = NumSlots 54
+            , nodeJoinPlan = NodeJoinPlan $ Map.fromList
+              [ (CoreNodeId 0, SlotNo {unSlotNo = 0})
+              , (CoreNodeId 1, SlotNo {unSlotNo = 0})
+              , (CoreNodeId 2, SlotNo {unSlotNo = 0})
+              , (CoreNodeId 3, SlotNo {unSlotNo = 53})
+              , (CoreNodeId 4, SlotNo {unSlotNo = 53})
+              ]
+              -- Passes if I drop either of these restarts.
+            , nodeRestarts = NodeRestarts $ Map.fromList
+              [ (SlotNo {unSlotNo = 50},Map.fromList [(CoreNodeId 0,NodeRestart)])
+              , (SlotNo {unSlotNo = 53},Map.fromList [(CoreNodeId 3,NodeRestart)])
+              ]
+            , nodeTopology = meshNodeTopology ncn5
+              -- Slot length of 19s passes, and 21s also fails; I haven't seen this matter before.
+            , slotLengths  = singletonSlotLengths (slotLengthFromSec 20)
+            , initSeed     = Seed {getSeed = (15062108706768000853,6202101653126031470,15211681930891010376,1718914402782239589,12639712845887620121)}
+            }
     , -- RealPBFT runs are slow, so do 10x less of this narrow test
       adjustOption (\(QuickCheckTests i) -> QuickCheckTests $ max 1 $ i `div` 10) $
       testProperty "re-delegation via NodeRekey" $ \seed w ->

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -9,7 +9,7 @@ import           Data.Tuple (swap)
 
 import           Control.Monad.Class.MonadThrow
 
-import           Ouroboros.Consensus.Util ((..:), (.:))
+import           Ouroboros.Consensus.Util ((...:), (..:), (.:))
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Storage.Common (BlockComponent, EpochSize)
@@ -41,7 +41,7 @@ openDBMock err epochSize = do
         , getBlockOrEBBComponent = queryE   ..: getBlockOrEBBComponentModel
         , appendBlock            = updateE_ ..: appendBlockModel
         , appendEBB              = updateE_ ..: appendEBBModel
-        , stream                 = updateEE ..: \bc s e -> fmap (fmap (first (iterator bc))) . streamModel s e
+        , stream                 = updateEE ...: \_rr bc s e -> fmap (fmap (first (iterator bc))) . streamModel s e
         , immutableDBErr         = err
         }
       where


### PR DESCRIPTION
Fixes #1543.

The ChainDB.Iterators and ChainDB.Readers use ImmutableDB.Iterators internally. Both take a ResourceRegistry to allocate the ImmutableDB.Iterator in so that the ImmutableDB.Iterator and the open handle it contains is closed when an exception occurs.

If an exception occurs at the wrong time while opening an ImmutableDB.Iterator, after opening the handle, we might leak the handle. Fix this by directly allocating the handle in the ResourceRegistry instead of the ImmutableDB.Iterator that refers to the handle.