### PR TITLE
Hard fork history

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
@@ -5,17 +5,20 @@ module Ouroboros.Consensus.Byron.Ledger.Conversions (
   , fromByronBlockNo
   , fromByronBlockCount
   , fromByronEpochSlots
+  , fromByronSlotLength
     -- * From @ouroboros-consensus@ to @cardano-ledger@
   , toByronSlotNo
   , toByronBlockCount
     -- * Extract info from the genesis config
   , genesisSecurityParam
   , genesisNumCoreNodes
+  , genesisSlotLength
   ) where
 
 import           Data.Coerce
 import qualified Data.Set as Set
 
+import           Cardano.Prelude (Natural)
 import           Cardano.Slotting.Block
 import           Cardano.Slotting.Slot
 
@@ -23,9 +26,11 @@ import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Common as CC
 import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Slotting as CC
+import qualified Cardano.Chain.Update as CC
 
 import           Ouroboros.Network.Block (ChainHash (..), HeaderHash)
 
+import           Ouroboros.Consensus.BlockchainTime.SlotLength
 import           Ouroboros.Consensus.Byron.Ledger.Orphans ()
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -50,6 +55,10 @@ fromByronBlockCount (CC.BlockCount k) = SecurityParam k
 
 fromByronEpochSlots :: CC.EpochSlots -> EpochSize
 fromByronEpochSlots (CC.EpochSlots n) = EpochSize n
+
+fromByronSlotLength :: Natural -> SlotLength
+fromByronSlotLength = slotLengthFromMillisec
+                    . (fromIntegral :: Natural -> Integer)
 
 {-------------------------------------------------------------------------------
   From @ouroboros-consensus@ to @cardano-ledger@
@@ -79,3 +88,8 @@ genesisNumCoreNodes =
     . Genesis.unGenesisKeyHashes
     . Genesis.gdGenesisKeyHashes
     . Genesis.configGenesisData
+
+genesisSlotLength :: Genesis.Config -> Natural
+genesisSlotLength =
+      CC.ppSlotDuration
+    . Genesis.configProtocolParameters

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/DualPBFT.hs
@@ -276,7 +276,7 @@ genDualPBFTTestConfig numSlots params = do
 
     return TestConfig {
           nodeRestarts = noRestarts
-        , slotLengths  = singletonSlotLengths (slotLengthFromSec 20)
+        , slotLength   = slotLengthFromSec 20
         , numCoreNodes = pbftNumNodes params
         , ..
         }

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
@@ -121,7 +121,7 @@ tests = testGroup "RealPBFT" $
             , nodeJoinPlan = NodeJoinPlan $ Map.fromList [(CoreNodeId 0,SlotNo 0), (CoreNodeId 1,SlotNo 20), (CoreNodeId 2,SlotNo 22)]
             , nodeRestarts = noRestarts
             , nodeTopology = meshNodeTopology ncn
-            , slotLengths = defaultSlotLengths
+            , slotLength   = defaultSlotLength
             , initSeed     = Seed (15069526818753326002, 9758937467355895013, 16548925776947010688, 13173070736975126721, 13719483751339084974)
             }
     , testProperty "rewind to EBB supported as of Issue #1312, #1" $
@@ -139,7 +139,7 @@ tests = testGroup "RealPBFT" $
             , nodeJoinPlan = NodeJoinPlan (Map.fromList [(CoreNodeId 0,SlotNo 0),(CoreNodeId 1,SlotNo 1)])
             , nodeRestarts = noRestarts
             , nodeTopology = meshNodeTopology ncn
-            , slotLengths  = defaultSlotLengths
+            , slotLength   = defaultSlotLength
             , initSeed     = Seed (15069526818753326002, 9758937467355895013, 16548925776947010688, 13173070736975126721, 13719483751339084974)
             }
     , testProperty "rewind to EBB supported as of Issue #1312, #2" $
@@ -153,7 +153,7 @@ tests = testGroup "RealPBFT" $
             , nodeJoinPlan = NodeJoinPlan (Map.fromList [(CoreNodeId 0,SlotNo {unSlotNo = 0}),(CoreNodeId 1,SlotNo {unSlotNo = 3})])
             , nodeRestarts = noRestarts
             , nodeTopology = meshNodeTopology ncn
-            , slotLengths  = defaultSlotLengths
+            , slotLength   = defaultSlotLength
             , initSeed     = Seed (16817746570690588019, 3284322327197424879, 14951803542883145318, 5227823917971823767, 14093715642382269482)
             }
     , testProperty "one testOutputTipBlockNos update per node per slot" $
@@ -170,7 +170,7 @@ tests = testGroup "RealPBFT" $
             , nodeJoinPlan = NodeJoinPlan (Map.fromList [(CoreNodeId 0,SlotNo {unSlotNo = 0}),(CoreNodeId 1,SlotNo {unSlotNo = 0})])
             , nodeRestarts = NodeRestarts (Map.fromList [(SlotNo {unSlotNo = 5},Map.fromList [(CoreNodeId 1,NodeRestart)])])
             , nodeTopology = meshNodeTopology ncn
-            , slotLengths  = defaultSlotLengths
+            , slotLength   = defaultSlotLength
             , initSeed     = Seed {getSeed = (17927476716858194849,11935807562313832971,15925564353519845641,3835030747036900598,2802397826914039548)}
             }
     , testProperty "BlockFetch live lock due to an EBB at the ImmutableDB tip, Issue #1435" $
@@ -188,7 +188,7 @@ tests = testGroup "RealPBFT" $
             , nodeJoinPlan = NodeJoinPlan $ Map.fromList [(CoreNodeId 0,SlotNo 3),(CoreNodeId 1,SlotNo 3),(CoreNodeId 2,SlotNo 5),(CoreNodeId 3,SlotNo 57)]
             , nodeRestarts = noRestarts
             , nodeTopology = meshNodeTopology ncn
-            , slotLengths  = defaultSlotLengths
+            , slotLength   = defaultSlotLength
             , initSeed     = Seed (11044330969750026700,14522662956180538128,9026549867550077426,3049168255170604478,643621447671665184)
             }
     , testProperty "ImmutableDB is leaking file handles, #1543" $
@@ -217,7 +217,7 @@ tests = testGroup "RealPBFT" $
               ]
             , nodeTopology = meshNodeTopology ncn5
               -- Slot length of 19s passes, and 21s also fails; I haven't seen this matter before.
-            , slotLengths  = singletonSlotLengths (slotLengthFromSec 20)
+            , slotLength   = slotLengthFromSec 20
             , initSeed     = Seed {getSeed = (15062108706768000853,6202101653126031470,15211681930891010376,1718914402782239589,12639712845887620121)}
             }
     , -- RealPBFT runs are slow, so do 10x less of this narrow test
@@ -242,7 +242,7 @@ tests = testGroup "RealPBFT" $
                 (SlotNo (slotsPerEpoch + mod w window))
                 (Map.singleton (CoreNodeId 0) NodeRekey)
             , nodeTopology = meshNodeTopology ncn
-            , slotLengths  = defaultSlotLengths
+            , slotLength   = defaultSlotLength
             , initSeed     = seed
             }
     , testProperty "exercise a corner case of mkCurrentBlockContext" $
@@ -263,7 +263,7 @@ tests = testGroup "RealPBFT" $
             , nodeRestarts = NodeRestarts $ Map.singleton
                 (SlotNo 1) (Map.singleton (CoreNodeId 1) NodeRestart)
             , nodeTopology = meshNodeTopology ncn
-            , slotLengths  = defaultSlotLengths
+            , slotLength   = defaultSlotLength
             , initSeed     = Seed (4690259409304062007,9560140637825988311,3774468764133159390,14745090572658815456,7199590241247856333)
             }
     , testProperty "correct EpochNumber in delegation certificate 1" $
@@ -279,7 +279,7 @@ tests = testGroup "RealPBFT" $
             , nodeJoinPlan = trivialNodeJoinPlan ncn4
             , nodeRestarts = NodeRestarts (Map.fromList [(SlotNo 59,Map.fromList [(CoreNodeId 3,NodeRekey)])])
             , nodeTopology = meshNodeTopology ncn4
-            , slotLengths  = defaultSlotLengths
+            , slotLength   = defaultSlotLength
             , initSeed     = Seed (17364222041321661634,8266509462575908621,10410472349244348261,9332246846568887555,6178891282750652496)
             }
     , testProperty "correct EpochNumber in delegation certificate 2" $
@@ -299,7 +299,7 @@ tests = testGroup "RealPBFT" $
             , nodeJoinPlan = NodeJoinPlan (Map.fromList [(CoreNodeId 0,SlotNo {unSlotNo = 1}),(CoreNodeId 1,SlotNo {unSlotNo = 1}),(CoreNodeId 2,SlotNo {unSlotNo = 58})])
             , nodeRestarts = NodeRestarts (Map.fromList [(SlotNo {unSlotNo = 58},Map.fromList [(CoreNodeId 2,NodeRekey)])])
             , nodeTopology = meshNodeTopology ncn3
-            , slotLengths  = defaultSlotLengths
+            , slotLength   = defaultSlotLength
             , initSeed     = Seed {getSeed = (15151717355257504044,5938503171282920606,17557892055617026469,2625071732074633531,737988411488637670)}
             }
     , testProperty "repeatedly add the the dlg cert tx" $
@@ -350,7 +350,7 @@ tests = testGroup "RealPBFT" $
             , nodeRestarts = NodeRestarts $ Map.fromList [(SlotNo 83,Map.fromList [(CoreNodeId 2,NodeRekey)])]
             , nodeTopology =    --   1 <-> 0 <-> 2
                 NodeTopology $ Map.fromList [(CoreNodeId 0,Set.fromList []),(CoreNodeId 1,Set.fromList [CoreNodeId 0]),(CoreNodeId 2,Set.fromList [CoreNodeId 0])]
-            , slotLengths  = defaultSlotLengths
+            , slotLength   = defaultSlotLength
             , initSeed     = Seed {getSeed = (6137414258840919713,13743611065535662953,11200456599001708481,15059765168210441725,7592004320108020587)}
             }
     , testProperty "topology prevents timely dlg cert tx propagation" $
@@ -387,7 +387,7 @@ tests = testGroup "RealPBFT" $
             , nodeRestarts = NodeRestarts (Map.fromList [(SlotNo {unSlotNo = 37},Map.fromList [(CoreNodeId 4,NodeRekey)])])
             , nodeTopology = -- 3 <-> {0,1,2} <-> 4
                 NodeTopology (Map.fromList [(CoreNodeId 0,Set.fromList []),(CoreNodeId 1,Set.fromList [CoreNodeId 0]),(CoreNodeId 2,Set.fromList [CoreNodeId 0, CoreNodeId 1]),(CoreNodeId 3,Set.fromList [CoreNodeId 0,CoreNodeId 1,CoreNodeId 2]),(CoreNodeId 4,Set.fromList [CoreNodeId 0,CoreNodeId 1,CoreNodeId 2])])
-            , slotLengths  = defaultSlotLengths
+            , slotLength   = defaultSlotLength
             , initSeed = Seed {getSeed = (13428626417421372024,5113871799759534838,13943132470772613446,18226529569527889118,4309403968134095151)}
             }
     , testProperty "mkDelegationEnvironment uses currentSlot not latestSlot" $
@@ -411,7 +411,7 @@ tests = testGroup "RealPBFT" $
          , nodeJoinPlan = trivialNodeJoinPlan ncn
          , nodeRestarts = NodeRestarts $ Map.singleton (SlotNo 30) $ Map.singleton (CoreNodeId 2) NodeRekey
          , nodeTopology = meshNodeTopology ncn
-         , slotLengths  = defaultSlotLengths
+         , slotLength   = defaultSlotLength
          , initSeed     = Seed (368401128646137767,7989071211759985580,4921478144180472393,11759221144888418607,7602439127562955319)
          }
     , testProperty "delayed message corner case" $
@@ -423,7 +423,7 @@ tests = testGroup "RealPBFT" $
             , nodeJoinPlan = NodeJoinPlan (Map.fromList [(CoreNodeId 0,SlotNo {unSlotNo = 0}),(CoreNodeId 1,SlotNo {unSlotNo = 1})])
             , nodeRestarts = noRestarts
             , nodeTopology = meshNodeTopology ncn
-            , slotLengths  = defaultSlotLengths
+            , slotLength   = defaultSlotLength
             , initSeed     = Seed (11954171112552902178,1213614443200450055,13600682863893184545,15433529895532611662,2464843772450023204)
             }
     , testProperty "simple convergence" $
@@ -439,8 +439,8 @@ tests = testGroup "RealPBFT" $
           prop_simple_real_pbft_convergence produceEBBs k testConfig
     ]
   where
-    defaultSlotLengths :: SlotLengths
-    defaultSlotLengths = singletonSlotLengths (SlotLength 1)
+    defaultSlotLength :: SlotLength
+    defaultSlotLength = SlotLength 1
 
 prop_deterministicPlan :: PBftParams -> NumSlots -> NumCoreNodes -> Property
 prop_deterministicPlan params numSlots numCoreNodes =
@@ -903,7 +903,7 @@ genRealPBFTTestConfig k = do
       , nodeTopology
       , numCoreNodes
       , numSlots
-      , slotLengths = singletonSlotLengths pbftSlotLength
+      , slotLength = pbftSlotLength
       , initSeed
       }
 
@@ -924,7 +924,7 @@ shrinkTestConfigSlotsOnly TestConfig
   , nodeJoinPlan
   , nodeRestarts
   , nodeTopology
-  , slotLengths
+  , slotLength
   , initSeed
   } =
     dropId $
@@ -934,7 +934,7 @@ shrinkTestConfigSlotsOnly TestConfig
         , nodeTopology = top'
         , numCoreNodes
         , numSlots     = t'
-        , slotLengths  = ls'
+        , slotLength   = len'
         , initSeed
         }
     | t'            <- andId shrink numSlots
@@ -943,7 +943,7 @@ shrinkTestConfigSlotsOnly TestConfig
     , p'            <- andId shrinkNodeJoinPlan adjustedP
     , r'            <- andId shrinkNodeRestarts adjustedR
     , top'          <- andId shrinkNodeTopology nodeTopology
-    , ls'           <- andId shrink slotLengths
+    , len'          <- andId shrink slotLength
     ]
 
 -- | Possibly promote some 'NodeRestart's to 'NodeRekey's

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -24,7 +24,6 @@ import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Update as Update
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Byron.Ledger
 import           Ouroboros.Consensus.Byron.Node as X
 import           Ouroboros.Consensus.Byron.Protocol (PBftByronCrypto)
@@ -70,40 +69,32 @@ data Protocol blk p where
     :: NumCoreNodes
     -> CoreNodeId
     -> SecurityParam
-    -> SlotLengths
-    -> Protocol
-         (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
-         ProtocolMockBFT
+    -> BlockConfig MockBftBlock
+    -> Protocol MockBftBlock ProtocolMockBFT
 
   -- | Run Praos against the mock ledger
   ProtocolMockPraos
     :: NumCoreNodes
     -> CoreNodeId
     -> PraosParams
-    -> SlotLengths
-    -> Protocol
-         (SimplePraosBlock SimpleMockCrypto PraosMockCrypto)
-         ProtocolMockPraos
+    -> BlockConfig MockPraosBlock
+    -> Protocol MockPraosBlock ProtocolMockPraos
 
   -- | Run Praos against the mock ledger but with an explicit leader schedule
   ProtocolLeaderSchedule
     :: NumCoreNodes
     -> CoreNodeId
     -> PraosParams
-    -> SlotLengths
+    -> BlockConfig MockPraosRuleBlock
     -> LeaderSchedule
-    -> Protocol
-         (SimplePraosRuleBlock SimpleMockCrypto)
-         ProtocolLeaderSchedule
+    -> Protocol MockPraosRuleBlock ProtocolLeaderSchedule
 
   -- | Run PBFT against the mock ledger
   ProtocolMockPBFT
     :: PBftParams
-    -> SlotLengths
+    -> BlockConfig MockPBftBlock
     -> CoreNodeId
-    -> Protocol
-         (SimplePBftBlock SimpleMockCrypto PBftMockCrypto)
-         ProtocolMockPBFT
+    -> Protocol MockPBftBlock ProtocolMockPBFT
 
   -- | Run PBFT against the real ledger
   ProtocolRealPBFT
@@ -129,17 +120,17 @@ verifyProtocol ProtocolRealPBFT{}       = Refl
 
 -- | Data required to run the selected protocol
 protocolInfo :: Protocol blk p -> ProtocolInfo blk
-protocolInfo (ProtocolMockBFT nodes nid params slotLengths) =
-    protocolInfoBft nodes nid params slotLengths
+protocolInfo (ProtocolMockBFT nodes nid params cfg) =
+    protocolInfoBft nodes nid params cfg
 
-protocolInfo (ProtocolMockPraos nodes nid params slotLengths) =
-    protocolInfoPraos nodes nid params slotLengths
+protocolInfo (ProtocolMockPraos nodes nid params cfg) =
+    protocolInfoPraos nodes nid params cfg
 
-protocolInfo (ProtocolLeaderSchedule nodes nid params slotLengths schedule) =
-    protocolInfoPraosRule nodes nid params slotLengths schedule
+protocolInfo (ProtocolLeaderSchedule nodes nid params cfg schedule) =
+    protocolInfoPraosRule nodes nid params cfg schedule
 
-protocolInfo (ProtocolMockPBFT params slotLengths nid) =
-    protocolInfoMockPBFT params slotLengths nid
+protocolInfo (ProtocolMockPBFT params cfg nid) =
+    protocolInfoMockPBFT params cfg nid
 
 protocolInfo (ProtocolRealPBFT gc mthr prv swv mplc) =
     protocolInfoByron gc mthr prv swv mplc

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -1,12 +1,12 @@
 module Ouroboros.Consensus.Mock.Node.BFT (
-    protocolInfoBft
+    MockBftBlock
+  , protocolInfoBft
   ) where
 
 import qualified Data.Map.Strict as Map
 
 import           Cardano.Crypto.DSIGN
 
-import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended
@@ -16,12 +16,14 @@ import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 
+type MockBftBlock = SimpleBftBlock SimpleMockCrypto BftMockCrypto
+
 protocolInfoBft :: NumCoreNodes
                 -> CoreNodeId
                 -> SecurityParam
-                -> SlotLengths
-                -> ProtocolInfo (SimpleBftBlock SimpleMockCrypto BftMockCrypto)
-protocolInfoBft numCoreNodes nid securityParam slotLengths =
+                -> BlockConfig MockBftBlock
+                -> ProtocolInfo MockBftBlock
+protocolInfoBft numCoreNodes nid securityParam cfg =
     ProtocolInfo {
         pInfoConfig = TopLevelConfig {
             configConsensus = BftConfig {
@@ -37,7 +39,7 @@ protocolInfoBft numCoreNodes nid securityParam slotLengths =
                   ]
               }
           , configLedger = SimpleLedgerConfig ()
-          , configBlock  = SimpleBlockConfig slotLengths
+          , configBlock  = cfg
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState ())

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -2,14 +2,14 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Mock.Node.PBFT (
-    protocolInfoMockPBFT
+    MockPBftBlock
+  , protocolInfoMockPBFT
   ) where
 
 import qualified Data.Bimap as Bimap
 
 import           Cardano.Crypto.DSIGN
 
-import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended
@@ -19,12 +19,13 @@ import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as S
 
+type MockPBftBlock = SimplePBftBlock SimpleMockCrypto PBftMockCrypto
+
 protocolInfoMockPBFT :: PBftParams
-                     -> SlotLengths
+                     -> BlockConfig MockPBftBlock
                      -> CoreNodeId
-                     -> ProtocolInfo (SimplePBftBlock SimpleMockCrypto
-                                                      PBftMockCrypto)
-protocolInfoMockPBFT params slotLengths nid =
+                     -> ProtocolInfo MockPBftBlock
+protocolInfoMockPBFT params cfg nid =
     ProtocolInfo {
         pInfoConfig = TopLevelConfig {
             configConsensus = PBftConfig {
@@ -37,7 +38,7 @@ protocolInfoMockPBFT params slotLengths nid =
                    }
                }
           , configLedger = SimpleLedgerConfig ledgerView
-          , configBlock  = SimpleBlockConfig slotLengths
+          , configBlock  = cfg
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState S.empty)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -4,7 +4,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Mock.Node.Praos (
-    protocolInfoPraos
+    MockPraosBlock
+  , protocolInfoPraos
   ) where
 
 import           Data.Map (Map)
@@ -13,7 +14,6 @@ import qualified Data.Map as Map
 import           Cardano.Crypto.KES
 import           Cardano.Crypto.VRF
 
-import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended
@@ -22,13 +22,14 @@ import           Ouroboros.Consensus.Mock.Protocol.Praos
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 
+type MockPraosBlock = SimplePraosBlock SimpleMockCrypto PraosMockCrypto
+
 protocolInfoPraos :: NumCoreNodes
                   -> CoreNodeId
                   -> PraosParams
-                  -> SlotLengths
-                  -> ProtocolInfo (SimplePraosBlock SimpleMockCrypto
-                                                    PraosMockCrypto)
-protocolInfoPraos numCoreNodes nid params slotLengths =
+                  -> BlockConfig MockPraosBlock
+                  -> ProtocolInfo MockPraosBlock
+protocolInfoPraos numCoreNodes nid params cfg =
     ProtocolInfo {
         pInfoConfig = TopLevelConfig {
             configConsensus = PraosConfig {
@@ -40,7 +41,7 @@ protocolInfoPraos numCoreNodes nid params slotLengths =
               , praosVerKeys      = verKeys
               }
           , configLedger = SimpleLedgerConfig addrDist
-          , configBlock  = SimpleBlockConfig slotLengths
+          , configBlock  = cfg
           }
       , pInfoInitLedger = ExtLedgerState {
             ledgerState = genesisSimpleLedgerState addrDist

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -1,6 +1,7 @@
 -- | Test the Praos chain selection rule but with explicit leader schedule
 module Ouroboros.Consensus.Mock.Node.PraosRule (
-    protocolInfoPraosRule
+    MockPraosRuleBlock
+  , protocolInfoPraosRule
   ) where
 
 import           Data.Map (Map)
@@ -9,7 +10,6 @@ import qualified Data.Map as Map
 import           Cardano.Crypto.KES
 import           Cardano.Crypto.VRF
 
-import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended
@@ -19,16 +19,18 @@ import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
 
+type MockPraosRuleBlock = SimplePraosRuleBlock SimpleMockCrypto
+
 protocolInfoPraosRule :: NumCoreNodes
                       -> CoreNodeId
                       -> PraosParams
-                      -> SlotLengths
+                      -> BlockConfig MockPraosRuleBlock
                       -> LeaderSchedule
-                      -> ProtocolInfo (SimplePraosRuleBlock SimpleMockCrypto)
+                      -> ProtocolInfo MockPraosRuleBlock
 protocolInfoPraosRule numCoreNodes
                       nid
                       params
-                      slotLengths
+                      cfg
                       schedule =
     ProtocolInfo {
       pInfoConfig = TopLevelConfig {
@@ -45,7 +47,7 @@ protocolInfoPraosRule numCoreNodes
             , wlsConfigNodeId   = nid
             }
         , configLedger = SimpleLedgerConfig ()
-        , configBlock  = SimpleBlockConfig slotLengths
+        , configBlock  = cfg
         }
     , pInfoInitLedger = ExtLedgerState
         { ledgerState = genesisSimpleLedgerState addrDist

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -41,7 +41,7 @@ tests = testGroup "BFT"
           , nodeJoinPlan = NodeJoinPlan (Map.fromList [(CoreNodeId 0,SlotNo {unSlotNo = 0}),(CoreNodeId 1,SlotNo {unSlotNo = 1})])
           , nodeRestarts = noRestarts
           , nodeTopology = meshNodeTopology ncn
-          , slotLengths = singletonSlotLengths (slotLengthFromSec 1)
+          , slotLength   = slotLengthFromSec 1
           , initSeed = Seed {getSeed = (12659702313441544615,9326820694273232011,15820857683988100572,2201554969601311572,4716411940989238571)}
           }
     ,
@@ -54,8 +54,7 @@ prop_simple_bft_convergence :: SecurityParam
                             -> TestConfig
                             -> Property
 prop_simple_bft_convergence k
-  testConfig@TestConfig{numCoreNodes, numSlots, slotLengths} =
-    tabulate "slot length changes" [show $ countSlotLengthChanges numSlots slotLengths] $
+  testConfig@TestConfig{numCoreNodes, numSlots, slotLength} =
     prop_general PropGeneralArgs
       { pgaCountTxs               = countSimpleGenTxs
       , pgaExpectedBlockRejection = const False
@@ -73,7 +72,11 @@ prop_simple_bft_convergence k
             { forgeEbbEnv = Nothing
             , nodeInfo    = \nid ->
                 plainTestNodeInitialization $
-                protocolInfoBft numCoreNodes nid k slotLengths
+                  protocolInfoBft
+                    numCoreNodes
+                    nid
+                    k
+                    (defaultSimpleBlockConfig k slotLength)
             , rekeying    = Nothing
             }
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -61,7 +61,7 @@ tests = testGroup "LeaderSchedule"
             , nodeJoinPlan
             , nodeRestarts = noRestarts
             , nodeTopology
-            , slotLengths
+            , slotLength
             , initSeed
             }
               schedule
@@ -77,7 +77,7 @@ tests = testGroup "LeaderSchedule"
     numCoreNodes = NumCoreNodes 3
     numSlots     = NumSlots $ maxRollbacks k * praosSlotsPerEpoch * numEpochs
     numEpochs    = 3
-    slotLengths  = singletonSlotLengths praosSlotLength
+    slotLength   = praosSlotLength
 
 praosSlotLength :: SlotLength
 praosSlotLength = slotLengthFromSec 2
@@ -109,7 +109,9 @@ prop_simple_leader_schedule_convergence
                                       numCoreNodes
                                       nid
                                       params
-                                      (singletonSlotLengths praosSlotLength)
+                                      (defaultSimpleBlockConfig
+                                        praosSecurityParam
+                                        praosSlotLength)
                                       schedule
             , rekeying    = Nothing
             }

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -60,7 +60,7 @@ tests = testGroup "PBFT" $
           ]
         , nodeRestarts = noRestarts
         , nodeTopology = meshNodeTopology ncn5
-        , slotLengths  = singletonSlotLengths $ slotLengthFromSec 1
+        , slotLength   = slotLengthFromSec 1
         , initSeed     = Seed (9550173506264790139,4734409083700350196,9697926137031612922,16476814117921936461,9569412668768792610)
         }
     , testProperty "simple convergence" $ \tc ->
@@ -101,7 +101,7 @@ prop_simple_pbft_convergence
             , nodeInfo    = plainTestNodeInitialization .
                             protocolInfoMockPBFT
                               params
-                              (singletonSlotLengths pbftSlotLength)
+                              (defaultSimpleBlockConfig k pbftSlotLength)
             , rekeying    = Nothing
             }
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -54,7 +54,7 @@ tests = testGroup "Praos"
             , nodeJoinPlan
             , nodeRestarts = noRestarts
             , nodeTopology
-            , slotLengths  = singletonSlotLengths praosSlotLength
+            , slotLength   = praosSlotLength
             , initSeed
             }
     ]
@@ -66,7 +66,7 @@ tests = testGroup "Praos"
       , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
       , nodeRestarts = noRestarts
       , nodeTopology = meshNodeTopology numCoreNodes
-      , slotLengths  = singletonSlotLengths praosSlotLength
+      , slotLength   = praosSlotLength
       , initSeed     = seed
       }
 
@@ -113,7 +113,9 @@ prop_simple_praos_convergence
                                       numCoreNodes
                                       nid
                                       params
-                                      (singletonSlotLengths praosSlotLength)
+                                      (defaultSimpleBlockConfig
+                                        praosSecurityParam
+                                        praosSlotLength)
             , rekeying    = Nothing
             }
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -87,7 +87,7 @@ data TestConfig = TestConfig
   , nodeJoinPlan :: !NodeJoinPlan
   , nodeRestarts :: !NodeRestarts
   , nodeTopology :: !NodeTopology
-  , slotLengths  :: !SlotLengths
+  , slotLength   :: !SlotLength
   , initSeed     :: !Seed
   }
   deriving (Show)
@@ -117,7 +117,7 @@ instance Arbitrary TestConfig where
       numSlots     <- arbitrary
       nodeJoinPlan <- genNodeJoinPlan numCoreNodes numSlots
       nodeTopology <- genNodeTopology numCoreNodes
-      slotLengths  <- arbitrary
+      slotLength   <- arbitrary
       initSeed     <- arbitrary
       pure TestConfig
         { numCoreNodes
@@ -126,7 +126,7 @@ instance Arbitrary TestConfig where
           -- TODO how to enrich despite variable schedules?
         , nodeRestarts = noRestarts
         , nodeTopology
-        , slotLengths
+        , slotLength
         , initSeed
         }
 
@@ -136,7 +136,7 @@ instance Arbitrary TestConfig where
     , nodeJoinPlan
     , nodeRestarts
     , nodeTopology
-    , slotLengths
+    , slotLength
     , initSeed
     } =
       dropId $
@@ -146,7 +146,7 @@ instance Arbitrary TestConfig where
           , nodeJoinPlan = p'
           , nodeRestarts = r'
           , nodeTopology = top'
-          , slotLengths  = ls'
+          , slotLength   = len'
           , initSeed
           }
       | n'             <- andId shrink numCoreNodes
@@ -157,7 +157,7 @@ instance Arbitrary TestConfig where
       , p'             <- andId shrinkNodeJoinPlan adjustedP
       , r'             <- andId shrinkNodeRestarts adjustedR
       , top'           <- andId shrinkNodeTopology adjustedTop
-      , ls'            <- andId shrink slotLengths
+      , len'           <- andId shrink slotLength
       ]
 
 {-------------------------------------------------------------------------------
@@ -212,7 +212,7 @@ runTestNetwork
     , nodeJoinPlan
     , nodeRestarts
     , nodeTopology
-    , slotLengths
+    , slotLength
     , initSeed
     }
   epochSize
@@ -227,7 +227,7 @@ runTestNetwork
           , tnaRNG            = seedToChaCha initSeed
           , tnaRekeyM         = Nothing
           , tnaRestarts       = nodeRestarts
-          , tnaSlotLengths    = slotLengths
+          , tnaSlotLength     = slotLength
           , tnaTopology       = nodeTopology
           , tnaEpochSize      = epochSize
           }

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -168,7 +168,7 @@ data ThreadNetworkArgs m blk = ThreadNetworkArgs
   , tnaRNG          :: ChaChaDRG
   , tnaRekeyM       :: Maybe (RekeyM m blk)
   , tnaRestarts     :: NodeRestarts
-  , tnaSlotLengths  :: SlotLengths
+  , tnaSlotLength   :: SlotLength
   , tnaTopology     :: NodeTopology
   , tnaEpochSize    :: EpochSize
     -- ^ Epoch size
@@ -258,7 +258,7 @@ runThreadNetwork ThreadNetworkArgs
   , tnaRNG            = initRNG
   , tnaRekeyM         = mbRekeyM
   , tnaRestarts       = nodeRestarts
-  , tnaSlotLengths    = slotLengths
+  , tnaSlotLength     = slotLength
   , tnaTopology       = nodeTopology
   , tnaEpochSize      = epochSize
   } = withRegistry $ \sharedRegistry -> do
@@ -272,7 +272,10 @@ runThreadNetwork ThreadNetworkArgs
     -- from the wrong thread. To stop the network, wait for all the nodes'
     -- blockchain times to be done and then kill the main thread of each node,
     -- which should terminate all other threads it spawned.
-    sharedTestBtime <- newTestBlockchainTime sharedRegistry numSlots slotLengths
+    sharedTestBtime <- newTestBlockchainTime
+                         sharedRegistry
+                         numSlots
+                         (singletonSlotLengths slotLength)
     let sharedBtime = testBlockchainTime sharedTestBtime
 
     -- This function is organized around the notion of a network of nodes as a

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/Arbitrary.hs
@@ -10,6 +10,7 @@ module Test.Util.Orphans.Arbitrary
     , genSmallEpochNo
     , genSmallSlotNo
     , SmallDiffTime (..)
+    , dawnOfTime
     ) where
 
 import           Data.Time

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/QuickCheck.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/QuickCheck.hs
@@ -3,6 +3,7 @@ module Test.Util.QuickCheck (
     -- * Comparison functions
     lt
   , ge
+  , expectRight
     -- * Improved variants
   , elements
   , (=:=)
@@ -32,6 +33,15 @@ x `ge` y = counterexample (show x ++ " < " ++ show y) $ x >= y
 -- | Like '<', but prints a counterexample when it fails.
 lt :: (Ord a, Show a) => a -> a -> Property
 x `lt` y = counterexample (show x ++ " >= " ++ show y) $ x < y
+
+-- | Check that we have the expected 'Right' value
+--
+-- @expectRight b ab@ is roughly equivalent to @Right b === ab@, but avoids an
+-- equality constraint on @a@.
+expectRight :: (Show a, Show b, Eq b) => b -> Either a b -> Property
+expectRight b (Right b') = b === b'
+expectRight _ (Left a)   = counterexample ("Unexpected left " ++ show a) $
+                             False
 
 {-------------------------------------------------------------------------------
   Improved variants

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -43,6 +43,7 @@ library
                        Ouroboros.Consensus.BlockchainTime.SlotLengths
                        Ouroboros.Consensus.BlockchainTime.WallClock
                        Ouroboros.Consensus.Config
+                       Ouroboros.Consensus.HardFork.History
                        Ouroboros.Consensus.HeaderValidation
                        Ouroboros.Consensus.Ledger.Abstract
                        Ouroboros.Consensus.Ledger.Dual
@@ -87,6 +88,7 @@ library
                        Ouroboros.Consensus.Util.CallStack
                        Ouroboros.Consensus.Util.CBOR
                        Ouroboros.Consensus.Util.Condense
+                       Ouroboros.Consensus.Util.Counting
                        Ouroboros.Consensus.Util.EarlyExit
                        Ouroboros.Consensus.Util.HList
                        Ouroboros.Consensus.Util.IOLike
@@ -256,6 +258,7 @@ test-suite test-consensus
   other-modules:
                        Test.Consensus.BlockchainTime.SlotLengths
                        Test.Consensus.BlockchainTime.WallClock
+                       Test.Consensus.HardFork.History
                        Test.Consensus.MiniProtocol.ChainSync.Client
                        Test.Consensus.MiniProtocol.LocalStateQuery.Server
                        Test.Consensus.Mempool

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History.hs
@@ -1,0 +1,762 @@
+{-# LANGUAGE DataKinds                 #-}
+{-# LANGUAGE DeriveAnyClass            #-}
+{-# LANGUAGE DeriveGeneric             #-}
+{-# LANGUAGE DerivingStrategies        #-}
+{-# LANGUAGE DerivingVia               #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs                     #-}
+{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE StandaloneDeriving        #-}
+{-# LANGUAGE TypeOperators             #-}
+{-# LANGUAGE ViewPatterns              #-}
+
+-- | Intended for qualified import
+--
+-- > import qualified Ouroboros.Consensus.HardFork.History as HardFork
+module Ouroboros.Consensus.HardFork.History (
+    -- * History
+    -- ** Params
+    EraParams(..)
+  , SafeZone(..)
+  , SafeBeforeEpoch(..)
+  , defaultEraParams
+    -- ** Shape
+  , Shape(..)
+  , singletonShape
+    -- ** Transitions
+  , Transitions(..)
+  , transitionsUnknown
+    -- * Summary
+  , Summary(..)    -- Non-opaque only for the benefit of tests
+  , SystemStart(..)
+  , summarize
+    -- * Conversions
+  , PastHorizonException(..)
+  , wallclockToSlot
+  , slotToWallclock
+  , slotToEpoch
+  , epochToSlot
+    -- * Support for 'EpochInfo'
+  , summaryToEpochInfo
+  , snapshotEpochInfo
+    -- * Exported only for the benefit of tests
+    -- ** Bounds
+    --
+    -- TODO: Document expected relation between 'boundSlot' and 'boundEpoch',
+    -- and test that 'initBound' and 'mkUpperBound' both establish it.
+  , Bound -- Still opaque, even for tests. Has internal invariants.
+  , boundEpoch
+  , boundSlot
+  , boundTime
+  , initBound
+  , mkUpperBound
+    -- ** Summary
+  , EraSummary(..)
+  , summaryBounds
+    -- ** Summary translations
+  , dropLast
+  , ShiftTime(..)
+    -- ** Invariants
+  , invariantSummary
+  , invariantShape
+    -- ** Auxiliary
+  , addEpochs
+  , addSlots
+  , countEpochs
+  , countSlots
+  ) where
+
+import           Control.Exception (Exception (..), assert, throw)
+import           Control.Monad.Except
+import           Data.Bifunctor
+import           Data.Fixed (divMod')
+import           Data.Foldable (toList)
+import           Data.Functor.Identity
+import qualified Data.List as List
+import           Data.Time
+import           Data.Void
+import           Data.Word
+import           GHC.Generics (Generic)
+
+import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
+import           Cardano.Slotting.EpochInfo.API
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Consensus.BlockchainTime.SlotLength
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.Counting
+import           Ouroboros.Consensus.Util.IOLike
+
+{-------------------------------------------------------------------------------
+  OVERVIEW
+
+  The overall chain consists of various /era/s. Each era has its own set of era
+  parameters such as the slot length and epoch size, as well as its own block
+  format, ledger format, ledger rules, etc. It is assumed that the overall
+  /shape/ of the chain is known. In other words, we statically know which eras
+  we expect and what their parameters are; adding an additional era would
+  require a code update. What we /don't/ know precisely is /when/ we transition
+  from one era to the next, i.e., the hard fork transition points.
+
+  When we are at genesis, the chain therefore looks something like this:
+
+  > *-------------------?--------------------?--------------------
+  > ^
+  > \-- tip
+
+  where we have (in this example) three eras (say, Byron, Shelley and Goguen)
+  and therefore two hard fork transitions. Hard forks happen at epoch
+  boundaries; the exact 'EpochNo' of each hard fork is determined by the era
+  preceding it. Naturally, the exact 'EpochNo' of /past/ hard forks is known:
+
+  > ---------------A--------------*----------?--------------------
+  >                               ^
+  >                               \-- tip
+
+  where A is a known hard fork transition, and the next hard fork transition
+  is still unknown.
+
+  SAFE ZONES
+
+  Future hard fork points may be known or unknown, where "known" means
+  "certain"; i.e., for Byron, it would mean an update proposal has been voted
+  on, confirmed, endorsed, and that endorsement is at least @k@ blocks deep into
+  the chain; for Shelley it means an update proposal is voted on and accepted,
+  and that acceptance is at least @k@ blocks deep into the chain.
+
+  When a hard fork point is still unknown, we assume that each era determines a
+  "safe zone": a number of slots from the tip of the ledger in which it is
+  guaranteed that the hard fork will not happen.
+
+  > CASE (i)
+  >
+  > ---------------A--------------*----------?--------------------
+  >                               \..../
+  >                                safe
+  >                                zone
+
+  Since the hard fork will not happen in the safe zone, we can extend the use of
+  the current set of era parameters past the tip into the safe zone, giving us a
+  limited ability to make predictions for the future (such as converting between
+  slot numbers and wallclock time).
+
+  We assume that once a transition point is known (and no longer subject to
+  roll-back), this is guaranteed not to change anymore and we can use the era's
+  parameters up to the transition point:
+
+  > CASE (ii)
+  >
+  > ---------------A--------------*----------------B--------------
+  >                               \.............../
+  >                                implicitly safe
+
+  Moreover, we assume that we can extend B's safe zone from the point of the
+  hard fork transition:
+
+  > CASE (iii)
+  >
+  > ---------------A--------------*----------------B--------------
+  >                               \.............../\..../
+  >                                implicitly safe  safe
+  >                                                 zone
+
+  This is justified because the safe zones arise from stability requirements
+  for the transactions that establish the transition point. The earliest point
+  such a transaction could be included in the chain is after the hard fork
+  transition, since it must be a transaction from the /new/ era.
+-------------------------------------------------------------------------------}
+
+-- | Parameters that can vary across hard forks
+data EraParams = EraParams {
+      eraEpochSize  :: !EpochSize
+    , eraSlotLength :: !SlotLength
+    , eraSafeZone   :: !SafeZone
+    }
+  deriving stock    (Show, Generic)
+  deriving anyclass (NoUnexpectedThunks)
+
+-- | Default 'EraParams'
+--
+-- We set the epoch size to @10k@ slots and the safe zone to @2k@ slots.
+defaultEraParams :: SecurityParam -> SlotLength -> EraParams
+defaultEraParams (SecurityParam k) slotLength = EraParams {
+      eraEpochSize  = EpochSize (k * 10)
+    , eraSlotLength = slotLength
+    , eraSafeZone   = SafeZone (k * 2) NoLowerBound
+    }
+
+-- | Zone in which it is guaranteed that no hard fork can take place
+data SafeZone = SafeZone {
+      -- | Number of slots from the tip of the ledger
+      safeFromTip     :: !Word64
+
+      -- | Optionally, an 'EpochNo' before which no hard fork can take place
+    , safeBeforeEpoch :: !SafeBeforeEpoch
+    }
+  deriving stock    (Show, Generic)
+  deriving anyclass (NoUnexpectedThunks)
+
+-- | Lower bound on when a transition can take place
+data SafeBeforeEpoch =
+    -- | No such lower bound is known
+    NoLowerBound
+
+    -- | 'EpochNo' before which a transition is guaranteed not to take place
+    --
+    -- Often such a value is available, since a new era is planned only after
+    -- the current era has already been running for a while. For example, at
+    -- the time of writing, we know the Byron to Shelley transition cannot
+    -- happen before epoch 180, since we are currently already in epoch 179.
+    --
+    -- Moreover, for epoch transitions that have /already/ taken place, the
+    -- exact 'EpochNo' of the transition can be used.
+    --
+    -- Providing this value is strictly an optimization; for example, it will
+    -- reduce the frequency with which 'summaryToEpochInfo' must update its
+    -- summary of the hard fork history.
+  | LowerBound !EpochNo
+  deriving stock    (Show, Generic)
+  deriving anyclass (NoUnexpectedThunks)
+
+-- | The shape of the chain
+--
+-- The shape determines how many hard forks we expect as well as the parameters
+-- for each era. The type argument is a type-level list containing one entry
+-- per era, emphasizing that this information is statically known.
+--
+-- The indices are currently not yet used, but the idea is that they look
+-- something like @'[Byron, Shelley, Goguen]@ and are then also used by the
+-- hard fork combinator (most likely this will be a list of block types, since
+-- most of consensus is indexed by block types).
+newtype Shape xs = Shape (Exactly xs EraParams)
+  deriving (Show)
+
+-- | There is only one era
+singletonShape :: EraParams -> Shape '[x]
+singletonShape params = Shape (ExactlyOne params)
+
+-- | The exact point of each confirmed hard fork transition
+--
+-- Unlike the 'Shape' of the chain, which is statically known, the 'Transitions'
+-- are derived from the state of the ledger (hard fork transition points only
+-- become known after a voting procedure).
+--
+-- Any transition listed here must be "certain". How certainty is established is
+-- ledger dependent, but it should imply that this is no longer subject to
+-- rollback.
+newtype Transitions xs = Transitions (LessThan xs EpochNo)
+  deriving (Show)
+
+-- | No known transitions yet
+transitionsUnknown :: Transitions (x ': xs)
+transitionsUnknown = Transitions LessThanOne
+
+{-------------------------------------------------------------------------------
+  Bounds
+-------------------------------------------------------------------------------}
+
+-- | Detailed information about the time bounds of an era
+--
+-- TODO: Document expected relation between 'boundSlot' and 'boundEpoch',
+-- and test that 'initBound' and 'mkUpperBound' both establish it.
+data Bound = Bound {
+      boundTime  :: !UTCTime
+    , boundSlot  :: !SlotNo
+    , boundEpoch :: !EpochNo
+    }
+  deriving (Show, Eq)
+
+initBound :: SystemStart -> Bound
+initBound (SystemStart start) = Bound {
+      boundTime  = start
+    , boundSlot  = SlotNo 0
+    , boundEpoch = EpochNo 0
+    }
+
+-- | Compute upper bound given just the epoch number and era parameters
+mkUpperBound :: EraParams -> Bound -> EpochNo -> Bound
+mkUpperBound EraParams{..} lo hiEpoch = Bound {
+      boundTime  = addUTCTime inEraTime  $ boundTime lo
+    , boundSlot  = addSlots   inEraSlots $ boundSlot lo
+    , boundEpoch = hiEpoch
+    }
+  where
+    inEraEpochs, inEraSlots :: Word64
+    inEraEpochs = countEpochs hiEpoch (boundEpoch lo)
+    inEraSlots  = inEraEpochs * unEpochSize eraEpochSize
+
+    inEraTime :: NominalDiffTime
+    inEraTime = fromIntegral inEraSlots * getSlotLength eraSlotLength
+
+{-------------------------------------------------------------------------------
+  Internal: summary
+
+  This is what we use internally for all translations.
+-------------------------------------------------------------------------------}
+
+-- | The summary zips 'Shape' with 'Forks', and provides detailed information
+-- about the start and end of each era.
+newtype Summary xs = Summary (AtMost xs EraSummary)
+
+deriving instance Show (Summary xs)
+deriving via OnlyCheckIsWHNF "Summary" (Summary xs)
+         instance NoUnexpectedThunks (Summary xs)
+
+-- | Information about a specific era
+data EraSummary = EraSummary {
+      eraStart  :: !Bound     -- ^ Inclusive lower bound
+    , eraEnd    :: !Bound     -- ^ Exclusive upper bound
+    , eraParams :: !EraParams -- ^ Active parameters
+    }
+  deriving (Show)
+
+{-------------------------------------------------------------------------------
+  Translations (primarily for the benefit of tests)
+-------------------------------------------------------------------------------}
+
+-- | Drop the last era
+dropLast :: Summary xs -> (Maybe (Summary xs), EraSummary)
+dropLast (Summary xs) = first (fmap Summary) $ atMostInit xs
+
+class ShiftTime a where
+  shiftTime :: NominalDiffTime -> a -> a
+
+instance ShiftTime SystemStart where
+  shiftTime delta (SystemStart start) = SystemStart $ shiftTime delta start
+
+instance ShiftTime a => ShiftTime [a] where
+  shiftTime = map . shiftTime
+
+instance ShiftTime (Summary xs) where
+  shiftTime delta (Summary summary) = Summary $ shiftTime delta <$> summary
+
+instance ShiftTime EraSummary where
+  shiftTime delta EraSummary{..} = EraSummary{
+      eraStart  = shiftTime delta eraStart
+    , eraEnd    = shiftTime delta eraEnd
+    , eraParams = eraParams
+    }
+
+instance ShiftTime Bound where
+  shiftTime delta Bound{..} = Bound {
+      boundTime  = shiftTime delta boundTime
+    , boundSlot  = boundSlot
+    , boundEpoch = boundEpoch
+    }
+
+instance ShiftTime UTCTime where
+  shiftTime = addUTCTime
+
+{-------------------------------------------------------------------------------
+  Simple 'Summary' queries
+-------------------------------------------------------------------------------}
+
+firstEraSummary :: Summary xs -> EraSummary
+firstEraSummary (Summary summary) = atMostHead summary
+
+lastEraSummary :: Summary xs -> EraSummary
+lastEraSummary (Summary summary) = atMostLast summary
+
+summarySystemStart :: Summary xs -> SystemStart
+summarySystemStart = SystemStart . boundTime . eraStart . firstEraSummary
+
+summaryToList :: Summary xs -> [EraSummary]
+summaryToList (Summary summary) = toList summary
+
+-- | Inclusive lower bound and exclusive upper bound for the entire summary
+summaryBounds :: Summary xs -> (Bound, Bound)
+summaryBounds summary = (
+      eraStart $ firstEraSummary summary
+    , eraEnd   $ lastEraSummary  summary
+    )
+
+{-------------------------------------------------------------------------------
+  Invariants
+-------------------------------------------------------------------------------}
+
+-- | Check 'Shape' invariants
+--
+-- The only part of the 'Shape' that must make sense is the 'safeBeforeEpoch'
+-- values (they must be strictly increasing).
+invariantShape :: Shape xs -> Except String ()
+invariantShape = \(Shape shape) ->
+    go (EpochNo 0) shape
+  where
+    go :: EpochNo -- ^ Lower bound on the start of the era
+       -> Exactly xs EraParams -> Except String ()
+    go lowerBound shape = do
+        nextLowerBound <-
+          case safeBeforeEpoch (eraSafeZone curParams) of
+            NoLowerBound -> do
+              return $ addEpochs 1 lowerBound
+            LowerBound e -> do
+              unless (e > lowerBound) $
+                throwError $ mconcat [
+                    "Invalid safeBeforeEpoch in "
+                  , show curParams
+                  , " (should be greater than "
+                  , show lowerBound
+                  ,  ")"
+                  ]
+              return $ e
+
+        case shape of
+          ExactlyOne _        -> return ()
+          ExactlySuc _ shape' -> go nextLowerBound shape'
+      where
+        curParams :: EraParams
+        curParams = exactlyHead shape
+
+-- | Check 'Summary' invariants
+invariantSummary :: Summary xs -> Except String ()
+invariantSummary = \s@(Summary summary) ->
+    go (initBound (summarySystemStart s)) summary
+  where
+    go :: Bound   -- ^ End of the previous era
+       -> AtMost xs EraSummary -> Except String ()
+    go prevEnd summary = do
+        unless (curStart == prevEnd) $
+          throwError $ mconcat [
+              "Bounds don't line up: "
+            , show prevEnd
+            , " /= "
+            , show curStart
+            ]
+
+        unless (boundEpoch curEnd > boundEpoch curStart) $
+          throwError "Empty era"
+
+        case safeBeforeEpoch (eraSafeZone curParams) of
+          NoLowerBound -> return ()
+          LowerBound e ->
+              unless (boundEpoch curEnd >= e) $
+                throwError $ mconcat [
+                    "Invalid upper epoch bound "
+                  , show (boundEpoch curStart)
+                  , " (should be greater than "
+                  , show e
+                  , ")"
+                  ]
+
+        unless (boundSlot curEnd == addSlots slotsInEra (boundSlot curStart)) $
+          throwError $ mconcat [
+              "Invalid final boundSlot in "
+            , show curSummary
+            ]
+
+        unless (boundTime curEnd == addUTCTime timeInEra (boundTime curStart)) $
+          throwError $ mconcat [
+              "Invalid final boundTime in "
+            , show curSummary
+            ]
+
+        case summary of
+          AtMostOne _      -> return ()
+          AtMostSuc _ next -> go curEnd next
+      where
+        curSummary :: EraSummary
+        curSummary = atMostHead summary
+
+        curStart, curEnd :: Bound
+        curParams        :: EraParams
+        EraSummary curStart curEnd curParams = curSummary
+
+        epochsInEra, slotsInEra :: Word64
+        epochsInEra = countEpochs (boundEpoch curEnd) (boundEpoch curStart)
+        slotsInEra  = epochsInEra * unEpochSize (eraEpochSize curParams)
+
+        timeInEra :: NominalDiffTime
+        timeInEra = fromIntegral slotsInEra
+                  * getSlotLength (eraSlotLength curParams)
+
+{-------------------------------------------------------------------------------
+  Internal: constructing the summary
+-------------------------------------------------------------------------------}
+
+newtype SystemStart = SystemStart { getSystemStart :: UTCTime }
+  deriving (Show)
+
+-- | Construct hard fork 'Summary'
+--
+-- NOTE (on epoch to slot translation). In order to translate 'SlotNo' to
+-- 'EpochNo', we simply "line up" all slots. For example, suppose we have
+-- an initial 'EpochSize' of 10, and then an 'EpochSize' of 20 from 'EpochNo'
+-- 3 onwards. We end up with something like
+--
+-- > Epoch | 0      | 1        | 2        | 3        | 4        | ..
+-- > Slot  | 0 .. 9 | 10 .. 19 | 20 .. 29 | 30 .. 49 | 50 .. 69 | ..
+--
+-- We do this translation /independent/ from the 'minimumPossibleSlotNo'
+-- for a particular ledger. This means that for ledgers where the
+-- 'minimumPossibleSlotNo' is not zero (e.g., Shelley sets it to 1), the maximum
+-- number of blocks (aka filled slots) in an epoch is just 1 (or more) less
+-- than the other epochs.
+summarize :: SystemStart
+          -> WithOrigin SlotNo -- ^ Slot at the tip of the ledger
+          -> Shape       xs
+          -> Transitions xs
+          -> Summary     xs
+summarize start ledgerTip = \(Shape shape) (Transitions transitions) ->
+    Summary $ go (initBound start) shape transitions
+  where
+    go :: Bound
+       -> Exactly  xs EraParams
+       -> LessThan xs EpochNo
+       -> AtMost   xs EraSummary
+    -- CASE (ii)
+    -- NOTE: Ledger tip might be close to the end of this era (or indeed past
+    -- it) but this doesn't matter for the summary of /this/ era.
+    go lo (ExactlySuc params ss) (LessThanSuc epoch fs) =
+        AtMostSuc (EraSummary lo hi params) $ go hi ss fs
+      where
+        hi = mkUpperBound params lo epoch
+    -- CASE (i) or (iii)
+    go lo (exactlyHead -> params@EraParams{..}) LessThanOne =
+        AtMostOne (EraSummary lo hi params)
+      where
+        hi :: Bound
+        hi = mkUpperBound params lo
+           . maxMaybeEpoch (safeBeforeEpoch eraSafeZone)
+           . slotToEpochBound params lo
+           . addSlots (safeFromTip eraSafeZone)
+             -- If the tip is already in this era, safe zone applies from the
+             -- ledger tip (CASE (i)). If the ledger tip is in the /previous/
+             -- era, but the transition to /this/ era is already known, the safe
+             -- zone applies from the start of this era (CASE (iii)).
+           $ maxMaybeSlot ledgerTip (boundSlot lo)
+    go _ (ExactlyOne _) (LessThanSuc _ fs) =
+        absurd $ lessThanEmpty fs
+
+    -- Given the 'SlotNo' of the first /slot/ in which a transition could take
+    -- place, compute the first /epoch/ in which this could happen (since
+    -- transitions only take place at epoch boundaries). If the 'SlotNo' happens
+    -- to be the first slot in an epoch, it will be that 'EpochNo'; if it isn't,
+    -- however, it will be the /next/ epoch.
+    slotToEpochBound :: EraParams -> Bound -> SlotNo -> EpochNo
+    slotToEpochBound EraParams{eraEpochSize = EpochSize epochSize} lo hiSlot =
+        addEpochs
+          (if inEpoch == 0 then epochs else epochs + 1)
+          (boundEpoch lo)
+      where
+        slots             = countSlots hiSlot (boundSlot lo)
+        (epochs, inEpoch) = slots `divMod` epochSize
+
+    maxMaybeEpoch :: SafeBeforeEpoch -> EpochNo -> EpochNo
+    maxMaybeEpoch NoLowerBound   = id
+    maxMaybeEpoch (LowerBound e) = max e
+
+    maxMaybeSlot :: WithOrigin SlotNo -> SlotNo -> SlotNo
+    maxMaybeSlot Origin = id
+    maxMaybeSlot (At s) = max s
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+addSlots  :: Word64 -> SlotNo  -> SlotNo
+addEpochs :: Word64 -> EpochNo -> EpochNo
+
+addSlots  n (SlotNo  x) = SlotNo  (x + n)
+addEpochs n (EpochNo x) = EpochNo (x + n)
+
+countSlots  :: SlotNo  -> SlotNo  -> Word64
+countEpochs :: EpochNo -> EpochNo -> Word64
+
+countSlots  (SlotNo  to) (SlotNo  fr) = assert (to >= fr) $ to - fr
+countEpochs (EpochNo to) (EpochNo fr) = assert (to >= fr) $ to - fr
+
+{-------------------------------------------------------------------------------
+  Internal: looking up values in the history
+-------------------------------------------------------------------------------}
+
+data Condition =
+    ContainsTime  UTCTime
+  | ContainsSlot  SlotNo
+  | ContainsEpoch EpochNo
+  deriving (Show)
+
+eval :: Condition -> EraSummary -> Bool
+eval condition EraSummary{..} =
+    case condition of
+      ContainsTime  x -> boundTime  `contains` x
+      ContainsSlot  x -> boundSlot  `contains` x
+      ContainsEpoch x -> boundEpoch `contains` x
+  where
+    contains :: Ord a => (Bound -> a) -> a -> Bool
+    f `contains` x = f eraStart <= x && x < f eraEnd
+
+find :: Summary xs -> Condition -> Except PastHorizonException EraSummary
+find summary condition =
+    case List.find (eval condition) (summaryToList summary) of
+      Nothing -> throwError $ PastHorizon summary condition
+      Just s  -> return s
+
+data PastHorizonException =
+    -- | We tried to convert something that is past the horizon
+    --
+    -- That is, we tried to convert something that is past the point in time
+    -- beyond which we lack information due to uncertainty about the next
+    -- hard fork.
+    --
+    -- We record both the hard fork summary and the thing that we are looking
+    -- for. Although both of these are internal types that can strictly speaking
+    -- leak out of the API through this exception, they are provided here
+    -- merely for debugging: if this exception is ever raised, it indicates
+    -- a bug somewhere.
+    forall xs. PastHorizon (Summary xs) Condition
+
+deriving instance Show PastHorizonException
+instance Exception PastHorizonException
+
+{-------------------------------------------------------------------------------
+  Conversion between wallclock and slots
+-------------------------------------------------------------------------------}
+
+-- | Translate 'UTCTime' to 'SlotNo'
+--
+-- Additionally returns the time spent in this slot.
+wallclockToSlot :: Summary xs
+                -> UTCTime
+                -> Except PastHorizonException (SlotNo, NominalDiffTime)
+wallclockToSlot summary time =
+    go <$> find summary (ContainsTime time)
+  where
+    go :: EraSummary -> (SlotNo, NominalDiffTime)
+    go EraSummary{..} = first toAbsSlot $ relTime `divMod'` slotLen
+      where
+        EraParams{..} = eraParams
+
+        toAbsSlot :: Word64 -> SlotNo
+        toAbsSlot relSlot = SlotNo $ unSlotNo (boundSlot eraStart) + relSlot
+
+        relTime, slotLen :: NominalDiffTime
+        relTime = time `diffUTCTime` (boundTime eraStart)
+        slotLen = getSlotLength eraSlotLength
+
+-- | Translate 'SlotNo' to the 'UTCTime' at the start of that slot
+--
+-- Additionally returns the length of the slot.
+slotToWallclock :: Summary xs
+                -> SlotNo
+                -> Except PastHorizonException (UTCTime, SlotLength)
+slotToWallclock summary slot =
+    go <$> find summary (ContainsSlot slot)
+  where
+    go :: EraSummary -> (UTCTime, SlotLength)
+    go EraSummary{..} = (
+          addUTCTime (fromIntegral relSlot * slotLen) (boundTime eraStart)
+        , eraSlotLength
+        )
+      where
+        EraParams{..} = eraParams
+
+        relSlot :: Word64
+        relSlot = unSlotNo slot - unSlotNo (boundSlot eraStart)
+
+        slotLen :: NominalDiffTime
+        slotLen = getSlotLength eraSlotLength
+
+{-------------------------------------------------------------------------------
+  Conversion between slots and epochs
+-------------------------------------------------------------------------------}
+
+-- | Translate 'SlotNo' to its corresponding 'EpochNo'
+--
+-- Additionally returns the relative slot within this epoch
+slotToEpoch :: Summary xs
+            -> SlotNo
+            -> Except PastHorizonException (EpochNo, Word64)
+slotToEpoch summary slot =
+    go <$> find summary (ContainsSlot slot)
+  where
+    go :: EraSummary -> (EpochNo, Word64)
+    go EraSummary{..} = first toAbsEpoch $ relSlot `divMod` epochSize
+      where
+        EraParams{..} = eraParams
+
+        toAbsEpoch :: Word64 -> EpochNo
+        toAbsEpoch relEpoch = EpochNo $ unEpochNo (boundEpoch eraStart) + relEpoch
+
+        relSlot, epochSize :: Word64
+        relSlot   = unSlotNo slot - unSlotNo (boundSlot eraStart)
+        epochSize = unEpochSize eraEpochSize
+
+-- | Translate 'EpochNo' to the 'SlotNo' of the first slot in that epoch
+--
+-- Additionally returns the size of the epoch.
+epochToSlot :: Summary xs
+            -> EpochNo
+            -> Except PastHorizonException (SlotNo, EpochSize)
+epochToSlot summary epoch =
+    go <$> find summary (ContainsEpoch epoch)
+  where
+    go :: EraSummary -> (SlotNo, EpochSize)
+    go EraSummary{..} = (
+          SlotNo $ unSlotNo (boundSlot eraStart) + relEpoch * epochSize
+        , eraEpochSize
+        )
+      where
+        EraParams{..} = eraParams
+
+        relEpoch, epochSize :: Word64
+        relEpoch  = unEpochNo epoch - unEpochNo (boundEpoch eraStart)
+        epochSize = unEpochSize eraEpochSize
+
+{-------------------------------------------------------------------------------
+  Translation to EpochInfo
+-------------------------------------------------------------------------------}
+
+-- | Construct 'EpochInfo' from a function that returns the hard fork summary
+--
+-- When a particular request fails with a 'PastHorizon' error, we ask for an
+-- updated summary, in the hope that the ledger state has advanced. If the query
+-- /still/ fails with that updated summary, the error is thrown as an exception.
+summaryToEpochInfo :: forall m xs. (MonadSTM m, MonadThrow m)
+                   => STM m (Summary xs) -> m (EpochInfo m)
+summaryToEpochInfo getSummary = do
+    initSummary <- atomically getSummary
+    var <- newTVarM initSummary
+    return $ mkInfo var
+  where
+    mkInfo :: StrictTVar m (Summary xs) -> EpochInfo m
+    mkInfo var = EpochInfo {
+          epochInfoSize  = withSummary var snd . flip epochToSlot
+        , epochInfoFirst = withSummary var fst . flip epochToSlot
+        , epochInfoEpoch = withSummary var fst . flip slotToEpoch
+        }
+
+    withSummary :: StrictTVar m (Summary xs)
+                -> (a -> b)
+                -> (Summary xs -> Except PastHorizonException a)
+                -> m b
+    withSummary var g f = do
+        summary <- atomically $ readTVar var
+        case runExcept $ f summary of
+          Right a -> return (g a)
+          Left  _ -> do
+            -- Perhaps the ledger has advanced. Ask for a new summary
+            summary' <- atomically $ getSummary
+            atomically $ writeTVar var summary'
+            case runExcept $ f summary' of
+              Right a -> return (g a)
+              Left  e -> throwM e
+
+-- | Construct an 'EpochInfo' for a /snapshot/ of the ledger state
+--
+-- When a particular request fails with a 'PastHorizon' error, we throw the
+-- error as a /pure/ exception. Such an exception would indicate a bug.
+snapshotEpochInfo :: forall xs. Summary xs -> EpochInfo Identity
+snapshotEpochInfo summary = EpochInfo {
+      epochInfoSize  = throwPastHorizon snd . flip epochToSlot
+    , epochInfoFirst = throwPastHorizon fst . flip epochToSlot
+    , epochInfoEpoch = throwPastHorizon fst . flip slotToEpoch
+    }
+  where
+    throwPastHorizon :: (a -> b)
+                     -> (Summary xs -> Except PastHorizonException a)
+                     -> Identity b
+    throwPastHorizon g f =
+        case runExcept $ f summary of
+          Right a -> Identity $ g a
+          Left  e -> throw e

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -262,6 +262,7 @@ castHeaderEnvelopeError = \case
         expected' = castHash expected
         actual'   = castHash actual
 
+-- | Validate header envelope (block, slot, hash)
 class HasAnnTip blk => ValidateEnvelope blk where
   -- | Validate the header envelope
   validateEnvelope :: BlockConfig blk
@@ -275,8 +276,8 @@ class HasAnnTip blk => ValidateEnvelope blk where
 
   -- | The smallest possible 'SlotNo'
   --
-  -- The /actual/ 'SlotNo' of the first block on the chain may well be larger
-  -- than this value of course (if some slots were empty)
+  -- NOTE: This does not affect the translation between 'SlotNo' and 'EpochNo'.
+  -- "Ouroboros.Consensus.HardFork.History" for details.
   minimumPossibleSlotNo :: Proxy blk -> SlotNo
   minimumPossibleSlotNo _ = SlotNo 0
 
@@ -309,7 +310,7 @@ class HasAnnTip blk => ValidateEnvelope blk where
           case oldTip of
             At (AnnTip s h b _) -> ( succ s, succ b, BlockHash h )
             Origin              -> ( minimumPossibleSlotNo proxy
-                                   , firstBlockNo proxy
+                                   , firstBlockNo          proxy
                                    , GenesisHash
                                    )
         where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -393,6 +393,18 @@ instance Bridge m a => LedgerSupportsProtocol (DualBlock m a) where
         (dualLedgerConfigMain cfg)
         (dualLedgerStateMain  state)
 
+instance Bridge m a => HasHardForkHistory (DualBlock m a) where
+  type HardForkIndices (DualBlock m a) = HardForkIndices m
+
+  hardForkShape cfg =
+      hardForkShape
+        (dualBlockConfigMain cfg)
+
+  hardForkTransitions cfg state =
+      hardForkTransitions
+        (dualLedgerConfigMain cfg)
+        (dualLedgerStateMain  state)
+
 instance Bridge m a => LedgerDerivedInfo (DualBlock m a) where
   knownSlotLengths cfg =
       knownSlotLengths

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/LedgerDerivedInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/LedgerDerivedInfo.hs
@@ -1,12 +1,39 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies     #-}
+
 module Ouroboros.Consensus.Node.LedgerDerivedInfo (
-    LedgerDerivedInfo(..)
+    HasHardForkHistory(..)
+  , LedgerDerivedInfo(..)
   ) where
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
+import           Ouroboros.Consensus.HardFork.History as HardFork
+import           Ouroboros.Consensus.Ledger.Abstract
+
+class HasHardForkHistory blk where
+  -- | Type level description of the hard fork shape
+  --
+  -- The exact way in which this will used will be determined once we have the
+  -- proper hard fork combinator, but intuitively it would be something like
+  -- @'[Byron, Shelley, Goguen]@.
+  type family HardForkIndices blk :: [*]
+
+  -- | Static (ledger independent) hard fork shape
+  hardForkShape :: BlockConfig blk
+                -> HardFork.Shape (HardForkIndices blk)
+
+  -- | Ledger-dependent hard fork transitions
+  --
+  -- TODO: This should eventually obsolete 'knownSlotLengths'
+  -- TODO: This should eventually address #1205
+  hardForkTransitions :: LedgerConfig blk
+                      -> LedgerState blk
+                      -> HardFork.Transitions (HardForkIndices blk)
 
 -- | Information the node requires to run which is dependent on the ledger state
-class LedgerDerivedInfo blk where
+class HasHardForkHistory blk => LedgerDerivedInfo blk where
   -- | The known slot length
   --
   -- TODO: This should take the LedgerState as argument

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Counting.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Counting.hs
@@ -1,0 +1,206 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE EmptyCase           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeOperators       #-}
+
+-- | Type-level counting
+module Ouroboros.Consensus.Util.Counting (
+    AtMost(..)
+  , LessThan(..)
+  , Exactly(..)
+    -- * Working with 'AtMost'
+  , atMostInit
+  , atMostHead
+  , atMostLast
+  , atMostMarkLast
+  , atMostZipExactly
+  , atMostMapMaybe
+  , atMostBetween
+    -- * Working with 'LessThan'
+  , lessThanEmpty
+  , lessThanNarrow
+    -- * Working with 'Exactly'
+  , exactlyHead
+  , exactlyZip
+  , exactlyZipList
+  ) where
+
+import           Data.List.NonEmpty (NonEmpty (..))
+import           Data.Void
+
+{-------------------------------------------------------------------------------
+  Type-level counting
+-------------------------------------------------------------------------------}
+
+-- | At most one value for each type level index, and at least one
+data AtMost :: [*] -> * -> * where
+  AtMostOne :: !a -> AtMost (x ': xs) a
+  AtMostSuc :: !a -> !(AtMost xs a) -> AtMost (x ': xs) a
+
+-- | Strictly less than one value for each type level index (possibly none)
+data LessThan :: [*] -> * -> * where
+  LessThanOne :: LessThan (x ': xs) a
+  LessThanSuc :: !a -> LessThan xs a -> LessThan (x ': xs) a
+
+-- | Exactly one value for each type levle index
+data Exactly :: [*] -> * -> * where
+  ExactlyOne :: !a -> Exactly '[x] a
+  ExactlySuc :: !a -> !(Exactly xs a) -> Exactly (x ': xs) a
+
+deriving instance Show a => Show (AtMost   xs a)
+deriving instance Show a => Show (LessThan xs a)
+deriving instance Show a => Show (Exactly  xs a)
+
+{-------------------------------------------------------------------------------
+  Working with 'AtMost'
+-------------------------------------------------------------------------------}
+
+instance Functor (AtMost xs) where
+  fmap f (AtMostOne a)    = AtMostOne (f a)
+  fmap f (AtMostSuc a as) = AtMostSuc (f a) (fmap f as)
+
+instance Foldable (AtMost xs) where
+  foldMap f (AtMostOne a)    = f a
+  foldMap f (AtMostSuc a as) = f a <> foldMap f as
+
+-- | Analogue of 'init' on lists
+--
+-- The type level index can stay the same since it's an upper bound only.
+atMostInit :: AtMost xs a -> (Maybe (AtMost xs a), a)
+atMostInit (AtMostOne a)    = (Nothing, a)
+atMostInit (AtMostSuc a as) =
+    case atMostInit as of
+      (Nothing , lastA) -> (Just (AtMostOne a), lastA)
+      (Just as', lastA) -> (Just (AtMostSuc a as'), lastA)
+
+-- | Analogue of 'head'
+atMostHead :: AtMost xs a -> a
+atMostHead (AtMostOne a)   = a
+atMostHead (AtMostSuc a _) = a
+
+-- | Analogue of 'last'
+atMostLast :: AtMost xs a -> a
+atMostLast = go
+  where
+    go :: AtMost xs a -> a
+    go (AtMostOne a)    = a
+    go (AtMostSuc _ as) = go as
+
+-- | Mark the last value
+--
+-- Primarily useful in combination with 'atMostBetween'
+atMostMarkLast :: AtMost xs a -> AtMost xs (a, Bool)
+atMostMarkLast = go
+  where
+    go :: AtMost xs a -> AtMost xs (a, Bool)
+    go (AtMostOne a)    = AtMostOne (a, True)
+    go (AtMostSuc a as) = AtMostSuc (a, False) (go as)
+
+-- | Construct a @b@ for every pair of adjacent @a@s
+atMostBetween :: forall xs a b. (a -> a -> b) -> AtMost xs a -> LessThan xs b
+atMostBetween f = \case
+    AtMostOne _    -> LessThanOne
+    AtMostSuc a as -> go a as
+  where
+    go :: forall x xs'. a -> AtMost xs' a -> LessThan (x ': xs') b
+    go a (AtMostOne a')    = LessThanSuc (f a a') LessThanOne
+    go a (AtMostSuc a' as) = LessThanSuc (f a a') (go a' as)
+
+atMostZipExactly :: Exactly xs a -> AtMost xs b -> AtMost xs (a, b)
+atMostZipExactly = go
+  where
+    go :: Exactly xs a -> AtMost xs b -> AtMost xs (a, b)
+    go (ExactlyOne a)    (AtMostOne b)    = AtMostOne (a, b)
+    go (ExactlySuc a _)  (AtMostOne b)    = AtMostOne (a, b)
+    go (ExactlySuc a as) (AtMostSuc b bs) = AtMostSuc (a, b) (go as bs)
+    go (ExactlyOne _)    (AtMostSuc _ bs) = absurd $ atMostEmpty bs
+
+atMostMapMaybe :: forall xs x a b.
+                  (a -> Maybe b) -> AtMost xs a -> LessThan (x ': xs) b
+atMostMapMaybe f = go
+  where
+    go :: forall xs' x'. AtMost xs' a -> LessThan (x' ': xs') b
+    go (AtMostOne a) =
+        case f a of
+          Nothing -> LessThanOne
+          Just b  -> LessThanSuc b LessThanOne
+    go (AtMostSuc a as) =
+        case f a of
+          Nothing -> LessThanOne
+          Just b  -> LessThanSuc b (go as)
+
+atMostEmpty :: AtMost '[] a -> Void
+atMostEmpty = \case {}
+
+{-------------------------------------------------------------------------------
+  Working with 'LessThan'
+-------------------------------------------------------------------------------}
+
+instance Functor (LessThan xs) where
+  fmap _ LessThanOne        = LessThanOne
+  fmap f (LessThanSuc a as) = LessThanSuc (f a) (fmap f as)
+
+instance Foldable (LessThan xs) where
+  foldMap _ LessThanOne        = mempty
+  foldMap f (LessThanSuc a as) = f a <> foldMap f as
+
+lessThanEmpty :: LessThan '[] a -> Void
+lessThanEmpty = \case {}
+
+-- | Narrow
+--
+-- The first argument is merely there as a (term-level) counter (a singleton).
+lessThanNarrow :: Exactly xs a -> LessThan (x ': xs) b -> Maybe (LessThan xs b)
+lessThanNarrow = go
+  where
+    go :: Exactly xs a -> LessThan (x ': xs) b -> Maybe (LessThan xs b)
+    -- We want one value fewer than 1, and we have 0; perfect
+    go (ExactlyOne _)    LessThanOne        = Just LessThanOne
+    -- We want one value fewer than (n + 1); we have 0; perfect
+    go (ExactlySuc _ _)  LessThanOne        = Just LessThanOne
+    -- We want one value fewer than 1, but we have at least 1; failure
+    go (ExactlyOne _)    (LessThanSuc _ _)  = Nothing
+    -- Recurse
+    go (ExactlySuc _ as) (LessThanSuc b bs) = (LessThanSuc b) <$> go as bs
+
+{-------------------------------------------------------------------------------
+  Working with 'Exactly'
+-------------------------------------------------------------------------------}
+
+instance Functor (Exactly xs) where
+  fmap f (ExactlyOne a)    = ExactlyOne (f a)
+  fmap f (ExactlySuc a as) = ExactlySuc (f a) (fmap f as)
+
+instance Foldable (Exactly xs) where
+  foldMap f (ExactlyOne a)    = f a
+  foldMap f (ExactlySuc a as) = f a <> foldMap f as
+
+-- | Analogue of 'head'
+exactlyHead :: Exactly xs a -> a
+exactlyHead (ExactlyOne a)   = a
+exactlyHead (ExactlySuc a _) = a
+
+exactlyZip :: Exactly xs a -> Exactly xs b -> Exactly xs (a, b)
+exactlyZip = go
+  where
+    go :: Exactly xs a -> Exactly xs b -> Exactly xs (a, b)
+    go (ExactlyOne a)    (ExactlyOne b)    = ExactlyOne (a, b)
+    go (ExactlySuc a as) (ExactlySuc b bs) = ExactlySuc (a, b) (go as bs)
+    go (ExactlyOne _)    (ExactlySuc _ bs) = absurd $ exactlyEmpty bs
+    go (ExactlySuc _ as) (ExactlyOne _)    = absurd $ exactlyEmpty as
+
+exactlyZipList :: Exactly xs a -> NonEmpty b -> AtMost xs (a, b)
+exactlyZipList = go
+  where
+    go :: Exactly xs a -> NonEmpty b -> AtMost xs (a, b)
+    go (ExactlyOne a)    (b :| _)         = AtMostOne (a, b)
+    go (ExactlySuc a _)  (b :| [])        = AtMostOne (a, b)
+    go (ExactlySuc a as) (b :| (b' : bs)) = AtMostSuc (a, b) (go as (b' :| bs))
+
+exactlyEmpty :: Exactly '[] a -> Void
+exactlyEmpty = \case {}

--- a/ouroboros-consensus/test-consensus/Main.hs
+++ b/ouroboros-consensus/test-consensus/Main.hs
@@ -4,6 +4,7 @@ import           Test.Tasty
 
 import qualified Test.Consensus.BlockchainTime.SlotLengths (tests)
 import qualified Test.Consensus.BlockchainTime.WallClock (tests)
+import qualified Test.Consensus.HardFork.History (tests)
 import qualified Test.Consensus.Mempool (tests)
 import qualified Test.Consensus.MiniProtocol.ChainSync.Client (tests)
 import qualified Test.Consensus.MiniProtocol.LocalStateQuery.Server (tests)
@@ -27,4 +28,5 @@ tests =
   , Test.Consensus.Protocol.PBFT.tests
   , Test.Consensus.ResourceRegistry.tests
   , Test.Consensus.Util.Versioned.tests
+  , Test.Consensus.HardFork.History.tests
   ]

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/History.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/History.hs
@@ -1,0 +1,837 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeOperators              #-}
+
+module Test.Consensus.HardFork.History (tests) where
+
+import           Control.Monad.Except
+import           Data.Foldable (toList)
+import           Data.Function (on)
+import           Data.Functor.Const
+import           Data.Functor.Identity
+import qualified Data.List as L
+import           Data.List.NonEmpty (NonEmpty (..))
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (catMaybes)
+import           Data.Time
+import           Data.Word
+
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Consensus.BlockchainTime.SlotLength
+import           Ouroboros.Consensus.HardFork.History (ShiftTime (..))
+import qualified Ouroboros.Consensus.HardFork.History as HF
+import           Ouroboros.Consensus.Util.Counting
+
+import           Test.Util.Orphans.Arbitrary
+
+tests :: TestTree
+tests = testGroup "HardForkHistory" [
+      testGroup "Summary" [
+          testGroup "Sanity" [
+              testProperty "generator" $ checkGenerator $ \ArbitrarySummary{..} ->
+                checkInvariant HF.invariantSummary arbitrarySummary
+            , testProperty "shrinker"  $ checkShrinker $ \ArbitrarySummary{..} ->
+                checkInvariant HF.invariantSummary arbitrarySummary
+            ]
+        , testGroup "Conversions" [
+              testProperty "roundtripWallclockSlot" roundtripWallclockSlot
+            , testProperty "roundtripSlotWallclock" roundtripSlotWallclock
+            , testProperty "roundtripSlotEpoch"     roundtripSlotEpoch
+            , testProperty "roundtripEpochSlot"     roundtripEpochSlot
+            , testProperty "reportsPastHorizon"     reportsPastHorizon
+            ]
+        ]
+    , testGroup "Chain" [
+          testGroup "Sanity" [
+              testProperty "generator" $ checkGenerator $ \ArbitraryChain{..} ->
+                checkInvariant HF.invariantShape arbitraryChainShape
+            , testProperty "shrinker"  $ checkShrinker $ \ArbitraryChain{..} ->
+                checkInvariant HF.invariantShape arbitraryChainShape
+            ]
+        , testGroup "Conversions" [
+              testProperty "summarizeInvariant" summarizeInvariant
+            , testProperty "eventSlotToEpoch"     eventSlotToEpoch
+            , testProperty "eventEpochToSlot"     eventEpochToSlot
+            , testProperty "eventSlotToWallclock" eventSlotToWallclock
+            , testProperty "eventWallclockToSlot" eventWallclockToSlot
+            ]
+        ]
+    ]
+
+{-------------------------------------------------------------------------------
+  Sanity checks
+
+  Explicit 'forAll' here since we don't want to assume that the shrinker is
+  correct here.
+-------------------------------------------------------------------------------}
+
+-- | Test the generator
+checkGenerator :: (Arbitrary a, Show a) => (a -> Property) -> Property
+checkGenerator p = forAll arbitrary $ p
+
+-- | Test the shrinker
+checkShrinker :: (Arbitrary a, Show a) => (a -> Property) -> Property
+checkShrinker p = forAll arbitrary $ conjoin . map p . shrink
+
+checkInvariant :: (a -> Except String ()) -> (a -> Property)
+checkInvariant f a =
+    case runExcept (f a) of
+      Left err -> counterexample err $ property False
+      Right () -> property True
+
+{-------------------------------------------------------------------------------
+  Tests using just 'Summary'
+-------------------------------------------------------------------------------}
+
+roundtripWallclockSlot :: ArbitrarySummary -> Property
+roundtripWallclockSlot ArbitrarySummary{ arbitrarySummary = summary
+                                       , beforeHorizonTime = time
+                                       } = noPastHorizonException $ do
+    (slot  ,  inSlot ) <- HF.wallclockToSlot summary time
+    (time' , _slotLen) <- HF.slotToWallclock summary slot
+    return $ addUTCTime inSlot time' === time
+
+roundtripSlotWallclock :: ArbitrarySummary -> Property
+roundtripSlotWallclock ArbitrarySummary{ arbitrarySummary  = summary
+                                       , beforeHorizonSlot = slot
+                                       } = noPastHorizonException $ do
+    (time  , _slotLen) <- HF.slotToWallclock summary slot
+    (slot' ,  inSlot ) <- HF.wallclockToSlot summary time
+    return $ slot' === slot .&&. inSlot === 0
+
+roundtripSlotEpoch :: ArbitrarySummary -> Property
+roundtripSlotEpoch ArbitrarySummary{ arbitrarySummary  = summary
+                                   , beforeHorizonSlot = slot
+                                   } = noPastHorizonException $ do
+    (epoch ,  inEpoch  ) <- HF.slotToEpoch summary slot
+    (slot' , _epochSize) <- HF.epochToSlot summary epoch
+    return $ HF.addSlots inEpoch slot' === slot
+
+roundtripEpochSlot :: ArbitrarySummary -> Property
+roundtripEpochSlot ArbitrarySummary{ arbitrarySummary   = summary
+                                   , beforeHorizonEpoch = epoch
+                                   } = noPastHorizonException $ do
+    (slot  , _epochSize) <- HF.epochToSlot summary epoch
+    (epoch',  inEpoch  ) <- HF.slotToEpoch summary slot
+    return $ epoch' === epoch .&&. inEpoch === 0
+
+reportsPastHorizon :: ArbitrarySummary -> Property
+reportsPastHorizon ArbitrarySummary{..} = conjoin [
+      isPastHorizonException $
+        HF.wallclockToSlot arbitrarySummary pastHorizonTime
+    , isPastHorizonException $
+        HF.slotToWallclock arbitrarySummary pastHorizonSlot
+    , isPastHorizonException $
+        HF.slotToEpoch arbitrarySummary pastHorizonSlot
+    , isPastHorizonException $
+        HF.epochToSlot arbitrarySummary pastHorizonEpoch
+    ]
+
+noPastHorizonException :: Except HF.PastHorizonException Property -> Property
+noPastHorizonException mProp =
+    case runExcept mProp of
+      Right prop -> prop
+      Left  ex   -> counterexample ("Unexpected " ++ show ex) $ property False
+
+isPastHorizonException :: Show a => Except HF.PastHorizonException a -> Property
+isPastHorizonException ma =
+    case runExcept ma of
+      Right a -> counterexample ("Unexpected " ++ show a) $ property False
+      Left _  -> property True
+
+{-------------------------------------------------------------------------------
+  Properties of summarize
+
+  TODO: We should strengten these tests: at the moment, the summary is
+  constructed from the /entire/ blockchain, and then applied to any of the
+  events in the blockchain. That is good, but we should additionally construct
+  the summary from a /prefix/ of the blockchain and then verify that we can
+  still convert events /after/ that prefix (up to the safe zone).
+-------------------------------------------------------------------------------}
+
+-- | Check that 'summarize' establishes 'invariantSummary'
+summarizeInvariant :: ArbitraryChain -> Property
+summarizeInvariant chain =
+    withArbitraryChainSummary chain $
+      checkInvariant HF.invariantSummary
+
+eventSlotToEpoch :: ArbitraryChain -> Property
+eventSlotToEpoch chain@ArbitraryChain{..} =
+    withArbitraryChainSummary chain $ \summary ->
+      noPastHorizonException $ do
+        (epoch, relSlot) <- HF.slotToEpoch summary eventAbsSlot
+        return $ epoch === eventEpoch .&&. relSlot === eventRelSlot
+  where
+    (EventTime{..}, _, _) = arbitraryChainPre !! arbitraryEventIx
+
+eventEpochToSlot :: ArbitraryChain -> Property
+eventEpochToSlot chain@ArbitraryChain{..} =
+    withArbitraryChainSummary chain $ \summary ->
+      noPastHorizonException $ do
+        (startOfEpoch, EpochSize epochSize) <- HF.epochToSlot summary eventEpoch
+        return $ eventAbsSlot === HF.addSlots eventRelSlot startOfEpoch
+            .&&. eventRelSlot < epochSize
+  where
+    (EventTime{..}, _, _) = arbitraryChainPre !! arbitraryEventIx
+
+eventSlotToWallclock :: ArbitraryChain -> Property
+eventSlotToWallclock chain@ArbitraryChain{..} =
+    withArbitraryChainSummary chain $ \summary ->
+      noPastHorizonException $ do
+        (time, _slotLen) <- HF.slotToWallclock summary eventAbsSlot
+        return $ time === eventTime
+  where
+    (EventTime{..}, _, _) = arbitraryChainPre !! arbitraryEventIx
+
+eventWallclockToSlot :: ArbitraryChain -> Property
+eventWallclockToSlot chain@ArbitraryChain{..} =
+    withArbitraryChainSummary chain $ \summary ->
+      noPastHorizonException $ do
+        (slot, inSlot) <- HF.wallclockToSlot summary eventTime
+        return $ slot === eventAbsSlot .&&. inSlot === 0
+  where
+    (EventTime{..}, _, _) = arbitraryChainPre !! arbitraryEventIx
+
+{-------------------------------------------------------------------------------
+  Arbitrary chain
+-------------------------------------------------------------------------------}
+
+data ArbitraryChain = forall xs. ArbitraryChain {
+      arbitraryChainStart :: HF.SystemStart
+    , arbitraryChainPre   :: PreChain
+    , arbitraryChainEras  :: Eras     xs
+    , arbitraryChainShape :: HF.Shape xs
+    , arbitraryChain      :: Chain    xs
+
+      -- Index into the 'PreChain' of events
+      -- Guaranteed to be within bounds
+    , arbitraryEventIx    :: Int
+    }
+
+deriving instance Show ArbitraryChain
+
+withArbitraryChainSummary :: ArbitraryChain
+                          -> (forall xs'. HF.Summary xs' -> a)
+                          -> a
+withArbitraryChainSummary ArbitraryChain{arbitraryChainEras = eras :: Eras xs, ..} f =
+    f summary
+  where
+    transitions :: HF.Transitions xs
+    transitions = chainTransitions eras arbitraryChain
+
+    tip :: WithOrigin SlotNo
+    tip = chainTip arbitraryChain
+
+    summary :: HF.Summary xs
+    summary = HF.summarize
+                arbitraryChainStart
+                tip
+                arbitraryChainShape
+                transitions
+
+instance Arbitrary ArbitraryChain where
+  arbitrary = chooseEras $ \eras -> do
+      start    <- HF.SystemStart <$> arbitrary
+      shape    <- genShape genParams (EpochNo 0) eras
+      preChain <- genPreChain start eras shape `suchThat` (not . null)
+      eventIx  <- choose (0, length preChain - 1)
+      return ArbitraryChain {
+          arbitraryChainStart   = start
+        , arbitraryChainPre     = preChain
+        , arbitraryChainEras    = eras
+        , arbitraryChainShape   = shape
+        , arbitraryChain        = fromPreChain eras preChain
+        , arbitraryEventIx      = eventIx
+        }
+    where
+      genParams :: Era -> EpochNo -> Gen (EpochNo, HF.EraParams)
+      genParams _era startOfThis = do
+          params      <- genEraParams      startOfThis
+          startOfNext <- genStartOfNextEra startOfThis params
+          return (startOfNext, params)
+
+  shrink c@ArbitraryChain{..} = concat [
+        -- Simplify the system start
+        [ resetArbitraryChainStart c
+        | HF.getSystemStart arbitraryChainStart /= dawnOfTime
+        ]
+
+        -- Pick an earlier event
+      , [ c { arbitraryEventIx = eventIx' }
+        | eventIx' <- shrink arbitraryEventIx
+        ]
+
+        -- Shrink the chain
+        -- We shrink the pre-chain, then re-generate the chain
+      , [ ArbitraryChain{ arbitraryChain    = fromPreChain
+                                                arbitraryChainEras
+                                                preChain'
+                        , arbitraryChainPre = preChain'
+                        , ..
+                        }
+        | preChain' <- init (L.inits arbitraryChainPre)
+        , arbitraryEventIx < length preChain'
+        ]
+      ]
+
+{-------------------------------------------------------------------------------
+  Chain model: Events
+-------------------------------------------------------------------------------}
+
+-- | We don't model a chain as a list of blocks, but rather as a list of events
+data Event f =
+    -- | Nothing of interest happens, time just ticks
+    Tick
+
+    -- | A new hard fork transition is confirmed
+    --
+    -- "Confirmed" here is taken to mean "no longer subject to rollback",
+    -- which is the concept that the hard fork history depends on.
+  | Confirm (f EpochNo)
+
+deriving instance Show a => Show (Event (Const a))
+deriving instance Show (Event Identity)
+
+-- | When did an event occur?
+--
+-- NOTE: We don't care about 'BlockNo' here. Our events don't record necessarily
+-- whether a block is actually present in a given slot or not.
+data EventTime = EventTime {
+      eventAbsSlot :: SlotNo
+    , eventEpoch   :: EpochNo
+    , eventRelSlot :: Word64
+    , eventTime    :: UTCTime
+    , eventEra     :: Era
+    }
+  deriving (Show)
+
+initTime :: HF.SystemStart -> Eras xs -> EventTime
+initTime (HF.SystemStart start) eras = EventTime {
+      eventAbsSlot = SlotNo  0
+    , eventEpoch   = EpochNo 0
+    , eventRelSlot = 0
+    , eventTime    = start
+    , eventEra     = exactlyHead eras
+    }
+
+-- | Next time slot
+--
+-- We assume the era does not change (this is done separately in 'genChain')
+stepTime :: HF.EraParams -> EventTime -> EventTime
+stepTime HF.EraParams{..} EventTime{..} = EventTime{
+      eventAbsSlot = succ eventAbsSlot
+    , eventEpoch   = epoch'
+    , eventRelSlot = relSlot'
+    , eventTime    = addUTCTime (getSlotLength eraSlotLength) eventTime
+    , eventEra     = eventEra
+    }
+  where
+    epoch'   :: EpochNo
+    relSlot' :: Word64
+    (epoch', relSlot') =
+        if succ eventRelSlot == unEpochSize eraEpochSize
+          then (succ eventEpoch, 0)
+          else (eventEpoch, succ eventRelSlot)
+
+{-------------------------------------------------------------------------------
+  Chain model
+-----------------------------------------------------------------------------}
+
+-- | Chain divided into eras
+--
+-- Like 'Summary', we might not have blocks in the chain for all eras.
+newtype Chain xs = Chain (AtMost xs (Events Identity))
+  deriving (Show)
+
+-- | Slot at the tip of the chain
+chainTip :: Chain xs -> WithOrigin SlotNo
+chainTip (Chain xs) = tip . reverse . concat . toList $ xs
+  where
+    tip :: [(EventTime, HF.EraParams, Event Identity)] -> WithOrigin SlotNo
+    tip []            = Origin
+    tip ((t, _, _):_) = At (eventAbsSlot t)
+
+-- | Find all confirmed transitions in the chain
+chainTransitions :: Eras xs -> Chain xs -> HF.Transitions xs
+chainTransitions = \eras (Chain chain) -> HF.Transitions $
+      mustBeJust
+    . lessThanNarrow eras
+    . atMostMapMaybe findTransition'
+    . atMostMarkLast
+    $ atMostZipExactly eras chain
+  where
+    mustBeJust :: Maybe (LessThan xs EpochNo) -> LessThan xs EpochNo
+    mustBeJust (Just e) = e
+    mustBeJust Nothing  = error $ concat [
+          "impossible: we checked that the last epoch contains no transition"
+        ]
+
+    -- Find transition point
+    --
+    -- Every era on the chain except the last MUST have a transition point
+    -- The last era in the chain /shape/ must NOT have a transition point
+    findTransition' :: ((Era, Events Identity), Bool) -> Maybe EpochNo
+    findTransition' ((era, es), lastEraOnChain) =
+        case (eraIsLast era, lastEraOnChain, findTransition era es) of
+          (True, _, Just e) ->
+            error $ concat [
+                "Unexpected transition "
+              , show e
+              , " in final era "
+              , show era
+              ]
+          (_, False, Nothing) ->
+            error $ concat [
+                "Missing transition in era "
+              , show era
+              ]
+          (_, _, me) ->
+            me
+
+-- | Locate transition point in a list of events
+findTransition :: Era -> Events Identity -> Maybe EpochNo
+findTransition era = mustBeUnique . catMaybes . map isTransition
+  where
+    mustBeUnique :: [EpochNo] -> Maybe EpochNo
+    mustBeUnique []  = Nothing
+    mustBeUnique [e] = Just e
+    mustBeUnique _   = error $ "multiple transition points in " ++ show era
+
+    isTransition :: (EventTime, HF.EraParams, Event Identity) -> Maybe EpochNo
+    isTransition (_, _, Confirm (Identity e)) = Just e
+    isTransition (_, _, Tick)                 = Nothing
+
+patchEvents :: Events (Const ()) -> Events Identity
+patchEvents events = map go events
+  where
+    bounds :: Map Era (EpochNo, EpochNo)
+    bounds = eventsEraBounds events
+
+    go :: (EventTime, HF.EraParams, Event (Const ()))
+       -> (EventTime, HF.EraParams, Event Identity)
+    go (time, params, event) = (time, params, event')
+      where
+        event' :: Event Identity
+        event' =
+          case event of
+            Tick               -> Tick
+            Confirm (Const ()) -> Confirm . Identity $ snd $
+                                    bounds Map.! eventEra time
+
+fromPreChain :: Eras xs -> PreChain -> Chain xs
+fromPreChain eras preChain = Chain $
+    snd <$> exactlyZipList eras grouped'
+  where
+    grouped' :: NonEmpty (Events Identity)
+    grouped' = case grouped of
+                 []   -> [] :| []
+                 e:es -> e  :| es
+
+    grouped :: [Events Identity]
+    grouped = L.groupBy ((==) `on` (\(t, _, _) -> eventEra t)) preChain
+
+{-------------------------------------------------------------------------------
+  Pre-chain
+-------------------------------------------------------------------------------}
+
+type Events f = [(EventTime, HF.EraParams, Event f)]
+type PreChain = Events Identity
+
+-- | Inclusive lower bound and exclusive upper bound for each era
+eventsEraBounds :: Events (Const ()) -> Map Era (EpochNo, EpochNo)
+eventsEraBounds []    = Map.empty
+eventsEraBounds chain =
+      Map.fromList
+    . map bounds
+    . L.groupBy ((==) `on` (\(t, _, _) -> eventEra t))
+    $ chain
+  where
+    bounds :: Events (Const ()) -> (Era, (EpochNo, EpochNo))
+    bounds era = (
+          (\(t, _, _) -> eventEra t) $ head era
+        , (minimum epochs, succ $ maximum epochs) -- Upper bound is exclusive
+        )
+      where
+        epochs :: [EpochNo]
+        epochs = map (\(t, _, _) -> eventEpoch t) era
+
+genPreChain :: HF.SystemStart -> Eras xs -> HF.Shape xs -> Gen PreChain
+genPreChain start eras shape = do
+    events <- patchEvents <$> genEvents start eras shape
+    n      <- choose (0, length events) -- See comment in 'genEvents'
+    return $ take n events
+
+-- | Generate events
+--
+-- It is important that this generates events for all eras (only the number of
+-- events in the final era don't matter). If we don't do that, the bounds
+-- computed by 'eventsEraBounds' are incorrect, and 'patchEvents' will be
+-- do the wrong thing.
+--
+-- Therefore, to generate a shorter chain, we must generate a sufficient
+-- number of events, then patch them, and only then can we take a prefix.
+genEvents :: HF.SystemStart -> Eras xs -> HF.Shape xs -> Gen (Events (Const ()))
+genEvents = \start eras (HF.Shape shape) -> sized $ \sz -> do
+    eventsInFinalEra <- choose (0, fromIntegral sz)
+    go eventsInFinalEra (initTime start eras) NotYet (exactlyZip eras shape)
+  where
+    -- We first construct a 'PreChain' where we decide the moments of the
+    -- /announcements/ of the transition points, but not yet the transition
+    -- points themselves. We then patch up the chain as a post-processing step.
+    go :: Word64         -- ^ Number of events in final era
+       -> EventTime      -- ^ Current time
+       -> CanStartNewEra
+       -> Exactly xs (Era, HF.EraParams)
+       -> Gen (Events (Const ()))
+    go 0 _   _        _     = return []
+    go n now canStart shape = do
+        case shape of
+          ExactlySuc _ shape' | canStartNow && eventRelSlot now == 0 -> do
+            shouldStartNow <- arbitrary
+            if shouldStartNow
+              then go' n now NotYet    shape'
+              else go' n now canStart' shape
+          _otherwise ->
+            go' n now canStart' shape
+      where
+        (canStart', canStartNow) = stepCanStartNewEra (eventEpoch now) canStart
+
+    -- After having decided whether or not to start a new era
+    go' :: Word64
+        -> EventTime
+        -> CanStartNewEra
+        -> Exactly xs (Era, HF.EraParams)
+        -> Gen (Events (Const ()))
+    go' n now canStart shape = do
+        (event, canStart') <- frequency $ concat [
+            [ (2, return (Tick, canStart)) ]
+
+            -- Avoid starting a count-down if another one is already in process
+            -- The final era cannot contain any transitions
+          , [ (1, return (Confirm (Const ()), CanStartIf eraSafeZone))
+            | NotYet         <- [canStart]
+            , ExactlySuc _ _ <- [shape]
+            ]
+          ]
+        ((now { eventEra = era }, params, event) :) <$>
+          go n' (stepTime params now) canStart' shape
+      where
+        (era, params@HF.EraParams{..}) = exactlyHead shape
+        n' = if eraIsLast era
+               then n - 1
+               else n
+
+
+data CanStartNewEra =
+    -- | The announcement of the transition hasn't yet happened
+    NotYet
+
+    -- | The announcement has happened
+    --
+    -- We must observe the 'SafeZone'
+  | CanStartIf HF.SafeZone
+
+stepCanStartNewEra :: EpochNo -> CanStartNewEra -> (CanStartNewEra, Bool)
+stepCanStartNewEra _            NotYet                = (NotYet, False)
+stepCanStartNewEra currentEpoch (CanStartIf safeZone) =
+    case HF.safeFromTip safeZone of
+      0 -> (CanStartIf safeZone, checkEpoch (HF.safeBeforeEpoch safeZone))
+      n -> (CanStartIf safeZone { HF.safeFromTip = n - 1 }, False)
+  where
+    checkEpoch :: HF.SafeBeforeEpoch -> Bool
+    checkEpoch HF.NoLowerBound   = True
+    checkEpoch (HF.LowerBound e) = currentEpoch >= e
+
+{-------------------------------------------------------------------------------
+  Arbitrary 'Summary'
+
+  We should be able to show properties of the conversion functions independent
+  of how the 'Summary' that they use is derived.
+-------------------------------------------------------------------------------}
+
+data ArbitrarySummary = forall xs. ArbitrarySummary {
+      arbitrarySummaryStart :: HF.SystemStart
+    , arbitrarySummary      :: HF.Summary xs
+    , beforeHorizonTime     :: UTCTime
+    , beforeHorizonSlot     :: SlotNo
+    , beforeHorizonEpoch    :: EpochNo
+    , pastHorizonTime       :: UTCTime
+    , pastHorizonSlot       :: SlotNo
+    , pastHorizonEpoch      :: EpochNo
+    }
+
+deriving instance Show ArbitrarySummary
+
+instance Arbitrary ArbitrarySummary where
+  arbitrary = chooseEras $ \is -> do
+      start   <- HF.SystemStart <$> arbitrary
+      summary <- genSummary genEraSummary (HF.initBound start) is
+
+      let summaryStart, summaryEnd :: HF.Bound
+          (summaryStart, summaryEnd) = HF.summaryBounds summary
+
+          summarySlots, summaryEpochs :: Word64
+          summarySlots  = HF.countSlots
+                            (HF.boundSlot summaryEnd)
+                            (HF.boundSlot summaryStart)
+          summaryEpochs = HF.countEpochs
+                            (HF.boundEpoch summaryEnd)
+                            (HF.boundEpoch summaryStart)
+
+          summaryTimeSpan :: NominalDiffTime
+          summaryTimeSpan = diffUTCTime
+                              (HF.boundTime summaryEnd)
+                              (HF.boundTime summaryStart)
+
+          summaryTimeSpanSeconds :: Double
+          summaryTimeSpanSeconds = realToFrac summaryTimeSpan
+
+      -- Pick arbitrary values before the horizon
+
+      beforeHorizonSlots   <- choose (0, summarySlots  - 1)
+      beforeHorizonEpochs  <- choose (0, summaryEpochs - 1)
+      beforeHorizonSeconds <- choose (0, summaryTimeSpanSeconds)
+                                `suchThat` \x -> x /= summaryTimeSpanSeconds
+
+      let beforeHorizonSlot  :: SlotNo
+          beforeHorizonEpoch :: EpochNo
+          beforeHorizonTime  :: UTCTime
+
+          beforeHorizonSlot  = HF.addSlots
+                                 beforeHorizonSlots
+                                 (HF.boundSlot summaryStart)
+          beforeHorizonEpoch = HF.addEpochs
+                                 beforeHorizonEpochs
+                                 (HF.boundEpoch summaryStart)
+          beforeHorizonTime  = addUTCTime
+                                 (realToFrac beforeHorizonSeconds)
+                                 (HF.boundTime summaryStart)
+
+      -- Pick arbitrary values past the horizon
+
+      pastHorizonSlots   :: Word64 <- choose (0, 10)
+      pastHorizonEpochs  :: Word64 <- choose (0, 10)
+      pastHorizonSeconds :: Double <- choose (0, 10)
+
+      let pastHorizonSlot  :: SlotNo
+          pastHorizonEpoch :: EpochNo
+          pastHorizonTime  :: UTCTime
+
+          pastHorizonSlot  = HF.addSlots
+                                pastHorizonSlots
+                                (HF.boundSlot summaryEnd)
+          pastHorizonEpoch = HF.addEpochs
+                                pastHorizonEpochs
+                                (HF.boundEpoch summaryEnd)
+          pastHorizonTime  = addUTCTime
+                                (realToFrac pastHorizonSeconds)
+                                (HF.boundTime summaryEnd)
+
+      return ArbitrarySummary{
+            arbitrarySummaryStart = start
+          , arbitrarySummary      = summary
+          , beforeHorizonTime
+          , beforeHorizonSlot
+          , beforeHorizonEpoch
+          , pastHorizonTime
+          , pastHorizonSlot
+          , pastHorizonEpoch
+          }
+    where
+      genEraSummary :: Era -> HF.Bound -> Gen (HF.Bound, HF.EraSummary)
+      genEraSummary _era lo = do
+          params <- genEraParams (HF.boundEpoch lo)
+          hi     <- genUpperBound lo params
+          return (hi, HF.EraSummary lo hi params)
+
+      genUpperBound :: HF.Bound -> HF.EraParams -> Gen HF.Bound
+      genUpperBound lo params = do
+          startOfNextEra <- genStartOfNextEra (HF.boundEpoch lo) params
+          return $ HF.mkUpperBound params lo startOfNextEra
+
+  shrink summary@ArbitrarySummary{..} = concat [
+        -- Simplify the system start
+        [ resetArbitrarySummaryStart summary
+        | HF.getSystemStart arbitrarySummaryStart /= dawnOfTime
+        ]
+
+        -- Reduce before-horizon slot
+      , [ summary { beforeHorizonSlot = SlotNo s }
+        | s <- shrink (unSlotNo beforeHorizonSlot)
+        ]
+
+        -- Reduce before-horizon epoch
+      , [ summary { beforeHorizonEpoch = EpochNo e }
+        | e <- shrink (unEpochNo beforeHorizonEpoch)
+        ]
+
+        -- Reduce before-horizon time
+      , [ summary { beforeHorizonTime = t }
+        | t <- shrink beforeHorizonTime
+        , t >= HF.getSystemStart arbitrarySummaryStart
+        ]
+
+        -- Drop an era /provided/ this doesn't cause of any of the before
+        -- horizon values to become past horizon
+      , [ ArbitrarySummary { arbitrarySummary = summary', .. }
+        | (Just summary', lastEra) <- [HF.dropLast arbitrarySummary]
+        , beforeHorizonSlot  < HF.boundSlot  (HF.eraStart lastEra)
+        , beforeHorizonEpoch < HF.boundEpoch (HF.eraStart lastEra)
+        , beforeHorizonTime  < HF.boundTime  (HF.eraStart lastEra)
+        ]
+      ]
+
+-- | Generate 'EpochNo' for the start of the next era
+genStartOfNextEra :: EpochNo ->  HF.EraParams -> Gen EpochNo
+genStartOfNextEra startOfEra HF.EraParams{..} =
+    case HF.safeBeforeEpoch eraSafeZone of
+       HF.LowerBound e -> (\n -> HF.addEpochs n e         ) <$> choose (0, 10)
+       HF.NoLowerBound -> (\n -> HF.addEpochs n startOfEra) <$> choose (1, 10)
+
+-- | Generate era parameters
+--
+-- Need to know the start of the era to generate a valid 'HF.LowerBound'.
+-- We do /not/ assume that the 'safeFromTip' must be less than an epoch.
+genEraParams :: EpochNo -> Gen HF.EraParams
+genEraParams startOfEra = do
+    eraEpochSize  <- EpochSize         <$> choose (1, 10)
+    eraSlotLength <- slotLengthFromSec <$> choose (1, 5)
+    eraSafeZone   <- genSafeZone
+    return HF.EraParams{..}
+  where
+    genSafeZone :: Gen HF.SafeZone
+    genSafeZone = do
+        safeFromTip     <- choose (1, 10)
+        safeBeforeEpoch <- genSafeBeforeEpoch
+        return HF.SafeZone{..}
+
+    genSafeBeforeEpoch :: Gen HF.SafeBeforeEpoch
+    genSafeBeforeEpoch = oneof [
+          return HF.NoLowerBound
+        , (\n -> HF.LowerBound (HF.addEpochs n startOfEra)) <$> choose (1, 5)
+        ]
+
+{-------------------------------------------------------------------------------
+  Auxiliary: generate arbitrary type-level indices
+-------------------------------------------------------------------------------}
+
+data Era = Era {
+       eraIndex  :: Word64
+     , eraIsLast :: Bool
+     }
+  deriving (Show, Eq, Ord)
+
+type Eras xs = Exactly xs Era
+
+chooseEras :: (forall xs. Eras xs -> Gen a) -> Gen a
+chooseEras k = oneof [
+      k $ ExactlyOne (Era 0 True)
+    , k $ ExactlySuc (Era 0 False) $ ExactlyOne (Era 1 True)
+    , k $ ExactlySuc (Era 0 False) $ ExactlySuc (Era 1 False) $ ExactlyOne (Era 2 True)
+    , k $ ExactlySuc (Era 0 False) $ ExactlySuc (Era 1 False) $ ExactlySuc (Era 2 False) $ ExactlyOne (Era 3 True)
+    ]
+
+{-------------------------------------------------------------------------------
+  Auxiliary: using 'Eras' to generate indexed types
+-------------------------------------------------------------------------------}
+
+genSummary :: forall m xs a. Monad m
+           => (Era -> a -> m (a, HF.EraSummary))  -- ^ Step
+           -> a                                   -- ^ Initial seed
+           -> Eras xs -> m (HF.Summary xs)
+genSummary f = \seed eras ->
+    HF.Summary <$> go seed eras
+  where
+    go :: forall xs'. a -> Eras xs' -> m (AtMost xs' HF.EraSummary)
+    go a (ExactlyOne e) = do
+        (_a', eraSummary) <- f e a
+        return $ AtMostOne eraSummary
+    go a (ExactlySuc e es) = do
+        (a', eraSummary) <- f e a
+        summary          <- go a' es
+        return $ AtMostSuc eraSummary summary
+
+genShape :: forall m xs a. Monad m
+         => (Era -> a -> m (a, HF.EraParams))  -- ^ Step
+         -> a                                  -- ^ Initial seed
+         -> Eras xs -> m (HF.Shape xs)
+genShape f = \seed eras ->
+    HF.Shape <$> go seed eras
+  where
+    go :: forall xs'. a -> Eras xs' -> m (Exactly xs' HF.EraParams)
+    go a (ExactlyOne e) = do
+        (_a', eraParams) <- f e a
+        return $ ExactlyOne eraParams
+    go a (ExactlySuc e es) = do
+        (a', eraParams) <- f e a
+        shape           <- go a' es
+        return $ ExactlySuc eraParams shape
+
+{-------------------------------------------------------------------------------
+  Shifting time
+-------------------------------------------------------------------------------}
+
+instance ShiftTime ArbitrarySummary where
+  shiftTime delta ArbitrarySummary{..} = ArbitrarySummary {
+      arbitrarySummaryStart = shiftTime delta arbitrarySummaryStart
+    , arbitrarySummary      = shiftTime delta arbitrarySummary
+    , beforeHorizonTime     = shiftTime delta beforeHorizonTime
+    , beforeHorizonSlot
+    , beforeHorizonEpoch
+    , pastHorizonTime
+    , pastHorizonSlot
+    , pastHorizonEpoch
+    }
+
+instance ShiftTime ArbitraryChain where
+  shiftTime delta ArbitraryChain{..} = ArbitraryChain {
+        arbitraryChainStart = shiftTime delta arbitraryChainStart
+      , arbitraryChain      = shiftTime delta arbitraryChain
+      , arbitraryChainPre   = shiftTime delta arbitraryChainPre
+      , arbitraryChainEras
+      , arbitraryChainShape
+      , arbitraryEventIx
+      }
+
+instance ShiftTime (Chain xs) where
+  shiftTime delta (Chain chain) = Chain $ shiftTime delta <$> chain
+
+instance ShiftTime (EventTime, HF.EraParams, Event f) where
+  shiftTime delta (time, params, event) = (shiftTime delta time, params, event)
+
+instance ShiftTime EventTime where
+  shiftTime delta t = t { eventTime = shiftTime delta (eventTime t) }
+
+-- | Reset the system start (during shrinking)
+--
+-- Since this brings the system start /back/, we don't care about the past
+-- horizon values. 'EpochNo' and 'SlotNo' are also unaffected.
+resetArbitrarySummaryStart :: ArbitrarySummary -> ArbitrarySummary
+resetArbitrarySummaryStart summary@ArbitrarySummary{..} =
+    shiftTime (negate ahead) summary
+  where
+    ahead :: NominalDiffTime
+    ahead = diffUTCTime (HF.getSystemStart arbitrarySummaryStart) dawnOfTime
+
+-- | Reset chain start
+resetArbitraryChainStart :: ArbitraryChain -> ArbitraryChain
+resetArbitraryChainStart chain@ArbitraryChain{..} =
+    shiftTime (negate ahead) chain
+  where
+    ahead :: NominalDiffTime
+    ahead = diffUTCTime (HF.getSystemStart arbitraryChainStart) dawnOfTime

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -40,6 +40,7 @@ import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util ((.:))
 import           Ouroboros.Consensus.Util.IOLike
 
+import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache as BlockCache
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.LedgerCursor as LedgerCursor
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB
@@ -57,7 +58,6 @@ import           Test.Tasty.QuickCheck
 
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock
-
 
 {-------------------------------------------------------------------------------
   Top-level tests
@@ -247,14 +247,21 @@ testCfg securityParam = TopLevelConfig {
         , bftVerKeys  = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
         }
     , configLedger = LedgerConfig
-    , configBlock  = TestBlockConfig slotLengths numCoreNodes
+    , configBlock  = TestBlockConfig slotLengths eraParams numCoreNodes
     }
   where
     slotLengths :: SlotLengths
-    slotLengths = singletonSlotLengths $ slotLengthFromSec 20
+    slotLengths = singletonSlotLengths slotLength
+
+    slotLength :: SlotLength
+    slotLength = slotLengthFromSec 20
 
     numCoreNodes :: NumCoreNodes
     numCoreNodes = NumCoreNodes 1
+
+    eraParams :: HardFork.EraParams
+    eraParams = HardFork.defaultEraParams securityParam slotLength
+
 
 {-------------------------------------------------------------------------------
   Orphans

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -79,6 +79,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.BlockchainTime.Mock
                      (settableBlockchainTime)
 import           Ouroboros.Consensus.Config
+import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
@@ -1276,14 +1277,20 @@ testCfg = TopLevelConfig {
         , bftVerKeys  = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
         }
     , configLedger = LedgerConfig
-    , configBlock  = TestBlockConfig slotLengths numCoreNodes
+    , configBlock  = TestBlockConfig slotLengths eraParams numCoreNodes
     }
   where
     slotLengths :: SlotLengths
-    slotLengths = singletonSlotLengths $ slotLengthFromSec 20
+    slotLengths = singletonSlotLengths slotLength
+
+    slotLength :: SlotLength
+    slotLength = slotLengthFromSec 20
 
     numCoreNodes :: NumCoreNodes
     numCoreNodes = NumCoreNodes 1
+
+    eraParams :: HardFork.EraParams
+    eraParams = HardFork.defaultEraParams k slotLength
 
     k = SecurityParam 2
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
@@ -86,6 +87,7 @@ import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
+import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
@@ -193,6 +195,11 @@ instance HasHeader (Header TestBlock) where
 
 data instance BlockConfig TestBlock = TestBlockConfig {
       testBlockSlotLengths :: !SlotLengths
+
+      -- | Era parameters
+      --
+      -- TODO: This should obsolete 'testBlockSlotLengths' (#1637)
+    , testBlockEraParams :: HardFork.EraParams
 
       -- | Number of core nodes
       --
@@ -443,6 +450,11 @@ instance LedgerSupportsProtocol TestBlock where
       ()
   anachronisticProtocolLedgerView_ _ _ _ =
       return ()
+
+instance HasHardForkHistory TestBlock where
+  type HardForkIndices TestBlock = '[()]
+  hardForkShape           = HardFork.singletonShape . testBlockEraParams
+  hardForkTransitions _ _ = HardFork.transitionsUnknown
 
 instance LedgerDerivedInfo TestBlock where
   knownSlotLengths = testBlockSlotLengths


### PR DESCRIPTION
This introduces the hard fork history, with records changing slot lengths and epoch sizes across hard fork boundaries, and derives `EpochInfo` and `BlockchainTime` from this.

This PR paves the way for (but does not yet close) #1637 and #1205.