### PR TITLE
Only enable the Byron-to-Shelley hard fork for NodeToNodeV_3

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -156,14 +156,20 @@ prependTag tag payload = mconcat [
 -- Note: we don't support all combinations, so we don't declare them as
 -- COMPLETE
 
--- | We support only Byron V1 with the hard fork disabled, as no other
--- versions have been released before the hard fork
+-- | We support Byron V1 with the hard fork disabled, as it was released before
+-- the hard fork
 pattern CardanoNodeToNodeVersion1 :: BlockNodeToNodeVersion (CardanoBlock sc)
 pattern CardanoNodeToNodeVersion1 =
     HardForkNodeToNodeDisabled (WrapNodeToNodeVersion ByronNodeToNodeVersion1)
 
+-- | We support Byron V2 with the hard fork disabled, as it was released
+-- before the hard fork
 pattern CardanoNodeToNodeVersion2 :: BlockNodeToNodeVersion (CardanoBlock sc)
 pattern CardanoNodeToNodeVersion2 =
+    HardForkNodeToNodeDisabled (WrapNodeToNodeVersion ByronNodeToNodeVersion2)
+
+pattern CardanoNodeToNodeVersion3 :: BlockNodeToNodeVersion (CardanoBlock sc)
+pattern CardanoNodeToNodeVersion3 =
     HardForkNodeToNodeEnabled (
          WrapNodeToNodeVersion ByronNodeToNodeVersion2
       :* WrapNodeToNodeVersion ShelleyNodeToNodeVersion1
@@ -194,6 +200,7 @@ instance TPraosCrypto sc => TranslateNetworkProtocolVersion (CardanoBlock sc) wh
   supportedNodeToNodeVersions _ = NE.fromList $
       [ CardanoNodeToNodeVersion1
       , CardanoNodeToNodeVersion2
+      , CardanoNodeToNodeVersion3
       ]
 
   supportedNodeToClientVersions _ = NE.fromList $
@@ -202,12 +209,13 @@ instance TPraosCrypto sc => TranslateNetworkProtocolVersion (CardanoBlock sc) wh
       , CardanoNodeToClientVersion3
       ]
 
-  mostRecentSupportedNodeToNode   _ = CardanoNodeToNodeVersion2
+  mostRecentSupportedNodeToNode   _ = CardanoNodeToNodeVersion3
   mostRecentSupportedNodeToClient _ = CardanoNodeToClientVersion3
 
   nodeToNodeProtocolVersion _ = \case
       CardanoNodeToNodeVersion1 -> NodeToNodeV_1
       CardanoNodeToNodeVersion2 -> NodeToNodeV_2
+      CardanoNodeToNodeVersion3 -> NodeToNodeV_3
       v                         -> error $ "unsupported version: " <> show v
 
   nodeToClientProtocolVersion _ = \case

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -25,9 +25,11 @@ data NodeToNodeVersion
     | NodeToNodeV_2
     -- ^ Changes:
     --
-    -- * Enable block size hints for Byron headers in ChainSync
+    -- Enable block size hints for Byron headers in ChainSync
+    | NodeToNodeV_3
+    -- ^ Changes:
     --
-    -- * Enable @CardanoNodeToNodeVersion2@
+    -- Enable @CardanoNodeToNodeVersion2@
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 
 nodeToNodeVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToNodeVersion
@@ -35,9 +37,11 @@ nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
   where
     encodeTerm NodeToNodeV_1  = CBOR.TInt 1
     encodeTerm NodeToNodeV_2  = CBOR.TInt 2
+    encodeTerm NodeToNodeV_3  = CBOR.TInt 3
 
     decodeTerm (CBOR.TInt 1) = Right NodeToNodeV_1
     decodeTerm (CBOR.TInt 2) = Right NodeToNodeV_2
+    decodeTerm (CBOR.TInt 3) = Right NodeToNodeV_3
     decodeTerm (CBOR.TInt n) = Left ( T.pack "decode NodeToNodeVersion: unknonw tag: "
                                         <> T.pack (show n)
                                     , Just n


### PR DESCRIPTION
Now that we enabled `NodeToNodeV_2` for Byron in #2278, we can no longer
enable the hard fork with the same version number, so we need `NodeToNodeV_3`.

Why not? Because if #2278 makes it into a release that is deployed on mainnet
without the release being ready for Byron-to-Shelley, then V2 should not
enable the hard fork (which it did before this commit).