### PR TITLE
test-infra: remove pgaCustomLabelling

### DIFF
--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
@@ -94,7 +94,6 @@ prop_convergence setup = withMaxSuccess 10 $
       , pgaFixedSchedule      = setupSchedule setup
       , pgaSecurityParam      = setupSecurityParam setup
       , pgaTestConfig         = cfg
-      , pgaCustomLabelling    = const id
       }
       (setupTestOutput setup)
   where

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
@@ -749,7 +749,6 @@ prop_simple_real_pbft_convergence produceEBBs k
           Just $ roundRobinLeaderSchedule numCoreNodes numSlots
       , pgaSecurityParam      = k
       , pgaTestConfig         = testConfig
-      , pgaCustomLabelling    = const id
       }
       testOutput .&&.
     prop_pvu .&&.

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -71,7 +71,6 @@ prop_simple_cardano_convergence k d
       , pgaFixedSchedule      = Nothing
       , pgaSecurityParam      = k
       , pgaTestConfig         = testConfig
-      , pgaCustomLabelling    = const id
       }
       testOutput
   where

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -59,7 +59,6 @@ prop_simple_real_tpraos_convergence k d
       , pgaFixedSchedule      = Nothing
       , pgaSecurityParam      = k
       , pgaTestConfig         = testConfig
-      , pgaCustomLabelling    = const id
       }
       testOutput
   where

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -87,7 +87,6 @@ prop_simple_bft_convergence k
           Just $ roundRobinLeaderSchedule numCoreNodes numSlots
       , pgaSecurityParam      = k
       , pgaTestConfig         = testConfig
-      , pgaCustomLabelling    = const id
       }
       testOutput
   where

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -101,7 +101,6 @@ prop_simple_leader_schedule_convergence
       , pgaFixedSchedule      = Just schedule
       , pgaSecurityParam      = praosSecurityParam
       , pgaTestConfig         = testConfig
-      , pgaCustomLabelling    = const id
       }
       testOutput
   where

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -90,7 +90,6 @@ prop_simple_pbft_convergence
           Just $ roundRobinLeaderSchedule numCoreNodes numSlots
       , pgaSecurityParam      = k
       , pgaTestConfig         = testConfig
-      , pgaCustomLabelling    = const id
       }
       testOutput
   where

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -105,7 +105,6 @@ prop_simple_praos_convergence
       , pgaFixedSchedule      = Nothing
       , pgaSecurityParam      = praosSecurityParam
       , pgaTestConfig         = testConfig
-      , pgaCustomLabelling    = const id
       }
       testOutput
   where

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -323,11 +323,6 @@ data PropGeneralArgs blk = PropGeneralArgs
     --
   , pgaSecurityParam      :: SecurityParam
   , pgaTestConfig         :: TestConfig
-
-    -- | Option to add custom labelling to a property
-    --
-    -- Can use @const id@ if no custom labelling is required.
-  , pgaCustomLabelling    :: TestOutput blk -> Property -> Property
   }
 
 -- | Expect no 'CannotLead's
@@ -446,7 +441,6 @@ prop_general pga testOutput =
     counterexample ("actual leader schedule: " <> condense actualLeaderSchedule) $
     counterexample ("consensus expected: " <> show isConsensusExpected) $
     counterexample ("maxForkLength: " <> show maxForkLength) $
-    pgaCustomLabelling pga testOutput $
     tabulate "consensus expected" [show isConsensusExpected] $
     tabulate "k" [show (maxRollbacks k)] $
     tabulate ("shortestLength (k = " <> show (maxRollbacks k) <> ")")

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -170,7 +170,6 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
         , pgaFixedSchedule      = Just leaderSchedule
         , pgaSecurityParam      = k
         , pgaTestConfig         = testConfig
-        , pgaCustomLabelling    = const id
         }
 
     testConfig :: TestConfig


### PR DESCRIPTION
This field is redundant. See the PR 2197 diff for an example of why it's not needed.