### PR TITLE
Shelley: detect corruption in headers and blocks

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -131,29 +131,29 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 42c57fed487b61c13a68a1600a6675ad987822d0
-  --sha256: 0iab9bwa7my1qb3nnwml8zv4g4zxi5rrypkfmdjs558yh00ykskq
+  tag: f950ed079b257ee7318c095b2c0363f28843f964
+  --sha256: 01xb5hz8qnj006ip6fxdwfaxw1n2avbzkp47nl554bqmaca5kkws
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 42c57fed487b61c13a68a1600a6675ad987822d0
-  --sha256: 0iab9bwa7my1qb3nnwml8zv4g4zxi5rrypkfmdjs558yh00ykskq
+  tag: f950ed079b257ee7318c095b2c0363f28843f964
+  --sha256: 01xb5hz8qnj006ip6fxdwfaxw1n2avbzkp47nl554bqmaca5kkws
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 42c57fed487b61c13a68a1600a6675ad987822d0
-  --sha256: 0iab9bwa7my1qb3nnwml8zv4g4zxi5rrypkfmdjs558yh00ykskq
+  tag: f950ed079b257ee7318c095b2c0363f28843f964
+  --sha256: 01xb5hz8qnj006ip6fxdwfaxw1n2avbzkp47nl554bqmaca5kkws
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 42c57fed487b61c13a68a1600a6675ad987822d0
-  --sha256: 0iab9bwa7my1qb3nnwml8zv4g4zxi5rrypkfmdjs558yh00ykskq
+  tag: f950ed079b257ee7318c095b2c0363f28843f964
+  --sha256: 01xb5hz8qnj006ip6fxdwfaxw1n2avbzkp47nl554bqmaca5kkws
   subdir: slotting
 
 source-repository-package

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Integrity.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Integrity.hs
@@ -1,29 +1,65 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns           #-}
 module Ouroboros.Consensus.Shelley.Ledger.Integrity (
     verifyBlockMatchesHeader
   , verifyHeaderIntegrity
   , verifyBlockIntegrity
   ) where
 
+import           Data.Word (Word64)
+
+import           Ouroboros.Network.Block (SlotNo (..), blockSlot)
+
 import           Ouroboros.Consensus.Block
 
 import qualified Shelley.Spec.Ledger.BlockChain as SL
+import qualified Shelley.Spec.Ledger.Keys as SL
+import qualified Shelley.Spec.Ledger.OCert as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block
+import           Ouroboros.Consensus.Shelley.Protocol
 
--- | Check if a block matches its header
+-- | Check if a block matches its header by checking whether the recomputed
+-- hash of the body matches the hash of the body stored in the header.
 verifyBlockMatchesHeader
   :: Crypto c
   => Header (ShelleyBlock c) -> ShelleyBlock c -> Bool
-verifyBlockMatchesHeader (ShelleyHeader header _)
-                         (ShelleyBlock (SL.Block header' _) _) =
-    -- TODO best approach
-    header == header'
+verifyBlockMatchesHeader hdr blk =
+    -- Compute the hash the body of the block (the transactions) and compare
+    -- that against the hash of the body stored in the header.
+    SL.bbHash txs == SL.bhash hdrBody
+  where
+    ShelleyHeader { shelleyHeaderRaw = SL.BHeader hdrBody _ } = hdr
+    ShelleyBlock  { shelleyBlockRaw  = SL.Block _ txs }       = blk
 
--- | Verify whether a header matches is not corrupted
-verifyHeaderIntegrity :: Header (ShelleyBlock c) -> Bool
-verifyHeaderIntegrity = const True -- TODO #1821
+-- | Verify whether a header is not corrupted
+verifyHeaderIntegrity
+  :: TPraosCrypto c
+  => Word64  -- ^ 'tpraosSlotsPerKESPeriod'
+  -> Header (ShelleyBlock c) -> Bool
+verifyHeaderIntegrity slotsPerKESPeriod hdr@ShelleyHeader { shelleyHeaderRaw } =
+    SL.verifyKES ocertVkHot hdrBody hdrSignature t
+  where
+    SL.BHeader hdrBody hdrSignature = shelleyHeaderRaw
+    SL.OCert {
+        ocertVkHot
+      , ocertKESPeriod = SL.KESPeriod startOfKesPeriod
+      } = SL.bheaderOCert hdrBody
+
+    currentKesPeriod = fromIntegral $
+      unSlotNo (blockSlot hdr) `div` slotsPerKESPeriod
+
+    t | currentKesPeriod >= startOfKesPeriod
+      = currentKesPeriod - startOfKesPeriod
+      | otherwise
+      = 0
 
 -- | Verifies whether the block is not corrupted by checking its signature and
 -- witnesses
-verifyBlockIntegrity :: ShelleyBlock c -> Bool
-verifyBlockIntegrity = const True -- TODO #1821
+verifyBlockIntegrity
+  :: TPraosCrypto c
+  => Word64  -- ^ 'tpraosSlotsPerKESPeriod'
+  -> ShelleyBlock c -> Bool
+verifyBlockIntegrity slotsPerKESPeriod blk =
+    verifyHeaderIntegrity slotsPerKESPeriod (getHeader blk) &&
+    verifyBlockMatchesHeader                (getHeader blk) blk

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -302,7 +302,10 @@ instance TPraosCrypto c => RunNode (ShelleyBlock c) where
   nodeBlockEncodingOverhead = const 1 -- Single list tag.
   -- Check this isn't altered by the TxWits stuff
 
-  nodeCheckIntegrity = const verifyBlockIntegrity
+  nodeCheckIntegrity cfg = verifyBlockIntegrity tpraosSlotsPerKESPeriod
+    where
+      TPraosParams { tpraosSlotsPerKESPeriod } =
+        tpraosParams $ configConsensus cfg
 
   nodeAddHeaderEnvelope _ _isEBB _blockSize = shelleyAddHeaderEnvelope
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,7 @@ extra-deps:
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 42c57fed487b61c13a68a1600a6675ad987822d0
+    commit: f950ed079b257ee7318c095b2c0363f28843f964
     subdirs:
       - binary
       - binary/test


### PR DESCRIPTION
Fixes #1821.

These checks are used by the databases to detect corruption in on-disk blocks.