### PR TITLE
Micro optimisations

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/RealPoint.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/RealPoint.hs
@@ -81,10 +81,14 @@ realPointHash :: RealPoint blk -> HeaderHash blk
 realPointHash (RealPoint _ h) = h
 
 blockRealPoint :: HasHeader blk => blk -> RealPoint blk
-blockRealPoint blk = RealPoint (blockSlot blk) (blockHash blk)
+blockRealPoint blk = RealPoint s h
+  where
+    HeaderFields { headerFieldSlot = s, headerFieldHash = h } = getHeaderFields blk
 
 headerRealPoint :: HasHeader (Header blk) => Header blk -> RealPoint blk
-headerRealPoint hdr = RealPoint (blockSlot hdr) (blockHash hdr)
+headerRealPoint hdr = RealPoint s h
+  where
+    HeaderFields { headerFieldSlot = s, headerFieldHash = h } = getHeaderFields hdr
 
 realPointToPoint :: RealPoint blk -> Point blk
 realPointToPoint (RealPoint s h) = BlockPoint s h

--- a/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
+++ b/ouroboros-network/src/Ouroboros/Network/AnchoredFragment.hs
@@ -189,7 +189,13 @@ anchorIsGenesis Anchor{}      = False
 -- In other words, this would be the block immediately /before/ the other blocks
 -- in the fragment.
 anchorFromBlock :: HasHeader block => block -> Anchor block
-anchorFromBlock b = Anchor (blockSlot b) (blockHash b) (blockNo b)
+anchorFromBlock b = Anchor sno hash bno
+  where
+    HeaderFields {
+        headerFieldSlot    = sno
+      , headerFieldBlockNo = bno
+      , headerFieldHash    = hash
+      } = getHeaderFields b
 
 -- | Compute which 'Point' this anchor corresponds to
 anchorToPoint :: Anchor block -> Point block

--- a/ouroboros-network/src/Ouroboros/Network/Block.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Block.hs
@@ -256,7 +256,9 @@ castPoint GenesisPoint           = GenesisPoint
 castPoint (BlockPoint slot hash) = BlockPoint slot (coerce hash)
 
 blockPoint :: HasHeader block => block -> Point block
-blockPoint b = Point (block (blockSlot b) (blockHash b))
+blockPoint b = Point (block s h)
+  where
+    HeaderFields { headerFieldSlot = s, headerFieldHash = h } = getHeaderFields b
 
 {-------------------------------------------------------------------------------
   Tip of a chain

--- a/ouroboros-network/test/Test/AnchoredFragment.hs
+++ b/ouroboros-network/test/Test/AnchoredFragment.hs
@@ -81,6 +81,7 @@ tests = testGroup "AnchoredFragment"
   , testProperty "filterWithStop_always_stop"         prop_filterWithStop_always_stop
   , testProperty "filterWithStop_never_stop"          prop_filterWithStop_never_stop
   , testProperty "filterWithStop"                     prop_filterWithStop
+  , testProperty "filterWithStop vs spec"             prop_filterWithStop_vs_spec
   , testProperty "filterWithStop_filter"              prop_filterWithStop_filter
   ]
 
@@ -715,6 +716,14 @@ prop_filterWithStop p stop (TestBlockAnchoredFragment_ anchor chain) =
       = reverse $ lastFrag':frags
       | otherwise
       = c ++ [stoppedFrag]
+
+prop_filterWithStop_vs_spec ::
+     (Block -> Bool)
+  -> (Block -> Bool)
+  -> TestBlockAnchoredFragment
+  -> Property
+prop_filterWithStop_vs_spec p stop (TestBlockAnchoredFragment_ _ chain) =
+    AF.filterWithStop p stop chain === AF.filterWithStopSpec p stop chain
 
 prop_filterWithStop_filter :: TestBlockAnchoredFragment -> Property
 prop_filterWithStop_filter (TestBlockAnchoredFragment chain) =

--- a/ouroboros-network/test/Test/AnchoredFragment.hs
+++ b/ouroboros-network/test/Test/AnchoredFragment.hs
@@ -60,6 +60,7 @@ tests = testGroup "AnchoredFragment"
   , testProperty "fromOldestFirst/toOldestFirst"      prop_fromOldestFirst_toOldestFirst
   , testProperty "toList/head"                        prop_toList_head
   , testProperty "toList/last"                        prop_toList_last
+  , testProperty "splitAt"                            prop_splitAt
   , testProperty "dropNewest"                         prop_dropNewest
   , testProperty "takeOldest"                         prop_takeOldest
   , testProperty "dropWhileNewest"                    prop_dropWhileNewest
@@ -128,6 +129,19 @@ prop_toList_last (TestBlockAnchoredFragment chain) =
     (headOrAnchor anchor . AF.toOldestFirst) chain == AF.last chain
   where
     anchor = AF.anchor chain
+
+prop_splitAt :: TestBlockAnchoredFragment -> Bool
+prop_splitAt (TestBlockAnchoredFragment chain) =
+    let blocks = AF.toOldestFirst chain in
+    and [ let (before,         after)         = AF.splitAt n chain
+              (beforeExpected, afterExpected) = L.splitAt  n blocks
+          in AF.toOldestFirst before == beforeExpected       &&
+             AF.toOldestFirst after  == afterExpected        &&
+             AF.anchorPoint   before == AF.anchorPoint chain &&
+             AF.headPoint     before == AF.anchorPoint after &&
+             AF.headPoint     after  == AF.headPoint   chain &&
+             AF.join before after    == Just chain
+        | n <- [0..Prelude.length blocks] ]
 
 prop_dropNewest :: TestBlockAnchoredFragment -> Bool
 prop_dropNewest (TestBlockAnchoredFragment chain) =

--- a/ouroboros-network/test/Test/AnchoredFragment.hs
+++ b/ouroboros-network/test/Test/AnchoredFragment.hs
@@ -77,7 +77,7 @@ tests = testGroup "AnchoredFragment"
   , testProperty "intersect"                          prop_intersect
   , testProperty "intersect when within bounds"       prop_intersect_bounds
   , testProperty "toChain/fromChain"                  prop_toChain_fromChain
-  , testProperty  "anchorNewest"                      prop_anchorNewest
+  , testProperty "anchorNewest"                       prop_anchorNewest
   , testProperty "filter"                             prop_filter
   , testProperty "filterWithStop_always_stop"         prop_filterWithStop_always_stop
   , testProperty "filterWithStop_never_stop"          prop_filterWithStop_never_stop

--- a/ouroboros-network/test/Test/ChainFragment.hs
+++ b/ouroboros-network/test/Test/ChainFragment.hs
@@ -78,6 +78,7 @@ tests = testGroup "ChainFragment"
   , testProperty "fromOldestFirst/toOldestFirst"             prop_fromOldestFirst_toOldestFirst
   , testProperty "toList/head"                               prop_toList_head
   , testProperty "toList/last"                               prop_toList_last
+  , testProperty "splitAt"                                   prop_splitAt
   , testProperty "dropNewest"                                prop_dropNewest
   , testProperty "dropOldest"                                prop_dropOldest
   , testProperty "takeNewest"                                prop_takeNewest
@@ -134,6 +135,16 @@ prop_toList_head (TestBlockChainFragment chain) =
 prop_toList_last :: TestBlockChainFragment -> Bool
 prop_toList_last (TestBlockChainFragment chain) =
     (listToMaybe . CF.toOldestFirst) chain == CF.last chain
+
+prop_splitAt :: TestBlockChainFragment -> Bool
+prop_splitAt (TestBlockChainFragment chain) =
+    let blocks = CF.toOldestFirst chain in
+    and [ let (before,         after)         = CF.splitAt n chain
+              (beforeExpected, afterExpected) = L.splitAt  n blocks
+          in CF.toOldestFirst before == beforeExpected &&
+             CF.toOldestFirst after  == afterExpected  &&
+             CF.joinSuccessor before after == chain
+        | n <- [0..Prelude.length blocks] ]
 
 prop_dropNewest :: TestBlockChainFragment -> Bool
 prop_dropNewest (TestBlockChainFragment chain) =


### PR DESCRIPTION
See the individual commit messages for more details.

Together, these reduce the time to sync the first 40k slots from a local `cardano-node` from ~45s to ~37s.