### PR TITLE
Check that Byron can update the software version

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -86,7 +86,7 @@ test-suite test
                        Test.ThreadNet.DualPBFT
                        Test.ThreadNet.RealPBFT
                        Test.ThreadNet.RealPBFT.ProtocolInfo
-                       Test.ThreadNet.RealPBFT.ProtocolVersionUpdate
+                       Test.ThreadNet.RealPBFT.TrackUpdates
                        Test.ThreadNet.TxGen.Byron
 
                        Ouroboros.Consensus.ByronDual.Ledger

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
@@ -82,7 +82,7 @@ import           Test.Util.Shrink (andId, dropId)
 import qualified Test.Util.Stream as Stream
 
 import           Test.ThreadNet.RealPBFT.ProtocolInfo
-import           Test.ThreadNet.RealPBFT.ProtocolVersionUpdate
+import           Test.ThreadNet.RealPBFT.TrackUpdates
 
 -- | Generate k values as small as this module is known to handle.
 --
@@ -195,8 +195,8 @@ tests = testGroup "RealPBFT" $
           -- The failure was: c0 leaks one ImmDB file handle (for path
           -- @00000.epoch@, read only, offset at 0).
           --
-          -- The test case seems somewhat fragile, since the 'slotLengths'
-          -- value seems to matter!
+          -- The test case seems somewhat fragile, since the 'slotLength' value
+          -- seems to matter!
           once $
           let ncn5 = NumCoreNodes 5 in
           prop_simple_real_pbft_convergence NoEBBs (SecurityParam 2) TestConfig
@@ -388,7 +388,7 @@ tests = testGroup "RealPBFT" $
             , nodeTopology = -- 3 <-> {0,1,2} <-> 4
                 NodeTopology (Map.fromList [(CoreNodeId 0,Set.fromList []),(CoreNodeId 1,Set.fromList [CoreNodeId 0]),(CoreNodeId 2,Set.fromList [CoreNodeId 0, CoreNodeId 1]),(CoreNodeId 3,Set.fromList [CoreNodeId 0,CoreNodeId 1,CoreNodeId 2]),(CoreNodeId 4,Set.fromList [CoreNodeId 0,CoreNodeId 1,CoreNodeId 2])])
             , slotLength   = defaultSlotLength
-            , initSeed = Seed {getSeed = (13428626417421372024,5113871799759534838,13943132470772613446,18226529569527889118,4309403968134095151)}
+            , initSeed     = Seed {getSeed = (13428626417421372024,5113871799759534838,13943132470772613446,18226529569527889118,4309403968134095151)}
             }
     , testProperty "mkDelegationEnvironment uses currentSlot not latestSlot" $
       -- After rekeying, node 2 continues to emit its dlg cert tx. This an ugly
@@ -425,6 +425,98 @@ tests = testGroup "RealPBFT" $
             , nodeTopology = meshNodeTopology ncn
             , slotLength   = defaultSlotLength
             , initSeed     = Seed (11954171112552902178,1213614443200450055,13600682863893184545,15433529895532611662,2464843772450023204)
+            }
+    , testProperty "mkUpdateLabels anticipates instant confirmation" $
+          -- caught a bug in 'mkUpdateLabels' where it didn't anticipate that
+          -- node c0 can confirm the proposal as soon as it joins when quorum
+          -- == 1
+          let ncn = NumCoreNodes 3 in
+          prop_simple_real_pbft_convergence NoEBBs (SecurityParam 9) TestConfig
+            { numCoreNodes = ncn
+            , numSlots     = NumSlots 1
+            , nodeJoinPlan = trivialNodeJoinPlan ncn
+            , nodeRestarts = noRestarts
+            , nodeTopology = meshNodeTopology ncn
+            , slotLength   = defaultSlotLength
+            , initSeed     = Seed {getSeed = (560784040296064078,562654861307142039,14390345921802859256,6074698800134646104,12960749422959162150)}
+            }
+    , testProperty "have nodes add transactions as promptly as possible, as expected by proposal tracking" $
+          -- this repro requires that changes to the ledger point triggers the
+          -- nearly oracular wallet to attempt to add its proposal vote again
+          --
+          -- Without that, node c1's own vote is not included in the block it
+          -- forges in the last slot, because it attempts to add the vote
+          -- before the proposal arrives from c0. With the trigger, the arrival
+          -- of c0's block triggers it. In particular, the ledger *slot*
+          -- doesn't change in this repro, since the new block and its
+          -- predecessor both inhabit slot 0. EBBeeeeeees!
+          let ncn = NumCoreNodes 4 in
+          prop_simple_real_pbft_convergence NoEBBs (SecurityParam 8) TestConfig
+            { numCoreNodes = ncn
+            , numSlots     = NumSlots 2
+            , nodeJoinPlan = trivialNodeJoinPlan ncn
+            , nodeRestarts = noRestarts
+            , nodeTopology = meshNodeTopology ncn
+            , slotLength   = defaultSlotLength
+            , initSeed     = Seed {getSeed = (17661772013144211573,3458753765485439359,3510665480596920798,18073896085829422849,10200170902568172302)}
+            }
+    , testProperty "track proposals even when c0 is not the first to lead" $
+          -- requires prompt and accurate vote tracking when c0 is not the
+          -- first node to lead
+          --
+          -- The necessary promptness trigger in this case is the arrival of
+          -- the proposal transaction.
+          let ncn = NumCoreNodes 4 in
+          prop_simple_real_pbft_convergence NoEBBs (SecurityParam 5) TestConfig
+            { numCoreNodes = ncn
+            , numSlots     = NumSlots 5
+            , nodeJoinPlan = NodeJoinPlan $ Map.fromList
+              [ (CoreNodeId 0, SlotNo 2)
+              , (CoreNodeId 1, SlotNo 3)
+              , (CoreNodeId 2, SlotNo 4)
+              , (CoreNodeId 3, SlotNo 4)
+              ]
+            , nodeRestarts = noRestarts
+            , nodeTopology = meshNodeTopology ncn
+            , slotLength   = defaultSlotLength
+            , initSeed     = Seed {getSeed = (7536539674426109099,5947274896735415773,14396421290275890646,8359457880945605675,13921484090802881569)}
+            }
+    , testProperty "cardano-ledger checks for proposal confirmation before it checks for expiry" $
+          -- must check for quorum before checking for expiration
+          let ncn = NumCoreNodes 5 in
+          prop_simple_real_pbft_convergence NoEBBs SecurityParam {maxRollbacks = 10} TestConfig
+            { numCoreNodes = ncn
+            , numSlots     = NumSlots 12
+            , nodeJoinPlan = NodeJoinPlan $ Map.fromList
+              [ (CoreNodeId 0, SlotNo 0)
+              , (CoreNodeId 1, SlotNo 0)
+              , (CoreNodeId 2, SlotNo 10)
+              , (CoreNodeId 3, SlotNo 10)
+              , (CoreNodeId 4, SlotNo 10)
+              ]
+            , nodeRestarts = noRestarts
+            , nodeTopology = meshNodeTopology ncn
+            , slotLength   = defaultSlotLength
+            , initSeed     = Seed {getSeed = (2578884099630273185,16934506387441904343,18333130054045336554,17133864958166263786,3231825379390681058)}
+            }
+    , testProperty "repropose an expired proposal" $
+          -- the proposal expires in slot 10, but then c0 reintroduces it in
+          -- slot 11 and it is eventually confirmed
+          let ncn = NumCoreNodes 5 in
+          prop_simple_real_pbft_convergence NoEBBs SecurityParam {maxRollbacks = 10} TestConfig
+            { numCoreNodes = ncn
+            , numSlots     = NumSlots 17
+            , nodeJoinPlan = NodeJoinPlan $ Map.fromList
+              [(CoreNodeId 0, SlotNo 0)
+              ,(CoreNodeId 1, SlotNo 10)
+              ,(CoreNodeId 2, SlotNo 11)
+              ,(CoreNodeId 3, SlotNo 11)
+              ,(CoreNodeId 4, SlotNo 16)
+              ]
+            , nodeRestarts = noRestarts
+            , nodeTopology = meshNodeTopology ncn
+            , slotLength   = defaultSlotLength
+            , initSeed     = Seed {getSeed = (306806859316465898,5351335255935493133,6240542044036351784,5824248410373935607,16492982022780410836)}
             }
     , testProperty "simple convergence" $
           \produceEBBs ->
@@ -552,6 +644,7 @@ prop_simple_real_pbft_convergence produceEBBs k
     tabulate "produce EBBs" [show produceEBBs] $
     tabulate "Ref.PBFT result" [Ref.resultConstrName refResult] $
     tabulate "proposed protocol version was adopted" [show aPvuRequired] $
+    tabulate "proposed software version was adopted" [show aSvuRequired] $
     counterexample ("params: " <> show params) $
     counterexample ("Ref.PBFT result: " <> show refResult) $
     counterexample
@@ -582,6 +675,7 @@ prop_simple_real_pbft_convergence produceEBBs k
       }
       testOutput .&&.
     prop_pvu .&&.
+    prop_svu .&&.
     not (all (Chain.null . snd) finalChains) .&&.
     conjoin (map (hasAllEBBs k numSlots produceEBBs) finalChains)
   where
@@ -640,9 +734,16 @@ prop_simple_real_pbft_convergence produceEBBs k
     finalLedgers = Map.toList $ nodeOutputFinalLedger <$> testOutputNodes testOutput
 
     pvuLabels :: [(NodeId, ProtocolVersionUpdateLabel)]
-    pvuLabels =
+    pvuLabels = map (fmap fst) updLabels
+
+    svuLabels :: [(NodeId, SoftwareVersionUpdateLabel)]
+    svuLabels = map (fmap snd) updLabels
+
+    updLabels
+      :: [(NodeId, (ProtocolVersionUpdateLabel, SoftwareVersionUpdateLabel))]
+    updLabels =
         [ (,) cid $
-          mkProtocolVersionUpdateLabel
+          mkUpdateLabels
             params
             numSlots
             genesisConfig
@@ -652,13 +753,22 @@ prop_simple_real_pbft_convergence produceEBBs k
         | (cid, ldgr) <- finalLedgers
         ]
 
-    -- whether the proposed protocol version was required have been adopted in
-    -- one of the chains
+    -- whether the proposed protocol version was required to have been adopted
+    -- in one of the chains
     aPvuRequired :: Bool
     aPvuRequired =
         or
         [ Just True == pvuRequired
         | (_, ProtocolVersionUpdateLabel{pvuRequired}) <- pvuLabels
+        ]
+
+    -- whether the proposed software version was required to have been adopted in
+    -- one of the chains
+    aSvuRequired :: Bool
+    aSvuRequired =
+        or
+        [ Just True == svuRequired
+        | (_, SoftwareVersionUpdateLabel{svuRequired}) <- svuLabels
         ]
 
     -- check whether the proposed protocol version should have been and if so
@@ -677,6 +787,24 @@ prop_simple_real_pbft_convergence produceEBBs k
             Just b  -> b == pvuObserved
             Nothing -> True
         | (cid, pvuLabel) <- pvuLabels
+        ]
+
+    -- check whether the proposed software version should have been and if so
+    -- was adopted
+    prop_svu :: Property
+    prop_svu =
+        counterexample (show svuLabels) $
+        conjoin
+        [ counterexample (show (cid, svuLabel)) $
+          let SoftwareVersionUpdateLabel
+                { svuObserved
+                , svuRequired
+                } = svuLabel
+          in
+          property $ case svuRequired of
+            Just b  -> b == svuObserved
+            Nothing -> True
+        | (cid, svuLabel) <- svuLabels
         ]
 
     params :: PBftParams

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT/ProtocolInfo.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT/ProtocolInfo.hs
@@ -65,7 +65,7 @@ mkProtocolRealPBFT params (CoreNodeId i)
 
 -- | The protocol version proposed as part of the hard-fork smoke test
 --
--- The initial Byron ledger state beings with protocol version @0.0.0@. In the
+-- The initial Byron ledger state begins with protocol version @0.0.0@. In the
 -- smoke test, if the proposal and votes are enabled, then we will be proposing
 -- an update to @1.0.0@.
 --
@@ -83,7 +83,7 @@ theProposedProtocolVersion = Update.ProtocolVersion 1 0 0
 -- configuration. Its use in the static configuration is legacy and does not
 -- seem to affect anything; see Issue #1732.
 --
--- The initial Byron ledger state beings with no recorded software versions.
+-- The initial Byron ledger state begins with no recorded software versions.
 -- For the addition of a new software version, the Byron ledger rules require
 -- that it starts at 0 or 1.
 --

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT/ProtocolInfo.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT/ProtocolInfo.hs
@@ -89,5 +89,6 @@ theProposedProtocolVersion = Update.ProtocolVersion 1 0 0
 --
 theProposedSoftwareVersion :: Update.SoftwareVersion
 theProposedSoftwareVersion = Update.SoftwareVersion
-  (Update.ApplicationName "Cardano Test")
+  -- appnames must be ASCII and <= 12 characters
+  (Update.ApplicationName "Dummy")
   0


### PR DESCRIPTION
Fixes #1733.

I needed to revise the expectations to handle voting more appropriately; there were some slight inaccuracies which I think had been mostly masked by the fact that adopting protocol version requires endorsements and further waiting -- so when _exactly_ the proposal was confirmed hadn't mattered in a test case yet. But for software versions, confirmation is adoption, so accurately predicting when that happen became directly necessary.

There is only one proposal, but it proposes both a protocol version and a software version update. The PV update implies the SV update, but not vice versa. For example, the test output includes the following.

```
    	      proposed protocol version was adopted (20 in total):
     	      70% False
    	      30% True
    	      
    	      proposed software version was adopted (20 in total):
    	      95% True
    	       5% False
```