### PR TITLE
OpCert replacement test

### DIFF
--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
@@ -1296,7 +1296,7 @@ mkRekeyUpd
   -> ProtocolInfo (ChaChaT m) ByronBlock
   -> SlotNo
   -> Crypto.SignKeyDSIGN Crypto.ByronDSIGN
-  -> Maybe (TestNodeInitialization ByronBlock)
+  -> Maybe (TestNodeInitialization m ByronBlock)
 mkRekeyUpd genesisConfig genesisSecrets epochInfo _ pInfo sno newSK =
   case pInfoLeaderCreds of
     Nothing              -> Nothing

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -7,21 +7,15 @@ module Test.ThreadNet.Cardano (
     tests
   ) where
 
-import           Control.Monad (replicateM)
 import           Data.List ((!!))
-import           Data.Word (Word64)
 
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Slotting.Slot (EpochSize (..))
-
-import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
-import           Ouroboros.Consensus.Util.Random
 
 import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.Degenerate
@@ -30,8 +24,6 @@ import           Ouroboros.Consensus.HardFork.Combinator.Unary
 import           Test.ThreadNet.General
 import           Test.ThreadNet.Infra.Shelley
 import           Test.Util.Orphans.Arbitrary ()
-
-import qualified Shelley.Spec.Ledger.OCert as SL
 
 import           Ouroboros.Consensus.Shelley.Node
 
@@ -43,96 +35,59 @@ import           Test.ThreadNet.TxGen.Shelley
 import           Test.ThreadNet.Util.NodeJoinPlan (trivialNodeJoinPlan)
 import           Test.ThreadNet.Util.NodeRestarts (noRestarts)
 
-data TestSetup = TestSetup
-  { setupD          :: Double
-    -- ^ decentralization parameter
-  , setupK          :: SecurityParam
-  , setupTestConfig :: TestConfig
-  }
-  deriving (Show)
-
-instance Arbitrary TestSetup where
-  arbitrary = do
-    setupD <- (/10)         <$> choose   (1, 10)
-    setupK <- SecurityParam <$> elements [5, 10]
-
-    setupTestConfig <- arbitrary
-
-    pure TestSetup
-      { setupD
-      , setupK
-      , setupTestConfig
-      }
-
-  -- TODO shrink
 
 tests :: TestTree
 tests = testGroup "Cardano" $
-    [ testProperty "simple convergence" $ withMaxSuccess 20 $ \setup ->
-          prop_simple_cardano_convergence setup
+    [ testProperty "simple convergence" $ withMaxSuccess 20 $
+          forAllShrink
+              (genShelleyTestConfig testTuning)
+              shrinkShelleyTestConfig
+            $ \testConfig ->
+          prop_simple_cardano_convergence testConfig
     ]
 
-prop_simple_cardano_convergence :: TestSetup -> Property
-prop_simple_cardano_convergence TestSetup
-  { setupD
-  , setupK
-  , setupTestConfig
-  } =
+prop_simple_cardano_convergence
+  :: ShelleyTestConfig
+  -> Property
+prop_simple_cardano_convergence
+  ShelleyTestConfig
+    {stcTestConfig, stcGenesis, stcCoreNodes} =
     prop_general PropGeneralArgs
-      { pgaBlockProperty      = const $ property True
-      , pgaCountTxs           = fromIntegral . length . extractTxs
-      , pgaExpectedCannotLead = noExpectedCannotLeads
-      , pgaFirstBlockNo       = 0
-      , pgaFixedMaxForkLength = Nothing
-      , pgaFixedSchedule      = Nothing
-      , pgaSecurityParam      = setupK
-      , pgaTestConfig         = setupTestConfig
-      , pgaTestConfigB        = testConfigB
+      { pgaBlockProperty          = const $ property True
+      , pgaCountTxs               = fromIntegral . length . extractTxs
+      , pgaExpectedCannotLead     = noExpectedCannotLeads
+      , pgaFirstBlockNo           = 0
+      , pgaFixedMaxForkLength     = Nothing
+      , pgaFixedSchedule          = Nothing
+      , pgaSecurityParam          = k
+      , pgaTestConfig             = stcTestConfig
+      , pgaTestConfigB            = testConfigB
       }
       testOutput
   where
     TestConfig
-      { initSeed
-      , numCoreNodes
-      } = setupTestConfig
+      { numCoreNodes
+      } = stcTestConfig
 
     testConfigB = TestConfigB
-      { epochSize
+      { epochSize    = sgEpochLength stcGenesis
       , forgeEbbEnv  = Nothing
       , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
       , nodeRestarts = noRestarts
       , slotLength   = tpraosSlotLength
-      , txGenExtra   = ShelleyTxGenExtra $ mkGenEnv coreNodes
+      , txGenExtra   = ShelleyTxGenExtra $ mkGenEnv stcCoreNodes
       }
 
     testOutput :: TestOutput (CardanoBlock TPraosMockCrypto)
     testOutput =
-        runTestNetwork setupTestConfig testConfigB TestConfigMB
-            { nodeInfo = \(CoreNodeId nid) -> plainTestNodeInitialization $
+        runTestNetwork stcTestConfig testConfigB
+            TestConfigMB
+            { nodeInfo    = \(CoreNodeId nid) -> plainTestNodeInitialization $
                 castProtocolInfo $ inject
                   (mkProtocolRealTPraos
-                    genesisConfig
-                    (coreNodes !! fromIntegral nid))
-            , mkRekeyM = Nothing
+                    stcGenesis
+                    (stcCoreNodes !! fromIntegral nid))
+            , mkRekeyM    = Nothing
             }
 
-    initialKESPeriod :: SL.KESPeriod
-    initialKESPeriod = SL.KESPeriod 0
-
-    maxKESEvolution :: Word64
-    maxKESEvolution = 100
-
-    coreNodes :: [CoreNode TPraosMockCrypto]
-    coreNodes =
-        withSeed initSeed $
-        replicateM (fromIntegral n) $
-        genCoreNode initialKESPeriod
-      where
-        NumCoreNodes n = numCoreNodes
-
-    genesisConfig :: ShelleyGenesis TPraosMockCrypto
-    genesisConfig =
-        mkGenesisConfig setupK setupD maxKESEvolution coreNodes
-
-    epochSize :: EpochSize
-    epochSize = sgEpochLength genesisConfig
+    k = sgSecurityParam stcGenesis

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -52,7 +52,6 @@ import qualified Data.Typeable as Typeable
 import           Data.Void (Void)
 import           GHC.Stack
 
-import           Cardano.Slotting.EpochInfo
 import           Cardano.Slotting.Slot
 
 import           Ouroboros.Network.Block
@@ -142,8 +141,6 @@ type RekeyM m blk =
   -> ProtocolInfo (ChaChaT m) blk
   -> SlotNo
      -- ^ The slot in which the node is rekeying
-  -> (SlotNo -> m EpochNo)
-     -- ^ Which epoch the slot is in
   -> m (TestNodeInitialization m blk)
      -- ^ 'tniProtocolInfo' should include new delegation cert/operational key,
      -- and 'tniCrucialTxs' should include the new delegation certificate
@@ -394,9 +391,6 @@ runThreadNetwork ThreadNetworkArgs
   where
     _ = keepRedundantConstraint (Proxy @(Show (LedgerView (BlockProtocol blk))))
 
-    epochInfo :: EpochInfo m
-    epochInfo = fixedSizeEpochInfo epochSize
-
     coreNodeIds :: [CoreNodeId]
     coreNodeIds = enumCoreNodes numCoreNodes
 
@@ -448,7 +442,7 @@ runThreadNetwork ThreadNetworkArgs
             -- the node is restarting because it just rekeyed
             tni' <- case (nr, mbRekeyM) of
               (NodeRekey, Just rekeyM) -> do
-                rekeyM coreNodeId pInfo s (epochInfoEpoch epochInfo)
+                rekeyM coreNodeId pInfo s
               _                        ->
                   pure $ plainTestNodeInitialization pInfo
             let TestNodeInitialization

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Rekeying.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Rekeying.hs
@@ -58,6 +58,6 @@ fromRekeyingToRekeyM Rekeying{rekeyFreshSKs, rekeyOracle, rekeyUpd} = do
         x <- atomically $ do
           x :< xs <- readTVar rekeyVar
           x <$ writeTVar rekeyVar xs
-        pure $ case rekeyUpd pInfo s' x of
+        pure $ case rekeyUpd cid pInfo s' x of
           Nothing  -> plainTestNodeInitialization pInfo
           Just tni -> tni

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Rekeying.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Rekeying.hs
@@ -32,13 +32,14 @@ data Rekeying m blk = forall opKey. Rekeying
     -- IE the first slot that will result in a block successfully being forged
     -- and diffused (eg no @PBftExceededSignThreshold@).
   , rekeyUpd ::
-         ProtocolInfo (ChaChaT m) blk
-      -> EpochNo
+         CoreNodeId
+      -> ProtocolInfo (ChaChaT m) blk
+      -> SlotNo
       -> opKey
       -> Maybe (TestNodeInitialization m blk)
      -- ^ new config and any corresponding delegation certificate transactions
      --
-     -- The epoch number is the one required to create a Byron redeleg cert.
+     -- The slot number is the one given by 'rekeyOracle'.
      --
      -- The 'TestNodeInitialization' includes the new 'ProtocolInfo' used when
      -- the node completes restarting.
@@ -51,13 +52,12 @@ data Rekeying m blk = forall opKey. Rekeying
 fromRekeyingToRekeyM :: IOLike m => Rekeying m blk -> m (RekeyM m blk)
 fromRekeyingToRekeyM Rekeying{rekeyFreshSKs, rekeyOracle, rekeyUpd} = do
     rekeyVar <- uncheckedNewTVarM rekeyFreshSKs
-    pure $ \cid pInfo s mkEno -> case rekeyOracle cid s of
+    pure $ \cid pInfo s -> case rekeyOracle cid s of
       Nothing -> pure $ plainTestNodeInitialization pInfo
       Just s' -> do
         x <- atomically $ do
           x :< xs <- readTVar rekeyVar
           x <$ writeTVar rekeyVar xs
-        eno <- mkEno s'
-        pure $ case rekeyUpd pInfo eno x of
+        pure $ case rekeyUpd pInfo s' x of
           Nothing  -> plainTestNodeInitialization pInfo
           Just tni -> tni

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Stream.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Stream.hs
@@ -3,6 +3,7 @@
 module Test.Util.Stream (
   Stream (..),
   nubOrdBy,
+  unfoldr
   ) where
 
 import qualified Data.Set as Set
@@ -16,3 +17,6 @@ nubOrdBy f = go
     go acc (x :< xs)
       | Set.member (f x) acc = go acc xs
       | otherwise            = x :< go (Set.insert (f x) acc) xs
+
+unfoldr :: (b -> (a,b)) -> b -> Stream a
+unfoldr f b0 = let (a, b') = f b0 in a :< unfoldr f b'


### PR DESCRIPTION
This adds a test of operational certificate replacement in Shelley.

- Extracts some more general Shelley configuration.
- Construct a node restart schedule for opcert replacement. This deliberately replaces some opcerts not on the correct slot, so we expect some nodes to be unable to lead in some slots.
- This entails making some changes to the "rekeying" infrastructure, because we need access to the slot.
- RealPBFT tests are updated accordingly.

At the moment we allow any slot to `CannotLead`, rather than deducing explicitly what slots cannot lead from the restart schedule. This PR has been dragging for a while, so I'd rather get some testing in now and then improve later.