### PR TITLE
Resolve unexpected thunks encountered during ChainDB tests

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -242,13 +242,13 @@ instance Condense (ChainHash TestBlock) where
   condense (BlockHash h) = show h
 
 data instance BlockConfig TestBlock = TestBlockConfig {
-      testBlockSlotLengths :: SlotLengths
+      testBlockSlotLengths :: !SlotLengths
 
       -- | Number of core nodes
       --
       -- We need this in order to compute the 'ValidateView', which must
       -- conjure up a validation key out of thin air
-    , testBlockNumCoreNodes :: NumCoreNodes
+    , testBlockNumCoreNodes :: !NumCoreNodes
     }
   deriving (Generic, NoUnexpectedThunks)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -322,10 +322,10 @@ class HasAnnTip blk => ValidateEnvelope blk where
 -- | Invalid header
 data HeaderError blk =
     -- | Invalid consensus protocol fields
-    HeaderProtocolError (ValidationErr (BlockProtocol blk))
+    HeaderProtocolError !(ValidationErr (BlockProtocol blk))
 
     -- | Failed to validate the envelope
-  | HeaderEnvelopeError (HeaderEnvelopeError blk)
+  | HeaderEnvelopeError !(HeaderEnvelopeError blk)
   deriving (Generic)
 
 deriving instance BlockSupportsProtocol blk => Eq                 (HeaderError blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeId.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeId.hs
@@ -24,8 +24,8 @@ import           Ouroboros.Consensus.Util.Condense (Condense (..))
 
 -- TODO: It is not at all clear that this makes any sense anymore. The network
 -- layer does not use or provide node ids (it uses addresses).
-data NodeId = CoreId CoreNodeId
-            | RelayId Word64
+data NodeId = CoreId !CoreNodeId
+            | RelayId !Word64
   deriving (Eq, Ord, Show, Generic, NoUnexpectedThunks)
 
 instance Condense NodeId where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -157,13 +157,13 @@ instance HasHeader (Header TestBlock) where
   blockInvariant = const True
 
 data instance BlockConfig TestBlock = TestBlockConfig {
-      testBlockSlotLengths :: SlotLengths
+      testBlockSlotLengths :: !SlotLengths
 
       -- | Number of core nodes
       --
       -- We need this in order to compute the 'ValidateView', which must
       -- conjure up a validation key out of thin air
-    , testBlockNumCoreNodes :: NumCoreNodes
+    , testBlockNumCoreNodes :: !NumCoreNodes
     }
   deriving (Generic, NoUnexpectedThunks)
 

--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -128,7 +128,7 @@ class ( Eq        (HeaderHash b)
       , NoUnexpectedThunks (HeaderHash b)
       ) => StandardHash b
 
-data ChainHash b = GenesisHash | BlockHash (HeaderHash b)
+data ChainHash b = GenesisHash | BlockHash !(HeaderHash b)
   deriving (Generic)
 
 deriving instance StandardHash block => Eq   (ChainHash block)


### PR DESCRIPTION
When running the tests with `--flag io-sim-classes:checktvarinvariant`, I noticed that some of them were triggering invariant violations as unexpected thunks were found.

The tests that were specifically failing were [`Test.Ouroboros.Storage.ChainDB.AddBlock.prop_addBlock_multiple_threads`](https://github.com/input-output-hk/ouroboros-network/blob/387ab3c3b33716cc6db1e7bf17764aa8daaf9911/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs#L106) and [`Test.Ouroboros.Storage.ChainDB.StateMachine.prop_sequential`](https://github.com/input-output-hk/ouroboros-network/blob/5fa286f0efc5cab4ec3eaa33f44a2ccec0cb207c/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs#L1298).