### PR TITLE
Add optional expiry slot to Mock transactions

### DIFF
--- a/ouroboros-consensus-byron/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/DualPBFT.hs
@@ -80,7 +80,8 @@ prop_convergence setup = withMaxSuccess 10 $
     (\prop -> if mightForgeInSlot0 then discard else prop) $
     tabulate "Ref.PBFT result" [Ref.resultConstrName refResult] $
     prop_general PropGeneralArgs
-      { pgaCountTxs               = countByronGenTxs . dualBlockMain
+      { pgaBlockProperty          = const $ property True
+      , pgaCountTxs               = countByronGenTxs . dualBlockMain
       , pgaExpectedBlockRejection = setupExpectedRejections setup
       , pgaFirstBlockNo           = 1
       , pgaFixedMaxForkLength     =

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
@@ -566,7 +566,8 @@ prop_simple_real_pbft_convergence produceEBBs k
           | (nid, ch) <- finalChains
           ]) $
     prop_general PropGeneralArgs
-      { pgaCountTxs               = Byron.countByronGenTxs
+      { pgaBlockProperty          = const $ property True
+      , pgaCountTxs               = Byron.countByronGenTxs
       , pgaExpectedBlockRejection =
           expectedBlockRejection k numCoreNodes nodeRestarts
       , pgaFirstBlockNo           = 1

--- a/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -84,6 +84,7 @@ test-suite test
                        Test.ThreadNet.Praos
                        Test.ThreadNet.TxGen.Mock
                        Test.ThreadNet.Util.HasCreator.Mock
+                       Test.ThreadNet.Util.SimpleBlock
 
   build-depends:       base
                      , binary

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -223,14 +223,14 @@ instance (SimpleCrypto c, Typeable ext) => HasHeader (SimpleBlock c ext) where
 instance (SimpleCrypto c, Typeable ext) => StandardHash (SimpleBlock c ext)
 
 {-------------------------------------------------------------------------------
-  HasTxs instance
+  HasMockTxs instance
 -------------------------------------------------------------------------------}
 
-instance Mock.HasTxs (SimpleBlock' c ext ext') where
-  getTxs = Mock.getTxs . simpleBody
+instance Mock.HasMockTxs (SimpleBlock' c ext ext') where
+  getMockTxs = Mock.getMockTxs . simpleBody
 
-instance Mock.HasTxs SimpleBody where
-  getTxs = simpleTxs
+instance Mock.HasMockTxs SimpleBody where
+  getMockTxs = simpleTxs
 
 {-------------------------------------------------------------------------------
   Envelope validation
@@ -320,7 +320,7 @@ updateSimpleLedgerState :: (SimpleCrypto c, Typeable ext)
 updateSimpleLedgerState b (SimpleLedgerState st) =
     SimpleLedgerState <$> updateMockState b st
 
-updateSimpleUTxO :: Mock.HasTxs a
+updateSimpleUTxO :: Mock.HasMockTxs a
                  => a
                  -> TickedLedgerState (SimpleBlock c ext)
                  -> Except (MockError (SimpleBlock c ext))
@@ -364,8 +364,8 @@ instance (Typeable p, Typeable c) => NoUnexpectedThunks (GenTx (SimpleBlock p c)
 instance HasTxs (SimpleBlock c ext) where
   extractTxs = map mkSimpleGenTx . simpleTxs . simpleBody
 
-instance Mock.HasTxs (GenTx (SimpleBlock p c)) where
-  getTxs = Mock.getTxs . simpleGenTx
+instance Mock.HasMockTxs (GenTx (SimpleBlock p c)) where
+  getMockTxs = Mock.getMockTxs . simpleGenTx
 
 instance Condense (GenTx (SimpleBlock p c)) where
     condense = condense . simpleGenTx

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -223,20 +223,14 @@ instance (SimpleCrypto c, Typeable ext) => HasHeader (SimpleBlock c ext) where
 instance (SimpleCrypto c, Typeable ext) => StandardHash (SimpleBlock c ext)
 
 {-------------------------------------------------------------------------------
-  HasUTxO instance
+  HasTxs instance
 -------------------------------------------------------------------------------}
 
-instance Mock.HasUtxo (SimpleBlock' c ext ext') where
-  txIns      = Mock.txIns      . simpleBody
-  txOuts     = Mock.txOuts     . simpleBody
-  confirmed  = Mock.confirmed  . simpleBody
-  updateUtxo = Mock.updateUtxo . simpleBody
+instance Mock.HasTxs (SimpleBlock' c ext ext') where
+  getTxs = Mock.getTxs . simpleBody
 
-instance Mock.HasUtxo SimpleBody where
-  txIns      = Mock.txIns      . simpleTxs
-  txOuts     = Mock.txOuts     . simpleTxs
-  confirmed  = Mock.confirmed  . simpleTxs
-  updateUtxo = Mock.updateUtxo . simpleTxs
+instance Mock.HasTxs SimpleBody where
+  getTxs = simpleTxs
 
 {-------------------------------------------------------------------------------
   Envelope validation
@@ -326,13 +320,14 @@ updateSimpleLedgerState :: (SimpleCrypto c, Typeable ext)
 updateSimpleLedgerState b (SimpleLedgerState st) =
     SimpleLedgerState <$> updateMockState b st
 
-updateSimpleUTxO :: Mock.HasUtxo a
+updateSimpleUTxO :: Mock.HasTxs a
                  => a
                  -> TickedLedgerState (SimpleBlock c ext)
                  -> Except (MockError (SimpleBlock c ext))
                            (TickedLedgerState (SimpleBlock c ext))
-updateSimpleUTxO b (TickedLedgerState slot (SimpleLedgerState st)) =
-    TickedLedgerState slot . SimpleLedgerState <$> updateMockUTxO b st
+updateSimpleUTxO x (TickedLedgerState slot (SimpleLedgerState st)) =
+    TickedLedgerState slot . SimpleLedgerState <$>
+      updateMockUTxO slot x st
 
 genesisSimpleLedgerState :: AddrDist -> LedgerState (SimpleBlock c ext)
 genesisSimpleLedgerState = SimpleLedgerState . genesisMockState
@@ -369,11 +364,8 @@ instance (Typeable p, Typeable c) => NoUnexpectedThunks (GenTx (SimpleBlock p c)
 instance HasTxs (SimpleBlock c ext) where
   extractTxs = map mkSimpleGenTx . simpleTxs . simpleBody
 
-instance Mock.HasUtxo (GenTx (SimpleBlock p c)) where
-  txIns      = Mock.txIns      . simpleGenTx
-  txOuts     = Mock.txOuts     . simpleGenTx
-  confirmed  = Mock.confirmed  . simpleGenTx
-  updateUtxo = Mock.updateUtxo . simpleGenTx
+instance Mock.HasTxs (GenTx (SimpleBlock p c)) where
+  getTxs = Mock.getTxs . simpleGenTx
 
 instance Condense (GenTx (SimpleBlock p c)) where
     condense = condense . simpleGenTx

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
@@ -100,7 +100,7 @@ updateMockUTxO1 now tx (MockState u c t) = case hasExpired of
       u' <- withExcept MockUtxoError $ updateUtxo tx u
       return $ MockState u' (c `Set.union` confirmed tx) t
   where
-      Tx expiry _ins _outs       = tx
+      Tx expiry _ins _outs = tx
 
       hasExpired :: Maybe (MockError blk)
       hasExpired = case expiry of

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass       #-}
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -23,13 +24,15 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Crypto.Hash
 import           Cardano.Prelude (NoUnexpectedThunks)
+import           Cardano.Slotting.Slot (SlotNo)
 
 import           Ouroboros.Network.Block (ChainHash, HasHeader, HeaderHash,
-                     Point, StandardHash, genesisPoint, pointHash)
+                     Point, StandardHash, blockSlot, genesisPoint, pointHash)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Mock.Ledger.Address
 import           Ouroboros.Consensus.Mock.Ledger.UTxO
+import           Ouroboros.Consensus.Util (repeatedlyM)
 
 {-------------------------------------------------------------------------------
   State of the mock ledger
@@ -45,7 +48,10 @@ data MockState blk = MockState {
 deriving instance Serialise (HeaderHash blk) => Serialise (MockState blk)
 
 data MockError blk =
-    MockUtxoError UtxoError
+    MockExpired !SlotNo !SlotNo
+    -- ^ The transaction expired in the first 'SlotNo', and it failed to
+    -- validate in the second 'SlotNo'.
+  | MockUtxoError UtxoError
   | MockInvalidHash (ChainHash blk) (ChainHash blk)
   deriving (Generic, NoUnexpectedThunks)
 
@@ -56,14 +62,15 @@ deriving instance Serialise (HeaderHash blk) => Serialise (MockError blk)
 updateMockState :: ( GetHeader blk
                    , HasHeader (Header blk)
                    , StandardHash blk
-                   , HasUtxo blk
+                   , HasTxs blk
                    )
                 => blk
                 -> MockState blk
                 -> Except (MockError blk) (MockState blk)
-updateMockState b st = do
-    st' <- updateMockTip (getHeader b) st
-    updateMockUTxO b st'
+updateMockState blk st = do
+    let hdr = getHeader blk
+    st' <- updateMockTip hdr st
+    updateMockUTxO (blockSlot hdr) blk st'
 
 updateMockTip :: (HasHeader (Header blk), StandardHash blk)
               => Header blk
@@ -75,13 +82,32 @@ updateMockTip hdr (MockState u c t)
     | otherwise
     = throwError $ MockInvalidHash (headerPrevHash hdr) (pointHash t)
 
-updateMockUTxO :: HasUtxo a
-               => a
+updateMockUTxO :: HasTxs a
+               => SlotNo
+               -> a
                -> MockState blk
                -> Except (MockError blk) (MockState blk)
-updateMockUTxO b (MockState u c t) = do
-    u' <- withExcept MockUtxoError $ updateUtxo b u
-    return $ MockState u' (c `Set.union` confirmed b) t
+updateMockUTxO now = repeatedlyM (updateMockUTxO1 now) . getTxs
+
+updateMockUTxO1 :: forall blk.
+                   SlotNo
+                -> Tx
+                -> MockState blk
+                -> Except (MockError blk) (MockState blk)
+updateMockUTxO1 now tx (MockState u c t) = case hasExpired of
+    Just e  -> throwError e
+    Nothing -> do
+      u' <- withExcept MockUtxoError $ updateUtxo tx u
+      return $ MockState u' (c `Set.union` confirmed tx) t
+  where
+      Tx expiry _ins _outs       = tx
+
+      hasExpired :: Maybe (MockError blk)
+      hasExpired = case expiry of
+          DoNotExpire       -> Nothing
+          ExpireAtOnsetOf s -> do
+            guard $ s <= now
+            Just $ MockExpired s now
 
 {-------------------------------------------------------------------------------
   Genesis

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
@@ -62,7 +62,7 @@ deriving instance Serialise (HeaderHash blk) => Serialise (MockError blk)
 updateMockState :: ( GetHeader blk
                    , HasHeader (Header blk)
                    , StandardHash blk
-                   , HasTxs blk
+                   , HasMockTxs blk
                    )
                 => blk
                 -> MockState blk
@@ -82,12 +82,12 @@ updateMockTip hdr (MockState u c t)
     | otherwise
     = throwError $ MockInvalidHash (headerPrevHash hdr) (pointHash t)
 
-updateMockUTxO :: HasTxs a
+updateMockUTxO :: HasMockTxs a
                => SlotNo
                -> a
                -> MockState blk
                -> Except (MockError blk) (MockState blk)
-updateMockUTxO now = repeatedlyM (updateMockUTxO1 now) . getTxs
+updateMockUTxO now = repeatedlyM (updateMockUTxO1 now) . getMockTxs
 
 updateMockUTxO1 :: forall blk.
                    SlotNo

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DeriveAnyClass       #-}
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE DerivingVia          #-}
+{-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE PatternSynonyms      #-}
-{-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Mock.Ledger.UTxO (
@@ -15,9 +15,14 @@ module Ouroboros.Consensus.Mock.Ledger.UTxO (
   , Amount
   , Ix
   , Utxo
+  , Expiry(..)
     -- * Computing UTxO
+  , HasTxs(..)
+  , txIns
+  , txOuts
+  , confirmed
+  , updateUtxo
   , UtxoError(..)
-  , HasUtxo(..)
     -- * Genesis
   , genesisTx
   , genesisUtxo
@@ -38,9 +43,10 @@ import           Cardano.Binary (ToCBOR (..))
 import           Cardano.Crypto.Hash
 import           Cardano.Prelude (NoUnexpectedThunks, UseIsNormalForm (..))
 
+import           Ouroboros.Network.Block (SlotNo)
 import           Ouroboros.Network.MockChain.Chain (Chain, toOldestFirst)
 
-import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util (repeatedlyM)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 
@@ -50,14 +56,23 @@ import           Ouroboros.Consensus.Mock.Ledger.Address
   Basic definitions
 -------------------------------------------------------------------------------}
 
-data Tx = UnsafeTx (Set TxIn) [TxOut]
+data Expiry
+  = DoNotExpire
+  | ExpireAtOnsetOf !SlotNo
+  deriving stock    (Show, Eq, Ord, Generic)
+  deriving anyclass (Serialise, NFData, NoUnexpectedThunks)
+
+instance Condense Expiry where
+  condense = show
+
+data Tx = UnsafeTx Expiry (Set TxIn) [TxOut]
   deriving stock    (Show, Eq, Ord, Generic)
   deriving anyclass (Serialise, NFData)
   deriving NoUnexpectedThunks via UseIsNormalForm Tx
 
-pattern Tx :: Set TxIn -> [TxOut] -> Tx
-pattern Tx ins outs <- UnsafeTx ins outs where
-  Tx ins outs = force $ UnsafeTx ins outs
+pattern Tx :: Expiry -> Set TxIn -> [TxOut] -> Tx
+pattern Tx expiry ins outs <- UnsafeTx expiry ins outs where
+  Tx expiry ins outs = force $ UnsafeTx expiry ins outs
 
 {-# COMPLETE Tx #-}
 
@@ -65,7 +80,7 @@ instance ToCBOR Tx where
   toCBOR = encode
 
 instance Condense Tx where
-  condense (Tx ins outs) = condense (ins, outs)
+  condense (Tx expiry ins outs) = condense (expiry, ins, outs)
 
 type Ix     = Word
 type Amount = Word
@@ -89,53 +104,54 @@ data UtxoError
 instance Condense UtxoError where
   condense = show
 
-class HasUtxo a where
-  txIns      :: a -> Set TxIn
-  txOuts     :: a -> Utxo
-  confirmed  :: a -> Set TxId
-  updateUtxo :: a -> Utxo -> Except UtxoError Utxo
+class HasTxs a where
+  getTxs :: a -> [Tx]
 
-{-------------------------------------------------------------------------------
-  HasUtxo instances
--------------------------------------------------------------------------------}
+instance HasTxs Tx where
+  getTxs = (:[])
 
-instance HasUtxo Tx where
-  txIns     (Tx ins _outs) = ins
-  txOuts tx@(Tx _ins outs) =
-      Map.fromList $ zipWith aux [0..] outs
-    where
-      aux :: Ix -> TxOut -> (TxIn, TxOut)
-      aux ix out = ((hash tx, ix), out)
+instance HasTxs a => HasTxs [a] where
+  getTxs = concatMap getTxs
 
-  confirmed       = Set.singleton . hash
-  updateUtxo tx = execStateT $ do
-    -- Remove all inputs from the Utxo and calculate the sum of all the input
-    -- amounts
-    inputAmount <- fmap sum $ forM (Set.toList (txIns tx)) $ \txIn -> do
-      u <- get
-      case Map.updateLookupWithKey (\_ _ -> Nothing) txIn u of
-        (Nothing,              _)  -> throwError $ MissingInput txIn
-        (Just (_addr, amount), u') -> put u' $> amount
+instance HasTxs a => HasTxs (Chain a) where
+  getTxs = getTxs . toOldestFirst
 
-    -- Check that the sum of the inputs is equal to the sum of the outputs
-    let outputAmount = sum $ map snd $ Map.elems $ txOuts tx
-    when (inputAmount /= outputAmount) $
-      throwError $ InputOutputMismatch inputAmount outputAmount
+txIns :: HasTxs a => a -> Set TxIn
+txIns = Set.unions . map each . getTxs
+  where
+    each (Tx _expiry ins _outs) = ins
 
-    -- Add the outputs to the Utxo
-    modify (`Map.union` txOuts tx)
+txOuts :: HasTxs a => a -> Utxo
+txOuts = Map.unions . map each . getTxs
+  where
+    each tx@(Tx _expiry _ins outs) =
+        Map.fromList $ zipWith aux [0..] outs
+      where
+        aux :: Ix -> TxOut -> (TxIn, TxOut)
+        aux ix out = ((hash tx, ix), out)
 
-instance HasUtxo a => HasUtxo [a] where
-  txIns      = foldr (Set.union . txIns)     Set.empty
-  txOuts     = foldr (Map.union . txOuts)    Map.empty
-  confirmed  = foldr (Set.union . confirmed) Set.empty
-  updateUtxo = repeatedlyM updateUtxo
+confirmed :: HasTxs a => a -> Set TxId
+confirmed = Set.fromList . map hash . getTxs
 
-instance HasUtxo a => HasUtxo (Chain a) where
-  txIns      = txIns      . toOldestFirst
-  txOuts     = txOuts     . toOldestFirst
-  updateUtxo = updateUtxo . toOldestFirst
-  confirmed  = confirmed  . toOldestFirst
+updateUtxo :: HasTxs a => a -> Utxo -> Except UtxoError Utxo
+updateUtxo = repeatedlyM each . getTxs
+  where
+    each tx = execStateT $ do
+        -- Remove all inputs from the Utxo and calculate the sum of all the
+        -- input amounts
+        inputAmount <- fmap sum $ forM (Set.toList (txIns tx)) $ \txIn -> do
+          u <- get
+          case Map.updateLookupWithKey (\_ _ -> Nothing) txIn u of
+            (Nothing,              _)  -> throwError $ MissingInput txIn
+            (Just (_addr, amount), u') -> put u' $> amount
+
+        -- Check that the sum of the inputs is equal to the sum of the outputs
+        let outputAmount = sum $ map snd $ Map.elems $ txOuts tx
+        when (inputAmount /= outputAmount) $
+          throwError $ InputOutputMismatch inputAmount outputAmount
+
+        -- Add the outputs to the Utxo
+        modify (`Map.union` txOuts tx)
 
 {-------------------------------------------------------------------------------
   Genesis
@@ -143,7 +159,8 @@ instance HasUtxo a => HasUtxo (Chain a) where
 
 -- | Transaction giving initial stake to the nodes
 genesisTx :: AddrDist -> Tx
-genesisTx addrDist = Tx mempty [(addr, 1000) | addr <- Map.keys addrDist]
+genesisTx addrDist =
+    Tx DoNotExpire mempty [(addr, 1000) | addr <- Map.keys addrDist]
 
 genesisUtxo :: AddrDist -> Utxo
 genesisUtxo addrDist = txOuts (genesisTx addrDist)

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/Consensus/Ledger/Mock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/Consensus/Ledger/Mock.hs
@@ -139,7 +139,7 @@ instance Arbitrary SimpleBody where
   arbitrary = SimpleBody <$> listOf arbitrary
 
 instance Arbitrary Tx where
-  arbitrary = Tx
+  arbitrary = Tx DoNotExpire
          <$> pure mempty  -- For simplicity
          <*> arbitrary
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -4,7 +4,8 @@ module Test.ThreadNet.BFT (
     tests
   ) where
 
-import qualified Data.Map as Map
+import qualified Data.Map.Strict as Map
+
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -16,7 +17,7 @@ import           Ouroboros.Consensus.BlockchainTime.Mock
 import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Mock.Node ()
 import           Ouroboros.Consensus.Mock.Node.BFT
-import           Ouroboros.Consensus.Node.ProtocolInfo
+import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Random (Seed (..))
@@ -27,11 +28,12 @@ import           Test.ThreadNet.Util
 import           Test.ThreadNet.Util.NodeJoinPlan
 import           Test.ThreadNet.Util.NodeRestarts
 import           Test.ThreadNet.Util.NodeTopology
+import           Test.ThreadNet.Util.SimpleBlock
 
 import           Test.Util.Orphans.Arbitrary ()
 
 tests :: TestTree
-tests = testGroup "BFT"
+tests = testGroup "BFT" $
     [ testProperty "delayed message corner case" $
         once $
         let ncn = NumCoreNodes 2 in
@@ -44,11 +46,30 @@ tests = testGroup "BFT"
           , slotLength   = slotLengthFromSec 1
           , initSeed = Seed {getSeed = (12659702313441544615,9326820694273232011,15820857683988100572,2201554969601311572,4716411940989238571)}
           }
-    ,
-      testProperty "simple convergence" $ \tc ->
+    , testProperty "Mock.applyChainTick is not a no-op" $
+        -- This repro failed via on a wip branch that included a fix for Issue
+        -- 1489 and but not for Issue 1559. PR 1562 fixed it. We're retaining
+        -- this as a regression test.
+        once $
+        let ncn = NumCoreNodes 3 in
+        prop_simple_bft_convergence (SecurityParam 5)
+        TestConfig
+          { numCoreNodes = ncn
+          , numSlots     = NumSlots 7
+          , nodeJoinPlan = NodeJoinPlan $ Map.fromList [(CoreNodeId 0, SlotNo 0),(CoreNodeId 1, SlotNo 2),(CoreNodeId 2, SlotNo 2)]
+          , nodeRestarts = noRestarts
+          , nodeTopology = meshNodeTopology ncn
+          , slotLengths  = defaultSlotLengths
+          , initSeed     = Seed (6358650144370660550,17563794202468751585,17692838336641672274,12649320068211251815,18441126729279419067)
+          }
+    , testProperty "simple convergence" $ \tc ->
+        -- TODO k > 1 as a workaround for Issue #1511.
+        --
         forAll (SecurityParam <$> elements [2 .. 10]) $ \k ->
         prop_simple_bft_convergence k tc
     ]
+  where
+    defaultSlotLengths = singletonSlotLengths $ slotLengthFromSec 1
 
 prop_simple_bft_convergence :: SecurityParam
                             -> TestConfig
@@ -56,7 +77,8 @@ prop_simple_bft_convergence :: SecurityParam
 prop_simple_bft_convergence k
   testConfig@TestConfig{numCoreNodes, numSlots, slotLength} =
     prop_general PropGeneralArgs
-      { pgaCountTxs               = countSimpleGenTxs
+      { pgaBlockProperty          = prop_validSimpleBlock
+      , pgaCountTxs               = countSimpleGenTxs
       , pgaExpectedBlockRejection = const False
       , pgaFirstBlockNo           = 0
       , pgaFixedMaxForkLength     = Nothing

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -43,7 +43,7 @@ tests = testGroup "BFT" $
           , nodeJoinPlan = NodeJoinPlan (Map.fromList [(CoreNodeId 0,SlotNo {unSlotNo = 0}),(CoreNodeId 1,SlotNo {unSlotNo = 1})])
           , nodeRestarts = noRestarts
           , nodeTopology = meshNodeTopology ncn
-          , slotLength   = slotLengthFromSec 1
+          , slotLength   = defaultSlotLength
           , initSeed = Seed {getSeed = (12659702313441544615,9326820694273232011,15820857683988100572,2201554969601311572,4716411940989238571)}
           }
     , testProperty "Mock.applyChainTick is not a no-op" $
@@ -59,7 +59,7 @@ tests = testGroup "BFT" $
           , nodeJoinPlan = NodeJoinPlan $ Map.fromList [(CoreNodeId 0, SlotNo 0),(CoreNodeId 1, SlotNo 2),(CoreNodeId 2, SlotNo 2)]
           , nodeRestarts = noRestarts
           , nodeTopology = meshNodeTopology ncn
-          , slotLengths  = defaultSlotLengths
+          , slotLength   = defaultSlotLength
           , initSeed     = Seed (6358650144370660550,17563794202468751585,17692838336641672274,12649320068211251815,18441126729279419067)
           }
     , testProperty "simple convergence" $ \tc ->
@@ -69,7 +69,7 @@ tests = testGroup "BFT" $
         prop_simple_bft_convergence k tc
     ]
   where
-    defaultSlotLengths = singletonSlotLengths $ slotLengthFromSec 1
+    defaultSlotLength = slotLengthFromSec 20
 
 prop_simple_bft_convergence :: SecurityParam
                             -> TestConfig

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -47,9 +47,9 @@ tests = testGroup "BFT" $
           , initSeed = Seed {getSeed = (12659702313441544615,9326820694273232011,15820857683988100572,2201554969601311572,4716411940989238571)}
           }
     , testProperty "Mock.applyChainTick is not a no-op" $
-        -- This repro failed via on a wip branch that included a fix for Issue
-        -- 1489 and but not for Issue 1559. PR 1562 fixed it. We're retaining
-        -- this as a regression test.
+        -- This repro failed on a wip branch that included a fix for Issue 1489
+        -- and but not for Issue 1559. PR 1562 fixed it. We're retaining this
+        -- as a regression test.
         once $
         let ncn = NumCoreNodes 3 in
         prop_simple_bft_convergence (SecurityParam 5)

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -35,6 +35,7 @@ import           Test.ThreadNet.Util.HasCreator.Mock ()
 import           Test.ThreadNet.Util.NodeJoinPlan
 import           Test.ThreadNet.Util.NodeRestarts
 import           Test.ThreadNet.Util.NodeTopology
+import           Test.ThreadNet.Util.SimpleBlock
 
 import           Test.Util.Orphans.Arbitrary ()
 
@@ -91,7 +92,8 @@ prop_simple_leader_schedule_convergence
   testConfig@TestConfig{numCoreNodes} schedule =
     counterexample (tracesToDot testOutputNodes) $
     prop_general PropGeneralArgs
-      { pgaCountTxs               = countSimpleGenTxs
+      { pgaBlockProperty          = prop_validSimpleBlock
+      , pgaCountTxs               = countSimpleGenTxs
       , pgaExpectedBlockRejection = const False
       , pgaFirstBlockNo           = 0
       , pgaFixedMaxForkLength     = Nothing

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -40,6 +40,7 @@ import           Test.ThreadNet.Util.HasCreator.Mock ()
 import           Test.ThreadNet.Util.NodeJoinPlan
 import           Test.ThreadNet.Util.NodeRestarts
 import           Test.ThreadNet.Util.NodeTopology
+import           Test.ThreadNet.Util.SimpleBlock
 
 import           Test.Util.Orphans.Arbitrary ()
 
@@ -76,7 +77,8 @@ prop_simple_pbft_convergence
     tabulate "Ref.PBFT result" [Ref.resultConstrName refResult] $
     prop_asSimulated .&&.
     prop_general PropGeneralArgs
-      { pgaCountTxs               = countSimpleGenTxs
+      { pgaBlockProperty          = prop_validSimpleBlock
+      , pgaCountTxs               = countSimpleGenTxs
       , pgaExpectedBlockRejection = expectedBlockRejection numCoreNodes
       , pgaFirstBlockNo           = 0
       , pgaFixedMaxForkLength     =

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -29,6 +29,7 @@ import           Test.ThreadNet.Util.HasCreator.Mock ()
 import           Test.ThreadNet.Util.NodeJoinPlan
 import           Test.ThreadNet.Util.NodeRestarts
 import           Test.ThreadNet.Util.NodeTopology
+import           Test.ThreadNet.Util.SimpleBlock
 
 import           Test.Util.Orphans.Arbitrary ()
 
@@ -95,7 +96,8 @@ prop_simple_praos_convergence
   testConfig@TestConfig{numCoreNodes} =
     counterexample (tracesToDot testOutputNodes) $
     prop_general PropGeneralArgs
-      { pgaCountTxs               = countSimpleGenTxs
+      { pgaBlockProperty          = prop_validSimpleBlock
+      , pgaCountTxs               = countSimpleGenTxs
       , pgaExpectedBlockRejection = const False
       , pgaFirstBlockNo           = 0
       , pgaFixedMaxForkLength     = Nothing

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Util/SimpleBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Util/SimpleBlock.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Test.ThreadNet.Util.SimpleBlock (
+  prop_validSimpleBlock,
+  ) where
+
+import           Test.QuickCheck
+
+import           Ouroboros.Network.Block (HasHeader, SlotNo (..), blockSlot)
+
+import           Ouroboros.Consensus.Mock.Ledger
+import           Ouroboros.Consensus.Util.Condense (condense)
+
+prop_validSimpleBlock
+  :: HasHeader (SimpleBlock' c ext ext')
+  => SimpleBlock' c ext ext' -> Property
+prop_validSimpleBlock blk = conjoin $ map each $ simpleTxs $ simpleBody blk
+  where
+    now :: SlotNo
+    now = blockSlot blk
+
+    msg :: String
+    msg = "block contains expired transaction:"
+
+    each :: Tx -> Property
+    each tx@(Tx expiry _ins _outs) =
+      counterexample (msg <> " " <> condense (now, tx)) $
+      case expiry of
+        DoNotExpire       -> True
+        ExpireAtOnsetOf s -> now < s

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -1083,9 +1083,9 @@ data NodeOutput blk = NodeOutput
   { nodeOutputAdds        :: Map SlotNo (Set (RealPoint blk, BlockNo))
   , nodeOutputFinalChain  :: Chain blk
   , nodeOutputFinalLedger :: LedgerState blk
-  , nodeOutputNodeDBs     :: NodeDBs MockFS
   , nodeOutputForges      :: Map SlotNo blk
   , nodeOutputInvalids    :: Map (RealPoint blk) [ExtValidationError blk]
+  , nodeOutputNodeDBs     :: NodeDBs MockFS
   }
 
 data TestOutput blk = TestOutput
@@ -1123,11 +1123,11 @@ mkTestOutput vertexInfos = do
                   [ (s, Set.singleton (p, bno)) | (s, p, bno) <- nodeEventsAdds ]
               , nodeOutputFinalChain  = ch
               , nodeOutputFinalLedger = ldgr
-              , nodeOutputNodeDBs     = nodeInfoDBs
               , nodeOutputForges      =
                   Map.fromList $
                   [ (s, b) | TraceForgedBlock s _ b _ <- nodeEventsForges ]
               , nodeOutputInvalids    = (:[]) <$> Map.fromList nodeEventsInvalids
+              , nodeOutputNodeDBs     = nodeInfoDBs
               }
 
         pure

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -60,11 +60,11 @@ import           Ouroboros.Network.MockChain.Chain (Chain (Genesis))
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import qualified Ouroboros.Network.BlockFetch.Client as BFClient
+import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..))
 import           Ouroboros.Network.Protocol.ChainSync.Type
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
 import           Ouroboros.Network.Protocol.TxSubmission.Type
-import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..))
 import qualified Ouroboros.Network.TxSubmission.Inbound as TxInbound
 import qualified Ouroboros.Network.TxSubmission.Outbound as TxOutbound
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -11,6 +11,7 @@ module Ouroboros.Consensus.Util.Orphans () where
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.Serialise (Serialise (..))
 import           Control.Concurrent.STM (readTVarIO)
+import           Control.DeepSeq (NFData (..))
 import           Control.Monad.Identity
 import           Control.Monad.Trans
 import           Crypto.Random
@@ -33,7 +34,8 @@ import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..),
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (HasHeader, HeaderHash, Point (..))
+import           Ouroboros.Network.Block (HasHeader, HeaderHash, Point (..),
+                     SlotNo (..))
 import           Ouroboros.Network.MockChain.Chain (Chain (..))
 import           Ouroboros.Network.Point (WithOrigin (..), blockPointHash,
                      blockPointSlot)
@@ -112,3 +114,9 @@ deriving via OnlyCheckIsWHNF "Decoder" (Decoder s a) instance NoUnexpectedThunks
 deriving via OnlyCheckIsWHNF "Tracer" (Tracer m ev) instance NoUnexpectedThunks (Tracer m ev)
 
 deriving newtype instance NoUnexpectedThunks Time
+
+{-------------------------------------------------------------------------------
+  NFData
+-------------------------------------------------------------------------------}
+
+deriving newtype instance NFData SlotNo


### PR DESCRIPTION
Fixes #1297.

Follow-up: `prop_general` is accumulating several block/protocol specific arguments; they probably deserve their own record type/class soon.