### PR TITLE
Shelley: do the chainChecks in validateEnvelope

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
@@ -19,6 +19,7 @@ import qualified Cardano.Chain.Slotting as CC
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 
 import           Ouroboros.Consensus.Byron.Ledger.Block
@@ -41,7 +42,7 @@ data ByronOtherHeaderEnvelopeError =
 instance ValidateEnvelope ByronBlock where
   type OtherHeaderEnvelopeError ByronBlock = ByronOtherHeaderEnvelopeError
 
-  validateEnvelope cfg oldTip hdr = do
+  validateEnvelope cfg _ledgerView oldTip hdr = do
       when (actualBlockNo /= expectedBlockNo) $
         throwError $ UnexpectedBlockNo expectedBlockNo actualBlockNo
       when (actualSlotNo < expectedSlotNo) $
@@ -88,4 +89,4 @@ instance ValidateEnvelope ByronBlock where
       canBeEBB (SlotNo s) = s `mod` epochSlots == 0
 
       epochSlots :: Word64
-      epochSlots = CC.unEpochSlots $ byronEpochSlots cfg
+      epochSlots = CC.unEpochSlots $ byronEpochSlots $ configBlock cfg

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
@@ -159,7 +160,9 @@ instance Crypto c => StandardHash (ShelleyBlock c)
 
 instance Crypto c => HasAnnTip (ShelleyBlock c)
 
-instance Crypto c => ValidateEnvelope (ShelleyBlock c)
+-- The 'ValidateEnvelope' instance lives in the
+-- "Ouroboros.Consensus.Shelley.Ledger.Ledger" module because of the
+-- dependency on the 'LedgerConfig'.
 
 {-------------------------------------------------------------------------------
   Conversions

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -276,7 +276,8 @@ class ( HasAnnTip blk
   type OtherHeaderEnvelopeError blk = Void
 
   -- | Validate the header envelope
-  validateEnvelope :: BlockConfig blk
+  validateEnvelope :: TopLevelConfig blk
+                   -> LedgerView (BlockProtocol blk)
                    -> WithOrigin (AnnTip blk)
                    -> Header blk
                    -> Except (HeaderEnvelopeError blk) ()
@@ -293,11 +294,12 @@ class ( HasAnnTip blk
   minimumPossibleSlotNo _ = SlotNo 0
 
   default validateEnvelope :: HasHeader (Header blk)
-                           => BlockConfig blk
+                           => TopLevelConfig blk
+                           -> LedgerView (BlockProtocol blk)
                            -> WithOrigin (AnnTip blk)
                            -> Header blk
                            -> Except (HeaderEnvelopeError blk) ()
-  validateEnvelope _cfg = defaultValidateEnvelope
+  validateEnvelope _cfg _ledgerView = defaultValidateEnvelope
 
 -- | Default implementation for 'validateEnvelope'.
 --
@@ -422,7 +424,7 @@ validateHeader :: (BlockSupportsProtocol blk, ValidateEnvelope blk)
                -> Except (HeaderError blk) (HeaderState blk)
 validateHeader cfg ledgerView hdr st = do
     withExcept HeaderEnvelopeError $
-      validateEnvelope (configBlock cfg) (headerStateTip st) hdr
+      validateEnvelope cfg ledgerView (headerStateTip st) hdr
     consensusState' <- withExcept HeaderProtocolError $
                          updateConsensusState
                            (configConsensus cfg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -367,9 +367,9 @@ instance Bridge m a => HasAnnTip (DualBlock m a) where
 
 instance Bridge m a => ValidateEnvelope (DualBlock m a) where
   type OtherHeaderEnvelopeError (DualBlock m a) = OtherHeaderEnvelopeError m
-  validateEnvelope cfg t =
+  validateEnvelope cfg ledgerView t =
         withExcept castHeaderEnvelopeError
-      . validateEnvelope (dualBlockConfigMain cfg) (castAnnTip <$> t)
+      . validateEnvelope (dualTopLevelConfigMain cfg) ledgerView (castAnnTip <$> t)
       . dualHeaderMain
 
   firstBlockNo          _ = firstBlockNo          (Proxy @m)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -366,6 +366,7 @@ instance Bridge m a => HasAnnTip (DualBlock m a) where
   getTipInfo = getTipInfo . dualHeaderMain
 
 instance Bridge m a => ValidateEnvelope (DualBlock m a) where
+  type OtherHeaderEnvelopeError (DualBlock m a) = OtherHeaderEnvelopeError m
   validateEnvelope cfg t =
         withExcept castHeaderEnvelopeError
       . validateEnvelope (dualBlockConfigMain cfg) (castAnnTip <$> t)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -965,7 +965,7 @@ data ChainSyncClientException =
           (Their (Tip blk))
 
       -- | Header validation threw an error.
-    | forall blk. BlockSupportsProtocol blk =>
+    | forall blk. (BlockSupportsProtocol blk, ValidateEnvelope blk) =>
         HeaderError
           (Point blk)  -- ^ Invalid header
           (HeaderError blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
@@ -18,6 +19,7 @@ import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
 import           Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as PSQ
+import           Data.Void (Void)
 
 import           Control.Tracer (Tracer)
 
@@ -112,3 +114,6 @@ deriving via OnlyCheckIsWHNF "Decoder" (Decoder s a) instance NoUnexpectedThunks
 deriving via OnlyCheckIsWHNF "Tracer" (Tracer m ev) instance NoUnexpectedThunks (Tracer m ev)
 
 deriving newtype instance NoUnexpectedThunks Time
+
+-- TODO move to cardano-prelude
+deriving anyclass instance NoUnexpectedThunks Void

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1161,6 +1161,7 @@ deriving instance ToExpr (AnnTip Blk)
 deriving instance ToExpr (LedgerState Blk)
 deriving instance ToExpr (HeaderState Blk)
 deriving instance ToExpr (HeaderError Blk)
+deriving instance ToExpr TestBlockOtherHeaderEnvelopeError
 deriving instance ToExpr (HeaderEnvelopeError Blk)
 deriving instance ToExpr BftValidationErr
 deriving instance ToExpr (ExtValidationError Blk)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -44,6 +44,7 @@ module Test.Ouroboros.Storage.TestBlock (
   , TestBlockError(..)
   , LedgerConfig(..)
   , testInitExtLedger
+  , TestBlockOtherHeaderEnvelopeError(..)
   , mkTestConfig
     -- * Corruptions
   , Corruptions
@@ -72,7 +73,6 @@ import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import           Data.Maybe (maybeToList)
-import qualified Data.Text as T
 import           Data.Word
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
@@ -489,7 +489,13 @@ instance HasAnnTip TestBlock where
   type TipInfo TestBlock = IsEBB
   getTipInfo = thIsEBB . unTestHeader
 
+data TestBlockOtherHeaderEnvelopeError =
+    UnexpectedEBBInSlot !SlotNo
+  deriving (Eq, Show, Generic, NoUnexpectedThunks)
+
 instance ValidateEnvelope TestBlock where
+  type OtherHeaderEnvelopeError TestBlock = TestBlockOtherHeaderEnvelopeError
+
   -- Not used in the storage tests, only the default implementation of
   -- 'validateEnvelope' and block production use it.
   firstBlockNo _ = error "unused"
@@ -502,8 +508,7 @@ instance ValidateEnvelope TestBlock where
       when (actualPrevHash /= expectedPrevHash) $
         throwError $ UnexpectedPrevHash expectedPrevHash actualPrevHash
       when (fromIsEBB newIsEBB && not (canBeEBB actualSlotNo)) $
-        throwError $ OtherEnvelopeError . T.pack $
-          "Unexpected EBB in slot " ++ show actualSlotNo
+        throwError $ OtherHeaderEnvelopeError $ UnexpectedEBBInSlot actualSlotNo
     where
       newIsEBB :: IsEBB
       newIsEBB = thIsEBB (unTestHeader hdr)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -500,7 +500,7 @@ instance ValidateEnvelope TestBlock where
   -- 'validateEnvelope' and block production use it.
   firstBlockNo _ = error "unused"
 
-  validateEnvelope cfg oldTip hdr = do
+  validateEnvelope cfg _ledgerView oldTip hdr = do
       when (actualBlockNo /= expectedBlockNo) $
         throwError $ UnexpectedBlockNo expectedBlockNo actualBlockNo
       when (actualSlotNo < expectedSlotNo) $
@@ -545,10 +545,16 @@ instance ValidateEnvelope TestBlock where
       nextBlockNo (At (_       , b)) _     = succ b
 
       canBeEBB :: SlotNo -> Bool
-      canBeEBB (SlotNo s) = testBlockEBBsAllowed cfg && s `mod` epochSlots == 0
+      canBeEBB (SlotNo s) = testBlockEBBsAllowed (configBlock cfg)
+                         && s `mod` epochSlots == 0
 
       epochSlots :: Word64
-      epochSlots = unEpochSize $ HardFork.eraEpochSize $ testBlockEraParams cfg
+      epochSlots =
+          unEpochSize
+        . HardFork.eraEpochSize
+        . testBlockEraParams
+        . configBlock
+        $ cfg
 
 instance LedgerSupportsProtocol TestBlock where
   protocolLedgerView _ _ = ()


### PR DESCRIPTION
In the Shelley ledger, the `CHAIN` rule is used to apply a whole block. In consensus, we split up the application of a block to the ledger into separate steps that are performed together by `applyExtLedgerState`:

* `applyChainTick`: executes the `TICK` transition
* `validateHeader`:
  - `validateEnvelope`: default checks
  - `updateConsensusState`: executes the `PRTCL` transition
* `applyLedgerBlock`: executes the `BBODY` transition and the remaining checks that are part of the `CHAIN` transition

The unfortunate thing was that we had to copy-paste some checks part of the `CHAIN` transition that were not part of any subtransition.

The Shelley has recently factored out these checks into the `chainChecks` function. This commit takes advantage of this change. The new situation:

* `applyChainTick`: executes the `TICK` transition
* `validateHeader`:
  - `validateEnvelope`: default checks + executes the `chainChecks`
  - `updateConsensusState`: executes the `PRTCL` transition
* `applyLedgerBlock`: executes the `BBODY` transition

Now all checks and transitions of the `CHAIN` rule nicely map onto separate steps in consensus.

Note that `chainChecks` can be done on the header, so this change means that we do these checks earlier, in the ChainSyncClient, instead of after downloading the block and applying it to the ledger with `applyExtLedgerState`.

---

To make this possible, some refactorings were needed:

* HeaderValidation: export defaultValidateEnvelope

* HeaderValidation: replace OtherEnvelopeError with a type family

  Instead of `Text`, we now allow a block-specific `OtherHeaderEnvelopeError`. We'll use this ability to do more header checks for Shelley without having to convert the errors to `Text`.

* HeaderValidation: pass more info to validateEnvelope

  In particular, replace `BlockConfig` with `TopLevelConfig`, and add `LedgerView`. We need this extra data to do some more checks for Shelley.