### PR TITLE
Update dependencies and make required changes

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -111,21 +111,21 @@ package small-steps
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9
-  --sha256: 17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7
+  tag: eb340f88c0d52b973c0e80bf98a8152097a056c0
+  --sha256: 0nz9h5jcxnzgbj0pmm5zq99pxx7by6i60cvyvnyi1mzv23a3zxhm
   subdir:   contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
-  --sha256: 1qlmz3alrlzx6fzsxc5zp9qqx15qapywrc7a9bvxz70yfzc7b5j4
+  tag: 91f357abae16099858193b999807323ca9a7c63c
+  --sha256: 11ya7j7ga0axvjb583pkcyxdza1p5219857817mwga7djzm5gb0b
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
-  --sha256: 1qlmz3alrlzx6fzsxc5zp9qqx15qapywrc7a9bvxz70yfzc7b5j4
+  tag: 91f357abae16099858193b999807323ca9a7c63c
+  --sha256: 11ya7j7ga0axvjb583pkcyxdza1p5219857817mwga7djzm5gb0b
   subdir: test
 
 source-repository-package
@@ -159,43 +159,43 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: ea8ee1f0711af70e7ba9dbcaa03d04043626018e
-  --sha256: 192ci4m9n05j4lp787ci77d5z3c3j7lxjkgr6h0rzfdxacib9mxg
+  tag: b0f4b024962eb834af55151697c8da72b6df4df8
+  --sha256: 1p1hcdyzsv5bs2sgz57p8xrjfy31nlyyipq8j6jgagv2zj43zk4f
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: ea8ee1f0711af70e7ba9dbcaa03d04043626018e
-  --sha256: 192ci4m9n05j4lp787ci77d5z3c3j7lxjkgr6h0rzfdxacib9mxg
+  tag: b0f4b024962eb834af55151697c8da72b6df4df8
+  --sha256: 1p1hcdyzsv5bs2sgz57p8xrjfy31nlyyipq8j6jgagv2zj43zk4f
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: ea8ee1f0711af70e7ba9dbcaa03d04043626018e
-  --sha256: 192ci4m9n05j4lp787ci77d5z3c3j7lxjkgr6h0rzfdxacib9mxg
+  tag: b0f4b024962eb834af55151697c8da72b6df4df8
+  --sha256: 1p1hcdyzsv5bs2sgz57p8xrjfy31nlyyipq8j6jgagv2zj43zk4f
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: ea8ee1f0711af70e7ba9dbcaa03d04043626018e
-  --sha256: 192ci4m9n05j4lp787ci77d5z3c3j7lxjkgr6h0rzfdxacib9mxg
+  tag: b0f4b024962eb834af55151697c8da72b6df4df8
+  --sha256: 1p1hcdyzsv5bs2sgz57p8xrjfy31nlyyipq8j6jgagv2zj43zk4f
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: ea8ee1f0711af70e7ba9dbcaa03d04043626018e
-  --sha256: 192ci4m9n05j4lp787ci77d5z3c3j7lxjkgr6h0rzfdxacib9mxg
+  tag: b0f4b024962eb834af55151697c8da72b6df4df8
+  --sha256: 1p1hcdyzsv5bs2sgz57p8xrjfy31nlyyipq8j6jgagv2zj43zk4f
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: ea8ee1f0711af70e7ba9dbcaa03d04043626018e
-  --sha256: 192ci4m9n05j4lp787ci77d5z3c3j7lxjkgr6h0rzfdxacib9mxg
+  tag: b0f4b024962eb834af55151697c8da72b6df4df8
+  --sha256: 1p1hcdyzsv5bs2sgz57p8xrjfy31nlyyipq8j6jgagv2zj43zk4f
   subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package
@@ -207,29 +207,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 90b14c056059d0082cb2641f9c77cb1b097be329
-  --sha256: 029lqlf33a3vvy933fil8qglv3hjaprankllr80h0acspqjzahk0
+  tag: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
+  --sha256: 0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4
   subdir: cardano-ledger
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 90b14c056059d0082cb2641f9c77cb1b097be329
-  --sha256: 029lqlf33a3vvy933fil8qglv3hjaprankllr80h0acspqjzahk0
+  tag: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
+  --sha256: 0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4
   subdir: crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 90b14c056059d0082cb2641f9c77cb1b097be329
-  --sha256: 029lqlf33a3vvy933fil8qglv3hjaprankllr80h0acspqjzahk0
+  tag: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
+  --sha256: 0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4
   subdir: cardano-ledger/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: 90b14c056059d0082cb2641f9c77cb1b097be329
-  --sha256: 029lqlf33a3vvy933fil8qglv3hjaprankllr80h0acspqjzahk0
+  tag: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
+  --sha256: 0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4
   subdir: crypto/test
 
 source-repository-package

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger.hs
@@ -13,7 +13,7 @@ import           Ouroboros.Consensus.Byron.Ledger.Config as X
 import           Ouroboros.Consensus.Byron.Ledger.DelegationHistory as X
                      (DelegationHistory)
 import           Ouroboros.Consensus.Byron.Ledger.Forge as X
-import           Ouroboros.Consensus.Byron.Ledger.HeaderValidation as X ()
+import           Ouroboros.Consensus.Byron.Ledger.HeaderValidation as X
 import           Ouroboros.Consensus.Byron.Ledger.Integrity as X
 import           Ouroboros.Consensus.Byron.Ledger.Ledger as X
 import           Ouroboros.Consensus.Byron.Ledger.Mempool as X

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
@@ -4,7 +4,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Byron.Ledger.HeaderValidation () where
+module Ouroboros.Consensus.Byron.Ledger.HeaderValidation (
+    ByronOtherHeaderEnvelopeError(..)
+  ) where
 
 import           Control.Arrow ((&&&))
 import           Control.Monad.Except

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -23,8 +23,11 @@ import           Data.Foldable (toList)
 import qualified Data.Sequence as Seq
 import           GHC.Generics (Generic)
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import           Cardano.Binary (FromCBOR (..), ToCBOR (..),
+                     FullByteString (..), Annotator (..))
 import           Cardano.Prelude (NoUnexpectedThunks (..), UseIsNormalForm (..))
+
+import           Ouroboros.Network.Block (unwrapCBORinCBOR, wrapCBORinCBOR)
 
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Mempool.API
@@ -39,6 +42,7 @@ import qualified Shelley.Spec.Ledger.UTxO as SL
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger
 import           Ouroboros.Consensus.Shelley.Protocol
+
 
 type ShelleyTxId c = SL.TxId c
 
@@ -91,10 +95,11 @@ instance Crypto c => HasTxs (ShelleyBlock c) where
 instance Crypto c => ToCBOR (GenTx (ShelleyBlock c)) where
   -- No need to encode the 'TxId', it's just a hash of the 'SL.TxBody' inside
   -- 'SL.Tx', so it can be recomputed.
-  toCBOR (ShelleyTx _txid tx) = toCBOR tx
+  toCBOR (ShelleyTx _txid tx) = wrapCBORinCBOR toCBOR tx
 
 instance Crypto c => FromCBOR (GenTx (ShelleyBlock c)) where
-  fromCBOR = mkShelleyTx <$> fromCBOR
+  fromCBOR = fmap mkShelleyTx $ unwrapCBORinCBOR
+    $ (. Full) . runAnnotator <$> fromCBOR
 
 {-------------------------------------------------------------------------------
   Pretty-printing

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
+++ b/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
@@ -280,8 +280,8 @@ test_golden_Block = goldenTestCBOR
     toCBOR
     exampleBlock
     [ TkListLen 4
-    , TkListLen 16
-    , TkBytes "2&\SOH9"
+    , TkListLen 16             -- Block header, as in test_golden_Header below
+    , TkBytes "\229Yo*"
     , TkInt 1677861428
     , TkInt 1239952560
     , TkInt 20
@@ -297,7 +297,7 @@ test_golden_Block = goldenTestCBOR
     , TkInteger 132220243341478360044794887852609007894
     , TkInt 194
     , TkInt 2
-    , TkBytes "\159\SYN\n5"
+    , TkBytes "t\199G\187"
     , TkInt 42768536
     , TkInt 0
     , TkInt 0
@@ -307,11 +307,11 @@ test_golden_Block = goldenTestCBOR
     , TkInt 0
     , TkInt 0
     , TkListLen 2
-    , TkInteger 191398642502988321904034898986188660442
+    , TkInteger 1904422759189137543741070836800193328
     , TkListLen 3
     , TkInt 42768536
     , TkInt 1
-    , TkInt 10
+    , TkInt 10                 -- End of block header
     , TkListLen 1
     , TkMapLen 5
     , TkInt 0
@@ -378,33 +378,33 @@ test_golden_Header = goldenTestCBOR
     toCBOR
     (getHeader exampleBlock)
     [ TkListLen 16
-    , TkBytes "2&\SOH9"
-    , TkInt 1677861428
-    , TkInt 1239952560
-    , TkInt 20
-    , TkListLen 2
+    , TkBytes "\229Yo*"     -- #1 prev hash
+    , TkInt 1677861428      -- #2 cold vk
+    , TkInt 1239952560      -- #3 vrf vk
+    , TkInt 20              -- #4 slotNo
+    , TkListLen 2           -- #5 VRF nonce
     , TkInt 2
     , TkListLen 2
     , TkInt 1239952560
     , TkInteger 155720561651862627124907358847946323278
-    , TkListLen 2
+    , TkListLen 2           -- #6 VRF leader
     , TkInt 0
     , TkListLen 2
     , TkInt 1239952560
     , TkInteger 132220243341478360044794887852609007894
-    , TkInt 194
-    , TkInt 2
-    , TkBytes "\159\SYN\n5"
-    , TkInt 42768536
-    , TkInt 0
-    , TkInt 0
-    , TkListLen 2
+    , TkInt 194             -- #7 body size
+    , TkInt 2               -- #8 block no
+    , TkBytes "t\199G\187"  -- #9 body hash
+    , TkInt 42768536        -- #10 op cert: vkey hot
+    , TkInt 0               -- #11 op cert: counter
+    , TkInt 0               -- #12 op cert: KES period
+    , TkListLen 2           -- #13 op cert: sigma
     , TkBytes "5\\\211K"
     , TkInt 1677861428
-    , TkInt 0
-    , TkInt 0
-    , TkListLen 2
-    , TkInteger 191398642502988321904034898986188660442
+    , TkInt 0               -- #14 protVer major
+    , TkInt 0               -- #15 protVer minor
+    , TkListLen 2           -- #16 header sig
+    , TkInteger 1904422759189137543741070836800193328
     , TkListLen 3
     , TkInt 42768536
     , TkInt 1
@@ -415,7 +415,7 @@ test_golden_HeaderHash :: Assertion
 test_golden_HeaderHash = goldenTestCBOR
     toCBOR
     (blockHash exampleBlock)
-    [ TkBytes "\135\233S4"
+    [ TkBytes "[8\SI3"
     ]
 
 test_golden_GenTx :: Assertion
@@ -670,7 +670,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkListLen 3
     , TkListLen 2
     , TkInt 10
-    , TkBytes "\195\213\vX"
+    , TkBytes "\133\&3\DC1\170"
     , TkListLen 2
     , TkListLen 1
     , TkInt 0
@@ -1117,7 +1117,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkListLen 3
     , TkListLen 2
     , TkInt 10
-    , TkBytes "\195\213\vX"
+    , TkBytes "\133\&3\DC1\170"
     , TkListLen 2
     , TkListLen 1
     , TkInt 0

--- a/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
+++ b/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
@@ -419,7 +419,7 @@ test_golden_HeaderHash = goldenTestCBOR
     ]
 
 test_golden_GenTx :: Assertion
-test_golden_GenTx = goldenTestCBOR
+test_golden_GenTx = goldenTestCBORInCBOR
     toCBOR
     exampleGenTx
     [ TkListLen 3

--- a/ouroboros-consensus-shelley/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley/test/Test/ThreadNet/RealTPraos.hs
@@ -263,9 +263,8 @@ mkGenesisConfig k maxKESEvolutions coreNodes = ShelleyGenesis {
     initialFunds = Map.fromList
       [ (addr, coin)
       | CoreNode { cnDelegateKey, cnStakingKey } <- coreNodes
-      , let addr = SL.AddrBase
-              (mkCredential cnDelegateKey)
-              (mkCredential cnStakingKey)
+      , let addr = SL.Addr (mkCredential cnDelegateKey)
+                           (SL.StakeRefBase (mkCredential cnStakingKey))
             coin = SL.Coin $ fromIntegral initialLovelacePerCoreNode
       ]
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Golden.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Golden.hs
@@ -4,14 +4,22 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Util.Golden
   ( goldenTestCBOR
+  , goldenTestCBORInCBOR
   ) where
 
-import           Codec.CBOR.Encoding (Encoding)
-import           Codec.CBOR.FlatTerm (FlatTerm, TermToken (..), toFlatTerm)
 import           Data.List (intercalate)
 import           Data.TreeDiff (ToExpr, ansiWlEditExpr, ediff)
+import qualified Data.ByteString as BS
+
+import           Codec.CBOR.Encoding (Encoding)
+import           Codec.CBOR.FlatTerm (FlatTerm, TermToken (..))
+import qualified Codec.CBOR.FlatTerm as CBOR
+import qualified Codec.CBOR.Read     as CBOR
+
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
+
+import qualified Control.Monad.ST.Lazy as ST.Lazy
 
 import           Test.Tasty.HUnit
 
@@ -29,7 +37,33 @@ goldenTestCBOR
 goldenTestCBOR enc a expectedFlatTerm =
     assertBool msg (actualFlatTerm == expectedFlatTerm)
   where
-    actualFlatTerm = toFlatTerm $ enc a
+    actualFlatTerm = CBOR.toFlatTerm $ enc a
+
+    msg
+      | null expectedFlatTerm
+      = "Running with an empty expected value, actual value is:\n" <>
+        pprintList actualFlatTerm
+      | otherwise
+      = "Expected term /= actual term, diff expected actual:\n" <>
+        show (ansiWlEditExpr (ediff expectedFlatTerm actualFlatTerm))
+
+-- | A variant on 'goldenTestCBOR' for use when the encoding uses the
+-- CBOR-in-CBOR wrapping. If we don't use this, the examples and the
+-- diffs become unreadable.
+--
+goldenTestCBORInCBOR
+  :: HasCallStack
+  => (a -> Encoding) -- ^ Encoder
+  -> a               -- ^ Example value to use for the golden test
+  -> FlatTerm        -- ^ Expected CBOR (flat) encoding
+  -> Assertion
+goldenTestCBORInCBOR enc a expectedFlatTerm =
+    assertBool msg (actualFlatTerm == expectedFlatTerm)
+  where
+    actualFlatTerm =
+      case CBOR.toFlatTerm $ enc a of
+        [TkTag 24, TkBytes b] -> decodePreEncoded b
+        tks                   -> tks
 
     msg
       | null expectedFlatTerm
@@ -56,3 +90,31 @@ pprintList (x:ys) = intercalate "\n" $
 
 deriving instance Generic TermToken
 deriving instance ToExpr TermToken
+
+
+decodePreEncoded :: BS.ByteString -> FlatTerm
+decodePreEncoded bs0 =
+    ST.Lazy.runST (provideInput bs0)
+  where
+    provideInput :: BS.ByteString -> ST.Lazy.ST s FlatTerm
+    provideInput bs
+      | BS.null bs = return []
+      | otherwise  = do
+          next <- ST.Lazy.strictToLazyST $ do
+              -- This will always be a 'Partial' here because decodeTermToken
+              -- always starts by requesting initial input. Only decoders that
+              -- fail or return a value without looking at their input can give
+              -- a different initial result.
+              CBOR.Partial k <- CBOR.deserialiseIncremental CBOR.decodeTermToken
+              k (Just bs)
+          collectOutput next
+
+    collectOutput :: CBOR.IDecode s TermToken -> ST.Lazy.ST s FlatTerm
+    collectOutput (CBOR.Fail _ _ err) = fail $ "toFlatTerm: encodePreEncoded "
+                                            ++ "used with invalid CBOR: "
+                                            ++ show err
+    collectOutput (CBOR.Partial    k) = ST.Lazy.strictToLazyST (k Nothing)
+                                        >>= collectOutput
+    collectOutput (CBOR.Done bs' _ x) = do xs <- provideInput bs'
+                                           return (x : xs)
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/91f357abae16099858193b999807323ca9a7c63c/snapshot.yaml
 
 packages:
   - ./typed-protocols
@@ -36,7 +36,7 @@ flags:
 
 extra-deps:
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9
+    commit: eb340f88c0d52b973c0e80bf98a8152097a056c0
     subdirs:
       - contra-tracer
 
@@ -49,7 +49,7 @@ extra-deps:
       - slotting
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: ea8ee1f0711af70e7ba9dbcaa03d04043626018e
+    commit: b0f4b024962eb834af55151697c8da72b6df4df8
     subdirs:
       - byron/chain/executable-spec
       - byron/ledger/executable-spec
@@ -65,7 +65,7 @@ extra-deps:
   - gray-code-0.3.1
 
   - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 90b14c056059d0082cb2641f9c77cb1b097be329
+    commit: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
     subdirs:
       - cardano-ledger
       - cardano-ledger/test
@@ -73,7 +73,7 @@ extra-deps:
       - crypto/test
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
+    commit: 91f357abae16099858193b999807323ca9a7c63c
     subdirs:
       - .
       - test
@@ -95,6 +95,7 @@ extra-deps:
   - Unique-0.4.7.6
   - statistics-linreg-0.3
   - network-3.1.0.1
+  - quiet-0.2
 
   # Windows only
   - Win32-2.6.2.0


### PR DESCRIPTION
Required so that `cardano-node` can build with a newer revision of `cardano-ledger-specs` which contains changes required for https://github.com/input-output-hk/cardano-node/pull/799.