### PR TITLE
Policy for lmitting number of accepted connections

### DIFF
--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -138,6 +138,7 @@ serverPingPong =
       (localSnocket iomgr defaultLocalSocketAddrPath)
       nullNetworkServerTracers
       networkState
+      (AcceptedConnectionsLimit maxBound maxBound 0)
       defaultLocalSocketAddr
       cborTermVersionDataCodec
       (\(DictVersion _) -> acceptableVersion)
@@ -243,6 +244,7 @@ serverPingPong2 =
       (localSnocket iomgr defaultLocalSocketAddrPath)
       nullNetworkServerTracers
       networkState
+      (AcceptedConnectionsLimit maxBound maxBound 0)
       defaultLocalSocketAddr
       cborTermVersionDataCodec
       (\(DictVersion _) -> acceptableVersion)

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -93,6 +93,7 @@ test-suite ouroboros-network-framework-tests
                        Test.Ouroboros.Network.Driver
                        Test.Ouroboros.Network.Socket
                        Test.Ouroboros.Network.Subscription
+                       Test.Ouroboros.Network.RateLimiting
 
   build-depends:       base
                      , bytestring

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -36,6 +36,7 @@ library
 
                        Ouroboros.Network.Server.ConnectionTable
                        Ouroboros.Network.Server.Socket
+                       Ouroboros.Network.Server.RateLimiting
                        Ouroboros.Network.Snocket
                        Ouroboros.Network.Socket
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/Server/RateLimiting.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Server/RateLimiting.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE BangPatterns   #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Rage limiting of accepted connections
+--
+module Ouroboros.Network.Server.RateLimiting
+  ( AcceptedConnectionsLimit (..)
+  , runConnectionRateLimits
+  ) where
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer
+import           Control.Monad (when)
+
+import           Data.Word
+
+
+-- | Policy which governs how to limit the number of accepted connections.
+--
+data AcceptedConnectionsLimit = AcceptedConnectionsLimit {
+
+    -- | Hard limit of accepted connections.
+    --
+    acceptedConnectionsHardLimit :: !Word32,
+
+    -- | Soft limit of accepted connections.  If we are above this threshold,
+    -- we will start rate limiting.
+    --
+    acceptedConnectionsSoftLimit :: !Word32,
+
+    -- | Max delay for limiting accepted connections.  We use linear
+    -- regression starting from 0 at the soft limit up to
+    -- `acceptedConnectionDelay` at the hard limit.
+    --
+    acceptedConnectionsDelay     :: !DiffTime
+  }
+  deriving (Eq, Ord, Show)
+
+
+-- | Rate limiting instruction.
+--
+data RateLimitDelay =
+      -- | no rate limiting
+      --
+      NoRateLimiting
+
+      -- | We are above the soft limit, we delay accepting the next connection>
+    | SoftDelay DiffTime
+
+      -- | We are above the hard limit, wait until the number of connections
+      -- drops below the given threshold (currently this is the hard limit,
+      -- which means we keep `acceptedConnectionsHardLimit` number of
+      -- connections, later we c could be configured to something between
+      -- `acceptedConnesiontSoftLimit` and `acceptedConnectionsHardLimit`).
+      --
+    | HardLimit Word32
+
+
+-- | Interpretation of the 'AcceptedConnectionsLimit' policy.
+--
+getRateLimitDecision :: Int
+                     -- ^ number of served concurrent connections
+                     -> AcceptedConnectionsLimit
+                     -- ^ limits
+                     -> RateLimitDelay
+getRateLimitDecision numberOfConnections
+                     AcceptedConnectionsLimit { acceptedConnectionsHardLimit
+                                              , acceptedConnectionsSoftLimit
+                                              , acceptedConnectionsDelay
+                                              }
+    -- below the soft limit we accept connections without any delay
+    | numberOfConnections  < softLimit = NoRateLimiting
+
+    -- above the hard limit will will wait until the number of connections drops
+    -- below the soft limit
+    | numberOfConnections >= hardLimit = HardLimit acceptedConnectionsHardLimit
+
+    -- in between we scale the delay using linear regression.
+    | otherwise =
+        SoftDelay $
+            fromIntegral (numberOfConnections - softLimit)
+          * acceptedConnectionsDelay
+          / fromIntegral ((hardLimit - softLimit) `max` 1)
+  where
+    hardLimit, softLimit :: Int
+    hardLimit = fromIntegral acceptedConnectionsHardLimit
+    softLimit = fromIntegral acceptedConnectionsSoftLimit
+
+
+-- | Get the number of current connections, make decision based on
+-- 'AcceptedConnectionsLimit' and execute it.
+--
+runConnectionRateLimits
+    :: ( MonadSTM   m
+       , MonadDelay m
+       , MonadTime  m
+       )
+    => STM m Int
+    -> AcceptedConnectionsLimit
+    -> m ()
+runConnectionRateLimits numberOfConnectionsSTM
+                        acceptedConnectionsLimit@AcceptedConnectionsLimit
+                          { acceptedConnectionsDelay } = do
+    numberOfConnections <- atomically numberOfConnectionsSTM
+    case getRateLimitDecision numberOfConnections acceptedConnectionsLimit of
+
+      NoRateLimiting  -> pure ()
+
+      SoftDelay delay -> threadDelay delay
+
+      -- wait until the current number of connection drops below the limit, and
+      -- wait at least 'acceptedConnectionsDelay'.  This is to avoid accepting
+      -- the last connection to frequently if it fails almost immediately .
+      HardLimit limit -> do
+        start <- getMonotonicTime
+        atomically $ do
+          numberOfConnections <- numberOfConnectionsSTM
+          check (numberOfConnections < fromIntegral limit)
+        end <- getMonotonicTime
+        let remainingDelay = end `diffTime` start - acceptedConnectionsDelay
+        when (remainingDelay > 0)
+          $ threadDelay remainingDelay

--- a/ouroboros-network-framework/src/Ouroboros/Network/Server/RateLimiting.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Server/RateLimiting.hs
@@ -18,6 +18,7 @@ import           Control.Monad (when)
 import           Control.Tracer (Tracer, traceWith)
 
 import           Data.Word
+import           Data.Typeable (Typeable (..))
 import           Text.Printf
 
 
@@ -143,7 +144,7 @@ runConnectionRateLimits tracer
 data AcceptConnectionsPolicyTrace
       = ServerTraceAcceptConnectionRateLimiting DiffTime Int
       | ServerTraceAcceptConnectionHardLimit Word32
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Typeable)
 
 instance Show AcceptConnectionsPolicyTrace where
     show (ServerTraceAcceptConnectionRateLimiting delay numberOfConnections) =

--- a/ouroboros-network-framework/src/Ouroboros/Network/Server/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Server/Socket.hs
@@ -10,7 +10,8 @@
 {-# OPTIONS_GHC "-fno-warn-name-shadowing" #-}
 
 module Ouroboros.Network.Server.Socket
-  ( BeginConnection
+  ( AcceptedConnectionsLimit (..)
+  , BeginConnection
   , HandleConnection (..)
   , ApplicationStart
   , CompleteConnection
@@ -25,15 +26,18 @@ module Ouroboros.Network.Server.Socket
 
 import Control.Exception (SomeException (..), IOException, mask, mask_, finally, onException, try)
 import Control.Concurrent.Async (Async)
+import Control.Monad.Class.MonadTime (MonadTime (..))
+import Control.Monad.Class.MonadTimer (MonadDelay (..))
 import qualified Control.Concurrent.Async as Async
 import Control.Concurrent.STM (STM)
 import qualified Control.Concurrent.STM as STM
-import Control.Monad (forM_, join)
-import Control.Monad.Class.MonadTime (Time, getMonotonicTime)
+import Control.Monad (forM_, join, when)
+import Control.Monad.Class.MonadTime (DiffTime, Time, diffTime, getMonotonicTime)
 import Control.Tracer (Tracer, traceWith)
 import Data.Foldable (traverse_)
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Word (Word32)
 
 import Ouroboros.Network.ErrorPolicy (CompleteApplicationResult (..), WithAddr, ErrorPolicyTrace)
 
@@ -56,6 +60,7 @@ ioSocket io = Socket
   }
 
 type StatusVar st = STM.TVar st
+
 
 -- | What to do with a new connection: reject it and give a new state, or
 -- accept it and give a new state with a continuation to run against the
@@ -154,17 +159,18 @@ acceptLoop
   :: ResultQ addr r
   -> ThreadsVar
   -> StatusVar st
+  -> AcceptedConnectionsLimit
   -> BeginConnection addr channel st r
   -> ApplicationStart addr st
   -> (IOException -> IO ()) -- ^ Exception on `Socket.accept`.
   -> Socket addr channel
   -> IO ()
-acceptLoop resQ threadsVar statusVar beginConnection applicationStart acceptException socket = do
-    mNextSocket <- acceptOne resQ threadsVar statusVar beginConnection applicationStart acceptException socket
+acceptLoop resQ threadsVar statusVar acceptedConnectionLimit beginConnection applicationStart acceptException socket = do
+    mNextSocket <- acceptOne resQ threadsVar statusVar acceptedConnectionLimit beginConnection applicationStart acceptException socket
     case mNextSocket of
       Nothing -> pure ()
       Just nextSocket ->
-        acceptLoop resQ threadsVar statusVar beginConnection applicationStart acceptException nextSocket
+        acceptLoop resQ threadsVar statusVar acceptedConnectionLimit beginConnection applicationStart acceptException nextSocket
 
 -- | Accept once from the socket, use the `Accept` to make a decision (accept
 -- or reject), and spawn the thread if accepted.
@@ -173,12 +179,19 @@ acceptOne
      ResultQ addr r
   -> ThreadsVar
   -> StatusVar st
+  -> AcceptedConnectionsLimit
   -> BeginConnection addr channel st r
   -> ApplicationStart addr st
   -> (IOException -> IO ()) -- ^ Exception on `Socket.accept`.
   -> Socket addr channel
   -> IO (Maybe (Socket addr channel))
-acceptOne resQ threadsVar statusVar beginConnection applicationStart acceptException socket = mask $ \restore -> do
+acceptOne resQ threadsVar statusVar acceptedConnectionsLimit beginConnection applicationStart acceptException socket = mask $ \restore -> do
+
+  -- Rate limiting of accepted connections; this might block.
+  runConnectionRateLimits
+    (Set.size <$> STM.readTVar threadsVar)
+    acceptedConnectionsLimit
+
   -- mask is to assure that every socket is closed.
   outcome <- try (restore (acceptConnection socket))
   case outcome :: Either IOException (addr, channel, IO (), Socket addr channel) of
@@ -253,12 +266,14 @@ mainLoop errorPolicyTrace resQ threadsVar statusVar complete main =
       traverse_ (traceWith errorPolicyTrace) carTrace
       mainLoop errorPolicyTrace resQ threadsVar statusVar complete main
 
+
 -- | Run a server.
 run
   :: Tracer IO (WithAddr addr ErrorPolicyTrace)
   -- TODO: extend this trace to trace server action (this might be useful for
   -- debugging)
   -> Socket addr channel
+  -> AcceptedConnectionsLimit
   -> (IOException -> IO ())
   -> BeginConnection addr channel st r
   -> ApplicationStart addr st
@@ -266,10 +281,10 @@ run
   -> Main st t
   -> STM.TVar st
   -> IO t
-run errroPolicyTrace socket acceptException beginConnection applicationStart complete main statusVar = do
+run errroPolicyTrace socket acceptedConnectionLimit acceptException beginConnection applicationStart complete main statusVar = do
   resQ <- STM.newTQueueIO
   threadsVar <- STM.newTVarIO Set.empty
-  let acceptLoopDo = acceptLoop resQ threadsVar statusVar beginConnection applicationStart acceptException socket
+  let acceptLoopDo = acceptLoop resQ threadsVar statusVar acceptedConnectionLimit beginConnection applicationStart acceptException socket
       -- The accept loop is killed when the main loop stops.
       mainDo = Async.withAsync acceptLoopDo $ \_ ->
         mainLoop errroPolicyTrace resQ threadsVar statusVar complete main

--- a/ouroboros-network-framework/test/Main.hs
+++ b/ouroboros-network-framework/test/Main.hs
@@ -7,6 +7,7 @@ import qualified Test.Network.TypedProtocol.ReqResp.Codec as ReqResp
 import qualified Test.Ouroboros.Network.Driver as Driver
 import qualified Test.Ouroboros.Network.Socket as Socket
 import qualified Test.Ouroboros.Network.Subscription as Subscription
+import qualified Test.Ouroboros.Network.RateLimiting as RateLimiting
 
 main :: IO ()
 main = defaultMain tests
@@ -19,6 +20,7 @@ tests =
   , Driver.tests
   , Socket.tests
   , Subscription.tests
+  , RateLimiting.tests
   ]
 
 

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/RateLimiting.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/RateLimiting.hs
@@ -1,0 +1,299 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Ouroboros.Network.RateLimiting where
+
+
+import           Control.Tracer (Tracer (..), contramapM)
+import           Control.Monad (when)
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer
+import           Control.Monad.IOSim
+import           Data.List (scanl')
+
+import           Ouroboros.Network.Server.RateLimiting
+
+import           Test.QuickCheck
+import           Text.Show.Functions ()
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+
+--
+-- The list of all properties
+--
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Network.RateLimiting"
+  [ testProperty "HardLimit" propRateLimit_NotExceedHardLimit
+  , testProperty "SoftLimit" propRateLimit_SoftLimitDelay
+  ]
+
+
+--
+-- Basic data types
+--
+
+-- | To emulate environment we generate 'Event's:  we either receive a new
+-- connection, or one of the accepted connections is terminating.
+--
+-- 'DiffTime' - a delay between consecutive events.
+--
+data Event
+      = IncomingConnection   DiffTime
+      | ConnectionTerminated DiffTime
+  deriving (Eq, Ord, Show)
+
+
+data WithNumberOfConnections a = WithNumberOfConnections {
+    message :: a,
+    numberOfConnections :: Int
+  }
+
+
+
+--
+-- Generators
+--
+
+
+-- | A newtype wrapper for 'Arbitrary' instances.
+--
+newtype Arb a = Arb { getArb :: a }
+  deriving (Eq, Ord, Show)
+
+
+genEvent :: Gen Event
+genEvent = frequency
+    [ (6, IncomingConnection   . toDiffTime <$> arbitrary)
+    , (4, ConnectionTerminated . toDiffTime <$> arbitrary)
+    ]
+
+toDiffTime :: NonNegative Int -> DiffTime
+toDiffTime = fromIntegral . getNonNegative
+
+fixEvents :: [Event] -> [Event]
+fixEvents = go 0
+  where
+    go :: Int -> [Event] -> [Event]
+    go _ [] = []
+    go 0 (ConnectionTerminated _ : events)     =      go 0 events
+    go n (ev@ConnectionTerminated {} : events) = ev : go (pred n) events
+    go n (ev@IncomingConnection {}   : events) = ev : go (succ n) events
+
+instance Arbitrary (Arb [Event]) where
+    arbitrary = Arb . fixEvents <$> listOf genEvent
+
+    shrink (Arb events) =
+      [ Arb (fixEvents events')
+      | events' <- shrinkList (const []) events
+      ]
+
+
+genAcceptedConnectionsLimit :: Int ->  Gen AcceptedConnectionsLimit
+genAcceptedConnectionsLimit limit = do
+    hardLimit <- resize limit arbitrary
+    softLimit <- resize (fromIntegral hardLimit) arbitrary
+    delay <- toDiffTime <$> arbitrary
+    pure $ AcceptedConnectionsLimit {
+        acceptedConnectionsHardLimit = hardLimit,
+        acceptedConnectionsSoftLimit = softLimit,
+        acceptedConnectionsDelay     = delay
+      }
+
+shrinkAcceptedConnectionsLimit :: AcceptedConnectionsLimit -> [AcceptedConnectionsLimit]
+shrinkAcceptedConnectionsLimit (AcceptedConnectionsLimit hardLimit softLimit delay) =
+  [ AcceptedConnectionsLimit hardLimit' softLimit delay
+  | hardLimit' <- shrink hardLimit
+  , hardLimit' >= softLimit
+  ]
+  ++
+  [ AcceptedConnectionsLimit hardLimit softLimit' delay
+  | softLimit' <- shrink softLimit
+  , softLimit' >= 0
+  ]
+  ++
+  [ AcceptedConnectionsLimit hardLimit softLimit delay'
+  | delay' <- fromRational `map` shrink (toRational delay)
+  , delay' >= 0 && delay' /= delay
+  ]
+
+
+instance Arbitrary (Arb ([Event], AcceptedConnectionsLimit)) where
+    arbitrary = do
+      Arb events <- arbitrary
+      let limit = foldr (\case
+                          IncomingConnection {}   -> succ
+                          ConnectionTerminated {} -> pred)
+                      0 events
+      limits <-
+        oneof [ genAcceptedConnectionsLimit (2 * limit)
+              , genAcceptedConnectionsLimit (limit `div` 2)
+              ]
+
+
+      pure $ Arb (events, limits)
+
+    shrink (Arb (events, limits)) =
+      [ Arb (events', limits)
+      | Arb events' <- shrink (Arb events)
+      ]
+      ++
+      [ Arb (events, limits')
+      | limits' <- shrinkAcceptedConnectionsLimit limits
+      ]
+
+
+--
+-- Simulations
+--
+
+rateLimittingExperiment
+    :: forall m.
+       ( MonadAsync m
+       , MonadSTM   m
+       , MonadTime  m
+       , MonadDelay m
+       )
+    => Tracer m (WithNumberOfConnections AcceptConnectionsPolicyTrace)
+    -> AcceptedConnectionsLimit
+    -> [Event]
+    -> m ()
+rateLimittingExperiment tracer policy events0 = do
+    v <- atomically $ newTVar 0
+
+    let numberOfConnectionsSTM :: STM m Int
+        numberOfConnectionsSTM = readTVar v
+
+    runConnectionRateLimits (getTracer v) numberOfConnectionsSTM policy
+      `race_`
+      shedulingThread v events0
+  where
+    -- thread which schedules events
+    shedulingThread :: TVar m Int -> [Event] -> m ()
+    shedulingThread _v [] = pure ()
+    shedulingThread v  (IncomingConnection delay : events) = do
+      when (delay > 0)
+        $ threadDelay delay
+      atomically $ modifyTVar' v succ
+      shedulingThread v events
+    shedulingThread v  (ConnectionTerminated delay : events) = do
+      when (delay > 0)
+        $ threadDelay delay
+      atomically $ modifyTVar' v pred
+      shedulingThread v events
+
+    -- tracer
+    getTracer :: TVar m Int
+              -> Tracer m AcceptConnectionsPolicyTrace
+    getTracer v =
+      contramapM
+        (\msg -> WithNumberOfConnections msg <$> atomically (readTVar v))
+        tracer
+
+
+-- | Run 'rateLimittingExperiment' in 'IOSim', and return the trace.
+--
+runRateLimitExperiment :: AcceptedConnectionsLimit
+                       -> [Event]
+                       -> [WithNumberOfConnections AcceptConnectionsPolicyTrace]
+runRateLimitExperiment policy events =
+    selectTraceEventsDynamic
+      $ runSimTrace
+      $ rateLimittingExperiment (Tracer traceM) policy events
+
+
+--
+-- QuickCheck properties
+--
+
+
+-- | We never should exceed the hard limit.
+--
+propRateLimit_NotExceedHardLimit
+    :: Arb ([Event], AcceptedConnectionsLimit)
+    -> Property
+propRateLimit_NotExceedHardLimit (Arb (events, policy)) =
+      label (buckets $ numberOfTurnsAboveHardLimit policy events)
+    $ isValid (runRateLimitExperiment policy events)
+  where
+    isValid :: [WithNumberOfConnections b]
+            -> Bool
+    isValid =
+      all
+        (\x -> numberOfConnections x
+                <= fromIntegral (acceptedConnectionsHardLimit policy))
+
+
+-- | When above soft limit and below the hard limit, the delay should be
+-- between '0' and 'acceptedConnectionsDelay'.
+--
+propRateLimit_SoftLimitDelay
+    :: Arb ([Event], AcceptedConnectionsLimit)
+    -> Property
+propRateLimit_SoftLimitDelay (Arb (events, policy)) =
+      label (buckets $ numberOfTurnsAboveSoftLimit policy events)
+    $ isValid $ runRateLimitExperiment policy events
+  where
+    isValid :: [WithNumberOfConnections AcceptConnectionsPolicyTrace]
+            -> Bool
+    isValid =
+          all  (\case
+                  WithNumberOfConnections (ServerTraceAcceptConnectionRateLimiting delay _) _ ->
+                         0 < delay
+                      &&
+                         delay <= acceptedConnectionsDelay policy
+
+                  WithNumberOfConnections ServerTraceAcceptConnectionHardLimit {} _ ->
+                      False)
+
+        . filter (\x ->
+                    numberOfConnections x > fromIntegral (acceptedConnectionsSoftLimit policy)
+                 &&
+                    numberOfConnections x < fromIntegral (acceptedConnectionsHardLimit policy))
+
+
+--
+-- QuickCheck labels
+--
+
+interpr :: Int -> Event -> Int -> Int
+interpr hardLimit IncomingConnection {}   m = succ m `min` hardLimit
+interpr _         ConnectionTerminated {} m = pred m `max` 0
+
+numberOfTurnsAboveHardLimit :: AcceptedConnectionsLimit
+                            -> [Event]
+                            -> Int
+numberOfTurnsAboveHardLimit AcceptedConnectionsLimit
+                              {acceptedConnectionsHardLimit} =
+      length
+    . filter (>= hardLimit)
+    . scanl' (flip (interpr hardLimit)) 0
+  where
+    hardLimit = fromIntegral acceptedConnectionsHardLimit
+
+
+numberOfTurnsAboveSoftLimit :: AcceptedConnectionsLimit
+                            -> [Event]
+                            -> Int
+numberOfTurnsAboveSoftLimit AcceptedConnectionsLimit
+                              {acceptedConnectionsSoftLimit} =
+      length
+    . filter (>= softLimit)
+    . scanl' (flip (interpr softLimit)) 0
+  where
+    softLimit = fromIntegral acceptedConnectionsSoftLimit
+
+
+buckets :: Int -> String
+buckets 0           = "0"
+buckets i | i <= 5  = "1 - 5"
+          | i <= 10 = "5 - 10"
+buckets i =
+    let _min = 10 * (i `div` 10)
+        _max = _min + 10
+    in show _min ++ " - " ++ show _max

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
@@ -251,9 +251,10 @@ prop_socket_send_recv initiatorAddr responderAddr f xs =
 
   where
     networkTracers = NetworkServerTracers {
-        nstMuxTracer         = activeMuxTracer,
-        nstHandshakeTracer   = nullTracer,
-        nstErrorPolicyTracer = showTracing stdoutTracer
+        nstMuxTracer          = activeMuxTracer,
+        nstHandshakeTracer    = nullTracer,
+        nstErrorPolicyTracer  = showTracing stdoutTracer,
+        nstAcceptPolicyTracer = nullTracer
       }
 
 

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
@@ -231,6 +231,7 @@ prop_socket_send_recv initiatorAddr responderAddr f xs =
         snocket
         networkTracers
         networkState
+        (AcceptedConnectionsLimit maxBound maxBound 0)
         responderAddr
         cborTermVersionDataCodec
         (\(DictVersion _) -> acceptableVersion)

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
@@ -567,6 +567,7 @@ prop_send_recv f xs _first = ioProperty $ withIOManager $ \iocp -> do
         sn
         nullNetworkServerTracers
         (NetworkMutableState tbl peerStatesVar)
+        (AcceptedConnectionsLimit maxBound maxBound 0)
         (Socket.addrAddress responderAddr)
         cborTermVersionDataCodec
         (\(DictVersion _) -> acceptableVersion)
@@ -704,6 +705,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
         (socketSnocket iocp)
         nullNetworkServerTracers
         (NetworkMutableState tbl stVar)
+        (AcceptedConnectionsLimit maxBound maxBound 0)
         responderAddr
         cborTermVersionDataCodec
         (\(DictVersion _) -> acceptableVersion)
@@ -722,6 +724,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
           sn
           nullNetworkServerTracers
           (NetworkMutableState tbl stVar)
+          (AcceptedConnectionsLimit maxBound maxBound 0)
           responderAddr
           cborTermVersionDataCodec
           (\(DictVersion _) -> acceptableVersion)
@@ -835,6 +838,7 @@ _demo = ioProperty $ withIOManager $ \iocp -> do
             (socketSnocket iocp)
             nullNetworkServerTracers
             (NetworkMutableState tbl stVar)
+            (AcceptedConnectionsLimit maxBound maxBound 0)
             (Socket.addrAddress addr)
             cborTermVersionDataCodec
             (\(DictVersion _) -> acceptableVersion)

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -178,6 +178,7 @@ serverChainSync sockAddr = withIOManager $ \iocp -> do
       (localSnocket iocp defaultLocalSocketAddrPath)
       nullNetworkServerTracers
       networkState
+      (AcceptedConnectionsLimit maxBound maxBound 0)
       (localAddressFromPath sockAddr)
       cborTermVersionDataCodec
       (\(DictVersion _) -> acceptableVersion)
@@ -395,6 +396,7 @@ serverBlockFetch sockAddr = withIOManager $ \iocp -> do
       (localSnocket iocp defaultLocalSocketAddrPath)
       nullNetworkServerTracers
       networkState
+      (AcceptedConnectionsLimit maxBound maxBound 0)
       (localAddressFromPath sockAddr)
       cborTermVersionDataCodec
       (\(DictVersion _) -> acceptableVersion)

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -39,6 +39,7 @@ import           Ouroboros.Network.NodeToClient (NodeToClientVersion (..) )
 import qualified Ouroboros.Network.NodeToClient as NodeToClient
 import           Ouroboros.Network.NodeToNode ( NodeToNodeVersion (..)
                                               , AcceptedConnectionsLimit (..)
+                                              , AcceptConnectionsPolicyTrace (..)
                                               )
 import qualified Ouroboros.Network.NodeToNode   as NodeToNode
 import           Ouroboros.Network.Socket ( ConnectionId (..)
@@ -69,6 +70,8 @@ data DiffusionTracers = DiffusionTracers {
       -- ^ Handshake protocol tracer for local clients
     , dtErrorPolicyTracer      :: Tracer IO (WithAddr SockAddr     ErrorPolicyTrace)
     , dtLocalErrorPolicyTracer :: Tracer IO (WithAddr LocalAddress ErrorPolicyTrace)
+    , dtAcceptPolicyTracer     :: Tracer IO AcceptConnectionsPolicyTrace
+      -- ^ Trace rate limiting of accepted connections
     }
 
 
@@ -182,6 +185,7 @@ runDataDiffusion tracers
                      , dtHandshakeLocalTracer
                      , dtErrorPolicyTracer
                      , dtLocalErrorPolicyTracer
+                     , dtAcceptPolicyTracer
                      } = tracers
 
     initiatorLocalAddresses :: LocalAddresses SockAddr
@@ -215,7 +219,8 @@ runDataDiffusion tracers
         (NetworkServerTracers
           dtMuxLocalTracer
           dtHandshakeLocalTracer
-          dtLocalErrorPolicyTracer)
+          dtLocalErrorPolicyTracer
+          dtAcceptPolicyTracer)
         networkLocalState
         (Snocket.localAddressFromPath daLocalAddress)
         (daLocalResponderApplication applications)
@@ -228,7 +233,8 @@ runDataDiffusion tracers
         (NetworkServerTracers
           dtMuxTracer
           dtHandshakeTracer
-          dtErrorPolicyTracer)
+          dtErrorPolicyTracer
+          dtAcceptPolicyTracer)
         networkState
         daAcceptedConnectionsLimit
         address

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -5,6 +5,7 @@
 module Ouroboros.Network.Diffusion
   ( DiffusionTracers (..)
   , DiffusionArguments (..)
+  , AcceptedConnectionsLimit (..)
   , DiffusionApplications (..)
   , OuroborosApplication (..)
   , runDataDiffusion
@@ -36,7 +37,9 @@ import           Ouroboros.Network.IOManager
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.NodeToClient (NodeToClientVersion (..) )
 import qualified Ouroboros.Network.NodeToClient as NodeToClient
-import           Ouroboros.Network.NodeToNode (NodeToNodeVersion (..))
+import           Ouroboros.Network.NodeToNode ( NodeToNodeVersion (..)
+                                              , AcceptedConnectionsLimit (..)
+                                              )
 import qualified Ouroboros.Network.NodeToNode   as NodeToNode
 import           Ouroboros.Network.Socket ( ConnectionId (..)
                                           , NetworkMutableState
@@ -80,6 +83,8 @@ data DiffusionArguments = DiffusionArguments {
       -- ^ ip subscription addresses
     , daDnsProducers :: [DnsSubscriptionTarget]
       -- ^ list of domain names to subscribe to
+    , daAcceptedConnectionsLimit :: AcceptedConnectionsLimit
+      -- ^ parameters for limiting number of accepted connections
     }
 
 data DiffusionApplications = DiffusionApplications {
@@ -125,6 +130,7 @@ runDataDiffusion tracers
                                     , daLocalAddress
                                     , daIpProducers
                                     , daDnsProducers
+                                    , daAcceptedConnectionsLimit
                                     }
                  applications@DiffusionApplications { daErrorPolicies } =
     withIOManager $ \iocp -> do
@@ -224,6 +230,7 @@ runDataDiffusion tracers
           dtHandshakeTracer
           dtErrorPolicyTracer)
         networkState
+        daAcceptedConnectionsLimit
         address
         (daResponderApplication applications)
         remoteErrorPolicy

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -269,6 +269,7 @@ withServer sn tracers networkState addr versions errPolicies =
     sn
     tracers
     networkState
+    (AcceptedConnectionsLimit maxBound maxBound 0)
     addr
     cborTermVersionDataCodec
     (\(DictVersion _) -> acceptableVersion)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -28,6 +28,7 @@ module Ouroboros.Network.NodeToNode (
   , NetworkServerTracers (..)
   , nullNetworkServerTracers
   , NetworkMutableState (..)
+  , AcceptedConnectionsLimit (..)
   , newNetworkMutableState
   , newNetworkMutableStateSTM
   , cleanNetworkMutableState
@@ -480,17 +481,19 @@ withServer
   => SocketSnocket
   -> NetworkServerTracers Socket.SockAddr NodeToNodeVersion
   -> NetworkMutableState Socket.SockAddr
+  -> AcceptedConnectionsLimit
   -> Socket.SockAddr
   -> Versions NodeToNodeVersion DictVersion
               (ConnectionId Socket.SockAddr ->
                  OuroborosApplication appType BL.ByteString IO a b)
   -> ErrorPolicies
   -> IO Void
-withServer sn tracers networkState addr versions errPolicies =
+withServer sn tracers networkState acceptedConnectionsLimit addr versions errPolicies =
   withServerNode
     sn
     tracers
     networkState
+    acceptedConnectionsLimit
     addr
     cborTermVersionDataCodec
     (\(DictVersion _) -> acceptableVersion)
@@ -506,15 +509,16 @@ withServer_V1
   => SocketSnocket
   -> NetworkServerTracers Socket.SockAddr NodeToNodeVersion
   -> NetworkMutableState Socket.SockAddr
+  -> AcceptedConnectionsLimit
   -> Socket.SockAddr
   -> NodeToNodeVersionData
   -> (ConnectionId Socket.SockAddr ->
         OuroborosApplication appType BL.ByteString IO x y)
   -> ErrorPolicies
   -> IO Void
-withServer_V1 sn tracers networkState addr versionData application =
+withServer_V1 sn tracers networkState acceptedConnectionsLimit addr versionData application =
     withServer
-      sn tracers networkState addr
+      sn tracers networkState acceptedConnectionsLimit addr
       (simpleSingletonVersions
           NodeToNodeV_1
           versionData

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -70,6 +70,7 @@ module Ouroboros.Network.NodeToNode (
   , SuspendDecision (..)
 
   -- ** Traces
+  , AcceptConnectionsPolicyTrace (..)
   , TraceSendRecv (..)
   , SubscriptionTrace (..)
   , DnsTrace (..)

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -145,6 +145,7 @@ demo chain0 updates = withIOManager $ \iocp -> do
       (socketSnocket iocp)
       nullNetworkServerTracers
       networkState
+      (AcceptedConnectionsLimit maxBound maxBound 0)
       producerAddress
       cborTermVersionDataCodec
       (\(DictVersion _) -> acceptableVersion)


### PR DESCRIPTION
This pr implements a policy which allows us to limit the number of accepted connections, addressing the issue #1391.

There are two thresholds:
- `acceptedConnectionsHardLimit`
- `acceptedConnectionsSoftLimit`
And a delay
- `acceptedConnectionsDelay`

If we are below the soft limit, we accept connections without any delay;
Above the *soft limit*, we start rate limiting using a linear regression of the `acceptedConnectionsDelay`.
If we hit the hard limit, then we wait until the number of connections drops
(but not shorted than `acceptedConnectionsDelay`).   (We could add a third
threshold to drop below that, but we should be good for now with this policy).

This is a standalone component, so it will be easy to bring it to
`connection-manager`.

Todo:
- [x] add a trace