### PR TITLE
Don't wait forever in TokNext TokMustReply

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -759,6 +759,7 @@ runThreadNetwork ThreadNetworkArgs
                   -- node
                   nullDebugProtocolTracers
                   (customProtocolCodecs pInfoConfig)
+                  Nothing
                   (protocolHandlers nodeArgs nodeKernel)
 
       -- In practice, a robust wallet/user can persistently add a transaction

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -209,6 +209,8 @@ run tracers protocolTracers chainDbTracer diffusionTracers diffusionArguments
       nodeKernel
       protocolTracers
       (protocolCodecs (getTopLevelConfig nodeKernel) version)
+      (Just 70) -- timeout after waiting this long for the next header
+                -- 70s allows for 3 slots (3 * 20s)
       (protocolHandlers nodeArgs nodeKernel)
 
     mkDiffusionApplications

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
@@ -50,16 +50,16 @@ byteLimitsChainSync = ProtocolSizeLimits stateToLimit
 --
 -- `TokIdle`  No timeout
 -- `TokNext TokCanAwait` `longWait` timeout
--- `TokNext TokMustReply` No timeout
--- `TokIntersect` `longWait timeout
-timeLimitsChainSync :: ProtocolTimeLimits (ChainSync header tip)
-timeLimitsChainSync = ProtocolTimeLimits stateToLimit
+-- `TokNext TokMustReply` consensusTimeout timeout
+-- `TokIntersect` `longWait` timeout
+timeLimitsChainSync :: Maybe DiffTime -> ProtocolTimeLimits (ChainSync header tip)
+timeLimitsChainSync consensusTimeout = ProtocolTimeLimits stateToLimit
   where
     stateToLimit :: forall (pr :: PeerRole) (st :: ChainSync header tip).
                     PeerHasAgency pr st -> Maybe DiffTime
     stateToLimit (ClientAgency TokIdle)                = waitForever
     stateToLimit (ServerAgency (TokNext TokCanAwait))  = shortWait
-    stateToLimit (ServerAgency (TokNext TokMustReply)) = waitForever
+    stateToLimit (ServerAgency (TokNext TokMustReply)) = consensusTimeout
     stateToLimit (ServerAgency TokIntersect)           = shortWait
 
 -- | The main CBOR 'Codec' for the 'ChainSync' protocol.


### PR DESCRIPTION
In the (TokNext TokMustReply) state the responder has indicated that it
currently doesn't have a new tip for us and we should wait.
This patch limits the time we wait to 70s which means that we don't end
up waiting forever incase of network problems.