### PR TITLE
Introduce HasBinaryBlockInfo and make it overridable in SerialiseHFC

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -229,5 +229,3 @@ instance RunNode DualByronBlock where
   -- the dual ledger tests, so integrity and match checks can just use the
   -- concrete implementation
   nodeCheckIntegrity cfg = nodeCheckIntegrity (dualTopLevelConfigMain cfg) . dualBlockMain
-
-  nodeGetBinaryBlockInfo = dualBinaryBlockInfo nodeGetBinaryBlockInfo

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -238,4 +238,3 @@ instance RunNode ByronBlock where
       genesisEBB = forgeEBB (configBlock cfg) (SlotNo 0) (BlockNo 0) GenesisHash
 
   nodeCheckIntegrity     = verifyBlockIntegrity . configBlock
-  nodeGetBinaryBlockInfo = byronBinaryBlockInfo

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
@@ -42,6 +42,9 @@ import           Ouroboros.Consensus.Byron.Protocol
   EncodeDisk & DecodeDisk
 -------------------------------------------------------------------------------}
 
+instance HasBinaryBlockInfo ByronBlock where
+  getBinaryBlockInfo = byronBinaryBlockInfo
+
 instance ImmDbSerialiseConstraints ByronBlock
 instance LgrDbSerialiseConstraints ByronBlock
 instance VolDbSerialiseConstraints ByronBlock

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ByronHFC.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ByronHFC.hs
@@ -77,3 +77,5 @@ instance SerialiseHFC '[ByronBlock] where
   reconstructHfcNestedCtxt _ prefix blockSize =
       mapSomeNestedCtxt NCZ $
         reconstructNestedCtxt (Proxy @(Header ByronBlock)) prefix blockSize
+  getHfcBinaryBlockInfo (DegenBlock b) =
+      getBinaryBlockInfo b

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Serialisation.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Serialisation.hs
@@ -14,7 +14,6 @@ import           Data.Proxy (Proxy (..))
 import           Ouroboros.Network.Block (Serialised (..))
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
 import           Ouroboros.Consensus.Storage.ImmutableDB (BinaryBlockInfo (..))
 import           Ouroboros.Consensus.Util (Dict (..))
@@ -87,7 +86,7 @@ prop_CardanoBinaryBlockInfo blk =
     encodedNestedHeader === extractedHeader
   where
     BinaryBlockInfo { headerOffset, headerSize } =
-      nodeGetBinaryBlockInfo blk
+      getBinaryBlockInfo blk
 
     extractedHeader :: Lazy.ByteString
     extractedHeader =

--- a/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
@@ -353,8 +353,7 @@ withImmDB fp cfg chunkInfo registry = ImmDB.withImmDB args
   where
     args :: ImmDbArgs IO blk
     args = (defaultArgs fp) {
-          immGetBinaryBlockInfo = nodeGetBinaryBlockInfo
-        , immCodecConfig        = configCodec cfg
+          immCodecConfig        = configCodec cfg
         , immChunkInfo          = chunkInfo
         , immValidation         = ValidateMostRecentChunk
         , immCheckIntegrity     = nodeCheckIntegrity cfg

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -370,4 +370,3 @@ instance TPraosCrypto c => RunNode (ShelleyBlock c) where
       TPraosParams { tpraosSlotsPerKESPeriod } =
         tpraosParams $ configConsensus cfg
 
-  nodeGetBinaryBlockInfo   = shelleyBinaryBlockInfo

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
@@ -28,6 +28,9 @@ import           Ouroboros.Consensus.Shelley.Protocol.State (TPraosState)
   EncodeDisk & DecodeDisk
 -------------------------------------------------------------------------------}
 
+instance Crypto c => HasBinaryBlockInfo (ShelleyBlock c) where
+  getBinaryBlockInfo = shelleyBinaryBlockInfo
+
 instance Crypto c => ImmDbSerialiseConstraints (ShelleyBlock c)
 instance Crypto c => LgrDbSerialiseConstraints (ShelleyBlock c)
 instance Crypto c => VolDbSerialiseConstraints (ShelleyBlock c)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -50,4 +50,3 @@ instance ( LedgerSupportsProtocol (SimpleBlock SimpleMockCrypto ext)
   nodeImmDbChunkInfo        = \cfg -> simpleChunkInfo $
     EpochSize $ 10 * maxRollbacks (configSecurityParam cfg)
   nodeCheckIntegrity        = \_ _ -> True
-  nodeGetBinaryBlockInfo    = simpleBlockBinaryBlockInfo

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -16,6 +16,7 @@ module Ouroboros.Consensus.Mock.Node.Serialisation (
 
 import           Codec.Serialise (Serialise, decode, encode)
 import qualified Data.ByteString.Lazy as Lazy
+import           Data.Typeable (Typeable)
 
 import           Ouroboros.Network.Block (Serialised)
 
@@ -40,9 +41,12 @@ type MockBlock ext = SimpleBlock SimpleMockCrypto ext
   We use the default instances relying on 'Serialise' where possible.
 -------------------------------------------------------------------------------}
 
-instance Serialise ext => ImmDbSerialiseConstraints (MockBlock ext)
+instance (Serialise ext, Typeable ext) => HasBinaryBlockInfo (MockBlock ext) where
+  getBinaryBlockInfo = simpleBlockBinaryBlockInfo
+
+instance (Serialise ext, Typeable ext) => ImmDbSerialiseConstraints (MockBlock ext)
 instance RunMockBlock SimpleMockCrypto ext => LgrDbSerialiseConstraints (MockBlock ext)
-instance Serialise ext => VolDbSerialiseConstraints (MockBlock ext)
+instance (Serialise ext, Typeable ext) => VolDbSerialiseConstraints (MockBlock ext)
 instance (Serialise ext, RunMockBlock SimpleMockCrypto ext)
       => SerialiseDiskConstraints  (MockBlock ext)
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -675,7 +675,6 @@ runThreadNetwork systemTime ThreadNetworkArgs
         , cdbGenesis              = return initLedger
         , cdbCheckInFuture        = InFuture.reference (configLedger cfg) InFuture.defaultClockSkew
                                       (OracularClock.finiteSystemTime clock)
-        , cdbGetBinaryBlockInfo   = nodeGetBinaryBlockInfo
         , cdbImmDbCacheConfig     = Index.CacheConfig 2 60
         -- Misc
         , cdbTracer               = instrumentationTracer <> nullDebugTracer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -73,7 +73,6 @@ instance ( RunNode b
 
   nodeImmDbChunkInfo cfg                 = nodeImmDbChunkInfo (project cfg)
   nodeCheckIntegrity cfg (DegenBlock  b) = nodeCheckIntegrity (project cfg) b
-  nodeGetBinaryBlockInfo (DegenBlock  b) = nodeGetBinaryBlockInfo           b
   nodeBlockFetchSize     (DegenHeader h) = nodeBlockFetchSize               h
 
   nodeInitChainDB cfg = nodeInitChainDB (project cfg) . contramap DegenBlock

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation.hs
@@ -10,6 +10,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common as
                      SerialiseHFC (..), isHardForkNodeToClientEnabled,
                      isHardForkNodeToNodeEnabled)
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk as X
+                     ()
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient as X
                      ()
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -404,7 +404,6 @@ mkChainDbArgs tracer registry inFuture dbPath cfg initLedger
     { ChainDB.cdbBlocksPerFile      = mkBlocksPerFile 1000
     , ChainDB.cdbChunkInfo          = chunkInfo
     , ChainDB.cdbGenesis            = return initLedger
-    , ChainDB.cdbGetBinaryBlockInfo = nodeGetBinaryBlockInfo
     , ChainDB.cdbDiskPolicy         = defaultDiskPolicy k
     , ChainDB.cdbCheckIntegrity     = nodeCheckIntegrity cfg
     , ChainDB.cdbParamsLgrDB        = ledgerDbDefaultParams k

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -41,7 +41,6 @@ import           Ouroboros.Consensus.Storage.ChainDB (ImmDbSerialiseConstraints,
                      VolDbSerialiseConstraints)
 import           Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB)
 import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
-import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
 import           Ouroboros.Consensus.Storage.ImmutableDB (ChunkInfo)
 
 {-------------------------------------------------------------------------------
@@ -79,6 +78,7 @@ class ( LedgerSupportsProtocol           blk
       , ConfigSupportsNode               blk
       , ConvertRawHash                   blk
       , CommonProtocolParams             blk
+      , HasBinaryBlockInfo               blk
       , SerialiseDiskConstraints         blk
       , SerialiseNodeToNodeConstraints   blk
       , SerialiseNodeToClientConstraints blk
@@ -105,10 +105,6 @@ class ( LedgerSupportsProtocol           blk
   -- whether the transactions are valid w.r.t. the ledger, or whether it's
   -- sent by a malicious node.
   nodeCheckIntegrity :: TopLevelConfig blk -> blk -> Bool
-
-  -- | Return information about the serialised block, i.e., how to extract the
-  -- bytes corresponding to the header from the serialised block.
-  nodeGetBinaryBlockInfo :: blk -> BinaryBlockInfo
 
   -- | This function is called when starting up the node, right after the
   -- ChainDB was opened, and before we connect to other nodes and start block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -21,8 +21,7 @@ import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
 import           Ouroboros.Consensus.Storage.FS.API
 
-import           Ouroboros.Consensus.Storage.ChainDB.Impl.ImmDB
-                     (BinaryBlockInfo (..), ChunkInfo)
+import           Ouroboros.Consensus.Storage.ChainDB.Impl.ImmDB (ChunkInfo)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.ImmDB as ImmDB
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB as LgrDB
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Types
@@ -36,33 +35,32 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.VolDB as VolDB
 data ChainDbArgs m blk = forall h1 h2 h3. (Eq h1, Eq h2, Eq h3) => ChainDbArgs {
 
       -- HasFS instances
-      cdbHasFSImmDb         :: HasFS m h1
-    , cdbHasFSVolDb         :: HasFS m h2
-    , cdbHasFSLgrDB         :: HasFS m h3
+      cdbHasFSImmDb       :: HasFS m h1
+    , cdbHasFSVolDb       :: HasFS m h2
+    , cdbHasFSLgrDB       :: HasFS m h3
 
       -- Policy
-    , cdbImmValidation      :: ImmDB.ValidationPolicy
-    , cdbVolValidation      :: VolDB.BlockValidationPolicy
-    , cdbBlocksPerFile      :: VolDB.BlocksPerFile
-    , cdbParamsLgrDB        :: LgrDB.LedgerDbParams
-    , cdbDiskPolicy         :: LgrDB.DiskPolicy
+    , cdbImmValidation    :: ImmDB.ValidationPolicy
+    , cdbVolValidation    :: VolDB.BlockValidationPolicy
+    , cdbBlocksPerFile    :: VolDB.BlocksPerFile
+    , cdbParamsLgrDB      :: LgrDB.LedgerDbParams
+    , cdbDiskPolicy       :: LgrDB.DiskPolicy
 
       -- Integration
-    , cdbTopLevelConfig     :: TopLevelConfig blk
-    , cdbChunkInfo          :: ChunkInfo
-    , cdbCheckIntegrity     :: blk -> Bool
-    , cdbGenesis            :: m (ExtLedgerState blk)
-    , cdbCheckInFuture      :: CheckInFuture m blk
-    , cdbGetBinaryBlockInfo :: blk -> BinaryBlockInfo
-    , cdbImmDbCacheConfig   :: ImmDB.CacheConfig
+    , cdbTopLevelConfig   :: TopLevelConfig blk
+    , cdbChunkInfo        :: ChunkInfo
+    , cdbCheckIntegrity   :: blk -> Bool
+    , cdbGenesis          :: m (ExtLedgerState blk)
+    , cdbCheckInFuture    :: CheckInFuture m blk
+    , cdbImmDbCacheConfig :: ImmDB.CacheConfig
 
       -- Misc
-    , cdbTracer             :: Tracer m (TraceEvent blk)
-    , cdbTraceLedger        :: Tracer m (LgrDB.LedgerDB blk)
-    , cdbRegistry           :: ResourceRegistry m
-    , cdbGcDelay            :: DiffTime
-    , cdbGcInterval         :: DiffTime
-    , cdbBlocksToAddSize    :: Word
+    , cdbTracer           :: Tracer m (TraceEvent blk)
+    , cdbTraceLedger      :: Tracer m (LgrDB.LedgerDB blk)
+    , cdbRegistry         :: ResourceRegistry m
+    , cdbGcDelay          :: DiffTime
+    , cdbGcInterval       :: DiffTime
+    , cdbBlocksToAddSize  :: Word
       -- ^ Size of the queue used to store asynchronously added blocks. This
       -- is the maximum number of blocks that could be kept in memory at the
       -- same time when the background thread processing the blocks can't keep
@@ -145,8 +143,7 @@ fromChainDbArgs :: ChainDbArgs m blk
                    )
 fromChainDbArgs ChainDbArgs{..} = (
       ImmDB.ImmDbArgs {
-          immGetBinaryBlockInfo = cdbGetBinaryBlockInfo
-        , immCodecConfig        = configCodec cdbTopLevelConfig
+          immCodecConfig        = configCodec cdbTopLevelConfig
         , immChunkInfo          = cdbChunkInfo
         , immValidation         = cdbImmValidation
         , immCheckIntegrity     = cdbCheckIntegrity
@@ -159,7 +156,6 @@ fromChainDbArgs ChainDbArgs{..} = (
           volHasFS              = cdbHasFSVolDb
         , volCheckIntegrity     = cdbCheckIntegrity
         , volBlocksPerFile      = cdbBlocksPerFile
-        , volGetBinaryBlockInfo = cdbGetBinaryBlockInfo
         , volCodecConfig        = configCodec cdbTopLevelConfig
         , volValidation         = cdbVolValidation
         , volTracer             = contramap TraceVolDBEvent cdbTracer
@@ -212,7 +208,6 @@ toChainDbArgs ImmDB.ImmDbArgs{..}
     , cdbCheckIntegrity       = immCheckIntegrity
     , cdbGenesis              = lgrGenesis
     , cdbCheckInFuture        = cdbsCheckInFuture
-    , cdbGetBinaryBlockInfo   = immGetBinaryBlockInfo
     , cdbImmDbCacheConfig     = immCacheConfig
       -- Misc
     , cdbTracer               = cdbsTracer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Serialisation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Serialisation.hs
@@ -62,13 +62,9 @@ import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.Serialise
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.ByteString.Short (ShortByteString)
-import qualified Data.ByteString.Short as Short
 import           Data.SOP.BasicFunctors
-import           Data.Word
-import           GHC.Generics (Generic)
 
 import           Cardano.Binary (enforceSize)
-import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Network.Block (Serialised (..), fromSerialised,
                      mkSerialised)
@@ -77,6 +73,8 @@ import           Ouroboros.Network.Util.ShowProxy
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Abstract
+import           Ouroboros.Consensus.Storage.Common (PrefixLen (..),
+                     addPrefixLen, takePrefix)
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.RedundantConstraints
 
@@ -315,22 +313,6 @@ class HasNestedContent f blk => ReconstructNestedCtxt f blk where
     -> SizeInBytes      -- ^ Block size
     -> SomeBlock (NestedCtxt f) blk
   reconstructNestedCtxt _ _ _ = SomeBlock indexIsTrivial
-
--- | Number of bytes from the start of a block needed to reconstruct the
--- nested context.
---
--- See 'reconstructPrefixLen'.
-newtype PrefixLen = PrefixLen {
-      getPrefixLen :: Word8
-    }
-  deriving (Eq, Ord, Show, Generic, NoUnexpectedThunks)
-
-addPrefixLen :: Word8 -> PrefixLen -> PrefixLen
-addPrefixLen m (PrefixLen n) = PrefixLen (m + n)
-
-takePrefix :: PrefixLen -> Lazy.ByteString -> ShortByteString
-takePrefix (PrefixLen n) =
-    Short.toShort . Lazy.toStrict . Lazy.take (fromIntegral n)
 
 {-------------------------------------------------------------------------------
   Forwarding instances

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Serialisation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Serialisation.hs
@@ -49,6 +49,9 @@ module Ouroboros.Consensus.Storage.ChainDB.Serialisation (
   , PrefixLen (..)
   , addPrefixLen
   , takePrefix
+    -- * Binary block info
+  , HasBinaryBlockInfo (..)
+  , BinaryBlockInfo (..)
     -- * Re-exported for convenience
   , SizeInBytes
     -- * Exported for the benefit of tests
@@ -73,8 +76,8 @@ import           Ouroboros.Network.Util.ShowProxy
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Abstract
-import           Ouroboros.Consensus.Storage.Common (PrefixLen (..),
-                     addPrefixLen, takePrefix)
+import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..),
+                     PrefixLen (..), addPrefixLen, takePrefix)
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.RedundantConstraints
 
@@ -313,6 +316,15 @@ class HasNestedContent f blk => ReconstructNestedCtxt f blk where
     -> SizeInBytes      -- ^ Block size
     -> SomeBlock (NestedCtxt f) blk
   reconstructNestedCtxt _ _ _ = SomeBlock indexIsTrivial
+
+{-------------------------------------------------------------------------------
+  Binary block info
+-------------------------------------------------------------------------------}
+
+class HasBinaryBlockInfo blk where
+  -- | Return information about the serialised block, i.e., how to extract the
+  -- bytes corresponding to the header from the serialised block.
+  getBinaryBlockInfo :: blk -> BinaryBlockInfo
 
 {-------------------------------------------------------------------------------
   Forwarding instances

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Parser.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Parser.hs
@@ -34,6 +34,8 @@ import           Ouroboros.Consensus.Storage.Common
 import           Ouroboros.Consensus.Storage.FS.API (HasFS)
 import           Ouroboros.Consensus.Storage.FS.CRC
 
+import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
+                     (HasBinaryBlockInfo (..))
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary as Secondary
 import           Ouroboros.Consensus.Storage.ImmutableDB.Types
 
@@ -67,18 +69,18 @@ chunkFileParser
        IOLike m
      , GetPrevHash blk
      , hash ~ HeaderHash blk
+     , HasBinaryBlockInfo blk
      )
   => CodecConfig blk
   -> HasFS m h
   -> (forall s. Decoder s (BL.ByteString -> blk))
-  -> (blk -> BinaryBlockInfo)
   -> (blk -> Bool)        -- ^ Check integrity of the block. 'False' = corrupt.
   -> ChunkFileParser
        (ChunkFileError hash)
        m
        (BlockSummary hash)
        hash
-chunkFileParser cfg hasFS decodeBlock getBinaryBlockInfo isNotCorrupt =
+chunkFileParser cfg hasFS decodeBlock isNotCorrupt =
     ChunkFileParser $ \fsPath expectedChecksums k ->
       Util.CBOR.withStreamIncrementalOffsets hasFS decoder fsPath
         ( k

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -58,7 +58,6 @@ import           Ouroboros.Consensus.Util.SOP
 import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.Condense ()
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation
-import qualified Ouroboros.Consensus.HardFork.Combinator.Serialisation as HFC
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types
 import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
                      (RequiringBoth (..))
@@ -413,10 +412,6 @@ instance RunNode TestBlock where
                          . History.getShape
                          . hardForkLedgerConfigShape
                          . configLedger
-  nodeGetBinaryBlockInfo = HFC.binaryBlockInfo
-                              $ fn (mapIK binaryBlockInfoA)
-                             :* fn (mapIK binaryBlockInfoB)
-                             :* Nil
 
 {-------------------------------------------------------------------------------
   Translation

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -20,7 +20,6 @@
 module Test.Consensus.HardFork.Combinator.A (
     ProtocolA
   , BlockA(..)
-  , binaryBlockInfoA
   , safeFromTipA
   , stabilityWindowA
     -- * Additional types
@@ -83,7 +82,6 @@ import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Serialisation
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
-import           Ouroboros.Consensus.Storage.Common
 import           Ouroboros.Consensus.Util (repeatedlyM)
 import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
@@ -133,19 +131,6 @@ data BlockA = BlkA {
   deriving stock    (Show, Eq, Generic)
   deriving anyclass (Serialise)
   deriving NoUnexpectedThunks via OnlyCheckIsWHNF "BlkA" BlockA
-
--- Standard cborg generic serialisation is:
---
--- > [number of fields in the product]
--- >   [tag of the constructor]
--- >   field1
--- >   ..
--- >   fieldN
-binaryBlockInfoA :: BlockA -> BinaryBlockInfo
-binaryBlockInfoA BlkA{..} = BinaryBlockInfo {
-      headerOffset = 2
-    , headerSize   = fromIntegral $ Lazy.length (serialise blkA_header)
-    }
 
 data instance Header BlockA = HdrA {
       hdrA_fields :: HeaderFields BlockA
@@ -443,6 +428,20 @@ instance Condense (TxId (GenTx BlockA)) where condense = show
 {-------------------------------------------------------------------------------
   Top-level serialisation constraints
 -------------------------------------------------------------------------------}
+
+instance HasBinaryBlockInfo BlockA where
+  -- Standard cborg generic serialisation is:
+  --
+  -- > [number of fields in the product]
+  -- >   [tag of the constructor]
+  -- >   field1
+  -- >   ..
+  -- >   fieldN
+  getBinaryBlockInfo BlkA{..} = BinaryBlockInfo {
+        headerOffset = 2
+      , headerSize   = fromIntegral $ Lazy.length (serialise blkA_header)
+      }
+
 
 instance SerialiseConstraintsHFC          BlockA
 instance ImmDbSerialiseConstraints        BlockA

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1633,7 +1633,6 @@ mkArgs cfg (MaxClockSkew maxClockSkew) chunkInfo initLedger tracer registry varC
     , cdbCheckInFuture        = InFuture.miracle
                                   (readTVar varCurSlot)
                                   maxClockSkew
-    , cdbGetBinaryBlockInfo   = testBlockBinaryBlockInfo
     , cdbImmDbCacheConfig     = Index.CacheConfig 2 60
 
     -- Misc

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -66,7 +66,6 @@ openTestDB registry hasFS =
                TestBlockCodecConfig
                hasFS
                (const <$> S.decode)
-               testBlockBinaryBlockInfo
                testBlockIsValid
 
 -- Shorthand

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -42,7 +42,6 @@ module Test.Ouroboros.Storage.TestBlock (
     -- ** Serialisation
   , testHashInfo
   , testBlockToBuilder
-  , testBlockBinaryBlockInfo
   , testBlockFromLazyByteString
   , testBlockToLazyByteString
     -- * Ledger
@@ -281,12 +280,6 @@ testBlockIsValid (TestBlock hdr body) =
 
 testBlockToBuilder :: TestBlock -> Builder
 testBlockToBuilder = CBOR.toBuilder . encode
-
-testBlockBinaryBlockInfo :: TestBlock -> BinaryBlockInfo
-testBlockBinaryBlockInfo tb = BinaryBlockInfo
-    { headerOffset = testBlockHeaderOffset
-    , headerSize   = testBlockHeaderSize tb
-    }
 
 testBlockHeaderOffset :: Word16
 testBlockHeaderOffset = 2 -- For the 'encodeListLen'
@@ -750,6 +743,12 @@ instance HasNestedContent f TestBlock
 {-------------------------------------------------------------------------------
   Test infrastructure: serialisation
 -------------------------------------------------------------------------------}
+
+instance HasBinaryBlockInfo TestBlock where
+  getBinaryBlockInfo tb = BinaryBlockInfo
+      { headerOffset = testBlockHeaderOffset
+      , headerSize   = testBlockHeaderSize tb
+      }
 
 instance ImmDbSerialiseConstraints TestBlock
 instance LgrDbSerialiseConstraints TestBlock

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -596,7 +596,6 @@ test cmds = do
         parser = blockFileParser'
           TestBlockCodecConfig
           hasFS
-          testBlockBinaryBlockInfo
           ((\blk bytes -> (takePrefix testPrefixLen bytes, blk)) <$> decode)
           testBlockIsValid
           ValidateAll


### PR DESCRIPTION
Fixes #2239.

Instead of having a `RunNode` method to get the `BinaryBlockInfo` of a
block (offset and size of the header within the block), create a separate type
class `HasBinaryBlockInfo` for it. This is another step in the clean-up process
of `RunNode` that started in the weeks before the HFC was merged.

This means we can provide a generic implementation of `HasBinaryBlockInfo` for
`HardForkBlock` that takes the HFC wrapper into account. This wrapper adds a
listlen 2 and a tag indicating the era to the start of each block, so we need to
shift the offset of the header by 2 bytes.

More importantly, we now allow overriding the `getBinaryBlockInfo` method in
`SerialiseHFC`, just like we allow overriding the disk en/decoder for blocks.
This allows us to do the right thing for the Byron era: no era wrapper for
Byron, but start using era wrappers for the eras after it.

This also fixes a bug: `cardano-node` running in pure Shelley mode uses
`ShelleyHFC`, i.e., a `ShelleyBlock` wrapped in the HFC. Since the generic
`RunNode` instance for `HardForkBlock '[blk]` forwards everything to the
instance for `blk`, we were using the `BinaryBlockInfo` implementation for
Shelley, which didn't account for the era wrapper in the header offset. Since
we *were* using the era wrapper to serialise `ShelleyHFC` blocks on disk, this
meant we were extracting the header from the on-disk blocks incorrectly,
resulting in deserialisation failures when reading headers from disk.

This refactoring allows us to fix it properly: now the defaults for
`SerialiseHFC` do the right thing for `ShelleyHFC`, and for `ByronHFC` we
forward to `ByronBlock`, just like for all the other methods. This means
`ShelleyHFC` starts out with an era wrapper around blocks from the first era (to
allow for easier transitions to later eras, which is the right thing to do from
the start), but `ByronHFC`'s block format is binary compatible with
`ByronBlock`.