### PR TITLE
ChainDB: optimise chain selection for forks

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -89,6 +89,15 @@ instance IsLedger (LedgerState ByronBlock) where
                                       byronLedgerState
         }
 
+  ledgerTipPoint (ByronLedgerState state _) =
+      case CC.cvsPreviousHash state of
+        -- In this case there are no blocks in the ledger state. The genesis
+        -- block does not occupy a slot, so its point is Origin.
+        Left _genHash -> GenesisPoint
+        Right hdrHash -> BlockPoint slot (ByronHash hdrHash)
+          where
+            slot = fromByronSlotNo (CC.cvsLastSlot state)
+
 instance ApplyBlock (LedgerState ByronBlock) ByronBlock where
   applyLedgerBlock = applyByronBlock validationMode
     where
@@ -99,15 +108,6 @@ instance ApplyBlock (LedgerState ByronBlock) ByronBlock where
         applyByronBlock validationMode cfg blk st
     where
       validationMode = CC.fromBlockValidationMode CC.NoBlockValidation
-
-  ledgerTipPoint (ByronLedgerState state _) =
-      case CC.cvsPreviousHash state of
-        -- In this case there are no blocks in the ledger state. The genesis
-        -- block does not occupy a slot, so its point is Origin.
-        Left _genHash -> GenesisPoint
-        Right hdrHash -> BlockPoint slot (ByronHash hdrHash)
-          where
-            slot = fromByronSlotNo (CC.cvsLastSlot state)
 
 data instance LedgerState ByronBlock = ByronLedgerState {
       byronLedgerState       :: !CC.ChainValidationState

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -56,6 +56,13 @@ instance IsLedger (LedgerState ByronSpecBlock) where
           (toByronSpecSlotNo       slot)
           (byronSpecLedgerState    state)
 
+  ledgerTipPoint state =
+      case byronSpecLedgerTip state of
+        Nothing   -> GenesisPoint
+        Just slot -> BlockPoint
+                       slot
+                       (getChainStateHash (byronSpecLedgerState state))
+
 instance ApplyBlock (LedgerState ByronSpecBlock) ByronSpecBlock where
   applyLedgerBlock cfg block (Ticked slot state) =
     withExcept ByronSpecLedgerError $
@@ -78,13 +85,6 @@ instance ApplyBlock (LedgerState ByronSpecBlock) ByronSpecBlock where
       dontExpectError mb = case runExcept mb of
         Left  _ -> error "reapplyLedgerBlock: unexpected error"
         Right b -> b
-
-  ledgerTipPoint state =
-      case byronSpecLedgerTip state of
-        Nothing   -> GenesisPoint
-        Just slot -> BlockPoint
-                       slot
-                       (getChainStateHash (byronSpecLedgerState state))
 
 data instance LedgerState ByronSpecBlock = ByronSpecLedgerState {
       -- | Tip of the ledger (most recently applied block, if any)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -182,6 +182,8 @@ instance TPraosCrypto c => IsLedger (LedgerState (ShelleyBlock c)) where
         . ShelleyLedgerState pt history
         $ SL.applyTickTransition (shelleyLedgerGlobals cfg) bhState slotNo
 
+  ledgerTipPoint = castPoint . ledgerTip
+
 instance TPraosCrypto c
       => ApplyBlock (LedgerState (ShelleyBlock c)) (ShelleyBlock c) where
   -- Note: in the Shelley ledger, the @CHAIN@ rule is used to apply a whole
@@ -234,8 +236,6 @@ instance TPraosCrypto c
       Right ledgerState' -> ledgerState'
       Left  err          -> error $
         "Reapplication of Shelley ledger block failed: " <> show err
-
-  ledgerTipPoint = ledgerTip
 
 data instance LedgerState (ShelleyBlock c) = ShelleyLedgerState {
       ledgerTip    :: !(Point (ShelleyBlock c))

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -308,6 +308,7 @@ instance MockProtocolSpecific c ext
   type LedgerErr (LedgerState (SimpleBlock c ext)) = MockError (SimpleBlock c ext)
 
   applyChainTick _ = Ticked
+  ledgerTipPoint (SimpleLedgerState st) = castPoint $ mockTip st
 
 instance MockProtocolSpecific c ext
       => ApplyBlock (LedgerState (SimpleBlock c ext)) (SimpleBlock c ext) where
@@ -316,7 +317,6 @@ instance MockProtocolSpecific c ext
     where
       mustSucceed (Left  err) = error ("reapplyLedgerBlock: unexpected error: " <> show err)
       mustSucceed (Right st)  = st
-  ledgerTipPoint (SimpleLedgerState st) = mockTip st
 
 newtype instance LedgerState (SimpleBlock c ext) = SimpleLedgerState {
       simpleLedgerState :: MockState (SimpleBlock c ext)
@@ -415,7 +415,7 @@ instance MockProtocolSpecific c ext => QueryLedger (SimpleBlock c ext) where
   data Query (SimpleBlock c ext) result where
       QueryLedgerTip :: Query (SimpleBlock c ext) (Point (SimpleBlock c ext))
 
-  answerQuery _cfg QueryLedgerTip = ledgerTipPoint
+  answerQuery _cfg QueryLedgerTip = castPoint . ledgerTipPoint
 
   eqQuery QueryLedgerTip QueryLedgerTip = Just Refl
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -721,7 +721,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                   where
                     EpochNo   x = currentEpoch
                     EpochSize y = epochSize0
-            let p = ledgerTipPoint $ tickedLedgerState tickedLdgSt
+            let p = ledgerTipPoint' (Proxy @blk) $ tickedLedgerState tickedLdgSt
 
             let needEBB = inFirstEra && NotOrigin ebbSlot > pointSlot p
             case mbForgeEbbEnv <* guard needEBB of

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -281,6 +281,8 @@ instance IsLedger (LedgerState TestBlock) where
 
   applyChainTick _ = Ticked
 
+  ledgerTipPoint = castPoint . lastAppliedPoint
+
 instance ApplyBlock (LedgerState TestBlock) TestBlock where
   applyLedgerBlock _ tb@TestBlock{..} (Ticked _ TestLedger{..})
     | blockPrevHash tb /= pointHash lastAppliedPoint
@@ -291,8 +293,6 @@ instance ApplyBlock (LedgerState TestBlock) TestBlock where
     = return     $ TestLedger (Chain.blockPoint tb)
 
   reapplyLedgerBlock _ tb _ = TestLedger (Chain.blockPoint tb)
-
-  ledgerTipPoint = lastAppliedPoint
 
 newtype instance LedgerState TestBlock =
     TestLedger {

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -473,6 +473,7 @@ test-suite test-storage
                        Test.Ouroboros.Storage.ChainDB.Model
                        Test.Ouroboros.Storage.ChainDB.Model.Test
                        Test.Ouroboros.Storage.ChainDB.StateMachine
+                       Test.Ouroboros.Storage.ChainDB.VolDB
                        Test.Ouroboros.Storage.FS
                        Test.Ouroboros.Storage.FS.StateMachine
                        Test.Ouroboros.Storage.ImmutableDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
@@ -46,7 +46,7 @@ data CheckInFuture m blk = CheckInFuture {
        -- | POSTCONDITION:
        -- > checkInFuture vf >>= \(af, fut) ->
        -- >   validatedFragment vf == af <=> null fut
-       checkInFuture :: ValidatedFragment blk (LedgerState blk)
+       checkInFuture :: ValidatedFragment (Header blk) (LedgerState blk)
                      -> m (AnchoredFragment (Header blk), [InFuture blk])
     }
   deriving NoUnexpectedThunks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Validated.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Validated.hs
@@ -56,7 +56,7 @@ invariant ValidatedFragment{..}
     = Right ()
   where
    ledgerTip, headPoint :: Point blk
-   ledgerTip = ledgerTipPoint validatedLedger
+   ledgerTip = castPoint $ ledgerTipPoint validatedLedger
    headPoint = castPoint $ AF.headPoint validatedFragment
 
 -- | Constructor for 'ValidatedFragment' that checks the invariant

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/ValidatedDiff.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/ValidatedDiff.hs
@@ -14,6 +14,7 @@ module Ouroboros.Consensus.Fragment.ValidatedDiff
 import           Control.Monad.Except (throwError)
 import           GHC.Stack (HasCallStack)
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Fragment.Diff
 import           Ouroboros.Consensus.Fragment.Validated (ValidatedFragment)
 import qualified Ouroboros.Consensus.Fragment.Validated as VF
@@ -52,7 +53,7 @@ new chainDiff ledger =
     UnsafeValidatedChainDiff chainDiff ledger
   where
     chainDiffTip = getTip chainDiff
-    ledgerTip    = ledgerTipPoint ledger
+    ledgerTip    = castPoint $ ledgerTipPoint ledger
     precondition
       | chainDiffTip == ledgerTip
       = return ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/ValidatedDiff.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/ValidatedDiff.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
 -- | Intended for qualified import
 --
 -- > import Ouroboros.Consensus.Fragment.ValidatedDiff (ValidatedChainDiff (..))
@@ -9,13 +11,15 @@ module Ouroboros.Consensus.Fragment.ValidatedDiff
   , getLedger
   , new
   , toValidatedFragment
+  , rollbackExceedsSuffix
   ) where
 
 import           Control.Monad.Except (throwError)
 import           GHC.Stack (HasCallStack)
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Fragment.Diff
+import           Ouroboros.Consensus.Fragment.Diff (ChainDiff)
+import qualified Ouroboros.Consensus.Fragment.Diff as Diff
 import           Ouroboros.Consensus.Fragment.Validated (ValidatedFragment)
 import qualified Ouroboros.Consensus.Fragment.Validated as VF
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -26,15 +30,15 @@ import           Ouroboros.Consensus.Util.Assert
 -- INVARIANT:
 --
 -- > getTip chainDiff == ledgerTipPoint ledger
-data ValidatedChainDiff blk l = UnsafeValidatedChainDiff
-    { getChainDiff :: ChainDiff blk
+data ValidatedChainDiff b l = UnsafeValidatedChainDiff
+    { getChainDiff :: ChainDiff b
     , getLedger    :: l
     }
 
 -- | Allow for pattern matching on a 'ValidatedChainDiff' without exposing the
 -- (unsafe) constructor. Use 'new' to construct a 'ValidatedChainDiff'.
 pattern ValidatedChainDiff
-  :: ChainDiff blk -> l -> ValidatedChainDiff blk l
+  :: ChainDiff b -> l -> ValidatedChainDiff b l
 pattern ValidatedChainDiff d l <- UnsafeValidatedChainDiff d l
 {-# COMPLETE ValidatedChainDiff #-}
 
@@ -43,16 +47,18 @@ pattern ValidatedChainDiff d l <- UnsafeValidatedChainDiff d l
 -- PRECONDITION:
 --
 -- > getTip chainDiff == ledgerTipPoint ledger
-new
-  :: (ApplyBlock l blk, HasCallStack)
-  => ChainDiff blk
+new ::
+     forall b l.
+     (IsLedger l, HasHeader b, HeaderHash l ~ HeaderHash b, HasCallStack)
+  => ChainDiff b
   -> l
-  -> ValidatedChainDiff blk l
+  -> ValidatedChainDiff b l
 new chainDiff ledger =
     assertWithMsg precondition $
     UnsafeValidatedChainDiff chainDiff ledger
   where
-    chainDiffTip = getTip chainDiff
+    chainDiffTip, ledgerTip :: Point b
+    chainDiffTip = Diff.getTip chainDiff
     ledgerTip    = castPoint $ ledgerTipPoint ledger
     precondition
       | chainDiffTip == ledgerTip
@@ -63,8 +69,11 @@ new chainDiff ledger =
           show chainDiffTip <> " /= " <> show ledgerTip
 
 toValidatedFragment
-  :: (ApplyBlock l blk, HasCallStack)
-  => ValidatedChainDiff blk l
-  -> ValidatedFragment blk l
+  :: (IsLedger l, HasHeader b, HeaderHash l ~ HeaderHash b, HasCallStack)
+  => ValidatedChainDiff b l
+  -> ValidatedFragment b l
 toValidatedFragment (UnsafeValidatedChainDiff cs l) =
-    VF.new (getSuffix cs) l
+    VF.new (Diff.getSuffix cs) l
+
+rollbackExceedsSuffix :: HasHeader b => ValidatedChainDiff b l -> Bool
+rollbackExceedsSuffix = Diff.rollbackExceedsSuffix . getChainDiff

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -253,13 +253,15 @@ instance SingleEraBlock b => IsLedger (LedgerState (DegenFork b)) where
 
   applyChainTick cfg slot (DLgr lgr) = DLgr <$> applyChainTick cfg slot lgr
 
+  ledgerTipPoint (DLgr l) =
+    (castPoint :: Point (LedgerState (HardForkBlock '[b])) -> Point (LedgerState (DegenFork b))) $
+    ledgerTipPoint l
+
 instance NoHardForks b => ApplyBlock (LedgerState (DegenFork b)) (DegenFork b) where
   applyLedgerBlock cfg (DBlk b) (Ticked slot (DLgr lgr)) =
     DLgr <$> applyLedgerBlock cfg b (Ticked slot lgr)
   reapplyLedgerBlock cfg (DBlk b) (Ticked slot (DLgr lgr)) =
     DLgr $ reapplyLedgerBlock cfg b (Ticked slot lgr)
-  ledgerTipPoint (DLgr l) =
-    (castPoint :: Point (HardForkBlock '[b]) -> Point (DegenFork b)) $ ledgerTipPoint l
 
 instance NoHardForks b => UpdateLedger (DegenFork b)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -112,10 +112,13 @@ applyHelper apply
           Match.bihcmap proxySingle singleEraInfo ledgerInfo mismatch
       Right matched ->
         fmap (fmap HardForkLedgerState . State.sequence) $ hsequence' $
-          hczipWith3 proxySingle applyCurrent cfgs injections matched
+          hczipWith3 proxySingle applyCurrent cfgs errInjections matched
   where
     cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
     ei   = State.epochInfoLedger hardForkConfig hardForkState
+
+    errInjections :: NP (Injection WrapApplyTxErr xs) xs
+    errInjections = injections
 
     applyCurrent
       :: forall blk. SingleEraBlock blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -253,12 +253,15 @@ update cfg@HardForkConsensusConfig{..}
          . State.tickAllPast hardForkConsensusConfigK
          . State.align
             (translateConsensus ei cfg)
-            (hczipWith proxySingle (fn_2 .: updateEra ei slot) cfgs injections)
+            (hczipWith proxySingle (fn_2 .: updateEra ei slot) cfgs errInjections)
             matched
          $ chainDepState
   where
     cfgs = getPerEraConsensusConfig hardForkConsensusConfigPerEra
     ei   = State.epochInfoLedgerView hardForkConsensusConfigShape ledgerView
+
+    errInjections :: NP (Injection WrapValidationErr xs) xs
+    errInjections = injections
 
 updateEra :: forall xs blk. SingleEraBlock blk
           => EpochInfo Identity

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -319,6 +319,10 @@ instance Bridge m a => IsLedger (LedgerState (DualBlock m a)) where
                   slot
                   dualLedgerStateAux
 
+  ledgerTipPoint = castPoint
+                 . (ledgerTipPoint :: LedgerState m -> Point (LedgerState m))
+                 . dualLedgerStateMain
+
 instance Bridge m a => ApplyBlock (LedgerState (DualBlock m a)) (DualBlock m a) where
   applyLedgerBlock DualLedgerConfig{..}
                    block@DualBlock{..}
@@ -358,10 +362,6 @@ instance Bridge m a => ApplyBlock (LedgerState (DualBlock m a)) (DualBlock m a) 
                                     block
                                     dualLedgerStateBridge
       }
-
-  ledgerTipPoint = castPoint
-                 . (ledgerTipPoint :: LedgerState m -> Point m)
-                 . dualLedgerStateMain
 
 data instance LedgerState (DualBlock m a) = DualLedgerState {
       dualLedgerStateMain   :: LedgerState m

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -115,6 +115,8 @@ _lemma_protocoLedgerView_applyLedgerBlock cfg blk st
 
 type instance LedgerCfg (ExtLedgerState blk) = TopLevelConfig blk
 
+type instance HeaderHash (ExtLedgerState blk) = HeaderHash (LedgerState blk)
+
 instance ( IsLedger (LedgerState  blk)
          , LedgerSupportsProtocol blk
          )
@@ -125,6 +127,8 @@ instance ( IsLedger (LedgerState  blk)
       Ticked slot $ ExtLedgerState ledger' header
     where
       Ticked _slot ledger' = applyChainTick (configLedger cfg) slot ledger
+
+  ledgerTipPoint = castPoint . ledgerTipPoint . ledgerState
 
 instance ( LedgerSupportsProtocol blk
          ) => ApplyBlock (ExtLedgerState blk) blk where
@@ -172,8 +176,6 @@ instance ( LedgerSupportsProtocol blk
 
       ledgerView :: LedgerView (BlockProtocol blk)
       ledgerView = protocolLedgerView (configLedger cfg) lgr
-
-  ledgerTipPoint = ledgerTipPoint . ledgerState
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -291,7 +291,9 @@ forkSyncStateOnTipPointChange registry menv =
 
     -- Using the tip ('Point') allows for quicker equality checks
     getCurrentTip :: STM m (Point blk)
-    getCurrentTip = ledgerTipPoint <$> getCurrentLedgerState (mpEnvLedger menv)
+    getCurrentTip =
+          ledgerTipPoint' (Proxy @blk)
+      <$> getCurrentLedgerState (mpEnvLedger menv)
 
 {-------------------------------------------------------------------------------
   Mempool Implementation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
@@ -49,7 +49,7 @@ data BlockFetchServerException =
       -- garbage collected. However, the network protocol will have timed out
       -- long before this happens.
       forall blk. (Typeable blk, StandardHash blk) =>
-        BlockGCed (HeaderHash blk)
+        BlockGCed (RealPoint blk)
 
       -- | Thrown when requesting the genesis block from the database
       --
@@ -119,9 +119,9 @@ blockFetchServer _tracer chainDB _version registry = senderSide
         IteratorExhausted      -> do
           ChainDB.iteratorClose it
           return $ SendMsgBatchDone $ return senderSide
-        IteratorBlockGCed hash -> do
+        IteratorBlockGCed pt -> do
           ChainDB.iteratorClose it
-          throwM $ BlockGCed @blk hash
+          throwM $ BlockGCed @blk pt
 
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -398,7 +398,7 @@ forkBlockProduction maxTxCapacityOverride IS{..} BlockProduction{..} =
             proof
         trace $ TraceForgedBlock
                   currentSlot
-                  (ledgerTipPoint (ledgerState extLedger))
+                  (ledgerTipPoint' (Proxy @blk) (ledgerState extLedger))
                   newBlock
                   (snapshotMempoolSize mempoolSnapshot)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -542,16 +542,16 @@ traverseIterator f it = it {
 data IteratorResult blk b =
     IteratorExhausted
   | IteratorResult b
-  | IteratorBlockGCed (HeaderHash blk)
+  | IteratorBlockGCed (RealPoint blk)
     -- ^ The block that was supposed to be streamed was garbage-collected from
     -- the VolatileDB, but not added to the ImmutableDB.
     --
     -- This will only happen when streaming very old forks very slowly.
   deriving (Functor, Foldable, Traversable)
 
-deriving instance (Eq   blk, Eq   b, Eq   (HeaderHash blk))
+deriving instance (Eq   blk, Eq   b, StandardHash blk)
                => Eq   (IteratorResult blk b)
-deriving instance (Show blk, Show b, Show (HeaderHash blk))
+deriving instance (Show blk, Show b, StandardHash blk)
                => Show (IteratorResult blk b)
 
 data UnknownRange blk =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -334,7 +334,8 @@ setCurrent :: IOLike m => LgrDB m blk -> LedgerDB blk -> STM m ()
 setCurrent LgrDB{..} = writeTVar $! varDB
 
 currentPoint :: UpdateLedger blk => LedgerDB blk -> Point blk
-currentPoint = ledgerTipPoint
+currentPoint = castPoint
+             . ledgerTipPoint
              . ledgerState
              . LedgerDB.ledgerDbCurrent
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -59,7 +59,6 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Types (
   ) where
 
 import           Control.Tracer
-import           Data.List.NonEmpty (NonEmpty)
 import           Data.Map.Strict (Map)
 import           Data.Time.Clock (DiffTime)
 import           Data.Typeable
@@ -76,6 +75,7 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.Fragment.Diff (ChainDiff)
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture)
 import           Ouroboros.Consensus.Ledger.Extended (ExtValidationError)
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
@@ -570,7 +570,7 @@ data TraceAddBlockEvent blk =
 
     -- | The block fits onto some fork, we'll try to switch to that fork (if
     -- it is preferable to our chain).
-  | TrySwitchToAFork (RealPoint blk) (NonEmpty (HeaderHash blk))
+  | TrySwitchToAFork (RealPoint blk) (ChainDiff (HeaderFields blk))
 
     -- | The block doesn't fit onto any other block, so we store it and ignore
     -- it.
@@ -714,7 +714,7 @@ data TraceIteratorEvent blk
   | StreamFromVolDB
       (StreamFrom blk)
       (StreamTo   blk)
-      [HeaderHash blk]
+      [RealPoint  blk]
 
     -- ^ Stream only from the VolatileDB.
   | StreamFromImmDB
@@ -725,17 +725,17 @@ data TraceIteratorEvent blk
   | StreamFromBoth
       (StreamFrom blk)
       (StreamTo   blk)
-      [HeaderHash blk]
+      [RealPoint  blk]
 
     -- ^ Stream from both the VolatileDB and the ImmutableDB.
-  | BlockMissingFromVolDB (HeaderHash blk)
+  | BlockMissingFromVolDB (RealPoint blk)
     -- ^ A block is no longer in the VolatileDB because it has been garbage
     -- collected. It might now be in the ImmutableDB if it was part of the
     -- current chain.
-  | BlockWasCopiedToImmDB (HeaderHash blk)
+  | BlockWasCopiedToImmDB (RealPoint blk)
     -- ^ A block that has been garbage collected from the VolatileDB is now
     -- found and streamed from the ImmutableDB.
-  | BlockGCedFromVolDB    (HeaderHash blk)
+  | BlockGCedFromVolDB    (RealPoint blk)
     -- ^ A block is no longer in the VolatileDB and isn't in the ImmutableDB
     -- either; it wasn't part of the current chain.
   | SwitchBackToVolDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
@@ -613,6 +613,7 @@ extractInfo :: GetPrevHash blk
 extractInfo b BinaryBlockInfo{..} = VolDB.BlockInfo {
       bbid          = blockHash b
     , bslot         = blockSlot b
+    , bbno          = blockNo   b
     , bpreBid       = fromChainHash (blockPrevHash b)
     , bisEBB        = blockToIsEBB b
     , bheaderOffset = headerOffset

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
@@ -24,9 +24,10 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.VolDB (
   , defaultArgs
   , openDB
     -- * Candidates
+  , LookupBlockInfo
   , candidates
+  , extendWithSuccessors
   , isReachable
-  , isReachableSTM
     -- * Paths
   , Path(..)
   , computePath
@@ -55,6 +56,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.VolDB (
     -- * Exported for testing purposes
   , mkVolDB
   , blockFileParser'
+  , fromChainHash
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)
@@ -64,9 +66,10 @@ import           Control.Tracer (Tracer, nullTracer)
 import           Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.ByteString.Short (ShortByteString)
+import           Data.Foldable (foldl')
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import           Data.Maybe (isJust, mapMaybe)
+import           Data.Maybe (fromMaybe, isJust, mapMaybe)
 import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
@@ -78,9 +81,13 @@ import           Streaming.Prelude (Of (..), Stream)
 import qualified Streaming.Prelude as S
 import           System.FilePath ((</>))
 
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
+import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (MaxSlotNo)
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Fragment.Diff (ChainDiff (..))
+import qualified Ouroboros.Consensus.Fragment.Diff as Diff
 import qualified Ouroboros.Consensus.Util.CBOR as Util.CBOR
 import           Ouroboros.Consensus.Util.IOLike
 
@@ -195,7 +202,7 @@ mkVolDB volDB getBinaryBlockInfo codecConfig = VolDB {..}
 
 getBlockInfo
   :: VolDB m blk
-  -> STM m (HeaderHash blk -> Maybe (VolDB.BlockInfo (HeaderHash blk)))
+  -> STM m (LookupBlockInfo blk)
 getBlockInfo db = withSTM db VolDB.getBlockInfo
 
 getIsMember :: Functor (STM m) => VolDB m blk -> STM m (HeaderHash blk -> Bool)
@@ -235,7 +242,7 @@ garbageCollect db slotNo = withDB db $ \vol ->
   Compute candidates
 -------------------------------------------------------------------------------}
 
--- | Compute all candidates starting at the specified hash
+-- | Compute all candidates starting at the specified point
 --
 -- PRECONDITION: the block to which the given point corresponds is part of the
 -- VolatileDB.
@@ -264,47 +271,271 @@ candidates succsOf b = mapMaybe NE.nonEmpty $ go (fromChainHash (pointHash b))
                , candidate <- go (NotOrigin next)
                ]
 
--- | Variant of 'isReachable' that obtains its arguments in the same 'STM'
--- transaction.
-isReachableSTM :: (IOLike m, HasHeader blk)
-               => VolDB m blk
-               -> STM m (Point blk) -- ^ The tip of the ImmutableDB (@I@).
-               -> RealPoint blk     -- ^ The point of the block (@B@) to check
-                                    -- the reachability of
-               -> STM m (Maybe (NonEmpty (HeaderHash blk)))
-isReachableSTM volDB getI b = do
-    (predecessor, i) <- (,) <$> getPredecessor volDB <*> getI
-    return $ isReachable predecessor i b
-
--- | Check whether the given point, corresponding to a block @B@, is reachable
--- from the tip of the ImmutableDB (@I@) by chasing the predecessors.
+-- | Extend the 'ChainDiff' with the successors found by 'candidates'.
 --
--- Returns a path (of hashes) from @I@ (excluded) to @B@ (included).
+-- In case no successors were found, the original 'ChainDiff' is returned as a
+-- singleton.
 --
--- PRECONDITION: @B ∈ V@, i.e. @B@ is part of the VolatileDB.
+-- In case successors /were/ found, the original 'ChainDiff' is /not/
+-- included, only its extensions.
 --
--- 'True' <=> for all transitive predecessors @B'@ of @B@ we have @B' ∈ V@ or
--- @B' = I@.
-isReachable :: forall blk. (HasHeader blk, HasCallStack)
-            => (HeaderHash blk -> Maybe (WithOrigin (HeaderHash blk)))
-            -> Point blk                                        -- ^ @I@
-            -> RealPoint blk                                    -- ^ @B@
-            -> Maybe (NonEmpty (HeaderHash blk))
-isReachable predecessor i b =
-    case computePath predecessor from to of
-      -- Bounds are not on the same fork
-      Nothing   -> Nothing
-      Just path -> case path of
-        CompletelyInVolDB hashes -> case NE.nonEmpty hashes of
-          Just hashes' -> Just hashes'
-          Nothing      ->
-            error "impossible: empty list of hashes with an inclusive bound"
-        PartiallyInVolDB  {}     -> Nothing
-        NotInVolDB        _      ->
-          error "impossible: block just added to VolatileDB missing"
+-- Only the longest possible extensions are returned, no intermediary prefixes
+-- of extensions.
+extendWithSuccessors ::
+     forall blk. HasHeader blk
+  => (WithOrigin (HeaderHash blk) -> Set (HeaderHash blk))
+  -> LookupBlockInfo blk
+  -> ChainDiff (HeaderFields blk)
+  -> NonEmpty (ChainDiff (HeaderFields blk))
+extendWithSuccessors succsOf lookupBlockInfo diff =
+    case NE.nonEmpty extensions of
+      Nothing          -> diff NE.:| []
+      Just extensions' -> extensions'
   where
-    from = StreamFromExclusive i
-    to   = StreamToInclusive   b
+    extensions =
+        [ foldl' Diff.append diff (lookupHeaderFields <$> candHashes)
+        | candHashes <- candidates succsOf (Diff.getTip diff)
+        ]
+
+    lookupHeaderFields :: HeaderHash blk -> HeaderFields blk
+    lookupHeaderFields =
+          headerFieldsFromBlockInfo
+          -- The successor mapping is populated with the blocks in the
+          -- VolatileDB, so looking up the block info of a successor /must/
+          -- succeed.
+        . fromMaybe (error "successor must in the VolatileDB")
+        . lookupBlockInfo
+
+{-------------------------------------------------------------------------------
+  Paths through the VolatileDB
+-------------------------------------------------------------------------------}
+
+-- | Return the block info for the block with the given hash. Return 'Nothing'
+-- when not in the VolatileDB.
+type LookupBlockInfo blk =
+  HeaderHash blk -> Maybe (VolDB.BlockInfo (HeaderHash blk))
+
+headerFieldsFromBlockInfo ::
+     VolDB.BlockInfo (HeaderHash blk)
+  -> HeaderFields blk
+headerFieldsFromBlockInfo VolDB.BlockInfo { bslot, bbid, bbno } =
+    HeaderFields {
+        headerFieldHash    = bbid
+      , headerFieldSlot    = bslot
+      , headerFieldBlockNo = bbno
+      }
+
+-- | A reverse path through the VolatileDB starting at a block in the
+-- VolatileDB until we reach genesis or leave the VolatileDB.
+data ReversePath blk =
+      -- | The path stopped at genesis
+      StoppedAtGenesis
+
+      -- | The path stopped at this hash, which is the hash of the predecessor
+      -- of the last block in the path (that was still stored in the
+      -- VolatileDB).
+      --
+      -- The block corresponding to the predecessor is /not/ stored in the
+      -- VolatileDB. Either because it is missing, or because it is old and
+      -- has been garbage collected.
+      --
+      -- Since block numbers are consecutive, we subtract 1 from the block
+      -- number of the last block to obtain the block number corresponding to
+      -- this hash.
+      --
+      -- EBBs share their block number with their predecessor:
+      --
+      -- > block:         regular block 1 | EBB | regular block 2
+      -- > block number:                X |   X | X + 1
+      --
+      -- So when the hash refers to regular block 1, we see that the successor
+      -- block is an EBB and use its block number without subtracting 1.
+      --
+      -- Edge case: if there are two or more consecutive EBBs, we might
+      -- predict the wrong block number, but there are no consecutive EBBs in
+      -- practice, they are one epoch apart.
+    | StoppedAt (HeaderHash blk) BlockNo
+
+      -- | Snoc: the block with the given 'HeaderFields' is in the VolatileDB.
+      -- We also track whether it is an EBB or not.
+      --
+      -- NOTE: we are intentionally lazy in the spine, as constructing the
+      -- path requires lookups in the VolatileDB's in-memory indices, which
+      -- are logarithmic in the size of the index.
+    | (ReversePath blk) ::> (HeaderFields blk, IsEBB)
+
+-- | Lazily compute the 'ReversePath' that starts (i.e., ends) with the given
+-- 'HeaderHash'.
+computeReversePath
+  :: forall blk.
+     LookupBlockInfo blk
+  -> HeaderHash blk
+     -- ^ End hash
+  -> Maybe (ReversePath blk)
+     -- ^ Reverse path from the end point to genesis or the first predecessor
+     -- not in the VolatileDB. Nothing when the end hash is not in the
+     -- VolatileDB.
+computeReversePath lookupBlockInfo endHash =
+    case lookupBlockInfo endHash of
+      Nothing                                               -> Nothing
+      Just blockInfo@VolDB.BlockInfo { bbno, bisEBB, bpreBid } -> Just $
+        go bpreBid bbno bisEBB ::> (headerFieldsFromBlockInfo blockInfo, bisEBB)
+  where
+    go ::
+         WithOrigin (HeaderHash blk)
+         -- ^ The predecessor of the last block added to the path. Not
+         -- necessarily in the VolatileDB.
+      -> BlockNo  -- ^ The block number of the last block
+      -> IsEBB    -- ^ Whether the last block is an EBB or not
+      -> ReversePath blk
+    go predecessor lastBlockNo lastIsEBB = case predecessor of
+      Origin             -> StoppedAtGenesis
+      NotOrigin prevHash -> case lookupBlockInfo prevHash of
+        Nothing ->
+          StoppedAt prevHash (prevBlockNo lastBlockNo lastIsEBB)
+        Just blockInfo@VolDB.BlockInfo { bbno, bisEBB, bpreBid } ->
+          go bpreBid bbno bisEBB ::> (headerFieldsFromBlockInfo blockInfo, bisEBB)
+
+    -- | Predict the block number of the missing predecessor.
+    --
+    -- PRECONDITION: the block number and 'IsEBB' correspond to a block that
+    -- has a predecessor.
+    --
+    -- For regular blocks, this is just block number - 1, EBBs are special of
+    -- course: they share their block number with their predecessor:
+    --
+    -- > block:         regular block 1 | EBB | regular block 2
+    -- > block number:                X |   X | X + 1
+    --
+    -- Edge case: if there are two or more consecutive EBBs, we might predict
+    -- the wrong block number, but there are no consecutive EBBs in practice
+    -- (nor in the tests), they are one epoch apart.
+    prevBlockNo :: BlockNo -> IsEBB -> BlockNo
+    prevBlockNo bno isEBB = case (bno, isEBB) of
+      (0, IsNotEBB) -> error "precondition violated"
+      (_, IsNotEBB) -> bno - 1
+      (_, IsEBB)    -> bno
+
+{-------------------------------------------------------------------------------
+  Reachability
+-------------------------------------------------------------------------------}
+
+-- | Try to connect the point @P@ to the chain fragment by chasing the
+-- predecessors.
+--
+-- When successful, return a 'ChainDiff': the number of blocks to roll back
+-- the chain fragment to the intersection point and a fragment anchored at the
+-- intersection point containing the 'HeaderFields' corresponding to the
+-- blocks needed to connect to @P@. The intersection point will be the most
+-- recent intersection point.
+--
+-- Returns 'Nothing' when @P@ is not in the VolatileDB or when @P@ is not
+-- connected to the given chain fragment.
+--
+-- POSTCONDITION: the returned number of blocks to roll back is less than or
+-- equal to the length of the given chain fragment.
+--
+-- Note that the number of returned points can be smaller than the number of
+-- blocks to roll back. This means @P@ is on a fork shorter than the given
+-- chain fragment.
+--
+-- A 'ChainDiff' is returned iff @P@ is on the chain fragment. Moreover, when
+-- the number of blocks to roll back is also 0, it must be that @P@ is the tip
+-- of the chain fragment.
+--
+-- When the suffix of the 'ChainDiff' is non-empty, @P@ will be the last point
+-- in the suffix.
+isReachable
+  :: forall blk. (HasHeader blk, GetHeader blk, HasCallStack)
+  => LookupBlockInfo blk
+  -> AnchoredFragment (Header blk) -- ^ Chain fragment to connect the point to
+  -> RealPoint blk
+  -> Maybe (ChainDiff (HeaderFields blk))
+isReachable lookupBlockInfo = \chain b ->
+    case computeReversePath lookupBlockInfo (realPointHash b) of
+      -- Block not in the VolatileDB, so it's unreachable
+      Nothing          -> Nothing
+      Just reversePath -> go chain reversePath 0 []
+  where
+    -- | NOTE: the 'ReversePath' is lazy in its spine. We will only force as
+    -- many elements as 'RealPoint's we return. In the worst case, the path is
+    -- not connected to the current chain at all, in which case we do force
+    -- the entire path.
+    --
+    -- We're trying to find a common block, i.e., one with the same point and
+    -- thus the same slot. Both the chain and the path are ordered by slots,
+    -- so we compare the slots and drop the largest one until we have a match
+    -- in slot, then we check hashes. If those don't match, we drop both.
+    -- Note: EBBs complicate things, see 'ebbAwareCompare'.
+    go
+      :: AnchoredFragment (Header blk)
+         -- ^ Prefix of the current chain
+      -> ReversePath blk
+         -- ^ Prefix of the path through the VolatileDB
+      -> Word64
+         -- ^ Number of blocks we have had to roll back from the current chain
+      -> [HeaderFields blk]
+         -- ^ Accumulator for the suffix, from oldest to newest
+      -> Maybe (ChainDiff (HeaderFields blk))
+    go chain path !rollback acc = case (chain, path) of
+        (AF.Empty anchor, StoppedAt hash bno)
+          | AF.anchorToBlockNo anchor == NotOrigin bno
+          , AF.anchorToHash anchor == BlockHash hash
+          -> Just (ChainDiff rollback (AF.fromOldestFirst (AF.castAnchor anchor) acc))
+          | otherwise
+          -> Nothing
+
+        (AF.Empty anchor, path' ::> (flds, _))
+          | AF.anchorToHeaderFields (AF.castAnchor anchor) == NotOrigin flds
+          -> Just (ChainDiff rollback (AF.fromOldestFirst (AF.castAnchor anchor) acc))
+          | AF.anchorToBlockNo anchor > NotOrigin (headerFieldBlockNo flds)
+          -> Nothing
+          | otherwise
+          -> go chain path' rollback (flds:acc)
+
+        (chain' AF.:> hdr, StoppedAt hash bno)
+          | blockNo hdr == bno
+          , headerHash hdr == hash
+          , let anchor = AF.castAnchor (AF.anchorFromBlock hdr)
+          -> Just (ChainDiff rollback (AF.fromOldestFirst anchor acc))
+          | blockNo hdr < bno
+          -> Nothing
+          | otherwise
+          -> go chain' path (rollback + 1) acc
+
+        (_, StoppedAtGenesis)
+          | AF.anchorIsGenesis (AF.anchor chain)
+          -> let !rollback' = rollback + fromIntegral (AF.length chain)
+             in Just (ChainDiff rollback' (AF.fromOldestFirst AF.AnchorGenesis acc))
+          | otherwise
+          -> Nothing
+
+        (chain' AF.:> hdr, path' ::> (flds, ptIsEBB)) ->
+          case hdr `ebbAwareCompare` (headerFieldBlockNo flds, ptIsEBB) of
+            -- Drop from the path
+            LT -> go chain path' rollback (flds:acc)
+            -- Drop from the current chain fragment
+            GT -> go chain' path (rollback + 1) acc
+            -- Same slot and value for 'IsEBB'
+            EQ | blockHash hdr == headerFieldHash flds
+               , let anchor = AF.castAnchor (AF.anchorFromBlock hdr)
+               -- Found a match
+               -> Just (ChainDiff rollback (AF.fromOldestFirst anchor acc))
+               -- Different hashes, drop both
+               | otherwise
+               -> go chain' path' (rollback + 1) (flds:acc)
+
+    -- | EBBs have the same block number as their predecessor, which means
+    -- that in case we have an EBB and a regular block with the same slot, the
+    -- EBB comes /after/ the regular block.
+    ebbAwareCompare :: Header blk -> (BlockNo, IsEBB) -> Ordering
+    ebbAwareCompare hdr (ptBlockNo, ptIsEBB) =
+      compare (blockNo hdr) ptBlockNo `mappend`
+      case (headerToIsEBB hdr, ptIsEBB) of
+        (IsEBB,    IsNotEBB) -> GT
+        (IsNotEBB, IsEBB)    -> LT
+        (IsEBB,    IsEBB)    -> EQ
+        (IsNotEBB, IsNotEBB) -> EQ
 
 {-------------------------------------------------------------------------------
   Compute paths
@@ -318,56 +549,92 @@ isReachable predecessor i b =
 -- If the range is invalid, 'Nothing' is returned.
 --
 -- See the documentation of 'Path'.
-computePath
-  :: forall blk. HasHeader blk
-  => (HeaderHash blk -> Maybe (WithOrigin (HeaderHash blk)))
-     -- Return the predecessor
+computePath ::
+     forall blk. HasHeader blk
+  => LookupBlockInfo blk
   -> StreamFrom blk
   -> StreamTo   blk
   -> Maybe (Path blk)
-computePath predecessor from to = case to of
-    StreamToInclusive (RealPoint _ end)
-      | Just prev <- predecessor end -> case from of
-          -- Easier to handle this special case (@StreamFromInclusive start,
-          -- StreamToInclusive end, start == end@) here:
-          StreamFromInclusive (RealPoint _ start)
-            | start == end -> return $ CompletelyInVolDB [end]
-          _                -> go [end] prev
-      | otherwise        -> return $ NotInVolDB end
-    StreamToExclusive (RealPoint _ end)
-      | Just prev <- predecessor end -> go [] prev
-      | otherwise                    -> return $ NotInVolDB end
+computePath lookupBlockInfo from to =
+    case computeReversePath lookupBlockInfo (realPointHash endPt) of
+      Nothing
+        -> Just $ NotInVolDB endPt
+      Just volPath
+        | exclUpperBound
+        -- When there's an exclusive upper bound, we must exclude the first
+        -- point of the reverse path from the returned 'Path'. We simply drop
+        -- it from the path before starting the main loop (@go@).
+        -> case volPath of
+             volPath' ::> _   -> go [] volPath'
+             -- If we're immediately stopped, the accumulator will be empty,
+             -- so no need to drop the last element. Reuse the termination
+             -- logic of @go@.
+             StoppedAt {}     -> go [] volPath
+             -- The exclusive end bound cannot be genesis, as it must be a
+             -- 'RealPoint', so the reverse path cannot start with
+             -- 'StoppedAtGenesis'.
+             StoppedAtGenesis -> error "exclusive end bound cannot be genesis"
+        | otherwise
+        -> go [] volPath
   where
-    -- | It only needs the predecessor @prev@ and not the actual hash, because
-    -- the hash is already added to @acc@ (if allowed by the bounds).
-    go :: [HeaderHash blk] -> WithOrigin (HeaderHash blk) -> Maybe (Path blk)
-    go acc prev = case prev of
-      -- Found genesis
-      Origin -> case from of
-        StreamFromInclusive _
-          -> Nothing
-        StreamFromExclusive GenesisPoint
-          -> return $ CompletelyInVolDB acc
-        StreamFromExclusive (BlockPoint {})
+    (endPt, exclUpperBound) = case to of
+        StreamToInclusive pt -> (pt, False)
+        StreamToExclusive pt -> (pt, True)
+
+    fieldsToRealPoint :: HeaderFields blk -> RealPoint blk
+    fieldsToRealPoint flds =
+        RealPoint (headerFieldSlot flds) (headerFieldHash flds)
+
+    -- | Convert the 'HeaderFields' to a 'RealPoint' and prepend that to the
+    -- accumulator.
+    --
+    -- NOTE: we will store the returned list in the state of a ChainDB
+    -- iterator as a lazy non-empty list. To avoid thunks, we force the
+    -- elements now, when adding them to the accumulator. TODO #2341
+    addToAcc :: HeaderFields blk -> [RealPoint blk] -> [RealPoint blk]
+    addToAcc flds pts = pt : pts
+        -- When the returned list is forced, @pt@ is forced. The returned list
+        -- is forced because the accumulator is forced in @go@.
+      where
+        !pt = fieldsToRealPoint flds
+
+    go ::
+         [RealPoint blk]  -- ^ Accumulator for the 'Path'
+      -> ReversePath blk  -- ^ Prefix of the path to 'StreamFrom'
+      -> Maybe (Path blk)
+    go !acc = \case
+        StoppedAtGenesis
+          | StreamFromExclusive GenesisPoint <- from
+          -> Just $ CompletelyInVolDB acc
+          | otherwise
+            -- If 'StreamFrom' was not from genesis, then the range must be
+            -- invalid.
           -> Nothing
 
-      NotOrigin predHash
-        | Just prev' <- predecessor predHash -> case from of
-          StreamFromInclusive pt
-            | predHash == realPointHash pt
-            -> return $ CompletelyInVolDB (predHash : acc)
-          StreamFromExclusive pt
-            | BlockHash predHash == pointHash pt
-            -> return $ CompletelyInVolDB acc
-          -- Bound not yet reached, invariants both ok!
-          _ -> go (predHash : acc) prev'
-        -- Predecessor not in the VolatileDB
-        | StreamFromExclusive pt <- from
-        , BlockHash predHash == pointHash pt
-          -- That's fine if we don't need to include it in the path.
-        -> return $ CompletelyInVolDB acc
-        | otherwise
-        -> return $ PartiallyInVolDB predHash acc
+        StoppedAt hash _bno
+          | StreamFromExclusive GenesisPoint <- from
+          -> Just $ PartiallyInVolDB hash acc
+          | StreamFromExclusive (BlockPoint _ hash') <- from
+          , hash == hash'
+          -> Just $ CompletelyInVolDB acc
+          | StreamFromExclusive (BlockPoint _ _) <- from
+          -> Just $ PartiallyInVolDB hash acc
+          | StreamFromInclusive _ <- from
+          -> Just $ PartiallyInVolDB hash acc
+
+        volPath' ::> (flds, _isEBB)
+          | StreamFromExclusive GenesisPoint <- from
+          -> go (addToAcc flds acc) volPath'
+          | StreamFromExclusive (BlockPoint _ hash') <- from
+          , headerFieldHash flds == hash'
+          -> Just $ CompletelyInVolDB acc
+          | StreamFromExclusive (BlockPoint _ _) <- from
+          -> go (addToAcc flds acc) volPath'
+          | StreamFromInclusive pt' <- from
+          , fieldsToRealPoint flds == pt'
+          -> Just $ CompletelyInVolDB (addToAcc flds acc)
+          | StreamFromInclusive _ <- from
+          -> go (addToAcc flds acc) volPath'
 
 -- | Variant of 'computePath' that obtains its arguments in the same 'STM'
 -- transaction. Throws an 'InvalidIteratorRange' exception when the range is
@@ -379,23 +646,23 @@ computePathSTM
   -> StreamTo   blk
   -> STM m (Path blk)
 computePathSTM volDB from to = do
-    predecessor <- getPredecessor volDB
-    case computePath predecessor from to of
+    lookupBlockInfo <- getBlockInfo volDB
+    case computePath lookupBlockInfo from to of
       Just path -> return path
       Nothing   -> throwM $ InvalidIteratorRange from to
 
 -- | A path through the VolatileDB from a 'StreamFrom' to a 'StreamTo'.
 --
 -- Invariant: the @ChainFragment@ (oldest first) constructed using the blocks
--- corresponding to the hashes in the path will be valid, i.e. the blocks will
--- fit onto each other.
-data Path blk
-  = NotInVolDB (HeaderHash blk)
+-- corresponding to the points in the path will be valid, i.e., the blocks
+-- will fit onto each other.
+data Path blk =
+    NotInVolDB (RealPoint blk)
     -- ^ The @end@ point (@'StreamToInclusive' end@ or @'StreamToExclusive'
     -- end@) was not part of the VolatileDB.
-  | CompletelyInVolDB [HeaderHash blk]
+  | CompletelyInVolDB [RealPoint blk]
     -- ^ A complete path, from start point to end point was constructed from
-    -- the VolatileDB. The list contains the hashes from oldest to newest.
+    -- the VolatileDB. The list contains the points from oldest to newest.
     --
     -- * If the lower bound was @'StreamFromInclusive' pt@, then @pt@ will be
     --   the first element of the list.
@@ -406,10 +673,10 @@ data Path blk
     --   the last element of the list.
     -- * If the upper bound was @'StreamToExclusive' pt@, then the last
     --   element of the list will correspond to the first block before @pt@.
-  | PartiallyInVolDB (HeaderHash blk) [HeaderHash blk]
+  | PartiallyInVolDB (HeaderHash blk) [RealPoint blk]
     -- ^ Only a partial path could be constructed from the VolatileDB. The
     -- missing predecessor could still be in the ImmutableDB. The list
-    -- contains the hashes from oldest to newest.
+    -- contains the points from oldest to newest.
     --
     -- * The first element in the list is the point for which no predecessor
     --   is available in the VolatileDB. The block corresponding to the point
@@ -423,7 +690,8 @@ data Path blk
     --
     -- The same invariants hold for the upper bound as for 'StartToEnd'.
 
-deriving instance Show (HeaderHash blk) => Show (Path blk)
+deriving instance HasHeader blk => Eq   (Path blk)
+deriving instance HasHeader blk => Show (Path blk)
 
 {-------------------------------------------------------------------------------
   Getting and parsing blocks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -774,6 +774,8 @@ ledgerDbSwitch cfg numRollbacks newBlocks db = do
 
 type instance LedgerCfg (LedgerDB l r) = LedgerCfg l
 
+type instance HeaderHash (LedgerDB l r) = HeaderHash l
+
 instance ( IsLedger l
            -- Required superclass constraints of 'IsLedger'
          , Show               r
@@ -787,6 +789,9 @@ instance ( IsLedger l
     where
       Ticked _slot l' = applyChainTick cfg slot (ledgerDbCurrent db)
 
+  ledgerTipPoint =
+      castPoint . ledgerTipPoint . ledgerDbCurrent
+
 instance ApplyBlock l blk => ApplyBlock (LedgerDB l (RealPoint blk)) blk where
   applyLedgerBlock cfg blk (Ticked slot db) = do
       fmap (\current' -> pushLedgerState current' (blockRealPoint blk) db) $
@@ -796,8 +801,6 @@ instance ApplyBlock l blk => ApplyBlock (LedgerDB l (RealPoint blk)) blk where
       (\current' -> pushLedgerState current' (blockRealPoint blk) db) $
         reapplyLedgerBlock cfg blk $
           Ticked slot (ledgerDbCurrent db)
-  ledgerTipPoint =
-      ledgerTipPoint . ledgerDbCurrent
 
 {-------------------------------------------------------------------------------
   Suppor for testing

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Types.hs
@@ -166,6 +166,7 @@ data ParsedBlockInfo blockId = ParsedBlockInfo {
 data BlockInfo blockId = BlockInfo {
       bbid          :: !blockId
     , bslot         :: !SlotNo
+    , bbno          :: !BlockNo
     , bpreBid       :: !(WithOrigin blockId)
     , bisEBB        :: !IsEBB
     , bheaderOffset :: !Word16

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -216,6 +216,7 @@ type instance LedgerCfg (LedgerState BlockA) =
 instance IsLedger (LedgerState BlockA) where
   type LedgerErr (LedgerState BlockA) = Void
   applyChainTick _ = Ticked
+  ledgerTipPoint   = castPoint . lgrA_tip
 
 instance ApplyBlock (LedgerState BlockA) BlockA where
   applyLedgerBlock cfg blk =
@@ -229,8 +230,6 @@ instance ApplyBlock (LedgerState BlockA) BlockA where
       case runExcept $ applyLedgerBlock cfg blk st of
         Left  _   -> error "reapplyLedgerBlock: impossible"
         Right st' -> st'
-
-  ledgerTipPoint = lgrA_tip
 
 instance UpdateLedger BlockA
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -184,11 +184,11 @@ type instance LedgerCfg (LedgerState BlockB) = ()
 instance IsLedger (LedgerState BlockB) where
   type LedgerErr (LedgerState BlockB) = Void
   applyChainTick _ = Ticked
+  ledgerTipPoint   = castPoint . lgrB_tip
 
 instance ApplyBlock (LedgerState BlockB) BlockB where
   applyLedgerBlock   = \_ b _ -> return $ LgrB (blockPoint b)
   reapplyLedgerBlock = \_ b _ -> LgrB (blockPoint b)
-  ledgerTipPoint     = lgrB_tip
 
 instance UpdateLedger BlockB
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB.hs
@@ -8,6 +8,7 @@ import qualified Test.Ouroboros.Storage.ChainDB.GcSchedule as GcSchedule
 import qualified Test.Ouroboros.Storage.ChainDB.Iterator as Iterator
 import qualified Test.Ouroboros.Storage.ChainDB.Model.Test as Model
 import qualified Test.Ouroboros.Storage.ChainDB.StateMachine as StateMachine
+import qualified Test.Ouroboros.Storage.ChainDB.VolDB as VolDB
 
 tests :: TestTree
 tests = testGroup "ChainDB" [
@@ -15,4 +16,5 @@ tests = testGroup "ChainDB" [
     , GcSchedule.tests
     , Model.tests
     , StateMachine.tests
+    , VolDB.tests
     ]

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -395,6 +395,7 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
     blockInfo tb = VolDB.BlockInfo
       { VolDB.bbid          = blockHash tb
       , VolDB.bslot         = blockSlot tb
+      , VolDB.bbno          = blockNo   tb
       , VolDB.bpreBid       = case blockPrevHash tb of
           GenesisHash -> Origin
           BlockHash h -> NotOrigin h

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -289,7 +289,7 @@ prop_general_test setup from to expected =
     (_trace, actual) = runIterator setup from to
     failure msg = counterexample msg False
 
-    ppStream :: [Either (HeaderHash TestBlock) TestBlock] -> String
+    ppStream :: [Either (RealPoint TestBlock) TestBlock] -> String
     ppStream = intercalate " :> " . map ppGCedOrBlock
 
 {-------------------------------------------------------------------------------
@@ -316,9 +316,9 @@ testSetupInfo TestSetup { immutable, volatile } = mconcat
     , intercalate ", " (map ppBlock volatile)
     ]
 
-ppGCedOrBlock :: Either (HeaderHash TestBlock) TestBlock -> String
-ppGCedOrBlock (Left  gcedHash) = "GCed: " <> condense gcedHash
-ppGCedOrBlock (Right blk)      = ppBlock blk
+ppGCedOrBlock :: Either (RealPoint TestBlock) TestBlock -> String
+ppGCedOrBlock (Left  gcedPt) = "GCed: " <> condense gcedPt
+ppGCedOrBlock (Right blk)    = ppBlock blk
 
 ppBlock :: TestBlock -> String
 ppBlock = condense
@@ -328,8 +328,8 @@ ppBlock = condense
 -------------------------------------------------------------------------------}
 
 type IterRes = Either (UnknownRange TestBlock)
-                      [Either (HeaderHash TestBlock) TestBlock]
-                      -- Left:  hash of garbage collected block
+                      [Either (RealPoint TestBlock) TestBlock]
+                      -- Left:  point of garbage collected block
                       -- Right: regular block
 
 -- | Open an iterator with the given bounds on the given 'TestSetup'. Return a
@@ -351,7 +351,7 @@ runIterator setup from to = runSimOrThrow $ withRegistry $ \r -> do
   where
     consume :: Monad m
             => Iterator m TestBlock TestBlock
-            -> m [Either (HeaderHash TestBlock) TestBlock]
+            -> m [Either (RealPoint TestBlock) TestBlock]
     consume it = iteratorNext it >>= \case
       IteratorResult blk -> (Right blk :) <$> consume it
       IteratorBlockGCed hash -> do

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/VolDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/VolDB.hs
@@ -1,0 +1,316 @@
+{-# LANGUAGE DisambiguateRecordFields   #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE UndecidableInstances       #-}
+
+module Test.Ouroboros.Storage.ChainDB.VolDB (tests) where
+
+import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
+import           Data.Map (Map)
+import qualified Data.Map as Map
+
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Fragment.Diff (ChainDiff (..))
+import qualified Ouroboros.Consensus.Fragment.Diff as Diff
+
+import           Ouroboros.Consensus.Storage.ChainDB.Impl.VolDB (fromChainHash,
+                     isReachable)
+import qualified Ouroboros.Consensus.Storage.VolatileDB as VolDB
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Test.Ouroboros.Storage.TestBlock
+import           Test.Util.Orphans.Slotting.Arbitrary ()
+
+{-------------------------------------------------------------------------------
+  Top-level tests
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "VolDB" [
+      testProperty "isReachable" prop_isReachable
+    ]
+
+{-------------------------------------------------------------------------------
+  Test properties
+-------------------------------------------------------------------------------}
+
+prop_isReachable :: ReachableSetup TestBlock -> Property
+prop_isReachable ReachableSetup { currentChain, forkTip, fork, blockInfo } =
+        isReachable (flip Map.lookup blockInfo) currentChain forkTip
+    === fork
+
+{-------------------------------------------------------------------------------
+  Test setup
+-------------------------------------------------------------------------------}
+
+data ReachableSetup blk = ReachableSetup {
+      currentChain :: AnchoredFragment (Header blk)
+    , forkTip      :: RealPoint blk
+    , fork         :: Maybe (ChainDiff (HeaderFields blk))
+    , blockInfo    :: Map (HeaderHash blk) (VolDB.BlockInfo (HeaderHash blk))
+    }
+
+deriving instance (HasHeader blk, Show (Header blk)) => Show (ReachableSetup blk)
+
+{-------------------------------------------------------------------------------
+  Generators
+-------------------------------------------------------------------------------}
+
+-- | All blocks on the current chain use this value as for their body. This
+-- allows us to statically convert a header from the current chain to a block.
+currentChainBody :: TestBody
+currentChainBody = TestBody 0 True
+
+genFirstBlock ::
+     Gen TestBody
+  -> Gen TestBlock
+genFirstBlock genBody = oneof
+    [ firstBlock 0            <$> genBody
+    , firstEBB   (const True) <$> genBody
+    ]
+
+genSuccessor ::
+     (HeaderFields TestBlock, IsEBB, ChainLength)
+  -> Gen TestBody
+  -> Gen TestBlock
+genSuccessor (prevHeaderFields, prevIsEBB, prevChainLength) genBody = frequency
+    [ ( if prevWasEBB then 0 else 1
+      , mkNextEBB' (const True) (prevHeaderFields, prevChainLength)
+          <$> chooseSlot (prevSlot + 1) (prevSlot + 2)
+          -- We don't care about EpochNo
+          <*> return 0
+          <*> genBody
+      )
+    , (3
+      , mkNextBlock' (prevHeaderFields, prevChainLength)
+          <$> chooseSlot (prevSlot + if prevWasEBB then 0 else 1) (prevSlot + 2)
+          <*> genBody
+      )
+    ]
+  where
+    prevSlot  = headerFieldSlot prevHeaderFields
+    prevWasEBB = case prevIsEBB of
+        IsEBB    -> True
+        IsNotEBB -> False
+
+    chooseSlot :: SlotNo -> SlotNo -> Gen SlotNo
+    chooseSlot (SlotNo start) (SlotNo end) = SlotNo <$> choose (start, end)
+
+genChainHelper ::
+     Gen TestBody
+  -> Int
+     -- ^ Number of headers to generate
+  -> WithOrigin (HeaderFields TestBlock, IsEBB, ChainLength)
+     -- ^ Optional previous block
+  -> Gen (AnchoredFragment (Header TestBlock))
+genChainHelper genBody = \n optPrevBlk ->
+    case optPrevBlk of
+      Origin | n == 0 ->
+        return $ AF.Empty AF.AnchorGenesis
+
+      Origin -> do
+        firstBlk <- genFirstBlock genBody
+        let initAcc  = AF.Empty AF.AnchorGenesis AF.:> getHeader firstBlk
+            prevInfo = ( getBlockHeaderFields firstBlk
+                       , blockToIsEBB firstBlk
+                       , ChainLength 1
+                       )
+        go (n - 1) prevInfo initAcc
+
+      NotOrigin prevInfo@(prevHeaderFields, _, _) -> do
+        let anchor  = AF.Anchor
+                        (headerFieldSlot    prevHeaderFields)
+                        (headerFieldHash    prevHeaderFields)
+                        (headerFieldBlockNo prevHeaderFields)
+            initAcc = AF.Empty anchor
+        go n prevInfo initAcc
+  where
+    go ::
+         Int
+      -> (HeaderFields TestBlock, IsEBB, ChainLength)
+      -> AnchoredFragment (Header TestBlock)
+      -> Gen (AnchoredFragment (Header TestBlock))
+    go n prevInfo@(_, _, prevChainLength) acc = case n of
+      0 -> return acc
+      _ -> do
+        blk <- genSuccessor prevInfo genBody
+        let isEBB     = blockToIsEBB blk
+            prevInfo' = (getBlockHeaderFields blk, isEBB, succ prevChainLength)
+        go (n - 1) prevInfo' (acc AF.:> getHeader blk)
+
+-- | Also returns the header corresponding to the anchor, unless the anchor is
+-- genesis.
+generateChain :: Gen ( AnchoredFragment (Header TestBlock)
+                     , Maybe (Header TestBlock)
+                     )
+generateChain = sized $ \size -> do
+    takeNewestN <- choose (0, size)
+    fullChain   <- genChainHelper (return currentChainBody) size Origin
+    let mbAnchorHdr = case AF.head (AF.dropNewest takeNewestN fullChain) of
+                        Left _          -> Nothing
+                        Right anchorHdr -> Just anchorHdr
+    return (AF.anchorNewest (fromIntegral takeNewestN) fullChain, mbAnchorHdr)
+
+-- | NOTE: the fork must be the minimal fork, i.e., it must not contain headers
+-- that are also part of the current chain.
+generateFork ::
+     ( AnchoredFragment (Header TestBlock)
+     , Maybe (Header TestBlock)
+     )
+  -> Gen (ChainDiff (HeaderFields TestBlock), [Header TestBlock])
+generateFork (chain, mbAnchorHdr) = sized $ \size -> do
+    -- Roll back 0 or more headers and add 0 or more headers
+    rollback <- choose (0, AF.length chain)
+    let mbPrevHdr = case AF.head (AF.dropNewest rollback chain) of
+          Left _    -> mbAnchorHdr
+          Right hdr -> Just hdr
+        wiPrevInfo = headerToPrevInfo <$> withOriginFromMaybe mbPrevHdr
+    toAdd <- choose (0, size)
+    suffix <- genChainHelper genBody toAdd wiPrevInfo
+    let diff = ChainDiff
+                 (fromIntegral rollback)
+                 (AF.mapAnchoredFragment
+                   (castHeaderFields . getHeaderFields)
+                   suffix)
+    return (diff, AF.toOldestFirst suffix)
+  where
+    genBody :: Gen TestBody
+    genBody = (`TestBody` True) <$> choose (1, 3)
+
+    headerToPrevInfo ::
+         Header TestBlock
+      -> (HeaderFields TestBlock, IsEBB, ChainLength)
+    headerToPrevInfo hdr =
+        ( castHeaderFields $ getHeaderFields hdr
+        , headerToIsEBB hdr
+        , thChainLength $ unTestHeader hdr
+        )
+
+-- | Generate headers that don't fit onto the given chain, but that may fit
+-- onto each other.
+generateDisconnectedHeaders ::
+     ( AnchoredFragment (Header TestBlock)
+     , Maybe (Header TestBlock)
+     )
+  -> Gen (NonEmpty (Header TestBlock))
+generateDisconnectedHeaders (chain, mbAnchorHdr) =
+    generateFork (chain, mbAnchorHdr) `suchThatMap` dropConnectingBlock
+  where
+    -- 'Maybe' because the suffix might be empty or contain only a single
+    -- block, which is the connecting one which we have to drop
+    dropConnectingBlock ::
+         (ChainDiff (HeaderFields TestBlock), [Header TestBlock])
+      -> Maybe (NonEmpty (Header TestBlock))
+    dropConnectingBlock (ChainDiff _ suffix, hdrs) = do
+        connectingPt <- either (const Nothing) (Just . castPoint . blockPoint) $
+                          AF.last suffix
+        NE.nonEmpty (filter ((/= connectingPt) . headerPoint) hdrs)
+
+chainDiffForkTip ::
+     ChainDiff (HeaderFields TestBlock)
+  -> Maybe (RealPoint TestBlock)
+chainDiffForkTip =
+      withOriginToMaybe
+    . pointToWithOriginRealPoint
+    . castPoint
+    . Diff.getTip
+
+headerToBlockInfo ::
+     (GetHeader blk, GetPrevHash blk)
+  => Header blk
+  -> VolDB.BlockInfo (HeaderHash blk)
+headerToBlockInfo hdr = VolDB.BlockInfo {
+      bbid          = headerHash hdr
+    , bslot         = blockSlot  hdr
+    , bbno          = blockNo    hdr
+    , bpreBid       = fromChainHash (headerPrevHash hdr)
+    , bisEBB        = headerToIsEBB hdr
+    -- We don't care about those two
+    , bheaderOffset = 0
+    , bheaderSize   = 0
+    }
+
+headersToBlockInfo ::
+     (GetHeader blk, GetPrevHash blk, Foldable f)
+  => f (Header blk)
+  -> Map (HeaderHash blk) (VolDB.BlockInfo (HeaderHash blk))
+headersToBlockInfo = foldMap $ \hdr ->
+    Map.singleton (headerHash hdr) (headerToBlockInfo hdr)
+
+instance Arbitrary (ReachableSetup TestBlock) where
+  arbitrary = do
+      (currentChain, mbAnchorHdr) <- generateChain
+      (forkTip, fork, forkBlockInfo) <- frequency
+        [ (3, generateConnectedFork    (currentChain, mbAnchorHdr))
+        , (1, generateDisconnectedFork (currentChain, mbAnchorHdr))
+        ]
+      let blockInfo = forkBlockInfo
+                   <> headersToBlockInfo mbAnchorHdr
+                   <> headersToBlockInfo (AF.toOldestFirst currentChain)
+      return ReachableSetup { currentChain, forkTip, fork, blockInfo }
+    where
+      generateConnectedFork (currentChain, mbAnchorHdr) = do
+          (forkTip, fork, headersOnFork) <-
+            generateFork (currentChain, mbAnchorHdr)
+              `suchThatMap` \(fork, headersOnFork) ->
+                (, fork, headersOnFork) <$> chainDiffForkTip fork
+          return (
+              forkTip
+            , Just fork
+            , headersToBlockInfo headersOnFork
+            )
+
+      generateDisconnectedFork (currentChain, mbAnchorHdr) = do
+          disconnectedHeaders <- generateDisconnectedHeaders (currentChain, mbAnchorHdr)
+          forkTip <- elements (map headerRealPoint (NE.toList disconnectedHeaders))
+          return (
+              forkTip
+            , Nothing
+            , headersToBlockInfo disconnectedHeaders
+            )
+
+  shrink ReachableSetup { currentChain, forkTip, fork, blockInfo } =
+      shrinkFork <> shrinkCurrentChain
+    where
+      shrinkFork = case fork of
+          -- We can't shrink the fork if there is no fork
+          Nothing -> []
+
+          Just (ChainDiff rollback suffix) ->
+            case suffix of
+              suffix'@(_ AF.:> forkTip') AF.:> _ -> return $
+                ReachableSetup {
+                    currentChain
+                  , forkTip   = RealPoint (blockSlot forkTip') (blockHash forkTip')
+                  , fork      = Just $ ChainDiff rollback suffix'
+                  , blockInfo = Map.delete (realPointHash forkTip) blockInfo
+                  }
+              _ -> []
+
+      shrinkCurrentChain = case fork of
+          -- We don't care much about shrinking this case: the fork is not
+          -- connected.
+          Nothing -> []
+
+          Just (ChainDiff rollback suffix)
+            | currentChain' AF.:> curTip <- currentChain
+            , AF.anchorFromBlock curTip /= AF.castAnchor (AF.anchor suffix)
+            -> return $ ReachableSetup {
+                currentChain = currentChain'
+              , forkTip      = forkTip
+              , fork         = Just $ ChainDiff (rollback - 1) suffix
+              , blockInfo    = Map.delete (headerHash curTip) blockInfo
+              }
+            | otherwise
+            -> []

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -549,6 +549,8 @@ instance IsLedger (LedgerState TestBlock) where
 
   applyChainTick _ = Ticked
 
+  ledgerTipPoint = castPoint . lastAppliedPoint
+
 instance ApplyBlock (LedgerState TestBlock) TestBlock where
   applyLedgerBlock _ tb@TestBlock{..} (Ticked _ TestLedger{..})
     | blockPrevHash tb /= lastAppliedHash
@@ -560,8 +562,6 @@ instance ApplyBlock (LedgerState TestBlock) TestBlock where
 
   reapplyLedgerBlock _ tb _ =
     TestLedger (Chain.blockPoint tb) (BlockHash (blockHash tb))
-
-  ledgerTipPoint = lastAppliedPoint
 
 data instance LedgerState TestBlock =
     TestLedger {

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -32,10 +32,13 @@ module Test.Ouroboros.Storage.TestBlock (
   , firstEBB
   , mkNextBlock
   , mkNextEBB
+  , mkNextBlock'
+  , mkNextEBB'
     -- ** Query
   , testBlockToBlockInfo
   , testBlockIsValid
   , testBlockIsEBB
+  , testBlockChainLength
     -- ** Serialisation
   , testHashInfo
   , testBlockToBuilder
@@ -265,6 +268,9 @@ testHashInfo = HashInfo
 testBlockIsEBB :: TestBlock -> IsEBB
 testBlockIsEBB = headerToIsEBB . getHeader
 
+testBlockChainLength :: TestBlock -> ChainLength
+testBlockChainLength = thChainLength . unTestHeader . getHeader
+
 -- | Check whether the header matches its hash and whether the body matches
 -- its hash.
 testBlockIsValid :: TestBlock -> Bool
@@ -417,18 +423,20 @@ firstBlock slotNo testBody =
       (ChainLength 1)
       Nothing
 
-mkNextBlock :: TestBlock  -- ^ Previous block
-            -> SlotNo
-            -> TestBody
-            -> TestBlock
-mkNextBlock prev slotNo testBody =
+mkNextBlock' ::
+     (HeaderFields TestBlock, ChainLength)
+     -- ^ Information about the previous block
+  -> SlotNo
+  -> TestBody
+  -> TestBlock
+mkNextBlock' (prevHeaderFields, prevChainLength) slotNo testBody =
     mkBlock
       (const False)
       testBody
-      (BlockHash (blockHash prev))
+      (BlockHash (headerFieldHash prevHeaderFields))
       slotNo
-      (succ (blockNo prev))
-      (succ (thChainLength (testHeader prev)))
+      (succ (headerFieldBlockNo prevHeaderFields))
+      (succ prevChainLength)
       Nothing
 
 firstEBB :: (SlotNo -> Bool)
@@ -440,21 +448,45 @@ firstEBB canContainEBB testBody =
 -- | Note that in various places, e.g., the ImmutableDB, we rely on the fact
 -- that the @slotNo@ should correspond to the first slot number of the epoch,
 -- as is the case for real EBBs.
-mkNextEBB :: (SlotNo -> Bool)
-          -> TestBlock  -- ^ Previous block
-          -> SlotNo     -- ^ @slotNo@
-          -> EpochNo
-          -> TestBody
-          -> TestBlock
-mkNextEBB canContainEBB prev slotNo epochNo testBody =
+mkNextEBB' ::
+     (SlotNo -> Bool)
+  -> (HeaderFields TestBlock, ChainLength)
+     -- ^ Information about the previous block
+  -> SlotNo
+  -> EpochNo
+  -> TestBody
+  -> TestBlock
+mkNextEBB' canContainEBB (prevHeaderFields, prevChainLength) slotNo epochNo testBody =
     mkBlock
       canContainEBB
       testBody
-      (BlockHash (blockHash prev))
+      (BlockHash (headerFieldHash prevHeaderFields))
       slotNo
-      (blockNo prev)
-      (succ (thChainLength (testHeader prev)))
+      (headerFieldBlockNo prevHeaderFields)
+      (succ prevChainLength)
       (Just epochNo)
+
+-- | Variant of 'mkNextBlock' that takes the entire previous block.
+mkNextBlock ::
+     TestBlock
+     -- ^ Previous block
+  -> SlotNo
+  -> TestBody
+  -> TestBlock
+mkNextBlock tb =
+    mkNextBlock' (getBlockHeaderFields tb, testBlockChainLength tb)
+
+-- | Variant of 'mkNextEBB' that takes the entire previous block.
+mkNextEBB ::
+     (SlotNo -> Bool)
+  -> TestBlock
+     -- ^ Previous block
+  -> SlotNo
+  -> EpochNo
+  -> TestBody
+  -> TestBlock
+mkNextEBB canContainEBB tb =
+    mkNextEBB' canContainEBB (getBlockHeaderFields tb, testBlockChainLength tb)
 
 {-------------------------------------------------------------------------------
   Test infrastructure: protocol

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -303,6 +303,7 @@ testBlockToBlockInfo :: TestBlock -> BlockInfo TestHeaderHash
 testBlockToBlockInfo tb = BlockInfo {
       bbid          = thHash
     , bslot         = thSlotNo
+    , bbno          = thBlockNo
     , bpreBid       = case thPrevHash of
         GenesisHash -> Origin
         BlockHash h -> NotOrigin h

--- a/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
@@ -22,6 +22,7 @@ module Ouroboros.Network.AnchoredFragment (
   anchorToBlockNo,
   anchorToHash,
   anchorIsGenesis,
+  anchorToHeaderFields,
   anchorToTip,
   castAnchor,
 
@@ -220,6 +221,10 @@ anchorToSlotNo (Anchor s _h _b) = At s
 anchorToHash :: Anchor block -> ChainHash block
 anchorToHash AnchorGenesis    = GenesisHash
 anchorToHash (Anchor _s h _b) = BlockHash h
+
+anchorToHeaderFields :: Anchor block -> WithOrigin (HeaderFields block)
+anchorToHeaderFields AnchorGenesis  = Origin
+anchorToHeaderFields (Anchor s h b) = At (HeaderFields s b h)
 
 -- | Translate 'Anchor' to 'Tip'
 --

--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -114,9 +114,12 @@ type family HeaderHash b :: *
 -- These fields are lazy because they are extracted from a block or block
 -- header; this type is not intended for storage.
 data HeaderFields b = HeaderFields {
-      headerFieldHash    :: HeaderHash b
-    , headerFieldSlot    :: SlotNo
+      headerFieldSlot    :: SlotNo
     , headerFieldBlockNo :: BlockNo
+    , headerFieldHash    :: HeaderHash b
+      -- ^ NOTE: this field is last so that the derived 'Eq' and 'Ord'
+      -- instances first compare the slot and block numbers, which is cheaper
+      -- than comparing hashes.
     }
   deriving (Generic)
 


### PR DESCRIPTION
Fixes #1223.

When a block fits onto a fork, we construct the fragment all the way going
back to the immutable tip instead of just a `ChainDiff` to the most recent
intersection with the current chain. For example, when switching to a fork
that requires rolling back 2 blocks, previously, we'd construct a fragment
containing `k` headers. Now, we'll construct a `ChainDiff` with rollback = 2
and a fragment of 2 headers.

* `VolDB`: introduce `ReversePath` and `computeReversePath` which lazily
  computes a path through the VolatileDB. By using these paths everywhere, we
  no longer have to think about looking things up in the VolatileDB.

* `VolDB`: let `isReachable` return a `ChainDiff` of `HeaderFields` instead of
  a list of hashes going all the way back to the immutable tip. This
  `ChainDiff` of `HeaderFields` can later be translated to a `ChainDiff` of
  `Header`s.

* `VolDB`: add `extendWithSuccessors` that will extend a `ChainDiff` of
  `HeaderFields` with its successors, using `candidates`.

* Add property tests for `isReachable`, which helped catch a tricky corner
  case involving EBBs.

* `VolDB`: rewrite `computePath` using `computeReversePath`.

* We can now use `RealPoint`s instead of `HeaderHash`s in many functions and
  types: `IteratorBlockGCed`, `ChainDB.Iterator`s, `VolDB.Path`, some trace
  events, etc.

We don't yet take advantage of the `RealPoint` in the implementation of
`ChainDB.Iterator`s.