### PR TITLE
network: also make the ChainSync CanAwait timeout configurable

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -59,6 +59,7 @@ import           Ouroboros.Network.MockChain.Chain (Chain (Genesis))
 
 import qualified Ouroboros.Network.BlockFetch.Client as BFClient
 import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..))
+import           Ouroboros.Network.Protocol.Limits (shortWait, waitForever)
 import           Ouroboros.Network.Protocol.TxSubmission.Type
 import qualified Ouroboros.Network.TxSubmission.Inbound as TxInbound
 import qualified Ouroboros.Network.TxSubmission.Outbound as TxOutbound
@@ -846,7 +847,11 @@ runThreadNetwork systemTime ThreadNetworkArgs
                   -- node
                   nullDebugProtocolTracers
                   (customNodeToNodeCodecs pInfoConfig)
-                  (return Nothing) -- Workaround for #1882, tests that can't cope with timeouts.
+                  -- see #1882, tests that can't cope with timeouts.
+                  (pure $ NTN.ChainSyncTimeout
+                     { canAwaitTimeout  = shortWait
+                     , mustReplyTimeout = waitForever
+                     })
                   (NTN.mkHandlers nodeArgs nodeKernel)
 
       -- In practice, a robust wallet/user can persistently add a transaction

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -26,6 +26,8 @@ module Ouroboros.Consensus.Network.NodeToNode (
     -- ** Projections
   , initiator
   , responder
+    -- * Re-exports
+  , ChainSyncTimeout (..)
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)
@@ -359,7 +361,7 @@ mkApps
   => NodeKernel m remotePeer localPeer blk -- ^ Needed for bracketing only
   -> Tracers m remotePeer blk e
   -> Codecs blk e m bCS bCS bBF bBF bTX
-  -> m (Maybe DiffTime)
+  -> m ChainSyncTimeout
   -> Handlers m remotePeer blk
   -> Apps m remotePeer blk bCS bBF bTX ()
 mkApps kernel Tracers {..} Codecs {..} genChainSyncTimeout Handlers {..} =


### PR DESCRIPTION
This PR prepares for #2292. My WIP branch for that induces rollbacks by enforcing short network partitions by delaying `MsgRollForward` messages for several slots. Since that message is a valid response in the `CanAwait` state, the tests will also need to relax/de-activate that timeout. This PR doesn't change the timeout. It only exposes it as a parameter.
