### PR TITLE
Refactor netowrk-mux.cabal file

### DIFF
--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -73,23 +73,9 @@ library
 
 test-suite test-network-mux
   type:                exitcode-stdio-1.0
-  hs-source-dirs:      test src
+  hs-source-dirs:      test
   main-is:             Main.hs
-  other-modules:       Network.Mux
-                       Network.Mux.Channel
-                       Network.Mux.Codec
-                       Network.Mux.Egress
-                       Network.Mux.Ingress
-                       Network.Mux.JobPool
-                       Network.Mux.Time
-                       Network.Mux.Timeout
-                       Network.Mux.Types
-                       Network.Mux.Trace
-                       Network.Mux.Bearer.Pipe
-                       Network.Mux.Bearer.Queues
-                       Network.Mux.Bearer.Socket
-
-                       Test.Mux
+  other-modules:       Test.Mux
                        Test.Mux.ReqResp
                        Test.Mux.Timeout
   default-language:    Haskell2010
@@ -97,6 +83,7 @@ test-suite test-network-mux
                        io-sim-classes,
                        io-sim            >=0.1 && < 0.2,
                        contra-tracer,
+                       network-mux,
 
                        array,
                        binary,


### PR DESCRIPTION
Pull `network-mux` library in `test-network-mux` component, rather than
import all modulues separately.
