### PR TITLE
DiskConfig

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -103,6 +103,10 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params mLeader =
                     dualCodecConfigMain = mkByronCodecConfig concreteGenesis
                   , dualCodecConfigAux  = ByronSpecCodecConfig
                   }
+              , blockConfigDisk = DualDiskConfig {
+                    dualDiskConfigMain = mkByronDiskConfig concreteGenesis
+                  , dualDiskConfigAux  = ByronSpecDiskConfig
+                  }
               }
           }
       , pInfoInitLedger = ExtLedgerState {

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -8,6 +8,7 @@ module Test.Consensus.Byron.Examples (
   , CC.dummyConfig
   , cfg
   , codecConfig
+  , diskConfig
   , leaderCredentials
     -- * Examples
   , examples
@@ -84,11 +85,15 @@ cfg = ByronConfig {
 codecConfig :: CodecConfig ByronBlock
 codecConfig = mkByronCodecConfig CC.dummyConfig
 
+diskConfig :: DiskConfig ByronBlock
+diskConfig = mkByronDiskConfig CC.dummyConfig
+
 fullBlockConfig :: FullBlockConfig (LedgerState ByronBlock) ByronBlock
 fullBlockConfig = FullBlockConfig {
       blockConfigLedger = CC.dummyConfig
     , blockConfigBlock  = cfg
     , blockConfigCodec  = codecConfig
+    , blockConfigDisk  = diskConfig
     }
 
 leaderCredentials :: ByronLeaderCredentials

--- a/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Golden.hs
+++ b/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Golden.hs
@@ -13,7 +13,7 @@ import           Test.Util.Serialisation.Golden
 import           Test.Consensus.Byron.Examples
 
 tests :: TestTree
-tests = goldenTest_all codecConfig $(getGoldenDir) examples
+tests = goldenTest_all diskConfig codecConfig $(getGoldenDir) examples
 
 instance ToGoldenDirectory ByronNodeToNodeVersion
   -- Use defaults

--- a/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Serialisation.hs
@@ -46,7 +46,7 @@ import           Test.Consensus.Byron.Generators
 
 tests :: TestTree
 tests = testGroup "Byron"
-    [ roundtrip_all testCodecCfg dictNestedHdr
+    [ roundtrip_all testDiskCfg testCodecCfg dictNestedHdr
 
     , testProperty "hashSize" $ prop_hashSize (Proxy @ByronBlock)
 
@@ -115,3 +115,7 @@ testCfg = pInfoConfig protocolInfo
 -- | Matches the values used for the generators.
 testCodecCfg :: CodecConfig ByronBlock
 testCodecCfg = configCodec testCfg
+
+-- | Matches the values used for the generators.
+testDiskCfg :: DiskConfig ByronBlock
+testDiskCfg = configDisk testCfg

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
@@ -226,7 +226,7 @@ instance GetPrevHash ByronBlock where
 instance Measured BlockMeasure ByronBlock where
   measure = blockMeasure
 
-fromByronPrevHash :: CodecConfig ByronBlock
+fromByronPrevHash :: BlockConfig ByronBlock
                   -> Maybe CC.HeaderHash -> ChainHash ByronBlock
 fromByronPrevHash _cfg = \case
     Nothing -> GenesisHash

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
@@ -16,6 +16,9 @@ module Ouroboros.Consensus.Byron.Ledger.Config (
     -- * Codec config
   , CodecConfig(..)
   , mkByronCodecConfig
+    -- * Disk config
+  , DiskConfig(..)
+  , mkByronDiskConfig
   ) where
 
 import           GHC.Generics (Generic)
@@ -72,14 +75,28 @@ byronEpochSlots = CC.Genesis.configEpochSlots . byronGenesisConfig
   Codec config
 -------------------------------------------------------------------------------}
 
-data instance CodecConfig ByronBlock = ByronCodecConfig {
-      getByronEpochSlots    :: !CC.Slot.EpochSlots
-    , getByronSecurityParam :: !SecurityParam
+newtype instance CodecConfig ByronBlock = ByronCodecConfig {
+      byronCodecConfigEpochSlots :: CC.Slot.EpochSlots
     }
   deriving (Generic, NoUnexpectedThunks)
 
 mkByronCodecConfig :: CC.Genesis.Config -> CodecConfig ByronBlock
 mkByronCodecConfig cfg = ByronCodecConfig {
-      getByronEpochSlots    = CC.Genesis.configEpochSlots cfg
-    , getByronSecurityParam = genesisSecurityParam cfg
+      byronCodecConfigEpochSlots = CC.Genesis.configEpochSlots cfg
+    }
+
+{-------------------------------------------------------------------------------
+  Disk config
+-------------------------------------------------------------------------------}
+
+data instance DiskConfig ByronBlock = ByronDiskConfig {
+      byronDiskConfigEpochSlots    :: !CC.Slot.EpochSlots
+    , byronDiskConfigSecurityParam :: !SecurityParam
+    }
+  deriving (Generic, NoUnexpectedThunks)
+
+mkByronDiskConfig :: CC.Genesis.Config -> DiskConfig ByronBlock
+mkByronDiskConfig cfg = ByronDiskConfig {
+      byronDiskConfigEpochSlots    = CC.Genesis.configEpochSlots cfg
+    , byronDiskConfigSecurityParam = genesisSecurityParam        cfg
     }

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -165,6 +165,7 @@ protocolInfoByron genesisConfig mSigThresh pVer sVer mLeader =
                 blockConfigLedger = genesisConfig
               , blockConfigBlock  = mkByronConfig genesisConfig pVer sVer
               , blockConfigCodec  = mkByronCodecConfig genesisConfig
+              , blockConfigDisk   = mkByronDiskConfig  genesisConfig
               }
           }
       , pInfoInitLedger = ExtLedgerState {
@@ -175,14 +176,11 @@ protocolInfoByron genesisConfig mSigThresh pVer sVer mLeader =
           return . byronBlockForging <$> mLeader
       }
 
-protocolClientInfoByron :: EpochSlots
-                        -> SecurityParam
-                        -> ProtocolClientInfo ByronBlock
-protocolClientInfoByron epochSlots securityParam  =
+protocolClientInfoByron :: EpochSlots -> ProtocolClientInfo ByronBlock
+protocolClientInfoByron epochSlots  =
     ProtocolClientInfo {
       pClientInfoCodecConfig = ByronCodecConfig {
-          getByronEpochSlots    = epochSlots
-        , getByronSecurityParam = securityParam
+          byronCodecConfigEpochSlots = epochSlots
         }
     }
 

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
@@ -11,6 +11,7 @@ module Ouroboros.Consensus.ByronSpec.Ledger.Block (
   , Header(..)
   , BlockConfig(..)
   , CodecConfig(..)
+  , DiskConfig(..)
   ) where
 
 import           Codec.Serialise
@@ -102,4 +103,7 @@ data instance BlockConfig ByronSpecBlock = ByronSpecBlockConfig
   deriving (Generic, NoUnexpectedThunks)
 
 data instance CodecConfig ByronSpecBlock = ByronSpecCodecConfig
+  deriving (Generic, NoUnexpectedThunks)
+
+data instance DiskConfig ByronSpecBlock = ByronSpecDiskConfig
   deriving (Generic, NoUnexpectedThunks)

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -183,7 +183,6 @@ runProtocol ProtocolCardano{} = Dict
 data ProtocolClient blk p where
   ProtocolClientByron
     :: EpochSlots
-    -> SecurityParam
     -> ProtocolClient
          ByronBlockHFC
          ProtocolByron
@@ -195,7 +194,6 @@ data ProtocolClient blk p where
 
   ProtocolClientCardano
     :: EpochSlots
-    -> SecurityParam
     -> ProtocolClient
          (CardanoBlock TPraosStandardCrypto)
          ProtocolCardano
@@ -214,11 +212,11 @@ runProtocolClient ProtocolClientCardano{} = Dict
 
 -- | Data required by clients of a node running the specified protocol.
 protocolClientInfo :: ProtocolClient blk p -> ProtocolClientInfo blk
-protocolClientInfo (ProtocolClientByron epochSlots secParam) =
-    inject $ protocolClientInfoByron epochSlots secParam
+protocolClientInfo (ProtocolClientByron epochSlots) =
+    inject $ protocolClientInfoByron epochSlots
 
 protocolClientInfo ProtocolClientShelley =
     inject $ protocolClientInfoShelley
 
-protocolClientInfo (ProtocolClientCardano epochSlots secParam) =
-    protocolClientInfoCardano epochSlots secParam
+protocolClientInfo (ProtocolClientCardano epochSlots) =
+    protocolClientInfoCardano epochSlots

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
@@ -56,6 +56,9 @@ module Ouroboros.Consensus.Cardano.Block (
     -- * CodecConfig
   , CardanoCodecConfig
   , CodecConfig (CardanoCodecConfig)
+    -- * DiskConfig
+  , CardanoDiskConfig
+  , DiskConfig (CardanoDiskConfig)
     -- * BlockConfig
   , CardanoBlockConfig
   , BlockConfig (CardanoBlockConfig)
@@ -389,6 +392,25 @@ pattern CardanoCodecConfig cfgByron cfgShelley =
     HardForkCodecConfig (PerEraCodecConfig (cfgByron :* cfgShelley :* Nil))
 
 {-# COMPLETE CardanoCodecConfig #-}
+
+{-------------------------------------------------------------------------------
+  DiskConfig
+-------------------------------------------------------------------------------}
+
+-- | The 'DiskConfig' for 'CardanoBlock'.
+--
+-- Thanks to the pattern synonyms, you can treat this as the product of
+-- the Byron and Shelley 'DiskConfig'.
+type CardanoDiskConfig sc = DiskConfig (CardanoBlock sc)
+
+pattern CardanoDiskConfig
+  :: DiskConfig ByronBlock
+  -> DiskConfig (ShelleyBlock sc)
+  -> CardanoDiskConfig sc
+pattern CardanoDiskConfig cfgByron cfgShelley =
+    HardForkDiskConfig (PerEraDiskConfig (cfgByron :* cfgShelley :* Nil))
+
+{-# COMPLETE CardanoDiskConfig #-}
 
 {-------------------------------------------------------------------------------
   BlockConfig

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ByronHFC.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ByronHFC.hs
@@ -68,10 +68,10 @@ instance SupportedNetworkProtocolVersion ByronBlockHFC where
 -- wrapper around blocks on disk. This makes sure we're compatible with the
 -- existing Byron blocks.
 instance SerialiseHFC '[ByronBlock] where
-  encodeDiskHfcBlock (DegenCodecConfig ccfg) (DegenBlock b) =
-      encodeDisk ccfg b
-  decodeDiskHfcBlock (DegenCodecConfig ccfg) =
-      fmap DegenBlock <$> decodeDisk ccfg
+  encodeDiskHfcBlock (DegenDiskConfig dcfg) (DegenBlock b) =
+      encodeDisk dcfg b
+  decodeDiskHfcBlock (DegenDiskConfig dcfg) =
+      fmap DegenBlock <$> decodeDisk dcfg
   reconstructHfcPrefixLen _ =
       reconstructPrefixLen (Proxy @(Header ByronBlock))
   reconstructHfcNestedCtxt _ prefix blockSize =

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Examples.hs
@@ -5,6 +5,7 @@
 module Test.Consensus.Cardano.Examples (
     -- * Setup
     codecConfig
+  , diskConfig
     -- * Examples
   , examples
   , exampleEraMismatchByron
@@ -182,6 +183,9 @@ eraInfoShelley = singleEraInfo (Proxy @(ShelleyBlock Crypto))
 
 codecConfig :: CardanoCodecConfig Crypto
 codecConfig = CardanoCodecConfig Byron.codecConfig Shelley.codecConfig
+
+diskConfig :: CardanoDiskConfig Crypto
+diskConfig = CardanoDiskConfig Byron.diskConfig Shelley.diskConfig
 
 {-------------------------------------------------------------------------------
   Additional injections

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Golden.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Golden.hs
@@ -17,7 +17,7 @@ import           Test.Util.Serialisation.Golden
 import           Test.Consensus.Cardano.Examples
 
 tests :: TestTree
-tests = goldenTest_all codecConfig $(getGoldenDir) examples
+tests = goldenTest_all diskConfig codecConfig $(getGoldenDir) examples
 
 instance TPraosCrypto sc => ToGoldenDirectory (HardForkNodeToNodeVersion (CardanoEras sc)) where
   toGoldenDirectory v = case v of

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Serialisation.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Serialisation.hs
@@ -42,7 +42,7 @@ import           Test.Consensus.Cardano.Generators (epochSlots, k)
 
 tests :: TestTree
 tests = testGroup "Cardano"
-    [ roundtrip_all testCodecCfg dictNestedHdr
+    [ roundtrip_all testDiskCfg testCodecCfg dictNestedHdr
 
       -- Note: the above roundtrip tests use 'TPraosMockCrypto' (because we
       -- most generators only work with mock crypto, not with real crypto).
@@ -65,7 +65,11 @@ tests = testGroup "Cardano"
 
 testCodecCfg :: CardanoCodecConfig (TPraosMockCrypto ShortHash)
 testCodecCfg =
-  CardanoCodecConfig (ByronCodecConfig epochSlots k) ShelleyCodecConfig
+  CardanoCodecConfig (ByronCodecConfig epochSlots) ShelleyCodecConfig
+
+testDiskCfg :: CardanoDiskConfig (TPraosMockCrypto ShortHash)
+testDiskCfg =
+  CardanoDiskConfig (ByronDiskConfig epochSlots k) ShelleyDiskConfig
 
 dictNestedHdr
   :: forall a.
@@ -92,8 +96,8 @@ prop_CardanoBinaryBlockInfo blk =
     extractedHeader =
         Lazy.take (fromIntegral headerSize)   $
         Lazy.drop (fromIntegral headerOffset) $
-        CBOR.toLazyByteString (encodeDisk testCodecCfg blk)
+        CBOR.toLazyByteString (encodeDisk testDiskCfg blk)
 
     encodedNestedHeader :: Lazy.ByteString
-    encodedNestedHeader = case encodeDepPair testCodecCfg (unnest (getHeader blk)) of
+    encodedNestedHeader = case encodeDepPair testDiskCfg (unnest (getHeader blk)) of
         GenDepPair _ (Serialised bytes) -> bytes

--- a/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
@@ -352,9 +352,9 @@ withImmDB fp cfg chunkInfo registry = ImmDB.withImmDB args
   where
     args :: ImmDbArgs IO blk
     args = (defaultArgs fp) {
-          immCodecConfig        = configCodec cfg
-        , immChunkInfo          = chunkInfo
-        , immValidation         = ValidateMostRecentChunk
-        , immCheckIntegrity     = nodeCheckIntegrity cfg
-        , immRegistry           = registry
+          immDiskConfig     = configDisk cfg
+        , immChunkInfo      = chunkInfo
+        , immValidation     = ValidateMostRecentChunk
+        , immCheckIntegrity = nodeCheckIntegrity cfg
+        , immRegistry       = registry
         }

--- a/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
@@ -216,11 +216,11 @@ showEBBs cfg immDB rr = do
           Just _epoch ->
             putStrLn $ intercalate "\t" [
                 show (blockHash blk)
-              , show (blockPrevHash (configCodec cfg) blk)
+              , show (blockPrevHash (configBlock cfg) blk)
               , show (    Map.lookup
                             (blockHash blk)
                             (Analysis.knownEBBs (Proxy @blk))
-                       == Just (blockPrevHash (configCodec cfg) blk)
+                       == Just (blockPrevHash (configBlock cfg) blk)
                      )
               ]
           _otherwise ->

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -11,6 +11,7 @@ module Test.Consensus.Shelley.Examples (
     testEpochInfo
   , testShelleyGenesis
   , codecConfig
+  , diskConfig
   , mkDummyHash
     -- * Examples
   , examples
@@ -130,6 +131,9 @@ testShelleyGenesis = SL.ShelleyGenesis {
 
 codecConfig :: CodecConfig (ShelleyBlock TPraosStandardCrypto)
 codecConfig = ShelleyCodecConfig
+
+diskConfig :: DiskConfig (ShelleyBlock TPraosStandardCrypto)
+diskConfig = ShelleyDiskConfig
 
 mkDummyHash :: forall h a. HashAlgorithm h => Proxy h -> Int -> Hash.Hash h a
 mkDummyHash _ = coerce . SL.hashWithSerialiser @h toCBOR

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
@@ -13,7 +13,7 @@ import           Test.Util.Serialisation.Golden
 import           Test.Consensus.Shelley.Examples
 
 tests :: TestTree
-tests = goldenTest_all codecConfig $(getGoldenDir) examples
+tests = goldenTest_all diskConfig codecConfig $(getGoldenDir) examples
 
 instance ToGoldenDirectory ShelleyNodeToNodeVersion
   -- Use defaults

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Serialisation.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Serialisation.hs
@@ -31,7 +31,7 @@ import           Test.Shelley.Spec.Ledger.Serialisation.Generators ()
 
 tests :: TestTree
 tests = testGroup "Shelley"
-    [ roundtrip_all testCodecCfg dictNestedHdr
+    [ roundtrip_all testDiskCfg testCodecCfg dictNestedHdr
 
       -- 'roundtrip_ConvertRawHash' for mock crypto is included in
       -- 'roundtrip_all', but 'prop_hashSize' is not
@@ -56,6 +56,9 @@ tests = testGroup "Shelley"
 
     pReal :: Proxy (ShelleyBlock (TPraosMockCrypto ShortHash))
     pReal = Proxy
+
+    testDiskCfg :: DiskConfig (ShelleyBlock (TPraosMockCrypto ShortHash))
+    testDiskCfg = ShelleyDiskConfig
 
     testCodecCfg :: CodecConfig (ShelleyBlock (TPraosMockCrypto ShortHash))
     testCodecCfg = ShelleyCodecConfig

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
@@ -9,6 +9,7 @@ module Ouroboros.Consensus.Shelley.Ledger.Config (
   , BlockConfig (..)
   , mkShelleyBlockConfig
   , CodecConfig (..)
+  , DiskConfig (..)
   ) where
 
 import           GHC.Generics (Generic)
@@ -72,4 +73,12 @@ mkShelleyBlockConfig protVer genesis blockIssuerVKey = ShelleyConfig {
 
 -- | No particular codec configuration is needed for Shelley
 data instance CodecConfig (ShelleyBlock c) = ShelleyCodecConfig
+  deriving (Generic, NoUnexpectedThunks)
+
+{-------------------------------------------------------------------------------
+  Disk config
+-------------------------------------------------------------------------------}
+
+-- | No particular disk configuration is needed for Shelley
+data instance DiskConfig (ShelleyBlock c) = ShelleyDiskConfig
   deriving (Generic, NoUnexpectedThunks)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -186,6 +186,7 @@ protocolInfoShelley genesis initialNonce maxMajorPV protVer mbCredentials =
             blockConfigLedger = ledgerConfig
           , blockConfigBlock  = blockConfig
           , blockConfigCodec  = ShelleyCodecConfig
+          , blockConfigDisk   = ShelleyDiskConfig
           }
       }
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -346,7 +346,7 @@ instance MockProtocolSpecific c ext
 instance MockProtocolSpecific c ext
       => ApplyBlock (LedgerState (SimpleBlock c ext)) (SimpleBlock c ext) where
   applyLedgerBlock cfg =
-      updateSimpleLedgerState (blockConfigCodec cfg)
+      updateSimpleLedgerState (blockConfigBlock cfg)
 
   reapplyLedgerBlock cfg =
       (mustSucceed . runExcept) .: applyLedgerBlock cfg
@@ -370,7 +370,7 @@ newtype instance Ticked (LedgerState (SimpleBlock c ext)) = TickedSimpleLedgerSt
 instance MockProtocolSpecific c ext => UpdateLedger (SimpleBlock c ext)
 
 updateSimpleLedgerState :: (SimpleCrypto c, Typeable ext)
-                        => CodecConfig (SimpleBlock c ext)
+                        => BlockConfig (SimpleBlock c ext)
                         -> SimpleBlock c ext
                         -> TickedLedgerState (SimpleBlock c ext)
                         -> Except (MockError (SimpleBlock c ext))

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -39,6 +39,7 @@ module Ouroboros.Consensus.Mock.Ledger.Block (
     -- * Configuration
   , BlockConfig(..)
   , CodecConfig(..)
+  , DiskConfig(..)
   , SimpleLedgerConfig(..)
     -- * Protocol-specific part
   , MockProtocolSpecific(..)
@@ -289,8 +290,17 @@ newtype instance BlockConfig (SimpleBlock c ext) =
   Codec config
 -------------------------------------------------------------------------------}
 
+-- | Nothing is needed simple blocks
+data instance CodecConfig (SimpleBlock c ext) = SimpleCodecConfig
+  deriving stock    (Generic)
+  deriving anyclass (NoUnexpectedThunks)
+
+{-------------------------------------------------------------------------------
+  Disk config
+-------------------------------------------------------------------------------}
+
 -- | Only the 'SecurityParam' is required for simple blocks
-newtype instance CodecConfig (SimpleBlock c ext) = SimpleCodecConfig SecurityParam
+newtype instance DiskConfig (SimpleBlock c ext) = SimpleDiskConfig SecurityParam
   deriving newtype (NoUnexpectedThunks)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -185,4 +185,4 @@ instance Serialise (PBftVerKeyHash c')
 
 instance (Serialise (PBftVerKeyHash c'), PBftCrypto c')
       => DecodeDisk (SimplePBftBlock c c') (S.PBftState c') where
-  decodeDisk (SimpleCodecConfig k) = S.decodePBftState k (pbftWindowSize k)
+  decodeDisk (SimpleDiskConfig k) = S.decodePBftState k (pbftWindowSize k)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
@@ -60,7 +60,7 @@ deriving instance Serialise (HeaderHash blk) => Serialise (MockError blk)
 instance Typeable blk => ShowProxy (MockError blk) where
 
 updateMockState :: (GetPrevHash blk, HasMockTxs blk)
-                => CodecConfig blk
+                => BlockConfig blk
                 -> blk
                 -> MockState blk
                 -> Except (MockError blk) (MockState blk)
@@ -70,7 +70,7 @@ updateMockState cfg blk st = do
     updateMockUTxO (blockSlot hdr) blk st'
 
 updateMockTip :: GetPrevHash blk
-              => CodecConfig blk
+              => BlockConfig blk
               -> Header blk
               -> MockState blk
               -> Except (MockError blk) (MockState blk)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -42,7 +42,8 @@ protocolInfoBft numCoreNodes nid securityParam eraParams =
           , topLevelConfigBlock = FullBlockConfig {
                 blockConfigLedger = SimpleLedgerConfig () eraParams
               , blockConfigBlock  = SimpleBlockConfig securityParam
-              , blockConfigCodec  = SimpleCodecConfig securityParam
+              , blockConfigCodec  = SimpleCodecConfig
+              , blockConfigDisk   = SimpleDiskConfig  securityParam
               }
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -40,7 +40,8 @@ protocolInfoMockPBFT params eraParams nid =
           , topLevelConfigBlock = FullBlockConfig {
                 blockConfigLedger = SimpleLedgerConfig ledgerView eraParams
               , blockConfigBlock  = SimpleBlockConfig  (pbftSecurityParam params)
-              , blockConfigCodec  = SimpleCodecConfig  (pbftSecurityParam params)
+              , blockConfigCodec  = SimpleCodecConfig
+              , blockConfigDisk   = SimpleDiskConfig   (pbftSecurityParam params)
               }
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -50,7 +50,8 @@ protocolInfoPraos numCoreNodes nid params eraParams eta0 =
           , topLevelConfigBlock = FullBlockConfig {
                 blockConfigLedger = SimpleLedgerConfig addrDist eraParams
               , blockConfigBlock  = SimpleBlockConfig (praosSecurityParam params)
-              , blockConfigCodec  = SimpleCodecConfig (praosSecurityParam params)
+              , blockConfigCodec  = SimpleCodecConfig
+              , blockConfigDisk   = SimpleDiskConfig  (praosSecurityParam params)
               }
           }
       , pInfoInitLedger = ExtLedgerState {

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -51,7 +51,8 @@ protocolInfoPraosRule numCoreNodes
         , topLevelConfigBlock = FullBlockConfig {
               blockConfigLedger = SimpleLedgerConfig () eraParams
             , blockConfigBlock  = SimpleBlockConfig (praosSecurityParam params)
-            , blockConfigCodec  = SimpleCodecConfig (praosSecurityParam params)
+            , blockConfigCodec  = SimpleCodecConfig
+            , blockConfigDisk   = SimpleDiskConfig  (praosSecurityParam params)
             }
         }
     , pInfoInitLedger = ExtLedgerState

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TypeFamilies          #-}
 
@@ -80,13 +81,13 @@ instance Serialise ext => SerialiseNodeToNode (MockBlock ext) (MockBlock ext) wh
   decodeNodeToNode _ _ = defaultDecodeCBORinCBOR
 
 instance Serialise ext => SerialiseNodeToNode (MockBlock ext) (Header (MockBlock ext)) where
-  encodeNodeToNode ccfg _ = encodeDisk ccfg . unnest
-  decodeNodeToNode ccfg _ = nest <$> decodeDisk ccfg
+  encodeNodeToNode ccfg _ = encodeDisk (undefined ccfg :: DiskConfig (MockBlock ext)) . unnest
+  decodeNodeToNode ccfg _ = nest <$> decodeDisk (undefined ccfg :: DiskConfig (MockBlock ext))
 
 instance SerialiseNodeToNode (MockBlock ext) (Serialised (MockBlock ext))
 instance Serialise ext => SerialiseNodeToNode (MockBlock ext) (SerialisedHeader (MockBlock ext)) where
-  encodeNodeToNode ccfg _ = encodeDisk ccfg
-  decodeNodeToNode ccfg _ = decodeDisk ccfg
+  encodeNodeToNode ccfg _ = encodeDisk (undefined ccfg :: DiskConfig (MockBlock ext))
+  decodeNodeToNode ccfg _ = decodeDisk (undefined ccfg :: DiskConfig (MockBlock ext))
 instance SerialiseNodeToNode (MockBlock ext) (GenTx (MockBlock ext))
 instance SerialiseNodeToNode (MockBlock ext) (GenTxId (MockBlock ext))
 

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -60,14 +60,17 @@ instance Arbitrary TestSetup where
 
 tests :: TestTree
 tests = testGroup "BFT" $
-    [ roundtrip_all testCodecCfg dictNestedHdr
+    [ roundtrip_all testDiskCfg testCodecCfg dictNestedHdr
     , testProperty "simple convergence" $ \setup ->
         prop_simple_bft_convergence setup
     ]
   where
     -- We pick a single value for @k@ for the serialisation tests
+    testDiskCfg :: DiskConfig MockBftBlock
+    testDiskCfg = SimpleDiskConfig (SecurityParam 4)
+
     testCodecCfg :: CodecConfig MockBftBlock
-    testCodecCfg = SimpleCodecConfig (SecurityParam 4)
+    testCodecCfg = SimpleCodecConfig
 
     dictNestedHdr :: forall a. NestedCtxt_ MockBftBlock Header a -> Dict (Eq a, Show a)
     dictNestedHdr CtxtMock = Dict

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -90,7 +90,7 @@ prop_simple_leader_schedule_convergence TestSetup
   , setupLeaderSchedule = schedule
   , setupSlotLength     = slotLength
   } =
-    counterexample (tracesToDot (SimpleCodecConfig k) testOutputNodes) $
+    counterexample (tracesToDot (SimpleBlockConfig k) testOutputNodes) $
     prop_general PropGeneralArgs
       { pgaBlockProperty       = prop_validSimpleBlock
       , pgaCountTxs            = countSimpleGenTxs

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -88,7 +88,7 @@ prop_simple_praos_convergence TestSetup
   , setupSlotLength   = slotLength
   , setupTestConfig   = testConfig
   } =
-    counterexample (tracesToDot (SimpleCodecConfig k) testOutputNodes) $
+    counterexample (tracesToDot (SimpleBlockConfig k) testOutputNodes) $
     prop_general PropGeneralArgs
       { pgaBlockProperty       = prop_validSimpleBlock
       , pgaCountTxs            = countSimpleGenTxs

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Util.hs
@@ -134,7 +134,7 @@ genesisBlockInfo = BlockInfo
 
 
 blockInfo :: (GetPrevHash b, HasCreator b)
-          => CodecConfig b -> b -> BlockInfo b
+          => BlockConfig b -> b -> BlockInfo b
 blockInfo cfg b = BlockInfo
     { biSlot     = blockSlot b
     , biCreator  = Just $ getCreator b
@@ -173,7 +173,7 @@ instance Labellable EdgeLabel where
     toLabelValue = const $ StrLabel Text.empty
 
 tracesToDot :: forall b. (GetPrevHash b, HasCreator b)
-            => CodecConfig b
+            => BlockConfig b
             -> Map NodeId (NodeOutput b)
             -> String
 tracesToDot cfg traces = Text.unpack $ printDotGraph $ graphToDot quickParams graph

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Serialisation/Golden.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Serialisation/Golden.hs
@@ -47,8 +47,8 @@ import           Cardano.Prelude (forceElemsToWHNF)
 
 import           Ouroboros.Network.Block (Serialised)
 
-import           Ouroboros.Consensus.Block (BlockProtocol, CodecConfig, Header,
-                     HeaderHash, SomeBlock)
+import           Ouroboros.Consensus.Block (BlockProtocol, CodecConfig,
+                     DiskConfig, Header, HeaderHash, SomeBlock)
 import           Ouroboros.Consensus.HeaderValidation (AnnTip)
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerState, Query)
 import           Ouroboros.Consensus.Ledger.Extended (ExtLedgerState,
@@ -301,15 +301,16 @@ goldenTest_all ::
 
      , HasCallStack
      )
-  => CodecConfig blk
+  => DiskConfig blk
+  -> CodecConfig blk
   -> FilePath
      -- ^ Path relative to the root of the repository that contains the golden
      -- files
   -> Examples blk
   -> TestTree
-goldenTest_all codecConfig goldenDir examples =
+goldenTest_all diskConfig codecConfig goldenDir examples =
     testGroup "Golden tests" [
-        goldenTest_SerialiseDisk         codecConfig goldenDir examples
+        goldenTest_SerialiseDisk         diskConfig  goldenDir examples
       , goldenTest_SerialiseNodeToNode   codecConfig goldenDir examples
       , goldenTest_SerialiseNodeToClient codecConfig goldenDir examples
       ]
@@ -318,17 +319,17 @@ goldenTest_all codecConfig goldenDir examples =
 -- 'SerialiseDiskConstraints'?
 goldenTest_SerialiseDisk ::
      forall blk. (SerialiseDiskConstraints blk, HasCallStack)
-  => CodecConfig blk
+  => DiskConfig blk
   -> FilePath
   -> Examples blk
   -> TestTree
-goldenTest_SerialiseDisk codecConfig goldenDir Examples {..} =
+goldenTest_SerialiseDisk diskConfig goldenDir Examples {..} =
     testGroup "SerialiseDisk" [
-        test "Block"          exampleBlock         (encodeDisk codecConfig)
+        test "Block"          exampleBlock         (encodeDisk diskConfig)
       , test "HeaderHash"     exampleHeaderHash     encode
-      , test "LedgerState"    exampleLedgerState   (encodeDisk codecConfig)
-      , test "AnnTip"         exampleAnnTip        (encodeDisk codecConfig)
-      , test "ChainDepState"  exampleChainDepState (encodeDisk codecConfig)
+      , test "LedgerState"    exampleLedgerState   (encodeDisk diskConfig)
+      , test "AnnTip"         exampleAnnTip        (encodeDisk diskConfig)
+      , test "ChainDepState"  exampleChainDepState (encodeDisk diskConfig)
       , test "ExtLedgerState" exampleExtLedgerState encodeExt
       ]
   where
@@ -342,9 +343,9 @@ goldenTest_SerialiseDisk codecConfig goldenDir Examples {..} =
 
     encodeExt =
         encodeExtLedgerState
-          (encodeDisk codecConfig)
-          (encodeDisk codecConfig)
-          (encodeDisk codecConfig)
+          (encodeDisk diskConfig)
+          (encodeDisk diskConfig)
+          (encodeDisk diskConfig)
 
 -- TODO how can we ensure that we have a test for each constraint listed in
 -- 'SerialiseNodeToNodeConstraints'?

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -300,14 +300,14 @@ instance IsLedger (LedgerState TestBlock) where
 
 instance ApplyBlock (LedgerState TestBlock) TestBlock where
   applyLedgerBlock cfg tb@TestBlock{..} (TickedTestLedger TestLedger{..})
-    | blockPrevHash ccfg tb /= pointHash lastAppliedPoint
-    = throwError $ InvalidHash (pointHash lastAppliedPoint) (blockPrevHash ccfg tb)
+    | blockPrevHash bcfg tb /= pointHash lastAppliedPoint
+    = throwError $ InvalidHash (pointHash lastAppliedPoint) (blockPrevHash bcfg tb)
     | not tbValid
     = throwError $ InvalidBlock
     | otherwise
     = return     $ TestLedger (Chain.blockPoint tb)
     where
-      ccfg = blockConfigCodec cfg
+      bcfg = blockConfigBlock cfg
 
   reapplyLedgerBlock _ tb _ = TestLedger (Chain.blockPoint tb)
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -28,6 +28,7 @@ module Test.Util.TestBlock (
   , Header(..)
   , BlockConfig(..)
   , CodecConfig(..)
+  , DiskConfig(..)
   , Query(..)
   , firstBlock
   , successorBlock
@@ -246,6 +247,10 @@ data instance BlockConfig TestBlock = TestBlockConfig {
 data instance CodecConfig TestBlock = TestBlockCodecConfig
   deriving (Show, Generic, NoUnexpectedThunks)
 
+-- | The 'TestBlock' does not need any disk config
+data instance DiskConfig TestBlock = TestBlockDiskConfig
+  deriving (Show, Generic, NoUnexpectedThunks)
+
 instance HasNetworkProtocolVersion TestBlock where
   -- Use defaults
 
@@ -394,6 +399,7 @@ singleNodeTestConfig = TopLevelConfig {
           blockConfigLedger = eraParams
         , blockConfigBlock  = TestBlockConfig numCoreNodes
         , blockConfigCodec  = TestBlockCodecConfig
+        , blockConfigDisk   = TestBlockDiskConfig
         }
     }
   where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -114,9 +114,9 @@ class (HasHeader blk, GetHeader blk) => GetPrevHash blk where
   -- This gets its own abstraction, because it will be a key part of the path
   -- to getting rid of EBBs: when we have blocks @A - EBB - B@, the prev hash
   -- of @B@ will be reported as @A@.
-  headerPrevHash :: CodecConfig blk -> Header blk -> ChainHash blk
+  headerPrevHash :: BlockConfig blk -> Header blk -> ChainHash blk
 
-blockPrevHash :: GetPrevHash blk => CodecConfig blk -> blk -> ChainHash blk
+blockPrevHash :: GetPrevHash blk => BlockConfig blk -> blk -> ChainHash blk
 blockPrevHash cfg = castHash . headerPrevHash cfg . getHeader
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -11,6 +11,7 @@ module Ouroboros.Consensus.Block.Abstract (
     -- * Configuration
   , BlockConfig
   , CodecConfig
+  , DiskConfig
     -- * Previous hash
   , GetPrevHash(..)
   , blockPrevHash
@@ -98,11 +99,17 @@ type family BlockProtocol blk :: *
 -- | Static configuration required to work with this type of blocks
 data family BlockConfig blk :: *
 
--- | Static configuration required for serialisation and deserialisation of
--- types pertaining to this type of block.
+-- | Static configuration required for (de)serialising types pertaining to
+-- this type of block when sending/receiving them across the network.
 --
 -- Data family instead of type family to get better type inference.
 data family CodecConfig blk :: *
+
+-- | Static configuration required for (de)serialising types pertaining to
+-- this type of block from/to disk.
+--
+-- Data family instead of type family to get better type inference.
+data family DiskConfig blk :: *
 
 {-------------------------------------------------------------------------------
   Get hash of previous block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
@@ -22,6 +22,7 @@ class ( GetHeader blk
       , NoUnexpectedThunks (Header blk)
       , NoUnexpectedThunks (BlockConfig blk)
       , NoUnexpectedThunks (CodecConfig blk)
+      , NoUnexpectedThunks (DiskConfig blk)
       ) => BlockSupportsProtocol blk where
   validateView :: BlockConfig blk
                -> Header blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
@@ -48,7 +48,8 @@ import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras as X
                      (MismatchEraInfo (..), OneEraApplyTxErr (..),
                      OneEraBlock (..), OneEraGenTx (..), OneEraGenTxId (..),
                      OneEraHash (..), OneEraHeader (..), OneEraTipInfo (..),
-                     PerEraCodecConfig (..), PerEraLedgerConfig (..))
+                     PerEraCodecConfig (..), PerEraDiskConfig (..),
+                     PerEraLedgerConfig (..))
 
 -- Re-export types required to initialize 'ProtocolInfo'
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -25,6 +25,7 @@ module Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
   , PerEraLedgerConfig(..)
   , PerEraBlockConfig(..)
   , PerEraCodecConfig(..)
+  , PerEraDiskConfig(..)
   , PerEraForgeStateInfo(..)
   , PerEraForgeStateUpdateError(..)
     -- * Value for /one/ era
@@ -92,6 +93,7 @@ newtype PerEraChainSelConfig  xs = PerEraChainSelConfig  { getPerEraChainSelConf
 newtype PerEraLedgerConfig    xs = PerEraLedgerConfig    { getPerEraLedgerConfig    :: NP WrapPartialLedgerConfig    xs }
 newtype PerEraBlockConfig     xs = PerEraBlockConfig     { getPerEraBlockConfig     :: NP BlockConfig                xs }
 newtype PerEraCodecConfig     xs = PerEraCodecConfig     { getPerEraCodecConfig     :: NP CodecConfig                xs }
+newtype PerEraDiskConfig      xs = PerEraDiskConfig      { getPerEraDiskConfig      :: NP DiskConfig                 xs }
 
 -- | We might not be a leader, but /when/ we need the 'ForgeStateInfo', e.g.,
 -- in 'checkIsLeader', then 'ForgeStateInfo' will be non-empty.
@@ -233,6 +235,9 @@ deriving via LiftNamedNP "PerEraBlockConfig" BlockConfig xs
 
 deriving via LiftNamedNP "PerEraCodecConfig" CodecConfig xs
          instance CanHardFork xs => NoUnexpectedThunks (PerEraCodecConfig xs)
+
+deriving via LiftNamedNP "PerEraDiskConfig" DiskConfig xs
+         instance CanHardFork xs => NoUnexpectedThunks (PerEraDiskConfig xs)
 
 deriving via LiftNamedNP "PerEraConsensusConfig" WrapPartialConsensusConfig xs
          instance CanHardFork xs => NoUnexpectedThunks (PerEraConsensusConfig xs)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -110,10 +110,10 @@ instance CanHardFork xs => GetPrevHash (HardForkBlock xs) where
       . getOneEraHeader
       . getHardForkHeader
     where
-      cfgs = getPerEraCodecConfig $ hardForkCodecConfigPerEra cfg
+      cfgs = getPerEraBlockConfig $ hardForkBlockConfigPerEra cfg
 
       getOnePrev :: forall blk. SingleEraBlock blk
-                 => CodecConfig blk -> Header blk -> ChainHash (HardForkBlock xs)
+                 => BlockConfig blk -> Header blk -> ChainHash (HardForkBlock xs)
       getOnePrev cfg' hdr =
           case headerPrevHash cfg' hdr of
             GenesisHash -> GenesisHash

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -23,6 +23,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Degenerate (
   , Query (DegenQuery)
   , Either (DegenQueryResult)
   , CodecConfig (DegenCodecConfig)
+  , DiskConfig (DegenDiskConfig)
   , BlockConfig (DegenBlockConfig)
   , ConsensusConfig (DegenConsensusConfig)
   , HardForkLedgerConfig (DegenLedgerConfig)
@@ -84,6 +85,7 @@ instance ( RunNode b
 {-# COMPLETE DegenBlock                    #-}
 {-# COMPLETE DegenBlockConfig              #-}
 {-# COMPLETE DegenCodecConfig              #-}
+{-# COMPLETE DegenDiskConfig               #-}
 {-# COMPLETE DegenGenTx                    #-}
 {-# COMPLETE DegenGenTxId                  #-}
 {-# COMPLETE DegenHeader                   #-}
@@ -181,6 +183,14 @@ pattern DegenCodecConfig ::
 pattern DegenCodecConfig x <- (project -> x)
   where
     DegenCodecConfig x = inject x
+
+pattern DegenDiskConfig ::
+     NoHardForks b
+  => DiskConfig b
+  -> DiskConfig (HardForkBlock '[b])
+pattern DegenDiskConfig x <- (project -> x)
+  where
+    DegenDiskConfig x = inject x
 
 pattern DegenBlockConfig ::
      NoHardForks b

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
@@ -89,7 +89,7 @@ instance SerialiseHFC xs
         encodeNS (hcmap pSHFC (fn . (K .: encodeDisk)) cfgs)
       . distribAnnTip
     where
-      cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
+      cfgs = getPerEraDiskConfig (hardForkDiskConfigPerEra cfg)
 
 instance SerialiseHFC xs
       => DecodeDisk (HardForkBlock xs) (AnnTip (HardForkBlock xs)) where
@@ -97,17 +97,17 @@ instance SerialiseHFC xs
         fmap undistribAnnTip
       $ decodeNS (hcmap pSHFC (Comp . decodeDisk) cfgs)
     where
-      cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
+      cfgs = getPerEraDiskConfig (hardForkDiskConfigPerEra cfg)
 
 instance SerialiseHFC xs
       => EncodeDisk (HardForkBlock xs) (HardForkChainDepState xs) where
   encodeDisk cfg =
       encodeTelescope (hcmap pSHFC (fn . aux) cfgs)
     where
-      cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
+      cfgs = getPerEraDiskConfig (hardForkDiskConfigPerEra cfg)
 
       aux :: SerialiseDiskConstraints blk
-          => CodecConfig blk -> WrapChainDepState blk -> K Encoding blk
+          => DiskConfig blk -> WrapChainDepState blk -> K Encoding blk
       aux cfg' (WrapChainDepState st) = K $ encodeDisk cfg' st
 
 instance SerialiseHFC xs
@@ -115,7 +115,7 @@ instance SerialiseHFC xs
   decodeDisk cfg =
       decodeTelescope (hcmap pSHFC (Comp . fmap WrapChainDepState . decodeDisk) cfgs)
     where
-      cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
+      cfgs = getPerEraDiskConfig (hardForkDiskConfigPerEra cfg)
 
 instance SerialiseHFC xs
       => EncodeDisk (HardForkBlock xs) (LedgerState (HardForkBlock xs) )where
@@ -123,7 +123,7 @@ instance SerialiseHFC xs
         encodeTelescope (hcmap pSHFC (fn . (K .: encodeDisk)) cfgs)
       . hardForkLedgerStatePerEra
     where
-      cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
+      cfgs = getPerEraDiskConfig (hardForkDiskConfigPerEra cfg)
 
 instance SerialiseHFC xs
       => DecodeDisk (HardForkBlock xs) (LedgerState (HardForkBlock xs)) where
@@ -131,4 +131,4 @@ instance SerialiseHFC xs
         fmap HardForkLedgerState
       $ decodeTelescope (hcmap pSHFC (Comp . decodeDisk) cfgs)
     where
-      cfgs = getPerEraCodecConfig (hardForkCodecConfigPerEra cfg)
+      cfgs = getPerEraDiskConfig (hardForkDiskConfigPerEra cfg)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
@@ -133,8 +133,8 @@ after f g x y z = f x y (g z)
 
 instance SerialiseHFC xs
       => SerialiseNodeToClient (HardForkBlock xs) (HardForkBlock xs) where
-  encodeNodeToClient ccfg _ = wrapCBORinCBOR   (encodeDiskHfcBlock ccfg)
-  decodeNodeToClient ccfg _ = unwrapCBORinCBOR (decodeDiskHfcBlock ccfg)
+  encodeNodeToClient ccfg _ = wrapCBORinCBOR   (encodeDiskHfcBlock (undefined ccfg))
+  decodeNodeToClient ccfg _ = unwrapCBORinCBOR (decodeDiskHfcBlock (undefined ccfg))
 
 {-------------------------------------------------------------------------------
   Serialised blocks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
@@ -108,8 +108,8 @@ after f g x y z = f x y (g z)
 
 instance SerialiseHFC xs
       => SerialiseNodeToNode (HardForkBlock xs) (HardForkBlock xs) where
-  encodeNodeToNode ccfg _ = wrapCBORinCBOR   (encodeDiskHfcBlock ccfg)
-  decodeNodeToNode ccfg _ = unwrapCBORinCBOR (decodeDiskHfcBlock ccfg)
+  encodeNodeToNode ccfg _ = wrapCBORinCBOR   (encodeDiskHfcBlock (undefined ccfg))
+  decodeNodeToNode ccfg _ = unwrapCBORinCBOR (decodeDiskHfcBlock (undefined ccfg))
 
 instance SerialiseHFC xs
       => SerialiseNodeToNode (HardForkBlock xs) (Header (HardForkBlock xs)) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
@@ -192,6 +192,10 @@ instance Isomorphic CodecConfig where
   project = defaultProjectNP
   inject  = defaultInjectNP
 
+instance Isomorphic DiskConfig where
+  project = defaultProjectNP
+  inject  = defaultInjectNP
+
 instance Isomorphic LedgerState where
   project = defaultProjectSt
   inject  = defaultInjectSt
@@ -264,6 +268,7 @@ instance Isomorphic TopLevelConfig where
         (auxLedger    $ configLedger    tlc)
         (project      $ configBlock     tlc)
         (project      $ configCodec     tlc)
+        (project      $ configDisk      tlc)
     where
       ei :: EpochInfo Identity
       ei = noHardForksEpochInfo $ project tlc
@@ -293,6 +298,7 @@ instance Isomorphic TopLevelConfig where
         (auxLedger    $ configLedger    tlc)
         (inject       $ configBlock     tlc)
         (inject       $ configCodec     tlc)
+        (inject       $ configDisk      tlc)
     where
       eraParams = getEraParams tlc
       k         = configSecurityParam tlc

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -378,7 +378,7 @@ validateEnvelope cfg ledgerView oldTip hdr = do
 
     actualSlotNo   = blockSlot hdr
     actualBlockNo  = blockNo   hdr
-    actualPrevHash = headerPrevHash (configCodec cfg) hdr
+    actualPrevHash = headerPrevHash (configBlock cfg) hdr
 
     expectedSlotNo :: SlotNo -- Lower bound only
     expectedSlotNo =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -279,7 +279,7 @@ instance Bridge m a => HasHeader (DualHeader m a) where
 instance Bridge m a => GetPrevHash (DualBlock m a) where
   headerPrevHash cfg =
         castHash
-      . headerPrevHash (dualCodecConfigMain cfg)
+      . headerPrevHash (dualBlockConfigMain cfg)
       . dualHeaderMain
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -115,6 +115,7 @@ extLedgerCfgToTopLevel FullBlockConfig{..} = TopLevelConfig {
           blockConfigLedger = extLedgerCfgLedger
         , blockConfigBlock  = blockConfigBlock
         , blockConfigCodec  = blockConfigCodec
+        , blockConfigDisk   = blockConfigDisk
         }
     }
   where
@@ -129,6 +130,7 @@ extLedgerCfgFromTopLevel tlc = FullBlockConfig {
         }
     , blockConfigBlock  = configBlock tlc
     , blockConfigCodec  = configCodec tlc
+    , blockConfigDisk   = configDisk tlc
     }
 
 type instance HeaderHash (ExtLedgerState blk) = HeaderHash (LedgerState blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -655,7 +655,7 @@ chainSyncClient mkPipelineDecision0 tracer cfg
 
           -- Validate header
           let expectPrevHash = castHash (AF.headHash theirFrag)
-              actualPrevHash = headerPrevHash (configCodec cfg) hdr
+              actualPrevHash = headerPrevHash (configBlock cfg) hdr
           when (actualPrevHash /= expectPrevHash) $
             disconnect $ DoesntFit actualPrevHash expectPrevHash ourTip theirTip
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -143,7 +143,8 @@ fromChainDbArgs :: ChainDbArgs m blk
                    )
 fromChainDbArgs ChainDbArgs{..} = (
       ImmDB.ImmDbArgs {
-          immCodecConfig        = configCodec cdbTopLevelConfig
+          immBlockConfig        = configBlock cdbTopLevelConfig
+        , immCodecConfig        = configCodec cdbTopLevelConfig
         , immChunkInfo          = cdbChunkInfo
         , immValidation         = cdbImmValidation
         , immCheckIntegrity     = cdbCheckIntegrity
@@ -156,6 +157,7 @@ fromChainDbArgs ChainDbArgs{..} = (
           volHasFS              = cdbHasFSVolDb
         , volCheckIntegrity     = cdbCheckIntegrity
         , volBlocksPerFile      = cdbBlocksPerFile
+        , volBlockConfig        = configBlock cdbTopLevelConfig
         , volCodecConfig        = configCodec cdbTopLevelConfig
         , volValidation         = cdbVolValidation
         , volTracer             = contramap TraceVolDBEvent cdbTracer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -144,7 +144,7 @@ fromChainDbArgs :: ChainDbArgs m blk
 fromChainDbArgs ChainDbArgs{..} = (
       ImmDB.ImmDbArgs {
           immBlockConfig        = configBlock cdbTopLevelConfig
-        , immCodecConfig        = configCodec cdbTopLevelConfig
+        , immDiskConfig         = configDisk cdbTopLevelConfig
         , immChunkInfo          = cdbChunkInfo
         , immValidation         = cdbImmValidation
         , immCheckIntegrity     = cdbCheckIntegrity
@@ -158,7 +158,7 @@ fromChainDbArgs ChainDbArgs{..} = (
         , volCheckIntegrity     = cdbCheckIntegrity
         , volBlocksPerFile      = cdbBlocksPerFile
         , volBlockConfig        = configBlock cdbTopLevelConfig
-        , volCodecConfig        = configCodec cdbTopLevelConfig
+        , volDiskConfig         = configDisk cdbTopLevelConfig
         , volValidation         = cdbVolValidation
         , volTracer             = contramap TraceVolDBEvent cdbTracer
         }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -456,7 +456,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
         return tipPoint
 
       -- The block @b@ fits onto the end of our current chain
-      | pointHash tipPoint == headerPrevHash (configCodec cdbTopLevelConfig) hdr -> do
+      | pointHash tipPoint == headerPrevHash (configBlock cdbTopLevelConfig) hdr -> do
         -- ### Add to current chain
         trace (TryAddToCurrentChain p)
         addToCurrentChain succsOf' curChainAndLedger

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
@@ -142,7 +142,8 @@ type TraceEvent blk =
 --
 -- See also 'defaultArgs'.
 data ImmDbArgs m blk = forall h. Eq h => ImmDbArgs {
-      immCodecConfig    :: CodecConfig blk
+      immBlockConfig    :: BlockConfig blk
+    , immCodecConfig    :: CodecConfig blk
     , immChunkInfo      :: ChunkInfo
     , immValidation     :: ImmDB.ValidationPolicy
     , immCheckIntegrity :: blk -> Bool
@@ -156,6 +157,7 @@ data ImmDbArgs m blk = forall h. Eq h => ImmDbArgs {
 --
 -- The following fields must still be defined:
 --
+-- * 'immBlockConfig'
 -- * 'immCodecConfig'
 -- * 'immChunkInfo'
 -- * 'immValidation'
@@ -167,6 +169,7 @@ defaultArgs fp = ImmDbArgs{
     , immCacheConfig        = cacheConfig
     , immTracer             = nullTracer
       -- Fields without a default
+    , immBlockConfig        = error "no default for immBlockConfig"
     , immCodecConfig        = error "no default for immCodecConfig"
     , immChunkInfo          = error "no default for immChunkInfo"
     , immValidation         = error "no default for immValidation"
@@ -244,7 +247,7 @@ openDB ImmDbArgs {..} = do
       , prefixLen   = reconstructPrefixLen (Proxy @(Header blk))
       }
     parser = ImmDB.chunkFileParser
-               immCodecConfig
+               immBlockConfig
                immHasFS
                (decodeDisk immCodecConfig)
                immCheckIntegrity

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -272,13 +272,13 @@ initFromDisk LgrDbArgs{..} replayTracer immDB = wrapFailure $ do
         (streamAPI immDB)
     return (db, replayed)
   where
-    ccfg = configCodec lgrTopLevelConfig
+    dcfg = configDisk lgrTopLevelConfig
 
     decodeExtLedgerState' :: forall s. Decoder s (ExtLedgerState blk)
     decodeExtLedgerState' = decodeExtLedgerState
-                              (decodeDisk ccfg)
-                              (decodeDisk ccfg)
-                              (decodeDisk ccfg)
+                              (decodeDisk dcfg)
+                              (decodeDisk dcfg)
+                              (decodeDisk dcfg)
 
 -- | For testing purposes
 mkLgrDB :: StrictTVar m (LedgerDB blk)
@@ -352,13 +352,13 @@ takeSnapshot lgrDB@LgrDB{ args = LgrDbArgs{..} } = wrapFailure $ do
       (encodeRealPoint encode)
       ledgerDB
   where
-    ccfg = configCodec lgrTopLevelConfig
+    dcfg = configDisk lgrTopLevelConfig
 
     encodeExtLedgerState' :: ExtLedgerState blk -> Encoding
     encodeExtLedgerState' = encodeExtLedgerState
-                              (encodeDisk ccfg)
-                              (encodeDisk ccfg)
-                              (encodeDisk ccfg)
+                              (encodeDisk dcfg)
+                              (encodeDisk dcfg)
+                              (encodeDisk dcfg)
 
 trimSnapshots :: MonadCatch m => LgrDB m blk -> m [DiskSnapshot]
 trimSnapshots LgrDB{ args = LgrDbArgs{..} } = wrapFailure $

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reader.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Reader.hs
@@ -276,8 +276,8 @@ instructionHelper registry varReader blockComponent fromMaybeSTM CDB{..} = do
   where
     trace = traceWith (contramap TraceReaderEvent cdbTracer)
 
-    codecConfig :: CodecConfig blk
-    codecConfig = configCodec cdbTopLevelConfig
+    diskConfig :: DiskConfig blk
+    diskConfig = configDisk cdbTopLevelConfig
 
     headerUpdateToBlockComponentUpdate
       :: f (ChainUpdate blk (Header blk)) -> m (f (ChainUpdate blk b))
@@ -321,7 +321,7 @@ instructionHelper registry varReader blockComponent fromMaybeSTM CDB{..} = do
         rawHdr :: Lazy.ByteString
         rawHdr = case unnest hdr of
           DepPair ctxt h ->
-            toLazyByteString $ encodeDiskDep codecConfig ctxt h
+            toLazyByteString $ encodeDiskDep diskConfig ctxt h
 
     next
       :: ImmDB.Iterator (HeaderHash blk) m (Point blk, b)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Parser.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Parser.hs
@@ -71,7 +71,7 @@ chunkFileParser
      , hash ~ HeaderHash blk
      , HasBinaryBlockInfo blk
      )
-  => CodecConfig blk
+  => BlockConfig blk
   -> HasFS m h
   -> (forall s. Decoder s (BL.ByteString -> blk))
   -> (blk -> Bool)        -- ^ Check integrity of the block. 'False' = corrupt.

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -287,6 +287,12 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
                     :* CCfgB
                     :* Nil
                 }
+            , blockConfigDisk = HardForkDiskConfig {
+                  hardForkDiskConfigPerEra = PerEraDiskConfig $
+                       DCfgA
+                    :* DCfgB
+                    :* Nil
+                }
             }
         }
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -29,6 +29,7 @@ module Test.Consensus.HardFork.Combinator.A (
     -- * Type family instances
   , BlockConfig(..)
   , CodecConfig(..)
+  , DiskConfig(..)
   , ConsensusConfig(..)
   , GenTx(..)
   , Header(..)
@@ -148,6 +149,9 @@ type instance BlockProtocol BlockA = ProtocolA
 type instance HeaderHash    BlockA = Strict.ByteString
 
 data instance CodecConfig BlockA = CCfgA
+  deriving (Generic, NoUnexpectedThunks)
+
+data instance DiskConfig BlockA = DCfgA
   deriving (Generic, NoUnexpectedThunks)
 
 instance ConfigSupportsNode BlockA where

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -25,6 +25,7 @@ module Test.Consensus.HardFork.Combinator.B (
     -- * Type family instances
   , BlockConfig(..)
   , CodecConfig(..)
+  , DiskConfig(..)
   , ConsensusConfig(..)
   , GenTx(..)
   , Header(..)
@@ -136,6 +137,9 @@ type instance BlockProtocol BlockB = ProtocolB
 type instance HeaderHash    BlockB = Strict.ByteString
 
 data instance CodecConfig BlockB = CCfgB
+  deriving (Generic, NoUnexpectedThunks)
+
+data instance DiskConfig BlockB = DCfgB
   deriving (Generic, NoUnexpectedThunks)
 
 instance ConfigSupportsNode BlockB where

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -399,6 +399,7 @@ runChainSync securityParam (ClientUpdates clientUpdates)
             blockConfigLedger = eraParams
           , blockConfigBlock  = TestBlockConfig numCoreNodes
           , blockConfigCodec  = TestBlockCodecConfig
+          , blockConfigDisk   = TestBlockDiskConfig
           }
       }
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -224,6 +224,7 @@ testCfg securityParam = TopLevelConfig {
           blockConfigLedger = eraParams
         , blockConfigBlock  = TestBlockConfig numCoreNodes
         , blockConfigCodec  = TestBlockCodecConfig
+        , blockConfigDisk   = TestBlockDiskConfig
         }
     }
   where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -391,7 +391,7 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
         (_volDBModel, volDB) <- VolDB.openDBMock (VolDB.mkBlocksPerFile 1)
         forM_ blocks $ \block ->
           VolDB.putBlock volDB (blockInfo block) (serialiseIncremental block)
-        return $ mkVolDB volDB testBlockConfig TestBlockCodecConfig
+        return $ mkVolDB volDB testBlockConfig TestBlockDiskConfig
 
     blockInfo :: TestBlock -> VolDB.BlockInfo (HeaderHash TestBlock)
     blockInfo tb = VolDB.BlockInfo
@@ -423,7 +423,7 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
           Just epoch -> ImmDB.appendEBB immDB
             epoch (blockNo block) (blockHash block)
             (CBOR.toBuilder (encode block)) (getBinaryBlockInfo block)
-        return $ mkImmDB immDB TestBlockCodecConfig chunkInfo
+        return $ mkImmDB immDB TestBlockDiskConfig chunkInfo
       where
         chunkInfo = ImmDB.simpleChunkInfo epochSize
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -23,6 +23,7 @@ import           Ouroboros.Network.MockChain.Chain (Chain)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
@@ -390,14 +391,14 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
         (_volDBModel, volDB) <- VolDB.openDBMock (VolDB.mkBlocksPerFile 1)
         forM_ blocks $ \block ->
           VolDB.putBlock volDB (blockInfo block) (serialiseIncremental block)
-        return $ mkVolDB volDB TestBlockCodecConfig
+        return $ mkVolDB volDB testBlockConfig TestBlockCodecConfig
 
     blockInfo :: TestBlock -> VolDB.BlockInfo (HeaderHash TestBlock)
     blockInfo tb = VolDB.BlockInfo
       { VolDB.bbid          = blockHash tb
       , VolDB.bslot         = blockSlot tb
       , VolDB.bbno          = blockNo   tb
-      , VolDB.bpreBid       = case blockPrevHash TestBlockCodecConfig tb of
+      , VolDB.bpreBid       = case blockPrevHash testBlockConfig tb of
           GenesisHash -> Origin
           BlockHash h -> NotOrigin h
       , VolDB.bisEBB        = testBlockIsEBB tb
@@ -425,3 +426,10 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
         return $ mkImmDB immDB TestBlockCodecConfig chunkInfo
       where
         chunkInfo = ImmDB.simpleChunkInfo epochSize
+
+    -- | Values don't matter
+    testBlockConfig :: BlockConfig TestBlock
+    testBlockConfig = TestBlockConfig {
+          testBlockEBBsAllowed  = True
+        , testBlockNumCoreNodes = NumCoreNodes 1
+        }

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -496,7 +496,7 @@ addBlockPromise cfg blk m = (result, m')
 stream
   :: GetPrevHash blk
   => SecurityParam
-  -> CodecConfig blk
+  -> BlockConfig blk
   -> StreamFrom  blk
   -> StreamTo    blk
   -> Model       blk
@@ -790,7 +790,7 @@ validate cfg Model { currentSlot, maxClockSkew, initLedger, invalid } chain =
 
 
 chains :: forall blk. (GetPrevHash blk)
-       => CodecConfig blk
+       => BlockConfig blk
        -> Map (HeaderHash blk) blk -> [Chain blk]
 chains cfg bs = go Chain.Genesis
   where
@@ -835,7 +835,7 @@ validChains cfg m bs =
     -- over the equally preferable A->B as it will be the first in the list
     -- after a stable sort.
     sortChains $
-    chains (configCodec cfg) bs
+    chains (configBlock cfg) bs
   where
     sortChains :: [Chain blk] -> [Chain blk]
     sortChains = sortBy (flip (Fragment.compareAnchoredCandidates cfg `on`
@@ -848,7 +848,7 @@ validChains cfg m bs =
 
 -- Map (HeaderHash blk) blk maps a block's hash to the block itself
 successors :: forall blk. GetPrevHash blk
-           => CodecConfig blk
+           => BlockConfig blk
            -> [blk]
            -> Map (ChainHash blk) (Map (HeaderHash blk) blk)
 successors cfg = Map.unionsWith Map.union . map single
@@ -859,7 +859,7 @@ successors cfg = Map.unionsWith Map.union . map single
 
 between :: forall blk. GetPrevHash blk
         => SecurityParam
-        -> CodecConfig blk
+        -> BlockConfig blk
         -> StreamFrom  blk
         -> StreamTo    blk
         -> Model       blk

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
@@ -91,14 +91,14 @@ prop_alwaysPickPreferredChain bt p =
 prop_between_currentChain :: BlockTree -> Property
 prop_between_currentChain bt =
     Right (AF.toOldestFirst $ Chain.toAnchoredFragment $ M.currentChain model) ===
-    M.between secParam ccfg from to model
+    M.between secParam bcfg from to model
   where
     blocks   = treeToBlocks bt
     model    = addBlocks blocks
     from     = StreamFromExclusive GenesisPoint
     to       = StreamToInclusive $ cantBeGenesis (M.tipPoint model)
     secParam = configSecurityParam singleNodeTestConfig
-    ccfg     = configCodec         singleNodeTestConfig
+    bcfg     = configBlock         singleNodeTestConfig
 
 -- | Workaround when we know the DB can't be empty, but the types don't
 cantBeGenesis :: HasCallStack => Point blk -> RealPoint blk

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -565,7 +565,7 @@ runPure cfg = \case
     GetGCedBlockComponent pt -> err mbGCedAllComponents $ query   (Model.getBlockComponentByPoint @Identity allComponents pt)
     GetMaxSlotNo             -> ok  MaxSlot             $ query    Model.getMaxSlotNo
     GetIsValid pt            -> ok  isValidResult       $ query   (Model.isValid cfg pt)
-    Stream from to           -> err iter                $ updateE (Model.stream k ccfg from to)
+    Stream from to           -> err iter                $ updateE (Model.stream k bcfg from to)
     IteratorNext  it         -> ok  IterResult          $ update  (Model.iteratorNext @Identity it allComponents)
     IteratorNextGCed it      -> ok  iterResultGCed      $ update  (Model.iteratorNext @Identity it allComponents)
     IteratorClose it         -> ok  Unit                $ update_ (Model.iteratorClose it)
@@ -579,7 +579,7 @@ runPure cfg = \case
     WipeVolDB                -> ok  Point               $ update  (Model.wipeVolDB cfg)
   where
     k    = configSecurityParam cfg
-    ccfg = configCodec         cfg
+    bcfg = configBlock         cfg
 
     advanceAndAdd slot blk m = (Model.tipPoint m', m')
       where
@@ -1042,7 +1042,7 @@ precondition Model {..} (At cmd) =
     -- TODO #871
     isValidIterator :: StreamFrom blk -> StreamTo blk -> Logic
     isValidIterator from to =
-        case Model.between secParam (configCodec cfg) from to' dbModel of
+        case Model.between secParam (configBlock cfg) from to' dbModel of
           Left  _    -> Bot
           -- All blocks must be valid
           Right blks -> forall blks $ \blk -> Boolean $

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -9,6 +9,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
@@ -42,6 +43,12 @@ tests = testGroup "ImmutableDB"
 fixedChunkInfo :: ChunkInfo
 fixedChunkInfo = simpleChunkInfo 10
 
+testBlockConfig :: BlockConfig TestBlock
+testBlockConfig = TestBlockConfig {
+      testBlockEBBsAllowed  = chunkInfoSupportsEBBs fixedChunkInfo
+    , testBlockNumCoreNodes = NumCoreNodes 1 -- unused in this test
+    }
+
 type Hash = TestHeaderHash
 
 -- Shorthand
@@ -63,7 +70,7 @@ openTestDB registry hasFS =
       }
   where
     parser = chunkFileParser
-               TestBlockCodecConfig
+               testBlockConfig
                hasFS
                (const <$> S.decode)
                testBlockIsValid

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -282,6 +282,7 @@ csBlockConfig' dbParams = FullBlockConfig {
       blockConfigLedger = HardFork.defaultEraParams k slotLength
     , blockConfigBlock  = TestBlockConfig (NumCoreNodes 1) -- Ledger DB doesn't care
     , blockConfigCodec  = TestBlockCodecConfig
+    , blockConfigDisk   = TestBlockDiskConfig
     }
   where
     k          = ledgerDbSecurityParam dbParams

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -170,6 +170,7 @@ instance LUT 'LedgerSimple where
         blockConfigLedger = HardFork.defaultEraParams k slotLength
       , blockConfigBlock  = TestBlockConfig (NumCoreNodes 1) -- Ledger DB doesn't care
       , blockConfigCodec  = TestBlockCodecConfig
+      , blockConfigDisk   = TestBlockDiskConfig
       }
     where
       k          = ledgerDbSecurityParam dbParams

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -24,6 +24,7 @@ module Test.Ouroboros.Storage.TestBlock (
   , Header(..)
   , BlockConfig(..)
   , CodecConfig(..)
+  , DiskConfig(..)
   , EBB(..)
   , ChainLength(..)
     -- ** Construction
@@ -243,6 +244,9 @@ data instance BlockConfig TestBlock = TestBlockConfig {
   deriving (Generic, NoUnexpectedThunks)
 
 data instance CodecConfig TestBlock = TestBlockCodecConfig
+  deriving (Generic, NoUnexpectedThunks)
+
+data instance DiskConfig TestBlock = TestBlockDiskConfig
   deriving (Generic, NoUnexpectedThunks)
 
 instance Condense TestBlock where
@@ -700,6 +704,7 @@ mkTestConfig k ChunkSize { chunkCanContainEBB, numRegularBlocks } =
               , testBlockNumCoreNodes = numCoreNodes
               }
           , blockConfigCodec  = TestBlockCodecConfig
+          , blockConfigDisk   = TestBlockDiskConfig
           }
       }
   where

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -582,14 +582,14 @@ instance IsLedger (LedgerState TestBlock) where
 
 instance ApplyBlock (LedgerState TestBlock) TestBlock where
   applyLedgerBlock cfg tb@TestBlock{..} (TickedTestLedger TestLedger{..})
-    | blockPrevHash ccfg tb /= lastAppliedHash
-    = throwError $ InvalidHash lastAppliedHash (blockPrevHash ccfg tb)
+    | blockPrevHash bcfg tb /= lastAppliedHash
+    = throwError $ InvalidHash lastAppliedHash (blockPrevHash bcfg tb)
     | not $ tbIsValid testBody
     = throwError $ InvalidBlock
     | otherwise
     = return     $ TestLedger (Chain.blockPoint tb) (BlockHash (blockHash tb))
     where
-      ccfg = blockConfigCodec cfg
+      bcfg = blockConfigBlock cfg
 
   reapplyLedgerBlock _ tb _ =
     TestLedger (Chain.blockPoint tb) (BlockHash (blockHash tb))

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -42,6 +42,7 @@ import           Text.Show.Pretty (ppShow)
 import           Ouroboros.Network.Block (MaxSlotNo)
 
 import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr)
 import           Ouroboros.Consensus.Util.IOLike
 
@@ -594,7 +595,7 @@ test cmds = do
 
     let hasFS  = mkSimErrorHasFS varFs varErrors
         parser = blockFileParser'
-          TestBlockCodecConfig
+          testBlockConfig
           hasFS
           ((\blk bytes -> (takePrefix testPrefixLen bytes, blk)) <$> decode)
           testBlockIsValid
@@ -632,6 +633,13 @@ test cmds = do
 
 testMaxBlocksPerFile :: BlocksPerFile
 testMaxBlocksPerFile = mkBlocksPerFile 3
+
+-- | Values don't matter
+testBlockConfig :: BlockConfig TestBlock
+testBlockConfig = TestBlockConfig {
+      testBlockEBBsAllowed  = True
+    , testBlockNumCoreNodes = NumCoreNodes 1
+    }
 
 testPrefixLen :: PrefixLen
 testPrefixLen = PrefixLen 10


### PR DESCRIPTION
Would fix #2383.

By introducing a separate `DiskConfig` for serialising things from/to disk, instead of (ab?)using the `CodecConfig`, we can remove the `SecurityParam` from Byron's `CodecConfig`.

Unfortunately, there are some complications (as I feared): sometimes, the network en/decoder uses the disk en/decoder. This means that we'd need to produce a `DiskConfig` while we only have a `CodecConfig` in scope. Making it possible to extract a `DiskConfig` from a `CodecConfig` going against the whole reason for introducing the `DiskConfig`: removing things from `CodecConfig` that are only needed for (de)serialising things from/to disk.

To see the problematic spots, look for the `undefined`s in this PR.

Nevertheless, I'm opening this as a draft that can be used for discussion and further thinking.
