### PR TITLE
Fixed #1723 - use LocalAddress in Diffusion module

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -110,7 +110,7 @@ data DiffusionApplications = DiffusionApplications {
     , daLocalResponderApplication :: Versions
                                        NodeToClientVersion
                                        DictVersion
-                                       (ConnectionId SockAddr ->
+                                       (ConnectionId LocalAddress ->
                                           OuroborosApplication
                                             ResponderApp
                                             ByteString IO Void ())


### PR DESCRIPTION
This must slipped through one of the recent factorization PRs - we're missing windows CI.