### PR TITLE
Make ouroboros-consensus warning free

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -67,7 +67,13 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts
 
@@ -124,14 +130,20 @@ test-suite test
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists
                        -threaded
                        -rtsopts
 
 executable db-converter
-   hs-source-dirs:     tools/db-converter
-   main-is:            Main.hs
-   build-depends:      base
+  hs-source-dirs:      tools/db-converter
+  main-is:             Main.hs
+  build-depends:       base
                      , bytestring
                      , cardano-binary
                      , cardano-crypto-wrapper
@@ -152,9 +164,15 @@ executable db-converter
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
 
-   default-language:   Haskell2010
-   ghc-options:        -Wall
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists
 
 executable db-analyser
   hs-source-dirs:      tools/db-analyser
@@ -174,4 +192,10 @@ executable db-analyser
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists

--- a/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Ledger.hs
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Ledger.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.ByronDual.Ledger (
     -- * Shorthand

--- a/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TypeFamilies      #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.ByronDual.Node (
     protocolInfoDualByron

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies      #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Byron.Ledger.Config (
     BlockConfig(..)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
@@ -46,7 +46,7 @@ fromByronBlockNo :: CC.ChainDifficulty -> BlockNo
 fromByronBlockNo = coerce
 
 fromByronBlockCount :: CC.BlockCount -> SecurityParam
-fromByronBlockCount (CC.BlockCount k) = SecurityParam (fromIntegral k)
+fromByronBlockCount (CC.BlockCount k) = SecurityParam k
 
 fromByronEpochSlots :: CC.EpochSlots -> EpochSize
 fromByronEpochSlots (CC.EpochSlots n) = EpochSize n
@@ -59,7 +59,7 @@ toByronSlotNo :: SlotNo -> CC.SlotNumber
 toByronSlotNo = coerce
 
 toByronBlockCount :: SecurityParam -> CC.BlockCount
-toByronBlockCount (SecurityParam k) = CC.BlockCount (fromIntegral k)
+toByronBlockCount (SecurityParam k) = CC.BlockCount k
 
 {-------------------------------------------------------------------------------
   Extract info from genesis

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Byron.Ledger.HeaderValidation () where
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -121,7 +121,10 @@ initByronLedgerState genesis mUtxo = ByronLedgerState {
     }
   where
     initState :: CC.ChainValidationState
-    Right initState = runExcept $ CC.initialChainValidationState genesis
+    initState = case runExcept $ CC.initialChainValidationState genesis of
+      Right st -> st
+      Left e   -> error $
+        "could not create initial ChainValidationState: " <> show e
 
     override :: Maybe CC.UTxO
              -> CC.ChainValidationState -> CC.ChainValidationState

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -11,7 +11,7 @@
 {-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE TypeFamilies      #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Byron mempool integration
 module Ouroboros.Consensus.Byron.Ledger.Mempool (

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion (
     ByronNetworkProtocolVersion(..)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE TypeFamilies          #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 -- | Instances required to support PBFT
 module Ouroboros.Consensus.Byron.Ledger.PBFT (
     toPBftLedgerView

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies      #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Byron.Ledger.Serialisation (
     -- * Serialisation

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Byron.Node (
     protocolInfoByron

--- a/ouroboros-consensus-byron/test/Test/Consensus/Byron/Ledger.hs
+++ b/ouroboros-consensus-byron/test/Test/Consensus/Byron/Ledger.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans -Wno-incomplete-uni-patterns #-}
 module Test.Consensus.Byron.Ledger (tests) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/DualPBFT.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.ThreadNet.DualPBFT (
     tests

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
@@ -510,7 +510,7 @@ expectedBlockRejection
     -- the node lead but rejected its own block. This is the only case we
     -- expect. (Rejecting its own block also prevents the node from propagating
     -- that block.)
-    ownBlock = fromIntegral i == mod (unSlotNo s) (fromIntegral nn)
+    ownBlock = i == mod (unSlotNo s) nn
 expectedBlockRejection _ _ _ _ = False
 
 -- | If we rekey in slot rekeySlot, it is in general possible that the leader
@@ -535,7 +535,7 @@ latestPossibleDlgMaturation
   :: SecurityParam -> NumCoreNodes -> SlotNo -> SlotNo
 latestPossibleDlgMaturation
   (SecurityParam k) (NumCoreNodes n) (SlotNo rekeySlot) =
-    SlotNo $ rekeySlot + fromIntegral n + 2 * k
+    SlotNo $ rekeySlot + n + 2 * k
 
 prop_simple_real_pbft_convergence :: ProduceEBBs
                                   -> SecurityParam
@@ -677,7 +677,7 @@ hasAllEBBs k (NumSlots t) produceEBBs (nid, c) =
       ProduceEBBs -> coerce [0 .. hi]
         where
           hi :: Word64
-          hi = if t < 1 then 0 else fromIntegral (t - 1) `div` denom
+          hi = if t < 1 then 0 else (t - 1) `div` denom
           denom = unEpochSlots $ kEpochSlots $ coerce k
 
     actual   = mapMaybe (nodeIsEBB . getHeader) $ Chain.toOldestFirst c

--- a/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
+++ b/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
@@ -53,4 +53,10 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies    #-}
 
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 
 module Ouroboros.Consensus.ByronSpec.Ledger.Ledger (
     ByronSpecLedgerError(..)

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE DerivingVia    #-}
 {-# LANGUAGE TypeFamilies   #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.ByronSpec.Ledger.Mempool (
     -- * Type family instances

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Orphans.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Orphans.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Missing instances for standard type classes in the Byron spec
 module Ouroboros.Consensus.ByronSpec.Ledger.Orphans () where

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -36,6 +36,12 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts

--- a/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -63,9 +63,14 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists
                        -Wno-unticked-promoted-constructors
-
 
 test-suite test
   type:                exitcode-stdio-1.0
@@ -100,7 +105,13 @@ test-suite test
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists
                        -fno-ignore-asserts
                        -threaded
                        -rtsopts

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Mock.Ledger.Block.BFT (
     SimpleBftBlock

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Mock.Ledger.Block.PBFT (
     SimplePBftBlock

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Mock.Ledger.Block.Praos (
     SimplePraosBlock

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Test the Praos chain selection rule (with explicit leader schedule)
 module Ouroboros.Consensus.Mock.Ledger.Block.PraosRule (

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Mock.Node () where
 
 import           Codec.Serialise (Serialise, decode, encode)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -413,7 +413,7 @@ infosEta l xs e =
         eta' = infosEta l xs e'
         from = epochFirst l e'
         n    = div (2 * praosSlotsPerEpoch) 3
-        to   = SlotNo $ unSlotNo from + fromIntegral n
+        to   = SlotNo $ unSlotNo from + n
         rhos = reverse [biRho b | b <- infosSlice from to xs]
     in  fromHash $ hash @(PraosHash c) (eta', e, rhos)
   where

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -166,5 +166,5 @@ expectedBlockRejection (NumCoreNodes nn) BlockRejection
     -- the node lead but rejected its own block. This is the only case we
     -- expect. (Rejecting its own block also prevents the node from propagating
     -- that block.)
-    ownBlock = fromIntegral i == mod s (fromIntegral nn)
+    ownBlock = i == mod s nn
 expectedBlockRejection _ _ = False

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -75,8 +75,7 @@ tests = testGroup "Praos"
 
     numCoreNodes = NumCoreNodes 3
     numEpochs    = 3
-    numSlots     = NumSlots $ fromIntegral $
-      maxRollbacks k * praosSlotsPerEpoch * numEpochs
+    numSlots     = NumSlots $ maxRollbacks k * praosSlotsPerEpoch * numEpochs
 
     params@PraosParams{praosSecurityParam = k, ..} = PraosParams
       { praosSecurityParam = SecurityParam 5

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
@@ -93,7 +93,13 @@ library
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists
                        -fno-ignore-asserts
 
 test-suite test
@@ -114,5 +120,11 @@ test-suite test
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists
                        -fno-ignore-asserts

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -108,7 +108,7 @@ truncateNodeTopology (NodeTopology m) (NumCoreNodes n') =
 
 truncateNodeRestarts :: NodeRestarts -> NumSlots -> NodeRestarts
 truncateNodeRestarts (NodeRestarts m) (NumSlots t) =
-    NodeRestarts $ Map.filterWithKey (\(SlotNo s) _ -> s < fromIntegral t) m
+    NodeRestarts $ Map.filterWithKey (\(SlotNo s) _ -> s < t) m
 
 instance Arbitrary TestConfig where
   arbitrary = do

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Ref/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Ref/PBFT.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE MultiWayIf          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ViewPatterns        #-}
 
 -- | A reference simulator of the PBFT protocol under \"ideal circumstances\"
 --
@@ -139,7 +138,7 @@ count a bs = length [ () | b <- toList bs, a == b ]
 prune :: Int -> Seq a -> (Seq a, Seq a)
 prune lim x = Seq.splitAt excess x
   where
-    excess = Seq.length x - fromIntegral lim
+    excess = Seq.length x - lim
 
 -- | Record the latest outcome in the state
 --
@@ -579,13 +578,13 @@ definitelyEnoughBlocks params = \case
 
     tick :: Outcome -> Word64
     tick Nominal = 0
-    tick _           = 1
+    tick _       = 1
 
     go :: Word64 -> [(Word64, Word64)] -> Bool
     go badCount exens
       | badCount > k = False
       | otherwise    = case exens of
-          []                   -> True
+          []                     -> True
           (exit, enter) : exens' -> go (badCount - exit + enter) exens'
 
 {-------------------------------------------------------------------------------
@@ -594,7 +593,7 @@ definitelyEnoughBlocks params = \case
 
 mkLeaderOf :: PBftParams -> SlotNo -> CoreNodeId
 mkLeaderOf params (SlotNo s) =
-    CoreNodeId $ fromIntegral $ s `mod` n
+    CoreNodeId $ s `mod` n
   where
     PBftParams{pbftNumNodes} = params
     NumCoreNodes n           = pbftNumNodes

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util.hs
@@ -241,6 +241,6 @@ emptyLeaderSchedule (NumSlots t) = LeaderSchedule $
 roundRobinLeaderSchedule :: NumCoreNodes -> NumSlots -> LeaderSchedule
 roundRobinLeaderSchedule (NumCoreNodes n) (NumSlots t) = LeaderSchedule $
     Map.fromList $
-    [ (SlotNo i, [CoreNodeId (fromIntegral i `mod` n)])
+    [ (SlotNo i, [CoreNodeId (i `mod` n)])
     | i <- [ 0 .. t - 1 ]
     ]

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/NodeRestarts.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/NodeRestarts.hs
@@ -65,7 +65,7 @@ genNodeRestarts (NodeJoinPlan m) (NumSlots t)
   | t < 1     = pure noRestarts
   | otherwise =
   fmap (NodeRestarts . Map.filter (not . Map.null) . Map.fromList) $ do
-    ss <- sublistOf [0 .. SlotNo (fromIntegral t - 1)]
+    ss <- sublistOf [0 .. SlotNo (t - 1)]
     forM ss $ \s ->
       fmap ((,) s) $
       let alreadyJoined = Map.keysSet $ Map.filter (< s) m
@@ -81,7 +81,7 @@ genNodeRestarts (NodeJoinPlan m) (NumSlots t)
       else fmap (Map.fromList . map (flip (,) NodeRestart)) $
            sublistOf $ Map.keys $ candidates
   where
-    isLeading (CoreNodeId i) s = fromIntegral i /= unSlotNo s `mod` n
+    isLeading (CoreNodeId i) s = i /= unSlotNo s `mod` n
       where
         n = fromIntegral $ Map.size m
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/MockFS.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/MockFS.hs
@@ -628,7 +628,7 @@ hPutSome h toWrite =
     snip :: Int -> Int -> ByteString -> (ByteString, ByteString)
     snip n m bs = (a, c)
       where
-        (a, bc) = BS.splitAt (fromIntegral n) bs
+        (a, bc) = BS.splitAt n bs
         c       = BS.drop m bc
 
 -- | Truncate a file

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/Arbitrary.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE NumericUnderscores   #-}
 {-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Util.Orphans.Arbitrary
     ( genLimitedEpochSize

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/IOLike.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/IOLike.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Util.Orphans.IOLike () where
 
 import           Control.Monad.Class.MonadSTM (lengthTBQueueDefault)

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeFamilies               #-}
 
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 -- | Minimal instantiation of the consensus layer to be able to run the ChainDB
 module Test.Util.TestBlock (
     -- * Blocks

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -236,7 +236,14 @@ library
                      , unix-bytestring
 
   ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists
+
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts
     cpp-options:       -DENABLE_ASSERTIONS
@@ -333,7 +340,13 @@ test-suite test-consensus
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists
                        -fno-ignore-asserts
                        -threaded
                        -rtsopts
@@ -428,5 +441,11 @@ test-suite test-storage
 
   default-language:    Haskell2010
   ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
                        -Wredundant-constraints
+                       -Wmissing-export-lists
                        -fno-ignore-asserts

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -15,7 +15,6 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 module Ouroboros.Consensus.MiniProtocol.ChainSync.Client (
     Consensus
   , chainSyncClient

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 module Ouroboros.Consensus.MiniProtocol.ChainSync.Server
   ( chainSyncHeadersServer
   , chainSyncBlocksServer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints -Werror=missing-fields #-}
+{-# OPTIONS_GHC -Werror=missing-fields #-}
 
 module Ouroboros.Consensus.NodeKernel (
     -- * Node kernel

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeNetwork.hs
@@ -10,8 +10,7 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints -Werror=missing-fields
-                -Wno-unticked-promoted-constructors #-}
+{-# OPTIONS_GHC -Werror=missing-fields -Wno-unticked-promoted-constructors #-}
 
 module Ouroboros.Consensus.NodeNetwork (
     ProtocolHandlers (..)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -140,7 +140,7 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
                    -- Relays are never leaders
                    Nothing
                  CoreId (CoreNodeId i) ->
-                   if n `mod` numCoreNodes == fromIntegral i
+                   if n `mod` numCoreNodes == i
                      then Just ()
                      else Nothing
     where
@@ -161,7 +161,7 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
         Left err -> throwError $ BftInvalidSignature err
     where
       BftParams{..}  = bftParams
-      expectedLeader = CoreId . CoreNodeId $ fromIntegral (n `mod` numCoreNodes)
+      expectedLeader = CoreId $ CoreNodeId (n `mod` numCoreNodes)
       NumCoreNodes numCoreNodes = bftNumNodes
 
   rewindConsensusState _ _ _ = Just ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/MockChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/MockChainSel.hs
@@ -2,7 +2,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
 
-module Ouroboros.Consensus.Protocol.MockChainSel where
+module Ouroboros.Consensus.Protocol.MockChainSel
+  ( selectChain
+  , selectUnvalidatedChain
+  ) where
 
 import           Data.Function (on)
 import           Data.List (sortBy)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
-
 module Ouroboros.Consensus.Storage.ChainDB.Impl (
     -- * Initialization
     ChainDbArgs(..)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE RankNTypes                #-}
 {-# LANGUAGE RecordWildCards           #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 module Ouroboros.Consensus.Storage.ChainDB.Impl.Args
   ( ChainDbArgs (..)
   , ChainDbSpecificArgs (..)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Background tasks:
 --
 -- * Copying blocks from the VolatileDB to the ImmutableDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Operations involving chain selection: the initial chain selection and
 -- adding a block.
 module Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE TupleSections             #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Thin wrapper around the ImmutableDB
 module Ouroboros.Consensus.Storage.ChainDB.Impl.ImmDB (
     ImmDB -- Opaque

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Iterator.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Iterators
 module Ouroboros.Consensus.Storage.ChainDB.Impl.Iterator
   ( stream

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LedgerCursor.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LedgerCursor.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 module Ouroboros.Consensus.Storage.ChainDB.Impl.LedgerCursor
   ( newLedgerCursor
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -14,7 +14,6 @@
 {-# LANGUAGE TupleSections             #-}
 {-# LANGUAGE TypeFamilies              #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Thin wrapper around the LedgerDB
 module Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB (
     LgrDB -- opaque

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Queries
 module Ouroboros.Consensus.Storage.ChainDB.Impl.Query
   ( -- * Queries

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reader.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Readers
 module Ouroboros.Consensus.Storage.ChainDB.Impl.Reader
   ( newReader

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reopen.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reopen.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
-
 -- | Closing and reopening
 module Ouroboros.Consensus.Storage.ChainDB.Impl.Reopen
   ( isOpen

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -13,7 +13,6 @@
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Types used throughout the implementation: handle, state, environment,
 -- types, trace types, etc.
 module Ouroboros.Consensus.Storage.ChainDB.Impl.Types (

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
@@ -13,7 +13,6 @@
 {-# LANGUAGE TypeOperators             #-}
 {-# LANGUAGE UndecidableInstances      #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Thin wrapper around the VolatileDB
 module Ouroboros.Consensus.Storage.ChainDB.Impl.VolDB (
     VolDB -- Opaque

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API.hs
@@ -238,7 +238,7 @@ hPutAllStrict hasFS h = go 0
     go !written bs = do
       n <- hPutSome hasFS h bs
       let bs'      = BS.drop (fromIntegral n) bs
-          written' = written + fromIntegral n
+          written' = written + n
       if BS.null bs'
         then return written'
         else go written' bs'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/IO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/IO.hs
@@ -43,9 +43,9 @@ ioHasFS mount = HasFS {
     , hSeek = \(Handle h fp) mode o -> rethrowFsError fp $
         F.seek h mode o
     , hGetSome = \(Handle h fp) n -> rethrowFsError fp $
-        F.read h (fromIntegral n)
+        F.read h n
     , hGetSomeAt = \(Handle h fp) n o -> rethrowFsError fp $
-        F.pread h (fromIntegral n) (unAbsOffset o)
+        F.pread h n (unAbsOffset o)
     , hTruncate = \(Handle h fp) sz -> rethrowFsError fp $
         F.truncate h sz
     , hGetSize = \(Handle h fp) -> rethrowFsError fp $

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Immutable on-disk database of binary blobs
 --
 -- = Internal format

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index
   ( -- * Index
     Index (..)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
@@ -11,7 +11,6 @@
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Cache
   ( -- * Environment
     CacheEnv

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Primary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Primary.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 -- | Primary Index
 --
 -- Intended for qualified import

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE TupleSections             #-}
 {-# LANGUAGE UndecidableInstances      #-}
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Iterator
   ( streamImpl
   , getSlotInfo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -862,13 +862,14 @@ _demo = db0 : go 1 8 db0
         let blockInfos = [ (Apply, Val (DR ('b', n-1)) (DB ('b', n-1)))
                          , (Apply, Val (DR ('b', n-0)) (DB ('b', n-0)))
                          ]
-            Identity (RollbackSuccessful (ValidBlocks db')) =
-                ledgerDbSwitch demoConf 1 blockInfos db
-        in [db']
+        in case runIdentity $ ledgerDbSwitch demoConf 1 blockInfos db of
+          RollbackSuccessful (ValidBlocks db') -> [db']
+          _                                    -> error "unexpected outcome"
       else
         let blockInfo = (Apply, Val (DR ('a', n)) (DB ('a', n)))
-            Identity (Right db') = ledgerDbPush demoConf blockInfo db
-        in db' : go (n + 1) m db'
+        in case runIdentity $ ledgerDbPush demoConf blockInfo db of
+          Right db' -> db' : go (n + 1) m db'
+          _         -> error "unexpected outcome"
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -134,9 +134,11 @@ pickOne (x:xs) = ([], x, xs)
 
 -- | Mark the last element of the list as 'Right'
 markLast :: [a] -> [Either a a]
-markLast [] = []
-markLast xs = let (y:ys) = reverse xs
-              in reverse $ Right y : map Left ys
+markLast = go
+  where
+    go []     = []
+    go [x]    = [Right x]
+    go (x:xs) = Left x : go xs
 
 lastMaybe :: [a] -> Maybe a
 lastMaybe []     = Nothing

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE UndecidableInstances       #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Util.Orphans () where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/SlotLengths.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/SlotLengths.hs
@@ -1,5 +1,5 @@
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Consensus.BlockchainTime.SlotLengths (tests) where
 
 import           Data.Maybe

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -457,7 +457,7 @@ genValidTx ledgerState@(SimpleLedgerState MockState { mockUtxo = utxo }) = do
         ins     = Set.fromList $ map fst assets
 
     -- At most spent half of someone's fortune
-    amount <- fromIntegral <$> choose (1, fortune `div` 2)
+    amount <- choose (1, fortune `div` 2)
     let outRecipient = (recipient, amount)
         outs
           | amount == fortune

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -420,7 +420,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
     -- | Take the last slot at which a client or server update is planned, or
     -- the slot at which syncing starts, and add one to it
     numSlots :: NumSlots
-    numSlots = NumSlots $ fromIntegral $ unSlotNo $ succ $ maximum
+    numSlots = NumSlots $ unSlotNo $ succ $ maximum
       [ lastSlot clientUpdates
       , lastSlot serverUpdates
       , startSyncingAt

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Protocol/PBFT.hs
@@ -520,8 +520,7 @@ prop_appendOldStatePreservesInvariant TestPBftState{..} =
 -- add a sufficient number signed blocks (and any number of EBBs).
 prop_appendOldStateRestoresPreWindow :: TestPBftState -> Property
 prop_appendOldStateRestoresPreWindow TestPBftState{..} =
-    let missing = fromIntegral
-                $ maxRollbacks      testPBftStateK
+    let missing = maxRollbacks      testPBftStateK
                 + S.getWindowSize   testPBftStateN
                 - S.countSignatures testOldPBftState
         inps = pre' <> post'

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 
-{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans -Wno-incomplete-uni-patterns #-}
 module Test.Ouroboros.Storage.ChainDB.Model.Test (
     tests
   ) where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -17,7 +17,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-{-# OPTIONS_GHC -Wno-orphans -Wredundant-constraints #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Ouroboros.Storage.ChainDB.StateMachine ( tests ) where
 
 import           Prelude hiding (elem)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
@@ -15,7 +15,7 @@
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Ouroboros.Storage.FS.StateMachine (
     tests

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# OPTIONS_GHC -Wredundant-constraints #-}
 
 -- | Model for the 'ImmutableDB' based on a chain.
 --

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Primary.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Primary.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE LambdaCase #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans -Wno-incomplete-uni-patterns #-}
 module Test.Ouroboros.Storage.ImmutableDB.Primary (tests) where
 
 import           Data.Binary (get, put)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -13,6 +13,7 @@ module Test.Ouroboros.Storage.LedgerDB.InMemory (
     tests
   ) where
 
+import           Data.Maybe (fromJust)
 import           Data.Word
 import           Test.QuickCheck
 import           Test.Tasty
@@ -327,7 +328,7 @@ mkRollbackSetup ssChainSetup ssNumRollback ssNumNew ssPrefixLen =
                          take (fromIntegral (csNumBlocks - ssNumRollback)) csChain
                        , ssNewBlocks
                        ]
-    Just ssSwitched  = ledgerDbSwitch' callbacks ssNumRollback ssNewBlocks csPushed
+    ssSwitched  = fromJust $ ledgerDbSwitch' callbacks ssNumRollback ssNewBlocks csPushed
 
 instance Arbitrary ChainSetup where
   arbitrary = do

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Ouroboros.Storage.LedgerDB.InMemory (
     tests

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -795,7 +795,7 @@ generator lgrDbParams (Model mock hs) = Just $ QC.oneof $ concat [
             Switch numRollback <$> genBlocks numNewBlocks (mockCurrent afterRollback)
         , fmap At $ return Snap
         , fmap At $ return Restore
-        , fmap At $ (Drop . fromIntegral) <$> QC.choose (0, mockChainLength mock)
+        , fmap At $ Drop <$> QC.choose (0, mockChainLength mock)
         ]
 
     possibleCorruptions :: [(Corruption, Reference DiskSnapshot Symbolic)]

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -21,7 +21,7 @@
 {-# LANGUAGE TypeOperators             #-}
 {-# LANGUAGE UndecidableInstances      #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Ouroboros.Storage.LedgerDB.OnDisk (
     tests


### PR DESCRIPTION
Fixes #1659.

We now use the following warning flags for all components in consensus:

    -Wall
    -Wcompat
    -Wincomplete-uni-patterns
    -Wincomplete-record-updates
    -Wpartial-fields
    -Widentities
    -Wredundant-constraints
    -Wmissing-export-lists

This PR fixes all warnings produced by these flags.