### PR TITLE
Decouple BinaryInfo from the block encoder

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -248,12 +248,13 @@ instance RunNode DualByronBlock where
   nodeCheckIntegrity cfg = nodeCheckIntegrity (dualTopLevelConfigMain cfg) . dualBlockMain
 
   -- The header is just the concrete header, so we can just reuse the Byron def
-  nodeAddHeaderEnvelope = \_ -> nodeAddHeaderEnvelope pb
+  nodeAddHeaderEnvelope  = \_ -> nodeAddHeaderEnvelope pb
+  nodeGetBinaryBlockInfo = dualBinaryBlockInfo nodeGetBinaryBlockInfo
 
   nodeExceptionIsFatal  = \_ -> nodeExceptionIsFatal pb
 
   -- Encoders
-  nodeEncodeBlockWithInfo  = \_ -> encodeDualBlockWithInfo encodeByronBlockWithInfo
+  nodeEncodeBlock          = \_ -> encodeDualBlock encodeByronBlock
   nodeEncodeHeader         = \ccfg version ->
                                   nodeEncodeHeader
                                     (dualCodecConfigMain ccfg)

--- a/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Serialisation.hs
@@ -34,7 +34,7 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr,
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 
-import           Ouroboros.Consensus.Storage.ImmutableDB (BinaryInfo (..))
+import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
 
 import           Ouroboros.Consensus.Byron.Ledger
 import           Ouroboros.Consensus.Byron.Node
@@ -66,7 +66,7 @@ tests = testGroup "Byron"
         -- TODO ConsensusState
         -- TODO LedgerState
 
-    , testProperty "BinaryInfo sanity check"   prop_encodeByronBlockWithInfo
+    , testProperty "BinaryBlockInfo sanity check" prop_byronBinaryBlockInfo
     , testGroup "ConvertRawHashInfo sanity check"
         [ testProperty "fromRawHash/toRawHash" prop_fromRawHash_toRawHash
         , testProperty "hashSize sanity check" prop_hashSize
@@ -130,21 +130,21 @@ prop_roundtrip_Result =
       (decodeByronResult GetUpdateInterfaceState)
 
 {-------------------------------------------------------------------------------
-  BinaryInfo
+  BinaryBlockInfo
 -------------------------------------------------------------------------------}
 
-prop_encodeByronBlockWithInfo :: ByronBlock -> Property
-prop_encodeByronBlockWithInfo blk =
+prop_byronBinaryBlockInfo :: ByronBlock -> Property
+prop_byronBinaryBlockInfo blk =
     headerAnnotation === extractedHeader
   where
-    BinaryInfo { binaryBlob, headerOffset, headerSize } =
-      encodeByronBlockWithInfo blk
+    BinaryBlockInfo { headerOffset, headerSize } =
+      byronBinaryBlockInfo blk
 
     extractedHeader :: Lazy.ByteString
     extractedHeader =
         Lazy.take (fromIntegral headerSize)   $
         Lazy.drop (fromIntegral headerOffset) $
-        toLazyByteString binaryBlob
+        toLazyByteString (encodeByronBlock blk)
 
     headerAnnotation :: Lazy.ByteString
     headerAnnotation = Lazy.fromStrict $ case byronBlockRaw blk of

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
@@ -7,7 +7,6 @@
 module Ouroboros.Consensus.Byron.Ledger.Serialisation (
     -- * Serialisation
     byronBlockEncodingOverhead
-  , encodeByronBlockWithInfo
   , encodeByronBlock
   , decodeByronBlock
   , encodeByronHeader
@@ -18,6 +17,7 @@ module Ouroboros.Consensus.Byron.Ledger.Serialisation (
   , decodeByronHeaderHash
     -- * Support for on-disk format
   , byronAddHeaderEnvelope
+  , byronBinaryBlockInfo
     -- * Exceptions
   , DropEncodedSizeException(..)
     -- * Low-level API
@@ -50,7 +50,7 @@ import           Ouroboros.Network.DeltaQ (SizeInBytes)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 
-import           Ouroboros.Consensus.Storage.ImmutableDB (BinaryInfo (..))
+import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
 
 import           Ouroboros.Consensus.Byron.Ledger.Block
 import           Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
@@ -102,27 +102,6 @@ encodeByronHeaderHash = toCBOR
 
 decodeByronHeaderHash :: Decoder s (HeaderHash ByronBlock)
 decodeByronHeaderHash = fromCBOR
-
--- | 'encodeByronBlock' including the offset and size of the header within the
--- resulting bytestring.
---
--- NOTE: the bytestring obtained by slicing the serialised block using the
--- header offset and size will correspond to the /header annotation/, but not
--- to the serialised header, as we add an envelope ('encodeListLen' + tag)
--- around a header in 'encodeByronHeader'. This envelope must thus still be
--- added to the sliced bytestring before it can be deserialised using
--- 'decodeByronHeader'.
-encodeByronBlockWithInfo :: ByronBlock -> BinaryInfo Encoding
-encodeByronBlockWithInfo blk = BinaryInfo
-    { binaryBlob   = encodeByronBlock blk
-    , headerOffset = 1 {- 'encodeListLen' of the outer 'Either' envelope -}
-                   + 1 {- the tag -}
-                   + 1 {- 'encodeListLen' of the block: header + body + ...  -}
-      -- Compute the length of the annotated header
-    , headerSize   = fromIntegral $ Strict.length $ case byronBlockRaw blk of
-        CC.ABOBBoundary b -> CC.boundaryHeaderAnnotation $ CC.boundaryHeader b
-        CC.ABOBBlock    b -> CC.headerAnnotation         $ CC.blockHeader    b
-    }
 
 -- | Encode a block
 --
@@ -294,6 +273,25 @@ ebbEnvelope :: IsEBB -> Lazy.ByteString
 ebbEnvelope = \case
   IsEBB    -> "\130\NUL"
   IsNotEBB -> "\130\SOH"
+
+-- | The 'BinaryBlockInfo' of the given 'ByronBlock'.
+--
+-- NOTE: the bytestring obtained by slicing the serialised block using the
+-- header offset and size will correspond to the /header annotation/, but not
+-- to the serialised header, as we add an envelope ('encodeListLen' + tag)
+-- around a header in 'encodeByronHeader'. This envelope must thus still be
+-- added to the sliced bytestring before it can be deserialised using
+-- 'decodeByronHeader'.
+byronBinaryBlockInfo :: ByronBlock -> BinaryBlockInfo
+byronBinaryBlockInfo blk = BinaryBlockInfo
+    { headerOffset = 1 {- 'encodeListLen' of the outer 'Either' envelope -}
+                   + 1 {- the tag -}
+                   + 1 {- 'encodeListLen' of the block: header + body + ...  -}
+      -- Compute the length of the annotated header
+    , headerSize   = fromIntegral $ Strict.length $ case byronBlockRaw blk of
+        CC.ABOBBoundary b -> CC.boundaryHeaderAnnotation $ CC.boundaryHeader b
+        CC.ABOBBlock    b -> CC.headerAnnotation         $ CC.blockHeader    b
+    }
 
 {-------------------------------------------------------------------------------
   Sized header

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -236,6 +236,7 @@ instance RunNode ByronBlock where
 
   nodeCheckIntegrity        = verifyBlockIntegrity . configBlock
   nodeAddHeaderEnvelope     = const byronAddHeaderEnvelope
+  nodeGetBinaryBlockInfo    = byronBinaryBlockInfo
   nodeExceptionIsFatal _ e
     | Just (_ :: DropEncodedSizeException) <- fromException e
     = Just DatabaseCorruption
@@ -243,7 +244,7 @@ instance RunNode ByronBlock where
     = Nothing
 
 
-  nodeEncodeBlockWithInfo   = \_    -> encodeByronBlockWithInfo
+  nodeEncodeBlock           = \_    -> encodeByronBlock
   nodeEncodeHeader          = \_    -> encodeByronHeader
   nodeEncodeWrappedHeader   = \_    -> encodeWrappedByronHeader
   nodeEncodeGenTx           = \_    -> encodeByronGenTx

--- a/ouroboros-consensus-byron/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-byron/tools/db-analyser/Main.hs
@@ -358,14 +358,15 @@ withImmDB fp cfg chunkInfo registry = ImmDB.withImmDB args
 
     args :: ImmDbArgs IO ByronBlock
     args = (defaultArgs fp) {
-          immDecodeHash     = nodeDecodeHeaderHash    ccfg
-        , immDecodeBlock    = nodeDecodeBlock         ccfg
-        , immDecodeHeader   = nodeDecodeHeader        ccfg SerialisedToDisk
-        , immEncodeHash     = nodeEncodeHeaderHash    ccfg
-        , immEncodeBlock    = nodeEncodeBlockWithInfo ccfg
-        , immChunkInfo      = chunkInfo
-        , immValidation     = ValidateMostRecentChunk
-        , immCheckIntegrity = nodeCheckIntegrity      cfg
-        , immAddHdrEnv      = nodeAddHeaderEnvelope   pb
-        , immRegistry       = registry
+          immDecodeHash         = nodeDecodeHeaderHash    ccfg
+        , immDecodeBlock        = nodeDecodeBlock         ccfg
+        , immDecodeHeader       = nodeDecodeHeader        ccfg SerialisedToDisk
+        , immEncodeHash         = nodeEncodeHeaderHash    ccfg
+        , immEncodeBlock        = nodeEncodeBlock         ccfg
+        , immGetBinaryBlockInfo = nodeGetBinaryBlockInfo
+        , immChunkInfo          = chunkInfo
+        , immValidation         = ValidateMostRecentChunk
+        , immCheckIntegrity     = nodeCheckIntegrity      cfg
+        , immAddHdrEnv          = nodeAddHeaderEnvelope   pb
+        , immRegistry           = registry
         }

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -351,8 +351,9 @@ instance TPraosCrypto c => RunNode (ShelleyBlock c) where
         tpraosParams $ configConsensus cfg
 
   nodeAddHeaderEnvelope _ _isEBB _blockSize = shelleyAddHeaderEnvelope
+  nodeGetBinaryBlockInfo   = shelleyBinaryBlockInfo
 
-  nodeEncodeBlockWithInfo  = \_   -> encodeShelleyBlockWithInfo
+  nodeEncodeBlock          = \_   -> encodeShelleyBlock
   nodeEncodeHeader         = \_ _ -> encodeShelleyHeader
   nodeEncodeWrappedHeader  = \_ _ -> encode
   nodeEncodeGenTx          = \_   -> toCBOR

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -57,7 +57,7 @@ module Ouroboros.Consensus.Mock.Ledger.Block (
     -- * Serialisation
   , encodeSimpleHeader
   , decodeSimpleHeader
-  , simpleBlockBinaryInfo
+  , simpleBlockBinaryBlockInfo
   ) where
 
 import qualified Codec.CBOR.Decoding as CBOR
@@ -92,7 +92,7 @@ import           Ouroboros.Consensus.Util ((.:))
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 
-import           Ouroboros.Consensus.Storage.ImmutableDB (BinaryInfo (..))
+import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
 
 {-------------------------------------------------------------------------------
   Definition of a block
@@ -497,10 +497,9 @@ instance (SimpleCrypto c, Serialise ext')
   encode = encodeSimpleHeader encode
   decode = decodeSimpleHeader encode decode
 
-simpleBlockBinaryInfo :: (SimpleCrypto c, Serialise ext')
-                      => SimpleBlock' c ext ext' -> BinaryInfo CBOR.Encoding
-simpleBlockBinaryInfo b = BinaryInfo
-    { binaryBlob   = encode b
-    , headerOffset = 2 -- For the 'encodeListLen'
+simpleBlockBinaryBlockInfo :: (SimpleCrypto c, Serialise ext')
+                           => SimpleBlock' c ext ext' -> BinaryBlockInfo
+simpleBlockBinaryBlockInfo b = BinaryBlockInfo
+    { headerOffset = 2 -- For the 'encodeListLen'
     , headerSize   = fromIntegral $ Lazy.length $ serialise (getHeader b)
     }

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -49,8 +49,9 @@ instance ( LedgerSupportsProtocol (SimpleBlock SimpleMockCrypto ext)
   nodeImmDbChunkInfo        = \cfg -> simpleChunkInfo $
     EpochSize $ 10 * maxRollbacks (configSecurityParam cfg)
   nodeCheckIntegrity        = \_ _ -> True
+  nodeGetBinaryBlockInfo    = simpleBlockBinaryBlockInfo
 
-  nodeEncodeBlockWithInfo   = \_   -> simpleBlockBinaryInfo
+  nodeEncodeBlock           = \_   -> encode
   nodeEncodeHeader          = \_ _ -> encode
   nodeEncodeWrappedHeader   = \_ _ -> encode
   nodeEncodeGenTx           = \_   -> encode

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/Consensus/Ledger/Mock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/Consensus/Ledger/Mock.hs
@@ -23,7 +23,7 @@ import           Ouroboros.Consensus.Block (ConvertRawHash (..), getHeader)
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Ledger.UTxO
 
-import           Ouroboros.Consensus.Storage.ImmutableDB (BinaryInfo (..))
+import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
 
 import           Test.QuickCheck
 import           Test.Tasty
@@ -42,7 +42,7 @@ tests = testGroup "Mock"
              )
           => proxy c -> String -> TestTree
     props _ title = testGroup title
-      [ testProperty "BinaryInfo sanity check" (prop_simpleBlockBinaryInfo @c @())
+      [ testProperty "BinaryBlockInfo sanity check" (prop_simpleBlockBinaryBlockInfo @c @())
       , testGroup "ConvertRawHash sanity check"
           [ testProperty "fromRawHash/toRawHash" (prop_simpleBlock_fromRawHash_toRawHash @c @())
           , testProperty "hashSize sanity check" (prop_simpleBlock_hashSize @c @())
@@ -50,22 +50,22 @@ tests = testGroup "Mock"
       ]
 
 {-------------------------------------------------------------------------------
-  BinaryInfo
+  BinaryBlockInfo
 -------------------------------------------------------------------------------}
 
-prop_simpleBlockBinaryInfo
+prop_simpleBlockBinaryBlockInfo
   :: (SimpleCrypto c, Serialise ext) => SimpleBlock c ext -> Property
-prop_simpleBlockBinaryInfo blk =
+prop_simpleBlockBinaryBlockInfo blk =
     serialisedHeader === extractedHeader
   where
-    BinaryInfo { binaryBlob, headerOffset, headerSize } =
-      simpleBlockBinaryInfo blk
+    BinaryBlockInfo { headerOffset, headerSize } =
+      simpleBlockBinaryBlockInfo blk
 
     extractedHeader :: Lazy.ByteString
     extractedHeader =
         Lazy.take (fromIntegral headerSize)   $
         Lazy.drop (fromIntegral headerOffset) $
-        toLazyByteString binaryBlob
+        toLazyByteString (encode blk)
 
     serialisedHeader :: Lazy.ByteString
     serialisedHeader = toLazyByteString $

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -585,7 +585,7 @@ runThreadNetwork ThreadNetworkArgs
         , cdbDecodeAnnTip         = nodeDecodeAnnTip         ccfg
           -- Encoders
         , cdbEncodeHash           = nodeEncodeHeaderHash     ccfg
-        , cdbEncodeBlock          = nodeEncodeBlockWithInfo  ccfg
+        , cdbEncodeBlock          = nodeEncodeBlock          ccfg
         , cdbEncodeHeader         = nodeEncodeHeader         ccfg SerialisedToDisk
         , cdbEncodeLedger         = nodeEncodeLedgerState    ccfg
         , cdbEncodeConsensusState = nodeEncodeConsensusState ccfg
@@ -609,6 +609,7 @@ runThreadNetwork ThreadNetworkArgs
                                       (configLedger cfg)
                                       (unwrapLogicalClock clock)
         , cdbAddHdrEnv            = nodeAddHeaderEnvelope (Proxy @blk)
+        , cdbGetBinaryBlockInfo   = nodeGetBinaryBlockInfo
         , cdbImmDbCacheConfig     = Index.CacheConfig 2 60
         -- Misc
         , cdbTracer               = instrumentationTracer <> nullDebugTracer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -295,6 +295,9 @@ instance (SingleEraBlock b, RunNode b) => RunNode (DegenFork b) where
 
   nodeImmDbChunkInfo  cfg = nodeImmDbChunkInfo (projCfg cfg)
 
+  nodeGetBinaryBlockInfo (DBlk blk) =
+      nodeGetBinaryBlockInfo (projBlock blk)
+
   nodeAddHeaderEnvelope _ = nodeAddHeaderEnvelope (Proxy @b)
   nodeExceptionIsFatal  _ = nodeExceptionIsFatal  (Proxy @b)
 
@@ -307,8 +310,6 @@ instance (SingleEraBlock b, RunNode b) => RunNode (DegenFork b) where
 
   -- Encoders
 
-  nodeEncodeBlockWithInfo (DCCfg cfg) (DBlk blk) =
-      nodeEncodeBlockWithInfo (projCodecConfig cfg) (projBlock blk)
   nodeEncodeBlock (DCCfg cfg) (DBlk blk) =
       nodeEncodeBlock (projCodecConfig cfg) (projBlock blk)
   nodeEncodeHeader (DCCfg cfg) version (DHdr hdr) =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/HasBlockBody.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/HasBlockBody.hs
@@ -16,7 +16,6 @@ module Ouroboros.Consensus.HardFork.Combinator.HasBlockBody (
     -- * HFC support
   , SerialiseHeaderBody(..)
   , Body(..)
-  , encodeHardForkBlock
   , hardForkBlockBinaryBlockInfo
   , toSerialiseOneHeader
   , toSerialiseOneBody
@@ -152,10 +151,8 @@ instance ( CanHardFork xs
         Nothing  -> fail "SerialiseHeaderBody: header/body mismatch"
         Just blk -> return $ SerialiseHeaderBody blk
 
--- | Encode a hard fork block
+-- | 'BinaryBlockInfo' for 'HardForkBlock'
 --
--- NOTE: This uses 'SerialiseHeaderBody' to serialise the header and body
--- separately, and then 'SerialiseOne' to encode the header and the body.
 -- This function is only useable if that serialisation strategy is used
 -- consistently. See 'toSerialiseOneHeader' and friends. Typically used with
 --
@@ -164,21 +161,6 @@ instance ( CanHardFork xs
 -- >
 -- > deriving via SerialiseOne Header SomeEras
 -- >          instance Serialise (Header SomeBlock)
---
-encodeHardForkBlock
-  :: ( CanHardFork xs
-     , All HasBlockBody xs
-     , All (Compose Serialise Header) xs
-     , All (Compose Serialise Body) xs
-     )
-  => HardForkBlock xs
-  -> Encoding
-encodeHardForkBlock = encode . SerialiseHeaderBody
-
--- | Return the 'BinaryBlockInfo' of a 'HardForkBlock'.
---
--- NOTE: This function is only useable if the 'SerialiseHeaderBody'
--- serialisation strategy is used.
 --
 -- TODO: The way this is currently defined is not very efficient; this is not
 -- a big deal right now as this is currently only used for tests.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -585,9 +585,6 @@ agreeOnError f (ma, mb) =
   For now we just require 'Serialise' for the auxiliary block.
 -------------------------------------------------------------------------------}
 
--- | The binary info just refers to the main block
---
--- This is sufficient, because we never need just the header of the auxiliary.
 encodeDualBlock :: (Bridge m a, Serialise a)
                 => (m -> Encoding)
                 -> DualBlock m a -> Encoding
@@ -693,6 +690,9 @@ decodeDualLedgerState decodeMain = do
       <*> decode
       <*> decode
 
+-- | The binary info just refers to the main block
+--
+-- This is sufficient, because we never need just the header of the auxiliary.
 dualBinaryBlockInfo :: (m -> BinaryBlockInfo)
                     -> DualBlock m a -> BinaryBlockInfo
 dualBinaryBlockInfo mainGetBinaryBlockInfo DualBlock{..} =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -35,7 +35,7 @@ module Ouroboros.Consensus.Ledger.Dual (
   , GenTx(..)
   , TxId(..)
     -- * Serialisation
-  , encodeDualBlockWithInfo
+  , encodeDualBlock
   , decodeDualBlock
   , encodeDualHeader
   , decodeDualHeader
@@ -47,6 +47,7 @@ module Ouroboros.Consensus.Ledger.Dual (
   , decodeDualGenTxErr
   , encodeDualLedgerState
   , decodeDualLedgerState
+  , dualBinaryBlockInfo
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)
@@ -64,8 +65,6 @@ import           Cardano.Prelude (AllowThunk (..), NoUnexpectedThunks)
 
 import           Ouroboros.Network.Block
 
-import           Ouroboros.Consensus.Storage.Common
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Config.SupportsNode
@@ -76,6 +75,8 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Util.Condense
+
+import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
 
 {-------------------------------------------------------------------------------
   Block
@@ -587,23 +588,15 @@ agreeOnError f (ma, mb) =
 -- | The binary info just refers to the main block
 --
 -- This is sufficient, because we never need just the header of the auxiliary.
-encodeDualBlockWithInfo :: (Bridge m a, Serialise a)
-                        => (m -> BinaryInfo Encoding)
-                        -> DualBlock m a -> BinaryInfo Encoding
-encodeDualBlockWithInfo encodeMainWithInfo DualBlock{..} =
-    BinaryInfo {
-        headerSize   = headerSize   mainWithInfo
-      , headerOffset = headerOffset mainWithInfo + 1
-      , binaryBlob   = mconcat [
-                           encodeListLen 3
-                         , binaryBlob mainWithInfo
-                         , encode dualBlockAux
-                         , encode dualBlockBridge
-                         ]
-      }
-  where
-    mainWithInfo :: BinaryInfo Encoding
-    mainWithInfo = encodeMainWithInfo dualBlockMain
+encodeDualBlock :: (Bridge m a, Serialise a)
+                => (m -> Encoding)
+                -> DualBlock m a -> Encoding
+encodeDualBlock encodeMain DualBlock{..} = mconcat [
+        encodeListLen 3
+      , encodeMain dualBlockMain
+      , encode dualBlockAux
+      , encode dualBlockBridge
+      ]
 
 decodeDualBlock :: (Bridge m a, Serialise a)
                 => Decoder s (Lazy.ByteString -> m)
@@ -699,3 +692,14 @@ decodeDualLedgerState decodeMain = do
       <$> decodeMain
       <*> decode
       <*> decode
+
+dualBinaryBlockInfo :: (m -> BinaryBlockInfo)
+                    -> DualBlock m a -> BinaryBlockInfo
+dualBinaryBlockInfo mainGetBinaryBlockInfo DualBlock{..} =
+    BinaryBlockInfo {
+        headerSize   = headerSize   mainBinaryBlockInfo
+      , headerOffset = headerOffset mainBinaryBlockInfo + 1
+      }
+  where
+    mainBinaryBlockInfo :: BinaryBlockInfo
+    mainBinaryBlockInfo = mainGetBinaryBlockInfo dualBlockMain

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -387,7 +387,7 @@ mkChainDbArgs tracer registry inFuture dbPath cfg initLedger
     , ChainDB.cdbDecodeHash           = nodeDecodeHeaderHash     ccfg
     , ChainDB.cdbDecodeLedger         = nodeDecodeLedgerState    ccfg
     , ChainDB.cdbDecodeAnnTip         = nodeDecodeAnnTip         ccfg
-    , ChainDB.cdbEncodeBlock          = nodeEncodeBlockWithInfo  ccfg
+    , ChainDB.cdbEncodeBlock          = nodeEncodeBlock          ccfg
     , ChainDB.cdbEncodeHeader         = nodeEncodeHeader         ccfg SerialisedToDisk
     , ChainDB.cdbEncodeConsensusState = nodeEncodeConsensusState ccfg
     , ChainDB.cdbEncodeHash           = nodeEncodeHeaderHash     ccfg
@@ -395,6 +395,7 @@ mkChainDbArgs tracer registry inFuture dbPath cfg initLedger
     , ChainDB.cdbEncodeAnnTip         = nodeEncodeAnnTip         ccfg
     , ChainDB.cdbChunkInfo            = chunkInfo
     , ChainDB.cdbGenesis              = return initLedger
+    , ChainDB.cdbGetBinaryBlockInfo   = nodeGetBinaryBlockInfo
     , ChainDB.cdbAddHdrEnv            = nodeAddHeaderEnvelope    pb
     , ChainDB.cdbDiskPolicy           = defaultDiskPolicy k
     , ChainDB.cdbCheckIntegrity       = nodeCheckIntegrity       cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -33,8 +33,8 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB)
-import           Ouroboros.Consensus.Storage.ImmutableDB (BinaryInfo (..),
-                     ChunkInfo)
+import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
+import           Ouroboros.Consensus.Storage.ImmutableDB (ChunkInfo)
 
 {-------------------------------------------------------------------------------
   RunNode proper
@@ -67,6 +67,10 @@ class ( LedgerSupportsProtocol    blk
   -- whether the transactions are valid w.r.t. the ledger, or whether it's
   -- sent by a malicious node.
   nodeCheckIntegrity :: TopLevelConfig blk -> blk -> Bool
+
+  -- | Return information about the serialised block, i.e., how to extract the
+  -- bytes corresponding to the header from the serialised block.
+  nodeGetBinaryBlockInfo :: blk -> BinaryBlockInfo
 
   -- | When extracting the bytes corresponding to header from a serialised
   -- block, it may be necessary to add an envelope to it to obtain a
@@ -122,9 +126,7 @@ class ( LedgerSupportsProtocol    blk
   nodeExceptionIsFatal _ _ = Nothing
 
   -- Encoders
-  nodeEncodeBlockWithInfo  :: CodecConfig blk -> blk -> BinaryInfo Encoding
   nodeEncodeBlock          :: CodecConfig blk -> blk -> Encoding
-  nodeEncodeBlock cfg blk = binaryBlob $ nodeEncodeBlockWithInfo cfg blk
   nodeEncodeHeader         :: CodecConfig blk
                            -> SerialisationVersion blk
                            -> Header blk -> Encoding

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
@@ -132,7 +132,7 @@ data ImmutableDB hash m = ImmutableDB
     --
     -- TODO the given binary blob may not be empty.
   , appendBlock_
-      :: HasCallStack => SlotNo -> BlockNo -> hash -> BinaryInfo Builder -> m ()
+      :: HasCallStack => SlotNo -> BlockNo -> hash -> Builder -> BinaryBlockInfo -> m ()
 
     -- | Appends a block as the EBB of the given epoch.
     --
@@ -147,7 +147,7 @@ data ImmutableDB hash m = ImmutableDB
     --
     -- TODO the given binary blob may not be empty.
   , appendEBB_
-      :: HasCallStack => EpochNo -> BlockNo -> hash -> BinaryInfo Builder -> m ()
+      :: HasCallStack => EpochNo -> BlockNo -> hash -> Builder -> BinaryBlockInfo -> m ()
 
     -- | Return an 'Iterator' to efficiently stream binary blocks out of the
     -- database.
@@ -312,13 +312,13 @@ getBlockOrEBBComponent = getBlockOrEBBComponent_
 appendBlock
   :: HasCallStack
   => ImmutableDB hash m
-  -> SlotNo -> BlockNo -> hash -> BinaryInfo Builder -> m ()
+  -> SlotNo -> BlockNo -> hash -> Builder -> BinaryBlockInfo -> m ()
 appendBlock = appendBlock_
 
 appendEBB
   :: HasCallStack
   => ImmutableDB hash m
-  -> EpochNo -> BlockNo -> hash -> BinaryInfo Builder -> m ()
+  -> EpochNo -> BlockNo -> hash -> Builder -> BinaryBlockInfo -> m ()
 appendEBB = appendEBB_
 
 stream

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Parser.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Parser.hs
@@ -78,7 +78,7 @@ chunkFileParser'
   -> (blk -> Maybe EpochNo)    -- ^ If an EBB, return the epoch number
   -> HasFS m h
   -> (forall s. Decoder s (BL.ByteString -> blk))
-  -> (blk -> BinaryInfo ())
+  -> (blk -> BinaryBlockInfo)
   -> (blk -> Bool)             -- ^ Check integrity of the block. 'False' =
                                -- corrupt.
   -> ChunkFileParser
@@ -87,7 +87,7 @@ chunkFileParser'
        (BlockSummary hash)
        hash
 chunkFileParser' getSlotNo getBlockNo getHash getPrevHash isEBB hasFS decodeBlock
-                 getBinaryInfo isNotCorrupt =
+                 getBinaryBlockInfo isNotCorrupt =
     ChunkFileParser $ \fsPath expectedChecksums k ->
       Util.CBOR.withStreamIncrementalOffsets hasFS decoder fsPath
         ( k
@@ -166,7 +166,7 @@ chunkFileParser' getSlotNo getBlockNo getHash getPrevHash isEBB hasFS decodeBloc
               Just epoch -> EBB epoch
               Nothing    -> Block (getSlotNo blk)
           }
-        BinaryInfo { headerOffset, headerSize } = getBinaryInfo blk
+        BinaryBlockInfo { headerOffset, headerSize } = getBinaryBlockInfo blk
 
     checkIfHashesLineUp
       :: Stream (Of (BlockSummary hash, WithOrigin hash))
@@ -195,7 +195,7 @@ chunkFileParser
   :: forall m blk h. (IOLike m, HasHeader blk, GetHeader blk)
   => HasFS m h
   -> (forall s. Decoder s (BL.ByteString -> blk))
-  -> (blk -> BinaryInfo ())
+  -> (blk -> BinaryBlockInfo)
   -> (blk -> Bool)           -- ^ Check integrity of the block. 'False' =
                              -- corrupt.
   -> ChunkFileParser

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Types.hs
@@ -17,7 +17,7 @@ module Ouroboros.Consensus.Storage.ImmutableDB.Types
   , BlockOrEBB (..)
   , isBlockOrEBB
   , HashInfo (..)
-  , BinaryInfo (..)
+  , BinaryBlockInfo (..)
   , ChunkFileParser (..)
   , ValidationPolicy (..)
   , WrongBoundError (..)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -46,6 +46,7 @@ module Ouroboros.Consensus.Util (
   , (.:)
   , (..:)
   , (...:)
+  , (....:)
     -- * Miscellaneous
   , fib
   ) where
@@ -239,6 +240,9 @@ allDisjoint = go Set.empty
 
 (...:) :: (e -> f) -> (a -> b -> c -> d -> e) -> (a -> b -> c -> d -> f)
 (f ...: g) a b c d = f (g a b c d)
+
+(....:) :: (f -> g) -> (a -> b -> c -> d -> e -> f) -> (a -> b -> c -> d -> e -> g)
+(f ....: g) a b c d e = f (g a b c d e)
 
 {-------------------------------------------------------------------------------
   Miscellaneous

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -308,8 +308,8 @@ instance RunNode TestBlock where
                             . lcfgA_eraParams
                             . firstEraLedgerConfig
                             . configLedger
+  nodeGetBinaryBlockInfo    = hardForkBlockBinaryBlockInfo
 
-  nodeEncodeBlockWithInfo   = \_   -> encodeHardForkBlockWithInfo
   nodeEncodeBlock           = \_   -> encode
   nodeEncodeHeader          = \_ _ -> encode
   nodeEncodeGenTx           = \_   -> encode . fromNS (Proxy @GenTx)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1502,7 +1502,7 @@ mkArgs cfg (MaxClockSkew maxClockSkew) chunkInfo initLedger tracer registry varC
 
       -- Encoders
     , cdbEncodeHash           = encode
-    , cdbEncodeBlock          = testBlockToBinaryInfo
+    , cdbEncodeBlock          = encode
     , cdbEncodeHeader         = encode
     , cdbEncodeLedger         = encode
     , cdbEncodeConsensusState = encode
@@ -1534,6 +1534,7 @@ mkArgs cfg (MaxClockSkew maxClockSkew) chunkInfo initLedger tracer registry varC
                                   (readTVar varCurSlot)
                                   maxClockSkew
     , cdbAddHdrEnv            = \_ _ -> id
+    , cdbGetBinaryBlockInfo   = testBlockBinaryBlockInfo
     , cdbImmDbCacheConfig     = Index.CacheConfig 2 60
 
     -- Misc

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -3,7 +3,6 @@
 module Test.Ouroboros.Storage.ImmutableDB (tests) where
 
 import qualified Codec.Serialise as S
-import           Control.Monad (void)
 import           Control.Tracer (nullTracer)
 
 import           Test.Tasty (TestTree, testGroup)
@@ -63,9 +62,11 @@ openTestDB registry hasFS =
       , parser
       }
   where
-    parser = chunkFileParser hasFS (const <$> S.decode) getBinaryInfo
-      testBlockIsValid
-    getBinaryInfo = void . testBlockToBinaryInfo
+    parser = chunkFileParser
+               hasFS
+               (const <$> S.decode)
+               testBlockBinaryBlockInfo
+               testBlockIsValid
 
 -- Shorthand
 withTestDB :: (HasCallStack, IOLike m, Eq h)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -6,7 +6,7 @@ module Test.Ouroboros.Storage.ImmutableDB.Mock (openDBMock) where
 import           Data.Bifunctor (first)
 import           Data.Tuple (swap)
 
-import           Ouroboros.Consensus.Util ((...:), (..:), (.:))
+import           Ouroboros.Consensus.Util ((....:), (...:), (..:), (.:))
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Consensus.Storage.Common (BlockComponent)
@@ -27,13 +27,13 @@ openDBMock chunkInfo = do
     immDB :: StrictTVar m (DBModel hash) -> ImmutableDB hash m
     immDB dbVar = ImmutableDB
         { closeDB_                = return ()
-        , getTip_                 = query       $ getTipModel
-        , getBlockComponent_      = queryE     .: getBlockComponentModel
-        , getEBBComponent_        = queryE     .: getEBBComponentModel
-        , getBlockOrEBBComponent_ = queryE    ..: getBlockOrEBBComponentModel
-        , appendBlock_            = updateE_ ...: appendBlockModel
-        , appendEBB_              = updateE_ ...: appendEBBModel
-        , stream_                 = updateEE ...: \_rr bc s e -> fmap (fmap (first (iterator bc))) . streamModel s e
+        , getTip_                 = query        $ getTipModel
+        , getBlockComponent_      = queryE      .: getBlockComponentModel
+        , getEBBComponent_        = queryE      .: getEBBComponentModel
+        , getBlockOrEBBComponent_ = queryE     ..: getBlockOrEBBComponentModel
+        , appendBlock_            = updateE_ ....: appendBlockModel
+        , appendEBB_              = updateE_ ....: appendEBBModel
+        , stream_                 = updateEE  ...: \_rr bc s e -> fmap (fmap (first (iterator bc))) . streamModel s e
         }
       where
         iterator :: BlockComponent (ImmutableDB hash m) b

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -45,7 +45,7 @@ import           GHC.Generics (Generic)
 import           Ouroboros.Network.Block (MaxSlotNo (..), SlotNo)
 import           Ouroboros.Network.Point (WithOrigin)
 
-import           Ouroboros.Consensus.Storage.Common (BinaryInfo (..),
+import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..),
                      BlockComponent (..), extractHeader)
 import           Ouroboros.Consensus.Storage.FS.API.Types (FsPath)
 import           Ouroboros.Consensus.Storage.VolatileDB.API
@@ -259,11 +259,13 @@ extractBlockComponent (BlockInfo {..}, bytes) = go
       GetPure a     -> a
       GetApply f bc -> go f $ go bc
 
-    header = extractHeader BinaryInfo {
-        binaryBlob   = bytes
-      , headerOffset = bheaderOffset
-      , headerSize   = bheaderSize
-      }
+    header =
+      extractHeader
+        BinaryBlockInfo {
+            headerOffset = bheaderOffset
+          , headerSize   = bheaderSize
+          }
+        bytes
 
 putBlockModel
   :: forall blockId. Ord blockId

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -183,7 +183,7 @@ deriving instance ToExpr EBB
 deriving instance ToExpr TestHeader
 deriving instance ToExpr TestBody
 deriving instance ToExpr TestBlock
-deriving instance ToExpr (BinaryInfo ByteString)
+deriving instance ToExpr BinaryBlockInfo
 deriving instance ToExpr (ChainHash TestHeader)
 deriving instance ToExpr BlockNo
 
@@ -584,7 +584,7 @@ test cmds = do
 
     let hasFS  = mkSimErrorHasFS varFs varErrors
         parser = blockFileParser' hasFS
-          testBlockToBinaryInfo (const <$> decode) testBlockIsValid
+          testBlockBinaryBlockInfo (const <$> decode) testBlockIsValid
           ValidateAll
         args = VolatileDbArgs
           { hasFS


### PR DESCRIPTION
Closes #2145.

Split

    nodeEncodeBlockWithInfo  :: CodecConfig blk -> blk -> BinaryInfo Encoding

Up into

    nodeGetBinaryBlockInfo :: blk -> BinaryBlockInfo
    nodeEncodeBlock        :: CodecConfig blk -> blk -> Encoding

where `BinaryBlockInfo` is the former `BinaryInfo` without its `blob`
argument. This also means `Binary(Block)Info` is no longer a functor, closing
issue #2145.

The reason both were coupled is that we thought that the information would be
computed during encoding, making it more efficient to do both at the same
time. However, for all real ledgers, we use annotations, making it cheap to
compute the `BinaryBlockInfo` without any real encoding work to be done.

Splitting them up will make later refactorings of the encoders/decoders
easier.