### PR TITLE
shelley-test: stop trying to generate transactions once UTxO is exhausted

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -179,78 +179,78 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: semantics/small-steps-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 2b5f688fb1823f8280ed12df110c7aa68f59363b
-  --sha256: 1801gr8v16mr88rjsq44y69awc1gk20x9pjx4xagp6fzkq4v5zmm
+  tag: 2ae53965017e18b6a02988762e5e80f07e7709ed
+  --sha256: 0a2qvknrppqpkmbhiirg3x4dzhf38xr2cs1yrhy820far5hwk70z
   subdir: shelley/chain-and-ledger/shelley-spec-ledger-test
 
 source-repository-package

--- a/stack.yaml
+++ b/stack.yaml
@@ -52,7 +52,7 @@ extra-deps:
       - slotting
 
   - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 2b5f688fb1823f8280ed12df110c7aa68f59363b
+    commit: 2ae53965017e18b6a02988762e5e80f07e7709ed
     subdirs:
       - byron/chain/executable-spec
       - byron/ledger/executable-spec


### PR DESCRIPTION
Fixes #2557. Fixes #2462.

We recently extended the length of the RealTPraos tests. This increased two probabilities, which together lead to Issue #2557:

- The probability that the total UTxO dwindles to zero during the test.
- The probability that the arbitrary Shelley transactions include a successful protocol parameter update that increase the minimum transaction fees from `A=0 B=0`.

This PR accepts the above event, and simply stops generated transactions while it appears that we cannot (cheaply) find one that the UTxO can afford.

This PR depends on the upstream PR input-output-hk/cardano-ledger-specs#1824. Thus it is Draft for now. But I think the content is simple enough to review already, so please have at it. Thanks!