### PR TITLE
cardano: fixup counting in rsShelleySlots ThreadNet property

### DIFF
--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -244,7 +244,7 @@ prop_simple_cardano_convergence TestSetup
     reachesShelley :: ReachesShelley
     reachesShelley = ReachesShelley
       { rsByronSlots    =
-          BoolProps.enabledIf $ t > numByronEpochs * unEpochSize epochSizeByron
+          BoolProps.enabledIf $ t > byronSlots
       , rsPV            = BoolProps.enabledIf setupHardFork
       , rsShelleyBlocks =
           or $
@@ -255,7 +255,7 @@ prop_simple_cardano_convergence TestSetup
           ]
       , rsShelleySlots  =
           assert (w >= k) $
-          BoolProps.requiredIf $ t > w + 1 - k
+          BoolProps.requiredIf $ t > byronSlots + w + 1 - k
             -- logic: if we are ensured at least @k@ blocks in @w@ slots, then
             -- we're ensured at least @1@ block in @w+1-k@ slots
       }
@@ -263,6 +263,9 @@ prop_simple_cardano_convergence TestSetup
         TestConfig{numSlots}        = setupTestConfig
         NumSlots t                  = numSlots
         TestOutput{testOutputNodes} = testOutput
+
+        byronSlots :: Word64
+        byronSlots = numByronEpochs * unEpochSize epochSizeByron
 
         k :: Word64
         k = maxRollbacks setupK


### PR DESCRIPTION
It's a bit of a corner case, but I caught this bug when running thousands of tests.

As a result, it was requiring Shelley blocks if we _merely reached_ the Shelley era. But if there are just a few slots in the Shelley era, it might get unlucky and have no active slots. This PR corrects it so that it doesn't fail when there are just a few unlucky Shelley slots.

I had previously noticed I wasn't seeing `Optional`s in the `tabulate`, but I thought I just unlucky -- I hadn't run large numbers. With the fix, I now see `Optional`s.