### PR TITLE
Pass only BlockConfig to nodeStartTime/NetworkMagic/ProtocolMagicId

### DIFF
--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -73,8 +73,9 @@ versionedProtocols ::
 versionedProtocols blkProxy topLevelConfig p
   = foldMapVersions applyVersion $ supportedNodeToClientVersions blkProxy
   where
+    blockConfig = configBlock topLevelConfig
     applyVersion v =
       versionedNodeToClientProtocols
         (nodeToClientProtocolVersion blkProxy v)
-        (NodeToClientVersionData { networkMagic = nodeNetworkMagic topLevelConfig })
-        (p v $ clientCodecs ( getCodecConfig $ configBlock topLevelConfig) v)
+        (NodeToClientVersionData { networkMagic = nodeNetworkMagic blockConfig })
+        (p v $ clientCodecs (getCodecConfig blockConfig) v)

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -230,9 +230,9 @@ instance RunNode DualByronBlock where
 
   -- Node config is a consensus concern, determined by the main block only
   nodeImmDbChunkInfo  = nodeImmDbChunkInfo  . dualTopLevelConfigMain
-  nodeStartTime       = nodeStartTime       . dualTopLevelConfigMain
-  nodeNetworkMagic    = nodeNetworkMagic    . dualTopLevelConfigMain
-  nodeProtocolMagicId = nodeProtocolMagicId . dualTopLevelConfigMain
+  nodeStartTime       = nodeStartTime       . dualBlockConfigMain
+  nodeNetworkMagic    = nodeNetworkMagic    . dualBlockConfigMain
+  nodeProtocolMagicId = nodeProtocolMagicId . dualBlockConfigMain
 
   -- The max block size we set to the max block size of the /concrete/ block
   -- (Correspondingly, 'txSize' for the Byron spec returns 0)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -202,6 +202,7 @@ instance RunNode ByronBlock where
                                 . kEpochSlots
                                 . Genesis.gdK
                                 . extractGenesisData
+                                . configBlock
                                 $ cfg
 
   nodeMaxBlockSize          = API.getMaxBlockSize . byronLedgerState
@@ -274,7 +275,6 @@ instance RunNode ByronBlock where
   nodeDecodeResult          = decodeByronResult
 
 
-extractGenesisData :: TopLevelConfig ByronBlock -> Genesis.GenesisData
+extractGenesisData :: BlockConfig ByronBlock -> Genesis.GenesisData
 extractGenesisData = Genesis.configGenesisData
                    . byronGenesisConfig
-                   . configBlock

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -36,6 +36,7 @@ import           Cardano.Chain.Slotting (EpochSlots)
 import qualified Cardano.Chain.Update as Update
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
@@ -189,7 +190,7 @@ protocolInfo (ProtocolRealTPraos genesis protVer mbLeaderCredentials) =
 protocolInfo (ProtocolCardano genesis protVer mbLeaderCredentials) =
     castProtocolInfo $
       injProtocolInfo
-        (nodeStartTime (pInfoConfig shelleyProtocolInfo))
+        (nodeStartTime (configBlock (pInfoConfig shelleyProtocolInfo)))
         shelleyProtocolInfo
   where
     shelleyProtocolInfo :: ProtocolInfo (ShelleyBlock TPraosStandardCrypto)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -323,9 +323,9 @@ instance TPraosCrypto c => RunNode (ShelleyBlock c) where
     . tpraosParams
     . configConsensus
 
-  nodeStartTime       = shelleyStartTime       . configBlock
-  nodeNetworkMagic    = shelleyNetworkMagic    . configBlock
-  nodeProtocolMagicId = shelleyProtocolMagicId . configBlock
+  nodeStartTime       = shelleyStartTime
+  nodeNetworkMagic    = shelleyNetworkMagic
+  nodeProtocolMagicId = shelleyProtocolMagicId
 
   nodeHashInfo = const shelleyHashInfo
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
@@ -23,7 +23,7 @@ import           Ouroboros.Consensus.Protocol.Abstract
 -- | Protocol specific functionality required to run consensus with mock blocks
 class MockProtocolSpecific c ext => RunMockBlock c ext where
   mockProtocolMagicId
-    :: TopLevelConfig (SimpleBlock c ext)
+    :: BlockConfig (SimpleBlock c ext)
     -> ProtocolMagicId
   mockEncodeConsensusState
     :: TopLevelConfig (SimpleBlock c ext)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -161,7 +161,7 @@ run runargs@RunNodeArgs{..} =
           inFuture = InFuture.reference
                        (configLedger cfg)
                        rnMaxClockSkew
-                       (defaultSystemTime $ nodeStartTime cfg)
+                       (defaultSystemTime $ nodeStartTime (configBlock cfg))
 
       let customiseChainDbArgs' args
             | lastShutDownWasClean
@@ -186,7 +186,7 @@ run runargs@RunNodeArgs{..} =
       btime <- hardForkBlockchainTime
                  registry
                  (blockchainTimeTracer rnTraceConsensus)
-                 (defaultSystemTime $ nodeStartTime cfg)
+                 (defaultSystemTime $ nodeStartTime (configBlock cfg))
                  (configLedger cfg)
                  (ledgerState <$> ChainDB.getCurrentLedger chainDB)
 
@@ -303,7 +303,7 @@ withDBChecks RunNodeArgs{..} body = do
     either throwM return =<< checkDbMarker
       hasFS
       mountPoint
-      (nodeProtocolMagicId pInfoConfig)
+      (nodeProtocolMagicId (configBlock pInfoConfig))
 
     -- Then create the lock file.
     withLockDB mountPoint $ do

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -60,9 +60,10 @@ class ( LedgerSupportsProtocol    blk
   nodeIsEBB               :: Header blk -> Maybe EpochNo
 
   nodeImmDbChunkInfo      :: TopLevelConfig blk -> ChunkInfo
-  nodeStartTime           :: TopLevelConfig blk -> SystemStart
-  nodeNetworkMagic        :: TopLevelConfig blk -> NetworkMagic
-  nodeProtocolMagicId     :: TopLevelConfig blk -> ProtocolMagicId
+
+  nodeStartTime           :: BlockConfig blk -> SystemStart
+  nodeNetworkMagic        :: BlockConfig blk -> NetworkMagic
+  nodeProtocolMagicId     :: BlockConfig blk -> ProtocolMagicId
 
   -- | Hash serialisation
   nodeHashInfo :: Proxy blk -> HashInfo (HeaderHash blk)


### PR DESCRIPTION
None of the implementations ever needed more than the `BlockConfig`. So
replace `TopLevelConfig` with `BlockConfig` in those methods.

This makes it easier to define those methods for a non-degenerate hard-fork,
where we can't always project out an era-specific `TopLevelConfig` from the
hard-fork one, because of the partial configs. We can trivially project out
the era-specific `BlockConfig`s, though.