### PR TITLE
Base FetchMode on the number of slots behind

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -263,12 +263,8 @@ initBlockFetchConsensusInterface cfg chainDB getCandidates blockFetchSize btime 
                 -- we're 1 slot behind.
                 Origin  -> unSlotNo curSlot + 1
                 At slot -> unSlotNo curSlot - unSlotNo slot
-              maxBlocksBehind = 5
-              -- Convert from blocks to slots. This is more or less the @f@
-              -- parameter, the frequency of blocks. TODO should be 10 for
-              -- Praos, so make this part of 'OuroborosTag'.
-              blocksToSlots = 1
-          return $ if slotsBehind < maxBlocksBehind * blocksToSlots
+              maxSlotsBehind = 20
+          return $ if slotsBehind < maxSlotsBehind
             -- When the current chain is near to "now", use deadline mode,
             -- when it is far away, use bulk sync mode.
             then FetchModeDeadline


### PR DESCRIPTION
Fixes #2028.

Simply base the current `FetchMode` on the number of slots behind our chain is
behind the current one instead of the number of blocks it is behind. For the
latter we'd need to know the expected density for the expected block type. Use
20 as a value that should be fine for both BFT and Praos.