### PR TITLE
Avoid recomputing the ShelleyLedgerConfig

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -342,10 +342,13 @@ protocolInfoCardano genesisByron mSigThresh pVer sVer mbCredsByron
     partialConsensusConfigShelley = tpraosParams
 
     partialLedgerConfigShelley :: PartialLedgerConfig (ShelleyBlock sc)
-    partialLedgerConfigShelley = ShelleyPartialLedgerConfig {
-        shelleyPartialLedgerGenesis = genesisShelley
-      , shelleyPartialMaxMajorPV    = maxMajorPV
-      }
+    partialLedgerConfigShelley = ShelleyPartialLedgerConfig $
+        Shelley.mkShelleyLedgerConfig
+          genesisShelley
+          -- 'completeLedgerConfig' will replace the 'History.dummyEpochInfo'
+          -- in the partial ledger config with the correct one.
+          History.dummyEpochInfo
+          maxMajorPV
 
     kShelley :: SecurityParam
     kShelley = SecurityParam $ sgSecurityParam genesisShelley

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
@@ -6,6 +6,7 @@
 module Ouroboros.Consensus.HardFork.History.EpochInfo (
     summaryToEpochInfo
   , snapshotEpochInfo
+  , dummyEpochInfo
   ) where
 
 import           Data.Functor.Identity
@@ -53,3 +54,13 @@ snapshotEpochInfo summary = EpochInfo {
   where
     runQueryPure' :: HasCallStack => Qry a -> Identity a
     runQueryPure' = Identity . flip runQueryPure summary
+
+-- | A dummy 'EpochInfo' that always throws an 'error'.
+--
+-- To be used as a placeholder before a summary is available.
+dummyEpochInfo :: EpochInfo Identity
+dummyEpochInfo = EpochInfo {
+      epochInfoSize_  = \_ -> error "dummyEpochInfo used"
+    , epochInfoFirst_ = \_ -> error "dummyEpochInfo used"
+    , epochInfoEpoch_ = \_ -> error "dummyEpochInfo used"
+    }


### PR DESCRIPTION
In #2375, we discovered that validating a Byron chain took 10x as long using
`CardanoBlock` than using `ByronBlock`.

Looking at the profiling report, we see it being dominated by:

```
exp' src/Shelley/Spec/NonIntegral.hs:(171,1)-(175,43) 52.1 56.7
ln'  src/Shelley/Spec/NonIntegral.hs:(159,1)-(162,27) 22.7 26.1
```

Which is strange, as we're validating a Byron-only chain! It turns out that
these two functions are called by `mkActiveSlotCoeff`, which is called as part
of `mkShelleyLedgerConfig`, which we are calling in `completeLedgerConfig`. This
happens for *each* block.

To fix this, we replace the partial ledger config of Shelley with a non-partial
one containing a dummy `EpochInfo Identity`. In `completeLedgerConfig` we
replace the dummy `EpochInfo Identity` with the correct one. This means we only
call `mkShelleyLedgerConfig` once and cache its result.