### PR TITLE
Handle exceptions thrown by makeResolvSeed

### DIFF
--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
@@ -295,6 +295,7 @@ permCheck a b = L.sort a == L.sort b
 
 prop_resolv :: forall m.
      ( MonadAsync m
+     , MonadCatch m
      , MonadSay   m
      , MonadSTM   m
      , MonadTime  m


### PR DESCRIPTION
makeResolvSeed will fail if /etc/resolv.conf is missing.
This can cause DNS subscription to stop working for OSes where
that file is generated automatically, for example OSX, during temporary
network outages.