### PR TITLE
Change how IOManager is handling exceptions

### DIFF
--- a/Win32-network/src/System/IOManager.hs
+++ b/Win32-network/src/System/IOManager.hs
@@ -62,9 +62,17 @@ type AssociateWithIOCP = IOManager
 type WithIOManager = forall a. (IOManager -> IO a) -> IO a
 
 
--- | 'withIOManger' must be called only once at the top level.  We wrap the
--- 'associateWithIOCompletionPort' in a newtype wrapper since it will be
--- carried arround through the application.
+-- | 'withIOManager' allows to do asynchronous io on Windows hiding the
+-- differences between posix and Win32.
+--
+-- It starts an io manger thread, which should be only one running at a time, so
+-- the best place to call it is very close to the 'main' function and last for
+-- duration of the application.
+--
+-- Async 'IO' operatitions which are using the 'iocp' port should not leak
+-- out-side of 'withIOManager'.  They will be silently cancelled when
+-- 'withIOManager' exists.  In particular one should not return 'IOManager'
+-- from 'withIOManager'.
 --
 withIOManager :: WithIOManager
 #if defined(mingw32_HOST_OS)

--- a/Win32-network/src/System/IOManager.hs
+++ b/Win32-network/src/System/IOManager.hs
@@ -1,11 +1,15 @@
 {-# LANGUAGE CPP        #-}
 {-# LANGUAGE RankNTypes #-}
 
+-- we are exporting `Void` with constructors
+{-# OPTIONS_GHC -Wno-dodgy-exports #-}
+
 -- | A shim layer for `Win32-network`'s `IOManager`
 --
 module System.IOManager
   ( WithIOManager
   , IOManager (..)
+  , IOManagerError (..)
   , withIOManager
 
   -- * Deprecated API
@@ -18,6 +22,14 @@ module System.IOManager
 import System.Win32.Types (HANDLE)
 import qualified System.Win32.Async.IOManager as Win32.Async
 import Network.Socket (Socket)
+#else
+import Data.Void (Void)
+#endif
+
+#if defined(mingw32_HOST_OS)
+type IOManagerError = Win32.Async.IOManagerError
+#else
+type IOManagerError = Void
 #endif
 
 -- | This is public api to interact with the io manager; On Windows 'IOManager'

--- a/Win32-network/test/Test/Async/Socket.hs
+++ b/Win32-network/test/Test/Async/Socket.hs
@@ -50,14 +50,14 @@ tests =
   , testProperty "sendTo and recvFrom"
       (ioProperty . prop_sendTo_recvFrom)
   , testProperty "PingPong test"
-      $ withMaxSuccess 100 prop_PingPong
+      prop_PingPong
   , testProperty "PingPongPipelined test"
-      $ withMaxSuccess 100 prop_PingPongPipelined
+      prop_PingPongPipelined
   , testGroup "vectored io"
     [ testProperty "PingPong test"
-        $ withMaxSuccess 100 prop_PingPongLazy
+        prop_PingPongLazy
     , testProperty "PingPongPipelined test"
-        $ withMaxSuccess 100 prop_PingPongPipelinedLazy
+        prop_PingPongPipelinedLazy
     ]
   ]
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -439,6 +439,12 @@ networkErrorPolicies = ErrorPolicies
                       MuxBearerClosed         -> Just (SuspendPeer shortDelay shortDelay)
                       MuxIOException{}        -> Just (SuspendPeer shortDelay shortDelay)
                       MuxSDUReadTimeout       -> Just (SuspendPeer shortDelay shortDelay)
+
+        -- Error thrown by 'IOManager', this is fatal on Windows, and it will
+        -- never fire on other platofrms.
+      , ErrorPolicy
+          $ \(_ :: IOManagerError)
+                -> Just Throw
       ]
     , epConErrorPolicies = [
         -- If an 'IOException' is thrown by the 'connect' call we suspend the
@@ -446,6 +452,10 @@ networkErrorPolicies = ErrorPolicies
         -- period.
         ErrorPolicy $ \(_ :: IOException) -> Just $
           SuspendPeer shortDelay shortDelay
+
+      , ErrorPolicy
+          $ \(_ :: IOManagerError)
+                -> Just Throw
       ]
     }
   where

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -100,6 +100,7 @@ import qualified Network.Socket as Socket
 
 import           Ouroboros.Network.Driver (TraceSendRecv(..))
 import           Ouroboros.Network.Driver.Limits (ProtocolLimitFailure)
+import           Ouroboros.Network.IOManager
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.Magic
 import           Ouroboros.Network.ErrorPolicy
@@ -735,6 +736,12 @@ remoteNetworkErrorPolicy = ErrorPolicies {
         , ErrorPolicy
             $ \(_ :: BlockFetchProtocolFailure)
                   -> Just theyBuggyOrEvil
+
+          -- Error thrown by 'IOManager', this is fatal on Windows, and it will
+          -- never fire on other platofrms.
+        , ErrorPolicy
+            $ \(_ :: IOManagerError)
+                  -> Just Throw
         ],
 
       -- Exception raised during connect; suspend connecting to that peer for
@@ -742,6 +749,10 @@ remoteNetworkErrorPolicy = ErrorPolicies {
       epConErrorPolicies = [
           ErrorPolicy $ \(_ :: IOException) -> Just $
             SuspendConsumer shortDelay
+
+        , ErrorPolicy
+            $ \(_ :: IOManagerError)
+                  -> Just Throw
         ]
     }
   where


### PR DESCRIPTION
With this patch `withIOManager` will rethrown the exception thrown when
`LPOVERLAPPED` was null.  This wasn't the case previously which was a mistake.

I also documented better (an experiment a bit more) with one particular case:
why we are not throwing exceptions when the `LPOVERLAPPED` is `NULL` and
`GetQueuedIoCompletionStatus` errored with `ERROR_INVALID_HANDLE`.  I can
reproduce this scenario when we close the iocp's `HANDLE`, but only in some
circumstances e.g. running the same test twice or more.  The first time
`dequeueCompletionPackets` exists cleanly (i.e. `GetQueuedIoCompletionStatus`
errors with `ERROR_ABANDONDED_WAIT_0`) and the next one errors with
`ERROR_INVALID_HANDLE`).  This behaviour is not documented in `MSDN`.

Also label the `IOManager` thread, which is useful for profiling with the
eventlog.

- withIOManager use IOException
- Removed withMaxSuccess from tests
- Label the IOManager thread
