### PR TITLE
Fix logic error in Shelley checkIsLeader.hasValidOCert

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -343,7 +343,7 @@ instance TPraosCrypto c => ConsensusProtocol (TPraos c) where
       -- current KES period.
       hasValidOCert :: TPraosIsCoreNode c -> Bool
       hasValidOCert TPraosIsCoreNode{tpraosIsCoreNodeOpCert} =
-          kesPeriod > c0 && kesPeriod < c1
+          kesPeriod >= c0 && kesPeriod < c1
         where
           SL.OCert _ _ (SL.KESPeriod c0) _ = tpraosIsCoreNodeOpCert
           c1 = c0 + fromIntegral (tpraosMaxKESEvo tpraosParams)


### PR DESCRIPTION
Operational certificates should also be valid during the KES start period and not just
afterward.