### PR TITLE
Remove `Init` phase from `TestBlockchainTime`

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Time.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Time.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass      #-}
-{-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -24,10 +22,8 @@ module Test.Util.Time (
 
 import           Control.Monad
 import           Data.Word
-import           GHC.Generics (Generic)
 import           GHC.Stack
 
-import           Cardano.Prelude (NoUnexpectedThunks)
 import           Cardano.Slotting.Slot
 
 import           Ouroboros.Consensus.BlockchainTime
@@ -64,13 +60,6 @@ data TestBlockchainTime m = TestBlockchainTime
 newtype NumSlots = NumSlots Word64
   deriving (Show)
 
--- | The current time during a test run.
-data TestClock =
-    Initializing
-    -- ^ This phase has a non-zero but negligible duration.
-  | Running !SlotNo
-  deriving (Eq, Generic, NoUnexpectedThunks)
-
 -- | Construct new blockchain time that ticks at the specified slot duration
 --
 -- NOTE: This is just one way to construct time. We can of course also connect
@@ -91,42 +80,33 @@ newTestBlockchainTime
     -> SlotLength         -- ^ Slot duration
     -> m (TestBlockchainTime m)
 newTestBlockchainTime registry (NumSlots numSlots) slotLen = do
-    slotVar <- newTVarM Initializing
+    slotVar <- newTVarM (SlotNo 0)
     doneVar <- newEmptyMVar ()
 
     void $ forkLinkedThread registry "TestBlockchainTime" $ loop slotVar doneVar
 
     return $ clone slotVar doneVar
   where
-    loop :: StrictTVar m TestClock -> StrictMVar m () -> m ()
+    loop :: StrictTVar m SlotNo -> StrictMVar m () -> m ()
     loop slotVar doneVar = go numSlots
       where
         -- count off each requested slot
         go :: Word64 -> m ()
         go 0 = putMVar doneVar () -- signal the end of the final slot
         go n = do
-            atomically $ modifyTVar slotVar $ Running . \case
-              Initializing -> SlotNo 0
-              Running slot -> succ slot
             threadDelay (nominalDelay (getSlotLength slotLen))
+            atomically $ modifyTVar slotVar $ succ
             go (n - 1)
 
     clone
-      :: StrictTVar m TestClock
+      :: StrictTVar m SlotNo
       -> StrictMVar m ()
       -> TestBlockchainTime m
     clone slotVar doneVar =
         TestBlockchainTime
-          { testBlockchainTimeSlot = get
+          { testBlockchainTimeSlot = readTVar slotVar
           , testBlockchainTimeDone = readMVar doneVar
           }
-      where
-        get :: STM m SlotNo
-        get = blockUntilJust $
-                (\case
-                    Initializing -> Nothing
-                    Running slot -> Just slot)
-            <$> readTVar slotVar
 
 {-------------------------------------------------------------------------------
   Alternative constructors

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/API.hs
@@ -63,8 +63,6 @@ onKnownSlotChange registry BlockchainTime{getCurrentSlot} label =
 -------------------------------------------------------------------------------}
 
 -- | The current slot can be changed by modifying the given 'StrictTVar'.
---
--- 'onSlotChange_' is not implemented and will return an 'error'.
 settableBlockchainTime :: MonadSTM m => StrictTVar m SlotNo -> BlockchainTime m
 settableBlockchainTime varCurSlot = BlockchainTime {
       getCurrentSlot = readTVar varCurSlot


### PR DESCRIPTION
I was hoping that this simplification would be possible. @nfrisby  explained that the _need_ for it arose from the fact that handlers to `onSlotChange` etc. we not called on the initial slot. That isn't the
case anymore, since we don't provide an initial value in `onSlotChange` (passing `Nothing`) so the action will in fact be called immediately. Unfortunately, the tests are failing, I'm not entirely sure why.

Fixing this will then make it easier to take steps towards a notion of time in the tests that is not slot based.