### PR TITLE
Add MonadEventlog

### DIFF
--- a/io-sim-classes/io-sim-classes.cabal
+++ b/io-sim-classes/io-sim-classes.cabal
@@ -35,6 +35,7 @@ library
   -- This has to be tidied up once the design becomes clear.
   exposed-modules:
                        Control.Monad.Class.MonadAsync
+                       Control.Monad.Class.MonadEventlog
                        Control.Monad.Class.MonadFork
                        Control.Monad.Class.MonadSay
                        Control.Monad.Class.MonadST

--- a/io-sim-classes/src/Control/Monad/Class/MonadEventlog.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadEventlog.hs
@@ -1,0 +1,36 @@
+module Control.Monad.Class.MonadEventlog (
+    MonadEventlog(..)
+  ) where
+
+import           Control.Monad.Reader
+import           Debug.Trace (traceEventIO, traceMarkerIO)
+
+class Monad m => MonadEventlog m where
+
+  -- | Emits a message to the eventlog, if eventlog profiling is available and
+  -- enabled at runtime.
+  traceEventM :: String -> m ()
+
+  -- | Emits a marker to the eventlog, if eventlog profiling is available and
+  -- enabled at runtime.
+  --
+  -- The 'String' is the name of the marker. The name is just used in the
+  -- profiling tools to help you keep clear which marker is which.
+  traceMarkerM :: String -> m ()
+
+
+--
+-- Instances for IO
+--
+
+instance MonadEventlog IO where
+  traceEventM = traceEventIO
+  traceMarkerM = traceMarkerIO
+
+--
+-- Instance for ReaderT
+--
+
+instance MonadEventlog m => MonadEventlog (ReaderT r m) where
+  traceEventM = lift . traceEventM
+  traceMarkerM = lift . traceMarkerM

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -35,6 +35,9 @@ module Control.Monad.IOSim (
   selectTraceEventsDynamic,
   selectTraceEventsSay,
   printTraceEventsSay,
+  -- * Eventlog
+  EventlogEvent(..),
+  EventlogMarker(..),
   -- * Low-level API
   execReadTVar
   ) where
@@ -71,6 +74,7 @@ import           Control.Monad.Fail as MonadFail
 
 import           Control.Monad.Class.MonadAsync hiding (Async)
 import qualified Control.Monad.Class.MonadAsync as MonadAsync
+import           Control.Monad.Class.MonadEventlog
 import           Control.Monad.Class.MonadFork hiding (ThreadId)
 import qualified Control.Monad.Class.MonadFork as MonadFork
 import           Control.Monad.Class.MonadSay
@@ -435,6 +439,18 @@ instance Show TimeoutException where
 instance Exception TimeoutException where
   toException   = asyncExceptionToException
   fromException = asyncExceptionFromException
+
+-- | Wrapper for Eventlog events so they can be retrieved from the trace with
+-- 'selectTraceEventsDynamic'.
+newtype EventlogEvent = EventlogEvent String
+
+-- | Wrapper for Eventlog markers so they can be retrieved from the trace with
+-- 'selectTraceEventsDynamic'.
+newtype EventlogMarker = EventlogMarker String
+
+instance MonadEventlog (SimM s) where
+  traceEventM = traceM . EventlogEvent
+  traceMarkerM = traceM . EventlogMarker
 
 traceM :: Typeable a => a -> SimM s ()
 traceM x = SimM $ \k -> Output (toDyn x) (k ())


### PR DESCRIPTION
The IO instance uses `traceMarkerIO` and `traceEventIO`.

The IOSim instance uses `traceM`.