### PR TITLE
Update dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -159,71 +159,71 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
-  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  tag: b687fa55369f480cb134c007e534662bef961cea
+  --sha256: 1bwbrj22a0nmsw990ac8k4ffz4xdazfb85dyl3lv3pa5yp3svw1j
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
-  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  tag: b687fa55369f480cb134c007e534662bef961cea
+  --sha256: 1bwbrj22a0nmsw990ac8k4ffz4xdazfb85dyl3lv3pa5yp3svw1j
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
-  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  tag: b687fa55369f480cb134c007e534662bef961cea
+  --sha256: 1bwbrj22a0nmsw990ac8k4ffz4xdazfb85dyl3lv3pa5yp3svw1j
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
-  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  tag: b687fa55369f480cb134c007e534662bef961cea
+  --sha256: 1bwbrj22a0nmsw990ac8k4ffz4xdazfb85dyl3lv3pa5yp3svw1j
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
-  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  tag: b687fa55369f480cb134c007e534662bef961cea
+  --sha256: 1bwbrj22a0nmsw990ac8k4ffz4xdazfb85dyl3lv3pa5yp3svw1j
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
-  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  tag: b687fa55369f480cb134c007e534662bef961cea
+  --sha256: 1bwbrj22a0nmsw990ac8k4ffz4xdazfb85dyl3lv3pa5yp3svw1j
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
-  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  tag: b687fa55369f480cb134c007e534662bef961cea
+  --sha256: 1bwbrj22a0nmsw990ac8k4ffz4xdazfb85dyl3lv3pa5yp3svw1j
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
-  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  tag: b687fa55369f480cb134c007e534662bef961cea
+  --sha256: 1bwbrj22a0nmsw990ac8k4ffz4xdazfb85dyl3lv3pa5yp3svw1j
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
-  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  tag: b687fa55369f480cb134c007e534662bef961cea
+  --sha256: 1bwbrj22a0nmsw990ac8k4ffz4xdazfb85dyl3lv3pa5yp3svw1j
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
-  --sha256: 1ddrh60ywhmwhizbr7rz2h27lvirz0lf6ccjgbd94z3i5vx88bxb
+  tag: b687fa55369f480cb134c007e534662bef961cea
+  --sha256: 1bwbrj22a0nmsw990ac8k4ffz4xdazfb85dyl3lv3pa5yp3svw1j
   subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -49,6 +49,7 @@ import qualified Shelley.Spec.Ledger.Keys as SL
 import qualified Shelley.Spec.Ledger.PParams as SL
 import qualified Shelley.Spec.Ledger.STS.Chain as STS
 import qualified Shelley.Spec.Ledger.STS.Ledger as STS
+import qualified Shelley.Spec.Ledger.STS.Ledgers as STS
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ConcreteCrypto)
 import qualified Test.Shelley.Spec.Ledger.Examples as Examples

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
@@ -22,6 +22,7 @@ import qualified Shelley.Spec.Ledger.Delegation.Certificates as SL
 import qualified Shelley.Spec.Ledger.Keys as SL
 import qualified Shelley.Spec.Ledger.PParams as SL
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (hashKeyVRF)
+import           Test.Shelley.Spec.Ledger.Orphans ()
 
 import           Ouroboros.Consensus.Shelley.Ledger
 
@@ -671,7 +672,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkInt 0
     , TkBytes "\144&R("
     , TkInt 99
-    , TkListLen 3
+    , TkListLen 4
     , TkMapLen 1
     , TkBytes "0P\247\158"
     , TkInt 10
@@ -695,6 +696,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkListLen 2
     , TkString "alice.pool"
     , TkBytes "{}"
+    , TkMapLen 0
     , TkMapLen 0
     , TkListLen 21
     , TkInt 0
@@ -1040,7 +1042,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkInt 0
     , TkBytes "\144&R("
     , TkInt 99
-    , TkListLen 3
+    , TkListLen 4
     , TkMapLen 1
     , TkBytes "0P\247\158"
     , TkInt 10
@@ -1064,6 +1066,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkListLen 2
     , TkString "alice.pool"
     , TkBytes "{}"
+    , TkMapLen 0
     , TkMapLen 0
     , TkListLen 21
     , TkInt 0

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -97,7 +97,8 @@ initialFundsPseudoTxIn addr =
     case addr of
       SL.Addr (SL.KeyHashObj    (SL.KeyHash    h)) _sref -> pseudoTxIn h
       SL.Addr (SL.ScriptHashObj (SL.ScriptHash h)) _sref -> pseudoTxIn h
-      SL.AddrBootstrap          (SL.KeyHash    h)        -> pseudoTxIn h
+      SL.AddrBootstrap byronAddr -> error $
+        "Unsupported Byron address in the genesis UTxO: " <> show byronAddr
   where
     pseudoTxIn :: Crypto.Hash (HASH c) a -> SL.TxIn c
     pseudoTxIn h = SL.TxIn (pseudoTxId h) 0

--- a/stack.yaml
+++ b/stack.yaml
@@ -49,7 +49,7 @@ extra-deps:
       - slotting
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 1a7bbd7266d6865bcfd75b1b1029a67fac088dd0
+    commit: b687fa55369f480cb134c007e534662bef961cea
     subdirs:
       - byron/chain/executable-spec
       - byron/ledger/executable-spec


### PR DESCRIPTION
Still not working. Building `network` I get:
```
src/Ouroboros/Consensus/Shelley/Node.hs:100:34: error:
    • Couldn't match expected type ‘cardano-ledger-0.1.0.0:Cardano.Chain.Common.Address.Address’
                  with actual type ‘SL.KeyHash discriminator0 crypto0’
    • In the pattern: SL.KeyHash h
      In the pattern: SL.AddrBootstrap (SL.KeyHash h)
      In a case alternative:
          SL.AddrBootstrap (SL.KeyHash h) -> pseudoTxIn h
    |
100 |       SL.AddrBootstrap          (SL.KeyHash    h)        -> pseudoTxIn h
```

Would also want  https://github.com/input-output-hk/cardano-ledger-specs/pull/1477 and https://github.com/input-output-hk/cardano-ledger-specs/pull/1476