### PR TITLE
ChainSyncClient: No `BlockNo` when tip is genesis

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -498,7 +498,7 @@ chainSyncClient mkPipelineDecision0 tracer cfg btime
               Nothing
               (handleNext kis mkPipelineDecision' n')
       where
-        theirTipBlockNo = tipBlockNo (unTheir theirTip)
+        theirTipBlockNo = getLegacyTipBlockNo (unTheir theirTip)
         decision = runPipelineDecision
           mkPipelineDecision
           n

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncServer.hs
@@ -15,7 +15,7 @@ module Ouroboros.Consensus.ChainSyncServer
 import           Control.Tracer
 
 import           Ouroboros.Network.Block (ChainUpdate (..), HeaderHash,
-                     Point (..), Serialised, Tip (..), castPoint)
+                     Point (..), Serialised, Tip (..), castPoint, legacyTip)
 import           Ouroboros.Network.Protocol.ChainSync.Server
 
 import           Ouroboros.Storage.ChainDB.API (ChainDB, Reader,
@@ -131,7 +131,7 @@ chainSyncServerForReader tracer chainDB rdr =
     getTip = atomically $ do
       tipPoint   <- castPoint <$> ChainDB.getTipPoint   chainDB
       tipBlockNo <-               ChainDB.getTipBlockNo chainDB
-      return Tip { tipPoint, tipBlockNo }
+      return $ legacyTip tipPoint tipBlockNo
 
 {-------------------------------------------------------------------------------
   Trace events

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -585,9 +585,9 @@ consensusNetworkApps kernel ProtocolTracers {..} ProtocolCodecs {..} ProtocolHan
 
 chainDbView :: IOLike m => ChainDB m blk -> ChainDbView m blk
 chainDbView chainDB = ChainDbView
-  { getCurrentChain   = ChainDB.getCurrentChain       chainDB
-  , getCurrentLedger  = ChainDB.getCurrentLedger      chainDB
-  , getOurTip         = Tip <$> ChainDB.getTipPoint   chainDB
-                            <*> ChainDB.getTipBlockNo chainDB
-  , getIsInvalidBlock = ChainDB.getIsInvalidBlock     chainDB
+  { getCurrentChain   = ChainDB.getCurrentChain             chainDB
+  , getCurrentLedger  = ChainDB.getCurrentLedger            chainDB
+  , getOurTip         = legacyTip <$> ChainDB.getTipPoint   chainDB
+                                  <*> ChainDB.getTipBlockNo chainDB
+  , getIsInvalidBlock = ChainDB.getIsInvalidBlock           chainDB
   }

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -113,12 +113,10 @@ prop_chainSync ChainSyncClientSetup {..} =
         label "InvalidRollBack" $
         counterexample ("InvalidRollBack intersection: " <> ppPoint intersection) $
         not (withinFragmentBounds intersection synchedFragment)
-      Just (NoMoreIntersection { _ourTip   = Our   (Tip ourHead   _)
-                               , _theirTip = Their (Tip theirHead _)
-                               }) ->
+      Just (NoMoreIntersection {_ourTip = Our ourTip, _theirTip = Their theirTip}) ->
         label "NoMoreIntersection" $
-        counterexample ("NoMoreIntersection ourHead: " <> ppPoint ourHead <>
-                        ", theirHead: " <> ppPoint theirHead) $
+        counterexample ("NoMoreIntersection ourHead: " <> ppPoint (getTipPoint ourTip) <>
+                        ", theirHead: " <> ppPoint (getTipPoint theirTip)) $
         not (clientFragment `forksWithinK` synchedFragment)
       Just e ->
         counterexample ("Exception: " ++ displayException e) False
@@ -290,7 +288,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
           , getCurrentLedger  = snd <$> readTVar varClientState
           , getOurTip         = do
               chain <- fst <$> readTVar varClientState
-              return $ Tip (Chain.headPoint chain) (Chain.headBlockNo chain)
+              return $ legacyTip (Chain.headPoint chain) (Chain.headBlockNo chain)
           , getIsInvalidBlock = return $
               WithFingerprint (const Nothing) (Fingerprint 0)
           }

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
@@ -16,7 +16,8 @@ import           Control.Monad.Class.MonadSTM.Strict
 
 import           Network.TypedProtocol.Pipelined
 
-import           Ouroboros.Network.Block (BlockNo, HasHeader (..), Tip(..))
+import           Ouroboros.Network.Block (BlockNo, HasHeader (..), Tip (..),
+                     getLegacyTipBlockNo)
 import           Ouroboros.Network.MockChain.Chain (Chain (..), Point (..))
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
@@ -63,7 +64,8 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
        -> Client header (Tip header) m a
        -> ClientPipelinedStIdle n header (Tip header) m a
 
-    go mkPipelineDecision n cliTipBlockNo srvTip@(Tip _ srvTipBlockNo) client@Client {rollforward, rollbackward} =
+    go mkPipelineDecision n cliTipBlockNo srvTip client@Client {rollforward, rollbackward} =
+      let srvTipBlockNo = getLegacyTipBlockNo srvTip in
       case (n, runPipelineDecision mkPipelineDecision n cliTipBlockNo srvTipBlockNo) of
         (_Zero, (Request, mkPipelineDecision')) ->
           SendMsgRequestNext

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -31,8 +31,8 @@ import           Network.TypedProtocol.Proofs (connect, connectPipelined)
 
 import           Ouroboros.Network.Channel
 
-import           Ouroboros.Network.Block (StandardHash, Tip (..), decodeTip,
-                     encodeTip, Serialised (..), castPoint)
+import           Ouroboros.Network.Block (Serialised (..), StandardHash,
+                     Tip (..), castPoint, decodeTip, encodeTip, legacyTip)
 import           Ouroboros.Network.MockChain.Chain (Chain, Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 import qualified Ouroboros.Network.MockChain.ProducerState as ChainProducerState
@@ -365,14 +365,14 @@ genChainSync genPoint genHeader genTip = oneof
 instance Arbitrary (AnyMessageAndAgency (ChainSync BlockHeader (Tip BlockHeader))) where
   arbitrary = genChainSync arbitrary arbitrary genTip
     where
-      genTip = Tip <$> arbitrary <*> arbitrary
+      genTip = legacyTip <$> arbitrary <*> arbitrary
 
 instance Arbitrary (AnyMessageAndAgency (ChainSync (Serialised BlockHeader) (Tip BlockHeader))) where
   arbitrary = genChainSync (castPoint <$> genPoint)
                            (serialiseBlock <$> arbitrary)
                            genTip
     where
-      genTip = Tip <$> arbitrary <*> arbitrary
+      genTip = legacyTip <$> arbitrary <*> arbitrary
 
       genPoint :: Gen (Point BlockHeader)
       genPoint = arbitrary
@@ -507,7 +507,7 @@ prop_codec_binary_compat_ChainSyncSerialised_ChainSync msg =
     stokEq (ClientAgency ca) = case ca of
       TokIdle -> SamePeerHasAgency $ ClientAgency TokIdle
     stokEq (ServerAgency sa) = case sa of
-      TokNext k     -> SamePeerHasAgency $ ServerAgency (TokNext k)
+      TokNext k    -> SamePeerHasAgency $ ServerAgency (TokNext k)
       TokIntersect -> SamePeerHasAgency $ ServerAgency TokIntersect
 
 chainSyncDemo

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Examples.hs
@@ -21,7 +21,7 @@ module Ouroboros.Network.Protocol.ChainSync.Examples (
 import           Control.Monad.Class.MonadSTM.Strict
 
 import           Ouroboros.Network.Block (BlockNo, HasHeader (..), HeaderHash,
-                     castPoint, genesisPoint, Tip(..))
+                     Tip (..), castPoint, genesisPoint, legacyTip)
 import           Ouroboros.Network.MockChain.Chain (Chain (..),
                      ChainUpdate (..), Point (..))
 import qualified Ouroboros.Network.MockChain.Chain as Chain
@@ -173,8 +173,8 @@ chainSyncServerExample recvMsgDoneClient chainvar = ChainSyncServer $
     sendNext :: ReaderId
              -> (Point blk, BlockNo, ChainUpdate header header)
              -> ServerStNext header (Tip blk) m a
-    sendNext r (tip, blkNo, AddBlock b) = SendMsgRollForward  b             (Tip tip blkNo) (idle' r)
-    sendNext r (tip, blkNo, RollBack p) = SendMsgRollBackward (castPoint p) (Tip tip blkNo) (idle' r)
+    sendNext r (tip, blkNo, AddBlock b) = SendMsgRollForward  b             (legacyTip tip blkNo) (idle' r)
+    sendNext r (tip, blkNo, RollBack p) = SendMsgRollBackward (castPoint p) (legacyTip tip blkNo) (idle' r)
 
     handleFindIntersect :: ReaderId
                         -> [Point header]
@@ -184,8 +184,8 @@ chainSyncServerExample recvMsgDoneClient chainvar = ChainSyncServer $
       -- Find the first point that is on our chain
       changed <- improveReadPoint r points
       case changed of
-        (Just pt, tip, blkNo) -> return $ SendMsgIntersectFound     pt (Tip tip blkNo) (idle' r)
-        (Nothing, tip, blkNo) -> return $ SendMsgIntersectNotFound     (Tip tip blkNo) (idle' r)
+        (Just pt, tip, blkNo) -> return $ SendMsgIntersectFound     pt (legacyTip tip blkNo) (idle' r)
+        (Nothing, tip, blkNo) -> return $ SendMsgIntersectNotFound     (legacyTip tip blkNo) (idle' r)
 
     newReader :: m ReaderId
     newReader = atomically $ do


### PR DESCRIPTION
The `Tip` data-type was

```haskell
data Tip b = Tip
  { tipPoint   :: !(Point b)
  , tipBlockNo :: !BlockNo
  }
```

where `Point` uses `WithOrigin`. This is not correct. When `tipPoint` is `Origin`, then there _is_ no `tipBlockNo` (`genesisBlockNo` is the block number of the first block on the chain). In this commit we change this to

```haskell
data Tip b =
    -- | The tip is genesis
    TipGenesis

    -- | The tip is not genesis
  | Tip !SlotNo !(HeaderHash b) !BlockNo
```

It doesn't, however, make any real changes, providing instead some "legacy" API that pretends that we _do_ always have a `BlockNo`. This primarily affects consensus only, in networking this only appears in examples and tests.

We also use this legacy format to avoid changing the binary presentation of `Tip`, so that this PR does _not_ break backwards compatibility.