### PR TITLE
MsgKTnxBye in TxSubmission protocol

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -882,7 +882,7 @@ data RestartCause
 -- | Fork two directed edges, one in each direction between the two vertices
 --
 forkBothEdges
-  :: (IOLike m, HasCallStack)
+  :: (IOLike m, HasNetworkProtocolVersion blk, HasCallStack)
   => ResourceRegistry m
   -> WrappedClock m
   -> Tracer m (SlotNo, MiniProtocolState, MiniProtocolExpectedException)
@@ -929,7 +929,7 @@ forkBothEdges sharedRegistry clock tr vertexStatusVars (node1, node2) = do
 -- edge via the @async@ interface rather than relying on some sort of mock
 -- socket semantics to convey the cancellation.
 directedEdge ::
-  forall m blk. IOLike m
+  forall m blk. (IOLike m, HasNetworkProtocolVersion blk)
   => Tracer m (SlotNo, MiniProtocolState, MiniProtocolExpectedException)
   -> WrappedClock m
   -> EdgeStatusVar m
@@ -973,7 +973,7 @@ directedEdge tr clock edgeStatusVar client server =
 --
 -- See 'directedEdge'.
 directedEdgeInner ::
-  forall m blk. IOLike m
+  forall m blk. (IOLike m, HasNetworkProtocolVersion blk)
   => EdgeStatusVar m
   -> (CoreNodeId, VertexStatusVar m blk)
      -- ^ client threads on this node
@@ -990,12 +990,14 @@ directedEdgeInner edgeStatusVar
 
     let miniProtocol ::
              (  LimitedApp' m NodeId blk
+             -> NodeToNodeVersion blk
              -> NodeId
              -> Channel m msg
              -> m ()
              )
             -- ^ client action to run on node1
           -> (  LimitedApp' m NodeId blk
+             -> NodeToNodeVersion blk
              -> NodeId
              -> Channel m msg
              -> m ()
@@ -1005,8 +1007,8 @@ directedEdgeInner edgeStatusVar
         miniProtocol client server = do
            (chan, dualChan) <- createConnectedChannels
            pure
-             ( client app1 (fromCoreNodeId node2) chan
-             , server app2 (fromCoreNodeId node1) dualChan
+             ( client app1 (mostRecentNodeToNodeVersion (Proxy @blk)) (fromCoreNodeId node2) chan
+             , server app2 (mostRecentNodeToNodeVersion (Proxy @blk)) (fromCoreNodeId node1) dualChan
              )
 
     -- NB only 'watcher' ever returns in these tests
@@ -1039,10 +1041,10 @@ directedEdgeInner edgeStatusVar
     wrapMPEE ::
          Exception e
       => (e -> MiniProtocolExpectedException)
-      -> (app -> peer -> chan -> m a)
-      -> (app -> peer -> chan -> m a)
-    wrapMPEE f m = \app them chan ->
-        catch (m app them chan) $ throwM . f
+      -> (app -> version -> peer -> chan -> m a)
+      -> (app -> version -> peer -> chan -> m a)
+    wrapMPEE f m = \app version them chan ->
+        catch (m app version them chan) $ throwM . f
 
     -- terminates when the vertex starts 'VFalling'
     --
@@ -1260,7 +1262,7 @@ data LimitedApp m peer blk =
 --
 -- Used internal to this module, essentially as an abbreviation.
 type LimitedApp' m peer blk =
-    NTN.Apps m peer
+    NTN.Apps m peer blk
         -- The 'ChainSync' and 'BlockFetch' protocols use @'Serialised' x@ for
         -- the servers and @x@ for the clients. Since both have to match to be
         -- sent across a channel, we can't use @'AnyMessage' ..@, instead, we

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -269,6 +269,7 @@ instance BlockHasCodecConfig TestBlock where
   getCodecConfig = const TestCodecConfig
 
 instance HasNetworkProtocolVersion TestBlock where
+  -- Use defaults
 
 {-------------------------------------------------------------------------------
   Test infrastructure: ledger state

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -62,7 +62,7 @@ import           Data.FingerTree.Strict (Measured (..))
 import           Data.Function (on)
 import           Data.Int
 import           Data.List (maximumBy, transpose)
-import           Data.List.NonEmpty (NonEmpty)
+import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
@@ -94,6 +94,7 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -266,6 +267,8 @@ data instance CodecConfig TestBlock = TestCodecConfig
 
 instance BlockHasCodecConfig TestBlock where
   getCodecConfig = const TestCodecConfig
+
+instance HasNetworkProtocolVersion TestBlock where
 
 {-------------------------------------------------------------------------------
   Test infrastructure: ledger state

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
@@ -27,6 +27,8 @@ import           Ouroboros.Network.Protocol.BlockFetch.Server
 import           Ouroboros.Network.Protocol.BlockFetch.Type (ChainRange (..))
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+                     (NodeToNodeVersion)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
@@ -73,9 +75,10 @@ blockFetchServer
        )
     => Tracer m (TraceBlockFetchServerEvent blk)
     -> ChainDB m blk
+    -> NodeToNodeVersion blk
     -> ResourceRegistry m
     -> BlockFetchServer (Serialised blk) m ()
-blockFetchServer _tracer chainDB registry = senderSide
+blockFetchServer _tracer chainDB _version registry = senderSide
   where
     senderSide :: BlockFetchServer (Serialised blk) m ()
     senderSide = BlockFetchServer receiveReq' ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -64,6 +64,8 @@ import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+                     (NodeToNodeVersion)
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.Assert (assertWithMsg)
@@ -342,6 +344,7 @@ chainSyncClient
     -> Tracer m (TraceChainSyncClientEvent blk)
     -> TopLevelConfig blk
     -> ChainDbView m blk
+    -> NodeToNodeVersion blk
     -> StrictTVar m (AnchoredFragment (Header blk))
     -> Consensus ChainSyncClientPipelined blk m
 chainSyncClient mkPipelineDecision0 tracer cfg
@@ -351,7 +354,8 @@ chainSyncClient mkPipelineDecision0 tracer cfg
                 , getOurTip
                 , getIsInvalidBlock
                 }
-                varCandidate = ChainSyncClientPipelined $
+                 _version
+                 varCandidate = ChainSyncClientPipelined $
     continueWithState () $ initialise
   where
     -- | Start ChainSync by looking for an intersection between our current

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
@@ -24,6 +24,8 @@ import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB, Reader,
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+                     (NodeToNodeVersion)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
@@ -36,9 +38,10 @@ chainSyncHeadersServer
     :: forall m blk. (IOLike m, HasHeader (Header blk))
     => Tracer m (TraceChainSyncServerEvent blk (Header blk))
     -> ChainDB m blk
+    -> NodeToNodeVersion blk
     -> ResourceRegistry m
     -> ChainSyncServer (Serialised (Header blk)) (Tip blk) m ()
-chainSyncHeadersServer tracer chainDB registry =
+chainSyncHeadersServer tracer chainDB _version registry =
     ChainSyncServer $ do
       rdr <- ChainDB.newReader chainDB registry getSerialisedHeaderWithPoint
       let ChainSyncServer server = chainSyncServerForReader tracer chainDB rdr

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -225,7 +225,7 @@ run runargs@RunNodeArgs{..} =
       :: NodeArgs   IO RemoteConnectionId LocalConnectionId blk
       -> NodeKernel IO RemoteConnectionId LocalConnectionId blk
       -> NodeToNodeVersion blk
-      -> NTN.Apps IO RemoteConnectionId ByteString ByteString ByteString ()
+      -> NTN.Apps IO RemoteConnectionId blk ByteString ByteString ByteString ()
     mkNodeToNodeApps nodeArgs nodeKernel version =
         NTN.mkApps
           nodeKernel
@@ -249,10 +249,10 @@ run runargs@RunNodeArgs{..} =
     mkDiffusionApplications
       :: MiniProtocolParameters
       -> (   NodeToNodeVersion   blk
-          -> NTN.Apps IO RemoteConnectionId ByteString ByteString ByteString ()
+          -> NTN.Apps IO RemoteConnectionId blk ByteString ByteString ByteString ()
          )
       -> (   NodeToClientVersion blk
-          -> NTC.Apps IO LocalConnectionId  ByteString ByteString ByteString ()
+          -> NTC.Apps IO LocalConnectionId      ByteString ByteString ByteString ()
          )
       -> DiffusionApplications
     mkDiffusionApplications miniProtocolParams ntnApps ntcApps =
@@ -262,7 +262,7 @@ run runargs@RunNodeArgs{..} =
                 version'
                 nodeToNodeVersionData
                 (DictVersion nodeToNodeCodecCBORTerm)
-                (NTN.responder miniProtocolParams version' $ ntnApps version)
+                (NTN.responder miniProtocolParams version $ ntnApps version)
             | version <- rnNodeToNodeVersions
             , let version' = nodeToNodeProtocolVersion (Proxy @blk) version
             ]
@@ -271,7 +271,7 @@ run runargs@RunNodeArgs{..} =
                 version'
                 nodeToNodeVersionData
                 (DictVersion nodeToNodeCodecCBORTerm)
-                (NTN.initiator miniProtocolParams version' $ ntnApps version)
+                (NTN.initiator miniProtocolParams version $ ntnApps version)
             | version <- rnNodeToNodeVersions
             , let version' = nodeToNodeProtocolVersion (Proxy @blk) version
             ]

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -294,6 +294,7 @@ runChainSync securityParam (ClientUpdates clientUpdates)
                    chainSyncTracer
                    (nodeCfg clientId)
                    chainDbView
+                   ()
 
     -- Set up the server
     varChainProducerState <- uncheckedNewTVarM $ initChainProducerState Genesis

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -294,7 +294,7 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
               nullTracer -- (contramap (show . TraceLabelPeer peerid) stdoutTracer)
               codecBlockFetch
               channel
-              (blockFetchClient clientCtx)
+              (blockFetchClient NodeToNodeV_1 clientCtx)
 
         blockFetchPolicy :: BlockFetchConsensusInterface
                              LocalConnectionId BlockHeader Block IO

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -56,7 +56,9 @@ library
                        Ouroboros.Network.Magic
                        Ouroboros.Network.Diffusion
                        Ouroboros.Network.NodeToNode
+                       Ouroboros.Network.NodeToNode.Version
                        Ouroboros.Network.NodeToClient
+                       Ouroboros.Network.NodeToClient.Version
                        Ouroboros.Network.Tracers
                        Ouroboros.Network.Point
                        Ouroboros.Network.PeerSelection.Types

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Examples.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Examples.hs
@@ -68,7 +68,7 @@ txSubmissionClient tracer txId txSize maxUnacked =
     client :: StrictSeq txid -> Map txid tx -> [tx] -> ClientStIdle txid tx m ()
     client !unackedSeq !unackedMap remainingTxs =
         assert invariant
-        ClientStIdle { recvMsgRequestTxIds, recvMsgRequestTxs }
+        ClientStIdle { recvMsgRequestTxIds, recvMsgRequestTxs, recvMsgKThxBye }
       where
         -- The entries in the unackedMap are a subset of those in the
         -- unackedSeq. The sequence is all of them, whereas we remove
@@ -151,6 +151,9 @@ txSubmissionClient tracer txId txSize maxUnacked =
 
             missing -> fail $ "txSubmissionClientConst.recvMsgRequestTxs: "
                            ++ "requested missing TxIds: " ++ show missing
+
+        recvMsgKThxBye :: m ()
+        recvMsgKThxBye = pure ()
 
 
 --

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Test.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE DataKinds                  #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
+-- usage of `MsgKThxBye` is safe in this module.
+{-# OPTIONS_GHC -Wno-warnings-deprecations #-}
 
 module Ouroboros.Network.Protocol.TxSubmission.Test (
     tests

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Test.hs
@@ -254,6 +254,9 @@ instance Arbitrary (AnyMessageAndAgency (TxSubmission TxId Tx)) where
     , AnyMessageAndAgency (ServerAgency TokIdle) <$>
         MsgRequestTxs <$> arbitrary
 
+    , AnyMessageAndAgency (ServerAgency TokIdle) <$>
+        pure MsgKThxBye
+
     , AnyMessageAndAgency (ClientAgency TokTxs) <$>
         MsgReplyTxs <$> arbitrary
 
@@ -290,6 +293,9 @@ instance (Eq txid, Eq tx) => Eq (AnyMessage (TxSubmission txid tx)) where
 
   (==) (AnyMessage MsgDone)
        (AnyMessage MsgDone) = True
+
+  (==) (AnyMessage MsgKThxBye)
+       (AnyMessage MsgKThxBye) = True
 
   _ == _ = False
 

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -27,6 +27,7 @@ import qualified Data.Set as Set
 
 import           Ouroboros.Network.Block
 
+import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
 import           Ouroboros.Network.Protocol.BlockFetch.Type
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Pipelined
@@ -74,9 +75,11 @@ blockFetchClient :: forall header block m void.
                     (MonadSTM m, MonadMonotonicTime m, MonadThrow m,
                      HasHeader header, HasHeader block,
                      HeaderHash header ~ HeaderHash block)
-                 => FetchClientContext header block m
+                 => NodeToNodeVersion
+                 -> FetchClientContext header block m
                  -> PeerPipelined (BlockFetch block) AsClient BFIdle m void
-blockFetchClient FetchClientContext {
+blockFetchClient _version
+                 FetchClientContext {
                    fetchClientCtxTracer    = tracer,
                    fetchClientCtxPolicy    = FetchClientPolicy {
                                                blockFetchSize,

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -1,0 +1,84 @@
+
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Ouroboros.Network.NodeToClient.Version
+  ( NodeToClientVersion (..)
+  , NodeToClientVersionData (..)
+  , nodeToClientVersionCodec
+  , nodeToClientCodecCBORTerm
+  ) where
+
+import           Data.Bits (setBit, clearBit, testBit)
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Data.Typeable (Typeable)
+
+import qualified Codec.CBOR.Term as CBOR
+
+import           Ouroboros.Network.CodecCBORTerm
+import           Ouroboros.Network.Magic
+import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..), Accept (..))
+
+
+-- | Enumeration of node to client protocol versions.
+--
+data NodeToClientVersion
+    = NodeToClientV_1
+    | NodeToClientV_2
+    -- ^ added local-query mini-protocol
+  deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
+
+-- | We set 16ths bit to distinguish `NodeToNodeVersion` and
+-- `NodeToClientVersion`.  This way connectin wrong protocol suite will fail
+-- during `Handshake` negotation
+--
+-- This is done in backward compatible way, so `NodeToClientV_1` encoding is not
+-- changed.
+--
+nodeToClientVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToClientVersion
+nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
+    where
+      encodeTerm NodeToClientV_1 = CBOR.TInt 1
+      encodeTerm NodeToClientV_2 = CBOR.TInt (2 `setBit` nodeToClientVersionBit)
+
+      decodeTerm (CBOR.TInt tag) =
+       case ( tag `clearBit` nodeToClientVersionBit
+            , tag `testBit`  nodeToClientVersionBit
+            ) of
+        (1, False) -> Right NodeToClientV_1
+        (2, True)  -> Right NodeToClientV_2
+        (n, _)     -> Left ( T.pack "decode NodeToClientVersion: unknown tag: " <> T.pack (show tag)
+                            , Just n)
+      decodeTerm _  = Left ( T.pack "decode NodeToClientVersion: unexpected term"
+                           , Nothing)
+
+
+nodeToClientVersionBit :: Int
+nodeToClientVersionBit = 15
+
+
+-- | Version data for NodeToClient protocol v1
+--
+newtype NodeToClientVersionData = NodeToClientVersionData
+  { networkMagic :: NetworkMagic }
+  deriving (Eq, Show, Typeable)
+
+instance Acceptable NodeToClientVersionData where
+    acceptableVersion local remote
+      | local == remote
+      = Accept
+      | otherwise =  Refuse $ T.pack $ "version data mismatch: "
+                                    ++ show local
+                                    ++ " /= " ++ show remote
+
+nodeToClientCodecCBORTerm :: CodecCBORTerm Text NodeToClientVersionData
+nodeToClientCodecCBORTerm = CodecCBORTerm {encodeTerm, decodeTerm}
+    where
+      encodeTerm :: NodeToClientVersionData -> CBOR.Term
+      encodeTerm NodeToClientVersionData { networkMagic } =
+        CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
+
+      decodeTerm :: CBOR.Term -> Either Text NodeToClientVersionData
+      decodeTerm (CBOR.TInt x) | x >= 0 && x <= 0xffffffff = Right (NodeToClientVersionData $ NetworkMagic $ fromIntegral x)
+                               | otherwise                 = Left $ T.pack $ "networkMagic out of bound: " <> show x
+      decodeTerm t             = Left $ T.pack $ "unknown encoding: " ++ show t

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Ouroboros.Network.NodeToNode.Version
+  ( NodeToNodeVersion (..)
+  , NodeToNodeVersionData (..)
+  , nodeToNodeVersionCodec
+  , nodeToNodeCodecCBORTerm
+  ) where
+
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Data.Typeable (Typeable)
+
+import qualified Codec.CBOR.Term as CBOR
+
+import           Ouroboros.Network.CodecCBORTerm
+import           Ouroboros.Network.Magic
+import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..), Accept (..))
+
+
+-- | Enumeration of node to node protocol versions.
+--
+data NodeToNodeVersion = NodeToNodeV_1
+  deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
+
+nodeToNodeVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToNodeVersion
+nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
+  where
+    encodeTerm NodeToNodeV_1  = CBOR.TInt 1
+
+    decodeTerm (CBOR.TInt 1) = Right NodeToNodeV_1
+    decodeTerm (CBOR.TInt n) = Left ( T.pack "decode NodeToNodeVersion: unknonw tag: "
+                                        <> T.pack (show n)
+                                    , Just n
+                                    )
+    decodeTerm _ = Left ( T.pack "decode NodeToNodeVersion: unexpected term"
+                        , Nothing)
+
+
+-- | Version data for NodeToNode protocol v1
+--
+newtype NodeToNodeVersionData = NodeToNodeVersionData
+  { networkMagic :: NetworkMagic }
+  deriving (Eq, Show, Typeable)
+
+instance Acceptable NodeToNodeVersionData where
+    acceptableVersion local remote
+      | local == remote
+      = Accept
+      | otherwise
+      =  Refuse $ T.pack $ "version data mismatch: "
+                        ++ show local
+                        ++ " /= " ++ show remote
+
+nodeToNodeCodecCBORTerm :: CodecCBORTerm Text NodeToNodeVersionData
+nodeToNodeCodecCBORTerm = CodecCBORTerm {encodeTerm, decodeTerm}
+    where
+      encodeTerm :: NodeToNodeVersionData -> CBOR.Term
+      encodeTerm NodeToNodeVersionData { networkMagic } =
+        CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
+
+      decodeTerm :: CBOR.Term -> Either Text NodeToNodeVersionData
+      decodeTerm (CBOR.TInt x) | x >= 0 && x <= 0xffffffff = Right (NodeToNodeVersionData $ NetworkMagic $ fromIntegral x)
+                               | otherwise                 = Left $ T.pack $ "networkMagic out of bound: " <> show x
+      decodeTerm t             = Left $ T.pack $ "unknown encoding: " ++ show t

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Client.hs
@@ -5,6 +5,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes          #-}
 
+-- usage of `MsgKThxBye` is safe in this module.
+{-# OPTIONS_GHC -Wno-warnings-deprecations #-}
+
 
 -- | A view of the transaction submission protocol from the point of view of
 -- the client.

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Codec.hs
@@ -105,6 +105,10 @@ codecTxSubmission encodeTxId decodeTxId
      <> CBOR.encodeListLenIndef
      <> foldr (\txid r -> encodeTxId txid <> r) CBOR.encodeBreak txids
 
+    encode (ServerAgency TokIdle) MsgKThxBye =
+         CBOR.encodeListLen 1
+      <> CBOR.encodeWord 5
+
     encode (ClientAgency TokTxs)  (MsgReplyTxs txs) =
         CBOR.encodeListLen 2
      <> CBOR.encodeWord 3
@@ -157,6 +161,9 @@ codecTxSubmission encodeTxId decodeTxId
           CBOR.decodeListLenIndef
           txids <- CBOR.decodeSequenceLenIndef (flip (:)) [] reverse decodeTxId
           return (SomeMessage (MsgRequestTxs txids))
+
+        (ServerAgency TokIdle,       1, 5) ->
+          return (SomeMessage MsgKThxBye)
 
         (ClientAgency TokTxs,     2, 3) -> do
           CBOR.decodeListLenIndef

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Codec.hs
@@ -6,6 +6,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 
+-- usage of `MsgKThxBye` is safe in this module.
+{-# OPTIONS_GHC -Wno-warnings-deprecations #-}
+
 module Ouroboros.Network.Protocol.TxSubmission.Codec (
     codecTxSubmission
   , codecTxSubmissionId

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Server.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+-- usage of `MsgKThxBye` is safe in this module.
+{-# OPTIONS_GHC -Wno-warnings-deprecations #-}
+
 -- | A view of the transaction submission protocol from the point of view of
 -- the server.
 --

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Server.hs
@@ -88,6 +88,12 @@ data ServerStIdle (n :: N) txid tx m a where
     -> (Collect txid tx -> m (ServerStIdle    n  txid tx m a))
     ->                        ServerStIdle (S n) txid tx m a
 
+  -- | Terminate the protocol by sending 'MsgKThxBye'.
+  --
+  SendMsgKThxBye
+    :: a                                   -- ^ Result if done
+    -> ServerStIdle Z txid tx m a
+
 
 -- | Transform a 'TxSubmissionServerPipelined' into a 'PeerPipelined'.
 --
@@ -135,6 +141,12 @@ txSubmissionServerPeerPipelined (TxSubmissionServerPipelined server) =
            case msg of
              MsgReplyTxs txs -> ReceiverDone (CollectTxs txids txs))
         (SenderEffect (go <$> k))
+
+    go (SendMsgKThxBye kDone) =
+      SenderYield
+        (ServerAgency TokIdle)
+        MsgKThxBye
+        (SenderDone TokDone kDone)
 
     go (CollectPipelined mNone collect) =
       SenderCollect

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
@@ -199,6 +199,12 @@ instance Protocol (TxSubmission txid tx) where
       :: [tx]
       -> Message (TxSubmission txid tx) StTxs StIdle
 
+    -- Server side termination message. The name is inpired by
+    -- [LOLCODE](https://en.wikipedia.org/wiki/LOLCODE).
+    --
+    MsgKThxBye
+      :: Message (TxSubmission txid tx) StIdle StDone
+
     -- | Termination message, initiated by the client when the server is
     -- making a blocking call for more transaction identifiers.
     --

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
@@ -228,6 +228,8 @@ instance Protocol (TxSubmission txid tx) where
 
   exclusionLemma_NobodyAndServerHaveAgency TokDone tok = case tok of {}
 
+{-# WARNING MsgKThxBye "MsgKThxBye: should only be used with not yet introduced NodeToNodeV_2" #-}
+
 
 -- | The value level equivalent of 'StBlockingStyle'.
 --

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Inbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Inbound.hs
@@ -35,6 +35,7 @@ import           Control.Tracer (Tracer)
 
 import           Network.TypedProtocol.Pipelined (N, Nat (..))
 
+import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
 import           Ouroboros.Network.Protocol.TxSubmission.Server
 import           Ouroboros.Network.TxSubmission.Mempool.Reader
                      (MempoolSnapshot (..), TxSubmissionMempoolReader (..))
@@ -163,8 +164,9 @@ txSubmissionInbound
   -> Word16         -- ^ Maximum number of unacknowledged txids allowed
   -> TxSubmissionMempoolReader txid tx idx m
   -> TxSubmissionMempoolWriter txid tx idx m
+  -> NodeToNodeVersion
   -> TxSubmissionServerPipelined txid tx m ()
-txSubmissionInbound _tracer maxUnacked mpReader mpWriter =
+txSubmissionInbound _tracer maxUnacked mpReader mpWriter _version =
     TxSubmissionServerPipelined $
       continueWithStateM (serverIdle Zero) initialServerState
   where

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
@@ -26,6 +26,7 @@ import           Control.Monad.Class.MonadThrow
 import           Control.Exception (Exception(..), assert)
 import           Control.Tracer (Tracer, traceWith)
 
+import           Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
 import           Ouroboros.Network.Protocol.TxSubmission.Client
 import           Ouroboros.Network.TxSubmission.Mempool.Reader
                      (MempoolSnapshot (..), TxSubmissionMempoolReader (..))
@@ -79,8 +80,9 @@ txSubmissionOutbound
   => Tracer m (TraceTxSubmissionOutbound txid tx)
   -> Word16         -- ^ Maximum number of unacknowledged txids allowed
   -> TxSubmissionMempoolReader txid tx idx m
+  -> NodeToNodeVersion
   -> TxSubmissionClient txid tx m ()
-txSubmissionOutbound tracer maxUnacked TxSubmissionMempoolReader{..} =
+txSubmissionOutbound tracer maxUnacked TxSubmissionMempoolReader{..} _version =
     TxSubmissionClient (pure (client Seq.empty Map.empty mempoolZeroIdx))
   where
     client :: StrictSeq txid -> Map txid idx -> idx -> ClientStIdle txid tx m ()

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
@@ -74,19 +74,19 @@ instance Exception TxSubmissionProtocolError where
 
 
 txSubmissionOutbound
-  :: forall txid tx idx m void.
+  :: forall txid tx idx m.
      (Ord txid, Ord idx, MonadSTM m, MonadThrow m)
   => Tracer m (TraceTxSubmissionOutbound txid tx)
   -> Word16         -- ^ Maximum number of unacknowledged txids allowed
   -> TxSubmissionMempoolReader txid tx idx m
-  -> TxSubmissionClient txid tx m void
+  -> TxSubmissionClient txid tx m ()
 txSubmissionOutbound tracer maxUnacked TxSubmissionMempoolReader{..} =
     TxSubmissionClient (pure (client Seq.empty Map.empty mempoolZeroIdx))
   where
-    client :: StrictSeq txid -> Map txid idx -> idx -> ClientStIdle txid tx m void
+    client :: StrictSeq txid -> Map txid idx -> idx -> ClientStIdle txid tx m ()
     client !unackedSeq !unackedMap !lastIdx =
         assert invariant
-        ClientStIdle { recvMsgRequestTxIds, recvMsgRequestTxs }
+        ClientStIdle { recvMsgRequestTxIds, recvMsgRequestTxs, recvMsgKThxBye }
       where
         invariant =
           Map.isSubmapOfBy
@@ -98,7 +98,7 @@ txSubmissionOutbound tracer maxUnacked TxSubmissionMempoolReader{..} =
                                TokBlockingStyle blocking
                             -> Word16
                             -> Word16
-                            -> m (ClientStTxIds blocking txid tx m void)
+                            -> m (ClientStTxIds blocking txid tx m ())
         recvMsgRequestTxIds blocking ackNo reqNo = do
 
           when (ackNo > fromIntegral (Seq.length unackedSeq)) $
@@ -169,7 +169,7 @@ txSubmissionOutbound tracer maxUnacked TxSubmissionMempoolReader{..} =
 
 
         recvMsgRequestTxs :: [txid]
-                          -> m (ClientStTxs txid tx m void)
+                          -> m (ClientStTxs txid tx m ())
         recvMsgRequestTxs txids = do
           -- Trace the IDs of the transactions requested.
           traceWith tracer (TraceTxSubmissionOutboundRecvMsgRequestTxs txids)
@@ -193,3 +193,6 @@ txSubmissionOutbound tracer maxUnacked TxSubmissionMempoolReader{..} =
           traceWith tracer (TraceTxSubmissionOutboundSendMsgReplyTxs txs)
 
           return $ SendMsgReplyTxs txs client'
+
+        recvMsgKThxBye :: m ()
+        recvMsgKThxBye = pure ()

--- a/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
@@ -43,6 +43,7 @@ import           Network.TypedProtocol.Pipelined
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Driver
 import           Ouroboros.Network.DeltaQ
+import           Ouroboros.Network.NodeToNode (NodeToNodeVersion (..))
 import           Ouroboros.Network.Protocol.BlockFetch.Codec
 import           Ouroboros.Network.Protocol.BlockFetch.Server
 import           Ouroboros.Network.Protocol.BlockFetch.Type
@@ -89,7 +90,7 @@ blockFetchExample1 decisionTracer clientStateTracer clientMsgTracer
                         (contramap (TraceLabelPeer peerno) clientMsgTracer)
                         (contramap (TraceLabelPeer peerno) serverMsgTracer)
                         registry peerno
-                        blockFetchClient
+                        (blockFetchClient NodeToNodeV_1)
                         (mockBlockFetchServer1 (unanchorFragment candidateChain))
                     | (peerno, candidateChain) <- zip [1..] candidateChains
                     ]

--- a/ouroboros-network/test/messages.cddl
+++ b/ouroboros-network/test/messages.cddl
@@ -65,12 +65,14 @@ txSubmissionMessage
     / msgRequestTxs
     / msgReplyTxs
     / tsMsgDone
+    / msgReplyKTnxBye
 
 msgRequestTxIds = [0, tsBlocking, txCount, txCount]
 msgReplyTxIds   = [1, [ *txIdAndSize] ]
 msgRequestTxs   = [2, tsIdList ]
 msgReplyTxs     = [3, tsIdList ]
 tsMsgDone       = [4]
+msgReplyKTnxBye = [5]
 
 tsBlocking      = false / true
 txCount         = word16


### PR DESCRIPTION
This PR adds a new message which changes.  Usage of it is will cause a Warning,
as we need to add a new `NodeToNode` version once it will be used.  
This PR changes tx-submission codec, but since we don't expect any `MsgKTnxBye`
it should be ok (making the codec depend on `NodeToNodeVersion` is not
difficult though but I think it's not worth the effort).

I only changed `NodeToNode` parts in `ouroboros-consensus`, similar changes
should be done in `NodeToClient` protocols, but I decided to leave it for
later, as we don't need it at the moment.

- Consensus's Handlers in should depend on NodeToNodeVersion
- Make BlockFetch client depend on negotiated version
- Make TxSubmission inbound and outbound side depend on negotiated version
- Added a GHC warning to MsgKTnxBye
- Moved NodeToNodeVersion and NodeToClientVersion to their own modules
- Updated cddl specification
- Updated protocol-tests
- Added MsgTnxBy tx-submission
