### PR TITLE
Improve accessibility of `test-consensus` tracers for debugging

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+
 module Ouroboros.Consensus.Node.Tracers
   ( -- * All tracers of a node bundled together
     Tracers' (..)
@@ -51,6 +54,25 @@ data Tracers' peer blk f = Tracers
   , forgeTracer                   :: f (TraceForgeEvent blk (GenTx blk))
   , blockchainTimeTracer          :: f  TraceBlockchainTimeEvent
   }
+
+instance (forall a. Semigroup (f a)) => Semigroup (Tracers' peer blk f) where
+  l <> r = Tracers
+    { chainSyncClientTracer         = f chainSyncClientTracer
+    , chainSyncServerHeaderTracer   = f chainSyncServerHeaderTracer
+    , chainSyncServerBlockTracer    = f chainSyncServerBlockTracer
+    , blockFetchDecisionTracer      = f blockFetchDecisionTracer
+    , blockFetchClientTracer        = f blockFetchClientTracer
+    , blockFetchServerTracer        = f blockFetchServerTracer
+    , txInboundTracer               = f txInboundTracer
+    , txOutboundTracer              = f txOutboundTracer
+    , localTxSubmissionServerTracer = f localTxSubmissionServerTracer
+    , mempoolTracer                 = f mempoolTracer
+    , forgeTracer                   = f forgeTracer
+    , blockchainTimeTracer          = f blockchainTimeTracer
+    }
+    where
+      f :: forall a. Semigroup a => (Tracers' peer blk f -> a) -> a
+      f prj = prj l <> prj r
 
 -- | A record of 'Tracer's for the node.
 type Tracers m peer blk = Tracers' peer blk (Tracer m)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -326,6 +326,23 @@ data ProtocolTracers' peer blk failure f = ProtocolTracers {
   , ptLocalStateQueryTracer      :: f (TraceLabelPeer peer (TraceSendRecv (LocalStateQuery blk (Query blk))))
   }
 
+instance (forall a. Semigroup (f a)) => Semigroup (ProtocolTracers' peer blk failure f) where
+  l <> r = ProtocolTracers {
+      ptChainSyncTracer            = f ptChainSyncTracer
+    , ptChainSyncSerialisedTracer  = f ptChainSyncSerialisedTracer
+    , ptBlockFetchTracer           = f ptBlockFetchTracer
+    , ptBlockFetchSerialisedTracer = f ptBlockFetchSerialisedTracer
+    , ptTxSubmissionTracer         = f ptTxSubmissionTracer
+    , ptLocalChainSyncTracer       = f ptLocalChainSyncTracer
+    , ptLocalTxSubmissionTracer    = f ptLocalTxSubmissionTracer
+    , ptLocalStateQueryTracer      = f ptLocalStateQueryTracer
+    }
+    where
+      f :: forall a. Semigroup a
+        => (ProtocolTracers' peer blk failure f -> a)
+        -> a
+      f prj = prj l <> prj r
+
 -- | Use a 'nullTracer' for each protocol.
 nullProtocolTracers :: Monad m => ProtocolTracers m peer blk failure
 nullProtocolTracers = ProtocolTracers {


### PR DESCRIPTION
This PR arose during a call this morning. We think it will make it easier for people less familiar with `test-consensus` to find which tracers they should consider enabling. Basic rule:

> Search in `Network.hs` for `"nullDebug"` and consider somehow adding `debugTracer` at those locations.