### PR TITLE
Add custom labels to `prop_general`

### DIFF
--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
@@ -92,6 +92,7 @@ prop_convergence setup = withMaxSuccess 10 $
       , pgaFixedSchedule          = setupSchedule setup
       , pgaSecurityParam          = setupSecurityParam setup
       , pgaTestConfig             = cfg
+      , pgaCustomLabelling        = const id
       }
       (setupTestOutput setup)
   where

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
@@ -739,6 +739,7 @@ prop_simple_real_pbft_convergence produceEBBs k
           Just $ roundRobinLeaderSchedule numCoreNodes numSlots
       , pgaSecurityParam          = k
       , pgaTestConfig             = testConfig
+      , pgaCustomLabelling        = const id
       }
       testOutput .&&.
     prop_pvu .&&.

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -71,6 +71,7 @@ prop_simple_cardano_convergence k d
       , pgaFixedSchedule          = Nothing
       , pgaSecurityParam          = k
       , pgaTestConfig             = testConfig
+      , pgaCustomLabelling        = const id
       }
       testOutput
   where

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -59,6 +59,7 @@ prop_simple_real_tpraos_convergence k d
       , pgaFixedSchedule          = Nothing
       , pgaSecurityParam          = k
       , pgaTestConfig             = testConfig
+      , pgaCustomLabelling        = const id
       }
       testOutput
   where

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -87,6 +87,7 @@ prop_simple_bft_convergence k
           Just $ roundRobinLeaderSchedule numCoreNodes numSlots
       , pgaSecurityParam          = k
       , pgaTestConfig             = testConfig
+      , pgaCustomLabelling        = const id
       }
       testOutput
   where

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -101,6 +101,7 @@ prop_simple_leader_schedule_convergence
       , pgaFixedSchedule          = Just schedule
       , pgaSecurityParam          = praosSecurityParam
       , pgaTestConfig             = testConfig
+      , pgaCustomLabelling        = const id
       }
       testOutput
   where

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -90,6 +90,7 @@ prop_simple_pbft_convergence
           Just $ roundRobinLeaderSchedule numCoreNodes numSlots
       , pgaSecurityParam          = k
       , pgaTestConfig             = testConfig
+      , pgaCustomLabelling        = const id
       }
       testOutput
   where

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -105,6 +105,7 @@ prop_simple_praos_convergence
       , pgaFixedSchedule          = Nothing
       , pgaSecurityParam          = praosSecurityParam
       , pgaTestConfig             = testConfig
+      , pgaCustomLabelling        = const id
       }
       testOutput
   where

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -324,6 +324,11 @@ data PropGeneralArgs blk = PropGeneralArgs
     --
   , pgaSecurityParam          :: SecurityParam
   , pgaTestConfig             :: TestConfig
+
+    -- | Option to add custom labelling to a property
+    --
+    -- Can use @const id@ if no custom labelling is required.
+  , pgaCustomLabelling        :: TestOutput blk -> Property -> Property
   }
 
 -- | The properties always required
@@ -352,7 +357,7 @@ prop_general ::
   -> TestOutput blk
   -> Property
 prop_general pga testOutput =
-    label ("nodeChains: " <> unlines ("" : map (\x -> "  " <> condense x) (Map.toList nodeChains))) $
+    counterexample ("nodeChains: " <> unlines ("" : map (\x -> "  " <> condense x) (Map.toList nodeChains))) $
     counterexample ("nodeJoinPlan: " <> condense nodeJoinPlan) $
     counterexample ("nodeRestarts: " <> condense nodeRestarts) $
     counterexample ("nodeTopology: " <> condense nodeTopology) $
@@ -362,6 +367,7 @@ prop_general pga testOutput =
     counterexample ("actual leader schedule: " <> condense actualLeaderSchedule) $
     counterexample ("consensus expected: " <> show isConsensusExpected) $
     counterexample ("maxForkLength: " <> show maxForkLength) $
+    pgaCustomLabelling pga testOutput $
     tabulate "consensus expected" [show isConsensusExpected] $
     tabulate "k" [show (maxRollbacks k)] $
     tabulate ("shortestLength (k = " <> show (maxRollbacks k) <> ")")

--- a/ouroboros-consensus/src/Data/SOP/Strict.hs
+++ b/ouroboros-consensus/src/Data/SOP/Strict.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE ConstraintKinds       #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE EmptyCase             #-}
@@ -25,6 +26,7 @@ module Data.SOP.Strict (
     -- * NS
   , NS(..)
   , unZ
+  , index_NS
     -- * Injections
   , Injection
   , injections
@@ -114,6 +116,13 @@ type instance Same       NS   = NS
 unZ :: NS f '[x] -> f x
 unZ (Z x) = x
 unZ (S x) = case x of {}
+
+index_NS :: forall f xs . NS f xs -> Int
+index_NS = go 0
+  where
+    go :: forall ys . Int -> NS f ys -> Int
+    go !acc (Z _) = acc
+    go !acc (S x) = go (acc + 1) x
 
 expand_NS :: SListI xs => (forall x. f x) -> NS f xs -> NP f xs
 expand_NS = cexpand_NS (Proxy @Top)


### PR DESCRIPTION
For the HFC tests, we take advantage of this to show how many A blocks and how
many B blocks we have, though I imagine it can come in handy in lots of other
places also.

I had accidentally left in a change to `prop_general` where we show the full chains always; this is not very useful for most tests.