### PR TITLE
Fix thunks in RealPBFT

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -116,25 +116,25 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 98048d95823b72e409b07481761b8a59c892c56c
+  tag: e8475e33772e7408e83ff22e4406673ea73f93fd
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 98048d95823b72e409b07481761b8a59c892c56c
+  tag: e8475e33772e7408e83ff22e4406673ea73f93fd
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 98048d95823b72e409b07481761b8a59c892c56c
+  tag: e8475e33772e7408e83ff22e4406673ea73f93fd
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 98048d95823b72e409b07481761b8a59c892c56c
+  tag: e8475e33772e7408e83ff22e4406673ea73f93fd
   subdir: crypto/test
 
 -- version number matching the one specified in the stack resolver file

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -34,8 +34,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "98048d95823b72e409b07481761b8a59c892c56c";
-      sha256 = "1cjr8kwa9h807l119hfmqiy5m5kvz6y1dqgb61hlf8ny1zjqywsw";
+      rev = "e8475e33772e7408e83ff22e4406673ea73f93fd";
+      sha256 = "1pb6fr91g4nmgds71av767hzwfmmkpmp9ldvdkr14v1hv7cqg4kx";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "98048d95823b72e409b07481761b8a59c892c56c";
-      sha256 = "1cjr8kwa9h807l119hfmqiy5m5kvz6y1dqgb61hlf8ny1zjqywsw";
+      rev = "e8475e33772e7408e83ff22e4406673ea73f93fd";
+      sha256 = "1pb6fr91g4nmgds71av767hzwfmmkpmp9ldvdkr14v1hv7cqg4kx";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -55,8 +55,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "98048d95823b72e409b07481761b8a59c892c56c";
-      sha256 = "1cjr8kwa9h807l119hfmqiy5m5kvz6y1dqgb61hlf8ny1zjqywsw";
+      rev = "e8475e33772e7408e83ff22e4406673ea73f93fd";
+      sha256 = "1pb6fr91g4nmgds71av767hzwfmmkpmp9ldvdkr14v1hv7cqg4kx";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -118,8 +118,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "98048d95823b72e409b07481761b8a59c892c56c";
-      sha256 = "1cjr8kwa9h807l119hfmqiy5m5kvz6y1dqgb61hlf8ny1zjqywsw";
+      rev = "e8475e33772e7408e83ff22e4406673ea73f93fd";
+      sha256 = "1pb6fr91g4nmgds71av767hzwfmmkpmp9ldvdkr14v1hv7cqg4kx";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -50,7 +50,7 @@ extra-deps:
   - gray-code-0.3.1
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 98048d95823b72e409b07481761b8a59c892c56c
+    commit: e8475e33772e7408e83ff22e4406673ea73f93fd
     subdirs:
       - cardano-ledger
       - cardano-ledger/test


### PR DESCRIPTION
This fixes the thunks found by running the RealPBFT consensus tests with the `checktvarinvariant` flag enabled for the `io-sim-classes` package.