### PR TITLE
Bump dependency on ledger-specs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -179,78 +179,78 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c742663756b0c83074d58ff78913ed270b710182
-  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
+  tag: 785e33056d23e55268b9503efb3c6899ed37255a
+  --sha256: 0h7br21pkwl85j55knrrhxnxhqhlsss59b96bk5hwq8w3nmkcrm2
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c742663756b0c83074d58ff78913ed270b710182
-  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
+  tag: 785e33056d23e55268b9503efb3c6899ed37255a
+  --sha256: 0h7br21pkwl85j55knrrhxnxhqhlsss59b96bk5hwq8w3nmkcrm2
   subdir: semantics/small-steps-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c742663756b0c83074d58ff78913ed270b710182
-  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
+  tag: 785e33056d23e55268b9503efb3c6899ed37255a
+  --sha256: 0h7br21pkwl85j55knrrhxnxhqhlsss59b96bk5hwq8w3nmkcrm2
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c742663756b0c83074d58ff78913ed270b710182
-  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
+  tag: 785e33056d23e55268b9503efb3c6899ed37255a
+  --sha256: 0h7br21pkwl85j55knrrhxnxhqhlsss59b96bk5hwq8w3nmkcrm2
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c742663756b0c83074d58ff78913ed270b710182
-  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
+  tag: 785e33056d23e55268b9503efb3c6899ed37255a
+  --sha256: 0h7br21pkwl85j55knrrhxnxhqhlsss59b96bk5hwq8w3nmkcrm2
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c742663756b0c83074d58ff78913ed270b710182
-  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
+  tag: 785e33056d23e55268b9503efb3c6899ed37255a
+  --sha256: 0h7br21pkwl85j55knrrhxnxhqhlsss59b96bk5hwq8w3nmkcrm2
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c742663756b0c83074d58ff78913ed270b710182
-  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
+  tag: 785e33056d23e55268b9503efb3c6899ed37255a
+  --sha256: 0h7br21pkwl85j55knrrhxnxhqhlsss59b96bk5hwq8w3nmkcrm2
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c742663756b0c83074d58ff78913ed270b710182
-  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
+  tag: 785e33056d23e55268b9503efb3c6899ed37255a
+  --sha256: 0h7br21pkwl85j55knrrhxnxhqhlsss59b96bk5hwq8w3nmkcrm2
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c742663756b0c83074d58ff78913ed270b710182
-  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
+  tag: 785e33056d23e55268b9503efb3c6899ed37255a
+  --sha256: 0h7br21pkwl85j55knrrhxnxhqhlsss59b96bk5hwq8w3nmkcrm2
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c742663756b0c83074d58ff78913ed270b710182
-  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
+  tag: 785e33056d23e55268b9503efb3c6899ed37255a
+  --sha256: 0h7br21pkwl85j55knrrhxnxhqhlsss59b96bk5hwq8w3nmkcrm2
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: c742663756b0c83074d58ff78913ed270b710182
-  --sha256: 1ys2c4kybhm9dmg0bf72jx1j6lr0hbqzr8rrhizqxshznz2rhv6p
+  tag: 785e33056d23e55268b9503efb3c6899ed37255a
+  --sha256: 0h7br21pkwl85j55knrrhxnxhqhlsss59b96bk5hwq8w3nmkcrm2
   subdir: shelley/chain-and-ledger/shelley-spec-ledger-test
 
 source-repository-package


### PR DESCRIPTION
This brings in
<https://github.com/input-output-hk/cardano-ledger-specs/pull/1881>.