### PR TITLE
Shelley/Cardano: take the initial nonce as a parameter

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -142,6 +142,12 @@ data Protocol (m :: * -> *) blk p where
   -- | Run TPraos against the real Shelley ledger
   ProtocolRealTPraos
     :: ShelleyGenesis TPraosStandardCrypto
+    -> Nonce
+       -- ^ The initial nonce, typically derived from the hash of Genesis
+       -- config JSON file.
+       --
+       -- WARNING: chains using different values of this parameter will be
+       -- mutually incompatible.
     -> ProtVer
     -> Natural -- ^ Max major protocol version
     -> Maybe (TPraosLeaderCredentials TPraosStandardCrypto)
@@ -157,6 +163,12 @@ data Protocol (m :: * -> *) blk p where
     -> Maybe PBftLeaderCredentials
        -- Shelley
     -> ShelleyGenesis TPraosStandardCrypto
+    -> Nonce
+       -- ^ The initial nonce for the Shelley era, typically derived from the
+       -- hash of Shelley Genesis config JSON file.
+       --
+       -- WARNING: chains using different values of this parameter will be
+       -- mutually incompatible.
     -> ProtVer -- TODO unify with 'Update.ProtocolVersion' (2 vs 3 numbers)
     -> Natural -- ^ Max major protocol version
     -> Maybe (TPraosLeaderCredentials TPraosStandardCrypto)
@@ -206,16 +218,16 @@ protocolInfo (ProtocolMockPBFT paramsPBft paramsEra nid) =
 protocolInfo (ProtocolRealPBFT gc mthr prv swv mplc) =
     protocolInfoByron gc mthr prv swv mplc
 
-protocolInfo (ProtocolRealTPraos genesis protVer maxMajorPV mbLeaderCredentials) =
-    protocolInfoShelley genesis maxMajorPV protVer mbLeaderCredentials
+protocolInfo (ProtocolRealTPraos genesis initialNonce protVer maxMajorPV mbLeaderCredentials) =
+    protocolInfoShelley genesis initialNonce maxMajorPV protVer mbLeaderCredentials
 
 protocolInfo (ProtocolCardano
                genesisByron mthr prv swv mbLeaderCredentialsByron
-               genesisShelley protVer maxMajorPV mbLeaderCredentialsShelley
+               genesisShelley initialNonce protVer maxMajorPV mbLeaderCredentialsShelley
                mbLowerBound hardCodedTransition) =
     protocolInfoCardano
       genesisByron mthr prv swv mbLeaderCredentialsByron
-      genesisShelley protVer maxMajorPV mbLeaderCredentialsShelley
+      genesisShelley initialNonce protVer maxMajorPV mbLeaderCredentialsShelley
       mbLowerBound hardCodedTransition
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -71,6 +71,8 @@ import qualified Ouroboros.Consensus.Byron.Ledger.Conversions as Byron
 import           Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
 import           Ouroboros.Consensus.Byron.Node
 
+import           Shelley.Spec.Ledger.BaseTypes (Nonce (..))
+
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
 import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
@@ -286,6 +288,9 @@ protocolInfoCardano
   -> Maybe PBftLeaderCredentials
      -- Shelley
   -> ShelleyGenesis sc
+  -> Nonce
+     -- ^ The initial nonce for the Shelley era, typically derived from the
+     -- hash of Shelley Genesis config JSON file.
   -> ProtVer
   -> Natural
   -> Maybe (TPraosLeaderCredentials sc)
@@ -294,7 +299,7 @@ protocolInfoCardano
   -> TriggerHardFork
   -> ProtocolInfo m (CardanoBlock sc)
 protocolInfoCardano genesisByron mSigThresh pVer sVer mbCredsByron
-                    genesisShelley protVer maxMajorPV mbCredsShelley
+                    genesisShelley initialNonce protVer maxMajorPV mbCredsShelley
                     mbLowerBound triggerHardFork =
     assertWithMsg (checkMaxKESEvolutions genesisShelley) $
     ProtocolInfo {
@@ -339,7 +344,7 @@ protocolInfoCardano genesisByron mSigThresh pVer sVer mbCredsByron
     -- Shelley
 
     tpraosParams :: TPraosParams
-    tpraosParams = Shelley.mkTPraosParams maxMajorPV genesisShelley
+    tpraosParams = Shelley.mkTPraosParams maxMajorPV initialNonce genesisShelley
 
     blockConfigShelley :: BlockConfig (ShelleyBlock sc)
     blockConfigShelley = Shelley.mkShelleyBlockConfig protVer genesisShelley

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -44,6 +44,7 @@ import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 import           Ouroboros.Consensus.Byron.Ledger.Conversions
 import           Ouroboros.Consensus.Byron.Node
 
+import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.Genesis as SL
 import qualified Shelley.Spec.Ledger.OCert as SL
 import qualified Shelley.Spec.Ledger.PParams as SL
@@ -176,6 +177,7 @@ prop_simple_cardano_convergence TestSetup
                   generatedSecrets
                   propPV
                   genesisShelley
+                  SL.NeutralNonce
                   (coreNodes !! fromIntegral nid)
                   (guard setupByronLowerBound *> Just numByronEpochs)
                   (TriggerHardForkAtVersion shelleyMajorVersion)
@@ -294,6 +296,7 @@ mkProtocolCardanoAndHardForkTxs
   -> CC.Update.ProtocolVersion
      -- Shelley
   -> ShelleyGenesis sc
+  -> SL.Nonce
   -> Shelley.CoreNode sc
      -- Hard fork
   -> Maybe EpochNo
@@ -301,7 +304,7 @@ mkProtocolCardanoAndHardForkTxs
   -> TestNodeInitialization m (CardanoBlock sc)
 mkProtocolCardanoAndHardForkTxs
     pbftParams coreNodeId genesisByron generatedSecretsByron propPV
-    genesisShelley coreNodeShelley
+    genesisShelley initialNonce coreNodeShelley
     mbLowerBound triggerHardFork =
     TestNodeInitialization
       { tniCrucialTxs   = crucialTxs
@@ -333,6 +336,7 @@ mkProtocolCardanoAndHardForkTxs
         (Just leaderCredentialsByron)
         -- Shelley
         genesisShelley
+        initialNonce
         protVerShelley
         maxMajorPVShelley
         (Just leaderCredentialsShelley)

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -294,11 +294,13 @@ mkGenesisConfig pVer k d slotLength maxKESEvolutions coreNodes =
 mkProtocolRealTPraos
   :: forall m c. (IOLike m, TPraosCrypto c)
   => ShelleyGenesis c
+  -> SL.Nonce
   -> CoreNode c
   -> ProtocolInfo m (ShelleyBlock c)
-mkProtocolRealTPraos genesis coreNode =
+mkProtocolRealTPraos genesis initialNonce coreNode =
     protocolInfoShelley
       genesis
+      initialNonce
       maxMajorPV
       protVer
       (Just (mkLeaderCredentials coreNode))

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -28,6 +28,7 @@ import           Test.Util.HardFork.Future (singleEraFuture)
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Random
 
+import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.OCert as SL
 import qualified Shelley.Spec.Ledger.PParams as SL
 
@@ -106,6 +107,7 @@ prop_simple_real_tpraos_convergence TestSetup
               plainTestNodeInitialization $
                 mkProtocolRealTPraos
                   genesisConfig
+                  SL.NeutralNonce
                   (coreNodes !! fromIntegral nid)
             , mkRekeyM = Nothing
             }

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -162,8 +162,6 @@ protocolInfoShelley genesis maxMajorPV protVer mbCredentials =
     ledgerConfig :: LedgerConfig (ShelleyBlock c)
     ledgerConfig = mkShelleyLedgerConfig genesis epochInfo maxMajorPV
 
-    -- TODO: This must instead be derived from the hard fork history.
-    -- <https://github.com/input-output-hk/ouroboros-network/issues/1205>
     epochInfo :: EpochInfo Identity
     epochInfo = fixedSizeEpochInfo $ SL.sgEpochLength genesis
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -192,14 +192,23 @@ data TPraosParams = TPraosParams {
     , tpraosMaxLovelaceSupply :: !Word64
       -- | Testnet or mainnet?
     , tpraosNetworkId         :: !SL.Network
+      -- | Initial nonce used for the TPraos protocol state. Typically this is
+      -- derived from the hash of the Shelley genesis config JSON file, but
+      -- different values may be used for testing purposes.
+      --
+      -- NOTE: this is only used when translating the Byron 'ChainDepState' to
+      -- the Shelley 'ChainDepState', at which point we'll need access to the
+      -- initial nonce at runtime. TODO #2326.
+    , tpraosInitialNonce      :: !SL.Nonce
     }
   deriving (Generic, NoUnexpectedThunks)
 
 mkTPraosParams
-  :: Natural -- ^ Max major protocol version
+  :: Natural   -- ^ Max major protocol version
+  -> SL.Nonce  -- ^ Initial nonce
   -> SL.ShelleyGenesis c
   -> TPraosParams
-mkTPraosParams maxMajorPV genesis = TPraosParams {
+mkTPraosParams maxMajorPV initialNonce genesis = TPraosParams {
       tpraosSlotsPerKESPeriod = SL.sgSlotsPerKESPeriod genesis
     , tpraosLeaderF           = SL.sgActiveSlotCoeff   genesis
     , tpraosMaxKESEvo         = SL.sgMaxKESEvolutions  genesis
@@ -208,6 +217,7 @@ mkTPraosParams maxMajorPV genesis = TPraosParams {
     , tpraosNetworkId         = SL.sgNetworkId         genesis
     , tpraosSecurityParam     = securityParam
     , tpraosMaxMajorPV        = maxMajorPV
+    , tpraosInitialNonce      = initialNonce
     }
   where
     securityParam = SecurityParam $ SL.sgSecurityParam genesis


### PR DESCRIPTION
Fixes #2005.

This nonce will be used to construct Shelley's initial `PrtclState`, both when
starting a fresh Shelley chain and when forking from Byron to Shelley (when
translating the Byron `ChainDepState` to the Shelley one).

We store the initial nonce in the `TPraosParams`, which is part of the
`ConsensusConfig` for `TPraos`. We need it here, at run-time, because we need
it when translating the Byron `ChainDepState` to the Shelley one.

`protocolInfoShelley` and `protocolInfoCardano` (as well as
`ProtocolRealTPraos` and `ProtocolCardano`) now take a `Nonce` argument that
will be used as the initial nonce. Typically the `Nonce` passed to these
functions (constructors) should be derived from the hash of the Shelley
Genesis config JSON file. Moreover, this allows us to choose a different
initial nonce for testing purposes, as required for #2235.

NOTE: up until now we have used `SL.NeutralNonce` as the initial nonce for
Shelley. When a different nonce is picked in `cardano-node`, i.e., one derived
from the hash of the Shelley Genesis config JSON file, it would cause a hard
fork.