### PR TITLE
use a richer distribution for k in RealTPraos ThreadNet test

### DIFF
--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -74,7 +74,8 @@ instance Arbitrary TestSetup where
 
 tests :: TestTree
 tests = testGroup "RealTPraos"
-    [ testProperty "simple convergence" $ withMaxSuccess 20 $ \setup ->
+    [ adjustOption (\(QuickCheckTests n) -> QuickCheckTests $ n `div` 5) $
+      testProperty "simple convergence" $ \setup ->
         prop_simple_real_tpraos_convergence setup
     ]
 

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -56,8 +56,8 @@ data TestSetup = TestSetup
 
 instance Arbitrary TestSetup where
   arbitrary = do
-    setupD <- (/10)         <$> choose   (1, 10)
-    setupK <- SecurityParam <$> elements [5, 10]
+    setupD <- (/10)         <$> choose (1, 10)
+    setupK <- SecurityParam <$> choose (1, 10)
 
     setupTestConfig <- arbitrary
 


### PR DESCRIPTION
Address a loose strand of #1735.

Now these tests may reach the third epoch and beyond.