### PR TITLE
Refactoring of OuroborosApplication

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -343,17 +343,16 @@ mkApps Tracers {..} Codecs {..} Handlers {..} =
 -- 'OuroborosApplication' for the node-to-client protocols.
 responder
   :: N.NodeToClientVersion
-  -> Apps m peer b b b a
-  -> peer
-  -> OuroborosApplication 'ResponderApp b m Void a
-responder version Apps {..} peer =
+  -> Apps m (ConnectionId peer) b b b a
+  -> OuroborosApplication 'ResponderApp peer b m Void a
+responder version Apps {..} =
     nodeToClientProtocols
-      NodeToClientProtocols {
+      (\peer -> NodeToClientProtocols {
           localChainSyncProtocol =
             (ResponderProtocolOnly (MuxPeerRaw (aChainSyncServer peer))),
           localTxSubmissionProtocol =
             (ResponderProtocolOnly (MuxPeerRaw (aTxSubmissionServer peer))),
           localStateQueryProtocol =
             (ResponderProtocolOnly (MuxPeerRaw (aStateQueryServer peer)))
-        }
+        })
       version

--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -86,9 +86,9 @@ maximumMiniProtocolLimits =
 --
 
 demoProtocol0 :: RunMiniProtocol appType bytes m a b
-              -> OuroborosApplication appType bytes m a b
+              -> OuroborosApplication appType addr bytes m a b
 demoProtocol0 pingPong =
-    OuroborosApplication [
+    OuroborosApplication $ \_connectionId -> [
       MiniProtocol {
         miniProtocolNum    = MiniProtocolNum 2,
         miniProtocolLimits = maximumMiniProtocolLimits,
@@ -105,11 +105,11 @@ clientPingPong pipelined =
       unversionedHandshakeCodec
       cborTermVersionDataCodec
       nullNetworkConnectTracers
-      (unversionedProtocol (\_peerid -> app))
+      (unversionedProtocol app)
       Nothing
       defaultLocalSocketAddr
   where
-    app :: OuroborosApplication InitiatorApp LBS.ByteString IO () Void
+    app :: OuroborosApplication InitiatorApp addr LBS.ByteString IO () Void
     app = demoProtocol0 pingPongInitiator
 
     pingPongInitiator | pipelined =
@@ -145,12 +145,12 @@ serverPingPong =
       unversionedHandshakeCodec
       cborTermVersionDataCodec
       (\(DictVersion _) -> acceptableVersion)
-      (unversionedProtocol (\_peerid -> SomeResponderApplication app))
+      (unversionedProtocol (SomeResponderApplication app))
       nullErrorPolicies
       $ \_ serverAsync ->
         wait serverAsync   -- block until async exception
   where
-    app :: OuroborosApplication ResponderApp LBS.ByteString IO Void ()
+    app :: OuroborosApplication ResponderApp addr LBS.ByteString IO Void ()
     app = demoProtocol0 pingPongResponder
 
     pingPongResponder =
@@ -176,9 +176,9 @@ pingPongServerStandard =
 
 demoProtocol1 :: RunMiniProtocol appType bytes m a b
               -> RunMiniProtocol appType bytes m a b
-              -> OuroborosApplication appType bytes m a b
+              -> OuroborosApplication appType addr bytes m a b
 demoProtocol1 pingPong pingPong' =
-    OuroborosApplication [
+    OuroborosApplication $ \_connectionId -> [
       MiniProtocol {
         miniProtocolNum    = MiniProtocolNum 2,
         miniProtocolLimits = maximumMiniProtocolLimits,
@@ -200,11 +200,11 @@ clientPingPong2 =
       unversionedHandshakeCodec
       cborTermVersionDataCodec
       nullNetworkConnectTracers
-      (unversionedProtocol (\_peerid -> app))
+      (unversionedProtocol app)
       Nothing
       defaultLocalSocketAddr
   where
-    app :: OuroborosApplication InitiatorApp LBS.ByteString IO  () Void
+    app :: OuroborosApplication InitiatorApp addr LBS.ByteString IO  () Void
     app = demoProtocol1 pingpong pingpong'
 
     pingpong =
@@ -253,12 +253,12 @@ serverPingPong2 =
       unversionedHandshakeCodec
       cborTermVersionDataCodec
       (\(DictVersion _) -> acceptableVersion)
-      (unversionedProtocol (\_peerid -> SomeResponderApplication app))
+      (unversionedProtocol (SomeResponderApplication app))
       nullErrorPolicies
       $ \_ serverAsync ->
         wait serverAsync   -- block until async exception
   where
-    app :: OuroborosApplication ResponderApp LBS.ByteString IO Void ()
+    app :: OuroborosApplication ResponderApp addr LBS.ByteString IO Void ()
     app = demoProtocol1 pingpong pingpong'
 
     pingpong =

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -39,6 +39,7 @@ library
                        Ouroboros.Network.Protocol.Handshake.Unversioned
                        Ouroboros.Network.Protocol.Limits
 
+                       Ouroboros.Network.ConnectionId
                        Ouroboros.Network.Server.ConnectionTable
                        Ouroboros.Network.Server.Socket
                        Ouroboros.Network.Server.RateLimiting

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionId.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionId.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DerivingVia         #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE DeriveGeneric       #-}
+
+module Ouroboros.Network.ConnectionId where
+
+import           Cardano.Prelude (UseIsNormalForm (..), NoUnexpectedThunks (..))
+
+import           GHC.Generics (Generic)
+
+
+-- | Connection is identified by local and remote address.
+--
+-- TODO: the type variable which this data type fills in is called `peerid`.  We
+-- should renamed to `connectionId`.
+--
+data ConnectionId addr = ConnectionId {
+    localAddress  :: !addr,
+    remoteAddress :: !addr
+  }
+  deriving (Eq, Ord, Show, Generic)
+  deriving NoUnexpectedThunks via (UseIsNormalForm (ConnectionId addr))

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -61,8 +61,6 @@ module Ouroboros.Network.Socket (
     , sockAddrFamily
     ) where
 
-import           Cardano.Prelude (UseIsNormalForm (..))
-
 import           Control.Concurrent.Async
 import           Control.Exception (IOException, SomeException (..))
 -- TODO: remove this, it will not be needed when `orElse` PR will be merged.
@@ -76,11 +74,8 @@ import qualified Codec.CBOR.Term     as CBOR
 import           Data.Typeable (Typeable)
 import qualified Data.ByteString.Lazy as BL
 import           Data.Void
-import           GHC.Generics (Generic)
 
 import qualified Network.Socket as Socket
-
-import           Cardano.Prelude (NoUnexpectedThunks (..))
 
 import           Control.Tracer
 
@@ -88,6 +83,7 @@ import qualified Network.Mux as Mx
 import Network.Mux.DeltaQ.TraceTransformer
 import           Network.Mux.Types (MuxBearer)
 
+import           Ouroboros.Network.ConnectionId
 import           Ouroboros.Network.Codec hiding (encode, decode)
 import           Ouroboros.Network.Driver.Limits
 import           Ouroboros.Network.Driver (TraceSendRecv)
@@ -142,19 +138,6 @@ sockAddrFamily
 sockAddrFamily (Socket.SockAddrInet  _ _    ) = Socket.AF_INET
 sockAddrFamily (Socket.SockAddrInet6 _ _ _ _) = Socket.AF_INET6
 sockAddrFamily (Socket.SockAddrUnix _       ) = Socket.AF_UNIX
-
-
--- | Connection is identified by local and remote address.
---
--- TODO: the type variable which this data type fills in is called `peerid`.  We
--- should renamed to `connectionId`.
---
-data ConnectionId addr = ConnectionId {
-    localAddress  :: !addr,
-    remoteAddress :: !addr
-  }
-  deriving (Eq, Ord, Show, Generic)
-  deriving NoUnexpectedThunks via (UseIsNormalForm (ConnectionId addr))
 
 
 -- |

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -97,28 +97,25 @@ data DiffusionApplications = DiffusionApplications {
       daResponderApplication      :: Versions
                                        NodeToNodeVersion
                                        DictVersion
-                                       (ConnectionId SockAddr ->
-                                          OuroborosApplication
-                                            ResponderApp
-                                            ByteString IO Void ())
+                                       (OuroborosApplication
+                                         ResponderApp SockAddr
+                                         ByteString IO Void ())
       -- ^ NodeToNode reposnder application (server role)
 
     , daInitiatorApplication      :: Versions
                                        NodeToNodeVersion
                                        DictVersion 
-                                       (ConnectionId SockAddr ->
-                                          OuroborosApplication
-                                            InitiatorApp
-                                            ByteString IO () Void)
+                                       (OuroborosApplication
+                                         InitiatorApp SockAddr
+                                         ByteString IO () Void)
       -- ^ NodeToNode initiator application (client role)
 
     , daLocalResponderApplication :: Versions
                                        NodeToClientVersion
                                        DictVersion
-                                       (ConnectionId LocalAddress ->
-                                          OuroborosApplication
-                                            ResponderApp
-                                            ByteString IO Void ())
+                                       (OuroborosApplication
+                                         ResponderApp LocalAddress
+                                         ByteString IO Void ())
       -- ^ NodeToClient responder applicaton (server role)
 
     , daErrorPolicies :: ErrorPolicies


### PR DESCRIPTION
Instead of using `ConnectionId addr -> OuorborosApplication ...` it redefines the `OuroborosApplication`:

```
newtype OuroborosApplication (appType :: AppType) addr bytes m a b =
      OuroborosApplication (ConnectionId addr -> [MiniProtocol appType bytes m a b])
```

At a later stage we will hide one more argument inside `OuroborosApplicatoin`
newtype wrapper:  the signal `STM` transaction to gracefully terminate client
protocols.

This PR requires #2090 to be merged first (it targets #2090 branch at the moment, just to show adequate diff). 

- Updated ouroboros-consensus
- Updated demo-chain-sync
- Updated ouroboros-network (lib & tests)
- Updated demo-ping-pong
- OuroborosApplicaiton
- Put ConnectionId in its own module.
