### PR TITLE
Add PParams field to ShelleyGenesis data structure

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -129,7 +129,6 @@ data ShelleyGenesis c = ShelleyGenesis {
     , sgNetworkMagic          :: !NetworkMagic
     , sgProtocolMagicId       :: !ProtocolMagicId
     , sgActiveSlotsCoeff      :: !Double
-    , sgDecentralisationParam :: !Double
     , sgSecurityParam         :: !SecurityParam
     , sgEpochLength           :: !EpochSize
     , sgSlotsPerKESPeriod     :: !Word64
@@ -138,8 +137,7 @@ data ShelleyGenesis c = ShelleyGenesis {
     , sgUpdateQuorum          :: !Word64
     , sgMaxMajorPV            :: !Natural
     , sgMaxLovelaceSupply     :: !Word64
-    , sgMaxBodySize           :: !Natural
-    , sgMaxHeaderSize         :: !Natural
+    , sgProtocolParams        :: !SL.PParams
     , sgGenDelegs             :: !(Map (SL.KeyHash 'SL.Genesis c) (SL.KeyHash 'SL.GenesisDelegate c))
     , sgInitialFunds          :: !(Map (SL.Addr c) SL.Coin)
     , sgStaking               :: !(ShelleyGenesisStaking c)
@@ -278,7 +276,7 @@ protocolInfoShelley genesis protVer mbCredentials =
       (fromIntegral (sgMaxLovelaceSupply genesis) - SL.balance genesisUtxO)
       (sgGenDelegs genesis)
       oSched
-      pparams
+      (sgProtocolParams genesis)
       -- TODO initial nonce, typically created from the hash of
       -- the last Byron block using 'SL.hashHeaderToNonce'.
       (SL.mkNonce 0)
@@ -297,17 +295,7 @@ protocolInfoShelley genesis protVer mbCredentials =
       SL.overlaySchedule
         initialEpochNo
         (Map.keysSet (sgGenDelegs genesis))
-        pparams
-
-    pparams :: SL.PParams
-    pparams = SL.emptyPParams {
-        SL._d =
-            SL.truncateUnitInterval
-          . realToFrac
-          $ sgDecentralisationParam genesis
-      , SL._maxBBSize = sgMaxBodySize genesis
-      , SL._maxBHSize = sgMaxHeaderSize genesis
-      }
+        (sgProtocolParams genesis)
 
     genesisUtxO :: SL.UTxO c
     genesisUtxO = SL.UTxO $ Map.fromList

--- a/ouroboros-consensus-shelley/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley/test/Test/ThreadNet/RealTPraos.hs
@@ -242,7 +242,6 @@ mkGenesisConfig k d maxKESEvolutions coreNodes = ShelleyGenesis {
     , sgNetworkMagic          = NetworkMagic 0
     , sgProtocolMagicId       = ProtocolMagicId 0
     , sgActiveSlotsCoeff      = 0.5 -- TODO 1 is not accepted by 'mkActiveSlotCoeff'
-    , sgDecentralisationParam = d
     , sgSecurityParam         = k
     , sgEpochLength           = EpochSize (10 * maxRollbacks k)
     , sgSlotsPerKESPeriod     = 10 -- TODO
@@ -251,8 +250,7 @@ mkGenesisConfig k d maxKESEvolutions coreNodes = ShelleyGenesis {
     , sgUpdateQuorum          = 1  -- TODO
     , sgMaxMajorPV            = 1000 -- TODO
     , sgMaxLovelaceSupply     = maxLovelaceSupply
-    , sgMaxBodySize           = 10000 -- TODO
-    , sgMaxHeaderSize         = 1000 -- TODO
+    , sgProtocolParams        = pparams
     , sgGenDelegs             = coreNodesToGenesisMapping
     , sgInitialFunds          = initialFunds
     , sgStaking               = initialStake
@@ -265,6 +263,16 @@ mkGenesisConfig k d maxKESEvolutions coreNodes = ShelleyGenesis {
     maxLovelaceSupply :: Word64
     maxLovelaceSupply =
       fromIntegral (length coreNodes) * initialLovelacePerCoreNode
+
+    pparams :: SL.PParams
+    pparams = SL.emptyPParams
+      { SL._d =
+            SL.truncateUnitInterval
+          . realToFrac
+          $ d
+      , SL._maxBBSize = 10000 -- TODO
+      , SL._maxBHSize = 1000 -- TODO
+      }
 
     coreNodesToGenesisMapping :: Map (SL.KeyHash 'SL.Genesis c) (SL.KeyHash 'SL.GenesisDelegate c)
     coreNodesToGenesisMapping  = Map.fromList


### PR DESCRIPTION
When spinning up a Shelley node, it will be useful to be able to specify these in the genesis configuration.