### PR TITLE
ThreadNet: unblock forge when the mempool is full if the crucial txs would be invalid

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -310,6 +310,9 @@ data MempoolSnapshot blk idx = MempoolSnapshot {
 
     -- | The block number of the "virtual block" under construction
   , snapshotSlotNo      :: SlotNo
+
+    -- | The ledger state after all transactions in the snapshot
+  , snapshotLedgerState :: TickedLedgerState blk
   }
 
 -- | The size of a mempool.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -510,6 +510,7 @@ implSnapshotFromIS is = MempoolSnapshot {
     , snapshotHasTx       = implSnapshotHasTx          is
     , snapshotMempoolSize = implSnapshotGetMempoolSize is
     , snapshotSlotNo      = isSlotNo is
+    , snapshotLedgerState = isLedgerState is
     }
 
 implSnapshotGetTxs :: InternalState blk


### PR DESCRIPTION
Fixes #2581.

In our current ThreadNet tests, either the crucial transactions are only relevant "early" in the test (eg RealTPraos, Cardano, etc) or else we've never seen the mempools filling up cause a Issue #2581-like failure (eg RealPBFT).

Based on the assumption that our crucial txs are used up "early" enough, this PR fixes Issue #2581. "Later" when the mempools have become full, the nodes are still able to immediately determine that the crucial txs are invalid (since they're already on the chain, etc). This unblocks the forge soon enough to not disturb the consensus behavior in the ThreadNet.