### PR TITLE
Mux test refactoring and two minor changes

### DIFF
--- a/network-mux/src/Network/Mux/Bearer/Pipe.hs
+++ b/network-mux/src/Network/Mux/Bearer/Pipe.hs
@@ -12,7 +12,6 @@ module Network.Mux.Bearer.Pipe (
   , pipeChannelFromNamedPipe
 #endif
   , pipeAsMuxBearer
-  , runMuxWithPipes
   ) where
 
 import           Control.Monad.Class.MonadThrow
@@ -119,11 +118,3 @@ pipeAsMuxBearer tracer channel =
           traceWith tracer $ Mx.MuxTraceSendEnd
           return ts
 
-runMuxWithPipes
-    :: Tracer IO Mx.MuxTrace
-    -> Mx.MuxApplication appType IO a b
-    -> PipeChannel
-    -> IO ()
-runMuxWithPipes muxTracer app channel = do
-    let bearer = pipeAsMuxBearer muxTracer channel
-    Mx.muxStart muxTracer app bearer

--- a/network-mux/src/Network/Mux/Bearer/Queues.hs
+++ b/network-mux/src/Network/Mux/Bearer/Queues.hs
@@ -3,7 +3,6 @@
 
 module Network.Mux.Bearer.Queues
   ( queuesAsMuxBearer
-  , runMuxWithQueues
   ) where
 
 import qualified Data.ByteString.Lazy as BL
@@ -12,7 +11,6 @@ import           Data.Word (Word16)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadTime
-import           Control.Monad.Class.MonadTimer
 import           Control.Monad.Class.MonadThrow
 import           Control.Tracer
 
@@ -68,26 +66,3 @@ queuesAsMuxBearer tracer writeQueue readQueue sduSize = do
           traceWith tracer $ Mx.MuxTraceSendEnd
           return ts
 
-runMuxWithQueues
-  :: ( MonadAsync m
-     , MonadCatch m
-     , MonadMask m
-     , MonadSTM m
-     , MonadThrow m
-     , MonadThrow (STM m)
-     , MonadTime m
-     , MonadTimer m
-     , Eq  (Async m ())
-     )
-  => Tracer m Mx.MuxTrace
-  -> Mx.MuxApplication appType m a b
-  -> TBQueue m BL.ByteString
-  -> TBQueue m BL.ByteString
-  -> Word16
-  -> m (Maybe SomeException)
-runMuxWithQueues tracer app wq rq mtu = do
-    let bearer = queuesAsMuxBearer tracer wq rq mtu
-    res_e <- try $ Mx.muxStart tracer app bearer
-    case res_e of
-         Left  e -> return (Just e)
-         Right _ -> return Nothing

--- a/network-mux/src/Network/Mux/Trace.hs
+++ b/network-mux/src/Network/Mux/Trace.hs
@@ -52,9 +52,6 @@ data MuxErrorType = MuxUnknownMiniProtocol
                   | MuxInitiatorOnly
                   -- ^ thrown when data arrives on a responder channel when the
                   -- mux was set up as an 'InitiatorApp'.
-                  |  MuxTooLargeMessage
-                  -- ^ thrown by 'muxChannel' when violationg
-                  -- 'maximumMessageSize' byte limit.
                   | MuxIOException IOException
                   -- ^ 'IOException' thrown by 
                   deriving (Show, Eq)

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -60,14 +60,8 @@ newtype MiniProtocolNum = MiniProtocolNum Word16
   deriving (Eq, Ord, Enum, Ix, Show)
 
 -- | Per Miniprotocol limits
--- maximumIngressQueue must be >= maximumMessageSize
 data MiniProtocolLimits =
      MiniProtocolLimits {
-       -- | Limit on the maximum size of an individual message that can be sent
-       -- over a given miniprotocol.
-       --
-       maximumMessageSize :: !Int64,
-
        -- | Limit on the maximum number of bytes that can be queued in the
        -- miniprotocol's ingress queue.
        --

--- a/network-mux/test/Test/Mux.hs
+++ b/network-mux/test/Test/Mux.hs
@@ -84,7 +84,6 @@ tests =
 defaultMiniProtocolLimits :: MiniProtocolLimits
 defaultMiniProtocolLimits =
     MiniProtocolLimits {
-      maximumMessageSize  = defaultMiniProtocolLimit,
       maximumIngressQueue = defaultMiniProtocolLimit
     }
 
@@ -94,7 +93,6 @@ defaultMiniProtocolLimit = 3000000
 smallMiniProtocolLimits :: MiniProtocolLimits
 smallMiniProtocolLimits =
     MiniProtocolLimits {
-      maximumMessageSize  = smallMiniProtocolLimit,
       maximumIngressQueue = smallMiniProtocolLimit
     }
 

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -147,7 +147,6 @@ instance ProtocolEnum DemoProtocol0 where
   fromProtocolEnum PingPong0 = MiniProtocolNum 2
 
 instance MiniProtocolLimits DemoProtocol0 where
-  maximumMessageSize _ = maxBound
   maximumIngressQueue _ = maxBound
 
 
@@ -242,7 +241,6 @@ instance ProtocolEnum DemoProtocol1 where
   fromProtocolEnum PingPong1' = MiniProtocolNum 3
 
 instance MiniProtocolLimits DemoProtocol1 where
-  maximumMessageSize _ = maxBound
   maximumIngressQueue _ = maxBound
 
 
@@ -346,7 +344,6 @@ instance ProtocolEnum DemoProtocol2 where
   fromProtocolEnum ChainSync2  = MiniProtocolNum 2
 
 instance MiniProtocolLimits DemoProtocol2 where
-  maximumMessageSize _ = maxBound
   maximumIngressQueue _ = maxBound
 
 
@@ -440,7 +437,6 @@ instance ProtocolEnum DemoProtocol3 where
   fromProtocolEnum BlockFetch3 = MiniProtocolNum 3
 
 instance MiniProtocolLimits DemoProtocol3 where
-  maximumMessageSize _ = maxBound
   maximumIngressQueue _ = maxBound
 
 

--- a/ouroboros-network/src/Ouroboros/Network/Mux.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Mux.hs
@@ -63,7 +63,6 @@ class ProtocolEnum ptcl where
     fromProtocolEnum :: ptcl -> MiniProtocolNum
 
 class MiniProtocolLimits ptcl where
-    maximumMessageSize :: ptcl -> Int64
     maximumIngressQueue :: ptcl -> Int64
 
 toApplication :: (Enum ptcl, Bounded ptcl,
@@ -76,7 +75,6 @@ toApplication (OuroborosInitiatorApplication f) peerid =
       [ MuxMiniProtocol {
           miniProtocolNum    = fromProtocolEnum ptcl,
           miniProtocolLimits = Mux.MiniProtocolLimits {
-                                 Mux.maximumMessageSize  = maximumMessageSize ptcl,
                                  Mux.maximumIngressQueue = maximumIngressQueue ptcl
                                },
           miniProtocolRun    =
@@ -90,7 +88,6 @@ toApplication (OuroborosResponderApplication f) peerid =
       [ MuxMiniProtocol {
           miniProtocolNum    = fromProtocolEnum ptcl,
           miniProtocolLimits = Mux.MiniProtocolLimits {
-                                 Mux.maximumMessageSize  = maximumMessageSize ptcl,
                                  Mux.maximumIngressQueue = maximumIngressQueue ptcl
                                },
           miniProtocolRun    =
@@ -104,7 +101,6 @@ toApplication (OuroborosInitiatorAndResponderApplication f g) peerid =
       [ MuxMiniProtocol {
           miniProtocolNum    = fromProtocolEnum ptcl,
           miniProtocolLimits = Mux.MiniProtocolLimits {
-                                 Mux.maximumMessageSize  = maximumMessageSize ptcl,
                                  Mux.maximumIngressQueue = maximumIngressQueue ptcl
                                },
           miniProtocolRun    =

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -122,7 +122,6 @@ instance ProtocolEnum NodeToClientProtocols where
 instance MiniProtocolLimits NodeToClientProtocols where
   -- TODO: provide sensible limits
   -- https://github.com/input-output-hk/ouroboros-network/issues/575
-  maximumMessageSize  _ = 0xffffffff
   maximumIngressQueue _ = 0xffffffff
 
 -- | Enumeration of node to client protocol versions.
@@ -394,7 +393,6 @@ networkErrorPolicies = ErrorPolicies
                       MuxDecodeError          -> Just ourBug
                       MuxIngressQueueOverRun  -> Just ourBug
                       MuxInitiatorOnly        -> Just ourBug
-                      MuxTooLargeMessage      -> Just ourBug
 
                       -- in case of bearer closed / or IOException we suspend
                       -- the peer for a short time

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -156,7 +156,6 @@ instance ProtocolEnum NodeToNodeProtocols where
 instance MiniProtocolLimits NodeToNodeProtocols where
   -- TODO: provide sensible limits
   -- https://github.com/input-output-hk/ouroboros-network/issues/575
-  maximumMessageSize  _ = 0xffffffff
   maximumIngressQueue _ = 0xffffffff
 
 -- | Enumeration of node to node protocol versions.
@@ -478,7 +477,6 @@ remoteNetworkErrorPolicy = ErrorPolicies {
                         MuxDecodeError          -> Just theyBuggyOrEvil
                         MuxIngressQueueOverRun  -> Just theyBuggyOrEvil
                         MuxInitiatorOnly        -> Just theyBuggyOrEvil
-                        MuxTooLargeMessage      -> Just theyBuggyOrEvil
 
                         -- in case of bearer closed / or IOException we suspend
                         -- the peer for a short time

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -64,7 +64,6 @@ data TestProtocols = ChainSyncPr
   deriving (Eq, Ord, Enum, Bounded, Show)
 
 instance Mx.MiniProtocolLimits TestProtocols where
-    maximumMessageSize _  = 0xffff
     maximumIngressQueue _ = 0xffff
 
 instance Mx.ProtocolEnum TestProtocols where

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -126,8 +126,8 @@ demo chain0 updates delay = do
                         (encodeTip encode) (decodeTip decode))
                         producerPeer)
 
-    clientAsync <- async $ Mx.runMuxWithQueues activeTracer (Mx.toApplication consumerApp "consumer") client_w client_r sduLen Nothing
-    serverAsync <- async $ Mx.runMuxWithQueues activeTracer (Mx.toApplication producerApp "producer") server_w server_r sduLen Nothing
+    clientAsync <- async $ Mx.runMuxWithQueues activeTracer (Mx.toApplication consumerApp "consumer") client_w client_r sduLen
+    serverAsync <- async $ Mx.runMuxWithQueues activeTracer (Mx.toApplication producerApp "producer") server_w server_r sduLen
 
     updateAid <- async $ sequence_
         [ do

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -40,6 +40,7 @@ import qualified Ouroboros.Network.Protocol.ChainSync.Examples as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Server as ChainSync
 import qualified Ouroboros.Network.Protocol.ChainSync.Type as ChainSync
 
+import qualified Network.Mux               as Mx (muxStart)
 import qualified Network.Mux.Bearer.Queues as Mx
 import qualified Ouroboros.Network.Mux as Mx
 
@@ -126,8 +127,11 @@ demo chain0 updates delay = do
                         (encodeTip encode) (decodeTip decode))
                         producerPeer)
 
-    clientAsync <- async $ Mx.runMuxWithQueues activeTracer (Mx.toApplication consumerApp "consumer") client_w client_r sduLen
-    serverAsync <- async $ Mx.runMuxWithQueues activeTracer (Mx.toApplication producerApp "producer") server_w server_r sduLen
+    let clientBearer = Mx.queuesAsMuxBearer activeTracer client_w client_r sduLen
+        serverBearer = Mx.queuesAsMuxBearer activeTracer server_w server_r sduLen
+
+    clientAsync <- async $ Mx.muxStart activeTracer (Mx.toApplication consumerApp "consumer") clientBearer
+    serverAsync <- async $ Mx.muxStart activeTracer (Mx.toApplication producerApp "producer") serverBearer
 
     updateAid <- async $ sequence_
         [ do
@@ -140,12 +144,10 @@ demo chain0 updates delay = do
         ]
 
     wait updateAid
-    r <- waitBoth clientAsync serverAsync
-    case r of
-         (_, Just _) -> return $ property False
-         _           -> do
-           ret <- atomically $ takeTMVar done
-           return $ property ret
+    _ <- waitBoth clientAsync serverAsync
+    -- TODO: use new mechanism to collect mini-protocol result:
+    ret <- atomically $ takeTMVar done
+    return $ property ret
 
   where
     checkTip target consumerVar = atomically $ do

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -81,7 +81,6 @@ instance ProtocolEnum DemoProtocols where
   fromProtocolEnum ChainSync = MiniProtocolNum 2
 
 instance MiniProtocolLimits DemoProtocols where
-  maximumMessageSize ChainSync  = defaultMiniProtocolLimit
   maximumIngressQueue ChainSync = defaultMiniProtocolLimit
 
 -- | A demonstration that we can run the simple chain consumer protocol

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -131,7 +131,6 @@ instance Mx.ProtocolEnum TestProtocols1 where
   fromProtocolEnum ChainSyncPr = MiniProtocolNum 2
 
 instance Mx.MiniProtocolLimits TestProtocols1 where
-  maximumMessageSize ChainSyncPr  = defaultMiniProtocolLimit
   maximumIngressQueue ChainSyncPr = defaultMiniProtocolLimit
 
 -- |
@@ -144,7 +143,6 @@ instance Mx.ProtocolEnum TestProtocols2 where
   fromProtocolEnum ReqRespPr = MiniProtocolNum 4
 
 instance Mx.MiniProtocolLimits TestProtocols2 where
-  maximumMessageSize ReqRespPr  = defaultMiniProtocolLimit
   maximumIngressQueue ReqRespPr = defaultMiniProtocolLimit
 
 --

--- a/ouroboros-network/test/Test/Subscription.hs
+++ b/ouroboros-network/test/Test/Subscription.hs
@@ -77,7 +77,6 @@ instance ProtocolEnum TestProtocols1 where
   fromProtocolEnum ChainSyncPr = MiniProtocolNum 2
 
 instance MiniProtocolLimits TestProtocols1 where
-  maximumMessageSize ChainSyncPr  = defaultMiniProtocolLimit
   maximumIngressQueue ChainSyncPr = defaultMiniProtocolLimit
 
 -- |
@@ -90,7 +89,6 @@ instance ProtocolEnum TestProtocols2 where
   fromProtocolEnum ReqRespPr = MiniProtocolNum 4
 
 instance MiniProtocolLimits TestProtocols2 where
-  maximumMessageSize ReqRespPr  = defaultMiniProtocolLimit
   maximumIngressQueue ReqRespPr = defaultMiniProtocolLimit
 
 


### PR DESCRIPTION
Mostly changes to the test code.

Two real changes, in preparation for more significant mux changes.

Eliminate maximumMessageSize limit
------------------------------

It is not enforced on the receiving side because the mux does not preserve message boundaries. Enforcing it on the outbound side is pointless.

It is unnecessary since we can enforce size limits during message decoding, and the overall limit is the ingress queue limit.

Second change dropped, to be included in a later PR.

~Change mechanism for flushing on protocol termination~
--------------

~The mux ensures that when a protocol thread terminates normally (rather than via an exception) that it waits for outbound messages to be sent.~

~This allows for a clean shutdown for the remote peer and this is required in various tests.~

~The previous mechanism used a counter that was shared across all the mini-protocols in the mux bundle, and had to be incremented and decremented in vairious places.~

~The new mechanism is much simpler because it is not shared across all the mini-protocols. It is per-protocol. It simply waits for the outbound queue for that protocol to become empty. It should also be slightly faster since there are fewer STM transactions and allocations in the outbound data path.~