### PR TITLE
Also upgrade to nixpkgs 20.09

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,7 +4,7 @@
 , sourcesOverride ? {}
 }:
 let
-  sources = import ./sources.nix { inherit pkgs; }
+  sources = import ./sources.nix { pkgs = import iohkNixMain.nixpkgs {}; }
     // sourcesOverride;
   iohkNixMain = import sources.iohk-nix {};
   haskellNix = (import sources."haskell.nix" { inherit system sourcesOverride; }).nixpkgsArgs;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -34,5 +34,17 @@
         "type": "tarball",
         "url": "https://github.com/input-output-hk/niv/archive/89da7b2e7ae0779fd351618fc74df1b1da5e6214.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nixpkgs": {
+        "branch": "nixpkgs-20.09-darwin",
+        "description": "Nix Packages collection",
+        "homepage": null,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "07e5844fdf6fe99f41229d7392ce81cfe191bcfc",
+        "sha256": "0p2z6jidm4rlp2yjfl553q234swj1vxl8z0z8ra1hm61lfrlcmb9",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/07e5844fdf6fe99f41229d7392ce81cfe191bcfc.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This should fix this error building ghc (that is currently breaking the eval of #2540):
```
rts/linker/PEi386.c:283:38: error:
     error: '__acrt_iob_func' undeclared here (not in a function); did you mean '__rts_iob_func'?
      283 | const void* __rts_iob_func = (void*)&__acrt_iob_func;
          |                                      ^~~~~~~~~~~~~~~
          |                                      __rts_iob_func
    |
283 | const void* __rts_iob_func = (void*)&__acrt_iob_func;
    |                                      ^
`x86_64-w64-mingw32-cc' failed in phase `C Compiler'. (Exit code: 1)
make[1]: *** [rts/ghc.mk:322: rts/dist/build/linker/PEi386.p_o] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:128: all] Error 2
builder for '/nix/store/b1j1lysc3ccwg7hl9y1shj09799zj7m4-x86_64-w64-mingw32-ghc-8.10.2.drv' failed with exit code 2
```