### PR TITLE
Trailing bytes

### DIFF
--- a/network-mux/src/Network/Mux/Trace.hs
+++ b/network-mux/src/Network/Mux/Trace.hs
@@ -133,6 +133,7 @@ data MuxTrace =
     | MuxTraceChannelRecvEnd !MiniProtocolNum !Int
     | MuxTraceChannelSendStart !MiniProtocolNum !Int
     | MuxTraceChannelSendEnd !MiniProtocolNum
+    | MuxTraceChannelPushBackTrailingBytes !Int
     | MuxTraceHandshakeStart
     | MuxTraceHandshakeClientEnd !DiffTime
     | MuxTraceHandshakeServerEnd
@@ -167,6 +168,7 @@ instance Show MuxTrace where
     show (MuxTraceChannelSendStart mid len) = printf "Channel Send Start on %s %d" (show mid)
         len
     show (MuxTraceChannelSendEnd mid) = printf "Channel Send End on %s" (show mid)
+    show (MuxTraceChannelPushBackTrailingBytes len) = printf "Channel: push back %d trailing bytes" len
     show MuxTraceHandshakeStart = "Handshake start"
     show (MuxTraceHandshakeClientEnd duration) = printf "Handshake Client end, duration %s" (show duration)
     show MuxTraceHandshakeServerEnd = "Handshake Server end"

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -216,7 +216,7 @@ data MuxBearer m = MuxBearer {
 -- 'MiniProtocolNum' and 'MiniProtocolDir'.
 --
 muxBearerAsChannel
-  :: forall m. Functor m
+  :: forall m. Applicative m
   => MuxBearer m
   -> MiniProtocolNum
   -> MiniProtocolDir
@@ -224,7 +224,8 @@ muxBearerAsChannel
 muxBearerAsChannel bearer ptclNum ptclDir =
       Channel {
         send = \blob -> void $ write bearer noTimeout (wrap blob),
-        recv = Just . msBlob . fst <$> read bearer noTimeout
+        recv = Just . msBlob . fst <$> read bearer noTimeout,
+        pushBackTrailingBytes = \_ -> pure ()
       }
     where
       -- wrap a 'ByteString' as 'MuxSDU'

--- a/ouroboros-network-framework/src/Ouroboros/Network/Mux.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Mux.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Ouroboros.Network.Mux
@@ -151,7 +152,7 @@ runMuxPeer
 runMuxPeer (MuxPeer tracer codec peer) channel =
     runPeer tracer codec channel peer
 
-runMuxPeer (MuxPeerPipelined tracer codec peer) channel =
+runMuxPeer (MuxPeerPipelined tracer codec peer) channel = do
     runPipelinedPeer tracer codec channel peer
 
 runMuxPeer (MuxPeerRaw action) channel =


### PR DESCRIPTION
This PR adds `pushBackTrailingData` to `ouroboros-network-framework`'s
`Channel` type (and similar method to `network-mux`'s `Channel`).

This PR does not change types of `runPeer` functions: they push trailing bytes
back to the channel.

`ouroboros-consensus` is using `MuxPeerRaw :: (Chanel m bytes -> m a) ::
MuxPeer bytes m a` what prevents us from actually hidding the `Channel` (we
cannot just hide `pushBackTrailingData`).  Once we remove `MuxPeerRaw` or any
direct usage of `runPeer` and `runPeerWithLimits` `consensus` will not have
access to the channel at all (as it it should not).

Also note that in the consensus scope one is not exposed to bytes (and they are
keept abstract, so the only available term is `undefined`).  This quite limits
the ways one can missuse `pushBackTrailingData`.

- trailing bytes: mux changes
- trailing bytes: ouroboros-network-framework
