### PR TITLE
Ammend github-page workflow

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -70,7 +70,7 @@ jobs:
           cp -r ./haddocks/* ./
           rm -rf haddocks
           git add -A
-          git commit -m "Deployed haddocks"
+          git commit -m "Deployed haddocks" --alow-empty
           git push https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git HEAD:gh-pages
 
 


### PR DESCRIPTION
The `github-page` workflow fails if theres nothing to commit.  Use
`--allow-empty` to aleviate it, this is not perfect but easiest to do.
