### PR TITLE
Split off CodecConfig from ConfigSupportsNode

### DIFF
--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -9,6 +9,7 @@ module Cardano.Client.Subscription (
 import           Data.Proxy
 import           Data.Void (Void)
 import qualified Data.ByteString.Lazy as BSL
+import           Ouroboros.Consensus.Block (getCodecConfig)
 import           Ouroboros.Consensus.Config (TopLevelConfig, configBlock)
 import           Ouroboros.Consensus.Network.NodeToClient (clientCodecs, ClientCodecs)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion (
@@ -31,7 +32,7 @@ import qualified Ouroboros.Network.Snocket as Snocket
 import qualified Ouroboros.Network.NodeToClient (NodeToClientVersion)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Prelude
-import           Ouroboros.Consensus.Config.SupportsNode (getCodecConfig, getNetworkMagic)
+import           Ouroboros.Consensus.Config.SupportsNode (getNetworkMagic)
 
 subscribe ::
   ( RunNode blk , MonadST m )

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
@@ -8,6 +8,7 @@
 
 module Ouroboros.Consensus.Byron.Ledger.Config (
     BlockConfig(..)
+  , CodecConfig(..)
   , byronGenesisHash
   , byronProtocolMagicId
   , byronProtocolMagic
@@ -24,8 +25,10 @@ import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Crypto as Crypto
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config.SecurityParam
 
 import           Ouroboros.Consensus.Byron.Ledger.Block
+import           Ouroboros.Consensus.Byron.Ledger.Conversions
 
 -- | Extended configuration we need for Byron
 data instance BlockConfig ByronBlock = ByronConfig {
@@ -57,3 +60,14 @@ byronProtocolMagic = CC.Genesis.configProtocolMagic . byronGenesisConfig
 
 byronEpochSlots :: BlockConfig ByronBlock -> CC.Slot.EpochSlots
 byronEpochSlots = CC.Genesis.configEpochSlots . byronGenesisConfig
+
+instance HasCodecConfig ByronBlock where
+  data CodecConfig ByronBlock = ByronCodecConfig {
+        getByronEpochSlots    :: !CC.Slot.EpochSlots
+      , getByronSecurityParam :: !SecurityParam
+      }
+
+  getCodecConfig bcfg = ByronCodecConfig {
+      getByronEpochSlots    = byronEpochSlots bcfg
+    , getByronSecurityParam = genesisSecurityParam (byronGenesisConfig bcfg)
+    }

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -22,8 +22,6 @@ module Ouroboros.Consensus.Byron.Node (
   , PBftLeaderCredentialsError
   , mkPBftLeaderCredentials
   , mkPBftIsLeader
-    -- * Type family instances
-  , CodecConfig(..)
     -- * For testing
   , plcCoreNodeId
   ) where
@@ -194,17 +192,6 @@ mkByronConfig genesisConfig pVer sVer = ByronConfig {
 -------------------------------------------------------------------------------}
 
 instance ConfigSupportsNode ByronBlock where
-
-  data CodecConfig ByronBlock = ByronCodecConfig {
-        getByronEpochSlots    :: !EpochSlots
-      , getByronSecurityParam :: !SecurityParam
-      }
-
-  getCodecConfig bcfg = ByronCodecConfig {
-      getByronEpochSlots    = byronEpochSlots bcfg
-    , getByronSecurityParam = genesisSecurityParam (byronGenesisConfig bcfg)
-    }
-
   getSystemStart =
       SystemStart
     . Genesis.gdStartTime

--- a/ouroboros-consensus-byron/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-byron/tools/db-analyser/Main.hs
@@ -36,7 +36,6 @@ import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..),
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -39,7 +39,6 @@ import           Cardano.Chain.Slotting (EpochSlots)
 import qualified Cardano.Chain.Update as Update
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Config.SupportsNode
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
@@ -5,6 +5,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Shelley.Ledger.Config (
     BlockConfig (..)
+  , CodecConfig (..)
   ) where
 
 import           GHC.Generics (Generic)
@@ -35,3 +36,9 @@ data instance BlockConfig (ShelleyBlock c) = ShelleyConfig {
     }
   deriving stock (Show, Generic)
   deriving anyclass NoUnexpectedThunks
+
+instance HasCodecConfig (ShelleyBlock c) where
+  -- | No particular codec configuration is needed for Shelley
+  data CodecConfig (ShelleyBlock c) = ShelleyCodecConfig
+
+  getCodecConfig = const ShelleyCodecConfig

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -13,7 +13,6 @@
 module Ouroboros.Consensus.Shelley.Node (
     protocolInfoShelley
   , protocolClientInfoShelley
-  , CodecConfig (..)
   , ShelleyGenesis (..)
   , initialFundsPseudoTxIn
   , ShelleyGenesisStaking (..)
@@ -325,11 +324,6 @@ protocolClientInfoShelley =
 -------------------------------------------------------------------------------}
 
 instance ConfigSupportsNode (ShelleyBlock c) where
-
-  -- | No particular codec configuration is needed for Shelley
-  data CodecConfig (ShelleyBlock c) = ShelleyCodecConfig
-
-  getCodecConfig     = const ShelleyCodecConfig
   getSystemStart     = shelleySystemStart
   getNetworkMagic    = shelleyNetworkMagic
   getProtocolMagicId = shelleyProtocolMagicId

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -36,6 +36,7 @@ module Ouroboros.Consensus.Mock.Ledger.Block (
   , countSimpleGenTxs
     -- * Configuration
   , BlockConfig(..)
+  , CodecConfig(..)
   , SimpleLedgerConfig(..)
     -- * Protocol-specific part
   , MockProtocolSpecific(..)
@@ -256,6 +257,13 @@ newtype instance BlockConfig (SimpleBlock c ext) =
     SimpleBlockConfig SecurityParam
   deriving stock   (Generic)
   deriving newtype (NoUnexpectedThunks)
+
+instance HasCodecConfig (SimpleBlock c ext) where
+
+  -- | Only the 'SecurityParam' is required for simple blocks
+  newtype CodecConfig (SimpleBlock c ext) = SimpleCodecConfig SecurityParam
+
+  getCodecConfig (SimpleBlockConfig secParam) = SimpleCodecConfig secParam
 
 instance HasHardForkHistory (SimpleBlock c ext) where
   type HardForkIndices (SimpleBlock c ext) = '[SimpleBlock c ext]

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -18,7 +18,6 @@ import           Cardano.Slotting.Slot
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Config.SecurityParam
-import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.HeaderValidation (defaultDecodeAnnTip,
                      defaultEncodeAnnTip)
 import           Ouroboros.Consensus.Ledger.SupportsProtocol

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
@@ -51,11 +51,6 @@ constructMockProtocolMagicId =
 
 instance RunMockBlock c ext
       => ConfigSupportsNode (SimpleBlock c ext) where
-
-  -- | Only the 'SecurityParam' is required for simple blocks
-  newtype CodecConfig (SimpleBlock c ext) = SimpleCodecConfig SecurityParam
-
-  getCodecConfig (SimpleBlockConfig secParam) = SimpleCodecConfig secParam
   getSystemStart = const $ SystemStart dummyDate
     where
       --  This doesn't matter much

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -71,7 +71,6 @@ import qualified Ouroboros.Network.TxSubmission.Outbound as TxOutbound
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsMempool

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -7,6 +7,7 @@ module Ouroboros.Consensus.Block.Abstract (
     BlockProtocol
     -- * Configuration
   , BlockConfig
+  , HasCodecConfig(..)
     -- * Working with headers
   , GetHeader(..)
   , headerHash
@@ -45,6 +46,15 @@ type family BlockProtocol blk :: *
 
 -- | Static configuration required to work with this type of blocks
 data family BlockConfig blk :: *
+
+class HasCodecConfig blk where
+  -- | Static configuration required for serialisation and deserialisation of
+  -- types pertaining to this type of block.
+  --
+  -- Data family instead of type family to get better type inference.
+  data family CodecConfig blk :: *
+
+  getCodecConfig :: BlockConfig blk -> CodecConfig blk
 
 {-------------------------------------------------------------------------------
   Link block to its header

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config/SupportsNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config/SupportsNode.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}
 module Ouroboros.Consensus.Config.SupportsNode (
     ConfigSupportsNode (..)
   ) where
@@ -14,13 +13,6 @@ import           Ouroboros.Consensus.BlockchainTime (SystemStart)
 -- running a node.
 class ConfigSupportsNode blk where
 
-  -- | Static configuration required for serialisation and deserialisation of
-  -- types pertaining to this type of block.
-  --
-  -- Data family instead of type family to get better type inference.
-  data family CodecConfig blk :: *
-
-  getCodecConfig     :: BlockConfig blk -> CodecConfig blk
   getSystemStart     :: BlockConfig blk -> SystemStart
   getNetworkMagic    :: BlockConfig blk -> NetworkMagic
   getProtocolMagicId :: BlockConfig blk -> ProtocolMagicId

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
@@ -56,7 +56,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Translation as X
 import           Ouroboros.Consensus.HardFork.Combinator.Forge as X ()
 
 -- Instance for 'ConfigSupportsNode'
-import           Ouroboros.Consensus.HardFork.Combinator.Node as X
+import           Ouroboros.Consensus.HardFork.Combinator.Node as X ()
 
 -- Definition of InPairs (required to define translations)
 import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -70,7 +70,6 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Block.Abstract
-import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (allEqual)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -14,8 +14,8 @@
 
 module Ouroboros.Consensus.HardFork.Combinator.Block (
     -- * Type family instances
-    BlockConfig(..)
-  , Header(..)
+    Header(..)
+  , CodecConfig(..)
   ) where
 
 import           Data.FingerTree.Strict (Measured (..))
@@ -93,6 +93,21 @@ instance CanHardFork xs => HasHeader (Header (HardForkBlock xs)) where
   blockNo        =            blockNo       . getHardForkHeader
   blockInvariant = const True
 
+{-------------------------------------------------------------------------------
+  Codec config
+-------------------------------------------------------------------------------}
+
+instance All HasCodecConfig xs => HasCodecConfig (HardForkBlock xs) where
+  newtype CodecConfig (HardForkBlock xs) = HardForkCodecConfig {
+        hardForkCodecConfigPerEra :: PerEraCodecConfig xs
+      }
+
+  getCodecConfig =
+        HardForkCodecConfig
+      . PerEraCodecConfig
+      . hcmap (Proxy @HasCodecConfig) getCodecConfig
+      . getPerEraBlockConfig
+      . hardForkBlockConfigPerEra
 
 {-------------------------------------------------------------------------------
   ConvertRawHash

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -52,6 +52,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Block
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger ()
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger.Query ()
 import           Ouroboros.Consensus.HardFork.Combinator.Mempool
+import           Ouroboros.Consensus.HardFork.Combinator.Node ()
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol ()
 import           Ouroboros.Consensus.HardFork.Combinator.Unary
 
@@ -104,20 +105,22 @@ newtype instance BlockConfig (DegenFork b) = DBCfg {
     }
   deriving (NoUnexpectedThunks)
 
+instance HasCodecConfig b => HasCodecConfig (DegenFork b) where
+  newtype CodecConfig (DegenFork b) = DCCfg {
+        unDCCfg :: CodecConfig (HardForkBlock '[b])
+      }
+
+  getCodecConfig = DCCfg . getCodecConfig . unDBCfg
+
 newtype instance LedgerState (DegenFork b) = DLgr {
       unDLgr :: LedgerState (HardForkBlock '[b])
     }
   deriving (Eq, Show, NoUnexpectedThunks)
 
 instance ConfigSupportsNode b => ConfigSupportsNode (DegenFork b) where
-  newtype CodecConfig (DegenFork b) = DCCfg {
-        unDCCfg :: CodecConfig (HardForkBlock '[b])
-      }
-
-  getCodecConfig     = DCCfg . getCodecConfig     . unDBCfg
-  getSystemStart     =         getSystemStart     . unDBCfg
-  getNetworkMagic    =         getNetworkMagic    . unDBCfg
-  getProtocolMagicId =         getProtocolMagicId . unDBCfg
+  getSystemStart     = getSystemStart     . unDBCfg
+  getNetworkMagic    = getNetworkMagic    . unDBCfg
+  getProtocolMagicId = getProtocolMagicId . unDBCfg
 
 {-------------------------------------------------------------------------------
   Forward HasHeader instances

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
@@ -2,15 +2,10 @@
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeApplications     #-}
-{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
-
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Node (
-    -- * Type family instances
-    CodecConfig(..)
-  ) where
+module Ouroboros.Consensus.HardFork.Combinator.Node () where
 
 import           Data.Proxy
 import           Data.SOP.Strict
@@ -28,17 +23,6 @@ import           Ouroboros.Consensus.HardFork.Combinator.Basics
 
 instance (All ConfigSupportsNode xs, IsNonEmpty xs)
       => ConfigSupportsNode (HardForkBlock xs) where
-  newtype CodecConfig (HardForkBlock xs) = HardForkCodecConfig {
-        hardForkCodecConfigPerEra :: PerEraCodecConfig xs
-      }
-
-  getCodecConfig =
-        HardForkCodecConfig
-      . PerEraCodecConfig
-      . hcmap (Proxy @ConfigSupportsNode) getCodecConfig
-      . getPerEraBlockConfig
-      . hardForkBlockConfigPerEra
-
   getSystemStart     = getSameConfigValue getSystemStart
   getNetworkMagic    = getSameConfigValue getNetworkMagic
   getProtocolMagicId = getSameConfigValue getProtocolMagicId

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
@@ -72,7 +72,6 @@ import           Ouroboros.Network.Block
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Block.Forge
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SupportsNode
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -93,7 +92,6 @@ import           Ouroboros.Consensus.HardFork.Combinator.Forge ()
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
 import           Ouroboros.Consensus.HardFork.Combinator.Mempool
-import           Ouroboros.Consensus.HardFork.Combinator.Node
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol
                      (HardForkEraLedgerView (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -156,16 +156,16 @@ dualTopLevelConfigMain TopLevelConfig{..} = TopLevelConfig{
     , configBlock     = dualBlockConfigMain  configBlock
     }
 
-instance ConfigSupportsNode m => ConfigSupportsNode (DualBlock m a) where
-
+instance HasCodecConfig m => HasCodecConfig (DualBlock m a) where
   newtype CodecConfig (DualBlock m a) = DualCodecConfig {
         dualCodecConfigMain :: CodecConfig m
-      }
+     }
 
   getCodecConfig DualBlockConfig{..} = DualCodecConfig {
         dualCodecConfigMain = getCodecConfig dualBlockConfigMain
       }
 
+instance ConfigSupportsNode m => ConfigSupportsNode (DualBlock m a) where
   getSystemStart     = getSystemStart     . dualBlockConfigMain
   getNetworkMagic    = getNetworkMagic    . dualBlockConfigMain
   getProtocolMagicId = getProtocolMagicId . dualBlockConfigMain

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -55,8 +55,8 @@ import           Ouroboros.Network.Protocol.LocalTxSubmission.Codec
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Server
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.MiniProtocol.ChainSync.Server

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -63,7 +63,6 @@ import           Ouroboros.Network.TxSubmission.Inbound
 import           Ouroboros.Network.TxSubmission.Outbound
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.MiniProtocol.BlockFetch.Server

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -20,7 +20,6 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -48,6 +48,7 @@ class ( LedgerSupportsProtocol    blk
       , HasNetworkProtocolVersion blk
       , CanForge                  blk
       , ConfigSupportsNode        blk
+      , HasCodecConfig            blk
       , ConvertRawHash            blk
         -- TODO: Remove after reconsidering rewindConsensusState:
       , Serialise (HeaderHash blk)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -131,10 +131,12 @@ data instance BlockConfig BlockA = BCfgA
 type instance BlockProtocol BlockA = ProtocolA
 type instance HeaderHash    BlockA = Hash
 
-instance ConfigSupportsNode BlockA where
+instance HasCodecConfig BlockA where
   data CodecConfig BlockA = CCfgA
 
   getCodecConfig     _ = CCfgA
+
+instance ConfigSupportsNode BlockA where
   getSystemStart     _ = SystemStart dawnOfTime
   getNetworkMagic    _ = NetworkMagic 0
   getProtocolMagicId _ = ProtocolMagicId 0

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -123,10 +123,12 @@ data instance BlockConfig BlockB = BCfgB
 type instance BlockProtocol BlockB = ProtocolB
 type instance HeaderHash    BlockB = Hash
 
-instance ConfigSupportsNode BlockB where
+instance HasCodecConfig BlockB where
   data CodecConfig BlockB = CCfgB
 
   getCodecConfig     _ = CCfgB
+
+instance ConfigSupportsNode BlockB where
   getSystemStart     _ = SystemStart dawnOfTime
   getNetworkMagic    _ = NetworkMagic 0
   getProtocolMagicId _ = ProtocolMagicId 0


### PR DESCRIPTION
In the future, we'll need `CodecConfig` and `getCodecConfig` in some contexts
where we don't care about the other methods of `ConfigSupportsNode`, e.g., in
the storage layer.