### PR TITLE
node to client api changes

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
@@ -47,6 +47,8 @@ newtype ChainSyncClient header tip m a = ChainSyncClient {
 chainSyncClientNull :: MonadTimer m => ChainSyncClient header tip m a
 chainSyncClientNull = ChainSyncClient $ forever $ threadDelay 43200 {- one day in seconds -}
 
+{-# DEPRECATED chainSyncClientNull "Use Ouroboros.Network.NodeToClient.chainSyncPeerNull" #-}
+
 -- | In the 'StIdle' protocol state, the server does not have agency and can choose to
 -- send a request next, or a find intersection message.
 --

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
@@ -36,6 +36,8 @@ localStateQueryClientNull :: MonadTimer m => LocalStateQueryClient block query m
 localStateQueryClientNull =
     LocalStateQueryClient $ forever $ threadDelay 43200 {- day in seconds -}
 
+{-# DEPRECATED localStateQueryClientNull "Use Ouroboros.Network.NodeToClient.localStateQueryPeerNull" #-}
+
 -- | In the 'StIdle' protocol state, the client has agency and must send:
 --
 --  * a request to acquire a state

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
@@ -21,13 +21,14 @@ module Ouroboros.Network.Protocol.LocalStateQuery.Client (
 
 import           Control.Monad (forever)
 import           Control.Monad.Class.MonadTimer
+import           Data.Kind (Type)
 import           Network.TypedProtocol.Core
 
 import           Ouroboros.Network.Block (Point)
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
 
 
-newtype LocalStateQueryClient block query m a = LocalStateQueryClient {
+newtype LocalStateQueryClient block (query :: Type -> Type) m a = LocalStateQueryClient {
       runLocalStateQueryClient :: m (ClientStIdle block query m a)
     }
 
@@ -94,7 +95,7 @@ data ClientStQuerying block query m a result = ClientStQuerying {
 -- client side of the 'LocalStateQuery' protocol.
 --
 localStateQueryClientPeer
-  :: forall block query m a.
+  :: forall block (query :: Type -> Type) m a.
      Monad m
   => LocalStateQueryClient block query m a
   -> Peer (LocalStateQuery block query) AsClient StIdle m a

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Server.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -16,13 +17,14 @@ module Ouroboros.Network.Protocol.LocalStateQuery.Server (
     , localStateQueryServerPeer
     ) where
 
+import           Data.Kind (Type)
 import           Network.TypedProtocol.Core
 
 import           Ouroboros.Network.Block (Point)
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
 
 
-newtype LocalStateQueryServer block query m a = LocalStateQueryServer {
+newtype LocalStateQueryServer block (query :: Type -> Type) m a = LocalStateQueryServer {
       runLocalStateQueryServer :: m (ServerStIdle block query m a)
     }
 
@@ -88,7 +90,7 @@ data ServerStQuerying block query m a result where
 -- side of the 'LocalStateQuery' protocol.
 --
 localStateQueryServerPeer
-  :: forall block query m a.
+  :: forall block (query :: Type -> Type) m a.
      Monad m
   => LocalStateQueryServer block query m a
   -> Peer (LocalStateQuery block query) AsServer StIdle m a

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Type.hs
@@ -16,6 +16,7 @@
 --
 module Ouroboros.Network.Protocol.LocalStateQuery.Type where
 
+import           Data.Kind (Type)
 import           Network.TypedProtocol.Core
 import           Ouroboros.Network.Block (Point, StandardHash)
 
@@ -26,7 +27,7 @@ import           Ouroboros.Network.Block (Point, StandardHash)
 -- It is parametrised over the type of block (for points), the type of queries
 -- and query results.
 --
-data LocalStateQuery block query where
+data LocalStateQuery block (query :: Type -> Type) where
 
   -- | The client has agency. It can ask to acquire a state or terminate.
   --

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Client.hs
@@ -25,7 +25,7 @@ module Ouroboros.Network.Protocol.LocalTxSubmission.Client (
   , localTxSubmissionClientPeer
 
       -- * Null local tx submission client
-    , localTxSubmissionClientNull
+  , localTxSubmissionClientNull
   ) where
 
 import           Control.Monad (forever)
@@ -45,6 +45,8 @@ newtype LocalTxSubmissionClient tx reject m a = LocalTxSubmissionClient {
 localTxSubmissionClientNull :: MonadTimer m => LocalTxSubmissionClient tx reject m a
 localTxSubmissionClientNull =
     LocalTxSubmissionClient $ forever $ threadDelay 43200 {- day in seconds -}
+
+{-# DEPRECATED localTxSubmissionClientNull "Use Ouroboros.Network.NodeToClient.localTxSubmissionPeerNull" #-}
 
 -- | The client side of the local transaction submission protocol.
 --


### PR DESCRIPTION
Small changes to NodeToClient api and LocalStateQuery protocol type signatures.

Related to #1950

- Added null peers in NodeToNode module
- Add kinds to type signatures of LocalQueryProtocol
