### PR TITLE
Use Quiet to derive Show instances

### DIFF
--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -38,7 +38,8 @@ library
                        statistics-linreg
                                        >=0.3 && <0.4,
                        vector          >=0.12 && <0.13,
-                       time            >=1.6 && <1.10
+                       time            >=1.6 && <1.10,
+                       quiet
 
   if os(windows)
     build-depends:     Win32           >= 2.5.4.1 && <2.9,

--- a/network-mux/src/Network/Mux/Trace.hs
+++ b/network-mux/src/Network/Mux/Trace.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE NamedFieldPuns            #-}
 {-# LANGUAGE DeriveFunctor             #-}
+{-# LANGUAGE DeriveGeneric             #-}
+{-# LANGUAGE DerivingVia               #-}
+{-# LANGUAGE DerivingStrategies        #-}
+{-# LANGUAGE StandaloneDeriving        #-}
 
 module Network.Mux.Trace (
       MuxError(..)
@@ -19,7 +23,9 @@ import           Text.Printf
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Exception
+import           GHC.Generics (Generic (..))
 import           GHC.Stack
+import           Quiet (Quiet (..))
 
 import           Network.Mux.Types
 
@@ -34,7 +40,9 @@ data MuxError = MuxError {
       errorType  :: !MuxErrorType
     , errorMsg   :: !String
     , errorStack :: !CallStack
-    } deriving Show
+    }
+  deriving Generic
+  deriving Show via Quiet MuxError
 
 
 -- | Enumeration of error conditions.
@@ -98,11 +106,10 @@ data WithMuxBearer peerid a = WithMuxBearer {
       wmbPeerId :: !peerid
       -- ^ A tag that should identify a specific mux bearer.
     , wmbEvent  :: !a
-}
+  }
+  deriving (Generic)
+  deriving Show via (Quiet (WithMuxBearer peerid a))
 --TODO: probably remove this type
-
-instance (Show a, Show peerid) => Show (WithMuxBearer peerid a) where
-    show WithMuxBearer {wmbPeerId, wmbEvent} = printf "Mux %s %s" (show wmbPeerId) (show wmbEvent)
 
 
 data MuxBearerState = Mature


### PR DESCRIPTION
- ouroboros-network-framework: use Quiet for deriving Show instances
- network-mux: use Quiet for deriving Show instances
