### PR TITLE
Provide context in `GetPrevHash`

### DIFF
--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -42,8 +42,8 @@ import           Ouroboros.Network.Protocol.Handshake.Version (DictVersion,
                      Versions, foldMapVersions)
 import qualified Ouroboros.Network.Snocket as Snocket
 
-import           Ouroboros.Consensus.Block (getCodecConfig)
-import           Ouroboros.Consensus.Config (TopLevelConfig, configBlock)
+import           Ouroboros.Consensus.Config (TopLevelConfig, configBlock,
+                     configCodec)
 import           Ouroboros.Consensus.Config.SupportsNode (getNetworkMagic)
 import           Ouroboros.Consensus.Network.NodeToClient (ClientCodecs,
                      cChainSyncCodec, cStateQueryCodec, cTxSubmissionCodec,
@@ -110,4 +110,4 @@ versionedProtocols blkProxy topLevelConfig p
       versionedNodeToClientProtocols
         (nodeToClientProtocolVersion blkProxy v)
         (NodeToClientVersionData { networkMagic = getNetworkMagic blockConfig })
-        (p v $ clientCodecs (getCodecConfig blockConfig) v)
+        (p v $ clientCodecs (configCodec topLevelConfig) v)

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -68,21 +68,25 @@ protocolInfoDualByron :: forall m. Monad m
 protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params mLeader =
     ProtocolInfo {
         pInfoConfig = TopLevelConfig {
-            configConsensus = PBftConfig {
-                pbftParams = params
+            topLevelConfigProtocol = FullProtocolConfig {
+                protocolConfigConsensus = PBftConfig {
+                    pbftParams = params
+                  }
+              , protocolConfigIndep  = ()
               }
-          , configIndep  = ()
-          , configLedger = DualLedgerConfig {
-                dualLedgerConfigMain = concreteGenesis
-              , dualLedgerConfigAux  = abstractConfig
-              }
-          , configBlock = DualBlockConfig {
-                dualBlockConfigMain = concreteConfig
-              , dualBlockConfigAux  = ByronSpecBlockConfig
-              }
-          , configCodec = DualCodecConfig {
-                dualCodecConfigMain = mkByronCodecConfig concreteGenesis
-              , dualCodecConfigAux  = ByronSpecCodecConfig
+          , topLevelConfigBlock = FullBlockConfig {
+                blockConfigLedger = DualLedgerConfig {
+                    dualLedgerConfigMain = concreteGenesis
+                  , dualLedgerConfigAux  = abstractConfig
+                  }
+              , blockConfigBlock = DualBlockConfig {
+                    dualBlockConfigMain = concreteConfig
+                  , dualBlockConfigAux  = ByronSpecBlockConfig
+                  }
+              , blockConfigCodec = DualCodecConfig {
+                    dualCodecConfigMain = mkByronCodecConfig concreteGenesis
+                  , dualCodecConfigAux  = ByronSpecCodecConfig
+                  }
               }
           }
       , pInfoInitLedger = ExtLedgerState {

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -80,6 +80,9 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params mLeader =
                 dualBlockConfigMain = concreteConfig
               , dualBlockConfigAux  = ByronSpecBlockConfig
               }
+          , configCodec = DualCodecConfig {
+                dualCodecConfigMain = mkByronCodecConfig concreteGenesis
+              }
           }
       , pInfoInitLedger = ExtLedgerState {
              ledgerState = DualLedgerState {

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -82,6 +82,7 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params mLeader =
               }
           , configCodec = DualCodecConfig {
                 dualCodecConfigMain = mkByronCodecConfig concreteGenesis
+              , dualCodecConfigAux  = ByronSpecCodecConfig
               }
           }
       , pInfoInitLedger = ExtLedgerState {

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
@@ -69,7 +69,8 @@ instance DecodeDisk DualByronBlock (Lazy.ByteString -> DualByronBlock) where
       epochSlots = extractEpochSlots ccfg
 
 instance DecodeDiskDep (NestedCtxt Header) DualByronBlock where
-  decodeDiskDep (DualCodecConfig ccfg) (NestedCtxt (CtxtDual ctxt)) =
+  decodeDiskDep (DualCodecConfig ccfg ByronSpecCodecConfig)
+                (NestedCtxt (CtxtDual ctxt)) =
       decodeDiskDep ccfg (NestedCtxt ctxt)
 
 instance EncodeDisk DualByronBlock (LedgerState DualByronBlock) where

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -41,7 +41,6 @@ import qualified Cardano.Crypto.DSIGN as Crypto
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
                      ProtocolInfo (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -40,7 +40,7 @@ import qualified Cardano.Crypto as Crypto
 import qualified Cardano.Crypto.DSIGN as Crypto
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Config (TopLevelConfig (..))
+import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..),
                      ProtocolInfo (..))
@@ -384,8 +384,8 @@ mkProtocolRealPBftAndHardForkTxs
       , tniProtocolInfo = pInfo
       }
   where
-    ProtocolInfo{pInfoConfig}   = pInfo
-    TopLevelConfig{configBlock} = pInfoConfig
+    ProtocolInfo{pInfoConfig} = pInfo
+    bcfg = configBlock pInfoConfig
 
     pInfo :: ProtocolInfo m ByronBlock
     pInfo = mkProtocolRealPBFT params cid genesisConfig genesisSecrets
@@ -408,7 +408,7 @@ mkProtocolRealPBftAndHardForkTxs
         loopbackAnnotations $
         -- signed by delegate SK
         Vote.signVote
-          (Byron.byronProtocolMagicId configBlock)
+          (Byron.byronProtocolMagicId bcfg)
           (Update.recoverUpId proposal)
           True   -- the serialization hardwires this value anyway
           (Crypto.noPassSafeSigner opKey)
@@ -435,15 +435,15 @@ mkHardForkProposal
 mkHardForkProposal params genesisConfig genesisSecrets propPV =
     -- signed by delegate SK
     Proposal.signProposal
-      (Byron.byronProtocolMagicId configBlock)
+      (Byron.byronProtocolMagicId bcfg)
       propBody
       (Crypto.noPassSafeSigner opKey)
   where
     pInfo :: ProtocolInfo Identity ByronBlock
     pInfo = mkProtocolRealPBFT params (CoreNodeId 0) genesisConfig genesisSecrets
 
-    ProtocolInfo{pInfoConfig}   = pInfo
-    TopLevelConfig{configBlock} = pInfoConfig
+    ProtocolInfo{pInfoConfig} = pInfo
+    bcfg = configBlock pInfoConfig
 
     Crypto.SignKeyByronDSIGN opKey = getOpKey pInfo
 

--- a/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Serialisation.hs
@@ -22,8 +22,6 @@ import           Cardano.Chain.Block (ABlockOrBoundary (..))
 import qualified Cardano.Chain.Block as CC.Block
 import qualified Cardano.Chain.Update as CC.Update
 
-
-import           Ouroboros.Consensus.Block (getCodecConfig)
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Serialisation ()
@@ -116,4 +114,4 @@ testCfg = pInfoConfig protocolInfo
 
 -- | Matches the values used for the generators.
 testCodecCfg :: CodecConfig ByronBlock
-testCodecCfg = getCodecConfig (configBlock testCfg)
+testCodecCfg = configCodec testCfg

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
@@ -39,7 +39,6 @@ import qualified Test.Cardano.Chain.Elaboration.UTxO as Spec.Test
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Dual
 import           Ouroboros.Consensus.Ledger.SupportsMempool

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
@@ -1285,12 +1285,12 @@ mkRekeyUpd
   -> Crypto.SignKeyDSIGN Crypto.ByronDSIGN
   -> Maybe (TestNodeInitialization m ByronBlock)
 mkRekeyUpd genesisConfig genesisSecrets pInfo eno newSK =
-  case pInfoLeaderCreds of
+  case pInfoLeaderCreds pInfo of
     Nothing              -> Nothing
     Just (isLeader, mfs) ->
       let PBftIsLeader{pbftCoreNodeId} = isLeader
           genSK = genesisSecretFor genesisConfig genesisSecrets pbftCoreNodeId
-          isLeader' = updSignKey genSK configBlock isLeader (coerce eno) newSK
+          isLeader' = updSignKey genSK bcfg isLeader (coerce eno) newSK
           pInfo' = pInfo { pInfoLeaderCreds = Just (isLeader', mfs) }
 
           PBftIsLeader{pbftDlgCert} = isLeader'
@@ -1299,10 +1299,7 @@ mkRekeyUpd genesisConfig genesisSecrets pInfo eno newSK =
         , tniProtocolInfo = pInfo'
         }
   where
-    ProtocolInfo{
-        pInfoConfig = TopLevelConfig{configBlock}
-      , pInfoLeaderCreds
-      } = pInfo
+    bcfg = configBlock (pInfoConfig pInfo)
 
 -- | The secret key for a node index
 --

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
@@ -37,7 +37,6 @@ import qualified Ouroboros.Network.MockChain.Chain as Chain
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.PBFT

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
@@ -203,7 +203,7 @@ instance HasHeader (Header ByronBlock) where
       }
 
 instance GetPrevHash ByronBlock where
-  headerPrevHash = fromByronPrevHash' . CC.abobHdrPrevHash . byronHeaderRaw
+  headerPrevHash _cfg = fromByronPrevHash' . CC.abobHdrPrevHash . byronHeaderRaw
 
 instance Measured BlockMeasure ByronBlock where
   measure = blockMeasure

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
@@ -7,12 +7,15 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Byron.Ledger.Config (
+    -- * Block config
     BlockConfig(..)
-  , CodecConfig(..)
   , byronGenesisHash
   , byronProtocolMagicId
   , byronProtocolMagic
   , byronEpochSlots
+    -- * Codec config
+  , CodecConfig(..)
+  , mkByronCodecConfig
   ) where
 
 import           GHC.Generics (Generic)
@@ -29,6 +32,10 @@ import           Ouroboros.Consensus.Config.SecurityParam
 
 import           Ouroboros.Consensus.Byron.Ledger.Block
 import           Ouroboros.Consensus.Byron.Ledger.Conversions
+
+{-------------------------------------------------------------------------------
+  Block config
+-------------------------------------------------------------------------------}
 
 -- | Extended configuration we need for Byron
 data instance BlockConfig ByronBlock = ByronConfig {
@@ -61,14 +68,18 @@ byronProtocolMagic = CC.Genesis.configProtocolMagic . byronGenesisConfig
 byronEpochSlots :: BlockConfig ByronBlock -> CC.Slot.EpochSlots
 byronEpochSlots = CC.Genesis.configEpochSlots . byronGenesisConfig
 
-instance HasCodecConfig ByronBlock where
-  data CodecConfig ByronBlock = ByronCodecConfig {
-        getByronEpochSlots    :: !CC.Slot.EpochSlots
-      , getByronSecurityParam :: !SecurityParam
-      }
-    deriving (Generic, NoUnexpectedThunks)
+{-------------------------------------------------------------------------------
+  Codec config
+-------------------------------------------------------------------------------}
 
-  getCodecConfig bcfg = ByronCodecConfig {
-      getByronEpochSlots    = byronEpochSlots bcfg
-    , getByronSecurityParam = genesisSecurityParam (byronGenesisConfig bcfg)
+data instance CodecConfig ByronBlock = ByronCodecConfig {
+      getByronEpochSlots    :: !CC.Slot.EpochSlots
+    , getByronSecurityParam :: !SecurityParam
+    }
+  deriving (Generic, NoUnexpectedThunks)
+
+mkByronCodecConfig :: CC.Genesis.Config -> CodecConfig ByronBlock
+mkByronCodecConfig cfg = ByronCodecConfig {
+      getByronEpochSlots    = CC.Genesis.configEpochSlots cfg
+    , getByronSecurityParam = genesisSecurityParam cfg
     }

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
@@ -1,7 +1,6 @@
 module Ouroboros.Consensus.Byron.Ledger.Conversions (
     -- * From @cardano-ledger@ to @ouroboros-consensus@
-    fromByronPrevHash
-  , fromByronSlotNo
+    fromByronSlotNo
   , fromByronBlockNo
   , fromByronBlockCount
   , fromByronEpochSlots
@@ -21,7 +20,6 @@ import qualified Data.Set as Set
 
 import           Cardano.Prelude (Natural)
 
-import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Common as CC
 import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Slotting as CC
@@ -36,11 +34,6 @@ import           Ouroboros.Consensus.Node.ProtocolInfo
 {-------------------------------------------------------------------------------
   From @cardano-ledger@ to @ouroboros-consensus@
 -------------------------------------------------------------------------------}
-
-fromByronPrevHash :: (CC.HeaderHash -> HeaderHash b)
-                  -> Maybe CC.HeaderHash -> ChainHash b
-fromByronPrevHash _ Nothing  = GenesisHash
-fromByronPrevHash f (Just h) = BlockHash (f h)
 
 fromByronSlotNo :: CC.SlotNumber -> SlotNo
 fromByronSlotNo = coerce

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -125,6 +125,7 @@ protocolInfoByron genesisConfig mSigThresh pVer sVer mLeader =
           , configIndep  = ()
           , configLedger = genesisConfig
           , configBlock  = byronConfig
+          , configCodec  = mkByronCodecConfig genesisConfig
           }
       , pInfoInitLedger = ExtLedgerState {
             ledgerState = initByronLedgerState genesisConfig Nothing

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -33,7 +33,6 @@ import           Ouroboros.Network.Magic (NetworkMagic (..))
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime (SystemStart (..))
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -119,13 +119,17 @@ protocolInfoByron :: forall m. Monad m
 protocolInfoByron genesisConfig mSigThresh pVer sVer mLeader =
     ProtocolInfo {
         pInfoConfig = TopLevelConfig {
-            configConsensus = PBftConfig {
-                pbftParams = byronPBftParams genesisConfig mSigThresh
+            topLevelConfigProtocol = FullProtocolConfig {
+                protocolConfigConsensus = PBftConfig {
+                    pbftParams = byronPBftParams genesisConfig mSigThresh
+                  }
+              , protocolConfigIndep = ()
               }
-          , configIndep  = ()
-          , configLedger = genesisConfig
-          , configBlock  = byronConfig
-          , configCodec  = mkByronCodecConfig genesisConfig
+          , topLevelConfigBlock = FullBlockConfig {
+                blockConfigLedger = genesisConfig
+              , blockConfigBlock  = byronConfig
+              , blockConfigCodec  = mkByronCodecConfig genesisConfig
+              }
           }
       , pInfoInitLedger = ExtLedgerState {
             ledgerState = initByronLedgerState genesisConfig Nothing

--- a/ouroboros-consensus-byron/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-byron/tools/db-analyser/Main.hs
@@ -350,7 +350,7 @@ withImmDB fp cfg chunkInfo registry = ImmDB.withImmDB args
     args :: ImmDbArgs IO ByronBlock
     args = (defaultArgs fp) {
           immGetBinaryBlockInfo = nodeGetBinaryBlockInfo
-        , immCodecConfig        = getCodecConfig $ configBlock cfg
+        , immCodecConfig        = configCodec cfg
         , immChunkInfo          = chunkInfo
         , immValidation         = ValidateMostRecentChunk
         , immCheckIntegrity     = nodeCheckIntegrity cfg

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
@@ -10,11 +10,14 @@ module Ouroboros.Consensus.ByronSpec.Ledger.Block (
   , ByronSpecHeader -- type alias
   , Header(..)
   , BlockConfig(..)
+  , CodecConfig(..)
   ) where
 
 import           Codec.Serialise
 import           Data.FingerTree.Strict (Measured (..))
 import           GHC.Generics (Generic)
+
+import           Cardano.Prelude (NoUnexpectedThunks)
 
 import qualified Byron.Spec.Chain.STS.Block as Spec
 import qualified Byron.Spec.Ledger.Core as Spec
@@ -96,3 +99,7 @@ instance GetPrevHash ByronSpecBlock where
 -------------------------------------------------------------------------------}
 
 data instance BlockConfig ByronSpecBlock = ByronSpecBlockConfig
+  deriving (Generic, NoUnexpectedThunks)
+
+data instance CodecConfig ByronSpecBlock = ByronSpecCodecConfig
+  deriving (Generic, NoUnexpectedThunks)

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
@@ -92,7 +92,7 @@ instance HasHeader ByronSpecHeader where
       }
 
 instance GetPrevHash ByronSpecBlock where
-  headerPrevHash = fromByronSpecPrevHash id . Spec._bhPrevHash . byronSpecHeader
+  headerPrevHash _cfg = fromByronSpecPrevHash id . Spec._bhPrevHash . byronSpecHeader
 
 {-------------------------------------------------------------------------------
   Config

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -43,7 +43,6 @@ import           Cardano.Prelude (Natural, cborError)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -386,12 +386,12 @@ protocolInfoCardano genesisByron mSigThresh pVer sVer mbCredsByron
               :* Nil
               )
           }
-      , configIndep     = PerEraChainIndepStateConfig
+      , configIndep = PerEraChainIndepStateConfig
               (  WrapChainIndepStateConfig ()
               :* WrapChainIndepStateConfig tpraosParams
               :* Nil
               )
-      , configLedger    = HardForkLedgerConfig {
+      , configLedger = HardForkLedgerConfig {
             hardForkLedgerConfigK      = k
           , hardForkLedgerConfigShape  = shape
           , hardForkLedgerConfigPerEra = PerEraLedgerConfig
@@ -400,7 +400,14 @@ protocolInfoCardano genesisByron mSigThresh pVer sVer mbCredsByron
               :* Nil
               )
           }
-      , configBlock     = CardanoBlockConfig blockConfigByron blockConfigShelley
+      , configBlock =
+          CardanoBlockConfig
+            blockConfigByron
+            blockConfigShelley
+      , configCodec =
+          CardanoCodecConfig
+            (Byron.mkByronCodecConfig genesisByron)
+            Shelley.ShelleyCodecConfig
       }
 
     creds :: Maybe
@@ -467,6 +474,7 @@ projByronTopLevelConfig cfg = byronCfg
         configBlock     = CardanoBlockConfig     byronBlockCfg     _
       , configConsensus = CardanoConsensusConfig byronConsensusCfg _
       , configLedger    = CardanoLedgerConfig    byronLedgerCfg    _
+      , configCodec     = CardanoCodecConfig     byronCodecCfg     _
       } = cfg
 
     byronCfg :: TopLevelConfig ByronBlock
@@ -475,4 +483,5 @@ projByronTopLevelConfig cfg = byronCfg
       , configConsensus = byronConsensusCfg
       , configIndep     = ()
       , configLedger    = byronLedgerConfig byronLedgerCfg
+      , configCodec     = byronCodecCfg
       }

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -141,7 +141,7 @@ instance Crypto c => HasHeader (Header (ShelleyBlock c)) where
     }
 
 instance Crypto c => GetPrevHash (ShelleyBlock c)  where
-  headerPrevHash =
+  headerPrevHash _cfg =
       fromShelleyPrevHash
     . SL.bheaderPrev
     . SL.bhbody

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
@@ -5,8 +5,8 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Shelley.Ledger.Config (
     BlockConfig (..)
-  , CodecConfig (..)
   , mkShelleyBlockConfig
+  , CodecConfig (..)
   ) where
 
 import           GHC.Generics (Generic)
@@ -39,13 +39,6 @@ data instance BlockConfig (ShelleyBlock c) = ShelleyConfig {
   deriving stock (Show, Generic)
   deriving anyclass NoUnexpectedThunks
 
-instance HasCodecConfig (ShelleyBlock c) where
-  -- | No particular codec configuration is needed for Shelley
-  data CodecConfig (ShelleyBlock c) = ShelleyCodecConfig
-    deriving (Generic, NoUnexpectedThunks)
-
-  getCodecConfig = const ShelleyCodecConfig
-
 mkShelleyBlockConfig :: SL.ProtVer -> SL.ShelleyGenesis c -> BlockConfig (ShelleyBlock c)
 mkShelleyBlockConfig protVer genesis = ShelleyConfig {
       shelleyProtocolVersion = protVer
@@ -53,3 +46,11 @@ mkShelleyBlockConfig protVer genesis = ShelleyConfig {
     , shelleyNetworkMagic    = NetworkMagic $ SL.sgNetworkMagic    genesis
     , shelleyProtocolMagicId =                SL.sgProtocolMagicId genesis
     }
+
+{-------------------------------------------------------------------------------
+  Codec config
+-------------------------------------------------------------------------------}
+
+-- | No particular codec configuration is needed for Shelley
+data instance CodecConfig (ShelleyBlock c) = ShelleyCodecConfig
+  deriving (Generic, NoUnexpectedThunks)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -67,7 +67,6 @@ import           Ouroboros.Network.Block (Serialised (..), decodePoint,
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Forecast
 import           Ouroboros.Consensus.HardFork.Abstract
 import qualified Ouroboros.Consensus.HardFork.History as HardFork

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -147,11 +147,15 @@ protocolInfoShelley genesis initialNonce maxMajorPV protVer mbCredentials =
   where
     topLevelConfig :: TopLevelConfig (ShelleyBlock c)
     topLevelConfig = TopLevelConfig {
-        configConsensus = consensusConfig
-      , configIndep     = tpraosParams
-      , configLedger    = ledgerConfig
-      , configBlock     = blockConfig
-      , configCodec     = ShelleyCodecConfig
+        topLevelConfigProtocol = FullProtocolConfig {
+            protocolConfigConsensus = consensusConfig
+          , protocolConfigIndep     = tpraosParams
+          }
+      , topLevelConfigBlock = FullBlockConfig {
+            blockConfigLedger = ledgerConfig
+          , blockConfigBlock  = blockConfig
+          , blockConfigCodec  = ShelleyCodecConfig
+          }
       }
 
     consensusConfig :: ConsensusConfig (BlockProtocol (ShelleyBlock c))

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -151,6 +151,7 @@ protocolInfoShelley genesis initialNonce maxMajorPV protVer mbCredentials =
       , configIndep     = tpraosParams
       , configLedger    = ledgerConfig
       , configBlock     = blockConfig
+      , configCodec     = ShelleyCodecConfig
       }
 
     consensusConfig :: ConsensusConfig (BlockProtocol (ShelleyBlock c))

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -37,7 +37,6 @@ import           Cardano.Slotting.EpochInfo
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Config.SupportsNode
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -253,7 +253,7 @@ instance (SimpleCrypto c, Typeable ext) => ValidateEnvelope (SimpleBlock c ext)
   -- Use defaults
 
 {-------------------------------------------------------------------------------
-  Config
+  Block config
 -------------------------------------------------------------------------------}
 
 newtype instance BlockConfig (SimpleBlock c ext) =
@@ -261,13 +261,17 @@ newtype instance BlockConfig (SimpleBlock c ext) =
   deriving stock   (Generic)
   deriving newtype (NoUnexpectedThunks)
 
-instance HasCodecConfig (SimpleBlock c ext) where
+{-------------------------------------------------------------------------------
+  Codec config
+-------------------------------------------------------------------------------}
 
-  -- | Only the 'SecurityParam' is required for simple blocks
-  newtype CodecConfig (SimpleBlock c ext) = SimpleCodecConfig SecurityParam
-    deriving newtype (NoUnexpectedThunks)
+-- | Only the 'SecurityParam' is required for simple blocks
+newtype instance CodecConfig (SimpleBlock c ext) = SimpleCodecConfig SecurityParam
+  deriving newtype (NoUnexpectedThunks)
 
-  getCodecConfig (SimpleBlockConfig secParam) = SimpleCodecConfig secParam
+{-------------------------------------------------------------------------------
+  Hard fork history
+-------------------------------------------------------------------------------}
 
 instance HasHardForkHistory (SimpleBlock c ext) where
   type HardForkIndices (SimpleBlock c ext) = '[SimpleBlock c ext]

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
@@ -56,23 +56,25 @@ deriving instance StandardHash blk => Eq   (MockError blk)
 deriving instance Serialise (HeaderHash blk) => Serialise (MockError blk)
 
 updateMockState :: (GetPrevHash blk, HasMockTxs blk)
-                => blk
+                => CodecConfig blk
+                -> blk
                 -> MockState blk
                 -> Except (MockError blk) (MockState blk)
-updateMockState blk st = do
+updateMockState cfg blk st = do
     let hdr = getHeader blk
-    st' <- updateMockTip hdr st
+    st' <- updateMockTip cfg hdr st
     updateMockUTxO (blockSlot hdr) blk st'
 
 updateMockTip :: GetPrevHash blk
-              => Header blk
+              => CodecConfig blk
+              -> Header blk
               -> MockState blk
               -> Except (MockError blk) (MockState blk)
-updateMockTip hdr (MockState u c t)
-    | headerPrevHash hdr == pointHash t
+updateMockTip cfg hdr (MockState u c t)
+    | headerPrevHash cfg hdr == pointHash t
     = return $ MockState u c (headerPoint hdr)
     | otherwise
-    = throwError $ MockInvalidHash (headerPrevHash hdr) (pointHash t)
+    = throwError $ MockInvalidHash (headerPrevHash cfg hdr) (pointHash t)
 
 updateMockUTxO :: HasMockTxs a
                => SlotNo

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -15,7 +15,6 @@ import           Data.Typeable (Typeable)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Mock.Node.Abstract

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -29,21 +29,25 @@ protocolInfoBft :: Monad m
 protocolInfoBft numCoreNodes nid securityParam eraParams =
     ProtocolInfo {
         pInfoConfig = TopLevelConfig {
-            configConsensus = BftConfig {
-                bftParams   = BftParams {
-                                  bftNumNodes      = numCoreNodes
-                                , bftSecurityParam = securityParam
-                                }
-              , bftSignKey  = signKey nid
-              , bftVerKeys  = Map.fromList [
-                    (CoreId n, verKey n)
-                  | n <- enumCoreNodes numCoreNodes
-                  ]
+            topLevelConfigProtocol = FullProtocolConfig {
+                protocolConfigConsensus = BftConfig {
+                    bftParams   = BftParams {
+                                      bftNumNodes      = numCoreNodes
+                                    , bftSecurityParam = securityParam
+                                    }
+                  , bftSignKey  = signKey nid
+                  , bftVerKeys  = Map.fromList [
+                        (CoreId n, verKey n)
+                      | n <- enumCoreNodes numCoreNodes
+                      ]
+                  }
+              , protocolConfigIndep = ()
               }
-          , configIndep  = ()
-          , configLedger = SimpleLedgerConfig () eraParams
-          , configBlock  = SimpleBlockConfig securityParam
-          , configCodec  = SimpleCodecConfig securityParam
+          , topLevelConfigBlock = FullBlockConfig {
+                blockConfigLedger = SimpleLedgerConfig () eraParams
+              , blockConfigBlock  = SimpleBlockConfig securityParam
+              , blockConfigCodec  = SimpleCodecConfig securityParam
+              }
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState ())

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -43,6 +43,7 @@ protocolInfoBft numCoreNodes nid securityParam eraParams =
           , configIndep  = ()
           , configLedger = SimpleLedgerConfig () eraParams
           , configBlock  = SimpleBlockConfig securityParam
+          , configCodec  = SimpleCodecConfig securityParam
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState ())

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -9,7 +9,6 @@ import           Cardano.Crypto.DSIGN
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Extended
@@ -26,14 +25,14 @@ protocolInfoBft :: Monad m
                 -> SecurityParam
                 -> HardFork.EraParams
                 -> ProtocolInfo m MockBftBlock
-protocolInfoBft numCoreNodes nid securityParam eraParams =
+protocolInfoBft numCoreNodes nid k eraParams =
     ProtocolInfo {
         pInfoConfig = TopLevelConfig {
             topLevelConfigProtocol = FullProtocolConfig {
                 protocolConfigConsensus = BftConfig {
                     bftParams   = BftParams {
                                       bftNumNodes      = numCoreNodes
-                                    , bftSecurityParam = securityParam
+                                    , bftSecurityParam = k
                                     }
                   , bftSignKey  = signKey nid
                   , bftVerKeys  = Map.fromList [
@@ -44,9 +43,9 @@ protocolInfoBft numCoreNodes nid securityParam eraParams =
               , protocolConfigIndep = ()
               }
           , topLevelConfigBlock = FullBlockConfig {
-                blockConfigLedger = SimpleLedgerConfig () eraParams
-              , blockConfigBlock  = SimpleBlockConfig securityParam
-              , blockConfigCodec  = SimpleCodecConfig securityParam
+                blockConfigLedger = SimpleLedgerConfig () eraParams k
+              , blockConfigBlock  = SimpleBlockConfig k
+              , blockConfigCodec  = SimpleCodecConfig k
               }
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -37,6 +37,7 @@ protocolInfoMockPBFT params eraParams nid =
           , configIndep  = ()
           , configLedger = SimpleLedgerConfig ledgerView eraParams
           , configBlock  = SimpleBlockConfig  (pbftSecurityParam params)
+          , configCodec  = SimpleCodecConfig  (pbftSecurityParam params)
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState S.empty)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -31,13 +31,17 @@ protocolInfoMockPBFT :: Monad m
 protocolInfoMockPBFT params eraParams nid =
     ProtocolInfo {
         pInfoConfig = TopLevelConfig {
-            configConsensus = PBftConfig {
-                pbftParams = params
+            topLevelConfigProtocol = FullProtocolConfig {
+                protocolConfigConsensus = PBftConfig {
+                    pbftParams = params
+                  }
+              , protocolConfigIndep = ()
               }
-          , configIndep  = ()
-          , configLedger = SimpleLedgerConfig ledgerView eraParams
-          , configBlock  = SimpleBlockConfig  (pbftSecurityParam params)
-          , configCodec  = SimpleCodecConfig  (pbftSecurityParam params)
+          , topLevelConfigBlock = FullBlockConfig {
+                blockConfigLedger = SimpleLedgerConfig ledgerView eraParams
+              , blockConfigBlock  = SimpleBlockConfig  (pbftSecurityParam params)
+              , blockConfigCodec  = SimpleCodecConfig  (pbftSecurityParam params)
+              }
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState S.empty)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -38,9 +38,9 @@ protocolInfoMockPBFT params eraParams nid =
               , protocolConfigIndep = ()
               }
           , topLevelConfigBlock = FullBlockConfig {
-                blockConfigLedger = SimpleLedgerConfig ledgerView eraParams
-              , blockConfigBlock  = SimpleBlockConfig  (pbftSecurityParam params)
-              , blockConfigCodec  = SimpleCodecConfig  (pbftSecurityParam params)
+                blockConfigLedger = SimpleLedgerConfig ledgerView eraParams k
+              , blockConfigBlock  = SimpleBlockConfig k
+              , blockConfigCodec  = SimpleCodecConfig k
               }
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
@@ -51,6 +51,9 @@ protocolInfoMockPBFT params eraParams nid =
           )
       }
   where
+    k :: SecurityParam
+    k = pbftSecurityParam params
+
     canBeLeader :: PBftIsLeader PBftMockCrypto
     canBeLeader = PBftIsLeader {
           pbftCoreNodeId = nid

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -36,17 +36,21 @@ protocolInfoPraos :: IOLike m
 protocolInfoPraos numCoreNodes nid params eraParams =
     ProtocolInfo {
         pInfoConfig = TopLevelConfig {
-            configConsensus = PraosConfig {
-                praosParams       = params
-              , praosSignKeyVRF   = signKeyVRF nid
-              , praosInitialEta   = 0
-              , praosInitialStake = genesisStakeDist addrDist
-              , praosVerKeys      = verKeys
+            topLevelConfigProtocol = FullProtocolConfig {
+                protocolConfigConsensus = PraosConfig {
+                    praosParams       = params
+                  , praosSignKeyVRF   = signKeyVRF nid
+                  , praosInitialEta   = 0
+                  , praosInitialStake = genesisStakeDist addrDist
+                  , praosVerKeys      = verKeys
+                  }
+              , protocolConfigIndep = ()
               }
-          , configIndep  = ()
-          , configLedger = SimpleLedgerConfig addrDist eraParams
-          , configBlock  = SimpleBlockConfig (praosSecurityParam params)
-          , configCodec  = SimpleCodecConfig (praosSecurityParam params)
+          , topLevelConfigBlock = FullBlockConfig {
+                blockConfigLedger = SimpleLedgerConfig addrDist eraParams
+              , blockConfigBlock  = SimpleBlockConfig (praosSecurityParam params)
+              , blockConfigCodec  = SimpleCodecConfig (praosSecurityParam params)
+              }
           }
       , pInfoInitLedger = ExtLedgerState {
             ledgerState = genesisSimpleLedgerState addrDist

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -46,6 +46,7 @@ protocolInfoPraos numCoreNodes nid params eraParams =
           , configIndep  = ()
           , configLedger = SimpleLedgerConfig addrDist eraParams
           , configBlock  = SimpleBlockConfig (praosSecurityParam params)
+          , configCodec  = SimpleCodecConfig (praosSecurityParam params)
           }
       , pInfoInitLedger = ExtLedgerState {
             ledgerState = genesisSimpleLedgerState addrDist

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -47,9 +47,9 @@ protocolInfoPraos numCoreNodes nid params eraParams =
               , protocolConfigIndep = ()
               }
           , topLevelConfigBlock = FullBlockConfig {
-                blockConfigLedger = SimpleLedgerConfig addrDist eraParams
-              , blockConfigBlock  = SimpleBlockConfig (praosSecurityParam params)
-              , blockConfigCodec  = SimpleCodecConfig (praosSecurityParam params)
+                blockConfigLedger = SimpleLedgerConfig addrDist eraParams k
+              , blockConfigBlock  = SimpleBlockConfig k
+              , blockConfigCodec  = SimpleCodecConfig k
               }
           }
       , pInfoInitLedger = ExtLedgerState {
@@ -68,6 +68,9 @@ protocolInfoPraos numCoreNodes nid params eraParams =
           )
       }
   where
+    k :: SecurityParam
+    k = praosSecurityParam params
+
     signKeyVRF :: CoreNodeId -> SignKeyVRF MockVRF
     signKeyVRF (CoreNodeId n) = SignKeyMockVRF n
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -38,21 +38,25 @@ protocolInfoPraosRule numCoreNodes
                       schedule =
     ProtocolInfo {
       pInfoConfig = TopLevelConfig {
-          configConsensus = WLSConfig {
-              wlsConfigSchedule = schedule
-            , wlsConfigP        = PraosConfig
-                { praosParams       = params
-                , praosSignKeyVRF   = NeverUsedSignKeyVRF
-                , praosInitialEta   = 0
-                , praosInitialStake = genesisStakeDist addrDist
-                , praosVerKeys      = verKeys
+          topLevelConfigProtocol = FullProtocolConfig {
+              protocolConfigConsensus = WLSConfig {
+                  wlsConfigSchedule = schedule
+                , wlsConfigP        = PraosConfig
+                    { praosParams       = params
+                    , praosSignKeyVRF   = NeverUsedSignKeyVRF
+                    , praosInitialEta   = 0
+                    , praosInitialStake = genesisStakeDist addrDist
+                    , praosVerKeys      = verKeys
+                    }
+                , wlsConfigNodeId   = nid
                 }
-            , wlsConfigNodeId   = nid
+            , protocolConfigIndep = ()
             }
-        , configIndep  = ()
-        , configLedger = SimpleLedgerConfig () eraParams
-        , configBlock  = SimpleBlockConfig (praosSecurityParam params)
-        , configCodec  = SimpleCodecConfig (praosSecurityParam params)
+        , topLevelConfigBlock = FullBlockConfig {
+              blockConfigLedger = SimpleLedgerConfig () eraParams
+            , blockConfigBlock  = SimpleBlockConfig (praosSecurityParam params)
+            , blockConfigCodec  = SimpleCodecConfig (praosSecurityParam params)
+            }
         }
     , pInfoInitLedger = ExtLedgerState
         { ledgerState = genesisSimpleLedgerState addrDist

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -52,6 +52,7 @@ protocolInfoPraosRule numCoreNodes
         , configIndep  = ()
         , configLedger = SimpleLedgerConfig () eraParams
         , configBlock  = SimpleBlockConfig (praosSecurityParam params)
+        , configCodec  = SimpleCodecConfig (praosSecurityParam params)
         }
     , pInfoInitLedger = ExtLedgerState
         { ledgerState = genesisSimpleLedgerState addrDist

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -53,9 +53,9 @@ protocolInfoPraosRule numCoreNodes
             , protocolConfigIndep = ()
             }
         , topLevelConfigBlock = FullBlockConfig {
-              blockConfigLedger = SimpleLedgerConfig () eraParams
-            , blockConfigBlock  = SimpleBlockConfig (praosSecurityParam params)
-            , blockConfigCodec  = SimpleCodecConfig (praosSecurityParam params)
+              blockConfigLedger = SimpleLedgerConfig () eraParams k
+            , blockConfigBlock  = SimpleBlockConfig k
+            , blockConfigCodec  = SimpleCodecConfig k
             }
         }
     , pInfoInitLedger = ExtLedgerState
@@ -69,6 +69,9 @@ protocolInfoPraosRule numCoreNodes
     }
   where
     addrDist = mkAddrDist numCoreNodes
+
+    k :: SecurityParam
+    k = praosSecurityParam params
 
     verKeys :: Map CoreNodeId (VerKeyKES NeverKES, VerKeyVRF NeverVRF)
     verKeys = Map.fromList [ (nid', (NeverUsedVerKeyKES, NeverUsedVerKeyVRF))

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -87,7 +87,7 @@ prop_simple_leader_schedule_convergence TestSetup
   , setupLeaderSchedule = schedule
   , setupSlotLength     = slotLength
   } =
-    counterexample (tracesToDot testOutputNodes) $
+    counterexample (tracesToDot (SimpleCodecConfig k) testOutputNodes) $
     prop_general PropGeneralArgs
       { pgaBlockProperty      = prop_validSimpleBlock
       , pgaCountTxs           = countSimpleGenTxs

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -103,7 +103,7 @@ prop_simple_praos_convergence TestSetup
   , setupNodeJoinPlan = nodeJoinPlan
   , setupSlotLength   = slotLength
   } =
-    counterexample (tracesToDot testOutputNodes) $
+    counterexample (tracesToDot (SimpleCodecConfig k) testOutputNodes) $
     prop_general PropGeneralArgs
       { pgaBlockProperty      = prop_validSimpleBlock
       , pgaCountTxs           = countSimpleGenTxs

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -917,7 +917,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
       where
         binaryProtocolCodecs =
           NTN.defaultCodecs
-            (getCodecConfig (configBlock cfg))
+            (configCodec cfg)
             (mostRecentSupportedNodeToNode (Proxy @blk))
 
 -- | Sum of 'CodecFailure' (from @identityCodecs@) and 'DeserialiseFailure'

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util.hs
@@ -118,14 +118,13 @@ genesisBlockInfo = BlockInfo
     , biPrevious = Nothing
     }
 
-
 blockInfo :: (GetPrevHash b, HasCreator b)
-          => b -> BlockInfo b
-blockInfo b = BlockInfo
+          => CodecConfig b -> b -> BlockInfo b
+blockInfo cfg b = BlockInfo
     { biSlot     = blockSlot b
     , biCreator  = Just $ getCreator b
     , biHash     = BlockHash $ blockHash b
-    , biPrevious = Just $ blockPrevHash b
+    , biPrevious = Just $ blockPrevHash cfg b
     }
 
 data NodeLabel = NodeLabel
@@ -159,15 +158,17 @@ instance Labellable EdgeLabel where
     toLabelValue = const $ StrLabel Text.empty
 
 tracesToDot :: forall b. (GetPrevHash b, HasCreator b)
-            => Map NodeId (NodeOutput b)
+            => CodecConfig b
+            -> Map NodeId (NodeOutput b)
             -> String
-tracesToDot traces = Text.unpack $ printDotGraph $ graphToDot quickParams graph
+tracesToDot cfg traces =
+    Text.unpack $ printDotGraph $ graphToDot quickParams graph
   where
     chainBlockInfos :: Chain b
                     -> Map (ChainHash b) (BlockInfo b)
     chainBlockInfos = Chain.foldChain f (Map.singleton GenesisHash genesisBlockInfo)
       where
-        f m b = let info = blockInfo b
+        f m b = let info = blockInfo cfg b
                 in  Map.insert (biHash info) info m
 
     blockInfos :: Map (ChainHash b) (BlockInfo b)

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -27,6 +27,7 @@ module Test.Util.TestBlock (
   , TestBlockError(..)
   , Header(..)
   , BlockConfig(..)
+  , CodecConfig(..)
   , Query(..)
   , firstBlock
   , successorBlock
@@ -235,6 +236,10 @@ data instance BlockConfig TestBlock = TestBlockConfig {
     }
   deriving (Generic, NoUnexpectedThunks)
 
+-- | The 'TestBlock' does not need any codec config
+data instance CodecConfig TestBlock = TestBlockCodecConfig
+  deriving (Generic, NoUnexpectedThunks)
+
 instance HasNetworkProtocolVersion TestBlock where
   -- Use defaults
 
@@ -369,6 +374,7 @@ singleNodeTestConfig = TopLevelConfig {
     , configIndep  = ()
     , configLedger = eraParams
     , configBlock  = TestBlockConfig numCoreNodes
+    , configCodec  = TestBlockCodecConfig
     }
   where
     slotLength :: SlotLength

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -364,17 +364,21 @@ testInitExtLedger = ExtLedgerState {
 -- | Trivial test configuration with a single core node
 singleNodeTestConfig :: TopLevelConfig TestBlock
 singleNodeTestConfig = TopLevelConfig {
-      configConsensus = BftConfig {
-          bftParams  = BftParams { bftSecurityParam = k
-                                 , bftNumNodes      = numCoreNodes
-                                 }
-        , bftSignKey = SignKeyMockDSIGN 0
-        , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
+      topLevelConfigProtocol = FullProtocolConfig {
+          protocolConfigConsensus = BftConfig {
+              bftParams  = BftParams { bftSecurityParam = k
+                                     , bftNumNodes      = numCoreNodes
+                                     }
+            , bftSignKey = SignKeyMockDSIGN 0
+            , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
+            }
+        , protocolConfigIndep = ()
         }
-    , configIndep  = ()
-    , configLedger = eraParams
-    , configBlock  = TestBlockConfig numCoreNodes
-    , configCodec  = TestBlockCodecConfig
+    , topLevelConfigBlock = FullBlockConfig {
+          blockConfigLedger = eraParams
+        , blockConfigBlock  = TestBlockConfig numCoreNodes
+        , blockConfigCodec  = TestBlockCodecConfig
+        }
     }
   where
     slotLength :: SlotLength

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -101,6 +101,7 @@ library
                        Ouroboros.Consensus.HardFork.History.Util
                        Ouroboros.Consensus.HeaderValidation
                        Ouroboros.Consensus.Ledger.Abstract
+                       Ouroboros.Consensus.Ledger.Basics
                        Ouroboros.Consensus.Ledger.CommonProtocolParams
                        Ouroboros.Consensus.Ledger.Dual
                        Ouroboros.Consensus.Ledger.Extended

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -10,7 +10,7 @@ module Ouroboros.Consensus.Block.Abstract (
     BlockProtocol
     -- * Configuration
   , BlockConfig
-  , HasCodecConfig(..)
+  , CodecConfig
     -- * Previous hash
   , GetPrevHash(..)
   , blockPrevHash
@@ -66,7 +66,6 @@ import           Data.FingerTree.Strict (Measured (..))
 import           Data.Maybe (isJust)
 import           Data.Word (Word32)
 
-import           Cardano.Prelude (NoUnexpectedThunks)
 import           Cardano.Slotting.Block (BlockNo (..))
 import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..),
                      SlotNo (..), WithOrigin (Origin), fromWithOrigin,
@@ -96,14 +95,11 @@ type family BlockProtocol blk :: *
 -- | Static configuration required to work with this type of blocks
 data family BlockConfig blk :: *
 
-class NoUnexpectedThunks (CodecConfig blk) => HasCodecConfig blk where
-  -- | Static configuration required for serialisation and deserialisation of
-  -- types pertaining to this type of block.
-  --
-  -- Data family instead of type family to get better type inference.
-  data family CodecConfig blk :: *
-
-  getCodecConfig :: BlockConfig blk -> CodecConfig blk
+-- | Static configuration required for serialisation and deserialisation of
+-- types pertaining to this type of block.
+--
+-- Data family instead of type family to get better type inference.
+data family CodecConfig blk :: *
 
 {-------------------------------------------------------------------------------
   Get hash of previous block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -111,10 +111,11 @@ class (HasHeader blk, GetHeader blk) => GetPrevHash blk where
   -- This gets its own abstraction, because it will be a key part of the path
   -- to getting rid of EBBs: when we have blocks @A - EBB - B@, the prev hash
   -- of @B@ will be reported as @A@.
-  headerPrevHash :: Header blk -> ChainHash blk
+  headerPrevHash :: CodecConfig blk -> Header blk -> ChainHash blk
 
-blockPrevHash :: GetPrevHash blk => blk -> ChainHash blk
-blockPrevHash = castHash . headerPrevHash . getHeader
+blockPrevHash :: GetPrevHash blk
+              => CodecConfig blk -> blk -> ChainHash blk
+blockPrevHash cfg = castHash . headerPrevHash cfg . getHeader
 
 {-------------------------------------------------------------------------------
   Link block to its header

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
@@ -21,6 +21,7 @@ class ( GetHeader blk
       , ConsensusProtocol (BlockProtocol blk)
       , NoUnexpectedThunks (Header blk)
       , NoUnexpectedThunks (BlockConfig blk)
+      , NoUnexpectedThunks (CodecConfig blk)
       ) => BlockSupportsProtocol blk where
   validateView :: BlockConfig blk
                -> Header blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
@@ -25,12 +25,14 @@ data TopLevelConfig blk = TopLevelConfig {
     , configIndep     :: !(ChainIndepStateConfig (BlockProtocol blk))
     , configLedger    :: !(LedgerConfig                         blk)
     , configBlock     :: !(BlockConfig                          blk)
+    , configCodec     :: !(CodecConfig                          blk)
     }
   deriving (Generic)
 
 instance ( ConsensusProtocol  (BlockProtocol blk)
          , UpdateLedger                      blk
          , NoUnexpectedThunks (BlockConfig   blk)
+         , NoUnexpectedThunks (CodecConfig   blk)
          ) => NoUnexpectedThunks (TopLevelConfig blk)
 
 configSecurityParam :: ConsensusProtocol (BlockProtocol blk)
@@ -44,6 +46,7 @@ castTopLevelConfig ::
        ~ ChainIndepStateConfig (BlockProtocol blk')
      , LedgerConfig blk ~ LedgerConfig blk'
      , Coercible (BlockConfig blk) (BlockConfig blk')
+     , Coercible (CodecConfig blk) (CodecConfig blk')
      )
   => TopLevelConfig blk -> TopLevelConfig blk'
 castTopLevelConfig TopLevelConfig{..} = TopLevelConfig{
@@ -51,4 +54,5 @@ castTopLevelConfig TopLevelConfig{..} = TopLevelConfig{
     , configIndep     = configIndep
     , configLedger    = configLedger
     , configBlock     = coerce configBlock
+    , configCodec     = coerce configCodec
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
@@ -16,7 +16,7 @@ import           GHC.Generics (Generic)
 import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Consensus.Block.Abstract
-import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Protocol.Abstract
 
 -- | The top-level node configuration
@@ -30,7 +30,7 @@ data TopLevelConfig blk = TopLevelConfig {
   deriving (Generic)
 
 instance ( ConsensusProtocol  (BlockProtocol blk)
-         , UpdateLedger                      blk
+         , NoUnexpectedThunks (LedgerConfig  blk)
          , NoUnexpectedThunks (BlockConfig   blk)
          , NoUnexpectedThunks (CodecConfig   blk)
          ) => NoUnexpectedThunks (TopLevelConfig blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
@@ -5,9 +5,24 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Ouroboros.Consensus.Config (
+    -- * The top-level node configuration
     TopLevelConfig(..)
-  , configSecurityParam
+  , mkTopLevelConfig
   , castTopLevelConfig
+    -- ** Derived extraction functions
+  , configConsensus
+  , configIndep
+  , configLedger
+  , configBlock
+  , configCodec
+    -- ** Additional convenience functions
+  , configSecurityParam
+    -- * Protocol config
+  , FullProtocolConfig(..)
+  , castFullProtocolConfig
+    -- * Block config
+  , FullBlockConfig(..)
+  , castFullBlockConfig
   ) where
 
 import           Data.Coerce
@@ -19,21 +34,54 @@ import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Protocol.Abstract
 
+{-------------------------------------------------------------------------------
+  Top-level config
+-------------------------------------------------------------------------------}
+
 -- | The top-level node configuration
 data TopLevelConfig blk = TopLevelConfig {
-      configConsensus :: !(ConsensusConfig       (BlockProtocol blk))
-    , configIndep     :: !(ChainIndepStateConfig (BlockProtocol blk))
-    , configLedger    :: !(LedgerConfig                         blk)
-    , configBlock     :: !(BlockConfig                          blk)
-    , configCodec     :: !(CodecConfig                          blk)
+      topLevelConfigProtocol :: !(FullProtocolConfig (BlockProtocol blk))
+    , topLevelConfigBlock    :: !(FullBlockConfig blk)
     }
   deriving (Generic)
 
-instance ( ConsensusProtocol  (BlockProtocol blk)
+instance ( ConsensusProtocol (BlockProtocol blk)
          , NoUnexpectedThunks (LedgerConfig  blk)
          , NoUnexpectedThunks (BlockConfig   blk)
          , NoUnexpectedThunks (CodecConfig   blk)
          ) => NoUnexpectedThunks (TopLevelConfig blk)
+
+-- | Convenience constructor for 'TopLevelConfig'
+mkTopLevelConfig :: ConsensusConfig       (BlockProtocol blk)
+                 -> ChainIndepStateConfig (BlockProtocol blk)
+                 -> LedgerConfig blk
+                 -> BlockConfig  blk
+                 -> CodecConfig  blk
+                 -> TopLevelConfig blk
+mkTopLevelConfig protocolConfigConsensus
+                 protocolConfigIndep
+                 blockConfigLedger
+                 blockConfigBlock
+                 blockConfigCodec =
+    TopLevelConfig {
+        topLevelConfigProtocol = FullProtocolConfig{..}
+      , topLevelConfigBlock    = FullBlockConfig{..}
+      }
+
+configConsensus :: TopLevelConfig blk -> ConsensusConfig (BlockProtocol blk)
+configConsensus = protocolConfigConsensus . topLevelConfigProtocol
+
+configIndep :: TopLevelConfig blk -> ChainIndepStateConfig (BlockProtocol blk)
+configIndep = protocolConfigIndep . topLevelConfigProtocol
+
+configLedger :: TopLevelConfig blk -> LedgerConfig blk
+configLedger = blockConfigLedger . topLevelConfigBlock
+
+configBlock  :: TopLevelConfig blk -> BlockConfig  blk
+configBlock = blockConfigBlock . topLevelConfigBlock
+
+configCodec  :: TopLevelConfig blk -> CodecConfig  blk
+configCodec = blockConfigCodec . topLevelConfigBlock
 
 configSecurityParam :: ConsensusProtocol (BlockProtocol blk)
                     => TopLevelConfig blk -> SecurityParam
@@ -50,9 +98,56 @@ castTopLevelConfig ::
      )
   => TopLevelConfig blk -> TopLevelConfig blk'
 castTopLevelConfig TopLevelConfig{..} = TopLevelConfig{
-      configConsensus = coerce configConsensus
-    , configIndep     = configIndep
-    , configLedger    = configLedger
-    , configBlock     = coerce configBlock
-    , configCodec     = coerce configCodec
+      topLevelConfigProtocol = castFullProtocolConfig topLevelConfigProtocol
+    , topLevelConfigBlock    = castFullBlockConfig    topLevelConfigBlock
+    }
+
+{-------------------------------------------------------------------------------
+  Protocol config
+-------------------------------------------------------------------------------}
+
+data FullProtocolConfig p = FullProtocolConfig {
+      protocolConfigConsensus :: !(ConsensusConfig       p)
+    , protocolConfigIndep     :: !(ChainIndepStateConfig p)
+    }
+  deriving (Generic)
+
+instance ConsensusProtocol p => NoUnexpectedThunks (FullProtocolConfig p)
+
+castFullProtocolConfig ::
+     ( Coercible (ConsensusConfig p) (ConsensusConfig p')
+     , ChainIndepStateConfig p ~ ChainIndepStateConfig p'
+     )
+  => FullProtocolConfig p -> FullProtocolConfig p'
+castFullProtocolConfig FullProtocolConfig{..} = FullProtocolConfig{
+      protocolConfigConsensus = coerce protocolConfigConsensus
+    , protocolConfigIndep     = protocolConfigIndep
+    }
+
+{-------------------------------------------------------------------------------
+  Block config
+-------------------------------------------------------------------------------}
+
+data FullBlockConfig blk = FullBlockConfig {
+      blockConfigLedger :: !(LedgerConfig blk)
+    , blockConfigBlock  :: !(BlockConfig  blk)
+    , blockConfigCodec  :: !(CodecConfig  blk)
+    }
+  deriving (Generic)
+
+instance ( NoUnexpectedThunks (LedgerConfig  blk)
+         , NoUnexpectedThunks (BlockConfig   blk)
+         , NoUnexpectedThunks (CodecConfig   blk)
+         ) => NoUnexpectedThunks (FullBlockConfig blk)
+
+castFullBlockConfig ::
+     ( LedgerConfig blk ~ LedgerConfig blk'
+     , Coercible (BlockConfig blk) (BlockConfig blk')
+     , Coercible (CodecConfig blk) (CodecConfig blk')
+     )
+  => FullBlockConfig blk -> FullBlockConfig blk'
+castFullBlockConfig FullBlockConfig{..} = FullBlockConfig{
+      blockConfigLedger = blockConfigLedger
+    , blockConfigBlock  = coerce blockConfigBlock
+    , blockConfigCodec  = coerce blockConfigCodec
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
@@ -23,6 +23,8 @@ module Ouroboros.Consensus.Config (
     -- * Block config
   , FullBlockConfig(..)
   , castFullBlockConfig
+    -- * Re-exports
+  , module Ouroboros.Consensus.Config.SecurityParam
   ) where
 
 import           Data.Coerce
@@ -31,6 +33,7 @@ import           GHC.Generics (Generic)
 import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Protocol.Abstract
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
@@ -48,7 +48,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras as X
                      (MismatchEraInfo (..), OneEraApplyTxErr (..),
                      OneEraBlock (..), OneEraGenTx (..), OneEraGenTxId (..),
                      OneEraHash (..), OneEraHeader (..), OneEraTipInfo (..),
-                     PerEraLedgerConfig (..))
+                     PerEraCodecConfig (..), PerEraLedgerConfig (..))
 
 -- Re-export types required to initialize 'ProtocolInfo'
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -32,7 +32,6 @@ class ( LedgerSupportsProtocol blk
       , HasPartialConsensusConfig (BlockProtocol blk)
       , HasPartialLedgerConfig blk
       , ConvertRawHash blk
-      , HasCodecConfig blk
       , ReconstructNestedCtxt Header blk
       , CommonProtocolParams blk
         -- Instances required to support testing

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -206,10 +206,10 @@ distribTopLevelConfig :: CanHardFork xs
                       => EpochInfo Identity
                       -> TopLevelConfig (HardForkBlock xs)
                       -> NP TopLevelConfig xs
-distribTopLevelConfig ei TopLevelConfig{..} =
+distribTopLevelConfig ei tlc =
     hcpure proxySingle
       (fn_5 (\cfgConsensus cfgIndep cfgLedger cfgBlock cfgCodec ->
-           TopLevelConfig
+           mkTopLevelConfig
              (completeConsensusConfig' ei cfgConsensus)
              (unwrapChainIndepStateConfig cfgIndep)
              (completeLedgerConfig'    ei cfgLedger)
@@ -217,15 +217,15 @@ distribTopLevelConfig ei TopLevelConfig{..} =
              cfgCodec))
     `hap`
       (getPerEraConsensusConfig $
-         hardForkConsensusConfigPerEra configConsensus)
+         hardForkConsensusConfigPerEra (configConsensus tlc))
     `hap`
-      (getPerEraChainIndepStateConfig configIndep)
+      (getPerEraChainIndepStateConfig (configIndep tlc))
     `hap`
       (getPerEraLedgerConfig $
-         hardForkLedgerConfigPerEra configLedger)
+         hardForkLedgerConfigPerEra (configLedger tlc))
     `hap`
       (getPerEraBlockConfig $
-         hardForkBlockConfigPerEra configBlock)
+         hardForkBlockConfigPerEra (configBlock tlc))
     `hap`
       (getPerEraCodecConfig $
-         hardForkCodecConfigPerEra configCodec)
+         hardForkCodecConfigPerEra (configCodec tlc))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -21,6 +21,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Basics (
     -- * Config
   , ConsensusConfig(..)
   , BlockConfig(..)
+  , CodecConfig(..)
   , HardForkLedgerConfig(..)
     -- ** Functions on config
   , completeLedgerConfig'
@@ -48,6 +49,7 @@ import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.IOLike
+import           Ouroboros.Consensus.Util.SOP
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
@@ -135,6 +137,15 @@ newtype instance BlockConfig (HardForkBlock xs) = HardForkBlockConfig {
   deriving newtype (NoUnexpectedThunks)
 
 {-------------------------------------------------------------------------------
+  Codec config
+-------------------------------------------------------------------------------}
+
+newtype instance CodecConfig (HardForkBlock xs) = HardForkCodecConfig {
+      hardForkCodecConfigPerEra :: PerEraCodecConfig xs
+    }
+  deriving newtype (NoUnexpectedThunks)
+
+{-------------------------------------------------------------------------------
   Ledger config
 -------------------------------------------------------------------------------}
 
@@ -197,12 +208,13 @@ distribTopLevelConfig :: CanHardFork xs
                       -> NP TopLevelConfig xs
 distribTopLevelConfig ei TopLevelConfig{..} =
     hcpure proxySingle
-      (fn_4 (\cfgConsensus cfgIndep cfgLedger cfgBlock ->
+      (fn_5 (\cfgConsensus cfgIndep cfgLedger cfgBlock cfgCodec ->
            TopLevelConfig
              (completeConsensusConfig' ei cfgConsensus)
              (unwrapChainIndepStateConfig cfgIndep)
              (completeLedgerConfig'    ei cfgLedger)
-             cfgBlock))
+             cfgBlock
+             cfgCodec))
     `hap`
       (getPerEraConsensusConfig $
          hardForkConsensusConfigPerEra configConsensus)
@@ -214,3 +226,6 @@ distribTopLevelConfig ei TopLevelConfig{..} =
     `hap`
       (getPerEraBlockConfig $
          hardForkBlockConfigPerEra configBlock)
+    `hap`
+      (getPerEraCodecConfig $
+         hardForkCodecConfigPerEra configCodec)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -43,7 +43,6 @@ import           Cardano.Slotting.EpochInfo
 
 import           Ouroboros.Consensus.Block.Abstract
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -102,16 +102,18 @@ instance CanHardFork xs => HasHeader (Header (HardForkBlock xs)) where
           HeaderFields{..} = getHeaderFields hdr
 
 instance CanHardFork xs => GetPrevHash (HardForkBlock xs) where
-  headerPrevHash =
+  headerPrevHash cfg =
         hcollapse
-      . hcmap proxySingle (K . getOnePrev)
+      . hczipWith proxySingle (K .: getOnePrev) cfgs
       . getOneEraHeader
       . getHardForkHeader
     where
+      cfgs = getPerEraCodecConfig $ hardForkCodecConfigPerEra cfg
+
       getOnePrev :: forall blk. SingleEraBlock blk
-                 => Header blk -> ChainHash (HardForkBlock xs)
-      getOnePrev hdr =
-          case headerPrevHash hdr of
+                 => CodecConfig blk -> Header blk -> ChainHash (HardForkBlock xs)
+      getOnePrev cfg' hdr =
+          case headerPrevHash cfg' hdr of
             GenesisHash -> GenesisHash
             BlockHash h -> BlockHash (OneEraHash $ toRawHash (Proxy @blk) h)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -18,7 +18,6 @@
 module Ouroboros.Consensus.HardFork.Combinator.Block (
     -- * Type family instances
     Header(..)
-  , CodecConfig(..)
   , NestedCtxt_(..)
   ) where
 
@@ -115,23 +114,6 @@ instance CanHardFork xs => GetPrevHash (HardForkBlock xs) where
           case headerPrevHash hdr of
             GenesisHash -> GenesisHash
             BlockHash h -> BlockHash (OneEraHash $ toRawHash (Proxy @blk) h)
-
-{-------------------------------------------------------------------------------
-  Codec config
--------------------------------------------------------------------------------}
-
-instance CanHardFork xs => HasCodecConfig (HardForkBlock xs) where
-  newtype CodecConfig (HardForkBlock xs) = HardForkCodecConfig {
-        hardForkCodecConfigPerEra :: PerEraCodecConfig xs
-      }
-    deriving (NoUnexpectedThunks)
-
-  getCodecConfig =
-        HardForkCodecConfig
-      . PerEraCodecConfig
-      . hcmap (Proxy @SingleEraBlock) getCodecConfig
-      . getPerEraBlockConfig
-      . hardForkBlockConfigPerEra
 
 {-------------------------------------------------------------------------------
   NestedContent

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -124,13 +124,10 @@ newtype instance BlockConfig (DegenFork b) = DBCfg {
     }
   deriving (NoUnexpectedThunks)
 
-instance SingleEraBlock b => HasCodecConfig (DegenFork b) where
-  newtype CodecConfig (DegenFork b) = DCCfg {
-        unDCCfg :: CodecConfig (HardForkBlock '[b])
-      }
-    deriving (NoUnexpectedThunks)
-
-  getCodecConfig = DCCfg . getCodecConfig . unDBCfg
+newtype instance CodecConfig (DegenFork b) = DCCfg {
+      unDCCfg :: CodecConfig (HardForkBlock '[b])
+    }
+  deriving (NoUnexpectedThunks)
 
 newtype instance ConsensusConfig (DegenForkProtocol b) = DConCfg {
       unDConCfg :: ConsensusConfig (HardForkProtocol '[b])

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -173,7 +173,7 @@ instance NoHardForks b => HasHeader (Header (DegenFork b)) where
       HeaderFields{..} = getHeaderFields hdr
 
 instance NoHardForks b => GetPrevHash (DegenFork b) where
-  headerPrevHash = castHash . headerPrevHash . unDHdr
+  headerPrevHash cfg = castHash . headerPrevHash (unDCCfg cfg) . unDHdr
 
 {-------------------------------------------------------------------------------
   Forward the 'ConsensusProtocol' instance

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
@@ -18,7 +18,6 @@ import           Data.SOP.Strict
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Combinator
-import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.TypeFamilyWrappers

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
@@ -26,7 +26,6 @@ import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Combinator
-import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
                      ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
@@ -27,7 +27,6 @@ import           Ouroboros.Network.Block (Serialised, unwrapCBORinCBOR,
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Combinator
-import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
                      ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
@@ -262,6 +262,7 @@ instance Isomorphic TopLevelConfig where
       , configIndep      = auxIndep     configIndep
       , configLedger     = auxLedger    configLedger
       , configBlock      = project      configBlock
+      , configCodec      = project      configCodec
       }
     where
       ei :: EpochInfo Identity
@@ -300,6 +301,7 @@ instance Isomorphic TopLevelConfig where
       , configIndep     = auxIndep     configIndep
       , configLedger    = auxLedger    configLedger
       , configBlock     = inject       configBlock
+      , configCodec     = inject       configCodec
       }
     where
       eraParams = getEraParams tlc

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
@@ -257,13 +257,13 @@ instance Isomorphic ChainHash where
 instance Isomorphic TopLevelConfig where
   project :: forall blk. NoHardForks blk
           => TopLevelConfig (HardForkBlock '[blk]) -> TopLevelConfig blk
-  project TopLevelConfig{..} = TopLevelConfig{
-        configConsensus  = auxConsensus configConsensus
-      , configIndep      = auxIndep     configIndep
-      , configLedger     = auxLedger    configLedger
-      , configBlock      = project      configBlock
-      , configCodec      = project      configCodec
-      }
+  project tlc =
+      mkTopLevelConfig
+        (auxConsensus $ configConsensus tlc)
+        (auxIndep     $ configIndep     tlc)
+        (auxLedger    $ configLedger    tlc)
+        (project      $ configBlock     tlc)
+        (project      $ configCodec     tlc)
     where
       ei :: EpochInfo Identity
       ei = fixedSizeEpochInfo
@@ -271,7 +271,7 @@ instance Isomorphic TopLevelConfig where
          . unK . hd
          . History.getShape
          . hardForkLedgerConfigShape
-         $ configLedger
+         $ configLedger tlc
 
       auxLedger :: LedgerConfig (HardForkBlock '[blk]) -> LedgerConfig blk
       auxLedger =
@@ -296,16 +296,16 @@ instance Isomorphic TopLevelConfig where
 
   inject :: forall blk. NoHardForks blk
          => TopLevelConfig blk -> TopLevelConfig (HardForkBlock '[blk])
-  inject tlc@TopLevelConfig{..} = TopLevelConfig{
-        configConsensus = auxConsensus configConsensus
-      , configIndep     = auxIndep     configIndep
-      , configLedger    = auxLedger    configLedger
-      , configBlock     = inject       configBlock
-      , configCodec     = inject       configCodec
-      }
+  inject tlc =
+      mkTopLevelConfig
+        (auxConsensus $ configConsensus tlc)
+        (auxIndep     $ configIndep     tlc)
+        (auxLedger    $ configLedger    tlc)
+        (inject       $ configBlock     tlc)
+        (inject       $ configCodec     tlc)
     where
       eraParams = getEraParams tlc
-      k         = protocolSecurityParam configConsensus
+      k         = configSecurityParam tlc
 
       auxLedger :: LedgerConfig blk -> LedgerConfig (HardForkBlock '[blk])
       auxLedger cfg = HardForkLedgerConfig {

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -352,9 +352,9 @@ validateEnvelope cfg ledgerView oldTip hdr = do
     actualBlockNo  :: BlockNo
     actualPrevHash :: ChainHash blk
 
-    actualSlotNo   = blockSlot      hdr
-    actualBlockNo  = blockNo        hdr
-    actualPrevHash = headerPrevHash hdr
+    actualSlotNo   = blockSlot hdr
+    actualBlockNo  = blockNo   hdr
+    actualPrevHash = headerPrevHash (configCodec cfg) hdr
 
     expectedSlotNo :: SlotNo -- Lower bound only
     expectedSlotNo =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE DeriveAnyClass        #-}
-{-# LANGUAGE DeriveFunctor         #-}
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE DerivingStrategies    #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -15,123 +11,37 @@
 
 -- | Interface to the ledger layer
 module Ouroboros.Consensus.Ledger.Abstract (
-    -- * Definition of a ledger independent of a choice of block
-    IsLedger(..)
-  , LedgerCfg
-  , Ticked(..)
-  , ApplyBlock(..)
+    -- * Apply block
+    ApplyBlock(..)
+  , UpdateLedger
     -- ** Derived
   , tickThenApply
   , tickThenReapply
   , foldLedger
   , refoldLedger
-    -- * Link block to its ledger
-  , LedgerState
-  , UpdateLedger
     -- ** Short-hand
-  , LedgerConfig
-  , LedgerError
-  , TickedLedgerState
   , ledgerTipHash
   , ledgerTipPoint'
   , ledgerTipSlot
     -- * Queries
   , QueryLedger(..)
   , ShowQuery(..)
+    -- * Re-exports
+  , module Ouroboros.Consensus.Ledger.Basics
   ) where
 
 import           Control.Monad.Except
 import           Data.Maybe (isJust)
 import           Data.Proxy
 import           Data.Type.Equality ((:~:))
-import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
-
-import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
                      (ShowQuery (..))
 
 import           Ouroboros.Consensus.Block.Abstract
+import           Ouroboros.Consensus.Ledger.Basics
 import           Ouroboros.Consensus.Util (repeatedly, repeatedlyM)
-
-{-------------------------------------------------------------------------------
-  Definition of a ledger independent of a choice of block
--------------------------------------------------------------------------------}
-
--- | Static environment required for the ledger
-type family LedgerCfg l :: *
-
-class ( -- Requirements on the ledger state itself
-        Show               l
-      , Eq                 l
-      , NoUnexpectedThunks l
-        -- Requirements on 'LedgerCfg'
-      , NoUnexpectedThunks (LedgerCfg l)
-        -- Requirements on 'LedgerErr'
-      , Show               (LedgerErr l)
-      , Eq                 (LedgerErr l)
-      , NoUnexpectedThunks (LedgerErr l)
-      ) => IsLedger l where
-  -- | Errors that can arise when updating the ledger
-  --
-  -- This is defined here rather than in 'ApplyBlock', since the /type/ of
-  -- these errors does not depend on the type of the block.
-  type family LedgerErr l :: *
-
-  -- | Apply "slot based" state transformations
-  --
-  -- When a block is applied to the ledger state, a number of things happen
-  -- purely based on the slot number of that block. For example:
-  --
-  -- * In Byron, scheduled updates are applied, and the update system state is
-  --   updated.
-  -- * In Shelley, delegation state is updated (on epoch boundaries).
-  --
-  -- The consensus layer must be able to apply such a "chain tick" function,
-  -- primarily when validating transactions in the mempool (which, conceptually,
-  -- live in "some block in the future") or when extracting valid transactions
-  -- from the mempool to insert into a new block to be produced.
-  --
-  -- This is not allowed to throw any errors. After all, if this could fail,
-  -- it would mean a /previous/ block set up the ledger state in such a way
-  -- that as soon as a certain slot was reached, /any/ block would be invalid.
-  --
-  -- PRECONDITION: The slot number must be strictly greater than the slot at
-  -- the tip of the ledger (except for EBBs, obviously..).
-  applyChainTick :: LedgerCfg l -> SlotNo -> l -> Ticked l
-
--- | Mark a ledger state or ledger view as " ticked "
---
--- Ticking refers to the passage of time (the ticking of the clock). When a
--- ledger state or ledger view is marked as ticked, it means  that time-related
--- changes have been applied to ledger state, or the right view has been
--- forecast for that slot.
---
--- Some examples of time related changes:
---
--- * Scheduled delegations might have been applied in Byron
--- * New leader schedule computed for Shelley
--- * Transition from Byron to Shelley activated in the hard fork combinator.
---
--- When applying a block, the ledger must first have been advanced to the slot
--- of the block.
-data Ticked l = Ticked {
-      -- | The slot number supplied to 'applyChainTick'
-      tickedSlotNo      :: !SlotNo
-
-      -- | The underlying ledger state
-      --
-      -- NOTE: 'applyChainTick' should /not/ change the tip of the underlying
-      -- ledger state, which should still refer to the most recent applied
-      -- /block/. In other words, we should have
-      --
-      -- >    ledgerTipPoint (tickedLedgerState (applyChainTick cfg slot st)
-      -- > == ledgerTipPoint st
-    , tickedLedgerState :: !l
-    }
-  deriving stock    (Generic, Functor)
-  deriving anyclass (NoUnexpectedThunks)
 
 {-------------------------------------------------------------------------------
   Apply block to ledger state
@@ -165,6 +75,9 @@ class ( IsLedger l
   -- Should be 'genesisPoint' when no blocks have been applied yet
   ledgerTipPoint :: l -> Point blk
 
+-- | Interaction with the ledger layer
+class ApplyBlock (LedgerState blk) blk => UpdateLedger blk
+
 {-------------------------------------------------------------------------------
   Derived functionality
 -------------------------------------------------------------------------------}
@@ -188,22 +101,8 @@ refoldLedger :: ApplyBlock l blk => LedgerCfg l -> [blk] -> l -> l
 refoldLedger = repeatedly . tickThenReapply
 
 {-------------------------------------------------------------------------------
-  Link block to its ledger
--------------------------------------------------------------------------------}
-
--- | Ledger state associated with a block
-data family LedgerState blk :: *
-
--- | Interaction with the ledger layer
-class ApplyBlock (LedgerState blk) blk => UpdateLedger blk
-
-{-------------------------------------------------------------------------------
   Short-hand
 -------------------------------------------------------------------------------}
-
-type LedgerConfig      blk = LedgerCfg (LedgerState blk)
-type LedgerError       blk = LedgerErr (LedgerState blk)
-type TickedLedgerState blk = Ticked    (LedgerState blk)
 
 -- | Wrapper around 'ledgerTipPoint' that uses a proxy to fix @blk@
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE TypeFamilies       #-}
+
+-- | Definition is 'IsLedger'
+--
+-- Normally this is imported from "Ouroboros.Consensus.Ledger.Abstract". We
+-- pull this out to avoid circular module dependencies.
+module Ouroboros.Consensus.Ledger.Basics (
+    -- * Definition of a ledger independent of a choice of block
+    LedgerCfg
+  , IsLedger(..)
+    -- * Link block to its ledger
+  , LedgerState
+  , LedgerConfig
+  , LedgerError
+  , TickedLedgerState
+    -- * Ticked ledger state
+  , Ticked(..)
+  ) where
+
+import           GHC.Generics (Generic)
+
+import           Cardano.Prelude (NoUnexpectedThunks)
+
+import           Ouroboros.Consensus.Block.Abstract
+
+{-------------------------------------------------------------------------------
+  Definition of a ledger independent of a choice of block
+-------------------------------------------------------------------------------}
+
+-- | Static environment required for the ledger
+type family LedgerCfg l :: *
+
+class ( -- Requirements on the ledger state itself
+        Show               l
+      , Eq                 l
+      , NoUnexpectedThunks l
+        -- Requirements on 'LedgerCfg'
+      , NoUnexpectedThunks (LedgerCfg l)
+        -- Requirements on 'LedgerErr'
+      , Show               (LedgerErr l)
+      , Eq                 (LedgerErr l)
+      , NoUnexpectedThunks (LedgerErr l)
+      ) => IsLedger l where
+  -- | Errors that can arise when updating the ledger
+  --
+  -- This is defined here rather than in 'ApplyBlock', since the /type/ of
+  -- these errors does not depend on the type of the block.
+  type family LedgerErr l :: *
+
+  -- | Apply "slot based" state transformations
+  --
+  -- When a block is applied to the ledger state, a number of things happen
+  -- purely based on the slot number of that block. For example:
+  --
+  -- * In Byron, scheduled updates are applied, and the update system state is
+  --   updated.
+  -- * In Shelley, delegation state is updated (on epoch boundaries).
+  --
+  -- The consensus layer must be able to apply such a "chain tick" function,
+  -- primarily when validating transactions in the mempool (which, conceptually,
+  -- live in "some block in the future") or when extracting valid transactions
+  -- from the mempool to insert into a new block to be produced.
+  --
+  -- This is not allowed to throw any errors. After all, if this could fail,
+  -- it would mean a /previous/ block set up the ledger state in such a way
+  -- that as soon as a certain slot was reached, /any/ block would be invalid.
+  --
+  -- PRECONDITION: The slot number must be strictly greater than the slot at
+  -- the tip of the ledger (except for EBBs, obviously..).
+  applyChainTick :: LedgerCfg l -> SlotNo -> l -> Ticked l
+
+{-------------------------------------------------------------------------------
+  Link block to its ledger
+-------------------------------------------------------------------------------}
+
+-- | Ledger state associated with a block
+data family LedgerState blk :: *
+
+type LedgerConfig      blk = LedgerCfg (LedgerState blk)
+type LedgerError       blk = LedgerErr (LedgerState blk)
+type TickedLedgerState blk = Ticked    (LedgerState blk)
+
+{-------------------------------------------------------------------------------
+  Ticked ledger state
+-------------------------------------------------------------------------------}
+
+-- | Mark a ledger state or ledger view as " ticked "
+--
+-- Ticking refers to the passage of time (the ticking of the clock). When a
+-- ledger state or ledger view is marked as ticked, it means  that time-related
+-- changes have been applied to ledger state, or the right view has been
+-- forecast for that slot.
+--
+-- Some examples of time related changes:
+--
+-- * Scheduled delegations might have been applied in Byron
+-- * New leader schedule computed for Shelley
+-- * Transition from Byron to Shelley activated in the hard fork combinator.
+--
+-- When applying a block, the ledger must first have been advanced to the slot
+-- of the block.
+data Ticked l = Ticked {
+      -- | The slot number supplied to 'applyChainTick'
+      tickedSlotNo      :: !SlotNo
+
+      -- | The underlying ledger state
+      --
+      -- NOTE: 'applyChainTick' should /not/ change the tip of the underlying
+      -- ledger state, which should still refer to the most recent applied
+      -- /block/. In other words, we should have
+      --
+      -- >    ledgerTipPoint (tickedLedgerState (applyChainTick cfg slot st)
+      -- > == ledgerTipPoint st
+    , tickedLedgerState :: !l
+    }
+  deriving stock    (Generic, Functor)
+  deriving anyclass (NoUnexpectedThunks)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -161,25 +161,24 @@ dualTopLevelConfigMain TopLevelConfig{..} = TopLevelConfig{
     , configIndep     =                      configIndep
     , configLedger    = dualLedgerConfigMain configLedger
     , configBlock     = dualBlockConfigMain  configBlock
+    , configCodec     = dualCodecConfigMain  configCodec
     }
-
-instance HasCodecConfig m => HasCodecConfig (DualBlock m a) where
-  newtype CodecConfig (DualBlock m a) = DualCodecConfig {
-        dualCodecConfigMain :: CodecConfig m
-     }
-
-  getCodecConfig DualBlockConfig{..} = DualCodecConfig {
-        dualCodecConfigMain = getCodecConfig dualBlockConfigMain
-      }
-
-deriving newtype instance HasCodecConfig m
-                       => NoUnexpectedThunks (CodecConfig (DualBlock m a))
 
 instance ConfigSupportsNode m => ConfigSupportsNode (DualBlock m a) where
   getSystemStart     = getSystemStart     . dualBlockConfigMain
   getNetworkMagic    = getNetworkMagic    . dualBlockConfigMain
   getProtocolMagicId = getProtocolMagicId . dualBlockConfigMain
 
+{-------------------------------------------------------------------------------
+  CodecConfig
+-------------------------------------------------------------------------------}
+
+newtype instance CodecConfig (DualBlock m a) = DualCodecConfig {
+      dualCodecConfigMain :: CodecConfig m
+    }
+
+deriving newtype instance NoUnexpectedThunks (CodecConfig m)
+                       => NoUnexpectedThunks (CodecConfig (DualBlock m a))
 
 {-------------------------------------------------------------------------------
   Bridge two ledgers

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -29,6 +29,8 @@ module Ouroboros.Consensus.Ledger.Dual (
   , DualGenTxErr(..)
     -- * Lifted functions
   , dualExtValidationErrorMain
+  , dualFullBlockConfigMain
+  , dualFullBlockConfigAux
   , dualTopLevelConfigMain
   , ctxtDualMain
     -- * Type class family instances
@@ -156,20 +158,35 @@ data instance BlockConfig (DualBlock m a) = DualBlockConfig {
     }
   deriving NoUnexpectedThunks via AllowThunk (BlockConfig (DualBlock m a))
 
--- | This is only used for block production
-dualTopLevelConfigMain :: TopLevelConfig (DualBlock m a) -> TopLevelConfig m
-dualTopLevelConfigMain TopLevelConfig{..} = TopLevelConfig{
-      configConsensus =                      configConsensus
-    , configIndep     =                      configIndep
-    , configLedger    = dualLedgerConfigMain configLedger
-    , configBlock     = dualBlockConfigMain  configBlock
-    , configCodec     = dualCodecConfigMain  configCodec
-    }
-
 instance ConfigSupportsNode m => ConfigSupportsNode (DualBlock m a) where
   getSystemStart     = getSystemStart     . dualBlockConfigMain
   getNetworkMagic    = getNetworkMagic    . dualBlockConfigMain
   getProtocolMagicId = getProtocolMagicId . dualBlockConfigMain
+
+{-------------------------------------------------------------------------------
+  Splitting the config
+-------------------------------------------------------------------------------}
+
+dualFullBlockConfigMain :: FullBlockConfig (DualBlock m a) -> FullBlockConfig m
+dualFullBlockConfigMain FullBlockConfig{..} = FullBlockConfig{
+      blockConfigLedger = dualLedgerConfigMain blockConfigLedger
+    , blockConfigBlock  = dualBlockConfigMain  blockConfigBlock
+    , blockConfigCodec  = dualCodecConfigMain  blockConfigCodec
+    }
+
+dualFullBlockConfigAux :: FullBlockConfig (DualBlock m a) -> FullBlockConfig a
+dualFullBlockConfigAux FullBlockConfig{..} = FullBlockConfig{
+      blockConfigLedger = dualLedgerConfigAux blockConfigLedger
+    , blockConfigBlock  = dualBlockConfigAux  blockConfigBlock
+    , blockConfigCodec  = dualCodecConfigAux  blockConfigCodec
+    }
+
+-- | This is only used for block production
+dualTopLevelConfigMain :: TopLevelConfig (DualBlock m a) -> TopLevelConfig m
+dualTopLevelConfigMain TopLevelConfig{..} = TopLevelConfig{
+      topLevelConfigProtocol = topLevelConfigProtocol
+    , topLevelConfigBlock    = dualFullBlockConfigMain topLevelConfigBlock
+    }
 
 {-------------------------------------------------------------------------------
   CodecConfig

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -267,7 +267,10 @@ instance Bridge m a => HasHeader (DualHeader m a) where
   getHeaderFields = castHeaderFields . getHeaderFields . dualHeaderMain
 
 instance Bridge m a => GetPrevHash (DualBlock m a) where
-  headerPrevHash = castHash . headerPrevHash . dualHeaderMain
+  headerPrevHash cfg =
+        castHash
+      . headerPrevHash (dualCodecConfigMain cfg)
+      . dualHeaderMain
 
 {-------------------------------------------------------------------------------
   Protocol

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -656,7 +656,7 @@ chainSyncClient mkPipelineDecision0 tracer cfg
 
           -- Validate header
           let expectPrevHash = castHash (AF.headHash theirFrag)
-              actualPrevHash = headerPrevHash hdr
+              actualPrevHash = headerPrevHash (configCodec cfg) hdr
           when (actualPrevHash /= expectPrevHash) $
             disconnect $ DoesntFit actualPrevHash expectPrevHash ourTip theirTip
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -243,7 +243,7 @@ run runargs@RunNodeArgs{..} =
       } = rnProtocolInfo
 
     codecConfig :: CodecConfig blk
-    codecConfig = getCodecConfig $ configBlock cfg
+    codecConfig = configCodec cfg
 
     mkNodeToNodeApps
       :: NodeArgs   IO RemoteConnectionId LocalConnectionId blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -72,7 +72,6 @@ class ( LedgerSupportsProtocol           blk
       , TranslateNetworkProtocolVersion  blk
       , CanForge                         blk
       , ConfigSupportsNode               blk
-      , HasCodecConfig                   blk
       , ConvertRawHash                   blk
       , CommonProtocolParams             blk
       , SerialiseDiskConstraints         blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -77,7 +77,6 @@ withDB
      , LedgerSupportsProtocol blk
      , HasHardForkHistory blk
      , ConvertRawHash blk
-     , HasCodecConfig blk
      , SerialiseDiskConstraints blk
      )
   => ChainDbArgs m blk
@@ -91,7 +90,6 @@ openDB
      , LedgerSupportsProtocol blk
      , HasHardForkHistory blk
      , ConvertRawHash blk
-     , HasCodecConfig blk
      , SerialiseDiskConstraints blk
      )
   => ChainDbArgs m blk
@@ -104,7 +102,6 @@ openDBInternal
      , LedgerSupportsProtocol blk
      , HasHardForkHistory blk
      , ConvertRawHash blk
-     , HasCodecConfig blk
      , SerialiseDiskConstraints blk
      )
   => ChainDbArgs m blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -14,7 +14,6 @@ import           Data.Time.Clock (DiffTime, secondsToDiffTime)
 
 import           Control.Tracer (Tracer, contramap)
 
-import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture)
 import           Ouroboros.Consensus.Ledger.Extended
@@ -138,8 +137,7 @@ defaultArgs fp = toChainDbArgs (ImmDB.defaultArgs fp)
 
 -- | Internal: split 'ChainDbArgs' into 'ImmDbArgs', 'VolDbArgs, 'LgrDbArgs',
 -- and 'ChainDbSpecificArgs'.
-fromChainDbArgs :: HasCodecConfig blk
-                => ChainDbArgs m blk
+fromChainDbArgs :: ChainDbArgs m blk
                 -> ( ImmDB.ImmDbArgs     m blk
                    , VolDB.VolDbArgs     m blk
                    , LgrDB.LgrDbArgs     m blk
@@ -148,7 +146,7 @@ fromChainDbArgs :: HasCodecConfig blk
 fromChainDbArgs ChainDbArgs{..} = (
       ImmDB.ImmDbArgs {
           immGetBinaryBlockInfo = cdbGetBinaryBlockInfo
-        , immCodecConfig        = getCodecConfig (configBlock cdbTopLevelConfig)
+        , immCodecConfig        = configCodec cdbTopLevelConfig
         , immChunkInfo          = cdbChunkInfo
         , immValidation         = cdbImmValidation
         , immCheckIntegrity     = cdbCheckIntegrity
@@ -162,7 +160,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , volCheckIntegrity     = cdbCheckIntegrity
         , volBlocksPerFile      = cdbBlocksPerFile
         , volGetBinaryBlockInfo = cdbGetBinaryBlockInfo
-        , volCodecConfig        = getCodecConfig (configBlock cdbTopLevelConfig)
+        , volCodecConfig        = configCodec cdbTopLevelConfig
         , volValidation         = cdbVolValidation
         , volTracer             = contramap TraceVolDBEvent cdbTracer
         }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -88,7 +88,6 @@ launchBgTasks
      ( IOLike m
      , LedgerSupportsProtocol blk
      , HasHardForkHistory blk
-     , HasCodecConfig blk
      , ImmDbSerialiseConstraints blk
      , LgrDbSerialiseConstraints blk
      , VolDbSerialiseConstraints blk
@@ -247,7 +246,6 @@ copyAndSnapshotRunner
      , ConsensusProtocol (BlockProtocol blk)
      , HasHeader blk
      , GetHeader blk
-     , HasCodecConfig blk
      , ImmDbSerialiseConstraints blk
      , LgrDbSerialiseConstraints blk
      , VolDbSerialiseConstraints blk
@@ -306,7 +304,7 @@ copyAndSnapshotRunner cdb@CDB{..} gcSchedule replayed =
 -- | Write a snapshot of the LedgerDB to disk and remove old snapshots
 -- (typically one) so that only 'onDiskNumSnapshots' snapshots are on disk.
 updateLedgerSnapshots
-  :: (IOLike m, HasCodecConfig blk, LgrDbSerialiseConstraints blk)
+  :: (IOLike m, LgrDbSerialiseConstraints blk)
   => ChainDbEnv m blk -> m ()
 updateLedgerSnapshots CDB{..} = do
     -- TODO avoid taking multiple snapshots corresponding to the same tip.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -45,7 +45,6 @@ import qualified Ouroboros.Network.AnchoredFragment as AF
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Fragment.InFuture (CheckInFuture (..))
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
 import           Ouroboros.Consensus.Fragment.Validated (ValidatedFragment)
@@ -456,7 +455,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
         return tipPoint
 
       -- The block @b@ fits onto the end of our current chain
-      | pointHash tipPoint == headerPrevHash hdr -> do
+      | pointHash tipPoint == headerPrevHash (configCodec cdbTopLevelConfig) hdr -> do
         -- ### Add to current chain
         trace (TryAddToCurrentChain p)
         addToCurrentChain succsOf' curChainAndLedger

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
@@ -247,8 +247,12 @@ openDB ImmDbArgs {..} = do
       , parser      = parser
       , prefixLen   = reconstructPrefixLen (Proxy @(Header blk))
       }
-    parser = ImmDB.chunkFileParser immHasFS (decodeDisk immCodecConfig)
-      immGetBinaryBlockInfo immCheckIntegrity
+    parser = ImmDB.chunkFileParser
+               immCodecConfig
+               immHasFS
+               (decodeDisk immCodecConfig)
+               immGetBinaryBlockInfo
+               immCheckIntegrity
 
 -- | For testing purposes
 mkImmDB :: ImmutableDB (HeaderHash blk) m

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
@@ -120,8 +120,8 @@ data ImmDB m blk = ImmDB {
     }
   deriving (Generic)
 
-deriving instance HasCodecConfig blk => NoUnexpectedThunks (ImmDB m blk)
-  -- use generic instance
+deriving instance NoUnexpectedThunks (CodecConfig blk)
+               => NoUnexpectedThunks (ImmDB m blk)
 
 -- | 'EncodeDisk' and 'DecodeDisk' constraints needed for the ImmDB.
 class ( EncodeDisk blk blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -187,7 +187,6 @@ defaultArgs fp = LgrDbArgs {
 openDB :: forall m blk.
           ( IOLike m
           , LedgerSupportsProtocol blk
-          , HasCodecConfig blk
           , LgrDbSerialiseConstraints blk
           , ImmDbSerialiseConstraints blk
           , HasCallStack
@@ -230,7 +229,6 @@ openDB args@LgrDbArgs{..} replayTracer immDB getBlock = do
 -- Returns the number of immutable blocks replayed.
 reopen :: ( IOLike m
           , LedgerSupportsProtocol blk
-          , HasCodecConfig blk
           , LgrDbSerialiseConstraints blk
           , ImmDbSerialiseConstraints blk
           , HasCallStack
@@ -248,7 +246,6 @@ initFromDisk
   :: forall blk m.
      ( IOLike m
      , LedgerSupportsProtocol blk
-     , HasCodecConfig blk
      , LgrDbSerialiseConstraints blk
      , ImmDbSerialiseConstraints blk
      , HasCallStack
@@ -271,7 +268,7 @@ initFromDisk LgrDbArgs{..} replayTracer immDB = wrapFailure $ do
         (streamAPI immDB)
     return (db, replayed)
   where
-    ccfg = getCodecConfig (configBlock lgrTopLevelConfig)
+    ccfg = configCodec lgrTopLevelConfig
 
     decodeExtLedgerState' :: forall s. Decoder s (ExtLedgerState blk)
     decodeExtLedgerState' = decodeExtLedgerState
@@ -339,7 +336,7 @@ currentPoint = ledgerTipPoint
              . LedgerDB.ledgerDbCurrent
 
 takeSnapshot :: forall m blk.
-                (IOLike m, HasCodecConfig blk, LgrDbSerialiseConstraints blk)
+                (IOLike m, LgrDbSerialiseConstraints blk)
              => LgrDB m blk -> m (DiskSnapshot, Point blk)
 takeSnapshot lgrDB@LgrDB{ args = LgrDbArgs{..} } = wrapFailure $ do
     ledgerDB <- atomically $ getCurrent lgrDB
@@ -350,7 +347,7 @@ takeSnapshot lgrDB@LgrDB{ args = LgrDbArgs{..} } = wrapFailure $ do
       (encodeRealPoint encode)
       ledgerDB
   where
-    ccfg = getCodecConfig (configBlock lgrTopLevelConfig)
+    ccfg = configCodec lgrTopLevelConfig
 
     encodeExtLedgerState' :: ExtLedgerState blk -> Encoding
     encodeExtLedgerState' = encodeExtLedgerState

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reader.hs
@@ -87,7 +87,6 @@ newReader
      ( IOLike m
      , HasHeader blk
      , GetHeader blk
-     , HasCodecConfig blk
      , ImmDbSerialiseConstraints blk
      , VolDbSerialiseConstraints blk
      , EncodeDiskDep (NestedCtxt Header) blk
@@ -127,7 +126,6 @@ makeNewReader
      ( IOLike m
      , HasHeader blk
      , GetHeader blk
-     , HasCodecConfig blk
      , ImmDbSerialiseConstraints blk
      , VolDbSerialiseConstraints blk
      , EncodeDiskDep (NestedCtxt Header) blk
@@ -208,7 +206,6 @@ instructionHelper
      ( IOLike m
      , HasHeader blk
      , GetHeader blk
-     , HasCodecConfig blk
      , ImmDbSerialiseConstraints blk
      , VolDbSerialiseConstraints blk
      , EncodeDiskDep (NestedCtxt Header) blk
@@ -280,7 +277,7 @@ instructionHelper registry varReader blockComponent fromMaybeSTM CDB{..} = do
     trace = traceWith (contramap TraceReaderEvent cdbTracer)
 
     codecConfig :: CodecConfig blk
-    codecConfig = getCodecConfig (configBlock cdbTopLevelConfig)
+    codecConfig = configCodec cdbTopLevelConfig
 
     headerUpdateToBlockComponentUpdate
       :: f (ChainUpdate blk (Header blk)) -> m (f (ChainUpdate blk b))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -254,7 +254,7 @@ data ChainDbEnv m blk = CDB
 -- | We include @blk@ in 'showTypeOf' because it helps resolving type families
 -- (but avoid including @m@ because we cannot impose @Typeable m@ as a
 -- constraint and still have it work with the simulator)
-instance (IOLike m, LedgerSupportsProtocol blk, HasCodecConfig blk)
+instance (IOLike m, LedgerSupportsProtocol blk)
       => NoUnexpectedThunks (ChainDbEnv m blk) where
     showTypeOf _ = "ChainDbEnv m " ++ show (typeRep (Proxy @blk))
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
@@ -219,7 +219,7 @@ putBlock
   :: (MonadCatch m, GetPrevHash blk, VolDbSerialiseConstraints blk)
   => VolDB m blk -> blk -> m ()
 putBlock db@VolDB{..} b = withDB db $ \vol ->
-    VolDB.putBlock vol (extractInfo b binaryBlockInfo) binaryBlob
+    VolDB.putBlock vol (extractInfo codecConfig b binaryBlockInfo) binaryBlob
   where
     binaryBlockInfo = getBinaryBlockInfo b
     binaryBlob      = CBOR.toBuilder $ encodeDisk codecConfig b
@@ -496,6 +496,7 @@ blockFileParser
        (HeaderHash blk)
 blockFileParser VolDbArgs{..} =
     blockFileParser'
+      volCodecConfig
       volHasFS
       volGetBinaryBlockInfo
       decodeNestedCtxtAndBlock
@@ -518,7 +519,8 @@ blockFileParser VolDbArgs{..} =
 -- the whole @VolDbArgs@.
 blockFileParser'
   :: forall m blk h. (IOLike m, GetPrevHash blk)
-  => HasFS m h
+  => CodecConfig blk
+  -> HasFS m h
   -> (blk -> BinaryBlockInfo)
   -> (forall s. Decoder s (Lazy.ByteString -> (ShortByteString, blk)))
   -> (blk -> Bool)
@@ -527,12 +529,17 @@ blockFileParser'
        Util.CBOR.ReadIncrementalErr
        m
        (HeaderHash blk)
-blockFileParser' hasFS getBinaryBlockInfo decodeNestedCtxtAndBlock isNotCorrupt validationPolicy =
+blockFileParser' cfg
+                 hasFS
+                 getBinaryBlockInfo
+                 decodeNestedCtxtAndBlock
+                 isNotCorrupt
+                 validationPolicy =
     VolDB.Parser $ \fsPath -> Util.CBOR.withStreamIncrementalOffsets
       hasFS decodeNestedCtxtAndBlock fsPath (checkEntries [])
   where
     extractInfo' :: blk -> VolDB.BlockInfo (HeaderHash blk)
-    extractInfo' blk = extractInfo blk (getBinaryBlockInfo blk)
+    extractInfo' blk = extractInfo cfg blk (getBinaryBlockInfo blk)
 
     noValidation :: Bool
     noValidation = validationPolicy == VolDB.NoValidation
@@ -607,13 +614,14 @@ fromChainHash GenesisHash      = Origin
 fromChainHash (BlockHash hash) = NotOrigin hash
 
 extractInfo :: GetPrevHash blk
-            => blk
+            => CodecConfig blk
+            -> blk
             -> BinaryBlockInfo
             -> VolDB.BlockInfo (HeaderHash blk)
-extractInfo b BinaryBlockInfo{..} = VolDB.BlockInfo {
+extractInfo cfg b BinaryBlockInfo{..} = VolDB.BlockInfo {
       bbid          = blockHash b
     , bslot         = blockSlot b
-    , bpreBid       = fromChainHash (blockPrevHash b)
+    , bpreBid       = fromChainHash (blockPrevHash cfg b)
     , bisEBB        = blockToIsEBB b
     , bheaderOffset = headerOffset
     , bheaderSize   = headerSize

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
@@ -112,8 +112,8 @@ data VolDB m blk = VolDB {
     }
   deriving (Generic)
 
-deriving instance HasCodecConfig blk => NoUnexpectedThunks (VolDB m blk)
-  -- use generic instance
+deriving instance NoUnexpectedThunks (CodecConfig blk)
+               => NoUnexpectedThunks (VolDB m blk)
 
 -- | 'EncodeDisk' and 'DecodeDisk' constraints needed for the VolDB.
 class ( EncodeDisk blk blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Parser.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Parser.hs
@@ -68,7 +68,8 @@ chunkFileParser
      , GetPrevHash blk
      , hash ~ HeaderHash blk
      )
-  => HasFS m h
+  => CodecConfig blk
+  -> HasFS m h
   -> (forall s. Decoder s (BL.ByteString -> blk))
   -> (blk -> BinaryBlockInfo)
   -> (blk -> Bool)        -- ^ Check integrity of the block. 'False' = corrupt.
@@ -77,7 +78,7 @@ chunkFileParser
        m
        (BlockSummary hash)
        hash
-chunkFileParser hasFS decodeBlock getBinaryBlockInfo isNotCorrupt =
+chunkFileParser cfg hasFS decodeBlock getBinaryBlockInfo isNotCorrupt =
     ChunkFileParser $ \fsPath expectedChecksums k ->
       Util.CBOR.withStreamIncrementalOffsets hasFS decoder fsPath
         ( k
@@ -149,7 +150,7 @@ chunkFileParser hasFS decodeBlock getBinaryBlockInfo isNotCorrupt =
         (BlockSummary entry (blockNo blk), prevHash)
       where
         -- Don't accidentally hold on to the block!
-        !prevHash = convertPrevHash $ blockPrevHash blk
+        !prevHash = convertPrevHash $ blockPrevHash cfg blk
         !entry    = Secondary.Entry
           { blockOffset  = Secondary.BlockOffset  offset
           , headerOffset = Secondary.HeaderOffset headerOffset

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
@@ -22,6 +22,7 @@ module Ouroboros.Consensus.Util.SOP (
   , lenses_NP
   , npToSListI
   , allComposeShowK
+  , fn_5
     -- * Type-level non-empty lists
   , IsNonEmpty(..)
   , ProofNonEmpty(..)
@@ -137,6 +138,15 @@ npToSListI = sListToSListI . npToSList
 allComposeShowK :: (SListI xs, Show a)
                 => Proxy xs -> Proxy a -> Dict (All (Compose Show (K a))) xs
 allComposeShowK _ _ = all_NP $ hpure Dict
+
+fn_5 :: (f0 a -> f1 a -> f2 a -> f3 a -> f4 a -> f5 a)
+     -> (f0 -.-> f1 -.-> f2 -.-> f3 -.-> f4 -.-> f5) a
+fn_5 f = Fn $ \x0 ->
+         Fn $ \x1 ->
+         Fn $ \x2 ->
+         Fn $ \x3 ->
+         Fn $ \x4 ->
+         f x0 x1 x2 x3 x4
 
 {-------------------------------------------------------------------------------
   Type-level non-empty lists

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -282,6 +282,12 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
                 :* blockConfigB nid
                 :* Nil
             }
+        , configCodec = HardForkCodecConfig {
+              hardForkCodecConfigPerEra = PerEraCodecConfig $
+                   CCfgA
+                :* CCfgB
+                :* Nil
+            }
         }
 
     consensusConfigA :: CoreNodeId -> ConsensusConfig ProtocolA

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -256,37 +256,41 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
 
     topLevelConfig :: CoreNodeId -> TopLevelConfig TestBlock
     topLevelConfig nid = TopLevelConfig {
-          configConsensus = HardForkConsensusConfig {
-              hardForkConsensusConfigK      = k
-            , hardForkConsensusConfigShape  = shape
-            , hardForkConsensusConfigPerEra = PerEraConsensusConfig $
-                   (WrapPartialConsensusConfig $ consensusConfigA nid)
-                :* (WrapPartialConsensusConfig $ consensusConfigB nid)
+          topLevelConfigProtocol = FullProtocolConfig {
+              protocolConfigConsensus = HardForkConsensusConfig {
+                  hardForkConsensusConfigK      = k
+                , hardForkConsensusConfigShape  = shape
+                , hardForkConsensusConfigPerEra = PerEraConsensusConfig $
+                       (WrapPartialConsensusConfig $ consensusConfigA nid)
+                    :* (WrapPartialConsensusConfig $ consensusConfigB nid)
+                    :* Nil
+                }
+            , protocolConfigIndep = PerEraChainIndepStateConfig $
+                   (WrapChainIndepStateConfig ())
+                :* (WrapChainIndepStateConfig ())
                 :* Nil
             }
-        , configIndep  = PerEraChainIndepStateConfig $
-                              (WrapChainIndepStateConfig ())
-                           :* (WrapChainIndepStateConfig ())
-                           :* Nil
-        , configLedger = HardForkLedgerConfig {
-              hardForkLedgerConfigK      = k
-            , hardForkLedgerConfigShape  = shape
-            , hardForkLedgerConfigPerEra = PerEraLedgerConfig $
-                   (WrapPartialLedgerConfig $ ledgerConfigA nid)
-                :* (WrapPartialLedgerConfig $ ledgerConfigB nid)
-                :* Nil
-            }
-        , configBlock = HardForkBlockConfig {
-              hardForkBlockConfigPerEra = PerEraBlockConfig $
-                   blockConfigA nid
-                :* blockConfigB nid
-                :* Nil
-            }
-        , configCodec = HardForkCodecConfig {
-              hardForkCodecConfigPerEra = PerEraCodecConfig $
-                   CCfgA
-                :* CCfgB
-                :* Nil
+        , topLevelConfigBlock = FullBlockConfig {
+              blockConfigLedger = HardForkLedgerConfig {
+                  hardForkLedgerConfigK      = k
+                , hardForkLedgerConfigShape  = shape
+                , hardForkLedgerConfigPerEra = PerEraLedgerConfig $
+                       (WrapPartialLedgerConfig $ ledgerConfigA nid)
+                    :* (WrapPartialLedgerConfig $ ledgerConfigB nid)
+                    :* Nil
+                }
+            , blockConfigBlock = HardForkBlockConfig {
+                  hardForkBlockConfigPerEra = PerEraBlockConfig $
+                       blockConfigA nid
+                    :* blockConfigB nid
+                    :* Nil
+                }
+            , blockConfigCodec = HardForkCodecConfig {
+                  hardForkCodecConfigPerEra = PerEraCodecConfig $
+                       CCfgA
+                    :* CCfgB
+                    :* Nil
+                }
             }
         }
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -183,7 +183,7 @@ instance HasHeader (Header BlockA) where
   getHeaderFields = castHeaderFields . hdrA_fields
 
 instance GetPrevHash BlockA where
-  headerPrevHash = hdrA_prev
+  headerPrevHash _cfg = hdrA_prev
 
 instance HasAnnTip BlockA where
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -28,6 +28,7 @@ module Test.Consensus.HardFork.Combinator.A (
   , TxPayloadA(..)
     -- * Type family instances
   , BlockConfig(..)
+  , CodecConfig(..)
   , ConsensusConfig(..)
   , GenTx(..)
   , Header(..)
@@ -162,11 +163,8 @@ data instance BlockConfig BlockA = BCfgA
 type instance BlockProtocol BlockA = ProtocolA
 type instance HeaderHash    BlockA = Strict.ByteString
 
-instance HasCodecConfig BlockA where
-  data CodecConfig BlockA = CCfgA
-    deriving (Generic, NoUnexpectedThunks)
-
-  getCodecConfig     _ = CCfgA
+data instance CodecConfig BlockA = CCfgA
+  deriving (Generic, NoUnexpectedThunks)
 
 instance ConfigSupportsNode BlockA where
   getSystemStart     _ = SystemStart dawnOfTime

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -237,7 +237,7 @@ instance CommonProtocolParams BlockA where
   maxTxSize     _ = maxBound
 
 instance CanForge BlockA where
-  forgeBlock TopLevelConfig{..} _ bno (Ticked sno st) _txs _ = BlkA {
+  forgeBlock tlc _ bno (Ticked sno st) _txs _ = BlkA {
         blkA_header = HdrA {
             hdrA_fields = HeaderFields {
                 headerFieldHash    = Lazy.toStrict . B.encode $ unSlotNo sno
@@ -250,7 +250,7 @@ instance CanForge BlockA where
       }
     where
       ledgerConfig :: PartialLedgerConfig BlockA
-      ledgerConfig = snd configLedger
+      ledgerConfig = snd $ configLedger tlc
 
 instance BlockSupportsProtocol BlockA where
   validateView _ _ = ()

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -162,7 +162,7 @@ instance HasHeader (Header BlockB) where
   getHeaderFields = castHeaderFields . hdrB_fields
 
 instance GetPrevHash BlockB where
-  headerPrevHash = hdrB_prev
+  headerPrevHash _cfg = hdrB_prev
 
 instance HasAnnTip BlockB where
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -24,6 +24,7 @@ module Test.Consensus.HardFork.Combinator.B (
   , safeZoneB
     -- * Type family instances
   , BlockConfig(..)
+  , CodecConfig(..)
   , ConsensusConfig(..)
   , GenTx(..)
   , Header(..)
@@ -141,11 +142,8 @@ data instance BlockConfig BlockB = BCfgB
 type instance BlockProtocol BlockB = ProtocolB
 type instance HeaderHash    BlockB = Strict.ByteString
 
-instance HasCodecConfig BlockB where
-  data CodecConfig BlockB = CCfgB
-    deriving (Generic, NoUnexpectedThunks)
-
-  getCodecConfig     _ = CCfgB
+data instance CodecConfig BlockB = CCfgB
+  deriving (Generic, NoUnexpectedThunks)
 
 instance ConfigSupportsNode BlockB where
   getSystemStart     _ = SystemStart dawnOfTime

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -319,11 +319,13 @@ testInitLedger = genesisSimpleLedgerState $ mkAddrDist (NumCoreNodes 5)
 testLedgerConfig :: LedgerConfig TestBlock
 testLedgerConfig = SimpleLedgerConfig {
       simpleMockLedgerConfig = ()
-    , simpleLedgerEraParams  =
-        HardFork.defaultEraParams
-          (SecurityParam 4)
-          (slotLengthFromSec 20)
+    , simpleLedgerK          = k
+    , simpleLedgerEraParams  = HardFork.defaultEraParams
+                                 k
+                                 (slotLengthFromSec 20)
     }
+  where
+    k = SecurityParam 4
 
 data TestSetup = TestSetup
   { testLedgerState        :: LedgerState TestBlock

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -399,6 +399,7 @@ runChainSync securityParam (ClientUpdates clientUpdates)
       , configIndep  = ()
       , configLedger = eraParams
       , configBlock  = TestBlockConfig numCoreNodes
+      , configCodec  = TestBlockCodecConfig
       }
 
     eraParams :: HardFork.EraParams

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -385,21 +385,25 @@ runChainSync securityParam (ClientUpdates clientUpdates)
 
     nodeCfg :: TopLevelConfig TestBlock
     nodeCfg = TopLevelConfig {
-        configConsensus = BftConfig
-          { bftParams   = BftParams
-                            { bftSecurityParam = securityParam
-                            , bftNumNodes      = numCoreNodes
-                            }
-          , bftSignKey  = SignKeyMockDSIGN 0
-          , bftVerKeys  = Map.fromList
-                          [ (CoreId (CoreNodeId 0), VerKeyMockDSIGN 0)
-                          , (CoreId (CoreNodeId 1), VerKeyMockDSIGN 1)
-                          ]
+        topLevelConfigProtocol = FullProtocolConfig{
+            protocolConfigConsensus = BftConfig
+              { bftParams  = BftParams
+                               { bftSecurityParam = securityParam
+                               , bftNumNodes      = numCoreNodes
+                               }
+              , bftSignKey = SignKeyMockDSIGN 0
+              , bftVerKeys = Map.fromList
+                             [ (CoreId (CoreNodeId 0), VerKeyMockDSIGN 0)
+                             , (CoreId (CoreNodeId 1), VerKeyMockDSIGN 1)
+                             ]
+              }
+          , protocolConfigIndep = ()
           }
-      , configIndep  = ()
-      , configLedger = eraParams
-      , configBlock  = TestBlockConfig numCoreNodes
-      , configCodec  = TestBlockCodecConfig
+      , topLevelConfigBlock = FullBlockConfig{
+            blockConfigLedger = eraParams
+          , blockConfigBlock  = TestBlockConfig numCoreNodes
+          , blockConfigCodec  = TestBlockCodecConfig
+          }
       }
 
     eraParams :: HardFork.EraParams

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -50,7 +50,6 @@ import           Ouroboros.Network.Protocol.ChainSync.Type (ChainSync)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended hiding (ledgerState)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -26,7 +26,6 @@ import           Ouroboros.Network.Protocol.LocalStateQuery.Type
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -214,17 +214,21 @@ initLgrDB k chain = do
 
 testCfg :: SecurityParam -> TopLevelConfig TestBlock
 testCfg securityParam = TopLevelConfig {
-      configConsensus = BftConfig
-        { bftParams  = BftParams { bftSecurityParam = securityParam
-                                 , bftNumNodes      = numCoreNodes
-                                 }
-        , bftSignKey = SignKeyMockDSIGN 0
-        , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
+      topLevelConfigProtocol = FullProtocolConfig {
+          protocolConfigConsensus = BftConfig
+            { bftParams  = BftParams { bftSecurityParam = securityParam
+                                     , bftNumNodes      = numCoreNodes
+                                     }
+            , bftSignKey = SignKeyMockDSIGN 0
+            , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
+            }
+        , protocolConfigIndep = ()
         }
-    , configIndep  = ()
-    , configLedger = eraParams
-    , configBlock  = TestBlockConfig numCoreNodes
-    , configCodec  = TestBlockCodecConfig
+    , topLevelConfigBlock = FullBlockConfig {
+          blockConfigLedger = eraParams
+        , blockConfigBlock  = TestBlockConfig numCoreNodes
+        , blockConfigCodec  = TestBlockCodecConfig
+        }
     }
   where
     slotLength :: SlotLength

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -224,6 +224,7 @@ testCfg securityParam = TopLevelConfig {
     , configIndep  = ()
     , configLedger = eraParams
     , configBlock  = TestBlockConfig numCoreNodes
+    , configCodec  = TestBlockCodecConfig
     }
   where
     slotLength :: SlotLength

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -395,7 +395,7 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
     blockInfo tb = VolDB.BlockInfo
       { VolDB.bbid          = blockHash tb
       , VolDB.bslot         = blockSlot tb
-      , VolDB.bpreBid       = case blockPrevHash tb of
+      , VolDB.bpreBid       = case blockPrevHash TestBlockCodecConfig tb of
           GenesisHash -> Origin
           BlockHash h -> NotOrigin h
       , VolDB.bisEBB        = testBlockIsEBB tb

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -467,13 +467,15 @@ addBlockPromise cfg blk m = (result, m')
 stream
   :: GetPrevHash blk
   => SecurityParam
-  -> StreamFrom blk -> StreamTo blk
-  -> Model blk
+  -> CodecConfig blk
+  -> StreamFrom  blk
+  -> StreamTo    blk
+  -> Model       blk
   -> Either ChainDbError
             (Either (UnknownRange blk) IteratorId, Model blk)
-stream securityParam from to m = do
+stream securityParam cfg from to m = do
     unless (validBounds from to) $ Left (InvalidIteratorRange from to)
-    case between securityParam from to m of
+    case between securityParam cfg from to m of
       Left  e    -> return (Left e,      m)
       Right blks -> return (Right itrId, m {
           iterators = Map.insert itrId blks (iterators m)
@@ -759,8 +761,9 @@ validate cfg Model { currentSlot, maxClockSkew, initLedger, invalid } chain =
 
 
 chains :: forall blk. (GetPrevHash blk)
-       => Map (HeaderHash blk) blk -> [Chain blk]
-chains bs = go Chain.Genesis
+       => CodecConfig blk
+       -> Map (HeaderHash blk) blk -> [Chain blk]
+chains cfg bs = go Chain.Genesis
   where
     -- Construct chains,
     go :: Chain blk -> [Chain blk]
@@ -777,7 +780,7 @@ chains bs = go Chain.Genesis
           Map.findWithDefault Map.empty (Chain.headHash ch) fwd
 
     fwd :: Map (ChainHash blk) (Map (HeaderHash blk) blk)
-    fwd = successors (Map.elems bs)
+    fwd = successors cfg (Map.elems bs)
 
 validChains :: forall blk. LedgerSupportsProtocol blk
             => TopLevelConfig blk
@@ -803,7 +806,7 @@ validChains cfg m bs =
     -- over the equally preferable A->B as it will be the first in the list
     -- after a stable sort.
     sortChains $
-    chains bs
+    chains (configCodec cfg) bs
   where
     sortChains :: [Chain blk] -> [Chain blk]
     sortChains = sortBy (flip (Fragment.compareAnchoredCandidates cfg `on`
@@ -816,17 +819,23 @@ validChains cfg m bs =
 
 -- Map (HeaderHash blk) blk maps a block's hash to the block itself
 successors :: forall blk. GetPrevHash blk
-           => [blk] -> Map (ChainHash blk) (Map (HeaderHash blk) blk)
-successors = Map.unionsWith Map.union . map single
+           => CodecConfig blk
+           -> [blk]
+           -> Map (ChainHash blk) (Map (HeaderHash blk) blk)
+successors cfg = Map.unionsWith Map.union . map single
   where
     single :: blk -> Map (ChainHash blk) (Map (HeaderHash blk) blk)
-    single b = Map.singleton (blockPrevHash b)
+    single b = Map.singleton (blockPrevHash cfg b)
                              (Map.singleton (blockHash b) b)
 
 between :: forall blk. GetPrevHash blk
-        => SecurityParam -> StreamFrom blk -> StreamTo blk -> Model blk
+        => SecurityParam
+        -> CodecConfig blk
+        -> StreamFrom  blk
+        -> StreamTo    blk
+        -> Model       blk
         -> Either (UnknownRange blk) [blk]
-between k from to m = do
+between k cfg from to m = do
     fork <- errFork
     -- See #871.
     if partOfCurrentChain fork ||
@@ -846,7 +855,7 @@ between k from to m = do
     -- A fragment for each possible chain in the database
     fragments :: [AnchoredFragment blk]
     fragments = map Chain.toAnchoredFragment
-              . chains
+              . chains cfg
               . blocks
               $ m
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
@@ -20,7 +20,6 @@ import qualified Ouroboros.Network.MockChain.Chain as Chain
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.Util.AnchoredFragment as AF
 
 import           Ouroboros.Consensus.Storage.ChainDB.API (StreamFrom (..),
@@ -92,13 +91,14 @@ prop_alwaysPickPreferredChain bt p =
 prop_between_currentChain :: BlockTree -> Property
 prop_between_currentChain bt =
     Right (AF.toOldestFirst $ Chain.toAnchoredFragment $ M.currentChain model) ===
-    M.between secParam from to model
+    M.between secParam ccfg from to model
   where
     blocks   = treeToBlocks bt
     model    = addBlocks blocks
     from     = StreamFromExclusive GenesisPoint
     to       = StreamToInclusive $ cantBeGenesis (M.tipPoint model)
     secParam = configSecurityParam singleNodeTestConfig
+    ccfg     = configCodec         singleNodeTestConfig
 
 -- | Workaround when we know the DB can't be empty, but the types don't
 cantBeGenesis :: HasCallStack => Point blk -> RealPoint blk

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -521,7 +521,7 @@ runPure cfg = \case
     GetBlockComponent pt     -> err MbAllComponents     $ query   (Model.getBlockComponentByPoint @Identity allComponents pt)
     GetGCedBlockComponent pt -> err mbGCedAllComponents $ query   (Model.getBlockComponentByPoint @Identity allComponents pt)
     GetMaxSlotNo             -> ok  MaxSlot             $ query    Model.getMaxSlotNo
-    Stream from to           -> err iter                $ updateE (Model.stream k from to)
+    Stream from to           -> err iter                $ updateE (Model.stream k ccfg from to)
     IteratorNext  it         -> ok  IterResult          $ update  (Model.iteratorNext @Identity it allComponents)
     IteratorNextGCed it      -> ok  iterResultGCed      $ update  (Model.iteratorNext @Identity it allComponents)
     IteratorClose it         -> ok  Unit                $ update_ (Model.iteratorClose it)
@@ -534,7 +534,8 @@ runPure cfg = \case
     Reopen                   -> openOrClosed            $ update_  Model.reopen
     WipeVolDB                -> ok  Point               $ update  (Model.wipeVolDB cfg)
   where
-    k = configSecurityParam cfg
+    k    = configSecurityParam cfg
+    ccfg = configCodec         cfg
 
     advanceAndAdd slot blk m = (Model.tipPoint m', m')
       where
@@ -998,7 +999,7 @@ precondition Model {..} (At cmd) =
     -- TODO #871
     isValidIterator :: StreamFrom blk -> StreamTo blk -> Logic
     isValidIterator from to =
-        case Model.between secParam from to' dbModel of
+        case Model.between secParam (configCodec cfg) from to' dbModel of
           Left  _    -> Bot
           -- All blocks must be valid
           Right blks -> forall blks $ \blk -> Boolean $

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -268,7 +268,6 @@ type TestConstraints blk =
   , Show                     (Header  blk)
   , ConvertRawHash                    blk
   , HasHardForkHistory                blk
-  , HasCodecConfig                    blk
   , SerialiseDiskConstraints          blk
   )
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -63,6 +63,7 @@ openTestDB registry hasFS =
       }
   where
     parser = chunkFileParser
+               TestBlockCodecConfig
                hasFS
                (const <$> S.decode)
                testBlockBinaryBlockInfo

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -785,8 +785,10 @@ precondition Model {..} (At (CmdErr { cmd })) =
   where
     fitsOnTip :: TestBlock -> Logic
     fitsOnTip b = case dbmTipBlock dbModel of
-      Nothing    -> blockPrevHash b .== GenesisHash
-      Just bPrev -> blockPrevHash b .== BlockHash (blockHash bPrev)
+      Nothing    -> getPrevHash b .== GenesisHash
+      Just bPrev -> getPrevHash b .== BlockHash (blockHash bPrev)
+
+    getPrevHash = blockPrevHash TestBlockCodecConfig
 
 transition :: (Show1 r, Eq1 r)
            => Model m r -> At CmdErr m r -> At Resp m r -> Model m r
@@ -1259,6 +1261,7 @@ test cacheConfig chunkInfo cmds = do
 
     let hasFS  = mkSimErrorHasFS fsVar varErrors
         parser = chunkFileParser
+                   TestBlockCodecConfig
                    hasFS
                    (const <$> decode)
                    testBlockBinaryBlockInfo

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -643,21 +643,25 @@ testInitExtLedger = ExtLedgerState {
 mkTestConfig :: SecurityParam -> ChunkSize -> TopLevelConfig TestBlock
 mkTestConfig k ChunkSize { chunkCanContainEBB, numRegularBlocks } =
     TopLevelConfig {
-        configConsensus = McsConsensusConfig () $ BftConfig {
-            bftParams  = BftParams {
-                             bftSecurityParam = k
-                           , bftNumNodes      = numCoreNodes
-                           }
-          , bftSignKey = SignKeyMockDSIGN 0
-          , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
+        topLevelConfigProtocol = FullProtocolConfig {
+            protocolConfigConsensus = McsConsensusConfig () $ BftConfig {
+                bftParams  = BftParams {
+                                 bftSecurityParam = k
+                               , bftNumNodes      = numCoreNodes
+                               }
+              , bftSignKey = SignKeyMockDSIGN 0
+              , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
+              }
+          , protocolConfigIndep  = ()
           }
-      , configIndep  = ()
-      , configLedger = eraParams
-      , configBlock  = TestBlockConfig {
-            testBlockEBBsAllowed  = chunkCanContainEBB
-          , testBlockNumCoreNodes = numCoreNodes
+      , topLevelConfigBlock = FullBlockConfig {
+            blockConfigLedger = eraParams
+          , blockConfigBlock  = TestBlockConfig {
+                testBlockEBBsAllowed  = chunkCanContainEBB
+              , testBlockNumCoreNodes = numCoreNodes
+              }
+          , blockConfigCodec  = TestBlockCodecConfig
           }
-      , configCodec  = TestBlockCodecConfig
       }
   where
     slotLength :: SlotLength

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -238,10 +238,8 @@ data instance BlockConfig TestBlock = TestBlockConfig {
     }
   deriving (Generic, NoUnexpectedThunks)
 
-instance HasCodecConfig TestBlock where
-  data CodecConfig TestBlock = TestBlockCodecConfig
-    deriving (Generic, NoUnexpectedThunks)
-  getCodecConfig = const TestBlockCodecConfig
+data instance CodecConfig TestBlock = TestBlockCodecConfig
+  deriving (Generic, NoUnexpectedThunks)
 
 instance Condense TestBlock where
   condense = show -- TODO
@@ -659,6 +657,7 @@ mkTestConfig k ChunkSize { chunkCanContainEBB, numRegularBlocks } =
             testBlockEBBsAllowed  = chunkCanContainEBB
           , testBlockNumCoreNodes = numCoreNodes
           }
+      , configCodec  = TestBlockCodecConfig
       }
   where
     slotLength :: SlotLength

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -594,6 +594,7 @@ test cmds = do
 
     let hasFS  = mkSimErrorHasFS varFs varErrors
         parser = blockFileParser'
+          TestBlockCodecConfig
           hasFS
           testBlockBinaryBlockInfo
           ((\blk bytes -> (takePrefix testPrefixLen bytes, blk)) <$> decode)


### PR DESCRIPTION
Critically, this provides all the plumbing so that in the end we can have

```haskell
-- | Translate from a raw Byron prev-hash to 'ChainHash'
--
-- This takes the 'CodecConfig' so that we can "translate away" EBBs (#2156).
fromByronPrevHash :: CodecConfig ByronBlock
                  -> Maybe CC.HeaderHash
                  -> ChainHash ByronBlock
```

(even if we don't yet take advantage of this).