### PR TITLE
Label all threads spawned by consensus

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadFork.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadFork.hs
@@ -6,6 +6,7 @@
 module Control.Monad.Class.MonadFork
   ( MonadThread (..)
   , MonadFork (..)
+  , labelThisThread
   ) where
 
 import qualified Control.Concurrent as IO
@@ -57,3 +58,7 @@ instance MonadFork m => MonadFork (ReaderT e m) where
                            restore' (ReaderT f) = ReaderT $ restore . f
                        in runReaderT (k restore') e
   throwTo e t = lift (throwTo e t)
+
+-- | Apply the label to the current thread
+labelThisThread :: MonadThread m => String -> m ()
+labelThisThread label = myThreadId >>= \tid -> labelThread tid label

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/BlockchainTime.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/BlockchainTime.hs
@@ -12,12 +12,18 @@ import           Ouroboros.Network.Block (SlotNo)
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Util.IOLike
 
-onSlot :: (HasCallStack, IOLike m) => BlockchainTime m -> SlotNo -> m () -> m ()
-onSlot btime slot k = do
+onSlot
+  :: (HasCallStack, IOLike m)
+  => BlockchainTime m
+  -> String
+  -> SlotNo  -- ^ Label for the thread
+  -> m ()
+  -> m ()
+onSlot btime label slot k = do
     startingSlot <- atomically $ getCurrentSlot btime
     when (startingSlot >= slot) $
       throwM $ OnSlotTooLate slot startingSlot
-    void $ onSlotChange btime $ \slot' ->
+    void $ onSlotChange btime label $ \slot' ->
       when (slot == slot') k
 
 data OnSlotException =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/API.hs
@@ -37,11 +37,12 @@ data BlockchainTime m = BlockchainTime {
       --
       -- Returns a handle to kill the thread.
       --
-      -- The thread will be linked to the registry in which the 'BlockchainTime'
-      -- itself was created.
+      -- The thread will be linked to the registry in which the
+      -- 'BlockchainTime' itself was created. The given 'String' will be used
+      -- to label the thread.
       --
       -- Use sites should call 'onSlotChange' rather than 'onSlotChange_'.
-    , onSlotChange_  :: HasCallStack => (SlotNo -> m ()) -> m (m ())
+    , onSlotChange_  :: HasCallStack => String -> (SlotNo -> m ()) -> m (m ())
     }
   deriving NoUnexpectedThunks via OnlyCheckIsWHNF "BlockchainTime" (BlockchainTime m)
 
@@ -49,7 +50,7 @@ data BlockchainTime m = BlockchainTime {
 --
 -- See documentation of 'onSlotChange_'.
 onSlotChange :: HasCallStack
-             => BlockchainTime m -> (SlotNo -> m ()) -> m (m ())
+             => BlockchainTime m -> String -> (SlotNo -> m ()) -> m (m ())
 onSlotChange = onSlotChange_
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/Mock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/Mock.hs
@@ -41,7 +41,7 @@ import           Ouroboros.Consensus.Util.STM
 fixedBlockchainTime :: MonadSTM m => SlotNo -> BlockchainTime m
 fixedBlockchainTime slot = BlockchainTime {
       getCurrentSlot = return slot
-    , onSlotChange_  = const (return (return ()))
+    , onSlotChange_  = \_ _ -> return (return ())
     }
 
 {-------------------------------------------------------------------------------
@@ -103,7 +103,7 @@ newTestBlockchainTime registry (NumSlots numSlots) slotLens = do
     slotVar <- newTVarM Initializing
     doneVar <- newEmptyMVar ()
 
-    void $ forkLinkedThread registry $ loop slotVar doneVar
+    void $ forkLinkedThread registry "TestBlockchainTime" $ loop slotVar doneVar
 
     return $ clone slotVar doneVar registry
   where
@@ -143,8 +143,8 @@ newTestBlockchainTime registry (NumSlots numSlots) slotLens = do
         btime :: BlockchainTime m
         btime = BlockchainTime {
             getCurrentSlot = get
-          , onSlotChange_  = fmap cancelThread .
-              onEachChange registry' Running (Just Initializing) get
+          , onSlotChange_  = \label -> fmap cancelThread .
+              onEachChange registry' label Running (Just Initializing) get
           }
 
 -- | Number of slot length changes if running for the specified number of slots

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -210,7 +210,13 @@ forkSyncStateOnTipPointChange :: forall m blk. (
                               -> MempoolEnv m blk
                               -> m ()
 forkSyncStateOnTipPointChange registry menv =
-    void $ onEachChange registry id Nothing getCurrentTip action
+    void $ onEachChange
+      registry
+      "Mempool.syncStateOnTipPointChange"
+      id
+      Nothing
+      getCurrentTip
+      action
   where
     action :: Point blk -> m ()
     action _tipPoint = void $ implSyncWithLedger menv

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -721,6 +721,7 @@ rejectInvalidBlocks
 rejectInvalidBlocks tracer registry getIsInvalidBlock getCandidate =
     void $ onEachChange
       registry
+      "ChainSync.Client.rejectInvalidBlocks"
       getFingerprint
       Nothing
       getIsInvalidBlock

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -199,7 +199,8 @@ initNodeKernel args@NodeArgs { registry, cfg, tracers, maxBlockSize
 
     -- Run the block fetch logic in the background. This will call
     -- 'addFetchedBlock' whenever a new block is downloaded.
-    void $ forkLinkedThread registry $ blockFetchLogic
+    void $ forkLinkedThread registry "NodeKernel.blockFetchLogic" $
+      blockFetchLogic
         (blockFetchDecisionTracer tracers)
         (blockFetchClientTracer   tracers)
         blockFetchInterface
@@ -358,7 +359,7 @@ forkBlockProduction
     -> BlockProduction m blk
     -> m ()
 forkBlockProduction maxBlockSizeOverride IS{..} BlockProduction{..} =
-    void $ onSlotChange btime $ withEarlyExit_ . go
+    void $ onSlotChange btime "NodeKernel.blockProduction" $ withEarlyExit_ . go
   where
     RunMonadRandom{..} = runMonadRandomDict
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
@@ -386,7 +386,8 @@ newEnv hasFS hashInfo registry tracer cacheConfig chunkInfo chunk = do
     bgThreadVar <- newMVar Nothing
     let cacheEnv = CacheEnv {..}
     mask_ $ modifyMVar_ bgThreadVar $ \_mustBeNothing -> do
-      !bgThread <- forkLinkedThread registry $ expireUnusedChunks cacheEnv
+      !bgThread <- forkLinkedThread registry "ImmutableDB.expireUnusedChunks" $
+        expireUnusedChunks cacheEnv
       return $ Just bgThread
     return cacheEnv
   where
@@ -621,7 +622,8 @@ restart cacheEnv chunk = do
       case mbBgThread of
         Just _  -> throwM $ userError "background thread still running"
         Nothing -> do
-          !bgThread <- forkLinkedThread registry $ expireUnusedChunks cacheEnv
+          !bgThread <- forkLinkedThread registry "ImmutableDB.expireUnusedChunks" $
+            expireUnusedChunks cacheEnv
           return $ Just bgThread
   where
     CacheEnv { hasFS, hashInfo, registry, cacheVar, bgThreadVar, chunkInfo } = cacheEnv

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -16,6 +16,7 @@ module Ouroboros.Consensus.Util.IOLike (
   , MonadSTMTxExtended(..)
     -- *** MonadFork
   , MonadFork(..) -- TODO: Should we hide this in favour of MonadAsync?
+  , labelThisThread
   , MonadThread(..)
     -- *** MonadAsync
   , MonadAsyncSTM(..)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
@@ -54,6 +54,7 @@ blockUntilChanged f b getA = do
 -- The thread will be linked to the registry.
 onEachChange :: forall m a b. (IOLike m, Eq b, HasCallStack)
              => ResourceRegistry m
+             -> String    -- ^ Label for the thread
              -> (a -> b)  -- ^ Obtain a fingerprint
              -> Maybe b   -- ^ Optional initial fingerprint
                           -- If 'Nothing', the action is executed once
@@ -61,8 +62,8 @@ onEachChange :: forall m a b. (IOLike m, Eq b, HasCallStack)
              -> STM m a
              -> (a -> m ())
              -> m (Thread m Void)
-onEachChange registry f mbInitB getA notify =
-    forkLinkedThread registry body
+onEachChange registry label f mbInitB getA notify =
+    forkLinkedThread registry label body
   where
     body :: m Void
     body = do
@@ -85,11 +86,12 @@ onEachChange registry f mbInitB getA notify =
 -- The thread will be linked to the registry.
 runWhenJust :: IOLike m
             => ResourceRegistry m
+            -> String  -- ^ Label for the thread
             -> STM m (Maybe a)
             -> (a -> m ())
             -> m ()
-runWhenJust registry getMaybeA action =
-    void $ forkLinkedThread registry $
+runWhenJust registry label getMaybeA action =
+    void $ forkLinkedThread registry label $
       action =<< atomically (blockUntilJust getMaybeA)
 
 blockUntilJust :: MonadSTMTx stm => stm (Maybe a) -> stm a

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/WallClock.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/WallClock.hs
@@ -272,8 +272,9 @@ testOverrideDelay systemStart slotLength numSlots = do
                 systemStart
                 (focusSlotLengths $ singletonSlotLengths slotLength)
       slotsVar <- uncheckedNewTVarM []
-      cancelCollection <- onSlotChange time $ \slotNo ->
-        atomically $ modifyTVar slotsVar (slotNo :)
+      cancelCollection <-
+        onSlotChange time "testOverrideDelay" $ \slotNo ->
+          atomically $ modifyTVar slotsVar (slotNo :)
       -- Wait to collect the required number of slots
       slots <- atomically $ do
         slots <- readTVar slotsVar

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -304,7 +304,7 @@ newThread alive parentReg = \shouldLink -> do
     comms      <- atomically $ newTQueue
     spawned    <- uncheckedNewEmptyMVar (error "no thread spawned yet")
 
-    thread <- forkThread parentReg $
+    thread <- forkThread parentReg "newThread" $
                 withRegistry $ \childReg ->
                   threadBody childReg spawned comms
     case shouldLink of

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Util/MonadSTM/RAWLock.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Util/MonadSTM/RAWLock.hs
@@ -65,7 +65,7 @@ prop_RAWLock_correctness (TestSetup rawDelays) =
               rawState <- readRAWState rawVars
               modifyTVar varTrace (rawState:)
 
-        threads <- mapM (forkLinkedThread registry) $
+        threads <- mapM (forkLinkedThread registry "testThread") $
           map (runReader   rawLock traceState varReaders)   readerDelays   <>
           map (runAppender rawLock traceState varAppenders) appenderDelays <>
           map (runWriter   rawLock traceState varWriters)   writerDelays

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Mock.hs
@@ -116,7 +116,8 @@ openDB cfg initLedger btime = do
           , ledgerCursorMove  = update . Model.ledgerCursorMove cfg lcId
           }
 
-    void $ onSlotChange btime $ update_ . Model.advanceCurSlot cfg
+    void $ onSlotChange btime "ChainDB.Mock.advanceCurSlot" $
+      update_ . Model.advanceCurSlot cfg
 
     return ChainDB {
         addBlockAsync       = update   . Model.addBlockPromise cfg


### PR DESCRIPTION
To make profiling with `ghc-events-analyze` more informative, threads
should be labelled.

The consensus layer consistently uses the `ResourceRegistry` to spawn
background threads, so we let `ResourceRegistry.fork(Linked)Thread` take the
thread label as argument. We are now pretty sure all threads spawned by
consensus are labelled.