### PR TITLE
tip-sample appliction

### DIFF
--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -102,6 +102,7 @@ library
                        Ouroboros.Network.Protocol.KeepAlive.Server
                        Ouroboros.Network.Protocol.KeepAlive.Codec
                        Ouroboros.Network.TipSample.Client
+                       Ouroboros.Network.TipSample.Server
                        Ouroboros.Network.TipSample.TipFragment
                        Ouroboros.Network.TxSubmission.Inbound
                        Ouroboros.Network.TxSubmission.Mempool.Reader

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -260,6 +260,7 @@ test-suite test-network
                        Test.Ouroboros.Network.MockNode
                        Test.Ouroboros.Network.TipSample.TipFragment
                        Test.Ouroboros.Network.TipSample.TipRegistry
+                       Test.Ouroboros.Network.TipSample.Client
                        Test.Mux
                        Test.Pipe
                        Test.Socket
@@ -288,11 +289,13 @@ test-suite test-network
                        serialise,
                        splitmix,
                        stm,
+                       statistics,
                        tasty,
                        tasty-hunit,
                        tasty-quickcheck,
                        text,
                        time,
+                       vector,
 
                        cardano-binary,
                        cardano-prelude,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -259,6 +259,7 @@ test-suite test-network
                        Test.Ouroboros.Network.KeepAlive
                        Test.Ouroboros.Network.MockNode
                        Test.Ouroboros.Network.TipSample.TipFragment
+                       Test.Ouroboros.Network.TipSample.TipRegistry
                        Test.Mux
                        Test.Pipe
                        Test.Socket

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -101,6 +101,7 @@ library
                        Ouroboros.Network.Protocol.KeepAlive.Client
                        Ouroboros.Network.Protocol.KeepAlive.Server
                        Ouroboros.Network.Protocol.KeepAlive.Codec
+                       Ouroboros.Network.TipSample.TipFragment
                        Ouroboros.Network.TxSubmission.Inbound
                        Ouroboros.Network.TxSubmission.Mempool.Reader
                        Ouroboros.Network.TxSubmission.Outbound
@@ -147,6 +148,7 @@ library
                        mtl,
                        network           >=3.1 && <3.2,
                        psqueues          >=0.2.3 && <0.3,
+                       quiet,
                        serialise         >=0.2 && <0.3,
                        random,
                        stm               >=2.4 && <2.6,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -101,6 +101,7 @@ library
                        Ouroboros.Network.Protocol.KeepAlive.Client
                        Ouroboros.Network.Protocol.KeepAlive.Server
                        Ouroboros.Network.Protocol.KeepAlive.Codec
+                       Ouroboros.Network.TipSample.Client
                        Ouroboros.Network.TipSample.TipFragment
                        Ouroboros.Network.TxSubmission.Inbound
                        Ouroboros.Network.TxSubmission.Mempool.Reader
@@ -149,6 +150,7 @@ library
                        network           >=3.1 && <3.2,
                        psqueues          >=0.2.3 && <0.3,
                        quiet,
+                       random,
                        serialise         >=0.2 && <0.3,
                        random,
                        stm               >=2.4 && <2.6,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -258,6 +258,7 @@ test-suite test-network
                        Test.Ouroboros.Network.BlockFetch
                        Test.Ouroboros.Network.KeepAlive
                        Test.Ouroboros.Network.MockNode
+                       Test.Ouroboros.Network.TipSample.TipFragment
                        Test.Mux
                        Test.Pipe
                        Test.Socket

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -104,6 +104,7 @@ library
                        Ouroboros.Network.TipSample.Client
                        Ouroboros.Network.TipSample.Server
                        Ouroboros.Network.TipSample.TipFragment
+                       Ouroboros.Network.TipSample.TipRegistry
                        Ouroboros.Network.TxSubmission.Inbound
                        Ouroboros.Network.TxSubmission.Mempool.Reader
                        Ouroboros.Network.TxSubmission.Outbound

--- a/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ChainFragment.hs
@@ -75,6 +75,7 @@ module Ouroboros.Network.ChainFragment (
   foldChainFragmentSpec,
   pointOnChainFragmentSpec,
   selectPointsSpec,
+  lookupBySlotFT
   ) where
 
 import           Prelude hiding (drop, filter, head, last, length, null,

--- a/ouroboros-network/src/Ouroboros/Network/TipSample/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TipSample/Client.hs
@@ -1,0 +1,398 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+
+module Ouroboros.Network.TipSample.Client
+  ( -- * 'TipSampleClient'
+    TipSamplePolicy (..)
+  , simpleTipSamplePolicy
+  , TipSampleActions (..)
+  , tipSampleClient
+
+    -- * Errors & traces
+  , TipSampleClientTrace (..)
+  , TipSampleClientValidationError (..)
+
+    -- Exported for testing
+  , TipSampleDecision (..)
+  , randomTipSampleDecision 
+  ) where
+
+import           Control.Arrow (second)
+import           Control.Monad.Class.MonadSTM.Strict
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
+
+import           Control.Tracer (Tracer, traceWith)
+
+
+import           Control.Exception (Exception (..))
+import           Data.Foldable (traverse_)
+import           Data.Typeable (Typeable)
+import           Data.Word (Word)
+import           System.Random
+
+import           Network.TypedProtocol.Pipelined ( N (..)
+                                                 , Nat (Succ, Zero)
+                                                 , unsafeIntToNat )
+
+import           Cardano.Slotting.Slot ( SlotNo (..), WithOrigin (..) )
+
+import           Ouroboros.Network.Block ( Tip (..)
+                                         , StandardHash
+                                         , getTipSlotNo )
+import           Ouroboros.Network.Mux (ControlMessageSTM, ControlMessage (..))
+import           Ouroboros.Network.TipSample.TipFragment ( TipFragment
+                                                         , TipFragment' ((:>), Empty)
+                                                         , Timed (..)
+                                                         )
+import qualified Ouroboros.Network.TipSample.TipFragment as TF
+import           Ouroboros.Network.Protocol.TipSample.Client
+
+
+
+
+-- | Policies which drive the 'TipSample' client.
+--
+data TipSamplePolicy = TipSamplePolicy {
+      -- | Max slot history kept by the client.
+      --
+      tspMaxHistory               :: Word,
+
+      -- | Bounds on uniform random choice of a slot ahead of the current slot.
+      --
+      tspSlotRange                :: (Word, Word),
+
+      -- | Weight for asking a single tip.
+      --
+      tspFollowSingleTipWeight    :: Word,
+
+      -- | Weight for asking a multiple tips.
+      --
+      tspFollowMultipleTipsWeight :: Word,
+
+      -- | Range from which we randomly choose how many tips to follow.  The
+      -- minimum range should be greater or equal @2@.
+      --
+      tspMultipleTipsRange        :: (Word, Word)
+    }
+  deriving Show
+
+
+data TipSampleDecision =
+      -- | Ask for a single tip after that many slots of the current slot.
+      FollowSingleTip Word
+
+      -- | Ask for multiple tips
+    | FollowMultipleTips
+         Word -- ^ after that many slots of the current slot.
+         Word -- ^ number of tips to receive
+
+
+randomTipSampleDecision
+    :: RandomGen g
+    => TipSamplePolicy
+    -> g
+    -> (TipSampleDecision, g)
+randomTipSampleDecision
+    TipSamplePolicy {
+      tspFollowSingleTipWeight,
+      tspFollowMultipleTipsWeight,
+      tspSlotRange,
+      tspMultipleTipsRange
+    }
+    g =
+      case randomR (0, 100) g of
+        (a, g') | a <= 100 * tspFollowSingleTipWeight `div` total
+                -> case randomR tspSlotRange g' of
+                    (n, g'') -> (FollowSingleTip n , g'')
+
+                | otherwise
+                -> case randomR tspSlotRange g' of
+                    (n, g'') -> case randomR tspMultipleTipsRange g'' of
+                      (r, g''') -> (FollowMultipleTips n r, g''')
+  where
+    total = tspFollowSingleTipWeight + tspFollowMultipleTipsWeight
+
+
+data TipSampleState header = TipSampleState {
+    tssLastTip :: !(Tip header),
+    tssGen     :: !StdGen
+  }
+
+
+data TipSampleClientValidationError header =
+    TipSampleWrongSlot SlotNo (Tip header)
+  | TipSampleWrongTip (Tip header) (Tip header)
+  deriving Show
+
+instance (Typeable header, StandardHash header)
+    => Exception (TipSampleClientValidationError header)
+
+afterSlotNo :: Tip header
+            -> Word
+            -> SlotNo
+afterSlotNo (Tip (SlotNo slotNo) _ _) x = SlotNo (slotNo + fromIntegral x)
+afterSlotNo TipGenesis                x = SlotNo (fromIntegral x)
+
+
+compareTipsBySlotNo :: Tip header
+                    -> Tip header
+                    -> Ordering
+compareTipsBySlotNo (Tip slotNo _ _) (Tip slotNo' _ _) = slotNo `compare` slotNo'
+compareTipsBySlotNo Tip{}            TipGenesis        = GT
+compareTipsBySlotNo TipGenesis       Tip{}             = LT
+compareTipsBySlotNo TipGenesis       TipGenesis        = EQ
+
+
+data TipSampleActions m header = TipSampleActions {
+    -- | Modify 'TipFragment' and return trace of the operation.
+    --
+    tsaModifyTipFragment :: forall a. (TipFragment header -> (a, TipFragment header)) -> STM m a,
+
+    -- | Get current 'SlotNo'.  The client maintains 'TipFragment' only for
+    -- a 'tspMaxHistory' of slots.
+    --
+    tsaGetCurrentSlotNo  :: STM m SlotNo,
+
+    -- | Convert 'SlotNo' to 'Time.
+    --
+    tsaSlotTime          :: m (SlotNo -> Maybe Time),
+
+    -- | 'tipSampleClient' tracer.
+    --
+    tsaTracer            :: Tracer m (TipSampleClientTrace header)
+  }
+
+
+-- | We request tip for a given slot (at most) `10` slots before it will become
+-- the current slot.
+--
+networkTipSlack :: SlotNo
+networkTipSlack = SlotNo 10
+
+
+-- | 'TipSample' client application.  It sends requests according to
+-- 'TipSamplePolicy', and records received tips.
+--
+-- It maintains the invariant that the slots increase monotonically in
+-- 'TipFragment'.  When we request multiple tips, the 'SlotNo' can go backward
+-- (if the remote peer rollbacked its chain).  In this case we rollback the
+-- 'TipFragment' too.
+--
+tipSampleClient :: forall header m.
+                   ( MonadMonotonicTime m
+                   , MonadSTM           m
+                   , MonadThrow         m
+                   , StandardHash header
+                   , Typeable     header
+                   )
+                => TipSamplePolicy
+                -> TipSampleActions m header
+                -> ControlMessageSTM m
+                -> StdGen
+                -- ^ Assuming that the `StdGen` is a result of a `split`.
+                -> TipSampleClient (Tip header) m ()
+tipSampleClient tipSamplePolicy@TipSamplePolicy { tspMaxHistory }
+                TipSampleActions {
+                  tsaModifyTipFragment,
+                  tsaGetCurrentSlotNo,
+                  tsaSlotTime,
+                  tsaTracer
+                }
+                controlMessageSTM g =
+    TipSampleClient $ clientStIdle (TipSampleState TipGenesis g)
+  where
+    -- We only validate 'SlotNo'; at this point we cannot trust the received
+    -- hash or 'BlockNo'.  Its validation is deffered until we actually use the
+    -- tip.
+    --
+    -- Note: we only validate the 'Tip' if we expect it to move forward.
+    validateTip :: Tip header
+                -> SlotNo
+                -> m ()
+    validateTip tip requestedSlotNo
+      | getTipSlotNo tip >= At requestedSlotNo
+      = pure ()
+      | otherwise
+      = do traceWith tsaTracer
+                     (TipSampleClientProtocolValidationError requestedSlotNo tip)
+           throwIO (TipSampleWrongSlot requestedSlotNo tip)
+
+
+    -- Await for slot or stop if we're asked for.  This is useful in 'StIdle'
+    -- state, in which case we await some slot keeping the agency before
+    -- deciding wheather to send a request or send the termination message.
+    awaitForSlot :: SlotNo
+                 -> m ControlMessage
+    awaitForSlot slotNo =
+      atomically $ do
+        currentSlot <- tsaGetCurrentSlotNo
+        if currentSlot >= slotNo
+          then do
+            cntrlMsg <- controlMessageSTM
+            case cntrlMsg of
+              Continue  -> pure Continue
+              -- we are relaying on the fact that 'Quiesce' is never returned.
+              Quiesce   -> retry
+              Terminate -> pure Terminate
+          else do
+            cntrlMsg <- controlMessageSTM
+            case cntrlMsg of
+              Continue  -> retry
+              Quiesce   -> retry
+              Terminate -> pure Terminate
+
+
+    clientStIdle :: TipSampleState header
+                 -> m (ClientStIdle (Tip header) m ())
+    clientStIdle st@TipSampleState { tssLastTip, tssGen } =
+
+      case randomTipSampleDecision tipSamplePolicy tssGen of
+        (FollowSingleTip n, tssGen') -> do
+          let requestedSlotNo = afterSlotNo tssLastTip n
+              r = Succ Zero
+          -- We send the message at most 'networkTipSlack' slots before the
+          -- requested slot no.  This give a change to send it early enough;
+          -- ideally, the other end should not have a header at the requested
+          -- slot when it receives the message.
+          cntrlMsg <- awaitForSlot (requestedSlotNo - networkTipSlack)
+          case cntrlMsg of
+            Continue -> pure $
+              SendMsgFollowTip
+                r requestedSlotNo
+                (receiveTips (Just requestedSlotNo) r st { tssGen = tssGen' })
+            -- 'Quiesce' is never returned by 'awaitForSlot'
+            Quiesce -> error "TipSampleClient: impossible happened."
+            Terminate -> pure $ SendMsgDone ()
+
+        (FollowMultipleTips n r, tssGen') -> do
+          let requestedSlotNo = afterSlotNo tssLastTip n
+              r' = unsafeIntToNat (fromIntegral r)
+          -- As in the 'FollowSingleTip' case.
+          cntrlMsg <- awaitForSlot (requestedSlotNo - networkTipSlack)
+          case cntrlMsg of
+            Continue -> pure $
+              SendMsgFollowTip
+                r' requestedSlotNo
+                (receiveTips (Just requestedSlotNo) r' st { tssGen = tssGen' })
+            Quiesce -> error "TipSampleClient: impossible happened."
+            Terminate -> pure $ SendMsgDone ()
+
+
+    receiveTips :: Maybe SlotNo
+                -- used to validate the first tip
+                -> Nat (S n)
+                -> TipSampleState header
+                -> HandleTips (S n) (Tip header) m ()
+
+    receiveTips mbSlotNo (Succ Zero) st =
+      ReceiveLastTip $ \tip -> do
+        t <- getMonotonicTime
+        -- validate the tip but only if 'mvSlotNo' is 'Just'
+        traverse_ (validateTip tip) mbSlotNo
+        mbOriginTime <-
+          case getTipSlotNo tip of
+            Origin -> pure Nothing
+            At slotNo -> fmap ($ slotNo) tsaSlotTime
+        let !mbPropagationTime = diffTime t <$> mbOriginTime
+        traceMessage
+          <- atomically $ rollbackOrRollforward st (Timed t tip) mbPropagationTime
+        traceWith tsaTracer traceMessage
+        clientStIdle st { tssLastTip = tip }
+
+    receiveTips mbSlotNo (Succ n@Succ {}) st =
+      ReceiveTip $ \tip -> do
+        t <- getMonotonicTime
+        -- validate the tip but only if 'mvSlotNo' is 'Just'
+        traverse_ (validateTip tip) mbSlotNo
+        mbOriginTime <-
+          case getTipSlotNo tip of
+            Origin -> pure Nothing
+            At slotNo -> fmap ($ slotNo) tsaSlotTime
+        let !mbPropagationTime = diffTime t <$> mbOriginTime
+        traceMessage <- atomically (rollbackOrRollforward st (Timed t tip) mbPropagationTime)
+        traceWith tsaTracer traceMessage
+        pure $ receiveTips Nothing n st { tssLastTip = tip }
+
+
+    -- Trim the 'TipFragment' whenever we modify the shared value.  We only
+    -- keep tips 'tpsRange' from the current 'SlotNo'.
+    modifyTipFragment
+      :: forall a.
+        (TipFragment header -> (a, TipFragment header))
+      -> STM m a
+    modifyTipFragment f = do
+      currentSlotNo <- tsaGetCurrentSlotNo
+      let initialSlotNo = case currentSlotNo of
+            SlotNo a | a >= fromIntegral tspMaxHistory
+                     -> SlotNo (a - fromIntegral tspMaxHistory)
+                     | otherwise
+                     -> SlotNo 0
+      tsaModifyTipFragment (second (TF.dropOldestUntilSlotNo initialSlotNo) . f)
+
+
+    rollbackOrRollforward
+        :: TipSampleState header
+        -> Timed (Tip header)
+        -> Maybe DiffTime
+        -> STM m (TipSampleClientTrace header)
+    rollbackOrRollforward TipSampleState { tssLastTip } tt mbPropagationTime =
+      modifyTipFragment $ \tf ->
+        case tssLastTip `compareTipsBySlotNo` timedData tt of
+          GT -> ( TipSampleClientAddTip tt mbPropagationTime
+                , tf :> tt
+                )
+
+            -- There was a rollback.
+            -- TODO: Currently we rollback our state, but in the future we
+            -- could have a more clever solution.
+          _ -> case timedData tt of
+                  Tip slotNo _ _ -> ( TipSampleClientRollback tt mbPropagationTime
+                                    , TF.dropNewestUntilSlotNo (pred slotNo) tf :> tt
+                                    )
+                  TipGenesis     -> ( TipSampleClientRollback tt mbPropagationTime
+                                    , Empty
+                                    )
+
+--
+-- Policy
+--
+
+
+simpleTipSamplePolicy
+    :: Word
+    -- ^ 'tspMaxHistory'
+    -> Word
+    -- ^ overall number of warm peers for which the policy is designed.
+    -> Word
+    -- ^ number of peers that should be challenged at each slot.
+    -> Word
+    -- ^ width of 'tspSlotRange'
+    -> TipSamplePolicy
+simpleTipSamplePolicy tspMaxHistory numberOfPeers bucketSize width =
+    TipSamplePolicy {
+        tspMaxHistory,
+        tspSlotRange =
+          let m = numberOfPeers `div` bucketSize
+              w = width `div` 2
+          in (m - w, m + w),
+        tspFollowSingleTipWeight    = 19,
+        tspFollowMultipleTipsWeight = 1,
+        tspMultipleTipsRange        = (4, 6)
+      }
+
+
+--
+-- Trace
+--
+
+data TipSampleClientTrace header =
+    TipSampleClientProtocolValidationError SlotNo !(Tip header)
+  | TipSampleClientAddTip   !(Timed (Tip header)) !(Maybe DiffTime)
+  | TipSampleClientRollback !(Timed (Tip header)) !(Maybe DiffTime)
+  deriving (Eq, Show)

--- a/ouroboros-network/src/Ouroboros/Network/TipSample/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TipSample/Server.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Network.TipSample.Server where
+
+import           Control.Monad.Class.MonadSTM
+
+import           Network.TypedProtocol.Pipelined (Nat (Succ, Zero), N (..))
+
+import           Cardano.Slotting.Slot (SlotNo)
+
+import           Ouroboros.Network.Block (Tip (..))
+import           Ouroboros.Network.Protocol.TipSample.Server
+
+
+-- | 'tip-sample' server application.
+--
+tipServer :: forall header m.
+             MonadSTM m
+          => STM m (Tip header)
+          -- ^ 'ChainDB' 'getCurrentSlot' method.
+          -> TipSampleServer (Tip header) m ()
+tipServer getCurrentTip = TipSampleServer (pure serverStIdle)
+  where
+    serverStIdle :: ServerStIdle (Tip header) m ()
+    serverStIdle = ServerStIdle {
+        handleFollowTip,
+        handleDone
+      }
+
+    handleFollowTip :: forall (n :: N).
+                       Nat (S n)
+                    -> SlotNo
+                    -> m (SendTips (S n) (Tip header) m ())
+    handleFollowTip n@(Succ Zero) slotNo = do
+      atomically $ do
+        tip <- getCurrentTip
+        case tip of
+          Tip slotNo' _ _ | slotNo' > slotNo -> pure $ SendLastTip n tip serverStIdle
+                          | otherwise -> retry
+          TipGenesis      -> retry
+    handleFollowTip n@(Succ m@Succ{}) slotNo = do
+        atomically $ do
+          tip <- getCurrentTip
+          case tip of
+            Tip slotNo' _ _ | slotNo' > slotNo -> pure $ SendNextTip n tip (go m)
+                            | otherwise -> retry
+            TipGenesis      -> retry
+      where
+        go :: forall (k :: N).
+              Nat (S k)
+           -> m (SendTips (S k) (Tip header) m ())
+        go k@(Succ Zero) =
+          atomically $ do
+            tip <- getCurrentTip
+            pure (SendLastTip k tip serverStIdle)
+        go k@(Succ l@Succ{}) =
+          atomically $ do
+            tip <- getCurrentTip
+            pure $ SendNextTip k tip (go l)
+
+    handleDone :: m ()
+    handleDone = pure ()

--- a/ouroboros-network/src/Ouroboros/Network/TipSample/TipFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TipSample/TipFragment.hs
@@ -1,0 +1,169 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE ViewPatterns               #-}
+
+-- @Measured TipMeasure (Tip block)@ is an orphaned instance.
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+
+-- | This is like `ChainFragment` but it does not do some of its assertions.
+--
+module Ouroboros.Network.TipSample.TipFragment
+  ( TipFragment
+  , TipFragment' (Empty, (:>), (:<), TipFragment)
+  , Timed (..)
+  , viewRight
+  , viewLeft
+  , lookupBySlotNo
+  , dropNewestUntilSlotNo
+  , dropOldestUntilSlotNo
+  , toOldestFirst
+
+    -- * Internal api
+  , TipMeasure (..)
+  , lookupBySlotFT
+  ) where
+
+import           Control.Monad.Class.MonadTime (Time)
+
+import           Cardano.Slotting.Slot (SlotNo, WithOrigin (..))
+
+import qualified Data.Foldable as Foldable
+import           Data.FingerTree.Strict (Measured (..), StrictFingerTree)
+import qualified Data.FingerTree.Strict as FT
+import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
+
+import           Ouroboros.Network.Block (Tip (..), getTipSlotNo)
+
+data TipMeasure = TipMeasure {
+    tmMinSlot :: !(WithOrigin SlotNo),
+    tmMaxSlot :: !(WithOrigin SlotNo),
+    tmSize    :: !Int
+  }
+
+instance Semigroup TipMeasure where
+  vl <> vr =
+    TipMeasure (min (tmMinSlot vl) (tmMinSlot vr))
+               (max (tmMaxSlot vl) (tmMaxSlot vr))
+               (tmSize vl + tmSize vr)
+
+instance Monoid TipMeasure where
+  mempty = TipMeasure (At maxBound) Origin 0
+  mappend = (<>)
+
+instance Measured TipMeasure (Tip block) where
+  measure (Tip slotNo _ _blockNo) = TipMeasure (At slotNo) (At slotNo) 1
+  measure TipGenesis = TipMeasure Origin Origin 1
+
+
+data Timed a = Timed {
+    timedAt   :: !Time,
+    timedData :: !a
+  }
+  deriving (Eq, Generic)
+  deriving Show via Quiet (Timed a)
+
+instance Measured TipMeasure a => Measured TipMeasure (Timed a) where
+    measure = measure . timedData
+
+newtype TipFragment' tip = TipFragment (StrictFingerTree TipMeasure tip)
+  deriving stock   (Show, Eq)
+  deriving newtype Foldable
+
+type TipFragment header = TipFragment' (Timed (Tip header))
+
+viewRight :: Measured TipMeasure tip => TipFragment' tip -> FT.ViewR TipFragment' tip
+viewRight (TipFragment c) = case FT.viewr c of
+  FT.EmptyR  -> FT.EmptyR
+  c' FT.:> tip -> TipFragment c' FT.:> tip
+
+viewLeft :: Measured TipMeasure tip => TipFragment' tip -> FT.ViewL TipFragment' tip
+viewLeft (TipFragment c) = case FT.viewl c of
+  FT.EmptyL -> FT.EmptyL
+  tip FT.:< c' -> tip FT.:< TipFragment c'
+
+pattern Empty :: Measured TipMeasure tip => TipFragment' tip
+pattern Empty <- (viewRight -> FT.EmptyR) where
+  Empty = TipFragment FT.empty
+
+-- | \( O(1) \). Add a tip to the right of the chain fragment.
+pattern (:>) :: Measured TipMeasure tip
+             => Measured TipMeasure tip
+             => TipFragment' tip -> tip -> TipFragment' tip
+pattern c :> tip <- (viewRight -> (c FT.:> tip)) where
+  TipFragment c :> tip = TipFragment (c FT.|> tip)
+
+-- | \( O(1) \). Add a tip to the left of the chain fragment.
+pattern (:<) :: Measured TipMeasure tip
+             => Measured TipMeasure tip
+             => tip -> TipFragment' tip -> TipFragment' tip
+pattern b :< c <- (viewLeft -> (b FT.:< c)) where
+  b :< TipFragment c = TipFragment (b FT.<| c)
+
+infixl 5 :>, :<
+
+{-# COMPLETE Empty, (:>) #-}
+{-# COMPLETE Empty, (:<) #-}
+
+-- | \( O(log(min(i,n-i))) \).
+-- Lookup by 'SlotNo';  note that 'lookupBySlotFT' does not guarantee that it
+-- will find the correct slot: it will find the tip with the smallest `SlotNo`
+-- which is greater or equal to the given 'slotNo'.
+--
+lookupBySlotFT :: WithOrigin SlotNo
+               -> TipFragment header
+               -> FT.SearchResult TipMeasure (Timed (Tip header))
+lookupBySlotFT slotNo (TipFragment c) =
+    FT.search (\vl vr -> tmMaxSlot vl >= slotNo && tmMinSlot vr > slotNo) c
+
+
+-- | \( O(log(min(i,n-i))) \).
+--
+-- Returns the right most tip with the given 'SlotNo' and the 'TipFragment'
+-- that follows it.
+--
+lookupBySlotNo :: WithOrigin SlotNo
+               -> TipFragment header
+               -> Maybe (Timed (Tip header), TipFragment header)
+lookupBySlotNo s tf =
+    case lookupBySlotFT s tf of
+      FT.Position _ a@(Timed _ tip) tf'
+        | getTipSlotNo tip == s -> Just (a,  TipFragment tf')
+        | otherwise             -> Nothing
+      FT.OnLeft  -> Nothing
+      FT.OnRight -> Nothing
+      FT.Nowhere -> Nothing
+
+-- | \( O(log(min(i,n-i))) \).
+-- Drop all newest @'Tip' header@ which 'SlotNo' is greater than the given one.
+--
+dropNewestUntilSlotNo :: SlotNo
+                      -> TipFragment header
+                      -> TipFragment header
+dropNewestUntilSlotNo slotNo (TipFragment c) =
+    TipFragment $ FT.takeUntil (\v -> tmMaxSlot v > At slotNo) c
+
+
+-- | \( O(log(min(i,n-i)) \).
+-- Drop all @'Tip' header@ which 'SlotNo' is smaller than the given one.
+--
+dropOldestUntilSlotNo :: SlotNo
+                      -> TipFragment header
+                      -> TipFragment header
+dropOldestUntilSlotNo slotNo (TipFragment c) =
+    TipFragment $ FT.dropUntil (\v -> tmMaxSlot v >= At slotNo) c
+
+
+-- | \( O(n) \). Make a list of blocks from a 'TipFragment', in
+-- oldest-to-newest order.
+toOldestFirst :: TipFragment header -> [Timed (Tip header)]
+toOldestFirst (TipFragment ft) = Foldable.toList ft

--- a/ouroboros-network/src/Ouroboros/Network/TipSample/TipRegistry.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TipSample/TipRegistry.hs
@@ -1,0 +1,300 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DerivingVia         #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | 'TipRegistry' keeps chains of tips of warm peers and allows to extract
+-- which peers offer headers from our chain the earliest.
+--
+module Ouroboros.Network.TipSample.TipRegistry
+  ( TipRegistryArguments (..)
+  , TipRegistry (..)
+  , TipFragmentVar (..)
+  , NumberOfWins (..)
+  , NumberOfPeers (..)
+  , makeTipRegistry
+  , TipRegistryTrace (..)
+  ) where
+
+import           Control.Monad.Class.MonadSTM.Strict
+import           Control.Monad.Class.MonadTime (Time)
+
+import           Control.Tracer (Tracer, traceWith)
+
+import           Data.Bifunctor (bimap)
+import           Data.Functor (($>))
+import           Data.List (sort)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Ord (Down (..))
+
+import           Cardano.Slotting.Slot (SlotNo, WithOrigin (..))
+
+import           Ouroboros.Network.Block ( HasHeader
+                                         , ChainHash (BlockHash)
+                                         , blockHash
+                                         , blockNo
+                                         , blockSlot
+                                         , getTipSlotNo
+                                         , getTipBlockNo
+                                         , getTipPoint
+                                         , pointHash )
+import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import qualified Ouroboros.Network.ChainFragment as CF
+
+import           Ouroboros.Network.TipSample.TipFragment ( TipFragment
+                                                         , TipFragment' (Empty)
+                                                         , Timed (..) )
+import qualified Ouroboros.Network.TipSample.TipFragment as TF
+
+
+-- TipFragmentVar
+newtype TipFragmentVar peerAddr m header =
+    TipFragmentVar
+      -- modifyTipFragment
+      { modifyTipFragment
+          :: forall a.
+             (TipFragment header -> (a, TipFragment header))
+          -> STM m a
+      }
+
+
+newtype NumberOfWins = NumberOfWins Int
+  deriving stock (Show, Eq)
+  deriving Ord  via (Down Int)
+  deriving Num  via Int
+  deriving Enum via Int
+
+
+newtype NumberOfPeers = NumberOfPeers Int
+  deriving stock (Show, Eq)
+  deriving Ord  via (Down Int)
+  deriving Num  via Int
+  deriving Enum via Int
+
+
+data TipRegistry peerAddr header m = TipRegistry {
+    -- | Returns an ordered list of peers which offered the most tips earliest.
+    -- The 'NumberOfPeers' is the overall number of all peers that the peer won
+    -- against across all slots.
+    --
+    getPeerResults :: m [(NumberOfWins, NumberOfPeers, peerAddr)],
+
+    -- | Returns an action which allows to modify 'TipFragment' for the given
+    -- peer in an 'STM' transaction.
+    --
+    registerPeer   :: peerAddr -> m (TipFragmentVar peerAddr m header),
+
+    -- | Removes a peer from 'TipRegistry' internal state.
+    --
+    unregisterPeer :: peerAddr -> m ()
+  }
+
+
+-- | Internal state of 'TipRegistry'; we keep each peer 'TipFragment' in
+-- a separate 'StrictTVar' to avoid synchronisation between threads.
+--
+newtype TipRegistryState peerAddr header m = TipRegistryState {
+    tipFragmentsVar :: StrictTVar m (Map peerAddr (StrictTVar m (TipFragment header)))
+  }
+
+data TipRegistryArguments peerAddr header m = TipRegistryArguments {
+      -- | Offset from the tip of the current chain.  This allows us to ignore
+      -- a few most recent headers.
+      traChainOffset     :: Int,
+
+      -- | Get current chain.
+      --
+      traGetCurrentChain :: STM m (AnchoredFragment header),
+
+      -- | Tracer.
+      traTracer          :: Tracer m (TipRegistryTrace peerAddr header)
+    }
+
+
+-- | 'TipRegistry'; it keeps track of the 'TipFragment's of registered peers
+-- and allows to compute results for the current chain.  The results are not
+-- cached as the chain might change (we are using the volatile part of the
+-- chain).
+--
+makeTipRegistry :: forall peerAddr header m.
+                   ( MonadSTM m
+                   , HasHeader header
+                   , Ord peerAddr
+                   )
+                => TipRegistryArguments peerAddr header m
+                -> m (TipRegistry       peerAddr header m)
+makeTipRegistry TipRegistryArguments { traChainOffset
+                                     , traGetCurrentChain
+                                     , traTracer } =
+    (makeTipRegistryImpl . TipRegistryState) <$> newTVarIO Map.empty
+  where
+    makeTipRegistryImpl :: TipRegistryState peerAddr header m
+                        -> TipRegistry      peerAddr header m
+    makeTipRegistryImpl trs = TipRegistry {
+        getPeerResults = getPeerResultsImpl trs,
+        registerPeer   = registerPeerImpl   trs,
+        unregisterPeer = unregisterPeerImpl trs
+      }
+
+    -- summarise results; we ignore all the slots in which there was only one
+    -- peer.
+    summariseResults :: Map SlotNo (NumberOfPeers, peerAddr)
+                     -> [(NumberOfWins, NumberOfPeers, peerAddr)]
+
+    summariseResults =
+          sort
+        . map (\(a, (b, c)) -> (b, c, a))
+        . Map.assocs
+        . Map.foldl' go Map.empty
+      where
+        go :: Map peerAddr (NumberOfWins, NumberOfPeers)
+           -> (NumberOfPeers, peerAddr)
+           -> Map peerAddr (NumberOfWins, NumberOfPeers)
+        go acc (numberOfPeers, peerAddr)
+          | numberOfPeers <= NumberOfPeers 1
+          = acc
+          | otherwise
+          = Map.alter (Just . maybe (NumberOfWins 1, numberOfPeers)
+                                    (bimap succ (+ numberOfPeers)))
+                      peerAddr acc
+
+
+    getPeerResultsImpl :: TipRegistryState peerAddr header m
+                       -> m [(NumberOfWins, NumberOfPeers, peerAddr)]
+
+    getPeerResultsImpl TipRegistryState { tipFragmentsVar } = do
+        currentChain <- AF.dropNewest traChainOffset <$> atomically traGetCurrentChain
+        atomically $ do
+          (peersMap :: Map peerAddr (TipFragment header)) <-
+            readTVar tipFragmentsVar >>= traverse readTVar
+
+          pure $! summariseResults (winningPeers currentChain peersMap)
+
+
+    -- create and register peer's `TipFragment`'s `TVar`.
+    registerPeerImpl :: TipRegistryState peerAddr header m
+                     -> peerAddr
+                     -> m (TipFragmentVar peerAddr m header)
+
+    registerPeerImpl TipRegistryState { tipFragmentsVar } peerAddr = do
+      k <- atomically $ do
+        tf <- newTVar Empty
+        modifyTVar tipFragmentsVar (Map.insert peerAddr tf)
+        pure $ TipFragmentVar $ \f -> do
+          (a, x) <- f <$> readTVar tf
+          writeTVar tf x $> a
+      traceWith traTracer (TipRegistryRegisteredPeer peerAddr)
+      pure k
+
+
+    -- remove peer's `TipFragment`'s `TVar` from the registry
+    unregisterPeerImpl :: TipRegistryState peerAddr header m
+                       -> peerAddr -> m ()
+
+    unregisterPeerImpl TipRegistryState { tipFragmentsVar } peerAddr = do
+      atomically $ modifyTVar tipFragmentsVar (Map.delete peerAddr)
+      traceWith traTracer (TipRegistryUnregisteredPeer peerAddr)
+
+
+--
+-- Operations needed by the client application.
+--
+
+
+-- | Find winning peers. Traverse the current chain and for each header find
+-- a winning peer; accumulate results.
+--
+-- This relies on the monotonicity of 'SlotNo's in 'TipFragment's, which is
+-- guarateed by 'tipSampleClient'. 
+--
+winningPeers
+    :: forall header peerAddr.
+       HasHeader header
+    => AnchoredFragment header
+    -- ^ current chain
+    -> Map peerAddr (TipFragment header)
+    -- ^ peer 'TipFragment'.  It may contain non valid 'Tip's.
+    -- use points!
+    -> Map SlotNo (NumberOfPeers, peerAddr)
+winningPeers currentChain0 tips0 =
+    fst $ CF.foldChainFragment go (Map.empty, tips0)
+                                  (AF.unanchorFragment currentChain0)
+  where
+    -- The outer loop traversing the chain; we thread peers map through the
+    -- computation: we truncate peers 'TipFragment's as we go.  Note:
+    -- 'CF.foldChainFragment' is a left fold, so we traverse the chain from
+    -- left (old) to right (new) headers, as we go we truncate the
+    -- 'TipFragment's (which improves computational complexity).
+    go :: (Map SlotNo (NumberOfPeers, peerAddr), Map peerAddr (TipFragment header))
+       -> header
+       -> (Map SlotNo (NumberOfPeers, peerAddr), Map peerAddr (TipFragment header))
+    go (acc, peersMap) header =
+      case takeRow header peersMap of
+        ( Just (_, !noPeers, !peerAddr), peersMap' ) ->
+          ( Map.insert (blockSlot header) (noPeers, peerAddr) acc
+          , peersMap'
+          )
+
+        ( Nothing, peersMap' ) -> (acc, peersMap')
+
+    -- The innter loop which is traversing all 'TipFragment's; it finds the
+    -- winning peer in a given slot and returns the winner and truncated
+    -- 'TipFragment's.  It only accounts valid 'Tip's.
+    takeRow :: header
+            -> Map peerAddr (TipFragment header)
+            -> ( Maybe (Time, NumberOfPeers, peerAddr)
+               , Map peerAddr (TipFragment header)
+               )
+    takeRow header = Map.mapAccumWithKey goTakeRow Nothing
+      where
+        blockSlotNo = blockSlot header
+        goTakeRow :: Maybe (Time, NumberOfPeers, peerAddr)
+                  -> peerAddr
+                  -> TipFragment header
+                  -> (Maybe (Time, NumberOfPeers, peerAddr), TipFragment header)
+        goTakeRow mr peerAddr tf =
+          -- we find the newest most block with the given 'SlotNo'
+          case TF.lookupBySlotNo (At blockSlotNo) tf of
+            Just (Timed t tip, tf')
+              -- validate the tip
+              | getTipSlotNo  tip == At blockSlotNo
+              , getTipBlockNo tip == At (blockNo header)
+              , pointHash (getTipPoint tip) == BlockHash (blockHash header)
+              -> case mr of
+                  Just (t', !noPeers', peerAddr')
+                    | t' <= t
+                    -> (Just (t', succ noPeers',   peerAddr'), tf')
+
+                    | otherwise
+                    -> (Just (t,  succ noPeers',   peerAddr),  tf')
+
+                  Nothing
+                    -> (Just (t,  NumberOfPeers 1, peerAddr),  tf')
+
+              -- there might be multiple headers with the same slot, if the
+              -- `Tip` has greater `blockNo` than the 'header', preserve it.
+              | getTipSlotNo tip == At blockSlotNo
+              , getTipBlockNo tip > At (blockNo header)
+              -> (mr, tf)
+
+              | otherwise
+              -> (mr, tf')
+
+            Nothing -> (mr, tf)
+
+
+--
+-- Trace
+--
+
+
+data TipRegistryTrace peerAddr header =
+    TipRegistryRegisteredPeer   !peerAddr
+  | TipRegistryUnregisteredPeer !peerAddr
+  deriving (Eq, Show)
+

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -16,6 +16,7 @@ import qualified Test.Ouroboros.Network.KeepAlive (tests)
 import qualified Ouroboros.Network.NodeToNode.Version.Test (tests)
 import qualified Ouroboros.Network.NodeToClient.Version.Test (tests)
 import qualified Test.Ouroboros.Network.TipSample.TipFragment (tests)
+import qualified Test.Ouroboros.Network.TipSample.TipRegistry (tests)
 import qualified Ouroboros.Network.Protocol.ChainSync.Test (tests)
 import qualified Ouroboros.Network.Protocol.BlockFetch.Test (tests)
 import qualified Ouroboros.Network.Protocol.Handshake.Test (tests)
@@ -60,6 +61,7 @@ tests =
   , Ouroboros.Network.NodeToNode.Version.Test.tests
   , Ouroboros.Network.NodeToClient.Version.Test.tests
   , Test.Ouroboros.Network.TipSample.TipFragment.tests
+  , Test.Ouroboros.Network.TipSample.TipRegistry.tests
 
     -- pseudo system-level
   , Test.Ouroboros.Network.MockNode.tests

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -15,6 +15,7 @@ import qualified Test.Ouroboros.Network.BlockFetch (tests)
 import qualified Test.Ouroboros.Network.KeepAlive (tests)
 import qualified Ouroboros.Network.NodeToNode.Version.Test (tests)
 import qualified Ouroboros.Network.NodeToClient.Version.Test (tests)
+import qualified Test.Ouroboros.Network.TipSample.TipFragment (tests)
 import qualified Ouroboros.Network.Protocol.ChainSync.Test (tests)
 import qualified Ouroboros.Network.Protocol.BlockFetch.Test (tests)
 import qualified Ouroboros.Network.Protocol.Handshake.Test (tests)
@@ -58,6 +59,7 @@ tests =
   , Test.Ouroboros.Network.KeepAlive.tests
   , Ouroboros.Network.NodeToNode.Version.Test.tests
   , Ouroboros.Network.NodeToClient.Version.Test.tests
+  , Test.Ouroboros.Network.TipSample.TipFragment.tests
 
     -- pseudo system-level
   , Test.Ouroboros.Network.MockNode.tests

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -17,6 +17,7 @@ import qualified Ouroboros.Network.NodeToNode.Version.Test (tests)
 import qualified Ouroboros.Network.NodeToClient.Version.Test (tests)
 import qualified Test.Ouroboros.Network.TipSample.TipFragment (tests)
 import qualified Test.Ouroboros.Network.TipSample.TipRegistry (tests)
+import qualified Test.Ouroboros.Network.TipSample.Client (tests)
 import qualified Ouroboros.Network.Protocol.ChainSync.Test (tests)
 import qualified Ouroboros.Network.Protocol.BlockFetch.Test (tests)
 import qualified Ouroboros.Network.Protocol.Handshake.Test (tests)
@@ -62,6 +63,7 @@ tests =
   , Ouroboros.Network.NodeToClient.Version.Test.tests
   , Test.Ouroboros.Network.TipSample.TipFragment.tests
   , Test.Ouroboros.Network.TipSample.TipRegistry.tests
+  , Test.Ouroboros.Network.TipSample.Client.tests
 
     -- pseudo system-level
   , Test.Ouroboros.Network.MockNode.tests

--- a/ouroboros-network/test/Test/ChainFragment.hs
+++ b/ouroboros-network/test/Test/ChainFragment.hs
@@ -8,6 +8,7 @@ module Test.ChainFragment
   ( tests
   , TestBlockChainFragmentAndUpdates(..)
   , TestBlockChainFragment(..)
+  , TestHeaderChainFragment(..)
   , TestChainFragmentAndPoint (..)
   , TestChainFragmentFork(..)
   , TestAddBlock(..)
@@ -28,7 +29,6 @@ import qualified Ouroboros.Network.MockChain.Chain as Chain
 import           Ouroboros.Network.Point (WithOrigin (At))
 import           Ouroboros.Network.Testing.ConcreteBlock
 import           Ouroboros.Network.Testing.Serialise (prop_serialise)
-import           Test.Chain ()
 import           Test.ChainGenerators (TestBlockChain (..),
                      TestChainAndRange (..), addSlotGap, genChainAnchor,
                      genNonNegative, genSlotGap)

--- a/ouroboros-network/test/Test/Ouroboros/Network/TipSample/Client.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/TipSample/Client.hs
@@ -1,0 +1,608 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DerivingVia         #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+
+module Test.Ouroboros.Network.TipSample.Client (tests) where
+
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadST
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadTimer
+import           Control.Monad.IOSim
+import           Control.Tracer (Tracer (..), contramap, nullTracer)
+
+import           Control.Arrow (second, (***))
+
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.Serialise as Serialise (Serialise (..), DeserialiseFailure)
+import           Data.ByteString.Lazy (ByteString)
+import           Data.Functor (($>))
+import           Data.Foldable (foldl')
+import           Data.List (partition, sort)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Vector as Vector
+import           System.Random (StdGen, mkStdGen)
+import qualified System.Random as Random
+import qualified Statistics.Quantile as Statistics
+
+import           Cardano.Slotting.Slot (WithOrigin (..))
+
+import           Network.TypedProtocol.Pipelined (N (..), Nat (Zero, Succ))
+
+import           Ouroboros.Network.Block
+import           Ouroboros.Network.Channel
+import           Ouroboros.Network.Codec
+import           Ouroboros.Network.Driver
+import           Ouroboros.Network.Mux (ControlMessage (..))
+import           Ouroboros.Network.AnchoredFragment ( AnchoredFragment )
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.ChainFragment (ChainFragment)
+import qualified Ouroboros.Network.ChainFragment as CF
+
+import           Ouroboros.Network.Protocol.TipSample.Type
+import           Ouroboros.Network.Protocol.TipSample.Codec
+import           Ouroboros.Network.Protocol.TipSample.Client
+import           Ouroboros.Network.Protocol.TipSample.Server
+import           Ouroboros.Network.TipSample.Client
+import           Ouroboros.Network.TipSample.TipFragment ( Timed (..) )
+import           Ouroboros.Network.TipSample.TipRegistry
+import           Ouroboros.Network.Util.ShowProxy
+
+import           Test.ChainGenerators hiding (tests)
+import           Test.ChainFragment (TestHeaderChainFragment (..))
+import           Ouroboros.Network.Testing.ConcreteBlock
+
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Network.TipSample"
+  [ testGroup "Client"
+    [ testProperty "client and registry"   prop_tipSampleClient
+    , testProperty "simpleTipSamplePolicy" prop_simpleTipSamplePolicy
+    ]
+  ]
+
+
+data TestChainFragmentAndRange =
+    TestChainFragmentAndRange (ChainFragment BlockHeader) Int Int Int
+  deriving (Show, Eq)
+
+
+data ClientId =
+    Client0
+  | Client1
+  deriving (Show, Eq, Ord)
+
+
+instance Arbitrary TestChainFragmentAndRange where
+    arbitrary = do
+        (prevhash, prevblock, prevslot) <- genChainAnchor
+        n <- choose (3, 100)
+        bodies <- vector n
+        slots  <- mkSlots prevslot <$>
+                    suchThat
+                      (vectorOf n genSlotGap)
+                      (\as -> length (filter (/= 0) as) >= 3)
+        let chain = CF.mapChainFragment blockHeader
+                  $ mkChainFragment prevhash prevblock (zip slots bodies)
+        maxHistory <- choose (1, n)
+        let Just (SlotNo maxSlot) = CF.headSlot chain
+        maxSlotRange <- choose (1, fromIntegral maxSlot - 1)
+        maxMultipleTipsRange <- choose (1, fromIntegral maxSlot - maxSlotRange)
+        return $ TestChainFragmentAndRange chain maxHistory maxSlotRange maxMultipleTipsRange
+      where
+        mkSlots :: SlotNo -> [Int] -> [SlotNo]
+        mkSlots (SlotNo prevslot) =
+            map SlotNo . tail
+          . scanl (\slot gap -> slot + fromIntegral gap) prevslot
+
+    shrink (TestChainFragmentAndRange chain maxHistory maxSlotRange maxMultipleTipsRange)
+        = if maxHistory > 1
+            then [ TestChainFragmentAndRange chain (pred maxHistory) maxSlotRange maxMultipleTipsRange ]
+            else []
+          ++
+          if maxSlotRange > 1
+            then [ TestChainFragmentAndRange chain maxHistory (pred maxSlotRange) maxMultipleTipsRange ]
+            else []
+          ++
+          if maxMultipleTipsRange > 1
+            then [ TestChainFragmentAndRange chain maxHistory maxSlotRange (pred maxMultipleTipsRange) ]
+            else []
+          ++
+          [ TestChainFragmentAndRange chain'
+                                      (maxHistory `min` CF.length chain')
+                                      maxSlotRange'
+                                      maxMultipleTipsRange'
+          | TestHeaderChainFragment chain' <- shrink (TestHeaderChainFragment chain)
+          , CF.length chain' >= 3
+          , let Just (maxSlotRange', maxMultipleTipsRange') =
+                  fixRanges (CF.length chain') maxSlotRange maxMultipleTipsRange
+          ]
+      where
+        -- invariant: @n + m < l@
+        fixRanges :: Int -> Int -> Int -> Maybe (Int, Int)
+        fixRanges l n m | n + m < l      = Just (n, m)
+                        | n > 1 && m > 1 = fixRanges (pred n) (pred m) l
+                        | n > 1          = fixRanges (pred n) m l
+                        | m > 1          = fixRanges n (pred m) l
+                        | otherwise      = Nothing
+
+
+
+-- | Run two 'tipSampleClient''s against two servers  using 'Channels', returns
+-- 'TipRegistry' results using 'getPeerResults' method.
+--
+tipSampleClientExperiment
+    :: forall header m.
+       ( MonadAsync         m
+       , MonadDelay         m
+       , MonadMonotonicTime m
+       , MonadST            m
+       , MonadSTM           m
+       , MonadCatch         m
+       , MonadThrow         m
+       , HasHeader          header
+       , ShowProxy          header
+       , Show               header
+       )
+    => Tracer m (ClientId, TipSampleClientTrace header)
+    -> AnchoredFragment header
+    -> TipSamplePolicy
+    -> Codec (TipSample (Tip header))
+             Serialise.DeserialiseFailure
+             m ByteString
+    -> (Channel m ByteString, Channel m ByteString)
+    -> (Channel m ByteString, Channel m ByteString)
+    -> StdGen
+    -> m [(NumberOfWins, NumberOfPeers, ClientId)]
+tipSampleClientExperiment clientTracer af
+                          tsp
+                          codec
+                          channels0
+                          channels1
+                          stdGen = do
+    tipRegistry <-
+      makeTipRegistry
+        TipRegistryArguments {
+            traChainOffset     = 0,
+            traGetCurrentChain = pure af,
+            traTracer          = nullTracer
+          }
+    let (stdGen0, stdGen1) = Random.split stdGen
+
+    currentSlotNoVar <- newTVarIO Origin
+
+    tfc0 <- registerPeer tipRegistry Client0
+    let client0 = makeTipSampleClient
+                    ((Client0,) `contramap` clientTracer)
+                    tfc0 currentSlotNoVar stdGen0
+
+    tfc1 <- registerPeer tipRegistry Client1
+    let client1 = makeTipSampleClient
+                    ((Client1,) `contramap` clientTracer)
+                    tfc1 currentSlotNoVar stdGen1
+
+    _ <-
+      (
+        runPeer nullTracer codec (fst channels0) (tipSampleServerPeer (tipSampleServer af))
+        `race_`
+        runPeer nullTracer codec (snd channels0) (tipSampleClientPeer client0)
+      )
+      `concurrently`
+      (
+        runPeer nullTracer codec (fst channels1) (tipSampleServerPeer (tipSampleServer af))
+        `race_`
+        runPeer nullTracer codec (snd channels1) (tipSampleClientPeer client1)
+      )
+      `concurrently`
+      runTime currentSlotNoVar
+
+    getPeerResults tipRegistry
+  where
+    -- we are gods, we are in control of time flow ;)
+    runTime :: TVar m (WithOrigin SlotNo) -> m ()
+    runTime var = go (AF.toOldestFirst af)
+      where
+        go [] = atomically $ do
+          a <- readTVar var
+          case a of
+            Origin    -> writeTVar var (At $ SlotNo 1)
+            At slotNo -> writeTVar var (At $ succ slotNo)
+        go (h : hs) = do
+          atomically $ writeTVar var (At $ blockSlot h)
+          threadDelay 1
+          go hs
+
+
+    makeTipSampleClient :: Tracer m (TipSampleClientTrace header)
+                        -> TipFragmentVar ClientId m header
+                        -> TVar m (WithOrigin SlotNo)
+                        -> StdGen
+                        -> TipSampleClient (Tip header) m ()
+    makeTipSampleClient tr (TipFragmentVar tsaModifyTipFragment) currentSlotNoVar stdGen' =
+      let tsaGetCurrentSlotNo :: STM m SlotNo
+          tsaGetCurrentSlotNo = do
+            curSlotNo <- readTVar currentSlotNoVar
+            case curSlotNo of
+              Origin -> retry
+              At slotNo -> pure slotNo
+
+          -- We need to stop the client before it will request a tip which is
+          -- outside of the chain.
+          stopAction :: STM m ControlMessage
+          stopAction = do
+            mbCurrentSlot <- readTVar currentSlotNoVar
+            let currentSlot =
+                  case mbCurrentSlot of
+                    Origin -> SlotNo 0
+                    At slotNo -> slotNo
+            -- check if the server will be able to find slots on the chain; It
+            -- must contain slot 'tspSlotRange' away from the current slot plus
+            -- 'tspMultipleTipsRange' elements on the rest of the chain.
+            case CF.lookupBySlotFT
+                    (AF.unanchorFragment af)
+                    (currentSlot + fromIntegral (snd (tspSlotRange tsp))) of
+              CF.Position _ _ cf'
+                | fromIntegral (CF.length (CF.ChainFragment cf'))
+                  >= snd (tspMultipleTipsRange tsp)
+                ->
+                pure Continue
+
+              _ ->
+                pure Terminate
+
+      in tipSampleClient
+               tsp
+               TipSampleActions {
+                   tsaModifyTipFragment,
+                   tsaGetCurrentSlotNo,
+                   tsaSlotTime = pure (const Nothing),
+                   tsaTracer = tr
+                 }
+               stopAction
+               stdGen'
+
+
+-- | A 'TipSampleServer' which sends @'Tip' header@'s from the given chain.
+--
+tipSampleServer :: forall header m.
+                   ( Monad m
+                   , HasHeader header
+                   , Show      header
+                   )
+                => AnchoredFragment header
+                -> TipSampleServer (Tip header) m ()
+tipSampleServer af = TipSampleServer $ pure (go (AF.unanchorFragment af))
+  where
+    go :: ChainFragment header -> ServerStIdle (Tip header) m ()
+    go cf = ServerStIdle {
+        handleFollowTip = handleFollowTip cf,
+        handleDone
+      }
+
+    handleFollowTip :: forall (n :: N).
+                       ChainFragment header
+                    -> Nat (S n)
+                    -> SlotNo
+                    -> m (SendTips (S n) (Tip header) m ())
+    handleFollowTip cf n0 slotNo =
+        case CF.lookupBySlotFT cf slotNo of
+          CF.Position _ header0 cf0 ->
+            pure $ sendTips n0 header0 (CF.ChainFragment cf0)
+          CF.OnLeft ->
+            pure $ error "handleFollowTip: unexpected OnLeft"
+          CF.OnRight ->
+            pure $ error "handleFollowTip: unexpected OnRight"
+          CF.Nowhere ->
+            pure $ error "handleFollowTip: unexpected Nowhere"
+
+      where
+        sendTips :: forall (k :: N).
+                    Nat (S k)
+                 -> header
+                 -> ChainFragment header
+                 -> SendTips (S k) (Tip header) m ()
+        sendTips n@(Succ Zero) header' cf' =
+          SendLastTip n (getHeaderTip header') (go cf')
+        sendTips n@(Succ n'@Succ{}) header' cf' =
+          SendNextTip n (getHeaderTip header') $
+            case cf' of
+              CF.Empty -> error $ "tipSampleServer: chain invariant violation: "
+                               ++ show (n, getHeaderTip header')
+              header'' CF.:< cf'' ->
+                pure $ sendTips n' header'' cf''
+
+
+    getHeaderTip :: header -> Tip header
+    getHeaderTip hdr = Tip (blockSlot hdr) (blockHash hdr) (blockNo hdr)
+
+    handleDone :: m ()
+    handleDone = pure ()
+
+
+-- | Seed for 'StdGen'.
+--
+newtype Seed = Seed Int
+  deriving Arbitrary via Large Int
+  deriving Show
+
+
+prop_tipSampleClient
+    :: TestChainFragmentAndRange
+    -> Seed
+    -> ([Positive Integer], [Positive Integer])
+    -- ^ delays applied to channels
+    -> Property
+prop_tipSampleClient (TestChainFragmentAndRange cf maxHistory maxSlotRange maxMultipleTipsRange)
+                     (Seed seed)
+                     (delays0, delays1) =
+    (\tr -> validateResults tr $ traceInfo tr) $
+    runSimTrace $ do
+
+      delaysVar0 <- newTVarIO $ (fromInteger . getPositive)
+                                `map` (cycle $ case delays0 of {[] -> [Positive 0]; _ -> delays0})
+      delaysVar1 <- newTVarIO $ (fromInteger . getPositive)
+                                `map` (cycle $ case delays1 of {[] -> [Positive 0]; _ -> delays1})
+      channelPair0 <- second (modifyChannel delaysVar0) <$> createConnectedChannels
+      channelPair1 <- second (modifyChannel delaysVar1) <$> createConnectedChannels
+
+      tipSampleClientExperiment
+        clientTracer
+        (AF.mkAnchoredFragment AF.AnchorGenesis cf)
+        policy
+        codec
+        channelPair0
+        channelPair1
+        (mkStdGen seed)
+  where
+    policy :: TipSamplePolicy
+    policy = TipSamplePolicy {
+          tspMaxHistory               = fromIntegral maxHistory,
+          tspSlotRange                = (1, fromIntegral maxSlotRange),
+          tspFollowSingleTipWeight    = 8,
+          tspFollowMultipleTipsWeight = 2,
+          tspMultipleTipsRange        = (2, fromIntegral maxMultipleTipsRange)
+        }
+
+    traceInfo :: Trace [(NumberOfWins, NumberOfPeers, ClientId)]
+              -> Either Failure
+                   ( [(NumberOfWins, NumberOfPeers, ClientId)]
+                   , [(ClientId, TipSampleClientTrace BlockHeader)]
+                   )
+    traceInfo tr =
+      let tr' = selectTraceEventsDynamic tr
+      in case traceResult True tr of
+        Left f   -> Left f
+        Right rs -> Right (rs, tr')
+
+
+    validateResults :: Trace a
+                    -> Either Failure
+                         ( [(NumberOfWins, NumberOfPeers, ClientId)]
+                         , [(ClientId, TipSampleClientTrace BlockHeader)]
+                         )
+                    -> Property
+    validateResults tr (Left failure) =
+        counterexample
+          (show failure ++ "\n" ++ (foldl' (\acc a -> acc ++ "\n" ++ show a) "" $ traceEvents tr))
+          False
+    validateResults _ (Right (results, trace)) =
+        map (\(a, _, c) -> (a, c)) results === computeResults tts0 tts1
+      where
+        (tts0, tts1) = dataFromTrace *** dataFromTrace
+                     $ partition ((Client0 ==) . fst)
+                     $ trace
+
+        dataFromTrace :: [(ClientId, TipSampleClientTrace BlockHeader)]
+                      -> [Timed (Tip BlockHeader)]
+        dataFromTrace = take maxHistory
+                      . foldr go []
+          where
+            go (_, TipSampleClientProtocolValidationError {}) acc = acc
+            go (_, TipSampleClientAddTip tt _)   acc = tt : acc
+            go (_, TipSampleClientRollback tt _) acc = tt : acc
+
+        -- we don't compute 'NumberOfPeers'; when there are only two peers it
+        -- will not change the order of the results
+        computeResults :: [Timed (Tip BlockHeader)]
+                       -> [Timed (Tip BlockHeader)]
+                       -> [(NumberOfWins, ClientId)]
+        computeResults = go (NumberOfWins 0) (NumberOfWins 0)
+          where
+            go :: NumberOfWins
+               -> NumberOfWins
+               -> [Timed (Tip BlockHeader)]
+               -> [Timed (Tip BlockHeader)]
+               -> [(NumberOfWins, ClientId)]
+
+            go !r0 !r1 [] [] =
+                filter (\(n, _) -> n > NumberOfWins 0) $ sort [(r0, Client0), (r1, Client1)]
+
+            go !r0 !r1 tf0@(tt0 : tf0') tf1@(tt1 : tf1') =
+                case getTipSlotNo (timedData tt0) `compare` getTipSlotNo (timedData tt1) of
+                  EQ -> if timedAt tt0 <= timedAt tt1
+                          -- biased towards peers with smaller address
+                          then go (succ r0) r1 tf0' tf1'
+                          else go r0 (succ r1) tf0' tf1'
+                  LT -> go r0 r1 tf0' tf1
+                  GT -> go r0 r1 tf0  tf1'
+
+            go !r0  r1 (_ : tf0') [] = go r0 r1 tf0' []
+
+            go  r0 !r1 [] (_ : tf1') = go r0 r1 []  tf1'
+
+
+    codec :: MonadST m
+          => Codec (TipSample (Tip BlockHeader))
+                   Serialise.DeserialiseFailure
+                   m ByteString
+    codec = codecTipSample encodeBlockHeaderTip decodeBlockHeaderTip
+      where
+        encodeBlockHeaderTip :: Tip BlockHeader -> CBOR.Encoding
+        encodeBlockHeaderTip TipGenesis =
+             CBOR.encodeListLen 1
+          <> CBOR.encodeWord 0
+        encodeBlockHeaderTip (Tip slot hash blockNo_) =
+             CBOR.encodeListLen 4
+          <> CBOR.encodeWord 1
+          <> Serialise.encode slot
+          <> Serialise.encode hash
+          <> Serialise.encode blockNo_
+
+        decodeBlockHeaderTip :: forall s. CBOR.Decoder s (Tip BlockHeader)
+        decodeBlockHeaderTip = do
+          l <- CBOR.decodeListLen
+          t <- CBOR.decodeWord
+          case (l, t) of
+            (1, 0) -> pure TipGenesis
+            (4, 1) -> Tip <$> Serialise.decode
+                          <*> Serialise.decode
+                          <*> Serialise.decode
+            _      -> fail $ "decodeTip: failure " ++ show (l, t)
+
+
+    -- modify receive side of clients using a random list of delays
+    modifyChannel :: ( MonadDelay m
+                     , MonadSTM   m
+                     )
+                  => TVar m [DiffTime]
+                  -> Channel m ByteString
+                  -> Channel m ByteString
+    modifyChannel v =
+      channelEffect
+        (\_ -> pure ())
+        (\_ -> do
+          delay
+            <- atomically $ do
+              as <- readTVar v
+              case as of
+                a : as' -> writeTVar v as' $> a
+                []      -> pure 0
+          threadDelay delay)
+
+    clientTracer :: forall s. Tracer (IOSim s) (ClientId, TipSampleClientTrace BlockHeader)
+    clientTracer = Tracer traceM
+
+
+data TestSimplePolicyArgs = TestSimplePolicyArgs
+    { tspaMaxHistory        :: Word
+    , tspaNumberOfWarmPeers :: Word
+    , tspaPeersPerSlot      :: Word
+    , tspaSlotRange         :: Word
+    }
+  deriving Show
+
+instance Arbitrary TestSimplePolicyArgs where
+    arbitrary = do
+      -- in the test 'tspaMaxHistory' also specifies how many experiments we
+      -- run for each quickcheck.
+      tspaMaxHistory <- choose (100, 300)
+      -- we only test the range we are interested in
+      tspaNumberOfWarmPeers <- choose (30, 70)
+      tspaPeersPerSlot <- choose (5, tspaNumberOfWarmPeers)
+      tspaSlotRange    <- choose (1, 2 * tspaNumberOfWarmPeers `div` tspaPeersPerSlot)
+      pure $ TestSimplePolicyArgs {
+          tspaMaxHistory,
+          tspaNumberOfWarmPeers,
+          tspaPeersPerSlot,
+          tspaSlotRange
+        }
+
+
+newtype PeerId = PeerId Word
+  deriving (Show, Eq, Ord)
+
+
+prop_simpleTipSamplePolicy
+    :: TestSimplePolicyArgs
+    -> Seed
+    -> Property
+prop_simpleTipSamplePolicy
+  TestSimplePolicyArgs {
+      tspaMaxHistory,
+      tspaNumberOfWarmPeers,
+      tspaPeersPerSlot,
+      tspaSlotRange
+    }
+  (Seed seed) =
+    validate $ runGame $ PeerId `map` [0 .. pred tspaNumberOfWarmPeers]
+  where
+    validate :: Map SlotNo [PeerId]
+             -> Property
+    validate m =
+      let v = Statistics.quantile
+                Statistics.normalUnbiased
+                1 3
+                (Vector.fromList $ (realToFrac . length) `map` Map.elems m)
+
+          -- We check that the first 3-quantile is larger than 75% of the
+          -- expected mean. This means that less than 1/3 of all the slots, less
+          -- than (0.75 * tspaPeersPerSlot) number of peers is fighting to win
+          -- the slot.
+          predicate = v >= 0.75 * realToFrac tspaPeersPerSlot
+      in
+         label (mkLabel v)
+       . counterexample (show m)
+       -- we check that the 'predicate' is valid in at least 90% of cases
+       . checkCoverage
+       . cover 90.0 predicate "peers-per-slot"
+       $ True
+
+    mkLabel :: Double -> String
+    mkLabel i = let l, mini, maxi :: Int
+                    l = 10
+                    mini = l * (round i `div` l)
+                    maxi = mini + l
+                in show mini ++ " - " ++ show maxi
+
+    policy = simpleTipSamplePolicy
+                tspaMaxHistory
+                tspaNumberOfWarmPeers
+                tspaPeersPerSlot
+                tspaSlotRange
+
+    runGame :: [PeerId] -> Map SlotNo [PeerId]
+    runGame
+        = snd
+        . foldl'
+            (\(g, acc) peerId ->
+              case Random.split g of
+                (g', g'') ->
+                  let !acc' = Map.unionWith (++)
+                                (Map.fromList . map (,[peerId]) $ slots g')
+                                acc
+                  in (g'', acc'))
+            (mkStdGen seed, Map.empty)
+
+    -- list of slots produced by 'randomTipSampleDecision' run recursively
+    slots :: StdGen -> [SlotNo]
+    slots = go (SlotNo 0) []
+      where
+        go :: SlotNo -> [SlotNo] -> StdGen -> [SlotNo]
+        go _currentSlot !acc _g
+          | length acc >= fromIntegral tspaMaxHistory
+          = reverse $ take (fromIntegral tspaMaxHistory) acc
+        go currentSlot  !acc g =
+          case randomTipSampleDecision policy g of
+            (FollowSingleTip slotNo, g') ->
+              let nextSlot = currentSlot + fromIntegral slotNo
+              in go nextSlot (nextSlot : acc) g'
+            (FollowMultipleTips slotNo range, g') ->
+              let firstSlot = currentSlot + fromIntegral slotNo
+                  lastSlot  = firstSlot + fromIntegral range
+              in go lastSlot
+                    ([lastSlot, pred lastSlot .. firstSlot] ++ acc)
+                    g'

--- a/ouroboros-network/test/Test/Ouroboros/Network/TipSample/TipFragment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/TipSample/TipFragment.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Ouroboros.Network.TipSample.TipFragment (tests) where
+
+import           Control.Monad.Class.MonadTime
+
+import qualified Data.Foldable as Foldable
+import qualified Data.FingerTree.Strict as FT
+
+import           Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..))
+
+import           Ouroboros.Network.Block (Tip (..), getTipSlotNo)
+import qualified Ouroboros.Network.ChainFragment as CF
+import           Ouroboros.Network.TipSample.TipFragment ( TipFragment
+                                                         , TipFragment' (Empty, (:<), (:>))
+                                                         , Timed (..))
+import qualified Ouroboros.Network.TipSample.TipFragment as TF
+
+import           Ouroboros.Network.Testing.ConcreteBlock
+import           Test.ChainFragment hiding (tests)
+
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Network.TipSample"
+  [ testGroup "TipFragment"
+    [ testProperty "toOldestFirst"         prop_toOldestFirst
+    , testProperty "lookupBySlotFT"        prop_lookupBySlotFT
+    , testProperty "lookupBySlotNo"        prop_lookupBySlotNo
+    , testProperty "dropNewestUntilSlotNo" prop_dropNewestUntilSlotNo
+    , testProperty "dropOldestUntilSlotNo" prop_dropOldestUntilSlotNo
+    ]
+  ]
+
+
+newtype TestTipFragment = TestTipFragment (TipFragment BlockHeader)
+  deriving Show
+
+instance Arbitrary TestTipFragment where
+    arbitrary = do
+      TestHeaderChainFragment cf <- arbitrary
+      (diffs :: [DiffTime])
+        <- vectorOf (CF.length cf) (fromRational . getPositive <$> arbitrary)
+      pure $ TestTipFragment
+           $ fst
+           $ Foldable.foldl'
+               (\(tf, t) (hdr, diff) ->
+                  let t' =  diff `addTime` t in
+                  ( tf :>
+                    Timed {
+                      timedAt   = t',
+                      timedData = Tip (headerSlot hdr) (headerHash hdr) (headerBlockNo hdr)
+                    }
+                  , t'))
+                (Empty, Time 0)
+                (zip (CF.toOldestFirst cf) diffs)
+
+data TestTipFragmentAndSlotNo = TestTipFragmentAndSlotNo SlotNo (TipFragment BlockHeader)
+  deriving Show
+
+instance Arbitrary TestTipFragmentAndSlotNo where
+    arbitrary = do
+      TestTipFragment tf <- arbitrary
+      let maxSlotNo =
+            case TF.viewRight tf of
+              FT.EmptyR -> 0
+              _ FT.:> (Timed _ (Tip (SlotNo slotNo) _ _)) -> slotNo
+              _ FT.:> (Timed _ TipGenesis) -> 0
+      slotNo <-
+        SlotNo <$>
+          frequency
+            -- 80% of cases the `SlotNo` will be smaller than the last slot in
+            -- the generated 'TipFragment'
+            [ (8, choose (0, maxSlotNo))
+            , (2, choose (maxSlotNo, 2 * maxSlotNo))
+            ]
+      pure (TestTipFragmentAndSlotNo slotNo tf)
+
+
+prop_toOldestFirst :: TestTipFragment
+                   -> Bool
+prop_toOldestFirst (TestTipFragment tf) =
+    tf == foldr (:<) Empty (TF.toOldestFirst tf)
+
+
+prop_lookupBySlotFT :: TestTipFragmentAndSlotNo
+                    -> Bool
+prop_lookupBySlotFT (TestTipFragmentAndSlotNo slotNo tf) =
+    case TF.lookupBySlotFT (At slotNo) tf of
+      FT.Position _ (Timed _ tip) _
+                 -> getTipSlotNo tip >= At slotNo
+      FT.OnLeft  -> False
+      FT.OnRight -> At slotNo > lastSlotNo || isEmpty
+      FT.Nowhere -> False
+  where
+    lastSlotNo = case tf of
+      _ :> Timed _ tip -> getTipSlotNo tip
+      Empty            -> Origin
+
+    isEmpty = case tf of
+      Empty -> True
+      _     -> False
+
+
+prop_lookupBySlotNo :: TestTipFragmentAndSlotNo
+                    -> Bool
+prop_lookupBySlotNo (TestTipFragmentAndSlotNo slotNo tf) =
+    case TF.lookupBySlotNo (At slotNo) tf of
+      Just (Timed _ tip, _) -> getTipSlotNo tip == At slotNo
+      Nothing               -> not (At slotNo `elem` slots)
+  where
+    slots :: [WithOrigin SlotNo]
+    slots = Foldable.foldr (\a as -> getTipSlotNo (timedData a) : as) [] tf
+
+
+prop_dropNewestUntilSlotNo :: TestTipFragmentAndSlotNo
+                           -> Bool
+prop_dropNewestUntilSlotNo (TestTipFragmentAndSlotNo slotNo tf) =
+       TF.toOldestFirst tf' == filter filterPred (TF.toOldestFirst tf)
+    &&
+        case tf' of
+          _ :> Timed _ tip -> getTipSlotNo tip <= At slotNo
+          Empty            -> At slotNo < firstSlotNo || isEmpty
+  where
+    tf' = TF.dropNewestUntilSlotNo slotNo tf
+
+    filterPred :: Timed (Tip BlockHeader) -> Bool
+    filterPred (Timed _ tip) = getTipSlotNo tip <= At slotNo
+
+    firstSlotNo = case tf of
+      Timed _ tip :< _ -> getTipSlotNo tip
+      Empty            -> Origin
+
+    isEmpty = case tf of
+      Empty -> True
+      _     -> False
+
+
+prop_dropOldestUntilSlotNo :: TestTipFragmentAndSlotNo
+                           -> Bool
+prop_dropOldestUntilSlotNo (TestTipFragmentAndSlotNo slotNo tf) =
+        TF.toOldestFirst tf' == filter filterPred (TF.toOldestFirst tf)
+    &&
+        case tf' of
+          Timed _ tip :< _ -> getTipSlotNo tip >= At slotNo
+          Empty            -> At slotNo > lastSlotNo || isEmpty
+  where
+    tf' = TF.dropOldestUntilSlotNo slotNo tf
+
+    filterPred :: Timed (Tip BlockHeader) -> Bool
+    filterPred (Timed _ tip) = getTipSlotNo tip >= At slotNo
+
+    lastSlotNo = case tf of
+      _ :> Timed _ tip -> getTipSlotNo tip
+      Empty            -> Origin
+
+    isEmpty = case tf of
+      Empty -> True
+      _     -> False

--- a/ouroboros-network/test/Test/Ouroboros/Network/TipSample/TipRegistry.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/TipSample/TipRegistry.hs
@@ -1,0 +1,278 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Ouroboros.Network.TipSample.TipRegistry
+  ( tests
+
+  , TestTipFragments (..)
+  )
+  where
+
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadSTM
+import           Control.Monad.IOSim
+import           Control.Tracer (nullTracer)
+import           Cardano.Slotting.Slot (WithOrigin (..))
+
+import           Data.List (sort)
+import           Data.Foldable (find, foldl', traverse_)
+import           Data.Maybe (isNothing)
+
+import           Ouroboros.Network.Block
+import           Ouroboros.Network.AnchoredFragment ( AnchoredFragment )
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import           Ouroboros.Network.ChainFragment (ChainFragment)
+import qualified Ouroboros.Network.ChainFragment as CF
+import           Ouroboros.Network.TipSample.TipFragment ( TipFragment
+                                                         , TipFragment' ((:<), (:>), Empty)
+                                                         , Timed (..) )
+import qualified Ouroboros.Network.TipSample.TipFragment as TF
+import           Ouroboros.Network.TipSample.TipRegistry
+
+import           Test.ChainFragment (TestHeaderChainFragment (..))
+import           Ouroboros.Network.Testing.ConcreteBlock
+
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Network.TipSample"
+  [ testGroup "TipRegistry"
+    [ testProperty "getPeerResults" prop_tipRegistry
+    , testProperty "unregisterPeer" prop_unregisterPeer
+    , testGroup "Generators"
+      [ testProperty "TestTipFragments generator" prop_TestFragmentsGenerator
+      , testProperty "TestTipFragments shrinker"  prop_TestFragmentsShrinker
+      ]
+    ]
+  ]
+
+
+data TestTipFragments = TestTipFragments (AnchoredFragment BlockHeader)
+                                         (TipFragment BlockHeader)
+                                         (TipFragment BlockHeader)
+  deriving Show
+
+
+data TipMask
+  = ValidTip DiffTime
+  | InvalidTip DiffTime (HeaderHash BlockHeader)
+  | IgnoredTip
+
+
+generateTipMask :: Gen TipMask
+generateTipMask =
+    frequency
+      [ (6, ValidTip . fromRational . getPositive <$> arbitrary)
+      , (2, InvalidTip
+              <$> (fromRational . getPositive <$> arbitrary)
+              <*> arbitrary
+        )
+      , (2, pure IgnoredTip)
+      ]
+
+-- Use the diff times and masks and transform 'ChainFragment' to
+-- a 'TipFragment'.
+makeTipFragment :: ChainFragment BlockHeader
+                -> [TipMask]
+                -> TipFragment BlockHeader
+makeTipFragment cf tipMasks =
+      fst
+    $ foldl'
+       (\(tf, t) (hdr, tipMask) ->
+          case tipMask of
+            IgnoredTip -> (tf, t)
+            ValidTip diff ->
+              let t' =  diff `addTime` t in
+              ( tf :>
+                Timed {
+                    timedAt   = t',
+                    timedData = Tip (headerSlot hdr) (headerHash hdr) (headerBlockNo hdr)
+                  }
+              , t')
+            InvalidTip diff invalidHash ->
+              let t' =  diff `addTime` t in
+              ( tf :>
+                Timed {
+                    timedAt   = t',
+                    timedData = Tip (headerSlot hdr) invalidHash (headerBlockNo hdr)
+                  }
+              , t'))
+       (Empty, Time 0)
+       (zip (CF.toOldestFirst cf) tipMasks)
+
+instance Arbitrary TestTipFragments where
+    arbitrary = do
+        TestHeaderChainFragment cf <- arbitrary
+        let cf' = fixCF cf
+            -- generate diff times & a mask at the same time.
+            mdiffs :: Gen [TipMask]
+            mdiffs = vectorOf (CF.length cf') generateTipMask
+
+        TestTipFragments (AF.mkAnchoredFragment AF.AnchorGenesis cf')
+          <$> (makeTipFragment cf' <$> mdiffs)
+          <*> (makeTipFragment cf' <$> mdiffs)
+      where
+        -- we only deal with chains that are monotonic in 'SlotNo'
+        fixCF :: ChainFragment BlockHeader
+              -> ChainFragment BlockHeader
+        fixCF (a CF.:< as@(a' CF.:< _))
+          | headerSlot a == headerSlot a'
+          = fixCF as
+          | otherwise
+          = a CF.:< fixCF as
+        fixCF as@(_ CF.:< CF.Empty) = as
+        fixCF CF.Empty = CF.Empty
+
+
+    -- a very basic shrinker
+    shrink (TestTipFragments af tf1 tf2) =
+        -- subtract head of the chain
+        (case af of
+          AF.Empty{}  -> []
+          af' AF.:> _ ->
+            case AF.headSlot af' of
+              At slotNo -> [ TestTipFragments
+                               af'
+                               (TF.dropNewestUntilSlotNo slotNo tf1)
+                               (TF.dropNewestUntilSlotNo slotNo tf2)
+                           ]
+              Origin    -> [ TestTipFragments af' Empty Empty ])
+      ++
+        -- subtract tail of the chain
+        (case af of
+          AF.Empty{}  -> []
+          _ AF.:< af' ->
+            case AF.headSlot af' of
+              At slotNo -> [ TestTipFragments
+                               af'
+                               (TF.dropOldestUntilSlotNo (succ slotNo) tf1)
+                               (TF.dropOldestUntilSlotNo (succ slotNo) tf2)
+                           ]
+              Origin    -> [ TestTipFragments af' Empty Empty ])
+
+--
+-- Generator tests
+--
+
+prop_TestFragmentsGenerator :: TestTipFragments -> Bool
+prop_TestFragmentsGenerator (TestTipFragments _af tf1 tf2) =
+       fst (foldl' monotonicPred (True, Nothing) tf1)
+    && fst (foldl' monotonicPred (True, Nothing) tf2)
+  where
+    monotonicPred (a, Nothing) (Timed _ tip) =
+      (a, Just tip)
+    monotonicPred (a, Just tip) (Timed _ tip') =
+      ( a && getTipSlotNo tip < getTipSlotNo tip'
+      , Just tip')
+
+prop_TestFragmentsShrinker :: TestTipFragments -> Bool
+prop_TestFragmentsShrinker = all prop_TestFragmentsGenerator . shrink
+
+--
+-- TipRegistry tests
+--
+
+tipRegistryProperty :: forall m.
+                       MonadSTM m
+                    => TestTipFragments
+                    -> m Property
+tipRegistryProperty (TestTipFragments af a b) = do
+    tipRegistry
+      <- makeTipRegistry TipRegistryArguments {
+                            traChainOffset = 0,
+                            traGetCurrentChain = pure af,
+                            traTracer = nullTracer
+                          }
+    registerPeer tipRegistry 1 >>= registerTips a
+    registerPeer tipRegistry 2 >>= registerTips b
+
+    ((pureResults a b ===) . map (\(x, _, y) -> (x, y)))
+      <$> getPeerResults tipRegistry
+  where
+
+    registerTips :: TipFragment BlockHeader
+                 -> TipFragmentVar Int m BlockHeader
+                 -> m ()
+    registerTips tf (TipFragmentVar fn) =
+      traverse_ (\tt -> atomically $ fn (\tf' -> ((), tf' :> tt))) tf
+
+    -- 'pureResults' relies on the invariant that 'TipFragment' is monotonic in
+    -- 'SlotNo'.
+    pureResults :: TipFragment BlockHeader
+                -> TipFragment BlockHeader
+                -> [(NumberOfWins, Int)]
+    pureResults x y = go (NumberOfWins 0) (NumberOfWins 0)
+                         (filterValidTips x) (filterValidTips y)
+      where
+        filterValidTips :: TipFragment BlockHeader
+                        -> TipFragment BlockHeader
+        filterValidTips =
+            foldl' (\zs z@(Timed _ tip) ->
+                     if AF.pointOnFragment (getTipPoint tip) af
+                       then zs :> z
+                       else zs
+                   ) Empty
+
+
+        go :: NumberOfWins
+           -> NumberOfWins
+           -> TipFragment BlockHeader
+           -> TipFragment BlockHeader
+           -> [(NumberOfWins, Int)]
+
+        go !r1 !r2 Empty Empty =
+            filter (\(n, _) -> n > NumberOfWins 0) $ sort [(r1, 1), (r2, 2)]
+
+        go !r1 !r2 tf1@(tt1 :< tf1') tf2@(tt2 :< tf2') =
+            case getTipSlotNo (timedData tt1) `compare` getTipSlotNo (timedData tt2) of
+              EQ -> if timedAt tt1 <= timedAt tt2
+                      -- biased towards peers with smaller address
+                      then go (succ r1) r2 tf1' tf2'
+                      else go r1 (succ r2) tf1' tf2'
+              LT -> go r1 r2 tf1' tf2
+              GT -> go r1 r2 tf1  tf2'
+
+        go !r1  r2 (_ :< tf1') tf2@Empty   = go r1 r2 tf1' tf2
+
+        go  r1 !r2 tf1@Empty   (_ :< tf2') = go r1 r2 tf1  tf2'
+
+
+prop_tipRegistry :: TestTipFragments
+                 -> Property
+prop_tipRegistry ttf = runSimOrThrow (tipRegistryProperty ttf)
+
+
+-- | Check that an unregistered peer does not appear in the results.
+--
+unregisterPeerProperty :: forall m. 
+                          MonadSTM m
+                       => TestTipFragments
+                       -> m Bool
+unregisterPeerProperty (TestTipFragments af a b) = do
+    tipRegistry
+      <- makeTipRegistry TipRegistryArguments {
+                            traChainOffset = 0,
+                            traGetCurrentChain = pure af,
+                            traTracer = nullTracer
+                          }
+    registerPeer tipRegistry 1 >>= registerTips a
+    registerPeer tipRegistry 2 >>= registerTips b
+    unregisterPeer tipRegistry 2
+    isValid <$> getPeerResults tipRegistry
+  where
+    isValid :: [(NumberOfWins, NumberOfPeers, Int)] -> Bool
+    isValid = isNothing . find (\(_, _, peerAddr) -> peerAddr == 2)
+
+    registerTips :: TipFragment BlockHeader
+                 -> TipFragmentVar Int m BlockHeader
+                 -> m ()
+    registerTips tf (TipFragmentVar fn) =
+      traverse_ (\tt -> atomically $ fn (\tf' -> ((), tf' :> tt))) tf
+
+prop_unregisterPeer :: TestTipFragments
+                    -> Bool
+prop_unregisterPeer ttf = runSimOrThrow (unregisterPeerProperty ttf)


### PR DESCRIPTION
This PR implements tip-sample application and `TipRegistry` which allows to
extract resutlts.

- tip-sample: TipFragment
- tip-sample: client application
- tip-sample: server application
- tip-sample: TipRegistry
- tip-sample: TipFragment tests
- tip-sample: TipRegistry tests
- ChainFragment: export lookupBySlotFT
- tip-sample: tipSampleClient integration test
