### PR TITLE
Update the d protocol parameter during RealTPraos ThreadNet tests

### DIFF
--- a/.buildkite/slow-ThreadNet-tests.sh
+++ b/.buildkite/slow-ThreadNet-tests.sh
@@ -13,15 +13,6 @@ set -euo pipefail
 #
 # INVARIANT: No whitespace in any word.
 #
-# At time of writing, 100 (nightly) Cardano tests take approximately 60 seconds
-# and 100 (nightly) RealTPraos tests take approximately 700s on the BuildKite
-# instance reserved for benchmarking. So, for example, a 1000 RealTPraos tests
-# should take a single core about two hours and 5000 Cardano tests should take
-# about fifty minutes.
-#
-# See
-# https://buildkite.com/input-output-hk/ouroboros-network-nightly/builds/144#0f2d1638-9751-4397-82e8-21ec5f457f1c
-#
 # We only test in multiples of 100 because otherwise it risks skewing the
 # QuickCheck generator distribution (note that QuickCheck sets `maxSize stdArgs
 # = 100`).
@@ -33,10 +24,10 @@ set -euo pipefail
 # overhead and also more reliable percentages in their QuickCheck statistics.
 rows=(
     # From the slowest individual invocation ...
-    '1 RealTPraos 1000'
-    '1 Cardano    5000'
-    '5 RealTPraos 100'
-    '5 Cardano    500'
+    '1 Cardano    5000'  # ~45 minutes per invocation
+    '2 RealTPraos 200'   # ~30 minutes per invocation (but high variance)
+    '4 RealTPraos 100'   # ~15 minutes per invocation (but high variance)
+    '5 Cardano    500'   # ~5 minutes per invocation
     # ... to fastest individual invocation
     #
     # And the number of invocations is non-decreasing.

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -27,7 +27,6 @@ import           Test.Tasty.QuickCheck
 import           Cardano.Slotting.Slot (EpochNo, EpochSize (..), SlotNo (..))
 
 import           Cardano.Crypto.Hash.Blake2b (Blake2b_256)
-import qualified Cardano.Crypto.KES.Class as KES
 
 import qualified Ouroboros.Network.MockChain.Chain as MockChain
 
@@ -347,6 +346,7 @@ prop_simple_cardano_convergence TestSetup
     TestConfig
       { initSeed
       , numCoreNodes
+      , numSlots
       } = setupTestConfig
 
     testConfigB = TestConfigB
@@ -435,10 +435,6 @@ prop_simple_cardano_convergence TestSetup
     initialKESPeriod :: SL.KESPeriod
     initialKESPeriod = SL.KESPeriod 0
 
-    maxKESEvolutions :: Word64
-    maxKESEvolutions = fromIntegral $
-      KES.totalPeriodsKES (Proxy @(KES Crypto))
-
     coreNodes :: [Shelley.CoreNode Crypto]
     coreNodes = runGen initSeed $
         replicateM (fromIntegral n) $
@@ -453,7 +449,7 @@ prop_simple_cardano_convergence TestSetup
           setupK
           setupD
           setupSlotLengthShelley
-          maxKESEvolutions
+          (Shelley.mkKesConfig (Proxy @(KES Crypto)) numSlots)
           coreNodes
 
     -- the Shelley ledger is designed to use a fixed epoch size, so this test
@@ -520,7 +516,6 @@ prop_simple_cardano_convergence TestSetup
             -- most 1 in a billion.
       }
       where
-        TestConfig{numSlots}        = setupTestConfig
         NumSlots t                  = numSlots
         TestOutput{testOutputNodes} = testOutput
 

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -103,8 +103,7 @@ partitionExclusiveUpperBound (Partition s (NumSlots d)) = Util.addSlots d s
 data TestSetup = TestSetup
   { setupByronLowerBound   :: Bool
     -- ^ whether to use the @HardFork.LowerBound@ optimization
-  , setupD                 :: Double
-    -- ^ decentralization parameter
+  , setupD                 :: Shelley.DecentralizationParam
   , setupHardFork          :: Bool
     -- ^ whether the proposal should trigger a hard fork or not
   , setupK                 :: SecurityParam
@@ -118,7 +117,9 @@ data TestSetup = TestSetup
 
 instance Arbitrary TestSetup where
   arbitrary = do
-    setupD <- (/10)         <$> choose (1, 10)
+    setupD <- arbitrary
+                -- TODO Issue 2388 prevents `d=0` in this test.
+                `suchThat` ((/= 0) . Shelley.decentralizationParamToRational)
     setupK <- SecurityParam <$> choose (2, 6)
 
     setupSlotLengthByron   <- arbitrary

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -39,6 +39,7 @@ library
                      , generic-random
                      , hedgehog-quickcheck
                      , iproute
+                     , quiet             >=0.2   && <0.3
                      , mtl               >=2.2   && <2.3
                      , QuickCheck
                      , time

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -119,7 +119,10 @@ prop_simple_real_tpraos_convergence TestSetup
       , messageDelay = noCalcMessageDelay
       , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
       , nodeRestarts = noRestarts
-      , txGenExtra   = ShelleyTxGenExtra $ mkGenEnv coreNodes
+      , txGenExtra   = ShelleyTxGenExtra
+          { stgeGenEnv  = mkGenEnv coreNodes
+          , stgeStartAt = SlotNo 0
+          }
       , version      = setupVersion
       }
 

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -47,8 +47,7 @@ import           Test.ThreadNet.Util.Seed (runGen)
 type Crypto = TPraosMockCrypto ShortHash
 
 data TestSetup = TestSetup
-  { setupD          :: Double
-    -- ^ decentralization parameter
+  { setupD          :: DecentralizationParam
   , setupK          :: SecurityParam
   , setupTestConfig :: TestConfig
   , setupVersion    :: (NodeToNodeVersion, BlockNodeToNodeVersion (ShelleyBlock Crypto))
@@ -57,7 +56,7 @@ data TestSetup = TestSetup
 
 instance Arbitrary TestSetup where
   arbitrary = do
-    setupD <- (/10)         <$> choose   (0, 10)
+    setupD <- arbitrary
     setupK <- SecurityParam <$> elements [5, 10]
 
     setupTestConfig <- arbitrary

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -6,14 +6,12 @@ module Test.ThreadNet.RealTPraos (tests) where
 import           Control.Monad (replicateM)
 import           Data.List ((!!))
 import           Data.Proxy (Proxy (..))
-import           Data.Word (Word64)
 
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import           Cardano.Crypto.Hash (ShortHash)
-import qualified Cardano.Crypto.KES.Class as KES
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
@@ -112,6 +110,7 @@ prop_simple_real_tpraos_convergence TestSetup
     TestConfig
       { initSeed
       , numCoreNodes
+      , numSlots
       } = setupTestConfig
 
     testConfigB = TestConfigB
@@ -138,10 +137,6 @@ prop_simple_real_tpraos_convergence TestSetup
     initialKESPeriod :: SL.KESPeriod
     initialKESPeriod = SL.KESPeriod 0
 
-    maxKESEvolutions :: Word64
-    maxKESEvolutions = fromIntegral $
-      KES.totalPeriodsKES (Proxy @(KES Crypto))
-
     coreNodes :: [CoreNode Crypto]
     coreNodes = runGen initSeed $
         replicateM (fromIntegral n) $
@@ -156,7 +151,7 @@ prop_simple_real_tpraos_convergence TestSetup
           setupK
           setupD
           tpraosSlotLength
-          maxKESEvolutions
+          (mkKesConfig (Proxy @(KES Crypto)) numSlots)
           coreNodes
 
     epochSize :: EpochSize

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -5,16 +5,20 @@ module Test.ThreadNet.RealTPraos (tests) where
 
 import           Control.Monad (replicateM)
 import           Data.List ((!!))
+import qualified Data.Map.Strict as Map
 import           Data.Proxy (Proxy (..))
+import           Data.Word (Word64)
 
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 import           Cardano.Crypto.Hash (ShortHash)
+import           Cardano.Slotting.EpochInfo (fixedSizeEpochInfo)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config.SecurityParam
+import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -22,16 +26,21 @@ import           Ouroboros.Consensus.NodeId
 
 import           Test.ThreadNet.General
 import           Test.ThreadNet.Infra.Shelley
+import           Test.ThreadNet.Network (TestNodeInitialization (..),
+                     nodeOutputFinalLedger)
 
 import           Test.Util.HardFork.Future (singleEraFuture)
 import           Test.Util.Nightly
 import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Slots (NumSlots (..))
 
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
+import qualified Shelley.Spec.Ledger.LedgerState as SL
 import qualified Shelley.Spec.Ledger.OCert as SL
 import qualified Shelley.Spec.Ledger.PParams as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
+import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
 import           Ouroboros.Consensus.Shelley.Node
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (KES)
 
@@ -46,29 +55,85 @@ type Crypto = TPraosMockCrypto ShortHash
 
 data TestSetup = TestSetup
   { setupD          :: DecentralizationParam
+  , setupD2         :: DecentralizationParam
+    -- ^ scheduled value
+    --
+    -- If not equal to 'setupD', every node immediately (ie slot 0) issues a
+    -- protocol update transaction that will change the @d@ protocol parameter
+    -- accordingly.
   , setupK          :: SecurityParam
   , setupTestConfig :: TestConfig
   , setupVersion    :: (NodeToNodeVersion, BlockNodeToNodeVersion (ShelleyBlock Crypto))
   }
   deriving (Show)
 
+minK :: Word64
+minK = 5   -- Less than this increases risk of CP violations
+
+maxK :: Word64
+maxK = 10   -- More than this wastes execution time
+
 instance Arbitrary TestSetup where
   arbitrary = do
-    setupD <- arbitrary
-    setupK <- SecurityParam <$> elements [5, 10]
+      setupD  <- arbitrary
+      setupD2 <- arbitrary
 
-    setupTestConfig <- arbitrary
+      setupK  <- SecurityParam <$> choose (minK, maxK)
 
-    setupVersion   <- genVersion (Proxy @(ShelleyBlock Crypto))
+      setupTestConfig <- arbitrary
 
-    pure TestSetup
-      { setupD
-      , setupK
-      , setupTestConfig
-      , setupVersion
-      }
+      setupVersion <- genVersion (Proxy @(ShelleyBlock Crypto))
+
+      pure TestSetup
+        { setupD
+        , setupD2
+        , setupK
+        , setupTestConfig
+        , setupVersion
+        }
 
   -- TODO shrink
+
+-- | We run for more slots at night.
+newtype NightlyTestSetup = NightlyTestSetup TestSetup
+  deriving (Show)
+
+instance Arbitrary NightlyTestSetup where
+  shrink (NightlyTestSetup setup) = NightlyTestSetup <$> shrink setup
+
+  arbitrary = do
+      setup <- arbitrary
+
+      -- At time of writing, this causes 100 tests to have an expected run time
+      -- of half an hour on the BuildKite queue=bench machine.
+      --
+      -- 100 extended tests has an average run time of 4643 seconds (cf
+      -- https://buildkite.com/input-output-hk/ouroboros-network-nightly/builds/167
+      -- ). 100 unextended tests has an average of 689 seconds (cf
+      -- https://buildkite.com/input-output-hk/ouroboros-network-nightly/builds/164).
+      --
+      -- 3/4*689 + 1/4*4643 seconds =~= 28 minutes.
+      moreEpochs <- frequency [(3, pure False), (1, pure True)]
+
+      NightlyTestSetup <$> if not moreEpochs then pure setup else do
+        let TestSetup
+              { setupK
+              , setupTestConfig
+              } = setup
+            TestConfig
+              { numSlots
+              } = setupTestConfig
+            NumSlots t = numSlots
+
+        -- run for multiple epochs
+        factor <- choose (1, 2)
+        let t' = t + factor * unEpochSize (mkEpochSize setupK)
+
+        pure setup
+          { setupTestConfig = setupTestConfig
+              { numSlots = NumSlots t'
+              }
+          }
 
 -- | Run relatively fewer tests
 --
@@ -81,19 +146,34 @@ fifthTestCount (QuickCheckTests n) = QuickCheckTests $
 
 tests :: TestTree
 tests = testGroup "RealTPraos ThreadNet"
-    [ askIohkNightlyEnabled $ \enabled ->
-      (if enabled then id else adjustOption fifthTestCount) $
-      testProperty "simple convergence" $ \setup ->
-        prop_simple_real_tpraos_convergence setup
+    [ let name = "simple convergence" in
+      askIohkNightlyEnabled $ \enabled ->
+      if enabled
+      then testProperty name $ \(NightlyTestSetup setup) ->
+             prop_simple_real_tpraos_convergence setup
+      else adjustOption fifthTestCount $
+           testProperty name $ \setup ->
+             prop_simple_real_tpraos_convergence setup
     ]
 
 prop_simple_real_tpraos_convergence :: TestSetup -> Property
 prop_simple_real_tpraos_convergence TestSetup
   { setupD
+  , setupD2
   , setupK
   , setupTestConfig
   , setupVersion
   } =
+    countertabulate "Epoch number of last slot"
+      ( show $
+        if 0 >= unNumSlots numSlots then 0 else
+        (unNumSlots numSlots - 1) `div` unEpochSize epochSize
+      ) $
+    countertabulate "Updating d"
+      ( if not dShouldUpdate then "No" else
+        "Yes, " <> show (compare setupD setupD2)
+      ) $
+    counterexample (show setupK) $
     prop_general PropGeneralArgs
       { pgaBlockProperty      = const $ property True
       , pgaCountTxs           = fromIntegral . length . extractTxs
@@ -105,8 +185,13 @@ prop_simple_real_tpraos_convergence TestSetup
       , pgaTestConfig         = setupTestConfig
       , pgaTestConfigB        = testConfigB
       }
-      testOutput
+      testOutput .&&.
+    prop_checkFinalD
   where
+    countertabulate :: String -> String -> Property -> Property
+    countertabulate lbl s =
+        tabulate lbl [s] . counterexample (lbl <> ": " <> s)
+
     TestConfig
       { initSeed
       , numCoreNodes
@@ -120,20 +205,64 @@ prop_simple_real_tpraos_convergence TestSetup
       , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
       , nodeRestarts = noRestarts
       , txGenExtra   = ShelleyTxGenExtra
-          { stgeGenEnv  = mkGenEnv coreNodes
-          , stgeStartAt = SlotNo 0
-          }
+        { stgeGenEnv          = mkGenEnv inclPPUs coreNodes
+        , stgeStartAt         =
+            SlotNo $ if includingDUpdateTx then 1 else 0
+            -- We don't generate any transactions before the transaction
+            -- carrying the proposal because they might consume its inputs
+            -- before it does, thereby rendering it invalid.
+        }
       , version      = setupVersion
       }
+
+    inclPPUs :: WhetherToGeneratePPUs
+    inclPPUs =
+        -- We don't generate any other updates, since doing so might
+        -- accidentally supplant the bespoke update that these tests are
+        -- expecting.
+        --
+        -- The transaction this test introduces causes all nodes to propose the
+        -- same parameter update. It'd technically be OK if some nodes then
+        -- changed their proposal to a different update, as long as at least
+        -- @Quorum@-many nodes were still proposing this test's original update
+        -- as of the epoch boundary. However, we keep the test simple and just
+        -- avoid introducing any other proposals.
+        if includingDUpdateTx then DoNotGeneratePPUs else DoGeneratePPUs
+
+    -- The slot immediately after the end of this test.
+    sentinel :: SlotNo
+    sentinel = SlotNo $ unNumSlots numSlots
+
+    -- We don't create the update proposal etc unless @d@ would change.
+    includingDUpdateTx :: Bool
+    includingDUpdateTx = setupD /= setupD2
+
+    -- The ledger state should have an updated @d@ as of this slot.
+    dUpdatedAsOf :: SlotNo
+    dUpdatedAsOf = SlotNo $ unEpochSize epochSize
+
+    -- Whether we expect @d@ to be updated during this test
+    dShouldUpdate :: Bool
+    dShouldUpdate = includingDUpdateTx && sentinel >= dUpdatedAsOf
 
     testOutput =
         runTestNetwork setupTestConfig testConfigB TestConfigMB
             { nodeInfo = \(CoreNodeId nid) ->
-              plainTestNodeInitialization $
-                mkProtocolRealTPraos
-                  genesisConfig
-                  SL.NeutralNonce
-                  (coreNodes !! fromIntegral nid)
+                TestNodeInitialization
+                  { tniProtocolInfo =
+                      mkProtocolRealTPraos
+                        genesisConfig
+                        SL.NeutralNonce
+                        nextProtVer
+                        (coreNodes !! fromIntegral nid)
+                  , tniCrucialTxs =
+                      if not includingDUpdateTx then [] else
+                      mkSetDecentralizationParamTxs
+                        coreNodes
+                        nextProtVer
+                        sentinel   -- Does not expire during test
+                        setupD2
+                  }
             , mkRekeyM = Nothing
             }
 
@@ -150,7 +279,7 @@ prop_simple_real_tpraos_convergence TestSetup
     genesisConfig :: ShelleyGenesis Crypto
     genesisConfig =
         mkGenesisConfig
-          (SL.ProtVer 0 0)
+          genesisProtVer
           setupK
           setupD
           tpraosSlotLength
@@ -159,3 +288,59 @@ prop_simple_real_tpraos_convergence TestSetup
 
     epochSize :: EpochSize
     epochSize = sgEpochLength genesisConfig
+
+    genesisProtVer :: SL.ProtVer
+    genesisProtVer = SL.ProtVer 0 0
+
+    -- Which protocol version to endorse
+    nextProtVer :: SL.ProtVer
+    nextProtVer = incrementMinorProtVer genesisProtVer
+
+    -- Does the final ledger state have the expected @d@ value when ticked over
+    -- to the 'sentinel' slot?
+    prop_checkFinalD :: Property
+    prop_checkFinalD =
+        conjoin $
+        [ let ls =
+                  -- Handle the corner case where the test has enough scheduled
+                  -- slots to reach the epoch transition but the last several
+                  -- slots end up empty.
+                  Shelley.tickedShelleyState $
+                  applyChainTick ledgerConfig sentinel lsUnticked
+
+              msg =
+                  "The ticked final ledger state of " <> show nid <>
+                  " has an unexpected value for the d protocol parameter."
+
+              -- The actual final value of @d@
+              actual :: SL.UnitInterval
+              actual = SL._d $ SL.esPp $ SL.nesEs ls
+
+              -- The expected final value of @d@
+              expected :: DecentralizationParam
+              expected = if dShouldUpdate then setupD2 else setupD
+          in
+          counterexample ("unticked " <> show lsUnticked) $
+          counterexample ("ticked   " <> show ls) $
+          counterexample ("(d,d2) = " <> show (setupD, setupD2)) $
+          counterexample
+            ( "(dUpdatedAsOf, dShouldUpdate) = " <>
+              show (dUpdatedAsOf, dShouldUpdate)
+            ) $
+          counterexample msg $
+          SL.unitIntervalToRational actual ===
+            decentralizationParamToRational expected
+        | (nid, lsUnticked) <- finalLedgers
+        ]
+      where
+        finalLedgers :: [(NodeId, LedgerState (ShelleyBlock Crypto))]
+        finalLedgers =
+            Map.toList $ nodeOutputFinalLedger <$> testOutputNodes testOutput
+
+        ledgerConfig :: LedgerConfig (ShelleyBlock Crypto)
+        ledgerConfig = Shelley.mkShelleyLedgerConfig
+            genesisConfig
+            (fixedSizeEpochInfo epochSize)
+            maxMajorPV
+          where
+            maxMajorPV = 1000   -- TODO

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -39,6 +39,7 @@ import           Codec.CBOR.Read (DeserialiseFailure)
 import qualified Control.Exception as Exn
 import           Control.Monad
 import qualified Control.Monad.Class.MonadSTM as MonadSTM
+import qualified Control.Monad.Class.MonadThrow as MonadThrow
 import           Control.Monad.Class.MonadTimer (MonadTimer)
 import qualified Control.Monad.Except as Exc
 import           Control.Tracer
@@ -53,6 +54,7 @@ import qualified Data.Set as Set
 import qualified Data.Typeable as Typeable
 import           Data.Void (Void)
 import           GHC.Stack
+import qualified Test.QuickCheck.Exception as QC
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..))
@@ -273,6 +275,7 @@ type EdgeStatusVar m = StrictTVar m EdgeStatus
 runThreadNetwork :: forall m blk.
                     ( IOLike m
                     , MonadTimer m
+                    , MonadThrow.MonadEvaluate m
                     , RunNode blk
                     , TxGen blk
                     , TracingConstraints blk
@@ -637,8 +640,38 @@ runThreadNetwork systemTime ThreadNetworkArgs
         ledger <- atomically $ ledgerState <$> getExtLedger
         -- Combine the node's seed with the current slot number, to make sure
         -- we generate different transactions in each slot.
-        let txs = runGen (nodeSeed `combineWith` unSlotNo curSlotNo) $
-                    testGenTxs numCoreNodes curSlotNo cfg txGenExtra ledger
+        let genTxs i =
+                runGen
+                  (nodeSeed `combineWith` unSlotNo curSlotNo `combineWith` i)
+                  (testGenTxs numCoreNodes curSlotNo cfg txGenExtra ledger)
+
+        -- These TxGen generators fail by invoking 'QC.discard'. We try many
+        -- times before actually giving up. When we give up, it fatal, not just
+        -- a discard.
+        let loop acc = do
+                let txs = genTxs acc
+                lr <- tryJust isDiscard $ MonadThrow.evaluate $ seqList txs
+                case lr of
+                  Right _ -> pure txs
+                  Left  _ ->
+                      if acc < accLimit then loop (acc + 1) else
+                      MonadThrow.throwM (TxGenFailure accLimit)
+              where
+                seqList :: forall a. [a] -> ()
+                seqList = \case
+                    []   -> ()
+                    x:xs -> x `seq` seqList xs
+
+                isDiscard :: Exn.SomeException -> Maybe ()
+                isDiscard = guard . QC.isDiscard
+
+                -- At time of writing, a RealTPraos test run maxed out at about
+                -- 85 consecutive failures here.
+                --
+                -- TODO Better justification.
+                accLimit = 1000 :: Int
+
+        txs <- loop (1 :: Int)
         void $ addTxs mempool txs
 
     mkArgs :: OracularClock m
@@ -1610,3 +1643,9 @@ data JitEbbError blk
 
 deriving instance LedgerSupportsProtocol blk => Show (JitEbbError blk)
 instance LedgerSupportsProtocol blk => Exception (JitEbbError blk)
+
+-- | The 'TxGen' generator consecutively failed too many times
+data TxGenFailure = TxGenFailure Int   -- ^ how many times it failed
+  deriving (Show)
+
+instance Exception TxGenFailure

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -56,6 +56,8 @@ import           Data.Void (Void)
 import           GHC.Stack
 import qualified Test.QuickCheck.Exception as QC
 
+import           Cardano.Prelude (forceElemsToWHNF)
+
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..))
 import           Ouroboros.Network.Channel
@@ -646,30 +648,30 @@ runThreadNetwork systemTime ThreadNetworkArgs
                   (testGenTxs numCoreNodes curSlotNo cfg txGenExtra ledger)
 
         -- These TxGen generators fail by invoking 'QC.discard'. We try many
-        -- times before actually giving up. When we give up, it fatal, not just
-        -- a discard.
-        let loop acc = do
-                let txs = genTxs acc
-                lr <- tryJust isDiscard $ MonadThrow.evaluate $ seqList txs
+        -- times before actually giving up. When we give up, it's fatal, not
+        -- just a discard.
+        let loop :: Int -> m [GenTx blk]
+            loop nthAttempt = do
+                let txs = genTxs nthAttempt
+                lr <-
+                  tryJust isDiscard $
+                  MonadThrow.evaluate (forceElemsToWHNF txs)
                 case lr of
                   Right _ -> pure txs
                   Left  _ ->
-                      if acc < accLimit then loop (acc + 1) else
-                      MonadThrow.throwM (TxGenFailure accLimit)
+                      if nthAttempt < attemptLimit
+                      then loop (nthAttempt + 1)
+                      else MonadThrow.throwM (TxGenFailure attemptLimit)
               where
-                seqList :: forall a. [a] -> ()
-                seqList = \case
-                    []   -> ()
-                    x:xs -> x `seq` seqList xs
-
                 isDiscard :: Exn.SomeException -> Maybe ()
                 isDiscard = guard . QC.isDiscard
 
                 -- At time of writing, a RealTPraos test run maxed out at about
                 -- 85 consecutive failures here.
                 --
-                -- TODO Better justification.
-                accLimit = 1000 :: Int
+                -- Revisit this scheme after Issue
+                -- input-output-hk/cardano-ledger-specs#1689
+                attemptLimit = 1000 :: Int
 
         txs <- loop (1 :: Int)
         void $ addTxs mempool txs


### PR DESCRIPTION
Fixes #1770.

Opening as Draft PR to gather input before refactoring/tidying. It seems to be working. A few specific questions:

  1) ~Any advice on avoiding the limit of `MockKES 10`? It seems like the `RealTPraos` test always fails with a KES-related `CannotLead` if it runs for more than 200 slots.~ @mrBliss explained, thanks!

  2) Did I miss any simpler solutions? This is my first foray into Shelley transaction creation and Shelley ledger state inspection.

  3) We can't lower `k` because that risks CP violations. But we need to reach the second epoch in order to test this update proposal (`epochSize = 10k/f = 20k` here, and `k>=5` seems to avoid CP violations so far). So I increased `numSlots`, which makes these already slow tests even slower. Any better ideas?

cc: @edsko