### PR TITLE
strengthen the Cardano ThreadNet test

### DIFF
--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -376,8 +376,11 @@ mkProtocolRealPBftAndHardForkTxs
   -> CoreNodeId
   -> Genesis.Config
   -> Genesis.GeneratedSecrets
+  -> Update.ProtocolVersion
+     -- ^ the protocol version that triggers the hard fork
   -> TestNodeInitialization m ByronBlock
-mkProtocolRealPBftAndHardForkTxs params cid genesisConfig genesisSecrets =
+mkProtocolRealPBftAndHardForkTxs
+  params cid genesisConfig genesisSecrets propPV =
     TestNodeInitialization
       { tniCrucialTxs   = proposals ++ votes
       , tniProtocolInfo = pInfo
@@ -417,7 +420,7 @@ mkProtocolRealPBftAndHardForkTxs params cid genesisConfig genesisSecrets =
     proposal :: AProposal ByteString
     proposal =
         loopbackAnnotations $
-        mkHardForkProposal params genesisConfig genesisSecrets
+        mkHardForkProposal params genesisConfig genesisSecrets propPV
 
 -- | A protocol parameter update proposal that doesn't actually change any
 -- parameter value but does propose 'theProposedProtocolVersion'
@@ -429,8 +432,9 @@ mkHardForkProposal
   => PBftParams
   -> Genesis.Config
   -> Genesis.GeneratedSecrets
+  -> Update.ProtocolVersion
   -> AProposal ()
-mkHardForkProposal params genesisConfig genesisSecrets =
+mkHardForkProposal params genesisConfig genesisSecrets propPV =
     -- signed by delegate SK
     Proposal.signProposal
       (Byron.byronProtocolMagicId configBlock)
@@ -447,7 +451,7 @@ mkHardForkProposal params genesisConfig genesisSecrets =
 
     propBody :: Proposal.ProposalBody
     propBody = Proposal.ProposalBody
-      { Proposal.protocolVersion          = theProposedProtocolVersion
+      { Proposal.protocolVersion          = propPV
       , Proposal.protocolParametersUpdate = Update.ProtocolParametersUpdate
         { Update.ppuScriptVersion     = Nothing
         , Update.ppuSlotDuration      = Nothing

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
@@ -922,6 +922,7 @@ prop_simple_real_pbft_convergence TestSetup
             { nodeInfo = \nid ->
                 mkProtocolRealPBftAndHardForkTxs
                   params nid genesisConfig genesisSecrets
+                  theProposedProtocolVersion
             , mkRekeyM = Just $ fromRekeyingToRekeyM Rekeying
               { rekeyOracle   = \cid s ->
                   let nominalSlots = case refResult of

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
@@ -34,6 +34,7 @@ library
                        Test.ThreadNet.Util.NodeTopology
 
                        Test.Util.Blob
+                       Test.Util.BoolProps
                        Test.Util.ChunkInfo
                        Test.Util.Corruption
                        Test.Util.FileLock

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/BoolProps.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/BoolProps.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE KindSignatures    #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE TypeOperators     #-}
+
+module Test.Util.BoolProps (
+  CollectReqs (..),
+  Prereq (..),
+  Requirement (..),
+  checkReqs,
+  enabledIf,
+  gCollectReqs,
+  requiredIf,
+  ) where
+
+import           GHC.Generics
+
+{-------------------------------------------------------------------------------
+  Generic boolean properties
+-------------------------------------------------------------------------------}
+
+-- | A prerequisite
+--
+-- If any prereq is 'Blocked', then the ultimate observation must be @False@.
+--
+-- See 'Requirement'.
+data Prereq = Blocked | Enabled
+  deriving (Eq, Show)
+
+enabledIf :: Bool -> Prereq
+enabledIf b = if b then Enabled else Blocked
+
+-- | A requirement
+--
+-- If all prereqs are 'Enabled' and all reqs are 'Required' then the ultimate
+-- observation must be @True@.
+data Requirement = Optional | Required
+  deriving (Eq, Show)
+
+requiredIf :: Bool -> Requirement
+requiredIf b = if b then Required else Optional
+
+-- | Collect all of the 'Prereq's and 'Requirement's from a composite type
+--
+-- The default definition uses "GHC.Generics" to automatically handle algebraic
+-- types containing only 'Prereq', 'Requirement', 'Bool', lists, and small
+-- tuples.
+--
+-- Note that 'collectReqs' ignores 'Bool's. It's up to the user to interpret
+-- 'Bool's as either disjunctive\/conjunctive\/etc observations.
+class CollectReqs a where
+  collectReqs :: a -> ([Prereq], [Requirement])
+
+  default collectReqs :: (Generic a, GCollectReqs (Rep a))
+                      => a -> ([Prereq], [Requirement])
+  collectReqs = gCollectReqs . from
+
+instance CollectReqs Bool where
+  collectReqs = mempty
+
+instance CollectReqs a => CollectReqs [a] where
+  collectReqs = foldMap collectReqs
+
+instance (CollectReqs a, CollectReqs b) => CollectReqs (a, b) where
+  collectReqs (a, b) = collectReqs a <> collectReqs b
+
+instance (CollectReqs a, CollectReqs b, CollectReqs c)
+      => CollectReqs (a, b, c) where
+  collectReqs (a, b, c) = collectReqs a <> collectReqs b <> collectReqs c
+
+instance (CollectReqs a, CollectReqs b, CollectReqs c, CollectReqs d)
+      => CollectReqs (a, b, c, d) where
+  collectReqs (a, b, c, d) =
+      collectReqs a <> collectReqs b <> collectReqs c <> collectReqs d
+
+instance CollectReqs Requirement where
+  collectReqs req = ([], [req])
+
+instance CollectReqs Prereq where
+  collectReqs prereq = ([prereq], [])
+
+-- | Via 'CollectReqs', check if the ultimate observation has a required value
+checkReqs :: CollectReqs a => a -> Maybe Bool
+checkReqs x
+      | Blocked  `elem` prereqs = Just False
+      | Optional `elem` reqs    = Nothing
+      | otherwise               = Just True
+    where
+      (prereqs, reqs) = collectReqs x
+
+{-------------------------------------------------------------------------------
+  Generic boolean properties, generically
+-------------------------------------------------------------------------------}
+
+class GCollectReqs rep where
+  gCollectReqs :: rep (x :: *) -> ([Prereq], [Requirement])
+
+instance GCollectReqs U1 where
+  gCollectReqs U1 = mempty
+
+instance GCollectReqs rep => GCollectReqs (M1 c meta rep) where
+  gCollectReqs (M1 rep) = gCollectReqs rep
+
+instance (GCollectReqs rep1, GCollectReqs rep2)
+      => GCollectReqs (rep1 :*: rep2) where
+  gCollectReqs (rep1 :*: rep2) = gCollectReqs rep1 <> gCollectReqs rep2
+
+instance (GCollectReqs rep1, GCollectReqs rep2)
+      => GCollectReqs (rep1 :+: rep2) where
+  gCollectReqs = \case
+      L1 rep -> gCollectReqs rep
+      R1 rep -> gCollectReqs rep
+
+instance CollectReqs c => GCollectReqs (K1 meta c) where
+  gCollectReqs (K1 c) = collectReqs c


### PR DESCRIPTION
This is a lightweight addition to the test so that it fails if:

  (1) It progresses to Shelley even though the adopted update proposal didn't increment the major protocol version.

  (2) It doesn't progress to Shelley even though the update proposal incremented the major version and there were enough slots that a Shelley block should have been created.