### PR TITLE
Remove the duplication between ProtocolMagicId and NetworkMagic

### DIFF
--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -100,6 +100,7 @@ executable db-converter
                      , streaming
                      , text
 
+                     , ouroboros-network
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Orphans.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Orphans.hs
@@ -129,6 +129,9 @@ instance Condense (CC.AMempoolPayload a) where
     condense (CC.MempoolUpdateVote vote) =
       "updatevote: " <> unpack (sformat build (void vote))
 
+instance Condense Cardano.Crypto.VerificationKey where
+  condense = unpack . sformat build
+
 {-------------------------------------------------------------------------------
   NoUnexpectedThunks
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -197,8 +197,6 @@ instance ConfigSupportsNode ByronBlock where
     . Genesis.gdProtocolMagicId
     . extractGenesisData
 
-  getProtocolMagicId = byronProtocolMagicId
-
 extractGenesisData :: BlockConfig ByronBlock -> Genesis.GenesisData
 extractGenesisData = Genesis.configGenesisData . byronGenesisConfig
 

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -86,7 +86,6 @@ test-suite test
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class
-                     , cardano-crypto-wrapper
                      , cardano-ledger
                      , cardano-ledger-test
                      , cardano-slotting
@@ -184,6 +183,7 @@ executable db-validator
                      , ouroboros-consensus-byron
                      , ouroboros-consensus-cardano
                      , ouroboros-consensus-shelley
+                     , ouroboros-network
 
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
@@ -21,10 +21,9 @@ import           System.FilePath ((</>))
 
 import           Cardano.Slotting.Slot
 
-import           Cardano.Crypto.ProtocolMagic
-
 import           Ouroboros.Network.Block (HasHeader (..), HeaderHash,
                      genesisPoint)
+import           Ouroboros.Network.Magic
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -59,20 +58,20 @@ main = do
       Just Cardano -> analyse cmdLine (Proxy @(CardanoBlock TPraosStandardCrypto))
       Nothing -> do
         -- check the dbmarker of the db if the block type is not specified.
-        protocolMagicId <- readDBMarker clImmDB
-        case unProtocolMagicId protocolMagicId of
+        networkMagic <- readDBMarker clImmDB
+        case unNetworkMagic networkMagic of
           764824073  -> analyse cmdLine (Proxy @ByronBlock)
           1097911063 -> analyse cmdLine (Proxy @ByronBlock)
           42         -> analyse cmdLine (Proxy @(ShelleyBlock TPraosStandardCrypto))
-          _          -> error $ "unsupported protocolMagicId: " ++ show protocolMagicId
+          _          -> error $ "unsupported networkMagic: " ++ show networkMagic
 
-readDBMarker :: FilePath -> IO ProtocolMagicId
+readDBMarker :: FilePath -> IO NetworkMagic
 readDBMarker dbPath = do
     bs <- BS.readFile markerPath
-    protocolMagicId <- runExceptT $ dbMarkerParse markerPath bs
+    networkMagic <- runExceptT $ dbMarkerParse markerPath bs
     return $ fromRight
-      (error "failed to parse protocolMagicId from db Marker file")
-      protocolMagicId
+      (error "failed to parse networkMagic from db Marker file")
+      networkMagic
   where
     markerPath = dbPath </> Text.unpack dbMarkerFile
 

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -32,7 +32,6 @@ library
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class
-                     , cardano-crypto-wrapper
                      , cardano-prelude
                      , cardano-slotting
                      , containers        >=0.5   && <0.7
@@ -79,7 +78,6 @@ test-suite test
                      , bytestring
                      , cardano-binary
                      , cardano-crypto-class
-                     , cardano-crypto-wrapper
                      , cardano-prelude
                      , cardano-slotting
                      , cborg             >=0.2.2 && <0.3

--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -50,7 +50,6 @@ library
                      , cardano-binary
                      , cardano-crypto-class
                      , cardano-crypto-praos
-                     , cardano-crypto-wrapper
                      , cardano-prelude
                      , cardano-slotting
                      , cborg             >=0.2.2 && <0.3

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
@@ -13,7 +13,6 @@ module Ouroboros.Consensus.Shelley.Ledger.Config (
 
 import           GHC.Generics (Generic)
 
-import           Cardano.Crypto (ProtocolMagicId (..))
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 
 import           Ouroboros.Network.Magic (NetworkMagic (..))
@@ -44,7 +43,6 @@ data instance BlockConfig (ShelleyBlock c) = ShelleyConfig {
       shelleyProtocolVersion :: !SL.ProtVer
     , shelleySystemStart     :: !SystemStart
     , shelleyNetworkMagic    :: !NetworkMagic
-    , shelleyProtocolMagicId :: !ProtocolMagicId
       -- | When chain selection is comparing two fragments, it will prefer the
       -- fragment with a tip signed by this key (provided that the 'BlockNo's
       -- and 'SlotNo's of the two tips are equal). For nodes that can produce
@@ -65,7 +63,6 @@ mkShelleyBlockConfig protVer genesis blockIssuerVKey = ShelleyConfig {
       shelleyProtocolVersion = protVer
     , shelleySystemStart     = SystemStart     $ SL.sgSystemStart  genesis
     , shelleyNetworkMagic    = NetworkMagic    $ SL.sgNetworkMagic genesis
-    , shelleyProtocolMagicId = ProtocolMagicId $ SL.sgNetworkMagic genesis
     , shelleyBlockIssuerVKey = blockIssuerVKey
     }
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -336,9 +336,8 @@ instance InspectLedger (ShelleyBlock c) where
 -------------------------------------------------------------------------------}
 
 instance ConfigSupportsNode (ShelleyBlock c) where
-  getSystemStart     = shelleySystemStart
-  getNetworkMagic    = shelleyNetworkMagic
-  getProtocolMagicId = shelleyProtocolMagicId
+  getSystemStart  = shelleySystemStart
+  getNetworkMagic = shelleyNetworkMagic
 
 {-------------------------------------------------------------------------------
   RunNode instance

--- a/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -47,7 +47,6 @@ library
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class
-                     , cardano-crypto-wrapper
                      , cardano-prelude
                      , cardano-slotting
                      , cborg             >=0.2.2 && <0.3

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -93,7 +93,7 @@ instance SignedHeader (SimpleBftHeader c c') where
 instance ( SimpleCrypto c
          , BftCrypto c'
          ) => RunMockBlock c (SimpleBftExt c c') where
-  mockProtocolMagicId = const constructMockProtocolMagicId
+  mockNetworkMagic = const constructMockNetworkMagic
 
 instance ( SimpleCrypto c
          , BftCrypto c'

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -104,7 +104,7 @@ instance ( SimpleCrypto c
          , PBftCrypto c'
          , Serialise (PBftVerKeyHash c')
          ) => RunMockBlock c (SimplePBftExt c c') where
-  mockProtocolMagicId = const constructMockProtocolMagicId
+  mockNetworkMagic = const constructMockNetworkMagic
 
 instance ( SimpleCrypto c
          , Signable MockDSIGN (SignedSimplePBft c PBftMockCrypto)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -108,7 +108,7 @@ instance PraosCrypto c' => SignedHeader (SimplePraosHeader c c') where
 instance ( SimpleCrypto c
          , PraosCrypto c'
          ) => RunMockBlock c (SimplePraosExt c c') where
-  mockProtocolMagicId = const constructMockProtocolMagicId
+  mockNetworkMagic = const constructMockNetworkMagic
 
 instance ( SimpleCrypto c
          , PraosCrypto c'

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -86,7 +86,7 @@ instance SimpleCrypto c => MockProtocolSpecific c SimplePraosRuleExt where
 -------------------------------------------------------------------------------}
 
 instance SimpleCrypto c => RunMockBlock c SimplePraosRuleExt where
-  mockProtocolMagicId = const constructMockProtocolMagicId
+  mockNetworkMagic = const constructMockNetworkMagic
 
 instance
   ( SimpleCrypto c

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
@@ -6,15 +6,13 @@
 module Ouroboros.Consensus.Mock.Node.Abstract (
     CodecConfig(..)
   , RunMockBlock(..)
-  , constructMockProtocolMagicId
+  , constructMockNetworkMagic
   ) where
 
 import           Data.Hashable (hash)
 import           Data.Time.Calendar (fromGregorian)
 import           Data.Time.Clock (UTCTime (..))
 import           GHC.Stack
-
-import           Cardano.Crypto (ProtocolMagicId (..))
 
 import           Ouroboros.Network.Magic (NetworkMagic (..))
 
@@ -31,17 +29,17 @@ class ( MockProtocolSpecific c ext
       , EncodeDisk (SimpleBlock c ext) (ChainDepState (BlockProtocol (SimpleBlock c ext)))
       , DecodeDisk (SimpleBlock c ext) (ChainDepState (BlockProtocol (SimpleBlock c ext)))
       ) => RunMockBlock c ext where
-  mockProtocolMagicId
+  mockNetworkMagic
     :: BlockConfig (SimpleBlock c ext)
-    -> ProtocolMagicId
+    -> NetworkMagic
 
 -- | Construct protocol magic ID depending on where in the code this is called
 --
 -- The sole purpose of this is to make sure that these mock protocols have
 -- different IDs from each other and from regular protocols.
-constructMockProtocolMagicId :: HasCallStack => ProtocolMagicId
-constructMockProtocolMagicId =
-    ProtocolMagicId $ fromIntegral $ hash (prettyCallStack callStack)
+constructMockNetworkMagic :: HasCallStack => NetworkMagic
+constructMockNetworkMagic =
+    NetworkMagic $ fromIntegral $ hash (prettyCallStack callStack)
 
 instance RunMockBlock c ext
       => ConfigSupportsNode (SimpleBlock c ext) where
@@ -49,5 +47,5 @@ instance RunMockBlock c ext
     where
       --  This doesn't matter much
       dummyDate = UTCTime (fromGregorian 2019 8 13) 0
-  getNetworkMagic    = const $ NetworkMagic 0x0000ffff
-  getProtocolMagicId = mockProtocolMagicId
+
+  getNetworkMagic = mockNetworkMagic

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -274,7 +274,6 @@ library
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class
-                     , cardano-crypto-wrapper
                      , cardano-prelude
                      , cardano-slotting
                      , cborg             >=0.2.2 && <0.3
@@ -410,7 +409,6 @@ test-suite test-consensus
   build-depends:       base
                      , cardano-binary
                      , cardano-crypto-class
-                     , cardano-crypto-wrapper
                      , cardano-prelude
                      , cardano-slotting
                      , cborg
@@ -525,7 +523,6 @@ test-suite test-storage
                      , binary
                      , bytestring
                      , cardano-crypto-class
-                     , cardano-crypto-wrapper
                      , cardano-prelude
                      , cardano-slotting
                      , cborg

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config/SupportsNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config/SupportsNode.hs
@@ -2,8 +2,6 @@ module Ouroboros.Consensus.Config.SupportsNode (
     ConfigSupportsNode (..)
   ) where
 
-import           Cardano.Crypto (ProtocolMagicId)
-
 import           Ouroboros.Network.Magic (NetworkMagic)
 
 import           Ouroboros.Consensus.Block.Abstract (BlockConfig)
@@ -12,7 +10,5 @@ import           Ouroboros.Consensus.BlockchainTime (SystemStart)
 -- | The 'BlockConfig' needs to contain some information in order to support
 -- running a node.
 class ConfigSupportsNode blk where
-
-  getSystemStart     :: BlockConfig blk -> SystemStart
-  getNetworkMagic    :: BlockConfig blk -> NetworkMagic
-  getProtocolMagicId :: BlockConfig blk -> ProtocolMagicId
+  getSystemStart  :: BlockConfig blk -> SystemStart
+  getNetworkMagic :: BlockConfig blk -> NetworkMagic

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
@@ -23,9 +23,8 @@ import           Ouroboros.Consensus.HardFork.Combinator.Basics
 
 instance (All ConfigSupportsNode xs, IsNonEmpty xs)
       => ConfigSupportsNode (HardForkBlock xs) where
-  getSystemStart     = getSameConfigValue getSystemStart
-  getNetworkMagic    = getSameConfigValue getNetworkMagic
-  getProtocolMagicId = getSameConfigValue getProtocolMagicId
+  getSystemStart  = getSameConfigValue getSystemStart
+  getNetworkMagic = getSameConfigValue getNetworkMagic
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -166,9 +166,8 @@ data instance BlockConfig (DualBlock m a) = DualBlockConfig {
   deriving NoUnexpectedThunks via AllowThunk (BlockConfig (DualBlock m a))
 
 instance ConfigSupportsNode m => ConfigSupportsNode (DualBlock m a) where
-  getSystemStart     = getSystemStart     . dualBlockConfigMain
-  getNetworkMagic    = getNetworkMagic    . dualBlockConfigMain
-  getProtocolMagicId = getProtocolMagicId . dualBlockConfigMain
+  getSystemStart  = getSystemStart  . dualBlockConfigMain
+  getNetworkMagic = getNetworkMagic . dualBlockConfigMain
 
 {-------------------------------------------------------------------------------
   Splitting the config

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -342,7 +342,7 @@ withDBChecks RunNodeArgs{..} body = do
     either throwM return =<< checkDbMarker
       hasFS
       mountPoint
-      (getProtocolMagicId (configBlock pInfoConfig))
+      (getNetworkMagic (configBlock pInfoConfig))
 
     -- Then create the lock file.
     withLockDB mountPoint $ do

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -21,13 +21,11 @@ import qualified Data.Set as Set
 import           Data.Text (Text, unpack)
 import           Data.Void
 import           Data.Word
-import           Formatting (build, sformat)
 import           Numeric.Natural
 import           Text.Printf (printf)
 
 import           Control.Monad.Class.MonadTime (Time (..))
 
-import           Cardano.Crypto (VerificationKey)
 import           Cardano.Crypto.DSIGN (Ed25519DSIGN, Ed448DSIGN, MockDSIGN,
                      SigDSIGN, pattern SigEd25519DSIGN, pattern SigEd448DSIGN,
                      pattern SigMockDSIGN, SignedDSIGN (..), VerKeyDSIGN)
@@ -165,13 +163,6 @@ instance Condense (HeaderHash b) => Condense (ChainHash b) where
 instance Condense a => Condense (WithOrigin a) where
   condense Origin = "origin"
   condense (At a) = condense a
-
-{-------------------------------------------------------------------------------
-  Orphans for cardano-crypto-wrapper
--------------------------------------------------------------------------------}
-
-instance Condense VerificationKey where
-  condense = unpack . sformat build
 
 {-------------------------------------------------------------------------------
   Orphans for cardano-crypto-classes

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -50,7 +50,6 @@ import           Data.Void
 import           Data.Word
 import           GHC.Generics (Generic)
 
-import           Cardano.Crypto.ProtocolMagic
 import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
 import           Cardano.Slotting.EpochInfo
 
@@ -155,9 +154,8 @@ data instance CodecConfig BlockA = CCfgA
   deriving (Generic, NoUnexpectedThunks)
 
 instance ConfigSupportsNode BlockA where
-  getSystemStart     _ = SystemStart dawnOfTime
-  getNetworkMagic    _ = NetworkMagic 0
-  getProtocolMagicId _ = ProtocolMagicId 0
+  getSystemStart  _ = SystemStart dawnOfTime
+  getNetworkMagic _ = NetworkMagic 0
 
 instance StandardHash BlockA
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -42,7 +42,6 @@ import qualified Data.Set as Set
 import           Data.Void
 import           GHC.Generics (Generic)
 
-import           Cardano.Crypto.ProtocolMagic
 import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
 
 import           Test.Util.Time (dawnOfTime)
@@ -141,9 +140,8 @@ data instance CodecConfig BlockB = CCfgB
   deriving (Generic, NoUnexpectedThunks)
 
 instance ConfigSupportsNode BlockB where
-  getSystemStart     _ = SystemStart dawnOfTime
-  getNetworkMagic    _ = NetworkMagic 0
-  getProtocolMagicId _ = ProtocolMagicId 0
+  getSystemStart  _ = SystemStart dawnOfTime
+  getNetworkMagic _ = NetworkMagic 0
 
 instance StandardHash BlockB
 


### PR DESCRIPTION
They are the same thing, just with different names in different libs. We
are standardising on NetworkMagic so this patch removes most uses of
ProtocolMagicId.