### PR TITLE
Update cardano-base dependency and make required changes

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -144,113 +144,113 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 13f44ad35d2762dbf98b3d3be56b7ba2adf515f4
-  --sha256: 0sl7adyrjf3w6025gvljxyr222s53avin0sv0gzhdypmj9wg5ml6
+  tag: 693b57a3b26f8d5619a62bbf0d4aa1ff3f5af809
+  --sha256: 1nwrsaay9ybhxaffna8n8y1a6v107x207vqwqjg5s5i75rnirml2
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 13f44ad35d2762dbf98b3d3be56b7ba2adf515f4
-  --sha256: 0sl7adyrjf3w6025gvljxyr222s53avin0sv0gzhdypmj9wg5ml6
+  tag: 693b57a3b26f8d5619a62bbf0d4aa1ff3f5af809
+  --sha256: 1nwrsaay9ybhxaffna8n8y1a6v107x207vqwqjg5s5i75rnirml2
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 13f44ad35d2762dbf98b3d3be56b7ba2adf515f4
-  --sha256: 0sl7adyrjf3w6025gvljxyr222s53avin0sv0gzhdypmj9wg5ml6
+  tag: 693b57a3b26f8d5619a62bbf0d4aa1ff3f5af809
+  --sha256: 1nwrsaay9ybhxaffna8n8y1a6v107x207vqwqjg5s5i75rnirml2
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 13f44ad35d2762dbf98b3d3be56b7ba2adf515f4
-  --sha256: 0sl7adyrjf3w6025gvljxyr222s53avin0sv0gzhdypmj9wg5ml6
+  tag: 693b57a3b26f8d5619a62bbf0d4aa1ff3f5af809
+  --sha256: 1nwrsaay9ybhxaffna8n8y1a6v107x207vqwqjg5s5i75rnirml2
   subdir: cardano-crypto-praos
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 13f44ad35d2762dbf98b3d3be56b7ba2adf515f4
-  --sha256: 0sl7adyrjf3w6025gvljxyr222s53avin0sv0gzhdypmj9wg5ml6
+  tag: 693b57a3b26f8d5619a62bbf0d4aa1ff3f5af809
+  --sha256: 1nwrsaay9ybhxaffna8n8y1a6v107x207vqwqjg5s5i75rnirml2
   subdir: slotting
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: 18015dc0b402ab9a5adf2b9cb88b558ec2a043e1
+  --sha256: 11jm5idkyi59mrrkzbjd7wjwx94kiwnadjqcazrybrclpw6syjaf
   subdir: semantics/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: 18015dc0b402ab9a5adf2b9cb88b558ec2a043e1
+  --sha256: 11jm5idkyi59mrrkzbjd7wjwx94kiwnadjqcazrybrclpw6syjaf
   subdir: semantics/small-steps-test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: 18015dc0b402ab9a5adf2b9cb88b558ec2a043e1
+  --sha256: 11jm5idkyi59mrrkzbjd7wjwx94kiwnadjqcazrybrclpw6syjaf
   subdir: byron/ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: 18015dc0b402ab9a5adf2b9cb88b558ec2a043e1
+  --sha256: 11jm5idkyi59mrrkzbjd7wjwx94kiwnadjqcazrybrclpw6syjaf
   subdir: byron/ledger/impl
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: 18015dc0b402ab9a5adf2b9cb88b558ec2a043e1
+  --sha256: 11jm5idkyi59mrrkzbjd7wjwx94kiwnadjqcazrybrclpw6syjaf
   subdir: byron/ledger/impl/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: 18015dc0b402ab9a5adf2b9cb88b558ec2a043e1
+  --sha256: 11jm5idkyi59mrrkzbjd7wjwx94kiwnadjqcazrybrclpw6syjaf
   subdir: byron/crypto
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: 18015dc0b402ab9a5adf2b9cb88b558ec2a043e1
+  --sha256: 11jm5idkyi59mrrkzbjd7wjwx94kiwnadjqcazrybrclpw6syjaf
   subdir: byron/crypto/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: 18015dc0b402ab9a5adf2b9cb88b558ec2a043e1
+  --sha256: 11jm5idkyi59mrrkzbjd7wjwx94kiwnadjqcazrybrclpw6syjaf
   subdir: byron/chain/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: 18015dc0b402ab9a5adf2b9cb88b558ec2a043e1
+  --sha256: 11jm5idkyi59mrrkzbjd7wjwx94kiwnadjqcazrybrclpw6syjaf
   subdir: shelley/chain-and-ledger/dependencies/non-integer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: 18015dc0b402ab9a5adf2b9cb88b558ec2a043e1
+  --sha256: 11jm5idkyi59mrrkzbjd7wjwx94kiwnadjqcazrybrclpw6syjaf
   subdir: shelley/chain-and-ledger/executable-spec
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: a6ce8feddc09bf78c4378c9b4592c6509bfddc81
-  --sha256: 1f8149wynplf83haqnx124jw89kg45i3wbsm8chl7g68qkw7xhzq
+  tag: 18015dc0b402ab9a5adf2b9cb88b558ec2a043e1
+  --sha256: 11jm5idkyi59mrrkzbjd7wjwx94kiwnadjqcazrybrclpw6syjaf
   subdir: shelley/chain-and-ledger/shelley-spec-ledger-test
 
 source-repository-package

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Crypto/DSIGN.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Crypto/DSIGN.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds            #-}
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE DerivingVia                #-}
@@ -103,11 +104,11 @@ instance DSIGNAlgorithm ByronDSIGN where
           then Right ()
           else Left "Verification failed"
 
-    seedSizeDSIGN _ = 32
+    type SeedSizeDSIGN ByronDSIGN = 32
 
-    sizeVerKeyDSIGN _ = 64
-    sizeSignKeyDSIGN _ = 128
-    sizeSigDSIGN _ = 64
+    type SizeVerKeyDSIGN ByronDSIGN = 64
+    type SizeSignKeyDSIGN ByronDSIGN = 128
+    type SizeSigDSIGN ByronDSIGN = 64
 
     rawSerialiseVerKeyDSIGN (VerKeyByronDSIGN (VerificationKey vk)) = CC.unXPub vk
     rawSerialiseSignKeyDSIGN (SignKeyByronDSIGN (SigningKey sk)) = CC.unXPrv sk

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -58,7 +58,7 @@ import           Numeric.Natural
 
 import           Cardano.Crypto.DSIGN.Ed448 (Ed448DSIGN)
 import           Cardano.Crypto.Hash.Class (HashAlgorithm (..), hashToBytes,
-                     hashWithSerialiser)
+                     hashWithSerialiser, sizeHash)
 import           Cardano.Crypto.Hash.MD5 (MD5)
 import           Cardano.Crypto.Hash.SHA256 (SHA256)
 import           Cardano.Crypto.KES.Class

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -45,10 +45,11 @@ import           Quiet (Quiet (..))
 import           Test.QuickCheck
 
 import           Cardano.Binary (toCBOR)
-import           Cardano.Crypto.DSIGN (DSIGNAlgorithm (..))
+import           Cardano.Crypto.DSIGN (DSIGNAlgorithm (..), seedSizeDSIGN)
 import           Cardano.Crypto.Hash (Hash, HashAlgorithm, hashWithSerialiser)
 import           Cardano.Crypto.KES (KESAlgorithm (..))
-import           Cardano.Crypto.Seed (mkSeedFromBytes)
+import           Cardano.Crypto.Libsodium.MLockedBytes (mlsbFromByteString)
+import           Cardano.Crypto.Seed (getSeedBytes, mkSeedFromBytes)
 import qualified Cardano.Crypto.Seed as Cardano.Crypto
 import           Cardano.Crypto.VRF (SignKeyVRF, VRFAlgorithm, VerKeyVRF,
                      deriveVerKeyVRF, genKeyVRF, seedSizeVRF)
@@ -166,7 +167,8 @@ genCoreNode startKESPeriod = do
     delKey <- genKeyDSIGN <$> genSeed (seedSizeDSIGN (Proxy @(DSIGN (Crypto era))))
     stkKey <- genKeyDSIGN <$> genSeed (seedSizeDSIGN (Proxy @(DSIGN (Crypto era))))
     vrfKey <- genKeyVRF   <$> genSeed (seedSizeVRF   (Proxy @(VRF   (Crypto era))))
-    kesKey <- genKeyKES   <$> genSeed (seedSizeKES   (Proxy @(KES   (Crypto era))))
+    kesKey <- genKeyKES   <$> mlsbFromByteString . getSeedBytes
+                          <$> genSeed (seedSizeKES   (Proxy @(KES   (Crypto era))))
     let kesPub = deriveVerKeyKES kesKey
         sigma = SL.signedDSIGN
           @era

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -36,6 +36,8 @@ import           Cardano.Crypto.KES (MockKES, NeverKES, SigKES,
                      pattern SignKeyMockKES, SignedKES (..), SimpleKES,
                      SingleKES, SumKES, VerKeyKES, pattern VerKeyMockKES,
                      pattern VerKeySingleKES, pattern VerKeySumKES)
+import           Cardano.Crypto.PinnedSizedBytes (PinnedSizedBytes,
+                     psbToByteString)
 
 import           Ouroboros.Consensus.Util.HList (All, HList (..))
 import qualified Ouroboros.Consensus.Util.HList as HList
@@ -173,6 +175,13 @@ instance Condense a => Condense (WithOrigin a) where
   Orphans for cardano-crypto-classes
 -------------------------------------------------------------------------------}
 
+instance Condense (PinnedSizedBytes n) where
+  condense psb =
+         show psb
+      ++ "<"
+      ++ show (BS.Strict.length $ psbToByteString psb)
+      ++ "b>"
+
 instance Condense (SigDSIGN v) => Condense (SignedDSIGN v a) where
   condense (SignedDSIGN sig) = condense sig
 
@@ -202,7 +211,7 @@ instance Condense (SigKES NeverKES) where
 instance Condense (SigDSIGN d) => Condense (SigKES (SimpleKES d t)) where
     condense (SigSimpleKES sig) = condense sig
 
-instance Condense (SigDSIGN d) => Condense (SigKES (SingleKES d)) where
+instance Condense (SigKES (SingleKES d)) where
     condense (SigSingleKES sig) = condense sig
 
 instance Show (VerKeyDSIGN d) => Condense (VerKeyDSIGN d) where
@@ -212,7 +221,7 @@ instance (Condense (SigKES d), Condense (VerKeyKES d))
   => Condense (SigKES (SumKES h d)) where
     condense (SigSumKES sk vk1 vk2) = condense (sk, vk1, vk2)
 
-instance Show (VerKeyDSIGN d) => Condense (VerKeyKES (SingleKES d)) where
+instance Condense (VerKeyKES (SingleKES d)) where
     condense (VerKeySingleKES h) = condense h
 
 instance Condense (VerKeyKES (SumKES h d)) where


### PR DESCRIPTION
Update the `cardano-base` dependency and make the required changes.

Depends on https://github.com/input-output-hk/cardano-ledger-specs/pull/1887 (edit: now merged).