### PR TITLE
Make threadDelay duration unbounded

### DIFF
--- a/network-mux/src/Network/Mux/Timeout.hs
+++ b/network-mux/src/Network/Mux/Timeout.hs
@@ -94,7 +94,7 @@ withTimeoutSerialNative body = body MonadTimer.timeout
 --
 -- The implementation here only relies upon 'threadDelay' which has an
 -- efficient implementation on all platforms. It uses a separate monitoring
--- thread which will through an exception to terminate the action if the
+-- thread which will throw an exception to terminate the action if the
 -- timeout expires. This is why it uses the \"with\" style: because it keeps
 -- a monitoring thread over a region of execution that may use many timeouts.
 -- The cost of allocating this thread is amortised over all the timeouts used.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Util.hs
@@ -17,10 +17,9 @@ import           Data.Time (NominalDiffTime, UTCTime, diffUTCTime)
 
 import           Cardano.Slotting.Slot
 
-import           Control.Monad.Class.MonadTimer (MonadDelay (..))
-
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
+import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Time
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
@@ -29,6 +29,7 @@ import           Cardano.Prelude (AllowThunk (..), NoUnexpectedThunks)
 import           Cardano.Slotting.Slot (SlotNo (..))
 
 import           Control.Monad.Class.MonadTime
+import qualified Control.Monad.Class.MonadTimer as Unused
 import           Control.Monad.IOSim
 
 import           Ouroboros.Consensus.BlockchainTime


### PR DESCRIPTION
https://github.com/input-output-hk/ouroboros-network/issues/2026

Timeout duration is still bounded by Int

A ci failure was detected https://hydra.iohk.io/build/2668383/nixlog/1. It's related to threadDelay, but I'm not sure if it's related to this pr.