### PR TITLE
Use ShortByteString for OneEraHash and ConvertRawHash

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
@@ -75,10 +75,10 @@ mkByronHash :: CC.ABlockOrBoundaryHdr ByteString -> ByronHash
 mkByronHash = ByronHash . CC.abobHdrHash
 
 instance ConvertRawHash ByronBlock where
-  toRawHash   _ = CC.hashToBytes . unByronHash
-  fromRawHash _ = ByronHash . CC.unsafeHashFromBytes
-  hashSize    _ = fromIntegral $ Crypto.hashDigestSize
-                                   (error "proxy" :: Crypto.Blake2b_256)
+  toShortRawHash   _ = CC.abstractHashToShort . unByronHash
+  fromShortRawHash _ = ByronHash . CC.unsafeAbstractHashFromShort
+  hashSize         _ = fromIntegral $ Crypto.hashDigestSize
+                                        (error "proxy" :: Crypto.Blake2b_256)
 
 {-------------------------------------------------------------------------------
   Block

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -323,8 +323,8 @@ translateHeaderHashByronToShelley
   => HeaderHash ByronBlock
   -> HeaderHash (ShelleyBlock sc)
 translateHeaderHashByronToShelley =
-      fromRawHash (Proxy @(ShelleyBlock sc))
-    . toRawHash   (Proxy @ByronBlock)
+      fromShortRawHash (Proxy @(ShelleyBlock sc))
+    . toShortRawHash   (Proxy @ByronBlock)
 
 translatePointByronToShelley
   :: Crypto sc

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/ByronCompatibility.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/ByronCompatibility.hs
@@ -158,9 +158,9 @@ type instance ApplyTxErr ByronToCardano = ApplyTxErr ByronBlock
 instance HasNetworkProtocolVersion ByronToCardano
 
 instance ConvertRawHash ByronToCardano where
-  toRawHash   _ = toRawHash   pb
-  fromRawHash _ = fromRawHash pb
-  hashSize    _ = hashSize    pb
+  toShortRawHash   _ = toShortRawHash   pb
+  fromShortRawHash _ = fromShortRawHash pb
+  hashSize         _ = hashSize         pb
 
 data instance CodecConfig ByronToCardano = CodecConfigB2C (CodecConfig ByronBlock)
 
@@ -438,9 +438,9 @@ type instance ApplyTxErr CardanoToByron = ApplyTxErr ByronBlock
 instance HasNetworkProtocolVersion CardanoToByron
 
 instance ConvertRawHash CardanoToByron where
-  toRawHash   _ = toRawHash   pb
-  fromRawHash _ = fromRawHash pb
-  hashSize    _ = hashSize    pb
+  toShortRawHash   _ = toShortRawHash   pb
+  fromShortRawHash _ = fromShortRawHash pb
+  hashSize         _ = hashSize         pb
 
 data instance CodecConfig CardanoToByron = CodecConfigC2B (CodecConfig ByronBlock)
 

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Examples.hs
@@ -218,10 +218,10 @@ serialisedHeaderShelley =
     . serialisedHeaderToPair
 
 headerHashByron :: HeaderHash ByronBlock -> HeaderHash (CardanoBlock Crypto)
-headerHashByron = OneEraHash . toRawHash (Proxy @ByronBlock)
+headerHashByron = OneEraHash . toShortRawHash (Proxy @ByronBlock)
 
 headerHashShelley :: HeaderHash (ShelleyBlock Crypto) -> HeaderHash (CardanoBlock Crypto)
-headerHashShelley = OneEraHash . toRawHash (Proxy @(ShelleyBlock Crypto))
+headerHashShelley = OneEraHash . toShortRawHash (Proxy @(ShelleyBlock Crypto))
 
 someQueryByron ::
      SomeBlock Query ByronBlock

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Generators.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Generators.hs
@@ -135,8 +135,8 @@ instance Arbitrary (ChainDepState (BlockProtocol blk))
 -- require all hashes to have the same length.
 instance Crypto sc => Arbitrary (OneEraHash (CardanoEras sc)) where
   arbitrary = OneEraHash <$> oneof
-    [ toRawHash (Proxy @ByronBlock) <$> arbitrary
-    , toRawHash (Proxy @(ShelleyBlock sc)) <$> arbitrary
+    [ toShortRawHash (Proxy @ByronBlock) <$> arbitrary
+    , toShortRawHash (Proxy @(ShelleyBlock sc)) <$> arbitrary
     ]
 
 instance HashAlgorithm h => Arbitrary (AnnTip (CardanoBlock (TPraosMockCrypto h))) where

--- a/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
@@ -225,7 +225,7 @@ mkCardanoProtocolInfo byronConfig shelleyConfig =
       (TriggerHardForkAtVersion 2)
 
 castHeaderHash :: HeaderHash ByronBlock -> HeaderHash (CardanoBlock c)
-castHeaderHash = OneEraHash . toRawHash (Proxy @ByronBlock)
+castHeaderHash = OneEraHash . toShortRawHash (Proxy @ByronBlock)
 
 castChainHash :: ChainHash ByronBlock -> ChainHash (CardanoBlock c)
 castChainHash GenesisHash   = GenesisHash

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -50,7 +50,7 @@ import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
-import           Ouroboros.Consensus.Util (hashFromBytesE)
+import           Ouroboros.Consensus.Util (hashFromBytesShortE)
 import           Ouroboros.Consensus.Util.Condense
 
 import qualified Shelley.Spec.Ledger.BlockChain as SL
@@ -76,11 +76,9 @@ instance Condense (ShelleyHash c) where
   condense = show . unShelleyHash
 
 instance Crypto c => ConvertRawHash (ShelleyBlock c) where
-  toRawHash   _ = Crypto.hashToBytes . SL.unHashHeader . unShelleyHash
-  fromRawHash _ = ShelleyHash
-                . SL.HashHeader
-                . hashFromBytesE
-  hashSize    _ = fromIntegral $ Crypto.sizeHash (Proxy @(HASH c))
+  toShortRawHash   _ = Crypto.hashToBytesShort . SL.unHashHeader . unShelleyHash
+  fromShortRawHash _ = ShelleyHash . SL.HashHeader . hashFromBytesShortE
+  hashSize         _ = fromIntegral $ Crypto.sizeHash (Proxy @(HASH c))
 
 {-------------------------------------------------------------------------------
   Shelley blocks and headers

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -92,7 +92,7 @@ import           Ouroboros.Consensus.Mock.Ledger.Address
 import           Ouroboros.Consensus.Mock.Ledger.State
 import qualified Ouroboros.Consensus.Mock.Ledger.UTxO as Mock
 import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam)
-import           Ouroboros.Consensus.Util (hashFromBytesE, (.:))
+import           Ouroboros.Consensus.Util (hashFromBytesShortE, (.:))
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 
@@ -229,9 +229,9 @@ instance (SimpleCrypto c, Typeable ext, Typeable ext')
       => StandardHash (SimpleBlock' c ext ext')
 
 instance SimpleCrypto c => ConvertRawHash (SimpleBlock' c ext ext') where
-  toRawHash   _ = Hash.hashToBytes
-  fromRawHash _ = hashFromBytesE
-  hashSize    _ = fromIntegral $ Hash.sizeHash (Proxy @(SimpleHash c))
+  toShortRawHash   _ = Hash.hashToBytesShort
+  fromShortRawHash _ = hashFromBytesShortE
+  hashSize         _ = fromIntegral $ Hash.sizeHash (Proxy @(SimpleHash c))
 
 {-------------------------------------------------------------------------------
   HasMockTxs instance

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/Consensus/Ledger/Mock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/Consensus/Ledger/Mock.hs
@@ -7,8 +7,8 @@ module Test.Consensus.Ledger.Mock (tests) where
 
 import           Codec.CBOR.Write (toLazyByteString)
 import           Codec.Serialise (Serialise, encode)
-import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Lazy as Lazy
+import qualified Data.ByteString.Short as Short
 import           Data.Proxy
 import           Data.Typeable
 
@@ -37,7 +37,7 @@ tests = testGroup "Mock"
     props _ title = testGroup title
       [ testProperty "BinaryBlockInfo sanity check" (prop_simpleBlockBinaryBlockInfo @c @())
       , testGroup "ConvertRawHash sanity check"
-          [ testProperty "fromRawHash/toRawHash" (prop_simpleBlock_fromRawHash_toRawHash @c @())
+          [ testProperty "ConvertRawHash roundtrip" (prop_simpleBlock_roundtrip_ConvertRawHash @c @())
           , testProperty "hashSize sanity check" (prop_simpleBlock_hashSize @c @())
           ]
       ]
@@ -69,11 +69,11 @@ prop_simpleBlockBinaryBlockInfo blk =
   ConvertRawHash
 -------------------------------------------------------------------------------}
 
-prop_simpleBlock_fromRawHash_toRawHash
+prop_simpleBlock_roundtrip_ConvertRawHash
   :: forall c ext. SimpleCrypto c
   => HeaderHash (SimpleBlock c ext) -> Property
-prop_simpleBlock_fromRawHash_toRawHash h =
-    h === fromRawHash p (toRawHash p h)
+prop_simpleBlock_roundtrip_ConvertRawHash h =
+    h === fromShortRawHash p (toShortRawHash p h)
   where
     p = Proxy @(SimpleBlock c ext)
 
@@ -81,7 +81,7 @@ prop_simpleBlock_hashSize
   :: forall c ext. SimpleCrypto c
   => HeaderHash (SimpleBlock c ext) -> Property
 prop_simpleBlock_hashSize h =
-      counterexample ("rawHash: " ++ show (toRawHash p h))
-    $ hashSize p === fromIntegral (Strict.length (toRawHash p h))
+      counterexample ("rawHash: " ++ show (toShortRawHash p h))
+    $ hashSize p === fromIntegral (Short.length (toShortRawHash p h))
   where
     p = Proxy @(SimpleBlock c ext)

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Serialisation/Roundtrip.hs
@@ -29,10 +29,10 @@ import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
 import           Codec.CBOR.Read (deserialiseFromBytes)
 import           Codec.CBOR.Write (toLazyByteString)
-import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Base16.Lazy as Base16
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.ByteString.Lazy.Char8 as Char8
+import qualified Data.ByteString.Short as Short
 import           Data.Function (on)
 import           Data.Proxy (Proxy (..))
 import           Data.Typeable
@@ -421,13 +421,13 @@ roundtrip_ConvertRawHash
   :: (StandardHash blk, ConvertRawHash blk)
   => Proxy blk -> HeaderHash blk -> Property
 roundtrip_ConvertRawHash p h =
-    h === fromRawHash p (toRawHash p h)
+    h === fromShortRawHash p (toShortRawHash p h)
 
 prop_hashSize
   :: ConvertRawHash blk
   => Proxy blk -> HeaderHash blk -> Property
 prop_hashSize p h =
-    hashSize p === fromIntegral (Strict.length (toRawHash p h))
+    hashSize p === fromIntegral (Short.length (toShortRawHash p h))
 
 {-------------------------------------------------------------------------------
   Serialised helpers

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -57,7 +57,7 @@ module Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
 
 import           Codec.Serialise (Serialise (..))
 import           Control.Monad.Except (throwError)
-import qualified Data.ByteString as Strict
+import           Data.ByteString.Short (ShortByteString)
 import           Data.SOP.Strict hiding (shift)
 import           Data.Text (Text)
 import           Data.Void
@@ -122,7 +122,7 @@ newtype OneEraApplyTxErr    xs = OneEraApplyTxErr    { getOneEraApplyTxErr    ::
 -- of the hash would necessarily have to increase, and that leads to trouble.
 -- So, the type parameter @xs@ here is merely a phantom one, and we just store
 -- the underlying raw hash.
-newtype OneEraHash (xs :: [k]) = OneEraHash { getOneEraHash :: Strict.ByteString }
+newtype OneEraHash (xs :: [k]) = OneEraHash { getOneEraHash :: ShortByteString }
   deriving newtype (Eq, Ord, Show, NoUnexpectedThunks, Serialise)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -92,7 +92,7 @@ instance CanHardFork xs => HasHeader (Header (HardForkBlock xs)) where
              => Header blk -> HeaderFields (Header (HardForkBlock xs))
       getOne hdr = HeaderFields {
             headerFieldHash    = OneEraHash $
-                                   toRawHash (Proxy @blk) headerFieldHash
+                                   toShortRawHash (Proxy @blk) headerFieldHash
           , headerFieldSlot    = headerFieldSlot
           , headerFieldBlockNo = headerFieldBlockNo
           }
@@ -113,7 +113,7 @@ instance CanHardFork xs => GetPrevHash (HardForkBlock xs) where
       getOnePrev cfg' hdr =
           case headerPrevHash cfg' hdr of
             GenesisHash -> GenesisHash
-            BlockHash h -> BlockHash (OneEraHash $ toRawHash (Proxy @blk) h)
+            BlockHash h -> BlockHash (OneEraHash $ toShortRawHash (Proxy @blk) h)
 
 {-------------------------------------------------------------------------------
   NestedContent
@@ -162,9 +162,9 @@ instance CanHardFork xs => HasNestedContent Header (HardForkBlock xs) where
 -------------------------------------------------------------------------------}
 
 instance CanHardFork xs => ConvertRawHash (HardForkBlock xs) where
-  toRawHash   _ = getOneEraHash
-  fromRawHash _ = OneEraHash
-  hashSize    _ = getSameValue hashSizes
+  toShortRawHash   _ = getOneEraHash
+  fromShortRawHash _ = OneEraHash
+  hashSize         _ = getSameValue hashSizes
     where
       hashSizes :: NP (K Word32) xs
       hashSizes = hcpure proxySingle hashSizeOne
@@ -193,8 +193,8 @@ instance CanHardFork xs => HasAnnTip (HardForkBlock xs) where
       tipInfoOne :: forall blk. SingleEraBlock blk
                  => WrapTipInfo blk -> OneEraHash xs
       tipInfoOne = OneEraHash
-                 . toRawHash   (Proxy @blk)
-                 . tipInfoHash (Proxy @blk)
+                 . toShortRawHash (Proxy @blk)
+                 . tipInfoHash    (Proxy @blk)
                  . unwrapTipInfo
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -74,7 +74,7 @@ getTip getLedgerTip =
              => Point blk -> Point (HardForkBlock xs)
     injPoint GenesisPoint     = GenesisPoint
     injPoint (BlockPoint s h) = BlockPoint s $ OneEraHash $
-                                  toRawHash (Proxy @blk) h
+                                  toShortRawHash (Proxy @blk) h
 
 {-------------------------------------------------------------------------------
   Recovery

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
@@ -225,14 +225,14 @@ instance Isomorphic WrapHeaderHash where
           => WrapHeaderHash (HardForkBlock '[blk]) -> WrapHeaderHash blk
   project =
         WrapHeaderHash
-      . fromRawHash (Proxy @blk) . getOneEraHash
+      . fromShortRawHash (Proxy @blk) . getOneEraHash
       . unwrapHeaderHash
 
   inject :: forall blk. ConvertRawHash blk
       => WrapHeaderHash blk -> WrapHeaderHash (HardForkBlock '[blk])
   inject =
         WrapHeaderHash
-      . OneEraHash . toRawHash (Proxy @blk)
+      . OneEraHash . toShortRawHash (Proxy @blk)
       . unwrapHeaderHash
 
 instance Isomorphic ChainHash where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -125,9 +125,9 @@ type instance HeaderHash (DualBlock m a) = HeaderHash m
 instance StandardHash m => StandardHash (DualBlock m a)
 
 instance ConvertRawHash m => ConvertRawHash (DualBlock m a) where
-  toRawHash   _ = toRawHash   (Proxy @m)
-  fromRawHash _ = fromRawHash (Proxy @m)
-  hashSize    _ = hashSize    (Proxy @m)
+  toShortRawHash   _ = toShortRawHash   (Proxy @m)
+  fromShortRawHash _ = fromShortRawHash (Proxy @m)
+  hashSize         _ = hashSize         (Proxy @m)
 
 {-------------------------------------------------------------------------------
   Header

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
@@ -205,7 +205,7 @@ hashInfo p = HashInfo { hashSize, getHash, putHash }
       return $! fromRawHash p bytes
 
     putHash :: HeaderHash blk -> Put
-    putHash = Put.putByteString . toRawHash p
+    putHash = Put.putShortByteString . toShortRawHash p
 
 withImmDB
   :: ( IOLike m

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -39,6 +39,7 @@ module Ouroboros.Consensus.Util (
   , safeMaximumOn
     -- * Hashes
   , hashFromBytesE
+  , hashFromBytesShortE
     -- * Bytestrings
   , byteStringChunks
   , lazyByteStringChunks
@@ -63,9 +64,11 @@ module Ouroboros.Consensus.Util (
   , Trivial(..)
   ) where
 
-import           Cardano.Crypto.Hash (Hash, HashAlgorithm, hashFromBytes)
+import           Cardano.Crypto.Hash (Hash, HashAlgorithm, hashFromBytes,
+                     hashFromBytesShort)
 import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Lazy as Lazy
+import           Data.ByteString.Short (ShortByteString)
 import           Data.Foldable (asum, toList)
 import           Data.Function (on)
 import           Data.Functor.Identity
@@ -198,16 +201,29 @@ safeMaximumOn f = safeMaximumBy (compare `on` f)
   Hashes
 -------------------------------------------------------------------------------}
 
--- | Calls 'hashFromBytes' and throws an error if the input is of the wrong length.
+-- | Calls 'hashFromBytes' and throws an error if the input is of the wrong
+-- length.
 hashFromBytesE
   :: forall h a. (HashAlgorithm h, HasCallStack)
   => Strict.ByteString
   -> Hash h a
-hashFromBytesE bs = fromMaybe
-  (error $ "hashFromBytes called with ByteString of the wrong length: "
-           <> show bs)
-  $ hashFromBytes bs
+hashFromBytesE bs = fromMaybe (error msg) $ hashFromBytes bs
+  where
+    msg =
+      "hashFromBytes called with ByteString of the wrong length: " <>
+      show bs
 
+-- | Calls 'hashFromBytesShort' and throws an error if the input is of the
+-- wrong length.
+hashFromBytesShortE
+  :: forall h a. (HashAlgorithm h, HasCallStack)
+  => ShortByteString
+  -> Hash h a
+hashFromBytesShortE bs = fromMaybe (error msg) $ hashFromBytesShort bs
+  where
+    msg =
+      "hashFromBytesShort called with ShortByteString of the wrong length: " <>
+      show bs
 {-------------------------------------------------------------------------------
   Bytestrings
 -------------------------------------------------------------------------------}


### PR DESCRIPTION
Since the Byron and Shelley hash types are `ShortByteString`s under the hood,
switch over the representation of `OneEraHash` from `Strict.ByteString` to
`ShortByteString` too.

To avoid the intermediary `Strict.ByteString` in the conversion, add
`toShortRawHash` and `fromShortRawHash` to `ConvertRawHash`.

This avoids the memory overhead that a regular strict `ByteString` has.
According to the [Haddocks of `ShortByteString`][SBS], using a
`ByteString` (unshared) for a 32 byte hash (which is the case for Byron and
Shelley) requires 72 + 32 bytes, but a `ShortByteString` requires only 32 + 32
bytes. This can make a noticeable difference in memory usage as we're keeping
lots of hashes in memory:

* O(k) in the in-memory indices of the VolatileDB (hash and prev hash)
* O(cached epochs * epoch size) in the secondary index caches of the
  ImmutableDB
* ...

[SBS]: http://hackage.haskell.org/package/bytestring-0.10.10.0/docs/Data-ByteString-Short.html#g:2