### PR TITLE
Make consensus layer compatible with GHC 8.10

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,7 +24,6 @@ packages: ./typed-protocols
 
 constraints:
   ip < 1.5,
-  graphviz == 2999.20.0.3,
   hedgehog >= 1.0,
   bimap >= 0.4.0
 

--- a/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
+++ b/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
@@ -33,7 +33,7 @@ library
                        Test.ThreadNet.Infra.Byron.TrackUpdates
                        Test.ThreadNet.TxGen.Byron
 
-  build-depends:       base              >=4.9   && <4.13
+  build-depends:       base              >=4.9   && <4.15
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class
@@ -79,7 +79,6 @@ test-suite test
                        Test.ThreadNet.RealPBFT
 
   build-depends:       base
-                     , binary
                      , binary-search
                      , bytestring
                      , cardano-binary

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/RealPBFT.hs
@@ -22,7 +22,6 @@ import qualified Data.ByteString as BS
 import           Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
-import           Data.Proxy (Proxy (..))
 import qualified Data.Set as Set
 import           Data.Word (Word64)
 

--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -47,8 +47,7 @@ library
                        Ouroboros.Consensus.Byron.Node.Serialisation
                        Ouroboros.Consensus.Byron.Protocol
 
-  build-depends:       base              >=4.9   && <4.13
-                     , binary            >=0.8   && <0.9
+  build-depends:       base              >=4.9   && <4.15
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto
@@ -61,7 +60,6 @@ library
                      , containers        >=0.5   && <0.7
                      , cryptonite        >=0.25  && <0.28
                      , formatting        >=6.3   && <6.4
-                     , memory
                      , mtl               >=2.2   && <2.3
                      , serialise         >=0.2   && <0.3
                      , text              >=1.2   && <1.3

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -40,7 +40,6 @@ import           Ouroboros.Consensus.Protocol.PBFT
 import           Ouroboros.Consensus.Byron.Crypto.DSIGN
 import           Ouroboros.Consensus.Byron.Ledger.Block
 import           Ouroboros.Consensus.Byron.Ledger.Config
-import           Ouroboros.Consensus.Byron.Ledger.Ledger
 import           Ouroboros.Consensus.Byron.Ledger.Mempool
 import           Ouroboros.Consensus.Byron.Ledger.PBFT
 import           Ouroboros.Consensus.Byron.Protocol
@@ -129,7 +128,7 @@ forgeRegularBlock
   -> [GenTx ByronBlock]                -- ^ Txs to add in the block
   -> PBftIsLeader PBftByronCrypto      -- ^ Leader proof ('IsLeader')
   -> ByronBlock
-forgeRegularBlock cfg bno sno st@TickedByronLedgerState{..} txs isLeader =
+forgeRegularBlock cfg bno sno st txs isLeader =
     forge $
       forgePBftFields
         (mkByronContextDSIGN cfg)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -44,7 +44,7 @@ import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.Serialise (decode, encode)
 import           Control.Monad.Except
 import           Data.ByteString (ByteString)
-import           Data.Type.Equality ((:~:) (Refl))
+import           Data.Kind (Type)
 import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
@@ -173,7 +173,7 @@ instance ApplyBlock (LedgerState ByronBlock) ByronBlock where
     where
       validationMode = CC.fromBlockValidationMode CC.NoBlockValidation
 
-data instance Query ByronBlock :: * -> * where
+data instance Query ByronBlock :: Type -> Type where
   GetUpdateInterfaceState :: Query ByronBlock UPI.State
 
 instance QueryLedger ByronBlock where

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
@@ -43,8 +43,6 @@ import qualified Data.ByteString as Strict
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Word (Word32)
 
-import           Codec.CBOR.Decoding (Decoder)
-import           Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as CBOR
 import           Codec.Serialise (Serialise (..))
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
@@ -198,7 +198,7 @@ instance ReconstructNestedCtxt Header ByronBlock where
         _ -> error $ "invalid ByronBlock with prefix: " <> show prefix
 
 instance EncodeDiskDepIx (NestedCtxt Header) ByronBlock where
-  encodeDiskDepIx ByronCodecConfig{..} (SomeBlock (NestedCtxt ctxt)) = mconcat [
+  encodeDiskDepIx _ccfg (SomeBlock (NestedCtxt ctxt)) = mconcat [
         CBOR.encodeListLen 2
       , case ctxt of
           CtxtByronBoundary size -> mconcat [
@@ -212,7 +212,7 @@ instance EncodeDiskDepIx (NestedCtxt Header) ByronBlock where
       ]
 
 instance EncodeDiskDep (NestedCtxt Header) ByronBlock where
-  encodeDiskDep ByronCodecConfig{..} (NestedCtxt ctxt) h =
+  encodeDiskDep _ccfg (NestedCtxt ctxt) h =
       case ctxt of
         CtxtByronRegular _size ->
           encodeByronRegularHeader h

--- a/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
+++ b/ouroboros-consensus-byronspec/ouroboros-consensus-byronspec.cabal
@@ -33,7 +33,7 @@ library
                        Ouroboros.Consensus.ByronSpec.Ledger.Orphans
                        Ouroboros.Consensus.ByronSpec.Ledger.Rules
 
-  build-depends:       base              >=4.9   && <4.13
+  build-depends:       base              >=4.9   && <4.15
                      , bimap             >=0.3   && <0.5
                      , cardano-binary
                      , cardano-ledger-test

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -33,8 +33,7 @@ library
                        Ouroboros.Consensus.Cardano.CanHardFork
                        Ouroboros.Consensus.Cardano.Node
 
-  build-depends:       base              >=4.9   && <4.13
-                     , binary            >=0.8   && <0.9
+  build-depends:       base              >=4.9   && <4.15
                      , bytestring        >=0.10  && <0.11
                      , cborg             >=0.2.2 && <0.3
                      , containers        >=0.5   && <0.7
@@ -84,8 +83,7 @@ test-suite test
                        Test.ThreadNet.TxGen.Cardano
 
   build-depends:       base
-                     , binary            >=0.8   && <0.9
-                     , bytestring        >=0.10  && <0.11
+                     , bytestring
                      , cardano-binary
                      , cardano-crypto-class
                      , cardano-crypto-wrapper
@@ -93,7 +91,7 @@ test-suite test
                      , cardano-ledger-test
                      , cardano-slotting
                      , cardano-prelude
-                     , cborg             >=0.2.2 && <0.3
+                     , cborg
                      , containers
                      , hedgehog-quickcheck
                      , mtl

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -27,6 +27,7 @@ module Ouroboros.Consensus.Cardano (
   , verifyProtocolClient
   ) where
 
+import           Data.Kind (Type)
 import           Data.Type.Equality
 
 import           Cardano.Prelude (Natural)
@@ -77,7 +78,7 @@ type ProtocolCardano        = HardForkProtocol '[ByronBlock, ShelleyBlock TPraos
 -------------------------------------------------------------------------------}
 
 -- | Consensus protocol to use
-data Protocol (m :: * -> *) blk p where
+data Protocol (m :: Type -> Type) blk p where
   -- | Run PBFT against the real Byron ledger
   ProtocolByron
     :: Genesis.Config

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -42,7 +42,7 @@ import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.HardFork.Combinator
 import           Ouroboros.Consensus.HardFork.Combinator.State.Types
 import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
-                     (InPairs (..), RequiringBoth (..))
+                     (RequiringBoth (..))
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
 

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -65,8 +65,6 @@ import qualified Ouroboros.Consensus.Byron.Ledger.Conversions as Byron
 import           Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
 import           Ouroboros.Consensus.Byron.Node
 
-import           Shelley.Spec.Ledger.BaseTypes (Nonce (..))
-
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
 import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/ByronCompatibility.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/ByronCompatibility.hs
@@ -16,7 +16,6 @@ import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Coerce (Coercible, coerce)
-import           Data.Proxy (Proxy (..))
 import           Data.SOP.BasicFunctors
 
 import           Cardano.Crypto.Hash (ShortHash)
@@ -34,8 +33,7 @@ import           Ouroboros.Consensus.Node.Serialisation
 import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
 import           Ouroboros.Consensus.TypeFamilyWrappers
 
-import           Ouroboros.Consensus.HardFork.Combinator (NestedCtxt_ (..),
-                     Query (..))
+import           Ouroboros.Consensus.HardFork.Combinator (NestedCtxt_ (..))
 
 import           Ouroboros.Consensus.Byron.Ledger
 import           Ouroboros.Consensus.Byron.Node ()

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Examples.hs
@@ -22,7 +22,6 @@ module Test.Consensus.Cardano.Examples (
   ) where
 
 import           Data.Bifunctor (first)
-import           Data.Proxy (Proxy (..))
 import           Data.SOP.Strict
 
 import           Ouroboros.Network.Block (Serialised (..))

--- a/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Serialisation.hs
+++ b/ouroboros-consensus-cardano/test/Test/Consensus/Cardano/Serialisation.hs
@@ -9,13 +9,11 @@ module Test.Consensus.Cardano.Serialisation (tests) where
 import           Cardano.Crypto.Hash (ShortHash)
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString.Lazy as Lazy
-import           Data.Proxy (Proxy (..))
 
 import           Ouroboros.Network.Block (Serialised (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
-import           Ouroboros.Consensus.Storage.ImmutableDB (BinaryBlockInfo (..))
 import           Ouroboros.Consensus.Util (Dict (..))
 
 import           Ouroboros.Consensus.HardFork.Combinator (NestedCtxt_ (..))

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -16,7 +16,6 @@ import           Control.Monad (guard, replicateM)
 import           Control.Monad.Identity (runIdentity)
 import           Control.Monad.Reader (runReaderT)
 import           Data.Functor ((<&>))
-import           Data.List ((!!))
 import qualified Data.Map as Map
 import           Data.Maybe (isJust, maybeToList)
 import           Data.Proxy (Proxy (..))

--- a/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
@@ -18,12 +18,8 @@ import           Control.Monad.Except
 import           Data.IORef
 import           Data.List (intercalate)
 import qualified Data.Map.Strict as Map
-import           Data.Proxy (Proxy (..))
 
 import           Cardano.Slotting.Slot
-
-import           Ouroboros.Network.Block (HasHeader (..), HeaderHash,
-                     genesisPoint)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -215,7 +211,7 @@ processAllChainDB chainDB rr callback = do
       Origin -> return ()
       At tip -> do
         Right itr <- ChainDB.stream chainDB rr GetBlock
-          (StreamFromExclusive genesisPoint)
+          (StreamFromExclusive GenesisPoint)
           (StreamToInclusive tip)
         go itr
   where
@@ -238,7 +234,7 @@ processAllImmDB immDB rr callback = do
       Origin -> return ()
       At tip -> do
         Right itr <- ImmDB.stream immDB rr GetBlock
-          (StreamFromExclusive genesisPoint)
+          (StreamFromExclusive GenesisPoint)
           (StreamToInclusive tip)
         go itr
   where

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
@@ -99,8 +99,7 @@ aBlockOrBoundary fromBoundary fromRegular blk = case blk of
 countTxOutputsByron :: Chain.ABlock ByteString -> Int
 countTxOutputsByron Chain.ABlock{..} = countTxPayload bodyTxPayload
   where
-    Chain.AHeader{..} = blockHeader
-    Chain.ABody{..}   = blockBody
+    Chain.ABody { bodyTxPayload } = blockBody
 
     countTxPayload :: Chain.ATxPayload a -> Int
     countTxPayload = sum

--- a/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
@@ -31,7 +31,7 @@ import qualified Ouroboros.Consensus.Storage.VolatileDB.Types as VolDB
 
 import           Analysis
 import           Block.Byron (ByronBlockArgs)
-import           Block.Cardano (Args (..), CardanoBlockArgs)
+import           Block.Cardano (CardanoBlockArgs)
 import           Block.Shelley (ShelleyBlockArgs)
 import           HasAnalysis
 

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -27,8 +27,7 @@ library
                        Test.ThreadNet.Infra.Shelley
                        Test.ThreadNet.TxGen.Shelley
 
-  build-depends:       base              >=4.9   && <4.13
-                     , binary            >=0.8   && <0.9
+  build-depends:       base              >=4.9   && <4.15
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class
@@ -75,13 +74,12 @@ test-suite test
                        Test.ThreadNet.RealTPraos
 
   build-depends:       base
-                     , binary
                      , bytestring
                      , cardano-binary
                      , cardano-crypto-class
                      , cardano-prelude
                      , cardano-slotting
-                     , cborg             >=0.2.2 && <0.3
+                     , cborg
                      , containers
                      , QuickCheck
                      , time

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -33,7 +33,6 @@ import           Data.Coerce (coerce)
 import           Data.Functor.Identity (Identity (..))
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromJust)
-import           Data.Proxy (Proxy (..))
 import           Data.Ratio ((%))
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -4,9 +4,7 @@
 module Test.ThreadNet.RealTPraos (tests) where
 
 import           Control.Monad (replicateM)
-import           Data.List ((!!))
 import qualified Data.Map.Strict as Map
-import           Data.Proxy (Proxy (..))
 import           Data.Word (Word64)
 
 import           Test.QuickCheck

--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -44,8 +44,7 @@ library
                        Ouroboros.Consensus.Shelley.Protocol.HotKey
                        Ouroboros.Consensus.Shelley.Protocol.Util
 
-  build-depends:       base              >=4.9   && <4.13
-                     , binary            >=0.8   && <0.9
+  build-depends:       base              >=4.9   && <4.15
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -39,7 +39,6 @@ import           Codec.Serialise (Serialise (..))
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Coerce (coerce)
 import           Data.FingerTree.Strict (Measured (..))
-import           Data.Proxy (Proxy (..))
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -55,7 +55,7 @@ import           Data.Kind (Type)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
-import           Data.Type.Equality ((:~:) (Refl), apply)
+import           Data.Type.Equality (apply)
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -340,7 +340,7 @@ instance TPraosCrypto c => ConsensusProtocol (TPraos c) where
 
   protocolSecurityParam = tpraosSecurityParam . tpraosParams
 
-  checkIsLeader cfg@TPraosConfig{..} TPraosCanBeLeader{..} slot cs = do
+  checkIsLeader cfg TPraosCanBeLeader{..} slot cs = do
       -- First, check whether we're in the overlay schedule
       case SL.lookupInOverlaySchedule slot (SL.lvOverlaySched lv) of
         -- Slot isn't in the overlay schedule, so we're in Praos

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/HotKey.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/HotKey.hs
@@ -30,9 +30,7 @@ import           GHC.Stack (HasCallStack)
 
 import           Cardano.Crypto.KES.Class hiding (forgetSignKeyKES)
 import qualified Cardano.Crypto.KES.Class as Relative (Period)
-import           Cardano.Prelude (NoUnexpectedThunks (..))
 
-import           Shelley.Spec.Ledger.Crypto (Crypto (..))
 import qualified Shelley.Spec.Ledger.OCert as Absolute (KESPeriod (..))
 
 import           Ouroboros.Consensus.Block (UpdateInfo (..))

--- a/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-mock/ouroboros-consensus-mock.cabal
@@ -41,9 +41,8 @@ library
                        Ouroboros.Consensus.Mock.Node.Serialisation
                        Ouroboros.Consensus.Mock.Protocol.Praos
 
-  build-depends:       base              >=4.9   && <4.13
+  build-depends:       base              >=4.9   && <4.15
                      , bimap             >=0.3   && <0.5
-                     , binary            >=0.8   && <0.9
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -68,6 +68,7 @@ import           Codec.Serialise (Serialise (..), serialise)
 import           Control.Monad.Except
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.FingerTree.Strict (Measured (..))
+import           Data.Kind (Type)
 import           Data.Proxy
 import           Data.Typeable
 import           Data.Word
@@ -90,7 +91,6 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Mock.Ledger.Address
 import           Ouroboros.Consensus.Mock.Ledger.State
 import qualified Ouroboros.Consensus.Mock.Ledger.UTxO as Mock
-import           Ouroboros.Consensus.Protocol.Abstract (SecurityParam)
 import           Ouroboros.Consensus.Util (ShowProxy (..), hashFromBytesShortE,
                      (.:))
 import           Ouroboros.Consensus.Util.Condense
@@ -310,7 +310,7 @@ class ( SimpleCrypto c
       , Show               (MockLedgerConfig c ext)
       , NoUnexpectedThunks (MockLedgerConfig c ext)
       ) => MockProtocolSpecific c ext where
-  type family MockLedgerConfig c ext :: *
+  type family MockLedgerConfig c ext :: Type
 
 {-------------------------------------------------------------------------------
   Update the ledger
@@ -496,7 +496,7 @@ instance InspectLedger (SimpleBlock c ext) where
 -------------------------------------------------------------------------------}
 
 class (HashAlgorithm (SimpleHash c), Typeable c) => SimpleCrypto c where
-  type family SimpleHash c :: *
+  type family SimpleHash c :: Type
 
 data SimpleStandardCrypto
 data SimpleMockCrypto

--- a/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -47,9 +47,9 @@ import           Codec.Serialise (Serialise (..))
 import           Control.Monad (unless)
 import           Control.Monad.Except (throwError)
 import           Control.Monad.Identity (runIdentity)
+import           Data.Kind (Type)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Proxy (Proxy (..))
 import           Data.Typeable
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
@@ -447,8 +447,6 @@ infosStake s@PraosConfig{..} xs e = case ys of
     []                  -> praosInitialStake
     (BlockInfo{..} : _) -> biStake
   where
-    PraosParams{..} = praosParams
-
     e' = if e >= 2 then EpochNo (unEpochNo e - 2) else 0
     ys = dropWhile (\b -> blockInfoEpoch s b > e') xs
 
@@ -497,10 +495,10 @@ class ( KESAlgorithm  (PraosKES  c)
       , Cardano.Crypto.VRF.Class.Signable (PraosVRF c) (Natural, SlotNo, VRFType)
       , ContextKES (PraosKES c) ~ ()
       , ContextVRF (PraosVRF c) ~ ()
-      ) => PraosCrypto (c :: *) where
-  type family PraosKES  c :: *
-  type family PraosVRF  c :: *
-  type family PraosHash c :: *
+      ) => PraosCrypto (c :: Type) where
+  type family PraosKES  c :: Type
+  type family PraosVRF  c :: Type
+  type family PraosHash c :: Type
 
 data PraosStandardCrypto
 data PraosMockCrypto

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/BFT.hs
@@ -7,8 +7,6 @@ module Test.ThreadNet.BFT (
     tests
   ) where
 
-import           Data.Proxy (Proxy (..))
-
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/LeaderSchedule.hs
@@ -9,7 +9,6 @@ module Test.ThreadNet.LeaderSchedule (
 import           Control.Monad (replicateM)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Proxy (Proxy (..))
 
 import           Test.QuickCheck
 import           Test.Tasty

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/PBFT.hs
@@ -7,7 +7,6 @@ module Test.ThreadNet.PBFT (
   ) where
 
 import qualified Data.Map.Strict as Map
-import           Data.Proxy (Proxy (..))
 import qualified Data.Set as Set
 
 import           Test.QuickCheck

--- a/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus/ouroboros-consensus-mock/test/Test/ThreadNet/Praos.hs
@@ -5,7 +5,6 @@ module Test.ThreadNet.Praos (
     tests
   ) where
 
-import           Data.Proxy (Proxy (..))
 import           Data.Word (Word64)
 import           Numeric.Natural (Natural)
 

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/ouroboros-consensus-test-infra.cabal
@@ -74,9 +74,8 @@ library
                        Test.Util.Tracer
                        Test.Util.WithEq
 
-  build-depends:       base              >=4.9 && <4.13
+  build-depends:       base              >=4.9 && <4.15
                      , base16-bytestring
-                     , binary            >=0.8   && <0.9
                      , bytestring        >=0.10  && <0.11
                      , cardano-crypto-class
                      , cardano-prelude

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Network.hs
@@ -48,7 +48,6 @@ import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
-import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Typeable as Typeable
@@ -76,8 +75,6 @@ import qualified Ouroboros.Network.TxSubmission.Outbound as TxOutbound
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
-import           Ouroboros.Consensus.BlockchainTime.WallClock.HardFork
-                     (hardForkBlockchainTime)
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
 import           Ouroboros.Consensus.Ledger.Abstract

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Ref/PBFT.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/ThreadNet/Ref/PBFT.hs
@@ -27,7 +27,7 @@ module Test.ThreadNet.Ref.PBFT (
 import           Control.Applicative ((<|>))
 import           Control.Arrow ((&&&))
 import           Control.Monad (guard)
-import           Data.Foldable (Foldable, foldl', toList)
+import           Data.Foldable (foldl', toList)
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Sequence (Seq)

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/BoolProps.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/BoolProps.hs
@@ -14,6 +14,7 @@ module Test.Util.BoolProps (
   requiredIf,
   ) where
 
+import           Data.Kind (Type)
 import           GHC.Generics
 
 {-------------------------------------------------------------------------------
@@ -94,7 +95,7 @@ checkReqs x
 -------------------------------------------------------------------------------}
 
 class GCollectReqs rep where
-  gCollectReqs :: rep (x :: *) -> ([Prereq], [Requirement])
+  gCollectReqs :: rep (x :: Type) -> ([Prereq], [Requirement])
 
 instance GCollectReqs U1 where
   gCollectReqs U1 = mempty

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/LogicalClock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/LogicalClock.hs
@@ -21,7 +21,6 @@ module Test.Util.LogicalClock (
   , blockUntilTick
   ) where
 
-import           Control.Exception (Exception)
 import           Control.Monad
 import           Data.Time (NominalDiffTime)
 import           Data.Word

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/IOLike.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Orphans/IOLike.hs
@@ -2,7 +2,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Test.Util.Orphans.IOLike () where
 
-import           Control.Monad.Class.MonadSTM (lengthTBQueueDefault)
 import           Control.Monad.IOSim
 import           Ouroboros.Consensus.Util.IOLike
 import           Test.Util.Orphans.NoUnexpectedThunks ()

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/QSM.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/QSM.hs
@@ -8,7 +8,7 @@ module Test.Util.QSM (
   ) where
 
 import           Control.Monad
-import           Control.Monad.Fail
+import qualified Control.Monad.Fail as Fail
 import           Data.Typeable
 
 import qualified Test.StateMachine.Logic as Logic
@@ -34,7 +34,7 @@ instance Monad (Example cmd) where
   Run c k  >>= f = Run c (k >=> f)
   Fail err >>= _ = Fail err
 
-instance MonadFail (Example cmd) where
+instance Fail.MonadFail (Example cmd) where
   fail = Fail
 
 -- | Run a command, and capture its references

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/Serialisation/Roundtrip.hs
@@ -34,7 +34,6 @@ import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.ByteString.Lazy.Char8 as Char8
 import qualified Data.ByteString.Short as Short
 import           Data.Function (on)
-import           Data.Proxy (Proxy (..))
 import           Data.Typeable
 
 import           Ouroboros.Network.Block (Serialised (..), fromSerialised,

--- a/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus/ouroboros-consensus-test-infra/src/Test/Util/TestBlock.hs
@@ -67,7 +67,6 @@ import           Data.Proxy
 import           Data.Tree (Tree (..))
 import qualified Data.Tree as Tree
 import           Data.TreeDiff (ToExpr)
-import           Data.Type.Equality ((:~:) (Refl))
 import           Data.Word
 import           GHC.Generics (Generic)
 import qualified System.Random as R
@@ -76,7 +75,7 @@ import           Test.QuickCheck hiding (Result)
 import           Cardano.Crypto.DSIGN
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.MockChain.Chain (Chain (..), Point)
+import           Ouroboros.Network.MockChain.Chain (Chain (..))
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
 import           Ouroboros.Consensus.Block hiding (hashSize)

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -266,11 +266,11 @@ library
                        UndecidableSuperClasses
                        ViewPatterns
 
-  build-depends:       base              >=4.9 && <4.13
+  build-depends:       base              >=4.9 && <4.15
                      , base16-bytestring
                      , bifunctors
                      , bimap             >=0.3   && <0.5
-                     , binary            >=0.8   && <0.9
+                     , binary            >=0.8   && <0.11
                      , bytestring        >=0.10  && <0.11
                      , cardano-binary
                      , cardano-crypto-class
@@ -284,11 +284,8 @@ library
                      , directory         >=1.3   && <1.4
                      , filelock
                      , filepath          >=1.4   && <1.5
-                     , formatting        >=6.3   && <6.4
                      , hashable
-                     , mmorph            >=1.1   && <1.2
                      , mtl               >=2.2   && <2.3
-                     , network           >=3.1   && <3.2
                      , psqueues          >=0.2.3 && <0.3
                      , random
                      , quiet             >=0.2   && <0.3

--- a/ouroboros-consensus/src-unix/Ouroboros/Consensus/Storage/IO.hs
+++ b/ouroboros-consensus/src-unix/Ouroboros/Consensus/Storage/IO.hs
@@ -17,7 +17,7 @@ import           Prelude hiding (read, truncate)
 
 import           Control.Monad (void)
 import           Data.ByteString (ByteString)
-import           Data.ByteString.Internal as Internal
+import qualified Data.ByteString.Internal as Internal
 import           Data.Int (Int64)
 import           Data.Word (Word32, Word64, Word8)
 import           Foreign (Ptr)

--- a/ouroboros-consensus/src/Data/SOP/Strict.hs
+++ b/ouroboros-consensus/src/Data/SOP/Strict.hs
@@ -36,6 +36,7 @@ module Data.SOP.Strict (
   ) where
 
 import           Data.Coerce
+import           Data.Kind (Type)
 
 import           Data.SOP hiding (Injection, NP (..), NS (..), hd, injections,
                      shiftInjection, tl, unZ)
@@ -49,7 +50,7 @@ import           Cardano.Prelude (NoUnexpectedThunks (..), ThunkInfo (..),
   NP
 -------------------------------------------------------------------------------}
 
-data NP :: (k -> *) -> [k] -> * where
+data NP :: (k -> Type) -> [k] -> Type where
   Nil  :: NP f '[]
   (:*) :: !(f x) -> !(NP f xs) -> NP f (x ': xs)
 
@@ -136,7 +137,7 @@ instance HTraverse_ NP where
   NS
 -------------------------------------------------------------------------------}
 
-data NS :: (k -> *) -> [k] -> * where
+data NS :: (k -> Type) -> [k] -> Type where
   Z :: !(f x) -> NS f (x ': xs)
   S :: !(NS f xs) -> NS f (x ': xs)
 
@@ -233,7 +234,7 @@ instance HTrans NS NS where
   Injections
 -------------------------------------------------------------------------------}
 
-type Injection (f :: k -> *) (xs :: [k]) = f -.-> K (NS f xs)
+type Injection (f :: k -> Type) (xs :: [k]) = f -.-> K (NS f xs)
 
 injections :: forall xs f. SListI xs => NP (Injection f xs) xs
 injections = go sList
@@ -271,14 +272,14 @@ deriving instance (All (Eq `Compose` f) xs, All (Ord `Compose` f) xs) => Ord (NP
 -------------------------------------------------------------------------------}
 
 instance All (Compose NoUnexpectedThunks f) xs
-      => NoUnexpectedThunks (NS (f :: k -> *) (xs :: [k])) where
+      => NoUnexpectedThunks (NS (f :: k -> Type) (xs :: [k])) where
   showTypeOf _ = "NS"
   whnfNoUnexpectedThunks ctxt = \case
       Z l -> noUnexpectedThunks ("Z" : ctxt) l
       S r -> noUnexpectedThunks ("S" : ctxt) r
 
 instance All (Compose NoUnexpectedThunks f) xs
-      => NoUnexpectedThunks (NP (f :: k -> *) (xs :: [k])) where
+      => NoUnexpectedThunks (NP (f :: k -> Type) (xs :: [k])) where
   showTypeOf _ = "NP"
   whnfNoUnexpectedThunks ctxt = \case
       Nil     -> return NoUnexpectedThunks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -66,6 +66,7 @@ import qualified Data.ByteString as Strict
 import           Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as Short
 import           Data.FingerTree.Strict (Measured (..))
+import           Data.Kind (Type)
 import           Data.Maybe (isJust)
 import           Data.Word (Word32)
 
@@ -89,20 +90,20 @@ import           Ouroboros.Consensus.Block.EBB
 -------------------------------------------------------------------------------}
 
 -- | Map block to consensus protocol
-type family BlockProtocol blk :: *
+type family BlockProtocol blk :: Type
 
 {-------------------------------------------------------------------------------
   Configuration
 -------------------------------------------------------------------------------}
 
 -- | Static configuration required to work with this type of blocks
-data family BlockConfig blk :: *
+data family BlockConfig blk :: Type
 
 -- | Static configuration required for serialisation and deserialisation of
 -- types pertaining to this type of block.
 --
 -- Data family instead of type family to get better type inference.
-data family CodecConfig blk :: *
+data family CodecConfig blk :: Type
 
 {-------------------------------------------------------------------------------
   Get hash of previous block
@@ -123,7 +124,7 @@ blockPrevHash cfg = castHash . headerPrevHash cfg . getHeader
   Link block to its header
 -------------------------------------------------------------------------------}
 
-data family Header blk :: *
+data family Header blk :: Type
 
 class HasHeader (Header blk) => GetHeader blk where
   getHeader          :: blk -> Header blk
@@ -240,7 +241,7 @@ decodeRawHash p = fromShortRawHash p <$> Serialise.decode
 --
 -- @SomeBlock f blk@ is isomorphic to @Some (f blk)@, but is more convenient
 -- in partial applications.
-data SomeBlock (f :: * -> * -> *) blk where
+data SomeBlock (f :: Type -> Type -> Type) blk where
   SomeBlock :: f blk a -> SomeBlock f blk
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forging.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forging.hs
@@ -23,6 +23,7 @@ module Ouroboros.Consensus.Block.Forging (
   ) where
 
 import           Control.Tracer (Tracer, traceWith)
+import           Data.Kind (Type)
 import           GHC.Stack
 
 import           Ouroboros.Consensus.Block.Abstract
@@ -36,15 +37,15 @@ import           Ouroboros.Consensus.Ticked
 --
 -- This should happen only rarely. An example might be that our hot key
 -- does not (yet/anymore) match the delegation state.
-type family CannotForge blk :: *
+type family CannotForge blk :: Type
 
 -- | Returned when a call to 'updateForgeState' succeeded and caused the forge
 -- state to change. This info is traced.
-type family ForgeStateInfo blk :: *
+type family ForgeStateInfo blk :: Type
 
 -- | Returned when a call 'updateForgeState' failed, e.g., because the KES key
 -- is no longer valid. This info is traced.
-type family ForgeStateUpdateError blk :: *
+type family ForgeStateUpdateError blk :: Type
 
 -- | The result of 'updateForgeState'.
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/NestedContent.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/NestedContent.hs
@@ -26,6 +26,7 @@ module Ouroboros.Consensus.Block.NestedContent (
   , module Ouroboros.Consensus.Util.DepPair
   ) where
 
+import           Data.Kind (Type)
 import           Data.Maybe (isJust)
 import           Data.Proxy
 import           Data.Type.Equality
@@ -94,7 +95,7 @@ curriedNest ctxt a = nest (DepPair ctxt a)
 -- | Context identifying what kind of block we have
 --
 -- In almost all places we will use 'NestedCtxt' rather than 'NestedCtxt_'.
-data family NestedCtxt_ blk :: (* -> *) -> (* -> *)
+data family NestedCtxt_ blk :: (Type -> Type) -> (Type -> Type)
 
 {-------------------------------------------------------------------------------
   Flip arguments

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/API.hs
@@ -15,7 +15,7 @@ module Ouroboros.Consensus.BlockchainTime.API (
 import           GHC.Generics (Generic)
 import           GHC.Stack
 
-import           Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
+import           Cardano.Prelude (OnlyCheckIsWHNF (..))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Abstract.hs
@@ -7,6 +7,8 @@ module Ouroboros.Consensus.HardFork.Abstract (
   , neverForksHardForkSummary
   ) where
 
+import           Data.Kind (Type)
+
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Ledger.Abstract
 
@@ -19,7 +21,7 @@ class HasHardForkHistory blk where
   -- in the hard fork, e.g., we might have something like
   --
   -- > '[ByronBlock, ShelleyBlock, GoguenBlock]
-  type family HardForkIndices blk :: [*]
+  type family HardForkIndices blk :: [Type]
 
   -- | Summary of the hard fork state
   --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/NoHardForks.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/NoHardForks.hs
@@ -7,7 +7,6 @@ import           Cardano.Slotting.EpochInfo
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
-import           Ouroboros.Consensus.HardFork.History (EraParams)
 import           Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Protocol.Abstract

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -22,7 +22,6 @@ module Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock (
 import           Codec.Serialise
 import           Data.Either (isRight)
 import           Data.Proxy
-import           Data.SOP.BasicFunctors (K (..))
 import           Data.SOP.Strict
 import qualified Data.Text as Text
 import           Data.Void

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -36,6 +36,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Basics (
   ) where
 
 import           Data.Functor.Identity
+import           Data.Kind (Type)
 import           Data.SOP.Strict
 import           Data.Typeable
 import           GHC.Generics (Generic)
@@ -62,7 +63,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.State.Types
   Hard fork protocol, block, and ledger state
 -------------------------------------------------------------------------------}
 
-data HardForkProtocol (xs :: [*])
+data HardForkProtocol (xs :: [Type])
 
 newtype HardForkBlock xs = HardForkBlock {
       getHardForkBlock :: OneEraBlock xs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -24,6 +24,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Block (
 import           Data.FingerTree.Strict (Measured (..))
 import           Data.Function (on)
 import           Data.Functor.Product
+import           Data.Kind (Type)
 import           Data.SOP.Strict
 import           Data.Typeable (Typeable)
 import           Data.Word
@@ -123,7 +124,7 @@ instance CanHardFork xs => GetPrevHash (HardForkBlock xs) where
   NestedContent
 -------------------------------------------------------------------------------}
 
-data instance NestedCtxt_ (HardForkBlock xs) :: (* -> *) -> (* -> *) where
+data instance NestedCtxt_ (HardForkBlock xs) :: (Type -> Type) -> (Type -> Type) where
     NCZ :: NestedCtxt_ x                  f a -> NestedCtxt_ (HardForkBlock (x ': xs)) f a
     NCS :: NestedCtxt_ (HardForkBlock xs) f a -> NestedCtxt_ (HardForkBlock (x ': xs)) f a
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Compat.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Compat.hs
@@ -17,6 +17,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Compat (
   , singleEraCompatQuery
   ) where
 
+import           Data.Kind (Type)
 import           Data.SOP.Strict
 
 import           Ouroboros.Consensus.Block
@@ -38,7 +39,7 @@ import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 
 -- | Version of @Query (HardForkBlock xs)@ without the restriction to have
 -- at least two eras
-data HardForkCompatQuery blk :: * -> * where
+data HardForkCompatQuery blk :: Type -> Type where
   CompatIfCurrent ::
        Query blk result
     -> HardForkCompatQuery blk result

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -37,6 +37,7 @@ import           Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as Enc
 import           Codec.Serialise (Serialise (..))
 import           Data.Bifunctor
+import           Data.Kind (Type)
 import           Data.Proxy
 import           Data.SOP.Strict
 import           Data.Type.Equality
@@ -77,7 +78,7 @@ instance All SingleEraBlock xs => ShowQuery (Query (HardForkBlock xs)) where
 
 type HardForkQueryResult xs = Either (MismatchEraInfo xs)
 
-data instance Query (HardForkBlock xs) :: * -> * where
+data instance Query (HardForkBlock xs) :: Type -> Type where
   -- | Answer a query about an era if it is the current one.
   QueryIfCurrent ::
        QueryIfCurrent xs result
@@ -173,7 +174,7 @@ getHardForkQuery q k1 k2 k3 = case q of
   Current era queries
 -------------------------------------------------------------------------------}
 
-data QueryIfCurrent :: [*] -> * -> * where
+data QueryIfCurrent :: [Type] -> Type -> Type where
   QZ :: Query x result           -> QueryIfCurrent (x ': xs) result
   QS :: QueryIfCurrent xs result -> QueryIfCurrent (x ': xs) result
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/PartialConfig.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/PartialConfig.hs
@@ -17,6 +17,7 @@ module Ouroboros.Consensus.HardFork.Combinator.PartialConfig (
   ) where
 
 import           Data.Functor.Identity
+import           Data.Kind (Type)
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 import           Cardano.Slotting.EpochInfo
@@ -29,7 +30,7 @@ import           Ouroboros.Consensus.Protocol.Abstract
 class ( ConsensusProtocol p
       , NoUnexpectedThunks (PartialConsensusConfig p)
       ) => HasPartialConsensusConfig p where
-  type PartialConsensusConfig p :: *
+  type PartialConsensusConfig p :: Type
   type PartialConsensusConfig p = ConsensusConfig p
 
   -- | Construct 'ConsensusConfig' from 'PartialConsensusConfig'
@@ -59,7 +60,7 @@ class ( ConsensusProtocol p
 class ( UpdateLedger blk
       , NoUnexpectedThunks (PartialLedgerConfig blk)
       ) => HasPartialLedgerConfig blk where
-  type PartialLedgerConfig blk :: *
+  type PartialLedgerConfig blk :: Type
   type PartialLedgerConfig blk = LedgerConfig blk
 
   -- | Construct 'LedgerConfig' from 'PartialLedgerCfg'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
@@ -14,6 +14,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel (
   , mapWithBlockNo
   ) where
 
+import           Data.Kind (Type)
 import           Data.SOP.Strict
 
 import           Ouroboros.Consensus.Block
@@ -28,7 +29,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Util.Tails (Tails (..))
   Configuration
 -------------------------------------------------------------------------------}
 
-data AcrossEraSelection :: * -> * -> * where
+data AcrossEraSelection :: Type -> Type -> Type where
   -- | Just compare block numbers
   --
   -- This is a useful default when two eras run totally different consensus
@@ -144,7 +145,7 @@ acrossEraSelection = \cfgs ffs l r ->
   WithBlockNo
 -------------------------------------------------------------------------------}
 
-data WithBlockNo (f :: k -> *) (a :: k) = WithBlockNo {
+data WithBlockNo (f :: k -> Type) (a :: k) = WithBlockNo {
       getBlockNo  :: BlockNo
     , dropBlockNo :: f a
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -76,6 +76,7 @@ import           Control.Exception (throw)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as Short
+import           Data.Kind (Type)
 import           Data.SOP.Strict
 import           Data.Word
 
@@ -104,10 +105,10 @@ import           Ouroboros.Consensus.Util.SOP
   Distinguish between the first era and all others
 -------------------------------------------------------------------------------}
 
-type family FirstEra (xs :: [*]) where
+type family FirstEra (xs :: [Type]) where
   FirstEra (x ': xs) = x
 
-type family LaterEra (xs :: [*]) where
+type family LaterEra (xs :: [Type]) where
   LaterEra (x ': xs) = xs
 
 isFirstEra :: forall f xs. All SingleEraBlock xs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Unary.hs
@@ -37,6 +37,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Unary (
 
 import           Data.Bifunctor (first)
 import           Data.Coerce
+import           Data.Kind (Type)
 import           Data.Proxy
 import           Data.SOP.Strict
 import           Data.Type.Equality
@@ -621,7 +622,7 @@ projQuery' :: Query (HardForkBlock '[b]) result
            -> ProjHardForkQuery b result
 projQuery' qry = projQuery qry $ \Refl -> ProjHardForkQuery
 
-data ProjHardForkQuery b :: * -> * where
+data ProjHardForkQuery b :: Type -> Type where
   ProjHardForkQuery ::
        Query b result'
     -> ProjHardForkQuery b (HardForkQueryResult '[b] result')

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/InPairs.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/InPairs.hs
@@ -33,6 +33,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Util.InPairs (
   , requiringBoth
   ) where
 
+import           Data.Kind (Type)
 import           Data.SOP.Strict hiding (hcmap, hcpure, hmap, hpure)
 
 import           Ouroboros.Consensus.Util.SOP
@@ -42,7 +43,7 @@ import           Ouroboros.Consensus.Util.SOP
 -------------------------------------------------------------------------------}
 
 -- | We have an @f x y@ for each pair @(x, y)@ of successive list elements
-data InPairs (f :: k -> k -> *) (xs :: [k]) where
+data InPairs (f :: k -> k -> Type) (xs :: [k]) where
   PNil  :: InPairs f '[x]
   PCons :: f x y -> InPairs f (y ': zs) -> InPairs f (x ': y ': zs)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Match.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Match.hs
@@ -38,6 +38,7 @@ import           Prelude hiding (flip)
 
 import           Data.Bifunctor
 import           Data.Functor.Product
+import           Data.Kind (Type)
 import           Data.SOP.Strict
 import           Data.Void
 
@@ -54,7 +55,7 @@ import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Teles
   Main API
 -------------------------------------------------------------------------------}
 
-data Mismatch :: (k -> *) -> (k -> *) -> [k] -> * where
+data Mismatch :: (k -> Type) -> (k -> Type) -> [k] -> Type where
   ML :: f x -> NS g xs -> Mismatch f g (x ': xs)
   MR :: NS f xs -> g x -> Mismatch f g (x ': xs)
   MS :: Mismatch f g xs -> Mismatch f g (x ': xs)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Tails.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Tails.hs
@@ -23,6 +23,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Util.Tails (
   , hcpure
   ) where
 
+import           Data.Kind (Type)
 import           Data.SOP.Strict hiding (hcmap, hcpure, hmap, hpure)
 import qualified Data.SOP.Strict as SOP
 
@@ -31,7 +32,7 @@ import qualified Data.SOP.Strict as SOP
 -------------------------------------------------------------------------------}
 
 -- | For every tail @(x ': xs)@ of the list, an @f x y@ for every @y@ in @xs@
-data Tails (f :: k -> k -> *) (xs :: [k]) where
+data Tails (f :: k -> k -> Type) (xs :: [k]) where
   TNil  :: Tails f '[]
   TCons :: NP (f x) xs -> Tails f xs -> Tails f (x ': xs)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Caching.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Caching.hs
@@ -10,6 +10,8 @@ module Ouroboros.Consensus.HardFork.History.Caching (
   , cachedRunQueryThrow
   ) where
 
+import           Data.Kind (Type)
+
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Consensus.HardFork.History.Qry
@@ -20,7 +22,7 @@ import           Ouroboros.Consensus.HardFork.History.Summary
 -------------------------------------------------------------------------------}
 
 -- | Stateful abstraction to execute queries
-data RunWithCachedSummary (xs :: [*]) m = RunWithCachedSummary {
+data RunWithCachedSummary (xs :: [Type]) m = RunWithCachedSummary {
       -- | Run the specified query
       --
       -- If the query fails with a 'PastHorizonException', it will update its

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Qry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Qry.hs
@@ -40,11 +40,12 @@ import           Data.Bifunctor
 import           Data.Fixed (divMod')
 import           Data.Foldable (asum, toList)
 import           Data.Functor.Identity
+import           Data.Kind (Type)
 import           Data.SOP.Strict (SListI)
 import           Data.Time hiding (UTCTime)
 import           Data.Word
 import           GHC.Generics (Generic)
-import           GHC.Show (showParen, showSpace, showString)
+import           GHC.Show (showSpace)
 import           GHC.Stack
 import           Quiet
 
@@ -141,7 +142,7 @@ import           Ouroboros.Consensus.HardFork.History.Util
 -- 'Qry' adds a monadic interface on top of 'Expr'. Although means that 'Qry'
 -- itself is not showable, the 'PastHorizonException' can nonetheless show the
 -- offending expression alongside the 'Summary' against which it was evaluated.
-data Qry :: * -> * where
+data Qry :: Type -> Type where
   QPure :: a -> Qry a
   QExpr :: ClosedExpr a -> (a -> Qry b) -> Qry b
 
@@ -184,7 +185,7 @@ deriving via Quiet EpochInEra  instance Show EpochInEra
 data ClosedExpr a = ClosedExpr (forall f. Expr f a)
 
 -- | Query expressions in PHOAS
-data Expr (f :: * -> *) :: * -> * where
+data Expr (f :: Type -> Type) :: Type -> Type where
   -- PHOAS infrastructure
 
   EVar  :: f a -> Expr f a

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Summary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Summary.hs
@@ -51,6 +51,7 @@ import           Codec.Serialise
 import           Control.Monad.Except
 import           Data.Bifunctor
 import           Data.Foldable (toList)
+import           Data.Kind (Type)
 import           Data.Proxy
 import           Data.SOP.Dict (Dict (..))
 import           Data.SOP.Strict (K (..), NP (..), SListI, lengthSList)
@@ -276,7 +277,7 @@ singletonShape params = Shape (exactlyOne params)
 -- Any transition listed here must be "certain". How certainty is established is
 -- ledger dependent, but it should imply that this is no longer subject to
 -- rollback.
-data Transitions :: [*] -> * where
+data Transitions :: [Type] -> Type where
   -- | If the indices are, say, @'[Byron, Shelley, Goguen]@, then we can have
   -- have at most two transitions: one to Shelley, and one to Goguen. There
   -- cannot be a transition /to/ the initial ledger.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -59,6 +59,7 @@ import           Codec.Serialise (Serialise, decode, encode)
 import           Control.Monad.Except
 import           Data.Coerce
 import           Data.Foldable (toList)
+import           Data.Kind (Type)
 import           Data.Proxy
 import           Data.Sequence.Strict (StrictSeq ((:<|), (:|>), Empty))
 import qualified Data.Sequence.Strict as Seq
@@ -115,7 +116,7 @@ class ( StandardHash blk
       , Eq                 (TipInfo blk)
       , NoUnexpectedThunks (TipInfo blk)
       ) => HasAnnTip blk where
-  type TipInfo blk :: *
+  type TipInfo blk :: Type
   type TipInfo blk = HeaderHash blk
 
   -- | Extract 'TipInfo' from a block header
@@ -341,7 +342,7 @@ class ( BasicEnvelopeValidation blk
       ) => ValidateEnvelope blk where
 
   -- | A block-specific error that 'validateEnvelope' can return.
-  type OtherHeaderEnvelopeError blk :: *
+  type OtherHeaderEnvelopeError blk :: Type
   type OtherHeaderEnvelopeError blk = Void
 
   -- | Do additional envelope checks

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -32,6 +32,7 @@ module Ouroboros.Consensus.Ledger.Abstract (
   ) where
 
 import           Control.Monad.Except
+import           Data.Kind (Type)
 import           Data.Maybe (isJust)
 import           Data.Proxy
 import           GHC.Stack (HasCallStack)
@@ -130,7 +131,7 @@ ledgerTipSlot = pointSlot . (ledgerTipPoint (Proxy @blk))
 -------------------------------------------------------------------------------}
 
 -- | Different queries supported by the ledger, indexed by the result type.
-data family Query blk :: * -> *
+data family Query blk :: Type -> Type
 
 -- | Query the ledger state.
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -20,6 +20,8 @@ module Ouroboros.Consensus.Ledger.Basics (
   , TickedLedgerState
   ) where
 
+import           Data.Kind (Type)
+
 import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Consensus.Block.Abstract
@@ -48,7 +50,7 @@ getTipSlot = pointSlot . getTip
 -------------------------------------------------------------------------------}
 
 -- | Static environment required for the ledger
-type family LedgerCfg l :: *
+type family LedgerCfg l :: Type
 
 class ( -- Requirements on the ledger state itself
         Show               l
@@ -70,7 +72,7 @@ class ( -- Requirements on the ledger state itself
   --
   -- This is defined here rather than in 'ApplyBlock', since the /type/ of
   -- these errors does not depend on the type of the block.
-  type family LedgerErr l :: *
+  type family LedgerErr l :: Type
 
   -- | Apply "slot based" state transformations
   --
@@ -106,7 +108,7 @@ class ( -- Requirements on the ledger state itself
 -------------------------------------------------------------------------------}
 
 -- | Ledger state associated with a block
-data family LedgerState blk :: *
+data family LedgerState blk :: Type
 
 type instance HeaderHash (LedgerState blk) = HeaderHash blk
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -64,6 +64,7 @@ import           Control.Monad.Except
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.ByteString.Short as Short
 import           Data.FingerTree.Strict (Measured (..))
+import           Data.Kind (Type)
 import           Data.Typeable
 import           GHC.Generics (Generic)
 import           GHC.Stack
@@ -86,7 +87,6 @@ import           Ouroboros.Consensus.Util (ShowProxy (..))
 import           Ouroboros.Consensus.Util.Condense
 
 import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
-import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
 
 {-------------------------------------------------------------------------------
   Block
@@ -249,13 +249,13 @@ class (
       ) => Bridge m a where
 
   -- | Additional information relating both ledgers
-  type BridgeLedger m a :: *
+  type BridgeLedger m a :: Type
 
   -- | Information required to update the bridge when applying a block
-  type BridgeBlock m a :: *
+  type BridgeBlock m a :: Type
 
   -- | Information required to update the bridge when applying a transaction
-  type BridgeTx m a :: *
+  type BridgeTx m a :: Type
 
   updateBridgeWithBlock :: DualBlock m a
                         -> BridgeLedger m a -> BridgeLedger m a

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Inspect.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Inspect.hs
@@ -13,6 +13,7 @@ module Ouroboros.Consensus.Ledger.Inspect (
   ) where
 
 import           Data.Either
+import           Data.Kind (Type)
 import           Data.Void
 
 import           Ouroboros.Consensus.Config
@@ -52,8 +53,8 @@ class ( Show     (LedgerWarning blk)
       , Eq       (LedgerUpdate  blk)
       , Condense (LedgerUpdate  blk)
       ) => InspectLedger blk where
-  type LedgerWarning blk :: *
-  type LedgerUpdate  blk :: *
+  type LedgerWarning blk :: Type
+  type LedgerUpdate  blk :: Type
 
   -- | Inspect the ledger
   --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -11,6 +11,7 @@ module Ouroboros.Consensus.Ledger.SupportsMempool (
   ) where
 
 import           Control.Monad.Except
+import           Data.Kind (Type)
 import           Data.Word (Word32)
 import           GHC.Stack (HasCallStack)
 
@@ -24,11 +25,11 @@ import           Ouroboros.Consensus.Util.IOLike
 -- The mempool (and, accordingly, blocks) consist of "generalized
 -- transactions"; this could be "proper" transactions (transferring funds) but
 -- also other kinds of things such as update proposals, delegations, etc.
-data family GenTx blk :: *
+data family GenTx blk :: Type
 
 -- | Updating the ledger with a single transaction may result in a different
 -- error type as when updating it with a block
-type family ApplyTxErr blk :: *
+type family ApplyTxErr blk :: Type
 
 class ( UpdateLedger blk
       , NoUnexpectedThunks (GenTx blk)
@@ -89,7 +90,7 @@ class ( UpdateLedger blk
   txInBlockSize :: GenTx blk -> Word32
 
 -- | A generalized transaction, 'GenTx', identifier.
-data family TxId tx :: *
+data family TxId tx :: Type
 
 -- | Transactions with an identifier
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -19,7 +19,6 @@ module Ouroboros.Consensus.Mempool.Impl (
   ) where
 
 import           Control.Exception (assert)
-import           Control.Monad (void)
 import           Control.Monad.Except
 import           Data.Maybe (isJust, isNothing, listToMaybe)
 import           Data.Set (Set)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -38,6 +38,7 @@ import           Codec.Serialise (Serialise)
 import           Control.Monad
 import           Control.Monad.Except
 import           Control.Tracer
+import           Data.Kind (Type)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy
@@ -67,7 +68,6 @@ import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.Assert (assertWithMsg)
 import           Ouroboros.Consensus.Util.IOLike
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm (checkInvariant)
 import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Util.STM (WithFingerprint (..),
                      onEachChange)
@@ -76,7 +76,7 @@ import           Ouroboros.Consensus.Storage.ChainDB (ChainDB,
                      InvalidBlockReason)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 
-type Consensus (client :: * -> * -> (* -> *) -> * -> *) blk m =
+type Consensus (client :: Type -> Type -> (Type -> Type) -> Type -> Type) blk m =
    client (Header blk) (Tip blk) m Void
 
 -- | Abstract over the ChainDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
@@ -14,8 +14,8 @@ module Ouroboros.Consensus.MiniProtocol.ChainSync.Server
 
 import           Control.Tracer
 
-import           Ouroboros.Network.Block (ChainUpdate (..), HasHeader (..),
-                     HeaderHash, Point (..), Serialised, Tip (..), castPoint)
+import           Ouroboros.Network.Block (ChainUpdate (..), Serialised,
+                     Tip (..))
 import           Ouroboros.Network.Protocol.ChainSync.Server
 
 import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB, Reader,

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -38,7 +38,6 @@ import           Control.Monad.Class.MonadTimer (MonadTimer)
 import           Control.Tracer
 import           Data.ByteString.Lazy (ByteString)
 import           Data.Map.Strict (Map)
-import           Data.Proxy (Proxy (..))
 import           Data.Void (Void)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/DbMarker.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/DbMarker.hs
@@ -11,9 +11,7 @@ module Ouroboros.Consensus.Node.DbMarker (
   , dbMarkerParse
   ) where
 
-import           Control.Monad (void)
 import           Control.Monad.Except
-import           Control.Monad.Trans.Class (lift)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS.Char8
 import           Data.ByteString.Lazy (fromStrict, toStrict)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
@@ -10,6 +10,7 @@ module Ouroboros.Consensus.Node.NetworkProtocolVersion
   , NodeToClientVersion(..)
   ) where
 
+import           Data.Kind (Type)
 import           Data.Map.Strict (Map)
 import           Data.Proxy
 
@@ -26,8 +27,8 @@ class ( Show (BlockNodeToNodeVersion   blk)
       , Eq   (BlockNodeToNodeVersion   blk)
       , Eq   (BlockNodeToClientVersion blk)
       ) => HasNetworkProtocolVersion blk where
-  type BlockNodeToNodeVersion   blk :: *
-  type BlockNodeToClientVersion blk :: *
+  type BlockNodeToNodeVersion   blk :: Type
+  type BlockNodeToClientVersion blk :: Type
 
   -- Defaults
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Recovery.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Recovery.hs
@@ -6,7 +6,6 @@ module Ouroboros.Consensus.Node.Recovery
   , removeCleanShutdownMarker
   ) where
 
-import           Control.Exception (SomeException)
 import           Control.Monad (unless, when)
 
 import           Ouroboros.Consensus.Node.Exit (ExitReason (..), toExitReason)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -20,7 +20,6 @@ module Ouroboros.Consensus.Node.Run (
 import           Data.Typeable (Typeable)
 
 import           Ouroboros.Network.Block (Serialised)
-import           Ouroboros.Network.BlockFetch (SizeInBytes)
 import           Ouroboros.Network.Util.ShowProxy
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -37,7 +37,6 @@ import           Ouroboros.Network.AnchoredFragment (AnchoredFragment (..))
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block (MaxSlotNo)
 import           Ouroboros.Network.BlockFetch
-import           Ouroboros.Network.BlockFetch.State (FetchMode (..))
 import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..))
 import           Ouroboros.Network.TxSubmission.Inbound
                      (TxSubmissionMempoolWriter)
@@ -57,7 +56,6 @@ import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Mempool
-import           Ouroboros.Consensus.Mempool.TxSeq (TicketNo)
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Node.Tracers
 import           Ouroboros.Consensus.Util (whenJust)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -13,6 +13,7 @@ module Ouroboros.Consensus.Protocol.Abstract (
 
 import           Codec.Serialise (Serialise)
 import           Control.Monad.Except
+import           Data.Kind (Type)
 import           Data.Typeable (Typeable)
 import           GHC.Stack
 
@@ -31,7 +32,7 @@ import           Ouroboros.Consensus.Ticked
 -- Defined out of the class so that protocols can define this type without
 -- having to define the entire protocol at the same time (or indeed in the same
 -- module).
-data family ConsensusConfig p :: *
+data family ConsensusConfig p :: Type
 
 -- | Chain selection
 class ( NoUnexpectedThunks (ChainSelConfig p)
@@ -41,11 +42,11 @@ class ( NoUnexpectedThunks (ChainSelConfig p)
       , Eq   (ChainSelConfig p)
       ) => ChainSelection p where
   -- | Configuration required for chain selection
-  type family ChainSelConfig p :: *
+  type family ChainSelConfig p :: Type
   type ChainSelConfig p = ()
 
   -- | View on a header required for chain selection
-  type family SelectView p :: *
+  type family SelectView p :: Type
   type SelectView p = BlockNo
 
   -- | Do we prefer the candidate chain over ours?
@@ -118,13 +119,13 @@ class ( Show (ChainDepState   p)
   --
   -- NOTE: This chain is blockchain dependent, i.e., updated when new blocks
   -- come in (more precisely, new /headers/), and subject to rollback.
-  type family ChainDepState p :: *
+  type family ChainDepState p :: Type
 
   -- | Evidence that a node /is/ the leader
-  type family IsLeader p :: *
+  type family IsLeader p :: Type
 
   -- | Evidence that we /can/ be a leader
-  type family CanBeLeader p :: *
+  type family CanBeLeader p :: Type
 
   -- | Projection of the ledger state the Ouroboros protocol needs access to
   --
@@ -165,13 +166,13 @@ class ( Show (ChainDepState   p)
   -- in the consensus layer since that depends on the computation (and sampling)
   -- of entropy, which is done consensus side, not ledger side (the reward
   -- calculation does not depend on this).
-  type family LedgerView p :: *
+  type family LedgerView p :: Type
 
   -- | Validation errors
-  type family ValidationErr p :: *
+  type family ValidationErr p :: Type
 
   -- | View on a header required to validate it
-  type family ValidateView p :: *
+  type family ValidateView p :: Type
 
   -- | 'ConsensusConfig' must include the 'ChainSelConfig' p
   chainSelConfig :: ConsensusConfig p -> ChainSelConfig p

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -28,6 +28,7 @@ module Ouroboros.Consensus.Protocol.BFT (
   ) where
 
 import           Control.Monad.Except
+import           Data.Kind (Type)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy
@@ -184,7 +185,7 @@ class ( Typeable c
       , NoUnexpectedThunks (SigDSIGN (BftDSIGN c))
       , ContextDSIGN (BftDSIGN c) ~ ()
       ) => BftCrypto c where
-  type family BftDSIGN c :: *
+  type family BftDSIGN c :: Type
 
 data BftStandardCrypto
 data BftMockCrypto

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -47,7 +47,6 @@ import           Control.Monad.Except
 import           Data.Bifunctor (first)
 import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
-import           Data.Proxy (Proxy (..))
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Typeable (Typeable)
@@ -306,7 +305,7 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
 
   tickChainDepState _ lv _ = TickedPBftState lv
 
-  updateChainDepState cfg@PBftConfig{..}
+  updateChainDepState cfg
                       toValidate
                       slot
                       (TickedPBftState (TickedPBftLedgerView dms) state) =
@@ -343,7 +342,7 @@ instance PBftCrypto c => ConsensusProtocol (PBft c) where
     where
       params = pbftWindowParams cfg
 
-  reupdateChainDepState cfg@PBftConfig{..}
+  reupdateChainDepState cfg
                         toValidate
                         slot
                         (TickedPBftState (TickedPBftLedgerView dms) state) =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/Crypto.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/Crypto.hs
@@ -13,6 +13,7 @@ module Ouroboros.Consensus.Protocol.PBFT.Crypto (
   , PBftMockCrypto
   ) where
 
+import           Data.Kind (Type)
 import           Data.Typeable
 
 import           Cardano.Crypto.DSIGN.Class
@@ -37,9 +38,9 @@ class ( Typeable c
       , NoUnexpectedThunks (PBftVerKeyHash c)
       , NoUnexpectedThunks (PBftDelegationCert c)
       ) => PBftCrypto c where
-  type family PBftDSIGN          c :: *
-  type family PBftDelegationCert c = (d :: *) | d -> c
-  type family PBftVerKeyHash     c = (d :: *) | d -> c
+  type family PBftDSIGN          c :: Type
+  type family PBftDelegationCert c = (d :: Type) | d -> c
+  type family PBftVerKeyHash     c = (d :: Type) | d -> c
 
   dlgCertGenVerKey :: PBftDelegationCert c -> VerKeyDSIGN (PBftDSIGN c)
   dlgCertDlgVerKey :: PBftDelegationCert c -> VerKeyDSIGN (PBftDSIGN c)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
@@ -582,7 +582,7 @@ serializationFormatVersion0 = 0
 
 encodePBftState :: Serialise (PBftVerKeyHash c)
                 => PBftState c -> Encoding
-encodePBftState st@PBftState{..} =
+encodePBftState st =
     encodeVersion serializationFormatVersion0 $ mconcat [
         Serialise.encodeListLen 3
       , encode (withOriginToMaybe anchor)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Signed.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Signed.hs
@@ -6,8 +6,10 @@ module Ouroboros.Consensus.Protocol.Signed (
   , SignedHeader(..)
   ) where
 
+import           Data.Kind (Type)
+
 -- | The part of the header that is signed
-type family Signed hdr :: *
+type family Signed hdr :: Type
 
 -- | Header that contain a signed part
 --

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -67,15 +67,12 @@ module Ouroboros.Consensus.Storage.ChainDB.API (
   ) where
 
 import qualified Codec.CBOR.Read as CBOR
-import           Control.Exception (Exception (..))
 import           Control.Monad (void)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.ByteString.Short (ShortByteString)
 import           Data.Typeable
 import           GHC.Generics (Generic)
 import           GHC.Stack
-
-import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/BlockComponent.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/BlockComponent.hs
@@ -23,7 +23,7 @@ import           Ouroboros.Consensus.Storage.ChainDB.API (BlockRef (..),
                      ChainDB, ChainDbFailure (..))
 import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
                      (DecodeDisk (..), DecodeDiskDep (..),
-                     ReconstructNestedCtxt (..), SizeInBytes)
+                     ReconstructNestedCtxt (..))
 import           Ouroboros.Consensus.Storage.Common
 
 -- | Translate a ChainDB 'BlockComponent' into a 'BlockComponent' known by the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -22,7 +22,6 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel
   ) where
 
 import           Control.Exception (assert)
-import           Control.Monad (unless)
 import           Control.Monad.Except
 import           Control.Monad.Trans.State.Strict
 import           Control.Tracer (Tracer, contramap, traceWith)
@@ -33,7 +32,6 @@ import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (isJust)
-import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           GHC.Stack (HasCallStack)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
@@ -75,7 +75,6 @@ import           Data.Binary.Put (Put)
 import qualified Data.Binary.Put as Put
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Functor ((<&>))
-import           Data.Proxy (Proxy (..))
 import           Data.Word (Word32)
 import           GHC.Generics (Generic)
 import           GHC.Stack

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -60,7 +60,6 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Types (
 
 import           Control.Tracer
 import           Data.Map.Strict (Map)
-import           Data.Time.Clock (DiffTime)
 import           Data.Typeable
 import           Data.Void (Void)
 import           Data.Word (Word64)
@@ -69,7 +68,7 @@ import           GHC.Stack (HasCallStack, callStack)
 
 import           Control.Monad.Class.MonadSTM.Strict (newEmptyTMVarM)
 
-import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..))
+import           Cardano.Prelude (OnlyCheckIsWHNF (..))
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/VolDB.hs
@@ -69,7 +69,6 @@ import           Data.Foldable (foldl')
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import           Data.Maybe (fromMaybe, isJust, mapMaybe)
-import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Typeable (Typeable)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/Common.hs
@@ -28,6 +28,7 @@ import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BL
 import           Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as Short
+import           Data.Kind (Type)
 import           Data.Word
 import           GHC.Generics
 
@@ -99,9 +100,9 @@ extractHeader BinaryBlockInfo { headerOffset, headerSize } =
 -- | The type of a block, header, and header hash of a database. Used by
 -- 'BlockComponent'.
 class DB db where
-  type DBBlock      db :: *
-  type DBHeader     db :: *
-  type DBHeaderHash db :: *
+  type DBBlock      db :: Type
+  type DBHeader     db :: Type
+  type DBHeaderHash db :: Type
 
 -- | Which component of the block to read from a database: the whole block,
 -- its header, its hash, the block size, ..., or combinations thereof.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
@@ -274,7 +274,7 @@ closeDBImpl ImmutableDBEnv { hasFS, tracer, varInternalState } = do
       DbClosed -> do
         putMVar varInternalState internalState
         traceWith tracer $ DBAlreadyClosed
-      DbOpen openState@OpenState {..} -> do
+      DbOpen openState -> do
         -- Close the database before doing the file-system operations so that
         -- in case these fail, we don't leave the database open.
         putMVar varInternalState DbClosed

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index.hs
@@ -20,7 +20,7 @@ import           Data.Functor.Identity (Identity (..))
 import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
 
-import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..))
+import           Cardano.Prelude (OnlyCheckIsWHNF (..))
 
 import           Ouroboros.Consensus.Block (IsEBB)
 import           Ouroboros.Consensus.Util.IOLike
@@ -31,8 +31,6 @@ import           Ouroboros.Consensus.Storage.FS.API.Types (AllowExisting,
                      Handle)
 
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks
-import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Layout
-                     (RelativeSlot)
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Cache
                      (CacheConfig (..))
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Cache as Cache

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
@@ -51,13 +51,11 @@ import           Data.Word (Word32, Word64)
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack, callStack)
 
-import           Cardano.Prelude (NoUnexpectedThunks (..), forceElemsToWHNF,
-                     unsafeNoUnexpectedThunks)
+import           Cardano.Prelude (forceElemsToWHNF, unsafeNoUnexpectedThunks)
 
 import           Ouroboros.Consensus.Block (IsEBB (..))
 import           Ouroboros.Consensus.Util (whenJust)
 import           Ouroboros.Consensus.Util.IOLike
-import           Ouroboros.Consensus.Util.MonadSTM.NormalForm (tryPutMVar)
 import qualified Ouroboros.Consensus.Util.MonadSTM.StrictMVar as Strict
 import           Ouroboros.Consensus.Util.ResourceRegistry
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Primary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Primary.hs
@@ -60,8 +60,6 @@ import           Foreign.Storable (sizeOf)
 import           GHC.Generics (Generic)
 import           GHC.Stack
 
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Consensus.Storage.FS.API

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Secondary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Secondary.hs
@@ -33,8 +33,6 @@ import           Foreign.Storable (Storable (sizeOf))
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 
-import           Cardano.Prelude (NoUnexpectedThunks)
-
 import           Ouroboros.Consensus.Block hiding (hashSize, headerHash)
 import           Ouroboros.Consensus.Util.IOLike
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
@@ -17,7 +17,6 @@ module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Iterator
   ) where
 
 import           Control.Exception (assert)
-import           Control.Monad (when)
 import           Control.Monad.Except
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as Lazy
@@ -30,8 +29,7 @@ import qualified Data.List.NonEmpty as NE
 import           Data.Maybe (isNothing)
 import           GHC.Generics (Generic)
 
-import           Cardano.Prelude (NoUnexpectedThunks (..),
-                     allNoUnexpectedThunks, forceElemsToWHNF)
+import           Cardano.Prelude (allNoUnexpectedThunks, forceElemsToWHNF)
 
 import           GHC.Stack (HasCallStack)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
@@ -30,8 +30,6 @@ import           Control.Tracer (Tracer)
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-
 import           Ouroboros.Consensus.Util (SomePair (..))
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry,
@@ -244,8 +242,6 @@ withOpenState ImmutableDBEnv { hasFS = hasFS :: HasFS m h, .. } action = do
       Left  e -> throwM e
       Right r -> return r
   where
-    HasFS{..} = hasFS
-
     -- We use 'readMVarSTM' to read a potentially stale internal state if
     -- somebody's appending to the ImmutableDB at the same time. Reads can
     -- safely happen concurrently with appends, so this is fine and allows for

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -346,7 +346,7 @@ writeSnapshot :: forall m l r h. MonadThrow m
               -> (l -> Encoding)
               -> (r -> Encoding)
               -> DiskSnapshot -> ChainSummary l r -> m ()
-writeSnapshot hasFS@HasFS{..} encLedger encRef ss cs = do
+writeSnapshot hasFS encLedger encRef ss cs = do
     withFile hasFS (snapshotToPath ss) (WriteMode MustBeNew) $ \h ->
       void $ hPut hasFS h $ CBOR.toBuilder (encode cs)
   where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/API.hs
@@ -14,7 +14,7 @@ import           Data.ByteString.Builder (Builder)
 import           Data.Set (Set)
 import           GHC.Stack (HasCallStack)
 
-import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..))
+import           Cardano.Prelude (OnlyCheckIsWHNF (..))
 
 import           Ouroboros.Network.Block (MaxSlotNo)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ticked.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ticked.hs
@@ -10,6 +10,7 @@ module Ouroboros.Consensus.Ticked (
     Ticked(..)
   ) where
 
+import           Data.Kind (Type)
 import           Data.SOP.BasicFunctors
 
 import           Cardano.Prelude (NoUnexpectedThunks)
@@ -30,7 +31,7 @@ import           Cardano.Prelude (NoUnexpectedThunks)
 -- * New leader schedule computed for Shelley
 -- * Transition from Byron to Shelley activated in the hard fork combinator.
 -- * Nonces switched out at the start of a new epoch.
-data family Ticked st :: *
+data family Ticked st :: Type
 
 -- Standard instance for use with trivial state
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -68,7 +68,7 @@ import           Data.Foldable (asum, toList)
 import           Data.Function (on)
 import           Data.Functor.Identity
 import           Data.Functor.Product
-import           Data.Kind
+import           Data.Kind (Constraint, Type)
 import           Data.List (foldl', maximumBy)
 import           Data.Maybe (fromMaybe)
 import           Data.Set (Set)
@@ -83,17 +83,17 @@ import           Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
   Type-level utility
 -------------------------------------------------------------------------------}
 
-data Dict :: Constraint -> * where
+data Dict :: Constraint -> Type where
   Dict :: a => Dict a
 
 class Empty a
 instance Empty a
 
-data Some (f :: k -> *) where
+data Some (f :: k -> Type) where
     Some :: f a -> Some f
 
 -- | Pair of functors instantiated to the /same/ existential
-data SomePair (f :: k -> *) (g :: k -> *) where
+data SomePair (f :: k -> Type) (g :: k -> Type) where
     SomePair :: f a -> g a -> SomePair f g
 
 mustBeRight :: Either Void a -> a

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Counting.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Counting.hs
@@ -45,6 +45,7 @@ module Ouroboros.Consensus.Util.Counting (
   ) where
 
 import qualified Data.Foldable as Foldable
+import           Data.Kind (Type)
 import           Data.SOP.Strict
 
 import           Ouroboros.Consensus.Util.SOP
@@ -56,12 +57,12 @@ import           Ouroboros.Consensus.Util.SOP
 type Exactly xs a = NP (K a) xs
 
 -- | At most one value for each type level index
-data AtMost :: [*] -> * -> * where
+data AtMost :: [Type] -> Type -> Type where
   AtMostNil  :: AtMost xs a
   AtMostCons :: !a -> !(AtMost xs a) -> AtMost (x ': xs) a
 
 -- | Non-empty variation on 'AtMost'
-data NonEmpty :: [*] -> * -> * where
+data NonEmpty :: [Type] -> Type -> Type where
   NonEmptyOne  :: !a -> NonEmpty (x ': xs) a
   NonEmptyCons :: !a -> !(NonEmpty xs a) -> NonEmpty (x ': xs) a
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/DepPair.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/DepPair.hs
@@ -22,6 +22,7 @@ module Ouroboros.Consensus.Util.DepPair (
   , Proxy(..)
   ) where
 
+import           Data.Kind (Type)
 import           Data.Proxy
 import           Data.SOP.Strict (I (..))
 import           Data.Type.Equality ((:~:) (..))
@@ -65,7 +66,7 @@ class SameDepIndex f where
 
 -- | A dependency is trivial if it always maps to the same type @b@
 class TrivialDependency f where
-  type TrivialIndex f :: *
+  type TrivialIndex f :: Type
   hasSingleIndex :: f a -> f b -> a :~: b
   indexIsTrivial :: f (TrivialIndex f)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/HList.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/HList.hs
@@ -34,8 +34,7 @@ module Ouroboros.Consensus.Util.HList (
   , afterFn
   ) where
 
-import           Data.Kind (Constraint)
-import           Data.Monoid ((<>))
+import           Data.Kind (Constraint, Type)
 import           Data.Proxy
 import           Prelude hiding (foldMap, foldl, foldr)
 
@@ -43,7 +42,7 @@ import           Prelude hiding (foldMap, foldl, foldr)
   Basic definitions
 -------------------------------------------------------------------------------}
 
-data HList :: [*] -> * where
+data HList :: [Type] -> Type where
   Nil  :: HList '[]
   (:*) :: a -> HList as -> HList (a ': as)
 
@@ -134,11 +133,11 @@ collapse _ f = go
   Singleton for HList
 -------------------------------------------------------------------------------}
 
-data SList :: [*] -> * where
+data SList :: [Type] -> Type where
   SNil :: SList '[]
   SCons :: SList as -> SList (a ': as)
 
-class IsList (xs :: [*]) where
+class IsList (xs :: [Type]) where
   isList :: SList xs
 
 instance              IsList '[]       where isList = SNil

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/RAWLock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/RAWLock.hs
@@ -27,7 +27,6 @@ module Ouroboros.Consensus.Util.MonadSTM.RAWLock
 
 import           Prelude hiding (read)
 
-import           Control.Monad (join)
 import           Control.Monad.Except
 import           Data.Functor (($>))
 import           GHC.Generics (Generic)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/OptNP.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/OptNP.hs
@@ -28,12 +28,13 @@ module Ouroboros.Consensus.Util.OptNP (
   ) where
 
 import           Control.Monad (guard)
+import           Data.Kind (Type)
 import           Data.Maybe (isJust)
 import           Data.SOP.Strict
 import           Data.Type.Equality
 
 -- | Like an 'NP', but with optional values
-data OptNP (empty :: Bool) (f :: k -> *) (xs :: [k]) where
+data OptNP (empty :: Bool) (f :: k -> Type) (xs :: [k]) where
   OptNil  :: OptNP 'True f '[]
   OptCons :: !(f x) -> !(OptNP empty f xs) -> OptNP 'False f (x ': xs)
   OptSkip :: !(OptNP empty f xs) -> OptNP empty f (x ': xs)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -50,7 +50,7 @@ module Ouroboros.Consensus.Util.ResourceRegistry (
   ) where
 
 import           Control.Applicative ((<|>))
-import           Control.Exception (Exception, asyncExceptionFromException)
+import           Control.Exception (asyncExceptionFromException)
 import           Control.Monad
 import           Control.Monad.Reader
 import           Control.Monad.State.Strict
@@ -65,7 +65,7 @@ import qualified Data.Set as Set
 import           Data.Tuple (swap)
 import           GHC.Generics (Generic)
 
-import           Cardano.Prelude (NoUnexpectedThunks (..), OnlyCheckIsWHNF (..),
+import           Cardano.Prelude (OnlyCheckIsWHNF (..),
                      UseIsNormalFormNamed (..), allNoUnexpectedThunks)
 
 import           Ouroboros.Consensus.Util (mustBeRight, whenJust)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
@@ -33,6 +33,7 @@ module Ouroboros.Consensus.Util.SOP (
   , checkIsNonEmpty
   ) where
 
+import           Data.Kind (Type)
 import           Data.SOP.Dict
 import           Data.SOP.Strict
 import           Data.Word
@@ -128,7 +129,7 @@ lenses_NP = go sList
 
 -- | Conjure up an 'SListI' constraint from an 'NP'
 npToSListI :: NP a xs -> (SListI xs => r) -> r
-npToSListI = sListToSListI . npToSList
+npToSListI np = sListToSListI $ npToSList np
   where
     sListToSListI :: SList xs -> (SListI xs => r) -> r
     sListToSListI SNil  k = k
@@ -155,7 +156,7 @@ fn_5 f = Fn $ \x0 ->
   Type-level non-empty lists
 -------------------------------------------------------------------------------}
 
-data ProofNonEmpty :: [*] -> * where
+data ProofNonEmpty :: [Type] -> Type where
   ProofNonEmpty :: Proxy x -> Proxy xs -> ProofNonEmpty (x ': xs)
 
 class IsNonEmpty xs where

--- a/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
@@ -12,19 +12,17 @@
 
 module Test.Consensus.BlockchainTime.Simple (tests) where
 
-import           Control.Exception (SomeException, fromException)
 import           Control.Monad.Except
 import           Control.Monad.Reader
 import           Control.Tracer
 import           Data.Fixed
-import           Data.Time (UTCTime)
 import qualified Data.Time.Clock as Time
 import           Test.QuickCheck hiding (Fixed)
 import           Test.Tasty hiding (after)
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck hiding (Fixed)
 
-import           Cardano.Prelude (AllowThunk (..), NoUnexpectedThunks)
+import           Cardano.Prelude (AllowThunk (..))
 
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.IOSim

--- a/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Infra.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/HardFork/Infra.hs
@@ -27,6 +27,7 @@ module Test.Consensus.HardFork.Infra (
   ) where
 
 import           Control.Monad.Except
+import           Data.Kind (Type)
 import           Data.SOP.Dict (Dict (..))
 import           Data.SOP.Strict
 import           Data.Word
@@ -70,7 +71,7 @@ data Era = Era {
      }
   deriving (Show, Eq, Ord)
 
-data Eras :: [*] -> * where
+data Eras :: [Type] -> Type where
     -- We guarantee to have at least one era
     Eras :: Exactly (x ': xs) Era -> Eras (x ': xs)
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Mempool.hs
@@ -45,8 +45,6 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.Mempool
 import           Ouroboros.Consensus.Mempool.TxSeq as TxSeq
 import           Ouroboros.Consensus.Mock.Ledger hiding (TxId)
-import           Ouroboros.Consensus.Mock.Ledger.Block
-                     (Ticked (TickedSimpleLedgerState))
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.Protocol.BFT
 import           Ouroboros.Consensus.Util (repeatedly, repeatedlyM,

--- a/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE TypeApplications    #-}
 module Test.Consensus.MiniProtocol.ChainSync.Client ( tests ) where
 
-import           Control.Monad (replicateM_, void)
 import           Control.Monad.Except (runExcept)
 import           Control.Monad.State.Strict
 import           Control.Tracer (Tracer (..), contramap, nullTracer, traceWith)

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Node.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Node.hs
@@ -9,7 +9,7 @@ module Test.Consensus.Node (tests) where
 import           Data.Bifunctor (second)
 import           Data.Functor ((<&>))
 import qualified Data.Map.Strict as Map
-import           Data.Time.Clock (DiffTime, secondsToDiffTime)
+import           Data.Time.Clock (secondsToDiffTime)
 import           System.Directory (getTemporaryDirectory)
 import           System.IO.Temp (withTempDirectory)
 

--- a/ouroboros-consensus/test-consensus/Test/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/Protocol/PBFT.hs
@@ -12,7 +12,6 @@ import qualified Control.Exception as Exn
 import           Data.Coerce (coerce)
 import           Data.Functor ((<&>))
 import           Data.List (inits, tails)
-import           Data.Proxy (Proxy (..))
 import qualified Data.Sequence.Strict as Seq
 import           Data.Word
 
@@ -423,8 +422,6 @@ prop_validGenerator st@TestPBftState{..} =
                    testOldPBftState
     .&&.
     Seq.null (S.preWindow testOldPBftState)
-  where
-    S.PBftState{..} = testPBftState
 
 -- | Our direct calculation of @csABb@ matches the result of the corresponding
 -- appends and a rewind.

--- a/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -22,10 +22,11 @@ import           Control.Monad.Except
 import           Data.Foldable (toList)
 import           Data.Function (on)
 import           Data.Functor.Classes
+import           Data.Kind (Type)
 import           Data.List (delete, sort)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.TreeDiff (ToExpr (..), defaultExprViaShow)
+import           Data.TreeDiff (defaultExprViaShow)
 import           Data.Typeable
 import qualified Generics.SOP as SOP
 import           GHC.Generics (Generic, Generic1)
@@ -265,7 +266,7 @@ data TestThread m = TestThread {
 -- | Instructions to a thread
 --
 -- The type argument indicates the result of the instruction
-data ThreadInstr m :: * -> * where
+data ThreadInstr m :: Type -> Type where
   -- | Have the thread spawn a child thread
   ThreadFork :: Link () -> ThreadInstr m (TestThread m)
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/GcSchedule.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/GcSchedule.hs
@@ -8,7 +8,7 @@ module Test.Ouroboros.Storage.ChainDB.GcSchedule (tests, example) where
 import           Control.Monad (forM)
 import           Control.Tracer (nullTracer)
 import           Data.Fixed (div')
-import           Data.List
+import           Data.List (foldl', partition, sort)
 import           Data.Time.Clock
 import           Data.Void (Void)
 

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -27,9 +27,9 @@ import           Ouroboros.Consensus.Util.Condense (condense)
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
-import           Ouroboros.Consensus.Storage.ChainDB.API (BlockComponent (..),
-                     Iterator (..), IteratorResult (..), StreamFrom (..),
-                     StreamTo (..), UnknownRange (..), traverseIterator)
+import           Ouroboros.Consensus.Storage.ChainDB.API (Iterator (..),
+                     IteratorResult (..), StreamFrom (..), StreamTo (..),
+                     UnknownRange (..), traverseIterator)
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.ImmDB (ImmDB, mkImmDB)
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Iterator
                      (IteratorEnv (..), newIterator)

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -959,7 +959,7 @@ between k cfg from to m = do
 -- tip).
 garbageCollectable :: forall blk. HasHeader blk
                    => SecurityParam -> Model blk -> blk -> Bool
-garbageCollectable secParam m@Model{..} b =
+garbageCollectable secParam m b =
     -- Note: we don't use the block number but the slot number, as the
     -- VolatileDB's garbage collection is in terms of slot numbers.
     NotOrigin (blockSlot b) < immutableSlotNo secParam m
@@ -973,7 +973,7 @@ garbageCollectable secParam m@Model{..} b =
 -- case from a block that was never added to the model in the first place.
 garbageCollectablePoint :: forall blk. HasHeader blk
                         => SecurityParam -> Model blk -> RealPoint blk -> Bool
-garbageCollectablePoint secParam m@Model{..} pt
+garbageCollectablePoint secParam m pt
     | Just blk <- getBlock (realPointHash pt) m
     = garbageCollectable secParam m blk
     | otherwise

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -41,7 +41,6 @@ import           Data.Maybe (fromMaybe)
 import           Data.Ord (Down (..))
 import           Data.Proxy
 import           Data.Sequence.Strict (StrictSeq)
-import           Data.TreeDiff (ToExpr (..))
 import           Data.Typeable
 import           Data.Void (Void)
 import           Data.Word (Word16, Word32, Word64)
@@ -59,7 +58,7 @@ import qualified Test.StateMachine.Types.Rank2 as Rank2
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
-import           Cardano.Prelude (AllowThunk (..), NoUnexpectedThunks)
+import           Cardano.Prelude (AllowThunk (..))
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import qualified Ouroboros.Network.AnchoredFragment as AF

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/FS.hs
@@ -10,8 +10,6 @@ import           Test.Ouroboros.Storage.Util
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit
 
-import           Ouroboros.Consensus.Storage.FS.API
-
 tests :: FilePath -> TestTree
 tests tmpDir = testGroup "HasFS"
     [ StateMachine.tests tmpDir
@@ -23,6 +21,4 @@ tests tmpDir = testGroup "HasFS"
 
 -- | A unit test example.
 _test_example :: Assertion
-_test_example =
-  apiEquivalenceFs (expectFsResult (@?= ())) $ \HasFS{..} ->
-    return ()
+_test_example = apiEquivalenceFs (expectFsResult (@?= ())) $ \_ -> return ()

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Primary.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/ImmutableDB/Primary.hs
@@ -17,7 +17,7 @@ import           Ouroboros.Consensus.Storage.FS.API
 import           Ouroboros.Consensus.Storage.FS.API.Types
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks
 import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
-                     (ChunkNo (..), RelativeSlot (..), maxRelativeIndex)
+                     (RelativeSlot (..), maxRelativeIndex)
 import           Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary
                      (PrimaryIndex, SecondaryOffset)
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary as Primary

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -39,12 +39,12 @@ import           Control.Tracer (nullTracer)
 import           Data.Bifunctor
 import           Data.Foldable (toList)
 import           Data.Functor.Classes
+import           Data.Kind (Type)
 import qualified Data.List as L
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromJust)
 import           Data.Proxy
-import           Data.TreeDiff (ToExpr (..))
 import           Data.Word
 import           GHC.Generics (Generic)
 import           System.Random (getStdRandom, randomR)
@@ -110,9 +110,9 @@ class ( Lgr.ApplyBlock (LedgerSt t) (BlockVal t)
       , Serialise (LedgerSt t)
       , Serialise (BlockRef t)
       ) => LUT (t :: LedgerUnderTest) where
-  type family LedgerSt t :: *
-  type family BlockVal t :: *
-  type family BlockRef t :: *
+  type family LedgerSt t :: Type
+  type family BlockVal t :: Type
+  type family BlockRef t :: Type
 
   -- | Genesis value
   ledgerGenesis :: Proxy t -> LedgerSt t

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -85,7 +85,6 @@ import           Control.Monad.Class.MonadThrow
 import           Cardano.Crypto.DSIGN
 import           Cardano.Prelude (NoUnexpectedThunks)
 
-import           Ouroboros.Network.MockChain.Chain (Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 
 import           Ouroboros.Consensus.Block
@@ -110,7 +109,6 @@ import           Ouroboros.Consensus.Util.Condense
 import           Ouroboros.Consensus.Util.Orphans ()
 
 import           Ouroboros.Consensus.Storage.ChainDB.Serialisation
-import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
 import           Ouroboros.Consensus.Storage.FS.API (HasFS (..), hGetExactly,
                      hPutAll, hSeek, withFile)
 import           Ouroboros.Consensus.Storage.FS.API.Types

--- a/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -28,10 +28,8 @@ import           Data.Kind (Type)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import           Data.Maybe (catMaybes, listToMaybe, mapMaybe)
-import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.TreeDiff (ToExpr (..))
 import           Data.Word
 import qualified Generics.SOP as SOP
 import           GHC.Generics
@@ -475,7 +473,7 @@ shrinkerImpl m (At (CmdErr cmd mbErr)) = fmap At $
     [ CmdErr cmd' mbErr | cmd'   <- shrinkCmd m cmd ]
 
 shrinkCmd :: Model Symbolic -> Cmd -> [Cmd]
-shrinkCmd Model{..} cmd = case cmd of
+shrinkCmd _ cmd = case cmd of
     GetBlockInfo   bids       -> GetBlockInfo <$> shrinkList (const []) bids
     FilterByPredecessor preds -> FilterByPredecessor <$> shrinkList (const []) preds
     Corruption cors           -> Corruption <$> shrinkCorruptions cors

--- a/stack.yaml
+++ b/stack.yaml
@@ -84,7 +84,7 @@ extra-deps:
   - bimap-0.4.0
   - binary-0.8.7.0
   - generic-monoid-0.1.0.0
-  - graphviz-2999.20.0.3
+  - graphviz-2999.20.1.3
   - hedgehog-quickcheck-0.1.1
   - markov-chain-usage-model-0.0.0  # Needed for `quickcheck-state-machine`
   - network-3.1.0.1

--- a/typed-protocols-examples/typed-protocols-examples.cabal
+++ b/typed-protocols-examples/typed-protocols-examples.cabal
@@ -21,7 +21,7 @@ library
   exposed-modules:   Network.TypedProtocol.Channel
                    , Network.TypedProtocol.Codec
                    , Network.TypedProtocol.Driver.Simple
-  
+
                    , Network.TypedProtocol.PingPong.Type
                    , Network.TypedProtocol.PingPong.Client
                    , Network.TypedProtocol.PingPong.Server
@@ -54,11 +54,11 @@ library
   ghc-options:       -Wall
                      -Wno-unticked-promoted-constructors
                      -Wcompat
-                     -Wincomplete-uni-patterns                            
-                     -Wincomplete-record-updates                          
-                     -Wpartial-fields                                     
-                     -Widentities                                         
-                     -Wredundant-constraints                              
+                     -Wincomplete-uni-patterns
+                     -Wincomplete-record-updates
+                     -Wpartial-fields
+                     -Widentities
+                     -Wredundant-constraints
 
 test-suite typed-protocols-tests
   type:              exitcode-stdio-1.0

--- a/typed-protocols/typed-protocols.cabal
+++ b/typed-protocols/typed-protocols.cabal
@@ -40,8 +40,8 @@ library
   ghc-options:       -Wall
                      -Wno-unticked-promoted-constructors
                      -Wcompat
-                     -Wincomplete-uni-patterns                            
-                     -Wincomplete-record-updates                          
-                     -Wpartial-fields                                     
-                     -Widentities                                         
-                     -Wredundant-constraints                              
+                     -Wincomplete-uni-patterns
+                     -Wincomplete-record-updates
+                     -Wpartial-fields
+                     -Widentities
+                     -Wredundant-constraints


### PR DESCRIPTION
All changes are backwards-compatible with 8.6

* Replace `*` with `Type`
* Remove imports that GHC now considers redundant
* `fail` is no longer a method of `Monad`, but of `MonadFail`. See
  <https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-fail#adapting-old-code>
* Remove record wildcard matches when no fields are
  used (`-Wunused-record-wildcards`)