### PR TITLE
Use a random timeout when waiting for new block headers

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -779,7 +779,7 @@ runThreadNetwork ThreadNetworkArgs
                   -- node
                   nullDebugProtocolTracers
                   (customNodeToNodeCodecs pInfoConfig)
-                  Nothing
+                  (return Nothing) -- Workaround for #1882, tests that can't cope with timeouts.
                   (NTN.mkHandlers nodeArgs nodeKernel)
 
       -- In practice, a robust wallet/user can persistently add a transaction

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -286,6 +286,7 @@ library
                      , mtl               >=2.2   && <2.3
                      , network           >=3.1   && <3.2
                      , psqueues          >=0.2.3 && <0.3
+                     , random
                      , serialise         >=0.2   && <0.3
                      , sop-core          >=0.5   && <0.6
                      , stm               >=2.5   && <2.6


### PR DESCRIPTION
Previously we used a timeout for 70s, which worked fine for BFT.

For Praos there is always a risk that the network will have a sequence
of empty slots. To better cope with this the exact timeout is randomly
picked (between 90 and 269 seconds).

Implements #2245