### PR TITLE
Remove redundant constraints

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -67,6 +67,7 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wredundant-constraints
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts
 
@@ -123,6 +124,7 @@ test-suite test
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wredundant-constraints
                        -threaded
                        -rtsopts
 
@@ -151,6 +153,7 @@ executable db-converter
 
    default-language:   Haskell2010
    ghc-options:        -Wall
+                       -Wredundant-constraints
 
 executable db-analyser
   hs-source-dirs:      tools/db-analyser
@@ -168,3 +171,4 @@ executable db-analyser
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wredundant-constraints

--- a/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
+++ b/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
@@ -53,3 +53,4 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wredundant-constraints

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -36,5 +36,6 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wredundant-constraints
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts

--- a/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -62,6 +62,7 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wredundant-constraints
                        -Wno-unticked-promoted-constructors
 
 
@@ -98,6 +99,7 @@ test-suite test
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wredundant-constraints
                        -fno-ignore-asserts
                        -threaded
                        -rtsopts

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
@@ -89,6 +89,7 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wredundant-constraints
                        -fno-ignore-asserts
 
 test-suite test
@@ -109,4 +110,5 @@ test-suite test
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wredundant-constraints
                        -fno-ignore-asserts

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE NamedFieldPuns            #-}
 {-# LANGUAGE PatternSynonyms           #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE TypeApplications          #-}
 
 module Test.ThreadNet.General (
     prop_general
@@ -55,6 +56,7 @@ import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random
+import           Ouroboros.Consensus.Util.RedundantConstraints
 
 import           Ouroboros.Consensus.Storage.Common (EpochNo)
 
@@ -301,6 +303,8 @@ prop_general countTxs k TestConfig{numSlots, nodeJoinPlan, nodeRestarts, nodeTop
       [ fileHandleLeakCheck nid nodeDBs
       | (nid, nodeDBs) <- Map.toList nodeOutputDBs ]
   where
+    _ = keepRedundantConstraint (Proxy @(Show (LedgerView (BlockProtocol blk))))
+
     prop_no_unexpected_BlockRejections =
         counterexample msg $
         Map.null blocks

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -90,6 +90,7 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random
+import           Ouroboros.Consensus.Util.RedundantConstraints
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
@@ -344,6 +345,8 @@ runThreadNetwork ThreadNetworkArgs
 
     mkTestOutput vertexInfos
   where
+    _ = keepRedundantConstraint (Proxy @(Show (LedgerView (BlockProtocol blk))))
+
     coreNodeIds :: [CoreNodeId]
     coreNodeIds = enumCoreNodes numCoreNodes
 
@@ -1059,7 +1062,6 @@ nullDebugTracer = nullTracer `asTypeOf` showTracing debugTracer
 nullDebugTracers ::
      ( Monad m
      , Show peer
-     , Show (LedgerView (BlockProtocol blk))
      , LedgerSupportsProtocol blk
      , TracingConstraints blk
      )
@@ -1073,7 +1075,6 @@ nullDebugProtocolTracers ::
      , TracingConstraints blk
      , Show peer
      , Show localPeer
-     , Show failure
      )
   => ProtocolTracers m peer localPeer blk failure
 nullDebugProtocolTracers =

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Split.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Split.hs
@@ -9,8 +9,6 @@ module Test.Util.Split (
 
 import           Data.Bifunctor (first)
 import           Data.Word (Word64)
-import           GHC.Stack (HasCallStack)
-
 
 {-------------------------------------------------------------------------------
   spanLeft
@@ -21,8 +19,7 @@ import           GHC.Stack (HasCallStack)
 -- INVARIANT The output data is a segmentation of the given list.
 spanLeft
   :: forall x a b.
-     HasCallStack
-  => (x -> Either a b) -> [x] -> ([a], Maybe (b, [x]))
+     (x -> Either a b) -> [x] -> ([a], Maybe (b, [x]))
 spanLeft prj xs = (reverse acc, mbBxs)
   where
     (acc, mbBxs) = spanLeft' prj xs
@@ -30,8 +27,7 @@ spanLeft prj xs = (reverse acc, mbBxs)
 -- | As 'spanLeft', but the @[a]@ is reversed.
 spanLeft'
   :: forall x a b.
-     HasCallStack
-  => (x -> Either a b) -> [x] -> ([a], Maybe (b, [x]))
+     (x -> Either a b) -> [x] -> ([a], Maybe (b, [x]))
 spanLeft' prj = go []
   where
     go acc = \case
@@ -53,8 +49,7 @@ data Prj a b = Prj !a !b
 -- INVARIANT The output data is a segmentation of the given list.
 splitAtJust
   :: forall x b.
-     HasCallStack
-  => (x -> Maybe b) -> Word64 -> [x] -> (Maybe ([x], b), [x])
+     (x -> Maybe b) -> Word64 -> [x] -> (Maybe ([x], b), [x])
 splitAtJust prj = \n xs ->
   if 0 == n then (Nothing, xs)
   else case peel xs of

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -238,6 +238,7 @@ library
                      , unix-bytestring
 
   ghc-options:         -Wall
+                       -Wredundant-constraints
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts
 
@@ -331,6 +332,7 @@ test-suite test-consensus
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wredundant-constraints
                        -fno-ignore-asserts
                        -threaded
                        -rtsopts
@@ -423,4 +425,5 @@ test-suite test-storage
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wredundant-constraints
                        -fno-ignore-asserts

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -349,16 +349,14 @@ deriving instance ( Eq (LedgerState m)
   Utilities for working with the extended ledger state
 -------------------------------------------------------------------------------}
 
-dualExtLedgerStateMain :: Bridge m a
-                       => ExtLedgerState (DualBlock m a)
+dualExtLedgerStateMain :: ExtLedgerState (DualBlock m a)
                        -> ExtLedgerState m
 dualExtLedgerStateMain ExtLedgerState{..} = ExtLedgerState{
       ledgerState = dualLedgerStateMain ledgerState
     , headerState = castHeaderState     headerState
     }
 
-dualExtValidationErrorMain :: Bridge m a
-                           => ExtValidationError (DualBlock m a)
+dualExtValidationErrorMain :: ExtValidationError (DualBlock m a)
                            -> ExtValidationError m
 dualExtValidationErrorMain = \case
     ExtValidationErrorLedger e -> ExtValidationErrorLedger (dualLedgerErrorMain e)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -339,7 +339,7 @@ implSyncWithLedger mpEnv@MempoolEnv{mpEnvTracer, mpEnvStateVar} = do
       traceWith mpEnvTracer $ TraceMempoolRemoveTxs removed mempoolSize
     return snapshot
 
-implGetSnapshot :: (IOLike m, ApplyTx blk)
+implGetSnapshot :: IOLike m
                 => MempoolEnv m blk
                 -> STM m (MempoolSnapshot blk TicketNo)
 implGetSnapshot MempoolEnv{mpEnvStateVar} =
@@ -370,7 +370,7 @@ implGetCapacity = pure . mpEnvCapacity
 
 -- | \( O(1) \). Return the number of transactions in the Mempool paired with
 -- their total size in bytes.
-getMempoolSize :: (IOLike m, ApplyTx blk)
+getMempoolSize :: IOLike m
                => MempoolEnv m blk
                -> STM m MempoolSize
 getMempoolSize MempoolEnv{mpEnvStateVar} =
@@ -380,8 +380,7 @@ getMempoolSize MempoolEnv{mpEnvStateVar} =
   MempoolSnapshot Implementation
 -------------------------------------------------------------------------------}
 
-implSnapshotFromIS :: ApplyTx blk
-                   => InternalState blk -> MempoolSnapshot blk TicketNo
+implSnapshotFromIS :: InternalState blk -> MempoolSnapshot blk TicketNo
 implSnapshotFromIS is = MempoolSnapshot {
       snapshotTxs         = implSnapshotGetTxs         is
     , snapshotTxsAfter    = implSnapshotGetTxsAfter    is
@@ -411,8 +410,7 @@ implSnapshotGetTx :: InternalState blk
                   -> Maybe (GenTx blk)
 implSnapshotGetTx IS{isTxs} tn = isTxs `TxSeq.lookupByTicketNo` tn
 
-implSnapshotGetMempoolSize :: ApplyTx blk
-                           => InternalState blk
+implSnapshotGetMempoolSize :: InternalState blk
                            -> MempoolSize
 implSnapshotGetMempoolSize = TxSeq.toMempoolSize . isTxs
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Recovery.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Recovery.hs
@@ -43,8 +43,7 @@ createMarkerOnCleanShutdown proxy mp = onExceptionIf
 
 -- | Return 'True' when 'cleanShutdownMarkerFile' exists.
 hasCleanShutdownMarker
-  :: IOLike m
-  => HasFS m h
+  :: HasFS m h
   -> m Bool
 hasCleanShutdownMarker hasFS =
     doesFileExist hasFS cleanShutdownMarkerFile
@@ -66,8 +65,7 @@ createCleanShutdownMarker hasFS = do
 --
 -- Will throw an 'FsResourceDoesNotExist' error when it does not exist.
 removeCleanShutdownMarker
-  :: IOLike m
-  => HasFS m h
+  :: HasFS m h
   -> m ()
 removeCleanShutdownMarker hasFS =
     removeFile hasFS cleanShutdownMarkerFile

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/MockChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/MockChainSel.hs
@@ -8,7 +8,6 @@ import           Data.Function (on)
 import           Data.List (sortBy)
 import           Data.Maybe (listToMaybe)
 
-import           Ouroboros.Network.Block (HasHeader (..))
 import           Ouroboros.Network.MockChain.Chain (Chain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
@@ -30,7 +29,7 @@ import           Ouroboros.Consensus.Protocol.Abstract
 -- somehow fail if the selected chain turns out to be invalid.)
 --
 -- Returns 'Nothing' if we stick with our current chain.
-selectChain :: forall p hdr l. (ConsensusProtocol p, HasHeader hdr)
+selectChain :: forall p hdr l. ConsensusProtocol p
             => (hdr -> SelectView p)
             -> NodeConfig p
             -> Chain hdr           -- ^ Our chain
@@ -65,7 +64,7 @@ selectChain view cfg ours candidates =
         go (Just a) (Just b) = compareCandidates cfg (view a) (view b)
 
 -- | Chain selection on unvalidated chains
-selectUnvalidatedChain :: forall p hdr. (ConsensusProtocol p, HasHeader hdr)
+selectUnvalidatedChain :: forall p hdr. ConsensusProtocol p
                        => (hdr -> SelectView p)
                        -> NodeConfig p
                        -> Chain hdr

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/ChainState.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/ChainState.hs
@@ -571,7 +571,7 @@ serializationFormatVersion0 :: VersionNumber
 serializationFormatVersion0 = 0
 
 encodePBftChainState
-  :: (PBftCrypto c, Serialise (PBftVerKeyHash c))
+  :: Serialise (PBftVerKeyHash c)
   => PBftChainState c -> Encoding
 encodePBftChainState st@PBftChainState{..} =
     encodeVersion serializationFormatVersion0 $ mconcat [
@@ -583,7 +583,7 @@ encodePBftChainState st@PBftChainState{..} =
   where
     (anchor, signers, ebbs') = toList st
 
-decodePBftChainState :: (PBftCrypto c, Serialise (PBftVerKeyHash c), HasCallStack)
+decodePBftChainState :: (PBftCrypto c, Serialise (PBftVerKeyHash c))
                      => SecurityParam
                      -> WindowSize
                      -> Decoder s (PBftChainState c)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/CRC.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/CRC.hs
@@ -92,7 +92,7 @@ hGetExactlyAtCRC hasFS h n offset = do
     return (bs, crc)
 
 -- | Variation on 'hGetAllAt' that also computes a CRC
-hGetAllAtCRC :: forall m h. (HasCallStack, Monad m)
+hGetAllAtCRC :: forall m h. Monad m
              => HasFS m h
              -> Handle h
              -> AbsOffset -- ^ The offset at which to read.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
@@ -214,7 +214,7 @@ modifyOpenState ImmutableDBEnv { _dbHasFS = hasFS :: HasFS m h, .. } action = do
           -- In case a user error, just restore the previous state
           ExitCaseSuccess (Left (UserError {}))       -> (DbOpen ost, return ())
 
-    mutation :: HasCallStack => OpenState m hash h -> m (r, OpenState m hash h)
+    mutation :: OpenState m hash h -> m (r, OpenState m hash h)
     mutation = runStateT (action hasFS)
 
 -- | Perform an action that accesses the internal state of an open database.
@@ -261,7 +261,7 @@ withOpenState ImmutableDBEnv { _dbHasFS = hasFS :: HasFS m h, .. } action = do
       DbOpen ost -> cleanUp hasFS ost
       DbClosed   -> return ()
 
-    access :: HasCallStack => OpenState m hash h -> m r
+    access :: OpenState m hash h -> m r
     access = action hasFS
 
 cleanUp :: Monad m => HasFS m h -> OpenState m hash h -> m ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
@@ -102,7 +102,6 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Typeable
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           GHC.Stack
@@ -180,8 +179,6 @@ openDB :: ( HasCallStack
           , IOLike m
           , Ord                blockId
           , NoUnexpectedThunks blockId
-          , Typeable           blockId
-          , Show               blockId
           )
        => HasFS m h
        -> ErrorHandling VolatileDBError m
@@ -238,9 +235,7 @@ isOpenDBImpl VolatileDBEnv{..} = do
 -- because 'reOpenDB' will always append to the last created file.
 reOpenDBImpl :: ( HasCallStack
                 , IOLike m
-                , Ord      blockId
-                , Typeable blockId
-                , Show     blockId
+                , Ord blockId
                 )
              => VolatileDBEnv m blockId
              -> m ()
@@ -483,9 +478,7 @@ mkInternalStateDB :: forall m blockId e h.
                      ( HasCallStack
                      , MonadThrow m
                      , MonadCatch m
-                     , Ord      blockId
-                     , Typeable blockId
-                     , Show     blockId
+                     , Ord blockId
                      )
                   => HasFS m h
                   -> ErrorHandling VolatileDBError m
@@ -526,9 +519,7 @@ mkInternalState
   :: forall blockId m h e. (
        HasCallStack
      , MonadCatch m
-     , Ord      blockId
-     , Typeable blockId
-     , Show     blockId
+     , Ord blockId
      )
   => HasFS m h
   -> ErrorHandling VolatileDBError m
@@ -695,11 +686,7 @@ getterSTM fromSt VolatileDBEnv{..} = do
 --   the given list, or most often, the original input list.
 -- * In case of an error, the error and the offset to truncate to.
 addToReverseIndex
-  :: forall blockId e. (
-       Ord      blockId
-     , Typeable blockId
-     , Show     blockId
-     )
+  :: forall blockId e. Ord blockId
   => FsPath
   -> ReverseIndex blockId
   -> ParsedInfo blockId

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/RedundantConstraints.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/RedundantConstraints.hs
@@ -3,7 +3,11 @@
 
 module Ouroboros.Consensus.Util.RedundantConstraints (
     keepRedundantConstraint
+    -- * Convenience re-export
+  , Proxy(..)
   ) where
+
+import           Data.Proxy
 
 -- | Can be used to silence individual "redundant constraint" warnings
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -537,7 +537,7 @@ closeRegistry rr = mask_ $ do
 
 -- | Helper for 'closeRegistry', 'releaseAll', and 'unsafeReleaseAll': release
 -- the resources allocated with the given 'ResourceId's.
-releaseResources :: (IOLike m, HasCallStack)
+releaseResources :: IOLike m
                  => ResourceRegistry m
                  -> Set ResourceId
                  -> (ResourceKey m -> m ())

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -535,9 +535,7 @@ readerClose rdrId m
   Ledger Cursors
 -------------------------------------------------------------------------------}
 
-getLedgerCursor
-  :: forall blk. LedgerSupportsProtocol blk
-  => Model blk -> (LedgerCursorId, Model blk)
+getLedgerCursor :: Model blk -> (LedgerCursorId, Model blk)
 getLedgerCursor m@Model { ledgerCursors = lcs, currentLedger } =
     (lcId, m { ledgerCursors = Map.insert lcId currentLedger lcs })
   where


### PR DESCRIPTION
This goes some way towards #1659, though the main reason for doing this
change now is that these redundant constraints were making it hard to
see the consequences of some of the changes I am making as part of
the work on the hard fork combinator (in particular, #1637).