### PR TITLE
Use commads for db-validator

### DIFF
--- a/nix/validate-mainnet.nix
+++ b/nix/validate-mainnet.nix
@@ -32,8 +32,10 @@ in
     cp -r ${mainnet-converted}/* $out
     chmod -R u+rw,g+rw,a+x $out/*
     ${db-validator}/bin/db-validator \
-      --configFile ${cardano-mainnet-config} \
+      --db $out \
+      byron \
       --genesisHash 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb \
-      --dbDir $out \
+      --configByron ${cardano-mainnet-config} \
+      --threshold 0.22 \
       ${immDBStr}
     ''


### PR DESCRIPTION
https://github.com/input-output-hk/ouroboros-network/issues/2460

~This probably breaks a nightly test.~ fixed

An example to use it with mainnet is the following:
```
cabal new-exec db-validator -- --db /path/to/db cardano 
--genesisHash 5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb 
--configByron /path/to/configuration/mainnet/mainnet-byron-genesis.json --threshold 0.22 
--configShelley /path/to/configuration/mainnet/mainnet-shelley-genesis.json 
--nonce 1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81 --verbose

```