### PR TITLE
Enable NodeToNodeV_2 and NodeToClientV_3

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -207,7 +207,7 @@ instance TPraosCrypto sc => TranslateNetworkProtocolVersion (CardanoBlock sc) wh
 
   nodeToNodeProtocolVersion _ = \case
       CardanoNodeToNodeVersion1 -> NodeToNodeV_1
-      CardanoNodeToNodeVersion2 -> error "NodeToNodeV_2"
+      CardanoNodeToNodeVersion2 -> NodeToNodeV_2
       v                         -> error $ "unsupported version: " <> show v
 
   nodeToClientProtocolVersion _ = \case

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -213,7 +213,7 @@ instance TPraosCrypto sc => TranslateNetworkProtocolVersion (CardanoBlock sc) wh
   nodeToClientProtocolVersion _ = \case
       CardanoNodeToClientVersion1 -> NodeToClientV_1
       CardanoNodeToClientVersion2 -> NodeToClientV_2
-      CardanoNodeToClientVersion3 -> error "NodeToClientV_3"
+      CardanoNodeToClientVersion3 -> NodeToClientV_3
       v                           -> error $ "unsupported version: " <> show v
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -165,27 +165,21 @@ nodeToClientProtocols
   -> NodeToClientVersion
   -> OuroborosApplication appType addr bytes m a b
 nodeToClientProtocols protocols version =
-    case version of
-      NodeToClientV_1 -> OuroborosApplication $ \connectionId shouldStopSTM ->
-        case protocols connectionId shouldStopSTM of
-          NodeToClientProtocols {
-              localChainSyncProtocol,
-              localTxSubmissionProtocol
-            } ->
-            [ localChainSyncMiniProtocol localChainSyncProtocol
-            , localTxSubmissionMiniProtocol localTxSubmissionProtocol
-            ]
-      NodeToClientV_2 -> OuroborosApplication $ \connectionId shouldStopSTM ->
-        case protocols connectionId shouldStopSTM of
-          NodeToClientProtocols {
-              localChainSyncProtocol,
-              localTxSubmissionProtocol,
-              localStateQueryProtocol
-            } ->
-            [ localChainSyncMiniProtocol localChainSyncProtocol
-            , localTxSubmissionMiniProtocol localTxSubmissionProtocol
-            , localStateQueryMiniProtocol localStateQueryProtocol
-            ]
+    OuroborosApplication $ \connectionId shouldStopSTM ->
+      case protocols connectionId shouldStopSTM of
+        NodeToClientProtocols {
+            localChainSyncProtocol,
+            localTxSubmissionProtocol,
+            localStateQueryProtocol
+          } ->
+          [ localChainSyncMiniProtocol localChainSyncProtocol
+          , localTxSubmissionMiniProtocol localTxSubmissionProtocol
+          ] <>
+          [ localStateQueryMiniProtocol localStateQueryProtocol
+          | case version of
+              NodeToClientV_1 -> False
+              _               -> True
+          ]
   where
     localChainSyncMiniProtocol localChainSyncProtocol = MiniProtocol {
         miniProtocolNum    = MiniProtocolNum 5,

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -26,6 +26,8 @@ data NodeToClientVersion
     = NodeToClientV_1
     | NodeToClientV_2
     -- ^ added local-query mini-protocol
+    | NodeToClientV_3
+    -- ^ enabled @CardanoNodeToClientVersion3@
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 
 -- | We set 16ths bit to distinguish `NodeToNodeVersion` and
@@ -40,6 +42,7 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
     where
       encodeTerm NodeToClientV_1 = CBOR.TInt 1
       encodeTerm NodeToClientV_2 = CBOR.TInt (2 `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_3 = CBOR.TInt (3 `setBit` nodeToClientVersionBit)
 
       decodeTerm (CBOR.TInt tag) =
        case ( tag `clearBit` nodeToClientVersionBit
@@ -47,6 +50,7 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
             ) of
         (1, False) -> Right NodeToClientV_1
         (2, True)  -> Right NodeToClientV_2
+        (3, True)  -> Right NodeToClientV_3
         (n, _)     -> Left ( T.pack "decode NodeToClientVersion: unknown tag: " <> T.pack (show tag)
                             , Just n)
       decodeTerm _  = Left ( T.pack "decode NodeToClientVersion: unexpected term"

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -20,15 +20,24 @@ import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..), 
 
 -- | Enumeration of node to node protocol versions.
 --
-data NodeToNodeVersion = NodeToNodeV_1
+data NodeToNodeVersion
+    = NodeToNodeV_1
+    | NodeToNodeV_2
+    -- ^ Changes:
+    --
+    -- * Enable block size hints for Byron headers in ChainSync
+    --
+    -- * Enable @CardanoNodeToNodeVersion2@
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 
 nodeToNodeVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToNodeVersion
 nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
   where
     encodeTerm NodeToNodeV_1  = CBOR.TInt 1
+    encodeTerm NodeToNodeV_2  = CBOR.TInt 2
 
     decodeTerm (CBOR.TInt 1) = Right NodeToNodeV_1
+    decodeTerm (CBOR.TInt 2) = Right NodeToNodeV_2
     decodeTerm (CBOR.TInt n) = Left ( T.pack "decode NodeToNodeVersion: unknonw tag: "
                                         <> T.pack (show n)
                                     , Just n

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
@@ -228,7 +228,7 @@ instance Protocol (TxSubmission txid tx) where
 
   exclusionLemma_NobodyAndServerHaveAgency TokDone tok = case tok of {}
 
-{-# WARNING MsgKThxBye "MsgKThxBye: should only be used with not yet introduced NodeToNodeV_2" #-}
+{-# WARNING MsgKThxBye "MsgKThxBye: must not be used with NodeToNodeV_1" #-}
 
 
 -- | The value level equivalent of 'StBlockingStyle'.


### PR DESCRIPTION
Fixes #1633.

This is required to let a `cardano-node` send Shelley "things" across the network after hard forking.