### PR TITLE
Move IOManager to Win32-network

### DIFF
--- a/Win32-network/Win32-network.cabal
+++ b/Win32-network/Win32-network.cabal
@@ -22,7 +22,8 @@ flag demo
 library
   hs-source-dirs:      src
   if os(windows)
-    exposed-modules:   System.Win32.NamedPipes
+    exposed-modules:   System.IOManager
+                       System.Win32.NamedPipes
                        System.Win32.Async
                        System.Win32.Async.File
                        System.Win32.Async.ErrCode
@@ -40,6 +41,12 @@ library
                        network           >= 3.1  && < 3.2,
                        Win32             >= 2.5.4.1
     extra-libraries:   ws2_32
+
+  else
+
+    exposed-modules:   System.IOManager
+    build-depends:     base              >= 4.5  && < 4.13
+
   default-language:    Haskell2010
   ghc-options:         -Wall
 
@@ -63,8 +70,10 @@ test-suite test-Win32-network
   hs-source-dirs:      test
   main-is:             Main.hs
   default-language:    Haskell2010
-  ghc-options:         -Wall
-                       -threaded
+  if os(windows)
+    buildable: True
+  else
+    buildable: False
   if os(windows)
     other-modules:       Test.Generators
                          Test.Async.PingPong
@@ -83,5 +92,5 @@ test-suite test-Win32-network
                          quickcheck-instances,
                          Win32,
                          Win32-network
-  else
-    build-depends:       base
+  ghc-options:          -Wall
+                        -threaded

--- a/Win32-network/Win32-network.cabal
+++ b/Win32-network/Win32-network.cabal
@@ -30,6 +30,7 @@ library
                        System.Win32.Async.Socket
                        System.Win32.Async.Socket.ByteString
                        System.Win32.Async.Socket.ByteString.Lazy
+                       System.Win32.Async.Internal
     other-modules:     System.Win32.Async.IOData
                        System.Win32.Async.IOManager
                        System.Win32.Async.Overlapped

--- a/Win32-network/Win32-network.cabal
+++ b/Win32-network/Win32-network.cabal
@@ -27,11 +27,11 @@ library
                        System.Win32.Async
                        System.Win32.Async.File
                        System.Win32.Async.ErrCode
-                       System.Win32.Async.IOManager
                        System.Win32.Async.Socket
                        System.Win32.Async.Socket.ByteString
                        System.Win32.Async.Socket.ByteString.Lazy
     other-modules:     System.Win32.Async.IOData
+                       System.Win32.Async.IOManager
                        System.Win32.Async.Overlapped
                        System.Win32.Async.Socket.Syscalls
                        System.Win32.Async.WSABuf

--- a/Win32-network/src/System/IOManager.hs
+++ b/Win32-network/src/System/IOManager.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE CPP        #-}
+{-# LANGUAGE RankNTypes #-}
+
+-- | A shim layer for `Win32-network`'s `IOManager`
+--
+module System.IOManager
+  ( WithIOManager
+  , IOManager (..)
+  , withIOManager
+  ) where
+
+
+#if defined(mingw32_HOST_OS)
+import System.Win32.Types (HANDLE)
+import qualified System.Win32.Async.IOManager as Win32.Async
+import Network.Socket (Socket)
+#endif
+
+-- | On Windows 'AssociateWithIOCP' holds
+-- `System.Win32.Async.IOManager.associateWithIOCompletionPort';
+-- on other platforms 'AssociateWithIOCP' can run over any type, and thus is
+-- guaranteed to be no-op.
+--
+#if defined(mingw32_HOST_OS)
+newtype IOManager = IOManager {
+    associateWithIOCP :: Either HANDLE Socket -> IO ()
+  }
+#else
+newtype IOManager = IOManager {
+    associateWithIOCP :: forall hole. hole -> IO ()
+  }
+#endif
+
+
+type WithIOManager = forall a. (IOManager -> IO a) -> IO a
+
+
+-- | 'withIOManger' must be called only once at the top level.  We wrap the
+-- 'associateWithIOCompletionPort' in a newtype wrapper since it will be
+-- carried arround through the application.
+--
+withIOManager :: WithIOManager
+#if defined(mingw32_HOST_OS)
+withIOManager = \f ->
+  Win32.Async.withIOManager $
+    \iocp -> f (IOManager $ \fd -> Win32.Async.associateWithIOCompletionPort fd iocp)
+#else
+withIOManager = \f -> f (IOManager $ \_ -> pure ())
+#endif

--- a/Win32-network/src/System/IOManager.hs
+++ b/Win32-network/src/System/IOManager.hs
@@ -7,6 +7,10 @@ module System.IOManager
   ( WithIOManager
   , IOManager (..)
   , withIOManager
+
+  -- * Deprecated API
+  , AssociateWithIOCP
+  , associateWithIOCP
   ) where
 
 
@@ -16,21 +20,32 @@ import qualified System.Win32.Async.IOManager as Win32.Async
 import Network.Socket (Socket)
 #endif
 
--- | On Windows 'AssociateWithIOCP' holds
--- `System.Win32.Async.IOManager.associateWithIOCompletionPort';
--- on other platforms 'AssociateWithIOCP' can run over any type, and thus is
+-- | This is public api to interact with the io manager; On Windows 'IOManager'
+-- holds 'System.Win32.Async.IOManager.associateWithIOCompletionPort';
+-- on other platforms 'IOManager' can run over any type, and thus is
 -- guaranteed to be no-op.
 --
 #if defined(mingw32_HOST_OS)
 newtype IOManager = IOManager {
-    associateWithIOCP :: Either HANDLE Socket -> IO ()
+    associateWithIOManager :: Either HANDLE Socket -> IO ()
   }
+
+associateWithIOCP :: IOManager -> Either HANDLE Socket -> IO ()
+associateWithIOCP = associateWithIOManager
+
 #else
 newtype IOManager = IOManager {
-    associateWithIOCP :: forall hole. hole -> IO ()
+    associateWithIOManager :: forall hole. hole -> IO ()
   }
+
+associateWithIOCP :: forall hole. IOManager -> hole -> IO ()
+associateWithIOCP = associateWithIOManager
 #endif
 
+type AssociateWithIOCP = IOManager
+{-# DEPRECATED AssociateWithIOCP "Usage of type alias AssociateWithIOCP is deprecated, use 'IOManager' instead " #-}
+
+{-# DEPRECATED associateWithIOCP "Usage of 'associateWithIOCP' is deprecated, use 'associateWithIOManager' instead." #-}
 
 type WithIOManager = forall a. (IOManager -> IO a) -> IO a
 

--- a/Win32-network/src/System/Win32/Async.hs
+++ b/Win32-network/src/System/Win32/Async.hs
@@ -6,11 +6,9 @@
 module System.Win32.Async
   ( module System.Win32.Async.File
   , module System.Win32.Async.ErrCode
-  , module System.Win32.Async.IOManager
   , module System.Win32.Async.Socket
   ) where
 
-import System.Win32.Async.IOManager
 import System.Win32.Async.File
 import System.Win32.Async.ErrCode
 import System.Win32.Async.Socket

--- a/Win32-network/src/System/Win32/Async/Internal.hs
+++ b/Win32-network/src/System/Win32/Async/Internal.hs
@@ -1,0 +1,10 @@
+-- | This module exposed internals of 'System.Win32.Async.IOManager' for
+-- testing purposes, use 'System.IOManager' instead.
+--
+module System.Win32.Async.Internal
+  ( createIOCompletionPort
+  , closeIOCompletionPort
+  , dequeueCompletionPackets
+  ) where
+
+import System.Win32.Async.IOManager

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -65,6 +65,7 @@ library
                      , network         >= 3.1
                      , network-mux     >= 0.1 && < 0.2
                      , contra-tracer
+                     , Win32-network   >= 0.1 && < 0.2
                      , dns
                      , iproute
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/IOManager.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/IOManager.hs
@@ -4,46 +4,7 @@
 -- | A shim layer for `Win32-network`'s `IOManager`
 --
 module Ouroboros.Network.IOManager
-  ( WithIOManager
-  , AssociateWithIOCP (..)
-  , withIOManager
+  ( module X
   ) where
 
-
-#if defined(mingw32_HOST_OS)
-import System.Win32.Types (HANDLE)
-import qualified System.Win32.Async.IOManager as Win32.Async
-import Network.Socket (Socket)
-#endif
-
--- | On Windows 'AssociateWithIOCP' holds
--- `System.Win32.Async.IOManager.associateWithIOCompletionPort';
--- on other platforms 'AssociateWithIOCP' can run over any type, and thus is
--- guaranteed to be no-op.
---
-#if defined(mingw32_HOST_OS)
-newtype AssociateWithIOCP = AssociateWithIOCP {
-    associateWithIOCP :: Either HANDLE Socket -> IO ()
-  }
-#else
-newtype AssociateWithIOCP = AssociateWithIOCP {
-    associateWithIOCP :: forall hole. hole -> IO ()
-  }
-#endif
-
-
-type WithIOManager = forall a. (AssociateWithIOCP -> IO a) -> IO a
-
-
--- | 'withIOManger' must be called only once at the top level.  We wrap the
--- 'associateWithIOCompletionPort' in a newtype wrapper since it will be
--- carried arround through the application.
---
-withIOManager :: WithIOManager
-#if defined(mingw32_HOST_OS)
-withIOManager = \f ->
-  Win32.Async.withIOManager $
-    \iocp -> f (AssociateWithIOCP $ \fd -> Win32.Async.associateWithIOCompletionPort fd iocp)
-#else
-withIOManager = \f -> f (AssociateWithIOCP $ \_ -> pure ())
-#endif
+import System.IOManager as X

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -97,7 +97,7 @@ import           Ouroboros.Network.Subscription.PeerState
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.Protocol.Handshake.Codec
-import           Ouroboros.Network.IOManager (AssociateWithIOCP)
+import           Ouroboros.Network.IOManager (IOManager)
 import           Ouroboros.Network.Snocket (Snocket)
 import qualified Ouroboros.Network.Snocket as Snocket
 import           Ouroboros.Network.Server.Socket ( AcceptedConnectionsLimit (..)
@@ -262,7 +262,7 @@ connectToNodeSocket
      , Show vNumber
      , Mx.HasInitiator appType ~ True
      )
-  => AssociateWithIOCP
+  => IOManager
   -> VersionDataCodec extra CBOR.Term
   -> NetworkConnectTracers Socket.SockAddr vNumber
   -> Versions vNumber extra

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -42,6 +42,7 @@ module Ouroboros.Network.NodeToClient (
   , localTxSubmissionClientNull
 
   -- * Re-exported network interface
+  , IOManager (..)
   , AssociateWithIOCP
   , withIOManager
   , LocalSnocket

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -100,7 +100,7 @@ demo chain0 updates = do
 -- posix anonymous pipes.
 #if defined(mingw32_HOST_OS)
   -- using named pipe
-  Win32.Async.withIOManager $ \iocp ->
+  withIOManager $ \ioManager ->
     let pipeName = "\\\\.\\pipe\\demo-pipe" in
     bracket
       ((,) <$> Win32.NamedPipes.createNamedPipe
@@ -124,9 +124,9 @@ demo chain0 updates = do
                  Nothing)
       (\(namedPipe, file) -> Win32.closeHandle namedPipe >> Win32.closeHandle file)
       $ \ (namedPipe, file) -> do
-        Win32.Async.associateWithIOCompletionPort (Left namedPipe)  iocp
+        associateWithIOManager ioManager (Left namedPipe)
         Win32.Async.connectNamedPipe namedPipe
-        Win32.Async.associateWithIOCompletionPort (Left file) iocp
+        associateWithIOManager ioManager (Left file)
         let chan1 = Mx.pipeChannelFromNamedPipe namedPipe
             chan2 = Mx.pipeChannelFromNamedPipe file
 #else


### PR DESCRIPTION
`IOManager` allows to build platform independent applications on top of
`Win32-network`.  This is preliminary work for making `ntp-client` run on
windows using `Win32-network`.

The PR contains graceful `DEPRECATATION` pragmas for old api.
