### PR TITLE
VolatileDB: Unify and extend getters

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -311,10 +311,9 @@ chainSelectionForBlock
 chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
     curSlot <- atomically $ getCurrentSlot cdbBlockchainTime
 
-    (invalid, isMember, succsOf, predecessor, curChain, tipPoint, ledgerDB)
-      <- atomically $ (,,,,,,)
+    (invalid, succsOf, predecessor, curChain, tipPoint, ledgerDB)
+      <- atomically $ (,,,,,)
           <$> (forgetFingerprint <$> readTVar cdbInvalid)
-          <*> VolDB.getIsMember     cdbVolDB
           <*> VolDB.getSuccessors   cdbVolDB
           <*> VolDB.getPredecessor  cdbVolDB
           <*> Query.getCurrentChain cdb
@@ -335,12 +334,12 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
         i = castPoint $ AF.anchorPoint curChain
 
         -- Let these two functions ignore invalid blocks
-        isMember' = ignoreInvalid    cdb invalid isMember
-        succsOf'  = ignoreInvalidSuc cdb invalid succsOf
+        predecessor' = ignoreInvalid    cdb invalid predecessor
+        succsOf'     = ignoreInvalidSuc cdb invalid succsOf
 
     -- The preconditions
     assert (blockSlot hdr <= curSlot)  $ return ()
-    assert (isMember (headerHash hdr)) $ return ()
+    assert (isJust $ predecessor (headerHash hdr)) $ return ()
 
     if
       -- The chain might have grown since we added the block such that the
@@ -358,7 +357,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
         trace (TryAddToCurrentChain p)
         addToCurrentChain succsOf' curChainAndLedger curSlot
 
-      | Just hashes <- VolDB.isReachable predecessor isMember' i p -> do
+      | Just hashes <- VolDB.isReachable predecessor' i p -> do
         -- ### Switch to a fork
         trace (TrySwitchToAFork p hashes)
         switchToAFork succsOf' curChainAndLedger hashes curSlot
@@ -966,17 +965,16 @@ truncateInvalidCandidate isInvalid (CandidateSuffix rollback suffix)
 -------------------------------------------------------------------------------}
 
 
--- | Wrap an @isMember@ function so that it returns 'False' for invalid
--- blocks.
+-- | Wrap a @getter@ function so that it returns 'Nothing' for invalid blocks.
 ignoreInvalid
   :: HasHeader blk
   => proxy blk
   -> InvalidBlocks blk
-  -> (HeaderHash blk -> Bool)
-  -> (HeaderHash blk -> Bool)
-ignoreInvalid _ invalid isMember hash
-    | Map.member hash invalid = False
-    | otherwise               = isMember hash
+  -> (HeaderHash blk -> Maybe a)
+  -> (HeaderHash blk -> Maybe a)
+ignoreInvalid _ invalid getter hash
+    | Map.member hash invalid = Nothing
+    | otherwise               = getter hash
 
 -- | Wrap a @successors@ function so that invalid blocks are not returned as
 -- successors.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/API.hs
@@ -56,12 +56,10 @@ data VolatileDB blockId m = VolatileDB {
       -- Note that it is not required that the given block has been added to
       -- the VolatileDB.
     , getSuccessors     :: HasCallStack => STM m (WithOrigin blockId -> Set blockId)
-      -- | Return a function that returns the predecessor of the block with
-      -- the given @blockId@.
-      --
-      -- PRECONDITION: the block must be a member of the VolatileDB, you can
-      -- use 'getIsMember' to check this.
-    , getPredecessor    :: HasCallStack => STM m (blockId -> WithOrigin blockId)
+      -- | Return a function that returns the 'BlockInfo' of the block with
+      -- the given @blockId@ or 'Nothing' if the @blockId@ is not found in the
+      -- VolatileDB.
+    , getBlockInfo      :: HasCallStack => STM m (blockId -> Maybe (BlockInfo blockId))
       -- | Try to remove all blocks with a slot number less than the given
       -- one.
       --
@@ -119,7 +117,6 @@ data VolatileDB blockId m = VolatileDB {
       -- avoid issues with /EBBs/, which have the same slot number as the
       -- block after it.
     , garbageCollect    :: HasCallStack => SlotNo -> m ()
-    , getIsMember       :: HasCallStack => STM m (blockId -> Bool)
       -- | Return the highest slot number ever stored by the VolatileDB.
     , getMaxSlotNo      :: HasCallStack => STM m MaxSlotNo
 } deriving NoUnexpectedThunks via OnlyCheckIsWHNF "VolatileDB" (VolatileDB blockId m)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
@@ -209,9 +209,8 @@ openDB hasFS err errSTM parser tracer maxBlocksPerFile = do
       , getBlockComponent = getBlockComponentImpl env
       , putBlock          = putBlockImpl          env
       , garbageCollect    = garbageCollectImpl    env
-      , getIsMember       = getIsMemberImpl       env
       , getSuccessors     = getSuccessorsImpl     env
-      , getPredecessor    = getPredecessorImpl    env
+      , getBlockInfo      = getBlockInfoImpl      env
       , getMaxSlotNo      = getMaxSlotNoImpl      env
       }
 
@@ -428,24 +427,17 @@ tryCollectFile hasFS VolatileDBEnv{..} slot st (fileId, fileInfo)
         mapMaybe (\b -> (b,) . bpreBid . ibBlockInfo <$> Map.lookup b _currentRevMap) bids
     succMap'          = foldl' deleteMapSet _currentSuccMap deletedPairs
 
-getIsMemberImpl :: forall m blockId. (IOLike m, Ord blockId)
-                => VolatileDBEnv m blockId
-                -> STM m (blockId -> Bool)
-getIsMemberImpl = getterSTM $ \st bid -> Map.member bid (_currentRevMap st)
-
 getSuccessorsImpl :: forall m blockId. (IOLike m, Ord blockId)
                   => VolatileDBEnv m blockId
                   -> STM m (WithOrigin blockId -> Set blockId)
 getSuccessorsImpl = getterSTM $ \st blockId ->
     fromMaybe Set.empty (Map.lookup blockId (_currentSuccMap st))
 
-getPredecessorImpl :: forall m blockId. (IOLike m, Ord blockId, HasCallStack)
-                   => VolatileDBEnv m blockId
-                   -> STM m (blockId -> WithOrigin blockId)
-getPredecessorImpl = getterSTM $ \st blockId ->
-    maybe (error msg) (bpreBid . ibBlockInfo) (Map.lookup blockId (_currentRevMap st))
-  where
-    msg = "precondition violated: block not member of the VolatileDB"
+getBlockInfoImpl :: forall m blockId. (IOLike m, Ord blockId, HasCallStack)
+                 => VolatileDBEnv m blockId
+                 -> STM m (blockId -> Maybe (BlockInfo blockId))
+getBlockInfoImpl = getterSTM $ \st blockId ->
+    ibBlockInfo <$> Map.lookup blockId (_currentRevMap st)
 
 getMaxSlotNoImpl :: forall m blockId. IOLike m
                  => VolatileDBEnv m blockId

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
@@ -433,7 +433,7 @@ getSuccessorsImpl :: forall m blockId. (IOLike m, Ord blockId)
 getSuccessorsImpl = getterSTM $ \st blockId ->
     fromMaybe Set.empty (Map.lookup blockId (_currentSuccMap st))
 
-getBlockInfoImpl :: forall m blockId. (IOLike m, Ord blockId, HasCallStack)
+getBlockInfoImpl :: forall m blockId. (IOLike m, Ord blockId)
                  => VolatileDBEnv m blockId
                  -> STM m (blockId -> Maybe (BlockInfo blockId))
 getBlockInfoImpl = getterSTM $ \st blockId ->

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Types.hs
@@ -159,7 +159,7 @@ data BlockInfo blockId = BlockInfo {
     , bisEBB        :: !IsEBB
     , bheaderOffset :: !Word16
     , bheaderSize   :: !Word16
-    } deriving (Show, Generic, NoUnexpectedThunks)
+    } deriving (Eq, Show, Generic, NoUnexpectedThunks)
 
 -- | The internal information the db keeps for each block.
 data InternalBlockInfo blockId = InternalBlockInfo {

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
@@ -34,9 +34,8 @@ openDBMock err errSTM maxBlocksPerFile = do
         , getBlockComponent = queryE   .: getBlockComponentModel
         , putBlock          = updateE_ .: putBlockModel
         , garbageCollect    = updateE_  . garbageCollectModel
-        , getIsMember       = querySTME $ getIsMemberModel
         , getSuccessors     = querySTME $ getSuccessorsModel
-        , getPredecessor    = querySTME $ getPredecessorModel
+        , getBlockInfo      = querySTME $ getBlockInfoModel
         , getMaxSlotNo      = querySTME $ getMaxSlotNoModel
         }
       where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -16,9 +16,8 @@ module Test.Ouroboros.Storage.VolatileDB.Model
     , getBlockComponentModel
     , putBlockModel
     , garbageCollectModel
+    , getBlockInfoModel
     , getSuccessorsModel
-    , getPredecessorModel
-    , getIsMemberModel
     , getMaxSlotNoModel
       -- * Corruptions
     , runCorruptionsModel
@@ -317,21 +316,12 @@ getSuccessorsModel dbm = whenOpen dbm $ \predecessor ->
       Map.empty
       (getBlockToPredecessor dbm)
 
-getPredecessorModel
+getBlockInfoModel
   :: Ord blockId
   => DBModel blockId
-  -> Either VolatileDBError (blockId -> WithOrigin blockId)
-getPredecessorModel dbm = whenOpen dbm $ \blockId ->
-    fromMaybe (error msg) $ Map.lookup blockId $ getBlockToPredecessor dbm
-   where
-     msg = "precondition violated: block not member of the VolatileDB"
-
-getIsMemberModel
-  :: Ord blockId
-  => DBModel blockId
-  -> Either VolatileDBError (blockId -> Bool)
-getIsMemberModel dbm = whenOpen dbm $ \blockId ->
-    Map.member blockId (blockIndex dbm)
+  -> Either VolatileDBError (blockId -> Maybe (BlockInfo blockId))
+getBlockInfoModel dbm = whenOpen dbm $ \blockId ->
+    fst <$> Map.lookup blockId (blockIndex dbm)
 
 getMaxSlotNoModel
   :: DBModel blockId

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -26,7 +26,7 @@ import           Data.Functor.Classes
 import           Data.Kind (Type)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
-import           Data.Maybe (listToMaybe, mapMaybe)
+import           Data.Maybe (catMaybes, listToMaybe, mapMaybe)
 import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
@@ -122,8 +122,7 @@ data Cmd
     | PutBlock TestBlock
     | GarbageCollect SlotNo
     | GetSuccessors [Predecessor]
-    | GetPredecessor [BlockId]
-    | GetIsMember [BlockId]
+    | GetBlockInfo [BlockId]
     | GetMaxSlotNo
     | Corruption Corruptions
     | DuplicateBlock FileId BlockId ByteString
@@ -140,9 +139,8 @@ data Success
     = Unit            ()
     | MbAllComponents (Maybe AllComponents)
     | Bool            Bool
-    | IsMember        [Bool]
     | Successors      [Set BlockId]
-    | Predecessor     [Predecessor]
+    | BlockInfos      [Maybe (BlockInfo BlockId)]
     | MaxSlot         MaxSlotNo
     deriving (Show, Eq)
 
@@ -238,8 +236,7 @@ runPure :: Cmd
 runPure = \case
     GetBlockComponent bid -> ok MbAllComponents            $ queryE   (getBlockComponentModel allComponents bid)
     GetSuccessors bids    -> ok (Successors  . (<$> bids)) $ queryE    getSuccessorsModel
-    GetPredecessor bids   -> ok (Predecessor . (<$> bids)) $ queryE    getPredecessorModel
-    GetIsMember bids      -> ok (IsMember    . (<$> bids)) $ queryE    getIsMemberModel
+    GetBlockInfo bids     -> ok (BlockInfos  . (<$> bids)) $ queryE    getBlockInfoModel
     GarbageCollect slot   -> ok Unit                       $ updateE_ (garbageCollectModel slot)
     IsOpen                -> ok Bool                       $ query     isOpenModel
     Close                 -> ok Unit                       $ update_   closeModel
@@ -304,7 +301,6 @@ transitionImpl model cmd _ = eventAfter $ lockstep model cmd
 preconditionImpl :: Model Symbolic -> At CmdErr Symbolic -> Logic
 preconditionImpl Model{..} (At (CmdErr cmd mbErrors)) =
     compatibleWithError .&& case cmd of
-      GetPredecessor bids -> forall bids (`elem` bidsInModel)
       Corruption cors ->
         forall (corruptionFiles cors) (`elem` getDBFiles dbModel)
 
@@ -317,9 +313,6 @@ preconditionImpl Model{..} (At (CmdErr cmd mbErrors)) =
         Just fileId' -> fileId .>= fileId'
       _ -> Top
   where
-    -- | All the 'BlockId' in the db.
-    bidsInModel :: [BlockId]
-    bidsInModel = blockIds dbModel
 
     -- | Corruption commands are not allowed to have errors.
     compatibleWithError :: Logic
@@ -355,8 +348,7 @@ generatorCmdImpl Model {..} = frequency
     , (if open dbModel then 1 else 5, return ReOpen)
     , (2, GetBlockComponent <$> genBlockId)
     , (2, GarbageCollect <$> genGCSlot)
-    , (2, GetIsMember <$> listOf genBlockId)
-    , (2, GetPredecessor <$> listOf genBlockId)
+    , (2, GetBlockInfo <$> listOf genBlockId)
     , (2, GetSuccessors <$> listOf genWithOriginBlockId)
     , (2, return GetMaxSlotNo)
 
@@ -479,8 +471,7 @@ shrinkerImpl m (At (CmdErr cmd mbErr)) = fmap At $
 
 shrinkCmd :: Model Symbolic -> Cmd -> [Cmd]
 shrinkCmd Model{..} cmd = case cmd of
-    GetIsMember    bids  -> GetIsMember    <$> shrinkList (const []) bids
-    GetPredecessor bids  -> GetPredecessor <$> shrinkList (const []) bids
+    GetBlockInfo   bids  -> GetBlockInfo   <$> shrinkList (const []) bids
     GetSuccessors  preds -> GetSuccessors  <$> shrinkList (const []) preds
     Corruption cors      -> Corruption <$> shrinkCorruptions cors
     _                    -> []
@@ -515,8 +506,7 @@ runDB VolatileDBEnv { db, hasFS } cmd = case cmd of
     GetBlockComponent bid -> MbAllComponents          <$> getBlockComponent db allComponents bid
     PutBlock b            -> Unit                     <$> putBlock db (testBlockToBlockInfo b) (testBlockToBuilder b)
     GetSuccessors  bids   -> Successors .  (<$> bids) <$> atomically (getSuccessors db)
-    GetPredecessor bids   -> Predecessor . (<$> bids) <$> atomically (getPredecessor db)
-    GetIsMember    bids   -> IsMember .    (<$> bids) <$> atomically (getIsMember db)
+    GetBlockInfo   bids   -> BlockInfos .  (<$> bids) <$> atomically (getBlockInfo db)
     GarbageCollect slot   -> Unit                     <$> garbageCollect db slot
     GetMaxSlotNo          -> MaxSlot                  <$> atomically (getMaxSlotNo db)
     IsOpen                -> Bool                     <$> isOpenDB db
@@ -554,14 +544,10 @@ prop_sequential = forAllCommands smUnused Nothing $ \cmds -> monadicIO $ do
           (cmdName . eventCmd <$> events)
         $ tabulate "Error Tags"
           (tagSimulatedErrors events)
-        $ tabulate "IsMember: total number of True's"
+        $ tabulate "GetBlockInfo: total number of Just's"
           [groupIsMember $ isMemberTrue events]
-        $ tabulate "IsMember: at least one True"
-          [show $ isMemberTrue' events]
         $ tabulate "Successors"
           (tagGetSuccessors events)
-        $ tabulate "Predecessor"
-          (tagGetPredecessor events)
         $ prop
   where
     dbm = initDBModel maxBlocksPerFile
@@ -732,18 +718,9 @@ isMemberTrue events = sum $ count <$> events
   where
     count :: Event Symbolic -> Int
     count e = case eventMockResp e of
-      Resp (Left _)              -> 0
-      Resp (Right (IsMember ls)) -> length $ filter id ls
-      Resp (Right _)             -> 0
-
-isMemberTrue' :: [Event Symbolic] -> Int
-isMemberTrue' events = sum $ count <$> events
-  where
-    count :: Event Symbolic -> Int
-    count e = case eventMockResp e of
-        Resp (Left _)              -> 0
-        Resp (Right (IsMember ls)) -> if null ls then 0 else 1
-        Resp (Right _)             -> 0
+      Resp (Left _)                -> 0
+      Resp (Right (BlockInfos ls)) -> length $ catMaybes ls
+      Resp (Right _)               -> 0
 
 data Tag =
     -- | Request a block successfully
@@ -814,15 +791,6 @@ tagGetSuccessors = mapMaybe f
         (GetSuccessors _pid, Resp (Right (Successors st))) ->
             if all Set.null st then Just "Empty Successors"
             else Just "Non empty Successors"
-        _otherwise -> Nothing
-
-tagGetPredecessor :: [Event Symbolic] -> [String]
-tagGetPredecessor = mapMaybe f
-  where
-    f :: Event Symbolic -> Maybe String
-    f ev = case (getCmd ev, eventMockResp ev) of
-        (GetPredecessor _pid, Resp (Right (Predecessor _))) ->
-            Just "Predecessor"
         _otherwise -> Nothing
 
 execCmd :: Model Symbolic


### PR DESCRIPTION
Related issue: https://github.com/input-output-hk/ouroboros-network/issues/1684
This is done:
> Unify getIsMember and getPredecessor, and return BlockInfo

This is not done yet:
> Possibly unify it with getSuccessors too, e.g., using return a pair of both results.