### PR TITLE
Reinit the dns lib before each call

### DIFF
--- a/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Dns.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Dns.hs
@@ -211,6 +211,10 @@ dnsResolve tracer getSeed withResolver peerStatesVar beforeConnect (DnsSubscript
              Just addrs -> listTargets (Left addrs) (Left a)
              Nothing    -> listTargets (Left a) (Right addrsVar)
 
+    resolveAAAA :: Resolver m
+                -> StrictTVar m Bool
+                -> StrictTMVar m [Socket.SockAddr]
+                -> m (Maybe DNS.DNSError)
     resolveAAAA resolver gotIpv6RspVar rspsVar = do
         r_e <- lookupAAAA resolver domain
         case r_e of
@@ -227,7 +231,10 @@ dnsResolve tracer getSeed withResolver peerStatesVar beforeConnect (DnsSubscript
                  atomically $ writeTVar gotIpv6RspVar True
                  return Nothing
 
-    resolveA :: Resolver m -> StrictTVar m Bool -> StrictTMVar m [Socket.SockAddr] -> m (Maybe DNS.DNSError)
+    resolveA :: Resolver m
+             -> StrictTVar m Bool
+             -> StrictTMVar m [Socket.SockAddr]
+             -> m (Maybe DNS.DNSError)
     resolveA resolver gotIpv6RspVar rspsVar= do
         r_e <- lookupA resolver domain
         case r_e of

--- a/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Dns.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Dns.hs
@@ -112,7 +112,9 @@ dnsResolve tracer getSeed withResolver peerStatesVar beforeConnect (DnsSubscript
         -- Though the DNS lib does have its own timeouts, these do not work
         -- on Windows reliably so as a workaround we add an extra layer
         -- of timeout on the outside.
-        -- TODO: fix upstream dns lib
+        -- TODO: Fix upstream dns lib.
+        --       On windows the aid_ipv6 and aid_ipv4 threads are leaked incase
+        --       of an exception in the main thread.
         res <- timeout 20 $ do
                  aid_ipv6 <- async $ resolveAAAA resolver gotIpv6Rsp ipv6Rsps
                  aid_ipv4 <- async $ resolveA resolver gotIpv6Rsp ipv4Rsps


### PR DESCRIPTION
The dns library only reads /etc/resolv.conf once which means that inorder to
cope with changing networks conditions we need to reinit the library
before each use.

Workaround for the bug reported in https://github.com/input-output-hk/cardano-node/issues/731 