### PR TITLE
Keep older ledger snapshots

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -309,7 +309,6 @@ updateLedgerSnapshots
   :: (IOLike m, LgrDbSerialiseConstraints blk)
   => ChainDbEnv m blk -> m ()
 updateLedgerSnapshots CDB{..} = do
-    -- TODO avoid taking multiple snapshots corresponding to the same tip.
     void $ LgrDB.takeSnapshot  cdbLgrDB
     void $ LgrDB.trimSnapshots cdbLgrDB
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -326,7 +326,7 @@ currentPoint = castPoint
 
 takeSnapshot :: forall m blk.
                 (IOLike m, LgrDbSerialiseConstraints blk)
-             => LgrDB m blk -> m (DiskSnapshot, Point blk)
+             => LgrDB m blk -> m (Maybe DiskSnapshot, Point blk)
 takeSnapshot lgrDB@LgrDB{ cfg, tracer, hasFS = SomeHasFS hasFS } = wrapFailure $ do
     ledgerDB <- atomically $ getCurrent lgrDB
     second withOriginRealPointToPoint <$> LedgerDB.takeSnapshot
@@ -334,6 +334,7 @@ takeSnapshot lgrDB@LgrDB{ cfg, tracer, hasFS = SomeHasFS hasFS } = wrapFailure $
       hasFS
       encodeExtLedgerState'
       (encodeRealPoint encode)
+      (LedgerDB.mkDiskSnapshot realPointSlot)
       ledgerDB
   where
     ccfg = configCodec cfg
@@ -344,7 +345,7 @@ takeSnapshot lgrDB@LgrDB{ cfg, tracer, hasFS = SomeHasFS hasFS } = wrapFailure $
                               (encodeDisk ccfg)
                               (encodeDisk ccfg)
 
-trimSnapshots :: MonadCatch m => LgrDB m blk -> m [DiskSnapshot]
+trimSnapshots :: MonadCatch m => LgrDB m blk -> m ()
 trimSnapshots LgrDB { diskPolicy, tracer, hasFS = SomeHasFS hasFS } = wrapFailure $
     LedgerDB.trimSnapshots tracer hasFS diskPolicy
 


### PR DESCRIPTION
https://github.com/input-output-hk/ouroboros-network/issues/2479

That's at a very early state, but some remarks so far:
- The filename for Genesis  is a special case. I'm using "genesis_..".
- If a slot already exists when we try to write a snapshot, we now just avoid writing it again. I think this is what this comment is refering to:
`-- TODO avoid taking multiple snapshots corresponding to the same tip.`