### PR TITLE
check that Byron can increment its adopted protocol version

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -85,6 +85,8 @@ test-suite test
                        Test.Consensus.Byron.Ledger
                        Test.ThreadNet.DualPBFT
                        Test.ThreadNet.RealPBFT
+                       Test.ThreadNet.RealPBFT.ProtocolInfo
+                       Test.ThreadNet.RealPBFT.ProtocolVersionUpdate
                        Test.ThreadNet.TxGen.Byron
 
                        Ouroboros.Consensus.ByronDual.Ledger

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/DualPBFT.hs
@@ -153,6 +153,7 @@ setupTestOutput setup@SetupDualPBft{..} =
         forgeEbbEnv = Nothing -- spec does not model EBBs
       , rekeying    = Nothing -- TODO
       , nodeInfo    = \coreNodeId ->
+          plainTestNodeInitialization $
           protocolInfoDualByron
             setupGenesis
             setupParams

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
@@ -17,14 +17,11 @@ module Test.ThreadNet.RealPBFT (
   ) where
 
 import           Data.Coerce (coerce)
-import           Data.Foldable (find)
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (fromMaybe, mapMaybe)
+import           Data.Maybe (mapMaybe)
 import qualified Data.Set as Set
 import           Data.Time (Day (..), UTCTime (..))
 import           Data.Word (Word64)
-import           GHC.Stack (HasCallStack)
 
 import           Numeric.Search.Range (searchFromTo)
 import           Test.QuickCheck
@@ -59,7 +56,6 @@ import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.Genesis as Genesis
 import           Cardano.Chain.ProtocolConstants (kEpochSlots)
 import           Cardano.Chain.Slotting (EpochNumber (..), unEpochSlots)
-import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Crypto as Crypto
 import qualified Cardano.Crypto.DSIGN as Crypto
 import qualified Test.Cardano.Chain.Genesis.Dummy as Dummy
@@ -68,11 +64,11 @@ import qualified Ouroboros.Consensus.Byron.Crypto.DSIGN as Crypto
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import           Ouroboros.Consensus.Byron.Ledger.Conversions
-import           Ouroboros.Consensus.Byron.Node
 import           Ouroboros.Consensus.Byron.Protocol
 
 import           Test.ThreadNet.General
-import           Test.ThreadNet.Network (NodeOutput (..))
+import           Test.ThreadNet.Network (NodeOutput (..),
+                     TestNodeInitialization (..))
 import qualified Test.ThreadNet.Ref.PBFT as Ref
 import           Test.ThreadNet.TxGen.Byron ()
 import           Test.ThreadNet.Util
@@ -83,6 +79,9 @@ import           Test.ThreadNet.Util.NodeTopology
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Shrink (andId, dropId)
 import qualified Test.Util.Stream as Stream
+
+import           Test.ThreadNet.RealPBFT.ProtocolInfo
+import           Test.ThreadNet.RealPBFT.ProtocolVersionUpdate
 
 -- | Generate k values as small as this module is known to handle.
 --
@@ -551,6 +550,7 @@ prop_simple_real_pbft_convergence produceEBBs k
     } =
     tabulate "produce EBBs" [show produceEBBs] $
     tabulate "Ref.PBFT result" [Ref.resultConstrName refResult] $
+    tabulate "proposed protocol version was adopted" [show aPvuRequired] $
     counterexample ("params: " <> show params) $
     counterexample ("Ref.PBFT result: " <> show refResult) $
     counterexample
@@ -575,6 +575,7 @@ prop_simple_real_pbft_convergence produceEBBs k
         (expectedBlockRejection k numCoreNodes nodeRestarts)
         1
         testOutput .&&.
+    prop_pvu .&&.
     not (all (Chain.null . snd) finalChains) .&&.
     conjoin (map (hasAllEBBs k numSlots produceEBBs) finalChains)
   where
@@ -584,7 +585,8 @@ prop_simple_real_pbft_convergence produceEBBs k
                 NoEBBs      -> Nothing
                 ProduceEBBs -> Just byronForgeEbbEnv
             , nodeInfo = \nid ->
-                mkProtocolRealPBFT params nid genesisConfig genesisSecrets
+                mkProtocolRealPBftAndHardForkTxs
+                  params nid genesisConfig genesisSecrets
             , rekeying = Just Rekeying
               { rekeyOracle   = \cid s ->
                   let nominalSlots = case refResult of
@@ -627,6 +629,49 @@ prop_simple_real_pbft_convergence produceEBBs k
 
     finalChains :: [(NodeId, Chain ByronBlock)]
     finalChains = Map.toList $ nodeOutputFinalChain <$> testOutputNodes testOutput
+
+    finalLedgers :: [(NodeId, Byron.LedgerState ByronBlock)]
+    finalLedgers = Map.toList $ nodeOutputFinalLedger <$> testOutputNodes testOutput
+
+    pvuLabels :: [(NodeId, ProtocolVersionUpdateLabel)]
+    pvuLabels =
+        [ (,) cid $
+          mkProtocolVersionUpdateLabel
+            params
+            numSlots
+            genesisConfig
+            nodeJoinPlan
+            refResult
+            ldgr
+        | (cid, ldgr) <- finalLedgers
+        ]
+
+    -- whether the proposed protocol version was required have been adopted in
+    -- one of the chains
+    aPvuRequired :: Bool
+    aPvuRequired =
+        or
+        [ Just True == pvuRequired
+        | (_, ProtocolVersionUpdateLabel{pvuRequired}) <- pvuLabels
+        ]
+
+    -- check whether the proposed protocol version should have been and if so
+    -- was adopted
+    prop_pvu :: Property
+    prop_pvu =
+        counterexample (show pvuLabels) $
+        conjoin
+        [ counterexample (show (cid, pvuLabel)) $
+          let ProtocolVersionUpdateLabel
+                { pvuObserved
+                , pvuRequired
+                } = pvuLabel
+          in
+          property $ case pvuRequired of
+            Just b  -> b == pvuObserved
+            Nothing -> True
+        | (cid, pvuLabel) <- pvuLabels
+        ]
 
     params :: PBftParams
     params = realPBftParams k numCoreNodes
@@ -681,43 +726,6 @@ hasAllEBBs k (NumSlots t) produceEBBs (nid, c) =
           denom = unEpochSlots $ kEpochSlots $ coerce k
 
     actual   = mapMaybe (nodeIsEBB . getHeader) $ Chain.toOldestFirst c
-
-mkProtocolRealPBFT :: HasCallStack
-                   => PBftParams
-                   -> CoreNodeId
-                   -> Genesis.Config
-                   -> Genesis.GeneratedSecrets
-                   -> ProtocolInfo ByronBlock
-mkProtocolRealPBFT params (CoreNodeId i)
-                   genesisConfig genesisSecrets =
-    protocolInfoByron
-      genesisConfig
-      (Just $ PBftSignatureThreshold pbftSignatureThreshold)
-      (Update.ProtocolVersion 1 0 0)
-      (Update.SoftwareVersion (Update.ApplicationName "Cardano Test") 2)
-      (Just leaderCredentials)
-  where
-    leaderCredentials :: PBftLeaderCredentials
-    leaderCredentials = either (error . show) id $
-        mkPBftLeaderCredentials
-          genesisConfig
-          dlgKey
-          dlgCert
-
-    PBftParams{pbftSignatureThreshold} = params
-
-    dlgKey :: Crypto.SigningKey
-    dlgKey = fromMaybe (error "dlgKey") $
-       find (\sec -> Delegation.delegateVK dlgCert == Crypto.toVerification sec)
-            $ Genesis.gsRichSecrets genesisSecrets
-
-    dlgCert :: Delegation.Certificate
-    dlgCert = snd $ Map.toAscList dlgMap !! (fromIntegral i)
-
-    dlgMap :: Map Common.KeyHash Delegation.Certificate
-    dlgMap = Genesis.unGenesisDelegation
-           $ Genesis.gdHeavyDelegation
-           $ Genesis.configGenesisData genesisConfig
 
 {-------------------------------------------------------------------------------
   Generating the genesis configuration
@@ -1009,7 +1017,7 @@ mkRekeyUpd
   -> ProtocolInfo ByronBlock
   -> EpochNo
   -> Crypto.SignKeyDSIGN Crypto.ByronDSIGN
-  -> Maybe (ProtocolInfo ByronBlock, Byron.GenTx ByronBlock)
+  -> Maybe (TestNodeInitialization ByronBlock)
 mkRekeyUpd genesisConfig genesisSecrets pInfo eno newSK =
   case pbftIsLeader configConsensus of
     PBftIsNotALeader       -> Nothing
@@ -1028,7 +1036,10 @@ mkRekeyUpd genesisConfig genesisSecrets pInfo eno newSK =
             }
 
           PBftIsLeader{pbftDlgCert} = isLeader'
-      in Just (pInfo', dlgTx pbftDlgCert)
+      in Just TestNodeInitialization
+        { tniCrucialTxs = [dlgTx pbftDlgCert]
+        , tniProtocolInfo = pInfo'
+        }
   where
     ProtocolInfo{pInfoConfig = TopLevelConfig{ configConsensus
                                              , configLedger

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT/ProtocolInfo.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT/ProtocolInfo.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.ThreadNet.RealPBFT.ProtocolInfo (
+  theProposedProtocolVersion,
+  theProposedSoftwareVersion,
+  mkProtocolRealPBFT,
+  ) where
+
+import           Data.Foldable (find)
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe)
+import           GHC.Stack (HasCallStack)
+
+import qualified Cardano.Chain.Common as Common
+import qualified Cardano.Chain.Delegation as Delegation
+import qualified Cardano.Chain.Genesis as Genesis
+import qualified Cardano.Chain.Update as Update
+import qualified Cardano.Crypto as Crypto
+
+import           Ouroboros.Consensus.Protocol.PBFT
+import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
+
+import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
+import           Ouroboros.Consensus.Byron.Node
+
+mkProtocolRealPBFT :: HasCallStack
+                   => PBftParams
+                   -> CoreNodeId
+                   -> Genesis.Config
+                   -> Genesis.GeneratedSecrets
+                   -> ProtocolInfo ByronBlock
+mkProtocolRealPBFT params (CoreNodeId i)
+                   genesisConfig genesisSecrets =
+    protocolInfoByron
+      genesisConfig
+      (Just $ PBftSignatureThreshold pbftSignatureThreshold)
+      theProposedProtocolVersion
+      theProposedSoftwareVersion
+      (Just leaderCredentials)
+  where
+    leaderCredentials :: PBftLeaderCredentials
+    leaderCredentials = either (error . show) id $
+        mkPBftLeaderCredentials
+          genesisConfig
+          dlgKey
+          dlgCert
+
+    PBftParams{pbftSignatureThreshold} = params
+
+    dlgKey :: Crypto.SigningKey
+    dlgKey = fromMaybe (error "dlgKey") $
+       find (\sec -> Delegation.delegateVK dlgCert == Crypto.toVerification sec)
+            $ Genesis.gsRichSecrets genesisSecrets
+
+    dlgCert :: Delegation.Certificate
+    dlgCert = snd $ Map.toAscList dlgMap !! (fromIntegral i)
+
+    dlgMap :: Map Common.KeyHash Delegation.Certificate
+    dlgMap = Genesis.unGenesisDelegation
+           $ Genesis.gdHeavyDelegation
+           $ Genesis.configGenesisData genesisConfig
+
+-- | The protocol version proposed as part of the hard-fork smoke test
+--
+-- The initial Byron ledger state beings with protocol version @0.0.0@. In the
+-- smoke test, if the proposal and votes are enabled, then we will be proposing
+-- an update to @1.0.0@.
+--
+-- This value occurs in two crucial places: the proposal and also the
+-- 'Byron.byronProtocolVersion' field of the static node config. See the
+-- Haddock comment on 'mkProtocolRealPBftAndHardForkTxs'.
+--
+theProposedProtocolVersion :: Update.ProtocolVersion
+theProposedProtocolVersion = Update.ProtocolVersion 1 0 0
+
+-- | The software version proposed as part of the hard-fork smoke test
+--
+-- We don't actually care about this for the smoke test, but we have to set it
+-- both as part of the proposal and also as part of the node's static
+-- configuration. Its use in the static configuration is legacy and does not
+-- seem to affect anything; see Issue #1732.
+--
+-- The initial Byron ledger state beings with no recorded software versions.
+-- For the addition of a new software version, the Byron ledger rules require
+-- that it starts at 0 or 1.
+--
+theProposedSoftwareVersion :: Update.SoftwareVersion
+theProposedSoftwareVersion = Update.SoftwareVersion
+  (Update.ApplicationName "Cardano Test")
+  0

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -70,6 +70,7 @@ prop_simple_bft_convergence k
         runTestNetwork testConfig epochSize TestConfigBlock
             { forgeEbbEnv = Nothing
             , nodeInfo    = \nid ->
+                plainTestNodeInitialization $
                 protocolInfoBft numCoreNodes nid k slotLengths
             , rekeying    = Nothing
             }

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -103,7 +103,8 @@ prop_simple_leader_schedule_convergence
     testOutput@TestOutput{testOutputNodes} =
         runTestNetwork testConfig epochSize TestConfigBlock
             { forgeEbbEnv = Nothing
-            , nodeInfo    = \nid -> protocolInfoPraosRule
+            , nodeInfo    = \nid -> plainTestNodeInitialization $
+                                    protocolInfoPraosRule
                                       numCoreNodes
                                       nid
                                       params

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -97,7 +97,8 @@ prop_simple_pbft_convergence
     testOutput =
         runTestNetwork testConfig epochSize TestConfigBlock
             { forgeEbbEnv = Nothing
-            , nodeInfo    = protocolInfoMockPBFT
+            , nodeInfo    = plainTestNodeInitialization .
+                            protocolInfoMockPBFT
                               params
                               (singletonSlotLengths pbftSlotLength)
             , rekeying    = Nothing

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -107,7 +107,8 @@ prop_simple_praos_convergence
     testOutput@TestOutput{testOutputNodes} =
         runTestNetwork testConfig epochSize TestConfigBlock
             { forgeEbbEnv = Nothing
-            , nodeInfo    = \nid -> protocolInfoPraos
+            , nodeInfo    = \nid -> plainTestNodeInitialization $
+                                    protocolInfoPraos
                                       numCoreNodes
                                       nid
                                       params

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -18,6 +18,8 @@ module Test.ThreadNet.Network (
   , ForgeEbbEnv (..)
   , RekeyM
   , ThreadNetworkArgs (..)
+  , TestNodeInitialization (..)
+  , plainTestNodeInitialization
   , TracingConstraints
     -- * Tracers
   , MiniProtocolExpectedException (..)
@@ -41,7 +43,6 @@ import qualified Data.List as List
 import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
@@ -137,15 +138,32 @@ type RekeyM m blk =
   -> SlotNo
      -- ^ The slot in which the node is rekeying
   -> (SlotNo -> m EpochNo)
-  -> m (ProtocolInfo blk, Maybe (GenTx blk))
-     -- ^ resulting config and any corresponding delegation certificate transaction
+  -> m (TestNodeInitialization blk)
+     -- ^ 'tniProtocolInfo' should include new delegation cert/operational key,
+     -- and 'tniCrucialTxs' should include the new delegation certificate
+     -- transaction
+
+-- | Data used when starting/restarting a node
+data TestNodeInitialization blk = TestNodeInitialization
+  { tniCrucialTxs   :: [GenTx blk]
+    -- ^ these transactions are added immediately and repeatedly (whenever the
+    -- 'ledgerTipSlot' changes)
+  , tniProtocolInfo :: ProtocolInfo blk
+  }
+
+plainTestNodeInitialization
+  :: ProtocolInfo blk -> TestNodeInitialization blk
+plainTestNodeInitialization pInfo = TestNodeInitialization
+    { tniCrucialTxs   = []
+    , tniProtocolInfo = pInfo
+    }
 
 -- | Parameters for the test node net
 --
 data ThreadNetworkArgs m blk = ThreadNetworkArgs
   { tnaForgeEbbEnv  :: Maybe (ForgeEbbEnv blk)
   , tnaJoinPlan     :: NodeJoinPlan
-  , tnaNodeInfo     :: CoreNodeId -> ProtocolInfo blk
+  , tnaNodeInfo     :: CoreNodeId -> TestNodeInitialization blk
   , tnaNumCoreNodes :: NumCoreNodes
   , tnaNumSlots     :: NumSlots
   , tnaRNG          :: ChaChaDRG
@@ -182,9 +200,10 @@ data ThreadNetworkArgs m blk = ThreadNetworkArgs
 -- context.
 --
 data VertexStatus m blk
-  = VDown (Chain blk)
+  = VDown (Chain blk) (LedgerState blk)
     -- ^ The vertex does not currently have a node instance; its previous
-    -- instance stopped with this chain (empty before first instance)
+    -- instance stopped with this chain and ledger state (empty/initial before
+    -- first instance)
   | VFalling
     -- ^ The vertex has a node instance, but it is about to transition to
     -- 'VDown' as soon as its edges transition to 'EDown'.
@@ -277,7 +296,13 @@ runThreadNetwork ThreadNetworkArgs
     -- allocate the status variable for each vertex
     vertexStatusVars <- fmap Map.fromList $ do
       forM coreNodeIds $ \nid -> do
-        v <- uncheckedNewTVarM (VDown Genesis)
+        -- assume they all start with the empty chain and the same initial
+        -- ledger
+        let nodeInitData = mkProtocolInfo (CoreNodeId 0)
+            TestNodeInitialization{tniProtocolInfo} = nodeInitData
+            ProtocolInfo{pInfoInitLedger} = tniProtocolInfo
+            ExtLedgerState{ledgerState} = pInfoInitLedger
+        v <- uncheckedNewTVarM (VDown Genesis ledgerState)
         pure (nid, v)
 
     -- fork the directed edges, which also allocates their status variables
@@ -353,7 +378,7 @@ runThreadNetwork ThreadNetworkArgs
       atomically $
       forM vertexInfos0 $ \(coreNodeId, vertexStatusVar, readNodeInfo) -> do
         readTVar vertexStatusVar >>= \case
-          VDown ch -> pure (coreNodeId, readNodeInfo, ch)
+          VDown ch ldgr -> pure (coreNodeId, readNodeInfo, ch, ldgr)
           _        -> retry
 
     mkTestOutput vertexInfos
@@ -387,8 +412,13 @@ runThreadNetwork ThreadNetworkArgs
       edgeStatusVars
       nodeInfo =
         void $ forkLinkedThread sharedRegistry $ do
-          loop 0 (mkProtocolInfo coreNodeId) NodeRestart restarts0
+          loop 0 tniProtocolInfo NodeRestart restarts0
       where
+        TestNodeInitialization
+           { tniCrucialTxs
+           , tniProtocolInfo
+           } = mkProtocolInfo coreNodeId
+
         restarts0 :: Map SlotNo NodeRestart
         restarts0 = Map.mapMaybe (Map.lookup coreNodeId) m
           where
@@ -397,16 +427,21 @@ runThreadNetwork ThreadNetworkArgs
         loop :: SlotNo -> ProtocolInfo blk -> NodeRestart -> Map SlotNo NodeRestart -> m ()
         loop s pInfo nr rs = do
           -- a registry solely for the resources of this specific node instance
-          (again, finalChain) <- withRegistry $ \nodeRegistry -> do
+          (again, finalChain, finalLdgr) <- withRegistry $ \nodeRegistry -> do
             let nodeTestBtime = testBlockchainTimeClone sharedTestBtime nodeRegistry
                 nodeBtime     = testBlockchainTime nodeTestBtime
 
             -- change the node's key and prepare a delegation transaction if
             -- the node is restarting because it just rekeyed
-            (pInfo', txs0) <- case (nr, mbRekeyM) of
+            tni' <- case (nr, mbRekeyM) of
               (NodeRekey, Just rekeyM) -> do
-                fmap maybeToList <$> rekeyM coreNodeId pInfo s (epochInfoEpoch epochInfo)
-              _                        -> pure (pInfo, [])
+                rekeyM coreNodeId pInfo s (epochInfoEpoch epochInfo)
+              _                        ->
+                  pure $ plainTestNodeInitialization pInfo
+            let TestNodeInitialization
+                  { tniCrucialTxs   = crucialTxs'
+                  , tniProtocolInfo = pInfo'
+                  } = tni'
 
             -- allocate the node's internal state and fork its internal threads
             -- (specifically not the communication threads running the Mini
@@ -417,7 +452,7 @@ runThreadNetwork ThreadNetworkArgs
               nodeRegistry
               pInfo'
               nodeInfo
-              txs0
+              (crucialTxs' ++ tniCrucialTxs)
             atomically $ writeTVar vertexStatusVar $ VUp kernel app
 
             -- wait until this node instance should stop
@@ -442,11 +477,15 @@ runThreadNetwork ThreadNetworkArgs
 
             -- assuming nothing else is changing it, read the final chain
             let chainDB = getChainDB kernel
+            ExtLedgerState{ledgerState} <- atomically $
+              ChainDB.getCurrentLedger chainDB
             finalChain <- ChainDB.toChain chainDB
 
-            pure (again, finalChain)   -- end of the node's withRegistry
+            pure (again, finalChain, ledgerState)
+            -- end of the node's withRegistry
 
-          atomically $ writeTVar vertexStatusVar $ VDown finalChain
+          atomically $ writeTVar vertexStatusVar $
+            VDown finalChain finalLdgr
 
           case again of
             Nothing                     -> pure ()
@@ -458,7 +497,7 @@ runThreadNetwork ThreadNetworkArgs
     -- If we add the transaction and then the mempools discards it for some
     -- reason, this thread will add it again.
     --
-    forkTxs0
+    forkCrucialTxs
       :: HasCallStack
       => ResourceRegistry m
       -> STM m (WithOrigin SlotNo)
@@ -467,7 +506,7 @@ runThreadNetwork ThreadNetworkArgs
       -> [GenTx blk]
          -- ^ valid transactions the node should immediately propagate
       -> m ()
-    forkTxs0 registry get mempool txs0 =
+    forkCrucialTxs registry get mempool txs0 =
       void $ forkLinkedThread registry $ do
         let loop mbSlot = do
               _ <- addTxs mempool txs0
@@ -708,7 +747,7 @@ runThreadNetwork ThreadNetworkArgs
       --
       -- TODO Is there a risk that this will block because the 'forkTxProducer'
       -- fills up the mempool too quickly?
-      forkTxs0
+      forkCrucialTxs
         registry
         ((ledgerTipSlot . ledgerState) <$> ChainDB.getCurrentLedger chainDB)
         mempool
@@ -1036,11 +1075,12 @@ newNodeInfo = do
 -------------------------------------------------------------------------------}
 
 data NodeOutput blk = NodeOutput
-  { nodeOutputAdds       :: Map SlotNo (Set (RealPoint blk, BlockNo))
-  , nodeOutputFinalChain :: Chain blk
-  , nodeOutputNodeDBs    :: NodeDBs MockFS
-  , nodeOutputForges     :: Map SlotNo blk
-  , nodeOutputInvalids   :: Map (RealPoint blk) [ExtValidationError blk]
+  { nodeOutputAdds        :: Map SlotNo (Set (RealPoint blk, BlockNo))
+  , nodeOutputFinalChain  :: Chain blk
+  , nodeOutputFinalLedger :: LedgerState blk
+  , nodeOutputNodeDBs     :: NodeDBs MockFS
+  , nodeOutputForges      :: Map SlotNo blk
+  , nodeOutputInvalids    :: Map (RealPoint blk) [ExtValidationError blk]
   }
 
 data TestOutput blk = TestOutput
@@ -1054,11 +1094,12 @@ mkTestOutput ::
     => [( CoreNodeId
         , m (NodeInfo blk MockFS [])
         , Chain blk
+        , LedgerState blk
         )]
     -> m (TestOutput blk)
 mkTestOutput vertexInfos = do
     (nodeOutputs', tipBlockNos') <- fmap unzip $ forM vertexInfos $
-      \(cid, readNodeInfo, ch) -> do
+      \(cid, readNodeInfo, ch, ldgr) -> do
         let nid = fromCoreNodeId cid
         nodeInfo <- readNodeInfo
         let NodeInfo
@@ -1072,15 +1113,16 @@ mkTestOutput vertexInfos = do
               , nodeEventsTipBlockNos
               } = nodeInfoEvents
         let nodeOutput = NodeOutput
-              { nodeOutputAdds       =
+              { nodeOutputAdds        =
                   Map.fromListWith Set.union $
                   [ (s, Set.singleton (p, bno)) | (s, p, bno) <- nodeEventsAdds ]
-              , nodeOutputFinalChain = ch
-              , nodeOutputNodeDBs    = nodeInfoDBs
-              , nodeOutputForges     =
+              , nodeOutputFinalChain  = ch
+              , nodeOutputFinalLedger = ldgr
+              , nodeOutputNodeDBs     = nodeInfoDBs
+              , nodeOutputForges      =
                   Map.fromList $
                   [ (s, b) | TraceForgedBlock s _ b _ <- nodeEventsForges ]
-              , nodeOutputInvalids   = (:[]) <$> Map.fromList nodeEventsInvalids
+              , nodeOutputInvalids    = (:[]) <$> Map.fromList nodeEventsInvalids
               }
 
         pure


### PR DESCRIPTION
I'm not sure if this should be considered to fully address #1514, but it's good first step.

It originally that #1161 is high-priority because of votes: they are replicated and fill up the blocks, making the test quite expensive. Other transactions (so far) haven't been as problematic because duplicate transactions other than votes are invalid.

Therefore this PR is rooted on top of a potential fix for 1161; it's blocked by the corresponding PR. Good news, though: the protocol version update is succeeding when expected.

I'm opening this as Draft since it currently includes the latest state of the other PR.