### PR TITLE
mux-demo: remove dependency on io-sim

### DIFF
--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -136,7 +136,6 @@ executable mux-demo
                        directory,
                        network-mux,
                        io-sim-classes,
-                       io-sim,
                        contra-tracer,
                        stm,
 


### PR DESCRIPTION
The `mux-demo` doesn't depend on the `io-sim` package.

I believe this is the only reason `cardano-node` needs to list `io-sim` as a
`source-repository-package`. In `cardano-node`, the tests are disabled for all
dependencies, but we can't disable building executables in dependencies, e.g.,
`mux-demo`.