### PR TITLE
reorganize TestConfig and TestConfigBlock

### DIFF
--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -40,28 +40,44 @@ import           Ouroboros.Consensus.Cardano.Block
 import           Test.Consensus.Shelley.MockCrypto (TPraosMockCrypto)
 import           Test.ThreadNet.TxGen.Cardano ()
 import           Test.ThreadNet.TxGen.Shelley
+import           Test.ThreadNet.Util.NodeJoinPlan (trivialNodeJoinPlan)
+import           Test.ThreadNet.Util.NodeRestarts (noRestarts)
+
+data TestSetup = TestSetup
+  { setupD          :: Double
+    -- ^ decentralization parameter
+  , setupK          :: SecurityParam
+  , setupTestConfig :: TestConfig
+  }
+  deriving (Show)
+
+instance Arbitrary TestSetup where
+  arbitrary = do
+    setupD <- (/10)         <$> choose   (1, 10)
+    setupK <- SecurityParam <$> elements [5, 10]
+
+    setupTestConfig <- arbitrary
+
+    pure TestSetup
+      { setupD
+      , setupK
+      , setupTestConfig
+      }
+
+  -- TODO shrink
 
 tests :: TestTree
 tests = testGroup "Cardano" $
-    [ testProperty "simple convergence" $ withMaxSuccess 20 $
-          forAll (SecurityParam <$> elements [5, 10])
-            $ \k ->
-          forAll (elements [x / 10 | x <- [1..10]])
-            $ \d ->
-          forAllShrink
-              (genRealTPraosTestConfig k)
-              shrinkRealTPraosTestConfig
-            $ \testConfig ->
-          prop_simple_cardano_convergence k d testConfig
+    [ testProperty "simple convergence" $ withMaxSuccess 20 $ \setup ->
+          prop_simple_cardano_convergence setup
     ]
 
-prop_simple_cardano_convergence
-  :: SecurityParam
-  -> Double -- Decentralisation parameter
-  -> TestConfig
-  -> Property
-prop_simple_cardano_convergence k d
-  testConfig@TestConfig{numCoreNodes = NumCoreNodes n, initSeed} =
+prop_simple_cardano_convergence :: TestSetup -> Property
+prop_simple_cardano_convergence TestSetup
+  { setupD
+  , setupK
+  , setupTestConfig
+  } =
     prop_general PropGeneralArgs
       { pgaBlockProperty      = const $ property True
       , pgaCountTxs           = fromIntegral . length . extractTxs
@@ -69,22 +85,35 @@ prop_simple_cardano_convergence k d
       , pgaFirstBlockNo       = 0
       , pgaFixedMaxForkLength = Nothing
       , pgaFixedSchedule      = Nothing
-      , pgaSecurityParam      = k
-      , pgaTestConfig         = testConfig
+      , pgaSecurityParam      = setupK
+      , pgaTestConfig         = setupTestConfig
+      , pgaTestConfigB        = testConfigB
       }
       testOutput
   where
+    TestConfig
+      { initSeed
+      , numCoreNodes
+      } = setupTestConfig
+
+    testConfigB = TestConfigB
+      { epochSize
+      , forgeEbbEnv  = Nothing
+      , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
+      , nodeRestarts = noRestarts
+      , slotLength   = tpraosSlotLength
+      , txGenExtra   = ShelleyTxGenExtra $ mkGenEnv coreNodes
+      }
+
     testOutput :: TestOutput (CardanoBlock TPraosMockCrypto)
     testOutput =
-        runTestNetwork testConfig epochSize TestConfigBlock
-            { forgeEbbEnv = Nothing
-            , nodeInfo    = \(CoreNodeId nid) -> plainTestNodeInitialization $
+        runTestNetwork setupTestConfig testConfigB TestConfigMB
+            { nodeInfo = \(CoreNodeId nid) -> plainTestNodeInitialization $
                 castProtocolInfo $ inject
                   (mkProtocolRealTPraos
                     genesisConfig
                     (coreNodes !! fromIntegral nid))
-            , rekeying    = Nothing
-            , txGenExtra  = ShelleyTxGenExtra $ mkGenEnv coreNodes
+            , mkRekeyM = Nothing
             }
 
     initialKESPeriod :: SL.KESPeriod
@@ -94,12 +123,16 @@ prop_simple_cardano_convergence k d
     maxKESEvolution = 100
 
     coreNodes :: [CoreNode TPraosMockCrypto]
-    coreNodes = withSeed initSeed $
-      replicateM (fromIntegral n) $
-      genCoreNode initialKESPeriod
+    coreNodes =
+        withSeed initSeed $
+        replicateM (fromIntegral n) $
+        genCoreNode initialKESPeriod
+      where
+        NumCoreNodes n = numCoreNodes
 
     genesisConfig :: ShelleyGenesis TPraosMockCrypto
-    genesisConfig = mkGenesisConfig k d maxKESEvolution coreNodes
+    genesisConfig =
+        mkGenesisConfig setupK setupD maxKESEvolution coreNodes
 
     epochSize :: EpochSize
     epochSize = sgEpochLength genesisConfig

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -14,8 +14,6 @@ module Test.ThreadNet.Infra.Shelley (
   , coreNodeKeys
   , mkProtocolRealTPraos
   , tpraosSlotLength
-  , genRealTPraosTestConfig
-  , shrinkRealTPraosTestConfig
   ) where
 
 import           Data.Map.Strict (Map)
@@ -277,27 +275,3 @@ mkProtocolRealTPraos genesis CoreNode { cnDelegateKey, cnVRF, cnKES, cnOCert } =
         , tpraosIsCoreNodeSignKeyVRF = cnVRF
         }
       }
-
-genRealTPraosTestConfig :: SecurityParam -> Gen TestConfig
-genRealTPraosTestConfig _k = do
-    numCoreNodes <- arbitrary
-    numSlots     <- arbitrary
-
-    -- TODO generate more interesting scenarios
-    let nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
-        nodeTopology = meshNodeTopology numCoreNodes
-
-    initSeed <- arbitrary
-
-    pure TestConfig
-      { nodeJoinPlan
-      , nodeRestarts = noRestarts
-      , nodeTopology
-      , numCoreNodes
-      , numSlots
-      , slotLength = tpraosSlotLength
-      , initSeed
-      }
-
-shrinkRealTPraosTestConfig :: TestConfig -> [TestConfig]
-shrinkRealTPraosTestConfig _ = [] -- TODO

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -22,8 +22,6 @@ import qualified Data.Sequence.Strict as Seq
 import qualified Data.Set as Set
 import           Data.Word (Word64)
 
-import           Test.QuickCheck
-
 import           Cardano.Crypto (ProtocolMagicId (..))
 import           Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (..), SignKeyDSIGN,
                      signedDSIGN)
@@ -43,11 +41,6 @@ import           Ouroboros.Consensus.Util.Random
 
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Time (dawnOfTime)
-
-import           Test.ThreadNet.General
-import           Test.ThreadNet.Util.NodeJoinPlan
-import           Test.ThreadNet.Util.NodeRestarts
-import           Test.ThreadNet.Util.NodeTopology
 
 import qualified Shelley.Spec.Ledger.Address as SL
 import qualified Shelley.Spec.Ledger.BaseTypes as SL

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -460,12 +460,12 @@ data PraosStandardCrypto
 data PraosMockCrypto
 
 instance PraosCrypto PraosStandardCrypto where
-  type PraosKES  PraosStandardCrypto = SimpleKES Ed448DSIGN 100
+  type PraosKES  PraosStandardCrypto = SimpleKES Ed448DSIGN 1000
   type PraosVRF  PraosStandardCrypto = SimpleVRF
   type PraosHash PraosStandardCrypto = SHA256
 
 instance PraosCrypto PraosMockCrypto where
-  type PraosKES  PraosMockCrypto = MockKES 100
+  type PraosKES  PraosMockCrypto = MockKES 1000
   type PraosVRF  PraosMockCrypto = MockVRF
   type PraosHash PraosMockCrypto = MD5
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -33,19 +33,41 @@ import           Test.ThreadNet.Util.SimpleBlock
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.WrappedClock (NumSlots (..))
 
+data TestSetup = TestSetup
+  { setupK            :: SecurityParam
+  , setupTestConfig   :: TestConfig
+  , setupNodeJoinPlan :: NodeJoinPlan
+  }
+  deriving (Show)
+
+instance Arbitrary TestSetup where
+  arbitrary = do
+      -- TODO k > 1 as a workaround for Issue #1511.
+      k <- SecurityParam <$> choose (2, 10)
+
+      testConfig <- arbitrary
+      let TestConfig{numCoreNodes, numSlots} = testConfig
+
+      nodeJoinPlan <- genNodeJoinPlan numCoreNodes numSlots
+
+      pure $ TestSetup k testConfig nodeJoinPlan
+
+  -- TODO shrink
+
 tests :: TestTree
 tests = testGroup "BFT" $
     [ testProperty "delayed message corner case" $
         once $
         let ncn = NumCoreNodes 2 in
-        prop_simple_bft_convergence (SecurityParam 3) TestConfig
-          { numCoreNodes = ncn
-          , numSlots = NumSlots 3
-          , nodeJoinPlan = NodeJoinPlan (Map.fromList [(CoreNodeId 0,SlotNo {unSlotNo = 0}),(CoreNodeId 1,SlotNo {unSlotNo = 1})])
-          , nodeRestarts = noRestarts
-          , nodeTopology = meshNodeTopology ncn
-          , slotLength   = defaultSlotLength
-          , initSeed = Seed {getSeed = (12659702313441544615,9326820694273232011,15820857683988100572,2201554969601311572,4716411940989238571)}
+        prop_simple_bft_convergence TestSetup
+          { setupK = SecurityParam 3
+          , setupTestConfig = TestConfig
+            { numCoreNodes = ncn
+            , numSlots = NumSlots 3
+            , nodeTopology = meshNodeTopology ncn
+            , initSeed = Seed {getSeed = (12659702313441544615,9326820694273232011,15820857683988100572,2201554969601311572,4716411940989238571)}
+            }
+          , setupNodeJoinPlan = NodeJoinPlan (Map.fromList [(CoreNodeId 0,SlotNo {unSlotNo = 0}),(CoreNodeId 1,SlotNo {unSlotNo = 1})])
           }
     , testProperty "Mock.applyChainTick is not a no-op" $
         -- This repro failed on a wip branch that included a fix for Issue 1489
@@ -53,30 +75,26 @@ tests = testGroup "BFT" $
         -- as a regression test.
         once $
         let ncn = NumCoreNodes 3 in
-        prop_simple_bft_convergence (SecurityParam 5)
-        TestConfig
-          { numCoreNodes = ncn
-          , numSlots     = NumSlots 7
-          , nodeJoinPlan = NodeJoinPlan $ Map.fromList [(CoreNodeId 0, SlotNo 0),(CoreNodeId 1, SlotNo 2),(CoreNodeId 2, SlotNo 2)]
-          , nodeRestarts = noRestarts
-          , nodeTopology = meshNodeTopology ncn
-          , slotLength   = defaultSlotLength
-          , initSeed     = Seed (6358650144370660550,17563794202468751585,17692838336641672274,12649320068211251815,18441126729279419067)
+        prop_simple_bft_convergence TestSetup
+          { setupK = SecurityParam 5
+          , setupTestConfig = TestConfig
+            { numCoreNodes = ncn
+            , numSlots     = NumSlots 7
+            , nodeTopology = meshNodeTopology ncn
+            , initSeed     = Seed (6358650144370660550,17563794202468751585,17692838336641672274,12649320068211251815,18441126729279419067)
+            }
+          , setupNodeJoinPlan = NodeJoinPlan $ Map.fromList [(CoreNodeId 0, SlotNo 0),(CoreNodeId 1, SlotNo 2),(CoreNodeId 2, SlotNo 2)]
           }
-    , testProperty "simple convergence" $ \tc ->
-        -- TODO k > 1 as a workaround for Issue #1511.
-        --
-        forAll (SecurityParam <$> elements [2 .. 10]) $ \k ->
-        prop_simple_bft_convergence k tc
+    , testProperty "simple convergence" $ \setup ->
+        prop_simple_bft_convergence setup
     ]
-  where
-    defaultSlotLength = slotLengthFromSec 20
 
-prop_simple_bft_convergence :: SecurityParam
-                            -> TestConfig
-                            -> Property
-prop_simple_bft_convergence k
-  testConfig@TestConfig{numCoreNodes, numSlots, slotLength} =
+prop_simple_bft_convergence :: TestSetup -> Property
+prop_simple_bft_convergence TestSetup
+  { setupK            = k
+  , setupTestConfig   = testConfig
+  , setupNodeJoinPlan = nodeJoinPlan
+  } =
     prop_general PropGeneralArgs
       { pgaBlockProperty      = prop_validSimpleBlock
       , pgaCountTxs           = countSimpleGenTxs
@@ -87,24 +105,31 @@ prop_simple_bft_convergence k
           Just $ roundRobinLeaderSchedule numCoreNodes numSlots
       , pgaSecurityParam      = k
       , pgaTestConfig         = testConfig
+      , pgaTestConfigB        = testConfigB
       }
       testOutput
   where
+    TestConfig{numCoreNodes, numSlots} = testConfig
+    slotLength = slotLengthFromSec 20
+    testConfigB = TestConfigB
+      { epochSize = EpochSize $ maxRollbacks k * 10
+          -- The mock ledger doesn't really care, and neither does BFT. We
+          -- stick with the common @k * 10@ size for now.
+      , forgeEbbEnv = Nothing
+      , nodeJoinPlan
+      , slotLength
+      , nodeRestarts = noRestarts
+      , txGenExtra   = ()
+      }
+
     testOutput =
-        runTestNetwork testConfig epochSize TestConfigBlock
-            { forgeEbbEnv = Nothing
-            , nodeInfo    = \nid ->
+        runTestNetwork testConfig testConfigB TestConfigMB
+            { nodeInfo = \nid ->
                 plainTestNodeInitialization $
                   protocolInfoBft
                     numCoreNodes
                     nid
                     k
                     (HardFork.defaultEraParams k slotLength)
-            , rekeying    = Nothing
-            , txGenExtra  = ()
+            , mkRekeyM = Nothing
             }
-
-    -- The mock ledger doesn't really care, and neither does BFT.
-    -- We stick with the common @k * 10@ size for now.
-    epochSize :: EpochSize
-    epochSize = EpochSize (maxRollbacks k * 10)

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -34,67 +34,75 @@ import           Test.ThreadNet.Util.SimpleBlock
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.WrappedClock (NumSlots (..))
 
+data TestSetup = TestSetup
+  { setupK            :: SecurityParam
+  , setupTestConfig   :: TestConfig
+  , setupEpochSize    :: EpochSize
+  , setupNodeJoinPlan :: NodeJoinPlan
+  , setupSlotLength   :: SlotLength
+  }
+  deriving (Show)
+
+instance Arbitrary TestSetup where
+  arbitrary = do
+      -- TODO k > 1 as a workaround for Issue #1511.
+      k          <- SecurityParam <$> choose (2, 10)
+      epochSize  <- EpochSize     <$> choose (1, 10)
+      slotLength <- arbitrary
+
+      testConfig <- arbitrary
+      let TestConfig{numCoreNodes, numSlots} = testConfig
+
+      nodeJoinPlan   <- genNodeJoinPlan numCoreNodes numSlots
+
+      pure $ TestSetup
+        k
+        testConfig
+        epochSize
+        nodeJoinPlan
+        slotLength
+
+  -- TODO shrink
+
 tests :: TestTree
 tests = testGroup "Praos"
     [ testProperty "simple convergence - special case (issue #131)" $
           testPraos $ Seed (49644418094676, 40315957626756, 42668365444963, 9796082466547, 32684299622558)
     , testProperty "simple convergence - special crowded case" $
           testPraos $ Seed (8871923881324151440, 881094692332313449, 3091285302407489889, 6410351877547894330, 14676014321459888687)
-    , testProperty "simple convergence"
-        $ \initSeed ->
-          forAllShrink
-              (genNodeJoinPlan numCoreNodes numSlots)
-              shrinkNodeJoinPlan
-            $ \nodeJoinPlan ->
-          forAllShrink
-              (genNodeTopology numCoreNodes)
-              shrinkNodeTopology
-            $ \nodeTopology ->
-          testPraos' TestConfig
-            { numCoreNodes
-            , numSlots
-            , nodeJoinPlan
-            , nodeRestarts = noRestarts
-            , nodeTopology
-            , slotLength   = praosSlotLength
-            , initSeed
-            }
+    , testProperty "simple convergence" $ \setup ->
+        prop_simple_praos_convergence setup
     ]
   where
     testPraos :: Seed -> Property
-    testPraos seed = testPraos' TestConfig
-      { numCoreNodes
-      , numSlots
-      , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
-      , nodeRestarts = noRestarts
-      , nodeTopology = meshNodeTopology numCoreNodes
-      , slotLength   = praosSlotLength
-      , initSeed     = seed
-      }
+    testPraos seed =
+        prop_simple_praos_convergence TestSetup
+        { setupK            = k
+        , setupTestConfig   = TestConfig
+          { initSeed     = seed
+          , nodeTopology = meshNodeTopology numCoreNodes
+          , numCoreNodes
+          , numSlots     =
+              NumSlots $ maxRollbacks k * unEpochSize epochSize * numEpochs
+          }
+        , setupEpochSize    = epochSize
+        , setupNodeJoinPlan = trivialNodeJoinPlan numCoreNodes
+        , setupSlotLength   = slotLengthFromSec 2
+        }
+      where
+        numCoreNodes = NumCoreNodes 3
+        k            = SecurityParam 5
+        epochSize    = EpochSize 3
+        numEpochs    = 3
 
-    testPraos' :: TestConfig -> Property
-    testPraos' = prop_simple_praos_convergence params
-
-    numCoreNodes = NumCoreNodes 3
-    numEpochs    = 3
-    numSlots     = NumSlots $ maxRollbacks k * praosSlotsPerEpoch * numEpochs
-
-    params@PraosParams{praosSecurityParam = k, ..} = PraosParams
-      { praosSecurityParam = SecurityParam 5
-      , praosSlotsPerEpoch = 3
-      , praosLeaderF       = 0.5
-      , praosLifetimeKES   = 1000000
-      }
-
-praosSlotLength :: SlotLength
-praosSlotLength = slotLengthFromSec 2
-
-prop_simple_praos_convergence :: PraosParams
-                              -> TestConfig
-                              -> Property
-prop_simple_praos_convergence
-  params@PraosParams{praosSecurityParam}
-  testConfig@TestConfig{numCoreNodes} =
+prop_simple_praos_convergence :: TestSetup -> Property
+prop_simple_praos_convergence TestSetup
+  { setupK            = k
+  , setupTestConfig   = testConfig
+  , setupEpochSize    = epochSize
+  , setupNodeJoinPlan = nodeJoinPlan
+  , setupSlotLength   = slotLength
+  } =
     counterexample (tracesToDot testOutputNodes) $
     prop_general PropGeneralArgs
       { pgaBlockProperty      = prop_validSimpleBlock
@@ -103,27 +111,39 @@ prop_simple_praos_convergence
       , pgaFirstBlockNo       = 0
       , pgaFixedMaxForkLength = Nothing
       , pgaFixedSchedule      = Nothing
-      , pgaSecurityParam      = praosSecurityParam
+      , pgaSecurityParam      = k
       , pgaTestConfig         = testConfig
+      , pgaTestConfigB        = testConfigB
       }
       testOutput
   where
+    testConfigB = TestConfigB
+      { epochSize
+      , forgeEbbEnv  = Nothing
+      , nodeJoinPlan
+      , slotLength
+      , nodeRestarts = noRestarts
+      , txGenExtra   = ()
+      }
+
+    params = PraosParams
+      { praosSecurityParam = k
+      , praosSlotsPerEpoch = unEpochSize epochSize
+      , praosLeaderF       = 0.5
+      , praosLifetimeKES   = 1000000
+      }
+
+    TestConfig{numCoreNodes} = testConfig
+
     testOutput@TestOutput{testOutputNodes} =
-        runTestNetwork testConfig epochSize TestConfigBlock
-            { forgeEbbEnv = Nothing
-            , nodeInfo    = \nid -> plainTestNodeInitialization $
+        runTestNetwork testConfig testConfigB TestConfigMB
+            { nodeInfo = \nid -> plainTestNodeInitialization $
                                     protocolInfoPraos
                                       numCoreNodes
                                       nid
                                       params
                                       (HardFork.defaultEraParams
-                                        praosSecurityParam
-                                        praosSlotLength)
-            , rekeying    = Nothing
-            , txGenExtra  = ()
+                                        k
+                                        slotLength)
+            , mkRekeyM = Nothing
             }
-
-    -- TODO: Right now mock Praos has an explicit epoch size in its parameters
-    -- This will make it unuseable in a hard fork context.
-    epochSize :: EpochSize
-    epochSize = EpochSize $ praosSlotsPerEpoch params

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
@@ -23,6 +23,7 @@ library
                        Test.ThreadNet.General
                        Test.ThreadNet.Network
                        Test.ThreadNet.Ref.PBFT
+                       Test.ThreadNet.Rekeying
                        Test.ThreadNet.TxGen
                        Test.ThreadNet.Util
                        Test.ThreadNet.Util.Expectations

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Rekeying.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Rekeying.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE NamedFieldPuns            #-}
+
+module Test.ThreadNet.Rekeying (
+  Rekeying (..),
+  fromRekeyingToRekeyM,
+  ) where
+
+import           Cardano.Slotting.Slot
+
+import           Ouroboros.Consensus.Node.ProtocolInfo
+import           Ouroboros.Consensus.NodeId
+
+import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.Random
+
+import           Test.ThreadNet.Network
+
+import           Test.Util.Stream
+
+-- | Functionality used by test node in order to update its operational key
+--
+-- This is the conceptual interface demanded from the test-specific logic. It
+-- is used to define 'tnaRekeyM', which the test infrastructure invokes per the
+-- 'NodeRestarts' schedule.
+data Rekeying m blk = forall opKey. Rekeying
+  { rekeyOracle
+      :: CoreNodeId -> SlotNo -> Maybe SlotNo
+    -- ^ The first /nominal/ slot after the given slot, assuming the given core
+    -- node cannot lead.
+    --
+    -- IE the first slot that will result in a block successfully being forged
+    -- and diffused (eg no @PBftExceededSignThreshold@).
+  , rekeyUpd ::
+         ProtocolInfo (ChaChaT m) blk
+      -> EpochNo
+      -> opKey
+      -> Maybe (TestNodeInitialization m blk)
+     -- ^ new config and any corresponding delegation certificate transactions
+     --
+     -- The epoch number is the one required to create a Byron redeleg cert.
+     --
+     -- The 'TestNodeInitialization' includes the new 'ProtocolInfo' used when
+     -- the node completes restarting.
+  , rekeyFreshSKs :: Stream opKey
+     -- ^ a stream that only repeats itself after an *effectively* *infinite*
+     -- number of iterations and also never includes an operational key from
+     -- the genesis configuration
+  }
+
+fromRekeyingToRekeyM :: IOLike m => Rekeying m blk -> m (RekeyM m blk)
+fromRekeyingToRekeyM Rekeying{rekeyFreshSKs, rekeyOracle, rekeyUpd} = do
+    rekeyVar <- uncheckedNewTVarM rekeyFreshSKs
+    pure $ \cid pInfo s mkEno -> case rekeyOracle cid s of
+      Nothing -> pure $ plainTestNodeInitialization pInfo
+      Just s' -> do
+        x <- atomically $ do
+          x :< xs <- readTVar rekeyVar
+          x <$ writeTVar rekeyVar xs
+        eno <- mkEno s'
+        pure $ case rekeyUpd pInfo eno x of
+          Nothing  -> plainTestNodeInitialization pInfo
+          Just tni -> tni

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -378,6 +378,7 @@ test-suite test-consensus
                        -- ThreadNet (also from -infra) (for the HFC tests)
                        Test.ThreadNet.General
                        Test.ThreadNet.Network
+                       Test.ThreadNet.Rekeying
                        Test.ThreadNet.TxGen
                        Test.ThreadNet.Util
                        Test.ThreadNet.Util.Expectations


### PR DESCRIPTION
This yak shaving pays down some tech debt and paves the way for PR #2066. Now that timey wimey things like `slotLength` and `epochSize` will be varying during the execution for some, their semantics and validity is more block-dependent than ever. So we're separating them out. This enables some reuse and will simplify the story told by the commits for the imminent PR #2066.

I did some weeding while I was in there, since I was already touching so many lines.

This diff is intended as a functionality-preserving refactoring with two major exceptions.

  * I've changed generators, so QC replay seeds are boinked (I don't think we rely on these anywhere.)

  * I expanded the parameters varied during the mock Praos tests (`LeaderSchedule.hs` and `Praos.hs`). I don't expect that to reveal any bugs we had been accidentally avoiding, but it could. Or maybe might cause timeouts. But again, I don't think so.