### PR TITLE
test-infra: uniform distribution for Seed

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/Seed.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util/Seed.hs
@@ -31,4 +31,4 @@ runGen (Seed seed) g =
     qcSeed = mkQCGen seed
 
 instance Arbitrary Seed where
-  arbitrary = Seed <$> arbitrary
+  arbitrary = Seed <$> choose (minBound, maxBound)


### PR DESCRIPTION
The `arbitrary :: Int` is not uniform; it favors values close to 0.

I'm not sure this diff ultimately matters, but this seems closer to our intentions.