### PR TITLE
Provide instance Condense (Header (ShelleyBlock c))

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -215,3 +215,6 @@ shelleyAddHeaderEnvelope = id
 
 instance Crypto c => Condense (ShelleyBlock c) where
   condense = show . shelleyBlockRaw
+
+instance Crypto c => Condense (Header (ShelleyBlock c)) where
+  condense = show . shelleyHeaderRaw


### PR DESCRIPTION
The instance for Header is required by the `TracingConstraints` in the node top level for all protocols, but it was missing for Shelley.