### PR TITLE
Delete `onSlotChange` from `BlockchainTime`

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/BlockchainTime.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/BlockchainTime.hs
@@ -11,19 +11,21 @@ import           Ouroboros.Network.Block (SlotNo)
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.ResourceRegistry
 
 onSlot
   :: (HasCallStack, IOLike m)
-  => BlockchainTime m
+  => ResourceRegistry m
+  -> BlockchainTime m
   -> String
   -> SlotNo  -- ^ Label for the thread
   -> m ()
   -> m ()
-onSlot btime label slot k = do
+onSlot registry btime label slot k = do
     startingSlot <- atomically $ getCurrentSlot btime
     when (startingSlot >= slot) $
       throwM $ OnSlotTooLate slot startingSlot
-    void $ onSlotChange btime label $ \slot' ->
+    void $ onSlotChange registry btime label $ \slot' ->
       when (slot == slot') k
 
 data OnSlotException =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock.hs
@@ -25,7 +25,6 @@ import           Ouroboros.Consensus.BlockchainTime.API
 import           Ouroboros.Consensus.BlockchainTime.SlotLengths
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
-import           Ouroboros.Consensus.Util.STM
 
 -- | Events emitted by 'realBlockchainTime'.
 data TraceBlockchainTimeEvent
@@ -63,8 +62,6 @@ realBlockchainTime registry tracer start ls = do
     -- The API is now a simple STM one
     return BlockchainTime {
         getCurrentSlot = readTVar slotVar
-      , onSlotChange_  = \label -> fmap cancelThread .
-          onEachChange registry label id (Just first) (readTVar slotVar)
       }
   where
     -- In each iteration of the loop, we recompute how long to wait until

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -359,7 +359,8 @@ forkBlockProduction
     -> BlockProduction m blk
     -> m ()
 forkBlockProduction maxBlockSizeOverride IS{..} BlockProduction{..} =
-    void $ onSlotChange btime "NodeKernel.blockProduction" $ withEarlyExit_ . go
+    void $ onSlotChange registry btime "NodeKernel.blockProduction" $
+      withEarlyExit_ . go
   where
     RunMonadRandom{..} = runMonadRandomDict
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -446,6 +446,7 @@ scheduledChainSelectionRunner
   => ChainDbEnv m blk -> m (m ())
 scheduledChainSelectionRunner cdb@CDB{..} =
     onSlotChange
+      cdbRegistry
       cdbBlockchainTime
       "ChainDB.scheduledChainSelection"
       (scheduledChainSelection cdb)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -313,7 +313,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
 
     -- Schedule updates of the client and server chains
     varLastUpdate <- uncheckedNewTVarM 0
-    void $ onSlotChange btime "scheduled updates" $ \slot -> do
+    void $ onSlotChange registry btime "scheduled updates" $ \slot -> do
       -- Stop updating the client and server chains when the chain sync client
       -- has thrown an exception, so that at the end, we can read the chains
       -- in the states they were in when the exception was thrown.
@@ -341,7 +341,7 @@ runChainSync securityParam maxClockSkew (ClientUpdates clientUpdates)
         atomically $ writeTVar varLastUpdate slot
 
     -- Connect client to server and run the chain sync protocol
-    onSlot btime "startSyncing" startSyncingAt $ do
+    onSlot registry btime "startSyncing" startSyncingAt $ do
       -- When updates are planned at the same slot that we start syncing, we
       -- wait until these updates are done before we start syncing.
       when (isJust (Map.lookup startSyncingAt clientUpdates) ||


### PR DESCRIPTION
This is now a derived function instead. This has two consequences:

1. `onSlotChange` must be passed a registry (previously it was
   implicitly using the registry in the `BlockchainTime`'s closure).
   This wasn't a problem, we had a registry in scope wherever it was
   needed. In fact, it was _beneficial_, as closing a
   `TestBlockchainTime` is now no longer required as a concept.

2. The function passed to `onSlotChange` will be called (once) _immediately_
   with the current slot; previously it would only be called from the
   _next_ slot. This is fine for the real code: we only use this in two
   places: block production and running scheduled chain selections. The
   tests were fine also, except the tests of the `BlockchainTime`
   specifically, which had a model predicting precisely for which slots
   the action would be called; this had to be shifted by one (i.e., when
   collecting 5 slots, previously we expected `1..5`, now we expected
   `0..4`).