### PR TITLE
Do not let d=0 in HFC ThreadNet test (ie revert #2378)

### DIFF
--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -56,7 +56,7 @@ data TestSetup = TestSetup
 
 instance Arbitrary TestSetup where
   arbitrary = do
-    setupD <- (/10)         <$> choose   (0, 10)
+    setupD <- (/10)         <$> choose   (1, 10)
     setupK <- SecurityParam <$> elements [5, 10]
 
     setupTestConfig <- arbitrary
@@ -74,8 +74,7 @@ instance Arbitrary TestSetup where
 
 tests :: TestTree
 tests = testGroup "RealTPraos"
-    [ adjustOption (\(QuickCheckTests n) -> QuickCheckTests $ n `div` 5) $
-      testProperty "simple convergence" $ \setup ->
+    [ testProperty "simple convergence" $ withMaxSuccess 20 $ \setup ->
         prop_simple_real_tpraos_convergence setup
     ]
 


### PR DESCRIPTION
I created this commit via `git revert -m c12c9cd03`

> This reverts commit c12c9cd03e1909c7ad514fbf8404b37e8e2e90fd, reversing changes made to fc548489331cf6a5fab148b1b121e3bf6a6b184f.

---

I've debugged the observed failure https://hydra.iohk.io/build/3393090/nixlog/1 and concluded that `d=0` is not currently supported (at least in the HFC test). Thus this PR reverts PR #2378.

The test runs for exactly two epochs, one Byron and one Shelley. There are no leaders in the Shelley era. I only ever see empty overlay schedules (as expected, since `d=0`) and an empty pool distribution (unexpected, at least by me) when I add tracing to the TPraos leadership check.

```
LedgerView
  { lvProtParams = ...
  , lvOverlaySched = fromList []
  , lvPoolDistr = PoolDistr {unPoolDistr = fromList []}
  , lvGenDelegs = ...
  }
```

(It also fails in the same way, against `origin/master`, if I let it run for exactly 3 epochs.)