### PR TITLE
Use correct KES construction

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -111,8 +111,8 @@ package small-steps
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: ae0bf700bed6a411dcf7f03a49f8c89e8344a7b9
-  --sha256: 0qy5sva142g4j4zbly8s89jb4pri8nhx7q3zbspgyrm8l7k4icc3
+  tag: 20309d5aa56b0ae5fd982465297a1d87aa5658a1
+  --sha256: 0j4k6faiy2isqfm12lmwz7szpdrkzxhfz6ljjkv5r2v41v0hnx6f
   subdir:   contra-tracer
 
 source-repository-package
@@ -131,71 +131,71 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: c845509c307af9df956ef203ac8ad67fe4d5d065
-  --sha256: 1ik5giyjinj5rq8yqxilw87n41c1zjrd83iihnfjnhpwwy86qza3
+  tag: 9d6e0f5efc8fe1bfff4825b3f52e80cdceac07b0
+  --sha256: 19hq5l9xdx1r5mv2aakazvf2xchdrlxdk6ywzdwwhv3g63ayfngn
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: c845509c307af9df956ef203ac8ad67fe4d5d065
-  --sha256: 1ik5giyjinj5rq8yqxilw87n41c1zjrd83iihnfjnhpwwy86qza3
+  tag: 9d6e0f5efc8fe1bfff4825b3f52e80cdceac07b0
+  --sha256: 19hq5l9xdx1r5mv2aakazvf2xchdrlxdk6ywzdwwhv3g63ayfngn
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: c845509c307af9df956ef203ac8ad67fe4d5d065
-  --sha256: 1ik5giyjinj5rq8yqxilw87n41c1zjrd83iihnfjnhpwwy86qza3
+  tag: 9d6e0f5efc8fe1bfff4825b3f52e80cdceac07b0
+  --sha256: 19hq5l9xdx1r5mv2aakazvf2xchdrlxdk6ywzdwwhv3g63ayfngn
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: c845509c307af9df956ef203ac8ad67fe4d5d065
-  --sha256: 1ik5giyjinj5rq8yqxilw87n41c1zjrd83iihnfjnhpwwy86qza3
+  tag: 9d6e0f5efc8fe1bfff4825b3f52e80cdceac07b0
+  --sha256: 19hq5l9xdx1r5mv2aakazvf2xchdrlxdk6ywzdwwhv3g63ayfngn
   subdir: slotting
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
-  --sha256: 0qva90k2alhznn88nkxp0ghphhnrynf2sl0n9jccc3q6hycdzxv8
+  tag: 25354e11ed43d59485c404f491a118efe0bd8e70
+  --sha256: 1hcmsc1pis5y9zdfw70jw5xy7y5ji16an82ppsl47r51s8h53lfk
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
-  --sha256: 0qva90k2alhznn88nkxp0ghphhnrynf2sl0n9jccc3q6hycdzxv8
+  tag: 25354e11ed43d59485c404f491a118efe0bd8e70
+  --sha256: 1hcmsc1pis5y9zdfw70jw5xy7y5ji16an82ppsl47r51s8h53lfk
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
-  --sha256: 0qva90k2alhznn88nkxp0ghphhnrynf2sl0n9jccc3q6hycdzxv8
+  tag: 25354e11ed43d59485c404f491a118efe0bd8e70
+  --sha256: 1hcmsc1pis5y9zdfw70jw5xy7y5ji16an82ppsl47r51s8h53lfk
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
-  --sha256: 0qva90k2alhznn88nkxp0ghphhnrynf2sl0n9jccc3q6hycdzxv8
+  tag: 25354e11ed43d59485c404f491a118efe0bd8e70
+  --sha256: 1hcmsc1pis5y9zdfw70jw5xy7y5ji16an82ppsl47r51s8h53lfk
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
-  --sha256: 0qva90k2alhznn88nkxp0ghphhnrynf2sl0n9jccc3q6hycdzxv8
+  tag: 25354e11ed43d59485c404f491a118efe0bd8e70
+  --sha256: 1hcmsc1pis5y9zdfw70jw5xy7y5ji16an82ppsl47r51s8h53lfk
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
-  --sha256: 0qva90k2alhznn88nkxp0ghphhnrynf2sl0n9jccc3q6hycdzxv8
+  tag: 25354e11ed43d59485c404f491a118efe0bd8e70
+  --sha256: 1hcmsc1pis5y9zdfw70jw5xy7y5ji16an82ppsl47r51s8h53lfk
   subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package

--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -48,6 +48,7 @@ library
                      , binary            >=0.8   && <0.9
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
+                     , cardano-crypto
                      , cardano-crypto-class
                      , cardano-crypto-wrapper
                      , cardano-ledger

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Genesis.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Genesis.hs
@@ -22,6 +22,7 @@ import           Ouroboros.Network.Magic (NetworkMagic)
 import           Ouroboros.Consensus.BlockchainTime (SlotLength, SystemStart)
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 
+import qualified Shelley.Spec.Ledger.Address as SL
 import           Shelley.Spec.Ledger.BaseTypes (ActiveSlotCoeff)
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.Coin as SL

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -81,7 +81,7 @@ shelleyHashInfo = HashInfo { hashSize, getHash, putHash }
   where
     hashSize :: Word32
     hashSize = fromIntegral $
-      Crypto.byteCount (Proxy :: Proxy (HASH c))
+      Crypto.sizeHash (Proxy :: Proxy (HASH c))
 
     getHash :: Get (ShelleyHash c)
     getHash = do

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -28,7 +28,6 @@ import           Data.Proxy (Proxy (..))
 import           Cardano.Binary (Annotator (..), FullByteString (..), fromCBOR,
                      toCBOR)
 import qualified Cardano.Crypto.Hash.Class as Crypto (Hash (..))
-import           Cardano.Crypto.KES.Class (SignKeyKES)
 import           Cardano.Slotting.EpochInfo
 import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..),
                      SlotNo (..), WithOrigin (Origin))
@@ -46,8 +45,10 @@ import           Ouroboros.Consensus.Node.State
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 
+import qualified Shelley.Spec.Ledger.Address as SL
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.BlockChain as SL
+import qualified Shelley.Spec.Ledger.Credential as SL
 import           Shelley.Spec.Ledger.Crypto (HASH)
 import qualified Shelley.Spec.Ledger.Delegation.Certificates as SL
 import qualified Shelley.Spec.Ledger.EpochBoundary as SL
@@ -66,7 +67,7 @@ import           Ouroboros.Consensus.Shelley.Ledger
 import qualified Ouroboros.Consensus.Shelley.Ledger.History as History
 import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
 import           Ouroboros.Consensus.Shelley.Protocol
-import           Ouroboros.Consensus.Shelley.Protocol.Crypto (KES)
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto (HotKey)
 import qualified Ouroboros.Consensus.Shelley.Protocol.State as State
 
 {-------------------------------------------------------------------------------
@@ -77,7 +78,7 @@ data TPraosLeaderCredentials c = TPraosLeaderCredentials {
     -- | Signing KES key. Note that this is not inside 'TPraosIsCoreNode' since
     --   it gets evolved automatically, whereas 'TPraosIsCoreNode' does not
     --   change.
-    tpraosLeaderCredentialsSignKey    :: SignKeyKES (KES c)
+    tpraosLeaderCredentialsSignKey    :: HotKey c
   , tpraosLeaderCredentialsIsCoreNode :: TPraosIsCoreNode c
   }
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns         #-}
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveAnyClass       #-}
 {-# LANGUAGE DeriveGeneric        #-}
@@ -132,8 +133,8 @@ type TPraosValidateView c = SL.BHeader c
 -------------------------------------------------------------------------------}
 
 data TPraosNodeState c =
-    -- | The online KES key used to sign blocks is available
-    TPraosKeyAvailable !(SignKeyKES (KES c))
+    -- | The online KES key used to sign blocks is available at the given period
+    TPraosKeyAvailable !(HotKey c)
 
     -- | The KES key is being evolved by another thread
     --
@@ -163,18 +164,15 @@ forgeTPraosFields :: ( MonadRandom m
 forgeTPraosFields updateNodeState TPraosProof{..} kesPeriod mkToSign = do
     hotKESKey   <- evolveKESKeyIfNecessary updateNodeState kesPeriod
     let
-      mbSignature = signedKES
+      signature = signedKES
         ()
         kesPeriodNat
         (mkToSign signedFields)
         hotKESKey
-    case mbSignature of
-      Nothing        -> error "signedKES failed"
-      Just signature ->
-        return TPraosFields {
-            tpraosSignature = signature
-          , tpraosToSign    = mkToSign signedFields
-          }
+    return TPraosFields {
+        tpraosSignature = signature
+      , tpraosToSign    = mkToSign signedFields
+      }
   where
     SL.KESPeriod kesPeriodNat = kesPeriod
 
@@ -201,39 +199,45 @@ evolveKESKeyIfNecessary updateNodeState (SL.KESPeriod kesPeriod) = do
     getOudatedKeyOrCurrentKey >>= \case
       Right currentKey -> return currentKey
       Left outdatedKey -> do
-        newKey <- evolveKey outdatedKey
+        let newKey@(HotKey _ key) = evolveKey outdatedKey
         saveNewKey newKey
-        return newKey
+        return key
   where
-    -- | Return either (@Left@) an outdated key (setting the node state to
-    -- 'TPraosKeyEvolving') or (@Right@) a key that's up-to-date w.r.t. the
-    -- current KES period (leaving the node state to 'TPraosKeyAvailable').
+    -- | Return either (@Left@) an outdated key with its current period (setting
+    -- the node state to 'TPraosKeyEvolving') or (@Right@) a key that's
+    -- up-to-date w.r.t. the current KES period (leaving the node state to
+    -- 'TPraosKeyAvailable').
     getOudatedKeyOrCurrentKey
-      :: m (Either (SignKeyKES (KES c)) (SignKeyKES (KES c)))
+      :: m (Either (HotKey c) (SignKeyKES (KES c)))
     getOudatedKeyOrCurrentKey = NodeState.runUpdate updateNodeState $ \case
       TPraosKeyEvolving ->
         -- Another thread is currently evolving the key; wait
         Nothing
-      TPraosKeyAvailable key
-        | let kesPeriodOfKey = KES.currentPeriodKES () key
-        , kesPeriodOfKey < kesPeriod
+      TPraosKeyAvailable hk@(HotKey kesPeriodOfKey key)
+        | kesPeriodOfKey < kesPeriod
           -- Must evolve key
-        -> return (TPraosKeyEvolving, Left key)
+        -> return (TPraosKeyEvolving, Left hk)
         | otherwise
-        -> return (TPraosKeyAvailable key, Right key)
+        -> return (TPraosKeyAvailable hk, Right key)
       TPraosNoKey ->
         error "no KES key available"
 
     -- | Evolve the given key so that its KES period matches @kesPeriod@.
-    evolveKey :: SignKeyKES (KES c) -> m (SignKeyKES (KES c))
-    evolveKey outdatedKey =
-      case KES.updateKES () outdatedKey kesPeriod of
-        -- TODO
-        Nothing         -> error "Could not update KES key"
-        Just evolvedKey -> return evolvedKey
+    evolveKey :: HotKey c -> HotKey c
+    evolveKey (HotKey oldPeriod outdatedKey) = go outdatedKey oldPeriod kesPeriod
+      where
+        go !sk c t
+          | t < c
+          = error "Asked to evolve KES key to old period"
+          | c == t
+          = HotKey kesPeriod sk
+          | otherwise
+          = case KES.updateKES () sk c of
+              Nothing  -> error "Could not update KES key"
+              Just sk' -> go sk' (c + 1) t
 
     -- | PRECONDITION: we're in the 'TPraosKeyEvolving' node state.
-    saveNewKey :: SignKeyKES (KES c) -> m ()
+    saveNewKey :: HotKey c -> m ()
     saveNewKey newKey = NodeState.runUpdate updateNodeState $ \case
       TPraosKeyEvolving -> Just (TPraosKeyAvailable newKey, ())
       _                 -> error "must be in evolving state"
@@ -408,9 +412,8 @@ mkShelleyGlobals :: TPraosParams -> SL.Globals
 mkShelleyGlobals TPraosParams {..} = SL.Globals {
       epochInfo         = tpraosEpochInfo
     , slotsPerKESPeriod = tpraosSlotsPerKESPeriod
-      -- TODO where does 3 * k come from?
-    , slotsPrior        = 3 * k
-    , startRewards      = 3 * k
+    , stabilityWindow   = ceiling $ 3 * (toRational f / fromIntegral k)
+    , randomnessStabilisationWindow = ceiling $ 4 * (toRational f / fromIntegral k)
     , securityParameter = k
     , maxKESEvo         = tpraosMaxKESEvo
     , quorum            = tpraosQuorum
@@ -420,6 +423,7 @@ mkShelleyGlobals TPraosParams {..} = SL.Globals {
     }
   where
     SecurityParam k = tpraosSecurityParam
+    f = SL.intervalValue . SL.activeSlotVal $ tpraosLeaderF
 
 -- | Check whether this node meets the leader threshold to issue a block.
 meetsLeaderThreshold

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds               #-}
+{-# LANGUAGE DeriveGeneric           #-}
 {-# LANGUAGE FlexibleContexts        #-}
 {-# LANGUAGE FlexibleInstances       #-}
 {-# LANGUAGE TypeFamilies            #-}
@@ -6,28 +7,32 @@
 {-# LANGUAGE UndecidableSuperClasses #-}
 module Ouroboros.Consensus.Shelley.Protocol.Crypto (
     module Shelley.Spec.Ledger.Crypto
+  , HotKey(..)
   , TPraosCrypto
   , TPraosStandardCrypto
   ) where
 
 import           Data.Typeable (Typeable)
+import           GHC.Generics (Generic)
 import           Numeric.Natural
 
 import           Cardano.Binary (ToCBOR)
 import qualified Cardano.Crypto.DSIGN.Class as DSIGN
 import           Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
 import           Cardano.Crypto.Hash.Blake2b (Blake2b_256)
+import           Cardano.Crypto.Hash.Class (Hash)
 import           Cardano.Crypto.KES.Class
 import qualified Cardano.Crypto.KES.Class as KES
-import           Cardano.Crypto.KES.Simple
+import           Cardano.Crypto.KES.Sum
 import qualified Cardano.Crypto.VRF.Class as VRF
 import           Cardano.Crypto.VRF.Simple (SimpleVRF)
+import           Cardano.Prelude (NoUnexpectedThunks (..))
 
 import           Ouroboros.Consensus.Util.Condense (Condense)
 
 import           Shelley.Spec.Ledger.BaseTypes (Seed)
 import           Shelley.Spec.Ledger.BlockChain (BHBody)
-import           Shelley.Spec.Ledger.Crypto (Crypto (..))
+import           Shelley.Spec.Ledger.Crypto (Crypto (..), Network (..))
 import           Shelley.Spec.Ledger.OCert (KESPeriod)
 import           Shelley.Spec.Ledger.TxData (TxBody)
 
@@ -39,7 +44,7 @@ class ( Crypto c
           (VerKeyKES (KES c), Natural, KESPeriod)
       , DSIGN.Signable
           (DSIGN c)
-          (TxBody c)
+          (Hash (HASH c) (TxBody c))
       , KES.Signable
           (KES c)
           (BHBody c)
@@ -51,8 +56,19 @@ data TPraosStandardCrypto
 
 instance Crypto TPraosStandardCrypto where
   type DSIGN TPraosStandardCrypto = Ed25519DSIGN
-  type KES   TPraosStandardCrypto = SimpleKES Ed25519DSIGN 14 -- TODO: replace with the Sum6KES or Sum7KES
+  type KES   TPraosStandardCrypto = Sum7KES Ed25519DSIGN Blake2b_256
   type VRF   TPraosStandardCrypto = SimpleVRF
   type HASH  TPraosStandardCrypto = Blake2b_256
 
+  -- TODO This is somewhat annoying, since we want it to be based upon a runtime
+  -- value.
+  networkMagicId = const Testnet
+
 instance TPraosCrypto TPraosStandardCrypto
+
+-- | A hot KES key. We store alongside the key the KES period for which it is
+-- valid.
+data HotKey c = HotKey !Period !(SignKeyKES (KES c))
+  deriving Generic
+
+instance TPraosCrypto c => NoUnexpectedThunks (HotKey c)

--- a/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger.hs
+++ b/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger.hs
@@ -43,6 +43,7 @@ import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.BlockChain as SL
 import qualified Shelley.Spec.Ledger.Coin as SL
+import qualified Shelley.Spec.Ledger.Credential as SL
 import qualified Shelley.Spec.Ledger.Delegation.Certificates as SL
 import qualified Shelley.Spec.Ledger.EpochBoundary as SL
 import qualified Shelley.Spec.Ledger.Keys as SL

--- a/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
+++ b/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
@@ -33,6 +33,7 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.BlockChain as SL
+import qualified Shelley.Spec.Ledger.Credential as SL
 import qualified Shelley.Spec.Ledger.Crypto as SL
 import qualified Shelley.Spec.Ledger.Delegation.Certificates as SL
 import qualified Shelley.Spec.Ledger.Keys as SL
@@ -40,7 +41,6 @@ import qualified Shelley.Spec.Ledger.PParams as SL
 import qualified Shelley.Spec.Ledger.STS.Chain as STS
 import qualified Shelley.Spec.Ledger.STS.Ledger as STS
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS
-import qualified Shelley.Spec.Ledger.TxData as SL
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ConcreteCrypto,
                      hashKeyVRF)
 import qualified Test.Shelley.Spec.Ledger.Examples.Examples as Examples
@@ -115,7 +115,7 @@ testQueries = testGroup "Queries"
       , TkListLen 1
       , TkListLen 2
       , TkInt 0
-      , TkBytes "\147\184\133\173"
+      , TkBytes "}\234\&6+"
       ]
 
     currentPParamsTerm =
@@ -247,7 +247,7 @@ testResults = testGroup "Results"
     proposedPParamsUpdatesTerm :: FlatTerm
     proposedPParamsUpdatesTerm =
       [ TkMapLen 1
-      , TkBytes "\147\184\133\173"
+      , TkBytes "}\234\&6+"
       , TkMapLen 1
       , TkInt 5
       , TkInt 100
@@ -256,12 +256,12 @@ testResults = testGroup "Results"
     stakeDistributionTerm :: FlatTerm
     stakeDistributionTerm =
       [ TkMapLen 1
-      , TkBytes "\147\184\133\173"
+      , TkBytes "\247\223\&4\142"
       , TkListLen 2
       , TkListLen 2
       , TkInt 1
       , TkInt 1
-      , TkBytes "\147\184\133\173"
+      , TkBytes "}\234\&6+"
       ]
 
     goldenTestResult :: Query Block result -> result -> FlatTerm -> Assertion
@@ -282,48 +282,35 @@ test_golden_Block = goldenTestCBOR
     , TkListLen 15
     , TkInt 2
     , TkInt 20
-    , TkBytes "\SO\212F\170"
-    , TkInt 3546075839721582641
-    , TkInt 3546075839721582641
+    , TkBytes "\191|nI"
+    , TkBytes "16260160"
+    , TkBytes "16260160"
     , TkListLen 2
     , TkInt 2
-    , TkListLen 2
-    , TkInt 3546075839721582641
-    , TkInteger 155720561651862627124907358847946323278
+    , TkBytes "16260160\245N"
     , TkListLen 2
     , TkInt 0
-    , TkListLen 2
-    , TkInt 3546075839721582641
-    , TkInteger 132220243341478360044794887852609007894
-    , TkInt 216
-    , TkBytes "\141\&6\253\&0"
-    , TkInt 3546075839721582641
+    , TkBytes "16260160q\SYN"
+    , TkInt 208
+    , TkBytes "\211W9O"
+    , TkBytes "16260160"
     , TkInt 0
     , TkInt 0
-    , TkListLen 2
-    , TkBytes "\198\FS[\226"
-    , TkInt 3546075839721582641
+    , TkBytes "\ETX\148G\SO16260160"
     , TkInt 0
     , TkInt 0
-    , TkListLen 2
-    , TkInteger 170325556512963171230836426693446393414
-    , TkListLen 2
-    , TkInt 3546075839721582641
-    , TkInt 1
+    , TkBytes "fh\ACK\135o\180w\134\DC3.\146pK\223\129\193\&16260160\NUL\NUL\NUL\NUL\NUL\NUL\NUL\SOH"
     , TkListLen 1
     , TkMapLen 5
     , TkInt 0
-    , TkListBegin
+    , TkListLen 1
     , TkListLen 2
-    , TkBytes "F\248m\RS"
+    , TkBytes "-/\249\&7"
     , TkInt 0
-    , TkBreak
     , TkInt 1
     , TkListLen 1
-    , TkListLen 4
-    , TkInt 0
-    , TkBytes "\174\232Lp"
-    , TkBytes "\212.\173\177"
+    , TkListLen 2
+    , TkBytes "\STX\EOT\140\196$0P\247\158"
     , TkInt 9999999999999998
     , TkInt 2
     , TkInt 1
@@ -332,7 +319,7 @@ test_golden_Block = goldenTestCBOR
     , TkInt 6
     , TkListLen 2
     , TkMapLen 2
-    , TkBytes "\133\130\191\198"
+    , TkBytes "u\197c\227"
     , TkMapLen 2
     , TkInt 8
     , TkInt 200
@@ -340,7 +327,7 @@ test_golden_Block = goldenTestCBOR
     , TkListLen 2
     , TkInt 1
     , TkBytes "e\138\176\224\245\253\239\216h\168\232\ENQ\209\SOH\169\140\195Z\181\ETB\233}\243\147q\130\218\fz\243\139="
-    , TkBytes "\244\249\211j"
+    , TkBytes "\229\221D\172"
     , TkMapLen 2
     , TkInt 8
     , TkInt 200
@@ -354,20 +341,14 @@ test_golden_Block = goldenTestCBOR
     , TkInt 0
     , TkListLen 3
     , TkListLen 2
-    , TkInt 3545801000469477428
+    , TkBytes "00000214"
+    , TkBytes "6\139\GS\DC200000214"
     , TkListLen 2
-    , TkBytes "7F\155\210"
-    , TkInt 3545801000469477428
+    , TkBytes "16415019"
+    , TkBytes "6\139\GS\DC216415019"
     , TkListLen 2
-    , TkInt 3472328296227811636
-    , TkListLen 2
-    , TkBytes "7F\155\210"
-    , TkInt 3472328296227811636
-    , TkListLen 2
-    , TkInt 3546079142551236921
-    , TkListLen 2
-    , TkBytes "7F\155\210"
-    , TkInt 3546079142551236921
+    , TkBytes "15795584"
+    , TkBytes "6\139\GS\DC215795584"
     , TkMapLen 0
     ]
 
@@ -379,41 +360,31 @@ test_golden_Header = goldenTestCBOR
     , TkListLen 15
     , TkInt 2
     , TkInt 20
-    , TkBytes "\SO\212F\170"
-    , TkInt 3546075839721582641
-    , TkInt 3546075839721582641
+    , TkBytes "\191|nI"
+    , TkBytes "16260160"
+    , TkBytes "16260160"
     , TkListLen 2
     , TkInt 2
-    , TkListLen 2
-    , TkInt 3546075839721582641
-    , TkInteger 155720561651862627124907358847946323278
+    , TkBytes "16260160\245N"
     , TkListLen 2
     , TkInt 0
-    , TkListLen 2
-    , TkInt 3546075839721582641
-    , TkInteger 132220243341478360044794887852609007894
-    , TkInt 216
-    , TkBytes "\141\&6\253\&0"
-    , TkInt 3546075839721582641
+    , TkBytes "16260160q\SYN"
+    , TkInt 208
+    , TkBytes "\211W9O"
+    , TkBytes "16260160"
     , TkInt 0
     , TkInt 0
-    , TkListLen 2
-    , TkBytes "\198\FS[\226"
-    , TkInt 3546075839721582641
+    , TkBytes "\ETX\148G\SO16260160"
     , TkInt 0
     , TkInt 0
-    , TkListLen 2
-    , TkInteger 170325556512963171230836426693446393414
-    , TkListLen 2
-    , TkInt 3546075839721582641
-    , TkInt 1
+    , TkBytes "fh\ACK\135o\180w\134\DC3.\146pK\223\129\193\&16260160\NUL\NUL\NUL\NUL\NUL\NUL\NUL\SOH"
     ]
 
 test_golden_HeaderHash :: Assertion
 test_golden_HeaderHash = goldenTestCBOR
     toCBOR
     (blockHash exampleBlock)
-    [ TkBytes "\237\239U\235"
+    [ TkBytes "=87\168"
     ]
 
 test_golden_GenTx :: Assertion
@@ -423,17 +394,14 @@ test_golden_GenTx = goldenTestCBORInCBOR
     [ TkListLen 3
     , TkMapLen 6
     , TkInt 0
-    , TkListBegin
+    , TkListLen 1
     , TkListLen 2
-    , TkBytes "`P\aC"
+    , TkBytes "\157\184\164\ETB"
     , TkInt 0
-    , TkBreak
     , TkInt 1
     , TkListLen 1
-    , TkListLen 4
-    , TkInt 0
-    , TkBytes "\174\232Lp"
-    , TkBytes "\212.\173\177"
+    , TkListLen 2
+    , TkBytes "\STX\EOT\140\196$0P\247\158"
     , TkInt 9999999999999726
     , TkInt 2
     , TkInt 3
@@ -445,21 +413,21 @@ test_golden_GenTx = goldenTestCBORInCBOR
     , TkInt 0
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkListLen 2
     , TkInt 0
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\ENQ\214\186\134"
+    , TkBytes "\191\152\145\198"
     , TkListLen 2
     , TkInt 0
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\228 \204\167"
+    , TkBytes "\ACK7\193<"
     , TkListLen 10
     , TkInt 3
-    , TkBytes "\212.\173\177"
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
+    , TkBytes "0P\247\158"
     , TkInt 1
     , TkInt 5
     , TkTag 30
@@ -468,9 +436,9 @@ test_golden_GenTx = goldenTestCBORInCBOR
     , TkInt 10
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkListLen 1
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkListLen 0
     , TkListLen 2
     , TkString "alice.pool"
@@ -480,16 +448,16 @@ test_golden_GenTx = goldenTestCBORInCBOR
     , TkMapLen 2
     , TkListLen 2
     , TkInt 0
-    , TkBytes "oY\252#"
-    , TkInt 99
+    , TkBytes "\ACK7\193<"
+    , TkInt 110
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\228 \204\167"
-    , TkInt 110
+    , TkBytes "\144&R("
+    , TkInt 99
     , TkInt 6
     , TkListLen 2
     , TkMapLen 1
-    , TkBytes "\224\253Xv"
+    , TkBytes "Rsb\139"
     , TkMapLen 1
     , TkInt 5
     , TkInt 255
@@ -498,45 +466,29 @@ test_golden_GenTx = goldenTestCBORInCBOR
     , TkInt 0
     , TkListLen 8
     , TkListLen 2
-    , TkInt 3545803182228911155
+    , TkBytes "00000214"
+    , TkBytes "9\235\242\239\&00000214"
     , TkListLen 2
-    , TkBytes "\203\250K\GS"
-    , TkInt 3545803182228911155
+    , TkBytes "15485867"
+    , TkBytes "9\235\242\239\&15485867"
     , TkListLen 2
-    , TkInt 3904965248267073080
+    , TkBytes "15640725"
+    , TkBytes "9\235\242\239\&15640725"
     , TkListLen 2
-    , TkBytes "\203\250K\GS"
-    , TkInt 3904965248267073080
+    , TkBytes "16260160"
+    , TkBytes "9\235\242\239\&16260160"
     , TkListLen 2
-    , TkInt 3545801000469477428
+    , TkBytes "61943468"
+    , TkBytes "9\235\242\239\&61943468"
     , TkListLen 2
-    , TkBytes "\203\250K\GS"
-    , TkInt 3545801000469477428
+    , TkBytes "15950443"
+    , TkBytes "9\235\242\239\&15950443"
     , TkListLen 2
-    , TkInt 3546076964918998576
+    , TkBytes "16105301"
+    , TkBytes "9\235\242\239\&16105301"
     , TkListLen 2
-    , TkBytes "\203\250K\GS"
-    , TkInt 3546076964918998576
-    , TkListLen 2
-    , TkInt 3472328296227811636
-    , TkListLen 2
-    , TkBytes "\203\250K\GS"
-    , TkInt 3472328296227811636
-    , TkListLen 2
-    , TkInt 3546075839721582641
-    , TkListLen 2
-    , TkBytes "\203\250K\GS"
-    , TkInt 3546075839721582641
-    , TkListLen 2
-    , TkInt 3545797697639822903
-    , TkListLen 2
-    , TkBytes "\203\250K\GS"
-    , TkInt 3545797697639822903
-    , TkListLen 2
-    , TkInt 3545799879399256629
-    , TkListLen 2
-    , TkBytes "\203\250K\GS"
-    , TkInt 3545799879399256629
+    , TkBytes "15795584"
+    , TkBytes "9\235\242\239\&15795584"
     , TkNull
     ]
 
@@ -544,8 +496,7 @@ test_golden_GenTxId :: Assertion
 test_golden_GenTxId = goldenTestCBOR
     toCBOR
     (txId exampleGenTx)
-    [ TkBytes "\203\250K\GS"
-    ]
+    [ TkBytes "\253d\142\221" ]
 
 test_golden_ApplyTxErr :: Assertion
 test_golden_ApplyTxErr = goldenTestCBOR
@@ -662,7 +613,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkListLen 3
     , TkListLen 2
     , TkInt 10
-    , TkBytes "\178\131\GS)"
+    , TkBytes "*d\157H"
     , TkListLen 2
     , TkListLen 1
     , TkInt 0
@@ -693,25 +644,21 @@ test_golden_LedgerState = goldenTestCBOR
     , TkListLen 4
     , TkMapLen 2
     , TkListLen 2
-    , TkBytes "`P\aC"
+    , TkBytes "\157\184\164\ETB"
     , TkInt 1
-    , TkListLen 4
-    , TkInt 0
-    , TkBytes "\174\SOH\SO\ENQ"
-    , TkBytes "\ENQ\214\186\134"
+    , TkListLen 2
+    , TkBytes "\STX\131?\NAK\145\191\152\145\198"
     , TkInt 1000000000000000
     , TkListLen 2
-    , TkBytes "\203\250K\GS"
+    , TkBytes "\253d\142\221"
     , TkInt 0
-    , TkListLen 4
-    , TkInt 0
-    , TkBytes "\174\232Lp"
-    , TkBytes "\212.\173\177"
+    , TkListLen 2
+    , TkBytes "\STX\EOT\140\196$0P\247\158"
     , TkInt 9999999999999726
     , TkInt 271
     , TkInt 3
     , TkMapLen 1
-    , TkBytes "\224\253Xv"
+    , TkBytes "Rsb\139"
     , TkMapLen 1
     , TkInt 5
     , TkInt 255
@@ -720,28 +667,28 @@ test_golden_LedgerState = goldenTestCBOR
     , TkMapLen 3
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\ENQ\214\186\134"
+    , TkBytes "\ACK7\193<"
     , TkInt 10
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkInt 10
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\228 \204\167"
+    , TkBytes "\191\152\145\198"
     , TkInt 10
     , TkMapLen 3
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\ENQ\214\186\134"
+    , TkBytes "\ACK7\193<"
     , TkInt 0
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkInt 0
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\228 \204\167"
+    , TkBytes "\191\152\145\198"
     , TkInt 0
     , TkMapLen 0
     , TkMapLen 3
@@ -751,55 +698,55 @@ test_golden_LedgerState = goldenTestCBOR
     , TkInt 0
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkListLen 3
     , TkInt 10
     , TkInt 0
     , TkInt 1
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\ENQ\214\186\134"
+    , TkBytes "\191\152\145\198"
     , TkListLen 3
     , TkInt 10
     , TkInt 0
     , TkInt 2
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\228 \204\167"
+    , TkBytes "\ACK7\193<"
     , TkMapLen 0
     , TkMapLen 7
-    , TkBytes "\b\CAN\169\214"
-    , TkBytes "\b\CAN\169\214"
-    , TkBytes "\133\130\191\198"
-    , TkBytes "\133\130\191\198"
-    , TkBytes "\152~8\208"
-    , TkBytes "\152~8\208"
-    , TkBytes "\183\147@\177"
-    , TkBytes "\183\147@\177"
-    , TkBytes "\189\240`\183"
-    , TkBytes "\189\240`\183"
-    , TkBytes "\224\253Xv"
-    , TkBytes "\224\253Xv"
-    , TkBytes "\244\249\211j"
-    , TkBytes "\244\249\211j"
+    , TkBytes "\CANg\231\ACK"
+    , TkBytes "\CANg\231\ACK"
+    , TkBytes "Rsb\139"
+    , TkBytes "Rsb\139"
+    , TkBytes "u\197c\227"
+    , TkBytes "u\197c\227"
+    , TkBytes "u\200\129\164"
+    , TkBytes "u\200\129\164"
+    , TkBytes "\174\134\&0\129"
+    , TkBytes "\174\134\&0\129"
+    , TkBytes "\203\GS\151\&8"
+    , TkBytes "\203\GS\151\&8"
+    , TkBytes "\229\221D\172"
+    , TkBytes "\229\221D\172"
     , TkMapLen 2
     , TkListLen 2
     , TkInt 0
-    , TkBytes "oY\252#"
-    , TkInt 99
+    , TkBytes "\ACK7\193<"
+    , TkInt 110
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\228 \204\167"
-    , TkInt 110
+    , TkBytes "\144&R("
+    , TkInt 99
     , TkListLen 3
     , TkMapLen 1
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkInt 10
     , TkMapLen 1
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkListLen 9
-    , TkBytes "\212.\173\177"
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
+    , TkBytes "0P\247\158"
     , TkInt 1
     , TkInt 5
     , TkTag 30
@@ -808,9 +755,9 @@ test_golden_LedgerState = goldenTestCBOR
     , TkInt 10
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkListLen 1
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkListLen 0
     , TkListLen 2
     , TkString "alice.pool"
@@ -918,7 +865,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkListLen 0
     , TkMapLen 0
     , TkMapLen 7
-    , TkBytes "\b\CAN\169\214"
+    , TkBytes "\CANg\231\ACK"
     , TkListBegin
     , TkInt 0
     , TkInt 14
@@ -929,7 +876,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkInt 84
     , TkInt 98
     , TkBreak
-    , TkBytes "\133\130\191\198"
+    , TkBytes "Rsb\139"
     , TkListBegin
     , TkInt 2
     , TkInt 16
@@ -939,7 +886,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkInt 72
     , TkInt 86
     , TkBreak
-    , TkBytes "\152~8\208"
+    , TkBytes "u\197c\227"
     , TkListBegin
     , TkInt 4
     , TkInt 18
@@ -949,7 +896,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkInt 74
     , TkInt 88
     , TkBreak
-    , TkBytes "\183\147@\177"
+    , TkBytes "u\200\129\164"
     , TkListBegin
     , TkInt 6
     , TkInt 20
@@ -959,7 +906,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkInt 76
     , TkInt 90
     , TkBreak
-    , TkBytes "\189\240`\183"
+    , TkBytes "\174\134\&0\129"
     , TkListBegin
     , TkInt 8
     , TkInt 22
@@ -969,7 +916,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkInt 78
     , TkInt 92
     , TkBreak
-    , TkBytes "\224\253Xv"
+    , TkBytes "\203\GS\151\&8"
     , TkListBegin
     , TkInt 10
     , TkInt 24
@@ -979,7 +926,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkInt 80
     , TkInt 94
     , TkBreak
-    , TkBytes "\244\249\211j"
+    , TkBytes "\229\221D\172"
     , TkListBegin
     , TkInt 12
     , TkInt 26
@@ -1078,7 +1025,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkListLen 3
     , TkListLen 2
     , TkInt 10
-    , TkBytes "\178\131\GS)"
+    , TkBytes "*d\157H"
     , TkListLen 2
     , TkListLen 1
     , TkInt 0
@@ -1109,25 +1056,21 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkListLen 4
     , TkMapLen 2
     , TkListLen 2
-    , TkBytes "`P\aC"
+    , TkBytes "\157\184\164\ETB"
     , TkInt 1
-    , TkListLen 4
-    , TkInt 0
-    , TkBytes "\174\SOH\SO\ENQ"
-    , TkBytes "\ENQ\214\186\134"
+    , TkListLen 2
+    , TkBytes "\STX\131?\NAK\145\191\152\145\198"
     , TkInt 1000000000000000
     , TkListLen 2
-    , TkBytes "\203\250K\GS"
+    , TkBytes "\253d\142\221"
     , TkInt 0
-    , TkListLen 4
-    , TkInt 0
-    , TkBytes "\174\232Lp"
-    , TkBytes "\212.\173\177"
+    , TkListLen 2
+    , TkBytes "\STX\EOT\140\196$0P\247\158"
     , TkInt 9999999999999726
     , TkInt 271
     , TkInt 3
     , TkMapLen 1
-    , TkBytes "\224\253Xv"
+    , TkBytes "Rsb\139"
     , TkMapLen 1
     , TkInt 5
     , TkInt 255
@@ -1136,28 +1079,28 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkMapLen 3
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\ENQ\214\186\134"
+    , TkBytes "\ACK7\193<"
     , TkInt 10
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkInt 10
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\228 \204\167"
+    , TkBytes "\191\152\145\198"
     , TkInt 10
     , TkMapLen 3
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\ENQ\214\186\134"
+    , TkBytes "\ACK7\193<"
     , TkInt 0
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkInt 0
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\228 \204\167"
+    , TkBytes "\191\152\145\198"
     , TkInt 0
     , TkMapLen 0
     , TkMapLen 3
@@ -1167,55 +1110,55 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkInt 0
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkListLen 3
     , TkInt 10
     , TkInt 0
     , TkInt 1
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\ENQ\214\186\134"
+    , TkBytes "\191\152\145\198"
     , TkListLen 3
     , TkInt 10
     , TkInt 0
     , TkInt 2
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\228 \204\167"
+    , TkBytes "\ACK7\193<"
     , TkMapLen 0
     , TkMapLen 7
-    , TkBytes "\b\CAN\169\214"
-    , TkBytes "\b\CAN\169\214"
-    , TkBytes "\133\130\191\198"
-    , TkBytes "\133\130\191\198"
-    , TkBytes "\152~8\208"
-    , TkBytes "\152~8\208"
-    , TkBytes "\183\147@\177"
-    , TkBytes "\183\147@\177"
-    , TkBytes "\189\240`\183"
-    , TkBytes "\189\240`\183"
-    , TkBytes "\224\253Xv"
-    , TkBytes "\224\253Xv"
-    , TkBytes "\244\249\211j"
-    , TkBytes "\244\249\211j"
+    , TkBytes "\CANg\231\ACK"
+    , TkBytes "\CANg\231\ACK"
+    , TkBytes "Rsb\139"
+    , TkBytes "Rsb\139"
+    , TkBytes "u\197c\227"
+    , TkBytes "u\197c\227"
+    , TkBytes "u\200\129\164"
+    , TkBytes "u\200\129\164"
+    , TkBytes "\174\134\&0\129"
+    , TkBytes "\174\134\&0\129"
+    , TkBytes "\203\GS\151\&8"
+    , TkBytes "\203\GS\151\&8"
+    , TkBytes "\229\221D\172"
+    , TkBytes "\229\221D\172"
     , TkMapLen 2
     , TkListLen 2
     , TkInt 0
-    , TkBytes "oY\252#"
-    , TkInt 99
+    , TkBytes "\ACK7\193<"
+    , TkInt 110
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\228 \204\167"
-    , TkInt 110
+    , TkBytes "\144&R("
+    , TkInt 99
     , TkListLen 3
     , TkMapLen 1
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkInt 10
     , TkMapLen 1
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkListLen 9
-    , TkBytes "\212.\173\177"
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
+    , TkBytes "0P\247\158"
     , TkInt 1
     , TkInt 5
     , TkTag 30
@@ -1224,9 +1167,9 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkInt 10
     , TkListLen 2
     , TkInt 0
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkListLen 1
-    , TkBytes "\212.\173\177"
+    , TkBytes "0P\247\158"
     , TkListLen 0
     , TkListLen 2
     , TkString "alice.pool"
@@ -1334,7 +1277,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkListLen 0
     , TkMapLen 0
     , TkMapLen 7
-    , TkBytes "\b\CAN\169\214"
+    , TkBytes "\CANg\231\ACK"
     , TkListBegin
     , TkInt 0
     , TkInt 14
@@ -1345,7 +1288,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkInt 84
     , TkInt 98
     , TkBreak
-    , TkBytes "\133\130\191\198"
+    , TkBytes "Rsb\139"
     , TkListBegin
     , TkInt 2
     , TkInt 16
@@ -1355,7 +1298,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkInt 72
     , TkInt 86
     , TkBreak
-    , TkBytes "\152~8\208"
+    , TkBytes "u\197c\227"
     , TkListBegin
     , TkInt 4
     , TkInt 18
@@ -1365,7 +1308,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkInt 74
     , TkInt 88
     , TkBreak
-    , TkBytes "\183\147@\177"
+    , TkBytes "u\200\129\164"
     , TkListBegin
     , TkInt 6
     , TkInt 20
@@ -1375,7 +1318,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkInt 76
     , TkInt 90
     , TkBreak
-    , TkBytes "\189\240`\183"
+    , TkBytes "\174\134\&0\129"
     , TkListBegin
     , TkInt 8
     , TkInt 22
@@ -1385,7 +1328,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkInt 78
     , TkInt 92
     , TkBreak
-    , TkBytes "\224\253Xv"
+    , TkBytes "\203\GS\151\&8"
     , TkListBegin
     , TkInt 10
     , TkInt 24
@@ -1395,7 +1338,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkInt 80
     , TkInt 94
     , TkBreak
-    , TkBytes "\244\249\211j"
+    , TkBytes "\229\221D\172"
     , TkListBegin
     , TkInt 12
     , TkInt 26

--- a/ouroboros-consensus-shelley/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley/test/Test/ThreadNet/RealTPraos.hs
@@ -49,8 +49,10 @@ import           Test.ThreadNet.Util.NodeTopology
 
 import           Test.Util.Orphans.Arbitrary ()
 
+import qualified Shelley.Spec.Ledger.Address as SL
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.Coin as SL
+import qualified Shelley.Spec.Ledger.Credential as SL
 import qualified Shelley.Spec.Ledger.Crypto as SL
 import qualified Shelley.Spec.Ledger.Keys as SL
 import qualified Shelley.Spec.Ledger.OCert as SL
@@ -60,7 +62,8 @@ import qualified Shelley.Spec.Ledger.TxData as SL
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import           Ouroboros.Consensus.Shelley.Node
 import           Ouroboros.Consensus.Shelley.Protocol
-import           Ouroboros.Consensus.Shelley.Protocol.Crypto (DSIGN)
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto (DSIGN,
+                     HotKey (..))
 
 import           Test.Consensus.Shelley.MockCrypto (TPraosMockCrypto)
 import qualified Test.Shelley.Spec.Ledger.Generator.Constants as Gen
@@ -276,8 +279,8 @@ mkGenesisConfig k d maxKESEvolutions coreNodes = ShelleyGenesis {
 
     coreNodesToGenesisMapping :: Map (SL.KeyHash 'SL.Genesis c) (SL.KeyHash 'SL.GenesisDelegate c)
     coreNodesToGenesisMapping  = Map.fromList
-      [ ( SL.KeyHash $ SL.hash $ deriveVerKeyDSIGN cnGenesisKey
-        , SL.KeyHash $ SL.hash $ deriveVerKeyDSIGN cnDelegateKey
+      [ ( SL.hashKey . SL.VKey $ deriveVerKeyDSIGN cnGenesisKey
+        , SL.hashKey . SL.VKey $ deriveVerKeyDSIGN cnDelegateKey
         )
       | CoreNode { cnGenesisKey, cnDelegateKey } <- coreNodes
       ]
@@ -341,7 +344,7 @@ mkProtocolRealTPraos genesis CoreNode { cnDelegateKey, cnVRF, cnKES, cnOCert } =
 
     credentials :: TPraosLeaderCredentials c
     credentials = TPraosLeaderCredentials {
-        tpraosLeaderCredentialsSignKey    = cnKES
+        tpraosLeaderCredentialsSignKey    = HotKey 0 cnKES
       , tpraosLeaderCredentialsIsCoreNode = TPraosIsCoreNode {
           tpraosIsCoreNodeOpCert     = cnOCert
         , tpraosIsCoreNodeColdVerKey = SL.VKey $ deriveVerKeyDSIGN cnDelegateKey

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -76,7 +76,7 @@ import           Data.Word
 import           GHC.Generics (Generic)
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import           Cardano.Crypto.Hash
+import           Cardano.Crypto.Hash hiding (castHash)
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 
 import           Ouroboros.Network.Block
@@ -504,4 +504,4 @@ simpleBlockHashInfo = HashInfo
     }
   where
     -- + 1 For the CBOR tag
-    hashSize = 1 + fromIntegral (byteCount (Proxy @(SimpleHash c)))
+    hashSize = 1 + fromIntegral (sizeHash (Proxy @(SimpleHash c)))

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -48,10 +48,10 @@ protocolInfoBft numCoreNodes nid securityParam eraParams =
       }
   where
     signKey :: CoreNodeId -> SignKeyDSIGN MockDSIGN
-    signKey (CoreNodeId n) = SignKeyMockDSIGN (fromIntegral n)
+    signKey (CoreNodeId n) = SignKeyMockDSIGN n
 
     verKey :: CoreNodeId -> VerKeyDSIGN MockDSIGN
-    verKey (CoreNodeId n) = VerKeyMockDSIGN (fromIntegral n)
+    verKey (CoreNodeId n) = VerKeyMockDSIGN n
 
     addrDist :: AddrDist
     addrDist = mkAddrDist numCoreNodes

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -53,10 +53,10 @@ protocolInfoMockPBFT params eraParams nid =
                        ]
 
     signKey :: CoreNodeId -> SignKeyDSIGN MockDSIGN
-    signKey (CoreNodeId n) = SignKeyMockDSIGN (fromIntegral n)
+    signKey (CoreNodeId n) = SignKeyMockDSIGN n
 
     verKey :: CoreNodeId -> VerKeyDSIGN MockDSIGN
-    verKey (CoreNodeId n) = VerKeyMockDSIGN (fromIntegral n)
+    verKey (CoreNodeId n) = VerKeyMockDSIGN n
 
     addrDist :: AddrDist
     addrDist = mkAddrDist (pbftNumNodes params)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -54,13 +54,13 @@ protocolInfoPraos numCoreNodes nid params eraParams =
       }
   where
     signKeyVRF :: CoreNodeId -> SignKeyVRF MockVRF
-    signKeyVRF (CoreNodeId n) = SignKeyMockVRF (fromIntegral n)
+    signKeyVRF (CoreNodeId n) = SignKeyMockVRF n
 
     verKeyVRF :: CoreNodeId -> VerKeyVRF MockVRF
-    verKeyVRF (CoreNodeId n) = VerKeyMockVRF (fromIntegral n)
+    verKeyVRF (CoreNodeId n) = VerKeyMockVRF n
 
     verKeyKES :: CoreNodeId -> VerKeyKES (MockKES t)
-    verKeyKES (CoreNodeId n) = VerKeyMockKES (fromIntegral n)
+    verKeyKES (CoreNodeId n) = VerKeyMockKES n
 
     addrDist :: AddrDist
     addrDist = mkAddrDist numCoreNodes

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Util/HasCreator/Mock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Util/HasCreator/Mock.hs
@@ -23,7 +23,7 @@ instance HasCreator (SimpleBftBlock c BftMockCrypto) where
                . simpleHeader
       where
         coreNodeId :: SignedDSIGN MockDSIGN a -> CoreNodeId
-        coreNodeId = CoreNodeId . fromIntegral . verKeyIdFromSigned
+        coreNodeId = CoreNodeId . verKeyIdFromSigned
 
 instance HasCreator (SimplePBftBlock c PBftMockCrypto) where
     getCreator = coreNodeId
@@ -33,7 +33,7 @@ instance HasCreator (SimplePBftBlock c PBftMockCrypto) where
                . simpleHeader
       where
         coreNodeId :: SignedDSIGN MockDSIGN a -> CoreNodeId
-        coreNodeId = CoreNodeId . fromIntegral . verKeyIdFromSigned
+        coreNodeId = CoreNodeId . verKeyIdFromSigned
 
 instance HasCreator (SimplePraosBlock c PraosMockCrypto) where
     getCreator = praosCreator

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -298,7 +298,7 @@ instance BlockSupportsProtocol TestBlock where
       -- We don't want /our/ signing key, but rather the signing key of the
       -- node that produced the block
       signKey :: Block.SlotNo -> SignKeyDSIGN MockDSIGN
-      signKey (SlotNo n) = SignKeyMockDSIGN $ fromIntegral (n `mod` numCore)
+      signKey (SlotNo n) = SignKeyMockDSIGN $ n `mod` numCore
 
 instance IsLedger (LedgerState TestBlock) where
   type LedgerCfg (LedgerState TestBlock) = HardFork.EraParams

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -29,12 +29,14 @@ import           Control.Monad.Class.MonadTime (Time (..))
 import           Cardano.Crypto (VerificationKey)
 import           Cardano.Crypto.DSIGN (Ed25519DSIGN, Ed448DSIGN, MockDSIGN,
                      SigDSIGN, pattern SigEd25519DSIGN, pattern SigEd448DSIGN,
-                     pattern SigMockDSIGN, SignedDSIGN (..))
+                     pattern SigMockDSIGN, SignedDSIGN (..), VerKeyDSIGN)
 import           Cardano.Crypto.Hash (Hash)
 import           Cardano.Crypto.KES (MockKES, NeverKES, SigKES,
                      pattern SigMockKES, pattern SigSimpleKES,
+                     pattern SigSingleKES, pattern SigSumKES,
                      pattern SignKeyMockKES, SignedKES (..), SimpleKES,
-                     pattern VerKeyMockKES)
+                     SingleKES, SumKES, VerKeyKES, pattern VerKeyMockKES,
+                     pattern VerKeySingleKES, pattern VerKeySumKES)
 import           Cardano.Slotting.Slot (WithOrigin (..))
 
 import           Ouroboros.Network.Block (BlockNo (..), ChainHash (..),
@@ -200,6 +202,22 @@ instance Condense (SigKES NeverKES) where
 
 instance Condense (SigDSIGN d) => Condense (SigKES (SimpleKES d t)) where
     condense (SigSimpleKES sig) = condense sig
+
+instance Condense (SigDSIGN d) => Condense (SigKES (SingleKES d)) where
+    condense (SigSingleKES sig) = condense sig
+
+instance Show (VerKeyDSIGN d) => Condense (VerKeyDSIGN d) where
+  condense = show
+
+instance (Condense (SigKES d), Condense (VerKeyKES d))
+  => Condense (SigKES (SumKES h d)) where
+    condense (SigSumKES sk vk1 vk2) = condense (sk, vk1, vk2)
+
+instance Show (VerKeyDSIGN d) => Condense (VerKeyKES (SingleKES d)) where
+    condense (VerKeySingleKES h) = condense h
+
+instance Condense (VerKeyKES (SumKES h d)) where
+    condense (VerKeySumKES h) = condense h
 
 instance Condense (Hash h a) where
     condense = show

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Protocol/PBFT.hs
@@ -293,7 +293,7 @@ genTestPBftState = do
 -------------------------------------------------------------------------------}
 
 genMockKey :: Int -> Gen (VerKeyDSIGN MockDSIGN)
-genMockKey numKeys = VerKeyMockDSIGN <$> choose (1, numKeys)
+genMockKey numKeys = VerKeyMockDSIGN <$> choose (1, fromIntegral numKeys)
 
 -- | Generate a possibly empty sequence of 'InputEBB's and 'InputSigner's
 --

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -437,7 +437,7 @@ instance BlockSupportsProtocol TestBlock where
       -- We don't want /our/ signing key, but rather the signing key of the
       -- node that produced the block
       signKey :: SlotNo -> SignKeyDSIGN MockDSIGN
-      signKey (SlotNo n) = SignKeyMockDSIGN $ fromIntegral (n `mod` numCore)
+      signKey (SlotNo n) = SignKeyMockDSIGN $ n `mod` numCore
 
   selectView _ hdr = (blockNo hdr, thIsEBB (unTestHeader hdr))
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,12 +36,12 @@ flags:
 
 extra-deps:
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: ae0bf700bed6a411dcf7f03a49f8c89e8344a7b9
+    commit: 20309d5aa56b0ae5fd982465297a1d87aa5658a1
     subdirs:
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: c845509c307af9df956ef203ac8ad67fe4d5d065
+    commit: 9d6e0f5efc8fe1bfff4825b3f52e80cdceac07b0
     subdirs:
       - binary
       - binary/test
@@ -49,7 +49,7 @@ extra-deps:
       - slotting
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 1b2a06df9a710f5cc9b511b6ae39c23bcfd04486
+    commit: 25354e11ed43d59485c404f491a118efe0bd8e70
     subdirs:
       - byron/chain/executable-spec
       - byron/ledger/executable-spec


### PR DESCRIPTION
This PR updates ouroboros-network to use the newest KES constructions from `cardano-base`, as well as fixing some bugs pertaining to how we signed with and evolved our KES keys.

Each commit can be reviewed independently.