### PR TITLE
Enable the KeepAlive responder

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -33,6 +33,7 @@ module Ouroboros.Consensus.Network.NodeToNode (
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
 import           Codec.Serialise (Serialise)
+import           Control.Monad (forever)
 import           Control.Monad.Class.MonadTimer (MonadTimer)
 import           Control.Tracer
 import           Data.ByteString.Lazy (ByteString)
@@ -48,6 +49,7 @@ import           Ouroboros.Network.BlockFetch.Client (BlockFetchClient,
 import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec
 import           Ouroboros.Network.Driver
+import           Ouroboros.Network.KeepAlive
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.NodeToNode
 import           Ouroboros.Network.Protocol.BlockFetch.Codec
@@ -59,6 +61,9 @@ import           Ouroboros.Network.Protocol.ChainSync.Codec
 import           Ouroboros.Network.Protocol.ChainSync.PipelineDecision
 import           Ouroboros.Network.Protocol.ChainSync.Server
 import           Ouroboros.Network.Protocol.ChainSync.Type
+import           Ouroboros.Network.Protocol.KeepAlive.Codec
+import           Ouroboros.Network.Protocol.KeepAlive.Server
+import           Ouroboros.Network.Protocol.KeepAlive.Type
 import           Ouroboros.Network.Protocol.TxSubmission.Client
 import           Ouroboros.Network.Protocol.TxSubmission.Codec
 import           Ouroboros.Network.Protocol.TxSubmission.Server
@@ -123,6 +128,11 @@ data Handlers m peer blk = Handlers {
         :: NodeToNodeVersion
         -> peer
         -> TxSubmissionServerPipelined (GenTxId blk) (GenTx blk) m ()
+
+    , hKeepAliveServer
+        :: NodeToNodeVersion
+        -> peer
+        -> KeepAliveServer m ()
     }
 
 mkHandlers
@@ -173,6 +183,7 @@ mkHandlers
             (getMempoolReader getMempool)
             (getMempoolWriter getMempool)
             version
+      , hKeepAliveServer = \_version _peer -> keepAliveServer
       }
 
 {-------------------------------------------------------------------------------
@@ -180,12 +191,13 @@ mkHandlers
 -------------------------------------------------------------------------------}
 
 -- | Node-to-node protocol codecs needed to run 'Handlers'.
-data Codecs blk e m bCS bSCS bBF bSBF bTX = Codecs {
+data Codecs blk e m bCS bSCS bBF bSBF bTX bKA = Codecs {
       cChainSyncCodec            :: Codec (ChainSync (Header blk) (Tip blk))           e m bCS
     , cChainSyncCodecSerialised  :: Codec (ChainSync (SerialisedHeader blk) (Tip blk)) e m bSCS
     , cBlockFetchCodec           :: Codec (BlockFetch blk)                             e m bBF
     , cBlockFetchCodecSerialised :: Codec (BlockFetch (Serialised blk))                e m bSBF
     , cTxSubmissionCodec         :: Codec (TxSubmission (GenTxId blk) (GenTx blk))     e m bTX
+    , cKeepAliveCodec            :: Codec KeepAlive                                    e m bKA
     }
 
 -- | Protocol codecs for the node-to-node protocols
@@ -193,7 +205,7 @@ defaultCodecs :: forall m blk. (IOLike m, SerialiseNodeToNodeConstraints blk)
               => CodecConfig       blk
               -> BlockNodeToNodeVersion blk
               -> Codecs blk DeserialiseFailure m
-                   ByteString ByteString ByteString ByteString ByteString
+                   ByteString ByteString ByteString ByteString ByteString ByteString
 defaultCodecs ccfg version = Codecs {
       cChainSyncCodec =
         codecChainSync
@@ -233,6 +245,9 @@ defaultCodecs ccfg version = Codecs {
           dec
           enc
           dec
+
+    , cKeepAliveCodec =
+        codecKeepAlive
     }
   where
     p :: Proxy blk
@@ -252,12 +267,14 @@ identityCodecs :: Monad m
                     (AnyMessage (BlockFetch blk))
                     (AnyMessage (BlockFetch (Serialised blk)))
                     (AnyMessage (TxSubmission (GenTxId blk) (GenTx blk)))
+                    (AnyMessage KeepAlive)
 identityCodecs = Codecs {
       cChainSyncCodec            = codecChainSyncId
     , cChainSyncCodecSerialised  = codecChainSyncId
     , cBlockFetchCodec           = codecBlockFetchId
     , cBlockFetchCodecSerialised = codecBlockFetchId
     , cTxSubmissionCodec         = codecTxSubmissionId
+    , cKeepAliveCodec            = codecKeepAliveId
     }
 
 {-------------------------------------------------------------------------------
@@ -324,7 +341,7 @@ showTracers tr = Tracers {
 -- | Applications for the node-to-node protocols
 --
 -- See 'Network.Mux.Types.MuxApplication'
-data Apps m peer bCS bBF bTX a = Apps {
+data Apps m peer bCS bBF bTX bKA a = Apps {
       -- | Start a chain sync client that communicates with the given upstream
       -- node.
       aChainSyncClient    :: NodeToNodeVersion -> peer -> Channel m bCS -> m (a, Maybe bCS)
@@ -345,11 +362,17 @@ data Apps m peer bCS bBF bTX a = Apps {
 
       -- | Start a transaction submission server.
     , aTxSubmissionServer :: NodeToNodeVersion -> peer -> Channel m bTX -> m (a, Maybe bTX)
+
+      -- | Start a keep-alive client.
+    , aKeepAliveClient :: NodeToNodeVersion -> peer -> Channel m bKA -> m (a, Maybe bKA)
+
+      -- | Start a keep-alive server.
+    , aKeepAliveServer :: NodeToNodeVersion -> peer -> Channel m bKA -> m (a, Maybe bKA)
     }
 
 -- | Construct the 'NetworkApplication' for the node-to-node protocols
 mkApps
-  :: forall m remotePeer localPeer blk e bCS bBF bTX.
+  :: forall m remotePeer localPeer blk e bCS bBF bTX bKA.
      ( IOLike m
      , MonadTimer m
      , Ord remotePeer
@@ -358,10 +381,10 @@ mkApps
      )
   => NodeKernel m remotePeer localPeer blk -- ^ Needed for bracketing only
   -> Tracers m remotePeer blk e
-  -> Codecs blk e m bCS bCS bBF bBF bTX
+  -> Codecs blk e m bCS bCS bBF bBF bTX bKA
   -> m ChainSyncTimeout
   -> Handlers m remotePeer blk
-  -> Apps m remotePeer bCS bBF bTX ()
+  -> Apps m remotePeer bCS bBF bTX bKA ()
 mkApps kernel Tracers {..} Codecs {..} genChainSyncTimeout Handlers {..} =
     Apps {..}
   where
@@ -477,6 +500,32 @@ mkApps kernel Tracers {..} Codecs {..} genChainSyncTimeout Handlers {..} =
         channel
         (txSubmissionServerPeerPipelined (hTxSubmissionServer version them))
 
+    aKeepAliveClient
+      :: NodeToNodeVersion
+      -> remotePeer
+      -> Channel m bKA
+      -> m ((), Maybe bKA)
+    aKeepAliveClient _version _them _channel = do
+      labelThisThread "KeepAliveClient"
+      -- TODO implement the client
+      forever (threadDelay 1000) >> return ((), Nothing)
+
+    aKeepAliveServer
+      :: NodeToNodeVersion
+      -> remotePeer
+      -> Channel m bKA
+      -> m ((), Maybe bKA)
+    aKeepAliveServer _version _them channel = do
+      labelThisThread "KeepAliveServer"
+      runPeerWithLimits
+        nullTracer
+        cKeepAliveCodec
+        (byteLimitsKeepAlive (const 0)) -- TODO: Real Bytelimits, see #1727
+        timeLimitsKeepAlive
+        channel
+        $ keepAliveServerPeer
+        $ keepAliveServer
+
 {-------------------------------------------------------------------------------
   Projections from 'Apps'
 -------------------------------------------------------------------------------}
@@ -490,7 +539,7 @@ mkApps kernel Tracers {..} Codecs {..} genChainSyncTimeout Handlers {..} =
 initiator
   :: MiniProtocolParameters
   -> NodeToNodeVersion
-  -> Apps m (ConnectionId peer) b b b a
+  -> Apps m (ConnectionId peer) b b b b a
   -> OuroborosApplication 'InitiatorMode peer b m a Void
 initiator miniProtocolParameters version Apps {..} =
     nodeToNodeProtocols
@@ -507,7 +556,9 @@ initiator miniProtocolParameters version Apps {..} =
           blockFetchProtocol =
             (InitiatorProtocolOnly (MuxPeerRaw (aBlockFetchClient version them))),
           txSubmissionProtocol =
-            (InitiatorProtocolOnly (MuxPeerRaw (aTxSubmissionClient version them)))
+            (InitiatorProtocolOnly (MuxPeerRaw (aTxSubmissionClient version them))),
+          keepAliveProtocol =
+            (InitiatorProtocolOnly (MuxPeerRaw (aKeepAliveClient version them)))
         })
 
 -- | A projection from 'NetworkApplication' to a server-side
@@ -517,7 +568,7 @@ initiator miniProtocolParameters version Apps {..} =
 responder
   :: MiniProtocolParameters
   -> NodeToNodeVersion
-  -> Apps m (ConnectionId peer) b b b a
+  -> Apps m (ConnectionId peer) b b b b a
   -> OuroborosApplication 'ResponderMode peer b m Void a
 responder miniProtocolParameters version Apps {..} =
     nodeToNodeProtocols
@@ -528,5 +579,8 @@ responder miniProtocolParameters version Apps {..} =
           blockFetchProtocol =
             (ResponderProtocolOnly (MuxPeerRaw (aBlockFetchServer version them))),
           txSubmissionProtocol =
-            (ResponderProtocolOnly (MuxPeerRaw (aTxSubmissionServer version them)))
+            (ResponderProtocolOnly (MuxPeerRaw (aTxSubmissionServer version them))),
+          keepAliveProtocol =
+            (ResponderProtocolOnly (MuxPeerRaw (aKeepAliveServer version them)))
+
         })

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -250,7 +250,7 @@ run runargs@RunNodeArgs{..} =
       :: NodeArgs   IO RemoteConnectionId LocalConnectionId blk
       -> NodeKernel IO RemoteConnectionId LocalConnectionId blk
       -> BlockNodeToNodeVersion blk
-      -> NTN.Apps IO RemoteConnectionId ByteString ByteString ByteString ()
+      -> NTN.Apps IO RemoteConnectionId ByteString ByteString ByteString ByteString ()
     mkNodeToNodeApps nodeArgs nodeKernel version =
         NTN.mkApps
           nodeKernel
@@ -291,7 +291,7 @@ run runargs@RunNodeArgs{..} =
     mkDiffusionApplications
       :: MiniProtocolParameters
       -> (   BlockNodeToNodeVersion blk
-          -> NTN.Apps IO RemoteConnectionId ByteString ByteString ByteString ()
+          -> NTN.Apps IO RemoteConnectionId ByteString ByteString ByteString ByteString ()
          )
       -> (   BlockNodeToClientVersion blk
           -> NTC.Apps IO LocalConnectionId      ByteString ByteString ByteString ()

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/KeepAlive/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/KeepAlive/Test.hs
@@ -17,6 +17,7 @@ import           Control.Tracer (nullTracer)
 import qualified Codec.CBOR.Read  as CBOR
 import           Data.Functor.Identity (Identity (..))
 import           Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy as BL
 
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Proofs
@@ -164,4 +165,4 @@ prop_byteLimits (AnyMessageAndAgency agency msg) =
      <= sizeLimitForState agency  
   where
     Codec { encode } = (codecKeepAlive :: Codec KeepAlive CBOR.DeserialiseFailure IO ByteString)
-    ProtocolSizeLimits { sizeLimitForState, dataSize } = byteLimitsKeepAlive
+    ProtocolSizeLimits { sizeLimitForState, dataSize } = byteLimitsKeepAlive (fromIntegral . BL.length)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -160,7 +160,12 @@ data NodeToNodeProtocols appType bytes m a b = NodeToNodeProtocols {
 
     -- | tx-submission mini-protocol
     --
-    txSubmissionProtocol :: RunMiniProtocol appType bytes m a b
+    txSubmissionProtocol :: RunMiniProtocol appType bytes m a b,
+
+    -- | keep-alive mini-protocol
+    --
+    keepAliveProtocol :: RunMiniProtocol appType bytes m a b
+
   }
 
 
@@ -228,7 +233,8 @@ nodeToNodeProtocols MiniProtocolParameters {
       NodeToNodeProtocols {
           chainSyncProtocol,
           blockFetchProtocol,
-          txSubmissionProtocol
+          txSubmissionProtocol,
+          keepAliveProtocol
         } ->
         [
           MiniProtocol {
@@ -245,6 +251,11 @@ nodeToNodeProtocols MiniProtocolParameters {
             miniProtocolNum    = MiniProtocolNum 4,
             miniProtocolLimits = txSubmissionProtocolLimits,
             miniProtocolRun    = txSubmissionProtocol
+          }
+        , MiniProtocol {
+            miniProtocolNum    = MiniProtocolNum 8,
+            miniProtocolLimits = keepAliveProtocolLimits,
+            miniProtocolRun    = keepAliveProtocol
           }
         ]
   where
@@ -353,6 +364,12 @@ nodeToNodeProtocols MiniProtocolParameters {
           --
           maximumIngressQueue = addSafetyMargin $
               fromIntegral txSubmissionMaxUnacked * (44 + 65_540)
+        }
+
+    keepAliveProtocolLimits =
+      MiniProtocolLimits {
+          -- One small outstanding message.
+          maximumIngressQueue = addSafetyMargin 1280
         }
 
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -26,7 +26,7 @@ data NodeToNodeVersion
     -- ^ Changes:
     --
     -- * Enable block size hints for Byron headers in ChainSync
-    --
+    -- * Enable Keep-Alive miniprotocol
     -- * Enable @CardanoNodeToNodeVersion2@
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 


### PR DESCRIPTION
Enable the responder side of the KeepAlive protocol for `NodeToNodeV_2`.
This makes it possible to take advantage of the KeepAlive protocol as soon as the initiator side is ready instead of having to wait for a new protocol version to be deployed.