### PR TITLE
CAD-742: make the EBB serialisation match cardano-sl

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -181,29 +181,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: e2240ccda93e52835cd25b04e1963c8929bbfa64
-  --sha256: 08c1dz9plnqb6i3ysnfbw6b6y2ij2f8crkij5aqrgsdjar51p91n
+  tag: d00fdb3407c5d13aa57f2ead79490a81854879a4
+  --sha256: 0hkvv14mnp9bgpii062lvid2a1k6ynj8zjdaws7d5yd040gsm1gz
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: e2240ccda93e52835cd25b04e1963c8929bbfa64
-  --sha256: 08c1dz9plnqb6i3ysnfbw6b6y2ij2f8crkij5aqrgsdjar51p91n
+  tag: d00fdb3407c5d13aa57f2ead79490a81854879a4
+  --sha256: 0hkvv14mnp9bgpii062lvid2a1k6ynj8zjdaws7d5yd040gsm1gz
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: e2240ccda93e52835cd25b04e1963c8929bbfa64
-  --sha256: 08c1dz9plnqb6i3ysnfbw6b6y2ij2f8crkij5aqrgsdjar51p91n
+  tag: d00fdb3407c5d13aa57f2ead79490a81854879a4
+  --sha256: 0hkvv14mnp9bgpii062lvid2a1k6ynj8zjdaws7d5yd040gsm1gz
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: e2240ccda93e52835cd25b04e1963c8929bbfa64
-  --sha256: 08c1dz9plnqb6i3ysnfbw6b6y2ij2f8crkij5aqrgsdjar51p91n
+  tag: d00fdb3407c5d13aa57f2ead79490a81854879a4
+  --sha256: 0hkvv14mnp9bgpii062lvid2a1k6ynj8zjdaws7d5yd040gsm1gz
   subdir: crypto/test
 
 -- version number matching the one specified in the stack resolver file

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -67,7 +67,7 @@ forgeEBB
 forgeEBB cfg curSlot curNo prevHash =
         mkByronBlock (byronEpochSlots byronConfig)
       . CC.Block.ABOBBoundary
-      . CC.reAnnotateBoundary (byronProtocolMagicId byronConfig)
+      . CC.reAnnotateABOBBoundary (byronProtocolMagicId byronConfig)
       $ boundaryBlock
   where
     byronConfig :: BlockConfig ByronBlock

--- a/stack.yaml
+++ b/stack.yaml
@@ -61,7 +61,7 @@ extra-deps:
   - gray-code-0.3.1
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: d1e9ef501a970740a5c7b077d8ff78780a76fe7c
+    commit: d00fdb3407c5d13aa57f2ead79490a81854879a4
     subdirs:
       - cardano-ledger
       - cardano-ledger/test

--- a/stack.yaml
+++ b/stack.yaml
@@ -61,7 +61,7 @@ extra-deps:
   - gray-code-0.3.1
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: e2240ccda93e52835cd25b04e1963c8929bbfa64
+    commit: d1e9ef501a970740a5c7b077d8ff78780a76fe7c
     subdirs:
       - cardano-ledger
       - cardano-ledger/test


### PR DESCRIPTION
There were two problems in the way `forgeEBB` was serialising the EBB, leading to a mismatch with `cardano-sl`:

1. the body proof was off, now fixed by @dcoutts in https://github.com/input-output-hk/cardano-ledger/pull/751/commits/9c53870095a8a6f72c3e84a3ea8cd297a8495de6
2. the ABOB tag wrapper was missing, leading to two missing leading bytes -- see `0x82`, `0x00` in the following serialisation from `cardano-sl`:
```
[nix-shell:~/cardano-node]$ cardano-cli pretty-print-cbor --filepath ebb.rewrite
    82  # list(2)
       00  # int(0)
       83  # list(3)
          85  # list(5)
             1a 00 98 96 80  # int(10000000)
             58 20 ec 4f af ee 43 d6 4b 00 9e aa e5 35 32 90
             16 72 50 b7 06 94 52 8e bb d4 79 61 96 73 12 8e
             9c c2  # bytes(32)
             58 20 af c0 da 64 18 3b f2 66 4f 3d 4e ec 72 38
             d5 24 ba 60 7f ae ea b2 4f c1 00 eb 86 1d ba 69
             97 1b  # bytes(32)
             82  # list(2)
                00  # int(0)
                81  # list(1)
                   00  # int(0)
             81  # list(1)
                a0  # map(0)
          9f  # list(*)
          ff  # break
          81  # list(1)
             a0  # map(0)
```
This PR makes the Rewrite's serialisation for the EBB match that of `cardano-sl`.