### PR TITLE
Reduce the use of `TopLevelConfig`

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
@@ -3,19 +3,27 @@ module Ouroboros.Consensus.Byron.Ledger.Conversions (
     fromByronPrevHash
   , fromByronSlotNo
   , fromByronBlockNo
-    -- From @ouroboros-consensus@ to @cardano-ledger@
+  , fromByronBlockCount
+    -- * From @ouroboros-consensus@ to @cardano-ledger@
   , toByronSlotNo
+    -- * Extract info from the genesis config
+  , genesisSecurityParam
+  , genesisNumCoreNodes
   ) where
 
 import           Data.Coerce
+import qualified Data.Set as Set
 
 import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Common as CC
+import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Slotting as CC
 
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Byron.Ledger.Orphans ()
+import           Ouroboros.Consensus.Node.ProtocolInfo
+import           Ouroboros.Consensus.Protocol.Abstract
 
 {-------------------------------------------------------------------------------
   From @cardano-ledger@ to @ouroboros-consensus@
@@ -32,9 +40,32 @@ fromByronSlotNo = coerce
 fromByronBlockNo :: CC.ChainDifficulty -> BlockNo
 fromByronBlockNo = coerce
 
+fromByronBlockCount :: CC.BlockCount -> SecurityParam
+fromByronBlockCount (CC.BlockCount k) = SecurityParam (fromIntegral k)
+
 {-------------------------------------------------------------------------------
   From @ouroboros-consensus@ to @cardano-ledger@
 -------------------------------------------------------------------------------}
 
 toByronSlotNo :: SlotNo -> CC.SlotNumber
 toByronSlotNo = coerce
+
+{-------------------------------------------------------------------------------
+  Extract info from genesis
+-------------------------------------------------------------------------------}
+
+genesisSecurityParam :: Genesis.Config -> SecurityParam
+genesisSecurityParam =
+      fromByronBlockCount
+    . Genesis.gdK
+    . Genesis.configGenesisData
+
+
+genesisNumCoreNodes :: Genesis.Config -> NumCoreNodes
+genesisNumCoreNodes =
+      NumCoreNodes
+    . fromIntegral
+    . Set.size
+    . Genesis.unGenesisKeyHashes
+    . Genesis.gdGenesisKeyHashes
+    . Genesis.configGenesisData

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
@@ -60,7 +60,6 @@ genesisSecurityParam =
     . Genesis.gdK
     . Genesis.configGenesisData
 
-
 genesisNumCoreNodes :: Genesis.Config -> NumCoreNodes
 genesisNumCoreNodes =
       NumCoreNodes

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -137,7 +137,7 @@ forgeRegularBlock
 forgeRegularBlock cfg _updateState curSlot curNo extLedger txs isLeader = do
     ouroborosPayload <-
       forgePBftFields
-        (mkByronContextDSIGN cfg)
+        (mkByronContextDSIGN (configBlock cfg))
         isLeader
         (reAnnotate $ Annotated toSign ())
     return $ forge ouroborosPayload

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
@@ -16,7 +16,6 @@ import qualified Cardano.Chain.Slotting as CC
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 
 import           Ouroboros.Consensus.Byron.Ledger.Block
@@ -81,4 +80,4 @@ instance ValidateEnvelope ByronBlock where
       canBeEBB (SlotNo s) = s `mod` epochSlots == 0
 
       epochSlots :: Word64
-      epochSlots = CC.unEpochSlots $ byronEpochSlots (configBlock cfg)
+      epochSlots = CC.unEpochSlots $ byronEpochSlots cfg

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Integrity.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Integrity.hs
@@ -13,7 +13,6 @@ import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Crypto.DSIGN.Class as CC.Crypto
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Protocol.PBFT
 
 import           Ouroboros.Consensus.Byron.Ledger.Block
@@ -32,7 +31,7 @@ verifyBlockMatchesHeader hdr blk =
 --
 -- Note that we cannot check this for an EBB, as an EBB contains no signature.
 -- This function will always return 'True' for an EBB.
-verifyHeaderSignature :: TopLevelConfig ByronBlock -> Header ByronBlock -> Bool
+verifyHeaderSignature :: BlockConfig ByronBlock -> Header ByronBlock -> Bool
 verifyHeaderSignature cfg hdr =
     case validateView cfg hdr of
       PBftValidateBoundary{} ->
@@ -54,7 +53,7 @@ verifyHeaderSignature cfg hdr =
 --
 -- Note that we cannot check this for an EBB, as an EBB contains no signature.
 -- This function will always return 'True' for an EBB.
-verifyHeaderIntegrity :: TopLevelConfig ByronBlock -> Header ByronBlock -> Bool
+verifyHeaderIntegrity :: BlockConfig ByronBlock -> Header ByronBlock -> Bool
 verifyHeaderIntegrity cfg hdr =
     verifyHeaderSignature cfg hdr &&
     -- @CC.headerProtocolMagicId@ is the only field of a regular header that
@@ -64,14 +63,14 @@ verifyHeaderIntegrity cfg hdr =
         -- EBB, we can't check it
         CC.ABOBBoundaryHdr _ -> True
   where
-    protocolMagicId = byronProtocolMagicId (configBlock cfg)
+    protocolMagicId = byronProtocolMagicId cfg
 
 -- | Verifies whether the block is not corrupted by checking its signature and
 -- witnesses.
 --
 -- This function will always return 'True' for an EBB, as we cannot check
 -- anything for an EBB.
-verifyBlockIntegrity :: TopLevelConfig ByronBlock -> ByronBlock -> Bool
+verifyBlockIntegrity :: BlockConfig ByronBlock -> ByronBlock -> Bool
 verifyBlockIntegrity cfg blk =
     verifyHeaderIntegrity    cfg hdr &&
     verifyBlockMatchesHeader     hdr blk

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -55,7 +55,6 @@ import qualified Ouroboros.Network.Point as Point
 import           Ouroboros.Network.Protocol.LocalStateQuery.Codec (Some (..))
 
 import           Ouroboros.Consensus.BlockchainTime
-import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.LedgerDerivedInfo
@@ -214,7 +213,7 @@ instance LedgerSupportsProtocol ByronBlock where
               At s -> Right $ toPBftLedgerView $
                 CC.previewDelegationMap (toByronSlotNo s) ls
     where
-      SecurityParam k = configSecurityParam cfg
+      SecurityParam k = genesisSecurityParam (unByronLedgerConfig cfg)
 
       now, maxHi, maxLo :: SlotNo
       now   = fromByronSlotNo $ CC.cvsLastSlot ls

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -58,6 +58,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Protocol.Abstract
 
 import           Ouroboros.Consensus.Byron.Ledger.Block
@@ -144,15 +145,6 @@ instance ShowQuery (Query ByronBlock) where
   showResult GetUpdateInterfaceState = show
 
 instance LedgerSupportsProtocol ByronBlock where
-  protocolSlotLengths =
-        singletonSlotLengths
-      . slotLengthFromMillisec
-      . (fromIntegral :: Natural -> Integer)
-      . CC.ppSlotDuration
-      . Gen.configProtocolParameters
-      . byronGenesisConfig
-      . configBlock
-
   protocolLedgerView _cfg =
         toPBftLedgerView
       . CC.getDelegationMap
@@ -230,6 +222,15 @@ instance LedgerSupportsProtocol ByronBlock where
                         then 0
                         else unSlotNo now - (2 * k)
       maxHi = SlotNo $ unSlotNo now + (2 * k)
+
+instance LedgerDerivedInfo ByronBlock where
+  knownSlotLengths =
+        singletonSlotLengths
+      . slotLengthFromMillisec
+      . (fromIntegral :: Natural -> Integer)
+      . CC.ppSlotDuration
+      . Gen.configProtocolParameters
+      . byronGenesisConfig
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
@@ -27,7 +27,6 @@ import qualified Cardano.Chain.Delegation as Delegation
 import           Ouroboros.Network.Block (HasHeader (..))
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.PBFT
@@ -43,10 +42,10 @@ type instance NodeState     ByronBlock = ()
 type instance BlockProtocol ByronBlock = PBft PBftByronCrypto
 
 -- | Construct DSIGN required for Byron crypto
-mkByronContextDSIGN :: TopLevelConfig ByronBlock
-                    -> VerKeyDSIGN ByronDSIGN
+mkByronContextDSIGN :: BlockConfig  ByronBlock
+                    -> VerKeyDSIGN  ByronDSIGN
                     -> ContextDSIGN ByronDSIGN
-mkByronContextDSIGN cfg = (byronProtocolMagicId (configBlock cfg),)
+mkByronContextDSIGN = (,) . byronProtocolMagicId
 
 instance BlockSupportsProtocol ByronBlock where
   validateView cfg hdr@ByronHeader{..} =
@@ -77,7 +76,7 @@ instance BlockSupportsProtocol ByronBlock where
                (CC.recoverSignedBytes epochSlots regular)
                (mkByronContextDSIGN cfg (pbftGenKey pbftFields))
     where
-      epochSlots = byronEpochSlots (configBlock cfg)
+      epochSlots = byronEpochSlots cfg
 
   selectView _ hdr = (blockNo hdr, byronHeaderIsEBB hdr)
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -240,7 +240,7 @@ instance RunNode ByronBlock where
                             $ Genesis.gdProtocolMagicId
                             . extractGenesisData
   nodeHashInfo              = const byronHashInfo
-  nodeCheckIntegrity        = verifyBlockIntegrity
+  nodeCheckIntegrity        = verifyBlockIntegrity . configBlock
   nodeAddHeaderEnvelope     = const byronAddHeaderEnvelope
   nodeToExitReason _ e
     | Just (_ :: DropEncodedSizeException) <- fromException e

--- a/ouroboros-consensus-byron/test/Test/Consensus/Byron/Ledger.hs
+++ b/ouroboros-consensus-byron/test/Test/Consensus/Byron/Ledger.hs
@@ -328,7 +328,7 @@ prop_detectCorruption_RegularBlock (RegularBlock blk) =
     detectCorruption
       encodeByronBlock
       (decodeByronBlock epochSlots)
-      (verifyBlockIntegrity testCfg)
+      (verifyBlockIntegrity (configBlock testCfg))
       blk
 
 testCfg :: TopLevelConfig ByronBlock

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -32,6 +32,8 @@ module Ouroboros.Consensus.Mock.Ledger.Block (
   , mkSimpleHeader
   , matchesSimpleHeader
   , countSimpleGenTxs
+    -- * Protocol-specific part
+  , MockProtocolSpecific
     -- * 'UpdateLedger'
   , LedgerState(..)
   , LedgerConfig(..)
@@ -236,11 +238,18 @@ instance (SimpleCrypto c, Typeable ext) => ValidateEnvelope (SimpleBlock c ext)
   -- Use defaults
 
 {-------------------------------------------------------------------------------
+  Protocol specific constraints
+-------------------------------------------------------------------------------}
+
+class ( SimpleCrypto c
+      , Typeable ext
+      ) => MockProtocolSpecific c ext where
+
+{-------------------------------------------------------------------------------
   Update the ledger
 -------------------------------------------------------------------------------}
 
-instance (SimpleCrypto c, Typeable ext, BlockSupportsProtocol (SimpleBlock c ext))
-      => UpdateLedger (SimpleBlock c ext) where
+instance MockProtocolSpecific c ext => UpdateLedger (SimpleBlock c ext) where
   newtype LedgerState (SimpleBlock c ext) = SimpleLedgerState {
         simpleLedgerState :: MockState (SimpleBlock c ext)
       }
@@ -284,8 +293,7 @@ genesisSimpleLedgerState = SimpleLedgerState . genesisMockState
   Support for the mempool
 -------------------------------------------------------------------------------}
 
-instance (SimpleCrypto c, Typeable ext, BlockSupportsProtocol (SimpleBlock c ext))
-      => ApplyTx (SimpleBlock c ext) where
+instance MockProtocolSpecific c ext => ApplyTx (SimpleBlock c ext) where
   data GenTx (SimpleBlock c ext) = SimpleGenTx
     { simpleGenTx   :: !Mock.Tx
     , simpleGenTxId :: !Mock.TxId
@@ -335,8 +343,7 @@ mkSimpleGenTx tx = SimpleGenTx
   Support for QueryLedger
 -------------------------------------------------------------------------------}
 
-instance (SimpleCrypto c, Typeable ext, BlockSupportsProtocol (SimpleBlock c ext))
-      => QueryLedger (SimpleBlock c ext) where
+instance MockProtocolSpecific c ext => QueryLedger (SimpleBlock c ext) where
   data Query (SimpleBlock c ext) result
     deriving (Show)
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -33,6 +33,8 @@ module Ouroboros.Consensus.Mock.Ledger.Block (
   , mkSimpleHeader
   , matchesSimpleHeader
   , countSimpleGenTxs
+    -- * Configuration
+  , BlockConfig(..)
     -- * Protocol-specific part
   , MockProtocolSpecific(..)
     -- * 'UpdateLedger'
@@ -76,12 +78,14 @@ import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.Mock.Ledger.Address
 import           Ouroboros.Consensus.Mock.Ledger.State
 import qualified Ouroboros.Consensus.Mock.Ledger.UTxO as Mock
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Util ((.:))
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -237,6 +241,18 @@ instance (SimpleCrypto c, Typeable ext) => HasAnnTip (SimpleBlock c ext)
 
 instance (SimpleCrypto c, Typeable ext) => ValidateEnvelope (SimpleBlock c ext)
   -- Use defaults
+
+{-------------------------------------------------------------------------------
+  Config
+-------------------------------------------------------------------------------}
+
+data instance BlockConfig (SimpleBlock c ext) = SimpleBlockConfig {
+      simpleBlockSlotLengths :: !SlotLengths
+    }
+  deriving (Generic, NoUnexpectedThunks)
+
+instance LedgerDerivedInfo (SimpleBlock c ext) where
+  knownSlotLengths = simpleBlockSlotLengths
 
 {-------------------------------------------------------------------------------
   Protocol specific constraints

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -16,7 +16,6 @@ module Ouroboros.Consensus.Mock.Ledger.Block.BFT (
   , SimpleBftHeader
   , SimpleBftExt(..)
   , SignedSimpleBft(..)
-  , BlockConfig(..)
   ) where
 
 import           Codec.Serialise (Serialise (..))
@@ -28,12 +27,10 @@ import           Cardano.Crypto.DSIGN
 import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Node.Abstract
-import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.Signed
@@ -64,12 +61,6 @@ data SignedSimpleBft c c' = SignedSimpleBft {
       signedSimpleBft :: SimpleStdHeader c (SimpleBftExt c c')
     }
   deriving (Generic)
-
-data instance BlockConfig (SimpleBftBlock c c') = SimpleBftBlockConfig {
-      -- | Slot lengths
-      simpleBftSlotLengths :: SlotLengths
-    }
-  deriving (Generic, NoUnexpectedThunks)
 
 type instance NodeState     (SimpleBftBlock c c') = ()
 type instance BlockProtocol (SimpleBftBlock c c') = Bft c'
@@ -131,9 +122,6 @@ instance ( SimpleCrypto c
       ()
   anachronisticProtocolLedgerView _ _ _ =
       Right ()
-
-instance LedgerDerivedInfo (SimpleBftBlock c c') where
-  knownSlotLengths = simpleBftSlotLengths
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -79,6 +79,13 @@ _simpleBFtHeader :: SimpleBftBlock c c' -> SimpleBftHeader c c'
 _simpleBFtHeader = simpleHeader
 
 {-------------------------------------------------------------------------------
+  Customization of the generic infrastructure
+-------------------------------------------------------------------------------}
+
+instance (SimpleCrypto c, Typeable c')
+      => MockProtocolSpecific c (SimpleBftExt c c')
+
+{-------------------------------------------------------------------------------
   Evidence that SimpleBlock can support BFT
 -------------------------------------------------------------------------------}
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -33,6 +33,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Node.Abstract
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.Signed
@@ -118,12 +119,13 @@ instance ( SimpleCrypto c
          , BftCrypto c'
          , Signable (BftDSIGN c') (SignedSimpleBft c c')
          ) => LedgerSupportsProtocol (SimpleBftBlock c c') where
-  protocolSlotLengths =
-      simpleBftSlotLengths . configBlock
   protocolLedgerView _ _ =
       ()
   anachronisticProtocolLedgerView _ _ _ =
       Right ()
+
+instance LedgerDerivedInfo (SimpleBftBlock c c') where
+  knownSlotLengths = simpleBftSlotLengths
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -83,7 +83,8 @@ _simpleBFtHeader = simpleHeader
 -------------------------------------------------------------------------------}
 
 instance (SimpleCrypto c, Typeable c')
-      => MockProtocolSpecific c (SimpleBftExt c c')
+      => MockProtocolSpecific c (SimpleBftExt c c') where
+  type MockLedgerConfig c (SimpleBftExt c c') = ()
 
 {-------------------------------------------------------------------------------
   Evidence that SimpleBlock can support BFT

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -36,6 +36,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Node.Abstract
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
@@ -135,12 +136,13 @@ instance ( SimpleCrypto c
 instance ( SimpleCrypto c
          , Signable MockDSIGN (SignedSimplePBft c PBftMockCrypto)
          ) => LedgerSupportsProtocol (SimplePBftBlock c PBftMockCrypto) where
-  protocolSlotLengths =
-      simplePBftSlotLengths . configBlock
   protocolLedgerView TopLevelConfig{..} _ls =
       simplePBftLedgerView configBlock
   anachronisticProtocolLedgerView TopLevelConfig{..} _ _ =
       Right $ simplePBftLedgerView configBlock
+
+instance LedgerDerivedInfo (SimplePBftBlock c PBftMockCrypto) where
+  knownSlotLengths = simplePBftSlotLengths
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -77,11 +77,8 @@ data SignedSimplePBft c c' = SignedSimplePBft {
   deriving (Generic)
 
 data instance BlockConfig (SimplePBftBlock c c') = SimplePBftBlockConfig {
-    -- | PBFT requires the ledger view; for the mock ledger, this is constant
-    simplePBftLedgerView :: PBftLedgerView c'
-
     -- | Slot lengths
-  , simplePBftSlotLengths :: SlotLengths
+    simplePBftSlotLengths :: SlotLengths
   }
   deriving (Generic, NoUnexpectedThunks)
 
@@ -96,9 +93,10 @@ _simplePBftHeader = simpleHeader
   Customization of the generic infrastructure
 -------------------------------------------------------------------------------}
 
-instance (SimpleCrypto c, Typeable c')
+instance (SimpleCrypto c, PBftCrypto c')
       => MockProtocolSpecific c (SimplePBftExt c c') where
-  type MockLedgerConfig c (SimplePBftExt c c') = ()
+  -- | PBFT requires the ledger view; for the mock ledger, this is constant
+  type MockLedgerConfig c (SimplePBftExt c c') = PBftLedgerView c'
 
 {-------------------------------------------------------------------------------
   Evidence that SimpleBlock can support PBFT
@@ -145,9 +143,9 @@ instance ( SimpleCrypto c
          , Signable MockDSIGN (SignedSimplePBft c PBftMockCrypto)
          ) => LedgerSupportsProtocol (SimplePBftBlock c PBftMockCrypto) where
   protocolLedgerView TopLevelConfig{..} _ls =
-      simplePBftLedgerView configBlock
+      simpleMockLedgerConfig configLedger
   anachronisticProtocolLedgerView TopLevelConfig{..} _ _ =
-      Right $ simplePBftLedgerView configBlock
+      Right $ simpleMockLedgerConfig configLedger
 
 instance LedgerDerivedInfo (SimplePBftBlock c PBftMockCrypto) where
   knownSlotLengths = simplePBftSlotLengths

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -17,7 +17,6 @@ module Ouroboros.Consensus.Mock.Ledger.Block.PBFT (
   , SimplePBftHeader
   , SimplePBftExt(..)
   , SignedSimplePBft(..)
-  , BlockConfig(..)
   ) where
 
 import           Codec.Serialise (Serialise (..))
@@ -31,12 +30,10 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 import           Ouroboros.Network.Block (HasHeader (..))
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Node.Abstract
-import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.ChainState as CS
@@ -75,12 +72,6 @@ data SignedSimplePBft c c' = SignedSimplePBft {
       signedSimplePBft :: SimpleStdHeader c (SimplePBftExt c c')
     }
   deriving (Generic)
-
-data instance BlockConfig (SimplePBftBlock c c') = SimplePBftBlockConfig {
-    -- | Slot lengths
-    simplePBftSlotLengths :: SlotLengths
-  }
-  deriving (Generic, NoUnexpectedThunks)
 
 type instance NodeState     (SimplePBftBlock c c') = ()
 type instance BlockProtocol (SimplePBftBlock c c') = PBft c'
@@ -146,9 +137,6 @@ instance ( SimpleCrypto c
       simpleMockLedgerConfig configLedger
   anachronisticProtocolLedgerView TopLevelConfig{..} _ _ =
       Right $ simpleMockLedgerConfig configLedger
-
-instance LedgerDerivedInfo (SimplePBftBlock c PBftMockCrypto) where
-  knownSlotLengths = simplePBftSlotLengths
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -133,10 +133,8 @@ instance ( SimpleCrypto c
 instance ( SimpleCrypto c
          , Signable MockDSIGN (SignedSimplePBft c PBftMockCrypto)
          ) => LedgerSupportsProtocol (SimplePBftBlock c PBftMockCrypto) where
-  protocolLedgerView TopLevelConfig{..} _ls =
-      simpleMockLedgerConfig configLedger
-  anachronisticProtocolLedgerView TopLevelConfig{..} _ _ =
-      Right $ simpleMockLedgerConfig configLedger
+  protocolLedgerView              cfg _   =         simpleMockLedgerConfig cfg
+  anachronisticProtocolLedgerView cfg _ _ = Right $ simpleMockLedgerConfig cfg
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -93,6 +93,13 @@ _simplePBftHeader :: SimplePBftBlock c c' -> SimplePBftHeader c c'
 _simplePBftHeader = simpleHeader
 
 {-------------------------------------------------------------------------------
+  Customization of the generic infrastructure
+-------------------------------------------------------------------------------}
+
+instance (SimpleCrypto c, Typeable c')
+      => MockProtocolSpecific c (SimplePBftExt c c')
+
+{-------------------------------------------------------------------------------
   Evidence that SimpleBlock can support PBFT
 -------------------------------------------------------------------------------}
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -97,7 +97,8 @@ _simplePBftHeader = simpleHeader
 -------------------------------------------------------------------------------}
 
 instance (SimpleCrypto c, Typeable c')
-      => MockProtocolSpecific c (SimplePBftExt c c')
+      => MockProtocolSpecific c (SimplePBftExt c c') where
+  type MockLedgerConfig c (SimplePBftExt c c') = ()
 
 {-------------------------------------------------------------------------------
   Evidence that SimpleBlock can support PBFT

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -39,6 +39,7 @@ import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Ledger.Stake
 import           Ouroboros.Consensus.Mock.Node.Abstract
 import           Ouroboros.Consensus.Mock.Protocol.Praos
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util.Condense
@@ -160,14 +161,14 @@ instance ( SimpleCrypto c
          , PraosCrypto c'
          , Signable (PraosKES c') (SignedSimplePraos c c')
          ) => LedgerSupportsProtocol (SimplePraosBlock c c') where
-  protocolSlotLengths =
-      simplePraosSlotLengths . configBlock
-
   protocolLedgerView TopLevelConfig{..} _ =
       equalStakeDist (simplePraosAddrDist configBlock)
 
   anachronisticProtocolLedgerView TopLevelConfig{..} _ _ =
       Right $ equalStakeDist (simplePraosAddrDist configBlock)
+
+instance LedgerDerivedInfo (SimplePraosBlock c c') where
+  knownSlotLengths = simplePraosSlotLengths
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -78,11 +78,8 @@ data SignedSimplePraos c c' = SignedSimplePraos {
     }
 
 data instance BlockConfig (SimplePraosBlock c c') = SimplePraosBlockConfig {
-      -- | See 'LedgerSupportsProtocol' instance for why we need the 'AddrDist'
-      simplePraosAddrDist :: AddrDist
-
       -- | Slot lengths
-    , simplePraosSlotLengths :: SlotLengths
+      simplePraosSlotLengths :: SlotLengths
     }
   deriving (Generic, NoUnexpectedThunks)
 
@@ -99,7 +96,8 @@ _simplePraosHeader = simpleHeader
 
 instance (SimpleCrypto c, Typeable c')
       => MockProtocolSpecific c (SimplePraosExt c c') where
-  type MockLedgerConfig c (SimplePraosExt c c') = ()
+  -- | See 'LedgerSupportsProtocol' instance for why we need the 'AddrDist'
+  type MockLedgerConfig c (SimplePraosExt c c') = AddrDist
 
 {-------------------------------------------------------------------------------
   Evidence that SimpleBlock can support Praos
@@ -171,10 +169,10 @@ instance ( SimpleCrypto c
          , Signable (PraosKES c') (SignedSimplePraos c c')
          ) => LedgerSupportsProtocol (SimplePraosBlock c c') where
   protocolLedgerView TopLevelConfig{..} _ =
-      equalStakeDist (simplePraosAddrDist configBlock)
+      equalStakeDist (simpleMockLedgerConfig configLedger)
 
   anachronisticProtocolLedgerView TopLevelConfig{..} _ _ =
-      Right $ equalStakeDist (simplePraosAddrDist configBlock)
+      Right $ equalStakeDist (simpleMockLedgerConfig configLedger)
 
 instance LedgerDerivedInfo (SimplePraosBlock c c') where
   knownSlotLengths = simplePraosSlotLengths

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -24,6 +24,7 @@ import qualified Codec.CBOR.Decoding as CBOR
 import           Codec.CBOR.Encoding (encodeListLen)
 import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.Serialise (Serialise (..))
+import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
@@ -91,6 +92,13 @@ type instance BlockProtocol (SimplePraosBlock c c') = Praos c'
 -- | Sanity check that block and header type synonyms agree
 _simplePraosHeader :: SimplePraosBlock c c' -> SimplePraosHeader c c'
 _simplePraosHeader = simpleHeader
+
+{-------------------------------------------------------------------------------
+  Customization of the generic infrastructure
+-------------------------------------------------------------------------------}
+
+instance (SimpleCrypto c, Typeable c')
+      => MockProtocolSpecific c (SimplePraosExt c c')
 
 {-------------------------------------------------------------------------------
   Evidence that SimpleBlock can support Praos

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -98,7 +98,8 @@ _simplePraosHeader = simpleHeader
 -------------------------------------------------------------------------------}
 
 instance (SimpleCrypto c, Typeable c')
-      => MockProtocolSpecific c (SimplePraosExt c c')
+      => MockProtocolSpecific c (SimplePraosExt c c') where
+  type MockLedgerConfig c (SimplePraosExt c c') = ()
 
 {-------------------------------------------------------------------------------
   Evidence that SimpleBlock can support Praos

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -147,6 +147,13 @@ instance ( SimpleCrypto c
          ) => BlockSupportsProtocol (SimpleBlock c (SimplePraosExt c c')) where
   validateView _ = praosValidateView (simplePraosExt . simpleHeaderExt)
 
+instance ( SimpleCrypto c
+         , PraosCrypto c'
+         , Signable (PraosKES c') (SignedSimplePraos c c')
+         ) => LedgerSupportsProtocol (SimplePraosBlock c c') where
+  protocolLedgerView              cfg _   =         stakeDist cfg
+  anachronisticProtocolLedgerView cfg _ _ = Right $ stakeDist cfg
+
 -- | Praos needs a ledger that can give it the "active stake distribution"
 --
 -- TODO: Currently our mock ledger does not do this, and just assumes that all
@@ -155,15 +162,8 @@ instance ( SimpleCrypto c
 -- documentation of 'LedgerView'). Ideally we'd change this however, but it
 -- may not be worth it; it would be a bit of work, and after we have integrated
 -- the Shelley rules, we'll have a proper instance anyway.
-instance ( SimpleCrypto c
-         , PraosCrypto c'
-         , Signable (PraosKES c') (SignedSimplePraos c c')
-         ) => LedgerSupportsProtocol (SimplePraosBlock c c') where
-  protocolLedgerView TopLevelConfig{..} _ =
-      equalStakeDist (simpleMockLedgerConfig configLedger)
-
-  anachronisticProtocolLedgerView TopLevelConfig{..} _ _ =
-      Right $ equalStakeDist (simpleMockLedgerConfig configLedger)
+stakeDist :: LedgerConfig (SimplePraosBlock c c') -> StakeDist
+stakeDist cfg = equalStakeDist (simpleMockLedgerConfig cfg)
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -16,7 +16,6 @@ module Ouroboros.Consensus.Mock.Ledger.Block.Praos (
   , SimplePraosHeader
   , SimplePraosExt(..)
   , SignedSimplePraos(..)
-  , BlockConfig(..)
   ) where
 
 import           Codec.CBOR.Decoding (decodeListLenOf)
@@ -32,7 +31,6 @@ import           Cardano.Crypto.KES
 import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Address
@@ -40,7 +38,6 @@ import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Ledger.Stake
 import           Ouroboros.Consensus.Mock.Node.Abstract
 import           Ouroboros.Consensus.Mock.Protocol.Praos
-import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Util.Condense
@@ -76,12 +73,6 @@ data SignedSimplePraos c c' = SignedSimplePraos {
       signedSimplePraos :: SimpleStdHeader c (SimplePraosExt c c')
     , signedPraosFields :: PraosExtraFields c'
     }
-
-data instance BlockConfig (SimplePraosBlock c c') = SimplePraosBlockConfig {
-      -- | Slot lengths
-      simplePraosSlotLengths :: SlotLengths
-    }
-  deriving (Generic, NoUnexpectedThunks)
 
 type instance NodeState     (SimplePraosBlock c c') = PraosNodeState c'
 type instance BlockProtocol (SimplePraosBlock c c') = Praos c'
@@ -173,9 +164,6 @@ instance ( SimpleCrypto c
 
   anachronisticProtocolLedgerView TopLevelConfig{..} _ _ =
       Right $ equalStakeDist (simpleMockLedgerConfig configLedger)
-
-instance LedgerDerivedInfo (SimplePraosBlock c c') where
-  knownSlotLengths = simplePraosSlotLengths
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -101,12 +101,9 @@ instance SimpleCrypto c
       => BlockSupportsProtocol (SimpleBlock c SimplePraosRuleExt) where
   validateView _ _ = ()
 
-instance SimpleCrypto c
-      => LedgerSupportsProtocol (SimplePraosRuleBlock c) where
-  protocolLedgerView _ _ =
-      ()
-  anachronisticProtocolLedgerView _ _ _ =
-      Right ()
+instance SimpleCrypto c => LedgerSupportsProtocol (SimplePraosRuleBlock c) where
+  protocolLedgerView              _ _   = ()
+  anachronisticProtocolLedgerView _ _ _ = Right ()
 
 {-------------------------------------------------------------------------------
   We don't need crypto for this protocol

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -34,6 +34,7 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Node.Abstract
 import           Ouroboros.Consensus.Mock.Protocol.Praos
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.NodeId (CoreNodeId)
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
@@ -104,12 +105,13 @@ instance SimpleCrypto c
 
 instance SimpleCrypto c
       => LedgerSupportsProtocol (SimplePraosRuleBlock c) where
-  protocolSlotLengths =
-      simplePraosRuleSlotLengths . configBlock
   protocolLedgerView _ _ =
       ()
   anachronisticProtocolLedgerView _ _ _ =
       Right ()
+
+instance LedgerDerivedInfo (SimplePraosRuleBlock c) where
+  knownSlotLengths = simplePraosRuleSlotLengths
 
 {-------------------------------------------------------------------------------
   We don't need crypto for this protocol

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -85,7 +85,8 @@ _simplePraosRuleHeader = simpleHeader
   Customization of the generic infrastructure
 -------------------------------------------------------------------------------}
 
-instance SimpleCrypto c => MockProtocolSpecific c SimplePraosRuleExt
+instance SimpleCrypto c => MockProtocolSpecific c SimplePraosRuleExt where
+  type MockLedgerConfig c SimplePraosRuleExt = ()
 
 {-------------------------------------------------------------------------------
   Evidence that 'SimpleBlock' can support Praos with an explicit leader schedule

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -82,6 +82,12 @@ _simplePraosRuleHeader :: SimplePraosRuleBlock c -> SimplePraosRuleHeader c
 _simplePraosRuleHeader = simpleHeader
 
 {-------------------------------------------------------------------------------
+  Customization of the generic infrastructure
+-------------------------------------------------------------------------------}
+
+instance SimpleCrypto c => MockProtocolSpecific c SimplePraosRuleExt
+
+{-------------------------------------------------------------------------------
   Evidence that 'SimpleBlock' can support Praos with an explicit leader schedule
 -------------------------------------------------------------------------------}
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -16,7 +16,6 @@ module Ouroboros.Consensus.Mock.Ledger.Block.PraosRule (
   , SimplePraosRuleExt(..)
   , SimplePraosRuleHeader
   , PraosCryptoUnused
-  , BlockConfig(..)
   ) where
 
 import           Codec.Serialise (Serialise (..))
@@ -28,13 +27,11 @@ import           Cardano.Crypto.VRF
 import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Node.Abstract
 import           Ouroboros.Consensus.Mock.Protocol.Praos
-import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.NodeId (CoreNodeId)
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
@@ -66,12 +63,6 @@ newtype SimplePraosRuleExt = SimplePraosRuleExt {
   deriving stock    (Generic, Show, Eq)
   deriving newtype  (Condense)
   deriving anyclass (NoUnexpectedThunks)
-
-data instance BlockConfig (SimplePraosRuleBlock c) = SimplePraosRuleBlockConfig {
-      -- | Slot lengths
-      simplePraosRuleSlotLengths :: SlotLengths
-    }
-  deriving (Generic, NoUnexpectedThunks)
 
 type instance NodeState     (SimplePraosRuleBlock c) = ()
 type instance BlockProtocol (SimplePraosRuleBlock c) =
@@ -116,9 +107,6 @@ instance SimpleCrypto c
       ()
   anachronisticProtocolLedgerView _ _ _ =
       Right ()
-
-instance LedgerDerivedInfo (SimplePraosRuleBlock c) where
-  knownSlotLengths = simplePraosRuleSlotLengths
 
 {-------------------------------------------------------------------------------
   We don't need crypto for this protocol

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
@@ -9,7 +9,6 @@ module Ouroboros.Consensus.Mock.Ledger.Forge (forgeSimple) where
 import           Codec.Serialise (Serialise (..), serialise)
 import           Crypto.Random (MonadRandom)
 import qualified Data.ByteString.Lazy as Lazy
-import           Data.Typeable (Typeable)
 import           Data.Word
 
 import           Cardano.Crypto.Hash
@@ -25,21 +24,14 @@ import           Ouroboros.Consensus.Mock.Node.Abstract
 import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.Abstract
 
-forgeSimple :: forall p c m ext.
-               ( MonadRandom m
-               , SimpleCrypto c
-               , RunMockBlock c ext
-               , BlockSupportsProtocol (SimpleBlock c ext)
-               , Typeable ext
-               , p ~ BlockProtocol (SimpleBlock c ext)
-               )
+forgeSimple :: forall c m ext. (MonadRandom m, RunMockBlock c ext)
             => TopLevelConfig (SimpleBlock c ext)
             -> Update m (NodeState (SimpleBlock c ext))
-            -> SlotNo                              -- ^ Current slot
-            -> BlockNo                             -- ^ Current block number
-            -> ExtLedgerState (SimpleBlock c ext)  -- ^ Current ledger
-            -> [GenTx (SimpleBlock c ext)]         -- ^ Txs to add in the block
-            -> IsLeader p                          -- ^ Proof we are slot leader
+            -> SlotNo                             -- ^ Current slot
+            -> BlockNo                            -- ^ Current block number
+            -> ExtLedgerState (SimpleBlock c ext) -- ^ Current ledger
+            -> [GenTx (SimpleBlock c ext)]        -- ^ Txs to add in the block
+            -> IsLeader (BlockProtocol (SimpleBlock c ext))
             -> m (SimpleBlock c ext)
 forgeSimple cfg updateState curSlot curBlock extLedger txs proof = do
     forgeExt cfg updateState proof $ SimpleBlock {

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -22,6 +22,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Mock.Node.Abstract
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.State
@@ -37,6 +38,7 @@ instance HasNetworkProtocolVersion (SimpleBlock SimpleMockCrypto ext) where
   -- Use defaults
 
 instance ( LedgerSupportsProtocol (SimpleBlock SimpleMockCrypto ext)
+         , LedgerDerivedInfo      (SimpleBlock SimpleMockCrypto ext)
            -- The below constraint seems redundant but is not! When removed,
            -- some of the tests loop, but only when compiled with @-O2@ ; with
            -- @-O0@ it is perfectly fine. ghc bug?!

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -22,7 +22,6 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Mock.Node.Abstract
-import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.State
@@ -38,7 +37,6 @@ instance HasNetworkProtocolVersion (SimpleBlock SimpleMockCrypto ext) where
   -- Use defaults
 
 instance ( LedgerSupportsProtocol (SimpleBlock SimpleMockCrypto ext)
-         , LedgerDerivedInfo      (SimpleBlock SimpleMockCrypto ext)
            -- The below constraint seems redundant but is not! When removed,
            -- some of the tests loop, but only when compiled with @-O2@ ; with
            -- @-O0@ it is perfectly fine. ghc bug?!

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
@@ -23,7 +23,7 @@ import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.Abstract
 
 -- | Protocol specific functionality required to run consensus with mock blocks
-class RunMockBlock c ext where
+class MockProtocolSpecific c ext => RunMockBlock c ext where
   -- | Construct the protocol specific part of the block
   --
   -- This is used in 'forgeSimple', which takes care of the generic part of

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -36,7 +36,7 @@ protocolInfoBft numCoreNodes nid securityParam slotLengths =
                   | n <- enumCoreNodes numCoreNodes
                   ]
               }
-          , configLedger = SimpleLedgerConfig
+          , configLedger = SimpleLedgerConfig ()
           , configBlock  = SimpleBftBlockConfig slotLengths
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -37,7 +37,7 @@ protocolInfoBft numCoreNodes nid securityParam slotLengths =
                   ]
               }
           , configLedger = SimpleLedgerConfig ()
-          , configBlock  = SimpleBftBlockConfig slotLengths
+          , configBlock  = SimpleBlockConfig slotLengths
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState ())

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -36,8 +36,8 @@ protocolInfoMockPBFT params slotLengths nid =
                    , pbftDlgCert    = (verKey nid, verKey nid)
                    }
                }
-          , configLedger = SimpleLedgerConfig ()
-          , configBlock  = SimplePBftBlockConfig ledgerView slotLengths
+          , configLedger = SimpleLedgerConfig ledgerView
+          , configBlock  = SimplePBftBlockConfig slotLengths
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState CS.empty)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -37,7 +37,7 @@ protocolInfoMockPBFT params slotLengths nid =
                    }
                }
           , configLedger = SimpleLedgerConfig ledgerView
-          , configBlock  = SimplePBftBlockConfig slotLengths
+          , configBlock  = SimpleBlockConfig slotLengths
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState CS.empty)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -36,7 +36,7 @@ protocolInfoMockPBFT params slotLengths nid =
                    , pbftDlgCert    = (verKey nid, verKey nid)
                    }
                }
-          , configLedger = SimpleLedgerConfig
+          , configLedger = SimpleLedgerConfig ()
           , configBlock  = SimplePBftBlockConfig ledgerView slotLengths
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -38,8 +38,8 @@ protocolInfoPraos numCoreNodes nid params slotLengths =
               , praosInitialStake = genesisStakeDist addrDist
               , praosVerKeys      = verKeys
               }
-          , configLedger = SimpleLedgerConfig ()
-          , configBlock  = SimplePraosBlockConfig addrDist slotLengths
+          , configLedger = SimpleLedgerConfig addrDist
+          , configBlock  = SimplePraosBlockConfig slotLengths
           }
       , pInfoInitLedger = ExtLedgerState {
             ledgerState = genesisSimpleLedgerState addrDist

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -38,7 +38,7 @@ protocolInfoPraos numCoreNodes nid params slotLengths =
               , praosInitialStake = genesisStakeDist addrDist
               , praosVerKeys      = verKeys
               }
-          , configLedger = SimpleLedgerConfig
+          , configLedger = SimpleLedgerConfig ()
           , configBlock  = SimplePraosBlockConfig addrDist slotLengths
           }
       , pInfoInitLedger = ExtLedgerState {

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -39,7 +39,7 @@ protocolInfoPraos numCoreNodes nid params slotLengths =
               , praosVerKeys      = verKeys
               }
           , configLedger = SimpleLedgerConfig addrDist
-          , configBlock  = SimplePraosBlockConfig slotLengths
+          , configBlock  = SimpleBlockConfig slotLengths
           }
       , pInfoInitLedger = ExtLedgerState {
             ledgerState = genesisSimpleLedgerState addrDist

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -44,7 +44,7 @@ protocolInfoPraosRule numCoreNodes
                 }
             , lsNodeConfigNodeId   = nid
             }
-        , configLedger = SimpleLedgerConfig
+        , configLedger = SimpleLedgerConfig ()
         , configBlock  = SimplePraosRuleBlockConfig slotLengths
         }
     , pInfoInitLedger = ExtLedgerState

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -45,7 +45,7 @@ protocolInfoPraosRule numCoreNodes
             , lsNodeConfigNodeId   = nid
             }
         , configLedger = SimpleLedgerConfig ()
-        , configBlock  = SimplePraosRuleBlockConfig slotLengths
+        , configBlock  = SimpleBlockConfig slotLengths
         }
     , pInfoInitLedger = ExtLedgerState
         { ledgerState = genesisSimpleLedgerState addrDist

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -87,6 +87,7 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -324,9 +325,11 @@ instance ValidateEnvelope TestBlock where
   firstBlockNo _ = Block.BlockNo 1
 
 instance LedgerSupportsProtocol TestBlock where
-  protocolSlotLengths = testBlockSlotLengths . configBlock
   protocolLedgerView _ _ = ()
   anachronisticProtocolLedgerView _ _ _ = Right ()
+
+instance LedgerDerivedInfo TestBlock where
+  knownSlotLengths = testBlockSlotLengths
 
 instance QueryLedger TestBlock where
   data Query TestBlock result where

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -59,6 +59,7 @@ library
                        Ouroboros.Consensus.Node.DbMarker
                        Ouroboros.Consensus.Node.ErrorPolicy
                        Ouroboros.Consensus.Node.Exit
+                       Ouroboros.Consensus.Node.LedgerDerivedInfo
                        Ouroboros.Consensus.Node.NetworkProtocolVersion
                        Ouroboros.Consensus.Node.ProtocolInfo
                        Ouroboros.Consensus.Node.Recovery

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
@@ -11,7 +11,6 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Block.Abstract
-import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Protocol.Abstract
 
 {-------------------------------------------------------------------------------
@@ -26,14 +25,14 @@ class ( GetHeader blk
       , NoUnexpectedThunks (Header blk)
       , NoUnexpectedThunks (BlockConfig blk)
       ) => BlockSupportsProtocol blk where
-  validateView :: TopLevelConfig blk
+  validateView :: BlockConfig blk
                -> Header blk -> ValidateView (BlockProtocol blk)
 
-  selectView   :: TopLevelConfig blk
+  selectView   :: BlockConfig blk
                -> Header blk -> SelectView   (BlockProtocol blk)
 
   -- Default chain selection just looks at longest chains
   default selectView :: SelectView (BlockProtocol blk) ~ BlockNo
-                     => TopLevelConfig blk
+                     => BlockConfig blk
                      -> Header blk -> SelectView (BlockProtocol blk)
   selectView _ = blockNo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/ChainSyncClient.hs
@@ -593,7 +593,10 @@ chainSyncClient mkPipelineDecision0 tracer cfg btime
         -- and our tip is within k blocks from our tip. This means that the
         -- anachronistic ledger view must be available, unless they are
         -- too far /ahead/ of us. In this case we must simply wait
-        case anachronisticProtocolLedgerView cfg curLedger (pointSlot hdrPoint) of
+        case anachronisticProtocolLedgerView
+              (configLedger cfg)
+              curLedger
+              (pointSlot hdrPoint) of
           Right lv          -> return lv
           Left TooFarAhead  -> retry
           -- unexpected alternative; see comment before this case expression

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -252,7 +252,7 @@ castHeaderEnvelopeError = \case
 
 class HasAnnTip blk => ValidateEnvelope blk where
   -- | Validate the header envelope
-  validateEnvelope :: TopLevelConfig blk
+  validateEnvelope :: BlockConfig blk
                    -> WithOrigin (AnnTip blk)
                    -> Header blk
                    -> Except (HeaderEnvelopeError blk) ()
@@ -269,7 +269,7 @@ class HasAnnTip blk => ValidateEnvelope blk where
   minimumPossibleSlotNo _ = SlotNo 0
 
   default validateEnvelope :: HasHeader (Header blk)
-                           => TopLevelConfig blk
+                           => BlockConfig blk
                            -> WithOrigin (AnnTip blk)
                            -> Header blk
                            -> Except (HeaderEnvelopeError blk) ()
@@ -373,7 +373,7 @@ validateHeader :: (BlockSupportsProtocol blk, ValidateEnvelope blk)
                -> Except (HeaderError blk) (HeaderState blk)
 validateHeader cfg ledgerView hdr st = do
     withExcept HeaderEnvelopeError $
-      validateEnvelope cfg (headerStateTip st) hdr
+      validateEnvelope (configBlock cfg) (headerStateTip st) hdr
     chainState' <- withExcept HeaderProtocolError $
                      applyChainState
                        (configConsensus cfg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -378,7 +378,7 @@ validateHeader cfg ledgerView hdr st = do
                      applyChainState
                        (configConsensus cfg)
                        ledgerView
-                       (validateView cfg hdr)
+                       (validateView (configBlock cfg) hdr)
                        (headerStateChain st)
     return $ headerStatePush
                (configSecurityParam cfg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -375,7 +375,7 @@ instance Bridge m a => HasAnnTip (DualBlock m a) where
 instance Bridge m a => ValidateEnvelope (DualBlock m a) where
   validateEnvelope cfg t =
         withExcept castHeaderEnvelopeError
-      . validateEnvelope (dualTopLevelConfigMain cfg) (castAnnTip <$> t)
+      . validateEnvelope (dualBlockConfigMain cfg) (castAnnTip <$> t)
       . dualHeaderMain
 
   firstBlockNo          _ = firstBlockNo          (Proxy @m)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -137,6 +137,14 @@ data instance BlockConfig (DualBlock m a) = DualBlockConfig {
     }
   deriving NoUnexpectedThunks via AllowThunk (BlockConfig (DualBlock m a))
 
+-- | This is only used for block production
+dualTopLevelConfigMain :: TopLevelConfig (DualBlock m a) -> TopLevelConfig m
+dualTopLevelConfigMain TopLevelConfig{..} = TopLevelConfig{
+      configConsensus =                      configConsensus
+    , configLedger    = dualLedgerConfigMain configLedger
+    , configBlock     = dualBlockConfigMain  configBlock
+    }
+
 {-------------------------------------------------------------------------------
   Bridge two ledgers
 -------------------------------------------------------------------------------}
@@ -213,13 +221,6 @@ instance Bridge m a => HasHeader (DualHeader m a) where
 
 type instance NodeState     (DualBlock m a) = NodeState     m
 type instance BlockProtocol (DualBlock m a) = BlockProtocol m
-
-dualTopLevelConfigMain :: TopLevelConfig (DualBlock m a) -> TopLevelConfig m
-dualTopLevelConfigMain TopLevelConfig{..} = TopLevelConfig{
-      configConsensus =                      configConsensus
-    , configLedger    = dualLedgerConfigMain configLedger
-    , configBlock     = dualBlockConfigMain  configBlock
-    }
 
 instance Bridge m a => BlockSupportsProtocol (DualBlock m a) where
   validateView cfg = validateView (dualBlockConfigMain cfg) . dualHeaderMain
@@ -386,13 +387,13 @@ instance Bridge m a => ValidateEnvelope (DualBlock m a) where
 instance Bridge m a => LedgerSupportsProtocol (DualBlock m a) where
   protocolLedgerView cfg state =
       protocolLedgerView
-        (dualTopLevelConfigMain cfg)
-        (dualLedgerStateMain    state)
+        (dualLedgerConfigMain cfg)
+        (dualLedgerStateMain  state)
 
   anachronisticProtocolLedgerView cfg state =
       anachronisticProtocolLedgerView
-        (dualTopLevelConfigMain cfg)
-        (dualLedgerStateMain    state)
+        (dualLedgerConfigMain cfg)
+        (dualLedgerStateMain  state)
 
 instance Bridge m a => LedgerDerivedInfo (DualBlock m a) where
   knownSlotLengths cfg =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -220,8 +220,8 @@ dualTopLevelConfigMain TopLevelConfig{..} = TopLevelConfig{
     }
 
 instance Bridge m a => BlockSupportsProtocol (DualBlock m a) where
-  validateView cfg = validateView (dualTopLevelConfigMain cfg) . dualHeaderMain
-  selectView   cfg = selectView   (dualTopLevelConfigMain cfg) . dualHeaderMain
+  validateView cfg = validateView (dualBlockConfigMain cfg) . dualHeaderMain
+  selectView   cfg = selectView   (dualBlockConfigMain cfg) . dualHeaderMain
 
 {-------------------------------------------------------------------------------
   Ledger errors

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -121,7 +121,7 @@ applyExtLedgerState prevApplied cfg blk ExtLedgerState{..} = do
     headerState' <- withExcept ExtValidationErrorHeader $
                       validateHeader
                         cfg
-                        (protocolLedgerView cfg ledgerState')
+                        (protocolLedgerView (configLedger cfg) ledgerState')
                         (getHeader blk)
                         headerState
     return $ ExtLedgerState ledgerState' headerState'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
@@ -7,7 +7,6 @@ import           Ouroboros.Network.Block (SlotNo)
 import           Ouroboros.Network.Point (WithOrigin)
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -60,12 +59,6 @@ class ( BlockSupportsProtocol blk
     -> LedgerState blk
     -> WithOrigin SlotNo -- ^ Slot for which you would like a ledger view
     -> Either AnachronyFailure (LedgerView (BlockProtocol blk))
-
-  -- | The slot lengths (across all hard forks)
-  --
-  -- TODO: This should take the LedgerState as argument
-  -- <https://github.com/input-output-hk/ouroboros-network/issues/1637>
-  protocolSlotLengths :: TopLevelConfig blk -> SlotLengths
 
 -- | See 'anachronisticProtocolLedgerView'.
 data AnachronyFailure

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
@@ -7,7 +7,6 @@ import           Ouroboros.Network.Block (SlotNo)
 import           Ouroboros.Network.Point (WithOrigin)
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -18,7 +17,7 @@ class ( BlockSupportsProtocol blk
       , ValidateEnvelope      blk
       ) => LedgerSupportsProtocol blk where
   -- | Extract ledger view from the ledger state
-  protocolLedgerView :: TopLevelConfig blk
+  protocolLedgerView :: LedgerConfig blk
                      -> LedgerState blk
                      -> LedgerView (BlockProtocol blk)
 
@@ -55,7 +54,7 @@ class ( BlockSupportsProtocol blk
   -- Invariant: when calling this function with slot @s@ yields a
   -- 'SlotBounded' @sb@, then @'atSlot' sb@ yields a 'Just'.
   anachronisticProtocolLedgerView
-    :: TopLevelConfig blk
+    :: LedgerConfig blk
     -> LedgerState blk
     -> WithOrigin SlotNo -- ^ Slot for which you would like a ledger view
     -> Either AnachronyFailure (LedgerView (BlockProtocol blk))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -54,9 +54,9 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.ChainSyncClient (ClockSkew (..))
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState (..))
-import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.DbMarker
 import           Ouroboros.Consensus.Node.ErrorPolicy
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Recovery
@@ -192,7 +192,7 @@ run tracers protocolTracers chainDbTracer diffusionTracers diffusionArguments
       , pInfoInitState  = initState
       } = pInfo
 
-    slotLengths = protocolSlotLengths cfg
+    slotLengths = knownSlotLengths (configBlock cfg)
 
     nodeToNodeVersionData   = NodeToNodeVersionData { networkMagic   = networkMagic }
     nodeToClientVersionData = NodeToClientVersionData { networkMagic = networkMagic }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/LedgerDerivedInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/LedgerDerivedInfo.hs
@@ -1,0 +1,17 @@
+module Ouroboros.Consensus.Node.LedgerDerivedInfo (
+    LedgerDerivedInfo(..)
+  ) where
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.BlockchainTime
+
+-- | Information the node requires to run which is dependent on the ledger state
+class LedgerDerivedInfo blk where
+  -- | The known slot length
+  --
+  -- TODO: This should take the LedgerState as argument
+  -- <https://github.com/input-output-hk/ouroboros-network/issues/1637>
+  knownSlotLengths :: BlockConfig blk -> SlotLengths
+
+  -- TODO: This should have a function for epoch lengths
+  -- <https://github.com/input-output-hk/ouroboros-network/issues/1205>

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -34,6 +34,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.Node.Exit (ExitReason)
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -48,10 +49,11 @@ import           Ouroboros.Consensus.Storage.ImmutableDB (BinaryInfo (..),
   RunNode proper
 -------------------------------------------------------------------------------}
 
-class ( LedgerSupportsProtocol blk
-      , ApplyTx blk
-      , HasTxId (GenTx blk)
-      , QueryLedger blk
+class ( LedgerSupportsProtocol    blk
+      , LedgerDerivedInfo         blk
+      , ApplyTx                   blk
+      , HasTxId            (GenTx blk)
+      , QueryLedger               blk
       , HasNetworkProtocolVersion blk
       , NoUnexpectedThunks (NodeState blk)
         -- TODO: Remove after reconsidering rewindChainState:

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -388,7 +388,10 @@ forkBlockProduction maxBlockSizeOverride IS{..} BlockProduction{..} =
 
         -- Check if we are the leader
         proof <-
-          case anachronisticProtocolLedgerView cfg ledger (At currentSlot) of
+          case anachronisticProtocolLedgerView
+                 (configLedger cfg)
+                 ledger
+                 (At currentSlot) of
             Right ledgerView -> do
               mIsLeader :: Maybe (IsLeader (BlockProtocol blk)) <- lift $
                 runMonadRandom $

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -165,8 +165,8 @@ preferAnchoredCandidate cfg ours theirs =
         -- Case 4
         preferCandidate
           (configConsensus cfg)
-          (selectView cfg ourTip)
-          (selectView cfg theirTip)
+          (selectView (configBlock cfg) ourTip)
+          (selectView (configBlock cfg) theirTip)
 
 -- | Lift 'compareCandidates' to 'AnchoredFragment'
 --
@@ -185,7 +185,7 @@ compareAnchoredCandidates cfg ours theirs =
       (_ :> ourTip, _ :> theirTip) ->
         compareCandidates
           (configConsensus cfg)
-          (selectView cfg ourTip)
-          (selectView cfg theirTip)
+          (selectView (configBlock cfg) ourTip)
+          (selectView (configBlock cfg) theirTip)
       _otherwise ->
         error "compareAnchoredCandidates: precondition violated"

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ChainSyncClient.hs
@@ -402,7 +402,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
         configConsensus = BftNodeConfig
           { bftParams   = BftParams
             { bftSecurityParam = securityParam
-            , bftNumNodes      = NumCoreNodes 2
+            , bftNumNodes      = numCoreNodes
             }
           , bftNodeId   = fromCoreNodeId coreNodeId
           , bftSignKey  = SignKeyMockDSIGN 0
@@ -412,8 +412,11 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
                           ]
           }
       , configLedger = LedgerConfig
-      , configBlock  = TestBlockConfig slotLengths
+      , configBlock  = TestBlockConfig slotLengths numCoreNodes
       }
+
+    numCoreNodes :: NumCoreNodes
+    numCoreNodes = NumCoreNodes 2
 
     -- | Take the last slot at which a client or server update is planned, or
     -- the slot at which syncing starts, and add one to it

--- a/ouroboros-consensus/test-consensus/Test/Consensus/LocalStateQueryServer.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/LocalStateQueryServer.hs
@@ -237,18 +237,21 @@ testCfg :: SecurityParam -> TopLevelConfig TestBlock
 testCfg securityParam = TopLevelConfig {
       configConsensus = BftNodeConfig
         { bftParams   = BftParams { bftSecurityParam = securityParam
-                                  , bftNumNodes      = NumCoreNodes 1
+                                  , bftNumNodes      = numCoreNodes
                                   }
         , bftNodeId   = CoreId (CoreNodeId 0)
         , bftSignKey  = SignKeyMockDSIGN 0
         , bftVerKeys  = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
         }
     , configLedger = LedgerConfig
-    , configBlock  = TestBlockConfig slotLengths
+    , configBlock  = TestBlockConfig slotLengths numCoreNodes
     }
   where
     slotLengths :: SlotLengths
     slotLengths = singletonSlotLengths $ slotLengthFromSec 20
+
+    numCoreNodes :: NumCoreNodes
+    numCoreNodes = NumCoreNodes 1
 
 {-------------------------------------------------------------------------------
   Orphans

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -637,7 +637,7 @@ withTestMempool setup@TestSetup { testLedgerState, testInitialTxs, testMempoolCa
     classify (not (null testInitialTxs)) "non-empty Mempool" $
     runSimOrThrow setUpAndRun
   where
-    cfg = SimpleLedgerConfig
+    cfg = SimpleLedgerConfig ()
 
     setUpAndRun :: forall m. IOLike m => m Property
     setUpAndRun = do
@@ -705,7 +705,7 @@ withTestMempool setup@TestSetup { testLedgerState, testInitialTxs, testMempoolCa
                          -> Property
     checkMempoolValidity ledgerState MempoolSnapshot { snapshotTxs } =
         case runExcept $ repeatedlyM
-               (applyTx SimpleLedgerConfig)
+               (applyTx (SimpleLedgerConfig ()))
                txs
                (notReallyTicked ledgerState) of
           Right _ -> property True

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -388,12 +388,17 @@ addBlock cfg blk m
     newChain  :: Chain blk
     newLedger :: ExtLedgerState blk
     (newChain, newLedger) =
-      fromMaybe (currentChain m, currentLedger m) $
-      selectChain (selectView cfg . getHeader) (configConsensus cfg) (currentChain m) $
-      filter
-        (Fragment.forksAtMostKBlocks (maxRollbacks secParam) currentChainFrag .
-         Chain.toAnchoredFragment . fst)
-        candidates
+        fromMaybe (currentChain m, currentLedger m)
+      . selectChain
+          (selectView (configBlock cfg) . getHeader)
+          (configConsensus cfg)
+          (currentChain m)
+      . filter
+          ( Fragment.forksAtMostKBlocks (maxRollbacks secParam) currentChainFrag
+          . Chain.toAnchoredFragment
+          . fst
+          )
+      $ candidates
 
 addBlocks :: (LedgerSupportsProtocol blk, ModelSupportsBlock blk)
           => TopLevelConfig blk

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1244,18 +1244,21 @@ testCfg :: TopLevelConfig TestBlock
 testCfg = TopLevelConfig {
       configConsensus = BftNodeConfig
         { bftParams   = BftParams { bftSecurityParam = k
-                                  , bftNumNodes      = NumCoreNodes 1
+                                  , bftNumNodes      = numCoreNodes
                                   }
         , bftNodeId   = CoreId (CoreNodeId 0)
         , bftSignKey  = SignKeyMockDSIGN 0
         , bftVerKeys  = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
         }
     , configLedger = LedgerConfig
-    , configBlock  = TestBlockConfig slotLengths
+    , configBlock  = TestBlockConfig slotLengths numCoreNodes
     }
   where
     slotLengths :: SlotLengths
     slotLengths = singletonSlotLengths $ slotLengthFromSec 20
+
+    numCoreNodes :: NumCoreNodes
+    numCoreNodes = NumCoreNodes 1
 
     k = SecurityParam 2
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -156,6 +156,12 @@ instance HasHeader (Header TestBlock) where
 
 data instance BlockConfig TestBlock = TestBlockConfig {
       testBlockSlotLengths :: SlotLengths
+
+      -- | Number of core nodes
+      --
+      -- We need this in order to compute the 'ValidateView', which must
+      -- conjure up a validation key out of thin air
+    , testBlockNumCoreNodes :: NumCoreNodes
     }
   deriving (Generic, NoUnexpectedThunks)
 
@@ -301,11 +307,10 @@ instance SignedHeader (Header TestBlock) where
   headerSigned _ = ()
 
 instance BlockSupportsProtocol TestBlock where
-  validateView TopLevelConfig{..} =
+  validateView TestBlockConfig{..} =
       bftValidateView bftFields
     where
-      BftNodeConfig{ bftParams = BftParams{..} } = configConsensus
-      NumCoreNodes numCore = bftNumNodes
+      NumCoreNodes numCore = testBlockNumCoreNodes
 
       bftFields :: Header TestBlock -> BftFields BftMockCrypto ()
       bftFields hdr = BftFields {

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -47,11 +47,11 @@ import qualified Ouroboros.Network.MockChain.Chain as Chain
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
-import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -370,12 +370,13 @@ instance ValidateEnvelope TestBlock where
   -- Use defaults
 
 instance LedgerSupportsProtocol TestBlock where
-  protocolSlotLengths =
-      testBlockSlotLengths . configBlock
   protocolLedgerView _ _ =
       ()
   anachronisticProtocolLedgerView _ _ _ =
       Right ()
+
+instance LedgerDerivedInfo TestBlock where
+  knownSlotLengths = testBlockSlotLengths
 
 testInitLedger :: LedgerState TestBlock
 testInitLedger = TestLedger GenesisPoint GenesisHash


### PR DESCRIPTION
Instead, attempt to pass only _parts_ of the config. This also does some additional refactoring.