### PR TITLE
Constrain the version of splitmix used.

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -353,7 +353,7 @@ executable demo-chain-sync
                        network,
                        random,
                        serialise,
-                       splitmix,
+                       splitmix < 0.1,
                        stm,
 
                        QuickCheck,


### PR DESCRIPTION
For some reason splitmix-0.1 drops the dependency on the random
package and so no longer provides the RandomGen class instance.