### PR TITLE
Introduce header revalidation to speed up Shelley block revalidation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -172,78 +172,78 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 736c9295f5896de28fbcedc6a8fc4d509fb78d10
-  --sha256: 1h6hfh0b1722azrd7x3shckdc6h6kpcv6r3fx6i92p2jqf9km5w5
+  tag: 9591f2d4b1915bcacd4797de563ca8a17d3b06f9
+  --sha256: 0xirm1rgawwdx2wj284hix0vfpm6w95rp315kmcwy5sd74qsynlc
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 736c9295f5896de28fbcedc6a8fc4d509fb78d10
-  --sha256: 1h6hfh0b1722azrd7x3shckdc6h6kpcv6r3fx6i92p2jqf9km5w5
+  tag: 9591f2d4b1915bcacd4797de563ca8a17d3b06f9
+  --sha256: 0xirm1rgawwdx2wj284hix0vfpm6w95rp315kmcwy5sd74qsynlc
   subdir: semantics/small-steps-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 736c9295f5896de28fbcedc6a8fc4d509fb78d10
-  --sha256: 1h6hfh0b1722azrd7x3shckdc6h6kpcv6r3fx6i92p2jqf9km5w5
+  tag: 9591f2d4b1915bcacd4797de563ca8a17d3b06f9
+  --sha256: 0xirm1rgawwdx2wj284hix0vfpm6w95rp315kmcwy5sd74qsynlc
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 736c9295f5896de28fbcedc6a8fc4d509fb78d10
-  --sha256: 1h6hfh0b1722azrd7x3shckdc6h6kpcv6r3fx6i92p2jqf9km5w5
+  tag: 9591f2d4b1915bcacd4797de563ca8a17d3b06f9
+  --sha256: 0xirm1rgawwdx2wj284hix0vfpm6w95rp315kmcwy5sd74qsynlc
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 736c9295f5896de28fbcedc6a8fc4d509fb78d10
-  --sha256: 1h6hfh0b1722azrd7x3shckdc6h6kpcv6r3fx6i92p2jqf9km5w5
+  tag: 9591f2d4b1915bcacd4797de563ca8a17d3b06f9
+  --sha256: 0xirm1rgawwdx2wj284hix0vfpm6w95rp315kmcwy5sd74qsynlc
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 736c9295f5896de28fbcedc6a8fc4d509fb78d10
-  --sha256: 1h6hfh0b1722azrd7x3shckdc6h6kpcv6r3fx6i92p2jqf9km5w5
+  tag: 9591f2d4b1915bcacd4797de563ca8a17d3b06f9
+  --sha256: 0xirm1rgawwdx2wj284hix0vfpm6w95rp315kmcwy5sd74qsynlc
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 736c9295f5896de28fbcedc6a8fc4d509fb78d10
-  --sha256: 1h6hfh0b1722azrd7x3shckdc6h6kpcv6r3fx6i92p2jqf9km5w5
+  tag: 9591f2d4b1915bcacd4797de563ca8a17d3b06f9
+  --sha256: 0xirm1rgawwdx2wj284hix0vfpm6w95rp315kmcwy5sd74qsynlc
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 736c9295f5896de28fbcedc6a8fc4d509fb78d10
-  --sha256: 1h6hfh0b1722azrd7x3shckdc6h6kpcv6r3fx6i92p2jqf9km5w5
+  tag: 9591f2d4b1915bcacd4797de563ca8a17d3b06f9
+  --sha256: 0xirm1rgawwdx2wj284hix0vfpm6w95rp315kmcwy5sd74qsynlc
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 736c9295f5896de28fbcedc6a8fc4d509fb78d10
-  --sha256: 1h6hfh0b1722azrd7x3shckdc6h6kpcv6r3fx6i92p2jqf9km5w5
+  tag: 9591f2d4b1915bcacd4797de563ca8a17d3b06f9
+  --sha256: 0xirm1rgawwdx2wj284hix0vfpm6w95rp315kmcwy5sd74qsynlc
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 736c9295f5896de28fbcedc6a8fc4d509fb78d10
-  --sha256: 1h6hfh0b1722azrd7x3shckdc6h6kpcv6r3fx6i92p2jqf9km5w5
+  tag: 9591f2d4b1915bcacd4797de563ca8a17d3b06f9
+  --sha256: 0xirm1rgawwdx2wj284hix0vfpm6w95rp315kmcwy5sd74qsynlc
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 736c9295f5896de28fbcedc6a8fc4d509fb78d10
-  --sha256: 1h6hfh0b1722azrd7x3shckdc6h6kpcv6r3fx6i92p2jqf9km5w5
+  tag: 9591f2d4b1915bcacd4797de563ca8a17d3b06f9
+  --sha256: 0xirm1rgawwdx2wj284hix0vfpm6w95rp315kmcwy5sd74qsynlc
   subdir: shelley/chain-and-ledger/shelley-spec-ledger-test
 
 source-repository-package

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -411,6 +411,15 @@ instance TPraosCrypto c => ConsensusProtocol (TPraos c) where
       shelleyGlobals = mkShelleyGlobals tpraosEpochInfo tpraosParams
       lv = getTickedPraosLedgerView (tickedPraosStateLedgerView cs)
 
+  reupdateChainDepState TPraosConfig{..} b slot cs =
+      let newCS = SL.reupdateChainDepState shelleyGlobals lv b (tickedPraosStateTicked cs)
+      in State.prune (fromIntegral k) $
+         State.append slot newCS (tickedPraosStateOrig cs)
+    where
+      SecurityParam k = tpraosSecurityParam tpraosParams
+      shelleyGlobals = mkShelleyGlobals tpraosEpochInfo tpraosParams
+      lv = getTickedPraosLedgerView (tickedPraosStateLedgerView cs)
+
   -- Rewind the chain state
   --
   -- We don't roll back to the exact slot since that slot might not have been

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -370,6 +370,18 @@ instance PraosCrypto c => ConsensusProtocol (Praos c) where
 
     return $ PraosChainDepState $ bi : praosHistory cds
 
+  reupdateChainDepState _
+                        (PraosValidateView PraosFields{..} _)
+                        slot
+                        (TickedPraosChainDepState (TickedStakeDist sd) cds) =
+    let PraosExtraFields{..} = praosExtraFields
+        !bi = BlockInfo
+            { biSlot  = slot
+            , biRho   = praosRho
+            , biStake = StakeDist sd
+            }
+    in PraosChainDepState $ bi : praosHistory cds
+
   -- Rewind the chain state
   --
   -- The mock implementation of Praos keeps the full history of the chain state

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -185,24 +185,13 @@ instance LedgerSupportsProtocol blk => ApplyBlock (ExtLedgerState blk) blk where
                (mapLedgerCfg extLedgerCfgLedger cfg)
                blk
                tickedLedgerState
-      , headerState = cantBeError $
-             validateHeader
+      , headerState =
+             revalidateHeader
                (extLedgerCfgToTopLevel cfg)
                tickedLedgerView
                (getHeader blk)
                tickedHeaderState
       }
-    where
-      cantBeError :: Show e => Except e a -> a
-      cantBeError =
-            either
-              (\e ->
-                  error $
-                    "reapplyLedgerBlock " <>
-                    show (blockPoint blk) <>
-                    ": " <> show e)
-              id
-          . runExcept
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -207,6 +207,24 @@ class ( Show (ChainDepState   p)
                       -> Ticked (ChainDepState p)
                       -> Except (ValidationErr p) (ChainDepState p)
 
+  -- | Re-apply a header to the same 'ChainDepState' we have been able to
+  -- successfully apply to before.
+  --
+  -- Since a header can only be applied to a single, specific,
+  -- 'ChainDepState', if we apply a previously applied header again it will be
+  -- applied in the very same 'ChainDepState', and therefore can't possibly
+  -- fail.
+  --
+  -- It is worth noting that since we already know that the header is valid
+  -- w.r.t. the provided 'ChainDepState', no validation checks should be
+  -- performed.
+  reupdateChainDepState :: HasCallStack
+                        => ConsensusConfig       p
+                        -> ValidateView          p
+                        -> SlotNo
+                        -> Ticked (ChainDepState p)
+                        -> ChainDepState         p
+
   -- | We require that protocols support a @k@ security parameter
   protocolSecurityParam :: ConsensusConfig p -> SecurityParam
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -159,8 +159,9 @@ instance BftCrypto c => ConsensusProtocol (Bft c) where
       expectedLeader = CoreId $ CoreNodeId (n `mod` numCoreNodes)
       NumCoreNodes numCoreNodes = bftNumNodes
 
-  tickChainDepState   _ _ _ _ = TickedTrivial
-  rewindChainDepState _ _ _ _ = Just ()
+  reupdateChainDepState _ _ _ _ = ()
+  tickChainDepState     _ _ _ _ = TickedTrivial
+  rewindChainDepState   _ _ _ _ = Just ()
 
 instance BftCrypto c => NoUnexpectedThunks (ConsensusConfig (Bft c))
   -- use generic instance

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -104,9 +104,10 @@ instance ConsensusProtocol p => ConsensusProtocol (WithLeaderSchedule p) where
             | wlsConfigNodeId `elem` nids -> Just ()
             | otherwise                   -> Nothing
 
-  tickChainDepState   _ _ _ _ = TickedTrivial
-  updateChainDepState _ _ _ _ = return ()
-  rewindChainDepState _ _ _ _ = Just ()
+  tickChainDepState     _ _ _ _ = TickedTrivial
+  updateChainDepState   _ _ _ _ = return ()
+  reupdateChainDepState _ _ _ _ = ()
+  rewindChainDepState   _ _ _ _ = Just ()
 
 instance ConsensusProtocol p
       => NoUnexpectedThunks (ConsensusConfig (WithLeaderSchedule p))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -51,6 +51,7 @@ instance (Typeable p, Typeable s, ConsensusProtocol p, ChainSelection s)
     checkIsLeader         = checkIsLeader         . mcsConfigP
     tickChainDepState     = tickChainDepState     . mcsConfigP
     updateChainDepState   = updateChainDepState   . mcsConfigP
+    reupdateChainDepState = reupdateChainDepState . mcsConfigP
     protocolSecurityParam = protocolSecurityParam . mcsConfigP
 
     rewindChainDepState _proxy = rewindChainDepState (Proxy @p)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -116,9 +116,10 @@ instance ConsensusProtocol ProtocolA where
 
   protocolSecurityParam = cfgA_k
 
-  tickChainDepState   _ _ _ _ = TickedTrivial
-  updateChainDepState _ _ _ _ = return ()
-  rewindChainDepState _ _ _ _ = Just ()
+  tickChainDepState     _ _ _ _ = TickedTrivial
+  updateChainDepState   _ _ _ _ = return ()
+  reupdateChainDepState _ _ _ _ = ()
+  rewindChainDepState   _ _ _ _ = Just ()
 
 data BlockA = BlkA {
       blkA_header :: Header BlockA

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -105,9 +105,10 @@ instance ConsensusProtocol ProtocolB where
 
   protocolSecurityParam = cfgB_k
 
-  tickChainDepState   _ _ _ _ = TickedTrivial
-  updateChainDepState _ _ _ _ = return ()
-  rewindChainDepState _ _ _ _ = Just ()
+  tickChainDepState     _ _ _ _ = TickedTrivial
+  updateChainDepState   _ _ _ _ = return ()
+  reupdateChainDepState _ _ _ _ = ()
+  rewindChainDepState   _ _ _ _ = Just ()
 
 data BlockB = BlkB {
       blkB_header :: Header BlockB

--- a/stack.yaml
+++ b/stack.yaml
@@ -52,7 +52,7 @@ extra-deps:
       - slotting
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 736c9295f5896de28fbcedc6a8fc4d509fb78d10
+    commit: 9591f2d4b1915bcacd4797de563ca8a17d3b06f9
     subdirs:
       - byron/chain/executable-spec
       - byron/ledger/executable-spec


### PR DESCRIPTION
Implements the plan described in #2520.

My block revalidation test went from 1m52s to 45s, which nicely matches the
expected speed-up: header validation took ~60% of the time.