### PR TITLE
ErrorPolicy: include block-specific exceptions

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -247,7 +247,7 @@ instance RunNode DualByronBlock where
   -- The header is just the concrete header, so we can just reuse the Byron def
   nodeAddHeaderEnvelope = \_ -> nodeAddHeaderEnvelope pb
 
-  nodeToExitReason      = \_ -> nodeToExitReason pb
+  nodeExceptionIsFatal  = \_ -> nodeExceptionIsFatal pb
 
   -- Encoders
   nodeEncodeBlockWithInfo  = const $ encodeDualBlockWithInfo encodeByronBlockWithInfo

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -229,7 +229,7 @@ instance RunNode ByronBlock where
   nodeHashInfo              = const byronHashInfo
   nodeCheckIntegrity        = verifyBlockIntegrity . configBlock
   nodeAddHeaderEnvelope     = const byronAddHeaderEnvelope
-  nodeToExitReason _ e
+  nodeExceptionIsFatal _ e
     | Just (_ :: DropEncodedSizeException) <- fromException e
     = Just DatabaseCorruption
     | otherwise

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -244,7 +244,7 @@ run tracers protocolTracers chainDbTracer diffusionTracers diffusionArguments
              (localResponderNetworkApplication $ networkApps version)
          | version <- supportedNetworkProtocolVersions (Proxy @blk)
          ]
-     , daErrorPolicies = consensusErrorPolicy
+     , daErrorPolicies = consensusErrorPolicy (Proxy @blk)
      }
 
     combineVersions :: Semigroup a => [a] -> a

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Recovery.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Recovery.hs
@@ -78,8 +78,8 @@ exceptionRequiresRecovery blkProxy e = case reason of
     _                  -> False
   where
     reason
-      | Just nodeReason <- nodeToExitReason blkProxy e
-      = nodeReason
+      | Just fatalReason <- nodeExceptionIsFatal blkProxy e
+      = fatalReason
       | otherwise
       = toExitReason e
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -136,11 +136,17 @@ class ( LedgerSupportsProtocol    blk
                   -> m ()
   nodeInitChainDB _ _ = return ()
 
-  -- | This function is called to give a more precise reason why some
-  -- exception that will shut down the node was thrown. See
-  -- 'Ouroboros.Consensus.Node.Exit' for more details.
+  -- | This function is called to determine whether a thrown exception is
+  -- fatal and should shut down the node or not. If fatal, it should return a
+  -- precise reason why. See 'Ouroboros.Consensus.Node.Exit' for more details.
   --
   -- One only has to handle exceptions specific to this @blk@.
+  --
+  -- Return 'Nothing' for exceptions not related to @blk@, they will be
+  -- classified by the existing error policy.
+  --
+  -- Also return 'Nothing' for exceptions /related/ to @blk@ that are /not
+  -- fatal/, they will fall through to the default policy.
   --
   -- NOTE: this is not about header/block/transaction validation errors, etc.
   -- These will not shut down the node and are handled already.
@@ -152,8 +158,8 @@ class ( LedgerSupportsProtocol    blk
   --
   -- In case you have no exceptions to handle specially, return 'Nothing'.
   -- This is what the default implementation does.
-  nodeToExitReason :: Proxy blk -> SomeException -> Maybe ExitReason
-  nodeToExitReason _ _ = Nothing
+  nodeExceptionIsFatal :: Proxy blk -> SomeException -> Maybe ExitReason
+  nodeExceptionIsFatal _ _ = Nothing
 
   -- Encoders
   nodeEncodeBlockWithInfo  :: TopLevelConfig blk -> blk -> BinaryInfo Encoding


### PR DESCRIPTION
Fixes #1553.

* Generalise `nodeToExitReason` to `nodeExceptionIsFatal`: it returns `Maybe ExitReason`, stating whether the exception is fatal or not, and if so, why.

* In the `consensusErrorPolicy`, shut down the node in case   `nodeExceptionIsFatal` says some exception is fatal.

* Add missing (non-block-specific) `SystemClockMovedBackException` to the policy.