### PR TITLE
Set KES for TPraosStandardCrypto to be SimpleKES Ed25519DSIGN 14

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
@@ -16,7 +16,6 @@ import           Numeric.Natural
 import           Cardano.Binary (ToCBOR)
 import qualified Cardano.Crypto.DSIGN.Class as DSIGN
 import           Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
-import           Cardano.Crypto.DSIGN.Ed448 (Ed448DSIGN)
 import           Cardano.Crypto.Hash.Blake2b (Blake2b_256)
 import           Cardano.Crypto.KES.Class
 import qualified Cardano.Crypto.KES.Class as KES
@@ -52,7 +51,7 @@ data TPraosStandardCrypto
 
 instance Crypto TPraosStandardCrypto where
   type DSIGN TPraosStandardCrypto = Ed25519DSIGN
-  type KES   TPraosStandardCrypto = SimpleKES Ed448DSIGN 100 -- TODO correct number of evolutions?
+  type KES   TPraosStandardCrypto = SimpleKES Ed25519DSIGN 14 -- TODO: replace with the Sum6KES or Sum7KES
   type VRF   TPraosStandardCrypto = SimpleVRF
   type HASH  TPraosStandardCrypto = Blake2b_256
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -27,9 +27,9 @@ import           Text.Printf (printf)
 import           Control.Monad.Class.MonadTime (Time (..))
 
 import           Cardano.Crypto (VerificationKey)
-import           Cardano.Crypto.DSIGN (Ed448DSIGN, MockDSIGN, SigDSIGN,
-                     pattern SigEd448DSIGN, pattern SigMockDSIGN,
-                     SignedDSIGN (..))
+import           Cardano.Crypto.DSIGN (Ed25519DSIGN, Ed448DSIGN, MockDSIGN,
+                     SigDSIGN, pattern SigEd25519DSIGN, pattern SigEd448DSIGN,
+                     pattern SigMockDSIGN, SignedDSIGN (..))
 import           Cardano.Crypto.Hash (Hash)
 import           Cardano.Crypto.KES (MockKES, NeverKES, SigKES,
                      pattern SigMockKES, pattern SigSimpleKES,
@@ -174,6 +174,9 @@ instance Condense VerificationKey where
 
 instance Condense (SigDSIGN v) => Condense (SignedDSIGN v a) where
   condense (SignedDSIGN sig) = condense sig
+
+instance Condense (SigDSIGN Ed25519DSIGN) where
+  condense (SigEd25519DSIGN s) = show s
 
 instance Condense (SigDSIGN Ed448DSIGN) where
   condense (SigEd448DSIGN s) = show s


### PR DESCRIPTION
This will be replaced with the SumNKES soonish, but in the meantime we
need a KES for the testnet that does not have enormous keys or
signatures. We also actively want a short KES period for the testnet to
get people used to the idea of cycling their hot keys.