### PR TITLE
JIT EBBs in the ThreadNet tests require ExtLedgerState in block production

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -732,19 +732,12 @@ runThreadNetwork ThreadNetworkArgs
                   blk <- forgeBlock pInfoConfig upd
                     currentBno tickedLdgSt' txs prf
 
-                  -- /if the new block is valid/, add the EBB to the
-                  -- ChainDB
-                  --
-                  -- If the new block is invalid, then adding the EBB would
-                  -- be premature in some scenarios.
-                  case Exc.runExcept $ apply blk tickedLdgSt' of
-                    -- ASSUMPTION: If it's invalid with the EBB,
-                    -- it will be invalid without the EBB.
-                    Left{}  -> forgeWithoutEBB
-                    Right{} -> do
-                      -- TODO: We assume this succeeds; failure modes?
-                      void $ lift $ ChainDB.addBlock chainDB ebb
-                      pure blk
+                  -- If the EBB or the subsequent block is invalid, then the
+                  -- ChainDB will reject it as invalid, and
+                  -- 'Test.ThreadNet.General.prop_general' will eventually fail
+                  -- because of a block rejection.
+                  void $ lift $ ChainDB.addBlock chainDB ebb
+                  pure blk
 
       let -- prop_general relies on these tracers
           instrumentationTracers = nullTracers


### PR DESCRIPTION
Fixes #2047.

PR #1942 changed blockProduction to take a LedgerState instead of
ExtLedgerState, which suffices for all forging. However, the ThreadNet tests'
current approach to EBBs requires anticipating during block production whether
the produced block will be invalid in anyway. (The node does not emit the EBB
unless the EBB unless it is also emitting a valid block.) And that anticipatory
validation must include protocol-level errors, which requires the full
ExtLedgerState.

It may be possible to instead change the tests to allow for EBBs without
successors, but I'm don't see how, so I currently propose leaving that for future work if we
prioritize it.

Edit: PR 2176 essentially fixed this failure mode _en passant_. This PR now just simplifies the JIT EBB logic accordingly.