### PR TITLE
Refactor network/consensus versioning

### DIFF
--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -21,6 +21,7 @@ library
   default-language:    Haskell2010
   build-depends:       base,
                        bytestring        >=0.10 && <0.11,
+                       containers,
                        io-sim-classes,
                        ouroboros-consensus,
                        ouroboros-network,

--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
 
 module Cardano.Client.Subscription (
@@ -23,91 +24,91 @@ module Cardano.Client.Subscription (
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadSTM
 import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Map.Strict as Map
 import           Data.Proxy
 import           Data.Void (Void)
 
 import           Network.Mux.Trace (MuxTrace, WithMuxBearer)
 
+import           Ouroboros.Network.Magic (NetworkMagic)
 import           Ouroboros.Network.Mux (MuxMode (..), MuxPeer (..),
                      OuroborosApplication, RunMiniProtocol (..),
                      RunOrStop (..))
 import           Ouroboros.Network.NodeToClient (ClientSubscriptionParams (..),
                      ConnectionId, LocalAddress,
                      NetworkClientSubcriptionTracers,
-                     NodeToClientProtocols (..), NodeToClientVersionData (..),
+                     NodeToClientProtocols (..),
+                     NodeToClientVersionData (NodeToClientVersionData),
                      ncSubscriptionWorker, newNetworkMutableState,
                      versionedNodeToClientProtocols)
-import qualified Ouroboros.Network.NodeToClient (NodeToClientVersion)
+import           Ouroboros.Network.NodeToClient (NodeToClientVersion)
 import           Ouroboros.Network.Protocol.Handshake.Version (DictVersion,
                      Versions, foldMapVersions)
 import qualified Ouroboros.Network.Snocket as Snocket
 
-import           Ouroboros.Consensus.Config (TopLevelConfig, configBlock,
-                     configCodec)
-import           Ouroboros.Consensus.Config.SupportsNode (getNetworkMagic)
+import           Ouroboros.Consensus.Block (CodecConfig)
 import           Ouroboros.Consensus.Network.NodeToClient (ClientCodecs,
                      cChainSyncCodec, cStateQueryCodec, cTxSubmissionCodec,
                      clientCodecs)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
-                     (BlockNodeToClientVersion, nodeToClientProtocolVersion,
-                     supportedNodeToClientVersions)
+                     (BlockNodeToClientVersion, supportedNodeToClientVersions)
 import           Ouroboros.Consensus.Node.Run (RunNode)
 
 subscribe ::
      RunNode blk
   => Snocket.LocalSnocket
-  -> TopLevelConfig blk
+  -> CodecConfig blk
+  -> NetworkMagic
   -> NetworkClientSubcriptionTracers
   -> ClientSubscriptionParams ()
-  -> (BlockNodeToClientVersion blk
+  -> (   NodeToClientVersion
       -> ClientCodecs blk IO
       -> ConnectionId LocalAddress
       -> NodeToClientProtocols 'InitiatorMode BSL.ByteString IO x y)
   -> IO Void
-subscribe
-  sn
-  topLevelConfig
-  tracers
-  subscriptionParams
-  protocols
-  = do
+subscribe snocket codecConfig networkMagic tracers subscriptionParams protocols = do
     networkState <- newNetworkMutableState
     ncSubscriptionWorker
-        sn
-        tracers
-        networkState
-        subscriptionParams
-        (versionedProtocols (Proxy :: Proxy blk) topLevelConfig
-          (\version codecs connectionId _ -> protocols version codecs connectionId))
-
+      snocket
+      tracers
+      networkState
+      subscriptionParams
+      (versionedProtocols codecConfig networkMagic
+        (\version codecs connectionId _ ->
+            protocols version codecs connectionId))
 
 versionedProtocols ::
-     ( MonadST m
-     , RunNode blk
-     )
-  => Proxy blk
-  -> TopLevelConfig blk
-  -> (BlockNodeToClientVersion blk
+     forall blk m appType bytes a b. (MonadST m, RunNode blk)
+  => CodecConfig blk
+  -> NetworkMagic
+  -> (   NodeToClientVersion
       -> ClientCodecs blk m
       -> ConnectionId LocalAddress
       -> STM m RunOrStop
       -> NodeToClientProtocols appType bytes m a b)
-  -- ^ callback which recieves codecs, connection id and STM action which can be
-  -- checked if the networking runtime system requests the protocols to stop.
-  --
-  -- TODO: the `RunOrStop` might not be needed for `node-to-client`, hence it's
-  -- not exposed in `subscribe`.  We should provide
-  -- `OuroborosClientApplication`, which does not include it.
+     -- ^ callback which receives codecs, connection id and STM action which
+     -- can be checked if the networking runtime system requests the protocols
+     -- to stop.
+     --
+     -- TODO: the 'RunOrStop' might not be needed for @node-to-client@, hence
+     -- it's not exposed in 'subscribe'. We should provide
+     -- 'OuroborosClientApplication', which does not include it.
   -> Versions
-       Ouroboros.Network.NodeToClient.NodeToClientVersion
+       NodeToClientVersion
        DictVersion
        (OuroborosApplication appType LocalAddress bytes m a b)
-versionedProtocols blkProxy topLevelConfig p
-  = foldMapVersions applyVersion $ supportedNodeToClientVersions blkProxy
+versionedProtocols codecConfig networkMagic callback =
+    foldMapVersions applyVersion $
+      Map.toList $ supportedNodeToClientVersions (Proxy @blk)
   where
-    blockConfig = configBlock topLevelConfig
-    applyVersion v =
+    applyVersion ::
+         (NodeToClientVersion, BlockNodeToClientVersion blk)
+      -> Versions
+           NodeToClientVersion
+           DictVersion
+           (OuroborosApplication appType LocalAddress bytes m a b)
+    applyVersion (version, blockVersion) =
       versionedNodeToClientProtocols
-        (nodeToClientProtocolVersion blkProxy v)
-        (NodeToClientVersionData { networkMagic = getNetworkMagic blockConfig })
-        (p v $ clientCodecs (configCodec topLevelConfig) v)
+        version
+        (NodeToClientVersionData networkMagic)
+        (callback version (clientCodecs codecConfig blockVersion))

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
@@ -44,13 +44,9 @@ instance HasNetworkProtocolVersion DualByronBlock where
   type BlockNodeToNodeVersion   DualByronBlock = BlockNodeToNodeVersion   ByronBlock
   type BlockNodeToClientVersion DualByronBlock = BlockNodeToClientVersion ByronBlock
 
-instance TranslateNetworkProtocolVersion DualByronBlock where
+instance SupportedNetworkProtocolVersion DualByronBlock where
   supportedNodeToNodeVersions     _ = supportedNodeToNodeVersions     pb
   supportedNodeToClientVersions   _ = supportedNodeToClientVersions   pb
-  mostRecentSupportedNodeToNode   _ = mostRecentSupportedNodeToNode   pb
-  mostRecentSupportedNodeToClient _ = mostRecentSupportedNodeToClient pb
-  nodeToNodeProtocolVersion       _ = nodeToNodeProtocolVersion       pb
-  nodeToClientProtocolVersion     _ = nodeToClientProtocolVersion     pb
 
 {-------------------------------------------------------------------------------
   EncodeDisk & DecodeDisk

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
@@ -14,6 +14,7 @@ import           Crypto.Number.Generate as Cryptonite
 import           Crypto.Random (MonadRandom)
 import           Data.ByteString (ByteString)
 import qualified Data.Map as Map
+import           Data.Proxy
 import qualified Data.Set as Set
 import           Data.Word
 import qualified Hedgehog
@@ -64,6 +65,7 @@ import qualified Test.ThreadNet.Ref.PBFT as Ref
 import           Test.ThreadNet.TxGen
 import           Test.ThreadNet.Util
 import           Test.ThreadNet.Util.NodeRestarts (noRestarts)
+import           Test.ThreadNet.Util.NodeToNodeVersion (newestVersion)
 
 import           Test.Util.HardFork.Future (singleEraFuture)
 import           Test.Util.Slots (NumSlots (..))
@@ -146,6 +148,7 @@ setupTestConfigB SetupDualPBft{..} = TestConfigB
   , nodeJoinPlan = setupNodeJoinPlan
   , nodeRestarts = setupNodeRestarts
   , txGenExtra   = ()
+  , version      = newestVersion (Proxy @DualByronBlock)
   }
   where
     RealPBFT.TestSetup{..} = setupRealPBft

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -7,10 +7,7 @@ module Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion (
   , ShelleyNodeToClientVersion(..)
   ) where
 
-import           Data.List.NonEmpty (NonEmpty (..))
-
-import qualified Ouroboros.Network.NodeToClient as N
-import qualified Ouroboros.Network.NodeToNode as N
+import qualified Data.Map.Strict as Map
 
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 
@@ -26,17 +23,15 @@ instance HasNetworkProtocolVersion (ShelleyBlock c) where
   type BlockNodeToNodeVersion   (ShelleyBlock c) = ShelleyNodeToNodeVersion
   type BlockNodeToClientVersion (ShelleyBlock c) = ShelleyNodeToClientVersion
 
-instance TranslateNetworkProtocolVersion (ShelleyBlock c) where
-  supportedNodeToNodeVersions   _ = ShelleyNodeToNodeVersion1
-                                  :| []
-  supportedNodeToClientVersions _ = ShelleyNodeToClientVersion1
-                                  :| []
-
-  mostRecentSupportedNodeToNode   _ = ShelleyNodeToNodeVersion1
-  mostRecentSupportedNodeToClient _ = ShelleyNodeToClientVersion1
-
-  nodeToNodeProtocolVersion _ ShelleyNodeToNodeVersion1 = N.NodeToNodeV_1
-
-  -- From the beginning, Shelley supports version 2 of the node-to-client
-  -- protocol (i.e. the local state query protocol is enabled from the start).
-  nodeToClientProtocolVersion _ ShelleyNodeToClientVersion1 = N.NodeToClientV_2
+instance SupportedNetworkProtocolVersion (ShelleyBlock c) where
+  supportedNodeToNodeVersions   _ = Map.fromList [
+        (NodeToNodeV_1, ShelleyNodeToNodeVersion1)
+        -- V_2 enables block size hints for Byron headers and the hard fork
+        -- combinator, unused by Shelley-only
+      ]
+  supportedNodeToClientVersions _ = Map.fromList [
+        (NodeToClientV_1, ShelleyNodeToClientVersion1)
+        -- Enable the LocalStateQuery protocol, no serialisation changes
+      , (NodeToClientV_2, ShelleyNodeToClientVersion1)
+        -- V_3 enables the hard fork, unused by Shelley-only
+      ]

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -11,6 +11,7 @@ module Ouroboros.Consensus.Mock.Node (
   ) where
 
 import           Codec.Serialise (Serialise)
+import qualified Data.Map.Strict as Map
 import           Data.Typeable (Typeable)
 
 import           Ouroboros.Consensus.Block
@@ -31,9 +32,9 @@ import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 instance HasNetworkProtocolVersion (SimpleBlock SimpleMockCrypto ext) where
   -- Use defaults
 
-instance TranslateNetworkProtocolVersion (SimpleBlock SimpleMockCrypto ext) where
-  nodeToNodeProtocolVersion   _ _ = NodeToNodeV_1
-  nodeToClientProtocolVersion _ _ = NodeToClientV_2
+instance SupportedNetworkProtocolVersion (SimpleBlock SimpleMockCrypto ext) where
+  supportedNodeToNodeVersions   _ = Map.singleton maxBound ()
+  supportedNodeToClientVersions _ = Map.singleton maxBound ()
 
 instance ( LedgerSupportsProtocol (SimpleBlock SimpleMockCrypto ext)
            -- The below constraint seems redundant but is not! When removed,

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -1,12 +1,14 @@
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 module Test.ThreadNet.BFT (
     tests
   ) where
 
 import qualified Data.Map.Strict as Map
+import           Data.Proxy (Proxy (..))
 
 import           Test.QuickCheck
 import           Test.Tasty
@@ -29,6 +31,7 @@ import           Test.ThreadNet.TxGen.Mock ()
 import           Test.ThreadNet.Util
 import           Test.ThreadNet.Util.NodeJoinPlan
 import           Test.ThreadNet.Util.NodeRestarts
+import           Test.ThreadNet.Util.NodeToNodeVersion
 import           Test.ThreadNet.Util.NodeTopology
 import           Test.ThreadNet.Util.SimpleBlock
 
@@ -138,6 +141,7 @@ prop_simple_bft_convergence TestSetup
       , nodeJoinPlan
       , nodeRestarts = noRestarts
       , txGenExtra   = ()
+      , version      = newestVersion (Proxy @MockBftBlock)
       }
 
     testOutput =

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.ThreadNet.LeaderSchedule (
     tests
@@ -8,8 +9,9 @@ module Test.ThreadNet.LeaderSchedule (
 import           Control.Monad (replicateM)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Test.QuickCheck
+import           Data.Proxy (Proxy (..))
 
+import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
@@ -31,6 +33,7 @@ import           Test.ThreadNet.Util
 import           Test.ThreadNet.Util.HasCreator.Mock ()
 import           Test.ThreadNet.Util.NodeJoinPlan
 import           Test.ThreadNet.Util.NodeRestarts
+import           Test.ThreadNet.Util.NodeToNodeVersion
 import           Test.ThreadNet.Util.SimpleBlock
 
 import           Test.Util.HardFork.Future (singleEraFuture)
@@ -110,6 +113,7 @@ prop_simple_leader_schedule_convergence TestSetup
       , nodeJoinPlan
       , nodeRestarts = noRestarts
       , txGenExtra   = ()
+      , version      = newestVersion (Proxy @MockPraosRuleBlock)
       }
 
     -- this is entirely ignored because of the 'WithLeaderSchedule' combinator

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -1,14 +1,16 @@
-{-# LANGUAGE LambdaCase     #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.ThreadNet.PBFT (
     tests
   ) where
 
 import qualified Data.Map.Strict as Map
+import           Data.Proxy (Proxy (..))
 import qualified Data.Set as Set
-import           Test.QuickCheck
 
+import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
@@ -21,7 +23,8 @@ import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Mock.Ledger.Block
 import           Ouroboros.Consensus.Mock.Ledger.Block.PBFT
 import           Ouroboros.Consensus.Mock.Node ()
-import           Ouroboros.Consensus.Mock.Node.PBFT (protocolInfoMockPBFT)
+import           Ouroboros.Consensus.Mock.Node.PBFT (MockPBftBlock,
+                     protocolInfoMockPBFT)
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.PBFT
@@ -36,6 +39,7 @@ import           Test.ThreadNet.Util
 import           Test.ThreadNet.Util.HasCreator.Mock ()
 import           Test.ThreadNet.Util.NodeJoinPlan
 import           Test.ThreadNet.Util.NodeRestarts
+import           Test.ThreadNet.Util.NodeToNodeVersion
 import           Test.ThreadNet.Util.NodeTopology
 import           Test.ThreadNet.Util.SimpleBlock
 
@@ -128,6 +132,7 @@ prop_simple_pbft_convergence TestSetup
       , nodeJoinPlan
       , nodeRestarts = noRestarts
       , txGenExtra   = ()
+      , version      = newestVersion (Proxy @MockPBftBlock)
       }
 
     NumCoreNodes nn = numCoreNodes

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -1,9 +1,12 @@
-{-# LANGUAGE NamedFieldPuns  #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns   #-}
+{-# LANGUAGE RecordWildCards  #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.ThreadNet.Praos (
     tests
   ) where
+
+import           Data.Proxy (Proxy (..))
 
 import           Test.QuickCheck
 
@@ -16,7 +19,8 @@ import           Ouroboros.Consensus.Config.SecurityParam
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Mock.Ledger
 import           Ouroboros.Consensus.Mock.Node ()
-import           Ouroboros.Consensus.Mock.Node.Praos (protocolInfoPraos)
+import           Ouroboros.Consensus.Mock.Node.Praos (MockPraosBlock,
+                     protocolInfoPraos)
 import           Ouroboros.Consensus.Mock.Protocol.Praos
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 
@@ -26,6 +30,7 @@ import           Test.ThreadNet.Util
 import           Test.ThreadNet.Util.HasCreator.Mock ()
 import           Test.ThreadNet.Util.NodeJoinPlan
 import           Test.ThreadNet.Util.NodeRestarts
+import           Test.ThreadNet.Util.NodeToNodeVersion
 import           Test.ThreadNet.Util.NodeTopology
 import           Test.ThreadNet.Util.SimpleBlock
 
@@ -124,6 +129,7 @@ prop_simple_praos_convergence TestSetup
       , nodeJoinPlan
       , nodeRestarts = noRestarts
       , txGenExtra   = ()
+      , version      = newestVersion (Proxy @MockPraosBlock)
       }
 
     params = PraosParams

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
@@ -31,6 +31,7 @@ library
                        Test.ThreadNet.Util.HasCreator
                        Test.ThreadNet.Util.NodeJoinPlan
                        Test.ThreadNet.Util.NodeRestarts
+                       Test.ThreadNet.Util.NodeToNodeVersion
                        Test.ThreadNet.Util.NodeTopology
 
                        Test.Util.Blob

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/General.hs
@@ -51,6 +51,7 @@ import qualified Ouroboros.Consensus.Block.Abstract as BA
 import qualified Ouroboros.Consensus.BlockchainTime as BTime
 import           Ouroboros.Consensus.Config.SecurityParam
 import           Ouroboros.Consensus.Ledger.Extended (ExtValidationError)
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.NodeId
@@ -176,9 +177,11 @@ data TestConfigB blk = TestConfigB
   , nodeJoinPlan :: NodeJoinPlan
   , nodeRestarts :: NodeRestarts
   , txGenExtra   :: TxGenExtra blk
+  , version      :: (NodeToNodeVersion, BlockNodeToNodeVersion blk)
   }
 
-deriving instance Show (TxGenExtra blk) => Show (TestConfigB blk)
+deriving instance (Show (TxGenExtra blk), Show (BlockNodeToNodeVersion blk))
+                => Show (TestConfigB blk)
 
 -- | Test configuration that depends on the block and the monad
 --
@@ -221,6 +224,7 @@ runTestNetwork TestConfig
   , nodeJoinPlan
   , nodeRestarts
   , txGenExtra
+  , version = (networkVersion, blockVersion)
   }
     mkTestConfigMB
   = runSimOrThrow $ do
@@ -246,6 +250,8 @@ runTestNetwork TestConfig
       , tnaRestarts     = nodeRestarts
       , tnaTopology     = nodeTopology
       , tnaTxGenExtra   = txGenExtra
+      , tnaVersion      = networkVersion
+      , tnaBlockVersion = blockVersion
       }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/NodeToNodeVersion.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/NodeToNodeVersion.hs
@@ -1,0 +1,37 @@
+module Test.ThreadNet.Util.NodeToNodeVersion (
+    genVersion
+  , genVersionFiltered
+  , newestVersion
+  ) where
+
+import qualified Data.Map.Strict as Map
+import           Data.Proxy (Proxy (..))
+
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+
+import           Test.QuickCheck (Gen)
+import           Test.Util.QuickCheck
+
+genVersion ::
+     SupportedNetworkProtocolVersion blk
+  => Proxy blk -> Gen (NodeToNodeVersion, BlockNodeToNodeVersion blk)
+genVersion = genVersionFiltered (const True)
+
+genVersionFiltered ::
+    SupportedNetworkProtocolVersion blk
+  => (BlockNodeToNodeVersion blk -> Bool)
+  -> Proxy blk
+  -> Gen (NodeToNodeVersion, BlockNodeToNodeVersion blk)
+genVersionFiltered f =
+      elements
+    . filter (f . snd)
+    . Map.toList
+    . supportedNodeToNodeVersions
+
+-- | Return the newest version, i.e., the version with the highest
+-- 'NodeToNodeVersion'. This can be used when you don't care about the
+-- versioning of a block.
+newestVersion ::
+     SupportedNetworkProtocolVersion blk
+  => Proxy blk -> (NodeToNodeVersion, BlockNodeToNodeVersion blk)
+newestVersion = Map.findMax . supportedNodeToNodeVersions

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -402,6 +402,7 @@ test-suite test-consensus
                        Test.ThreadNet.Util.HasCreator
                        Test.ThreadNet.Util.NodeJoinPlan
                        Test.ThreadNet.Util.NodeRestarts
+                       Test.ThreadNet.Util.NodeToNodeVersion
                        Test.ThreadNet.Util.NodeTopology
 
   build-depends:       base

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -675,13 +675,9 @@ instance HasNetworkProtocolVersion b => HasNetworkProtocolVersion (DegenFork b) 
   type BlockNodeToNodeVersion   (DegenFork b) = BlockNodeToNodeVersion   b
   type BlockNodeToClientVersion (DegenFork b) = BlockNodeToClientVersion b
 
-instance TranslateNetworkProtocolVersion b => TranslateNetworkProtocolVersion (DegenFork b) where
-  supportedNodeToNodeVersions     _ = supportedNodeToNodeVersions     (Proxy @b)
-  supportedNodeToClientVersions   _ = supportedNodeToClientVersions   (Proxy @b)
-  mostRecentSupportedNodeToNode   _ = mostRecentSupportedNodeToNode   (Proxy @b)
-  mostRecentSupportedNodeToClient _ = mostRecentSupportedNodeToClient (Proxy @b)
-  nodeToNodeProtocolVersion       _ = nodeToNodeProtocolVersion       (Proxy @b)
-  nodeToClientProtocolVersion     _ = nodeToClientProtocolVersion     (Proxy @b)
+instance SupportedNetworkProtocolVersion b => SupportedNetworkProtocolVersion (DegenFork b) where
+  supportedNodeToNodeVersions   _ = supportedNodeToNodeVersions   (Proxy @b)
+  supportedNodeToClientVersions _ = supportedNodeToClientVersions (Proxy @b)
 
 instance (NoHardForks b, RunNode b) => RunNode (DegenFork b) where
   nodeBlockFetchSize (DHdr hdr) = nodeBlockFetchSize (project hdr)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation.hs
@@ -6,7 +6,8 @@ module Ouroboros.Consensus.HardFork.Combinator.Serialisation (
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common as X
                      (HardForkNodeToClientVersion (..),
                      HardForkNodeToNodeVersion (..), SerialiseConstraintsHFC,
-                     SerialiseHFC (..))
+                     SerialiseHFC (..), isHardForkNodeToClientEnabled,
+                     isHardForkNodeToNodeEnabled)
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk as X
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient as X
                      ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -32,6 +32,8 @@ module Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common (
     -- * Versioning
   , HardForkNodeToNodeVersion(..)
   , HardForkNodeToClientVersion(..)
+  , isHardForkNodeToNodeEnabled
+  , isHardForkNodeToClientEnabled
     -- * Dealing with annotations
   , AnnDecoder(..)
     -- * Serialisation of telescopes
@@ -134,6 +136,14 @@ data HardForkNodeToNodeVersion xs where
 data HardForkNodeToClientVersion xs where
   HardForkNodeToClientDisabled :: WrapNodeToClientVersion x -> HardForkNodeToClientVersion (x ': xs)
   HardForkNodeToClientEnabled  :: NP WrapNodeToClientVersion xs -> HardForkNodeToClientVersion xs
+
+isHardForkNodeToNodeEnabled :: HardForkNodeToNodeVersion xs -> Bool
+isHardForkNodeToNodeEnabled HardForkNodeToNodeEnabled {} = True
+isHardForkNodeToNodeEnabled _                            = False
+
+isHardForkNodeToClientEnabled :: HardForkNodeToClientVersion xs -> Bool
+isHardForkNodeToClientEnabled HardForkNodeToClientEnabled {} = True
+isHardForkNodeToClientEnabled _                              = False
 
 deriving instance All (Compose Show WrapNodeToNodeVersion)   xs => Show (HardForkNodeToNodeVersion xs)
 deriving instance All (Compose Show WrapNodeToClientVersion) xs => Show (HardForkNodeToClientVersion xs)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
@@ -73,7 +73,7 @@ blockFetchServer
        )
     => Tracer m (TraceBlockFetchServerEvent blk)
     -> ChainDB m blk
-    -> BlockNodeToNodeVersion blk
+    -> NodeToNodeVersion
     -> ResourceRegistry m
     -> BlockFetchServer (Serialised blk) m ()
 blockFetchServer _tracer chainDB _version registry = senderSide

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -341,7 +341,7 @@ chainSyncClient
     -> Tracer m (TraceChainSyncClientEvent blk)
     -> TopLevelConfig blk
     -> ChainDbView m blk
-    -> BlockNodeToNodeVersion blk
+    -> NodeToNodeVersion
     -> StrictTVar m (AnchoredFragment (Header blk))
     -> Consensus ChainSyncClientPipelined blk m
 chainSyncClient mkPipelineDecision0 tracer cfg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
@@ -42,7 +42,7 @@ chainSyncHeadersServer
        )
     => Tracer m (TraceChainSyncServerEvent blk)
     -> ChainDB m blk
-    -> BlockNodeToNodeVersion blk
+    -> NodeToNodeVersion
     -> ResourceRegistry m
     -> ChainSyncServer (SerialisedHeader blk) (Tip blk) m ()
 chainSyncHeadersServer tracer chainDB _version registry =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
@@ -4,13 +4,13 @@
 
 module Ouroboros.Consensus.Node.NetworkProtocolVersion
   ( HasNetworkProtocolVersion(..)
-  , TranslateNetworkProtocolVersion(..)
+  , SupportedNetworkProtocolVersion(..)
     -- * Re-exports
   , NodeToNodeVersion(..)
   , NodeToClientVersion(..)
   ) where
 
-import           Data.List.NonEmpty (NonEmpty (..))
+import           Data.Map.Strict (Map)
 import           Data.Proxy
 
 import           Ouroboros.Network.NodeToClient
@@ -34,55 +34,11 @@ class ( Show (BlockNodeToNodeVersion   blk)
   type BlockNodeToNodeVersion   blk = ()
   type BlockNodeToClientVersion blk = ()
 
-class HasNetworkProtocolVersion blk => TranslateNetworkProtocolVersion blk where
+class HasNetworkProtocolVersion blk => SupportedNetworkProtocolVersion blk where
   -- | Enumerate all supported node-to-node versions
   supportedNodeToNodeVersions
-    :: Proxy blk -> NonEmpty (BlockNodeToNodeVersion blk)
+    :: Proxy blk -> Map NodeToNodeVersion (BlockNodeToNodeVersion blk)
 
   -- | Enumerate all supported node-to-client versions
   supportedNodeToClientVersions
-    :: Proxy blk -> NonEmpty (BlockNodeToClientVersion blk)
-
-  -- | The most recent support node-to-node version
-  --
-  -- This is only used in the tests, where we are running the protocol with
-  -- the version we expect to be ran in practice.
-  mostRecentSupportedNodeToNode
-    :: Proxy blk -> BlockNodeToNodeVersion blk
-
-  -- | The most recent supported node-to-client version
-  --
-  -- This is only used in the tests, where we are running the protocol with
-  -- the version we expect to be ran in practice.
-  mostRecentSupportedNodeToClient
-    :: Proxy blk -> BlockNodeToClientVersion blk
-
-  -- | Translate to network-layer type
-  nodeToNodeProtocolVersion
-    :: Proxy blk -> BlockNodeToNodeVersion blk -> NodeToNodeVersion
-
-  -- | Translate to network-layer type
-  nodeToClientProtocolVersion
-    :: Proxy blk -> BlockNodeToClientVersion blk -> NodeToClientVersion
-
-  -- Defaults
-
-  default supportedNodeToNodeVersions
-    :: BlockNodeToNodeVersion blk ~ ()
-    => Proxy blk -> NonEmpty (BlockNodeToNodeVersion blk)
-  supportedNodeToNodeVersions _ = () :| []
-
-  default supportedNodeToClientVersions
-    :: BlockNodeToClientVersion blk ~ ()
-    => Proxy blk -> NonEmpty (BlockNodeToClientVersion blk)
-  supportedNodeToClientVersions _ = () :| []
-
-  default mostRecentSupportedNodeToNode
-    :: BlockNodeToNodeVersion blk ~ ()
-    => Proxy blk -> BlockNodeToNodeVersion blk
-  mostRecentSupportedNodeToNode _ = ()
-
-  default mostRecentSupportedNodeToClient
-    :: BlockNodeToClientVersion blk ~ ()
-    => Proxy blk -> BlockNodeToClientVersion blk
-  mostRecentSupportedNodeToClient _ = ()
+    :: Proxy blk -> Map NodeToClientVersion (BlockNodeToClientVersion blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -69,7 +69,7 @@ class ( LedgerSupportsProtocol           blk
       , LedgerSupportsMempool            blk
       , HasTxId                   (GenTx blk)
       , QueryLedger                      blk
-      , TranslateNetworkProtocolVersion  blk
+      , SupportedNetworkProtocolVersion  blk
       , CanForge                         blk
       , ConfigSupportsNode               blk
       , ConvertRawHash                   blk

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -21,7 +21,6 @@
 
 module Test.Consensus.HardFork.Combinator (tests) where
 
-import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map as Map
 import           Data.SOP.BasicFunctors
 import           Data.SOP.Strict hiding (shape)
@@ -73,6 +72,7 @@ import           Test.ThreadNet.TxGen
 import           Test.ThreadNet.Util
 import           Test.ThreadNet.Util.NodeJoinPlan
 import           Test.ThreadNet.Util.NodeRestarts
+import           Test.ThreadNet.Util.NodeToNodeVersion
 import           Test.ThreadNet.Util.NodeTopology
 
 import           Test.Util.HardFork.Future
@@ -210,6 +210,7 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
         , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
         , nodeRestarts = noRestarts
         , txGenExtra   = ()
+        , version      = newestVersion (Proxy @TestBlock)
         }
       where
         TestConfig{..} = testConfig
@@ -392,13 +393,9 @@ versionN2C = HardForkNodeToClientEnabled $
                :* WrapNodeToClientVersion ()
                :* Nil
 
-instance TranslateNetworkProtocolVersion TestBlock where
-  supportedNodeToNodeVersions     _   = versionN2N :| []
-  supportedNodeToClientVersions   _   = versionN2C :| []
-  mostRecentSupportedNodeToNode   _   = versionN2N
-  mostRecentSupportedNodeToClient _   = versionN2C
-  nodeToNodeProtocolVersion       _ _ = NodeToNodeV_1
-  nodeToClientProtocolVersion     _ _ = NodeToClientV_2
+instance SupportedNetworkProtocolVersion TestBlock where
+  supportedNodeToNodeVersions   _ = Map.singleton maxBound versionN2N
+  supportedNodeToClientVersions _ = Map.singleton maxBound versionN2C
 
 instance SerialiseHFC '[BlockA, BlockB]
   -- Use defaults

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -288,7 +288,7 @@ runChainSync securityParam (ClientUpdates clientUpdates)
                    chainSyncTracer
                    nodeCfg
                    chainDbView
-                   ()
+                   maxBound
 
     -- Set up the server
     varChainProducerState <- uncheckedNewTVarM $ initChainProducerState Genesis


### PR DESCRIPTION
Fixes #2309.

Previously, we had a list of supported `BlockNodeToNodeVersion`s and a method
to translate them to a `NodeToNodeVersion`. This meant that there were two
layers of "support": (1) include the version in `BlockNodeToNodeVersion`
and (2) return a non-`error` for it in the translation function.

Replace these methods by a map from `NodeToNodeVersion` to
`BlockNodeToNodeVersion`. Similarly for `NodeToClient`. An important insight
is that not each network version requires a consensus-side block version. For
example, enabling the `LocalStateQuery` `NodeToClient` protocol requires a new
network version, but no block version, as the serialisation format doesn't
change. A new block version is only needed when the serialisation changes, so
not when protocols get added/removed or the protocol messages are
added/removed.

This means we don't need separate Byron (nor Cardano) versions for
`NodeToClientV_2`, as the serialisation format didn't change, so remove these
redundant versions and map `NodeToClientV_2` to `ByronNodeToClientVersion1`.

The `mostRecentSupportedNodeToNode` method was only used for the ThreadNet
tests to make sure we were testing the most recent version. Remove this method
in favour of randomly picking a supported version in the tests. The
`Test.ThreadNet.Util.NodeToNodeVersion` was added to aid in picking a version.

* Rewrite `foldMapVersions` and `combineVersions` to work for any `Foldable`
  instead of a `NonEmpty`, as we now use a `Map` instead of a `NonEmpty` for
  the supported versions.

* Rewrite `Cardano.Client.Subscription` to take a `CodecConfig` +
  `NetworkMagic` instead of an entire `TopLevelConfig`. Producing a
  `TopLevelConfig` is a lot of work for clients. The whole point of
  introducing the `CodecConfig` was to make it easier for clients.