### PR TITLE
Update haskell.nix and fix windows cross

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -33,22 +33,6 @@ let
     compiler-nix-name = compiler;
     modules = [
 
-      # Allow reinstallation of Win32
-      { nonReinstallablePkgs =
-        [ "rts" "ghc-heap" "ghc-prim" "integer-gmp" "integer-simple" "base"
-          "deepseq" "array" "ghc-boot-th" "pretty" "template-haskell"
-          # ghcjs custom packages
-          "ghcjs-prim" "ghcjs-th"
-          "ghc-boot"
-          "ghc" "array" "binary" "bytestring" "containers"
-          "filepath" "ghc-boot" "ghc-compact" "ghc-prim"
-          # "ghci" "haskeline"
-          "hpc"
-          "mtl" "parsec" "text" "transformers"
-          "xhtml"
-          # "stm" "terminfo"
-        ];
-      }
       # Compile all local packages with -Werror:
       {
         packages = lib.genAttrs projectPackages
@@ -59,15 +43,22 @@ let
         packages.prometheus.components.library.doExactConfig = true;
         enableLibraryProfiling = profiling;
       }
-      (if stdenv.hostPlatform.isWindows then {
-        # Disable cabal-doctest tests by turning off custom setups
-        packages.comonad.package.buildType = lib.mkForce "Simple";
-        packages.distributive.package.buildType = lib.mkForce "Simple";
-        packages.lens.package.buildType = lib.mkForce "Simple";
-        packages.nonempty-vector.package.buildType = lib.mkForce "Simple";
-        packages.semigroupoids.package.buildType = lib.mkForce "Simple";
-        packages.system-filepath.package.buildType = lib.mkForce "Simple";
-
+      ({ pkgs, ... }: lib.mkIf pkgs.stdenv.hostPlatform.isWindows {
+        # Allow reinstallation of Win32
+        nonReinstallablePkgs =
+          [ "rts" "ghc-heap" "ghc-prim" "integer-gmp" "integer-simple" "base"
+            "deepseq" "array" "ghc-boot-th" "pretty" "template-haskell"
+            # ghcjs custom packages
+            "ghcjs-prim" "ghcjs-th"
+            "ghc-boot"
+            "ghc" "array" "binary" "bytestring" "containers"
+            "filepath" "ghc-boot" "ghc-compact" "ghc-prim"
+            # "ghci" "haskeline"
+            "hpc"
+            "mtl" "parsec" "text" "transformers"
+            "xhtml"
+            # "stm" "terminfo"
+          ];
         # ruby/perl dependencies cannot be cross-built for cddl tests:
         packages.ouroboros-network.flags.cddl = false;
 
@@ -80,11 +71,10 @@ let
         packages.network.components.library.build-tools = lib.mkForce [];
 
         # Make sure that libsodium DLLs are available for tests
-        packages.ouroboros-consensus-shelley-test.components.all.postInstall = lib.mkForce "";
         packages.ouroboros-consensus-shelley-test.components.tests.test.postInstall = ''ln -s ${libsodium}/bin/libsodium-23.dll $out/bin/libsodium-23.dll'';
-        packages.ouroboros-consensus-cardano-test.components.all.postInstall = lib.mkForce "";
         packages.ouroboros-consensus-cardano-test.components.tests.test.postInstall = ''ln -s ${libsodium}/bin/libsodium-23.dll $out/bin/libsodium-23.dll'';
-      } else {
+      })
+      ({ pkgs, ... }: lib.mkIf (!pkgs.stdenv.hostPlatform.isWindows) {
         packages.ouroboros-network.flags.cddl = true;
         packages.ouroboros-network.components.tests.test-cddl.build-tools = [pkgs.cddl pkgs.cbor-diag];
         packages.ouroboros-network.components.tests.test-cddl.preCheck = "export HOME=`pwd`";

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "35b1ec8cd577bfc5abf7d0325f38aab01de5ed00",
-        "sha256": "0mg18i6g7nxd7qk0kaca6k8dsc3kam21772zlr19k03ff67ws55j",
+        "rev": "100a618930694f37a1027436d627c2d271993f46",
+        "sha256": "05y70pg2k3x4bfhilw7c3nl8b2ckp6b0h9bsnqj048w4l1my1g54",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/35b1ec8cd577bfc5abf7d0325f38aab01de5ed00.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/100a618930694f37a1027436d627c2d271993f46.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {


### PR DESCRIPTION
Currently the use of nonReinstallablePkgs to make the Win32
reinstallable breaks cross compilation of any package using a
custom-setup.  This is because nonReinstallablePkgs is applied
unconditionally and therefor applies to the "build" packages
that are used for compiling the setup executables.

The work around has been to add `buildType - lib.mkForce "Simple"`
to any packages that use a custom setup executable.  Maintaining this
list is annoying and difficult (in part because the error message
given when a package needs to be added a long way from clear).

It turns out the correct fix is to make the override for
nonReinstallablePkgs conditional and the correct way to do that
is to use `pkgs` from the module arguments to detect when the
`hostPlatform.isWindows`.  We also need to use `mkIf` to avoid
infinite recursion.  So the windows specific module is now wrapped
in:

```
({ pkgs, ... }: lib.mkIf pkgs.stdenv.hostPlatform.isWindows {...})
```

This change also updates to a more recent `haskell.nix` commit and
removes the references to the `.all` components (they have been
removed from haskell.nix).