### PR TITLE
Handshake protocol number belongs to 'ouroboros-network'

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -131,13 +131,18 @@ data NodeToNodeProtocols = ChainSyncWithHeadersPtcl
 
 -- | These are the actual wire format protocol numbers.
 --
--- The application specific protocol numbers start from 2 because of the two
--- mux built-in protocols.
+-- The application specific protocol numbers start from 2.  The
+-- @'MiniProtocolNum' 0@ is reserved for the 'Handshake' protocol, while
+-- @'MiniProtocolNum' 1@ is reserved for DeltaQ messages.
+-- 'Handshake' protocol is not included in 'NodeToNodeProtocols' as it runs
+-- before mux is started but it reusing 'MuxBearer' to send and receive
+-- messages.  Only when the handshake protocol suceedes, we will know which
+-- protocols to run / multiplex. 
 --
--- These are chosen to not overlap with the node to client protocol numbers.
--- This is not essential for correctness, but is helpful to allow a single
--- shared implementation of tools that can analyse both protocols, e.g.
--- wireshark plugins.
+-- These are chosen to not overlap with the node to client protocol numbers (and
+-- the handshake protocol number).  This is not essential for correctness, but
+-- is helpful to allow a single shared implementation of tools that can analyse
+-- both protocols, e.g.  wireshark plugins.
 --
 instance ProtocolEnum NodeToNodeProtocols where
   fromProtocolEnum ChainSyncWithHeadersPtcl = MiniProtocolNum 2

--- a/ouroboros-network/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Socket.hs
@@ -135,6 +135,11 @@ instance NoUnexpectedThunks ConnectionId where
 maxTransmissionUnit :: Int64
 maxTransmissionUnit = 4 * 1440
 
+-- | The handshake protocol number.
+--
+handshakeProtocolNum :: MiniProtocolNum
+handshakeProtocolNum = MiniProtocolNum 0
+
 -- |
 -- Connect to a remote node.  It is using bracket to enclose the underlying
 -- socket acquisition.  This implies that when the continuation exits the
@@ -230,7 +235,7 @@ connectToNode' versionDataCodec NetworkConnectTracers {nctMuxTracer, nctHandshak
               BL.length
               (contramap (Mx.WithMuxBearer connectionId) nctHandshakeTracer)
               codecHandshake
-              (fromChannel (Mx.muxBearerAsControlChannel bearer Mx.ModeInitiator))
+              (fromChannel (Mx.muxBearerAsChannel bearer handshakeProtocolNum Mx.ModeInitiator))
               (handshakeClientPeer versionDataCodec versions)
     ts_end <- getMonotonicTime
     case mapp of
@@ -307,7 +312,7 @@ beginConnection muxTracer handshakeTracer versionDataCodec acceptVersion fn t ad
                 BL.length
                 (contramap (Mx.WithMuxBearer peerid) handshakeTracer)
                 codecHandshake
-                (fromChannel (Mx.muxBearerAsControlChannel bearer Mx.ModeResponder))
+                (fromChannel (Mx.muxBearerAsChannel bearer handshakeProtocolNum Mx.ModeResponder))
                 (handshakeServerPeer versionDataCodec acceptVersion versions)
         case mapp of
           Left err -> do


### PR DESCRIPTION
It should be defined in 'ouroboros-network' rather than in
'network-mux'.  There is no control protocol in 'network-mux' anymore.
This patch adds haddoc docstrings, renames 'muxBearerAsControlChannel'
to 'muxBearerAsChannel'.