### PR TITLE
codecs - more verbose failures

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
@@ -66,18 +66,17 @@ codecBlockFetchUnwrapped encodeBlock     decodeBlock
   decode stok = do
     len <- CBOR.decodeListLen
     key <- CBOR.decodeWord
-    -- TODO: match for 'len' as we do in other codecs
-    case (stok, key) of
-      (ClientAgency TokIdle, 0) -> do
+    case (stok, key, len) of
+      (ClientAgency TokIdle, 0, 3) -> do
         from <- decodePoint
         to   <- decodePoint
         return $ SomeMessage $ MsgRequestRange (ChainRange from to)
-      (ClientAgency TokIdle, 1) -> return $ SomeMessage MsgClientDone
-      (ServerAgency TokBusy, 2) -> return $ SomeMessage MsgStartBatch
-      (ServerAgency TokBusy, 3) -> return $ SomeMessage MsgNoBlocks
-      (ServerAgency TokStreaming, 4) -> SomeMessage . MsgBlock
+      (ClientAgency TokIdle, 1, 1) -> return $ SomeMessage MsgClientDone
+      (ServerAgency TokBusy, 2, 1) -> return $ SomeMessage MsgStartBatch
+      (ServerAgency TokBusy, 3, 1) -> return $ SomeMessage MsgNoBlocks
+      (ServerAgency TokStreaming, 4, 2) -> SomeMessage . MsgBlock
                                           <$> decodeBlock
-      (ServerAgency TokStreaming, 5) -> return $ SomeMessage MsgBatchDone
+      (ServerAgency TokStreaming, 5, 1) -> return $ SomeMessage MsgBatchDone
 
       --
       -- failures per protocol state

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
@@ -26,6 +26,7 @@ import           Codec.CBOR.Encoding (encodeListLen, encodeWord)
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.Serialise as Serialise
+import           Text.Printf
 
 -- | The main CBOR 'Codec' for the 'ChainSync' protocol.
 --
@@ -126,7 +127,18 @@ codecChainSyncUnwrapped encodeHeader decodeHeader
         (7, 1, ClientAgency TokIdle) ->
           return (SomeMessage MsgDone)
 
-        _ -> fail ("codecChainSync: unexpected key " ++ show (key, len))
+        --
+        -- failures per protcol state
+        --
+
+        (_, _, ClientAgency TokIdle) ->
+          fail (printf "codecChainSync (%s) unexpected key (%d, %d)" (show stok) key len)
+        (_, _, ServerAgency (TokNext TokCanAwait)) ->
+          fail (printf "codecChainSync (%s) unexpected key (%d, %d)" (show stok) key len)
+        (_, _, ServerAgency (TokNext TokMustReply)) ->
+          fail (printf "codecChainSync (%s) unexpected key (%d, %d)" (show stok) key len)
+        (_, _, ServerAgency TokIntersect) ->
+          fail (printf "codecChainSync (%s) unexpected key (%d, %d)" (show stok) key len)
 
 -- | Codec for chain sync that encodes/decodes headers
 --

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Codec.hs
@@ -19,6 +19,7 @@ import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Read as CBOR
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Type.Equality ((:~:) (..))
+import           Text.Printf
 
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
 import           Ouroboros.Network.Codec
@@ -133,14 +134,18 @@ codecLocalStateQuery encodePoint  decodePoint
         (ClientAgency TokIdle, 1, 7) ->
           return (SomeMessage MsgDone)
 
+        --
+        -- failures per protocol state
+        --
+
         (ClientAgency TokIdle, _, _) ->
-          fail "codecLocalStateQuery.Idle: unexpected key"
+          fail (printf "codecLocalStateQuery (%s) unexpected key (%d, %d)" (show stok) key len)
         (ClientAgency TokAcquired, _, _) ->
-          fail "codecLocalStateQuery.Acquired: unexpected key"
+          fail (printf "codecLocalStateQuery (%s) unexpected key (%d, %d)" (show stok) key len)
         (ServerAgency TokAcquiring, _, _) ->
-          fail "codecLocalStateQuery.Acquiring: unexpected key"
+          fail (printf "codecLocalStateQuery (%s) unexpected key (%d, %d)" (show stok) key len)
         (ServerAgency (TokQuerying _), _, _) ->
-          fail "codecLocalStateQuery.Querying: unexpected key"
+          fail (printf "codecLocalStateQuery (%s) unexpected key (%d, %d)" (show stok) key len)
 
 
 -- | An identity 'Codec' for the 'LocalStateQuery' protocol. It does not do

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Codec.hs
@@ -17,6 +17,7 @@ import           Data.ByteString.Lazy (ByteString)
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Read     as CBOR
+import           Text.Printf
 
 import           Ouroboros.Network.Codec
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
@@ -77,10 +78,7 @@ codecLocalTxSubmission encodeTx decodeTx encodeReject decodeReject =
         (ClientAgency TokIdle, 1, 3) ->
           return (SomeMessage MsgDone)
 
-        (ClientAgency TokIdle, _, _) ->
-          fail "codecLocalTxSubmission.Idle: unexpected key"
-        (ServerAgency TokBusy, _, _) ->
-          fail "codecLocalTxSubmission.Busy: unexpected key"
+        _ -> fail (printf "codecLocalTxSubmission (%s) unexpected key (%d, %d)" (show stok) key len)
 
 codecLocalTxSubmissionId
   :: forall tx reject m.


### PR DESCRIPTION
This PR contains two patches:
* make the `fail` message uniform, and always show the state, token and length (of cbor list)
* let the `chain-sync` codec fail if length of a cbor list is not right.
