### PR TITLE
Prelude in C♯ minor: The Hard Fork Combinator

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -241,32 +241,28 @@ instance LedgerSupportsProtocol ByronBlock where
                 Origin -> SlotNo $ 2 * k
                 At s   -> SlotNo $ unSlotNo s + 1 + (2 * k)
 
+
+
+byronEraParams :: Gen.Config -> HardFork.EraParams
+byronEraParams genesis = HardFork.EraParams {
+      eraEpochSize  = fromByronEpochSlots $ Gen.configEpochSlots genesis
+    , eraSlotLength = fromByronSlotLength $ genesisSlotLength genesis
+    , eraSafeZone   = HardFork.SafeZone {
+          safeFromTip     = 2 * k
+
+          -- @180@ is merely a lower bound on the 'EpochNo' in which the
+          -- Byron-to-Shelley transition could take place. We can update
+          -- it over time, and set it to the precise value once the
+          -- transition has actually taken place.
+        , safeBeforeEpoch = HardFork.LowerBound (EpochNo 180)
+        }
+    }
+  where
+    SecurityParam k = genesisSecurityParam genesis
+
 instance HasHardForkHistory ByronBlock where
-  type HardForkIndices ByronBlock = '[()]
-
-  hardForkShape _ genesis = HardFork.singletonShape eraParams
-    where
-      SecurityParam k = genesisSecurityParam genesis
-
-      eraParams :: HardFork.EraParams
-      eraParams = HardFork.EraParams {
-            eraEpochSize  = fromByronEpochSlots $ Gen.configEpochSlots genesis
-          , eraSlotLength = fromByronSlotLength $ genesisSlotLength genesis
-          , eraSafeZone   = HardFork.SafeZone {
-                safeFromTip     = 2 * k
-
-                -- @180@ is merely a lower bound on the 'EpochNo' in which the
-                -- Byron-to-Shelley transition could take place. We can update
-                -- it over time, and set it to the precise value once the
-                -- transition has actually taken place.
-              , safeBeforeEpoch = HardFork.LowerBound (EpochNo 180)
-              }
-          }
-
-  -- TODO: This is wrong. We should look at the state of the ledger.
-  -- Once we actually start using the hard fork combinator, we should fix this.
-  -- <https://github.com/input-output-hk/ouroboros-network/issues/1786>
-  hardForkTransitions _ _ = HardFork.transitionsUnknown
+  type HardForkIndices ByronBlock = '[ByronBlock]
+  hardForkSummary = neverForksHardForkSummary byronEraParams
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -274,14 +274,8 @@ instance TPraosCrypto c => LedgerSupportsProtocol (ShelleyBlock c) where
                 At s   -> SlotNo $ unSlotNo s + 1 + (2 * k)
 
 instance HasHardForkHistory (ShelleyBlock c) where
-  type HardForkIndices (ShelleyBlock c) = '[()]
-
-  hardForkShape _ cfg = HardFork.singletonShape $ shelleyLedgerEraParams cfg
-
-  -- TODO: This is wrong. We should look at the state of the ledger.
-  -- Once we actually start using the hard fork combinator, we should fix this.
-  -- <https://github.com/input-output-hk/ouroboros-network/issues/1786>
-  hardForkTransitions _ _ = HardFork.transitionsUnknown
+  type HardForkIndices (ShelleyBlock c) = '[ShelleyBlock c]
+  hardForkSummary = neverForksHardForkSummary shelleyLedgerEraParams
 
 {-------------------------------------------------------------------------------
   QueryLedger

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -258,9 +258,8 @@ instance BlockHasCodecConfig (SimpleBlock c ext) where
   getCodecConfig = const SimpleCodecConfig
 
 instance HasHardForkHistory (SimpleBlock c ext) where
-  type HardForkIndices (SimpleBlock c ext) = '[()]
-  hardForkShape _         = HardFork.singletonShape . simpleLedgerEraParams
-  hardForkTransitions _ _ = HardFork.transitionsUnknown
+  type HardForkIndices (SimpleBlock c ext) = '[SimpleBlock c ext]
+  hardForkSummary = neverForksHardForkSummary simpleLedgerEraParams
 
 {-------------------------------------------------------------------------------
   Protocol specific constraints

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/LogicalClock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/LogicalClock.hs
@@ -151,7 +151,7 @@ blockUntilTick clock tick = atomically $ do
 --
 -- We do this by providing it a 'SystemTime' instance that translates ticks
 -- to time.
-hardForkBlockchainTime :: (IOLike m, HasHardForkHistory blk, UpdateLedger blk, HasCallStack)
+hardForkBlockchainTime :: (IOLike m, HasHardForkHistory blk, HasCallStack)
                        => ResourceRegistry m
                        -> Tracer m BTime.TraceBlockchainTimeEvent
                        -> LogicalClock m

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -363,9 +363,8 @@ instance LedgerSupportsProtocol TestBlock where
   ledgerViewForecastAt _ _ = Just . trivialForecast
 
 instance HasHardForkHistory TestBlock where
-  type HardForkIndices TestBlock = '[()]
-  hardForkShape _         = HardFork.singletonShape
-  hardForkTransitions _ _ = HardFork.transitionsUnknown
+  type HardForkIndices TestBlock = '[TestBlock]
+  hardForkSummary = neverForksHardForkSummary id
 
 instance QueryLedger TestBlock where
   data Query TestBlock result where

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -51,6 +51,34 @@ library
                        Ouroboros.Consensus.Fragment.Validated
                        Ouroboros.Consensus.Fragment.ValidatedDiff
                        Ouroboros.Consensus.HardFork.Abstract
+                       Ouroboros.Consensus.HardFork.Combinator
+                       Ouroboros.Consensus.HardFork.Combinator.Abstract
+                       Ouroboros.Consensus.HardFork.Combinator.Basics
+                       Ouroboros.Consensus.HardFork.Combinator.Block
+                       Ouroboros.Consensus.HardFork.Combinator.Degenerate
+                       Ouroboros.Consensus.HardFork.Combinator.Forge
+                       Ouroboros.Consensus.HardFork.Combinator.Ledger
+                       Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
+                       Ouroboros.Consensus.HardFork.Combinator.Mempool
+                       Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+                       Ouroboros.Consensus.HardFork.Combinator.Protocol
+                       Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
+                       Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
+                       Ouroboros.Consensus.HardFork.Combinator.Protocol.State
+                       Ouroboros.Consensus.HardFork.Combinator.SingleEra
+                       Ouroboros.Consensus.HardFork.Combinator.SingleEra.Combined
+                       Ouroboros.Consensus.HardFork.Combinator.SingleEra.Info
+                       Ouroboros.Consensus.HardFork.Combinator.SingleEra.Wrappers
+                       Ouroboros.Consensus.HardFork.Combinator.State
+                       Ouroboros.Consensus.HardFork.Combinator.State.Infra
+                       Ouroboros.Consensus.HardFork.Combinator.Translation
+                       Ouroboros.Consensus.HardFork.Combinator.Unary
+                       Ouroboros.Consensus.HardFork.Combinator.Util.DerivingVia
+                       Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
+                       Ouroboros.Consensus.HardFork.Combinator.Util.Match
+                       Ouroboros.Consensus.HardFork.Combinator.Util.SOP
+                       Ouroboros.Consensus.HardFork.Combinator.Util.Tails
+                       Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
                        Ouroboros.Consensus.HardFork.History
                        Ouroboros.Consensus.HeaderValidation
                        Ouroboros.Consensus.Ledger.Abstract
@@ -168,6 +196,9 @@ library
                        Ouroboros.Consensus.Storage.VolatileDB.Impl.Util
                        Ouroboros.Consensus.Storage.VolatileDB.Types
 
+                       -- Strict wrapper around SOP
+                       Data.SOP.Strict
+
   default-language:    Haskell2010
   other-extensions:
                        BangPatterns
@@ -230,6 +261,7 @@ library
                      , network           >=3.1   && <3.2
                      , psqueues          >=0.2.3 && <0.3
                      , serialise         >=0.2   && <0.3
+                     , sop-core          >=0.5   && <0.6
                      , stm               >=2.5   && <2.6
                      , streaming
                      , text              >=1.2   && <1.3

--- a/ouroboros-consensus/src/Data/SOP/Strict.hs
+++ b/ouroboros-consensus/src/Data/SOP/Strict.hs
@@ -1,0 +1,219 @@
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE EmptyCase            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Strict variant of SOP
+--
+-- This does not currently attempt to be exhaustive.
+module Data.SOP.Strict (
+    -- * NP
+    NP(..)
+  , hd
+  , tl
+    -- * NS
+  , NS(..)
+  , unZ
+    -- * Injections
+  , Injection
+  , injections
+    -- * Re-exports from @sop-core@
+  , module Data.SOP
+  , module Data.SOP.Constraint
+  ) where
+
+import           Data.SOP hiding (Injection, NP (..), NS (..), hd, injections,
+                     shiftInjection, tl, unZ)
+import           Data.SOP.Constraint
+
+import           Cardano.Prelude (NoUnexpectedThunks (..), ThunkInfo (..),
+                     allNoUnexpectedThunks)
+
+{-------------------------------------------------------------------------------
+  NP
+-------------------------------------------------------------------------------}
+
+data NP :: (k -> *) -> [k] -> * where
+  Nil  :: NP f '[]
+  (:*) :: !(f x) -> !(NP f xs) -> NP f (x ': xs)
+
+infixr 5 :*
+
+type instance CollapseTo NP a = [a]
+type instance AllN       NP c = All c
+type instance Prod       NP   = NP
+type instance SListIN    NP   = SListI
+
+hd :: NP f (x ': xs) -> f x
+hd (x :* _) = x
+
+tl :: NP f (x ': xs) -> NP f xs
+tl (_ :* xs) = xs
+
+ap_NP :: NP (f -.-> g) xs -> NP f xs -> NP g xs
+ap_NP Nil          Nil       = Nil
+ap_NP (Fn f :* fs) (x :* xs) = f x :* ap_NP fs xs
+
+pure_NP :: SListI xs => (forall a. f a) -> NP f xs
+pure_NP = cpure_NP (Proxy @Top)
+
+cpure_NP :: forall c xs proxy f. All c xs
+         => proxy c -> (forall a. c a => f a) -> NP f xs
+cpure_NP _ f = go sList
+  where
+    go :: All c xs' => SList xs' -> NP f xs'
+    go SNil  = Nil
+    go SCons = f :* go sList
+
+collapse_NP :: NP (K a) xs -> [a]
+collapse_NP = go
+  where
+    go :: NP (K a) xs -> [a]
+    go Nil         = []
+    go (K x :* xs) = x : go xs
+
+instance HPure NP where
+  hpure  = pure_NP
+  hcpure = cpure_NP
+
+instance HAp NP where
+  hap = ap_NP
+
+instance HCollapse NP where
+  hcollapse = collapse_NP
+
+{-------------------------------------------------------------------------------
+  NS
+-------------------------------------------------------------------------------}
+
+data NS :: (k -> *) -> [k] -> * where
+  Z :: !(f x) -> NS f (x ': xs)
+  S :: !(NS f xs) -> NS f (x ': xs)
+
+type instance CollapseTo NS a = a
+type instance AllN       NS c = All c
+type instance Prod       NS   = NP
+type instance SListIN    NS   = SListI
+
+unZ :: NS f '[x] -> f x
+unZ (Z x) = x
+unZ (S x) = case x of {}
+
+expand_NS :: SListI xs => (forall x. f x) -> NS f xs -> NP f xs
+expand_NS = cexpand_NS (Proxy @Top)
+
+cexpand_NS :: forall c proxy f xs. All c xs
+           => proxy c -> (forall x. c x => f x) -> NS f xs -> NP f xs
+cexpand_NS p d = go
+  where
+    go :: forall xs'. All c xs' => NS f xs' -> NP f xs'
+    go (Z x) = x :* hcpure p d
+    go (S i) = d :* go i
+
+ap_NS :: NP (f -.-> g) xs -> NS f xs -> NS g xs
+ap_NS = go
+  where
+    go :: NP (f -.-> g) xs -> NS f xs -> NS g xs
+    go (f :* _)  (Z x)  = Z $ apFn f x
+    go (_ :* fs) (S xs) = S $ go fs xs
+    go Nil       x      = case x of {}
+
+collapse_NS :: NS (K a) xs -> a
+collapse_NS = go
+  where
+    go :: NS (K a) xs  -> a
+    go (Z (K x)) = x
+    go (S xs)    = go xs
+
+ctraverse'_NS  :: forall c proxy xs f f' g. (All c xs,  Functor g)
+               => proxy c
+               -> (forall a. c a => f a -> g (f' a))
+               -> NS f xs  -> g (NS f' xs)
+ctraverse'_NS _ f = go
+  where
+    go :: All c ys => NS f ys -> g (NS f' ys)
+    go (Z x)  = Z <$> f x
+    go (S xs) = S <$> go xs
+
+instance HExpand NS where
+  hexpand  = expand_NS
+  hcexpand = cexpand_NS
+
+instance HAp NS where
+  hap = ap_NS
+
+instance HCollapse NS where
+  hcollapse = collapse_NS
+
+instance HSequence NS  where
+  hctraverse' = ctraverse'_NS
+  htraverse'  = hctraverse' (Proxy @Top)
+  hsequence'  = htraverse' unComp
+
+{-------------------------------------------------------------------------------
+  Injections
+-------------------------------------------------------------------------------}
+
+type Injection (f :: k -> *) (xs :: [k]) = f -.-> K (NS f xs)
+
+injections :: forall xs f. SListI xs => NP (Injection f xs) xs
+injections = go sList
+  where
+    go :: SList xs' -> NP (Injection f xs') xs'
+    go SNil  = Nil
+    go SCons = fn (K . Z) :* hmap shiftInjection (go sList)
+
+shiftInjection :: Injection f xs a -> Injection f (x ': xs) a
+shiftInjection (Fn f) = Fn $ K . S . unK . f
+
+{-------------------------------------------------------------------------------
+  Instances
+-------------------------------------------------------------------------------}
+
+deriving instance All (Show `Compose` f) xs => Show (NS f xs)
+deriving instance All (Eq   `Compose` f) xs => Eq   (NS f xs)
+deriving instance (All (Eq `Compose` f) xs, All (Ord `Compose` f) xs) => Ord (NS f xs)
+
+-- | Copied from sop-core
+--
+-- Not derived, since derived instance ignores associativity info
+instance All (Show `Compose` f) xs => Show (NP f xs) where
+  showsPrec _ Nil       = showString "Nil"
+  showsPrec d (f :* fs) = showParen (d > 5)
+                        $ showsPrec (5 + 1) f
+                        . showString " :* "
+                        . showsPrec 5 fs
+
+deriving instance  All (Eq `Compose` f) xs                            => Eq  (NP f xs)
+deriving instance (All (Eq `Compose` f) xs, All (Ord `Compose` f) xs) => Ord (NP f xs)
+
+{-------------------------------------------------------------------------------
+  NoUnexpectedThunks
+-------------------------------------------------------------------------------}
+
+instance All (Compose NoUnexpectedThunks f) xs
+      => NoUnexpectedThunks (NS (f :: k -> *) (xs :: [k])) where
+  showTypeOf _ = "NS"
+  whnfNoUnexpectedThunks ctxt = \case
+      Z l -> noUnexpectedThunks ("Z" : ctxt) l
+      S r -> noUnexpectedThunks ("S" : ctxt) r
+
+instance All (Compose NoUnexpectedThunks f) xs
+      => NoUnexpectedThunks (NP (f :: k -> *) (xs :: [k])) where
+  showTypeOf _ = "NP"
+  whnfNoUnexpectedThunks ctxt = \case
+      Nil     -> return NoUnexpectedThunks
+      x :* xs -> allNoUnexpectedThunks [
+                     noUnexpectedThunks ("fst" : ctxt) x
+                   , noUnexpectedThunks ("snd" : ctxt) xs
+                   ]

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forge.hs
@@ -7,11 +7,12 @@ module Ouroboros.Consensus.Block.Forge (
   , Update(..)
   , updateFromTVar
   , liftUpdate
+  , coerceUpdate
   ) where
 
 import           Crypto.Random (MonadRandom)
 import           Data.Bifunctor (first)
-
+import           Data.Coerce
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 import           Cardano.Slotting.Block
@@ -72,3 +73,6 @@ liftUpdate :: (large -> small)
 liftUpdate get set (Update update) = Update $ \f ->
     update $ \large ->
       first (flip set large) <$> (f (get large))
+
+coerceUpdate :: Coercible a b => Update m a -> Update m b
+coerceUpdate = liftUpdate coerce (\new _old -> coerce new)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
@@ -10,7 +10,6 @@ module Ouroboros.Consensus.BlockchainTime.WallClock.HardFork (
 
 import           Control.Monad
 import           Control.Tracer
-import           Data.Proxy
 import           Data.Time (NominalDiffTime, UTCTime)
 import           Data.Void
 import           GHC.Stack
@@ -29,7 +28,6 @@ import           Ouroboros.Consensus.Util.Time
 hardForkBlockchainTime :: forall m blk.
                           ( IOLike m
                           , HasHardForkHistory blk
-                          , UpdateLedger blk
                           , HasCallStack
                           )
                        => ResourceRegistry m
@@ -56,11 +54,7 @@ hardForkBlockchainTime registry
       }
   where
     summarize :: LedgerState blk -> HF.Summary (HardForkIndices blk)
-    summarize st = HF.summarize
-                     systemTimeStart
-                     (ledgerTipSlot st)
-                     (hardForkShape (Proxy @blk) cfg)
-                     (hardForkTransitions        cfg st)
+    summarize st = hardForkSummary systemTimeStart cfg st
 
     loop :: HF.RunWithCachedSummary xs m
          -> StrictTVar m CurrentSlot

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
@@ -1,13 +1,17 @@
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE RecordWildCards      #-}
+{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Config (
     TopLevelConfig(..)
   , configSecurityParam
   , configCodec
+  , castTopLevelConfig
   ) where
 
+import           Data.Coerce
 import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
@@ -38,3 +42,15 @@ configCodec
   => TopLevelConfig blk
   -> CodecConfig blk
 configCodec = getCodecConfig . configBlock
+
+castTopLevelConfig :: ( Coercible (ConsensusConfig (BlockProtocol blk))
+                                  (ConsensusConfig (BlockProtocol blk'))
+                      , LedgerConfig blk ~ LedgerConfig blk'
+                      , Coercible (BlockConfig blk) (BlockConfig blk')
+                      )
+                   => TopLevelConfig blk -> TopLevelConfig blk'
+castTopLevelConfig TopLevelConfig{..} = TopLevelConfig{
+      configConsensus = coerce configConsensus
+    , configLedger    = configLedger
+    , configBlock     = coerce configBlock
+    }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
@@ -23,7 +23,6 @@ module Ouroboros.Consensus.Fragment.InFuture (
   ) where
 
 import           Data.Bifunctor
-import           Data.Proxy
 import           Data.Time (NominalDiffTime, diffUTCTime)
 import           Data.Word
 
@@ -117,12 +116,7 @@ reference cfg (ClockSkew clockSkew) SystemTime{..} = CheckInFuture {
         -- summary can be used to check all of the blocks in the fragment
         return $
           checkFragment
-            (HF.summarize
-               systemTimeStart
-               (ledgerTipSlot
-                  (VF.validatedLedger validated))
-               (hardForkShape (Proxy @blk) cfg)
-               (hardForkTransitions cfg (VF.validatedLedger validated)))
+            (hardForkSummary systemTimeStart cfg (VF.validatedLedger validated))
             now
             (VF.validatedFragment validated)
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Abstract.hs
@@ -3,25 +3,68 @@
 
 module Ouroboros.Consensus.HardFork.Abstract (
     HasHardForkHistory(..)
+  , neverForksHardForkSummary
   ) where
 
-import           Ouroboros.Consensus.HardFork.History as HardFork
+import           Ouroboros.Consensus.BlockchainTime.WallClock.Types
+                     (SystemStart)
+import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Ledger.Abstract
 
 class HasHardForkHistory blk where
   -- | Type level description of the hard fork shape
   --
-  -- The exact way in which this will used will be determined once we have the
-  -- proper hard fork combinator, but intuitively it would be something like
-  -- @'[Byron, Shelley, Goguen]@.
+  -- The 'Summary' infrastructure does not care what the types in this list
+  -- are, it just cares how /many/ eras there are. The hard fork combinator
+  -- will instantiate 'HardForkIndices' to the types of the blocks involved
+  -- in the hard fork, e.g., we might have something like
+  --
+  -- > '[ByronBlock, ShelleyBlock, GoguenBlock]
   type family HardForkIndices blk :: [*]
 
-  -- | Static (ledger independent) hard fork shape
-  hardForkShape :: proxy blk
-                -> LedgerConfig blk
-                -> HardFork.Shape (HardForkIndices blk)
+  -- | Summary of the hard fork state
+  --
+  -- NOTE: 'HasHardForkHistory' is the only abstraction that the consensus
+  -- layer is aware in relation to potential hard forks, and is needed only for
+  -- time translations (in block production and in the chain DB). It is
+  -- independent from the hard fork combinator and can be used for blocks that
+  -- never fork (in which case the 'Summary' will be trivial) or indeed for
+  -- blocks that do support transitions but do not use the hard fork combinator.
+  --
+  -- It is however useful to consider what this function means in the (typical)
+  -- case that the hard fork combinator /is/ used. The HFC introduces the
+  -- concept of a partial ledger config, which is essentially the ledger config
+  -- minus an 'EpochInfo'. Whenever the HFC calls functions on the underlying
+  -- ledger, it maintains enough state to be able to /construct/ an 'EpochInfo'
+  -- on the fly and then combines that with the 'PartialLedgerConfig' to get
+  -- the full 'LedgerConfig'. The config of the HFC /itself/ however does /not/
+  -- require an 'EpochInfo', and so the config that we pass here will not
+  -- contain that 'EpochInfo' (if it did, that would be strange: we'd be
+  -- computing the 'Summary' required to construct an 'EpochInfo' while we
+  -- already have one). Critically, the HFC implements 'hardForkSummary'
+  -- directly and does not call 'hardForkSummary' in the underlying ledgers.
+  --
+  -- When running ledgers that are normally run using the HFC as standalone
+  -- ledgers, then the 'LedgerConfig' here must indeed already contain timing
+  -- information, and so this function becomes little more than a projection
+  -- (indeed, in this case the 'LedgerState' should be irrelevant).
+  hardForkSummary :: SystemStart
+                  -> LedgerConfig blk
+                  -> LedgerState blk
+                  -> HardFork.Summary (HardForkIndices blk)
 
-  -- | Ledger-dependent hard fork transitions
-  hardForkTransitions :: LedgerConfig blk
-                      -> LedgerState blk
-                      -> HardFork.Transitions (HardForkIndices blk)
+-- | Helper function that can be used to define 'hardForkSummary'
+--
+-- This is basically a proof of the claim of the documentation of
+-- 'hardForkSummary' that 'hardForkSummary' becomes a mere projection of
+-- a block's ledger state when there are no hard forks. It is useful to give
+-- blocks such as 'ShelleyBlock' their own 'HasHardForkHistory' instance so that
+-- we can run them as independent ledgers (in addition to being run with the
+-- hard fork combinator).
+neverForksHardForkSummary :: (LedgerConfig blk -> HardFork.EraParams)
+                          -> SystemStart
+                          -> LedgerConfig blk
+                          -> LedgerState blk
+                          -> HardFork.Summary '[blk]
+neverForksHardForkSummary getParams start cfg _st =
+    HardFork.neverForksSummary start (getParams cfg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
@@ -1,0 +1,84 @@
+-- | The hard fork combinator
+--
+-- Intended for unqualified import
+module Ouroboros.Consensus.HardFork.Combinator (
+    module X
+  ) where
+
+-- Defines 'SingleEraBlock' and 'CanHardFork'
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract as X
+
+-- Defines 'HardForkProtocol', 'HardForkBlock', and 'LedgerState',
+-- as well as various config types.
+import           Ouroboros.Consensus.HardFork.Combinator.Basics as X
+
+-- Defines 'HasPartialConsensusConfig' and 'HasPartialLedgerConfig'
+import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig as X
+
+-- Instances for 'BlockHasCodecConfig', 'GetHeader', 'HasHeader',
+-- 'BasicEnvelopeValidation'
+import           Ouroboros.Consensus.HardFork.Combinator.Block as X
+
+-- Instances for 'IsLedger', 'ApplyBlock', 'UpdateLedger',
+-- 'LedgerSupportsProtocol', 'HasHardForkHistory', 'ValidateEnvelope'
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger as X
+
+-- Instances for 'ApplyTx', 'HasTxId', 'HasTxs'
+import           Ouroboros.Consensus.HardFork.Combinator.Mempool as X
+
+-- Instance for 'ConsensusProtocol'
+import           Ouroboros.Consensus.HardFork.Combinator.Protocol as X
+
+-- Instances for 'ShowQuery' and 'QueryLedger'
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger.Query as X
+
+-- Instance for 'ChainSelection'
+import           Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel as X
+
+-- Defines 'SingleEraInfo' and 'LedgerEraInfo'
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra.Info as X
+
+-- Defines the various translation types required for concrete HFC instances
+import           Ouroboros.Consensus.HardFork.Combinator.Translation as X
+
+-- Instance for 'CanForge'
+import           Ouroboros.Consensus.HardFork.Combinator.Forge as X ()
+
+-- Omitted from this export:
+--
+-- * "Ouroboros.Consensus.HardFork.Combinator.State"
+--   This defines 'HardForkState', a wrapper around a 'Telescope'. We use this
+--   to define 'HardForkLedgerState', 'HardForkLedgerView' as well as
+--   'HardForkConsensusState', but the type itself should mostly be internal
+--   to the hard fork combinator.
+--
+-- * "module Ouroboros.Consensus.HardFork.Combinator.State.Infra"
+--   This module is only separate from @.State@ to avoid some cyclic module
+--   dependencies. Most modules internally to the HFC should import from
+--   @.State@ directly, and outside of the HFC not even @.State@ should be
+--   needed (see above).
+--
+-- * "Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView"
+--   This is internal to "Ouroboros.Consensus.HardFork.Combinator.Protocol"
+--
+-- * "Ouroboros.Consensus.HardFork.Combinator.Protocol.State"
+--   This is internal to "Ouroboros.Consensus.HardFork.Combinator.Protocol"
+--
+-- * "Ouroboros.Consensus.HardFork.Combinator.Degenerate"
+--   This defines 'DegenFork', which is useful as a test case that the hard
+--   fork combinator when applied to a single block results in a system
+--   that is equivalent to just using that single block directly.
+--
+-- * "Ouroboros.Consensus.HardFork.Combinator.Unary"
+--   Mostly used in combination with 'DegenFork'.
+--
+-- * Most of @Ouroboros.Consensus.HardFork.Combinator.SingleEra.*@
+--   These types are primarily used internally to define the HFC types.
+--   In a few cases some of the HFC types /are/ types from the SingleEra
+--   module hierarchy directly; in such cases, we should export them from
+--   this module.
+--   TODO: Currently we only do this for @SingleEra.Info@, but we might also
+--   need to do it for other types.
+--
+-- * Ouroboros.Consensus.HardFork.Combinator.Util.*
+--   Utility functions and types

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DataKinds               #-}
+{-# LANGUAGE DeriveAnyClass          #-}
+{-# LANGUAGE DeriveGeneric           #-}
+{-# LANGUAGE DerivingStrategies      #-}
+{-# LANGUAGE FlexibleContexts        #-}
+{-# LANGUAGE FlexibleInstances       #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Abstract (
+    SingleEraBlock(..)
+  , proxySingle
+  , CanHardFork(..)
+    -- * Re-exports
+  , IsNonEmpty(..)
+  , ProofNonEmpty(..)
+  ) where
+
+import           Codec.Serialise (Serialise)
+import           Data.Proxy
+import           Data.SOP.Strict
+import           Data.Typeable
+
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Network.Block
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.HardFork.History (EraParams)
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Mempool.API
+
+import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra.Info
+import           Ouroboros.Consensus.HardFork.Combinator.Translation
+import           Ouroboros.Consensus.HardFork.Combinator.Util.SOP
+
+-- | Blocks from which we can assemble a hard fork
+class ( LedgerSupportsProtocol blk
+      , ApplyTx blk
+      , HasTxId (GenTx blk)
+      , QueryLedger blk
+      , CanForge blk
+      , HasPartialConsensusConfig (BlockProtocol blk)
+      , HasPartialLedgerConfig blk
+        -- Instances required to support testing
+      , Show blk
+      , Show (Header blk)
+        -- Only needed for the PBFT hack; see 'rewindConsensusState'
+      , Serialise (HeaderHash blk)
+      ) => SingleEraBlock blk where
+  -- | Era parameters
+  --
+  -- The era parameters must be static (cannot depend on the ledger state).
+  --
+  -- Since we ne need this to construct the 'HardForkSummary' (and hence the
+  -- 'EpochInfo', this takes the /partial/ config, not the full config
+  -- (or we'd end up in a catch-22).
+  singleEraParams     :: proxy blk -> PartialLedgerConfig blk -> EraParams
+
+  -- | Era transition
+  --
+  -- This should only report the transition point once it is stable (rollback
+  -- cannot affect it anymore).
+  --
+  -- This takes the partial config rather than the full config for the same
+  -- reason as 'singleEraParam'.
+  singleEraTransition :: PartialLedgerConfig blk -> LedgerState blk -> Maybe EpochNo
+
+  -- | Era information (for use in error messages)
+  singleEraInfo       :: proxy blk -> SingleEraInfo blk
+
+proxySingle :: Proxy SingleEraBlock
+proxySingle = Proxy
+
+class (All SingleEraBlock xs, Typeable xs, IsNonEmpty xs) => CanHardFork xs where
+  hardForkEraTranslation     :: EraTranslation     xs
+  hardForkEraTransitionCheck :: EraTransitionCheck xs
+
+instance SingleEraBlock blk => CanHardFork '[blk] where
+  hardForkEraTranslation     = trivialEraTranslation
+  hardForkEraTransitionCheck = trivialEraTransitionCheck

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -1,0 +1,153 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Basics (
+    -- * Hard fork protocol, block, and ledger state
+    HardForkProtocol
+  , HardForkBlock(..)
+  , LedgerState(..)
+    -- * Config
+  , ConsensusConfig(..)
+  , BlockConfig(..)
+  , HardForkLedgerConfig(..)
+    -- ** Functions on config
+  , completeLedgerConfig'
+  , completeConsensusConfig'
+  , distribTopLevelConfig
+    -- ** Convenience re-exports
+  , EpochInfo
+  , Identity
+  ) where
+
+import           Data.Functor.Identity
+import           Data.SOP.Strict
+import           GHC.Generics (Generic)
+
+import           Cardano.Prelude (NoUnexpectedThunks)
+import           Cardano.Slotting.EpochInfo
+
+import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Config.SecurityParam
+import qualified Ouroboros.Consensus.HardFork.History as History
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Protocol.Abstract
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+import           Ouroboros.Consensus.HardFork.Combinator.State.Infra
+
+{-------------------------------------------------------------------------------
+  Hard fork protocol, block, and ledger state
+-------------------------------------------------------------------------------}
+
+data HardForkProtocol (xs :: [*])
+
+newtype HardForkBlock xs = HardForkBlock {
+      getHardForkBlock :: OneEraBlock xs
+    }
+  deriving (Show)
+
+type instance BlockProtocol (HardForkBlock xs) = HardForkProtocol xs
+
+newtype instance LedgerState (HardForkBlock xs) = HardForkLedgerState {
+      getHardForkLedgerState :: HardForkState LedgerState xs
+    }
+  deriving stock   (Show, Eq)
+  deriving newtype (NoUnexpectedThunks)
+
+{-------------------------------------------------------------------------------
+  Protocol config
+-------------------------------------------------------------------------------}
+
+data instance ConsensusConfig (HardForkProtocol xs) = HardForkConsensusConfig {
+      -- | The value of @k@ cannot change at hard fork boundaries
+      hardForkConsensusConfigK :: !(SecurityParam)
+
+      -- | The shape of the hard fork
+      --
+      -- We require this in the consensus config because consensus might need
+      -- access to 'EpochInfo', and in order to compute that, we need the
+      -- 'EraParams' of all eras.
+    , hardForkConsensusConfigShape :: !(History.Shape xs)
+
+      -- | Config for each era
+    , hardForkConsensusConfigPerEra :: !(PerEraConsensusConfig xs)
+    }
+  deriving stock    (Generic)
+  deriving anyclass (NoUnexpectedThunks)
+
+{-------------------------------------------------------------------------------
+  Block config
+-------------------------------------------------------------------------------}
+
+newtype instance BlockConfig (HardForkBlock xs) = HardForkBlockConfig {
+      hardForkBlockConfigPerEra :: PerEraBlockConfig xs
+    }
+  deriving newtype (NoUnexpectedThunks)
+
+{-------------------------------------------------------------------------------
+  Ledger config
+-------------------------------------------------------------------------------}
+
+data HardForkLedgerConfig xs = HardForkLedgerConfig {
+      hardForkLedgerConfigK      :: !SecurityParam
+    , hardForkLedgerConfigShape  :: !(History.Shape xs)
+    , hardForkLedgerConfigPerEra :: !(PerEraLedgerConfig xs)
+    }
+  deriving (Generic)
+
+instance CanHardFork xs => NoUnexpectedThunks (HardForkLedgerConfig xs)
+
+type instance LedgerCfg (LedgerState (HardForkBlock xs)) = HardForkLedgerConfig xs
+
+{-------------------------------------------------------------------------------
+  Operations on config
+-------------------------------------------------------------------------------}
+
+completeLedgerConfig' :: forall blk.
+                         HasPartialLedgerConfig blk
+                      => EpochInfo Identity
+                      -> SingleEraLedgerConfig blk
+                      -> LedgerConfig blk
+completeLedgerConfig' ei =
+      completeLedgerConfig (Proxy @blk) ei
+    . getSingleEraLedgerConfig
+
+completeConsensusConfig' :: forall blk.
+                            HasPartialConsensusConfig (BlockProtocol blk)
+                         => EpochInfo Identity
+                         -> SingleEraConsensusConfig blk
+                         -> ConsensusConfig (BlockProtocol blk)
+completeConsensusConfig' ei =
+      completeConsensusConfig (Proxy @(BlockProtocol blk)) ei
+    . getSingleEraConsensusConfig
+
+distribTopLevelConfig :: CanHardFork xs
+                      => EpochInfo Identity
+                      -> TopLevelConfig (HardForkBlock xs)
+                      -> NP TopLevelConfig xs
+distribTopLevelConfig ei TopLevelConfig{..} =
+    hczipWith3 proxySingle
+      (\cfgConsensus cfgLedger cfgBlock ->
+           TopLevelConfig
+             (completeConsensusConfig' ei cfgConsensus)
+             (completeLedgerConfig'    ei cfgLedger)
+             cfgBlock)
+      (getPerEraConsensusConfig $
+         hardForkConsensusConfigPerEra configConsensus)
+      (getPerEraLedgerConfig $
+         hardForkLedgerConfigPerEra configLedger)
+      (getPerEraBlockConfig $
+         hardForkBlockConfigPerEra configBlock)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -1,0 +1,211 @@
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Block (
+    -- * Type family instances
+    BlockConfig(..)
+  , CodecConfig(..)
+  , Header(..)
+  ) where
+
+import           Data.FingerTree.Strict (Measured (..))
+import           Data.Function (on)
+import           Data.Functor.Product
+import           Data.SOP.Strict
+
+import           Cardano.Prelude (NoUnexpectedThunks)
+
+import           Ouroboros.Network.Block
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Util ((.:))
+import           Ouroboros.Consensus.Util.Condense
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+import           Ouroboros.Consensus.HardFork.Combinator.Translation
+import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
+                     (InPairs (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Match as Match
+
+{-------------------------------------------------------------------------------
+  CodecConfig
+-------------------------------------------------------------------------------}
+
+newtype instance CodecConfig (HardForkBlock xs) = HardForkCodecConfig {
+      hardForkCodecConfigPerEra :: PerEraCodecConfig xs
+    }
+
+instance CanHardFork xs => BlockHasCodecConfig (HardForkBlock xs) where
+  getCodecConfig =
+        HardForkCodecConfig
+      . PerEraCodecConfig
+      . hcmap proxySingle getCodecConfig
+      . getPerEraBlockConfig
+      . hardForkBlockConfigPerEra
+
+{-------------------------------------------------------------------------------
+  GetHeader
+-------------------------------------------------------------------------------}
+
+instance CanHardFork xs => GetHeader (HardForkBlock xs) where
+  newtype Header (HardForkBlock xs) = HardForkHeader {
+        getHardForkHeader :: OneEraHeader xs
+      }
+    deriving (Show, NoUnexpectedThunks)
+
+  getHeader = HardForkHeader . oneEraBlockHeader . getHardForkBlock
+
+{-------------------------------------------------------------------------------
+  HasHeader
+-------------------------------------------------------------------------------}
+
+type instance HeaderHash (HardForkBlock xs) = OneEraHash xs
+
+instance CanHardFork xs => StandardHash (HardForkBlock xs)
+
+instance CanHardFork xs => Measured BlockMeasure (HardForkBlock xs) where
+  measure = blockMeasure
+
+instance CanHardFork xs => HasHeader (HardForkBlock xs) where
+  blockHash      =            blockHash     . getHeader
+  blockPrevHash  = castHash . blockPrevHash . getHeader
+  blockSlot      =            blockSlot     . getHeader
+  blockNo        =            blockNo       . getHeader
+  blockInvariant = const True
+
+instance CanHardFork xs => HasHeader (Header (HardForkBlock xs)) where
+  blockHash      =            blockHash     . getHardForkHeader
+  blockPrevHash  = castHash . blockPrevHash . getHardForkHeader
+  blockSlot      =            blockSlot     . getHardForkHeader
+  blockNo        =            blockNo       . getHardForkHeader
+  blockInvariant = const True
+
+{-------------------------------------------------------------------------------
+  HasAnnTip
+-------------------------------------------------------------------------------}
+
+instance CanHardFork xs => HasAnnTip (HardForkBlock xs) where
+  type TipInfo (HardForkBlock xs) = OneEraTipInfo xs
+
+  getTipInfo =
+        OneEraTipInfo
+      . hcmap proxySingle (SingleEraTipInfo . getTipInfo)
+      . getOneEraHeader
+      . getHardForkHeader
+
+  tipInfoHash _ =
+        OneEraHash
+      . hcmap proxySingle aux
+      . getOneEraTipInfo
+    where
+      aux :: forall blk. SingleEraBlock blk
+          => SingleEraTipInfo blk -> SingleEraHash blk
+      aux = SingleEraHash . tipInfoHash (Proxy @blk) . getSingleEraTipInfo
+
+{-------------------------------------------------------------------------------
+  BasicEnvelopeValidation
+-------------------------------------------------------------------------------}
+
+instance CanHardFork xs => BasicEnvelopeValidation (HardForkBlock xs) where
+  expectedFirstBlockNo _ =
+      case isNonEmpty (Proxy @xs) of
+        ProofNonEmpty p -> expectedFirstBlockNo p
+
+  minimumPossibleSlotNo _ =
+      case isNonEmpty (Proxy @xs) of
+        ProofNonEmpty p -> minimumPossibleSlotNo p
+
+  -- TODO: If the block is from a different era as the current tip, we just
+  -- expect @succ b@. This may not be sufficient: if we ever transition /to/
+  -- an era with EBBs, this is not correct.
+  expectedNextBlockNo _ (OneEraTipInfo oldTip) (OneEraTipInfo newBlock) b =
+      case Match.matchNS oldTip newBlock of
+        Right matched  -> hcollapse $ hcmap proxySingle aux matched
+        Left _mismatch -> succ b
+    where
+      aux :: forall blk. SingleEraBlock blk
+          => Product SingleEraTipInfo SingleEraTipInfo blk
+          -> K BlockNo blk
+      aux (Pair (SingleEraTipInfo old) (SingleEraTipInfo new)) = K $
+          expectedNextBlockNo (Proxy @blk) old new b
+
+  -- TODO: If the block is from a different era as the current tip, we just
+  -- expect @succ s@. This may not be sufficient: if we ever transition /to/
+  -- an era with EBBs, this is not correct.
+  minimumNextSlotNo _ (OneEraTipInfo oldTip) (OneEraTipInfo newBlock) s =
+      case Match.matchNS oldTip newBlock of
+        Right matched  -> hcollapse $ hcmap proxySingle aux matched
+        Left _mismatch -> succ s
+    where
+      aux :: forall blk. SingleEraBlock blk
+          => Product SingleEraTipInfo SingleEraTipInfo blk
+          -> K SlotNo blk
+      aux (Pair (SingleEraTipInfo old) (SingleEraTipInfo new)) = K $
+          minimumNextSlotNo (Proxy @blk) old new s
+
+  checkPrevHash HardForkBlockConfig{..} =
+           go (getCheckEraTransition hardForkEraTransitionCheck) cfgs
+      `on` getOneEraHash
+    where
+      cfgs = getPerEraBlockConfig hardForkBlockConfigPerEra
+
+      -- This is a pretty straight-forward aligning of two NS, except we allow
+      -- the current tip to be /one/ era before the next block; in this case
+      -- the 'hardForkEraTransitionCheck' will do the check for us.
+      go :: All SingleEraBlock xs'
+         => InPairs CheckTransition xs'
+         -> NP BlockConfig xs'
+         -> NS SingleEraHash xs' -> NS SingleEraHash xs' -> Bool
+      go _            (c :* _)       (Z h) (Z h')     = aux c h h'
+      go (PCons _ fs) (_ :* cs)      (S h) (S h')     = go fs cs h h'
+      go (PCons f _)  (c :* c' :* _) (Z h) (S (Z h')) = checkOne f c c' h h'
+      go _            _              _     _          = False
+
+      checkOne :: CheckTransition blk blk'
+               -> BlockConfig blk
+               -> BlockConfig blk'
+               -> SingleEraHash blk
+               -> SingleEraHash blk'
+               -> Bool
+      checkOne f c c' h h' =
+          checkTransitionWith f c c'
+            (getSingleEraHash h)
+            (BlockHash $ getSingleEraHash h')
+
+      aux :: forall blk. SingleEraBlock blk
+          => BlockConfig blk -> SingleEraHash blk -> SingleEraHash blk -> Bool
+      aux cfg = checkPrevHash cfg `on` getSingleEraHash
+
+{-------------------------------------------------------------------------------
+  Other instances (primarily for the benefit of tests)
+-------------------------------------------------------------------------------}
+
+instance All Condense xs => Condense (HardForkBlock xs) where
+  condense =
+        hcollapse
+      . hcmap (Proxy @Condense) (K . condense . unI)
+      . getOneEraBlock
+      . getHardForkBlock
+
+
+instance All Eq xs => Eq (HardForkBlock xs) where
+  (==) = (aux .: Match.matchNS) `on` (getOneEraBlock . getHardForkBlock)
+    where
+      aux :: Either (Match.Mismatch I I xs) (NS (Product I I) xs) -> Bool
+      aux (Left  _) = False
+      aux (Right m) = hcollapse $
+                        hcmap (Proxy @Eq) (\(Pair x y) -> K $ x == y) m

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -1,0 +1,372 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE EmptyCase                  #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Degenerate (
+    DegenFork(..)
+    -- * Type families
+  , Header(..)
+  , BlockConfig(..)
+  , LedgerState(..)
+  , GenTx(..)
+  , TxId(..)
+  , CodecConfig(..)
+    -- * Test support
+  , projCfg
+  ) where
+
+import           Cardano.Prelude (NoUnexpectedThunks (..))
+import           Control.Monad.Except
+import           Data.FingerTree.Strict (Measured (..))
+import           Data.Function (on)
+import           Data.Proxy
+import           Data.Type.Equality
+import           Data.Void
+
+import           Ouroboros.Network.Block
+import           Ouroboros.Network.Protocol.LocalStateQuery.Codec (Some (..))
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Mempool.API
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import           Ouroboros.Consensus.Node.Run
+import qualified Ouroboros.Consensus.Storage.ChainDB.Init as InitChainDB
+
+import           Ouroboros.Consensus.HardFork.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Block
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger ()
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger.Query ()
+import           Ouroboros.Consensus.HardFork.Combinator.Mempool
+import           Ouroboros.Consensus.HardFork.Combinator.Protocol ()
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+import           Ouroboros.Consensus.HardFork.Combinator.Unary
+
+-- | Degenerate hard fork with a single era
+--
+-- NOTE: It is important to realize that in general
+--
+-- > HardForkBlock '[b]
+--
+-- and
+--
+-- > DegenFork b
+--
+-- may behave differently. Crucially, they might have
+--
+-- * different serialization formats, where the former uses a serialization
+--   format that is forward-compatible with hard fork transitions, whereas
+--   the latter may well not be
+-- * related to the previous point, it will have its own network protocol
+--   versioning
+--
+-- The main use of 'DegenFork' is for testing, and as evidence that all
+-- type class instances that are required for the hard fork are present.
+newtype DegenFork b = DBlk {
+      unDBlk :: HardForkBlock '[b]
+    }
+  deriving (Eq, Show)
+
+type instance BlockProtocol (DegenFork b) = BlockProtocol (HardForkBlock '[b])
+
+{-------------------------------------------------------------------------------
+  Data family instances
+-------------------------------------------------------------------------------}
+
+instance SingleEraBlock b => GetHeader (DegenFork b) where
+  newtype Header (DegenFork b) = DHdr {
+        unDHdr :: Header (HardForkBlock '[b])
+      }
+    deriving (Show, NoUnexpectedThunks)
+
+  getHeader (DBlk b) = DHdr (getHeader b)
+
+newtype instance CodecConfig (DegenFork b) = DCCfg {
+      unDCCfg :: CodecConfig (HardForkBlock '[b])
+    }
+
+newtype instance BlockConfig (DegenFork b) = DBCfg {
+      unDBCfg :: BlockConfig (HardForkBlock '[b])
+    }
+  deriving (NoUnexpectedThunks)
+
+newtype instance LedgerState (DegenFork b) = DLgr {
+      unDLgr :: LedgerState (HardForkBlock '[b])
+    }
+  deriving (Eq, Show, NoUnexpectedThunks)
+
+instance SingleEraBlock b => BlockHasCodecConfig (DegenFork b) where
+  getCodecConfig = DCCfg . getCodecConfig . unDBCfg
+
+{-------------------------------------------------------------------------------
+  Forward HasHeader instances
+-------------------------------------------------------------------------------}
+
+type instance HeaderHash (DegenFork b) = HeaderHash (HardForkBlock '[b])
+
+instance SingleEraBlock b => StandardHash (DegenFork b)
+
+instance SingleEraBlock b => Measured BlockMeasure (DegenFork b) where
+  measure = blockMeasure
+
+instance SingleEraBlock b => HasHeader (DegenFork b) where
+    blockHash      =            blockHash     . unDBlk
+    blockPrevHash  = castHash . blockPrevHash . unDBlk
+    blockSlot      =            blockSlot     . unDBlk
+    blockNo        =            blockNo       . unDBlk
+
+    blockInvariant = const True
+
+instance SingleEraBlock b => HasHeader (Header (DegenFork b)) where
+  blockHash      =            blockHash     . unDHdr
+  blockPrevHash  = castHash . blockPrevHash . unDHdr
+  blockSlot      =            blockSlot     . unDHdr
+  blockNo        =            blockNo       . unDHdr
+  blockInvariant = const True
+
+{-------------------------------------------------------------------------------
+  Forward 'HardForkBlock' instances
+-------------------------------------------------------------------------------}
+
+type instance LedgerCfg (LedgerState (DegenFork b)) = LedgerCfg (LedgerState (HardForkBlock '[b]))
+
+instance SingleEraBlock b => IsLedger (LedgerState (DegenFork b)) where
+  type LedgerErr (LedgerState (DegenFork b)) = LedgerErr (LedgerState (HardForkBlock '[b]))
+
+  applyChainTick cfg slot (DLgr lgr) = DLgr <$> applyChainTick cfg slot lgr
+
+instance SingleEraBlock b => ApplyBlock (LedgerState (DegenFork b)) (DegenFork b) where
+  applyLedgerBlock cfg (DBlk b) (Ticked slot (DLgr lgr)) =
+    DLgr <$> applyLedgerBlock cfg b (Ticked slot lgr)
+  reapplyLedgerBlock cfg (DBlk b) (Ticked slot (DLgr lgr)) =
+    DLgr $ reapplyLedgerBlock cfg b (Ticked slot lgr)
+  ledgerTipPoint (DLgr l) =
+    (castPoint :: Point (HardForkBlock '[b]) -> Point (DegenFork b)) $ ledgerTipPoint l
+
+instance SingleEraBlock b => UpdateLedger (DegenFork b)
+
+instance SingleEraBlock b => HasHardForkHistory (DegenFork b) where
+  type HardForkIndices (DegenFork b) = '[b]
+
+  hardForkSummary start cfg (DLgr lgr) = hardForkSummary start cfg lgr
+
+instance SingleEraBlock b => HasAnnTip (DegenFork b) where
+  type TipInfo (DegenFork b) = TipInfo (HardForkBlock '[b])
+
+  tipInfoHash _ = tipInfoHash (Proxy @(HardForkBlock '[b]))
+  getTipInfo (DHdr hdr) = getTipInfo hdr
+
+instance SingleEraBlock b => BasicEnvelopeValidation (DegenFork b) where
+  expectedFirstBlockNo  _ = expectedFirstBlockNo  (Proxy @b)
+  minimumPossibleSlotNo _ = minimumPossibleSlotNo (Proxy @b)
+  expectedNextBlockNo   _ = expectedNextBlockNo   (Proxy @b) `on` projTipInfo
+  minimumNextSlotNo     _ = minimumNextSlotNo     (Proxy @b) `on` projTipInfo
+
+  checkPrevHash (DBCfg cfg) =
+      checkPrevHash (projBlockConfig cfg) `on` projHeaderHash
+
+instance SingleEraBlock b => ValidateEnvelope (DegenFork b) where
+  type OtherHeaderEnvelopeError (DegenFork b) = OtherHeaderEnvelopeError (HardForkBlock '[b])
+
+  additionalEnvelopeChecks cfg view (DHdr hdr) =
+      withExcept injEnvelopeErr $
+        additionalEnvelopeChecks
+          (projCfg cfg)
+          (projLedgerView (Proxy @b) <$> view)
+          (projHeader hdr)
+
+instance SingleEraBlock b => BlockSupportsProtocol (DegenFork b) where
+  validateView (DBCfg cfg) (DHdr hdr) = validateView cfg hdr
+  selectView   (DBCfg cfg) (DHdr hdr) = selectView   cfg hdr
+
+instance SingleEraBlock b => LedgerSupportsProtocol (DegenFork b) where
+  protocolLedgerView   cfg (DLgr lgr) = protocolLedgerView   cfg lgr
+  ledgerViewForecastAt cfg (DLgr lgr) = ledgerViewForecastAt cfg lgr
+
+instance SingleEraBlock b => ApplyTx (DegenFork b) where
+  newtype GenTx (DegenFork b) = DTx {
+        unDTx :: GenTx (HardForkBlock '[b])
+      }
+    deriving (Show, NoUnexpectedThunks)
+
+  type ApplyTxErr (DegenFork b) = ApplyTxErr (HardForkBlock '[b])
+
+  txInvariant = txInvariant . unDTx
+
+  applyTx cfg (DTx tx) (Ticked slot (DLgr lgr)) =
+    fmap DLgr <$> applyTx cfg tx (Ticked slot lgr)
+  reapplyTx cfg (DTx tx) (Ticked slot (DLgr lgr)) =
+    fmap DLgr <$> reapplyTx cfg tx (Ticked slot lgr)
+
+instance SingleEraBlock b => HasTxId (GenTx (DegenFork b)) where
+  newtype TxId (GenTx (DegenFork b)) = DTxId {
+        unDTxId :: TxId (GenTx (HardForkBlock '[b]))
+      }
+    deriving (Show, Eq, Ord, NoUnexpectedThunks)
+
+  txId (DTx tx) = DTxId (txId tx)
+
+instance SingleEraBlock b => ShowQuery (Query (DegenFork b)) where
+  showResult (DQry qry) = showResult qry
+
+instance SingleEraBlock b => QueryLedger (DegenFork b) where
+  newtype Query (DegenFork b) result = DQry {
+        unDQry :: Query (HardForkBlock '[b]) result
+      }
+    deriving (Show)
+
+  answerQuery cfg (DQry qry) (DLgr lgr) = answerQuery cfg qry lgr
+  eqQuery (DQry qry1) (DQry qry2) = eqQuery qry1 qry2
+
+instance SingleEraBlock b => CanForge (DegenFork b) where
+  type ForgeState (DegenFork b) = ForgeState (HardForkBlock '[b])
+
+  forgeBlock cfg upd block (Ticked slot (DLgr lgr)) txs proof =
+      (DBlk . injBlock) <$>
+        forgeBlock
+          (projCfg cfg)
+          (projUpdateForgeState upd)
+          block
+          (Ticked slot (projLedgerState lgr))
+          (map (projGenTx . unDTx) txs)
+          (projIsLeader proof)
+
+instance HasTxs b => HasTxs (DegenFork b) where
+  extractTxs = map DTx . extractTxs . unDBlk
+
+{-------------------------------------------------------------------------------
+  RunNode instance
+
+  As discussed in the module header, for this we delegate to @b@, rather than
+  to @HardForkBlock '[b]@
+-------------------------------------------------------------------------------}
+
+projCfg :: SingleEraBlock b => TopLevelConfig (DegenFork b) -> TopLevelConfig b
+projCfg = projTopLevelConfig . castTopLevelConfig
+
+instance HasNetworkProtocolVersion b => HasNetworkProtocolVersion (DegenFork b) where
+  type NodeToNodeVersion   (DegenFork b) = NodeToNodeVersion   b
+  type NodeToClientVersion (DegenFork b) = NodeToClientVersion b
+
+  -- | Enumerate all supported node-to-node versions
+  supportedNodeToNodeVersions   _ = supportedNodeToNodeVersions   (Proxy @b)
+  supportedNodeToClientVersions _ = supportedNodeToClientVersions (Proxy @b)
+  mostRecentNodeToNodeVersion   _ = mostRecentNodeToNodeVersion   (Proxy @b)
+  mostRecentNodeToClientVersion _ = mostRecentNodeToClientVersion (Proxy @b)
+  nodeToNodeProtocolVersion     _ = nodeToNodeProtocolVersion     (Proxy @b)
+  nodeToClientProtocolVersion   _ = nodeToClientProtocolVersion   (Proxy @b)
+
+instance (SingleEraBlock b, RunNode b) => RunNode (DegenFork b) where
+  nodeBlockMatchesHeader (DHdr hdr) (DBlk blk) = nodeBlockMatchesHeader (projHeader hdr) (projBlock blk)
+  nodeBlockFetchSize     (DHdr hdr)            = nodeBlockFetchSize     (projHeader hdr)
+  nodeIsEBB              (DHdr hdr)            = nodeIsEBB              (projHeader hdr)
+
+  nodeImmDbChunkInfo  cfg = nodeImmDbChunkInfo  (projCfg cfg)
+  nodeStartTime       cfg = nodeStartTime       (projCfg cfg)
+  nodeNetworkMagic    cfg = nodeNetworkMagic    (projCfg cfg)
+  nodeProtocolMagicId cfg = nodeProtocolMagicId (projCfg cfg)
+
+  nodeHashInfo          _ = injHashInfo (nodeHashInfo (Proxy @b))
+  nodeAddHeaderEnvelope _ = nodeAddHeaderEnvelope (Proxy @b)
+  nodeExceptionIsFatal  _ = nodeExceptionIsFatal  (Proxy @b)
+
+  nodeInitChainDB cfg initDB =
+      nodeInitChainDB
+        (projCfg cfg)
+        (projInitChainDB (InitChainDB.cast initDB))
+
+  nodeMaxBlockSize          (DLgr lgr) = nodeMaxBlockSize          (projLedgerState lgr)
+  nodeBlockEncodingOverhead (DLgr lgr) = nodeBlockEncodingOverhead (projLedgerState lgr)
+  nodeMaxTxSize             (DLgr lgr) = nodeMaxTxSize             (projLedgerState lgr)
+
+  nodeCheckIntegrity cfg (DBlk blk) = nodeCheckIntegrity (projCfg cfg) (projBlock blk)
+
+  nodeTxInBlockSize (DTx tx) = nodeTxInBlockSize (projGenTx tx)
+
+  -- Encoders
+
+  nodeEncodeBlockWithInfo (DCCfg cfg) (DBlk blk) =
+      nodeEncodeBlockWithInfo (projCodecConfig cfg) (projBlock blk)
+  nodeEncodeBlock (DCCfg cfg) (DBlk blk) =
+      nodeEncodeBlock (projCodecConfig cfg) (projBlock blk)
+  nodeEncodeHeader (DCCfg cfg) version (DHdr hdr) =
+      nodeEncodeHeader (projCodecConfig cfg) (castSerialisationVersion version) (projHeader hdr)
+  nodeEncodeWrappedHeader (DCCfg cfg) version (Serialised hdr) =
+      nodeEncodeWrappedHeader (projCodecConfig cfg) (castSerialisationAcrossNetwork version) (Serialised hdr)
+  nodeEncodeGenTx (DTx tx) =
+      nodeEncodeGenTx (projGenTx tx)
+  nodeEncodeGenTxId (DTxId tid) =
+      nodeEncodeGenTxId (projGenTxId tid)
+  nodeEncodeHeaderHash _ hash =
+      nodeEncodeHeaderHash (Proxy @b) (projHeaderHash hash)
+  nodeEncodeLedgerState cfg (DLgr lgr) =
+      nodeEncodeLedgerState (projCfg cfg) (projLedgerState lgr)
+  nodeEncodeConsensusState cfg st =
+      nodeEncodeConsensusState (projCfg cfg) (projConsensusState st)
+  nodeEncodeApplyTxError _ err =
+      nodeEncodeApplyTxError (Proxy @b) (projApplyTxErr err)
+  nodeEncodeAnnTip _ tip =
+      nodeEncodeAnnTip (Proxy @b) (projAnnTip (castAnnTip tip))
+  nodeEncodeQuery (DQry qry) =
+      projQuery qry $ \_pf qry' -> nodeEncodeQuery qry'
+  nodeEncodeResult (DQry qry) mResult =
+      projQuery qry $ \Refl qry' ->
+        case mResult of
+          Right result -> nodeEncodeResult qry' result
+          Left  err    -> absurd $ mismatchOneEra err
+
+  -- Decoders
+
+  nodeDecodeBlock (DCCfg cfg) =
+      (\f -> DBlk . injBlock . f) <$>
+        nodeDecodeBlock (projCodecConfig cfg)
+  nodeDecodeHeader (DCCfg cfg) version =
+      (\f -> DHdr . injHeader . f) <$>
+        nodeDecodeHeader (projCodecConfig cfg) (castSerialisationVersion version)
+  nodeDecodeWrappedHeader (DCCfg cfg) version =
+      (\(Serialised hdr) -> Serialised hdr) <$>
+        nodeDecodeWrappedHeader (projCodecConfig cfg) (castSerialisationAcrossNetwork version)
+  nodeDecodeGenTx =
+      (DTx . injGenTx) <$>
+        nodeDecodeGenTx
+  nodeDecodeGenTxId =
+      (DTxId . injGenTxId) <$>
+        nodeDecodeGenTxId
+  nodeDecodeHeaderHash _ =
+      injHeaderHash <$>
+        nodeDecodeHeaderHash (Proxy @b)
+  nodeDecodeLedgerState cfg =
+      (DLgr . injLedgerState (nodeStartTime cfg)) <$>
+        nodeDecodeLedgerState cfg'
+    where
+      cfg' = projCfg cfg
+  nodeDecodeConsensusState cfg =
+      injConsensusState (nodeStartTime cfg) <$>
+        nodeDecodeConsensusState cfg'
+    where
+      cfg' = projCfg cfg
+  nodeDecodeApplyTxError _ =
+      injApplyTxErr <$>
+        nodeDecodeApplyTxError (Proxy @b)
+  nodeDecodeAnnTip _ =
+      (castAnnTip . injAnnTip) <$>
+        nodeDecodeAnnTip (Proxy @b)
+  nodeDecodeQuery =
+      (\(Some qry) -> Some (DQry $ injQuery qry)) <$>
+        nodeDecodeQuery
+  nodeDecodeResult (DQry qry) =
+      projQuery qry $ \Refl qry' ->
+        Right <$> nodeDecodeResult qry'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forge.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Ouroboros.Consensus.HardFork.Combinator.Forge (
+
+  ) where
+
+import           Crypto.Random (MonadRandom)
+import           Data.Coerce
+import           Data.Functor.Product
+import           Data.SOP.Strict
+
+import           Ouroboros.Consensus.Block.Forge
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Mempool.API
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Mempool
+import           Ouroboros.Consensus.HardFork.Combinator.Protocol ()
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import           Ouroboros.Consensus.HardFork.Combinator.Util.SOP
+
+instance (CanHardFork xs, All CanForge xs) => CanForge (HardForkBlock xs) where
+  type ForgeState (HardForkBlock xs) = PerEraForgeState xs
+
+  forgeBlock cfg updateForgeState blockNo
+             Ticked { tickedSlotNo, tickedLedgerState }
+             txs isLeader =
+      -- First establish the 'IsLeader' and the 'LedgerState' are from the
+      -- same era. As we have passed the ledger view of the ticked ledger to
+      -- obtain the 'IsLeader' value, it __must__ be from the same era.
+      case State.match
+             (getOneEraIsLeader isLeader)
+             (getHardForkLedgerState tickedLedgerState) of
+        Left _mismatch ->
+          error "IsLeader from different era than the TickedLedgerState"
+        Right matched  ->
+          -- Although we get a list with transactions that each could be from
+          -- a different era, we know they have been validated against the
+          -- 'LedgerState', which means they __must__ be from the same era.
+          fmap (HardForkBlock . OneEraBlock) $
+          hsequence $
+          hcpure (Proxy @CanForge) (fn_4 matchedForgeBlock)
+            `hap` (distribTopLevelConfig ei cfg)
+            `hap` (distribUpdateForgeState updateForgeState)
+            `hap` (partition_NS (map (getOneEraGenTx . getHardForkGenTx) txs))
+            `hap` (State.tip matched)
+    where
+      ei :: EpochInfo Identity
+      ei = State.epochInfoLedger
+             (configLedger cfg)
+             (getHardForkLedgerState tickedLedgerState)
+
+      -- | Unwraps all the layers needed for SOP and call 'forgeBlock'.
+      matchedForgeBlock
+        :: forall m blk. (MonadRandom m, CanForge blk)
+        => TopLevelConfig blk
+        -> (Update m :.: SingleEraForgeState) blk
+        -> ([] :.: GenTx) blk
+        -> Product SingleEraIsLeader LedgerState blk
+        -> m blk
+      matchedForgeBlock matchedCfg
+                        (Comp matchedForgeState)
+                        (Comp matchedTxs)
+                        (Pair matchedIsLeader matchedLedgerState) =
+          forgeBlock
+            matchedCfg
+            (coerceUpdate matchedForgeState)
+            blockNo
+            (Ticked tickedSlotNo matchedLedgerState)
+            matchedTxs
+            (getSingleEraIsLeader matchedIsLeader)
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+distribUpdateForgeState
+  :: forall xs m. SListI xs
+  => Update m (ForgeState (HardForkBlock xs))
+  -> NP (Update m :.: SingleEraForgeState) xs
+distribUpdateForgeState updateAll = hliftA (Comp . mkSingleEraUpdate) lenses_NP
+  where
+    mkSingleEraUpdate
+      :: Lens SingleEraForgeState xs blk
+      -> Update m (SingleEraForgeState blk)
+    mkSingleEraUpdate Lens { getter, setter } =
+        liftUpdate
+          (getter . coerce)
+          (coerce . setter)
+          updateAll

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -1,0 +1,390 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE EmptyCase             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Ledger (
+    HardForkEnvelopeErr(..)
+  ) where
+
+import           Control.Monad.Except
+import           Data.Functor.Product
+import           Data.SOP.Strict
+import           GHC.Generics (Generic)
+
+import           Cardano.Prelude (NoUnexpectedThunks)
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Network.Block
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Forecast
+import           Ouroboros.Consensus.HardFork.Abstract
+import qualified Ouroboros.Consensus.HardFork.History as History
+import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Protocol.Abstract
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Block
+import           Ouroboros.Consensus.HardFork.Combinator.Protocol ()
+import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
+                     (HardForkEraLedgerView (..), HardForkLedgerView,
+                     mkHardForkEraLedgerView)
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+import           Ouroboros.Consensus.HardFork.Combinator.State (Current (..),
+                     HardForkState_ (..), Past (..), Snapshot (..),
+                     TransitionOrTip (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import           Ouroboros.Consensus.HardFork.Combinator.Translation
+import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
+                     (InPairs (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Match as Match
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
+                     (Telescope (..))
+
+{-------------------------------------------------------------------------------
+  IsLedger
+-------------------------------------------------------------------------------}
+
+data HardForkLedgerError xs =
+    -- | Validation error from one of the eras
+    HardForkLedgerErrorFromEra (OneEraLedgerError xs)
+
+    -- | We tried to apply a block from the wrong era
+  | HardForkLedgerErrorWrongEra (MismatchEraInfo xs)
+  deriving (Generic, Show, Eq, NoUnexpectedThunks)
+
+instance CanHardFork xs => IsLedger (LedgerState (HardForkBlock xs)) where
+  type LedgerErr (LedgerState (HardForkBlock xs)) = HardForkLedgerError  xs
+
+  applyChainTick cfg@HardForkLedgerConfig{..} slot (HardForkLedgerState st) =
+        fmap HardForkLedgerState
+      . State.sequence
+      . hczipWith proxySingle (tickOne ei slot) cfgs
+      . State.extendToSlot cfg slot
+      $ st
+    where
+      cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
+      ei   = State.epochInfoLedger cfg st
+
+tickOne :: forall blk. SingleEraBlock blk
+        => EpochInfo Identity
+        -> SlotNo
+        -> SingleEraLedgerConfig      blk
+        -> LedgerState                blk
+        -> (Ticked :.: LedgerState)   blk
+tickOne ei slot pcfg st = Comp $
+    applyChainTick (completeLedgerConfig' ei pcfg) slot st
+
+{-------------------------------------------------------------------------------
+  ApplyBlock
+-------------------------------------------------------------------------------}
+
+instance CanHardFork xs
+      => ApplyBlock (LedgerState (HardForkBlock xs)) (HardForkBlock xs) where
+
+  applyLedgerBlock ledgerCfg@HardForkLedgerConfig{..}
+                   (HardForkBlock (OneEraBlock block))
+                   (Ticked slot (HardForkLedgerState st)) =
+      case State.match block (hmap (Comp . Ticked slot) st) of
+        Left mismatch ->
+          -- Block from the wrong era (note that 'applyChainTick' will already
+          -- have initiated the transition to the next era if appropriate).
+          throwError $ HardForkLedgerErrorWrongEra . MismatchEraInfo $
+                         Match.bihcmap proxySingle singleEraInfo ledgerInfo mismatch
+        Right matched ->
+          fmap (HardForkLedgerState . State.tickAllPast k) $ hsequence' $
+            hczipWith3 proxySingle (apply ei) cfgs injections matched
+    where
+      cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
+      k    = hardForkLedgerConfigK
+      ei   = State.epochInfoLedger ledgerCfg st
+
+  reapplyLedgerBlock ledgerCfg@HardForkLedgerConfig{..}
+                     (HardForkBlock (OneEraBlock block))
+                     (Ticked slot (HardForkLedgerState st)) =
+      case State.match block (hmap (Comp . Ticked slot) st) of
+        Left _mismatch ->
+          -- We already applied this block to this ledger state,
+          -- so it can't be from the wrong era
+          error "reapplyLedgerBlock: can't be from other era"
+        Right matched ->
+          HardForkLedgerState . State.tickAllPast k $
+            hczipWith proxySingle (reapply ei) cfgs matched
+    where
+      cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
+      k    = hardForkLedgerConfigK
+      ei   = State.epochInfoLedger ledgerCfg st
+
+  ledgerTipPoint =
+        castPoint
+      . distribPoint
+      . hcmap proxySingle ledgerTipPoint
+      . State.tip
+      . getHardForkLedgerState
+
+apply :: SingleEraBlock blk
+      => EpochInfo Identity
+      -> SingleEraLedgerConfig blk
+      -> Injection SingleEraLedgerError xs blk
+      -> Product I (Ticked :.: LedgerState) blk
+      -> (Except (HardForkLedgerError xs) :.: LedgerState) blk
+apply ei cfg injectErr (Pair (I block) (Comp st)) = Comp $
+    withExcept (injectLedgerError injectErr) $
+      applyLedgerBlock (completeLedgerConfig' ei cfg) block st
+
+reapply :: SingleEraBlock blk
+        => EpochInfo Identity
+        -> SingleEraLedgerConfig blk
+        -> Product I (Ticked :.: LedgerState) blk
+        -> LedgerState blk
+reapply ei cfg (Pair (I block) (Comp st)) =
+    reapplyLedgerBlock (completeLedgerConfig' ei cfg) block st
+
+{-------------------------------------------------------------------------------
+  UpdateLedger
+-------------------------------------------------------------------------------}
+
+instance CanHardFork xs => UpdateLedger (HardForkBlock xs)
+
+{-------------------------------------------------------------------------------
+  HasHardForkHistory
+-------------------------------------------------------------------------------}
+
+instance CanHardFork xs => HasHardForkHistory (HardForkBlock xs) where
+  type HardForkIndices (HardForkBlock xs) = xs
+
+  -- We can ignore the system start, because the 'SystemStart' of the first
+  -- era is already known from the 'Bound's embedded in the 'HardForkState'.
+  hardForkSummary _start cfg = State.reconstructSummaryLedger cfg
+                             . getHardForkLedgerState
+
+{-------------------------------------------------------------------------------
+  HeaderValidation
+-------------------------------------------------------------------------------}
+
+data HardForkEnvelopeErr xs =
+    -- | Validation error from one of the eras
+    HardForkEnvelopeErrFromEra (OneEraEnvelopeErr xs)
+
+    -- | We tried to apply a block from the wrong era
+  | HardForkEnvelopeErrWrongEra (MismatchEraInfo xs)
+  deriving (Eq, Show, Generic, NoUnexpectedThunks)
+
+instance CanHardFork xs => ValidateEnvelope (HardForkBlock xs) where
+  type OtherHeaderEnvelopeError (HardForkBlock xs) = HardForkEnvelopeErr xs
+
+  additionalEnvelopeChecks tlc
+                           (Ticked slot hardForkView) =
+                          \(HardForkHeader (OneEraHeader hdr)) ->
+      case Match.matchNS hdr (hmap (Comp . Ticked slot) (State.tip hardForkView)) of
+        Left mismatch ->
+          throwError $
+            HardForkEnvelopeErrWrongEra . MismatchEraInfo $
+              Match.bihcmap proxySingle singleEraInfo ledgerViewInfo mismatch
+        Right matched ->
+          hcollapse $ hczipWith3 proxySingle aux cfgs injections matched
+    where
+      ei :: EpochInfo Identity
+      ei = State.epochInfoLedgerView
+             (hardForkLedgerConfigShape $ configLedger tlc)
+             hardForkView
+
+      cfgs :: NP TopLevelConfig xs
+      cfgs = distribTopLevelConfig ei tlc
+
+      aux :: forall blk. SingleEraBlock blk
+          => TopLevelConfig blk
+          -> Injection SingleEraEnvelopeErr xs blk
+          -> Product Header (Ticked :.: HardForkEraLedgerView) blk
+          -> K (Except (HardForkEnvelopeErr xs) ()) blk
+      aux cfg injErr (Pair hdr (Comp view)) = K $
+          withExcept injErr' $
+            additionalEnvelopeChecks cfg (hardForkEraLedgerView <$> view) hdr
+        where
+          injErr' :: OtherHeaderEnvelopeError blk -> HardForkEnvelopeErr xs
+          injErr' = HardForkEnvelopeErrFromEra
+                  . OneEraEnvelopeErr
+                  . unK . apFn injErr
+                  . SingleEraEnvelopeErr
+
+{-------------------------------------------------------------------------------
+  LedgerSupportsProtocol
+-------------------------------------------------------------------------------}
+
+instance CanHardFork xs => LedgerSupportsProtocol (HardForkBlock xs) where
+  protocolLedgerView ledgerCfg@HardForkLedgerConfig{..} (HardForkLedgerState st) =
+      State.bihczipWith (\_ _ -> K ()) (mkHardForkEraLedgerView ei) cfgs st
+    where
+      cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
+      ei   = State.epochInfoLedger ledgerCfg st
+
+  ledgerViewForecastAt ledgerCfg@HardForkLedgerConfig{..} (HardForkLedgerState st) p = do
+      st' <- State.retractToSlot p st
+      f   <- hsequence' $ hczipWith proxySingle forecastOne cfgs st'
+      return $ mkForecast
+                 (translateLedgerView hardForkEraTranslation)
+                 cfgs
+                 (getHardForkState f)
+    where
+      cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
+      ei   = State.epochInfoLedger ledgerCfg st
+
+      -- Change a telescope of a forecast into a forecast of a telescope
+      mkForecast :: All SingleEraBlock xs'
+                 => InPairs TranslateEraLedgerView xs'
+                 -> NP SingleEraLedgerConfig xs'
+                 -> Telescope (Past g) (Current (Forecast :.: HardForkEraLedgerView)) xs'
+                 -> Forecast (HardForkLedgerView xs')
+      mkForecast PNil _ (TZ (Current start (Comp f))) =
+          forecastFinalEra start f
+      mkForecast (PCons g _) (cfg :* cfg' :* _) (TZ (Current start f)) =
+          forecastNotFinal g cfg cfg' start (unComp f)
+      mkForecast (PCons _ gs) (_ :* cfgs') (TS past f) =
+          shiftView past <$> mkForecast gs cfgs' f
+      mkForecast PNil _ (TS _ f) =
+          case f of {}
+
+      shiftView :: Past g blk
+                -> HardForkLedgerView (blk' : blks)
+                -> HardForkLedgerView (blk : blk' : blks)
+      shiftView past =
+            HardForkState
+          . TS (past { pastSnapshot = NoSnapshot })
+          . getHardForkState
+
+      -- We're in the final era. No translation required
+      forecastFinalEra :: History.Bound
+                       -> Forecast (HardForkEraLedgerView blk)
+                       -> Forecast (HardForkLedgerView '[blk])
+      forecastFinalEra start f =
+          Forecast (forecastAt f) $ \slot ->
+            aux <$> forecastFor f slot
+        where
+          aux :: HardForkEraLedgerView blk -> HardForkLedgerView '[blk]
+          aux = HardForkState . TZ . Current start
+
+      -- Make forecast with potential need to translate to next era
+      --
+      -- NOTE 1: It is possible that we had to go to a previous era to get this
+      -- forecast (point @p@ might not have been in the current era). If that is
+      -- the case, the forecast should nonetheless be anchored in that previous
+      -- era, /and not have any knowledge of anything that happened in current
+      -- era/. Therefore, we take the forecast from that previous era, apply it
+      -- as normal, and only /then/ translate to the next era if appropriate.
+      --
+      -- NOTE 2: If we did have to go to a previous era to get a forecast, then
+      -- that ledger must certainly have been aware of the transition.
+      --
+      -- NOTE 3: We assume that we only ever have to translate to the /next/
+      -- era (as opposed to /any/ subsequent era).
+      forecastNotFinal :: forall blk blk' blks.
+                          (SingleEraBlock blk, SingleEraBlock blk')
+                       => TranslateEraLedgerView blk blk'
+                       -> SingleEraLedgerConfig blk
+                       -> SingleEraLedgerConfig blk'
+                       -> History.Bound     -- Forecast era start
+                       -> Forecast (HardForkEraLedgerView blk)
+                       -> Forecast (HardForkLedgerView (blk ': blk' ': blks))
+      forecastNotFinal g pcfg pcfg' start f =
+          Forecast (forecastAt f) $ \slot ->
+            translateIf slot <$> forecastFor f slot
+        where
+          cfg  :: LedgerConfig blk
+          cfg' :: LedgerConfig blk'
+          cfg  = completeLedgerConfig' ei pcfg
+          cfg' = completeLedgerConfig' ei pcfg'
+
+          -- Translate if the slot is past the end of the epoch
+          translateIf :: SlotNo
+                      -> HardForkEraLedgerView blk
+                      -> HardForkLedgerView (blk ': blk' ': blks)
+          translateIf slot view = HardForkState $
+            case hardForkEraTransition view of
+              TransitionAt tip epoch ->
+                let end = History.mkUpperBound
+                            (singleEraParams' pcfg)
+                            start
+                            epoch
+                in if slot >= History.boundSlot end then
+                     let view' :: HardForkEraLedgerView blk'
+                         view' = HardForkEraLedgerView {
+                                     hardForkEraLedgerView =
+                                       translateLedgerViewWith g
+                                         cfg
+                                         cfg'
+                                         (History.boundEpoch end)
+                                         (hardForkEraLedgerView view)
+                                   , hardForkEraTransition =
+                                       -- We don't know the transition to the
+                                       -- /next/ era, and it's important that
+                                       -- any safe zones are applied to the
+                                       -- tip in the /previous/ era.
+                                       LedgerTip tip
+                                   }
+                     in TS (Past start end NoSnapshot) $
+                        TZ (Current end view')
+                   else
+                     TZ (Current end view)
+              LedgerTip _tip ->
+                -- End of the era is not yet known. We don't have to worry about
+                -- the safe zone here, because we are limited by whatever the
+                -- range of the forecast is for this era.
+                TZ (Current start view)
+
+      -- | Forecast of a single era, as well as the end of that era (if any)
+      forecastOne :: SingleEraBlock blk
+                  => SingleEraLedgerConfig blk
+                  -> LedgerState blk
+                  -> (Maybe :.: (Forecast :.: HardForkEraLedgerView)) blk
+      forecastOne pcfg st' = Comp $
+          (Comp . fmap mkView) <$>
+            ledgerViewForecastAt (completeLedgerConfig' ei pcfg) st' p
+        where
+          transition :: TransitionOrTip
+          transition = State.transitionOrTip pcfg st'
+
+          -- See comment of 'hardForkEraTransition' for justification of the
+          -- use of @st'@ to determine the transition/tip.
+          mkView :: LedgerView (BlockProtocol blk)
+                 -> HardForkEraLedgerView blk
+          mkView view = HardForkEraLedgerView {
+                hardForkEraTransition = transition
+              , hardForkEraLedgerView = view
+              }
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+ledgerInfo :: forall blk. SingleEraBlock blk
+           => Current (Ticked :.: LedgerState) blk -> LedgerEraInfo blk
+ledgerInfo _ = LedgerEraInfo $ singleEraInfo (Proxy @blk)
+
+ledgerViewInfo :: forall blk. SingleEraBlock blk
+               => (Ticked :.: HardForkEraLedgerView) blk -> LedgerEraInfo blk
+ledgerViewInfo _ = LedgerEraInfo $ singleEraInfo (Proxy @blk)
+
+injectLedgerError :: Injection SingleEraLedgerError xs blk
+                  -> LedgerError blk
+                  -> HardForkLedgerError xs
+injectLedgerError inj =
+      HardForkLedgerErrorFromEra
+    . OneEraLedgerError
+    . unK
+    . apFn inj
+    . SingleEraLedgerError

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Ledger.Query (
+    Query(..)
+  , HardForkQuery(..)
+  , HardForkQueryResult
+  , getHardForkQuery
+  ) where
+
+import           Data.Bifunctor
+import           Data.Functor.Product
+import           Data.Proxy
+import           Data.SOP.Strict
+import           Data.Type.Equality
+
+import           Ouroboros.Consensus.Ledger.Abstract
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger ()
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Match
+                     (Mismatch (..))
+
+instance CanHardFork xs => ShowQuery (Query (HardForkBlock xs)) where
+  showResult = \(HardForkQuery qry) mResult ->
+      case mResult of
+        Left  err    -> show err
+        Right result -> go qry result
+    where
+      go :: All SingleEraBlock xs'
+         => HardForkQuery xs' result -> result -> String
+      go (QZ qry) = showResult qry
+      go (QS qry) = go qry
+
+type HardForkQueryResult xs = Either (MismatchEraInfo xs)
+
+instance CanHardFork xs => QueryLedger (HardForkBlock xs) where
+  data Query (HardForkBlock xs) :: * -> * where
+    HardForkQuery :: HardForkQuery xs result
+                  -> Query (HardForkBlock xs) (HardForkQueryResult xs result)
+
+  answerQuery hardForkConfig@HardForkLedgerConfig{..}
+              (HardForkQuery hardForkQuery)
+              (HardForkLedgerState hardForkState) =
+      go hardForkQuery (hzipWith Pair cfgs (State.tip hardForkState))
+    where
+      cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
+      ei   = State.epochInfoLedger hardForkConfig hardForkState
+
+      go :: All SingleEraBlock xs'
+         => HardForkQuery xs' result
+         -> NS (Product SingleEraLedgerConfig LedgerState) xs'
+         -> HardForkQueryResult xs' result
+      go (QZ qry) (Z (Pair cfg st)) =
+          Right $ answerQuery (completeLedgerConfig' ei cfg) qry st
+      go (QS qry) (S st) =
+          first shiftMismatch $ go qry st
+      go (QZ qry) (S st) =
+          Left $ MismatchEraInfo $ ML (queryInfo qry) (hcmap proxySingle ledgerInfo st)
+      go (QS qry) (Z st) =
+          Left $ MismatchEraInfo $ MR (hardForkQueryInfo qry) (ledgerInfo st)
+
+  eqQuery = \(HardForkQuery qry) (HardForkQuery qry') ->
+      -- Lift the type equality to the @Either@
+      case go qry qry' of
+        Nothing   -> Nothing
+        Just Refl -> Just Refl
+    where
+      go :: All SingleEraBlock xs'
+         => HardForkQuery xs' result
+         -> HardForkQuery xs' result'
+         -> Maybe (result :~: result')
+      go (QZ qry) (QZ qry') = eqQuery qry qry'
+      go (QS qry) (QS qry') = go qry qry'
+      go _        _         = Nothing
+
+deriving instance CanHardFork xs => Show (Query (HardForkBlock xs) result)
+
+getHardForkQuery :: Query (HardForkBlock xs) (HardForkQueryResult xs result)
+                 -> HardForkQuery xs result
+getHardForkQuery (HardForkQuery qry) = qry
+
+{-------------------------------------------------------------------------------
+  Queries
+-------------------------------------------------------------------------------}
+
+data HardForkQuery :: [*] -> * -> * where
+  QZ :: Query x result          -> HardForkQuery (x ': xs) result
+  QS :: HardForkQuery xs result -> HardForkQuery (x ': xs) result
+
+deriving instance All SingleEraBlock xs => Show (HardForkQuery xs result)
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+ledgerInfo :: forall blk. SingleEraBlock blk
+           => Product SingleEraLedgerConfig LedgerState blk
+           -> LedgerEraInfo blk
+ledgerInfo _ = LedgerEraInfo $ singleEraInfo (Proxy @blk)
+
+queryInfo :: forall blk result. SingleEraBlock blk
+          => Query blk result -> SingleEraInfo blk
+queryInfo _ = singleEraInfo (Proxy @blk)
+
+hardForkQueryInfo :: All SingleEraBlock xs
+                  => HardForkQuery xs result -> NS SingleEraInfo xs
+hardForkQueryInfo = go
+  where
+    go :: All SingleEraBlock xs'
+       => HardForkQuery xs' result -> NS SingleEraInfo xs'
+    go (QZ qry) = Z (queryInfo qry)
+    go (QS qry) = S (go qry)
+
+shiftMismatch :: MismatchEraInfo xs -> MismatchEraInfo (x ': xs)
+shiftMismatch = MismatchEraInfo . MS . getMismatchEraInfo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Mempool (
+    HardForkApplyTxErr(..)
+  , GenTx(..)
+  , TxId(..)
+  ) where
+
+import           Control.Monad.Except
+import           Data.Functor.Product
+import           Data.SOP.Strict
+import           GHC.Generics (Generic)
+import           GHC.Stack (HasCallStack)
+
+import           Cardano.Prelude (NoUnexpectedThunks)
+
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Mempool.API
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger ()
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Match as Match
+
+data HardForkApplyTxErr xs =
+    -- | Validation error from one of the eras
+    HardForkApplyTxErrFromEra !(OneEraApplyTxErr xs)
+
+    -- | We tried to apply a block from the wrong era
+  | HardForkApplyTxErrWrongEra !(MismatchEraInfo xs)
+  deriving (Generic)
+
+deriving stock instance CanHardFork xs => Show (HardForkApplyTxErr xs)
+
+instance CanHardFork xs => ApplyTx (HardForkBlock xs) where
+  newtype GenTx (HardForkBlock xs) = HardForkGenTx {
+        getHardForkGenTx :: OneEraGenTx xs
+      }
+    deriving (Show, NoUnexpectedThunks)
+
+  type ApplyTxErr (HardForkBlock xs) = HardForkApplyTxErr xs
+
+  applyTx   = applyHelper applyTx
+  reapplyTx = applyHelper reapplyTx
+
+applyHelper
+  :: forall xs. CanHardFork xs
+  => (    forall blk. (SingleEraBlock blk, HasCallStack)
+       => LedgerConfig blk
+       -> GenTx blk
+       -> TickedLedgerState blk
+       -> Except (ApplyTxErr blk) (TickedLedgerState blk)
+     )
+  -> LedgerConfig (HardForkBlock xs)
+  -> GenTx (HardForkBlock xs)
+  -> TickedLedgerState (HardForkBlock xs)
+  -> Except (HardForkApplyTxErr xs) (TickedLedgerState (HardForkBlock xs))
+applyHelper apply
+            hardForkConfig@HardForkLedgerConfig{..}
+            (HardForkGenTx (OneEraGenTx hardForkTx))
+            (Ticked slot (HardForkLedgerState hardForkState)) =
+    case State.match hardForkTx (hmap (Comp . Ticked slot) hardForkState) of
+      Left mismatch ->
+        throwError $ HardForkApplyTxErrWrongEra . MismatchEraInfo $
+          Match.bihcmap proxySingle singleEraInfo ledgerInfo mismatch
+      Right matched ->
+        fmap (fmap HardForkLedgerState . State.sequence) $ hsequence' $
+          hczipWith3 proxySingle applyCurrent cfgs injections matched
+  where
+    cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
+    ei   = State.epochInfoLedger hardForkConfig hardForkState
+
+    applyCurrent
+      :: forall blk. SingleEraBlock blk
+      => SingleEraLedgerConfig blk
+      -> Injection SingleEraApplyTxErr xs blk
+      -> Product GenTx (Ticked :.: LedgerState) blk
+      -> (Except (HardForkApplyTxErr xs) :.: (Ticked :.: LedgerState)) blk
+    applyCurrent cfg injectErr (Pair tx (Comp st)) = Comp $ fmap Comp $
+      withExcept (injectApplyTxErr injectErr) $
+        apply (completeLedgerConfig' ei cfg) tx st
+
+instance CanHardFork xs => HasTxId (GenTx (HardForkBlock xs)) where
+  newtype TxId (GenTx (HardForkBlock xs)) = HardForkGenTxId {
+        getHardForkGenTxId :: OneEraGenTxId xs
+      }
+    deriving (Show, Eq, Ord, NoUnexpectedThunks)
+
+  txId = HardForkGenTxId . OneEraGenTxId
+       . hcmap proxySingle (SingleEraGenTxId . txId)
+       . getOneEraGenTx . getHardForkGenTx
+
+{-------------------------------------------------------------------------------
+  HasTxs
+
+  This is not required by consensus itself, but is required by RunNode.
+-------------------------------------------------------------------------------}
+
+instance All HasTxs xs => HasTxs (HardForkBlock xs) where
+  extractTxs =
+        hcollapse
+      . hzipWith (\inj -> K . map (mkTx inj) . unComp) injections
+      . hcmap (Proxy @HasTxs) (Comp . extractTxs . unI)
+      . getOneEraBlock
+      . getHardForkBlock
+    where
+      mkTx :: Injection GenTx xs blk -> GenTx blk -> GenTx (HardForkBlock xs)
+      mkTx inj = HardForkGenTx . OneEraGenTx . unK . apFn inj
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+ledgerInfo :: forall blk. SingleEraBlock blk
+           => State.Current (Ticked :.: LedgerState) blk -> LedgerEraInfo blk
+ledgerInfo _ = LedgerEraInfo $ singleEraInfo (Proxy @blk)
+
+injectApplyTxErr :: Injection SingleEraApplyTxErr xs blk
+                 -> ApplyTxErr blk
+                 -> HardForkApplyTxErr xs
+injectApplyTxErr inj =
+      HardForkApplyTxErrFromEra
+    . OneEraApplyTxErr
+    . unK
+    . apFn inj
+    . SingleEraApplyTxErr

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Protocol (
+    -- * Re-exports to keep 'Protocol.State' an internal module
+    HardForkConsensusState
+  , HardForkValidationErr(..)
+    -- * Re-exports to keep 'Protocol.LedgerView' an internal module
+  , HardForkLedgerView
+  , HardForkEraLedgerView(..)
+  , mkHardForkEraLedgerView
+  ) where
+
+import           Data.SOP.Strict
+
+import           Ouroboros.Network.Block
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util ((.:))
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Block
+import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+import           Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
+                     (HardForkSelectView (..))
+import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
+                     (HardForkEraLedgerView (..), HardForkLedgerView,
+                     mkHardForkEraLedgerView)
+import           Ouroboros.Consensus.HardFork.Combinator.Protocol.State
+                     (HardForkConsensusState, HardForkValidationErr)
+import qualified Ouroboros.Consensus.HardFork.Combinator.Protocol.State as ProtocolState
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+
+{-------------------------------------------------------------------------------
+  ConsensusProtocol
+-------------------------------------------------------------------------------}
+
+instance CanHardFork xs => ConsensusProtocol (HardForkProtocol xs) where
+  type ConsensusState (HardForkProtocol xs) = HardForkConsensusState xs
+  type ValidationErr  (HardForkProtocol xs) = HardForkValidationErr  xs
+  type LedgerView     (HardForkProtocol xs) = HardForkLedgerView     xs
+  type IsLeader       (HardForkProtocol xs) = OneEraIsLeader         xs
+  type ValidateView   (HardForkProtocol xs) = OneEraValidateView     xs
+
+  -- Operations on the state
+
+  checkIsLeader          = ProtocolState.check
+  updateConsensusState   = ProtocolState.update
+  rewindConsensusState _ = ProtocolState.rewind
+
+  --
+  -- Straight-forward extensions
+  --
+
+  -- We can be a leader if we can be a leader in /any/ era
+  checkIfCanBeLeader =
+        or
+      . hcollapse
+      . hcmap proxySingle (K . aux)
+      . getPerEraConsensusConfig
+      . hardForkConsensusConfigPerEra
+    where
+      aux :: forall blk. SingleEraBlock blk
+          => SingleEraConsensusConfig blk -> Bool
+      aux = partialCheckIfCanBeLeader (Proxy @(BlockProtocol blk))
+          . getSingleEraConsensusConfig
+
+  -- Security parameter must be equal across /all/ eras
+  protocolSecurityParam = hardForkConsensusConfigK
+
+  -- Extract 'ChainSelConfig'
+  chainSelConfig =
+        PerEraChainSelConfig
+      . hcmap proxySingle aux
+      . getPerEraConsensusConfig
+      . hardForkConsensusConfigPerEra
+    where
+      aux :: forall blk. SingleEraBlock blk
+          => SingleEraConsensusConfig blk -> SingleEraChainSelConfig blk
+      aux = SingleEraChainSelConfig
+          . partialChainSelConfig (Proxy @(BlockProtocol blk))
+          . getSingleEraConsensusConfig
+
+{-------------------------------------------------------------------------------
+  BlockSupportsProtocol
+-------------------------------------------------------------------------------}
+
+instance CanHardFork xs => BlockSupportsProtocol (HardForkBlock xs) where
+  validateView HardForkBlockConfig{..} =
+        OneEraValidateView
+      . hczipWith proxySingle (SingleEraValidateView .: validateView) cfgs
+      . getOneEraHeader
+      . getHardForkHeader
+    where
+      cfgs = getPerEraBlockConfig hardForkBlockConfigPerEra
+
+  selectView HardForkBlockConfig{..} hdr =
+        HardForkSelectView (blockNo hdr)
+      . OneEraSelectView
+      . hczipWith proxySingle (SingleEraSelectView .: selectView) cfgs
+      . getOneEraHeader
+      $ getHardForkHeader hdr
+    where
+      cfgs = getPerEraBlockConfig hardForkBlockConfigPerEra

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- Intended for qualified import
+--
+-- > import Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel (HardForkSelectView(..))
+-- > import qualified Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel as ChainSel
+module Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel (
+    HardForkSelectView(..)
+  ) where
+
+import           Data.Functor.Product
+import           Data.SOP.Strict
+
+import           Cardano.Slotting.Block
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util ((.:))
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Match
+
+data HardForkSelectView xs = HardForkSelectView {
+      hardForkSelectViewBlockNo :: BlockNo
+    , hardForkSelectViewOneEra  :: OneEraSelectView xs
+    }
+
+-- | Chain selection across eras
+--
+-- TODO: If the two chains are from different eras, we simply pick the longer
+-- one. This may not be okay for all hard fork transitions; we might need to
+-- generalize this later.
+instance CanHardFork xs => ChainSelection (HardForkProtocol xs) where
+  type ChainSelConfig (HardForkProtocol xs) = PerEraChainSelConfig xs
+  type SelectView     (HardForkProtocol xs) = HardForkSelectView   xs
+
+  -- We leave 'preferCandidate' at the default
+
+  compareCandidates _ (PerEraChainSelConfig cfgs) =
+      either (uncurry different) same .: matchView
+    where
+      -- If the two views are from the same era, just use 'compareCandidates'
+      same :: NS (Product SingleEraSelectView SingleEraSelectView) xs -> Ordering
+      same = hcollapse . hczipWith proxySingle compareCandidates' cfgs
+
+      -- If the two tips are in different eras, just compare chain length
+      different :: BlockNo -> BlockNo -> Ordering
+      different = Prelude.compare
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+compareCandidates' :: forall blk. SingleEraBlock blk
+                   => SingleEraChainSelConfig blk
+                   -> Product SingleEraSelectView SingleEraSelectView blk
+                   -> K Ordering blk
+compareCandidates' (SingleEraChainSelConfig cfg)
+                   (Pair (SingleEraSelectView view1)
+                         (SingleEraSelectView view2)) = K $
+    compareCandidates (Proxy @(BlockProtocol blk)) cfg view1 view2
+
+matchView :: HardForkSelectView xs
+          -> HardForkSelectView xs
+          -> Either (BlockNo, BlockNo)
+                    (NS (Product SingleEraSelectView SingleEraSelectView) xs)
+matchView cand1 cand2 =
+    case matchNS (getOneEraSelectView $ hardForkSelectViewOneEra cand1)
+                 (getOneEraSelectView $ hardForkSelectViewOneEra cand2) of
+      Right matched  -> Right matched
+      Left _mismatch -> Left  ( hardForkSelectViewBlockNo cand1
+                              , hardForkSelectViewBlockNo cand2
+                              )

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/LedgerView.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/LedgerView.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView (
+    -- * Single era
+    HardForkEraLedgerView(..)
+  , mkHardForkEraLedgerView
+    -- * Hard fork
+  , HardForkLedgerView
+  ) where
+
+import           Data.SOP.Strict
+
+import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Protocol.Abstract
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+import           Ouroboros.Consensus.HardFork.Combinator.State.Infra
+                     (HardForkState_, TransitionOrTip (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.State.Infra as State
+
+{-------------------------------------------------------------------------------
+  Ledger view for single era
+-------------------------------------------------------------------------------}
+
+data HardForkEraLedgerView blk = HardForkEraLedgerView {
+      -- | Transition to the next era or the tip of the ledger otherwise
+      --
+      -- NOTE: When forecasting a view, this is set to the /actual/ tip of the
+      -- ledger, not the forecast slot number. It is this tip that determines
+      -- where the safe zone starts, and that should not vary with the slot
+      -- of the forecast.
+      --
+      -- Indeed, it is even possible that this tip is in a /previous/ era.
+      hardForkEraTransition :: !TransitionOrTip
+
+      -- | Underlying ledger view
+    , hardForkEraLedgerView :: !(LedgerView (BlockProtocol blk))
+    }
+
+deriving instance SingleEraBlock blk => Show (HardForkEraLedgerView blk)
+
+mkHardForkEraLedgerView :: SingleEraBlock blk
+                        => EpochInfo Identity
+                        -> SingleEraLedgerConfig blk
+                        -> LedgerState blk
+                        -> HardForkEraLedgerView blk
+mkHardForkEraLedgerView ei pcfg st = HardForkEraLedgerView {
+      hardForkEraLedgerView = protocolLedgerView (completeLedgerConfig' ei pcfg) st
+    , hardForkEraTransition = State.transitionOrTip pcfg st
+    }
+
+{-------------------------------------------------------------------------------
+  HardForkLedgerView
+-------------------------------------------------------------------------------}
+
+type HardForkLedgerView xs = HardForkState_ (K ()) HardForkEraLedgerView xs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/State.hs
@@ -1,0 +1,230 @@
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving  #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+-- | Intended for qualified import
+--
+-- > import Ouroboros.Consensus.HardFork.Combinator.Protocol.State (HardForkConsensusState)
+-- > import qualified Ouroboros.Consensus.HardFork.Combinator.Protocol.State as ProtocolState
+module Ouroboros.Consensus.HardFork.Combinator.Protocol.State (
+    HardForkConsensusState
+  , HardForkValidationErr(..)
+    -- * Update the state
+  , check
+  , rewind
+  , update
+  ) where
+
+import           Codec.Serialise (Serialise)
+import           Control.Monad.Except
+import           Crypto.Random (MonadRandom)
+import           Data.Functor.Product
+import           Data.SOP.Strict
+import           GHC.Generics (Generic)
+
+import           Ouroboros.Network.Block
+
+import           Cardano.Prelude (NoUnexpectedThunks)
+
+import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util ((.:))
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+import           Ouroboros.Consensus.HardFork.Combinator.State (HardForkState,
+                     Translate (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import           Ouroboros.Consensus.HardFork.Combinator.Translation
+import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
+                     (InPairs (..), RequiringBoth (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Match as Match
+
+{-------------------------------------------------------------------------------
+  Types
+-------------------------------------------------------------------------------}
+
+type HardForkConsensusState xs = HardForkState SingleEraConsensusState xs
+
+data HardForkValidationErr xs =
+    -- | Validation error from one of the eras
+    HardForkValidationErrFromEra (OneEraValidationErr xs)
+
+    -- | We tried to apply a block from the wrong era
+  | HardForkValidationErrWrongEra (MismatchEraInfo xs)
+  deriving (Generic)
+
+{-------------------------------------------------------------------------------
+  Leader check
+
+  NOTE: The precondition to `align` is satisfied: the consensus state will never
+  be ahead (but possibly behind) the ledger state, which we tick first.
+-------------------------------------------------------------------------------}
+
+check :: forall m xs. (MonadRandom m, CanHardFork xs)
+      => ConsensusConfig (HardForkProtocol xs)
+      -> Ticked (HardForkLedgerView xs)
+      -> HardForkConsensusState xs
+      -> m (Maybe (OneEraIsLeader xs))
+check cfg@HardForkConsensusConfig{..} (Ticked slot ledgerView) =
+      fmap aux
+    . hsequence'
+    . State.tip
+    . State.align
+        (translateConsensus ei cfg)
+        (hcmap proxySingle (fn_2 . checkOne ei slot) cfgs)
+        ledgerView
+  where
+    cfgs = getPerEraConsensusConfig hardForkConsensusConfigPerEra
+    ei   = State.epochInfoLedgerView hardForkConsensusConfigShape ledgerView
+
+    aux :: NS (Maybe :.: SingleEraIsLeader) xs -> Maybe (OneEraIsLeader xs)
+    aux ns = hcollapse (hzipWith (K .: injectProof) injections ns)
+
+checkOne :: (MonadRandom m, SingleEraBlock blk)
+         => EpochInfo Identity
+         -> SlotNo
+         -> SingleEraConsensusConfig            blk
+         -> HardForkEraLedgerView               blk
+         -> SingleEraConsensusState             blk
+         -> (m :.: Maybe :.: SingleEraIsLeader) blk
+checkOne ei slot cfg
+         HardForkEraLedgerView{..}
+         (SingleEraConsensusState consensusState) = Comp . fmap Comp $
+     fmap (fmap SingleEraIsLeader) $
+       checkIsLeader
+         (completeConsensusConfig' ei cfg)
+         (Ticked slot hardForkEraLedgerView)
+         consensusState
+
+{-------------------------------------------------------------------------------
+  Rolling forward and backward
+-------------------------------------------------------------------------------}
+
+rewind :: (CanHardFork xs, Serialise (HeaderHash hdr))
+       => SecurityParam
+       -> Point hdr
+       -> HardForkConsensusState xs
+       -> Maybe (HardForkConsensusState xs)
+rewind k p =
+        -- Using just the 'SlotNo' is okay: no EBBs near transition
+        State.retractToSlot (pointSlot p)
+    >=> (hsequence' . hcmap proxySingle rewindOne)
+  where
+    rewindOne :: forall blk. SingleEraBlock          blk
+              => SingleEraConsensusState             blk
+              -> (Maybe :.: SingleEraConsensusState) blk
+    rewindOne (SingleEraConsensusState st) = Comp $
+        SingleEraConsensusState <$>
+          rewindConsensusState (Proxy @(BlockProtocol blk)) k p st
+
+update :: forall xs. CanHardFork xs
+       => ConsensusConfig (HardForkProtocol xs)
+       -> Ticked (HardForkLedgerView xs)
+       -> OneEraValidateView xs
+       -> HardForkConsensusState xs
+       -> Except (HardForkValidationErr xs) (HardForkConsensusState xs)
+update cfg@HardForkConsensusConfig{..}
+       (Ticked slot ledgerView)
+       (OneEraValidateView validateView)
+       consensusState =
+    case State.match validateView ledgerView of
+      Left mismatch ->
+        throwError $ HardForkValidationErrWrongEra . MismatchEraInfo $
+          Match.bihcmap proxySingle singleEraInfo ledgerInfo mismatch
+      Right matched ->
+           hsequence'
+         . State.tickAllPast hardForkConsensusConfigK
+         . State.align
+            (translateConsensus ei cfg)
+            (hczipWith proxySingle (fn_2 .: updateEra ei slot) cfgs injections)
+            matched
+         $ consensusState
+  where
+    cfgs = getPerEraConsensusConfig hardForkConsensusConfigPerEra
+    ei   = State.epochInfoLedgerView hardForkConsensusConfigShape ledgerView
+
+updateEra :: forall xs blk. SingleEraBlock blk
+          => EpochInfo Identity
+          -> SlotNo
+          -> SingleEraConsensusConfig                                        blk
+          -> Injection SingleEraValidationErr xs                             blk
+          -> Product SingleEraValidateView HardForkEraLedgerView             blk
+          -> SingleEraConsensusState                                         blk
+          -> (Except (HardForkValidationErr xs) :.: SingleEraConsensusState) blk
+updateEra ei slot cfg injectErr
+          (Pair (SingleEraValidateView validateView) HardForkEraLedgerView{..})
+          (SingleEraConsensusState consensusState) = Comp $
+    withExcept (injectValidationErr injectErr) $
+      fmap SingleEraConsensusState $
+        updateConsensusState
+          (completeConsensusConfig' ei cfg)
+          (Ticked slot hardForkEraLedgerView)
+          validateView
+          consensusState
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+ledgerInfo :: forall blk. SingleEraBlock blk
+           => State.Current HardForkEraLedgerView blk -> LedgerEraInfo blk
+ledgerInfo _ = LedgerEraInfo $ singleEraInfo (Proxy @blk)
+
+translateConsensus :: CanHardFork xs
+                   => EpochInfo Identity
+                   -> ConsensusConfig (HardForkProtocol xs)
+                   -> InPairs (Translate SingleEraConsensusState) xs
+translateConsensus ei HardForkConsensusConfig{..} =
+    InPairs.requiringBoth
+      (getPerEraConsensusConfig hardForkConsensusConfigPerEra)
+      (InPairs.hcmap
+        proxySingle
+        (RequireBoth . aux)
+        (translateConsensusState hardForkEraTranslation))
+  where
+    aux :: forall blk blk'. (SingleEraBlock blk, SingleEraBlock blk')
+        => TranslateEraConsensusState blk blk'
+        -> SingleEraConsensusConfig blk
+        -> SingleEraConsensusConfig blk'
+        -> Translate SingleEraConsensusState blk blk'
+    aux f pcfg pcfg' = Translate $ \epoch (SingleEraConsensusState st) ->
+        SingleEraConsensusState $
+          translateConsensusStateWith f cfg cfg' epoch st
+      where
+        cfg  :: ConsensusConfig (BlockProtocol blk)
+        cfg' :: ConsensusConfig (BlockProtocol blk')
+        cfg  = completeConsensusConfig' ei pcfg
+        cfg' = completeConsensusConfig' ei pcfg'
+
+injectValidationErr :: Injection SingleEraValidationErr xs blk
+                    -> ValidationErr (BlockProtocol blk)
+                    -> HardForkValidationErr xs
+injectValidationErr inj =
+      HardForkValidationErrFromEra
+    . OneEraValidationErr
+    . unK
+    . apFn inj
+    . SingleEraValidationErr
+
+injectProof :: Injection SingleEraIsLeader xs blk
+            -> (:.:) Maybe SingleEraIsLeader blk
+            -> Maybe (OneEraIsLeader xs)
+injectProof inj (Comp pf) = (OneEraIsLeader . unK . apFn inj) <$> pf
+
+{-------------------------------------------------------------------------------
+  Instances
+-------------------------------------------------------------------------------}
+
+deriving instance CanHardFork xs => Eq                 (HardForkValidationErr xs)
+deriving instance CanHardFork xs => Show               (HardForkValidationErr xs)
+deriving instance CanHardFork xs => NoUnexpectedThunks (HardForkValidationErr xs)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/SingleEra.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/SingleEra.hs
@@ -1,0 +1,7 @@
+module Ouroboros.Consensus.HardFork.Combinator.SingleEra (
+    module X
+  ) where
+
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra.Combined as X
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra.Info as X
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra.Wrappers as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/SingleEra/Combined.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/SingleEra/Combined.hs
@@ -1,0 +1,326 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE QuantifiedConstraints      #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.SingleEra.Combined (
+    -- * Value for /each/ era
+    PerEraConsensusConfig(..)
+  , PerEraChainSelConfig(..)
+  , PerEraLedgerConfig(..)
+  , PerEraBlockConfig(..)
+  , PerEraCodecConfig(..)
+  , PerEraForgeState(..)
+    -- * Value for /one/ era
+  , OneEraBlock(..)
+  , OneEraHeader(..)
+  , OneEraHash(..)
+  , OneEraTipInfo(..)
+  , OneEraEnvelopeErr(..)
+  , OneEraValidationErr(..)
+  , OneEraLedgerError(..)
+  , OneEraValidateView(..)
+  , OneEraSelectView(..)
+  , OneEraIsLeader(..)
+  , OneEraGenTx(..)
+  , OneEraGenTxId(..)
+  , OneEraApplyTxErr(..)
+    -- * Value for two /different/ eras
+  , MismatchEraInfo(..)
+  , mismatchOneEra
+    -- * Utility
+  , oneEraBlockHeader
+    -- * Distributive properties
+  , distribPoint
+  ) where
+
+import           Codec.Serialise (Serialise (..))
+import           Codec.Serialise.Decoding (Decoder)
+import qualified Codec.Serialise.Decoding as Dec
+import           Codec.Serialise.Encoding (Encoding)
+import qualified Codec.Serialise.Encoding as Enc
+import           Data.FingerTree.Strict (Measured (..))
+import           Data.SOP.Strict hiding (shift)
+import           Data.Void
+import           Data.Word
+
+import           Cardano.Prelude (NoUnexpectedThunks)
+
+import           Ouroboros.Network.Block
+
+import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Mempool.API
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra.Info
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra.Wrappers
+import           Ouroboros.Consensus.HardFork.Combinator.Util.DerivingVia
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Match (Mismatch)
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Match as Match
+
+{-------------------------------------------------------------------------------
+  Value for /each/ era
+
+  TODO: Here and elsewhere we should use a strict variant of sop-core.
+-------------------------------------------------------------------------------}
+
+newtype PerEraConsensusConfig xs = PerEraConsensusConfig { getPerEraConsensusConfig :: NP SingleEraConsensusConfig xs }
+newtype PerEraChainSelConfig  xs = PerEraChainSelConfig  { getPerEraChainSelConfig  :: NP SingleEraChainSelConfig  xs }
+newtype PerEraLedgerConfig    xs = PerEraLedgerConfig    { getPerEraLedgerConfig    :: NP SingleEraLedgerConfig    xs }
+newtype PerEraBlockConfig     xs = PerEraBlockConfig     { getPerEraBlockConfig     :: NP BlockConfig              xs }
+newtype PerEraCodecConfig     xs = PerEraCodecConfig     { getPerEraCodecConfig     :: NP CodecConfig              xs }
+newtype PerEraForgeState      xs = PerEraForgeState      { getPerEraForgeState      :: NP SingleEraForgeState      xs }
+
+{-------------------------------------------------------------------------------
+  Value for /one/ era
+-------------------------------------------------------------------------------}
+
+newtype OneEraBlock         xs = OneEraBlock         { getOneEraBlock         :: NS I                        xs }
+newtype OneEraHeader        xs = OneEraHeader        { getOneEraHeader        :: NS Header                   xs }
+newtype OneEraHash          xs = OneEraHash          { getOneEraHash          :: NS SingleEraHash            xs }
+newtype OneEraTipInfo       xs = OneEraTipInfo       { getOneEraTipInfo       :: NS SingleEraTipInfo         xs }
+newtype OneEraEnvelopeErr   xs = OneEraEnvelopeErr   { getOneEraEnvelopeErr   :: NS SingleEraEnvelopeErr     xs }
+newtype OneEraValidationErr xs = OneEraValidationErr { getOneEraValidationErr :: NS SingleEraValidationErr   xs }
+newtype OneEraLedgerError   xs = OneEraLedgerError   { getOneEraLedgerError   :: NS SingleEraLedgerError     xs }
+newtype OneEraValidateView  xs = OneEraValidateView  { getOneEraValidateView  :: NS SingleEraValidateView    xs }
+newtype OneEraSelectView    xs = OneEraSelectView    { getOneEraSelectView    :: NS SingleEraSelectView      xs }
+newtype OneEraIsLeader      xs = OneEraIsLeader      { getOneEraIsLeader      :: NS SingleEraIsLeader        xs }
+newtype OneEraGenTx         xs = OneEraGenTx         { getOneEraGenTx         :: NS GenTx                    xs }
+newtype OneEraGenTxId       xs = OneEraGenTxId       { getOneEraGenTxId       :: NS SingleEraGenTxId         xs }
+newtype OneEraApplyTxErr    xs = OneEraApplyTxErr    { getOneEraApplyTxErr    :: NS SingleEraApplyTxErr      xs }
+
+{-------------------------------------------------------------------------------
+  Value for two /different/ eras
+-------------------------------------------------------------------------------}
+
+newtype MismatchEraInfo xs = MismatchEraInfo {
+      -- | Era mismatch
+      --
+      -- We have an era mismatch between the era of a block/header/tx/query
+      -- and the era of the current ledger.
+      getMismatchEraInfo :: Mismatch SingleEraInfo LedgerEraInfo xs
+    }
+
+mismatchOneEra :: MismatchEraInfo '[b] -> Void
+mismatchOneEra = Match.mismatchOne . getMismatchEraInfo
+
+{-------------------------------------------------------------------------------
+  Utility
+-------------------------------------------------------------------------------}
+
+oneEraBlockHeader :: CanHardFork xs => OneEraBlock xs -> OneEraHeader xs
+oneEraBlockHeader =
+      OneEraHeader
+    . hcmap proxySingle (getHeader . unI)
+    . getOneEraBlock
+
+{-------------------------------------------------------------------------------
+  HasHeader instance for OneEraHeader
+-------------------------------------------------------------------------------}
+
+type instance HeaderHash (OneEraHeader xs) = OneEraHash xs
+
+instance CanHardFork xs => StandardHash (OneEraHeader xs)
+
+instance CanHardFork xs => Measured BlockMeasure (OneEraHeader xs) where
+  measure = blockMeasure
+
+instance CanHardFork xs => HasHeader (OneEraHeader xs) where
+  blockHash     = OneEraHash
+                . hcmap proxySingle (SingleEraHash . blockHash)
+                . getOneEraHeader
+  blockPrevHash = distribChainHash
+                . hcmap proxySingle (Comp . blockPrevHash)
+                . getOneEraHeader
+
+  blockSlot = hcollapse . hcmap proxySingle (K . blockSlot) . getOneEraHeader
+  blockNo   = hcollapse . hcmap proxySingle (K . blockNo)   . getOneEraHeader
+
+  blockInvariant = const True
+
+{-------------------------------------------------------------------------------
+  HasHeader instance for OneEraBlock
+-------------------------------------------------------------------------------}
+
+type instance HeaderHash (OneEraBlock xs) = OneEraHash xs
+
+instance CanHardFork xs => StandardHash (OneEraBlock xs)
+
+instance CanHardFork xs => Measured BlockMeasure (OneEraBlock xs) where
+  measure = blockMeasure
+
+instance CanHardFork xs => HasHeader (OneEraBlock xs) where
+  blockHash      =            blockHash     . oneEraBlockHeader
+  blockPrevHash  = castHash . blockPrevHash . oneEraBlockHeader
+  blockSlot      =            blockSlot     . oneEraBlockHeader
+  blockNo        =            blockNo       . oneEraBlockHeader
+  blockInvariant = const True
+
+{-------------------------------------------------------------------------------
+  Distributive properties
+-------------------------------------------------------------------------------}
+
+distribChainHash :: NS (ChainHash :.: Header) xs -> ChainHash (OneEraHeader xs)
+distribChainHash = go
+  where
+    go :: NS (ChainHash :.: Header) xs -> ChainHash (OneEraHeader xs)
+    go (Z (Comp GenesisHash))   = GenesisHash
+    go (Z (Comp (BlockHash h))) = BlockHash (OneEraHash (Z $ SingleEraHash h))
+    go (S h)                    = shiftChainHash $ go h
+
+distribPoint :: NS Point xs -> Point (OneEraBlock xs)
+distribPoint = go
+  where
+    go :: NS Point xs -> Point (OneEraBlock xs)
+    go (Z GenesisPoint)     = GenesisPoint
+    go (Z (BlockPoint s h)) = BlockPoint s (OneEraHash $ Z $ SingleEraHash h)
+    go (S p)                = shiftPoint (go p)
+
+shiftChainHash :: ChainHash (OneEraHeader xs) -> ChainHash (OneEraHeader (x ': xs))
+shiftChainHash GenesisHash   = GenesisHash
+shiftChainHash (BlockHash h) = BlockHash (shiftHash h)
+
+shiftPoint :: Point (OneEraBlock xs) -> Point (OneEraBlock (x ': xs))
+shiftPoint GenesisPoint     = GenesisPoint
+shiftPoint (BlockPoint s h) = BlockPoint s (shiftHash h)
+
+shiftHash :: OneEraHash xs -> OneEraHash (x ': xs)
+shiftHash (OneEraHash h) = OneEraHash (S h)
+
+{-------------------------------------------------------------------------------
+  NoUnexpectedThunks instances
+-------------------------------------------------------------------------------}
+
+deriving via LiftNamedNP "PerEraBlockConfig" BlockConfig xs
+         instance CanHardFork xs => NoUnexpectedThunks (PerEraBlockConfig xs)
+
+deriving via LiftNamedNP "PerEraConsensusConfig" SingleEraConsensusConfig xs
+         instance CanHardFork xs => NoUnexpectedThunks (PerEraConsensusConfig xs)
+
+deriving via LiftNamedNP "PerEraChainSelConfig" SingleEraChainSelConfig xs
+         instance CanHardFork xs => NoUnexpectedThunks (PerEraChainSelConfig xs)
+
+deriving via LiftNamedNP "PerEraLedgerConfig" SingleEraLedgerConfig xs
+         instance CanHardFork xs => NoUnexpectedThunks (PerEraLedgerConfig xs)
+
+deriving via LiftNamedNP "PerEraForgeState" SingleEraForgeState xs
+         instance CanHardFork xs => NoUnexpectedThunks (PerEraForgeState xs)
+
+deriving via LiftNamedNS "OneEraHeader" Header xs
+         instance CanHardFork xs => NoUnexpectedThunks (OneEraHeader xs)
+
+deriving via LiftNamedNS "OneEraHash" SingleEraHash xs
+         instance CanHardFork xs => NoUnexpectedThunks (OneEraHash xs)
+
+deriving via LiftNamedNS "OneEraEnvelopeErr" SingleEraEnvelopeErr xs
+         instance CanHardFork xs => NoUnexpectedThunks (OneEraEnvelopeErr xs)
+
+deriving via LiftNamedNS "OneEraTipInfo" SingleEraTipInfo xs
+         instance CanHardFork xs => NoUnexpectedThunks (OneEraTipInfo xs)
+
+deriving via LiftNamedNS "OneEraGenTxId" SingleEraGenTxId xs
+         instance CanHardFork xs => NoUnexpectedThunks (OneEraGenTxId xs)
+
+deriving via LiftNamedNS "OneEraLedgerError" SingleEraLedgerError xs
+         instance CanHardFork xs => NoUnexpectedThunks (OneEraLedgerError xs)
+
+deriving via LiftNamedNS "OneEraValidationErr" SingleEraValidationErr xs
+         instance CanHardFork xs => NoUnexpectedThunks (OneEraValidationErr xs)
+
+deriving via LiftNamedNS "OneEraGenTx" GenTx xs
+         instance CanHardFork xs => NoUnexpectedThunks (OneEraGenTx xs)
+
+deriving via LiftNamedMismatch "MismatchEraInfo" SingleEraInfo LedgerEraInfo xs
+         instance CanHardFork xs => NoUnexpectedThunks (MismatchEraInfo xs)
+
+{-------------------------------------------------------------------------------
+  Other instances
+-------------------------------------------------------------------------------}
+
+deriving via LiftNS SingleEraHash          xs instance CanHardFork xs => Eq   (OneEraHash xs)
+deriving via LiftNS SingleEraHash          xs instance CanHardFork xs => Ord  (OneEraHash xs)
+deriving via LiftNS SingleEraHash          xs instance CanHardFork xs => Show (OneEraHash xs)
+
+deriving via LiftNS SingleEraTipInfo       xs instance CanHardFork xs => Eq   (OneEraTipInfo xs)
+deriving via LiftNS SingleEraTipInfo       xs instance CanHardFork xs => Show (OneEraTipInfo xs)
+
+deriving via LiftNS SingleEraEnvelopeErr   xs instance CanHardFork xs => Eq   (OneEraEnvelopeErr xs)
+deriving via LiftNS SingleEraEnvelopeErr   xs instance CanHardFork xs => Show (OneEraEnvelopeErr xs)
+
+deriving via LiftNS SingleEraGenTxId       xs instance CanHardFork xs => Eq   (OneEraGenTxId xs)
+deriving via LiftNS SingleEraGenTxId       xs instance CanHardFork xs => Ord  (OneEraGenTxId xs)
+
+deriving via LiftNS SingleEraLedgerError   xs instance CanHardFork xs => Eq   (OneEraLedgerError xs)
+deriving via LiftNS SingleEraLedgerError   xs instance CanHardFork xs => Show (OneEraLedgerError xs)
+
+deriving via LiftNS SingleEraValidationErr xs instance CanHardFork xs => Eq   (OneEraValidationErr xs)
+deriving via LiftNS SingleEraValidationErr xs instance CanHardFork xs => Show (OneEraValidationErr xs)
+
+deriving via LiftMismatch SingleEraInfo LedgerEraInfo xs instance CanHardFork xs => Eq   (MismatchEraInfo xs)
+deriving via LiftMismatch SingleEraInfo LedgerEraInfo xs instance CanHardFork xs => Show (MismatchEraInfo xs)
+
+{-------------------------------------------------------------------------------
+  Show instances used in tests only
+-------------------------------------------------------------------------------}
+
+deriving via LiftNS I                   xs instance CanHardFork xs => Show (OneEraBlock      xs)
+deriving via LiftNS Header              xs instance CanHardFork xs => Show (OneEraHeader     xs)
+deriving via LiftNS GenTx               xs instance CanHardFork xs => Show (OneEraGenTx      xs)
+deriving via LiftNS SingleEraGenTxId    xs instance CanHardFork xs => Show (OneEraGenTxId    xs)
+deriving via LiftNS SingleEraApplyTxErr xs instance CanHardFork xs => Show (OneEraApplyTxErr xs)
+
+{-------------------------------------------------------------------------------
+  Serialisation
+
+  This is only required for the PBFT hack (see 'rewindConsensusState')
+-------------------------------------------------------------------------------}
+
+deriving instance SingleEraBlock blk => Serialise (SingleEraHash blk)
+
+deriving via SerialiseOne SingleEraHash xs
+         instance CanHardFork xs => Serialise (OneEraHash xs)
+
+{-------------------------------------------------------------------------------
+  Serialise support
+-------------------------------------------------------------------------------}
+
+newtype SerialiseOne f xs = SerialiseOne (NS f xs)
+
+instance ( All SingleEraBlock xs
+         , forall blk. SingleEraBlock blk => Serialise (f blk)
+         ) => Serialise (SerialiseOne f xs) where
+  encode (SerialiseOne ns) =
+      hcollapse $ hczipWith proxySingle aux indices ns
+    where
+      aux :: SingleEraBlock blk => K Word8 blk -> f blk -> K Encoding blk
+      aux (K i) x = K (Enc.encodeWord8 i <> encode x)
+
+      indices :: NP (K Word8) xs
+      indices = go 0 sList
+        where
+          go :: Word8 -> SList xs' -> NP (K Word8) xs'
+          go !_ SNil  = Nil
+          go !i SCons = K i :* go (i + 1) sList
+
+  decode = do
+      i <- fromIntegral <$> Dec.decodeWord8
+      if i < length decoders
+        then SerialiseOne <$> decoders !! i
+        else fail "decode: invalid index"
+    where
+      decoders :: [Decoder s (NS f xs)]
+      decoders = hcollapse $ hcmap proxySingle aux injections
+
+      aux :: SingleEraBlock blk
+          => Injection f xs blk -> K (Decoder s (NS f xs)) blk
+      aux inj = K (unK . apFn inj <$> decode)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/SingleEra/Info.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/SingleEra/Info.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.SingleEra.Info (
+    SingleEraInfo(..)
+  , LedgerEraInfo(..)
+  ) where
+
+import           Data.Text (Text)
+import           GHC.Generics (Generic)
+
+import           Cardano.Prelude (NoUnexpectedThunks (..))
+
+-- | Information about an era (mostly for type errors)
+data SingleEraInfo blk = SingleEraInfo {
+      singleEraName :: !Text
+    }
+  deriving stock    (Generic, Eq, Show)
+  deriving anyclass (NoUnexpectedThunks)
+
+-- | Additional newtype wrapper around 'SingleEraInfo'
+--
+-- This is primarily useful for use in error messages: it marks which era
+-- info came from the ledger, and which came from a tx/block/header/etc.
+newtype LedgerEraInfo blk = LedgerEraInfo {
+      getLedgerEraInfo :: SingleEraInfo blk
+    }
+  deriving stock   (Eq, Show)
+  deriving newtype (NoUnexpectedThunks)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/SingleEra/Wrappers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/SingleEra/Wrappers.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
+
+-- | Newtype wrappers around type families
+module Ouroboros.Consensus.HardFork.Combinator.SingleEra.Wrappers (
+    -- * Block based
+    SingleEraHash(..)
+  , SingleEraTipInfo(..)
+  , SingleEraEnvelopeErr(..)
+  , SingleEraLedgerConfig(..)
+  , SingleEraLedgerError(..)
+  , SingleEraGenTxId(..)
+  , SingleEraApplyTxErr(..)
+  , SingleEraForgeState(..)
+    -- * Protocol based
+  , SingleEraConsensusState(..)
+  , SingleEraConsensusConfig(..)
+  , SingleEraChainSelConfig(..)
+  , SingleEraIsLeader(..)
+  , SingleEraValidationErr(..)
+  , SingleEraValidateView(..)
+  , SingleEraSelectView(..)
+    -- * EraInfo
+  , LedgerEraInfo(..)
+    -- * Convenience
+  , singleEraParams'
+  , singleEraTransition'
+  ) where
+
+import           Data.Proxy
+
+import           Cardano.Prelude (NoUnexpectedThunks)
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Network.Block
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.HardFork.History (EraParams)
+import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Mempool.API
+import           Ouroboros.Consensus.Protocol.Abstract
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra.Info
+
+{-------------------------------------------------------------------------------
+  Newtype wrappers around type families
+
+  We need these because type families cannot be partially applied.
+-------------------------------------------------------------------------------}
+
+newtype SingleEraHash         blk = SingleEraHash         { getSingleEraHash         :: HeaderHash               blk }
+newtype SingleEraTipInfo      blk = SingleEraTipInfo      { getSingleEraTipInfo      :: TipInfo                  blk }
+newtype SingleEraEnvelopeErr  blk = SingleEraEnvelopeErr  { getSingleEraEnvelopeErr  :: OtherHeaderEnvelopeError blk }
+newtype SingleEraLedgerConfig blk = SingleEraLedgerConfig { getSingleEraLedgerConfig :: PartialLedgerConfig      blk }
+newtype SingleEraLedgerError  blk = SingleEraLedgerError  { getSingleEraLedgerError  :: LedgerError              blk }
+newtype SingleEraGenTxId      blk = SingleEraGenTxId      { getSingleEraGenTxId      :: GenTxId                  blk }
+newtype SingleEraApplyTxErr   blk = SingleEraApplyTxErr   { getSingleEraApplyTxErr   :: ApplyTxErr               blk }
+newtype SingleEraForgeState   blk = SingleEraForgeState   { getSingleEraForgeState   :: ForgeState               blk }
+
+{-------------------------------------------------------------------------------
+  Consensus based
+-------------------------------------------------------------------------------}
+
+newtype SingleEraConsensusState  blk = SingleEraConsensusState  { getSingleEraConsensusState  :: ConsensusState         (BlockProtocol blk) }
+newtype SingleEraConsensusConfig blk = SingleEraConsensusConfig { getSingleEraConsensusConfig :: PartialConsensusConfig (BlockProtocol blk) }
+newtype SingleEraChainSelConfig  blk = SingleEraChainSelConfig  { getSingleEraChainSelConfig  :: ChainSelConfig         (BlockProtocol blk) }
+newtype SingleEraIsLeader        blk = SingleEraIsLeader        { getSingleEraIsLeader        :: IsLeader               (BlockProtocol blk) }
+newtype SingleEraValidationErr   blk = SingleEraValidationErr   { getSingleEraValidationErr   :: ValidationErr          (BlockProtocol blk) }
+newtype SingleEraValidateView    blk = SingleEraValidateView    { getSingleEraValidateView    :: ValidateView           (BlockProtocol blk) }
+newtype SingleEraSelectView      blk = SingleEraSelectView      { getSingleEraSelectView      :: SelectView             (BlockProtocol blk) }
+
+{-------------------------------------------------------------------------------
+  Convenience functions
+-------------------------------------------------------------------------------}
+
+singleEraParams' :: forall blk. SingleEraBlock blk
+                 => SingleEraLedgerConfig blk -> EraParams
+singleEraParams' = singleEraParams (Proxy @blk) . getSingleEraLedgerConfig
+
+singleEraTransition' :: SingleEraBlock blk
+                     => SingleEraLedgerConfig blk -> LedgerState blk -> Maybe EpochNo
+singleEraTransition' = singleEraTransition . getSingleEraLedgerConfig
+
+{-------------------------------------------------------------------------------
+  Instances
+-------------------------------------------------------------------------------}
+
+deriving newtype instance SingleEraBlock blk => Eq                 (SingleEraHash blk)
+deriving newtype instance SingleEraBlock blk => Ord                (SingleEraHash blk)
+deriving newtype instance SingleEraBlock blk => Show               (SingleEraHash blk)
+deriving newtype instance SingleEraBlock blk => NoUnexpectedThunks (SingleEraHash blk)
+
+deriving newtype instance SingleEraBlock blk => Eq                 (SingleEraTipInfo blk)
+deriving newtype instance SingleEraBlock blk => Show               (SingleEraTipInfo blk)
+deriving newtype instance SingleEraBlock blk => NoUnexpectedThunks (SingleEraTipInfo blk)
+
+deriving newtype instance SingleEraBlock blk => Eq                 (SingleEraEnvelopeErr blk)
+deriving newtype instance SingleEraBlock blk => Show               (SingleEraEnvelopeErr blk)
+deriving newtype instance SingleEraBlock blk => NoUnexpectedThunks (SingleEraEnvelopeErr blk)
+
+deriving newtype instance SingleEraBlock blk => Eq                 (SingleEraGenTxId blk)
+deriving newtype instance SingleEraBlock blk => Ord                (SingleEraGenTxId blk)
+deriving newtype instance SingleEraBlock blk => NoUnexpectedThunks (SingleEraGenTxId blk)
+
+deriving newtype instance SingleEraBlock blk => Eq                 (SingleEraLedgerError blk)
+deriving newtype instance SingleEraBlock blk => Show               (SingleEraLedgerError blk)
+deriving newtype instance SingleEraBlock blk => NoUnexpectedThunks (SingleEraLedgerError blk)
+
+deriving newtype instance SingleEraBlock blk => Eq                 (SingleEraConsensusState blk)
+deriving newtype instance SingleEraBlock blk => Show               (SingleEraConsensusState blk)
+deriving newtype instance SingleEraBlock blk => NoUnexpectedThunks (SingleEraConsensusState blk)
+
+deriving newtype instance SingleEraBlock blk => Eq                 (SingleEraValidationErr blk)
+deriving newtype instance SingleEraBlock blk => Show               (SingleEraValidationErr blk)
+deriving newtype instance SingleEraBlock blk => NoUnexpectedThunks (SingleEraValidationErr blk)
+
+deriving newtype instance SingleEraBlock blk => NoUnexpectedThunks (SingleEraConsensusConfig blk)
+deriving newtype instance SingleEraBlock blk => NoUnexpectedThunks (SingleEraChainSelConfig  blk)
+deriving newtype instance SingleEraBlock blk => NoUnexpectedThunks (SingleEraLedgerConfig    blk)
+deriving newtype instance SingleEraBlock blk => NoUnexpectedThunks (SingleEraForgeState      blk)
+
+{-------------------------------------------------------------------------------
+  Instances primarily for the benefit of tests
+-------------------------------------------------------------------------------}
+
+deriving newtype instance SingleEraBlock blk => Show (SingleEraGenTxId    blk)
+deriving newtype instance SingleEraBlock blk => Show (SingleEraApplyTxErr blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -1,0 +1,258 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+-- | Intended for qualified import
+--
+-- > import Ouroboros.Consensus.HardFork.Combinator.State (HardForkState_(..))
+-- > import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+module Ouroboros.Consensus.HardFork.Combinator.State (
+    module Ouroboros.Consensus.HardFork.Combinator.State.Infra
+    -- * Serialisation support
+  , recover
+    -- * EpochInfo
+  , reconstructSummaryLedger
+  , epochInfoLedger
+  , epochInfoLedgerView
+    -- * Ledger specific functionality
+  , extendToSlot
+  , transitions
+  ) where
+
+import           Prelude hiding (sequence)
+
+import           Control.Monad (guard)
+import           Data.Functor.Identity
+import           Data.Functor.Product
+import           Data.SOP.Strict hiding (shape)
+
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Consensus.BlockchainTime
+import qualified Ouroboros.Consensus.HardFork.History as History
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Util ((.:))
+import           Ouroboros.Consensus.Util.Counting
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+import           Ouroboros.Consensus.HardFork.Combinator.State.Infra
+import           Ouroboros.Consensus.HardFork.Combinator.Translation
+import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs (InPairs,
+                     Requiring (..), RequiringBoth (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
+                     (Extend (..), ScanNext (..), Telescope)
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Telescope
+
+{-------------------------------------------------------------------------------
+  Recovery
+-------------------------------------------------------------------------------}
+
+-- | Recover 'HardForkState_' from partial information
+--
+-- The primary goal of this is to make sure that for the /current/ state we
+-- really only need to store the underlying @f@. It is not strictly essential
+-- that this is possible but it helps with the unary hardfork case, and it may
+-- in general help with binary compatibility.
+recover :: forall g f xs. CanHardFork xs
+        => SystemStart
+        -> Telescope (Past g) f xs
+        -> HardForkState_ g f xs
+recover systemStart =
+    case isNonEmpty (Proxy @xs) of
+      ProofNonEmpty _ ->
+          HardForkState
+        . Telescope.bihmap
+            (\(Pair _ past) -> past)
+            recoverCurrent
+        . Telescope.scanl
+            (InPairs.hpure $ ScanNext $ const $ K . pastEnd)
+            (K (History.initBound systemStart))
+  where
+    recoverCurrent :: Product (K History.Bound) f blk -> Current f blk
+    recoverCurrent (Pair (K prevEnd) st) = Current {
+          currentStart = prevEnd
+        , currentState = st
+        }
+
+{-------------------------------------------------------------------------------
+  Reconstruct EpochInfo
+-------------------------------------------------------------------------------}
+
+reconstructSummaryLedger :: CanHardFork xs
+                         => HardForkLedgerConfig xs
+                         -> HardForkState LedgerState xs
+                         -> History.Summary xs
+reconstructSummaryLedger HardForkLedgerConfig{..} =
+    reconstructSummary
+        hardForkLedgerConfigShape
+        (hcmap proxySingle (fn . (K .: transitionOrTip)) cfgs)
+  where
+    cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
+
+-- | Construct 'EpochInfo' from the ledger state
+--
+-- NOTE: The resulting 'EpochInfo' is a snapshot only, with a limited range.
+-- It should not be stored.
+epochInfoLedger :: CanHardFork xs
+                => HardForkLedgerConfig xs
+                -> HardForkState LedgerState xs
+                -> EpochInfo Identity
+epochInfoLedger cfg =
+      History.snapshotEpochInfo
+    . reconstructSummaryLedger cfg
+
+-- | Construct 'EpochInfo' from a ledger view
+--
+-- The same comments apply as for 'epochInfoLedger', except more so: the range
+-- of the 'EpochInfo' is determined by the ledger that the view was derived
+-- from; when the view is a forecast, that range does not extend (obviously).
+epochInfoLedgerView :: CanHardFork xs
+                    => History.Shape xs
+                    -> HardForkLedgerView xs
+                    -> EpochInfo Identity
+epochInfoLedgerView shape =
+      History.snapshotEpochInfo
+    . reconstructSummary
+        shape
+        (hpure (fn $ K . hardForkEraTransition))
+
+{-------------------------------------------------------------------------------
+  Extending
+-------------------------------------------------------------------------------}
+
+-- | Extend the telescope until the specified slot is within the era at the tip
+extendToSlot :: forall xs. CanHardFork xs
+             => HardForkLedgerConfig xs
+             -> SlotNo
+             -> HardForkState LedgerState xs -> HardForkState LedgerState xs
+extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st) =
+      HardForkState . unI
+    . Telescope.extend
+        ( InPairs.requiringBoth cfgs
+        $ InPairs.hcmap proxySingle (\f -> RequireBoth $ \cfg cfg'
+                                        -> Require $ \(K t)
+                                        -> Extend $ \cur
+                                        -> I $ howExtend f cfg cfg' t cur)
+        $ translate
+        )
+        (hcmap proxySingle (fn . whenExtend) cfgs)
+    $ st
+  where
+    -- Return the end of this era if we should transition to the next
+    whenExtend :: SingleEraBlock              blk
+               => SingleEraLedgerConfig       blk
+               -> Current LedgerState         blk
+               -> (Maybe :.: K History.Bound) blk
+    whenExtend pcfg cur = Comp $ K <$> do
+        transition <- singleEraTransition' pcfg (currentState cur)
+        let endBound = History.mkUpperBound
+                         (singleEraParams' pcfg)
+                         (currentStart cur)
+                         transition
+        guard (slot >= History.boundSlot endBound)
+        return endBound
+
+    howExtend :: (SingleEraBlock blk, SingleEraBlock blk')
+              => TranslateEraLedgerState blk blk'
+              -> SingleEraLedgerConfig blk
+              -> SingleEraLedgerConfig blk'
+              -> History.Bound
+              -> Current LedgerState blk
+              -> (Past LedgerState blk, Current LedgerState blk')
+    howExtend f pcfg pcfg' currentEnd cur = (
+          Past {
+              pastStart    = currentStart cur
+            , pastEnd      = currentEnd
+            , pastSnapshot = Snapshot 0 (currentState cur)
+            }
+        , Current {
+              currentStart = currentEnd
+            , currentState = translateLedgerStateWith f
+                               (completeLedgerConfig' ei pcfg )
+                               (completeLedgerConfig' ei pcfg')
+                               (History.boundEpoch currentEnd)
+                               (currentState cur)
+            }
+        )
+
+    cfgs :: NP SingleEraLedgerConfig xs
+    cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
+
+    ei :: EpochInfo Identity
+    ei = epochInfoLedger ledgerCfg ledgerSt
+
+    translate :: InPairs TranslateEraLedgerState xs
+    translate = translateLedgerState hardForkEraTranslation
+
+{-------------------------------------------------------------------------------
+  Collect all current hard fork transitions
+
+  TODO: If we make 'hardForkSummary' the primitive function in
+  'HasHardForkHistory', ideally this should not be necessary anymore: the
+  summary is trivially derivable from the ledger state. This would then
+  also obsolete the need for caching.
+-------------------------------------------------------------------------------}
+
+transitions :: forall g xs. CanHardFork xs
+            => HardForkLedgerConfig xs
+            -> HardForkState_ g LedgerState xs -> History.Transitions xs
+transitions HardForkLedgerConfig{..} (HardForkState st) =
+    case isNonEmpty (Proxy @xs) of
+      ProofNonEmpty _ ->
+        History.Transitions $
+          shiftTransitions (getPerEraLedgerConfig cfg) $
+            allTransitions (getPerEraLedgerConfig cfg) st
+  where
+    cfg = hardForkLedgerConfigPerEra
+
+-- | Find transition points in all eras
+--
+-- This associates each transition with the era it transitions /from/.
+-- See also 'shiftTransitions'.
+allTransitions :: CanHardFork                                xs
+               => NP SingleEraLedgerConfig                   xs
+               -> Telescope (Past f) (Current (LedgerState)) xs
+               -> AtMost                                     xs EpochNo
+allTransitions cfgs st =
+    Telescope.toAtMost $
+      Telescope.bihap
+        (hpure (fn past))
+        (hcmap proxySingle (fn . cur) cfgs)
+        st
+  where
+    past :: Past f blk -> K EpochNo blk
+    past = K . History.boundEpoch . pastEnd
+
+    cur :: SingleEraBlock blk
+        => SingleEraLedgerConfig blk
+        -> Current LedgerState blk
+        -> K (Maybe EpochNo) blk
+    cur cfg = K . singleEraTransition' cfg . currentState
+
+-- | Associate transitions with the era they transition /to/
+--
+-- 'allTransitions' associates transitions with the era in which they occur,
+-- but the hard fork history infrastructure expects them to be associated with
+-- the era that they transition /to/. 'shiftTransitions' implements this
+-- shift of perspective, and also verifies that the final era cannot have
+-- a transition.
+shiftTransitions :: NP f (x ': xs) -- Just as an index
+                 -> AtMost (x ': xs) EpochNo -> AtMost xs EpochNo
+shiftTransitions = go
+  where
+    go :: NP f (x ': xs)
+       -> AtMost (x ': xs) EpochNo -> AtMost xs EpochNo
+    go _                  AtMostNil                = AtMostNil
+    go (_ :* cs@(_ :* _)) (AtMostCons t ts)        = AtMostCons t (go cs ts)
+    go (_ :* Nil)         (AtMostCons _ AtMostNil) = error invalidTransition
+
+    invalidTransition :: String
+    invalidTransition = "Unexpected transition in final era"

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Infra.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Infra.hs
@@ -1,0 +1,462 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DerivingVia           #-}
+{-# LANGUAGE EmptyCase             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+
+-- | 'HardForkState' infrastructure that is independent from @.Basics@
+--
+-- Separate module to avoid circular module dependencies
+module Ouroboros.Consensus.HardFork.Combinator.State.Infra (
+    -- * Types
+    HardForkState_(..)
+  , HardForkState
+  , Past(..)
+  , Snapshot(..)
+  , Current(..)
+    -- * GC
+  , tickAllPast
+    -- * Lifting 'Telescope' operations
+  , tip
+  , match
+  , sequence
+  , bihczipWith
+  , fromTZ
+    -- * Aligning
+  , Translate(..)
+  , align
+    -- * Rewinding
+  , retractToSlot
+    -- * EpochInfo/Summary
+  , TransitionOrTip(..)
+  , transitionOrTip
+  , reconstructSummary
+  ) where
+
+import           Prelude hiding (sequence)
+
+import           Data.Functor.Identity
+import           Data.Functor.Product
+import           Data.SOP.Strict hiding (shape)
+import           Data.Word
+import           GHC.Generics (Generic)
+
+import           Cardano.Prelude (NoUnexpectedThunks)
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Consensus.Config.SecurityParam
+import           Ouroboros.Consensus.HardFork.History (Bound (..), EraEnd (..),
+                     EraParams (..), EraSummary (..))
+import qualified Ouroboros.Consensus.HardFork.History as History
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Util.Counting
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra
+import           Ouroboros.Consensus.HardFork.Combinator.Util.DerivingVia
+import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs (InPairs,
+                     Requiring (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Match (Mismatch)
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Match as Match
+import           Ouroboros.Consensus.HardFork.Combinator.Util.SOP
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
+                     (Extend (..), Retract (..), Telescope (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Telescope
+
+{-------------------------------------------------------------------------------
+  Types
+-------------------------------------------------------------------------------}
+
+-- | Generic hard fork state
+--
+-- This is used both for the consensus state and the ledger state.
+newtype HardForkState_ g f xs = HardForkState {
+      getHardForkState :: Telescope (Past g) (Current f) xs
+    }
+
+-- | Hard for state where both 'Past' and 'Current' use the same functor
+--
+-- In most cases this is what we need; we only end up with different functors
+-- after things like 'match'.
+type HardForkState f = HardForkState_ f f
+
+-- | Information about the current era
+data Current f blk = Current {
+      currentStart :: !Bound
+    , currentState :: !(f blk)
+    }
+  deriving (Generic)
+
+-- | Information about a past era
+data Past f blk = Past {
+      pastStart    :: !Bound
+    , pastEnd      :: !Bound
+    , pastSnapshot :: !(Snapshot f blk)
+    }
+  deriving (Generic)
+
+-- | Past snapshot
+--
+-- We record for each past era how many blocks have been applied to /any/
+-- subsequent era. Here is an example with @k = 3@ with three ledgers
+-- @A@, @B@ and @C@, with maximum roll back marked for a few states:
+--
+-- > Initial ledger   Curr A0
+-- >
+-- > Apply block      Curr A1                      <--\
+-- >                                                  |
+-- > Transition       Past 0 A1, Curr B0              |
+-- > Apply block      Past 1 A1, Curr B1              |  <--\
+-- >                                                  |     |
+-- > Apply block      Past 2 A1, Curr B2              |     |
+-- >                                                  |     |
+-- > Transition       Past 2 A1, Past 0 B2, Curr C0   |     |
+-- > Apply block      Past 3 A1, Past 1 B2, Curr C1   /     |  <--\
+-- >                                                        |     |
+-- > Apply block      Past 4 A1, Past 2 B2, Curr C2         |     |
+-- > GC               Past GCd,  Past 2 B2, Curr C2         /     |
+-- >                                                              |
+-- > Apply block      Past GCd,  Past 3 B2, Curr C3               |
+-- >                                                              |
+-- > Apply block      Past GCd,  Past 4 B2, Curr C4               |
+-- > GC               Past GCd,  Past GCd,  Curr C4               /
+--
+-- Note that at the point where past states are GCed, we indeed can no longer
+-- roll back to the point before the corresponding transitions.
+data Snapshot f blk =
+    -- | Past snapshot still available
+    --
+    -- Invariant: the count must be @<= k@ (see diagram above).
+    Snapshot !Word64 !(f blk)
+
+    -- | Past consensus state not available anymore
+    --
+    -- After @k@ blocks have been applied, we are sure that we don't need
+    -- the old consensus state anymore and so we don't need to keep it around.
+  | NoSnapshot
+  deriving (Generic)
+
+getSnapshot :: Snapshot f blk -> Maybe (f blk)
+getSnapshot (Snapshot _ st) = Just st
+getSnapshot NoSnapshot      = Nothing
+
+{-------------------------------------------------------------------------------
+  Lifting functions on @f@ to @Current @f@
+-------------------------------------------------------------------------------}
+
+lift :: (f blk -> f' blk) -> Current f blk -> Current f' blk
+lift f = runIdentity . liftM (Identity . f)
+
+liftM :: Functor m
+      => (f blk -> m (f' blk)) -> Current f blk -> m (Current f' blk)
+liftM f (Current start cur) = Current start <$> f cur
+
+{-------------------------------------------------------------------------------
+  Lifting functions on @f@ to @Past f@
+-------------------------------------------------------------------------------}
+
+liftPast :: (f blk -> f' blk) -> Past f blk -> Past f' blk
+liftPast f = runIdentity . liftPastM (Identity . f)
+
+liftPastM :: Applicative m
+          => (f blk -> m (f' blk)) -> Past f blk -> m (Past f' blk)
+liftPastM f (Past start end snapshot) =
+    Past start end <$>
+      case snapshot of
+        NoSnapshot    -> pure NoSnapshot
+        Snapshot n st -> Snapshot n <$> f st
+
+{-------------------------------------------------------------------------------
+  SOP class instances
+
+  These are convenient, allowing us to treat the 'HardForkState' just like any
+  other SOP type; in particular, they deal with lifting functions to 'Current'.
+-------------------------------------------------------------------------------}
+
+type instance Prod    (HardForkState_ g)   = NP
+type instance SListIN (HardForkState_ g)   = SListI
+type instance AllN    (HardForkState_ g) c = All c
+
+instance HAp (HardForkState_ g) where
+  hap np (HardForkState st) = HardForkState $
+      hap (map_NP' (Fn . lift . apFn) np) st
+
+instance HSequence (HardForkState_ g) where
+  hctraverse' = \p f (HardForkState st) -> HardForkState <$>
+                                              hctraverse' p (liftM f) st
+  htraverse' = hctraverse' (Proxy @Top)
+  hsequence' = htraverse' unComp
+
+{-------------------------------------------------------------------------------
+  GC
+-------------------------------------------------------------------------------}
+
+tickAllPast :: SListI xs
+            => SecurityParam -> HardForkState_ g f xs -> HardForkState_ g f xs
+tickAllPast k (HardForkState st) = HardForkState $
+    Telescope.bihmap (tickPast k) id st
+
+-- | Tick all past states
+--
+-- This is used to GC past snapshots when they exceed @k@.
+tickPast :: SecurityParam -> Past g blk -> Past g blk
+tickPast k past = past { pastSnapshot = tickSnapshot k (pastSnapshot past) }
+
+tickSnapshot :: SecurityParam -> Snapshot f blk -> Snapshot f blk
+tickSnapshot (SecurityParam k) = \case
+    Snapshot n st | n < k -> Snapshot (n + 1) st
+    _                     -> NoSnapshot
+
+{-------------------------------------------------------------------------------
+  Lift telescope operations
+-------------------------------------------------------------------------------}
+
+tip :: SListI xs => HardForkState_ g f xs -> NS f xs
+tip (HardForkState st) = hmap currentState $ Telescope.tip st
+
+match :: SListI xs
+      => NS h xs
+      -> HardForkState_ g f xs
+      -> Either (Mismatch h (Current f) xs) (HardForkState_ g (Product h f) xs)
+match ns (HardForkState t) =
+    HardForkState . hmap distrib <$> Match.matchTelescope ns t
+  where
+    distrib :: Product h (Current f) blk -> Current (Product h f) blk
+    distrib (Pair x (Current start y)) =
+        Current start (Pair x y)
+
+sequence :: forall g f m xs. (SListI xs, Functor m)
+         => HardForkState_ g (m :.: f) xs -> m (HardForkState_ g f xs)
+sequence = \(HardForkState st) -> HardForkState <$>
+    Telescope.sequence (hmap distrib st)
+  where
+    distrib :: Current (m :.: f) blk -> (m :.: Current f) blk
+    distrib (Current start st) = Comp $
+        Current start <$> unComp st
+
+bihczipWith :: forall xs h g' g f' f. CanHardFork xs
+            => (forall blk. SingleEraBlock blk => h blk -> g blk -> g' blk)
+            -> (forall blk. SingleEraBlock blk => h blk -> f blk -> f' blk)
+            -> NP h xs -> HardForkState_ g f xs -> HardForkState_ g' f' xs
+bihczipWith g f ns (HardForkState st) = HardForkState $
+    Telescope.bihczipWith proxySingle (liftPast . g) (lift . f) ns st
+
+fromTZ :: HardForkState_ g f '[blk] -> f blk
+fromTZ = currentState . Telescope.fromTZ . getHardForkState
+
+{-------------------------------------------------------------------------------
+  Aligning
+-------------------------------------------------------------------------------}
+
+newtype Translate f x y = Translate {
+      translateWith :: EpochNo -> f x -> f y
+    }
+
+align :: forall xs h f f' f''. CanHardFork xs
+      => InPairs (Translate f) xs
+      -> NP (f' -.-> f -.-> f'') xs
+      -> HardForkState_ h f'  xs -- ^ State we are aligning with
+      -> HardForkState_ f f   xs -- ^ State we are aligning
+      -> HardForkState_ f f'' xs
+align fs updTip (HardForkState alignWith) (HardForkState toAlign) =
+    HardForkState . unI $
+      Telescope.alignExtend
+        (InPairs.hmap (\f    -> Require $
+                       \past -> Extend  $
+                       \cur  -> I       $
+                         newCurrent f past cur) fs)
+        (hmap (fn_2 . liftUpdTip) updTip)
+        alignWith
+        toAlign
+  where
+    liftUpdTip :: (f' -.-> f -.-> f'') blk
+               -> Current f' blk -> Current f blk -> Current f'' blk
+    liftUpdTip f = lift . apFn . apFn f . currentState
+
+    newCurrent :: Translate f blk blk'
+               -> Past g' blk
+               -> Current f blk
+               -> (Past f blk, Current f blk')
+    newCurrent f pastG curF = (
+          Past    { pastStart    = currentStart curF
+                  , pastEnd      = curEnd
+                  , pastSnapshot = Snapshot 0 (currentState curF)
+                  }
+        , Current { currentStart = curEnd
+                  , currentState = translateWith f
+                                     (boundEpoch curEnd)
+                                     (currentState curF)
+                  }
+        )
+      where
+        curEnd :: Bound
+        curEnd = pastEnd pastG
+
+{-------------------------------------------------------------------------------
+  Rewinding
+-------------------------------------------------------------------------------}
+
+-- | Rewind until the specified slot is within the era at the tip
+retractToSlot :: forall f xs. SListI xs
+              => WithOrigin SlotNo
+              -> HardForkState f xs -> Maybe (HardForkState f xs)
+retractToSlot slot (HardForkState st) =
+    HardForkState <$>
+      Telescope.retractIf
+        (Tails.hpure retract)
+        (hmap (fn . containsSlot) (markFirst True sList))
+        st
+  where
+    markFirst :: Bool -> SList xs' -> NP (K Bool) xs'
+    markFirst _ SNil  = Nil
+    markFirst b SCons = K b :* markFirst False sList
+
+    containsSlot :: K Bool blk -> Past f blk -> K Bool blk
+    containsSlot (K isFirst) Past{..} = K $
+        case slot of
+          Origin -> isFirst -- Assume 'Origin' in the first era
+          At s   -> boundSlot pastStart <= s && s < boundSlot pastEnd
+
+    retract :: Retract Maybe (Past f) (Current f) blk blk'
+    retract = Retract $ \past _oldCur ->
+        Current (pastStart past) <$> getSnapshot (pastSnapshot past)
+
+{-------------------------------------------------------------------------------
+  Summary/EpochInfo
+-------------------------------------------------------------------------------}
+
+-- | Property of a particular ledger state: transition to the next era if known,
+-- or the tip of the ledger otherwise.
+data TransitionOrTip =
+    -- | Transition to the next era has been confirmed and is stable
+    TransitionAt !(WithOrigin SlotNo) !EpochNo
+
+    -- | Transition to the next era not yet known; we reported ledger tip
+  | LedgerTip !(WithOrigin SlotNo)
+  deriving (Show)
+
+transitionOrTip :: SingleEraBlock blk
+                => SingleEraLedgerConfig blk
+                -> LedgerState blk
+                -> TransitionOrTip
+transitionOrTip cfg st =
+    case singleEraTransition' cfg st of
+      Just epoch -> TransitionAt (ledgerTipSlot st) epoch
+      Nothing    -> LedgerTip (ledgerTipSlot st)
+
+reconstructSummary :: forall g f xs. CanHardFork xs
+                   => History.Shape xs
+                   -> NP (f -.-> K TransitionOrTip) xs
+                   -- ^ Return the 'EpochNo' of the transition to the next
+                   -- era if known, or the 'SlotNo' at the tip otherwise.
+                   -> HardForkState_ g f xs
+                   -> History.Summary xs
+reconstructSummary (History.Shape shape) transition (HardForkState st) =
+    History.Summary $ go shape transition st
+  where
+    go :: All SingleEraBlock xs'
+       => Exactly xs' EraParams
+       -> NP (f -.-> K TransitionOrTip) xs'
+       -> Telescope (Past g) (Current f) xs'
+       -> NonEmpty xs' EraSummary
+    go (ExactlyCons params ss) (_ :* ts) (TS Past{..} t) =
+        NonEmptyCons (EraSummary pastStart (EraEnd pastEnd) params) $ go ss ts t
+    go (ExactlyCons params ExactlyNil) _ (TZ Current{..}) =
+        -- The current era is the last. We assume it lasts until all eternity.
+        NonEmptyOne (EraSummary currentStart EraUnbounded params)
+    go (ExactlyCons params (ExactlyCons nextParams _)) (t :* _) (TZ Current{..}) =
+        case unK $ apFn t currentState of
+          TransitionAt _tip epoch ->
+            -- We haven't reached the next era yet, but the transition is
+            -- already known. The safe zone applies from the start of the
+            -- next era.
+            let currentEnd = History.mkUpperBound params currentStart epoch
+                nextStart  = currentEnd
+            in NonEmptyCons EraSummary {
+                   eraStart  = currentStart
+                 , eraParams = params
+                 , eraEnd    = EraEnd currentEnd
+                 }
+             $ NonEmptyOne EraSummary {
+                   eraStart  = nextStart
+                 , eraParams = nextParams
+                 , eraEnd    = applySafeZone
+                                 nextParams
+                                 nextStart
+                                 (At (boundSlot nextStart))
+                 }
+          LedgerTip ledgerTip -> NonEmptyOne $
+            -- The transition to the /next/ era is not yet known, but it's
+            -- possible that the tip was actually in the previous era. If that
+            -- is the case, the safe zone of /this/ era extends from the start
+            -- of this era.  Otherwise, the safe zone extends from the current
+            -- ledger tip.
+            EraSummary {
+                eraStart  = currentStart
+              , eraParams = params
+              , eraEnd    = applySafeZone
+                              params
+                              currentStart
+                              (max ledgerTip (At (boundSlot currentStart)))
+              }
+
+    go ExactlyNil _ t = case t of {}
+
+    -- Apply safe zone from the specified 'SlotNo'
+    --
+    -- All arguments must be referring to or in the same era.
+    applySafeZone :: EraParams -> Bound -> WithOrigin SlotNo -> EraEnd
+    applySafeZone params@EraParams{..} start =
+          History.mkEraEnd params start
+        . History.maxMaybeEpoch (History.safeBeforeEpoch eraSafeZone)
+        . History.slotToEpochBound params start
+        . History.addSlots (History.safeFromTip eraSafeZone)
+        . fromWithOrigin (boundSlot start)
+
+{-------------------------------------------------------------------------------
+  Instances
+-------------------------------------------------------------------------------}
+
+deriving instance Eq                 (f blk) => Eq                 (Current f blk)
+deriving instance Show               (f blk) => Show               (Current f blk)
+deriving instance NoUnexpectedThunks (f blk) => NoUnexpectedThunks (Current f blk)
+
+deriving instance Eq                 (f blk) => Eq                 (Past f blk)
+deriving instance Show               (f blk) => Show               (Past f blk)
+deriving instance NoUnexpectedThunks (f blk) => NoUnexpectedThunks (Past f blk)
+
+deriving instance Eq                 (f blk) => Eq                 (Snapshot f blk)
+deriving instance Show               (f blk) => Show               (Snapshot f blk)
+deriving instance NoUnexpectedThunks (f blk) => NoUnexpectedThunks (Snapshot f blk)
+
+deriving via LiftTelescope (Past g) (Current f) xs
+         instance ( CanHardFork xs
+                  , forall blk. SingleEraBlock blk => Show (f blk)
+                  , forall blk. SingleEraBlock blk => Show (g blk)
+                  ) => Show (HardForkState_ g f xs)
+
+deriving via LiftTelescope (Past g) (Current f) xs
+         instance ( CanHardFork xs
+                  , forall blk. SingleEraBlock blk => Eq (f blk)
+                  , forall blk. SingleEraBlock blk => Eq (g blk)
+                  ) => Eq (HardForkState_ g f xs)
+
+deriving via LiftNamedTelescope "HardForkState" (Past g) (Current f) xs
+         instance ( CanHardFork xs
+                  , forall blk. SingleEraBlock blk => NoUnexpectedThunks (f blk)
+                  , forall blk. SingleEraBlock blk => NoUnexpectedThunks (g blk)
+                  ) => NoUnexpectedThunks (HardForkState_ g f xs)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE DataKinds   #-}
+{-# LANGUAGE DerivingVia #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Translation (
+    -- * Translate from one era to the next
+    TranslateEraLedgerState(..)
+  , TranslateEraLedgerView(..)
+  , TranslateEraConsensusState(..)
+  , EraTranslation(..)
+  , trivialEraTranslation
+    -- * Check that eras line up
+  , CheckTransition(..)
+  , EraTransitionCheck(..)
+  , trivialEraTransitionCheck
+  ) where
+
+import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Network.Block
+
+import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Protocol.Abstract
+
+import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
+                     (InPairs (..))
+
+{-------------------------------------------------------------------------------
+  Translate from one era to the next
+-------------------------------------------------------------------------------}
+
+newtype TranslateEraLedgerState blk blk' = TranslateEraLedgerState {
+      translateLedgerStateWith :: LedgerConfig blk
+                               -> LedgerConfig blk'
+                               -> EpochNo
+                               -> LedgerState blk
+                               -> LedgerState blk'
+    }
+
+newtype TranslateEraLedgerView blk blk' = TranslateEraLedgerView {
+      translateLedgerViewWith :: LedgerConfig blk
+                              -> LedgerConfig blk'
+                              -> EpochNo
+                              -> LedgerView (BlockProtocol blk)
+                              -> LedgerView (BlockProtocol blk')
+    }
+
+newtype TranslateEraConsensusState blk blk' = TranslateEraConsensusState {
+      translateConsensusStateWith :: ConsensusConfig (BlockProtocol blk)
+                                  -> ConsensusConfig (BlockProtocol blk')
+                                  -> EpochNo
+                                  -> ConsensusState (BlockProtocol blk)
+                                  -> ConsensusState (BlockProtocol blk')
+    }
+
+data EraTranslation xs = EraTranslation {
+      translateLedgerState    :: InPairs TranslateEraLedgerState xs
+    , translateLedgerView     :: InPairs TranslateEraLedgerView xs
+    , translateConsensusState :: InPairs TranslateEraConsensusState xs
+    }
+  deriving NoUnexpectedThunks
+       via OnlyCheckIsWHNF "EraTranslation" (EraTranslation xs)
+
+trivialEraTranslation :: EraTranslation '[blk]
+trivialEraTranslation = EraTranslation {
+      translateLedgerState    = PNil
+    , translateLedgerView     = PNil
+    , translateConsensusState = PNil
+    }
+
+{-------------------------------------------------------------------------------
+  Check that the transition lines up
+-------------------------------------------------------------------------------}
+
+data CheckTransition blk blk' = CheckTransition {
+      -- | The hash of the last block in one era must line up with the prev-hash
+      -- hash of the first block in the next.
+      checkTransitionWith :: BlockConfig blk
+                          -> BlockConfig blk'
+                          -> HeaderHash blk
+                          -> ChainHash blk'
+                          -> Bool
+    }
+
+newtype EraTransitionCheck xs = EraTransitionCheck {
+      getCheckEraTransition :: InPairs CheckTransition xs
+    }
+
+trivialEraTransitionCheck :: EraTransitionCheck '[blk]
+trivialEraTransitionCheck = EraTransitionCheck PNil

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
@@ -1,0 +1,295 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE EmptyCase           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+-- | Witness isomorphism between @b@ and @HardForkBlock '[b]@
+module Ouroboros.Consensus.HardFork.Combinator.Unary (
+    -- * Projections
+    projAnnTip
+  , projApplyTxErr
+  , projBlock
+  , projBlockConfig
+  , projChainHash
+  , projCodecConfig
+  , projConsensusConfig
+  , projConsensusState
+  , projForgeState
+  , projGenTx
+  , projGenTxId
+  , projHeader
+  , projHeaderHash
+  , projInitChainDB
+  , projIsLeader
+  , projLedgerConfig
+  , projLedgerState
+  , projLedgerView
+  , projQuery
+  , projTipInfo
+  , projTopLevelConfig
+  , projUpdateForgeState
+    -- * Injections
+  , injAnnTip
+  , injApplyTxErr
+  , injBlock
+  , injConsensusState
+  , injEnvelopeErr
+  , injForgeState
+  , injGenTx
+  , injGenTxId
+  , injHashInfo
+  , injHeader
+  , injHeaderHash
+  , injLedgerState
+  , injQuery
+  ) where
+
+import           Data.SOP.Strict
+import           Data.Type.Equality
+import           Data.Void
+
+import           Cardano.Slotting.EpochInfo
+
+import           Ouroboros.Network.Block
+
+import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Block.Forge
+import           Ouroboros.Consensus.BlockchainTime
+import           Ouroboros.Consensus.Config
+import qualified Ouroboros.Consensus.HardFork.History as History
+import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Mempool.API
+import           Ouroboros.Consensus.Protocol.Abstract
+
+import           Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB)
+import qualified Ouroboros.Consensus.Storage.ChainDB.Init as InitChainDB
+import           Ouroboros.Consensus.Storage.ImmutableDB (HashInfo (..))
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Block
+import           Ouroboros.Consensus.HardFork.Combinator.Forge ()
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
+import           Ouroboros.Consensus.HardFork.Combinator.Mempool
+import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+import           Ouroboros.Consensus.HardFork.Combinator.Protocol
+                     (HardForkEraLedgerView (..))
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra.Combined
+import           Ouroboros.Consensus.HardFork.Combinator.SingleEra.Wrappers
+import           Ouroboros.Consensus.HardFork.Combinator.State
+                     (HardForkState_ (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Telescope
+
+{-------------------------------------------------------------------------------
+  Projections
+-------------------------------------------------------------------------------}
+
+projIsLeader :: IsLeader (BlockProtocol (HardForkBlock '[b]))
+             -> IsLeader (BlockProtocol b)
+projIsLeader = getSingleEraIsLeader . unZ . getOneEraIsLeader
+
+projGenTx :: GenTx (HardForkBlock '[b]) -> GenTx b
+projGenTx = unZ . getOneEraGenTx . getHardForkGenTx
+
+injGenTx :: GenTx b -> GenTx (HardForkBlock '[b])
+injGenTx = HardForkGenTx . OneEraGenTx . Z
+
+projGenTxId :: GenTxId (HardForkBlock '[b]) -> GenTxId b
+projGenTxId = getSingleEraGenTxId . unZ . getOneEraGenTxId . getHardForkGenTxId
+
+injGenTxId :: GenTxId b -> GenTxId (HardForkBlock '[b])
+injGenTxId = HardForkGenTxId . OneEraGenTxId . Z . SingleEraGenTxId
+
+projBlock :: HardForkBlock '[b] -> b
+projBlock = unI . unZ . getOneEraBlock . getHardForkBlock
+
+injBlock :: b -> HardForkBlock '[b]
+injBlock = HardForkBlock . OneEraBlock . Z . I
+
+projHeaderHash :: HeaderHash (HardForkBlock '[b]) -> HeaderHash b
+projHeaderHash = getSingleEraHash . unZ . getOneEraHash
+
+injHeaderHash :: HeaderHash b -> HeaderHash (HardForkBlock '[b])
+injHeaderHash = OneEraHash . Z . SingleEraHash
+
+projChainHash :: ChainHash (HardForkBlock '[b]) -> ChainHash b
+projChainHash GenesisHash   = GenesisHash
+projChainHash (BlockHash h) = BlockHash (projHeaderHash h)
+
+projHeader :: Header (HardForkBlock '[b]) -> Header b
+projHeader = unZ . getOneEraHeader . getHardForkHeader
+
+injHeader :: Header b -> Header (HardForkBlock '[b])
+injHeader = HardForkHeader . OneEraHeader . Z
+
+projBlockConfig :: BlockConfig (HardForkBlock '[b]) -> BlockConfig b
+projBlockConfig = hd . getPerEraBlockConfig . hardForkBlockConfigPerEra
+
+projCodecConfig :: CodecConfig (HardForkBlock '[b]) -> CodecConfig b
+projCodecConfig = hd . getPerEraCodecConfig . hardForkCodecConfigPerEra
+
+projLedgerConfig :: forall b. SingleEraBlock b
+                 => LedgerConfig (HardForkBlock '[b])
+                 -> (EpochInfo Identity, LedgerConfig b)
+projLedgerConfig =
+      complete
+    . getSingleEraLedgerConfig
+    . hd
+    . getPerEraLedgerConfig
+    . hardForkLedgerConfigPerEra
+  where
+    complete :: PartialLedgerConfig b -> (EpochInfo Identity, LedgerConfig b)
+    complete cfg = (ei, completeLedgerConfig (Proxy @b) ei cfg)
+      where
+        ei :: EpochInfo Identity
+        ei = fixedSizeEpochInfo $
+               History.eraEpochSize (singleEraParams (Proxy @b) cfg)
+
+projConsensusConfig :: forall b. SingleEraBlock b
+                    => EpochInfo Identity
+                    -> ConsensusConfig (BlockProtocol (HardForkBlock '[b]))
+                    -> ConsensusConfig (BlockProtocol b)
+projConsensusConfig ei =
+      completeConsensusConfig (Proxy @(BlockProtocol b)) ei
+    . getSingleEraConsensusConfig
+    . hd
+    . getPerEraConsensusConfig
+    . hardForkConsensusConfigPerEra
+
+projLedgerState :: LedgerState (HardForkBlock '[b]) -> LedgerState b
+projLedgerState =
+      State.currentState
+    . Telescope.fromTZ
+    . getHardForkState
+    . getHardForkLedgerState
+
+injLedgerState :: SystemStart -> LedgerState b -> LedgerState (HardForkBlock '[b])
+injLedgerState systemStart =
+      HardForkLedgerState
+    . HardForkState
+    . Telescope.TZ
+    . State.Current (History.initBound systemStart)
+
+projLedgerView :: proxy b
+               -> LedgerView (BlockProtocol (HardForkBlock '[b]))
+               -> LedgerView (BlockProtocol b)
+projLedgerView _ =
+      hardForkEraLedgerView
+    . State.fromTZ
+
+projConsensusState :: ConsensusState (BlockProtocol (HardForkBlock '[b]))
+                   -> ConsensusState (BlockProtocol b)
+projConsensusState =
+      getSingleEraConsensusState
+    . State.currentState
+    . Telescope.fromTZ
+    . getHardForkState
+
+injConsensusState :: SystemStart
+                  -> ConsensusState (BlockProtocol b)
+                  -> ConsensusState (BlockProtocol (HardForkBlock '[b]))
+injConsensusState systemStart =
+      HardForkState
+    . Telescope.TZ
+    . State.Current (History.initBound systemStart)
+    . SingleEraConsensusState
+
+projTopLevelConfig :: forall b. SingleEraBlock b
+                   => TopLevelConfig (HardForkBlock '[b]) -> TopLevelConfig b
+projTopLevelConfig TopLevelConfig{..} = TopLevelConfig{
+      configConsensus  = projConsensusConfig ei configConsensus
+    , configLedger     = configLedger'
+    , configBlock      = projBlockConfig configBlock
+    }
+  where
+    (ei, configLedger') = projLedgerConfig configLedger
+
+projForgeState :: proxy b -> ForgeState (HardForkBlock '[b]) -> ForgeState b
+projForgeState _ = getSingleEraForgeState . hd . getPerEraForgeState
+
+injForgeState :: proxy b -> ForgeState b -> ForgeState (HardForkBlock '[b])
+injForgeState _ = PerEraForgeState . (:* Nil) . SingleEraForgeState
+
+injHashInfo :: HashInfo (HeaderHash b)
+            -> HashInfo (HeaderHash (HardForkBlock '[b]))
+injHashInfo info = HashInfo {
+      hashSize = hashSize info
+    , getHash  = injHeaderHash <$> getHash info
+    , putHash  = putHash info . projHeaderHash
+    }
+
+projInitChainDB :: InitChainDB m (HardForkBlock '[b]) -> InitChainDB m b
+projInitChainDB initDB = InitChainDB.InitChainDB {
+      InitChainDB.checkEmpty = InitChainDB.checkEmpty initDB
+    , InitChainDB.addBlock   = InitChainDB.addBlock initDB . injBlock
+    }
+
+projApplyTxErr :: ApplyTxErr (HardForkBlock '[b]) -> ApplyTxErr b
+projApplyTxErr (HardForkApplyTxErrFromEra err) =
+      getSingleEraApplyTxErr
+    . unZ
+    . getOneEraApplyTxErr
+    $ err
+projApplyTxErr (HardForkApplyTxErrWrongEra err) =
+      absurd
+    . mismatchOneEra
+    $ err
+
+injApplyTxErr :: ApplyTxErr b -> ApplyTxErr (HardForkBlock '[b])
+injApplyTxErr =
+      HardForkApplyTxErrFromEra
+    . OneEraApplyTxErr
+    . Z
+    . SingleEraApplyTxErr
+
+projTipInfo :: TipInfo (HardForkBlock '[b]) -> TipInfo b
+projTipInfo =
+      getSingleEraTipInfo
+    . unZ
+    . getOneEraTipInfo
+
+projAnnTip :: AnnTip (HardForkBlock '[b]) -> AnnTip b
+projAnnTip (AnnTip s b nfo) = AnnTip s b (projTipInfo nfo)
+
+injAnnTip :: AnnTip b -> AnnTip (HardForkBlock '[b])
+injAnnTip (AnnTip s b nfo) =
+    AnnTip s b (OneEraTipInfo (Z (SingleEraTipInfo nfo)))
+
+projQuery :: Query (HardForkBlock '[b]) result
+          -> (forall result'.
+                  (result :~: HardForkQueryResult '[b] result')
+               -> Query b result'
+               -> a)
+          -> a
+projQuery (HardForkQuery (QZ qry)) k = k Refl qry
+projQuery (HardForkQuery (QS qry)) _ = case qry of {}
+
+injQuery :: Query b result
+         -> Query (HardForkBlock '[b]) (HardForkQueryResult '[b] result)
+injQuery = HardForkQuery . QZ
+
+injEnvelopeErr :: OtherHeaderEnvelopeError b
+               -> OtherHeaderEnvelopeError (HardForkBlock '[b])
+injEnvelopeErr =
+      HardForkEnvelopeErrFromEra
+    . OneEraEnvelopeErr
+    . Z
+    . SingleEraEnvelopeErr
+
+projUpdateForgeState :: forall b m.
+                        Update m (ForgeState (HardForkBlock '[b]))
+                     -> Update m (ForgeState b)
+projUpdateForgeState = liftUpdate get set
+  where
+    get :: PerEraForgeState '[b] -> ForgeState b
+    get = projForgeState (Proxy @b)
+
+    set :: ForgeState b -> PerEraForgeState '[b] -> PerEraForgeState '[b]
+    set = const . injForgeState (Proxy @b)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/DerivingVia.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/DerivingVia.hs
@@ -1,0 +1,269 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Util.DerivingVia (
+    LiftNS(..)
+  , LiftNP(..)
+  , LiftTelescope(..)
+  , LiftMismatch(..)
+  , LiftNamedNS(..)
+  , LiftNamedNP(..)
+  , LiftNamedTelescope(..)
+  , LiftNamedMismatch(..)
+  ) where
+
+import           Data.List (intercalate)
+import           Data.Proxy
+import           Data.SOP.Dict
+import           Data.SOP.Strict
+import           Data.Typeable
+import           GHC.TypeLits
+
+import           Cardano.Prelude (NoUnexpectedThunks (..))
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Match (Mismatch)
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
+                     (Telescope)
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+proofAll :: SListI xs
+         => (forall x . Dict c x -> Dict d x)
+         -> Dict (All c) xs -> Dict (All d) xs
+proofAll f dict = all_NP (hmap f (unAll_NP dict))
+
+proofLift :: (SingleEraBlock x => c (f x))
+          => Dict SingleEraBlock x -> Dict (Compose c f) x
+proofLift Dict = Dict
+
+liftEras :: (All SingleEraBlock xs, forall x. SingleEraBlock x => c (f x))
+         => Proxy xs -> Proxy c -> Proxy f -> Dict (All (Compose c f)) xs
+liftEras _ _ _ = proofAll proofLift Dict
+
+{-------------------------------------------------------------------------------
+  LiftNS
+-------------------------------------------------------------------------------}
+
+newtype LiftNS f xs = LiftNS (NS f xs)
+
+instance (All SingleEraBlock xs, forall x. SingleEraBlock x => Eq (f x))
+      => Eq (LiftNS f xs) where
+  LiftNS x == LiftNS y =
+      case liftEras (Proxy @xs) (Proxy @Eq) (Proxy @f) of { Dict ->
+          x == y
+        }
+
+instance (All SingleEraBlock xs, forall x. SingleEraBlock x => Ord (f x))
+      => Ord (LiftNS f xs) where
+  LiftNS x `compare` LiftNS y =
+      case liftEras (Proxy @xs) (Proxy @Eq)  (Proxy @f) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @Ord) (Proxy @f) of { Dict ->
+          x `compare` y
+        }}
+
+instance (All SingleEraBlock xs, forall x. SingleEraBlock x => Show (f x))
+      => Show (LiftNS f xs) where
+  show (LiftNS x) =
+      case liftEras (Proxy @xs) (Proxy @Show) (Proxy @f) of { Dict ->
+          show x
+        }
+
+{-------------------------------------------------------------------------------
+  LiftNP
+-------------------------------------------------------------------------------}
+
+newtype LiftNP f xs = LiftNP (NP f xs)
+
+instance (All SingleEraBlock xs, forall x. SingleEraBlock x => Eq (f x))
+      => Eq (LiftNP f xs) where
+  LiftNP x == LiftNP y =
+      case liftEras (Proxy @xs) (Proxy @Eq) (Proxy @f) of { Dict ->
+          x == y
+        }
+
+instance (All SingleEraBlock xs, forall x. SingleEraBlock x => Ord (f x))
+      => Ord (LiftNP f xs) where
+  LiftNP x `compare` LiftNP y =
+      case liftEras (Proxy @xs) (Proxy @Eq)  (Proxy @f) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @Ord) (Proxy @f) of { Dict ->
+          x `compare` y
+        }}
+
+instance (All SingleEraBlock xs, forall x. SingleEraBlock x => Show (f x))
+      => Show (LiftNP f xs) where
+  show (LiftNP x) =
+      case liftEras (Proxy @xs) (Proxy @Show) (Proxy @f) of { Dict ->
+          show x
+        }
+
+{-------------------------------------------------------------------------------
+  LiftTelescope
+-------------------------------------------------------------------------------}
+
+newtype LiftTelescope g f xs = LiftTelescope (Telescope g f xs)
+
+instance ( All SingleEraBlock xs
+         , forall x. SingleEraBlock x => Eq (g x)
+         , forall x. SingleEraBlock x => Eq (f x)
+         ) => Eq (LiftTelescope g f xs) where
+  LiftTelescope x == LiftTelescope y =
+      case liftEras (Proxy @xs) (Proxy @Eq) (Proxy @g) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @Eq) (Proxy @f) of { Dict ->
+          x == y
+        }}
+
+instance ( All SingleEraBlock xs
+         , forall x. SingleEraBlock x => Ord (f x)
+         , forall x. SingleEraBlock x => Ord (g x)
+         ) => Ord (LiftTelescope g f xs) where
+  compare (LiftTelescope x) (LiftTelescope y) =
+      case liftEras (Proxy @xs) (Proxy @Eq)  (Proxy @g) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @Ord) (Proxy @g) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @Eq)  (Proxy @f) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @Ord) (Proxy @f) of { Dict ->
+          compare x y
+        }}}}
+
+instance ( All SingleEraBlock xs
+         , forall x. SingleEraBlock x => Show (g x)
+         , forall x. SingleEraBlock x => Show (f x)
+         ) => Show (LiftTelescope g f xs) where
+  show (LiftTelescope x) =
+      case liftEras (Proxy @xs) (Proxy @Show) (Proxy @g) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @Show) (Proxy @f) of { Dict ->
+          show x
+        }}
+
+{-------------------------------------------------------------------------------
+  LiftMismatch
+-------------------------------------------------------------------------------}
+
+newtype LiftMismatch f g xs = LiftMismatch (Mismatch f g xs)
+
+instance ( All SingleEraBlock xs
+         , forall x. SingleEraBlock x => Eq (f x)
+         , forall x. SingleEraBlock x => Eq (g x)
+         ) => Eq (LiftMismatch f g xs) where
+  LiftMismatch x == LiftMismatch y =
+      case liftEras (Proxy @xs) (Proxy @Eq) (Proxy @f) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @Eq) (Proxy @g) of { Dict ->
+          x == y
+        }}
+
+instance ( All SingleEraBlock xs
+         , forall x. SingleEraBlock x => Ord (f x)
+         , forall x. SingleEraBlock x => Ord (g x)
+         ) => Ord (LiftMismatch f g xs) where
+  compare (LiftMismatch x) (LiftMismatch y) =
+      case liftEras (Proxy @xs) (Proxy @Eq)  (Proxy @f) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @Ord) (Proxy @f) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @Eq)  (Proxy @g) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @Ord) (Proxy @g) of { Dict ->
+          compare x y
+        }}}}
+
+instance ( All SingleEraBlock xs
+         , forall x. SingleEraBlock x => Show (f x)
+         , forall x. SingleEraBlock x => Show (g x)
+         ) => Show (LiftMismatch f g xs) where
+  show (LiftMismatch x) =
+      case liftEras (Proxy @xs) (Proxy @Show) (Proxy @f) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @Show) (Proxy @g) of { Dict ->
+          show x
+        }}
+
+{-------------------------------------------------------------------------------
+  LiftNamedNS
+-------------------------------------------------------------------------------}
+
+newtype LiftNamedNS (name :: Symbol) f xs = LiftNamedNS (NS f xs)
+
+instance ( All SingleEraBlock xs
+         , forall x. SingleEraBlock x => NoUnexpectedThunks (f x)
+         , KnownSymbol name
+         ) => NoUnexpectedThunks (LiftNamedNS name f xs) where
+  showTypeOf _ = symbolVal (Proxy @name) ++ " " ++ showBlockTypes (sList :: SList xs)
+
+  whnfNoUnexpectedThunks ctxt (LiftNamedNS x) =
+      case liftEras (Proxy @xs) (Proxy @NoUnexpectedThunks) (Proxy @f) of { Dict ->
+          whnfNoUnexpectedThunks ctxt x
+        }
+
+{-------------------------------------------------------------------------------
+  LiftNamedNP
+-------------------------------------------------------------------------------}
+
+newtype LiftNamedNP (name :: Symbol) f xs = LiftNamedNP (NP f xs)
+
+instance ( All SingleEraBlock xs
+         , forall x. SingleEraBlock x => NoUnexpectedThunks (f x)
+         , KnownSymbol name
+         ) => NoUnexpectedThunks (LiftNamedNP name f xs) where
+  showTypeOf _ = symbolVal (Proxy @name) ++ " " ++ showBlockTypes (sList :: SList xs)
+
+  whnfNoUnexpectedThunks ctxt (LiftNamedNP x) =
+      case liftEras (Proxy @xs) (Proxy @NoUnexpectedThunks) (Proxy @f) of { Dict ->
+          whnfNoUnexpectedThunks ctxt x
+        }
+
+{-------------------------------------------------------------------------------
+  LiftNamedTelescope
+-------------------------------------------------------------------------------}
+
+newtype LiftNamedTelescope (name :: Symbol) f g xs = LiftNamedTelescope (Telescope f g xs)
+
+instance ( All SingleEraBlock xs
+         , forall x. SingleEraBlock x => NoUnexpectedThunks (f x)
+         , forall x. SingleEraBlock x => NoUnexpectedThunks (g x)
+         , KnownSymbol name
+         ) => NoUnexpectedThunks (LiftNamedTelescope name f g xs) where
+  showTypeOf _ = symbolVal (Proxy @name) ++ " " ++ showBlockTypes (sList :: SList xs)
+
+  whnfNoUnexpectedThunks ctxt (LiftNamedTelescope x) =
+      case liftEras (Proxy @xs) (Proxy @NoUnexpectedThunks) (Proxy @f) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @NoUnexpectedThunks) (Proxy @g) of { Dict ->
+          whnfNoUnexpectedThunks ctxt x
+        }}
+
+{-------------------------------------------------------------------------------
+  LiftNamedTelescope
+-------------------------------------------------------------------------------}
+
+newtype LiftNamedMismatch (name :: Symbol) f g xs = LiftNamedMismatch (Mismatch f g xs)
+
+instance ( All SingleEraBlock xs
+         , forall x. SingleEraBlock x => NoUnexpectedThunks (f x)
+         , forall x. SingleEraBlock x => NoUnexpectedThunks (g x)
+         , KnownSymbol name
+         ) => NoUnexpectedThunks (LiftNamedMismatch name f g xs) where
+  showTypeOf _ = symbolVal (Proxy @name) ++ " " ++ showBlockTypes (sList :: SList xs)
+
+  whnfNoUnexpectedThunks ctxt (LiftNamedMismatch x) =
+      case liftEras (Proxy @xs) (Proxy @NoUnexpectedThunks) (Proxy @f) of { Dict ->
+      case liftEras (Proxy @xs) (Proxy @NoUnexpectedThunks) (Proxy @g) of { Dict ->
+          whnfNoUnexpectedThunks ctxt x
+        }}
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+showBlockTypes :: All SingleEraBlock xs => SList xs -> String
+showBlockTypes =
+    (\names -> "[" ++ intercalate "," names ++ "]") . hcollapse . go
+  where
+    go :: All SingleEraBlock xs' => SList xs' -> NP (K String) xs'
+    go SNil  = Nil
+    go SCons = typeRep' :* go sList
+
+    typeRep' :: forall blk. SingleEraBlock blk => K String blk
+    typeRep' = K . show $ typeRep (Proxy @blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/InPairs.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/InPairs.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+-- | Intended for qualified import
+--
+-- > import Ouroboros.Consensus.HardFork.Combinator.Util.InPairs (InPairs(..))
+-- > import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
+module Ouroboros.Consensus.HardFork.Combinator.Util.InPairs (
+    -- * InPairs
+    InPairs(..)
+  , hmap
+  , hcmap
+  , hpure
+  , hcpure
+    -- * Requiring
+  , Requiring(..)
+  , RequiringBoth(..)
+  , requiring
+  , requiringBoth
+  ) where
+
+import           Data.SOP.Strict hiding (hcmap, hcpure, hmap, hpure)
+
+import           Ouroboros.Consensus.HardFork.Combinator.Util.SOP
+
+{-------------------------------------------------------------------------------
+  InPairs
+-------------------------------------------------------------------------------}
+
+-- | We have an @f x y@ for each pair @(x, y)@ of successive list elements
+data InPairs (f :: k -> k -> *) (xs :: [k]) where
+  PNil  :: InPairs f '[x]
+  PCons :: f x y -> InPairs f (y ': zs) -> InPairs f (x ': y ': zs)
+
+hmap :: SListI xs => (forall x y. f x y -> g x y) -> InPairs f xs -> InPairs g xs
+hmap = hcmap (Proxy @Top)
+
+hcmap :: forall proxy c f g xs. All c xs
+      => proxy c
+      -> (forall x y. (c x, c y) => f x y -> g x y)
+      -> InPairs f xs -> InPairs g xs
+hcmap _ f = go
+  where
+    go :: All c xs' => InPairs f xs' -> InPairs g xs'
+    go PNil         = PNil
+    go (PCons x xs) = PCons (f x) (go xs)
+
+hpure :: (SListI xs, IsNonEmpty xs) => (forall x y. f x y) -> InPairs f xs
+hpure = hcpure (Proxy @Top)
+
+hcpure :: forall proxy c xs f. (All c xs, IsNonEmpty xs)
+       => proxy c
+       -> (forall x y. (c x, c y) => f x y) -> InPairs f xs
+hcpure _ f =
+    case isNonEmpty (Proxy @xs) of
+      ProofNonEmpty _ -> go sList
+  where
+    go :: (c x, All c xs') => SList xs' -> InPairs f (x ': xs')
+    go SNil  = PNil
+    go SCons = PCons f (go sList)
+
+{-------------------------------------------------------------------------------
+  RequiringBoth
+-------------------------------------------------------------------------------}
+
+data Requiring h f x y = Require {
+      provide :: h x -> f x y
+    }
+
+data RequiringBoth h f x y = RequireBoth {
+      provideBoth :: h x -> h y -> f x y
+    }
+
+requiring :: SListI xs => NP h xs -> InPairs (Requiring h f) xs -> InPairs f xs
+requiring np =
+      requiringBoth np
+    . hmap (\f -> RequireBoth $ \hx _hy -> provide f hx)
+
+requiringBoth :: NP h xs -> InPairs (RequiringBoth h f) xs -> InPairs f xs
+requiringBoth = flip go
+  where
+    go :: InPairs (RequiringBoth h f) xs -> NP h xs -> InPairs f xs
+    go PNil         _              = PNil
+    go (PCons f fs) (x :* y :* zs) = PCons (provideBoth f x y) (go fs (y :* zs))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Match.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Match.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DerivingStrategies   #-}
+{-# LANGUAGE EmptyCase            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Intended for qualified import
+--
+-- > import Ouroboros.Consensus.HardFork.Combinator.Util.Match (Mismatch)
+-- > import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Match as Match
+module Ouroboros.Consensus.HardFork.Combinator.Util.Match (
+    Mismatch(..)
+  , matchNS
+  , matchTelescope
+    -- * Utilities
+  , mismatchOne
+    -- * SOP operators
+  , bihap
+  , bihmap
+  , bihcmap
+  ) where
+
+import           Data.Bifunctor
+import           Data.Functor.Product
+import           Data.SOP.Strict
+import           Data.Void
+
+import           Cardano.Prelude (NoUnexpectedThunks (..),
+                     allNoUnexpectedThunks)
+
+import           Ouroboros.Consensus.HardFork.Combinator.Util.SOP ()
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
+                     (Telescope (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Telescope
+
+{-------------------------------------------------------------------------------
+  Main API
+-------------------------------------------------------------------------------}
+
+data Mismatch :: (k -> *) -> (k -> *) -> [k] -> * where
+  ML :: f x -> NS g xs -> Mismatch f g (x ': xs)
+  MR :: NS f xs -> g x -> Mismatch f g (x ': xs)
+  MS :: Mismatch f g xs -> Mismatch f g (x ': xs)
+
+matchNS :: NS f xs -> NS g xs -> Either (Mismatch f g xs) (NS (Product f g) xs)
+matchNS = go
+  where
+    go :: NS f xs -> NS g xs -> Either (Mismatch f g xs) (NS (Product f g) xs)
+    go (Z fx) (Z gx) = Right (Z (Pair fx gx))
+    go (S l)  (S r)  = bimap MS S $ go l r
+    go (Z fx) (S r)  = Left $ ML fx r
+    go (S l)  (Z gx) = Left $ MR l gx
+
+matchTelescope :: NS h xs
+               -> Telescope g f xs
+               -> Either (Mismatch h f xs) (Telescope g (Product h f) xs)
+matchTelescope = go
+  where
+    go :: NS h xs
+       -> Telescope g f xs
+       -> Either (Mismatch h f xs) (Telescope g (Product h f) xs)
+    go (Z l)  (TZ fx)    = Right (TZ (Pair l fx))
+    go (S r)  (TS  gx t) = bimap MS (TS gx) $ go r t
+    go (Z hx) (TS _gx t) = Left $ ML hx (Telescope.tip t)
+    go (S l)  (TZ fx)    = Left $ MR l fx
+
+{-------------------------------------------------------------------------------
+  Utilities
+-------------------------------------------------------------------------------}
+
+-- | We cannot give a mismatch if we have only one type variable
+mismatchOne :: Mismatch f g '[x] -> Void
+mismatchOne (ML _ ns) = case ns of {}
+mismatchOne (MR ns _) = case ns of {}
+mismatchOne (MS m)    = case m  of {}
+
+{-------------------------------------------------------------------------------
+  Subset of the (generalized) SOP operators
+-------------------------------------------------------------------------------}
+
+bihap :: NP (f -.-> f') xs
+      -> NP (g -.-> g') xs
+      -> Mismatch f g xs -> Mismatch f' g' xs
+bihap = \gs fs t -> go t gs fs
+  where
+    go :: Mismatch f g xs
+       -> NP (f -.-> f') xs
+       -> NP (g -.-> g') xs
+       -> Mismatch f' g' xs
+    go (ML fx r) (f :* _)  (_ :* gs) = ML (apFn f fx) (hap gs r)
+    go (MR l gx) (_ :* fs) (g :* _)  = MR (hap fs l) (apFn g gx)
+    go (MS m)    (_ :* fs) (_ :* gs) = MS (go m fs gs)
+
+bihmap :: SListI xs
+       => (forall x. f x -> f' x)
+       -> (forall x. g x -> g' x)
+       -> Mismatch f g xs -> Mismatch f' g' xs
+bihmap = bihcmap (Proxy @Top)
+
+-- | Bifunctor analogue of 'hcmap'
+bihcmap :: All c xs
+        => proxy c
+        -> (forall x. c x => f x -> f' x)
+        -> (forall x. c x => g x -> g' x)
+        -> Mismatch f g xs -> Mismatch f' g' xs
+bihcmap p g f = bihap (hcpure p (fn g)) (hcpure p (fn f))
+
+{-------------------------------------------------------------------------------
+  Standard type class instances
+-------------------------------------------------------------------------------}
+
+deriving stock instance ( All (Compose Eq f) xs
+                        , All (Compose Eq g) xs
+                        ) => Eq (Mismatch f g xs)
+
+deriving stock instance ( All (Compose Eq  f) xs
+                        , All (Compose Ord f) xs
+                        , All (Compose Eq  g) xs
+                        , All (Compose Ord g) xs
+                        ) => Ord (Mismatch f g xs)
+
+deriving stock instance ( All (Compose Show f) xs
+                        , All (Compose Show g) xs
+                        ) => Show (Mismatch f g xs)
+
+instance ( All (Compose NoUnexpectedThunks f) xs
+         , All (Compose NoUnexpectedThunks g) xs
+         ) => NoUnexpectedThunks (Mismatch f g xs) where
+  showTypeOf _ = "Mismatch"
+  whnfNoUnexpectedThunks ctxt = \case
+    ML l r -> allNoUnexpectedThunks [
+                  noUnexpectedThunks ("l" : "ML" : ctxt) l
+                , noUnexpectedThunks ("r" : "ML" : ctxt) r
+                ]
+    MR l r -> allNoUnexpectedThunks [
+                  noUnexpectedThunks ("l" : "MR" : ctxt) l
+                , noUnexpectedThunks ("r" : "MR" : ctxt) r
+                ]
+    MS m   -> noUnexpectedThunks ("MS" : ctxt) m

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/SOP.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/SOP.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE EmptyCase            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Util.SOP (
+    -- * Minor variations on standard SOP operators
+    sequence_NS'
+  , map_NP'
+  , partition_NS
+  , Lens(..)
+  , lenses_NP
+    -- * Type-level non-empty lists
+  , IsNonEmpty(..)
+  , ProofNonEmpty(..)
+  ) where
+
+import           Data.SOP.Strict
+
+{-------------------------------------------------------------------------------
+  Minor variations on standard SOP operators
+-------------------------------------------------------------------------------}
+
+-- | Version of 'sequence_NS' that requires only 'Functor'
+--
+-- The version in the library requires 'Applicative', which is unnecessary.
+sequence_NS' :: forall xs f g. Functor f
+             => NS (f :.: g) xs -> f (NS g xs)
+sequence_NS' = go
+  where
+    go :: NS (f :.: g) xs' -> f (NS g xs')
+    go (Z (Comp fx)) = Z <$> fx
+    go (S r)         = S <$> go r
+
+-- | Version of 'map_NP' that does not require a singleton
+map_NP' :: forall f g xs. (forall a. f a -> g a) -> NP f xs -> NP g xs
+map_NP' f = go
+  where
+    go :: NP f xs' -> NP g xs'
+    go Nil       = Nil
+    go (x :* xs) = f x :* go xs
+
+partition_NS :: forall xs f. SListI xs => [NS f xs] -> NP ([] :.: f) xs
+partition_NS =
+      foldr (hzipWith append) (hpure nil)
+    . map (hexpand nil . hmap singleton)
+  where
+    nil :: ([] :.: f) a
+    nil = Comp []
+
+    singleton :: f a -> ([] :.: f) a
+    singleton = Comp . (:[])
+
+    append :: ([] :.: f) a -> ([] :.: f) a -> ([] :.: f) a
+    append (Comp as) (Comp as') = Comp (as ++ as')
+
+-- | Simple lens to access an element of an n-ary product.
+data Lens f xs a = Lens {
+      getter :: NP f xs -> f a
+    , setter :: f a -> NP f xs -> NP f xs
+    }
+
+-- | Generate all lenses to access the element of an n-ary product.
+lenses_NP :: forall f xs. SListI xs => NP (Lens f xs) xs
+lenses_NP = go sList
+  where
+    go :: SList xs' -> NP (Lens f xs') xs'
+    go SNil  = Nil
+    go SCons = lensFirst :* hmap shiftLens (go sList)
+
+    lensFirst :: Lens f (x ': xs') x
+    lensFirst = Lens {
+          getter = hd
+        , setter = \a' (_ :* as) -> a' :* as
+        }
+
+    shiftLens :: Lens f xs' a -> Lens f (x ': xs') a
+    shiftLens l = Lens {
+          getter = getter l . tl
+        , setter = \a' (a :* as) -> a :* setter l a' as
+        }
+
+{-------------------------------------------------------------------------------
+  Type-level non-empty lists
+-------------------------------------------------------------------------------}
+
+data ProofNonEmpty :: [*] -> * where
+  ProofNonEmpty :: Proxy x -> ProofNonEmpty (x ': xs)
+
+class IsNonEmpty xs where
+  isNonEmpty :: proxy xs -> ProofNonEmpty xs
+
+instance IsNonEmpty (x ': xs) where
+  isNonEmpty _ = ProofNonEmpty (Proxy @x)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Tails.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Tails.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+-- > import Ouroboros.Consensus.HardFork.Combinator.Util.Tails (Tails(..))
+-- > import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
+module Ouroboros.Consensus.HardFork.Combinator.Util.Tails (
+    Tails(..)
+  , hmap
+  , hcmap
+  , hpure
+  , hcpure
+  ) where
+
+import           Data.SOP.Strict hiding (hcmap, hcpure, hmap, hpure)
+import qualified Data.SOP.Strict as SOP
+
+{-------------------------------------------------------------------------------
+  Tails
+-------------------------------------------------------------------------------}
+
+-- | For every tail @(x ': xs)@ of the list, an @f x y@ for every @y@ in @xs@
+data Tails (f :: k -> k -> *) (xs :: [k]) where
+  TNil  :: Tails f '[]
+  TCons :: NP (f x) xs -> Tails f xs -> Tails f (x ': xs)
+
+hmap :: SListI xs
+     => (forall x y. f x y -> g x y)
+     -> Tails f xs -> Tails g xs
+hmap = hcmap (Proxy @Top)
+
+hcmap :: forall proxy c f g xs. All c xs
+      => proxy c
+      -> (forall x y. (c x, c y) => f x y -> g x y)
+      -> Tails f xs -> Tails g xs
+hcmap p g = go
+  where
+    go :: All c xs' => Tails f xs' -> Tails g xs'
+    go TNil           = TNil
+    go (TCons fs fss) = TCons (SOP.hcmap p g fs) (go fss)
+
+hpure :: SListI xs => (forall x y. f x y) -> Tails f xs
+hpure = hcpure (Proxy @Top)
+
+hcpure :: forall proxy f c xs. All c xs
+       => proxy c
+       -> (forall x y. (c x, c y) => f x y) -> Tails f xs
+hcpure p f = go sList
+  where
+    go :: All c xs' => SList xs' -> Tails f xs'
+    go SNil  = TNil
+    go SCons = TCons (SOP.hcpure p f) (go sList)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Telescope.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Telescope.hs
@@ -1,0 +1,511 @@
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE EmptyCase            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Intended for qualified import
+--
+-- > import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Telescope
+module Ouroboros.Consensus.HardFork.Combinator.Util.Telescope (
+    -- * Telescope
+    Telescope(..)
+  , sequence
+    -- ** Utilities
+  , tip
+  , fromTip
+  , toAtMost
+  , fromTZ
+    -- ** Bifunctor analogues of SOP functions
+  , bihap
+  , bihmap
+  , bihczipWith
+    -- * Extension, retraction, alignment
+  , Extend(..)
+  , extend
+  , Retract(..)
+  , retract
+  , align
+    -- ** Simplified API
+  , extendIf
+  , retractIf
+  , alignExtend
+  , alignExtendNS
+    -- * Additional API
+  , ScanNext(..)
+  , scanl
+  ) where
+
+import           Prelude hiding (scanl, sequence, zipWith)
+
+import           Data.Functor.Product
+import           Data.Kind
+import           Data.SOP.Strict
+import           GHC.Stack
+
+import           Cardano.Prelude (NoUnexpectedThunks (..),
+                     allNoUnexpectedThunks)
+import           Ouroboros.Consensus.Util.Counting
+
+import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
+                     (InPairs (..), Requiring (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Tails (Tails (..))
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
+
+{-------------------------------------------------------------------------------
+  Telescope
+-------------------------------------------------------------------------------}
+
+-- | Telescope
+--
+-- A telescope is an extension of an 'NS', where every time we "go right" in the
+-- sum we have an additional value.
+--
+-- Blockchain intuition: think of @g@ as representing some kind of past state,
+-- and @f@ some kind of current state. Then depending on how many hard fork
+-- transitions we have had, we might either have, say
+--
+-- > TZ currentByronState
+-- > TS pastByronState $ TZ currentShelleyState
+-- > TS pastByronState $ TS pastShelleyState $ TZ currentGoguenState
+--
+-- The 'Telescope' API mostly follows @sop-core@ conventions, supporting
+-- functor ('hmap', 'hcmap'), applicative ('hap', 'hpure'), foldable
+-- ('hcollapse') and traversable ('hsequence''). However, since 'Telescope'
+-- is a bi-functor, it cannot reuse the @sop-core@ classes. The naming scheme
+-- of the functions is adopted from @sop-core@ though; for example:
+--
+-- > bi h (c) zipWith
+-- > |  |  |    |
+-- > |  |  |    \ zipWith: the name from base
+-- > |  |  |
+-- > |  |  \ constrained: version of the function with a constraint parameter
+-- > |  |
+-- > |  \ higher order: 'Telescope' (like 'NS'/'NP') is a /higher order/ functor
+-- > |
+-- > \ bifunctor: 'Telescope' (unlike 'NS'/'NP') is a higher order /bifunctor/
+--
+-- In addition to the standard SOP operators, the new operators that make
+-- a 'Telescope' a telescope are 'extend', 'retract' and 'align'; see their
+-- documentation for details.
+data Telescope (g :: k -> Type) (f :: k -> Type) (xs :: [k]) where
+  TZ :: !(f x) ->                        Telescope g f (x ': xs)
+  TS :: !(g x) -> !(Telescope g f xs) -> Telescope g f (x ': xs)
+
+{-------------------------------------------------------------------------------
+  SOP class instances for 'Telescope'
+-------------------------------------------------------------------------------}
+
+type instance Prod    (Telescope g)   = NP
+type instance SListIN (Telescope g)   = SListI
+type instance AllN    (Telescope g) c = All c
+
+instance HAp (Telescope g) where
+  hap = flip go
+    where
+      -- We could define this in terms of 'bihap' but we lack 'SListI'
+      go :: Telescope g f xs -> NP (f -.-> f') xs -> Telescope g f' xs
+      go (TZ fx)   (f :* _)  = TZ (apFn f fx)
+      go (TS gx t) (_ :* fs) = TS gx (go t fs)
+
+instance HTraverse_ (Telescope g) where
+  hctraverse_ p = bihctraverse_ p (\_ -> pure ())
+  htraverse_    = bihtraverse_    (\_ -> pure ())
+
+instance HSequence (Telescope g) where
+  hsequence'    = bihsequence' . bihmap (Comp . pure) id
+  hctraverse' p = bihctraverse' p pure
+  htraverse'    = bihtraverse'    pure
+
+-- | Specialization of 'hsequence'' with weaker constraints
+-- ('Functor' rather than 'Applicative')
+sequence :: forall m g f xs. Functor m
+         => Telescope g (m :.: f) xs -> m (Telescope g f xs)
+sequence = go
+  where
+    go :: Telescope g (m :.: f) xs' -> m (Telescope g f xs')
+    go (TZ (Comp fx)) = TZ <$> fx
+    go (TS gx t)      = TS gx <$> go t
+
+{-------------------------------------------------------------------------------
+  Bifunctor analogues of class methods
+-------------------------------------------------------------------------------}
+
+-- | Bifunctor analogue of 'hap'
+bihap :: NP (g -.-> g') xs
+      -> NP (f -.-> f') xs
+      -> Telescope g f xs -> Telescope g' f' xs
+bihap = \gs fs t -> go t gs fs
+  where
+    go :: Telescope g f xs
+       -> NP (g -.-> g') xs
+       -> NP (f -.-> f') xs
+       -> Telescope g' f' xs
+    go (TZ fx)   _         (f :* _)  = TZ (apFn f fx)
+    go (TS gx t) (g :* gs) (_ :* fs) = TS (apFn g gx) (go t gs fs)
+
+-- | Bifunctor analogue of 'hctraverse''
+bihctraverse' :: forall proxy c m g g' f f' xs. (All c xs, Applicative m)
+              => proxy c
+              -> (forall x. c x => g x -> m (g' x))
+              -> (forall x. c x => f x -> m (f' x))
+              -> Telescope g f xs -> m (Telescope g' f' xs)
+bihctraverse' _ g f = go
+  where
+    go :: All c xs' => Telescope g f xs' -> m (Telescope g' f' xs')
+    go (TZ fx)   = TZ <$> f fx
+    go (TS gx t) = TS <$> g gx <*> go t
+
+-- | Bifunctor analogue of 'htraverse''
+bihtraverse' :: (SListI xs, Applicative m)
+             => (forall x. g x -> m (g' x))
+             -> (forall x. f x -> m (f' x))
+             -> Telescope g f xs -> m (Telescope g' f' xs)
+bihtraverse' = bihctraverse' (Proxy @Top)
+
+-- | Bifunctor analogue of 'hsequence''
+bihsequence' :: forall m g f xs. (SListI xs, Applicative m)
+             => Telescope (m :.: g) (m :.: f) xs -> m (Telescope g f xs)
+bihsequence' = bihtraverse' unComp unComp
+
+-- | Bifunctor analogue of 'hctraverse_'
+bihctraverse_ :: forall proxy c xs m g f. (All c xs, Applicative m)
+              => proxy c
+              -> (forall x. c x => g x -> m ())
+              -> (forall x. c x => f x -> m ())
+              -> Telescope g f xs -> m ()
+bihctraverse_ _ g f = go
+  where
+    go :: All c xs' => Telescope g f xs' -> m ()
+    go (TZ fx)   = f fx
+    go (TS gx t) = g gx *> go t
+
+bihtraverse_ :: (SListI xs, Applicative m)
+             => (forall x. g x -> m ())
+             -> (forall x. f x -> m ())
+             -> Telescope g f xs -> m ()
+bihtraverse_ = bihctraverse_ (Proxy @Top)
+
+{-------------------------------------------------------------------------------
+  Bifunctor analogues of derived functions
+-------------------------------------------------------------------------------}
+
+-- | Bifunctor analogue of 'hmap'
+bihmap :: SListI xs
+       => (forall x. g x -> g' x)
+       -> (forall x. f x -> f' x)
+       -> Telescope g f xs -> Telescope g' f' xs
+bihmap = bihcmap (Proxy @Top)
+
+-- | Bifunctor analogue of 'hcmap'
+bihcmap :: All c xs
+        => proxy c
+        -> (forall x. c x => g x -> g' x)
+        -> (forall x. c x => f x -> f' x)
+        -> Telescope g f xs -> Telescope g' f' xs
+bihcmap p g f = bihap (hcpure p (fn g)) (hcpure p (fn f))
+
+-- | Bifunctor equivalent of 'hczipWith'
+bihczipWith :: All c xs
+            => proxy c
+            -> (forall x. c x => h x -> g x -> g' x)
+            -> (forall x. c x => h x -> f x -> f' x)
+            -> NP h xs -> Telescope g f xs -> Telescope g' f' xs
+bihczipWith p g f ns = bihap (hcmap p (fn . g) ns) (hcmap p (fn . f) ns)
+
+{-------------------------------------------------------------------------------
+  Simple telescope
+
+  This is an internal type that is useful primarily useful as a sanity check
+  of our bifunctor generalizations.
+-------------------------------------------------------------------------------}
+
+-- | 'Telescope' with both functors set to the same @f@
+newtype SimpleTelescope f xs = SimpleTelescope {
+      getSimpleTelescope :: Telescope f f xs
+    }
+
+type instance Prod    SimpleTelescope   = NP
+type instance SListIN SimpleTelescope   = SListI
+type instance AllN    SimpleTelescope c = All c
+
+instance HAp SimpleTelescope where
+  hap fs = SimpleTelescope . bihap fs fs . getSimpleTelescope
+
+instance HTraverse_ SimpleTelescope where
+  hctraverse_ p f = bihctraverse_ p f f . getSimpleTelescope
+  htraverse_    f = bihtraverse_    f f . getSimpleTelescope
+
+instance HSequence SimpleTelescope where
+  hsequence'      = fmap SimpleTelescope . bihsequence'        . getSimpleTelescope
+  hctraverse' p f = fmap SimpleTelescope . bihctraverse' p f f . getSimpleTelescope
+  htraverse'    f = fmap SimpleTelescope . bihtraverse'    f f . getSimpleTelescope
+
+{-------------------------------------------------------------------------------
+  Utilities
+-------------------------------------------------------------------------------}
+
+tip :: Telescope g f xs -> NS f xs
+tip (TZ   l) = Z l
+tip (TS _ r) = S (tip r)
+
+fromTip :: NS f xs -> Telescope (K ()) f xs
+fromTip (Z l) = TZ l
+fromTip (S r) = TS (K ()) (fromTip r)
+
+toAtMost :: Telescope (K a) (K (Maybe a)) xs -> AtMost xs a
+toAtMost = go
+  where
+    go :: Telescope (K a) (K (Maybe a)) xs -> AtMost xs a
+    go (TZ (K ma))  = maybe AtMostNil atMostOne ma
+    go (TS (K a) t) = AtMostCons a (go t)
+
+fromTZ :: Telescope g f '[x] -> f x
+fromTZ (TZ fx)  = fx
+fromTZ (TS _ t) = case t of {}
+
+{-------------------------------------------------------------------------------
+  Extension and retraction
+-------------------------------------------------------------------------------}
+
+newtype Extend m g f x y = Extend { extendWith :: f x -> m (g x, f y) }
+
+-- | Extend the telescope
+--
+-- We will not attempt to extend the telescope past its final segment.
+--
+-- Blockchain intuition: suppose we have a telescope containing the ledger
+-- state. The "how to extend" argument would take, say, the final Byron
+-- state to the initial Shelley state; and "where to extend from" argument
+-- would indicate when we want to extend: when the current slot number has
+-- gone past the end of the Byron era.
+extend :: forall m h g f xs. Monad m
+       => InPairs (Requiring h (Extend m g f)) xs -- ^ How to extend
+       -> NP (f -.-> Maybe :.: h) xs              -- ^ Where to extend /from/
+       -> Telescope g f xs -> m (Telescope g f xs)
+extend = go
+  where
+    go :: InPairs (Requiring h (Extend m g f)) xs'
+       -> NP (f -.-> Maybe :.: h) xs'
+       -> Telescope g f xs' -> m (Telescope g f xs')
+    go PNil _ (TZ fx) =
+        return (TZ fx)
+    go (PCons e es) (p :* ps) (TZ fx) =
+        case unComp $ apFn p fx of
+          Nothing ->
+            return (TZ fx)
+          Just hx -> do
+            (gx, fy) <- extendWith (provide e hx) fx
+            TS gx <$> go es ps (TZ fy)
+    go (PCons _ es) (_ :* ps) (TS gx fx) =
+        TS gx <$> go es ps fx
+    go PNil _ (TS _ t) =
+        case t of {}
+
+newtype Retract m g f x y = Retract { retractWith :: g x -> f y -> m (f x) }
+
+-- | Retract a telescope
+--
+-- Blockchain intuition: suppose we have a telescope containing the consensus
+-- state. When we rewind the consensus state, we might cross a hard fork
+-- transition point. So we first /retract/ the telescope /to/ the era containing
+-- the slot number that we want to rewind to, and only then call
+-- 'rewindConsensusState' on that era. Of course, retraction may fail (we
+-- might not /have/ past consensus state to rewind to anymore); this failure
+-- would require a choice for a particular monad @m@.
+retract :: forall m h g f xs. (Monad m, SListI xs)
+        => Tails (Requiring h (Retract m g f)) xs  -- ^ How to retract
+        -> NP (g -.-> Maybe :.: h) xs              -- ^ Where to retract /to/
+        -> Telescope g f xs -> m (Telescope g f xs)
+retract = go
+  where
+    go :: SListI xs'
+       => Tails (Requiring h (Retract m g f)) xs'
+       -> NP (g -.-> Maybe :.: h) xs'
+       -> Telescope g f xs' -> m (Telescope g f xs')
+    go _            _         (TZ fx)   = return $ TZ fx
+    go (TCons r rs) (p :* ps) (TS gx t) =
+        case unComp (apFn p gx) of
+          Just hx ->
+            fmap (TZ . hcollapse) $ hsequence' $
+              hzipWith (retractAux hx gx) r (tip t)
+          Nothing ->
+            TS gx <$> go rs ps t
+
+-- | Internal auxiliary to 'retract' and 'alignWith'
+retractAux :: Functor m
+           => h x  -- Proof that we need to retract
+           -> g x  -- Era we are retracting to
+           -> Requiring h (Retract m g f) x z
+           -> f z  -- Current tip (what we are retracting from)
+           -> (m :.: K (f x)) z
+retractAux hx gx r fz = Comp $ K <$> retractWith (provide r hx) gx fz
+
+-- | Align a telescope with another, then apply a function to the tips
+--
+-- Aligning is a combination of extension and retraction, extending or
+-- retracting the telescope as required to match up with the other telescope.
+--
+-- Blockchain intuition: suppose we have one telescope containing the
+-- already-ticked ledger state, and another telescope containing the consensus
+-- state. Since the ledger state has already been ticked, it might have been
+-- advanced to the next era. If this happens, we should then align the
+-- consensus state with the ledger state, moving /it/ also to the next era,
+-- before we can do the consensus header validation check. Note that in this
+-- particular example, the ledger state will always be ahead of the consensus
+-- state, never behind; 'alignExtend' can be used in this case.
+align :: forall m g' g f' f f'' xs. (SListI xs, Monad m)
+      => InPairs (Requiring g' (Extend  m g f)) xs  -- ^ How to extend
+      -> Tails   (Requiring f' (Retract m g f)) xs  -- ^ How to retract
+      -> NP (f' -.-> f -.-> f'') xs  -- ^ Function to apply at the tip
+      -> Telescope g' f' xs          -- ^ Telescope we are aligning with
+      -> Telescope g f xs -> m (Telescope g f'' xs)
+align = go
+  where
+    go :: SListI xs'
+       => InPairs (Requiring g' (Extend  m g f)) xs'
+       -> Tails   (Requiring f' (Retract m g f)) xs'
+       -> NP (f' -.-> f -.-> f'') xs'
+       -> Telescope g' f' xs' -> Telescope g f xs' -> m (Telescope g f'' xs')
+    go _ _ (f :* _) (TZ f'x) (TZ fx) =
+        return $ TZ (f `apFn` f'x `apFn` fx)
+    go (PCons _ es) (TCons _ rs) (_ :* fs) (TS _ f'x) (TS gx fx) =
+        TS gx <$> go es rs fs f'x fx
+    go _ (TCons r _) (f :* _) (TZ f'x) (TS gx fx) =
+        fmap (TZ . (\fx' -> f `apFn` f'x `apFn` fx') . hcollapse) $ hsequence' $
+          hzipWith (retractAux f'x gx) r (tip fx)
+    go (PCons e es) (TCons _ rs) (_ :* fs) (TS g'x t'x) (TZ fx) = do
+        (gx, fy) <- extendWith (provide e g'x) fx
+        TS gx <$> go es rs fs t'x (TZ fy)
+    go PNil _ _ _ (TS _ t) =
+        case t of {}
+    go PNil _ _ (TS _ t) _ =
+        case t of {}
+
+{-------------------------------------------------------------------------------
+  Derived API
+-------------------------------------------------------------------------------}
+
+-- | Version of 'extend' where the evidence is a simple 'Bool'
+extendIf :: (SListI xs, Monad m)
+         => InPairs (Extend m g f) xs -- ^ How to extend
+         -> NP (f -.-> K Bool) xs     -- ^ Where to extend /from/
+         -> Telescope g f xs -> m (Telescope g f xs)
+extendIf es ps =
+    extend
+      (InPairs.hmap (Require . const) es)
+      (hmap (\f -> fn $ fromBool . apFn f) ps)
+
+-- | Version of 'retract' where the evidence is a simple 'Bool'
+retractIf :: (Monad m, SListI xs)
+          => Tails (Retract m g f) xs  -- ^ How to retract
+          -> NP (g -.-> K Bool) xs     -- ^ Where to retract /to/
+          -> Telescope g f xs -> m (Telescope g f xs)
+retractIf rs ps =
+    retract
+      (Tails.hmap (Require . const) rs)
+      (hmap (\f -> fn $ fromBool . apFn f) ps)
+
+-- | Version of 'align' that never retracts, only extends
+--
+-- PRE: The telescope we are aligning with cannot be behind us.
+alignExtend :: (SListI xs, Monad m, HasCallStack)
+            => InPairs (Requiring g' (Extend m g f)) xs  -- ^ How to extend
+            -> NP (f' -.-> f -.-> f'') xs  -- ^ Function to apply at the tip
+            -> Telescope g' f' xs          -- ^ Telescope we are aligning with
+            -> Telescope g f xs -> m (Telescope g f'' xs)
+alignExtend es =
+    align es (Tails.hpure $ Require $ \_ -> error precondition)
+  where
+    precondition :: String
+    precondition = "alignExtend: precondition violated"
+
+-- | Version of 'alignExtend' that extends with an NS instead
+alignExtendNS :: (SListI xs, Monad m, HasCallStack)
+              => InPairs (Extend m g f) xs   -- ^ How to extend
+              -> NP (f' -.-> f -.-> f'') xs  -- ^ Function to apply at the tip
+              -> NS f' xs                    -- ^ NS we are aligning with
+              -> Telescope g f xs -> m (Telescope g f'' xs)
+alignExtendNS es atTip ns =
+   alignExtend
+     (InPairs.hmap (Require . const) es)
+     atTip
+     (fromTip ns)
+
+-- | Internal auxiliary to 'extendIf' and 'retractIf'
+fromBool :: K Bool x -> (Maybe :.: K ()) x
+fromBool (K True)  = Comp $ Just $ K ()
+fromBool (K False) = Comp $ Nothing
+
+{-------------------------------------------------------------------------------
+  Additional API
+-------------------------------------------------------------------------------}
+
+newtype ScanNext h g x y = ScanNext { getNext :: h x -> g x -> h y }
+
+-- | Telescope analogue of 'scanl' on lists
+--
+-- This function is modelled on
+--
+-- > scanl :: (b -> a -> b) -> b -> [a] -> [b]
+--
+-- but there are a few differences:
+--
+-- * Since every seed has a different type, we must be given a function
+--   for each transition.
+-- * Unlike 'scanl', we preserve the length of the telescope
+--   ('scanl' prepends the initial seed)
+-- * Instead of generating a telescope containing only the seeds, we
+--   instead pair the seeds with the elements.
+scanl :: InPairs (ScanNext h g) (x ': xs)
+      -> h x
+      -> Telescope g f (x ': xs)
+      -> Telescope (Product h g) (Product h f) (x ': xs)
+scanl = go
+  where
+    go :: InPairs (ScanNext h g) (x' ': xs')
+       -> h x'
+       -> Telescope g f (x' ': xs')
+       -> Telescope (Product h g) (Product h f) (x' ': xs')
+    go _            hx (TZ fx)   = TZ (Pair hx fx)
+    go (PCons f fs) hx (TS gx t) = TS (Pair hx gx) $ go fs (getNext f hx gx) t
+    go PNil         _  (TS _  t) = case t of {}
+
+{-------------------------------------------------------------------------------
+  Standard type class instances
+-------------------------------------------------------------------------------}
+
+deriving instance ( All (Compose Eq g) xs
+                  , All (Compose Eq f) xs
+                  ) => Eq (Telescope g f xs)
+
+deriving instance ( All (Compose Eq  g) xs
+                  , All (Compose Ord g) xs
+                  , All (Compose Eq  f) xs
+                  , All (Compose Ord f) xs
+                  ) => Ord (Telescope g f xs)
+
+deriving instance ( All (Compose Show g) xs
+                  , All (Compose Show f) xs
+                  ) => Show (Telescope g f xs)
+
+instance ( All (Compose NoUnexpectedThunks g) xs
+         , All (Compose NoUnexpectedThunks f) xs
+         ) => NoUnexpectedThunks (Telescope g f xs) where
+  showTypeOf _ = "Telescope"
+  whnfNoUnexpectedThunks ctxt = \case
+      TZ f   -> noUnexpectedThunks ("TZ" : ctxt) f
+      TS g t -> allNoUnexpectedThunks [
+                   noUnexpectedThunks ("g" : "TS" : ctxt) g
+                 , noUnexpectedThunks ("t" : "TS" : ctxt) t
+                 ]

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -189,6 +189,7 @@ class (
       , Serialise (BridgeLedger m a)
       , Serialise (BridgeBlock  m a)
       , Serialise (BridgeTx     m a)
+      , Show      (BridgeTx     m a)
       ) => Bridge m a where
 
   -- | Additional information relating both ledgers
@@ -417,12 +418,9 @@ instance Bridge m a => LedgerSupportsProtocol (DualBlock m a) where
 instance Bridge m a => HasHardForkHistory (DualBlock m a) where
   type HardForkIndices (DualBlock m a) = HardForkIndices m
 
-  hardForkShape _ cfg =
-      hardForkShape (Proxy @m)
-        (dualLedgerConfigMain cfg)
-
-  hardForkTransitions cfg state =
-      hardForkTransitions
+  hardForkSummary start cfg state =
+      hardForkSummary
+        start
         (dualLedgerConfigMain cfg)
         (dualLedgerStateMain  state)
 
@@ -513,13 +511,8 @@ instance Bridge m a => HasTxId (GenTx (DualBlock m a)) where
 
   txId = DualGenTxId . txId . dualGenTxMain
 
-deriving instance ( Show (GenTx m)
-                  , Show (GenTx a)
-                  , Show (BridgeTx m a)
-                  ) => Show (GenTx (DualBlock m a))
-deriving instance ( Show (ApplyTxErr m)
-                  , Show (ApplyTxErr a)
-                  ) => Show (DualGenTxErr m a)
+deriving instance Bridge m a => Show (GenTx (DualBlock m a))
+deriving instance Bridge m a => Show (DualGenTxErr m a)
 
 deriving instance Show (GenTxId m) => Show (TxId (GenTx (DualBlock m a)))
 deriving instance Eq   (GenTxId m) => Eq   (TxId (GenTx (DualBlock m a)))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -37,6 +37,8 @@ import           Ouroboros.Consensus.Util.IOLike
 
 class ( UpdateLedger blk
       , NoUnexpectedThunks (GenTx blk)
+      , Show (GenTx blk)
+      , Show (ApplyTxErr blk)
       ) => ApplyTx blk where
   -- | Generalized transaction
   --
@@ -74,7 +76,10 @@ class ( UpdateLedger blk
 --
 -- The mempool will use these to locate transactions, so two different
 -- transactions should have different identifiers.
-class (Ord (TxId tx), NoUnexpectedThunks (TxId tx)) => HasTxId tx where
+class ( Show               (TxId tx)
+      , Ord                (TxId tx)
+      , NoUnexpectedThunks (TxId tx)
+      ) => HasTxId tx where
   -- | A generalized transaction, 'GenTx', identifier.
   data family TxId tx :: *
 
@@ -91,6 +96,10 @@ class (Ord (TxId tx), NoUnexpectedThunks (TxId tx)) => HasTxId tx where
 -- | Shorthand: ID of a generalized transaction
 type GenTxId blk = TxId (GenTx blk)
 
+-- | Collect all transactions from a block
+--
+-- This is used for tooling only. We don't require it as part of RunNode
+-- (and cannot, because we cannot give an instance for the dual ledger).
 class HasTxs blk where
   -- | Return the transactions part of the given block in no particular order.
   extractTxs :: blk -> [GenTx blk]

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -27,6 +27,7 @@ module Ouroboros.Consensus.Util (
   , takeLast
   , dropLast
   , firstJust
+  , allEqual
     -- * Safe variants of existing base functions
   , lastMaybe
   , safeMaximum
@@ -151,6 +152,11 @@ dropLast n = reverse . drop (fromIntegral n) . reverse
 
 firstJust :: forall a b f. Foldable f => (a -> Maybe b) -> f a -> Maybe b
 firstJust f = asum . fmap f . toList
+
+allEqual :: Eq a => [a] -> Bool
+allEqual []       = True
+allEqual [_]      = True
+allEqual (x:y:zs) = x == y && allEqual (y:zs)
 
 {-------------------------------------------------------------------------------
   Safe variants of existing base functions

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Counting.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Counting.hs
@@ -26,6 +26,7 @@ module Ouroboros.Consensus.Util.Counting (
   , exactlyWeaken
   , exactlyWeakenNonEmpty
   , exactlyReplicate
+  , exactlyFromNP
     -- * Working with 'AtMost'
   , atMostOne
   , atMostInit
@@ -38,6 +39,7 @@ module Ouroboros.Consensus.Util.Counting (
   ) where
 
 import qualified Data.Foldable as Foldable
+import           Data.SOP.Strict
 
 {-------------------------------------------------------------------------------
   Types
@@ -130,6 +132,13 @@ exactlyReplicate = go
     go :: Word -> a -> (forall xs. Exactly xs a -> r) -> r
     go 0 _ k = k ExactlyNil
     go n a k = go (n - 1) a $ \xs -> k (ExactlyCons a xs)
+
+exactlyFromNP :: NP (K a) xs -> Exactly xs a
+exactlyFromNP = go
+  where
+    go :: NP (K a) xs -> Exactly xs a
+    go Nil         = ExactlyNil
+    go (K x :* xs) = ExactlyCons x (go xs)
 
 {-------------------------------------------------------------------------------
   Working with 'AtMost'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -4,9 +4,13 @@
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE UndecidableInstances       #-}
+
 {-# OPTIONS_GHC -Wno-orphans #-}
+
 module Ouroboros.Consensus.Util.Orphans () where
 
 import           Codec.CBOR.Decoding (Decoder)
@@ -19,6 +23,7 @@ import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
 import           Data.IntPSQ (IntPSQ)
 import qualified Data.IntPSQ as PSQ
+import           Data.SOP.Strict
 import           Data.Void (Void)
 
 import           Control.Tracer (Tracer)
@@ -117,3 +122,7 @@ deriving newtype instance NoUnexpectedThunks Time
 
 -- TODO move to cardano-prelude
 deriving anyclass instance NoUnexpectedThunks Void
+
+instance NoUnexpectedThunks a => NoUnexpectedThunks (K a b) where
+  showTypeOf _ = showTypeOf (Proxy @a)
+  whnfNoUnexpectedThunks ctxt (K a) = whnfNoUnexpectedThunks ("K":ctxt) a

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -537,9 +537,8 @@ instance LedgerSupportsProtocol TestBlock where
   ledgerViewForecastAt _ _ = Just . trivialForecast
 
 instance HasHardForkHistory TestBlock where
-  type HardForkIndices TestBlock = '[()]
-  hardForkShape _         = HardFork.singletonShape
-  hardForkTransitions _ _ = HardFork.transitionsUnknown
+  type HardForkIndices TestBlock = '[TestBlock]
+  hardForkSummary = neverForksHardForkSummary id
 
 testInitLedger :: LedgerState TestBlock
 testInitLedger = TestLedger GenesisPoint GenesisHash


### PR DESCRIPTION
Much like [Rachmaninoff's famous prelude](https://en.wikipedia.org/wiki/Prelude_in_C-sharp_minor_(Rachmaninoff)), the work on the hard fork combinator consists of three phases:

* Various months of working through all the grim consequences of having transition points in the chain.
* A period of highly agitated hacking and writing the actual hard fork combinator (this PR)
* A quiet ending where we introduce the hard fork combinator on mainnet and everything Just Works (TM)

The new hard fork combinator is `n`-ary rather than binary. Not only does this mean we will be able to smoothly handle the transition from Shelley to post-Shelley (Shelley+MSIG, Goguen, and beyond), it also means that the code is very uniform and consistent; this also has various advantages for testing. For example, we can instantiate the combinator with a _single_ block, and then test that "hard forking between just one block" (degenerate case) is equivalent to just running with that single block without the hard fork combinator meditating.

# Supported interfaces

The consensus layer is a large piece of code that offers a lot of interfaces, and the hard fork combinator must deal with virtually all of those interfaces.

This PR is still WIP, but the vast majority of the interfaces have been completed:

## Consensus protocol integration

- [x] `ConsensusProtocol` instance
      This includes chain selection, the leader check, consensus-specific header validation and consensus-specific rollback.

- [x] `BlockSupportsProtocol` instance      

## Block integration

- [x] `BlockHasCodecConfig` instance
- [x] `GetHeader` instance
- [x] `StandardHash` instance
- [x] `HasHeader` instances (block and header)
- [x] `HasAnnTip` instance (depends on #2059)
- [x] `ValidateEnvelope` instance (#2071)
     The trickiest part here is to verify that hashes line up across the transition point.

## Ledger integration

- [x] `IsLedger` instance
- [x] `ApplyBlock` instance
- [x] `UpdateLedger` instance
- [x] `HasHardForkHistory` instance
- [x] `LedgerSupportsProtocol` instance

## Mempool integration

- [x] `ApplyTx` instance
- [x] `HasTxId` instance

## LocalStateQuery integration

- [x] `ShowQuery` instance
- [x] `QueryLedger` instance

# Integration with Byron / Shelley

- [ ] `CanHardFork` instance (#2072)
      Although the hard fork combinator takes care of most of the details, some ledger specific info must be required; in particular, the translation from the final Byron ledger state to the initial Shelley ledger state.

- [ ] Serialisation. We must decide on a serialization format for the hard fork block, and make sure that it is backwards compatible with the existing Byron mainnet.  (#2073)

- [ ] `RunNode` instance (#2074)

# Testing

- [x] `RunNode` instance for `DegenFork`
      In order to test that the hard fork combinator implements all the interfaces required for `RunNode`, there is a `DegenFork` type that is a witness to the degenerate case where we are hard forking "between" exactly one era, which has a `RunNode` instance derived from the underlying block.

- [ ] We should run the standard consensus tests with `DegenFork` as a sanity check (#2075)

- [ ] We should run use the `DualBlock` infrastructure to compare `ByronBlock` to `HardForkBlock '[ByronBlock]`: the two should be isomorphic. (#2077)

- [ ] Indeed, we should run a full node and have it try sync to mainnet or staging with `HardForkBlock '[ByronBlock]` (#2076)

- [ ] We should run `DualBlock` with `HardForkBlock '[ByronBlock, ByronBlock]` and some arbitrary transition point. This will allow us to make check that stuff goes okay at transition points without having to think about translations between Byron and Shelley. (#2078)

- [ ] We should run the consensus tests with `HardForkBlock '[MockA, MockB]` for two very simple block ledgers. (#2079)

- [ ] We should run the consensus tests with `HardForkBlock '[ByronBlock, ShelleyBlock]` where we set the epoch size and slot length for both to the same value. This allows us to check everything _except_ timing concerns (#2078)

- [ ] Finally, we should test with the full Cardano chain, going from `Byron` to `Shelley`, including timing changes. This will depend on improvements to the testing infrastructure (most importantly #2029 and #2027) as well as improvements to the Shelley integration (at least #2030). (#2078)

# Miscellaneous other TODOs/improvements

- [ ] We need to finish the documentation of the hard fork combinator and update it with latest insights (draft PR at #1741) as well as reconsider timing constraints (https://github.com/input-output-hk/ouroboros-network/blob/nfrisby/doc-stability-window/doc/stability-window-design.md , PR #2056, I have some local markdown files that describe some of the timing subtleties that I need to polish and add to the repo, possibly others). (#2081)

- [ ] `HasHardForkHistory` should have `hardForkSummary` as primitive instead of `hardForkTransitions` (and possibly also replacing `hardForkShape`. The state of the hard fork combinator allows us to read the `Summary` off almost straight away without having to recompute anything at all.  (#2080)

- [ ] `HasHardForkHistory` should be given a default in terms of `SingleEraBlock`. (#2080)
