### PR TITLE
Handle async exceptions better

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/Pure.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/Pure.hs
@@ -31,6 +31,7 @@ pureHasFS = HasFS {
     , hGetSome                 = Mock.hGetSome
     , hGetSomeAt               = Mock.hGetSomeAt
     , hPutSome                 = Mock.hPutSome
+    , hPutSomeAt               = Mock.hPutSomeAt
     , hTruncate                = Mock.hTruncate
     , hGetSize                 = Mock.hGetSize
     , createDirectory          = Mock.createDirectory

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/STM.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/STM.hs
@@ -46,6 +46,7 @@ simHasFS var = HasFS {
     , hGetSome                 = sim  .: Mock.hGetSome
     , hGetSomeAt               = sim ..: Mock.hGetSomeAt
     , hPutSome                 = sim  .: Mock.hPutSome
+    , hPutSomeAt               = sim ..: Mock.hPutSomeAt
     , hTruncate                = sim  .: Mock.hTruncate
     , hGetSize                 = sim  .  Mock.hGetSize
     , createDirectory          = sim  .  Mock.createDirectory

--- a/ouroboros-consensus/src-unix/Ouroboros/Consensus/Storage/IO.hs
+++ b/ouroboros-consensus/src-unix/Ouroboros/Consensus/Storage/IO.hs
@@ -8,6 +8,7 @@ module Ouroboros.Consensus.Storage.IO (
     , read
     , pread
     , write
+    , pwrite
     , close
     , getSize
     , sameError
@@ -25,7 +26,8 @@ import           System.Posix (Fd)
 import qualified System.Posix as Posix
 
 -- Package 'unix' exports the same module.
-import           "unix-bytestring" System.Posix.IO.ByteString (fdPreadBuf)
+import           "unix-bytestring" System.Posix.IO.ByteString (fdPreadBuf,
+                     fdPwriteBuf)
 
 import           Ouroboros.Consensus.Storage.FS.API.Types (AllowExisting (..),
                      FsError, OpenMode (..), SeekMode (..), sameFsError)
@@ -78,9 +80,14 @@ open fp openMode = Posix.openFd fp posixOpenMode fileMode fileFlags
 
 
 -- | Writes the data pointed by the input 'Ptr Word8' into the input 'FHandle'.
-write :: FHandle -> Ptr Word8 -> Int64 -> IO Word32
+write :: FHandle -> Ptr Word8 -> Word32 -> IO Word32
 write h data' bytes = withOpenHandle "write" h $ \fd ->
     fromIntegral <$> Posix.fdWriteBuf fd data' (fromIntegral bytes)
+
+pwrite :: FHandle -> Ptr Word8 -> Word32 -> Word64 -> IO Word32
+pwrite h data' bytes offset = withOpenHandle "pwrite" h $ \fd ->
+    fromIntegral <$>
+      fdPwriteBuf fd data' (fromIntegral bytes) (fromIntegral offset)
 
 -- | Seek within the file.
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API/Types.hs
@@ -197,7 +197,7 @@ instance Show (Handle h) where
 -------------------------------------------------------------------------------}
 
 newtype AbsOffset = AbsOffset { unAbsOffset :: Word64 }
-  deriving (Eq, Ord, Enum, Bounded, Num, Show)
+  deriving (Eq, Ord, Enum, Bounded, Num, Show, NoUnexpectedThunks)
 
 {-------------------------------------------------------------------------------
   Errors

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/IO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/IO.hs
@@ -53,6 +53,10 @@ ioHasFS mount = HasFS {
     , hPutSome = \(Handle h fp) bs -> rethrowFsError fp $ do
         BS.unsafeUseAsCStringLen bs $ \(ptr, len) ->
             fromIntegral <$> F.write h (castPtr ptr) (fromIntegral len)
+    , hPutSomeAt = \(Handle h fp) bs o -> rethrowFsError fp $ do
+        BS.unsafeUseAsCStringLen bs $ \(ptr, len) ->
+            fromIntegral <$>
+                F.pwrite h (castPtr ptr) (fromIntegral len) (unAbsOffset o)
     , createDirectory = \fp -> rethrowFsError fp $
         Dir.createDirectory (root fp)
     , listDirectory = \fp -> rethrowFsError fp $


### PR DESCRIPTION
This pr improves the way the Volatile DB handles exceptions. See also https://github.com/input-output-hk/ouroboros-network/issues/1638#issuecomment-586964762

So far only filesystem errors were handled and tested. In these cases the db closes, reopens, parses all blocks and, recovers to a consistent state. The db has the property that if any command that failed is executed again, the db reaches a state as if it never failed in the first place. For example if during gc some files fail to be removed, calling the same gc will remove them successfully. Or if half the bytes of a block are written, they will be truncated during reopening and the block can be successfully inserted after that.

This pr tries to get the idea to the next level: no reopening in between should actually be needed. We can use this property to make sure the db stays consistent even after async exceptions. The main idea is the following: if some bytes were written, but the internal state was not updated because of an exception, the db will overwrite the existing bytes with the next block. There are some edge cases that were also taken care of:

- `pwrite` is introduced, so that we never use the file offset that the os keeps.
- It's possible that a `putBlock` call creates a new file before it receives an exception. The next `putBlock` will overwrite the bytes and find that the next file exists, so it will fail. To fix this, we now open with `AllowExisting`.
- It's possible that a `putBlock` call opens a new handle before it receives an exception, so this handle may leak. To fix we use `ResourceRegistry` for these handles. This `ResourceRegistry` differs from regular ones, in that it only releases its resources if it meets an exception (`bracketOnError`). So it doesn't have a global scope, but we open a new ResourceRegistry when we call `putBlock`.
- It's possible that a `putBlock` call closes the current handle before it receives an exception, so the next call should not use this handle. To fix this, we add a new flag `_exceptionEncountered` which tags the internal state when an exception is encountered. This is an indication that the current write handle may be closed and should not be used. A new handle is opened in this case. Again `ResourceRegistry` is used, so that no handles leak on next exceptions.
- we never gc the most recent file, as this may change the file offset.

This pr also adds tests both in the fs, for the new `pwrite` syscall, but also in the VolatileDB. In the VolatileDB we introduce a new command, where a thread receives an async exception while it calls putBlock. The property that we test is that this call is actually a no-op. There is some uncertainty though, in exactly which point this exception was thrown, so we take some additional steps to make sure we simulate a case where the exception was thrown in the middle of a `putBlock` call.

Things TODO:
- documentation should be added
- gc can't handle async exceptions. This is because, on a next call, if we try to remove a file which it is not there, that's an error. If we handle these errors in a lenient way, this is ready to change though.
- Add windows support for `pwrite`



