### PR TITLE
Make it possible to run effects in additional places in mini-protocols.

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -683,7 +683,7 @@ chainSyncClient mkPipelineDecision0 tracer cfg
               (requestNext kis mkPipelineDecision' (Succ n) theirTip candTipBlockNo)
           (Succ n', (CollectOrPipeline, mkPipelineDecision')) ->
             CollectResponse
-              (Just $ SendMsgRequestNextPipelined $
+              (Just $ pure $ SendMsgRequestNextPipelined $
                 requestNext kis mkPipelineDecision' (Succ n) theirTip candTipBlockNo)
               (handleNext kis mkPipelineDecision' n')
           (Succ n', (Collect, mkPipelineDecision')) ->

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
@@ -102,7 +102,7 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
             -- do not directly loop here, but send something; otherwise we
             -- would just build a busy loop polling the driver's receiving
             -- queue.
-            (Just $ SendMsgRequestNextPipelined $ go mkPipelineDecision' (Succ n) cliTipBlockNo srvTip client)
+            (Just $ pure $ SendMsgRequestNextPipelined $ go mkPipelineDecision' (Succ n) cliTipBlockNo srvTip client)
             ClientStNext {
                 recvMsgRollForward = \srvHeader srvTip' -> do
                   addBlock srvHeader

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Direct.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Direct.hs
@@ -33,9 +33,9 @@ direct (LocalStateQueryClient mclient) (LocalStateQueryServer mserver) = do
       :: ClientStAcquiring block query m a
       -> ServerStAcquiring block query m b
       -> m (a, b)
-    directAcquiring ClientStAcquiring{recvMsgAcquired} (SendMsgAcquired server') =
-      let client' = recvMsgAcquired
-      in directAcquired client' server'
+    directAcquiring ClientStAcquiring{recvMsgAcquired} (SendMsgAcquired server') = do
+      client' <- recvMsgAcquired
+      directAcquired client' server'
     directAcquiring ClientStAcquiring{recvMsgFailure} (SendMsgFailure failure server') = do
       client' <- recvMsgFailure failure
       directIdle client' server'

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/ClientPipelined.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/ClientPipelined.hs
@@ -65,9 +65,9 @@ data ClientPipelinedStIdle n header tip  m a where
       -> ClientPipelinedStIdle      Z header tip m a
 
     CollectResponse
-      :: Maybe (ClientPipelinedStIdle (S n) header tip m a)
-      -> ClientStNext                    n  header tip m a
-      -> ClientPipelinedStIdle        (S n) header tip m a
+      :: Maybe (m (ClientPipelinedStIdle (S n) header tip m a))
+      -> ClientStNext                       n  header tip m a
+      -> ClientPipelinedStIdle           (S n) header tip m a
 
     SendMsgDone
       :: a
@@ -240,7 +240,7 @@ chainSyncClientPeerSender n@(Succ n')
                               }) =
 
     SenderCollect
-      (chainSyncClientPeerSender n <$> mStIdle)
+      (SenderEffect . fmap (chainSyncClientPeerSender n) <$> mStIdle)
       (\instr -> SenderEffect $ chainSyncClientPeerSender n' <$> collect instr)
     where
       collect (RollForward header point) =

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
@@ -60,7 +60,7 @@ data ClientStIdle block query (m :: Type -> Type) a where
 -- It must be prepared to handle either.
 --
 data ClientStAcquiring block query m a = ClientStAcquiring {
-      recvMsgAcquired :: ClientStAcquired block query m a,
+      recvMsgAcquired :: m (ClientStAcquired block query m a),
 
       recvMsgFailure  :: AcquireFailure
                       -> m (ClientStIdle  block query m a)
@@ -122,7 +122,7 @@ localStateQueryClientPeer (LocalStateQueryClient handler) =
       -> Peer (LocalStateQuery block query) AsClient StAcquiring m a
     handleStAcquiring ClientStAcquiring{recvMsgAcquired, recvMsgFailure} =
       Await (ServerAgency TokAcquiring) $ \req -> case req of
-        MsgAcquired        -> handleStAcquired recvMsgAcquired
+        MsgAcquired        -> Effect $ handleStAcquired <$> recvMsgAcquired
         MsgFailure failure -> Effect $ handleStIdle <$> recvMsgFailure failure
 
     handleStAcquired

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Examples.hs
@@ -42,7 +42,7 @@ localStateQueryClient = LocalStateQueryClient . pure . goIdle []
       -> ClientStAcquiring block query m
                            [(Point block, Either AcquireFailure result)]
     goAcquiring acc pt q ptqss' = ClientStAcquiring {
-        recvMsgAcquired = goQuery q $ \r -> goAcquired ((pt, Right r):acc) ptqss'
+        recvMsgAcquired = pure $ goQuery q $ \r -> goAcquired ((pt, Right r):acc) ptqss'
       , recvMsgFailure  = \failure -> pure $ goIdle ((pt, Left failure):acc) ptqss'
       }
 


### PR DESCRIPTION
A typical client would here want to be able to run extra computation in order to carry on and do whatever it needs to do to collect or constuct the next request to send. Being restricted to only pure computation here makes it fairly hard to pipelined another request unless the request can be constructed out of thin air or, has already been collected and buffered upfront.
    
Similarly, when acquiring a point on the chain, being able to run an extra effect while acquiring can be pretty useful.