### PR TITLE
add a network partition to Cardano HFC ThreadNet tests at interesting times

### DIFF
--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
@@ -141,6 +141,7 @@ setupTestConfigB :: SetupDualPBft -> TestConfigB DualByronBlock
 setupTestConfigB SetupDualPBft{..} = TestConfigB
   { forgeEbbEnv  = Nothing -- spec does not model EBBs
   , future       = singleEraFuture setupSlotLength epochSize
+  , messageDelay = noCalcMessageDelay
   , nodeJoinPlan = setupNodeJoinPlan
   , nodeRestarts = setupNodeRestarts
   , txGenExtra   = ()

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
@@ -909,6 +909,7 @@ prop_simple_real_pbft_convergence TestSetup
           NoEBBs      -> Nothing
           ProduceEBBs -> Just byronForgeEbbEnv
       , future       = singleEraFuture slotLength epochSize
+      , messageDelay = noCalcMessageDelay
       , nodeJoinPlan
       , nodeRestarts
       , txGenExtra   = ()

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -161,6 +161,7 @@ prop_simple_cardano_convergence TestSetup
           EraFinal setupSlotLengthShelley epochSizeShelley
           else
           EraFinal setupSlotLengthByron   epochSizeByron
+      , messageDelay = noCalcMessageDelay
       , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
       , nodeRestarts = noRestarts
       , txGenExtra   = ()

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE MultiWayIf          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -16,21 +18,22 @@ import qualified Data.Map as Map
 import           Data.Proxy (Proxy (..))
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
+import           Numeric.Natural (Natural)
 
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Prelude (Natural)
+import           Cardano.Slotting.Slot (EpochNo, EpochSize (..), SlotNo (..))
 
 import           Cardano.Crypto.Hash.Blake2b (Blake2b_256)
 import qualified Cardano.Crypto.KES.Class as KES
 
-import           Ouroboros.Network.MockChain.Chain (chainToList)
+import qualified Ouroboros.Network.MockChain.Chain as MockChain
 
-import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
+import qualified Ouroboros.Consensus.HardFork.History.Util as Util
 import           Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.NodeId
@@ -61,16 +64,29 @@ import           Test.Consensus.Shelley.MockCrypto (TPraosMockCrypto)
 import           Test.ThreadNet.General
 import qualified Test.ThreadNet.Infra.Byron as Byron
 import qualified Test.ThreadNet.Infra.Shelley as Shelley
-import           Test.ThreadNet.Network (NodeOutput (..),
+import           Test.ThreadNet.Network (CalcMessageDelay (..), NodeOutput (..),
                      TestNodeInitialization (..))
 import           Test.ThreadNet.TxGen.Cardano ()
+import           Test.ThreadNet.Util.Expectations (NumBlocks (..))
 import           Test.ThreadNet.Util.NodeJoinPlan (trivialNodeJoinPlan)
 import           Test.ThreadNet.Util.NodeRestarts (noRestarts)
+import           Test.ThreadNet.Util.NodeTopology (meshNodeTopology)
 import qualified Test.Util.BoolProps as BoolProps
 import           Test.Util.HardFork.Future
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Random
 import           Test.Util.Slots (NumSlots (..))
+
+-- | When and for how long the nodes are partitioned
+--
+-- The nodes are divided via message delays into two sub-networks by the parity
+-- of their 'CoreNodeId'.
+data Partition = Partition SlotNo NumSlots
+  -- ^ the scheduled start slot and duration (which includes the start slot)
+  deriving (Show)
+
+partitionExclusiveUpperBound :: Partition -> SlotNo
+partitionExclusiveUpperBound (Partition s (NumSlots d)) = Util.addSlots d s
 
 -- | The varying data of this test
 --
@@ -85,6 +101,7 @@ data TestSetup = TestSetup
   , setupHardFork          :: Bool
     -- ^ whether the proposal should trigger a hard fork or not
   , setupK                 :: SecurityParam
+  , setupPartition         :: Partition
   , setupSlotLengthByron   :: SlotLength
   , setupSlotLengthShelley :: SlotLength
   , setupTestConfig        :: TestConfig
@@ -93,28 +110,165 @@ data TestSetup = TestSetup
 
 instance Arbitrary TestSetup where
   arbitrary = do
-    setupD <- (/10)         <$> choose   (1, 10)
-    setupK <- SecurityParam <$> choose   (2, 5)
+    setupD <- (/10)         <$> choose (1, 10)
+    setupK <- SecurityParam <$> choose (2, 6)
 
     setupSlotLengthByron   <- arbitrary
     setupSlotLengthShelley <- arbitrary
 
-    setupTestConfig <- arbitrary
+    setupTestConfig <- do
+      tc <- arbitrary
+
+      -- This test has more slots than most, so we de-emphasize the relatively
+      -- expensive n=5 case. For example:
+      --
+      -- > 250 tests with 30% 2, 30% 3, 30% 4, and 10% 5 took 500s
+      -- > 250 tests with 100% 5 took 1000s
+      ncn <- frequency [(9, choose (2, 4)), (1, pure 5)]
+
+      let NumSlots t = numSlots tc
+      pure tc
+        { numCoreNodes = NumCoreNodes ncn
+        , numSlots     =
+            NumSlots $
+            min 150 $
+            -- make it very likely that there are multiple epochs
+            numByronEpochs * 10 * maxRollbacks setupK + div t 2
+        }
+
+    let TestConfig{numCoreNodes, numSlots} = setupTestConfig
 
     setupByronLowerBound <- arbitrary
     setupHardFork        <- frequency [(9, pure True), (1, pure False)]
+    setupPartition       <- genPartition numCoreNodes numSlots setupK
 
     pure TestSetup
       { setupByronLowerBound
       , setupD
       , setupHardFork
       , setupK
+      , setupPartition
       , setupSlotLengthByron
       , setupSlotLengthShelley
-      , setupTestConfig
+      , setupTestConfig = setupTestConfig
+        { nodeTopology =
+            -- use a mesh topology so the partition classes definitely remain
+            -- internally connected
+            meshNodeTopology numCoreNodes
+        }
       }
 
   -- TODO shrink
+
+-- | Generate 'setupPartition'
+genPartition :: NumCoreNodes -> NumSlots -> SecurityParam -> Gen Partition
+genPartition (NumCoreNodes n) (NumSlots t) (SecurityParam k) = do
+    let ultimateSlot :: Word64
+        ultimateSlot = assert (t > 0) $ t - 1
+
+        crop :: Word64 -> Word64
+        crop s = min ultimateSlot s
+
+    -- Fundamental plan: all @MsgRollForward@ sent during the partition only
+    -- arrive at the onset of slot after it. The partition begins at the onset
+    -- of @firstSlotIn@ and ends at the onset of @firstSlotAfter@.
+
+    -- FACT (A) The leader of @firstSlotAfter@ will forge before fully reacting
+    -- to the @MsgRollForward@s that just arrived, due to a race in the test
+    -- infrastructure that is consistently won by the forge. Thus the two
+    -- class's unique extensions consist of the blocks forged in the slots from
+    -- @firstSlotIn@ to @firstSlotAfter@ /inclusive/.
+
+    -- @w@ is defined below this large comment to be how long the partition
+    -- should last (this may be 'crop'ped farther below if the partition ends
+    -- up near the end of the test)
+    --
+    -- Because of FACT (A), we limit the partition duration so that at least
+    -- one of the two partition classes will forge /strictly/ /less/ /than/ @k@
+    -- such blocks. While both classes would be able to rollback if we let them
+    -- forge @k@ such blocks, they might (TODO "might" or "will"?) not able to
+    -- /decide/ that they need to rollback, since the relevant ChainSync client
+    -- might (TODO will?) not be able to forecast a ledger view far-enough into
+    -- the future to validate the @k+1@st header from the other class after the
+    -- partition ends. It will remain unaware that a longer chain exists and
+    -- end up stuck on its own distinct chain. Hence it's a Common Prefix
+    -- violation.
+    --
+    -- We therefore motivate an upper bound on the partition duration @w@ for a
+    -- net with @n@ nodes by considering the two variables' parities.
+    --
+    -- o For @n = 2h@ nodes and @w = 2u@ slots, the classes respectively forge
+    --   @u@ and @u+1@ blocks. (The @+1@th block is forged in
+    --   @firstSlotAfter@.) The preceding paragraph requires @u < k@ requires
+    --   @u <= k-1@ requires @w <= 2k-2@. So @w <= 2k-2@ when @w@ is even.
+    --
+    -- o For @n = 2h@ nodes and @w = 2u+1@ slots, the classes both forge @u+1@
+    --   blocks. (The second @+1@th block is forged in @firstSlotAfter@.) The
+    --   preceding paragraph requires @u+1 < k@ requires @u <= k-2@ requires @w
+    --   <= 2k-3@. So @w <= 2k-3@ when @w@ is odd. Note that @w <= 2k-2@ is
+    --   equivalent since @w@ is assumed odd.
+    --
+    -- o For @n = 2h+1@ nodes, the smaller class forges at most the number of
+    --   blocks considered in the above cases for even @n@, so this case
+    --   doesn't contribute anything novel to the upper bound. The smaller
+    --   class has less than half of the nodes and so will violate Chain Growth
+    --   /if/ /given/ /enough/ /time/ /alone/. But for Byron at least, the
+    --   logic for avoiding a Common Prefix violation already establishes a
+    --   sufficiently strict upper bound to preclude a Chain Growth violation,
+    --   since Chain Growth isn't technically violated until @2k@ slots have
+    --   passed (it's also relevant that the net forges at full round-robin
+    --   speed until the partition starts). (TODO does that cover Shelley too?)
+    --
+    -- Thus @w@ can range from @0@ to @2k-2@ inclusive.
+    w <- assert (k > 0) $ choose (0, 2 * k - 2)
+
+    -- Each of the the following milestones happens at the listed slot in the
+    -- absence of a partition.
+    --
+    -- o In slots 0 and 1 the proposal and the votes confirm it
+    --
+    -- o In slot 2k+1 the confirmation becomes stable
+    --
+    -- o In slot 2k+1+quorum the nodes endorse it
+    --
+    -- o In slot 4k+1+quorum the endorsement is stable
+    --
+    -- o In slot 10k the update is adopted.
+    --
+    -- We are most interested in what happens when the partition is near these
+    -- milestones.
+    mbFocus <- do
+      let quorum = div n 2   -- in the right ballpark
+      frequency $
+        map (\(wgt, mbDur) -> (wgt, pure mbDur)) $
+        filter (maybe True (< t) . snd)
+          [ (5,  Nothing)
+          , (1,  Just 0)
+          , (1,  Just $ 2 * k + 1)
+          , (1,  Just $ 2 * k + 1 + quorum)
+          , (1,  Just $ 4 * k + 1)
+          , (1,  Just $ 4 * k + 1 + quorum)
+          , (20, assert (numByronEpochs == (1 :: Int)) $ Just $ 10 * k)
+          ]
+
+    -- Position the partition so that it at least abuts the focus slot.
+    firstSlotIn <- choose $
+      case mbFocus of
+        Nothing    -> (0,                            ultimateSlot    )
+        Just focus -> (crop $ focus `monus` (w + 1), crop $ focus + 1)
+
+    let -- Because of FACT (A), we require there to be at least one slot after
+        -- the partition. This doesn't ensure full consensus, because the block
+        -- forged in @firstSlotAfter@ may create a chain as long as that of the
+        -- other partition (Byron) or even multiple such chains (Shelley). But
+        -- it does ensure that all final chains will be the same length.
+        firstSlotAfter :: Word64
+        firstSlotAfter = crop $ firstSlotIn + w
+
+        d :: Word64
+        d = Util.countSlots (SlotNo firstSlotAfter) (SlotNo firstSlotIn)
+
+    pure $ Partition (SlotNo firstSlotIn) (NumSlots d)
 
 tests :: TestTree
 tests = testGroup "Cardano" $
@@ -128,23 +282,31 @@ prop_simple_cardano_convergence TestSetup
   , setupD
   , setupHardFork
   , setupK
+  , setupPartition
   , setupSlotLengthByron
   , setupSlotLengthShelley
   , setupTestConfig
   } =
     tabulate "ReachesShelley label" [label_ReachesShelley reachesShelley] $
-    prop_general PropGeneralArgs
+    tabulatePartitionDuration $
+    tabulateFinalIntersectionDepth $
+    tabulatePartitionPosition $
+    prop_general_semisync PropGeneralArgs
       { pgaBlockProperty      = const $ property True
       , pgaCountTxs           = fromIntegral . length . extractTxs
       , pgaExpectedCannotLead = noExpectedCannotLeads
       , pgaFirstBlockNo       = 0
-      , pgaFixedMaxForkLength = Nothing
-      , pgaFixedSchedule      = Nothing
+      , pgaFixedMaxForkLength = Just maxForkLength
+      , pgaFixedSchedule      =
+          -- the leader schedule isn't fixed because the Shelley leader
+          -- schedule is (at least ideally) unpredictable
+          Nothing
       , pgaSecurityParam      = setupK
       , pgaTestConfig         = setupTestConfig
       , pgaTestConfigB        = testConfigB
       }
       testOutput .&&.
+    prop_inSync testOutput .&&.
     prop_ReachesShelley reachesShelley
   where
     TestConfig
@@ -157,11 +319,15 @@ prop_simple_cardano_convergence TestSetup
       , future       =
           if setupHardFork
           then
+          -- In this case the PVU will trigger the transition to Shelley.
+          --
+          -- By FACT (B), the PVU is always successful if we reach the second
+          -- era.
           EraCons  setupSlotLengthByron   epochSizeByron   eraSizeByron $
           EraFinal setupSlotLengthShelley epochSizeShelley
           else
           EraFinal setupSlotLengthByron   epochSizeByron
-      , messageDelay = noCalcMessageDelay
+      , messageDelay = mkMessageDelay setupPartition
       , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
       , nodeRestarts = noRestarts
       , txGenExtra   = ()
@@ -184,6 +350,30 @@ prop_simple_cardano_convergence TestSetup
                   (TriggerHardForkAtVersion shelleyMajorVersion)
             , mkRekeyM = Nothing
             }
+
+    maxForkLength :: NumBlocks
+    maxForkLength = NumBlocks $
+        if rsShelleyBlocks reachesShelley
+        then
+          -- Shelley inherently creates small forks, but we haven't yet seen a
+          -- Common Prefix violation in this test even though @k@ is small
+          --
+          -- TODO I'd value having a repro that demonstrates a violation of
+          -- this typical limit, so I'm leaving it in for now. If it never
+          -- fails, we should figure out why not. Even with @k=2 ncn=5 d=0.1@
+          -- fixed the deepest fork I'm seeing is ~2.5% @k-1@
+          -- 'finalIntersectionDepth'.
+          maxRollbacks setupK
+        else
+          -- Recall that all nodes join ASAP, so the partition is the only
+          -- potential cause for a fork during Byron. See the reasoning in
+          -- 'genPartition' for the motivation of this limit.
+          div partitionDuration 2 + mod partitionDuration 2
+
+    partitionDuration :: Word64
+    partitionDuration = d
+      where
+        Partition _ (NumSlots d) = setupPartition
 
     -- Byron
 
@@ -237,6 +427,30 @@ prop_simple_cardano_convergence TestSetup
     epochSizeShelley = sgEpochLength genesisShelley
 
     -- the protocol version of the Byron era proposal
+    --
+    -- FACT (B) This proposal is always adopted at the first epoch boundary.
+    --
+    -- o 'genTestConfig' ensures the test reaches the epoch boundary unless
+    --   there's a fatal error during execution. Specifically, 'rsByronSlots'
+    --   will always be 'Enabled'.
+    --
+    -- o 'genPartition' limits the partition duration to at most @2k-2@ slots.
+    --   This leaves at least @10k - (2k-2) = 8k+2@ slots in the epoch
+    --   unaffected by the partition. Moreover, the blocks forged during the
+    --   partition do make some progress, even though it's not full progress.
+    --   So @8k+2@ is conservative.
+    --
+    -- o As " crucial transactions ", the proposal and vote are added to the
+    --   chain eventually and ASAP, even if they are initially placed on the
+    --   losing partition class's chain.
+    --
+    -- o Thus, within the first two of the @8k+2@ unaffected slots, the
+    --   proposal has been confirmed. Similar reasoning ensures that it is then
+    --   stably confirmed, endorsed, and stably endorsed, before the epoch
+    --   boundary and @SafeZone@. IE @2 + 2k + q + 2k + 2k < 8k+2@, since the
+    --   quorum @q@ is ~60% of 'numCoreNodes' and so @q < 2k@, since
+    --   'numCoreNodes' is at most 5 and @k@ is at least @2@. (Also recall that
+    --   @8k+2@ is conservative.)
     propPV :: CC.Update.ProtocolVersion
     propPV =
       if setupHardFork
@@ -248,44 +462,100 @@ prop_simple_cardano_convergence TestSetup
         CC.Update.ProtocolVersion
           byronMajorVersion (byronInitialMinorVersion + 1) 0
 
+    -- Classifying test cases
+
     reachesShelley :: ReachesShelley
     reachesShelley = ReachesShelley
       { rsByronSlots    =
-          BoolProps.enabledIf $ t > byronSlots
+          BoolProps.enabledIf $ t > numByronSlots
       , rsPV            = BoolProps.enabledIf setupHardFork
       , rsShelleyBlocks =
           or $
           [ isShelley blk
           | (_nid, no) <- Map.toList testOutputNodes
           , let NodeOutput{nodeOutputFinalChain} = no
-          , blk <- chainToList nodeOutputFinalChain
+          , blk <- MockChain.chainToList nodeOutputFinalChain
           ]
       , rsShelleySlots  =
           assert (w >= k) $
-          BoolProps.requiredIf $ t > byronSlots + w + 1 - k
-            -- logic: if we are ensured at least @k@ blocks in @w@ slots, then
-            -- we're ensured at least @1@ block in @w+1-k@ slots
+          BoolProps.requiredIf $
+          t > numByronSlots + ceiling (logBase (1-f) oneBillionth)
+            -- We only require a Shelley block if there are enough Shelley
+            -- slots that the chance of them all being inactive slots is at
+            -- most 1 in a billion.
       }
       where
         TestConfig{numSlots}        = setupTestConfig
         NumSlots t                  = numSlots
         TestOutput{testOutputNodes} = testOutput
 
-        byronSlots :: Word64
-        byronSlots = numByronEpochs * unEpochSize epochSizeByron
-
         k :: Word64
         k = maxRollbacks setupK
 
+        coeff :: SL.ActiveSlotCoeff
+        coeff = SL.sgActiveSlotCoeff genesisShelley
+
         w :: Word64
-        w = Shelley.computeStabilityWindow
-            setupK
-            (SL.sgActiveSlotCoeff genesisShelley)
+        w = Shelley.computeStabilityWindow setupK coeff
+
+        -- the independent probability that a Shelley slot will have at least
+        -- one leader
+        f :: Double
+        f = fromRational $ SL.unitIntervalToRational $ SL.activeSlotVal coeff
+
+        -- a strong threshold, along the lines of " not even once in the
+        -- lifetime of the project "
+        oneBillionth :: Double
+        oneBillionth = 1e-9
 
         isShelley :: CardanoBlock c -> Bool
         isShelley = \case
             BlockByron{}   -> False
             BlockShelley{} -> True
+
+    numByronSlots :: Word64
+    numByronSlots = numByronEpochs * unEpochSize epochSizeByron
+
+    finalBlockEra :: String
+    finalBlockEra =
+        if rsShelleyBlocks reachesShelley then "Shelley" else "Byron"
+
+    finalIntersectionDepth :: Word64
+    finalIntersectionDepth = d
+      where
+        NumBlocks d = calcFinalIntersectionDepth testOutput
+
+    tabulatePartitionDuration :: Property -> Property
+    tabulatePartitionDuration =
+        tabul "count"  (show               partitionDuration) .
+        tabul "k frac" (approxFracK setupK partitionDuration)
+      where
+        tabul s x =
+            tabulate ("partition duration, " <> s) [x <> " slots"]
+
+    tabulateFinalIntersectionDepth :: Property -> Property
+    tabulateFinalIntersectionDepth =
+        tabul "count"  (show               finalIntersectionDepth) .
+        tabul "k frac" (approxFracK setupK finalIntersectionDepth) .
+        tabul "k diff" (diffK       setupK finalIntersectionDepth)
+      where
+        lbl = "final intersection depth"
+        tabul s x = tabulate
+            (lbl <> ", " <> finalBlockEra <> ", " <> s)
+            [x <> " blocks"]
+
+    tabulatePartitionPosition :: Property -> Property
+    tabulatePartitionPosition =
+        tabulate "partition in or abuts era (Byron, Shelley)"
+          [ show (inclByron, inclShelley) ]
+      where
+        Partition (SlotNo firstSlotIn) (NumSlots d) = setupPartition
+        firstSlotAfter                              = firstSlotIn + d
+
+        trans = ledgerReachesShelley reachesShelley
+
+        inclByron   = d > 0 && (not trans || firstSlotIn    <= numByronSlots)
+        inclShelley = d > 0 && (trans     && firstSlotAfter >= numByronSlots)
 
 mkProtocolCardanoAndHardForkTxs
   :: forall sc m. (IOLike m, TPraosCrypto sc)
@@ -331,7 +601,9 @@ mkProtocolCardanoAndHardForkTxs
     pInfo = protocolInfoCardano
         -- Byron
         genesisByron
-        (Just $ PBftSignatureThreshold pbftSignatureThreshold)
+        -- Trivialize the PBFT signature window so that the forks induced by
+        -- the network partition are as deep as possible.
+        (Just $ PBftSignatureThreshold 1)
         propPV
         softVerByron
         (Just leaderCredentialsByron)
@@ -346,7 +618,6 @@ mkProtocolCardanoAndHardForkTxs
         triggerHardFork
 
     -- Byron
-    PBftParams { pbftSignatureThreshold } = pbftParams
 
     leaderCredentialsByron :: PBftLeaderCredentials
     leaderCredentialsByron =
@@ -412,7 +683,7 @@ numByronEpochs = 1
   ReachesShelley property
 -------------------------------------------------------------------------------}
 
--- | Whether the test included Shelley blocks and relevent (pre)reqs
+-- | Whether the test included Shelley blocks and (pre)reqs relevant to that
 --
 -- Note these fields are ordered alphabetically not semantically; see
 -- 'label_ReachesShelley'.
@@ -438,9 +709,9 @@ label_ReachesShelley reachesShelley =
     prepend "ss" rsShelleySlots $
     show         rsShelleyBlocks
   where
-    -- incur a warning if the number of fields changes
+    -- incur a GHC warning if the number of fields changes
     ReachesShelley _ _ _ _dummy = reachesShelley
-    -- this pattern should explicitly bind all fields
+    -- this pattern should bind each field by name
     ReachesShelley
       { rsByronSlots
       , rsPV
@@ -448,16 +719,20 @@ label_ReachesShelley reachesShelley =
       , rsShelleySlots
       } = reachesShelley
 
-    infixr `prepend`
     prepend :: Show a => String -> a -> String -> String
     prepend s req x = s <> " " <> show req <> ", " <> x
+
+-- | Is the update proposal adopted?
+ledgerReachesShelley :: ReachesShelley -> Bool
+ledgerReachesShelley rs = BoolProps.checkReqs rs /= Just False
 
 -- | Checks if the observation satisfies the (pre)reqs
 prop_ReachesShelley :: ReachesShelley -> Property
 prop_ReachesShelley rs = case BoolProps.checkReqs rs of
     Nothing  -> property True
     Just req ->
-        counterexample (msg req <> ": " <> show rs) $
+        counterexample (show rs) $
+        counterexample (msg req) $
         rsShelleyBlocks == req
   where
     ReachesShelley{rsShelleyBlocks} = rs
@@ -466,3 +741,45 @@ prop_ReachesShelley rs = case BoolProps.checkReqs rs of
     msg req = if req
         then "the final chains should include at least one Shelley block"
         else "the final chains should not include any Shelley blocks"
+
+{-------------------------------------------------------------------------------
+  A short even-odd partition
+-------------------------------------------------------------------------------}
+
+-- | The temporary partition as a 'CalcMessageDelay'
+--
+-- Calculates the delays that implement 'setupPartition'.
+mkMessageDelay :: Partition -> CalcMessageDelay blk
+mkMessageDelay part = CalcMessageDelay $
+    \(CoreNodeId i, CoreNodeId j) curSlot _hdr -> NumSlots $ if
+      | curSlot <  firstSlotIn    -> 0
+      | curSlot >= firstSlotAfter -> 0
+      | mod i 2 == mod j 2        -> 0
+      | otherwise                 -> unSlotNo $ firstSlotAfter - curSlot
+  where
+    Partition firstSlotIn _ = part
+    firstSlotAfter          = partitionExclusiveUpperBound part
+
+{-------------------------------------------------------------------------------
+  Miscellany
+-------------------------------------------------------------------------------}
+
+-- | Render a number as a positive difference from @k@
+--
+-- PREREQUISITE: The number must not be greater than @k@.
+diffK :: SecurityParam -> Word64 -> String
+diffK (SecurityParam k) v =
+    assert (k >= v) $
+    "k - " <> show (k - v)
+
+-- | Render a number as the nearest tenths of @k@
+approxFracK :: SecurityParam -> Word64 -> String
+approxFracK (SecurityParam k) v =
+    "k * " <> show (fromIntegral tenths / 10 :: Double)
+  where
+    ratio  = toRational v / toRational k
+    tenths = round (ratio * 10) :: Int
+
+-- | <https://en.wikipedia.org/wiki/Monus>
+monus :: (Num a, Ord a) => a -> a -> a
+monus a b = if a <= b then 0 else a - b

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -96,6 +96,7 @@ prop_simple_real_tpraos_convergence TestSetup
     testConfigB = TestConfigB
       { forgeEbbEnv  = Nothing
       , future       = singleEraFuture tpraosSlotLength epochSize
+      , messageDelay = noCalcMessageDelay
       , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
       , nodeRestarts = noRestarts
       , txGenExtra   = ShelleyTxGenExtra $ mkGenEnv coreNodes

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -134,6 +134,7 @@ prop_simple_bft_convergence TestSetup
           (EpochSize $ maxRollbacks k * 10)
           -- The mock ledger doesn't really care, and neither does BFT. We
           -- stick with the common @k * 10@ size for now.
+      , messageDelay = noCalcMessageDelay
       , nodeJoinPlan
       , nodeRestarts = noRestarts
       , txGenExtra   = ()

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -106,6 +106,7 @@ prop_simple_leader_schedule_convergence TestSetup
     testConfigB = TestConfigB
       { forgeEbbEnv  = Nothing
       , future       = singleEraFuture slotLength epochSize
+      , messageDelay = noCalcMessageDelay
       , nodeJoinPlan
       , nodeRestarts = noRestarts
       , txGenExtra   = ()

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -124,6 +124,7 @@ prop_simple_pbft_convergence TestSetup
           (EpochSize $ maxRollbacks k * 10)
           -- The mock ledger doesn't really care, and neither does PBFT. We
           -- stick with the common @k * 10@ size for now.
+      , messageDelay = noCalcMessageDelay
       , nodeJoinPlan
       , nodeRestarts = noRestarts
       , txGenExtra   = ()

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -120,6 +120,7 @@ prop_simple_praos_convergence TestSetup
     testConfigB = TestConfigB
       { forgeEbbEnv  = Nothing
       , future       = singleEraFuture slotLength epochSize
+      , messageDelay = noCalcMessageDelay
       , nodeJoinPlan
       , nodeRestarts = noRestarts
       , txGenExtra   = ()

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -225,7 +225,6 @@ runTestNetwork TestConfig
           { nodeInfo
           , mkRekeyM
           } = mkTestConfigMB
-    setCurrentTime dawnOfTime
     let systemTime =
             BTime.defaultSystemTime
               (BTime.SystemStart dawnOfTime)

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -66,7 +66,7 @@ import qualified Ouroboros.Network.Protocol.ChainSync.Type as CS
 
 import qualified Ouroboros.Network.BlockFetch.Client as BFClient
 import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..))
-import           Ouroboros.Network.Protocol.Limits (shortWait, waitForever)
+import           Ouroboros.Network.Protocol.Limits (waitForever)
 import           Ouroboros.Network.Protocol.TxSubmission.Type
 import qualified Ouroboros.Network.TxSubmission.Inbound as TxInbound
 import qualified Ouroboros.Network.TxSubmission.Outbound as TxOutbound
@@ -909,7 +909,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                   (customNodeToNodeCodecs pInfoConfig)
                   -- see #1882, tests that can't cope with timeouts.
                   (pure $ NTN.ChainSyncTimeout
-                     { canAwaitTimeout  = shortWait
+                     { canAwaitTimeout  = waitForever
                      , mustReplyTimeout = waitForever
                      })
                   (NTN.mkHandlers nodeArgs nodeKernel)

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util.hs
@@ -6,7 +6,8 @@
 
 module Test.ThreadNet.Util (
   -- * Chain properties
-    prop_all_common_prefix
+    chainCommonPrefix
+  , prop_all_common_prefix
   , shortestLength
   -- * LeaderSchedule
   , emptyLeaderSchedule
@@ -98,6 +99,19 @@ prop_common_prefix l x y = go x y .&&. go y x
                         Just s  ->    ", last slot "
                                    <> show (unSlotNo s)
                                    <> ")"
+
+-- | Find the common prefix of two chains
+chainCommonPrefix :: HasHeader b => Chain b -> Chain b -> Chain b
+chainCommonPrefix Genesis        _              = Genesis
+chainCommonPrefix _              Genesis        = Genesis
+chainCommonPrefix cl@(cl' :> bl) cr@(cr' :> br) =
+    case blockNo bl `compare` blockNo br of
+      LT -> chainCommonPrefix cl  cr'
+      GT -> chainCommonPrefix cl' cr
+      EQ ->
+          if blockHash bl /= blockHash br
+          then chainCommonPrefix cl' cr'
+          else cl
 
 {-------------------------------------------------------------------------------
   Generation of a dot-file to represent the trace as a graph

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/NodeTopology.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/NodeTopology.hs
@@ -8,8 +8,10 @@ module Test.ThreadNet.Util.NodeTopology
   , edgesNodeTopology
   , genNodeTopology
   , shrinkNodeTopology
+  , mapNodeTopology
   , meshNodeTopology
   , minimumDegreeNodeTopology
+  , unionNodeTopology
   ) where
 
 import           Data.Map.Strict (Map)
@@ -137,3 +139,17 @@ minimumDegreeNodeTopology top@(NodeTopology m) =
     check = \case
         []   -> Nothing
         x:xs -> Just $ foldl min x xs
+
+unionNodeTopology :: NodeTopology -> NodeTopology -> NodeTopology
+unionNodeTopology (NodeTopology l) (NodeTopology r) =
+    NodeTopology $ Map.unionWith Set.union l r
+
+mapNodeTopology :: (CoreNodeId -> CoreNodeId) -> NodeTopology -> NodeTopology
+mapNodeTopology f topo =
+    NodeTopology $ Map.fromListWith Set.union $
+    [ f l `sortedSingleton` f r
+    | (l, r) <- edgesNodeTopology topo
+    ]
+  where
+    sortedSingleton l r =
+        if l > r then (l, Set.singleton r) else (r, Set.singleton l)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -206,6 +206,7 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
                      eraSizeA $
             EraFinal (eraSlotLength eraParamsB)
                      (eraEpochSize  eraParamsB)
+        , messageDelay = noCalcMessageDelay
         , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
         , nodeRestarts = noRestarts
         , txGenExtra   = ()


### PR DESCRIPTION
Closes #2292.

The individual commits are relatively self-contained.

`createConnectedChannelsWithDelay` and `chainSyncMiddle` are the main additions to `Network.hs` deserving of review. I'd appreciate any insights on how to refine/simplify those.

`ThreadNet/Cardano.hs` contains the bulk of the changes; lots of comments related to the tuning of the generators.