### PR TITLE
cleaned cabal files

### DIFF
--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -57,35 +57,34 @@ library
 
   -- other-modules:
   -- other-extensions:
-  build-depends:       base            >=4.12 && <4.13
-                     , async           >=2.1  && <2.3
-                     , bytestring      >=0.10 && <0.11
-                     , containers      >=0.5  && <0.7
+  build-depends:       base            >=4.12  && <4.13
+                     , async           >=2.1   && <2.3
+                     , bytestring      >=0.10  && <0.11
+                     , cborg           >=0.2.1 && <0.3
+                     , containers      >=0.5   && <0.7
+                     , dns                        < 4.0
+                     , iproute         >=1.7   && < 1.8
                      , mtl
                      , stm
                      , text
                      , time
 
-                     , cborg           >=0.2.1 && <0.3
-                     , io-sim-classes  >= 0.1 && < 0.2
-                     , typed-protocols >= 0.1 && < 0.2
-                     , network         >= 3.1 && < 3.2
-                     , network-mux     >= 0.1 && < 0.2
+                     , cardano-prelude
                      , contra-tracer
-                     , Win32-network   >= 0.1 && < 0.2
-                     , dns                       < 4.0
-                     , iproute         >= 1.7.0 && < 1.8
+
+                     , io-sim-classes  >=0.1   && < 0.2
+                     , network         >=3.1   && < 3.2
+                     , network-mux     >=0.1   && < 0.2
+                     , typed-protocols >=0.1   && < 0.2
+                     , Win32-network   >=0.1   && < 0.2
 
                        -- Used by the handshake protocol for now
-                     , serialise       >=0.2 && <0.3
+                     , serialise       >=0.2   && <0.3
                        -- Remove once codec is defined locally
                      , typed-protocols-examples
-                       -- Drop dep once use of Data.Semigroup.Action is removed
-                     , cardano-prelude
 
   if os(windows)
-    build-depends:     Win32-network   <  0.2.0.0,
-                       Win32           >= 2.5.4.1 && <2.9
+    build-depends:     Win32           >= 2.5.4.1 && <2.9
 
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -114,32 +113,33 @@ test-suite ouroboros-network-framework-tests
 
   build-depends:       base
                      , bytestring
+                     , cborg
                      , containers
                      , directory
+                     , dns
+                     , iproute
+                     , network
+                     , serialise
                      , text
                      , time
 
-                     , cborg
-                     , serialise
-                     , io-sim-classes
-                     , typed-protocols
-                     , typed-protocols-examples
-                     , network         >= 3.1
-                     , network-mux     >= 0.1 && < 0.2
-                     , ouroboros-network-framework
-                     , ouroboros-network-testing
-                     , contra-tracer
-                     , dns
-                     , iproute
-
-                     , io-sim
                      , QuickCheck
                      , tasty
                      , tasty-quickcheck
 
+                     , contra-tracer
+
+                     , io-sim
+                     , io-sim-classes
+                     , network-mux
+                     , ouroboros-network-framework
+                     , ouroboros-network-testing
+                     , typed-protocols
+                     , typed-protocols-examples
+
   if os(windows)
-    build-depends:     Win32-network   <  0.2.0.0,
-                       Win32           >= 2.5.4.1 && <2.9
+    build-depends:     Win32-network                <0.2,
+                       Win32           >=2.5.4.1 && <2.9
 
   default-language:    Haskell2010
   ghc-options:         -rtsopts
@@ -162,20 +162,22 @@ executable demo-ping-pong
                        bytestring,
                        cborg,
                        containers,
-                       contra-tracer,
                        directory,
-                       network-mux,
                        network,
-                       ouroboros-network-framework,
-                       io-sim-classes,
                        stm,
                        text,
+
+                       contra-tracer,
+
+                       io-sim-classes,
+                       network-mux,
+                       ouroboros-network-framework,
                        typed-protocols,
                        typed-protocols-examples
 
   if os(windows)
-    build-depends:     Win32-network   <  0.2.0.0,
-                       Win32           >= 2.5.4.1 && <2.9
+    build-depends:     Win32-network                <0.2,
+                       Win32           >=2.5.4.1 && <2.9
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -131,33 +131,33 @@ library
                        TypeFamilies,
                        TypeInType
   build-depends:       base              >=4.9 && <4.13,
-                       network-mux       >=0.1 && <1.0,
-                       typed-protocols   >=0.1 && < 1.0,
-                       ouroboros-network-framework
-                                         >=0.1 && <1.0,
-                       io-sim-classes    >=0.1 && < 0.2,
-
-                       contra-tracer,
-
                        async             >=2.2 && <2.3,
                        base16-bytestring,
                        binary            >=0.8 && <0.9,
                        bytestring        >=0.10 && <0.11,
-                       cardano-binary,
-                       cardano-prelude,
-                       cardano-slotting,
                        cborg             >=0.2.1 && <0.3,
                        containers,
                        directory,
                        dns,
-                       mtl,
                        fingertree        >=0.1.4.2 && <0.2,
                        iproute,
+                       mtl,
                        network           >=3.1 && <3.2,
                        psqueues          >=0.2.3 && <0.3,
                        serialise         >=0.2 && <0.3,
                        stm               >=2.4 && <2.6,
-                       time              >=1.6 && <1.10
+                       time              >=1.6 && <1.10,
+
+                       cardano-binary,
+                       cardano-prelude,
+                       cardano-slotting,
+                       contra-tracer,
+
+                       io-sim-classes    >=0.1 && < 0.2,
+                       network-mux       >=0.1 && <1.0,
+                       ouroboros-network-framework
+                                         >=0.1 && <1.0,
+                       typed-protocols   >=0.1 && < 1.0
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
@@ -217,13 +217,14 @@ library ouroboros-protocol-tests
                        text,
 
                        cardano-prelude,
-
                        contra-tracer,
+
                        io-sim,
                        io-sim-classes,
-                       typed-protocols,
+                       ouroboros-network,
                        ouroboros-network-framework,
-                       ouroboros-network
+                       typed-protocols
+
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
 
@@ -247,43 +248,45 @@ test-suite test-network
                        Test.Version
   default-language:    Haskell2010
   build-depends:       base,
+                       QuickCheck,
                        array,
                        async,
                        binary,
                        bytestring,
-                       cardano-binary,
-                       cardano-prelude,
-                       cardano-slotting,
                        cborg,
                        containers,
-                       contra-tracer,
                        directory,
                        dns,
                        fingertree,
                        hashable,
-                       io-sim            >=0.1 && < 0.2,
-                       io-sim-classes,
                        iproute,
                        mtl,
-                       network-mux       >=0.1 && <0.2,
                        network,
-                       psqueues,
-                       ouroboros-network-testing,
                        pipes,
                        process,
-                       QuickCheck,
+                       psqueues,
                        serialise,
                        splitmix,
                        stm,
+                       tasty,
                        tasty-hunit,
                        tasty-quickcheck,
-                       tasty,
                        text,
                        time,
-                       typed-protocols,
-                       ouroboros-network-framework,
+
+                       cardano-binary,
+                       cardano-prelude,
+                       cardano-slotting,
+                       contra-tracer,
+
+                       io-sim,
+                       io-sim-classes,
+                       network-mux,
                        ouroboros-network,
-                       ouroboros-protocol-tests
+                       ouroboros-network-framework,
+                       ouroboros-network-testing,
+                       ouroboros-protocol-tests,
+                       typed-protocols
 
   if os(windows)
     build-depends:     Win32-network                 <0.2.0.0,
@@ -307,30 +310,34 @@ test-suite test-cddl
   default-language:    Haskell2010
   build-depends:       base,
                        bytestring,
-                       cardano-binary,
-                       cardano-prelude,
-                       cardano-slotting,
                        cborg,
                        containers,
-                       contra-tracer,
                        directory,
                        filepath,
                        fingertree,
                        hashable,
+                       pipes,
+                       process-extras,
+                       serialise,
+                       text,
+
+                       QuickCheck,
+                       tasty,
+                       tasty-quickcheck,
+
+                       cardano-binary,
+                       cardano-prelude,
+                       cardano-slotting,
+                       contra-tracer,
+
                        io-sim,
                        io-sim-classes,
                        network-mux,
-                       pipes,
-                       process-extras,
-                       QuickCheck,
-                       serialise,
-                       tasty,
-                       tasty-quickcheck,
-                       text,
                        typed-protocols,
                        ouroboros-network-framework,
                        ouroboros-network,
                        ouroboros-protocol-tests
+
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -fno-ignore-asserts
@@ -342,18 +349,22 @@ executable demo-chain-sync
                        async,
                        bytestring,
                        containers,
-                       contra-tracer,
                        directory,
-                       network-mux,
                        network,
-                       ouroboros-network-framework,
-                       ouroboros-network,
-                       QuickCheck,
                        random,
                        serialise,
                        splitmix,
                        stm,
-                       typed-protocols
+
+                       QuickCheck,
+
+                       contra-tracer,
+
+                       network-mux,
+                       typed-protocols,
+                       ouroboros-network-framework,
+                       ouroboros-network
+
   default-language:    Haskell2010
   ghc-options:         -Wall
                        -threaded


### PR DESCRIPTION
I just wanted to remove a stale comment:

> Drop dep once use of Data.Semigroup.Action is removed

in `ouroboros-network-framework.cabal` file, but I ended up cleaning it a bit more.


- cleaned ouroboros-netowrk-framework.cabal file
- cleaned ouroboros-network.cabal file
