### PR TITLE
Update to latest cardano-ledger-specs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -115,8 +115,8 @@ package small-steps
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 2a1afe23d88b91027f972dd7c70cd4aadfb19768
-  --sha256: 0azd8m9qqvpmlqaddyi41iyksx08zn4ffyngmg83psp74l6dwzyf
+  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
+  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
   subdir:   contra-tracer
 
 source-repository-package
@@ -135,99 +135,99 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 21fb94831099a6b8a4baf7dbc7e2d4c2a76384f1
-  --sha256: 0jsi4pvz3qvi5f7vk0kjsbdjnjgblbhw3granpn3igrm3dbbhk64
+  tag: 1d24715aca78f1ef21278e9ce185792135079ddf
+  --sha256: 1js70y0hnnqnlr04v1k5gb9c03f05iws5s5z7k1i4xjp96wvp0pb
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 21fb94831099a6b8a4baf7dbc7e2d4c2a76384f1
-  --sha256: 0jsi4pvz3qvi5f7vk0kjsbdjnjgblbhw3granpn3igrm3dbbhk64
+  tag: 1d24715aca78f1ef21278e9ce185792135079ddf
+  --sha256: 1js70y0hnnqnlr04v1k5gb9c03f05iws5s5z7k1i4xjp96wvp0pb
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 21fb94831099a6b8a4baf7dbc7e2d4c2a76384f1
-  --sha256: 0jsi4pvz3qvi5f7vk0kjsbdjnjgblbhw3granpn3igrm3dbbhk64
+  tag: 1d24715aca78f1ef21278e9ce185792135079ddf
+  --sha256: 1js70y0hnnqnlr04v1k5gb9c03f05iws5s5z7k1i4xjp96wvp0pb
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 21fb94831099a6b8a4baf7dbc7e2d4c2a76384f1
-  --sha256: 0jsi4pvz3qvi5f7vk0kjsbdjnjgblbhw3granpn3igrm3dbbhk64
+  tag: 1d24715aca78f1ef21278e9ce185792135079ddf
+  --sha256: 1js70y0hnnqnlr04v1k5gb9c03f05iws5s5z7k1i4xjp96wvp0pb
   subdir: slotting
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 18f0c670eb24b1f519e298a430651fb38af01117
-  --sha256: 0w6jq0z7qdl331la8wpyya28dvqn77m69nvzssw5pxhp9bwzmjf4
+  tag: ee92681752dc1a27ac77cb3466af8dca4ade997f
+  --sha256: 14k6dfq8ssc3c4shll813b8wfkf9vgsz2djvg2sll9pf2fz2g1vi
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 18f0c670eb24b1f519e298a430651fb38af01117
-  --sha256: 0w6jq0z7qdl331la8wpyya28dvqn77m69nvzssw5pxhp9bwzmjf4
+  tag: ee92681752dc1a27ac77cb3466af8dca4ade997f
+  --sha256: 14k6dfq8ssc3c4shll813b8wfkf9vgsz2djvg2sll9pf2fz2g1vi
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 18f0c670eb24b1f519e298a430651fb38af01117
-  --sha256: 0w6jq0z7qdl331la8wpyya28dvqn77m69nvzssw5pxhp9bwzmjf4
+  tag: ee92681752dc1a27ac77cb3466af8dca4ade997f
+  --sha256: 14k6dfq8ssc3c4shll813b8wfkf9vgsz2djvg2sll9pf2fz2g1vi
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 18f0c670eb24b1f519e298a430651fb38af01117
-  --sha256: 0w6jq0z7qdl331la8wpyya28dvqn77m69nvzssw5pxhp9bwzmjf4
+  tag: ee92681752dc1a27ac77cb3466af8dca4ade997f
+  --sha256: 14k6dfq8ssc3c4shll813b8wfkf9vgsz2djvg2sll9pf2fz2g1vi
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 18f0c670eb24b1f519e298a430651fb38af01117
-  --sha256: 0w6jq0z7qdl331la8wpyya28dvqn77m69nvzssw5pxhp9bwzmjf4
+  tag: ee92681752dc1a27ac77cb3466af8dca4ade997f
+  --sha256: 14k6dfq8ssc3c4shll813b8wfkf9vgsz2djvg2sll9pf2fz2g1vi
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 18f0c670eb24b1f519e298a430651fb38af01117
-  --sha256: 0w6jq0z7qdl331la8wpyya28dvqn77m69nvzssw5pxhp9bwzmjf4
+  tag: ee92681752dc1a27ac77cb3466af8dca4ade997f
+  --sha256: 14k6dfq8ssc3c4shll813b8wfkf9vgsz2djvg2sll9pf2fz2g1vi
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 18f0c670eb24b1f519e298a430651fb38af01117
-  --sha256: 0w6jq0z7qdl331la8wpyya28dvqn77m69nvzssw5pxhp9bwzmjf4
+  tag: ee92681752dc1a27ac77cb3466af8dca4ade997f
+  --sha256: 14k6dfq8ssc3c4shll813b8wfkf9vgsz2djvg2sll9pf2fz2g1vi
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 18f0c670eb24b1f519e298a430651fb38af01117
-  --sha256: 0w6jq0z7qdl331la8wpyya28dvqn77m69nvzssw5pxhp9bwzmjf4
+  tag: ee92681752dc1a27ac77cb3466af8dca4ade997f
+  --sha256: 14k6dfq8ssc3c4shll813b8wfkf9vgsz2djvg2sll9pf2fz2g1vi
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 18f0c670eb24b1f519e298a430651fb38af01117
-  --sha256: 0w6jq0z7qdl331la8wpyya28dvqn77m69nvzssw5pxhp9bwzmjf4
+  tag: ee92681752dc1a27ac77cb3466af8dca4ade997f
+  --sha256: 14k6dfq8ssc3c4shll813b8wfkf9vgsz2djvg2sll9pf2fz2g1vi
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 18f0c670eb24b1f519e298a430651fb38af01117
-  --sha256: 0w6jq0z7qdl331la8wpyya28dvqn77m69nvzssw5pxhp9bwzmjf4
+  tag: ee92681752dc1a27ac77cb3466af8dca4ade997f
+  --sha256: 14k6dfq8ssc3c4shll813b8wfkf9vgsz2djvg2sll9pf2fz2g1vi
   subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -26,6 +26,7 @@ import           Data.Functor.Identity (Identity (..))
 import qualified Data.Map.Strict as Map
 import           Data.Proxy (Proxy (..))
 import           Data.Time (UTCTime (..), fromGregorian)
+import           Data.Word (Word64)
 
 import           Cardano.Crypto (ProtocolMagicId (..))
 import           Cardano.Crypto.Hash (ShortHash)
@@ -128,23 +129,23 @@ exampleApplyTxErr =
     $ pure
     $ STS.LedgerFailure
     $ STS.UtxowFailure
-    $ STS.InvalidWitnessesUTXOW ([SL.VKey 1], [])
+    $ STS.InvalidWitnessesUTXOW [SL.VKey 1]
 
 exampleConsensusState :: ConsensusState (BlockProtocol (Block ShortHash))
 exampleConsensusState =
     TPraosState.append 2      (mkPrtclState 2) $
     TPraosState.empty  (At 1) (mkPrtclState 1)
   where
-    mkPrtclState :: Natural -> STS.PrtclState (TPraosMockCrypto ShortHash)
+    mkPrtclState :: Word64 -> STS.PrtclState (TPraosMockCrypto ShortHash)
     mkPrtclState seed = STS.PrtclState
       (Map.fromList
        [ (SL.KeyHash (mkDummyHash (Proxy @(TPraosMockCrypto ShortHash)) 1), 1)
        , (SL.KeyHash (mkDummyHash (Proxy @(TPraosMockCrypto ShortHash)) 2), 2)
        ])
       SL.NeutralNonce
-      (SL.mkNonce seed)
-      (SL.mkNonce seed)
-      (SL.mkNonce seed)
+      (SL.mkNonceFromNumber seed)
+      (SL.mkNonceFromNumber seed)
+      (SL.mkNonceFromNumber seed)
 
 exampleLedgerState :: LedgerState (Block ShortHash)
 exampleLedgerState = reapplyLedgerBlock
@@ -167,9 +168,9 @@ exampleHeaderState = genesisHeaderState st
       (Map.fromList
         [(SL.KeyHash (mkDummyHash (Proxy @(TPraosMockCrypto ShortHash)) 1), 1)])
       SL.NeutralNonce
-      (SL.mkNonce 1)
+      (SL.mkNonceFromNumber 1)
       SL.NeutralNonce
-      (SL.mkNonce 2)
+      (SL.mkNonceFromNumber 2)
 
     st :: TPraosState (ConcreteCrypto ShortHash)
     st = TPraosState.empty (At 1) prtclState

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
@@ -268,7 +268,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkListLen 3
     , TkListLen 2
     , TkInt 10
-    , TkBytes "\ETXv\132]"
+    , TkBytes "\211\231\US\147"
     , TkListLen 2
     , TkListLen 1
     , TkInt 0
@@ -616,7 +616,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkListLen 3
     , TkListLen 2
     , TkInt 10
-    , TkBytes "\ETXv\132]"
+    , TkBytes "\211\231\US\147"
     , TkListLen 2
     , TkListLen 1
     , TkInt 0

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/TPraos.hs
@@ -5,7 +5,7 @@
 -- TODO where to put this?
 module Ouroboros.Consensus.Shelley.Ledger.TPraos () where
 
-import           Cardano.Crypto.VRF.Class (certifiedNatural)
+import           Cardano.Crypto.VRF.Class (certifiedOutput)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Signed
@@ -14,7 +14,6 @@ import           Ouroboros.Consensus.Shelley.Ledger.Config ()
 import           Ouroboros.Consensus.Shelley.Protocol
 
 import qualified Shelley.Spec.Ledger.BlockChain as SL
-import qualified Shelley.Spec.Ledger.Keys as SL
 import qualified Shelley.Spec.Ledger.OCert as SL
 
 {-------------------------------------------------------------------------------
@@ -30,8 +29,7 @@ instance TPraosCrypto c => BlockSupportsProtocol (ShelleyBlock c) where
     ChainSelectView
       { csvChainLength = SL.bheaderBlockNo . SL.bhbody $ hdr
       , csvLeaderVRF =
-              SL.fromNatural
-            . certifiedNatural
+              certifiedOutput
             . SL.bheaderL
             . SL.bhbody
             $ hdr

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -264,7 +264,7 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
   checkIsLeader cfg@PraosConfig{..} nid (Ticked slot _u) cs = do
       rho <- evalCertified () rho' praosSignKeyVRF
       y   <- evalCertified () y'   praosSignKeyVRF
-      return $ if fromIntegral (certifiedNatural y) < t
+      return $ if fromIntegral (getOutputVRFNatural (certifiedOutput y)) < t
           then IsLeader PraosProof {
                    praosProofRho  = rho
                  , praosProofY    = y
@@ -314,7 +314,7 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
         throwError $ PraosInvalidCert
             vkVRF
             rho'
-            (certifiedNatural praosRho)
+            (getOutputVRFNatural (certifiedOutput praosRho))
             (certifiedProof praosRho)
 
     -- verify y proof
@@ -322,12 +322,13 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
         throwError $ PraosInvalidCert
             vkVRF
             y'
-            (certifiedNatural praosY)
+            (getOutputVRFNatural (certifiedOutput praosY))
             (certifiedProof praosY)
 
     -- verify stake
-    unless (fromIntegral (certifiedNatural praosY) < t) $
-        throwError $ PraosInsufficientStake t $ certifiedNatural praosY
+    unless (fromIntegral (getOutputVRFNatural (certifiedOutput praosY)) < t) $
+        throwError $ PraosInsufficientStake t $
+                       getOutputVRFNatural (certifiedOutput praosY)
 
     let !bi = BlockInfo
             { biSlot  = slot

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,12 +36,12 @@ flags:
 
 extra-deps:
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 2a1afe23d88b91027f972dd7c70cd4aadfb19768
+    commit: efa4b5ecd7f0a13124616b12679cd42517cd905a
     subdirs:
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 21fb94831099a6b8a4baf7dbc7e2d4c2a76384f1
+    commit: 1d24715aca78f1ef21278e9ce185792135079ddf
     subdirs:
       - binary
       - binary/test
@@ -49,7 +49,7 @@ extra-deps:
       - slotting
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 18f0c670eb24b1f519e298a430651fb38af01117
+    commit: ee92681752dc1a27ac77cb3466af8dca4ade997f
     subdirs:
       - byron/chain/executable-spec
       - byron/ledger/executable-spec


### PR DESCRIPTION
Main change is the change in the VRF leader calculation and types. It no
longer goes via UnitInterval.

This means we do our chain selection comparison on the full natural.