### PR TITLE
Renamed ouroboros-network-framework

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
@@ -88,7 +88,7 @@ library
                      , io-sim
                      , typed-protocols
                      , ouroboros-network
-                     , ouroboros-network-framework
+                     , ouroboros-network-frm
                      , ouroboros-consensus
 
   default-language:    Haskell2010

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -228,7 +228,7 @@ library
                      , io-sim-classes
                      , typed-protocols
                      , network-mux
-                     , ouroboros-network-framework
+                     , ouroboros-network-frm
                      , ouroboros-network
 
 
@@ -328,7 +328,7 @@ test-suite test-consensus
                      , io-sim
                      , typed-protocols
                      , ouroboros-network
-                     , ouroboros-network-framework
+                     , ouroboros-network-frm
                      , ouroboros-consensus
 
                        -- ouroboros-consensus-test-infra

--- a/ouroboros-network-framework/ouroboros-network-frm.cabal
+++ b/ouroboros-network-framework/ouroboros-network-frm.cabal
@@ -3,7 +3,7 @@ cabal-version:       >=1.10
 --  'cabal init'.  For further documentation, see
 -- http://haskell.org/cabal/users-guide/
 
-name:                ouroboros-network-framework
+name:                ouroboros-network-frm
 version:             0.1.0.0
 -- synopsis:
 -- description:
@@ -81,7 +81,7 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
 
-test-suite ouroboros-network-framework-tests
+test-suite test-framework
   type:                exitcode-stdio-1.0
   main-is:             Main.hs
   hs-source-dirs:      test
@@ -107,7 +107,7 @@ test-suite ouroboros-network-framework-tests
                      , typed-protocols-examples
                      , network         >= 3.1
                      , network-mux     >= 0.1 && < 0.2
-                     , ouroboros-network-framework
+                     , ouroboros-network-frm
                      , ouroboros-network-testing
                      , contra-tracer
                      , dns
@@ -141,7 +141,7 @@ executable demo-ping-pong
                        directory,
                        network-mux,
                        network,
-                       ouroboros-network-framework,
+                       ouroboros-network-frm,
                        io-sim-classes,
                        stm,
                        text,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -121,7 +121,7 @@ library
   build-depends:       base              >=4.9 && <4.13,
                        network-mux       >=0.1 && <1.0,
                        typed-protocols   >=0.1 && < 1.0,
-                       ouroboros-network-framework
+                       ouroboros-network-frm
                                          >=0.1 && <1.0,
                        io-sim-classes    >=0.1 && < 0.2,
 
@@ -198,7 +198,7 @@ library ouroboros-protocol-tests
                        io-sim,
                        io-sim-classes,
                        typed-protocols,
-                       ouroboros-network-framework,
+                       ouroboros-network-frm,
                        ouroboros-network
 
 test-suite test-network
@@ -254,7 +254,7 @@ test-suite test-network
                        text,
                        time,
                        typed-protocols,
-                       ouroboros-network-framework,
+                       ouroboros-network-frm,
                        ouroboros-network,
                        ouroboros-protocol-tests
 
@@ -299,7 +299,7 @@ test-suite test-cddl
                        tasty-quickcheck,
                        text,
                        typed-protocols,
-                       ouroboros-network-framework,
+                       ouroboros-network-frm,
                        ouroboros-network,
                        ouroboros-protocol-tests
   ghc-options:         -Wall
@@ -317,7 +317,7 @@ executable demo-chain-sync
                        directory,
                        network-mux,
                        network,
-                       ouroboros-network-framework,
+                       ouroboros-network-frm,
                        ouroboros-network,
                        QuickCheck,
                        random,


### PR DESCRIPTION
The ouroboros-netowrk-framework is too long to build on windows.
