### PR TITLE
consensus: Quiet Show for CoreNodeId, SecurityParam, SlotLength, SystemStart

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Types.hs
@@ -43,8 +43,9 @@ import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..),
 --
 -- Slots are counted from the system start.
 newtype SystemStart = SystemStart { getSystemStart :: UTCTime }
-  deriving (Eq, Show)
+  deriving (Eq, Generic)
   deriving NoUnexpectedThunks via UseIsNormalForm SystemStart
+  deriving Show via Quiet SystemStart
 
 {-------------------------------------------------------------------------------
   Relative time
@@ -98,7 +99,8 @@ data SystemTime m = SystemTime {
 
 -- | Slot length
 newtype SlotLength = SlotLength { getSlotLength :: NominalDiffTime }
-  deriving (Show, Eq, Generic, NoUnexpectedThunks)
+  deriving (Eq, Generic, NoUnexpectedThunks)
+  deriving Show via Quiet SlotLength
 
 -- | Constructor for 'SlotLength'
 mkSlotLength :: NominalDiffTime -> SlotLength

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config/SecurityParam.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config/SecurityParam.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Ouroboros.Consensus.Config.SecurityParam (
@@ -7,6 +8,7 @@ module Ouroboros.Consensus.Config.SecurityParam (
 
 import           Data.Word
 import           GHC.Generics (Generic)
+import           Quiet
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
@@ -20,4 +22,5 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 -- NOTE: This talks about the number of /blocks/ we can roll back, not
 -- the number of /slots/.
 newtype SecurityParam = SecurityParam { maxRollbacks :: Word64 }
-  deriving (Show, Eq, Generic, NoUnexpectedThunks)
+  deriving (Eq, Generic, NoUnexpectedThunks)
+  deriving Show via Quiet SecurityParam

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeId.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeId.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Ouroboros.Consensus.NodeId (
@@ -13,6 +14,7 @@ module Ouroboros.Consensus.NodeId (
 import           Codec.Serialise (Serialise)
 import           Data.Word
 import           GHC.Generics (Generic)
+import           Quiet
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
@@ -36,8 +38,9 @@ instance Condense NodeId where
 newtype CoreNodeId = CoreNodeId {
       unCoreNodeId :: Word64
     }
-  deriving stock   (Show, Eq, Ord)
+  deriving stock   (Eq, Ord, Generic)
   deriving newtype (Condense, Serialise, NoUnexpectedThunks)
+  deriving Show via Quiet CoreNodeId
 
 fromCoreNodeId :: CoreNodeId -> NodeId
 fromCoreNodeId = CoreId


### PR DESCRIPTION
Use `Quiet` for more types, especially those that show up in ThreadNet counterexamples.