### PR TITLE
Mini Protocol Mux Limts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ghcid
 doc/network.aux
 doc/network.bbl
 doc/network.blg

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -60,12 +60,11 @@ import           Ouroboros.Network.MockChain.Chain (Chain (Genesis))
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import qualified Ouroboros.Network.BlockFetch.Client as BFClient
-import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
-                     (pipelineDecisionLowHighMark)
 import           Ouroboros.Network.Protocol.ChainSync.Type
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
 import           Ouroboros.Network.Protocol.TxSubmission.Type
+import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..))
 import qualified Ouroboros.Network.TxSubmission.Inbound as TxInbound
 import qualified Ouroboros.Network.TxSubmission.Outbound as TxOutbound
 
@@ -707,19 +706,23 @@ runThreadNetwork ThreadNetworkArgs
                 -- ChainDB
                 instrumentationTracers <> nullDebugTracers
             , registry
-            , maxClockSkew        = ClockSkew 1
-            , cfg                 = pInfoConfig
-            , initState           = pInfoInitState
+            , maxClockSkew           = ClockSkew 1
+            , cfg                    = pInfoConfig
+            , initState              = pInfoInitState
             , btime
             , chainDB
-            , initChainDB         = nodeInitChainDB
-            , blockProduction     = Just blockProduction
-            , blockFetchSize      = nodeBlockFetchSize
-            , blockMatchesHeader  = nodeBlockMatchesHeader
-            , maxUnackTxs         = 1000 -- TODO
-            , maxBlockSize        = NoOverride
-            , mempoolCap          = NoMempoolCapacityBytesOverride
-            , chainSyncPipelining = pipelineDecisionLowHighMark 2 4
+            , initChainDB            = nodeInitChainDB
+            , blockProduction        = Just blockProduction
+            , blockFetchSize         = nodeBlockFetchSize
+            , blockMatchesHeader     = nodeBlockMatchesHeader
+            , maxBlockSize           = NoOverride
+            , mempoolCap             = NoMempoolCapacityBytesOverride
+            , miniProtocolParameters = MiniProtocolParameters {
+                  chainSyncPipelineingHighMark = 4,
+                  chainSyncPipelineingLowMark  = 2,
+                  blockFetchPipelineingMax     = 10,
+                  txSubmissionMaxUnacked       = 1000 -- TODO ?
+                }
             }
 
       nodeKernel <- initNodeKernel nodeArgs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -47,7 +47,7 @@ import           Ouroboros.Network.NodeToClient (DictVersion (..),
                      nodeToClientCodecCBORTerm)
 import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..),
                      NodeToNodeVersionData (..), RemoteConnectionId,
-                     nodeToNodeCodecCBORTerm)
+                     defaultMiniProtocolParameters, nodeToNodeCodecCBORTerm)
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
@@ -331,23 +331,18 @@ mkNodeArgs
 mkNodeArgs registry cfg initState tracers btime chainDB isProducer = NodeArgs
     { tracers
     , registry
-    , maxClockSkew          = ClockSkew 1
+    , maxClockSkew           = ClockSkew 1
     , cfg
     , initState
     , btime
     , chainDB
-    , initChainDB           = nodeInitChainDB
+    , initChainDB            = nodeInitChainDB
     , blockProduction
-    , blockFetchSize        = nodeBlockFetchSize
-    , blockMatchesHeader    = nodeBlockMatchesHeader
-    , maxBlockSize          = NoOverride
-    , mempoolCap            = NoMempoolCapacityBytesOverride
-    , miniProtocolParameters = MiniProtocolParameters {
-        chainSyncPipelineingLowMark  = 200
-      , chainSyncPipelineingHighMark = 300
-      , blockFetchPipelineingMax     = 100
-      , txSubmissionMaxUnacked       = 10
-      }
+    , blockFetchSize         = nodeBlockFetchSize
+    , blockMatchesHeader     = nodeBlockMatchesHeader
+    , maxBlockSize           = NoOverride
+    , mempoolCap             = NoMempoolCapacityBytesOverride
+    , miniProtocolParameters = defaultMiniProtocolParameters
     }
   where
     blockProduction = case isProducer of

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -45,10 +45,9 @@ import           Ouroboros.Network.Magic
 import           Ouroboros.Network.NodeToClient (DictVersion (..),
                      LocalConnectionId, NodeToClientVersionData (..),
                      nodeToClientCodecCBORTerm)
-import           Ouroboros.Network.NodeToNode (NodeToNodeVersionData (..),
-                     RemoteConnectionId, nodeToNodeCodecCBORTerm)
-import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
-                     (pipelineDecisionLowHighMark)
+import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..),
+                     NodeToNodeVersionData (..), RemoteConnectionId,
+                     nodeToNodeCodecCBORTerm)
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
@@ -178,7 +177,7 @@ run tracers protocolTracers chainDbTracer diffusionTracers diffusionArguments
         onNodeKernel registry nodeKernel
 
         let networkApps = mkNetworkApps nodeArgs nodeKernel
-            diffusionApplications = mkDiffusionApplications networkApps
+            diffusionApplications = mkDiffusionApplications (miniProtocolParameters nodeArgs) networkApps
 
         runDataDiffusion diffusionTracers
                          diffusionArguments
@@ -213,20 +212,21 @@ run tracers protocolTracers chainDbTracer diffusionTracers diffusionArguments
       (protocolHandlers nodeArgs nodeKernel)
 
     mkDiffusionApplications
-      :: (   NetworkProtocolVersion blk
+      :: MiniProtocolParameters
+      -> (   NetworkProtocolVersion blk
           -> NetworkApplication
               IO RemoteConnectionId LocalConnectionId
               ByteString ByteString ByteString ByteString ByteString ByteString
               ()
          )
       -> DiffusionApplications
-    mkDiffusionApplications networkApps = DiffusionApplications
+    mkDiffusionApplications miniProtocolParams networkApps = DiffusionApplications
       { daResponderApplication = combineVersions [
       simpleSingletonVersions
     (nodeToNodeProtocolVersion (Proxy @blk) version)
     nodeToNodeVersionData
     (DictVersion nodeToNodeCodecCBORTerm)
-    (responderNetworkApplication $ networkApps version)
+    (responderNetworkApplication miniProtocolParams $ networkApps version)
       | version <- supportedNetworkProtocolVersions (Proxy @blk)
       ]
      , daInitiatorApplication = combineVersions [
@@ -234,7 +234,7 @@ run tracers protocolTracers chainDbTracer diffusionTracers diffusionArguments
              (nodeToNodeProtocolVersion (Proxy @blk) version)
              nodeToNodeVersionData
              (DictVersion nodeToNodeCodecCBORTerm)
-             (initiatorNetworkApplication $ networkApps version)
+             (initiatorNetworkApplication miniProtocolParams $ networkApps version)
          | version <- supportedNetworkProtocolVersions (Proxy @blk)
          ]
      , daLocalResponderApplication = combineVersions [
@@ -331,19 +331,23 @@ mkNodeArgs
 mkNodeArgs registry cfg initState tracers btime chainDB isProducer = NodeArgs
     { tracers
     , registry
-    , maxClockSkew        = ClockSkew 1
+    , maxClockSkew          = ClockSkew 1
     , cfg
     , initState
     , btime
     , chainDB
-    , initChainDB         = nodeInitChainDB
+    , initChainDB           = nodeInitChainDB
     , blockProduction
-    , blockFetchSize      = nodeBlockFetchSize
-    , blockMatchesHeader  = nodeBlockMatchesHeader
-    , maxUnackTxs         = 100 -- TODO
-    , maxBlockSize        = NoOverride
-    , mempoolCap          = NoMempoolCapacityBytesOverride
-    , chainSyncPipelining = pipelineDecisionLowHighMark 200 300 -- TODO
+    , blockFetchSize        = nodeBlockFetchSize
+    , blockMatchesHeader    = nodeBlockMatchesHeader
+    , maxBlockSize          = NoOverride
+    , mempoolCap            = NoMempoolCapacityBytesOverride
+    , miniProtocolParameters = MiniProtocolParameters {
+        chainSyncPipelineingLowMark  = 200
+      , chainSyncPipelineingHighMark = 300
+      , blockFetchPipelineingMax     = 100
+      , txSubmissionMaxUnacked       = 10
+      }
     }
   where
     blockProduction = case isProducer of

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -366,7 +366,7 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
                       (contramap show stdoutTracer) -- state tracer
                       blockFetchPolicy
                       registry
-                      (BlockFetchConfiguration 1 1)
+                      (BlockFetchConfiguration 1 1 10)
                  >> return ()
 
     chainAsync <- async (chainSelection Map.empty)

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
@@ -13,6 +13,7 @@ module Ouroboros.Network.Protocol.ChainSync.ExamplesPipelined
     ) where
 
 import           Control.Monad.Class.MonadSTM.Strict
+import           Data.Word
 
 import           Network.TypedProtocol.Pipelined
 
@@ -239,7 +240,7 @@ chainSyncClientPipelinedMax
          ( HasHeader header
          , MonadSTM m
          )
-      => Int
+      => Word32
       -- ^ maximal number of outstanding requests
       -> StrictTVar m (Chain header)
       -> Client header (Tip header) m a
@@ -292,7 +293,7 @@ chainSyncClientPipelinedMin
          ( HasHeader header
          , MonadSTM m
          )
-      => Int
+      => Word32
       -- ^ maximal number of outstanding requests
       -> StrictTVar m (Chain header)
       -> Client header (Tip header) m a
@@ -305,9 +306,9 @@ chainSyncClientPipelinedLowHigh
          ( HasHeader header
          , MonadSTM m
          )
-      => Int
+      => Word32
       -- ^ low mark
-      -> Int
+      -> Word32
       -- ^ high mark
       -> StrictTVar m (Chain header)
       -> Client header (Tip header) m a

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -13,6 +13,7 @@ import qualified Codec.Serialise as S
 import           Control.Monad (unless, void)
 import qualified Control.Monad.ST as ST
 import           Data.ByteString.Lazy (ByteString)
+import           Data.Word
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
@@ -216,7 +217,7 @@ chainSyncPipelinedForkExperiment run mkClient (ChainProducerStateForkTest cps ch
 --
 
 propChainSyncPipeliendMaxDirectST :: ChainProducerStateForkTest
-                                  -> Positive Int
+                                  -> Positive Word32
                                   -> Bool
 propChainSyncPipeliendMaxDirectST cps (Positive omax) =
     runSimOrThrow $
@@ -226,7 +227,7 @@ propChainSyncPipeliendMaxDirectST cps (Positive omax) =
         cps
 
 propChainSyncPipeliendMaxDirectIO :: ChainProducerStateForkTest
-                                  -> Positive Int
+                                  -> Positive Word32
                                   -> Property
 propChainSyncPipeliendMaxDirectIO cps (Positive omax) =
     ioProperty $
@@ -236,7 +237,7 @@ propChainSyncPipeliendMaxDirectIO cps (Positive omax) =
         cps
 
 propChainSyncPipeliendMinDirectST :: ChainProducerStateForkTest
-                                  -> Positive Int
+                                  -> Positive Word32
                                   -> Bool
 propChainSyncPipeliendMinDirectST cps (Positive omax) =
     runSimOrThrow $
@@ -246,7 +247,7 @@ propChainSyncPipeliendMinDirectST cps (Positive omax) =
         cps
 
 propChainSyncPipeliendMinDirectIO :: ChainProducerStateForkTest
-                                  -> Positive Int
+                                  -> Positive Word32
                                   -> Property
 propChainSyncPipeliendMinDirectIO cps (Positive omax) =
     ioProperty $
@@ -261,7 +262,7 @@ propChainSyncPipeliendMinDirectIO cps (Positive omax) =
 
 propChainSyncPipelinedMaxConnectST :: ChainProducerStateForkTest
                                    -> [Bool]
-                                   -> Positive Int
+                                   -> Positive Word32
                                    -> Bool
 propChainSyncPipelinedMaxConnectST cps choices (Positive omax) =
     runSimOrThrow $
@@ -278,7 +279,7 @@ propChainSyncPipelinedMaxConnectST cps choices (Positive omax) =
 
 propChainSyncPipelinedMinConnectST :: ChainProducerStateForkTest
                                    -> [Bool]
-                                   -> Positive Int
+                                   -> Positive Word32
                                    -> Bool
 propChainSyncPipelinedMinConnectST cps choices (Positive omax) =
     runSimOrThrow $
@@ -294,7 +295,7 @@ propChainSyncPipelinedMinConnectST cps choices (Positive omax) =
 
 propChainSyncPipelinedMaxConnectIO :: ChainProducerStateForkTest
                                    -> [Bool]
-                                   -> Positive Int
+                                   -> Positive Word32
                                    -> Property
 propChainSyncPipelinedMaxConnectIO cps choices (Positive omax) =
     ioProperty $
@@ -310,7 +311,7 @@ propChainSyncPipelinedMaxConnectIO cps choices (Positive omax) =
 
 propChainSyncPipelinedMinConnectIO :: ChainProducerStateForkTest
                                    -> [Bool]
-                                   -> Positive Int
+                                   -> Positive Word32
                                    -> Property
 propChainSyncPipelinedMinConnectIO cps choices (Positive omax) =
     ioProperty $
@@ -627,7 +628,7 @@ chainSyncDemoPipelined clientChan serverChan mkClient (ChainProducerStateForkTes
 
 propChainSyncDemoPipelinedMaxST
   :: ChainProducerStateForkTest
-  -> Positive Int
+  -> Positive Word32
   -> Property
 propChainSyncDemoPipelinedMaxST cps (Positive omax) =
   runSimOrThrow $ do
@@ -639,7 +640,7 @@ propChainSyncDemoPipelinedMaxST cps (Positive omax) =
 
 propChainSyncDemoPipelinedMaxIO
   :: ChainProducerStateForkTest
-  -> Positive Int
+  -> Positive Word32
   -> Property
 propChainSyncDemoPipelinedMaxIO cps (Positive omax) =
   ioProperty $ do
@@ -651,7 +652,7 @@ propChainSyncDemoPipelinedMaxIO cps (Positive omax) =
 
 propChainSyncDemoPipelinedMinST
   :: ChainProducerStateForkTest
-  -> Positive Int
+  -> Positive Word32
   -> Property
 propChainSyncDemoPipelinedMinST cps (Positive omax) =
   runSimOrThrow $ do
@@ -663,7 +664,7 @@ propChainSyncDemoPipelinedMinST cps (Positive omax) =
 
 propChainSyncDemoPipelinedMinIO
   :: ChainProducerStateForkTest
-  -> Positive Int
+  -> Positive Word32
   -> Property
 propChainSyncDemoPipelinedMinIO cps (Positive omax) =
   ioProperty $ do
@@ -675,8 +676,8 @@ propChainSyncDemoPipelinedMinIO cps (Positive omax) =
 
 propChainSyncDemoPipelinedLowHighST
   :: ChainProducerStateForkTest
-  -> Positive Int
-  -> Positive Int
+  -> Positive Word32
+  -> Positive Word32
   -> Property
 propChainSyncDemoPipelinedLowHighST cps (Positive x) (Positive y) =
     runSimOrThrow $ do
@@ -691,8 +692,8 @@ propChainSyncDemoPipelinedLowHighST cps (Positive x) (Positive y) =
 
 propChainSyncDemoPipelinedLowHighIO
   :: ChainProducerStateForkTest
-  -> Positive Int
-  -> Positive Int
+  -> Positive Word32
+  -> Positive Word32
   -> Property
 propChainSyncDemoPipelinedLowHighIO cps (Positive x) (Positive y) =
     ioProperty $ do
@@ -707,8 +708,8 @@ propChainSyncDemoPipelinedLowHighIO cps (Positive x) (Positive y) =
 
 propChainSyncDemoPipelinedMinBufferedIO
   :: ChainProducerStateForkTest
-  -> Positive Int
-  -> Positive Int
+  -> Positive Word32
+  -> Positive Word32
   -> Property
 propChainSyncDemoPipelinedMinBufferedIO cps (Positive n) (Positive m) =
     ioProperty $ do

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -211,7 +211,10 @@ data BlockFetchConfiguration =
          bfcMaxConcurrencyBulkSync :: !Word,
 
          -- | Maximum concurrent downloads during deadline syncing.
-         bfcMaxConcurrencyDeadline :: !Word
+         bfcMaxConcurrencyDeadline :: !Word,
+
+         -- | Maximum requests in flight per each peer.
+         bfcMaxRequestsInflight    :: !Word
      }
 
 -- | Execute the block fetch logic. It monitors the current chain and candidate
@@ -254,10 +257,7 @@ blockFetchLogic decisionTracer clientStateTracer
     fetchDecisionPolicy :: FetchDecisionPolicy header
     fetchDecisionPolicy =
       FetchDecisionPolicy {
-        -- TODO: This is a protocol constant, but determined elsewhere.
-        -- It should be passed in.
-        maxInFlightReqsPerPeer   = 10,
-
+        maxInFlightReqsPerPeer   = bfcMaxRequestsInflight,
         maxConcurrencyBulkSync   = bfcMaxConcurrencyBulkSync,
         maxConcurrencyDeadline   = bfcMaxConcurrencyDeadline,
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -14,6 +14,7 @@ module Ouroboros.Network.NodeToNode (
     nodeToNodeProtocols
   , NodeToNodeProtocols (..)
   , MiniProtocolParameters (..)
+  , defaultMiniProtocolParameters
   , NodeToNodeVersion (..)
   , NodeToNodeVersionData (..)
   , DictVersion (..)
@@ -165,6 +166,14 @@ data MiniProtocolParameters = MiniProtocolParameters {
       -- ^ maximal number of unacked tx (pipelineing is bounded by twice this
       -- number)
     }
+
+defaultMiniProtocolParameters :: MiniProtocolParameters
+defaultMiniProtocolParameters = MiniProtocolParameters {
+      chainSyncPipelineingLowMark  = 200
+    , chainSyncPipelineingHighMark = 300
+    , blockFetchPipelineingMax     = 100
+    , txSubmissionMaxUnacked       = 10
+  }
 
 -- | Make an 'OuroborosApplication' for the bundle of mini-protocols that
 -- make up the overall node-to-node protocol.

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -13,6 +13,7 @@
 module Ouroboros.Network.NodeToNode (
     nodeToNodeProtocols
   , NodeToNodeProtocols (..)
+  , MiniProtocolParameters (..)
   , NodeToNodeVersion (..)
   , NodeToNodeVersionData (..)
   , DictVersion (..)
@@ -80,11 +81,13 @@ module Ouroboros.Network.NodeToNode (
 import qualified Control.Concurrent.Async as Async
 import           Control.Exception (IOException)
 import qualified Data.ByteString.Lazy as BL
+import           Data.Int (Int64)
 import           Data.Time.Clock (DiffTime)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Typeable (Typeable)
 import           Data.Void (Void)
+import           Data.Word
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Term as CBOR
@@ -140,6 +143,29 @@ data NodeToNodeProtocols appType bytes m a b = NodeToNodeProtocols {
   }
 
 
+data MiniProtocolParameters = MiniProtocolParameters {
+      chainSyncPipelineingHighMark :: !Word32,
+      -- ^ high threshold for pipelining (we will never exceed that many
+      -- messages pipelined).
+
+      chainSyncPipelineingLowMark  :: !Word32,
+      -- ^ low threshold: if we hit the 'chainSyncPipelineingHighMark' we will
+      -- listen for responses until there are at most
+      -- 'chainSyncPipelineingLowMark' pipelined message
+      --
+      -- Must be smaller than 'chainSyncPipelineingHighMark'.
+      --
+      -- Note: 'chainSyncPipelineingLowMark' and 'chainSyncPipelineingLowMark'
+      -- are passed to 'pipelineDecisionLowHighMark'.
+
+      blockFetchPipelineingMax     :: !Word,
+      -- ^ maximal number of pipelined messages in 'block-fetch' mini-protocol.
+
+      txSubmissionMaxUnacked       :: !Word16
+      -- ^ maximal number of unacked tx (pipelineing is bounded by twice this
+      -- number)
+    }
+
 -- | Make an 'OuroborosApplication' for the bundle of mini-protocols that
 -- make up the overall node-to-node protocol.
 --
@@ -151,7 +177,7 @@ data NodeToNodeProtocols appType bytes m a b = NodeToNodeProtocols {
 -- 'Handshake' protocol is not included in 'NodeToNodeProtocols' as it runs
 -- before mux is started but it reusing 'MuxBearer' to send and receive
 -- messages.  Only when the handshake protocol suceedes, we will know which
--- protocols to run / multiplex. 
+-- protocols to run / multiplex.
 --
 -- These are chosen to not overlap with the node to client protocol numbers (and
 -- the handshake protocol number).  This is not essential for correctness, but
@@ -159,9 +185,15 @@ data NodeToNodeProtocols appType bytes m a b = NodeToNodeProtocols {
 -- both protocols, e.g.  wireshark plugins.
 --
 nodeToNodeProtocols
-  :: NodeToNodeProtocols appType bytes m a b
+  :: MiniProtocolParameters
+  -> NodeToNodeProtocols appType bytes m a b
   -> OuroborosApplication appType bytes m a b
-nodeToNodeProtocols NodeToNodeProtocols {
+nodeToNodeProtocols MiniProtocolParameters {
+                        chainSyncPipelineingHighMark,
+                        blockFetchPipelineingMax,
+                        txSubmissionMaxUnacked
+                      }
+                    NodeToNodeProtocols {
                         chainSyncProtocol,
                         blockFetchProtocol,
                         txSubmissionProtocol
@@ -179,12 +211,18 @@ nodeToNodeProtocols NodeToNodeProtocols {
       }
     , MiniProtocol {
         miniProtocolNum    = MiniProtocolNum 4,
-        miniProtocolLimits = maximumMiniProtocolLimits,
+        miniProtocolLimits = txSubmissionProtocolLimits,
         miniProtocolRun    = txSubmissionProtocol
       }
     ]
   where
-    chainSyncProtocolLimits :: MiniProtocolLimits
+    addSafetyMargin :: Int64 -> Int64
+    addSafetyMargin x = x + x `div` 10
+
+    chainSyncProtocolLimits
+      , blockFetchProtocolLimits
+      , txSubmissionProtocolLimits :: MiniProtocolLimits
+
     chainSyncProtocolLimits =
       MiniProtocolLimits {
           -- chain sync has two potentially large messages:
@@ -243,16 +281,19 @@ nodeToNodeProtocols NodeToNodeProtocols {
           --   = 716
           --   ```
           --
-          -- Since chain sync can pipeline up to 300 of 'MsgRollForward'
-          -- messages the maximal queue size can be @300 * 716 = 214_800@.  We
-          -- add 10% to that for safety.
+          -- Since chain sync can pipeline up to 'chainSyncPipelineingHighMark' of 'MsgRollForward'
+          -- messages the maximal queue size can be
+          -- @chainSyncPipelineingHighMark * 716@.  The current value of
+          -- 'chainSyncPipelineingHighMark' is '300' thus the upper bound is
+          -- `214.8Kb`)  We add 10% to that for safety.
           --
-          maximumIngressQueue = 236_280
+          maximumIngressQueue = addSafetyMargin $
+            fromIntegral chainSyncPipelineingHighMark * 716
         }
 
     blockFetchProtocolLimits = MiniProtocolLimits {
-        -- block-fetch client can pipeline at most `10` blocks.  This is
-        -- currently hard coded in
+        -- block-fetch client can pipeline at most 'blockFetchPipelineingMax'
+        -- blocks (currently '10').  This is currently hard coded in
         -- 'Ouroboros.Network.BlockFetch.blockFetchLogic' (where
         -- @maxInFlightReqsPerPeer = 10@ is specified).  In the future the
         -- block fetch client will count bytes rather than blocks.  By far
@@ -270,18 +311,76 @@ nodeToNodeProtocols NodeToNodeProtocols {
         -- So the overall limit is `10 * 2_097_154 = 20_971_540` (i.e. aroudn
         -- '20Mb'), we add 10% safety margin:
         --
-        maximumIngressQueue = 23_068_694
+        maximumIngressQueue = addSafetyMargin $
+          fromIntegral blockFetchPipelineingMax * 2_097_154
       }
 
+    txSubmissionProtocolLimits = MiniProtocolLimits {
+          -- tx-submission server can pipeline both 'MsgRequestTxIds' and
+          -- 'MsgRequestTx'. This means that there can be many
+          -- 'MsgReplyTxIds', 'MsgReplyTxs' messages in an inbound queue (their
+          -- sizes are strictly greater than the corresponding request
+          -- messages).
+          --
+          -- Each 'MsgRequestTx' can contain at max @maxTxIdsToRequest = 3@
+          -- (defined in -- 'Ouroboros.Network.TxSubmission.Inbound.txSubmissionInbound')
+          --
+          -- Each 'MsgRequestTx' can request at max @maxTxToRequest = 2@
+          -- (defined in -- 'Ouroboros.Network.TxSubmission.Inbound.txSubmissionInbound')
+          --
+          -- The 'txSubmissionInBound' server can at most put `100`
+          -- unacknowledged transactions.  It also pipelines both 'MsgRequestTx`
+          -- and `MsgRequestTx` in turn. This means that the inbound queue can
+          -- have at most `100` `MsgRequestTxIds` and `MsgRequestTx` which will
+          -- contain a single `TxId` / `Tx`.
+          --
+          -- TODO: the unacknowledged transactions are configured in `NodeArgs`,
+          -- and we should take this parameter as an input for this computation.
+          --
+          -- The upper bound of size of a single transaction is 64k, while the
+          -- size of `TxId` is `34` bytes (`type TxId = Hash Tx`).
+          --
+          -- Ingress side of `txSubmissinInbound`
+          --
+          -- * 'MsgReplyTxs' carrying a single `TxId`:
+          -- ```
+          --    1  -- encodeListLen 2
+          --  + 1  -- encodeWord 1
+          --  + 1  -- encodeListLenIndef
+          --  + 1  -- encodeListLen 2
+          --  + 34 -- encode 'TxId'
+          --  + 5  -- encodeWord32 (size of tx)
+          --  + 1  -- encodeBreak
+          --  = 44
+          -- ```
+          -- * 'MsgReplyTx' carrying a single 'Tx':
+          -- ```
+          --    1      -- encodeListLen 2
+          --  + 1      -- encodeWord 3
+          --  + 1      -- encodeListLenIndef
+          --  + 65_536 -- 64kb transaction
+          --  + 1      -- encodeBreak
+          --  = 65_540
+          -- ```
+          --
+          -- On the ingress side of 'txSubmissionOutbound' we can have at most
+          -- `MaxUnacked' 'MsgRequestTxsIds' and the same ammount of
+          -- 'MsgRequsetTx' containing a single 'TxId'.  The size of
+          -- 'MsgRequestTxsIds' is much smaller that 'MsgReplyTx', and the size
+          -- of `MsgReqeustTx` with a single 'TxId' is smaller than
+          -- 'MsgReplyTxIds' which contains a single 'TxId' (it just contains
+          -- the 'TxId' without the size of 'Tx' in bytes).  So the ingress
+          -- queue of 'txSubmissionOutbound' is bounded by the ingress side of
+          -- the 'txSubmissionInbound'
+          --
+          -- Currently the value of 'txSubmissionMaxUnacked' is '100', for
+          -- which the upper bound is `100 * (44 + 65_540) = 6_558_400`, we add
+          -- 10% as a safety margin.
+          --
+          maximumIngressQueue = addSafetyMargin $
+              fromIntegral txSubmissionMaxUnacked * (44 + 65_540)
+        }
 
-
-  -- TODO: provide sensible limits
-  -- https://github.com/input-output-hk/ouroboros-network/issues/575
-maximumMiniProtocolLimits :: MiniProtocolLimits
-maximumMiniProtocolLimits =
-    MiniProtocolLimits {
-      maximumIngressQueue = 0xffffffff
-    }
 
 -- | Enumeration of node to node protocol versions.
 --

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -236,18 +236,18 @@ nodeToNodeProtocols MiniProtocolParameters {
       MiniProtocolLimits {
           -- chain sync has two potentially large messages:
           --
-          -- * 'MsgFindIntersect'
+          -- - 'MsgFindIntersect'
           --      it can include up to 18 'Points' (see
           --      'Ouroboros.Consensus.ChainSyncClient.chainSyncClient'; search
           --      for the 'offset' term)
-          -- * 'MnsgRollForward'
+          -- - 'MnsgRollForward'
           --      These messages are pipelined.  Up to 300 messages can be
           --      pipelined (this is defined in
           --      'Ouroboros.Consensus.NodeKernel.NodeArgs', which is
           --      instantiated in 'Ouroboros.Consensus.Node.mkNodeArgs').
           --
           -- Sizes:
-          -- * @Point (HeaderHash ByronBlock)@ - 45 as witnessed by
+          -- - @Point (HeaderHash ByronBlock)@ - 45 as witnessed by
           --    @encodedPointSize (szGreedy :: Proxy (HeaderHash ByronBlock) -> Size) (Proxy :: Proxy (Point ByronBlock))
           --    or
           --    ```
@@ -259,7 +259,7 @@ nodeToNodeProtocols MiniProtocolParameters {
           --             'Cardano.Chain.Block.HeaderHash'
           --    = 45
           --
-          -- * @Tip (HeaderHash ByronBlock)@ - 55 as witnessed by
+          -- - @Tip (HeaderHash ByronBlock)@ - 55 as witnessed by
           --    @encodedTipSize (szGreedy :: Proxy (HeaderHash ByronBlock) -> Size) (Proxy :: Proxy (Tip ByronBlock))
           --    or
           --    ```
@@ -269,7 +269,7 @@ nodeToNodeProtocols MiniProtocolParameters {
           --    + 55
           --    ```
           --
-          -- * @MsgFindIntersect@ carrying 18 @Point (HeaderHash ByronBlock)@
+          -- - @MsgFindIntersect@ carrying 18 @Point (HeaderHash ByronBlock)@
           --   ```
           --     1 -- encodeListLen 2
           --   + 1 -- enocdeWord 4
@@ -278,7 +278,7 @@ nodeToNodeProtocols MiniProtocolParameters {
           --   = 994
           --   ```
           --
-          -- * @MsgRollForward@
+          -- - @MsgRollForward@
           --   ```
           --     1   -- encodeListLen 3
           --   + 1   -- encodeWord 2
@@ -309,7 +309,7 @@ nodeToNodeProtocols MiniProtocolParameters {
         -- the largest (and the only pipelined message) in 'block-fetch'
         -- protocol is 'MsgBlock'.  We put a hard limit of 2Mb on each block.
         --
-        -- * size of 'MsgBlock'
+        -- - size of 'MsgBlock'
         --   ```
         --       1               -- encodeListLen 2
         --     + 1               -- encodeWord 4
@@ -351,7 +351,7 @@ nodeToNodeProtocols MiniProtocolParameters {
           --
           -- Ingress side of `txSubmissinInbound`
           --
-          -- * 'MsgReplyTxs' carrying a single `TxId`:
+          -- - 'MsgReplyTxs' carrying a single `TxId`:
           -- ```
           --    1  -- encodeListLen 2
           --  + 1  -- encodeWord 1
@@ -362,7 +362,7 @@ nodeToNodeProtocols MiniProtocolParameters {
           --  + 1  -- encodeBreak
           --  = 44
           -- ```
-          -- * 'MsgReplyTx' carrying a single 'Tx':
+          -- - 'MsgReplyTx' carrying a single 'Tx':
           -- ```
           --    1      -- encodeListLen 2
           --  + 1      -- encodeWord 3

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -174,7 +174,7 @@ nodeToNodeProtocols NodeToNodeProtocols {
       }
     , MiniProtocol {
         miniProtocolNum    = MiniProtocolNum 3,
-        miniProtocolLimits = maximumMiniProtocolLimits,
+        miniProtocolLimits = blockFetchProtocolLimits,
         miniProtocolRun    = blockFetchProtocol
       }
     , MiniProtocol {
@@ -249,6 +249,31 @@ nodeToNodeProtocols NodeToNodeProtocols {
           --
           maximumIngressQueue = 236_280
         }
+
+    blockFetchProtocolLimits = MiniProtocolLimits {
+        -- block-fetch client can pipeline at most `10` blocks.  This is
+        -- currently hard coded in
+        -- 'Ouroboros.Network.BlockFetch.blockFetchLogic' (where
+        -- @maxInFlightReqsPerPeer = 10@ is specified).  In the future the
+        -- block fetch client will count bytes rather than blocks.  By far
+        -- the largest (and the only pipelined message) in 'block-fetch'
+        -- protocol is 'MsgBlock'.  We put a hard limit of 2Mb on each block.
+        --
+        -- * size of 'MsgBlock'
+        --   ```
+        --       1               -- encodeListLen 2
+        --     + 1               -- encodeWord 4
+        --     + 2 * 1024 * 1024 -- block size limit
+        --     = 2_097_154
+        --   ```
+        --
+        -- So the overall limit is `10 * 2_097_154 = 20_971_540` (i.e. aroudn
+        -- '20Mb'), we add 10% safety margin:
+        --
+        maximumIngressQueue = 23_068_694
+      }
+
+
 
   -- TODO: provide sensible limits
   -- https://github.com/input-output-hk/ouroboros-network/issues/575

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/PipelineDecision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/PipelineDecision.hs
@@ -14,6 +14,7 @@ module Ouroboros.Network.Protocol.ChainSync.PipelineDecision
     ) where
 
 import           Control.Exception (assert)
+import           Data.Word
 
 import           Network.TypedProtocol.Pipelined
 
@@ -99,7 +100,7 @@ constantPipelineDecision f = MkPipelineDecision
 --    Collect
 -- @
 --
-pipelineDecisionMax :: Int -> Nat n -> WithOrigin BlockNo -> WithOrigin BlockNo
+pipelineDecisionMax :: Word32 -> Nat n -> WithOrigin BlockNo -> WithOrigin BlockNo
                     -> PipelineDecision n
 pipelineDecisionMax omax n cliTipBlockNo srvTipBlockNo =
     case n of
@@ -138,7 +139,7 @@ pipelineDecisionMax omax n cliTipBlockNo srvTipBlockNo =
 -- | Present minimum pipelining of at most @omax@ requests, collect responses
 -- eagerly.
 --
-pipelineDecisionMin :: Int -> Nat n -> WithOrigin BlockNo -> WithOrigin BlockNo
+pipelineDecisionMin :: Word32 -> Nat n -> WithOrigin BlockNo -> WithOrigin BlockNo
                     -> PipelineDecision n
 pipelineDecisionMin omax n cliTipBlockNo srvTipBlockNo =
     case n of
@@ -171,7 +172,7 @@ pipelineDecisionMin omax n cliTipBlockNo srvTipBlockNo =
 -- number of pipelined messages exceeds the high mark, it collects messages
 -- until there are at most @lowMark@ outstanding requests.
 --
-pipelineDecisionLowHighMark :: Int -> Int -> MkPipelineDecision
+pipelineDecisionLowHighMark :: Word32 -> Word32-> MkPipelineDecision
 pipelineDecisionLowHighMark lowMark highMark =
     assert (lowMark <= highMark) goLow
   where

--- a/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
@@ -125,7 +125,7 @@ blockFetchExample1 decisionTracer clientStateTracer clientMsgTracer
           decisionTracer clientStateTracer
           (sampleBlockFetchPolicy1 blockHeap currentChainHeaders candidateChainHeaders)
           registry
-          (BlockFetchConfiguration 2 1)
+          (BlockFetchConfiguration 2 1 10)
         >> return ()
 
     driver :: TestFetchedBlockHeap m Block -> m ()


### PR DESCRIPTION
This PR consists of two major parts: estimations of inbound queue size for each mini-protocol, plus a refactoring to gather parameters that are needed to set them in one central place.

* calculations of limits for each protocol (every one in each commit)
* when we have those we can add 'MiniProtocolParameters' which take all the required data to compute the limits: chain sync pipelineing parameters, block fetch pipelineing & tx submission unacknowledged `TxIds` (from which one can compute upper bound for pipelining).

`MiniProtocolParameters` are set by `mkNodeArgs` function in `ouroboros-consensus` and passed down the stack.  `NodeArgs` can be change by the `cardano-node`, this makes us safe from changing the parameters at some level without making required changes in `ouroboros-network` - which potentially could end-up badly.