### PR TITLE
Cleanup consensus imports

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Ledger.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Ledger.hs
@@ -42,8 +42,6 @@ import qualified Test.Cardano.Chain.Elaboration.Keys as Spec.Test
 
 import qualified Cardano.Chain.UTxO as Impl
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -30,8 +30,6 @@ import qualified Cardano.Chain.Update as Impl
 import qualified Cardano.Chain.Update.Validation.Interface as Impl
 import qualified Cardano.Chain.UTxO as Impl
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.HeaderValidation
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
@@ -11,11 +11,11 @@ import           Data.Proxy
 
 import           Cardano.Chain.Slotting (EpochSlots)
 
-import           Ouroboros.Network.Block
-
-import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,
+                     wrapCBORinCBOR)
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Dual
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTxId)

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -26,10 +26,7 @@ import qualified Cardano.Chain.Genesis as CC.Genesis
 import qualified Cardano.Chain.Update.Validation.Interface as CC.UPI
 import qualified Cardano.Chain.UTxO as CC
 
-import           Ouroboros.Network.Block (SlotNo)
-import           Ouroboros.Network.Point (WithOrigin (At))
-
-import           Ouroboros.Consensus.Block (BlockProtocol, IsEBB (..))
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Protocol.Abstract
@@ -68,7 +65,7 @@ exampleChainDepState = withEBB
     withoutEBB = S.fromList
       secParam
       windowSize
-      (At 2, Seq.fromList signers, S.NothingEbbInfo)
+      (NotOrigin 2, Seq.fromList signers, S.NothingEbbInfo)
 
     -- info about an arbitrary hypothetical EBB
     exampleEbbSlot            :: SlotNo

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -35,9 +35,6 @@ import qualified Cardano.Chain.UTxO as CC.UTxO
 import           Cardano.Crypto (ProtocolMagicId (..))
 import           Cardano.Crypto.Hashing (Hash)
 
-import           Ouroboros.Network.Block (BlockNo (..), SlotNo (..))
-import           Ouroboros.Network.Point (WithOrigin (..), withOrigin)
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.HeaderValidation (AnnTip (..))
@@ -311,7 +308,7 @@ instance Arbitrary (PBftState PBftByronCrypto) where
             else do
               newSigner <- PBftState.PBftSigner slot <$> arbitrary
               return $ PBftState.append k windowSize newSigner st
-          go (steps - 1) (At slot) st'
+          go (steps - 1) (NotOrigin slot) st'
 
       windowSize = PBftState.WindowSize (maxRollbacks k)
 

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -39,8 +39,7 @@ import qualified Cardano.Chain.Update.Vote as Vote
 import qualified Cardano.Crypto as Crypto
 import qualified Cardano.Crypto.DSIGN as Crypto
 
-import           Ouroboros.Network.Block (SlotNo (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config (TopLevelConfig (..))
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
@@ -25,8 +25,6 @@ import           Test.QuickCheck.Hedgehog (hedgehog)
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Slotting.Slot
-
 import qualified Cardano.Chain.ProtocolConstants as Impl
 import qualified Cardano.Chain.UTxO as Impl
 
@@ -38,6 +36,7 @@ import qualified Control.State.Transition.Generator as Spec.QC
 
 import qualified Test.Cardano.Chain.Elaboration.UTxO as Spec.Test
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Config.SecurityParam

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
@@ -30,9 +30,7 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import           Cardano.Crypto.Seed (mkSeedFromBytes)
-import           Cardano.Slotting.Slot
 
-import           Ouroboros.Network.Block (SlotNo (..))
 import           Ouroboros.Network.MockChain.Chain (Chain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
@@ -42,7 +42,6 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Binary
 import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Cardano.Slotting.Slot (EpochNo (..))
 
 import qualified Crypto.Hash as Crypto
 
@@ -51,7 +50,6 @@ import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Chain.Slotting as CC
 import qualified Cardano.Crypto.Hashing as CC
 
-import           Ouroboros.Network.Block
 import           Ouroboros.Network.DeltaQ (SizeInBytes)
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
@@ -20,8 +20,6 @@ import           Data.Coerce
 import qualified Data.Set as Set
 
 import           Cardano.Prelude (Natural)
-import           Cardano.Slotting.Block
-import           Cardano.Slotting.Slot
 
 import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Common as CC
@@ -29,8 +27,7 @@ import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Slotting as CC
 import qualified Cardano.Chain.Update as CC
 
-import           Ouroboros.Network.Block (ChainHash (..), HeaderHash)
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Byron.Ledger.Orphans ()
 import           Ouroboros.Consensus.Config.SecurityParam

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/DelegationHistory.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/DelegationHistory.hs
@@ -32,9 +32,7 @@ import qualified Cardano.Chain.Delegation as Delegation
 import           Cardano.Prelude (NoUnexpectedThunks)
 import           Cardano.Slotting.SlotBounded (Bounds (..), SlotBounded (..))
 
-import           Ouroboros.Network.Block (SlotNo (..))
-import           Ouroboros.Network.Point (WithOrigin (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.History (History (..))
 import qualified Ouroboros.Consensus.Ledger.History as History
 import           Ouroboros.Consensus.Protocol.PBFT

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -29,8 +29,6 @@ import qualified Cardano.Chain.UTxO as CC.UTxO
 import qualified Cardano.Crypto as Crypto
 import           Cardano.Crypto.DSIGN
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
@@ -18,8 +18,6 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 
 import qualified Cardano.Chain.Slotting as CC
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
@@ -24,8 +24,6 @@ import           Cardano.Crypto.DSIGN
 import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Delegation as Delegation
 
-import           Ouroboros.Network.Block (HasHeader (..))
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Protocol.PBFT

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
@@ -53,7 +53,6 @@ import           Cardano.Binary
 import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Slotting as CC
 
-import           Ouroboros.Network.Block
 import           Ouroboros.Network.DeltaQ (SizeInBytes)
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -27,10 +27,7 @@ import           Cardano.Chain.ProtocolConstants (kEpochSlots)
 import           Cardano.Chain.Slotting (EpochSlots (..))
 import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Crypto as Crypto
-import           Cardano.Slotting.Slot
 
-import           Ouroboros.Network.Block (BlockNo (..), ChainHash (..),
-                     SlotNo (..))
 import           Ouroboros.Network.Magic (NetworkMagic (..))
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
@@ -23,7 +23,8 @@ import           Cardano.Prelude (cborError)
 import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Byron.API as CC
 
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (Serialised (..), unwrapCBORinCBOR,
+                     wrapCBORinCBOR)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation

--- a/ouroboros-consensus-byron/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-byron/tools/db-analyser/Main.hs
@@ -21,7 +21,6 @@ import           Options.Applicative
 
 import           Cardano.Binary (unAnnotated)
 import           Cardano.Slotting.EpochInfo
-import           Cardano.Slotting.Slot
 
 import qualified Cardano.Chain.Block as Chain
 import qualified Cardano.Chain.Genesis as Genesis
@@ -29,9 +28,6 @@ import           Cardano.Chain.Slotting (EpochSlots (..))
 import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.UTxO as Chain
 import qualified Cardano.Crypto as Crypto
-
-import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..),
-                     genesisPoint)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -235,10 +231,10 @@ processAll :: ImmDB IO ByronBlock
 processAll immDB rr callback = do
     tipPoint <- getPointAtTip immDB
     case pointToWithOriginRealPoint tipPoint of
-      Origin -> return ()
-      At tip -> do
+      Origin        -> return ()
+      NotOrigin tip -> do
         Right itr <- stream immDB rr GetBlock
-          (StreamFromExclusive genesisPoint)
+          (StreamFromExclusive GenesisPoint)
           (StreamToInclusive tip)
         go itr
   where

--- a/ouroboros-consensus-byron/tools/db-converter/Main.hs
+++ b/ouroboros-consensus-byron/tools/db-converter/Main.hs
@@ -45,8 +45,8 @@ import           Cardano.Chain.Slotting (EpochSlots (..))
 import qualified Cardano.Chain.Update as CC.Update
 import           Cardano.Crypto (Hash, RequiresNetworkMagic (..),
                      decodeAbstractHash)
-import           Cardano.Slotting.Slot
 
+import           Ouroboros.Consensus.Block
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
 import qualified Ouroboros.Consensus.Node as Node
 import           Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
@@ -19,8 +19,6 @@ import           GHC.Generics (Generic)
 import qualified Byron.Spec.Chain.STS.Block as Spec
 import qualified Byron.Spec.Ledger.Core as Spec
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Conversions

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Conversions.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Conversions.hs
@@ -9,9 +9,7 @@ module Ouroboros.Consensus.ByronSpec.Ledger.Conversions (
   , toByronSpecSlotNo
   ) where
 
-import           Cardano.Slotting.Slot (SlotNo (..))
-
-import           Ouroboros.Network.Block (ChainHash (..), HeaderHash)
+import           Ouroboros.Consensus.Block
 
 import qualified Byron.Spec.Chain.STS.Block as Spec
 import qualified Byron.Spec.Ledger.Core as Spec

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Forge.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Forge.hs
@@ -8,8 +8,7 @@ import qualified Byron.Spec.Chain.STS.Block as Spec
 import qualified Byron.Spec.Ledger.Core as Spec
 import qualified Byron.Spec.Ledger.Update as Spec
 
-import           Ouroboros.Network.Block
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Accessors

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -27,8 +27,7 @@ import qualified Byron.Spec.Chain.STS.Rule.Chain as Spec
 import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Control.State.Transition as Spec
 
-import           Ouroboros.Network.Block
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -38,7 +38,6 @@ import           Cardano.Prelude (Natural)
 import qualified Cardano.Chain.Genesis as Genesis
 import           Cardano.Chain.Slotting (EpochSlots)
 import qualified Cardano.Chain.Update as Update
-import           Cardano.Slotting.Slot (EpochNo)
 
 import           Ouroboros.Consensus.Block
 import qualified Ouroboros.Consensus.HardFork.History as HardFork

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -37,9 +37,6 @@ import qualified Cardano.Chain.UTxO as CC
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.Hashing as Hashing
 import           Cardano.Prelude (Natural, NoUnexpectedThunks)
-import           Cardano.Slotting.Slot
-
-import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.History (Bound (..),
@@ -189,10 +186,10 @@ byronTransition ByronPartialLedgerConfig{..}
         endorsementDepth :: Word64
         endorsementDepth =
             case ledgerTipSlot st of
-              Origin -> error "byronTransition: impossible"
-              At s   -> if s < endorsedInSlot
-                          then error "byronTransition: impossible"
-                          else History.countSlots s endorsedInSlot
+              Origin       -> error "byronTransition: impossible"
+              NotOrigin s  -> if s < endorsedInSlot
+                                then error "byronTransition: impossible"
+                                else History.countSlots s endorsedInSlot
 
     -- check if the candidate update protocol induces a hard fork to Shelley
     bumpsMajorProtocolVersion :: CC.Update.CandidateProtocolUpdate -> Bool

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -40,7 +40,6 @@ import qualified Cardano.Chain.Genesis as Genesis
 import           Cardano.Chain.Slotting (EpochSlots)
 import qualified Cardano.Chain.Update as Update
 import           Cardano.Prelude (Natural, cborError)
-import           Cardano.Slotting.Slot (EpochNo)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Generators.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Generators.hs
@@ -13,7 +13,6 @@ module Test.Consensus.Cardano.Generators (
   ) where
 
 import           Cardano.Crypto.Hash (Hash, HashAlgorithm)
-import           Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 import           Data.Coerce
 import qualified Data.List.NonEmpty as NE
 import           Data.Proxy

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -22,13 +22,13 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import           Cardano.Prelude (Natural)
-import           Cardano.Slotting.Slot (EpochNo, EpochSize (..))
 
 import           Cardano.Crypto.Hash.Blake2b (Blake2b_256)
 import qualified Cardano.Crypto.KES.Class as KES
 
 import           Ouroboros.Network.MockChain.Chain (chainToList)
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -33,9 +33,6 @@ import           Cardano.Crypto.Hash (ShortHash)
 import           Cardano.Prelude (Natural)
 import           Cardano.Slotting.EpochInfo
 
-import           Ouroboros.Network.Block (HeaderHash, blockHash, genesisPoint)
-import           Ouroboros.Network.Point (WithOrigin (..))
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -133,8 +130,8 @@ exampleApplyTxErr =
 
 exampleChainDepState :: ChainDepState (BlockProtocol (Block ShortHash))
 exampleChainDepState =
-    TPraosState.append 2      (mkPrtclState 2) $
-    TPraosState.empty  (At 1) (mkPrtclState 1)
+    TPraosState.append 2             (mkPrtclState 2) $
+    TPraosState.empty  (NotOrigin 1) (mkPrtclState 1)
   where
     mkPrtclState :: Word64 -> STS.PrtclState (TPraosMockCrypto ShortHash)
     mkPrtclState seed = STS.PrtclState
@@ -152,7 +149,7 @@ exampleLedgerState = reapplyLedgerBlock
     ledgerCfg
     (mkShelleyBlock newBlock :: Block ShortHash)
     (Ticked 0 ShelleyLedgerState {
-        ledgerTip    = genesisPoint
+        ledgerTip    = GenesisPoint
       , history      = History.empty
       , shelleyState = STS.chainNes startState
       })
@@ -173,7 +170,7 @@ exampleHeaderState = genesisHeaderState st
       (SL.mkNonceFromNumber 2)
 
     st :: TPraosState (ConcreteCrypto ShortHash)
-    st = TPraosState.empty (At 1) prtclState
+    st = TPraosState.empty (NotOrigin 1) prtclState
 
 exampleExtLedgerState :: ExtLedgerState (Block ShortHash)
 exampleExtLedgerState = ExtLedgerState {

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -17,9 +17,7 @@ module Test.Consensus.Shelley.Generators (
 
 import           Cardano.Crypto.Hash (Hash, HashAlgorithm)
 
-import           Ouroboros.Network.Block (BlockNo (..), pattern BlockPoint,
-                     Point, SlotNo (..), mkSerialised)
-import           Ouroboros.Network.Point (WithOrigin (..), withOrigin)
+import           Ouroboros.Network.Block (mkSerialised)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
@@ -113,7 +111,7 @@ instance HashAlgorithm h => Arbitrary (TPraosState (TPraosMockCrypto h)) where
       steps     <- choose (0, 5)
       startSlot <- frequency
         [ (1, return Origin)
-        , (5, At . SlotNo <$> choose (0, 100))
+        , (5, NotOrigin . SlotNo <$> choose (0, 100))
         ]
       initState <- TPraosState.empty startSlot <$> arbitrary
       go steps startSlot initState
@@ -127,7 +125,7 @@ instance HashAlgorithm h => Arbitrary (TPraosState (TPraosMockCrypto h)) where
         | otherwise  = do
           let slot = withOrigin (SlotNo 0) succ prevSlot
           newPrtclState <- arbitrary
-          go (steps - 1) (At slot) (TPraosState.append slot newPrtclState st)
+          go (steps - 1) (NotOrigin slot) (TPraosState.append slot newPrtclState st)
 
 instance (HashAlgorithm h, forall a. Arbitrary (Hash h a))
       => Arbitrary (History.LedgerViewHistory (TPraosMockCrypto h)) where

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -32,8 +32,8 @@ import           Cardano.Crypto.KES.Class (SignKeyKES, deriveVerKeyKES,
 import           Cardano.Crypto.Seed (mkSeedFromBytes)
 import           Cardano.Crypto.VRF.Class (SignKeyVRF, deriveVerKeyVRF,
                      genKeyVRF)
-import           Cardano.Slotting.Slot (EpochSize (..))
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Node.ProtocolInfo

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
@@ -12,9 +12,7 @@ import qualified Data.Set as Set
 import           Cardano.Binary (toCBOR)
 import           Cardano.Crypto.Hash (ShortHash)
 
-import           Ouroboros.Network.Block (Point (..))
-import           Ouroboros.Network.Point (WithOrigin (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 
 import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
@@ -116,7 +114,7 @@ testQueries = testGroup "Queries"
 testResults :: TestTree
 testResults = testGroup "Results"
     [ testCase "LedgerTip"
-        $ goldenTestResult GetLedgerTip (Point Origin) [TkListLen 0]
+        $ goldenTestResult GetLedgerTip GenesisPoint [TkListLen 0]
     , testCase "EpochNo"
         $ goldenTestResult GetEpochNo 0 [TkInt 0]
     , testCase "NonMyopicMemberRewards"

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -14,8 +14,8 @@ import           Test.Tasty.QuickCheck
 
 import           Cardano.Crypto.Hash (ShortHash)
 import qualified Cardano.Crypto.KES.Class as KES
-import           Cardano.Slotting.Slot (EpochSize (..))
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)
 import           Ouroboros.Consensus.Node.ProtocolInfo

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -47,10 +47,6 @@ import           Cardano.Binary (Annotator (..), FromCBOR (..),
 import qualified Cardano.Crypto.Hash as Crypto
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 
-import           Ouroboros.Network.Block (BlockMeasure, ChainHash (..),
-                     HasHeader (..), HeaderHash, StandardHash, blockMeasure,
-                     castHash)
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -19,10 +19,6 @@ module Ouroboros.Consensus.Shelley.Ledger.Forge (
 import           Control.Exception
 import qualified Data.Sequence.Strict as Seq
 
-import           Cardano.Slotting.Block
-
-import           Ouroboros.Network.Block (castHash)
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/History.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/History.hs
@@ -28,8 +28,8 @@ import           Data.Word (Word64)
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..), enforceSize)
 import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Cardano.Slotting.Slot (SlotNo (..), WithOrigin)
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.History (History (..))
 import qualified Ouroboros.Consensus.Ledger.History as History
 import           Ouroboros.Consensus.Util.CBOR (decodeSeq, encodeSeq)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Integrity.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Integrity.hs
@@ -8,8 +8,6 @@ module Ouroboros.Consensus.Shelley.Ledger.Integrity (
 import           Data.Either (isRight)
 import           Data.Word (Word64)
 
-import           Ouroboros.Network.Block (SlotNo (..), blockSlot)
-
 import           Ouroboros.Consensus.Block
 
 import qualified Shelley.Spec.Ledger.BlockChain as SL

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -34,10 +34,6 @@ import           Cardano.Prelude (Natural)
 
 import           Cardano.Crypto.KES.Class
 import           Cardano.Slotting.EpochInfo
-import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..),
-                     SlotNo (..), WithOrigin (Origin))
-
-import           Ouroboros.Network.Block (genesisPoint)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -184,7 +180,7 @@ protocolInfoShelley genesis initialNonce maxMajorPV protVer mbCredentials =
 
     initLedgerState :: LedgerState (ShelleyBlock c)
     initLedgerState = ShelleyLedgerState {
-        ledgerTip    = genesisPoint
+        ledgerTip    = GenesisPoint
       , history      = History.empty
       , shelleyState = SL.chainNes initShelleyState
       }

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -56,8 +56,7 @@ import qualified Cardano.Crypto.VRF.Class as VRF
 import           Cardano.Prelude (Natural, NoUnexpectedThunks (..))
 import           Cardano.Slotting.EpochInfo
 
-import           Ouroboros.Network.Block (BlockNo, pointSlot, unSlotNo)
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/State.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/State.hs
@@ -25,9 +25,7 @@ import           GHC.Stack (HasCallStack)
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..), enforceSize)
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 
-import           Ouroboros.Network.Block (SlotNo (..))
-import           Ouroboros.Network.Point (WithOrigin (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.Versioned
 
@@ -103,7 +101,7 @@ append
   -> TPraosState c
   -> TPraosState c
 append slot prtclState st = st {
-      historicalStates = Map.insert (At slot) prtclState (historicalStates st)
+      historicalStates = Map.insert (NotOrigin slot) prtclState (historicalStates st)
     }
 
 -- | Prune the state to a given maximum size

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Util.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Util.hs
@@ -8,8 +8,9 @@ module Ouroboros.Consensus.Shelley.Protocol.Util (
   ) where
 
 import           Cardano.Slotting.EpochInfo
-import           Cardano.Slotting.Slot
 import           Data.Functor.Identity (Identity (..))
+
+import           Ouroboros.Consensus.Block
 
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -77,8 +77,6 @@ import           Cardano.Crypto.Hash (Hash, HashAlgorithm, MD5, ShortHash)
 import qualified Cardano.Crypto.Hash as Hash
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Abstract
 import qualified Ouroboros.Consensus.HardFork.History as HardFork

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -27,8 +27,6 @@ import           Cardano.Binary (ToCBOR (..))
 import           Cardano.Crypto.DSIGN
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block (HasHeader (..))
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.Ledger.SupportsProtocol

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
@@ -16,8 +16,6 @@ import           Data.Word
 
 import           Cardano.Crypto.Hash
 
-import           Ouroboros.Network.Block (BlockNo, SlotNo)
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
@@ -24,10 +24,6 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Crypto.Hash
 import           Cardano.Prelude (NoUnexpectedThunks)
-import           Cardano.Slotting.Slot (SlotNo)
-
-import           Ouroboros.Network.Block (ChainHash, HeaderHash, Point,
-                     StandardHash, blockSlot, genesisPoint, pointHash)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Mock.Ledger.Address
@@ -117,5 +113,5 @@ genesisMockState :: AddrDist -> MockState blk
 genesisMockState addrDist = MockState {
       mockUtxo      = genesisUtxo addrDist
     , mockConfirmed = Set.singleton (hash (genesisTx addrDist))
-    , mockTip       = genesisPoint
+    , mockTip       = GenesisPoint
     }

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs
@@ -43,9 +43,9 @@ import           Cardano.Binary (ToCBOR (..))
 import           Cardano.Crypto.Hash
 import           Cardano.Prelude (NoUnexpectedThunks, UseIsNormalForm (..))
 
-import           Ouroboros.Network.Block (SlotNo)
 import           Ouroboros.Network.MockChain.Chain (Chain, toOldestFirst)
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util (repeatedlyM)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -13,8 +13,6 @@ module Ouroboros.Consensus.Mock.Node (
 import           Codec.Serialise (Serialise)
 import           Data.Typeable (Typeable)
 
-import           Cardano.Slotting.Slot
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Config.SecurityParam

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -17,7 +17,7 @@ module Ouroboros.Consensus.Mock.Node.Serialisation (
 import           Codec.Serialise (Serialise, decode, encode)
 import qualified Data.ByteString.Lazy as Lazy
 
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (Serialised)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (AnnTip,

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -63,12 +63,8 @@ import           Cardano.Crypto.VRF.Mock (MockVRF)
 import           Cardano.Crypto.VRF.Simple (SimpleVRF)
 import           Cardano.Prelude (NoUnexpectedThunks (..), fromMaybe)
 import           Cardano.Slotting.EpochInfo
-import           Cardano.Slotting.Slot
 
-import           Ouroboros.Network.Block (HasHeader (..), SlotNo (..),
-                     pointSlot)
-import           Ouroboros.Network.Point (WithOrigin (At))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Mock.Ledger.Stake
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
@@ -351,7 +347,7 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
   -- filled; instead we roll back the the block just before it.
   rewindChainDepState _proxy _k rewindTo =
       -- This may drop us back to the empty list if we go back to genesis
-      Just . dropWhile (\bi -> At (biSlot bi) > pointSlot rewindTo)
+      Just . dropWhile (\bi -> NotOrigin (biSlot bi) > pointSlot rewindTo)
 
   -- (Standard) Praos uses the standard chain selection rule, so no need to
   -- override (though see note regarding clock skew).

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/Consensus/Ledger/Mock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/Consensus/Ledger/Mock.hs
@@ -15,9 +15,7 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Ouroboros.Network.Block (HeaderHash)
-
-import           Ouroboros.Consensus.Block (ConvertRawHash (..), getHeader)
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Mock.Ledger.Block
 
 import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/Consensus/Ledger/Mock/Generators.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/Consensus/Ledger/Mock/Generators.hs
@@ -24,8 +24,6 @@ import           Cardano.Crypto.Hash
 
 import           Test.QuickCheck
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.SupportsMempool

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -12,8 +12,7 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -13,10 +13,7 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Slotting.Slot
-
-import           Ouroboros.Network.Block (SlotNo (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -12,11 +12,9 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Slotting.Slot
-
-import           Ouroboros.Network.Block (SlotNo (..), blockSlot)
 import           Ouroboros.Network.MockChain.Chain (foldChain)
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -10,8 +10,7 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/TxGen/Mock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/TxGen/Mock.hs
@@ -10,8 +10,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           GHC.Stack (HasCallStack)
 
-import           Ouroboros.Network.Block (SlotNo (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Mock.Ledger
 
 import           Test.ThreadNet.TxGen

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Util/SimpleBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Util/SimpleBlock.hs
@@ -6,8 +6,7 @@ module Test.ThreadNet.Util.SimpleBlock (
 
 import           Test.QuickCheck
 
-import           Ouroboros.Network.Block (HasHeader, SlotNo (..), blockSlot)
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Util.Condense (condense)
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -39,10 +39,7 @@ import           Test.QuickCheck
 
 import           Control.Monad.IOSim (runSimOrThrow, setCurrentTime)
 
-import           Ouroboros.Network.Block (BlockNo (..), HasHeader, HeaderHash,
-                     SlotNo (..))
 import qualified Ouroboros.Network.MockChain.Chain as MockChain
-import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block
 import qualified Ouroboros.Consensus.BlockchainTime as BTime
@@ -635,10 +632,10 @@ prop_general pga testOutput =
                     property (d >= toEnum numActiveSlots)
 
             BlockNo d = case (b1, b2) of
-                          (At b1', At b2') -> b2' - b1'
-                          (Origin, At b2') -> b2' + 1
-                          (Origin, Origin) -> 0
-                          (At _,   Origin) -> error "prop_growth: negative growth"
+                          (NotOrigin b1', NotOrigin b2') -> b2' - b1'
+                          (Origin,        NotOrigin b2') -> b2' + 1
+                          (Origin,        Origin)        -> 0
+                          (NotOrigin _,   Origin)        -> error "prop_growth: negative growth"
             numActiveSlots =
                 Map.size $
                 flip Map.filterWithKey (getLeaderSchedule growthSchedule) $

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -52,14 +52,10 @@ import qualified Data.Typeable as Typeable
 import           Data.Void (Void)
 import           GHC.Stack
 
-import           Cardano.Slotting.Slot
-
-import           Ouroboros.Network.Block
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec (AnyMessage (..), CodecFailure,
                      mapFailureCodec)
 import           Ouroboros.Network.MockChain.Chain (Chain (Genesis))
-import           Ouroboros.Network.Point (WithOrigin (..))
 
 import qualified Ouroboros.Network.BlockFetch.Client as BFClient
 import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..))
@@ -726,7 +722,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                     EpochSize y = epochSize0
             let p = ledgerTipPoint $ tickedLedgerState tickedLdgSt
 
-            let needEBB = inFirstEra && At ebbSlot > pointSlot p
+            let needEBB = inFirstEra && NotOrigin ebbSlot > pointSlot p
             case mbForgeEbbEnv <* guard needEBB of
               Nothing ->
                  -- no EBB needed, forge without making one

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Ref/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Ref/PBFT.hs
@@ -37,8 +37,7 @@ import qualified Data.Set as Set
 import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
 
-import           Ouroboros.Network.Block (SlotNo (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Rekeying.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Rekeying.hs
@@ -6,11 +6,9 @@ module Test.ThreadNet.Rekeying (
   fromRekeyingToRekeyM,
   ) where
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
-
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Test.ThreadNet.Network

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/TxGen.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/TxGen.hs
@@ -4,9 +4,9 @@ module Test.ThreadNet.TxGen
   ( TxGen (..)
   ) where
 
-import           Cardano.Slotting.Slot (SlotNo)
 import           Data.Kind (Type)
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx)

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util.hs
@@ -32,7 +32,6 @@ import           Data.Word (Word64)
 import           Numeric.Natural (Natural)
 import           Test.QuickCheck
 
-import           Ouroboros.Network.Block
 import           Ouroboros.Network.MockChain.Chain (Chain (..))
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/BlockProduction.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/BlockProduction.hs
@@ -7,8 +7,6 @@ module Test.ThreadNet.Util.BlockProduction (
 import           Control.Monad.Trans (lift)
 import           Control.Tracer (natTracer)
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/Expectations.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/Expectations.hs
@@ -9,8 +9,7 @@ import           Data.Foldable (foldl')
 import qualified Data.Map.Strict as Map
 import           Data.Word (Word64)
 
-import           Ouroboros.Network.Block (SlotNo (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
 import           Ouroboros.Consensus.Protocol.LeaderSchedule

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/NodeJoinPlan.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/NodeJoinPlan.hs
@@ -17,8 +17,7 @@ import qualified Data.Map.Strict as Map
 import           GHC.Stack (HasCallStack)
 import           Test.QuickCheck
 
-import           Ouroboros.Network.Block (SlotNo (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Util.Condense

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/NodeRestarts.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/NodeRestarts.hs
@@ -12,8 +12,7 @@ import qualified Data.Set as Set
 import           Data.Traversable (forM)
 import           Test.QuickCheck
 
-import           Ouroboros.Network.Block (SlotNo (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Util.Condense
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/HardFork/Future.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/HardFork/Future.hs
@@ -22,9 +22,7 @@ import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           Quiet (Quiet (..))
 
-import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..),
-                     SlotNo (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime (SlotLength (..))
 import           Ouroboros.Consensus.Util (nTimes)
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/HardFork/OracularClock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/HardFork/OracularClock.hs
@@ -22,8 +22,7 @@ import           GHC.Stack
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import qualified Ouroboros.Consensus.BlockchainTime as BTime
 import           Ouroboros.Consensus.Util.Time (nominalDelay)
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/MockChain.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/MockChain.hs
@@ -13,8 +13,9 @@ module Test.Util.MockChain (
 import           Data.Foldable (foldl')
 import           Data.Sequence.Strict (StrictSeq (..))
 
-import           Ouroboros.Network.Block
 import           Ouroboros.Network.MockChain.Chain
+
+import           Ouroboros.Consensus.Block
 
 {-------------------------------------------------------------------------------
   Utility functions on chains

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/Arbitrary.hs
@@ -16,9 +16,7 @@ import           Data.Time
 import           Data.Word (Word64)
 import           Test.QuickCheck hiding (Fixed (..))
 
-import           Cardano.Slotting.Block
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Fragment.InFuture (ClockSkew)
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/Slotting/Arbitrary.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/Slotting/Arbitrary.hs
@@ -6,9 +6,10 @@
 -- conflict with other instances in cardano-ledger-specs.
 module Test.Util.Orphans.Slotting.Arbitrary () where
 
-import           Cardano.Slotting.Slot
 import           Data.Word
 import           Test.QuickCheck
+
+import           Cardano.Slotting.Slot
 
 deriving via Word64 instance Arbitrary SlotNo
 deriving via Word64 instance Arbitrary EpochNo

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Serialisation.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Serialisation.hs
@@ -31,8 +31,8 @@ import           Data.Function (on)
 import           Data.Proxy (Proxy (..))
 import           Data.Typeable
 
-import           Ouroboros.Network.Block (HeaderHash, Serialised (..),
-                     StandardHash, fromSerialised, mkSerialised)
+import           Ouroboros.Network.Block (Serialised (..), fromSerialised,
+                     mkSerialised)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forge.hs
@@ -29,8 +29,6 @@ import           Data.Proxy (Proxy (..))
 import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
-import           Cardano.Slotting.Block
-import           Cardano.Slotting.Slot
 
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Config

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
@@ -8,8 +8,6 @@ module Ouroboros.Consensus.Block.SupportsProtocol (
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/API.hs
@@ -17,8 +17,7 @@ import           GHC.Stack
 
 import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
 
-import           Ouroboros.Network.Block (SlotNo)
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (onEachChange)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Simple.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Simple.hs
@@ -15,10 +15,7 @@ import           Data.Fixed (divMod')
 import           Data.Time (NominalDiffTime)
 import           Data.Void
 
-import           Cardano.Slotting.Slot
-
-import           Ouroboros.Network.Block (SlotNo)
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime.API
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Util

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Util.hs
@@ -11,8 +11,7 @@ module Ouroboros.Consensus.BlockchainTime.WallClock.Util (
 import           Control.Exception (Exception)
 import           Data.Time (NominalDiffTime, UTCTime)
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types
                      (SystemStart)
 import           Ouroboros.Consensus.HardFork.History (PastHorizonException)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Forecast.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Forecast.hs
@@ -10,7 +10,7 @@ module Ouroboros.Consensus.Forecast (
 import           Control.Exception (Exception)
 import           Control.Monad.Except
 
-import           Cardano.Slotting.Slot hiding (at)
+import           Ouroboros.Consensus.Block
 
 data Forecast a = Forecast {
       forecastAt  :: WithOrigin SlotNo
@@ -34,7 +34,7 @@ constantForecastOf :: a -> WithOrigin SlotNo -> Forecast a
 constantForecastOf a at = Forecast {
       forecastAt  = at
     , forecastFor = \for ->
-                      if At for >= at
+                      if NotOrigin for >= at
                         then return a
                         else error "trivialForecast: precondition violated"
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Diff.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Diff.hs
@@ -30,9 +30,8 @@ import           GHC.Stack (HasCallStack)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (HasHeader, Point, castPoint)
 
-import           Ouroboros.Consensus.Block (Header)
+import           Ouroboros.Consensus.Block
 
 
 -- | A diff of a chain (fragment).

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
@@ -32,7 +32,6 @@ import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
 
 import           Ouroboros.Network.AnchoredFragment
                      (AnchoredFragment ((:>), Empty))
-import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Validated.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Validated.hs
@@ -20,7 +20,6 @@ import           GHC.Stack
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -6,7 +6,6 @@ module Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock (
   , proxySingle
   ) where
 
-import           Cardano.Slotting.Slot
 import           Data.Proxy
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -66,8 +66,6 @@ import           GHC.Stack
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.TypeFamilyWrappers

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -29,8 +29,6 @@ import           Data.Word
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.TypeFamilyWrappers

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -48,7 +48,7 @@ import           Data.Type.Equality
 import           Data.Typeable
 import           Data.Void
 
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (Serialised (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forge.hs
@@ -15,8 +15,6 @@ module Ouroboros.Consensus.HardFork.Combinator.Forge (
 import           Data.Functor.Product
 import           Data.SOP.Strict
 
-import           Cardano.Slotting.Slot (SlotNo)
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
@@ -34,7 +32,7 @@ import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 instance (CanHardFork xs, All CanForge xs) => CanForge (HardForkBlock xs) where
   type ExtraForgeState (HardForkBlock xs) = PerEraExtraForgeState xs
 
-  forgeBlock cfg forgeState blockNo
+  forgeBlock cfg forgeState bno
              Ticked { tickedSlotNo, tickedLedgerState }
              txs isLeader =
       -- First establish the 'IsLeader' and the 'LedgerState' are from the
@@ -76,7 +74,7 @@ instance (CanHardFork xs, All CanForge xs) => CanForge (HardForkBlock xs) where
           forgeBlock
             matchedCfg
             matchedForgeState
-            blockNo
+            bno
             (Ticked tickedSlotNo matchedLedgerState)
             matchedTxs
             (unwrapIsLeader matchedIsLeader)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -27,9 +27,6 @@ import           Data.SOP.Strict hiding (shape)
 import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
-import           Cardano.Slotting.Slot
-
-import           Ouroboros.Network.Block
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -31,8 +31,6 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
@@ -15,8 +15,6 @@ module Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel (
 import           Data.Functor.Product
 import           Data.SOP.Strict
 
-import           Cardano.Slotting.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.TypeFamilyWrappers

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -76,7 +76,7 @@ import           Data.Word
 
 import           Cardano.Binary (enforceSize)
 
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (Serialised)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Combinator

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
@@ -21,7 +21,8 @@ import           Control.Exception (throw)
 import           Data.Proxy
 import           Data.SOP.Strict
 
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,
+                     wrapCBORinCBOR)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Combinator

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
@@ -22,7 +22,8 @@ import           Control.Exception (throw)
 import           Data.Proxy
 import           Data.SOP.Strict
 
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,
+                     wrapCBORinCBOR)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Combinator

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -30,12 +30,11 @@ import           Data.Functor.Identity
 import           Data.Functor.Product
 import           Data.SOP.Strict hiding (shape)
 
-import           Cardano.Slotting.Slot
-
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Util ((.:))
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Basics

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Infra.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Infra.hs
@@ -33,8 +33,7 @@ import           Prelude hiding (sequence)
 import           Data.Functor.Product
 import           Data.SOP.Strict hiding (shape)
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.HardFork.History (Bound (..), EraEnd (..),
                      EraParams (..), EraSummary (..))
@@ -192,8 +191,8 @@ retractToSlot slot (HardForkState st) =
     containsSlot :: K Bool blk -> Past f blk -> K Bool blk
     containsSlot (K isFirst) Past{..} = K $
         case slot of
-          Origin -> isFirst -- Assume 'Origin' in the first era
-          At s   -> boundSlot pastStart <= s && s < boundSlot pastEnd
+          Origin      -> isFirst -- Assume 'Origin' in the first era
+          NotOrigin s -> boundSlot pastStart <= s && s < boundSlot pastEnd
 
     retract :: Retract Maybe (Past f) (Current f) blk blk'
     retract = Retract $ \past _oldCur ->
@@ -279,5 +278,5 @@ reconstructSummary (History.Shape shape) transition (HardForkState st) =
         . History.addSlots (History.safeFromTip eraSafeZone)
 
     next :: WithOrigin SlotNo -> SlotNo
-    next Origin = SlotNo 0
-    next (At s) = succ s
+    next Origin        = SlotNo 0
+    next (NotOrigin s) = succ s

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
@@ -18,8 +18,7 @@ import           Prelude hiding (sequence)
 import           Data.Word
 import           GHC.Generics (Generic)
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.History (Bound)
 
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
@@ -39,8 +39,6 @@ import           Data.Void
 
 import           Cardano.Slotting.EpochInfo
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as History

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EraParams.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EraParams.hs
@@ -19,8 +19,8 @@ import           Data.Word
 import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
-import           Cardano.Slotting.Slot
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types
 import           Ouroboros.Consensus.Config.SecurityParam
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Qry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Qry.hs
@@ -25,8 +25,7 @@ import           Data.Time hiding (UTCTime)
 import           Data.Word
 import           GHC.Stack
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types
 import           Ouroboros.Consensus.Util.IOLike
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Summary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Summary.hs
@@ -58,8 +58,8 @@ import           GHC.Stack
 
 import           Cardano.Binary (enforceSize)
 import           Cardano.Prelude (NoUnexpectedThunks, UseIsNormalFormNamed (..))
-import           Cardano.Slotting.Slot
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types
 import           Ouroboros.Consensus.Util.Counting
 import           Ouroboros.Consensus.Util.SOP
@@ -368,8 +368,8 @@ summarize ledgerTip = \(Shape shape) (Transitions transitions) ->
 
     -- Upper bound is exclusive, so we count from the /next/ ledger tip
     next :: WithOrigin SlotNo -> SlotNo
-    next Origin = SlotNo 0
-    next (At s) = succ s
+    next Origin        = SlotNo 0
+    next (NotOrigin s) = succ s
 
 {-------------------------------------------------------------------------------
   Invariants

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Util.hs
@@ -9,7 +9,7 @@ module Ouroboros.Consensus.HardFork.History.Util (
 import           Control.Exception (assert)
 import           Data.Word
 
-import           Cardano.Slotting.Slot
+import           Ouroboros.Consensus.Block
 
 {-------------------------------------------------------------------------------
   Adding and subtracting slots/epochs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -49,8 +49,6 @@ import           GHC.Stack (HasCallStack)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block
-import           Ouroboros.Network.Point (WithOrigin)
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
                      (ShowQuery (..))
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -68,8 +68,6 @@ import           GHC.Stack
 import           Cardano.Binary (enforceSize)
 import           Cardano.Prelude (AllowThunk (..), NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Config.SupportsNode

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -33,8 +33,6 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/History.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/History.hs
@@ -31,9 +31,7 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 import           Cardano.Slotting.SlotBounded (Bounds (..), SlotBounded (..))
 import qualified Cardano.Slotting.SlotBounded as SB
 
-import           Ouroboros.Network.Block (SlotNo (..))
-import           Ouroboros.Network.Point (WithOrigin (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util (firstJust)
 
 {-------------------------------------------------------------------------------
@@ -119,7 +117,7 @@ snapOld k now old = trim k now . go
     lowerBound History{..} =
         case historySnapshots of
           Empty     -> historyAnchor
-          (_ :|> s) -> At (sbUpper s)
+          (_ :|> s) -> NotOrigin (sbUpper s)
 
 -- | Drop snapshots guaranteed not to be needed anymore
 --
@@ -141,12 +139,12 @@ trim :: forall st.
 trim k now h@History{..} =
     case trimSeq historySnapshots of
       Nothing      -> h
-      Just (s, ss) -> History (At (sbUpper s)) ss
+      Just (s, ss) -> History (NotOrigin (sbUpper s)) ss
   where
     -- Earliest slot we might roll back to
     earliest :: WithOrigin SlotNo
     earliest = if now >= (2 * coerce k)
-                 then At $ now - (2 * coerce k)
+                 then NotOrigin $ now - (2 * coerce k)
                  else Origin
 
     -- Trim the list of snapshots, if we can.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
@@ -9,9 +9,6 @@ module Ouroboros.Consensus.Ledger.SupportsProtocol (
 import           Control.Monad.Except
 import           GHC.Stack (HasCallStack)
 
-import           Ouroboros.Network.Block (SlotNo)
-import           Ouroboros.Network.Point hiding (at)
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HeaderValidation
@@ -98,7 +95,7 @@ _lemma_ledgerViewForecastAt_applyChainTick
   -> SlotNo
   -> Either String ()
 _lemma_ledgerViewForecastAt_applyChainTick cfg st forecast for
-    | At for >= ledgerTipSlot st
+    | NotOrigin for >= ledgerTipSlot st
     , let lhs = forecastFor forecast for
           rhs = protocolLedgerView cfg
               . tickedLedgerState

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -30,13 +30,10 @@ import           GHC.Generics (Generic)
 
 import           Control.Tracer
 
-import           Ouroboros.Network.Block (ChainHash, Point, SlotNo,
-                     StandardHash)
-import           Ouroboros.Network.Point (WithOrigin (..))
-
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
@@ -781,5 +778,5 @@ tickLedgerState  cfg (ForgeInUnknownSlot st) =
     -- Once we do, the ValidateEnvelope constraint can go.
     slot :: SlotNo
     slot = case ledgerTipSlot st of
-             Origin -> minimumPossibleSlotNo (Proxy @blk)
-             At s   -> succ s
+             Origin      -> minimumPossibleSlotNo (Proxy @blk)
+             NotOrigin s -> succ s

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
@@ -19,8 +19,7 @@ module Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
 import           Control.Tracer (Tracer)
 import           Data.Typeable (Typeable)
 
-import           Ouroboros.Network.Block (pattern BlockPoint, HeaderHash,
-                     Serialised (..), StandardHash)
+import           Ouroboros.Network.Block (Serialised (..))
 import           Ouroboros.Network.Protocol.BlockFetch.Server
                      (BlockFetchBlockSender (..), BlockFetchSendBlocks (..),
                      BlockFetchServer (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -52,8 +52,7 @@ import           Cardano.Prelude (unsafeNoUnexpectedThunks)
 import           Network.TypedProtocol.Pipelined
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block
-import           Ouroboros.Network.Point (WithOrigin (..))
+import           Ouroboros.Network.Block (Tip, getTipBlockNo, getTipPoint)
 import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
 import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -11,8 +11,7 @@ import           Ouroboros.Network.Protocol.LocalStateQuery.Server
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
                      (AcquireFailure (..))
 
-import           Ouroboros.Network.Block (Point)
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -38,7 +38,8 @@ import           Control.Tracer
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Void (Void)
 
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (Serialised, decodePoint, decodeTip,
+                     encodePoint, encodeTip)
 import           Ouroboros.Network.BlockFetch
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -38,7 +38,8 @@ import           Data.Proxy (Proxy (..))
 import           Data.Void (Void)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (Serialised (..), decodePoint,
+                     decodeTip, encodePoint, encodeTip)
 import           Ouroboros.Network.BlockFetch
 import           Ouroboros.Network.BlockFetch.Client (BlockFetchClient,
                      blockFetchClient)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/BlockProduction.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/BlockProduction.hs
@@ -13,8 +13,6 @@ module Ouroboros.Consensus.Node.BlockProduction (
 import           Control.Tracer (Tracer, traceWith)
 import           Crypto.Random (MonadRandom)
 
-import           Ouroboros.Network.Block
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -16,7 +16,6 @@ module Ouroboros.Consensus.Node.Tracers
 
 import           Control.Tracer (Tracer, nullTracer, showTracing)
 
-import           Ouroboros.Network.Block (BlockNo, Point, SlotNo)
 import           Ouroboros.Network.BlockFetch (FetchDecision,
                      TraceFetchClientState, TraceLabelPeer)
 import           Ouroboros.Network.TxSubmission.Inbound

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -36,11 +36,10 @@ import           Control.Tracer
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (MaxSlotNo)
 import           Ouroboros.Network.BlockFetch
 import           Ouroboros.Network.BlockFetch.State (FetchMode (..))
 import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..))
-import           Ouroboros.Network.Point (WithOrigin (..))
 import           Ouroboros.Network.TxSubmission.Inbound
                      (TxSubmissionMempoolWriter)
 import qualified Ouroboros.Network.TxSubmission.Inbound as Inbound
@@ -261,8 +260,8 @@ initBlockFetchConsensusInterface cfg chainDB getCandidates blockFetchSize btime 
           let slotsBehind = case curChainSlot of
                 -- There's nothing in the chain. If the current slot is 0, then
                 -- we're 1 slot behind.
-                Origin  -> unSlotNo curSlot + 1
-                At slot -> unSlotNo curSlot - unSlotNo slot
+                Origin         -> unSlotNo curSlot + 1
+                NotOrigin slot -> unSlotNo curSlot - unSlotNo slot
               maxSlotsBehind = 1000
           return $ if slotsBehind < maxSlotsBehind
             -- When the current chain is near to "now", use deadline mode,
@@ -489,7 +488,7 @@ mkCurrentBlockContext
 mkCurrentBlockContext currentSlot c = case c of
     Empty AF.AnchorGenesis ->
       -- The chain is entirely empty.
-      Right $ BlockContext (expectedFirstBlockNo (Proxy @blk)) genesisPoint
+      Right $ BlockContext (expectedFirstBlockNo (Proxy @blk)) GenesisPoint
 
     Empty (AF.Anchor anchorSlot anchorHash anchorBlockNo) ->
       let p :: Point blk = BlockPoint anchorSlot anchorHash

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -23,8 +23,7 @@ import           GHC.Stack
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block (BlockNo, HeaderHash, Point, SlotNo)
-
+import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.Abstract (Ticked)
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -38,8 +38,7 @@ import           GHC.Generics (Generic)
 import           Cardano.Crypto.DSIGN
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 
-import           Ouroboros.Network.Block
-
+import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), NodeId (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -25,8 +25,7 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block (SlotNo (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..), fromCoreNodeId)
 import           Ouroboros.Consensus.Protocol.Abstract

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -51,11 +51,6 @@ import           GHC.Generics (Generic)
 import           Cardano.Crypto.DSIGN.Class
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block (BlockNo, pattern BlockPoint,
-                     pattern GenesisPoint, HasHeader (..), HeaderHash, Point,
-                     SlotNo (..))
-import           Ouroboros.Network.Point (WithOrigin (..))
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract (Ticked (..))
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -331,7 +326,7 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
           -- FIXME confirm that non-strict inequality is ok in general.
           -- It's here because EBBs have the same slot as the first block of their
           -- epoch.
-          unless (At slot >= S.lastSignedSlot state)
+          unless (NotOrigin slot >= S.lastSignedSlot state)
             $ throwError PBftInvalidSlot
 
           case Bimap.lookupR (hashVerKey pbftIssuer) dms of
@@ -415,7 +410,7 @@ rewind k p = S.rewind k (pbftWindowSize k) p'
   where
     p' = case p of
       GenesisPoint    -> Origin
-      BlockPoint s hh -> At (s, headerHashBytes (Proxy :: Proxy hdr) hh)
+      BlockPoint s hh -> NotOrigin (s, headerHashBytes (Proxy :: Proxy hdr) hh)
 
 {-------------------------------------------------------------------------------
   PBFT specific types

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State/HeaderHashBytes.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State/HeaderHashBytes.hs
@@ -21,7 +21,7 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block (HeaderHash)
+import           Ouroboros.Consensus.Block
 
 newtype HeaderHashBytes = HeaderHashBytes BS.ByteString
   deriving stock (Generic, Show)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -40,8 +40,6 @@ import qualified Data.Map.Strict as Map
 import           GHC.Stack (HasCallStack)
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (pattern BlockPoint,
-                     pattern GenesisPoint, HasHeader, Point, castPoint)
 
 import           Ouroboros.Consensus.Block
 import qualified Ouroboros.Consensus.Fragment.Validated as VF

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -53,9 +53,6 @@ import           GHC.Stack (HasCallStack)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (ChainHash (..), HasHeader, Point,
-                     SlotNo (..), blockPoint, pointHash, pointSlot)
-import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -297,8 +294,8 @@ copyAndSnapshotRunner cdb@CDB{..} gcSchedule replayed =
         loop mPrevSnapshot distance'
 
     scheduleGC' :: WithOrigin SlotNo -> m ()
-    scheduleGC' Origin      = return ()
-    scheduleGC' (At slotNo) =
+    scheduleGC' Origin             = return ()
+    scheduleGC' (NotOrigin slotNo) =
         scheduleGC
           (contramap TraceGCEvent cdbTracer)
           slotNo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/BlockCache.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/BlockCache.hs
@@ -18,7 +18,7 @@ import           Prelude hiding (lookup)
 import           Data.Map (Map)
 import qualified Data.Map as Map
 
-import           Ouroboros.Network.Block (HasHeader (..), HeaderHash)
+import           Ouroboros.Consensus.Block
 
 newtype BlockCache blk = BlockCache (Map (HeaderHash blk) blk)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/BlockComponent.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/BlockComponent.hs
@@ -16,9 +16,6 @@ import qualified Data.ByteString.Lazy as Lazy
 import           Data.ByteString.Short (ShortByteString)
 import           Data.Proxy
 
-import           Ouroboros.Network.Block (pattern BlockPoint, HasHeader,
-                     HeaderHash, SlotNo)
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.IOLike
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -42,8 +42,6 @@ import           GHC.Stack (HasCallStack)
 import           Ouroboros.Network.AnchoredFragment (Anchor,
                      AnchoredFragment (..))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block
-import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -337,11 +335,11 @@ olderThanK
      -- block @k@ blocks back.
   -> Bool
 olderThanK hdr isEBB immBlockNo
-    | At bNo == immBlockNo
+    | NotOrigin bNo == immBlockNo
     , isEBB == IsEBB
     = False
     | otherwise
-    = At bNo <= immBlockNo
+    = NotOrigin bNo <= immBlockNo
   where
     bNo = blockNo hdr
 
@@ -631,8 +629,8 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
         (tipPoint, (tipEpoch, tipSlotInEpoch)) =
           case pointToWithOriginRealPoint
                  (ledgerTipPoint' (Proxy @blk) ledger) of
-            Origin -> error "cannot have switched to an empty chain"
-            At tip ->
+            Origin        -> error "cannot have switched to an empty chain"
+            NotOrigin tip ->
               let query = History.slotToEpoch' (realPointSlot tip)
               in (tip, History.runQueryPure query summary)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LedgerCursor.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LedgerCursor.hs
@@ -5,8 +5,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.LedgerCursor
   ( newLedgerCursor
   ) where
 
-import           Ouroboros.Network.Block (Point, pointSlot)
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState)
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -69,11 +69,6 @@ import           System.FilePath ((</>))
 
 import           Cardano.Prelude (OnlyCheckIsWHNF (..))
 
-import           Ouroboros.Network.Block (HasHeader (..), HeaderHash, Point,
-                     SlotNo)
-import qualified Ouroboros.Network.Block as Block
-import           Ouroboros.Network.Point (WithOrigin)
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
@@ -459,7 +454,7 @@ streamAPI immDB = StreamAPI streamAfter
                 -> m a
     streamAfter tip k = do
       slotNoAtTip <- ImmDB.getSlotNoAtTip immDB
-      if Block.pointSlot tip' > slotNoAtTip
+      if pointSlot tip' > slotNoAtTip
         then k Nothing
         else withRegistry $ \registry -> do
           mItr <- ImmDB.streamAfter immDB registry GetBlock tip'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reader.hs
@@ -25,10 +25,7 @@ import           GHC.Stack (HasCallStack, callStack)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader,
-                     HeaderHash, Point, SlotNo, blockSlot, castPoint,
-                     genesisPoint, pointHash, pointSlot)
-import           Ouroboros.Network.Point (WithOrigin (..))
+import           Ouroboros.Network.Block (ChainUpdate (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -241,7 +238,7 @@ instructionHelper registry varReader blockComponent fromMaybeSTM CDB{..} = do
         -- Just return the contents of the state and end the transaction in
         -- these two cases.
         ReaderInit
-          -> return $ Left (RollBackTo genesisPoint, Nothing)
+          -> return $ Left (RollBackTo GenesisPoint, Nothing)
         ReaderInImmDB rollState immIt
           -> return $ Left (rollState, Just immIt)
 
@@ -468,7 +465,7 @@ forward registry varReader blockComponent CDB{..} = \pts -> do
         -- state of the reader.
         -> case readerState of
             ReaderInit
-              | pt == genesisPoint
+              | pt == GenesisPoint
               -- The 'ReaderInit' state is equivalent to @'RollBackTo'
               -- 'genesisPoint'@, so the state doesn't have to change when
               -- requesting a rollback to genesis.
@@ -498,7 +495,7 @@ forward registry varReader blockComponent CDB{..} = \pts -> do
                 updateState ReaderInit
                 return $ Just pt
 
-              At pt' -> do
+              NotOrigin pt' -> do
                 inImmDB <- ImmDB.hasBlock cdbImmDB pt'
                 if inImmDB then do
                   immIt <- ImmDB.streamAfterKnownBlock cdbImmDB registry

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -71,12 +71,8 @@ import           GHC.Stack (HasCallStack, callStack)
 import           Control.Monad.Class.MonadSTM.Strict (newEmptyTMVarM)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..))
-import           Cardano.Slotting.Slot (EpochNo)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
-import           Ouroboros.Network.Block (BlockNo, HasHeader, HeaderHash, Point,
-                     SlotNo)
-import           Ouroboros.Network.Point (WithOrigin)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
@@ -11,8 +11,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Init (
 import           Data.Coerce
 import           Data.Functor.Contravariant
 
-import           Ouroboros.Network.Block
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Serialisation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Serialisation.hs
@@ -70,7 +70,8 @@ import           GHC.Generics (Generic)
 import           Cardano.Binary (enforceSize)
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (Serialised (..), fromSerialised,
+                     mkSerialised)
 import           Ouroboros.Network.BlockFetch (SizeInBytes)
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/Common.hs
@@ -27,8 +27,6 @@ import           Data.ByteString.Short (ShortByteString)
 import           Data.Word
 import           GHC.Generics
 
-import           Cardano.Slotting.Slot
-
 import           Ouroboros.Network.DeltaQ (SizeInBytes)
 
 import           Ouroboros.Consensus.Block
@@ -40,8 +38,8 @@ import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
 -------------------------------------------------------------------------------}
 
 tipIsGenesis :: WithOrigin r -> Bool
-tipIsGenesis Origin = True
-tipIsGenesis (At _) = False
+tipIsGenesis Origin        = True
+tipIsGenesis (NotOrigin _) = False
 
 {-------------------------------------------------------------------------------
   BinaryBlockInfo

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
@@ -24,14 +24,13 @@ module Ouroboros.Consensus.Storage.ImmutableDB.API
 
 import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..),
                      ThunkInfo (..))
-import           Cardano.Slotting.Block
-import           Cardano.Slotting.Slot
 
 import           Data.ByteString.Builder (Builder)
 
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
 import           Ouroboros.Consensus.Storage.Common

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks/Internal.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks/Internal.hs
@@ -44,8 +44,8 @@ import           Data.Word
 import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
-import           Cardano.Slotting.Slot
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.CallStack
 import           Ouroboros.Consensus.Util.RedundantConstraints
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks/Layout.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks/Layout.hs
@@ -44,9 +44,8 @@ import           GHC.Generics (Generic)
 import           GHC.Stack
 
 import           Cardano.Prelude (NoUnexpectedThunks)
-import           Cardano.Slotting.Slot
 
-import           Ouroboros.Consensus.Block.EBB
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Storage.ImmutableDB.Types (BlockOrEBB (..))
 
 -- Most types in the Chunks interface are opaque in the public API, since their

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Secondary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Secondary.hs
@@ -34,11 +34,8 @@ import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
-import           Cardano.Slotting.Slot
 
-import           Ouroboros.Network.Block (SlotNo (..))
-
-import           Ouroboros.Consensus.Block (IsEBB (..))
+import           Ouroboros.Consensus.Block hiding (hashSize, headerHash)
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Consensus.Storage.FS.API

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
@@ -32,11 +32,10 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..),
                      allNoUnexpectedThunks, forceElemsToWHNF)
-import           Cardano.Slotting.Slot
 
 import           GHC.Stack (HasCallStack)
 
-import           Ouroboros.Consensus.Block (IsEBB (..))
+import           Ouroboros.Consensus.Block hiding (headerHash)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceKey,
                      ResourceRegistry, allocate, release, unsafeRelease)
@@ -146,7 +145,7 @@ streamImpl dbEnv registry blockComponent mbStart mbEnd =
           -- If any of the two bounds were specified, 'validateIteratorRange'
           -- would have thrown a 'ReadFutureSlotError'.
           assert (isNothing mbStart && isNothing mbEnd) $ return mkEmptyIterator
-        At tip -> do
+        NotOrigin tip -> do
           WithHash endHash endChunkSlot <- fillInEndBound   currentIndex tip mbEnd
           (secondaryOffset, start)      <- fillInStartBound currentIndex     mbStart
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Util.hs
@@ -40,8 +40,7 @@ import qualified Data.Text as T
 import           GHC.Stack (HasCallStack, callStack)
 import           Text.Read (readMaybe)
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.IOLike
 
@@ -174,8 +173,8 @@ validateIteratorRange chunkInfo tip mbStart mbEnd = runExceptT $ do
   where
     isNewerThanTip :: SlotNo -> Bool
     isNewerThanTip slot = case tip of
-      Origin -> True
-      At b   -> slot > slotNoOfBlockOrEBB chunkInfo b
+      Origin      -> True
+      NotOrigin b -> slot > slotNoOfBlockOrEBB chunkInfo b
 
 -- | Wrapper around 'Get.runGetOrFail' that throws an 'InvalidFileError' when
 -- it failed or when there was unconsumed input.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Types.hs
@@ -48,8 +48,6 @@ import           Streaming (Of, Stream)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..),
                      UseIsNormalFormNamed (..))
-import           Cardano.Slotting.Block
-import           Cardano.Slotting.Slot
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Storage.Common

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -81,9 +81,8 @@ import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
-import           Cardano.Slotting.Slot
 
-import           Ouroboros.Consensus.Block.RealPoint
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Util
@@ -507,7 +506,7 @@ ledgerDbTip :: LedgerDB l r -> WithOrigin r
 ledgerDbTip LedgerDB{..} =
     case ledgerDbBlocks of
       Empty    -> csTip ledgerDbAnchor
-      _ :|> cp -> At (cpBlock cp)
+      _ :|> cp -> NotOrigin (cpBlock cp)
 
 -- | Have we seen at least @k@ blocks?
 ledgerDbIsSaturated :: LedgerDB l r -> Bool
@@ -527,7 +526,7 @@ ledgerDbIsSaturated LedgerDB{..} =
 shiftAnchor :: forall r l. HasCallStack
             => StrictSeq (Checkpoint l r) -> ChainSummary l r -> ChainSummary l r
 shiftAnchor toRemove ChainSummary{..} = ChainSummary {
-      csTip    = At csTip'
+      csTip    = NotOrigin csTip'
     , csLength = csLength + fromIntegral (Seq.length toRemove)
     , csLedger = csLedger'
     }
@@ -720,7 +719,7 @@ ledgerDbPast cfg tip db
           _otherwise                  -> Just blocks'
       where
         blocks' :: StrictSeq (Checkpoint l r)
-        blocks' = Seq.dropWhileR (\cp -> At (cpBlock cp) /= tip) blocks
+        blocks' = Seq.dropWhileR (\cp -> NotOrigin (cpBlock cp) /= tip) blocks
 
 {-------------------------------------------------------------------------------
   Updates

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -45,8 +45,7 @@ import           GHC.Generics (Generic)
 import           GHC.Stack
 import           Text.Read (readMaybe)
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr,
                      readIncremental)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/API.hs
@@ -16,9 +16,9 @@ import           GHC.Stack (HasCallStack)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..))
 
-import           Ouroboros.Network.Block (MaxSlotNo, SlotNo)
-import           Ouroboros.Network.Point (WithOrigin)
+import           Ouroboros.Network.Block (MaxSlotNo)
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Consensus.Storage.Common (BlockComponent (..),

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
@@ -114,9 +114,9 @@ import qualified Data.Set as Set
 import           Data.Word (Word64)
 import           GHC.Stack
 
-import           Ouroboros.Network.Block (MaxSlotNo (..), SlotNo)
-import           Ouroboros.Network.Point (WithOrigin)
+import           Ouroboros.Network.Block (MaxSlotNo (..))
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.IOLike
 import qualified Ouroboros.Consensus.Util.MonadSTM.RAWLock as RAWLock
 import           Ouroboros.Consensus.Util.ResourceRegistry (allocateTemp,

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/FileInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/FileInfo.hs
@@ -27,8 +27,9 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block (MaxSlotNo (..), SlotNo)
+import           Ouroboros.Network.Block (MaxSlotNo (..))
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Storage.VolatileDB.Types
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Util.hs
@@ -27,13 +27,12 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import           Text.Read (readMaybe)
 
-import           Ouroboros.Network.Point (WithOrigin)
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util (lastMaybe)
+import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Consensus.Storage.FS.API.Types
 import           Ouroboros.Consensus.Storage.VolatileDB.Types
-import           Ouroboros.Consensus.Util.IOLike
 
 {------------------------------------------------------------------------------
   FileId utilities

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Types.hs
@@ -35,10 +35,7 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block hiding (Tip, decodeTip, encodeTip)
-import           Ouroboros.Network.Point (WithOrigin)
-
-import           Ouroboros.Consensus.Block (IsEBB)
+import           Ouroboros.Consensus.Block
 
 import           Ouroboros.Consensus.Storage.FS.API.Types
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/TypeFamilyWrappers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/TypeFamilyWrappers.hs
@@ -37,8 +37,6 @@ import           Codec.Serialise (Serialise)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.Block (HeaderHash)
-
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -20,7 +20,6 @@ import           GHC.Stack
 import           Ouroboros.Network.AnchoredFragment
                      (AnchoredFragment ((:>), Empty))
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (HasHeader, blockPoint)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
@@ -48,9 +48,7 @@ import qualified Streaming as S
 import           Streaming.Prelude (Of (..), Stream)
 import qualified Streaming.Prelude as S
 
-import           Cardano.Slotting.Slot (WithOrigin, withOriginFromMaybe,
-                     withOriginToMaybe)
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Consensus.Storage.FS.API

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -37,13 +37,14 @@ import           Cardano.Crypto.KES (MockKES, NeverKES, SigKES,
                      pattern SignKeyMockKES, SignedKES (..), SimpleKES,
                      SingleKES, SumKES, VerKeyKES, pattern VerKeyMockKES,
                      pattern VerKeySingleKES, pattern VerKeySumKES)
-import           Cardano.Slotting.Slot (WithOrigin (..))
-
-import           Ouroboros.Network.Block (BlockNo (..), ChainHash (..),
-                     HeaderHash, SlotNo (..))
 
 import           Ouroboros.Consensus.Util.HList (All, HList (..))
 import qualified Ouroboros.Consensus.Util.HList as HList
+
+-- Imports from lower-level libs to avoid circular dependencies
+import           Cardano.Slotting.Block (BlockNo (..))
+import           Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..))
+import           Ouroboros.Network.Block (ChainHash (..), HeaderHash)
 
 {-------------------------------------------------------------------------------
   Main class

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -40,11 +40,9 @@ import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..),
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (HasHeader, HeaderHash, Point (..))
 import           Ouroboros.Network.MockChain.Chain (Chain (..))
-import           Ouroboros.Network.Point (WithOrigin (..), blockPointHash,
-                     blockPointSlot)
 
+import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Util.Condense
 
 {-------------------------------------------------------------------------------
@@ -52,12 +50,8 @@ import           Ouroboros.Consensus.Util.Condense
 -------------------------------------------------------------------------------}
 
 instance Condense (HeaderHash block) => Condense (Point block) where
-    condense (Point Origin)        = "Origin"
-    condense (Point (At blk)) =
-      "(Point " <> condense ptSlot <> ", " <> condense ptHash <> ")"
-      where
-      ptSlot = blockPointSlot blk
-      ptHash = blockPointHash blk
+    condense GenesisPoint     = "Origin"
+    condense (BlockPoint s h) = "(Point " <> condense s <> ", " <> condense h <> ")"
 
 instance Condense block => Condense (Chain block) where
     condense Genesis   = "Genesis"

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/TraceSize.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/TraceSize.hs
@@ -14,9 +14,6 @@ import           Control.Monad.IO.Class
 import           Control.Tracer
 import           Data.Word
 
-import           Ouroboros.Network.Block (Point (..), SlotNo (..))
-import           Ouroboros.Network.Point (WithOrigin (..))
-
 import           Ouroboros.Consensus.Block
 
 import           Ouroboros.Consensus.Storage.LedgerDB.InMemory (LedgerDB)
@@ -72,5 +69,5 @@ traceLedgerDbSize p (Tracer f) = Tracer $ \(!db) -> do
             }
   where
     shouldTrace :: WithOrigin (RealPoint blk) -> Bool
-    shouldTrace Origin  = p 0
-    shouldTrace (At pt) = p (unSlotNo (realPointSlot pt))
+    shouldTrace Origin         = p 0
+    shouldTrace (NotOrigin pt) = p (unSlotNo (realPointSlot pt))

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
@@ -25,11 +25,11 @@ import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck hiding (Fixed)
 
 import           Cardano.Prelude (AllowThunk (..), NoUnexpectedThunks)
-import           Cardano.Slotting.Slot (SlotNo (..))
 
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.IOSim
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -29,14 +29,11 @@ import           Data.Word
 import           GHC.Generics (Generic)
 import           Quiet (Quiet (..))
 
-import           Cardano.Slotting.Slot
-
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 import           Test.Util.Time (dawnOfTime)
 
-import           Ouroboros.Network.Block
 import qualified Ouroboros.Network.MockChain.Chain as Mock
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -52,11 +52,11 @@ import           GHC.Generics (Generic)
 import           Cardano.Crypto.ProtocolMagic
 import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
 import           Cardano.Slotting.EpochInfo
-import           Cardano.Slotting.Slot
 
 import           Test.Util.Time (dawnOfTime)
 
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,
+                     wrapCBORinCBOR)
 import           Ouroboros.Network.Magic
 
 import           Ouroboros.Consensus.Block
@@ -371,10 +371,10 @@ instance SingleEraBlock BlockA where
       -- time (when successful) must not be subject to rollback.
       let confirmationDepth =
             case ledgerTipSlot st of
-              Origin -> error "impossible"
-              At s   -> if s < confirmedInSlot
-                          then error "impossible"
-                          else History.countSlots s confirmedInSlot
+              Origin      -> error "impossible"
+              NotOrigin s -> if s < confirmedInSlot
+                               then error "impossible"
+                               else History.countSlots s confirmedInSlot
       guard $ confirmationDepth >= stabilityWindowA (lcfgA_k cfg)
 
       -- Consensus /also/ insists that as long as the transition to the next era

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -43,11 +43,11 @@ import           GHC.Generics (Generic)
 
 import           Cardano.Crypto.ProtocolMagic
 import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
-import           Cardano.Slotting.Slot
 
 import           Test.Util.Time (dawnOfTime)
 
-import           Ouroboros.Network.Block
+import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,
+                     wrapCBORinCBOR)
 import           Ouroboros.Network.Magic
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/Common.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/Common.hs
@@ -20,9 +20,8 @@ import qualified Data.ByteString as Strict
 import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
-import           Cardano.Slotting.Slot
 
-import           Ouroboros.Network.Block
+import           Ouroboros.Consensus.Block
 
 {-------------------------------------------------------------------------------
   Types shared by A and B

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/History.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/History.hs
@@ -30,8 +30,8 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import           Cardano.Slotting.EpochInfo
-import           Cardano.Slotting.Slot
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Forecast
 import qualified Ouroboros.Consensus.HardFork.History as HF
@@ -501,7 +501,7 @@ chainTip (Chain xs) = tip . reverse . concat . toList $ xs
   where
     tip :: [Event] -> WithOrigin (EpochNo, SlotNo)
     tip []    = Origin
-    tip (e:_) = At (eventTimeEpochNo (eventTime e), eventTimeSlot (eventTime e))
+    tip (e:_) = NotOrigin (eventTimeEpochNo (eventTime e), eventTimeSlot (eventTime e))
 
 -- | Find all confirmed transitions in the chain
 chainTransitions :: Eras xs -> Chain xs -> HF.Transitions xs
@@ -845,4 +845,4 @@ mockHardForkLedgerView = \(HF.Shape pss) (HF.Transitions ts) (Chain ess) ->
 
     tip :: [Event] -> WithOrigin SlotNo
     tip [] = Origin
-    tip es = At $ eventTimeSlot $ eventTime (last es)
+    tip es = NotOrigin $ eventTimeSlot $ eventTime (last es)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Infra.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Infra.hs
@@ -32,8 +32,7 @@ import           Data.SOP.Strict
 import           Data.Word
 import           Test.QuickCheck
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import qualified Ouroboros.Consensus.HardFork.History as HF
 import           Ouroboros.Consensus.Util.Counting

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Summary.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Summary.hs
@@ -16,8 +16,7 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import qualified Ouroboros.Consensus.HardFork.History as HF
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -36,10 +36,7 @@ import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Control.Tracer (Tracer (..))
 
-import           Ouroboros.Network.Block (pattern BlockPoint, HeaderHash,
-                     SlotNo, pointSlot)
-import           Ouroboros.Network.Point (WithOrigin (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
@@ -555,8 +552,8 @@ applyTxToLedger (SimpleLedgerState mockState) tx =
       SimpleLedgerState mockState' { mockTip = BlockPoint slot' hash' }
 
     slot' = case pointSlot $ mockTip mockState of
-      Origin -> 0
-      At s   -> succ s
+      Origin      -> 0
+      NotOrigin s -> succ s
 
     -- A little trick to instantiate the phantom parameter of 'Hash' (and
     -- 'HeaderHash') with 'TestBlock' while actually hashing the slot number:

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -27,11 +27,11 @@ import           Test.Tasty.QuickCheck
 import           Control.Monad.IOSim (runSimOrThrow)
 
 import           Cardano.Crypto.DSIGN.Mock
-import           Cardano.Slotting.Slot
+
+import           Ouroboros.Network.Block (getTipPoint)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block hiding (ChainUpdate (..))
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Driver
 import           Ouroboros.Network.MockChain.Chain (Chain (Genesis))
@@ -39,8 +39,6 @@ import qualified Ouroboros.Network.MockChain.Chain as Chain
 import           Ouroboros.Network.MockChain.ProducerState (chainState,
                      initChainProducerState)
 import qualified Ouroboros.Network.MockChain.ProducerState as CPS
-import           Ouroboros.Network.Point (WithOrigin (..), blockPointHash,
-                     blockPointSlot)
 import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
 import           Ouroboros.Network.Protocol.ChainSync.Codec (codecChainSyncId)
 import           Ouroboros.Network.Protocol.ChainSync.Examples
@@ -49,6 +47,7 @@ import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
 import           Ouroboros.Network.Protocol.ChainSync.Server
 import           Ouroboros.Network.Protocol.ChainSync.Type (ChainSync)
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Config.SecurityParam
@@ -705,15 +704,11 @@ ppBlock :: TestBlock -> String
 ppBlock = condense
 
 ppPoint :: StandardHash blk => Point blk -> String
-ppPoint (Point Origin)   = "Origin"
-ppPoint (Point (At blk)) =
-    "(S:" <> show s <> "; H:" <> show h <> ")"
-  where
-    SlotNo s = blockPointSlot blk
-    h        = blockPointHash blk
+ppPoint GenesisPoint              = "Origin"
+ppPoint (BlockPoint (SlotNo s) h) = "(S:" <> show s <> "; H:" <> show h <> ")"
 
 ppChain :: Chain TestBlock -> String
-ppChain = ppBlocks genesisPoint . Chain.toOldestFirst
+ppChain = ppBlocks GenesisPoint . Chain.toOldestFirst
 
 ppFragment :: AnchoredFragment TestBlock -> String
 ppFragment f = ppBlocks (AF.anchorPoint f) (AF.toOldestFirst f)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -14,11 +14,8 @@ import           Control.Monad.IOSim (runSimOrThrow)
 import           Cardano.Crypto.DSIGN.Mock
 
 import           Network.TypedProtocol.Proofs (connect)
-import           Ouroboros.Network.Block (Point (..), SlotNo, blockPoint,
-                     pointSlot)
 import           Ouroboros.Network.MockChain.Chain (Chain (..))
 import qualified Ouroboros.Network.MockChain.Chain as Chain
-import           Ouroboros.Network.Point (WithOrigin (..))
 import           Ouroboros.Network.Protocol.LocalStateQuery.Client
 import           Ouroboros.Network.Protocol.LocalStateQuery.Examples
                      (localStateQueryClient)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/GcSchedule.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/GcSchedule.hs
@@ -14,8 +14,7 @@ import           Data.Void (Void)
 
 import           Control.Monad.IOSim (runSimOrThrow)
 
-import           Ouroboros.Network.Block (SlotNo (..))
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util (lastMaybe, safeMaximum)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -18,15 +18,10 @@ import qualified Data.ByteString.Lazy as Lazy
 import           Data.List (intercalate)
 import qualified Data.Map.Strict as Map
 
-import           Cardano.Slotting.Slot hiding (At)
-
 import           Control.Monad.IOSim (runSimOrThrow)
 
-import           Ouroboros.Network.Block (ChainHash (..), HasHeader (..),
-                     HeaderHash)
 import           Ouroboros.Network.MockChain.Chain (Chain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
-import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.Condense (condense)
@@ -402,7 +397,7 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
       , VolDB.bslot         = blockSlot tb
       , VolDB.bpreBid       = case getPrevHash tb of
           GenesisHash -> Origin
-          BlockHash h -> At h
+          BlockHash h -> NotOrigin h
       , VolDB.bisEBB        = testBlockIsEBB tb
       , VolDB.bheaderOffset = 0
       , VolDB.bheaderSize   = 0

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
@@ -16,10 +16,7 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
-import           Ouroboros.Network.Block (pattern BlockPoint,
-                     pattern GenesisPoint, HasHeader (..), Point, genesisPoint)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
-import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -52,7 +49,7 @@ addBlocks blks = M.addBlocks cfg blks m
 prop_getBlock_addBlock :: BlockTree -> Permutation -> Property
 prop_getBlock_addBlock bt p =
         M.getBlock (blockHash newBlock) (M.addBlock singleNodeTestConfig newBlock model)
-    === if At (blockNo newBlock) > M.immutableBlockNo secParam model
+    === if NotOrigin (blockNo newBlock) > M.immutableBlockNo secParam model
         then Just newBlock
         else Nothing
   where
@@ -99,7 +96,7 @@ prop_between_currentChain bt =
   where
     blocks   = treeToBlocks bt
     model    = addBlocks blocks
-    from     = StreamFromExclusive genesisPoint
+    from     = StreamFromExclusive GenesisPoint
     to       = StreamToInclusive $ cantBeGenesis (M.tipPoint model)
     secParam = configSecurityParam singleNodeTestConfig
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -8,8 +8,7 @@ import           Control.Tracer (nullTracer)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit
 
-import           Cardano.Slotting.Slot
-
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -60,12 +60,6 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
 import           Cardano.Prelude (AllowThunk (..), NoUnexpectedThunks)
-import           Cardano.Slotting.Slot hiding (At)
-import qualified Cardano.Slotting.Slot as S
-
-import           Ouroboros.Network.Block (BlockNo (..), HasHeader (..),
-                     HeaderHash, SlotNo (..))
-import qualified Ouroboros.Network.Block as Block
 
 import           Ouroboros.Consensus.Block
 import qualified Ouroboros.Consensus.Util.Classify as C
@@ -94,6 +88,7 @@ import           Test.Util.FS.Sim.Error (Errors, mkSimErrorHasFS, withErrors)
 import qualified Test.Util.FS.Sim.MockFS as Mock
 import           Test.Util.Orphans.Arbitrary (genSmallSlotNo)
 import           Test.Util.Orphans.Slotting.Arbitrary ()
+import           Test.Util.Orphans.ToExpr ()
 import           Test.Util.QuickCheck (collects)
 import           Test.Util.RefEnv (RefEnv)
 import qualified Test.Util.RefEnv as RE
@@ -615,7 +610,7 @@ generateCmd Model {..} = At <$> frequency
         chunk = chunkIndexOfSlot dbmChunkInfo s
         size  = getChunkSize     dbmChunkInfo chunk
 
-    empty = dbmTip dbModel == S.Origin
+    empty = dbmTip dbModel == Origin
 
     noBlocks = all isNothing (dbmRegular dbModel)
 
@@ -790,8 +785,8 @@ precondition Model {..} (At (CmdErr { cmd })) =
   where
     fitsOnTip :: TestBlock -> Logic
     fitsOnTip b = case dbmTipBlock dbModel of
-      Nothing    -> getPrevHash b .== Block.GenesisHash
-      Just bPrev -> getPrevHash b .== Block.BlockHash (blockHash bPrev)
+      Nothing    -> getPrevHash b .== GenesisHash
+      Just bPrev -> getPrevHash b .== BlockHash (blockHash bPrev)
 
 transition :: (Show1 r, Eq1 r)
            => Model m r -> At CmdErr m r -> At Resp m r -> Model m r
@@ -1164,9 +1159,6 @@ instance CommandNames (At CmdErr m) where
   cmdNames (_ :: Proxy (At CmdErr m r)) =
     constrNames (Proxy @(Cmd (IterRef m r)))
 
-instance ToExpr SlotNo where
-  toExpr (SlotNo w) = App "SlotNo" [toExpr w]
-
 instance ToExpr EpochNo
 instance ToExpr EpochSize
 instance ToExpr ChunkSize
@@ -1183,7 +1175,7 @@ instance (ToExpr a, ToExpr b, ToExpr c, ToExpr d, ToExpr e, ToExpr f, ToExpr g,
       ]
 instance ToExpr (IteratorResult AllComponents)
 instance ToExpr (IteratorModel Hash)
-instance ToExpr (HeaderHash h) => ToExpr (Block.ChainHash h)
+instance ToExpr (HeaderHash h) => ToExpr (ChainHash h)
 instance ToExpr EBB
 instance ToExpr IsEBB
 instance ToExpr ChainLength
@@ -1194,7 +1186,6 @@ instance ToExpr TestBody
 instance ToExpr TestBlock
 instance ToExpr ImmDB.BlockOrEBB
 instance (ToExpr a, ToExpr hash) => ToExpr (ImmDB.TipInfo hash a)
-instance ToExpr r => ToExpr (S.WithOrigin r)
 instance ToExpr BinaryBlockInfo
 instance ToExpr hash => ToExpr (InSlot hash)
 instance ToExpr PrefixLen

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -19,10 +19,9 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Slotting.Slot
-
 import           Ouroboros.Network.Testing.Serialise (prop_serialise)
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
@@ -159,7 +158,7 @@ prop_pastLedger setup@ChainSetup{..} =
     tip :: WithOrigin TestBlock
     tip = case prefix of
             []         -> Origin
-            _otherwise -> At (last prefix)
+            _otherwise -> NotOrigin (last prefix)
 
     afterPrefix :: LedgerDB (LedgerState TestBlock) TestBlock
     afterPrefix = ledgerDbPushMany' (eraParams setup) prefix csGenSnaps
@@ -234,7 +233,7 @@ prop_pastAfterSwitch setup@SwitchSetup{..} =
     tip :: WithOrigin TestBlock
     tip = case prefix of
             []         -> Origin
-            _otherwise -> At (last prefix)
+            _otherwise -> NotOrigin (last prefix)
 
     afterPrefix :: LedgerDB (LedgerState TestBlock) TestBlock
     afterPrefix = ledgerDbPushMany' (eraParams ssChainSetup) prefix (csGenSnaps ssChainSetup)
@@ -437,4 +436,4 @@ instance Arbitrary (Trivial (WithOrigin Int)) where
   arbitrary = fmap Trivial $ do
                 gen <- arbitrary
                 if gen then return Origin
-                       else At <$> arbitrary
+                       else NotOrigin <$> arbitrary

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -82,12 +82,9 @@ import           Control.Monad.Class.MonadThrow
 
 import           Cardano.Crypto.DSIGN
 import           Cardano.Prelude (NoUnexpectedThunks)
-import           Cardano.Slotting.Slot
 
-import           Ouroboros.Network.Block
 import           Ouroboros.Network.MockChain.Chain (Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
-import           Ouroboros.Network.Point (WithOrigin (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
@@ -311,7 +308,7 @@ testBlockToBlockInfo tb = BlockInfo {
     , bslot         = thSlotNo
     , bpreBid       = case thPrevHash of
         GenesisHash -> Origin
-        BlockHash h -> At h
+        BlockHash h -> NotOrigin h
     , bisEBB        = blockToIsEBB tb
     , bheaderOffset = testBlockHeaderOffset
     , bheaderSize   = testBlockHeaderSize tb

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -42,9 +42,9 @@ import qualified Data.Set as Set
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 
-import           Ouroboros.Network.Block (MaxSlotNo (..), SlotNo)
-import           Ouroboros.Network.Point (WithOrigin)
+import           Ouroboros.Network.Block (MaxSlotNo (..))
 
+import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..),
                      BlockComponent (..), PrefixLen (..), extractHeader,
                      takePrefix)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -39,12 +39,7 @@ import           GHC.Stack
 import           System.Random (getStdRandom, randomR)
 import           Text.Show.Pretty (ppShow)
 
-import           Cardano.Slotting.Slot (EpochNo (..))
-
-import           Ouroboros.Network.Block (BlockNo (..), ChainHash (..),
-                     MaxSlotNo (..), SlotNo (..), blockHash)
-import           Ouroboros.Network.Point (WithOrigin)
-import qualified Ouroboros.Network.Point as WithOrigin
+import           Ouroboros.Network.Block (MaxSlotNo)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr)
@@ -426,8 +421,8 @@ generatorCmdImpl Model {..} = frequency
 
     genWithOriginBlockId :: Gen (WithOrigin BlockId)
     genWithOriginBlockId = frequency
-      [ (1, return WithOrigin.Origin)
-      , (8, WithOrigin.At <$> genBlockId)
+      [ (1, return Origin)
+      , (8, NotOrigin <$> genBlockId)
       ]
 
     -- In general, we only want to GC part of the blocks, not all of them


### PR DESCRIPTION
We now consistently only import from `Ouroboros.Consensus.Block` for block
related stuff, including things we used to import from `network` and/or
`cardano-base`.

This also renames `At` to `NotOrigin` (at least within consensus) to avoid the
frequent clashes with our use of `At` in the tests.

We no longer export the crazy `Block` type from `network` but only export the
pattern synonyms; and `RealPoint` doesn't use `Block` at all anymore.