### PR TITLE
Remove constantSubscriptionTarget

### DIFF
--- a/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Client.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Client.hs
@@ -75,6 +75,6 @@ clientSubscriptionWorker snocket
         wpLocalAddresses         = Identity cspAddress,
         wpSelectAddress          = \_ (Identity addr) -> Just addr,
         wpConnectionAttemptDelay = const cspConnectionAttemptDelay,
-        wpSubscriptionTarget     = pure (constantSubscriptionTarget cspAddress),
+        wpSubscriptionTarget     = pure (listSubscriptionTarget [cspAddress]),
         wpValency                = 1
       }

--- a/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Subscriber.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Subscriber.hs
@@ -1,7 +1,6 @@
 
 module Ouroboros.Network.Subscription.Subscriber
     ( SubscriptionTarget (..)
-    , constantSubscriptionTarget
     , listSubscriptionTarget
     ) where
 
@@ -12,10 +11,6 @@ newtype SubscriptionTarget m target = SubscriptionTarget
       -- ^ This should be used with the exception that implementations can block on
       -- the order of seconds.
     }
-
-constantSubscriptionTarget :: Applicative m => target -> SubscriptionTarget m target
-constantSubscriptionTarget target =
-    SubscriptionTarget (pure (Just (target, constantSubscriptionTarget target)))
 
 listSubscriptionTarget
     :: Applicative m


### PR DESCRIPTION
constantSubscriptionTarget creates an infinite stream of identical
subscription targets which causes subscriptionLoop.innerLoop to
livelock. Replace usage with a listSubscriptionTarget with a single
element instead.