### PR TITLE
Update dependency on ledger-specs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -179,78 +179,78 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 4edcdab87510b2657c62bcf14035817ce6e23455
-  --sha256: 0pny288kg9di32wdi0y6fbbr3791flc6x44zmvvw6m1hx8299hhq
+  tag: c742663756b0c83074d58ff78913ed270b710182
+  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 4edcdab87510b2657c62bcf14035817ce6e23455
-  --sha256: 0pny288kg9di32wdi0y6fbbr3791flc6x44zmvvw6m1hx8299hhq
+  tag: c742663756b0c83074d58ff78913ed270b710182
+  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
   subdir: semantics/small-steps-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 4edcdab87510b2657c62bcf14035817ce6e23455
-  --sha256: 0pny288kg9di32wdi0y6fbbr3791flc6x44zmvvw6m1hx8299hhq
+  tag: c742663756b0c83074d58ff78913ed270b710182
+  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 4edcdab87510b2657c62bcf14035817ce6e23455
-  --sha256: 0pny288kg9di32wdi0y6fbbr3791flc6x44zmvvw6m1hx8299hhq
+  tag: c742663756b0c83074d58ff78913ed270b710182
+  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 4edcdab87510b2657c62bcf14035817ce6e23455
-  --sha256: 0pny288kg9di32wdi0y6fbbr3791flc6x44zmvvw6m1hx8299hhq
+  tag: c742663756b0c83074d58ff78913ed270b710182
+  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 4edcdab87510b2657c62bcf14035817ce6e23455
-  --sha256: 0pny288kg9di32wdi0y6fbbr3791flc6x44zmvvw6m1hx8299hhq
+  tag: c742663756b0c83074d58ff78913ed270b710182
+  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 4edcdab87510b2657c62bcf14035817ce6e23455
-  --sha256: 0pny288kg9di32wdi0y6fbbr3791flc6x44zmvvw6m1hx8299hhq
+  tag: c742663756b0c83074d58ff78913ed270b710182
+  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 4edcdab87510b2657c62bcf14035817ce6e23455
-  --sha256: 0pny288kg9di32wdi0y6fbbr3791flc6x44zmvvw6m1hx8299hhq
+  tag: c742663756b0c83074d58ff78913ed270b710182
+  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 4edcdab87510b2657c62bcf14035817ce6e23455
-  --sha256: 0pny288kg9di32wdi0y6fbbr3791flc6x44zmvvw6m1hx8299hhq
+  tag: c742663756b0c83074d58ff78913ed270b710182
+  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 4edcdab87510b2657c62bcf14035817ce6e23455
-  --sha256: 0pny288kg9di32wdi0y6fbbr3791flc6x44zmvvw6m1hx8299hhq
+  tag: c742663756b0c83074d58ff78913ed270b710182
+  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 4edcdab87510b2657c62bcf14035817ce6e23455
-  --sha256: 0pny288kg9di32wdi0y6fbbr3791flc6x44zmvvw6m1hx8299hhq
+  tag: c742663756b0c83074d58ff78913ed270b710182
+  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
   subdir: shelley/chain-and-ledger/shelley-spec-ledger-test
 
 source-repository-package

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -39,14 +39,15 @@ import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Chain.Common as Byron
 import           Cardano.Chain.Genesis (GeneratedSecrets (..))
 
-import qualified Cardano.Ledger.Val as Val
-import qualified Shelley.Spec.Ledger.Address as SL
+import           Cardano.Ledger.Val ((<->))
+import qualified Shelley.Spec.Ledger.Address as SL (BootstrapAddress (..))
 import qualified Shelley.Spec.Ledger.Address.Bootstrap as SL
+                     (makeBootstrapWitness)
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.BaseTypes as SL
-import qualified Shelley.Spec.Ledger.Keys as SL
-import qualified Shelley.Spec.Ledger.Tx as SL
-import qualified Shelley.Spec.Ledger.UTxO as SL
+import qualified Shelley.Spec.Ledger.BaseTypes as SL (truncateUnitInterval)
+import qualified Shelley.Spec.Ledger.Keys as SL (hashWithSerialiser,
+                     signedDSIGN)
+import qualified Shelley.Spec.Ledger.Tx as SL (WitnessSetHKD (..))
 
 import           Ouroboros.Consensus.Shelley.Ledger (GenTx, ShelleyBlock,
                      mkShelleyTx)
@@ -164,7 +165,7 @@ migrateUTxO migrationInfo curSlot lcfg lst
         unspentCoin :: SL.Coin
         unspentCoin =
             assert (pickedCoin > spentCoin) $
-            pickedCoin Val.~~ spentCoin
+            pickedCoin <-> spentCoin
 
         body :: SL.TxBody (ShelleyEra c)
         body = SL.TxBody

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
@@ -55,12 +55,10 @@ import           Ouroboros.Consensus.Byron.Ledger.Block (ByronBlock)
 import           Ouroboros.Consensus.Byron.Ledger.Conversions
 import           Ouroboros.Consensus.Byron.Node
 
-import qualified Shelley.Spec.Ledger.BaseTypes as SL
-import qualified Shelley.Spec.Ledger.Genesis as SL
-import qualified Shelley.Spec.Ledger.OCert as SL
-import qualified Shelley.Spec.Ledger.OverlaySchedule as SL
-import qualified Shelley.Spec.Ledger.PParams as SL
-import qualified Shelley.Spec.Ledger.StabilityWindow as SL
+import qualified Shelley.Spec.Ledger.API as SL
+import qualified Shelley.Spec.Ledger.BaseTypes as SL (ActiveSlotCoeff,
+                     mkNonceFromNumber)
+import qualified Shelley.Spec.Ledger.OverlaySchedule as SL (overlaySlots)
 
 import           Ouroboros.Consensus.Shelley.Node
 

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -64,12 +64,6 @@ import           Cardano.Ledger.Crypto (ADDRHASH, DSIGN, HASH)
 import qualified Cardano.Ledger.Era as Era
 
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.BaseTypes as SL
-import qualified Shelley.Spec.Ledger.ByronTranslation as SL
-import qualified Shelley.Spec.Ledger.Genesis as SL
-import qualified Shelley.Spec.Ledger.PParams as SL
-import qualified Shelley.Spec.Ledger.STS.Prtcl as SL
-import qualified Shelley.Spec.Ledger.STS.Tickn as SL
 
 import           Ouroboros.Consensus.Cardano.Block
 

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -19,7 +19,7 @@ import           Options.Applicative
 import qualified Cardano.Chain.Genesis as Genesis
 import qualified Cardano.Chain.Update as Update
 
-import qualified Shelley.Spec.Ledger.PParams as SL
+import qualified Shelley.Spec.Ledger.API as SL
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.HardFork.Combinator (OneEraHash (..))

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
@@ -17,8 +17,7 @@ import qualified Data.Map.Strict as Map
 import           Options.Applicative
 
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.BlockChain as SL
-import qualified Shelley.Spec.Ledger.PParams as SL
+import qualified Shelley.Spec.Ledger.BlockChain as SL (TxSeq (..))
 
 import           Ouroboros.Consensus.Node.ProtocolInfo
 

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -65,12 +65,13 @@ import           Test.Util.Time (dawnOfTime)
 import           Cardano.Ledger.Crypto (DSIGN, KES, VRF)
 import           Cardano.Ledger.Era (Era (Crypto))
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.BaseTypes as SL
-import qualified Shelley.Spec.Ledger.Genesis as SL
-import qualified Shelley.Spec.Ledger.Keys as SL
-import qualified Shelley.Spec.Ledger.OCert as SL
-import qualified Shelley.Spec.Ledger.PParams as SL
-import qualified Shelley.Spec.Ledger.Tx as SL
+import qualified Shelley.Spec.Ledger.BaseTypes as SL (truncateUnitInterval,
+                     unitIntervalFromRational)
+import qualified Shelley.Spec.Ledger.Keys as SL (signedDSIGN)
+import qualified Shelley.Spec.Ledger.OCert as SL (OCertSignable (..))
+import qualified Shelley.Spec.Ledger.PParams as SL (emptyPParams,
+                     emptyPParamsUpdate)
+import qualified Shelley.Spec.Ledger.Tx as SL (WitnessSetHKD (..))
 
 import           Ouroboros.Consensus.Shelley.Ledger (GenTx (..), ShelleyBlock,
                      mkShelleyTx)

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -33,9 +33,8 @@ import           Test.Util.Orphans.Arbitrary ()
 import           Test.Util.Slots (NumSlots (..))
 
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.BaseTypes as SL
-import qualified Shelley.Spec.Ledger.OCert as SL
-import qualified Shelley.Spec.Ledger.PParams as SL
+import qualified Shelley.Spec.Ledger.BaseTypes as SL (UnitInterval,
+                     mkNonceFromNumber, unitIntervalToRational)
 
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -53,7 +53,7 @@ import           Ouroboros.Consensus.Storage.Common (BinaryBlockInfo (..))
 import           Ouroboros.Consensus.Util (ShowProxy (..), hashFromBytesShortE)
 import           Ouroboros.Consensus.Util.Condense
 
-import qualified Shelley.Spec.Ledger.BlockChain as SL
+import qualified Shelley.Spec.Ledger.API as SL
 
 import           Cardano.Ledger.Crypto (HASH)
 import           Cardano.Ledger.Era (Era (Crypto))

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
@@ -21,8 +21,6 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime
 
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.Genesis as SL
-import qualified Shelley.Spec.Ledger.PParams as SL (ProtVer)
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
@@ -26,11 +26,10 @@ import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.Condense
 
+import qualified Shelley.Spec.Ledger.API as SL
 import           Shelley.Spec.Ledger.BaseTypes (strictMaybeToMaybe)
-import qualified Shelley.Spec.Ledger.Genesis as SL
-import qualified Shelley.Spec.Ledger.Keys as SL
-import qualified Shelley.Spec.Ledger.LedgerState as SL
-import qualified Shelley.Spec.Ledger.PParams as SL
+import qualified Shelley.Spec.Ledger.LedgerState as SL (proposals)
+import qualified Shelley.Spec.Ledger.PParams as SL (PParamsUpdate)
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Integrity.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Integrity.hs
@@ -11,8 +11,7 @@ import           Data.Word (Word64)
 import           Ouroboros.Consensus.Block
 
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.Keys as SL
-import qualified Shelley.Spec.Ledger.OCert as SL
+import qualified Shelley.Spec.Ledger.Keys as SL (verifySignedKES)
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Protocol

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -87,12 +87,9 @@ import           Ouroboros.Consensus.Util.CBOR (decodeWithOrigin,
 import           Ouroboros.Consensus.Util.Versioned
 
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.BaseTypes as SL
-import qualified Shelley.Spec.Ledger.Genesis as SL
-import qualified Shelley.Spec.Ledger.LedgerState as SL
-import qualified Shelley.Spec.Ledger.StabilityWindow as SL
-import qualified Shelley.Spec.Ledger.STS.Chain as STS
-import qualified Shelley.Spec.Ledger.UTxO as SL
+import qualified Shelley.Spec.Ledger.LedgerState as SL (RewardAccounts,
+                     proposals)
+import qualified Shelley.Spec.Ledger.STS.Chain as SL (ChainPredicateFailure)
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.TPraos ()
@@ -540,7 +537,7 @@ instance Era era => BasicEnvelopeValidation (ShelleyBlock era) where
 
 instance Era era => ValidateEnvelope (ShelleyBlock era) where
   type OtherHeaderEnvelopeError (ShelleyBlock era) =
-    STS.ChainPredicateFailure era
+    SL.ChainPredicateFailure era
 
   additionalEnvelopeChecks cfg (TickedPraosLedgerView ledgerView) hdr =
       SL.chainChecks globals pparams (shelleyHeaderRaw hdr)
@@ -572,9 +569,9 @@ getFilteredDelegationsAndRewardAccounts :: SL.ShelleyState era
 getFilteredDelegationsAndRewardAccounts ss creds =
     (filteredDelegations, filteredRwdAcnts)
   where
-    dstate = getDState ss
-    filteredDelegations = Map.restrictKeys (SL._delegations dstate) creds
-    filteredRwdAcnts = Map.restrictKeys (SL._rewards dstate) creds
+    SL.DState { _rewards = rewards, _delegations = delegations } = getDState ss
+    filteredDelegations = Map.restrictKeys delegations creds
+    filteredRwdAcnts = Map.restrictKeys rewards creds
 
 {-------------------------------------------------------------------------------
   Serialisation

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -41,8 +41,8 @@ import           Ouroboros.Consensus.Util (ShowProxy (..))
 import           Ouroboros.Consensus.Util.Condense
 
 import qualified Shelley.Spec.Ledger.API as SL
-import           Shelley.Spec.Ledger.BlockChain as SL
-import qualified Shelley.Spec.Ledger.UTxO as SL
+import           Shelley.Spec.Ledger.BlockChain as SL (TxSeq (..))
+import qualified Shelley.Spec.Ledger.UTxO as SL (txid)
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.Ledger

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/TPraos.hs
@@ -12,7 +12,6 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Protocol.Signed
 
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.BlockChain as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block
 import           Ouroboros.Consensus.Shelley.Ledger.Config

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -48,22 +48,9 @@ import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.IOLike
 
-import qualified Cardano.Ledger.Val as Val
+import           Cardano.Ledger.Val ((<->))
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.BaseTypes as SL
-import qualified Shelley.Spec.Ledger.BlockChain as SL
-import qualified Shelley.Spec.Ledger.Coin as SL
-import qualified Shelley.Spec.Ledger.EpochBoundary as SL
-import qualified Shelley.Spec.Ledger.Genesis as SL
-import qualified Shelley.Spec.Ledger.Keys as SL
 import qualified Shelley.Spec.Ledger.OCert as Absolute (KESPeriod (..))
-import qualified Shelley.Spec.Ledger.OCert as SL
-import qualified Shelley.Spec.Ledger.PParams as SL
-import qualified Shelley.Spec.Ledger.STS.Chain as SL
-import qualified Shelley.Spec.Ledger.STS.NewEpoch as SL
-import qualified Shelley.Spec.Ledger.STS.Prtcl as SL
-import qualified Shelley.Spec.Ledger.STS.Tickn as SL
-import qualified Shelley.Spec.Ledger.UTxO as SL
 
 import           Ouroboros.Consensus.Shelley.Ledger
 import           Ouroboros.Consensus.Shelley.Ledger.Inspect ()
@@ -234,7 +221,7 @@ protocolInfoShelley genesis initialNonce maxMajorPV protVer mbCredentials =
       Origin
       initialEpochNo
       initialUtxo
-      (SL.word64ToCoin (SL.sgMaxLovelaceSupply genesis) Val.~~ SL.balance initialUtxo)
+      (SL.word64ToCoin (SL.sgMaxLovelaceSupply genesis) <-> SL.balance initialUtxo)
       (SL.sgGenDelegs genesis)
       (SL.sgProtocolParams genesis)
       initialNonce

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -67,15 +67,11 @@ import           Ouroboros.Consensus.Util.Versioned
 import           Cardano.Ledger.Crypto (VRF)
 import           Cardano.Ledger.Era (Era (Crypto))
 import qualified Shelley.Spec.Ledger.API as SL
-import qualified Shelley.Spec.Ledger.BaseTypes as SL
-import qualified Shelley.Spec.Ledger.BlockChain as SL
-import qualified Shelley.Spec.Ledger.Delegation.Certificates as SL
-import qualified Shelley.Spec.Ledger.Genesis as SL
-import qualified Shelley.Spec.Ledger.Keys as SL
+import qualified Shelley.Spec.Ledger.BaseTypes as SL (ActiveSlotCoeff, Seed)
+import qualified Shelley.Spec.Ledger.BlockChain as SL (checkLeaderValue, mkSeed,
+                     seedEta, seedL)
 import qualified Shelley.Spec.Ledger.OCert as Absolute (KESPeriod (..))
-import qualified Shelley.Spec.Ledger.OverlaySchedule as SL
-import qualified Shelley.Spec.Ledger.StabilityWindow as SL
-import qualified Shelley.Spec.Ledger.STS.Tickn as STS
+import qualified Shelley.Spec.Ledger.STS.Tickn as SL (ticknStateEpochNonce)
 
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto
 import           Ouroboros.Consensus.Shelley.Protocol.HotKey (HotKey)
@@ -416,8 +412,8 @@ instance TPraosCrypto era => ConsensusProtocol (TPraos era) where
       d          = SL._d $ SL.lvProtParams lv
       asc        = tpraosLeaderF $ tpraosParams cfg
       firstSlot  = firstSlotOfEpochOfSlot (tpraosEpochInfo cfg) slot
-      gkeys      = Map.keys dlgMap
-      eta0       = STS.ticknStateEpochNonce $ SL.csTickn chainState
+      gkeys      = Map.keysSet dlgMap
+      eta0       = SL.ticknStateEpochNonce $ SL.csTickn chainState
       vkhCold    = SL.hashKey tpraosCanBeLeaderColdVerKey
       rho'       = SL.mkSeed SL.seedEta slot eta0
       y'         = SL.mkSeed SL.seedL   slot eta0

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
@@ -19,14 +19,15 @@ import           Cardano.Ledger.Crypto (Crypto (..))
 import           Cardano.Ledger.Era (Era)
 import           Cardano.Ledger.Shelley (Shelley)
 
-import           Shelley.Spec.Ledger.API (BHBody, TxBody)
+import           Shelley.Spec.Ledger.API (BHBody, Hash, TxBody)
 import           Shelley.Spec.Ledger.BaseTypes (Seed)
-import qualified Shelley.Spec.Ledger.Keys as SL
+import qualified Shelley.Spec.Ledger.Keys as SL (DSignable, KESignable,
+                     VRFSignable)
 import           Shelley.Spec.Ledger.OCert (OCertSignable)
 
 class ( Era era
       , SL.DSignable    era (OCertSignable era)
-      , SL.DSignable    era (SL.Hash era (TxBody era))
+      , SL.DSignable    era (Hash era (TxBody era))
       , SL.KESignable   era (BHBody era)
       , SL.VRFSignable  era Seed
       ) => TPraosCrypto era


### PR DESCRIPTION
Many Shelley imports are now redundant as `Shelley.Spec.Ledger.API` exports much
more. Unfortunately, still not everything we need. Explicitly list which imports
are missing from the API.