### PR TITLE
test-consensus: off-by-one in the HFC A.hs ledger

### DIFF
--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -288,28 +288,28 @@ instance LedgerSupportsMempool BlockA where
               -- both the aforementioned @k@ additional blocks and also a
               -- further @safeFromTipA k@ slots after the last of those.
 
-              -- the last slot that must be in the current era
+              -- The last slot that must be in the current era
               firstPossibleLastSlotThisEra =
                   History.addSlots (stabilityWindowA k + safeFromTipA k) sno
+
+              -- The 'EpochNo' corresponding to 'firstPossibleLastSlotThisEra'
+              --
+              -- NOTE: We cannot use 'EpochInfo' for this. The 'EpochInfo'
+              -- only allows us to look ahead as far as the safe zone allows,
+              -- but here we are, almost by definition, looking further ahead
+              -- than that (stability window + safe zone).
+              --
+              -- (Once we construct an 'EpochInfo' with the known transition, it
+              -- would allow us to look this far ahead, but we cannot use it
+              -- to /determine/ the transition point.)
               lastEpochThisEra =
                   History.addEpochs
                     (History.countSlots
                        firstPossibleLastSlotThisEra firstSlotTipEpoch
                      `div` unEpochSize epochSizeTipEpoch)
                     tipEpoch
-                  `asTypeOf`
-                     -- an equivalent expression
-                     --
-                     -- The following would be equivalent if it couldn't fail
-                     -- with 'PastHorizonException', which it may since we may
-                     -- be inspecting a slot beyond the ledger's safe zone. In
-                     -- particular, the @ei@ the HFC provided to us is overly
-                     -- conservative for our specific purpose here. We're using
-                     -- it to decide here when this era should end. This era
-                     -- could only end sooner than that if this decision itself
-                     -- gets discarded! (TODO: double-check this claim)
-                     runEI epochInfoEpoch firstPossibleLastSlotThisEra
-              -- the first epoch that may be in the next era (recall: eras are
+
+              -- The first epoch that may be in the next era (recall: eras are
               -- epoch-aligned)
               firstEpochNextEra = succ lastEpochThisEra
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -15,6 +15,7 @@
 module Test.Consensus.HardFork.Combinator.B (
     ProtocolB
   , BlockB(..)
+  , safeZoneB
     -- * Additional types
     -- * Type family instances
   , ConsensusConfig(..)
@@ -48,6 +49,7 @@ import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.HasBlockBody
+import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
@@ -197,6 +199,14 @@ instance LedgerSupportsProtocol BlockB where
 instance HasPartialConsensusConfig ProtocolB
 
 instance HasPartialLedgerConfig BlockB
+
+-- | A basic 'History.SafeZone'
+--
+-- The mock B ledger has no transactions and so can't end and so needs no
+-- safezone. However, we give it a default one anyway, since that makes the
+-- test more realistic.
+safeZoneB :: SecurityParam -> History.SafeZone
+safeZoneB (SecurityParam k) = History.defaultSafeZone k
 
 instance LedgerSupportsMempool BlockB where
   data GenTx BlockB


### PR DESCRIPTION
Small diff. 

FWIW, my draft PR for the more general test with varying epoch sizes, slot lengths, tx slot (and hence A era size), etc and epoch size and slot length changing at the fork, fails without this change. Even without that, I think we can demonstrate that @>=@ is wrong.

For example, `countSlots 6 5` is 1. But if we're asking "how many slots (which are 1-to-1 with blocks in this test) _after_ the block forged in slot 5 will there be _before_ the onset of slot 6", then the number we want to is actually 0. Note that we should count neither slot 5 (that's the block of interest) nor slot 6 (that's the first slot of the next epoch).

`master` currently includes the transition tx in slot 2, and the A-B fork happens at the end of the first epoch. So the A era is slots 0-5, and B starts with slot 6. If we instead include the tx in slot 4, then the transition still happens after the first fork. That is wrong, since `k = 2` and the tx's block is only buried under 1 block as of the onset of slot 6. After this PR, adding the tx in slot 4 correctly delays the A-B fork to after the second epoch.

My PR #2066 is hopefully imminent; as I said above, it exercises/needs this.