### PR TITLE
Shelley: check thunks for GenTx

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE DerivingVia                #-}
@@ -23,8 +24,8 @@ import           Data.Foldable (toList)
 import qualified Data.Sequence as Seq
 import           GHC.Generics (Generic)
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..),
-                     FullByteString (..), Annotator (..))
+import           Cardano.Binary (Annotator (..), FromCBOR (..),
+                     FullByteString (..), ToCBOR (..))
 import           Cardano.Prelude (NoUnexpectedThunks (..), UseIsNormalForm (..))
 
 import           Ouroboros.Network.Block (unwrapCBORinCBOR, wrapCBORinCBOR)
@@ -49,9 +50,8 @@ type ShelleyTxId c = SL.TxId c
 instance TPraosCrypto c => ApplyTx (ShelleyBlock c) where
 
   data GenTx (ShelleyBlock c) = ShelleyTx !(ShelleyTxId c) !(SL.Tx c)
-    deriving (Eq, Generic)
-    -- TODO
-    deriving (NoUnexpectedThunks) via UseIsNormalForm (GenTx (ShelleyBlock c))
+    deriving stock    (Eq, Generic)
+    deriving anyclass (NoUnexpectedThunks)
 
   type ApplyTxErr (ShelleyBlock c) = SL.ApplyTxError c
 


### PR DESCRIPTION
And it passes the tests with `+checktvarinvariant` enabled.