### PR TITLE
Make `Exactly` a newtype

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -36,7 +36,7 @@ import           Control.Exception (assert)
 import qualified Data.ByteString.Short as Short
 import           Data.Functor.Contravariant (contramap)
 import qualified Data.Map.Strict as Map
-import           Data.SOP.Strict (NP (..), hd, unK)
+import           Data.SOP.Strict (NP (..))
 import           Data.Word (Word16)
 
 import           Cardano.Binary (DecoderError (..), enforceSize)
@@ -57,7 +57,7 @@ import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 import           Ouroboros.Consensus.Storage.Serialisation
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Assert
-import           Ouroboros.Consensus.Util.Counting (exactlyTwo)
+import           Ouroboros.Consensus.Util.Counting
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.OptNP (OptNP (..))
 
@@ -229,7 +229,7 @@ instance CardanoHardForkConstraints c => RunNode (CardanoBlock c) where
   nodeImmutableDbChunkInfo =
         simpleChunkInfo
       . History.eraEpochSize
-      . unK . hd
+      . exactlyHead
       . History.getShape
       . hardForkLedgerConfigShape
       . configLedger

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -22,7 +22,6 @@
 module Test.Consensus.HardFork.Combinator (tests) where
 
 import qualified Data.Map as Map
-import           Data.SOP.BasicFunctors
 import           Data.SOP.Strict hiding (shape)
 import           Data.Word
 import           GHC.Generics (Generic)
@@ -399,7 +398,7 @@ instance RunNode TestBlock where
   nodeImmutableDbChunkInfo =
         simpleChunkInfo
       . eraEpochSize
-      . unK . hd
+      . exactlyHead
       . History.getShape
       . hardForkLedgerConfigShape
       . configLedger

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -50,6 +50,7 @@ import           Ouroboros.Consensus.Ledger.SupportsProtocol
 import           Ouroboros.Consensus.Protocol.Abstract
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Condense
+import           Ouroboros.Consensus.Util.Counting (getExactly)
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
@@ -328,7 +329,7 @@ instance CanHardFork xs => LedgerSupportsProtocol (HardForkBlock xs) where
           proxySingle
           forecastOne
           pcfgs
-          (History.getShape hardForkLedgerConfigShape)
+          (getExactly (History.getShape hardForkLedgerConfigShape))
           (getHardForkState st))
     where
       ei    = State.epochInfoLedger ledgerCfg st
@@ -565,7 +566,7 @@ instance CanHardFork xs => InspectLedger (HardForkBlock xs) where
                 (HardForkLedgerState after) =
       inspectHardForkLedger
         pcfgs
-        shape
+        (getExactly shape)
         cfgs
         (Telescope.tip (getHardForkState before))
         (Telescope.tip (getHardForkState after))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -52,6 +52,7 @@ import           Ouroboros.Consensus.HardFork.History (Bound (..), EraParams,
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Node.Serialisation (Some (..))
+import           Ouroboros.Consensus.Util.Counting (getExactly)
 import           Ouroboros.Consensus.Util.DepPair
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
@@ -244,7 +245,7 @@ answerQueryAnytime ::
   -> Situated h LedgerState xs
   -> result
 answerQueryAnytime HardForkLedgerConfig{..} =
-    go cfgs (getShape hardForkLedgerConfigShape)
+    go cfgs (getExactly (getShape hardForkLedgerConfigShape))
   where
     cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -41,6 +41,7 @@ import           Ouroboros.Consensus.Block
 import qualified Ouroboros.Consensus.HardFork.History as History
 import           Ouroboros.Consensus.Ledger.Abstract hiding (getTip)
 import           Ouroboros.Consensus.Util ((.:))
+import           Ouroboros.Consensus.Util.Counting (getExactly)
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
@@ -119,7 +120,7 @@ mostRecentTransitionInfo HardForkLedgerConfig{..} st =
         proxySingle
         getTransition
         cfgs
-        (History.getShape hardForkLedgerConfigShape)
+        (getExactly (History.getShape hardForkLedgerConfigShape))
         (Telescope.tip (getHardForkState st))
   where
     cfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra
@@ -187,7 +188,7 @@ extendToSlot ledgerCfg@HardForkLedgerConfig{..} slot ledgerSt@(HardForkState st)
            proxySingle
            (fn .: whenExtend)
            pcfgs
-           (History.getShape hardForkLedgerConfigShape))
+           (getExactly (History.getShape hardForkLedgerConfigShape)))
     $ st
   where
     pcfgs = getPerEraLedgerConfig hardForkLedgerConfigPerEra

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Infra.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Infra.hs
@@ -170,12 +170,12 @@ reconstructSummary (History.Shape shape) transition (HardForkState st) =
     go :: Exactly xs' EraParams
        -> Telescope (K Past) (Current f) xs'
        -> NonEmpty xs' EraSummary
-    go (K params :* ss) (TS (K Past{..}) t) =
+    go (ExactlyCons params ss) (TS (K Past{..}) t) =
         NonEmptyCons (EraSummary pastStart (EraEnd pastEnd) params) $ go ss t
-    go (K params :* Nil) (TZ Current{..}) =
+    go (ExactlyCons params ExactlyNil) (TZ Current{..}) =
         -- The current era is the last. We assume it lasts until all eternity.
         NonEmptyOne (EraSummary currentStart EraUnbounded params)
-    go (K params :* K nextParams :* _) (TZ Current{..}) =
+    go (ExactlyCons params (ExactlyCons nextParams _)) (TZ Current{..}) =
         case transition of
           TransitionKnown epoch ->
             -- We haven't reached the next era yet, but the transition is
@@ -219,7 +219,7 @@ reconstructSummary (History.Shape shape) transition (HardForkState st) =
                               (boundSlot currentStart)
               }
 
-    go Nil t = case t of {}
+    go ExactlyNil t = case t of {}
 
     -- Apply safe zone from the specified 'SlotNo'
     --


### PR DESCRIPTION
This is an internal refactoring only, but it means that Exactly can be given
sane `Functor`, `Foldable`, `Transversable`, as well as `Show` and `Eq`
instances (without any complicated `All ( .. Compose ...)` constraints). A lot
more convenient to work with.