### PR TITLE
Introduce ChainIndepState

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -73,6 +73,7 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params mLeader =
             configConsensus = PBftConfig {
                 pbftParams = params
               }
+          , configIndep  = ()
           , configLedger = DualLedgerConfig {
                 dualLedgerConfigMain = concreteGenesis
               , dualLedgerConfigAux  = abstractConfig

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
@@ -77,12 +77,12 @@ instance EncodeDisk DualByronBlock (LedgerState DualByronBlock) where
 instance DecodeDisk DualByronBlock (LedgerState DualByronBlock) where
   decodeDisk _ = decodeDualLedgerState decodeByronLedgerState
 
--- | @'ConsensusState' ('BlockProtocol' 'DualByronBlock')@
+-- | @'ChainDepState' ('BlockProtocol' 'DualByronBlock')@
 instance EncodeDisk DualByronBlock (PBftState PBftByronCrypto) where
-  encodeDisk _ = encodeByronConsensusState
--- | @'ConsensusState' ('BlockProtocol' 'DualByronBlock')@
+  encodeDisk _ = encodeByronChainDepState
+-- | @'ChainDepState' ('BlockProtocol' 'DualByronBlock')@
 instance DecodeDisk DualByronBlock (PBftState PBftByronCrypto) where
-  decodeDisk ccfg = decodeByronConsensusState k
+  decodeDisk ccfg = decodeByronChainDepState k
     where
       k = getByronSecurityParam $ dualCodecConfigMain ccfg
 

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TypeApplications  #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 module Test.Consensus.Byron.Examples (
-    exampleConsensusState
+    exampleChainDepState
   , exampleLedgerState
   , exampleHeaderState
   , exampleExtLedgerState
@@ -48,7 +48,7 @@ import qualified Test.Cardano.Chain.UTxO.Example as CC
 -------------------------------------------------------------------------------}
 
 -- | Note that we must use the same value for the 'SecurityParam' as for the
--- 'S.WindowSize', because 'decodeByronConsensusState' only takes the
+-- 'S.WindowSize', because 'decodeByronChainDepState' only takes the
 -- 'SecurityParam' and uses it as the basis for the 'S.WindowSize'.
 secParam :: SecurityParam
 secParam = SecurityParam 2
@@ -60,8 +60,8 @@ windowSize = S.WindowSize 2
   Examples
 -------------------------------------------------------------------------------}
 
-exampleConsensusState :: ConsensusState (BlockProtocol ByronBlock)
-exampleConsensusState = withEBB
+exampleChainDepState :: ChainDepState (BlockProtocol ByronBlock)
+exampleChainDepState = withEBB
   where
     signers = map (`S.PBftSigner` CC.exampleKeyHash) [1..4]
 
@@ -75,7 +75,7 @@ exampleConsensusState = withEBB
     exampleEbbHeaderHashBytes :: HeaderHashBytes
     exampleEbbSlot            = 6
     exampleEbbHeaderHashBytes = mkHeaderHashBytesForTestingOnly
-                                  (Lazy8.pack "test_golden_ConsensusState6")
+                                  (Lazy8.pack "test_golden_ChainDepState6")
 
     withEBB = S.appendEBB secParam windowSize
                 exampleEbbSlot exampleEbbHeaderHashBytes

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -59,7 +59,6 @@ import           Test.ThreadNet.Util.NodeTopology
 
 import           Test.ThreadNet.Infra.Byron.ProtocolInfo
 
-import           Test.Util.Random
 import           Test.Util.Slots (NumSlots (..))
 
 -- | The expectation and observation regarding whether the hard-fork proposal
@@ -389,7 +388,7 @@ mkProtocolRealPBftAndHardForkTxs
     ProtocolInfo{pInfoConfig}   = pInfo
     TopLevelConfig{configBlock} = pInfoConfig
 
-    pInfo :: ProtocolInfo (ChaChaT m) ByronBlock
+    pInfo :: ProtocolInfo m ByronBlock
     pInfo = mkProtocolRealPBFT params cid genesisConfig genesisSecrets
 
     proposals :: [Byron.GenTx ByronBlock]

--- a/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Golden.hs
+++ b/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Golden.hs
@@ -32,7 +32,7 @@ tests :: TestTree
 tests = testGroup "Golden tests"
     -- Note that for most Byron types, we simply wrap the en/decoders from
     -- cardano-ledger, which already has golden tests for them.
-    [ testCase "ConsensusState" test_golden_ConsensusState
+    [ testCase "ChainDepState"  test_golden_ChainDepState
     , testCase "LedgerState"    test_golden_LedgerState
     , testCase "GenTxId"        test_golden_GenTxId
     , testCase "UPIState"       test_golden_UPIState
@@ -46,10 +46,10 @@ tests = testGroup "Golden tests"
     , testCase "Result"         test_golden_Result
     ]
 
-test_golden_ConsensusState :: Assertion
-test_golden_ConsensusState = goldenTestCBOR
-    encodeByronConsensusState
-    exampleConsensusState
+test_golden_ChainDepState :: Assertion
+test_golden_ChainDepState = goldenTestCBOR
+    encodeByronChainDepState
+    exampleChainDepState
     [ TkListLen 2
     , TkInt 0
     , TkListLen 3
@@ -73,7 +73,7 @@ test_golden_ConsensusState = goldenTestCBOR
     , TkListLen 4
     , TkInt 0
     , TkInt 6
-    , TkBytes "test_golden_ConsensusState6"
+    , TkBytes "test_golden_ChainDepState6"
     , TkListLen 2
     , TkInt 1
     , TkInt 4

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
@@ -1282,7 +1282,7 @@ genNodeRekeys params nodeJoinPlan nodeTopology numSlots@(NumSlots t)
 mkRekeyUpd
   :: Genesis.Config
   -> Genesis.GeneratedSecrets
-  -> ProtocolInfo (ChaChaT m) ByronBlock
+  -> ProtocolInfo m ByronBlock
   -> EpochNo
   -> Crypto.SignKeyDSIGN Crypto.ByronDSIGN
   -> Maybe (TestNodeInitialization m ByronBlock)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -44,18 +44,17 @@ import           Ouroboros.Consensus.Byron.Ledger.PBFT
 import           Ouroboros.Consensus.Byron.Protocol
 
 instance CanForge ByronBlock where
-  type ForgeState ByronBlock = ()
   forgeBlock = forgeByronBlock
 
 forgeByronBlock
-  :: forall m. (Monad m, HasCallStack)
+  :: HasCallStack
   => TopLevelConfig ByronBlock
   -> ForgeState ByronBlock
   -> BlockNo                         -- ^ Current block number
   -> TickedLedgerState ByronBlock    -- ^ Current ledger
   -> [GenTx ByronBlock]              -- ^ Txs to add in the block
   -> PBftIsLeader PBftByronCrypto    -- ^ Leader proof ('IsLeader')
-  -> m ByronBlock
+  -> ByronBlock
 forgeByronBlock = forgeRegularBlock
 
 forgeEBB
@@ -126,21 +125,20 @@ initBlockPayloads = BlockPayloads
   }
 
 forgeRegularBlock
-  :: forall m. (Monad m, HasCallStack)
+  :: HasCallStack
   => TopLevelConfig ByronBlock
   -> ForgeState ByronBlock
   -> BlockNo                           -- ^ Current block number
   -> TickedLedgerState ByronBlock      -- ^ Current ledger
   -> [GenTx ByronBlock]                -- ^ Txs to add in the block
   -> PBftIsLeader PBftByronCrypto      -- ^ Leader proof ('IsLeader')
-  -> m ByronBlock
-forgeRegularBlock cfg () curNo tickedLedger txs isLeader =
-    let ouroborosPayload =
-          forgePBftFields
-            (mkByronContextDSIGN $ configBlock cfg)
-            isLeader
-            (reAnnotate $ Annotated toSign ())
-    in return $ forge ouroborosPayload
+  -> ByronBlock
+forgeRegularBlock cfg _forgeState curNo tickedLedger txs isLeader =
+    forge $
+      forgePBftFields
+        (mkByronContextDSIGN $ configBlock cfg)
+        isLeader
+        (reAnnotate $ Annotated toSign ())
   where
     curSlot :: SlotNo
     curSlot = tickedSlotNo tickedLedger

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -354,12 +354,12 @@ decodeByronAnnTip = decodeAnnTipIsEBB decodeByronHeaderHash
 encodeByronExtLedgerState :: ExtLedgerState ByronBlock -> Encoding
 encodeByronExtLedgerState = encodeExtLedgerState
     encodeByronLedgerState
-    encodeByronConsensusState
+    encodeByronChainDepState
     encodeByronAnnTip
 
 encodeByronHeaderState :: HeaderState ByronBlock -> Encoding
 encodeByronHeaderState = encodeHeaderState
-    encodeByronConsensusState
+    encodeByronChainDepState
     encodeByronAnnTip
 
 encodeByronLedgerState :: LedgerState ByronBlock -> Encoding

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
@@ -9,8 +9,8 @@
 module Ouroboros.Consensus.Byron.Ledger.PBFT (
     toPBftLedgerView
   , fromPBftLedgerView
-  , encodeByronConsensusState
-  , decodeByronConsensusState
+  , encodeByronChainDepState
+  , decodeByronChainDepState
   , mkByronContextDSIGN
   ) where
 
@@ -84,12 +84,12 @@ toPBftLedgerView = PBftLedgerView . Delegation.unMap
 fromPBftLedgerView :: PBftLedgerView PBftByronCrypto -> Delegation.Map
 fromPBftLedgerView = Delegation.Map . pbftDelegates
 
-encodeByronConsensusState
-  :: ConsensusState (BlockProtocol ByronBlock)
+encodeByronChainDepState
+  :: ChainDepState (BlockProtocol ByronBlock)
   -> Encoding
-encodeByronConsensusState = S.encodePBftState
+encodeByronChainDepState = S.encodePBftState
 
-decodeByronConsensusState
+decodeByronChainDepState
   :: SecurityParam
-  -> Decoder s (ConsensusState (BlockProtocol ByronBlock))
-decodeByronConsensusState k = S.decodePBftState k (pbftWindowSize k)
+  -> Decoder s (ChainDepState (BlockProtocol ByronBlock))
+decodeByronChainDepState k = S.decodePBftState k (pbftWindowSize k)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -125,6 +125,7 @@ protocolInfoByron genesisConfig mSigThresh pVer sVer mLeader =
             configConsensus = PBftConfig {
                 pbftParams = byronPBftParams genesisConfig mSigThresh
               }
+          , configIndep  = ()
           , configLedger = genesisConfig
           , configBlock  = byronConfig
           }

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
@@ -56,12 +56,12 @@ instance EncodeDisk ByronBlock (LedgerState ByronBlock) where
 instance DecodeDisk ByronBlock (LedgerState ByronBlock) where
   decodeDisk _ = decodeByronLedgerState
 
--- | @'ConsensusState' ('BlockProtocol' 'ByronBlock')@
+-- | @'ChainDepState' ('BlockProtocol' 'ByronBlock')@
 instance EncodeDisk ByronBlock (PBftState PBftByronCrypto) where
-  encodeDisk _ = encodeByronConsensusState
--- | @'ConsensusState' ('BlockProtocol' 'ByronBlock')@
+  encodeDisk _ = encodeByronChainDepState
+-- | @'ChainDepState' ('BlockProtocol' 'ByronBlock')@
 instance DecodeDisk ByronBlock (PBftState PBftByronCrypto) where
-  decodeDisk ccfg = decodeByronConsensusState (getByronSecurityParam ccfg)
+  decodeDisk ccfg = decodeByronChainDepState (getByronSecurityParam ccfg)
 
 instance EncodeDisk ByronBlock (AnnTip ByronBlock) where
   encodeDisk _ = encodeByronAnnTip

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -31,7 +31,6 @@ module Ouroboros.Consensus.Cardano (
   , verifyProtocolClient
   ) where
 
-import           Crypto.Random (MonadRandom)
 import           Data.Type.Equality
 
 import           Cardano.Prelude (Natural)
@@ -51,6 +50,7 @@ import           Ouroboros.Consensus.Protocol.BFT as X
 import           Ouroboros.Consensus.Protocol.LeaderSchedule as X
 import           Ouroboros.Consensus.Protocol.PBFT as X
 import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Consensus.HardFork.Combinator
 
@@ -189,7 +189,7 @@ verifyProtocol ProtocolCardano{}        = Refl
 -------------------------------------------------------------------------------}
 
 -- | Data required to run the selected protocol
-protocolInfo :: forall m blk p. MonadRandom m
+protocolInfo :: forall m blk p. IOLike m
              => Protocol m blk p -> ProtocolInfo m blk
 protocolInfo (ProtocolMockBFT nodes nid k paramsEra) =
     protocolInfoBft nodes nid k paramsEra

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -296,9 +296,9 @@ instance TPraosCrypto sc => HasPartialLedgerConfig (ShelleyBlock sc) where
 
 instance TPraosCrypto c => CanHardFork (CardanoEras c) where
   hardForkEraTranslation = EraTranslation {
-      translateLedgerState    = PCons translateLedgerStateByronToShelleyWrapper    PNil
-    , translateLedgerView     = PCons translateLedgerViewByronToShelleyWrapper     PNil
-    , translateConsensusState = PCons translateConsensusStateByronToShelleyWrapper PNil
+      translateLedgerState   = PCons translateLedgerStateByronToShelleyWrapper   PNil
+    , translateLedgerView    = PCons translateLedgerViewByronToShelleyWrapper    PNil
+    , translateChainDepState = PCons translateChainDepStateByronToShelleyWrapper PNil
     }
 
 {-------------------------------------------------------------------------------
@@ -452,22 +452,22 @@ translateLedgerStateByronToShelley cfgShelley epochNo ledgerByron =
           (Map.keysSet (sgGenDelegs genesisShelley))
           (sgProtocolParams genesisShelley)
 
-translateConsensusStateByronToShelleyWrapper
+translateChainDepStateByronToShelleyWrapper
   :: forall sc.
      RequiringBoth
        WrapConsensusConfig
-       (Translate WrapConsensusState)
+       (Translate WrapChainDepState)
        ByronBlock
        (ShelleyBlock sc)
-translateConsensusStateByronToShelleyWrapper =
-    RequireBoth $ \_ _ -> Translate   $ \_ (WrapConsensusState pbftState) ->
-      WrapConsensusState (translateConsensusStateByronToShelley pbftState)
+translateChainDepStateByronToShelleyWrapper =
+    RequireBoth $ \_ _ -> Translate   $ \_ (WrapChainDepState pbftState) ->
+      WrapChainDepState (translateChainDepStateByronToShelley pbftState)
 
-translateConsensusStateByronToShelley
+translateChainDepStateByronToShelley
   :: forall bc sc.
      PBftState bc
   -> TPraosState sc
-translateConsensusStateByronToShelley pbftState =
+translateChainDepStateByronToShelley pbftState =
     TPraosState.empty (PBftState.tipSlot pbftState) $
       SL.PrtclState
         Map.empty

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Generators.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Generators.hs
@@ -109,13 +109,13 @@ instance (sc ~ TPraosMockCrypto h, HashAlgorithm h, forall a. Arbitrary (Hash h 
   arbitrary = arbitraryHardForkState (Proxy @LedgerState)
 
 instance (sc ~ TPraosMockCrypto h, HashAlgorithm h)
-      => Arbitrary (HardForkConsensusState (CardanoEras sc)) where
-  arbitrary = arbitraryHardForkState (Proxy @WrapConsensusState)
+      => Arbitrary (HardForkChainDepState (CardanoEras sc)) where
+  arbitrary = arbitraryHardForkState (Proxy @WrapChainDepState)
 
 -- | Forwarding
-instance Arbitrary (ConsensusState (BlockProtocol blk))
-      => Arbitrary (WrapConsensusState blk) where
-  arbitrary = WrapConsensusState <$> arbitrary
+instance Arbitrary (ChainDepState (BlockProtocol blk))
+      => Arbitrary (WrapChainDepState blk) where
+  arbitrary = WrapChainDepState <$> arbitrary
 
 -- | NOTE: Byron hashes are always 32 bytes, but for Shelley it depends on the
 -- crypto: with 'TPraosStandardCrypto' the hash is also 32 bytes, but with

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -316,7 +316,7 @@ mkProtocolCardanoAndHardForkTxs
               generatedSecretsByron
               propPV
 
-    pInfo :: ProtocolInfo (ChaChaT m) (CardanoBlock sc)
+    pInfo :: ProtocolInfo m (CardanoBlock sc)
     pInfo = protocolInfoCardano
         -- Byron
         genesisByron

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -15,7 +15,7 @@ module Test.Consensus.Shelley.Examples (
   , exampleGenTx
   , exampleGenTxId
   , exampleApplyTxErr
-  , exampleConsensusState
+  , exampleChainDepState
   , exampleLedgerState
   , exampleHeaderState
   , exampleExtLedgerState
@@ -131,8 +131,8 @@ exampleApplyTxErr =
     $ STS.UtxowFailure
     $ STS.InvalidWitnessesUTXOW [SL.VKey 1]
 
-exampleConsensusState :: ConsensusState (BlockProtocol (Block ShortHash))
-exampleConsensusState =
+exampleChainDepState :: ChainDepState (BlockProtocol (Block ShortHash))
+exampleChainDepState =
     TPraosState.append 2      (mkPrtclState 2) $
     TPraosState.empty  (At 1) (mkPrtclState 1)
   where

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -38,6 +38,7 @@ import           Cardano.Slotting.Slot (EpochSize (..))
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Node.ProtocolInfo
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Random
@@ -56,8 +57,7 @@ import qualified Shelley.Spec.Ledger.TxData as SL
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import           Ouroboros.Consensus.Shelley.Node
 import           Ouroboros.Consensus.Shelley.Protocol
-import           Ouroboros.Consensus.Shelley.Protocol.Crypto (DSIGN,
-                     HotKey (..))
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto (DSIGN)
 
 import           Test.Consensus.Shelley.MockCrypto (TPraosMockCrypto)
 import qualified Test.Shelley.Spec.Ledger.Generator.Core as Gen
@@ -150,7 +150,7 @@ genCoreNode startKESPeriod = do
 mkLeaderCredentials :: TPraosCrypto c => CoreNode c -> TPraosLeaderCredentials c
 mkLeaderCredentials CoreNode { cnDelegateKey, cnVRF, cnKES, cnOCert } =
     TPraosLeaderCredentials {
-        tpraosLeaderCredentialsSignKey    = HotKey 0 cnKES
+        tpraosLeaderCredentialsSignKey    = cnKES
       , tpraosLeaderCredentialsIsCoreNode = TPraosIsCoreNode {
           tpraosIsCoreNodeOpCert     = cnOCert
         , tpraosIsCoreNodeColdVerKey = SL.VKey $ deriveVerKeyDSIGN cnDelegateKey
@@ -287,7 +287,7 @@ mkGenesisConfig pVer k d slotLength maxKESEvolutions coreNodes =
     mkCredential = SL.KeyHashObj . SL.hashKey . SL.VKey . deriveVerKeyDSIGN
 
 mkProtocolRealTPraos
-  :: forall m c. (MonadRandom m, TPraosCrypto c)
+  :: forall m c. (IOLike m, TPraosCrypto c)
   => ShelleyGenesis c
   -> CoreNode c
   -> ProtocolInfo m (ShelleyBlock c)

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
@@ -40,7 +40,7 @@ import           Test.Consensus.Shelley.MockCrypto
 
 tests :: TestTree
 tests = testGroup "Golden tests"
-    [ testCase "ConsensusState" test_golden_ConsensusState
+    [ testCase "ChainDepState"  test_golden_ChainDepState
     , testCase "LedgerState"    test_golden_LedgerState
     , testCase "HeaderState"    test_golden_HeaderState
     , testCase "ExtLedgerState" test_golden_ExtLedgerState
@@ -206,10 +206,10 @@ testResults = testGroup "Results"
     goldenTestResult :: Query (Block ShortHash) result -> result -> FlatTerm -> Assertion
     goldenTestResult q = goldenTestCBOR (encodeShelleyResult q)
 
-test_golden_ConsensusState :: Assertion
-test_golden_ConsensusState = goldenTestCBOR
+test_golden_ChainDepState :: Assertion
+test_golden_ChainDepState = goldenTestCBOR
     toCBOR
-    exampleConsensusState
+    exampleChainDepState
     [ TkListLen 2
     , TkInt 0
     , TkListLen 2

--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -41,6 +41,7 @@ library
                        Ouroboros.Consensus.Shelley.Protocol
                        Ouroboros.Consensus.Shelley.Protocol.State
                        Ouroboros.Consensus.Shelley.Protocol.Crypto
+                       Ouroboros.Consensus.Shelley.Protocol.Crypto.HotKey
                        Ouroboros.Consensus.Shelley.Protocol.Util
 
   build-depends:       base              >=4.9   && <4.13

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns             #-}
 {-# LANGUAGE DeriveGeneric            #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE LambdaCase               #-}
@@ -14,23 +13,12 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Shelley.Ledger.Forge (
-    -- * ForgeState
-    TPraosForgeState (..)
-    -- * Forging
-  , forgeShelleyBlock
-    -- * Updating the state
-  , evolveKESKeyIfNecessary
+    forgeShelleyBlock
   ) where
 
 import           Control.Exception
-import           Crypto.Random (MonadRandom)
-import           Data.Proxy (Proxy (..))
 import qualified Data.Sequence.Strict as Seq
-import           Data.Typeable (typeRep)
-import           GHC.Generics (Generic)
 
-import qualified Cardano.Crypto.KES.Class as KES
-import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Cardano.Slotting.Block
 
 import           Ouroboros.Network.Block (castHash)
@@ -41,98 +29,43 @@ import           Ouroboros.Consensus.Ledger.Abstract
 
 import qualified Shelley.Spec.Ledger.BlockChain as SL
 import qualified Shelley.Spec.Ledger.Keys as SL
-import qualified Shelley.Spec.Ledger.OCert as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.Config
 import           Ouroboros.Consensus.Shelley.Ledger.Integrity
 import           Ouroboros.Consensus.Shelley.Ledger.Mempool
 import           Ouroboros.Consensus.Shelley.Protocol
-import           Ouroboros.Consensus.Shelley.Protocol.Crypto
 
 {-------------------------------------------------------------------------------
   CanForge
 -------------------------------------------------------------------------------}
 
 instance TPraosCrypto c => CanForge (ShelleyBlock c) where
-  type ForgeState (ShelleyBlock c) = TPraosForgeState c
   forgeBlock = forgeShelleyBlock
-
-{-------------------------------------------------------------------------------
-  ForgeState
--------------------------------------------------------------------------------}
-
--- | This is the state containing the private key corresponding to the public
--- key that Praos uses to verify headers. That is why we call it
--- 'TPraosForgeState' instead of 'ShelleyForgeState'.
-data TPraosForgeState c = TPraosForgeState {
-      -- | The online KES key used to sign blocks
-      tpraosHotKey :: !(HotKey c)
-    }
-  deriving (Generic)
-
-deriving instance TPraosCrypto c => Show (TPraosForgeState c)
-
--- We override 'showTypeOf' to make sure to show @c@
-instance TPraosCrypto c => NoUnexpectedThunks (TPraosForgeState c) where
-  showTypeOf _ = show $ typeRep (Proxy @(TPraosForgeState c))
-
--- | Get the KES key from the node state, evolve if its KES period doesn't
--- match the given one.
-evolveKESKeyIfNecessary
-  :: forall m c. (MonadRandom m, TPraosCrypto c)
-  => Update m (TPraosForgeState c)
-  -> SL.KESPeriod -- ^ Relative KES period (to the start period of the OCert)
-  -> m ()
-evolveKESKeyIfNecessary updateForgeState (SL.KESPeriod kesPeriod) = do
-    runUpdate_ updateForgeState $ \(TPraosForgeState hk@(HotKey kesPeriodOfKey _)) ->
-      if kesPeriodOfKey >= kesPeriod then
-        -- No need to evolve
-        return $ TPraosForgeState hk
-      else do
-        let hk' = evolveKey hk
-        -- Any stateful code (for instance, running finalizers to clear the
-        -- memory associated with the old key) would happen here
-        return $ TPraosForgeState hk'
-  where
-    -- | Evolve the given key so that its KES period matches @kesPeriod@.
-    evolveKey :: HotKey c -> HotKey c
-    evolveKey (HotKey oldPeriod outdatedKey) = go outdatedKey oldPeriod kesPeriod
-      where
-        go !sk c t
-          | t < c
-          = error "Asked to evolve KES key to old period"
-          | c == t
-          = HotKey kesPeriod sk
-          | otherwise
-          = case KES.updateKES () sk c of
-              Nothing  -> error "Could not update KES key"
-              Just sk' -> go sk' (c + 1) t
 
 {-------------------------------------------------------------------------------
   Forging
 -------------------------------------------------------------------------------}
 
 forgeShelleyBlock
-  :: (MonadRandom m, TPraosCrypto c)
+  :: TPraosCrypto c
   => TopLevelConfig (ShelleyBlock c)
   -> ForgeState (ShelleyBlock c)
   -> BlockNo                             -- ^ Current block number
   -> TickedLedgerState (ShelleyBlock c)  -- ^ Current ledger
   -> [GenTx (ShelleyBlock c)]            -- ^ Txs to add in the block
   -> TPraosProof c                       -- ^ Leader proof ('IsLeader')
-  -> m (ShelleyBlock c)
-forgeShelleyBlock cfg forgeState curNo tickedLedger txs isLeader = do
-    return $ assert (verifyBlockIntegrity tpraosSlotsPerKESPeriod blk) blk
-
+  -> ShelleyBlock c
+forgeShelleyBlock cfg forgeState curNo tickedLedger txs isLeader =
+    assert (verifyBlockIntegrity tpraosSlotsPerKESPeriod blk) blk
   where
     TPraosConfig { tpraosParams = TPraosParams { tpraosSlotsPerKESPeriod } } =
       configConsensus cfg
 
     curSlot      = tickedSlotNo tickedLedger
-    tpraosFields = forgeTPraosFields hotKESKey isLeader mkBhBody
+    hotKey       = chainIndepState forgeState
+    tpraosFields = forgeTPraosFields hotKey isLeader mkBhBody
     blk          = mkShelleyBlock $ SL.Block (mkHeader tpraosFields) body
-    hotKESKey    = tpraosHotKey forgeState
     body         = SL.TxSeq $ Seq.fromList $ (\(ShelleyTx _ tx) -> tx) <$> txs
 
     mkHeader TPraosFields { tpraosSignature, tpraosToSign } =

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -191,7 +191,7 @@ instance TPraosCrypto c
   -- + 'applyChainTick': executes the @TICK@ transition
   -- + 'validateHeader':
   --    - 'validateEnvelope': executes the @chainChecks@
-  --    - 'updateConsensusState': executes the @PRTCL@ transition
+  --    - 'updateChainDepState': executes the @PRTCL@ transition
   -- + 'applyLedgerBlock': executes the @BBODY@ transition
   --
   applyLedgerBlock cfg

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
@@ -48,10 +48,10 @@ instance Crypto c => EncodeDisk (ShelleyBlock c) (LedgerState (ShelleyBlock c)) 
 instance Crypto c => DecodeDisk (ShelleyBlock c) (LedgerState (ShelleyBlock c)) where
   decodeDisk _ = decodeShelleyLedgerState
 
--- | @'ConsensusState' ('BlockProtocol' ('ShelleyBlock' c))@
+-- | @'ChainDepState' ('BlockProtocol' ('ShelleyBlock' c))@
 instance Crypto c => EncodeDisk (ShelleyBlock c) (TPraosState c) where
   encodeDisk _ = toCBOR
--- | @'ConsensusState' ('BlockProtocol' ('ShelleyBlock' c))@
+-- | @'ChainDepState' ('BlockProtocol' ('ShelleyBlock' c))@
 instance Crypto c => DecodeDisk (ShelleyBlock c) (TPraosState c) where
   decodeDisk _ = fromCBOR
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
@@ -1,20 +1,15 @@
 {-# LANGUAGE DataKinds               #-}
-{-# LANGUAGE DeriveGeneric           #-}
 {-# LANGUAGE FlexibleContexts        #-}
-{-# LANGUAGE FlexibleInstances       #-}
-{-# LANGUAGE StandaloneDeriving      #-}
 {-# LANGUAGE TypeFamilies            #-}
 {-# LANGUAGE UndecidableInstances    #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 module Ouroboros.Consensus.Shelley.Protocol.Crypto (
     module Shelley.Spec.Ledger.Crypto
-  , HotKey(..)
   , TPraosCrypto
   , TPraosStandardCrypto
   ) where
 
 import           Data.Typeable (Typeable)
-import           GHC.Generics (Generic)
 import           Numeric.Natural
 
 import           Cardano.Binary (ToCBOR)
@@ -22,12 +17,10 @@ import qualified Cardano.Crypto.DSIGN.Class as DSIGN
 import           Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
 import           Cardano.Crypto.Hash.Blake2b (Blake2b_224, Blake2b_256)
 import           Cardano.Crypto.Hash.Class (Hash)
-import           Cardano.Crypto.KES.Class
 import qualified Cardano.Crypto.KES.Class as KES
 import           Cardano.Crypto.KES.Sum
 import qualified Cardano.Crypto.VRF.Class as VRF
 import           Cardano.Crypto.VRF.Simple (SimpleVRF)
-import           Cardano.Prelude (NoUnexpectedThunks (..))
 
 import           Ouroboros.Consensus.Util.Condense (Condense)
 
@@ -63,13 +56,3 @@ instance Crypto TPraosStandardCrypto where
   type ADDRHASH TPraosStandardCrypto = Blake2b_224
 
 instance TPraosCrypto TPraosStandardCrypto
-
--- | A hot KES key. We store alongside the key the KES period for which it is
--- valid.
-data HotKey c = HotKey !Period !(SignKeyKES (KES c))
-  deriving Generic
-
-instance Show (HotKey c) where
-  show _ = "<HotKey>"
-
-instance TPraosCrypto c => NoUnexpectedThunks (HotKey c)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto/HotKey.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto/HotKey.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | Hot key
+--
+-- Intended for qualified import
+module Ouroboros.Consensus.Shelley.Protocol.Crypto.HotKey (
+    KESEvolution
+  , HotKey (..)
+  , toPeriod
+  , evolve
+  ) where
+
+import           GHC.Generics (Generic)
+
+import           Cardano.Crypto.KES.Class
+import qualified Cardano.Crypto.KES.Class as Relative (Period)
+import           Cardano.Prelude (NoUnexpectedThunks (..))
+
+import           Shelley.Spec.Ledger.Crypto (Crypto (..))
+import qualified Shelley.Spec.Ledger.OCert as Absolute (KESPeriod (..))
+
+import           Ouroboros.Consensus.Util.IOLike
+
+
+-- | We call the relative periods that a KES key is valid its evolution, to
+-- avoid confusion with absolute periods.
+type KESEvolution = Relative.Period
+
+-- | A hot KES key
+data HotKey c = HotKey {
+      hkStart     :: !Absolute.KESPeriod
+   ,  hkEnd       :: !Absolute.KESPeriod
+      -- ^ Currently derived from `TPraosParams`:
+      -- > hkEnd = hkStart + tpraosMaxKESEvo
+    , hkEvolution :: !KESEvolution
+      -- ^ Invariant:
+      -- > hkStart + hkEvolution in [hkStart, hkEnd]
+    , hkKey       :: !(SignKeyKES (KES c))
+    }
+  deriving (Generic)
+
+instance Show (HotKey c) where
+  show HotKey { hkStart, hkEnd, hkEvolution } = mconcat [
+        "<HotKey: start = "
+      , show hkStart
+      , ", end = "
+      , show hkEnd
+      , ", evolution = "
+      , show hkEvolution
+      , ">"
+      ]
+
+instance Crypto c => NoUnexpectedThunks (HotKey c)
+
+-- | Return the evolution of the given KES period, /when/ it falls within the
+-- range of the 'HotKey' (@[hkStart, hkEnd]@).
+toEvolution :: HotKey c -> Absolute.KESPeriod -> Maybe KESEvolution
+toEvolution HotKey { hkStart = Absolute.KESPeriod lo
+                   , hkEnd   = Absolute.KESPeriod hi
+                   }
+            (Absolute.KESPeriod cur)
+    | lo <= cur, cur <= hi = Just (cur - lo)
+    | otherwise            = Nothing
+
+-- | Return the current period of the 'HotKey'.
+toPeriod :: HotKey c -> Absolute.KESPeriod
+toPeriod HotKey { hkStart = Absolute.KESPeriod lo, hkEvolution } =
+    Absolute.KESPeriod (lo + hkEvolution)
+
+-- | Evolve the 'HotKey' so that its evolution matches the given KES period.
+--
+-- When the 'HotKey' has already evolved further than the given KES period, we
+-- return 'Nothing'.
+--
+-- When the given KES period is outside the bounds of the 'HotKey', we return
+-- 'Nothing'.
+evolve ::
+     forall c m. (IOLike m, Crypto c)
+  => Absolute.KESPeriod
+  -> HotKey c
+  -> m (Maybe (HotKey c))
+evolve targetPeriod hk = do
+    let mNewHotKey = do
+           targetEvolution <- toEvolution hk targetPeriod
+           key' <- go targetEvolution (hkEvolution hk) (hkKey hk)
+           return HotKey {
+               hkStart     = hkStart hk
+             , hkEnd       = hkEnd   hk
+             , hkEvolution = targetEvolution
+             , hkKey       = key'
+             }
+    -- Any stateful code (for instance, running finalizers to clear the
+    -- memory associated with the old key) would happen here or in (a
+    -- monadic) 'go'.
+    return mNewHotKey
+  where
+    go :: KESEvolution
+       -> KESEvolution
+       -> SignKeyKES (KES c)
+       -> Maybe (SignKeyKES (KES c))
+    go targetEvolution curEvolution key
+      | targetEvolution == curEvolution
+      = Just key
+      | targetEvolution < curEvolution
+      = Nothing
+      | otherwise
+      = case updateKES () key curEvolution of
+          -- This cannot happen
+          Nothing   -> error "Could not update KES key"
+          Just key' -> go targetEvolution (curEvolution + 1) key'

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -136,9 +136,8 @@ instance ( SimpleCrypto c
          , Signable (BftDSIGN c') (SignedSimpleBft c c')
          )
      => CanForge (SimpleBftBlock c c') where
-  type ForgeState (SimpleBftBlock c c') = ()
   forgeBlock = forgeSimple $ ForgeExt $ \cfg _update _isLeader ->
-      return . forgeBftExt cfg
+      forgeBftExt cfg
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -153,9 +153,8 @@ instance ( SimpleCrypto c
          , ContextDSIGN (PBftDSIGN c') ~ ()
          )
      => CanForge (SimplePBftBlock c c') where
-  type ForgeState (SimplePBftBlock c c') = ()
   forgeBlock = forgeSimple $ ForgeExt $ \_cfg _update isLeader ->
-      return . forgePBftExt isLeader
+      forgePBftExt isLeader
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -128,9 +128,8 @@ forgePraosRuleExt cfg SimpleBlock{..} =
     SimpleHeader{..} = simpleHeader
 
 instance SimpleCrypto c => CanForge (SimplePraosRuleBlock c) where
-  type ForgeState (SimplePraosRuleBlock c) = ()
   forgeBlock = forgeSimple $ ForgeExt $ \cfg _update _isLeader ->
-      return . forgePraosRuleExt cfg
+      forgePraosRuleExt cfg
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 
@@ -12,7 +11,6 @@ module Ouroboros.Consensus.Mock.Ledger.Forge (
   ) where
 
 import           Codec.Serialise (Serialise (..), serialise)
-import           Crypto.Random (MonadRandom)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Word
 
@@ -31,17 +29,15 @@ import           Ouroboros.Consensus.Protocol.Abstract
 -- This is used in 'forgeSimple', which takes care of the generic part of the
 -- mock block.
 data ForgeExt c ext = ForgeExt {
-      forgeExt :: forall m. MonadRandom m
-               => TopLevelConfig          (SimpleBlock c ext)
+      forgeExt :: TopLevelConfig          (SimpleBlock c ext)
                -> ForgeState              (SimpleBlock c ext)
                -> IsLeader (BlockProtocol (SimpleBlock c ext))
                -> SimpleBlock' c ext ()
-               -> m (SimpleBlock c ext)
+               -> SimpleBlock c ext
     }
 
-forgeSimple :: forall c m ext.
-               ( MonadRandom m
-               , SimpleCrypto c
+forgeSimple :: forall c ext.
+               ( SimpleCrypto c
                , MockProtocolSpecific c ext
                )
             => ForgeExt c ext
@@ -51,8 +47,8 @@ forgeSimple :: forall c m ext.
             -> TickedLedgerState (SimpleBlock c ext) -- ^ Current ledger
             -> [GenTx (SimpleBlock c ext)]           -- ^ Txs to include
             -> IsLeader (BlockProtocol (SimpleBlock c ext))
-            -> m (SimpleBlock c ext)
-forgeSimple ForgeExt { forgeExt } cfg forgeState curBlock tickedLedger txs proof = do
+            -> SimpleBlock c ext
+forgeSimple ForgeExt { forgeExt } cfg forgeState curBlock tickedLedger txs proof =
     forgeExt cfg forgeState proof $ SimpleBlock {
         simpleHeader = mkSimpleHeader encode stdHeader ()
       , simpleBody   = body

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
@@ -28,8 +28,8 @@ import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
 
 -- | Protocol specific functionality required to run consensus with mock blocks
 class ( MockProtocolSpecific c ext
-      , EncodeDisk (SimpleBlock c ext) (ConsensusState (BlockProtocol (SimpleBlock c ext)))
-      , DecodeDisk (SimpleBlock c ext) (ConsensusState (BlockProtocol (SimpleBlock c ext)))
+      , EncodeDisk (SimpleBlock c ext) (ChainDepState (BlockProtocol (SimpleBlock c ext)))
+      , DecodeDisk (SimpleBlock c ext) (ChainDepState (BlockProtocol (SimpleBlock c ext)))
       ) => RunMockBlock c ext where
   mockProtocolMagicId
     :: BlockConfig (SimpleBlock c ext)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -40,6 +40,7 @@ protocolInfoBft numCoreNodes nid securityParam eraParams =
                   | n <- enumCoreNodes numCoreNodes
                   ]
               }
+          , configIndep  = ()
           , configLedger = SimpleLedgerConfig () eraParams
           , configBlock  = SimpleBlockConfig securityParam
           }

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -34,6 +34,7 @@ protocolInfoMockPBFT params eraParams nid =
             configConsensus = PBftConfig {
                 pbftParams = params
               }
+          , configIndep  = ()
           , configLedger = SimpleLedgerConfig ledgerView eraParams
           , configBlock  = SimpleBlockConfig  (pbftSecurityParam params)
           }

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -20,10 +20,11 @@ import           Ouroboros.Consensus.Mock.Protocol.Praos
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.LeaderSchedule
+import           Ouroboros.Consensus.Util.IOLike
 
 type MockPraosRuleBlock = SimplePraosRuleBlock SimpleMockCrypto
 
-protocolInfoPraosRule :: Monad m
+protocolInfoPraosRule :: IOLike m
                       => NumCoreNodes
                       -> CoreNodeId
                       -> PraosParams
@@ -48,6 +49,7 @@ protocolInfoPraosRule numCoreNodes
                 }
             , wlsConfigNodeId   = nid
             }
+        , configIndep  = ()
         , configLedger = SimpleLedgerConfig () eraParams
         , configBlock  = SimpleBlockConfig (praosSecurityParam params)
         }

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Rekeying.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Rekeying.hs
@@ -15,7 +15,6 @@ import           Ouroboros.Consensus.Util.IOLike
 
 import           Test.ThreadNet.Network
 
-import           Test.Util.Random
 import           Test.Util.Stream
 
 -- | Functionality used by test node in order to update its operational key
@@ -32,7 +31,7 @@ data Rekeying m blk = forall opKey. Rekeying
     -- IE the first slot that will result in a block successfully being forged
     -- and diffused (eg no @PBftExceededSignThreshold@).
   , rekeyUpd ::
-         ProtocolInfo (ChaChaT m) blk
+         ProtocolInfo m blk
       -> EpochNo
       -> opKey
       -> Maybe (TestNodeInitialization m blk)

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Serialisation.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Serialisation.hs
@@ -43,7 +43,7 @@ import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.Run (SerialiseNodeToClientConstraints,
                      SerialiseNodeToNodeConstraints)
 import           Ouroboros.Consensus.Node.Serialisation
-import           Ouroboros.Consensus.Protocol.Abstract (ConsensusState)
+import           Ouroboros.Consensus.Protocol.Abstract (ChainDepState)
 import           Ouroboros.Consensus.Storage.ChainDB (SerialiseDiskConstraints)
 import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
 import           Ouroboros.Consensus.Util (Dict (..))
@@ -77,7 +77,7 @@ roundtrip_all
      , Arbitrary' (HeaderHash blk)
      , Arbitrary' (LedgerState blk)
      , Arbitrary' (AnnTip blk)
-     , Arbitrary' (ConsensusState (BlockProtocol blk))
+     , Arbitrary' (ChainDepState (BlockProtocol blk))
 
      , ArbitraryWithVersion (BlockNodeToNodeVersion blk) blk
      , ArbitraryWithVersion (BlockNodeToNodeVersion blk) (Header blk)
@@ -113,7 +113,7 @@ roundtrip_SerialiseDisk
      , Arbitrary' (Header blk)
      , Arbitrary' (LedgerState blk)
      , Arbitrary' (AnnTip blk)
-     , Arbitrary' (ConsensusState (BlockProtocol blk))
+     , Arbitrary' (ChainDepState (BlockProtocol blk))
      )
   => CodecConfig blk
   -> (forall a. NestedCtxt_ blk Header a -> Dict (Eq a, Show a))
@@ -134,7 +134,7 @@ roundtrip_SerialiseDisk ccfg dictNestedHdr =
     , adjustOption (\(QuickCheckTests n) -> QuickCheckTests (1 `max` (div n 10))) $
       rt (Proxy @(LedgerState blk)) "LedgerState"
     , rt (Proxy @(AnnTip blk)) "AnnTip"
-    , rt (Proxy @(ConsensusState (BlockProtocol blk))) "ConsensusState"
+    , rt (Proxy @(ChainDepState (BlockProtocol blk))) "ChainDepState"
     ]
   where
     rt :: forall a. (Arbitrary' a, EncodeDisk blk a, DecodeDisk blk a)

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -369,6 +369,7 @@ singleNodeTestConfig = TopLevelConfig {
         , bftSignKey = SignKeyMockDSIGN 0
         , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
         }
+    , configIndep  = ()
     , configLedger = eraParams
     , configBlock  = TestBlockConfig numCoreNodes
     }

--- a/ouroboros-consensus/src/Data/SOP/Strict.hs
+++ b/ouroboros-consensus/src/Data/SOP/Strict.hs
@@ -89,6 +89,15 @@ collapse_NP = go
     go Nil         = []
     go (K x :* xs) = x : go xs
 
+ctraverse'_NP  ::
+     forall c proxy xs f f' g. (All c xs,  Applicative g)
+  => proxy c -> (forall a. c a => f a -> g (f' a)) -> NP f xs  -> g (NP f' xs)
+ctraverse'_NP _ f = go
+  where
+    go :: All c ys => NP f ys -> g (NP f' ys)
+    go Nil       = pure Nil
+    go (x :* xs) = (:*) <$> f x <*> go xs
+
 ctraverse__NP ::
      forall c proxy xs f g. (All c xs, Applicative g)
   => proxy c -> (forall a. c a => f a -> g ()) -> NP f xs -> g ()
@@ -113,6 +122,11 @@ instance HAp NP where
 
 instance HCollapse NP where
   hcollapse = collapse_NP
+
+instance HSequence NP where
+  hctraverse' = ctraverse'_NP
+  htraverse'  = hctraverse' (Proxy @Top)
+  hsequence'  = htraverse' unComp
 
 instance HTraverse_ NP where
   hctraverse_ = ctraverse__NP

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
@@ -21,9 +21,10 @@ import           Ouroboros.Consensus.Protocol.Abstract
 
 -- | The top-level node configuration
 data TopLevelConfig blk = TopLevelConfig {
-      configConsensus :: !(ConsensusConfig (BlockProtocol blk))
-    , configLedger    :: !(LedgerConfig                   blk)
-    , configBlock     :: !(BlockConfig                    blk)
+      configConsensus :: !(ConsensusConfig       (BlockProtocol blk))
+    , configIndep     :: !(ChainIndepStateConfig (BlockProtocol blk))
+    , configLedger    :: !(LedgerConfig                         blk)
+    , configBlock     :: !(BlockConfig                          blk)
     }
   deriving (Generic)
 
@@ -36,14 +37,18 @@ configSecurityParam :: ConsensusProtocol (BlockProtocol blk)
                     => TopLevelConfig blk -> SecurityParam
 configSecurityParam = protocolSecurityParam . configConsensus
 
-castTopLevelConfig :: ( Coercible (ConsensusConfig (BlockProtocol blk))
-                                  (ConsensusConfig (BlockProtocol blk'))
-                      , LedgerConfig blk ~ LedgerConfig blk'
-                      , Coercible (BlockConfig blk) (BlockConfig blk')
-                      )
-                   => TopLevelConfig blk -> TopLevelConfig blk'
+castTopLevelConfig ::
+     ( Coercible (ConsensusConfig (BlockProtocol blk))
+                 (ConsensusConfig (BlockProtocol blk'))
+     ,   ChainIndepStateConfig (BlockProtocol blk)
+       ~ ChainIndepStateConfig (BlockProtocol blk')
+     , LedgerConfig blk ~ LedgerConfig blk'
+     , Coercible (BlockConfig blk) (BlockConfig blk')
+     )
+  => TopLevelConfig blk -> TopLevelConfig blk'
 castTopLevelConfig TopLevelConfig{..} = TopLevelConfig{
       configConsensus = coerce configConsensus
+    , configIndep     = configIndep
     , configLedger    = configLedger
     , configBlock     = coerce configBlock
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
@@ -52,8 +52,9 @@ import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras as X
 
 -- Re-export types required to initialize 'ProtocolInfo'
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras as X
-                     (PerEraBlockConfig (..), PerEraConsensusConfig (..),
-                     PerEraForgeState (..))
+                     (PerEraBlockConfig (..), PerEraChainIndepState (..),
+                     PerEraChainIndepStateConfig (..),
+                     PerEraConsensusConfig (..), PerEraExtraForgeState (..))
 
 -- Defines the various translation types required for concrete HFC instances
 import           Ouroboros.Consensus.HardFork.Combinator.Translation as X
@@ -86,9 +87,9 @@ import           Ouroboros.Consensus.HardFork.Combinator.State as X
 -- * "Ouroboros.Consensus.HardFork.Combinator.State"
 --   This defines 'HardForkState', a wrapper around a 'Telescope'. We use this
 --   to define 'HardForkLedgerState', 'HardForkLedgerView' as well as
---   'HardForkConsensusState', but the type itself should mostly be internal
---   to the hard fork combinator. We do export the constructor for it, as this
---   may be required for serialisation code.
+--   'HardForkChainDepState', but the type itself should mostly be internal to
+--   the hard fork combinator. We do export the constructor for it, as this may
+--   be required for serialisation code.
 --
 -- * "module Ouroboros.Consensus.HardFork.Combinator.State.Infra"
 --   This module is only separate from @.State@ to avoid some cyclic module

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
@@ -123,20 +123,20 @@ instance SerialiseHFC xs
       cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
 
 instance SerialiseHFC xs
-      => EncodeDisk (HardForkBlock xs) (HardForkConsensusState xs) where
+      => EncodeDisk (HardForkBlock xs) (HardForkChainDepState xs) where
   encodeDisk cfg =
       encodeTelescope (hcmap pSHFC (fn . aux) cfgs)
     where
       cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
 
       aux :: SerialiseDiskConstraints blk
-          => CodecConfig blk -> WrapConsensusState blk -> K Encoding blk
-      aux cfg' (WrapConsensusState st) = K $ encodeDisk cfg' st
+          => CodecConfig blk -> WrapChainDepState blk -> K Encoding blk
+      aux cfg' (WrapChainDepState st) = K $ encodeDisk cfg' st
 
 instance SerialiseHFC xs
-      => DecodeDisk (HardForkBlock xs) (HardForkConsensusState xs) where
+      => DecodeDisk (HardForkBlock xs) (HardForkChainDepState xs) where
   decodeDisk cfg =
-      decodeTelescope (hcmap pSHFC (Comp . fmap WrapConsensusState . decodeDisk) cfgs)
+      decodeTelescope (hcmap pSHFC (Comp . fmap WrapChainDepState . decodeDisk) cfgs)
     where
       cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
@@ -21,16 +21,16 @@ import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
 -------------------------------------------------------------------------------}
 
 data EraTranslation xs = EraTranslation {
-      translateLedgerState    :: InPairs (RequiringBoth WrapLedgerConfig    (Translate LedgerState))        xs
-    , translateLedgerView     :: InPairs (RequiringBoth WrapLedgerConfig    (Translate WrapLedgerView))     xs
-    , translateConsensusState :: InPairs (RequiringBoth WrapConsensusConfig (Translate WrapConsensusState)) xs
+      translateLedgerState   :: InPairs (RequiringBoth WrapLedgerConfig    (Translate LedgerState))       xs
+    , translateLedgerView    :: InPairs (RequiringBoth WrapLedgerConfig    (Translate WrapLedgerView))    xs
+    , translateChainDepState :: InPairs (RequiringBoth WrapConsensusConfig (Translate WrapChainDepState)) xs
     }
   deriving NoUnexpectedThunks
        via OnlyCheckIsWHNF "EraTranslation" (EraTranslation xs)
 
 trivialEraTranslation :: EraTranslation '[blk]
 trivialEraTranslation = EraTranslation {
-      translateLedgerState    = PNil
-    , translateLedgerView     = PNil
-    , translateConsensusState = PNil
+      translateLedgerState   = PNil
+    , translateLedgerView    = PNil
+    , translateChainDepState = PNil
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Telescope.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Telescope.hs
@@ -338,7 +338,7 @@ newtype Retract m g f x y = Retract { retractWith :: g x -> f y -> m (f x) }
 -- state. When we rewind the consensus state, we might cross a hard fork
 -- transition point. So we first /retract/ the telescope /to/ the era containing
 -- the slot number that we want to rewind to, and only then call
--- 'rewindConsensusState' on that era. Of course, retraction may fail (we
+-- 'rewindChainDepState' on that era. Of course, retraction may fail (we
 -- might not /have/ past consensus state to rewind to anymore); this failure
 -- would require a choice for a particular monad @m@.
 retract :: forall m h g f xs. Monad m

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -160,6 +160,7 @@ data instance BlockConfig (DualBlock m a) = DualBlockConfig {
 dualTopLevelConfigMain :: TopLevelConfig (DualBlock m a) -> TopLevelConfig m
 dualTopLevelConfigMain TopLevelConfig{..} = TopLevelConfig{
       configConsensus =                      configConsensus
+    , configIndep     =                      configIndep
     , configLedger    = dualLedgerConfigMain configLedger
     , configBlock     = dualBlockConfigMain  configBlock
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -74,7 +74,7 @@ instance LedgerSupportsProtocol blk => NoUnexpectedThunks (ExtLedgerState blk) w
   showTypeOf _ = show $ typeRep (Proxy @(ExtLedgerState blk))
 
 deriving instance ( LedgerSupportsProtocol blk
-                  , Eq (ConsensusState (BlockProtocol blk))
+                  , Eq (ChainDepState (BlockProtocol blk))
                   ) => Eq (ExtLedgerState blk)
 
 -- | Lemma:
@@ -182,11 +182,11 @@ instance ( LedgerSupportsProtocol blk
 -------------------------------------------------------------------------------}
 
 encodeExtLedgerState :: (LedgerState   blk -> Encoding)
-                     -> (ConsensusState (BlockProtocol blk) -> Encoding)
+                     -> (ChainDepState (BlockProtocol blk) -> Encoding)
                      -> (AnnTip        blk -> Encoding)
                      -> ExtLedgerState blk -> Encoding
 encodeExtLedgerState encodeLedgerState
-                     encodeConsensusState
+                     encodeChainDepState
                      encodeAnnTip
                      ExtLedgerState{..} = mconcat [
       encodeLedgerState  ledgerState
@@ -194,22 +194,22 @@ encodeExtLedgerState encodeLedgerState
     ]
   where
     encodeHeaderState' = encodeHeaderState
-                           encodeConsensusState
+                           encodeChainDepState
                            encodeAnnTip
 
 decodeExtLedgerState :: (forall s. Decoder s (LedgerState    blk))
-                     -> (forall s. Decoder s (ConsensusState (BlockProtocol blk)))
+                     -> (forall s. Decoder s (ChainDepState  (BlockProtocol blk)))
                      -> (forall s. Decoder s (AnnTip         blk))
                      -> (forall s. Decoder s (ExtLedgerState blk))
 decodeExtLedgerState decodeLedgerState
-                     decodeConsensusState
+                     decodeChainDepState
                      decodeAnnTip = do
     ledgerState <- decodeLedgerState
     headerState <- decodeHeaderState'
     return ExtLedgerState{..}
   where
     decodeHeaderState' = decodeHeaderState
-                           decodeConsensusState
+                           decodeChainDepState
                            decodeAnnTip
 
 {-------------------------------------------------------------------------------
@@ -219,8 +219,8 @@ decodeExtLedgerState decodeLedgerState
 castExtLedgerState
   :: ( Coercible (LedgerState blk)
                  (LedgerState blk')
-     , Coercible (ConsensusState (BlockProtocol blk))
-                 (ConsensusState (BlockProtocol blk'))
+     , Coercible (ChainDepState (BlockProtocol blk))
+                 (ChainDepState (BlockProtocol blk'))
      , TipInfo blk ~ TipInfo blk'
      )
   => ExtLedgerState blk -> ExtLedgerState blk'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -153,10 +153,9 @@ bracketChainSyncClient tracer ChainDbView { getIsInvalidBlock } varCandidates
 -- selection.
 --
 -- We also validate the headers of a candidate chain by advancing the
--- 'ConsensusState' with the headers, which returns an error when validation
--- failed. Thus, in addition to the chain fragment of each candidate, we
--- also store a 'ConsensusState' corresponding to the head of the candidate
--- chain.
+-- 'ChainDepState' with the headers, which returns an error when validation
+-- failed. Thus, in addition to the chain fragment of each candidate, we also
+-- store a 'ChainDepState' corresponding to the head of the candidate chain.
 --
 -- We must keep the candidate chain synchronised with the corresponding
 -- upstream chain. The upstream node's chain might roll forward or

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -65,12 +65,12 @@ castProtocolInfo
                  (ConsensusConfig (BlockProtocol blk'))
      , Coercible (BlockConfig blk) (BlockConfig blk')
      , Coercible (LedgerState blk) (LedgerState blk')
-     , Coercible (ConsensusState (BlockProtocol blk))
-                 (ConsensusState (BlockProtocol blk'))
-     , CanBeLeader (BlockProtocol blk) ~ CanBeLeader (BlockProtocol blk')
+     , Coercible (ChainDepState (BlockProtocol blk))
+                 (ChainDepState (BlockProtocol blk'))
      , LedgerConfig blk ~ LedgerConfig blk'
      , TipInfo      blk ~ TipInfo      blk'
      , ForgeState   blk ~ ForgeState   blk'
+     , Functor m
      )
   => ProtocolInfo m blk
   -> ProtocolInfo m blk'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -115,8 +115,8 @@ showTracers :: ( Show blk
                , Show (GenTxId blk)
                , Show (ApplyTxErr blk)
                , Show (Header blk)
+               , Show (ExtraForgeState blk)
                , Show remotePeer
-               , Show (ForgeState blk)
                , LedgerSupportsProtocol blk
                )
             => Tracer m String -> Tracers m remotePeer localPeer blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -39,24 +39,35 @@ instance ChainSelection s => ChainSelection (ModChainSel p s) where
   preferCandidate   _ = preferCandidate   (Proxy @s)
   compareCandidates _ = compareCandidates (Proxy @s)
 
+instance HasChainIndepState p => HasChainIndepState (ModChainSel p s) where
+  type ChainIndepStateConfig (ModChainSel p s) = ChainIndepStateConfig p
+  type ChainIndepState       (ModChainSel p s) = ChainIndepState       p
+
+  updateChainIndepState _proxy = updateChainIndepState (Proxy @p)
+
 instance (Typeable p, Typeable s, ConsensusProtocol p, ChainSelection s)
       => ConsensusProtocol (ModChainSel p s) where
-    type ConsensusState (ModChainSel p s) = ConsensusState p
-    type IsLeader       (ModChainSel p s) = IsLeader       p
-    type CanBeLeader    (ModChainSel p s) = CanBeLeader    p
-    type CannotLead     (ModChainSel p s) = CannotLead     p
-    type LedgerView     (ModChainSel p s) = LedgerView     p
-    type ValidationErr  (ModChainSel p s) = ValidationErr  p
-    type ValidateView   (ModChainSel p s) = ValidateView   p
+    type ChainDepState (ModChainSel p s) = ChainDepState   p
+    type IsLeader      (ModChainSel p s) = IsLeader        p
+    type CanBeLeader   (ModChainSel p s) = CanBeLeader     p
+    type CannotLead    (ModChainSel p s) = CannotLead      p
+    type LedgerView    (ModChainSel p s) = LedgerView      p
+    type ValidationErr (ModChainSel p s) = ValidationErr   p
+    type ValidateView  (ModChainSel p s) = ValidateView    p
 
-    checkIsLeader cfg canBeLeader ledgerView consensusState =
+    checkIsLeader cfg canBeLeader ledgerView chainDepState chainIndepState =
       castLeaderCheck <$>
-        checkIsLeader (mcsConfigP cfg) canBeLeader ledgerView consensusState
+        checkIsLeader
+          (mcsConfigP cfg)
+          canBeLeader
+          ledgerView
+          chainDepState
+          chainIndepState
 
-    updateConsensusState  = updateConsensusState  . mcsConfigP
+    updateChainDepState   = updateChainDepState   . mcsConfigP
     protocolSecurityParam = protocolSecurityParam . mcsConfigP
 
-    rewindConsensusState _proxy = rewindConsensusState (Proxy @p)
+    rewindChainDepState _proxy = rewindChainDepState (Proxy @p)
 
     chainSelConfig = mcsConfigS
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
@@ -408,7 +408,7 @@ append k n signer@(PBftSigner _ gk) PBftState{..} =
 
 -- | Rewind the state to the specified slot
 --
--- This matches the semantics of 'rewindConsensusState' in 'OuroborosTag', in
+-- This matches the semantics of 'rewindchainDepState' in 'OuroborosTag', in
 -- that this should be the state after the given point.
 --
 -- NOTE: It only makes sense to rewind to a slot containing a block that we
@@ -677,10 +677,10 @@ data MaybeEbbInfo
 
 -- | Info about an EBB
 --
--- The serialised bytes of the EBB's header hash and its latest previous signed
--- slot. We use 'HeaderHashBytes' instead of the EBB's actual @HeaderHash@
--- because the 'ConsensusState' type family (which we instantiate as
--- 'PBftState') does not take a type argument that to which we can apply
+-- The serialised bytes of the EBB's header hash and its latest previous
+-- signed slot. We use 'HeaderHashBytes' instead of the EBB's actual
+-- @HeaderHash@ because the 'ChainDepState' type family (which we instantiate
+-- as 'PBftState') does not take a type argument that to which we can apply
 -- @HeaderHash@. This is a compromise.
 --
 -- INVARIANT @At 'eiSlot' > 'eiPrevSlot'@

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -144,8 +144,8 @@ class ( -- TODO remove/replace this one once we remove it from the
       , DecodeDisk blk (LedgerState blk)
       , EncodeDisk blk (AnnTip      blk)
       , DecodeDisk blk (AnnTip      blk)
-      , EncodeDisk blk (ConsensusState (BlockProtocol blk))
-      , DecodeDisk blk (ConsensusState (BlockProtocol blk))
+      , EncodeDisk blk (ChainDepState (BlockProtocol blk))
+      , DecodeDisk blk (ChainDepState (BlockProtocol blk))
       ) => LgrDbSerialiseConstraints blk
 
 -- | Shorter synonym for the instantiated 'LedgerDB.LedgerDB'.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Serialisation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Serialisation.hs
@@ -332,13 +332,13 @@ takePrefix (PrefixLen n) =
   Forwarding instances
 -------------------------------------------------------------------------------}
 
-instance EncodeDisk blk (ConsensusState (BlockProtocol blk))
-      => EncodeDisk blk (WrapConsensusState blk) where
-  encodeDisk cfg (WrapConsensusState st) = encodeDisk cfg st
+instance EncodeDisk blk (ChainDepState (BlockProtocol blk))
+      => EncodeDisk blk (WrapChainDepState blk) where
+  encodeDisk cfg (WrapChainDepState st) = encodeDisk cfg st
 
-instance DecodeDisk blk (ConsensusState (BlockProtocol blk))
-      => DecodeDisk blk (WrapConsensusState blk) where
-  decodeDisk cfg = WrapConsensusState <$> decodeDisk cfg
+instance DecodeDisk blk (ChainDepState (BlockProtocol blk))
+      => DecodeDisk blk (WrapChainDepState blk) where
+  decodeDisk cfg = WrapChainDepState <$> decodeDisk cfg
 
 instance EncodeDisk blk blk
       => EncodeDisk blk (I blk) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/TypeFamilyWrappers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/TypeFamilyWrappers.hs
@@ -8,7 +8,7 @@ module Ouroboros.Consensus.TypeFamilyWrappers (
     -- * Block based
     WrapApplyTxErr(..)
   , WrapEnvelopeErr(..)
-  , WrapForgeState(..)
+  , WrapExtraForgeState(..)
   , WrapGenTxId(..)
   , WrapHeaderHash(..)
   , WrapLedgerConfig(..)
@@ -19,7 +19,9 @@ module Ouroboros.Consensus.TypeFamilyWrappers (
   , WrapCannotLead(..)
   , WrapChainSelConfig(..)
   , WrapConsensusConfig(..)
-  , WrapConsensusState(..)
+  , WrapChainDepState(..)
+  , WrapChainIndepState(..)
+  , WrapChainIndepStateConfig(..)
   , WrapIsLeader(..)
   , WrapLeaderCheck(..)
   , WrapLedgerView(..)
@@ -43,35 +45,38 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Util (Trivial (..))
 
 {-------------------------------------------------------------------------------
   Block based
 -------------------------------------------------------------------------------}
 
-newtype WrapApplyTxErr   blk = WrapApplyTxErr   { unwrapApplyTxErr   :: ApplyTxErr               blk }
-newtype WrapEnvelopeErr  blk = WrapEnvelopeErr  { unwrapEnvelopeErr  :: OtherHeaderEnvelopeError blk }
-newtype WrapForgeState   blk = WrapForgeState   { unwrapForgeState   :: ForgeState               blk }
-newtype WrapGenTxId      blk = WrapGenTxId      { unwrapGenTxId      :: GenTxId                  blk }
-newtype WrapHeaderHash   blk = WrapHeaderHash   { unwrapHeaderHash   :: HeaderHash               blk }
-newtype WrapLedgerConfig blk = WrapLedgerConfig { unwrapLedgerConfig :: LedgerConfig             blk }
-newtype WrapLedgerErr    blk = WrapLedgerErr    { unwrapLedgerErr    :: LedgerError              blk }
-newtype WrapTipInfo      blk = WrapTipInfo      { unwrapTipInfo      :: TipInfo                  blk }
+newtype WrapApplyTxErr      blk = WrapApplyTxErr      { unwrapApplyTxErr      :: ApplyTxErr               blk }
+newtype WrapEnvelopeErr     blk = WrapEnvelopeErr     { unwrapEnvelopeErr     :: OtherHeaderEnvelopeError blk }
+newtype WrapExtraForgeState blk = WrapExtraForgeState { unwrapExtraForgeState :: ExtraForgeState          blk }
+newtype WrapGenTxId         blk = WrapGenTxId         { unwrapGenTxId         :: GenTxId                  blk }
+newtype WrapHeaderHash      blk = WrapHeaderHash      { unwrapHeaderHash      :: HeaderHash               blk }
+newtype WrapLedgerConfig    blk = WrapLedgerConfig    { unwrapLedgerConfig    :: LedgerConfig             blk }
+newtype WrapLedgerErr       blk = WrapLedgerErr       { unwrapLedgerErr       :: LedgerError              blk }
+newtype WrapTipInfo         blk = WrapTipInfo         { unwrapTipInfo         :: TipInfo                  blk }
 
 {-------------------------------------------------------------------------------
   Consensus based
 -------------------------------------------------------------------------------}
 
-newtype WrapCanBeLeader     blk = WrapCanBeLeader     { unwrapCanBeLeader     :: CanBeLeader     (BlockProtocol blk) }
-newtype WrapCannotLead      blk = WrapCannotLead      { unwrapCannotLead      :: CannotLead      (BlockProtocol blk) }
-newtype WrapChainSelConfig  blk = WrapChainSelConfig  { unwrapChainSelConfig  :: ChainSelConfig  (BlockProtocol blk) }
-newtype WrapConsensusConfig blk = WrapConsensusConfig { unwrapConsensusConfig :: ConsensusConfig (BlockProtocol blk) }
-newtype WrapConsensusState  blk = WrapConsensusState  { unwrapConsensusState  :: ConsensusState  (BlockProtocol blk) }
-newtype WrapIsLeader        blk = WrapIsLeader        { unwrapIsLeader        :: IsLeader        (BlockProtocol blk) }
-newtype WrapLeaderCheck     blk = WrapLeaderCheck     { unwrapLeaderCheck     :: LeaderCheck     (BlockProtocol blk) }
-newtype WrapLedgerView      blk = WrapLedgerView      { unwrapLedgerView      :: LedgerView      (BlockProtocol blk) }
-newtype WrapSelectView      blk = WrapSelectView      { unwrapSelectView      :: SelectView      (BlockProtocol blk) }
-newtype WrapValidateView    blk = WrapValidateView    { unwrapValidateView    :: ValidateView    (BlockProtocol blk) }
-newtype WrapValidationErr   blk = WrapValidationErr   { unwrapValidationErr   :: ValidationErr   (BlockProtocol blk) }
+newtype WrapCanBeLeader           blk = WrapCanBeLeader           { unwrapCanBeLeader           :: CanBeLeader           (BlockProtocol blk) }
+newtype WrapCannotLead            blk = WrapCannotLead            { unwrapCannotLead            :: CannotLead            (BlockProtocol blk) }
+newtype WrapChainSelConfig        blk = WrapChainSelConfig        { unwrapChainSelConfig        :: ChainSelConfig        (BlockProtocol blk) }
+newtype WrapConsensusConfig       blk = WrapConsensusConfig       { unwrapConsensusConfig       :: ConsensusConfig       (BlockProtocol blk) }
+newtype WrapChainDepState         blk = WrapChainDepState         { unwrapChainDepState         :: ChainDepState         (BlockProtocol blk) }
+newtype WrapChainIndepState       blk = WrapChainIndepState       { unwrapChainIndepState       :: ChainIndepState       (BlockProtocol blk) }
+newtype WrapChainIndepStateConfig blk = WrapChainIndepStateConfig { unwrapChainIndepStateConfig :: ChainIndepStateConfig (BlockProtocol blk) }
+newtype WrapIsLeader              blk = WrapIsLeader              { unwrapIsLeader              :: IsLeader              (BlockProtocol blk) }
+newtype WrapLeaderCheck           blk = WrapLeaderCheck           { unwrapLeaderCheck           :: LeaderCheck           (BlockProtocol blk) }
+newtype WrapLedgerView            blk = WrapLedgerView            { unwrapLedgerView            :: LedgerView            (BlockProtocol blk) }
+newtype WrapSelectView            blk = WrapSelectView            { unwrapSelectView            :: SelectView            (BlockProtocol blk) }
+newtype WrapValidateView          blk = WrapValidateView          { unwrapValidateView          :: ValidateView          (BlockProtocol blk) }
+newtype WrapValidationErr         blk = WrapValidationErr         { unwrapValidationErr         :: ValidationErr         (BlockProtocol blk) }
 
 {-------------------------------------------------------------------------------
   Versioning
@@ -92,35 +97,42 @@ deriving instance Eq (TipInfo                  blk) => Eq (WrapTipInfo     blk)
 
 deriving instance Ord (GenTxId blk) => Ord (WrapGenTxId blk)
 
-deriving instance Show (ApplyTxErr               blk) => Show (WrapApplyTxErr  blk)
-deriving instance Show (ForgeState               blk) => Show (WrapForgeState  blk)
-deriving instance Show (GenTxId                  blk) => Show (WrapGenTxId     blk)
-deriving instance Show (LedgerError              blk) => Show (WrapLedgerErr   blk)
-deriving instance Show (OtherHeaderEnvelopeError blk) => Show (WrapEnvelopeErr blk)
-deriving instance Show (TipInfo                  blk) => Show (WrapTipInfo     blk)
+deriving instance Show (ApplyTxErr               blk) => Show (WrapApplyTxErr      blk)
+deriving instance Show (ExtraForgeState          blk) => Show (WrapExtraForgeState blk)
+deriving instance Show (GenTxId                  blk) => Show (WrapGenTxId         blk)
+deriving instance Show (LedgerError              blk) => Show (WrapLedgerErr       blk)
+deriving instance Show (OtherHeaderEnvelopeError blk) => Show (WrapEnvelopeErr     blk)
+deriving instance Show (TipInfo                  blk) => Show (WrapTipInfo         blk)
 
-deriving instance NoUnexpectedThunks (ForgeState               blk) => NoUnexpectedThunks (WrapForgeState  blk)
-deriving instance NoUnexpectedThunks (GenTxId                  blk) => NoUnexpectedThunks (WrapGenTxId     blk)
-deriving instance NoUnexpectedThunks (LedgerError              blk) => NoUnexpectedThunks (WrapLedgerErr   blk)
-deriving instance NoUnexpectedThunks (OtherHeaderEnvelopeError blk) => NoUnexpectedThunks (WrapEnvelopeErr blk)
-deriving instance NoUnexpectedThunks (TipInfo                  blk) => NoUnexpectedThunks (WrapTipInfo     blk)
+deriving instance NoUnexpectedThunks (ExtraForgeState          blk) => NoUnexpectedThunks (WrapExtraForgeState blk)
+deriving instance NoUnexpectedThunks (GenTxId                  blk) => NoUnexpectedThunks (WrapGenTxId         blk)
+deriving instance NoUnexpectedThunks (LedgerError              blk) => NoUnexpectedThunks (WrapLedgerErr       blk)
+deriving instance NoUnexpectedThunks (OtherHeaderEnvelopeError blk) => NoUnexpectedThunks (WrapEnvelopeErr     blk)
+deriving instance NoUnexpectedThunks (TipInfo                  blk) => NoUnexpectedThunks (WrapTipInfo         blk)
+
+deriving instance Trivial (ExtraForgeState blk) => Trivial (WrapExtraForgeState blk)
 
 {-------------------------------------------------------------------------------
   .. consensus based
 -------------------------------------------------------------------------------}
 
-deriving instance Eq (ConsensusState (BlockProtocol blk)) => Eq (WrapConsensusState blk)
+deriving instance Eq (ChainDepState  (BlockProtocol blk)) => Eq (WrapChainDepState  blk)
 deriving instance Eq (ValidationErr  (BlockProtocol blk)) => Eq (WrapValidationErr  blk)
 
-deriving instance Show (CannotLead     (BlockProtocol blk)) => Show (WrapCannotLead     blk)
-deriving instance Show (ConsensusState (BlockProtocol blk)) => Show (WrapConsensusState blk)
-deriving instance Show (LedgerView     (BlockProtocol blk)) => Show (WrapLedgerView     blk)
-deriving instance Show (SelectView     (BlockProtocol blk)) => Show (WrapSelectView     blk)
-deriving instance Show (ValidationErr  (BlockProtocol blk)) => Show (WrapValidationErr  blk)
+deriving instance Show (CannotLead      (BlockProtocol blk)) => Show (WrapCannotLead      blk)
+deriving instance Show (ChainDepState   (BlockProtocol blk)) => Show (WrapChainDepState   blk)
+deriving instance Show (ChainIndepState (BlockProtocol blk)) => Show (WrapChainIndepState blk)
+deriving instance Show (LedgerView      (BlockProtocol blk)) => Show (WrapLedgerView      blk)
+deriving instance Show (SelectView      (BlockProtocol blk)) => Show (WrapSelectView      blk)
+deriving instance Show (ValidationErr   (BlockProtocol blk)) => Show (WrapValidationErr   blk)
 
-deriving instance NoUnexpectedThunks (ChainSelConfig (BlockProtocol blk)) => NoUnexpectedThunks (WrapChainSelConfig blk)
-deriving instance NoUnexpectedThunks (ConsensusState (BlockProtocol blk)) => NoUnexpectedThunks (WrapConsensusState blk)
-deriving instance NoUnexpectedThunks (ValidationErr  (BlockProtocol blk)) => NoUnexpectedThunks (WrapValidationErr  blk)
+deriving instance NoUnexpectedThunks (ChainSelConfig        (BlockProtocol blk)) => NoUnexpectedThunks (WrapChainSelConfig        blk)
+deriving instance NoUnexpectedThunks (ChainDepState         (BlockProtocol blk)) => NoUnexpectedThunks (WrapChainDepState         blk)
+deriving instance NoUnexpectedThunks (ChainIndepState       (BlockProtocol blk)) => NoUnexpectedThunks (WrapChainIndepState       blk)
+deriving instance NoUnexpectedThunks (ChainIndepStateConfig (BlockProtocol blk)) => NoUnexpectedThunks (WrapChainIndepStateConfig blk)
+deriving instance NoUnexpectedThunks (ValidationErr         (BlockProtocol blk)) => NoUnexpectedThunks (WrapValidationErr         blk)
+
+deriving instance Trivial (ChainIndepState (BlockProtocol blk)) => Trivial (WrapChainIndepState blk)
 
 {-------------------------------------------------------------------------------
   Versioning
@@ -139,5 +151,5 @@ deriving instance Eq (BlockNodeToClientVersion blk) => Eq (WrapNodeToClientVersi
 -------------------------------------------------------------------------------}
 
 deriving instance Serialise (GenTxId                       blk)  => Serialise (WrapGenTxId        blk)
-deriving instance Serialise (ConsensusState (BlockProtocol blk)) => Serialise (WrapConsensusState blk)
+deriving instance Serialise (ChainDepState  (BlockProtocol blk)) => Serialise (WrapChainDepState  blk)
 deriving instance Serialise (TipInfo                       blk)  => Serialise (WrapTipInfo        blk)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -102,23 +102,26 @@ data instance ConsensusConfig ProtocolA = CfgA {
 instance ChainSelection ProtocolA where
   -- Use defaults
 
-instance ConsensusProtocol ProtocolA where
-  type ConsensusState ProtocolA = ()
-  type LedgerView     ProtocolA = ()
-  type IsLeader       ProtocolA = ()
-  type CanBeLeader    ProtocolA = ()
-  type CannotLead     ProtocolA = Void
-  type ValidateView   ProtocolA = ()
-  type ValidationErr  ProtocolA = Void
+instance HasChainIndepState ProtocolA where
+  -- Use defaults
 
-  checkIsLeader CfgA{..} () (Ticked slot _) _ =
+instance ConsensusProtocol ProtocolA where
+  type ChainDepState ProtocolA = ()
+  type LedgerView    ProtocolA = ()
+  type IsLeader      ProtocolA = ()
+  type CanBeLeader   ProtocolA = ()
+  type CannotLead    ProtocolA = Void
+  type ValidateView  ProtocolA = ()
+  type ValidationErr ProtocolA = Void
+
+  checkIsLeader CfgA{..} () (Ticked slot _) _ _ =
       return $ if slot `Set.member` cfgA_leadInSlots
                  then IsLeader ()
                  else NotLeader
 
   protocolSecurityParam = cfgA_k
-  updateConsensusState  = \_ _ _ _ -> return ()
-  rewindConsensusState  = \_ _ _ _ -> Just ()
+  updateChainDepState  = \_ _ _ _ -> return ()
+  rewindChainDepState  = \_ _ _ _ -> Just ()
 
 data BlockA = BlkA {
       blkA_header :: Header BlockA
@@ -241,7 +244,7 @@ instance CommonProtocolParams BlockA where
   maxTxSize     _ = maxBound
 
 instance CanForge BlockA where
-  forgeBlock TopLevelConfig{..} _ bno (Ticked sno st) _txs _ = return $ BlkA {
+  forgeBlock TopLevelConfig{..} _ bno (Ticked sno st) _txs _ = BlkA {
         blkA_header = HdrA {
             hdrA_fields = HeaderFields {
                 headerFieldHash     = Lazy.toStrict . B.encode $ unSlotNo sno

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -89,23 +89,26 @@ data instance ConsensusConfig ProtocolB = CfgB {
 instance ChainSelection ProtocolB where
   -- Use defaults
 
-instance ConsensusProtocol ProtocolB where
-  type ConsensusState ProtocolB = ()
-  type LedgerView     ProtocolB = ()
-  type IsLeader       ProtocolB = ()
-  type CanBeLeader    ProtocolB = ()
-  type CannotLead     ProtocolB = Void
-  type ValidateView   ProtocolB = ()
-  type ValidationErr  ProtocolB = Void
+instance HasChainIndepState ProtocolB where
+  -- Use defaults
 
-  checkIsLeader CfgB{..} () (Ticked slot _) _ =
+instance ConsensusProtocol ProtocolB where
+  type ChainDepState ProtocolB = ()
+  type LedgerView    ProtocolB = ()
+  type IsLeader      ProtocolB = ()
+  type CanBeLeader   ProtocolB = ()
+  type CannotLead    ProtocolB = Void
+  type ValidateView  ProtocolB = ()
+  type ValidationErr ProtocolB = Void
+
+  checkIsLeader CfgB{..} () (Ticked slot _) _ _ =
       return $ if slot `Set.member` cfgB_leadInSlots
                  then IsLeader ()
                  else NotLeader
 
   protocolSecurityParam = cfgB_k
-  updateConsensusState  = \_ _ _ _ -> return ()
-  rewindConsensusState  = \_ _ _ _ -> Just ()
+  updateChainDepState  = \_ _ _ _ -> return ()
+  rewindChainDepState  = \_ _ _ _ -> Just ()
 
 data BlockB = BlkB {
       blkB_header :: Header BlockB
@@ -199,7 +202,7 @@ instance CommonProtocolParams BlockB where
   maxTxSize     _ = maxBound
 
 instance CanForge BlockB where
-  forgeBlock _ _ bno (Ticked sno st) _txs _ = return $ BlkB {
+  forgeBlock _ _ bno (Ticked sno st) _txs _ = BlkB {
       blkB_header = HdrB {
           hdrB_fields = HeaderFields {
               headerFieldHash     = Lazy.toStrict . B.encode $ unSlotNo sno

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -397,6 +397,7 @@ runChainSync securityParam (ClientUpdates clientUpdates)
                           , (CoreId (CoreNodeId 1), VerKeyMockDSIGN 1)
                           ]
           }
+      , configIndep  = ()
       , configLedger = eraParams
       , configBlock  = TestBlockConfig numCoreNodes
       }

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -224,6 +224,7 @@ testCfg securityParam = TopLevelConfig {
         , bftSignKey = SignKeyMockDSIGN 0
         , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
         }
+    , configIndep  = ()
     , configLedger = eraParams
     , configBlock  = TestBlockConfig numCoreNodes
     }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -260,7 +260,7 @@ runAllComponentsM (mblk, mhdr, a, b, c, d, e, f, g, h) = do
 type TestConstraints blk =
   ( ConsensusProtocol  (BlockProtocol blk)
   , LedgerSupportsProtocol            blk
-  , Eq (ConsensusState (BlockProtocol blk))
+  , Eq (ChainDepState  (BlockProtocol blk))
   , Eq (LedgerState                   blk)
   , Eq                                blk
   , Show                              blk

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -27,7 +27,7 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Ledger.Abstract
-import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util hiding (Trivial (..))
 
 import           Ouroboros.Consensus.Storage.LedgerDB.InMemory
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -657,6 +657,7 @@ mkTestConfig k ChunkSize { chunkCanContainEBB, numRegularBlocks } =
           , bftSignKey = SignKeyMockDSIGN 0
           , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
           }
+      , configIndep  = ()
       , configLedger = eraParams
       , configBlock  = TestBlockConfig {
             testBlockEBBsAllowed  = chunkCanContainEBB
@@ -727,7 +728,7 @@ instance EncodeDiskDep   (NestedCtxt Header) TestBlock
 instance DecodeDiskDepIx (NestedCtxt Header) TestBlock
 instance DecodeDiskDep   (NestedCtxt Header) TestBlock
 
--- ConsensusState
+-- ChainDepState
 instance EncodeDisk TestBlock ()
 instance DecodeDisk TestBlock ()
 


### PR DESCRIPTION
Closes #2058, #2229.

* Get rid of the `TPraosForgeState` wrapper around `HotKey` and track more.
  information about the `HotKey`.
* Rename `ConsensusState` to `ChainDepState`.
* Introduce `ChainIndepState` and use it to track the `HotKey` for `TPraos`.
* Rename `ForgeState` to `ExtraForgeState` (block-specific, unused, but for
  future use, e.g., hardware devices, online opcert renewal) and define
  `ForgeState` to be the product of `ChainIndepState` and `ExtraForgeState`.
* Pass the `ChainIndepState` to `checkIsLeader` so that `TPraos` can check the
  validity of the KES key (original goal of this PR).
* Remove `Update`.
* Make `forgeBlock` pure by removing `MonadRandom` (work towards #2036).
* Also remove `MonadRandom` from `ProtocolInfo`.