### PR TITLE
ImmutableDB: migrate XXXXX.epoch to XXXXX.chunk

### DIFF
--- a/ouroboros-consensus-byron/tools/db-converter/Main.hs
+++ b/ouroboros-consensus-byron/tools/db-converter/Main.hs
@@ -119,7 +119,7 @@ main = do
       putStrLn $ "Writing to " ++ show dbDir
       for_ (sort epochFiles) $ \f -> do
         putStrLn $ "Converting file " ++ show f
-        convertEpochFile (EpochSlots epochSlots) f dbDir'
+        convertChunkFile (EpochSlots epochSlots) f dbDir'
     Validate
       { dbDir
       , configFile
@@ -139,16 +139,16 @@ main = do
           Left err     -> throwIO $ MkConfigError err
           Right config -> validateChainDb dbDir' config onlyImmDB verbose
 
-convertEpochFile
+convertChunkFile
   :: EpochSlots
   -> Path Abs File -- ^ Input
   -> Path Abs Dir -- ^ Ouput directory
   -> IO (Either CC.ParseError ())
-convertEpochFile es inFile outDir = do
+convertChunkFile es inFile outDir = do
     createDirIfMissing True dbDir
-    -- Old filename format is XXXXX.dat, new is XXXXX.epoch
+    -- Old filename format is XXXXX.epoch, new is XXXXX.chunk
     outFileName <- parseRelFile (toFilePath (filename inFile))
-    outFile <- (dbDir </> outFileName) -<.> "epoch"
+    outFile <- (dbDir </> outFileName) -<.> "chunk"
     IO.withFile (toFilePath outFile) IO.WriteMode $ \h ->
       runResourceT $ runExceptT $ S.mapM_ (liftIO . BS.hPut h) . S.map encode $ inStream
   where

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/FsTree.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/FsTree.hs
@@ -28,6 +28,7 @@ module Test.Util.FS.Sim.FsTree (
   , createDirIfMissing
   , createDirWithParents
   , removeFile
+  , renameFile
     -- * Pretty-printing
   , pretty
   ) where
@@ -250,6 +251,17 @@ removeFile fp =
     alterFileMaybe fp Left errNotExist (const (Right Nothing))
   where
     errNotExist = Left (FsMissing fp (pathLast fp :| []))
+
+-- | Rename the file (which must exist) from the first path to the second
+-- path. If there is already a file at the latter path, it is replaced by the
+-- new one.
+renameFile :: FsPath -> FsPath -> FsTree a -> Either FsTreeError (FsTree a)
+renameFile fpOld fpNew tree = do
+    oldF  <- getFile fpOld tree
+    -- Remove the old file
+    tree' <- removeFile fpOld tree
+    -- Overwrite the new file with the old one
+    alterFile fpNew Left (Right oldF) (const (Right oldF)) tree'
 
 {-------------------------------------------------------------------------------
   Pretty-printing

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/MockFS.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/MockFS.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE MultiWayIf                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE TupleSections              #-}
@@ -43,6 +44,7 @@ module Test.Util.FS.Sim.MockFS (
   , doesDirectoryExist
   , doesFileExist
   , removeFile
+  , renameFile
     -- * Exported for the benefit of tests only
   , HandleState       -- opaque
   , OpenHandleState   -- opaque
@@ -787,6 +789,27 @@ removeFile fp =
       _ -> do
         files' <- checkFsTree $ FS.removeFile fp (mockFiles fs)
         return ((), fs { mockFiles = files' })
+
+renameFile :: CanSimFS m => FsPath -> FsPath -> m ()
+renameFile fpOld fpNew =
+    modifyMockFS $ \fs -> if
+      | fpOld `S.member` openFilePaths fs
+      -> throwError $ errRenameOpenFile fpOld
+      | fpNew `S.member` openFilePaths fs
+      -> throwError $ errRenameOpenFile fpNew
+      | otherwise
+      -> do
+        files' <- checkFsTree $ FS.renameFile fpOld fpNew (mockFiles fs)
+        return ((), fs { mockFiles = files' })
+  where
+    errRenameOpenFile fp = FsError {
+        fsErrorType   = FsIllegalOperation
+      , fsErrorPath   = fsToFsErrorPathUnmounted fp
+      , fsErrorString = "cannot rename opened file"
+      , fsErrorNo     = Nothing
+      , fsErrorStack  = callStack
+      , fsLimitation  = True
+      }
 
 {-------------------------------------------------------------------------------
   Pretty-printing

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/Pure.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/Pure.hs
@@ -40,5 +40,6 @@ pureHasFS = HasFS {
     , doesDirectoryExist       = Mock.doesDirectoryExist
     , doesFileExist            = Mock.doesFileExist
     , removeFile               = Mock.removeFile
+    , renameFile               = Mock.renameFile
     , mkFsErrorPath            = fsToFsErrorPathUnmounted
     }

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/STM.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/FS/Sim/STM.hs
@@ -55,6 +55,7 @@ simHasFS var = HasFS {
     , doesDirectoryExist       = sim  .  Mock.doesDirectoryExist
     , doesFileExist            = sim  .  Mock.doesFileExist
     , removeFile               = sim  .  Mock.removeFile
+    , renameFile               = sim  .: Mock.renameFile
     , mkFsErrorPath            = fsToFsErrorPathUnmounted
     }
   where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API.hs
@@ -134,6 +134,11 @@ data HasFS m h = HasFS {
     -- | Remove the file (which must exist)
   , removeFile               :: HasCallStack => FsPath -> m ()
 
+    -- | Rename the file (which must exist) from the first path to the second
+    -- path. If there is already a file at the latter path, it is replaced by
+    -- the new one.
+  , renameFile                 :: HasCallStack => FsPath -> FsPath -> m ()
+
     -- | Useful for better error reporting
   , mkFsErrorPath            :: FsPath -> FsErrorPath
   }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/IO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/IO.hs
@@ -66,6 +66,8 @@ ioHasFS mount = HasFS {
         Dir.createDirectoryIfMissing createParent (root fp)
     , removeFile = \fp -> rethrowFsError fp $
         Dir.removeFile (root fp)
+    , renameFile = \fp1 fp2 -> rethrowFsError fp1 $
+        Dir.renameFile (root fp1) (root fp2)
     , mkFsErrorPath = fsToFsErrorPath mount
     }
   where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
@@ -350,7 +350,7 @@ deleteAfterImpl dbEnv@ImmutableDBEnv { tracer } newTip =
               withFile hasFS chunkFile (AppendMode AllowExisting) $ \eHnd ->
                 hTruncate hasFS eHnd offset
             where
-              chunkFile = renderFile "epoch" chunk
+              chunkFile = fsPathChunkFile chunk
               offset    = unBlockOffset (Secondary.blockOffset entry)
                         + fromIntegral size
 
@@ -513,7 +513,7 @@ extractBlockComponent hasFS chunkInfo chunk curChunkInfo (entry, blockSize) = \c
       , blockOrEBB
       } = entry
     CurrentChunkInfo curChunk curChunkOffset = curChunkInfo
-    chunkFile = renderFile "epoch" chunk
+    chunkFile = fsPathChunkFile chunk
 
 getBlockOrEBBComponentImpl
   :: forall m hash b. (HasCallStack, IOLike m, Eq hash)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
@@ -73,8 +73,9 @@ import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary as P
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary
                      (BlockSize (..))
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary as Secondary
-import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util (renderFile,
-                     throwUnexpectedError)
+import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
+                     (fsPathChunkFile, fsPathPrimaryIndexFile,
+                     fsPathSecondaryIndexFile, throwUnexpectedError)
 import           Ouroboros.Consensus.Storage.ImmutableDB.Types (HashInfo (..),
                      TraceCacheEvent (..), UnexpectedError (..),
                      WithBlockSize (..))
@@ -498,7 +499,7 @@ readSecondaryIndex hasFS@HasFS { hGetSize } hashInfo chunk firstIsEBB = do
     Secondary.readAllEntries hasFS hashInfo secondaryOffset
       chunk stopCondition chunkFileSize firstIsEBB
   where
-    chunkFile = renderFile "epoch" chunk
+    chunkFile = fsPathChunkFile chunk
     -- Read from the start
     secondaryOffset = 0
     -- Don't stop until the end
@@ -528,7 +529,7 @@ loadCurrentChunkInfo hasFS chunkInfo hashInfo chunk = do
     else
       return $ emptyCurrentChunkInfo chunk
   where
-    primaryIndexFile = renderFile "primary" chunk
+    primaryIndexFile = fsPathPrimaryIndexFile chunk
 
 loadPastChunkInfo
   :: (HasCallStack, IOLike m)
@@ -770,7 +771,7 @@ readEntries cacheEnv@CacheEnv { hashInfo } chunk toRead =
     -- likely, so we mention that file in the error message.
     noEntry :: SecondaryOffset -> m a
     noEntry secondaryOffset = throwUnexpectedError $ InvalidFileError
-      (renderFile "secondary" chunk)
+      (fsPathSecondaryIndexFile chunk)
       ("no entry missing for " <> show secondaryOffset)
       callStack
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Secondary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Secondary.hs
@@ -48,8 +48,8 @@ import           Ouroboros.Consensus.Storage.FS.CRC
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary
                      (SecondaryOffset)
-import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util (renderFile,
-                     runGet, runGetWithUnconsumed)
+import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
+                     (fsPathSecondaryIndexFile, runGet, runGetWithUnconsumed)
 import           Ouroboros.Consensus.Storage.ImmutableDB.Types (BlockOrEBB (..),
                      HashInfo (..), WithBlockSize (..))
 
@@ -197,7 +197,7 @@ readEntries hasFS HashInfo { hashSize, getHash } chunk toRead =
             runGet secondaryIndexFile (getEntry isEBB getHash)
           return (entry, LastEntry)
   where
-    secondaryIndexFile = renderFile "secondary" chunk
+    secondaryIndexFile = fsPathSecondaryIndexFile chunk
     nbBytes            = fromIntegral $ entrySize hashSize
     nbBlockOffsetBytes = fromIntegral (sizeOf (blockOffset (error "blockOffset")))
     HasFS { hGetSize } = hasFS
@@ -223,7 +223,7 @@ readAllEntries hasFS HashInfo { getHash } secondaryOffset chunk stopAfter
       bl <- hGetAllAt hasFS sHnd (AbsOffset (fromIntegral secondaryOffset))
       go isEBB bl [] Nothing
   where
-    secondaryIndexFile = renderFile "secondary" chunk
+    secondaryIndexFile = fsPathSecondaryIndexFile chunk
 
     go :: IsEBB  -- ^ Interpret the next entry as an EBB?
        -> Lazy.ByteString
@@ -299,7 +299,7 @@ truncateToEntry hasFS HashInfo { hashSize } chunk secondaryOffset =
     withFile hasFS secondaryIndexFile (AppendMode AllowExisting) $ \sHnd ->
       hTruncate sHnd offset
   where
-    secondaryIndexFile  = renderFile "secondary" chunk
+    secondaryIndexFile  = fsPathSecondaryIndexFile chunk
     HasFS { hTruncate } = hasFS
     offset              = fromIntegral (secondaryOffset + entrySize hashSize)
 
@@ -317,5 +317,5 @@ writeAllEntries hasFS hashInfo chunk entries =
       hTruncate sHnd 0
       mapM_ (appendEntry hasFS hashInfo sHnd) entries
   where
-    secondaryIndexFile  = renderFile "secondary" chunk
+    secondaryIndexFile  = fsPathSecondaryIndexFile chunk
     HasFS { hTruncate } = hasFS

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
@@ -417,7 +417,7 @@ iteratorNextImpl dbEnv it@IteratorHandle
       where
         Secondary.Entry { blockOffset, checksum, blockOrEBB } = entry
         offset    = AbsOffset $ Secondary.unBlockOffset blockOffset
-        chunkFile = renderFile "epoch" chunk
+        chunkFile = fsPathChunkFile chunk
 
     -- | We don't rely on the position of the handle, we always use
     -- 'hGetExactlyAt', i.e. @pread@ for reading from a given offset.
@@ -550,7 +550,7 @@ iteratorStateForChunk hasFS index registry
     -- will be closed in case of an exception.
     (key, eHnd) <- allocate
       registry
-      (\_key -> hOpen (renderFile "epoch" chunk) ReadMode)
+      (\_key -> hOpen (fsPathChunkFile chunk) ReadMode)
       hClose
 
     -- If the last entry in @entries@ corresponds to the last block in the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
@@ -113,9 +113,9 @@ mkOpenState
   -> AllowExisting
   -> WithTempRegistry (OpenState m hash h) m (OpenState m hash h)
 mkOpenState hasFS@HasFS{..} index chunk tip existing = do
-    eHnd <- allocateHandle currentChunkHandle     $ hOpen (renderFile "epoch"     chunk) appendMode
-    pHnd <- allocateHandle currentPrimaryHandle   $ Index.openPrimaryIndex index  chunk  existing
-    sHnd <- allocateHandle currentSecondaryHandle $ hOpen (renderFile "secondary" chunk) appendMode
+    eHnd <- allocateHandle currentChunkHandle     $ hOpen (fsPathChunkFile          chunk) appendMode
+    pHnd <- allocateHandle currentPrimaryHandle   $ Index.openPrimaryIndex index    chunk  existing
+    sHnd <- allocateHandle currentSecondaryHandle $ hOpen (fsPathSecondaryIndexFile chunk) appendMode
     chunkOffset     <- lift $ hGetSize eHnd
     secondaryOffset <- lift $ hGetSize sHnd
     return OpenState

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Util.hs
@@ -10,7 +10,9 @@
 module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
   ( -- * Utilities
     Two (..)
-  , renderFile
+  , fsPathChunkFile
+  , fsPathPrimaryIndexFile
+  , fsPathSecondaryIndexFile
   , throwUserError
   , throwUnexpectedError
   , wrapFsError
@@ -60,6 +62,15 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Types
 data Two a = Two a a
   deriving (Functor, Foldable, Traversable)
 
+fsPathChunkFile :: ChunkNo -> FsPath
+fsPathChunkFile = renderFile "epoch"
+
+fsPathPrimaryIndexFile :: ChunkNo -> FsPath
+fsPathPrimaryIndexFile = renderFile "primary"
+
+fsPathSecondaryIndexFile :: ChunkNo -> FsPath
+fsPathSecondaryIndexFile = renderFile "secondary"
+
 -- | Opposite of 'parseDBFile'.
 renderFile :: Text -> ChunkNo -> FsPath
 renderFile fileType (ChunkNo chunk) = fsPathFromList [name]
@@ -99,11 +110,11 @@ removeFilesStartingFrom HasFS { removeFile, listDirectory } chunk = do
     filesInDBFolder <- listDirectory (mkFsPath [])
     let (chunkFiles, primaryFiles, secondaryFiles) = dbFilesOnDisk filesInDBFolder
     forM_ (takeWhile (>= chunk) (Set.toDescList chunkFiles)) $ \e ->
-      removeFile (renderFile "epoch" e)
+      removeFile (fsPathChunkFile e)
     forM_ (takeWhile (>= chunk) (Set.toDescList primaryFiles)) $ \i ->
-      removeFile (renderFile "primary" i)
+      removeFile (fsPathPrimaryIndexFile i)
     forM_ (takeWhile (>= chunk) (Set.toDescList secondaryFiles)) $ \i ->
-      removeFile (renderFile "secondary" i)
+      removeFile (fsPathSecondaryIndexFile i)
 
 throwUserError :: (MonadThrow m, HasCallStack) => UserError -> m a
 throwUserError e = throwM $ UserError e callStack

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Util.hs
@@ -10,6 +10,7 @@
 module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
   ( -- * Utilities
     Two (..)
+  , renderFile
   , fsPathChunkFile
   , fsPathPrimaryIndexFile
   , fsPathSecondaryIndexFile
@@ -63,7 +64,7 @@ data Two a = Two a a
   deriving (Functor, Foldable, Traversable)
 
 fsPathChunkFile :: ChunkNo -> FsPath
-fsPathChunkFile = renderFile "epoch"
+fsPathChunkFile = renderFile "chunk"
 
 fsPathPrimaryIndexFile :: ChunkNo -> FsPath
 fsPathPrimaryIndexFile = renderFile "primary"
@@ -80,8 +81,8 @@ renderFile fileType (ChunkNo chunk) = fsPathFromList [name]
 -- | Parse the prefix and chunk number from the filename of an index or chunk
 -- file.
 --
--- > parseDBFile "00001.epoch"
--- Just ("epoch", 1)
+-- > parseDBFile "00001.chunk"
+-- Just ("chunk", 1)
 -- > parseDBFile "00012.primary"
 -- Just ("primary", 12)
 parseDBFile :: String -> Maybe (String, ChunkNo)
@@ -96,7 +97,7 @@ dbFilesOnDisk = foldl' categorise mempty
   where
     categorise fs@(!chunk, !primary, !secondary) file =
       case parseDBFile file of
-        Just ("epoch",     n) -> (Set.insert n chunk, primary, secondary)
+        Just ("chunk",     n) -> (Set.insert n chunk, primary, secondary)
         Just ("primary",   n) -> (chunk, Set.insert n primary, secondary)
         Just ("secondary", n) -> (chunk, primary, Set.insert n secondary)
         _                     -> fs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Validation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Validation.hs
@@ -388,9 +388,9 @@ validateChunk ValidateEnv{..} shouldBeFinalised chunk mbPrevHash = do
 
       return $ summaryToTipInfo <$> lastMaybe summary
   where
-    chunkFile          = renderFile "epoch"     chunk
-    primaryIndexFile   = renderFile "primary"   chunk
-    secondaryIndexFile = renderFile "secondary" chunk
+    chunkFile          = fsPathChunkFile          chunk
+    primaryIndexFile   = fsPathPrimaryIndexFile   chunk
+    secondaryIndexFile = fsPathSecondaryIndexFile chunk
 
     HasFS { hTruncate, doesFileExist } = hasFS
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Types.hs
@@ -40,6 +40,7 @@ module Ouroboros.Consensus.Storage.ImmutableDB.Types
 import           Control.Exception (Exception (..))
 import           Data.Binary (Get, Put)
 import           Data.List.NonEmpty (NonEmpty)
+import           Data.Text (Text)
 import           Data.Word
 import           GHC.Generics (Generic)
 import           GHC.Stack (CallStack, prettyCallStack)
@@ -350,6 +351,9 @@ data TraceEvent e hash
     | InvalidSecondaryIndex ChunkNo
     | RewritePrimaryIndex   ChunkNo
     | RewriteSecondaryIndex ChunkNo
+    | Migrating Text
+      -- ^ Performing a migration of the on-disk files
+
       -- Delete after
     | DeletingAfter (ImmTipWithInfo hash)
       -- Closing the DB

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -449,7 +449,7 @@ findCorruptionRollBackPoint :: FileCorruption -> FsPath -> DBModel hash
                             -> RollBackPoint
 findCorruptionRollBackPoint corr file dbm =
     case (Text.unpack . snd <$> fsPathSplit file) >>= parseDBFile of
-      Just ("epoch",      chunk) -> findChunkCorruptionRollBackPoint corr chunk dbm
+      Just ("chunk",      chunk) -> findChunkCorruptionRollBackPoint corr chunk dbm
       -- Index files are always recoverable
       Just ("primary",   _chunk) -> DontRollBack
       Just ("secondary", _chunk) -> DontRollBack

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -71,7 +71,9 @@ import           Ouroboros.Network.Block (BlockNo (..), HasHeader (..),
 import qualified Ouroboros.Network.Block as Block
 
 import           Ouroboros.Consensus.Storage.Common
-import           Ouroboros.Consensus.Storage.FS.API.Types (FsError (..), FsPath)
+import           Ouroboros.Consensus.Storage.FS.API (HasFS (..))
+import           Ouroboros.Consensus.Storage.FS.API.Types (FsError (..), FsPath,
+                     mkFsPath)
 import           Ouroboros.Consensus.Storage.ImmutableDB hiding
                      (BlockOrEBB (..))
 import qualified Ouroboros.Consensus.Storage.ImmutableDB as ImmDB
@@ -123,6 +125,7 @@ data Cmd it
   | IteratorHasNext        it
   | IteratorClose          it
   | Reopen                 ValidationPolicy
+  | Migrate                ValidationPolicy
   | DeleteAfter            (ImmTipWithInfo Hash)
   | Corruption             Corruption
   deriving (Generic, Show, Functor, Foldable, Traversable)
@@ -235,6 +238,12 @@ run env@ImmutableDBEnv { varDB, varNextId, varIters, args } cmd =
         closeDB db
         reopen env valPol
         Tip <$> getTip db
+      Migrate valPol -> do
+        closeOpenIterators varIters
+        closeDB db
+        unmigrate hasFS
+        reopen env valPol
+        Tip <$> getTip db
       Corruption (MkCorruption corrs) -> do
         closeOpenIterators varIters
         closeDB db
@@ -274,6 +283,15 @@ run env@ImmutableDBEnv { varDB, varNextId, varIters, args } cmd =
     noWrongBoundError (Left e)  = error ("impossible: " <> show e)
     noWrongBoundError (Right a) = a
 
+-- | To test migration from "XXXXX.epoch" to "XXXXX.chunk" do the opposite
+-- renaming, i.e., /unmigrate/ while the database is closed. When the database
+-- is reopened, it should trigger the migration code.
+unmigrate :: Monad m => HasFS m h -> m ()
+unmigrate HasFS { listDirectory, renameFile } = do
+    (chunkFiles, _, _) <- dbFilesOnDisk <$> listDirectory (mkFsPath [])
+    forM_ chunkFiles $ \chunk ->
+      renameFile (fsPathChunkFile chunk) (renderFile "epoch" chunk)
+
 {-------------------------------------------------------------------------------
   Instantiating the semantics
 -------------------------------------------------------------------------------}
@@ -306,6 +324,7 @@ runPure = \case
     DeleteAfter tip            -> ok Unit            $ update_  (deleteAfterModel tip)
     Corruption corr            -> ok Tip             $ update   (simulateCorruptions (getCorruptions corr))
     Reopen _                   -> ok Tip             $ update    reopenModel
+    Migrate _                  -> ok Tip             $ update    reopenModel
   where
     query  f m = (Right (f m), m)
     queryE f m = (f m, m)
@@ -563,6 +582,8 @@ generateCmd Model {..} = At <$> frequency
                    , (1, return $ IteratorClose   iter) ])
     , (1, Reopen <$> genValPol)
 
+    , (1, Migrate <$> genValPol)
+
     , (4, DeleteAfter <$> genTip)
 
       -- Only if there are files on disk can we generate commands that corrupt
@@ -702,6 +723,7 @@ shrinkCmd Model {..} (At cmd) = fmap At $ case cmd of
     DeleteAfter tip                    ->
       [DeleteAfter tip' | tip' <- shrinkTip tip]
     Reopen {}                          -> []
+    Migrate {}                         -> []
     Corruption corr                    ->
       [Corruption corr' | corr' <- shrinkCorruption corr]
   where
@@ -903,6 +925,8 @@ data Tag
 
   | TagCorruption
 
+  | TagMigrate
+
   | TagErrorDuringAppendBlock
 
   | TagErrorDuringAppendEBB
@@ -983,6 +1007,7 @@ tag = QSM.classify
     , tagIteratorStreamedN Map.empty
     , tagIteratorWithoutBounds
     , tagCorruption
+    , tagMigrate
     , tagErrorDuring TagErrorDuringAppendBlock $ \case
       { At (AppendBlock {}) -> True; _ -> False }
     , tagErrorDuring TagErrorDuringAppendEBB $ \case
@@ -1077,6 +1102,14 @@ tag = QSM.classify
       { predApply = \ev -> case eventCmdNoErr ev of
           At (Corruption {}) -> Left  TagCorruption
           _                  -> Right tagCorruption
+      , predFinish = Nothing
+      }
+
+    tagMigrate :: EventPred m
+    tagMigrate = Predicate
+      { predApply = \ev -> case eventCmdNoErr ev of
+          At (Migrate {}) -> Left  TagMigrate
+          _               -> Right tagMigrate
       , predFinish = Nothing
       }
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -81,8 +81,7 @@ import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl as ImmDB
                      (Internal (..))
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index as Index
                      (CacheConfig (..))
-import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util (renderFile,
-                     tryImmDB)
+import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
 import           Ouroboros.Consensus.Storage.ImmutableDB.Parser (ChunkFileError,
                      chunkFileParser)
 
@@ -666,9 +665,13 @@ generateCmd Model {..} = At <$> frequency
 -- created. For each epoch an epoch, primary index, and secondary index file.
 getDBFiles :: DBModel Hash -> [FsPath]
 getDBFiles dbm =
-    [ renderFile fileType epoch
-    | epoch <- chunksBetween firstChunkNo (dbmCurrentChunk dbm)
-    , fileType <- ["epoch", "primary", "secondary"]
+    [ file
+    | chunk <- chunksBetween firstChunkNo (dbmCurrentChunk dbm)
+    , file  <-
+      [ fsPathChunkFile chunk
+      , fsPathPrimaryIndexFile chunk
+      , fsPathSecondaryIndexFile chunk
+      ]
     ]
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1755.

On startup, the ImmutableDB will rename any XXXXX.epoch files to XXXXX.chunk before validation.
