### PR TITLE
Give the ThreadNet tests their own EpochInfo

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -95,6 +95,7 @@ test-suite test
                      , cardano-ledger
                      , cardano-ledger-test
                      , cardano-prelude
+                     , cardano-slotting
                      , cborg
                      , containers
                      , cryptonite

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
@@ -4,8 +4,10 @@ module Ouroboros.Consensus.Byron.Ledger.Conversions (
   , fromByronSlotNo
   , fromByronBlockNo
   , fromByronBlockCount
+  , fromByronEpochSlots
     -- * From @ouroboros-consensus@ to @cardano-ledger@
   , toByronSlotNo
+  , toByronBlockCount
     -- * Extract info from the genesis config
   , genesisSecurityParam
   , genesisNumCoreNodes
@@ -14,12 +16,15 @@ module Ouroboros.Consensus.Byron.Ledger.Conversions (
 import           Data.Coerce
 import qualified Data.Set as Set
 
+import           Cardano.Slotting.Block
+import           Cardano.Slotting.Slot
+
 import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Common as CC
 import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Slotting as CC
 
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (ChainHash (..), HeaderHash)
 
 import           Ouroboros.Consensus.Byron.Ledger.Orphans ()
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -43,12 +48,18 @@ fromByronBlockNo = coerce
 fromByronBlockCount :: CC.BlockCount -> SecurityParam
 fromByronBlockCount (CC.BlockCount k) = SecurityParam (fromIntegral k)
 
+fromByronEpochSlots :: CC.EpochSlots -> EpochSize
+fromByronEpochSlots (CC.EpochSlots n) = EpochSize n
+
 {-------------------------------------------------------------------------------
   From @ouroboros-consensus@ to @cardano-ledger@
 -------------------------------------------------------------------------------}
 
 toByronSlotNo :: SlotNo -> CC.SlotNumber
 toByronSlotNo = coerce
+
+toByronBlockCount :: SecurityParam -> CC.BlockCount
+toByronBlockCount (SecurityParam k) = CC.BlockCount (fromIntegral k)
 
 {-------------------------------------------------------------------------------
   Extract info from genesis

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -9,15 +9,15 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Slotting.Slot (SlotNo (..))
+import           Cardano.Slotting.Slot
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.BlockchainTime.Mock
 import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Mock.Node ()
 import           Ouroboros.Consensus.Mock.Node.BFT
-import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Node.ProtocolInfo
+import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Random (Seed (..))
 
@@ -67,9 +67,14 @@ prop_simple_bft_convergence k
         testOutput
   where
     testOutput =
-        runTestNetwork testConfig TestConfigBlock
+        runTestNetwork testConfig epochSize TestConfigBlock
             { forgeEbbEnv = Nothing
             , nodeInfo    = \nid ->
                 protocolInfoBft numCoreNodes nid k slotLengths
             , rekeying    = Nothing
             }
+
+    -- The mock ledger doesn't really care, and neither does BFT.
+    -- We stick with the common @k * 10@ size for now.
+    epochSize :: EpochSize
+    epochSize = EpochSize (maxRollbacks k * 10)

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -13,6 +13,8 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
+import           Cardano.Slotting.Slot
+
 import           Ouroboros.Network.Block (SlotNo (..))
 
 import           Ouroboros.Consensus.BlockchainTime
@@ -99,7 +101,7 @@ prop_simple_leader_schedule_convergence
       testOutput
   where
     testOutput@TestOutput{testOutputNodes} =
-        runTestNetwork testConfig TestConfigBlock
+        runTestNetwork testConfig epochSize TestConfigBlock
             { forgeEbbEnv = Nothing
             , nodeInfo    = \nid -> protocolInfoPraosRule
                                       numCoreNodes
@@ -109,6 +111,11 @@ prop_simple_leader_schedule_convergence
                                       schedule
             , rekeying    = Nothing
             }
+
+    -- I don't think this value actually matters if we override the leader
+    -- schedule
+    epochSize :: EpochSize
+    epochSize = EpochSize $ praosSlotsPerEpoch params
 
 {-------------------------------------------------------------------------------
   Dependent generation and shrinking of leader schedules

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -11,6 +11,8 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
+import           Cardano.Slotting.Slot
+
 import           Ouroboros.Network.Block (SlotNo (..), blockSlot)
 import           Ouroboros.Network.MockChain.Chain (foldChain)
 
@@ -93,13 +95,18 @@ prop_simple_pbft_convergence
     params = PBftParams k numCoreNodes sigThd
 
     testOutput =
-        runTestNetwork testConfig TestConfigBlock
+        runTestNetwork testConfig epochSize TestConfigBlock
             { forgeEbbEnv = Nothing
             , nodeInfo    = protocolInfoMockPBFT
                               params
                               (singletonSlotLengths pbftSlotLength)
             , rekeying    = Nothing
             }
+
+    -- The mock ledger doesn't really care, and neither does BFT.
+    -- We stick with the common @k * 10@ size for now.
+    epochSize :: EpochSize
+    epochSize = EpochSize (maxRollbacks k * 10)
 
     refResult :: Ref.Result
     refResult = Ref.simulate params nodeJoinPlan numSlots

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -10,6 +10,8 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
+import           Cardano.Slotting.Slot
+
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.BlockchainTime.Mock
 import           Ouroboros.Consensus.Mock.Ledger
@@ -104,7 +106,7 @@ prop_simple_praos_convergence
       testOutput
   where
     testOutput@TestOutput{testOutputNodes} =
-        runTestNetwork testConfig TestConfigBlock
+        runTestNetwork testConfig epochSize TestConfigBlock
             { forgeEbbEnv = Nothing
             , nodeInfo    = \nid -> protocolInfoPraos
                                       numCoreNodes
@@ -113,3 +115,8 @@ prop_simple_praos_convergence
                                       (singletonSlotLengths praosSlotLength)
             , rekeying    = Nothing
             }
+
+    -- TODO: Right now mock Praos has an explicit epoch size in its parameters
+    -- This will make it unuseable in a hard fork context.
+    epochSize :: EpochSize
+    epochSize = EpochSize $ praosSlotsPerEpoch params

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -57,7 +57,8 @@ import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.RedundantConstraints
 
-import           Ouroboros.Consensus.Storage.Common (EpochNo)
+import           Ouroboros.Consensus.Storage.Common
+import           Ouroboros.Consensus.Storage.EpochInfo
 
 import           Test.ThreadNet.Network
 import           Test.ThreadNet.TxGen
@@ -200,6 +201,9 @@ runTestNetwork ::
      , Show (LedgerView (BlockProtocol blk))
      )
   => TestConfig
+  -> EpochSize
+  -- ^ Temporary: until we start testing the hard fork combinator, we just
+  -- support a single 'EpochSize'. See also comments for 'tnaEpochInfo'.
   -> TestConfigBlock blk
   -> TestOutput blk
 runTestNetwork
@@ -212,6 +216,7 @@ runTestNetwork
     , slotLengths
     , initSeed
     }
+  epochSize
   TestConfigBlock{forgeEbbEnv, nodeInfo, rekeying}
   = runSimOrThrow $ do
     let tna = ThreadNetworkArgs
@@ -225,6 +230,7 @@ runTestNetwork
           , tnaRestarts       = nodeRestarts
           , tnaSlotLengths    = slotLengths
           , tnaTopology       = nodeTopology
+          , tnaEpochInfo      = fixedSizeEpochInfo epochSize
           }
 
     case rekeying of

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -58,7 +58,6 @@ import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.RedundantConstraints
 
 import           Ouroboros.Consensus.Storage.Common
-import           Ouroboros.Consensus.Storage.EpochInfo
 
 import           Test.ThreadNet.Network
 import           Test.ThreadNet.TxGen
@@ -230,7 +229,7 @@ runTestNetwork
           , tnaRestarts       = nodeRestarts
           , tnaSlotLengths    = slotLengths
           , tnaTopology       = nodeTopology
-          , tnaEpochInfo      = fixedSizeEpochInfo epochSize
+          , tnaEpochSize      = epochSize
           }
 
     case rekeying of

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns         #-}
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveAnyClass       #-}
@@ -49,10 +48,10 @@ import qualified Data.Set as Set
 import qualified Data.Typeable as Typeable
 import           GHC.Stack
 
+import           Ouroboros.Network.Block
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec (AnyMessage (..), CodecFailure,
                      mapFailureCodec)
-import           Ouroboros.Network.Block
 import           Ouroboros.Network.MockChain.Chain (Chain (Genesis))
 import           Ouroboros.Network.Point (WithOrigin (..))
 
@@ -97,7 +96,7 @@ import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Storage.ChainDB.Impl (ChainDbArgs (..))
 import           Ouroboros.Consensus.Storage.Common (EpochNo (..))
 import           Ouroboros.Consensus.Storage.EpochInfo (EpochInfo,
-                     epochInfoEpoch, newEpochInfo)
+                     epochInfoEpoch)
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmDB
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index as Index
 import qualified Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy as LgrDB
@@ -159,6 +158,15 @@ data ThreadNetworkArgs m blk = ThreadNetworkArgs
   , tnaRestarts     :: NodeRestarts
   , tnaSlotLengths  :: SlotLengths
   , tnaTopology     :: NodeTopology
+  , tnaEpochInfo    :: EpochInfo m
+    -- ^ Epoch sizes
+    --
+    -- The ThreadNet tests need to know epoch boundaries in order to know when
+    -- to insert EBBs, when delegation certificates become active, etc. (This
+    -- is therefore not related to the /chunking/ of the immutable DB.)
+    --
+    -- This is temporary: once we have proper support for the hard fork
+    -- combinator, 'EpochInfo' must be /derived/ from the current ledger state.
   }
 
 {-------------------------------------------------------------------------------
@@ -240,6 +248,7 @@ runThreadNetwork ThreadNetworkArgs
   , tnaRestarts       = nodeRestarts
   , tnaSlotLengths    = slotLengths
   , tnaTopology       = nodeTopology
+  , tnaEpochInfo      = epochInfo
   } = withRegistry $ \sharedRegistry -> do
     -- This shared registry is used for 'newTestBlockchainTime' and the
     -- network communication threads. Each node will create its own registry
@@ -304,9 +313,6 @@ runThreadNetwork ThreadNetworkArgs
 
       -- fork the per-vertex state variables, including the mock filesystem
       (nodeInfo, readNodeInfo) <- newNodeInfo
-      epochInfo <- do
-        let ProtocolInfo{pInfoConfig} = mkProtocolInfo coreNodeId
-        newEpochInfo $ nodeEpochSize (Proxy @blk) pInfoConfig
 
       let myEdgeStatusVars =
             [ v
@@ -314,7 +320,6 @@ runThreadNetwork ThreadNetworkArgs
             , coreNodeId `elem` [n1, n2]
             ]
       forkVertex
-        epochInfo
         varRNG
         sharedTestBtime
         sharedRegistry
@@ -367,8 +372,7 @@ runThreadNetwork ThreadNetworkArgs
     joinSlotOf = coreNodeIdJoinSlot nodeJoinPlan
 
     forkVertex
-      :: EpochInfo m
-      -> StrictTVar m ChaChaDRG
+      :: StrictTVar m ChaChaDRG
       -> TestBlockchainTime m
       -> ResourceRegistry m
       -> CoreNodeId
@@ -377,7 +381,6 @@ runThreadNetwork ThreadNetworkArgs
       -> NodeInfo blk (StrictTVar m MockFS) (Tracer m)
       -> m ()
     forkVertex
-      epochInfo
       varRNG
       sharedTestBtime
       sharedRegistry
@@ -411,7 +414,6 @@ runThreadNetwork ThreadNetworkArgs
             -- (specifically not the communication threads running the Mini
             -- Protocols, like the ChainSync Client)
             (kernel, app) <- forkNode
-              epochInfo
               varRNG
               nodeBtime
               nodeRegistry
@@ -496,7 +498,6 @@ runThreadNetwork ThreadNetworkArgs
            -> ResourceRegistry m
            -> TopLevelConfig blk
            -> ExtLedgerState blk
-           -> EpochInfo m
            -> Tracer m (RealPoint blk, ExtValidationError blk)
               -- ^ invalid block tracer
            -> Tracer m (RealPoint blk, BlockNo)
@@ -505,7 +506,7 @@ runThreadNetwork ThreadNetworkArgs
            -> ChainDbArgs m blk
     mkArgs
       btime registry
-      cfg initLedger epochInfo
+      cfg initLedger
       invalidTracer addTracer
       nodeDBs = ChainDbArgs
         { -- Decoders
@@ -565,8 +566,7 @@ runThreadNetwork ThreadNetworkArgs
 
     forkNode
       :: HasCallStack
-      => EpochInfo m
-      -> StrictTVar m ChaChaDRG
+      => StrictTVar m ChaChaDRG
       -> BlockchainTime m
       -> ResourceRegistry m
       -> ProtocolInfo blk
@@ -576,7 +576,7 @@ runThreadNetwork ThreadNetworkArgs
       -> m ( NodeKernel m NodeId blk
            , LimitedApp m NodeId blk
            )
-    forkNode epochInfo varRNG btime registry pInfo nodeInfo txs0 = do
+    forkNode varRNG btime registry pInfo nodeInfo txs0 = do
       let ProtocolInfo{..} = pInfo
 
       let NodeInfo
@@ -591,7 +591,7 @@ runThreadNetwork ThreadNetworkArgs
             traceWith (nodeEventsAdds nodeInfoEvents) (s, p, bno)
       let chainDbArgs = mkArgs
             btime registry
-            pInfoConfig pInfoInitLedger epochInfo
+            pInfoConfig pInfoInitLedger
             invalidTracer
             addTracer
             nodeInfoDBs


### PR DESCRIPTION
They are currently using `nodeEpochSize` from `RunNode`, but that function will soon disappear (consensus will not really need to be aware of epoch boundaries at all anymore).

This will need to be revised again once we have the hard fork combinator, in which case `EpochInfo` should be derived from the ledger state instead.