### PR TITLE
Follow-up on #1589

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ChainDB/Impl/ImmDB.hs
@@ -23,7 +23,6 @@ module Ouroboros.Storage.ChainDB.Impl.ImmDB (
   , getSlotNoAtTip
   , getKnownBlockComponent
   , getBlockComponent
-  , getBlockComponentAtTip
   , getBlockComponentWithPoint
     -- * Appending a block
   , appendBlock
@@ -374,18 +373,6 @@ getBlockComponent db blockComponent epochOrSlot = withDB db $ \imm ->
       Right slot -> ImmDB.getBlockComponent imm blockComponent' slot
   where
     blockComponent' = translateToRawDB (parse db) (addHdrEnv db) blockComponent
-
-getBlockComponentAtTip
-  :: (MonadCatch m, HasHeader blk, HasCallStack)
-  => ImmDB m blk -> BlockComponent (ChainDB m blk) b -> m (Maybe b)
-getBlockComponentAtTip db blockComponent = do
-    immTip <- withDB db $ \imm -> ImmDB.getTip imm
-    case forgetTipInfo <$> immTip of
-      TipGen -> return Nothing
-      Tip (ImmDB.EBB epoch) ->
-        Just <$> getKnownBlockComponent db blockComponent (Left epoch)
-      Tip (ImmDB.Block slot) ->
-        Just <$> getKnownBlockComponent db blockComponent (Right slot)
 
 -- | Return the block component of the block corresponding to the given point,
 -- if it is part of the ImmutableDB.

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -288,7 +288,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
           , getCurrentLedger  = snd <$> readTVar varClientState
           , getOurTip         = do
               chain <- fst <$> readTVar varClientState
-              return $ legacyTip (Chain.headPoint chain) (Chain.headBlockNo chain)
+              return $ Chain.headTip chain
           , getIsInvalidBlock = return $
               WithFingerprint (const Nothing) (Fingerprint 0)
           }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -228,7 +228,7 @@ lastK (SecurityParam k) f =
 -- In the real implementation this will correspond to the block number of the
 -- block at the tip of the Immutable DB.
 immutableBlockNo :: HasHeader blk
-                 => SecurityParam -> Model blk -> Block.BlockNo
+                 => SecurityParam -> Model blk -> WithOrigin Block.BlockNo
 immutableBlockNo (SecurityParam k) =
         Chain.headBlockNo
       . Chain.drop (fromIntegral k)
@@ -333,7 +333,7 @@ addBlock :: forall blk. ProtocolLedgerView blk
 addBlock cfg blk m
     -- If the block is as old as the tip of the ImmutableDB, i.e. older than
     -- @k@, we ignore it, as we can never switch to it. TODO what about EBBs?
-  | Block.blockNo blk <= immutableBlockNo secParam m
+  | At (Block.blockNo blk) <= immutableBlockNo secParam m
     -- Unless we're adding the first block to the empty chain: the empty chain
     -- has the same block number as the genesis EBB, i.e. 0, so we don't want
     -- to ignore it in this case.

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
@@ -15,6 +15,7 @@ import           Test.Tasty.QuickCheck
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (HasHeader (..), genesisPoint)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
+import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -44,7 +45,7 @@ addBlocks blks = M.addBlocks cfg blks m
 prop_getBlock_addBlock :: BlockTree -> Permutation -> Property
 prop_getBlock_addBlock bt p =
         M.getBlock (blockHash newBlock) (M.addBlock singleNodeTestConfig newBlock model)
-    === if blockNo newBlock > M.immutableBlockNo secParam model
+    === if At (blockNo newBlock) > M.immutableBlockNo secParam model
         then Just newBlock
         else Nothing
   where

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
@@ -48,10 +48,10 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
       -- found an intersection or not. If not, we'll just sync from genesis.
       ClientPipelinedStIntersect {
         recvMsgIntersectFound    = \_ srvTip -> do
-          cliTipBlockNo <- At . Chain.headBlockNo <$> atomically (readTVar chainvar)
+          cliTipBlockNo <- Chain.headBlockNo <$> atomically (readTVar chainvar)
           pure $ go mkPipelineDecision0 Zero cliTipBlockNo srvTip client,
         recvMsgIntersectNotFound = \  srvTip -> do
-          cliTipBlockNo <- At . Chain.headBlockNo <$> atomically (readTVar chainvar)
+          cliTipBlockNo <- Chain.headBlockNo <$> atomically (readTVar chainvar)
           pure $ go mkPipelineDecision0 Zero cliTipBlockNo srvTip client
       }
 
@@ -175,8 +175,7 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
         --TODO: handle rollback failure
         let (Just !chain') = Chain.rollback p chain
         writeTVar chainvar chain'
-        -- TODO update Chain.headBlockNo to return @WithOrigin BlockNo@
-        pure $ if Chain.null chain' then Origin else At (Chain.headBlockNo chain')
+        pure $ Chain.headBlockNo chain'
 
 -- | Offsets from the head of the chain to select points on the consumer's
 -- chain to send to the producer. The specific choice here is fibonacci up

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
@@ -17,9 +17,10 @@ import           Control.Monad.Class.MonadSTM.Strict
 import           Network.TypedProtocol.Pipelined
 
 import           Ouroboros.Network.Block (BlockNo, HasHeader (..), Tip (..),
-                     getLegacyTipBlockNo)
+                     getTipBlockNo)
 import           Ouroboros.Network.MockChain.Chain (Chain (..), Point (..))
 import qualified Ouroboros.Network.MockChain.Chain as Chain
+import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
 import           Ouroboros.Network.Protocol.ChainSync.Examples (Client (..))
@@ -47,17 +48,17 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
       -- found an intersection or not. If not, we'll just sync from genesis.
       ClientPipelinedStIntersect {
         recvMsgIntersectFound    = \_ srvTip -> do
-          cliTipBlockNo <- Chain.headBlockNo <$> atomically (readTVar chainvar)
+          cliTipBlockNo <- At . Chain.headBlockNo <$> atomically (readTVar chainvar)
           pure $ go mkPipelineDecision0 Zero cliTipBlockNo srvTip client,
         recvMsgIntersectNotFound = \  srvTip -> do
-          cliTipBlockNo <- Chain.headBlockNo <$> atomically (readTVar chainvar)
+          cliTipBlockNo <- At . Chain.headBlockNo <$> atomically (readTVar chainvar)
           pure $ go mkPipelineDecision0 Zero cliTipBlockNo srvTip client
       }
 
     -- Drive pipelining by using @mkPipelineDecision@ callback.
     go :: MkPipelineDecision
        -> Nat n
-       -> BlockNo
+       -> WithOrigin BlockNo
        -- ^ our head
        -> Tip header
        -- ^ head of the server
@@ -65,7 +66,7 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
        -> ClientPipelinedStIdle n header (Tip header) m a
 
     go mkPipelineDecision n cliTipBlockNo srvTip client@Client {rollforward, rollbackward} =
-      let srvTipBlockNo = getLegacyTipBlockNo srvTip in
+      let srvTipBlockNo = getTipBlockNo srvTip in
       case (n, runPipelineDecision mkPipelineDecision n cliTipBlockNo srvTipBlockNo) of
         (_Zero, (Request, mkPipelineDecision')) ->
           SendMsgRequestNext
@@ -81,7 +82,7 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
                     choice <- rollforward srvHeader
                     pure $ case choice of
                       Left a        -> SendMsgDone a
-                      Right client' -> go mkPipelineDecision' n (blockNo srvHeader) srvTip' client',
+                      Right client' -> go mkPipelineDecision' n (At (blockNo srvHeader)) srvTip' client',
                   recvMsgRollBackward = \pRollback srvTip' -> do
                     cliTipBlockNo' <- rollback pRollback
                     choice <- rollbackward pRollback srvTip'
@@ -107,7 +108,7 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
                   choice <- rollforward srvHeader
                   pure $ case choice of
                     Left a        -> collectAndDone n' a
-                    Right client' -> go mkPipelineDecision' n' (blockNo srvHeader) srvTip' client',
+                    Right client' -> go mkPipelineDecision' n' (At (blockNo srvHeader)) srvTip' client',
                 recvMsgRollBackward = \pRollback srvTip' -> do
                   cliTipBlockNo' <- rollback pRollback
                   choice <- rollbackward pRollback srvTip'
@@ -125,7 +126,7 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
                   choice <- rollforward srvHeader
                   pure $ case choice of
                     Left a        -> collectAndDone n' a
-                    Right client' -> go mkPipelineDecision' n' (blockNo srvHeader) srvTip' client',
+                    Right client' -> go mkPipelineDecision' n' (At (blockNo srvHeader)) srvTip' client',
                 recvMsgRollBackward = \pRollback srvTip' -> do
                   cliTipBlockNo' <- rollback pRollback
                   choice <- rollbackward pRollback srvTip'
@@ -168,13 +169,14 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
         let !chain' = Chain.addBlock b chain
         writeTVar chainvar chain'
 
-    rollback :: Point header -> m BlockNo
+    rollback :: Point header -> m (WithOrigin BlockNo)
     rollback p = atomically $ do
         chain <- readTVar chainvar
         --TODO: handle rollback failure
         let (Just !chain') = Chain.rollback p chain
         writeTVar chainvar chain'
-        pure $ Chain.headBlockNo chain'
+        -- TODO update Chain.headBlockNo to return @WithOrigin BlockNo@
+        pure $ if Chain.null chain' then Origin else At (Chain.headBlockNo chain')
 
 -- | Offsets from the head of the chain to select points on the consumer's
 -- chain to send to the producer. The specific choice here is fibonacci up

--- a/ouroboros-network/protocol-tests/Test/ChainGenerators.hs
+++ b/ouroboros-network/protocol-tests/Test/ChainGenerators.hs
@@ -287,7 +287,7 @@ instance Arbitrary TestAddBlock where
     [ TestAddBlock c' b'
     | TestBlockChain c' <- shrink (TestBlockChain c)
     , let b' = fixupBlock (Chain.headHash c')
-                          (Chain.headBlockNo c') b
+                          (Chain.legacyHeadBlockNo c') b
     ]
 
 genAddBlock :: (HasHeader block, HeaderHash block ~ ConcreteHeaderHash)
@@ -300,7 +300,7 @@ genAddBlock chain = do
           At slotNo -> addSlotGap slotGap slotNo
         pb = mkPartialBlock nextSlotNo body
         b  = fixupBlock (Chain.headHash chain)
-                        (Chain.headBlockNo chain) pb
+                        (Chain.legacyHeadBlockNo chain) pb
     return b
 
 prop_arbitrary_TestAddBlock :: TestAddBlock -> Bool
@@ -407,8 +407,8 @@ countChainUpdateNetProgress = go 0
     go n c  (u:us) = go n' c' us
       where
         Just c' = Chain.applyChainUpdate u c
-        n'      = n + fromEnum (Chain.headBlockNo c')
-                    - fromEnum (Chain.headBlockNo c)
+        n'      = n + fromEnum (Chain.legacyHeadBlockNo c')
+                    - fromEnum (Chain.legacyHeadBlockNo c)
 
 
 --

--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -33,6 +33,7 @@ module Ouroboros.Network.Block (
   , atSlot
   , withHash
   , Tip(..)
+  , castTip
   , getTipPoint
   , getTipBlockNo
   , getLegacyTipBlockNo
@@ -197,6 +198,11 @@ data Tip b =
 deriving instance StandardHash b => Eq                 (Tip b)
 deriving instance StandardHash b => Show               (Tip b)
 deriving instance StandardHash b => NoUnexpectedThunks (Tip b)
+
+-- | The equivalent of 'castPoint' for 'Tip'
+castTip :: (HeaderHash a ~ HeaderHash b) => Tip a -> Tip b
+castTip TipGenesis  = TipGenesis
+castTip (Tip s h b) = Tip s h b
 
 getTipPoint :: Tip b -> Point b
 getTipPoint TipGenesis  = GenesisPoint

--- a/ouroboros-network/test/Ouroboros/Network/MockNode.hs
+++ b/ouroboros-network/test/Ouroboros/Network/MockNode.hs
@@ -407,4 +407,4 @@ coreNode nid slotDuration gchain chans = do
     fixupBlock c =
       Concrete.fixupBlock
         (Chain.headHash c)
-        (Chain.headBlockNo c)
+        (Chain.legacyHeadBlockNo c)


### PR DESCRIPTION
Fixes #1594 and #1595.

* ChainSyncClient: use WithOrigin BlockNo for MkPipelineDecision

* ChainDB: don't read the header at the ImmutableDB's tip on startup
