### PR TITLE
Export a couple error types we have to trace

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -24,6 +24,7 @@ module Ouroboros.Consensus.Shelley.Protocol (
   , TPraosProof (..)
   , TPraosIsCoreNode (..)
   , mkShelleyGlobals
+  , TPraosCannotLead(..)
     -- * Crypto
   , Crypto
   , TPraosCrypto

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -31,7 +31,8 @@ module Ouroboros.Consensus.Protocol.PBFT (
   , pbftValidateBoundary
     -- * Type instances
   , ConsensusConfig(..)
-    -- * Exported for testing
+    -- * Exported for tracing errors
+  , PBftValidationErr(..)
   , PBftCannotLead(..)
   ) where
 


### PR DESCRIPTION
These types appear in the tracers, and thus the node top level must
render them, so they must be exported.