### PR TITLE
handle exceptions while decoding

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadAsync.hs
@@ -12,6 +12,7 @@ module Control.Monad.Class.MonadAsync
   , MonadAsyncSTM (..)
   , AsyncCancelled(..)
   , ExceptionInLinkedThread(..)
+  , isCancel
   , link
   , linkTo
   , linkOnly

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -235,7 +235,7 @@ copyToImmDB CDB{..} = withCopyLock $ do
 -- * Schedule GC of the VolDB ('scheduleGC') for the 'SlotNo' of the most
 --   recent block that was copied.
 --
--- It is important that we only take LgrDB snapshots when are are /sure/ they
+-- It is important that we only take LgrDB snapshots when we are /sure/ they
 -- have been copied to the ImmDB, since the LgrDB assumes that all snapshots
 -- correspond to immutable blocks. (Of course, data corruption can occur and we
 -- can handle it by reverting to an older LgrDB snapshot, but we should need

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Validation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Validation.hs
@@ -348,7 +348,7 @@ validateChunk ValidateEnv{..} shouldBeFinalised chunk mbPrevHash = do
 
     lift $ do
 
-      -- If the parser returneds a deserialisation error, truncate the chunk
+      -- If the parser returns a deserialisation error, truncate the chunk
       -- file. Don't truncate the database just yet, because the
       -- deserialisation error may be due to some extra random bytes that
       -- shouldn't have been there in the first place.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
@@ -125,6 +125,9 @@ data ReadIncrementalErr =
 
     -- | Deserialisation was successful, but there was additional data
   | TrailingBytes ByteString
+
+    -- | An unknown exception, like a 'UserError' or an 'IOException'
+  | UnKnownException String
   deriving (Eq, Show)
 
 -- | Read a file incrementally
@@ -195,7 +198,26 @@ withStreamIncrementalOffsets hasFS@HasFS{..} decoder fp = \k ->
           S.lift (liftST (CBOR.R.deserialiseIncremental decoder)) >>=
             go liftST h 0 Nothing [] fileSize
   where
+    -- | First run the 'action'. If an exception happened, wrap it and return
+    -- the current 'offset'. If no exception happened run the continuation.
+    liftWithHandler
+      :: Word64
+      -> (b -> Stream (Of (Word64, (Word64, a))) m (Maybe (ReadIncrementalErr, Word64)))
+      -> m b
+      -> Stream (Of (Word64, (Word64, a))) m (Maybe (ReadIncrementalErr, Word64))
+    liftWithHandler offset cont action = do
+      ret <- S.lift $ try action
+      case ret of
+        Right ok -> cont ok
+        Left e   -> do
+          when (isAsync e) $
+            S.lift $ throwM e
+          return $ Just (UnKnownException $ show e, offset)
+
     -- TODO stream from HasFS?
+    -- TODO: It feels like this should run on a a custom Monad, where exception
+    -- handling is built in. Stream has no MonadCatch instance, so defining our
+    -- own Monad wrapper, will simplify the code below.
     go :: (forall x. ST s x -> m x)
        -> Handle h
        -> Word64                   -- ^ Offset
@@ -205,45 +227,56 @@ withStreamIncrementalOffsets hasFS@HasFS{..} decoder fp = \k ->
        -> CBOR.R.IDecode s (LBS.ByteString -> a)
        -> Stream (Of (Word64, (Word64, a))) m (Maybe (ReadIncrementalErr, Word64))
     go liftST h offset mbUnconsumed bss fileSize dec = case dec of
-      CBOR.R.Partial k -> do
-        -- First use the unconsumed bytes from a previous read before read
-        -- some more bytes from the file.
-        bs   <- case mbUnconsumed of
-          Just unconsumed -> return unconsumed
-          Nothing         -> S.lift $ hGetSome h (fromIntegral defaultChunkSize)
-        dec' <- S.lift $ liftST $ k (checkEmpty bs)
-        go liftST h offset Nothing (bs:bss) fileSize dec'
+      CBOR.R.Partial k -> liftWithHandler offset
+        (\(bs, dec') -> go liftST h offset Nothing (bs:bss) fileSize dec')
+        $ do
+          -- First use the unconsumed bytes from a previous read before read
+          -- some more bytes from the file.
+          bs <- case mbUnconsumed of
+            Just unconsumed -> return unconsumed
+            Nothing         -> hGetSome h (fromIntegral defaultChunkSize)
+          -- evaluate all thunks here, since exceptions will be handled properly
+          -- in this block.
+          bs' <- evaluate bs
+          dec' <- liftST (k $ checkEmpty bs) >>= evaluate
+          return (bs', dec')
 
-      CBOR.R.Done leftover size mkA -> do
-        let nextOffset = offset + fromIntegral size
-            -- We've been keeping track of the bytes pushed into the decoder
-            -- for this item so far in bss. Now there's some trailing data to
-            -- remove and we can get the whole bytes used for this item. We
-            -- supply the bytes to the final decoded value. This is to support
-            -- annotating values with their original input bytes.
-            aBytes     = case bss of
-                []      -> LBS.empty
-                bs:bss' -> LBS.fromChunks (reverse (bs' : bss'))
-                  where
-                    bs' = BS.take (BS.length bs - BS.length leftover) bs
-            -- The bang on the @a'@ here allows the used 'Decoder' to force
-            -- its computation. For example, the decoder might decode a whole
-            -- block and then (maybe through a use of 'fmap') just return its
-            -- hash. If we don't force the value it returned here, we're just
-            -- putting a thunk that references the whole block in the list
-            -- instead of merely the hash.
-            !a         = mkA aBytes
-        S.yield (offset, (fromIntegral size, a))
-        case checkEmpty leftover of
-          Nothing
-            | nextOffset == fileSize
-              -- We're at the end of the file, so stop
-            -> return Nothing
-          -- Some more bytes, so try to read the next @a@.
-          mbLeftover ->
-            S.lift (liftST (CBOR.R.deserialiseIncremental decoder)) >>=
-            go liftST h nextOffset mbLeftover [] fileSize
-
+      CBOR.R.Done leftover size mkA -> liftWithHandler offset
+        (\(nextOffset, a) -> do
+            S.yield (offset, (fromIntegral size, a))
+            case checkEmpty leftover of
+              Nothing
+                | nextOffset == fileSize
+                  -- We're at the end of the file, so stop
+                -> return Nothing
+              -- Some more bytes, so try to read the next @a@.
+              mbLeftover ->
+                liftWithHandler offset
+                  (go liftST h nextOffset mbLeftover [] fileSize)
+                  (evaluate =<< liftST (CBOR.R.deserialiseIncremental decoder))
+        )
+        $ do
+          nextOffset <- evaluate $ offset + fromIntegral size
+              -- We've been keeping track of the bytes pushed into the decoder
+              -- for this item so far in bss. Now there's some trailing data to
+              -- remove and we can get the whole bytes used for this item. We
+              -- supply the bytes to the final decoded value. This is to support
+              -- annotating values with their original input bytes.
+          let aBytes     = case bss of
+                  []      -> LBS.empty
+                  bs:bss' -> LBS.fromChunks (reverse (bs' : bss'))
+                    where
+                      bs' = BS.take (BS.length bs - BS.length leftover) bs
+              -- Forcing the evaluation on the @a'@ here has double benefit.
+              -- First it makes sure thunks are evaluated in a block where
+              -- exceptions are handled. Secondly it allows the used 'Decoder'
+              -- to force its computation. For example, the decoder might decode
+              -- a whole block and then (maybe through a use of 'fmap') just
+              -- return its hash. If we don't force the value it returned here,
+              -- we're just putting a thunk that references the whole block in
+              -- the list instead of merely the hash.
+          a <- evaluate $ mkA aBytes
+          return (nextOffset, a)
       CBOR.R.Fail _ _ err -> return $ Just (ReadFailed err, offset)
 
     checkEmpty :: ByteString -> Maybe ByteString

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/EarlyExit.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/EarlyExit.hs
@@ -187,6 +187,9 @@ instance (MonadMask m, MonadAsync m, MonadCatch (STM m))
     asyncWithUnmask $ \unmask ->
       withEarlyExit (f (earlyExit . unmask . withEarlyExit))
 
+instance (MonadEvaluate m, MonadCatch m) => MonadEvaluate (WithEarlyExit m) where
+  evaluate = WithEarlyExit . lift . evaluate
+
 commute :: Either SomeException (Maybe a) -> Maybe (Either SomeException a)
 commute (Left e)         = Just (Left e)
 commute (Right Nothing)  = Nothing

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -11,6 +11,7 @@ module Ouroboros.Consensus.Util.IOLike (
   , Exception(..)
   , SomeException
   , ExitCase(..)
+  , evaluate
     -- *** MonadSTM
   , module Ouroboros.Consensus.Util.MonadSTM.NormalForm
   , MonadSTMTxExtended(..)
@@ -87,6 +88,7 @@ class ( MonadAsync              m
       , MonadCatch              m
       , MonadMask               m
       , MonadMonotonicTime      m
+      , MonadEvaluate           m
       , MonadThrow         (STM m)
       , MonadSTMTxExtended (STM m)
       , forall a. NoUnexpectedThunks (m a)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -22,6 +22,7 @@ module Ouroboros.Consensus.Util.IOLike (
   , MonadAsyncSTM(..)
   , MonadAsync(..)
   , ExceptionInLinkedThread(..)
+  , isAsync
   , link
   , linkTo
     -- *** MonadST
@@ -43,6 +44,9 @@ module Ouroboros.Consensus.Util.IOLike (
 import qualified Control.Concurrent.STM as IO
 
 import           Cardano.Prelude (Natural, NoUnexpectedThunks (..))
+
+import           Control.Exception (AsyncException)
+import           Data.Maybe (isJust)
 
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadEventlog
@@ -91,3 +95,7 @@ class ( MonadAsync              m
       ) => IOLike m where
 
 instance IOLike IO
+
+isAsync :: SomeException -> Bool
+isAsync e = isJust (fromException e :: Maybe AsyncException) ||
+            isCancel e


### PR DESCRIPTION
https://github.com/input-output-hk/ouroboros-network/issues/1966

This makes sure that a file is always truncated even in case of some unexpected exception.