### PR TITLE
Move the create dir to the DB marker check

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -306,7 +306,7 @@ withDBChecks RunNodeArgs{..} body = do
       (nodeProtocolMagicId (Proxy @blk) pInfoConfig)
 
     -- Then create the lock file.
-    withLockDB hasFS mountPoint $ do
+    withLockDB mountPoint $ do
 
       -- When we shut down cleanly, we create a marker file so that the next
       -- time we start, we know we don't have to validate the contents of the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/DbMarker.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/DbMarker.hs
@@ -83,6 +83,7 @@ checkDbMarker hasFS mountPoint protocolMagicId = runExceptT $ do
           actualProtocolMagicId
           protocolMagicId
     else do
+      lift $ createDirectoryIfMissing hasFS False root
       isEmpty <- lift $ Set.null <$> listDirectory hasFS root
       if isEmpty then
         createProtocolMagicIdFile


### PR DESCRIPTION
Having put the DB marker check first, the creation of the DB dir also
has to move to the DB marker check.

Not initially spotted since another file path in the node top level also
creates dirs, and these happened to be aliased in one tested
configuration but they are not in general.