### PR TITLE
Minor API improvements

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
@@ -43,9 +43,7 @@ data ByronOtherHeaderEnvelopeError =
     UnexpectedEBBInSlot !SlotNo
   deriving (Eq, Show, Generic, NoUnexpectedThunks)
 
-instance ValidateEnvelope ByronBlock where
-  type OtherHeaderEnvelopeError ByronBlock = ByronOtherHeaderEnvelopeError
-
+instance BasicEnvelopeValidation ByronBlock where
   expectedFirstBlockNo  _ = BlockNo 0
   minimumPossibleSlotNo _ = SlotNo 0
 
@@ -60,6 +58,9 @@ instance ValidateEnvelope ByronBlock where
       case (prevIsEBB, curIsEBB) of
         (IsEBB, IsNotEBB) -> s
         _otherwise        -> succ s
+
+instance ValidateEnvelope ByronBlock where
+  type OtherHeaderEnvelopeError ByronBlock = ByronOtherHeaderEnvelopeError
 
   additionalEnvelopeChecks cfg _ledgerView hdr =
       when (fromIsEBB newIsEBB && not (canBeEBB actualSlotNo)) $

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -77,9 +77,10 @@ import           Ouroboros.Consensus.Byron.Ledger.HeaderValidation ()
 import           Ouroboros.Consensus.Byron.Ledger.PBFT
 import           Ouroboros.Consensus.Byron.Ledger.Serialisation
 
+type instance LedgerCfg (LedgerState ByronBlock) = Gen.Config
+
 instance IsLedger (LedgerState ByronBlock) where
   type LedgerErr (LedgerState ByronBlock) = CC.ChainValidationError
-  type LedgerCfg (LedgerState ByronBlock) = Gen.Config
 
   applyChainTick cfg slotNo ByronLedgerState{..} =
       Ticked slotNo ByronLedgerState {

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -43,9 +43,10 @@ newtype ByronSpecLedgerError = ByronSpecLedgerError {
   deriving (Show, Eq)
   deriving NoUnexpectedThunks via AllowThunk ByronSpecLedgerError
 
+type instance LedgerCfg (LedgerState ByronSpecBlock) = ByronSpecGenesis
+
 instance IsLedger (LedgerState ByronSpecBlock) where
   type LedgerErr (LedgerState ByronSpecBlock) = ByronSpecLedgerError
-  type LedgerCfg (LedgerState ByronSpecBlock) = ByronSpecGenesis
 
   applyChainTick cfg slot state = Ticked slot $
       updateByronSpecLedgerStateKeepTip state $

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -156,9 +156,10 @@ mkShelleyLedgerConfig genesis epochInfo = ShelleyLedgerConfig {
         , activeSlotCoeff   = sgActiveSlotCoeff   genesis
         }
 
+type instance LedgerCfg (LedgerState (ShelleyBlock c)) = ShelleyLedgerConfig c
+
 instance TPraosCrypto c => IsLedger (LedgerState (ShelleyBlock c)) where
   type LedgerErr (LedgerState (ShelleyBlock c)) = ShelleyLedgerError c
-  type LedgerCfg (LedgerState (ShelleyBlock c)) = ShelleyLedgerConfig c
 
   applyChainTick
     cfg
@@ -378,6 +379,9 @@ instance Crypto c => ShowQuery (Query (ShelleyBlock c)) where
 {-------------------------------------------------------------------------------
   ValidateEnvelope
 -------------------------------------------------------------------------------}
+
+instance Crypto c => BasicEnvelopeValidation (ShelleyBlock c) where
+  -- defaults all OK
 
 instance Crypto c => ValidateEnvelope (ShelleyBlock c) where
   type OtherHeaderEnvelopeError (ShelleyBlock c) =

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -237,6 +237,9 @@ instance Mock.HasMockTxs SimpleBody where
 instance (SimpleCrypto c, Typeable ext) => HasAnnTip (SimpleBlock c ext)
   -- Use defaults
 
+instance (SimpleCrypto c, Typeable ext) => BasicEnvelopeValidation (SimpleBlock c ext)
+  -- Use defaults
+
 instance (SimpleCrypto c, Typeable ext) => ValidateEnvelope (SimpleBlock c ext)
   -- Use defaults
 
@@ -287,9 +290,10 @@ deriving instance Show (MockLedgerConfig c ext) => Show (SimpleLedgerConfig c ex
 deriving instance NoUnexpectedThunks (MockLedgerConfig c ext)
                => NoUnexpectedThunks (SimpleLedgerConfig c ext)
 
+type instance LedgerCfg (LedgerState (SimpleBlock c ext)) = SimpleLedgerConfig c ext
+
 instance MockProtocolSpecific c ext
       => IsLedger (LedgerState (SimpleBlock c ext)) where
-  type LedgerCfg (LedgerState (SimpleBlock c ext)) = SimpleLedgerConfig c ext
   type LedgerErr (LedgerState (SimpleBlock c ext)) = MockError (SimpleBlock c ext)
 
   applyChainTick _ = Ticked

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -300,8 +300,9 @@ instance BlockSupportsProtocol TestBlock where
       signKey :: Block.SlotNo -> SignKeyDSIGN MockDSIGN
       signKey (SlotNo n) = SignKeyMockDSIGN $ n `mod` numCore
 
+type instance LedgerCfg (LedgerState TestBlock) = HardFork.EraParams
+
 instance IsLedger (LedgerState TestBlock) where
-  type LedgerCfg (LedgerState TestBlock) = HardFork.EraParams
   type LedgerErr (LedgerState TestBlock) = TestBlockError
 
   applyChainTick _ = Ticked
@@ -343,9 +344,12 @@ lastAppliedBlock (TestLedger p) = go p
 instance HasAnnTip TestBlock where
   -- Use defaults
 
-instance ValidateEnvelope TestBlock where
+instance BasicEnvelopeValidation TestBlock where
   -- The block number of a test block is derived from the length of the hash
   expectedFirstBlockNo _ = Block.BlockNo 1
+
+instance ValidateEnvelope TestBlock where
+  -- Use defaults
 
 instance LedgerSupportsProtocol TestBlock where
   protocolLedgerView   _ _ = ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -15,6 +15,7 @@
 module Ouroboros.Consensus.Ledger.Abstract (
     -- * Definition of a ledger independent of a choice of block
     IsLedger(..)
+  , LedgerCfg
   , Ticked(..)
   , ApplyBlock(..)
     -- ** Derived
@@ -57,6 +58,9 @@ import           Ouroboros.Consensus.Util
   Definition of a ledger independent of a choice of block
 -------------------------------------------------------------------------------}
 
+-- | Static environment required for the ledger
+type family LedgerCfg l :: *
+
 class ( -- Requirements on the ledger state itself
         Show               l
       , Eq                 l
@@ -68,9 +72,6 @@ class ( -- Requirements on the ledger state itself
       , Eq                 (LedgerErr l)
       , NoUnexpectedThunks (LedgerErr l)
       ) => IsLedger l where
-  -- | Static environment required for the ledger
-  type family LedgerCfg l :: *
-
   -- | Errors that can arise when updating the ledger
   --
   -- This is defined here rather than in 'ApplyBlock', since the /type/ of

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -277,8 +277,9 @@ data DualLedgerConfig m a = DualLedgerConfig {
     }
   deriving NoUnexpectedThunks via AllowThunk (DualLedgerConfig m a)
 
+type instance LedgerCfg (LedgerState (DualBlock m a)) = DualLedgerConfig m a
+
 instance Bridge m a => IsLedger (LedgerState (DualBlock m a)) where
-  type LedgerCfg (LedgerState (DualBlock m a)) = DualLedgerConfig m a
   type LedgerErr (LedgerState (DualBlock m a)) = DualLedgerError   m a
 
   applyChainTick DualLedgerConfig{..}
@@ -387,14 +388,15 @@ instance Bridge m a => HasAnnTip (DualBlock m a) where
   tipInfoHash _ = tipInfoHash (Proxy @m)
   getTipInfo    = getTipInfo . dualHeaderMain
 
-instance Bridge m a => ValidateEnvelope (DualBlock m a) where
-  type OtherHeaderEnvelopeError (DualBlock m a) = OtherHeaderEnvelopeError m
-
+instance Bridge m a => BasicEnvelopeValidation (DualBlock m a) where
   expectedFirstBlockNo  _ = expectedFirstBlockNo  (Proxy @m)
   expectedNextBlockNo   _ = expectedNextBlockNo   (Proxy @m)
   minimumPossibleSlotNo _ = minimumPossibleSlotNo (Proxy @m)
   minimumNextSlotNo     _ = minimumNextSlotNo     (Proxy @m)
   checkPrevHash         _ = checkPrevHash         (Proxy @m)
+
+instance Bridge m a => ValidateEnvelope (DualBlock m a) where
+  type OtherHeaderEnvelopeError (DualBlock m a) = OtherHeaderEnvelopeError m
 
   additionalEnvelopeChecks cfg ledgerView hdr =
       additionalEnvelopeChecks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -112,11 +112,12 @@ _lemma_protocoLedgerView_applyLedgerBlock cfg blk st
   The extended ledger can behave like a ledger
 -------------------------------------------------------------------------------}
 
+type instance LedgerCfg (ExtLedgerState blk) = TopLevelConfig blk
+
 instance ( IsLedger (LedgerState  blk)
          , LedgerSupportsProtocol blk
          )
       => IsLedger (ExtLedgerState blk) where
-  type LedgerCfg (ExtLedgerState blk) = TopLevelConfig     blk
   type LedgerErr (ExtLedgerState blk) = ExtValidationError blk
 
   applyChainTick cfg slot (ExtLedgerState ledger header) =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -773,13 +773,14 @@ ledgerDbSwitch cfg numRollbacks newBlocks db = do
   The LedgerDB itself behaves like a ledger
 -------------------------------------------------------------------------------}
 
+type instance LedgerCfg (LedgerDB l r) = LedgerCfg l
+
 instance ( IsLedger l
            -- Required superclass constraints of 'IsLedger'
          , Show               r
          , Eq                 r
          , NoUnexpectedThunks r
          ) => IsLedger (LedgerDB l r) where
-  type LedgerCfg (LedgerDB l r) = LedgerCfg l
   type LedgerErr (LedgerDB l r) = LedgerErr l
 
   applyChainTick cfg slot db =

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -451,8 +451,9 @@ data TestBlockError =
   | InvalidBlock
   deriving (Eq, Show, Generic, NoUnexpectedThunks)
 
+type instance LedgerCfg (LedgerState TestBlock) = HardFork.EraParams
+
 instance IsLedger (LedgerState TestBlock) where
-  type LedgerCfg (LedgerState TestBlock) = HardFork.EraParams
   type LedgerErr (LedgerState TestBlock) = TestBlockError
 
   applyChainTick _ = Ticked
@@ -491,9 +492,7 @@ data TestBlockOtherHeaderEnvelopeError =
     UnexpectedEBBInSlot !SlotNo
   deriving (Eq, Show, Generic, NoUnexpectedThunks)
 
-instance ValidateEnvelope TestBlock where
-  type OtherHeaderEnvelopeError TestBlock = TestBlockOtherHeaderEnvelopeError
-
+instance BasicEnvelopeValidation TestBlock where
   minimumPossibleSlotNo _ = SlotNo 0
 
   -- EBB shares its slot number with its successor
@@ -510,6 +509,9 @@ instance ValidateEnvelope TestBlock where
       case (prevIsEBB, curIsEBB) of
         (IsNotEBB, IsEBB) -> b
         _otherwise        -> succ b
+
+instance ValidateEnvelope TestBlock where
+  type OtherHeaderEnvelopeError TestBlock = TestBlockOtherHeaderEnvelopeError
 
   additionalEnvelopeChecks cfg _ledgerView hdr =
       when (fromIsEBB newIsEBB && not (canBeEBB actualSlotNo)) $


### PR DESCRIPTION
This makes two changes:

* `LedgerCfg` is now an independent type family. This means that we can
  now refer to the config of a particular ledger without necessarily
  having to give all the instances. We previously moved `LedgerState`
  out of `UpdateLedger` for the same reason, but that wasn't quite
  enough.
* Split `BasicEnvelopeValidation` off from `ValidateEnvelope`; unlike
  `ValidateEnvelope` itself, `BasicEnvelopeValidation` is not ledger
  dependent.