### PR TITLE
Add Golden tests for HashInfo

### DIFF
--- a/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Golden.hs
+++ b/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Golden.hs
@@ -5,6 +5,8 @@ module Test.Consensus.Byron.Golden (tests) where
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.FlatTerm (FlatTerm, TermToken (..))
 import           Codec.CBOR.Read (deserialiseFromBytes)
+import qualified Data.Binary.Put as Put
+import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -14,6 +16,8 @@ import qualified Cardano.Chain.Update as CC
 import qualified Cardano.Chain.Update.Validation.Endorsement as CC
 import qualified Cardano.Chain.Update.Validation.Interface as CC.UPI
 import qualified Cardano.Chain.Update.Validation.Registration as CC
+
+import           Ouroboros.Consensus.Storage.ImmutableDB.API (HashInfo (..))
 
 import           Ouroboros.Consensus.Byron.Ledger
 
@@ -44,6 +48,7 @@ tests = testGroup "Golden tests"
     , testCase "ExtLedgerState" test_golden_ExtLedgerState
     , testCase "Query"          test_golden_Query
     , testCase "Result"         test_golden_Result
+    , testCase "HashInfo"       test_golden_HashInfo
     ]
 
 test_golden_ConsensusState :: Assertion
@@ -1132,6 +1137,16 @@ test_golden_Result = goldenTestCBOR
       , TkBytes "r#\ESC\141\CAN\213_f7Y\FS-q\252G\164'\156\180f\250PY\210\235\188|\138\DC2 \250\236"
       , TkInt 0
       ]
+
+test_golden_HashInfo :: Assertion
+test_golden_HashInfo = goldenTestCBOR
+    encodeHashWithHashInfo
+    exampleHeaderHash
+    [ TkBytes "y\USBV\225Lg\185\ETX\\;\128\160\130j\223q\157\&66\193\142\239\SYN\201\139\132\184\&3r=Q"
+    ]
+  where
+    encodeHashWithHashInfo =
+      toCBOR . Builder.toLazyByteString . Put.execPut . putHash byronHashInfo
 
 -- | Check whether we can successfully decode the contents of the given file.
 -- This file will typically contain an older serialisation format.

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
@@ -6,6 +6,8 @@
 module Test.Consensus.Shelley.Golden (tests) where
 
 import           Codec.CBOR.FlatTerm (FlatTerm, TermToken (..))
+import qualified Data.Binary.Put as Put
+import qualified Data.ByteString.Builder as Builder
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -15,6 +17,7 @@ import           Ouroboros.Network.Block (Point (..))
 import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Storage.ImmutableDB.API (HashInfo (..))
 
 import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
 import qualified Shelley.Spec.Ledger.Credential as SL
@@ -51,6 +54,7 @@ tests = testGroup "Golden tests"
     , testCase "ExtLedgerState" test_golden_ExtLedgerState
     , testQueries
     , testResults
+    , testCase "HashInfo"       test_golden_HashInfo
     ]
 
 testQueries :: TestTree
@@ -1271,3 +1275,13 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkListLen 0
     , TkListLen 0
     ]
+
+test_golden_HashInfo :: Assertion
+test_golden_HashInfo = goldenTestCBOR
+    encodeHashWithHashInfo
+    exampleHeaderHash
+    [ TkBytes "\CAN\225\"\183"
+    ]
+  where
+    encodeHashWithHashInfo =
+      toCBOR . Builder.toLazyByteString . Put.execPut . putHash shelleyHashInfo


### PR DESCRIPTION
https://github.com/input-output-hk/ouroboros-network/issues/1889

Here we only add tests for the `HashHeader` serialized by the `HashInfo`.
The immutable db uses the `HashInfo` to serialize the whole `Entry hash`.
With the help of https://github.com/input-output-hk/cardano-prelude/pull/105, in the future we can have more complete golden tests. 