### PR TITLE
ImmutableDB: use TempResourceRegistry in modifyOpenState

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadThrow.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadThrow.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE RankNTypes        #-}
 
 module Control.Monad.Class.MonadThrow
@@ -123,7 +124,7 @@ data ExitCase a
   = ExitCaseSuccess a
   | ExitCaseException SomeException
   | ExitCaseAbort
-  deriving Show
+  deriving (Show, Functor)
 
 -- | Support for safely working in the presence of asynchronous exceptions.
 --

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/Error.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/Error.hs
@@ -441,6 +441,7 @@ mkSimErrorHasFS fsVar errorsVar =
         , hClose     = \h ->
             withErr' errorsVar h (hClose h) "hClose"
             hCloseE (\e es -> es { hCloseE = e })
+        , hIsOpen    = hIsOpen
         , hSeek      = \h m n ->
             withErr' errorsVar h (hSeek h m n) "hSeek"
             hSeekE (\e es -> es { hSeekE = e })

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/MockFS.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/MockFS.hs
@@ -29,6 +29,7 @@ module Test.Util.FS.Sim.MockFS (
     -- * Operations on files
   , hOpen
   , hClose
+  , hIsOpen
   , hSeek
   , hGetSome
   , hGetSomeAt
@@ -495,6 +496,10 @@ hClose h = withHandleRead h $ \_fs -> \case
       return ((), HandleClosed (ClosedHandle (openFilePath hs)))
     HandleClosed hs ->
       return ((), HandleClosed hs)
+
+-- | Mock implementation of 'hIsOpen'
+hIsOpen :: CanSimFS m => Handle' -> m Bool
+hIsOpen h = gets (`handleIsOpen` handleRaw h)
 
 -- | Mock implementation of 'hSeek'
 --

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/Pure.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/Pure.hs
@@ -27,6 +27,7 @@ pureHasFS = HasFS {
       dumpState                = Mock.dumpState
     , hOpen                    = Mock.hOpen
     , hClose                   = Mock.hClose
+    , hIsOpen                  = Mock.hIsOpen
     , hSeek                    = Mock.hSeek
     , hGetSome                 = Mock.hGetSome
     , hGetSomeAt               = Mock.hGetSomeAt

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/STM.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/STM.hs
@@ -42,6 +42,7 @@ simHasFS var = HasFS {
       dumpState                = sim     Mock.dumpState
     , hOpen                    = sim  .: Mock.hOpen
     , hClose                   = sim  .  Mock.hClose
+    , hIsOpen                  = sim  .  Mock.hIsOpen
     , hSeek                    = sim ..: Mock.hSeek
     , hGetSome                 = sim  .: Mock.hGetSome
     , hGetSomeAt               = sim ..: Mock.hGetSomeAt

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/DbMarker.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/DbMarker.hs
@@ -162,7 +162,7 @@ lockDbMarkerFile registry dbPath = do
     mlockFile <- allocateEither
                     registry
                     (const $ justToRight <$> tryLockFile fullPath Exclusive)
-                    unlockFile
+                    (\f -> unlockFile f >> return True)
     case mlockFile of
       Left () -> throwM $ DbLocked fullPath
       Right _ -> return ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ErrorPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ErrorPolicy.hs
@@ -25,7 +25,8 @@ import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
 import           Ouroboros.Consensus.Node.DbMarker (DbMarkerError)
 import           Ouroboros.Consensus.Node.Run (RunNode (nodeExceptionIsFatal))
 import           Ouroboros.Consensus.Util.ResourceRegistry
-                     (RegistryClosedException, ResourceRegistryThreadException)
+                     (RegistryClosedException, ResourceRegistryThreadException,
+                     TempRegistryException)
 
 consensusErrorPolicy :: RunNode blk => Proxy blk -> ErrorPolicies
 consensusErrorPolicy pb = ErrorPolicies {
@@ -86,6 +87,7 @@ consensusErrorPolicy pb = ErrorPolicies {
           -- the connection but leave the rest of the node running.
         , ErrorPolicy $ \(_ :: RegistryClosedException)         -> Just ourBug
         , ErrorPolicy $ \(_ :: ResourceRegistryThreadException) -> Just ourBug
+        , ErrorPolicy $ \(_ :: TempRegistryException)           -> Just ourBug
 
           -- An exception in the block fetch server meant the client asked
           -- for some blocks we used to have but got GCed. This means the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -45,7 +45,7 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.VolDB as VolDB
   Arguments
 -------------------------------------------------------------------------------}
 
-data ChainDbArgs m blk = forall h1 h2 h3. ChainDbArgs {
+data ChainDbArgs m blk = forall h1 h2 h3. (Eq h1, Eq h2, Eq h3) => ChainDbArgs {
 
       -- Decoders
       cdbDecodeHash           :: forall s. Decoder s (HeaderHash blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
@@ -144,7 +144,7 @@ type TraceEvent blk =
 -- | Arguments to initialize the ImmutableDB
 --
 -- See also 'defaultArgs'.
-data ImmDbArgs m blk = forall h. ImmDbArgs {
+data ImmDbArgs m blk = forall h. Eq h => ImmDbArgs {
       immDecodeHash     :: forall s. Decoder s (HeaderHash blk)
     , immDecodeBlock    :: forall s. Decoder s (Lazy.ByteString -> blk)
     , immDecodeHeader   :: forall s. Decoder s (Lazy.ByteString -> Header blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -145,7 +145,7 @@ type LgrDBConf m blk =
   Initialization
 -------------------------------------------------------------------------------}
 
-data LgrDbArgs m blk = forall h. LgrDbArgs {
+data LgrDbArgs m blk = forall h. Eq h => LgrDbArgs {
       lgrTopLevelConfig       :: TopLevelConfig blk
     , lgrHasFS                :: HasFS m h
     , lgrDecodeLedger         :: forall s. Decoder s (LedgerState                   blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
@@ -138,7 +138,7 @@ type TraceEvent blk =
   Initialization
 -------------------------------------------------------------------------------}
 
-data VolDbArgs m blk = forall h. VolDbArgs {
+data VolDbArgs m blk = forall h. Eq h => VolDbArgs {
       volHasFS          :: HasFS m h
     , volCheckIntegrity :: blk -> Bool
     , volBlocksPerFile  :: BlocksPerFile

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE DerivingVia         #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -17,6 +18,7 @@ module Ouroboros.Consensus.Storage.FS.API (
     , hPutAll
     , hPutAllStrict
     , withFile
+    , hClose'
     ) where
 
 import           Control.Monad (foldM)
@@ -50,6 +52,9 @@ data HasFS m h = HasFS {
 
     -- | Close a file
   , hClose                   :: HasCallStack => Handle h -> m ()
+
+    -- | Is the handle open?
+  , hIsOpen                  :: HasCallStack => Handle h -> m Bool
 
     -- | Seek handle
     --
@@ -137,6 +142,16 @@ data HasFS m h = HasFS {
 withFile :: (HasCallStack, MonadThrow m)
          => HasFS m h -> FsPath -> OpenMode -> (Handle h -> m a) -> m a
 withFile HasFS{..} fp openMode = bracket (hOpen fp openMode) hClose
+
+-- | Returns 'True' when the handle was still open.
+hClose' :: (HasCallStack, Monad m) => HasFS m h -> Handle h -> m Bool
+hClose' HasFS { hClose, hIsOpen } h = do
+    isOpen <- hIsOpen h
+    if isOpen then do
+      hClose h
+      return True
+    else
+      return False
 
 -- | Makes sure it reads all requested bytes.
 -- If eof is found before all bytes are read, it throws an exception.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API/Types.hs
@@ -288,7 +288,11 @@ ioToFsError :: HasCallStack
 ioToFsError fep ioErr = FsError
     { fsErrorType   = ioToFsErrorType ioErr
     , fsErrorPath   = fep
-    , fsErrorString = IO.ioeGetErrorString ioErr
+      -- We don't use 'ioeGetErrorString', because that only returns the
+      -- description in case 'isUserErrorType' is true, otherwise it will
+      -- return 'ioToFsErrorType', which we already include in 'fsErrorType'.
+      -- So we use the underlying field directly.
+    , fsErrorString = GHC.ioe_description ioErr
     , fsErrorNo     = Errno <$> GHC.ioe_errno ioErr
     , fsErrorStack  = callStack
     , fsLimitation  = False

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/Handle.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/Handle.hs
@@ -4,6 +4,7 @@
 -- instances and not directly by client code.
 module Ouroboros.Consensus.Storage.FS.Handle (
       HandleOS (..)
+    , isOpenHandleOS
     , closeHandleOS
     , withOpenHandle
     , isHandleClosedException
@@ -11,6 +12,7 @@ module Ouroboros.Consensus.Storage.FS.Handle (
 
 import           Control.Concurrent.MVar
 import           Control.Exception hiding (handle)
+import           Data.Maybe (isJust)
 import           System.IO.Error as IO
 
 -- | File handlers for the IO instance for HasFS.
@@ -29,6 +31,9 @@ instance Eq (HandleOS a) where
 
 instance Show (HandleOS a) where
   show h = "<Handle " ++ filePath h ++ ">"
+
+isOpenHandleOS :: HandleOS osHandle -> IO Bool
+isOpenHandleOS = fmap isJust . readMVar . handle
 
 -- | This is a no-op when the handle is already closed.
 closeHandleOS :: HandleOS osHandle -> (osHandle -> IO ()) -> IO ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/IO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/IO.hs
@@ -40,6 +40,7 @@ ioHasFS mount = HasFS {
         return $ Handle (H.HandleOS path hVar) fp
     , hClose = \(Handle h fp) -> rethrowFsError fp $
         F.close h
+    , hIsOpen = H.isOpenHandleOS . handleRaw
     , hSeek = \(Handle h fp) mode o -> rethrowFsError fp $
         F.seek h mode o
     , hGetSome = \(Handle h fp) n -> rethrowFsError fp $

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
@@ -452,7 +452,7 @@ iteratorNextImpl dbEnv it@IteratorHandle
         -- No more entries in this chunk, so open the next.
         Nothing -> do
           -- Release the resource, i.e., close the handle.
-          release itChunkKey
+          void $ release itChunkKey
           -- If this was the final chunk, close the iterator
           if itChunk >= chunkIndex itEnd then
             iteratorCloseImpl it
@@ -530,7 +530,7 @@ iteratorCloseImpl IteratorHandle { itState } = do
         -- closing all open iterators, i.e., the iterators opened by the
         -- protocol threads. So we're releasing handles allocated in resource
         -- registry A from a thread tracked by resource registry B. See #1390.
-        unsafeRelease itChunkKey
+        void $ unsafeRelease itChunkKey
 
 iteratorStateForChunk
   :: (HasCallStack, IOLike m, Eq hash)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
@@ -1,13 +1,14 @@
-{-# LANGUAGE BangPatterns              #-}
-{-# LANGUAGE DeriveAnyClass            #-}
-{-# LANGUAGE DeriveGeneric             #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE NamedFieldPuns            #-}
-{-# LANGUAGE OverloadedStrings         #-}
-{-# LANGUAGE RankNTypes                #-}
-{-# LANGUAGE RecordWildCards           #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 module Ouroboros.Consensus.Storage.ImmutableDB.Impl.State
   ( -- * State types
     ImmutableDBEnv (..)
@@ -17,6 +18,7 @@ module Ouroboros.Consensus.Storage.ImmutableDB.Impl.State
     -- * State helpers
   , mkOpenState
   , getOpenState
+  , ModifyOpenState
   , modifyOpenState
   , withOpenState
   , closeOpenHandles
@@ -34,7 +36,7 @@ import           Ouroboros.Consensus.BlockchainTime (BlockchainTime)
 import           Ouroboros.Consensus.Util (SomePair (..))
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry,
-                     allocate)
+                     WithTempRegistry, allocateTemp, modifyWithTempRegistry)
 
 import           Ouroboros.Consensus.Storage.FS.API
 import           Ouroboros.Consensus.Storage.FS.API.Types
@@ -55,7 +57,7 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Types
 ------------------------------------------------------------------------------}
 
 -- | The environment used by the immutable database.
-data ImmutableDBEnv m hash = forall h e. ImmutableDBEnv
+data ImmutableDBEnv m hash = forall h e. Eq h => ImmutableDBEnv
     { hasFS            :: !(HasFS m h)
     , varInternalState :: !(StrictMVar m (InternalState m hash h))
     , chunkFileParser  :: !(ChunkFileParser e m (BlockSummary hash) hash)
@@ -105,20 +107,19 @@ data OpenState m hash h = OpenState
 
 -- | Create the internal open state for the given chunk.
 mkOpenState
-  :: forall m hash h. (HasCallStack, IOLike m)
-  => ResourceRegistry m
-  -> HasFS m h
+  :: forall m hash h. (HasCallStack, IOLike m, Eq h)
+  => HasFS m h
   -> Index m hash h
   -> ChunkNo
   -> ImmTipWithInfo hash
   -> AllowExisting
-  -> m (OpenState m hash h)
-mkOpenState registry HasFS{..} index chunk tip existing = do
-    eHnd <- allocateHandle $ hOpen (renderFile "epoch"     chunk) appendMode
-    pHnd <- allocateHandle $ Index.openPrimaryIndex index  chunk  existing
-    sHnd <- allocateHandle $ hOpen (renderFile "secondary" chunk) appendMode
-    chunkOffset     <- hGetSize eHnd
-    secondaryOffset <- hGetSize sHnd
+  -> WithTempRegistry (OpenState m hash h) m (OpenState m hash h)
+mkOpenState hasFS@HasFS{..} index chunk tip existing = do
+    eHnd <- allocateHandle currentChunkHandle     $ hOpen (renderFile "epoch"     chunk) appendMode
+    pHnd <- allocateHandle currentPrimaryHandle   $ Index.openPrimaryIndex index  chunk  existing
+    sHnd <- allocateHandle currentSecondaryHandle $ hOpen (renderFile "secondary" chunk) appendMode
+    chunkOffset     <- lift $ hGetSize eHnd
+    secondaryOffset <- lift $ hGetSize sHnd
     return OpenState
       { currentChunk           = chunk
       , currentChunkOffset     = BlockOffset chunkOffset
@@ -132,8 +133,14 @@ mkOpenState registry HasFS{..} index chunk tip existing = do
   where
     appendMode = AppendMode existing
 
-    allocateHandle :: m (Handle h) -> m (Handle h)
-    allocateHandle open = snd <$> allocate registry (const open) hClose
+    allocateHandle
+      :: (OpenState m hash h -> Handle h)
+      -> m (Handle h)
+      -> WithTempRegistry (OpenState m hash h) m (Handle h)
+    allocateHandle getHandle open =
+      -- To check whether the handle made it in the final state, we check for
+      -- equality.
+      allocateTemp open (hClose' hasFS) ((==) . getHandle)
 
 -- | Get the 'OpenState' of the given database, throw a 'ClosedDBError' in
 -- case it is closed.
@@ -153,6 +160,10 @@ getOpenState ImmutableDBEnv {..} = do
        DbClosed         -> throwUserError  ClosedDBError
        DbOpen openState -> return (SomePair hasFS openState)
 
+-- | Shorthand
+type ModifyOpenState m hash h =
+  StateT (OpenState m hash h) (WithTempRegistry (OpenState m hash h) m)
+
 -- | Modify the internal state of an open database.
 --
 -- In case the database is closed, a 'ClosedDBError' is thrown.
@@ -160,57 +171,59 @@ getOpenState ImmutableDBEnv {..} = do
 -- In case an 'UnexpectedError' is thrown, the database is closed to prevent
 -- further appending to a database in a potentially inconsistent state.
 --
+-- The action is run in the 'ModifyOpenState' monad, which is a 'StateT'
+-- transformer (of the 'OpenState') over the 'WithTempRegistry' monad. This
+-- monad can be used to allocate resources in that will be transferred to the
+-- returned 'OpenState' that is safely stored in the 'ImmutableDBEnv'. This
+-- approach makes sure that no resources are leaked when an exception is
+-- thrown while running the action modifying the state.
+--
 -- __Note__: This /takes/ the 'TMVar', /then/ runs the action (which might be
 -- in 'IO'), and then puts the 'TMVar' back, just like
 -- 'Control.Concurrent.MVar.modifyMVar' does. Consequently, it has the same
 -- gotchas that @modifyMVar@ does; the effects are observable and it is
 -- susceptible to deadlock.
-modifyOpenState :: forall m hash r. (HasCallStack, IOLike m)
-                => ImmutableDBEnv m hash
-                -> (forall h. HasFS m h -> StateT (OpenState m hash h) m r)
-                -> m r
-modifyOpenState ImmutableDBEnv { hasFS = hasFS :: HasFS m h, .. } action = do
-    (mr, ()) <- generalBracket open close (tryImmDB . mutation)
-    case mr of
-      Left  e      -> throwM e
-      Right (r, _) -> return r
+modifyOpenState
+  :: forall m hash a. (HasCallStack, IOLike m)
+  => ImmutableDBEnv m hash
+  -> (forall h. Eq h => HasFS m h -> ModifyOpenState m hash h a)
+  -> m a
+modifyOpenState ImmutableDBEnv { hasFS = hasFS :: HasFS m h, .. } modSt =
+    wrapFsError $ modifyWithTempRegistry getSt putSt (modSt hasFS)
   where
-    HasFS{..}         = hasFS
-
-    -- We use @m (Either e a)@ instead of @EitherT e m a@ for 'generalBracket'
-    -- so that 'close' knows which error is thrown (@Either e (s, r)@ vs. @(s,
-    -- r)@).
-
-    open :: m (OpenState m hash h)
     -- TODO Is uninterruptibleMask_ absolutely necessary here?
-    open = uninterruptibleMask_ $ takeMVar varInternalState >>= \case
+    getSt :: m (OpenState m hash h)
+    getSt = uninterruptibleMask_ $ takeMVar varInternalState >>= \case
       DbOpen ost -> return ost
       DbClosed   -> do
         putMVar varInternalState DbClosed
         throwUserError ClosedDBError
 
-    close :: OpenState m hash h
-          -> ExitCase (Either ImmutableDBError (r, OpenState m hash h))
-          -> m ()
-    close !ost ec = do
+    putSt :: OpenState m hash h -> ExitCase (OpenState m hash h) -> m ()
+    putSt ost ec = do
         -- It is crucial to replace the MVar.
         putMVar varInternalState st'
-        followUp
+        unless (dbIsOpen st') $ cleanUp hasFS ost
       where
-        (st', followUp) = case ec of
-          -- If we were interrupted, restore the original state.
-          ExitCaseAbort                               -> (DbOpen ost, return ())
-          ExitCaseException _ex                       -> (DbOpen ost, return ())
-          -- In case of success, update to the newest state
-          ExitCaseSuccess (Right (_, ost'))           -> (DbOpen ost', return ())
-          -- In case of an unexpected error (not an exception), close the DB
-          -- for safety
-          ExitCaseSuccess (Left (UnexpectedError {})) -> (DbClosed, cleanUp hasFS ost)
-          -- In case a user error, just restore the previous state
-          ExitCaseSuccess (Left (UserError {}))       -> (DbOpen ost, return ())
+        st' = case ec of
+          ExitCaseSuccess ost'  -> DbOpen ost'
 
-    mutation :: OpenState m hash h -> m (r, OpenState m hash h)
-    mutation = runStateT (action hasFS)
+          -- When something goes wrong, close the ImmutableDB for safety.
+          -- Except for user errors, because they stem from incorrect use of
+          -- the ImmutableDB.
+          --
+          -- NOTE: we only modify the ImmutableDB in a background thread of
+          -- the ChainDB, not in per-connection threads that could be killed
+          -- at any point. When an exception is encountered while modifying
+          -- the ImmutableDB in the background thread, or that background
+          -- thread itself is killed with an async exception, we will shut
+          -- down the node anway, so it is safe to close the ImmutableDB here.
+          ExitCaseAbort         -> DbClosed
+          ExitCaseException ex
+            | Just (UserError {}) <- fromException ex
+            -> DbOpen ost
+            | otherwise
+            -> DbClosed
 
 -- | Perform an action that accesses the internal state of an open database.
 --
@@ -252,7 +265,7 @@ withOpenState ImmutableDBEnv { hasFS = hasFS :: HasFS m h, .. } action = do
 
     shutDown :: m ()
     shutDown = swapMVar varInternalState DbClosed >>= \case
-      DbOpen ost -> cleanUp hasFS ost
+      DbOpen ost -> wrapFsError $ cleanUp hasFS ost
       DbClosed   -> return ()
 
     access :: OpenState m hash h -> m r
@@ -263,9 +276,6 @@ withOpenState ImmutableDBEnv { hasFS = hasFS :: HasFS m h, .. } action = do
 -- Idempotent, as closing a handle is idempotent.
 closeOpenHandles :: Monad m => HasFS m h -> OpenState m hash h -> m ()
 closeOpenHandles HasFS { hClose } OpenState {..}  = do
-    -- If one of the 'hClose' calls fails, the error will bubble up to the
-    -- bracketed call to 'withRegistry', which will close the
-    -- 'ResourceRegistry' and thus all the remaining handles in it.
     hClose currentChunkHandle
     hClose currentPrimaryHandle
     hClose currentSecondaryHandle

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -3,11 +3,14 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE ExistentialQuantification  #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 module Ouroboros.Consensus.Util.ResourceRegistry (
     ResourceRegistry -- opaque
@@ -34,6 +37,12 @@ module Ouroboros.Consensus.Util.ResourceRegistry (
   , waitAnyThread
   , linkToRegistry
   , forkLinkedThread
+    -- * Temporary registry
+  , WithTempRegistry -- opaque
+  , runWithTempRegistry
+  , TempRegistryException(..)
+  , allocateTemp
+  , modifyWithTempRegistry
     -- * Combinators primarily for testing
   , unsafeNewRegistry
   , closeRegistry
@@ -43,7 +52,8 @@ module Ouroboros.Consensus.Util.ResourceRegistry (
 import           Control.Applicative ((<|>))
 import           Control.Exception (Exception, asyncExceptionFromException)
 import           Control.Monad
-import           Control.Monad.State
+import           Control.Monad.Reader
+import           Control.Monad.State.Strict
 import           Data.Bifunctor
 import           Data.Either (partitionEithers)
 import           Data.Map.Strict (Map)
@@ -58,7 +68,7 @@ import           GHC.Generics (Generic)
 import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..),
                      UseIsNormalFormNamed (..), allNoUnexpectedThunks)
 
-import           Ouroboros.Consensus.Util (mustBeRight)
+import           Ouroboros.Consensus.Util (mustBeRight, whenJust)
 import           Ouroboros.Consensus.Util.CallStack
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -334,6 +344,10 @@ data RegistryStatus =
 data ResourceKey m = ResourceKey !(ResourceRegistry m) !ResourceId
   deriving (Generic, NoUnexpectedThunks)
 
+-- | Return the 'ResourceId' of a 'ResourceKey'.
+resourceKeyId :: ResourceKey m -> ResourceId
+resourceKeyId (ResourceKey _rr rid) = rid
+
 -- | Resource ID
 --
 -- Resources allocated later have a "larger" key (in terms of the 'Ord'
@@ -573,6 +587,185 @@ releaseResources rr keys releaser = do
 -- See documentation of 'ResourceRegistry' for a detailed discussion.
 withRegistry :: (IOLike m, HasCallStack) => (ResourceRegistry m -> m a) -> m a
 withRegistry = bracket unsafeNewRegistry closeRegistry
+
+{-------------------------------------------------------------------------------
+  Temporary registry
+-------------------------------------------------------------------------------}
+
+-- | Run an action with a temporary resource registry.
+--
+-- When allocating resources that are meant to end up in some final state,
+-- e.g., stored in a 'TVar', after which they are guaranteed to be released
+-- correctly, it is possible that an exception is thrown after allocating such
+-- a resource, but before it was stored in the final state. In that case, the
+-- resource would be leaked. 'runWithTempRegistry' solves that problem.
+--
+-- When no exception is thrown before the end of 'runWithTempRegistry', the
+-- user must have transferred all the resources it allocated to their final
+-- state. This means that these resources don't have to be released by the
+-- temporary registry anymore, the final state is now in charge of releasing
+-- them.
+--
+-- In case an exception is thrown before the end of 'runWithTempRegistry',
+-- /all/ resources allocated in the temporary registry will be released.
+--
+-- Resources must be allocated using 'allocateTemp'.
+--
+-- To make sure that the user doesn't forget to transfer a resource to the
+-- final state @st@, the user must pass a function to 'allocateTemp' that
+-- checks whether a given @st@ contains the resource, i.e., whether the
+-- resource was successfully transferred to its final destination.
+--
+-- When no exception is thrown before the end of 'runWithTempRegistry', we
+-- check whether all allocated resources have been transferred to the final
+-- state @st@. If there's a resource that hasn't been transferred to the final
+-- state /and/ that hasn't be released or closed before (see the release
+-- function passed to 'allocateTemp'), a 'TempRegistryRemainingResource'
+-- exception will be thrown.
+--
+-- For that reason, 'WithTempRegistry' is parameterised over the final state
+-- type @st@ and the given 'WithTempRegistry' action must return the final
+-- state.
+--
+-- NOTE: we explicitly don't let 'runWithTempRegistry' return the final state,
+-- because the state /must/ have been stored somewhere safely, transferring
+-- the resources, before the temporary registry is closed.
+runWithTempRegistry
+  :: (IOLike m, HasCallStack)
+  => WithTempRegistry st m (a, st)
+  -> m a
+runWithTempRegistry m = withRegistry $ \rr -> do
+    varTransferredTo <- newTVarM mempty
+    let tempRegistry = TempRegistry {
+            tempResourceRegistry = rr
+          , tempTransferredTo    = varTransferredTo
+          }
+    (a, st) <- runReaderT (unWithTempRegistry m) tempRegistry
+    -- We won't reach this point if an exception is thrown, so we won't check
+    -- for remaining resources in that case.
+    --
+    -- No need to mask here, whether we throw the async exception or
+    -- 'TempRegistryRemainingResource' doesn't matter.
+    transferredTo <- atomically $ readTVar varTransferredTo
+    untrackTransferredTo rr transferredTo st
+
+    context <- captureContext
+    remainingResources <- releaseAllHelper rr context release
+
+    whenJust (listToMaybe remainingResources) $ \remainingResource ->
+      throwM $ TempRegistryRemainingResource {
+          tempRegistryContext  = registryContext rr
+        , tempRegistryResource = remainingResource
+        }
+    return a
+
+-- | When 'runWithTempRegistry' exits successfully while there are still
+-- resources remaining in the temporary registry that haven't been transferred
+-- to the final state.
+data TempRegistryException =
+    forall m. IOLike m => TempRegistryRemainingResource {
+        -- | The context in which the temporary registry was created.
+        tempRegistryContext  :: !(Context m)
+
+        -- | The context in which the resource was allocated that was not
+        -- transferred to the final state.
+      , tempRegistryResource :: !(Context m)
+      }
+
+deriving instance Show TempRegistryException
+instance Exception TempRegistryException
+
+-- | Given a final state, return the 'ResourceId's of the resources that have
+-- been /transferred to/ that state.
+newtype TransferredTo st = TransferredTo {
+      runTransferredTo :: st -> Set ResourceId
+    }
+  deriving newtype (Semigroup, Monoid)
+  deriving NoUnexpectedThunks via OnlyCheckIsWHNF "TransferredTo" (TransferredTo st)
+
+-- | The environment used to run a 'WithTempRegistry' action.
+data TempRegistry st m = TempRegistry {
+      tempResourceRegistry :: !(ResourceRegistry m)
+    , tempTransferredTo    :: !(StrictTVar m (TransferredTo st))
+      -- ^ Used as a @Writer@.
+    }
+
+-- | An action with a temporary registry in scope, see 'runWithTempRegistry'
+-- for more details.
+--
+-- The most important function to run in this monad is 'allocateTemp'.
+newtype WithTempRegistry st m a = WithTempRegistry {
+      unWithTempRegistry :: ReaderT (TempRegistry st m) m a
+    }
+  deriving newtype (Functor, Applicative, Monad, MonadThrow, MonadCatch, MonadMask, MonadSTM)
+
+instance MonadTrans (WithTempRegistry st) where
+  lift = WithTempRegistry . lift
+
+instance MonadState s m => MonadState s (WithTempRegistry st m) where
+  state = WithTempRegistry . state
+
+-- | Untrack all the resources from the registry that have been transferred to
+-- the given state.
+--
+-- Untracking a resource means removing it from the registry without releasing
+-- it.
+--
+-- NOTE: does not check that it's called by the same thread that allocated the
+-- resources, as it's an internal function only used in 'runWithTempRegistry'.
+untrackTransferredTo
+  :: IOLike m
+  => ResourceRegistry m
+  -> TransferredTo st
+  -> st
+  -> m ()
+untrackTransferredTo rr transferredTo st =
+    updateState rr $ mapM_ removeResource rids
+  where
+    rids = runTransferredTo transferredTo st
+
+-- | Allocate a resource in a temporary registry until it has been transferred
+-- to the final state @st@. See 'runWithTempRegistry' for more details.
+allocateTemp
+  :: (IOLike m, HasCallStack)
+  => m a
+     -- ^ Allocate the resource
+  -> (a -> m Bool)
+     -- ^ Release the resource, return 'True' when the resource was actually
+     -- released, return 'False' when the resource was already released.
+     --
+     -- Note that it is safe to always return 'True' when unsure.
+  -> (st -> a -> Bool)
+     -- ^ Check whether the resource is in the given state
+  -> WithTempRegistry st m a
+allocateTemp alloc free isTransferred = WithTempRegistry $ do
+    TempRegistry rr varTransferredTo <- ask
+    (key, a) <- lift $ fmap mustBeRight $
+      allocateEither rr (fmap Right . const alloc) free
+    atomically $ modifyTVar varTransferredTo $ mappend $
+      TransferredTo $ \st ->
+        if isTransferred st a
+        then Set.singleton (resourceKeyId key)
+        else Set.empty
+    return a
+
+-- | Higher level API on top of 'runWithTempRegistry': modify the given @st@,
+-- allocating resources in the process that will be transferred to the
+-- returned @st@.
+modifyWithTempRegistry
+  :: forall m st a. IOLike m
+  => m st                                 -- ^ Get the state
+  -> (st -> ExitCase st -> m ())          -- ^ Store the new state
+  -> StateT st (WithTempRegistry st m) a  -- ^ Modify the state
+  -> m a
+modifyWithTempRegistry getSt putSt modSt = runWithTempRegistry $
+    fst <$> generalBracket (lift getSt) transfer mutate
+  where
+    transfer :: st -> ExitCase (a, st) -> WithTempRegistry st m ()
+    transfer initSt ec = lift $ putSt initSt (snd <$> ec)
+
+    mutate :: st -> WithTempRegistry st m (a, st)
+    mutate = runStateT modSt
 
 {-------------------------------------------------------------------------------
   Simple queries on the registry

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -46,6 +46,7 @@ import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB
                      (LedgerDbParams (..), LgrDB, LgrDBConf, LgrDbArgs (..),
                      mkLgrDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB as LgrDB
+import           Ouroboros.Consensus.Storage.FS.API (HasFS)
 import           Ouroboros.Consensus.Storage.LedgerDB.Conf (LedgerDbConf (..))
 import qualified Ouroboros.Consensus.Storage.LedgerDB.InMemory as LgrDB
                      (ledgerDbFromGenesis)
@@ -219,7 +220,7 @@ initLgrDB k chain = do
 
     args = LgrDbArgs
       { lgrTopLevelConfig       = cfg
-      , lgrHasFS                = error "lgrHasFS"
+      , lgrHasFS                = error "lgrHasFS" :: HasFS m ()
       , lgrDecodeLedger         = error "lgrDecodeLedger"
       , lgrDecodeConsensusState = error "lgrDecodeConsensusState"
       , lgrDecodeHash           = error "lgrDecodeHash"

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -48,7 +48,7 @@ fixedChunkInfo = simpleChunkInfo 10
 type Hash = TestHeaderHash
 
 -- Shorthand
-openTestDB :: (HasCallStack, IOLike m)
+openTestDB :: (HasCallStack, IOLike m, Eq h)
            => ResourceRegistry m
            -> HasFS m h
            -> m (ImmutableDB Hash m)
@@ -69,7 +69,7 @@ openTestDB registry hasFS = fst <$> openDBInternal
     getBinaryInfo = void . testBlockToBinaryInfo
 
 -- Shorthand
-withTestDB :: (HasCallStack, IOLike m)
+withTestDB :: (HasCallStack, IOLike m, Eq h)
            => HasFS m h
            -> (ImmutableDB Hash m -> m a)
            -> m a

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/Util.hs
@@ -125,7 +125,7 @@ apiEquivalence :: (HasCallStack, Eq a, Show a)
                -> (e -> String)
                -> (e -> e -> Bool)
                -> (Either e a -> Assertion)
-               -> (forall h. HasFS IO h -> IO a)
+               -> (forall h. Eq h => HasFS IO h -> IO a)
                -> Assertion
 apiEquivalence tryE prettyError sameErr resAssert m = do
     sysTmpDir <- getTemporaryDirectory
@@ -162,13 +162,13 @@ apiEquivalence tryE prettyError sameErr resAssert m = do
 
 apiEquivalenceFs :: (HasCallStack, Eq a, Show a)
                  => (Either FsError a -> Assertion)
-                 -> (forall h. HasFS IO h -> IO a)
+                 -> (forall h. Eq h => HasFS IO h -> IO a)
                  -> Assertion
 apiEquivalenceFs = apiEquivalence tryFS prettyFsError sameError
 
 apiEquivalenceImmDB :: (HasCallStack, Eq a, Show a)
                     => (Either ImmutableDBError a -> Assertion)
-                    -> (forall h. HasFS IO h -> IO a)
+                    -> (forall h. Eq h => HasFS IO h -> IO a)
                     -> Assertion
 apiEquivalenceImmDB =
     apiEquivalence tryImmDB prettyImmutableDBError sameImmutableDBError


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/cardano-node/issues/651

Consider the following scenario:

* We open the ChainDB
* Which opens the ImmutableDB
* The background thread in the ChainDB that copies blocks from the VolatileDB
  to the ImmutableDB is started
* ...
* We have copied enough blocks such that we have to start a new epoch in the
  ImmutableDB, calling:
  ```haskell
  mkOpenState registry HasFS{..} index epoch tip existing = do
      eHnd <- allocateHandle $ hOpen (renderFile "epoch" epoch)     appendMode
      pHnd <- allocateHandle $ Index.openPrimaryIndex index epoch existing
      sHnd <- allocateHandle $ hOpen (renderFile "secondary" epoch) appendMode
      ...
  ```
* ...
* Now we CTRL-C the node
* The `ResourceRegistry` starts to release resources in LIFO order: It
  releases the three handles of the current epoch. Note that it does this
  before it releases the background thread that copies blocks to the
  ImmutableDB. So there's a short time frame in which the handles are closed
  and the background thread copying blocks hasn't been killed yet. In this
  time frame, we get a `FsIllegalOperation` because we're trying to write
  using a closed handle.

The solution is to not use the global registry for the per-epoch handles,
because they will be released before a thread using them is terminated. The
main reason these handles are stored in a `ResourceRegistry` is to avoid
leaking them before they have made it into the new ImmutableDB state. After
that point, they won't leak, as closing the ImmutableDB (a release action
registered in the global registry) will close them.

Instead, we use `modifyWithTempRegistry` to release them in case we encounter
an exception before we store them in the state.