### PR TITLE
buildkite: fixup Nix attr for nightly slow-ThreadNet-tests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,7 @@ let
       gnuparallel = pkgs.parallel;
       glibcLocales = pkgs.glibcLocales;
 
-      Cardano    = haskellPackages.ouroboros-consensus-cardano.components.tests.test;
+      Cardano    = haskellPackages.ouroboros-consensus-cardano-test.components.tests.test;
       RealTPraos = haskellPackages.ouroboros-consensus-shelley-test.components.tests.test;
     };
 


### PR DESCRIPTION
Fixes Issue #2560.

I think this PR just needs a rubber-stamp Approval, since https://buildkite.com/input-output-hk/ouroboros-network-nightly/builds/215 validated this fixup (by 40 seconds in it has already made it farther than the failures 213 and 214, but I'll let it finish /shrug).