### PR TITLE
test-infra: remove ebbSlotBefore in favor of the new epochSize

### DIFF
--- a/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
@@ -584,7 +584,7 @@ prop_simple_real_pbft_convergence produceEBBs k
         runTestNetwork testConfig epochSize TestConfigBlock
             { forgeEbbEnv = case produceEBBs of
                 NoEBBs      -> Nothing
-                ProduceEBBs -> Just $ byronForgeEbbEnv k
+                ProduceEBBs -> Just byronForgeEbbEnv
             , nodeInfo = \nid ->
                 mkProtocolRealPBFT params nid genesisConfig genesisSecrets
             , rekeying = Just Rekeying
@@ -637,12 +637,9 @@ prop_simple_real_pbft_convergence produceEBBs k
     genesisSecrets :: Genesis.GeneratedSecrets
     (genesisConfig, genesisSecrets) = generateGenesisConfig params
 
-byronForgeEbbEnv :: SecurityParam -> ForgeEbbEnv ByronBlock
-byronForgeEbbEnv k = ForgeEbbEnv
-    { forgeEBB      = Byron.forgeEBB
-    , ebbSlotBefore = \(SlotNo s) ->
-        let denom = unEpochSlots $ kEpochSlots $ coerce k
-        in SlotNo $ denom * div s denom
+byronForgeEbbEnv :: ForgeEbbEnv ByronBlock
+byronForgeEbbEnv = ForgeEbbEnv
+    { forgeEBB = Byron.forgeEBB
     }
 
 -- | Whether to produce EBBs in the tests or not

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -128,12 +128,6 @@ data ForgeEbbEnv blk = ForgeEbbEnv
       -> ChainHash blk
          -- EBB predecessor's hash
       -> blk
-  , ebbSlotBefore :: SlotNo -> SlotNo
-    -- ^ Given the slot of a proper block B, returns the slot of the latest
-    -- expected EBB that should precede B.
-    --
-    -- Note that this is pure, unlike 'EpochInfo', which would usually be used
-    -- for this.
   }
 
 -- | How to rekey a node with a fresh operational key
@@ -614,7 +608,12 @@ runThreadNetwork ThreadNetworkArgs
                 case mbForgeEbbEnv of
                   Nothing          -> forgeWithoutEBB
                   Just forgeEbbEnv -> do
-                    let ebbSlot = ebbSlotBefore forgeEbbEnv currentSlot
+                    let ebbSlot :: SlotNo
+                        ebbSlot =
+                            SlotNo $ denom * div numer denom
+                          where
+                            SlotNo numer    = currentSlot
+                            EpochSize denom = epochSize
 
                     let p = ledgerTipPoint $ ledgerState extLdgSt
                     let mSlot = pointSlot p


### PR DESCRIPTION
A quick simplification enabled by #1734.