### PR TITLE
Introduce RealPoint

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -162,6 +162,7 @@ executable db-analyser
                      , cardano-binary
                      , cardano-crypto-wrapper
                      , cardano-ledger
+                     , cardano-slotting
                      , mtl
                      , optparse-applicative
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -33,13 +33,12 @@ import           Test.QuickCheck
 
 import           Control.Monad.IOSim (runSimOrThrow)
 
-import           Ouroboros.Network.Block (BlockNo (..), pattern BlockPoint,
-                     pattern GenesisPoint, HasHeader, HeaderHash, Point,
-                     SlotNo (..), blockPoint)
+import           Ouroboros.Network.Block (BlockNo (..), HasHeader, HeaderHash,
+                     SlotNo (..))
 import qualified Ouroboros.Network.MockChain.Chain as MockChain
 import           Ouroboros.Network.Point (WithOrigin (..))
 
-import           Ouroboros.Consensus.Block (BlockProtocol)
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.BlockchainTime.Mock
 import           Ouroboros.Consensus.Ledger.Extended (ExtValidationError)
@@ -318,11 +317,10 @@ prop_general countTxs k TestConfig{numSlots, nodeJoinPlan, nodeRestarts, nodeTop
             | (nid, no) <- Map.toList testOutputNodes
             , let NodeOutput{nodeOutputInvalids} = no
             ]
-        ok p nid err = case p of
+        ok (RealPoint s h) nid err =
           -- TODO The ExtValidationError data declaration imposes this case on
           -- us but should never exercise it.
-          GenesisPoint   -> False
-          BlockPoint s h -> expectedBlockRejection BlockRejection
+          expectedBlockRejection BlockRejection
             { brBlockHash = h
             , brBlockSlot = s
             , brReason    = err
@@ -356,7 +354,7 @@ prop_general countTxs k TestConfig{numSlots, nodeJoinPlan, nodeRestarts, nodeTop
       where
         actuallyLead ::
              NodeId
-          -> Set (Point blk)
+          -> Set (RealPoint blk)
           -> SlotNo
           -> blk
           -> Maybe [CoreNodeId]
@@ -368,7 +366,7 @@ prop_general countTxs k TestConfig{numSlots, nodeJoinPlan, nodeRestarts, nodeTop
             let j = nodeIdJoinSlot nodeJoinPlan nid
             guard $ j <= s
 
-            guard $ not $ Set.member (blockPoint b) invalids
+            guard $ not $ Set.member (blockRealPoint b) invalids
 
             pure [cid]
 
@@ -531,8 +529,7 @@ prop_general countTxs k TestConfig{numSlots, nodeJoinPlan, nodeRestarts, nodeTop
     prop_no_unexpected_message_delays =
         conjoin $
         [ case p of
-              GenesisPoint            -> error "impossible"
-              BlockPoint sendSlot hsh ->
+              RealPoint sendSlot hsh ->
                   prop1 nid recvSlot sendSlot hsh bno
         | (nid, m)          <- Map.toList adds
         , (recvSlot, pbnos) <- Map.toList m

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -501,9 +501,9 @@ runThreadNetwork ThreadNetworkArgs
            -> TopLevelConfig blk
            -> ExtLedgerState blk
            -> EpochInfo m
-           -> Tracer m (Point blk, ExtValidationError blk)
+           -> Tracer m (RealPoint blk, ExtValidationError blk)
               -- ^ invalid block tracer
-           -> Tracer m (Point blk, BlockNo)
+           -> Tracer m (RealPoint blk, BlockNo)
               -- ^ added block tracer
            -> NodeDBs (StrictTVar m MockFS)
            -> ChainDbArgs m blk
@@ -929,11 +929,11 @@ data NodeInfo blk db ev = NodeInfo
 -- The @ev@ type parameter is instantiated by this module at types for
 -- 'Tracer's and lists: actions for accumulating and lists as accumulations.
 data NodeEvents blk ev = NodeEvents
-  { nodeEventsAdds        :: ev (SlotNo, Point blk, BlockNo)
+  { nodeEventsAdds        :: ev (SlotNo, RealPoint blk, BlockNo)
     -- ^ every 'AddedBlockToVolDB' excluding EBBs
   , nodeEventsForges      :: ev (TraceForgeEvent blk (GenTx blk))
     -- ^ every 'TraceForgeEvent'
-  , nodeEventsInvalids    :: ev (Point blk, ExtValidationError blk)
+  , nodeEventsInvalids    :: ev (RealPoint blk, ExtValidationError blk)
     -- ^ the point of every 'ChainDB.InvalidBlock' event
   , nodeEventsTipBlockNos :: ev (SlotNo, WithOrigin BlockNo)
     -- ^ 'ChainDB.getTipBlockNo' for each node at the onset of each slot
@@ -989,11 +989,11 @@ newNodeInfo = do
 -------------------------------------------------------------------------------}
 
 data NodeOutput blk = NodeOutput
-  { nodeOutputAdds       :: Map SlotNo (Set (Point blk, BlockNo))
+  { nodeOutputAdds       :: Map SlotNo (Set (RealPoint blk, BlockNo))
   , nodeOutputFinalChain :: Chain blk
   , nodeOutputNodeDBs    :: NodeDBs MockFS
   , nodeOutputForges     :: Map SlotNo blk
-  , nodeOutputInvalids   :: Map (Point blk) [ExtValidationError blk]
+  , nodeOutputInvalids   :: Map (RealPoint blk) [ExtValidationError blk]
   }
 
 data TestOutput blk = TestOutput

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -34,6 +34,7 @@ library
                        Ouroboros.Consensus.Block
                        Ouroboros.Consensus.Block.Abstract
                        Ouroboros.Consensus.Block.EBB
+                       Ouroboros.Consensus.Block.RealPoint
                        Ouroboros.Consensus.Block.SupportsProtocol
                        Ouroboros.Consensus.BlockFetchServer
                        Ouroboros.Consensus.BlockchainTime

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
@@ -5,4 +5,5 @@ module Ouroboros.Consensus.Block (
 
 import           Ouroboros.Consensus.Block.Abstract as X
 import           Ouroboros.Consensus.Block.EBB as X
+import           Ouroboros.Consensus.Block.RealPoint as X
 import           Ouroboros.Consensus.Block.SupportsProtocol as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/RealPoint.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/RealPoint.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE PatternSynonyms      #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Ouroboros.Consensus.Block.RealPoint (
+    -- * Non-genesis points
+    RealPoint -- Opaque
+  , pattern RealPoint
+  , encodeRealPoint
+  , decodeRealPoint
+    -- * Derived
+  , realPointSlot
+  , realPointHash
+  , blockRealPoint
+  , headerRealPoint
+  , realPointToPoint
+  , withOriginRealPointToPoint
+  , pointToWithOriginRealPoint
+  ) where
+
+import           Codec.CBOR.Decoding (Decoder)
+import           Codec.CBOR.Encoding (Encoding, encodeListLen)
+import           Codec.Serialise (decode, encode)
+import           Data.Proxy
+import           Data.Typeable (Typeable, typeRep)
+import           GHC.Generics
+
+import           Cardano.Binary (enforceSize)
+import           Cardano.Prelude (NoUnexpectedThunks (..))
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Network.Block
+import qualified Ouroboros.Network.Point as Point
+
+import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Util.Condense
+
+{-------------------------------------------------------------------------------
+  Non-genesis point
+-------------------------------------------------------------------------------}
+
+-- | Point of an actual block (i.e., not genesis)
+newtype RealPoint blk = MkRealPoint (Point.Block SlotNo (HeaderHash blk))
+  deriving (Generic)
+
+-- TODO: The Ord instance should go
+-- <https://github.com/input-output-hk/ouroboros-network/issues/1693>
+deriving instance StandardHash blk => Eq   (RealPoint blk)
+deriving instance StandardHash blk => Ord  (RealPoint blk)
+deriving instance StandardHash blk => Show (RealPoint blk)
+
+instance (StandardHash blk, Typeable blk)
+      => NoUnexpectedThunks (RealPoint blk) where
+  showTypeOf _ = show $ typeRep (Proxy @(RealPoint blk))
+
+{-# COMPLETE RealPoint #-}
+pattern RealPoint :: SlotNo -> HeaderHash blk -> RealPoint blk
+pattern RealPoint s h = MkRealPoint (Point.Block s h)
+
+instance Condense (HeaderHash blk) => Condense (RealPoint blk) where
+  condense (RealPoint s h) = "(Point " <> condense s <> ", " <> condense h <> ")"
+
+encodeRealPoint :: (HeaderHash blk -> Encoding)
+                -> (RealPoint  blk -> Encoding)
+encodeRealPoint encodeHash (RealPoint s h) = mconcat [
+      encodeListLen 2
+    , encode s
+    , encodeHash h
+    ]
+
+decodeRealPoint :: (forall s. Decoder s (HeaderHash blk))
+                -> (forall s. Decoder s (RealPoint  blk))
+decodeRealPoint decodeHash = do
+    enforceSize "RealPoint" 2
+    RealPoint <$> decode <*> decodeHash
+
+{-------------------------------------------------------------------------------
+  Derived
+-------------------------------------------------------------------------------}
+
+realPointSlot :: RealPoint blk -> SlotNo
+realPointSlot (RealPoint s _) = s
+
+realPointHash :: RealPoint blk -> HeaderHash blk
+realPointHash (RealPoint _ h) = h
+
+blockRealPoint :: HasHeader blk => blk -> RealPoint blk
+blockRealPoint blk = RealPoint (blockSlot blk) (blockHash blk)
+
+headerRealPoint :: HasHeader (Header blk) => Header blk -> RealPoint blk
+headerRealPoint hdr = RealPoint (blockSlot hdr) (blockHash hdr)
+
+realPointToPoint :: RealPoint blk -> Point blk
+realPointToPoint (RealPoint s h) = BlockPoint s h
+
+withOriginRealPointToPoint :: WithOrigin (RealPoint blk) -> Point blk
+withOriginRealPointToPoint Origin = GenesisPoint
+withOriginRealPointToPoint (At p) = realPointToPoint p
+
+pointToWithOriginRealPoint :: Point blk -> WithOrigin (RealPoint blk)
+pointToWithOriginRealPoint GenesisPoint     = Origin
+pointToWithOriginRealPoint (BlockPoint s h) = At $ RealPoint s h

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ErrorPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ErrorPolicy.hs
@@ -65,7 +65,6 @@ consensusErrorPolicy = ErrorPolicies {
           -- entirely, it will only be reopened after a node restart.
         , ErrorPolicy $ \(e :: ChainDbError) ->
             case e of
-              NoGenesisBlock{}       -> Just theyBuggyOrEvil
               ClosedDBError{}        -> Just shutdownNode
               ClosedReaderError{}    -> Just ourBug
               InvalidIteratorRange{} -> Just theyBuggyOrEvil

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -91,10 +91,10 @@ openDBInternal args launchBgTasks = do
 
     volDB   <- VolDB.openDB argsVolDb
     traceWith tracer $ TraceOpenEvent OpenedVolDB
-    lgrReplayTracer <- LgrDB.decorateReplayTracer
-      (Args.cdbEpochInfo args)
-      immDbTipPoint
-      (contramap TraceLedgerReplayEvent tracer)
+    let lgrReplayTracer =
+          LgrDB.decorateReplayTracer
+            immDbTipPoint
+            (contramap TraceLedgerReplayEvent tracer)
     (lgrDB, replayed) <- LgrDB.openDB argsLgrDb
                             lgrReplayTracer
                             immDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reopen.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reopen.hs
@@ -127,10 +127,10 @@ reopen (CDBHandle varState) launchBgTasks = do
         VolDB.reopen cdbVolDB
         traceWith cdbTracer $ TraceOpenEvent OpenedVolDB
 
-        lgrReplayTracer <- LgrDB.decorateReplayTracer
-          cdbEpochInfo
-          immDbTipPoint
-          (contramap TraceLedgerReplayEvent cdbTracer)
+        let lgrReplayTracer =
+              LgrDB.decorateReplayTracer
+                immDbTipPoint
+                (contramap TraceLedgerReplayEvent cdbTracer)
         replayed <- LgrDB.reopen cdbLgrDB cdbImmDB lgrReplayTracer
         traceWith cdbTracer $ TraceOpenEvent OpenedLgrDB
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/Common.hs
@@ -1,12 +1,9 @@
-{-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE FlexibleContexts  #-}
-{-# LANGUAGE GADTs             #-}
-{-# LANGUAGE LambdaCase        #-}
-{-# LANGUAGE NamedFieldPuns    #-}
-{-# LANGUAGE RankNTypes        #-}
-{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE DeriveFunctor  #-}
+{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE GADTs          #-}
+{-# LANGUAGE LambdaCase     #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TypeFamilies   #-}
 
 module Ouroboros.Consensus.Storage.Common (
     -- * Epochs
@@ -14,11 +11,6 @@ module Ouroboros.Consensus.Storage.Common (
   , EpochSize(..)
     -- * Indexing
   , tipIsGenesis
-  , tipToPoint
-  , tipFromPoint
-    -- * Serialisation
-  , encodeTip
-  , decodeTip
     -- * BinaryInfo
   , BinaryInfo (..)
   , extractHeader
@@ -30,22 +22,16 @@ module Ouroboros.Consensus.Storage.Common (
   , SizeInBytes
   ) where
 
-import           Codec.CBOR.Decoding (Decoder)
-import           Codec.CBOR.Encoding (Encoding)
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BL
 import           Data.Word
 import           GHC.Generics
 
-import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..))
+import           Cardano.Slotting.Slot
 
-import           Ouroboros.Network.Block (Point (..), SlotNo, genesisPoint)
 import           Ouroboros.Network.DeltaQ (SizeInBytes)
-import           Ouroboros.Network.Point (WithOrigin (..))
 
-import           Ouroboros.Consensus.Block (IsEBB)
-import           Ouroboros.Consensus.Util.CBOR (decodeWithOrigin,
-                     encodeWithOrigin)
+import           Ouroboros.Consensus.Block
 
 {-------------------------------------------------------------------------------
   Indexing
@@ -54,30 +40,6 @@ import           Ouroboros.Consensus.Util.CBOR (decodeWithOrigin,
 tipIsGenesis :: WithOrigin r -> Bool
 tipIsGenesis Origin = True
 tipIsGenesis (At _) = False
-
-tipToPoint :: WithOrigin (Point blk) -> Point blk
-tipToPoint Origin = genesisPoint
-tipToPoint (At p) = p
-
--- | Tip from a point
---
--- NOTE: We really shouldn't instantate 'WithOrigin' with 'Point'; see
--- <https://github.com/input-output-hk/ouroboros-network/issues/1155>
-tipFromPoint :: Point blk -> WithOrigin (Point blk)
-tipFromPoint (Point Origin) = Origin
-tipFromPoint p              = At p
-
-{-------------------------------------------------------------------------------
-  Serialization
--------------------------------------------------------------------------------}
-
-encodeTip :: (r            -> Encoding)
-          -> (WithOrigin r -> Encoding)
-encodeTip = encodeWithOrigin
-
-decodeTip :: (forall s. Decoder s             r)
-          -> (forall s. Decoder s (WithOrigin r))
-decodeTip = decodeWithOrigin
 
 {-------------------------------------------------------------------------------
   BinaryInfo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -80,8 +80,9 @@ import           Cardano.Slotting.Slot
 
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util.CBOR (decodeWithOrigin,
+                     encodeWithOrigin)
 
-import           Ouroboros.Consensus.Storage.Common
 import           Ouroboros.Consensus.Storage.LedgerDB.Conf
 
 {-------------------------------------------------------------------------------
@@ -806,7 +807,7 @@ encodeChainSummary :: (l -> Encoding)
                    -> ChainSummary l r -> Encoding
 encodeChainSummary encodeLedger encodeRef ChainSummary{..} = mconcat [
       Enc.encodeListLen 3
-    , encodeTip encodeRef csTip
+    , encodeWithOrigin encodeRef csTip
     , Enc.encodeWord64 csLength
     , encodeLedger csLedger
     ]
@@ -816,7 +817,7 @@ decodeChainSummary :: (forall s. Decoder s l)
                    -> forall s. Decoder s (ChainSummary l r)
 decodeChainSummary decodeLedger decodeRef = do
     Dec.decodeListLenOf 3
-    csTip    <- decodeTip decodeRef
+    csTip    <- decodeWithOrigin decodeRef
     csLength <- Dec.decodeWord64
     csLedger <- decodeLedger
     return ChainSummary{..}

--- a/ouroboros-consensus/test-consensus/Test/Consensus/LocalStateQueryServer.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/LocalStateQueryServer.hs
@@ -27,7 +27,7 @@ import           Ouroboros.Network.Protocol.LocalStateQuery.Server
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
                      (AcquireFailure (..))
 
-import           Ouroboros.Consensus.Block (getHeader)
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -43,7 +43,8 @@ import           Ouroboros.Consensus.Util.IOLike
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache as BlockCache
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.LedgerCursor as LedgerCursor
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB
-                     (LedgerDbParams (..), LgrDB, LgrDbArgs (..), mkLgrDB)
+                     (LedgerDbParams (..), LgrDB, LgrDBConf, LgrDbArgs (..),
+                     mkLgrDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB as LgrDB
 import           Ouroboros.Consensus.Storage.LedgerDB.Conf (LedgerDbConf (..))
 import qualified Ouroboros.Consensus.Storage.LedgerDB.InMemory as LgrDB
@@ -189,9 +190,9 @@ initLgrDB k chain = do
           atomically $ LgrDB.setCurrent lgrDB ledgerDB'
           return lgrDB
   where
-    blockMapping :: Map (Point TestBlock) TestBlock
+    blockMapping :: Map (RealPoint TestBlock) TestBlock
     blockMapping = Map.fromList
-      [(blockPoint b, b) | b <- Chain.toOldestFirst chain]
+      [(blockRealPoint b, b) | b <- Chain.toOldestFirst chain]
 
     params :: LedgerDbParams
     params = LedgerDbParams
@@ -201,6 +202,7 @@ initLgrDB k chain = do
 
     cfg = testCfg k
 
+    conf :: LgrDBConf m TestBlock
     conf = LedgerDbConf
       { ldbConfGenesis = return testInitExtLedger
       , ldbConfApply   = runExcept .:

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -22,12 +22,12 @@ import qualified Data.Map.Strict as Map
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Ouroboros.Network.Block (ChainHash (..), HasHeader (..),
-                     HeaderHash, blockPoint)
+                     HeaderHash)
 import           Ouroboros.Network.MockChain.Chain (Chain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 import           Ouroboros.Network.Point (WithOrigin (..))
 
-import           Ouroboros.Consensus.Block (IsEBB (..), getHeader)
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
@@ -128,8 +128,8 @@ prop_773_bug = prop_general_test
       { immutable = Chain.fromOldestFirst [a, b, c, d]
       , volatile  = [c, d]
       }
-    (StreamFromInclusive (blockPoint a))
-    (StreamToInclusive   (blockPoint c))
+    (StreamFromInclusive (blockRealPoint a))
+    (StreamToInclusive   (blockRealPoint c))
     (Right (map Right [a, b, c]))
 
 -- | Requested stream = A -> E
@@ -144,8 +144,8 @@ prop_773_working = prop_general_test
       { immutable = Chain.fromOldestFirst [a, b, c, d]
       , volatile  = [c, d, e]
       }
-    (StreamFromInclusive (blockPoint a))
-    (StreamToInclusive   (blockPoint e))
+    (StreamFromInclusive (blockRealPoint a))
+    (StreamToInclusive   (blockRealPoint e))
     (Right (map Right [a, b, c, d, e]))
 
 -- | Requested stream = B' -> B' where EBB, B, and B' are all blocks in the
@@ -160,9 +160,9 @@ prop_1435_case1 = prop_general_test
       { immutable = Chain.fromOldestFirst [ebb, b]
       , volatile  = []
       }
-    (StreamFromInclusive (blockPoint b'))
-    (StreamToInclusive   (blockPoint b'))
-    (Left (ForkTooOld (StreamFromInclusive (blockPoint b'))))
+    (StreamFromInclusive (blockRealPoint b'))
+    (StreamToInclusive   (blockRealPoint b'))
+    (Left (ForkTooOld (StreamFromInclusive (blockRealPoint b'))))
   where
     ebb = firstEBB          TestBody { tbForkNo = 0, tbIsValid = True }
     b   = mkNextBlock ebb 0 TestBody { tbForkNo = 0, tbIsValid = True }
@@ -180,9 +180,9 @@ prop_1435_case2 = prop_general_test
       { immutable = Chain.fromOldestFirst [ebb, b]
       , volatile  = []
       }
-    (StreamFromInclusive (blockPoint ebb'))
-    (StreamToInclusive   (blockPoint ebb'))
-    (Left (ForkTooOld (StreamFromInclusive (blockPoint ebb'))))
+    (StreamFromInclusive (blockRealPoint ebb'))
+    (StreamToInclusive   (blockRealPoint ebb'))
+    (Left (ForkTooOld (StreamFromInclusive (blockRealPoint ebb'))))
   where
     ebb  = firstEBB          TestBody { tbForkNo = 0, tbIsValid = True }
     b    = mkNextBlock ebb 0 TestBody { tbForkNo = 0, tbIsValid = True }
@@ -200,8 +200,8 @@ prop_1435_case3 = prop_general_test
       { immutable = Chain.fromOldestFirst [ebb, b]
       , volatile  = []
       }
-    (StreamFromInclusive (blockPoint ebb))
-    (StreamToInclusive   (blockPoint ebb))
+    (StreamFromInclusive (blockRealPoint ebb))
+    (StreamToInclusive   (blockRealPoint ebb))
     (Right (map Right [ebb]))
   where
     ebb  = firstEBB          TestBody { tbForkNo = 0, tbIsValid = True }
@@ -219,8 +219,8 @@ prop_1435_case4 = prop_general_test
       { immutable = Chain.fromOldestFirst [ebb]
       , volatile  = [b]
       }
-    (StreamFromInclusive (blockPoint ebb))
-    (StreamToInclusive   (blockPoint ebb))
+    (StreamFromInclusive (blockRealPoint ebb))
+    (StreamToInclusive   (blockRealPoint ebb))
     (Right (map Right [ebb]))
   where
     ebb  = firstEBB          TestBody { tbForkNo = 0, tbIsValid = True }
@@ -238,9 +238,9 @@ prop_1435_case5 = prop_general_test
       { immutable = Chain.fromOldestFirst [ebb]
       , volatile  = []
       }
-    (StreamFromInclusive (blockPoint b'))
-    (StreamToInclusive   (blockPoint b'))
-    (Left (ForkTooOld (StreamFromInclusive (blockPoint b'))))
+    (StreamFromInclusive (blockRealPoint b'))
+    (StreamToInclusive   (blockRealPoint b'))
+    (Left (ForkTooOld (StreamFromInclusive (blockRealPoint b'))))
   where
     ebb  = firstEBB          TestBody { tbForkNo = 0, tbIsValid = True }
     b'   = mkNextBlock ebb 0 TestBody { tbForkNo = 1, tbIsValid = True }
@@ -257,9 +257,9 @@ prop_1435_case6 = prop_general_test
       { immutable = Chain.fromOldestFirst [ebb]
       , volatile  = []
       }
-    (StreamFromInclusive (blockPoint ebb'))
-    (StreamToInclusive   (blockPoint ebb'))
-    (Left (ForkTooOld (StreamFromInclusive (blockPoint ebb'))))
+    (StreamFromInclusive (blockRealPoint ebb'))
+    (StreamToInclusive   (blockRealPoint ebb'))
+    (Left (ForkTooOld (StreamFromInclusive (blockRealPoint ebb'))))
   where
     ebb  = firstEBB TestBody { tbForkNo = 0, tbIsValid = True }
     ebb' = firstEBB TestBody { tbForkNo = 1, tbIsValid = True }

--- a/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
@@ -207,11 +207,6 @@ anchorToBlockNo AnchorGenesis    = Origin
 anchorToBlockNo (Anchor _s _h b) = At b
 
 -- | Extract the 'SlotNo' from the anchor
---
--- NOTE: When the 'Anchor' is 'AnchorGenesis', this returns 'Origin'.
--- It does /not/ return 'genesisSlotNo', which is badly named, and is instead
--- the block number of the first block on the chain
--- (i.e., 'genesisPoint' and 'genesisSlotNo' don't go hand in hand!)
 anchorToSlotNo :: Anchor block -> WithOrigin SlotNo
 anchorToSlotNo AnchorGenesis    = Origin
 anchorToSlotNo (Anchor s _h _b) = At s


### PR DESCRIPTION
This instantiates the LedgerDB with `RealPoint` for its references, and moreover uses `RealPoint` to statically avoid the `NoGenesisBlock` exception.

We should have done this much sooner.

Closes #1155.