### PR TITLE
Add `SlotNo` to `TickedLedgerState`

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -114,10 +114,21 @@ ledgerTipSlot = pointSlot . ledgerTipPoint
 
 -- | Ledger state with the chain tick function already applied
 --
--- This is merely a marker, so that we can keep track at the type level whether
--- or not the chain tick function has been applied.
-newtype TickedLedgerState blk = TickedLedgerState {
-      getTickedLedgerState :: LedgerState blk
+-- 'applyChainTick' is intended to mark the passage of time, without changing
+-- the tip of the underlying ledger (i.e., no blocks have been applied).
+data TickedLedgerState blk = TickedLedgerState {
+      -- | The slot number supplied to 'applyChainTick'
+      tickedSlotNo      :: SlotNo
+
+      -- | The underlying ledger state
+      --
+      -- NOTE: 'applyChainTick' should /not/ change the tip of the underlying
+      -- ledger state, which should still refer to the most recent applied
+      -- /block/. In other words, we should have
+      --
+      -- >    ledgerTipPoint (tickedLedgerState (applyChainTick cfg slot st)
+      -- > == ledgerTipPoint st
+    , tickedLedgerState :: LedgerState blk
     }
 
 -- | Link protocol to ledger

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Auxiliary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Auxiliary.hs
@@ -259,8 +259,7 @@ applyChainTick :: Gen.Config
                -> CC.ChainValidationState
                -> CC.ChainValidationState
 applyChainTick cfg slotNo state = state {
-      CC.cvsLastSlot        = slotNo
-    , CC.cvsUpdateState     = CC.epochTransition
+      CC.cvsUpdateState     = CC.epochTransition
                                 (mkEpochEnvironment cfg state)
                                 (CC.cvsUpdateState state)
                                 slotNo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Ledger.hs
@@ -85,7 +85,7 @@ instance UpdateLedger ByronBlock where
     }
 
   applyChainTick cfg slotNo ByronLedgerState{..} =
-      TickedLedgerState ByronLedgerState {
+      TickedLedgerState slotNo ByronLedgerState {
           byronDelegationHistory = byronDelegationHistory
         , byronLedgerState       = Aux.applyChainTick
                                       (unByronLedgerConfig cfg)
@@ -283,7 +283,7 @@ applyByronBlock validationMode
                 fcfg@(ByronLedgerConfig cfg)
                 fblk@(ByronBlock blk _ (ByronHash blkHash))
                 ls = do
-    let TickedLedgerState ls' = applyChainTick fcfg (blockSlot fblk) ls
+    let TickedLedgerState _slot ls' = applyChainTick fcfg (blockSlot fblk) ls
     case blk of
       CC.ABOBBlock    blk' -> applyABlock validationMode cfg blk' blkHash ls'
       CC.ABOBBoundary blk' -> applyABoundaryBlock        cfg blk'         ls'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Byron/Mempool.hs
@@ -194,8 +194,8 @@ applyByronGenTx :: CC.ValidationMode
                 -> GenTx ByronBlock
                 -> TickedLedgerState ByronBlock
                 -> Except (ApplyTxErr ByronBlock) (TickedLedgerState ByronBlock)
-applyByronGenTx validationMode cfg genTx (TickedLedgerState st) =
-    (\state -> TickedLedgerState $ st {byronLedgerState = state}) <$>
+applyByronGenTx validationMode cfg genTx (TickedLedgerState slot st) =
+    (\state -> TickedLedgerState slot $ st {byronLedgerState = state}) <$>
       applyMempoolPayload
         validationMode
         (unByronLedgerConfig cfg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/ByronSpec/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/ByronSpec/Ledger.hs
@@ -63,8 +63,8 @@ instance UpdateLedger ByronSpecBlock where
 
   type LedgerError ByronSpecBlock = ByronSpecLedgerError
 
-  applyChainTick cfg slot state = TickedLedgerState $
-      updateByronSpecLedgerStateNewTip slot $
+  applyChainTick cfg slot state = TickedLedgerState slot $
+      updateByronSpecLedgerStateKeepTip state $
         Rules.applyChainTick
           (unByronSpecLedgerConfig cfg)
           (toByronSpecSlotNo       slot)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/ByronSpec/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/ByronSpec/Mempool.hs
@@ -42,8 +42,8 @@ instance ApplyTx ByronSpecBlock where
   -- spec does not impose a maximum block size.
   txSize _ = 0
 
-  applyTx cfg tx (TickedLedgerState st) =
-      (TickedLedgerState . updateByronSpecLedgerStateKeepTip st) <$>
+  applyTx cfg tx (TickedLedgerState slot st) =
+      (TickedLedgerState slot . updateByronSpecLedgerStateKeepTip st) <$>
         GenTx.apply
           (unByronSpecLedgerConfig cfg)
           (unByronSpecGenTx        tx)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/ByronSpec/Rules.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/ByronSpec/Rules.hs
@@ -86,9 +86,6 @@ applyChainTick cfg slot st =
           -- Apply scheduled delegations (empty list of new delegation certs)
       >=> liftDELEG cfg []
 
-          -- Set most recent slot
-      >=> modChainStateSlot (\_oldSlot -> pure slot)
-
 {-------------------------------------------------------------------------------
   Lift STS transition rules to the chain level
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Mock/Block.hs
@@ -241,7 +241,7 @@ instance (SimpleCrypto c, Typeable ext, SupportedBlock (SimpleBlock c ext))
 
   type LedgerError (SimpleBlock c ext) = MockError (SimpleBlock c ext)
 
-  applyChainTick _ _ = TickedLedgerState
+  applyChainTick _ = TickedLedgerState
   applyLedgerBlock _cfg = updateSimpleLedgerState
   reapplyLedgerBlock _cfg = (mustSucceed . runExcept) .: updateSimpleLedgerState
     where
@@ -264,8 +264,8 @@ updateSimpleUTxO :: (Monad m, Mock.HasUtxo a)
                  -> ExceptT (MockError (SimpleBlock c ext))
                             m
                             (TickedLedgerState (SimpleBlock c ext))
-updateSimpleUTxO b (TickedLedgerState (SimpleLedgerState st)) =
-    TickedLedgerState . SimpleLedgerState <$> updateMockUTxO b st
+updateSimpleUTxO b (TickedLedgerState slot (SimpleLedgerState st)) =
+    TickedLedgerState slot . SimpleLedgerState <$> updateMockUTxO b st
 
 genesisSimpleLedgerState :: AddrDist -> LedgerState (SimpleBlock c ext)
 genesisSimpleLedgerState = SimpleLedgerState . genesisMockState

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -18,7 +18,7 @@ import qualified Data.Map as Map
 import           Data.Maybe (isJust, isNothing)
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Word (Word32)
+import           Data.Word
 
 import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
@@ -529,27 +529,39 @@ genInvalidTx invalidTxIds TestLedger { tlTxIds } = frequency
 -- TODO property to check that is never possible for a valid transaction that
 -- is in the chain to become invalid afterwards?
 
+-- | Apply a transaction to the ledger
+--
+-- We don't have blocks in this test, but transactions only. In this function
+-- we pretend the transaction /is/ a block, apply it (by faking a
+-- 'TickedLedgerState'), and then updating the tip of the ledger state,
+-- incrementing the slot number and faking a hash.
 applyTxToLedger :: LedgerState TestBlock
                 -> TestTx
                 -> Except TestTxError (LedgerState TestBlock)
 applyTxToLedger = \ledgerState tx ->
-    -- We need to change the 'ledgerTipPoint' because that is used to check
-    -- whether the ledger state has changed.
-    -- TODO: We pretend that the ledger state is "ticked" here; this does not
-    -- matter for our test ledger. We should at some point test with a test
-    -- ledger in which we chain tick /does/ make a difference; it would be
-    -- great if we had tests for instance with test blocks with a TTL.
-    -- If we do change that here, however, then the 'updateLedgerTipPoint'
-    -- function below is also not acceptable.
-    updateLedgerTipPoint <$>
-      applyTx LedgerConfig (TestGenTx tx) (TickedLedgerState ledgerState)
+    (updateLedgerTipPoint . tickedLedgerState) <$>
+      applyTx LedgerConfig (TestGenTx tx) (notReallyTicked ledgerState)
   where
-    updateLedgerTipPoint (TickedLedgerState ledgerState) = ledgerState
-        { tlLastApplied = BlockPoint { withHash = unSlotNo slot', atSlot = slot' } }
+    -- Wrap in 'TickedLedgerState' so that we can call 'applyTx'
+    notReallyTicked :: LedgerState TestBlock -> TickedLedgerState TestBlock
+    notReallyTicked = TickedLedgerState (error "SlotNo unused")
+
+    -- Update the tip of the ledger state
+    -- (so that the mempool notices the ledger state has changed)
+    updateLedgerTipPoint ledgerState = ledgerState {
+          tlLastApplied = BlockPoint {
+              withHash = fakeHash slot'
+            , atSlot   = slot'
+            }
+        }
       where
+        fakeHash :: SlotNo -> Word64
+        fakeHash = unSlotNo
+
+        slot' :: SlotNo
         slot' = case ledgerTipSlot ledgerState of
-          Origin  -> SlotNo 0
-          At slot -> succ slot
+                  Origin  -> SlotNo 0
+                  At slot -> succ slot
 
 {-------------------------------------------------------------------------------
   TestSetupWithTxs

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool/TestBlock.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool/TestBlock.hs
@@ -113,7 +113,7 @@ instance UpdateLedger TestBlock where
   data LedgerConfig TestBlock = LedgerConfig
   type LedgerError  TestBlock = ()
 
-  applyChainTick _ _ = TickedLedgerState
+  applyChainTick _ = TickedLedgerState
 
   applyLedgerBlock   = notNeeded
   reapplyLedgerBlock = notNeeded
@@ -141,9 +141,9 @@ instance ApplyTx TestBlock where
 
   type ApplyTxErr TestBlock = TestTxError
 
-  applyTx _ (TestGenTx tx) (TickedLedgerState ledger@TestLedger { tlTxIds }) = do
+  applyTx _ (TestGenTx tx) (TickedLedgerState slot ledger@TestLedger { tlTxIds }) = do
     testTxValidate tx tlTxIds
-    return $ TickedLedgerState ledger { tlTxIds = testTxId tx : tlTxIds }
+    return $ TickedLedgerState slot ledger { tlTxIds = testTxId tx : tlTxIds }
 
   reapplyTx = applyTx
 

--- a/ouroboros-consensus/test-consensus/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/ThreadNet/DualPBFT.hs
@@ -269,7 +269,7 @@ instance TxGen DualByronBlock where
          -> m [GenTx DualByronBlock]
       go acc 0 _  = return (reverse acc)
       go acc n st = do
-          mTx <- hedgehogAdapter $ genTx cfg (getTickedLedgerState st)
+          mTx <- hedgehogAdapter $ genTx cfg (tickedLedgerState st)
           case mTx of
             Nothing -> return (reverse acc)
             Just tx ->

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -331,7 +331,7 @@ instance UpdateLedger TestBlock where
   data LedgerConfig TestBlock = LedgerConfig
   type LedgerError  TestBlock = TestBlockError
 
-  applyChainTick _ _ = TickedLedgerState
+  applyChainTick _ = TickedLedgerState
 
   applyLedgerBlock _ tb@TestBlock{..} TestLedger{..}
     | blockPrevHash tb /= lastAppliedHash

--- a/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/test-util/Test/Util/TestBlock.hs
@@ -284,7 +284,7 @@ instance UpdateLedger TestBlock where
   data LedgerConfig TestBlock = LedgerConfig
   type LedgerError  TestBlock = TestBlockError
 
-  applyChainTick _ _ = TickedLedgerState
+  applyChainTick _ = TickedLedgerState
 
   applyLedgerBlock _ tb@TestBlock{..} TestLedger{..}
     | Block.blockPrevHash tb /= Block.pointHash lastAppliedPoint


### PR DESCRIPTION
and leave the tip of the underlying ledger unchanged. I modified the Byron ledger and spec to do this; the mock ledgers were also leaving the tip unchanged, but without the additional `SlotNo` in `TickedLedgerState` this was causing trouble (as in a bug that @nfrisby found when looking at #1297).

Closes #1559.