### PR TITLE
connect for named pipes

### DIFF
--- a/Win32-network/src/System/Win32/NamedPipes.hsc
+++ b/Win32-network/src/System/Win32/NamedPipes.hsc
@@ -3,8 +3,6 @@
 
 {-# LANGUAGE CPP                #-}
 {-# LANGUAGE BangPatterns       #-}
-{-# LANGUAGE CApiFFI            #-}
-{-# LANGUAGE InterruptibleFFI   #-}
 {-# LANGUAGE MultiWayIf         #-}
 {-# LANGUAGE NumericUnderscores #-}
 

--- a/Win32-network/src/System/Win32/NamedPipes.hsc
+++ b/Win32-network/src/System/Win32/NamedPipes.hsc
@@ -40,10 +40,6 @@ module System.Win32.NamedPipes (
     TimeOut,
     nMPWAIT_USE_DEFAULT_WAIT,
     nMPWAIT_WAIT_FOREVER,
-
-    -- ** create named pipe
-    -- | This directly reuses other Win32 file APIs
-    createFile
   ) where
 
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
@@ -323,7 +323,7 @@ namedPipeSnocket ioManager path = Snocket {
 
     -- To connect, simply create a file whose name is the named pipe name.
     , openToConnect  = \(LocalAddress pipeName) -> do
-        hpipe <- Win32.createFile pipeName
+        hpipe <- Win32.connect pipeName
                    (Win32.gENERIC_READ .|. Win32.gENERIC_WRITE )
                    Win32.fILE_SHARE_NONE
                    Nothing

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -115,7 +115,7 @@ demo chain0 updates = do
                   maxBound
                   0
                   Nothing
-           <*> Win32.NamedPipes.createFile
+           <*> Win32.NamedPipes.connect
                  pipeName
                  (Win32.gENERIC_READ .|. Win32.gENERIC_WRITE)
                  (Win32.fILE_SHARE_NONE)


### PR DESCRIPTION
`connect` as designed in
[https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipe-client](MSDN's
named-pipe-client).

- Win32-netork: do not re-export createFile from NamedPipes module
- Added System.Win32.NamedPipe.connect
- Added waitNamedPipe Win32 syscall
- Modify demo-chain-sync

There's more than needed, I'll need to rebase this branch when #1876 gets
merged to get rid of this patches:
- Use sensible buffer sizes for Windows named pipes
