### PR TITLE
typed-protocols-examples:  fix compilation with GHC 8.10.1 / GHC 8.8

### DIFF
--- a/typed-protocols-examples/src/Network/TypedProtocol/Channel.hs
+++ b/typed-protocols-examples/src/Network/TypedProtocol/Channel.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
@@ -18,6 +20,9 @@ module Network.TypedProtocol.Channel
   ) where
 
 import           Control.Monad ((>=>))
+#if !MIN_VERSION_base(4,13,0)
+import           Control.Monad.Fail (MonadFail)
+#endif
 import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadTimer
 import qualified Data.ByteString      as BS
@@ -167,7 +172,7 @@ createConnectedBufferedChannels sz = do
 --
 -- This is primarily useful for testing protocols.
 --
-createPipelineTestChannels :: MonadSTM m
+createPipelineTestChannels :: (MonadFail (STM m), MonadSTM m)
                            => Natural -> m (Channel m a, Channel m a)
 createPipelineTestChannels sz = do
     -- Create two TBQueues to act as the channel buffers (one for each

--- a/typed-protocols-examples/src/Network/TypedProtocol/Codec.hs
+++ b/typed-protocols-examples/src/Network/TypedProtocol/Codec.hs
@@ -380,7 +380,7 @@ prop_codec_splits splits runM codec msg =
 -- 'PeerHasAgency' for protocol B of some @st :: ps@.
 data SamePeerHasAgency (pr :: PeerRole) (ps :: *) where
   SamePeerHasAgency
-    :: forall (pr :: PeerRole) (st :: ps).
+    :: forall (pr :: PeerRole) ps (st :: ps).
        PeerHasAgency pr st
     -> SamePeerHasAgency pr ps
 

--- a/typed-protocols-examples/src/Network/TypedProtocol/PingPong/Codec.hs
+++ b/typed-protocols-examples/src/Network/TypedProtocol/PingPong/Codec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
@@ -15,14 +16,16 @@ codecPingPong
 codecPingPong =
     Codec{encode, decode}
   where
-    encode :: PeerHasAgency pr st
+    encode :: forall pr (st :: PingPong) (st' :: PingPong)
+           .  PeerHasAgency pr st
            -> Message PingPong st st'
            -> String
     encode (ClientAgency TokIdle) MsgPing = "ping\n"
     encode (ClientAgency TokIdle) MsgDone = "done\n"
     encode (ServerAgency TokBusy) MsgPong = "pong\n"
 
-    decode :: PeerHasAgency pr st
+    decode :: forall pr (st :: PingPong)
+           .  PeerHasAgency pr st
            -> m (DecodeStep String CodecFailure m (SomeMessage st))
     decode stok =
       decodeTerminatedFrame '\n' $ \str trailing ->

--- a/typed-protocols-examples/src/Network/TypedProtocol/ReqResp/Codec.hs
+++ b/typed-protocols-examples/src/Network/TypedProtocol/ReqResp/Codec.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TypeInType #-}
 
 module Network.TypedProtocol.ReqResp.Codec where
 
@@ -12,23 +14,30 @@ import           Network.TypedProtocol.PingPong.Codec (decodeTerminatedFrame)
 import           Text.Read (readMaybe)
 
 
-codecReqResp
-  :: forall req resp m.
-     (Monad m, Show req, Show resp, Read req, Read resp)
+codecReqResp ::
+    forall req resp m
+  . (Monad m, Show req, Show resp, Read req, Read resp)
   => Codec (ReqResp req resp) CodecFailure m String
 codecReqResp =
     Codec{encode, decode}
   where
-    encode :: forall (pr :: PeerRole) st st'.
-              PeerHasAgency pr st
-           -> Message (ReqResp req resp) st st'
+    encode :: forall req' resp'
+                     (pr  :: PeerRole)
+                     (st  :: ReqResp req' resp')
+                     (st' :: ReqResp req' resp')
+           . (Show (Message (ReqResp req' resp') st st'))
+           => PeerHasAgency pr st
+           -> Message (ReqResp req' resp') st st'
            -> String
     encode (ClientAgency TokIdle) msg = show msg ++ "\n"
     encode (ServerAgency TokBusy) msg = show msg ++ "\n"
 
-    decode :: forall (pr :: PeerRole) st.
-              PeerHasAgency pr st
-           -> m (DecodeStep String CodecFailure m (SomeMessage st))
+    decode :: forall req' resp' m'
+                     (pr :: PeerRole)
+                     (st :: ReqResp req' resp')
+           .  (Monad m', Read req', Read resp')
+           => PeerHasAgency pr st
+           -> m' (DecodeStep String CodecFailure m' (SomeMessage st))
     decode stok =
       decodeTerminatedFrame '\n' $ \str trailing ->
         case (stok, break (==' ') str) of


### PR DESCRIPTION
This fixes build of `typed-protocols-examples` with ghc 8.10.1.