### PR TITLE
Add ledger updates to replay events

### DIFF
--- a/ouroboros-consensus-test/src/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/ToExpr.hs
@@ -13,7 +13,35 @@ import           Cardano.Slotting.Slot
 import           Ouroboros.Network.Block
 import           Ouroboros.Network.Point
 
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Protocol.Abstract
+
+{-------------------------------------------------------------------------------
+  ouroboros-network
+-------------------------------------------------------------------------------}
+
 instance ToExpr SlotNo
+instance ToExpr BlockNo
+
 instance ToExpr t => ToExpr (WithOrigin t)
 instance ToExpr (HeaderHash blk) => ToExpr (Point blk)
 instance (ToExpr slot, ToExpr hash) => ToExpr (Block slot hash)
+
+{-------------------------------------------------------------------------------
+  ouroboros-consensus
+-------------------------------------------------------------------------------}
+
+instance ( ToExpr (LedgerState blk)
+         , ToExpr (ChainDepState (BlockProtocol blk))
+         , ToExpr (TipInfo blk)
+         ) => ToExpr (ExtLedgerState blk)
+
+instance ( ToExpr (ChainDepState (BlockProtocol blk))
+         , ToExpr (TipInfo blk)
+         ) => ToExpr (HeaderState blk)
+
+instance ( ToExpr (TipInfo blk)
+         ) => ToExpr (AnnTip blk)

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -48,12 +48,13 @@ module Test.Util.TestBlock (
   , testInitLedger
   , testInitExtLedger
   , singleNodeTestConfig
+  , singleNodeTestConfigWithK
     -- * Support for tests
   , Permutation(..)
   , permute
   ) where
 
-import           Codec.Serialise (Serialise)
+import           Codec.Serialise (Serialise (..))
 import           Control.DeepSeq (force)
 import           Control.Monad.Except (throwError)
 import           Data.FingerTree.Strict (Measured (..))
@@ -87,6 +88,7 @@ import qualified Ouroboros.Consensus.HardFork.History as HardFork
 import           Ouroboros.Consensus.HeaderValidation
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -340,6 +342,9 @@ newtype instance Ticked (LedgerState TestBlock) = TickedTestLedger {
 
 instance UpdateLedger TestBlock
 
+instance InspectLedger TestBlock where
+  -- Defaults are fine
+
 -- | Last applied block
 --
 -- Returns 'Nothing' if the ledger is empty.
@@ -396,7 +401,10 @@ testInitExtLedger = ExtLedgerState {
 
 -- | Trivial test configuration with a single core node
 singleNodeTestConfig :: TopLevelConfig TestBlock
-singleNodeTestConfig = TopLevelConfig {
+singleNodeTestConfig = singleNodeTestConfigWithK (SecurityParam 4)
+
+singleNodeTestConfigWithK :: SecurityParam -> TopLevelConfig TestBlock
+singleNodeTestConfigWithK k = TopLevelConfig {
       topLevelConfigProtocol = BftConfig {
           bftParams  = BftParams { bftSecurityParam = k
                                  , bftNumNodes      = numCoreNodes
@@ -417,9 +425,6 @@ singleNodeTestConfig = TopLevelConfig {
 
     eraParams :: HardFork.EraParams
     eraParams = HardFork.defaultEraParams k slotLength
-
-    -- We fix k at 4 for now
-    k = SecurityParam 4
 
 {-------------------------------------------------------------------------------
   Chain of blocks
@@ -587,3 +592,19 @@ permute (Permutation n) = go (R.mkStdGen n)
     go g as = let (i, g')           = R.randomR (0, length as - 1) g
                   (before, a:after) = splitAt i as
               in a : go g' (before ++ after)
+
+{-------------------------------------------------------------------------------
+  Additional Serialise instances
+-------------------------------------------------------------------------------}
+
+instance Serialise (AnnTip TestBlock) where
+  encode = defaultEncodeAnnTip encode
+  decode = defaultDecodeAnnTip decode
+
+instance Serialise (ExtLedgerState TestBlock) where
+  encode = encodeExtLedgerState encode encode encode
+  decode = decodeExtLedgerState decode decode decode
+
+instance Serialise (RealPoint TestBlock) where
+  encode = encodeRealPoint encode
+  decode = decodeRealPoint decode

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1145,12 +1145,7 @@ deriving instance Generic (Chain blk)
 deriving instance Generic (ChainProducerState blk)
 deriving instance Generic (ReaderState blk)
 
-deriving instance ( ToExpr (HeaderState blk)
-                  , ToExpr (LedgerState blk)
-                  )
-                 => ToExpr (ExtLedgerState blk)
 deriving instance ToExpr Fingerprint
-deriving instance ToExpr BlockNo
 deriving instance ToExpr ReaderNext
 deriving instance ToExpr MaxSlotNo
 deriving instance ToExpr (HeaderHash blk) => ToExpr (ChainHash blk)
@@ -1167,15 +1162,17 @@ deriving instance ( ToExpr (HeaderHash blk)
                   )
                  => ToExpr (InvalidBlockReason blk)
 deriving instance ( ToExpr blk
-                  , ToExpr (HeaderHash  blk)
-                  , ToExpr (HeaderState blk)
+                  , ToExpr (HeaderHash blk)
+                  , ToExpr (ChainDepState (BlockProtocol blk))
+                  , ToExpr (TipInfo blk)
                   , ToExpr (LedgerState blk)
                   , ToExpr (ExtValidationError blk)
                   )
                  => ToExpr (DBModel blk)
 deriving instance ( ToExpr blk
                   , ToExpr (HeaderHash  blk)
-                  , ToExpr (HeaderState blk)
+                  , ToExpr (ChainDepState (BlockProtocol blk))
+                  , ToExpr (TipInfo blk)
                   , ToExpr (LedgerState blk)
                   , ToExpr (ExtValidationError blk)
                   )
@@ -1194,9 +1191,7 @@ deriving instance ToExpr TestBodyHash
 deriving instance ToExpr TestBlockError
 deriving instance ToExpr Blk
 deriving instance ToExpr (TipInfoIsEBB Blk)
-deriving instance ToExpr (AnnTip Blk)
 deriving instance ToExpr (LedgerState Blk)
-deriving instance ToExpr (HeaderState Blk)
 deriving instance ToExpr (HeaderError Blk)
 deriving instance ToExpr TestBlockOtherHeaderEnvelopeError
 deriving instance ToExpr (HeaderEnvelopeError Blk)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -1094,7 +1094,6 @@ instance ToExpr ChunkSize
 instance ToExpr ChunkNo
 instance ToExpr ChunkSlot
 instance ToExpr RelativeSlot
-instance ToExpr BlockNo
 instance (ToExpr a, ToExpr b, ToExpr c, ToExpr d, ToExpr e, ToExpr f, ToExpr g,
           ToExpr h, ToExpr i, ToExpr j)
       => ToExpr (a, b, c, d, e, f, g, h, i, j) where

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -266,7 +266,6 @@ library
 
   build-depends:       base              >=4.9 && <4.15
                      , base16-bytestring
-                     , bifunctors
                      , bimap             >=0.3   && <0.5
                      , binary            >=0.8   && <0.11
                      , bytestring        >=0.10  && <0.11

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Args.hs
@@ -26,6 +26,7 @@ import           Ouroboros.Consensus.Util.ResourceRegistry (ResourceRegistry)
 
 import           Ouroboros.Consensus.Storage.FS.API
 
+import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB (LedgerDB')
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB as LgrDB
 import           Ouroboros.Consensus.Storage.ChainDB.Impl.Types
                      (TraceEvent (..))
@@ -61,7 +62,7 @@ data ChainDbArgs f m blk = ChainDbArgs {
 
       -- Misc
     , cdbTracer                 :: Tracer m (TraceEvent blk)
-    , cdbTraceLedger            :: Tracer m (LgrDB.LedgerDB blk)
+    , cdbTraceLedger            :: Tracer m (LedgerDB' blk)
     , cdbRegistry               :: HKD f (ResourceRegistry m)
     , cdbGcDelay                :: DiffTime
     , cdbGcInterval             :: DiffTime

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -89,8 +89,8 @@ import           Ouroboros.Consensus.Storage.ChainDB.API (AddBlockPromise (..),
                      StreamTo, UnknownRange)
 import           Ouroboros.Consensus.Storage.Serialisation
 
-import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB (LgrDB,
-                     LgrDbSerialiseConstraints)
+import           Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB (LedgerDB',
+                     LgrDB, LgrDbSerialiseConstraints)
 import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB as LgrDB
 import           Ouroboros.Consensus.Storage.ImmutableDB (ImmutableDB,
                      ImmutableDbSerialiseConstraints)
@@ -225,7 +225,7 @@ data ChainDbEnv m blk = CDB
     -- Note that 'copyToImmutableDB' can still be executed concurrently with all
     -- others functions, just not with itself.
   , cdbTracer          :: !(Tracer m (TraceEvent blk))
-  , cdbTraceLedger     :: !(Tracer m (LgrDB.LedgerDB blk))
+  , cdbTraceLedger     :: !(Tracer m (LedgerDB' blk))
   , cdbRegistry        :: !(ResourceRegistry m)
     -- ^ Resource registry that will be used to (re)start the background
     -- threads, see 'cdbBgThreads'.
@@ -486,7 +486,7 @@ data TraceEvent blk
   | TraceInitChainSelEvent      (TraceInitChainSelEvent       blk)
   | TraceOpenEvent              (TraceOpenEvent               blk)
   | TraceIteratorEvent          (TraceIteratorEvent           blk)
-  | TraceLedgerEvent            (LgrDB.TraceEvent (RealPoint  blk))
+  | TraceLedgerEvent            (LgrDB.TraceEvent             blk)
   | TraceLedgerReplayEvent      (LgrDB.TraceLedgerReplayEvent blk)
   | TraceImmutableDBEvent       (ImmutableDB.TraceEvent       blk)
   | TraceVolatileDBEvent        (VolatileDB.TraceEvent        blk)


### PR DESCRIPTION
The bulk of this PR is changing the on-disk part of the `LedgerDB` to be parameterized over `blk`, just like the `LgrDB`. This brings the two closer together, and so this would be a good basis for unifying the two, although that isn't done in this PR yet. We _do_ simplify the QSM tests for the legder DB (the whole `LUT` business is gone, see commit message), something that was long overdue. But the main goal of this PR was to be able to add `LedgerUpdate`s to the `TraceReplayEvent`; this is particularly useful when using the DB analyser replaying all blocks, as we can then also see some information about how the ledger is evolving when it does that (since no chain selection happens during this replay, the normal `AddedToCurrentChain` trace message does not occur). 