### PR TITLE
Refactor BlockHasCodecConfig into ConfigSupportsNode

### DIFF
--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -13,7 +13,7 @@ import           Ouroboros.Consensus.Config (TopLevelConfig, configBlock)
 import           Ouroboros.Consensus.Network.NodeToClient (clientCodecs, ClientCodecs)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion (
                     nodeToClientProtocolVersion , supportedNodeToClientVersions)
-import           Ouroboros.Consensus.Node.Run (RunNode, nodeNetworkMagic)
+import           Ouroboros.Consensus.Node.Run (RunNode)
 import           Ouroboros.Network.Mux (AppType (..), OuroborosApplication)
 import           Ouroboros.Network.NodeToClient (ClientSubscriptionParams (..),
                     ConnectionId, LocalAddress,
@@ -31,8 +31,8 @@ import qualified Ouroboros.Network.Snocket as Snocket
 import qualified Ouroboros.Network.NodeToClient (NodeToClientVersion)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Prelude
-import           Ouroboros.Consensus.Block.Abstract (getCodecConfig)
-  
+import           Ouroboros.Consensus.Config.SupportsNode (getCodecConfig, getNetworkMagic)
+
 subscribe ::
   ( RunNode blk , MonadST m )
   => Snocket.LocalSnocket
@@ -77,5 +77,5 @@ versionedProtocols blkProxy topLevelConfig p
     applyVersion v =
       versionedNodeToClientProtocols
         (nodeToClientProtocolVersion blkProxy v)
-        (NodeToClientVersionData { networkMagic = nodeNetworkMagic blockConfig })
+        (NodeToClientVersionData { networkMagic = getNetworkMagic blockConfig })
         (p v $ clientCodecs (getCodecConfig blockConfig) v)

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -53,7 +53,6 @@ import qualified Ouroboros.Consensus.Protocol.PBFT.State as S
 import qualified Ouroboros.Consensus.Storage.ChainDB.Init as InitChainDB
 
 import           Ouroboros.Consensus.Byron.Ledger
-import           Ouroboros.Consensus.Byron.Ledger.Config (byronEpochSlots)
 import           Ouroboros.Consensus.Byron.Node
 import           Ouroboros.Consensus.Byron.Protocol
 
@@ -230,9 +229,6 @@ instance RunNode DualByronBlock where
 
   -- Node config is a consensus concern, determined by the main block only
   nodeImmDbChunkInfo  = nodeImmDbChunkInfo  . dualTopLevelConfigMain
-  nodeStartTime       = nodeStartTime       . dualBlockConfigMain
-  nodeNetworkMagic    = nodeNetworkMagic    . dualBlockConfigMain
-  nodeProtocolMagicId = nodeProtocolMagicId . dualBlockConfigMain
 
   -- The max block size we set to the max block size of the /concrete/ block
   -- (Correspondingly, 'txSize' for the Byron spec returns 0)
@@ -313,7 +309,7 @@ instance RunNode DualByronBlock where
   nodeDecodeResult         = \case {}
 
 extractEpochSlots :: CodecConfig DualByronBlock -> EpochSlots
-extractEpochSlots = byronEpochSlots . dualCodecConfigMain
+extractEpochSlots = getByronEpochSlots . dualCodecConfigMain
 
 {-------------------------------------------------------------------------------
   The headers for DualByronBlock and ByronBlock are identical, so we can

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
@@ -8,10 +8,10 @@
 
 module Ouroboros.Consensus.Byron.Ledger.Config (
     BlockConfig(..)
-  , CodecConfig(..)
   , byronGenesisHash
   , byronProtocolMagicId
   , byronProtocolMagic
+  , byronEpochSlots
   ) where
 
 import           GHC.Generics (Generic)
@@ -24,6 +24,7 @@ import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Crypto as Crypto
 
 import           Ouroboros.Consensus.Block
+
 import           Ouroboros.Consensus.Byron.Ledger.Block
 
 -- | Extended configuration we need for Byron
@@ -45,16 +46,6 @@ data instance BlockConfig ByronBlock = ByronConfig {
     }
   deriving (Generic, NoUnexpectedThunks)
 
-data instance CodecConfig ByronBlock = ByronCodecConfig {
-  byronEpochSlots :: CC.Slot.EpochSlots
-} deriving (Generic, NoUnexpectedThunks)
-
-instance BlockHasCodecConfig ByronBlock where
-  getCodecConfig ByronConfig { byronGenesisConfig }
-    = ByronCodecConfig
-      { byronEpochSlots = CC.Genesis.configEpochSlots byronGenesisConfig
-      }
-
 byronGenesisHash :: BlockConfig ByronBlock -> CC.Genesis.GenesisHash
 byronGenesisHash = CC.Genesis.configGenesisHash . byronGenesisConfig
 
@@ -63,3 +54,6 @@ byronProtocolMagicId = Crypto.getProtocolMagicId . byronProtocolMagic
 
 byronProtocolMagic :: BlockConfig ByronBlock -> Crypto.ProtocolMagic
 byronProtocolMagic = CC.Genesis.configProtocolMagic . byronGenesisConfig
+
+byronEpochSlots :: BlockConfig ByronBlock -> CC.Slot.EpochSlots
+byronEpochSlots = CC.Genesis.configEpochSlots . byronGenesisConfig

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
@@ -76,4 +76,8 @@ instance ValidateEnvelope ByronBlock where
       canBeEBB (SlotNo s) = s `mod` epochSlots == 0
 
       epochSlots :: Word64
-      epochSlots = CC.unEpochSlots $ byronEpochSlots $ configCodec cfg
+      epochSlots =
+          CC.unEpochSlots
+        . byronEpochSlots
+        . configBlock
+        $ cfg

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
@@ -74,7 +74,7 @@ instance BlockSupportsProtocol ByronBlock where
                (CC.recoverSignedBytes epochSlots regular)
                (mkByronContextDSIGN cfg (pbftGenKey pbftFields))
     where
-      epochSlots = byronEpochSlots $ getCodecConfig cfg
+      epochSlots = byronEpochSlots cfg
 
   selectView _ hdr = (blockNo hdr, byronHeaderIsEBB hdr)
 

--- a/ouroboros-consensus-byron/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-byron/tools/db-analyser/Main.hs
@@ -36,6 +36,7 @@ import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..),
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
@@ -350,16 +351,16 @@ withImmDB :: FilePath
           -> IO a
 withImmDB fp cfg chunkInfo registry = ImmDB.withImmDB args
   where
-    bcfg = configCodec cfg
+    ccfg = getCodecConfig $ configBlock cfg
     pb   = Proxy @ByronBlock
 
     args :: ImmDbArgs IO ByronBlock
     args = (defaultArgs fp) {
           immDecodeHash     = nodeDecodeHeaderHash    pb
-        , immDecodeBlock    = nodeDecodeBlock         bcfg
-        , immDecodeHeader   = nodeDecodeHeader        bcfg SerialisedToDisk
+        , immDecodeBlock    = nodeDecodeBlock         ccfg
+        , immDecodeHeader   = nodeDecodeHeader        ccfg SerialisedToDisk
         , immEncodeHash     = nodeEncodeHeaderHash    pb
-        , immEncodeBlock    = nodeEncodeBlockWithInfo bcfg
+        , immEncodeBlock    = nodeEncodeBlockWithInfo ccfg
         , immChunkInfo      = chunkInfo
         , immHashInfo       = nodeHashInfo            pb
         , immValidation     = ValidateMostRecentChunk

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
@@ -94,7 +94,3 @@ instance HasHeader ByronSpecHeader where
 -------------------------------------------------------------------------------}
 
 data instance BlockConfig ByronSpecBlock = ByronSpecBlockConfig
-data instance CodecConfig ByronSpecBlock = ByronSpecCodecConfig
-
-instance BlockHasCodecConfig ByronSpecBlock where
-  getCodecConfig = const ByronSpecCodecConfig

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -37,6 +37,7 @@ import qualified Cardano.Chain.Update as Update
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Config.SupportsNode
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
@@ -190,7 +191,7 @@ protocolInfo (ProtocolRealTPraos genesis protVer mbLeaderCredentials) =
 protocolInfo (ProtocolCardano genesis protVer mbLeaderCredentials) =
     castProtocolInfo $
       injProtocolInfo
-        (nodeStartTime (configBlock (pInfoConfig shelleyProtocolInfo)))
+        (getSystemStart (configBlock (pInfoConfig shelleyProtocolInfo)))
         shelleyProtocolInfo
   where
     shelleyProtocolInfo :: ProtocolInfo (ShelleyBlock TPraosStandardCrypto)

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -80,7 +80,7 @@ prop_simple_cardano_convergence k d
             , nodeInfo    = \(CoreNodeId nid) ->
               plainTestNodeInitialization @(CardanoBlock TPraosMockCrypto) $
                 castProtocolInfo $ injProtocolInfo
-                  (sgStartTime genesisConfig)
+                  (sgSystemStart genesisConfig)
                   (mkProtocolRealTPraos
                     genesisConfig
                     (coreNodes !! fromIntegral nid))

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -75,7 +75,7 @@ testEpochInfo = SL.epochInfo SL.testGlobals
 -- | These are dummy values.
 testShelleyGenesis :: ShelleyGenesis c
 testShelleyGenesis = ShelleyGenesis {
-      sgStartTime         = SystemStart $ UTCTime (fromGregorian 2020 5 14) 0
+      sgSystemStart       = SystemStart $ UTCTime (fromGregorian 2020 5 14) 0
     , sgNetworkMagic      = NetworkMagic 0
     , sgNetworkId         = SL.Testnet
     , sgProtocolMagicId   = ProtocolMagicId 0

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -160,7 +160,7 @@ mkGenesisConfig
   -> ShelleyGenesis c
 mkGenesisConfig k d maxKESEvolutions coreNodes = ShelleyGenesis {
       -- Matches the start of the ThreadNet tests
-      sgStartTime             = SystemStart dawnOfTime
+      sgSystemStart           = SystemStart dawnOfTime
     , sgNetworkMagic          = NetworkMagic 0
     , sgNetworkId             = networkId
     , sgProtocolMagicId       = ProtocolMagicId 0

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Genesis.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Genesis.hs
@@ -72,7 +72,7 @@ emptyGenesisStaking = ShelleyGenesisStaking
 -- transition naturally from Byron, and thus will never have its own genesis
 -- information.
 data ShelleyGenesis c = ShelleyGenesis {
-      sgStartTime             :: !SystemStart
+      sgSystemStart           :: !SystemStart
     , sgNetworkMagic          :: !NetworkMagic
     , sgNetworkId             :: !SL.Network
     , sgProtocolMagicId       :: !ProtocolMagicId

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
@@ -5,7 +5,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Shelley.Ledger.Config (
     BlockConfig (..)
-  , CodecConfig (..)
   ) where
 
 import           GHC.Generics (Generic)
@@ -30,17 +29,9 @@ data instance BlockConfig (ShelleyBlock c) = ShelleyConfig {
       -- | The highest protocol version this node supports. It will be stored
       -- the headers of produced blocks.
       shelleyProtocolVersion :: !SL.ProtVer
-    , shelleyStartTime       :: !SystemStart
+    , shelleySystemStart     :: !SystemStart
     , shelleyNetworkMagic    :: !NetworkMagic
     , shelleyProtocolMagicId :: !ProtocolMagicId
     }
   deriving stock (Show, Generic)
   deriving anyclass NoUnexpectedThunks
-
--- | No particular codec configuration is needed for Shelley
-data instance CodecConfig (ShelleyBlock c) = ShelleyCodecConfig
-  deriving stock (Show, Generic)
-  deriving anyclass NoUnexpectedThunks
-
-instance BlockHasCodecConfig (ShelleyBlock c) where
-  getCodecConfig = const ShelleyCodecConfig

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -250,13 +250,6 @@ instance (SimpleCrypto c, Typeable ext) => ValidateEnvelope (SimpleBlock c ext)
 data instance BlockConfig (SimpleBlock c ext) = SimpleBlockConfig
   deriving (Generic, NoUnexpectedThunks)
 
--- | No additional codec information is required for simple blocks
-data instance CodecConfig (SimpleBlock c ext) = SimpleCodecConfig
-  deriving (Generic, NoUnexpectedThunks)
-
-instance BlockHasCodecConfig (SimpleBlock c ext) where
-  getCodecConfig = const SimpleCodecConfig
-
 instance HasHardForkHistory (SimpleBlock c ext) where
   type HardForkIndices (SimpleBlock c ext) = '[SimpleBlock c ext]
   hardForkSummary = neverForksHardForkSummary simpleLedgerEraParams

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -262,12 +262,6 @@ data instance BlockConfig TestBlock = TestBlockConfig {
     }
   deriving (Generic, NoUnexpectedThunks)
 
-data instance CodecConfig TestBlock = TestCodecConfig
-  deriving (Generic, NoUnexpectedThunks)
-
-instance BlockHasCodecConfig TestBlock where
-  getCodecConfig = const TestCodecConfig
-
 instance HasNetworkProtocolVersion TestBlock where
   -- Use defaults
 

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -44,6 +44,7 @@ library
                        Ouroboros.Consensus.BlockchainTime.WallClock.Types
                        Ouroboros.Consensus.BlockchainTime.WallClock.Util
                        Ouroboros.Consensus.Config
+                       Ouroboros.Consensus.Config.SupportsNode
                        Ouroboros.Consensus.Config.SecurityParam
                        Ouroboros.Consensus.Forecast
                        Ouroboros.Consensus.Fragment.Diff
@@ -61,6 +62,7 @@ library
                        Ouroboros.Consensus.HardFork.Combinator.Ledger
                        Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
                        Ouroboros.Consensus.HardFork.Combinator.Mempool
+                       Ouroboros.Consensus.HardFork.Combinator.Node
                        Ouroboros.Consensus.HardFork.Combinator.PartialConfig
                        Ouroboros.Consensus.HardFork.Combinator.Protocol
                        Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -7,8 +7,6 @@ module Ouroboros.Consensus.Block.Abstract (
     BlockProtocol
     -- * Configuration
   , BlockConfig
-  , CodecConfig
-  , BlockHasCodecConfig(..)
     -- * Working with headers
   , GetHeader(..)
   , headerHash
@@ -33,16 +31,8 @@ type family BlockProtocol blk :: *
   Configuration
 -------------------------------------------------------------------------------}
 
--- | Static configuration required for serialisation and deserialisation of
---   types pertaining to this type of block
-data family CodecConfig blk :: *
-
 -- | Static configuration required to work with this type of blocks
 data family BlockConfig blk :: *
-
--- | The codec configuration is a subset of the block configuration
-class BlockHasCodecConfig blk where
-  getCodecConfig :: BlockConfig blk -> CodecConfig blk
 
 {-------------------------------------------------------------------------------
   Link block to its header

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
@@ -24,7 +24,6 @@ class ( GetHeader blk
       , ConsensusProtocol (BlockProtocol blk)
       , NoUnexpectedThunks (Header blk)
       , NoUnexpectedThunks (BlockConfig blk)
-      , BlockHasCodecConfig blk
       ) => BlockSupportsProtocol blk where
   validateView :: BlockConfig blk
                -> Header blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
@@ -7,7 +7,6 @@
 module Ouroboros.Consensus.Config (
     TopLevelConfig(..)
   , configSecurityParam
-  , configCodec
   , castTopLevelConfig
   ) where
 
@@ -36,12 +35,6 @@ instance ( ConsensusProtocol  (BlockProtocol blk)
 configSecurityParam :: ConsensusProtocol (BlockProtocol blk)
                     => TopLevelConfig blk -> SecurityParam
 configSecurityParam = protocolSecurityParam . configConsensus
-
-configCodec
-  :: BlockHasCodecConfig blk
-  => TopLevelConfig blk
-  -> CodecConfig blk
-configCodec = getCodecConfig . configBlock
 
 castTopLevelConfig :: ( Coercible (ConsensusConfig (BlockProtocol blk))
                                   (ConsensusConfig (BlockProtocol blk'))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config/SupportsNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config/SupportsNode.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE TypeFamilies #-}
+module Ouroboros.Consensus.Config.SupportsNode (
+    ConfigSupportsNode (..)
+  ) where
+
+import           Cardano.Crypto (ProtocolMagicId)
+
+import           Ouroboros.Network.Magic (NetworkMagic)
+
+import           Ouroboros.Consensus.Block.Abstract (BlockConfig)
+import           Ouroboros.Consensus.BlockchainTime (SystemStart)
+
+-- | The 'BlockConfig' needs to contain some information in order to support
+-- running a node.
+class ConfigSupportsNode blk where
+
+  -- | Static configuration required for serialisation and deserialisation of
+  -- types pertaining to this type of block.
+  --
+  -- Data family instead of type family to get better type inference.
+  data family CodecConfig blk :: *
+
+  getCodecConfig     :: BlockConfig blk -> CodecConfig blk
+  getSystemStart     :: BlockConfig blk -> SystemStart
+  getNetworkMagic    :: BlockConfig blk -> NetworkMagic
+  getProtocolMagicId :: BlockConfig blk -> ProtocolMagicId

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -60,6 +60,7 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.TypeFamilyWrappers
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -15,7 +15,6 @@
 module Ouroboros.Consensus.HardFork.Combinator.Block (
     -- * Type family instances
     BlockConfig(..)
-  , CodecConfig(..)
   , Header(..)
   ) where
 
@@ -38,22 +37,6 @@ import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Match as Match
-
-{-------------------------------------------------------------------------------
-  CodecConfig
--------------------------------------------------------------------------------}
-
-newtype instance CodecConfig (HardForkBlock xs) = HardForkCodecConfig {
-      hardForkCodecConfigPerEra :: PerEraCodecConfig xs
-    }
-
-instance CanHardFork xs => BlockHasCodecConfig (HardForkBlock xs) where
-  getCodecConfig =
-        HardForkCodecConfig
-      . PerEraCodecConfig
-      . hcmap proxySingle getCodecConfig
-      . getPerEraBlockConfig
-      . hardForkBlockConfigPerEra
 
 {-------------------------------------------------------------------------------
   GetHeader

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ouroboros.Consensus.HardFork.Combinator.Node (
+    -- * Type family instances
+    CodecConfig(..)
+  ) where
+
+import           Control.Monad.Except (throwError)
+import           Data.Proxy
+import           Data.SOP.Strict
+
+import           Ouroboros.Consensus.Config.SupportsNode
+import           Ouroboros.Consensus.Util (allEqual)
+import           Ouroboros.Consensus.Util.Assert
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+
+{-------------------------------------------------------------------------------
+  ConfigSupportsNode
+-------------------------------------------------------------------------------}
+
+instance (All ConfigSupportsNode xs, IsNonEmpty xs)
+      => ConfigSupportsNode (HardForkBlock xs) where
+  newtype CodecConfig (HardForkBlock xs) = HardForkCodecConfig {
+        hardForkCodecConfigPerEra :: PerEraCodecConfig xs
+      }
+
+  getCodecConfig =
+        HardForkCodecConfig
+      . PerEraCodecConfig
+      . hcmap (Proxy @ConfigSupportsNode) getCodecConfig
+      . getPerEraBlockConfig
+      . hardForkBlockConfigPerEra
+
+  getSystemStart     = getSameValue "getSystemStart"     getSystemStart
+  getNetworkMagic    = getSameValue "getNetworkMagic"    getNetworkMagic
+  getProtocolMagicId = getSameValue "getProtocolMagicId" getProtocolMagicId
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+getSameValue
+  :: forall xs a. (All ConfigSupportsNode xs, IsNonEmpty xs, Eq a)
+  => String
+  -> (forall blk. ConfigSupportsNode blk => BlockConfig blk -> a)
+  -> BlockConfig (HardForkBlock xs)
+  -> a
+getSameValue label getValue blockConfig =
+    case isNonEmpty (Proxy @xs) of
+      ProofNonEmpty _ ->
+        assertWithMsg allEqualCheck (unK (hd values))
+  where
+    values :: NP (K a) xs
+    values =
+          hcmap (Proxy @ConfigSupportsNode) (K . getValue)
+        . getPerEraBlockConfig
+        . hardForkBlockConfigPerEra
+        $ blockConfig
+
+    allEqualCheck :: Either String ()
+    allEqualCheck
+        | allEqual (hcollapse values)
+        = return ()
+        | otherwise
+        = throwError $ "differing values for " <> label <> " across hard fork"

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
@@ -74,6 +74,7 @@ import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Block.Forge
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Config.SupportsNode
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -95,6 +96,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Forge ()
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
 import           Ouroboros.Consensus.HardFork.Combinator.Mempool
+import           Ouroboros.Consensus.HardFork.Combinator.Node
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol
                      (HardForkEraLedgerView (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -56,8 +56,8 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Codec
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Server
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
 
-import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Server

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -63,6 +63,7 @@ import           Ouroboros.Network.TxSubmission.Inbound
 import           Ouroboros.Network.TxSubmission.Outbound
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mempool.API
 import           Ouroboros.Consensus.MiniProtocol.BlockFetch.Server

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -19,6 +19,7 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -16,17 +16,15 @@ import qualified Data.ByteString.Lazy as Lazy
 import           Data.Proxy (Proxy)
 import           Data.Word (Word32)
 
-import           Cardano.Crypto (ProtocolMagicId)
 import           Cardano.Slotting.Slot
 
 import           Ouroboros.Network.Block (HeaderHash, Serialised)
 import           Ouroboros.Network.BlockFetch (SizeInBytes)
-import           Ouroboros.Network.Magic (NetworkMagic)
 import           Ouroboros.Network.Protocol.LocalStateQuery.Codec (Some (..))
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.HardFork.Abstract
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -52,6 +50,7 @@ class ( LedgerSupportsProtocol    blk
       , QueryLedger               blk
       , HasNetworkProtocolVersion blk
       , CanForge                  blk
+      , ConfigSupportsNode        blk
         -- TODO: Remove after reconsidering rewindConsensusState:
       , Serialise (HeaderHash blk)
       ) => RunNode blk where
@@ -60,10 +59,6 @@ class ( LedgerSupportsProtocol    blk
   nodeIsEBB               :: Header blk -> Maybe EpochNo
 
   nodeImmDbChunkInfo      :: TopLevelConfig blk -> ChunkInfo
-
-  nodeStartTime           :: BlockConfig blk -> SystemStart
-  nodeNetworkMagic        :: BlockConfig blk -> NetworkMagic
-  nodeProtocolMagicId     :: BlockConfig blk -> ProtocolMagicId
 
   -- | Hash serialisation
   nodeHashInfo :: Proxy blk -> HashInfo (HeaderHash blk)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -214,12 +214,6 @@ data instance BlockConfig TestBlock = TestBlockConfig {
     }
   deriving (Generic, NoUnexpectedThunks)
 
-data instance CodecConfig TestBlock = TestCodecConfig
-  deriving (Generic, NoUnexpectedThunks)
-
-instance BlockHasCodecConfig TestBlock where
-  getCodecConfig = const TestCodecConfig
-
 instance Condense TestBlock where
   condense = show -- TODO
 


### PR DESCRIPTION
* Move `BlockHasCodecConfig` to the new `Ouroboros.Consensus.Node.Config`
  module, renaming it to `ConfigSupportsNode`.

* Make `CodecConfig` part of `ConfigSupportsNode`.

* Move `nodeStartTime`, `nodeNetworkMagic`, and `getProtocolMagicId` from
  `RunNode` to  `ConfigSupportsNode`, replacing `node-` with `get-`.

* Rename `getStartTime` to `getSystemStart`. Do a similar renaming in
  `ShelleyGenesis`.

* Remove `BlockHasCodecConfig` from test blocks that no longer need it.

* Provide a `ConfigSupportsNode` instance for `HardForkBlock`.