### PR TITLE
Fix current failures on nightly Cardano ThreadNet tests

### DIFF
--- a/.buildkite/slow-ThreadNet-tests.sh
+++ b/.buildkite/slow-ThreadNet-tests.sh
@@ -24,10 +24,10 @@ set -euo pipefail
 # overhead and also more reliable percentages in their QuickCheck statistics.
 rows=(
     # From the slowest individual invocation ...
-    '1 Cardano    2000'  # ~35 minutes per invocation
+    '1 Cardano    1500'  # ~70 minutes per invocation
     '2 RealTPraos 200'   # ~30 minutes per invocation (but high variance)
     '4 RealTPraos 100'   # ~15 minutes per invocation (but high variance)
-    '5 Cardano    300'   # ~5  minutes per invocation
+    '5 Cardano    200'   # ~9  minutes per invocation
     # ... to fastest individual invocation
     #
     # And the number of invocations is non-decreasing.

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -496,6 +496,7 @@ prop_simple_cardano_convergence TestSetup
         Shelley.mkGenesisConfig
           (SL.ProtVer shelleyMajorVersion 0)
           setupK
+          activeSlotCoeff
           setupD
           setupSlotLengthShelley
           (Shelley.mkKesConfig (Proxy @(KES Crypto)) numSlots)
@@ -769,6 +770,9 @@ mkProtocolCardanoAndHardForkTxs
   Constants
 -------------------------------------------------------------------------------}
 
+activeSlotCoeff :: Rational
+activeSlotCoeff = 0.5
+
 maxMajorPVShelley :: Natural
 maxMajorPVShelley = 100   -- arbitrary
 
@@ -892,7 +896,7 @@ byronEpochSize (SecurityParam k) =
     unEpochSlots $ kEpochSlots $ CC.Common.BlockCount k
 
 shelleyEpochSize :: SecurityParam -> Word64
-shelleyEpochSize = unEpochSize . Shelley.mkEpochSize
+shelleyEpochSize k = unEpochSize $ Shelley.mkEpochSize k activeSlotCoeff
 
 isShelley :: CardanoBlock c -> Bool
 isShelley = \case

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -367,21 +367,7 @@ prop_simple_cardano_convergence TestSetup
     tabulatePartitionDuration $
     tabulateFinalIntersectionDepth $
     tabulatePartitionPosition $
-    prop_general_semisync PropGeneralArgs
-      { pgaBlockProperty       = const $ property True
-      , pgaCountTxs            = fromIntegral . length . extractTxs
-      , pgaExpectedCannotForge = noExpectedCannotForges
-      , pgaFirstBlockNo        = 0
-      , pgaFixedMaxForkLength  = Just maxForkLength
-      , pgaFixedSchedule       =
-          -- the leader schedule isn't fixed because the Shelley leader
-          -- schedule is (at least ideally) unpredictable
-          Nothing
-      , pgaSecurityParam       = setupK
-      , pgaTestConfig          = setupTestConfig
-      , pgaTestConfigB         = testConfigB
-      }
-      testOutput .&&.
+    prop_general_semisync pga testOutput .&&.
     prop_inSync testOutput .&&.
     prop_ReachesShelley reachesShelley
   where
@@ -390,6 +376,21 @@ prop_simple_cardano_convergence TestSetup
       , numCoreNodes
       , numSlots
       } = setupTestConfig
+
+    pga = PropGeneralArgs
+        { pgaBlockProperty       = const $ property True
+        , pgaCountTxs            = fromIntegral . length . extractTxs
+        , pgaExpectedCannotForge = noExpectedCannotForges
+        , pgaFirstBlockNo        = 1
+        , pgaFixedMaxForkLength  = Just maxForkLength
+        , pgaFixedSchedule       =
+            -- the leader schedule isn't fixed because the Shelley leader
+            -- schedule is (at least ideally) unpredictable
+            Nothing
+        , pgaSecurityParam       = setupK
+        , pgaTestConfig          = setupTestConfig
+        , pgaTestConfigB         = testConfigB
+        }
 
     testConfigB = TestConfigB
       { forgeEbbEnv  = Nothing
@@ -643,7 +644,7 @@ prop_simple_cardano_convergence TestSetup
     finalIntersectionDepth :: Word64
     finalIntersectionDepth = depth
       where
-        NumBlocks depth = calcFinalIntersectionDepth testOutput
+        NumBlocks depth = calcFinalIntersectionDepth pga testOutput
 
     tabulatePartitionDuration :: Property -> Property
     tabulatePartitionDuration =

--- a/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano/test/Test/ThreadNet/Cardano.hs
@@ -138,9 +138,10 @@ instance Arbitrary TestSetup where
                 -- Shelley epoch, since stake pools can only be created and
                 -- delegated to via Shelley transactions.
                 `suchThat` ((/= 0) . Shelley.decentralizationParamToRational)
-    setupK <- SecurityParam <$> choose (4, 6)
-                -- If k < 4, common prefix violations become too likely in
-                -- Praos mode.
+    setupK <- SecurityParam <$> choose (8, 10)
+                -- If k < 8, common prefix violations become too likely in
+                -- Praos mode for thin overlay schedules (ie low d), even for
+                -- f=0.2.
 
     setupInitialNonce <- frequency
       [ (1, pure SL.NeutralNonce)
@@ -770,8 +771,14 @@ mkProtocolCardanoAndHardForkTxs
   Constants
 -------------------------------------------------------------------------------}
 
+-- | The active slot coefficient, @f@.
+--
+-- Some of these tests includes Shelley epochs in which stakepools are actually
+-- leading. In that case, the @k@, @d@, and @f@ parameters and the length of
+-- any scheduled network partitions need to be balanced so that Common Prefix
+-- violations (in particular, wedges) are extremely unlikely.
 activeSlotCoeff :: Rational
-activeSlotCoeff = 0.5
+activeSlotCoeff = 0.2   -- c.f. mainnet is more conservative, using 0.05
 
 maxMajorPVShelley :: Natural
 maxMajorPVShelley = 100   -- arbitrary

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -75,6 +75,9 @@ minK = 5   -- Less than this increases risk of CP violations
 maxK :: Word64
 maxK = 10   -- More than this wastes execution time
 
+activeSlotCoeff :: Rational
+activeSlotCoeff = 0.5   -- TODO this is high
+
 instance Arbitrary TestSetup where
   arbitrary = do
       setupD  <- arbitrary
@@ -135,7 +138,7 @@ instance Arbitrary NightlyTestSetup where
 
         -- run for multiple epochs
         factor <- choose (1, 2)
-        let t' = t + factor * unEpochSize (mkEpochSize setupK)
+        let t' = t + factor * unEpochSize (mkEpochSize setupK activeSlotCoeff)
 
         pure setup
           { setupTestConfig = setupTestConfig
@@ -290,6 +293,7 @@ prop_simple_real_tpraos_convergence TestSetup
         mkGenesisConfig
           genesisProtVer
           setupK
+          activeSlotCoeff
           setupD
           tpraosSlotLength
           (mkKesConfig (Proxy @(KES Crypto)) numSlots)


### PR DESCRIPTION
Fixes #2549 (CP violations in Cardano net). I can't predict how soon we'll see a CP violation again, but I'd suspect this change will afford us weeks -- in my local Mock Praos testing, I've never seen `k=8 f=0.2` fail during 300 slots, after >=10,000 of test runs.

So I think these numbers are worth a merge now. For example, they passed one nightly:

https://buildkite.com/input-output-hk/ouroboros-network-nightly/builds/208#872eb9dc-c494-4328-9dba-c871157739b6

We can reopen if we see similar failure relatively soon. Also, I hope to revisit once my more general related line of work converges on some extrapolatable probabilities.