### PR TITLE
Version codec

### DIFF
--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -29,6 +29,7 @@ import Ouroboros.Network.Mux
 import Ouroboros.Network.ErrorPolicy
 import Ouroboros.Network.IOManager
 
+import Ouroboros.Network.Protocol.Handshake.Codec
 import Ouroboros.Network.Protocol.Handshake.Type
 import Ouroboros.Network.Protocol.Handshake.Version
 
@@ -101,6 +102,7 @@ clientPingPong pipelined =
     withIOManager $ \iomgr ->
     connectToNode
       (localSnocket iomgr defaultLocalSocketAddrPath)
+      unversionedHandshakeCodec
       cborTermVersionDataCodec
       nullNetworkConnectTracers
       (unversionedProtocol (\_peerid -> app))
@@ -140,6 +142,7 @@ serverPingPong =
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)
       defaultLocalSocketAddr
+      unversionedHandshakeCodec
       cborTermVersionDataCodec
       (\(DictVersion _) -> acceptableVersion)
       (unversionedProtocol (\_peerid -> SomeResponderApplication app))
@@ -194,6 +197,7 @@ clientPingPong2 =
     withIOManager $ \iomgr ->
     connectToNode
       (localSnocket iomgr defaultLocalSocketAddrPath)
+      unversionedHandshakeCodec
       cborTermVersionDataCodec
       nullNetworkConnectTracers
       (unversionedProtocol (\_peerid -> app))
@@ -246,6 +250,7 @@ serverPingPong2 =
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)
       defaultLocalSocketAddr
+      unversionedHandshakeCodec
       cborTermVersionDataCodec
       (\(DictVersion _) -> acceptableVersion)
       (unversionedProtocol (\_peerid -> SomeResponderApplication app))

--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -29,8 +29,8 @@ import Ouroboros.Network.Mux
 import Ouroboros.Network.ErrorPolicy
 import Ouroboros.Network.IOManager
 
-import Ouroboros.Network.Protocol.Handshake.Codec
 import Ouroboros.Network.Protocol.Handshake.Type
+import Ouroboros.Network.Protocol.Handshake.Unversioned
 import Ouroboros.Network.Protocol.Handshake.Version
 
 import Network.TypedProtocol.Pipelined

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -32,6 +32,7 @@ library
                        Ouroboros.Network.Protocol.Handshake.Type
                        Ouroboros.Network.Protocol.Handshake.Codec
                        Ouroboros.Network.Protocol.Handshake.Version
+                       Ouroboros.Network.Protocol.Handshake.Unversioned
                        Ouroboros.Network.Protocol.Limits
 
                        Ouroboros.Network.Server.ConnectionTable

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -21,6 +21,7 @@ extra-source-files:  CHANGELOG.md
 
 library
   exposed-modules:     Ouroboros.Network.Codec
+                       Ouroboros.Network.CodecCBORTerm
                        Ouroboros.Network.Channel
                        Ouroboros.Network.Driver
                        Ouroboros.Network.Driver.Simple

--- a/ouroboros-network-framework/src/Ouroboros/Network/CodecCBORTerm.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/CodecCBORTerm.hs
@@ -1,0 +1,13 @@
+module Ouroboros.Network.CodecCBORTerm where
+
+import qualified Codec.CBOR.Term as CBOR
+
+
+-- | A pure codec which encodes to / decodes from 'CBOR.Term'.  This is useful
+-- if one expects a valid @cbor@ encoding, which one might not know how to
+-- decode like in the 'Handshake' protocol.
+--
+data CodecCBORTerm fail a = CodecCBORTerm
+  { encodeTerm :: a -> CBOR.Term
+  , decodeTerm :: CBOR.Term -> Either fail a
+  }

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
@@ -33,6 +33,7 @@ import qualified Codec.CBOR.Read     as CBOR
 import qualified Codec.CBOR.Term     as CBOR
 
 import           Ouroboros.Network.Codec
+import           Ouroboros.Network.CodecCBORTerm
 import           Ouroboros.Network.Driver.Limits
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -12,8 +11,6 @@ module Ouroboros.Network.Protocol.Handshake.Codec
 
   , byteLimitsHandshake
   , timeLimitsHandshake
-
-  , unversionedHandshakeCodec
 
   , encodeRefuseReason
   , decodeRefuseReason
@@ -35,7 +32,7 @@ import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Read     as CBOR
 import qualified Codec.CBOR.Term     as CBOR
 
-import           Ouroboros.Network.Codec hiding (encode, decode)
+import           Ouroboros.Network.Codec
 import           Ouroboros.Network.Driver.Limits
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
@@ -212,23 +209,3 @@ decodeRefuseReason versionNumberCodec = do
           Left e        -> fail $ "decode Refused: unknonwn version: " ++ show e
           Right vNumber -> Refused vNumber <$> CBOR.decodeString
       _ -> fail $ "decode RefuseReason: unknown tag " ++ show tag
-
-
--- | 'Handshake' codec used in various tests.
---
-unversionedHandshakeCodec :: ( MonadST m
-                            , MonadThrow m
-                            )
-                         => Codec (Handshake UnversionedProtocol CBOR.Term)
-                                  CBOR.DeserialiseFailure m ByteString
-unversionedHandshakeCodec = codecHandshake unversionedProtocolCodec
-  where
-    unversionedProtocolCodec :: CodecCBORTerm (String, Maybe Int) UnversionedProtocol
-    unversionedProtocolCodec = CodecCBORTerm { encodeTerm, decodeTerm }
-      where
-        encodeTerm UnversionedProtocol = CBOR.TInt 1
-        decodeTerm (CBOR.TInt 1) = Right UnversionedProtocol
-        decodeTerm (CBOR.TInt n) = Left ("decode UnversionedProtocol: unknown tag", Just n)
-        decodeTerm _             = Left ("decode UnversionedProtocol: deserialisation failure", Nothing)
-
-

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -50,6 +50,7 @@ import qualified Codec.CBOR.Term     as CBOR
 
 import           Network.TypedProtocol.Core
 
+import           Ouroboros.Network.CodecCBORTerm
 import           Ouroboros.Network.Protocol.Handshake.Version
 
 -- |

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -160,14 +160,16 @@ instance (Typeable vNumber, Show vNumber)
 -- | Codec for version data ('vData' in code) exchanged by the handshake
 -- protocol.
 --
-data VersionDataCodec extra bites = VersionDataCodec {
-    encodeData :: forall vData. extra vData -> vData -> bites,
+data VersionDataCodec extra bytes = VersionDataCodec {
+    encodeData :: forall vData. extra vData -> vData -> bytes,
     -- ^ encoder of 'vData' which has access to 'extra vData' which can bring
     -- extra instances into the scope (by means of pattern matching on a GADT).
-    decodeData :: forall vData. extra vData -> bites -> Either Text vData
+    decodeData :: forall vData. extra vData -> bytes -> Either Text vData
     -- ^ decoder of 'vData'.
   }
 
+-- TODO: remove this from top level API, this is the only way we encode or
+-- decode version data.
 cborTermVersionDataCodec :: VersionDataCodec DictVersion CBOR.Term
 cborTermVersionDataCodec = VersionDataCodec {
       encodeData = \(DictVersion codec) -> encodeTerm codec,

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Unversioned.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Unversioned.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE NamedFieldPuns      #-}
+
+-- | Unversioned protocol, used in tests and demo applications.
+--
+module Ouroboros.Network.Protocol.Handshake.Unversioned
+  ( UnversionedProtocol (..)
+  , UnversionedProtocolData (..)
+  , unversionedHandshakeCodec
+  , unversionedProtocolDataCodec
+  , unversionedProtocol
+  ) where
+
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadThrow
+
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Term as CBOR
+
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Data.ByteString.Lazy (ByteString)
+
+import           Ouroboros.Network.Codec
+
+import           Ouroboros.Network.Protocol.Handshake.Codec
+import           Ouroboros.Network.Protocol.Handshake.Type
+import           Ouroboros.Network.Protocol.Handshake.Version
+
+
+-- | Version negotiation for an unversioned protocol. We only use this for
+-- tests and demos where proper versioning is excessive.
+--
+data UnversionedProtocol = UnversionedProtocol
+  deriving (Eq, Ord, Enum, Show)
+
+
+data UnversionedProtocolData = UnversionedProtocolData
+  deriving (Eq, Show)
+
+
+instance Acceptable UnversionedProtocolData where
+  acceptableVersion UnversionedProtocolData
+                    UnversionedProtocolData = Accept
+
+
+unversionedProtocolDataCodec :: CodecCBORTerm Text UnversionedProtocolData
+unversionedProtocolDataCodec = CodecCBORTerm {encodeTerm, decodeTerm}
+    where
+      encodeTerm :: UnversionedProtocolData -> CBOR.Term
+      encodeTerm UnversionedProtocolData = CBOR.TNull
+
+      decodeTerm :: CBOR.Term -> Either Text UnversionedProtocolData
+      decodeTerm CBOR.TNull = Right UnversionedProtocolData
+      decodeTerm t          = Left $ T.pack $ "unexpected term: " ++ show t
+
+
+-- | Make a 'Versions' for an unversioned protocol. Only use this for
+-- tests and demos where proper versioning is excessive.
+--
+unversionedProtocol :: app -> Versions UnversionedProtocol DictVersion app
+unversionedProtocol =
+    simpleSingletonVersions UnversionedProtocol UnversionedProtocolData
+                            (DictVersion unversionedProtocolDataCodec)
+
+
+-- | 'Handshake' codec used in various tests.
+--
+unversionedHandshakeCodec :: ( MonadST m
+                            , MonadThrow m
+                            )
+                         => Codec (Handshake UnversionedProtocol CBOR.Term)
+                                  CBOR.DeserialiseFailure m ByteString
+unversionedHandshakeCodec = codecHandshake unversionedProtocolCodec
+  where
+    unversionedProtocolCodec :: CodecCBORTerm (String, Maybe Int) UnversionedProtocol
+    unversionedProtocolCodec = CodecCBORTerm { encodeTerm, decodeTerm }
+      where
+        encodeTerm UnversionedProtocol = CBOR.TInt 1
+        decodeTerm (CBOR.TInt 1) = Right UnversionedProtocol
+        decodeTerm (CBOR.TInt n) = Left ("decode UnversionedProtocol: unknown tag", Just n)
+        decodeTerm _             = Left ("decode UnversionedProtocol: deserialisation failure", Nothing)
+
+

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Unversioned.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Unversioned.hs
@@ -21,6 +21,7 @@ import qualified Data.Text as T
 import           Data.ByteString.Lazy (ByteString)
 
 import           Ouroboros.Network.Codec
+import           Ouroboros.Network.CodecCBORTerm
 
 import           Ouroboros.Network.Protocol.Handshake.Codec
 import           Ouroboros.Network.Protocol.Handshake.Type

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Version.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Version.hs
@@ -25,24 +25,17 @@ module Ouroboros.Network.Protocol.Handshake.Version
   , combineVersions
   , foldMapVersions'
   , combineVersions'
-
-  -- * No Versioning
-  -- exposed for tests
-  , UnversionedProtocol (..)
-  , unversionedProtocol
   ) where
 
-import Data.Map (Map)
-import Data.Text (Text)
+import           Data.Map (Map)
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
-import qualified Data.Text as T
+import           Data.Text (Text)
 import qualified Data.Map as Map
-import Data.Typeable ((:~:)(Refl), Typeable, eqT)
+import           Data.Typeable ((:~:)(Refl), Typeable, eqT)
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Term as CBOR
-import Codec.Serialise (Serialise(..))
 
 
 -- Description of versions.
@@ -234,37 +227,3 @@ simpleSingletonVersions vNum vData extra r =
   Versions
     $ Map.singleton vNum
         (Sigma vData (Version (Application $ \_ _ -> r) extra))
-
--- | Version negotiation for an unversioned protocol. Only use this for
--- tests and demos where proper versioning is excessive.
---
-data UnversionedProtocol = UnversionedProtocol
-  deriving (Eq, Ord, Enum, Show)
-
-
-data UnversionedProtocolData = UnversionedProtocolData
-  deriving (Eq, Show)
-
-instance Acceptable UnversionedProtocolData where
-  acceptableVersion UnversionedProtocolData
-                    UnversionedProtocolData = Accept
-
-
-unversionedProtocolDataCodec :: CodecCBORTerm Text UnversionedProtocolData
-unversionedProtocolDataCodec = CodecCBORTerm {encodeTerm, decodeTerm}
-    where
-      encodeTerm :: UnversionedProtocolData -> CBOR.Term
-      encodeTerm UnversionedProtocolData = CBOR.TNull
-
-      decodeTerm :: CBOR.Term -> Either Text UnversionedProtocolData
-      decodeTerm CBOR.TNull = Right UnversionedProtocolData
-      decodeTerm t          = Left $ T.pack $ "unexpected term: " ++ show t
-
-
--- | Make a 'Versions' for an unversioned protocol. Only use this for
--- tests and demos where proper versioning is excessive.
---
-unversionedProtocol :: app -> Versions UnversionedProtocol DictVersion app
-unversionedProtocol =
-    simpleSingletonVersions UnversionedProtocol UnversionedProtocolData
-                            (DictVersion unversionedProtocolDataCodec)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Version.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Version.hs
@@ -21,11 +21,15 @@ module Ouroboros.Network.Protocol.Handshake.Version
 
   -- * Simple or no versioning
   , simpleSingletonVersions
-  , unversionedProtocol
   , foldMapVersions
   , combineVersions
   , foldMapVersions'
   , combineVersions'
+
+  -- * No Versioning
+  -- exposed for tests
+  , UnversionedProtocol (..)
+  , unversionedProtocol
   ) where
 
 import Data.Map (Map)
@@ -237,13 +241,6 @@ simpleSingletonVersions vNum vData extra r =
 data UnversionedProtocol = UnversionedProtocol
   deriving (Eq, Ord, Enum, Show)
 
-instance Serialise UnversionedProtocol where
-    encode UnversionedProtocol = CBOR.encodeWord 1
-    decode = do
-      tag <- CBOR.decodeWord
-      case tag of
-        1 -> return UnversionedProtocol
-        _ -> fail "decode UnversionedProtocol: expected version 1"
 
 data UnversionedProtocolData = UnversionedProtocolData
   deriving (Eq, Show)
@@ -251,6 +248,7 @@ data UnversionedProtocolData = UnversionedProtocolData
 instance Acceptable UnversionedProtocolData where
   acceptableVersion UnversionedProtocolData
                     UnversionedProtocolData = Accept
+
 
 unversionedProtocolDataCodec :: CodecCBORTerm Text UnversionedProtocolData
 unversionedProtocolDataCodec = CodecCBORTerm {encodeTerm, decodeTerm}
@@ -261,6 +259,7 @@ unversionedProtocolDataCodec = CodecCBORTerm {encodeTerm, decodeTerm}
       decodeTerm :: CBOR.Term -> Either Text UnversionedProtocolData
       decodeTerm CBOR.TNull = Right UnversionedProtocolData
       decodeTerm t          = Left $ T.pack $ "unexpected term: " ++ show t
+
 
 -- | Make a 'Versions' for an unversioned protocol. Only use this for
 -- tests and demos where proper versioning is excessive.

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
@@ -60,6 +60,7 @@ import           Network.Mux.Timeout
 
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
+import           Ouroboros.Network.Protocol.Handshake.Codec
 
 import           Test.QuickCheck
 import           Test.Tasty (DependencyType (..), TestTree, after, testGroup)
@@ -239,6 +240,7 @@ prop_socket_send_recv initiatorAddr responderAddr f xs =
         networkState
         (AcceptedConnectionsLimit maxBound maxBound 0)
         responderAddr
+        unversionedHandshakeCodec
         cborTermVersionDataCodec
         (\(DictVersion _) -> acceptableVersion)
         (unversionedProtocol (\_peerid -> SomeResponderApplication responderApp))
@@ -246,6 +248,7 @@ prop_socket_send_recv initiatorAddr responderAddr f xs =
         $ \_ _ -> do
           connectToNode
             snocket
+            unversionedHandshakeCodec
             cborTermVersionDataCodec
             (NetworkConnectTracers activeMuxTracer nullTracer)
             (unversionedProtocol (\_peerid -> initiatorApp))
@@ -477,6 +480,7 @@ prop_socket_client_connect_error _ xs =
     (res :: Either IOException Bool)
       <- try $ False <$ connectToNode
         (socketSnocket iomgr)
+        unversionedHandshakeCodec
         cborTermVersionDataCodec
         nullNetworkConnectTracers
         (unversionedProtocol (\_peerid -> app))

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
@@ -59,8 +59,8 @@ import           Network.Mux.Types ( MiniProtocolMode (..) , MuxSDU (..), MuxSDU
 import           Network.Mux.Timeout
 
 import           Ouroboros.Network.Protocol.Handshake.Type
+import           Ouroboros.Network.Protocol.Handshake.Unversioned
 import           Ouroboros.Network.Protocol.Handshake.Version
-import           Ouroboros.Network.Protocol.Handshake.Codec
 
 import           Test.QuickCheck
 import           Test.Tasty (DependencyType (..), TestTree, after, testGroup)

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
@@ -42,6 +42,7 @@ import qualified Network.TypedProtocol.ReqResp.Server as ReqResp
 import qualified Network.TypedProtocol.ReqResp.Codec.CBOR as ReqResp
 import qualified Network.TypedProtocol.ReqResp.Examples   as ReqResp
 
+import           Ouroboros.Network.Protocol.Handshake.Codec
 import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Version
 
@@ -585,6 +586,7 @@ prop_send_recv f xs _first = ioProperty $ withIOManager $ \iocp -> do
         (NetworkMutableState tbl peerStatesVar)
         (AcceptedConnectionsLimit maxBound maxBound 0)
         (Socket.addrAddress responderAddr)
+        unversionedHandshakeCodec
         cborTermVersionDataCodec
         (\(DictVersion _) -> acceptableVersion)
         (unversionedProtocol (\_peerid -> SomeResponderApplication responderApp))
@@ -608,6 +610,7 @@ prop_send_recv f xs _first = ioProperty $ withIOManager $ \iocp -> do
             (\_ -> waitSiblingSTM siblingVar)
             (connectToNodeSocket
                 iocp
+                unversionedHandshakeCodec
                 cborTermVersionDataCodec
                 nullNetworkConnectTracers
                 (unversionedProtocol (\_peerid -> initiatorApp)))
@@ -724,6 +727,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
         (NetworkMutableState tbl stVar)
         (AcceptedConnectionsLimit maxBound maxBound 0)
         responderAddr
+        unversionedHandshakeCodec
         cborTermVersionDataCodec
         (\(DictVersion _) -> acceptableVersion)
         (unversionedProtocol (\_peerid -> SomeResponderApplication (appX rrcfg)))
@@ -743,6 +747,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
           (NetworkMutableState tbl stVar)
           (AcceptedConnectionsLimit maxBound maxBound 0)
           responderAddr
+          unversionedHandshakeCodec
           cborTermVersionDataCodec
           (\(DictVersion _) -> acceptableVersion)
           (unversionedProtocol (\_peerid -> SomeResponderApplication (appX rrcfg)))
@@ -767,6 +772,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
               (\_ -> waitSiblingSTM (rrcSiblingVar rrcfg))
               (connectToNodeSocket
                   iocp
+                  unversionedHandshakeCodec
                   cborTermVersionDataCodec
                   nullNetworkConnectTracers
                   (unversionedProtocol (\_peerid -> appX rrcfg)))
@@ -837,6 +843,7 @@ _demo = ioProperty $ withIOManager $ \iocp -> do
               }
             (connectToNodeSocket
                 iocp
+                unversionedHandshakeCodec
                 cborTermVersionDataCodec
                 nullNetworkConnectTracers
                 (unversionedProtocol (\_peerid -> appReq)))
@@ -857,6 +864,7 @@ _demo = ioProperty $ withIOManager $ \iocp -> do
             (NetworkMutableState tbl stVar)
             (AcceptedConnectionsLimit maxBound maxBound 0)
             (Socket.addrAddress addr)
+            unversionedHandshakeCodec
             cborTermVersionDataCodec
             (\(DictVersion _) -> acceptableVersion)
             (unversionedProtocol (\_peerid -> SomeResponderApplication appRsp))

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
@@ -42,8 +42,8 @@ import qualified Network.TypedProtocol.ReqResp.Server as ReqResp
 import qualified Network.TypedProtocol.ReqResp.Codec.CBOR as ReqResp
 import qualified Network.TypedProtocol.ReqResp.Examples   as ReqResp
 
-import           Ouroboros.Network.Protocol.Handshake.Codec
 import           Ouroboros.Network.Protocol.Handshake.Type
+import           Ouroboros.Network.Protocol.Handshake.Unversioned
 import           Ouroboros.Network.Protocol.Handshake.Version
 
 import           Ouroboros.Network.Driver

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -54,6 +54,7 @@ import           Ouroboros.Network.Testing.ConcreteBlock
 import           Ouroboros.Network.Codec
 import           Ouroboros.Network.Driver
 import           Ouroboros.Network.Protocol.Handshake.Type
+import           Ouroboros.Network.Protocol.Handshake.Unversioned
 import           Ouroboros.Network.Protocol.Handshake.Version
 
 import qualified Ouroboros.Network.Protocol.ChainSync.Client as ChainSync
@@ -154,10 +155,11 @@ clientChainSync sockPaths = withIOManager $ \iocp ->
       threadDelay (50000 * index)
       connectToNode
         (localSnocket iocp sockPath)
+        unversionedHandshakeCodec
         cborTermVersionDataCodec
         nullNetworkConnectTracers
         (simpleSingletonVersions
-           (0::Int)
+           UnversionedProtocol
            (NodeToNodeVersionData $ NetworkMagic 0)
            (DictVersion nodeToNodeCodecCBORTerm)
            (\_peerid -> app))
@@ -186,10 +188,11 @@ serverChainSync sockAddr = withIOManager $ \iocp -> do
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)
       (localAddressFromPath sockAddr)
+      unversionedHandshakeCodec
       cborTermVersionDataCodec
       (\(DictVersion _) -> acceptableVersion)
       (simpleSingletonVersions
-        (0::Int)
+        UnversionedProtocol
         (NodeToNodeVersionData $ NetworkMagic 0)
         (DictVersion nodeToNodeCodecCBORTerm)
         (\_peerid -> SomeResponderApplication app))
@@ -356,10 +359,11 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
                     [ async $
                         connectToNode
                           (localSnocket iocp defaultLocalSocketAddrPath)
+                          unversionedHandshakeCodec
                           cborTermVersionDataCodec
                           nullNetworkConnectTracers
                           (simpleSingletonVersions
-                            (0 :: Int)
+                            UnversionedProtocol
                             (NodeToNodeVersionData (NetworkMagic 0))
                             (DictVersion nodeToNodeCodecCBORTerm)
                             app)
@@ -404,10 +408,11 @@ serverBlockFetch sockAddr = withIOManager $ \iocp -> do
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)
       (localAddressFromPath sockAddr)
+      unversionedHandshakeCodec
       cborTermVersionDataCodec
       (\(DictVersion _) -> acceptableVersion)
       (simpleSingletonVersions
-        (0::Int)
+        UnversionedProtocol
         (NodeToNodeVersionData $ NetworkMagic 0)
         (DictVersion nodeToNodeCodecCBORTerm)
         (\_peerid -> SomeResponderApplication app))

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -287,6 +287,8 @@ test-suite test-cddl
                        cborg,
                        containers,
                        contra-tracer,
+                       directory,
+                       filepath,
                        fingertree,
                        hashable,
                        io-sim,

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -412,10 +412,19 @@ prop_channel createChannels clientVersions serverVersions =
           cborTermVersionDataCodec
           (\(DictVersion _) -> acceptableVersion)
           serverVersions)
-    return $
-           maybe False id clientRes === either (const False) id clientRes'
-      .&&.
-           maybe False id serverRes === either (const False) id serverRes'
+    pure $
+      case (clientRes', serverRes') of
+        -- buth succeeded, we just check that the application (which is
+        -- a boolean value) is the one that was put inside 'Version'
+        (Right c, Right s) -> Just c === clientRes
+                         .&&. Just s === serverRes
+
+        -- both failed
+        (Left{}, Left{})   -> property True
+
+        -- it should not happen that one protocol succeeds and the other end
+        -- fails
+        _                  -> property False
 
 
 -- | Run 'prop_channel' in the simulation monad.

--- a/ouroboros-network/test-cddl/Main.hs
+++ b/ouroboros-network/test-cddl/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DataKinds #-}
@@ -17,6 +18,9 @@ import qualified Data.ByteString.Internal as BSI
 import Data.ByteString.Lazy (ByteString)
 import Data.ByteString.Lazy.Char8 as Char8 (lines, unpack)
 import Data.List (intercalate)
+
+import System.Directory (doesDirectoryExist)
+import System.FilePath
 
 import Test.QuickCheck
 import Test.Tasty (defaultMain, TestTree, testGroup, adjustOption)
@@ -49,10 +53,6 @@ import Ouroboros.Network.Protocol.LocalTxSubmission.Type as LocalTxSubmission
 import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Test as LocalTxSubmission (Tx, Reject)
 
 
--- These files must be in place:
-specFile :: FilePath
-specFile = "test/messages.cddl"
-
 cddlTool :: FilePath
 cddlTool = "cddl"
 
@@ -60,21 +60,26 @@ diag2cborTool :: FilePath
 diag2cborTool = "diag2cbor.rb"
 
 main :: IO ()
-main = defaultMain tests
+main = do
+    a <- doesDirectoryExist "ouroboros-network"
+    let specPath =
+          if a then "ouroboros-network" </> "test" </> "messages.cddl"
+               else "test" </> "messages.cddl"
+    defaultMain (tests specPath)
 
-tests :: TestTree
-tests =
+tests :: FilePath -> TestTree
+tests specPath =
   adjustOption (const $ QuickCheckMaxSize 10) $ testGroup "messages.cddl-spec"
   [
 -- These tests call the CDDL-tool to parse an arbitray message.
 -- The parser of the CDDL-tool is slow (exponential runtime & space).
-    testProperty "encode ChainSync"             prop_specCS
-  , testProperty "encode BlockFetch"            prop_specBF
-  , testProperty "encode TxSubmission"          prop_specTxSubmission
-  , testProperty "encode Handshake"             prop_specHandshake
-  , testProperty "encode local Tx submission"   prop_specLocalTxSubmission
+    testProperty "encode ChainSync"             (prop_specCS specPath)
+  , testProperty "encode BlockFetch"            (prop_specBF specPath)
+  , testProperty "encode TxSubmission"          (prop_specTxSubmission specPath)
+  , testProperty "encode Handshake"             (prop_specHandshake specPath)
+  , testProperty "encode local Tx submission"   (prop_specLocalTxSubmission specPath)
   -- Test the parsers with CDDL-generated messages.
-  , testProperty "generate and decode" $ ioProperty $ generateAndDecode 100 specFile
+  , testProperty "generate and decode" $ ioProperty $ generateAndDecode 100 specPath
   ]
 
 -- The concrete/monomorphic types used for the test.
@@ -102,28 +107,30 @@ codecTS = codecTxSubmission Serialise.encode Serialise.decode Serialise.encode S
 codecLT :: MonoCodec LT
 codecLT = codecLocalTxSubmission Serialise.encode Serialise.decode Serialise.encode Serialise.decode
 
-prop_specCS :: AnyMessageAndAgency CS -> Property
-prop_specCS = prop_CDDLSpec (0, codecCS)
+prop_specCS :: FilePath -> AnyMessageAndAgency CS -> Property
+prop_specCS specPath = prop_CDDLSpec specPath (0, codecCS)
 
-prop_specBF :: AnyMessageAndAgency BF -> Property
-prop_specBF = prop_CDDLSpec (3, codecBF)
+prop_specBF :: FilePath -> AnyMessageAndAgency BF -> Property
+prop_specBF specPath = prop_CDDLSpec specPath (3, codecBF)
 
-prop_specTxSubmission :: AnyMessageAndAgency TS -> Property
-prop_specTxSubmission = prop_CDDLSpec (4, codecTS)
+prop_specTxSubmission :: FilePath -> AnyMessageAndAgency TS -> Property
+prop_specTxSubmission specPath = prop_CDDLSpec specPath (4, codecTS)
 
-prop_specLocalTxSubmission :: AnyMessageAndAgency LT -> Property
-prop_specLocalTxSubmission = prop_CDDLSpec (6, codecLT)
+prop_specLocalTxSubmission :: FilePath -> AnyMessageAndAgency LT -> Property
+prop_specLocalTxSubmission specPath = prop_CDDLSpec specPath (6, codecLT)
 
 -- TODO: this test should use 'nodeToNodeHandshakeCodec' and
 -- 'nodeToClientHandshakeCodec'
-prop_specHandshake :: AnyMessageAndAgency HS -> Property
-prop_specHandshake = prop_CDDLSpec (5, versionNumberHandshakeCodec)
+prop_specHandshake :: FilePath -> AnyMessageAndAgency HS -> Property
+prop_specHandshake specPath = prop_CDDLSpec specPath (5, versionNumberHandshakeCodec)
 
-prop_CDDLSpec :: (Word, MonoCodec ps) -> AnyMessageAndAgency ps -> Property
-prop_CDDLSpec (tagWord, codec) (AnyMessageAndAgency agency msg)
+prop_CDDLSpec :: FilePath -- ^ "messages.cddl" spec file path
+              -> (Word, MonoCodec ps)
+              -> AnyMessageAndAgency ps -> Property
+prop_CDDLSpec specPath (tagWord, codec) (AnyMessageAndAgency agency msg)
     = ioProperty $ do
 --         print $ BSL.unpack wrappedMsg
-         validateCBOR specFile wrappedMsg
+         validateCBOR specPath wrappedMsg
     where
         innerBS = encode codec agency msg
         body = case deserialiseFromBytes decodeTerm innerBS of

--- a/ouroboros-network/test-cddl/Main.hs
+++ b/ouroboros-network/test-cddl/Main.hs
@@ -39,9 +39,8 @@ import Ouroboros.Network.Protocol.ChainSync.Test ()
 import Ouroboros.Network.Protocol.BlockFetch.Codec (codecBlockFetch)
 import Ouroboros.Network.Protocol.BlockFetch.Test ()
 import Ouroboros.Network.Protocol.BlockFetch.Type as BlockFetch
-import Ouroboros.Network.Protocol.Handshake.Codec (codecHandshake)
 import Ouroboros.Network.Protocol.Handshake.Type as Handshake
-import Ouroboros.Network.Protocol.Handshake.Test (VersionNumber)
+import Ouroboros.Network.Protocol.Handshake.Test (VersionNumber, versionNumberHandshakeCodec)
 import Ouroboros.Network.Protocol.TxSubmission.Codec (codecTxSubmission)
 import Ouroboros.Network.Protocol.TxSubmission.Type as TxSubmission
 import Ouroboros.Network.Protocol.TxSubmission.Test (TxId, Tx)
@@ -115,8 +114,10 @@ prop_specTxSubmission = prop_CDDLSpec (4, codecTS)
 prop_specLocalTxSubmission :: AnyMessageAndAgency LT -> Property
 prop_specLocalTxSubmission = prop_CDDLSpec (6, codecLT)
 
+-- TODO: this test should use 'nodeToNodeHandshakeCodec' and
+-- 'nodeToClientHandshakeCodec'
 prop_specHandshake :: AnyMessageAndAgency HS -> Property
-prop_specHandshake = prop_CDDLSpec (5, codecHandshake)
+prop_specHandshake = prop_CDDLSpec (5, versionNumberHandshakeCodec)
 
 prop_CDDLSpec :: (Word, MonoCodec ps) -> AnyMessageAndAgency ps -> Property
 prop_CDDLSpec (tagWord, codec) (AnyMessageAndAgency agency msg)
@@ -257,7 +258,8 @@ decodeMsg (tag, input) = case tag of
             , runBlockFetch (ServerAgency BlockFetch.TokStreaming)
             ]
 
-        runHandshake = run (codecHandshake :: MonoCodec HS)
+        -- Use 'nodeToNodeHandshakeCodec' and 'nodeToClientHandshakeCodec'
+        runHandshake = run (versionNumberHandshakeCodec :: MonoCodec HS)
         handshakeParsers = [
               runHandshake (ClientAgency TokPropose)
             , runHandshake (ServerAgency TokConfirm)

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -147,10 +147,11 @@ demo chain0 updates = withIOManager $ \iocp -> do
       networkState
       (AcceptedConnectionsLimit maxBound maxBound 0)
       producerAddress
+      nodeToNodeHandshakeCodec
       cborTermVersionDataCodec
       (\(DictVersion _) -> acceptableVersion)
       (simpleSingletonVersions
-        (0::Int)
+        NodeToNodeV_1
         (NodeToNodeVersionData $ NetworkMagic 0)
         (DictVersion nodeToNodeCodecCBORTerm)
         (\_peerid -> SomeResponderApplication responderApp))
@@ -159,10 +160,11 @@ demo chain0 updates = withIOManager $ \iocp -> do
       withAsync
         (connectToNode
           (socketSnocket iocp)
+          nodeToNodeHandshakeCodec
           cborTermVersionDataCodec
           nullNetworkConnectTracers
           (simpleSingletonVersions
-            (0::Int)
+            NodeToNodeV_1
             (NodeToNodeVersionData $ NetworkMagic 0)
             (DictVersion nodeToNodeCodecCBORTerm)
             (\_peerid -> initiatorApp))


### PR DESCRIPTION
This PR changes how Handshake codec works.  Previously it would fail if 
an unknown version number was submitted, now it will not.

This change should not change wire format of the handshake messages. 

In addition it allows to confiugure which protocols versions are used by
consensus, there will be an accompanying PR in `cardano-node` repository which
adds an option to the confituration file.

I hope this fixes #1971, though I havent tested it (for that we need a new protocol
version).

- Make it possible to configure NodeToNodeVersion / NodeToClientVersion
- Make test-cddl run with cabal by default
- Updated 'test-cddl' component
- Fix a typo, added TODO comment
- Updated chain-sync demo
- Updatd test-network
- Updated ouroboros-protocol-tests library
- Updated ouroboros-network library
- CodecCBORTerm deserves its own module
- Move Unversioned to its own module
- Updated ping-pong demo
- Updated ouroboros-network-framework-tests
- Added unversionedHandshakeCodec
- RefuseReason changes
- Change Handshake protocol codec
- Change Socket API
