### PR TITLE
Revert "Smooth switching from slower to faster peers"

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/DeltaQ.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/DeltaQ.hs
@@ -12,7 +12,6 @@ module Ouroboros.Network.BlockFetch.DeltaQ (
     calculatePeerFetchInFlightLimits,
     estimateResponseDeadlineProbability,
     estimateExpectedResponseDuration,
-    comparePeerGSV,
 --    estimateBlockFetchResponse,
 --    blockArrivalShedule,
   ) where
@@ -28,16 +27,6 @@ data PeerFetchInFlightLimits = PeerFetchInFlightLimits {
        inFlightBytesLowWatermark  :: SizeInBytes
      }
   deriving Show
-
--- Order two PeerGSVs based on `g`.
-comparePeerGSV :: PeerGSV -> PeerGSV -> Ordering
-comparePeerGSV a b = compare (gs a) (gs b)
-  where
-    gs :: PeerGSV -> DiffTime
-    gs PeerGSV { outboundGSV = GSV g_out _s_out _v_out,
-                 inboundGSV  = GSV g_in  _s_in  _v_in
-               } = g_out + g_in
-
 
 calculatePeerFetchInFlightLimits :: PeerGSV -> PeerFetchInFlightLimits
 calculatePeerFetchInFlightLimits PeerGSV {

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
@@ -148,7 +148,7 @@ fetchLogicIteration decisionTracer clientStateTracer
     -- Trace the batch of fetch decisions
     traceWith decisionTracer
       [ TraceLabelPeer peer (fmap fetchRequestPoints decision)
-      | (decision, (_, _, _, peer, _)) <- decisions ]
+      | (decision, (_, _, _, (_, peer))) <- decisions ]
 
     -- Tell the fetch clients to act on our decisions
     statusUpdates <- fetchLogicIterationAct clientStateTracer
@@ -159,7 +159,7 @@ fetchLogicIteration decisionTracer clientStateTracer
 
     return stateFingerprint''
   where
-    swizzleReqVar (d,(_,_,g,_,(rq,p))) = (d,g,rq,p)
+    swizzleReqVar (d,(_,_,g,(rq,p))) = (d,g,rq,p)
 
     fetchRequestPoints :: HasHeader hdr => FetchRequest hdr -> [Point hdr]
     fetchRequestPoints (FetchRequest headerss) =
@@ -178,7 +178,7 @@ fetchDecisionsForStateSnapshot
   => FetchDecisionPolicy header
   -> FetchStateSnapshot peer header block m
   -> [( FetchDecision (FetchRequest header),
-        PeerInfo header peer (FetchClientStateVars m header, peer)
+        PeerInfo header (FetchClientStateVars m header, peer)
       )]
 
 fetchDecisionsForStateSnapshot
@@ -213,7 +213,7 @@ fetchDecisionsForStateSnapshot
         fetchStatePeerGSVs
 
     swizzle (peer, ((chain, (status, inflight, vars)), gsvs)) =
-      (chain, (status, inflight, gsvs, peer, (vars, peer)))
+      (chain, (status, inflight, gsvs, (vars, peer)))
 
 
 -- | Act on decisions to send new requests. In fact all we do here is update


### PR DESCRIPTION
Smooth switching logic is not suitable to run with out the keep-alive client.