### PR TITLE
Allow effects after SendMsgRelease in the local state query wrapper

### DIFF
--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Direct.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Direct.hs
@@ -50,7 +50,8 @@ direct (LocalStateQueryClient mclient) (LocalStateQueryServer mserver) = do
     directAcquired (SendMsgReAcquire pt client') ServerStAcquired{recvMsgReAcquire} = do
       server' <- recvMsgReAcquire pt
       directAcquiring client' server'
-    directAcquired (SendMsgRelease client') ServerStAcquired{recvMsgRelease} = do
+    directAcquired (SendMsgRelease client) ServerStAcquired{recvMsgRelease} = do
+      client' <- client
       server' <- recvMsgRelease
       directIdle client' server'
 

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
@@ -81,7 +81,7 @@ data ClientStAcquired block query m a where
                    -> ClientStAcquiring block query m a
                    -> ClientStAcquired  block query m a
 
-  SendMsgRelease   :: ClientStIdle      block query m a
+  SendMsgRelease   :: m (ClientStIdle   block query m a)
                    -> ClientStAcquired  block query m a
 
 -- | In the 'StQuerying' protocol state, the client does not have agency.
@@ -140,7 +140,7 @@ localStateQueryClientPeer (LocalStateQueryClient handler) =
       SendMsgRelease stIdle ->
         Yield (ClientAgency TokAcquired)
               MsgRelease
-              (handleStIdle stIdle)
+              (Effect (handleStIdle <$> stIdle))
 
     handleStQuerying
       :: query result

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Examples.hs
@@ -51,7 +51,7 @@ localStateQueryClient = LocalStateQueryClient . pure . goIdle []
       -> [(Point block, query result)]   -- ^ Remainder
       -> ClientStAcquired block query m
                           [(Point block, Either AcquireFailure result)]
-    goAcquired acc [] = SendMsgRelease $ SendMsgDone $ reverse acc
+    goAcquired acc [] = SendMsgRelease $ pure $ SendMsgDone $ reverse acc
     goAcquired acc ((pt, qs):ptqss') = SendMsgReAcquire pt $
       goAcquiring acc pt qs ptqss'
 


### PR DESCRIPTION
In the LocalStateQueryClient wrapper type, allow effects in one state
where we did not allow them before. This is useful for doing effects
before looping back to the idle state.