### PR TITLE
Revert "Enable NodeToNodeV_2 for Byron"

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
@@ -38,15 +38,17 @@ instance HasNetworkProtocolVersion ByronBlock where
 
 instance TranslateNetworkProtocolVersion ByronBlock where
   supportedNodeToNodeVersions   _ = ByronNodeToNodeVersion1
-                                  :| [ ByronNodeToNodeVersion2 ]
+                                  :| []
   supportedNodeToClientVersions _ = ByronNodeToClientVersion1
                                   :| [ ByronNodeToClientVersion2 ]
 
-  mostRecentSupportedNodeToNode   _ = ByronNodeToNodeVersion2
+  mostRecentSupportedNodeToNode   _ = ByronNodeToNodeVersion1
   mostRecentSupportedNodeToClient _ = ByronNodeToClientVersion2
 
+  -- Note ByronNodeToNodeVersion2 is enabled as part of the hard-fork-enabled
+  -- CardanoNodeToNodeVersion2
   nodeToNodeProtocolVersion _ ByronNodeToNodeVersion1 = N.NodeToNodeV_1
-  nodeToNodeProtocolVersion _ ByronNodeToNodeVersion2 = N.NodeToNodeV_2
+  nodeToNodeProtocolVersion _ ByronNodeToNodeVersion2 = error "version 2 not supported"
 
   nodeToClientProtocolVersion _ ByronNodeToClientVersion1 = N.NodeToClientV_1
   nodeToClientProtocolVersion _ ByronNodeToClientVersion2 = N.NodeToClientV_2


### PR DESCRIPTION
This reverts commit 69c39d57f33565f9acf34f18e1640ba40e08a6e9.

If this change ends up being released and deployed before Byron-to-Shelley is
ready, then we'll need a NodeToNodeV_3 to enable Byron-to-Shelley.

See #2281 for the alternative approach.