### PR TITLE
Rename RunOrStop as ControlMessage

### DIFF
--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -15,7 +15,7 @@ module Cardano.Client.Subscription (
   , MuxTrace
   , RunMiniProtocol (..)
   , WithMuxBearer
-  , RunOrStop (..)
+  , ControlMessage (..)
   , cChainSyncCodec
   , cStateQueryCodec
   , cTxSubmissionCodec
@@ -33,7 +33,7 @@ import           Network.Mux.Trace (MuxTrace, WithMuxBearer)
 import           Ouroboros.Network.Magic (NetworkMagic)
 import           Ouroboros.Network.Mux (MuxMode (..), MuxPeer (..),
                      OuroborosApplication, RunMiniProtocol (..),
-                     RunOrStop (..))
+                     ControlMessage (..))
 import           Ouroboros.Network.NodeToClient (ClientSubscriptionParams (..),
                      ConnectionId, LocalAddress,
                      NetworkClientSubcriptionTracers,
@@ -84,7 +84,7 @@ versionedProtocols ::
   -> (   NodeToClientVersion
       -> ClientCodecs blk m
       -> ConnectionId LocalAddress
-      -> STM m RunOrStop
+      -> STM m ControlMessage
       -> NodeToClientProtocols appType bytes m a b)
      -- ^ callback which receives codecs, connection id and STM action which
      -- can be checked if the networking runtime system requests the protocols

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -135,7 +135,7 @@ data Handlers m peer blk = Handlers {
 
     , hKeepAliveClient
         :: NodeToNodeVersion
-        -> ScheduledStop m
+        -> ControlMessageSTM m
         -> peer
         -> StrictTVar m (Map peer PeerGSV)
         -> KeepAliveInterval
@@ -539,7 +539,7 @@ mkApps kernel Tracers {..} Codecs {..} genChainSyncTimeout Handlers {..} =
                          timeLimitsKeepAlive
                          channel
                          $ keepAliveClientPeer
-                         $ hKeepAliveClient version (neverStop (Proxy :: Proxy m)) them dqCtx
+                         $ hKeepAliveClient version (continueForever (Proxy :: Proxy m)) them dqCtx
                              (KeepAliveInterval 10)
 
       bracketKeepAliveClient (getFetchClientRegistry kernel) them kacApp

--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -94,7 +94,7 @@ maximumMiniProtocolLimits =
 demoProtocol0 :: RunMiniProtocol appType bytes m a b
               -> OuroborosApplication appType addr bytes m a b
 demoProtocol0 pingPong =
-    OuroborosApplication $ \_connectionId _shouldStopSTM -> [
+    OuroborosApplication $ \_connectionId _controlMessageSTM -> [
       MiniProtocol {
         miniProtocolNum    = MiniProtocolNum 2,
         miniProtocolLimits = maximumMiniProtocolLimits,
@@ -184,7 +184,7 @@ demoProtocol1 :: RunMiniProtocol appType bytes m a b
               -> RunMiniProtocol appType bytes m a b
               -> OuroborosApplication appType addr bytes m a b
 demoProtocol1 pingPong pingPong' =
-    OuroborosApplication $ \_connectionId _shouldStopSTM -> [
+    OuroborosApplication $ \_connectionId _controlMessageSTM -> [
       MiniProtocol {
         miniProtocolNum    = MiniProtocolNum 2,
         miniProtocolLimits = maximumMiniProtocolLimits,

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -268,7 +268,7 @@ connectToNode' sn handshakeCodec versionDataCodec NetworkConnectTracers {nctMuxT
              traceWith muxTracer $ Mx.MuxTraceHandshakeClientEnd (diffTime ts_end ts_start)
              Mx.muxStart
                muxTracer
-               (toApplication connectionId (neverStop (Proxy :: Proxy IO)) app)
+               (toApplication connectionId (continueForever (Proxy :: Proxy IO)) app)
                (Snocket.toBearer sn sduTimeout muxTracer sd)
 
 
@@ -385,7 +385,7 @@ beginConnection sn muxTracer handshakeTracer handshakeCodec versionDataCodec acc
                  traceWith muxTracer' $ Mx.MuxTraceHandshakeServerEnd
                  Mx.muxStart
                    muxTracer'
-                   (toApplication connectionId (neverStop (Proxy :: Proxy IO)) app)
+                   (toApplication connectionId (continueForever (Proxy :: Proxy IO)) app)
                    (Snocket.toBearer sn sduTimeout muxTracer' sd)
 
       RejectConnection st' _peerid -> pure $ Server.Reject st'

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
@@ -117,7 +117,7 @@ defaultMiniProtocolLimit = 3000000
 testProtocols2 :: RunMiniProtocol appType bytes m a b
                -> OuroborosApplication appType addr bytes m a b
 testProtocols2 reqResp =
-    OuroborosApplication $ \_connectionId _shouldStopSTM -> [
+    OuroborosApplication $ \_connectionId _controlMessageSTM -> [
       MiniProtocol {
         miniProtocolNum    = MiniProtocolNum 4,
         miniProtocolLimits = MiniProtocolLimits {
@@ -341,7 +341,7 @@ prop_socket_recv_error f rerr =
                           localAddress = Socket.addrAddress muxAddress,
                           remoteAddress
                         }
-                  Mx.muxStart nullTracer (toApplication connectionId (neverStop (Proxy :: Proxy IO)) app) bearer
+                  Mx.muxStart nullTracer (toApplication connectionId (continueForever (Proxy :: Proxy IO)) app) bearer
           )
           $ \muxAsync -> do
 

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
@@ -72,7 +72,7 @@ defaultMiniProtocolLimit = 3000000
 testProtocols1 :: RunMiniProtocol appType bytes m a b
                -> OuroborosApplication appType addr bytes m a b
 testProtocols1 chainSync =
-    OuroborosApplication $ \_connectionId _shouldStopSTM -> [
+    OuroborosApplication $ \_connectionId _controlMessageSTM -> [
        MiniProtocol {
         miniProtocolNum    = MiniProtocolNum 2,
         miniProtocolLimits = MiniProtocolLimits {
@@ -88,7 +88,7 @@ testProtocols1 chainSync =
 testProtocols2 :: RunMiniProtocol appType bytes m a b
                -> OuroborosApplication appType addr bytes m a b
 testProtocols2 reqResp =
-    OuroborosApplication $ \_connectionId _shouldStopSTM -> [
+    OuroborosApplication $ \_connectionId _controlMessageSTM -> [
        MiniProtocol {
         miniProtocolNum    = MiniProtocolNum 4,
         miniProtocolLimits = MiniProtocolLimits {

--- a/ouroboros-network/src/Ouroboros/Network/KeepAlive.hs
+++ b/ouroboros-network/src/Ouroboros/Network/KeepAlive.hs
@@ -22,7 +22,7 @@ import           Data.Maybe (fromJust)
 import qualified Data.Map.Strict as M
 import           System.Random (StdGen, random)
 
-import           Ouroboros.Network.Mux (RunOrStop (..), ScheduledStop)
+import           Ouroboros.Network.Mux (ControlMessage (..), ControlMessageSTM)
 import           Ouroboros.Network.DeltaQ
 import           Ouroboros.Network.Protocol.KeepAlive.Client
 import           Ouroboros.Network.Protocol.KeepAlive.Server
@@ -47,27 +47,29 @@ keepAliveClient
        )
     => Tracer m (TraceKeepAliveClient peer)
     -> StdGen
-    -> ScheduledStop m
+    -> ControlMessageSTM m
     -> peer
     -> (StrictTVar m (M.Map peer PeerGSV))
     -> KeepAliveInterval
     -> KeepAliveClient m ()
-keepAliveClient tracer inRng shouldStopSTM peer dqCtx KeepAliveInterval { keepAliveInterval } =
+keepAliveClient tracer inRng controlMessageSTM peer dqCtx KeepAliveInterval { keepAliveInterval } =
     let (cookie, rng) = random inRng in
     SendMsgKeepAlive (Cookie cookie) (go rng Nothing)
   where
     payloadSize = 2
 
     decisionSTM :: Lazy.TVar m Bool
-                -> STM  m RunOrStop
+                -> STM  m ControlMessage
     decisionSTM delayVar = do
-       shouldStop <- shouldStopSTM
-       case shouldStop of
-            Stop -> return Stop
-            Run  -> do
+       controlMessage <- controlMessageSTM
+       case controlMessage of
+            Terminate -> return Terminate
+
+            -- Contitnue
+            _  -> do
               done <- Lazy.readTVar delayVar
               if done
-                 then return Run
+                 then return Continue
                  else retry
 
     go :: StdGen -> Maybe Time -> m (KeepAliveClient m ())
@@ -95,10 +97,12 @@ keepAliveClient tracer inRng shouldStopSTM peer dqCtx KeepAliveInterval { keepAl
       decision <- atomically (decisionSTM delayVar)
       now <- getMonotonicTime
       case decision of
-        Run  ->
+        -- 'decisionSTM' above cannot return 'Quiesce'
+        Quiesce   -> error "keepAlive: impossible happened"
+        Continue  ->
             let (cookie, rng') = random rng in
             pure (SendMsgKeepAlive (Cookie cookie) $ go rng' $ Just now)
-        Stop -> pure (SendMsgDone (pure ()))
+        Terminate -> pure (SendMsgDone (pure ()))
 
 
 keepAliveServer

--- a/ouroboros-network/src/Ouroboros/Network/KeepAlive.hs
+++ b/ouroboros-network/src/Ouroboros/Network/KeepAlive.hs
@@ -65,7 +65,7 @@ keepAliveClient tracer inRng controlMessageSTM peer dqCtx KeepAliveInterval { ke
        case controlMessage of
             Terminate -> return Terminate
 
-            -- Contitnue
+            -- Continue
             _  -> do
               done <- Lazy.readTVar delayVar
               if done

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -161,12 +161,12 @@ data NodeToClientProtocols appType bytes m a b = NodeToClientProtocols {
 -- wireshark plugins.
 --
 nodeToClientProtocols
-  :: (ConnectionId addr -> STM m RunOrStop -> NodeToClientProtocols appType bytes m a b)
+  :: (ConnectionId addr -> STM m ControlMessage -> NodeToClientProtocols appType bytes m a b)
   -> NodeToClientVersion
   -> OuroborosApplication appType addr bytes m a b
 nodeToClientProtocols protocols version =
-    OuroborosApplication $ \connectionId shouldStopSTM ->
-      case protocols connectionId shouldStopSTM of
+    OuroborosApplication $ \connectionId controlMessageSTM ->
+      case protocols connectionId controlMessageSTM of
         NodeToClientProtocols {
             localChainSyncProtocol,
             localTxSubmissionProtocol,
@@ -215,7 +215,7 @@ nodeToClientHandshakeCodec = codecHandshake nodeToClientVersionCodec
 versionedNodeToClientProtocols
     :: NodeToClientVersion
     -> NodeToClientVersionData
-    -> (ConnectionId LocalAddress -> STM m RunOrStop -> NodeToClientProtocols appType bytes m a b)
+    -> (ConnectionId LocalAddress -> STM m ControlMessage -> NodeToClientProtocols appType bytes m a b)
     -> Versions NodeToClientVersion
                 DictVersion
                 (OuroborosApplication appType LocalAddress bytes m a b)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -220,7 +220,7 @@ defaultMiniProtocolParameters = MiniProtocolParameters {
 --
 nodeToNodeProtocols
   :: MiniProtocolParameters
-  -> (ConnectionId addr -> STM m RunOrStop -> NodeToNodeProtocols appType bytes m a b)
+  -> (ConnectionId addr -> STM m ControlMessage -> NodeToNodeProtocols appType bytes m a b)
   -> NodeToNodeVersion
   -> OuroborosApplication appType addr bytes m a b
 nodeToNodeProtocols MiniProtocolParameters {
@@ -229,8 +229,8 @@ nodeToNodeProtocols MiniProtocolParameters {
                         txSubmissionMaxUnacked
                       }
                     protocols _version =
-  OuroborosApplication $ \connectionId shouldStopSTM ->
-    case protocols connectionId shouldStopSTM of
+  OuroborosApplication $ \connectionId controlMessageSTM ->
+    case protocols connectionId controlMessageSTM of
       NodeToNodeProtocols {
           chainSyncProtocol,
           blockFetchProtocol,

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -151,7 +151,7 @@ demo chain0 updates delay = do
         activeTracer
         (Mx.toApplication
           (ConnectionId "client" "server")
-          (neverStop (Proxy :: Proxy m))
+          (continueForever (Proxy :: Proxy m))
           consumerApp)
         clientBearer
     serverAsync <- async $
@@ -159,7 +159,7 @@ demo chain0 updates delay = do
         activeTracer
         (Mx.toApplication
           (ConnectionId "server" "client")
-          (neverStop (Proxy :: Proxy m))
+          (continueForever (Proxy :: Proxy m))
           producerApp)
         serverBearer
 

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -193,7 +193,7 @@ demo chain0 updates = do
                 activeTracer
                 (toApplication
                   (ConnectionId "producer" "consumer")
-                  (neverStop (Proxy :: Proxy IO))
+                  (continueForever (Proxy :: Proxy IO))
                   producerApp)
                 clientBearer
         _ <- async $
@@ -201,7 +201,7 @@ demo chain0 updates = do
                 activeTracer
                 (toApplication
                   (ConnectionId "consumer" "producer")
-                  (neverStop (Proxy :: Proxy IO))
+                  (continueForever (Proxy :: Proxy IO))
                   consumerApp)
                 serverBearer
 


### PR DESCRIPTION
This patch is pulled out from `coot/connection-manager` branch to avoid future
merge conflicts.
