### PR TITLE
Use correct slot length

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -107,8 +107,21 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params mLeader =
 
     -- 'Spec.Test.abEnvToCfg' ignores the UTxO, because the Byron genesis
     -- data doesn't contain a UTxO, but only a 'UTxOConfiguration'.
+    --
+    -- It also ignores the slot length (the Byron spec does not talk about
+    -- slot lengths at all) so we have to set this ourselves.
     concreteGenesis :: Impl.Config
-    concreteGenesis = Spec.Test.abEnvToCfg $ Genesis.toChainEnv abstractGenesis
+    concreteGenesis = translated {
+          Impl.configGenesisData = configGenesisData {
+              Impl.gdProtocolParameters = protocolParameters {
+                   Impl.ppSlotDuration = byronSpecGenesisSlotLength
+                }
+            }
+        }
+      where
+        translated = Spec.Test.abEnvToCfg $ Genesis.toChainEnv abstractGenesis
+        configGenesisData  = Impl.configGenesisData translated
+        protocolParameters = Impl.gdProtocolParameters configGenesisData
 
     initAbstractState :: LedgerState ByronSpecBlock
     initConcreteState :: LedgerState ByronBlock

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
@@ -9,6 +9,7 @@ module Ouroboros.Consensus.Byron.Ledger.Conversions (
     -- * From @ouroboros-consensus@ to @cardano-ledger@
   , toByronSlotNo
   , toByronBlockCount
+  , toByronSlotLength
     -- * Extract info from the genesis config
   , genesisSecurityParam
   , genesisNumCoreNodes
@@ -69,6 +70,10 @@ toByronSlotNo = coerce
 
 toByronBlockCount :: SecurityParam -> CC.BlockCount
 toByronBlockCount (SecurityParam k) = CC.BlockCount k
+
+toByronSlotLength :: SlotLength -> Natural
+toByronSlotLength = (fromIntegral :: Integer -> Natural)
+                  . slotLengthToMillisec
 
 {-------------------------------------------------------------------------------
   Extract info from genesis

--- a/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron/test/Test/ThreadNet/RealPBFT.hs
@@ -592,7 +592,7 @@ tests = testGroup "RealPBFT" $
     ]
   where
     defaultSlotLength :: SlotLength
-    defaultSlotLength = SlotLength 1
+    defaultSlotLength = slotLengthFromSec 1
 
 prop_deterministicPlan :: PBftParams -> NumSlots -> NumCoreNodes -> Property
 prop_deterministicPlan params numSlots numCoreNodes =

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Genesis.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Genesis.hs
@@ -22,6 +22,7 @@ module Ouroboros.Consensus.ByronSpec.Ledger.Genesis (
 
 import           Data.Coerce (coerce)
 import           Data.Set (Set)
+import           Numeric.Natural (Natural)
 
 import           Cardano.Prelude (AllowThunk (..), NoUnexpectedThunks)
 
@@ -43,6 +44,14 @@ data ByronSpecGenesis = ByronSpecGenesis {
     , byronSpecGenesisInitUtxo      :: Spec.UTxO
     , byronSpecGenesisInitPParams   :: Spec.PParams
     , byronSpecGenesisSecurityParam :: Spec.BlockCount
+
+      -- | Slot length
+      --
+      -- The Byron spec itself does not talk about slot length at all. Here we
+      -- record it primarily to support the relation between the spec and the
+      -- real implementation. For this reason we choose the same representation
+      -- as the real PBFT does ('ppSlotDuration' in 'ProtocolParameters').
+    , byronSpecGenesisSlotLength    :: Natural
     }
   deriving stock (Show)
   deriving NoUnexpectedThunks via AllowThunk ByronSpecGenesis
@@ -148,8 +157,9 @@ toChainEnv ByronSpecGenesis{..} = disableConsensusChecks (
 -- a concept of a genesis config, and instead the CHAIN environment fulfills
 -- that role. In order to be able to reuse the test generators, we therefore
 -- also define a translation in the opposite direction.
-fromChainEnv :: Spec.Environment Spec.CHAIN -> ByronSpecGenesis
-fromChainEnv ( _currentSlot
+fromChainEnv :: Natural -> Spec.Environment Spec.CHAIN -> ByronSpecGenesis
+fromChainEnv byronSpecGenesisSlotLength
+             ( _currentSlot
              , byronSpecGenesisInitUtxo
              , byronSpecGenesisDelegators
              , byronSpecGenesisInitPParams

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -73,7 +73,7 @@ prop_simple_pbft_convergence :: SecurityParam
                              -> TestConfig
                              -> Property
 prop_simple_pbft_convergence
-  k testConfig@TestConfig{numCoreNodes, numSlots, nodeJoinPlan} =
+  k testConfig@TestConfig{numCoreNodes, numSlots, nodeJoinPlan, slotLength} =
     tabulate "Ref.PBFT result" [Ref.resultConstrName refResult] $
     prop_asSimulated .&&.
     prop_general PropGeneralArgs
@@ -103,7 +103,7 @@ prop_simple_pbft_convergence
             , nodeInfo    = plainTestNodeInitialization .
                             protocolInfoMockPBFT
                               params
-                              (defaultSimpleBlockConfig k pbftSlotLength)
+                              (defaultSimpleBlockConfig k slotLength)
             , rekeying    = Nothing
             , txGenExtra  = ()
             }
@@ -149,9 +149,6 @@ prop_simple_pbft_convergence
             foldChain snoc id nodeOutputFinalChain [] :: [SlotNo]
           where
             snoc acc blk = acc . (blockSlot blk :)
-
-pbftSlotLength :: SlotLength
-pbftSlotLength = slotLengthFromSec 20
 
 type Blk = SimpleBlock SimpleMockCrypto
              (SimplePBftExt SimpleMockCrypto PBftMockCrypto)

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -80,6 +80,7 @@ import           Ouroboros.Consensus.MiniProtocol.ChainSync.Client
                      (ClockSkew (..))
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
+import           Ouroboros.Consensus.Node.LedgerDerivedInfo
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
@@ -768,6 +769,12 @@ runThreadNetwork ThreadNetworkArgs
                   txSubmissionMaxUnacked      = 1000 -- TODO ?
                 }
             }
+
+      unless (knownSlotLength (configBlock pInfoConfig) == slotLength) $
+        error $ "Inconsistent slot lengths: "
+             ++ show (knownSlotLength (configBlock pInfoConfig))
+             ++ " /= "
+             ++ show slotLength
 
       nodeKernel <- initNodeKernel nodeArgs
       let mempool = getMempool nodeKernel

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/Arbitrary.hs
@@ -65,7 +65,9 @@ instance Arbitrary SlotLength where
 
   -- Try to shrink the slot length to just "1", for tests where the slot length
   -- really doesn't matter very much
-  shrink (SlotLength n) = if n /= 1 then [SlotLength 1] else []
+  shrink slotLen = if slotLen /= oneSec then [oneSec] else []
+    where
+      oneSec = slotLengthFromSec 1
 
 deriving via UTCTime         instance Arbitrary SystemStart
 deriving via Positive Word64 instance Arbitrary SlotNo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock.hs
@@ -8,7 +8,9 @@ module Ouroboros.Consensus.BlockchainTime.WallClock (
     -- * System start
     SystemStart(..)
     -- * Slot length
-  , SlotLength(..)
+  , SlotLength -- Opaque
+  , getSlotLength
+  , mkSlotLength
     -- ** Conversions
   , slotLengthFromSec
   , slotLengthToSec
@@ -47,6 +49,10 @@ newtype SystemStart = SystemStart { getSystemStart :: UTCTime }
 newtype SlotLength = SlotLength { getSlotLength :: NominalDiffTime }
   deriving (Show, Eq, Generic, NoUnexpectedThunks)
 
+-- | Constructor for 'SlotLength'
+mkSlotLength :: NominalDiffTime -> SlotLength
+mkSlotLength = SlotLength
+
 slotLengthFromSec :: Integer -> SlotLength
 slotLengthFromSec = slotLengthFromMillisec . (* 1000)
 
@@ -54,7 +60,7 @@ slotLengthToSec :: SlotLength -> Integer
 slotLengthToSec = (`div` 1000) . slotLengthToMillisec
 
 slotLengthFromMillisec :: Integer -> SlotLength
-slotLengthFromMillisec = SlotLength . conv
+slotLengthFromMillisec = mkSlotLength . conv
   where
     -- Explicit type annotation here means that /if/ we change the precision,
     -- we are forced to reconsider this code.

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
@@ -66,7 +66,7 @@ data TestDelayIO = TestDelayIO {
 instance Arbitrary TestDelayIO where
   arbitrary = do
       tdioStart'  <- arbitrary
-      tdioSlotLen <- slotLengthFromMillisec <$> choose (1, 1_000)
+      tdioSlotLen <- slotLengthFromMillisec <$> choose (100, 1_000)
       return TestDelayIO{..}
 
 -- | Just as a sanity check, also run the tests in IO
@@ -230,7 +230,7 @@ prop_delayClockShift schedule =
 
     testResult :: Either Failure [SlotNo]
     testResult = overrideDelay dawnOfTime schedule $
-        testOverrideDelay (SystemStart dawnOfTime) (SlotLength 1) numSlots
+        testOverrideDelay (SystemStart dawnOfTime) (slotLengthFromSec 1) numSlots
 
     checkException :: SlotNo -> SlotNo -> SomeException -> Property
     checkException before after e
@@ -252,7 +252,7 @@ prop_delayNoClockShift =
     withMaxSuccess 1 $ ioProperty $ do
       now   <- getCurrentTime
       slots <- originalDelay $
-                 testOverrideDelay (SystemStart now) (SlotLength 0.1) 5
+                 testOverrideDelay (SystemStart now) (slotLengthFromMillisec 100) 5
       assertEqual "slots" slots [SlotNo n | n <- [0..4]]
 
 testOverrideDelay :: forall m. (IOLike m, MonadDelay (OverrideDelay m))


### PR DESCRIPTION
The mock PBFT, real PBFT and dual PBFT were all setting the slot length independently from the slot length in the `TestConfig`, so that we were working with two inconsistent values. This didn't matter when we were working with a fake clock that was `SlotNo` based, but it is causing test failures in the hard fork blockchain time branch. (It is also just incorrect, of course.)
