### PR TITLE
Added ghc-tags-plugin

### DIFF
--- a/Win32-network/Win32-network.cabal
+++ b/Win32-network/Win32-network.cabal
@@ -19,6 +19,11 @@ flag demo
   description: Build the named pipe demos
   default:     False
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   hs-source-dirs:      src
   if os(windows)
@@ -38,6 +43,10 @@ library
                        bytestring        >= 0.10 && < 0.11,
                        network           >= 3.1  && < 3.2,
                        Win32             >= 2.5.4.1
+
+    if flag(tags)
+      build-depends:     ghc-tags-plugin
+
     extra-libraries:   ws2_32
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -53,6 +62,10 @@ executable named-pipe-demo
                          Win32-network
   else
     build-depends:       base
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   default-language:    Haskell2010
   ghc-options:         -Wall
                        -threaded
@@ -84,3 +97,6 @@ test-suite test-Win32-network
                          Win32-network
   else
     build-depends:       base
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin

--- a/io-sim-classes/io-sim-classes.cabal
+++ b/io-sim-classes/io-sim-classes.cabal
@@ -28,6 +28,11 @@ flag asserts
   manual:      False
   default:     False
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   hs-source-dirs:      src
 
@@ -59,6 +64,10 @@ library
                        mtl   >=2.2 && <2.3,
                        stm   >=2.4 && <2.6,
                        time  >=1.6 && <1.10
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
 

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -18,6 +18,11 @@ flag asserts
   manual:      False
   default:     False
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 source-repository head
   type:     git
   location: https://github.com/input-output-hk/ouroboros-network
@@ -45,6 +50,9 @@ library
                        psqueues          >=0.2 && <0.3,
                        time              >=1.6 && <1.10
 
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   ghc-options:         -Wall
   if flag(asserts)
      ghc-options:      -fno-ignore-asserts
@@ -65,6 +73,9 @@ test-suite test-sim
                        tasty,
                        tasty-quickcheck,
                        time
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   ghc-options:         -Wall
                        -fno-ignore-asserts

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -24,6 +24,11 @@ Flag ipv6
   -- Default to False since travis lacks IPv6 support
   Default: False
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   build-depends:       base            >=4.9 && <4.13,
                        io-sim-classes  >=0.1 && <0.2,
@@ -42,6 +47,9 @@ library
   if os(windows)
     build-depends:     Win32           >= 2.5.4.1 && <2.9,
                        Win32-network   >=0.1 && <0.2
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
@@ -114,6 +122,10 @@ test-suite test-network-mux
   if os(windows)
     build-depends:     Win32           >= 2.5.4.1 && <2.9,
                        Win32-network   >=0.1 && <0.2
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts
@@ -139,6 +151,10 @@ executable mux-demo
                        serialise,
                        Win32,
                        Win32-network
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   default-language:    Haskell2010
   ghc-options:         -Wall
                        -threaded

--- a/ntp-client/ntp-client.cabal
+++ b/ntp-client/ntp-client.cabal
@@ -9,6 +9,11 @@ build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.20
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 Library
   exposed-modules:      Network.NTP.Client
                         Network.NTP.Packet
@@ -22,6 +27,9 @@ Library
                       , network         >= 3.1 && <3.2
                       , stm             >=2.4 && <2.6
                       , time            >=1.6 && <1.10
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   hs-source-dirs:       src
   default-language:     Haskell2010
@@ -38,6 +46,10 @@ test-suite test-ntp-client
                       , tasty
                       , tasty-quickcheck
                       , ntp-client
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   default-language:   Haskell2010
   ghc-options:        -Wall
 
@@ -48,5 +60,9 @@ executable demo-ntp-client
                       , base            >=4.9 && <4.13
                       , contra-tracer   >=0.1 && <0.2
                       , ntp-client
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   default-language:   Haskell2010
   ghc-options:        -Wall

--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -22,6 +22,11 @@ flag asserts
   manual:      False
   default:     False
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   hs-source-dirs:      src
 
@@ -64,6 +69,9 @@ library
 
                      , ouroboros-network
                      , ouroboros-consensus
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -122,6 +130,9 @@ test-suite test
                      , hedgehog
                      , serialise
 
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   default-language:    Haskell2010
   ghc-options:         -Wall
                        -Wredundant-constraints
@@ -151,6 +162,9 @@ executable db-converter
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
 
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
    default-language:   Haskell2010
    ghc-options:        -Wall
                        -Wredundant-constraints
@@ -169,6 +183,9 @@ executable db-analyser
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
                      , ouroboros-network
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
+++ b/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
@@ -17,6 +17,11 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/ouroboros-network
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   hs-source-dirs:      src
 
@@ -50,6 +55,9 @@ library
 
                      , ouroboros-network
                      , ouroboros-consensus
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -22,6 +22,11 @@ flag asserts
   manual:      False
   default:     False
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   hs-source-dirs:      src
   exposed-modules:
@@ -33,6 +38,9 @@ library
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-mock
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -17,6 +17,11 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/ouroboros-network
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   hs-source-dirs:      src
 
@@ -60,6 +65,9 @@ library
                      , ouroboros-network
                      , ouroboros-consensus
 
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   default-language:    Haskell2010
   ghc-options:         -Wall
                        -Wredundant-constraints
@@ -96,6 +104,9 @@ test-suite test
                      , ouroboros-consensus
                      , ouroboros-consensus-test-infra
                      , ouroboros-consensus-mock
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
@@ -17,6 +17,11 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/ouroboros-network
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   hs-source-dirs:      src
   exposed-modules:
@@ -88,6 +93,9 @@ library
                      , ouroboros-network-framework
                      , ouroboros-consensus
 
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   default-language:    Haskell2010
   ghc-options:         -Wall
                        -Wredundant-constraints
@@ -108,6 +116,9 @@ test-suite test
 
                      , ouroboros-consensus
                      , ouroboros-consensus-test-infra
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -22,6 +22,11 @@ flag asserts
   manual:      False
   default:     False
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   hs-source-dirs:      src
 
@@ -230,12 +235,14 @@ library
                      , ouroboros-network-framework
                      , ouroboros-network
 
-
   if os(windows)
      build-depends:    Win32 >= 2.6.2.0
   else
      build-depends:    unix
                      , unix-bytestring
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   ghc-options:         -Wall
                        -Wredundant-constraints
@@ -332,6 +339,9 @@ test-suite test-consensus
                      , hashable
                      , random
 
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   default-language:    Haskell2010
   ghc-options:         -Wall
                        -Wredundant-constraints
@@ -425,6 +435,9 @@ test-suite test-storage
                        -- ouroboros-consensus-test-infra
                      , base16-bytestring
                      , deepseq
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -19,6 +19,11 @@ maintainer:          alex@well-typed.com, duncan@well-typed.com, marcin.szamotul
 build-type:          Simple
 extra-source-files:  CHANGELOG.md
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   exposed-modules:     Ouroboros.Network.Codec
                        Ouroboros.Network.Channel
@@ -78,6 +83,9 @@ library
     build-depends:     Win32-network   <  0.2.0.0,
                        Win32           >= 2.5.4.1 && <2.9
 
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -121,6 +129,8 @@ test-suite ouroboros-network-framework-tests
   if os(windows)
     build-depends:     Win32-network   <  0.2.0.0,
                        Win32           >= 2.5.4.1 && <2.9
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   default-language:    Haskell2010
   ghc-options:         -rtsopts
@@ -151,6 +161,8 @@ executable demo-ping-pong
   if os(windows)
     build-depends:     Win32-network   <  0.2.0.0,
                        Win32           >= 2.5.4.1 && <2.9
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-network-testing/ouroboros-network-testing.cabal
+++ b/ouroboros-network-testing/ouroboros-network-testing.cabal
@@ -17,6 +17,11 @@ source-repository head
   type:     git
   location: https://github.com/input-output-hk/ouroboros-network
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   hs-source-dirs:      src
 
@@ -54,6 +59,9 @@ library
                        cborg             >=0.2.1 && <0.3,
                        serialise         >=0.2 && <0.3,
                        QuickCheck
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -33,6 +33,11 @@ flag cddl
   -- These tests need the cddl and the cbor-diag Ruby-package
   Default: True
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 source-repository head
   type:     git
   location: https://github.com/input-output-hk/ouroboros-network
@@ -144,6 +149,9 @@ library
                        stm               >=2.4 && <2.6,
                        time              >=1.6 && <1.10
 
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
   if flag(asserts)
@@ -199,6 +207,9 @@ library ouroboros-protocol-tests
                        typed-protocols,
                        ouroboros-network-framework,
                        ouroboros-network
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
 
 test-suite test-network
   type:                exitcode-stdio-1.0
@@ -257,6 +268,9 @@ test-suite test-network
                        ouroboros-network,
                        ouroboros-protocol-tests
 
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   if os(windows)
     build-depends:     Win32-network                 <0.2.0.0,
                        Win32           >= 2.5.4.1 && <2.9
@@ -301,6 +315,10 @@ test-suite test-cddl
                        ouroboros-network-framework,
                        ouroboros-network,
                        ouroboros-protocol-tests
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts
@@ -324,6 +342,10 @@ executable demo-chain-sync
                        splitmix,
                        stm,
                        typed-protocols
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   default-language:    Haskell2010
   ghc-options:         -Wall
                        -threaded

--- a/typed-protocols-examples/typed-protocols-examples.cabal
+++ b/typed-protocols-examples/typed-protocols-examples.cabal
@@ -17,6 +17,11 @@ build-type:          Simple
 
 cabal-version:       >=1.10
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   exposed-modules:   Network.TypedProtocol.Channel
                    , Network.TypedProtocol.Codec
@@ -49,6 +54,9 @@ library
                      time,
                      typed-protocols
 
+  if flag(tags)
+    build-depends:   ghc-tags-plugin
+
   hs-source-dirs:    src
   default-language:  Haskell2010
   ghc-options:       -Wall
@@ -71,6 +79,10 @@ test-suite typed-protocols-tests
                    , tasty
                    , tasty-quickcheck
                    , time
+
+  if flag(tags)
+    build-depends:     ghc-tags-plugin
+
   default-language:  Haskell2010
   ghc-options:       -rtsopts
                      -Wall

--- a/typed-protocols/typed-protocols.cabal
+++ b/typed-protocols/typed-protocols.cabal
@@ -17,6 +17,11 @@ build-type:          Simple
 
 cabal-version:       >=1.10
 
+flag tags
+  Description: Enable ghc-tags-plugin to generate tags file
+  Manual: True
+  Default: False
+
 library
   exposed-modules:   Network.TypedProtocol
                    , Network.TypedProtocol.Core
@@ -34,6 +39,9 @@ library
                    , BangPatterns
   build-depends:     base,
                      io-sim-classes
+
+  if flag(tags)
+    build-depends:   ghc-tags-plugin
 
   hs-source-dirs:    src
   default-language:  Haskell2010


### PR DESCRIPTION
ghc-tags-plugin is a GHC compiler plugin which inspects parsed tree and
writes tags file (currently only in vim-format, emacs format will come
soon).  It leaves the parsed tree unchanged.  The plugin is much better
in finding tags than let say `hasktags` (inspecting syntax try vs
pattern matching), especially for type level heavy code
(typed-protocols, ourobors-network protocol implementations or
ouroboros-consensus).

This patch adds `tags` cabal flag to all cabal files which enabled the
plugin.  Then one can configure each local package in
`cabal.package.local` to use it, e.g.

```
package typed-protocols
  flags: +tags
  ghc-options: -fplugin=Plugin.GhcTags
```

Disclaimer: I am the author of the plugin :)

https://hackage.haskell.org/package/ghc-tags-plugin-0.1.0.1

A better option would be to write a nix expression which does that
without modifying all the cabal files, but that's more complex.