### PR TITLE
ImmutableDB: don't accidentally kill the cache expiration thread

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
@@ -792,7 +792,7 @@ startNewChunk registry hasFS index chunkInfo = do
 
     lift $
       Index.appendOffsets index currentPrimaryHandle backfillOffsets
-      `finally` cleanUp hasFS st
+      `finally` closeOpenHandles hasFS st
 
     st' <- lift $ mkOpenState registry hasFS index (nextChunkNo currentChunk)
       currentTip MustBeNew


### PR DESCRIPTION
When starting a new chunk, we were using `cleanUp` to close the file handles
of the current chunk, but this function also shuts down the cache expiration
thread. Since we were not restarting that thread, this meant we were no more
expiring cached epochs, leaking memory in the process!