### PR TITLE
typed-protocols:  allow compilation with GHC 8.10.1

### DIFF
--- a/typed-protocols/src/Network/TypedProtocol/Proofs.hs
+++ b/typed-protocols/src/Network/TypedProtocol/Proofs.hs
@@ -139,7 +139,7 @@ connect = go
 -- 'connectPipelined' to return the states in which the peers terminated.
 --
 data TerminalStates ps where
-     TerminalStates :: forall (st :: ps).
+     TerminalStates :: forall ps (st :: ps).
                        NobodyHasAgency st
                     -> NobodyHasAgency st
                     -> TerminalStates ps


### PR DESCRIPTION
..which otherwise fails:

src/Network/TypedProtocol/Proofs.hs:142:38: error:
    Not in scope: type variable ‘ps’
    |
142 |      TerminalStates :: forall (st :: ps).
    |                                      ^^

src/Network/TypedProtocol/Proofs.hs:145:39: error:
    Not in scope: type variable ‘ps’
    |
145 |                     -> TerminalStates ps
    |                                       ^^