### PR TITLE
Avoid use of TMVar

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -40,6 +40,7 @@ module Ouroboros.Consensus.Util.IOLike (
   , updateMVar
   , updateMVar_
   , modifyMVar
+  , modifyMVar_
     -- *** MonadFork
   , ThreadId
   , myThreadId

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
@@ -21,6 +21,7 @@ module Ouroboros.Consensus.Util.MonadSTM.StrictMVar (
   , updateMVar
   , updateMVar_
   , modifyMVar
+  , modifyMVar_
   ) where
 
 import           Control.Concurrent.STM (readTVarIO)
@@ -178,6 +179,9 @@ modifyMVar var action =
       ExitCaseException _ex   -> putMVar var a
       ExitCaseAbort           -> putMVar var a
 
+modifyMVar_ :: (MonadSTM m, MonadCatch m, HasCallStack)
+            => StrictMVar m a -> (a -> m a) -> m ()
+modifyMVar_ var action = modifyMVar var (fmap (, ()) . action)
 
 {-------------------------------------------------------------------------------
   NoUnexpectedThunks

--- a/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index/Cache.hs
+++ b/ouroboros-consensus/src/Ouroboros/Storage/ImmutableDB/Impl/Index/Cache.hs
@@ -53,9 +53,7 @@ import           Data.Word (Word32, Word64)
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack, callStack)
 
-import           Control.Monad.Class.MonadSTM.Strict (StrictTMVar, isEmptyTMVar,
-                     newEmptyTMVarM, putTMVar, tryTakeTMVar)
-import           Control.Monad.Class.MonadThrow (bracketOnError)
+import           Control.Monad.Class.MonadThrow (bracketOnError, mask_, throwM)
 import           Control.Monad.Class.MonadTime (Time (..))
 
 import           Cardano.Prelude (NoUnexpectedThunks (..), forceElemsToWHNF)
@@ -356,7 +354,8 @@ data CacheEnv m hash h = CacheEnv
   , tracer      :: Tracer m TraceCacheEvent
   , cacheVar    :: StrictMVar m (Cached hash)
   , cacheConfig :: CacheConfig
-  , bgThreadVar :: StrictTMVar m (Thread m Void)
+  , bgThreadVar :: StrictMVar m (Maybe (Thread m Void))
+    -- ^ Nothing if no thread running
   }
 
 -- | Creates a new 'CacheEnv' and launches a background thread that expires
@@ -379,10 +378,11 @@ newEnv hasFS err hashInfo registry tracer cacheConfig epoch = do
 
     currentEpochInfo <- loadCurrentEpochInfo hasFS err hashInfo epoch
     cacheVar <- newMVarWithInvariants $ emptyCached epoch currentEpochInfo
-    bgThreadVar <- newEmptyTMVarM
+    bgThreadVar <- newMVar Nothing
     let cacheEnv = CacheEnv {..}
-    bgThread <- forkLinkedThread registry $ expireUnusedEpochs cacheEnv
-    atomically $ putTMVar bgThreadVar bgThread
+    mask_ $ modifyMVar_ bgThreadVar $ \_mustBeNothing -> do
+      !bgThread <- forkLinkedThread registry $ expireUnusedEpochs cacheEnv
+      return $ Just bgThread
     return cacheEnv
   where
     CacheConfig { pastEpochsToCache } = cacheConfig
@@ -591,9 +591,10 @@ getEpochInfo cacheEnv epoch = do
 --
 -- This operation is idempotent.
 close :: IOLike m => CacheEnv m hash h -> m ()
-close CacheEnv { bgThreadVar } = do
-    mbBgThread <- atomically $ tryTakeTMVar bgThreadVar
-    mapM_ cancelThread mbBgThread
+close CacheEnv { bgThreadVar } =
+    mask_ $ modifyMVar_ bgThreadVar $ \mbBgThread -> do
+      mapM_ cancelThread mbBgThread
+      return Nothing
 
 -- | Restarts the background expiration thread, drops all previously cached
 -- information, loads the given epoch.
@@ -608,11 +609,12 @@ restart
 restart cacheEnv epoch = do
     currentEpochInfo <- loadCurrentEpochInfo hasFS err hashInfo epoch
     void $ swapMVar cacheVar $ emptyCached epoch currentEpochInfo
-    noRunningBgThread <- atomically $ isEmptyTMVar bgThreadVar
-    if noRunningBgThread then do
-      bgThread <- forkLinkedThread registry $ expireUnusedEpochs cacheEnv
-      atomically $ putTMVar bgThreadVar bgThread
-    else error "background thread still running"
+    mask_ $ modifyMVar_ bgThreadVar $ \mbBgThread ->
+      case mbBgThread of
+        Just _  -> throwM $ userError "background thread still running"
+        Nothing -> do
+          !bgThread <- forkLinkedThread registry $ expireUnusedEpochs cacheEnv
+          return $ Just bgThread
   where
     CacheEnv { hasFS, err, hashInfo, registry, cacheVar, bgThreadVar } = cacheEnv
 


### PR DESCRIPTION
As this does not support an invariant (thunks check). This also avoids
some race conditions in the code.

I didn't end up using `modifyMVar_` despite introducing it, but since it
might be useful at another point, left it in.