### PR TITLE
Introduce 'CodecConfig' abstration.

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -52,8 +52,8 @@ import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Consensus.Byron.Ledger
-import           Ouroboros.Consensus.Byron.Node hiding (extractEpochSlots)
-import qualified Ouroboros.Consensus.Byron.Node as Byron
+import           Ouroboros.Consensus.Byron.Ledger.Config (byronEpochSlots)
+import           Ouroboros.Consensus.Byron.Node
 import           Ouroboros.Consensus.Byron.Protocol
 
 import           Ouroboros.Consensus.ByronSpec.Ledger
@@ -269,12 +269,12 @@ instance RunNode DualByronBlock where
   nodeEncodeBlockWithInfo  = const $ encodeDualBlockWithInfo encodeByronBlockWithInfo
   nodeEncodeHeader         = \cfg version ->
                                   nodeEncodeHeader
-                                    (dualBlockConfigMain cfg)
+                                    (dualCodecConfigMain cfg)
                                     (castSerialisationVersion version)
                                 . dualHeaderMain
   nodeEncodeWrappedHeader  = \cfg version ->
                                   nodeEncodeWrappedHeader
-                                    (dualBlockConfigMain cfg)
+                                    (dualCodecConfigMain cfg)
                                     (castSerialisationAcrossNetwork version)
                                 . dualWrappedMain
   nodeEncodeLedgerState    = encodeDualLedgerState encodeByronLedgerState
@@ -291,12 +291,12 @@ instance RunNode DualByronBlock where
   nodeDecodeHeader         = \cfg version ->
                                (DualHeader .) <$>
                                  nodeDecodeHeader
-                                   (dualBlockConfigMain cfg)
+                                   (dualCodecConfigMain cfg)
                                    (castSerialisationVersion version)
   nodeDecodeWrappedHeader  = \cfg version ->
                                rewrapMain <$>
                                  nodeDecodeWrappedHeader
-                                   (dualBlockConfigMain cfg)
+                                   (dualCodecConfigMain cfg)
                                    (castSerialisationAcrossNetwork version)
   nodeDecodeGenTx          = decodeDualGenTx   decodeByronGenTx
   nodeDecodeGenTxId        = decodeDualGenTxId decodeByronGenTxId
@@ -309,8 +309,8 @@ instance RunNode DualByronBlock where
   nodeDecodeQuery          = error "DualByron.nodeDecodeQuery"
   nodeDecodeResult         = \case {}
 
-extractEpochSlots :: BlockConfig DualByronBlock -> EpochSlots
-extractEpochSlots = Byron.extractEpochSlots . dualBlockConfigMain
+extractEpochSlots :: CodecConfig DualByronBlock -> EpochSlots
+extractEpochSlots = byronEpochSlots . dualCodecConfigMain
 
 {-------------------------------------------------------------------------------
   The headers for DualByronBlock and ByronBlock are identical, so we can

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
@@ -1,16 +1,17 @@
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE TypeFamilies      #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Byron.Ledger.Config (
     BlockConfig(..)
+  , CodecConfig(..)
+  , byronGenesisHash
   , byronProtocolMagicId
   , byronProtocolMagic
-  , byronGenesisHash
-  , byronEpochSlots
   ) where
 
 import           GHC.Generics (Generic)
@@ -44,14 +45,21 @@ data instance BlockConfig ByronBlock = ByronConfig {
     }
   deriving (Generic, NoUnexpectedThunks)
 
+data instance CodecConfig ByronBlock = ByronCodecConfig {
+  byronEpochSlots :: CC.Slot.EpochSlots
+} deriving (Generic, NoUnexpectedThunks)
+
+instance BlockHasCodecConfig ByronBlock where
+  getCodecConfig ByronConfig { byronGenesisConfig }
+    = ByronCodecConfig
+      { byronEpochSlots = CC.Genesis.configEpochSlots byronGenesisConfig
+      }
+
+byronGenesisHash :: BlockConfig ByronBlock -> CC.Genesis.GenesisHash
+byronGenesisHash = CC.Genesis.configGenesisHash . byronGenesisConfig
+
 byronProtocolMagicId :: BlockConfig ByronBlock -> Crypto.ProtocolMagicId
 byronProtocolMagicId = Crypto.getProtocolMagicId . byronProtocolMagic
 
 byronProtocolMagic :: BlockConfig ByronBlock -> Crypto.ProtocolMagic
 byronProtocolMagic = CC.Genesis.configProtocolMagic . byronGenesisConfig
-
-byronGenesisHash :: BlockConfig ByronBlock -> CC.Genesis.GenesisHash
-byronGenesisHash = CC.Genesis.configGenesisHash . byronGenesisConfig
-
-byronEpochSlots :: BlockConfig ByronBlock -> CC.Slot.EpochSlots
-byronEpochSlots = CC.Genesis.configEpochSlots . byronGenesisConfig

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
@@ -91,4 +91,4 @@ instance ValidateEnvelope ByronBlock where
       canBeEBB (SlotNo s) = s `mod` epochSlots == 0
 
       epochSlots :: Word64
-      epochSlots = CC.unEpochSlots $ byronEpochSlots $ configBlock cfg
+      epochSlots = CC.unEpochSlots $ byronEpochSlots $ configCodec cfg

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -57,6 +57,7 @@ import           Ouroboros.Network.Point (WithOrigin (..))
 import qualified Ouroboros.Network.Point as Point
 import           Ouroboros.Network.Protocol.LocalStateQuery.Codec (Some (..))
 
+import           Ouroboros.Consensus.Block (getCodecConfig)
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.Abstract
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
@@ -249,7 +250,7 @@ instance HasHardForkHistory ByronBlock where
 
       eraParams :: HardFork.EraParams
       eraParams = HardFork.EraParams {
-            eraEpochSize  = fromByronEpochSlots $ byronEpochSlots cfg
+            eraEpochSize  = fromByronEpochSlots . byronEpochSlots $ getCodecConfig cfg
           , eraSlotLength = fromByronSlotLength $ genesisSlotLength genesis
           , eraSafeZone   = HardFork.SafeZone {
                 safeFromTip     = 2 * k

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
@@ -76,7 +76,7 @@ instance BlockSupportsProtocol ByronBlock where
                (CC.recoverSignedBytes epochSlots regular)
                (mkByronContextDSIGN cfg (pbftGenKey pbftFields))
     where
-      epochSlots = byronEpochSlots cfg
+      epochSlots = byronEpochSlots $ getCodecConfig cfg
 
   selectView _ hdr = (blockNo hdr, byronHeaderIsEBB hdr)
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -22,8 +22,6 @@ module Ouroboros.Consensus.Byron.Node (
   , pbftLeaderOrNot
     -- * For testing
   , plcCoreNodeId
-    -- * Exported for the benefit of ByronDual
-  , extractEpochSlots
   ) where
 
 import           Codec.Serialise (decode, encode)
@@ -250,8 +248,8 @@ instance RunNode ByronBlock where
   nodeEncodeQuery           = encodeByronQuery
   nodeEncodeResult          = encodeByronResult
 
-  nodeDecodeBlock           = decodeByronBlock . extractEpochSlots
-  nodeDecodeHeader          = \ cfg -> decodeByronHeader (extractEpochSlots cfg)
+  nodeDecodeBlock           = decodeByronBlock . byronEpochSlots
+  nodeDecodeHeader          = \ cfg -> decodeByronHeader (byronEpochSlots cfg)
   nodeDecodeWrappedHeader   = \_cfg -> decodeWrappedByronHeader
   nodeDecodeGenTx           = decodeByronGenTx
   nodeDecodeGenTxId         = decodeByronGenTxId
@@ -270,6 +268,3 @@ extractGenesisData :: TopLevelConfig ByronBlock -> Genesis.GenesisData
 extractGenesisData = Genesis.configGenesisData
                    . byronGenesisConfig
                    . configBlock
-
-extractEpochSlots :: BlockConfig ByronBlock -> EpochSlots
-extractEpochSlots = Genesis.configEpochSlots . byronGenesisConfig

--- a/ouroboros-consensus-byron/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-byron/tools/db-analyser/Main.hs
@@ -350,7 +350,7 @@ withImmDB :: FilePath
           -> IO a
 withImmDB fp cfg chunkInfo registry = ImmDB.withImmDB args
   where
-    bcfg = configBlock cfg
+    bcfg = configCodec cfg
     pb   = Proxy @ByronBlock
 
     args :: ImmDbArgs IO ByronBlock

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
@@ -94,3 +94,7 @@ instance HasHeader ByronSpecHeader where
 -------------------------------------------------------------------------------}
 
 data instance BlockConfig ByronSpecBlock = ByronSpecBlockConfig
+data instance CodecConfig ByronSpecBlock = ByronSpecCodecConfig
+
+instance BlockHasCodecConfig ByronSpecBlock where
+  getCodecConfig = const ByronSpecCodecConfig

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
@@ -5,6 +5,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Shelley.Ledger.Config (
     BlockConfig (..)
+  , CodecConfig (..)
   ) where
 
 import           GHC.Generics (Generic)
@@ -37,3 +38,11 @@ data instance BlockConfig (ShelleyBlock c) = ShelleyConfig {
     }
   deriving stock (Show, Generic)
   deriving anyclass NoUnexpectedThunks
+
+-- | No particular codec configuration is needed for Shelley
+data instance CodecConfig (ShelleyBlock c) = ShelleyCodecConfig
+  deriving stock (Show, Generic)
+  deriving anyclass NoUnexpectedThunks
+
+instance BlockHasCodecConfig (ShelleyBlock c) where
+  getCodecConfig = const ShelleyCodecConfig

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -250,6 +250,13 @@ data instance BlockConfig (SimpleBlock c ext) = SimpleBlockConfig {
     }
   deriving (Generic, NoUnexpectedThunks)
 
+-- | No additional codec information is required for simple blocks
+data instance CodecConfig (SimpleBlock c ext) = SimpleCodecConfig
+  deriving (Generic, NoUnexpectedThunks)
+
+instance BlockHasCodecConfig (SimpleBlock c ext) where
+  getCodecConfig = const SimpleCodecConfig
+
 defaultSimpleBlockConfig :: SecurityParam
                          -> SlotLength
                          -> BlockConfig (SimpleBlock c ext)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -98,11 +98,14 @@ instance SimpleCrypto c => RunMockBlock c SimplePraosRuleExt where
   mockEncodeConsensusState = const encode
   mockDecodeConsensusState = const decode
 
-instance SimpleCrypto c
-      => BlockSupportsProtocol (SimpleBlock c SimplePraosRuleExt) where
+instance
+  ( SimpleCrypto c
+  ) => BlockSupportsProtocol (SimpleBlock c SimplePraosRuleExt) where
   validateView _ _ = ()
 
-instance SimpleCrypto c => LedgerSupportsProtocol (SimplePraosRuleBlock c) where
+instance
+  ( SimpleCrypto c
+  ) => LedgerSupportsProtocol (SimplePraosRuleBlock c) where
   protocolLedgerView _ _ = ()
   ledgerViewForecastAt_ _ _ = Just . trivialForecast
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -614,7 +614,7 @@ runThreadNetwork ThreadNetworkArgs
         , cdbBlocksToAddSize      = 2
         }
       where
-        bcfg = configBlock cfg
+        bcfg = configCodec cfg
 
         -- prop_general relies on this tracer
         instrumentationTracer = Tracer $ \case
@@ -853,7 +853,7 @@ runThreadNetwork ThreadNetworkArgs
               NTN.cTxSubmissionCodec NTN.identityCodecs
         }
       where
-        binaryProtocolCodecs = NTN.defaultCodecs (configBlock cfg)
+        binaryProtocolCodecs = NTN.defaultCodecs (configCodec cfg)
                                  (mostRecentNodeToNodeVersion (Proxy @blk))
 
 -- | Sum of 'CodecFailure' (from @identityCodecs@) and 'DeserialiseFailure'

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -261,6 +261,12 @@ data instance BlockConfig TestBlock = TestBlockConfig {
     }
   deriving (Generic, NoUnexpectedThunks)
 
+data instance CodecConfig TestBlock = TestCodecConfig
+  deriving (Generic, NoUnexpectedThunks)
+
+instance BlockHasCodecConfig TestBlock where
+  getCodecConfig = const TestCodecConfig
+
 {-------------------------------------------------------------------------------
   Test infrastructure: ledger state
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -7,6 +7,8 @@ module Ouroboros.Consensus.Block.Abstract (
     BlockProtocol
     -- * Configuration
   , BlockConfig
+  , CodecConfig
+  , BlockHasCodecConfig(..)
     -- * Working with headers
   , GetHeader(..)
   , headerHash
@@ -31,8 +33,16 @@ type family BlockProtocol blk :: *
   Configuration
 -------------------------------------------------------------------------------}
 
+-- | Static configuration required for serialisation and deserialisation of
+--   types pertaining to this type of block
+data family CodecConfig blk :: *
+
 -- | Static configuration required to work with this type of blocks
 data family BlockConfig blk :: *
+
+-- | The codec configuration is a subset of the block configuration
+class BlockHasCodecConfig blk where
+  getCodecConfig :: BlockConfig blk -> CodecConfig blk
 
 {-------------------------------------------------------------------------------
   Link block to its header

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
@@ -24,9 +24,11 @@ class ( GetHeader blk
       , ConsensusProtocol (BlockProtocol blk)
       , NoUnexpectedThunks (Header blk)
       , NoUnexpectedThunks (BlockConfig blk)
+      , BlockHasCodecConfig blk
       ) => BlockSupportsProtocol blk where
   validateView :: BlockConfig blk
-               -> Header blk -> ValidateView (BlockProtocol blk)
+               -> Header blk
+               -> ValidateView (BlockProtocol blk)
 
   selectView   :: BlockConfig blk
                -> Header blk -> SelectView   (BlockProtocol blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
@@ -5,6 +5,7 @@
 module Ouroboros.Consensus.Config (
     TopLevelConfig(..)
   , configSecurityParam
+  , configCodec
   ) where
 
 import           GHC.Generics (Generic)
@@ -31,3 +32,9 @@ instance ( ConsensusProtocol  (BlockProtocol blk)
 configSecurityParam :: ConsensusProtocol (BlockProtocol blk)
                     => TopLevelConfig blk -> SecurityParam
 configSecurityParam = protocolSecurityParam . configConsensus
+
+configCodec
+  :: BlockHasCodecConfig blk
+  => TopLevelConfig blk
+  -> CodecConfig blk
+configCodec = getCodecConfig . configBlock

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -146,7 +146,7 @@ type ClientCodecs blk  m =
 -- anything different based on the version, so @_version@ is unused; it's just
 -- that not all codecs are used, depending on the version number.
 defaultCodecs :: forall m blk. (RunNode blk, MonadST m)
-              => BlockConfig         blk
+              => CodecConfig         blk
               -> NodeToClientVersion blk
               -> DefaultCodecs blk m
 defaultCodecs _cfg _version = Codecs {
@@ -179,7 +179,7 @@ defaultCodecs _cfg _version = Codecs {
 -- / deserialise blocks in /chain-sync/ protocol.
 --
 clientCodecs :: forall m blk. (RunNode blk, MonadST m)
-             => BlockConfig         blk
+             => CodecConfig         blk
              -> NodeToClientVersion blk
              -> ClientCodecs blk m
 clientCodecs cfg _version = Codecs {

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -172,7 +172,7 @@ data Codecs blk e m bCS bSCS bBF bSBF bTX = Codecs {
 
 -- | Protocol codecs for the node-to-node protocols
 defaultCodecs :: forall m blk. (IOLike m, RunNode blk)
-              => BlockConfig       blk
+              => CodecConfig       blk
               -> NodeToNodeVersion blk
               -> Codecs blk DeserialiseFailure m
                    ByteString ByteString ByteString ByteString ByteString

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -230,7 +230,7 @@ run runargs@RunNodeArgs{..} =
         NTN.mkApps
           nodeKernel
           rnTraceNTN
-          (NTN.defaultCodecs (configBlock (getTopLevelConfig nodeKernel)) version)
+          (NTN.defaultCodecs (configCodec (getTopLevelConfig nodeKernel)) version)
           (Just 70) -- timeout after waiting this long for the next header
                     -- 70s allows for 3 slots (3 * 20s)
           (NTN.mkHandlers nodeArgs nodeKernel)
@@ -243,7 +243,7 @@ run runargs@RunNodeArgs{..} =
     mkNodeToClientApps nodeArgs nodeKernel version =
         NTC.mkApps
           rnTraceNTC
-          (NTC.defaultCodecs (configBlock (getTopLevelConfig nodeKernel)) version)
+          (NTC.defaultCodecs (configCodec (getTopLevelConfig nodeKernel)) version)
           (NTC.mkHandlers nodeArgs nodeKernel)
 
     mkDiffusionApplications
@@ -364,14 +364,14 @@ mkChainDbArgs
 mkChainDbArgs tracer registry inFuture dbPath cfg initLedger
               chunkInfo = (ChainDB.defaultArgs dbPath)
     { ChainDB.cdbBlocksPerFile        = mkBlocksPerFile 1000
-    , ChainDB.cdbDecodeBlock          = nodeDecodeBlock          bcfg
-    , ChainDB.cdbDecodeHeader         = nodeDecodeHeader         bcfg SerialisedToDisk
+    , ChainDB.cdbDecodeBlock          = nodeDecodeBlock          ccfg
+    , ChainDB.cdbDecodeHeader         = nodeDecodeHeader         ccfg SerialisedToDisk
     , ChainDB.cdbDecodeConsensusState = nodeDecodeConsensusState pb cfg
     , ChainDB.cdbDecodeHash           = nodeDecodeHeaderHash     pb
     , ChainDB.cdbDecodeLedger         = nodeDecodeLedgerState
     , ChainDB.cdbDecodeTipInfo        = nodeDecodeTipInfo        pb
-    , ChainDB.cdbEncodeBlock          = nodeEncodeBlockWithInfo  bcfg
-    , ChainDB.cdbEncodeHeader         = nodeEncodeHeader         bcfg SerialisedToDisk
+    , ChainDB.cdbEncodeBlock          = nodeEncodeBlockWithInfo  ccfg
+    , ChainDB.cdbEncodeHeader         = nodeEncodeHeader         ccfg SerialisedToDisk
     , ChainDB.cdbEncodeConsensusState = nodeEncodeConsensusState pb cfg
     , ChainDB.cdbEncodeHash           = nodeEncodeHeaderHash     pb
     , ChainDB.cdbEncodeLedger         = nodeEncodeLedgerState
@@ -393,7 +393,7 @@ mkChainDbArgs tracer registry inFuture dbPath cfg initLedger
     }
   where
     k    = configSecurityParam cfg
-    bcfg = configBlock         cfg
+    ccfg = configCodec         cfg
     pb   = Proxy @blk
 
 mkNodeArgs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -160,13 +160,13 @@ class ( LedgerSupportsProtocol    blk
   nodeExceptionIsFatal _ _ = Nothing
 
   -- Encoders
-  nodeEncodeBlockWithInfo  :: BlockConfig blk -> blk -> BinaryInfo Encoding
-  nodeEncodeBlock          :: BlockConfig blk -> blk -> Encoding
+  nodeEncodeBlockWithInfo  :: CodecConfig blk -> blk -> BinaryInfo Encoding
+  nodeEncodeBlock          :: CodecConfig blk -> blk -> Encoding
   nodeEncodeBlock cfg blk = binaryBlob $ nodeEncodeBlockWithInfo cfg blk
-  nodeEncodeHeader         :: BlockConfig blk
+  nodeEncodeHeader         :: CodecConfig blk
                            -> SerialisationVersion blk
                            -> Header blk -> Encoding
-  nodeEncodeWrappedHeader  :: BlockConfig blk
+  nodeEncodeWrappedHeader  :: CodecConfig blk
                            -> SerialisationAcrossNetwork blk
                            -> Serialised (Header blk) -> Encoding
   nodeEncodeGenTx          :: GenTx  blk -> Encoding
@@ -180,13 +180,13 @@ class ( LedgerSupportsProtocol    blk
   nodeEncodeResult         :: Query blk result -> result -> Encoding
 
   -- Decoders
-  nodeDecodeHeader         :: forall s. BlockConfig blk
+  nodeDecodeHeader         :: forall s. CodecConfig blk
                            -> SerialisationVersion blk
                            -> Decoder s (Lazy.ByteString -> Header blk)
-  nodeDecodeWrappedHeader  :: forall s. BlockConfig blk
+  nodeDecodeWrappedHeader  :: forall s. CodecConfig blk
                            -> SerialisationAcrossNetwork blk
                            -> Decoder s (Serialised (Header blk))
-  nodeDecodeBlock          :: forall s. BlockConfig blk -> Decoder s (Lazy.ByteString -> blk)
+  nodeDecodeBlock          :: forall s. CodecConfig blk -> Decoder s (Lazy.ByteString -> blk)
   nodeDecodeGenTx          :: forall s. Decoder s (GenTx blk)
   nodeDecodeGenTxId        :: forall s. Decoder s (GenTxId blk)
   nodeDecodeHeaderHash     :: forall s. Proxy blk -> Decoder s (HeaderHash blk)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -217,6 +217,12 @@ data instance BlockConfig TestBlock = TestBlockConfig {
     }
   deriving (Generic, NoUnexpectedThunks)
 
+data instance CodecConfig TestBlock = TestCodecConfig
+  deriving (Generic, NoUnexpectedThunks)
+
+instance BlockHasCodecConfig TestBlock where
+  getCodecConfig = const TestCodecConfig
+
 instance Condense TestBlock where
   condense = show -- TODO
 


### PR DESCRIPTION
This separates concerns which are required for the codecs from the wider
block configuration.

Addressed #2049 

This should make it more easily possible for the API/Wallet to interact with nodes.