### PR TITLE
Revert "ImmutableDB: truncate blocks from the future"

### DIFF
--- a/ouroboros-consensus-byron/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-byron/tools/db-analyser/Main.hs
@@ -35,7 +35,6 @@ import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..),
                      genesisPoint)
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.BlockchainTime.Mock (fixedBlockchainTime)
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -365,6 +364,4 @@ withImmDB fp cfg chunkInfo registry = ImmDB.withImmDB args
         , immCheckIntegrity = nodeCheckIntegrity      cfg
         , immAddHdrEnv      = nodeAddHeaderEnvelope   (Proxy @ByronBlock)
         , immRegistry       = registry
-          -- We don't want to truncate blocks from the future
-        , immBlockchainTime = fixedBlockchainTime maxBound
         }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -183,7 +183,6 @@ fromChainDbArgs ChainDbArgs{..} = (
         , immAddHdrEnv        = cdbAddHdrEnv
         , immCacheConfig      = cdbImmDbCacheConfig
         , immRegistry         = cdbRegistry
-        , immBlockchainTime   = cdbBlockchainTime
         }
     , VolDB.VolDbArgs {
           volHasFS            = cdbHasFSVolDb

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
@@ -82,7 +82,6 @@ import           Ouroboros.Network.Block (pattern BlockPoint,
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.BlockchainTime (BlockchainTime)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
@@ -159,7 +158,6 @@ data ImmDbArgs m blk = forall h. Eq h => ImmDbArgs {
     , immTracer         :: Tracer m (TraceEvent blk)
     , immCacheConfig    :: Index.CacheConfig
     , immRegistry       :: ResourceRegistry m
-    , immBlockchainTime :: BlockchainTime m
     }
 
 -- | Default arguments when using the 'IO' monad
@@ -178,7 +176,6 @@ data ImmDbArgs m blk = forall h. Eq h => ImmDbArgs {
 -- * 'immCheckIntegrity'
 -- * 'immAddHdrEnv'
 -- * 'immRegistry'
--- * 'immBlockchainTime'
 defaultArgs :: FilePath -> ImmDbArgs IO blk
 defaultArgs fp = ImmDbArgs{
       immHasFS          = ioHasFS $ MountPoint (fp </> "immutable")
@@ -197,7 +194,6 @@ defaultArgs fp = ImmDbArgs{
     , immCheckIntegrity = error "no default for immCheckIntegrity"
     , immAddHdrEnv      = error "no default for immAddHdrEnv"
     , immRegistry       = error "no default for immRegistry"
-    , immBlockchainTime = error "no default for immBlockchainTime"
     }
   where
     -- Cache 250 past chunks by default. This will take roughly 250 MB of RAM.
@@ -241,7 +237,6 @@ openDB ImmDbArgs {..} = do
       , hashInfo    = immHashInfo
       , tracer      = immTracer
       , cacheConfig = immCacheConfig
-      , btime       = immBlockchainTime
       , valPol      = immValidation
       , parser      = parser
       }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
@@ -107,8 +107,6 @@ import           Cardano.Slotting.Block
 import           Cardano.Slotting.Slot
 
 import           Ouroboros.Consensus.Block (IsEBB (..))
-import           Ouroboros.Consensus.BlockchainTime (BlockchainTime,
-                     getCurrentSlot)
 import           Ouroboros.Consensus.Util (SomePair (..))
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry,
@@ -178,7 +176,6 @@ data ImmutableDbArgs m h hash e = ImmutableDbArgs
     , hashInfo    :: HashInfo hash
     , tracer      :: Tracer m (TraceEvent e hash)
     , cacheConfig :: Index.CacheConfig
-    , btime       :: BlockchainTime m
     , valPol      :: ValidationPolicy
     , parser      :: ChunkFileParser e m (BlockSummary hash) hash
     }
@@ -234,7 +231,6 @@ openDBInternal
   => ImmutableDbArgs m h hash e
   -> m (ImmutableDB hash m, Internal hash m)
 openDBInternal ImmutableDbArgs {..} = runWithTempRegistry $ do
-    currentSlot <- atomically $ getCurrentSlot btime
     let validateEnv = ValidateEnv
           { hasFS
           , chunkInfo
@@ -242,7 +238,6 @@ openDBInternal ImmutableDbArgs {..} = runWithTempRegistry $ do
           , parser
           , tracer
           , cacheConfig
-          , currentSlot
           }
     ost <- validateAndReopen validateEnv registry valPol
 
@@ -257,7 +252,6 @@ openDBInternal ImmutableDbArgs {..} = runWithTempRegistry $ do
           , tracer           = tracer
           , registry         = registry
           , cacheConfig      = cacheConfig
-          , blockchainTime   = btime
           }
         db = mkDBRecord dbEnv
         internal = Internal

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
@@ -32,7 +32,6 @@ import           GHC.Stack (HasCallStack)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 
-import           Ouroboros.Consensus.BlockchainTime (BlockchainTime)
 import           Ouroboros.Consensus.Util (SomePair (..))
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry,
@@ -66,7 +65,6 @@ data ImmutableDBEnv m hash = forall h e. Eq h => ImmutableDBEnv
     , tracer           :: !(Tracer m (TraceEvent e hash))
     , registry         :: !(ResourceRegistry m)
     , cacheConfig      :: !Index.CacheConfig
-    , blockchainTime   :: !(BlockchainTime m)
     }
 
 data InternalState m hash h =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Validation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Validation.hs
@@ -63,7 +63,6 @@ data ValidateEnv m hash h e = ValidateEnv
   , parser      :: !(ChunkFileParser e m (BlockSummary hash) hash)
   , tracer      :: !(Tracer m (TraceEvent e hash))
   , cacheConfig :: !Index.CacheConfig
-  , currentSlot :: !SlotNo
   }
 
 -- | Perform validation as per the 'ValidationPolicy' using 'validate' and
@@ -323,7 +322,7 @@ validateChunk ValidateEnv{..} shouldBeFinalised chunk mbPrevHash = do
     -- expensive integrity check of a block.
     let expectedChecksums = map Secondary.checksum entriesFromSecondaryIndex
     (entriesWithPrevHashes, mbErr) <- lift $
-        runChunkFileParser parser chunkFile currentSlot expectedChecksums $ \entries ->
+        runChunkFileParser parser chunkFile expectedChecksums $ \entries ->
           (\(es :> mbErr) -> (es, mbErr)) <$> S.toList entries
 
     -- Check whether the first block of this chunk fits onto the last block of

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Types.hs
@@ -130,8 +130,6 @@ newtype ChunkFileParser e m entry hash = ChunkFileParser
   { runChunkFileParser
       :: forall r.
          FsPath
-      -> SlotNo
-         -- Current slot (wall clock)
       -> [CRC]
          -- The expected checksums are given as input. This list can be empty
          -- when the secondary index file is missing. If the expected checksum

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -12,7 +12,6 @@ import           Test.Tasty.HUnit
 import           Cardano.Slotting.Slot
 
 import           Ouroboros.Consensus.Block (getHeader)
-import           Ouroboros.Consensus.BlockchainTime.Mock (fixedBlockchainTime)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
@@ -61,7 +60,6 @@ openTestDB registry hasFS =
       , hashInfo    = testHashInfo
       , tracer      = nullTracer
       , cacheConfig = Index.CacheConfig 2 60
-      , btime       = fixedBlockchainTime maxBound
       , valPol      = ValidateMostRecentChunk
       , parser
       }


### PR DESCRIPTION
This reverts commit 81f2f1e17f4bf331525d4ae915d9c0ae68d4b8b4.

See #1773, we first have to open the ImmutableDB /with/ all blocks because we
don't know yet in which slot we are. We need the ImmutableDB to obtain a
ledger state which will tell us which slot we're in. Afterwards, we can
truncate the future blocks from the ImmutableDB. This last step will be done
by the ChainDB and will follow in a future PR.