### PR TITLE
Add cardano-client to the required CI builds

### DIFF
--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -30,3 +30,13 @@ library
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
+
+test-suite test-cardano-client
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  default-language:    Haskell2010
+  build-depends:       base,
+                       tasty,
+                       cardano-client
+  ghc-options:         -Wall

--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -1,3 +1,4 @@
+just break it
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -1,4 +1,3 @@
-just break it
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/cardano-client/test/Main.hs
+++ b/cardano-client/test/Main.hs
@@ -1,0 +1,13 @@
+module Main
+where
+import Test.Tasty (defaultMain, testGroup)
+import Cardano.Client.Subscription ()
+
+-- At the moment, there are no reasonable tests for the cardano-client library.
+-- However the dummy test-suite is still needed because,
+-- the CI generates the set of required builds bases on the test-suits.
+-- A dummy test-suite is the easiest way to make the cardano-client library a required build.
+-- Real tests may be added later.
+
+main :: IO ()
+main = defaultMain $ testGroup "cardano-client-tests" []

--- a/shell.nix
+++ b/shell.nix
@@ -36,6 +36,7 @@ let
        io-sim
        io-sim-classes
        ntp-client
+       cardano-client
     ];
 
     # These programs will be available inside the nix-shell.

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,6 +18,7 @@ packages:
   - ./io-sim-classes
   - ./ntp-client
   - ./Win32-network
+  - ./cardano-client
 
 flags:
   io-sim-classes:


### PR DESCRIPTION
By default CI picks up all test-suites as required build.
There are no reasonable tests for the cardano-client library at the moment.
This add a dummy test-suite to still make it a required build.