### PR TITLE
windows vectored io for sockets

### DIFF
--- a/Win32-network/Win32-network.cabal
+++ b/Win32-network/Win32-network.cabal
@@ -28,6 +28,7 @@ library
                        System.Win32.Async.ErrCode
                        System.Win32.Async.IOManager
                        System.Win32.Async.Internal
+                       System.Win32.Async.WSABuf
                        System.Win32.Async.Socket
                        System.Win32.Async.Socket.ByteString
     c-sources:         cbits/Win32Async.c

--- a/Win32-network/Win32-network.cabal
+++ b/Win32-network/Win32-network.cabal
@@ -31,6 +31,7 @@ library
                        System.Win32.Async.WSABuf
                        System.Win32.Async.Socket
                        System.Win32.Async.Socket.ByteString
+                       System.Win32.Async.Socket.ByteString.Lazy
     c-sources:         cbits/Win32Async.c
                        cbits/Win32Socket.c
     build-depends:     base              >= 4.5  && < 4.13,

--- a/Win32-network/cbits/Win32Socket.c
+++ b/Win32-network/cbits/Win32Socket.c
@@ -11,7 +11,7 @@ typedef struct _WSA_PER_IO_DATA {
 } WSA_PER_IO_DATA;
 
 DllExport
-void HsSendBuf(SOCKET s, CHAR *buf, ULONG len, HsStablePtr userData)
+void HsSendBuf(SOCKET s, WSABUF *lpBuffers, DWORD dwBufferCount, HsStablePtr userData)
 {
   int res;
   WSA_PER_IO_DATA *perIoDataPtr;
@@ -26,11 +26,7 @@ void HsSendBuf(SOCKET s, CHAR *buf, ULONG len, HsStablePtr userData)
   perIoDataPtr->WSAOverlapped.OffsetHigh = 0;
   perIoDataPtr->UserData = userData;
 
-  WSABUF wsaBuf;
-  wsaBuf.len = len;
-  wsaBuf.buf = buf;
-
-  res = WSASend(s, &wsaBuf, 1, NULL, 0, &(perIoDataPtr->WSAOverlapped), NULL);
+  res = WSASend(s, lpBuffers, dwBufferCount, NULL, 0, &(perIoDataPtr->WSAOverlapped), NULL);
   if (!res) {
     DWORD error;
     error = WSAGetLastError();

--- a/Win32-network/src/System/Win32/Async.hs
+++ b/Win32-network/src/System/Win32/Async.hs
@@ -1,3 +1,8 @@
+-- | This is the main module of `Win32-network` package which should be used
+-- with "System.Win32.Async.Socket.ByteString",
+-- "System.Win32.Async.Socket.ByteString.Lazy" or "System.Win32.Async.File" for
+-- sending and/or receiving.
+--
 module System.Win32.Async
   ( module System.Win32.Async.File
   , module System.Win32.Async.ErrCode

--- a/Win32-network/src/System/Win32/Async.hs
+++ b/Win32-network/src/System/Win32/Async.hs
@@ -8,11 +8,9 @@ module System.Win32.Async
   , module System.Win32.Async.ErrCode
   , module System.Win32.Async.IOManager
   , module System.Win32.Async.Socket
-  , module System.Win32.Async.Socket.ByteString
   ) where
 
 import System.Win32.Async.IOManager
 import System.Win32.Async.File
 import System.Win32.Async.ErrCode
 import System.Win32.Async.Socket
-import System.Win32.Async.Socket.ByteString

--- a/Win32-network/src/System/Win32/Async/IOManager.hs
+++ b/Win32-network/src/System/Win32/Async/IOManager.hs
@@ -30,8 +30,8 @@ import qualified System.Win32.Types as Win32
 import qualified System.Win32.File  as Win32 (closeHandle)
 import System.Win32.Async.ErrCode
 
--- | New type wrapper which holds 'HANDLE' of the I/O completion port.
--- <https://docs.microsoft.com/en-us/windows/win32/fileio/createiocompletionport>
+-- | New type wrapper which holds 'HANDLE' of an [I/O completion
+-- port](https://docs.microsoft.com/en-us/windows/win32/fileio/createiocompletionport).
 --
 newtype IOCompletionPort = IOCompletionPort HANDLE
   deriving Show
@@ -39,7 +39,7 @@ newtype IOCompletionPort = IOCompletionPort HANDLE
 closeIOCompletionPort :: IOCompletionPort -> IO ()
 closeIOCompletionPort (IOCompletionPort iocp) = Win32.closeHandle iocp
 
--- | Windows documentation:
+-- | [msdn documentation](https://docs.microsoft.com/en-us/windows/win32/fileio/createiocompletionport)
 --
 createIOCompletionPort
     :: DWORD  -- ^ number of concurrent threads
@@ -57,7 +57,9 @@ foreign import ccall unsafe "windows.h CreateIoCompletionPort"
     c_CreateIoCompletionPort :: HANDLE -> HANDLE -> Ptr () -> DWORD -> IO HANDLE
 
 -- | Associate with I/O completion port.  This can be used multiple times on
--- a file descriptor.
+-- a file descriptor.  A 'HANDLE' must be opend with
+-- 'System.Win32.fILE_FLAG_OVERLAPPED' flag for this call to succeed; 'Socket's
+-- do not require special initialisation.
 --
 associateWithIOCompletionPort :: Either HANDLE Socket
                               -> IOCompletionPort

--- a/Win32-network/src/System/Win32/Async/Internal.hs
+++ b/Win32-network/src/System/Win32/Async/Internal.hs
@@ -1,11 +1,20 @@
-module System.Win32.Async.Internal where
+module System.Win32.Async.Internal
+  ( SOCKET
+  , CInt (..)
+  , waitForCompletion
+  , wsaWaitForCompletion
+  ) where
 
 import Control.Concurrent
 
+import Foreign.C (CInt (..))
 import Foreign.StablePtr (StablePtr, newStablePtr)
 import System.Win32.Types (ErrCode)
 import qualified System.Win32.Types as Win32
 import System.Win32.Async.ErrCode
+
+
+type SOCKET = CInt
 
 waitForCompletion :: String
                   -> (StablePtr (MVar (Either ErrCode Int)) -> IO ())

--- a/Win32-network/src/System/Win32/Async/Socket.hs
+++ b/Win32-network/src/System/Win32/Async/Socket.hs
@@ -54,7 +54,7 @@ connect :: Socket -> SockAddr -> IO ()
 connect sock addr = do
     v <- newEmptyMVar
     _ <- mask_ $ forkIOWithUnmask $ \unmask -> 
-        unmask (Socket.connect sock addr >> putMVar v Nothing)
+        (unmask (Socket.connect sock addr) >> putMVar v Nothing)
         `catch` (\(e :: IOException) -> putMVar v (Just e))
     r <- takeMVar v
     case r of
@@ -76,7 +76,7 @@ accept :: Socket -> IO (Socket, SockAddr)
 accept sock = do
     v <- newEmptyMVar
     _ <- mask_ $ forkIOWithUnmask $ \unmask -> 
-          unmask (Socket.accept sock >>= putMVar v . Right)
+          (unmask (Socket.accept sock) >>= putMVar v . Right)
           `catch` (\(e :: IOException) -> putMVar v (Left e))
     r <- takeMVar v
     case r of

--- a/Win32-network/src/System/Win32/Async/Socket.hs
+++ b/Win32-network/src/System/Win32/Async/Socket.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE InterruptibleFFI    #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module System.Win32.Async.Socket
@@ -16,12 +17,15 @@ import           Data.Word
 import           Foreign.C (CInt (..))
 import           Foreign.Ptr (Ptr)
 import           Foreign.StablePtr (StablePtr)
+import           Foreign.Marshal.Alloc (alloca)
+import           Foreign.Storable (Storable (poke))
 
 import           Network.Socket (Socket, SockAddr)
 import qualified Network.Socket as Socket
 
 import           System.Win32.Types
 import           System.Win32.Async.Internal
+import           System.Win32.Async.WSABuf
 
 
 type SOCKET = CInt
@@ -34,12 +38,14 @@ sendBuf :: Socket
 sendBuf sock buf size = Socket.withFdSocket sock $ \fd ->
     -- on Windows sockets are Word32, GHC represents file descriptors with CInt
     -- which is Int32.
-    wsaWaitForCompletion "sendBuf" (c_sendBuf fd buf (fromIntegral size))
+    alloca $ \bufs_ptr -> do
+      poke bufs_ptr WSABuf {buf, len = fromIntegral size}
+      wsaWaitForCompletion "sendBuf" (c_sendBuf fd bufs_ptr 1)
 
 foreign import ccall safe "HsSendBuf"
     c_sendBuf :: SOCKET
-              -> Ptr Word8
-              -> Word32
+              -> Ptr WSABuf  -- ^ lpBuffers
+              -> DWORD       -- ^ dwBufferCount
               -> StablePtr b
               -> IO ()
 

--- a/Win32-network/src/System/Win32/Async/Socket.hs
+++ b/Win32-network/src/System/Win32/Async/Socket.hs
@@ -28,9 +28,6 @@ import           System.Win32.Async.Internal
 import           System.Win32.Async.WSABuf
 
 
-type SOCKET = CInt
-
-
 sendBuf :: Socket
         -> Ptr Word8
         -> Int

--- a/Win32-network/src/System/Win32/Async/Socket/ByteString.hs
+++ b/Win32-network/src/System/Win32/Async/Socket/ByteString.hs
@@ -20,8 +20,10 @@ import           Network.Socket (Socket)
 import           System.Win32.Async.Socket
 
 
--- | Send a 'ByteString' over a socket, which must be in a connected state.
--- Returns number of bytes sent.
+-- | Send a 'ByteString' over a socket, which must be in a connected state, and
+-- must be associated with an IO completion port via
+-- 'System.Win32.Async.IOManager.associateWithIOCompletionProt'.  Returns number
+-- of bytes sent.
 --
 send :: Socket
      -> ByteString
@@ -42,6 +44,11 @@ sendAll sock bs = do
       $ sendAll sock (BS.drop sent bs)
 
 
+-- | Recv a 'ByteString' from a socket, which must be in a connected state, and
+-- must be associated with an IO completion port via
+-- 'System.Win32.Async.IOManager.associateWithIOCompletionProt'.  It may return
+-- less bytes than requested.
+--
 recv :: Socket
      -> Int
      -> IO ByteString

--- a/Win32-network/src/System/Win32/Async/Socket/ByteString/Lazy.hs
+++ b/Win32-network/src/System/Win32/Async/Socket/ByteString/Lazy.hs
@@ -34,6 +34,10 @@ import qualified System.Win32.Async.Socket.ByteString as Socket.ByteString
 -- transmit at most 1024 chunks, it is safe to transmit less than 4194304
 -- bytes.
 --
+-- The socket must be in a connected state, and must be associated with an IO
+-- completion port via
+-- 'System.Win32.Async.IOManager.associateWithIOCompletionProt'.
+--
 send :: Socket
      -> ByteString
      -> IO Int64
@@ -80,6 +84,11 @@ sendAll sock  bs = do
     let bs' = BL.drop sent bs
     when (sent >= 0 && not (BL.null bs')) $ sendAll sock bs'
 
+-- | Receive bytes from a socket, which must be in a connected state, and must
+-- be associated with an IO completion port via
+-- 'System.Win32.Async.IOManager.associateWithIOCompletionProt'.
+-- It can return less bytes than requested.
+--
 recv :: Socket
      -> Int
      -> IO ByteString

--- a/Win32-network/src/System/Win32/Async/Socket/ByteString/Lazy.hs
+++ b/Win32-network/src/System/Win32/Async/Socket/ByteString/Lazy.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE BangPatterns #-}
+
+module System.Win32.Async.Socket.ByteString.Lazy
+  ( send
+  , sendAll
+  ) where
+
+
+import           Control.Monad (when)
+import           Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy as BL
+import           Data.ByteString.Unsafe (unsafeUseAsCStringLen)
+import           Data.Int (Int64)
+import           Foreign.C (CInt (..))
+import           Foreign.Marshal.Array (allocaArray)
+import           Foreign.Ptr
+import           Foreign.StablePtr (StablePtr)
+import           Foreign.Storable
+
+import           Network.Socket (Socket)
+import qualified Network.Socket as Socket
+
+import           System.Win32.Types (DWORD)
+
+import           System.Win32.Async.WSABuf
+import           System.Win32.Async.Internal
+
+
+-- | Sending each chunk using vectored I/O.  In one system call one can
+-- transmit at most 1024 chunks, it is safe to transmit less than 4194304
+-- bytes.
+--
+send :: Socket
+     -> ByteString
+     -> IO Int64
+send sock bs = do
+    let cs  = take maxNumChunks (BL.toChunks bs)
+        size = length cs
+    siz <- Socket.withFdSocket sock $ \fd -> allocaArray size $ \ptr ->
+             withPokes cs ptr $ \nwsabuf ->
+               wsaWaitForCompletion "send" (c_sendBuf fd ptr nwsabuf)
+    return $ fromIntegral siz
+  where
+    withPokes ss p f = loop ss p 0 0
+      where
+        loop (c:cs) q k !nwsabuf
+            | k < maxNumBytes = unsafeUseAsCStringLen c $ \(ptr, strlen) -> do
+                poke q $ WSABuf (fromIntegral strlen) (castPtr ptr)
+                loop cs
+                     (q `plusPtr` sizeOf (undefined :: WSABuf))
+                     (k + fromIntegral strlen)
+                     (nwsabuf + 1)
+            | otherwise = f nwsabuf
+        loop _ _ _ nwsabuf = f nwsabuf
+
+    maxNumBytes, maxNumChunks :: Int
+    maxNumBytes  = 4194304 -- maximum number of bytes to transmit in one system call
+    maxNumChunks = 1024    -- maximum number of chunks to transmit in one system call
+
+
+foreign import ccall safe "HsSendBuf"
+    c_sendBuf :: SOCKET
+              -> Ptr WSABuf  -- ^ lpBuffers
+              -> DWORD       -- ^ dwBufferCount
+              -> StablePtr b
+              -> IO ()
+
+
+sendAll :: Socket
+        -> ByteString
+        -> IO ()
+sendAll _sock bs | BL.null bs = return ()
+sendAll sock  bs = do
+    sent <- send sock bs
+    -- it is simpler than `Network.Socket.Lazy.sendAll` - waiting for sending
+    -- all the chunks is already perfomed by 'send'.
+    let bs' = BL.drop sent bs
+    when (sent >= 0 && not (BL.null bs')) $ sendAll sock bs'

--- a/Win32-network/src/System/Win32/Async/WSABuf.hsc
+++ b/Win32-network/src/System/Win32/Async/WSABuf.hsc
@@ -1,0 +1,33 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+#include <winsock2.h>
+
+module System.Win32.Async.WSABuf
+  ( WSABuf (..)
+  ) where
+
+import Data.Word (Word8)
+import Foreign.Ptr (Ptr)
+import Foreign.Storable (Storable (..))
+import System.Win32.Types (ULONG)
+
+
+-- | 'WSABuf' is Haskell representation of 'WSABUF' struct.
+--
+data WSABuf = WSABuf {
+    len :: ULONG,
+    buf :: Ptr Word8
+  }
+
+instance Storable WSABuf where
+    sizeOf _    = (#const sizeof(WSABUF))
+    alignment _ = (#alignment WSABUF)
+
+    peek p = do
+      len <- (#peek WSABUF, len) p
+      buf <- (#peek WSABUF, buf) p
+      return $ WSABuf len buf
+
+    poke p WSABuf {len, buf} = do
+      (#poke WSABUF, len) p len
+      (#poke WSABUF, buf) p buf

--- a/Win32-network/src/System/Win32/NamedPipes.hsc
+++ b/Win32-network/src/System/Win32/NamedPipes.hsc
@@ -21,6 +21,7 @@ module System.Win32.NamedPipes (
     pIPE_ACCESS_DUPLEX,
     pIPE_ACCESS_INBOUND,
     pIPE_ACCESS_OUTBOUND,
+    fILE_FLAG_OVERLAPPED,
     PipeMode,
     pIPE_TYPE_BYTE,
     pIPE_TYPE_MESSAGE,
@@ -103,6 +104,20 @@ pIPE_UNLIMITED_INSTANCES = #const PIPE_UNLIMITED_INSTANCES
 --
 -- For full details see
 -- <https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-createnamedpipea>
+--
+-- To create a named pipe which can be associate with IO completion port on
+-- needs to pass 'fILE_FLAG_OVERLAPPED' to 'OpenMode' argument,
+-- e.g.
+--
+-- >  Win32.createNamedPipe pipeName
+-- >                        (pIPE_ACCESS_DUPLEX .|. fILE_FLAG_OVERLAPPED)
+-- >                        (pIPE_TYPE_BYTE .|. pIPE_READMODE_BYTE)
+-- >                        pIPE_UNLIMITED_INSTANCES
+-- >                        512
+-- >                        512
+-- >                        0
+-- >                        Nothing
+--
 --
 createNamedPipe :: String   -- ^ pipe name of form @\.\pipe\{pipename}@
                 -> OpenMode

--- a/network-mux/src/Network/Mux/Bearer/Socket.hs
+++ b/network-mux/src/Network/Mux/Bearer/Socket.hs
@@ -21,8 +21,7 @@ import qualified Network.Socket as Socket
 #if !defined(mingw32_HOST_OS)
 import qualified Network.Socket.ByteString.Lazy as Socket (recv, sendAll)
 #else
-import           Data.Foldable (traverse_)
-import qualified System.Win32.Async as Win32.Async
+import qualified System.Win32.Async.Socket.ByteString.Lazy as Win32.Async
 #endif
 
 import qualified Network.Mux as Mx
@@ -36,9 +35,10 @@ import qualified Network.Mux.Time as Mx
 -- |
 -- Create @'MuxBearer'@ from a socket.
 --
--- On Windows 'System.Win32.Async` operations are used to read and write.  This
--- means that the socket must be associated with the I/O completion port with
--- 'System.Win32.Async.associateWithIOCompletionPort'.
+-- On Windows 'System.Win32.Async` operations are used to read and write from
+-- a socket.  This means that the socket must be associated with the I/O
+-- completion port with
+-- 'System.Win32.Async.IOManager.associateWithIOCompletionPort'.
 --
 -- Note: 'IOException's thrown by 'sendAll' and 'recv' are wrapped in
 -- 'MuxError'.
@@ -74,7 +74,7 @@ socketAsMuxBearer tracer sd =
       recvLen' waitingOnNxtHeader l bufs = do
           traceWith tracer $ Mx.MuxTraceRecvStart $ fromIntegral l
 #if defined(mingw32_HOST_OS)
-          buf <- BL.fromStrict <$> Win32.Async.recv sd (fromIntegral l)
+          buf <- Win32.Async.recv sd (fromIntegral l)
 #else
           buf <- Socket.recv sd l
 #endif
@@ -102,8 +102,7 @@ socketAsMuxBearer tracer sd =
               buf  = Mx.encodeMuxSDU sdu'
           traceWith tracer $ Mx.MuxTraceSendStart sdu'
 #if defined(mingw32_HOST_OS)
-          -- TODO: issue #1430: vectored I/O on Windows
-          traverse_ (Win32.Async.sendAll sd) (BL.toChunks buf)
+          Win32.Async.sendAll sd buf
 #else
           Socket.sendAll sd buf
 #endif

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -261,10 +261,6 @@ test-suite test-network
     build-depends:     Win32-network                 <0.2.0.0,
                        Win32           >= 2.5.4.1 && <2.9
 
-  if os(windows)
-    build-depends:     Win32-network                 <0.2.0.0,
-                       Win32           >= 2.5.4.1 && <2.9
-
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -40,7 +40,7 @@ import           System.Process (createPipe)
 import           System.IO (hClose)
 #endif
 
-import           Ouroboros.Network.Block (decodeTip, encodeTip)
+import           Ouroboros.Network.Block (encodeTip, decodeTip)
 import           Ouroboros.Network.MockChain.Chain (Chain, ChainUpdate, Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 import qualified Ouroboros.Network.MockChain.ProducerState as CPS


### PR DESCRIPTION
Currently this PR is opened to merge into `coot/windows-api`, but after #1516 is merged it will be re-targeted to `master` - it's just to make the diff adequate.

This PR provides vectored IO for sockets, vectored IO for file handles will be done at a later stage.
It also includes documentation overview, which will be useful for other teams (`cardano-wallet` or `cardano-launcher`). 