### PR TITLE
Use 2^6 KES periods rather than 2^7

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
@@ -50,7 +50,7 @@ data TPraosStandardCrypto
 
 instance Crypto TPraosStandardCrypto where
   type DSIGN    TPraosStandardCrypto = Ed25519DSIGN
-  type KES      TPraosStandardCrypto = Sum7KES Ed25519DSIGN Blake2b_256
+  type KES      TPraosStandardCrypto = Sum6KES Ed25519DSIGN Blake2b_256
   type VRF      TPraosStandardCrypto = PraosVRF
   type HASH     TPraosStandardCrypto = Blake2b_256
   type ADDRHASH TPraosStandardCrypto = Blake2b_224


### PR DESCRIPTION
So instead of 24hr KES periods we will use 36hr ones, and still get 90
days within 64 periods. This makes better use of the space than 128
periods of 24hrs that we chop off at 90 days.

It also brings the header size to under 1kb.