### PR TITLE
Trace the success cases of block forging

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -146,13 +146,19 @@ showTracers tr = Tracers
 --
 -- > TraceStartLeadershipCheck
 -- >          |
+-- >          +--- TraceSlotIsImmutable (leadership check failed)
+-- >          |
 -- >          +--- TraceBlockFromFuture (leadership check failed)
 -- >          |
--- >          +--- TraceSlotIsImmutable (leadership check failed)
+-- >  TraceBlockContext
 -- >          |
 -- >          +--- TraceNoLedgerState (leadership check failed)
 -- >          |
+-- >   TraceLedgerState
+-- >          |
 -- >          +--- TraceNoLedgerView (leadership check failed)
+-- >          |
+-- >   TraceLedgerView
 -- >          |
 -- >          +--- TraceForgeStateUpdateError (leadership check failed)
 -- >          |
@@ -170,124 +176,138 @@ showTracers tr = Tracers
 -- >          |
 -- >  TraceAdoptedBlock
 data TraceForgeEvent blk
-  -- | Start of the leadership check
-  --
-  -- We record the current slot number.
-  --
-  -- This event terminates with one of the following concluding trace messages:
-  --
-  -- * TraceNodeNotLeader if we are not the leader
-  -- * TraceNodeIsLeader if we are the leader
-  -- * TraceBlockFromFuture (rarely)
-  -- * TraceSlotIsImmutable (leadership check failed)
-  -- * TraceNoLedgerState (rarely)
-  -- * TraceNoLedgerView (rarely)
+    -- | Start of the leadership check
+    --
+    -- We record the current slot number.
   = TraceStartLeadershipCheck SlotNo
 
-  -- | We did the leadership check and concluded we are not the leader
-  --
-  -- We record the current slot number
-  | TraceNodeNotLeader SlotNo
-
-  -- | Updating the forge state failed.
-  --
-  -- For example, the KES key could not be evolved anymore.
-  --
-  -- We record the error returned by 'updateForgeState'.
-  | TraceForgeStateUpdateError SlotNo (ForgeStateUpdateError blk)
-
-  -- | We did the leadership check and concluded that we should lead and forge
-  -- a block, but cannot
-  --
-  -- This should only happen rarely and should be logged with warning severity.
-  --
-  -- Records why we cannot forge a block.
-  | TraceNodeCannotForge SlotNo (CannotForge blk)
-
-  -- | Leadership check failed: we were unable to get the ledger state
-  -- for the point of the block we want to connect to
-  --
-  -- This can happen if after choosing which block to connect to the node
-  -- switched to a different fork. We expect this to happen only rather rarely,
-  -- so this certainly merits a warning; if it happens a lot, that merits an
-  -- investigation.
-  --
-  -- We record both the current slot number as well as the point of the block
-  -- we attempt to connect the new block to (that we requested the ledger state
-  -- for).
-  | TraceNoLedgerState SlotNo (Point blk)
-
-  -- | Leadership check failed: we were unable to get the ledger view for the
-  -- current slot number
-  --
-  -- This will only happen if there are many missing blocks between the tip of
-  -- our chain and the current slot.
-  --
-  -- We record also the failure returned by 'forecastFor'.
-  | TraceNoLedgerView SlotNo OutsideForecastRange
-
-  -- | Leadership check failed: the current chain contains a block from a slot
-  -- /after/ the current slot
-  --
-  -- This can only happen if the system is under heavy load.
-  --
-  -- We record both the current slot number as well as the slot number of the
-  -- block at the tip of the chain.
-  --
-  -- See also <https://github.com/input-output-hk/ouroboros-network/issues/1462>
-  | TraceBlockFromFuture SlotNo SlotNo
-
-  -- | Leadership check failed: the tip of the ImmDB inhabits the current slot
-  --
-  -- This might happen in two cases.
-  --
-  --  1. the clock moved backwards, on restart we ignored everything from the
-  --     VolatileDB since it's all in the future, and now the tip of the
-  --     ImmutableDB points to a block produced in the same slot we're trying
-  --     to produce a block in
-  --
-  --  2. k = 0 and we already adopted a block from another leader of the same
-  --     slot.
-  --
-  -- We record both the current slot number as well as the tip of the ImmDB.
-  --
-  -- See also <https://github.com/input-output-hk/ouroboros-network/issues/1462>
+    -- | Leadership check failed: the tip of the ImmDB inhabits the current slot
+    --
+    -- This might happen in two cases.
+    --
+    --  1. the clock moved backwards, on restart we ignored everything from the
+    --     VolatileDB since it's all in the future, and now the tip of the
+    --     ImmutableDB points to a block produced in the same slot we're trying
+    --     to produce a block in
+    --
+    --  2. k = 0 and we already adopted a block from another leader of the same
+    --     slot.
+    --
+    -- We record both the current slot number as well as the tip of the ImmDB.
+    --
+    -- See also <https://github.com/input-output-hk/ouroboros-network/issues/1462>
   | TraceSlotIsImmutable SlotNo (Point blk) BlockNo
 
-  -- | We did the leadership check and concluded we /are/ the leader
-  --
-  -- The node will soon forge; it is about to read its transactions and
-  -- current DB. This will be followed by TraceForgedBlock.
+    -- | Leadership check failed: the current chain contains a block from a slot
+    -- /after/ the current slot
+    --
+    -- This can only happen if the system is under heavy load.
+    --
+    -- We record both the current slot number as well as the slot number of the
+    -- block at the tip of the chain.
+    --
+    -- See also <https://github.com/input-output-hk/ouroboros-network/issues/1462>
+  | TraceBlockFromFuture SlotNo SlotNo
+
+    -- | We found out to which block we are going to connect the block we are about
+    -- to forge.
+    --
+    -- We record the current slot number, the block number of the block to
+    -- connect to and its point.
+    --
+    -- Note that block number of the block we will try to forge is one more than
+    -- the recorded block number.
+  | TraceBlockContext SlotNo BlockNo (Point blk)
+
+    -- | Leadership check failed: we were unable to get the ledger state for the
+    -- point of the block we want to connect to
+    --
+    -- This can happen if after choosing which block to connect to the node
+    -- switched to a different fork. We expect this to happen only rather
+    -- rarely, so this certainly merits a warning; if it happens a lot, that
+    -- merits an investigation.
+    --
+    -- We record both the current slot number as well as the point of the block
+    -- we attempt to connect the new block to (that we requested the ledger
+    -- state for).
+  | TraceNoLedgerState SlotNo (Point blk)
+
+    -- | We obtained a ledger state for the point of the block we want to
+    -- connect to
+    --
+    -- We record both the current slot number as well as the point of the block
+    -- we attempt to connect the new block to (that we requested the ledger
+    -- state for).
+  | TraceLedgerState SlotNo (Point blk)
+
+    -- | Leadership check failed: we were unable to get the ledger view for the
+    -- current slot number
+    --
+    -- This will only happen if there are many missing blocks between the tip of
+    -- our chain and the current slot.
+    --
+    -- We record also the failure returned by 'forecastFor'.
+  | TraceNoLedgerView SlotNo OutsideForecastRange
+
+    -- | We obtained a ledger view for the current slot number
+    --
+    -- We record the current slot number.
+  | TraceLedgerView SlotNo
+
+    -- | Updating the forge state failed.
+    --
+    -- For example, the KES key could not be evolved anymore.
+    --
+    -- We record the error returned by 'updateForgeState'.
+  | TraceForgeStateUpdateError SlotNo (ForgeStateUpdateError blk)
+
+    -- | We did the leadership check and concluded that we should lead and forge
+    -- a block, but cannot.
+    --
+    -- This should only happen rarely and should be logged with warning severity.
+    --
+    -- Records why we cannot forge a block.
+  | TraceNodeCannotForge SlotNo (CannotForge blk)
+
+    -- | We did the leadership check and concluded we are not the leader
+    --
+    -- We record the current slot number
+  | TraceNodeNotLeader SlotNo
+
+    -- | We did the leadership check and concluded we /are/ the leader
+    --
+    -- The node will soon forge; it is about to read its transactions from the
+    -- Mempool. This will be followed by TraceForgedBlock.
   | TraceNodeIsLeader SlotNo
 
-  -- | We forged a block
-  --
-  -- We record the current slot number, the point of the predecessor, the block
-  -- itself, and the total size of the mempool snapshot at the time we produced
-  -- the block (which may be significantly larger than the block, due to
-  -- maximum block size)
-  --
-  -- This will be followed by one of three messages:
-  --
-  -- * TraceAdoptedBlock (normally)
-  -- * TraceDidntAdoptBlock (rarely)
-  -- * TraceForgedInvalidBlock (hopefully never -- this would indicate a bug)
+    -- | We forged a block
+    --
+    -- We record the current slot number, the point of the predecessor, the block
+    -- itself, and the total size of the mempool snapshot at the time we produced
+    -- the block (which may be significantly larger than the block, due to
+    -- maximum block size)
+    --
+    -- This will be followed by one of three messages:
+    --
+    -- * TraceAdoptedBlock (normally)
+    -- * TraceDidntAdoptBlock (rarely)
+    -- * TraceForgedInvalidBlock (hopefully never -- this would indicate a bug)
   | TraceForgedBlock SlotNo (Point blk) blk MempoolSize
 
-  -- | We adopted the block we produced, we also trace the transactions
-  -- that were adopted.
-  | TraceAdoptedBlock SlotNo blk [GenTx blk]
-
-  -- | We did not adopt the block we produced, but the block was valid. We
-  -- must have adopted a block that another leader of the same slot produced
-  -- before we got the chance of adopting our own block. This is very rare,
-  -- this warrants a warning.
+    -- | We did not adopt the block we produced, but the block was valid. We
+    -- must have adopted a block that another leader of the same slot produced
+    -- before we got the chance of adopting our own block. This is very rare,
+    -- this warrants a warning.
   | TraceDidntAdoptBlock SlotNo blk
 
-  -- | We forged a block that is invalid according to the ledger in the
-  -- ChainDB. This means there is an inconsistency between the mempool
-  -- validation and the ledger validation. This is a serious error!
+    -- | We forged a block that is invalid according to the ledger in the
+    -- ChainDB. This means there is an inconsistency between the mempool
+    -- validation and the ledger validation. This is a serious error!
   | TraceForgedInvalidBlock SlotNo blk (InvalidBlockReason blk)
+
+    -- | We adopted the block we produced, we also trace the transactions
+    -- that were adopted.
+  | TraceAdoptedBlock SlotNo blk [GenTx blk]
 
 deriving instance ( LedgerSupportsProtocol blk
                   , Eq blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -308,6 +308,8 @@ forkBlockForging maxTxCapacityOverride IS{..} blockForging =
               trace failure
               exitEarly
 
+        trace $ TraceBlockContext currentSlot bcBlockNo bcPrevPoint
+
         -- Get ledger state corresponding to bcPrevPoint
         --
         -- This might fail if, in between choosing 'bcPrevPoint' and this call to
@@ -321,6 +323,8 @@ forkBlockForging maxTxCapacityOverride IS{..} blockForging =
             Nothing -> do
               trace $ TraceNoLedgerState currentSlot bcPrevPoint
               exitEarly
+
+        trace $ TraceLedgerState currentSlot bcPrevPoint
 
         -- Check if we are not too far ahead of the chain
         --
@@ -343,6 +347,8 @@ forkBlockForging maxTxCapacityOverride IS{..} blockForging =
             exitEarly
           Right _ ->
             return ()
+
+        trace $ TraceLedgerView currentSlot
 
         -- Tick the ledger state for the 'SlotNo' we're producing a block for
         let ticked = applyChainTick


### PR DESCRIPTION
If another chain freeze event (CAD-1747) ever reoccurs, this will help with
find out where in the forge process it went wrong.

Reorder the constructors of `TraceForgeEvent` so that they are in the same order
as the flowchart in the docstring. Indent them correctly.