### PR TITLE
Update to latest cardano-ledger-specs

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -70,6 +70,9 @@ import qualified Ouroboros.Consensus.Shelley.Protocol.State as State
 -------------------------------------------------------------------------------}
 
 data TPraosLeaderCredentials c = TPraosLeaderCredentials {
+    -- | Signing KES key. Note that this is not inside 'TPraosIsCoreNode' since
+    --   it gets evolved automatically, whereas 'TPraosIsCoreNode' does not
+    --   change.
     tpraosLeaderCredentialsSignKey    :: SignKeyKES (KES c)
   , tpraosLeaderCredentialsIsCoreNode :: TPraosIsCoreNode c
   }


### PR DESCRIPTION
Slightly mixed PR:

- Adds a comment explaining the confusion I had in a meeting this morning
- Updates to the latest cardano-ledger-specs, which means we can drop the requirement for an initial "previous key hash" in nonce calculations.