### PR TITLE
Avoid needing instance for `GetPrevHash` for both headers and blocks

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
@@ -203,15 +203,12 @@ instance HasHeader (Header ByronBlock) where
   blockNo   = fromByronBlockNo . CC.abobHdrChainDifficulty . byronHeaderRaw
 
 instance GetPrevHash ByronBlock where
-  getPrevHash = castHash . getPrevHash . getHeader
-
-instance GetPrevHash (Header ByronBlock) where
-  getPrevHash = fromByronPrevHash' . CC.abobHdrPrevHash . byronHeaderRaw
+  headerPrevHash = fromByronPrevHash' . CC.abobHdrPrevHash . byronHeaderRaw
 
 instance Measured BlockMeasure ByronBlock where
   measure = blockMeasure
 
-fromByronPrevHash' :: Maybe CC.HeaderHash -> ChainHash (Header ByronBlock)
+fromByronPrevHash' :: Maybe CC.HeaderHash -> ChainHash ByronBlock
 fromByronPrevHash' = fromByronPrevHash ByronHash
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
@@ -89,10 +89,7 @@ instance HasHeader ByronSpecHeader where
   blockSlot = fromByronSpecSlotNo . Spec._bhSlot . byronSpecHeader
 
 instance GetPrevHash ByronSpecBlock where
-  getPrevHash = castHash . getPrevHash . getHeader
-
-instance GetPrevHash ByronSpecHeader where
-  getPrevHash = fromByronSpecPrevHash id . Spec._bhPrevHash . byronSpecHeader
+  headerPrevHash = fromByronSpecPrevHash id . Spec._bhPrevHash . byronSpecHeader
 
 {-------------------------------------------------------------------------------
   Config

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -141,10 +141,7 @@ instance Crypto c => HasHeader (Header (ShelleyBlock c)) where
   blockNo    = coerce . SL.bheaderBlockNo . SL.bhbody . shelleyHeaderRaw
 
 instance Crypto c => GetPrevHash (ShelleyBlock c)  where
-  getPrevHash = castHash . getPrevHash . getHeader
-
-instance Crypto c => GetPrevHash (Header (ShelleyBlock c)) where
-  getPrevHash =
+  headerPrevHash =
       fromShelleyPrevHash
     . SL.bheaderPrev
     . SL.bhbody
@@ -166,7 +163,7 @@ instance Crypto c => HasAnnTip (ShelleyBlock c)
 -------------------------------------------------------------------------------}
 
 -- | From @cardano-ledger-specs@ to @ouroboros-consensus@
-fromShelleyPrevHash :: SL.PrevHash c -> ChainHash (Header (ShelleyBlock c))
+fromShelleyPrevHash :: SL.PrevHash c -> ChainHash (ShelleyBlock c)
 fromShelleyPrevHash SL.GenesisHash   = GenesisHash
 fromShelleyPrevHash (SL.BlockHash h) = BlockHash (ShelleyHash h)
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
@@ -55,11 +55,7 @@ deriving instance StandardHash blk => Show (MockError blk)
 deriving instance StandardHash blk => Eq   (MockError blk)
 deriving instance Serialise (HeaderHash blk) => Serialise (MockError blk)
 
-updateMockState :: ( GetHeader blk
-                   , GetPrevHash (Header blk)
-                   , StandardHash blk
-                   , HasMockTxs blk
-                   )
+updateMockState :: (GetPrevHash blk, HasMockTxs blk)
                 => blk
                 -> MockState blk
                 -> Except (MockError blk) (MockState blk)
@@ -68,7 +64,7 @@ updateMockState blk st = do
     st' <- updateMockTip hdr st
     updateMockUTxO (blockSlot hdr) blk st'
 
-updateMockTip :: (GetPrevHash (Header blk), StandardHash blk)
+updateMockTip :: GetPrevHash blk
               => Header blk
               -> MockState blk
               -> Except (MockError blk) (MockState blk)

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/Consensus/Ledger/Mock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/Consensus/Ledger/Mock.hs
@@ -10,6 +10,7 @@ import           Codec.Serialise (Serialise, encode)
 import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Proxy
+import           Data.Typeable
 
 import           Test.QuickCheck
 import           Test.Tasty
@@ -46,7 +47,8 @@ tests = testGroup "Mock"
 -------------------------------------------------------------------------------}
 
 prop_simpleBlockBinaryBlockInfo
-  :: (SimpleCrypto c, Serialise ext) => SimpleBlock c ext -> Property
+  :: (SimpleCrypto c, Serialise ext, Typeable ext)
+  => SimpleBlock c ext -> Property
 prop_simpleBlockBinaryBlockInfo blk =
     serialisedHeader === extractedHeader
   where

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Util/SimpleBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Util/SimpleBlock.hs
@@ -4,6 +4,8 @@ module Test.ThreadNet.Util.SimpleBlock (
   prop_validSimpleBlock,
   ) where
 
+import           Data.Typeable
+
 import           Test.QuickCheck
 
 import           Ouroboros.Consensus.Block
@@ -11,7 +13,7 @@ import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Util.Condense (condense)
 
 prop_validSimpleBlock
-  :: HasHeader (SimpleBlock' c ext ext')
+  :: (SimpleCrypto c, Typeable ext, Typeable ext')
   => SimpleBlock' c ext ext' -> Property
 prop_validSimpleBlock blk = conjoin $ map each $ simpleTxs $ simpleBody blk
   where

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util.hs
@@ -125,7 +125,7 @@ blockInfo b = BlockInfo
     { biSlot     = blockSlot b
     , biCreator  = Just $ getCreator b
     , biHash     = BlockHash $ blockHash b
-    , biPrevious = Just $ getPrevHash b
+    , biPrevious = Just $ blockPrevHash b
     }
 
 data NodeLabel = NodeLabel

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -198,12 +198,10 @@ instance HasHeader (Header TestBlock) where
   blockNo   = blockNo   . testHeader
 
 instance GetPrevHash TestBlock where
-  getPrevHash b = case NE.nonEmpty . NE.tail . unTestHash . tbHash $ b of
-    Nothing       -> GenesisHash
-    Just prevHash -> BlockHash (TestHash prevHash)
-
-instance GetPrevHash (Header TestBlock) where
-  getPrevHash = castHash . getPrevHash . testHeader
+  headerPrevHash (TestHeader b) =
+      case NE.nonEmpty . NE.tail . unTestHash . tbHash $ b of
+        Nothing       -> GenesisHash
+        Just prevHash -> BlockHash (TestHash prevHash)
 
 instance StandardHash TestBlock
 
@@ -285,8 +283,8 @@ instance IsLedger (LedgerState TestBlock) where
 
 instance ApplyBlock (LedgerState TestBlock) TestBlock where
   applyLedgerBlock _ tb@TestBlock{..} (Ticked _ TestLedger{..})
-    | getPrevHash tb /= pointHash lastAppliedPoint
-    = throwError $ InvalidHash (pointHash lastAppliedPoint) (getPrevHash tb)
+    | blockPrevHash tb /= pointHash lastAppliedPoint
+    = throwError $ InvalidHash (pointHash lastAppliedPoint) (blockPrevHash tb)
     | not tbValid
     = throwError $ InvalidBlock
     | otherwise

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -13,7 +13,7 @@ module Ouroboros.Consensus.Block.Abstract (
   , HasCodecConfig(..)
     -- * Previous hash
   , GetPrevHash(..)
-  , headerPrevHash
+  , blockPrevHash
     -- * Working with headers
   , GetHeader(..)
   , headerHash
@@ -101,22 +101,22 @@ class NoUnexpectedThunks (CodecConfig blk) => HasCodecConfig blk where
   Get hash of previous block
 -------------------------------------------------------------------------------}
 
-class HasHeader blk => GetPrevHash blk where
+class (HasHeader blk, GetHeader blk) => GetPrevHash blk where
   -- | Get the hash of the predecessor of this block
   --
   -- This gets its own abstraction, because it will be a key part of the path
   -- to getting rid of EBBs: when we have blocks @A - EBB - B@, the prev hash
   -- of @B@ will be reported as @A@.
-  getPrevHash :: blk -> ChainHash blk
+  headerPrevHash :: Header blk -> ChainHash blk
 
-headerPrevHash :: GetPrevHash (Header blk) => Header blk -> ChainHash blk
-headerPrevHash = castHash . getPrevHash
+blockPrevHash :: GetPrevHash blk => blk -> ChainHash blk
+blockPrevHash = castHash . headerPrevHash . getHeader
 
 {-------------------------------------------------------------------------------
   Link block to its header
 -------------------------------------------------------------------------------}
 
-class GetHeader blk where
+class HasHeader (Header blk) => GetHeader blk where
   data family Header blk :: *
   getHeader          :: blk -> Header blk
   -- | Check whether the header is the header of the block.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
@@ -18,7 +18,6 @@ import           Ouroboros.Consensus.Protocol.Abstract
 -- | Evidence that a block supports its protocol
 class ( GetHeader blk
       , GetPrevHash blk
-      , GetPrevHash (Header blk)
       , ConsensusProtocol (BlockProtocol blk)
       , NoUnexpectedThunks (Header blk)
       , NoUnexpectedThunks (BlockConfig blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -236,18 +236,6 @@ instance CanHardFork xs => HasHeader (OneEraHeader xs) where
   blockSlot = hcollapse . hcmap proxySingle (K . blockSlot) . getOneEraHeader
   blockNo   = hcollapse . hcmap proxySingle (K . blockNo)   . getOneEraHeader
 
-instance CanHardFork xs => GetPrevHash (OneEraHeader xs) where
-  getPrevHash = hcollapse
-              . hcmap proxySingle (K . getOnePrev)
-              . getOneEraHeader
-    where
-      getOnePrev :: forall blk. SingleEraBlock blk
-                 => Header blk -> ChainHash (OneEraHeader xs)
-      getOnePrev hdr =
-          case getPrevHash hdr of
-            GenesisHash -> GenesisHash
-            BlockHash h -> BlockHash (OneEraHash $ toRawHash (Proxy @blk) h)
-
 {-------------------------------------------------------------------------------
   HasHeader instance for OneEraBlock
 -------------------------------------------------------------------------------}
@@ -263,9 +251,6 @@ instance CanHardFork xs => HasHeader (OneEraBlock xs) where
   blockHash = blockHash . oneEraBlockHeader
   blockSlot = blockSlot . oneEraBlockHeader
   blockNo   = blockNo   . oneEraBlockHeader
-
-instance CanHardFork xs => GetPrevHash (OneEraBlock xs) where
-  getPrevHash = castHash . getPrevHash . oneEraBlockHeader
 
 {-------------------------------------------------------------------------------
   NoUnexpectedThunks instances

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -173,11 +173,8 @@ instance SingleEraBlock b => HasHeader (Header (DegenFork b)) where
   blockSlot =         blockSlot . unDHdr
   blockNo   =         blockNo   . unDHdr
 
-instance SingleEraBlock b => GetPrevHash (DegenFork b) where
-  getPrevHash = castHash . getPrevHash . unDBlk
-
-instance SingleEraBlock b => GetPrevHash (Header (DegenFork b)) where
-  getPrevHash = castHash . getPrevHash . unDHdr
+instance NoHardForks b => GetPrevHash (DegenFork b) where
+  headerPrevHash = castHash . headerPrevHash . unDHdr
 
 {-------------------------------------------------------------------------------
   Forward the 'ConsensusProtocol' instance

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -307,7 +307,7 @@ class ( HasHeader (Header blk)
 
 -- | Validate header envelope
 class ( BasicEnvelopeValidation blk
-      , GetPrevHash (Header blk)
+      , GetPrevHash blk
       , Eq                 (OtherHeaderEnvelopeError blk)
       , Show               (OtherHeaderEnvelopeError blk)
       , NoUnexpectedThunks (OtherHeaderEnvelopeError blk)
@@ -391,7 +391,7 @@ deriving instance (BlockSupportsProtocol blk, ValidateEnvelope blk)
                => Eq                 (HeaderError blk)
 deriving instance (BlockSupportsProtocol blk, ValidateEnvelope blk)
                => Show               (HeaderError blk)
-deriving instance (BlockSupportsProtocol blk, ValidateEnvelope blk)
+deriving instance (BlockSupportsProtocol blk, ValidateEnvelope blk, Typeable blk)
                => NoUnexpectedThunks (HeaderError blk)
 
 castHeaderError :: (   ValidationErr (BlockProtocol blk )

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -128,7 +128,7 @@ instance ConvertRawHash m => ConvertRawHash (DualBlock m a) where
   Header
 -------------------------------------------------------------------------------}
 
-instance GetHeader m => GetHeader (DualBlock m a) where
+instance Bridge m a => GetHeader (DualBlock m a) where
   newtype Header (DualBlock m a) = DualHeader { dualHeaderMain :: Header m }
     deriving NoUnexpectedThunks via AllowThunk (Header (DualBlock m a))
 
@@ -248,10 +248,7 @@ instance Bridge m a => HasHeader (DualHeader m a) where
   blockNo   = blockNo   . dualHeaderMain
 
 instance Bridge m a => GetPrevHash (DualBlock m a) where
-  getPrevHash = castHash . getPrevHash . getHeader
-
-instance Bridge m a => GetPrevHash (DualHeader m a) where
-  getPrevHash = castHash . getPrevHash . dualHeaderMain
+  headerPrevHash = castHash . headerPrevHash . dualHeaderMain
 
 {-------------------------------------------------------------------------------
   Protocol

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -139,7 +139,6 @@ copyToImmDB
      , ConsensusProtocol (BlockProtocol blk)
      , HasHeader blk
      , GetHeader blk
-     , HasHeader (Header blk)
      , VolDbSerialiseConstraints blk
      , ImmDbSerialiseConstraints blk
      , HasCallStack
@@ -248,7 +247,6 @@ copyAndSnapshotRunner
      , ConsensusProtocol (BlockProtocol blk)
      , HasHeader blk
      , GetHeader blk
-     , HasHeader (Header blk)
      , HasCodecConfig blk
      , ImmDbSerialiseConstraints blk
      , LgrDbSerialiseConstraints blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -456,7 +456,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
         return tipPoint
 
       -- The block @b@ fits onto the end of our current chain
-      | pointHash tipPoint == castHash (getPrevHash hdr) -> do
+      | pointHash tipPoint == headerPrevHash hdr -> do
         -- ### Add to current chain
         trace (TryAddToCurrentChain p)
         addToCurrentChain succsOf' curChainAndLedger

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
@@ -210,7 +210,6 @@ hashInfo p = HashInfo { hashSize, getHash, putHash }
 withImmDB
   :: ( IOLike m
      , GetPrevHash blk
-     , GetHeader blk
      , ConvertRawHash blk
      , ImmDbSerialiseConstraints blk
      )
@@ -222,7 +221,6 @@ openDB
   :: forall m blk.
      ( IOLike m
      , GetPrevHash blk
-     , GetHeader blk
      , ConvertRawHash blk
      , ImmDbSerialiseConstraints blk
      )

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reader.hs
@@ -86,7 +86,6 @@ newReader
   :: forall m blk b.
      ( IOLike m
      , HasHeader blk
-     , HasHeader (Header blk)
      , GetHeader blk
      , HasCodecConfig blk
      , ImmDbSerialiseConstraints blk
@@ -127,7 +126,6 @@ makeNewReader
   :: forall m blk b.
      ( IOLike m
      , HasHeader blk
-     , HasHeader (Header blk)
      , GetHeader blk
      , HasCodecConfig blk
      , ImmDbSerialiseConstraints blk
@@ -209,7 +207,6 @@ instructionHelper
   :: forall m blk b f.
      ( IOLike m
      , HasHeader blk
-     , HasHeader (Header blk)
      , GetHeader blk
      , HasCodecConfig blk
      , ImmDbSerialiseConstraints blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Parser.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Parser.hs
@@ -65,7 +65,6 @@ data BlockSummary hash = BlockSummary {
 chunkFileParser
   :: forall m blk h hash. (
        IOLike m
-     , GetHeader blk
      , GetPrevHash blk
      , hash ~ HeaderHash blk
      )
@@ -150,7 +149,7 @@ chunkFileParser hasFS decodeBlock getBinaryBlockInfo isNotCorrupt =
         (BlockSummary entry (blockNo blk), prevHash)
       where
         -- Don't accidentally hold on to the block!
-        !prevHash = convertPrevHash $ getPrevHash blk
+        !prevHash = convertPrevHash $ blockPrevHash blk
         !entry    = Secondary.Entry
           { blockOffset  = Secondary.BlockOffset  offset
           , headerOffset = Secondary.HeaderOffset headerOffset

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -189,10 +189,7 @@ instance HasHeader (Header BlockA) where
   blockNo   = headerFieldNo   . hdrA_fields
 
 instance GetPrevHash BlockA where
-  getPrevHash = castHash . getPrevHash . getHeader
-
-instance GetPrevHash (Header BlockA) where
-  getPrevHash = castHash . headerFieldPrevHash . hdrA_fields
+  headerPrevHash = headerFieldPrevHash . hdrA_fields
 
 instance HasAnnTip BlockA where
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -168,10 +168,7 @@ instance HasHeader (Header BlockB) where
   blockNo   = headerFieldNo   . hdrB_fields
 
 instance GetPrevHash BlockB where
-  getPrevHash = castHash . getPrevHash . getHeader
-
-instance GetPrevHash (Header BlockB) where
-  getPrevHash = castHash . headerFieldPrevHash . hdrB_fields
+  headerPrevHash = headerFieldPrevHash . hdrB_fields
 
 instance HasAnnTip BlockB where
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -395,7 +395,7 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
     blockInfo tb = VolDB.BlockInfo
       { VolDB.bbid          = blockHash tb
       , VolDB.bslot         = blockSlot tb
-      , VolDB.bpreBid       = case getPrevHash tb of
+      , VolDB.bpreBid       = case blockPrevHash tb of
           GenesisHash -> Origin
           BlockHash h -> NotOrigin h
       , VolDB.bisEBB        = testBlockIsEBB tb

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -820,7 +820,7 @@ successors :: forall blk. GetPrevHash blk
 successors = Map.unionsWith Map.union . map single
   where
     single :: blk -> Map (ChainHash blk) (Map (HeaderHash blk) blk)
-    single b = Map.singleton (getPrevHash b)
+    single b = Map.singleton (blockPrevHash b)
                              (Map.singleton (blockHash b) b)
 
 between :: forall blk. GetPrevHash blk

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -785,8 +785,8 @@ precondition Model {..} (At (CmdErr { cmd })) =
   where
     fitsOnTip :: TestBlock -> Logic
     fitsOnTip b = case dbmTipBlock dbModel of
-      Nothing    -> getPrevHash b .== GenesisHash
-      Just bPrev -> getPrevHash b .== BlockHash (blockHash bPrev)
+      Nothing    -> blockPrevHash b .== GenesisHash
+      Just bPrev -> blockPrevHash b .== BlockHash (blockHash bPrev)
 
 transition :: (Show1 r, Eq1 r)
            => Model m r -> At CmdErr m r -> At Resp m r -> Model m r

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -223,10 +223,7 @@ instance HasHeader (Header TestBlock) where
   blockNo   = thBlockNo . unTestHeader
 
 instance GetPrevHash TestBlock where
-  getPrevHash = castHash . getPrevHash  . getHeader
-
-instance GetPrevHash (Header TestBlock) where
-  getPrevHash = castHash . thPrevHash . unTestHeader
+  headerPrevHash = castHash . thPrevHash . unTestHeader
 
 data instance BlockConfig TestBlock = TestBlockConfig {
       -- | Whether the test block can be EBBs or not. This can vary per test
@@ -553,8 +550,8 @@ instance IsLedger (LedgerState TestBlock) where
 
 instance ApplyBlock (LedgerState TestBlock) TestBlock where
   applyLedgerBlock _ tb@TestBlock{..} (Ticked _ TestLedger{..})
-    | getPrevHash tb /= lastAppliedHash
-    = throwError $ InvalidHash lastAppliedHash (getPrevHash tb)
+    | blockPrevHash tb /= lastAppliedHash
+    = throwError $ InvalidHash lastAppliedHash (blockPrevHash tb)
     | not $ tbIsValid testBody
     = throwError $ InvalidBlock
     | otherwise


### PR DESCRIPTION
Make `headerPrevHash` the primitive, and `blockPrevHash` derived. This means we only need to give/require the instance for `GetPrevHash` for headers, and don't need to duplicate it for blocks (which is now just a single function `blockPrevHash`).