### PR TITLE
VolatileDB: only obtain the write lock if we can GC a file

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Index.hs
@@ -11,7 +11,7 @@ module Ouroboros.Consensus.Storage.VolatileDB.Impl.Index (
   , lookup
   , insert
   , delete
-  , toList
+  , toAscList
   , elems
   , lastFile
   ) where
@@ -47,8 +47,8 @@ insert path info = modifyIndex (IM.insert path info)
 delete :: FileId -> Index blockId -> Index blockId
 delete path = modifyIndex (IM.delete path)
 
-toList :: Index blockId -> [(FileId, FileInfo blockId)]
-toList (Index mp) = IM.toList mp
+toAscList :: Index blockId -> [(FileId, FileInfo blockId)]
+toAscList (Index mp) = IM.toAscList mp
 
 elems :: Index blockId -> [FileInfo blockId]
 elems (Index mp) = IM.elems mp


### PR DESCRIPTION
Previously, `garbageCollect` was obtaining the exclusive write lock every time
it was called, starving any concurrent readers and appender, even if it
couldn't garbage collect any file.

Now, we read the state first to determine whether we can garbage collect at
least one file, if so, we obtain the exclusive write lock and do the actual
garbage collection.