### PR TITLE
ChainDB: update a docstring and simplify a function

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
@@ -33,7 +33,6 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.ImmDB (
   , closeDB
   , iteratorNext
   , iteratorHasNext
-  , iteratorPeek
   , iteratorClose
     -- * Tracing
   , TraceEvent
@@ -640,12 +639,6 @@ iteratorHasNext :: (HasCallStack, MonadCatch m)
                 -> ImmDB.Iterator (HeaderHash blk) m a
                 -> m (Maybe (Either EpochNo SlotNo, HeaderHash blk))
 iteratorHasNext db it = withDB db $ const $ ImmDB.iteratorHasNext it
-
-iteratorPeek :: (HasCallStack, MonadCatch m)
-             => ImmDB m blk
-             -> ImmDB.Iterator (HeaderHash blk) m a
-             -> m (ImmDB.IteratorResult a)
-iteratorPeek db it = withDB db $ const $ ImmDB.iteratorPeek it
 
 iteratorClose :: (HasCallStack, MonadCatch m)
               => ImmDB m blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
@@ -66,7 +66,7 @@ import           Control.Monad.Except
 import           Control.Tracer (Tracer, nullTracer)
 import           Data.Bifunctor
 import qualified Data.ByteString.Lazy as Lazy
-import           Data.Functor (($>), (<&>))
+import           Data.Functor ((<&>))
 import           GHC.Stack
 import           System.FilePath ((</>))
 
@@ -473,10 +473,9 @@ stream db registry blockComponent from to = runExceptT $ do
                  m
                  (ImmDB.Iterator (HeaderHash blk) m b)
     openStream start end = ExceptT $
-        bimap toUnknownRange (fmap snd . stopAt to) <$>
-      -- 'stopAt' needs to know the hash of each streamed block, so we \"Get\"
-      -- it in addition to @b@, but we drop it afterwards.
-        openIterator db registry ((,) <$> GetHash <*> blockComponent) start end
+        fmap (first toUnknownRange) $
+        traverse (stopAt to) =<<
+        openIterator db registry blockComponent start end
       where
         toUnknownRange :: ImmDB.WrongBoundError (HeaderHash blk) -> UnknownRange blk
         toUnknownRange e
@@ -494,32 +493,40 @@ stream db registry blockComponent from to = runExceptT $ do
           ImmDB.EmptySlotError slot     -> slot
           ImmDB.WrongHashError slot _ _ -> slot
 
-    -- | The ImmutableDB doesn't support an exclusive end bound, so we stop
-    -- the iterator when it reaches its exclusive end bound.
-    stopAt :: forall a.
-              StreamTo blk
-           -> ImmDB.Iterator (HeaderHash blk) m (HeaderHash blk, a)
-           -> ImmDB.Iterator (HeaderHash blk) m (HeaderHash blk, a)
+    -- | The ImmutableDB doesn't support an exclusive end bound, so we take
+    -- care of that here. We are given an iterator that uses the point of the
+    -- exclusive end bound as its inclusive end bound. We convert the iterator
+    -- into one obeying the exclusive end bound by always looking at the hash
+    -- of the next block to stream (which is cheap).
+    --
+    -- No-op if the end bound is inclusive.
+    stopAt :: StreamTo blk
+           -> ImmDB.Iterator (HeaderHash blk) m b
+           -> m (ImmDB.Iterator (HeaderHash blk) m b)
     stopAt = \case
-      StreamToInclusive _  -> id
-      StreamToExclusive pt -> \it -> it
-          { ImmDB.iteratorNext    = ignoreExclusiveBound <$> ImmDB.iteratorNext it
-          , ImmDB.iteratorPeek    = ignoreExclusiveBound <$> ImmDB.iteratorPeek it
-          , ImmDB.iteratorHasNext = ImmDB.iteratorHasNext it >>= \case
-              Nothing -> return Nothing
-              Just next@(_epochOrSlot, hash)
-                | isEnd hash
-                -> ImmDB.iteratorClose it $> Nothing
-                | otherwise
-                -> return $ Just next
-          }
+      StreamToInclusive _     -> return
+      StreamToExclusive endPt -> \it -> do
+          -- Whenever the iterator is moved to the next block, we check
+          -- whether the next block (cheap with 'ImmDB.iteratorHasNext') is
+          -- the end bound, in which case we close the iterator. All other
+          -- operations on the iterator can remain the same.
+          --
+          -- We must do the check immediately, because the very first block
+          -- might be the exclusive upper bound.
+          closeWhenEndIsNext it
+          return it
+            { ImmDB.iteratorNext =
+                ImmDB.iteratorNext it <* closeWhenEndIsNext it
+            }
         where
-          isEnd hash = realPointHash pt == hash
-          ignoreExclusiveBound = \case
-            ImmDB.IteratorResult (hash, _)
-              | isEnd hash
-              -> ImmDB.IteratorExhausted
-            itRes -> itRes
+          closeWhenEndIsNext it = ImmDB.iteratorHasNext it >>= \case
+            Nothing
+              -> return ()
+            Just (_epochOrSlot, hash)
+              | realPointHash endPt == hash
+              -> ImmDB.iteratorClose it
+              | otherwise
+              -> return ()
 
 -- | Stream headers/blocks after the given point
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
@@ -224,16 +224,6 @@ data Iterator hash m a = Iterator
     -- 'iteratorClose'.
     iteratorNext    :: HasCallStack => m (IteratorResult a)
 
-    -- | Read the blob the 'Iterator' is currently pointing.
-    --
-    -- This operation is idempotent.
-    --
-    -- The next time 'iteratorNext' is called, the same 'IteratorResult' will
-    -- be returned.
-    --
-    -- Throws a 'ClosedDBError' if the database is closed.
-  , iteratorPeek    :: HasCallStack => m (IteratorResult a)
-
     -- | Return the epoch number (in case of an EBB) or slot number and hash
     -- of the next blob, if there is a next. Return 'Nothing' if not.
     --
@@ -252,7 +242,7 @@ instance NoUnexpectedThunks (Iterator hash m a) where
   whnfNoUnexpectedThunks _ctxt _itr = return NoUnexpectedThunks
 
 -- | Variant of 'traverse' instantiated to @'Iterator' hash m@ that executes
--- the monadic function when calling 'iteratorNext' and 'iteratorPeek'.
+-- the monadic function when calling 'iteratorNext'.
 traverseIterator
   :: Monad m
   => (a -> m b)
@@ -260,7 +250,6 @@ traverseIterator
   -> Iterator hash m b
 traverseIterator f itr = Iterator{
       iteratorNext    = iteratorNext itr >>= traverse f
-    , iteratorPeek    = iteratorPeek itr >>= traverse f
     , iteratorHasNext = iteratorHasNext itr
     , iteratorClose   = iteratorClose itr
     }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -41,7 +41,6 @@ openDBMock chunkInfo = do
                  -> Iterator hash m b
         iterator blockComponent itId = Iterator
           { iteratorNext    = update  $ iteratorNextModel    itId blockComponent
-          , iteratorPeek    = query   $ iteratorPeekModel    itId blockComponent
           , iteratorHasNext = query   $ iteratorHasNextModel itId
           , iteratorClose   = update_ $ iteratorCloseModel   itId
           }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -42,7 +42,6 @@ module Test.Ouroboros.Storage.ImmutableDB.Model
   , streamModel
   , streamAllModel
   , iteratorNextModel
-  , iteratorPeekModel
   , iteratorHasNextModel
   , iteratorCloseModel
   ) where
@@ -874,23 +873,6 @@ iteratorNextModel itId blockComponent dbm@DBModel {..} =
           res = IteratorResult $
             extractBlockComponent hash slot isEBB bi blockComponent
 
-          (slot, isEBB) = case epochOrSlot of
-            Left epoch  -> (slotNoOfEBB' dbm epoch, IsEBB)
-            Right slot' -> (slot', IsNotEBB)
-
-iteratorPeekModel
-  :: IteratorId
-  -> BlockComponent (ImmutableDB hash m) b
-  -> DBModel hash
-  -> IteratorResult b
-iteratorPeekModel itId blockComponent dbm@DBModel { dbmIterators } =
-    case Map.lookup itId dbmIterators of
-      Nothing                      -> IteratorExhausted
-      Just (IteratorModel [])      -> IteratorExhausted
-      Just (IteratorModel ((epochOrSlot, hash, bi):_)) ->
-          IteratorResult $
-            extractBlockComponent hash slot isEBB bi blockComponent
-        where
           (slot, isEBB) = case epochOrSlot of
             Left epoch  -> (slotNoOfEBB' dbm epoch, IsEBB)
             Right slot' -> (slot', IsNotEBB)


### PR DESCRIPTION
* ChainDB.Iterator: update costs in the docstring 

  Opening an iterator no longer requires reading the blocks corresponding to the bounds from disk, their hashes can be looked up in the cached primary and secondary indices of the ImmutableDB. Update the out-of-date docstring.

* ImmutableDB: remove unused `iteratorPeek`

* ChainDB.ImmDB: simpler implementation of exclusive end bound 