### PR TITLE
Reduce config scope creep

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -423,8 +423,7 @@ instance TPraosCrypto c => ConsensusProtocol (TPraos c) where
   --
   -- We don't roll back to the exact slot since that slot might not have been
   -- filled; instead we roll back the the block just before it.
-  rewindConsensusState TPraosConfig{..} cs rewindTo =
-    State.rewind (pointSlot rewindTo) cs
+  rewindConsensusState _proxy _k = State.rewind . pointSlot
 
 mkShelleyGlobals :: TPraosParams -> SL.Globals
 mkShelleyGlobals TPraosParams {..} = SL.Globals {

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -315,16 +315,16 @@ data instance ConsensusConfig (TPraos c) = TPraosConfig {
 -- Use generic instance
 instance TPraosCrypto c => NoUnexpectedThunks (ConsensusConfig (TPraos c))
 
-instance TPraosCrypto c => ConsensusProtocol (TPraos c) where
+instance TPraosCrypto c => ChainSelection (TPraos c) where
+  -- TODO override compareCandidates and preferCandidate to check the
+  -- certificate number. #1877
 
+instance TPraosCrypto c => ConsensusProtocol (TPraos c) where
   type ConsensusState  (TPraos c) = TPraosState c
   type IsLeader        (TPraos c) = TPraosProof c
   type LedgerView      (TPraos c) = SL.LedgerView c
   type ValidationErr   (TPraos c) = [[STS.PredicateFailure (STS.PRTCL c)]]
   type ValidateView    (TPraos c) = TPraosValidateView c
-
-  -- TODO override compareCandidates and preferCandidate to check the
-  -- certificate number?
 
   protocolSecurityParam = tpraosSecurityParam . tpraosParams
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -250,6 +250,9 @@ data instance ConsensusConfig (Praos c) = PraosConfig
   }
   deriving (Generic)
 
+instance PraosCrypto c => ChainSelection (Praos c) where
+  -- Use defaults
+
 instance PraosCrypto c => ConsensusProtocol (Praos c) where
   protocolSecurityParam = praosSecurityParam . praosParams
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -353,9 +353,9 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
   --
   -- We don't roll back to the exact slot since that slot might not have been
   -- filled; instead we roll back the the block just before it.
-  rewindConsensusState PraosConfig{..} cs rewindTo =
+  rewindConsensusState _proxy _k rewindTo =
       -- This may drop us back to the empty list if we go back to genesis
-      Just $ dropWhile (\bi -> At (biSlot bi) > pointSlot rewindTo) cs
+      Just . dropWhile (\bi -> At (biSlot bi) > pointSlot rewindTo)
 
   -- (Standard) Praos uses the standard chain selection rule, so no need to
   -- override (though see note regarding clock skew).

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
@@ -66,6 +67,7 @@ import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
+import           Data.Proxy
 import           Data.Tree (Tree (..))
 import qualified Data.Tree as Tree
 import           Data.TreeDiff (ToExpr)
@@ -97,6 +99,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
+import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.MockChainSel
 import           Ouroboros.Consensus.Protocol.Signed
@@ -487,7 +490,11 @@ treePreferredChain :: TopLevelConfig TestBlock
                    -> BlockTree -> Chain TestBlock
 treePreferredChain cfg =
       fromMaybe Genesis
-    . selectUnvalidatedChain Block.blockNo (configConsensus cfg) Genesis
+    . selectUnvalidatedChain
+        (Proxy @(BlockProtocol TestBlock))
+        Block.blockNo
+        (chainSelConfig (configConsensus cfg))
+        Genesis
     . treeToChains
 
 instance Show BlockTree where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -216,9 +216,10 @@ rewindHeaderState :: forall blk.
                   -> HeaderState blk -> Maybe (HeaderState blk)
 rewindHeaderState cfg p HeaderState{..} = do
     consensusState' <- rewindConsensusState
-                         (configConsensus cfg)
-                         headerStateConsensus
+                         (Proxy @(BlockProtocol blk))
+                         (configSecurityParam cfg)
                          p
+                         headerStateConsensus
     return $ HeaderState {
         headerStateConsensus = consensusState'
       , headerStateTips      = Seq.dropWhileR rolledBack headerStateTips

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -5,6 +5,7 @@
 module Ouroboros.Consensus.Protocol.Abstract (
     -- * Abstract definition of the Ouroboros protocol
     ConsensusProtocol(..)
+  , ChainSelection(..)
   , ConsensusConfig
     -- * Convenience re-exports
   , SecurityParam(..)
@@ -34,6 +35,67 @@ import           Ouroboros.Consensus.Ledger.Abstract (Ticked)
 -- module).
 data family ConsensusConfig p :: *
 
+-- | Chain selection
+class NoUnexpectedThunks (ChainSelConfig p) => ChainSelection p where
+  -- | Configuration required for chain selection
+  type family ChainSelConfig p :: *
+  type ChainSelConfig p = ()
+
+  -- | View on a header required for chain selection
+  type family SelectView p :: *
+  type SelectView p = BlockNo
+
+  -- | Do we prefer the candidate chain over ours?
+  --
+  -- Should return 'True' when we prefer the candidate over our chain.
+  --
+  -- We pass only the tips of the chains; for all consensus protocols we are
+  -- interested in, this provides sufficient context. (Ouroboros Genesis is
+  -- the only exception, but we will handle the genesis rule elsewhere.)
+  --
+  -- PRECONDITIONS:
+  --
+  -- * The candidate chain does not extend into the future.
+  -- * The candidate must intersect with our chain within @k@ blocks from
+  --   our tip.
+  --
+  -- NOTE: An assumption that is quite deeply ingrained in the design of the
+  -- consensus layer is that if a chain can be extended, it always should (e.g.,
+  -- see the chain database spec in @ChainDB.md@). This means that any chain
+  -- is always preferred over the empty chain, and 'preferCandidate' does not
+  -- need (indeed, cannot) be called if our current chain is empty.
+  preferCandidate :: proxy          p
+                  -> ChainSelConfig p
+                  -> SelectView     p      -- ^ Tip of our chain
+                  -> SelectView     p      -- ^ Tip of the candidate
+                  -> Bool
+
+  -- | Compare two candidates, both of which we prefer to our own chain
+  --
+  -- PRECONDITION: both candidates must be preferred to our own chain
+  compareCandidates :: proxy          p
+                    -> ChainSelConfig p
+                    -> SelectView     p
+                    -> SelectView     p
+                    -> Ordering
+
+  --
+  -- Default chain selection
+  --
+  -- The default preference uses the default comparison. The default comparison
+  -- simply uses the block number.
+  --
+
+  preferCandidate p cfg ours cand = compareCandidates p cfg ours cand == LT
+
+  default compareCandidates :: Ord (SelectView p)
+                            => proxy          p
+                            -> ChainSelConfig p
+                            -> SelectView     p
+                            -> SelectView     p
+                            -> Ordering
+  compareCandidates _ _ = compare
+
 -- | The (open) universe of Ouroboros protocols
 --
 -- This class encodes the part that is independent from any particular
@@ -47,8 +109,8 @@ class ( Show (ConsensusState p)
       , NoUnexpectedThunks (ConsensusState  p)
       , NoUnexpectedThunks (ValidationErr   p)
       , Typeable p -- so that p can appear in exceptions
+      , ChainSelection p
       ) => ConsensusProtocol p where
-
   -- | Protocol-specific state
   --
   -- NOTE: This chain is blockchain dependent, i.e., updated when new blocks
@@ -105,40 +167,11 @@ class ( Show (ConsensusState p)
   -- | View on a header required to validate it
   type family ValidateView p :: *
 
-  -- | View on a header required for chain selection
-  type family SelectView p :: *
-
-  -- | Do we prefer the candidate chain over ours?
-  --
-  -- Should return 'True' when we prefer the candidate over our chain.
-  --
-  -- We pass only the tips of the chains; for all consensus protocols we are
-  -- interested in, this provides sufficient context. (Ouroboros Genesis is
-  -- the only exception, but we will handle the genesis rule elsewhere.)
-  --
-  -- PRECONDITIONS:
-  --
-  -- * The candidate chain does not extend into the future.
-  -- * The candidate must intersect with our chain within @k@ blocks from
-  --   our tip.
-  --
-  -- NOTE: An assumption that is quite deeply ingrained in the design of the
-  -- consensus layer is that if a chain can be extended, it always should (e.g.,
-  -- see the chain database spec in @ChainDB.md@). This means that any chain
-  -- is always preferred over the empty chain, and 'preferCandidate' does not
-  -- need (indeed, cannot) be called if our current chain is empty.
-  preferCandidate :: ConsensusConfig p
-                  -> SelectView      p      -- ^ Tip of our chain
-                  -> SelectView      p      -- ^ Tip of the candidate
-                  -> Bool
-
-  -- | Compare two candidates, both of which we prefer to our own chain
-  --
-  -- PRECONDITION: both candidates must be preferred to our own chain
-  compareCandidates :: ConsensusConfig p
-                    -> SelectView      p
-                    -> SelectView      p
-                    -> Ordering
+  -- | 'ConsensusConfig' must include the 'ChainSelConfig' p
+  chainSelConfig :: ConsensusConfig p -> ChainSelConfig p
+  default chainSelConfig :: (ChainSelConfig p ~ ())
+                         => ConsensusConfig p -> ChainSelConfig p
+  chainSelConfig _ = ()
 
   -- | Check if a node is the leader
   checkIsLeader :: MonadRandom m
@@ -191,22 +224,3 @@ class ( Show (ConsensusState p)
                        -> SecurityParam
                        -> Point hdr      -- ^ Point to rewind to
                        -> ConsensusState p -> Maybe (ConsensusState p)
-
-  --
-  -- Default chain selection
-  --
-  -- The default preference uses the default comparison. The default comparison
-  -- simply uses the block number.
-  --
-
-  type SelectView p = BlockNo
-
-  preferCandidate cfg ours cand =
-    compareCandidates cfg ours cand == LT
-
-  default compareCandidates :: Ord (SelectView p)
-                            => ConsensusConfig p
-                            -> SelectView      p
-                            -> SelectView      p
-                            -> Ordering
-  compareCandidates _ = compare

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -187,10 +187,10 @@ class ( Show (ConsensusState p)
   -- TODO: The Serialise instance is only required for a hack in PBFT.
   -- Reconsider later.
   rewindConsensusState :: Serialise (HeaderHash hdr)
-                       => ConsensusConfig p
-                       -> ConsensusState  p
-                       -> Point hdr    -- ^ Point to rewind to
-                       -> Maybe (ConsensusState p)
+                       => proxy p
+                       -> SecurityParam
+                       -> Point hdr      -- ^ Point to rewind to
+                       -> ConsensusState p -> Maybe (ConsensusState p)
 
   --
   -- Default chain selection

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -125,6 +125,9 @@ data instance ConsensusConfig (Bft c) = BftConfig {
     }
   deriving (Generic)
 
+instance BftCrypto c => ChainSelection (Bft c) where
+  -- Use defaults
+
 instance BftCrypto c => ConsensusProtocol (Bft c) where
   type ValidationErr  (Bft c) = BftValidationErr
   type ValidateView   (Bft c) = BftValidateView c

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -167,7 +167,7 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
       expectedLeader = CoreId $ CoreNodeId (n `mod` numCoreNodes)
       NumCoreNodes numCoreNodes = bftNumNodes
 
-  rewindConsensusState _ _ _ = Just ()
+  rewindConsensusState _ _ _ _ = Just ()
 
 instance BftCrypto c => NoUnexpectedThunks (ConsensusConfig (Bft c))
   -- use generic instance

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 
 module Ouroboros.Consensus.Protocol.LeaderSchedule (
@@ -15,6 +17,7 @@ module Ouroboros.Consensus.Protocol.LeaderSchedule (
 
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import           Data.Proxy
 import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
@@ -26,7 +29,18 @@ import           Ouroboros.Consensus.NodeId (CoreNodeId (..), fromCoreNodeId)
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
 
-newtype LeaderSchedule = LeaderSchedule {getLeaderSchedule :: Map SlotNo [CoreNodeId]}
+{-------------------------------------------------------------------------------
+  Leader schedule
+
+  The leader schedule allows us to define, in tests, precisely when each node
+  is meant to lead. Unlike in, say, Praos, where this is determined by a single
+  random seed, this gives us the ability to construct test cases in an
+  inspectable and shrinkable manner.
+-------------------------------------------------------------------------------}
+
+newtype LeaderSchedule = LeaderSchedule {
+        getLeaderSchedule :: Map SlotNo [CoreNodeId]
+      }
     deriving stock    (Show, Eq, Ord, Generic)
     deriving anyclass (NoUnexpectedThunks)
 
@@ -42,8 +56,20 @@ instance Condense LeaderSchedule where
                                 $ map (\(s, ls) -> (s, map fromCoreNodeId ls))
                                 $ Map.toList m
 
+{-------------------------------------------------------------------------------
+  ConsensusProtocol instance
+-------------------------------------------------------------------------------}
+
 -- | Extension of protocol @p@ by a static leader schedule.
 data WithLeaderSchedule p
+
+-- | Chain selection is unchanged
+instance ChainSelection p => ChainSelection (WithLeaderSchedule p) where
+  type ChainSelConfig (WithLeaderSchedule p) = ChainSelConfig p
+  type SelectView     (WithLeaderSchedule p) = SelectView     p
+
+  preferCandidate   _ = preferCandidate   (Proxy @p)
+  compareCandidates _ = compareCandidates (Proxy @p)
 
 data instance ConsensusConfig (WithLeaderSchedule p) = WLSConfig
   { wlsConfigSchedule :: !LeaderSchedule
@@ -58,11 +84,9 @@ instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
   type ValidationErr  (WithLeaderSchedule p) = ()
   type IsLeader       (WithLeaderSchedule p) = ()
   type ValidateView   (WithLeaderSchedule p) = ()
-  type SelectView     (WithLeaderSchedule p) = SelectView p
 
-  preferCandidate       WLSConfig{..} = preferCandidate       wlsConfigP
-  compareCandidates     WLSConfig{..} = compareCandidates     wlsConfigP
-  protocolSecurityParam WLSConfig{..} = protocolSecurityParam wlsConfigP
+  protocolSecurityParam = protocolSecurityParam . wlsConfigP
+  chainSelConfig        = chainSelConfig        . wlsConfigP
 
   checkIfCanBeLeader _ = True -- Conservative approximation
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -74,7 +74,7 @@ instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
             | otherwise                   -> Nothing
 
   updateConsensusState _ _ _ _ = return ()
-  rewindConsensusState _ _ _  = Just ()
+  rewindConsensusState _ _ _ _ = Just ()
 
 instance ConsensusProtocol p
       => NoUnexpectedThunks (ConsensusConfig (WithLeaderSchedule p))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 
 module Ouroboros.Consensus.Protocol.ModChainSel (
@@ -59,11 +60,12 @@ instance (Typeable p, Typeable s, ChainSelection p s)
     checkIfCanBeLeader    (McsConsensusConfig cfg) = checkIfCanBeLeader    cfg
     checkIsLeader         (McsConsensusConfig cfg) = checkIsLeader         cfg
     updateConsensusState  (McsConsensusConfig cfg) = updateConsensusState  cfg
-    rewindConsensusState  (McsConsensusConfig cfg) = rewindConsensusState  cfg
     protocolSecurityParam (McsConsensusConfig cfg) = protocolSecurityParam cfg
 
-    preferCandidate   (McsConsensusConfig cfg) = preferCandidate'   (Proxy :: Proxy s) cfg
-    compareCandidates (McsConsensusConfig cfg) = compareCandidates' (Proxy :: Proxy s) cfg
+    rewindConsensusState _proxy = rewindConsensusState (Proxy @p)
+
+    preferCandidate   (McsConsensusConfig cfg) = preferCandidate'   (Proxy @s) cfg
+    compareCandidates (McsConsensusConfig cfg) = compareCandidates' (Proxy @s) cfg
 
 instance ConsensusProtocol p
       => NoUnexpectedThunks (ConsensusConfig (ModChainSel p s))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -308,9 +308,7 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
     where
       params = pbftWindowParams cfg
 
-  rewindConsensusState cfg = flip (rewind cfg params)
-    where
-      params = pbftWindowParams cfg
+  rewindConsensusState _proxy = rewind
 
   compareCandidates PBftConfig{..} (lBlockNo, lIsEBB) (rBlockNo, rIsEBB) =
       -- Prefer the highest block number, as it is a proxy for chain length
@@ -391,15 +389,9 @@ appendEBB PBftConfig{..} PBftWindowParams{..} =
     PBftParams{..} = pbftParams
 
 rewind :: forall c hdr. (PBftCrypto c, Serialise (HeaderHash hdr))
-       => ConsensusConfig (PBft c)
-       -> PBftWindowParams
-       -> Point hdr
-       -> PBftState c
-       -> Maybe (PBftState c)
-rewind PBftConfig{..} PBftWindowParams{..} p =
-    S.rewind pbftSecurityParam windowSize p'
+       => SecurityParam -> Point hdr -> PBftState c -> Maybe (PBftState c)
+rewind k p = S.rewind k (pbftWindowSize k) p'
   where
-    PBftParams{..} = pbftParams
     p' = case p of
       GenesisPoint    -> Origin
       BlockPoint s hh -> At (s, headerHashBytes (Proxy :: Proxy hdr) hh)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 -- | Utility functions on anchored fragments
 --
@@ -12,6 +13,7 @@ module Ouroboros.Consensus.Util.AnchoredFragment (
   ) where
 
 import           Data.Function (on)
+import           Data.Proxy
 import           Data.Word (Word64)
 import           GHC.Stack
 
@@ -164,7 +166,8 @@ preferAnchoredCandidate cfg ours theirs =
       (_ :> ourTip, _ :> theirTip) ->
         -- Case 4
         preferCandidate
-          (configConsensus cfg)
+          (Proxy @(BlockProtocol blk))
+          (chainSelConfig (configConsensus cfg))
           (selectView (configBlock cfg) ourTip)
           (selectView (configBlock cfg) theirTip)
 
@@ -175,7 +178,7 @@ preferAnchoredCandidate cfg ours theirs =
 -- Implementation note: since the empty fragment is never preferred over our
 -- chain, this is trivial. See discussion in 'preferAnchoredCandidate' for
 -- details.
-compareAnchoredCandidates :: (BlockSupportsProtocol blk, HasCallStack)
+compareAnchoredCandidates :: forall blk. (BlockSupportsProtocol blk, HasCallStack)
                           => TopLevelConfig blk
                           -> AnchoredFragment (Header blk)
                           -> AnchoredFragment (Header blk)
@@ -184,7 +187,8 @@ compareAnchoredCandidates cfg ours theirs =
     case (ours, theirs) of
       (_ :> ourTip, _ :> theirTip) ->
         compareCandidates
-          (configConsensus cfg)
+          (Proxy @(BlockProtocol blk))
+          (chainSelConfig (configConsensus cfg))
           (selectView (configBlock cfg) ourTip)
           (selectView (configBlock cfg) theirTip)
       _otherwise ->

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -88,6 +88,7 @@ import           Data.List (isInfixOf, isPrefixOf, sortBy)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, isJust)
+import           Data.Proxy
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 
@@ -396,8 +397,9 @@ addBlock cfg blk m
     (newChain, newLedger) =
         fromMaybe (currentChain m, currentLedger m)
       . selectChain
+          (Proxy @(BlockProtocol blk))
           (selectView (configBlock cfg) . getHeader)
-          (configConsensus cfg)
+          (chainSelConfig (configConsensus cfg))
           (currentChain m)
       . filter (extendsImmutableChain . fst)
       $ candidates
@@ -955,8 +957,9 @@ wipeVolDB cfg m =
     (newChain, newLedger) =
         isSameAsImmDbChain
       $ selectChain
+          (Proxy @(BlockProtocol blk))
           (selectView (configBlock cfg) . getHeader)
-          (configConsensus cfg)
+          (chainSelConfig (configConsensus cfg))
           Chain.genesis
       $ snd
       $ validChains cfg m (immDbBlocks m)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1003,7 +1003,8 @@ isEquallyOrMorePreferableThan cfg chain1 chain2 =
       (Just _,    Nothing)   -> True
       (Just blk1, Just blk2) -> LT /=
         compareCandidates
-          (configConsensus cfg)
+          (Proxy @(BlockProtocol blk))
+          (chainSelConfig (configConsensus cfg))
           (selectView (configBlock cfg) (getHeader blk1))
           (selectView (configBlock cfg) (getHeader blk2))
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -100,6 +100,7 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
+import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Protocol.ModChainSel
 import           Ouroboros.Consensus.Protocol.Signed
@@ -404,13 +405,10 @@ ebbAwareCompareCandidates (lBlockNo, lIsEBB) (rBlockNo, rIsEBB) =
      score IsEBB    = 1
      score IsNotEBB = 0
 
-instance ChainSelection (Bft BftMockCrypto) BftWithEBBs where
-  type SelectView' (Bft BftMockCrypto) = (BlockNo, IsEBB)
+instance ChainSelection BftWithEBBs where
+  type SelectView BftWithEBBs = (BlockNo, IsEBB)
 
-  compareCandidates' _ _ = ebbAwareCompareCandidates
-
-  preferCandidate' _ _ ours cand =
-    ebbAwareCompareCandidates ours cand == LT
+  compareCandidates _ _ = ebbAwareCompareCandidates
 
 type instance BlockProtocol TestBlock =
   ModChainSel (Bft BftMockCrypto) BftWithEBBs
@@ -554,7 +552,7 @@ testInitExtLedger = ExtLedgerState {
 mkTestConfig :: SecurityParam -> ChunkSize -> TopLevelConfig TestBlock
 mkTestConfig k ChunkSize { chunkCanContainEBB, numRegularBlocks } =
     TopLevelConfig {
-        configConsensus = McsConsensusConfig BftConfig {
+        configConsensus = McsConsensusConfig () $ BftConfig {
             bftParams   = BftParams {
                 bftSecurityParam = k
               , bftNumNodes      = numCoreNodes


### PR DESCRIPTION
As part of the hard fork work, we need to reconstruct the right `EpochInfo` at various points. We can do this in most places, but we don't quite always have sufficient context. This PR eliminates the need to do it in those places by making two changes:

* Pass `SecurityParam` instead of full `ConsensusConfig` to `rewindConsensusState`
* Make `ChainSelection` independent concept with its own config, and pass only the `ChainSelConfig` to `compareCandidates` and `preferCandidate`.

Details in the commits.