### PR TITLE
ChainDB: batch garbage collections

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -607,11 +607,13 @@ runThreadNetwork ThreadNetworkArgs
         , cdbBlockchainTime       = btime
         , cdbAddHdrEnv            = nodeAddHeaderEnvelope (Proxy @blk)
         , cdbImmDbCacheConfig     = Index.CacheConfig 2 60
-        -- Misc
+          -- Misc
         , cdbTracer               = instrumentationTracer <> nullDebugTracer
         , cdbTraceLedger          = nullDebugTracer
         , cdbRegistry             = registry
+          -- TODO vary these
         , cdbGcDelay              = 0
+        , cdbGcInterval           = 1
         , cdbBlocksToAddSize      = 2
         }
       where

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/QuickCheck.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/QuickCheck.hs
@@ -2,6 +2,8 @@
 module Test.Util.QuickCheck (
     -- * Comparison functions
     lt
+  , le
+  , gt
   , ge
   , expectRight
     -- * Improved variants
@@ -24,15 +26,25 @@ import qualified Test.QuickCheck as QC
 -------------------------------------------------------------------------------}
 
 infix 4 `lt`
+infix 4 `le`
+infix 4 `gt`
 infix 4 `ge`
-
--- | Like '>=', but prints a counterexample when it fails.
-ge :: (Ord a, Show a) => a -> a -> Property
-x `ge` y = counterexample (show x ++ " < " ++ show y) $ x >= y
 
 -- | Like '<', but prints a counterexample when it fails.
 lt :: (Ord a, Show a) => a -> a -> Property
 x `lt` y = counterexample (show x ++ " >= " ++ show y) $ x < y
+
+-- | Like '<=', but prints a counterexample when it fails.
+le :: (Ord a, Show a) => a -> a -> Property
+x `le` y = counterexample (show x ++ " > " ++ show y) $ x <= y
+
+-- | Like '>', but prints a counterexample when it fails.
+gt :: (Ord a, Show a) => a -> a -> Property
+x `gt` y = counterexample (show x ++ " <= " ++ show y) $ x > y
+
+-- | Like '>=', but prints a counterexample when it fails.
+ge :: (Ord a, Show a) => a -> a -> Property
+x `ge` y = counterexample (show x ++ " < " ++ show y) $ x >= y
 
 -- | Check that we have the expected 'Right' value
 --

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -369,6 +369,7 @@ test-suite test-storage
                        Test.Ouroboros.Storage.ChainDB
                        Test.Ouroboros.Storage.ChainDB.AddBlock
                        Test.Ouroboros.Storage.ChainDB.Iterator
+                       Test.Ouroboros.Storage.ChainDB.GcSchedule
                        Test.Ouroboros.Storage.ChainDB.Mock
                        Test.Ouroboros.Storage.ChainDB.Mock.Test
                        Test.Ouroboros.Storage.ChainDB.Model

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -38,7 +38,6 @@ import           Control.Monad (when)
 import           Control.Tracer (Tracer)
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Proxy (Proxy (..))
-import           Data.Time.Clock (secondsToDiffTime)
 
 import           Ouroboros.Network.Diffusion
 import           Ouroboros.Network.Magic
@@ -314,7 +313,6 @@ mkChainDbArgs tracer registry btime dbPath cfg initLedger
     , ChainDB.cdbTracer               = tracer
     , ChainDB.cdbImmValidation        = ValidateMostRecentChunk
     , ChainDB.cdbVolValidation        = NoValidation
-    , ChainDB.cdbGcDelay              = secondsToDiffTime 10
     , ChainDB.cdbBlockchainTime       = btime
     }
   where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -145,6 +145,7 @@ openDBInternal args launchBgTasks = do
                   , cdbTraceLedger     = Args.cdbTraceLedger args
                   , cdbRegistry        = Args.cdbRegistry args
                   , cdbGcDelay         = Args.cdbGcDelay args
+                  , cdbGcInterval      = Args.cdbGcInterval args
                   , cdbKillBgThreads   = varKillBgThreads
                   , cdbChunkInfo       = Args.cdbChunkInfo args
                   , cdbIsEBB           = toIsEBB . isJust . Args.cdbIsEBB args

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -209,6 +209,9 @@ data ChainDbEnv m blk = CDB
   , cdbGcDelay         :: !DiffTime
     -- ^ How long to wait between copying a block from the VolatileDB to
     -- ImmutableDB and garbage collecting it from the VolatileDB
+  , cdbGcInterval      :: !DiffTime
+    -- ^ Minimum time between two garbage collections. Is used to batch
+    -- garbage collections.
   , cdbKillBgThreads   :: !(StrictTVar m (m ()))
     -- ^ A handle to kill the background threads.
   , cdbChunkInfo       :: !ImmDB.ChunkInfo
@@ -666,9 +669,9 @@ data TraceCopyToImmDBEvent blk
   deriving (Generic, Eq, Show)
 
 data TraceGCEvent blk
-  = ScheduledGC SlotNo DiffTime
+  = ScheduledGC SlotNo Time
     -- ^ A garbage collection for the given 'SlotNo' was scheduled to happen
-    -- after the given delay.
+    -- at the given time.
   | PerformedGC SlotNo
     -- ^ A garbage collection for the given 'SlotNo' was performed.
   deriving (Generic, Eq, Show)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -24,6 +24,8 @@ import           Formatting (build, sformat)
 import           Numeric.Natural
 import           Text.Printf (printf)
 
+import           Control.Monad.Class.MonadTime (Time (..))
+
 import           Cardano.Crypto (VerificationKey)
 import           Cardano.Crypto.DSIGN (Ed448DSIGN, MockDSIGN, SigDSIGN,
                      pattern SigEd448DSIGN, pattern SigMockDSIGN,
@@ -200,3 +202,6 @@ instance Condense (SigDSIGN d) => Condense (SigKES (SimpleKES d)) where
 
 instance Condense (Hash h a) where
     condense = show
+
+instance Condense Time where
+    condense (Time dt) = show dt

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB.hs
@@ -5,6 +5,7 @@ module Test.Ouroboros.Storage.ChainDB (
 import           Test.Tasty
 
 import qualified Test.Ouroboros.Storage.ChainDB.AddBlock as AddBlock
+import qualified Test.Ouroboros.Storage.ChainDB.GcSchedule as GcSchedule
 import qualified Test.Ouroboros.Storage.ChainDB.Iterator as Iterator
 import qualified Test.Ouroboros.Storage.ChainDB.Mock.Test as Mock
 import qualified Test.Ouroboros.Storage.ChainDB.Model.Test as Model
@@ -14,6 +15,7 @@ tests :: TestTree
 tests = testGroup "ChainDB" [
       AddBlock.tests
     , Iterator.tests
+    , GcSchedule.tests
     , Model.tests
     , Mock.tests
     , StateMachine.tests

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -284,8 +284,10 @@ mkArgs cfg chunkInfo initLedger tracer registry hashInfo
     , cdbTracer               = tracer
     , cdbTraceLedger          = nullTracer
     , cdbRegistry             = registry
-    , cdbGcDelay              = 0
     , cdbBlocksToAddSize      = 2
+      -- We don't run the background threads, so these are not used
+    , cdbGcDelay              = 1
+    , cdbGcInterval           = 1
     }
   where
     addDummyBinaryInfo :: CBOR.Encoding -> BinaryInfo CBOR.Encoding

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/GcSchedule.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/GcSchedule.hs
@@ -1,0 +1,463 @@
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE RecordWildCards            #-}
+module Test.Ouroboros.Storage.ChainDB.GcSchedule (tests, example) where
+
+import           Control.Monad (forM)
+import           Control.Tracer (nullTracer)
+import           Data.Fixed (div')
+import           Data.List
+import           Data.Time.Clock
+import           Data.Void (Void)
+
+import           Control.Monad.IOSim (runSimOrThrow)
+
+import           Ouroboros.Network.Block (SlotNo (..))
+
+import           Ouroboros.Consensus.Util (lastMaybe, safeMaximum)
+import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Consensus.Util.IOLike
+
+import           Ouroboros.Consensus.Storage.ChainDB.Impl.Background
+                     (GcParams (..), ScheduledGc (..))
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Background as Impl
+
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Test.Util.Orphans.IOLike ()
+import           Test.Util.QuickCheck
+
+{-------------------------------------------------------------------------------
+  Top-level tests
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "GcSchedule"
+    [ testProperty "queueLength"        prop_queueLength
+    , testProperty "overlap"            prop_overlap
+    , testProperty "unnecessaryOverlap" prop_unnecessaryOverlap
+    , testProperty "model vs impl"      prop_model_vs_impl
+    ]
+
+{-------------------------------------------------------------------------------
+  Properties
+-------------------------------------------------------------------------------}
+
+-- | Property 1
+--
+-- 'queueLength' <= 'gcDelay' `div` 'gcInterval' + @slack@
+--
+-- Where:
+-- * @slack = 1@ when 'gcInterval' divides 'gcDelay'. In this case, the delay
+--   divides the interval nicely in different buckets. However, if we're not
+--   at the start of a bucket and part of it is in the past, we'll need one
+--   extra bucket to compensate, hence 1.
+-- * @slack = 2@ in the other cases: in addition to the 1 of the previous
+--   case, we must also account for one extra bucket because 'gcInterval'
+--   doesn't nicely divide 'gcDelay' into buckets. In other words: we need to
+--   round up.
+prop_queueLength :: TestSetup -> Property
+prop_queueLength TestSetup{..} =
+    testDelay >= testInterval ==>
+      conjoin
+        [ gcSummaryQueueLength `le` (gcDelay `div'` gcInterval) + slack
+        | GcStateSummary { gcSummaryQueueLength } <- testTrace
+        ]
+  where
+    GcParams{..} = testGcParams
+    slack
+      | testDelay `mod` testInterval == 0
+      = 1
+      | otherwise
+      = 2
+
+-- | Property 2:
+--
+-- 'overlap' < the number of blocks that could arrive 'gcDelay' +
+-- 'gcInterval'.
+prop_overlap :: TestSetup -> Property
+prop_overlap TestSetup{..} =
+    conjoin
+      [ gcSummaryOverlap `lt` blocksInInterval (gcDelay + gcInterval)
+      | GcStateSummary { gcSummaryOverlap } <- testTrace
+      ]
+  where
+    GcParams{..} = testGcParams
+
+-- | Property 3:
+--
+-- 'unnecessaryOverlap' < the number of blocks that could arrive in
+-- 'gcInterval'.
+prop_unnecessaryOverlap :: TestSetup -> Property
+prop_unnecessaryOverlap TestSetup{..} =
+    conjoin
+      [ gcSummaryUnnecessary `lt` blocksInInterval gcInterval
+      | GcStateSummary { gcSummaryUnnecessary } <- testTrace
+      ]
+  where
+    GcParams{..} = testGcParams
+
+-- TODO the unnecessaryOverlap should at some point go back to 0 after it has
+-- increased: test this property
+
+blocksInInterval :: DiffTime -> Int
+blocksInInterval interval = round (realToFrac interval :: Double)
+
+-- | Verify that the queue of the real implementation matches the model queue
+-- at each point in the trace.
+--
+-- Moreover, verify that the real implementation will have performed all its
+-- garbage collections at the same times as the model implementation.
+prop_model_vs_impl :: TestSetup -> Property
+prop_model_vs_impl TestSetup {..} = conjoin
+    [ counterexample "Expected queue evolution /= actual" $
+        map (reverseQueue . gcSummaryQueue) testTrace === gcQueueTrace
+    , counterexample "Expected final garbage collections /= actual" $
+        testGcGarbageCollections === gcs
+    ]
+  where
+    (gcQueueTrace, gcs) = runGcSchedule testGcParams (genBlocks testNumBlocks)
+
+    -- In the model we store the queue in reverse order, so we have to reverse
+    -- it to match the order of the implementation's queue.
+    reverseQueue :: GcQueue -> GcQueue
+    reverseQueue (GcQueue q) = GcQueue (reverse q)
+
+{-------------------------------------------------------------------------------
+  Block
+-------------------------------------------------------------------------------}
+
+newtype Block = Block Int
+  deriving stock   (Show)
+  deriving newtype (Condense)
+
+blockArrivalTime :: Block -> Time
+blockArrivalTime (Block n) = Time (secondsToDiffTime (fromIntegral n))
+
+blockSlotNo :: Block -> SlotNo
+blockSlotNo (Block n) = SlotNo (fromIntegral n)
+
+{-------------------------------------------------------------------------------
+  GcQueue, GcBlocks, GcGarbageCollected, GcState
+-------------------------------------------------------------------------------}
+
+-- | Queue of scheduled GCs, in reverse order
+newtype GcQueue = GcQueue { unGcQueue :: [ScheduledGc] }
+  deriving newtype (Eq, Condense)
+
+instance Show GcQueue where
+  show = condense
+
+-- | Blocks still to GC, together with the earliest time at which the block
+-- could have been GC'ed.
+--
+-- In no particular order.
+--
+-- NOTE: in the real implementation, a GC for slot @s@ means removing all
+-- blocks with a slot number < @s@ (because of EBBs, which share the slot with
+-- the regular block after it). In this test, we ignore this and use <=, so a
+-- GC for the slot of the block will remove the block.
+newtype GcBlocks = GcBlocks { unGcBlocks :: [(Block, Time)] }
+  deriving newtype (Condense)
+
+instance Show GcBlocks where
+  show = condense
+
+-- | Garbage collections that have happened. A garbage collection is triggered
+-- for a slot number. We remember at which time it happened.
+--
+-- In no particular order.
+--
+-- The NOTE of 'GcBlocks' also applies here.
+newtype GcGarbageCollections = GcGarbageCollections [(SlotNo, Time)]
+  deriving newtype (Eq, Condense, NoUnexpectedThunks)
+
+instance Show GcGarbageCollections where
+  show = condense
+
+data GcState = GcState {
+      gcQueue              :: GcQueue
+    , gcBlocks             :: GcBlocks
+    , gcGarbageCollections :: GcGarbageCollections
+    }
+  deriving (Show)
+
+emptyGcState :: GcState
+emptyGcState =
+    GcState
+      (GcQueue [])
+      (GcBlocks [])
+      (GcGarbageCollections [])
+
+-- | The length of the queue
+queueLength :: GcState -> Int
+queueLength = length . unGcQueue . gcQueue
+
+-- | The overlap (number of blocks) between ImmutableDB and VolatileDB
+overlap :: GcState -> Int
+overlap = length . unGcBlocks . gcBlocks
+
+-- | Number of blocks that could be GC'ed but haven't been
+unnecessaryOverlap
+  :: Time  -- ^ The current time
+  -> GcState
+  -> Int
+unnecessaryOverlap now =
+    length . filter ((<= now) . snd) . unGcBlocks . gcBlocks
+
+-- | Run all garbage collections schedule before or at the given time.
+runGc :: Time -> GcState -> GcState
+runGc now gcState = GcState {
+      gcQueue              = GcQueue gcQueueLater
+    , gcBlocks             = case mbHighestGCedSlot of
+        Nothing              -> gcBlocks gcState
+        Just highestGCedSlot -> GcBlocks $
+          filter
+            ((> highestGCedSlot) . blockSlotNo . fst)
+            (unGcBlocks (gcBlocks gcState))
+    , gcGarbageCollections = GcGarbageCollections $
+        map toGarbageCollection gcQueueNow <> pastGarbageCollections
+    }
+  where
+    (gcQueueLater, gcQueueNow) =
+      partition ((> now) . scheduledGcTime) (unGcQueue (gcQueue gcState))
+    mbHighestGCedSlot = safeMaximum $ map scheduledGcSlot gcQueueNow
+    GcGarbageCollections pastGarbageCollections =
+      gcGarbageCollections gcState
+
+    toGarbageCollection :: ScheduledGc -> (SlotNo, Time)
+    toGarbageCollection (ScheduledGc time slot) = (slot, time)
+
+step
+  :: GcParams
+  -> Block
+  -> GcState
+  -> GcState
+step gcParams block =
+    -- Note the two calls to 'runGc': we simulate the behaviour of two threads
+    -- (schedule GCs, execute schedule) from this (single-threaded) function.
+    --
+    -- The first (innermost) 'runGc' is needed to run any outstanding GCs at
+    -- @now@. In other words, we run the "execute schedule" thread. Otherwise,
+    -- we will see GCs scheduled in the past in the queue when we schedule a
+    -- new one.
+    --
+    -- The second (outermost) 'runGc' is needed to immediately run the
+    -- scheduled GCs in case we have a 'gcDelay' of 0.
+      runGc now
+    . schedule
+    . runGc now
+  where
+    slot = blockSlotNo block
+    now  = blockArrivalTime block
+
+    schedule :: GcState -> GcState
+    schedule gcState = GcState {
+          gcQueue              = GcQueue gcQueue'
+        , gcBlocks             = GcBlocks $
+              (block, gcDelay gcParams `addTime` now)
+            : unGcBlocks (gcBlocks gcState)
+        , gcGarbageCollections = gcGarbageCollections gcState
+        }
+      where
+        scheduledTime = Impl.computeTimeForGC gcParams now
+        gcQueue' = case unGcQueue (gcQueue gcState) of
+          ScheduledGc prevScheduledTime _prevSlot:queue'
+            | scheduledTime == prevScheduledTime
+            -> ScheduledGc scheduledTime slot:queue'
+          queue
+            -> ScheduledGc scheduledTime slot:queue
+
+{-------------------------------------------------------------------------------
+  GcStateSummary
+-------------------------------------------------------------------------------}
+
+data GcStateSummary = GcStateSummary {
+      gcSummaryNow         :: Time
+    , gcSummaryQueue       :: GcQueue
+    , gcSummaryQueueLength :: Int
+    , gcSummaryOverlap     :: Int
+    , gcSummaryUnnecessary :: Int
+    }
+  deriving (Show)
+
+computeGcStateSummary :: Time -> GcState -> GcStateSummary
+computeGcStateSummary now gcState = GcStateSummary {
+      gcSummaryNow         = now
+    , gcSummaryQueue       = gcQueue                gcState
+    , gcSummaryQueueLength = queueLength            gcState
+    , gcSummaryOverlap     = overlap                gcState
+    , gcSummaryUnnecessary = unnecessaryOverlap now gcState
+    }
+
+{-------------------------------------------------------------------------------
+  Trace
+-------------------------------------------------------------------------------}
+
+type Trace a = [a]
+
+computeTrace :: GcParams -> [Block] -> Trace (Time, GcState)
+computeTrace gcParams blocks =
+    zip
+      (map blockArrivalTime blocks)
+      -- Remember:
+      -- scanl f z [x1, x2, ...] == [z, z `f` x1, (z `f` x1) `f` x2, ...]
+      (drop 1 (scanl (flip (step gcParams)) emptyGcState blocks))
+
+summarise :: GcParams -> Int -> Trace GcStateSummary
+summarise gcParams numBlocks =
+   map (uncurry computeGcStateSummary) $
+     computeTrace gcParams (genBlocks numBlocks)
+
+example :: GcParams -> Trace GcStateSummary
+example gcParams = summarise gcParams 1000
+
+-- | Process the remaining scheduled garbage collections in the queue. The
+-- already performed garbage collections ('gcGarbageCollections') are included
+-- in the final 'GcGarbageCollections'.
+processQueueToEnd :: GcState -> GcGarbageCollections
+processQueueToEnd gcState@GcState { gcQueue = GcQueue queue } =
+    gcGarbageCollections (foldl' (flip runGc) gcState timesToGcAt)
+  where
+    timesToGcAt = sort (map scheduledGcTime queue)
+
+{-------------------------------------------------------------------------------
+  Run the real GcSchedule
+-------------------------------------------------------------------------------}
+
+runGcSchedule :: GcParams -> [Block] -> (Trace GcQueue, GcGarbageCollections)
+runGcSchedule gcParams blocks = runSimOrThrow test
+  where
+    test :: IOLike m => m (Trace GcQueue, GcGarbageCollections)
+    test = do
+      varGCs <- newTVarM (GcGarbageCollections [])
+      gcSchedule <- Impl.newGcSchedule
+      withAsync (gcThread varGCs gcSchedule) $ \asyncGcThread -> do
+        link asyncGcThread
+
+        gcQueueTrace <- forM blocks $ \block -> do
+          waitUntil (blockArrivalTime block)
+          Impl.scheduleGC nullTracer (blockSlotNo block) gcParams gcSchedule
+          -- Just the minimal number of time so that the background thread
+          -- gets its chance to run. Since this is the IO simulator, it will
+          -- run instantly.
+          threadDelay (picosecondsToDiffTime 1)
+          GcQueue <$> atomically (Impl.dumpGcSchedule gcSchedule)
+
+        -- Wait until the implementation's queue is empty
+        atomically $ do
+          queue <- Impl.dumpGcSchedule gcSchedule
+          check (null queue)
+
+        cancel asyncGcThread
+        gcs <- atomically $ readTVar varGCs
+        return (gcQueueTrace, gcs)
+
+    gcThread
+      :: IOLike m
+      => StrictTVar m GcGarbageCollections
+      -> Impl.GcSchedule m
+      -> m Void
+    gcThread varGCs gcSchedule =
+      Impl.gcScheduleRunner gcSchedule $ \slotNo -> do
+        -- Record the time at which a GC for @slotNo@ was triggered in a TVar
+        now <- getMonotonicTime
+        atomically $ modifyTVar varGCs $ \(GcGarbageCollections gcs) ->
+          GcGarbageCollections $ (slotNo, now) : gcs
+
+    waitUntil :: IOLike m => Time -> m ()
+    waitUntil t = do
+      now <- getMonotonicTime
+      let toWait = max 0 (t `diffTime` now)
+      threadDelay toWait
+
+{-------------------------------------------------------------------------------
+  TestSetup
+-------------------------------------------------------------------------------}
+
+data TestSetup = TestSetup {
+    -- | Number of blocks
+    --
+    -- This determines the length of the trace. Shrinking this value means
+    -- we find the smallest trace that yields the error
+    testNumBlocks            :: Int
+
+    -- | GC delay in seconds
+    --
+    -- We keep this as a separate value /in seconds/ so that (1) it is easily
+    -- shrinkable and (2) we can meaningfully use 'blocksInInterval'
+  , testDelay                :: Integer
+
+    -- | GC interval in seconds
+    --
+    -- See 'testDelay'
+  , testInterval             :: Integer
+
+    -- Derived
+  , testGcParams             :: GcParams
+  , testTrace                :: Trace GcStateSummary
+    -- | The garbage collections that will have been performed after
+    -- processing the whole queue.
+  , testGcGarbageCollections :: GcGarbageCollections
+  }
+  deriving (Show)
+
+genBlocks :: Int -> [Block]
+genBlocks numBlocks = map Block [1..numBlocks]
+
+mkTestSetup :: Int -> Integer -> Integer -> TestSetup
+mkTestSetup numBlocks delay interval = TestSetup {
+      testNumBlocks            = numBlocks
+    , testDelay                = delay
+    , testInterval             = interval
+      -- Derived values
+    , testGcParams             = gcParams
+    , testTrace                = map (uncurry computeGcStateSummary) trace
+    , testGcGarbageCollections = processQueueToEnd finalState
+    }
+  where
+    trace = computeTrace gcParams (genBlocks numBlocks)
+
+    finalState = maybe emptyGcState snd (lastMaybe trace)
+
+    gcParams :: GcParams
+    gcParams = GcParams {
+          gcDelay    = secondsToDiffTime delay
+        , gcInterval = secondsToDiffTime interval
+        }
+
+
+instance Arbitrary TestSetup where
+  arbitrary =
+      mkTestSetup
+        <$> ((* 10) <$> getSize) -- Number of blocks
+        <*> choose (0, 100)      -- Delay
+        <*> choose (1, 120)      -- Interval
+
+  shrink TestSetup{..} = concat [
+        [ mkTestSetup testNumBlocks' testDelay testInterval
+        | testNumBlocks' <- shrink testNumBlocks
+        ]
+
+      , [ mkTestSetup testNumBlocks testDelay' testInterval
+        | testDelay' <- shrink testDelay
+        ]
+
+      , [ mkTestSetup testNumBlocks testDelay testInterval'
+        | testInterval' <- shrink testInterval
+        , testInterval' > 0
+        ]
+
+        -- Shrink two values shrink /together/
+        -- Note: we don't compute all possible combinations, we shrink both
+      , [ mkTestSetup testNumBlocks testDelay' testInterval'
+        | testDelay    > 0
+        , testInterval > 1
+        , let testDelay'    = testDelay    - 1
+        , let testInterval' = testInterval - 1
+        ]
+      ]

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1541,8 +1541,10 @@ mkArgs cfg chunkInfo initLedger tracer registry varCurSlot
     , cdbTracer               = tracer
     , cdbTraceLedger          = nullTracer
     , cdbRegistry             = registry
-    , cdbGcDelay              = 0
     , cdbBlocksToAddSize      = 2
+      -- We don't run the background threads, so these are not used
+    , cdbGcDelay              = 1
+    , cdbGcInterval           = 1
     }
 
 tests :: TestTree


### PR DESCRIPTION
Previously, we scheduled a garbage collection for each block for 10 seconds in
the future. This meant that our scheduled GCs queue was blocks/s * 10 long.
When tracing the queue length on my machine, it hovered between 5000 and 6000
entries. Moreover, a VolatileDB garbage collection is triggered at blocks/s,
which should result in a lot of contention for the VolatileDB state.

Even worse is that a 10 second delay is too short to reliably ensure the block
will have been flushed to disk (in the ImmutableDB) before it is garbage
collected. However, increasing this delay would make the queue significantly
longer.

To fix these issues, we introduce a GC interval (in seconds). We batch all GCs
in the same interval together. This means that the queue length is now at most
⌈delay / interval⌉ + 1, e.g., 60s / 10s = 7, which is much shorter than
5000-6000. Moreover, there will be at most one GC every `interval` seconds,
e.g., 10s.

The cost of switching to a longer GC delay is that the in-memory index of the
VolatileDB will be larger, making operations on it, such as lookups, more
expensive (most operations are `O(n*log(n))`). See the docstring of
'defaultSpecificArgs' for what the new default values of `gcDelay` and
`gcInterval` mean in practice.