### PR TITLE
Concurrently combinator & Handler in MonadCatch

### DIFF
--- a/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Dns.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Dns.hs
@@ -101,10 +101,10 @@ dnsResolve :: forall a m s.
     -> m (SubscriptionTarget m Socket.SockAddr)
 dnsResolve tracer getSeed withResolverFn peerStatesVar beforeConnect (DnsSubscriptionTarget domain _ _) = do
     rs_e <- (Right <$> getSeed) `catches`
-        [ mkHandler (\ (e :: DNS.DNSError) ->
+        [ Handler (\ (e :: DNS.DNSError) ->
             return (Left $ toException e) :: m (Either SomeException a))
         -- On windows getSeed fails with BadConfiguration if the network is down.
-        , mkHandler (\ (e :: IOError) ->
+        , Handler (\ (e :: IOError) ->
             return (Left $ toException e) :: m (Either SomeException a))
         -- On OSX getSeed can fail with IOError if all network devices are down.
         ]


### PR DESCRIPTION
`ConcurentlyM`, like `Concurently` but for `MonadAsync`.   It's not part of the
`MonadAsync` which makes it simpler to implement and use, but we're not reusing
`Concurrently` for `MonadAsync`'s `IO` instance.
