### PR TITLE
Mux error logging & cardano-client ChangeLog.md file

### DIFF
--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -11,8 +11,7 @@ author:              IOHK Engineering Team
 maintainer:          operations@iohk.io
 category:            Network
 build-type:          Simple
-extra-source-files:
-  ChangeLog.md
+-- extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
 
 library

--- a/network-mux/src/Network/Mux/Trace.hs
+++ b/network-mux/src/Network/Mux/Trace.hs
@@ -63,8 +63,10 @@ data MuxErrorType = MuxUnknownMiniProtocol
                   -- ^ thrown when reading of a single SDU takes too long
                   | MuxSDUWriteTimeout
                   -- ^ thrown when writing a single SDU takes too long
-                  | MuxShutdown
+                  | MuxShutdown !(Maybe MuxErrorType)
                   -- ^ Result of runMiniProtocol's completionAction in case of an error.
+                  | MuxCleanShutdown
+                  -- ^ Mux stopped by 'stopMux'
                   deriving (Show, Eq)
 
 instance Exception MuxError where

--- a/network-mux/test/Test/Mux.hs
+++ b/network-mux/test/Test/Mux.hs
@@ -1217,7 +1217,7 @@ dummyAppToChannel DummyApp {daAction, daRunTime} = \_ -> do
     threadDelay daRunTime
     case daAction of
          DummyAppSucceed -> return ((), Nothing)
-         DummyAppFail    -> throwM $ MuxError MuxShutdown "App Fail"
+         DummyAppFail    -> throwM $ MuxError (MuxShutdown Nothing) "App Fail"
 
 appToInfo :: MiniProtocolDirection mode -> DummyApp -> MiniProtocolInfo mode
 appToInfo d da = MiniProtocolInfo (daNum da) d defaultMiniProtocolLimits

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -574,7 +574,8 @@ networkErrorPolicies = ErrorPolicies
                       MuxDecodeError          -> Just ourBug
                       MuxIngressQueueOverRun  -> Just ourBug
                       MuxInitiatorOnly        -> Just ourBug
-                      MuxShutdown             -> Just ourBug
+                      MuxShutdown {}          -> Just ourBug
+                      MuxCleanShutdown        -> Just ourBug
 
                       -- in case of bearer closed / or IOException we suspend
                       -- the peer for a short time

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -668,7 +668,8 @@ remoteNetworkErrorPolicy = ErrorPolicies {
                         MuxIOException{}        -> Just (SuspendPeer shortDelay shortDelay)
                         MuxSDUReadTimeout       -> Just (SuspendPeer shortDelay shortDelay)
                         MuxSDUWriteTimeout      -> Just (SuspendPeer shortDelay shortDelay)
-                        MuxShutdown             -> Just (SuspendPeer shortDelay shortDelay)
+                        MuxShutdown {}          -> Just (SuspendPeer shortDelay shortDelay)
+                        MuxCleanShutdown        -> Just (SuspendPeer shortDelay shortDelay)
 
           -- Error policy for TxSubmission protocol: outbound side (client role)
         , ErrorPolicy


### PR DESCRIPTION
This PR contains two small changes:

- network-mux: don't wrap MuxErrors inside them selves.
- cardano-client: removed ChangeLog.md from cabal
