### PR TITLE
Implement HasNetworkProtocolVersion instance for ShelleyBlock

### DIFF
--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -34,6 +34,7 @@ library
                        Ouroboros.Consensus.Shelley.Ledger.Integrity
                        Ouroboros.Consensus.Shelley.Ledger.Ledger
                        Ouroboros.Consensus.Shelley.Ledger.Mempool
+                       Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
                        Ouroboros.Consensus.Shelley.Ledger.TPraos
                        Ouroboros.Consensus.Shelley.Node
                        Ouroboros.Consensus.Shelley.Protocol

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger.hs
@@ -8,3 +8,4 @@ import           Ouroboros.Consensus.Shelley.Ledger.Forge as X
 import           Ouroboros.Consensus.Shelley.Ledger.Integrity as X
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger as X
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool as X
+import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion as X

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE TypeFamilies #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion (
+    ShelleyNodeToNodeVersion(..)
+  , ShelleyNodeToClientVersion(..)
+  ) where
+
+import           Data.List.NonEmpty (NonEmpty (..))
+
+import qualified Ouroboros.Network.NodeToClient as N
+import qualified Ouroboros.Network.NodeToNode as N
+
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+
+import           Ouroboros.Consensus.Shelley.Ledger.Block
+
+data ShelleyNodeToNodeVersion = ShelleyNodeToNodeVersion1
+  deriving (Show, Eq, Ord, Enum, Bounded)
+
+data ShelleyNodeToClientVersion = ShelleyNodeToClientVersion1
+  deriving (Show, Eq, Ord, Enum, Bounded)
+
+instance HasNetworkProtocolVersion (ShelleyBlock c) where
+  type NodeToNodeVersion   (ShelleyBlock c) = ShelleyNodeToNodeVersion
+  type NodeToClientVersion (ShelleyBlock c) = ShelleyNodeToClientVersion
+
+  supportedNodeToNodeVersions   _ = ShelleyNodeToNodeVersion1
+                                  :| []
+  supportedNodeToClientVersions _ = ShelleyNodeToClientVersion1
+                                  :| []
+
+  mostRecentNodeToNodeVersion   _ = ShelleyNodeToNodeVersion1
+  mostRecentNodeToClientVersion _ = ShelleyNodeToClientVersion1
+
+  nodeToNodeProtocolVersion _ ShelleyNodeToNodeVersion1 = N.NodeToNodeV_1
+
+  -- From the beginning, Shelley supports version 2 of the node-to-client
+  -- protocol (i.e. the local state query protocol is enabled from the start).
+  nodeToClientProtocolVersion _ ShelleyNodeToClientVersion1 = N.NodeToClientV_2

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -45,7 +45,6 @@ import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
-import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.State
@@ -69,6 +68,7 @@ import qualified Shelley.Spec.Ledger.UTxO as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger
 import qualified Ouroboros.Consensus.Shelley.Ledger.History as History
+import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
 import           Ouroboros.Consensus.Shelley.Protocol
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (KES)
 import qualified Ouroboros.Consensus.Shelley.Protocol.State as State
@@ -360,9 +360,6 @@ protocolInfoShelley genesis protVer mbCredentials =
 {-------------------------------------------------------------------------------
   RunNode instance
 -------------------------------------------------------------------------------}
-
-instance HasNetworkProtocolVersion (ShelleyBlock c) where
-  -- Use defaults
 
 instance TPraosCrypto c => RunNode (ShelleyBlock c) where
   nodeForgeBlock = forgeShelleyBlock


### PR DESCRIPTION
For a particular issue I'm working on in `cardano-node` (more specifically, `cardano-api` and `cardano-cli`), I'll need to be able to determine and utilize the node-to-client protocol versions supported by a Shelley node. This PR adds support for just that.