### PR TITLE
Test Shelley protocol in decentralised mode

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -111,8 +111,8 @@ package small-steps
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: cda172dac4428058ebcb832673f379c9f92d411e
-  --sha256: 0bgx4x9vwxgk38dncx09xwm06h9m2cqhg94300mw3map77bcwarl
+  tag: 0aae419140b50e93154c146ec9cbea9d3c7ac9ba
+  --sha256: 02r67h6wc07r4wp2cqka798dlpf7siwb8y52khvdknv3mw6hm84z
   subdir:   contra-tracer
 
 source-repository-package
@@ -131,71 +131,71 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 5035c9ed95e9d47f050314a7d96b1b2043288f61
-  --sha256: 103z0009sz586f2mvnmwl2hp9n94qy0n72ik521xhq7zmfwyv3m7
+  tag: 2cc27584bb19bd5be9f1721fd4a2393bb99c6119
+  --sha256: 1zjrjh6hr2v4vsr9yj3vr73q1358mymi0ri1kl4cy4i54b4iwbfv
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 5035c9ed95e9d47f050314a7d96b1b2043288f61
-  --sha256: 103z0009sz586f2mvnmwl2hp9n94qy0n72ik521xhq7zmfwyv3m7
+  tag: 2cc27584bb19bd5be9f1721fd4a2393bb99c6119
+  --sha256: 1zjrjh6hr2v4vsr9yj3vr73q1358mymi0ri1kl4cy4i54b4iwbfv
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 5035c9ed95e9d47f050314a7d96b1b2043288f61
-  --sha256: 103z0009sz586f2mvnmwl2hp9n94qy0n72ik521xhq7zmfwyv3m7
+  tag: 2cc27584bb19bd5be9f1721fd4a2393bb99c6119
+  --sha256: 1zjrjh6hr2v4vsr9yj3vr73q1358mymi0ri1kl4cy4i54b4iwbfv
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 5035c9ed95e9d47f050314a7d96b1b2043288f61
-  --sha256: 103z0009sz586f2mvnmwl2hp9n94qy0n72ik521xhq7zmfwyv3m7
+  tag: 2cc27584bb19bd5be9f1721fd4a2393bb99c6119
+  --sha256: 1zjrjh6hr2v4vsr9yj3vr73q1358mymi0ri1kl4cy4i54b4iwbfv
   subdir: slotting
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 52afaab4fe99df8fff1e7666e665a923118cfc53
-  --sha256: 1ldgpw37lnrgd09hhv2zxak9vc0kxbysmpsn7qd74zg3vli5z66j
+  tag: bda15b9fa712bf9063ff7312dddef6f8d70e3f8e
+  --sha256: 138sbsfyhp1wm8yhiiafqzhi6sfcpp1xkwpyd28qckj2mxf8z6n0
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 52afaab4fe99df8fff1e7666e665a923118cfc53
-  --sha256: 1ldgpw37lnrgd09hhv2zxak9vc0kxbysmpsn7qd74zg3vli5z66j
+  tag: bda15b9fa712bf9063ff7312dddef6f8d70e3f8e
+  --sha256: 138sbsfyhp1wm8yhiiafqzhi6sfcpp1xkwpyd28qckj2mxf8z6n0
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 52afaab4fe99df8fff1e7666e665a923118cfc53
-  --sha256: 1ldgpw37lnrgd09hhv2zxak9vc0kxbysmpsn7qd74zg3vli5z66j
+  tag: bda15b9fa712bf9063ff7312dddef6f8d70e3f8e
+  --sha256: 138sbsfyhp1wm8yhiiafqzhi6sfcpp1xkwpyd28qckj2mxf8z6n0
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 52afaab4fe99df8fff1e7666e665a923118cfc53
-  --sha256: 1ldgpw37lnrgd09hhv2zxak9vc0kxbysmpsn7qd74zg3vli5z66j
+  tag: bda15b9fa712bf9063ff7312dddef6f8d70e3f8e
+  --sha256: 138sbsfyhp1wm8yhiiafqzhi6sfcpp1xkwpyd28qckj2mxf8z6n0
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 52afaab4fe99df8fff1e7666e665a923118cfc53
-  --sha256: 1ldgpw37lnrgd09hhv2zxak9vc0kxbysmpsn7qd74zg3vli5z66j
+  tag: bda15b9fa712bf9063ff7312dddef6f8d70e3f8e
+  --sha256: 138sbsfyhp1wm8yhiiafqzhi6sfcpp1xkwpyd28qckj2mxf8z6n0
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 52afaab4fe99df8fff1e7666e665a923118cfc53
-  --sha256: 1ldgpw37lnrgd09hhv2zxak9vc0kxbysmpsn7qd74zg3vli5z66j
+  tag: bda15b9fa712bf9063ff7312dddef6f8d70e3f8e
+  --sha256: 138sbsfyhp1wm8yhiiafqzhi6sfcpp1xkwpyd28qckj2mxf8z6n0
   subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -176,7 +176,10 @@ protocolInfoShelley genesis protVer mbCredentials =
     tpraosParams = TPraosParams {
         tpraosEpochInfo         = epochInfo
       , tpraosSlotsPerKESPeriod = sgSlotsPerKESPeriod genesis
-      , tpraosLeaderF           = sgActiveSlotsCoeff  genesis
+      , tpraosLeaderF           = SL.mkActiveSlotCoeff
+                                . SL.truncateUnitInterval
+                                . toRational
+                                $ sgActiveSlotsCoeff  genesis
       , tpraosSecurityParam     = sgSecurityParam     genesis
       , tpraosMaxKESEvo         = sgMaxKESEvolutions  genesis
       , tpraosQuorum            = sgUpdateQuorum      genesis

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric            #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE DuplicateRecordFields    #-}
 {-# LANGUAGE NamedFieldPuns           #-}
 {-# LANGUAGE OverloadedStrings        #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
@@ -8,8 +9,10 @@
 module Ouroboros.Consensus.Shelley.Node (
     protocolInfoShelley
   , ShelleyGenesis (..)
+  , ShelleyGenesisStaking (..)
   , TPraosLeaderCredentials (..)
   , SL.ProtVer
+  , emptyGenesisStaking
   ) where
 
 import           Codec.Serialise (decode, encode)
@@ -53,10 +56,13 @@ import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.BlockChain as SL
 import qualified Shelley.Spec.Ledger.Coin as SL
 import           Shelley.Spec.Ledger.Crypto (HASH)
+import qualified Shelley.Spec.Ledger.Delegation.Certificates as SL
+import qualified Shelley.Spec.Ledger.EpochBoundary as SL
 import qualified Shelley.Spec.Ledger.Keys as SL
 import qualified Shelley.Spec.Ledger.LedgerState as SL
 import qualified Shelley.Spec.Ledger.PParams as SL
 import qualified Shelley.Spec.Ledger.STS.Chain as SL
+import qualified Shelley.Spec.Ledger.STS.NewEpoch as SL
 import qualified Shelley.Spec.Ledger.STS.Prtcl as SL
 import qualified Shelley.Spec.Ledger.TxData as SL
 import qualified Shelley.Spec.Ledger.UTxO as SL
@@ -77,6 +83,37 @@ data TPraosLeaderCredentials c = TPraosLeaderCredentials {
     --   change.
     tpraosLeaderCredentialsSignKey    :: SignKeyKES (KES c)
   , tpraosLeaderCredentialsIsCoreNode :: TPraosIsCoreNode c
+  }
+
+-- | Genesis Shelley staking configuration.
+--
+-- This allows us to configure some initial stake pools and delegation to them,
+-- in order to test Praos in a static configuration, without requiring on-chain
+-- registration and delegation.
+--
+-- For simplicity, pools defined in the genesis staking do not pay deposits for
+-- their registration.
+data ShelleyGenesisStaking c = ShelleyGenesisStaking {
+    -- | Pools to register
+    --
+    --   The key in this map is the hash of the public key of the _pool_. This
+    --   need not correspond to any payment or staking key, but must correspond
+    --   to the cold key held by 'TPraosIsCoreNode'.
+    sgsPools :: !(Map (SL.KeyHash c) (SL.PoolParams c))
+    -- | Stake-holding key hash credentials and the pools to delegate that stake
+    -- to. We require the raw staking key hash in order to:
+    --
+    -- - Avoid pointer addresses, which would be tricky when there's no slot or
+    --   transaction to point to.
+    -- - Avoid script credentials.
+  , sgsStake :: !(Map (SL.KeyHash c) (SL.KeyHash c))
+  } deriving (Eq, Show, Generic)
+
+-- | Empty genesis staking
+emptyGenesisStaking :: ShelleyGenesisStaking c
+emptyGenesisStaking = ShelleyGenesisStaking
+  { sgsPools = Map.empty
+  , sgsStake = Map.empty
   }
 
 -- | Shelley genesis information
@@ -103,6 +140,7 @@ data ShelleyGenesis c = ShelleyGenesis {
     , sgMaxHeaderSize         :: !Natural
     , sgGenDelegs             :: !(Map (SL.GenKeyHash c) (SL.KeyHash c))
     , sgInitialFunds          :: !(Map (SL.Addr c) SL.Coin)
+    , sgStaking               :: !(ShelleyGenesisStaking c)
     }
   deriving (Eq, Show, Generic)
 
@@ -198,7 +236,7 @@ protocolInfoShelley genesis protVer mbCredentials =
     initialEpochNo = 0
 
     initShelleyState :: SL.ChainState c
-    initShelleyState = SL.initialShelleyState
+    initShelleyState = registerGenesisStaking $ SL.initialShelleyState
       Origin
       initialEpochNo
       genesisUtxO
@@ -253,6 +291,68 @@ protocolInfoShelley genesis protVer mbCredentials =
             "In the beginning"
 
         magicTxIn = SL.TxIn magicTxInId 0
+
+    -- Register the initial staking.
+    --
+    -- This function embodies a little more logic than ideal. We might want to
+    -- move it into `cardano-ledger-specs.`
+    registerGenesisStaking :: SL.ChainState c -> SL.ChainState c
+    registerGenesisStaking cs@(SL.ChainState {chainNes = oldChainNes} ) = cs
+        { SL.chainNes = newChainNes }
+      where
+        ShelleyGenesisStaking { sgsPools, sgsStake } = sgStaking genesis
+        oldEpochState = SL.nesEs $ oldChainNes
+        oldLedgerState = SL.esLState oldEpochState
+        oldDPState = SL._delegationState oldLedgerState
+
+        -- Note that this is only applicable in the initial configuration where
+        -- there is no existing stake distribution, since it would completely
+        -- overwrite any such thing.
+        newPoolDistr = SL.calculatePoolDistr initSnapShot
+
+        newChainNes = oldChainNes
+          { SL.nesEs = newEpochState
+          , SL.nesPd = newPoolDistr
+          }
+        newEpochState = oldEpochState
+          { SL.esLState = newLedgerState }
+        newLedgerState = oldLedgerState
+          { SL._delegationState = newDPState }
+        newDPState = oldDPState
+          { SL._dstate = newDState
+          , SL._pstate = newPState
+          }
+        -- New delegation state. Since we're using base addresses, we only care
+        -- about updating the '_delegations' field.
+        --
+        -- See STS DELEG for details
+        newDState :: SL.DState c
+        newDState = (SL._dstate oldDPState) {
+          SL._delegations = Map.mapKeys SL.KeyHashObj sgsStake
+        }
+
+        -- We consider pools as having been registered in slot 0
+        -- See STS POOL for details
+        newPState :: SL.PState c
+        newPState = (SL._pstate oldDPState) {
+          SL._stPools = SL.StakePools $ Map.map (const $ SlotNo 0) $ sgsPools
+        , SL._pParams = sgsPools
+        }
+
+        -- The new stake distribution is made on the basis of a snapshot taken
+        -- during the previous epoch. We create a "fake" snapshot in order to
+        -- establish an initial stake distribution.
+        initSnapShot = SL.SnapShot
+          { SL._stake = SL.Stake . Map.mapKeys addrKeyHash $ sgInitialFunds genesis
+          , SL._delegations = Map.mapKeys SL.KeyHashObj sgsStake
+          , SL._poolParams = sgsPools
+          }
+          where
+            addrKeyHash (SL.AddrBootstrap kh) = SL.KeyHashObj kh
+            addrKeyHash (SL.Addr _ sr) = case sr of
+              SL.StakeRefBase kh -> kh
+              _ -> error "Pointer stake addresses not allowed in initial snapshot"
+
 
 {-------------------------------------------------------------------------------
   RunNode instance

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -228,12 +228,7 @@ protocolInfoShelley genesis protVer mbCredentials =
 
     pparams :: SL.PParams
     pparams = SL.emptyPParams {
-        SL._activeSlotCoeff =
-            SL.mkActiveSlotCoeff
-          . SL.truncateUnitInterval
-          . realToFrac
-          $ sgActiveSlotsCoeff genesis
-      , SL._d =
+        SL._d =
             SL.truncateUnitInterval
           . realToFrac
           $ sgDecentralisationParam genesis

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -415,6 +415,7 @@ mkShelleyGlobals TPraosParams {..} = SL.Globals {
     , quorum            = tpraosQuorum
     , maxMajorPV        = tpraosMaxMajorPV
     , maxLovelaceSupply = tpraosMaxLovelaceSupply
+    , activeSlotCoeff   = tpraosLeaderF
     }
   where
     SecurityParam k = tpraosSecurityParam

--- a/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger.hs
+++ b/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger.hs
@@ -22,7 +22,7 @@ import           Data.Proxy (Proxy (..))
 import           Data.Ratio ((%))
 import           Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
-import           Data.Word (Word64)
+import           Data.Word (Word64, Word8)
 import           Numeric.Natural (Natural)
 
 import           Cardano.Binary (Annotator (..), FullByteString (..), fromCBOR,
@@ -506,7 +506,7 @@ instance Crypto c => Arbitrary (SL.Stake c) where
   arbitrary = SL.Stake <$> arbitrary
 
 instance Arbitrary SL.Url where
-  arbitrary = return $ SL.Url $ SL.text64 "text"
+  arbitrary = return $ SL.mkUrl "text"
 
 instance Arbitrary a => Arbitrary (StrictSeq a) where
   arbitrary = StrictSeq.toStrict <$> arbitrary
@@ -514,6 +514,22 @@ instance Arbitrary a => Arbitrary (StrictSeq a) where
 
 instance Arbitrary SL.PoolMetaData where
   arbitrary = (`SL.PoolMetaData` "bytestring") <$> arbitrary
+
+instance Arbitrary SL.Port where
+  arbitrary = fromIntegral @Word8 @SL.Port <$> arbitrary
+
+instance Arbitrary SL.IPv4 where
+  arbitrary = SL.mkIPv4 <$> arbitrary
+
+instance Arbitrary SL.IPv6 where
+  arbitrary = SL.mkIPv6 <$> arbitrary
+
+instance Arbitrary SL.DnsName where
+  arbitrary = pure $ SL.mkDnsName "foo.example.com"
+
+instance Arbitrary SL.StakePoolRelay where
+  arbitrary = genericArbitraryU
+  shrink    = genericShrink
 
 instance Crypto c => Arbitrary (SL.PoolParams c) where
   arbitrary = SL.PoolParams

--- a/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
+++ b/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
@@ -181,7 +181,6 @@ testResults = testGroup "Results"
         , _a0              = SNothing
         , _rho             = SNothing
         , _tau             = SNothing
-        , _activeSlotCoeff = SNothing
         , _d               = SNothing
         , _extraEntropy    = SNothing
         , _protocolVersion = SNothing
@@ -220,10 +219,6 @@ testResults = testGroup "Results"
       , TkInt 1
       , TkInt 0
       , TkInt 100
-      , TkTag 30
-      , TkListLen 2
-      , TkInt 0
-      , TkInt 1
       , TkTag 30
       , TkListLen 2
       , TkInt 0
@@ -284,7 +279,7 @@ test_golden_Block = goldenTestCBOR
     , TkListLen 15
     , TkInt 2
     , TkInt 20
-    , TkBytes "\143\170\SUB\179"
+    , TkBytes "C\166{\152"
     , TkInt 1677861428
     , TkInt 1239952560
     , TkListLen 2
@@ -298,7 +293,7 @@ test_golden_Block = goldenTestCBOR
     , TkInt 1239952560
     , TkInteger 132220243341478360044794887852609007894
     , TkInt 192
-    , TkBytes "\236a\DC3-"
+    , TkBytes "\134\198\226\SOH"
     , TkInt 42768536
     , TkInt 0
     , TkInt 0
@@ -308,7 +303,7 @@ test_golden_Block = goldenTestCBOR
     , TkInt 0
     , TkInt 0
     , TkListLen 2
-    , TkInteger 119070125142606865931133057462608271957
+    , TkInteger 323122327138243464417254254528169710042
     , TkListLen 3
     , TkInt 42768536
     , TkInt 1
@@ -318,7 +313,7 @@ test_golden_Block = goldenTestCBOR
     , TkInt 0
     , TkListBegin
     , TkListLen 2
-    , TkBytes ")\175\130\SYN"
+    , TkBytes "\227\RS\202y"
     , TkInt 0
     , TkBreak
     , TkInt 1
@@ -339,7 +334,7 @@ test_golden_Block = goldenTestCBOR
     , TkMapLen 2
     , TkInt 8
     , TkInt 200
-    , TkInt 18
+    , TkInt 17
     , TkListLen 2
     , TkInt 1
     , TkBytes "e\138\176\224\245\253\239\216h\168\232\ENQ\209\SOH\169\140\195Z\181\ETB\233}\243\147q\130\218\fz\243\139="
@@ -347,7 +342,7 @@ test_golden_Block = goldenTestCBOR
     , TkMapLen 2
     , TkInt 8
     , TkInt 200
-    , TkInt 18
+    , TkInt 17
     , TkListLen 2
     , TkInt 1
     , TkBytes "e\138\176\224\245\253\239\216h\168\232\ENQ\209\SOH\169\140\195Z\181\ETB\233}\243\147q\130\218\fz\243\139="
@@ -359,17 +354,17 @@ test_golden_Block = goldenTestCBOR
     , TkListLen 2
     , TkInt 1677861428
     , TkListLen 2
-    , TkBytes "\160b\153\145"
+    , TkBytes "\240\181\194\134"
     , TkInt 1677861428
     , TkListLen 2
     , TkInt 302809592
     , TkListLen 2
-    , TkBytes "\160b\153\145"
+    , TkBytes "\240\181\194\134"
     , TkInt 302809592
     , TkListLen 2
     , TkInt 1733510303
     , TkListLen 2
-    , TkBytes "\160b\153\145"
+    , TkBytes "\240\181\194\134"
     , TkInt 1733510303
     , TkMapLen 0
     ]
@@ -382,7 +377,7 @@ test_golden_Header = goldenTestCBOR
     , TkListLen 15
     , TkInt 2
     , TkInt 20
-    , TkBytes "\143\170\SUB\179"
+    , TkBytes "C\166{\152"
     , TkInt 1677861428
     , TkInt 1239952560
     , TkListLen 2
@@ -396,7 +391,7 @@ test_golden_Header = goldenTestCBOR
     , TkInt 1239952560
     , TkInteger 132220243341478360044794887852609007894
     , TkInt 192
-    , TkBytes "\236a\DC3-"
+    , TkBytes "\134\198\226\SOH"
     , TkInt 42768536
     , TkInt 0
     , TkInt 0
@@ -406,7 +401,7 @@ test_golden_Header = goldenTestCBOR
     , TkInt 0
     , TkInt 0
     , TkListLen 2
-    , TkInteger 119070125142606865931133057462608271957
+    , TkInteger 323122327138243464417254254528169710042
     , TkListLen 3
     , TkInt 42768536
     , TkInt 1
@@ -417,7 +412,7 @@ test_golden_HeaderHash :: Assertion
 test_golden_HeaderHash = goldenTestCBOR
     toCBOR
     (blockHash exampleBlock)
-    [ TkBytes "\205\151\216\183"
+    [ TkBytes "\160Ar\206"
     ]
 
 test_golden_GenTx :: Assertion
@@ -870,10 +865,6 @@ test_golden_LedgerState = goldenTestCBOR
     , TkInt 5
     , TkTag 30
     , TkListLen 2
-    , TkInt 9
-    , TkInt 10
-    , TkTag 30
-    , TkListLen 2
     , TkInt 1
     , TkInt 2
     , TkListLen 1
@@ -918,10 +909,6 @@ test_golden_LedgerState = goldenTestCBOR
     , TkListLen 2
     , TkInt 1
     , TkInt 5
-    , TkTag 30
-    , TkListLen 2
-    , TkInt 9
-    , TkInt 10
     , TkTag 30
     , TkListLen 2
     , TkInt 1
@@ -1286,10 +1273,6 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkInt 5
     , TkTag 30
     , TkListLen 2
-    , TkInt 9
-    , TkInt 10
-    , TkTag 30
-    , TkListLen 2
     , TkInt 1
     , TkInt 2
     , TkListLen 1
@@ -1334,10 +1317,6 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkListLen 2
     , TkInt 1
     , TkInt 5
-    , TkTag 30
-    , TkListLen 2
-    , TkInt 9
-    , TkInt 10
     , TkTag 30
     , TkListLen 2
     , TkInt 1

--- a/ouroboros-consensus-shelley/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley/test/Test/ThreadNet/RealTPraos.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE NamedFieldPuns           #-}
 {-# LANGUAGE PatternSynonyms          #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE TypeApplications         #-}
 {-# LANGUAGE TypeFamilies             #-}
 module Test.ThreadNet.RealTPraos (
     tests
@@ -13,6 +14,8 @@ import           Control.Monad (replicateM)
 import           Data.List ((!!))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import qualified Data.Sequence.Strict as Seq
+import qualified Data.Set as Set
 import           Data.Time (Day (..), UTCTime (..))
 import           Data.Word (Word64)
 
@@ -45,6 +48,7 @@ import           Test.ThreadNet.Util.NodeTopology
 
 import           Test.Util.Orphans.Arbitrary ()
 
+import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.Coin as SL
 import qualified Shelley.Spec.Ledger.Crypto as SL
 import qualified Shelley.Spec.Ledger.Keys as SL
@@ -228,7 +232,7 @@ mkGenesisConfig k maxKESEvolutions coreNodes = ShelleyGenesis {
     , sgNetworkMagic          = NetworkMagic 0
     , sgProtocolMagicId       = ProtocolMagicId 0
     , sgActiveSlotsCoeff      = 0.5 -- TODO 1 is not accepted by 'mkActiveSlotCoeff'
-    , sgDecentralisationParam = 1
+    , sgDecentralisationParam = 0
     , sgSecurityParam         = k
     , sgEpochLength           = EpochSize (10 * maxRollbacks k)
     , sgSlotsPerKESPeriod     = 10 -- TODO
@@ -241,6 +245,7 @@ mkGenesisConfig k maxKESEvolutions coreNodes = ShelleyGenesis {
     , sgMaxHeaderSize         = 1000 -- TODO
     , sgGenDelegs             = coreNodesToGenesisMapping
     , sgInitialFunds          = initialFunds
+    , sgStaking               = initialStake
     }
   where
     initialLovelacePerCoreNode :: Word64
@@ -267,6 +272,39 @@ mkGenesisConfig k maxKESEvolutions coreNodes = ShelleyGenesis {
                            (SL.StakeRefBase (mkCredential cnStakingKey))
             coin = SL.Coin $ fromIntegral initialLovelacePerCoreNode
       ]
+
+    -- In this initial stake, each core node delegates its stake to itself.
+    initialStake :: ShelleyGenesisStaking c
+    initialStake = ShelleyGenesisStaking
+      { sgsPools = Map.fromList
+          [ (pk, pp)
+          | pp@(SL.PoolParams { _poolPubKey = pk }) <- Map.elems coreNodeToPoolMapping
+          ]
+      , sgsStake = Map.map SL._poolPubKey coreNodeToPoolMapping
+      }
+      where
+        coreNodeToPoolMapping :: Map (SL.KeyHash c) (SL.PoolParams c)
+          = Map.fromList
+            [ ( SL.KeyHash $ SL.hash $ deriveVerKeyDSIGN cnStakingKey
+              , SL.PoolParams
+                { SL._poolPubKey = poolHash
+                , SL._poolVrf = vrfHash
+                  -- Each core node pledges its full stake to the pool.
+                , SL._poolPledge = SL.Coin $ fromIntegral initialLovelacePerCoreNode
+                , SL._poolCost = SL.Coin 1
+                , SL._poolMargin = SL.UnsafeUnitInterval 0
+                  -- Reward accounts live in a separate "namespace" to other
+                  -- accounts, so it should be fine to use the same address.
+                , SL._poolRAcnt = SL.RewardAcnt $ mkCredential cnDelegateKey
+                , SL._poolOwners = Set.singleton poolHash
+                , SL._poolRelays = Seq.empty
+                , SL._poolMD = SL.SNothing
+                }
+              )
+            | CoreNode { cnDelegateKey, cnStakingKey, cnVRF } <- coreNodes
+            , let poolHash = SL.hashKey . SL.VKey $ deriveVerKeyDSIGN cnDelegateKey
+            , let vrfHash = SL.hashKeyVRF @c $ deriveVerKeyVRF cnVRF
+            ]
 
     mkCredential :: SignKeyDSIGN (DSIGN c) -> SL.Credential c
     mkCredential = SL.KeyHashObj . SL.hashKey . SL.VKey . deriveVerKeyDSIGN

--- a/release.nix
+++ b/release.nix
@@ -8,12 +8,12 @@
 ############################################################################
 
 # The project sources
-{ ouroroboros-network ? { outPath = ./.; rev = "abcdef"; }
+{ ouroboros-network ? { outPath = ./.; rev = "abcdef"; }
 
 # Function arguments to pass to the project
 , projectArgs ? {
     config = { allowUnfree = false; inHydra = true; };
-    gitrev = ouroroboros-network.rev;
+    gitrev = ouroboros-network.rev;
   }
 
 # The systems that the jobset will be built for.
@@ -38,8 +38,8 @@
 with (import pkgs.iohkNix.release-lib) {
   inherit pkgs;
   inherit supportedSystems supportedCrossSystems scrubJobs projectArgs;
-  packageSet = import ouroroboros-network;
-  gitrev = ouroroboros-network.rev;
+  packageSet = import ouroboros-network;
+  gitrev = ouroboros-network.rev;
 };
 
 with pkgs.lib;

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,12 +36,12 @@ flags:
 
 extra-deps:
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: cda172dac4428058ebcb832673f379c9f92d411e
+    commit: 0aae419140b50e93154c146ec9cbea9d3c7ac9ba
     subdirs:
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 5035c9ed95e9d47f050314a7d96b1b2043288f61
+    commit: 2cc27584bb19bd5be9f1721fd4a2393bb99c6119
     subdirs:
       - binary
       - binary/test
@@ -49,7 +49,7 @@ extra-deps:
       - slotting
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 52afaab4fe99df8fff1e7666e665a923118cfc53
+    commit: bda15b9fa712bf9063ff7312dddef6f8d70e3f8e
     subdirs:
       - byron/chain/executable-spec
       - byron/ledger/executable-spec


### PR DESCRIPTION
This PR sets up testing of the Shelley/TPraos protocol in decentralised mode, where blocks are produced by stake pool operators rather than genesis delegates.

It can be reviewed commit by commit.

- We firstly bump the dependency on cardano-ledger-specs, which is needed to expose a couple of utilities and pick up some bug fixes. This also addresses some unrelated changes needed due to other updates, and could be a PR by itself if desired.
- The second commit adds the ability to specify an initial staking configuration in Shelley genesis, which means we can test stake pools without needing to establish them with on chain transactions.
- The third commit updates the tests to generate this initial stake in a testing configuration.
- The fourth commit changes the TPraos implementation to use the same VRF calculations as in the ledger.
- The fifth commit expands the scope of our testing to include full decentralised mode.