### PR TITLE
Various changes after splitting consensus API

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
@@ -7,6 +7,8 @@ module Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion (
   , ByronNodeToClientVersion(..)
   ) where
 
+import           Data.List.NonEmpty (NonEmpty (..))
+
 import qualified Ouroboros.Network.NodeToClient as N
 import qualified Ouroboros.Network.NodeToNode as N
 
@@ -34,10 +36,10 @@ instance HasNetworkProtocolVersion ByronBlock where
   type NodeToNodeVersion   ByronBlock = ByronNodeToNodeVersion
   type NodeToClientVersion ByronBlock = ByronNodeToClientVersion
 
-  supportedNodeToNodeVersions   _ = [ ByronNodeToNodeVersion1 ]
-  supportedNodeToClientVersions _ = [ ByronNodeToClientVersion1
-                                    , ByronNodeToClientVersion2
-                                    ]
+  supportedNodeToNodeVersions   _ = ByronNodeToNodeVersion1
+                                  :| []
+  supportedNodeToClientVersions _ = ByronNodeToClientVersion1
+                                  :| [ ByronNodeToClientVersion2 ]
 
   mostRecentNodeToNodeVersion   _ = ByronNodeToNodeVersion1
   mostRecentNodeToClientVersion _ = ByronNodeToClientVersion2

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -178,9 +178,9 @@ defaultCodecs _cfg _version = Codecs {
 -- / deserialise blocks in /chain-sync/ protocol.
 --
 clientCodecs :: forall m blk. (RunNode blk, MonadST m)
-              => BlockConfig         blk
-              -> NodeToClientVersion blk
-              -> ClientCodecs blk m
+             => BlockConfig         blk
+             -> NodeToClientVersion blk
+             -> ClientCodecs blk m
 clientCodecs cfg _version = Codecs {
       cChainSyncCodec =
         codecChainSync

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -132,7 +132,7 @@ data Codecs blk e m bCS bTX bSQ = Codecs {
 -- Implementation mode: currently none of the consensus encoders/decoders do
 -- anything different based on the version, so @_version@ is unused; it's just
 -- that not all codecs are used, depending on the version number.
-defaultCodecs :: forall m blk. (IOLike m, RunNode blk)
+defaultCodecs :: forall m blk. (RunNode blk, MonadST m)
               => BlockConfig         blk
               -> NodeToClientVersion blk
               -> Codecs blk DeserialiseFailure m ByteString ByteString ByteString

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -46,7 +46,8 @@ import           Ouroboros.Network.NodeToClient (DictVersion (..),
                      nodeToClientCodecCBORTerm)
 import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..),
                      NodeToNodeVersionData (..), RemoteConnectionId,
-                     defaultMiniProtocolParameters, nodeToNodeCodecCBORTerm)
+                     defaultMiniProtocolParameters, nodeToNodeCodecCBORTerm,
+                     combineVersions')
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
@@ -253,7 +254,7 @@ run RunNodeArgs{..} = do
       -> DiffusionApplications
     mkDiffusionApplications miniProtocolParams ntnApps ntcApps =
       DiffusionApplications {
-          daResponderApplication = combineVersions [
+          daResponderApplication = combineVersions' [
               simpleSingletonVersions
                 version'
                 nodeToNodeVersionData
@@ -262,7 +263,7 @@ run RunNodeArgs{..} = do
             | version <- supportedNodeToNodeVersions (Proxy @blk)
             , let version' = nodeToNodeProtocolVersion (Proxy @blk) version
             ]
-        , daInitiatorApplication = combineVersions [
+        , daInitiatorApplication = combineVersions' [
               simpleSingletonVersions
                 version'
                 nodeToNodeVersionData
@@ -271,7 +272,7 @@ run RunNodeArgs{..} = do
             | version <- supportedNodeToNodeVersions (Proxy @blk)
             , let version' = nodeToNodeProtocolVersion (Proxy @blk) version
             ]
-        , daLocalResponderApplication = combineVersions [
+        , daLocalResponderApplication = combineVersions' [
               simpleSingletonVersions
                 version'
                 nodeToClientVersionData
@@ -282,9 +283,6 @@ run RunNodeArgs{..} = do
             ]
         , daErrorPolicies = consensusErrorPolicy (Proxy @blk)
         }
-
-    combineVersions :: Semigroup a => [a] -> a
-    combineVersions = foldr1 (<>)
 
 openChainDB
   :: forall blk. RunNode blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE NumericUnderscores  #-}
+{-# LANGUAGE MonadComprehensions #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -47,7 +48,7 @@ import           Ouroboros.Network.NodeToClient (DictVersion (..),
 import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..),
                      NodeToNodeVersionData (..), RemoteConnectionId,
                      defaultMiniProtocolParameters, nodeToNodeCodecCBORTerm,
-                     combineVersions')
+                     combineVersions)
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
@@ -254,7 +255,7 @@ run RunNodeArgs{..} = do
       -> DiffusionApplications
     mkDiffusionApplications miniProtocolParams ntnApps ntcApps =
       DiffusionApplications {
-          daResponderApplication = combineVersions' [
+          daResponderApplication = combineVersions [
               simpleSingletonVersions
                 version'
                 nodeToNodeVersionData
@@ -263,7 +264,7 @@ run RunNodeArgs{..} = do
             | version <- supportedNodeToNodeVersions (Proxy @blk)
             , let version' = nodeToNodeProtocolVersion (Proxy @blk) version
             ]
-        , daInitiatorApplication = combineVersions' [
+        , daInitiatorApplication = combineVersions [
               simpleSingletonVersions
                 version'
                 nodeToNodeVersionData
@@ -272,7 +273,7 @@ run RunNodeArgs{..} = do
             | version <- supportedNodeToNodeVersions (Proxy @blk)
             , let version' = nodeToNodeProtocolVersion (Proxy @blk) version
             ]
-        , daLocalResponderApplication = combineVersions' [
+        , daLocalResponderApplication = combineVersions [
               simpleSingletonVersions
                 version'
                 nodeToClientVersionData

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
@@ -17,6 +17,7 @@ module Ouroboros.Consensus.Node.NetworkProtocolVersion
   ) where
 
 import           Data.Proxy
+import           Data.List.NonEmpty (NonEmpty (..))
 
 import qualified Ouroboros.Network.NodeToClient as N
 import qualified Ouroboros.Network.NodeToNode as N
@@ -36,11 +37,11 @@ class ( Show (NodeToNodeVersion   blk)
 
   -- | Enumerate all supported node-to-node versions
   supportedNodeToNodeVersions
-    :: Proxy blk -> [NodeToNodeVersion blk]
+    :: Proxy blk -> NonEmpty (NodeToNodeVersion blk)
 
   -- | Enumerate all supported node-to-client versions
   supportedNodeToClientVersions
-    :: Proxy blk -> [NodeToClientVersion blk]
+    :: Proxy blk -> NonEmpty (NodeToClientVersion blk)
 
   -- | The most recent node-to-node version
   mostRecentNodeToNodeVersion
@@ -65,13 +66,13 @@ class ( Show (NodeToNodeVersion   blk)
 
   default supportedNodeToNodeVersions
     :: NodeToNodeVersion blk ~ ()
-    => Proxy blk -> [NodeToNodeVersion blk]
-  supportedNodeToNodeVersions _ = [()]
+    => Proxy blk -> NonEmpty (NodeToNodeVersion blk)
+  supportedNodeToNodeVersions _ = () :| []
 
   default supportedNodeToClientVersions
     :: NodeToClientVersion blk ~ ()
-    => Proxy blk -> [NodeToClientVersion blk]
-  supportedNodeToClientVersions _ = [()]
+    => Proxy blk -> NonEmpty (NodeToClientVersion blk)
+  supportedNodeToClientVersions _ = () :| []
 
   default mostRecentNodeToNodeVersion
     :: NodeToNodeVersion blk ~ ()

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Direct.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Direct.hs
@@ -13,8 +13,10 @@ direct
   => LocalStateQueryClient block query m a
   -> LocalStateQueryServer block query m b
   -> m (a, b)
-direct (LocalStateQueryClient client) (LocalStateQueryServer mserver) =
-    mserver >>= directIdle client
+direct (LocalStateQueryClient mclient) (LocalStateQueryServer mserver) = do
+    client <- mclient
+    server <- mserver
+    directIdle client server
   where
     directIdle
       :: ClientStIdle block query m a

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -10,7 +10,6 @@
 --
 module Ouroboros.Network.NodeToClient (
     nodeToClientProtocols
-  , versionedNodeToClientProtocols
   , NodeToClientProtocols (..)
   , NodeToClientVersion (..)
   , NodeToClientVersionData (..)
@@ -52,6 +51,15 @@ module Ouroboros.Network.NodeToClient (
   , LocalSnocket
   , localSnocket
   , LocalAddress
+
+    -- * Versions
+  , Versions (..)
+  , versionedNodeToClientProtocols
+  , simpleSingletonVersions
+  , foldMapVersions
+  , combineVersions
+  , foldMapVersions'
+  , combineVersions'
 
   -- * Re-exports
   , ConnectionId (..)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -43,6 +43,7 @@ module Ouroboros.Network.NodeToClient (
   -- * Re-exported clients
   , chainSyncClientNull
   , localTxSubmissionClientNull
+  , localStateQueryClientNull
 
   -- * Re-exported network interface
   , IOManager (..)
@@ -104,6 +105,7 @@ import           Ouroboros.Network.ErrorPolicy
 import           Ouroboros.Network.Tracers
 import           Ouroboros.Network.Protocol.ChainSync.Client (chainSyncClientNull)
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Client (localTxSubmissionClientNull)
+import           Ouroboros.Network.Protocol.LocalStateQuery.Client (localStateQueryClientNull)
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version hiding (Accept)
 import qualified Ouroboros.Network.Protocol.Handshake.Version as V

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -10,6 +10,7 @@
 --
 module Ouroboros.Network.NodeToClient (
     nodeToClientProtocols
+  , versionedNodeToClientProtocols
   , NodeToClientProtocols (..)
   , NodeToClientVersion (..)
   , NodeToClientVersionData (..)
@@ -180,6 +181,26 @@ maximumMiniProtocolLimits =
     MiniProtocolLimits {
       maximumIngressQueue = 0xffffffff
     }
+
+
+
+-- | 'Versions' containing a single version of 'nodeToClientProtocols'.
+--
+versionedNodeToClientProtocols
+    :: NodeToClientVersion
+    -> NodeToClientVersionData
+    -> NodeToClientProtocols appType bytes m a b
+    -> Versions NodeToClientVersion
+                DictVersion
+                (ConnectionId LocalAddress ->
+                   OuroborosApplication appType bytes m a b)
+versionedNodeToClientProtocols versionNumber versionData protocols =
+    simpleSingletonVersions
+      versionNumber
+      versionData
+      (DictVersion nodeToClientCodecCBORTerm)
+      (const $ nodeToClientProtocols protocols versionNumber)
+
 
 -- | Enumeration of node to client protocol versions.
 --

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -59,8 +59,6 @@ module Ouroboros.Network.NodeToClient (
   , simpleSingletonVersions
   , foldMapVersions
   , combineVersions
-  , foldMapVersions'
-  , combineVersions'
 
   -- * Re-exports
   , ConnectionId (..)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -59,8 +59,6 @@ module Ouroboros.Network.NodeToNode (
   , simpleSingletonVersions
   , foldMapVersions
   , combineVersions
-  , foldMapVersions'
-  , combineVersions'
 
   -- * Re-exports
   , ConnectionId (..)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -54,6 +54,14 @@ module Ouroboros.Network.NodeToNode (
   , dnsSubscriptionWorker
   , dnsSubscriptionWorker_V1
 
+    -- ** Versions
+  , Versions (..)
+  , simpleSingletonVersions
+  , foldMapVersions
+  , combineVersions
+  , foldMapVersions'
+  , combineVersions'
+
   -- * Re-exports
   , ConnectionId (..)
   , RemoteConnectionId

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Examples.hs
@@ -24,7 +24,7 @@ localStateQueryClient
   => [(Point block, query result)]
   -> LocalStateQueryClient block query m
                            [(Point block, Either AcquireFailure result)]
-localStateQueryClient = LocalStateQueryClient . goIdle []
+localStateQueryClient = LocalStateQueryClient . pure . goIdle []
   where
     goIdle
       :: [(Point block, Either AcquireFailure result)]  -- ^ Accumulator


### PR DESCRIPTION
These changes I came up with when I started updating `cardano-node` repository.

Related to #1950

- supported versions should be a non empty list
- ClientCodecs: node-to-client protocol codecs
- defaultCodec: don't impose IOLike where MonadST is enough
- added localStateQueryClientNull
- Added utililty functions for folding multiple Versions
- NodeToClient.versionedNodeToClientProtocols
