### PR TITLE
Move Ouroboros.Consensus.Util.Random to Test.Util.Random

### DIFF
--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -46,7 +46,6 @@ import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
                      ProtocolInfo (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.PBFT
-import           Ouroboros.Consensus.Util.Random
 
 import qualified Ouroboros.Consensus.Byron.Crypto.DSIGN as Crypto
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
@@ -59,6 +58,7 @@ import           Test.ThreadNet.Util.NodeTopology
 
 import           Test.ThreadNet.Infra.Byron.ProtocolInfo
 
+import           Test.Util.Random
 import           Test.Util.WrappedClock (NumSlots (..))
 
 -- | The expectation and observation regarding whether the hard-fork proposal

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
@@ -46,7 +46,6 @@ import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.Crypto as Crypto
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Condense (condense)
-import           Ouroboros.Consensus.Util.Random
 
 import qualified Cardano.Binary
 import qualified Cardano.Chain.Block as Block
@@ -76,6 +75,7 @@ import           Test.ThreadNet.Util.NodeRestarts
 import           Test.ThreadNet.Util.NodeTopology
 
 import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Random
 import qualified Test.Util.Stream as Stream
 import           Test.Util.WrappedClock (NumSlots (..))
 

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -23,7 +23,6 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.PBFT
-import           Ouroboros.Consensus.Util.Random
 
 import qualified Cardano.Chain.Genesis as CC.Genesis
 import qualified Cardano.Chain.Update as CC.Update
@@ -49,6 +48,7 @@ import           Test.ThreadNet.TxGen.Cardano ()
 import           Test.ThreadNet.Util.NodeJoinPlan (trivialNodeJoinPlan)
 import           Test.ThreadNet.Util.NodeRestarts (noRestarts)
 import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Random
 
 data TestSetup = TestSetup
   { setupD          :: Double

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -36,9 +36,9 @@ import           Cardano.Slotting.Slot (EpochSize (..))
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Node.ProtocolInfo
-import           Ouroboros.Consensus.Util.Random
 
 import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Random
 import           Test.Util.Time (dawnOfTime)
 
 import qualified Shelley.Spec.Ledger.Address as SL

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -16,12 +16,12 @@ import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
-import           Ouroboros.Consensus.Util.Random
 
 import           Test.ThreadNet.General
 import           Test.ThreadNet.Infra.Shelley
 
 import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Random
 
 import qualified Shelley.Spec.Ledger.OCert as SL
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -24,7 +24,6 @@ import           Ouroboros.Consensus.Mock.Node.Serialisation
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Util (Dict (..))
-import           Ouroboros.Consensus.Util.Random (Seed (..))
 
 import           Test.ThreadNet.General
 import           Test.ThreadNet.TxGen.Mock ()
@@ -37,6 +36,7 @@ import           Test.ThreadNet.Util.SimpleBlock
 import           Test.Consensus.Ledger.Mock.Generators ()
 
 import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Random
 import           Test.Util.Serialisation
 import           Test.Util.WrappedClock (NumSlots (..))
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -29,7 +29,6 @@ import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.PBFT
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Condense (condense)
-import           Ouroboros.Consensus.Util.Random (Seed (..))
 
 import           Test.ThreadNet.General
 import           Test.ThreadNet.Network
@@ -43,6 +42,7 @@ import           Test.ThreadNet.Util.NodeTopology
 import           Test.ThreadNet.Util.SimpleBlock
 
 import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Random (Seed (..))
 import           Test.Util.WrappedClock (NumSlots (..))
 
 data TestSetup = TestSetup

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -20,7 +20,6 @@ import           Ouroboros.Consensus.Mock.Node ()
 import           Ouroboros.Consensus.Mock.Node.Praos (protocolInfoPraos)
 import           Ouroboros.Consensus.Mock.Protocol.Praos
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
-import           Ouroboros.Consensus.Util.Random
 
 import           Test.ThreadNet.General
 import           Test.ThreadNet.TxGen.Mock ()
@@ -32,6 +31,7 @@ import           Test.ThreadNet.Util.NodeTopology
 import           Test.ThreadNet.Util.SimpleBlock
 
 import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Random
 import           Test.Util.WrappedClock (NumSlots (..))
 
 data TestSetup = TestSetup

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/TxGen/Mock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/TxGen/Mock.hs
@@ -13,9 +13,9 @@ import           GHC.Stack (HasCallStack)
 import           Ouroboros.Network.Block (SlotNo (..))
 
 import           Ouroboros.Consensus.Mock.Ledger
-import           Ouroboros.Consensus.Util.Random
 
 import           Test.ThreadNet.TxGen
+import           Test.Util.Random
 
 {-------------------------------------------------------------------------------
   TxGen SimpleBlock

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
@@ -26,6 +26,7 @@ library
                        Test.ThreadNet.Rekeying
                        Test.ThreadNet.TxGen
                        Test.ThreadNet.Util
+                       Test.ThreadNet.Util.BlockProduction
                        Test.ThreadNet.Util.Expectations
                        Test.ThreadNet.Util.HasCreator
                        Test.ThreadNet.Util.NodeJoinPlan
@@ -51,6 +52,7 @@ library
                        Test.Util.Orphans.ToExpr
                        Test.Util.QSM
                        Test.Util.QuickCheck
+                       Test.Util.Random
                        Test.Util.Range
                        Test.Util.RefEnv
                        Test.Util.Roundtrip

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -60,7 +60,6 @@ import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
-import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.RedundantConstraints
 
 import           Test.ThreadNet.Network
@@ -75,6 +74,7 @@ import qualified Test.Util.FS.Sim.MockFS as Mock
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Orphans.IOLike ()
 import           Test.Util.Orphans.NoUnexpectedThunks ()
+import           Test.Util.Random
 import           Test.Util.Range
 import           Test.Util.Shrink (andId, dropId)
 import           Test.Util.Time (dawnOfTime)

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -79,7 +79,6 @@ import           Ouroboros.Consensus.Mempool
 import qualified Ouroboros.Consensus.MiniProtocol.BlockFetch.Server as BFServer
 import qualified Ouroboros.Consensus.MiniProtocol.ChainSync.Client as CSClient
 import qualified Ouroboros.Consensus.Network.NodeToNode as NTN
-import           Ouroboros.Consensus.Node.BlockProduction
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
@@ -90,7 +89,6 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
-import           Ouroboros.Consensus.Util.Random
 import           Ouroboros.Consensus.Util.RedundantConstraints
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM
@@ -104,6 +102,7 @@ import qualified Ouroboros.Consensus.Storage.LedgerDB.InMemory as LgrDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB as VolDB
 
 import           Test.ThreadNet.TxGen
+import           Test.ThreadNet.Util.BlockProduction
 import           Test.ThreadNet.Util.NodeJoinPlan
 import           Test.ThreadNet.Util.NodeRestarts
 import           Test.ThreadNet.Util.NodeTopology
@@ -112,6 +111,7 @@ import           Test.Util.FS.Sim.MockFS (MockFS)
 import qualified Test.Util.FS.Sim.MockFS as Mock
 import           Test.Util.FS.Sim.STM (simHasFS)
 import qualified Test.Util.LogicalClock as LogicalClock
+import           Test.Util.Random
 import           Test.Util.Time
 import           Test.Util.Tracer
 import           Test.Util.WrappedClock (NumSlots (..), WrappedClock (..))

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Rekeying.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Rekeying.hs
@@ -12,10 +12,10 @@ import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
 
 import           Ouroboros.Consensus.Util.IOLike
-import           Ouroboros.Consensus.Util.Random
 
 import           Test.ThreadNet.Network
 
+import           Test.Util.Random
 import           Test.Util.Stream
 
 -- | Functionality used by test node in order to update its operational key

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/TxGen.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/TxGen.hs
@@ -11,7 +11,8 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx)
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
-import           Ouroboros.Consensus.Util.Random
+
+import           Test.Util.Random
 
 {-------------------------------------------------------------------------------
   TxGen class

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/BlockProduction.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/BlockProduction.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module Test.ThreadNet.Util.BlockProduction (
+    blockProductionIOLike
+  ) where
+
+import           Control.Monad.Trans (lift)
+import           Control.Tracer (natTracer)
+
+import           Ouroboros.Network.Block
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.SupportsMempool
+import           Ouroboros.Consensus.Node.BlockProduction
+import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util.IOLike
+
+import           Test.Util.Random
+
+-- | Block production in 'IOLike'
+--
+-- Unlike 'IO', 'IOLike' does not give us 'MonadRandom', and so we need to
+-- simulate it.
+blockProductionIOLike :: forall m blk.
+                         (IOLike m, BlockSupportsProtocol blk, CanForge blk)
+                      => TopLevelConfig blk
+                      -> CanBeLeader (BlockProtocol blk)
+                      -> MaintainForgeState (ChaChaT m) blk
+                      -> StrictTVar m ChaChaDRG
+                      -> (   ForgeState blk
+                          -> BlockNo
+                          -> TickedLedgerState blk
+                          -> [GenTx blk]
+                          -> IsLeader (BlockProtocol blk)
+                          -> ChaChaT m blk)
+                      -> m (BlockProduction m blk)
+blockProductionIOLike cfg canBeLeader mfs varRNG forge = do
+    varForgeState <- newMVar (initForgeState mfs)
+    let upd :: Update (ChaChaT m) (ForgeState blk)
+        upd = updateFromMVar (castStrictMVar varForgeState)
+    return $ BlockProduction {
+        getLeaderProof = \tracer ledgerState consensusState ->
+          simMonadRandom varRNG $
+            defaultGetLeaderProof
+              cfg
+              canBeLeader
+              mfs
+              (traceUpdate (natTracer lift tracer) upd)
+              ledgerState
+              consensusState
+      , produceBlock = \bno ledgerState txs proof -> do
+          forgeState <- readMVar varForgeState
+          simMonadRandom varRNG $
+            forge
+              forgeState
+              bno
+              ledgerState
+              txs
+              proof
+      }

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/Arbitrary.hs
@@ -23,12 +23,12 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Fragment.InFuture (ClockSkew)
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
 import           Ouroboros.Consensus.Node.ProtocolInfo
-import           Ouroboros.Consensus.Util.Random (Seed (..))
 
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
                      (ChunkNo (..), ChunkSize (..), RelativeSlot (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Layout
 
+import           Test.Util.Random (Seed (..))
 import           Test.Util.Time
 
 minNumCoreNodes :: Word64

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Random.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Random.hs
@@ -9,24 +9,23 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Util.Random (
-      -- * Producing values in MonadRandom
-      generateElement
-      -- * Connecting MonadRandom to Gen
-    , Seed (..)
-    , withSeed
-    , seedToChaCha
-    , nullSeed
-      -- * Adding DRNG to a monad stack
-    , ChaChaT -- opaque
-    , runChaChaT
-    , simMonadRandom
-      -- * Convenience re-exports
-    , MonadRandom (..)
-    , MonadTrans(..)
-    , ChaChaDRG
-    )
-    where
+module Test.Util.Random (
+    -- * Producing values in MonadRandom
+    generateElement
+    -- * Connecting MonadRandom to Gen
+  , Seed (..)
+  , withSeed
+  , seedToChaCha
+  , nullSeed
+    -- * Adding DRNG to a monad stack
+  , ChaChaT -- opaque
+  , runChaChaT
+  , simMonadRandom
+    -- * Convenience re-exports
+  , MonadRandom (..)
+  , MonadTrans(..)
+  , ChaChaDRG
+  ) where
 
 import           Codec.Serialise (Serialise)
 import           Control.Monad.Reader

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -158,7 +158,6 @@ library
                        Ouroboros.Consensus.Util.MonadSTM.RAWLock
                        Ouroboros.Consensus.Util.MonadSTM.StrictMVar
                        Ouroboros.Consensus.Util.Orphans
-                       Ouroboros.Consensus.Util.Random
                        Ouroboros.Consensus.Util.RedundantConstraints
                        Ouroboros.Consensus.Util.ResourceRegistry
                        Ouroboros.Consensus.Util.Singletons
@@ -372,6 +371,7 @@ test-suite test-consensus
                        Test.Util.Orphans.ToExpr
                        Test.Util.QSM
                        Test.Util.QuickCheck
+                       Test.Util.Random
                        Test.Util.Range
                        Test.Util.Roundtrip
                        Test.Util.Shrink
@@ -389,6 +389,7 @@ test-suite test-consensus
                        Test.ThreadNet.Rekeying
                        Test.ThreadNet.TxGen
                        Test.ThreadNet.Util
+                       Test.ThreadNet.Util.BlockProduction
                        Test.ThreadNet.Util.Expectations
                        Test.ThreadNet.Util.HasCreator
                        Test.ThreadNet.Util.NodeJoinPlan
@@ -495,6 +496,7 @@ test-suite test-storage
                        Test.Util.Orphans.NoUnexpectedThunks
                        Test.Util.Orphans.ToExpr
                        Test.Util.QuickCheck
+                       Test.Util.Random
                        Test.Util.Range
                        Test.Util.RefEnv
                        Test.Util.SOP
@@ -542,6 +544,7 @@ test-suite test-storage
 
                        -- ouroboros-consensus-test-infra
                      , base16-bytestring
+                     , cryptonite
                      , deepseq
 
   default-language:    Haskell2010

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -51,7 +51,6 @@ import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Counting
 import           Ouroboros.Consensus.Util.Orphans ()
-import           Ouroboros.Consensus.Util.Random (Seed (..))
 import           Ouroboros.Consensus.Util.SOP
 
 import           Ouroboros.Consensus.HardFork.Combinator
@@ -73,6 +72,7 @@ import           Test.ThreadNet.Util.NodeJoinPlan
 import           Test.ThreadNet.Util.NodeRestarts
 import           Test.ThreadNet.Util.NodeTopology
 
+import           Test.Util.Random (Seed (..))
 import           Test.Util.WrappedClock (NumSlots (..))
 
 import           Test.Consensus.HardFork.Combinator.A


### PR DESCRIPTION
Fixes #2259.

`blockProductionIOLike` from `Ouroboros.Consensus.Node.BlockProduction`
depended on it, but as it is only used in the ThreadNet tests, move that
function to `Test.ThreadNet.Util.BlockProduction`.