### PR TITLE
Fix problems with paths to golden folders

### DIFF
--- a/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
+++ b/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
@@ -91,7 +91,6 @@ test-suite test
                      , cardano-slotting
                      , cborg
                      , containers
-                     , filepath
                      , hedgehog-quickcheck
                      , mtl
                      , QuickCheck

--- a/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Golden.hs
+++ b/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Golden.hs
@@ -1,21 +1,19 @@
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Consensus.Byron.Golden (tests) where
-
-import           System.FilePath ((</>))
 
 import           Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
 import           Ouroboros.Consensus.Byron.Node ()
 
 import           Test.Tasty
 
+import           Test.Util.Paths
 import           Test.Util.Serialisation.Golden
 
 import           Test.Consensus.Byron.Examples
 
 tests :: TestTree
-tests = goldenTest_all codecConfig goldenDir examples
-  where
-    goldenDir = "ouroboros-consensus-byron-test" </> "test" </> "golden"
+tests = goldenTest_all codecConfig $(getGoldenDir) examples
 
 instance ToGoldenDirectory ByronNodeToNodeVersion
   -- Use defaults

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -91,7 +91,6 @@ test-suite test
                      , cardano-prelude
                      , cborg             >=0.2.2 && <0.3
                      , containers
-                     , filepath
                      , mtl
                      , QuickCheck
                      , tasty

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Golden.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Golden.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell   #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Consensus.Cardano.Golden (tests) where
-
-import           System.FilePath ((</>))
 
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation
 
@@ -11,14 +10,13 @@ import           Ouroboros.Consensus.Cardano.Node
 
 import           Test.Tasty
 
+import           Test.Util.Paths
 import           Test.Util.Serialisation.Golden
 
 import           Test.Consensus.Cardano.Examples
 
 tests :: TestTree
-tests = goldenTest_all codecConfig goldenDir examples
-  where
-    goldenDir = "ouroboros-consensus-cardano" </> "test" </> "golden"
+tests = goldenTest_all codecConfig $(getGoldenDir) examples
 
 instance ToGoldenDirectory (HardForkNodeToNodeVersion (CardanoEras sc)) where
   toGoldenDirectory v = case v of

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -84,7 +84,6 @@ test-suite test
                      , cardano-slotting
                      , cborg             >=0.2.2 && <0.3
                      , containers
-                     , filepath
                      , QuickCheck
                      , time
                      , tasty

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
@@ -1,21 +1,19 @@
+{-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Consensus.Shelley.Golden (tests) where
-
-import           System.FilePath ((</>))
 
 import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
 import           Ouroboros.Consensus.Shelley.Node ()
 
 import           Test.Tasty
 
+import           Test.Util.Paths
 import           Test.Util.Serialisation.Golden
 
 import           Test.Consensus.Shelley.Examples
 
 tests :: TestTree
-tests = goldenTest_all codecConfig goldenDir examples
-  where
-    goldenDir = "ouroboros-consensus-shelley-test" </> "test" </> "golden"
+tests = goldenTest_all codecConfig $(getGoldenDir) examples
 
 instance ToGoldenDirectory ShelleyNodeToNodeVersion
   -- Use defaults

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
@@ -54,6 +54,7 @@ library
                        Test.Util.Orphans.NoUnexpectedThunks
                        Test.Util.Orphans.Slotting.Arbitrary
                        Test.Util.Orphans.ToExpr
+                       Test.Util.Paths
                        Test.Util.QSM
                        Test.Util.QuickCheck
                        Test.Util.Range
@@ -83,6 +84,7 @@ library
                      , deepseq
                      , directory
                      , fgl
+                     , file-embed
                      , filepath
                      , generics-sop
                      , graphviz
@@ -96,6 +98,7 @@ library
                      , tasty-golden
                      , tasty-hunit
                      , tasty-quickcheck
+                     , template-haskell
                      , text              >=1.2   && <1.3
                      , time
                      , transformers

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Paths.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Paths.hs
@@ -1,0 +1,46 @@
+-- | Utility function for finding a directory relative to the package root
+-- directory.
+--
+-- Copied from
+-- <https://github.com/input-output-hk/cardano-wallet/blob/master/lib/test-utils/src/Test/Utils/Paths.hs>
+module Test.Util.Paths (
+    getGoldenDir
+  , getRelPath
+  , inNixBuild
+  ) where
+
+
+import           Control.Monad.IO.Class (liftIO)
+import           Data.FileEmbed (makeRelativeToProject)
+import           Language.Haskell.TH.Syntax (Exp, Q, liftData)
+import           System.Environment (lookupEnv)
+import           System.FilePath ((</>))
+
+-- | A TH function to get the path corresponding to the golden output
+-- directory relative to the package root directory.
+getGoldenDir :: Q Exp
+getGoldenDir = getRelPath ("test" </> "golden")
+
+-- | A TH function to get the path corresponding to the given 'FilePath' which
+-- is relative to the package root directory.
+--
+-- It combines the current source file location and cabal file to locate the
+-- package directory in such a way that works in both the stack/cabal package
+-- build and ghci.
+--
+-- For the Nix build, rather than baking in a path that starts with @/build@, it
+-- makes the test data path relative to the current directory.
+getRelPath :: FilePath -> Q Exp
+getRelPath relPath = do
+    absPath <- makeRelativeToProject relPath
+    useRel <- liftIO inNixBuild
+    liftData (if useRel then relPath else absPath)
+
+-- | Infer from environment variables whether we are running within a Nix build
+-- (and not just a nix-shell).
+inNixBuild :: IO Bool
+inNixBuild = do
+    let testEnv = fmap (maybe False (not . null)) . lookupEnv
+    haveNixBuildDir <- testEnv "NIX_BUILD_TOP"
+    inNixShell <- testEnv "IN_NIX_SHELL"
+    pure (haveNixBuildDir && not inNixShell)


### PR DESCRIPTION
The Nix CI was not finding them, creating the golden results each time.
Moreover, `cabal test` was making the directories relative to each subpackage
whereas `cabal run` was making the directories relative to the root.

Copy a solution found by our friends from cardano-wallet.