### PR TITLE
Update dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -74,10 +74,6 @@ package ouroboros-consensus-shelley
 package ouroboros-consensus-cardano
   flags: +asserts
 
-
-package cardano-ledger
-  tests: False
-
 package cardano-binary
   tests: False
 
@@ -118,84 +114,112 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: bd7eb69d27bfaee46d435bc1d2720520b1446426
-  --sha256: 1cmxh1gk7lvgs6bfr8v6k2lpjxmk0qam58clvdvxkybrlbh186ps
+  tag: 594f587bfab626a405ac532112cc0b942ad3efdb
+  --sha256: 09h9kd6drhw53i1k8ahwk95kb0c1nbbxr8f3p9rx63yq3hdga2cw
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: bd7eb69d27bfaee46d435bc1d2720520b1446426
-  --sha256: 1cmxh1gk7lvgs6bfr8v6k2lpjxmk0qam58clvdvxkybrlbh186ps
+  tag: 594f587bfab626a405ac532112cc0b942ad3efdb
+  --sha256: 09h9kd6drhw53i1k8ahwk95kb0c1nbbxr8f3p9rx63yq3hdga2cw
   subdir: test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 033a66c705a24d2d29732f7fb2fceaa9674b7ba5
-  --sha256: 0qw2sv4h0zhnrh79nip4k183f2nvj3sf8bnkq0bpywr65y7q0qyv
+  tag: 9b82346b78e212fcd3e795faf9dd7f3266ab7297
+  --sha256: 04iv32x233bck4xd34x2g0yaxj438f57d3z6m0pvvzj2yca1slxm
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 033a66c705a24d2d29732f7fb2fceaa9674b7ba5
-  --sha256: 0qw2sv4h0zhnrh79nip4k183f2nvj3sf8bnkq0bpywr65y7q0qyv
+  tag: 9b82346b78e212fcd3e795faf9dd7f3266ab7297
+  --sha256: 04iv32x233bck4xd34x2g0yaxj438f57d3z6m0pvvzj2yca1slxm
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 033a66c705a24d2d29732f7fb2fceaa9674b7ba5
-  --sha256: 0qw2sv4h0zhnrh79nip4k183f2nvj3sf8bnkq0bpywr65y7q0qyv
+  tag: 9b82346b78e212fcd3e795faf9dd7f3266ab7297
+  --sha256: 04iv32x233bck4xd34x2g0yaxj438f57d3z6m0pvvzj2yca1slxm
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 033a66c705a24d2d29732f7fb2fceaa9674b7ba5
-  --sha256: 0qw2sv4h0zhnrh79nip4k183f2nvj3sf8bnkq0bpywr65y7q0qyv
+  tag: 9b82346b78e212fcd3e795faf9dd7f3266ab7297
+  --sha256: 04iv32x233bck4xd34x2g0yaxj438f57d3z6m0pvvzj2yca1slxm
   subdir: slotting
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 61aaa8228b7f9ec4aacd87546849ff610899f6a6
-  --sha256: 16gx0vyrfxw2d8z4j3xxchnq6q2lw4hchf0s3a0b1gf8v2k2zks9
+  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
+  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 61aaa8228b7f9ec4aacd87546849ff610899f6a6
-  --sha256: 16gx0vyrfxw2d8z4j3xxchnq6q2lw4hchf0s3a0b1gf8v2k2zks9
+  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
+  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 61aaa8228b7f9ec4aacd87546849ff610899f6a6
-  --sha256: 16gx0vyrfxw2d8z4j3xxchnq6q2lw4hchf0s3a0b1gf8v2k2zks9
+  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
+  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  subdir: byron/ledger/impl
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
+  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  subdir: byron/ledger/impl/test
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
+  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  subdir: byron/crypto
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
+  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  subdir: byron/crypto/test
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-specs
+  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
+  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 61aaa8228b7f9ec4aacd87546849ff610899f6a6
-  --sha256: 16gx0vyrfxw2d8z4j3xxchnq6q2lw4hchf0s3a0b1gf8v2k2zks9
+  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
+  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 61aaa8228b7f9ec4aacd87546849ff610899f6a6
-  --sha256: 16gx0vyrfxw2d8z4j3xxchnq6q2lw4hchf0s3a0b1gf8v2k2zks9
+  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
+  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 61aaa8228b7f9ec4aacd87546849ff610899f6a6
-  --sha256: 16gx0vyrfxw2d8z4j3xxchnq6q2lw4hchf0s3a0b1gf8v2k2zks9
+  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
+  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
   subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package
@@ -203,34 +227,6 @@ source-repository-package
   location: https://github.com/input-output-hk/goblins
   tag: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
   --sha256: 17p5x0hj6c67jkdqx0cysqlwq2zs2l87azihn1alzajy9ak6ii0b
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger
-  tag: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
-  --sha256: 0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4
-  subdir: cardano-ledger
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger
-  tag: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
-  --sha256: 0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4
-  subdir: crypto
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger
-  tag: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
-  --sha256: 0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4
-  subdir: cardano-ledger/test
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-ledger
-  tag: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
-  --sha256: 0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4
-  subdir: crypto/test
 
 source-repository-package
   type: git

--- a/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
+++ b/ouroboros-consensus-shelley/test/Test/Consensus/Shelley/Ledger/Golden.hs
@@ -287,7 +287,7 @@ test_golden_Block = goldenTestCBOR
     , TkListLen 15
     , TkInt 2
     , TkInt 20
-    , TkBytes "\191|nI"
+    , TkBytes "\247\SYN\214\203"
     , TkBytes "16260160"
     , TkBytes "16260160"
     , TkListLen 2
@@ -297,25 +297,25 @@ test_golden_Block = goldenTestCBOR
     , TkInt 0
     , TkBytes "16260160q\SYN"
     , TkInt 208
-    , TkBytes "\211W9O"
+    , TkBytes "K\NAK\248\233"
     , TkBytes "16260160"
     , TkInt 0
     , TkInt 0
     , TkBytes "\ETX\148G\SO16260160"
     , TkInt 0
     , TkInt 0
-    , TkBytes "fh\ACK\135o\180w\134\DC3.\146pK\223\129\193\&16260160\NUL\NUL\NUL\NUL\NUL\NUL\NUL\SOH"
+    , TkBytes "\183t\157|\221\192\149\218\169\253\139f\175|\ETXP16260160\NUL\NUL\NUL\NUL\NUL\NUL\NUL\SOH"
     , TkListLen 1
     , TkMapLen 5
     , TkInt 0
     , TkListLen 1
     , TkListLen 2
-    , TkBytes "-/\249\&7"
+    , TkBytes "\208\254\v9"
     , TkInt 0
     , TkInt 1
     , TkListLen 1
     , TkListLen 2
-    , TkBytes "\STX\EOT\140\196$0P\247\158"
+    , TkBytes "\NUL\EOT\140\196$0P\247\158"
     , TkInt 9999999999999998
     , TkInt 2
     , TkInt 1
@@ -347,13 +347,13 @@ test_golden_Block = goldenTestCBOR
     , TkListLen 3
     , TkListLen 2
     , TkBytes "00000214"
-    , TkBytes "6\139\GS\DC200000214"
+    , TkBytes "\219\231w\192\&00000214"
     , TkListLen 2
     , TkBytes "16415019"
-    , TkBytes "6\139\GS\DC216415019"
+    , TkBytes "\219\231w\192\&16415019"
     , TkListLen 2
     , TkBytes "15795584"
-    , TkBytes "6\139\GS\DC215795584"
+    , TkBytes "\219\231w\192\&15795584"
     , TkMapLen 0
     ]
 
@@ -365,7 +365,7 @@ test_golden_Header = goldenTestCBOR
     , TkListLen 15
     , TkInt 2
     , TkInt 20
-    , TkBytes "\191|nI"
+    , TkBytes "\247\SYN\214\203"
     , TkBytes "16260160"
     , TkBytes "16260160"
     , TkListLen 2
@@ -375,21 +375,21 @@ test_golden_Header = goldenTestCBOR
     , TkInt 0
     , TkBytes "16260160q\SYN"
     , TkInt 208
-    , TkBytes "\211W9O"
+    , TkBytes "K\NAK\248\233"
     , TkBytes "16260160"
     , TkInt 0
     , TkInt 0
     , TkBytes "\ETX\148G\SO16260160"
     , TkInt 0
     , TkInt 0
-    , TkBytes "fh\ACK\135o\180w\134\DC3.\146pK\223\129\193\&16260160\NUL\NUL\NUL\NUL\NUL\NUL\NUL\SOH"
+    , TkBytes "\183t\157|\221\192\149\218\169\253\139f\175|\ETXP16260160\NUL\NUL\NUL\NUL\NUL\NUL\NUL\SOH"
     ]
 
 test_golden_HeaderHash :: Assertion
 test_golden_HeaderHash = goldenTestCBOR
     toCBOR
     (blockHash exampleBlock)
-    [ TkBytes "=87\168"
+    [ TkBytes "\CAN\225\"\183"
     ]
 
 test_golden_GenTx :: Assertion
@@ -406,7 +406,7 @@ test_golden_GenTx = goldenTestCBORInCBOR
     , TkInt 1
     , TkListLen 1
     , TkListLen 2
-    , TkBytes "\STX\EOT\140\196$0P\247\158"
+    , TkBytes "\NUL\EOT\140\196$0P\247\158"
     , TkInt 9999999999999726
     , TkInt 2
     , TkInt 3
@@ -472,28 +472,28 @@ test_golden_GenTx = goldenTestCBORInCBOR
     , TkListLen 8
     , TkListLen 2
     , TkBytes "00000214"
-    , TkBytes "9\235\242\239\&00000214"
+    , TkBytes "\237d}\FS00000214"
     , TkListLen 2
     , TkBytes "15485867"
-    , TkBytes "9\235\242\239\&15485867"
+    , TkBytes "\237d}\FS15485867"
     , TkListLen 2
     , TkBytes "15640725"
-    , TkBytes "9\235\242\239\&15640725"
+    , TkBytes "\237d}\FS15640725"
     , TkListLen 2
     , TkBytes "16260160"
-    , TkBytes "9\235\242\239\&16260160"
+    , TkBytes "\237d}\FS16260160"
     , TkListLen 2
     , TkBytes "61943468"
-    , TkBytes "9\235\242\239\&61943468"
+    , TkBytes "\237d}\FS61943468"
     , TkListLen 2
     , TkBytes "15950443"
-    , TkBytes "9\235\242\239\&15950443"
+    , TkBytes "\237d}\FS15950443"
     , TkListLen 2
     , TkBytes "16105301"
-    , TkBytes "9\235\242\239\&16105301"
+    , TkBytes "\237d}\FS16105301"
     , TkListLen 2
     , TkBytes "15795584"
-    , TkBytes "9\235\242\239\&15795584"
+    , TkBytes "\237d}\FS15795584"
     , TkNull
     ]
 
@@ -501,7 +501,8 @@ test_golden_GenTxId :: Assertion
 test_golden_GenTxId = goldenTestCBOR
     toCBOR
     (txId exampleGenTx)
-    [ TkBytes "\253d\142\221" ]
+    [ TkBytes "\245\v\196;"
+    ]
 
 test_golden_ApplyTxErr :: Assertion
 test_golden_ApplyTxErr = goldenTestCBOR
@@ -605,7 +606,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkListLen 3
     , TkListLen 2
     , TkInt 10
-    , TkBytes "*d\157H"
+    , TkBytes "\180G,\222"
     , TkListLen 2
     , TkListLen 1
     , TkInt 0
@@ -639,13 +640,13 @@ test_golden_LedgerState = goldenTestCBOR
     , TkBytes "\157\184\164\ETB"
     , TkInt 1
     , TkListLen 2
-    , TkBytes "\STX\131?\NAK\145\191\152\145\198"
+    , TkBytes "\NUL\131?\NAK\145\191\152\145\198"
     , TkInt 1000000000000000
     , TkListLen 2
-    , TkBytes "\253d\142\221"
+    , TkBytes "\245\v\196;"
     , TkInt 0
     , TkListLen 2
-    , TkBytes "\STX\EOT\140\196$0P\247\158"
+    , TkBytes "\NUL\EOT\140\196$0P\247\158"
     , TkInt 9999999999999726
     , TkInt 271
     , TkInt 3
@@ -830,107 +831,107 @@ test_golden_LedgerState = goldenTestCBOR
     , TkInt 100
     , TkTag 30
     , TkListLen 2
-     , TkInt 0
-     , TkInt 1
-     , TkTag 30
-     , TkListLen 2
-     , TkInt 21
-     , TkInt 10000
-     , TkTag 30
-     , TkListLen 2
-     , TkInt 1
-     , TkInt 5
-     , TkTag 30
-     , TkListLen 2
-     , TkInt 1
-     , TkInt 2
-     , TkListLen 1
-     , TkInt 0
-     , TkInt 0
-     , TkInt 0
-     , TkInt 100
-     , TkListLen 3
-     , TkMapLen 0
-     , TkInt 0
-     , TkListLen 3
-     , TkMapLen 0
-     , TkMapLen 0
-     , TkMapLen 0
-     , TkListLen 0
-     , TkMapLen 0
-     , TkMapLen 7
-     , TkBytes "\CANg\231\ACK"
-     , TkListBegin
-     , TkInt 0
-     , TkInt 14
-     , TkInt 28
-     , TkInt 42
-     , TkInt 56
-     , TkInt 70
-     , TkInt 84
-     , TkInt 98
-     , TkBreak
-     , TkBytes "Rsb\139"
-     , TkListBegin
-     , TkInt 2
-     , TkInt 16
-     , TkInt 30
-     , TkInt 44
-     , TkInt 58
-     , TkInt 72
-     , TkInt 86
-     , TkBreak
-     , TkBytes "u\197c\227"
-     , TkListBegin
-     , TkInt 4
-     , TkInt 18
-     , TkInt 32
-     , TkInt 46
-     , TkInt 60
-     , TkInt 74
-     , TkInt 88
-     , TkBreak
-     , TkBytes "u\200\129\164"
-     , TkListBegin
-     , TkInt 6
-     , TkInt 20
-     , TkInt 34
-     , TkInt 48
-     , TkInt 62
-     , TkInt 76
-     , TkInt 90
-     , TkBreak
-     , TkBytes "\174\134\&0\129"
-     , TkListBegin
-     , TkInt 8
-     , TkInt 22
-     , TkInt 36
-     , TkInt 50
-     , TkInt 64
-     , TkInt 78
-     , TkInt 92
-     , TkBreak
-     , TkBytes "\203\GS\151\&8"
-     , TkListBegin
-     , TkInt 10
-     , TkInt 24
-     , TkInt 38
-     , TkInt 52
-     , TkInt 66
-     , TkInt 80
-     , TkInt 94
-     , TkBreak
-     , TkBytes "\229\221D\172"
-     , TkListBegin
-     , TkInt 12
-     , TkInt 26
-     , TkInt 40
-     , TkInt 54
-     , TkInt 68
-     , TkInt 82
-     , TkInt 96
-     , TkBreak
-     ]
+    , TkInt 0
+    , TkInt 1
+    , TkTag 30
+    , TkListLen 2
+    , TkInt 21
+    , TkInt 10000
+    , TkTag 30
+    , TkListLen 2
+    , TkInt 1
+    , TkInt 5
+    , TkTag 30
+    , TkListLen 2
+    , TkInt 1
+    , TkInt 2
+    , TkListLen 1
+    , TkInt 0
+    , TkInt 0
+    , TkInt 0
+    , TkInt 100
+    , TkListLen 3
+    , TkMapLen 0
+    , TkInt 0
+    , TkListLen 3
+    , TkMapLen 0
+    , TkMapLen 0
+    , TkMapLen 0
+    , TkListLen 0
+    , TkMapLen 0
+    , TkMapLen 7
+    , TkBytes "\CANg\231\ACK"
+    , TkListBegin
+    , TkInt 0
+    , TkInt 14
+    , TkInt 28
+    , TkInt 42
+    , TkInt 56
+    , TkInt 70
+    , TkInt 84
+    , TkInt 98
+    , TkBreak
+    , TkBytes "Rsb\139"
+    , TkListBegin
+    , TkInt 2
+    , TkInt 16
+    , TkInt 30
+    , TkInt 44
+    , TkInt 58
+    , TkInt 72
+    , TkInt 86
+    , TkBreak
+    , TkBytes "u\197c\227"
+    , TkListBegin
+    , TkInt 4
+    , TkInt 18
+    , TkInt 32
+    , TkInt 46
+    , TkInt 60
+    , TkInt 74
+    , TkInt 88
+    , TkBreak
+    , TkBytes "u\200\129\164"
+    , TkListBegin
+    , TkInt 6
+    , TkInt 20
+    , TkInt 34
+    , TkInt 48
+    , TkInt 62
+    , TkInt 76
+    , TkInt 90
+    , TkBreak
+    , TkBytes "\174\134\&0\129"
+    , TkListBegin
+    , TkInt 8
+    , TkInt 22
+    , TkInt 36
+    , TkInt 50
+    , TkInt 64
+    , TkInt 78
+    , TkInt 92
+    , TkBreak
+    , TkBytes "\203\GS\151\&8"
+    , TkListBegin
+    , TkInt 10
+    , TkInt 24
+    , TkInt 38
+    , TkInt 52
+    , TkInt 66
+    , TkInt 80
+    , TkInt 94
+    , TkBreak
+    , TkBytes "\229\221D\172"
+    , TkListBegin
+    , TkInt 12
+    , TkInt 26
+    , TkInt 40
+    , TkInt 54
+    , TkInt 68
+    , TkInt 82
+    , TkInt 96
+    , TkBreak
+    ]
 
 exampleLedgerState :: LedgerState Block
 exampleLedgerState = reapplyLedgerBlock
@@ -1028,7 +1029,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkListLen 3
     , TkListLen 2
     , TkInt 10
-    , TkBytes "*d\157H"
+    , TkBytes "\180G,\222"
     , TkListLen 2
     , TkListLen 1
     , TkInt 0
@@ -1062,13 +1063,13 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkBytes "\157\184\164\ETB"
     , TkInt 1
     , TkListLen 2
-    , TkBytes "\STX\131?\NAK\145\191\152\145\198"
+    , TkBytes "\NUL\131?\NAK\145\191\152\145\198"
     , TkInt 1000000000000000
     , TkListLen 2
-    , TkBytes "\253d\142\221"
+    , TkBytes "\245\v\196;"
     , TkInt 0
     , TkListLen 2
-    , TkBytes "\STX\EOT\140\196$0P\247\158"
+    , TkBytes "\NUL\EOT\140\196$0P\247\158"
     , TkInt 9999999999999726
     , TkInt 271
     , TkInt 3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/bd7eb69d27bfaee46d435bc1d2720520b1446426/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/594f587bfab626a405ac532112cc0b942ad3efdb/snapshot.yaml
 
 packages:
   - ./typed-protocols
@@ -41,7 +41,7 @@ extra-deps:
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 033a66c705a24d2d29732f7fb2fceaa9674b7ba5
+    commit: 9b82346b78e212fcd3e795faf9dd7f3266ab7297
     subdirs:
       - binary
       - binary/test
@@ -49,10 +49,14 @@ extra-deps:
       - slotting
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 61aaa8228b7f9ec4aacd87546849ff610899f6a6
+    commit: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
     subdirs:
       - byron/chain/executable-spec
       - byron/ledger/executable-spec
+      - byron/ledger/impl
+      - byron/ledger/impl/test
+      - byron/crypto
+      - byron/crypto/test
       - semantics/executable-spec
       - shelley/chain-and-ledger/dependencies/non-integer
       - shelley/chain-and-ledger/executable-spec
@@ -64,16 +68,8 @@ extra-deps:
   - moo-1.2
   - gray-code-0.3.1
 
-  - git: https://github.com/input-output-hk/cardano-ledger
-    commit: 9ee8a6630a8719ba54554c3ce10c555bf5dff4cc
-    subdirs:
-      - cardano-ledger
-      - cardano-ledger/test
-      - crypto
-      - crypto/test
-
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: bd7eb69d27bfaee46d435bc1d2720520b1446426
+    commit: 594f587bfab626a405ac532112cc0b942ad3efdb
     subdirs:
       - .
       - test


### PR DESCRIPTION
Specifically, use cardano-ledger-specs version after cardano-ledger
has been merged into it.