### PR TITLE
Bump dependency on cardano-ledger-specs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -159,43 +159,43 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 28b4381461252b523473972c85b003301a5deadc
-  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
+  tag: 156086266486da710c5037c11f83d2112434926f
+  --sha256: 1wp4n39k4i3rnkn0cnhwlfkdj73zml58957mjrxb40q2ngjl4ydw
   subdir: byron/semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 28b4381461252b523473972c85b003301a5deadc
-  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
+  tag: 156086266486da710c5037c11f83d2112434926f
+  --sha256: 1wp4n39k4i3rnkn0cnhwlfkdj73zml58957mjrxb40q2ngjl4ydw
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 28b4381461252b523473972c85b003301a5deadc
-  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
+  tag: 156086266486da710c5037c11f83d2112434926f
+  --sha256: 1wp4n39k4i3rnkn0cnhwlfkdj73zml58957mjrxb40q2ngjl4ydw
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 28b4381461252b523473972c85b003301a5deadc
-  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
+  tag: 156086266486da710c5037c11f83d2112434926f
+  --sha256: 1wp4n39k4i3rnkn0cnhwlfkdj73zml58957mjrxb40q2ngjl4ydw
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 28b4381461252b523473972c85b003301a5deadc
-  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
+  tag: 156086266486da710c5037c11f83d2112434926f
+  --sha256: 1wp4n39k4i3rnkn0cnhwlfkdj73zml58957mjrxb40q2ngjl4ydw
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 28b4381461252b523473972c85b003301a5deadc
-  --sha256: 1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk
+  tag: 156086266486da710c5037c11f83d2112434926f
+  --sha256: 1wp4n39k4i3rnkn0cnhwlfkdj73zml58957mjrxb40q2ngjl4ydw
   subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package

--- a/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
+++ b/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
@@ -69,8 +69,9 @@ test_golden_Block :: Assertion
 test_golden_Block = goldenTestCBOR
     toCBOR
     exampleBlock
-    [ TkListLen 19
-    , TkBytes "R]\STX\193"
+    [ TkListLen 4
+    , TkListLen 16
+    , TkBytes "2&\SOH9"
     , TkInt 1677861428
     , TkInt 1239952560
     , TkInt 20
@@ -78,12 +79,12 @@ test_golden_Block = goldenTestCBOR
     , TkInt 2
     , TkListLen 2
     , TkInt 1239952560
-    , TkInteger 41946005475178663182620722476359969013
+    , TkInteger 155720561651862627124907358847946323278
     , TkListLen 2
     , TkInt 0
     , TkListLen 2
     , TkInt 1239952560
-    , TkInteger 105192313543810009112138634467866559854
+    , TkInteger 132220243341478360044794887852609007894
     , TkInt 194
     , TkInt 2
     , TkBytes "\159\SYN\n5"
@@ -96,7 +97,7 @@ test_golden_Block = goldenTestCBOR
     , TkInt 0
     , TkInt 0
     , TkListLen 2
-    , TkInteger 205434739841108429842581223023660727856
+    , TkInteger 191398642502988321904034898986188660442
     , TkListLen 3
     , TkInt 42768536
     , TkInt 1
@@ -167,7 +168,7 @@ test_golden_Header = goldenTestCBOR
     toCBOR
     (getHeader exampleBlock)
     [ TkListLen 16
-    , TkBytes "R]\STX\193"
+    , TkBytes "2&\SOH9"
     , TkInt 1677861428
     , TkInt 1239952560
     , TkInt 20
@@ -175,12 +176,12 @@ test_golden_Header = goldenTestCBOR
     , TkInt 2
     , TkListLen 2
     , TkInt 1239952560
-    , TkInteger 41946005475178663182620722476359969013
+    , TkInteger 155720561651862627124907358847946323278
     , TkListLen 2
     , TkInt 0
     , TkListLen 2
     , TkInt 1239952560
-    , TkInteger 105192313543810009112138634467866559854
+    , TkInteger 132220243341478360044794887852609007894
     , TkInt 194
     , TkInt 2
     , TkBytes "\159\SYN\n5"
@@ -193,7 +194,7 @@ test_golden_Header = goldenTestCBOR
     , TkInt 0
     , TkInt 0
     , TkListLen 2
-    , TkInteger 205434739841108429842581223023660727856
+    , TkInteger 191398642502988321904034898986188660442
     , TkListLen 3
     , TkInt 42768536
     , TkInt 1
@@ -204,7 +205,7 @@ test_golden_HeaderHash :: Assertion
 test_golden_HeaderHash = goldenTestCBOR
     toCBOR
     (blockHash exampleBlock)
-    [ TkBytes ")?eL"
+    [ TkBytes "\135\233S4"
     ]
 
 test_golden_GenTx :: Assertion
@@ -459,7 +460,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkListLen 3
     , TkListLen 2
     , TkInt 10
-    , TkBytes "5\246\240\SUB"
+    , TkBytes "\195\213\vX"
     , TkListLen 2
     , TkListLen 1
     , TkInt 0

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,7 +49,7 @@ extra-deps:
       - slotting
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 28b4381461252b523473972c85b003301a5deadc
+    commit: 156086266486da710c5037c11f83d2112434926f
     subdirs:
       - byron/chain/executable-spec
       - byron/ledger/executable-spec


### PR DESCRIPTION
This incorporates:
* cardano-ledger-specs#1313 which simplifies our implementation of
  `shelleyAddHeaderEnvelope`.
* cardano-ledger-specs#1342 which fixes a generator that sometimes caused a
  serialisation roundtrip property test to fail (see
  https://hydra.iohk.io/build/2157662/nixlog/28).