### PR TITLE
Export distribForgeState

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forge.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forge.hs
@@ -11,6 +11,7 @@
 
 module Ouroboros.Consensus.HardFork.Combinator.Forge (
     undistribMaintainForgeState
+  , distribForgeState
   ) where
 
 import           Data.Functor.Product


### PR DESCRIPTION
This exports `distribForgeState` from
`Ouroboros.Consensus.HardFork.Combinator.Forge`, which is needed in order to
trace the KES metrics after the Shelley transition in the Cardano
protocol (input-output-hk/cardano-node#1448).