### PR TITLE
Don't combine ticked LedgerView and ChainDepState

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/State.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/State.hs
@@ -63,14 +63,6 @@ data TPraosState c = TPraosState {
 
 instance Crypto c => NoUnexpectedThunks (TPraosState c)
 
--- | Ticked ChainDep state
---
--- We add the ticked state to the history only when applying a header.
-data instance Ticked (TPraosState c) = TickedPraosState {
-      tickedPraosStateTicked :: SL.ChainDepState c
-    , tickedPraosStateOrig   :: TPraosState c
-    }
-
 checkInvariants :: TPraosState c -> Either String ()
 checkInvariants TPraosState { anchor, historicalStates }
     -- Don't use 'Map.findMin', as its partial, giving a worse error message.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -229,7 +229,6 @@ instance SingleEraBlock b => ConsensusProtocol (DegenForkProtocol b) where
                 canBeLeader
                 chainIndepState
                 slot
-                tickedLedgerView
                 (TDCSt tickedChainDepState) =
     castLeaderCheck $
       checkIsLeader
@@ -237,23 +236,13 @@ instance SingleEraBlock b => ConsensusProtocol (DegenForkProtocol b) where
         canBeLeader
         chainIndepState
         slot
-        tickedLedgerView
         tickedChainDepState
 
   tickChainDepState (DConCfg cfg) view slot (DCSt st) =
       TDCSt $ tickChainDepState cfg view slot st
 
-  updateChainDepState (DConCfg cfg)
-                      valView
-                      slot
-                      tickedLedgerView
-                      (TDCSt chainDepState) =
-      DCSt <$> updateChainDepState
-                 cfg
-                 valView
-                 slot
-                 tickedLedgerView
-                 chainDepState
+  updateChainDepState (DConCfg cfg) valView slot (TDCSt chainDepState) =
+      DCSt <$> updateChainDepState cfg valView slot chainDepState
 
   rewindChainDepState _ secParam pt (DCSt chainDepState) =
       DCSt <$>

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forge.hs
@@ -44,7 +44,9 @@ instance (CanHardFork xs, All CanForge xs) => CanForge (HardForkBlock xs) where
       -- First establish the 'IsLeader' and the 'LedgerState' are from the
       -- same era. As we have passed the ledger view of the ticked ledger to
       -- obtain the 'IsLeader' value, it __must__ be from the same era.
-      -- TODO: Can we avoid this error?
+      -- Unfortunately, we cannot avoid this 'error' call: the 'IsLeader'
+      -- evidence could conceivably include the ledger /view/, but not the
+      -- ledger /state/.
       case State.match (getOneEraIsLeader isLeader) ledgerState of
         Left _mismatch ->
           error "IsLeader from different era than the TickedLedgerState"

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -483,7 +483,6 @@ validateHeader cfg ledgerView hdr st = do
         (configConsensus cfg)
         (validateView (configBlock cfg) hdr)
         (blockSlot hdr)
-        ledgerView
         (tickedHeaderStateConsensus st)
     return $
       headerStatePush

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/BlockProduction.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/BlockProduction.hs
@@ -30,9 +30,8 @@ data BlockProduction m blk = BlockProduction {
       getLeaderProof_ :: HasCallStack
                       => Tracer m (ForgeState blk)
                       -> SlotNo
-                      -> Ticked (LedgerView    (BlockProtocol blk))
                       -> Ticked (ChainDepState (BlockProtocol blk))
-                      -> m (LeaderCheck        (BlockProtocol blk))
+                      -> m (LeaderCheck (BlockProtocol blk))
 
       -- | Produce a block
       --
@@ -57,9 +56,8 @@ getLeaderProof :: HasCallStack
                => BlockProduction m blk
                -> Tracer m (ForgeState blk)
                -> SlotNo
-               -> Ticked (LedgerView    (BlockProtocol blk))
                -> Ticked (ChainDepState (BlockProtocol blk))
-               -> m (LeaderCheck        (BlockProtocol blk))
+               -> m (LeaderCheck (BlockProtocol blk))
 getLeaderProof = getLeaderProof_
 
 defaultBlockProduction ::
@@ -134,10 +132,9 @@ defaultGetLeaderProof ::
   -> StrictMVar m (ForgeState blk)
   -> Tracer m (ForgeState blk)
   -> SlotNo
-  -> Ticked (LedgerView (BlockProtocol blk))
   -> Ticked (ChainDepState (BlockProtocol blk))
   -> m (LeaderCheck (BlockProtocol blk))
-defaultGetLeaderProof cfg proof mfs varForgeState tracer slot lgrSt chainDepSt = do
+defaultGetLeaderProof cfg proof mfs varForgeState tracer slot chainDepSt = do
     forgeState' <- modifyMVar varForgeState $ \forgeState -> do
       forgeState' <-
         updateForgeState
@@ -152,5 +149,4 @@ defaultGetLeaderProof cfg proof mfs varForgeState tracer slot lgrSt chainDepSt =
                proof
                (chainIndepState forgeState')
                slot
-               lgrSt
                chainDepSt

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -361,7 +361,6 @@ forkBlockProduction maxTxCapacityOverride IS{..} blockProduction =
             getLeaderProof blockProduction
               (forgeStateTracer tracers)
               currentSlot
-              (tickedLedgerView ticked)
               (tickedHeaderStateConsensus $ tickedHeaderState ticked)
           case mIsLeader of
             IsLeader   p -> return p

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -237,11 +237,15 @@ class ( Show (ChainDepState   p)
                 -> CanBeLeader           p
                 -> ChainIndepState       p
                 -> SlotNo
-                -> Ticked (LedgerView    p)
                 -> Ticked (ChainDepState p)
                 -> LeaderCheck           p
 
   -- | Tick the 'ChainDepState'
+  --
+  -- We pass the ticked 'LedgerView' to 'tickChainDepState'. Functions that
+  -- /take/ a ticked 'ChainDepState' are not separately passed a ticked ledger
+  -- view; protocols that require it, can include it in their ticked
+  -- 'ChainDepState' type.
   tickChainDepState :: ConsensusConfig p
                     -> Ticked (LedgerView p)
                     -> SlotNo
@@ -253,7 +257,6 @@ class ( Show (ChainDepState   p)
                       => ConsensusConfig       p
                       -> ValidateView          p
                       -> SlotNo
-                      -> Ticked (LedgerView    p)
                       -> Ticked (ChainDepState p)
                       -> Except (ValidationErr p) (ChainDepState p)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -139,7 +139,7 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
 
   protocolSecurityParam = bftSecurityParam . bftParams
 
-  checkIsLeader BftConfig{..} (CoreNodeId i) _ (SlotNo n) _ _ =
+  checkIsLeader BftConfig{..} (CoreNodeId i) _ (SlotNo n) _ =
       if n `mod` numCoreNodes == i
       then IsLeader ()
       else NotLeader
@@ -150,7 +150,6 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
   updateChainDepState BftConfig{..}
                       (BftValidateView BftFields{..} signed)
                       (SlotNo n)
-                      _
                       _ =
       -- TODO: Should deal with unknown node IDs
       case verifySignedDSIGN

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -102,16 +102,16 @@ instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
   protocolSecurityParam = protocolSecurityParam . wlsConfigP
   chainSelConfig        = chainSelConfig        . wlsConfigP
 
-  checkIsLeader WLSConfig{..} () _ slot _ _ =
+  checkIsLeader WLSConfig{..} () _ slot _ =
     case Map.lookup slot $ getLeaderSchedule wlsConfigSchedule of
         Nothing -> error $ "WithLeaderSchedule: missing slot " ++ show slot
         Just nids
             | wlsConfigNodeId `elem` nids -> IsLeader ()
             | otherwise                   -> NotLeader
 
-  tickChainDepState   _ _ _ _   = TickedTrivial
-  updateChainDepState _ _ _ _ _ = return ()
-  rewindChainDepState _ _ _ _   = Just ()
+  tickChainDepState   _ _ _ _ = TickedTrivial
+  updateChainDepState _ _ _ _ = return ()
+  rewindChainDepState _ _ _ _ = Just ()
 
 instance ConsensusProtocol p
       => NoUnexpectedThunks (ConsensusConfig (WithLeaderSchedule p))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -55,12 +55,11 @@ instance (Typeable p, Typeable s, ConsensusProtocol p, ChainSelection s)
     type ValidationErr (ModChainSel p s) = ValidationErr   p
     type ValidateView  (ModChainSel p s) = ValidateView    p
 
-    checkIsLeader cfg canBeLeader ledgerView slot chainDepState chainIndepState =
+    checkIsLeader cfg canBeLeader slot chainDepState chainIndepState =
       castLeaderCheck $
         checkIsLeader
           (mcsConfigP cfg)
           canBeLeader
-          ledgerView
           slot
           chainDepState
           chainIndepState

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
@@ -189,11 +189,6 @@ data PBftState c = PBftState {
     }
   deriving (Generic)
 
--- Ticking has no effect on the PBFtState
-newtype instance Ticked (PBftState c) = TickedPBftState {
-      getTickedPBftState :: PBftState c
-    }
-
 {-------------------------------------------------------------------------------
   Invariant
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -114,16 +114,16 @@ instance ConsensusProtocol ProtocolA where
   type ValidateView  ProtocolA = ()
   type ValidationErr ProtocolA = Void
 
-  checkIsLeader CfgA{..} () _ slot _ _ =
+  checkIsLeader CfgA{..} () _ slot _ =
       if slot `Set.member` cfgA_leadInSlots
       then IsLeader ()
       else NotLeader
 
   protocolSecurityParam = cfgA_k
 
-  tickChainDepState   _ _ _ _   = TickedTrivial
-  updateChainDepState _ _ _ _ _ = return ()
-  rewindChainDepState _ _ _ _   = Just ()
+  tickChainDepState   _ _ _ _ = TickedTrivial
+  updateChainDepState _ _ _ _ = return ()
+  rewindChainDepState _ _ _ _ = Just ()
 
 data BlockA = BlkA {
       blkA_header :: Header BlockA

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -101,16 +101,16 @@ instance ConsensusProtocol ProtocolB where
   type ValidateView  ProtocolB = ()
   type ValidationErr ProtocolB = Void
 
-  checkIsLeader CfgB{..} () _ slot _ _ =
+  checkIsLeader CfgB{..} () _ slot _ =
       if slot `Set.member` cfgB_leadInSlots
       then IsLeader ()
       else NotLeader
 
   protocolSecurityParam = cfgB_k
 
-  tickChainDepState   _ _ _ _   = TickedTrivial
-  updateChainDepState _ _ _ _ _ = return ()
-  rewindChainDepState _ _ _ _   = Just ()
+  tickChainDepState   _ _ _ _ = TickedTrivial
+  updateChainDepState _ _ _ _ = return ()
+  rewindChainDepState _ _ _ _ = Just ()
 
 data BlockB = BlkB {
       blkB_header :: Header BlockB


### PR DESCRIPTION
This was leading to unnecessary `error` calls. Instead, if protocols need the ticked ledger view, they can include it in the ticked chain dep state.