### PR TITLE
Introduce CommonProtocolParams

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -51,6 +51,7 @@ import           Cardano.Binary (fromCBOR, toCBOR)
 import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Chain.Genesis as Gen
+import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.Update.Validation.Interface as UPI
 import qualified Cardano.Chain.UTxO as CC
 import qualified Cardano.Chain.ValidationMode as CC
@@ -66,6 +67,7 @@ import           Ouroboros.Consensus.HardFork.Abstract
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 
@@ -153,6 +155,17 @@ deriving instance Show (Query ByronBlock result)
 
 instance ShowQuery (Query ByronBlock) where
   showResult GetUpdateInterfaceState = show
+
+instance CommonProtocolParams ByronBlock where
+  maxHeaderSize = fromIntegral . Update.ppMaxHeaderSize . getProtocolParameters
+  maxTxSize     = fromIntegral . Update.ppMaxTxSize     . getProtocolParameters
+
+-- | Return the protocol parameters adopted by the given ledger.
+getProtocolParameters :: LedgerState ByronBlock -> Update.ProtocolParameters
+getProtocolParameters =
+      CC.adoptedProtocolParameters
+    . CC.cvsUpdateState
+    . byronLedgerState
 
 instance LedgerSupportsProtocol ByronBlock where
   protocolLedgerView _cfg =

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -61,7 +61,6 @@ import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.MempoolPayload as CC
 import qualified Cardano.Chain.Update as Update
-import qualified Cardano.Chain.Update.Validation.Interface as Update
 import qualified Cardano.Chain.UTxO as Utxo
 import qualified Cardano.Chain.ValidationMode as CC
 
@@ -112,14 +111,6 @@ instance LedgerSupportsMempool ByronBlock where
 
   maxTxCapacity (Ticked _ st) =
     CC.getMaxBlockSize (byronLedgerState st) - byronBlockEncodingOverhead
-
-  -- TODO cardano-ledger should expose API.getMaxTxSize
-  maxTxSize =
-      fromIntegral
-    . Update.ppMaxBlockSize
-    . Update.adoptedProtocolParameters
-    . CC.cvsUpdateState
-    . byronLedgerState
 
   txInBlockSize =
       fromIntegral

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -24,11 +24,13 @@ import           GHC.Generics (Generic)
 import           Cardano.Prelude (AllowThunk (..), NoUnexpectedThunks)
 
 import qualified Byron.Spec.Chain.STS.Rule.Chain as Spec
+import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Control.State.Transition as Spec
 
 import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Accessors
 import           Ouroboros.Consensus.ByronSpec.Ledger.Block
@@ -99,6 +101,16 @@ data instance LedgerState ByronSpecBlock = ByronSpecLedgerState {
   deriving NoUnexpectedThunks via AllowThunk (LedgerState ByronSpecBlock)
 
 instance UpdateLedger ByronSpecBlock
+
+instance CommonProtocolParams ByronSpecBlock where
+  maxHeaderSize = fromIntegral . Spec._maxHdrSz . getPParams
+  maxTxSize     = fromIntegral . Spec._maxTxSz  . getPParams
+
+getPParams :: LedgerState ByronSpecBlock -> Spec.PParams
+getPParams =
+      Spec.protocolParameters
+    . getChainStateUPIState
+    . byronSpecLedgerState
 
 {-------------------------------------------------------------------------------
   Working with the ledger state

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
@@ -47,5 +47,4 @@ instance LedgerSupportsMempool ByronSpecBlock where
 
   -- Dummy values, as these are not used in practice.
   maxTxCapacity = const maxBound
-  maxTxSize     = const maxBound
   txInBlockSize = const 0

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -73,6 +73,7 @@ import           Ouroboros.Consensus.HardFork.Abstract
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Util.Versioned
@@ -446,6 +447,10 @@ instance Crypto c => ShowQuery (Query (ShelleyBlock c)) where
   showResult GetCurrentLedgerState                        = show
   showResult (GetCBOR {})                                 = show
   showResult (GetFilteredDelegationsAndRewardAccounts {}) = show
+
+instance TPraosCrypto c => CommonProtocolParams (ShelleyBlock c) where
+  maxHeaderSize = fromIntegral . SL._maxBHSize . getPParams . shelleyState
+  maxTxSize     = fromIntegral . SL._maxTxSize . getPParams . shelleyState
 
 {-------------------------------------------------------------------------------
   ValidateEnvelope

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -69,8 +69,6 @@ instance TPraosCrypto c => LedgerSupportsMempool (ShelleyBlock c) where
     where
       SL.PParams { _maxBBSize = maxBlockBodySize } = getPParams shelleyState
 
-  maxTxSize = fromIntegral . SL._maxTxSize . getPParams . shelleyState
-
   txInBlockSize (ShelleyTx _ tx) =
     fromIntegral . Lazy.length . SL.txFullBytes $ tx
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -84,6 +84,7 @@ import           Ouroboros.Consensus.HardFork.Abstract
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Mock.Ledger.Address
 import           Ouroboros.Consensus.Mock.Ledger.State
@@ -343,6 +344,11 @@ updateSimpleUTxO x (Ticked slot (SimpleLedgerState st)) =
 genesisSimpleLedgerState :: AddrDist -> LedgerState (SimpleBlock c ext)
 genesisSimpleLedgerState = SimpleLedgerState . genesisMockState
 
+-- | Dummy values
+instance MockProtocolSpecific c ext => CommonProtocolParams (SimpleBlock c ext) where
+  maxHeaderSize = const 2000000
+  maxTxSize     = const 2000000
+
 {-------------------------------------------------------------------------------
   Support for the mempool
 -------------------------------------------------------------------------------}
@@ -363,7 +369,6 @@ instance MockProtocolSpecific c ext
   -- Large value so that the Mempool tests never run out of capacity when they
   -- don't override it.
   maxTxCapacity = const 1000000000
-  maxTxSize     = const 2000000
   txInBlockSize = txSize
 
 instance HasTxId (GenTx (SimpleBlock c ext)) where

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -67,6 +67,7 @@ library
                        Ouroboros.Consensus.HardFork.Combinator.Forge
                        Ouroboros.Consensus.HardFork.Combinator.Info
                        Ouroboros.Consensus.HardFork.Combinator.Ledger
+                       Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
                        Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
                        Ouroboros.Consensus.HardFork.Combinator.Mempool
                        Ouroboros.Consensus.HardFork.Combinator.Node
@@ -100,6 +101,7 @@ library
                        Ouroboros.Consensus.HardFork.History.Util
                        Ouroboros.Consensus.HeaderValidation
                        Ouroboros.Consensus.Ledger.Abstract
+                       Ouroboros.Consensus.Ledger.CommonProtocolParams
                        Ouroboros.Consensus.Ledger.Dual
                        Ouroboros.Consensus.Ledger.Extended
                        Ouroboros.Consensus.Ledger.History

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
@@ -32,6 +32,10 @@ import           Ouroboros.Consensus.HardFork.Combinator.Mempool as X
 -- Instance for 'ConsensusProtocol'
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol as X
 
+-- Instance for 'CommonProtocolParams'
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams as X
+                     ()
+
 -- Instances for 'ShowQuery' and 'QueryLedger'
 -- Definition of 'Query', required for serialisation code
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger.Query as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -12,6 +12,7 @@ import           Data.Proxy
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.History (Bound, EraParams)
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
@@ -34,6 +35,7 @@ class ( LedgerSupportsProtocol blk
       , ConvertRawHash blk
       , HasCodecConfig blk
       , ReconstructNestedCtxt Header blk
+      , CommonProtocolParams blk
         -- Instances required to support testing
       , Eq   (GenTx blk)
       , Eq   (ApplyTxErr blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -55,6 +55,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -314,10 +315,7 @@ instance NoHardForks b => LedgerSupportsMempool (DegenFork b) where
   maxTxCapacity (Ticked slot (DLgr lgr)) =
     maxTxCapacity (Ticked slot (project lgr))
 
-  maxTxSize (DLgr lgr) = maxTxSize (project lgr)
-
   txInBlockSize (DTx tx) = txInBlockSize (project tx)
-
 
 instance SingleEraBlock b => HasTxId (GenTx (DegenFork b)) where
   newtype TxId (GenTx (DegenFork b)) = DTxId {
@@ -338,6 +336,10 @@ instance SingleEraBlock b => QueryLedger (DegenFork b) where
 
   answerQuery cfg (DQry qry) (DLgr lgr) = answerQuery cfg qry lgr
   eqQuery (DQry qry1) (DQry qry2) = eqQuery qry1 qry2
+
+instance NoHardForks b => CommonProtocolParams (DegenFork b) where
+  maxHeaderSize (DLgr lgr) = maxHeaderSize (project lgr)
+  maxTxSize     (DLgr lgr) = maxTxSize     (project lgr)
 
 instance NoHardForks b => CanForge (DegenFork b) where
   type ForgeState (DegenFork b) = ForgeState (HardForkBlock '[b])

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/CommonProtocolParams.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/CommonProtocolParams.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE RankNTypes #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams () where
+
+import           Data.SOP.Strict
+
+import           Ouroboros.Consensus.Ledger.CommonProtocolParams
+
+import           Ouroboros.Consensus.HardFork.Combinator.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger ()
+import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+
+instance CanHardFork xs => CommonProtocolParams (HardForkBlock xs) where
+  maxHeaderSize = askCurrentLedger maxHeaderSize
+  maxTxSize     = askCurrentLedger maxTxSize
+
+askCurrentLedger
+  :: CanHardFork xs
+  => (forall blk. CommonProtocolParams blk => LedgerState blk -> a)
+  -> LedgerState (HardForkBlock xs) -> a
+askCurrentLedger f =
+      hcollapse
+    . hcmap proxySingle (K . f)
+    . State.tip
+    . getHardForkLedgerState

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -84,12 +84,6 @@ instance CanHardFork xs => LedgerSupportsMempool (HardForkBlock xs) where
     . getHardForkLedgerState
     $ st
 
-  maxTxSize =
-      hcollapse
-    . hcmap proxySingle (K . maxTxSize)
-    . State.tip
-    . getHardForkLedgerState
-
   txInBlockSize =
       hcollapse
     . hcmap proxySingle (K . txInBlockSize)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/CommonProtocolParams.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/CommonProtocolParams.hs
@@ -1,0 +1,18 @@
+module Ouroboros.Consensus.Ledger.CommonProtocolParams (
+    CommonProtocolParams (..)
+  ) where
+
+import           Data.Word (Word32)
+
+import           Ouroboros.Consensus.Ledger.Abstract
+
+-- | Ask the ledger for common protocol parameters.
+class UpdateLedger blk => CommonProtocolParams blk where
+
+  -- | The maximum header size in bytes according to the currently adopted
+  -- protocol parameters of the ledger state.
+  maxHeaderSize :: LedgerState blk -> Word32
+
+  -- | The maximum transaction size in bytes according to the currently
+  -- adopted protocol parameters of the ledger state.
+  maxTxSize :: LedgerState blk -> Word32

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -76,6 +76,7 @@ import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.HardFork.Abstract
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
@@ -194,6 +195,7 @@ class (
       , LedgerSupportsProtocol m
       , HasHardForkHistory     m
       , LedgerSupportsMempool  m
+      , CommonProtocolParams   m
       , HasTxId (GenTx         m)
       , Show (ApplyTxErr       m)
 
@@ -458,6 +460,11 @@ instance Bridge m a => QueryLedger (DualBlock m a) where
 instance ShowQuery (Query (DualBlock m a)) where
   showResult = \case {}
 
+-- | Forward to the main ledger
+instance Bridge m a => CommonProtocolParams (DualBlock m a) where
+  maxHeaderSize = maxHeaderSize . dualLedgerStateMain
+  maxTxSize     = maxTxSize     . dualLedgerStateMain
+
 {-------------------------------------------------------------------------------
   Mempool support
 -------------------------------------------------------------------------------}
@@ -524,7 +531,6 @@ instance Bridge m a => LedgerSupportsMempool (DualBlock m a) where
   maxTxCapacity (Ticked slot DualLedgerState{..}) =
       maxTxCapacity (Ticked slot dualLedgerStateMain)
 
-  maxTxSize     = maxTxSize     . dualLedgerStateMain
   txInBlockSize = txInBlockSize . dualGenTxMain
 
 instance Bridge m a => HasTxId (GenTx (DualBlock m a)) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -59,10 +59,6 @@ class ( UpdateLedger blk
   -- other fixed overheads from the maximum block size.
   maxTxCapacity :: TickedLedgerState blk -> Word32
 
-  -- | The maximum transaction size in bytes according to the currently
-  -- adopted protocol parameters of the ledger state.
-  maxTxSize :: LedgerState blk -> Word32
-
   -- | Return the post-serialisation size in bytes of a 'GenTx' /when it is
   -- embedded in a block/. This size might differ from the size of the
   -- serialisation used to send and receive the transaction across the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -25,6 +25,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.HardFork.Abstract
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -73,6 +74,7 @@ class ( LedgerSupportsProtocol           blk
       , ConfigSupportsNode               blk
       , HasCodecConfig                   blk
       , ConvertRawHash                   blk
+      , CommonProtocolParams             blk
       , SerialiseDiskConstraints         blk
       , SerialiseNodeToNodeConstraints   blk
       , SerialiseNodeToClientConstraints blk

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -70,6 +70,7 @@ import           Ouroboros.Consensus.HardFork.History (Bound (..),
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -230,6 +231,10 @@ instance ApplyBlock (LedgerState BlockA) BlockA where
 
 instance UpdateLedger BlockA
 
+instance CommonProtocolParams BlockA where
+  maxHeaderSize _ = maxBound
+  maxTxSize     _ = maxBound
+
 instance CanForge BlockA where
   forgeBlock TopLevelConfig{..} _ bno (Ticked sno st) _txs _ = return $ BlkA {
         blkA_header = HdrA {
@@ -290,7 +295,6 @@ instance LedgerSupportsMempool BlockA where
   reapplyTx = applyTx
 
   maxTxCapacity _ = maxBound
-  maxTxSize     _ = maxBound
   txInBlockSize _ = 0
 
 instance HasTxId (GenTx BlockA) where

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -58,6 +58,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -188,6 +189,10 @@ instance ApplyBlock (LedgerState BlockB) BlockB where
 
 instance UpdateLedger BlockB
 
+instance CommonProtocolParams BlockB where
+  maxHeaderSize _ = maxBound
+  maxTxSize     _ = maxBound
+
 instance CanForge BlockB where
   forgeBlock _ _ bno (Ticked sno st) _txs _ = return $ BlkB {
       blkB_header = HdrB {
@@ -229,7 +234,6 @@ instance LedgerSupportsMempool BlockB where
   reapplyTx = applyTx
 
   maxTxCapacity _ = maxBound
-  maxTxSize     _ = maxBound
   txInBlockSize _ = 0
 
 instance HasTxId (GenTx BlockB) where


### PR DESCRIPTION
Using this class you can query the ledger for the current max
header/transaction size.

This supersedes the `maxTxSize` method of `LedgerSupportsMempool`.

Moreover, we fix a bug in the implementation of `maxTxSize` for `ByronBlock`:
it was returning the max block size instead of the max transaction size!