### PR TITLE
Use MD5 instead of ShortHash in Mempool tests

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs
@@ -69,7 +69,7 @@ instance Condense Tx where
 
 type Ix     = Word
 type Amount = Word
-type TxId   = Hash ShortHash Tx
+type TxId   = Hash MD5 Tx
 type TxIn   = (TxId, Ix)
 type TxOut  = (Addr, Amount)
 type Utxo   = Map TxIn TxOut

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -239,6 +239,9 @@ data MempoolAddTxResult blk
     -- ^ The transaction was rejected and could not be added to the mempool
     -- for the specified reason.
 
+deriving instance Eq (ApplyTxErr blk) => Eq (MempoolAddTxResult blk)
+deriving instance Show (ApplyTxErr blk) => Show (MempoolAddTxResult blk)
+
 isTxAddedOrAlreadyInMempool :: MempoolAddTxResult blk -> Bool
 isTxAddedOrAlreadyInMempool MempoolTxAdded            = True
 isTxAddedOrAlreadyInMempool MempoolTxAlreadyInMempool = True


### PR DESCRIPTION
Closes #1779.

I also included some of the additions that we needed in order to debug the original hash collision.