### PR TITLE
test: show mock chain tips instead of entire chains in failures

### DIFF
--- a/ouroboros-consensus-test/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/General.hs
@@ -408,6 +408,7 @@ noExpectedCannotForges _ _ _ = False
 prop_general ::
   forall blk.
      ( Condense blk
+     , Condense (HeaderHash blk)
      , Eq blk
      , RunNode blk
      )
@@ -435,6 +436,7 @@ data Synchronicity = SemiSync | Sync
 prop_general_semisync ::
   forall blk.
      ( Condense blk
+     , Condense (HeaderHash blk)
      , Eq blk
      , RunNode blk
      )
@@ -446,6 +448,7 @@ prop_general_semisync = prop_general_internal SemiSync
 prop_general_internal ::
   forall blk.
      ( Condense blk
+     , Condense (HeaderHash blk)
      , Eq blk
      , RunNode blk
      )
@@ -454,7 +457,7 @@ prop_general_internal ::
   -> TestOutput blk
   -> Property
 prop_general_internal syncity pga testOutput =
-    counterexample ("nodeChains: " <> unlines ("" : map (\x -> "  " <> condense x) (Map.toList nodeChains))) $
+    counterexample ("nodeChains: " <> nodeChainsString) $
     counterexample ("nodeJoinPlan: " <> condense nodeJoinPlan) $
     counterexample ("nodeRestarts: " <> condense nodeRestarts) $
     counterexample ("nodeTopology: " <> condense nodeTopology) $
@@ -622,6 +625,12 @@ prop_general_internal syncity pga testOutput =
     nodeChains    = nodeOutputFinalChain <$> testOutputNodes
     nodeOutputDBs = nodeOutputNodeDBs    <$> testOutputNodes
     nodeUpdates   = nodeOutputUpdates    <$> testOutputNodes
+
+    nodeChainsString :: String
+    nodeChainsString =
+        unlines $ ("" :) $
+        map (\x -> "  " <> condense x) $
+        Map.toList $ fmap MockChain.headTip nodeChains
 
     isConsensusExpected :: Bool
     isConsensusExpected = consensusExpected k nodeJoinPlan schedule

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util.hs
@@ -61,12 +61,12 @@ import           Test.ThreadNet.Util.NodeJoinPlan (NodeJoinPlan)
 shortestLength :: Map NodeId (Chain b) -> Natural
 shortestLength = fromIntegral . minimum . map Chain.length . Map.elems
 
-prop_all_common_prefix :: (HasHeader b, Condense b, Eq b)
+prop_all_common_prefix :: (HasHeader b, Condense (HeaderHash b), Eq b)
                        => Word64 -> [Chain b] -> Property
 prop_all_common_prefix _ []     = property True
 prop_all_common_prefix l (c:cs) = conjoin [prop_common_prefix l c d | d <- cs]
 
-prop_common_prefix :: forall b. (HasHeader b, Condense b, Eq b)
+prop_common_prefix :: forall b. (HasHeader b, Condense (HeaderHash b), Eq b)
                    => Word64 -> Chain b -> Chain b -> Property
 prop_common_prefix l x y = go x y .&&. go y x
   where
@@ -91,14 +91,10 @@ prop_common_prefix l x y = go x y .&&. go y x
                               in  (l' + 1, c'')
 
     showChain :: Chain b -> String
-    showChain c = condense c
+    showChain c = condense (Chain.headTip c)
                   <> "\n(length "
                   <> show (Chain.length c)
-                  <> case Chain.lastSlot c of
-                        Nothing -> ")"
-                        Just s  ->    ", last slot "
-                                   <> show (unSlotNo s)
-                                   <> ")"
+                  <> ")"
 
 -- | Find the common prefix of two chains
 chainCommonPrefix :: HasHeader b => Chain b -> Chain b -> Chain b

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -74,6 +74,7 @@ import           Ouroboros.Consensus.Ledger.SupportsMempool
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (allEqual)
 import           Ouroboros.Consensus.Util.Assert
+import           Ouroboros.Consensus.Util.Condense (Condense (..))
 import           Ouroboros.Consensus.Util.OptNP (OptNP)
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
@@ -134,6 +135,9 @@ newtype OneEraHash (xs :: [k]) = OneEraHash { getOneEraHash :: ShortByteString }
 
 instance Show (OneEraHash xs) where
   show = BSC.unpack . B16.encode . Short.fromShort . getOneEraHash
+
+instance Condense (OneEraHash xs) where
+  condense = show
 
 {-------------------------------------------------------------------------------
   Value for two /different/ eras

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -44,7 +44,7 @@ import qualified Ouroboros.Consensus.Util.HList as HList
 import           Cardano.Slotting.Block (BlockNo (..))
 import           Cardano.Slotting.Slot (EpochNo (..), SlotNo (..),
                      WithOrigin (..))
-import           Ouroboros.Network.Block (ChainHash (..), HeaderHash)
+import           Ouroboros.Network.Block (ChainHash (..), HeaderHash, Tip (..))
 
 {-------------------------------------------------------------------------------
   Main class
@@ -159,6 +159,11 @@ instance Condense EpochNo where
 instance Condense (HeaderHash b) => Condense (ChainHash b) where
   condense GenesisHash   = "genesis"
   condense (BlockHash h) = condense h
+
+instance Condense (HeaderHash b) => Condense (Tip b) where
+  condense TipGenesis       = "genesis"
+  condense (Tip slot h bno) =
+      "b" <> condense bno <> "-s" <> condense slot <> "-h" <> condense h
 
 instance Condense a => Condense (WithOrigin a) where
   condense Origin = "origin"


### PR DESCRIPTION
Some of our failures now include hundreds of blocks. 'show' for hundreds of
blocks for each of 2-5 nodes creates hundreds of megabytes of output, most of
which is entirely useless. That much output makes the logs difficult to
interpret and unnecessarily bloats the artifacts from the nightly build run.

If that info is actually required for a debugging session, the unlucky dev can
revert this commit. (Though I would recommend projecting out the relevant parts
of the blocks and/or subarrays of the chain instead of dumping the whole
thing.)