### PR TITLE
ThreadNet: add ShelleyAllegra tests

### DIFF
--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -24,6 +24,10 @@ library
                        Test.Consensus.Cardano.Generators
                        Test.Consensus.Cardano.MockCrypto
 
+                       Test.ThreadNet.Infra.ShelleyBasedHardFork
+                       Test.ThreadNet.Infra.TwoEras
+
+                       Test.ThreadNet.TxGen.Allegra
                        Test.ThreadNet.TxGen.Cardano
 
   build-depends:       base
@@ -77,6 +81,7 @@ test-suite test
                        Test.Consensus.Cardano.Golden
                        Test.Consensus.Cardano.Serialisation
                        Test.ThreadNet.Cardano
+                       Test.ThreadNet.ShelleyAllegra
 
   build-depends:       base
                      , bytestring

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
@@ -38,7 +38,7 @@ import           Ouroboros.Consensus.Util.Counting (Exactly (..))
 import           Ouroboros.Consensus.Util.SOP (Index (..))
 
 import           Ouroboros.Consensus.HardFork.Combinator
-import           Ouroboros.Consensus.HardFork.Combinator.Nary
+import           Ouroboros.Consensus.HardFork.Combinator.Embed.Nary
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -1,0 +1,278 @@
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Test infrastructure to test hard-forking from one Shelley-based era to
+-- another, e.g., Shelley to Allegra.
+module Test.ThreadNet.Infra.ShelleyBasedHardFork (
+    -- * Blocks
+    ShelleyBasedHardForkEras
+  , ShelleyBasedHardForkBlock
+    -- * Transactions
+  , pattern GenTxShelley1
+  , pattern GenTxShelley2
+    -- * Node
+  , ShelleyBasedHardForkConstraints
+  , protocolInfoShelleyBasedHardFork
+  ) where
+
+import           Control.Monad.Except (runExcept)
+import qualified Data.Map.Strict as Map
+import           Data.SOP.Strict
+import           Data.Void (Void)
+
+import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig)
+import           Ouroboros.Consensus.Node
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import           Ouroboros.Consensus.TypeFamilyWrappers
+import           Ouroboros.Consensus.Util (eitherToMaybe)
+import           Ouroboros.Consensus.Util.IOLike (IOLike)
+
+import           Ouroboros.Consensus.HardFork.Combinator
+import           Ouroboros.Consensus.HardFork.Combinator.Embed.Binary
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation
+import qualified Ouroboros.Consensus.HardFork.Combinator.State.Types as HFC
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
+import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
+import qualified Ouroboros.Consensus.HardFork.History as History
+
+import qualified Cardano.Ledger.Era as SL
+import qualified Shelley.Spec.Ledger.API as SL
+
+import           Ouroboros.Consensus.Shelley.Eras
+import           Ouroboros.Consensus.Shelley.Ledger
+import           Ouroboros.Consensus.Shelley.Node
+import           Ouroboros.Consensus.Shelley.Protocol
+
+import           Ouroboros.Consensus.Cardano.CanHardFork
+                     (ShelleyPartialLedgerConfig (..), forecastAcrossShelley,
+                     translateChainDepStateAcrossShelley)
+import           Ouroboros.Consensus.Cardano.Node
+                     (ProtocolParamsTransition (..), TriggerHardFork (..))
+
+import           Test.ThreadNet.TxGen
+import           Test.ThreadNet.TxGen.Shelley ()
+
+{-------------------------------------------------------------------------------
+  Block type
+-------------------------------------------------------------------------------}
+
+-- | Two eras, both Shelley-based.
+type ShelleyBasedHardForkEras era1 era2 =
+    '[ShelleyBlock era1, ShelleyBlock era2]
+
+type ShelleyBasedHardForkBlock era1 era2 =
+  HardForkBlock (ShelleyBasedHardForkEras era1 era2)
+
+{-------------------------------------------------------------------------------
+  Pattern synonyms, for encapsulation and legibility
+-------------------------------------------------------------------------------}
+
+type ShelleyBasedHardForkGenTx era1 era2 =
+  GenTx (ShelleyBasedHardForkBlock era1 era2)
+
+pattern GenTxShelley1 ::
+     GenTx (ShelleyBlock era1)
+  -> ShelleyBasedHardForkGenTx era1 era2
+pattern GenTxShelley1 tx = HardForkGenTx (OneEraGenTx (Z tx))
+
+pattern GenTxShelley2 ::
+     GenTx (ShelleyBlock era2)
+  -> ShelleyBasedHardForkGenTx era1 era2
+pattern GenTxShelley2 tx = HardForkGenTx (OneEraGenTx (S (Z tx)))
+
+{-# COMPLETE GenTxShelley1, GenTxShelley2 #-}
+
+pattern ShelleyBasedHardForkNodeToNodeVersion1 ::
+     BlockNodeToNodeVersion (ShelleyBasedHardForkBlock era1 era2)
+pattern ShelleyBasedHardForkNodeToNodeVersion1 =
+    HardForkNodeToNodeEnabled
+      HardForkSpecificNodeToNodeVersion1
+      (  EraNodeToNodeEnabled ShelleyNodeToNodeVersion1
+      :* EraNodeToNodeEnabled ShelleyNodeToNodeVersion1
+      :* Nil
+      )
+
+pattern ShelleyBasedHardForkNodeToClientVersion1 ::
+     BlockNodeToClientVersion (ShelleyBasedHardForkBlock era1 era2)
+pattern ShelleyBasedHardForkNodeToClientVersion1 =
+    HardForkNodeToClientEnabled
+      HardForkSpecificNodeToClientVersion2
+      (  EraNodeToClientEnabled ShelleyNodeToClientVersion2
+      :* EraNodeToClientEnabled ShelleyNodeToClientVersion2
+      :* Nil
+      )
+
+{-------------------------------------------------------------------------------
+  Consensus instances
+-------------------------------------------------------------------------------}
+
+type ShelleyBasedHardForkConstraints era1 era2 =
+  ( ShelleyBasedEra era1
+  , ShelleyBasedEra era2
+  , EraCrypto era1 ~ EraCrypto era2
+  , SL.PreviousEra era2 ~ era1
+
+  , SL.TranslateEra       era2 SL.Tx
+  , SL.TranslateEra       era2 SL.NewEpochState
+  , SL.TranslateEra       era2 SL.ShelleyGenesis
+
+  , SL.TranslationError   era2 SL.NewEpochState  ~ Void
+  , SL.TranslationError   era2 SL.ShelleyGenesis ~ Void
+
+  , SL.TranslationContext era2 ~ ()
+  )
+
+instance ShelleyBasedHardForkConstraints era1 era2
+      => SerialiseHFC (ShelleyBasedHardForkEras era1 era2)
+   -- use defaults
+
+instance ShelleyBasedHardForkConstraints era1 era2
+      => CanHardFork (ShelleyBasedHardForkEras era1 era2) where
+  hardForkEraTranslation = EraTranslation {
+        translateLedgerState   = PCons translateLedgerState                PNil
+      , translateChainDepState = PCons translateChainDepStateAcrossShelley PNil
+      , translateLedgerView    = PCons translateLedgerView                 PNil
+      }
+    where
+      translateLedgerState ::
+           InPairs.RequiringBoth
+             WrapLedgerConfig
+             (HFC.Translate LedgerState)
+             (ShelleyBlock era1)
+             (ShelleyBlock era2)
+      translateLedgerState = InPairs.ignoringBoth $ HFC.Translate $ \_epochNo ->
+          unComp . SL.translateEra' () . Comp
+
+      translateLedgerView ::
+           InPairs.RequiringBoth
+              WrapLedgerConfig
+              (HFC.TranslateForecast LedgerState WrapLedgerView)
+              (ShelleyBlock era1)
+              (ShelleyBlock era2)
+      translateLedgerView =
+          InPairs.RequireBoth $ \(WrapLedgerConfig cfg1) (WrapLedgerConfig cfg2) ->
+            HFC.TranslateForecast $ forecastAcrossShelley cfg1 cfg2
+
+  hardForkChainSel = Tails.mk2 SelectSameProtocol
+
+  hardForkInjectTxs = InPairs.mk2 $ InPairs.ignoringBoth (InjectTx translateTx)
+    where
+      translateTx ::
+           GenTx (ShelleyBlock era1)
+        -> Maybe (GenTx (ShelleyBlock era2))
+      translateTx =
+          fmap unComp . eitherToMaybe . runExcept . SL.translateEra () . Comp
+
+instance ShelleyBasedHardForkConstraints era1 era2
+      => SupportedNetworkProtocolVersion (ShelleyBasedHardForkBlock era1 era2) where
+  supportedNodeToNodeVersions _ = Map.fromList $
+      [ (maxBound, ShelleyBasedHardForkNodeToNodeVersion1)
+      ]
+
+  supportedNodeToClientVersions _ = Map.fromList $
+      [ (maxBound, ShelleyBasedHardForkNodeToClientVersion1)
+      ]
+
+{-------------------------------------------------------------------------------
+  Protocol info
+-------------------------------------------------------------------------------}
+
+protocolInfoShelleyBasedHardFork ::
+     forall m era1 era2. (IOLike m, ShelleyBasedHardForkConstraints era1 era2)
+  => ProtocolParamsShelleyBased era1 Identity
+  -> SL.ProtVer
+  -> SL.ProtVer
+  -> ProtocolParamsTransition (ShelleyBlock era1) (ShelleyBlock era2)
+  -> ProtocolInfo m (ShelleyBasedHardForkBlock era1 era2)
+protocolInfoShelleyBasedHardFork protocolParamsShelleyBased
+                                 protVer1
+                                 protVer2
+                                 protocolParamsTransition =
+    protocolInfoBinary
+      -- Era 1
+      protocolInfo1
+      eraParams1
+      tpraosParams
+      toPartialLedgerConfig1
+      -- Era 2
+      protocolInfo2
+      eraParams2
+      tpraosParams
+      toPartialLedgerConfig2
+  where
+    ProtocolParamsShelleyBased {
+        shelleyBasedGenesis
+      , shelleyBasedInitialNonce
+      , shelleyBasedLeaderCredentials
+      } = protocolParamsShelleyBased
+
+    -- Era 1
+
+    genesis1 :: SL.ShelleyGenesis era1
+    genesis1 = shelleyBasedGenesis
+
+    protocolInfo1 :: ProtocolInfo m (ShelleyBlock era1)
+    protocolInfo1 =
+        protocolInfoShelleyBased
+          protocolParamsShelleyBased
+          protVer1
+
+    eraParams1 :: History.EraParams
+    eraParams1 = shelleyEraParams genesis1
+
+    ProtocolParamsTransition { transitionTrigger } = protocolParamsTransition
+
+    toPartialLedgerConfig1 ::
+         LedgerConfig (ShelleyBlock era1)
+      -> PartialLedgerConfig (ShelleyBlock era1)
+    toPartialLedgerConfig1 cfg = ShelleyPartialLedgerConfig {
+          shelleyLedgerConfig    = cfg
+        , shelleyTriggerHardFork = transitionTrigger
+        }
+
+    -- Era 2
+
+    genesis2 :: SL.ShelleyGenesis era2
+    genesis2 = SL.translateEra' () genesis1
+
+    protocolInfo2 :: ProtocolInfo m (ShelleyBlock era2)
+    protocolInfo2 =
+        protocolInfoShelleyBased
+          ProtocolParamsShelleyBased {
+              shelleyBasedGenesis = genesis2
+            , shelleyBasedInitialNonce
+            , shelleyBasedLeaderCredentials
+            }
+          protVer2
+
+    eraParams2 :: History.EraParams
+    eraParams2 = shelleyEraParams genesis2
+
+    toPartialLedgerConfig2 ::
+         LedgerConfig (ShelleyBlock era2)
+      -> PartialLedgerConfig (ShelleyBlock era2)
+    toPartialLedgerConfig2 cfg = ShelleyPartialLedgerConfig {
+          shelleyLedgerConfig    = cfg
+        , shelleyTriggerHardFork = TriggerHardForkNever
+        }
+
+{-------------------------------------------------------------------------------
+  TxGen instance
+-------------------------------------------------------------------------------}
+
+-- | Use a generic implementation for 'TxGen'
+instance ( TxGen (ShelleyBlock era1)
+         , TxGen (ShelleyBlock era2)
+         , ShelleyBasedHardForkConstraints era1 era2
+         ) => TxGen (ShelleyBasedHardForkBlock era1 era2) where
+  type TxGenExtra (ShelleyBasedHardForkBlock era1 era2) =
+    NP WrapTxGenExtra (ShelleyBasedHardForkEras era1 era2)
+  testGenTxs = testGenTxsHfc

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/TwoEras.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/TwoEras.hs
@@ -1,0 +1,490 @@
+{-# LANGUAGE DataKinds      #-}
+{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE GADTs          #-}
+{-# LANGUAGE LambdaCase     #-}
+{-# LANGUAGE MultiWayIf     #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TypeOperators  #-}
+
+-- | Definitions used in ThreadNet tests that involve two eras.
+module Test.ThreadNet.Infra.TwoEras (
+    -- * Generators
+    Partition (..)
+  , genNonce
+  , genPartition
+  , genTestConfig
+  -- * Era inspection
+  , ReachesEra2 (..)
+  , activeSlotCoeff
+  , isFirstEraBlock
+  , ledgerReachesEra2
+  , mkMessageDelay
+  , numFirstEraEpochs
+  , partitionExclusiveUpperBound
+  , secondEraOverlaySlots
+  , shelleyEpochSize
+  -- * Properties
+  , label_hadActiveNonOverlaySlots
+  , label_ReachesEra2
+  , prop_ReachesEra2
+  , tabulateFinalIntersectionDepth
+  , tabulatePartitionDuration
+  , tabulatePartitionPosition
+  ) where
+
+import           Control.Exception (assert)
+import           Control.Monad.Identity (Identity (runIdentity))
+import           Data.Functor ((<&>))
+import qualified Data.Map as Map
+import           Data.Maybe (isJust)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.Word (Word64)
+import           GHC.Generics (Generic)
+
+import           Test.QuickCheck
+
+import           Cardano.Slotting.EpochInfo
+import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..),
+                     SlotNo (..))
+
+import           Ouroboros.Consensus.Config.SecurityParam
+import qualified Ouroboros.Consensus.HardFork.History.Util as Util
+import           Ouroboros.Consensus.Node.ProtocolInfo
+import           Ouroboros.Consensus.NodeId
+
+import           Data.SOP.Strict (NS (..))
+import           Ouroboros.Consensus.HardFork.Combinator (HardForkBlock (..),
+                     OneEraBlock (..))
+
+import qualified Cardano.Chain.Common as CC.Common
+import           Cardano.Chain.ProtocolConstants (kEpochSlots)
+import           Cardano.Chain.Slotting (unEpochSlots)
+
+import qualified Shelley.Spec.Ledger.BaseTypes as SL
+import qualified Shelley.Spec.Ledger.OverlaySchedule as SL
+
+import           Test.ThreadNet.General
+import qualified Test.ThreadNet.Infra.Shelley as Shelley
+import           Test.ThreadNet.Network (CalcMessageDelay (..), NodeOutput (..))
+import           Test.ThreadNet.Util.Expectations (NumBlocks (..))
+import qualified Test.ThreadNet.Util.NodeTopology as Topo
+import qualified Test.Util.BoolProps as BoolProps
+import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Slots (NumSlots (..))
+
+-- | When and for how long the nodes are partitioned
+--
+-- The nodes are divided via message delays into two sub-networks by the parity
+-- of their 'CoreNodeId'.
+data Partition = Partition SlotNo NumSlots
+  -- ^ the scheduled start slot and duration (which includes the start slot)
+  deriving (Show)
+
+partitionExclusiveUpperBound :: Partition -> SlotNo
+partitionExclusiveUpperBound (Partition s (NumSlots dur)) =
+    Util.addSlots dur s
+
+genNonce :: Gen SL.Nonce
+genNonce = frequency
+      [ (1, pure SL.NeutralNonce)
+      , (9, SL.mkNonceFromNumber <$> arbitrary)
+      ]
+
+-- | Generate a 'setupTestConfig' relevant to the case where the first era (eg
+-- Byron) lasts for one epoch and the second era (eg Shelley) lasts for an
+-- interesting number of slots.
+genTestConfig :: SecurityParam -> (EpochSize, EpochSize) -> Gen TestConfig
+genTestConfig k (EpochSize epochSize1, EpochSize epochSize2) = do
+    initSeed <- arbitrary
+
+    numSlots <- do
+      let wiggle = min epochSize1 (2 * maxRollbacks k)
+
+          approachSecondEra     =
+              choose (0, wiggle)     <&> \t -> epochSize1 + t - wiggle
+          reachSecondEra        =
+              choose (1, epochSize2) <&> \t -> epochSize1 + t
+          reachThirdEpochOfSecondEra =
+              choose (1, epochSize2) <&> \t -> epochSize1 + 2 * epochSize2 + t
+
+      fmap NumSlots $ frequency $
+        [ (05, approachSecondEra)
+        , (64, reachSecondEra)
+        , (31, reachThirdEpochOfSecondEra)
+        ]
+
+    -- This test has more slots than most, so we de-emphasize the relatively
+    -- expensive n=5 case. For example:
+    --
+    -- > 250 tests with 30% 2, 30% 3, 30% 4, and 10% 5 took 500s
+    -- > 250 tests with 100% 5 took 1000s
+    ncn <- frequency [(9, choose (2, 4)), (1, pure 5)]
+
+    -- Ensure that each partition class is internally connected.
+    nodeTopology <- do
+      topo0   <- Topo.genNodeTopology $ NumCoreNodes ncn
+      oddTopo <- do
+        -- eg nodes 1 3 for ncn = 5
+        topo <- Topo.genNodeTopology $ NumCoreNodes $ div ncn 2
+        let rename (CoreNodeId i) = CoreNodeId (2 * i + 1)
+        pure $ Topo.mapNodeTopology rename topo
+      evenTopo <- do
+        -- eg nodes 0 2 4 for ncn = 5
+        topo <- Topo.genNodeTopology $ NumCoreNodes $ ncn - div ncn 2
+        let rename (CoreNodeId i) = CoreNodeId (2 * i)
+        pure $ Topo.mapNodeTopology rename topo
+      pure $
+        Topo.unionNodeTopology evenTopo $
+        Topo.unionNodeTopology oddTopo $
+        topo0
+
+    pure TestConfig
+      { initSeed
+      , nodeTopology
+      , numCoreNodes = NumCoreNodes ncn
+      , numSlots
+      }
+
+-- | Generate 'setupPartition'
+genPartition :: NumCoreNodes -> NumSlots -> SecurityParam -> Gen Partition
+genPartition (NumCoreNodes n) (NumSlots t) (SecurityParam k) = do
+    let ultimateSlot :: Word64
+        ultimateSlot = assert (t > 0) $ t - 1
+
+        crop :: Word64 -> Word64
+        crop s = min ultimateSlot s
+
+    -- Fundamental plan: all @MsgRollForward@ sent during the partition only
+    -- arrive at the onset of slot after it. The partition begins at the onset
+    -- of @firstSlotIn@ and ends at the onset of @firstSlotAfter@.
+
+    -- FACT (A) The leader of @firstSlotAfter@ will forge before fully reacting
+    -- to the @MsgRollForward@s that just arrived, due to a race in the test
+    -- infrastructure that is consistently won by the forge. Thus the two
+    -- class's unique extensions consist of the blocks forged in the slots from
+    -- @firstSlotIn@ to @firstSlotAfter@ /inclusive/.
+
+    -- @w@ is defined below this large comment to be how long the partition
+    -- should last (this may be 'crop'ped farther below if the partition ends
+    -- up near the end of the test)
+    --
+    -- Because of FACT (A), we limit the partition duration so that at least
+    -- one of the two partition classes will forge /strictly/ /less/ /than/ @k@
+    -- such blocks. While both classes would be able to rollback if we let them
+    -- forge @k@ such blocks, they might (TODO "might" or "will"?) not able to
+    -- /decide/ that they need to rollback, since the relevant ChainSync client
+    -- might (TODO will?) not be able to forecast a ledger view far-enough into
+    -- the future to validate the @k+1@st header from the other class after the
+    -- partition ends. It will remain unaware that a longer chain exists and
+    -- end up stuck on its own distinct chain. Hence it's a Common Prefix
+    -- violation.
+    --
+    -- We therefore motivate an upper bound on the partition duration @w@ for a
+    -- net with @n@ nodes by considering the two variables' parities.
+    --
+    -- o For @n = 2h@ nodes and @w = 2u@ slots, the classes respectively forge
+    --   @u@ and @u+1@ blocks. (The @+1@th block is forged in
+    --   @firstSlotAfter@.) The preceding paragraph requires @u < k@ requires
+    --   @u <= k-1@ requires @w <= 2k-2@. So @w <= 2k-2@ when @w@ is even.
+    --
+    -- o For @n = 2h@ nodes and @w = 2u+1@ slots, the classes both forge @u+1@
+    --   blocks. (The second @+1@th block is forged in @firstSlotAfter@.) The
+    --   preceding paragraph requires @u+1 < k@ requires @u <= k-2@ requires @w
+    --   <= 2k-3@. So @w <= 2k-3@ when @w@ is odd. Note that @w <= 2k-2@ is
+    --   equivalent since @w@ is assumed odd.
+    --
+    -- o For @n = 2h+1@ nodes, the smaller class forges at most the number of
+    --   blocks considered in the above cases for even @n@, so this case
+    --   doesn't contribute anything novel to the upper bound. The smaller
+    --   class has less than half of the nodes and so will violate Chain Growth
+    --   /if/ /given/ /enough/ /time/ /alone/. But for Byron at least, the
+    --   logic for avoiding a Common Prefix violation already establishes a
+    --   sufficiently strict upper bound to preclude a Chain Growth violation,
+    --   since Chain Growth isn't technically violated until @2k@ slots have
+    --   passed (it's also relevant that the net forges at full round-robin
+    --   speed until the partition starts). (TODO does that cover Shelley too?)
+    --
+    -- Thus @w@ can range from @0@ to @2k-2@ inclusive.
+    w <- assert (k > 0) $ choose (0, 2 * k - 2)
+
+    -- Each of the the following milestones happens at the listed slot in the
+    -- absence of a partition.
+    --
+    -- o In slots 0 and 1 the proposal and the votes confirm it
+    --
+    -- o In slot 2k+1 the confirmation becomes stable
+    --
+    -- o In slot 2k+1+quorum the nodes endorse it
+    --
+    -- o In slot 4k+1+quorum the endorsement is stable
+    --
+    -- o In slot 10k the update is adopted.
+    --
+    -- We are most interested in what happens when the partition is near these
+    -- milestones.
+    mbFocus <- do
+      let quorum = div n 2   -- in the right ballpark
+      frequency $
+        map (\(wgt, mbDur) -> (wgt, pure mbDur)) $
+        filter (maybe True (< t) . snd)
+          [ (5,  Nothing)
+          , (1,  Just 0)
+          , (1,  Just $ 2 * k + 1)
+          , (1,  Just $ 2 * k + 1 + quorum)
+          , (1,  Just $ 4 * k + 1)
+          , (1,  Just $ 4 * k + 1 + quorum)
+          , (20, assert (numFirstEraEpochs == (1 :: Int)) $
+                 Just $ byronEpochSize (SecurityParam k))
+          ]
+
+    -- Position the partition so that it at least abuts the focus slot.
+    firstSlotIn <- choose $
+      case mbFocus of
+        Nothing    -> (0,                            ultimateSlot    )
+        Just focus -> (crop $ focus `monus` (w + 1), crop $ focus + 1)
+
+    let -- Because of FACT (A), we require there to be at least one slot after
+        -- the partition. This doesn't ensure full consensus, because the block
+        -- forged in @firstSlotAfter@ may create a chain as long as that of the
+        -- other partition (first era) or even multiple such chains (second
+        -- era). But it does ensure that all final chains will be the same
+        -- length.
+        firstSlotAfter :: Word64
+        firstSlotAfter = crop $ firstSlotIn + w
+
+        dur :: Word64
+        dur = Util.countSlots (SlotNo firstSlotAfter) (SlotNo firstSlotIn)
+
+    pure $ Partition (SlotNo firstSlotIn) (NumSlots dur)
+
+-- | Whether there was a block forged in a non-overlay slot in the second era.
+--
+-- This event evidences that the stake pools were correctly created and
+-- delegated to.
+label_hadActiveNonOverlaySlots ::
+     TestOutput (HardForkBlock (era ': eras))
+  -> Set SlotNo
+  -> String
+label_hadActiveNonOverlaySlots testOutput overlaySlots =
+    show $ or $
+    [ Set.notMember slot overlaySlots
+    | (_nid, no) <- Map.toList testOutputNodes
+    , let NodeOutput{nodeOutputForges} = no
+    , (slot, blk) <- Map.toDescList nodeOutputForges
+    , not $ isFirstEraBlock blk
+    ]
+  where
+    TestOutput{testOutputNodes} = testOutput
+
+-- | All OBFT overlay slots in the second era.
+secondEraOverlaySlots ::
+     NumSlots
+  -> NumSlots
+  -> SL.UnitInterval
+  -> EpochSize
+  -> Set SlotNo
+secondEraOverlaySlots numSlots (NumSlots numFirstEraSlots) d secondEraEpochSize =
+    Set.filter (< SlotNo t) $
+    Set.unions $
+    takeWhile (isJust . Set.lookupLT (SlotNo t)) $
+    map overlayOffsets [0..]
+  where
+    NumSlots t = numSlots
+
+    -- The overlay slots in the ith epoch of the second era.
+    --
+    -- TODO: This function conceptually should be simpler if we created a
+    -- sufficiently accurate 'EpochInfo' and so didn't need the shift. But
+    -- doing so (eg by constructing a HardFork @Summary@) is currently
+    -- significantly more involved than this workaround.
+    overlayOffsets :: Word64 -> Set SlotNo
+    overlayOffsets i =
+        -- Shift to account for the first era.
+        Set.mapMonotonic (Util.addSlots numFirstEraSlots) .
+        Set.fromList $
+        -- Note: this is only correct if each epoch uses the same value for @d@
+        SL.overlaySlots
+          (runIdentity $ epochInfoFirst epochInfo (EpochNo i))
+          -- notably contains setupD
+          d
+            -- NB 0 <-> the first epoch of the second era
+          (runIdentity $ epochInfoSize epochInfo (EpochNo i))
+
+    -- Suitable only for this narrow context
+    epochInfo :: EpochInfo Identity
+    epochInfo = fixedSizeEpochInfo secondEraEpochSize
+
+tabulatePartitionPosition ::
+     NumSlots -> Partition -> Bool -> Property -> Property
+tabulatePartitionPosition (NumSlots numFirstEraSlots) part transitions =
+    tabulate "partition in or abuts era (First era, Second era)"
+      [ show (inclFirstEra, inclSecondEra) ]
+  where
+    Partition (SlotNo firstSlotIn) (NumSlots dur) = part
+    firstSlotAfter                                = firstSlotIn + dur
+
+    inclFirstEra  =
+        dur > 0 && (not transitions || firstSlotIn    <= numFirstEraSlots)
+    inclSecondEra =
+        dur > 0 && (transitions     && firstSlotAfter >= numFirstEraSlots)
+
+tabulateFinalIntersectionDepth :: SecurityParam -> NumBlocks -> String -> Property -> Property
+tabulateFinalIntersectionDepth k (NumBlocks finalIntersectionDepth) finalBlockEra =
+    tabul "count"  (show          finalIntersectionDepth) .
+    tabul "k frac" (approxFracK k finalIntersectionDepth) .
+    tabul "k diff" (diffK       k finalIntersectionDepth)
+  where
+    lbl = "final intersection depth"
+    tabul s x = tabulate
+        (lbl <> ", " <> finalBlockEra <> ", " <> s)
+        [x <> " blocks"]
+
+tabulatePartitionDuration :: SecurityParam -> Partition -> Property -> Property
+tabulatePartitionDuration k part =
+    tabul "count"  (show          dur) .
+    tabul "k frac" (approxFracK k dur)
+  where
+    tabul s x =
+        tabulate ("partition duration, " <> s) [x <> " slots"]
+
+    Partition _ (NumSlots dur) = part
+
+{-------------------------------------------------------------------------------
+  Constants
+-------------------------------------------------------------------------------}
+
+-- | The active slot coefficient, @f@.
+--
+-- Some of these tests include epochs in the second era in which stakepools are
+-- actually leading. In that case, the @k@, @d@, and @f@ parameters and the
+-- length of any scheduled network partitions need to be balanced so that Common
+-- Prefix violations (in particular, wedges) are extremely unlikely.
+activeSlotCoeff :: Rational
+activeSlotCoeff = 0.2   -- c.f. mainnet is more conservative, using 0.05
+
+-- | The number of epochs in the first era in this test
+--
+-- All nodes join in slot 0, we generate the proposal in slot 0, we also
+-- generate the votes in slot 0, and the nodes are endorsing the proposal as of
+-- slot 0. Thus we expect that the first era will end after one epoch. Otherwise
+-- it would indicate some sort of protocol failure.
+numFirstEraEpochs :: Num a => a
+numFirstEraEpochs = 1
+
+{-------------------------------------------------------------------------------
+  ReachesEra2 property
+-------------------------------------------------------------------------------}
+
+-- | Whether the test included second era blocks and (pre)reqs relevant to that
+--
+-- Note these fields are ordered alphabetically not semantically; see
+-- 'label_ReachesEra2'.
+data ReachesEra2 = ReachesEra2
+  { rsEra1Slots  :: BoolProps.Prereq
+    -- ^ enough slots in the first era to enable a block in the second era
+  , rsPV         :: BoolProps.Prereq
+    -- ^ sufficient protocol version to enable a block in the second era
+  , rsEra2Blocks :: Bool
+    -- ^ blocks from the second era included in final chains
+  , rsEra2Slots  :: BoolProps.Requirement
+    -- ^ enough slots in the second era to necessitate a block in the second era
+  }
+  deriving (Generic, Show)
+
+instance BoolProps.CollectReqs ReachesEra2
+
+-- | List the (pre)reqs in semantic order, followed by the observation
+label_ReachesEra2 :: ReachesEra2 -> String
+label_ReachesEra2 reachesEra2 =
+    prepend "pv"     rsPV $
+    prepend "slots1" rsEra1Slots $
+    prepend "slots2" rsEra2Slots $
+    "blocks2 " <> show rsEra2Blocks
+  where
+    -- incur a GHC warning if the number of fields changes
+    ReachesEra2 _ _ _ _dummy = reachesEra2
+    -- this pattern should bind each field by name
+    ReachesEra2
+      { rsEra1Slots
+      , rsPV
+      , rsEra2Blocks
+      , rsEra2Slots
+      } = reachesEra2
+
+    prepend :: Show a => String -> a -> String -> String
+    prepend s req x = s <> " " <> show req <> ", " <> x
+
+-- | Is the update proposal adopted?
+ledgerReachesEra2 :: ReachesEra2 -> Bool
+ledgerReachesEra2 rs = BoolProps.checkReqs rs /= Just False
+
+-- | Checks if the observation satisfies the (pre)reqs
+prop_ReachesEra2 :: ReachesEra2 -> Property
+prop_ReachesEra2 rs = case BoolProps.checkReqs rs of
+    Nothing  -> property True
+    Just req ->
+        counterexample (show rs) $
+        counterexample (msg req) $
+        rsEra2Blocks == req
+  where
+    ReachesEra2{rsEra2Blocks} = rs
+
+    msg :: Bool -> String
+    msg req = if req
+        then "the final chains should include at least one second era block"
+        else "the final chains should not include any second era blocks"
+
+{-------------------------------------------------------------------------------
+  A short even-odd partition
+-------------------------------------------------------------------------------}
+
+-- | The temporary partition as a 'CalcMessageDelay'
+--
+-- Calculates the delays that implement 'setupPartition'.
+mkMessageDelay :: Partition -> CalcMessageDelay blk
+mkMessageDelay part = CalcMessageDelay $
+    \(CoreNodeId i, CoreNodeId j) curSlot _hdr -> NumSlots $ if
+      | curSlot <  firstSlotIn    -> 0
+      | curSlot >= firstSlotAfter -> 0
+      | mod i 2 == mod j 2        -> 0
+      | otherwise                 -> unSlotNo $ firstSlotAfter - curSlot
+  where
+    Partition firstSlotIn _ = part
+    firstSlotAfter          = partitionExclusiveUpperBound part
+
+{-------------------------------------------------------------------------------
+  Miscellany
+-------------------------------------------------------------------------------}
+
+byronEpochSize :: SecurityParam -> Word64
+byronEpochSize (SecurityParam k) =
+    unEpochSlots $ kEpochSlots $ CC.Common.BlockCount k
+
+shelleyEpochSize :: SecurityParam -> Word64
+shelleyEpochSize k = unEpochSize $ Shelley.mkEpochSize k activeSlotCoeff
+
+isFirstEraBlock :: HardForkBlock (era ': eras) -> Bool
+isFirstEraBlock = \case
+    HardForkBlock (OneEraBlock Z{}) -> True
+    _                               -> False
+
+-- | Render a number as a positive difference from @k@
+--
+-- PREREQUISITE: The number must not be greater than @k@.
+diffK :: SecurityParam -> Word64 -> String
+diffK (SecurityParam k) v =
+    assert (k >= v) $
+    "k - " <> show (k - v)
+
+-- | Render a number as the nearest tenths of @k@
+approxFracK :: SecurityParam -> Word64 -> String
+approxFracK (SecurityParam k) v =
+    "k * " <> show (fromIntegral tenths / 10 :: Double)
+  where
+    ratio  = toRational v / toRational k
+    tenths = round (ratio * 10) :: Int
+
+-- | <https://en.wikipedia.org/wiki/Monus>
+monus :: (Num a, Ord a) => a -> a -> a
+monus a b = if a <= b then 0 else a - b

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Allegra.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Allegra.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Test.ThreadNet.TxGen.Allegra () where
+
+import           Ouroboros.Consensus.Shelley.Eras
+import           Ouroboros.Consensus.Shelley.Ledger
+
+import           Test.ThreadNet.TxGen (TxGen (..))
+
+-- | Dummy generator until CAD-2119 is done, i.e., the transaction generator in
+-- the ledger has been generalised over the eras.
+instance TxGen (ShelleyBlock (AllegraEra c)) where
+
+  type TxGenExtra (ShelleyBlock (AllegraEra c)) = ()
+
+  testGenTxs _ _ _ _ _ _ = pure []

--- a/ouroboros-consensus-cardano-test/test/Main.hs
+++ b/ouroboros-consensus-cardano-test/test/Main.hs
@@ -9,6 +9,7 @@ import qualified Test.Consensus.Cardano.ByronCompatibility (tests)
 import qualified Test.Consensus.Cardano.Golden (tests)
 import qualified Test.Consensus.Cardano.Serialisation (tests)
 import qualified Test.ThreadNet.Cardano (tests)
+import qualified Test.ThreadNet.ShelleyAllegra (tests)
 
 main :: IO ()
 main = sodiumInit >> defaultMainWithIohkNightly tests
@@ -20,4 +21,5 @@ tests =
   , Test.Consensus.Cardano.Golden.tests
   , Test.Consensus.Cardano.Serialisation.tests
   , Test.ThreadNet.Cardano.tests
+  , Test.ThreadNet.ShelleyAllegra.tests
   ]

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
@@ -1,12 +1,8 @@
-{-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE MultiWayIf          #-}
+{-# LANGUAGE GADTs               #-}
 {-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-{-# LANGUAGE TypeFamilies        #-}
 
 module Test.ThreadNet.Cardano (
     tests
@@ -14,27 +10,21 @@ module Test.ThreadNet.Cardano (
 
 import           Control.Exception (assert)
 import           Control.Monad (replicateM)
-import           Control.Monad.Identity (Identity (runIdentity))
-import           Data.Functor ((<&>))
 import qualified Data.Map as Map
-import           Data.Maybe (isJust, maybeToList)
+import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word (Word64)
-import           GHC.Generics (Generic)
 
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
-import           Cardano.Slotting.EpochInfo
-import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..),
-                     SlotNo (..))
+import           Cardano.Slotting.Slot (EpochSize (..), SlotNo (..))
 
 import           Ouroboros.Consensus.BlockchainTime
 import           Ouroboros.Consensus.Config.SecurityParam
-import qualified Ouroboros.Consensus.HardFork.History.Util as Util
 import           Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -56,9 +46,7 @@ import           Ouroboros.Consensus.Byron.Ledger.Conversions
 import           Ouroboros.Consensus.Byron.Node
 
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.BaseTypes as SL (ActiveSlotCoeff,
-                     mkNonceFromNumber)
-import qualified Shelley.Spec.Ledger.OverlaySchedule as SL (overlaySlots)
+import qualified Shelley.Spec.Ledger.BaseTypes as SL (ActiveSlotCoeff)
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
 import           Ouroboros.Consensus.Shelley.Node
@@ -71,14 +59,13 @@ import           Test.Consensus.Cardano.MockCrypto (MockCryptoCompatByron)
 import           Test.ThreadNet.General
 import qualified Test.ThreadNet.Infra.Byron as Byron
 import qualified Test.ThreadNet.Infra.Shelley as Shelley
-import           Test.ThreadNet.Network (CalcMessageDelay (..), NodeOutput (..),
+import           Test.ThreadNet.Network (NodeOutput (..),
                      TestNodeInitialization (..))
 import           Test.ThreadNet.TxGen.Cardano (CardanoTxGenExtra (..))
 import           Test.ThreadNet.Util.Expectations (NumBlocks (..))
 import           Test.ThreadNet.Util.NodeJoinPlan (trivialNodeJoinPlan)
 import           Test.ThreadNet.Util.NodeRestarts (noRestarts)
 import           Test.ThreadNet.Util.NodeToNodeVersion (genVersionFiltered)
-import qualified Test.ThreadNet.Util.NodeTopology as Topo
 import           Test.ThreadNet.Util.Seed (runGen)
 import qualified Test.Util.BoolProps as BoolProps
 import           Test.Util.HardFork.Future
@@ -86,21 +73,11 @@ import           Test.Util.Nightly
 import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Slots (NumSlots (..))
 
+import           Test.ThreadNet.Infra.TwoEras
+
 -- | Use 'MockCryptoCompatByron' so that bootstrap addresses and
 -- bootstrap witnesses are supported.
 type Crypto = MockCryptoCompatByron
-
--- | When and for how long the nodes are partitioned
---
--- The nodes are divided via message delays into two sub-networks by the parity
--- of their 'CoreNodeId'.
-data Partition = Partition SlotNo NumSlots
-  -- ^ the scheduled start slot and duration (which includes the start slot)
-  deriving (Show)
-
-partitionExclusiveUpperBound :: Partition -> SlotNo
-partitionExclusiveUpperBound (Partition s (NumSlots dur)) =
-    Util.addSlots dur s
 
 -- | The varying data of this test
 --
@@ -136,15 +113,17 @@ instance Arbitrary TestSetup where
                 -- Praos mode for thin overlay schedules (ie low d), even for
                 -- f=0.2.
 
-    setupInitialNonce <- frequency
-      [ (1, pure SL.NeutralNonce)
-      , (9, SL.mkNonceFromNumber <$> arbitrary)
-      ]
+    setupInitialNonce <- genNonce
 
     setupSlotLengthByron   <- arbitrary
     setupSlotLengthShelley <- arbitrary
 
-    setupTestConfig                       <- genTestConfig setupK
+    setupTestConfig <- genTestConfig
+                         setupK
+                         ( EpochSize $ byronEpochSize setupK
+                         , EpochSize $ shelleyEpochSize setupK
+                         )
+
     let TestConfig{numCoreNodes, numSlots} = setupTestConfig
 
     setupHardFork        <- frequency [(49, pure True), (1, pure False)]
@@ -167,172 +146,6 @@ instance Arbitrary TestSetup where
       }
 
   -- TODO shrink
-
--- | Generate 'setupTestConfig'
-genTestConfig :: SecurityParam -> Gen TestConfig
-genTestConfig k = do
-    initSeed <- arbitrary
-
-    numSlots <- do
-      let byronE   = byronEpochSize k
-          shelleyE = shelleyEpochSize k
-          wiggle   = min byronE (2 * maxRollbacks k)
-
-          approachShelleyEra     =
-              choose (0, wiggle)   <&> \t -> byronE + t - wiggle
-          reachShelleyEra        =
-              choose (1, shelleyE) <&> \t -> byronE + t
-          reachThirdShelleyEpoch =
-              choose (1, shelleyE) <&> \t -> byronE + 2 * shelleyE + t
-
-      fmap NumSlots $ frequency $
-        [ (05, approachShelleyEra)
-        , (64, reachShelleyEra)
-        , (31, reachThirdShelleyEpoch)
-        ]
-
-    -- This test has more slots than most, so we de-emphasize the relatively
-    -- expensive n=5 case. For example:
-    --
-    -- > 250 tests with 30% 2, 30% 3, 30% 4, and 10% 5 took 500s
-    -- > 250 tests with 100% 5 took 1000s
-    ncn <- frequency [(9, choose (2, 4)), (1, pure 5)]
-
-    -- Ensure that each partition class is internally connected.
-    nodeTopology <- do
-      topo0   <- Topo.genNodeTopology $ NumCoreNodes ncn
-      oddTopo <- do
-        -- eg nodes 1 3 for ncn = 5
-        topo <- Topo.genNodeTopology $ NumCoreNodes $ div ncn 2
-        let rename (CoreNodeId i) = CoreNodeId (2 * i + 1)
-        pure $ Topo.mapNodeTopology rename topo
-      evenTopo <- do
-        -- eg nodes 0 2 4 for ncn = 5
-        topo <- Topo.genNodeTopology $ NumCoreNodes $ ncn - div ncn 2
-        let rename (CoreNodeId i) = CoreNodeId (2 * i)
-        pure $ Topo.mapNodeTopology rename topo
-      pure $
-        Topo.unionNodeTopology evenTopo $
-        Topo.unionNodeTopology oddTopo $
-        topo0
-
-    pure TestConfig
-      { initSeed
-      , nodeTopology
-      , numCoreNodes = NumCoreNodes ncn
-      , numSlots
-      }
-
--- | Generate 'setupPartition'
-genPartition :: NumCoreNodes -> NumSlots -> SecurityParam -> Gen Partition
-genPartition (NumCoreNodes n) (NumSlots t) (SecurityParam k) = do
-    let ultimateSlot :: Word64
-        ultimateSlot = assert (t > 0) $ t - 1
-
-        crop :: Word64 -> Word64
-        crop s = min ultimateSlot s
-
-    -- Fundamental plan: all @MsgRollForward@ sent during the partition only
-    -- arrive at the onset of slot after it. The partition begins at the onset
-    -- of @firstSlotIn@ and ends at the onset of @firstSlotAfter@.
-
-    -- FACT (A) The leader of @firstSlotAfter@ will forge before fully reacting
-    -- to the @MsgRollForward@s that just arrived, due to a race in the test
-    -- infrastructure that is consistently won by the forge. Thus the two
-    -- class's unique extensions consist of the blocks forged in the slots from
-    -- @firstSlotIn@ to @firstSlotAfter@ /inclusive/.
-
-    -- @w@ is defined below this large comment to be how long the partition
-    -- should last (this may be 'crop'ped farther below if the partition ends
-    -- up near the end of the test)
-    --
-    -- Because of FACT (A), we limit the partition duration so that at least
-    -- one of the two partition classes will forge /strictly/ /less/ /than/ @k@
-    -- such blocks. While both classes would be able to rollback if we let them
-    -- forge @k@ such blocks, they might (TODO "might" or "will"?) not able to
-    -- /decide/ that they need to rollback, since the relevant ChainSync client
-    -- might (TODO will?) not be able to forecast a ledger view far-enough into
-    -- the future to validate the @k+1@st header from the other class after the
-    -- partition ends. It will remain unaware that a longer chain exists and
-    -- end up stuck on its own distinct chain. Hence it's a Common Prefix
-    -- violation.
-    --
-    -- We therefore motivate an upper bound on the partition duration @w@ for a
-    -- net with @n@ nodes by considering the two variables' parities.
-    --
-    -- o For @n = 2h@ nodes and @w = 2u@ slots, the classes respectively forge
-    --   @u@ and @u+1@ blocks. (The @+1@th block is forged in
-    --   @firstSlotAfter@.) The preceding paragraph requires @u < k@ requires
-    --   @u <= k-1@ requires @w <= 2k-2@. So @w <= 2k-2@ when @w@ is even.
-    --
-    -- o For @n = 2h@ nodes and @w = 2u+1@ slots, the classes both forge @u+1@
-    --   blocks. (The second @+1@th block is forged in @firstSlotAfter@.) The
-    --   preceding paragraph requires @u+1 < k@ requires @u <= k-2@ requires @w
-    --   <= 2k-3@. So @w <= 2k-3@ when @w@ is odd. Note that @w <= 2k-2@ is
-    --   equivalent since @w@ is assumed odd.
-    --
-    -- o For @n = 2h+1@ nodes, the smaller class forges at most the number of
-    --   blocks considered in the above cases for even @n@, so this case
-    --   doesn't contribute anything novel to the upper bound. The smaller
-    --   class has less than half of the nodes and so will violate Chain Growth
-    --   /if/ /given/ /enough/ /time/ /alone/. But for Byron at least, the
-    --   logic for avoiding a Common Prefix violation already establishes a
-    --   sufficiently strict upper bound to preclude a Chain Growth violation,
-    --   since Chain Growth isn't technically violated until @2k@ slots have
-    --   passed (it's also relevant that the net forges at full round-robin
-    --   speed until the partition starts). (TODO does that cover Shelley too?)
-    --
-    -- Thus @w@ can range from @0@ to @2k-2@ inclusive.
-    w <- assert (k > 0) $ choose (0, 2 * k - 2)
-
-    -- Each of the the following milestones happens at the listed slot in the
-    -- absence of a partition.
-    --
-    -- o In slots 0 and 1 the proposal and the votes confirm it
-    --
-    -- o In slot 2k+1 the confirmation becomes stable
-    --
-    -- o In slot 2k+1+quorum the nodes endorse it
-    --
-    -- o In slot 4k+1+quorum the endorsement is stable
-    --
-    -- o In slot 10k the update is adopted.
-    --
-    -- We are most interested in what happens when the partition is near these
-    -- milestones.
-    mbFocus <- do
-      let quorum = div n 2   -- in the right ballpark
-      frequency $
-        map (\(wgt, mbDur) -> (wgt, pure mbDur)) $
-        filter (maybe True (< t) . snd)
-          [ (5,  Nothing)
-          , (1,  Just 0)
-          , (1,  Just $ 2 * k + 1)
-          , (1,  Just $ 2 * k + 1 + quorum)
-          , (1,  Just $ 4 * k + 1)
-          , (1,  Just $ 4 * k + 1 + quorum)
-          , (20, assert (numByronEpochs == (1 :: Int)) $
-                 Just $ byronEpochSize (SecurityParam k))
-          ]
-
-    -- Position the partition so that it at least abuts the focus slot.
-    firstSlotIn <- choose $
-      case mbFocus of
-        Nothing    -> (0,                            ultimateSlot    )
-        Just focus -> (crop $ focus `monus` (w + 1), crop $ focus + 1)
-
-    let -- Because of FACT (A), we require there to be at least one slot after
-        -- the partition. This doesn't ensure full consensus, because the block
-        -- forged in @firstSlotAfter@ may create a chain as long as that of the
-        -- other partition (Byron) or even multiple such chains (Shelley). But
-        -- it does ensure that all final chains will be the same length.
-        firstSlotAfter :: Word64
-        firstSlotAfter = crop $ firstSlotIn + w
-
-        dur :: Word64
-        dur = Util.countSlots (SlotNo firstSlotAfter) (SlotNo firstSlotIn)
-
-    pure $ Partition (SlotNo firstSlotIn) (NumSlots dur)
 
 -- | Run relatively fewer tests
 --
@@ -369,14 +182,20 @@ prop_simple_cardano_convergence TestSetup
   } =
     prop_general_semisync pga testOutput .&&.
     prop_inSync testOutput .&&.
-    prop_ReachesShelley reachesShelley .&&.
+    prop_ReachesEra2 reachesEra2 .&&.
     prop_noCPViolation .&&.
-    ( tabulate "ReachesShelley label" [label_ReachesShelley reachesShelley] $
+    ( tabulate "ReachesEra2 label" [label_ReachesEra2 reachesEra2] $
       tabulate "Observed forge during a non-overlay Shelley slot"
-        [label_hadActiveNonOverlaySlots] $
-      tabulatePartitionDuration $
-      tabulateFinalIntersectionDepth $
-      tabulatePartitionPosition $
+        [label_hadActiveNonOverlaySlots testOutput overlaySlots] $
+      tabulatePartitionDuration setupK setupPartition $
+      tabulateFinalIntersectionDepth
+        setupK
+        (NumBlocks finalIntersectionDepth)
+        finalBlockEra $
+      tabulatePartitionPosition
+        (NumSlots numByronSlots)
+        setupPartition
+        (ledgerReachesEra2 reachesEra2) $
       property True
     )
   where
@@ -448,7 +267,7 @@ prop_simple_cardano_convergence TestSetup
 
     maxForkLength :: NumBlocks
     maxForkLength = NumBlocks $
-        if rsShelleyBlocks reachesShelley
+        if rsEra2Blocks reachesEra2
         then
           -- Shelley inherently creates small forks, but we haven't yet seen a
           -- Common Prefix violation in this test even though @k@ is small
@@ -482,7 +301,7 @@ prop_simple_cardano_convergence TestSetup
         fromByronEpochSlots $ CC.Genesis.configEpochSlots genesisByron
 
     eraSizeByron :: EraSize
-    eraSizeByron = EraSize numByronEpochs
+    eraSizeByron = EraSize numFirstEraEpochs
 
     genesisByron     :: CC.Genesis.Config
     generatedSecrets :: CC.Genesis.GeneratedSecrets
@@ -529,7 +348,7 @@ prop_simple_cardano_convergence TestSetup
     -- FACT (B) This proposal is always adopted at the first epoch boundary.
     --
     -- o 'genTestConfig' ensures the test reaches the epoch boundary unless
-    --   there's a fatal error during execution. Specifically, 'rsByronSlots'
+    --   there's a fatal error during execution. Specifically, 'rsEra1Slots'
     --   will always be 'Enabled'.
     --
     -- o 'genPartition' limits the partition duration to at most @2k-2@ slots.
@@ -562,25 +381,25 @@ prop_simple_cardano_convergence TestSetup
 
     -- Classifying test cases
 
-    reachesShelley :: ReachesShelley
-    reachesShelley = ReachesShelley
-      { rsByronSlots    =
+    reachesEra2 :: ReachesEra2
+    reachesEra2 = ReachesEra2
+      { rsEra1Slots    =
           BoolProps.enabledIf $ t > numByronSlots
       , rsPV            = BoolProps.enabledIf setupHardFork
-      , rsShelleyBlocks =
+      , rsEra2Blocks =
           or $
-          [ isShelley blk
+          [ not $ isFirstEraBlock blk
           | (_nid, no) <- Map.toList testOutputNodes
           , let NodeOutput{nodeOutputForges} = no
           , (blk, _m) <- maybeToList $ Map.maxView nodeOutputForges
                 -- the last block the node forged
           ]
-      , rsShelleySlots  =
+      , rsEra2Slots  =
           assert (w >= k) $
           BoolProps.requiredIf $
           -- The active slots in the first two Shelley epochs are all overlay
           -- slots, so the first Shelley block will arise from one of those.
-          not $ Set.null overlaySlots
+          not $ Set.null $ overlaySlots
       }
       where
         NumSlots t                  = numSlots
@@ -595,61 +414,20 @@ prop_simple_cardano_convergence TestSetup
         w :: Word64
         w = SL.computeStabilityWindow k coeff
 
-    -- Whether there was a Shelley block forged in a non-overlay slot.
-    --
-    -- This event evidences that the stake pools were correctly created and
-    -- delegated to.
-    label_hadActiveNonOverlaySlots :: String
-    label_hadActiveNonOverlaySlots =
-        show $ or $
-        [ Set.notMember slot overlaySlots
-        | (_nid, no) <- Map.toList testOutputNodes
-        , let NodeOutput{nodeOutputForges} = no
-        , (slot, blk) <- Map.toDescList nodeOutputForges
-        , isShelley blk
-        ]
-      where
-        TestOutput{testOutputNodes} = testOutput
-
-    -- All OBFT overlay slots in the test.
     overlaySlots :: Set SlotNo
     overlaySlots =
-        Set.filter (< SlotNo t) $
-        Set.unions $
-        takeWhile (isJust . Set.lookupLT (SlotNo t)) $
-        map overlayOffsets [0..]
-      where
-        NumSlots t = numSlots
-
-        -- The overlay slots in the ith Shelley epoch.
-        --
-        -- TODO: This function conceptually should be simpler if we created a
-        -- sufficiently accurate 'EpochInfo' and so didn't need the shift. But
-        -- doing so (eg by constructing a HardFork @Summary@) is currently
-        -- significantly more involved than this workaround.
-        overlayOffsets :: Word64 -> Set SlotNo
-        overlayOffsets i =
-            -- Shift to account for the initial Byron era.
-            Set.mapMonotonic (Util.addSlots numByronSlots) .
-            Set.fromList $
-            -- Note: this is only correct if each epoch uses the same value for @d@
-            SL.overlaySlots
-              (runIdentity $ epochInfoFirst epochInfo (EpochNo i))
-              -- notably contains setupD
-              (SL._d (sgProtocolParams genesisShelley))
-                -- NB 0 <-> the first /Shelley/ epoch
-              (runIdentity $ epochInfoSize epochInfo (EpochNo i))
-
-    -- Suitable only for this narrow context
-    epochInfo :: EpochInfo Identity
-    epochInfo = fixedSizeEpochInfo epochSizeShelley
+        secondEraOverlaySlots
+          numSlots
+          (NumSlots numByronSlots)
+          (SL._d (sgProtocolParams genesisShelley))
+          epochSizeShelley
 
     numByronSlots :: Word64
-    numByronSlots = numByronEpochs * unEpochSize epochSizeByron
+    numByronSlots = numFirstEraEpochs * unEpochSize epochSizeByron
 
     finalBlockEra :: String
     finalBlockEra =
-        if rsShelleyBlocks reachesShelley then "Shelley" else "Byron"
+        if rsEra2Blocks reachesEra2 then "Shelley" else "Byron"
 
     finalIntersectionDepth :: Word64
     finalIntersectionDepth = depth
@@ -664,40 +442,6 @@ prop_simple_cardano_convergence TestSetup
           ) $
         counterexample "CP violation in final chains!" $
         property $ maxRollbacks setupK >= finalIntersectionDepth
-
-    tabulatePartitionDuration :: Property -> Property
-    tabulatePartitionDuration =
-        tabul "count"  (show               partitionDuration) .
-        tabul "k frac" (approxFracK setupK partitionDuration)
-      where
-        tabul s x =
-            tabulate ("partition duration, " <> s) [x <> " slots"]
-
-    tabulateFinalIntersectionDepth :: Property -> Property
-    tabulateFinalIntersectionDepth =
-        tabul "count"  (show               finalIntersectionDepth) .
-        tabul "k frac" (approxFracK setupK finalIntersectionDepth) .
-        tabul "k diff" (diffK       setupK finalIntersectionDepth)
-      where
-        lbl = "final intersection depth"
-        tabul s x = tabulate
-            (lbl <> ", " <> finalBlockEra <> ", " <> s)
-            [x <> " blocks"]
-
-    tabulatePartitionPosition :: Property -> Property
-    tabulatePartitionPosition =
-        tabulate "partition in or abuts era (Byron, Shelley)"
-          [ show (inclByron, inclShelley) ]
-      where
-        Partition (SlotNo firstSlotIn) (NumSlots dur) = setupPartition
-        firstSlotAfter                                = firstSlotIn + dur
-
-        trans = ledgerReachesShelley reachesShelley
-
-        inclByron   =
-            dur > 0 && (not trans || firstSlotIn    <= numByronSlots)
-        inclShelley =
-            dur > 0 && (trans     && firstSlotAfter >= numByronSlots)
 
 mkProtocolCardanoAndHardForkTxs
   :: forall c m. (IOLike m, CardanoHardForkConstraints c)
@@ -795,15 +539,6 @@ mkProtocolCardanoAndHardForkTxs
   Constants
 -------------------------------------------------------------------------------}
 
--- | The active slot coefficient, @f@.
---
--- Some of these tests includes Shelley epochs in which stakepools are actually
--- leading. In that case, the @k@, @d@, and @f@ parameters and the length of
--- any scheduled network partitions need to be balanced so that Common Prefix
--- violations (in particular, wedges) are extremely unlikely.
-activeSlotCoeff :: Rational
-activeSlotCoeff = 0.2   -- c.f. mainnet is more conservative, using 0.05
-
 -- | The major protocol version of Byron in this test
 --
 -- On mainnet, the Byron era spans multiple major versions: 0 for Classic and 1
@@ -837,96 +572,6 @@ maryMajorVersion = allegraMajorVersion + 1
 byronInitialMinorVersion :: Num a => a
 byronInitialMinorVersion = 0
 
--- | The number of Byron epochs in this test
---
--- All nodes join in slot 0, we generate the proposal in slot 0, we also
--- generate the votes in slot 0, and the nodes are endorsing the proposal as of
--- slot 0. Thus we expect that Byron will end after one era. Otherwise it would
--- indicate some sort of protocol failure.
-numByronEpochs :: Num a => a
-numByronEpochs = 1
-
-{-------------------------------------------------------------------------------
-  ReachesShelley property
--------------------------------------------------------------------------------}
-
--- | Whether the test included Shelley blocks and (pre)reqs relevant to that
---
--- Note these fields are ordered alphabetically not semantically; see
--- 'label_ReachesShelley'.
-data ReachesShelley = ReachesShelley
-  { rsByronSlots    :: BoolProps.Prereq
-    -- ^ enough Byron slots to enable a Shelley block
-  , rsPV            :: BoolProps.Prereq
-    -- ^ sufficient protocol version to enable a Shelley block
-  , rsShelleyBlocks :: Bool
-    -- ^ Shelley blocks included in final chains
-  , rsShelleySlots  :: BoolProps.Requirement
-    -- ^ enough Shelley slots to necessitate a Shelley block
-  }
-  deriving (Generic, Show)
-
-instance BoolProps.CollectReqs ReachesShelley
-
--- | List the (pre)reqs in semantic order, followed by the observation
-label_ReachesShelley :: ReachesShelley -> String
-label_ReachesShelley reachesShelley =
-    prepend "pv" rsPV $
-    prepend "bs" rsByronSlots $
-    prepend "ss" rsShelleySlots $
-    show         rsShelleyBlocks
-  where
-    -- incur a GHC warning if the number of fields changes
-    ReachesShelley _ _ _ _dummy = reachesShelley
-    -- this pattern should bind each field by name
-    ReachesShelley
-      { rsByronSlots
-      , rsPV
-      , rsShelleyBlocks
-      , rsShelleySlots
-      } = reachesShelley
-
-    prepend :: Show a => String -> a -> String -> String
-    prepend s req x = s <> " " <> show req <> ", " <> x
-
--- | Is the update proposal adopted?
-ledgerReachesShelley :: ReachesShelley -> Bool
-ledgerReachesShelley rs = BoolProps.checkReqs rs /= Just False
-
--- | Checks if the observation satisfies the (pre)reqs
-prop_ReachesShelley :: ReachesShelley -> Property
-prop_ReachesShelley rs = case BoolProps.checkReqs rs of
-    Nothing  -> property True
-    Just req ->
-        counterexample (show rs) $
-        counterexample (msg req) $
-        rsShelleyBlocks == req
-  where
-    ReachesShelley{rsShelleyBlocks} = rs
-
-    msg :: Bool -> String
-    msg req = if req
-        then "the final chains should include at least one Shelley block"
-        else "the final chains should not include any Shelley blocks"
-
-{-------------------------------------------------------------------------------
-  A short even-odd partition
--------------------------------------------------------------------------------}
-
--- | The temporary partition as a 'CalcMessageDelay'
---
--- Calculates the delays that implement 'setupPartition'.
-mkMessageDelay :: Partition -> CalcMessageDelay blk
-mkMessageDelay part = CalcMessageDelay $
-    \(CoreNodeId i, CoreNodeId j) curSlot _hdr -> NumSlots $ if
-      | curSlot <  firstSlotIn    -> 0
-      | curSlot >= firstSlotAfter -> 0
-      | mod i 2 == mod j 2        -> 0
-      | otherwise                 -> unSlotNo $ firstSlotAfter - curSlot
-  where
-    Partition firstSlotIn _ = part
-    firstSlotAfter          = partitionExclusiveUpperBound part
-
 {-------------------------------------------------------------------------------
   Miscellany
 -------------------------------------------------------------------------------}
@@ -934,35 +579,3 @@ mkMessageDelay part = CalcMessageDelay $
 byronEpochSize :: SecurityParam -> Word64
 byronEpochSize (SecurityParam k) =
     unEpochSlots $ kEpochSlots $ CC.Common.BlockCount k
-
-shelleyEpochSize :: SecurityParam -> Word64
-shelleyEpochSize k = unEpochSize $ Shelley.mkEpochSize k activeSlotCoeff
-
--- | Return 'True' when the block is a block from the Shelley era.
---
--- Note it will return 'False' for other Shelley-flavoured eras like Allegra and
--- Mary.
-isShelley :: CardanoBlock c -> Bool
-isShelley = \case
-    BlockShelley{} -> True
-    _              -> False
-
--- | Render a number as a positive difference from @k@
---
--- PREREQUISITE: The number must not be greater than @k@.
-diffK :: SecurityParam -> Word64 -> String
-diffK (SecurityParam k) v =
-    assert (k >= v) $
-    "k - " <> show (k - v)
-
--- | Render a number as the nearest tenths of @k@
-approxFracK :: SecurityParam -> Word64 -> String
-approxFracK (SecurityParam k) v =
-    "k * " <> show (fromIntegral tenths / 10 :: Double)
-  where
-    ratio  = toRational v / toRational k
-    tenths = round (ratio * 10) :: Int
-
--- | <https://en.wikipedia.org/wiki/Monus>
-monus :: (Num a, Ord a) => a -> a -> a
-monus a b = if a <= b then 0 else a - b

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
@@ -1,0 +1,390 @@
+{-# LANGUAGE DeriveGeneric        #-}
+{-# LANGUAGE DerivingVia          #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE MultiWayIf           #-}
+{-# LANGUAGE NamedFieldPuns       #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.ThreadNet.ShelleyAllegra (
+    tests
+  ) where
+
+import           Control.Monad (replicateM)
+import           Data.Functor.Identity (Identity (..))
+import qualified Data.Map as Map
+import           Data.Maybe (maybeToList)
+import           Data.Proxy (Proxy (..))
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Data.SOP.Strict (NP (..))
+import           Data.Word (Word64)
+
+import           Test.QuickCheck
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Cardano.Crypto.Hash (ShortHash)
+import           Cardano.Slotting.Slot (EpochSize (..), SlotNo (..))
+
+import           Ouroboros.Consensus.BlockchainTime
+import           Ouroboros.Consensus.Config.SecurityParam
+import           Ouroboros.Consensus.Ledger.SupportsMempool (extractTxs)
+import           Ouroboros.Consensus.Node.NetworkProtocolVersion
+import           Ouroboros.Consensus.Node.ProtocolInfo
+import           Ouroboros.Consensus.NodeId
+
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
+                     (isHardForkNodeToNodeEnabled)
+
+import qualified Shelley.Spec.Ledger.BaseTypes as SL
+import qualified Shelley.Spec.Ledger.OCert as SL
+import qualified Shelley.Spec.Ledger.PParams as SL
+
+import           Ouroboros.Consensus.Shelley.Eras
+import           Ouroboros.Consensus.Shelley.Node
+                     (ProtocolParamsShelleyBased (..), ShelleyGenesis (..))
+
+import           Ouroboros.Consensus.Cardano.Condense ()
+import           Ouroboros.Consensus.Cardano.Node
+                     (ProtocolParamsTransition (..), TriggerHardFork (..))
+
+import           Test.ThreadNet.General
+import           Test.ThreadNet.Network (NodeOutput (..),
+                     TestNodeInitialization (..))
+import           Test.ThreadNet.Util.Expectations (NumBlocks (..))
+import           Test.ThreadNet.Util.NodeJoinPlan (trivialNodeJoinPlan)
+import           Test.ThreadNet.Util.NodeRestarts (noRestarts)
+import           Test.ThreadNet.Util.NodeToNodeVersion (genVersionFiltered)
+import           Test.ThreadNet.Util.Seed (runGen)
+import qualified Test.Util.BoolProps as BoolProps
+import           Test.Util.HardFork.Future (EraSize (..), Future (..))
+import           Test.Util.Nightly (askIohkNightlyEnabled)
+import           Test.Util.Orphans.Arbitrary ()
+import           Test.Util.Slots (NumSlots (..))
+
+import           Test.Consensus.Shelley.MockCrypto (MockCrypto)
+import qualified Test.ThreadNet.Infra.Shelley as Shelley
+import           Test.ThreadNet.Infra.ShelleyBasedHardFork
+import           Test.ThreadNet.TxGen
+import           Test.ThreadNet.TxGen.Allegra ()
+import           Test.ThreadNet.TxGen.Shelley
+
+import           Test.ThreadNet.Infra.TwoEras
+
+-- | No Byron era, so our crypto can be trivial.
+type Crypto = MockCrypto ShortHash
+
+type ShelleyAllegraBlock =
+  ShelleyBasedHardForkBlock (ShelleyEra Crypto) (AllegraEra Crypto)
+
+-- | The varying data of this test
+--
+-- Note: The Shelley nodes in this test all join, propose an update, and endorse
+-- it literally as soon as possible. Therefore, if the test reaches the end of
+-- the first epoch, the proposal will be adopted.
+data TestSetup = TestSetup
+  { setupD            :: Shelley.DecentralizationParam
+  , setupHardFork     :: Bool
+    -- ^ whether the proposal should trigger a hard fork or not
+  , setupInitialNonce :: SL.Nonce
+    -- ^ the initial Shelley 'SL.ticknStateEpochNonce'
+    --
+    -- We vary it to ensure we explore different leader schedules.
+  , setupK            :: SecurityParam
+  , setupPartition    :: Partition
+  , setupSlotLength   :: SlotLength
+  , setupTestConfig   :: TestConfig
+  , setupVersion      :: (NodeToNodeVersion, BlockNodeToNodeVersion ShelleyAllegraBlock)
+  }
+  deriving (Show)
+
+instance Arbitrary TestSetup where
+  arbitrary = do
+    setupD <- arbitrary
+                -- The decentralization parameter cannot be 0 in the first
+                -- Shelley epoch, since stake pools can only be created and
+                -- delegated to via Shelley transactions.
+                `suchThat` ((/= 0) . Shelley.decentralizationParamToRational)
+    setupK <- SecurityParam <$> choose (8, 10)
+                -- If k < 8, common prefix violations become too likely in
+                -- Praos mode for thin overlay schedules (ie low d), even for
+                -- f=0.2.
+
+    setupInitialNonce <- genNonce
+
+    setupSlotLength   <- arbitrary
+
+    let epochSize = EpochSize $ shelleyEpochSize setupK
+    setupTestConfig <- genTestConfig
+                         setupK
+                         (epochSize, epochSize)
+    let TestConfig{numCoreNodes, numSlots} = setupTestConfig
+
+    setupHardFork  <- frequency [(49, pure True), (1, pure False)]
+
+    -- TODO How reliable is the Byron-based partition duration logic when
+    -- reused for Shelley?
+    setupPartition <- genPartition numCoreNodes numSlots setupK
+
+    setupVersion   <- genVersionFiltered
+                        isHardForkNodeToNodeEnabled
+                        (Proxy @ShelleyAllegraBlock)
+
+    pure TestSetup
+      { setupD
+      , setupHardFork
+      , setupInitialNonce
+      , setupK
+      , setupPartition
+      , setupSlotLength
+      , setupTestConfig
+      , setupVersion
+      }
+
+  -- TODO shrink
+
+-- | Run relatively fewer tests
+--
+-- These tests are slow, so we settle for running fewer of them in this test
+-- suite since it is invoked frequently (eg CI for each push).
+oneTenthTestCount :: QuickCheckTests -> QuickCheckTests
+oneTenthTestCount (QuickCheckTests n) = QuickCheckTests $
+    if 0 == n then 0 else
+    max 1 $ n `div` 10
+
+tests :: TestTree
+tests = testGroup "ShelleyAllegra ThreadNet" $
+    [ let name = "simple convergence" in
+      askIohkNightlyEnabled $ \enabled ->
+      (if enabled then id else adjustOption oneTenthTestCount) $
+      testProperty name $ \setup ->
+        prop_simple_shelleyAllegra_convergence setup
+    ]
+
+prop_simple_shelleyAllegra_convergence :: TestSetup -> Property
+prop_simple_shelleyAllegra_convergence TestSetup
+  { setupD
+  , setupHardFork
+  , setupInitialNonce
+  , setupK
+  , setupPartition
+  , setupSlotLength
+  , setupTestConfig
+  , setupVersion
+  } =
+    prop_general_semisync pga testOutput .&&.
+    prop_inSync testOutput .&&.
+    prop_ReachesEra2 reachesEra2 .&&.
+    prop_noCPViolation .&&.
+    ( tabulate "ReachesEra2 label" [label_ReachesEra2 reachesEra2] $
+      tabulate "Observed forge during a non-overlay slot in the second era"
+        [ label_hadActiveNonOverlaySlots
+            testOutput
+            overlaySlots
+        ] $
+      tabulatePartitionDuration setupK setupPartition $
+      tabulateFinalIntersectionDepth
+        setupK
+        (NumBlocks finalIntersectionDepth)
+        finalBlockEra $
+      tabulatePartitionPosition
+        (NumSlots numFirstEraSlots)
+        setupPartition
+        (ledgerReachesEra2 reachesEra2) $
+      property True
+    )
+  where
+    TestConfig
+      { initSeed
+      , numCoreNodes
+      , numSlots
+      } = setupTestConfig
+
+    pga = PropGeneralArgs
+        { pgaBlockProperty       = const $ property True
+        , pgaCountTxs            = fromIntegral . length . extractTxs
+        , pgaExpectedCannotForge = noExpectedCannotForges
+        , pgaFirstBlockNo        = 0
+        , pgaFixedMaxForkLength  = Just maxForkLength
+          -- the leader schedule isn't fixed because the Shelley leader
+          -- schedule is (at least ideally) unpredictable
+        , pgaFixedSchedule       = Nothing
+        , pgaSecurityParam       = setupK
+        , pgaTestConfig          = setupTestConfig
+        , pgaTestConfigB         = testConfigB
+        }
+
+    txGenExtra = ShelleyTxGenExtra
+      { stgeGenEnv  = mkGenEnv DoNotGeneratePPUs coreNodes
+        -- We don't generate any transactions before the transaction
+        -- carrying the proposal because they might consume its inputs
+        -- before it does, thereby rendering it invalid.
+      , stgeStartAt = SlotNo 1
+      }
+
+    testConfigB = TestConfigB
+      { forgeEbbEnv  = Nothing
+      , future       =
+          if setupHardFork
+          then
+          -- In this case the PVU will trigger the transition to the second era
+          --
+          -- By FACT (B), the PVU is always successful if we reach the second
+          -- era.
+          EraCons  setupSlotLength epochSize firstEraSize $
+          EraFinal setupSlotLength epochSize
+          else
+          EraFinal setupSlotLength epochSize
+      , messageDelay = mkMessageDelay setupPartition
+      , nodeJoinPlan = trivialNodeJoinPlan numCoreNodes
+      , nodeRestarts = noRestarts
+      , txGenExtra   = WrapTxGenExtra txGenExtra :* WrapTxGenExtra () :* Nil
+      , version      = setupVersion
+      }
+
+    testOutput :: TestOutput ShelleyAllegraBlock
+    testOutput = runTestNetwork setupTestConfig testConfigB TestConfigMB {
+          nodeInfo = \(CoreNodeId nid) ->
+            TestNodeInitialization {
+                tniCrucialTxs   =
+                  if not setupHardFork then [] else
+                  fmap GenTxShelley1 $
+                  Shelley.mkSetDecentralizationParamTxs
+                    coreNodes
+                    (SL.ProtVer majorVersion2 0)
+                    (SlotNo $ unNumSlots numSlots)   -- never expire
+                    setupD   -- unchanged
+              , tniProtocolInfo =
+                  protocolInfoShelleyBasedHardFork
+                    ProtocolParamsShelleyBased {
+                        shelleyBasedGenesis           = genesisShelley
+                      , shelleyBasedInitialNonce      = setupInitialNonce
+                      , shelleyBasedLeaderCredentials = Identity $
+                          Shelley.mkLeaderCredentials (coreNodes !! fromIntegral nid)
+                      }
+                    (SL.ProtVer majorVersion1 0)
+                    (SL.ProtVer majorVersion2 0)
+                    ProtocolParamsTransition {
+                        transitionTrigger = TriggerHardForkAtVersion majorVersion2
+                      }
+              }
+          , mkRekeyM = Nothing
+          }
+
+    maxForkLength :: NumBlocks
+    maxForkLength = NumBlocks $ maxRollbacks setupK
+
+    initialKESPeriod :: SL.KESPeriod
+    initialKESPeriod = SL.KESPeriod 0
+
+    coreNodes :: [Shelley.CoreNode Crypto]
+    coreNodes = runGen initSeed $
+        replicateM (fromIntegral n) $
+          Shelley.genCoreNode initialKESPeriod
+      where
+        NumCoreNodes n = numCoreNodes
+
+    maxLovelaceSupply :: Word64
+    maxLovelaceSupply =
+      fromIntegral (length coreNodes) * Shelley.initialLovelacePerCoreNode
+
+    genesisShelley :: ShelleyGenesis (ShelleyEra Crypto)
+    genesisShelley =
+        Shelley.mkGenesisConfig
+          (SL.ProtVer majorVersion1 0)
+          setupK
+          activeSlotCoeff
+          setupD
+          maxLovelaceSupply
+          setupSlotLength
+          (Shelley.mkKesConfig (Proxy @Crypto) numSlots)
+          coreNodes
+
+    -- the Shelley ledger is designed to use a fixed epoch size, so this test
+    -- does not randomize it
+    epochSize :: EpochSize
+    epochSize = sgEpochLength genesisShelley
+
+    firstEraSize :: EraSize
+    firstEraSize = EraSize numFirstEraEpochs
+
+    -- Classifying test cases
+
+    reachesEra2 :: ReachesEra2
+    reachesEra2 = ReachesEra2
+      { rsEra1Slots  =
+          BoolProps.enabledIf $ t > numFirstEraSlots
+      , rsPV         = BoolProps.enabledIf setupHardFork
+      , rsEra2Blocks =
+          or $
+          [ not $ isFirstEraBlock blk
+          | (_nid, no) <- Map.toList testOutputNodes
+          , let NodeOutput{nodeOutputForges} = no
+          , (blk, _m) <- maybeToList $ Map.maxView nodeOutputForges
+                -- the last block the node forged
+          ]
+      , rsEra2Slots  =
+          --- TODO this comment and code are wrong
+
+          BoolProps.requiredIf $
+          -- The active slots in the first two Shelley epochs are all overlay
+          -- slots, so the first Shelley block will arise from one of those.
+          not $ Set.null overlaySlots
+      }
+      where
+        NumSlots t                  = numSlots
+        TestOutput{testOutputNodes} = testOutput
+
+    -- All OBFT overlay slots in the second era.
+    overlaySlots :: Set SlotNo
+    overlaySlots =
+        secondEraOverlaySlots
+          numSlots
+          (NumSlots numFirstEraSlots)
+          (SL._d (sgProtocolParams genesisShelley))
+          epochSize
+
+    numFirstEraSlots :: Word64
+    numFirstEraSlots =
+        numFirstEraEpochs * unEpochSize epochSize
+
+    finalBlockEra :: String
+    finalBlockEra =
+        if rsEra2Blocks reachesEra2
+        then "Allegra"
+        else "Shelley"
+
+    finalIntersectionDepth :: Word64
+    finalIntersectionDepth = depth
+      where
+        NumBlocks depth = calcFinalIntersectionDepth pga testOutput
+
+    prop_noCPViolation :: Property
+    prop_noCPViolation =
+        counterexample
+          ( "finalChains: " <>
+            show (nodeOutputFinalChain <$> testOutputNodes testOutput)
+          ) $
+        counterexample "CP violation in final chains!" $
+        property $ maxRollbacks setupK >= finalIntersectionDepth
+
+{-------------------------------------------------------------------------------
+  Constants
+-------------------------------------------------------------------------------}
+
+-- | The major protocol version of the first era in this test
+majorVersion1 :: Num a => a
+majorVersion1 = 0
+
+-- | The major protocol version of the second era in this test
+majorVersion2 :: Num a => a
+majorVersion2 = majorVersion1 + 1

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -46,7 +46,7 @@ import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Ouroboros.Consensus.HardFork.Combinator
-import           Ouroboros.Consensus.HardFork.Combinator.Unary
+import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
 
 import           Ouroboros.Consensus.Byron.Ledger
 import           Ouroboros.Consensus.Byron.Node as X

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -22,6 +22,8 @@ module Ouroboros.Consensus.Cardano.CanHardFork (
   , ByronPartialLedgerConfig (..)
   , ShelleyPartialLedgerConfig (..)
   , CardanoHardForkConstraints
+  , forecastAcrossShelley
+  , translateChainDepStateAcrossShelley
   ) where
 
 import           Control.Monad

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -508,7 +508,7 @@ mkSetDecentralizationParamTxs coreNodes pVer ttl dNew =
 -------------------------------------------------------------------------------}
 
 initialLovelacePerCoreNode :: Word64
-initialLovelacePerCoreNode = 1000
+initialLovelacePerCoreNode = 1000000
 
 mkCredential ::
      PraosCrypto (EraCrypto era)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -18,7 +18,8 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Shelley.Node (
-    protocolInfoShelley
+    protocolInfoShelleyBased
+  , protocolInfoShelley
   , ProtocolParamsShelleyBased (..)
   , ProtocolParamsShelley (..)
   , ProtocolParamsAllegra (..)
@@ -62,7 +63,7 @@ import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.IOLike
 
-import           Cardano.Ledger.Val ((<->))
+import           Cardano.Ledger.Val (coin, inject, (<->))
 import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.OCert as Absolute (KESPeriod (..))
 
@@ -241,14 +242,23 @@ protocolInfoShelley ::
   => ProtocolParamsShelleyBased (ShelleyEra c) f
   -> ProtocolParamsShelley
   -> ProtocolInfo m (ShelleyBlock (ShelleyEra c))
-protocolInfoShelley ProtocolParamsShelleyBased {
-                        shelleyBasedGenesis           = genesis
-                      , shelleyBasedInitialNonce      = initialNonce
-                      , shelleyBasedLeaderCredentials = credentialss
-                      }
+protocolInfoShelley protocolParamsShelleyBased
                     ProtocolParamsShelley {
                         shelleyProtVer = protVer
                       } =
+    protocolInfoShelleyBased protocolParamsShelleyBased protVer
+
+protocolInfoShelleyBased ::
+     forall m era f. (IOLike m, ShelleyBasedEra era, Foldable f)
+  => ProtocolParamsShelleyBased era f
+  -> SL.ProtVer
+  -> ProtocolInfo m (ShelleyBlock era)
+protocolInfoShelleyBased ProtocolParamsShelleyBased {
+                             shelleyBasedGenesis           = genesis
+                           , shelleyBasedInitialNonce      = initialNonce
+                           , shelleyBasedLeaderCredentials = credentialss
+                           }
+                         protVer =
     assertWithMsg (validateGenesis genesis) $
     ProtocolInfo {
         pInfoConfig       = topLevelConfig
@@ -259,7 +269,7 @@ protocolInfoShelley ProtocolParamsShelleyBased {
     maxMajorProtVer :: MaxMajorProtVer
     maxMajorProtVer = MaxMajorProtVer $ SL.pvMajor protVer
 
-    topLevelConfig :: TopLevelConfig (ShelleyBlock (ShelleyEra c))
+    topLevelConfig :: TopLevelConfig (ShelleyBlock era)
     topLevelConfig = TopLevelConfig {
         topLevelConfigProtocol = consensusConfig
       , topLevelConfigLedger   = ledgerConfig
@@ -268,13 +278,13 @@ protocolInfoShelley ProtocolParamsShelleyBased {
       , topLevelConfigStorage  = storageConfig
       }
 
-    consensusConfig :: ConsensusConfig (BlockProtocol (ShelleyBlock (ShelleyEra c)))
+    consensusConfig :: ConsensusConfig (BlockProtocol (ShelleyBlock era))
     consensusConfig = TPraosConfig {
         tpraosParams
       , tpraosEpochInfo = epochInfo
       }
 
-    ledgerConfig :: LedgerConfig (ShelleyBlock (ShelleyEra c))
+    ledgerConfig :: LedgerConfig (ShelleyBlock era)
     ledgerConfig = mkShelleyLedgerConfig genesis epochInfo maxMajorProtVer
 
     epochInfo :: EpochInfo Identity
@@ -283,27 +293,27 @@ protocolInfoShelley ProtocolParamsShelleyBased {
     tpraosParams :: TPraosParams
     tpraosParams = mkTPraosParams maxMajorProtVer initialNonce genesis
 
-    blockConfig :: BlockConfig (ShelleyBlock (ShelleyEra c))
+    blockConfig :: BlockConfig (ShelleyBlock era)
     blockConfig =
         mkShelleyBlockConfig
           protVer
           genesis
           (tpraosBlockIssuerVKey <$> toList credentialss)
 
-    storageConfig :: StorageConfig (ShelleyBlock (ShelleyEra c))
+    storageConfig :: StorageConfig (ShelleyBlock era)
     storageConfig = ShelleyStorageConfig {
           shelleyStorageConfigSlotsPerKESPeriod = tpraosSlotsPerKESPeriod tpraosParams
         , shelleyStorageConfigSecurityParam     = tpraosSecurityParam     tpraosParams
         }
 
-    initLedgerState :: LedgerState (ShelleyBlock (ShelleyEra c))
+    initLedgerState :: LedgerState (ShelleyBlock era)
     initLedgerState = ShelleyLedgerState {
         shelleyLedgerTip        = Origin
       , shelleyLedgerState      = SL.chainNes initShelleyState
       , shelleyLedgerTransition = ShelleyTransitionInfo {shelleyAfterVoting = 0}
       }
 
-    initChainDepState :: TPraosState c
+    initChainDepState :: TPraosState (EraCrypto era)
     initChainDepState = TPraosState Origin $
       SL.ChainDepState {
           SL.csProtocol = SL.PrtclState
@@ -320,39 +330,40 @@ protocolInfoShelley ProtocolParamsShelleyBased {
     initialEpochNo :: EpochNo
     initialEpochNo = 0
 
-    initialUtxo :: SL.UTxO (ShelleyEra c)
+    initialUtxo :: SL.UTxO era
     initialUtxo = SL.genesisUtxO genesis
 
-    initShelleyState :: SL.ChainState (ShelleyEra c)
+    initShelleyState :: SL.ChainState era
     initShelleyState = registerGenesisStaking $ SL.initialShelleyState
       Origin
       initialEpochNo
       initialUtxo
-      (SL.word64ToCoin (SL.sgMaxLovelaceSupply genesis) <-> SL.balance initialUtxo)
+      (coin $ inject (SL.word64ToCoin (SL.sgMaxLovelaceSupply genesis))
+          <-> SL.balance initialUtxo)
       (SL.sgGenDelegs genesis)
       (SL.sgProtocolParams genesis)
       initialNonce
 
-    initExtLedgerState :: ExtLedgerState (ShelleyBlock (ShelleyEra c))
+    initExtLedgerState :: ExtLedgerState (ShelleyBlock era)
     initExtLedgerState = ExtLedgerState {
         ledgerState = initLedgerState
       , headerState = genesisHeaderState initChainDepState
       }
 
-    -- Register the initial staking.
+    -- | Register the initial staking.
     --
     -- This function embodies a little more logic than ideal. We might want to
-    -- move it into `cardano-ledger-specs.`
+    -- move it into @cardano-ledger-specs@.
     --
     -- HERE BE DRAGONS! This function is intended to help in testing. It should
-    -- not be called with anything other than 'emptyGenesisStaking' in
+    -- not be called with anything other than 'SL.emptyGenesisStaking' in
     -- production.
-    registerGenesisStaking :: SL.ChainState (ShelleyEra c) -> SL.ChainState (ShelleyEra c)
-    registerGenesisStaking cs@(SL.ChainState {chainNes = oldChainNes} ) = cs
+    registerGenesisStaking :: SL.ChainState era -> SL.ChainState era
+    registerGenesisStaking cs@SL.ChainState {chainNes = oldChainNes} = cs
         { SL.chainNes = newChainNes }
       where
         SL.ShelleyGenesisStaking { sgsPools, sgsStake } = SL.sgStaking genesis
-        oldEpochState = SL.nesEs $ oldChainNes
+        oldEpochState = SL.nesEs oldChainNes
         oldLedgerState = SL.esLState oldEpochState
         oldDPState = SL._delegationState oldLedgerState
 
@@ -380,7 +391,7 @@ protocolInfoShelley ProtocolParamsShelleyBased {
         -- about updating the '_delegations' field.
         --
         -- See STS DELEG for details
-        newDState :: SL.DState (ShelleyEra c)
+        newDState :: SL.DState era
         newDState = (SL._dstate oldDPState) {
           SL._rewards = Map.map (const $ SL.Coin 0)
                       . Map.mapKeys SL.KeyHashObj
@@ -390,7 +401,7 @@ protocolInfoShelley ProtocolParamsShelleyBased {
 
         -- We consider pools as having been registered in slot 0
         -- See STS POOL for details
-        newPState :: SL.PState (ShelleyEra c)
+        newPState :: SL.PState era
         newPState = (SL._pstate oldDPState) {
           SL._pParams = sgsPools
         }

--- a/ouroboros-consensus-test/src/Test/ThreadNet/TxGen.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/TxGen.hs
@@ -1,19 +1,31 @@
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
 -- | Transaction generator for testing
-module Test.ThreadNet.TxGen
-  ( TxGen (..)
+module Test.ThreadNet.TxGen (
+    TxGen (..)
+    -- * Implementation for HFC
+  , WrapTxGenExtra (..)
+  , testGenTxsHfc
   ) where
 
 import           Data.Kind (Type)
+import           Data.SOP.Strict
 
 import           Test.QuickCheck (Gen)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
-import           Ouroboros.Consensus.Ledger.SupportsMempool (GenTx)
 import           Ouroboros.Consensus.Node.ProtocolInfo (NumCoreNodes (..))
 import           Ouroboros.Consensus.NodeId (CoreNodeId)
+import           Ouroboros.Consensus.Util.SOP
+
+import           Ouroboros.Consensus.HardFork.Combinator
+import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 
 {-------------------------------------------------------------------------------
   TxGen class
@@ -39,3 +51,56 @@ class TxGen blk where
              -> TxGenExtra blk
              -> LedgerState blk
              -> Gen [GenTx blk]
+
+{-------------------------------------------------------------------------------
+  Implementation for HFC
+-------------------------------------------------------------------------------}
+
+-- | Newtypes wrapper around the 'TxGenExtra' type family so that it can be
+-- partially applied.
+newtype WrapTxGenExtra blk = WrapTxGenExtra {
+      unwrapTxGenExtra :: TxGenExtra blk
+    }
+
+-- | Function that can be used for 'TxGen' instances for 'HardForkBlock'.
+--
+-- We don't provide a generic instance of 'TxGen' because it might be desirable
+-- to provide custom implementations for specific instantiations of the eras of
+-- 'HardForkBlock'. Instead, we provide this function that can be used when a
+-- generic implemenation is desired.
+--
+-- Choose @NP WrapTxGenExtra xs@ for the instance of the 'TxGenExtra' type
+-- family, where @xs@ matches the concrete instantiation.
+testGenTxsHfc ::
+     forall xs. (All TxGen xs, CanHardFork xs)
+  => CoreNodeId
+  -> NumCoreNodes
+  -> SlotNo
+  -> TopLevelConfig (HardForkBlock xs)
+  -> NP WrapTxGenExtra xs
+  -> LedgerState (HardForkBlock xs)
+  -> Gen [GenTx (HardForkBlock xs)]
+testGenTxsHfc coreNodeId numCoreNodes curSlotNo cfg extras state =
+    hcollapse $
+    hcizipWith3
+      (Proxy @TxGen)
+      aux
+      cfgs
+      extras
+      (State.tip (hardForkLedgerStatePerEra state))
+  where
+    cfgs = distribTopLevelConfig ei cfg
+    ei   = State.epochInfoLedger
+             (configLedger cfg)
+             (hardForkLedgerStatePerEra state)
+
+    aux ::
+         forall blk. TxGen blk
+      => Index xs blk
+      -> TopLevelConfig blk
+      -> WrapTxGenExtra blk
+      -> LedgerState blk
+      -> K (Gen [GenTx (HardForkBlock xs)]) blk
+    aux index cfg' (WrapTxGenExtra extra') state' = K $
+        fmap (injectNS' (Proxy @GenTx) index)
+          <$> testGenTxs coreNodeId numCoreNodes curSlotNo cfg' extra' state'

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -65,6 +65,7 @@ library
                        Ouroboros.Consensus.HardFork.Combinator.Compat
                        Ouroboros.Consensus.HardFork.Combinator.Condense
                        Ouroboros.Consensus.HardFork.Combinator.Degenerate
+                       Ouroboros.Consensus.HardFork.Combinator.Embed.Binary
                        Ouroboros.Consensus.HardFork.Combinator.Embed.Nary
                        Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
                        Ouroboros.Consensus.HardFork.Combinator.Forging
@@ -291,6 +292,7 @@ library
                      , psqueues          >=0.2.3 && <0.3
                      , random
                      , quiet             >=0.2   && <0.3
+                     , semialign         >=1.1   && <1.2
                      , serialise         >=0.2   && <0.3
                      , sop-core          >=0.5   && <0.6
                      , stm               >=2.5   && <2.6

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -65,6 +65,8 @@ library
                        Ouroboros.Consensus.HardFork.Combinator.Compat
                        Ouroboros.Consensus.HardFork.Combinator.Condense
                        Ouroboros.Consensus.HardFork.Combinator.Degenerate
+                       Ouroboros.Consensus.HardFork.Combinator.Embed.Nary
+                       Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
                        Ouroboros.Consensus.HardFork.Combinator.Forging
                        Ouroboros.Consensus.HardFork.Combinator.Info
                        Ouroboros.Consensus.HardFork.Combinator.InjectTxs
@@ -72,7 +74,6 @@ library
                        Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
                        Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
                        Ouroboros.Consensus.HardFork.Combinator.Mempool
-                       Ouroboros.Consensus.HardFork.Combinator.Nary
                        Ouroboros.Consensus.HardFork.Combinator.Node
                        Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage
                        Ouroboros.Consensus.HardFork.Combinator.PartialConfig
@@ -90,7 +91,6 @@ library
                        Ouroboros.Consensus.HardFork.Combinator.State.Lift
                        Ouroboros.Consensus.HardFork.Combinator.State.Types
                        Ouroboros.Consensus.HardFork.Combinator.Translation
-                       Ouroboros.Consensus.HardFork.Combinator.Unary
                        Ouroboros.Consensus.HardFork.Combinator.Util.DerivingVia
                        Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
                        Ouroboros.Consensus.HardFork.Combinator.Util.Match

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
@@ -116,10 +116,10 @@ import           Ouroboros.Consensus.HardFork.Combinator.InjectTxs as X
 --   fork combinator when applied to a single block results in a system
 --   that is equivalent to just using that single block directly.
 --
--- * "Ouroboros.Consensus.HardFork.Combinator.Unary"
+-- * "Ouroboros.Consensus.HardFork.Combinator.Embed.Unary"
 --   Mostly used in combination with 'DegenFork'.
 --
--- * "Ouroboros.Consensus.HardFork.Combinator.Nary"
+-- * "Ouroboros.Consensus.HardFork.Combinator.Embed.Nary"
 --   Used for injection into n-ary sums. Alternative to @Unary@.
 --
 -- * Most of @Ouroboros.Consensus.HardFork.Combinator.SingleEra.*@

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -100,7 +100,7 @@ newtype PerEraStorageConfig   xs = PerEraStorageConfig   { getPerEraStorageConfi
 
   The reason for using @OptNP 'False f xs@ as opposed to @NP (Maybe :.: f) xs@
   is to maintain the isomorphism between @blk@ and @HardForkBlock '[blk]@ in
-  "Ouroboros.Consensus.HardFork.Combinator.Unary"
+  "Ouroboros.Consensus.HardFork.Combinator.Embed.Unary"
 -------------------------------------------------------------------------------}
 
 newtype SomeErasCanBeLeader xs = SomeErasCanBeLeader { getSomeErasCanBeLeader :: OptNP 'False WrapCanBeLeader xs }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -42,6 +42,7 @@ import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract.NoHardForks
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
                      ()
@@ -55,7 +56,6 @@ import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Serialise
                      ()
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode
                      ()
-import           Ouroboros.Consensus.HardFork.Combinator.Unary
 
 {-------------------------------------------------------------------------------
   Simple patterns

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Binary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Binary.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Ouroboros.Consensus.HardFork.Combinator.Embed.Binary (
+    protocolInfoBinary
+  ) where
+
+import           Control.Exception (assert)
+import           Data.Align (alignWith)
+import           Data.SOP.Strict (NP (..))
+import           Data.These (These (..))
+
+import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Config
+import           Ouroboros.Consensus.HeaderValidation
+import           Ouroboros.Consensus.Ledger.Basics (LedgerConfig)
+import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Node
+import           Ouroboros.Consensus.Protocol.Abstract (protocolSecurityParam)
+import           Ouroboros.Consensus.TypeFamilyWrappers
+import           Ouroboros.Consensus.Util.Counting (exactlyTwo)
+import           Ouroboros.Consensus.Util.OptNP (OptNP (..))
+
+import           Ouroboros.Consensus.HardFork.Combinator
+import qualified Ouroboros.Consensus.HardFork.History as History
+
+{-------------------------------------------------------------------------------
+  ProtocolInfo
+-------------------------------------------------------------------------------}
+
+protocolInfoBinary ::
+     forall m blk1 blk2.
+     (CanHardFork '[blk1, blk2], Monad m)
+     -- First era
+  => ProtocolInfo m blk1
+  -> History.EraParams
+  -> (ConsensusConfig (BlockProtocol blk1) -> PartialConsensusConfig (BlockProtocol blk1))
+  -> (LedgerConfig blk1 -> PartialLedgerConfig blk1)
+     -- Second era
+  -> ProtocolInfo m blk2
+  -> History.EraParams
+  -> (ConsensusConfig (BlockProtocol blk2) -> PartialConsensusConfig (BlockProtocol blk2))
+  -> (LedgerConfig blk2 -> PartialLedgerConfig blk2)
+  -> ProtocolInfo m (HardForkBlock '[blk1, blk2])
+protocolInfoBinary protocolInfo1 eraParams1 toPartialConsensusConfig1 toPartialLedgerConfig1
+                   protocolInfo2 eraParams2 toPartialConsensusConfig2 toPartialLedgerConfig2 =
+    ProtocolInfo {
+        pInfoConfig = TopLevelConfig {
+            topLevelConfigProtocol = HardForkConsensusConfig {
+                hardForkConsensusConfigK      = k
+              , hardForkConsensusConfigShape  = shape
+              , hardForkConsensusConfigPerEra = PerEraConsensusConfig
+                  (  WrapPartialConsensusConfig (toPartialConsensusConfig1 consensusConfig1)
+                  :* WrapPartialConsensusConfig (toPartialConsensusConfig2 consensusConfig2)
+                  :* Nil
+                  )
+              }
+          , topLevelConfigLedger = HardForkLedgerConfig {
+                hardForkLedgerConfigShape  = shape
+              , hardForkLedgerConfigPerEra = PerEraLedgerConfig
+                  (  WrapPartialLedgerConfig (toPartialLedgerConfig1 ledgerConfig1)
+                  :* WrapPartialLedgerConfig (toPartialLedgerConfig2 ledgerConfig2)
+                  :* Nil
+                  )
+              }
+          , topLevelConfigBlock =
+              HardForkBlockConfig $
+                PerEraBlockConfig $
+                  (blockConfig1 :* blockConfig2 :* Nil)
+          , topLevelConfigCodec =
+              HardForkCodecConfig $
+                PerEraCodecConfig $
+                  (codecConfig1 :* codecConfig2 :* Nil)
+          , topLevelConfigStorage =
+              HardForkStorageConfig $
+                PerEraStorageConfig $
+                  (storageConfig1 :* storageConfig2 :* Nil)
+          }
+      , pInfoInitLedger = ExtLedgerState {
+            ledgerState =
+              HardForkLedgerState $
+                initHardForkState initLedgerState1
+          , headerState =
+              genesisHeaderState $
+                initHardForkState $
+                  WrapChainDepState $
+                    headerStateChainDep initHeaderState1
+          }
+      , pInfoBlockForging =
+          alignWith alignBlockForging <$> blockForging1 <*> blockForging2
+      }
+  where
+    ProtocolInfo {
+        pInfoConfig = TopLevelConfig {
+            topLevelConfigProtocol = consensusConfig1
+          , topLevelConfigLedger   = ledgerConfig1
+          , topLevelConfigBlock    = blockConfig1
+          , topLevelConfigCodec    = codecConfig1
+          , topLevelConfigStorage  = storageConfig1
+          }
+      , pInfoInitLedger = ExtLedgerState {
+            ledgerState = initLedgerState1
+          , headerState = initHeaderState1
+          }
+      , pInfoBlockForging = blockForging1
+      } = protocolInfo1
+
+    ProtocolInfo {
+        pInfoConfig = TopLevelConfig {
+            topLevelConfigProtocol = consensusConfig2
+          , topLevelConfigLedger   = ledgerConfig2
+          , topLevelConfigBlock    = blockConfig2
+          , topLevelConfigCodec    = codecConfig2
+          , topLevelConfigStorage  = storageConfig2
+          }
+      , pInfoBlockForging = blockForging2
+      } = protocolInfo2
+
+    k1, k2, k :: SecurityParam
+    k1 = protocolSecurityParam consensusConfig1
+    k2 = protocolSecurityParam consensusConfig2
+    k = assert (k1 == k2) k1
+
+    shape :: History.Shape '[blk1, blk2]
+    shape = History.Shape $ exactlyTwo eraParams1 eraParams2
+
+    alignBlockForging ::
+         These (BlockForging m blk1) (BlockForging m blk2)
+      -> BlockForging m (HardForkBlock '[blk1, blk2])
+    alignBlockForging = \case
+      This bf1 ->
+        hardForkBlockForging
+          (forgeLabel bf1)
+          (OptCons bf1 $ OptSkip OptNil)
+      That bf2 ->
+        hardForkBlockForging
+          (forgeLabel bf2)
+          (OptSkip $ OptCons bf2 OptNil)
+      These bf1 bf2 ->
+        hardForkBlockForging
+          (forgeLabel bf1 <> "-" <> forgeLabel bf2)
+          (OptCons bf1 $ OptCons bf2 OptNil)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE RecordWildCards          #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
 {-# LANGUAGE TypeApplications         #-}
-module Ouroboros.Consensus.HardFork.Combinator.Nary (
+module Ouroboros.Consensus.HardFork.Combinator.Embed.Nary (
     Inject (..)
   , inject'
     -- * Defaults

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -17,7 +17,7 @@
 {-# LANGUAGE TypeOperators         #-}
 
 -- | Witness isomorphism between @b@ and @HardForkBlock '[b]@
-module Ouroboros.Consensus.HardFork.Combinator.Unary (
+module Ouroboros.Consensus.HardFork.Combinator.Embed.Unary (
     Isomorphic(..)
   , project'
   , inject'


### PR DESCRIPTION
Fixes #2633.

This follows up #2627 by adding tests that exercise the ability to hard from from a Shelley-based era to the next Shelley-based era (in this case, Shelley to Allegra).

This PR introduces the `TwoEras.hs` infrastructure. For every era we have, we should have a two-era test that has a primary interest of whether or not a proposal in that era can successfully induce a hard fork, especially in the presence of a short network partition. I suggest, as part of Issue #2472, we should continue to emphasize these "Will it fork?" tests.

As of this PR, `Cardano.hs` tests that we can hard fork out of Byron and `ShelleyAllegra.hs` tests that we can hard fork out of `Shelley`. At the moment, both have two eras, and so they can share the infrastructure that was factored out into `TwoEras.hs`

Eventually `Cardano.hs` will have 3-4 eras. At that time, I propose we introduce a `Byron______.hs` module that specifically tests leaving Byron. Maybe to Byron again, or still to Shelley, etc. To summarize: we should have a separate test dedicated to testing each adjacent pair of eras on mainnet and one more that tests a hard fork from the last mainnet era to another copy of itself.

Edit: Edsko and I have something along these lines in mind while working on Issue 2472, the rewrite. But we hope to have it be a tidy consolidated thing instead of as explicit as the above proposal.