### PR TITLE
Replace 2 * k with the stability window in ledgerViewForecastAt

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -263,20 +263,20 @@ instance TPraosCrypto c => LedgerSupportsProtocol (ShelleyBlock c) where
     where
       ShelleyLedgerState {history , shelleyState} = ledgerState
       globals = shelleyLedgerGlobals cfg
-      k       = SL.securityParameter globals
+      swindow = SL.stabilityWindow globals
       tip     = ledgerTipSlot ledgerState
 
       -- Inclusive lower bound
       minLo :: WithOrigin SlotNo
       minLo = case tip of
-                At (SlotNo s) | s >= (2 * k) -> At (SlotNo (s - (2 * k)))
+                At (SlotNo s) | s >= swindow -> At (SlotNo (s - swindow))
                 _otherwise                   -> Origin
 
       -- Exclusive upper bound
       maxHi :: SlotNo
       maxHi = case at of
-                Origin -> SlotNo $ 2 * k
-                At s   -> SlotNo $ unSlotNo s + 1 + (2 * k)
+                Origin -> SlotNo swindow
+                At s   -> SlotNo $ unSlotNo s + 1 + swindow
 
 instance HasHardForkHistory (ShelleyBlock c) where
   type HardForkIndices (ShelleyBlock c) = '[ShelleyBlock c]


### PR DESCRIPTION
For Praos we should be using the stability window `(3*k/f)` rather than the
Ouroboros Classic value of 2*k.