### PR TITLE
Use a shared directory for ouroboros-consensus-byrondual

### DIFF
--- a/ouroboros-consensus-byron/README.md
+++ b/ouroboros-consensus-byron/README.md
@@ -1,0 +1,20 @@
+# Consensus-Byron
+
+This package contains:
+
+* `src`: integration of the Byron ledger with the consensus layer.
+
+* `ouroboros-consensus-byrondual`: integration of the Byron ledger paired with
+  the Byron spec ledger. This should be a separate package, but it depends on
+  `src`, and `test` depends on it, so it cannot be separated.
+
+* `test`: Byron ledger tests, protocol tests simulating various node setups,
+  both running (just) the Byron ledger, and the Byron ledger in lockstep with
+  the Byron spec ledger to detect any discrepancies. Hence the dependency on
+  `ouroboros-consensus-byrondual`.
+
+* `tools/db-analyser`: tool to show some information of a database containing
+  Byron blocks.
+
+* `tools/db-converter`: tool to convert an old `cardano-sl` database to a new
+  `ouroboros-consensus` database.

--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -71,35 +71,9 @@ library
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts
 
--- This should be an external library, but we depend on it in our tests
-library byrondual
-  hs-source-dirs:      ouroboros-consensus-byrondual/src
-
-  exposed-modules:
-                       Ouroboros.Consensus.ByronDual.Ledger
-                       Ouroboros.Consensus.ByronDual.Node
-
-  build-depends:       base              >=4.9   && <4.13
-                     , bytestring        >=0.10  && <0.11
-                     , cardano-crypto-class
-                     , cardano-ledger
-                     , cardano-ledger-test
-                     , containers        >=0.5   && <0.7
-                     , cryptonite        >=0.25  && <0.26
-                     , cs-ledger
-                     , serialise         >=0.2   && <0.3
-
-                     , ouroboros-network
-                     , ouroboros-consensus
-                     , ouroboros-consensus-byron
-                     , ouroboros-consensus-byronspec
-
-  default-language:    Haskell2010
-  ghc-options:         -Wall
-
 test-suite test
   type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
+  hs-source-dirs:      test ouroboros-consensus-byrondual/src
   main-is:             Main.hs
   other-modules:
                        Test.Consensus.Byron.Ledger
@@ -107,6 +81,10 @@ test-suite test
                        Test.ThreadNet.RealPBFT
                        Test.ThreadNet.Ref.RealPBFT
                        Test.ThreadNet.TxGen.Byron
+
+                       Ouroboros.Consensus.ByronDual.Ledger
+                       Ouroboros.Consensus.ByronDual.Node
+
   build-depends:       base
                      , binary
                      , binary-search
@@ -131,18 +109,18 @@ test-suite test
                      , time
                      , transformers
 
-                       -- Needed for the dual ledger
-                     , cs-blockchain
-                     , cs-ledger
-                     , small-steps
-                     , hedgehog
-
                      , ouroboros-network
                      , ouroboros-consensus
                      , ouroboros-consensus-test-infra
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-byronspec
-                     , byrondual
+
+                       -- ouroboros-consensus-byrondual
+                     , cs-blockchain
+                     , cs-ledger
+                     , small-steps
+                     , hedgehog
+                     , serialise
 
   default-language:    Haskell2010
   ghc-options:         -Wall


### PR DESCRIPTION
Previously, `ouroboros-consensus-byron/ouroboros-consensus-byrondual` was an
internal cabal library defined in `ouroboros-consensus-byron.cabal`. That
internal library depends on the spec ledger. Only the tests depend
`ouroboros-consensus-byrondual`.

The `cardano-node` repository depends on `ouroboros-consensus-byron`. However,
it also complained about not being able to find the
`ouroboros-consensus-byrondual` package, which depends on the spec ledger,
even when the tests are disabled. We shouldn't have to add a dependency on the
spec ledger when we only want to depend on `ouroboros-consensus-byron`. I
believe it is because we're using an internal cabal library for it, a
relatively new feature.

So to avoid this, we avoid defining `ouroboros-consensus-byrondual` as an
internal cabal library and include it as a source directory in the tests.