### PR TITLE
Update cardano-ledger-specs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -118,8 +118,8 @@ package small-steps-test
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
-  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
+  tag: d8f35c3c725be67148681227f9d64876f5909120
+  --sha256: 09v1m9km3arzxaqlyaw576w69fwfi02q7nm5ias162sfzzg8za4x
   subdir:   contra-tracer
 
 source-repository-package
@@ -138,113 +138,113 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 7d795c3040ea7785812efa1c97864bbb41b15d3e
-  --sha256: 130i0yj4y9br1m2bhisi6wni3f40i31nfhg878hv0kwi17chl9sz
+  tag: df8687488449f71dce3d881800c21e41fe1b7fc1
+  --sha256: 1chlqsp0g8lspnw2ia7v28pblr8iqqdiba51miznnclnj2vq9s2m
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 7d795c3040ea7785812efa1c97864bbb41b15d3e
-  --sha256: 130i0yj4y9br1m2bhisi6wni3f40i31nfhg878hv0kwi17chl9sz
+  tag: df8687488449f71dce3d881800c21e41fe1b7fc1
+  --sha256: 1chlqsp0g8lspnw2ia7v28pblr8iqqdiba51miznnclnj2vq9s2m
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 7d795c3040ea7785812efa1c97864bbb41b15d3e
-  --sha256: 130i0yj4y9br1m2bhisi6wni3f40i31nfhg878hv0kwi17chl9sz
+  tag: df8687488449f71dce3d881800c21e41fe1b7fc1
+  --sha256: 1chlqsp0g8lspnw2ia7v28pblr8iqqdiba51miznnclnj2vq9s2m
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 7d795c3040ea7785812efa1c97864bbb41b15d3e
-  --sha256: 130i0yj4y9br1m2bhisi6wni3f40i31nfhg878hv0kwi17chl9sz
+  tag: df8687488449f71dce3d881800c21e41fe1b7fc1
+  --sha256: 1chlqsp0g8lspnw2ia7v28pblr8iqqdiba51miznnclnj2vq9s2m
   subdir: cardano-crypto-praos
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 7d795c3040ea7785812efa1c97864bbb41b15d3e
-  --sha256: 130i0yj4y9br1m2bhisi6wni3f40i31nfhg878hv0kwi17chl9sz
+  tag: df8687488449f71dce3d881800c21e41fe1b7fc1
+  --sha256: 1chlqsp0g8lspnw2ia7v28pblr8iqqdiba51miznnclnj2vq9s2m
   subdir: slotting
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e15f78477686ea39db13c46bc126cae009493a91
-  --sha256: 106j6fbyx8znz547gq1zd8gnnfz3fla1z7as08d13lvd079l0r5p
+  tag: aa29b85e79ecc94aad8cb50af1151b07a2fb8971
+  --sha256: 17b7dqqr04a21a4ibn89rj14isw71q3ha6nbzb8zs52bg9myksq8
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e15f78477686ea39db13c46bc126cae009493a91
-  --sha256: 106j6fbyx8znz547gq1zd8gnnfz3fla1z7as08d13lvd079l0r5p
+  tag: aa29b85e79ecc94aad8cb50af1151b07a2fb8971
+  --sha256: 17b7dqqr04a21a4ibn89rj14isw71q3ha6nbzb8zs52bg9myksq8
   subdir: semantics/small-steps-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e15f78477686ea39db13c46bc126cae009493a91
-  --sha256: 106j6fbyx8znz547gq1zd8gnnfz3fla1z7as08d13lvd079l0r5p
+  tag: aa29b85e79ecc94aad8cb50af1151b07a2fb8971
+  --sha256: 17b7dqqr04a21a4ibn89rj14isw71q3ha6nbzb8zs52bg9myksq8
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e15f78477686ea39db13c46bc126cae009493a91
-  --sha256: 106j6fbyx8znz547gq1zd8gnnfz3fla1z7as08d13lvd079l0r5p
+  tag: aa29b85e79ecc94aad8cb50af1151b07a2fb8971
+  --sha256: 17b7dqqr04a21a4ibn89rj14isw71q3ha6nbzb8zs52bg9myksq8
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e15f78477686ea39db13c46bc126cae009493a91
-  --sha256: 106j6fbyx8znz547gq1zd8gnnfz3fla1z7as08d13lvd079l0r5p
+  tag: aa29b85e79ecc94aad8cb50af1151b07a2fb8971
+  --sha256: 17b7dqqr04a21a4ibn89rj14isw71q3ha6nbzb8zs52bg9myksq8
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e15f78477686ea39db13c46bc126cae009493a91
-  --sha256: 106j6fbyx8znz547gq1zd8gnnfz3fla1z7as08d13lvd079l0r5p
+  tag: aa29b85e79ecc94aad8cb50af1151b07a2fb8971
+  --sha256: 17b7dqqr04a21a4ibn89rj14isw71q3ha6nbzb8zs52bg9myksq8
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e15f78477686ea39db13c46bc126cae009493a91
-  --sha256: 106j6fbyx8znz547gq1zd8gnnfz3fla1z7as08d13lvd079l0r5p
+  tag: aa29b85e79ecc94aad8cb50af1151b07a2fb8971
+  --sha256: 17b7dqqr04a21a4ibn89rj14isw71q3ha6nbzb8zs52bg9myksq8
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e15f78477686ea39db13c46bc126cae009493a91
-  --sha256: 106j6fbyx8znz547gq1zd8gnnfz3fla1z7as08d13lvd079l0r5p
+  tag: aa29b85e79ecc94aad8cb50af1151b07a2fb8971
+  --sha256: 17b7dqqr04a21a4ibn89rj14isw71q3ha6nbzb8zs52bg9myksq8
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e15f78477686ea39db13c46bc126cae009493a91
-  --sha256: 106j6fbyx8znz547gq1zd8gnnfz3fla1z7as08d13lvd079l0r5p
+  tag: aa29b85e79ecc94aad8cb50af1151b07a2fb8971
+  --sha256: 17b7dqqr04a21a4ibn89rj14isw71q3ha6nbzb8zs52bg9myksq8
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e15f78477686ea39db13c46bc126cae009493a91
-  --sha256: 106j6fbyx8znz547gq1zd8gnnfz3fla1z7as08d13lvd079l0r5p
+  tag: aa29b85e79ecc94aad8cb50af1151b07a2fb8971
+  --sha256: 17b7dqqr04a21a4ibn89rj14isw71q3ha6nbzb8zs52bg9myksq8
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: e15f78477686ea39db13c46bc126cae009493a91
-  --sha256: 106j6fbyx8znz547gq1zd8gnnfz3fla1z7as08d13lvd079l0r5p
+  tag: aa29b85e79ecc94aad8cb50af1151b07a2fb8971
+  --sha256: 17b7dqqr04a21a4ibn89rj14isw71q3ha6nbzb8zs52bg9myksq8
   subdir: shelley/chain-and-ledger/executable-spec/test
 
 source-repository-package

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -65,16 +65,11 @@ import           Ouroboros.Consensus.Util (hashFromBytesE)
 
 import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
-import qualified Shelley.Spec.Ledger.Coin as SL
-import qualified Shelley.Spec.Ledger.Delegation.Certificates as SL
 import qualified Shelley.Spec.Ledger.EpochBoundary as SL
-import qualified Shelley.Spec.Ledger.Keys as SL
 import qualified Shelley.Spec.Ledger.LedgerState as SL
-import qualified Shelley.Spec.Ledger.PParams as SL
 import qualified Shelley.Spec.Ledger.Rewards as SL
 import qualified Shelley.Spec.Ledger.STS.Prtcl as SL
 import qualified Shelley.Spec.Ledger.STS.Tickn as SL
-import qualified Shelley.Spec.Ledger.TxData as SL
 import qualified Shelley.Spec.Ledger.UTxO as SL
 
 import           Ouroboros.Consensus.Cardano.Block

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -52,21 +52,16 @@ import           Ouroboros.Consensus.Util.Time
 import qualified Shelley.Spec.Ledger.API as SL
 import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
-import qualified Shelley.Spec.Ledger.Coin as SL
-import qualified Shelley.Spec.Ledger.Credential as SL
 import qualified Shelley.Spec.Ledger.Crypto as SL
 import qualified Shelley.Spec.Ledger.Delegation.Certificates as SL
 import qualified Shelley.Spec.Ledger.Genesis as SL
 import qualified Shelley.Spec.Ledger.Keys as SL
 import qualified Shelley.Spec.Ledger.PParams as SL
-import qualified Shelley.Spec.Ledger.Scripts as SL
 import qualified Shelley.Spec.Ledger.STS.Chain as STS
 import qualified Shelley.Spec.Ledger.STS.Ledger as STS
 import qualified Shelley.Spec.Ledger.STS.Ledgers as STS
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS
 import qualified Shelley.Spec.Ledger.STS.Tickn as STS
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ConcreteCrypto,
-                     hashKeyVRF)
 import qualified Test.Shelley.Spec.Ledger.Examples as Examples
 import           Test.Shelley.Spec.Ledger.Orphans ()
 import qualified Test.Shelley.Spec.Ledger.Utils as SL (testGlobals)
@@ -187,7 +182,7 @@ examples = Golden.Examples {
     stakeDistribution :: SL.PoolDistr (TPraosMockCrypto ShortHash)
     stakeDistribution = SL.PoolDistr $ Map.singleton
         (SL.KeyHash $ SL.hashWithSerialiser toCBOR 4)
-        (SL.IndividualPoolStake 1 (hashKeyVRF $ VerKeyFakeVRF 0))
+        (SL.IndividualPoolStake 1 (SL.hashVerKeyVRF $ VerKeyFakeVRF 0))
 
 exampleBlock :: Block ShortHash
 exampleBlock = mkShelleyBlock Examples.blockEx3B
@@ -284,7 +279,7 @@ exampleHeaderState = genesisHeaderState st
           SL.mkNonceFromNumber 2
       }
 
-    st :: TPraosState (ConcreteCrypto ShortHash)
+    st :: TPraosState (TPraosMockCrypto ShortHash)
     st = TPraosState.empty (NotOrigin 1) prtclState
 
 exampleExtLedgerState :: ExtLedgerState (Block ShortHash)

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/MockCrypto.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/MockCrypto.hs
@@ -1,29 +1,38 @@
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Consensus.Shelley.MockCrypto (
     TPraosMockCrypto
   , Block
   ) where
 
+import           Cardano.Crypto.DSIGN (MockDSIGN)
 import           Cardano.Crypto.Hash (HashAlgorithm)
+import           Cardano.Crypto.KES (MockKES)
+
+import           Test.Cardano.Crypto.VRF.Fake (FakeVRF)
 
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosCrypto)
 
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ConcreteCrypto)
+import           Shelley.Spec.Ledger.Crypto (Crypto (..))
 
--- | Use 'ConcreteCrypto' from cardano-ledger-specs as our mock crypto. This
--- means we can reuse all their examples and generators.
+-- | A mock replacement for 'TPraosStandardCrypto'
 --
--- We call it 'TPraosMockCrypto', because the name 'ConcreteCrypto' is
--- confusing, \"concrete\" gives the impression it is the real crypto, but
--- it's not (that's our 'TPraosStandardCrypto').
-type TPraosMockCrypto h = ConcreteCrypto h
+-- We run the tests with this mock crypto, as it is easier to generate and
+-- debug things. The code is parametric in the crypto, so it shouldn't make
+-- much of a difference. This also has the important advantage
+-- that we can reuse the generators from cardano-ledger-specs.
+data TPraosMockCrypto h
+
+instance HashAlgorithm h => Crypto (TPraosMockCrypto h) where
+  type ADDRHASH (TPraosMockCrypto h) = h
+  type DSIGN    (TPraosMockCrypto h) = MockDSIGN
+  type HASH     (TPraosMockCrypto h) = h
+  type KES      (TPraosMockCrypto h) = MockKES 10
+  type VRF      (TPraosMockCrypto h) = FakeVRF
 
 instance HashAlgorithm h => TPraosCrypto (TPraosMockCrypto h)
 
--- | We run the tests with mock crypto, as it is easier to generate and debug
--- things. The code is parametric in the crypto, so it shouldn't make much of
--- a difference. This also has the important advantage that we can reuse the
--- generators from cardano-ledger-specs.
 type Block h = ShelleyBlock (TPraosMockCrypto h)

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
@@ -30,7 +30,6 @@ import           Test.QuickCheck
 
 import           Test.ThreadNet.TxGen (TxGen (..))
 
-import qualified Test.Shelley.Spec.Ledger.ConcreteCryptoTypes as CSL
 import qualified Test.Shelley.Spec.Ledger.Generator.Constants as Gen
 import qualified Test.Shelley.Spec.Ledger.Generator.Core as Gen
 import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Gen.Presets
@@ -86,7 +85,7 @@ genTx _cfg slotNo TickedShelleyLedgerState { tickedShelleyState } genEnv =
       ledgerEnv
       (utxoSt, dpState)
   where
-    epochState :: CSL.EpochState (TPraosMockCrypto h)
+    epochState :: SL.EpochState (TPraosMockCrypto h)
     epochState = SL.nesEs tickedShelleyState
 
     ledgerEnv :: STS.LedgerEnv
@@ -97,13 +96,13 @@ genTx _cfg slotNo TickedShelleyLedgerState { tickedShelleyState } genEnv =
       , ledgerAccount  = SL.esAccountState epochState
       }
 
-    utxoSt :: CSL.UTxOState (TPraosMockCrypto h)
+    utxoSt :: SL.UTxOState (TPraosMockCrypto h)
     utxoSt =
         SL._utxoState
       . SL.esLState
       $ epochState
 
-    dpState :: CSL.DPState (TPraosMockCrypto h)
+    dpState :: SL.DPState (TPraosMockCrypto h)
     dpState =
         SL._delegationState
       . SL.esLState

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
@@ -122,7 +122,12 @@ mkGenEnv whetherPPUs coreNodes = Gen.GenEnv keySpace constants
     constants =
         setCerts $
         setPPUs $
-        Gen.defaultConstants{ Gen.frequencyMIRCert = 0 }
+        Gen.defaultConstants
+          { Gen.frequencyMIRCert = 0
+          , Gen.genTxRetries     = 1000
+                -- At time of writing, about 85 retries have been enough for
+                -- any individual invocation; most need much fewer.
+          }
       where
         -- Testing with certificates requires additional handling in the
         -- testing framework, because, for example, they may transfer block

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -83,14 +83,8 @@ import qualified Control.State.Transition as STS
 import qualified Shelley.Spec.Ledger.Address as SL
 import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
-import qualified Shelley.Spec.Ledger.BlockChain as SL
-import qualified Shelley.Spec.Ledger.Coin as SL
-import qualified Shelley.Spec.Ledger.Credential as SL
-import qualified Shelley.Spec.Ledger.Delegation.Certificates as SL
 import qualified Shelley.Spec.Ledger.Genesis as SL
-import qualified Shelley.Spec.Ledger.Keys as SL
 import qualified Shelley.Spec.Ledger.LedgerState as SL
-import qualified Shelley.Spec.Ledger.PParams as SL
 import qualified Shelley.Spec.Ledger.STS.Chain as STS
 import qualified Shelley.Spec.Ledger.UTxO as SL
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -42,8 +42,6 @@ import           Ouroboros.Consensus.Util.Condense
 
 import qualified Shelley.Spec.Ledger.API as SL
 import           Shelley.Spec.Ledger.BlockChain as SL
-import qualified Shelley.Spec.Ledger.PParams as SL
-import qualified Shelley.Spec.Ledger.Tx as SL
 import qualified Shelley.Spec.Ledger.UTxO as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -57,8 +57,6 @@ import qualified Shelley.Spec.Ledger.Address as SL
 import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.BlockChain as SL
-import qualified Shelley.Spec.Ledger.Coin as SL
-import qualified Shelley.Spec.Ledger.Credential as SL
 import qualified Shelley.Spec.Ledger.EpochBoundary as SL
 import qualified Shelley.Spec.Ledger.Genesis as SL
 import qualified Shelley.Spec.Ledger.Keys as SL

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -71,8 +71,6 @@ import qualified Shelley.Spec.Ledger.Crypto as SL
 import qualified Shelley.Spec.Ledger.Delegation.Certificates as SL
 import qualified Shelley.Spec.Ledger.Genesis as SL
 import qualified Shelley.Spec.Ledger.Keys as SL
-import qualified Shelley.Spec.Ledger.LedgerState as SL
-import qualified Shelley.Spec.Ledger.OCert as SL
 import qualified Shelley.Spec.Ledger.OCert as Absolute (KESPeriod (..))
 import qualified Shelley.Spec.Ledger.STS.Tickn as STS
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -38,12 +38,12 @@ flags:
 
 extra-deps:
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: efa4b5ecd7f0a13124616b12679cd42517cd905a
+    commit: d8f35c3c725be67148681227f9d64876f5909120
     subdirs:
       - contra-tracer
 
   - git: https://github.com/input-output-hk/cardano-base
-    commit: 7d795c3040ea7785812efa1c97864bbb41b15d3e
+    commit: df8687488449f71dce3d881800c21e41fe1b7fc1
     subdirs:
       - binary
       - binary/test
@@ -52,7 +52,7 @@ extra-deps:
       - slotting
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: e15f78477686ea39db13c46bc126cae009493a91
+    commit: aa29b85e79ecc94aad8cb50af1151b07a2fb8971
     subdirs:
       - byron/chain/executable-spec
       - byron/ledger/executable-spec


### PR DESCRIPTION
The first commit integrates with the upstream PRs input-output-hk/cardano-ledger-specs#1735 and input-output-hk/cardano-ledger-specs#1739, which generalize the contexts and instances necessary for using the cardano-ledger-specs test case generators.

The second commit removes a workaround. PR input-output-hk/cardano-ledger-specs#1731 changed the Shelley transaction generator to no longer fail with `QC.discard` and moreover to attempt a given number of retries before failing fatally. That supplants our temporary workaround.

~It also generalizes the `TPraosMockCrypto` definition to allow for a separate address hashing algorithm, which in turn allows Test.Util.ThreadNet.Cardano to satisfy the assumption currently made by the Byron-to-Shelley translation that the key hashes in the bootstrap addresses have the same bit length as those in normal Shelley addresses.~