### PR TITLE
Move txSize from ApplyTx to RunNode and Mempool

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byrondual/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -240,6 +240,11 @@ instance RunNode DualByronBlock where
   nodeMaxBlockSize          = nodeMaxBlockSize          . dualLedgerStateMain
   nodeBlockEncodingOverhead = nodeBlockEncodingOverhead . dualLedgerStateMain
 
+  -- We pretend the abstract transactions have no size, and let the size of
+  -- the mempool be limited by concrete transactions only. This is ok, because
+  -- the spec does not impose a maximum block size.
+  nodeTxSize = nodeTxSize . dualGenTxMain
+
   -- Envelope
   nodeHashInfo     = \_p -> nodeHashInfo     pb
   nodeEncodeAnnTip = \_p -> nodeEncodeAnnTip pb . castAnnTip

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -43,7 +43,6 @@ import           Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as CBOR
 import           Control.Monad.Except
 import           Data.ByteString (ByteString)
-import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Maybe (maybeToList)
 import           Data.Word
@@ -89,9 +88,6 @@ instance ApplyTx ByronBlock where
     | ByronUpdateVote     !Update.VoteId            !(Update.AVote            ByteString)
     deriving (Eq, Generic)
     deriving NoUnexpectedThunks via UseIsNormalForm (GenTx ByronBlock)
-
-  txSize =
-      fromIntegral . Strict.length . CC.mempoolPayloadRecoverBytes . toMempoolPayload
 
   -- Check that the annotation is the canonical encoding. This is currently
   -- enforced by 'decodeByronGenTx', see its docstring for more context.

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -27,6 +27,7 @@ module Ouroboros.Consensus.Byron.Node (
 
 import           Control.Exception (Exception (..))
 import           Control.Monad.Except
+import qualified Data.ByteString as Strict
 import           Data.Coerce (coerce)
 import           Data.Maybe
 
@@ -205,6 +206,10 @@ instance RunNode ByronBlock where
 
   nodeMaxBlockSize          = API.getMaxBlockSize . byronLedgerState
   nodeBlockEncodingOverhead = const byronBlockEncodingOverhead
+  nodeTxSize                = fromIntegral
+                            . Strict.length
+                            . API.mempoolPayloadRecoverBytes
+                            . toMempoolPayload
 
   -- If the current chain is empty, produce a genesis EBB and add it to the
   -- ChainDB. Only an EBB can have Genesis (= empty chain) as its predecessor.

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
@@ -35,11 +35,6 @@ instance ApplyTx ByronSpecBlock where
 
   type ApplyTxErr ByronSpecBlock = ByronSpecGenTxErr
 
-  -- We pretend the abstract transactions have no size, and let the size of the
-  -- mempool be limited by concrete transactions only. This is ok, because the
-  -- spec does not impose a maximum block size.
-  txSize _ = 0
-
   applyTx cfg tx (Ticked slot st) =
       (Ticked slot . updateByronSpecLedgerStateKeepTip st) <$>
         GenTx.apply

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -36,7 +36,6 @@ import           Ouroboros.Consensus.Util.Condense
 
 import qualified Shelley.Spec.Ledger.API as SL
 import           Shelley.Spec.Ledger.BlockChain as SL
-import qualified Shelley.Spec.Ledger.LedgerState as SL
 import qualified Shelley.Spec.Ledger.Tx as SL
 import qualified Shelley.Spec.Ledger.UTxO as SL
 
@@ -54,10 +53,6 @@ instance TPraosCrypto c => ApplyTx (ShelleyBlock c) where
     deriving anyclass (NoUnexpectedThunks)
 
   type ApplyTxErr (ShelleyBlock c) = SL.ApplyTxError c
-
-  -- TODO why does that function live in LedgerState? It looks like a crazy
-  -- function.
-  txSize (ShelleyTx _ tx) = fromIntegral $ SL.txsize tx
 
   txInvariant = const True
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -174,8 +174,8 @@ initialFundsPseudoTxIn addr =
     castHash (Crypto.UnsafeHash h) = Crypto.UnsafeHash h
 
 protocolInfoShelley
-  :: forall c. Crypto c
-  => ShelleyGenesis c
+  :: forall c.
+     ShelleyGenesis c
   -> SL.ProtVer
   -> Maybe (TPraosLeaderCredentials c)
   -> ProtocolInfo (ShelleyBlock c)
@@ -373,8 +373,7 @@ protocolInfoShelley genesis protVer mbCredentials =
                 error "Pointer stake addresses not allowed in initial snapshot"
               SL.StakeRefNull -> Nothing
 
-
-protocolClientInfoShelley :: Crypto c => ProtocolClientInfo (ShelleyBlock c)
+protocolClientInfoShelley :: ProtocolClientInfo (ShelleyBlock c)
 protocolClientInfoShelley =
     ProtocolClientInfo {
       -- No particular codec configuration is needed for Shelley
@@ -422,6 +421,8 @@ instance TPraosCrypto c => RunNode (ShelleyBlock c) where
   -- TODO
   nodeBlockEncodingOverhead = const 1 -- Single list tag.
   -- Check this isn't altered by the TxWits stuff
+
+  nodeTxSize (ShelleyTx _ tx) = fromIntegral $ SL.txsize tx
 
   nodeCheckIntegrity cfg = verifyBlockIntegrity tpraosSlotsPerKESPeriod
     where

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -46,6 +46,7 @@ module Ouroboros.Consensus.Mock.Ledger.Block (
     -- * 'ApplyTx' (mempool support)
   , GenTx(..)
   , mkSimpleGenTx
+  , txSize
     -- * 'TxId'
   , unSimpleGenTxId
     -- * Crypto
@@ -338,8 +339,6 @@ instance MockProtocolSpecific c ext => ApplyTx (SimpleBlock c ext) where
     } deriving stock    (Generic, Eq, Ord)
       deriving anyclass (Serialise)
 
-  txSize = fromIntegral . Lazy.length . serialise
-
   type ApplyTxErr (SimpleBlock c ext) = MockError (SimpleBlock c ext)
 
   applyTx   = const updateSimpleUTxO
@@ -376,6 +375,9 @@ mkSimpleGenTx tx = SimpleGenTx
     { simpleGenTx   = tx
     , simpleGenTxId = hash tx
     }
+
+txSize :: GenTx (SimpleBlock c ext) -> TxSizeInBytes
+txSize = fromIntegral . Lazy.length . serialise
 
 {-------------------------------------------------------------------------------
   Support for QueryLedger

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -65,6 +65,7 @@ instance ( LedgerSupportsProtocol (SimpleBlock SimpleMockCrypto ext)
   nodeHashInfo              = const simpleBlockHashInfo
   nodeMaxBlockSize          = const 2000000 -- TODO
   nodeBlockEncodingOverhead = const 1000 -- TODO
+  nodeTxSize                = txSize
   nodeCheckIntegrity        = \_ _ -> True
 
   nodeEncodeBlockWithInfo   = const simpleBlockBinaryInfo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -454,8 +454,6 @@ instance Bridge m a => ApplyTx (DualBlock m a) where
 
   type ApplyTxErr (DualBlock m a) = DualGenTxErr m a
 
-  txSize DualGenTx{..} = txSize dualGenTxMain + txSize dualGenTxAux
-
   applyTx DualLedgerConfig{..}
           tx@DualGenTx{..}
           (Ticked slot DualLedgerState{..}) = do

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalTxSubmission/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalTxSubmission/Server.hs
@@ -21,7 +21,7 @@ import           Ouroboros.Consensus.Util.IOLike
 -- | Local transaction submission server, for adding txs to the 'Mempool'
 --
 localTxSubmissionServer
-  :: (MonadSTM m, ApplyTx blk)
+  :: MonadSTM m
   => Tracer m (TraceLocalTxSubmissionServerEvent blk)
   -> Mempool m blk idx
   -> LocalTxSubmissionServer (GenTx blk) (ApplyTxErr blk) m ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -113,6 +113,17 @@ class ( LedgerSupportsProtocol    blk
                         -> Lazy.ByteString -> Lazy.ByteString
   nodeAddHeaderEnvelope _ _ _ = id  -- Default to no envelope
 
+  -- | Return the post-serialisation size in bytes of a 'GenTx'.
+  --
+  -- Can be implemented by serialising the 'GenTx', but, ideally, this is
+  -- implement more efficiently. E.g., by returning the length of the
+  -- annotation.
+  --
+  -- > forall tx:
+  -- >   nodeTxSize tx ==
+  -- >   BSL.length (CBOR.toLazyByteString (nodeEncodeGenTx tx))
+  --
+  nodeTxSize :: GenTx blk -> TxSizeInBytes
 
   -- | This function is called when starting up the node, right after the
   -- ChainDB was opened, and before we connect to other nodes and start block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -273,6 +273,7 @@ initInternalState NodeArgs { tracers, chainDB, registry, cfg,
                                   (configLedger cfg)
                                   mpCap
                                   (mempoolTracer tracers)
+                                  nodeTxSize
 
     fetchClientRegistry <- newFetchClientRegistry
 
@@ -612,7 +613,7 @@ mkCurrentBlockContext currentSlot c = case c of
 -------------------------------------------------------------------------------}
 
 getMempoolReader
-  :: forall m blk. (IOLike m, ApplyTx blk, HasTxId (GenTx blk))
+  :: forall m blk. (IOLike m, HasTxId (GenTx blk))
   => Mempool m blk TicketNo
   -> TxSubmissionMempoolReader (GenTxId blk) (GenTx blk) TicketNo m
 getMempoolReader mempool = MempoolReader.TxSubmissionMempoolReader
@@ -627,7 +628,7 @@ getMempoolReader mempool = MempoolReader.TxSubmissionMempoolReader
                                       snapshotHasTx } =
       MempoolReader.MempoolSnapshot
         { mempoolTxIdsAfter = \idx ->
-            [ (txId tx, idx', txSize tx)
+            [ (txId tx, idx', getTxSize mempool tx)
             | (tx, idx') <- snapshotTxsAfter idx
             ]
         , mempoolLookupTx   = snapshotLookupTx
@@ -635,7 +636,7 @@ getMempoolReader mempool = MempoolReader.TxSubmissionMempoolReader
         }
 
 getMempoolWriter
-  :: (IOLike m, ApplyTx blk, HasTxId (GenTx blk))
+  :: (IOLike m, HasTxId (GenTx blk))
   => Mempool m blk TicketNo
   -> TxSubmissionMempoolWriter (GenTxId blk) (GenTx blk) TicketNo m
 getMempoolWriter mempool = Inbound.TxSubmissionMempoolWriter

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -667,6 +667,7 @@ withTestMempool setup@TestSetup { testLedgerState, testInitialTxs, testMempoolCa
                                               cfg
                                               testMempoolCap
                                               tracer
+                                              txSize
       result  <- addTxs mempool testInitialTxs
       -- the invalid transactions are reported in the same order they were
       -- added, so the first error is not the result of a cascade


### PR DESCRIPTION
The `txSize` method returns the size of a serialised transaction in bytes.
None of the other consensus classes deal with serialisation-related details,
all such details are collected in the `RunNode` class.

Remove `txSize` from `ApplyTx` and add it as `nodeTxSize` to `RunNode`. Let
the `Mempool` implementation take a function of the given type as argument.
Additionally, expose `getTxSize` in the Mempool API. Otherwise, the function
in question would, rather inconveniently, have to be passed in a lot more
places.

This change helps with the hard-fork combinator: it is likely that we'll have
to add a container around transactions of the hard-fork block type when
encoding them so that we can distinguish Byron from Shelley transactions when
decoding them. Such a container will add at least one extra byte to the size
of a transaction. Accounting for this extra byte should not be done in
`ApplyTx`, but in `RunNode`.