### PR TITLE
Add a ProtocolClient and ProtocolClientInfo for node clients

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -12,6 +12,7 @@
 
 module Ouroboros.Consensus.Byron.Node (
     protocolInfoByron
+  , protocolClientInfoByron
   , mkByronConfig
   , PBftSignatureThreshold(..)
   , defaultPBftSignatureThreshold
@@ -147,6 +148,12 @@ protocolInfoByron genesisConfig mSigThresh pVer sVer mLeader =
       }
   where
     byronConfig = mkByronConfig genesisConfig pVer sVer
+
+protocolClientInfoByron :: EpochSlots -> ProtocolClientInfo ByronBlock
+protocolClientInfoByron byronEpochSlots =
+    ProtocolClientInfo {
+      pClientInfoCodecConfig = ByronCodecConfig { byronEpochSlots }
+    }
 
 byronPBftParams :: Genesis.Config -> Maybe PBftSignatureThreshold -> PBftParams
 byronPBftParams cfg threshold = PBftParams {

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -9,6 +9,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Shelley.Node (
     protocolInfoShelley
+  , protocolClientInfoShelley
   , ShelleyGenesis (..)
   , initialFundsPseudoTxIn
   , ShelleyGenesisStaking (..)
@@ -371,6 +372,14 @@ protocolInfoShelley genesis protVer mbCredentials =
               SL.StakeRefPtr _ ->
                 error "Pointer stake addresses not allowed in initial snapshot"
               SL.StakeRefNull -> Nothing
+
+
+protocolClientInfoShelley :: Crypto c => ProtocolClientInfo (ShelleyBlock c)
+protocolClientInfoShelley =
+    ProtocolClientInfo {
+      -- No particular codec configuration is needed for Shelley
+      pClientInfoCodecConfig = ShelleyCodecConfig
+    }
 
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -4,12 +4,14 @@ module Ouroboros.Consensus.Node.ProtocolInfo (
     NumCoreNodes(..)
   , enumCoreNodes
   , ProtocolInfo(..)
+  , ProtocolClientInfo(..)
   ) where
 
 import           Data.Word
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Node.State
@@ -37,3 +39,8 @@ data ProtocolInfo b = ProtocolInfo {
       , pInfoInitState  :: NodeState      b
       , pInfoInitLedger :: ExtLedgerState b -- ^ Genesis ledger state
       }
+
+-- | Data required by clients of a node running the specified protocol.
+data ProtocolClientInfo b = ProtocolClientInfo {
+       pClientInfoCodecConfig :: CodecConfig b
+     }


### PR DESCRIPTION
These mirror the Protocol and ProtocolInfo needed to actually run a
node, but the purpose of these is to collect the info needed to interact
with a node running that protocol. So far it only contains the
CodecConfig.