### PR TITLE
Pass the ticked ledger to (re)applyLedgerBlock

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -50,7 +50,7 @@ import qualified Cardano.Chain.Update.Validation.Interface as UPI
 import qualified Cardano.Chain.UTxO as CC
 import qualified Cardano.Chain.ValidationMode as CC
 
-import           Ouroboros.Network.Block (Point (..), SlotNo (..), blockSlot)
+import           Ouroboros.Network.Block (Point (..), SlotNo (..))
 import           Ouroboros.Network.Point (WithOrigin (..))
 import qualified Ouroboros.Network.Point as Point
 import           Ouroboros.Network.Protocol.LocalStateQuery.Codec (Some (..))
@@ -290,16 +290,14 @@ validationErrorImpossible = cantBeError . runExcept
 applyByronBlock :: CC.ValidationMode
                 -> LedgerConfig ByronBlock
                 -> ByronBlock
-                -> LedgerState ByronBlock
+                -> TickedLedgerState ByronBlock
                 -> Except (LedgerError ByronBlock) (LedgerState ByronBlock)
 applyByronBlock validationMode
-                fcfg@(ByronLedgerConfig cfg)
-                fblk@(ByronBlock blk _ (ByronHash blkHash))
-                ls = do
-    let TickedLedgerState _slot ls' = applyChainTick fcfg (blockSlot fblk) ls
-    case blk of
-      CC.ABOBBlock    blk' -> applyABlock validationMode cfg blk' blkHash ls'
-      CC.ABOBBoundary blk' -> applyABoundaryBlock        cfg blk'         ls'
+                (ByronLedgerConfig cfg)
+                (ByronBlock blk _ (ByronHash blkHash))
+                (TickedLedgerState _slot ls) = case blk of
+      CC.ABOBBlock    blk' -> applyABlock validationMode cfg blk' blkHash ls
+      CC.ABOBBoundary blk' -> applyABoundaryBlock        cfg blk'         ls
 
 applyABlock :: CC.ValidationMode
             -> Gen.Config

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -71,8 +71,14 @@ instance UpdateLedger ByronSpecBlock where
           (toByronSpecSlotNo       slot)
           (byronSpecLedgerState    state)
 
-  applyLedgerBlock cfg block state = withExcept ByronSpecLedgerError $
-      updateByronSpecLedgerStateNewTip (blockSlot block) <$>
+  applyLedgerBlock cfg block (TickedLedgerState slot state) =
+    withExcept ByronSpecLedgerError $
+      updateByronSpecLedgerStateNewTip slot <$>
+        -- Note that the CHAIN rule also applies the chain tick. So even
+        -- though the ledger we received has already been ticked with
+        -- 'applyChainTick', we do it again as part of CHAIN. This is safe, as
+        -- it is idempotent. If we wanted to avoid the repeated tick, we would
+        -- have to call the subtransitions of CHAIN (except for ticking).
         Rules.liftCHAIN
           (unByronSpecLedgerConfig cfg)
           (byronSpecBlock          block)

--- a/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
+++ b/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
@@ -884,7 +884,7 @@ test_golden_LedgerState = goldenTestCBOR
     exampleLedgerState = reapplyLedgerBlock
       (ShelleyLedgerConfig SL.testGlobals)
       (mkShelleyBlock newBlock)
-      (ShelleyLedgerState {
+      (TickedLedgerState 0 ShelleyLedgerState {
           ledgerTip    = genesisPoint
         , history      = History.empty
         , shelleyState = STS.chainNes startState

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -314,10 +314,10 @@ deriving instance MockProtocolSpecific c ext
 
 updateSimpleLedgerState :: (SimpleCrypto c, Typeable ext)
                         => SimpleBlock c ext
-                        -> LedgerState (SimpleBlock c ext)
+                        -> TickedLedgerState (SimpleBlock c ext)
                         -> Except (MockError (SimpleBlock c ext))
                                   (LedgerState (SimpleBlock c ext))
-updateSimpleLedgerState b (SimpleLedgerState st) =
+updateSimpleLedgerState b (TickedLedgerState _ (SimpleLedgerState st)) =
     SimpleLedgerState <$> updateMockState b st
 
 updateSimpleUTxO :: Mock.HasMockTxs a

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -313,7 +313,7 @@ instance UpdateLedger TestBlock where
 
   applyChainTick _ = TickedLedgerState
 
-  applyLedgerBlock _ tb@TestBlock{..} TestLedger{..}
+  applyLedgerBlock _ tb@TestBlock{..} (TickedLedgerState _ TestLedger{..})
     | Block.blockPrevHash tb /= Block.pointHash lastAppliedPoint
     = throwError $ InvalidHash (Block.pointHash lastAppliedPoint) (Block.blockPrevHash tb)
     | not tbValid

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -81,10 +81,11 @@ class ( HasHeader blk
 
   -- | Apply a block to the ledger state.
   --
-  -- This should apply the /entire/ block (i.e., including 'applyChainTick').
+  -- This is passed the ledger state ticked with the slot of the given block,
+  -- so 'applyChainTick' has already been called.
   applyLedgerBlock :: LedgerConfig blk
                    -> blk
-                   -> LedgerState blk
+                   -> TickedLedgerState blk
                    -> Except (LedgerError blk) (LedgerState blk)
 
   -- | Re-apply a block to the very same ledger state it was applied in before.
@@ -99,7 +100,7 @@ class ( HasHeader blk
   reapplyLedgerBlock :: HasCallStack
                      => LedgerConfig blk
                      -> blk
-                     -> LedgerState blk
+                     -> TickedLedgerState blk
                      -> LedgerState blk
 
   -- | Point of the most recently applied block

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -471,7 +471,7 @@ instance UpdateLedger TestBlock where
 
   applyChainTick _ = TickedLedgerState
 
-  applyLedgerBlock _ tb@TestBlock{..} TestLedger{..}
+  applyLedgerBlock _ tb@TestBlock{..} (TickedLedgerState _ TestLedger{..})
     | blockPrevHash tb /= lastAppliedHash
     = throwError $ InvalidHash lastAppliedHash (blockPrevHash tb)
     | not $ tbIsValid testBody


### PR DESCRIPTION
For the Byron and Shelley ledgers, the first thing `(re)applyLedgerBlock`
does, is tick the ledger. Since we already tick the ledger in
`applyExtLedgerState` (before obtaining a `LedgerView` from it to pass to
`validateHeader`) we can simply pass the ticked ledger to
`(re)applyLedgerBlock`, avoiding the repeated tick.