### PR TITLE
Update for Hash representation change

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -131,29 +131,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f869bee9b08ba1044b1476737c9d65083e1c6c7f
-  --sha256: 0df3bdf13cwx3hd8n4q53g9hybb0w8mh837y64ydd88xhdfaf6a3
+  tag: 742a789a520387c6cd30a4ca28bc4fc8588a41c7
+  --sha256: 0zqar90z7hdklxcimfxb2dmk0cq43bywa7p255hynn7ss0nxszz6
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f869bee9b08ba1044b1476737c9d65083e1c6c7f
-  --sha256: 0df3bdf13cwx3hd8n4q53g9hybb0w8mh837y64ydd88xhdfaf6a3
+  tag: 742a789a520387c6cd30a4ca28bc4fc8588a41c7
+  --sha256: 0zqar90z7hdklxcimfxb2dmk0cq43bywa7p255hynn7ss0nxszz6
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f869bee9b08ba1044b1476737c9d65083e1c6c7f
-  --sha256: 0df3bdf13cwx3hd8n4q53g9hybb0w8mh837y64ydd88xhdfaf6a3
+  tag: 742a789a520387c6cd30a4ca28bc4fc8588a41c7
+  --sha256: 0zqar90z7hdklxcimfxb2dmk0cq43bywa7p255hynn7ss0nxszz6
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: f869bee9b08ba1044b1476737c9d65083e1c6c7f
-  --sha256: 0df3bdf13cwx3hd8n4q53g9hybb0w8mh837y64ydd88xhdfaf6a3
+  tag: 742a789a520387c6cd30a4ca28bc4fc8588a41c7
+  --sha256: 0zqar90z7hdklxcimfxb2dmk0cq43bywa7p255hynn7ss0nxszz6
   subdir: slotting
 
 source-repository-package
@@ -207,29 +207,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 512c26a66a6a63278846646b81bf8eadcd4ae99c
-  --sha256: 117fx48g459n80s42hmcbgraq6ham98cbisr82z96ghlwn8y31sa
+  tag: 53ca3542019824d169378fa36a842eb4659b7ceb
+  --sha256: 1mwqcqfnxy14hs8g7x3q0ws3bhsmfhxpv8h7xf6r466n246fi83k
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 512c26a66a6a63278846646b81bf8eadcd4ae99c
-  --sha256: 117fx48g459n80s42hmcbgraq6ham98cbisr82z96ghlwn8y31sa
+  tag: 53ca3542019824d169378fa36a842eb4659b7ceb
+  --sha256: 1mwqcqfnxy14hs8g7x3q0ws3bhsmfhxpv8h7xf6r466n246fi83k
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 512c26a66a6a63278846646b81bf8eadcd4ae99c
-  --sha256: 117fx48g459n80s42hmcbgraq6ham98cbisr82z96ghlwn8y31sa
+  tag: 53ca3542019824d169378fa36a842eb4659b7ceb
+  --sha256: 1mwqcqfnxy14hs8g7x3q0ws3bhsmfhxpv8h7xf6r466n246fi83k
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 512c26a66a6a63278846646b81bf8eadcd4ae99c
-  --sha256: 117fx48g459n80s42hmcbgraq6ham98cbisr82z96ghlwn8y31sa
+  tag: 53ca3542019824d169378fa36a842eb4659b7ceb
+  --sha256: 1mwqcqfnxy14hs8g7x3q0ws3bhsmfhxpv8h7xf6r466n246fi83k
   subdir: crypto/test
 
 source-repository-package

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,7 @@ extra-deps:
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: f869bee9b08ba1044b1476737c9d65083e1c6c7f
+    commit: 742a789a520387c6cd30a4ca28bc4fc8588a41c7
     subdirs:
       - binary
       - binary/test
@@ -65,7 +65,7 @@ extra-deps:
   - gray-code-0.3.1
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 512c26a66a6a63278846646b81bf8eadcd4ae99c
+    commit: 53ca3542019824d169378fa36a842eb4659b7ceb
     subdirs:
       - cardano-ledger
       - cardano-ledger/test


### PR DESCRIPTION
The AbstractHash type is now actually abstract, in the ADT sense. So use the appropriate functions since we cannot get at the constructor any more.