### PR TITLE
Mention cause and point when revalidating a header fails

### DIFF
--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -267,6 +267,7 @@ library
                        ViewPatterns
 
   build-depends:       base              >=4.9 && <4.13
+                     , base16-bytestring
                      , bifunctors
                      , bimap             >=0.3   && <0.5
                      , binary            >=0.8   && <0.9

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -58,7 +58,10 @@ module Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
 
 import           Codec.Serialise (Serialise (..))
 import           Control.Monad.Except (throwError)
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Char8 as BSC
 import           Data.ByteString.Short (ShortByteString)
+import qualified Data.ByteString.Short as Short
 import           Data.SOP.Strict hiding (shift)
 import           Data.Text (Text)
 import           Data.Void
@@ -125,7 +128,10 @@ newtype OneEraApplyTxErr    xs = OneEraApplyTxErr    { getOneEraApplyTxErr    ::
 -- So, the type parameter @xs@ here is merely a phantom one, and we just store
 -- the underlying raw hash.
 newtype OneEraHash (xs :: [k]) = OneEraHash { getOneEraHash :: ShortByteString }
-  deriving newtype (Eq, Ord, Show, NoUnexpectedThunks, Serialise)
+  deriving newtype (Eq, Ord, NoUnexpectedThunks, Serialise)
+
+instance Show (OneEraHash xs) where
+  show = BSC.unpack . B16.encode . Short.fromShort . getOneEraHash
 
 {-------------------------------------------------------------------------------
   Value for two /different/ eras

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -193,9 +193,16 @@ instance LedgerSupportsProtocol blk => ApplyBlock (ExtLedgerState blk) blk where
                tickedHeaderState
       }
     where
-      cantBeError :: Except e a -> a
-      cantBeError = either (error "reapplyLedgerBlock: impossible") id
-                  . runExcept
+      cantBeError :: Show e => Except e a -> a
+      cantBeError =
+            either
+              (\e ->
+                  error $
+                    "reapplyLedgerBlock " <>
+                    show (blockPoint blk) <>
+                    ": " <> show e)
+              id
+          . runExcept
 
 {-------------------------------------------------------------------------------
   Serialisation


### PR DESCRIPTION
I ran into this when validating the mainnet_candidate with the `db-validator` tool. Thanks to the improved error message I discovered that it was because of an incorrect value used for PBftSignatureThreshold, which is hard-coded to the default of 0.22 in the db-validator.

Bonus: base16 `Show` instance of `OneEraHash`.