### PR TITLE
Decoder failure's context

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -36,6 +36,7 @@ import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
 import           Control.Tracer
 import           Data.ByteString.Lazy (ByteString)
+import           Data.Typeable (Typeable)
 import           Data.Void (Void)
 
 import           Ouroboros.Network.Block (Serialised, decodePoint, decodeTip,
@@ -311,7 +312,12 @@ data Apps m peer bCS bTX bSQ a = Apps {
 
 -- | Construct the 'NetworkApplication' for the node-to-client protocols
 mkApps
-  :: forall m peer blk e bCS bTX bSQ. (IOLike m, Exception e)
+  :: forall m peer blk e bCS bTX bSQ.
+     ( IOLike m
+     , Exception e
+     , Typeable blk
+     , Typeable (ApplyTxErr blk)
+     )
   => Tracers m peer blk e
   -> Codecs blk e m bCS bTX bSQ
   -> Handlers m peer blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -17,6 +17,8 @@ module Ouroboros.Consensus.Node.Run (
   , RunNode (..)
   ) where
 
+import           Data.Typeable (Typeable)
+
 import           Ouroboros.Network.Block (Serialised)
 import           Ouroboros.Network.BlockFetch (SizeInBytes)
 
@@ -77,6 +79,8 @@ class ( LedgerSupportsProtocol           blk
       , SerialiseDiskConstraints         blk
       , SerialiseNodeToNodeConstraints   blk
       , SerialiseNodeToClientConstraints blk
+      , Typeable                         blk
+      , Typeable                         (ApplyTxErr blk)
       ) => RunNode blk where
   nodeBlockFetchSize      :: Header blk -> SizeInBytes
 

--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 
+{-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 module Main where
@@ -28,12 +29,14 @@ import Ouroboros.Network.Snocket
 import Ouroboros.Network.Mux
 import Ouroboros.Network.ErrorPolicy
 import Ouroboros.Network.IOManager
+import Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 import Ouroboros.Network.Protocol.Handshake.Codec
 import Ouroboros.Network.Protocol.Handshake.Unversioned
 import Ouroboros.Network.Protocol.Handshake.Version
 
 import Network.TypedProtocol.Pipelined
+import Network.TypedProtocol.PingPong.Type (PingPong)
 import Network.TypedProtocol.PingPong.Client as PingPong
 import Network.TypedProtocol.PingPong.Server as PingPong
 import Network.TypedProtocol.PingPong.Codec.CBOR  as PingPong
@@ -55,6 +58,9 @@ main = do
         void serverPingPong2
 
       _          -> usage
+
+instance ShowProxy PingPong where
+    showProxy _ = "PingPong"
 
 usage :: IO ()
 usage = do

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -107,6 +107,7 @@ test-suite ouroboros-network-framework-tests
                        Test.Network.TypedProtocol.PingPong.Codec
                        Test.Network.TypedProtocol.ReqResp.Codec
                        Test.Ouroboros.Network.Driver
+                       Test.Ouroboros.Network.Orphans
                        Test.Ouroboros.Network.Socket
                        Test.Ouroboros.Network.Subscription
                        Test.Ouroboros.Network.RateLimiting

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -29,6 +29,7 @@ library
                        Ouroboros.Network.ErrorPolicy
                        Ouroboros.Network.IOManager
                        Ouroboros.Network.Mux
+                       Ouroboros.Network.Util.ShowProxy
 
                        Ouroboros.Network.Protocol.Handshake
                        Ouroboros.Network.Protocol.Handshake.Type

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
@@ -24,7 +24,6 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Codec.CBOR.Read     as CBOR
 import qualified Codec.CBOR.Term     as CBOR
 
-import           Network.Mux.Timeout
 import           Network.Mux.Trace
 import           Network.Mux.Types
 import           Network.TypedProtocol.Codec
@@ -44,40 +43,30 @@ import           Ouroboros.Network.Protocol.Handshake.Server
 handshakeProtocolNum :: MiniProtocolNum
 handshakeProtocolNum = MiniProtocolNum 0
 
--- | Timeout for the complete handshake exchange.
---
-handshakeTimeout :: DiffTime
-handshakeTimeout = 10 -- 10 seconds
-
 -- | Wrapper around initiator and responder errors experienced by tryHandshake.
 --
 data HandshakeException a =
     HandshakeProtocolLimit ProtocolLimitFailure
   | HandshakeProtocolError a
-  | HandshakeTimeout
 
 
 -- | Try to complete either initiator or responder side of the Handshake protocol
 -- within `handshakeTimeout` seconds.
 --
-tryHandshake :: ( MonadAsync m
-                , MonadFork m
-                , MonadMonotonicTime m
-                , MonadTimer m
+tryHandshake :: forall m a r.
+                ( MonadAsync m
                 , MonadMask m
-                , MonadThrow (STM m)
                 )
              => m (Either a r)
              -> m (Either (HandshakeException a) r)
 tryHandshake doHandshake = do
-    mapp <- withTimeoutSerial $ \timeoutFn -> timeoutFn handshakeTimeout $ try doHandshake
+    mapp <- try doHandshake
     case mapp of
-         Nothing -> return $ Left HandshakeTimeout
-         Just (Left (err :: ProtocolLimitFailure)) ->
-             return $ Left $ HandshakeProtocolLimit err
-         Just (Right (Left err)) ->
-             return $ Left $ HandshakeProtocolError err
-         Just (Right (Right r)) -> return $ Right r
+      Left err ->
+          return $ Left $ HandshakeProtocolLimit err
+      Right (Left err) ->
+          return $ Left $ HandshakeProtocolError err
+      Right (Right r) -> return $ Right r
 
 
 --

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
@@ -20,6 +20,7 @@ import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 
 import           Control.Tracer (Tracer, contramap)
+import           Data.Typeable (Typeable)
 import qualified Data.ByteString.Lazy as BL
 import qualified Codec.CBOR.Read     as CBOR
 import qualified Codec.CBOR.Term     as CBOR
@@ -105,6 +106,7 @@ runHandshakeClient
        , MonadMask m
        , MonadThrow (STM m)
        , Ord vNumber
+       , Typeable vNumber
        )
     => MuxBearer m
     -> connectionId
@@ -139,6 +141,7 @@ runHandshakeServer
        , MonadMask m
        , MonadThrow (STM m)
        , Ord vNumber
+       , Typeable vNumber
        )
     => MuxBearer m
     -> connectionId

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
@@ -80,9 +80,11 @@ byteLimitsHandshake = ProtocolSizeLimits stateToLimit (fromIntegral . BL.length)
     stateToLimit (ClientAgency TokPropose) = maxTransmissionUnit
     stateToLimit (ServerAgency TokConfirm) = maxTransmissionUnit
 
--- Time limits
--- We don't use a per-state timeout, instead there is an overall timeout
--- for the complete handshake protocol exchange.
+-- | Time limits.
+--
+-- We use a bearer which has `10s` timeout on sending or receiving a single
+-- `MuxSDU`.  Handshake messages must fit into a single `MuxSDU`, thus we don't
+-- set another timeout here.
 timeLimitsHandshake :: forall vNumber. ProtocolTimeLimits (Handshake vNumber CBOR.Term)
 timeLimitsHandshake = ProtocolTimeLimits stateToLimit
   where

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -32,6 +32,7 @@ import           Data.Typeable (Typeable)
 import           Data.Map (Map)
 
 import           Network.TypedProtocol.Core
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 
 -- |
@@ -43,6 +44,9 @@ data Handshake vNumber vParams where
     StPropose :: Handshake vNumber vParams
     StConfirm :: Handshake vNumber vParams
     StDone    :: Handshake vNumber vParams
+
+instance ShowProxy (Handshake vNumber vParams) where
+    showProxy _ = "Handshake"
 
 -- |
 -- Reasons by which a server can refuse proposed version.

--- a/ouroboros-network-framework/src/Ouroboros/Network/Util/ShowProxy.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Util/ShowProxy.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE DefaultSignatures   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+
+module Ouroboros.Network.Util.ShowProxy
+  ( ShowProxy (..)
+  , Proxy (..)
+  ) where
+
+import Data.Proxy (Proxy (..))
+
+class ShowProxy p where
+    showProxy :: Proxy p -> String

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Orphans.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Orphans.hs
@@ -1,0 +1,14 @@
+{-# OPTIONS_GHC -Wno-orphans     #-}
+module Test.Ouroboros.Network.Orphans () where
+
+import           Network.TypedProtocol.PingPong.Type (PingPong)
+import           Network.TypedProtocol.ReqResp.Type  (ReqResp)
+
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
+
+
+instance ShowProxy PingPong where
+    showProxy _ = "PingPong"
+
+instance ShowProxy (ReqResp req resp) where
+    showProxy _ = "ReqResp"

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
@@ -51,6 +51,7 @@ import           Ouroboros.Network.ErrorPolicy
 import           Ouroboros.Network.IOManager
 -- TODO: remove Mx prefixes
 import           Ouroboros.Network.Mux
+
 import qualified Network.Mux as Mx (MuxError(..), MuxErrorType(..))
 import qualified Network.Mux.Compat as Mx (muxStart)
 import qualified Network.Mux.Bearer.Socket as Mx (socketAsMuxBearer)
@@ -61,6 +62,8 @@ import           Network.Mux.Timeout
 import           Ouroboros.Network.Protocol.Handshake.Codec
 import           Ouroboros.Network.Protocol.Handshake.Unversioned
 import           Ouroboros.Network.Protocol.Handshake.Version
+
+import           Test.Ouroboros.Network.Orphans ()
 
 import           Test.QuickCheck
 import           Test.Tasty (DependencyType (..), TestTree, after, testGroup)

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
@@ -57,6 +57,8 @@ import           Ouroboros.Network.Subscription.PeerState
 import           Ouroboros.Network.Subscription.Subscriber
 import           Ouroboros.Network.Subscription.Worker (LocalAddresses(..), WorkerParams(..))
 
+import           Test.Ouroboros.Network.Orphans ()
+
 import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty, shuffle)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -104,7 +104,8 @@ import           Network.Mux (WithMuxBearer (..))
 
 import           Ouroboros.Network.Codec
 import           Ouroboros.Network.Driver (TraceSendRecv(..))
-import           Ouroboros.Network.Driver.Limits (ProtocolLimitFailure)
+import           Ouroboros.Network.Driver.Simple (DecoderFailure)
+import           Ouroboros.Network.Driver.Limits (ProtocolLimitFailure (..))
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.NodeToClient.Version
 import           Ouroboros.Network.ErrorPolicy
@@ -563,8 +564,8 @@ networkErrorPolicies = ErrorPolicies
 
         -- deserialisation failure of a message from a trusted node
       , ErrorPolicy
-          $ \(_ :: CBOR.DeserialiseFailure)
-                -> Just ourBug
+         $ \(_ :: DecoderFailure CBOR.DeserialiseFailure)
+               -> Just ourBug
 
       , ErrorPolicy
           $ \(e :: MuxError)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Type.hs
@@ -12,6 +12,7 @@ module Ouroboros.Network.Protocol.BlockFetch.Type where
 import           Data.Void (Void)
 
 import           Ouroboros.Network.Block (StandardHash, Point)
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 import           Network.TypedProtocol.Core (Protocol (..))
 
 -- | Range of blocks, defined by a lower and upper point, inclusive.
@@ -25,6 +26,8 @@ data BlockFetch block where
   BFStreaming :: BlockFetch block
   BFDone      :: BlockFetch block
 
+instance ShowProxy (BlockFetch block) where
+    showProxy _ = "BlockFetch"
 
 instance Protocol (BlockFetch block) where
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Type.hs
@@ -13,6 +13,7 @@
 module Ouroboros.Network.Protocol.ChainSync.Type where
 
 import Ouroboros.Network.Block (Point, StandardHash)
+import Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 import Network.TypedProtocol.Core
 
@@ -39,6 +40,10 @@ data ChainSync header tip where
 
   -- | Both the client and server are in the terminal state. They're done.
   StDone      :: ChainSync header tip
+
+
+instance ShowProxy (ChainSync header tip) where
+    showProxy _ = "ChainSync"
 
 -- | Sub-cases of the 'StNext' state. This is needed since the server can
 -- either send one reply back, or two.

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/KeepAlive/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/KeepAlive/Type.hs
@@ -24,6 +24,7 @@
 module Ouroboros.Network.Protocol.KeepAlive.Type where
 
 import Network.TypedProtocol.Core
+import Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 
 -- | A kind to identify our protocol, and the types of the states in the state
@@ -43,6 +44,8 @@ data KeepAlive where
     --
     StDone   :: KeepAlive
 
+instance ShowProxy KeepAlive where
+    showProxy _ = "KeepAlive"
 
 instance Protocol KeepAlive where
     -- | The messages in the keep alive protocol.

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Type.hs
@@ -19,6 +19,7 @@ module Ouroboros.Network.Protocol.LocalStateQuery.Type where
 import           Data.Kind (Type)
 import           Network.TypedProtocol.Core
 import           Ouroboros.Network.Block (Point, StandardHash)
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 
 -- | The kind of the local state query protocol, and the types of
@@ -54,6 +55,9 @@ data LocalStateQuery block (query :: Type -> Type) where
   -- | Nobody has agency. The terminal state.
   --
   StDone :: LocalStateQuery block query
+
+instance ShowProxy (LocalStateQuery block query) where
+    showProxy _ = "LocalStateQuery"
 
 instance Protocol (LocalStateQuery block query) where
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxMonitor/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxMonitor/Type.hs
@@ -15,6 +15,7 @@ module Ouroboros.Network.Protocol.LocalTxMonitor.Type where
 
 
 import           Network.TypedProtocol.Core
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 
 -- | The kind of the local transaction monitoring protocol, and the types of
@@ -40,6 +41,10 @@ data LocalTxMonitor tx where
   -- | Nobody has agency. The terminal state.
   --
   StDone   :: LocalTxMonitor tx
+
+
+instance ShowProxy (ShowProxy (LocalTxMonitor tx)) where
+    showProxy _ = "LocalTxMonitor"
 
 
 instance Protocol (LocalTxMonitor tx) where

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Type.hs
@@ -15,6 +15,7 @@ module Ouroboros.Network.Protocol.LocalTxSubmission.Type where
 
 
 import           Network.TypedProtocol.Core
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 
 
 -- | The kind of the local transaction-submission protocol, and the types of
@@ -43,6 +44,10 @@ data LocalTxSubmission tx reject where
   -- | Nobody has agency. The terminal state.
   --
   StDone   :: LocalTxSubmission tx reject
+
+
+instance ShowProxy (LocalTxSubmission tx reject) where
+    showProxy _ = "LocalTxSubmission"
 
 
 -- | Isomorphic with Maybe but with a name that better describes its purpose and

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/TxSubmission/Type.hs
@@ -17,6 +17,8 @@ import           Data.List.NonEmpty (NonEmpty)
 
 import           Network.TypedProtocol.Core
 
+import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
+
 -- | Transactions are typically not big, but in principle in future we could
 -- have ones over 64k large.
 --
@@ -61,6 +63,10 @@ data TxSubmission txid tx where
   -- | Nobody has agency; termination state.
   --
   StDone   :: TxSubmission txid tx
+
+
+instance ShowProxy (TxSubmission txid tx) where
+    showProxy _ = "TxSubmission"
 
 
 data StBlockingStyle where

--- a/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
@@ -18,6 +18,7 @@ import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.Typeable (Typeable)
 
 import           Control.Exception (assert)
 import           Control.Monad (forever)
@@ -190,7 +191,8 @@ exampleFixedPeerGSVs =
 
 runFetchClient :: (MonadAsync m, MonadFork m, MonadMask m, MonadThrow (STM m),
                    MonadST m, MonadTime m, MonadTimer m,
-                   Ord peerid, Serialise block, Serialise (HeaderHash block))
+                   Ord peerid, Serialise block, Serialise (HeaderHash block),
+                   Typeable block)
                 => Tracer m (TraceSendRecv (BlockFetch block))
                 -> FetchClientRegistry peerid header block m
                 -> peerid
@@ -209,7 +211,8 @@ runFetchClient tracer registry peerid channel client =
 runFetchServer :: (MonadAsync m, MonadFork m, MonadMask m, MonadThrow (STM m),
                    MonadST m, MonadTime m, MonadTimer m,
                    Serialise block,
-                   Serialise (HeaderHash block))
+                   Serialise (HeaderHash block),
+                   Typeable block)
                 => Tracer m (TraceSendRecv (BlockFetch block))
                 -> Channel m LBS.ByteString
                 -> BlockFetchServer block m a
@@ -225,7 +228,8 @@ runFetchClientAndServerAsync
                :: (MonadAsync m, MonadFork m, MonadMask m, MonadThrow (STM m),
                    MonadST m, MonadTime m, MonadTimer m, Ord peerid,
                    Serialise header, Serialise block,
-                   Serialise (HeaderHash block))
+                   Serialise (HeaderHash block),
+                   Typeable block)
                 => Tracer m (TraceSendRecv (BlockFetch block))
                 -> Tracer m (TraceSendRecv (BlockFetch block))
                 -> FetchClientRegistry peerid header block m


### PR DESCRIPTION
This series of patches fixes issue #1964;  For

- `DeserialiseFailure`
- `ProtocolLimitFailure`

we include additional context:  the error constructors contain singleton for
the corresponding protocol state.  Together with the `ShowProxy` class
& instances for all mini-protocols, this allows to log protocol name & the
state.

- handshake: use protocol limits to impose timeouts
- ShowProxy class
- DecoderFailure: extended context
- DecoderFailure: updated componets
- updated ouroboros-consensus
- ProtocolLimitFailure: extended context
- ProtocolLimitFailure: updated components
