### PR TITLE
Use sensible buffer sizes for Windows named pipes

### DIFF
--- a/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
@@ -308,10 +308,10 @@ namedPipeSnocket ioManager path = Snocket {
                    (Win32.pIPE_ACCESS_DUPLEX .|. Win32.fILE_FLAG_OVERLAPPED)
                    (Win32.pIPE_TYPE_BYTE .|. Win32.pIPE_READMODE_BYTE)
                    Win32.pIPE_UNLIMITED_INSTANCES
-                   maxBound
-                   maxBound
-                   0
-                   Nothing
+                   65536   -- outbound pipe size
+                   16384   -- inbound pipe size
+                   0       -- default timeout
+                   Nothing -- default security
         associateWithIOManager ioManager (Left hpipe)
           `catch` \(e :: IOException) -> do
             Win32.closeHandle hpipe
@@ -363,10 +363,10 @@ namedPipeSnocket ioManager path = Snocket {
                  (Win32.pIPE_ACCESS_DUPLEX .|. Win32.fILE_FLAG_OVERLAPPED)
                  (Win32.pIPE_TYPE_BYTE .|. Win32.pIPE_READMODE_BYTE)
                  Win32.pIPE_UNLIMITED_INSTANCES
-                 maxBound
-                 maxBound
-                 0
-                 Nothing
+                 65536   -- outbound pipe size
+                 16384   -- inbound pipe size
+                 0       -- default timeout
+                 Nothing -- default security
               `catch` \(e :: IOException) -> do
                  putStrLn $ "accept: " ++ show e
                  throwIO e


### PR DESCRIPTION
When creating a Windows named pipe one has to specify the buffer sizes. Previously we were specifying the maximum size, however this is unwise:

The MSDN docs say:

> The input and output buffer sizes are advisory. The actual buffer size reserved for each end of the named pipe is either the system default, the system minimum or maximum, or the specified size rounded up to the next allocation boundary. The buffer size specified should be small enough that your process will not run out of nonpaged pool, but large enough to accommodate typical requests.

So this changes the values to 64k outbound and 16k inbound.