### PR TITLE
Extend Cardano ThreadNet tests so that Shelley era contains active stake pools

### DIFF
--- a/.buildkite/slow-ThreadNet-tests.sh
+++ b/.buildkite/slow-ThreadNet-tests.sh
@@ -24,10 +24,10 @@ set -euo pipefail
 # overhead and also more reliable percentages in their QuickCheck statistics.
 rows=(
     # From the slowest individual invocation ...
-    '1 Cardano    5000'  # ~45 minutes per invocation
+    '1 Cardano    2000'  # ~35 minutes per invocation
     '2 RealTPraos 200'   # ~30 minutes per invocation (but high variance)
     '4 RealTPraos 100'   # ~15 minutes per invocation (but high variance)
-    '5 Cardano    500'   # ~5 minutes per invocation
+    '5 Cardano    300'   # ~5  minutes per invocation
     # ... to fastest individual invocation
     #
     # And the number of invocations is non-decreasing.

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/TxGen/Byron.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/TxGen/Byron.hs
@@ -8,4 +8,4 @@ import           Test.ThreadNet.TxGen
 instance TxGen ByronBlock where
   -- We don't generate transactions for 'ByronBlock', but we do for
   -- 'DualByronBlock'.
-  testGenTxs _ _ _ _ _ = return []
+  testGenTxs _ _ _ _ _ _ = return []

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualPBFT.hs
@@ -259,7 +259,7 @@ realPBftParams ByronSpecGenesis{..} =
 -------------------------------------------------------------------------------}
 
 instance TxGen DualByronBlock where
-  testGenTxs _numCoreNodes curSlotNo cfg () = \st -> do
+  testGenTxs _coreNodeId _numCoreNodes curSlotNo cfg () = \st -> do
       n <- choose (0, 20)
       go [] n $ applyChainTick (configLedger cfg) curSlotNo st
     where

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -88,6 +88,7 @@ test-suite test
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class
+                     , cardano-crypto-wrapper
                      , cardano-ledger
                      , cardano-ledger-test
                      , cardano-slotting

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -74,9 +74,10 @@ test-suite test
   main-is:             Main.hs
   other-modules:
                        Test.Consensus.Cardano.ByronCompatibility
+                       Test.Consensus.Cardano.Examples
                        Test.Consensus.Cardano.Generators
                        Test.Consensus.Cardano.Golden
-                       Test.Consensus.Cardano.Examples
+                       Test.Consensus.Cardano.MockCrypto
                        Test.Consensus.Cardano.Serialisation
                        Test.Consensus.Cardano.Translation
                        Test.ThreadNet.Cardano
@@ -102,6 +103,7 @@ test-suite test
                      , time
 
                      , shelley-spec-ledger
+                     , shelley-spec-ledger-test
 
                      , ouroboros-network
                      , ouroboros-consensus

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/MockCrypto.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/MockCrypto.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DataKinds    #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Test.Consensus.Cardano.MockCrypto (
+    BlockCompatByron
+  , TPraosMockCryptoCompatByron
+  ) where
+
+import           Cardano.Crypto.DSIGN (Ed25519DSIGN)
+import           Cardano.Crypto.Hash (Blake2b_224, HashAlgorithm)
+import           Cardano.Crypto.KES (MockKES)
+
+import           Test.Cardano.Crypto.VRF.Fake (FakeVRF)
+
+import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto (TPraosCrypto)
+
+import           Shelley.Spec.Ledger.Crypto (Crypto (..))
+
+-- | A mock replacement for 'TPraosStandardCrypto' that is compatible with
+-- bootstrapping from Byron
+--
+-- This mocks more components than does
+-- 'Test.Consensus.Shelley.MockCrypto.TPraosMockCrypto'. This prevents the
+-- @cardano-ledger-specs@ generators from being re-used. Currently, this is not
+-- an obstacle for example in the Cardano ThreadNet tests.
+--
+-- NOTE: The "Ouroboros.Consensus.Cardano.CanHardFork" translation currently
+-- assumes that @ADDRHASH@ has the same bit size as Byron address hashes (ie
+-- 224); that's why we use 'Blake2b_224' here.
+--
+-- NOTE: The @shelley-spec-ledger@ package currently requires that @'DSIGN' ~
+-- 'Ed25519DSIGN' in order to use Byron bootstrap witnesses.
+data TPraosMockCryptoCompatByron h
+
+instance HashAlgorithm h => Crypto (TPraosMockCryptoCompatByron h) where
+  type ADDRHASH (TPraosMockCryptoCompatByron h) = Blake2b_224
+  type DSIGN    (TPraosMockCryptoCompatByron h) = Ed25519DSIGN
+  type HASH     (TPraosMockCryptoCompatByron h) = h
+  type KES      (TPraosMockCryptoCompatByron h) = MockKES 10
+  type VRF      (TPraosMockCryptoCompatByron h) = FakeVRF
+
+instance HashAlgorithm h => TPraosCrypto (TPraosMockCryptoCompatByron h)
+
+type BlockCompatByron h = ShelleyBlock (TPraosMockCryptoCompatByron h)

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -13,9 +13,15 @@ module Test.ThreadNet.Cardano (
 
 import           Control.Exception (assert)
 import           Control.Monad (guard, replicateM)
+import           Control.Monad.Identity (runIdentity)
+import           Control.Monad.Reader (runReaderT)
+import           Data.Functor ((<&>))
 import           Data.List ((!!))
 import qualified Data.Map as Map
+import           Data.Maybe (isJust, maybeToList)
 import           Data.Proxy (Proxy (..))
+import           Data.Set (Set)
+import qualified Data.Set as Set
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
@@ -24,11 +30,11 @@ import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Slotting.Slot (EpochNo, EpochSize (..), SlotNo (..))
+import           Cardano.Slotting.EpochInfo
+import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..),
+                     SlotNo (..))
 
 import           Cardano.Crypto.Hash.Blake2b (Blake2b_256)
-
-import qualified Ouroboros.Network.MockChain.Chain as MockChain
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
@@ -43,7 +49,10 @@ import           Ouroboros.Consensus.Util.IOLike (IOLike)
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
                      (isHardForkNodeToNodeEnabled)
 
+import qualified Cardano.Chain.Common as CC.Common
 import qualified Cardano.Chain.Genesis as CC.Genesis
+import           Cardano.Chain.ProtocolConstants (kEpochSlots)
+import           Cardano.Chain.Slotting (unEpochSlots)
 import qualified Cardano.Chain.Update as CC.Update
 
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
@@ -53,8 +62,10 @@ import           Ouroboros.Consensus.Byron.Node
 import qualified Shelley.Spec.Ledger.BaseTypes as SL
 import qualified Shelley.Spec.Ledger.Genesis as SL
 import qualified Shelley.Spec.Ledger.OCert as SL
+import qualified Shelley.Spec.Ledger.OverlaySchedule as SL
 import qualified Shelley.Spec.Ledger.PParams as SL
 
+import           Ouroboros.Consensus.Shelley.Ledger (mkShelleyGlobals)
 import           Ouroboros.Consensus.Shelley.Node
 import qualified Ouroboros.Consensus.Shelley.Protocol as Shelley
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (KES, TPraosCrypto)
@@ -69,7 +80,7 @@ import qualified Test.ThreadNet.Infra.Byron as Byron
 import qualified Test.ThreadNet.Infra.Shelley as Shelley
 import           Test.ThreadNet.Network (CalcMessageDelay (..), NodeOutput (..),
                      TestNodeInitialization (..))
-import           Test.ThreadNet.TxGen.Cardano ()
+import           Test.ThreadNet.TxGen.Cardano (CardanoTxGenExtra (..))
 import           Test.ThreadNet.Util.Expectations (NumBlocks (..))
 import           Test.ThreadNet.Util.NodeJoinPlan (trivialNodeJoinPlan)
 import           Test.ThreadNet.Util.NodeRestarts (noRestarts)
@@ -94,7 +105,8 @@ data Partition = Partition SlotNo NumSlots
   deriving (Show)
 
 partitionExclusiveUpperBound :: Partition -> SlotNo
-partitionExclusiveUpperBound (Partition s (NumSlots d)) = Util.addSlots d s
+partitionExclusiveUpperBound (Partition s (NumSlots dur)) =
+    Util.addSlots dur s
 
 -- | The varying data of this test
 --
@@ -107,6 +119,10 @@ data TestSetup = TestSetup
   , setupD                 :: Shelley.DecentralizationParam
   , setupHardFork          :: Bool
     -- ^ whether the proposal should trigger a hard fork or not
+  , setupInitialNonce      :: SL.Nonce
+    -- ^ the initial Shelley 'SL.ticknStateEpochNonce'
+    --
+    -- We vary it to ensure we explore different leader schedules.
   , setupK                 :: SecurityParam
   , setupPartition         :: Partition
   , setupSlotLengthByron   :: SlotLength
@@ -119,9 +135,18 @@ data TestSetup = TestSetup
 instance Arbitrary TestSetup where
   arbitrary = do
     setupD <- arbitrary
-                -- TODO Issue 2388 prevents `d=0` in this test.
+                -- The decentralization parameter cannot be 0 in the first
+                -- Shelley epoch, since stake pools can only be created and
+                -- delegated to via Shelley transactions.
                 `suchThat` ((/= 0) . Shelley.decentralizationParamToRational)
-    setupK <- SecurityParam <$> choose (2, 6)
+    setupK <- SecurityParam <$> choose (4, 6)
+                -- If k < 4, common prefix violations become too likely in
+                -- Praos mode.
+
+    setupInitialNonce <- frequency
+      [ (1, pure SL.NeutralNonce)
+      , (9, SL.mkNonceFromNumber <$> arbitrary)
+      ]
 
     setupSlotLengthByron   <- arbitrary
     setupSlotLengthShelley <- arbitrary
@@ -130,7 +155,7 @@ instance Arbitrary TestSetup where
     let TestConfig{numCoreNodes, numSlots} = setupTestConfig
 
     setupByronLowerBound <- arbitrary
-    setupHardFork        <- frequency [(9, pure True), (1, pure False)]
+    setupHardFork        <- frequency [(49, pure True), (1, pure False)]
     setupPartition       <- genPartition numCoreNodes numSlots setupK
 
     setupVersion         <- genVersionFiltered
@@ -141,6 +166,7 @@ instance Arbitrary TestSetup where
       { setupByronLowerBound
       , setupD
       , setupHardFork
+      , setupInitialNonce
       , setupK
       , setupPartition
       , setupSlotLengthByron
@@ -156,12 +182,23 @@ genTestConfig :: SecurityParam -> Gen TestConfig
 genTestConfig k = do
     initSeed <- arbitrary
 
-    -- Ensure there are almost always sufficient slots for multiple eras.
     numSlots <- do
-      t <- choose (5, 50)
-      pure $ NumSlots $
-        min 150 $
-        numByronEpochs * 9 * maxRollbacks k + t
+      let byronE   = byronEpochSize k
+          shelleyE = shelleyEpochSize k
+          wiggle   = min byronE (2 * maxRollbacks k)
+
+          approachShelleyEra     =
+              choose (0, wiggle)   <&> \t -> byronE + t - wiggle
+          reachShelleyEra        =
+              choose (1, shelleyE) <&> \t -> byronE + t
+          reachThirdShelleyEpoch =
+              choose (1, shelleyE) <&> \t -> byronE + 2 * shelleyE + t
+
+      fmap NumSlots $ frequency $
+        [ (05, approachShelleyEra)
+        , (64, reachShelleyEra)
+        , (31, reachThirdShelleyEpoch)
+        ]
 
     -- This test has more slots than most, so we de-emphasize the relatively
     -- expensive n=5 case. For example:
@@ -283,7 +320,8 @@ genPartition (NumCoreNodes n) (NumSlots t) (SecurityParam k) = do
           , (1,  Just $ 2 * k + 1 + quorum)
           , (1,  Just $ 4 * k + 1)
           , (1,  Just $ 4 * k + 1 + quorum)
-          , (20, assert (numByronEpochs == (1 :: Int)) $ Just $ 10 * k)
+          , (20, assert (numByronEpochs == (1 :: Int)) $
+                 Just $ byronEpochSize (SecurityParam k))
           ]
 
     -- Position the partition so that it at least abuts the focus slot.
@@ -300,10 +338,10 @@ genPartition (NumCoreNodes n) (NumSlots t) (SecurityParam k) = do
         firstSlotAfter :: Word64
         firstSlotAfter = crop $ firstSlotIn + w
 
-        d :: Word64
-        d = Util.countSlots (SlotNo firstSlotAfter) (SlotNo firstSlotIn)
+        dur :: Word64
+        dur = Util.countSlots (SlotNo firstSlotAfter) (SlotNo firstSlotIn)
 
-    pure $ Partition (SlotNo firstSlotIn) (NumSlots d)
+    pure $ Partition (SlotNo firstSlotIn) (NumSlots dur)
 
 tests :: TestTree
 tests = testGroup "Cardano ThreadNet" $
@@ -316,6 +354,7 @@ prop_simple_cardano_convergence TestSetup
   { setupByronLowerBound
   , setupD
   , setupHardFork
+  , setupInitialNonce
   , setupK
   , setupPartition
   , setupSlotLengthByron
@@ -324,6 +363,8 @@ prop_simple_cardano_convergence TestSetup
   , setupVersion
   } =
     tabulate "ReachesShelley label" [label_ReachesShelley reachesShelley] $
+    tabulate "Observed forge during a non-overlay Shelley slot"
+      [label_hadActiveNonOverlaySlots] $
     tabulatePartitionDuration $
     tabulateFinalIntersectionDepth $
     tabulatePartitionPosition $
@@ -367,7 +408,13 @@ prop_simple_cardano_convergence TestSetup
       , messageDelay = mkMessageDelay setupPartition
       , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
       , nodeRestarts = noRestarts
-      , txGenExtra   = ()
+      , txGenExtra   = CardanoTxGenExtra
+        { ctgeByronGenesisKeys = generatedSecrets
+        , ctgeNetworkMagic     =
+            CC.Common.makeNetworkMagic $
+            CC.Genesis.configProtocolMagic genesisByron
+        , ctgeShelleyCoreNodes = coreNodes
+        }
       , version      = setupVersion
       }
 
@@ -382,7 +429,7 @@ prop_simple_cardano_convergence TestSetup
                   generatedSecrets
                   propPV
                   genesisShelley
-                  SL.NeutralNonce
+                  setupInitialNonce
                   (coreNodes !! fromIntegral nid)
                   (guard setupByronLowerBound *> Just numByronEpochs)
                   (TriggerHardForkAtVersion shelleyMajorVersion)
@@ -409,9 +456,9 @@ prop_simple_cardano_convergence TestSetup
           div partitionDuration 2 + mod partitionDuration 2
 
     partitionDuration :: Word64
-    partitionDuration = d
+    partitionDuration = dur
       where
-        Partition _ (NumSlots d) = setupPartition
+        Partition _ (NumSlots dur) = setupPartition
 
     -- Byron
 
@@ -506,16 +553,16 @@ prop_simple_cardano_convergence TestSetup
           or $
           [ isShelley blk
           | (_nid, no) <- Map.toList testOutputNodes
-          , let NodeOutput{nodeOutputFinalChain} = no
-          , blk <- MockChain.chainToList nodeOutputFinalChain
+          , let NodeOutput{nodeOutputForges} = no
+          , (blk, _m) <- maybeToList $ Map.maxView nodeOutputForges
+                -- the last block the node forged
           ]
       , rsShelleySlots  =
           assert (w >= k) $
           BoolProps.requiredIf $
-          t > numByronSlots + ceiling (logBase (1-f) oneBillionth)
-            -- We only require a Shelley block if there are enough Shelley
-            -- slots that the chance of them all being inactive slots is at
-            -- most 1 in a billion.
+          -- The active slots in the first two Shelley epochs are all overlay
+          -- slots, so the first Shelley block will arise from one of those.
+          not $ Set.null overlaySlots
       }
       where
         NumSlots t                  = numSlots
@@ -530,20 +577,62 @@ prop_simple_cardano_convergence TestSetup
         w :: Word64
         w = Shelley.computeStabilityWindow setupK coeff
 
-        -- the independent probability that a Shelley slot will have at least
-        -- one leader
-        f :: Double
-        f = fromRational $ SL.unitIntervalToRational $ SL.activeSlotVal coeff
+    -- Whether there was a Shelley block forged in a non-overlay slot.
+    --
+    -- This event evidences that the stake pools were correctly created and
+    -- delegated to.
+    label_hadActiveNonOverlaySlots :: String
+    label_hadActiveNonOverlaySlots =
+        show $ or $
+        [ Set.notMember slot overlaySlots
+        | (_nid, no) <- Map.toList testOutputNodes
+        , let NodeOutput{nodeOutputForges} = no
+        , (slot, blk) <- Map.toDescList nodeOutputForges
+        , isShelley blk
+        ]
+      where
+        TestOutput{testOutputNodes} = testOutput
 
-        -- a strong threshold, along the lines of " not even once in the
-        -- lifetime of the project "
-        oneBillionth :: Double
-        oneBillionth = 1e-9
+    -- All OBFT overlay slots in the test.
+    overlaySlots :: Set SlotNo
+    overlaySlots =
+        Set.filter (< SlotNo t) $
+        Set.unions $
+        takeWhile (isJust . Set.lookupLT (SlotNo t)) $
+        map overlayOffsets [0..]
+      where
+        NumSlots t = numSlots
 
-        isShelley :: CardanoBlock c -> Bool
-        isShelley = \case
-            BlockByron{}   -> False
-            BlockShelley{} -> True
+        -- The overlay slots in the ith Shelley epoch.
+        --
+        -- TODO: This function conceptually should be simpler if we created a
+        -- sufficiently accurate 'EpochInfo' and so didn't need the shift. But
+        -- doing so (eg by constructing a HardFork @Summary@) is currently
+        -- significantly involved than this workaround.
+        overlayOffsets :: Word64 -> Set SlotNo
+        overlayOffsets i =
+            -- Shift to account for the initial Byron era.
+            Set.mapMonotonic (Util.addSlots numByronSlots) $
+
+            Map.keysSet $
+            SL.overlayScheduleToMap $
+            runIdentity $ flip runReaderT shelleyGlobals $
+            SL.overlaySchedule
+              @Crypto
+              (EpochNo i)   -- NB 0 <-> the first /Shelley/ epoch
+              genesisKeyHashes
+              (sgProtocolParams genesisShelley)   -- notably contains setupD
+
+        shelleyGlobals =
+            mkShelleyGlobals
+              genesisShelley
+              -- Suitable only for this narrow context
+              (fixedSizeEpochInfo epochSizeShelley)
+              maxMajorPVShelley
+
+        genesisKeyHashes =
+            Set.fromList $
+            map (Shelley.mkKeyHash . Shelley.cnGenesisKey) coreNodes
 
     numByronSlots :: Word64
     numByronSlots = numByronEpochs * unEpochSize epochSizeByron
@@ -553,9 +642,9 @@ prop_simple_cardano_convergence TestSetup
         if rsShelleyBlocks reachesShelley then "Shelley" else "Byron"
 
     finalIntersectionDepth :: Word64
-    finalIntersectionDepth = d
+    finalIntersectionDepth = depth
       where
-        NumBlocks d = calcFinalIntersectionDepth testOutput
+        NumBlocks depth = calcFinalIntersectionDepth testOutput
 
     tabulatePartitionDuration :: Property -> Property
     tabulatePartitionDuration =
@@ -581,13 +670,15 @@ prop_simple_cardano_convergence TestSetup
         tabulate "partition in or abuts era (Byron, Shelley)"
           [ show (inclByron, inclShelley) ]
       where
-        Partition (SlotNo firstSlotIn) (NumSlots d) = setupPartition
-        firstSlotAfter                              = firstSlotIn + d
+        Partition (SlotNo firstSlotIn) (NumSlots dur) = setupPartition
+        firstSlotAfter                                = firstSlotIn + dur
 
         trans = ledgerReachesShelley reachesShelley
 
-        inclByron   = d > 0 && (not trans || firstSlotIn    <= numByronSlots)
-        inclShelley = d > 0 && (trans     && firstSlotAfter >= numByronSlots)
+        inclByron   =
+            dur > 0 && (not trans || firstSlotIn    <= numByronSlots)
+        inclShelley =
+            dur > 0 && (trans     && firstSlotAfter >= numByronSlots)
 
 mkProtocolCardanoAndHardForkTxs
   :: forall sc m. (IOLike m, TPraosCrypto sc)
@@ -671,15 +762,15 @@ mkProtocolCardanoAndHardForkTxs
     protVerShelley :: SL.ProtVer
     protVerShelley = SL.ProtVer shelleyMajorVersion 0
 
-    maxMajorPVShelley :: Natural
-    maxMajorPVShelley = 100
-
     leaderCredentialsShelley :: TPraosLeaderCredentials sc
     leaderCredentialsShelley = Shelley.mkLeaderCredentials coreNodeShelley
 
 {-------------------------------------------------------------------------------
   Constants
 -------------------------------------------------------------------------------}
+
+maxMajorPVShelley :: Natural
+maxMajorPVShelley = 100   -- arbitrary
 
 -- | The major protocol version of Byron in this test
 --
@@ -795,6 +886,18 @@ mkMessageDelay part = CalcMessageDelay $
 {-------------------------------------------------------------------------------
   Miscellany
 -------------------------------------------------------------------------------}
+
+byronEpochSize :: SecurityParam -> Word64
+byronEpochSize (SecurityParam k) =
+    unEpochSlots $ kEpochSlots $ CC.Common.BlockCount k
+
+shelleyEpochSize :: SecurityParam -> Word64
+shelleyEpochSize = unEpochSize . Shelley.mkEpochSize
+
+isShelley :: CardanoBlock c -> Bool
+isShelley = \case
+    BlockByron{}   -> False
+    BlockShelley{} -> True
 
 -- | Render a number as a positive difference from @k@
 --

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -63,7 +63,7 @@ import           Ouroboros.Consensus.Cardano.Block
 import           Ouroboros.Consensus.Cardano.Condense ()
 import           Ouroboros.Consensus.Cardano.Node
 
-import           Test.Consensus.Shelley.MockCrypto (TPraosMockCrypto)
+import           Test.Consensus.Cardano.MockCrypto (TPraosMockCryptoCompatByron)
 import           Test.ThreadNet.General
 import qualified Test.ThreadNet.Infra.Byron as Byron
 import qualified Test.ThreadNet.Infra.Shelley as Shelley
@@ -81,7 +81,9 @@ import           Test.Util.HardFork.Future
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Slots (NumSlots (..))
 
-type Crypto = TPraosMockCrypto Blake2b_256
+-- | Use 'TPraosMockCryptoCompatByron' so that bootstrap addresses and
+-- bootstrap witnesses are supported.
+type Crypto = TPraosMockCryptoCompatByron Blake2b_256
 
 -- | When and for how long the nodes are partitioned
 --

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/TxGen/Cardano.hs
@@ -1,15 +1,312 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.ThreadNet.TxGen.Cardano () where
+module Test.ThreadNet.TxGen.Cardano (
+    CardanoTxGenExtra (..),
+  ) where
+
+import           Control.Exception (assert)
+
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Maybe (maybeToList)
+import qualified Data.Sequence.Strict as StrictSeq
+import qualified Data.Set as Set
+import           Data.SOP.Strict
+
+import           Ouroboros.Consensus.Block (SlotNo (..))
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger
+                     (tickedHardForkLedgerStatePerEra)
+import           Ouroboros.Consensus.HardFork.Combinator.State.Types
+                     (currentState, getHardForkState)
+import           Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Tele
+import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig, LedgerState,
+                     applyChainTick)
+import           Ouroboros.Consensus.NodeId (CoreNodeId (..))
+
+import           Cardano.Binary (toCBOR)
+
+import           Cardano.Crypto (toVerification)
+import           Cardano.Crypto.DSIGN (Ed25519DSIGN)
+import           Cardano.Crypto.DSIGN.Class (SignKeyDSIGN)
+import           Cardano.Crypto.Hash (Blake2b_224)
+import qualified Cardano.Crypto.Signing as Byron
+import           Cardano.Crypto.VRF.Class (SignKeyVRF)
+
+import qualified Cardano.Chain.Common as Byron
+import           Cardano.Chain.Genesis (GeneratedSecrets (..))
+
+import qualified Shelley.Spec.Ledger.Address as SL
+import qualified Shelley.Spec.Ledger.Address.Bootstrap as SL
+import qualified Shelley.Spec.Ledger.BaseTypes as SL
+import qualified Shelley.Spec.Ledger.Coin as SL
+import qualified Shelley.Spec.Ledger.Credential as SL
+import qualified Shelley.Spec.Ledger.Keys as SL
+import qualified Shelley.Spec.Ledger.LedgerState as SL
+import qualified Shelley.Spec.Ledger.Tx as SL
+import qualified Shelley.Spec.Ledger.TxData as SL
+import qualified Shelley.Spec.Ledger.UTxO as SL
+
+import           Ouroboros.Consensus.Shelley.Ledger (GenTx, ShelleyBlock,
+                     mkShelleyTx)
+import           Ouroboros.Consensus.Shelley.Ledger.Ledger (tickedShelleyState)
+import           Ouroboros.Consensus.Shelley.Protocol.Crypto (ADDRHASH, DSIGN,
+                     TPraosCrypto, VRF)
 
 import           Ouroboros.Consensus.Cardano
+import           Ouroboros.Consensus.Cardano.Block (CardanoEras, GenTx (..))
 
+import qualified Test.ThreadNet.Infra.Shelley as Shelley
 import           Test.ThreadNet.TxGen
 
-import           Test.Consensus.Shelley.MockCrypto (TPraosMockCryptoCompatByron)
+data CardanoTxGenExtra c = CardanoTxGenExtra
+  { ctgeByronGenesisKeys :: GeneratedSecrets
+  , ctgeNetworkMagic     :: Byron.NetworkMagic
+  , ctgeShelleyCoreNodes :: [Shelley.CoreNode c]
+  }
 
-instance TxGen (CardanoBlock (TPraosMockCryptoCompatByron h)) where
-  -- TODO
-  testGenTxs _ _ _ _ _ = return []
+instance ( TPraosCrypto c
+           -- These equalities allow the transition from Byron to Shelley,
+           -- since @shelley-spec-ledger@ requires Ed25519 for Byron bootstrap
+           -- addresses and the current Byron-to-Shelley translation requires a
+           -- 224-bit hash.
+         , ADDRHASH c ~ Blake2b_224
+         , DSIGN    c ~ Ed25519DSIGN
+         )
+      => TxGen (CardanoBlock c) where
+
+  type TxGenExtra (CardanoBlock c) = CardanoTxGenExtra c
+
+  -- TODO also generate " typical " Byron and Shelley transactions
+  testGenTxs (CoreNodeId i) _ncn curSlot cfg extra ls =
+      pure $ maybeToList $ migrateUTxO migrationInfo curSlot lcfg ls
+    where
+      lcfg = blockConfigLedger $ topLevelConfigBlock cfg
+
+      CardanoTxGenExtra
+        { ctgeByronGenesisKeys
+        , ctgeNetworkMagic
+        , ctgeShelleyCoreNodes
+        } = extra
+
+      GeneratedSecrets
+        { gsRichSecrets
+        } = ctgeByronGenesisKeys
+
+      migrationInfo = MigrationInfo
+        { byronMagic = ctgeNetworkMagic
+        , byronSK
+        , paymentSK
+        , poolSK
+        , stakingSK
+        , vrfSK
+        }
+
+      byronSK :: Byron.SigningKey
+      byronSK = gsRichSecrets !! fromIntegral i
+
+      Shelley.CoreNode
+        { Shelley.cnDelegateKey = paymentSK
+        , Shelley.cnStakingKey  = stakingSK
+        , Shelley.cnVRF         = vrfSK
+        } = ctgeShelleyCoreNodes !! fromIntegral i
+
+      -- Reuse the payment key as the pool key, since it's an individual
+      -- stake pool and the namespaces are separate.
+      poolSK :: SignKeyDSIGN (DSIGN c)
+      poolSK = paymentSK
+
+-- | See 'migrateUTxO'
+data MigrationInfo c = MigrationInfo
+  { byronMagic :: Byron.NetworkMagic
+    -- ^ Needed for creating a Byron address.
+  , byronSK    :: Byron.SigningKey
+    -- ^ The core node's Byron secret.
+  , paymentSK  :: SignKeyDSIGN (DSIGN c)
+  , poolSK     :: SignKeyDSIGN (DSIGN c)
+  , stakingSK  :: SignKeyDSIGN (DSIGN c)
+  , vrfSK      :: SignKeyVRF (VRF c)
+    -- ^ To be re-used by the individual pool.
+  }
+
+-- | Convert a core node's utxo from Byron to an active Shelley stake pool.
+--
+-- Returns a transaction that registers a staking key, registers an individual
+-- stake pool, delegates that stake key to that stake pool, and transfers all
+-- utxo from the Byron 'byronAddr' to the Shelley address corresponding to the
+-- pair of 'paymentSK' and 'stakingSK'.
+--
+-- It returns 'Nothing' if the core node does not have any utxo in its
+-- 'byronAddr' (eg if this transaction has already been applied).
+migrateUTxO :: forall c.
+               (TPraosCrypto c, DSIGN c ~ Ed25519DSIGN)
+            => MigrationInfo c
+            -> SlotNo
+            -> LedgerConfig (CardanoBlock c)
+            -> LedgerState (CardanoBlock c)
+            -> Maybe (GenTx (CardanoBlock c))
+migrateUTxO migrationInfo curSlot lcfg lst
+    | Just utxo <- mbUTxO =
+
+    let picked :: Map (SL.TxIn c) (SL.TxOut c)
+        picked =
+            Map.filter pick $ SL.unUTxO utxo
+          where
+            pick (SL.TxOut addr _) =
+                addr == SL.AddrBootstrap (SL.BootstrapAddress byronAddr)
+
+        -- Total held by 'byronAddr'
+        pickedCoin :: SL.Coin
+        pickedCoin =
+            sum $ fmap (\(SL.TxOut _ coin) -> coin) picked
+
+        -- NOTE: The Cardano ThreadNet tests use the
+        -- ouroboros-consensus-shelley-test infra's genesis config, which sets
+        -- relevant protocol params to 0.
+        fee        :: SL.Coin
+        fee        = 0
+
+        deposits   :: SL.Coin
+        deposits   = 0
+
+        spentCoin   :: SL.Coin
+        spentCoin   = deposits + fee
+
+        unspentCoin :: SL.Coin
+        unspentCoin =
+            assert (pickedCoin > spentCoin) $
+            pickedCoin - spentCoin
+
+        body :: SL.TxBody c
+        body = SL.TxBody
+          { SL._certs    = StrictSeq.fromList $
+              [ SL.DCertDeleg $ SL.RegKey $ Shelley.mkCredential stakingSK
+              , SL.DCertPool  $ SL.RegPool $ poolParams unspentCoin
+              , SL.DCertDeleg $ SL.Delegate $ SL.Delegation
+                  { SL._delegator = Shelley.mkCredential stakingSK
+                  , SL._delegatee = Shelley.mkKeyHash poolSK
+                  }
+              ]
+          , SL._inputs   = Map.keysSet picked
+          , SL._mdHash   = SL.SNothing
+          , SL._outputs  =
+              StrictSeq.singleton $ SL.TxOut shelleyAddr unspentCoin
+          , SL._ttl      = SlotNo maxBound
+          , SL._txUpdate = SL.SNothing
+          , SL._txfee    = fee
+          , SL._wdrls    = SL.Wdrl Map.empty
+          }
+
+        bodyHash :: SL.Hash c (SL.TxBody c)
+        bodyHash = SL.hashWithSerialiser toCBOR body
+
+        -- Witness the use of bootstrap address's utxo.
+        byronWit :: SL.BootstrapWitness c
+        byronWit =
+            SL.makeBootstrapWitness bodyHash byronSK $
+            Byron.addrAttributes byronAddr
+
+        -- Witness the stake delegation.
+        delegWit :: SL.WitVKey c 'SL.Witness
+        delegWit =
+            SL.WitVKey
+              (Shelley.mkVerKey stakingSK)
+              (SL.signedDSIGN @c stakingSK bodyHash)
+
+        -- Witness the pool registration.
+        poolWit :: SL.WitVKey c 'SL.Witness
+        poolWit =
+            SL.WitVKey
+              (Shelley.mkVerKey poolSK)
+              (SL.signedDSIGN @c poolSK bodyHash)
+
+    in
+    if Map.null picked then Nothing else
+    (Just . GenTxShelley. mkShelleyTx) $
+    SL.Tx
+      { SL._body       = body
+      , SL._metadata   = SL.SNothing
+      , SL._witnessSet = SL.WitnessSet
+          { SL.addrWits = Set.fromList [delegWit, poolWit]
+          , SL.bootWits = Set.singleton byronWit
+          , SL.msigWits = Map.empty
+          }
+      }
+
+    | otherwise           = Nothing
+
+  where
+    mbUTxO :: Maybe (SL.UTxO c)
+    mbUTxO =
+        fmap getUTxOShelley $
+        ejectShelleyTickedLedgerState $
+        applyChainTick lcfg curSlot $
+        lst
+
+    MigrationInfo
+      { byronMagic
+      , byronSK
+      , paymentSK
+      , poolSK
+      , stakingSK
+      , vrfSK
+      } = migrationInfo
+
+    byronAddr :: Byron.Address
+    byronAddr =
+        Byron.makeVerKeyAddress byronMagic $ toVerification byronSK
+
+    -- We use a base reference for the stake so that we can refer to it in the
+    -- same tx that registers it.
+    shelleyAddr :: SL.Addr c
+    shelleyAddr =
+        SL.Addr Shelley.networkId
+          (Shelley.mkCredential paymentSK)
+          (SL.StakeRefBase $ Shelley.mkCredential stakingSK)
+
+    -- A simplistic individual pool
+    poolParams :: SL.Coin -> SL.PoolParams c
+    poolParams pledge = SL.PoolParams
+        { SL._poolCost   = SL.Coin 1
+        , SL._poolMD     = SL.SNothing
+        , SL._poolMargin = SL.truncateUnitInterval 0
+        , SL._poolOwners = Set.singleton $ Shelley.mkKeyHash poolSK
+        , SL._poolPledge = pledge
+        , SL._poolPubKey = Shelley.mkKeyHash poolSK
+        , SL._poolRAcnt  =
+            SL.RewardAcnt Shelley.networkId $ Shelley.mkCredential poolSK
+        , SL._poolRelays = StrictSeq.empty
+        , SL._poolVrf    = Shelley.mkKeyHashVrf vrfSK
+        }
+
+-----
+
+ejectShelleyNS :: NS f (CardanoEras c) -> Maybe (f (ShelleyBlock c))
+ejectShelleyNS = \case
+    S (Z x) -> Just x
+    _       -> Nothing
+
+getUTxOShelley :: Ticked (LedgerState (ShelleyBlock c))
+               -> SL.UTxO c
+getUTxOShelley tls =
+    SL._utxo $
+    SL._utxoState $
+    SL.esLState $
+    SL.nesEs $
+    tickedShelleyState tls
+
+ejectShelleyTickedLedgerState :: Ticked (LedgerState (CardanoBlock c))
+                              -> Maybe (Ticked (LedgerState (ShelleyBlock c)))
+ejectShelleyTickedLedgerState ls =
+    fmap (unComp . currentState) $
+    ejectShelleyNS $
+    Tele.tip $
+    getHardForkState $
+    tickedHardForkLedgerStatePerEra $
+    ls

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/TxGen/Cardano.hs
@@ -8,8 +8,8 @@ import           Ouroboros.Consensus.Cardano
 
 import           Test.ThreadNet.TxGen
 
-import           Test.Consensus.Shelley.MockCrypto (TPraosMockCrypto)
+import           Test.Consensus.Shelley.MockCrypto (TPraosMockCryptoCompatByron)
 
-instance TxGen (CardanoBlock (TPraosMockCrypto h)) where
+instance TxGen (CardanoBlock (TPraosMockCryptoCompatByron h)) where
   -- TODO
   testGenTxs _ _ _ _ _ = return []

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
@@ -49,7 +49,7 @@ instance HashAlgorithm h => TxGen (ShelleyBlock (TPraosMockCrypto h)) where
 
   type TxGenExtra (ShelleyBlock (TPraosMockCrypto h)) = ShelleyTxGenExtra h
 
-  testGenTxs _numCoreNodes curSlotNo cfg extra lst
+  testGenTxs _coreNodeId _numCoreNodes curSlotNo cfg extra lst
       | stgeStartAt > curSlotNo = pure []
       | otherwise               = do
       n <- choose (0, 20)

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/TxGen/Mock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/TxGen/Mock.hs
@@ -21,7 +21,7 @@ import           Test.Util.QuickCheck
 -------------------------------------------------------------------------------}
 
 instance TxGen (SimpleBlock SimpleMockCrypto ext) where
-  testGenTxs numCoreNodes curSlotNo _cfg () ledgerState = do
+  testGenTxs _coreNodeId numCoreNodes curSlotNo _cfg () ledgerState = do
       n <- choose (0, 20)
       -- We don't update the UTxO after each transaction, so some of the
       -- generated transactions could very well be invalid.

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/TxGen.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/TxGen.hs
@@ -13,6 +13,7 @@ import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx)
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
+import           Ouroboros.Consensus.NodeId (CoreNodeId)
 
 {-------------------------------------------------------------------------------
   TxGen class
@@ -31,7 +32,8 @@ class TxGen blk where
   --
   -- Note: this function returns a list so that an empty list can be returned
   -- in case we are unable to generate transactions for a @blk@.
-  testGenTxs :: NumCoreNodes
+  testGenTxs :: CoreNodeId
+             -> NumCoreNodes
              -> SlotNo
              -> TopLevelConfig blk
              -> TxGenExtra blk

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -360,7 +360,7 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
 
 -- We ignore the mempool for these tests
 instance TxGen TestBlock where
-  testGenTxs _ _ _ _ _ = return []
+  testGenTxs _ _ _ _ _ _ = return []
 
 {-------------------------------------------------------------------------------
   Hard fork


### PR DESCRIPTION
Fixes #2388.

The big commit could be decomposed a little, but the excess diff I'm thinking of is mostly minor (whitespace/renaming/adding one param to `testGenTxs` etc) and localized -- it's obvious when you see it. Please ping me if the decomposition would be worthwhile by making your review that much easier.

cc: @edsko FYI