### PR TITLE
Introduce TranslateNetworkProtocolVersion

### DIFF
--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -9,7 +9,7 @@ module Cardano.Client.Subscription (
   , ConnectionId
   , LocalAddress
   , NodeToClientProtocols (..)
-  , NodeToClientVersion
+  , BlockNodeToClientVersion
   , MuxPeer (..)
   , MuxTrace
   , RunMiniProtocol (..)
@@ -29,7 +29,8 @@ import           Data.Void (Void)
 import           Network.Mux.Trace (MuxTrace, WithMuxBearer)
 
 import           Ouroboros.Network.Mux (MuxMode (..), MuxPeer (..),
-                     OuroborosApplication, RunMiniProtocol (..), RunOrStop (..))
+                     OuroborosApplication, RunMiniProtocol (..),
+                     RunOrStop (..))
 import           Ouroboros.Network.NodeToClient (ClientSubscriptionParams (..),
                      ConnectionId, LocalAddress,
                      NetworkClientSubcriptionTracers,
@@ -48,7 +49,7 @@ import           Ouroboros.Consensus.Network.NodeToClient (ClientCodecs,
                      cChainSyncCodec, cStateQueryCodec, cTxSubmissionCodec,
                      clientCodecs)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
-                     (NodeToClientVersion, nodeToClientProtocolVersion,
+                     (BlockNodeToClientVersion, nodeToClientProtocolVersion,
                      supportedNodeToClientVersions)
 import           Ouroboros.Consensus.Node.Run (RunNode)
 
@@ -58,7 +59,7 @@ subscribe ::
   -> TopLevelConfig blk
   -> NetworkClientSubcriptionTracers
   -> ClientSubscriptionParams ()
-  -> (NodeToClientVersion blk
+  -> (BlockNodeToClientVersion blk
       -> ClientCodecs blk IO
       -> ConnectionId LocalAddress
       -> NodeToClientProtocols 'InitiatorMode BSL.ByteString IO x y)
@@ -86,7 +87,7 @@ versionedProtocols ::
      )
   => Proxy blk
   -> TopLevelConfig blk
-  -> (NodeToClientVersion blk
+  -> (BlockNodeToClientVersion blk
       -> ClientCodecs blk m
       -> ConnectionId LocalAddress
       -> STM m RunOrStop

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
@@ -41,15 +41,16 @@ pb :: Proxy ByronBlock
 pb = Proxy
 
 instance HasNetworkProtocolVersion DualByronBlock where
-  type NodeToNodeVersion   DualByronBlock = NodeToNodeVersion   ByronBlock
-  type NodeToClientVersion DualByronBlock = NodeToClientVersion ByronBlock
+  type BlockNodeToNodeVersion   DualByronBlock = BlockNodeToNodeVersion   ByronBlock
+  type BlockNodeToClientVersion DualByronBlock = BlockNodeToClientVersion ByronBlock
 
-  supportedNodeToNodeVersions   _ = supportedNodeToNodeVersions   pb
-  supportedNodeToClientVersions _ = supportedNodeToClientVersions pb
-  mostRecentNodeToNodeVersion   _ = mostRecentNodeToNodeVersion   pb
-  mostRecentNodeToClientVersion _ = mostRecentNodeToClientVersion pb
-  nodeToNodeProtocolVersion     _ = nodeToNodeProtocolVersion     pb
-  nodeToClientProtocolVersion   _ = nodeToClientProtocolVersion   pb
+instance TranslateNetworkProtocolVersion DualByronBlock where
+  supportedNodeToNodeVersions     _ = supportedNodeToNodeVersions     pb
+  supportedNodeToClientVersions   _ = supportedNodeToClientVersions   pb
+  mostRecentSupportedNodeToNode   _ = mostRecentSupportedNodeToNode   pb
+  mostRecentSupportedNodeToClient _ = mostRecentSupportedNodeToClient pb
+  nodeToNodeProtocolVersion       _ = nodeToNodeProtocolVersion       pb
+  nodeToClientProtocolVersion     _ = nodeToClientProtocolVersion     pb
 
 {-------------------------------------------------------------------------------
   EncodeDisk & DecodeDisk

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
@@ -33,16 +33,17 @@ data ByronNodeToClientVersion =
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 instance HasNetworkProtocolVersion ByronBlock where
-  type NodeToNodeVersion   ByronBlock = ByronNodeToNodeVersion
-  type NodeToClientVersion ByronBlock = ByronNodeToClientVersion
+  type BlockNodeToNodeVersion   ByronBlock = ByronNodeToNodeVersion
+  type BlockNodeToClientVersion ByronBlock = ByronNodeToClientVersion
 
+instance TranslateNetworkProtocolVersion ByronBlock where
   supportedNodeToNodeVersions   _ = ByronNodeToNodeVersion1
                                   :| []
   supportedNodeToClientVersions _ = ByronNodeToClientVersion1
                                   :| [ ByronNodeToClientVersion2 ]
 
-  mostRecentNodeToNodeVersion   _ = ByronNodeToNodeVersion1
-  mostRecentNodeToClientVersion _ = ByronNodeToClientVersion2
+  mostRecentSupportedNodeToNode   _ = ByronNodeToNodeVersion1
+  mostRecentSupportedNodeToClient _ = ByronNodeToClientVersion2
 
   nodeToNodeProtocolVersion _ ByronNodeToNodeVersion1 = N.NodeToNodeV_1
   nodeToNodeProtocolVersion _ ByronNodeToNodeVersion2 = error "version 2 not yet supported"

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -23,16 +23,17 @@ data ShelleyNodeToClientVersion = ShelleyNodeToClientVersion1
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 instance HasNetworkProtocolVersion (ShelleyBlock c) where
-  type NodeToNodeVersion   (ShelleyBlock c) = ShelleyNodeToNodeVersion
-  type NodeToClientVersion (ShelleyBlock c) = ShelleyNodeToClientVersion
+  type BlockNodeToNodeVersion   (ShelleyBlock c) = ShelleyNodeToNodeVersion
+  type BlockNodeToClientVersion (ShelleyBlock c) = ShelleyNodeToClientVersion
 
+instance TranslateNetworkProtocolVersion (ShelleyBlock c) where
   supportedNodeToNodeVersions   _ = ShelleyNodeToNodeVersion1
                                   :| []
   supportedNodeToClientVersions _ = ShelleyNodeToClientVersion1
                                   :| []
 
-  mostRecentNodeToNodeVersion   _ = ShelleyNodeToNodeVersion1
-  mostRecentNodeToClientVersion _ = ShelleyNodeToClientVersion1
+  mostRecentSupportedNodeToNode   _ = ShelleyNodeToNodeVersion1
+  mostRecentSupportedNodeToClient _ = ShelleyNodeToClientVersion1
 
   nodeToNodeProtocolVersion _ ShelleyNodeToNodeVersion1 = N.NodeToNodeV_1
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -34,6 +34,10 @@ import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 instance HasNetworkProtocolVersion (SimpleBlock SimpleMockCrypto ext) where
   -- Use defaults
 
+instance TranslateNetworkProtocolVersion (SimpleBlock SimpleMockCrypto ext) where
+  nodeToNodeProtocolVersion   _ _ = NodeToNodeV_1
+  nodeToClientProtocolVersion _ _ = NodeToClientV_2
+
 instance ( LedgerSupportsProtocol (SimpleBlock SimpleMockCrypto ext)
            -- The below constraint seems redundant but is not! When removed,
            -- some of the tests loop, but only when compiled with @-O2@ ; with

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Serialisation.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Serialisation.hs
@@ -61,8 +61,8 @@ roundtrip_all
      , SerialiseNodeToNodeConstraints blk
      , SerialiseNodeToClientConstraints blk
 
-     , Show (NodeToNodeVersion blk)
-     , Show (NodeToClientVersion blk)
+     , Show (BlockNodeToNodeVersion blk)
+     , Show (BlockNodeToClientVersion blk)
 
      , HasAnnTip blk
 
@@ -73,19 +73,19 @@ roundtrip_all
      , Arbitrary' (AnnTip blk)
      , Arbitrary' (ConsensusState (BlockProtocol blk))
 
-     , ArbitraryWithVersion (NodeToNodeVersion blk) (HeaderHash blk)
-     , ArbitraryWithVersion (NodeToNodeVersion blk) blk
-     , ArbitraryWithVersion (NodeToNodeVersion blk) (Header blk)
-     , ArbitraryWithVersion (NodeToNodeVersion blk) (GenTx blk)
-     , ArbitraryWithVersion (NodeToNodeVersion blk) (GenTxId blk)
-     , ArbitraryWithVersion (NodeToNodeVersion blk) (SomeBlock (NestedCtxt Header) blk)
+     , ArbitraryWithVersion (BlockNodeToNodeVersion blk) (HeaderHash blk)
+     , ArbitraryWithVersion (BlockNodeToNodeVersion blk) blk
+     , ArbitraryWithVersion (BlockNodeToNodeVersion blk) (Header blk)
+     , ArbitraryWithVersion (BlockNodeToNodeVersion blk) (GenTx blk)
+     , ArbitraryWithVersion (BlockNodeToNodeVersion blk) (GenTxId blk)
+     , ArbitraryWithVersion (BlockNodeToNodeVersion blk) (SomeBlock (NestedCtxt Header) blk)
 
-     , ArbitraryWithVersion (NodeToClientVersion blk) (HeaderHash blk)
-     , ArbitraryWithVersion (NodeToClientVersion blk) blk
-     , ArbitraryWithVersion (NodeToClientVersion blk) (GenTx blk)
-     , ArbitraryWithVersion (NodeToClientVersion blk) (ApplyTxErr blk)
-     , ArbitraryWithVersion (NodeToClientVersion blk) (Some (Query blk))
-     , ArbitraryWithVersion (NodeToClientVersion blk) (SomeResult blk)
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (HeaderHash blk)
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) blk
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (GenTx blk)
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (ApplyTxErr blk)
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (Some (Query blk))
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeResult blk)
      )
   => CodecConfig blk
   -> (forall a. NestedCtxt_ blk Header a -> Dict (Eq a, Show a))
@@ -162,12 +162,12 @@ type ArbitraryWithVersion v a = (Arbitrary (WithVersion v a), Eq a, Show a)
 roundtrip_SerialiseNodeToNode
   :: forall blk.
      ( SerialiseNodeToNodeConstraints blk
-     , Show (NodeToNodeVersion blk)
-     , ArbitraryWithVersion (NodeToNodeVersion blk) (HeaderHash blk)
-     , ArbitraryWithVersion (NodeToNodeVersion blk) blk
-     , ArbitraryWithVersion (NodeToNodeVersion blk) (Header blk)
-     , ArbitraryWithVersion (NodeToNodeVersion blk) (GenTx blk)
-     , ArbitraryWithVersion (NodeToNodeVersion blk) (GenTxId blk)
+     , Show (BlockNodeToNodeVersion blk)
+     , ArbitraryWithVersion (BlockNodeToNodeVersion blk) (HeaderHash blk)
+     , ArbitraryWithVersion (BlockNodeToNodeVersion blk) blk
+     , ArbitraryWithVersion (BlockNodeToNodeVersion blk) (Header blk)
+     , ArbitraryWithVersion (BlockNodeToNodeVersion blk) (GenTx blk)
+     , ArbitraryWithVersion (BlockNodeToNodeVersion blk) (GenTxId blk)
 
        -- Needed for testing the @Serialised blk@
      , EncodeDisk blk blk
@@ -236,16 +236,16 @@ roundtrip_SerialiseNodeToNode ccfg =
     ]
   where
     enc :: SerialiseNodeToNode blk a
-        => NodeToNodeVersion blk -> a -> Encoding
+        => BlockNodeToNodeVersion blk -> a -> Encoding
     enc = encodeNodeToNode ccfg
 
     dec :: SerialiseNodeToNode blk a
-        => NodeToNodeVersion blk -> forall s. Decoder s a
+        => BlockNodeToNodeVersion blk -> forall s. Decoder s a
     dec = decodeNodeToNode ccfg
 
     rt
       :: forall a.
-         ( Arbitrary (WithVersion (NodeToNodeVersion blk) a)
+         ( Arbitrary (WithVersion (BlockNodeToNodeVersion blk) a)
          , Eq a
          , Show a
          , SerialiseNodeToNode blk a
@@ -260,13 +260,13 @@ roundtrip_SerialiseNodeToNode ccfg =
 roundtrip_SerialiseNodeToClient
   :: forall blk.
      ( SerialiseNodeToClientConstraints blk
-     , Show (NodeToClientVersion blk)
-     , ArbitraryWithVersion (NodeToClientVersion blk) (HeaderHash blk)
-     , ArbitraryWithVersion (NodeToClientVersion blk) blk
-     , ArbitraryWithVersion (NodeToClientVersion blk) (GenTx blk)
-     , ArbitraryWithVersion (NodeToClientVersion blk) (ApplyTxErr blk)
-     , ArbitraryWithVersion (NodeToClientVersion blk) (Some (Query blk))
-     , ArbitraryWithVersion (NodeToClientVersion blk) (SomeResult blk)
+     , Show (BlockNodeToClientVersion blk)
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (HeaderHash blk)
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) blk
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (GenTx blk)
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (ApplyTxErr blk)
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (Some (Query blk))
+     , ArbitraryWithVersion (BlockNodeToClientVersion blk) (SomeResult blk)
 
        -- Needed for testing the @Serialised blk@
      , EncodeDisk blk blk
@@ -303,16 +303,16 @@ roundtrip_SerialiseNodeToClient ccfg =
     ]
   where
     enc :: SerialiseNodeToClient blk a
-        => NodeToClientVersion blk -> a -> Encoding
+        => BlockNodeToClientVersion blk -> a -> Encoding
     enc = encodeNodeToClient ccfg
 
     dec :: SerialiseNodeToClient blk a
-        => NodeToClientVersion blk -> forall s. Decoder s a
+        => BlockNodeToClientVersion blk -> forall s. Decoder s a
     dec = decodeNodeToClient ccfg
 
     rt
       :: forall a.
-         ( Arbitrary (WithVersion (NodeToClientVersion blk) a)
+         ( Arbitrary (WithVersion (BlockNodeToClientVersion blk) a)
          , Eq a
          , Show a
          , SerialiseNodeToClient blk a
@@ -336,7 +336,7 @@ roundtrip_envelopes ::
      , HasNestedContent Header blk
      )
   => CodecConfig blk
-  -> WithVersion (NodeToNodeVersion blk) (SomeBlock (NestedCtxt Header) blk)
+  -> WithVersion (BlockNodeToNodeVersion blk) (SomeBlock (NestedCtxt Header) blk)
   -> Property
 roundtrip_envelopes ccfg (WithVersion v (SomeBlock ctxt)) =
     roundtrip

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -447,7 +447,7 @@ defaultEncodeNodeToNode
      , SerialiseNodeToNode b (f b)
      )
   => Proxy (f b)
-  -> CodecConfig (DegenFork b) -> NodeToNodeVersion (DegenFork b)
+  -> CodecConfig (DegenFork b) -> BlockNodeToNodeVersion (DegenFork b)
   -> x -> Encoding
 defaultEncodeNodeToNode p (DCCfg ccfg) version x =
     encodeNodeToNode (project ccfg) version (project' p x :: f b)
@@ -460,7 +460,7 @@ defaultDecodeNodeToNode
      , SerialiseNodeToNode b (f b)
      )
   => Proxy (f b)
-  -> CodecConfig (DegenFork b) -> NodeToNodeVersion (DegenFork b)
+  -> CodecConfig (DegenFork b) -> BlockNodeToNodeVersion (DegenFork b)
   -> forall s. Decoder s x
 defaultDecodeNodeToNode _ (DCCfg ccfg) version =
     coerce . inject <$> decodeNodeToNode @b @(f b) (project ccfg) version
@@ -525,7 +525,7 @@ defaultEncodeNodeToClient
      , SerialiseNodeToClient b (f b)
      )
   => Proxy (f b)
-  -> CodecConfig (DegenFork b) -> NodeToClientVersion (DegenFork b)
+  -> CodecConfig (DegenFork b) -> BlockNodeToClientVersion (DegenFork b)
   -> x -> Encoding
 defaultEncodeNodeToClient p (DCCfg ccfg) version x =
     encodeNodeToClient (project ccfg) version (project' p x :: f b)
@@ -538,7 +538,7 @@ defaultDecodeNodeToClient
      , SerialiseNodeToClient b (f b)
      )
   => Proxy (f b)
-  -> CodecConfig (DegenFork b) -> NodeToClientVersion (DegenFork b)
+  -> CodecConfig (DegenFork b) -> BlockNodeToClientVersion (DegenFork b)
   -> forall s. Decoder s x
 defaultDecodeNodeToClient _ (DCCfg ccfg) version =
     coerce . inject <$> decodeNodeToClient @b @(f b) (project ccfg) version
@@ -651,16 +651,16 @@ projCfg :: NoHardForks b => TopLevelConfig (DegenFork b) -> TopLevelConfig b
 projCfg = project . castTopLevelConfig
 
 instance HasNetworkProtocolVersion b => HasNetworkProtocolVersion (DegenFork b) where
-  type NodeToNodeVersion   (DegenFork b) = NodeToNodeVersion   b
-  type NodeToClientVersion (DegenFork b) = NodeToClientVersion b
+  type BlockNodeToNodeVersion   (DegenFork b) = BlockNodeToNodeVersion   b
+  type BlockNodeToClientVersion (DegenFork b) = BlockNodeToClientVersion b
 
-  -- | Enumerate all supported node-to-node versions
-  supportedNodeToNodeVersions   _ = supportedNodeToNodeVersions   (Proxy @b)
-  supportedNodeToClientVersions _ = supportedNodeToClientVersions (Proxy @b)
-  mostRecentNodeToNodeVersion   _ = mostRecentNodeToNodeVersion   (Proxy @b)
-  mostRecentNodeToClientVersion _ = mostRecentNodeToClientVersion (Proxy @b)
-  nodeToNodeProtocolVersion     _ = nodeToNodeProtocolVersion     (Proxy @b)
-  nodeToClientProtocolVersion   _ = nodeToClientProtocolVersion   (Proxy @b)
+instance TranslateNetworkProtocolVersion b => TranslateNetworkProtocolVersion (DegenFork b) where
+  supportedNodeToNodeVersions     _ = supportedNodeToNodeVersions     (Proxy @b)
+  supportedNodeToClientVersions   _ = supportedNodeToClientVersions   (Proxy @b)
+  mostRecentSupportedNodeToNode   _ = mostRecentSupportedNodeToNode   (Proxy @b)
+  mostRecentSupportedNodeToClient _ = mostRecentSupportedNodeToClient (Proxy @b)
+  nodeToNodeProtocolVersion       _ = nodeToNodeProtocolVersion       (Proxy @b)
+  nodeToClientProtocolVersion     _ = nodeToClientProtocolVersion     (Proxy @b)
 
 instance (NoHardForks b, RunNode b) => RunNode (DegenFork b) where
   nodeBlockFetchSize (DHdr hdr) = nodeBlockFetchSize (project hdr)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
@@ -28,7 +28,6 @@ import           Ouroboros.Network.Protocol.BlockFetch.Type (ChainRange (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
-                     (NodeToNodeVersion)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
@@ -75,7 +74,7 @@ blockFetchServer
        )
     => Tracer m (TraceBlockFetchServerEvent blk)
     -> ChainDB m blk
-    -> NodeToNodeVersion blk
+    -> BlockNodeToNodeVersion blk
     -> ResourceRegistry m
     -> BlockFetchServer (Serialised blk) m ()
 blockFetchServer _tracer chainDB _version registry = senderSide

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -65,7 +65,6 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
-                     (NodeToNodeVersion)
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.Assert (assertWithMsg)
@@ -344,7 +343,7 @@ chainSyncClient
     -> Tracer m (TraceChainSyncClientEvent blk)
     -> TopLevelConfig blk
     -> ChainDbView m blk
-    -> NodeToNodeVersion blk
+    -> BlockNodeToNodeVersion blk
     -> StrictTVar m (AnchoredFragment (Header blk))
     -> Consensus ChainSyncClientPipelined blk m
 chainSyncClient mkPipelineDecision0 tracer cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
@@ -26,7 +26,6 @@ import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
-                     (NodeToNodeVersion)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
@@ -43,7 +42,7 @@ chainSyncHeadersServer
        )
     => Tracer m (TraceChainSyncServerEvent blk)
     -> ChainDB m blk
-    -> NodeToNodeVersion blk
+    -> BlockNodeToNodeVersion blk
     -> ResourceRegistry m
     -> ChainSyncServer (SerialisedHeader blk) (Tip blk) m ()
 chainSyncHeadersServer tracer chainDB _version registry =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -149,8 +149,8 @@ type ClientCodecs blk  m =
 -- anything different based on the version, so @_version@ is unused; it's just
 -- that not all codecs are used, depending on the version number.
 defaultCodecs :: forall m blk. (MonadST m, SerialiseNodeToClientConstraints blk)
-              => CodecConfig         blk
-              -> NodeToClientVersion blk
+              => CodecConfig blk
+              -> BlockNodeToClientVersion blk
               -> DefaultCodecs blk m
 defaultCodecs ccfg version = Codecs {
       cChainSyncCodec =
@@ -189,8 +189,8 @@ defaultCodecs ccfg version = Codecs {
 -- / deserialise blocks in /chain-sync/ protocol.
 --
 clientCodecs :: forall m blk. (MonadST m, SerialiseNodeToClientConstraints blk)
-             => CodecConfig         blk
-             -> NodeToClientVersion blk
+             => CodecConfig blk
+             -> BlockNodeToClientVersion blk
              -> ClientCodecs blk m
 clientCodecs ccfg version = Codecs {
       cChainSyncCodec =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -126,11 +126,11 @@ data RunNodeArgs blk = RunNodeArgs {
 
       -- | node-to-node protocol versions to run.
       --
-    , rnNodeToNodeVersions   :: NonEmpty (NodeToNodeVersion blk)
+    , rnNodeToNodeVersions   :: NonEmpty (BlockNodeToNodeVersion blk)
 
       -- | node-to-client protocol versions to run.
       --
-    , rnNodeToClientVersions :: NonEmpty (NodeToClientVersion blk)
+    , rnNodeToClientVersions :: NonEmpty (BlockNodeToClientVersion blk)
 
       -- | Hook called after the initialisation of the 'NodeKernel'
       --
@@ -241,7 +241,7 @@ run runargs@RunNodeArgs{..} =
     mkNodeToNodeApps
       :: NodeArgs   IO RemoteConnectionId LocalConnectionId blk
       -> NodeKernel IO RemoteConnectionId LocalConnectionId blk
-      -> NodeToNodeVersion blk
+      -> BlockNodeToNodeVersion blk
       -> NTN.Apps IO RemoteConnectionId blk ByteString ByteString ByteString ()
     mkNodeToNodeApps nodeArgs nodeKernel version =
         NTN.mkApps
@@ -255,7 +255,7 @@ run runargs@RunNodeArgs{..} =
     mkNodeToClientApps
       :: NodeArgs   IO RemoteConnectionId LocalConnectionId blk
       -> NodeKernel IO RemoteConnectionId LocalConnectionId blk
-      -> NodeToClientVersion blk
+      -> BlockNodeToClientVersion blk
       -> NTC.Apps IO LocalConnectionId ByteString ByteString ByteString ()
     mkNodeToClientApps nodeArgs nodeKernel version =
         NTC.mkApps
@@ -265,10 +265,10 @@ run runargs@RunNodeArgs{..} =
 
     mkDiffusionApplications
       :: MiniProtocolParameters
-      -> (   NodeToNodeVersion   blk
+      -> (   BlockNodeToNodeVersion blk
           -> NTN.Apps IO RemoteConnectionId blk ByteString ByteString ByteString ()
          )
-      -> (   NodeToClientVersion blk
+      -> (   BlockNodeToClientVersion blk
           -> NTC.Apps IO LocalConnectionId      ByteString ByteString ByteString ()
          )
       -> DiffusionApplications

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
@@ -4,82 +4,85 @@
 
 module Ouroboros.Consensus.Node.NetworkProtocolVersion
   ( HasNetworkProtocolVersion(..)
+  , TranslateNetworkProtocolVersion(..)
+    -- * Re-exports
+  , NodeToNodeVersion(..)
+  , NodeToClientVersion(..)
   ) where
 
 import           Data.List.NonEmpty (NonEmpty (..))
 import           Data.Proxy
 
-import qualified Ouroboros.Network.NodeToClient as N
-import qualified Ouroboros.Network.NodeToNode as N
+import           Ouroboros.Network.NodeToClient
+import           Ouroboros.Network.NodeToNode
 
 {-------------------------------------------------------------------------------
   Protocol versioning
 -------------------------------------------------------------------------------}
 
 -- | Protocol versioning
-class ( Show (NodeToNodeVersion   blk)
-      , Show (NodeToClientVersion blk)
-      , Eq   (NodeToNodeVersion   blk)
-      , Eq   (NodeToClientVersion blk)
+class ( Show (BlockNodeToNodeVersion   blk)
+      , Show (BlockNodeToClientVersion blk)
+      , Eq   (BlockNodeToNodeVersion   blk)
+      , Eq   (BlockNodeToClientVersion blk)
       ) => HasNetworkProtocolVersion blk where
-  type NodeToNodeVersion   blk :: *
-  type NodeToClientVersion blk :: *
-
-  -- | Enumerate all supported node-to-node versions
-  supportedNodeToNodeVersions
-    :: Proxy blk -> NonEmpty (NodeToNodeVersion blk)
-
-  -- | Enumerate all supported node-to-client versions
-  supportedNodeToClientVersions
-    :: Proxy blk -> NonEmpty (NodeToClientVersion blk)
-
-  -- | The most recent node-to-node version
-  mostRecentNodeToNodeVersion
-    :: Proxy blk -> NodeToNodeVersion blk
-
-  -- | The most recent node-to-client version
-  mostRecentNodeToClientVersion
-    :: Proxy blk -> NodeToClientVersion blk
-
-  -- | Translate to network-layer type
-  nodeToNodeProtocolVersion
-    :: Proxy blk -> NodeToNodeVersion blk -> N.NodeToNodeVersion
-
-  -- | Translate to network-layer type
-  nodeToClientProtocolVersion
-    :: Proxy blk -> NodeToClientVersion blk -> N.NodeToClientVersion
+  type BlockNodeToNodeVersion   blk :: *
+  type BlockNodeToClientVersion blk :: *
 
   -- Defaults
 
-  type NodeToNodeVersion   blk = ()
-  type NodeToClientVersion blk = ()
+  type BlockNodeToNodeVersion   blk = ()
+  type BlockNodeToClientVersion blk = ()
+
+class HasNetworkProtocolVersion blk => TranslateNetworkProtocolVersion blk where
+  -- | Enumerate all supported node-to-node versions
+  supportedNodeToNodeVersions
+    :: Proxy blk -> NonEmpty (BlockNodeToNodeVersion blk)
+
+  -- | Enumerate all supported node-to-client versions
+  supportedNodeToClientVersions
+    :: Proxy blk -> NonEmpty (BlockNodeToClientVersion blk)
+
+  -- | The most recent support node-to-node version
+  --
+  -- This is only used in the tests, where we are running the protocol with
+  -- the version we expect to be ran in practice.
+  mostRecentSupportedNodeToNode
+    :: Proxy blk -> BlockNodeToNodeVersion blk
+
+  -- | The most recent supported node-to-client version
+  --
+  -- This is only used in the tests, where we are running the protocol with
+  -- the version we expect to be ran in practice.
+  mostRecentSupportedNodeToClient
+    :: Proxy blk -> BlockNodeToClientVersion blk
+
+  -- | Translate to network-layer type
+  nodeToNodeProtocolVersion
+    :: Proxy blk -> BlockNodeToNodeVersion blk -> NodeToNodeVersion
+
+  -- | Translate to network-layer type
+  nodeToClientProtocolVersion
+    :: Proxy blk -> BlockNodeToClientVersion blk -> NodeToClientVersion
+
+  -- Defaults
 
   default supportedNodeToNodeVersions
-    :: NodeToNodeVersion blk ~ ()
-    => Proxy blk -> NonEmpty (NodeToNodeVersion blk)
+    :: BlockNodeToNodeVersion blk ~ ()
+    => Proxy blk -> NonEmpty (BlockNodeToNodeVersion blk)
   supportedNodeToNodeVersions _ = () :| []
 
   default supportedNodeToClientVersions
-    :: NodeToClientVersion blk ~ ()
-    => Proxy blk -> NonEmpty (NodeToClientVersion blk)
+    :: BlockNodeToClientVersion blk ~ ()
+    => Proxy blk -> NonEmpty (BlockNodeToClientVersion blk)
   supportedNodeToClientVersions _ = () :| []
 
-  default mostRecentNodeToNodeVersion
-    :: NodeToNodeVersion blk ~ ()
-    => Proxy blk -> NodeToNodeVersion blk
-  mostRecentNodeToNodeVersion _ = ()
+  default mostRecentSupportedNodeToNode
+    :: BlockNodeToNodeVersion blk ~ ()
+    => Proxy blk -> BlockNodeToNodeVersion blk
+  mostRecentSupportedNodeToNode _ = ()
 
-  default mostRecentNodeToClientVersion
-    :: NodeToClientVersion blk ~ ()
-    => Proxy blk -> NodeToClientVersion blk
-  mostRecentNodeToClientVersion _ = ()
-
-  default nodeToNodeProtocolVersion
-    :: NodeToNodeVersion blk ~ ()
-    => Proxy blk -> NodeToNodeVersion blk -> N.NodeToNodeVersion
-  nodeToNodeProtocolVersion _ () = N.NodeToNodeV_1
-
-  default nodeToClientProtocolVersion
-    :: NodeToClientVersion blk ~ ()
-    => Proxy blk -> NodeToClientVersion blk -> N.NodeToClientVersion
-  nodeToClientProtocolVersion _ () = N.NodeToClientV_1
+  default mostRecentSupportedNodeToClient
+    :: BlockNodeToClientVersion blk ~ ()
+    => Proxy blk -> BlockNodeToClientVersion blk
+  mostRecentSupportedNodeToClient _ = ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -63,16 +63,16 @@ class ( SerialiseNodeToClient blk (HeaderHash blk)
       , SerialiseResult       blk (Query blk)
       ) => SerialiseNodeToClientConstraints blk
 
-class ( LedgerSupportsProtocol    blk
-      , HasHardForkHistory        blk
-      , LedgerSupportsMempool     blk
-      , HasTxId            (GenTx blk)
-      , QueryLedger               blk
-      , HasNetworkProtocolVersion blk
-      , CanForge                  blk
-      , ConfigSupportsNode        blk
-      , HasCodecConfig            blk
-      , ConvertRawHash            blk
+class ( LedgerSupportsProtocol           blk
+      , HasHardForkHistory               blk
+      , LedgerSupportsMempool            blk
+      , HasTxId                   (GenTx blk)
+      , QueryLedger                      blk
+      , TranslateNetworkProtocolVersion  blk
+      , CanForge                         blk
+      , ConfigSupportsNode               blk
+      , HasCodecConfig                   blk
+      , ConvertRawHash                   blk
       , SerialiseDiskConstraints         blk
       , SerialiseNodeToNodeConstraints   blk
       , SerialiseNodeToClientConstraints blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Serialisation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Serialisation.hs
@@ -49,18 +49,20 @@ import           Ouroboros.Consensus.TypeFamilyWrappers
 -- | Serialise a type @a@ so that it can be sent across network via a
 -- node-to-node protocol.
 class SerialiseNodeToNode blk a where
-  encodeNodeToNode :: CodecConfig blk -> NodeToNodeVersion blk -> a -> Encoding
-  decodeNodeToNode :: CodecConfig blk -> NodeToNodeVersion blk -> forall s. Decoder s a
+  encodeNodeToNode :: CodecConfig blk -> BlockNodeToNodeVersion blk -> a -> Encoding
+  decodeNodeToNode :: CodecConfig blk -> BlockNodeToNodeVersion blk -> forall s. Decoder s a
 
   -- When the config is not needed, we provide a default, unversioned
   -- implementation using 'Serialise'
+
   default encodeNodeToNode
     :: Serialise a
-    => CodecConfig blk -> NodeToNodeVersion blk -> a -> Encoding
+    => CodecConfig blk -> BlockNodeToNodeVersion blk -> a -> Encoding
   encodeNodeToNode _ccfg _version = encode
+
   default decodeNodeToNode
     :: Serialise a
-    => CodecConfig blk -> NodeToNodeVersion blk -> forall s. Decoder s a
+    => CodecConfig blk -> BlockNodeToNodeVersion blk -> forall s. Decoder s a
   decodeNodeToNode _ccfg _version = decode
 
 {-------------------------------------------------------------------------------
@@ -70,18 +72,20 @@ class SerialiseNodeToNode blk a where
 -- | Serialise a type @a@ so that it can be sent across the network via
 -- node-to-client protocol.
 class SerialiseNodeToClient blk a where
-  encodeNodeToClient :: CodecConfig blk -> NodeToClientVersion blk -> a -> Encoding
-  decodeNodeToClient :: CodecConfig blk -> NodeToClientVersion blk -> forall s. Decoder s a
+  encodeNodeToClient :: CodecConfig blk -> BlockNodeToClientVersion blk -> a -> Encoding
+  decodeNodeToClient :: CodecConfig blk -> BlockNodeToClientVersion blk -> forall s. Decoder s a
 
   -- When the config is not needed, we provide a default, unversioned
   -- implementation using 'Serialise'
+
   default encodeNodeToClient
     :: Serialise a
-    => CodecConfig blk -> NodeToClientVersion blk -> a -> Encoding
+    => CodecConfig blk -> BlockNodeToClientVersion blk -> a -> Encoding
   encodeNodeToClient _ccfg _version = encode
+
   default decodeNodeToClient
     :: Serialise a
-    => CodecConfig blk -> NodeToClientVersion blk -> forall s. Decoder s a
+    => CodecConfig blk -> BlockNodeToClientVersion blk -> forall s. Decoder s a
   decodeNodeToClient _ccfg _version = decode
 
 {-------------------------------------------------------------------------------
@@ -96,13 +100,13 @@ class SerialiseResult blk query where
   encodeResult
     :: forall result.
        CodecConfig blk
-    -> NodeToClientVersion blk
+    -> BlockNodeToClientVersion blk
     -> query result
     -> result -> Encoding
   decodeResult
     :: forall result.
        CodecConfig blk
-    -> NodeToClientVersion blk
+    -> BlockNodeToClientVersion blk
     -> query result
     -> forall s. Decoder s result
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -358,6 +358,10 @@ instance CanHardFork '[BlockA, BlockB] where
 
 instance HasNetworkProtocolVersion TestBlock where
 
+instance TranslateNetworkProtocolVersion TestBlock where
+  nodeToNodeProtocolVersion   _ _ = NodeToNodeV_1
+  nodeToClientProtocolVersion _ _ = NodeToClientV_2
+
 instance RunNode TestBlock where
   nodeBlockFetchSize        = const 0
   nodeCheckIntegrity        = \_ _ -> True


### PR DESCRIPTION
The HFC needs _versions_ for each eras, but the _translation_ can only be
specified at the top-level, this is not compositional.