### PR TITLE
Use the IO instance of MonadRandom

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Ledger.hs
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Ledger.hs
@@ -47,7 +47,7 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Dual
 import           Ouroboros.Consensus.Ledger.Extended
-import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.PBFT
 
 import           Ouroboros.Consensus.Byron.Crypto.DSIGN
@@ -207,19 +207,16 @@ bridgeTransactionIds = Spec.Test.transactionIds
 -------------------------------------------------------------------------------}
 
 forgeDualByronBlock
-  :: forall m.
-     ( HasNodeState_ () m  -- @()@ is the @NodeState@ of PBFT
-     , MonadRandom m
-     , HasCallStack
-     )
+  :: forall m. (MonadRandom m, HasCallStack)
   => TopLevelConfig DualByronBlock
+  -> Update m (NodeState DualByronBlock)
   -> SlotNo                          -- ^ Current slot
   -> BlockNo                         -- ^ Current block number
   -> ExtLedgerState DualByronBlock   -- ^ Ledger
   -> [GenTx DualByronBlock]          -- ^ Txs to add in the block
   -> PBftIsLeader PBftByronCrypto    -- ^ Leader proof ('IsLeader')
   -> m DualByronBlock
-forgeDualByronBlock cfg curSlotNo curBlockNo extLedger txs isLeader = do
+forgeDualByronBlock cfg updateState curSlotNo curBlockNo extLedger txs isLeader = do
     -- NOTE: We do not /elaborate/ the real Byron block from the spec one, but
     -- instead we /forge/ it. This is important, because we want to test that
     -- codepath. This does mean that we do not get any kind of "bridge" between
@@ -229,6 +226,7 @@ forgeDualByronBlock cfg curSlotNo curBlockNo extLedger txs isLeader = do
 
     main <- forgeByronBlock
               (dualTopLevelConfigMain cfg)
+              updateState
               curSlotNo
               curBlockNo
               (dualExtLedgerStateMain extLedger)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -36,7 +36,7 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
-import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.PBFT
 
 import           Ouroboros.Consensus.Byron.Crypto.DSIGN
@@ -47,12 +47,9 @@ import           Ouroboros.Consensus.Byron.Ledger.PBFT
 import           Ouroboros.Consensus.Byron.Protocol
 
 forgeByronBlock
-  :: forall m.
-     ( HasNodeState_ () m  -- @()@ is the @NodeState@ of PBFT
-     , MonadRandom m
-     , HasCallStack
-     )
+  :: forall m. (MonadRandom m, HasCallStack)
   => TopLevelConfig ByronBlock
+  -> Update m (NodeState ByronBlock)
   -> SlotNo                          -- ^ Current slot
   -> BlockNo                         -- ^ Current block number
   -> ExtLedgerState ByronBlock       -- ^ Ledger
@@ -128,19 +125,16 @@ initBlockPayloads = BlockPayloads
   }
 
 forgeRegularBlock
-  :: forall m.
-     ( HasNodeState_ () m  -- @()@ is the @NodeState@ of PBFT
-     , MonadRandom m
-     , HasCallStack
-     )
+  :: forall m. (MonadRandom m, HasCallStack)
   => TopLevelConfig ByronBlock
+  -> Update m (NodeState ByronBlock)
   -> SlotNo                            -- ^ Current slot
   -> BlockNo                           -- ^ Current block number
   -> ExtLedgerState ByronBlock         -- ^ Ledger
   -> [GenTx ByronBlock]                -- ^ Txs to add in the block
   -> PBftIsLeader PBftByronCrypto    -- ^ Leader proof ('IsLeader')
   -> m ByronBlock
-forgeRegularBlock cfg curSlot curNo extLedger txs isLeader = do
+forgeRegularBlock cfg _updateState curSlot curNo extLedger txs isLeader = do
     ouroborosPayload <-
       forgePBftFields
         (mkByronContextDSIGN cfg)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
@@ -28,6 +28,7 @@ import           Ouroboros.Network.Block (HasHeader (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
@@ -38,6 +39,7 @@ import           Ouroboros.Consensus.Byron.Ledger.Config
 import           Ouroboros.Consensus.Byron.Ledger.Serialisation ()
 import           Ouroboros.Consensus.Byron.Protocol
 
+type instance NodeState     ByronBlock = ()
 type instance BlockProtocol ByronBlock = PBft PBftByronCrypto
 
 -- | Construct DSIGN required for Byron crypto

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -33,6 +33,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Node.Abstract
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util.Condense
@@ -69,6 +70,7 @@ data instance BlockConfig (SimpleBftBlock c c') = SimpleBftBlockConfig {
     }
   deriving (Generic, NoUnexpectedThunks)
 
+type instance NodeState     (SimpleBftBlock c c') = ()
 type instance BlockProtocol (SimpleBftBlock c c') = Bft c'
 
 -- | Sanity check that block and header type synonyms agree
@@ -89,7 +91,7 @@ instance ( SimpleCrypto c
          , Signable (BftDSIGN c') (SignedSimpleBft c c')
          )
       => RunMockBlock c (SimpleBftExt c c') where
-  forgeExt cfg () SimpleBlock{..} = do
+  forgeExt cfg _updateState () SimpleBlock{..} = do
       ext :: SimpleBftExt c c' <- fmap SimpleBftExt $
         forgeBftFields (configConsensus cfg) $
           SignedSimpleBft {

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -36,6 +36,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Node.Abstract
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
 import           Ouroboros.Consensus.Protocol.Signed
@@ -83,6 +84,7 @@ data instance BlockConfig (SimplePBftBlock c c') = SimplePBftBlockConfig {
   }
   deriving (Generic, NoUnexpectedThunks)
 
+type instance NodeState     (SimplePBftBlock c c') = ()
 type instance BlockProtocol (SimplePBftBlock c c') = PBft c'
 
 -- | Sanity check that block and header type synonyms agree
@@ -104,7 +106,7 @@ instance ( SimpleCrypto c
          , ContextDSIGN (PBftDSIGN c') ~ ()
          , Serialise (PBftVerKeyHash c')
          ) => RunMockBlock c (SimplePBftExt c c') where
-  forgeExt _cfg isLeader SimpleBlock{..} = do
+  forgeExt _cfg _updateState isLeader SimpleBlock{..} = do
       ext :: SimplePBftExt c c' <- fmap SimplePBftExt $
         forgePBftFields
           (const ())

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -34,6 +34,7 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Node.Abstract
 import           Ouroboros.Consensus.Mock.Protocol.Praos
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.NodeId (CoreNodeId)
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
 import           Ouroboros.Consensus.Util.Condense
@@ -71,8 +72,9 @@ data instance BlockConfig (SimplePraosRuleBlock c) = SimplePraosRuleBlockConfig 
     }
   deriving (Generic, NoUnexpectedThunks)
 
+type instance NodeState     (SimplePraosRuleBlock c) = ()
 type instance BlockProtocol (SimplePraosRuleBlock c) =
-   WithLeaderSchedule (Praos PraosCryptoUnused)
+    WithLeaderSchedule (Praos PraosCryptoUnused)
 
 -- | Sanity check that block and header type synonyms agree
 _simplePraosRuleHeader :: SimplePraosRuleBlock c -> SimplePraosRuleHeader c
@@ -83,7 +85,7 @@ _simplePraosRuleHeader = simpleHeader
 -------------------------------------------------------------------------------}
 
 instance SimpleCrypto c => RunMockBlock c SimplePraosRuleExt where
-  forgeExt cfg () SimpleBlock{..} = do
+  forgeExt cfg _updateState () SimpleBlock{..} = do
       let ext = SimplePraosRuleExt $ lsNodeConfigNodeId (configConsensus cfg)
       return SimpleBlock {
           simpleHeader = mkSimpleHeader encode simpleHeaderStd ext

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
@@ -22,11 +22,11 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Node.Abstract
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.Abstract
 
 forgeSimple :: forall p c m ext.
-               ( HasNodeState p m
-               , MonadRandom m
+               ( MonadRandom m
                , SimpleCrypto c
                , RunMockBlock c ext
                , BlockSupportsProtocol (SimpleBlock c ext)
@@ -34,14 +34,15 @@ forgeSimple :: forall p c m ext.
                , p ~ BlockProtocol (SimpleBlock c ext)
                )
             => TopLevelConfig (SimpleBlock c ext)
+            -> Update m (NodeState (SimpleBlock c ext))
             -> SlotNo                              -- ^ Current slot
             -> BlockNo                             -- ^ Current block number
             -> ExtLedgerState (SimpleBlock c ext)  -- ^ Current ledger
             -> [GenTx (SimpleBlock c ext)]         -- ^ Txs to add in the block
             -> IsLeader p                          -- ^ Proof we are slot leader
             -> m (SimpleBlock c ext)
-forgeSimple cfg curSlot curBlock extLedger txs proof = do
-    forgeExt cfg proof $ SimpleBlock {
+forgeSimple cfg updateState curSlot curBlock extLedger txs proof = do
+    forgeExt cfg updateState proof $ SimpleBlock {
         simpleHeader = mkSimpleHeader encode stdHeader ()
       , simpleBody   = body
       }

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -12,6 +12,8 @@ import           Data.Time.Calendar (fromGregorian)
 import           Data.Time.Clock (UTCTime (..))
 import           Data.Typeable (Typeable)
 
+import           Cardano.Prelude (NoUnexpectedThunks)
+
 import           Ouroboros.Network.Magic (NetworkMagic (..))
 
 import           Ouroboros.Consensus.Block
@@ -22,6 +24,7 @@ import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Mock.Node.Abstract
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 
 import           Ouroboros.Consensus.Storage.Common (EpochSize (..))
@@ -38,6 +41,7 @@ instance ( LedgerSupportsProtocol (SimpleBlock SimpleMockCrypto ext)
            -- some of the tests loop, but only when compiled with @-O2@ ; with
            -- @-O0@ it is perfectly fine. ghc bug?!
          , BlockSupportsProtocol (SimpleBlock SimpleMockCrypto ext)
+         , NoUnexpectedThunks (NodeState (SimpleBlock SimpleMockCrypto ext))
          , Typeable ext
          , Serialise ext
          , RunMockBlock SimpleMockCrypto ext

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
@@ -19,6 +19,7 @@ import           Cardano.Crypto (ProtocolMagicId (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Mock.Ledger.Block
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.Abstract
 
 -- | Protocol specific functionality required to run consensus with mock blocks
@@ -27,12 +28,10 @@ class RunMockBlock c ext where
   --
   -- This is used in 'forgeSimple', which takes care of the generic part of
   -- the mock block.
-  forgeExt :: ( HasNodeState p m
-              , MonadRandom m
-              , p ~ BlockProtocol (SimpleBlock c ext)
-              )
-           => TopLevelConfig (SimpleBlock c ext)
-           -> IsLeader p
+  forgeExt :: MonadRandom m
+           => TopLevelConfig          (SimpleBlock c ext)
+           -> Update m     (NodeState (SimpleBlock c ext))
+           -> IsLeader (BlockProtocol (SimpleBlock c ext))
            -> SimpleBlock' c ext ()
            -> m (SimpleBlock c ext)
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -45,7 +45,7 @@ protocolInfoPraos numCoreNodes nid params slotLengths =
             ledgerState = genesisSimpleLedgerState addrDist
           , headerState = genesisHeaderState []
           }
-      , pInfoInitState = PraosNodeState $ SignKeyMockKES
+      , pInfoInitState = PraosKeyAvailable $ SignKeyMockKES
            (fst $ verKeys Map.! nid)   -- key ID
            0                           -- KES initial slot
            (praosLifetimeKES params)   -- KES lifetime

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Main.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Main.hs
@@ -6,7 +6,7 @@ import qualified Test.Consensus.Ledger.Mock (tests)
 import qualified Test.ThreadNet.BFT (tests)
 import qualified Test.ThreadNet.LeaderSchedule (tests)
 import qualified Test.ThreadNet.PBFT (tests)
--- import qualified Test.ThreadNet.Praos (tests)
+import qualified Test.ThreadNet.Praos (tests)
 
 main :: IO ()
 main = defaultMain tests
@@ -18,5 +18,5 @@ tests =
   , Test.ThreadNet.BFT.tests
   , Test.ThreadNet.LeaderSchedule.tests
   , Test.ThreadNet.PBFT.tests
---  , Test.ThreadNet.Praos.tests
+  , Test.ThreadNet.Praos.tests
   ]

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
@@ -43,6 +43,7 @@ library
                        Test.Util.Orphans.NoUnexpectedThunks
                        Test.Util.QSM
                        Test.Util.QuickCheck
+                       Test.Util.Random
                        Test.Util.Range
                        Test.Util.RefEnv
                        Test.Util.Roundtrip

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Random.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Random.hs
@@ -1,0 +1,43 @@
+module Test.Util.Random
+  ( runMonadRandomWithTVar
+  ) where
+
+import           Crypto.Random (MonadRandom, drgNew)
+
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.Random
+
+-- | A 'RunMonadRandom' record to use in cases where we don't have access to
+-- the system random number generator, e.g., in the tests.
+--
+-- We store a 'ChaChaDRG' in a TVar, and whenever we need to run a computation
+-- requiring 'MonadRandom', we split the 'ChaChaDRG', store a split half back
+-- in the TVar and run the computation using the other half. Each random
+-- computation will use a different DRG, even concurrent ones.
+--
+-- Remember that will only be used in the tests code, in the real
+-- implementation we will use 'runMonadRandomIO'.
+runMonadRandomWithTVar
+  :: MonadSTM m
+  => StrictTVar m ChaChaDRG
+  -> RunMonadRandom m
+runMonadRandomWithTVar varRNG = RunMonadRandom $ \n -> do
+    -- We can't run @n@ atomically, so to make sure we never run
+    -- computations with the same RNG, we first split it,
+    -- /atomically/, and then run the computation with one half of
+    -- the RNG.
+    rng <- atomically $ do
+      rng <- readTVar varRNG
+      ((split1, split2), _rng') <- runChaChaT fakeSplitDRG rng
+      writeTVar varRNG split1
+      return split2
+    fst <$> runChaChaT n rng
+  where
+    -- The 'ChaChaDRG' is not splittable. We fake splitting it by using the
+    -- 'ChaChaT' 'MonadRandom' instance to generate two new 'ChaChaDRG's. If
+    -- this turns out to be problematic, there is actually no need to store a
+    -- 'ChaChaDRG' in the 'TVar'; we should instead use a splittable PRNG, and
+    -- then use in combination with 'drgNew' or 'drgNewTest' to produce a
+    -- 'ChaChaDRG'.
+    fakeSplitDRG :: MonadRandom m => m (ChaChaDRG, ChaChaDRG)
+    fakeSplitDRG = (,) <$> drgNew <*> drgNew

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -63,6 +63,7 @@ library
                        Ouroboros.Consensus.Node.ProtocolInfo
                        Ouroboros.Consensus.Node.Recovery
                        Ouroboros.Consensus.Node.Run
+                       Ouroboros.Consensus.Node.State
                        Ouroboros.Consensus.Node.Tracers
                        Ouroboros.Consensus.NodeId
                        Ouroboros.Consensus.NodeKernel

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -73,6 +73,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mempool.API
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Util.Condense
 
 {-------------------------------------------------------------------------------
@@ -208,6 +209,7 @@ instance Bridge m a => HasHeader (DualHeader m a) where
   Protocol
 -------------------------------------------------------------------------------}
 
+type instance NodeState     (DualBlock m a) = NodeState     m
 type instance BlockProtocol (DualBlock m a) = BlockProtocol m
 
 dualTopLevelConfigMain :: TopLevelConfig (DualBlock m a) -> TopLevelConfig m

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -36,7 +36,6 @@ module Ouroboros.Consensus.Node
 import           Codec.Serialise (DeserialiseFailure)
 import           Control.Monad (when)
 import           Control.Tracer (Tracer)
-import           Crypto.Random
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Proxy (Proxy (..))
 import           Data.Time.Clock (secondsToDiffTime)
@@ -51,7 +50,6 @@ import           Ouroboros.Network.NodeToNode (NodeToNodeVersionData (..),
 import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
                      (pipelineDecisionLowHighMark)
 
-import           Ouroboros.Consensus.Block (BlockProtocol)
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.ChainSyncClient (ClockSkew (..))
 import           Ouroboros.Consensus.Config
@@ -63,12 +61,13 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Recovery
 import           Ouroboros.Consensus.Node.Run
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Node.Tracers
 import           Ouroboros.Consensus.NodeKernel
 import           Ouroboros.Consensus.NodeNetwork
-import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
+import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB, ChainDbArgs)
@@ -321,7 +320,7 @@ mkNodeArgs
   :: forall blk. RunNode blk
   => ResourceRegistry IO
   -> TopLevelConfig blk
-  -> NodeState (BlockProtocol blk)
+  -> NodeState blk
   -> Tracers IO RemoteConnectionId blk
   -> BlockchainTime IO
   -> ChainDB IO blk
@@ -348,6 +347,6 @@ mkNodeArgs registry cfg initState tracers btime chainDB isProducer = NodeArgs
     blockProduction = case isProducer of
       IsNotProducer -> Nothing
       IsProducer    -> Just BlockProduction
-                         { produceDRG   = drgNew
-                         , produceBlock = nodeForgeBlock cfg
+                         { produceBlock       = nodeForgeBlock cfg
+                         , runMonadRandomDict = runMonadRandomIO
                          }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -10,11 +10,10 @@ import           Data.Word
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.NodeId
-import           Ouroboros.Consensus.Protocol.Abstract
 
 {-------------------------------------------------------------------------------
   Number of core nodes
@@ -35,7 +34,6 @@ enumCoreNodes (NumCoreNodes numNodes) =
 -- | Data required to run the specified protocol.
 data ProtocolInfo b = ProtocolInfo {
         pInfoConfig     :: TopLevelConfig b
-      , pInfoInitState  :: NodeState  (BlockProtocol b)
-        -- | The ledger state at genesis
-      , pInfoInitLedger :: ExtLedgerState b
+      , pInfoInitState  :: NodeState      b
+      , pInfoInitLedger :: ExtLedgerState b -- ^ Genesis ledger state
       }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -35,8 +35,9 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.Node.Exit (ExitReason)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Util.IOLike (IOLike)
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB)
 import           Ouroboros.Consensus.Storage.Common (EpochNo, EpochSize)
@@ -52,11 +53,13 @@ class ( LedgerSupportsProtocol blk
       , HasTxId (GenTx blk)
       , QueryLedger blk
       , HasNetworkProtocolVersion blk
+      , NoUnexpectedThunks (NodeState blk)
         -- TODO: Remove after reconsidering rewindChainState:
       , Serialise (HeaderHash blk)
       ) => RunNode blk where
-  nodeForgeBlock          :: (HasNodeState (BlockProtocol blk) m, MonadRandom m)
+  nodeForgeBlock          :: MonadRandom m
                           => TopLevelConfig blk
+                          -> Update m (NodeState blk)
                           -> SlotNo              -- ^ Current slot
                           -> BlockNo             -- ^ Current block number
                           -> ExtLedgerState blk  -- ^ Current ledger

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/State.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE RankNTypes   #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Ouroboros.Consensus.Node.State (
+    NodeState
+    -- * Infrastructure for dealing with state updates
+  , Update(..)
+  , updateFromTVar
+  , liftUpdate
+  ) where
+
+import           Data.Bifunctor (first)
+
+import           Ouroboros.Consensus.Util.IOLike
+
+{-------------------------------------------------------------------------------
+  Updating the state
+-------------------------------------------------------------------------------}
+
+-- | Update a stateful value
+newtype Update m a = Update {
+      -- | Update the value, and produce a result
+      --
+      -- If 'Nothing', the action will be retried.
+      runUpdate :: forall b. (a -> Maybe (a, b)) -> m b
+    }
+
+updateFromTVar :: MonadSTM m => StrictTVar m a -> Update m a
+updateFromTVar var = Update $ \f -> atomically $ do
+    a <- readTVar var
+    case f a of
+      Nothing      -> retry
+      Just (a', b) -> writeTVar var a' >> return b
+
+liftUpdate :: (large -> small)
+           -> (small -> large -> large)
+           -> Update m large
+           -> Update m small
+liftUpdate get set (Update update) = Update $ \f ->
+    update $ \large ->
+      first (flip set large) <$> (f (get large))
+
+{-------------------------------------------------------------------------------
+  State
+-------------------------------------------------------------------------------}
+
+-- | (Chain-independent) node state required to run the protocol
+type family NodeState blk :: *

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -17,23 +17,11 @@ module Ouroboros.Consensus.Protocol.Abstract (
     ConsensusProtocol(..)
   , NodeConfig
   , SecurityParam(..)
-    -- * State monad for Ouroboros state
-  , HasNodeState
-  , HasNodeState_(..)
-  , NodeStateT
-  , NodeStateT_ -- opaque
-  , nodeStateT
-  , runNodeStateT
-  , evalNodeStateT
-  , runNodeState
-  , evalNodeState
   ) where
 
 import           Codec.Serialise (Serialise)
 import           Control.Monad.Except
-import           Control.Monad.State
 import           Crypto.Random (MonadRandom (..))
-import           Data.Functor.Identity
 import           Data.Typeable (Typeable)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
@@ -43,8 +31,6 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Network.Block (BlockNo, HeaderHash, Point,
                      SlotNo (..))
-
-import           Ouroboros.Consensus.Util.Random
 
 -- | Static node configuration
 --
@@ -66,13 +52,9 @@ class ( Show (ChainState    p)
       , Eq   (ValidationErr p)
       , NoUnexpectedThunks (NodeConfig    p)
       , NoUnexpectedThunks (ChainState    p)
-      , NoUnexpectedThunks (NodeState     p)
       , NoUnexpectedThunks (ValidationErr p)
       , Typeable p -- so that p can appear in exceptions
       ) => ConsensusProtocol p where
-
-  -- | State of the node required to run the protocol
-  type family NodeState p :: *
 
   -- | Blockchain dependent protocol-specific state
   type family ChainState p :: *
@@ -160,7 +142,7 @@ class ( Show (ChainState    p)
   compareCandidates :: NodeConfig p -> SelectView p -> SelectView p -> Ordering
 
   -- | Check if a node is the leader
-  checkIsLeader :: (HasNodeState p m, MonadRandom m)
+  checkIsLeader :: MonadRandom m
                 => NodeConfig p
                 -> SlotNo
                 -> LedgerView p
@@ -237,52 +219,3 @@ class ( Show (ChainState    p)
 -- the number of /slots/.
 newtype SecurityParam = SecurityParam { maxRollbacks :: Word64 }
   deriving (Show, Eq, Generic, NoUnexpectedThunks)
-
-{-------------------------------------------------------------------------------
-  State monad
--------------------------------------------------------------------------------}
-
-type HasNodeState p = HasNodeState_ (NodeState p)
-
--- | State monad for the Ouroboros specific state
---
--- We introduce this so that we can have both MonadState and OuroborosState
--- in a monad stack.
-class Monad m => HasNodeState_ s m | m -> s where
-  getNodeState :: m s
-  putNodeState :: s -> m ()
-
-instance HasNodeState_ s m => HasNodeState_ s (ChaChaT m) where
-  getNodeState = lift $ getNodeState
-  putNodeState = lift . putNodeState
-
-{-------------------------------------------------------------------------------
-  Monad transformer introducing 'HasNodeState_'
--------------------------------------------------------------------------------}
-
-newtype NodeStateT_ s m a = NodeStateT { unNodeStateT :: StateT s m a }
-  deriving (Functor, Applicative, Monad, MonadTrans)
-
-type NodeStateT p = NodeStateT_ (NodeState p)
-
-nodeStateT :: (s -> m (a, s)) -> NodeStateT_ s m a
-nodeStateT = NodeStateT . StateT
-
-runNodeStateT :: NodeStateT_ s m a -> s -> m (a, s)
-runNodeStateT = runStateT . unNodeStateT
-
-evalNodeStateT :: Monad m => NodeStateT_ s m a -> s -> m a
-evalNodeStateT act = fmap fst . runNodeStateT act
-
-runNodeState :: (forall m. Monad m => NodeStateT_ s m a) -> s -> (a, s)
-runNodeState act = runIdentity . runNodeStateT act
-
-evalNodeState :: (forall m. Monad m => NodeStateT_ s m a) -> s -> a
-evalNodeState act = fst . runNodeState act
-
-instance Monad m => HasNodeState_ s (NodeStateT_ s m) where
-  getNodeState = NodeStateT $ get
-  putNodeState = NodeStateT . put
-
-instance MonadRandom m => MonadRandom (NodeStateT_ s m) where
-  getRandomBytes = lift . getRandomBytes

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -128,7 +128,6 @@ data instance NodeConfig (Bft c) = BftNodeConfig {
 instance BftCrypto c => ConsensusProtocol (Bft c) where
   type ValidationErr (Bft c) = BftValidationErr
   type ValidateView  (Bft c) = BftValidateView c
-  type NodeState     (Bft c) = ()
   type LedgerView    (Bft c) = ()
   type IsLeader      (Bft c) = ()
   type ChainState    (Bft c) = ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -53,7 +53,6 @@ data instance NodeConfig (WithLeaderSchedule p) = WLSNodeConfig
 
 instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
   type ChainState    (WithLeaderSchedule p) = ()
-  type NodeState     (WithLeaderSchedule p) = ()
   type LedgerView    (WithLeaderSchedule p) = ()
   type ValidationErr (WithLeaderSchedule p) = ()
   type IsLeader      (WithLeaderSchedule p) = ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -41,7 +41,6 @@ newtype instance NodeConfig (ModChainSel p s) = McsNodeConfig (NodeConfig p)
 
 instance (Typeable p, Typeable s, ChainSelection p s)
       => ConsensusProtocol (ModChainSel p s) where
-    type NodeState     (ModChainSel p s) = NodeState     p
     type ChainState    (ModChainSel p s) = ChainState    p
     type IsLeader      (ModChainSel p s) = IsLeader      p
     type LedgerView    (ModChainSel p s) = LedgerView    p

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -248,7 +248,6 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
   type ValidationErr (PBft c) = PBftValidationErr c
   type ValidateView  (PBft c) = PBftValidateView  c
   type SelectView    (PBft c) = PBftSelectView
-  type NodeState     (PBft c) = ()
 
   -- | We require two things from the ledger state:
   --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Random.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Random.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 module Ouroboros.Consensus.Util.Random (
       -- * Producing values in MonadRandom
@@ -12,6 +14,9 @@ module Ouroboros.Consensus.Util.Random (
       -- * Adding DRNG to a monad stack
     , ChaChaT -- opaque
     , runChaChaT
+      -- * Run MonadRandom computations
+    , RunMonadRandom (..)
+    , runMonadRandomIO
       -- * Convenience re-exports
     , MonadRandom (..)
     , ChaChaDRG
@@ -25,6 +30,8 @@ import           Crypto.Random (ChaChaDRG, MonadPseudoRandom, MonadRandom (..),
                      drgNewTest, randomBytesGenerate, withDRG)
 import           Data.List (genericLength)
 import           Data.Word (Word64)
+
+import           Control.Monad.Class.MonadSTM
 
 {-------------------------------------------------------------------------------
   Producing values in MonadRandom
@@ -63,8 +70,29 @@ newtype ChaChaT m a = ChaChaT { unChaChaT :: StateT ChaChaDRG m a }
 instance Monad m => MonadRandom (ChaChaT m) where
   getRandomBytes = ChaChaT . state . randomBytesGenerate
 
+instance MonadSTM m => MonadSTM (ChaChaT m) where
+  type STM (ChaChaT m) = STM m
+  atomically = lift . atomically
+
 -- | Run the 'MonadPseudoRandomT' monad
 --
 -- This is the analogue of cryptonite's 'withDRG'.
 runChaChaT :: ChaChaT m a -> ChaChaDRG -> m (a, ChaChaDRG)
 runChaChaT = runStateT  . unChaChaT
+
+{-------------------------------------------------------------------------------
+  Run MonadRandom computations
+-------------------------------------------------------------------------------}
+
+newtype RunMonadRandom m = RunMonadRandom
+  { runMonadRandom :: forall a. MonadSTM m
+                   => (forall n. ( MonadRandom n
+                                 , MonadSTM    n
+                                 , STM         n ~ STM m
+                                 ) => n a)
+                   -> m a
+  }
+
+-- | Use the 'MonadRandom' instance for 'IO'.
+runMonadRandomIO :: RunMonadRandom IO
+runMonadRandomIO = RunMonadRandom id

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
@@ -20,20 +20,15 @@ module Ouroboros.Consensus.Util.STM (
   , Sim(..)
   , simId
   , simStateT
-  , simOuroborosStateT
-  , simChaChaT
   ) where
 
 import           Control.Monad.State
-import           Data.Coerce
 import           Data.Void
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           GHC.Stack
 
-import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.IOLike
-import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 {-------------------------------------------------------------------------------
@@ -134,24 +129,4 @@ simStateT stVar (Sim k) = Sim $ \(StateT f) -> do
     st       <- readTVar stVar
     (a, st') <- k (f st)
     writeTVar stVar st'
-    return a
-
-simOuroborosStateT :: IOLike m
-                   => StrictTVar m s
-                   -> Sim n m
-                   -> Sim (NodeStateT_ s n) m
-simOuroborosStateT stVar (Sim k) = Sim $ \n -> do
-    st       <- readTVar stVar
-    (a, st') <- k (runNodeStateT n st)
-    writeTVar stVar st'
-    return a
-
-simChaChaT :: (IOLike m, Coercible a ChaChaDRG)
-           => StrictTVar m a
-           -> Sim n m
-           -> Sim (ChaChaT n) m
-simChaChaT stVar (Sim k) = Sim $ \n -> do
-    st       <- readTVar stVar
-    (a, st') <- k (runChaChaT n (coerce st))
-    writeTVar stVar (coerce st')
     return a


### PR DESCRIPTION
Fixes #1616.

Previously, block production had to live in STM, but this is no longer the
case as of #1445. This means that we no longer need to run `MonadRandom`
computations in STM. To do that, we stored a DRG in a TVar.

Now, we can simply use IO's instance of `MonadRandom`. In the tests we still
use the DRG-in-a-TVar trick, but we split it whenever we get a DRG.

We use the `RunMonadRandom` record for this purpose.

---

Replace NodeState with MonadState

Previously, we need a separate `HasNodeState` class and `NodeStateT` monad
transformer because there was already a `StateT` in our stack, i.e., the one
containing the DRG. As that is gone, we can switch back to a regular
`MonadState` + `StateT`.

The cost is an orphan instance: `MonadRandom (StateT s m)`