### PR TITLE
db-analyser: clean up

### DIFF
--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -76,7 +76,6 @@ executable db-analyser
                      , cardano-binary
                      , cardano-crypto-wrapper
                      , cardano-ledger
-                     , cardano-slotting
                      , containers
                      , contra-tracer
                      , directory

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
@@ -13,10 +13,8 @@ module Block.Byron (
 
 import           Control.Monad.Except
 import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import           Data.Foldable (asum)
-import           GHC.Natural (Natural)
 import           Options.Applicative
 
 import           Cardano.Binary (Raw, unAnnotated)
@@ -51,8 +49,6 @@ instance HasAnalysis ByronBlock where
       config <- openGenesisByron configFileByron genesisHash requiresNetworkMagic
       return $ mkByronProtocolInfo config threshold
     countTxOutputs = aBlockOrBoundary (const 0) countTxOutputsByron
-    blockHeaderSize = fromIntegral .
-      aBlockOrBoundary blockBoundaryHeaderSize blockHeaderSizeByron
     blockTxSizes = aBlockOrBoundary (const []) blockTxSizesByron
     knownEBBs = const Byron.knownEBBs
 
@@ -107,13 +103,6 @@ countTxOutputsByron Chain.ABlock{..} = countTxPayload bodyTxPayload
 
     countTx :: Chain.Tx -> Int
     countTx = length . Chain.txOutputs
-
-blockBoundaryHeaderSize ::  Chain.ABoundaryBlock ByteString -> Natural
-blockBoundaryHeaderSize =
-    fromIntegral . BS.length . Chain.boundaryHeaderAnnotation . Chain.boundaryHeader
-
-blockHeaderSizeByron ::  Chain.ABlock ByteString -> Natural
-blockHeaderSizeByron = Chain.headerLength . Chain.blockHeader
 
 blockTxSizesByron :: Chain.ABlock ByteString -> [SizeInBytes]
 blockTxSizesByron block =

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -60,9 +60,6 @@ instance HasAnalysis (CardanoBlock StandardCrypto) where
   countTxOutputs blk = case blk of
     Cardano.BlockByron b    -> countTxOutputs b
     Cardano.BlockShelley sh -> countTxOutputs sh
-  blockHeaderSize blk = case blk of
-    Cardano.BlockByron b    -> blockHeaderSize b
-    Cardano.BlockShelley sh -> blockHeaderSize sh
   blockTxSizes blk = case blk of
     Cardano.BlockByron b    -> blockTxSizes b
     Cardano.BlockShelley sh -> blockTxSizes sh

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
@@ -42,8 +42,6 @@ instance HasAnalysis (ShelleyBlock StandardShelley) where
       return $ mkShelleyProtocolInfo config initialNonce
     countTxOutputs blk = case Shelley.shelleyBlockRaw blk of
       SL.Block _ (SL.TxSeq txs) -> sum $ fmap countOutputs txs
-    blockHeaderSize =
-      fromIntegral . SL.bHeaderSize . SL.bheader . Shelley.shelleyBlockRaw
     blockTxSizes blk = case Shelley.shelleyBlockRaw blk of
       SL.Block _ (SL.TxSeq txs) ->
         toList $ fmap (fromIntegral . BL.length . SL.txFullBytes) txs

--- a/ouroboros-consensus-cardano/tools/db-analyser/HasAnalysis.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/HasAnalysis.hs
@@ -19,6 +19,5 @@ class GetPrevHash blk => HasAnalysis blk where
     argsParser      :: proxy blk -> Parser (Args blk)
     mkProtocolInfo  :: Args blk -> IO (ProtocolInfo IO blk)
     countTxOutputs  :: blk -> Int
-    blockHeaderSize :: blk -> SizeInBytes
     blockTxSizes    :: blk -> [SizeInBytes]
     knownEBBs       :: proxy blk -> Map (HeaderHash blk) (ChainHash blk)


### PR DESCRIPTION
* Fix mainnet vs. testnet bug. Classic boolean blindness: in one place the
  `Bool` meant "testnet" and in another "mainnet". Fix it by using
  `RequiresNetworkMagic` instead of `Bool`.

* Pass the initial ledger to the analyses. This opens the door for analyses that
  do block and/or header validation.

* Replace `IORef`s by threading some state around.

* Parameterise `processAll` over `BlockComponent`. Now, for example,
  `showHeaderSize` no longer needs to decode the blocks, it just receives the slot
  number and the header size from the indices.

* Introduce `AnalysisEnv`.

* Drop unused dependency on `cardano-slotting`.