### PR TITLE
Shelley: prefer self-produced blocks during chain selection

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -353,7 +353,11 @@ protocolInfoCardano genesisByron mSigThresh pVer sVer mbCredsByron
     tpraosParams = Shelley.mkTPraosParams maxMajorPV initialNonce genesisShelley
 
     blockConfigShelley :: BlockConfig (ShelleyBlock sc)
-    blockConfigShelley = Shelley.mkShelleyBlockConfig protVer genesisShelley
+    blockConfigShelley =
+        Shelley.mkShelleyBlockConfig
+          protVer
+          genesisShelley
+          (tpraosBlockIssuerVKey mbCredsShelley)
 
     partialConsensusConfigShelley :: PartialConsensusConfig (BlockProtocol (ShelleyBlock sc))
     partialConsensusConfigShelley = tpraosParams

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -158,7 +158,7 @@ exampleLedgerState = reapplyLedgerBlock
     Examples.CHAINExample { startState, newBlock } = Examples.ex2A (Proxy @ShortHash)
     cfg = FullBlockConfig {
           blockConfigLedger = mkShelleyLedgerConfig testShelleyGenesis testEpochInfo testMaxMajorPV
-        , blockConfigBlock  = mkShelleyBlockConfig (SL.ProtVer 2 0) testShelleyGenesis
+        , blockConfigBlock  = mkShelleyBlockConfig (SL.ProtVer 2 0) testShelleyGenesis NotABlockIssuer
         , blockConfigCodec  = ShelleyCodecConfig
         }
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
@@ -1,10 +1,12 @@
+{-# LANGUAGE DataKinds      #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric  #-}
 {-# LANGUAGE DerivingVia    #-}
 {-# LANGUAGE TypeFamilies   #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.Shelley.Ledger.Config (
-    BlockConfig (..)
+    BlockIssuerVKey (..)
+  , BlockConfig (..)
   , mkShelleyBlockConfig
   , CodecConfig (..)
   ) where
@@ -20,6 +22,7 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 
 import qualified Shelley.Spec.Ledger.Genesis as SL
+import qualified Shelley.Spec.Ledger.Keys as SL
 import qualified Shelley.Spec.Ledger.PParams as SL (ProtVer)
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block
@@ -28,6 +31,13 @@ import           Ouroboros.Consensus.Shelley.Ledger.Block
   Additional node configuration
 -------------------------------------------------------------------------------}
 
+-- | In case we're a block issuer, the verification key we use.
+data BlockIssuerVKey c =
+    BlockIssuerVKey !(SL.VKey 'SL.BlockIssuer c)
+  | NotABlockIssuer
+  deriving stock (Show, Generic)
+  deriving anyclass (NoUnexpectedThunks)
+
 data instance BlockConfig (ShelleyBlock c) = ShelleyConfig {
       -- | The highest protocol version this node supports. It will be stored
       -- the headers of produced blocks.
@@ -35,16 +45,28 @@ data instance BlockConfig (ShelleyBlock c) = ShelleyConfig {
     , shelleySystemStart     :: !SystemStart
     , shelleyNetworkMagic    :: !NetworkMagic
     , shelleyProtocolMagicId :: !ProtocolMagicId
+      -- | When chain selection is comparing two fragments, it will prefer the
+      -- fragment with a tip signed by this key (provided that the 'BlockNo's
+      -- and 'SlotNo's of the two tips are equal). For nodes that can produce
+      -- blocks, this should be set to the verification key corresponding to
+      -- the node's signing key, to make sure we prefer self-issued blocks.
+      -- For non block producing nodes, this can be set to 'NotABlockIssuer'.
+    , shelleyBlockIssuerVKey :: !(BlockIssuerVKey c)
     }
   deriving stock (Show, Generic)
   deriving anyclass NoUnexpectedThunks
 
-mkShelleyBlockConfig :: SL.ProtVer -> SL.ShelleyGenesis c -> BlockConfig (ShelleyBlock c)
-mkShelleyBlockConfig protVer genesis = ShelleyConfig {
+mkShelleyBlockConfig ::
+     SL.ProtVer
+  -> SL.ShelleyGenesis c
+  -> BlockIssuerVKey c
+  -> BlockConfig (ShelleyBlock c)
+mkShelleyBlockConfig protVer genesis blockIssuerVKey = ShelleyConfig {
       shelleyProtocolVersion = protVer
     , shelleySystemStart     = SystemStart  $ SL.sgSystemStart     genesis
     , shelleyNetworkMagic    = NetworkMagic $ SL.sgNetworkMagic    genesis
     , shelleyProtocolMagicId =                SL.sgProtocolMagicId genesis
+    , shelleyBlockIssuerVKey = blockIssuerVKey
     }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/TPraos.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- TODO where to put this?
@@ -10,7 +11,7 @@ import           Cardano.Crypto.VRF.Class (certifiedOutput)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Signed
 import           Ouroboros.Consensus.Shelley.Ledger.Block
-import           Ouroboros.Consensus.Shelley.Ledger.Config ()
+import           Ouroboros.Consensus.Shelley.Ledger.Config
 import           Ouroboros.Consensus.Shelley.Protocol
 
 import qualified Shelley.Spec.Ledger.BlockChain as SL
@@ -25,17 +26,27 @@ type instance BlockProtocol (ShelleyBlock c) = TPraos c
 instance TPraosCrypto c => BlockSupportsProtocol (ShelleyBlock c) where
   validateView _cfg (ShelleyHeader hdr _) = hdr
 
-  selectView _ (ShelleyHeader hdr _) =
-    ChainSelectView
-      { csvChainLength = SL.bheaderBlockNo . SL.bhbody $ hdr
-      , csvLeaderVRF =
-              certifiedOutput
-            . SL.bheaderL
-            . SL.bhbody
-            $ hdr
-      , csvIssuer = SL.bheaderVk . SL.bhbody $ hdr
-      , csvIssueNo = SL.ocertN . SL.bheaderOCert . SL.bhbody $ hdr
+  selectView cfg hdr@(ShelleyHeader shdr _) = TPraosChainSelectView {
+        csvChainLength = blockNo hdr
+      , csvSlotNo      = blockSlot hdr
+      , csvSelfIssued  = selfIssued
+      , csvIssuer      = SL.bheaderVk hdrBody
+      , csvIssueNo     = SL.ocertN . SL.bheaderOCert $ hdrBody
+      , csvLeaderVRF   = certifiedOutput . SL.bheaderL $ hdrBody
       }
+    where
+      hdrBody :: SL.BHBody c
+      hdrBody = SL.bhbody shdr
+
+      selfIssued :: SelfIssued
+      selfIssued = case shelleyBlockIssuerVKey cfg of
+        NotABlockIssuer
+          -> NotSelfIssued
+        BlockIssuerVKey vkey
+          | vkey == SL.bheaderVk hdrBody
+          -> SelfIssued
+          | otherwise
+          -> NotSelfIssued
 
 -- TODO correct place for these two?
 type instance Signed (Header (ShelleyBlock c)) = SL.BHBody c


### PR DESCRIPTION
Fixes #1286.

* Include `SelfIssued` in `TPraosChainSelectView`, use that to prefer the self
  issued tip in case the tips are produced in the same slot.

* Store the block issuer verification key (new, strict `BlockIssuerVKey` data
  type) in the `BlockConfig` so that we have access to it when we need to
  extract the 'SelectView' for a header.