### PR TITLE
Refactor ledger config

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -90,19 +90,17 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params mLeader =
             topLevelConfigProtocol = PBftConfig {
                 pbftParams = params
               }
-          , topLevelConfigBlock = FullBlockConfig {
-                blockConfigLedger = DualLedgerConfig {
-                    dualLedgerConfigMain = concreteGenesis
-                  , dualLedgerConfigAux  = abstractConfig
-                  }
-              , blockConfigBlock = DualBlockConfig {
-                    dualBlockConfigMain = concreteConfig
-                  , dualBlockConfigAux  = ByronSpecBlockConfig
-                  }
-              , blockConfigCodec = DualCodecConfig {
-                    dualCodecConfigMain = mkByronCodecConfig concreteGenesis
-                  , dualCodecConfigAux  = ByronSpecCodecConfig
-                  }
+          , topLevelConfigLedger = DualLedgerConfig {
+                dualLedgerConfigMain = concreteGenesis
+              , dualLedgerConfigAux  = abstractConfig
+              }
+          , topLevelConfigBlock = DualBlockConfig {
+                dualBlockConfigMain = concreteConfig
+              , dualBlockConfigAux  = ByronSpecBlockConfig
+              }
+          , topLevelConfigCodec = DualCodecConfig {
+                dualCodecConfigMain = mkByronCodecConfig concreteGenesis
+              , dualCodecConfigAux  = ByronSpecCodecConfig
               }
           }
       , pInfoInitLedger = ExtLedgerState {

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -5,9 +5,9 @@ module Test.Consensus.Byron.Examples (
     -- * Setup
     secParam
   , windowSize
-  , CC.dummyConfig
   , cfg
   , codecConfig
+  , ledgerConfig
   , leaderCredentials
     -- * Examples
   , examples
@@ -83,12 +83,8 @@ cfg = ByronConfig {
 codecConfig :: CodecConfig ByronBlock
 codecConfig = mkByronCodecConfig CC.dummyConfig
 
-fullBlockConfig :: FullBlockConfig (LedgerState ByronBlock) ByronBlock
-fullBlockConfig = FullBlockConfig {
-      blockConfigLedger = CC.dummyConfig
-    , blockConfigBlock  = cfg
-    , blockConfigCodec  = codecConfig
-    }
+ledgerConfig :: LedgerConfig ByronBlock
+ledgerConfig = CC.dummyConfig
 
 leaderCredentials :: ByronLeaderCredentials
 leaderCredentials =
@@ -131,7 +127,7 @@ exampleBlock =
       cfg
       (BlockNo 1)
       (SlotNo 1)
-      (applyChainTick CC.dummyConfig (SlotNo 1) ledgerStateAfterEBB)
+      (applyChainTick ledgerConfig (SlotNo 1) ledgerStateAfterEBB)
       [exampleGenTx]
       (fakeMkIsLeader leaderCredentials)
   where
@@ -199,18 +195,18 @@ emptyLedgerState = ByronLedgerState {
   where
     initState :: CC.Block.ChainValidationState
     Right initState = runExcept $
-      CC.Block.initialChainValidationState CC.dummyConfig
+      CC.Block.initialChainValidationState ledgerConfig
 
 ledgerStateAfterEBB :: LedgerState ByronBlock
 ledgerStateAfterEBB =
-      reapplyLedgerBlock fullBlockConfig exampleEBB
-    . applyChainTick CC.dummyConfig (SlotNo 0)
+      reapplyLedgerBlock ledgerConfig exampleEBB
+    . applyChainTick ledgerConfig (SlotNo 0)
     $ emptyLedgerState
 
 exampleLedgerState :: LedgerState ByronBlock
 exampleLedgerState =
-      reapplyLedgerBlock fullBlockConfig exampleBlock
-    . applyChainTick CC.dummyConfig (SlotNo 1)
+      reapplyLedgerBlock ledgerConfig exampleBlock
+    . applyChainTick ledgerConfig (SlotNo 1)
     $ ledgerStateAfterEBB
 
 exampleHeaderState :: HeaderState ByronBlock
@@ -234,7 +230,7 @@ exampleGenTxId :: TxId (GenTx ByronBlock)
 exampleGenTxId = ByronTxId CC.exampleTxId
 
 exampleUPIState :: CC.UPI.State
-exampleUPIState = CC.UPI.initialState CC.dummyConfig
+exampleUPIState = CC.UPI.initialState ledgerConfig
 
 exampleApplyTxErr :: CC.ApplyMempoolPayloadErr
 exampleApplyTxErr =

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
@@ -221,14 +221,13 @@ instance HasHeader (Header ByronBlock) where
       }
 
 instance GetPrevHash ByronBlock where
-  headerPrevHash cfg = fromByronPrevHash cfg . CC.abobHdrPrevHash . byronHeaderRaw
+  headerPrevHash = fromByronPrevHash . CC.abobHdrPrevHash . byronHeaderRaw
 
 instance Measured BlockMeasure ByronBlock where
   measure = blockMeasure
 
-fromByronPrevHash :: CodecConfig ByronBlock
-                  -> Maybe CC.HeaderHash -> ChainHash ByronBlock
-fromByronPrevHash _cfg = \case
+fromByronPrevHash :: Maybe CC.HeaderHash -> ChainHash ByronBlock
+fromByronPrevHash = \case
     Nothing -> GenesisHash
     Just h  -> BlockHash (ByronHash h)
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -292,7 +292,7 @@ validationErrorImpossible = cantBeError . runExcept
 -------------------------------------------------------------------------------}
 
 applyByronBlock :: CC.ValidationMode
-                -> FullBlockConfig (LedgerState ByronBlock) ByronBlock
+                -> LedgerConfig ByronBlock
                 -> ByronBlock
                 -> TickedLedgerState ByronBlock
                 -> Except (LedgerError ByronBlock) (LedgerState ByronBlock)
@@ -301,10 +301,8 @@ applyByronBlock validationMode
                 (ByronBlock blk _ (ByronHash blkHash))
                 ls =
     case blk of
-      CC.ABOBBlock    blk' -> applyABlock validationMode lcfg blk' blkHash ls
-      CC.ABOBBoundary blk' -> applyABoundaryBlock        lcfg blk'         ls
-  where
-    lcfg = blockConfigLedger cfg
+      CC.ABOBBlock    blk' -> applyABlock validationMode cfg blk' blkHash ls
+      CC.ABOBBoundary blk' -> applyABoundaryBlock        cfg blk'         ls
 
 applyABlock :: CC.ValidationMode
             -> Gen.Config

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -161,11 +161,9 @@ protocolInfoByron genesisConfig mSigThresh pVer sVer mLeader =
             topLevelConfigProtocol = PBftConfig {
                 pbftParams = byronPBftParams compactedGenesisConfig mSigThresh
               }
-          , topLevelConfigBlock = FullBlockConfig {
-                blockConfigLedger = compactedGenesisConfig
-              , blockConfigBlock  = mkByronConfig compactedGenesisConfig pVer sVer
-              , blockConfigCodec  = mkByronCodecConfig compactedGenesisConfig
-              }
+          , topLevelConfigLedger = compactedGenesisConfig
+          , topLevelConfigBlock  = mkByronConfig compactedGenesisConfig pVer sVer
+          , topLevelConfigCodec  = mkByronCodecConfig compactedGenesisConfig
           }
       , pInfoInitLedger = ExtLedgerState {
             -- Important: don't pass the compacted genesis config to

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
@@ -92,7 +92,7 @@ instance HasHeader ByronSpecHeader where
       }
 
 instance GetPrevHash ByronSpecBlock where
-  headerPrevHash _cfg = fromByronSpecPrevHash id . Spec._bhPrevHash . byronSpecHeader
+  headerPrevHash = fromByronSpecPrevHash id . Spec._bhPrevHash . byronSpecHeader
 
 {-------------------------------------------------------------------------------
   Config

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -27,7 +27,6 @@ import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Control.State.Transition as Spec
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.CommonProtocolParams
 import           Ouroboros.Consensus.Ticked
@@ -127,7 +126,7 @@ instance ApplyBlock (LedgerState ByronSpecBlock) ByronSpecBlock where
         -- it is idempotent. If we wanted to avoid the repeated tick, we would
         -- have to call the subtransitions of CHAIN (except for ticking).
         Rules.liftCHAIN
-          (blockConfigLedger cfg)
+          cfg
           (byronSpecBlock block)
           state
 

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
@@ -144,7 +144,7 @@ injExamplesShelley Golden.Examples {..} = Golden.Examples {
       ]
 
 byronEraParams :: History.EraParams
-byronEraParams = Byron.byronEraParams History.NoLowerBound Byron.dummyConfig
+byronEraParams = Byron.byronEraParams History.NoLowerBound Byron.ledgerConfig
 
 shelleyEraParams :: History.EraParams
 shelleyEraParams = Shelley.shelleyEraParams Shelley.testShelleyGenesis

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -73,7 +73,7 @@ instance CardanoHardForkConstraints c => TxGen (CardanoBlock c) where
   testGenTxs (CoreNodeId i) _ncn curSlot cfg extra ls =
       pure $ maybeToList $ migrateUTxO migrationInfo curSlot lcfg ls
     where
-      lcfg = blockConfigLedger $ topLevelConfigBlock cfg
+      lcfg = topLevelConfigLedger cfg
 
       CardanoTxGenExtra
         { ctgeByronGenesisKeys

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
@@ -24,7 +24,6 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
-import           Numeric.Natural (Natural)
 
 import           Test.QuickCheck
 import           Test.Tasty
@@ -646,7 +645,7 @@ prop_simple_cardano_convergence TestSetup
               genesisShelley
               -- Suitable only for this narrow context
               (fixedSizeEpochInfo epochSizeShelley)
-              maxMajorPVShelley
+              (getMaxMajorProtVer maxMajorPVShelley)
 
         genesisKeyHashes =
             Set.fromList $
@@ -805,8 +804,8 @@ mkProtocolCardanoAndHardForkTxs
 activeSlotCoeff :: Rational
 activeSlotCoeff = 0.2   -- c.f. mainnet is more conservative, using 0.05
 
-maxMajorPVShelley :: Natural
-maxMajorPVShelley = 100   -- arbitrary
+maxMajorPVShelley :: MaxMajorProtVer
+maxMajorPVShelley = MaxMajorProtVer 100   -- arbitrary
 
 -- | The major protocol version of Byron in this test
 --

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -30,8 +30,6 @@ module Ouroboros.Consensus.Cardano (
 import           Data.Kind (Type)
 import           Data.Type.Equality
 
-import           Cardano.Prelude (Natural)
-
 import qualified Cardano.Chain.Genesis as Genesis
 import           Cardano.Chain.Slotting (EpochSlots)
 import qualified Cardano.Chain.Update as Update
@@ -99,7 +97,7 @@ data Protocol (m :: Type -> Type) blk p where
        -- WARNING: chains using different values of this parameter will be
        -- mutually incompatible.
     -> ProtVer
-    -> Natural -- ^ Max major protocol version
+    -> MaxMajorProtVer
     -> Maybe (TPraosLeaderCredentials StandardShelley)
     -> Protocol m (ShelleyBlockHFC StandardShelley) ProtocolShelley
 
@@ -120,7 +118,7 @@ data Protocol (m :: Type -> Type) blk p where
        -- WARNING: chains using different values of this parameter will be
        -- mutually incompatible.
     -> ProtVer -- TODO unify with 'Update.ProtocolVersion' (2 vs 3 numbers)
-    -> Natural -- ^ Max major protocol version
+    -> MaxMajorProtVer
     -> Maybe (TPraosLeaderCredentials StandardShelley)
        -- Hard fork
     -> Maybe EpochNo

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -17,6 +17,7 @@ module Ouroboros.Consensus.Cardano.Node (
     protocolInfoCardano
   , protocolClientInfoCardano
   , CardanoHardForkConstraints
+  , MaxMajorProtVer (..)
   , TriggerHardFork (..)
   , initialLedgerStateCardano
   , ledgerConfigCardano
@@ -42,7 +43,7 @@ import           Cardano.Binary (DecoderError (..), enforceSize)
 import qualified Cardano.Chain.Genesis as Byron.Genesis
 import           Cardano.Chain.Slotting (EpochSlots)
 import qualified Cardano.Chain.Update as Byron.Update
-import           Cardano.Prelude (Natural, cborError)
+import           Cardano.Prelude (cborError)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -73,8 +74,8 @@ import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
 import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
 import           Ouroboros.Consensus.Shelley.Node
-import           Ouroboros.Consensus.Shelley.Protocol (TPraosCrypto,
-                     TPraosParams (..))
+import           Ouroboros.Consensus.Shelley.Protocol (MaxMajorProtVer (..),
+                     TPraosCrypto, TPraosParams (..))
 import qualified Ouroboros.Consensus.Shelley.Protocol as Shelley
 
 import           Ouroboros.Consensus.Cardano.Block
@@ -269,7 +270,7 @@ protocolInfoCardano
      -- ^ The initial nonce for the Shelley era, typically derived from the
      -- hash of Shelley Genesis config JSON file.
   -> ProtVer
-  -> Natural
+  -> MaxMajorProtVer
   -> Maybe (TPraosLeaderCredentials (ShelleyEra c))
      -- Hard fork
   -> Maybe EpochNo  -- ^ lower bound on first Shelley epoch
@@ -321,7 +322,11 @@ protocolInfoCardano genesisByron mSigThresh pVer sVer mbCredsByron
     -- Shelley
 
     tpraosParams :: TPraosParams
-    tpraosParams = Shelley.mkTPraosParams maxMajorPV initialNonce genesisShelley
+    tpraosParams =
+        Shelley.mkTPraosParams
+          maxMajorPV
+          initialNonce
+          genesisShelley
 
     blockConfigShelley :: BlockConfig (ShelleyBlock (ShelleyEra c))
     blockConfigShelley =
@@ -336,7 +341,9 @@ protocolInfoCardano genesisByron mSigThresh pVer sVer mbCredsByron
 
     partialLedgerConfigShelley :: PartialLedgerConfig (ShelleyBlock (ShelleyEra c))
     partialLedgerConfigShelley =
-        mkPartialLedgerConfigShelley genesisShelley maxMajorPV
+        mkPartialLedgerConfigShelley
+          genesisShelley
+          maxMajorPV
 
     kShelley :: SecurityParam
     kShelley = SecurityParam $ sgSecurityParam genesisShelley
@@ -445,7 +452,7 @@ ledgerConfigCardano ::
 
      -- Shelley
   -> ShelleyGenesis (ShelleyEra c)
-  -> Natural  -- ^ Max major protocol version
+  -> MaxMajorProtVer
 
      -- Hard fork
   -> TriggerHardFork
@@ -483,7 +490,9 @@ ledgerConfigCardano genesisByron
 
     partialLedgerConfigShelley :: PartialLedgerConfig (ShelleyBlock (ShelleyEra c))
     partialLedgerConfigShelley =
-        mkPartialLedgerConfigShelley genesisShelley maxMajorPV
+        mkPartialLedgerConfigShelley
+          genesisShelley
+          maxMajorPV
 
     -- Cardano
 
@@ -502,7 +511,7 @@ ledgerConfigCardano genesisByron
 
 mkPartialLedgerConfigShelley ::
      ShelleyGenesis (ShelleyEra c)
-  -> Natural  -- ^ Max major protocol version
+  -> MaxMajorProtVer
   -> PartialLedgerConfig (ShelleyBlock (ShelleyEra c))
 mkPartialLedgerConfigShelley genesisShelley maxMajorPV =
     ShelleyPartialLedgerConfig $

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -243,9 +243,7 @@ instance CardanoHardForkConstraints c => RunNode (CardanoBlock c) where
     where
       TopLevelConfig {
           topLevelConfigProtocol = CardanoConsensusConfig _ shelleyPartialConsensusCfg
-        , topLevelConfigBlock = FullBlockConfig {
-              blockConfigBlock = CardanoBlockConfig byronBlockCfg _
-            }
+        , topLevelConfigBlock    = CardanoBlockConfig byronBlockCfg _
         } = cfg
 
       TPraosParams { tpraosSlotsPerKESPeriod } = shelleyPartialConsensusCfg
@@ -294,10 +292,8 @@ protocolInfoCardano genesisByron mSigThresh pVer sVer mbCredsByron
     ProtocolInfo {
         pInfoConfig = topLevelConfigByron@TopLevelConfig {
             topLevelConfigProtocol = consensusConfigByron
-          , topLevelConfigBlock = FullBlockConfig {
-                blockConfigLedger = ledgerConfigByron
-              , blockConfigBlock  = blockConfigByron
-              }
+          , topLevelConfigLedger   = ledgerConfigByron
+          , topLevelConfigBlock    = blockConfigByron
           }
       , pInfoInitLedger = ExtLedgerState {
             ledgerState = initLedgerStateByron
@@ -373,25 +369,23 @@ protocolInfoCardano genesisByron mSigThresh pVer sVer mbCredsByron
               :* Nil
               )
           }
-      , topLevelConfigBlock = FullBlockConfig {
-            blockConfigLedger = HardForkLedgerConfig {
-                hardForkLedgerConfigK      = k
-              , hardForkLedgerConfigShape  = shape
-              , hardForkLedgerConfigPerEra = PerEraLedgerConfig
-                  (  WrapPartialLedgerConfig partialLedgerConfigByron
-                  :* WrapPartialLedgerConfig partialLedgerConfigShelley
-                  :* Nil
-                  )
-              }
-          , blockConfigBlock =
-              CardanoBlockConfig
-                blockConfigByron
-                blockConfigShelley
-          , blockConfigCodec =
-              CardanoCodecConfig
-                (configCodec topLevelConfigByron)
-                Shelley.ShelleyCodecConfig
+      , topLevelConfigLedger = HardForkLedgerConfig {
+            hardForkLedgerConfigK      = k
+          , hardForkLedgerConfigShape  = shape
+          , hardForkLedgerConfigPerEra = PerEraLedgerConfig
+              (  WrapPartialLedgerConfig partialLedgerConfigByron
+              :* WrapPartialLedgerConfig partialLedgerConfigShelley
+              :* Nil
+              )
           }
+      , topLevelConfigBlock =
+          CardanoBlockConfig
+            blockConfigByron
+            blockConfigShelley
+      , topLevelConfigCodec =
+          CardanoCodecConfig
+            (configCodec topLevelConfigByron)
+            Shelley.ShelleyCodecConfig
       }
 
     blockForging :: Maybe (m (BlockForging m (CardanoBlock c)))
@@ -449,19 +443,15 @@ projByronTopLevelConfig cfg = byronCfg
   where
     TopLevelConfig {
         topLevelConfigProtocol = CardanoConsensusConfig byronConsensusCfg _
-      , topLevelConfigBlock = FullBlockConfig {
-            blockConfigBlock  = CardanoBlockConfig  byronBlockCfg  _
-          , blockConfigLedger = CardanoLedgerConfig byronLedgerCfg _
-          , blockConfigCodec  = CardanoCodecConfig  byronCodecCfg  _
-          }
+      , topLevelConfigLedger   = CardanoLedgerConfig    byronLedgerCfg _
+      , topLevelConfigBlock    = CardanoBlockConfig     byronBlockCfg  _
+      , topLevelConfigCodec    = CardanoCodecConfig     byronCodecCfg  _
       } = cfg
 
     byronCfg :: TopLevelConfig ByronBlock
     byronCfg = TopLevelConfig {
         topLevelConfigProtocol = byronConsensusCfg
-      , topLevelConfigBlock = FullBlockConfig {
-            blockConfigBlock  = byronBlockCfg
-          , blockConfigLedger = byronLedgerConfig byronLedgerCfg
-          , blockConfigCodec  = byronCodecCfg
-          }
+      , topLevelConfigLedger   = byronLedgerConfig byronLedgerCfg
+      , topLevelConfigBlock    = byronBlockCfg
+      , topLevelConfigCodec    = byronCodecCfg
       }

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -39,9 +39,9 @@ import           Data.SOP.Strict (NP (..), hd, unK)
 import           Data.Word (Word16)
 
 import           Cardano.Binary (DecoderError (..), enforceSize)
-import qualified Cardano.Chain.Genesis as Genesis
+import qualified Cardano.Chain.Genesis as Byron.Genesis
 import           Cardano.Chain.Slotting (EpochSlots)
-import qualified Cardano.Chain.Update as Update
+import qualified Cardano.Chain.Update as Byron.Update
 import           Cardano.Prelude (Natural, cborError)
 
 import           Ouroboros.Consensus.Block
@@ -258,10 +258,10 @@ instance CardanoHardForkConstraints c => RunNode (CardanoBlock c) where
 protocolInfoCardano
   :: forall c m. (IOLike m, CardanoHardForkConstraints c)
      -- Byron
-  => Genesis.Config
+  => Byron.Genesis.Config
   -> Maybe PBftSignatureThreshold
-  -> Update.ProtocolVersion
-  -> Update.SoftwareVersion
+  -> Byron.Update.ProtocolVersion
+  -> Byron.Update.SoftwareVersion
   -> Maybe ByronLeaderCredentials
      -- Shelley
   -> ShelleyGenesis (ShelleyEra c)
@@ -431,7 +431,7 @@ protocolClientInfoCardano epochSlots secParam = ProtocolClientInfo {
 -------------------------------------------------------------------------------}
 
 -- | Create the initial 'LedgerState' based on the given Byron genesis config.
-initialLedgerStateCardano :: Genesis.Config -> LedgerState (CardanoBlock c)
+initialLedgerStateCardano :: Byron.Genesis.Config -> LedgerState (CardanoBlock c)
 initialLedgerStateCardano =
       HardForkLedgerState
     . initHardForkState
@@ -441,7 +441,7 @@ initialLedgerStateCardano =
 ledgerConfigCardano ::
      forall c.
      -- Byron
-     Genesis.Config
+     Byron.Genesis.Config
 
      -- Shelley
   -> ShelleyGenesis (ShelleyEra c)

--- a/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
@@ -167,7 +167,7 @@ showBlockTxsSize _cfg immDB rr = processAll immDB rr process
 showEBBs
   :: forall blk. (HasAnalysis blk, ImmDbSerialiseConstraints blk)
   => Analysis blk
-showEBBs cfg immDB rr = do
+showEBBs _cfg immDB rr = do
     putStrLn "EBB\tPrev\tKnown"
     processAll immDB rr processIfEBB
   where
@@ -177,11 +177,11 @@ showEBBs cfg immDB rr = do
           Just _epoch ->
             putStrLn $ intercalate "\t" [
                 show (blockHash blk)
-              , show (blockPrevHash (configCodec cfg) blk)
+              , show (blockPrevHash blk)
               , show (    Map.lookup
                             (blockHash blk)
                             (HasAnalysis.knownEBBs (Proxy @blk))
-                       == Just (blockPrevHash (configCodec cfg) blk)
+                       == Just (blockPrevHash blk)
                      )
               ]
           _otherwise ->

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -25,7 +25,8 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Combinator (OneEraHash (..))
 import           Ouroboros.Consensus.Node.ProtocolInfo
 
-import           Ouroboros.Consensus.Shelley.Node (Nonce (..), ShelleyGenesis)
+import           Ouroboros.Consensus.Shelley.Node (MaxMajorProtVer (..),
+                     Nonce (..), ShelleyGenesis)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
@@ -91,7 +92,7 @@ mkCardanoProtocolInfo byronConfig shelleyConfig signatureThreshold initialNonce 
       shelleyConfig
       initialNonce
       (SL.ProtVer 2 0)
-      2000
+      (MaxMajorProtVer 1000)
       Nothing
       Nothing
       (TriggerHardForkAtVersion 2)

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
@@ -25,8 +25,8 @@ import           Ouroboros.Consensus.Node.ProtocolInfo
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Shelley
-import           Ouroboros.Consensus.Shelley.Node (Nonce (..), ShelleyGenesis,
-                     protocolInfoShelley)
+import           Ouroboros.Consensus.Shelley.Node (MaxMajorProtVer (..),
+                     Nonce (..), ShelleyGenesis, protocolInfoShelley)
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto
 
 import           HasAnalysis
@@ -62,7 +62,7 @@ mkShelleyProtocolInfo genesis initialNonce =
     protocolInfoShelley
       genesis
       initialNonce
-      2000
+      (MaxMajorProtVer 1000)
       (SL.ProtVer 0 0)
       Nothing
 

--- a/ouroboros-consensus-mock-test/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus-mock-test/test/Test/ThreadNet/LeaderSchedule.hs
@@ -89,7 +89,7 @@ prop_simple_leader_schedule_convergence TestSetup
   , setupLeaderSchedule = schedule
   , setupSlotLength     = slotLength
   } =
-    counterexample (tracesToDot (SimpleCodecConfig k) testOutputNodes) $
+    counterexample (tracesToDot testOutputNodes) $
     prop_general PropGeneralArgs
       { pgaBlockProperty       = prop_validSimpleBlock
       , pgaCountTxs            = countSimpleGenTxs

--- a/ouroboros-consensus-mock-test/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus-mock-test/test/Test/ThreadNet/Praos.hs
@@ -87,7 +87,7 @@ prop_simple_praos_convergence TestSetup
   , setupSlotLength   = slotLength
   , setupTestConfig   = testConfig
   } =
-    counterexample (tracesToDot (SimpleCodecConfig k) testOutputNodes) $
+    counterexample (tracesToDot testOutputNodes) $
     prop_general PropGeneralArgs
       { pgaBlockProperty       = prop_validSimpleBlock
       , pgaCountTxs            = countSimpleGenTxs

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -243,7 +243,7 @@ instance (SimpleCrypto c, Typeable ext, Typeable ext')
   getHeaderFields = getBlockHeaderFields
 
 instance (SimpleCrypto c, Typeable ext) => GetPrevHash (SimpleBlock c ext) where
-  headerPrevHash _cfg = simplePrev . simpleHeaderStd
+  headerPrevHash = simplePrev . simpleHeaderStd
 
 instance (SimpleCrypto c, Typeable ext, Typeable ext')
       => StandardHash (SimpleBlock' c ext ext')
@@ -345,8 +345,7 @@ instance MockProtocolSpecific c ext
 
 instance MockProtocolSpecific c ext
       => ApplyBlock (LedgerState (SimpleBlock c ext)) (SimpleBlock c ext) where
-  applyLedgerBlock cfg =
-      updateSimpleLedgerState (blockConfigCodec cfg)
+  applyLedgerBlock _ = updateSimpleLedgerState
 
   reapplyLedgerBlock cfg =
       (mustSucceed . runExcept) .: applyLedgerBlock cfg
@@ -370,13 +369,12 @@ newtype instance Ticked (LedgerState (SimpleBlock c ext)) = TickedSimpleLedgerSt
 instance MockProtocolSpecific c ext => UpdateLedger (SimpleBlock c ext)
 
 updateSimpleLedgerState :: (SimpleCrypto c, Typeable ext)
-                        => CodecConfig (SimpleBlock c ext)
-                        -> SimpleBlock c ext
+                        => SimpleBlock c ext
                         -> TickedLedgerState (SimpleBlock c ext)
                         -> Except (MockError (SimpleBlock c ext))
                                   (LedgerState (SimpleBlock c ext))
-updateSimpleLedgerState cfg b (TickedSimpleLedgerState (SimpleLedgerState st)) =
-    SimpleLedgerState <$> updateMockState cfg b st
+updateSimpleLedgerState b (TickedSimpleLedgerState (SimpleLedgerState st)) =
+    SimpleLedgerState <$> updateMockState b st
 
 updateSimpleUTxO :: Mock.HasMockTxs a
                  => SlotNo

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
@@ -60,25 +60,23 @@ deriving instance Serialise (HeaderHash blk) => Serialise (MockError blk)
 instance Typeable blk => ShowProxy (MockError blk) where
 
 updateMockState :: (GetPrevHash blk, HasMockTxs blk)
-                => CodecConfig blk
-                -> blk
+                => blk
                 -> MockState blk
                 -> Except (MockError blk) (MockState blk)
-updateMockState cfg blk st = do
+updateMockState blk st = do
     let hdr = getHeader blk
-    st' <- updateMockTip cfg hdr st
+    st' <- updateMockTip hdr st
     updateMockUTxO (blockSlot hdr) blk st'
 
 updateMockTip :: GetPrevHash blk
-              => CodecConfig blk
-              -> Header blk
+              => Header blk
               -> MockState blk
               -> Except (MockError blk) (MockState blk)
-updateMockTip cfg hdr (MockState u c t)
-    | headerPrevHash cfg hdr == pointHash t
+updateMockTip hdr (MockState u c t)
+    | headerPrevHash hdr == pointHash t
     = return $ MockState u c (headerPoint hdr)
     | otherwise
-    = throwError $ MockInvalidHash (headerPrevHash cfg hdr) (pointHash t)
+    = throwError $ MockInvalidHash (headerPrevHash hdr) (pointHash t)
 
 updateMockUTxO :: HasMockTxs a
                => SlotNo

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -39,11 +39,9 @@ protocolInfoBft numCoreNodes nid securityParam eraParams =
                   | n <- enumCoreNodes numCoreNodes
                   ]
               }
-          , topLevelConfigBlock = FullBlockConfig {
-                blockConfigLedger = SimpleLedgerConfig () eraParams
-              , blockConfigBlock  = SimpleBlockConfig securityParam
-              , blockConfigCodec  = SimpleCodecConfig securityParam
-              }
+          , topLevelConfigLedger = SimpleLedgerConfig () eraParams
+          , topLevelConfigBlock  = SimpleBlockConfig securityParam
+          , topLevelConfigCodec  = SimpleCodecConfig securityParam
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState ())

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -37,11 +37,9 @@ protocolInfoMockPBFT params eraParams nid =
             topLevelConfigProtocol = PBftConfig {
                 pbftParams = params
               }
-          , topLevelConfigBlock = FullBlockConfig {
-                blockConfigLedger = SimpleLedgerConfig ledgerView eraParams
-              , blockConfigBlock  = SimpleBlockConfig  (pbftSecurityParam params)
-              , blockConfigCodec  = SimpleCodecConfig  (pbftSecurityParam params)
-              }
+          , topLevelConfigLedger = SimpleLedgerConfig ledgerView eraParams
+          , topLevelConfigBlock  = SimpleBlockConfig  (pbftSecurityParam params)
+          , topLevelConfigCodec  = SimpleCodecConfig  (pbftSecurityParam params)
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState S.empty)

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -47,11 +47,9 @@ protocolInfoPraos numCoreNodes nid params eraParams eta0 =
               , praosInitialStake = genesisStakeDist addrDist
               , praosVerKeys      = verKeys
               }
-          , topLevelConfigBlock = FullBlockConfig {
-                blockConfigLedger = SimpleLedgerConfig addrDist eraParams
-              , blockConfigBlock  = SimpleBlockConfig (praosSecurityParam params)
-              , blockConfigCodec  = SimpleCodecConfig (praosSecurityParam params)
-              }
+          , topLevelConfigLedger = SimpleLedgerConfig addrDist eraParams
+          , topLevelConfigBlock  = SimpleBlockConfig (praosSecurityParam params)
+          , topLevelConfigCodec  = SimpleCodecConfig (praosSecurityParam params)
           }
       , pInfoInitLedger = ExtLedgerState {
             ledgerState = genesisSimpleLedgerState addrDist

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -48,11 +48,9 @@ protocolInfoPraosRule numCoreNodes
                 }
             , wlsConfigNodeId   = nid
             }
-        , topLevelConfigBlock = FullBlockConfig {
-              blockConfigLedger = SimpleLedgerConfig () eraParams
-            , blockConfigBlock  = SimpleBlockConfig (praosSecurityParam params)
-            , blockConfigCodec  = SimpleCodecConfig (praosSecurityParam params)
-            }
+        , topLevelConfigLedger = SimpleLedgerConfig () eraParams
+        , topLevelConfigBlock  = SimpleBlockConfig (praosSecurityParam params)
+        , topLevelConfigCodec  = SimpleCodecConfig (praosSecurityParam params)
         }
     , pInfoInitLedger = ExtLedgerState
         { ledgerState = genesisSimpleLedgerState addrDist

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -387,7 +387,7 @@ mkProtocolRealTPraos genesis initialNonce protVer coreNode =
       protVer
       (Just (mkLeaderCredentials coreNode))
   where
-    maxMajorPV = 1000 -- TODO
+    maxMajorPV = MaxMajorProtVer 1000 -- TODO
 
 {-------------------------------------------------------------------------------
   Necessary transactions for updating the 'DecentralizationParam'

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -364,6 +364,4 @@ prop_simple_real_tpraos_convergence TestSetup
         ledgerConfig = Shelley.mkShelleyLedgerConfig
             genesisConfig
             (fixedSizeEpochInfo epochSize)
-            maxMajorPV
-          where
-            maxMajorPV = 1000   -- TODO
+            (MaxMajorProtVer 1000) -- TODO

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -147,7 +147,7 @@ instance Era era => HasHeader (Header (ShelleyBlock era)) where
     }
 
 instance Era era => GetPrevHash (ShelleyBlock era)  where
-  headerPrevHash _cfg =
+  headerPrevHash =
       fromShelleyPrevHash
     . SL.bheaderPrev
     . SL.bhbody

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -220,7 +220,7 @@ instance TPraosCrypto era
 applyHelper ::
      (TPraosCrypto era, Monad m)
   => (SL.Globals -> SL.ShelleyState era -> SL.Block era -> m (SL.ShelleyState era))
-  -> FullBlockConfig (LedgerState (ShelleyBlock era)) (ShelleyBlock era)
+  -> LedgerConfig (ShelleyBlock era)
   -> ShelleyBlock era
   -> Ticked (LedgerState (ShelleyBlock era))
   -> m (LedgerState (ShelleyBlock era))
@@ -232,7 +232,7 @@ applyHelper f cfg blk (TickedShelleyLedgerState _ oldShelleyState) = do
       , shelleyState = newShelleyState
       }
   where
-    globals = shelleyLedgerGlobals (blockConfigLedger cfg)
+    globals = shelleyLedgerGlobals cfg
 
 instance TPraosCrypto era => LedgerSupportsProtocol (ShelleyBlock era) where
   protocolLedgerView _cfg = TickedPraosLedgerView

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -60,7 +60,7 @@ import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..), enforceSize)
-import           Cardano.Prelude (Natural, NoUnexpectedThunks (..))
+import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Cardano.Slotting.EpochInfo
 
 import           Ouroboros.Network.Block (Serialised (..), decodePoint,
@@ -93,8 +93,8 @@ import qualified Shelley.Spec.Ledger.UTxO as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.TPraos ()
-import           Ouroboros.Consensus.Shelley.Protocol (TPraosCrypto,
-                     Ticked (TickedPraosLedgerView))
+import           Ouroboros.Consensus.Shelley.Protocol (MaxMajorProtVer (..),
+                     TPraosCrypto, Ticked (TickedPraosLedgerView))
 
 {-------------------------------------------------------------------------------
   Ledger errors
@@ -139,9 +139,9 @@ shelleyEraParams genesis = HardFork.EraParams {
 mkShelleyLedgerConfig
   :: SL.ShelleyGenesis era
   -> EpochInfo Identity
-  -> Natural
+  -> MaxMajorProtVer
   -> ShelleyLedgerConfig era
-mkShelleyLedgerConfig genesis epochInfo maxMajorPV =
+mkShelleyLedgerConfig genesis epochInfo (MaxMajorProtVer maxMajorPV) =
     ShelleyLedgerConfig {
         shelleyLedgerGenesis   = genesis
       , shelleyLedgerGlobals   = SL.mkShelleyGlobals genesis epochInfo maxMajorPV

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -176,11 +176,9 @@ protocolInfoShelley genesis initialNonce maxMajorPV protVer mbCredentials =
     topLevelConfig :: TopLevelConfig (ShelleyBlock era)
     topLevelConfig = TopLevelConfig {
         topLevelConfigProtocol = consensusConfig
-      , topLevelConfigBlock = FullBlockConfig {
-            blockConfigLedger = ledgerConfig
-          , blockConfigBlock  = blockConfig
-          , blockConfigCodec  = ShelleyCodecConfig
-          }
+      , topLevelConfigLedger   = ledgerConfig
+      , topLevelConfigBlock    = blockConfig
+      , topLevelConfigCodec    = ShelleyCodecConfig
       }
 
     consensusConfig :: ConsensusConfig (BlockProtocol (ShelleyBlock era))

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -22,6 +22,7 @@ module Ouroboros.Consensus.Shelley.Node (
   , tpraosBlockIssuerVKey
   , SL.ProtVer
   , SL.Nonce (..)
+  , MaxMajorProtVer (..)
   , SL.emptyGenesisStaking
   , validateGenesis
   ) where
@@ -33,7 +34,6 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 
 import qualified Cardano.Crypto.VRF as VRF
-import           Cardano.Prelude (Natural)
 import           Cardano.Slotting.EpochInfo
 
 import           Ouroboros.Consensus.Block
@@ -161,7 +161,7 @@ protocolInfoShelley
   -> SL.Nonce
      -- ^ The initial nonce, typically derived from the hash of Genesis config
      -- JSON file.
-  -> Natural -- ^ Max major protocol version
+  -> MaxMajorProtVer
   -> SL.ProtVer
   -> Maybe (TPraosLeaderCredentials era)
   -> ProtocolInfo m (ShelleyBlock era)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -27,6 +27,7 @@ module Ouroboros.Consensus.Shelley.Protocol (
   , TPraosIsLeader (..)
   , mkShelleyGlobals
   , TPraosState
+  , MaxMajorProtVer (..)
     -- * Crypto
   , Era
   , TPraosCrypto
@@ -156,6 +157,15 @@ type TPraosValidateView era = SL.BHeader era
   Protocol proper
 -------------------------------------------------------------------------------}
 
+-- | The maximum major protocol version.
+--
+-- Must be at least the current major protocol version. For Cardano mainnet, the
+-- Shelley era has major protocol verison __2__.
+newtype MaxMajorProtVer = MaxMajorProtVer {
+      getMaxMajorProtVer :: Natural
+    }
+  deriving (Eq, Show, Generic, NoUnexpectedThunks)
+
 data TPraos era
 
 -- | TPraos parameters that are node independent
@@ -176,7 +186,7 @@ data TPraosParams = TPraosParams {
     , tpraosQuorum            :: !Word64
       -- | All blocks invalid after this protocol version, see
       -- 'Globals.maxMajorPV'.
-    , tpraosMaxMajorPV        :: !Natural
+    , tpraosMaxMajorPV        :: !MaxMajorProtVer
       -- | Maximum number of lovelace in the system, see
       -- 'Globals.maxLovelaceSupply'.
     , tpraosMaxLovelaceSupply :: !Word64
@@ -194,7 +204,7 @@ data TPraosParams = TPraosParams {
   deriving (Generic, NoUnexpectedThunks)
 
 mkTPraosParams
-  :: Natural   -- ^ Max major protocol version
+  :: MaxMajorProtVer
   -> SL.Nonce  -- ^ Initial nonce
   -> SL.ShelleyGenesis era
   -> TPraosParams
@@ -429,7 +439,7 @@ mkShelleyGlobals epochInfo TPraosParams {..} = SL.Globals {
     , securityParameter             = k
     , maxKESEvo                     = tpraosMaxKESEvo
     , quorum                        = tpraosQuorum
-    , maxMajorPV                    = tpraosMaxMajorPV
+    , maxMajorPV                    = getMaxMajorProtVer tpraosMaxMajorPV
     , maxLovelaceSupply             = tpraosMaxLovelaceSupply
     , activeSlotCoeff               = tpraosLeaderF
     , networkId                     = tpraosNetworkId

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -836,7 +836,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
 
                   -- fail if the EBB is invalid
                   -- if it is valid, we retick to the /same/ slot
-                  let apply = applyLedgerBlock (topLevelConfigBlock pInfoConfig)
+                  let apply = applyLedgerBlock (configLedger pInfoConfig)
                   tickedLdgSt' <- case Exc.runExcept $ apply ebb tickedLdgSt of
                     Left e   -> Exn.throw $ JitEbbError @blk e
                     Right st -> pure $ applyChainTick

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util.hs
@@ -130,12 +130,12 @@ genesisBlockInfo = BlockInfo
 
 
 blockInfo :: (GetPrevHash b, HasCreator b)
-          => CodecConfig b -> b -> BlockInfo b
-blockInfo cfg b = BlockInfo
+          => b -> BlockInfo b
+blockInfo b = BlockInfo
     { biSlot     = blockSlot b
     , biCreator  = Just $ getCreator b
     , biHash     = BlockHash $ blockHash b
-    , biPrevious = Just $ blockPrevHash cfg b
+    , biPrevious = Just $ blockPrevHash b
     }
 
 data NodeLabel = NodeLabel
@@ -169,16 +169,15 @@ instance Labellable EdgeLabel where
     toLabelValue = const $ StrLabel Text.empty
 
 tracesToDot :: forall b. (GetPrevHash b, HasCreator b)
-            => CodecConfig b
-            -> Map NodeId (NodeOutput b)
+            => Map NodeId (NodeOutput b)
             -> String
-tracesToDot cfg traces = Text.unpack $ printDotGraph $ graphToDot quickParams graph
+tracesToDot traces = Text.unpack $ printDotGraph $ graphToDot quickParams graph
   where
     chainBlockInfos :: Chain b
                     -> Map (ChainHash b) (BlockInfo b)
     chainBlockInfos = Chain.foldChain f (Map.singleton GenesisHash genesisBlockInfo)
       where
-        f m b = let info = blockInfo cfg b
+        f m b = let info = blockInfo b
                 in  Map.insert (biHash info) info m
 
     blockInfos :: Map (ChainHash b) (BlockInfo b)

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -387,11 +387,9 @@ singleNodeTestConfig = TopLevelConfig {
         , bftSignKey = SignKeyMockDSIGN 0
         , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
         }
-    , topLevelConfigBlock = FullBlockConfig {
-          blockConfigLedger = eraParams
-        , blockConfigBlock  = TestBlockConfig numCoreNodes
-        , blockConfigCodec  = TestBlockCodecConfig
-        }
+    , topLevelConfigLedger = eraParams
+    , topLevelConfigBlock  = TestBlockConfig numCoreNodes
+    , topLevelConfigCodec  = TestBlockCodecConfig
     }
   where
     slotLength :: SlotLength

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -204,7 +204,7 @@ instance HasHeader (Header TestBlock) where
       }
 
 instance GetPrevHash TestBlock where
-  headerPrevHash _cfg (TestHeader b) =
+  headerPrevHash (TestHeader b) =
       case NE.nonEmpty . NE.tail . unTestHash . tbHash $ b of
         Nothing       -> GenesisHash
         Just prevHash -> BlockHash (TestHash prevHash)
@@ -298,15 +298,13 @@ instance IsLedger (LedgerState TestBlock) where
   applyChainTick _ _ = TickedTestLedger
 
 instance ApplyBlock (LedgerState TestBlock) TestBlock where
-  applyLedgerBlock cfg tb@TestBlock{..} (TickedTestLedger TestLedger{..})
-    | blockPrevHash ccfg tb /= pointHash lastAppliedPoint
-    = throwError $ InvalidHash (pointHash lastAppliedPoint) (blockPrevHash ccfg tb)
+  applyLedgerBlock _ tb@TestBlock{..} (TickedTestLedger TestLedger{..})
+    | blockPrevHash tb /= pointHash lastAppliedPoint
+    = throwError $ InvalidHash (pointHash lastAppliedPoint) (blockPrevHash tb)
     | not tbValid
     = throwError $ InvalidBlock
     | otherwise
     = return     $ TestLedger (Chain.blockPoint tb)
-    where
-      ccfg = blockConfigCodec cfg
 
   reapplyLedgerBlock _ tb _ = TestLedger (Chain.blockPoint tb)
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -266,27 +266,25 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
                 :* (WrapPartialConsensusConfig $ consensusConfigB nid)
                 :* Nil
             }
-        , topLevelConfigBlock = FullBlockConfig {
-              blockConfigLedger = HardForkLedgerConfig {
-                  hardForkLedgerConfigK      = k
-                , hardForkLedgerConfigShape  = shape
-                , hardForkLedgerConfigPerEra = PerEraLedgerConfig $
-                       (WrapPartialLedgerConfig $ ledgerConfigA nid)
-                    :* (WrapPartialLedgerConfig $ ledgerConfigB nid)
-                    :* Nil
-                }
-            , blockConfigBlock = HardForkBlockConfig {
-                  hardForkBlockConfigPerEra = PerEraBlockConfig $
-                       blockConfigA nid
-                    :* blockConfigB nid
-                    :* Nil
-                }
-            , blockConfigCodec = HardForkCodecConfig {
-                  hardForkCodecConfigPerEra = PerEraCodecConfig $
-                       CCfgA
-                    :* CCfgB
-                    :* Nil
-                }
+        , topLevelConfigLedger = HardForkLedgerConfig {
+              hardForkLedgerConfigK      = k
+            , hardForkLedgerConfigShape  = shape
+            , hardForkLedgerConfigPerEra = PerEraLedgerConfig $
+                   (WrapPartialLedgerConfig $ ledgerConfigA nid)
+                :* (WrapPartialLedgerConfig $ ledgerConfigB nid)
+                :* Nil
+            }
+        , topLevelConfigBlock = HardForkBlockConfig {
+              hardForkBlockConfigPerEra = PerEraBlockConfig $
+                   blockConfigA nid
+                :* blockConfigB nid
+                :* Nil
+            }
+        , topLevelConfigCodec = HardForkCodecConfig {
+              hardForkCodecConfigPerEra = PerEraCodecConfig $
+                   CCfgA
+                :* CCfgB
+                :* Nil
             }
         }
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -167,7 +167,7 @@ instance HasHeader (Header BlockA) where
   getHeaderFields = castHeaderFields . hdrA_fields
 
 instance GetPrevHash BlockA where
-  headerPrevHash _cfg = hdrA_prev
+  headerPrevHash = hdrA_prev
 
 instance HasAnnTip BlockA where
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -214,10 +214,9 @@ instance IsLedger (LedgerState BlockA) where
 instance ApplyBlock (LedgerState BlockA) BlockA where
   applyLedgerBlock cfg blk =
         fmap setTip
-      . repeatedlyM (applyTx
-                       (blockConfigLedger cfg)
-                       (blockSlot blk))
-                    (blkA_body blk)
+      . repeatedlyM
+          (applyTx cfg (blockSlot blk))
+          (blkA_body blk)
     where
       setTip :: TickedLedgerState BlockA -> LedgerState BlockA
       setTip (TickedLedgerStateA st) = st { lgrA_tip = blockPoint blk }

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -155,7 +155,7 @@ instance HasHeader (Header BlockB) where
   getHeaderFields = castHeaderFields . hdrB_fields
 
 instance GetPrevHash BlockB where
-  headerPrevHash _cfg = hdrB_prev
+  headerPrevHash = hdrB_prev
 
 instance HasAnnTip BlockB where
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -445,7 +445,7 @@ updateClientState cfg chain ledgerState chainUpdates =
         where
           chain'       = foldl' (flip Chain.addBlock) chain bs
           ledgerState' = runValidate $ foldLedger
-                                         (extLedgerCfgFromTopLevel cfg)
+                                         (ExtLedgerCfg cfg)
                                          bs
                                          ledgerState
       Nothing
@@ -453,7 +453,7 @@ updateClientState cfg chain ledgerState chainUpdates =
       -- scratch
         | Just chain' <- Chain.applyChainUpdates (toChainUpdates chainUpdates) chain
         -> let ledgerState' = runValidate $ foldLedger
-                                              (extLedgerCfgFromTopLevel cfg)
+                                              (ExtLedgerCfg cfg)
                                               (Chain.toOldestFirst chain')
                                               testInitExtLedger
            in (chain', ledgerState')
@@ -500,7 +500,7 @@ computePastLedger cfg pt chain
         | castPoint (getTip st) == pt
         = st
         | blk:blks' <- blks
-        = go (tickThenReapply (extLedgerCfgFromTopLevel cfg) blk st) blks'
+        = go (tickThenReapply (ExtLedgerCfg cfg) blk st) blks'
         | otherwise
         = error "point not in the list of blocks"
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -401,11 +401,9 @@ runChainSync securityParam (ClientUpdates clientUpdates)
                            , (CoreId (CoreNodeId 1), VerKeyMockDSIGN 1)
                            ]
           }
-      , topLevelConfigBlock = FullBlockConfig {
-            blockConfigLedger = eraParams
-          , blockConfigBlock  = TestBlockConfig numCoreNodes
-          , blockConfigCodec  = TestBlockCodecConfig
-          }
+      , topLevelConfigLedger = eraParams
+      , topLevelConfigBlock  = TestBlockConfig numCoreNodes
+      , topLevelConfigCodec  = TestBlockCodecConfig
       }
 
     eraParams :: HardFork.EraParams

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -223,11 +223,9 @@ testCfg securityParam = TopLevelConfig {
         , bftSignKey = SignKeyMockDSIGN 0
         , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
         }
-    , topLevelConfigBlock = FullBlockConfig {
-          blockConfigLedger = eraParams
-        , blockConfigBlock  = TestBlockConfig numCoreNodes
-        , blockConfigCodec  = TestBlockCodecConfig
-        }
+    , topLevelConfigLedger = eraParams
+    , topLevelConfigBlock  = TestBlockConfig numCoreNodes
+    , topLevelConfigCodec  = TestBlockCodecConfig
     }
   where
     slotLength :: SlotLength

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -397,7 +397,7 @@ initIteratorEnv TestSetup { immutable, volatile } tracer = do
       { VolDB.bbid          = blockHash tb
       , VolDB.bslot         = blockSlot tb
       , VolDB.bbno          = blockNo   tb
-      , VolDB.bpreBid       = case blockPrevHash TestBlockCodecConfig tb of
+      , VolDB.bpreBid       = case blockPrevHash tb of
           GenesisHash -> Origin
           BlockHash h -> NotOrigin h
       , VolDB.bisEBB        = testBlockIsEBB tb

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -329,7 +329,7 @@ getPastLedger cfg p m@Model{..} =
       [] | p /= GenesisPoint ->
         Nothing
       _otherwise ->
-        Just $ refoldLedger (extLedgerCfgFromTopLevel cfg) prefix initLedger
+        Just $ refoldLedger (ExtLedgerCfg cfg) prefix initLedger
   where
     prefix :: [blk]
     prefix = reverse
@@ -665,7 +665,7 @@ validate cfg Model { currentSlot, maxClockSkew, initLedger, invalid } chain =
     go ledger validPrefix = \case
       -- Return 'mbFinal' if it contains an "earlier" result
       []    -> ValidatedChain validPrefix ledger invalid
-      b:bs' -> case runExcept (tickThenApply (extLedgerCfgFromTopLevel cfg) b ledger) of
+      b:bs' -> case runExcept (tickThenApply (ExtLedgerCfg cfg) b ledger) of
         -- Invalid block according to the ledger
         Left e
           -> ValidatedChain
@@ -734,7 +734,7 @@ validate cfg Model { currentSlot, maxClockSkew, initLedger, invalid } chain =
       -> InvalidBlocks blk
     findInvalidBlockInTheFuture ledger = \case
       []    -> Map.empty
-      b:bs' -> case runExcept (tickThenApply (extLedgerCfgFromTopLevel cfg) b ledger) of
+      b:bs' -> case runExcept (tickThenApply (ExtLedgerCfg cfg) b ledger) of
         Left e        -> mkInvalid b (ValidationError e)
         Right ledger'
           | blockSlot b > SlotNo (unSlotNo currentSlot + maxClockSkew)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
@@ -91,14 +91,13 @@ prop_alwaysPickPreferredChain bt p =
 prop_between_currentChain :: BlockTree -> Property
 prop_between_currentChain bt =
     Right (AF.toOldestFirst $ Chain.toAnchoredFragment $ M.currentChain model) ===
-    M.between secParam ccfg from to model
+    M.between secParam from to model
   where
     blocks   = treeToBlocks bt
     model    = addBlocks blocks
     from     = StreamFromExclusive GenesisPoint
     to       = StreamToInclusive $ cantBeGenesis (M.tipPoint model)
     secParam = configSecurityParam singleNodeTestConfig
-    ccfg     = configCodec         singleNodeTestConfig
 
 -- | Workaround when we know the DB can't be empty, but the types don't
 cantBeGenesis :: HasCallStack => Point blk -> RealPoint blk

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -565,7 +565,7 @@ runPure cfg = \case
     GetGCedBlockComponent pt -> err mbGCedAllComponents $ query   (Model.getBlockComponentByPoint @Identity allComponents pt)
     GetMaxSlotNo             -> ok  MaxSlot             $ query    Model.getMaxSlotNo
     GetIsValid pt            -> ok  isValidResult       $ query   (Model.isValid cfg pt)
-    Stream from to           -> err iter                $ updateE (Model.stream k ccfg from to)
+    Stream from to           -> err iter                $ updateE (Model.stream k from to)
     IteratorNext  it         -> ok  IterResult          $ update  (Model.iteratorNext @Identity it allComponents)
     IteratorNextGCed it      -> ok  iterResultGCed      $ update  (Model.iteratorNext @Identity it allComponents)
     IteratorClose it         -> ok  Unit                $ update_ (Model.iteratorClose it)
@@ -578,8 +578,7 @@ runPure cfg = \case
     Reopen                   -> openOrClosed            $ update_  Model.reopen
     WipeVolDB                -> ok  Point               $ update  (Model.wipeVolDB cfg)
   where
-    k    = configSecurityParam cfg
-    ccfg = configCodec         cfg
+    k = configSecurityParam cfg
 
     advanceAndAdd slot blk m = (Model.tipPoint m', m')
       where
@@ -1042,7 +1041,7 @@ precondition Model {..} (At cmd) =
     -- TODO #871
     isValidIterator :: StreamFrom blk -> StreamTo blk -> Logic
     isValidIterator from to =
-        case Model.between secParam (configCodec cfg) from to' dbModel of
+        case Model.between secParam from to' dbModel of
           Left  _    -> Bot
           -- All blocks must be valid
           Right blks -> forall blks $ \blk -> Boolean $

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -63,7 +63,6 @@ openTestDB registry hasFS =
       }
   where
     parser = chunkFileParser
-               TestBlockCodecConfig
                hasFS
                (const <$> S.decode)
                testBlockIsValid

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -781,11 +781,8 @@ precondition Model {..} (At (CmdErr { cmd })) =
   where
     fitsOnTip :: TestBlock -> Logic
     fitsOnTip b = case dbmTipBlock dbModel of
-      Nothing    -> getPrevHash b .== GenesisHash
-      Just bPrev -> getPrevHash b .== BlockHash (blockHash bPrev)
-
-    getPrevHash :: TestBlock -> ChainHash TestBlock
-    getPrevHash = blockPrevHash TestBlockCodecConfig
+      Nothing    -> blockPrevHash b .== GenesisHash
+      Just bPrev -> blockPrevHash b .== BlockHash (blockHash bPrev)
 
 transition :: (Show1 r, Eq1 r)
            => Model m r -> At CmdErr m r -> At Resp m r -> Model m r
@@ -1258,7 +1255,6 @@ test cacheConfig chunkInfo cmds = do
 
     let hasFS  = mkSimErrorHasFS fsVar varErrors
         parser = chunkFileParser
-                   TestBlockCodecConfig
                    hasFS
                    (const <$> decode)
                    testBlockIsValid

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -26,7 +26,6 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.Ledger.Abstract
-import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Util
 
 import           Ouroboros.Consensus.Storage.LedgerDB.InMemory
@@ -251,15 +250,11 @@ data ChainSetup = ChainSetup {
     }
   deriving (Show)
 
-csBlockConfig :: ChainSetup -> FullBlockConfig (LedgerState TestBlock) TestBlock
+csBlockConfig :: ChainSetup -> LedgerConfig TestBlock
 csBlockConfig = csBlockConfig' . csParams
 
-csBlockConfig' :: LedgerDbParams -> FullBlockConfig (LedgerState TestBlock) TestBlock
-csBlockConfig' dbParams = FullBlockConfig {
-      blockConfigLedger = HardFork.defaultEraParams k slotLength
-    , blockConfigBlock  = TestBlockConfig (NumCoreNodes 1) -- Ledger DB doesn't care
-    , blockConfigCodec  = TestBlockCodecConfig
-    }
+csBlockConfig' :: LedgerDbParams -> LedgerConfig TestBlock
+csBlockConfig' dbParams = HardFork.defaultEraParams k slotLength
   where
     k          = ledgerDbSecurityParam dbParams
     slotLength = slotLengthFromSec 20

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -64,7 +64,6 @@ import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import qualified Ouroboros.Consensus.Ledger.Abstract as Lgr
-import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.IOLike
 
@@ -130,7 +129,7 @@ class ( Lgr.ApplyBlock (LedgerSt t) (BlockVal t)
   genBlock      :: Proxy t -> LedgerSt t -> Gen (BlockVal t)
 
 type LedgerErr t = Lgr.LedgerErr (LedgerSt t)
-type LedgerCfg t = FullBlockConfig (LedgerSt t) (BlockVal t)
+type LedgerCfg t = Lgr.LedgerCfg (LedgerSt t)
 
 refValPair :: LUT t => Proxy t -> BlockVal t -> (BlockRef t, BlockVal t)
 refValPair p b = (blockRef p b, b)
@@ -166,11 +165,7 @@ instance LUT 'LedgerSimple where
   ledgerApply _ c b = runExcept . Lgr.tickThenApply c b
   blockRef      _ b = b
 
-  ledgerConfig _ dbParams = FullBlockConfig {
-        blockConfigLedger = HardFork.defaultEraParams k slotLength
-      , blockConfigBlock  = TestBlockConfig (NumCoreNodes 1) -- Ledger DB doesn't care
-      , blockConfigCodec  = TestBlockCodecConfig
-      }
+  ledgerConfig _ dbParams = HardFork.defaultEraParams k slotLength
     where
       k          = ledgerDbSecurityParam dbParams
       slotLength = slotLengthFromSec 20
@@ -552,7 +547,7 @@ data StandaloneDB m t = DB {
     , dbResolve :: ResolveBlock m (BlockRef t) (BlockVal t)
 
       -- | Ledger config
-    , dbLedgerCfg :: FullBlockConfig (LedgerSt t) (BlockVal t)
+    , dbLedgerCfg :: LedgerCfg t
     }
 
 initStandaloneDB :: forall m t. (IOLike m, LUT t)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -225,7 +225,7 @@ instance HasHeader (Header TestBlock) where
       }
 
 instance GetPrevHash TestBlock where
-  headerPrevHash _cfg = castHash . thPrevHash . unTestHeader
+  headerPrevHash = castHash . thPrevHash . unTestHeader
 
 data instance BlockConfig TestBlock = TestBlockConfig {
       -- | Whether the test block can be EBBs or not. This can vary per test
@@ -579,15 +579,13 @@ instance IsLedger (LedgerState TestBlock) where
   applyChainTick _ _ = TickedTestLedger
 
 instance ApplyBlock (LedgerState TestBlock) TestBlock where
-  applyLedgerBlock cfg tb@TestBlock{..} (TickedTestLedger TestLedger{..})
-    | blockPrevHash ccfg tb /= lastAppliedHash
-    = throwError $ InvalidHash lastAppliedHash (blockPrevHash ccfg tb)
+  applyLedgerBlock _ tb@TestBlock{..} (TickedTestLedger TestLedger{..})
+    | blockPrevHash tb /= lastAppliedHash
+    = throwError $ InvalidHash lastAppliedHash (blockPrevHash tb)
     | not $ tbIsValid testBody
     = throwError $ InvalidBlock
     | otherwise
     = return     $ TestLedger (Chain.blockPoint tb) (BlockHash (blockHash tb))
-    where
-      ccfg = blockConfigCodec cfg
 
   reapplyLedgerBlock _ tb _ =
     TestLedger (Chain.blockPoint tb) (BlockHash (blockHash tb))

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -689,14 +689,12 @@ mkTestConfig k ChunkSize { chunkCanContainEBB, numRegularBlocks } =
           , bftSignKey = SignKeyMockDSIGN 0
           , bftVerKeys = Map.singleton (CoreId (CoreNodeId 0)) (VerKeyMockDSIGN 0)
           }
-      , topLevelConfigBlock = FullBlockConfig {
-            blockConfigLedger = eraParams
-          , blockConfigBlock  = TestBlockConfig {
-                testBlockEBBsAllowed  = chunkCanContainEBB
-              , testBlockNumCoreNodes = numCoreNodes
-              }
-          , blockConfigCodec  = TestBlockCodecConfig
+      , topLevelConfigLedger = eraParams
+      , topLevelConfigBlock  = TestBlockConfig {
+            testBlockEBBsAllowed  = chunkCanContainEBB
+          , testBlockNumCoreNodes = numCoreNodes
           }
+      , topLevelConfigCodec  = TestBlockCodecConfig
       }
   where
     slotLength :: SlotLength

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -592,7 +592,6 @@ test cmds = do
 
     let hasFS  = mkSimErrorHasFS varFs varErrors
         parser = blockFileParser'
-          TestBlockCodecConfig
           hasFS
           ((\blk bytes -> (takePrefix testPrefixLen bytes, blk)) <$> decode)
           testBlockIsValid

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -111,14 +111,10 @@ data family CodecConfig blk :: Type
 
 class (HasHeader blk, GetHeader blk) => GetPrevHash blk where
   -- | Get the hash of the predecessor of this block
-  --
-  -- This gets its own abstraction, because it will be a key part of the path
-  -- to getting rid of EBBs: when we have blocks @A - EBB - B@, the prev hash
-  -- of @B@ will be reported as @A@.
-  headerPrevHash :: CodecConfig blk -> Header blk -> ChainHash blk
+  headerPrevHash :: Header blk -> ChainHash blk
 
-blockPrevHash :: GetPrevHash blk => CodecConfig blk -> blk -> ChainHash blk
-blockPrevHash cfg = castHash . headerPrevHash cfg . getHeader
+blockPrevHash :: GetPrevHash blk => blk -> ChainHash blk
+blockPrevHash = castHash . headerPrevHash . getHeader
 
 {-------------------------------------------------------------------------------
   Link block to its header

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -28,7 +28,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Basics (
   , completeLedgerConfig''
   , completeConsensusConfig'
   , completeConsensusConfig''
-  , distribFullBlockConfig
+  , distribLedgerConfig
   , distribTopLevelConfig
     -- ** Convenience re-exports
   , EpochInfo
@@ -179,27 +179,16 @@ completeConsensusConfig'' ei =
     . completeConsensusConfig (Proxy @(BlockProtocol blk)) ei
     . unwrapPartialConsensusConfig
 
-distribFullBlockConfig :: CanHardFork xs
-                       => EpochInfo Identity
-                       -> FullBlockConfig (LedgerState (HardForkBlock xs)) (HardForkBlock xs)
-                       -> NP WrapFullBlockConfig xs
-distribFullBlockConfig ei cfg =
-    hcpure proxySingle
-      (fn_3 (\cfgLedger cfgBlock cfgCodec -> WrapFullBlockConfig $
-           FullBlockConfig {
-               blockConfigLedger = completeLedgerConfig' ei cfgLedger
-             , blockConfigBlock  = cfgBlock
-             , blockConfigCodec  = cfgCodec
-             }))
-    `hap`
-      (getPerEraLedgerConfig $
-         hardForkLedgerConfigPerEra (blockConfigLedger cfg))
-    `hap`
-      (getPerEraBlockConfig $
-         hardForkBlockConfigPerEra (blockConfigBlock cfg))
-    `hap`
-      (getPerEraCodecConfig $
-         hardForkCodecConfigPerEra (blockConfigCodec cfg))
+distribLedgerConfig ::
+     CanHardFork xs
+  => EpochInfo Identity
+  -> LedgerConfig (HardForkBlock xs)
+  -> NP WrapLedgerConfig xs
+distribLedgerConfig ei cfg =
+    hcmap
+      proxySingle
+      (completeLedgerConfig'' ei)
+      (getPerEraLedgerConfig $ hardForkLedgerConfigPerEra cfg)
 
 distribTopLevelConfig :: CanHardFork xs
                       => EpochInfo Identity

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -105,18 +105,16 @@ instance CanHardFork xs => HasHeader (Header (HardForkBlock xs)) where
           HeaderFields{..} = getHeaderFields hdr
 
 instance CanHardFork xs => GetPrevHash (HardForkBlock xs) where
-  headerPrevHash cfg =
+  headerPrevHash =
         hcollapse
-      . hczipWith proxySingle (K .: getOnePrev) cfgs
+      . hcmap proxySingle (K . getOnePrev)
       . getOneEraHeader
       . getHardForkHeader
     where
-      cfgs = getPerEraCodecConfig $ hardForkCodecConfigPerEra cfg
-
       getOnePrev :: forall blk. SingleEraBlock blk
-                 => CodecConfig blk -> Header blk -> ChainHash (HardForkBlock xs)
-      getOnePrev cfg' hdr =
-          case headerPrevHash cfg' hdr of
+                 => Header blk -> ChainHash (HardForkBlock xs)
+      getOnePrev hdr =
+          case headerPrevHash hdr of
             GenesisHash -> GenesisHash
             BlockHash h -> BlockHash (OneEraHash $ toShortRawHash (Proxy @blk) h)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -179,11 +179,10 @@ instance CanHardFork xs
           fmap (HardForkLedgerState . State.tickAllPast k) $ hsequence' $
             hczipWith3 proxySingle apply cfgs errInjections matched
     where
-      cfgs = distribFullBlockConfig ei cfg
-      lcfg = blockConfigLedger cfg
-      k    = hardForkLedgerConfigK lcfg
+      cfgs = distribLedgerConfig ei cfg
+      k    = hardForkLedgerConfigK cfg
       ei   = State.epochInfoPrecomputedTransitionInfo
-               (hardForkLedgerConfigShape (blockConfigLedger cfg))
+               (hardForkLedgerConfigShape cfg)
                transition
                st
 
@@ -202,28 +201,27 @@ instance CanHardFork xs
           HardForkLedgerState . State.tickAllPast k $
             hczipWith proxySingle reapply cfgs matched
     where
-      cfgs = distribFullBlockConfig ei cfg
-      lcfg = blockConfigLedger cfg
-      k    = hardForkLedgerConfigK lcfg
+      cfgs = distribLedgerConfig ei cfg
+      k    = hardForkLedgerConfigK cfg
       ei   = State.epochInfoPrecomputedTransitionInfo
-               (hardForkLedgerConfigShape (blockConfigLedger cfg))
+               (hardForkLedgerConfigShape cfg)
                transition
                st
 
 apply :: SingleEraBlock blk
-      => WrapFullBlockConfig                               blk
+      => WrapLedgerConfig                                  blk
       -> Injection WrapLedgerErr xs                        blk
       -> Product I (Ticked :.: LedgerState)                blk
       -> (Except (HardForkLedgerError xs) :.: LedgerState) blk
-apply (WrapFullBlockConfig cfg) injectErr (Pair (I block) (Comp st)) = Comp $
+apply (WrapLedgerConfig cfg) injectErr (Pair (I block) (Comp st)) = Comp $
     withExcept (injectLedgerError injectErr) $
       applyLedgerBlock cfg block st
 
 reapply :: SingleEraBlock blk
-        => WrapFullBlockConfig                blk
+        => WrapLedgerConfig                   blk
         -> Product I (Ticked :.: LedgerState) blk
         -> LedgerState                        blk
-reapply (WrapFullBlockConfig cfg) (Pair (I block) (Comp st)) =
+reapply (WrapLedgerConfig cfg) (Pair (I block) (Comp st)) =
     reapplyLedgerBlock cfg block st
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -380,9 +380,9 @@ validateEnvelope cfg ledgerView oldTip hdr = do
     actualBlockNo  :: BlockNo
     actualPrevHash :: ChainHash blk
 
-    actualSlotNo   = blockSlot hdr
-    actualBlockNo  = blockNo   hdr
-    actualPrevHash = headerPrevHash (configCodec cfg) hdr
+    actualSlotNo   = blockSlot      hdr
+    actualBlockNo  = blockNo        hdr
+    actualPrevHash = headerPrevHash hdr
 
     expectedSlotNo :: SlotNo -- Lower bound only
     expectedSlotNo =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -373,11 +373,11 @@ instance Bridge m a => ApplyBlock (LedgerState (DualBlock m a)) (DualBlock m a) 
       (main', aux') <-
         agreeOnError DualLedgerError (
             applyLedgerBlock
-              (dualFullBlockConfigMain cfg)
+              (dualLedgerConfigMain cfg)
               dualBlockMain
               tickedDualLedgerStateMain
           , applyMaybeBlock
-              (dualFullBlockConfigAux cfg)
+              (dualLedgerConfigAux cfg)
               dualBlockAux
               tickedDualLedgerStateAux
               tickedDualLedgerStateAuxOrig
@@ -395,11 +395,11 @@ instance Bridge m a => ApplyBlock (LedgerState (DualBlock m a)) (DualBlock m a) 
                      TickedDualLedgerState{..} =
     DualLedgerState {
           dualLedgerStateMain   = reapplyLedgerBlock
-                                    (dualFullBlockConfigMain cfg)
+                                    (dualLedgerConfigMain cfg)
                                     dualBlockMain
                                     tickedDualLedgerStateMain
         , dualLedgerStateAux    = reapplyMaybeBlock
-                                    (dualFullBlockConfigAux cfg)
+                                    (dualLedgerConfigAux cfg)
                                     dualBlockAux
                                     tickedDualLedgerStateAux
                                     tickedDualLedgerStateAuxOrig
@@ -709,7 +709,7 @@ type instance ForgeStateUpdateError (DualBlock m a) = ForgeStateUpdateError m
 --
 -- Returns state unchanged on 'Nothing'
 applyMaybeBlock :: UpdateLedger blk
-                => FullBlockConfig (LedgerState blk) blk
+                => LedgerConfig blk
                 -> Maybe blk
                 -> TickedLedgerState blk
                 -> LedgerState blk
@@ -721,10 +721,10 @@ applyMaybeBlock cfg (Just block) tst _  = applyLedgerBlock cfg block tst
 --
 -- See also 'applyMaybeBlock'
 reapplyMaybeBlock :: UpdateLedger blk
-                  => FullBlockConfig (LedgerState blk) blk
+                  => LedgerConfig blk
                   -> Maybe blk
                   -> TickedLedgerState blk
-                -> LedgerState blk
+                  -> LedgerState blk
                   -> LedgerState blk
 reapplyMaybeBlock _   Nothing      _   st = st
 reapplyMaybeBlock cfg (Just block) tst _  = reapplyLedgerBlock cfg block tst

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -277,10 +277,7 @@ instance Bridge m a => HasHeader (DualHeader m a) where
   getHeaderFields = castHeaderFields . getHeaderFields . dualHeaderMain
 
 instance Bridge m a => GetPrevHash (DualBlock m a) where
-  headerPrevHash cfg =
-        castHash
-      . headerPrevHash (dualCodecConfigMain cfg)
-      . dualHeaderMain
+  headerPrevHash = castHash . headerPrevHash . dualHeaderMain
 
 {-------------------------------------------------------------------------------
   Protocol

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -29,8 +29,6 @@ module Ouroboros.Consensus.Ledger.Dual (
   , DualGenTxErr(..)
     -- * Lifted functions
   , dualExtValidationErrorMain
-  , dualFullBlockConfigMain
-  , dualFullBlockConfigAux
   , dualTopLevelConfigMain
   , ctxtDualMain
     -- * Type class family instances
@@ -173,29 +171,13 @@ instance ConfigSupportsNode m => ConfigSupportsNode (DualBlock m a) where
   Splitting the config
 -------------------------------------------------------------------------------}
 
-dualFullBlockConfigMain ::
-     FullBlockConfig (LedgerState (DualBlock m a)) (DualBlock m a)
-  -> FullBlockConfig (LedgerState m) m
-dualFullBlockConfigMain FullBlockConfig{..} = FullBlockConfig{
-      blockConfigLedger = dualLedgerConfigMain blockConfigLedger
-    , blockConfigBlock  = dualBlockConfigMain  blockConfigBlock
-    , blockConfigCodec  = dualCodecConfigMain  blockConfigCodec
-    }
-
-dualFullBlockConfigAux ::
-     FullBlockConfig (LedgerState (DualBlock m a)) (DualBlock m a)
-  -> FullBlockConfig (LedgerState a) a
-dualFullBlockConfigAux FullBlockConfig{..} = FullBlockConfig{
-      blockConfigLedger = dualLedgerConfigAux blockConfigLedger
-    , blockConfigBlock  = dualBlockConfigAux  blockConfigBlock
-    , blockConfigCodec  = dualCodecConfigAux  blockConfigCodec
-    }
-
 -- | This is only used for block production
 dualTopLevelConfigMain :: TopLevelConfig (DualBlock m a) -> TopLevelConfig m
 dualTopLevelConfigMain TopLevelConfig{..} = TopLevelConfig{
       topLevelConfigProtocol = topLevelConfigProtocol
-    , topLevelConfigBlock    = dualFullBlockConfigMain topLevelConfigBlock
+    , topLevelConfigLedger   = dualLedgerConfigMain topLevelConfigLedger
+    , topLevelConfigBlock    = dualBlockConfigMain  topLevelConfigBlock
+    , topLevelConfigCodec    = dualCodecConfigMain  topLevelConfigCodec
     }
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -685,7 +685,7 @@ chainSyncClient mkPipelineDecision0 tracer cfg
 
           -- Validate header
           let expectPrevHash = castHash (AF.headHash theirFrag)
-              actualPrevHash = headerPrevHash (configCodec cfg) hdr
+              actualPrevHash = headerPrevHash hdr
           when (actualPrevHash /= expectPrevHash) $
             disconnect $ DoesntFit actualPrevHash expectPrevHash ourTip theirTip
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -351,13 +351,7 @@ forkBlockForging maxTxCapacityOverride IS{..} blockForging =
         trace $ TraceLedgerView currentSlot
 
         -- Tick the ledger state for the 'SlotNo' we're producing a block for
-        let ticked = applyChainTick
-                       (ExtLedgerCfg {
-                            extLedgerCfgProtocol = topLevelConfigProtocol cfg
-                          , extLedgerCfgLedger   = configLedger cfg
-                          })
-                       currentSlot
-                       unticked
+        let ticked = applyChainTick (ExtLedgerCfg cfg) currentSlot unticked
 
         -- Check if we are the leader
         proof <- do

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -454,7 +454,7 @@ chainSelectionForBlock cdb@CDB{..} blockCache hdr = do
         return tipPoint
 
       -- The block @b@ fits onto the end of our current chain
-      | pointHash tipPoint == headerPrevHash (configCodec cdbTopLevelConfig) hdr -> do
+      | pointHash tipPoint == headerPrevHash hdr -> do
         -- ### Add to current chain
         trace (TryAddToCurrentChain p)
         addToCurrentChain succsOf' curChainAndLedger

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ImmDB.hs
@@ -242,7 +242,6 @@ openDB ImmDbArgs { immHasFS = SomeHasFS hasFS, ..} = do
       , prefixLen   = reconstructPrefixLen (Proxy @(Header blk))
       }
     parser = ImmDB.chunkFileParser
-               immCodecConfig
                hasFS
                (decodeDisk immCodecConfig)
                immCheckIntegrity

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -244,7 +244,7 @@ initFromDisk LgrDbArgs { lgrHasFS = SomeHasFS hasFS, .. } replayTracer immDB = w
         decodeExtLedgerState'
         (decodeRealPoint decode)
         lgrParams
-        (extLedgerCfgFromTopLevel lgrTopLevelConfig)
+        (ExtLedgerCfg lgrTopLevelConfig)
         lgrGenesis
         (streamAPI immDB)
     return (db, replayed)
@@ -377,7 +377,7 @@ validate LgrDB{..} ledgerDB blockCache numRollbacks = \hdrs -> do
     aps <- mkAps hdrs <$> atomically (readTVar varPrevApplied)
     res <- fmap rewrap $ LedgerDB.defaultResolveWithErrors resolveBlock $
              LedgerDB.ledgerDbSwitch
-               (extLedgerCfgFromTopLevel cfg)
+               (ExtLedgerCfg cfg)
                numRollbacks
                aps
                ledgerDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Parser.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Parser.hs
@@ -71,8 +71,7 @@ chunkFileParser
      , hash ~ HeaderHash blk
      , HasBinaryBlockInfo blk
      )
-  => CodecConfig blk
-  -> HasFS m h
+  => HasFS m h
   -> (forall s. Decoder s (BL.ByteString -> blk))
   -> (blk -> Bool)        -- ^ Check integrity of the block. 'False' = corrupt.
   -> ChunkFileParser
@@ -80,7 +79,7 @@ chunkFileParser
        m
        (BlockSummary hash)
        hash
-chunkFileParser cfg hasFS decodeBlock isNotCorrupt =
+chunkFileParser hasFS decodeBlock isNotCorrupt =
     ChunkFileParser $ \fsPath expectedChecksums k ->
       Util.CBOR.withStreamIncrementalOffsets hasFS decoder fsPath
         ( k
@@ -152,7 +151,7 @@ chunkFileParser cfg hasFS decodeBlock isNotCorrupt =
         (BlockSummary entry (blockNo blk), prevHash)
       where
         -- Don't accidentally hold on to the block!
-        !prevHash = convertPrevHash $ blockPrevHash cfg blk
+        !prevHash = convertPrevHash $ blockPrevHash blk
         !entry    = Secondary.Entry
           { blockOffset  = Secondary.BlockOffset  offset
           , headerOffset = Secondary.HeaderOffset headerOffset

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -46,7 +46,6 @@ import           GHC.Stack
 import           Text.Read (readMaybe)
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Util.CBOR (ReadIncrementalErr,
                      readIncremental)
@@ -163,7 +162,7 @@ initLedgerDB :: forall m h l r b. (IOLike m, ApplyBlock l b, HasCallStack)
              -> (forall s. Decoder s l)
              -> (forall s. Decoder s r)
              -> LedgerDbParams
-             -> FullBlockConfig l b
+             -> LedgerCfg l
              -> m l -- ^ Genesis ledger state
              -> StreamAPI m r b
              -> m (InitLog r, LedgerDB l r, Word64)
@@ -234,7 +233,7 @@ initFromSnapshot :: forall m h l r b. (IOLike m, ApplyBlock l b, HasCallStack)
                  -> (forall s. Decoder s l)
                  -> (forall s. Decoder s r)
                  -> LedgerDbParams
-                 -> FullBlockConfig l b
+                 -> LedgerCfg l
                  -> StreamAPI m r b
                  -> DiskSnapshot
                  -> ExceptT (InitFailure r) m (WithOrigin r, LedgerDB l r, Word64)
@@ -248,7 +247,7 @@ initFromSnapshot tracer hasFS decLedger decRef params conf streamAPI ss = do
 -- | Attempt to initialize the ledger DB starting from the given ledger DB
 initStartingWith :: forall m l r b. (Monad m, ApplyBlock l b, HasCallStack)
                  => Tracer m (TraceReplayEvent r ())
-                 -> FullBlockConfig l b
+                 -> LedgerCfg l
                  -> StreamAPI m r b
                  -> LedgerDB l r
                  -> ExceptT (InitFailure r) m (LedgerDB l r, Word64)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/TypeFamilyWrappers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/TypeFamilyWrappers.hs
@@ -19,7 +19,6 @@ module Ouroboros.Consensus.TypeFamilyWrappers (
   , WrapLedgerUpdate(..)
   , WrapLedgerWarning(..)
   , WrapTipInfo(..)
-  , WrapFullBlockConfig(..)
     -- * Protocol based
   , WrapCanBeLeader(..)
   , WrapChainDepState(..)
@@ -42,7 +41,6 @@ import           Codec.Serialise (Serialise)
 import           Cardano.Prelude (NoUnexpectedThunks)
 
 import           Ouroboros.Consensus.Block
-import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Inspect
@@ -66,7 +64,6 @@ newtype WrapLedgerErr             blk = WrapLedgerErr             { unwrapLedger
 newtype WrapLedgerUpdate          blk = WrapLedgerUpdate          { unwrapLedgerUpdate          :: LedgerUpdate             blk }
 newtype WrapLedgerWarning         blk = WrapLedgerWarning         { unwrapLedgerWarning         :: LedgerWarning            blk }
 newtype WrapTipInfo               blk = WrapTipInfo               { unwrapTipInfo               :: TipInfo                  blk }
-newtype WrapFullBlockConfig       blk = WrapFullBlockConfig       { unwrapFullBlockConfig       :: FullBlockConfig (LedgerState blk) blk }
 
 {-------------------------------------------------------------------------------
   Consensus based


### PR DESCRIPTION
This refactoring reduces the number of configs needed to apply Cardano blocks to a ledger.

* To create the `CardanoLedgerConfig c`, use `ledgerConfigCardano`
* To create the initial ledger state, use `initialLedgerStateCardano`
* To (re)apply a `CardanoBlock`, use `tickThenApply` or `tickThenReapply` with the given ledger config and state
