### PR TITLE
Backport DNS fixes

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -148,6 +148,7 @@ library
                        cardano-slotting,
                        cborg             >=0.2.1 && <0.3,
                        containers,
+                       directory,
                        dns,
                        mtl,
                        fingertree        >=0.1.4.2 && <0.2,

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 
 module Ouroboros.Network.PeerSelection.RootPeersDNS (
     -- * DNS based provider for local root peers
@@ -20,20 +21,29 @@ module Ouroboros.Network.PeerSelection.RootPeersDNS (
   ) where
 
 import           Data.Word (Word32)
+import           Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Set as Set
 import           Data.Set (Set)
 import qualified Data.Map.Strict as Map
 import           Data.Map.Strict (Map)
 
+import           Control.Exception (Exception (..), IOException)
 import           Control.Monad (when, unless)
 import           Control.Monad.Class.MonadAsync
+-- TODO: use `MonadSTM.Strict`
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
-import           Control.Tracer (Tracer(..), traceWith)
+import           Control.Monad.Class.MonadThrow
+import           Control.Tracer (Tracer(..), contramap, traceWith)
+
+import           Data.Time (UTCTime)
+import           System.Directory (getModificationTime)
 
 import           Data.IP (IPv4)
 import qualified Data.IP as IP
+import           Network.DNS (DNSError)
 import qualified Network.DNS as DNS
 import qualified Network.Socket as Socket
 
@@ -51,6 +61,165 @@ data DomainAddress = DomainAddress {
 
 
 -----------------------------------------------
+-- Resource
+--
+
+-- | Evolving resource; We use it to reinitialise the dns library if the
+-- `/etc/resolv.conf` file was modified.
+--
+data Resource err a = Resource {
+    withResource :: IO (Either err a, Resource err a)
+  }
+
+-- | Like 'withResource' but retries untill success.
+--
+withResource' :: Tracer IO err
+              -> NonEmpty DiffTime
+              -- ^ delays between each re-try
+              -> Resource err a
+              -> IO (a, Resource err a)
+withResource' tracer delays0 = go delays0
+  where
+    dropHead :: NonEmpty a -> NonEmpty a
+    dropHead as@(_ :| [])  = as
+    dropHead (_ :| a : as) = a :| as
+
+    go !delays resource = do
+      er <- withResource resource
+      case er of
+        (Left err, resource') -> do
+          traceWith tracer err
+          threadDelay (NonEmpty.head delays)
+          withResource' tracer (dropHead delays) resource'
+        (Right r, resource') ->
+          pure (r, resource')
+
+
+constantResource :: a -> Resource err a
+constantResource a = Resource (pure (Right a, constantResource a))
+
+data DNSorIOError
+    = DNSError !DNSError
+    | IOError  !IOException
+  deriving Show
+
+instance Exception DNSorIOError where
+
+
+-- | Strict version of 'Maybe' adjusted to the needs ot
+-- 'asyncResolverResource'.
+--
+data TimedResolver
+    = TimedResolver !DNS.Resolver !UTCTime
+    | NoResolver
+
+-- |
+--
+-- TODO: it could be useful for `publicRootPeersProvider`.
+--
+resolverResource :: DNS.ResolvConf -> IO (Resource DNSorIOError DNS.Resolver)
+resolverResource resolvConf = do
+    rs <- DNS.makeResolvSeed resolvConf
+    case DNS.resolvInfo resolvConf of
+      DNS.RCFilePath filePath ->
+        pure $ go filePath NoResolver
+
+      _ -> DNS.withResolver rs (pure . constantResource)
+
+  where
+    handlers :: FilePath
+             -> TimedResolver
+             -> [Handler IO
+                  ( Either DNSorIOError DNS.Resolver
+                  , Resource DNSorIOError DNS.Resolver)]
+    handlers filePath tr =
+      [ Handler $
+          \(err :: IOException) ->
+            pure (Left (IOError err), go filePath tr)
+      , Handler $
+          \(err :: DNS.DNSError) ->
+              pure (Left (DNSError err), go filePath tr)
+      ]
+
+    go :: FilePath
+       -> TimedResolver
+       -> Resource DNSorIOError DNS.Resolver
+    go filePath tr@NoResolver = Resource $
+      do
+        modTime <- getModificationTime filePath
+        rs <- DNS.makeResolvSeed resolvConf
+        DNS.withResolver rs
+          (\resolver ->
+            pure (Right resolver, go filePath (TimedResolver resolver modTime)))
+      `catches` handlers filePath tr
+
+    go filePath tr@(TimedResolver resolver modTime) = Resource $
+      do
+        modTime' <- getModificationTime filePath
+        if modTime' <= modTime
+          then pure (Right resolver, go filePath (TimedResolver resolver modTime))
+          else do
+            rs <- DNS.makeResolvSeed resolvConf
+            DNS.withResolver rs
+              (\resolver' ->
+                pure (Right resolver', go filePath (TimedResolver resolver' modTime')))
+      `catches` handlers filePath tr
+
+
+-- | `Resource` which passes the 'DNS.Resolver' through a 'TVar'.  Better than
+-- 'resolverResource' when using in multiple threads.
+--
+asyncResolverResource :: DNS.ResolvConf -> IO (Resource DNSorIOError DNS.Resolver)
+asyncResolverResource resolvConf =
+    case DNS.resolvInfo resolvConf of
+      DNS.RCFilePath filePath -> do
+        resourceVar <- newTVarM NoResolver
+        pure $ go filePath resourceVar
+      _ -> do
+        rs <- DNS.makeResolvSeed resolvConf
+        DNS.withResolver rs (pure . constantResource)
+  where
+    handlers :: FilePath -> TVar IO TimedResolver
+             -> [Handler IO
+                  ( Either DNSorIOError DNS.Resolver
+                  , Resource DNSorIOError DNS.Resolver)]
+    handlers filePath resourceVar =
+      [ Handler $
+          \(err :: IOException) ->
+            pure (Left (IOError err), go filePath resourceVar)
+      , Handler $
+          \(err :: DNS.DNSError) ->
+            pure (Left (DNSError err), go filePath resourceVar)
+      ]
+
+    go :: FilePath -> TVar IO TimedResolver
+       -> Resource DNSorIOError DNS.Resolver
+    go filePath resourceVar = Resource $ do
+      r <- atomically (readTVar resourceVar)
+      case r of
+        NoResolver ->
+          do
+            modTime <- getModificationTime filePath
+            rs <- DNS.makeResolvSeed resolvConf
+            DNS.withResolver rs $ \resolver -> do
+              atomically (writeTVar resourceVar (TimedResolver resolver modTime))
+              pure (Right resolver, go filePath resourceVar)
+          `catches` handlers filePath resourceVar
+
+        TimedResolver resolver modTime ->
+          do
+            modTime' <- getModificationTime filePath
+            if modTime' <= modTime
+                then pure (Right resolver, go filePath resourceVar)
+                else do
+                  rs <- DNS.makeResolvSeed resolvConf
+                  DNS.withResolver rs $ \resolver' -> do
+                    atomically (writeTVar resourceVar (TimedResolver resolver' modTime'))
+                    pure (Right resolver', go filePath resourceVar)
+          `catches` handlers filePath resourceVar
+
+
+-----------------------------------------------
 -- local root peer set provider based on DNS
 --
 
@@ -58,9 +227,10 @@ data TraceLocalRootPeers =
        TraceLocalRootDomains [(DomainAddress, PeerAdvertise)]
      | TraceLocalRootWaiting DomainAddress DiffTime
      | TraceLocalRootResult  DomainAddress [(IPv4, DNS.TTL)]
-     | TraceLocalRootFailure DomainAddress DNS.DNSError
+     | TraceLocalRootFailure DomainAddress DNSorIOError
        --TODO: classify DNS errors, config error vs transitory
   deriving Show
+
 
 -- |
 --
@@ -75,25 +245,29 @@ localRootPeersProvider :: Tracer IO TraceLocalRootPeers
 localRootPeersProvider tracer resolvConf rootPeersVar domains = do
     traceWith tracer (TraceLocalRootDomains domains)
     unless (null domains) $ do
-      rs <- DNS.makeResolvSeed resolvConf
-      DNS.withResolver rs $ \resolver ->
-        withAsyncAll (map (monitorDomain resolver) domains) $ \asyncs ->
-          waitAny asyncs >> return ()
+      rr <- asyncResolverResource resolvConf
+      withAsyncAll (map (monitorDomain rr) domains) $ \asyncs ->
+        waitAny asyncs >> return ()
   where
-    monitorDomain :: DNS.Resolver -> (DomainAddress, PeerAdvertise) -> IO ()
-    monitorDomain resolver (domain@DomainAddress {daDomain, daPortNumber}, advertisePeer) =
-        go 0
+    monitorDomain :: Resource DNSorIOError DNS.Resolver -> (DomainAddress, PeerAdvertise) -> IO ()
+    monitorDomain rr0 (domain@DomainAddress {daDomain, daPortNumber}, advertisePeer) =
+        go rr0 0
       where
-        go :: DiffTime -> IO ()
-        go !ttl = do
+        go :: Resource DNSorIOError DNS.Resolver -> DiffTime -> IO ()
+        go !rr !ttl = do
           when (ttl > 0) $ do
             traceWith tracer (TraceLocalRootWaiting domain ttl)
             threadDelay ttl
+
+          (resolver, rrNext) <-
+            withResource' (TraceLocalRootFailure domain `contramap` tracer)
+                          (1 :| [3, 6, 9, 12])
+                          rr
           reply <- lookupAWithTTL resolver daDomain
           case reply of
             Left  err -> do
-              traceWith tracer (TraceLocalRootFailure domain err)
-              go (ttlForDnsError err ttl)
+              traceWith tracer (TraceLocalRootFailure domain (DNSError err))
+              go rrNext (ttlForDnsError err ttl)
 
             Right results -> do
               traceWith tracer (TraceLocalRootResult domain results)
@@ -112,7 +286,7 @@ localRootPeersProvider tracer resolvConf rootPeersVar domains = do
                 when (Map.lookup domain rootPeers /= Just resultsMap) $
                   writeTVar rootPeersVar rootPeers'
 
-              go (ttlForResults (map snd results))
+              go rrNext (ttlForResults (map snd results))
 
 
 ---------------------------------------------
@@ -135,32 +309,41 @@ publicRootPeersProvider :: Tracer IO TracePublicRootPeers
                         -> IO a
 publicRootPeersProvider tracer resolvConf domains action = do
     traceWith tracer (TracePublicRootDomains domains)
-    rs <- DNS.makeResolvSeed resolvConf
-    DNS.withResolver rs $ \resolver ->
-      action (requestPublicRootPeers resolver)
+    rr <- resolverResource resolvConf
+    resourceVar <- newTVarM rr
+    action (requestPublicRootPeers resourceVar)
   where
-    requestPublicRootPeers :: DNS.Resolver -> Int -> IO (Set Socket.SockAddr, DiffTime)
-    requestPublicRootPeers resolver _numRequested = do
-        let lookups =
-              [ lookupAWithTTL resolver daDomain
-              |  DomainAddress {daDomain} <- domains ]
-        -- The timeouts here are handled by the dns library. They're configured
-        -- via the DNS.ResolvConf resolvTimeout field and defaults to 3 sec.
-        results <- withAsyncAll lookups (atomically . mapM waitSTM)
-        sequence_
-          [ traceWith tracer $ case result of
-              Left  dnserr -> TracePublicRootFailure daDomain dnserr
-              Right ipttls -> TracePublicRootResult  daDomain ipttls
-          | (DomainAddress {daDomain}, result) <- zip domains results ]
-        let successes = [ (Socket.SockAddrInet daPortNumber (IP.toHostAddress ip), ipttl)
-                        | (Right ipttls, DomainAddress {daPortNumber}) <- (zip results domains)
-                        , (ip, ipttl) <- ipttls
-                        ]
-            !ips      = Set.fromList  (map fst successes)
-            !ttl      = ttlForResults (map snd successes)
-        -- If all the lookups failed we'll return an empty set with a minimum
-        -- TTL, and the governor will invoke its exponential backoff.
-        return (ips, ttl)
+    requestPublicRootPeers :: TVar IO (Resource DNSorIOError DNS.Resolver)
+                           -> Int -> IO (Set Socket.SockAddr, DiffTime)
+    requestPublicRootPeers resourceVar _numRequested = do
+        rr <- atomically $ readTVar resourceVar
+        (er, rr') <- withResource rr
+        atomically $ writeTVar resourceVar rr'
+        case er of
+          Left (DNSError err) -> throwM err
+          Left (IOError  err) -> throwM err
+          Right resolver -> do
+            let lookups =
+                  [ lookupAWithTTL resolver daDomain
+                  |  DomainAddress {daDomain} <- domains ]
+            -- The timeouts here are handled by the 'lookupAWithTTL'. They're
+            -- configured via the DNS.ResolvConf resolvTimeout field and defaults
+            -- to 3 sec.
+            results <- withAsyncAll lookups (atomically . mapM waitSTM)
+            sequence_
+              [ traceWith tracer $ case result of
+                  Left  dnserr -> TracePublicRootFailure daDomain dnserr
+                  Right ipttls -> TracePublicRootResult  daDomain ipttls
+              | (DomainAddress {daDomain}, result) <- zip domains results ]
+            let successes = [ (Socket.SockAddrInet daPortNumber (IP.toHostAddress ip), ipttl)
+                            | (Right ipttls, DomainAddress {daPortNumber}) <- (zip results domains)
+                            , (ip, ipttl) <- ipttls
+                            ]
+                !ips      = Set.fromList  (map fst successes)
+                !ttl      = ttlForResults (map snd successes)
+            -- If all the lookups failed we'll return an empty set with a minimum
+            -- TTL, and the governor will invoke its exponential backoff.
+            return (ips, ttl)
 
 
 ---------------------------------------------
@@ -222,11 +405,11 @@ withAsyncAll xs0 action = go [] xs0
 -- Examples
 --
 {-
-exampleLocal :: [DNS.Domain] -> IO ()
+exampleLocal :: [DomainAddress] -> IO ()
 exampleLocal domains = do
-    rootPeersVar <- newTVarM Map.empty
-    withAsync (observer rootPeersVar Map.empty) $ \_ ->
-      provider rootPeersVar
+      rootPeersVar <- newTVarM Map.empty
+      withAsync (observer rootPeersVar Map.empty) $ \_ ->
+        provider rootPeersVar
   where
     provider rootPeersVar =
       localRootPeersProvider
@@ -244,7 +427,7 @@ exampleLocal domains = do
       traceWith (showTracing stdoutTracer) x
       observer var x
 
-examplePublic :: [DNS.Domain] -> IO ()
+examplePublic :: [DomainAddress] -> IO ()
 examplePublic domains = do
     publicRootPeersProvider
       (showTracing stdoutTracer)

--- a/ouroboros-network/test/Ouroboros/Network/PeerSelection/Test.hs
+++ b/ouroboros-network/test/Ouroboros/Network/PeerSelection/Test.hs
@@ -34,11 +34,12 @@ import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTime
 import           Control.Tracer (Tracer (..), contramap, traceWith)
 
-import           Control.Monad.Class.MonadTimer
+import           Control.Monad.Class.MonadTimer hiding (timeout)
 import           Control.Monad.IOSim
 
 import qualified Network.DNS as DNS (defaultResolvConf)
 import           Network.Socket (SockAddr)
+import           Network.Mux.Timeout
 
 import           Ouroboros.Network.PeerSelection.Governor hiding
                      (PeerSelectionState (..))
@@ -1034,8 +1035,10 @@ renderRanges r n = show lower ++ " -- " ++ show upper
 
 _governorFindingPublicRoots :: Int -> [DomainAddress] -> IO Void
 _governorFindingPublicRoots targetNumberOfRootPeers domains =
+    withTimeoutSerial $ \timeout ->
     publicRootPeersProvider
       tracer
+      timeout
       DNS.defaultResolvConf
       domains $ \requestPublicRootPeers ->
 

--- a/ouroboros-network/test/Ouroboros/Network/PeerSelection/Test.hs
+++ b/ouroboros-network/test/Ouroboros/Network/PeerSelection/Test.hs
@@ -38,6 +38,8 @@ import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim
 
 import qualified Network.DNS as DNS (defaultResolvConf)
+import           Network.Socket (SockAddr)
+
 import           Ouroboros.Network.PeerSelection.Governor hiding
                      (PeerSelectionState (..))
 import qualified Ouroboros.Network.PeerSelection.Governor as Governor
@@ -1030,7 +1032,7 @@ renderRanges r n = show lower ++ " -- " ++ show upper
 -- Live examples
 --
 
-_governorFindingPublicRoots :: Int -> [Domain] -> IO Void
+_governorFindingPublicRoots :: Int -> [DomainAddress] -> IO Void
 _governorFindingPublicRoots targetNumberOfRootPeers domains =
     publicRootPeersProvider
       tracer
@@ -1045,7 +1047,7 @@ _governorFindingPublicRoots targetNumberOfRootPeers domains =
     tracer :: Show a => Tracer IO a
     tracer  = Tracer (BS.putStrLn . BS.pack . show)
 
-    actions :: PeerSelectionActions IPv4 () IO
+    actions :: PeerSelectionActions SockAddr () IO
     actions = PeerSelectionActions {
                 readLocalRootPeers       = return Map.empty,
                 readPeerSelectionTargets = return targets,
@@ -1066,7 +1068,7 @@ _governorFindingPublicRoots targetNumberOfRootPeers domains =
                 targetNumberOfActivePeers      = 0
               }
 
-    policy :: PeerSelectionPolicy IPv4 IO
+    policy :: PeerSelectionPolicy SockAddr IO
     policy  = PeerSelectionPolicy {
                 policyPickKnownPeersForGossip = pickTrivially,
                 policyPickColdPeersToForget   = pickTrivially,
@@ -1080,5 +1082,5 @@ _governorFindingPublicRoots targetNumberOfRootPeers domains =
                 policyGossipBatchWaitTime     = 0, -- seconds
                 policyGossipOverallTimeout    = 0  -- seconds
               }
-    pickTrivially :: Applicative m => Map IPv4 a -> Int -> m (Set IPv4)
+    pickTrivially :: Applicative m => Map SockAddr a -> Int -> m (Set SockAddr)
     pickTrivially m n = pure . Set.take n . Map.keysSet $ m


### PR DESCRIPTION
- Issue #1893
- Issue #1873

Patches:
- peer-selection: publicRootPeersProvider
- peer-selection: localRootPeersProvider
- peer-selection: Resource
- peer-selection: Use MonadSTM.Strict in RootPeersDNS
- peer-selection: use timeout in RootPeersDNS
