### PR TITLE
toCBORABlockOrBoundaryHdr

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -181,29 +181,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 026aa98773c43da4a66cff201c58a0e7a3f09b0b
-  --sha256: 05ff5rhaxcchvnlajnfqlnsh8q5x4srll633q3cjhvmi5ljx82iw
+  tag: e2240ccda93e52835cd25b04e1963c8929bbfa64
+  --sha256: 08c1dz9plnqb6i3ysnfbw6b6y2ij2f8crkij5aqrgsdjar51p91n
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 026aa98773c43da4a66cff201c58a0e7a3f09b0b
-  --sha256: 05ff5rhaxcchvnlajnfqlnsh8q5x4srll633q3cjhvmi5ljx82iw
+  tag: e2240ccda93e52835cd25b04e1963c8929bbfa64
+  --sha256: 08c1dz9plnqb6i3ysnfbw6b6y2ij2f8crkij5aqrgsdjar51p91n
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 026aa98773c43da4a66cff201c58a0e7a3f09b0b
-  --sha256: 05ff5rhaxcchvnlajnfqlnsh8q5x4srll633q3cjhvmi5ljx82iw
+  tag: e2240ccda93e52835cd25b04e1963c8929bbfa64
+  --sha256: 08c1dz9plnqb6i3ysnfbw6b6y2ij2f8crkij5aqrgsdjar51p91n
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 026aa98773c43da4a66cff201c58a0e7a3f09b0b
-  --sha256: 05ff5rhaxcchvnlajnfqlnsh8q5x4srll633q3cjhvmi5ljx82iw
+  tag: e2240ccda93e52835cd25b04e1963c8929bbfa64
+  --sha256: 08c1dz9plnqb6i3ysnfbw6b6y2ij2f8crkij5aqrgsdjar51p91n
   subdir: crypto/test
 
 -- version number matching the one specified in the stack resolver file

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
@@ -296,21 +296,8 @@ fakeByronBlockSizeHint = 2000
 -- (which never send or store these headers), but should be inverse to
 -- 'decodeSizedHeader', and moreover uses 'fromCBORABlockOrBoundaryHdr' from
 -- cardano-ledger, and so we don't have too much choice in this encoder.
---
--- TODO: This ought to live in cardano-ledger itself.
 encodeUnsizedHeader :: UnsizedHeader -> Encoding
-encodeUnsizedHeader (UnsizedHeader raw _ _) = mconcat [
-      CBOR.encodeListLen 2
-    , case raw of
-        CC.ABOBBoundaryHdr h -> mconcat [
-            CBOR.encodeWord 0
-          , CBOR.encodePreEncoded $ CC.boundaryHeaderAnnotation h
-          ]
-        CC.ABOBBlockHdr h -> mconcat [
-            CBOR.encodeWord 1
-          , CBOR.encodePreEncoded $ CC.headerAnnotation h
-          ]
-    ]
+encodeUnsizedHeader (UnsizedHeader raw _ _) = CC.toCBORABlockOrBoundaryHdr raw
 
 -- | Inverse of 'encodeSizedHeader'
 decodeUnsizedHeader :: CC.EpochSlots

--- a/stack.yaml
+++ b/stack.yaml
@@ -61,7 +61,7 @@ extra-deps:
   - gray-code-0.3.1
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 026aa98773c43da4a66cff201c58a0e7a3f09b0b
+    commit: e2240ccda93e52835cd25b04e1963c8929bbfa64
     subdirs:
       - cardano-ledger
       - cardano-ledger/test


### PR DESCRIPTION
Fixes #1805.

Bump dependency on `cardano-ledger`, this brings in https://github.com/input-output-hk/cardano-ledger/pull/729.