### PR TITLE
Introduce queries about an era that can be answered in any era

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -291,8 +291,8 @@ deriving via LiftNP WrapExtraForgeState xs instance CanHardFork xs => Show (PerE
 
 deriving via LiftNS WrapApplyTxErr      xs instance CanHardFork xs => Eq   (OneEraApplyTxErr xs)
 
-deriving via LiftMismatch SingleEraInfo LedgerEraInfo xs instance CanHardFork xs => Eq   (MismatchEraInfo xs)
-deriving via LiftMismatch SingleEraInfo LedgerEraInfo xs instance CanHardFork xs => Show (MismatchEraInfo xs)
+deriving via LiftMismatch SingleEraInfo LedgerEraInfo xs instance All SingleEraBlock xs => Eq   (MismatchEraInfo xs)
+deriving via LiftMismatch SingleEraInfo LedgerEraInfo xs instance All SingleEraBlock xs => Show (MismatchEraInfo xs)
 
 deriving newtype instance All (Trivial `Compose` WrapChainIndepState)  xs => Trivial (PerEraChainIndepState xs)
 deriving newtype instance All (Trivial `Compose` WrapExtraForgeState)  xs => Trivial (PerEraExtraForgeState xs)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -1,33 +1,50 @@
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving  #-}
-{-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeFamilies        #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE EmptyCase             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE KindSignatures        #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE RecordWildCards       #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.HardFork.Combinator.Ledger.Query (
     Query(..)
-  , HardForkQuery(..)
+  , QueryIfCurrent(..)
   , HardForkQueryResult
+  , QueryAnytime(..)
   , getHardForkQuery
   , hardForkQueryInfo
+  , encodeQueryAnytimeResult
+  , decodeQueryAnytimeResult
   ) where
 
+import           Codec.CBOR.Decoding (Decoder)
+import qualified Codec.CBOR.Decoding as Dec
+import           Codec.CBOR.Encoding (Encoding)
+import qualified Codec.CBOR.Encoding as Enc
+import           Codec.Serialise (Serialise (..))
 import           Data.Bifunctor
-import           Data.Functor.Product
 import           Data.Proxy
 import           Data.SOP.Strict
 import           Data.Type.Equality
 
+import           Cardano.Binary (enforceSize)
+
+import           Ouroboros.Consensus.HardFork.History (Bound (..), EraParams,
+                     Shape (..))
+import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Node.Serialisation (Some (..))
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
@@ -35,102 +52,232 @@ import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Info
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger ()
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+import           Ouroboros.Consensus.HardFork.Combinator.State (Current (..),
+                     Past (..), Situated (..))
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Match
                      (Mismatch (..))
 
-instance CanHardFork xs => ShowQuery (Query (HardForkBlock xs)) where
-  showResult = \(HardForkQuery qry) mResult ->
+instance All SingleEraBlock xs => ShowQuery (Query (HardForkBlock xs)) where
+  showResult (QueryAnytime   qry _) result = showResult qry result
+  showResult (QueryIfCurrent qry)  mResult =
       case mResult of
         Left  err    -> show err
-        Right result -> go qry result
-    where
-      go :: All SingleEraBlock xs'
-         => HardForkQuery xs' result -> result -> String
-      go (QZ qry) = showResult qry
-      go (QS qry) = go qry
+        Right result -> showResult qry result
 
 type HardForkQueryResult xs = Either (MismatchEraInfo xs)
 
-instance CanHardFork xs => QueryLedger (HardForkBlock xs) where
+instance All SingleEraBlock xs => QueryLedger (HardForkBlock xs) where
   data Query (HardForkBlock xs) :: * -> * where
-    HardForkQuery :: HardForkQuery xs result
-                  -> Query (HardForkBlock xs) (HardForkQueryResult xs result)
+    -- | Answer a query about an era if it is the current one.
+    QueryIfCurrent ::
+         QueryIfCurrent xs result
+      -> Query (HardForkBlock xs) (HardForkQueryResult xs result)
+
+    -- | Answer a query about an era from /any/ era.
+    --
+    -- NOTE: this is restricted to eras other than the first era so that the
+    -- HFC applied to a single era is still isomorphic to the single era.
+    QueryAnytime ::
+         QueryAnytime result
+      -> EraIndex xs
+      -> Query (HardForkBlock (x ': xs)) result
 
   answerQuery hardForkConfig@HardForkLedgerConfig{..}
-              (HardForkQuery hardForkQuery)
+              query
               (HardForkLedgerState hardForkState) =
-      go hardForkQuery (hzipWith Pair cfgs (State.tip hardForkState))
+      case query of
+        QueryIfCurrent queryIfCurrent ->
+          interpretQueryIfCurrent
+            ei
+            cfgs
+            queryIfCurrent
+            (State.tip hardForkState)
+        QueryAnytime queryAnytime (EraIndex era) ->
+          interpretQueryAnytime
+            hardForkConfig
+            queryAnytime
+            (EraIndex (S era))
+            hardForkState
     where
       cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
       ei   = State.epochInfoLedger hardForkConfig hardForkState
 
-      go :: All SingleEraBlock xs'
-         => HardForkQuery xs' result
-         -> NS (Product WrapPartialLedgerConfig LedgerState) xs'
-         -> HardForkQueryResult xs' result
-      go (QZ qry) (Z (Pair cfg st)) =
-          Right $ answerQuery (completeLedgerConfig' ei cfg) qry st
-      go (QS qry) (S st) =
-          first shiftMismatch $ go qry st
-      go (QZ qry) (S st) =
-          Left $ MismatchEraInfo $ ML (queryInfo qry) (hcmap proxySingle ledgerInfo st)
-      go (QS qry) (Z st) =
-          Left $ MismatchEraInfo $ MR (hardForkQueryInfo qry) (ledgerInfo st)
+  eqQuery (QueryAnytime qry era) (QueryAnytime qry' era')
+    | era == era'
+    = eqQueryAnytime qry qry'
+    | otherwise
+    = Nothing
+  eqQuery (QueryIfCurrent qry) (QueryIfCurrent qry') =
+      apply Refl <$> eqQueryIfCurrent qry qry'
+  eqQuery (QueryIfCurrent {}) (QueryAnytime {}) =
+      Nothing
+  eqQuery (QueryAnytime {}) (QueryIfCurrent {}) =
+      Nothing
 
-  eqQuery = \(HardForkQuery qry) (HardForkQuery qry') ->
-      -- Lift the type equality to the @Either@
-      case go qry qry' of
-        Nothing   -> Nothing
-        Just Refl -> Just Refl
-    where
-      go :: All SingleEraBlock xs'
-         => HardForkQuery xs' result
-         -> HardForkQuery xs' result'
-         -> Maybe (result :~: result')
-      go (QZ qry) (QZ qry') = eqQuery qry qry'
-      go (QS qry) (QS qry') = go qry qry'
-      go _        _         = Nothing
-
-deriving instance CanHardFork xs => Show (Query (HardForkBlock xs) result)
+deriving instance All SingleEraBlock xs => Show (Query (HardForkBlock xs) result)
 
 getHardForkQuery :: Query (HardForkBlock xs) result
                  -> (forall result'.
                           result :~: HardForkQueryResult xs result'
-                       -> HardForkQuery xs result'
-                       -> a)
-                 -> a
-getHardForkQuery (HardForkQuery qry) k = k Refl qry
+                       -> QueryIfCurrent xs result'
+                       -> r)
+                 -> (forall x' xs'.
+                          xs :~: x' ': xs'
+                       -> QueryAnytime result
+                       -> EraIndex xs'
+                       -> r)
+                 -> r
+getHardForkQuery (QueryIfCurrent qry) k1 _   = k1 Refl qry
+getHardForkQuery (QueryAnytime qry era) _ k2 = k2 Refl qry era
 
 {-------------------------------------------------------------------------------
-  Queries
+  Current era queries
 -------------------------------------------------------------------------------}
 
-data HardForkQuery :: [*] -> * -> * where
-  QZ :: Query x result          -> HardForkQuery (x ': xs) result
-  QS :: HardForkQuery xs result -> HardForkQuery (x ': xs) result
+data QueryIfCurrent :: [*] -> * -> * where
+  QZ :: Query x result           -> QueryIfCurrent (x ': xs) result
+  QS :: QueryIfCurrent xs result -> QueryIfCurrent (x ': xs) result
 
-deriving instance All SingleEraBlock xs => Show (HardForkQuery xs result)
+deriving instance All SingleEraBlock xs => Show (QueryIfCurrent xs result)
+
+instance All SingleEraBlock xs => ShowQuery (QueryIfCurrent xs) where
+  showResult (QZ qry) = showResult qry
+  showResult (QS qry) = showResult qry
+
+eqQueryIfCurrent ::
+     All SingleEraBlock xs
+  => QueryIfCurrent xs result
+  -> QueryIfCurrent xs result'
+  -> Maybe (result :~: result')
+eqQueryIfCurrent (QZ qry) (QZ qry') = eqQuery qry qry'
+eqQueryIfCurrent (QS qry) (QS qry') = eqQueryIfCurrent qry qry'
+eqQueryIfCurrent _        _         = Nothing
+
+interpretQueryIfCurrent ::
+     forall result xs. All SingleEraBlock xs
+  => EpochInfo Identity
+  -> NP WrapPartialLedgerConfig xs
+  -> QueryIfCurrent xs result
+  -> NS LedgerState xs
+  -> HardForkQueryResult xs result
+interpretQueryIfCurrent ei = go
+  where
+    go :: All SingleEraBlock xs'
+       => NP WrapPartialLedgerConfig xs'
+       -> QueryIfCurrent xs' result
+       -> NS LedgerState xs'
+       -> HardForkQueryResult xs' result
+    go (c :* _)  (QZ qry) (Z st) =
+        Right $ answerQuery (completeLedgerConfig' ei c) qry st
+    go (_ :* cs) (QS qry) (S st) =
+        first shiftMismatch $ go cs qry st
+    go _         (QZ qry) (S st) =
+        Left $ MismatchEraInfo $ ML (queryInfo qry) (hcmap proxySingle ledgerInfo st)
+    go _         (QS qry) (Z st) =
+        Left $ MismatchEraInfo $ MR (hardForkQueryInfo qry) (ledgerInfo st)
+
+{-------------------------------------------------------------------------------
+  Any era queries
+-------------------------------------------------------------------------------}
+
+data QueryAnytime result where
+  EraStart :: QueryAnytime (Maybe Bound)
+
+deriving instance Show (QueryAnytime result)
+
+instance ShowQuery QueryAnytime where
+  showResult EraStart = show
+
+eqQueryAnytime ::
+     QueryAnytime result
+  -> QueryAnytime result'
+  -> Maybe (result :~: result')
+eqQueryAnytime EraStart EraStart = Just Refl
+
+interpretQueryAnytime ::
+     forall result xs. All SingleEraBlock xs
+  => HardForkLedgerConfig xs
+  -> QueryAnytime result
+  -> EraIndex xs
+  -> State.HardForkState LedgerState xs
+  -> result
+interpretQueryAnytime cfg query (EraIndex era) st =
+    answerQueryAnytime cfg query (State.situate era st)
+
+answerQueryAnytime ::
+     All SingleEraBlock xs
+  => HardForkLedgerConfig xs
+  -> QueryAnytime result
+  -> Situated h LedgerState xs
+  -> result
+answerQueryAnytime HardForkLedgerConfig{..} =
+    go cfgs (getShape hardForkLedgerConfigShape)
+  where
+    cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
+
+    go :: All SingleEraBlock xs'
+       => NP WrapPartialLedgerConfig xs'
+       -> NP (K EraParams) xs'
+       -> QueryAnytime result
+       -> Situated h LedgerState xs'
+       -> result
+    go Nil       _             _        ctxt = case ctxt of {}
+    go (c :* cs) (K ps :* pss) EraStart ctxt = case ctxt of
+      SituatedShift ctxt'   -> go cs pss EraStart ctxt'
+      SituatedFuture _ _    -> Nothing
+      SituatedPast past _   -> Just $ pastStart past
+      SituatedCurrent cur _ -> Just $ currentStart cur
+      SituatedNext cur _    ->
+        History.mkUpperBound ps (currentStart cur) <$>
+          singleEraTransition
+          (unwrapPartialLedgerConfig c)
+          ps
+          (currentStart cur)
+          (currentState cur)
+
+{-------------------------------------------------------------------------------
+  Serialisation
+-------------------------------------------------------------------------------}
+
+instance Serialise (Some QueryAnytime) where
+  encode (Some EraStart) = mconcat [
+        Enc.encodeListLen 1
+      , Enc.encodeWord8 0
+      ]
+
+  decode = do
+    enforceSize "QueryAnytime" 1
+    tag <- Dec.decodeWord8
+    case tag of
+      0 -> return $ Some EraStart
+      _ -> fail $ "QueryAnytime: invalid tag " ++ show tag
+
+encodeQueryAnytimeResult :: QueryAnytime result -> result -> Encoding
+encodeQueryAnytimeResult EraStart = encode
+
+decodeQueryAnytimeResult :: QueryAnytime result -> forall s. Decoder s result
+decodeQueryAnytimeResult EraStart = decode
 
 {-------------------------------------------------------------------------------
   Auxiliary
 -------------------------------------------------------------------------------}
 
 ledgerInfo :: forall blk. SingleEraBlock blk
-           => Product WrapPartialLedgerConfig LedgerState blk
+           => LedgerState blk
            -> LedgerEraInfo blk
 ledgerInfo _ = LedgerEraInfo $ singleEraInfo (Proxy @blk)
 
-queryInfo :: forall blk result. SingleEraBlock blk
-          => Query blk result -> SingleEraInfo blk
+queryInfo :: forall blk query result. SingleEraBlock blk
+          => query blk result -> SingleEraInfo blk
 queryInfo _ = singleEraInfo (Proxy @blk)
 
 hardForkQueryInfo :: All SingleEraBlock xs
-                  => HardForkQuery xs result -> NS SingleEraInfo xs
+                  => QueryIfCurrent xs result -> NS SingleEraInfo xs
 hardForkQueryInfo = go
   where
     go :: All SingleEraBlock xs'
-       => HardForkQuery xs' result -> NS SingleEraInfo xs'
+       => QueryIfCurrent xs' result -> NS SingleEraInfo xs'
     go (QZ qry) = Z (queryInfo qry)
     go (QS qry) = S (go qry)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RecordWildCards     #-}
@@ -85,7 +86,7 @@ recover =
   Reconstruct EpochInfo
 -------------------------------------------------------------------------------}
 
-mostRecentTransitionInfo :: CanHardFork xs
+mostRecentTransitionInfo :: All SingleEraBlock xs
                          => HardForkLedgerConfig xs
                          -> HardForkState_ g LedgerState xs
                          -> TransitionInfo
@@ -110,7 +111,7 @@ mostRecentTransitionInfo HardForkLedgerConfig{..} st =
           Nothing -> TransitionUnknown (ledgerTipSlot currentState)
           Just e  -> TransitionKnown e
 
-reconstructSummaryLedger :: CanHardFork xs
+reconstructSummaryLedger :: All SingleEraBlock xs
                          => HardForkLedgerConfig xs
                          -> HardForkState_ g LedgerState xs
                          -> History.Summary xs
@@ -124,7 +125,7 @@ reconstructSummaryLedger cfg@HardForkLedgerConfig{..} st =
 --
 -- NOTE: The resulting 'EpochInfo' is a snapshot only, with a limited range.
 -- It should not be stored.
-epochInfoLedger :: CanHardFork xs
+epochInfoLedger :: All SingleEraBlock xs
                 => HardForkLedgerConfig xs
                 -> HardForkState_ g LedgerState xs
                 -> EpochInfo Identity

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
@@ -531,9 +531,13 @@ projQuery :: Query (HardForkBlock '[b]) result
                -> Query b result'
                -> a)
           -> a
-projQuery qry k = getHardForkQuery qry $ \Refl -> k Refl . aux
+projQuery qry k =
+    getHardForkQuery
+      qry
+      (\Refl -> k Refl . aux)
+      (\Refl _ eraIndex -> absurd $ emptyEraIndex eraIndex)
   where
-    aux :: HardForkQuery '[b] result -> Query b result
+    aux :: QueryIfCurrent '[b] result -> Query b result
     aux (QZ q) = q
     aux (QS q) = case q of {}
 
@@ -542,7 +546,7 @@ projQuery qry k = getHardForkQuery qry $ \Refl -> k Refl . aux
 -- Not an instance of 'Isomorphic' because the types change.
 injQuery :: Query b result
          -> Query (HardForkBlock '[b]) (HardForkQueryResult '[b] result)
-injQuery = HardForkQuery . QZ
+injQuery = QueryIfCurrent . QZ
 
 projNestedCtxt :: NestedCtxt f (HardForkBlock '[blk]) a -> NestedCtxt f blk a
 projNestedCtxt = NestedCtxt . aux . flipNestedCtxt

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -124,10 +124,10 @@ ledgerTipSlot = pointSlot . (ledgerTipPoint' (Proxy @blk))
 --
 -- Used by the LocalStateQuery protocol to allow clients to query the ledger
 -- state.
-class (UpdateLedger blk, ShowQuery (Query blk)) => QueryLedger blk where
+class ShowQuery (Query blk) => QueryLedger blk where
 
   -- | Different queries supported by the ledger, indexed by the result type.
-  data family Query  blk :: * -> *
+  data family Query blk :: * -> *
 
   -- | Answer the given query about the ledger state.
   answerQuery :: LedgerConfig blk -> Query blk result -> LedgerState blk -> result

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
@@ -17,6 +17,7 @@ module Ouroboros.Consensus.Util.SOP (
   , map_NP'
   , partition_NS
   , npWithIndices
+  , nsToIndex
   , nsFromIndex
   , Lens(..)
   , lenses_NP
@@ -85,6 +86,9 @@ npWithIndices = go 0 sList
     go !_ SNil  = Nil
     go 24 SCons = error "npWithIndices out of range"
     go !i SCons = K i :* go (i + 1) sList
+
+nsToIndex :: SListI xs => NS f xs -> Word8
+nsToIndex = hcollapse . hzipWith const npWithIndices
 
 -- | We only allow up to 23, see 'npWithIndices'.
 nsFromIndex :: SListI xs => Word8 -> Maybe (NS (K ()) xs)


### PR DESCRIPTION
Fixes #2346.

* Split `HardForkQuery` up into:
  1. `QueryIfCurrent`: queries about a certain era that only can be answered
     when the current ledger is in the respective era.
  2. `QueryAnytime`: queries about a certain era that can be answered when the
     current ledger is in *any* era. No queries about the first era can be
     asked to keep the HFC with a single ledger isomorphic to just the ledger.

     An example query is `EraStart`, which returns the start epoch/time/slot
     of an era.

* The pattern synonyms for `CardanoQuery` were renamed from `QueryByron` and
  `QueryShelley` to `QueryIfCurrentByron`, `QueryIfCurrentShelley`, and
  `QueryAnytimeShelley`.