### PR TITLE
ChainDB: add blocks asynchronously

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -44,6 +44,7 @@ module Control.Monad.Class.MonadSTM
   , writeTBQueueDefault
   , isEmptyTBQueueDefault
   , isFullTBQueueDefault
+  , lengthTBQueueDefault
   ) where
 
 import           Prelude hiding (read)
@@ -423,3 +424,19 @@ isFullTBQueueDefault (TBQueue rsize _read wsize _write _size) = do
          if (r > 0)
             then return False
             else return True
+
+-- 'lengthTBQueue' was added in stm-2.5.0.0, but since we support older
+-- versions of stm, we don't include it as a method in the type class. If we
+-- were to conditionally (@MIN_VERSION_stm(2,5,0)@) include the method in the
+-- type class, the IO simulator would have to conditionally include the
+-- method, requiring a dependency on the @stm@ package, which would be
+-- strange.
+--
+-- Nevertheless, we already provide a default implementation. Downstream
+-- packages that don't mind having a >= 2.5 constraint on stm can use this to
+-- implement 'lengthTBQueue' for the IO simulator.
+lengthTBQueueDefault :: MonadSTM m => TBQueueDefault m a -> STM m Natural
+lengthTBQueueDefault (TBQueue rsize _read wsize _write size) = do
+  r <- readTVar rsize
+  w <- readTVar wsize
+  return $! size - r - w

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -13,6 +13,7 @@
 module Control.Monad.IOSim (
   -- * Simulation monad
   SimM,
+  SimSTM,
   -- ** Run simulation
   runSim,
   runSimOrThrow,
@@ -140,6 +141,8 @@ data StmA s a where
   Retry        :: StmA s b
   OrElse       :: StmA s a -> StmA s a -> (a -> StmA s b) -> StmA s b
 
+-- Exported type
+type SimSTM = STM
 
 data MaskingState = Unmasked | MaskedInterruptible | MaskedUninterruptible
   deriving (Eq, Ord, Show)

--- a/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -199,7 +199,7 @@ instance RunNode DualByronBlock where
       tip <- atomically $ ChainDB.getTipPoint chainDB
       case tip of
         BlockPoint {} -> return () -- Chain is not empty
-        GenesisPoint  -> ChainDB.addBlock chainDB genesisEBB
+        GenesisPoint  -> ChainDB.addBlock_ chainDB genesisEBB
           where
             genesisEBB :: DualByronBlock
             genesisEBB = DualBlock {

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -209,7 +209,7 @@ instance RunNode ByronBlock where
     case tip of
       -- Chain is not empty
       BlockPoint {} -> return ()
-      GenesisPoint  -> ChainDB.addBlock chainDB genesisEBB
+      GenesisPoint  -> ChainDB.addBlock_ chainDB genesisEBB
         where
           genesisEBB = forgeEBB cfg (SlotNo 0) (BlockNo 0) GenesisHash
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -492,7 +492,7 @@ runThreadNetwork ThreadNetworkArgs
                 pure (mSlot, fromWithOrigin (firstBlockNo (Proxy @blk)) bno, pointHash p)
               when (prevSlot < At ebbSlotNo) $ do
                 let ebb = forgeEBB cfg ebbSlotNo ebbBlockNo prevHash
-                ChainDB.addBlock chainDB ebb
+                ChainDB.addBlock_ chainDB ebb
 
           go (succ epoch)
 
@@ -551,6 +551,7 @@ runThreadNetwork ThreadNetworkArgs
         , cdbTraceLedger          = nullDebugTracer
         , cdbRegistry             = registry
         , cdbGcDelay              = 0
+        , cdbChainSelQueueSize    = 2
         }
       where
         -- prop_general relies on this tracer

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/IOLike.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/IOLike.hs
@@ -1,8 +1,13 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Test.Util.Orphans.IOLike () where
 
+import           Control.Monad.Class.MonadSTM (lengthTBQueueDefault)
 import           Control.Monad.IOSim
 import           Ouroboros.Consensus.Util.IOLike
 import           Test.Util.Orphans.NoUnexpectedThunks ()
+
+instance MonadSTMTxExtended (SimSTM s) where
+  lengthTBQueue = lengthTBQueueDefault
 
 instance IOLike (SimM s)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -216,7 +216,7 @@ library
                      , network           >=3.1   && <3.2
                      , psqueues          >=0.2.3 && <0.3
                      , serialise         >=0.2   && <0.3
-                     , stm
+                     , stm               >=2.5   && <2.6
                      , streaming
                      , text              >=1.2   && <1.3
                      , time

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -126,6 +126,7 @@ openDBInternal args launchBgTasks = do
     varCopyLock        <- newMVar  ()
     varKillBgThreads   <- newTVarM $ return ()
     varFutureBlocks    <- newTVarM Map.empty
+    blocksToAdd        <- newBlocksToAdd (Args.cdbChainSelQueueSize args)
 
     let env = CDB { cdbImmDB           = immDB
                   , cdbVolDB           = volDB
@@ -147,11 +148,12 @@ openDBInternal args launchBgTasks = do
                   , cdbIsEBB           = toIsEBB . isJust . Args.cdbIsEBB args
                   , cdbCheckIntegrity  = Args.cdbCheckIntegrity args
                   , cdbBlockchainTime  = Args.cdbBlockchainTime args
+                  , cdbBlocksToAdd     = blocksToAdd
                   , cdbFutureBlocks    = varFutureBlocks
                   }
     h <- fmap CDBHandle $ newTVarM $ ChainDbOpen env
     let chainDB = ChainDB
-          { addBlock           = getEnv1    h ChainSel.addBlock
+          { addBlockAsync      = getEnv1    h ChainSel.addBlockAsync
           , getCurrentChain    = getEnvSTM  h Query.getCurrentChain
           , getCurrentLedger   = getEnvSTM  h Query.getCurrentLedger
           , getTipBlock        = getEnv     h Query.getTipBlock
@@ -176,6 +178,7 @@ openDBInternal args launchBgTasks = do
           , intGarbageCollect          = getEnv1 h Background.garbageCollect
           , intUpdateLedgerSnapshots   = getEnv  h Background.updateLedgerSnapshots
           , intScheduledChainSelection = getEnv1 h Background.scheduledChainSelection
+          , intAddBlockRunner          = getEnv  h Background.addBlockRunner
           , intKillBgThreads           = varKillBgThreads
           }
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -104,18 +104,24 @@ data ChainDbArgs m blk = forall h1 h2 h3. ChainDbArgs {
     , cdbTraceLedger          :: Tracer m (LgrDB.LedgerDB blk)
     , cdbRegistry             :: ResourceRegistry m
     , cdbGcDelay              :: DiffTime
+    , cdbChainSelQueueSize    :: Word
+      -- ^ Size of the queue used to store asynchronously added blocks. This
+      -- is the maximum number of blocks that could be kept in memory at the
+      -- same time when the background thread processing the blocks can't keep
+      -- up.
     }
 
 -- | Arguments specific to the ChainDB, not to the ImmutableDB, VolatileDB, or
 -- LedgerDB.
 data ChainDbSpecificArgs m blk = ChainDbSpecificArgs {
-      cdbsTracer         :: Tracer m (TraceEvent blk)
-    , cdbsRegistry       :: ResourceRegistry m
+      cdbsTracer            :: Tracer m (TraceEvent blk)
+    , cdbsRegistry          :: ResourceRegistry m
       -- ^ TODO: the ImmutableDB takes a 'ResourceRegistry' too, but we're
       -- using it for ChainDB-specific things. Revisit these arguments.
-    , cdbsGcDelay        :: DiffTime
-    , cdbsBlockchainTime :: BlockchainTime m
-    , cdbsEncodeHeader   :: Header blk -> Encoding
+    , cdbsGcDelay           :: DiffTime
+    , cdbsBlockchainTime    :: BlockchainTime m
+    , cdbsEncodeHeader      :: Header blk -> Encoding
+    , cdbsChainSelQueueSize :: Word
     }
 
 -- | Default arguments
@@ -128,12 +134,13 @@ data ChainDbSpecificArgs m blk = ChainDbSpecificArgs {
 -- * 'cdbsEncodeHeader'
 defaultSpecificArgs :: ChainDbSpecificArgs m blk
 defaultSpecificArgs = ChainDbSpecificArgs{
-      cdbsGcDelay        = oneHour
+      cdbsGcDelay           = oneHour
+    , cdbsChainSelQueueSize = 10
       -- Fields without a default
-    , cdbsTracer         = error "no default for cdbsTracer"
-    , cdbsRegistry       = error "no default for cdbsRegistry"
-    , cdbsBlockchainTime = error "no default for cdbsBlockchainTime"
-    , cdbsEncodeHeader   = error "no default for cdbsEncodeHeader"
+    , cdbsTracer          = error "no default for cdbsTracer"
+    , cdbsRegistry        = error "no default for cdbsRegistry"
+    , cdbsBlockchainTime  = error "no default for cdbsBlockchainTime"
+    , cdbsEncodeHeader    = error "no default for cdbsEncodeHeader"
     }
   where
     oneHour = secondsToDiffTime 60 * 60
@@ -210,11 +217,12 @@ fromChainDbArgs ChainDbArgs{..} = (
         , lgrTraceLedger          = cdbTraceLedger
         }
     , ChainDbSpecificArgs {
-          cdbsTracer          = cdbTracer
-        , cdbsRegistry        = cdbRegistry
-        , cdbsGcDelay         = cdbGcDelay
-        , cdbsBlockchainTime  = cdbBlockchainTime
-        , cdbsEncodeHeader    = cdbEncodeHeader
+          cdbsTracer            = cdbTracer
+        , cdbsRegistry          = cdbRegistry
+        , cdbsGcDelay           = cdbGcDelay
+        , cdbsBlockchainTime    = cdbBlockchainTime
+        , cdbsEncodeHeader      = cdbEncodeHeader
+        , cdbsChainSelQueueSize = cdbChainSelQueueSize
         }
     )
 
@@ -270,4 +278,5 @@ toChainDbArgs ImmDB.ImmDbArgs{..}
     , cdbTraceLedger          = lgrTraceLedger
     , cdbRegistry             = immRegistry
     , cdbGcDelay              = cdbsGcDelay
+    , cdbChainSelQueueSize    = cdbsChainSelQueueSize
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -25,7 +25,8 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Background
   , newGcSchedule
   , scheduleGC
   , gcScheduleRunner
-    -- * Taking and trimming ledger snapshots
+    -- * Adding blocks to the ChainDB
+  , addBlockRunner
     -- * Executing scheduled chain selections
   , scheduledChainSelection
   , scheduledChainSelectionRunner
@@ -60,7 +61,7 @@ import           Ouroboros.Consensus.Storage.ChainDB.API (BlockRef (..),
                      ChainDbFailure (..))
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache as BlockCache
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel
-                     (chainSelectionForBlock)
+                     (addBlockSync, chainSelectionForBlock)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.ImmDB as ImmDB
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB as LgrDB
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Types
@@ -76,6 +77,8 @@ launchBgTasks
   -> Word64 -- ^ Number of immutable blocks replayed on ledger DB startup
   -> m ()
 launchBgTasks cdb@CDB{..} replayed = do
+    !addBlockThread <- launch $
+      addBlockRunner cdb
     gcSchedule <- newGcSchedule
     !gcThread <- launch $
       gcScheduleRunner gcSchedule $ garbageCollect cdb
@@ -83,7 +86,7 @@ launchBgTasks cdb@CDB{..} replayed = do
       copyAndSnapshotRunner cdb gcSchedule replayed
     !chainSyncThread <- scheduledChainSelectionRunner cdb
     atomically $ writeTVar cdbKillBgThreads $
-      sequence_ [gcThread, copyAndSnapshotThread, chainSyncThread]
+      sequence_ [addBlockThread, gcThread, copyAndSnapshotThread, chainSyncThread]
   where
     launch :: m Void -> m (m ())
     launch = fmap cancelThread . forkLinkedThread cdbRegistry
@@ -374,45 +377,65 @@ gcScheduleRunner (GcSchedule queue) runGc = forever $ do
     runGc slotNo
 
 {-------------------------------------------------------------------------------
+  Adding blocks to the ChainDB
+-------------------------------------------------------------------------------}
+
+-- | Read blocks from 'cdbBlocksToAdd' and add them synchronously to the
+-- ChainDB.
+addBlockRunner
+  :: (IOLike m, LedgerSupportsProtocol blk, HasCallStack)
+  => ChainDbEnv m blk
+  -> m Void
+addBlockRunner cdb@CDB{..} = forever $ do
+    blockToAdd <- getBlockToAdd cdbBlocksToAdd
+    addBlockSync cdb blockToAdd
+
+{-------------------------------------------------------------------------------
   Executing scheduled chain selections
 -------------------------------------------------------------------------------}
 
--- | Retrieve the blocks from 'cdbFutureBlocks' for which chain selection was
--- scheduled at the current slot. Run chain selection for each of them.
+-- | Retrieve the 'FutureBlockToAdd's from 'cdbFutureBlocks' for which chain
+-- selection was scheduled at the current slot. Run chain selection for each
+-- of them.
 scheduledChainSelection
   :: (IOLike m, LedgerSupportsProtocol blk, HasCallStack)
   => ChainDbEnv m blk
   -> SlotNo  -- ^ The current slot
   -> m ()
 scheduledChainSelection cdb@CDB{..} curSlot = do
-    (mbHdrs, remaining)
+    (mbFutureBlocks, remaining)
       <- atomically $ updateTVar cdbFutureBlocks $ \futureBlocks ->
         -- Extract and delete the value stored at @curSlot@
-        let (mbHdrs, remaining) = Map.updateLookupWithKey
+        let (mbFutureBlocks, remaining) = Map.updateLookupWithKey
               (\_ _ -> Nothing) curSlot futureBlocks
-        in (remaining, (mbHdrs, remaining))
-    -- The list of headers is stored in reverse order so we can easily
-    -- prepend. We reverse them here now so we add them in chronological
-    -- order, even though this should not matter, as they are all blocks for
-    -- the same slot: at most one block per slot can be adopted.
+        in (remaining, (mbFutureBlocks, remaining))
+    -- The list is stored in reverse order so we can easily prepend. We
+    -- reverse them here now so we add them in chronological order, even
+    -- though this should not matter, as they are all blocks for the same
+    -- slot: at most one block per slot can be adopted.
     --
     -- The only exception is an EBB, which shares the slot with a regular
     -- block. Either order of adding them would result in the same chain, but
     -- adding the EBB before the regular block is cheaper, as we can simply
     -- extend the current chain instead of adding a disconnected block first
     -- and then switching to a very short fork.
-    whenJust (NE.reverse <$> mbHdrs) $ \hdrs -> do
+    whenJust (NE.reverse <$> mbFutureBlocks) $ \futureBlocks -> do
       let nbScheduled = fromIntegral $ sum $ length <$> Map.elems remaining
-      traceWith cdbTracer $
-        TraceAddBlockEvent $
-        RunningScheduledChainSelection (fmap headerPoint hdrs) curSlot nbScheduled
+      traceWith cdbTracer $ TraceAddBlockEvent $
+        RunningScheduledChainSelection
+          (fmap (headerPoint . futureBlockHdr) futureBlocks)
+          curSlot
+          nbScheduled
       -- If an exception occurs during a call to 'chainSelectionForBlock',
       -- then no chain selection will be performed for the blocks after it.
       -- Only real errors that would shut down the ChainDB could be thrown. In
       -- which case, the ChainDB has to be (re)started, triggering a full
       -- chain selection, which would include these blocks. So there is no
       -- risk of "forgetting" to add a block.
-      mapM_ (chainSelectionForBlock cdb BlockCache.empty) hdrs
+      forM_ futureBlocks $ \(FutureBlockToAdd hdr varChainSelectionPerformed) -> do
+        newTip <- chainSelectionForBlock cdb BlockCache.empty hdr
+        -- Important: notify that chain selection has been performed for the block
+        atomically $ putTMVar varChainSelectionPerformed newTip
 
 -- | Whenever the current slot changes, call 'scheduledChainSelection' for the
 -- (new) current slot.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GADTs                #-}
 {-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE MultiWayIf           #-}
+{-# LANGUAGE NamedFieldPuns       #-}
 {-# LANGUAGE PatternSynonyms      #-}
 {-# LANGUAGE RecordWildCards      #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
@@ -13,7 +14,8 @@
 -- adding a block.
 module Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel
   ( initialChainSelection
-  , addBlock
+  , addBlockAsync
+  , addBlockSync
   , chainSelectionForBlock
     -- * Type for in-sync chain and ledger
   , ChainAndLedger -- Opaque
@@ -62,8 +64,8 @@ import           Ouroboros.Consensus.Util.AnchoredFragment
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.STM (WithFingerprint (..))
 
-import           Ouroboros.Consensus.Storage.ChainDB.API
-                     (InvalidBlockReason (..))
+import           Ouroboros.Consensus.Storage.ChainDB.API (AddBlockPromise (..),
+                     InvalidBlockReason (..))
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache
                      (BlockCache)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache as BlockCache
@@ -161,7 +163,38 @@ initialChainSelection immDB volDB lgrDB tracer cfg varInvalid curSlot = do
         curChainAndLedger
         (fmap (mkCandidateSuffix 0) candidates)
 
--- | Add a block to the ChainDB.
+-- | Add a block to the ChainDB, /asynchronously/.
+--
+-- This adds a 'BlockToAdd' corresponding to the given block to the
+-- 'cdbBlocksToAdd' queue. The entries in that queue are processed using
+-- 'addBlockSync', see that function for more information.
+--
+-- When the queue is full, this function will still block.
+--
+-- An important advantage of this asynchronous approach over a synchronous
+-- approach is that it doesn't have the following disadvantage: when a thread
+-- adding a block to the ChainDB is killed, which can happen when
+-- disconnecting from the corresponding node, we might have written the block
+-- to disk, but not updated the corresponding in-memory state (e.g., that of
+-- the VolatileDB), leaving both out of sync.
+--
+-- With this asynchronous approach, threads adding blocks asynchronously can
+-- be killed without worries, the background thread processing the blocks
+-- synchronously won't be killed. Only when the whole ChainDB shuts down will
+-- that background thread get killed. But since there will be no more
+-- in-memory state, it can't get out of sync with the file system state. On
+-- the next startup, a correct in-memory state will be reconstructed from the
+-- file system state.
+addBlockAsync
+  :: forall m blk. (IOLike m, HasHeader blk)
+  => ChainDbEnv m blk
+  -> blk
+  -> m (AddBlockPromise m blk)
+addBlockAsync CDB { cdbTracer, cdbBlocksToAdd } =
+    enqueueBlockToAdd (contramap TraceAddBlockEvent cdbTracer) cdbBlocksToAdd
+
+-- | Add a block to the ChainDB, /synchronously/, called in the background
+-- thread. This is not meant to be called by the user.
 --
 -- This is the only operation that actually changes the ChainDB. It will store
 -- the block on disk and trigger chain selection, possibly switching to a
@@ -169,7 +202,7 @@ initialChainSelection immDB volDB lgrDB tracer cfg varInvalid curSlot = do
 --
 -- When the slot of the block is > the current slot, a chain selection will be
 -- scheduled in the slot of the block.
-addBlock
+addBlockSync
   :: forall m blk.
      ( IOLike m
      , HasHeader blk
@@ -177,41 +210,52 @@ addBlock
      , HasCallStack
      )
   => ChainDbEnv m blk
-  -> blk
+  -> BlockToAdd m blk
   -> m ()
-addBlock cdb@CDB{..} b = do
+addBlockSync cdb@CDB {..} BlockToAdd { blockToAdd = b, .. } = do
     -- No need to be in the same STM transaction
     curSlot <- atomically $ getCurrentSlot cdbBlockchainTime
 
-    (isMember, invalid, immBlockNo) <- atomically $ (,,)
+    (isMember, invalid, curChain) <- atomically $ (,,)
       <$> VolDB.getIsMember               cdbVolDB
       <*> (forgetFingerprint <$> readTVar cdbInvalid)
-      <*> (AF.anchorBlockNo  <$> Query.getCurrentChain cdb)
+      <*> Query.getCurrentChain           cdb
+
+    let immBlockNo = AF.anchorBlockNo curChain
+        curTip     = castPoint (AF.headPoint curChain)
 
     -- We follow the steps from section "## Adding a block" in ChainDB.md
 
     -- ### Ignore
     if
-      | olderThanK hdr (cdbIsEBB hdr) immBlockNo ->
+      | olderThanK hdr (cdbIsEBB hdr) immBlockNo -> do
         trace $ IgnoreBlockOlderThanK (blockPoint b)
-      | isMember (blockHash b) ->
+        deliverPromises curTip
+
+      | isMember (blockHash b) -> do
         trace $ IgnoreBlockAlreadyInVolDB (blockPoint b)
-      | Just (InvalidBlockInfo reason _) <- Map.lookup (blockHash b) invalid ->
+        deliverPromises curTip
+
+      | Just (InvalidBlockInfo reason _) <- Map.lookup (blockHash b) invalid -> do
         trace $ IgnoreInvalidBlock (blockPoint b) reason
+        deliverPromises curTip
 
-      --- ### Store but schedule chain selection
+      -- ### Store but schedule chain selection
       | blockSlot b > curSlot -> do
-
         VolDB.putBlock cdbVolDB b
-        trace $ BlockInTheFuture (blockPoint b) curSlot
         trace $ AddedBlockToVolDB (blockPoint b) (blockNo b) (cdbIsEBB hdr)
+        atomically $ putTMVar varBlockProcessed curTip
+        -- We'll fill in 'varChainSelectionPerformed' when the scheduled chain
+        -- selection is performed.
+        trace $ BlockInTheFuture (blockPoint b) curSlot
         scheduleChainSelection curSlot (blockSlot b)
 
       -- The remaining cases
       | otherwise -> do
         VolDB.putBlock cdbVolDB b
         trace $ AddedBlockToVolDB (blockPoint b) (blockNo b) (cdbIsEBB hdr)
-        chainSelectionForBlock cdb (BlockCache.singleton b) hdr
+        newTip <- chainSelectionForBlock cdb (BlockCache.singleton b) hdr
+        deliverPromises newTip
   where
     trace :: TraceAddBlockEvent blk -> m ()
     trace = traceWith (contramap TraceAddBlockEvent cdbTracer)
@@ -219,14 +263,22 @@ addBlock cdb@CDB{..} b = do
     hdr :: Header blk
     hdr = getHeader b
 
+    -- | Use the given 'Point' to fill in the 'TMVar's corresponding to the
+    -- block's 'AddBlockPromise'.
+    deliverPromises :: Point blk -> m ()
+    deliverPromises tip = atomically $ do
+      putTMVar varBlockProcessed          tip
+      putTMVar varChainSelectionPerformed tip
+
     scheduleChainSelection
       :: SlotNo  -- ^ Current slot number
       -> SlotNo  -- ^ Slot number of the block
       -> m ()
     scheduleChainSelection curSlot slot = do
       nbScheduled <- atomically $ updateTVar cdbFutureBlocks $ \futureBlocks ->
-        let futureBlocks' = Map.insertWith strictAppend slot
-              (forceElemsToWHNF (hdr NE.:| [])) futureBlocks
+        let futureBlockToAdd = FutureBlockToAdd hdr varChainSelectionPerformed
+            futureBlocks' = Map.insertWith strictAppend slot
+              (forceElemsToWHNF (futureBlockToAdd NE.:| [])) futureBlocks
             nbScheduled   = fromIntegral $ sum $ length <$> Map.elems futureBlocks
         in (futureBlocks', nbScheduled)
       trace $ ScheduledChainSelection (headerPoint hdr) curSlot nbScheduled
@@ -273,6 +325,8 @@ olderThanK hdr isEBB immBlockNo
 --
 -- PRECONDITION: the slot of the block <= the current (wall) slot
 --
+-- The new tip of the current chain is returned.
+--
 -- = Constructing candidate fragments
 --
 -- The VolatileDB keeps a \"successors\" map in memory, telling us the hashes
@@ -307,7 +361,7 @@ chainSelectionForBlock
   => ChainDbEnv m blk
   -> BlockCache blk
   -> Header blk
-  -> m ()
+  -> m (Point blk)
 chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
     curSlot <- atomically $ getCurrentSlot cdbBlockchainTime
 
@@ -344,12 +398,14 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
     if
       -- The chain might have grown since we added the block such that the
       -- block is older than @k@.
-      | olderThanK hdr (cdbIsEBB hdr) immBlockNo ->
+      | olderThanK hdr (cdbIsEBB hdr) immBlockNo -> do
         trace $ IgnoreBlockOlderThanK p
+        return tipPoint
 
       -- We might have validated the block in the meantime
-      | Just (InvalidBlockInfo reason _) <- Map.lookup (headerHash hdr) invalid ->
+      | Just (InvalidBlockInfo reason _) <- Map.lookup (headerHash hdr) invalid -> do
         trace $ IgnoreInvalidBlock p reason
+        return tipPoint
 
       -- The block @b@ fits onto the end of our current chain
       | pointHash tipPoint == castHash (blockPrevHash hdr) -> do
@@ -362,9 +418,10 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
         trace (TrySwitchToAFork p hashes)
         switchToAFork succsOf' curChainAndLedger hashes curSlot
 
-      | otherwise ->
+      | otherwise -> do
         -- ### Store but don't change the current chain
         trace (StoreButDontChange p)
+        return tipPoint
 
     -- Note that we may have extended the chain, but have not trimmed it to
     -- @k@ blocks/headers. That is the job of the background thread, which
@@ -387,7 +444,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
                          -- ^ The current chain and ledger
                       -> SlotNo
                          -- ^ The current slot
-                      -> m ()
+                      -> m (Point blk)
     addToCurrentChain succsOf curChainAndLedger@(ChainAndLedger curChain _)
                       curSlot = assert (AF.validExtension curChain hdr) $ do
         let suffixesAfterB = VolDB.candidates succsOf p
@@ -429,14 +486,15 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
         -- candidate will be a two-block (the EBB and the new block)
         -- extension of the current chain.
         case candidateSuffixes of
-          Nothing                 -> return ()
+          Nothing                 -> return curTip
           Just candidateSuffixes' ->
             chainSelection' curChainAndLedger candidateSuffixes' >>= \case
-              Nothing                -> return ()
+              Nothing                -> return curTip
               Just newChainAndLedger ->
                 trySwitchTo newChainAndLedger (AddedToCurrentChain p)
       where
         curHead = AF.headAnchor curChain
+        curTip  = castPoint $ AF.headPoint curChain
 
     -- | We have found a path of hashes to the new block through the
     -- VolatileDB. We try to extend this path by looking for forks that start
@@ -450,7 +508,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
                      -- ^ An uninterrupted path of hashes @(i,b]@.
                   -> SlotNo
                      -- ^ The current slot
-                  -> m ()
+                  -> m (Point blk)
     switchToAFork succsOf curChainAndLedger@(ChainAndLedger curChain _) hashes
                   curSlot = do
         let suffixesAfterB = VolDB.candidates succsOf p
@@ -473,15 +531,15 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
 
         case NE.nonEmpty candidateSuffixes of
           -- No candidates preferred over the current chain
-          Nothing                 -> return ()
+          Nothing                 -> return curTip
           Just candidateSuffixes' ->
             chainSelection' curChainAndLedger candidateSuffixes' >>= \case
-              Nothing                -> return ()
+              Nothing                -> return curTip
               Just newChainAndLedger ->
                 trySwitchTo newChainAndLedger (SwitchedToAFork p)
       where
         i = AF.castAnchor $ anchor curChain
-
+        curTip = castPoint $ AF.headPoint curChain
 
     -- | 'chainSelection' partially applied to the parameters from the
     -- 'ChainDbEnv'.
@@ -550,7 +608,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
          )
          -- ^ Given the previous chain and the new chain, return the event
          -- to trace when we switched to the new chain.
-      -> m ()
+      -> m (Point blk)
     trySwitchTo (ChainAndLedger newChain newLedger) mkTraceEvent = do
       (curChain, switched) <- atomically $ do
         curChain <- readTVar cdbChain
@@ -584,8 +642,10 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
       if switched then do
         trace $ mkTraceEvent curChain newChain
         traceWith cdbTraceLedger newLedger
+        return $ castPoint $ AF.headPoint newChain
       else do
         trace $ ChainChangedInBg curChain newChain
+        return $ castPoint $ AF.headPoint curChain
 
     -- | Build a cache from the headers in the fragment.
     cacheHeaders :: AnchoredFragment (Header blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/EarlyExit.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/EarlyExit.hs
@@ -26,7 +26,7 @@ import           Control.Monad.Trans.Maybe
 import           Data.Function (on)
 import           Data.Proxy
 
-import           Cardano.Prelude (NoUnexpectedThunks(..))
+import           Cardano.Prelude (NoUnexpectedThunks (..))
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
@@ -37,7 +37,8 @@ import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 
 import           Ouroboros.Consensus.Util ((.:))
-import           Ouroboros.Consensus.Util.IOLike (IOLike, StrictTVar, StrictMVar)
+import           Ouroboros.Consensus.Util.IOLike (IOLike,
+                     MonadSTMTxExtended (..), StrictMVar, StrictTVar)
 
 {-------------------------------------------------------------------------------
   Basic definitions
@@ -112,6 +113,9 @@ instance MonadSTMTx stm => MonadSTMTx (WithEarlyExit stm) where
   writeTBQueue    = lift .: writeTBQueue
   isEmptyTBQueue  = lift .  isEmptyTBQueue
   isFullTBQueue   = lift .  isFullTBQueue
+
+instance MonadSTMTxExtended stm => MonadSTMTxExtended (WithEarlyExit stm) where
+  lengthTBQueue   = lift .  lengthTBQueue
 
 instance MonadSTM m => MonadSTM (WithEarlyExit m) where
   type STM (WithEarlyExit m) = WithEarlyExit (STM m)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -20,6 +20,7 @@ module Ouroboros.Consensus.Util.IOLike (
   , MonadAsyncSTM(..)
   , MonadAsync(..)
   , ExceptionInLinkedThread(..)
+  , link
   , linkTo
     -- *** MonadST
   , MonadST(..)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -287,6 +287,7 @@ mkArgs cfg initLedger tracer registry hashInfo
     , cdbTraceLedger          = nullTracer
     , cdbRegistry             = registry
     , cdbGcDelay              = 0
+    , cdbChainSelQueueSize    = 2
     }
   where
     addDummyBinaryInfo :: CBOR.Encoding -> BinaryInfo CBOR.Encoding

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -119,7 +119,7 @@ openDB cfg initLedger btime = do
     void $ onSlotChange btime $ update_ . Model.advanceCurSlot cfg
 
     return ChainDB {
-        addBlock            = update_  . Model.addBlock cfg
+        addBlockAsync       = update   . Model.addBlockPromise cfg
       , getCurrentChain     = querySTM $ Model.lastK k getHeader
       , getCurrentLedger    = querySTM $ Model.currentLedger
       , getBlockComponent   = queryE  .: Model.getBlockComponentByPoint

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -304,8 +304,8 @@ run :: forall m blk. (IOLike m, HasHeader blk)
     ->    Cmd     blk (TestIterator m blk) (TestReader m blk)
     -> m (Success blk (TestIterator m blk) (TestReader m blk))
 run chainDB@ChainDB{..} internal registry varCurSlot varNextId = \case
-    AddBlock blk             -> Unit                <$> (advanceAndAdd (blockSlot blk) blk)
-    AddFutureBlock blk s     -> Unit                <$> (advanceAndAdd s               blk)
+    AddBlock blk             -> Point               <$> (advanceAndAdd (blockSlot blk) blk)
+    AddFutureBlock blk s     -> Point               <$> (advanceAndAdd s               blk)
     GetCurrentChain          -> Chain               <$> atomically getCurrentChain
     GetCurrentLedger         -> Ledger              <$> atomically getCurrentLedger
     GetPastLedger pt         -> MbLedger            <$> getPastLedger chainDB pt
@@ -343,7 +343,7 @@ run chainDB@ChainDB{..} internal registry varCurSlot varNextId = \case
         forM_ [prevCurSlot + 1..newCurSlot] $ \slot -> do
           atomically $ writeTVar varCurSlot slot
           intScheduledChainSelection internal slot
-      addBlock blk
+      addBlock chainDB blk
 
     giveWithEq :: a -> m (WithEq a)
     giveWithEq a =
@@ -460,8 +460,8 @@ runPure :: forall blk.
         -> DBModel         blk
         -> (Resp           blk IteratorId ReaderId, DBModel blk)
 runPure cfg = \case
-    AddBlock blk             -> ok  Unit                $ update_ (advanceAndAdd (blockSlot blk) blk)
-    AddFutureBlock blk s     -> ok  Unit                $ update_ (advanceAndAdd s               blk)
+    AddBlock blk             -> ok  Point               $ update  (advanceAndAdd (blockSlot blk) blk)
+    AddFutureBlock blk s     -> ok  Point               $ update  (advanceAndAdd s               blk)
     GetCurrentChain          -> ok  Chain               $ query   (Model.lastK k getHeader)
     GetCurrentLedger         -> ok  Ledger              $ query    Model.currentLedger
     GetPastLedger pt         -> ok  MbLedger            $ query   (Model.getPastLedger cfg pt)
@@ -486,8 +486,9 @@ runPure cfg = \case
   where
     k = configSecurityParam cfg
 
-    advanceAndAdd slot blk =
-      Model.addBlock cfg blk . Model.advanceCurSlot cfg slot
+    advanceAndAdd slot blk m = (Model.tipPoint m', m')
+      where
+        m' = Model.addBlock cfg blk $ Model.advanceCurSlot cfg slot m
 
     iter = either UnknownRange Iter
     mbGCedAllComponents = MbGCedAllComponents . MaybeGCedBlock False
@@ -1304,9 +1305,13 @@ prop_sequential = forAllCommands smUnused Nothing $ \cmds -> QC.monadicIO $ do
         <*> uncheckedNewTVarM Mock.empty
       let args = mkArgs testCfg testInitExtLedger tracer threadRegistry varCurSlot fsVars
       (db, internal)     <- QC.run $ openDBInternal args False
+      -- TODO use withAsync or registry
+      addBlockAsync      <- QC.run $ async $ intAddBlockRunner internal
+      QC.run $ link addBlockAsync
       let sm' = sm db internal iteratorRegistry varCurSlot varNextId genBlk testCfg testInitExtLedger
       (hist, model, res) <- runCommands sm' cmds
       (realChain, realChain', trace, fses, remainingCleanups) <- QC.run $ do
+        cancel addBlockAsync
         trace <- getTrace
         open <- atomically $ isOpen db
         unless open $ intReopen internal False
@@ -1489,6 +1494,7 @@ mkArgs cfg initLedger tracer registry varCurSlot
     , cdbTraceLedger          = nullTracer
     , cdbRegistry             = registry
     , cdbGcDelay              = 0
+    , cdbChainSelQueueSize    = 2
     }
 
 tests :: TestTree


### PR DESCRIPTION
Fixes #1463.

Instead of adding blocks synchronously, they are now put into a queue, after
which `addBlockAsync` returns an `AddBlockResult`, which can be used to wait
until the block has been processed.

A background thread will read the blocks from the queue and add them
synchronously to the ChainDB. The queue is limited in size; when it is full,
callers of `addBlockAsync` might still have to wait.

With this asynchronous approach, threads adding blocks asynchronously can be
killed without worries, the background thread processing the blocks
synchronously won't be killed. Only when the whole ChainDB shuts down will
that background thread get killed. But since there will be no more in-memory
state, it can't get out of sync with the file system state. On the next
startup, a correct in-memory state will be reconstructed from the file system
state.

By letting the BlockFetchClient add blocks asynchronously, we also get a
20-40% bulk chain sync speed-up in some microbenchmarks.