### PR TITLE
Move LedgerState out of UpdateLedger

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Ledger.hs
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Ledger.hs
@@ -227,7 +227,7 @@ forgeDualByronBlock cfg updateState curBlockNo tickedLedger txs isLeader = do
               (dualTopLevelConfigMain cfg)
               updateState
               curBlockNo
-              (TickedLedgerState {
+              (Ticked {
                    tickedSlotNo      = curSlotNo
                  , tickedLedgerState = dualLedgerStateMain $
                                          tickedLedgerState tickedLedger

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -81,7 +81,7 @@ instance IsLedger (LedgerState ByronBlock) where
   type LedgerCfg (LedgerState ByronBlock) = Gen.Config
 
   applyChainTick cfg slotNo ByronLedgerState{..} =
-      TickedLedgerState slotNo ByronLedgerState {
+      Ticked slotNo ByronLedgerState {
           byronDelegationHistory = byronDelegationHistory
         , byronLedgerState       = CC.applyChainTick
                                       cfg
@@ -300,7 +300,7 @@ applyByronBlock :: CC.ValidationMode
 applyByronBlock validationMode
                 cfg
                 (ByronBlock blk _ (ByronHash blkHash))
-                (TickedLedgerState _slot ls) = case blk of
+                (Ticked _slot ls) = case blk of
       CC.ABOBBlock    blk' -> applyABlock validationMode cfg blk' blkHash ls
       CC.ABOBBoundary blk' -> applyABoundaryBlock        cfg blk'         ls
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -109,12 +109,13 @@ instance ApplyBlock (LedgerState ByronBlock) ByronBlock where
           where
             slot = fromByronSlotNo (CC.cvsLastSlot state)
 
-instance UpdateLedger ByronBlock where
-  data LedgerState ByronBlock = ByronLedgerState {
-        byronLedgerState       :: !CC.ChainValidationState
-      , byronDelegationHistory :: !DelegationHistory
-      }
-    deriving (Eq, Show, Generic, NoUnexpectedThunks)
+data instance LedgerState ByronBlock = ByronLedgerState {
+      byronLedgerState       :: !CC.ChainValidationState
+    , byronDelegationHistory :: !DelegationHistory
+    }
+  deriving (Eq, Show, Generic, NoUnexpectedThunks)
+
+instance UpdateLedger ByronBlock
 
 initByronLedgerState :: Gen.Config
                      -> Maybe CC.UTxO -- ^ Optionally override UTxO

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -207,8 +207,8 @@ applyByronGenTx :: CC.ValidationMode
                 -> GenTx ByronBlock
                 -> TickedLedgerState ByronBlock
                 -> Except (ApplyTxErr ByronBlock) (TickedLedgerState ByronBlock)
-applyByronGenTx validationMode cfg genTx (TickedLedgerState slot st) =
-    (\state -> TickedLedgerState slot $ st {byronLedgerState = state}) <$>
+applyByronGenTx validationMode cfg genTx (Ticked slot st) =
+    (\state -> Ticked slot $ st {byronLedgerState = state}) <$>
       CC.applyMempoolPayload
         validationMode
         cfg

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -84,19 +84,20 @@ instance ApplyBlock (LedgerState ByronSpecBlock) ByronSpecBlock where
                        slot
                        (getChainStateHash (byronSpecLedgerState state))
 
-instance UpdateLedger ByronSpecBlock where
-  data LedgerState ByronSpecBlock = ByronSpecLedgerState {
-        -- | Tip of the ledger (most recently applied block, if any)
-        --
-        -- The spec state stores the last applied /hash/, but not the /slot/.
-        byronSpecLedgerTip :: Maybe SlotNo
+data instance LedgerState ByronSpecBlock = ByronSpecLedgerState {
+      -- | Tip of the ledger (most recently applied block, if any)
+      --
+      -- The spec state stores the last applied /hash/, but not the /slot/.
+      byronSpecLedgerTip :: Maybe SlotNo
 
-        -- | The spec state proper
-      , byronSpecLedgerState :: Spec.State Spec.CHAIN
-      }
-    deriving stock (Show, Eq, Generic)
-    deriving anyclass (Serialise)
-    deriving NoUnexpectedThunks via AllowThunk (LedgerState ByronSpecBlock)
+      -- | The spec state proper
+    , byronSpecLedgerState :: Spec.State Spec.CHAIN
+    }
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (Serialise)
+  deriving NoUnexpectedThunks via AllowThunk (LedgerState ByronSpecBlock)
+
+instance UpdateLedger ByronSpecBlock
 
 {-------------------------------------------------------------------------------
   Working with the ledger state

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -47,7 +47,7 @@ instance IsLedger (LedgerState ByronSpecBlock) where
   type LedgerErr (LedgerState ByronSpecBlock) = ByronSpecLedgerError
   type LedgerCfg (LedgerState ByronSpecBlock) = ByronSpecGenesis
 
-  applyChainTick cfg slot state = TickedLedgerState slot $
+  applyChainTick cfg slot state = Ticked slot $
       updateByronSpecLedgerStateKeepTip state $
         Rules.applyChainTick
           cfg
@@ -55,7 +55,7 @@ instance IsLedger (LedgerState ByronSpecBlock) where
           (byronSpecLedgerState    state)
 
 instance ApplyBlock (LedgerState ByronSpecBlock) ByronSpecBlock where
-  applyLedgerBlock cfg block (TickedLedgerState slot state) =
+  applyLedgerBlock cfg block (Ticked slot state) =
     withExcept ByronSpecLedgerError $
       updateByronSpecLedgerStateNewTip slot <$>
         -- Note that the CHAIN rule also applies the chain tick. So even

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
@@ -40,8 +40,8 @@ instance ApplyTx ByronSpecBlock where
   -- spec does not impose a maximum block size.
   txSize _ = 0
 
-  applyTx cfg tx (TickedLedgerState slot st) =
-      (TickedLedgerState slot . updateByronSpecLedgerStateKeepTip st) <$>
+  applyTx cfg tx (Ticked slot st) =
+      (Ticked slot . updateByronSpecLedgerStateKeepTip st) <$>
         GenTx.apply
           cfg
           (unByronSpecGenTx     tx)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -103,7 +103,7 @@ instance TPraosCrypto c => IsLedger (LedgerState (ShelleyBlock c)) where
     globals
     slotNo
     (ShelleyLedgerState pt history bhState) =
-      TickedLedgerState slotNo
+      Ticked slotNo
         . ShelleyLedgerState pt history
         $ SL.applyTickTransition globals bhState slotNo
 
@@ -121,7 +121,7 @@ instance TPraosCrypto c
   --
   applyLedgerBlock globals
                    blk
-                   TickedLedgerState {
+                   Ticked {
                        tickedLedgerState = ShelleyLedgerState {
                            history
                          , shelleyState = oldShelleyState
@@ -316,7 +316,7 @@ instance Crypto c => ValidateEnvelope (ShelleyBlock c) where
   type OtherHeaderEnvelopeError (ShelleyBlock c) =
     STS.PredicateFailure (STS.CHAIN c)
 
-  validateEnvelope cfg (TickedLedgerState _ ledgerView) oldTip hdr = do
+  validateEnvelope cfg (Ticked _ ledgerView) oldTip hdr = do
       -- In addition to the default 'validateEnvelope' ...
       defaultValidateEnvelope oldTip hdr
       -- ... perform the @chainChecks@ that are part of the @CHAIN@ rule.

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -20,7 +20,6 @@
 module Ouroboros.Consensus.Shelley.Ledger.Ledger (
     ShelleyLedgerError (..)
   , LedgerState (..)
-  , UpdateLedger (..)
   , QueryLedger (..)
   , Query (..)
   , NonMyopicMemberRewards (..)
@@ -160,13 +159,14 @@ instance TPraosCrypto c
 
   ledgerTipPoint = ledgerTip
 
-instance TPraosCrypto c => UpdateLedger (ShelleyBlock c) where
-  data LedgerState (ShelleyBlock c) = ShelleyLedgerState {
-        ledgerTip    :: !(Point (ShelleyBlock c))
-      , history      :: !(History.LedgerViewHistory c)
-      , shelleyState :: !(SL.ShelleyState c)
-      }
-    deriving (Eq, Show, Generic, NoUnexpectedThunks)
+data instance LedgerState (ShelleyBlock c) = ShelleyLedgerState {
+      ledgerTip    :: !(Point (ShelleyBlock c))
+    , history      :: !(History.LedgerViewHistory c)
+    , shelleyState :: !(SL.ShelleyState c)
+    }
+  deriving (Eq, Show, Generic, NoUnexpectedThunks)
+
+instance TPraosCrypto c => UpdateLedger (ShelleyBlock c)
 
 instance TPraosCrypto c => LedgerSupportsProtocol (ShelleyBlock c) where
   protocolLedgerView _cfg = SL.currentLedgerView . shelleyState

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -316,7 +316,7 @@ instance Crypto c => ValidateEnvelope (ShelleyBlock c) where
   type OtherHeaderEnvelopeError (ShelleyBlock c) =
     STS.PredicateFailure (STS.CHAIN c)
 
-  validateEnvelope cfg ledgerView oldTip hdr = do
+  validateEnvelope cfg (TickedLedgerState _ ledgerView) oldTip hdr = do
       -- In addition to the default 'validateEnvelope' ...
       defaultValidateEnvelope oldTip hdr
       -- ... perform the @chainChecks@ that are part of the @CHAIN@ rule.

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -127,8 +127,8 @@ applyShelleyTx
   -> GenTx (ShelleyBlock c)
   -> TickedLedgerState (ShelleyBlock c)
   -> Except (ApplyTxErr (ShelleyBlock c)) (TickedLedgerState (ShelleyBlock c))
-applyShelleyTx globals (ShelleyTx _ tx) (TickedLedgerState slot st) =
-    (\state -> TickedLedgerState slot $ st { shelleyState = state }) <$>
+applyShelleyTx globals (ShelleyTx _ tx) (Ticked slot st) =
+    (\state -> Ticked slot $ st { shelleyState = state }) <$>
        SL.overShelleyState
         (SL.applyTxs globals mempoolEnv (Seq.singleton tx))
         shelleyState

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -57,6 +57,7 @@ import           Cardano.Slotting.EpochInfo
 
 import           Ouroboros.Network.Block (pointSlot)
 
+import           Ouroboros.Consensus.Ledger.Abstract
 import qualified Ouroboros.Consensus.Node.State as NodeState
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Condense
@@ -76,7 +77,6 @@ import           Ouroboros.Consensus.Shelley.Protocol.Crypto
 import           Ouroboros.Consensus.Shelley.Protocol.State (TPraosState)
 import qualified Ouroboros.Consensus.Shelley.Protocol.State as State
 import           Ouroboros.Consensus.Shelley.Protocol.Util
-
 
 {-------------------------------------------------------------------------------
   Fields required by TPraos in the header
@@ -373,7 +373,7 @@ instance TPraosCrypto c => ConsensusProtocol (TPraos c) where
             where
               SL.GenDelegs dlgMap = SL.lvGenDelegs lv
 
-  updateConsensusState TPraosConfig{..} lv b cs = do
+  updateConsensusState TPraosConfig{..} (TickedLedgerState _ lv) b cs = do
       newCS <- except . flip runReader shelleyGlobals $
         applySTS @(STS.PRTCL c) $ STS.TRC (prtclEnv, prtclState, b)
       return

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -324,7 +324,7 @@ instance TPraosCrypto c => ConsensusProtocol (TPraos c) where
       TPraosIsACoreNode{}  -> True
       TPraosIsNotACoreNode -> False
 
-  checkIsLeader cfg@TPraosConfig{..} slot lv cs =
+  checkIsLeader cfg@TPraosConfig{..} (TickedLedgerState slot lv) cs =
     case tpraosIsCoreNodeOrNot of
       TPraosIsNotACoreNode          -> return Nothing
       TPraosIsACoreNode isACoreNode -> go isACoreNode

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -324,7 +324,7 @@ instance TPraosCrypto c => ConsensusProtocol (TPraos c) where
       TPraosIsACoreNode{}  -> True
       TPraosIsNotACoreNode -> False
 
-  checkIsLeader cfg@TPraosConfig{..} (TickedLedgerState slot lv) cs =
+  checkIsLeader cfg@TPraosConfig{..} (Ticked slot lv) cs =
     case tpraosIsCoreNodeOrNot of
       TPraosIsNotACoreNode          -> return Nothing
       TPraosIsACoreNode isACoreNode -> go isACoreNode
@@ -373,7 +373,7 @@ instance TPraosCrypto c => ConsensusProtocol (TPraos c) where
             where
               SL.GenDelegs dlgMap = SL.lvGenDelegs lv
 
-  updateConsensusState TPraosConfig{..} (TickedLedgerState _ lv) b cs = do
+  updateConsensusState TPraosConfig{..} (Ticked _ lv) b cs = do
       newCS <- except . flip runReader shelleyGlobals $
         applySTS @(STS.PRTCL c) $ STS.TRC (prtclEnv, prtclState, b)
       return

--- a/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
+++ b/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
@@ -1004,7 +1004,7 @@ exampleLedgerState :: LedgerState Block
 exampleLedgerState = reapplyLedgerBlock
     SL.testGlobals
     (mkShelleyBlock newBlock)
-    (TickedLedgerState 0 ShelleyLedgerState {
+    (Ticked 0 ShelleyLedgerState {
         ledgerTip    = genesisPoint
       , history      = History.empty
       , shelleyState = STS.chainNes startState

--- a/ouroboros-consensus-shelley/test/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley/test/Test/ThreadNet/TxGen/Shelley.hs
@@ -66,7 +66,7 @@ genTx
   -> TickedLedgerState (ShelleyBlock TPraosMockCrypto)
   -> Gen.GenEnv
   -> Gen (GenTx (ShelleyBlock TPraosMockCrypto))
-genTx _cfg TickedLedgerState { tickedSlotNo, tickedLedgerState } genEnv =
+genTx _cfg Ticked { tickedSlotNo, tickedLedgerState } genEnv =
     mkShelleyTx <$> Gen.genTx
       genEnv
       ledgerEnv

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -282,7 +282,7 @@ instance MockProtocolSpecific c ext
   type LedgerCfg (LedgerState (SimpleBlock c ext)) = MockLedgerConfig       c ext
   type LedgerErr (LedgerState (SimpleBlock c ext)) = MockError (SimpleBlock c ext)
 
-  applyChainTick _ = TickedLedgerState
+  applyChainTick _ = Ticked
 
 instance MockProtocolSpecific c ext
       => ApplyBlock (LedgerState (SimpleBlock c ext)) (SimpleBlock c ext) where
@@ -305,7 +305,7 @@ updateSimpleLedgerState :: (SimpleCrypto c, Typeable ext)
                         -> TickedLedgerState (SimpleBlock c ext)
                         -> Except (MockError (SimpleBlock c ext))
                                   (LedgerState (SimpleBlock c ext))
-updateSimpleLedgerState b (TickedLedgerState _ (SimpleLedgerState st)) =
+updateSimpleLedgerState b (Ticked _ (SimpleLedgerState st)) =
     SimpleLedgerState <$> updateMockState b st
 
 updateSimpleUTxO :: Mock.HasMockTxs a
@@ -313,9 +313,8 @@ updateSimpleUTxO :: Mock.HasMockTxs a
                  -> TickedLedgerState (SimpleBlock c ext)
                  -> Except (MockError (SimpleBlock c ext))
                            (TickedLedgerState (SimpleBlock c ext))
-updateSimpleUTxO x (TickedLedgerState slot (SimpleLedgerState st)) =
-    TickedLedgerState slot . SimpleLedgerState <$>
-      updateMockUTxO slot x st
+updateSimpleUTxO x (Ticked slot (SimpleLedgerState st)) =
+    Ticked slot . SimpleLedgerState <$> updateMockUTxO slot x st
 
 genesisSimpleLedgerState :: AddrDist -> LedgerState (SimpleBlock c ext)
 genesisSimpleLedgerState = SimpleLedgerState . genesisMockState

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -293,12 +293,13 @@ instance MockProtocolSpecific c ext
       mustSucceed (Right st)  = st
   ledgerTipPoint (SimpleLedgerState st) = mockTip st
 
-instance MockProtocolSpecific c ext => UpdateLedger (SimpleBlock c ext) where
-  newtype LedgerState (SimpleBlock c ext) = SimpleLedgerState {
-        simpleLedgerState :: MockState (SimpleBlock c ext)
-      }
-    deriving stock   (Generic, Show, Eq)
-    deriving newtype (Serialise, NoUnexpectedThunks)
+newtype instance LedgerState (SimpleBlock c ext) = SimpleLedgerState {
+      simpleLedgerState :: MockState (SimpleBlock c ext)
+    }
+  deriving stock   (Generic, Show, Eq)
+  deriving newtype (Serialise, NoUnexpectedThunks)
+
+instance MockProtocolSpecific c ext => UpdateLedger (SimpleBlock c ext)
 
 updateSimpleLedgerState :: (SimpleCrypto c, Typeable ext)
                         => SimpleBlock c ext

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -266,7 +266,7 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
         CoreId{}  -> True
         RelayId{} -> False  -- Relays are never leaders
 
-  checkIsLeader cfg@PraosConfig{..} (TickedLedgerState slot _u) cs =
+  checkIsLeader cfg@PraosConfig{..} (Ticked slot _u) cs =
     case praosNodeId of
         RelayId _  -> return Nothing
         CoreId nid -> do
@@ -283,7 +283,7 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
               else Nothing
 
   updateConsensusState cfg@PraosConfig{..}
-                       (TickedLedgerState _ sd)
+                       (Ticked _ sd)
                        (PraosValidateView slot PraosFields{..} toSign)
                        cs = do
     let PraosExtraFields{..} = praosExtraFields

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -266,7 +266,7 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
         CoreId{}  -> True
         RelayId{} -> False  -- Relays are never leaders
 
-  checkIsLeader cfg@PraosConfig{..} slot _u cs =
+  checkIsLeader cfg@PraosConfig{..} (TickedLedgerState slot _u) cs =
     case praosNodeId of
         RelayId _  -> return Nothing
         CoreId nid -> do

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -67,6 +67,7 @@ import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..),
                      pointSlot)
 import           Ouroboros.Network.Point (WithOrigin (At))
 
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Mock.Ledger.Stake
 import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
@@ -282,7 +283,7 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
               else Nothing
 
   updateConsensusState cfg@PraosConfig{..}
-                       sd
+                       (TickedLedgerState _ sd)
                        (PraosValidateView slot PraosFields{..} toSign)
                        cs = do
     let PraosExtraFields{..} = praosExtraFields

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -316,14 +316,15 @@ instance ApplyBlock (LedgerState TestBlock) TestBlock where
 
   ledgerTipPoint = lastAppliedPoint
 
-instance UpdateLedger TestBlock where
-  newtype LedgerState TestBlock =
-      TestLedger {
-          -- The ledger state simply consists of the last applied block
-          lastAppliedPoint :: Point TestBlock
-        }
-    deriving stock   (Show, Eq, Generic)
-    deriving newtype (Serialise, NoUnexpectedThunks, ToExpr)
+newtype instance LedgerState TestBlock =
+    TestLedger {
+        -- The ledger state simply consists of the last applied block
+        lastAppliedPoint :: Point TestBlock
+      }
+  deriving stock   (Show, Eq, Generic)
+  deriving newtype (Serialise, NoUnexpectedThunks, ToExpr)
+
+instance UpdateLedger TestBlock
 
 -- | Last applied block
 --

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -301,10 +301,10 @@ instance IsLedger (LedgerState TestBlock) where
   type LedgerCfg (LedgerState TestBlock) = ()
   type LedgerErr (LedgerState TestBlock) = TestBlockError
 
-  applyChainTick _ = TickedLedgerState
+  applyChainTick _ = Ticked
 
 instance ApplyBlock (LedgerState TestBlock) TestBlock where
-  applyLedgerBlock _ tb@TestBlock{..} (TickedLedgerState _ TestLedger{..})
+  applyLedgerBlock _ tb@TestBlock{..} (Ticked _ TestLedger{..})
     | Block.blockPrevHash tb /= Block.pointHash lastAppliedPoint
     = throwError $ InvalidHash (Block.pointHash lastAppliedPoint) (Block.blockPrevHash tb)
     | not tbValid

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -63,7 +63,7 @@ import           Ouroboros.Network.Block hiding (Tip (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Ledger.Abstract (TickedLedger)
+import           Ouroboros.Consensus.Ledger.Abstract (Ticked)
 import           Ouroboros.Consensus.Protocol.Abstract
 import qualified Ouroboros.Consensus.Util.CBOR as Util.CBOR
 
@@ -278,7 +278,7 @@ class ( HasAnnTip blk
 
   -- | Validate the header envelope
   validateEnvelope :: TopLevelConfig blk
-                   -> TickedLedger (LedgerView (BlockProtocol blk))
+                   -> Ticked (LedgerView (BlockProtocol blk))
                    -> WithOrigin (AnnTip blk)
                    -> Header blk
                    -> Except (HeaderEnvelopeError blk) ()
@@ -296,7 +296,7 @@ class ( HasAnnTip blk
 
   default validateEnvelope :: HasHeader (Header blk)
                            => TopLevelConfig blk
-                           -> TickedLedger (LedgerView (BlockProtocol blk))
+                           -> Ticked (LedgerView (BlockProtocol blk))
                            -> WithOrigin (AnnTip blk)
                            -> Header blk
                            -> Except (HeaderEnvelopeError blk) ()
@@ -419,7 +419,7 @@ castHeaderError (HeaderEnvelopeError e) = HeaderEnvelopeError $
 -- entire block (not just the block body).
 validateHeader :: (BlockSupportsProtocol blk, ValidateEnvelope blk)
                => TopLevelConfig blk
-               -> TickedLedger (LedgerView (BlockProtocol blk))
+               -> Ticked (LedgerView (BlockProtocol blk))
                -> Header blk
                -> HeaderState blk
                -> Except (HeaderError blk) (HeaderState blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -63,6 +63,7 @@ import           Ouroboros.Network.Block hiding (Tip (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Abstract (TickedLedger)
 import           Ouroboros.Consensus.Protocol.Abstract
 import qualified Ouroboros.Consensus.Util.CBOR as Util.CBOR
 
@@ -277,7 +278,7 @@ class ( HasAnnTip blk
 
   -- | Validate the header envelope
   validateEnvelope :: TopLevelConfig blk
-                   -> LedgerView (BlockProtocol blk)
+                   -> TickedLedger (LedgerView (BlockProtocol blk))
                    -> WithOrigin (AnnTip blk)
                    -> Header blk
                    -> Except (HeaderEnvelopeError blk) ()
@@ -295,7 +296,7 @@ class ( HasAnnTip blk
 
   default validateEnvelope :: HasHeader (Header blk)
                            => TopLevelConfig blk
-                           -> LedgerView (BlockProtocol blk)
+                           -> TickedLedger (LedgerView (BlockProtocol blk))
                            -> WithOrigin (AnnTip blk)
                            -> Header blk
                            -> Except (HeaderEnvelopeError blk) ()
@@ -418,7 +419,7 @@ castHeaderError (HeaderEnvelopeError e) = HeaderEnvelopeError $
 -- entire block (not just the block body).
 validateHeader :: (BlockSupportsProtocol blk, ValidateEnvelope blk)
                => TopLevelConfig blk
-               -> LedgerView (BlockProtocol blk)
+               -> TickedLedger (LedgerView (BlockProtocol blk))
                -> Header blk
                -> HeaderState blk
                -> Except (HeaderError blk) (HeaderState blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveFunctor         #-}
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleContexts      #-}
@@ -115,7 +116,7 @@ data TickedLedger l = TickedLedgerState {
       -- > == ledgerTipPoint st
     , tickedLedgerState :: !l
     }
-  deriving stock    (Generic)
+  deriving stock    (Generic, Functor)
   deriving anyclass (NoUnexpectedThunks)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -23,7 +23,8 @@ module Ouroboros.Consensus.Ledger.Abstract (
   , foldLedger
   , refoldLedger
     -- * Link block to its ledger
-  , UpdateLedger(..)
+  , LedgerState
+  , UpdateLedger
     -- ** Short-hand
   , LedgerConfig
   , LedgerError
@@ -188,9 +189,11 @@ refoldLedger = repeatedly . tickThenReapply
   Link block to its ledger
 -------------------------------------------------------------------------------}
 
+-- | Ledger state associated with a block
+data family LedgerState blk :: *
+
 -- | Interaction with the ledger layer
-class ApplyBlock (LedgerState blk) blk => UpdateLedger blk where
-  data family LedgerState blk :: *
+class ApplyBlock (LedgerState blk) blk => UpdateLedger blk
 
 {-------------------------------------------------------------------------------
   Short-hand

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -331,13 +331,14 @@ instance Bridge m a => ApplyBlock (LedgerState (DualBlock m a)) (DualBlock m a) 
                  . (ledgerTipPoint :: LedgerState m -> Point m)
                  . dualLedgerStateMain
 
-instance Bridge m a => UpdateLedger (DualBlock m a) where
-  data LedgerState (DualBlock m a) = DualLedgerState {
-        dualLedgerStateMain   :: LedgerState m
-      , dualLedgerStateAux    :: LedgerState a
-      , dualLedgerStateBridge :: BridgeLedger m a
-      }
-    deriving NoUnexpectedThunks via AllowThunk (LedgerState (DualBlock m a))
+data instance LedgerState (DualBlock m a) = DualLedgerState {
+      dualLedgerStateMain   :: LedgerState m
+    , dualLedgerStateAux    :: LedgerState a
+    , dualLedgerStateBridge :: BridgeLedger m a
+    }
+  deriving NoUnexpectedThunks via AllowThunk (LedgerState (DualBlock m a))
+
+instance Bridge m a => UpdateLedger (DualBlock m a)
 
 deriving instance ( Show (LedgerState m)
                   , Show (LedgerState a)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -269,7 +269,7 @@ instance Bridge m a => IsLedger (LedgerState (DualBlock m a)) where
                  slot
                  DualLedgerState{..} =
       assert (tickedSlotNo tickedM == tickedSlotNo tickedA) $
-      TickedLedgerState (tickedSlotNo tickedM) DualLedgerState {
+      Ticked (tickedSlotNo tickedM) DualLedgerState {
           dualLedgerStateMain   = tickedLedgerState tickedM
         , dualLedgerStateAux    = tickedLedgerState tickedA
         , dualLedgerStateBridge = dualLedgerStateBridge
@@ -290,17 +290,17 @@ instance Bridge m a => IsLedger (LedgerState (DualBlock m a)) where
 instance Bridge m a => ApplyBlock (LedgerState (DualBlock m a)) (DualBlock m a) where
   applyLedgerBlock DualLedgerConfig{..}
                    block@DualBlock{..}
-                   (TickedLedgerState slot DualLedgerState{..}) = do
+                   (Ticked slot DualLedgerState{..}) = do
       (main', aux') <-
         agreeOnError DualLedgerError (
             applyLedgerBlock
               dualLedgerConfigMain
               dualBlockMain
-              (TickedLedgerState slot dualLedgerStateMain)
+              (Ticked slot dualLedgerStateMain)
           , applyMaybeBlock
               dualLedgerConfigAux
               dualBlockAux
-              (TickedLedgerState slot dualLedgerStateAux)
+              (Ticked slot dualLedgerStateAux)
           )
       return DualLedgerState {
           dualLedgerStateMain   = main'
@@ -312,16 +312,16 @@ instance Bridge m a => ApplyBlock (LedgerState (DualBlock m a)) (DualBlock m a) 
 
   reapplyLedgerBlock DualLedgerConfig{..}
                      block@DualBlock{..}
-                     (TickedLedgerState slot DualLedgerState{..}) =
+                     (Ticked slot DualLedgerState{..}) =
     DualLedgerState {
           dualLedgerStateMain   = reapplyLedgerBlock
                                     dualLedgerConfigMain
                                     dualBlockMain
-                                    (TickedLedgerState slot dualLedgerStateMain)
+                                    (Ticked slot dualLedgerStateMain)
         , dualLedgerStateAux    = reapplyMaybeBlock
                                     dualLedgerConfigAux
                                     dualBlockAux
-                                    (TickedLedgerState slot dualLedgerStateAux)
+                                    (Ticked slot dualLedgerStateAux)
         , dualLedgerStateBridge = updateBridgeWithBlock
                                     block
                                     dualLedgerStateBridge
@@ -440,19 +440,19 @@ instance Bridge m a => ApplyTx (DualBlock m a) where
 
   applyTx DualLedgerConfig{..}
           tx@DualGenTx{..}
-          (TickedLedgerState slot DualLedgerState{..}) = do
-      (TickedLedgerState _ main', TickedLedgerState _ aux') <-
+          (Ticked slot DualLedgerState{..}) = do
+      (Ticked _ main', Ticked _ aux') <-
         agreeOnError DualGenTxErr (
             applyTx
               dualLedgerConfigMain
               dualGenTxMain
-              (TickedLedgerState slot dualLedgerStateMain)
+              (Ticked slot dualLedgerStateMain)
           , applyTx
               dualLedgerConfigAux
               dualGenTxAux
-              (TickedLedgerState slot dualLedgerStateAux)
+              (Ticked slot dualLedgerStateAux)
           )
-      return $ TickedLedgerState slot DualLedgerState {
+      return $ Ticked slot DualLedgerState {
           dualLedgerStateMain   = main'
         , dualLedgerStateAux    = aux'
         , dualLedgerStateBridge = updateBridgeWithTx
@@ -462,19 +462,19 @@ instance Bridge m a => ApplyTx (DualBlock m a) where
 
   reapplyTx DualLedgerConfig{..}
             tx@DualGenTx{..}
-            (TickedLedgerState slot DualLedgerState{..}) = do
-      (TickedLedgerState _ main', TickedLedgerState _ aux') <-
+            (Ticked slot DualLedgerState{..}) = do
+      (Ticked _ main', Ticked _ aux') <-
         agreeOnError DualGenTxErr (
             reapplyTx
               dualLedgerConfigMain
               dualGenTxMain
-              (TickedLedgerState slot dualLedgerStateMain)
+              (Ticked slot dualLedgerStateMain)
           , reapplyTx
               dualLedgerConfigAux
               dualGenTxAux
-              (TickedLedgerState slot dualLedgerStateAux)
+              (Ticked slot dualLedgerStateAux)
           )
-      return $ TickedLedgerState slot DualLedgerState {
+      return $ Ticked slot DualLedgerState {
           dualLedgerStateMain   = main'
         , dualLedgerStateAux    = aux'
         , dualLedgerStateBridge = updateBridgeWithTx

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -138,7 +138,7 @@ instance ( LedgerSupportsProtocol blk
       hdr' <- withExcept ExtValidationErrorHeader $
                 validateHeader
                   cfg
-                  ledgerView
+                  (TickedLedgerState slot ledgerView)
                   (getHeader blk)
                   hdr
       lgr' <- withExcept ExtValidationErrorLedger $
@@ -167,7 +167,7 @@ instance ( LedgerSupportsProtocol blk
         , headerState = cantBeError $
                          validateHeader
                            cfg
-                           ledgerView
+                           (TickedLedgerState slot ledgerView)
                            (getHeader blk)
                            hdr
         }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -704,7 +704,7 @@ chainSyncClient mkPipelineDecision0 tracer cfg
                   -> Point blk   -- ^ Intersection between our and their chain
                   -> Our (Tip blk)       -- ^ Only to produce an error message
                   -> Their (Tip blk)     -- ^ Only to produce an error message
-                  -> STM m (TickedLedger (LedgerView (BlockProtocol blk)))
+                  -> STM m (Ticked (LedgerView (BlockProtocol blk)))
     getLedgerView hdr intersection ourTip theirTip = do
         curLedger <- ledgerState <$> getCurrentLedger
 
@@ -730,7 +730,7 @@ chainSyncClient mkPipelineDecision0 tracer cfg
               Right lv ->
                 -- Forecasting is equivalent to ticking
                 -- ('lemma_ledgerViewForecastAt_applyChainTick' )
-                return (TickedLedgerState (realPointSlot hdrPoint) lv)
+                return (Ticked (realPointSlot hdrPoint) lv)
       where
         hdrPoint = headerRealPoint hdr
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -424,15 +424,11 @@ forkBlockProduction maxBlockSizeOverride IS{..} BlockProduction{..} =
 
         -- Check if we are the leader
         proof <- do
-          let ledgerView = protocolLedgerView
-                             (configLedger cfg)
-                             (tickedLedgerState ticked)
           mIsLeader :: Maybe (IsLeader (BlockProtocol blk)) <- lift $
             runMonadRandom $ \_lift' ->
               checkIsLeader
                 (configConsensus cfg)
-                currentSlot
-                ledgerView
+                (protocolLedgerView (configLedger cfg) <$> ticked)
                 (headerStateConsensus (headerState extLedger))
           case mIsLeader of
             Just p  -> return p

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -32,6 +32,8 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 import           Ouroboros.Network.Block (BlockNo, HeaderHash, Point,
                      SlotNo (..))
 
+import           Ouroboros.Consensus.Ledger.Abstract (TickedLedger)
+
 -- | Static configuration required to run the consensus protocol
 --
 -- Every method in the 'ConsensusProtocol' class takes the consensus
@@ -163,10 +165,10 @@ class ( Show (ConsensusState p)
 
   -- | Apply a header
   updateConsensusState :: HasCallStack
-                       => ConsensusConfig p
-                       -> LedgerView      p -- /Updated/ ledger state
-                       -> ValidateView    p
-                       -> ConsensusState  p -- /Previous/ Ouroboros state
+                       => ConsensusConfig          p
+                       -> TickedLedger (LedgerView p)
+                       -> ValidateView             p
+                       -> ConsensusState           p
                        -> Except (ValidationErr p) (ConsensusState p)
 
   -- | We require that protocols support a @k@ security parameter

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -29,8 +29,7 @@ import           GHC.Stack
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block (BlockNo, HeaderHash, Point,
-                     SlotNo (..))
+import           Ouroboros.Network.Block (BlockNo, HeaderHash, Point)
 
 import           Ouroboros.Consensus.Ledger.Abstract (TickedLedger)
 
@@ -154,11 +153,10 @@ class ( Show (ConsensusState p)
 
   -- | Check if a node is the leader
   checkIsLeader :: MonadRandom m
-                => ConsensusConfig p
-                -> SlotNo
-                -> LedgerView      p
-                -> ConsensusState  p
-                -> m (Maybe (IsLeader p))
+                => ConsensusConfig          p
+                -> TickedLedger (LedgerView p)
+                -> ConsensusState           p
+                -> m (Maybe (IsLeader       p))
 
   -- | Check if a node is configured such that it can be a leader.
   checkIfCanBeLeader :: ConsensusConfig p -> Bool

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -31,7 +31,7 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Network.Block (BlockNo, HeaderHash, Point)
 
-import           Ouroboros.Consensus.Ledger.Abstract (TickedLedger)
+import           Ouroboros.Consensus.Ledger.Abstract (Ticked)
 
 -- | Static configuration required to run the consensus protocol
 --
@@ -153,20 +153,20 @@ class ( Show (ConsensusState p)
 
   -- | Check if a node is the leader
   checkIsLeader :: MonadRandom m
-                => ConsensusConfig          p
-                -> TickedLedger (LedgerView p)
-                -> ConsensusState           p
-                -> m (Maybe (IsLeader       p))
+                => ConsensusConfig    p
+                -> Ticked (LedgerView p)
+                -> ConsensusState     p
+                -> m (Maybe (IsLeader p))
 
   -- | Check if a node is configured such that it can be a leader.
   checkIfCanBeLeader :: ConsensusConfig p -> Bool
 
   -- | Apply a header
   updateConsensusState :: HasCallStack
-                       => ConsensusConfig          p
-                       -> TickedLedger (LedgerView p)
-                       -> ValidateView             p
-                       -> ConsensusState           p
+                       => ConsensusConfig    p
+                       -> Ticked (LedgerView p)
+                       -> ValidateView       p
+                       -> ConsensusState     p
                        -> Except (ValidationErr p) (ConsensusState p)
 
   -- | We require that protocols support a @k@ security parameter

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -41,6 +41,7 @@ import           GHC.Generics (Generic)
 
 import           Ouroboros.Network.Block
 
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -140,7 +141,7 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
         CoreId{}  -> True
         RelayId{} -> False  -- Relays are never leaders
 
-  checkIsLeader BftConfig{..} (SlotNo n) _l _cs = do
+  checkIsLeader BftConfig{..} (TickedLedgerState (SlotNo n) _l) _cs = do
       return $ case bftNodeId of
                  RelayId _ -> Nothing
                  CoreId (CoreNodeId i) ->

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -141,7 +141,7 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
         CoreId{}  -> True
         RelayId{} -> False  -- Relays are never leaders
 
-  checkIsLeader BftConfig{..} (TickedLedgerState (SlotNo n) _l) _cs = do
+  checkIsLeader BftConfig{..} (Ticked (SlotNo n) _l) _cs = do
       return $ case bftNodeId of
                  RelayId _ -> Nothing
                  CoreId (CoreNodeId i) ->

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -21,6 +21,7 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Network.Block (SlotNo (..))
 
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), fromCoreNodeId)
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
@@ -65,7 +66,7 @@ instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
 
   checkIfCanBeLeader _ = True -- Conservative approximation
 
-  checkIsLeader WLSConfig{..} slot _ _ = return $
+  checkIsLeader WLSConfig{..} (TickedLedgerState slot _) _ = return $
     case Map.lookup slot $ getLeaderSchedule wlsConfigSchedule of
         Nothing                           -> Nothing
         Just nids

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -66,7 +66,7 @@ instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
 
   checkIfCanBeLeader _ = True -- Conservative approximation
 
-  checkIsLeader WLSConfig{..} (TickedLedgerState slot _) _ = return $
+  checkIsLeader WLSConfig{..} (Ticked slot _) _ = return $
     case Map.lookup slot $ getLeaderSchedule wlsConfigSchedule of
         Nothing                           -> Nothing
         Just nids

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -58,7 +58,7 @@ import           Ouroboros.Network.Block (BlockNo, pattern BlockPoint,
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Ledger.Abstract (TickedLedger (..))
+import           Ouroboros.Consensus.Ledger.Abstract (Ticked (..))
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -265,7 +265,7 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
         PBftIsALeader{}  -> True
         PBftIsNotALeader -> False
 
-  checkIsLeader PBftConfig{pbftIsLeader, pbftParams} (TickedLedgerState (SlotNo n) _l) _cs =
+  checkIsLeader PBftConfig{pbftIsLeader, pbftParams} (Ticked (SlotNo n) _l) _cs =
       case pbftIsLeader of
         PBftIsNotALeader                           -> return Nothing
 
@@ -279,7 +279,7 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
             PBftIsLeader{pbftCoreNodeId = CoreNodeId i} = credentials
             PBftParams{pbftNumNodes = NumCoreNodes numCoreNodes} = pbftParams
 
-  updateConsensusState cfg@PBftConfig{..} (TickedLedgerState _ lv@(PBftLedgerView dms)) toValidate state =
+  updateConsensusState cfg@PBftConfig{..} (Ticked _ lv@(PBftLedgerView dms)) toValidate state =
       case toValidate of
         PBftValidateBoundary slot hash ->
           return $! appendEBB cfg params slot hash state

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -265,7 +265,7 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
         PBftIsALeader{}  -> True
         PBftIsNotALeader -> False
 
-  checkIsLeader PBftConfig{pbftIsLeader, pbftParams} (SlotNo n) _l _cs =
+  checkIsLeader PBftConfig{pbftIsLeader, pbftParams} (TickedLedgerState (SlotNo n) _l) _cs =
       case pbftIsLeader of
         PBftIsNotALeader                           -> return Nothing
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -58,6 +58,7 @@ import           Ouroboros.Network.Block (BlockNo, pattern BlockPoint,
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Ledger.Abstract (TickedLedger (..))
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -278,7 +279,7 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
             PBftIsLeader{pbftCoreNodeId = CoreNodeId i} = credentials
             PBftParams{pbftNumNodes = NumCoreNodes numCoreNodes} = pbftParams
 
-  updateConsensusState cfg@PBftConfig{..} lv@(PBftLedgerView dms) toValidate state =
+  updateConsensusState cfg@PBftConfig{..} (TickedLedgerState _ lv@(PBftLedgerView dms)) toValidate state =
       case toValidate of
         PBftValidateBoundary slot hash ->
           return $! appendEBB cfg params slot hash state

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -783,19 +783,19 @@ instance ( IsLedger l
   type LedgerErr (LedgerDB l r) = LedgerErr l
 
   applyChainTick cfg slot db =
-      TickedLedgerState slot $ db { ledgerDbCurrent = l' }
+      Ticked slot $ db { ledgerDbCurrent = l' }
     where
-      TickedLedgerState _slot l' = applyChainTick cfg slot (ledgerDbCurrent db)
+      Ticked _slot l' = applyChainTick cfg slot (ledgerDbCurrent db)
 
 instance ApplyBlock l blk => ApplyBlock (LedgerDB l (RealPoint blk)) blk where
-  applyLedgerBlock cfg blk (TickedLedgerState slot db) = do
+  applyLedgerBlock cfg blk (Ticked slot db) = do
       fmap (\current' -> pushLedgerState current' (blockRealPoint blk) db) $
         applyLedgerBlock cfg blk $
-          TickedLedgerState slot (ledgerDbCurrent db)
-  reapplyLedgerBlock cfg blk (TickedLedgerState slot db) =
+          Ticked slot (ledgerDbCurrent db)
+  reapplyLedgerBlock cfg blk (Ticked slot db) =
       (\current' -> pushLedgerState current' (blockRealPoint blk) db) $
         reapplyLedgerBlock cfg blk $
-          TickedLedgerState slot (ledgerDbCurrent db)
+          Ticked slot (ledgerDbCurrent db)
   ledgerTipPoint =
       ledgerTipPoint . ledgerDbCurrent
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -724,7 +724,7 @@ withTestMempool setup@TestSetup { testLedgerState, testInitialTxs, testMempoolCa
       where
         -- Wrap in 'TickedLedgerState' so that we can call 'applyTx'
         notReallyTicked :: LedgerState TestBlock -> TickedLedgerState TestBlock
-        notReallyTicked = TickedLedgerState 0
+        notReallyTicked = Ticked 0
 
         txs = map fst snapshotTxs
         mkErrMsg e =

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -469,15 +469,16 @@ instance ApplyBlock (LedgerState TestBlock) TestBlock where
 
   ledgerTipPoint = lastAppliedPoint
 
-instance UpdateLedger TestBlock where
-  data LedgerState TestBlock =
-      TestLedger {
-          -- The ledger state simply consists of the last applied block
-          lastAppliedPoint :: !(Point TestBlock)
-        , lastAppliedHash  :: !(ChainHash TestBlock)
-        }
-    deriving stock    (Show, Eq, Generic)
-    deriving anyclass (Serialise, NoUnexpectedThunks)
+data instance LedgerState TestBlock =
+    TestLedger {
+        -- The ledger state simply consists of the last applied block
+        lastAppliedPoint :: !(Point TestBlock)
+      , lastAppliedHash  :: !(ChainHash TestBlock)
+      }
+  deriving stock    (Show, Eq, Generic)
+  deriving anyclass (Serialise, NoUnexpectedThunks)
+
+instance UpdateLedger TestBlock
 
 instance HasAnnTip TestBlock where
   type TipInfo TestBlock = IsEBB

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -453,10 +453,10 @@ instance IsLedger (LedgerState TestBlock) where
   type LedgerCfg (LedgerState TestBlock) = ()
   type LedgerErr (LedgerState TestBlock) = TestBlockError
 
-  applyChainTick _ = TickedLedgerState
+  applyChainTick _ = Ticked
 
 instance ApplyBlock (LedgerState TestBlock) TestBlock where
-  applyLedgerBlock _ tb@TestBlock{..} (TickedLedgerState _ TestLedger{..})
+  applyLedgerBlock _ tb@TestBlock{..} (Ticked _ TestLedger{..})
     | blockPrevHash tb /= lastAppliedHash
     = throwError $ InvalidHash lastAppliedHash (blockPrevHash tb)
     | not $ tbIsValid testBody


### PR DESCRIPTION
This makes it possible to define the `LedgerState` independent from the `UpdateLedger` instance, which is useful sometimes.

Note that this is just one commit; the rest is #2037, which should be merged soon.
