### PR TITLE
test-infra: add PropGeneralArgs record type for prop_general

### DIFF
--- a/ouroboros-consensus-byron/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/DualPBFT.hs
@@ -79,17 +79,19 @@ prop_convergence :: SetupDualPBft -> Property
 prop_convergence setup = withMaxSuccess 10 $
     (\prop -> if mightForgeInSlot0 then discard else prop) $
     tabulate "Ref.PBFT result" [Ref.resultConstrName refResult] $
-    prop_general
-      (countByronGenTxs . dualBlockMain)
-      (setupSecurityParam      setup)
-      cfg
-      (setupSchedule           setup)
-      (Just $ NumBlocks $ case refResult of
-         Ref.Forked{} -> 1
-         _            -> 0)
-      (setupExpectedRejections setup)
-      1
-      (setupTestOutput         setup)
+    prop_general PropGeneralArgs
+      { pgaCountTxs               = countByronGenTxs . dualBlockMain
+      , pgaExpectedBlockRejection = setupExpectedRejections setup
+      , pgaFirstBlockNo           = 1
+      , pgaFixedMaxForkLength     =
+          Just $ NumBlocks $ case refResult of
+            Ref.Forked{} -> 1
+            _            -> 0
+      , pgaFixedSchedule          = setupSchedule setup
+      , pgaSecurityParam          = setupSecurityParam setup
+      , pgaTestConfig             = cfg
+      }
+      (setupTestOutput setup)
   where
     cfg = setupConfig setup
 

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
@@ -564,17 +564,21 @@ prop_simple_real_pbft_convergence produceEBBs k
             ]
           | (nid, ch) <- finalChains
           ]) $
-    prop_general
-        Byron.countByronGenTxs
-        k
-        testConfig
-        (Just $ roundRobinLeaderSchedule numCoreNodes numSlots)
-        (Just $ NumBlocks $ case refResult of
-           Ref.Forked{} -> 1
-           _            -> 0)
-        (expectedBlockRejection k numCoreNodes nodeRestarts)
-        1
-        testOutput .&&.
+    prop_general PropGeneralArgs
+      { pgaCountTxs               = Byron.countByronGenTxs
+      , pgaExpectedBlockRejection =
+          expectedBlockRejection k numCoreNodes nodeRestarts
+      , pgaFirstBlockNo           = 1
+      , pgaFixedMaxForkLength     =
+          Just $ NumBlocks $ case refResult of
+            Ref.Forked{} -> 1
+            _            -> 0
+      , pgaFixedSchedule          =
+          Just $ roundRobinLeaderSchedule numCoreNodes numSlots
+      , pgaSecurityParam          = k
+      , pgaTestConfig             = testConfig
+      }
+      testOutput .&&.
     prop_pvu .&&.
     not (all (Chain.null . snd) finalChains) .&&.
     conjoin (map (hasAllEBBs k numSlots produceEBBs) finalChains)

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -56,15 +56,17 @@ prop_simple_bft_convergence :: SecurityParam
 prop_simple_bft_convergence k
   testConfig@TestConfig{numCoreNodes, numSlots, slotLengths} =
     tabulate "slot length changes" [show $ countSlotLengthChanges numSlots slotLengths] $
-    prop_general
-        countSimpleGenTxs
-        k
-        testConfig
-        (Just $ roundRobinLeaderSchedule numCoreNodes numSlots)
-        Nothing
-        (const False)
-        0
-        testOutput
+    prop_general PropGeneralArgs
+      { pgaCountTxs               = countSimpleGenTxs
+      , pgaExpectedBlockRejection = const False
+      , pgaFirstBlockNo           = 0
+      , pgaFixedMaxForkLength     = Nothing
+      , pgaFixedSchedule          =
+          Just $ roundRobinLeaderSchedule numCoreNodes numSlots
+      , pgaSecurityParam          = k
+      , pgaTestConfig             = testConfig
+      }
+      testOutput
   where
     testOutput =
         runTestNetwork testConfig epochSize TestConfigBlock

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -90,14 +90,15 @@ prop_simple_leader_schedule_convergence
   params@PraosParams{praosSecurityParam}
   testConfig@TestConfig{numCoreNodes} schedule =
     counterexample (tracesToDot testOutputNodes) $
-    prop_general
-      countSimpleGenTxs
-      praosSecurityParam
-      testConfig
-      (Just schedule)
-      Nothing
-      (const False)
-      0
+    prop_general PropGeneralArgs
+      { pgaCountTxs               = countSimpleGenTxs
+      , pgaExpectedBlockRejection = const False
+      , pgaFirstBlockNo           = 0
+      , pgaFixedMaxForkLength     = Nothing
+      , pgaFixedSchedule          = Just schedule
+      , pgaSecurityParam          = praosSecurityParam
+      , pgaTestConfig             = testConfig
+      }
       testOutput
   where
     testOutput@TestOutput{testOutputNodes} =

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -75,19 +75,20 @@ prop_simple_pbft_convergence
   k testConfig@TestConfig{numCoreNodes, numSlots, nodeJoinPlan} =
     tabulate "Ref.PBFT result" [Ref.resultConstrName refResult] $
     prop_asSimulated .&&.
-    prop_general
-        countSimpleGenTxs
-        k
-        testConfig
-        (Just $ roundRobinLeaderSchedule numCoreNodes numSlots)
-        -- do not use the "Test.ThreadNet.Util.Expectations" module; it doesn't
-        -- consider the PBFT threshold
-        (Just $ NumBlocks $ case refResult of
-           Ref.Forked{} -> 1
-           _            -> 0)
-        (expectedBlockRejection numCoreNodes)
-        0
-        testOutput
+    prop_general PropGeneralArgs
+      { pgaCountTxs               = countSimpleGenTxs
+      , pgaExpectedBlockRejection = expectedBlockRejection numCoreNodes
+      , pgaFirstBlockNo           = 0
+      , pgaFixedMaxForkLength     =
+          Just $ NumBlocks $ case refResult of
+            Ref.Forked{} -> 1
+            _            -> 0
+      , pgaFixedSchedule          =
+          Just $ roundRobinLeaderSchedule numCoreNodes numSlots
+      , pgaSecurityParam          = k
+      , pgaTestConfig             = testConfig
+      }
+      testOutput
   where
     NumCoreNodes nn = numCoreNodes
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -94,14 +94,15 @@ prop_simple_praos_convergence
   params@PraosParams{praosSecurityParam}
   testConfig@TestConfig{numCoreNodes} =
     counterexample (tracesToDot testOutputNodes) $
-    prop_general
-      countSimpleGenTxs
-      praosSecurityParam
-      testConfig
-      Nothing
-      Nothing
-      (const False)
-      0
+    prop_general PropGeneralArgs
+      { pgaCountTxs               = countSimpleGenTxs
+      , pgaExpectedBlockRejection = const False
+      , pgaFirstBlockNo           = 0
+      , pgaFixedMaxForkLength     = Nothing
+      , pgaFixedSchedule          = Nothing
+      , pgaSecurityParam          = praosSecurityParam
+      , pgaTestConfig             = testConfig
+      }
       testOutput
   where
     testOutput@TestOutput{testOutputNodes} =


### PR DESCRIPTION
Simple tidying: just collecting the arguments into a record type and improving the comments _en passant_.