### PR TITLE
Add the fake initial snapshot to the snapshots.

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -253,6 +253,10 @@ protocolInfoShelley genesis initialNonce maxMajorPV protVer mbCredentials =
     --
     -- This function embodies a little more logic than ideal. We might want to
     -- move it into `cardano-ledger-specs.`
+    --
+    -- HERE BE DRAGONS! This function is intended to help in testing. It should
+    -- not be called with anything other than 'emptyGenesisStaking' in
+    -- production.
     registerGenesisStaking :: SL.ChainState c -> SL.ChainState c
     registerGenesisStaking cs@(SL.ChainState {chainNes = oldChainNes} ) = cs
         { SL.chainNes = newChainNes }
@@ -274,8 +278,7 @@ protocolInfoShelley genesis initialNonce maxMajorPV protVer mbCredentials =
         newEpochState = oldEpochState
           { SL.esLState = newLedgerState
           , SL.esSnapshots = (SL.esSnapshots oldEpochState)
-            { SL._pstakeMark = initSnapShot
-            }
+            { SL._pstakeMark = initSnapShot }
           }
         newLedgerState = oldLedgerState
           { SL._delegationState = newDPState }

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -272,7 +272,11 @@ protocolInfoShelley genesis initialNonce maxMajorPV protVer mbCredentials =
           , SL.nesPd = newPoolDistr
           }
         newEpochState = oldEpochState
-          { SL.esLState = newLedgerState }
+          { SL.esLState = newLedgerState
+          , SL.esSnapshots = (SL.esSnapshots oldEpochState)
+            { SL._pstakeMark = initSnapShot
+            }
+          }
         newLedgerState = oldLedgerState
           { SL._delegationState = newDPState }
         newDPState = oldDPState

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -52,6 +52,7 @@ import qualified Shelley.Spec.Ledger.Address as SL
 import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.BlockChain as SL
+import qualified Shelley.Spec.Ledger.Coin as SL
 import qualified Shelley.Spec.Ledger.Credential as SL
 import qualified Shelley.Spec.Ledger.Delegation.Certificates as SL
 import qualified Shelley.Spec.Ledger.EpochBoundary as SL
@@ -292,7 +293,16 @@ protocolInfoShelley genesis initialNonce maxMajorPV protVer mbCredentials =
         -- See STS DELEG for details
         newDState :: SL.DState c
         newDState = (SL._dstate oldDPState) {
-          SL._delegations = Map.mapKeys SL.KeyHashObj sgsStake
+          SL._stkCreds = SL.StakeCreds
+                        . Map.map (const $ SlotNo 0)
+                        . Map.mapKeys SL.KeyHashObj
+                        $ sgsStake
+        , SL._rewards = Map.mapKeys ( SL.mkRwdAcnt (SL.sgNetworkId genesis)
+                                    . SL.KeyHashObj
+                                    )
+                      . Map.map (const $ SL.Coin 0)
+                      $ sgsStake
+        , SL._delegations = Map.mapKeys SL.KeyHashObj sgsStake
         }
 
         -- We consider pools as having been registered in slot 0


### PR DESCRIPTION
This is needed to allow the initial stake pools to continue producing
blocks into the second epoch.

HERE BE DRAGONS: this function is not suitable for production use!