### PR TITLE
Drop openssl dep

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -210,8 +210,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-crypto/
-  tag: 3c707936ba0a665375acf5bd240dc4b6eaa6c0bc
-  --sha256: 0g8ln8k8wx4csdv92bz09pr7v9dp4lcyv1334b09c9rgwdwhqg1b
+  tag: 2547ad1e80aeabca2899951601079408becbc92c
+  --sha256: 1p2kg2w02q5w1cvqzhfhqmxviy4xrzada3mmb096j2n6hfr20kri
 
 source-repository-package
   type: git

--- a/ouroboros-consensus/src-win32/Ouroboros/Consensus/Storage/IO.hs
+++ b/ouroboros-consensus/src-win32/Ouroboros/Consensus/Storage/IO.hs
@@ -62,7 +62,7 @@ write fh data' bytes = withOpenHandle "write" fh $ \h ->
 
 seek :: FHandle -> SeekMode -> Int64 -> IO ()
 seek fh seekMode size = void <$> withOpenHandle "seek" fh $ \h ->
-  setFilePointerEx h (fromIntegral size) (fromSeekMode seekMode)
+  setFilePointerEx h size (fromSeekMode seekMode)
 
 fromSeekMode :: SeekMode -> FilePtrDirection
 fromSeekMode AbsoluteSeek = fILE_BEGIN
@@ -97,8 +97,8 @@ close :: FHandle -> IO ()
 close fh = closeHandleOS fh closeHandle
 
 getSize :: FHandle -> IO Word64
-getSize fh = withOpenHandle "getSize" fh $ \h -> do
-  fromIntegral . bhfiSize <$>  getFileInformationByHandle h
+getSize fh = withOpenHandle "getSize" fh $ \h ->
+  bhfiSize <$> getFileInformationByHandle h
 
 -- | For the following error types, our mock FS implementation (and the Posix
 -- implementation) throw the same errors:


### PR DESCRIPTION
With this pr, ouroboros-consensus no longer needs openssl to build. This significantly simplifies building on windows. Related https://github.com/input-output-hk/ouroboros-network/issues/1082

WIP: TODO nix