### PR TITLE
Undo MonadDelay wrapper

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -33,9 +33,7 @@ module Ouroboros.Consensus.Util.IOLike (
   , addTime
   , diffTime
     -- *** MonadDelay
-  , MonadDelay -- Opaque to favor the usage of 'threadDelay'
-    -- *** MonadDelay Wrappers
-  , threadDelay
+  , MonadDelay(..)
     -- *** MonadEventlog
   , MonadEventlog(..)
     -- *** Cardano prelude
@@ -52,8 +50,7 @@ import           Control.Monad.Class.MonadFork
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime hiding (MonadTime (..))
-import           Control.Monad.Class.MonadTimer hiding (threadDelay)
-import qualified Control.Monad.Class.MonadTimer as MonadTimer
+import           Control.Monad.Class.MonadTimer
 
 import           Ouroboros.Consensus.Util.MonadSTM.NormalForm
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -94,21 +91,3 @@ class ( MonadAsync              m
       ) => IOLike m where
 
 instance IOLike IO
-
-{-------------------------------------------------------------------------------
-  MonadDelay Wrappers
--------------------------------------------------------------------------------}
-
--- | In some cases, 'MonadTimer.threadDelay' can't be used for delays over
--- ~35mins, because it uses an 'Int', which can overflow (see
--- 'diffTimeToMicrosecondsAsInt' for more info). This can be safely used to
--- sleep for longer periods of time, so we favor its usage in all cases.
-threadDelay :: MonadDelay m => DiffTime -> m ()
-threadDelay time
-    | time > maxDelay
-    = MonadTimer.threadDelay maxDelay *> threadDelay (time - maxDelay)
-    | otherwise
-    = MonadTimer.threadDelay time
-  where
-    maxDelay :: DiffTime
-    maxDelay = fromIntegral (maxBound :: Int)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
@@ -28,7 +28,6 @@ import           Cardano.Prelude (AllowThunk (..), NoUnexpectedThunks)
 import           Cardano.Slotting.Slot (SlotNo (..))
 
 import           Control.Monad.Class.MonadTime
-import qualified Control.Monad.Class.MonadTimer as Unused
 import           Control.Monad.IOSim
 
 import           Ouroboros.Consensus.BlockchainTime


### PR DESCRIPTION
After https://github.com/input-output-hk/ouroboros-network/pull/2135 the wrapper is no longer needed.
Undoes https://github.com/input-output-hk/ouroboros-network/pull/2095