### PR TITLE
Initialise the initial UTxO correctly.

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -279,12 +279,14 @@ protocolInfoShelley genesis protVer mbCredentials =
 
     genesisUtxO :: SL.UTxO c
     genesisUtxO = SL.UTxO $ Map.fromList
-        [ (magicTxIn, txOut)
-        | (addr, amount) <- Map.toList (sgInitialFunds genesis)
+        [ (magicTxIn idx, txOut)
+        | ((addr, amount), idx) <- Map.toList (sgInitialFunds genesis) `zip` [0 ..]
         , let txOut = SL.TxOut addr amount
         ]
       where
-        -- TODO
+        -- Note that the ID for this transaction is completely arbitrary; the
+        -- initial UTxO is magical not due to its ID, but due to being included
+        -- in the initial ledger state.
         magicTxInId =
             SL.TxId
           . coerce
@@ -293,7 +295,7 @@ protocolInfoShelley genesis protVer mbCredentials =
             @ByteString
             "In the beginning"
 
-        magicTxIn = SL.TxIn magicTxInId 0
+        magicTxIn = SL.TxIn magicTxInId
 
     -- Register the initial staking.
     --


### PR DESCRIPTION
UTxO is implemented as a map. Previously the keys were duplicates and,
as such, there was only one entry.

Addresses #2004 