### PR TITLE
buildkite: stop restricting nightly ThreadNet to queue=bench

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -3,7 +3,6 @@ steps:
   - label:   'slow ThreadNet tests'
     command: '.buildkite/slow-ThreadNet-tests.sh'
     agents:
-      queue:  benchmark     # so this runs alone on a dedicated "machine"
       system: x86_64-linux
 
   - label:   'validate mainnet'


### PR DESCRIPTION
One line diff.

As advise in Slack #devops-crossteam-ci: https://input-output-rnd.slack.com/archives/CAP8NM7N0/p1598891217015200?thread_ts=1598881991.009500&cid=CAP8NM7N0

DevOps Team said let this auto-scaling job loose on the normal CI machine (not the `bench` queue), and we'll check to see if it causes any trouble (eg interferes with co-located jobs etc).