### PR TITLE
Update to more recent cardano-ledger-specs.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -170,71 +170,71 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c4cce950ff1539a077ef527341b20f21fe4793e6
-  --sha256: 0pvxild5nzdnmmqskywqswy7b03kaqjfp4ys1hkgnpi62yl29h7l
+  tag: 12b13f390d64df6af6054b0d33bb3767756da041
+  --sha256: 0v9zj73sz984xpg0azckfpibkllribbzksg18isx2m7w58bya77m
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c4cce950ff1539a077ef527341b20f21fe4793e6
-  --sha256: 0pvxild5nzdnmmqskywqswy7b03kaqjfp4ys1hkgnpi62yl29h7l
+  tag: 12b13f390d64df6af6054b0d33bb3767756da041
+  --sha256: 0v9zj73sz984xpg0azckfpibkllribbzksg18isx2m7w58bya77m
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c4cce950ff1539a077ef527341b20f21fe4793e6
-  --sha256: 0pvxild5nzdnmmqskywqswy7b03kaqjfp4ys1hkgnpi62yl29h7l
+  tag: 12b13f390d64df6af6054b0d33bb3767756da041
+  --sha256: 0v9zj73sz984xpg0azckfpibkllribbzksg18isx2m7w58bya77m
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c4cce950ff1539a077ef527341b20f21fe4793e6
-  --sha256: 0pvxild5nzdnmmqskywqswy7b03kaqjfp4ys1hkgnpi62yl29h7l
+  tag: 12b13f390d64df6af6054b0d33bb3767756da041
+  --sha256: 0v9zj73sz984xpg0azckfpibkllribbzksg18isx2m7w58bya77m
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c4cce950ff1539a077ef527341b20f21fe4793e6
-  --sha256: 0pvxild5nzdnmmqskywqswy7b03kaqjfp4ys1hkgnpi62yl29h7l
+  tag: 12b13f390d64df6af6054b0d33bb3767756da041
+  --sha256: 0v9zj73sz984xpg0azckfpibkllribbzksg18isx2m7w58bya77m
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c4cce950ff1539a077ef527341b20f21fe4793e6
-  --sha256: 0pvxild5nzdnmmqskywqswy7b03kaqjfp4ys1hkgnpi62yl29h7l
+  tag: 12b13f390d64df6af6054b0d33bb3767756da041
+  --sha256: 0v9zj73sz984xpg0azckfpibkllribbzksg18isx2m7w58bya77m
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c4cce950ff1539a077ef527341b20f21fe4793e6
-  --sha256: 0pvxild5nzdnmmqskywqswy7b03kaqjfp4ys1hkgnpi62yl29h7l
+  tag: 12b13f390d64df6af6054b0d33bb3767756da041
+  --sha256: 0v9zj73sz984xpg0azckfpibkllribbzksg18isx2m7w58bya77m
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c4cce950ff1539a077ef527341b20f21fe4793e6
-  --sha256: 0pvxild5nzdnmmqskywqswy7b03kaqjfp4ys1hkgnpi62yl29h7l
+  tag: 12b13f390d64df6af6054b0d33bb3767756da041
+  --sha256: 0v9zj73sz984xpg0azckfpibkllribbzksg18isx2m7w58bya77m
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c4cce950ff1539a077ef527341b20f21fe4793e6
-  --sha256: 0pvxild5nzdnmmqskywqswy7b03kaqjfp4ys1hkgnpi62yl29h7l
+  tag: 12b13f390d64df6af6054b0d33bb3767756da041
+  --sha256: 0v9zj73sz984xpg0azckfpibkllribbzksg18isx2m7w58bya77m
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c4cce950ff1539a077ef527341b20f21fe4793e6
-  --sha256: 0pvxild5nzdnmmqskywqswy7b03kaqjfp4ys1hkgnpi62yl29h7l
+  tag: 12b13f390d64df6af6054b0d33bb3767756da041
+  --sha256: 0v9zj73sz984xpg0azckfpibkllribbzksg18isx2m7w58bya77m
   subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -76,6 +76,7 @@ import qualified Shelley.Spec.Ledger.LedgerState as SL
 import qualified Shelley.Spec.Ledger.PParams as SL
 import qualified Shelley.Spec.Ledger.Rewards as SL
 import qualified Shelley.Spec.Ledger.STS.Prtcl as SL
+import qualified Shelley.Spec.Ledger.STS.Tickn as SL
 import qualified Shelley.Spec.Ledger.TxData as SL
 import qualified Shelley.Spec.Ledger.UTxO as SL
 
@@ -471,12 +472,11 @@ translateChainDepStateByronToShelley
   -> TPraosState sc
 translateChainDepStateByronToShelley TPraosConfig { tpraosParams } pbftState =
     TPraosState.empty (PBftState.tipSlot pbftState) $
-      SL.PrtclState
-        Map.empty
-        nonce
-        nonce
-        nonce
-        nonce
+      SL.ChainDepState
+        { SL.csProtocol = SL.PrtclState Map.empty nonce nonce
+        , SL.csTickn = SL.TicknState nonce nonce
+        , SL.csLabNonce = nonce
+        }
   where
     nonce = tpraosInitialNonce tpraosParams
 

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -191,6 +191,11 @@ instance (HashAlgorithm h, forall a. Arbitrary (Hash h a))
   arbitrary = genericArbitraryU
   shrink    = genericShrink
 
+instance (HashAlgorithm h)
+    => Arbitrary (SL.ChainDepState (TPraosMockCrypto h)) where
+  arbitrary = genericArbitraryU
+  shrink = genericShrink
+
 {-------------------------------------------------------------------------------
   Versioned generators for serialisation
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
@@ -218,12 +218,20 @@ test_golden_ChainDepState = goldenTestCBOR
     , TkListLen 2
     , TkInt 1
     , TkInt 1
+    , TkListLen 3
     , TkListLen 5
     , TkMapLen 2
     , TkBytes "U\165@\b"
     , TkInt 1
     , TkBytes "\158h\140X"
     , TkInt 2
+    , TkListLen 2
+    , TkInt 1
+    , TkBytes "K\245\DC2/4ET\197;\222.\187\140\210\183\227\209`\n\214\&1\195\133\165\215\204\226<w\133E\154"
+    , TkListLen 2
+    , TkInt 1
+    , TkBytes "K\245\DC2/4ET\197;\222.\187\140\210\183\227\209`\n\214\&1\195\133\165\215\204\226<w\133E\154"
+    , TkListLen 2
     , TkListLen 1
     , TkInt 0
     , TkListLen 2
@@ -234,21 +242,23 @@ test_golden_ChainDepState = goldenTestCBOR
     , TkBytes "K\245\DC2/4ET\197;\222.\187\140\210\183\227\209`\n\214\&1\195\133\165\215\204\226<w\133E\154"
     , TkListLen 2
     , TkInt 1
-    , TkBytes "K\245\DC2/4ET\197;\222.\187\140\210\183\227\209`\n\214\&1\195\133\165\215\204\226<w\133E\154"
-    , TkListLen 2
-    , TkInt 1
     , TkInt 2
+    , TkListLen 3
     , TkListLen 5
     , TkMapLen 2
     , TkBytes "U\165@\b"
     , TkInt 1
     , TkBytes "\158h\140X"
     , TkInt 2
-    , TkListLen 1
-    , TkInt 0
     , TkListLen 2
     , TkInt 1
     , TkBytes "\219\193\180\201\NUL\255\228\141W[]\165\198\&8\EOT\SOH%\246]\176\254>$IKv\234\152dW\217\134"
+    , TkListLen 2
+    , TkInt 1
+    , TkBytes "\219\193\180\201\NUL\255\228\141W[]\165\198\&8\EOT\SOH%\246]\176\254>$IKv\234\152dW\217\134"
+    , TkListLen 2
+    , TkListLen 1
+    , TkInt 0
     , TkListLen 2
     , TkInt 1
     , TkBytes "\219\193\180\201\NUL\255\228\141W[]\165\198\&8\EOT\SOH%\246]\176\254>$IKv\234\152dW\217\134"
@@ -266,7 +276,7 @@ test_golden_LedgerState = goldenTestCBOR
     , TkListLen 3
     , TkListLen 2
     , TkInt 10
-    , TkBytes "\211\231\US\147"
+    , TkBytes "t\177\DC2\228"
     , TkListLen 2
     , TkListLen 1
     , TkInt 0
@@ -589,17 +599,22 @@ test_golden_HeaderState = goldenTestCBOR
     , TkListLen 2
     , TkInt 1
     , TkInt 1
+    , TkListLen 3
     , TkListLen 5
     , TkMapLen 1
     , TkBytes "U\165@\b"
     , TkInt 1
-    , TkListLen 1
-    , TkInt 0
     , TkListLen 2
     , TkInt 1
     , TkBytes "K\245\DC2/4ET\197;\222.\187\140\210\183\227\209`\n\214\&1\195\133\165\215\204\226<w\133E\154"
     , TkListLen 1
     , TkInt 0
+    , TkListLen 2
+    , TkListLen 1
+    , TkInt 0
+    , TkListLen 2
+    , TkInt 1
+    , TkBytes "\219\193\180\201\NUL\255\228\141W[]\165\198\&8\EOT\SOH%\246]\176\254>$IKv\234\152dW\217\134"
     , TkListLen 2
     , TkInt 1
     , TkBytes "\219\193\180\201\NUL\255\228\141W[]\165\198\&8\EOT\SOH%\246]\176\254>$IKv\234\152dW\217\134"
@@ -616,7 +631,7 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkListLen 3
     , TkListLen 2
     , TkInt 10
-    , TkBytes "\211\231\US\147"
+    , TkBytes "t\177\DC2\228"
     , TkListLen 2
     , TkListLen 1
     , TkInt 0
@@ -933,17 +948,22 @@ test_golden_ExtLedgerState = goldenTestCBOR
     , TkListLen 2
     , TkInt 1
     , TkInt 1
+    , TkListLen 3
     , TkListLen 5
     , TkMapLen 1
     , TkBytes "U\165@\b"
     , TkInt 1
-    , TkListLen 1
-    , TkInt 0
     , TkListLen 2
     , TkInt 1
     , TkBytes "K\245\DC2/4ET\197;\222.\187\140\210\183\227\209`\n\214\&1\195\133\165\215\204\226<w\133E\154"
     , TkListLen 1
     , TkInt 0
+    , TkListLen 2
+    , TkListLen 1
+    , TkInt 0
+    , TkListLen 2
+    , TkInt 1
+    , TkBytes "\219\193\180\201\NUL\255\228\141W[]\165\198\&8\EOT\SOH%\246]\176\254>$IKv\234\152dW\217\134"
     , TkListLen 2
     , TkInt 1
     , TkBytes "\219\193\180\201\NUL\255\228\141W[]\165\198\&8\EOT\SOH%\246]\176\254>$IKv\234\152dW\217\134"

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -49,6 +49,7 @@ import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.IOLike
 
 import qualified Shelley.Spec.Ledger.Address as SL
+import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.BlockChain as SL
 import qualified Shelley.Spec.Ledger.Credential as SL
@@ -61,6 +62,7 @@ import qualified Shelley.Spec.Ledger.PParams as SL
 import qualified Shelley.Spec.Ledger.STS.Chain as SL
 import qualified Shelley.Spec.Ledger.STS.NewEpoch as SL
 import qualified Shelley.Spec.Ledger.STS.Prtcl as SL
+import qualified Shelley.Spec.Ledger.STS.Tickn as SL
 import qualified Shelley.Spec.Ledger.UTxO as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger
@@ -202,12 +204,17 @@ protocolInfoShelley genesis initialNonce maxMajorPV protVer mbCredentials =
 
     initChainDepState :: State.TPraosState c
     initChainDepState = State.empty Origin $
-      SL.PrtclState
-         (SL.chainOCertIssue     initShelleyState)
-         (SL.chainEpochNonce     initShelleyState)
-         (SL.chainEvolvingNonce  initShelleyState)
-         (SL.chainCandidateNonce initShelleyState)
-         (SL.chainPrevEpochNonce initShelleyState)
+      SL.ChainDepState {
+          SL.csProtocol = SL.PrtclState
+            (SL.chainOCertIssue     initShelleyState)
+            (SL.chainEvolvingNonce  initShelleyState)
+            (SL.chainCandidateNonce initShelleyState)
+        , SL.csTickn = SL.TicknState
+            (SL.chainEpochNonce     initShelleyState)
+            (SL.chainPrevEpochNonce initShelleyState)
+        , SL.csLabNonce =
+            (SL.chainPrevEpochNonce initShelleyState)
+        }
 
     initialEpochNo :: EpochNo
     initialEpochNo = 0

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Util.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Util.hs
@@ -4,16 +4,12 @@
 -- package from cardano-ledger-specs.
 module Ouroboros.Consensus.Shelley.Protocol.Util (
     isNewEpoch
-  , prtclStateEta0
   ) where
 
 import           Cardano.Slotting.EpochInfo
 import           Data.Functor.Identity (Identity (..))
 
 import           Ouroboros.Consensus.Block
-
-import qualified Shelley.Spec.Ledger.BaseTypes as SL
-import qualified Shelley.Spec.Ledger.STS.Prtcl as STS
 
 -- | Verify whether a slot represents a change to a new epoch with regard to
 -- some other slot.
@@ -32,8 +28,3 @@ isNewEpoch ei newSlot referenceWO = runIdentity $ do
     reference = fromWithOrigin genesisSlotNo referenceWO
     -- TODO
     genesisSlotNo = SlotNo 0
-
-prtclStateEta0
-  :: STS.State (STS.PRTCL c)
-  -> SL.Nonce
-prtclStateEta0 (STS.PrtclState _ eta0 _ _ _) = eta0

--- a/stack.yaml
+++ b/stack.yaml
@@ -50,7 +50,7 @@ extra-deps:
       - slotting
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: c4cce950ff1539a077ef527341b20f21fe4793e6
+    commit: 12b13f390d64df6af6054b0d33bb3767756da041
     subdirs:
       - byron/chain/executable-spec
       - byron/ledger/executable-spec


### PR DESCRIPTION
This re-enables the PBFT VRF checks. These now seem to be passing
consensus tests.

Note that currently this references an unmerged branch - I want to verify the changes here before re-enabling this back in the ledger specs.