### PR TITLE
Remove mock protocols from ProtocolInfo

### DIFF
--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -54,7 +54,6 @@ library
                      , ouroboros-network
                      , ouroboros-consensus
                      , ouroboros-consensus-byron
-                     , ouroboros-consensus-mock
                      , ouroboros-consensus-shelley
 
   default-language:    Haskell2010


### PR DESCRIPTION
Until quite a while ago, we were using `ProtocolInfo` in our tests, which meant
that `ProtocolInfo` had to include the mock blocks in order for us to run our
tests with the mock blocks.

While it was useful in the beginning to test/demo `cardano-node` with mock
blocks, since the introduction of `ByronBlock`, I don't think anyone has run
`cardano-node` using a mock block in quite a while.

Removing the mock blocks from `ProtocolInfo` will probably allow `cardano-node`
to simplify/remove quite a bit of stuff, e.g., command line argument handling.

Note that initially including the mock blocks in `ProtocolInfo` (in addition to
`ByronBlock`) has served its purpose: a lot of code in `cardano-node` was
written to be parametric in the `blk` type, instead of hard-coding it to
`ByronBlock`, which made it much easier to add support for `ShelleyBlock` and
`CardanoBlock` in the last months.