### PR TITLE
Shelley Tx generation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -159,43 +159,43 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 5c5854be017f75c703b11c1aad4b765f511ee70e
-  --sha256: 0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8
+  tag: 27281d832f2d1d09198efc8ab1916a55c079208a
+  --sha256: 14x6yf7hhzd3d1xgd91wj76dmx6mxgjxv7bp7sjaa6ss6yvkjsg9
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 5c5854be017f75c703b11c1aad4b765f511ee70e
-  --sha256: 0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8
+  tag: 27281d832f2d1d09198efc8ab1916a55c079208a
+  --sha256: 14x6yf7hhzd3d1xgd91wj76dmx6mxgjxv7bp7sjaa6ss6yvkjsg9
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 5c5854be017f75c703b11c1aad4b765f511ee70e
-  --sha256: 0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8
+  tag: 27281d832f2d1d09198efc8ab1916a55c079208a
+  --sha256: 14x6yf7hhzd3d1xgd91wj76dmx6mxgjxv7bp7sjaa6ss6yvkjsg9
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 5c5854be017f75c703b11c1aad4b765f511ee70e
-  --sha256: 0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8
+  tag: 27281d832f2d1d09198efc8ab1916a55c079208a
+  --sha256: 14x6yf7hhzd3d1xgd91wj76dmx6mxgjxv7bp7sjaa6ss6yvkjsg9
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 5c5854be017f75c703b11c1aad4b765f511ee70e
-  --sha256: 0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8
+  tag: 27281d832f2d1d09198efc8ab1916a55c079208a
+  --sha256: 14x6yf7hhzd3d1xgd91wj76dmx6mxgjxv7bp7sjaa6ss6yvkjsg9
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 5c5854be017f75c703b11c1aad4b765f511ee70e
-  --sha256: 0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8
+  tag: 27281d832f2d1d09198efc8ab1916a55c079208a
+  --sha256: 14x6yf7hhzd3d1xgd91wj76dmx6mxgjxv7bp7sjaa6ss6yvkjsg9
   subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package
@@ -207,29 +207,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 90b14c056059d0082cb2641f9c77cb1b097be329
-  --sha256: 029lqlf33a3vvy933fil8qglv3hjaprankllr80h0acspqjzahk0
+  tag: 11ba6964a65f9d54f3cda30ad82927481617f436
+  --sha256: 05vlmhxqsjn2y8ff864mm0jjbkl9pmb5qscbhwk6nrngqvxg00ys
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 90b14c056059d0082cb2641f9c77cb1b097be329
-  --sha256: 029lqlf33a3vvy933fil8qglv3hjaprankllr80h0acspqjzahk0
+  tag: 11ba6964a65f9d54f3cda30ad82927481617f436
+  --sha256: 05vlmhxqsjn2y8ff864mm0jjbkl9pmb5qscbhwk6nrngqvxg00ys
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 90b14c056059d0082cb2641f9c77cb1b097be329
-  --sha256: 029lqlf33a3vvy933fil8qglv3hjaprankllr80h0acspqjzahk0
+  tag: 11ba6964a65f9d54f3cda30ad82927481617f436
+  --sha256: 05vlmhxqsjn2y8ff864mm0jjbkl9pmb5qscbhwk6nrngqvxg00ys
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 90b14c056059d0082cb2641f9c77cb1b097be329
-  --sha256: 029lqlf33a3vvy933fil8qglv3hjaprankllr80h0acspqjzahk0
+  tag: 11ba6964a65f9d54f3cda30ad82927481617f436
+  --sha256: 05vlmhxqsjn2y8ff864mm0jjbkl9pmb5qscbhwk6nrngqvxg00ys
   subdir: crypto/test
 
 source-repository-package

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/DualPBFT.hs
@@ -31,10 +31,10 @@ import qualified Cardano.Chain.ProtocolConstants as Impl
 import qualified Cardano.Chain.UTxO as Impl
 
 import qualified Byron.Spec.Chain.STS.Rule.Chain as Spec
-import qualified Control.State.Transition.Extended as Spec
-import qualified Control.State.Transition.Generator as Spec.QC
 import qualified Byron.Spec.Ledger.Core as Spec
 import qualified Byron.Spec.Ledger.UTxO as Spec
+import qualified Control.State.Transition.Extended as Spec
+import qualified Control.State.Transition.Generator as Spec.QC
 
 import qualified Test.Cardano.Chain.Elaboration.UTxO as Spec.Test
 
@@ -161,6 +161,7 @@ setupTestOutput setup@SetupDualPBft{..} =
             setupGenesis
             setupParams
             (Just coreNodeId)
+      , txGenExtra  = ()
       }
 
 -- | Override 'TestConfig'
@@ -297,7 +298,7 @@ realPBftParams ByronSpecGenesis{..} =
 -------------------------------------------------------------------------------}
 
 instance TxGen DualByronBlock where
-  testGenTxs _numCoreNodes curSlotNo cfg = \st -> do
+  testGenTxs _numCoreNodes curSlotNo cfg () = \st -> do
       n <- generateBetween 0 20
       go [] n $ applyChainTick (configLedger cfg) curSlotNo st
     where

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
@@ -780,6 +780,7 @@ prop_simple_real_pbft_convergence produceEBBs k
                   withSeed initSeed $   -- seems fine to reuse seed for this
                   sequence $ let ms = Crypto.genKeyDSIGN Stream.:< ms in ms
               }
+            , txGenExtra = ()
             }
 
     -- Byron has a hard-coded relation between k and the size of an epoch

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/TxGen/Byron.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/TxGen/Byron.hs
@@ -8,4 +8,4 @@ import           Test.ThreadNet.TxGen
 instance TxGen ByronBlock where
   -- We don't generate transactions for 'ByronBlock', but we do for
   -- 'DualByronBlock'.
-  testGenTxs _ _ _ _ = return []
+  testGenTxs _ _ _ _ _ = return []

--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -92,6 +92,7 @@ test-suite test
                      , cryptonite        >=0.25  && <0.26
                      , generic-random
                      , hedgehog-quickcheck
+                     , mtl
                      , QuickCheck
                      , time
                      , tasty

--- a/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger.hs
+++ b/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger.hs
@@ -262,7 +262,7 @@ genHash proxy = mkDummyHash proxy <$> arbitrary
 
 instance Arbitrary Block where
   arbitrary = do
-    let Gen.KeySpace_ { Gen.ksCoreNodes } = Gen.Preset.keySpace
+    let Gen.KeySpace_ { Gen.ksCoreNodes } = Gen.geKeySpace Gen.Preset.genEnv
     prevHash         <- unShelleyHash <$> arbitrary
     allPoolKeys      <- elements (map snd ksCoreNodes)
     txs              <- return [] -- arbitrary
@@ -517,7 +517,7 @@ instance Arbitrary (SL.EpochState TPraosMockCrypto) where
     <*> arbitrary
 
 instance Arbitrary SL.PParams where
-  arbitrary = Gen.genPParams
+  arbitrary = Gen.genPParams (Gen.geConstants Gen.Preset.genEnv)
 
 instance Crypto c => Arbitrary (SL.GenDelegs c) where
   arbitrary = SL.GenDelegs <$> arbitrary

--- a/ouroboros-consensus-shelley/test/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley/test/Test/ThreadNet/TxGen/Shelley.hs
@@ -1,14 +1,119 @@
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE FlexibleInstances        #-}
+{-# LANGUAGE NamedFieldPuns           #-}
+{-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE ViewPatterns             #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.ThreadNet.TxGen.Shelley () where
+module Test.ThreadNet.TxGen.Shelley
+  ( ShelleyTxGenExtra(..)
+  ) where
+
+import           Control.Monad.Except (runExcept)
+import           Crypto.Number.Generate (generateBetween, generateMax)
+import           Crypto.Random (MonadRandom)
+import qualified Data.Sequence as Seq
+
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Abstract
+
+import qualified Shelley.Spec.Ledger.LedgerState as SL
+import qualified Shelley.Spec.Ledger.STS.Ledger as STS
+import qualified Shelley.Spec.Ledger.Tx as SL
+
+import           Ouroboros.Consensus.Shelley.Ledger
+
+import           Test.QuickCheck.Gen (Gen (..), suchThat)
+import           Test.QuickCheck.Random (mkQCGen)
 
 import           Test.ThreadNet.TxGen (TxGen (..))
 
-import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
+import qualified Test.Shelley.Spec.Ledger.ConcreteCryptoTypes as CSL
+import qualified Test.Shelley.Spec.Ledger.Generator.Core as Gen
+import qualified Test.Shelley.Spec.Ledger.Generator.Utxo as Gen
 
 import           Test.Consensus.Shelley.MockCrypto (TPraosMockCrypto)
 
+data ShelleyTxGenExtra = ShelleyTxGenExtra
+  { -- | Generator environment.
+    stgeGenEnv :: Gen.GenEnv
+  }
 
 instance TxGen (ShelleyBlock TPraosMockCrypto) where
+
+  type TxGenExtra (ShelleyBlock TPraosMockCrypto) = ShelleyTxGenExtra
+
   -- TODO #1823
-  testGenTxs _ _ _ _ = return []
+  testGenTxs _numCoreNodes curSlotNo cfg (ShelleyTxGenExtra genEnv) lst = do
+      n <- generateBetween 0 20
+      go [] n $ applyChainTick (configLedger cfg) curSlotNo lst
+    where
+      go :: MonadRandom m
+         => [GenTx (ShelleyBlock TPraosMockCrypto)]  -- ^ Accumulator
+         -> Integer  -- ^ Number of txs to still produce
+         -> TickedLedgerState (ShelleyBlock TPraosMockCrypto)
+         -> m [GenTx (ShelleyBlock TPraosMockCrypto)]
+      go acc 0 _  = return (reverse acc)
+      go acc n st = do
+        tx <- quickCheckAdapter $ genTx cfg st genEnv
+        case runExcept $ applyTx (configLedger cfg) tx st of
+          -- We don't mind generating invalid transactions
+          Left  _   -> go (tx:acc) (n - 1) st
+          Right st' -> go (tx:acc) (n - 1) st'
+
+genTx
+  :: TopLevelConfig (ShelleyBlock TPraosMockCrypto)
+  -> TickedLedgerState (ShelleyBlock TPraosMockCrypto)
+  -> Gen.GenEnv
+  -> Gen (GenTx (ShelleyBlock TPraosMockCrypto))
+genTx _cfg TickedLedgerState { tickedSlotNo, tickedLedgerState } genEnv =
+    mkShelleyTx <$> Gen.genTx
+      genEnv
+      ledgerEnv
+      (utxoSt, dpState) `suchThat` isSimpleTx
+  where
+    -- Filter (for the moment) to "simple" transactions - in particular, we
+    -- filter all transactions which have certificates. Testing with
+    -- certificates requires additional handling in the testing framework,
+    -- because, for example, they may transfer block issuance rights from one
+    -- node to another, and we must have the relevant nodes brought online at
+    -- that point.
+    isSimpleTx (SL._body -> txb) =
+      (Seq.null $ SL._certs txb)
+    ShelleyLedgerState { shelleyState } = tickedLedgerState
+
+    epochState :: CSL.EpochState
+    epochState = SL.nesEs shelleyState
+
+    ledgerEnv :: STS.LedgerEnv
+    ledgerEnv = STS.LedgerEnv {
+        ledgerSlotNo   = tickedSlotNo
+      , ledgerIx       = 0 -- TODO Ix
+      , ledgerPp       = SL.esPp epochState
+      , ledgerReserves =
+            SL._reserves
+          . SL.esAccountState
+          $ epochState
+      }
+
+    utxoSt :: CSL.UTxOState
+    utxoSt =
+        SL._utxoState
+      . SL.esLState
+      $ epochState
+
+    dpState :: CSL.DPState
+    dpState =
+        SL._delegationState
+      . SL.esLState
+      $ epochState
+
+{-------------------------------------------------------------------------------
+  QuickCheck to MonadRandom adapter
+-------------------------------------------------------------------------------}
+
+-- | Run the generator by producing a random seed
+quickCheckAdapter :: MonadRandom m => Gen a -> m a
+quickCheckAdapter (MkGen g) = do
+    seed <- fromIntegral <$> generateMax (fromIntegral (maxBound :: Int))
+    return $ g (mkQCGen seed) 30

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -100,6 +100,7 @@ prop_simple_bft_convergence k
                     k
                     (defaultSimpleBlockConfig k slotLength)
             , rekeying    = Nothing
+            , txGenExtra  = ()
             }
 
     -- The mock ledger doesn't really care, and neither does BFT.

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -116,6 +116,7 @@ prop_simple_leader_schedule_convergence
                                         praosSlotLength)
                                       schedule
             , rekeying    = Nothing
+            , txGenExtra  = ()
             }
 
     -- I don't think this value actually matters if we override the leader

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -105,6 +105,7 @@ prop_simple_pbft_convergence
                               params
                               (defaultSimpleBlockConfig k pbftSlotLength)
             , rekeying    = Nothing
+            , txGenExtra  = ()
             }
 
     -- The mock ledger doesn't really care, and neither does BFT.

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -119,6 +119,7 @@ prop_simple_praos_convergence
                                         praosSecurityParam
                                         praosSlotLength)
             , rekeying    = Nothing
+            , txGenExtra  = ()
             }
 
     -- TODO: Right now mock Praos has an explicit epoch size in its parameters

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/TxGen/Mock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/TxGen/Mock.hs
@@ -22,7 +22,7 @@ import           Test.ThreadNet.TxGen
 -------------------------------------------------------------------------------}
 
 instance TxGen (SimpleBlock SimpleMockCrypto ext) where
-  testGenTxs numCoreNodes curSlotNo _cfg ledgerState = do
+  testGenTxs numCoreNodes curSlotNo _cfg () ledgerState = do
       n <- generateBetween 0 20
       -- We don't update the UTxO after each transaction, so some of the
       -- generated transactions could very well be invalid.

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -168,6 +168,7 @@ data TestConfigBlock blk = TestConfigBlock
   { forgeEbbEnv :: Maybe (ForgeEbbEnv blk)
   , nodeInfo    :: CoreNodeId -> TestNodeInitialization blk
   , rekeying    :: Maybe (Rekeying blk)
+  , txGenExtra  :: TxGenExtra blk
   }
 
 data Rekeying blk = forall opKey. Rekeying
@@ -216,7 +217,7 @@ runTestNetwork
     , initSeed
     }
   epochSize
-  TestConfigBlock{forgeEbbEnv, nodeInfo, rekeying}
+  TestConfigBlock{forgeEbbEnv, nodeInfo, rekeying, txGenExtra}
   = runSimOrThrow $ do
     let tna = ThreadNetworkArgs
           { tnaForgeEbbEnv    = forgeEbbEnv
@@ -230,6 +231,7 @@ runTestNetwork
           , tnaSlotLength     = slotLength
           , tnaTopology       = nodeTopology
           , tnaEpochSize      = epochSize
+          , tnaTxGenExtra     = txGenExtra
           }
 
     case rekeying of

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/TxGen.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/TxGen.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE TypeFamilies #-}
 -- | Transaction generator for testing
 module Test.ThreadNet.TxGen
   ( TxGen (..)
   ) where
 
 import           Cardano.Slotting.Slot (SlotNo)
+import           Data.Kind (Type)
 
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -16,6 +18,11 @@ import           Ouroboros.Consensus.Util.Random
 -------------------------------------------------------------------------------}
 
 class TxGen blk where
+
+  -- | Extra information required to generate transactions
+  type TxGenExtra blk :: Type
+  type TxGenExtra blk = ()
+
   -- | Generate a number of transactions, valid or invalid, that can be
   -- submitted to a node's Mempool.
   --
@@ -27,5 +34,6 @@ class TxGen blk where
              => NumCoreNodes
              -> SlotNo
              -> TopLevelConfig blk
+             -> TxGenExtra blk
              -> LedgerState blk
              -> m [GenTx blk]

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,7 +49,7 @@ extra-deps:
       - slotting
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 5c5854be017f75c703b11c1aad4b765f511ee70e
+    commit: 27281d832f2d1d09198efc8ab1916a55c079208a
     subdirs:
       - byron/chain/executable-spec
       - byron/ledger/executable-spec
@@ -65,7 +65,7 @@ extra-deps:
   - gray-code-0.3.1
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 90b14c056059d0082cb2641f9c77cb1b097be329
+    commit: 11ba6964a65f9d54f3cda30ad82927481617f436
     subdirs:
       - cardano-ledger
       - cardano-ledger/test


### PR DESCRIPTION
Should be fairly small changes here, the majority of what was needed was on the `cardano-ledger-specs` side. Transactions now generate correctly in Shelley tests, although as yet the tests themselves fail, most likely due to complex transactions which we can't yet handle correctly.

Actual contributions of this PR:
- We add additional context (`TxGenExtra`) for transaction generation, which can be instantiated at specific block types.
- We set this to `GenEnv` for Shelley, which allows us to construct an appropriate Key space for transaction generation.