### PR TITLE
Update to tasty-hedgehog-1.0.0.2 in stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -84,7 +84,7 @@ extra-deps:
   - hedgehog-quickcheck-0.1.1
   - markov-chain-usage-model-0.0.0  # Needed for `quickcheck-state-machine`
   - splitmix-0.0.2
-  - tasty-hedgehog-1.0.0.1
+  - tasty-hedgehog-1.0.0.2
   - Unique-0.4.7.6
   - statistics-linreg-0.3
   - network-3.1.0.1


### PR DESCRIPTION
It seems this is necessary because of https://github.com/input-output-hk/ouroboros-network/commit/0c37054b8e1267a562eb871f836281d975a41ff7#diff-fafd0cdcd559a7b124cc61c29413fb54R1.

`cardano-prelude`'s `snapshot.yaml` was updated to use `hedgehog-1.0.2` which is too great of a version to be used with `tasty-hedgehog-1.0.0.1`.