### PR TITLE
shelley-test: epoch size of 10k/f not 10k

### DIFF
--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -153,10 +153,10 @@ prop_simple_cardano_convergence TestSetup
       , future       =
           if setupHardFork
           then
-          EraCons  setupSlotLengthByron   epochSize (EraSize numByronEpochs) $
-          EraFinal setupSlotLengthShelley epochSize
+          EraCons  setupSlotLengthByron   epochSizeByron   eraSizeByron $
+          EraFinal setupSlotLengthShelley epochSizeShelley
           else
-          EraFinal setupSlotLengthByron   epochSize
+          EraFinal setupSlotLengthByron   epochSizeByron
       , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
       , nodeRestarts = noRestarts
       , txGenExtra   = ()
@@ -179,24 +179,19 @@ prop_simple_cardano_convergence TestSetup
             , mkRekeyM = Nothing
             }
 
-    -- The team does not currently plan for Byron or Shelley to ever use an
-    -- epoch size other than 10k.
-    epochSize :: EpochSize
-    epochSize =
-        assert (tenK == epochSizeByron) $
-        assert (tenK == epochSizeShelley) $
-        tenK
-      where
-        tenK = EpochSize (10 * maxRollbacks setupK)
-
     -- Byron
 
     pbftParams :: PBftParams
     pbftParams = Byron.realPBftParams setupK numCoreNodes
 
+    -- the Byron ledger is designed to use a fixed epoch size, so this test
+    -- does not randomize it
     epochSizeByron :: EpochSize
     epochSizeByron =
         fromByronEpochSlots $ CC.Genesis.configEpochSlots genesisByron
+
+    eraSizeByron :: EraSize
+    eraSizeByron = EraSize numByronEpochs
 
     genesisByron     :: CC.Genesis.Config
     generatedSecrets :: CC.Genesis.GeneratedSecrets
@@ -229,6 +224,8 @@ prop_simple_cardano_convergence TestSetup
           maxKESEvolution
           coreNodes
 
+    -- the Shelley ledger is designed to use a fixed epoch size, so this test
+    -- does not randomize it
     epochSizeShelley :: EpochSize
     epochSizeShelley = sgEpochLength genesisShelley
 

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -174,9 +174,9 @@ mkGenesisConfig pVer k d slotLength maxKESEvolutions coreNodes =
     , sgNetworkMagic          = 0
     , sgNetworkId             = networkId
     , sgProtocolMagicId       = ProtocolMagicId 0
-    , sgActiveSlotsCoeff      = 0.5 -- TODO 1 is not accepted by 'mkActiveSlotCoeff'
+    , sgActiveSlotsCoeff      = recip recipF   -- ie f
     , sgSecurityParam         = maxRollbacks k
-    , sgEpochLength           = EpochSize (10 * maxRollbacks k)
+    , sgEpochLength           = EpochSize (10 * maxRollbacks k * recipF)
     , sgSlotsPerKESPeriod     = 10 -- TODO
     , sgMaxKESEvolutions      = maxKESEvolutions
     , sgSlotLength            = getSlotLength slotLength
@@ -188,6 +188,10 @@ mkGenesisConfig pVer k d slotLength maxKESEvolutions coreNodes =
     , sgStaking               = initialStake
     }
   where
+    -- the reciprocal of the active slot coefficient
+    recipF :: Num a => a
+    recipF = 2   -- so f = 0.5
+
     networkId :: SL.Network
     networkId = SL.Testnet
 


### PR DESCRIPTION
The Shelley era should use an epoch size of `10k/f`, not just `10/k`.