### PR TITLE
Move nodeBlockMatchesHeader and nodeHeaderIsEBB to GetHeader

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -239,9 +239,6 @@ instance RunNode DualByronBlock where
   nodeEncodeAnnTip = \_p -> nodeEncodeAnnTip pb . castAnnTip
   nodeDecodeAnnTip = \_p -> castAnnTip <$> nodeDecodeAnnTip pb
 
-  -- We can look at the concrete header to see if this is an EBB
-  nodeIsEBB = nodeIsEBB . dualHeaderMain
-
   -- For now the size of the block is just an estimate, and so we just reuse
   -- the estimate from the concrete header.
   nodeBlockFetchSize = nodeBlockFetchSize . dualHeaderMain
@@ -249,8 +246,7 @@ instance RunNode DualByronBlock where
   -- We don't really care too much about data loss or malicious behaviour for
   -- the dual ledger tests, so integrity and match checks can just use the
   -- concrete implementation
-  nodeBlockMatchesHeader hdr = nodeBlockMatchesHeader (dualHeaderMain         hdr) . dualBlockMain
-  nodeCheckIntegrity     cfg = nodeCheckIntegrity     (dualTopLevelConfigMain cfg) . dualBlockMain
+  nodeCheckIntegrity cfg = nodeCheckIntegrity (dualTopLevelConfigMain cfg) . dualBlockMain
 
   -- The header is just the concrete header, so we can just reuse the Byron def
   nodeAddHeaderEnvelope = \_ -> nodeAddHeaderEnvelope pb

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
@@ -44,7 +44,6 @@ import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended (ExtValidationError (..))
 import           Ouroboros.Consensus.Node.ProtocolInfo
-import           Ouroboros.Consensus.Node.Run (nodeIsEBB)
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.Crypto as Crypto
@@ -937,7 +936,7 @@ hasAllEBBs k produceEBBs outcomes (nid, c) =
               hi = unSlotNo s `div` denom
               denom = unEpochSlots $ kEpochSlots $ coerce k
 
-    actual   = mapMaybe (nodeIsEBB . getHeader) $ Chain.toOldestFirst c
+    actual   = mapMaybe blockIsEBB $ Chain.toOldestFirst c
 
 {-------------------------------------------------------------------------------
   Generating the genesis configuration

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Integrity.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Integrity.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 module Ouroboros.Consensus.Byron.Ledger.Integrity
-  ( verifyBlockMatchesHeader
-  , verifyHeaderSignature
+  ( verifyHeaderSignature
   , verifyHeaderIntegrity
   , verifyBlockIntegrity
   ) where
@@ -9,7 +8,6 @@ module Ouroboros.Consensus.Byron.Ledger.Integrity
 import           Data.Either (isRight)
 
 import qualified Cardano.Chain.Block as CC
-import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Crypto.DSIGN.Class as CC.Crypto
 
 import           Ouroboros.Consensus.Block
@@ -18,14 +16,6 @@ import           Ouroboros.Consensus.Protocol.PBFT
 import           Ouroboros.Consensus.Byron.Ledger.Block
 import           Ouroboros.Consensus.Byron.Ledger.Config
 import           Ouroboros.Consensus.Byron.Ledger.PBFT ()
-
--- | Check if a block matches its header
---
--- Note that we cannot check this for an EBB, as the EBB header doesn't store
--- a hash of the EBB body.
-verifyBlockMatchesHeader :: Header ByronBlock -> ByronBlock -> Bool
-verifyBlockMatchesHeader hdr blk =
-    CC.abobMatchesBody (byronHeaderRaw hdr) (byronBlockRaw blk)
 
 -- | Verify whether a header matches its signature.
 --
@@ -72,7 +62,7 @@ verifyHeaderIntegrity cfg hdr =
 -- anything for an EBB.
 verifyBlockIntegrity :: BlockConfig ByronBlock -> ByronBlock -> Bool
 verifyBlockIntegrity cfg blk =
-    verifyHeaderIntegrity    cfg hdr &&
-    verifyBlockMatchesHeader     hdr blk
+    verifyHeaderIntegrity cfg hdr &&
+    blockMatchesHeader        hdr blk
   where
     hdr = getHeader blk

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -33,7 +33,6 @@ import           Control.Monad.Except
 import           Data.Coerce (coerce)
 import           Data.Maybe
 
-import qualified Cardano.Chain.Block as Cardano.Block
 import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.Genesis as Genesis
 import           Cardano.Chain.ProtocolConstants (kEpochSlots)
@@ -219,14 +218,7 @@ extractGenesisData = Genesis.configGenesisData . byronGenesisConfig
 -------------------------------------------------------------------------------}
 
 instance RunNode ByronBlock where
-  nodeBlockMatchesHeader    = verifyBlockMatchesHeader
   nodeBlockFetchSize        = byronHeaderBlockSizeHint
-  nodeIsEBB                 = \hdr -> case byronHeaderRaw hdr of
-    Cardano.Block.ABOBBlockHdr _       -> Nothing
-    Cardano.Block.ABOBBoundaryHdr bhdr -> Just
-                              . EpochNo
-                              . Cardano.Block.boundaryEpoch
-                              $ bhdr
 
   -- The epoch size is fixed and can be derived from @k@ by the ledger
   -- ('kEpochSlots').

--- a/ouroboros-consensus-byron/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-byron/tools/db-analyser/Main.hs
@@ -367,7 +367,6 @@ withImmDB fp cfg chunkInfo registry = ImmDB.withImmDB args
         , immChunkInfo      = chunkInfo
         , immHashInfo       = nodeHashInfo            pb
         , immValidation     = ValidateMostRecentChunk
-        , immIsEBB          = nodeIsEBB
         , immCheckIntegrity = nodeCheckIntegrity      cfg
         , immAddHdrEnv      = nodeAddHeaderEnvelope   pb
         , immRegistry       = registry

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
@@ -61,6 +61,13 @@ instance GetHeader ByronSpecBlock where
       , byronSpecHeaderHash = byronSpecBlockHash
       }
 
+  -- We don't care about integrity checks, so we don't bother checking whether
+  -- the hashes of the body are correct
+  blockMatchesHeader hdr blk = blockHash hdr == blockHash blk
+
+  -- No EBBs
+  headerIsEBB = const Nothing
+
 type ByronSpecHeader = Header ByronSpecBlock
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -127,6 +127,16 @@ instance Crypto c => GetHeader (ShelleyBlock c) where
     , shelleyHeaderHash = hdrHash
     }
 
+  blockMatchesHeader hdr blk =
+      -- Compute the hash the body of the block (the transactions) and compare
+      -- that against the hash of the body stored in the header.
+      SL.bbHash txs == SL.bhash hdrBody
+    where
+      ShelleyHeader { shelleyHeaderRaw = SL.BHeader hdrBody _ } = hdr
+      ShelleyBlock  { shelleyBlockRaw  = SL.Block _ txs }       = blk
+
+  headerIsEBB = const Nothing
+
 mkShelleyHeader :: Crypto c => SL.BHeader c -> Header (ShelleyBlock c)
 mkShelleyHeader raw = ShelleyHeader {
       shelleyHeaderRaw  = raw

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Integrity.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Integrity.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE NamedFieldPuns           #-}
 module Ouroboros.Consensus.Shelley.Ledger.Integrity (
-    verifyBlockMatchesHeader
-  , verifyHeaderIntegrity
+    verifyHeaderIntegrity
   , verifyBlockIntegrity
   ) where
 
@@ -19,19 +18,6 @@ import qualified Shelley.Spec.Ledger.OCert as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Protocol
-
--- | Check if a block matches its header by checking whether the recomputed
--- hash of the body matches the hash of the body stored in the header.
-verifyBlockMatchesHeader
-  :: Crypto c
-  => Header (ShelleyBlock c) -> ShelleyBlock c -> Bool
-verifyBlockMatchesHeader hdr blk =
-    -- Compute the hash the body of the block (the transactions) and compare
-    -- that against the hash of the body stored in the header.
-    SL.bbHash txs == SL.bhash hdrBody
-  where
-    ShelleyHeader { shelleyHeaderRaw = SL.BHeader hdrBody _ } = hdr
-    ShelleyBlock  { shelleyBlockRaw  = SL.Block _ txs }       = blk
 
 -- | Verify whether a header is not corrupted
 verifyHeaderIntegrity
@@ -64,4 +50,4 @@ verifyBlockIntegrity
   -> ShelleyBlock c -> Bool
 verifyBlockIntegrity slotsPerKESPeriod blk =
     verifyHeaderIntegrity slotsPerKESPeriod (getHeader blk) &&
-    verifyBlockMatchesHeader                (getHeader blk) blk
+    blockMatchesHeader                      (getHeader blk) blk

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -340,11 +340,7 @@ instance ConfigSupportsNode (ShelleyBlock c) where
 -------------------------------------------------------------------------------}
 
 instance TPraosCrypto c => RunNode (ShelleyBlock c) where
-  nodeBlockMatchesHeader = verifyBlockMatchesHeader
-
   nodeBlockFetchSize = fromIntegral . SL.bsize . SL.bhbody . shelleyHeaderRaw
-
-  nodeIsEBB = const Nothing
 
   -- We fix the chunk size to 10k
   nodeImmDbChunkInfo =

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -114,7 +114,7 @@ data SimpleBlock' c ext ext' = SimpleBlock {
   deriving stock    (Generic, Show, Eq)
   deriving anyclass (Serialise)
 
-instance GetHeader (SimpleBlock' c ext ext') where
+instance SimpleCrypto c => GetHeader (SimpleBlock' c ext ext') where
   data Header (SimpleBlock' c ext ext') = SimpleHeader {
         -- | The header hash
         --
@@ -137,6 +137,10 @@ instance GetHeader (SimpleBlock' c ext ext') where
     deriving (Generic, Show, Eq, NoUnexpectedThunks)
 
   getHeader = simpleHeader
+
+  blockMatchesHeader = matchesSimpleHeader
+
+  headerIsEBB = const Nothing
 
 data SimpleStdHeader c ext = SimpleStdHeader {
       simplePrev      :: ChainHash (SimpleBlock c ext)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -63,9 +63,7 @@ instance ( LedgerSupportsProtocol (SimpleBlock SimpleMockCrypto ext)
          , Serialise ext
          , RunMockBlock SimpleMockCrypto ext
          ) => RunNode (SimpleBlock SimpleMockCrypto ext) where
-  nodeBlockMatchesHeader    = matchesSimpleHeader
   nodeBlockFetchSize        = fromIntegral . simpleBlockSize . simpleHeaderStd
-  nodeIsEBB                 = const Nothing
   nodeImmDbChunkInfo        = \cfg -> simpleChunkInfo $
     EpochSize $ 10 * maxRollbacks (configSecurityParam cfg)
   nodeHashInfo              = const simpleBlockHashInfo

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -604,7 +604,6 @@ runThreadNetwork ThreadNetworkArgs
         , cdbTopLevelConfig       = cfg
         , cdbChunkInfo            = ImmDB.simpleChunkInfo epochSize
         , cdbHashInfo             = nodeHashInfo (Proxy @blk)
-        , cdbIsEBB                = nodeIsEBB
         , cdbCheckIntegrity       = nodeCheckIntegrity cfg
         , cdbGenesis              = return initLedger
         , cdbCheckInFuture        = LogicalClock.checkInFuture
@@ -772,7 +771,6 @@ runThreadNetwork ThreadNetworkArgs
             , initChainDB             = nodeInitChainDB
             , blockProduction         = Just blockProduction
             , blockFetchSize          = nodeBlockFetchSize
-            , blockMatchesHeader      = nodeBlockMatchesHeader
             , maxTxCapacityOverride   = NoMaxTxCapacityOverride
             , mempoolCapacityOverride = NoMempoolCapacityBytesOverride
             , miniProtocolParameters  = MiniProtocolParameters {

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -211,6 +211,8 @@ instance GetHeader TestBlock where
     deriving stock   (Eq, Show)
     deriving newtype (NoUnexpectedThunks, Serialise)
   getHeader = TestHeader
+  blockMatchesHeader (TestHeader blk') blk = blk == blk'
+  headerIsEBB = const Nothing
 
 type instance HeaderHash TestBlock = TestHash
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -95,6 +95,11 @@ instance SingleEraBlock b => GetHeader (DegenFork b) where
 
   getHeader (DBlk b) = DHdr (getHeader b)
 
+  blockMatchesHeader (DHdr hdr) (DBlk blk) =
+      blockMatchesHeader (projHeader hdr) (projBlock blk)
+
+  headerIsEBB (DHdr hdr) = headerIsEBB (projHeader hdr)
+
 newtype instance BlockConfig (DegenFork b) = DBCfg {
       unDBCfg :: BlockConfig (HardForkBlock '[b])
     }
@@ -279,9 +284,7 @@ instance HasNetworkProtocolVersion b => HasNetworkProtocolVersion (DegenFork b) 
   nodeToClientProtocolVersion   _ = nodeToClientProtocolVersion   (Proxy @b)
 
 instance (SingleEraBlock b, FromRawHash b, RunNode b) => RunNode (DegenFork b) where
-  nodeBlockMatchesHeader (DHdr hdr) (DBlk blk) = nodeBlockMatchesHeader (projHeader hdr) (projBlock blk)
   nodeBlockFetchSize     (DHdr hdr)            = nodeBlockFetchSize     (projHeader hdr)
-  nodeIsEBB              (DHdr hdr)            = nodeIsEBB              (projHeader hdr)
 
   nodeImmDbChunkInfo  cfg = nodeImmDbChunkInfo (projCfg cfg)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -123,6 +123,12 @@ instance GetHeader m => GetHeader (DualBlock m a) where
 
   getHeader = DualHeader . getHeader . dualBlockMain
 
+  blockMatchesHeader hdr =
+      blockMatchesHeader (dualHeaderMain hdr) . dualBlockMain
+
+  -- We can look at the concrete header to see if this is an EBB
+  headerIsEBB = headerIsEBB . dualHeaderMain
+
 type DualHeader m a = Header (DualBlock m a)
 
 deriving instance Show (Header m) => Show (DualHeader m a)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -384,7 +384,6 @@ mkChainDbArgs tracer registry inFuture dbPath cfg initLedger
     , ChainDB.cdbGenesis              = return initLedger
     , ChainDB.cdbAddHdrEnv            = nodeAddHeaderEnvelope    pb
     , ChainDB.cdbDiskPolicy           = defaultDiskPolicy k
-    , ChainDB.cdbIsEBB                = nodeIsEBB
     , ChainDB.cdbCheckIntegrity       = nodeCheckIntegrity       cfg
     , ChainDB.cdbParamsLgrDB          = ledgerDbDefaultParams k
     , ChainDB.cdbTopLevelConfig       = cfg
@@ -422,7 +421,6 @@ mkNodeArgs registry cfg mIsLeader tracers btime chainDB = do
       , blockProduction
       , initChainDB             = nodeInitChainDB
       , blockFetchSize          = nodeBlockFetchSize
-      , blockMatchesHeader      = nodeBlockMatchesHeader
       , maxTxCapacityOverride   = NoMaxTxCapacityOverride
       , mempoolCapacityOverride = NoMempoolCapacityBytesOverride
       , miniProtocolParameters  = defaultMiniProtocolParameters

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -15,8 +15,6 @@ import           Control.Exception (SomeException)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Proxy (Proxy)
 
-import           Cardano.Slotting.Slot
-
 import           Ouroboros.Network.Block (HeaderHash, Serialised)
 import           Ouroboros.Network.BlockFetch (SizeInBytes)
 import           Ouroboros.Network.Protocol.LocalStateQuery.Codec (Some (..))
@@ -53,9 +51,7 @@ class ( LedgerSupportsProtocol    blk
         -- TODO: Remove after reconsidering rewindConsensusState:
       , Serialise (HeaderHash blk)
       ) => RunNode blk where
-  nodeBlockMatchesHeader  :: Header blk -> blk -> Bool
   nodeBlockFetchSize      :: Header blk -> SizeInBytes
-  nodeIsEBB               :: Header blk -> Maybe EpochNo
 
   nodeImmDbChunkInfo      :: TopLevelConfig blk -> ChunkInfo
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -31,14 +31,13 @@ import           Control.Monad (when)
 import           Control.Tracer
 import           Data.Functor ((<&>))
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (isJust)
 import           GHC.Stack (HasCallStack)
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (pattern BlockPoint,
                      pattern GenesisPoint, HasHeader, Point, castPoint)
 
-import           Ouroboros.Consensus.Block (Header, toIsEBB)
+import           Ouroboros.Consensus.Block (Header)
 import qualified Ouroboros.Consensus.Fragment.Validated as VF
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Util (whenJust)
@@ -149,7 +148,6 @@ openDBInternal args launchBgTasks = do
                   , cdbGcInterval      = Args.cdbGcInterval args
                   , cdbKillBgThreads   = varKillBgThreads
                   , cdbChunkInfo       = Args.cdbChunkInfo args
-                  , cdbIsEBB           = toIsEBB . isJust . Args.cdbIsEBB args
                   , cdbCheckIntegrity  = Args.cdbCheckIntegrity args
                   , cdbCheckInFuture   = Args.cdbCheckInFuture args
                   , cdbBlocksToAdd     = blocksToAdd

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -160,7 +160,7 @@ copyToImmDB CDB{..} = withCopyLock $ do
         -- When we found a corrupt block, shut down the node. This exception
         -- will make sure we restart with validation enabled.
         unless (cdbCheckIntegrity blk) $
-          let blockRef = BlockRef (blockPoint blk) (cdbIsEBB (getHeader blk))
+          let blockRef = BlockRef (blockPoint blk) (headerToIsEBB (getHeader blk))
           in throwM $ VolDbCorruptBlock blockRef
 
         -- We're the only one modifying the ImmutableDB, so the tip cannot

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reader.hs
@@ -86,6 +86,7 @@ newReader
      ( IOLike m
      , HasHeader blk
      , HasHeader (Header blk)
+     , GetHeader blk
      )
   => ChainDbHandle m blk
   -> (Header blk -> Encoding)
@@ -126,6 +127,7 @@ makeNewReader
      ( IOLike m
      , HasHeader blk
      , HasHeader (Header blk)
+     , GetHeader blk
      )
   => ChainDbHandle m blk
   -> (Header blk -> Encoding)
@@ -205,6 +207,7 @@ instructionHelper
      ( IOLike m
      , HasHeader blk
      , HasHeader (Header blk)
+     , GetHeader blk
      , Traversable f, Applicative f
      )
   => ResourceRegistry m
@@ -290,7 +293,7 @@ instructionHelper registry varReader blockComponent encodeHeader fromMaybeSTM CD
         GetRawHeader  -> return $ toLazyByteString $ encodeHeader hdr
         GetHash       -> return $ headerHash hdr
         GetSlot       -> return $ blockSlot hdr
-        GetIsEBB      -> return $ cdbIsEBB hdr
+        GetIsEBB      -> return $ headerToIsEBB hdr
         GetBlockSize  -> getBlockComponent GetBlockSize
         -- We could look up the header size in the index of the VolatileDB,
         -- but getting the serialisation is cheap because we keep the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -215,7 +215,6 @@ data ChainDbEnv m blk = CDB
   , cdbKillBgThreads   :: !(StrictTVar m (m ()))
     -- ^ A handle to kill the background threads.
   , cdbChunkInfo       :: !ImmDB.ChunkInfo
-  , cdbIsEBB           :: !(Header blk -> IsEBB)
   , cdbCheckIntegrity  :: !(blk -> Bool)
   , cdbCheckInFuture   :: !(CheckInFuture m blk)
   , cdbBlocksToAdd     :: !(BlocksToAdd m blk)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/AddBlock.hs
@@ -27,7 +27,7 @@ import           Control.Tracer
 import           Ouroboros.Network.MockChain.Chain (Chain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
-import           Ouroboros.Consensus.Block (IsEBB (..), getHeader)
+import           Ouroboros.Consensus.Block (getHeader)
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
 import           Ouroboros.Consensus.HeaderValidation
@@ -61,7 +61,7 @@ import           Test.Util.Orphans.NoUnexpectedThunks ()
 import           Test.Util.SOP
 import           Test.Util.TestBlock
 
-import           Test.Ouroboros.Storage.ChainDB.Model (ModelSupportsBlock (..))
+import           Test.Ouroboros.Storage.ChainDB.Model (ModelSupportsBlock)
 import qualified Test.Ouroboros.Storage.ChainDB.Model as Model
 import           Test.Ouroboros.Storage.ChainDB.StateMachine ()
 
@@ -274,7 +274,6 @@ mkArgs cfg chunkInfo initLedger tracer registry hashInfo
     , cdbTopLevelConfig       = cfg
     , cdbChunkInfo            = chunkInfo
     , cdbHashInfo             = hashInfo
-    , cdbIsEBB                = const Nothing
     , cdbCheckIntegrity       = const True
     , cdbCheckInFuture        = InFuture.dontCheck
     , cdbGenesis              = return initLedger
@@ -304,5 +303,4 @@ mkArgs cfg chunkInfo initLedger tracer registry hashInfo
   Orphan instances
 -------------------------------------------------------------------------------}
 
-instance ModelSupportsBlock TestBlock where
-  isEBB = const IsNotEBB
+instance ModelSupportsBlock TestBlock

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
@@ -31,7 +31,7 @@ import           Ouroboros.Consensus.Storage.ChainDB.API (StreamFrom (..),
 
 import           Test.Util.TestBlock
 
-import           Test.Ouroboros.Storage.ChainDB.Model (ModelSupportsBlock (..))
+import           Test.Ouroboros.Storage.ChainDB.Model (ModelSupportsBlock)
 import qualified Test.Ouroboros.Storage.ChainDB.Model as M
 
 tests :: TestTree
@@ -113,4 +113,3 @@ cantBeGenesis (BlockPoint s h) = RealPoint s h
 -------------------------------------------------------------------------------}
 
 instance ModelSupportsBlock TestBlock where
-  isEBB = const IsNotEBB

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -11,7 +11,6 @@ import           Test.Tasty.HUnit
 
 import           Cardano.Slotting.Slot
 
-import           Ouroboros.Consensus.Block (getHeader)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
@@ -64,9 +63,8 @@ openTestDB registry hasFS =
       , parser
       }
   where
-    parser = chunkFileParser hasFS (const <$> S.decode) isEBB getBinaryInfo
+    parser = chunkFileParser hasFS (const <$> S.decode) getBinaryInfo
       testBlockIsValid
-    isEBB  = testHeaderEpochNoIfEBB fixedChunkInfo . getHeader
     getBinaryInfo = void . testBlockToBinaryInfo
 
 -- Shorthand

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -86,7 +86,7 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util (parseDBFile,
                      validateIteratorRange)
 import           Ouroboros.Consensus.Storage.ImmutableDB.Types
 
-import           Test.Ouroboros.Storage.TestBlock
+import           Test.Ouroboros.Storage.TestBlock hiding (EBB)
 
 data InSlot hash =
     -- | This slot contains only a regular block


### PR DESCRIPTION
This is another step in the direction of emptying the `RunNode` sin bin.
Moreover, the hard-fork combinator can now provide straightforward
implementations for these methods.