### PR TITLE
Increase bfcMaxConcurrencyDeadline

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -177,7 +177,7 @@ initNodeKernel args@NodeArgs { registry, cfg, tracers, maxTxCapacityOverride
     blockFetchConfiguration :: BlockFetchConfiguration
     blockFetchConfiguration = BlockFetchConfiguration
       { bfcMaxConcurrencyBulkSync = 1 -- Set to 1 for now, see #1526
-      , bfcMaxConcurrencyDeadline = 1
+      , bfcMaxConcurrencyDeadline = 4
       , bfcMaxRequestsInflight    = blockFetchPipeliningMax miniProtocolParameters
       }
 


### PR DESCRIPTION
Inrease bfcMaxConcurrencyDeadline from one to four.
This lowers the risk of getting stuck fetching a block
from a slow peer in case of slot collision.