### PR TITLE
Bump dependency on quickcheck-state-machine

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -216,8 +216,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/advancedtelematic/quickcheck-state-machine
-  tag: 19c5080dd940f7c23b26e7f469d6b06a40da70e3
-  --sha256: 135p3hwglpgjb4gsafsxijxg9ki8xvpk6alvcvh9ryiwgkdyxkl6
+  tag: 2bf37003ca1c0c57e4354610d7c47da0a0e77b5c
+  --sha256: 1cr38aplhmwczrjc2xqya3mjp0zkbk20jjhhzk0spydbcsbi4l5l
 
 package quickcheck-state-machine
   tests: False

--- a/stack.yaml
+++ b/stack.yaml
@@ -75,7 +75,7 @@ extra-deps:
       - test
 
   - git: https://github.com/advancedtelematic/quickcheck-state-machine
-    commit: 19c5080dd940f7c23b26e7f469d6b06a40da70e3
+    commit: 2bf37003ca1c0c57e4354610d7c47da0a0e77b5c
 
   - bimap-0.4.0
   - binary-0.8.7.0


### PR DESCRIPTION
This includes
https://github.com/advancedtelematic/quickcheck-state-machine/pull/362, which
renames a file from Aux.hs to Auxiliary.hs, unbreaking the Windows build.