### PR TITLE
quickcheck-randomized: draft package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -23,6 +23,7 @@ packages: ./typed-protocols
           ./ntp-client
           ./Win32-network
           ./cardano-client
+          ./quickcheck-randomized
 
 constraints:
   ip < 1.5,

--- a/ouroboros-consensus-shelley-test/test/Main.hs
+++ b/ouroboros-consensus-shelley-test/test/Main.hs
@@ -12,7 +12,10 @@ main = defaultMainWithIohkNightly tests
 
 tests :: TestTree
 tests =
-  testGroup "shelley"
+  testGroup "shelley" $
+  [ Test.ThreadNet.RealTPraos.tests
+  ]
+  `asTypeOf`
   [ Test.Consensus.Shelley.Golden.tests
   , Test.Consensus.Shelley.Serialisation.tests
   , Test.ThreadNet.RealTPraos.tests

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -269,7 +269,7 @@ prop_simple_real_tpraos_convergence TestSetup
         -- @Quorum@-many nodes were still proposing this test's original update
         -- as of the epoch boundary. However, we keep the test simple and just
         -- avoid introducing any other proposals.
-        if includingDUpdateTx then DoNotGeneratePPUs else DoGeneratePPUs
+        DoNotGeneratePPUs `asTypeOf` if includingDUpdateTx then DoNotGeneratePPUs else DoGeneratePPUs
 
     -- The slot immediately after the end of this test.
     sentinel :: SlotNo

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -3,6 +3,13 @@
 
 module Test.ThreadNet.RealTPraos (tests) where
 
+import Test.ThreadNet.Util.NodeTopology
+{-
+import qualified Data.Set as Set
+import Test.ThreadNet.Util.Seed
+import Data.String (fromString)
+-}
+
 import           Control.Monad (replicateM)
 import qualified Data.Map.Strict as Map
 import           Data.Word (Word64)
@@ -86,9 +93,19 @@ instance Arbitrary TestSetup where
         , (9, SL.mkNonceFromNumber <$> arbitrary)
         ]
 
-      setupK  <- SecurityParam <$> choose (minK, maxK)
+      let setupK = SecurityParam minK
 
-      setupTestConfig <- arbitrary
+      setupTestConfig <- do
+        let numCoreNodes = NumCoreNodes 3
+        initSeed <- arbitrary
+        nodeTopology <- genNodeTopology numCoreNodes
+        let numSlots = NumSlots 300
+        pure TestConfig {
+            initSeed
+          , nodeTopology
+          , numCoreNodes
+          , numSlots
+          }
 
       setupVersion <- genVersion (Proxy @(ShelleyBlock Era))
 
@@ -154,7 +171,10 @@ fifthTestCount (QuickCheckTests n) = QuickCheckTests $
     max 1 $ n `div` 5
 
 tests :: TestTree
-tests = testGroup "RealTPraos ThreadNet"
+tests = testGroup "RealTPraos ThreadNet" $
+{-    [ testProperty "repro" $ prop_simple_real_tpraos_convergence repro
+    ]
+    `asTypeOf` -}
     [ let name = "simple convergence" in
       askIohkNightlyEnabled $ \enabled ->
       if enabled

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -184,9 +184,6 @@ repro = TestSetup {
 
 tests :: TestTree
 tests = testGroup "RealTPraos ThreadNet" $
-    [ testProperty "repro" $ prop_simple_real_tpraos_convergence repro
-    ]
-    `asTypeOf`
     [ let name = "simple convergence" in
       askIohkNightlyEnabled $ \enabled ->
       if enabled
@@ -195,6 +192,9 @@ tests = testGroup "RealTPraos ThreadNet" $
       else adjustOption fifthTestCount $
            testProperty name $ \setup ->
              prop_simple_real_tpraos_convergence setup
+    ]
+    `asTypeOf`
+    [ testProperty "repro" $ prop_simple_real_tpraos_convergence repro
     ]
 
 prop_simple_real_tpraos_convergence :: TestSetup -> Property

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -4,11 +4,9 @@
 module Test.ThreadNet.RealTPraos (tests) where
 
 import Test.ThreadNet.Util.NodeTopology
-{-
 import qualified Data.Set as Set
 import Test.ThreadNet.Util.Seed
 import Data.String (fromString)
--}
 
 import           Control.Monad (replicateM)
 import qualified Data.Map.Strict as Map
@@ -77,8 +75,8 @@ data TestSetup = TestSetup
 minK :: Word64
 minK = 5   -- Less than this increases risk of CP violations
 
-maxK :: Word64
-maxK = 10   -- More than this wastes execution time
+--maxK :: Word64
+--maxK = 10   -- More than this wastes execution time
 
 activeSlotCoeff :: Rational
 activeSlotCoeff = 0.5   -- TODO this is high
@@ -170,11 +168,25 @@ fifthTestCount (QuickCheckTests n) = QuickCheckTests $
     if 0 == n then 0 else
     max 1 $ n `div` 5
 
+repro :: TestSetup
+repro = TestSetup {
+    setupD = DecentralizationParam (2 / 5)
+  , setupD2 = DecentralizationParam (2 / 5)
+  , setupInitialNonce = Nonce $ fromString $ "50826b21b9425d8ec67bfee595a3d81cb7f277b4cb5c72db0a34b97eef3a3cdc"
+  , setupK = SecurityParam 5
+  , setupTestConfig = TestConfig {
+      initSeed = Seed (-4488399573397301335)
+    , nodeTopology = NodeTopology (Map.fromList [(CoreNodeId 0,Set.fromList []),(CoreNodeId 1,Set.fromList [CoreNodeId 0]),(CoreNodeId 2,Set.fromList [CoreNodeId 0,CoreNodeId 1])])
+    , numCoreNodes = NumCoreNodes 3, numSlots = NumSlots 161
+    }
+  , setupVersion = (NodeToNodeV_1,Shelley.ShelleyNodeToNodeVersion1)
+  }
+
 tests :: TestTree
 tests = testGroup "RealTPraos ThreadNet" $
-{-    [ testProperty "repro" $ prop_simple_real_tpraos_convergence repro
+    [ testProperty "repro" $ prop_simple_real_tpraos_convergence repro
     ]
-    `asTypeOf` -}
+    `asTypeOf`
     [ let name = "simple convergence" in
       askIohkNightlyEnabled $ \enabled ->
       if enabled

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -79,7 +79,7 @@ activeSlotCoeff = 0.5   -- TODO this is high
 instance Arbitrary TestSetup where
   arbitrary = do
       setupD  <- arbitrary
-      setupD2 <- arbitrary
+      setupD2 <- pure setupD
 
       setupInitialNonce <- frequency
         [ (1, pure SL.NeutralNonce)

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/RealTPraos.hs
@@ -6,7 +6,7 @@ module Test.ThreadNet.RealTPraos (tests) where
 import Test.ThreadNet.Util.NodeTopology
 import qualified Data.Set as Set
 import Test.ThreadNet.Util.Seed
-import Data.String (fromString)
+-- import Data.String (fromString)
 
 import           Control.Monad (replicateM)
 import qualified Data.Map.Strict as Map
@@ -170,20 +170,24 @@ fifthTestCount (QuickCheckTests n) = QuickCheckTests $
 
 repro :: TestSetup
 repro = TestSetup {
-    setupD = DecentralizationParam (2 / 5)
-  , setupD2 = DecentralizationParam (2 / 5)
-  , setupInitialNonce = Nonce $ fromString $ "50826b21b9425d8ec67bfee595a3d81cb7f277b4cb5c72db0a34b97eef3a3cdc"
+    setupD = DecentralizationParam (1 / 5)
+  , setupD2 = DecentralizationParam (1 / 5)
+  , setupInitialNonce = NeutralNonce
   , setupK = SecurityParam 5
   , setupTestConfig = TestConfig {
-      initSeed = Seed (-4488399573397301335)
+      initSeed = Seed 3197045859947473347
     , nodeTopology = NodeTopology (Map.fromList [(CoreNodeId 0,Set.fromList []),(CoreNodeId 1,Set.fromList [CoreNodeId 0]),(CoreNodeId 2,Set.fromList [CoreNodeId 0,CoreNodeId 1])])
-    , numCoreNodes = NumCoreNodes 3, numSlots = NumSlots 161
+    , numCoreNodes = NumCoreNodes 3
+    , numSlots = NumSlots 187
     }
   , setupVersion = (NodeToNodeV_1,Shelley.ShelleyNodeToNodeVersion1)
   }
 
 tests :: TestTree
 tests = testGroup "RealTPraos ThreadNet" $
+    [ testProperty "repro" $ prop_simple_real_tpraos_convergence repro
+    ]
+    `asTypeOf`
     [ let name = "simple convergence" in
       askIohkNightlyEnabled $ \enabled ->
       if enabled
@@ -192,9 +196,6 @@ tests = testGroup "RealTPraos ThreadNet" $
       else adjustOption fifthTestCount $
            testProperty name $ \setup ->
              prop_simple_real_tpraos_convergence setup
-    ]
-    `asTypeOf`
-    [ testProperty "repro" $ prop_simple_real_tpraos_convergence repro
     ]
 
 prop_simple_real_tpraos_convergence :: TestSetup -> Property

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -672,6 +672,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                 (nodeSeed `combineWith` unSlotNo curSlotNo)
                 (testGenTxs coreNodeId numCoreNodes curSlotNo cfg txGenExtra ledger)
 
+        traceWith debugTracer $ show (coreNodeId, map txId txs)
         void $ addTxs mempool txs
 
     mkArgs :: CoreNodeId

--- a/quickcheck-randomized/LICENSE
+++ b/quickcheck-randomized/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/quickcheck-randomized/NOTICE
+++ b/quickcheck-randomized/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2019 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/quickcheck-randomized/quickcheck-randomized.cabal
+++ b/quickcheck-randomized/quickcheck-randomized.cabal
@@ -1,0 +1,87 @@
+name:                  quickcheck-randomized
+version:               0.1.0.0
+synopsis:              QuickCheck combinators for testing randomized algorithms
+description:           See "Test.QuickCheck.Randomized.Coin".
+license:               Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:             2020 Input Output (Hong Kong) Ltd.
+author:                IOHK Engineering Team
+maintainer:            operations@iohk.io
+category:              Network
+build-type:            Simple
+cabal-version:         >=1.10
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+
+library
+  hs-source-dirs:      src
+
+  exposed-modules:
+                       Test.QuickCheck.Randomized
+
+                       Test.QuickCheck.Randomized.Coin
+                       Test.QuickCheck.Randomized.Coin.Rule
+                       Test.QuickCheck.Randomized.Coin.Tune
+
+                       Test.QuickCheck.Randomized.Common
+                       Test.QuickCheck.Randomized.Common.Bounds
+                       Test.QuickCheck.Randomized.Common.Complements
+                       Test.QuickCheck.Randomized.Common.Count
+                       Test.QuickCheck.Randomized.Common.Events
+                       Test.QuickCheck.Randomized.Common.Interval
+                       Test.QuickCheck.Randomized.Common.Probability
+                       Test.QuickCheck.Randomized.Common.Validation
+
+                       Test.QuickCheck.Randomized.Distribution.Binomial
+
+  build-depends:       base              >=4.9   && <4.15
+                     , QuickCheck
+                     , binary-search
+                     , containers
+                     , quiet
+                     , statistics
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+                       -fno-ignore-asserts
+
+test-suite test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Main.hs
+  other-modules:
+                       Test.Test.QuickCheck.Randomized.Coin
+                       Test.Test.QuickCheck.Randomized.Coin.Common
+                       Test.Test.QuickCheck.Randomized.Coin.Direct
+                       Test.Test.QuickCheck.Randomized.Coin.Meta
+
+  build-depends:       base
+                     , QuickCheck
+                     , tasty
+                     , tasty-quickcheck
+
+                     , quickcheck-randomized
+
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+                       -fno-ignore-asserts
+                       -threaded
+                       -rtsopts

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized.hs
@@ -1,0 +1,5 @@
+module Test.QuickCheck.Randomized (
+  module X,
+  ) where
+
+import           Test.QuickCheck.Randomized.Common as X

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized/Coin.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized/Coin.hs
@@ -1,0 +1,10 @@
+-- | Testing coins.
+--
+-- Import this module qualified.
+
+module Test.QuickCheck.Randomized.Coin (
+  module X,
+  ) where
+
+import           Test.QuickCheck.Randomized.Coin.Rule as X
+import           Test.QuickCheck.Randomized.Coin.Tune as X

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized/Coin/Rule.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized/Coin/Rule.hs
@@ -1,0 +1,413 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE EmptyCase             #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE Rank2Types            #-}
+{-# LANGUAGE TypeFamilies          #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+-- | Test the bias of a coin via its binomial sampling distribution.
+--
+-- Import this module qualified. Better yet, import
+-- "Test.QuickCheck.Randomized.Coin" qualified instead.
+
+module Test.QuickCheck.Randomized.Coin.Rule (
+  -- * Testing
+  Arguments (..),
+  Coin (..),
+  Face (..),
+  Rule (..),
+  applyArguments,
+  applyRule,
+  mkRule,
+  withRule,
+  -- * Making coins
+  fromBias,
+  fromProperty,
+  fromPropertyLabel,
+  -- * Analysis
+  falseFail,
+  falsePass,
+  isActuallyTwoSided,
+  ) where
+
+import           Data.Coerce (coerce)
+import           Data.Type.Coercion (coerceWith)
+import           GHC.Generics
+
+import           Test.QuickCheck (arbitrary)
+import           Test.QuickCheck.Gen
+import qualified Test.QuickCheck.Gen.Unsafe
+import           Test.QuickCheck.Property
+
+import           Test.QuickCheck.Randomized.Common
+import           Test.QuickCheck.Randomized.Distribution.Binomial
+                     (Binomial (..))
+import qualified Test.QuickCheck.Randomized.Distribution.Binomial as Binomial
+
+{-------------------------------------------------------------------------------
+  Events
+-------------------------------------------------------------------------------}
+
+-- | The two possible outcomes of a coin toss.
+--
+-- A biased coin is the archetypal example for this statistical test, where the
+-- @p@ parameter of the Bernoulli distribution is the probability of each
+-- (idealized) toss landing 'Heads'.
+--
+-- This wording lets us use the terminology " heads or tails " for each toss
+-- instead of " success or failure ", which are already in use in the broader
+-- context of a test suite.
+data Face = Heads | Tails
+  deriving (Eq, Show)
+
+type instance Not Heads = Tails
+type instance Not Tails = Heads
+
+{-------------------------------------------------------------------------------
+  Test inputs
+-------------------------------------------------------------------------------}
+
+-- | The parameters of The Binomial Rule.
+data Arguments = Arguments {
+    alpha    :: !(MaxBound (Prob FalseFail))
+    -- ^ The resulting test will fail with a probability @<= 'alpha'@ when
+    -- applied to a correct coin.
+    --
+    -- NOTE Use 'neverProb' to back-compute 'alpha' from an estimate of how
+    -- many times the rule will /ever/ be applied to /a correct coin/. EG 10
+    -- times per week, conservatively, for a nightly test, for a project
+    -- lifetime of 20 years is 10400 executions of the nightly test suite. Then
+    -- multiply that by the (average) number of statistical tests in the suite
+    -- to find the 'Count' argument to 'neverProb'.
+  , expected :: !(Binomial Heads)
+    -- ^ The sampling distribution of a correct coin.
+  }
+  deriving (Generic, Show, Validate)
+
+-- | See 'mkRule' and 'applyRule'.
+data Rule = Rule {
+    arguments :: !Arguments
+    -- ^ The arguments that induced this rule. The 'tosses' is needed to apply
+    -- the rule, but the rest is for convenience only, such as inclusion in the
+    -- 'counterexample' message.
+  , interval  :: !(Interval (Count Heads))
+    -- ^ The resulting test fails iff the number of heads in the sample is not
+    -- in this interval.
+  }
+  deriving (Generic, Show, Validate)
+
+{-------------------------------------------------------------------------------
+  Binomial test logic
+-------------------------------------------------------------------------------}
+
+-- | The most demanding rule with approximately-equal tail regions such that
+-- each satisfies @'alpha' / 2@.
+--
+-- Is 'Nothing' if the rule is degenerate such that it can never fail. In other
+-- words, if @'tosses' . 'expected'@ is too low for the other 'Arguments'.
+--
+-- NOTE One of the tail regions may be empty; see 'isActuallyTwoSided'.
+mkRule :: Arguments -> Maybe Rule
+mkRule arguments = assertValid arguments $
+    if   interval == Binomial.support expected
+    then Nothing
+    else Just rule
+  where
+    Arguments {
+        alpha
+      , expected
+      } = arguments
+    Binomial {
+        bias
+      , tosses
+      } = expected
+
+    rule :: Rule
+    rule = Rule {
+        arguments
+      , interval
+      }
+
+    interval :: Interval (Count Heads)
+    interval  = Interval
+        justEnoughHeads
+        ( coerceWith (tradeMaxBound tradeCount) $
+          complementMinBound
+            (complementCount tosses)
+            justEnoughTails
+        )
+
+    justEnoughHeads :: MinBound (Count Heads)
+    justEnoughHeads = Binomial.quantile expected tailProb
+
+    justEnoughTails :: MinBound (Count Tails)
+    justEnoughTails =
+        Binomial.quantile
+          Binomial {
+              bias   = coerceWith tradeProb $ complementProb bias
+            , tosses
+            }
+          tailProb
+
+    -- One equal tail of the two-sided test.
+    --
+    -- NOTE Usually much smaller than the bias, so the one's complement here
+    -- would lose precision.
+    tailProb :: forall (face :: Face). MinBound (Prob (InRange face))
+    tailProb = MinBound $ coerceWith unsafeCoerceProb $ (unMaxBound alpha) / 2
+
+{-------------------------------------------------------------------------------
+  Analysis
+-------------------------------------------------------------------------------}
+
+-- | Whether the rule's 'interval' induces two non-empty rejection regions.
+isActuallyTwoSided :: Rule -> Bool
+isActuallyTwoSided rule =
+    MinBound 0 /= lo && n /= hi
+  where
+    Rule {
+        arguments
+      , interval
+      } = rule
+    Arguments {
+        expected
+      } = arguments
+
+    Interval lo hi = interval
+
+    Interval _ n = Binomial.support expected
+
+-- | See 'FalseFail'; the /specification/ in this case is that the coin's
+-- actual bias is exactly @'Binomial.bias' . 'expected'@.
+falseFail :: Rule -> Prob FalseFail
+falseFail rule =
+    coerceWith unsafeCoerceProb alpha'
+  where
+    Rule {
+        arguments
+      , interval
+      } = rule
+    Arguments {
+        expected
+      } = arguments
+
+    alpha' :: ProbNot (InRange Heads)
+    alpha' =
+        complementProb $ Binomial.intervalCdf expected interval
+
+-- | See 'FalsePass'; the /specification/ in this case is that the rule is
+-- forgiven if it passes when the coin is " only slightly " incorrect, ie if
+-- its actual bias is within 'Leniency' of @'Binomial.bias' . 'expected'@,
+-- inclusive of the bounds.
+falsePass :: Rule -> Leniency (Prob Heads) -> Prob FalsePass
+falsePass rule leniency =
+    coerceWith unsafeCoerceProb beta'
+  where
+    Rule {
+        arguments
+      , interval
+      } = rule
+    Arguments {
+        expected
+      } = arguments
+    Binomial {
+        bias
+      , tosses
+      } = expected
+
+    beta' :: Prob (InRange Heads)
+    beta' =
+        risk (-) `max` risk (+)
+      where
+        -- How much the offset sampling distribution overlaps with the correct
+        -- sampling distribution's acceptance interval.
+        risk :: (Prob Heads -> Prob Heads -> Prob Heads) -> Prob (InRange Heads)
+        risk o =
+            -- If the leniency extends the bias to 0 and/or 1, then no coin
+            -- exists beyond that: the leniency has trivialized that side of
+            -- the test.
+            if 0 == bias' || 1 == bias' then 0 else
+            Binomial.intervalCdf (mkD bias') interval
+          where
+            bias' :: Prob Heads
+            bias' = clipProb $ o bias $ unLeniency leniency
+
+        mkD bias' = Binomial {
+            bias   = bias'
+          , tosses
+          }
+
+{-------------------------------------------------------------------------------
+  Propertys
+-------------------------------------------------------------------------------}
+
+-- | A coin can be tossed to come up 'Heads' or 'Tails'.
+--
+-- For interop with QuickCheck, we represent a coin as a 'Property'. The
+-- interpretation is as follows.
+--
+-- o If the underlying predicate is 'False', the toss fatally fails. EG
+--   'applyRule' will fail with the relevant counterexample.
+--
+-- o If the underlying predicate is 'True', then the coin is 'Heads' iff the
+--   string 'headsLabel' has been applied via 'label' or 'classify'. It's
+--   'Tails' otherwise.
+--
+-- o If the underlying predicate involved 'discard', then that toss is rejected
+--   and we attempt another toss.
+data Coin = Coin {
+    headsLabel :: !String
+    -- ^ The label via 'label' or 'classify' that determines 'Heads'.
+  , toss       :: !Property
+  }
+
+-- | A coin with the given bias.
+fromBias :: Prob Heads -> Coin
+fromBias bias = fromProperty $
+    if 0 == bias then property False else
+    forAll arbitrary $ \p -> property $ p <= bias
+
+-- | Wrapper around 'mkRule'.
+--
+-- It's @'property' False@ if 'mkRule' yields 'Nothing'.
+withRule :: Arguments -> (Rule -> Property) -> Property
+withRule arguments k =
+    withValid arguments $
+    case mkRule arguments of
+      Nothing   ->
+          counterexample "The rule is degenerate." False
+      Just rule ->
+          withValid rule $
+          k rule
+
+-- | Apply the induced rule to the coin.
+applyArguments :: Arguments -> Coin -> Property
+applyArguments arguments coin =
+    withRule arguments $ \rule -> applyRule rule coin
+
+-- | Apply the rule to the coin.
+--
+-- Our use here involves the same caveats as 'idempotentIOProperty'. Moreover,
+-- QuickCheck's /verbose/ /checking/ will print a result for every toss of the
+-- coin!
+--
+-- NOTE Any 'expectFailure' within the coin is ignored: the argument @'Coin' p@
+-- and @'Coin' ('expectFailure' p)@ will induce the same resulting 'Property'
+-- via 'applyRule'.
+applyRule :: Rule -> Coin -> Property
+applyRule rule coin =
+    withValid rule $ countHeads (0 :: Count Heads) tosses
+  where
+    Coin {
+        headsLabel
+      , toss
+      } = coin
+
+    Rule {
+        arguments
+      , interval
+      } = rule
+    Arguments {
+        expected
+      } = arguments
+    Binomial {
+        tosses
+      } = expected
+
+    decide :: Count Heads -> Property
+    decide acc = case compareToInterval acc interval of
+        LT -> err "Too few Heads!"
+        EQ -> property True
+        GT -> err "Too many Heads!"
+      where
+        err :: String -> Property
+        err s =
+            counterexample (s <> show acc <> " for " <> show rule) False
+
+    -- IO Gen Prop ~# IO (Seed -> Size -> Prop)
+    --
+    -- Gen IO Prop ~# Seed -> Size -> IO Prop
+    --
+    -- commute m seed size = (\g -> g seed size) <$> m
+    --
+    -- QuickCheck itself uses the IO layer for eg verbose printing via
+    -- callbacks, catching pure exceptions, timeouts, etc. The IO layer is
+    -- /also/ used for stuff the user injected via 'ioProperty' eg.
+    --
+    -- Our use here involves the same caveats as 'idempotentIOProperty'.
+    commute :: IO (Gen Prop) -> Gen (IO Prop)
+    commute = Test.QuickCheck.Gen.Unsafe.promote
+
+    embed :: IO Property -> Gen Prop
+    embed =
+        fmap (MkProp . IORose . fmap unProp) .
+        commute .
+        fmap unProperty
+
+    -- TODO accumulate labels etc for Tails, to include in counterexample
+    -- message?
+    countHeads :: Count Heads -> Count (Trial Face) -> Property
+    countHeads acc i
+        | i <= (0 :: Count (Trial Face)) = decide acc
+        | otherwise                      = MkProperty $ do
+            -- NOTE It is this bind that splits the PRNG state.
+            rose <- unProp <$> unProperty toss :: Gen (Rose Result)
+            embed $ do
+              MkRose res _roses <- reduceRose rose
+              pure $ case ok res of
+                Nothing    -> countHeads acc i
+                Just False -> MkProperty $ pure $ MkProp rose
+                Just True  -> do
+                  let hit1 = headsLabel `elem` classes res
+                      hit2 = headsLabel `elem` labels res
+                      upd = if hit1 || hit2 then (+1) else id
+                  countHeads (upd acc) (i - 1)
+
+-- | Use a 'Property' as a coin. A 'Property' sample is 'Heads' if the
+-- specified label is present via 'label' or 'classify', 'Tails' otherwise.
+--
+-- NOTE A 'discard' induces a replacement toss. Any counterexample from the
+-- coin causes the whole statistical test to fail.
+fromPropertyLabel :: String -> Property -> Coin
+fromPropertyLabel headsLabel toss = Coin {
+    headsLabel
+  , toss
+  }
+
+-- | Use a 'Property' as a coin. A successful 'Property' is 'Heads' and a
+-- failing 'Property' is 'Tails'.
+--
+-- NOTE A 'discard' induces a replacement toss.
+fromProperty :: Property -> Coin
+fromProperty prop = Coin {
+    headsLabel
+  , toss
+  }
+  where
+    headsLabel = "quickcheck-randomized:Heads"
+    toss       = onEachResult tweakResult prop
+
+    tweakResult :: Result -> Result
+    tweakResult res = case ok res of
+        Nothing    -> res
+        Just False -> res'{ok = Just True}
+        Just True  -> res'{labels  = headsLabel : labels res}
+      where
+        res' = res {
+            classes = filter (/= headsLabel) $ classes res
+          , labels  = filter (/= headsLabel) $ labels res
+          }
+
+{-------------------------------------------------------------------------------
+  Miscellany
+-------------------------------------------------------------------------------}
+
+onEachResult :: (Result -> Result) -> Property -> Property
+onEachResult f =
+    coerce $
+    (fmap $ fmap f :: Gen (Rose Result) -> Gen (Rose Result))

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized/Coin/Tune.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized/Coin/Tune.hs
@@ -1,0 +1,208 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+-- | Tune the "Test.QuickCheck.Randomized.Coin" test.
+--
+-- Import this module qualified. Better yet, import
+-- "Test.QuickCheck.Randomized.Coin" qualified instead.
+
+module Test.QuickCheck.Randomized.Coin.Tune (
+  -- * Tune 'leniency'
+  LeniencyArguments (..),
+  TunedLeniency (..),
+  tuneLeniency,
+  -- * Tune 'tosses'
+  TossesArguments (..),
+  TunedTosses (..),
+  applyTossesArguments,
+  tuneTosses,
+  ) where
+
+import           Control.Monad (guard)
+import           Data.Maybe (fromMaybe)
+import           GHC.Generics
+
+import           Test.QuickCheck.Property
+
+import           Test.QuickCheck.Randomized.Coin.Rule
+import           Test.QuickCheck.Randomized.Common
+import           Test.QuickCheck.Randomized.Distribution.Binomial
+                     (Binomial (..))
+
+{-------------------------------------------------------------------------------
+  Tuning tosses
+-------------------------------------------------------------------------------}
+
+-- | See 'tuneTosses'.
+data TossesArguments = TossesArguments {
+    alpha     :: !(MaxBound (Prob FalseFail))
+    -- ^ See 'alpha' for 'Arguments'.
+  , beta      :: !(MaxBound (Prob FalsePass))
+  , bias      :: !(Prob Heads)
+  , leniency  :: !(Leniency (Prob Heads))
+    -- ^ Defines the condition for 'FalsePass'.
+    --
+    -- NOTE It does not affect 'FalseFail'.
+  , maxTosses :: !(MaxBound (Count (Trial Face)))
+  }
+  deriving (Generic, Show, Validate)
+
+-- | See 'tuneTosses'.
+data TunedTosses
+    = OkTosses !(MinBound (Count (Trial Face))) !Rule
+      -- ^ The minimum number of tosses. For convenience, we also include the
+      -- corresponding rule.
+    | InsufficientMaxTosses
+      -- ^ Even 'maxTosses' could not satisfy the remaining 'TossesArguments'.
+  deriving (Show)
+
+-- | Finds the mininum number of tosses up to 'maxTosses' that induces a
+-- non-degenerate rule that satisfies the specified 'alpha' and 'beta' limits,
+-- if any.
+tuneTosses :: TossesArguments -> TunedTosses
+tuneTosses hyper =
+    assertValid hyper $
+    case smallestInIntervalMaybe interval predicate of
+      Nothing             -> InsufficientMaxTosses
+      Just (tosses, rule) -> OkTosses (MinBound tosses) rule
+  where
+    TossesArguments {
+        alpha
+      , beta
+      , bias
+      , leniency
+      , maxTosses
+      } = hyper
+
+    interval :: Interval (Count (Trial Face))
+    interval = MinBound 0 `Interval` maxTosses
+
+    mkD :: Count (Trial Face) -> Prob Heads -> Binomial Heads
+    mkD k b = Binomial {
+        bias   = b
+      , tosses = k
+      }
+
+    -- Upward-closed because risk is antitone wrt number of tosses and @(<= q)@
+    -- is downward-closed.
+    predicate :: Count (Trial Face) -> Maybe (Count (Trial Face), Rule)
+    predicate k = do
+        rule <- mkRule Arguments {
+            alpha
+          , expected = mkD k bias
+          }
+        guard $ falsePass rule leniency <= unMaxBound beta
+        pure (k, rule)
+
+-- | Apply the induced rule to the coin.
+applyTossesArguments :: TossesArguments -> Coin -> Property
+applyTossesArguments hyper coin =
+    case tuneTosses hyper of
+        OkTosses (MinBound _tosses) rule -> applyRule rule coin
+        InsufficientMaxTosses            ->
+          counterexample
+            (prefix <> "The " <> show hyper <> " are unsatisfiable.")
+            False
+  where
+    prefix = "applyTossesArguments: "
+
+{-------------------------------------------------------------------------------
+  Tuning leniency
+-------------------------------------------------------------------------------}
+
+-- | See 'tuneLeniency'.
+data LeniencyArguments = LeniencyArguments {
+    beta         :: !(MaxBound (Prob FalsePass))
+  , leniencyGrid :: !(Count (Leniency (Prob Heads)))
+    -- ^ How many evenly-spaced leniencies from the half-open @(0, 1]@ to
+    -- consider.
+  , rule         :: !Rule
+  }
+  deriving (Generic, Show, Validate)
+
+-- | See 'tuneLeniency'.
+data TunedLeniency
+    = OkLeniency !(MinBound (Leniency (Prob Heads)))
+    | DegenerateLeniency
+      -- ^ There is no coin outside of the necessary leniency interval.
+  deriving (Show)
+
+-- | Finds the mininum 'leniency' on the given grid that satisfies the
+-- specified 'alpha' and 'beta' limits, if any.
+tuneLeniency :: LeniencyArguments -> TunedLeniency
+tuneLeniency hyper = assertValid hyper $ do
+    case smallestInInterval leniencyInterval predicate of
+      Nothing ->
+          -- The grid includes a leniency of 1, which totally trivializes the
+          -- test for any bias, and so even a 'beta' of 0 will be satisfiable.
+          error "impossible"
+      Just i  ->
+          if degenerate then DegenerateLeniency else
+          OkLeniency (MinBound leniency)
+        where
+          leniency :: Leniency (Prob Heads)
+          leniency = mkL i
+
+          degenerate :: Bool
+          degenerate =
+              bias - unLeniency leniency <= 0 &&
+              bias + unLeniency leniency >= 1
+  where
+    LeniencyArguments {
+        beta
+      , leniencyGrid
+      , rule
+      } = hyper
+    Rule {
+        arguments
+      } = rule
+    Arguments {
+        expected
+      } = arguments
+    Binomial {
+        bias
+      } = expected
+
+    -- Leniency must be positive.
+    leniencyInterval :: Interval (Count (Leniency (Prob Heads)))
+    leniencyInterval = MinBound 1 `Interval` MaxBound leniencyGrid
+
+    -- Monotonic. Positive if the argument is. Always @<= 1@.
+    mkL :: Count (Leniency (Prob Heads)) -> Leniency (Prob Heads)
+    mkL (Count i) =
+        Leniency $ Prob $
+        fromIntegral i / fromIntegral (unCount leniencyGrid)
+
+    -- Upward-closed because the risk is antitone wrt leniency and @(<= q)@ is
+    -- downward-closed.
+    predicate :: Count (Leniency (Prob Heads)) -> Bool
+    predicate i = falsePass rule (mkL i) <= unMaxBound beta
+
+_example1 :: TunedTosses
+_example1 = tuneTosses TossesArguments {
+    alpha     = MaxBound $ Prob 1e-6
+  , beta      = MaxBound $ Prob 1e-3
+  , bias      = Prob 0.01
+  , leniency  = Leniency $ Prob 0.03
+  , maxTosses = MaxBound $ Count $ 10 ^ (6 :: Int)
+  }
+
+_example2 :: TunedLeniency
+_example2 = tuneLeniency LeniencyArguments {
+    beta         = MaxBound $ Prob 1e-2
+  , leniencyGrid = Count $ 10 ^ (6 :: Int)
+  , rule
+  }
+  where
+    rule = fromMaybe (error "_example2") $ mkRule Arguments {
+        alpha    = MaxBound $ Prob 1e-6
+      , expected = Binomial {
+          bias   = Prob 0.2
+        , tosses = Count $ 10 ^ (5 :: Int)
+        }
+      }

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common.hs
@@ -1,0 +1,11 @@
+module Test.QuickCheck.Randomized.Common (
+  module X,
+  ) where
+
+import           Test.QuickCheck.Randomized.Common.Bounds as X
+import           Test.QuickCheck.Randomized.Common.Complements as X
+import           Test.QuickCheck.Randomized.Common.Count as X
+import           Test.QuickCheck.Randomized.Common.Events as X
+import           Test.QuickCheck.Randomized.Common.Interval as X
+import           Test.QuickCheck.Randomized.Common.Probability as X
+import           Test.QuickCheck.Randomized.Common.Validation as X

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Bounds.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Bounds.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+
+-- | Bounds, either user-specified or computed.
+
+module Test.QuickCheck.Randomized.Common.Bounds (
+  -- * Bounds
+  Leniency (..),
+  MaxBound (..),
+  MinBound (..),
+  complementMaxBound,
+  complementMinBound,
+  tradeLeniency,
+  tradeMaxBound,
+  tradeMinBound,
+  ) where
+
+import           Data.Proxy
+import           Data.Semigroup (Max (..), Min (..))
+import           Data.Type.Coercion
+
+import           GHC.Generics
+import           Quiet (Quiet (..))
+
+import           Test.QuickCheck.Randomized.Common.Complements
+import           Test.QuickCheck.Randomized.Common.Count
+import           Test.QuickCheck.Randomized.Common.Probability
+import           Test.QuickCheck.Randomized.Common.Validation
+
+{-------------------------------------------------------------------------------
+  Boundaries
+-------------------------------------------------------------------------------}
+
+-- | The left argument to @<=@.
+newtype MinBound a = MinBound {unMinBound :: a}
+  deriving stock (Generic)
+  deriving newtype (Eq, Ord, Validate)
+  deriving (Semigroup) via Max a
+  deriving (Show) via Quiet (MinBound a)
+
+instance Monoid (MinBound (Count_ pol ev)) where mempty = MinBound 0
+instance Monoid (MinBound (Prob_  pol ev)) where mempty = MinBound 0
+
+-- | The right argument to @<=@.
+newtype MaxBound a = MaxBound {unMaxBound :: a}
+  deriving stock (Generic)
+  deriving newtype (Eq, Ord, Validate)
+  deriving (Semigroup) via Min a
+  deriving (Show) via Quiet (MaxBound a)
+
+instance Monoid (MaxBound (Prob_ pol ev)) where mempty = MaxBound 1
+
+-- | This is an additive difference from some nominal value.
+--
+-- It's a /positive/ value, interpretable as the 'MaxBound' of some /absolute/
+-- /difference/.
+newtype Leniency a = Leniency {unLeniency :: a}
+  deriving stock (Generic)
+  deriving newtype (Eq, Ord)
+  deriving (Semigroup) via Min a
+  deriving (Show) via Quiet (Leniency a)
+
+instance Monoid (Leniency (Prob_ pol ev)) where mempty = Leniency (Prob 1)
+
+-- | Positive
+instance (Num a, Ord a, Show a) => Validate (Leniency a) where
+  validate (Leniency diff) =
+      invalidityUnless (0 < diff) $
+      "Invalid Leniency! " <> show diff <> " is nonpositive."
+
+-- | A 'MinBound' for some event typically determines a 'MaxBound' on its
+--
+-- EG @'MinBound' ('Prob' ev) -> 'MaxBound' ('ProbNot' ev)@
+complementMinBound :: forall pol1 pol2 k f (ev :: k).
+     Complements pol1 pol2
+  => (f pol1 ev -> f pol2 ev)
+  -> MinBound (f pol1 ev)
+  -> MaxBound (f pol2 ev)
+complementMinBound complement =
+    MaxBound . complement . unMinBound
+  where
+    _ = complements (Proxy :: Proxy pol1) (Proxy :: Proxy pol2)
+
+-- | See 'complementMinBound'.
+complementMaxBound :: forall pol1 pol2 k f (ev :: k).
+     Complements pol1 pol2
+  => (f pol1 ev -> f pol2 ev)
+  -> MaxBound (f pol1 ev)
+  -> MinBound (f pol2 ev)
+complementMaxBound complement =
+    MinBound . complement . unMaxBound
+  where
+    _ = complements (Proxy :: Proxy pol1) (Proxy :: Proxy pol2)
+
+-- | A 'MinBound' for some event is also a 'MinBound' on the complement of its
+-- complement.
+--
+-- EG @'MinBound' ('Prob' ev) ``Coercion`` 'MinBound' ('ProbNot' ('Not' ev))@
+tradeMinBound :: forall pol1 pol2 k f (ev1 :: k) (ev2 :: k).
+     (Complements pol1 pol2, Complements ev1 ev2)
+  => (f pol1 ev1 `Coercion` f pol2 ev2)
+  -> MinBound (f pol1 ev1) `Coercion` MinBound (f pol2 ev2)
+tradeMinBound Coercion =
+    Coercion
+  where
+    _ = complements (Proxy :: Proxy pol1) (Proxy :: Proxy pol2)
+    _ = complements (Proxy :: Proxy ev1)  (Proxy :: Proxy ev2)
+
+-- | See 'tradeMinBound'.
+tradeMaxBound :: forall pol1 pol2 k f (ev1 :: k) (ev2 :: k).
+     (Complements pol1 pol2, Complements ev1 ev2)
+  => (f pol1 ev1 `Coercion` f pol2 ev2)
+  -> MaxBound (f pol1 ev1) `Coercion` MaxBound (f pol2 ev2)
+tradeMaxBound Coercion =
+    Coercion
+  where
+    _ = complements (Proxy :: Proxy pol1) (Proxy :: Proxy pol2)
+    _ = complements (Proxy :: Proxy ev1)  (Proxy :: Proxy ev2)
+
+-- | See 'tradeMinBound'.
+tradeLeniency :: forall pol1 pol2 k f (ev1 :: k) (ev2 :: k).
+     (Complements pol1 pol2, Complements ev1 ev2)
+  => (f pol1 ev1 `Coercion` f pol2 ev2)
+  -> Leniency (f pol1 ev1) `Coercion` Leniency (f pol2 ev2)
+tradeLeniency Coercion =
+    Coercion
+  where
+    _ = complements (Proxy :: Proxy pol1) (Proxy :: Proxy pol2)
+    _ = complements (Proxy :: Proxy ev1)  (Proxy :: Proxy ev2)

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Complements.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Complements.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+module Test.QuickCheck.Randomized.Common.Complements (
+  Not,
+  Complements,
+  complements,
+  ) where
+
+import           Data.Proxy
+
+-- | In a general sense, @'Not' a@ is the complement of @a@.
+--
+-- For 'Bool' it's a type-level @not@. For /events/, it's the complementary
+-- event, eg heads versus tails.
+type family Not (a :: k) :: k
+
+type instance Not True  = False
+type instance Not False = True
+
+-- | This constraint allows @pol1@ to determine @pol2@ and vice versa.
+type Complements pol1 pol2 = (pol1 ~ Not pol2, pol2 ~ Not pol1)
+
+-- | Invoked in order to incorporate semantic constraints that GHC would
+-- otherwise consider redundant.
+complements :: forall k proxy (a :: k) b.
+       Complements a b => proxy a -> proxy b -> ()
+complements _ _ =
+    ()
+  where
+    _ = (Proxy :: Proxy a) `asTypeOf` (Proxy :: Proxy (Not b))
+    _ = (Proxy :: Proxy b) `asTypeOf` (Proxy :: Proxy (Not a))
+

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Count.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Count.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+module Test.QuickCheck.Randomized.Common.Count (
+  -- * Count
+  Count_ (..),
+  Count,
+  CountNot,
+  complementCount,
+  tradeCount,
+  unsafeCoerceCount,
+  ) where
+
+import           Control.Exception (assert)
+import           Data.Proxy
+import           Data.Type.Coercion
+import           GHC.Generics
+import           Quiet (Quiet (..))
+
+
+import           Test.QuickCheck.Randomized.Common.Complements
+import           Test.QuickCheck.Randomized.Common.Events
+import           Test.QuickCheck.Randomized.Common.Validation
+
+-- | A count, @0 <= k < infinity@.
+--
+-- The phantom arguments indicate the corresponding event, including whether or
+-- not it is complemented.
+--
+-- NOTE We use a signed representation so that underflow is detectable.
+newtype Count_ (pol :: Bool) (ev :: k) = Count {unCount :: Int}   -- TODO Integer?
+  deriving stock (Generic)
+  deriving newtype (Enum, Eq, Integral, Num, Ord, Real)
+  deriving (Show) via Quiet (Count_ pol ev)
+
+-- | Non-negative
+instance Validate (Count_ pol ev) where
+  validate (Count k) =
+      invalidityUnless (k >= 0) $
+      "Invalid count! " <> show k <> " is negative."
+
+-- | The event is not complemented.
+type Count    = Count_ True
+
+-- | The event is complemented.
+type CountNot = Count_ False
+
+-- | See 'Test.QuickCheck.Randomized.Common.Probability.unsafeProb'.
+unsafeCoerceCount :: Count_ pol1 (ev1 :: k1) `Coercion` Count_ pol2 (ev2 :: k2)
+unsafeCoerceCount = Coercion
+
+-- | See 'Test.QuickCheck.Randomized.Common.Probability.complementProb'.
+complementCount :: forall pol1 pol2 k ev.
+     Complements pol1 pol2
+  => Count (Trial k) -> Count_ pol1 (ev :: k) -> Count_ pol2 ev
+complementCount (Count n) (Count k) =
+    assert (n >= k) $
+    Count $ n - k
+  where
+    _ = complements (Proxy :: Proxy pol1) (Proxy :: Proxy pol2)
+
+-- | See 'Test.QuickCheck.Randomized.Common.Probability.tradeProb'.
+tradeCount :: forall pol1 pol2 k ev1 ev2.
+     (Complements pol1 pol2, Complements ev1 ev2)
+  => Count_ pol1 (ev1 :: k) `Coercion` Count_ pol2 ev2
+tradeCount =
+    Coercion
+  where
+    _ = complements (Proxy :: Proxy pol1) (Proxy :: Proxy pol2)
+    _ = complements (Proxy :: Proxy ev1)  (Proxy :: Proxy ev2)

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Events.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Events.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | General /events/: happenings and\/or things that can be counted and\/or
+-- can have a probability, etc.
+
+module Test.QuickCheck.Randomized.Common.Events (
+  -- * Events
+  Ever,
+  FalseResult (FalseFail, FalsePass),
+  InRange,
+  Trial,
+  -- * Property combinators
+  negateProperty,
+  ) where
+
+import           Test.QuickCheck.Property
+
+data FalseResult
+  = FalseFail
+    -- ^ Event: The statistical test fails even though the code indeed
+    -- satisfies its specification.
+    --
+    -- NOTE 'FalsePass' may use a less precise specification.
+  | FalsePass
+    -- ^ Event: The statistical test passes even though the code does not
+    -- satisfy its specification.
+    --
+    -- NOTE 'FalseFail' may use a more precise specification.
+
+-- | Event: The realization of a one-dimensional random variable is in some
+-- range.
+--
+-- NOTE It would be too burdensome to include the range itself in the type, so
+-- we settle for the imprecise type.
+data InRange (ev :: k)
+
+-- | Event: A trial in which each outcome has a corresponding type value of
+-- kind @outcome@. Examples include: tossing a coin, rolling a die, drawing a
+-- ball from an urn, drawing a sample from a PRNG, etc.
+--
+-- NOTE The complement of this event does not seem to have useful semantics.
+-- Relatedly, we only use it with 'Count'.
+data Trial (outcome :: *)
+
+-- | Event: The event happens at least once during some number of repititions.
+data Ever (ev :: k)
+
+{-------------------------------------------------------------------------------
+  Property combinators
+-------------------------------------------------------------------------------}
+
+-- | Negate the underlying predicate of a 'Property'.
+--
+-- This is different than 'expectFailure'.
+--
+-- o 'expectFailure' means " quickly check that the property does not hold ",
+--   and so it causes QuickCheck to stop iterating once it falsifies the
+--   predicate. That's not what we want here.
+--
+-- o 'negateProperty' instead means " quickly check that the negation of the
+--   property holds ", and so it does /not/ short-circuit the QuickCheck
+--   iteration loop.
+negateProperty :: Property -> Property
+negateProperty =
+    MkProperty . fmap (MkProp . fmap neg . unProp) . unProperty
+  where
+    neg :: Result -> Result
+    neg res = res{ok = not <$> ok res}

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Interval.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Interval.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+module Test.QuickCheck.Randomized.Common.Interval (
+  -- * Interval
+  Interval (..),
+  chooseInIntegralInterval,
+  compareToInterval,
+  inInterval,
+  smallestInInterval,
+  smallestInIntervalMaybe,
+  ) where
+
+import           Data.Maybe (isJust)
+import           GHC.Generics
+import           Numeric.Search.Range (searchFromTo)
+
+import           Test.QuickCheck
+
+import           Test.QuickCheck.Randomized.Common.Bounds
+import           Test.QuickCheck.Randomized.Common.Validation
+
+-- | A non-empty closed interval.
+data Interval a =
+    Interval !(MinBound a) !(MaxBound a)
+  deriving (Eq, Generic, Ord, Show)
+
+-- | Non-empty, @lo <= hi@
+instance (Ord a, Validate a) => Validate (Interval a) where
+  validate interval =
+      invalidityUnless (lo <= hi) "empty interval!"
+      <> validateViaRep interval
+    where
+      Interval (MinBound lo) (MaxBound hi) = interval
+
+compareToInterval :: Ord a => a -> Interval a -> Ordering
+compareToInterval x interval
+    | x < lo    = LT
+    | x > hi    = GT
+    | otherwise = EQ
+  where
+    Interval (MinBound lo) (MaxBound hi) = interval
+
+-- | Whether @lo <= x && x <= hi@.
+inInterval :: Ord a => Interval a -> a -> Bool
+inInterval interval x = EQ == compareToInterval x interval
+
+-- | The predicate must be /upward-closed/: if @p k@ then @p ('succ' k)@.
+--
+-- It's 'Nothing' if the predicate is false for the whole interval.
+smallestInInterval ::
+    Integral a => Interval a -> (a -> Bool) -> Maybe a
+smallestInInterval interval predicate =
+    searchFromTo predicate lo hi
+  where
+    Interval (MinBound lo) (MaxBound hi) = interval
+
+-- | The predicate must be /upward-closed/: if @'isJust' (f k)@ then @'isJust'
+-- (f ('succ' k))@.
+--
+-- It's 'Nothing' if the predicate is false for the whole interval.
+smallestInIntervalMaybe ::
+    Integral a => Interval a -> (a -> Maybe b) -> Maybe b
+smallestInIntervalMaybe interval f =
+    (proj . f) <$> searchFromTo (isJust . f) lo hi
+  where
+    Interval (MinBound lo) (MaxBound hi) = interval
+
+    proj = \case
+        Nothing -> error "impossible"
+        Just x  -> x
+
+chooseInIntegralInterval :: Integral a => Interval a -> Gen a
+chooseInIntegralInterval interval
+    | hi < lo   = error msg
+    | otherwise = do
+        d <- choose (0, toInteger $ hi - lo)
+        pure $ lo + fromInteger d
+  where
+    Interval (MinBound lo) (MaxBound hi) = interval
+
+    msg :: String
+    msg =
+        "chooseInIntegralInterval: empty " <>
+        show (toInteger lo, toInteger hi)

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Probability.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Probability.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds                  #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+module Test.QuickCheck.Randomized.Common.Probability (
+  -- * Probability
+  Prob_ (..),
+  Prob,
+  ProbNot,
+  clipProb,
+  complementProb,
+  neverProb,
+  tradeProb,
+  unsafeCoerceProb,
+  ) where
+
+import           Data.Proxy
+import           Data.Type.Coercion
+import           GHC.Generics
+import           Quiet (Quiet (..))
+
+import           Test.QuickCheck
+
+import           Test.QuickCheck.Randomized.Common.Complements
+import           Test.QuickCheck.Randomized.Common.Count
+import           Test.QuickCheck.Randomized.Common.Events
+import           Test.QuickCheck.Randomized.Common.Validation
+
+{-------------------------------------------------------------------------------
+  Key values
+-------------------------------------------------------------------------------}
+
+-- | A probability, @0 <= p <= 1@.
+--
+-- The phantom arguments indicate the corresponding event, including whether or
+-- not it is complemented.
+newtype Prob_ (pol :: Bool) (ev :: k) = Prob {unProb :: Double}   -- TODO Rational? Fixed?
+  deriving stock (Generic)
+  deriving newtype (Eq, Fractional, Num, Ord)
+  deriving (Show) via Quiet (Prob_ pol ev)
+
+instance Arbitrary (Prob_ pol ev) where
+  arbitrary = Prob <$> choose (0, 1)
+
+-- | Unit interval, @0 <= p <= 1@
+instance Validate (Prob_ pol ev) where
+  validate (Prob p) =
+      invalidityUnless (0 <= p && p <= 1 ) $
+      "Invalid probability! " <> show p <> " is outside the unit interval."
+
+-- | The event is not complemented; @Pr[ ev ]@.
+type Prob    = Prob_ True
+
+-- | The event is complemented; @Pr[ not ev ]@.
+type ProbNot = Prob_ False
+
+-- | In some context, two events may be definitionally equivalent. This
+-- coercion is thus crucial for expresiveness, but also error prone.
+--
+-- Use @'coerceWith' 'unsafeCoerceProb'@ instead of @'Prob' . 'unProb'@ to make
+-- such definitions explicit.
+unsafeCoerceProb :: Prob_ pol1 (ev1 :: k1) `Coercion` Prob_ pol2 (ev2 :: k2)
+unsafeCoerceProb = Coercion
+
+-- | Complement a probability.
+--
+-- NOTE Avoid complements of small probabilites when possible:
+-- @'complementProb'@ loses floating-point precision.
+complementProb :: forall pol1 pol2 k ev.
+    Complements pol1 pol2 => Prob_ pol1 (ev :: k) -> Prob_ pol2 ev
+complementProb (Prob p) =
+    Prob $ 1 - p
+  where
+    _ = complements (Proxy :: Proxy pol1) (Proxy :: Proxy pol2)
+
+-- | A 'Prob_' of some event is also a 'Prob_' of the complement of its
+-- complement.
+--
+-- EG @'Prob' ev ``Coercion`` 'ProbNot' ('Not' ev)@
+tradeProb :: forall pol1 pol2 k ev1 ev2.
+     (Complements pol1 pol2, Complements ev1 ev2)
+  => Prob_ pol1 (ev1 :: k) `Coercion` Prob_ pol2 ev2
+tradeProb =
+    Coercion
+  where
+    _ = complements (Proxy :: Proxy pol1) (Proxy :: Proxy pol2)
+    _ = complements (Proxy :: Proxy ev1)  (Proxy :: Proxy ev2)
+
+-- | Clip a probability to the unit interval. Used to tidy-up after adjusting a
+-- probability (cf 'Test.QuickCheck.Randomized.Bounds.Leniency').
+clipProb :: Prob_ pol (ev :: k) -> Prob_ pol ev
+clipProb (Prob p) = Prob $ max 0 $ min 1 p
+
+-- | Compute the probability of an event happening in each independent
+-- repetition, as required by the probability for the event ever happening.
+--
+-- TODO For very small @p@, how different is this from @p / n@?
+neverProb :: Count (Trial k) -> Prob (Ever ev) -> Prob ev
+neverProb (Count n) (Prob ever) =
+    Prob each
+  where
+    -- Solve ever = 1 - (1 - each) ^ n for each.
+
+    -- ever = 1 - (1 - each) ^ n
+    -- 1 - ever = (1 - each) ^ n
+    -- (1 - ever) ** (1 / n) = 1 - each
+    --  = each
+
+    each = 1 - (1 - ever) ** (1 / fromIntegral n)

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Validation.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Validation.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DefaultSignatures   #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators       #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+module Test.QuickCheck.Randomized.Common.Validation (
+  -- * Validation
+  Breadcrumb,
+  Invalidities (..),
+  Validate (..),
+  assertValid,
+  nullInvalidities,
+  invalidity,
+  invalidityUnless,
+  innerInvalidities,
+  validateViaRep,
+  withValid,
+  -- * The definition of 'validateViaRep'
+  ValidateField (..),
+  ValidateFields (..),
+  ValidateRep (..),
+  ) where
+
+import           Control.Exception (assert)
+import qualified Data.Map as Map
+import           Data.Proxy
+import           Data.Semigroup (Max (..), Min (..))
+import           GHC.Generics
+import           GHC.TypeLits
+
+import           Test.QuickCheck
+
+-- | A data name, a constructor name, a field name, a field number, etc.
+type Breadcrumb = String
+
+data Invalidities = Invalidities [String] (Map.Map Breadcrumb Invalidities)
+  deriving (Show)
+
+instance Monoid Invalidities where
+  mempty = Invalidities [] Map.empty
+
+-- | Accumulative
+instance Semigroup Invalidities where
+  Invalidities l1 l2 <> Invalidities r1 r2 =
+      Invalidities (l1 <> r1) (Map.unionWith (<>) l2 r2)
+
+-- | There are no invalidities.
+nullInvalidities :: Invalidities -> Bool
+nullInvalidities (Invalidities msgs inners) =
+    null msgs && all nullInvalidities inners
+
+-- | @'assert' False@ unless 'nullInvalidities'.
+assertValid :: Validate a => a -> b -> b
+assertValid = assert . nullInvalidities . validate
+
+-- | @'property' False@ unless 'nullInvalidities'.
+withValid :: Validate a => a -> Property -> Property
+withValid a prop =
+    if   nullInvalidities invalidities
+    then prop
+    else counterexample (show invalidities) False
+  where
+    invalidities = validate a
+
+-- | An invalidity.
+invalidity :: String -> Invalidities
+invalidity msg = Invalidities [msg] Map.empty
+
+-- | An 'invalidity', conditionally.
+invalidityUnless :: Bool -> String -> Invalidities
+invalidityUnless b msg = if b then mempty else invalidity msg
+
+-- | Include the invalidities of part of a value as sub-invalidities scoped
+-- appropriately with the given 'BreadCrumb'.
+innerInvalidities :: Breadcrumb -> Invalidities -> Invalidities
+innerInvalidities turn invalidities
+    | nullInvalidities invalidities = mempty
+    | otherwise                     = Invalidities [] (Map.singleton turn invalidities)
+
+class Validate a where
+  validate :: a -> Invalidities
+
+  default validate :: (Generic a, ValidateRep (Rep a)) => a -> Invalidities
+  validate = validateViaRep
+
+instance Validate ()
+instance (Validate a, Validate b) => Validate (a, b)
+instance (Validate a, Validate b, Validate c) => Validate (a, b, c)
+instance
+     (Validate a, Validate b, Validate c, Validate d)
+  => Validate (a, b, c, d)
+instance
+     (Validate a, Validate b, Validate c, Validate d, Validate e)
+  => Validate (a, b, c, d, e)
+instance
+     (Validate a, Validate b, Validate c, Validate d, Validate e, Validate f)
+  => Validate (a, b, c, d, e, f)
+instance
+     (Validate a, Validate b, Validate c, Validate d, Validate e, Validate f, Validate g)
+  => Validate (a, b, c, d, e, f, g)
+
+instance Validate a => Validate (Min a)
+instance Validate a => Validate (Max a)
+
+{-------------------------------------------------------------------------------
+  Generics
+-------------------------------------------------------------------------------}
+
+-- | Use "GHC.Generics" to validate every field of every constructor.
+validateViaRep :: (Generic a, ValidateRep (Rep a)) => a -> Invalidities
+validateViaRep = validateRep . from
+
+class ValidateRep r where
+  validateRep :: r x -> Invalidities
+
+instance (Datatype meta, ValidateRep rep) => ValidateRep (M1 D meta rep) where
+  validateRep d@(M1 x) = innerInvalidities ("type " <> datatypeName d) $ validateRep x
+
+instance ValidateRep V1 where validateRep _ = mempty
+
+instance (ValidateRep l, ValidateRep r) => ValidateRep (l :+: r) where
+  validateRep = \case
+      L1 l -> validateRep l
+      R1 r -> validateRep r
+
+instance (Constructor meta, ValidateFields rep) => ValidateRep (M1 C meta rep) where
+  validateRep c@(M1 x) = innerInvalidities ("constructor " <> conName c) $ validateFields 0 x
+
+class ValidateFields r where
+  validateFields :: Int -> r x -> Invalidities
+
+instance ValidateFields U1 where validateFields _ _ = mempty
+
+instance (ValidateFields l, ValidateFields r) => ValidateFields (l :*: r) where
+  validateFields !k (l :*: r) =
+      validateFields k l <> validateFields (k + 1) r
+
+instance
+     ValidateField rep
+  => ValidateFields (M1 S (MetaSel Nothing su ss ds) rep) where
+  validateFields !k (M1 x) =
+      innerInvalidities ("field #" <> show k) $ validateField x
+
+instance
+     (KnownSymbol n, ValidateField rep)
+  => ValidateFields (M1 S (MetaSel (Just n) su ss ds) rep) where
+  validateFields !_k (M1 x) = innerInvalidities n $ validateField x
+    where
+      n = "field " <> symbolVal (Proxy :: Proxy n)
+
+class ValidateField r where
+  validateField :: r x -> Invalidities
+
+instance Validate a => ValidateField (K1 i a) where
+  validateField (K1 x) = validate x

--- a/quickcheck-randomized/src/Test/QuickCheck/Randomized/Distribution/Binomial.hs
+++ b/quickcheck-randomized/src/Test/QuickCheck/Randomized/Distribution/Binomial.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Key functions for the binomial distribution.
+--
+-- Import this module qualified.
+
+module Test.QuickCheck.Randomized.Distribution.Binomial (
+  Binomial (..),
+  cdf,
+  intervalCdf,
+  pmf,
+  quantile,
+  support,
+  ) where
+
+import           Data.Maybe (fromMaybe)
+import           Data.Type.Coercion (coerceWith)
+import           GHC.Generics
+
+import qualified Statistics.Distribution as Stats
+import qualified Statistics.Distribution.Binomial as Stats
+
+import           Test.QuickCheck.Randomized.Common
+
+-- | The parameters of the common @Binomial(n, p)@ notation.
+data Binomial (ev :: k) = Binomial {
+    bias   :: !(Prob ev)
+    -- ^ @p@
+  , tosses :: !(Count (Trial k))
+    -- ^ @n@
+  }
+  deriving (Generic, Show, Validate)
+
+-- | The /support/ of the distribution, all values with positive probability.
+support :: Binomial ev -> Interval (Count ev)
+support d =
+    MinBound 0 `Interval` MaxBound (coerceWith unsafeCoerceCount tosses)
+  where
+    Binomial {
+        tosses
+      } = d
+
+-- | A more precise type for @statistics@'s 'Stats.probability'.
+--
+-- INVARIANT @'pmf' d k = Pr[ X = k | X ~ d ]@
+pmf :: forall k (ev :: k).
+    Binomial ev -> Count ev -> Prob (InRange ev)
+pmf d (Count k) =
+    Prob $ Stats.probability (Stats.binomial n p) k
+  where
+    Binomial {
+        bias
+      , tosses
+      } = d
+
+    Count n = tosses
+    Prob  p = bias
+
+-- | A more precise type for @statistics@'s 'Stats.cumulative'.
+--
+-- INVARIANT @'cdf' d k = Pr[ X <= k | X ~ d ]@
+--
+-- INVARIANT @'unMinBound' q <= 'cdf' d ('unMinBound' $ 'quantile' d q)@
+cdf :: forall k (ev :: k).
+    Binomial ev -> MaxBound (Count ev) -> Prob (InRange ev)
+cdf d (MaxBound (Count k)) =
+    Prob $ Stats.cumulative (Stats.binomial n p) $ fromIntegral k
+  where
+    Binomial {
+        bias
+      , tosses
+      } = d
+
+    Count n = tosses
+    Prob  p = bias
+
+-- | INVARIANT @'unMinBound' q <= 'cdf' d ('unMinBound' $ 'quantile' d q)@
+--
+-- The @statistics@ library only defines @quantile@ for continuous
+-- distributions. We recover it for the (discrete) Binomial distribution from
+-- the monotonic 'cdf' via binary search.
+quantile :: forall k (ev :: k).
+     Binomial ev
+  -> MinBound (Prob (InRange ev))
+  -> MinBound (Count ev)
+quantile d q =
+    MinBound $ fromMaybe (unMaxBound hi) $
+    smallestInInterval interval predicate
+  where
+    Binomial {
+        tosses
+      } = d
+
+    interval :: Interval (Count ev)
+    interval = MinBound 0 `Interval` hi
+
+    hi :: MaxBound (Count ev)
+    hi = MaxBound $ coerceWith unsafeCoerceCount tosses
+
+    -- Upward-closed because cdf is monotonic and @(>= q)@ is upward-closed.
+    predicate :: Count ev -> Bool
+    predicate k = cdf d (MaxBound k) >= unMinBound q
+
+-- | A generalization of 'cdf'.
+--
+-- INVARIANT @'intervalCdf' d ('Interval' ('MinBound' lo) ('MaxBound' hi)) = Pr[ lo <= X <= hi | X ~ d ]@
+--
+-- Both 'cdf' and 'intervalCdf' are definite integrals of the probability mass
+-- function; 'cdf' only considers a lower-bound of 0.
+--
+-- INVARIANT @'cdf' d k = 'intervalCdf' d ('Interval' ('MinBound' 0) ('MaxBound' k))@
+intervalCdf :: forall k (ev :: k).
+     Binomial (ev :: k)
+  -> Interval (Count ev)
+  -> Prob (InRange ev)
+intervalCdf d (Interval lo hi) =
+    lowEnough - tooLow   -- TODO improve numerical stability?
+  where
+    lowEnough :: Prob (InRange ev)
+    lowEnough = cdf d hi
+
+    -- NOTE Underflow prevented by the if-expression.
+    tooLow :: Prob (InRange ev)
+    tooLow =
+        if MinBound 0 == lo then 0 else cdf d $ MaxBound $ unMinBound lo - 1

--- a/quickcheck-randomized/test/Main.hs
+++ b/quickcheck-randomized/test/Main.hs
@@ -1,0 +1,14 @@
+module Main (main) where
+
+import           Test.Tasty
+
+import qualified Test.Test.QuickCheck.Randomized.Coin as Coin
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests =
+  testGroup "Test.QuickCheck.Randomized"
+  [ Coin.tests
+  ]

--- a/quickcheck-randomized/test/Test/Test/QuickCheck/Randomized/Coin.hs
+++ b/quickcheck-randomized/test/Test/Test/QuickCheck/Randomized/Coin.hs
@@ -1,0 +1,12 @@
+module Test.Test.QuickCheck.Randomized.Coin (tests) where
+
+import           Test.Tasty
+
+import qualified Test.Test.QuickCheck.Randomized.Coin.Direct (tests)
+import qualified Test.Test.QuickCheck.Randomized.Coin.Meta (tests)
+
+tests :: TestTree
+tests = testGroup "Coin" $
+    [ Test.Test.QuickCheck.Randomized.Coin.Direct.tests
+    , Test.Test.QuickCheck.Randomized.Coin.Meta.tests
+    ]

--- a/quickcheck-randomized/test/Test/Test/QuickCheck/Randomized/Coin/Common.hs
+++ b/quickcheck-randomized/test/Test/Test/QuickCheck/Randomized/Coin/Common.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+module Test.Test.QuickCheck.Randomized.Coin.Common (
+  withBiasBeyondLeniency,
+  withRule,
+  ) where
+
+import           Test.QuickCheck
+
+import           Test.QuickCheck.Randomized
+import           Test.QuickCheck.Randomized.Coin (Face (..))
+import qualified Test.QuickCheck.Randomized.Coin as Coin
+
+-- | A 'classify' wrapper around 'Coin.withRule'.
+withRule :: Coin.Arguments -> (Coin.Rule -> Property) -> Property
+withRule arguments k =
+    Coin.withRule arguments $ \rule ->
+    classify (Coin.isActuallyTwoSided rule) "two-sided" $
+    k rule
+
+-- | Generate a bias that is /strictly outside/ of the leniency range.
+withBiasBeyondLeniency ::
+     Prob Heads
+  -> Leniency (Prob Heads)
+  -> (Prob Heads -> Property)
+  -> Property
+withBiasBeyondLeniency bias leniency k =
+    withValid (bias, leniency) $
+    counterexample "Degenerate leniency" (0 < lo || hi < 1) .&&.
+    forAll gen k
+  where
+    lo = clipProb $ bias - unLeniency leniency
+    hi = clipProb $ bias + unLeniency leniency
+
+    gen :: Gen (Prob Heads)
+    gen = raw `suchThat` predicate
+
+    raw :: Gen (Prob Heads)
+    raw = Prob <$> oneof [choose (0, unProb lo), choose (unProb hi, 1)]
+
+    predicate :: Prob Heads -> Bool
+    predicate p = p < lo || hi < p

--- a/quickcheck-randomized/test/Test/Test/QuickCheck/Randomized/Coin/Direct.hs
+++ b/quickcheck-randomized/test/Test/Test/QuickCheck/Randomized/Coin/Direct.hs
@@ -1,0 +1,174 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+module Test.Test.QuickCheck.Randomized.Coin.Direct (
+  TestSetup (..),
+  tests,
+  ) where
+
+import           Data.Functor ((<&>))
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Test.QuickCheck.Randomized
+import           Test.QuickCheck.Randomized.Coin (Face (..))
+import qualified Test.QuickCheck.Randomized.Coin as Coin
+import           Test.QuickCheck.Randomized.Distribution.Binomial
+                     (Binomial (..))
+
+import           Test.Test.QuickCheck.Randomized.Coin.Common
+
+tests :: TestTree
+tests = testGroup ""
+    [ testProperty
+        "Direct.sanity check: tuneLeniency worstCase is non-degenerate" $
+      once $
+      case Coin.tuneLeniency <$> worstCase of
+        Just (Coin.OkLeniency leniency) ->
+            leniency === MinBound (Leniency 0.491118)
+        _                               -> property False
+    , askOption $ \(QuickCheckTests n) ->
+      testProperty "correct coin passes" (prop_CorrectCoinPass n)
+    , askOption $ \(QuickCheckTests n) ->
+      testProperty "incorrect coin fails" (prop_IncorrectCoinFail n)
+    ]
+
+{-------------------------------------------------------------------------------
+  Infrastructure
+-------------------------------------------------------------------------------}
+
+data TestSetup = TestSetup {
+    bias   :: !(Prob Heads)
+  , tosses :: !(Count (Trial Face))
+  }
+  deriving (Show)
+
+minTosses :: MinBound (Count (Trial Face))
+minTosses = MinBound 100
+
+maxTosses :: MaxBound (Count (Trial Face))
+maxTosses = MaxBound 10000
+
+instance Arbitrary TestSetup where
+  arbitrary = do
+    bias   <- arbitrary
+    tosses <- chooseInIntegralInterval $ Interval minTosses maxTosses
+    pure $ TestSetup {
+        bias
+      , tosses
+      }
+
+{-------------------------------------------------------------------------------
+  Properties
+-------------------------------------------------------------------------------}
+
+-- | This property applies a very conservative rule to a correct coin and
+-- requires it to always pass.
+prop_CorrectCoinPass :: Int -> TestSetup -> Property
+prop_CorrectCoinPass n testSetup =
+    withRule arguments $ \rule ->
+    Coin.applyRule rule (Coin.fromBias bias)
+  where
+    TestSetup {
+        bias
+      , tosses
+      } = testSetup
+
+    alpha :: MaxBound (Prob FalseFail)
+    alpha = MaxBound $ neverProb (Count n) (Prob 1e-9 :: Prob (Ever FalseFail))
+
+    arguments :: Coin.Arguments
+    arguments = Coin.Arguments {
+        -- aka "one in a billion, even despite so many repetitions per
+        -- invocation of the test suite"
+        alpha
+      , expected = Binomial {
+          bias
+        , tosses
+        }
+      }
+
+-- | This property applies a very conservative rule to a coin with a bias that
+-- is outside of the leniency region and requires it to always fail.
+prop_IncorrectCoinFail :: Int -> TestSetup -> Property
+prop_IncorrectCoinFail n testSetup =
+    ( \prop ->
+        counterexample
+          "sanity check doesn't apply for n>1e6"
+          (n <= 10 ^ (6 :: Int)) .&&.
+        prop
+    ) $
+    withRule arguments $ \rule ->
+    withValid (leniencyArguments rule) $
+    case Coin.tuneLeniency (leniencyArguments rule) of
+      Coin.DegenerateLeniency  ->
+          -- This is impossible because even 'worstCase' induces a leniency of
+          -- @0.491118@. If this test somehow surpasses 'worstCase', then the
+          -- guard atop this 'Property' should fail before this case happens.
+          counterexample
+            ( "Impossible! The " <> show (leniencyArguments rule) <>
+              " induce a degenerate leniency."
+            )
+            False
+      Coin.OkLeniency leniency ->
+          counterexample (show leniency) $
+          withBiasBeyondLeniency bias (unMinBound leniency) $ \bias' ->
+          negateProperty $
+          Coin.applyRule rule (Coin.fromBias bias')
+  where
+    TestSetup {
+        bias
+      , tosses
+      } = testSetup
+
+    -- IE "one in a billion, even despite so many test cases, each testing a
+    -- coin"
+    beta :: MaxBound (Prob FalsePass)
+    beta  = MaxBound $ neverProb (Count n) (Prob 1e-9 :: Prob (Ever FalsePass))
+
+    leniencyArguments rule = Coin.LeniencyArguments {
+        beta
+      , leniencyGrid = Count $ 10 ^ (5 :: Int)
+      , rule
+      }
+
+    arguments :: Coin.Arguments
+    arguments = Coin.Arguments {
+        -- Because we use a coin with a bias beyond the leniency, @alpha@ is
+        -- only relevant to this 'Property' in so much as it affects the size
+        -- of the 'Coin.Rule''s @interval@.
+        alpha    = worstCaseAlpha
+      , expected = Binomial {
+          bias
+        , tosses
+        }
+      }
+
+-- | A reference point used in the design of 'prop_IncorrectCoinFail'.
+worstCaseAlpha :: MaxBound (Prob FalseFail)
+worstCaseAlpha = MaxBound $ neverProb (Count (10 ^ (6 :: Int))) 1e-6
+
+-- | A reference point used in the design of 'prop_IncorrectCoinFail'.
+worstCaseBeta :: MaxBound (Prob FalsePass)
+worstCaseBeta = MaxBound $ neverProb (Count (10 ^ (6 :: Int))) 1e-9
+
+-- | A reference point used in the design of 'prop_IncorrectCoinFail'.
+worstCase :: Maybe Coin.LeniencyArguments
+worstCase =
+    mbRule <&> \rule -> Coin.LeniencyArguments {
+        beta         = worstCaseBeta
+      , leniencyGrid = Count $ 10 ^ (6 :: Int)
+      , rule
+      }
+  where
+    mbRule = Coin.mkRule Coin.Arguments {
+        alpha    = worstCaseAlpha
+      , expected = Binomial {
+          bias   = Prob 0.5   -- fair coin maximizes tuned leniency
+        , tosses = unMinBound minTosses
+        }
+      }

--- a/quickcheck-randomized/test/Test/Test/QuickCheck/Randomized/Coin/Meta.hs
+++ b/quickcheck-randomized/test/Test/Test/QuickCheck/Randomized/Coin/Meta.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+module Test.Test.QuickCheck.Randomized.Coin.Meta (tests) where
+
+import           Data.Type.Coercion (coerceWith)
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+import           Test.QuickCheck.Randomized
+import           Test.QuickCheck.Randomized.Coin (Coin, Face (..))
+import qualified Test.QuickCheck.Randomized.Coin as Coin
+import           Test.QuickCheck.Randomized.Distribution.Binomial
+                     (Binomial (..))
+
+import           Test.Test.QuickCheck.Randomized.Coin.Common
+import           Test.Test.QuickCheck.Randomized.Coin.Direct (TestSetup (..))
+
+tests :: TestTree
+tests = testGroup "" $
+    [ testProperty
+        ( "Meta.sanity check: " <>
+          "tuneLeniency worstCase is within generator's bound"
+        ) $ sanityCheck
+    , adjustOption (min (QuickCheckTests 5)) $
+      askOption $ \(QuickCheckTests n) ->
+      testProperty "rule as a meta coin" (prop_MetaCorrectCoinPass n)
+    ]
+
+{-------------------------------------------------------------------------------
+  Infrastructure
+-------------------------------------------------------------------------------}
+
+-- | A test that treats a rule applied to a coin as another coin itself.
+--
+-- KEY IDEA Define the outer coin's heads as the inner rule failing on a
+-- correct inner coin.
+--
+-- Thus the 'bias' of the outer coin is the inner rule's actual probability of
+-- a 'FalseFail'.
+data MetaTestSetup = MetaTestSetup {
+    innerAlpha     :: !(MaxBound (Prob FalseFail))
+    -- ^ The actual @'Prob' 'FalseFail'@ of the resulting inner rule is the
+    -- bias of the outer coin.
+  , innerTestSetup :: !TestSetup
+  , outerLeniency  :: !(Leniency (Prob Heads))
+  }
+  deriving (Show)
+
+maxTosses :: MaxBound (Count (Trial Face))
+maxTosses = MaxBound 10000
+
+-- | If 'leniency' is this large, then 'worstCase' is guaranteed to be 'Just'.
+minOuterLeniency :: MinBound (Leniency (Prob Coin.Heads))
+minOuterLeniency = MinBound $ Leniency 0.1
+
+instance Arbitrary MetaTestSetup where
+  arbitrary = do
+      innerTestSetup <- arbitrary
+
+      innerAlpha <- (MaxBound . Prob) <$> choose (0.05, 0.95)
+
+      -- This is a reasonable default value. Big enough that we should not
+      -- require so many tosses. Small enough that bugs are unlikely to be this
+      -- subtle.
+      let outerLeniency = unMinBound minOuterLeniency
+
+      pure MetaTestSetup {
+          innerAlpha
+        , innerTestSetup
+        , outerLeniency
+        }
+
+{-------------------------------------------------------------------------------
+  Properties
+-------------------------------------------------------------------------------}
+
+sanityCheck :: Property
+sanityCheck =
+    once $
+    case worstCase of
+      Just leniency ->
+          counterexample (show (leniency, minOuterLeniency)) $
+          leniency <= minOuterLeniency
+      Nothing       -> property False
+
+-- | See 'MetaTestSetup'. This property requires that the bias of the outer
+-- coin is the inner rule's actual probability of @'Prob' 'FalseFail'@.
+prop_MetaCorrectCoinPass :: Int -> MetaTestSetup -> Property
+prop_MetaCorrectCoinPass n testSetup =
+    ( \prop ->
+        counterexample
+          "sanity check doesn't apply for n >1e6"
+          (n < 10 ^ (6 :: Int)) .&&.
+        prop
+    ) $
+    let MetaTestSetup {
+            innerAlpha
+          , innerTestSetup
+          , outerLeniency
+          } = testSetup
+        TestSetup {
+            bias   = innerBias
+          , tosses = innerTosses
+          } = innerTestSetup
+
+        innerCoin :: Coin
+        innerCoin = Coin.fromBias innerBias
+
+        innerArguments :: Coin.Arguments
+        innerArguments = Coin.Arguments {
+            alpha    = innerAlpha
+          , expected = Binomial {
+              bias   = innerBias
+            , tosses = innerTosses
+            }
+          }
+    in
+    withRule innerArguments $ \innerRule ->
+    let -- See KEY IDEA above.
+        outerCoin :: Coin
+        outerCoin =
+            Coin.fromProperty $
+            negateProperty $   -- Heads is FalseFail
+            Coin.applyRule innerRule innerCoin
+
+        outerAlpha :: MaxBound (Prob FalseFail)
+        outerAlpha = mkOuterAlpha n
+
+        outerBeta :: MaxBound (Prob FalsePass)
+        outerBeta = mkOuterBeta n
+
+        -- See KEY IDEA above.
+        outerBias :: Prob Heads
+        outerBias =
+            coerceWith unsafeCoerceProb
+              (Coin.falseFail innerRule :: Prob FalseFail)
+
+        mbOuterTosses :: Coin.TunedTosses
+        mbOuterTosses = Coin.tuneTosses Coin.TossesArguments {
+            alpha     = outerAlpha
+          , beta      = outerBeta
+          , bias      = outerBias
+          , leniency  = outerLeniency
+          , maxTosses
+          }
+    in
+    case mbOuterTosses of
+      Coin.InsufficientMaxTosses                     ->
+          -- The 'MetaTestSetup' 'Arbitrary' instance chooses 'outerLeniency'
+          -- such that we don't need more than 'maxTosses'. If that's not true,
+          -- then the 'worstCase' sanity check would fail.
+          counterexample "InsufficientMaxTosses" False
+      Coin.OkTosses (MinBound outerTosses) outerRule ->
+          tabulate
+            "(totalTosses, innerRule, outerRule)"
+            [show (innerTosses * outerTosses, innerRule, outerRule)] $
+          Coin.applyRule outerRule outerCoin
+
+-- | Used for 'prop_MetaCorrectCoinPass'.
+mkOuterAlpha :: Int -> MaxBound (Prob FalseFail)
+mkOuterAlpha n =
+    MaxBound $ neverProb (Count n) (Prob 1e-9 :: Prob (Ever FalseFail))
+
+-- | Used for 'prop_MetaCorrectCoinPass'.
+mkOuterBeta :: Int -> MaxBound (Prob FalsePass)
+mkOuterBeta n =
+    MaxBound $ neverProb (Count n) (Prob 1e-9 :: Prob (Ever FalsePass))
+
+-- | A reference point used in the design of 'prop_MetaCorrectCoinPass'.
+worstCase :: Maybe (MinBound (Leniency (Prob Coin.Heads)))
+worstCase = do
+    let arguments = Coin.Arguments {
+            alpha    = mkOuterAlpha $ 10 ^ (6 :: Int)
+          , expected = Binomial {
+              bias   = Prob 0.5   -- fair coin maximizes tuned leniency
+            , tosses = unMaxBound maxTosses
+            }
+          }
+    rule <- Coin.mkRule arguments
+
+    let hyper = Coin.tuneLeniency Coin.LeniencyArguments {
+            beta         = mkOuterBeta $ 10 ^ (6 :: Int)
+          , leniencyGrid = Count $ 10 ^ (6 :: Int)
+          , rule
+          }
+    case hyper of
+      Coin.DegenerateLeniency  -> Nothing
+      Coin.OkLeniency leniency -> Just leniency


### PR DESCRIPTION
Adds the `quickcheck-randomized` package. See its test suite for example usage. See the Haddock throughout for further details.

I've opened in Draft form to request comments. Please let me know what you think, and how I can assist your review.

In particular, I think bikeshedding names would now be appropriate.

Possible changes I have in mind for this Draft PR:

  * add a `Tutorial` module. The existing test suite might be enough of a demonstration for some, but maybe not for someone starting from 0% exposure.

  * add examples of testing a non-coin (eg a die) as a coin, though I think it should be pretty simple for someone aware of `Test.QuickCheck.Randomized.Coin.Rule.fromProperty` or `Test.QuickCheck.Randomized.Coin.Rule.fromPropertyLabel` and `Test.QuickCheck.Randomized.Coin.Tune`. (Ultimately a die-ish thing should be tested with a scheme derived from the [Multinomial Test](https://en.wikipedia.org/wiki/Multinomial_test) instead of shoehorning it into the Binomial Test -- that's future work.)

  * simplify the types: these definitions for `Prob_`et al and `Count_` et al emerged as I was struggling to deal conveniently (ie inference behaves nicely, in both directions) with complemented events, despite a closed data kind. With some more consideration now that the interface has stabilized, I think we could simplify these. (This opinion is partially due to me recently realizing these are actually not needed for `intervalCdf`.) However, I think I can also defend the current design (in a context more general than just coins), if that discussion is warranted.

The remaining TODOs are one enhancement and several concerns regarding numerical precision.

```$ git grep -e TODO -- quickcheck-randomized/
quickcheck-randomized/src/Test/QuickCheck/Randomized/Coin/Rule.hs:    -- TODO accumulate labels etc for Tails, to include in counterexample
quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Count.hs:newtype Count_ (pol :: Bool) (ev :: k) = Count {unCount :: Int}   -- TODO Integer?
quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Probability.hs:newtype Prob_ (pol :: Bool) (ev :: k) = Prob {unProb :: Double}   -- TODO Rational? Fixed?
quickcheck-randomized/src/Test/QuickCheck/Randomized/Common/Probability.hs:-- TODO For very small @p@, how different is this from @p / n@?
quickcheck-randomized/src/Test/QuickCheck/Randomized/Distribution/Binomial.hs:    lowEnough - tooLow   -- TODO improve numerical stability?
```