### PR TITLE
network: add IsIdle argument to the PeerFetchStatusReady fingerprint

### DIFF
--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -353,7 +353,7 @@ tracePropertyClientStateSanity es =
         == fromIntegral peerFetchBytesInFlight
 
      && case status of
-          PeerFetchStatusReady _ -> True
+          PeerFetchStatusReady{} -> True
           PeerFetchStatusBusy    -> True
           _                      -> False -- not used in this test
 


### PR DESCRIPTION
Fixes #1147.

I've been using this commit during all of my recent development on the tests -- without it, Issue #1147 failures have occasionally masked my other focus.

I still don't have a repro on master, but I think I'll be able to find one after a couple more PRs are merged -- the #1147 failure has arisen during my development even without the simulated network latency that originally revealed it.

Disclaimer: though this commit seems well-vetted by the use in the not-yet-on-`master` tests mentioned above, I do not understand the `BlockFetch` code very well, and moreover it's been a while since I actually wrote this code (in particular, I'm not exactly sure what it is that the Boolean adds beyond checking if the adjacent set is empty). It'd be wonderful to see a localized test case for this.