### PR TITLE
Split Qry into Qry and Expr

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Types.hs
@@ -30,6 +30,7 @@ import           Control.Exception (assert)
 import           Data.Fixed
 import           Data.Time (NominalDiffTime, UTCTime, addUTCTime, diffUTCTime)
 import           GHC.Generics (Generic)
+import           Quiet
 
 import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..),
                      UseIsNormalForm (..))
@@ -51,8 +52,9 @@ newtype SystemStart = SystemStart { getSystemStart :: UTCTime }
 
 -- | 'RelativeTime' is time relative to the 'SystemStart'
 newtype RelativeTime = RelativeTime { getRelativeTime :: NominalDiffTime }
-  deriving stock   (Show, Eq, Ord, Generic)
+  deriving stock   (Eq, Ord, Generic)
   deriving newtype (NoUnexpectedThunks)
+  deriving Show via Quiet RelativeTime
 
 addRelTime :: NominalDiffTime -> RelativeTime -> RelativeTime
 addRelTime delta (RelativeTime t) = RelativeTime (t + delta)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
@@ -36,7 +36,7 @@ summaryToEpochInfo =
   where
     go :: RunWithCachedSummary xs m -> EpochInfo (STM m)
     go run = EpochInfo {
-          epochInfoSize_  = \e -> cachedRunQueryThrow run (QEpochSize   e)
+          epochInfoSize_  = \e -> cachedRunQueryThrow run (epochToSize  e)
         , epochInfoFirst_ = \e -> cachedRunQueryThrow run (epochToSlot' e)
         , epochInfoEpoch_ = \s -> cachedRunQueryThrow run (fst <$> slotToEpoch' s)
         }
@@ -47,7 +47,7 @@ summaryToEpochInfo =
 -- error as a /pure/ exception. Such an exception would indicate a bug.
 snapshotEpochInfo :: forall xs. Summary xs -> EpochInfo Identity
 snapshotEpochInfo summary = EpochInfo {
-      epochInfoSize_  = \e -> runQueryPure' (QEpochSize   e)
+      epochInfoSize_  = \e -> runQueryPure' (epochToSize  e)
     , epochInfoFirst_ = \e -> runQueryPure' (epochToSlot' e)
     , epochInfoEpoch_ = \s -> runQueryPure' (fst <$> slotToEpoch' s)
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Summary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Summary.hs
@@ -28,7 +28,6 @@ module Ouroboros.Consensus.HardFork.History.Summary (
   , mkEraEnd
     -- * Overall summary
   , Summary(..)
-  , PastHorizonException(..)
     -- ** Construction
   , summaryWithExactly
   , neverForksSummary
@@ -49,7 +48,6 @@ import           Codec.CBOR.Decoding (TokenType (TypeNull), decodeNull,
                      peekTokenType)
 import           Codec.CBOR.Encoding (encodeListLen, encodeNull)
 import           Codec.Serialise
-import           Control.Exception (Exception)
 import           Control.Monad.Except
 import           Data.Bifunctor
 import           Data.Foldable (toList)
@@ -59,7 +57,6 @@ import           Data.SOP.Strict (K (..), NP (..), SListI, lengthSList)
 import           Data.Time hiding (UTCTime)
 import           Data.Word
 import           GHC.Generics (Generic)
-import           GHC.Stack
 
 import           Cardano.Binary (enforceSize)
 import           Cardano.Prelude (NoUnexpectedThunks, UseIsNormalFormNamed (..))
@@ -203,18 +200,6 @@ newtype Summary xs = Summary (NonEmpty xs EraSummary)
 -- WHNF is sufficient, because the counting types are all strict
 deriving via UseIsNormalFormNamed "Summary" (Summary xs)
          instance NoUnexpectedThunks (Summary xs)
-
--- | We tried to convert something that is past the horizon
---
--- That is, we tried to convert something that is past the point in time
--- beyond which we lack information due to uncertainty about the next
--- hard fork.
---
--- We record the condition we were looking for and the bounds on the summary.
-data PastHorizonException = PastHorizon CallStack [EraSummary]
-
-deriving instance Show PastHorizonException
-instance Exception PastHorizonException
 
 {-------------------------------------------------------------------------------
   Trivial summary


### PR DESCRIPTION
While `Qry` still provides a monadic interface, most of the actual calculation happens in the interpreter for `Expr`, and any past-horizon exceptions come from the evaluation of an `Expr`. Unlike `Qry`, `Expr` uses PHOAS, which means that we can actually `Show` expressions, despite them containing functions. This means that we can include the offending expression in the exception.

This is also a strict generalization: previously, an entire `Qry` was always evaluated against a single era; with the split, every `Expr` is evaluated against a single era, but every `Expr` embedded in a `Qry` can be evaluated against a _different_ era.

Closes #2463.