### PR TITLE
Add timeout around dns lookups

### DIFF
--- a/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Worker.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Worker.hs
@@ -243,10 +243,10 @@ subscriptionLoop
     -- outer loop: set new 'conThread' variable, get targets and traverse
     -- through them trying to connect to each addr.
     forever $ do
+      traceWith tr (SubscriptionTraceStart valency)
       start <- getMonotonicTime
       conThreads <- atomically $ newTVar Set.empty
       sTarget <- subscriptionTargets
-      traceWith tr (SubscriptionTraceStart valency)
       innerLoop conThreads valencyVar sTarget
       atomically $ waitValencyCounter valencyVar
 


### PR DESCRIPTION
This adds 20s timeout, the dns library is by deafult using 3s timeout.  We
could experiment more with smaller timeouts.

Fixes #1873

- Add 20s timeout around dns lookup.
- Moved SubscriptionTraceStart mesage
