### PR TITLE
 ImmutableDB: truncate blocks from the future 

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/Mock.hs
@@ -7,6 +7,8 @@
 module Ouroboros.Consensus.BlockchainTime.Mock (
     -- * Fixed time
     fixedBlockchainTime
+    -- * Settable time
+  , settableBlockchainTime
     -- * Testing time
   , NumSlots(..)
   , TestClock(..)
@@ -41,6 +43,19 @@ fixedBlockchainTime :: MonadSTM m => SlotNo -> BlockchainTime m
 fixedBlockchainTime slot = BlockchainTime {
       getCurrentSlot = return slot
     , onSlotChange_  = const (return (return ()))
+    }
+
+{-------------------------------------------------------------------------------
+  Settable time
+-------------------------------------------------------------------------------}
+
+-- | The current slot can be changed by modifying the given 'StrictTVar'.
+--
+-- 'onSlotChange_' is not implemented and will return an 'error'.
+settableBlockchainTime :: MonadSTM m => StrictTVar m SlotNo -> BlockchainTime m
+settableBlockchainTime varCurSlot = BlockchainTime {
+      getCurrentSlot = readTVar varCurSlot
+    , onSlotChange_  = error "unimplemented onSlotChange_"
     }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/Args.hs
@@ -177,6 +177,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , immAddHdrEnv        = cdbAddHdrEnv
         , immCacheConfig      = cdbImmDbCacheConfig
         , immRegistry         = cdbRegistry
+        , immBlockchainTime   = cdbBlockchainTime
         }
     , VolDB.VolDbArgs {
           volHasFS            = cdbHasFSVolDb

--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -78,6 +78,7 @@ import           Ouroboros.Network.Block (pattern BlockPoint, ChainHash (..),
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block (GetHeader (..), IsEBB (..))
+import           Ouroboros.Consensus.BlockchainTime (BlockchainTime)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
@@ -157,6 +158,7 @@ data ImmDbArgs m blk = forall h. ImmDbArgs {
     , immTracer         :: Tracer m (TraceEvent blk)
     , immCacheConfig    :: Index.CacheConfig
     , immRegistry       :: ResourceRegistry m
+    , immBlockchainTime :: BlockchainTime m
     }
 
 -- | Default arguments when using the 'IO' monad
@@ -175,6 +177,7 @@ data ImmDbArgs m blk = forall h. ImmDbArgs {
 -- * 'immCheckIntegrity'
 -- * 'immAddHdrEnv'
 -- * 'immRegistry'
+-- * 'immBlockchainTime'
 defaultArgs :: FilePath -> ImmDbArgs IO blk
 defaultArgs fp = ImmDbArgs{
       immErr          = EH.exceptions
@@ -194,6 +197,7 @@ defaultArgs fp = ImmDbArgs{
     , immCheckIntegrity = error "no default for immCheckIntegrity"
     , immAddHdrEnv      = error "no default for immAddHdrEnv"
     , immRegistry       = error "no default for immRegistry"
+    , immBlockchainTime = error "no default for immBlockchainTime"
     }
   where
     -- Cache 250 past epochs by default. This will take roughly 250 MB of RAM.
@@ -228,6 +232,7 @@ openDB ImmDbArgs{..} = do
       parser
       immTracer
       immCacheConfig
+      immBlockchainTime
     return ImmDB
       { immDB     = immDB
       , decHeader = immDecodeHeader

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/State.hs
@@ -31,6 +31,7 @@ import           Cardano.Prelude (NoUnexpectedThunks (..))
 
 import           Control.Monad.Class.MonadThrow hiding (onException)
 
+import           Ouroboros.Consensus.BlockchainTime (BlockchainTime)
 import           Ouroboros.Consensus.Util (SomePair (..))
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry,
@@ -67,6 +68,7 @@ data ImmutableDBEnv m hash = forall h e. ImmutableDBEnv
     , _dbTracer          :: !(Tracer m (TraceEvent e hash))
     , _dbRegistry        :: !(ResourceRegistry m)
     , _dbCacheConfig     :: !Index.CacheConfig
+    , _dbBlockchainTime  :: !(BlockchainTime m)
     }
 
 data InternalState m hash h =

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Validation.hs
@@ -64,6 +64,7 @@ data ValidateEnv m hash h e = ValidateEnv
   , tracer      :: !(Tracer m (TraceEvent e hash))
   , registry    :: !(ResourceRegistry m)
   , cacheConfig :: !Index.CacheConfig
+  , currentSlot :: !SlotNo
   }
 
 -- | Perform validation as per the 'ValidationPolicy' using 'validate' and
@@ -296,7 +297,7 @@ validateEpoch ValidateEnv{..} shouldBeFinalised epoch mbPrevHash = do
     -- expensive integrity check of a block.
     let expectedChecksums = map Secondary.checksum entriesFromSecondaryIndex
     (entriesWithPrevHashes, mbErr) <- lift $
-        runEpochFileParser parser epochFile expectedChecksums $ \stream ->
+        runEpochFileParser parser epochFile currentSlot expectedChecksums $ \stream ->
           (\(es :> mbErr) -> (es, mbErr)) <$> S.toList stream
 
     -- Check whether the first block of this epoch fits onto the last block of

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Parser.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Parser.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE NamedFieldPuns           #-}
 {-# LANGUAGE RankNTypes               #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE TupleSections            #-}
 -- | The ImmutableDB doesn't care about the serialisation format, but in
 -- practice we use CBOR. If we were to change the serialisation format, we
 -- would have to write a new 'EpochFileParser' implementation, but the rest of
@@ -25,7 +26,7 @@ import qualified Streaming as S
 import qualified Streaming.Prelude as S
 
 import           Ouroboros.Network.Block (ChainHash (..), HasHeader (..),
-                     HeaderHash)
+                     HeaderHash, SlotNo)
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import qualified Ouroboros.Consensus.Util.CBOR as Util.CBOR
@@ -55,6 +56,12 @@ data EpochFileError hash =
     -- 'BlockOrEBB' number returned 'False', indicating that the block got
     -- corrupted.
   | EpochErrCorrupt hash BlockOrEBB
+
+    -- | The block has a slot number greater than the current slot (wall
+    -- clock). This block is in the future, so we must truncate it.
+  | EpochErrFutureBlock
+      SlotNo  -- ^ Current slot (wall clock)
+      SlotNo  -- ^ Slot number of the block
   deriving (Eq, Show)
 
 epochFileParser'
@@ -75,15 +82,35 @@ epochFileParser'
        hash
 epochFileParser' getSlotNo getHash getPrevHash hasFS decodeBlock isEBB
                  getBinaryInfo isNotCorrupt =
-    EpochFileParser $ \fsPath expectedChecksums k ->
+    EpochFileParser $ \fsPath currentSlotNo expectedChecksums k ->
       Util.CBOR.withStreamIncrementalOffsets hasFS decoder fsPath
-        (k . checkIfHashesLineUp . checkEntries expectedChecksums)
+        ( k
+        . checkIfHashesLineUp
+        . checkEntries expectedChecksums
+        . checkFutureSlot currentSlotNo
+        . fmap (fmap (first EpochErrRead))
+        )
   where
     decoder :: forall s. Decoder s (BL.ByteString -> (blk, CRC))
     decoder = decodeBlock <&> \mkBlk bs ->
       let !blk      = mkBlk bs
           !checksum = computeCRC bs
       in (blk, checksum)
+
+    -- | Stop when a block has slot number > the current slot, return
+    -- 'EpochErrFutureBlock'.
+    checkFutureSlot
+      :: SlotNo  -- ^ Current slot (wall clock).
+      -> Stream (Of (Word64, (Word64, (blk, CRC))))
+                m
+                (Maybe (EpochFileError hash, Word64))
+      -> Stream (Of (Word64, (Word64, (blk, CRC))))
+                m
+                (Maybe (EpochFileError hash, Word64))
+    checkFutureSlot currentSlotNo = mapS $ \x@(offset, (_, (blk, _))) ->
+      if getSlotNo blk > currentSlotNo
+      then Left $ Just (EpochErrFutureBlock currentSlotNo (getSlotNo blk), offset)
+      else Right x
 
     -- | Go over the expected checksums and blocks in parallel. Stop with an
     -- error when a block is corrupt. Yield correct entries along the way.
@@ -100,33 +127,36 @@ epochFileParser' getSlotNo getHash getPrevHash hasFS decodeBlock isEBB
          -- ^ Expected checksums
       -> Stream (Of (Word64, (Word64, (blk, CRC))))
                 m
-                (Maybe (Util.CBOR.ReadIncrementalErr, Word64))
+                (Maybe (EpochFileError hash, Word64))
          -- ^ Input stream of blocks (with additional info)
       -> Stream (Of (Secondary.Entry hash, WithOrigin hash))
                 m
                 (Maybe (EpochFileError hash, Word64))
-    checkEntries = go
+    checkEntries = \expected -> mapAccumS expected handle
       where
-        go expected blkAndInfos = S.lift (S.next blkAndInfos) >>= \case
-          -- No more blocks, but maybe some expected entries. We ignore them.
-          Left mbErr -> return $ first EpochErrRead <$> mbErr
-          -- A block
-          Right (blkAndInfo@(offset, (_, (blk, checksum))), blkAndInfos') ->
-              case expected of
-                expectedChecksum:expected'
-                  | expectedChecksum == checksum
-                  -> S.yield entryAndPrevHash *> go expected' blkAndInfos'
-                -- No expected entry or a mismatch
-                _ | isNotCorrupt blk
-                    -- The (expensive) integrity check passed, so continue
-                  -> S.yield entryAndPrevHash *> go (drop 1 expected) blkAndInfos'
-                  | otherwise
-                    -- The block is corrupt, stop
-                  -> return $ Just (EpochErrCorrupt headerHash blockOrEBB, offset)
-            where
-              entryAndPrevHash@(actualEntry, _) =
-                entryForBlockAndInfo blkAndInfo
-              Secondary.Entry { headerHash, blockOrEBB } = actualEntry
+        handle
+          :: [CRC]
+          -> (Word64, (Word64, (blk, CRC)))
+          -> Either (Maybe (EpochFileError hash, Word64))
+                    ( (Secondary.Entry hash, WithOrigin hash)
+                    , [CRC]
+                    )
+        handle expected blkAndInfo@(offset, (_, (blk, checksum))) =
+            case expected of
+              expectedChecksum:expected'
+                | expectedChecksum == checksum
+                -> Right (entryAndPrevHash, expected')
+              -- No expected entry or a mismatch
+              _ | isNotCorrupt blk
+                  -- The (expensive) integrity check passed, so continue
+                -> Right (entryAndPrevHash, drop 1 expected)
+                | otherwise
+                  -- The block is corrupt, stop
+                -> Left $ Just (EpochErrCorrupt headerHash blockOrEBB, offset)
+          where
+            entryAndPrevHash@(actualEntry, _) =
+              entryForBlockAndInfo blkAndInfo
+            Secondary.Entry { headerHash, blockOrEBB } = actualEntry
 
     entryForBlockAndInfo
       :: (Word64, (Word64, (blk, CRC)))
@@ -154,26 +184,19 @@ epochFileParser' getSlotNo getHash getPrevHash hasFS decodeBlock isEBB
       -> Stream (Of (Secondary.Entry hash, WithOrigin hash))
                 m
                 (Maybe (EpochFileError hash, Word64))
-    checkIfHashesLineUp = \input -> S.lift (S.next input) >>= \case
-        Left mbErr ->
-          return mbErr
-        Right ((entry, prevHash), input') ->
-          S.yield (entry, prevHash) *>
-          go (At (Secondary.headerHash entry)) input'
+    checkIfHashesLineUp = mapAccumS0 checkFirst checkNext
       where
-        -- Loop invariant: the @hashOfPrevBlock@ is the hash of the most
-        -- recently checked block.
-        go hashOfPrevBlock input = S.lift (S.next input) >>= \case
-          Left mbErr
-            -> return mbErr
-          Right ((entry, prevHash), input')
-            | prevHash == hashOfPrevBlock
-            -> S.yield (entry, prevHash) *>
-               go (At (Secondary.headerHash entry)) input'
-            | otherwise
-            -> let err = EpochErrHashMismatch hashOfPrevBlock prevHash
-                   offset = Secondary.unBlockOffset $ Secondary.blockOffset entry
-               in return $ Just (err, offset)
+        -- We pass the hash of the previous block around as the state (@s@).
+        checkFirst x@(entry, _) = Right (x, Secondary.headerHash entry)
+
+        checkNext hashOfPrevBlock x@(entry, prevHash)
+          | prevHash == At hashOfPrevBlock
+          = Right (x, Secondary.headerHash entry)
+          | otherwise
+          = Left (Just (err, offset))
+            where
+              err = EpochErrHashMismatch (At hashOfPrevBlock) prevHash
+              offset = Secondary.unBlockOffset $ Secondary.blockOffset entry
 
 -- | A version of 'epochFileParser'' for blocks that implement 'HasHeader'.
 epochFileParser
@@ -195,3 +218,47 @@ epochFileParser =
     convertPrevHash :: ChainHash blk -> WithOrigin (HeaderHash blk)
     convertPrevHash GenesisHash   = Origin
     convertPrevHash (BlockHash h) = At h
+
+{-------------------------------------------------------------------------------
+  Streaming utilities
+-------------------------------------------------------------------------------}
+
+-- | Thread some state through a 'Stream'. An early return is possible by
+-- returning 'Left'.
+mapAccumS
+  :: Monad m
+  => s  -- ^ Initial state
+  -> (s -> a -> Either r (b, s))
+  -> Stream (Of a) m r
+  -> Stream (Of b) m r
+mapAccumS st0 handle = go st0
+  where
+    go st input = S.lift (S.next input) >>= \case
+      Left  r           -> return r
+      Right (a, input') -> case handle st a of
+        Left r         -> return r
+        Right (b, st') -> S.yield b *> go st' input'
+
+-- | Variant of 'mapAccumS' that calls the first function argument on the
+-- first element in the stream to construct the initial state. For all
+-- elements in the stream after the first one, the second function argument is
+-- used.
+mapAccumS0
+  :: forall m a b r s. Monad m
+  => (a -> Either r (b, s))
+  -> (s -> a -> Either r (b, s))
+  -> Stream (Of a) m r
+  -> Stream (Of b) m r
+mapAccumS0 handleFirst handleNext = mapAccumS Nothing handle
+  where
+    handle :: Maybe s -> a -> Either r (b, Maybe s)
+    handle mbSt = fmap (fmap Just) . maybe handleFirst handleNext mbSt
+
+-- | Map over elements of a stream, allowing an early return by returning
+-- 'Left'.
+mapS
+  :: Monad m
+  => (a -> Either r b)
+  -> Stream (Of a) m r
+  -> Stream (Of b) m r
+mapS handle = mapAccumS () (\() a -> (, ()) <$> handle a)

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Types.hs
@@ -107,13 +107,15 @@ newtype EpochFileParser e m entry hash = EpochFileParser
   { runEpochFileParser
       :: forall r.
          FsPath
-      ->  [CRC]
-          -- The expected checksums are given as input. This list can be empty
-          -- when the secondary index file is missing. If the expected
-          -- checksum matches the actual checksum, we can avoid the expensive
-          -- integrity check of the block.
+      -> SlotNo
+         -- Current slot (wall clock)
+      -> [CRC]
+         -- The expected checksums are given as input. This list can be empty
+         -- when the secondary index file is missing. If the expected checksum
+         -- matches the actual checksum, we can avoid the expensive integrity
+         -- check of the block.
       -> (Stream (Of (entry, WithOrigin hash)) m (Maybe (e, Word64)) -> m r)
-          -- Continuation to ensure the file is closed
+         -- Continuation to ensure the file is closed
       -> m r
   }
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/ImmDB.hs
@@ -20,6 +20,7 @@ import           Ouroboros.Network.Block (BlockNo (..), ChainHash (..),
                      SlotNo (..), blockPoint)
 
 import           Ouroboros.Consensus.Block (BlockProtocol)
+import           Ouroboros.Consensus.BlockchainTime.Mock (fixedBlockchainTime)
 import           Ouroboros.Consensus.Ledger.Byron (ByronBlock)
 import           Ouroboros.Consensus.Ledger.Byron.Forge (forgeEBB)
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -85,6 +86,8 @@ withImmDB k = withRegistry $ \registry -> do
       , immTracer         = nullTracer
       , immCacheConfig    = ImmDB.CacheConfig 2 60
       , immRegistry       = registry
+        -- All blocks will be in the past, so no truncation will happen
+      , immBlockchainTime = fixedBlockchainTime maxBound
       }
 
 testCfg :: NodeConfig (BlockProtocol ByronBlock)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -73,6 +73,8 @@ import qualified Ouroboros.Network.Point as Point
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
+import           Ouroboros.Consensus.BlockchainTime.Mock
+                     (settableBlockchainTime)
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Node.ProtocolInfo.Abstract
@@ -1259,15 +1261,6 @@ smUnused :: StateMachine (Model Blk IO) (At Cmd Blk IO) IO (At Resp Blk IO)
 smUnused =
     sm dbUnused internalUnused registryUnunused varCurSlotUnused varNextIdUnused
       genBlk testCfg testInitExtLedger
-
--- | The current slot can be changed by modifying the given 'StrictTVar'.
--- 'onSlotChange_' is not implemented as it is currently not used by the
--- ChainDB.
-settableBlockchainTime :: IOLike m => StrictTVar m SlotNo -> BlockchainTime m
-settableBlockchainTime varCurSlot = BlockchainTime {
-      getCurrentSlot = readTVar varCurSlot
-    , onSlotChange_  = error "unimplemented onSlotChange_"
-    }
 
 prop_sequential :: Property
 prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -17,6 +17,7 @@ import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck (testProperty)
 
 import           Ouroboros.Consensus.Block (getHeader)
+import           Ouroboros.Consensus.BlockchainTime.Mock (fixedBlockchainTime)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
@@ -77,6 +78,7 @@ openTestDB registry hasFS err = fst <$> openDBInternal
     parser
     nullTracer
     (Index.CacheConfig 2 60)
+    (fixedBlockchainTime maxBound)
   where
     parser = epochFileParser hasFS (const <$> S.decode) isEBB getBinaryInfo
       testBlockIsValid

--- a/ouroboros-consensus/tools/db-analyse/Main.hs
+++ b/ouroboros-consensus/tools/db-analyse/Main.hs
@@ -26,6 +26,7 @@ import qualified Cardano.Crypto as Crypto
 import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..),
                      genesisPoint)
 
+import           Ouroboros.Consensus.BlockchainTime.Mock (fixedBlockchainTime)
 import           Ouroboros.Consensus.Ledger.Byron (ByronBlock,
                      ByronConsensusProtocol, ByronHash)
 import qualified Ouroboros.Consensus.Ledger.Byron as Byron
@@ -266,4 +267,6 @@ withImmDB fp cfg epochInfo registry = ImmDB.withImmDB args
         , immCheckIntegrity = nodeCheckIntegrity      cfg
         , immAddHdrEnv      = nodeAddHeaderEnvelope   (Proxy @ByronBlock)
         , immRegistry       = registry
+          -- We don't want to truncate blocks from the future
+        , immBlockchainTime = fixedBlockchainTime maxBound
         }


### PR DESCRIPTION
Fixes #1550.

During validation, truncate any blocks >= the current (wall clock) slot.