### PR TITLE
Use BlockNo for Byron transition

### DIFF
--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -22,6 +22,7 @@ module Test.Consensus.Byron.Examples (
   ) where
 
 import           Control.Monad.Except (runExcept)
+import qualified Data.Map.Strict as Map
 
 import qualified Cardano.Chain.Block as CC.Block
 import qualified Cardano.Chain.Byron.API as CC
@@ -173,7 +174,7 @@ emptyLedgerState :: LedgerState ByronBlock
 emptyLedgerState = ByronLedgerState {
       byronLedgerTipBlockNo = Origin
     , byronLedgerState      = initState
-    , byronLedgerTransition = ByronTransitionUnknown
+    , byronLedgerTransition = ByronTransitionInfo Map.empty
     }
   where
     initState :: CC.Block.ChainValidationState

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -14,6 +14,7 @@ module Test.Consensus.Byron.Generators (
 
 import           Control.Monad (replicateM)
 import           Data.Coerce (coerce)
+import qualified Data.Map.Strict as Map
 
 import           Cardano.Binary (fromCBOR, toCBOR)
 import           Cardano.Chain.Block (ABlockOrBoundary (..),
@@ -261,10 +262,8 @@ instance Arbitrary CC.Del.Map where
   arbitrary = CC.Del.fromList <$> arbitrary
 
 instance Arbitrary ByronTransition where
-  arbitrary = oneof [
-        pure ByronTransitionUnknown
-        -- TODO: Add case once we implement this type properly (#2455)
-      ]
+  arbitrary = ByronTransitionInfo . Map.fromList <$> arbitrary
+
 instance Arbitrary (LedgerState ByronBlock) where
   arbitrary = ByronLedgerState <$> arbitrary <*> arbitrary <*> arbitrary
 

--- a/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
@@ -6,6 +6,7 @@ module Main (main) where
 
 import           Data.Foldable (asum)
 import           Options.Applicative
+import           System.IO
 
 import           Control.Tracer (Tracer (..), nullTracer)
 
@@ -181,7 +182,8 @@ analyse CmdLine {..} args =
       return $ Tracer $ \ev -> do
         traceTime <- getMonotonicTime
         let diff = diffTime traceTime startTime
-        putStrLn $ concat ["[", show diff, "] ", show ev]
+        hPutStrLn stderr $ concat ["[", show diff, "] ", show ev]
+        hFlush stderr
 
     immValidationPolicy = case (analysis, validation) of
       (_, Just ValidateAllBlocks)      -> ImmutableDB.ValidateAllChunks


### PR DESCRIPTION
The first part of this PR is #2621.

This PR proper addresses #2455. In particular, the change in computation is justified theoretically in https://github.com/input-output-hk/ouroboros-network/issues/2455#issuecomment-696036239 . Comparing the log before and after this PR confirms that it does what that comment set out to do. Before, as mentioned in https://github.com/input-output-hk/ouroboros-network/issues/2455#issuecomment-695944784 ,

```
BlockNo  SlotNo   Event
--------------------------------------------------------------------------------
4469128  4471417  2.0.0 registered
4469130  4471419  2.0.0 confirmed
4473450  4475739  2.0.0 stably confirmed, endorsements: 0
4476955  4479244  2.0.0 stably confirmed, endorsements: 1
4476960  4479249  2.0.0 stably confirmed, endorsements: 2
4476964  4479253  2.0.0 stably confirmed, endorsements: 3
4476965  4479254  2.0.0 candidate
4481285  4483574  2.0.0 stable candidate, scheduled for 208
                  Hard fork from Byron to Shelley confirmed for epoch 208
4490511  4492800  Hard fork from Byron to Shelley complete
```

after 

```
BlockNo  SlotNo   Event
--------------------------------------------------------------------------------
4469128  4471417  2.0.0 registered
4469130  4471419  2.0.0 confirmed
4473450  4475739  2.0.0 stably confirmed; endorsements: 0
4476955  4479244  2.0.0 stably confirmed; endorsements: 1
4476960  4479249  2.0.0 stably confirmed; endorsements: 2
4476964  4479253  2.0.0 stably confirmed; endorsements: 3
4476965  4479254  2.0.0 candidate; tentatively scheduled for epoch 208
4479125  4481414  2.0.0 hard fork from Byron to Shelley confirmed for epoch 208
4481285  4483574  2.0.0 stable candidate, scheduled for epoch 208
4481285  4492800  hard fork from Byron to Shelley complete
```

Notice that the only difference is that the HFC is already informed about the hard fork in block 4479125, wich

```
4479125 - 4476965 = 2160
```

indeed is `k` blocks after the proposal became a candidate, and hence is stable. 

(I _think_ checking for `k`, rather than `k + 1` is correct: if we set `k = 0`, no rollback is possible at all, so the _moment_ we see a block adopted that has the candidate in it, we know it will happen.)