### PR TITLE
Added -Wall to ouroboros-protocol-tests library

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -208,6 +208,8 @@ library ouroboros-protocol-tests
                        typed-protocols,
                        ouroboros-network-framework,
                        ouroboros-network
+  ghc-options:         -Wall
+                       -Wno-unticked-promoted-constructors
 
 test-suite test-network
   type:                exitcode-stdio-1.0

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -24,7 +24,6 @@ import           Network.TypedProtocol.Proofs
 
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec
-import           Ouroboros.Network.Driver
 import           Ouroboros.Network.Driver.Simple (runConnectedPeers)
 
 import           Ouroboros.Network.Block (Serialised (..), StandardHash,

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Direct.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Direct.hs
@@ -4,17 +4,9 @@ module Ouroboros.Network.Protocol.Handshake.Direct
   ( pureHandshake
   ) where
 
-import           Control.Exception
-import           Data.Text (Text)
 import           Data.Typeable (Typeable, cast)
-import           Data.Map (Map)
 import qualified Data.Map as Map
 
-import qualified Codec.CBOR.Term     as CBOR
-
-import           Network.TypedProtocol.Core
-
-import           Ouroboros.Network.CodecCBORTerm
 import           Ouroboros.Network.Protocol.Handshake.Version
 
 -- | Pure computation which serves as a reference implementation of the

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -6,16 +6,13 @@
 
 module Ouroboros.Network.Protocol.Handshake.Test where
 
-import           Control.Monad.ST (runST)
-
-import           Data.Bool (bool)
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BL
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Typeable (Typeable, cast)
 import           Data.List (nub)
-import           Data.Maybe (fromMaybe, isJust)
+import           Data.Maybe (isJust)
 import qualified Data.Map as Map
 import           GHC.Generics
 
@@ -37,7 +34,6 @@ import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM, splits2
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec
 import           Ouroboros.Network.CodecCBORTerm
-import           Ouroboros.Network.Driver
 import           Ouroboros.Network.Driver.Simple ( runConnectedPeers
                                                  , runConnectedPeersAsymmetric
                                                  )
@@ -46,17 +42,10 @@ import           Ouroboros.Network.Protocol.Handshake.Type
 import           Ouroboros.Network.Protocol.Handshake.Client
 import           Ouroboros.Network.Protocol.Handshake.Server
 import           Ouroboros.Network.Protocol.Handshake.Codec
-import           Ouroboros.Network.Protocol.Handshake.Unversioned
 import           Ouroboros.Network.Protocol.Handshake.Version
 import           Ouroboros.Network.Protocol.Handshake.Direct
 
-import qualified Codec.CBOR.Encoding as CBOR
-import qualified Codec.CBOR.Decoding as CBOR
-import qualified Codec.CBOR.Term     as CBOR
-import qualified Codec.CBOR.Read     as CBOR
 import qualified Codec.CBOR.Write    as CBOR
-import           Codec.Serialise (Serialise)
-import qualified Codec.Serialise     as CBOR
 
 import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Test.hs
@@ -27,7 +27,6 @@ import           Network.TypedProtocol.Proofs
 
 import           Ouroboros.Network.Codec hiding (prop_codec)
 import           Ouroboros.Network.Channel
-import           Ouroboros.Network.Driver
 import           Ouroboros.Network.Driver.Simple (runConnectedPeers)
 
 import           Ouroboros.Network.MockChain.Chain (Point)

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
@@ -32,7 +32,6 @@ import           Network.TypedProtocol.Proofs
 
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec hiding (prop_codec)
-import           Ouroboros.Network.Driver
 import           Ouroboros.Network.Driver.Simple (runConnectedPeers)
 
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Client

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Direct.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Direct.hs
@@ -56,6 +56,9 @@ directPipelined (TxSubmissionServerPipelined mserver)
       SendMsgReplyTxs txs client' <- recvMsgRequestTxs txids
       directSender (enqueue (CollectTxs txids txs) q) server' client'
 
+    directSender EmptyQ (SendMsgKThxBye a) ClientStIdle {recvMsgKThxBye} =
+      (\b -> (a,b)) <$> recvMsgKThxBye
+
     directSender q (CollectPipelined (Just server') _) client =
       directSender q server' client
 

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Test.hs
@@ -37,7 +37,6 @@ import           Network.TypedProtocol.Proofs
 
 import           Ouroboros.Network.Codec hiding (prop_codec)
 import           Ouroboros.Network.Channel
-import           Ouroboros.Network.Driver
 import           Ouroboros.Network.Driver.Simple
                    (runConnectedPeersPipelined)
 


### PR DESCRIPTION
- Enabled -Wall for ouroboros-protocol-tests
- Fixed TxSubmission's warnings
- Fixed LocalTxSubmission's warnings
- Fixed LocalStateQuery's warnings
- Fixed Handshake's warnings
- Fixed BlockFetch's warnings
