### PR TITLE
Choose the correct initial nonces when hard forking to Shelley

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -425,8 +425,12 @@ translateChainDepStateByronToShelley TPraosConfig { tpraosParams } pbftState =
     TPraosState.empty (PBftState.tipSlot pbftState) $
       SL.ChainDepState
         { SL.csProtocol = SL.PrtclState Map.empty nonce nonce
-        , SL.csTickn = SL.TicknState nonce nonce
-        , SL.csLabNonce = nonce
+        , SL.csTickn    = SL.TicknState {
+              ticknStateEpochNonce    = nonce
+            , ticknStatePrevHashNonce = SL.NeutralNonce
+            }
+          -- Overridden before used
+        , SL.csLabNonce = SL.NeutralNonce
         }
   where
     nonce = tpraosInitialNonce tpraosParams


### PR DESCRIPTION
In `SL.initialShelleyState`, `SL.NeutralNonce` is used for `chainPrevEpochNonce`. In `initChainDepState`, we use that nonce for the second argument to `SL.TicknState` and `SL.csLabNonce`. Previously, we were incorrectly using the `initialNonce` for that.

~Unfortunately, our tests are not able to detect this, possibly because we're using `FakeVRF`?~

The `csLabNonce` nonce is overridden before it is used, to that change doesn't have any effect, except that setting it to `initialNonce` might be misleading, suggesting that the nonce matters.

The other nonce *does* change the chain, but that's not something the test could or should catch.