### PR TITLE
Network version: NodeToNodeV_4

### DIFF
--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -16,6 +16,7 @@ module Cardano.Client.Subscription (
   , RunMiniProtocol (..)
   , WithMuxBearer
   , ControlMessage (..)
+  , AgreedOptions
   , cChainSyncCodec
   , cStateQueryCodec
   , cTxSubmissionCodec
@@ -41,7 +42,7 @@ import           Ouroboros.Network.NodeToClient (ClientSubscriptionParams (..),
                      NodeToClientVersionData (NodeToClientVersionData),
                      ncSubscriptionWorker, newNetworkMutableState,
                      versionedNodeToClientProtocols)
-import           Ouroboros.Network.NodeToClient (NodeToClientVersion)
+import           Ouroboros.Network.NodeToClient (AgreedOptions, NodeToClientVersion)
 import           Ouroboros.Network.Protocol.Handshake.Version (DictVersion,
                      Versions, foldMapVersions)
 import qualified Ouroboros.Network.Snocket as Snocket
@@ -95,7 +96,7 @@ versionedProtocols ::
      -- 'OuroborosClientApplication', which does not include it.
   -> Versions
        NodeToClientVersion
-       DictVersion
+       (DictVersion NodeToClientVersion AgreedOptions)
        (OuroborosApplication appType LocalAddress bytes m a b)
 versionedProtocols codecConfig networkMagic callback =
     foldMapVersions applyVersion $
@@ -105,7 +106,7 @@ versionedProtocols codecConfig networkMagic callback =
          (NodeToClientVersion, BlockNodeToClientVersion blk)
       -> Versions
            NodeToClientVersion
-           DictVersion
+           (DictVersion NodeToClientVersion AgreedOptions)
            (OuroborosApplication appType LocalAddress bytes m a b)
     applyVersion (version, blockVersion) =
       versionedNodeToClientProtocols

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -48,11 +48,10 @@ import           Ouroboros.Network.Diffusion
 import           Ouroboros.Network.Magic
 import           Ouroboros.Network.NodeToClient (LocalConnectionId,
                      NodeToClientVersionData (..), nodeToClientDictVersion)
-import           Ouroboros.Network.NodeToNode (DiffusionMode (..),
-                     MiniProtocolParameters (..), NodeToNodeVersion (..),
-                     NodeToNodeVersionData (..), RemoteConnectionId,
-                     combineVersions, defaultMiniProtocolParameters,
-                     nodeToNodeDictVersion)
+import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..),
+                     NodeToNodeVersion (..), NodeToNodeVersionData (..),
+                     RemoteConnectionId, combineVersions,
+                     defaultMiniProtocolParameters, nodeToNodeDictVersion)
 import           Ouroboros.Network.Protocol.Limits (shortWait)
 
 import           Ouroboros.Consensus.Block
@@ -235,7 +234,7 @@ run runargs@RunNodeArgs{..} =
 
     nodeToNodeVersionData = NodeToNodeVersionData
       { networkMagic  = rnNetworkMagic
-      , diffusionMode = InitiatorAndResponderDiffusionMode
+      , diffusionMode = daDiffusionMode rnDiffusionArguments
       }
     nodeToClientVersionData = NodeToClientVersionData
       { networkMagic = rnNetworkMagic }

--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -150,7 +150,7 @@ serverPingPong =
       defaultLocalSocketAddr
       unversionedHandshakeCodec
       cborTermVersionDataCodec
-      (\(DictVersion _) -> acceptableVersion)
+      (\DictVersion {} -> acceptableVersion)
       (unversionedProtocol (SomeResponderApplication app))
       nullErrorPolicies
       $ \_ serverAsync ->
@@ -258,7 +258,7 @@ serverPingPong2 =
       defaultLocalSocketAddr
       unversionedHandshakeCodec
       cborTermVersionDataCodec
-      (\(DictVersion _) -> acceptableVersion)
+      (\DictVersion {} -> acceptableVersion)
       (unversionedProtocol (SomeResponderApplication app))
       nullErrorPolicies
       $ \_ serverAsync ->

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
@@ -75,7 +75,7 @@ tryHandshake doHandshake = do
 
 -- | Common arguments for both 'Handshake' client & server.
 --
-data HandshakeArguments connectionId vNumber extra m application = HandshakeArguments {
+data HandshakeArguments connectionId vNumber extra m application agreedOptions = HandshakeArguments {
       -- | 'Handshake' tracer
       --
       haHandshakeTracer :: Tracer m (WithMuxBearer connectionId
@@ -88,7 +88,7 @@ data HandshakeArguments connectionId vNumber extra m application = HandshakeArgu
       -- | A codec for protocol parameters.
       --
       haVersionDataCodec
-        ::  VersionDataCodec extra CBOR.Term,
+        ::  VersionDataCodec extra CBOR.Term vNumber agreedOptions,
 
       -- | versioned application aggreed upon with the 'Handshake' protocol.
       haVersions :: Versions vNumber extra application
@@ -108,8 +108,9 @@ runHandshakeClient
        )
     => MuxBearer m
     -> connectionId
-    -> HandshakeArguments connectionId vNumber extra m application
-    -> m (Either (HandshakeException (HandshakeClientProtocolError vNumber)) application)
+    -> HandshakeArguments connectionId vNumber extra m application agreedOptions
+    -> m (Either (HandshakeException (HandshakeClientProtocolError vNumber))
+                 (application, agreedOptions))
 runHandshakeClient bearer
                    connectionId
                    HandshakeArguments {
@@ -143,8 +144,10 @@ runHandshakeServer
     => MuxBearer m
     -> connectionId
     -> (forall vData. extra vData -> vData -> vData -> Accept)
-    -> HandshakeArguments connectionId vNumber extra m application
-    -> m (Either (HandshakeException (RefuseReason vNumber)) application)
+    -> HandshakeArguments connectionId vNumber extra m application agreedOptions
+    -> m (Either
+           (HandshakeException (RefuseReason vNumber))
+           (application, agreedOptions))
 runHandshakeServer bearer
                    connectionId
                    acceptVersion

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
@@ -56,6 +56,8 @@ handshakeClientPeer VersionDataCodec {encodeData, decodeData, getAgreedOptions} 
                 Done TokDone (Left (HandshakeError $ HandshakeDecodeError vNumber err))
 
               Right vData' ->
+                -- TODO: we should check that we agree on received @vData'@,
+                -- this might be less trivial than testing for equality.
                 Done TokDone $ Right $ ( runApplication (versionApplication version) vData vData'
                                        , getAgreedOptions (versionExtra version) vNumber vData'
                                        )

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Client.hs
@@ -27,10 +27,14 @@ import           Ouroboros.Network.Protocol.Handshake.Version
 --
 handshakeClientPeer
   :: Ord vNumber
-  => VersionDataCodec extra CBOR.Term
+  => VersionDataCodec extra CBOR.Term vNumber agreedOptions
   -> Versions vNumber extra r
-  -> Peer (Handshake vNumber CBOR.Term) AsClient StPropose m (Either (HandshakeClientProtocolError vNumber) r)
-handshakeClientPeer VersionDataCodec {encodeData, decodeData} versions =
+  -> Peer (Handshake vNumber CBOR.Term)
+          AsClient StPropose m
+          (Either
+            (HandshakeClientProtocolError vNumber)
+            (r, agreedOptions))
+handshakeClientPeer VersionDataCodec {encodeData, decodeData, getAgreedOptions} versions =
   -- send known versions
   Yield (ClientAgency TokPropose) (MsgProposeVersions $ encodeVersions encodeData versions) $
 
@@ -52,7 +56,9 @@ handshakeClientPeer VersionDataCodec {encodeData, decodeData} versions =
                 Done TokDone (Left (HandshakeError $ HandshakeDecodeError vNumber err))
 
               Right vData' ->
-                Done TokDone $ Right $ runApplication (versionApplication version) vData vData'
+                Done TokDone $ Right $ ( runApplication (versionApplication version) vData vData'
+                                       , getAgreedOptions (versionExtra version) vNumber vData'
+                                       )
 
 encodeVersions
   :: forall vNumber extra r vParams.

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
@@ -47,20 +47,28 @@ import           Ouroboros.Network.Protocol.Handshake.Version
 -- | Codec for version data ('vData' in code) exchanged by the handshake
 -- protocol.
 --
-data VersionDataCodec extra bytes = VersionDataCodec {
+-- Note: 'extra' type param is instantiated to 'DictVersion'; 'agreedOptions'
+-- is instatiated to 'NodeToNodeVersionData' in "Ouroboros.Network.NodeToNode"
+-- or to '()' in "Ouroboros.Network.NodeToClient".
+--
+data VersionDataCodec extra bytes vNumber agreedOptions = VersionDataCodec {
     encodeData :: forall vData. extra vData -> vData -> bytes,
     -- ^ encoder of 'vData' which has access to 'extra vData' which can bring
     -- extra instances into the scope (by means of pattern matching on a GADT).
-    decodeData :: forall vData. extra vData -> bytes -> Either Text vData
+    decodeData :: forall vData. extra vData -> bytes -> Either Text vData,
     -- ^ decoder of 'vData'.
+    getAgreedOptions :: forall vData. extra vData -> vNumber -> vData -> agreedOptions
+    -- ^ map negotiated 'vData' into version independent representation
+    -- 'agreedOptions'.
   }
 
 -- TODO: remove this from top level API, this is the only way we encode or
 -- decode version data.
-cborTermVersionDataCodec :: VersionDataCodec DictVersion CBOR.Term
+cborTermVersionDataCodec :: VersionDataCodec (DictVersion vNumber agreedOptions) CBOR.Term vNumber agreedOptions
 cborTermVersionDataCodec = VersionDataCodec {
-      encodeData = \(DictVersion codec) -> encodeTerm codec,
-      decodeData = \(DictVersion codec) -> decodeTerm codec
+      encodeData = \(DictVersion codec _) -> encodeTerm codec,
+      decodeData = \(DictVersion codec _) -> decodeTerm codec,
+      getAgreedOptions = \(DictVersion _ f) -> f
     }
 
 -- |

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Unversioned.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Unversioned.hs
@@ -57,10 +57,10 @@ unversionedProtocolDataCodec = CodecCBORTerm {encodeTerm, decodeTerm}
 -- | Make a 'Versions' for an unversioned protocol. Only use this for
 -- tests and demos where proper versioning is excessive.
 --
-unversionedProtocol :: app -> Versions UnversionedProtocol DictVersion app
+unversionedProtocol :: app -> Versions UnversionedProtocol (DictVersion UnversionedProtocol UnversionedProtocolData) app
 unversionedProtocol =
     simpleSingletonVersions UnversionedProtocol UnversionedProtocolData
-                            (DictVersion unversionedProtocolDataCodec)
+      (DictVersion unversionedProtocolDataCodec (\_ _ -> UnversionedProtocolData))
 
 
 -- | 'Handshake' codec used in various tests.

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Version.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Version.hs
@@ -121,13 +121,19 @@ data VersionMismatch vNum where
 data Dict constraint thing where
   Dict :: constraint thing => Dict constraint thing
 
-data DictVersion vData where
+-- | 'DictVersion' is used to instantiate the 'extra' param of 'Version'.
+-- 'hanshakeParams' is instatiated in either "Ouroboros.Network.NodeToNode" or
+-- "Ouroboros.Network.NodeToClient" to 'HandshakeParams'.
+--
+data DictVersion vNumber agreedOptions vData where
      DictVersion :: ( Typeable vData
                     , Acceptable vData
                     , Show vData
                     )
                  => CodecCBORTerm Text vData
-                 -> DictVersion vData
+                 -> (vNumber -> vData -> agreedOptions)
+                 -- ^ agreed vData
+                 -> DictVersion vNumber agreedOptions vData
 
 -- | Pick the version with the highest version number (by `Ord vNum`) common
 -- in both maps.

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -185,7 +185,7 @@ sduHandshakeTimeout = 10
 --
 -- Exceptions thrown by @'MuxApplication'@ are rethrown by @'connectTo'@.
 connectToNode
-  :: forall appType vNumber extra fd addr a b.
+  :: forall appType vNumber extra fd addr agreedOptions a b.
      ( Ord vNumber
      , Typeable vNumber
      , Show vNumber
@@ -193,7 +193,7 @@ connectToNode
      )
   => Snocket IO fd addr
   -> Codec (Handshake vNumber CBOR.Term) CBOR.DeserialiseFailure IO BL.ByteString
-  -> VersionDataCodec extra CBOR.Term
+  -> VersionDataCodec extra CBOR.Term vNumber agreedOptions
   -> NetworkConnectTracers addr vNumber
   -> Versions vNumber extra (OuroborosApplication appType addr BL.ByteString IO a b)
   -- ^ application to run over the connection
@@ -223,7 +223,7 @@ connectToNode sn handshakeCodec versionDataCodec tracers versions localAddr remo
 --
 -- Exceptions thrown by @'MuxApplication'@ are rethrown by @'connectTo'@.
 connectToNode'
-  :: forall appType vNumber extra fd addr a b.
+  :: forall appType vNumber extra fd addr agreedOptions a b.
      ( Ord vNumber
      , Typeable vNumber
      , Show vNumber
@@ -231,7 +231,7 @@ connectToNode'
      )
   => Snocket IO fd addr
   -> Codec (Handshake vNumber CBOR.Term) CBOR.DeserialiseFailure IO BL.ByteString
-  -> VersionDataCodec extra CBOR.Term
+  -> VersionDataCodec extra CBOR.Term vNumber agreedOptions
   -> NetworkConnectTracers addr vNumber
   -> Versions vNumber extra (OuroborosApplication appType addr BL.ByteString IO a b)
   -- ^ application to run over the connection
@@ -263,7 +263,7 @@ connectToNode' sn handshakeCodec versionDataCodec NetworkConnectTracers {nctMuxT
              traceWith muxTracer $ Mx.MuxTraceHandshakeClientError err (diffTime ts_end ts_start)
              throwIO err
 
-         Right app -> do
+         Right (app, _handshakeParams) -> do
              traceWith muxTracer $ Mx.MuxTraceHandshakeClientEnd (diffTime ts_end ts_start)
              Mx.muxStart
                muxTracer
@@ -273,7 +273,7 @@ connectToNode' sn handshakeCodec versionDataCodec NetworkConnectTracers {nctMuxT
 
 -- Wraps a Socket inside a Snocket and calls connectToNode'
 connectToNodeSocket
-  :: forall appType vNumber extra a b.
+  :: forall appType vNumber extra agreedOptions a b.
      ( Ord vNumber
      , Typeable vNumber
      , Show vNumber
@@ -281,7 +281,7 @@ connectToNodeSocket
      )
   => IOManager
   -> Codec (Handshake vNumber CBOR.Term) CBOR.DeserialiseFailure IO BL.ByteString
-  -> VersionDataCodec extra CBOR.Term
+  -> VersionDataCodec extra CBOR.Term vNumber agreedOptions
   -> NetworkConnectTracers Socket.SockAddr vNumber
   -> Versions vNumber extra (OuroborosApplication appType Socket.SockAddr BL.ByteString IO a b)
   -- ^ application to run over the connection
@@ -337,7 +337,7 @@ data AcceptConnection st vNumber extra peerid m bytes where
 -- of the incoming connection.
 --
 beginConnection
-    :: forall vNumber extra addr st fd.
+    :: forall vNumber extra addr st fd agreedOptions.
        ( Ord vNumber
        , Typeable vNumber
        , Show vNumber
@@ -346,7 +346,7 @@ beginConnection
     -> Tracer IO (Mx.WithMuxBearer (ConnectionId addr) Mx.MuxTrace)
     -> Tracer IO (Mx.WithMuxBearer (ConnectionId addr) (TraceSendRecv (Handshake vNumber CBOR.Term)))
     -> Codec (Handshake vNumber CBOR.Term) CBOR.DeserialiseFailure IO BL.ByteString
-    -> VersionDataCodec extra CBOR.Term
+    -> VersionDataCodec extra CBOR.Term vNumber agreedOptions
     -> (forall vData. extra vData -> vData -> vData -> Accept)
     -> (Time -> addr -> st -> STM.STM (AcceptConnection st vNumber extra addr IO BL.ByteString))
     -- ^ either accept or reject a connection.
@@ -380,7 +380,7 @@ beginConnection sn muxTracer handshakeTracer handshakeCodec versionDataCodec acc
                  traceWith muxTracer' $ Mx.MuxTraceHandshakeServerError err
                  throwIO err
 
-             Right (SomeResponderApplication app) -> do
+             Right (SomeResponderApplication app, _agreedOptions) -> do
                  traceWith muxTracer' $ Mx.MuxTraceHandshakeServerEnd
                  Mx.muxStart
                    muxTracer'
@@ -494,7 +494,7 @@ cleanNetworkMutableState NetworkMutableState {nmsPeerStates} =
 -- Thin wrapper around @'Server.run'@.
 --
 runServerThread
-    :: forall vNumber extra fd addr b.
+    :: forall vNumber extra fd addr agreedOptions b.
        ( Ord vNumber
        , Typeable vNumber
        , Show vNumber
@@ -506,7 +506,7 @@ runServerThread
     -> fd
     -> AcceptedConnectionsLimit
     -> Codec (Handshake vNumber CBOR.Term) CBOR.DeserialiseFailure IO BL.ByteString
-    -> VersionDataCodec extra CBOR.Term
+    -> VersionDataCodec extra CBOR.Term vNumber agreedOptions
     -> (forall vData. extra vData -> vData -> vData -> Accept)
     -> Versions vNumber extra (SomeResponderApplication addr BL.ByteString IO b)
     -> ErrorPolicies
@@ -575,7 +575,7 @@ runServerThread NetworkServerTracers { nstMuxTracer
 -- | Run a server application. It will listen on the given address for incoming
 -- connection, otherwise like withServerNode'.
 withServerNode
-    :: forall vNumber extra t fd addr b.
+    :: forall vNumber extra t fd addr agreedOptions b.
        ( Ord vNumber
        , Typeable vNumber
        , Show vNumber
@@ -587,7 +587,7 @@ withServerNode
     -> AcceptedConnectionsLimit
     -> addr
     -> Codec (Handshake vNumber CBOR.Term) CBOR.DeserialiseFailure IO BL.ByteString
-    -> VersionDataCodec extra CBOR.Term
+    -> VersionDataCodec extra CBOR.Term vNumber agreedOptions
     -> (forall vData. extra vData -> vData -> vData -> Accept)
     -> Versions vNumber extra (SomeResponderApplication addr BL.ByteString IO b)
     -- ^ The mux application that will be run on each incoming connection from
@@ -641,7 +641,7 @@ withServerNode sn
 -- thread which runs the server.  This makes it useful for testing, where we
 -- need to guarantee that a socket is open before we try to connect to it.
 withServerNode'
-    :: forall vNumber extra t fd addr b.
+    :: forall vNumber extra t fd addr agreedOptions b.
        ( Ord vNumber
        , Typeable vNumber
        , Show vNumber
@@ -653,7 +653,7 @@ withServerNode'
     -> AcceptedConnectionsLimit
     -> fd
     -> Codec (Handshake vNumber CBOR.Term) CBOR.DeserialiseFailure IO BL.ByteString
-    -> VersionDataCodec extra CBOR.Term
+    -> VersionDataCodec extra CBOR.Term vNumber agreedOptions
     -> (forall vData. extra vData -> vData -> vData -> Accept)
     -> Versions vNumber extra (SomeResponderApplication addr BL.ByteString IO b)
     -- ^ The mux application that will be run on each incoming connection from

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -301,7 +301,7 @@ connectToNodeSocket iocp handshakeCodec versionDataCodec tracers versions sd =
 --
 data SomeResponderApplication addr bytes m b where
      SomeResponderApplication
-       :: forall appType addr m bytes a b.
+       :: forall appType addr bytes m a b.
           Mx.HasResponder appType ~ True
        => (OuroborosApplication appType addr bytes m a b)
        -> SomeResponderApplication addr bytes m b
@@ -320,7 +320,7 @@ data SomeResponderApplication addr bytes m b where
 data AcceptConnection st vNumber extra peerid m bytes where
 
     AcceptConnection
-      :: forall st vNumber extra peerid m bytes b.
+      :: forall st vNumber extra peerid bytes m b.
          !st
       -> !(ConnectionId peerid)
       -> Versions vNumber extra (SomeResponderApplication peerid bytes m b)

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
@@ -246,7 +246,7 @@ prop_socket_send_recv initiatorAddr responderAddr f xs =
         responderAddr
         unversionedHandshakeCodec
         cborTermVersionDataCodec
-        (\(DictVersion _) -> acceptableVersion)
+        (\DictVersion {} -> acceptableVersion)
         (unversionedProtocol (SomeResponderApplication responderApp))
         nullErrorPolicies
         $ \_ _ -> do

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
@@ -587,7 +587,7 @@ prop_send_recv f xs _first = ioProperty $ withIOManager $ \iocp -> do
         (Socket.addrAddress responderAddr)
         unversionedHandshakeCodec
         cborTermVersionDataCodec
-        (\(DictVersion _) -> acceptableVersion)
+        (\DictVersion {} -> acceptableVersion)
         (unversionedProtocol (SomeResponderApplication responderApp))
         nullErrorPolicies
         $ \_ _ -> do
@@ -730,7 +730,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
         responderAddr
         unversionedHandshakeCodec
         cborTermVersionDataCodec
-        (\(DictVersion _) -> acceptableVersion)
+        (\DictVersion {} -> acceptableVersion)
         (unversionedProtocol (SomeResponderApplication (appX rrcfg)))
         nullErrorPolicies
         $ \localAddr _ -> do
@@ -750,7 +750,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
           responderAddr
           unversionedHandshakeCodec
           cborTermVersionDataCodec
-          (\(DictVersion _) -> acceptableVersion)
+          (\DictVersion {} -> acceptableVersion)
           (unversionedProtocol (SomeResponderApplication (appX rrcfg)))
           nullErrorPolicies
           $ \localAddr _ -> do
@@ -867,7 +867,7 @@ _demo = ioProperty $ withIOManager $ \iocp -> do
             (Socket.addrAddress addr)
             unversionedHandshakeCodec
             cborTermVersionDataCodec
-            (\(DictVersion _) -> acceptableVersion)
+            (\DictVersion {} -> acceptableVersion)
             (unversionedProtocol (SomeResponderApplication appRsp))
             nullErrorPolicies
             (\_ _ -> threadDelay delay)

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -40,7 +40,6 @@ import qualified Codec.Serialise as CBOR
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block
 import qualified Ouroboros.Network.ChainFragment as CF
-import           Ouroboros.Network.Magic
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.NodeToClient (LocalConnectionId)
@@ -160,8 +159,8 @@ clientChainSync sockPaths = withIOManager $ \iocp ->
         nullNetworkConnectTracers
         (simpleSingletonVersions
            UnversionedProtocol
-           (NodeToNodeVersionData $ NetworkMagic 0)
-           (DictVersion nodeToNodeCodecCBORTerm)
+           UnversionedProtocolData
+           (DictVersion unversionedProtocolDataCodec (,))
            app)
         Nothing
         (localAddressFromPath sockPath)
@@ -190,11 +189,11 @@ serverChainSync sockAddr = withIOManager $ \iocp -> do
       (localAddressFromPath sockAddr)
       unversionedHandshakeCodec
       cborTermVersionDataCodec
-      (\(DictVersion _) -> acceptableVersion)
+      (\DictVersion {} -> acceptableVersion)
       (simpleSingletonVersions
         UnversionedProtocol
-        (NodeToNodeVersionData $ NetworkMagic 0)
-        (DictVersion nodeToNodeCodecCBORTerm)
+        UnversionedProtocolData
+        (DictVersion unversionedProtocolDataCodec (,))
         (SomeResponderApplication app))
       nullErrorPolicies
       $ \_ serverAsync ->
@@ -367,8 +366,8 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
                           nullNetworkConnectTracers
                           (simpleSingletonVersions
                             UnversionedProtocol
-                            (NodeToNodeVersionData (NetworkMagic 0))
-                            (DictVersion nodeToNodeCodecCBORTerm)
+                            UnversionedProtocolData
+                            (DictVersion unversionedProtocolDataCodec (,))
                             app)
                           Nothing
                           (localAddressFromPath sockAddr)
@@ -419,11 +418,11 @@ serverBlockFetch sockAddr = withIOManager $ \iocp -> do
       (localAddressFromPath sockAddr)
       unversionedHandshakeCodec
       cborTermVersionDataCodec
-      (\(DictVersion _) -> acceptableVersion)
+      (\DictVersion {} -> acceptableVersion)
       (simpleSingletonVersions
         UnversionedProtocol
-        (NodeToNodeVersionData $ NetworkMagic 0)
-        (DictVersion nodeToNodeCodecCBORTerm)
+        UnversionedProtocolData
+        (DictVersion unversionedProtocolDataCodec (,))
         (SomeResponderApplication app))
       nullErrorPolicies
       $ \_ serverAsync ->

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -243,6 +243,8 @@ test-suite test-network
   other-modules:       Ouroboros.Network.BlockFetch.Examples
                        Ouroboros.Network.MockNode
                        Ouroboros.Network.PeerSelection.Test
+                       Ouroboros.Network.NodeToNode.Version.Test
+                       Ouroboros.Network.NodeToClient.Version.Test
 
                        Test.AnchoredFragment
                        Test.Chain

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -99,7 +99,7 @@ data DiffusionApplications = DiffusionApplications {
 
       daResponderApplication      :: Versions
                                        NodeToNodeVersion
-                                       DictVersion
+                                       (DictVersion NodeToNodeVersion NodeToNode.AgreedOptions)
                                        (OuroborosApplication
                                          ResponderMode SockAddr
                                          ByteString IO Void ())
@@ -107,7 +107,7 @@ data DiffusionApplications = DiffusionApplications {
 
     , daInitiatorApplication      :: Versions
                                        NodeToNodeVersion
-                                       DictVersion 
+                                       (DictVersion NodeToNodeVersion NodeToNode.AgreedOptions)
                                        (OuroborosApplication
                                          InitiatorMode SockAddr
                                          ByteString IO () Void)
@@ -115,7 +115,7 @@ data DiffusionApplications = DiffusionApplications {
 
     , daLocalResponderApplication :: Versions
                                        NodeToClientVersion
-                                       DictVersion
+                                       (DictVersion NodeToClientVersion NodeToClient.AgreedOptions)
                                        (OuroborosApplication
                                          ResponderMode LocalAddress
                                          ByteString IO Void ())

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -4,8 +4,10 @@
 module Ouroboros.Network.NodeToClient.Version
   ( NodeToClientVersion (..)
   , NodeToClientVersionData (..)
+  , AgreedOptions
   , nodeToClientVersionCodec
   , nodeToClientCodecCBORTerm
+  , nodeToClientDictVersion
   ) where
 
 import           Data.Bits (setBit, clearBit, testBit)
@@ -17,7 +19,8 @@ import qualified Codec.CBOR.Term as CBOR
 
 import           Ouroboros.Network.CodecCBORTerm
 import           Ouroboros.Network.Magic
-import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..), Accept (..))
+import           Ouroboros.Network.Protocol.Handshake.Version
+                  (Acceptable (..), Accept (..), DictVersion (..))
 
 
 -- | Enumeration of node to client protocol versions.
@@ -86,3 +89,9 @@ nodeToClientCodecCBORTerm = CodecCBORTerm {encodeTerm, decodeTerm}
       decodeTerm (CBOR.TInt x) | x >= 0 && x <= 0xffffffff = Right (NodeToClientVersionData $ NetworkMagic $ fromIntegral x)
                                | otherwise                 = Left $ T.pack $ "networkMagic out of bound: " <> show x
       decodeTerm t             = Left $ T.pack $ "unknown encoding: " ++ show t
+
+
+type AgreedOptions = ()
+
+nodeToClientDictVersion :: DictVersion NodeToClientVersion AgreedOptions NodeToClientVersionData
+nodeToClientDictVersion = DictVersion nodeToClientCodecCBORTerm (\_ _ -> ())

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -1,10 +1,15 @@
+{-# LANGUAGE BangPatterns   #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Ouroboros.Network.NodeToNode.Version
   ( NodeToNodeVersion (..)
   , NodeToNodeVersionData (..)
+  , DiffusionMode (..)
+  , AgreedOptions (..)
+  , ConnectionMode (..)
   , nodeToNodeVersionCodec
   , nodeToNodeCodecCBORTerm
+  , nodeToNodeDictVersion
   ) where
 
 import           Data.Text (Text)
@@ -15,7 +20,8 @@ import qualified Codec.CBOR.Term as CBOR
 
 import           Ouroboros.Network.CodecCBORTerm
 import           Ouroboros.Network.Magic
-import           Ouroboros.Network.Protocol.Handshake.Version (Acceptable (..), Accept (..))
+import           Ouroboros.Network.Protocol.Handshake.Version
+                  (Acceptable (..), Accept (..), DictVersion (..))
 
 
 -- | Enumeration of node to node protocol versions.
@@ -32,6 +38,11 @@ data NodeToNodeVersion
     -- ^ Changes:
     --
     -- * Enable KeepAlive miniprotocol
+    | NodeToNodeV_4
+    -- ^ Changes:
+    --
+    -- * Added 'DiffusionMode' Handhskake argument.  Also from this version up
+    -- the node will use duplex connections.
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 
 nodeToNodeVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToNodeVersion
@@ -40,10 +51,12 @@ nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
     encodeTerm NodeToNodeV_1  = CBOR.TInt 1
     encodeTerm NodeToNodeV_2  = CBOR.TInt 2
     encodeTerm NodeToNodeV_3  = CBOR.TInt 3
+    encodeTerm NodeToNodeV_4  = CBOR.TInt 4
 
     decodeTerm (CBOR.TInt 1) = Right NodeToNodeV_1
     decodeTerm (CBOR.TInt 2) = Right NodeToNodeV_2
     decodeTerm (CBOR.TInt 3) = Right NodeToNodeV_3
+    decodeTerm (CBOR.TInt 4) = Right NodeToNodeV_4
     decodeTerm (CBOR.TInt n) = Left ( T.pack "decode NodeToNodeVersion: unknonw tag: "
                                         <> T.pack (show n)
                                     , Just n
@@ -52,29 +65,106 @@ nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
                         , Nothing)
 
 
--- | Version data for NodeToNode protocol v1
+
+-- | The flag which indicates wheather the node runs only initiator or both
+-- initiator or responder node.   It does not however specify weather the node
+-- is using duplex connections, this is implicit see 'NodeToNodeV_4'
 --
-newtype NodeToNodeVersionData = NodeToNodeVersionData
-  { networkMagic :: NetworkMagic }
-  deriving (Eq, Show, Typeable)
+data DiffusionMode
+    = InitiatorOnlyDiffusionMode
+    | InitiatorAndResponderDiffusionMode
+  deriving (Typeable, Eq, Show)
+
+
+-- | Version data for NodeToNode protocol
+--
+data NodeToNodeVersionData = NodeToNodeVersionData
+  { networkMagic  :: !NetworkMagic
+  , diffusionMode :: !DiffusionMode
+  }
+  deriving (Show, Typeable)
+  -- 'Eq' instance is not provided, it is not what we need in version
+  -- negotiation (see 'Acceptable' instance below).
 
 instance Acceptable NodeToNodeVersionData where
     acceptableVersion local remote
-      | local == remote
+      | networkMagic local == networkMagic remote
       = Accept
       | otherwise
-      =  Refuse $ T.pack $ "version data mismatch: "
-                        ++ show local
-                        ++ " /= " ++ show remote
+      = Refuse $ T.pack $ "version data mismatch: "
+                       ++ show local
+                       ++ " /= " ++ show remote
 
-nodeToNodeCodecCBORTerm :: CodecCBORTerm Text NodeToNodeVersionData
-nodeToNodeCodecCBORTerm = CodecCBORTerm {encodeTerm, decodeTerm}
-    where
-      encodeTerm :: NodeToNodeVersionData -> CBOR.Term
-      encodeTerm NodeToNodeVersionData { networkMagic } =
-        CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
 
-      decodeTerm :: CBOR.Term -> Either Text NodeToNodeVersionData
-      decodeTerm (CBOR.TInt x) | x >= 0 && x <= 0xffffffff = Right (NodeToNodeVersionData $ NetworkMagic $ fromIntegral x)
-                               | otherwise                 = Left $ T.pack $ "networkMagic out of bound: " <> show x
-      decodeTerm t             = Left $ T.pack $ "unknown encoding: " ++ show t
+nodeToNodeCodecCBORTerm :: NodeToNodeVersion -> CodecCBORTerm Text NodeToNodeVersionData
+nodeToNodeCodecCBORTerm version
+  | version <= NodeToNodeV_3
+  = let encodeTerm :: NodeToNodeVersionData -> CBOR.Term
+        encodeTerm NodeToNodeVersionData { networkMagic }
+          = CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
+
+        decodeTerm :: CBOR.Term -> Either Text NodeToNodeVersionData
+        decodeTerm (CBOR.TInt x)
+          | x >= 0
+          , x <= 0xffffffff
+          = Right
+              NodeToNodeVersionData {
+                  networkMagic = NetworkMagic (fromIntegral x),
+                  -- the default 'NodeMode' for version @≤ NodeToNodeV_3@
+                  diffusionMode = InitiatorAndResponderDiffusionMode
+                }
+          | otherwise
+          = Left $ T.pack $ "networkMagic out of bound: " <> show x
+        decodeTerm t
+          = Left $ T.pack $ "unknown encoding: " ++ show t
+    in CodecCBORTerm {encodeTerm, decodeTerm}
+
+  | otherwise -- NodeToNodeV_4 and beyond
+  = let encodeTerm :: NodeToNodeVersionData -> CBOR.Term
+        encodeTerm NodeToNodeVersionData { networkMagic, diffusionMode }
+          = CBOR.TList
+              [ CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
+              , CBOR.TBool (case diffusionMode of
+                             InitiatorOnlyDiffusionMode         -> True
+                             InitiatorAndResponderDiffusionMode -> False)
+              ]
+
+        decodeTerm :: CBOR.Term -> Either Text NodeToNodeVersionData
+        decodeTerm (CBOR.TList [CBOR.TInt x, CBOR.TBool diffusionMode])
+          | x >= 0
+          , x <= 0xffffffff
+          = Right
+              NodeToNodeVersionData {
+                  networkMagic = NetworkMagic (fromIntegral x),
+                  diffusionMode = if diffusionMode
+                                  then InitiatorOnlyDiffusionMode
+                                  else InitiatorAndResponderDiffusionMode
+                }
+          | otherwise
+          = Left $ T.pack $ "networkMagic out of bound: " <> show x
+        decodeTerm t
+          = Left $ T.pack $ "unknown encoding: " ++ show t
+    in CodecCBORTerm {encodeTerm, decodeTerm}
+
+
+data ConnectionMode = UnidirectionalMode | DuplexMode
+
+data AgreedOptions = AgreedOptions {
+    agreedConnectionMode :: ConnectionMode,
+    agreedOptions        :: NodeToNodeVersionData
+  }
+
+
+mkAgreedOptions :: NodeToNodeVersion -> NodeToNodeVersionData -> AgreedOptions
+mkAgreedOptions version agreedOptions
+  | version <= NodeToNodeV_3
+  = AgreedOptions { agreedConnectionMode = UnidirectionalMode, agreedOptions }
+  | otherwise
+  = AgreedOptions { agreedConnectionMode = DuplexMode, agreedOptions }
+
+
+
+nodeToNodeDictVersion :: NodeToNodeVersion
+                      -> DictVersion NodeToNodeVersion AgreedOptions NodeToNodeVersionData
+nodeToNodeDictVersion version =
+    DictVersion (nodeToNodeCodecCBORTerm version) mkAgreedOptions

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -41,7 +41,7 @@ data NodeToNodeVersion
     | NodeToNodeV_4
     -- ^ Changes:
     --
-    -- * Added 'DiffusionMode' Handhskake argument.  Also from this version up
+    -- * Added 'DiffusionMode' Handshake argument.  Also from this version up
     -- the node will use duplex connections.
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -13,6 +13,8 @@ import qualified Test.Version (tests)
 import qualified Test.Ouroboros.Network.MockNode (tests)
 import qualified Test.Ouroboros.Network.BlockFetch (tests)
 import qualified Test.Ouroboros.Network.KeepAlive (tests)
+import qualified Ouroboros.Network.NodeToNode.Version.Test (tests)
+import qualified Ouroboros.Network.NodeToClient.Version.Test (tests)
 import qualified Ouroboros.Network.Protocol.ChainSync.Test (tests)
 import qualified Ouroboros.Network.Protocol.BlockFetch.Test (tests)
 import qualified Ouroboros.Network.Protocol.Handshake.Test (tests)
@@ -54,6 +56,8 @@ tests =
   , Test.Ouroboros.Network.BlockFetch.tests
   , Ouroboros.Network.PeerSelection.Test.tests
   , Test.Ouroboros.Network.KeepAlive.tests
+  , Ouroboros.Network.NodeToNode.Version.Test.tests
+  , Ouroboros.Network.NodeToClient.Version.Test.tests
 
     -- pseudo system-level
   , Test.Ouroboros.Network.MockNode.tests

--- a/ouroboros-network/test/Ouroboros/Network/NodeToClient/Version/Test.hs
+++ b/ouroboros-network/test/Ouroboros/Network/NodeToClient/Version/Test.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ouroboros.Network.NodeToClient.Version.Test (tests) where
+
+import           Ouroboros.Network.CodecCBORTerm
+import           Ouroboros.Network.Magic
+import           Ouroboros.Network.NodeToClient.Version
+
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Network.NodeToClient.Version"
+    [ testProperty "nodeToClientCodecCBORTerm" prop_nodeToClientCodec
+    ]
+
+instance Arbitrary NodeToClientVersionData where
+    arbitrary =
+      NodeToClientVersionData
+        <$> (NetworkMagic <$> arbitrary)
+
+prop_nodeToClientCodec :: NodeToClientVersionData -> Bool
+prop_nodeToClientCodec ntcData =
+      case decodeTerm (encodeTerm ntcData) of
+        Right ntcData' -> networkMagic ntcData' == networkMagic  ntcData
+        Left {}        -> False
+    where
+      CodecCBORTerm { encodeTerm, decodeTerm } = nodeToClientCodecCBORTerm

--- a/ouroboros-network/test/Ouroboros/Network/NodeToNode/Version/Test.hs
+++ b/ouroboros-network/test/Ouroboros/Network/NodeToNode/Version/Test.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE NamedFieldPuns  #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Ouroboros.Network.NodeToNode.Version.Test (tests) where
+
+import           Ouroboros.Network.CodecCBORTerm
+import           Ouroboros.Network.Magic
+import           Ouroboros.Network.NodeToNode.Version
+
+import           Test.QuickCheck
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Network.NodeToNode.Version"
+    [ testProperty "nodeToNodeCodecCBORTerm" prop_nodeToNodeCodec
+    ]
+
+instance Arbitrary NodeToNodeVersion where
+    arbitrary = oneof [ pure NodeToNodeV_1
+                      , pure NodeToNodeV_2
+                      , pure NodeToNodeV_3
+                      , pure NodeToNodeV_4
+                      ]
+
+    shrink NodeToNodeV_4 = [NodeToNodeV_3]
+    shrink NodeToNodeV_3 = [NodeToNodeV_2]
+    shrink NodeToNodeV_2 = [NodeToNodeV_1]
+    shrink NodeToNodeV_1 = []
+
+instance Arbitrary NodeToNodeVersionData where
+    arbitrary =
+      NodeToNodeVersionData
+        <$> (NetworkMagic <$> arbitrary)
+        <*> oneof [ pure InitiatorOnlyDiffusionMode
+                  , pure InitiatorAndResponderDiffusionMode
+                  ]
+
+prop_nodeToNodeCodec :: NodeToNodeVersion -> NodeToNodeVersionData -> Bool
+prop_nodeToNodeCodec ntnVersion ntnData =
+      case decodeTerm (encodeTerm ntnData) of
+        Right ntnData' -> networkMagic  ntnData' == networkMagic  ntnData
+                       && if ntnVersion <= NodeToNodeV_3
+                            then diffusionMode ntnData' == InitiatorAndResponderDiffusionMode
+                            else diffusionMode ntnData' == diffusionMode ntnData
+        Left {}        -> False
+    where
+      CodecCBORTerm { encodeTerm, decodeTerm } = nodeToNodeCodecCBORTerm ntnVersion

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -158,11 +158,13 @@ demo chain0 updates = withIOManager $ \iocp -> do
       producerAddress
       nodeToNodeHandshakeCodec
       cborTermVersionDataCodec
-      (\(DictVersion _) -> acceptableVersion)
+      (\DictVersion {} -> acceptableVersion)
       (simpleSingletonVersions
         NodeToNodeV_1
-        (NodeToNodeVersionData $ NetworkMagic 0)
-        (DictVersion nodeToNodeCodecCBORTerm)
+        (NodeToNodeVersionData {
+          networkMagic  = NetworkMagic 0,
+          diffusionMode = InitiatorAndResponderDiffusionMode })
+        (nodeToNodeDictVersion NodeToNodeV_1)
         (SomeResponderApplication responderApp))
       nullErrorPolicies
       $ \realProducerAddress _ -> do
@@ -174,8 +176,10 @@ demo chain0 updates = withIOManager $ \iocp -> do
           nullNetworkConnectTracers
           (simpleSingletonVersions
             NodeToNodeV_1
-            (NodeToNodeVersionData $ NetworkMagic 0)
-            (DictVersion nodeToNodeCodecCBORTerm)
+            (NodeToNodeVersionData {
+              networkMagic  = NetworkMagic 0,
+              diffusionMode = InitiatorOnlyDiffusionMode })
+            (nodeToNodeDictVersion NodeToNodeV_1)
             initiatorApp)
           (Just consumerAddress)
           realProducerAddress)


### PR DESCRIPTION
`NodeToNodeV_4` extends NodeToNodeVersionData with `DiffusionMode` flag.  This flag decides weather a node runs responder or not and is presented when negotiation connection options using `Handshake` protocol.  It is also passed through `DiffusionArguments`: if `IitiatorOnlyDiffusionMode` is used, the diffusion will not run the responder.

`NodeToNodeV_4` is not used by the node yet.  It can be taken by `p2p-node` (in PR #2526) or by consensus whoever will need it first.

Handshake is extended to return 'agreedOptions'.  For 'NodeToNode' we then
abuse it by allowing to escape with the existencial 'vData'.  This is because in
near future we will refactor the handshake which does not need any more its
dependent type machinery.  Instead of it we use version aware codec of
'NodeToNodeVersionData', which this PR introduces (together with tests).

Note that `InitiatorAndResponderDiffusionMode` will be enforced by the codec if the version is strictly lower than 'NodeToNodeV_4'.
