### PR TITLE
buildkite: fix exit code in nightly ThreadNet script

### DIFF
--- a/.buildkite/slow-ThreadNet-tests.sh
+++ b/.buildkite/slow-ThreadNet-tests.sh
@@ -166,6 +166,8 @@ innerCommand () {
         --iohk-enable-nightly-tests \
         1>"$logfile" 2>&1
 
+    xc=$?
+
     # Notify the user
     #
     # Likely atomic, since it's almost surely less than PIPE_BUF.
@@ -173,6 +175,8 @@ innerCommand () {
     # https://arto.s3.amazonaws.com/notes/posix#pipe-buf
     echo Completed Invocation-${uniqueInvocationId}, $suite ${n}: \
         $(tail -n1 "$logfile")
+
+    return $xc
 }
 # Exported so GNU parallel workers can see it.
 export -f innerCommand


### PR DESCRIPTION
:face_palm:

This BuildKite demonstrates the fix works. https://buildkite.com/input-output-hk/ouroboros-network-nightly/builds/186#037a7df9-04df-4f44-a6eb-2db0af2e6e5a (It had an additional commit that reduced the nightly invocations to just `RealTPraos` and reduced `RealTPraos` to just a coin toss.)