### PR TITLE
Implement lemmas 1 & 2 from #1765

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -207,13 +207,13 @@ instance LedgerSupportsProtocol ByronBlock where
   -- i.e., that delegate is allowed to issue a block in that very same slot.
   anachronisticProtocolLedgerView cfg (ByronLedgerState ls ss) slot =
       case History.find slot ss of
-        Just sb -> Right (toPBftLedgerView sb) -- Case (A)
+        Just sb -> return $ toPBftLedgerView sb -- Case (A)
         Nothing -- Case (B), (C) or (D)
-          | slot <  At maxLo -> Left TooFarBehind -- lower bound is inclusive
-          | slot >= At maxHi -> Left TooFarAhead  -- upper bound is exclusive
+          | slot <  At maxLo -> throwError TooFarBehind -- lower bound is inclusive
+          | slot >= At maxHi -> throwError TooFarAhead  -- upper bound is exclusive
           | otherwise        -> case slot of
-              Origin -> Left TooFarBehind -- this should be unreachable
-              At s -> Right $ toPBftLedgerView $
+              Origin -> throwError TooFarBehind -- this should be unreachable
+              At s -> return $ toPBftLedgerView $
                 CC.previewDelegationMap (toByronSlotNo s) ls
     where
       SecurityParam k = genesisSecurityParam (unByronLedgerConfig cfg)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -205,7 +205,7 @@ instance LedgerSupportsProtocol ByronBlock where
   -- TODO: verify that the sdSlot of ScheduledDelegation is the slot at which
   -- it becomes active (i.e., that delegation should be applied /in/ that slot)
   -- i.e., that delegate is allowed to issue a block in that very same slot.
-  anachronisticProtocolLedgerView cfg (ByronLedgerState ls ss) slot =
+  anachronisticProtocolLedgerView_ cfg (ByronLedgerState ls ss) slot =
       case History.find slot ss of
         Just sb -> return $ toPBftLedgerView sb -- Case (A)
         Nothing -- Case (B), (C) or (D)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -120,7 +120,7 @@ instance ( SimpleCrypto c
          ) => LedgerSupportsProtocol (SimpleBftBlock c c') where
   protocolLedgerView _ _ =
       ()
-  anachronisticProtocolLedgerView _ _ _ =
+  anachronisticProtocolLedgerView_ _ _ _ =
       return ()
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -121,7 +121,7 @@ instance ( SimpleCrypto c
   protocolLedgerView _ _ =
       ()
   anachronisticProtocolLedgerView _ _ _ =
-      Right ()
+      return ()
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -133,8 +133,8 @@ instance ( SimpleCrypto c
 instance ( SimpleCrypto c
          , Signable MockDSIGN (SignedSimplePBft c PBftMockCrypto)
          ) => LedgerSupportsProtocol (SimplePBftBlock c PBftMockCrypto) where
-  protocolLedgerView              cfg _   =          simpleMockLedgerConfig cfg
-  anachronisticProtocolLedgerView cfg _ _ = return $ simpleMockLedgerConfig cfg
+  protocolLedgerView               cfg _   =          simpleMockLedgerConfig cfg
+  anachronisticProtocolLedgerView_ cfg _ _ = return $ simpleMockLedgerConfig cfg
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -133,8 +133,8 @@ instance ( SimpleCrypto c
 instance ( SimpleCrypto c
          , Signable MockDSIGN (SignedSimplePBft c PBftMockCrypto)
          ) => LedgerSupportsProtocol (SimplePBftBlock c PBftMockCrypto) where
-  protocolLedgerView              cfg _   =         simpleMockLedgerConfig cfg
-  anachronisticProtocolLedgerView cfg _ _ = Right $ simpleMockLedgerConfig cfg
+  protocolLedgerView              cfg _   =          simpleMockLedgerConfig cfg
+  anachronisticProtocolLedgerView cfg _ _ = return $ simpleMockLedgerConfig cfg
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -151,8 +151,8 @@ instance ( SimpleCrypto c
          , PraosCrypto c'
          , Signable (PraosKES c') (SignedSimplePraos c c')
          ) => LedgerSupportsProtocol (SimplePraosBlock c c') where
-  protocolLedgerView              cfg _   =          stakeDist cfg
-  anachronisticProtocolLedgerView cfg _ _ = return $ stakeDist cfg
+  protocolLedgerView               cfg _   =          stakeDist cfg
+  anachronisticProtocolLedgerView_ cfg _ _ = return $ stakeDist cfg
 
 -- | Praos needs a ledger that can give it the "active stake distribution"
 --

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -151,8 +151,8 @@ instance ( SimpleCrypto c
          , PraosCrypto c'
          , Signable (PraosKES c') (SignedSimplePraos c c')
          ) => LedgerSupportsProtocol (SimplePraosBlock c c') where
-  protocolLedgerView              cfg _   =         stakeDist cfg
-  anachronisticProtocolLedgerView cfg _ _ = Right $ stakeDist cfg
+  protocolLedgerView              cfg _   =          stakeDist cfg
+  anachronisticProtocolLedgerView cfg _ _ = return $ stakeDist cfg
 
 -- | Praos needs a ledger that can give it the "active stake distribution"
 --

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -103,7 +103,7 @@ instance SimpleCrypto c
 
 instance SimpleCrypto c => LedgerSupportsProtocol (SimplePraosRuleBlock c) where
   protocolLedgerView              _ _   = ()
-  anachronisticProtocolLedgerView _ _ _ = Right ()
+  anachronisticProtocolLedgerView _ _ _ = return ()
 
 {-------------------------------------------------------------------------------
   We don't need crypto for this protocol

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -102,8 +102,8 @@ instance SimpleCrypto c
   validateView _ _ = ()
 
 instance SimpleCrypto c => LedgerSupportsProtocol (SimplePraosRuleBlock c) where
-  protocolLedgerView              _ _   = ()
-  anachronisticProtocolLedgerView _ _ _ = return ()
+  protocolLedgerView               _ _   = ()
+  anachronisticProtocolLedgerView_ _ _ _ = return ()
 
 {-------------------------------------------------------------------------------
   We don't need crypto for this protocol

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -197,7 +197,6 @@ runTestNetwork ::
      ( RunNode blk
      , TxGen blk
      , TracingConstraints blk
-     , Show (LedgerView (BlockProtocol blk))
      )
   => TestConfig
   -> EpochSize
@@ -277,7 +276,6 @@ prop_general ::
      , Eq blk
      , HasHeader blk
      , RunNode blk
-     , Show (LedgerView (BlockProtocol blk))
      )
   => (blk -> Word64) -- ^ Count transactions
   -> SecurityParam

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -248,7 +248,6 @@ runThreadNetwork :: forall m blk.
                     , TxGen blk
                     , TracingConstraints blk
                     , HasCallStack
-                    , Show (LedgerView (BlockProtocol blk))
                     )
                  => ThreadNetworkArgs m blk -> m (TestOutput blk)
 runThreadNetwork ThreadNetworkArgs

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -327,7 +327,7 @@ instance ValidateEnvelope TestBlock where
 
 instance LedgerSupportsProtocol TestBlock where
   protocolLedgerView _ _ = ()
-  anachronisticProtocolLedgerView _ _ _ = return ()
+  anachronisticProtocolLedgerView_ _ _ _ = return ()
 
 instance LedgerDerivedInfo TestBlock where
   knownSlotLengths = testBlockSlotLengths

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -327,7 +327,7 @@ instance ValidateEnvelope TestBlock where
 
 instance LedgerSupportsProtocol TestBlock where
   protocolLedgerView _ _ = ()
-  anachronisticProtocolLedgerView _ _ _ = Right ()
+  anachronisticProtocolLedgerView _ _ _ = return ()
 
 instance LedgerDerivedInfo TestBlock where
   knownSlotLengths = testBlockSlotLengths

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -83,6 +83,7 @@ library
                        Ouroboros.Consensus.Protocol.Signed
                        Ouroboros.Consensus.Util
                        Ouroboros.Consensus.Util.AnchoredFragment
+                       Ouroboros.Consensus.Util.Assert
                        Ouroboros.Consensus.Util.CallStack
                        Ouroboros.Consensus.Util.CBOR
                        Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -388,8 +388,8 @@ instance Bridge m a => LedgerSupportsProtocol (DualBlock m a) where
         (dualLedgerConfigMain cfg)
         (dualLedgerStateMain  state)
 
-  anachronisticProtocolLedgerView cfg state =
-      anachronisticProtocolLedgerView
+  anachronisticProtocolLedgerView_ cfg state =
+      anachronisticProtocolLedgerView_
         (dualLedgerConfigMain cfg)
         (dualLedgerStateMain  state)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
@@ -3,6 +3,8 @@ module Ouroboros.Consensus.Ledger.SupportsProtocol (
   , AnachronyFailure(..)
   ) where
 
+import           Control.Monad.Except
+
 import           Ouroboros.Network.Block (SlotNo)
 import           Ouroboros.Network.Point (WithOrigin)
 
@@ -57,7 +59,7 @@ class ( BlockSupportsProtocol blk
     :: LedgerConfig blk
     -> LedgerState blk
     -> WithOrigin SlotNo -- ^ Slot for which you would like a ledger view
-    -> Either AnachronyFailure (LedgerView (BlockProtocol blk))
+    -> Except AnachronyFailure (LedgerView (BlockProtocol blk))
 
 -- | See 'anachronisticProtocolLedgerView'.
 data AnachronyFailure

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
@@ -1,17 +1,21 @@
 module Ouroboros.Consensus.Ledger.SupportsProtocol (
     LedgerSupportsProtocol(..)
   , AnachronyFailure(..)
+  , anachronisticProtocolLedgerView
+  , lemma_protocolLedgerView_anachronistic_applyChainTick
   ) where
 
 import           Control.Monad.Except
+import           GHC.Stack (HasCallStack)
 
 import           Ouroboros.Network.Block (SlotNo)
-import           Ouroboros.Network.Point (WithOrigin)
+import           Ouroboros.Network.Point
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.Assert
 
 -- | Link protocol to ledger
 class ( BlockSupportsProtocol blk
@@ -55,7 +59,7 @@ class ( BlockSupportsProtocol blk
   --
   -- Invariant: when calling this function with slot @s@ yields a
   -- 'SlotBounded' @sb@, then @'atSlot' sb@ yields a 'Just'.
-  anachronisticProtocolLedgerView
+  anachronisticProtocolLedgerView_
     :: LedgerConfig blk
     -> LedgerState blk
     -> WithOrigin SlotNo -- ^ Slot for which you would like a ledger view
@@ -66,3 +70,52 @@ data AnachronyFailure
   = TooFarAhead
   | TooFarBehind
   deriving (Eq,Show)
+
+-- | Variant of 'anachronisticProtocolLedgerView_' which checks (when
+-- assertions are enabled) whether
+-- 'lemma_protocolLedgerView_anachronistic_applyChainTick' holds.
+--
+-- Use this function instead of 'anachronisticProtocolLedgerView_'.
+anachronisticProtocolLedgerView
+  :: (LedgerSupportsProtocol blk, HasCallStack)
+  => LedgerConfig blk
+  -> LedgerState blk
+  -> WithOrigin SlotNo -- ^ Slot for which you would like a ledger view
+  -> Except AnachronyFailure (LedgerView (BlockProtocol blk))
+anachronisticProtocolLedgerView cfg st slot =
+    assertWithMsg
+      (lemma_protocolLedgerView_anachronistic_applyChainTick cfg st slot)
+      (anachronisticProtocolLedgerView_ cfg st slot)
+
+-- | Lemma:
+--
+-- > for all (At s) >= ledgerTipSlot st,
+-- >   Right st' = anachronisticProtocolLedgerView_ cfg st (At s) ->
+-- >   st' == protocolLedgerView cfg (tickedLedgerState (applyChainTick cfg s st))
+--
+-- This should be true for each ledger because consensus depends on it.
+lemma_protocolLedgerView_anachronistic_applyChainTick
+  :: LedgerSupportsProtocol blk
+  => LedgerConfig blk
+  -> LedgerState blk
+  -> WithOrigin SlotNo -- ^ Slot for which you would like a ledger view
+  -> Either String ()
+lemma_protocolLedgerView_anachronistic_applyChainTick cfg st slot
+    | slot >= ledgerTipSlot st
+    , At s <- slot
+    , let lhs = anachronisticProtocolLedgerView_ cfg st slot
+          rhs =
+              protocolLedgerView cfg
+            . tickedLedgerState
+            . applyChainTick cfg s
+            $ st
+    , Right lhs' <- runExcept lhs
+    , lhs' /= rhs
+    = Left $ unlines
+      [ "anachronisticProtocolLedgerView /= protocolLedgerView . applyChainTick:"
+      , show lhs'
+      , " /= "
+      , show rhs
+      ]
+    | otherwise
+    = Right ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -575,7 +575,7 @@ chainSyncClient mkPipelineDecision0 tracer cfg btime
         -- and our tip is within k blocks from our tip. This means that the
         -- anachronistic ledger view must be available, unless they are
         -- too far /ahead/ of us. In this case we must simply wait
-        case anachronisticProtocolLedgerView
+        case runExcept $ anachronisticProtocolLedgerView
               (configLedger cfg)
               curLedger
               (pointSlot hdrPoint) of

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -26,6 +26,7 @@ module Ouroboros.Consensus.NodeKernel (
   ) where
 
 import           Control.Monad
+import           Control.Monad.Except
 import           Data.Map.Strict (Map)
 import           Data.Maybe (isJust)
 import           Data.Proxy
@@ -396,7 +397,7 @@ forkBlockProduction maxBlockSizeOverride IS{..} BlockProduction{..} =
 
         -- Check if we are the leader
         proof <-
-          case anachronisticProtocolLedgerView
+          case runExcept $ anachronisticProtocolLedgerView
                  (configLedger cfg)
                  ledger
                  (At currentSlot) of

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -49,7 +49,9 @@ data family ConsensusConfig p :: *
 -- block representation.
 class ( Show (ConsensusState p)
       , Show (ValidationErr  p)
+      , Show (LedgerView     p)
       , Eq   (ValidationErr  p)
+      , Eq   (LedgerView     p)
       , NoUnexpectedThunks (ConsensusConfig p)
       , NoUnexpectedThunks (ConsensusState  p)
       , NoUnexpectedThunks (ValidationErr   p)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Assert.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Assert.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE TypeApplications #-}
+module Ouroboros.Consensus.Util.Assert
+  ( assertWithMsg
+  ) where
+
+import           GHC.Stack (HasCallStack)
+
+import           Ouroboros.Consensus.Util.RedundantConstraints
+
+assertWithMsg :: HasCallStack => Either String () -> a -> a
+#if ENABLE_ASSERTIONS
+assertWithMsg (Left msg) _ = error msg
+#endif
+assertWithMsg _          a = a
+  where
+    _ = keepRedundantConstraint (Proxy @HasCallStack)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -442,7 +442,7 @@ instance LedgerSupportsProtocol TestBlock where
   protocolLedgerView _ _ =
       ()
   anachronisticProtocolLedgerView _ _ _ =
-      Right ()
+      return ()
 
 instance LedgerDerivedInfo TestBlock where
   knownSlotLengths = testBlockSlotLengths

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -441,7 +441,7 @@ instance ValidateEnvelope TestBlock where
 instance LedgerSupportsProtocol TestBlock where
   protocolLedgerView _ _ =
       ()
-  anachronisticProtocolLedgerView _ _ _ =
+  anachronisticProtocolLedgerView_ _ _ _ =
       return ()
 
 instance LedgerDerivedInfo TestBlock where


### PR DESCRIPTION
* Add `assertWithMsg`

* Use `Except` for `anachronisticProtocolLedgerView`

  To be consistent with the other ledger methods, e.g., `applyLedgerBlock`.

* Check Lemma 1 from #1765

* Check Lemma 2 from #1765

* Switch the order of validation in `applyExtLedgerState`
  
  Fixes #1771.