### PR TITLE
Update to haskell.nix with __acrt_iob_func fix

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "6134e66e1decf2155ba500dd5de00adb06e2cdee",
-        "sha256": "1w6mvlblszl3spx46m3a4bz13xah18gkznzpk0fzkmfizasv7lgi",
+        "rev": "33cd29ee330d34c8c99a9ce56fb3529b44cf3224",
+        "sha256": "1jgwz2iahvn43w398aanm4djzjmr5a2hcv1ijzi9vh79circ7ffz",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/6134e66e1decf2155ba500dd5de00adb06e2cdee.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/33cd29ee330d34c8c99a9ce56fb3529b44cf3224.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {


### PR DESCRIPTION
This will include the patch that was added in
https://github.com/input-output-hk/haskell.nix/pull/870
to fix this issue:

```
remote-iserv.exe:  | /nix/store/kiljkg0bh7kc5cp5a0cqkshnabnfh73c-mingw-w64-6.0.0-x86_64-w64-mingw32/lib/libmingw32.a: unknown symbol `__acrt_iob_func'
remote-iserv.exe:  | /nix/store/kiljkg0bh7kc5cp5a0cqkshnabnfh73c-mingw-w64-6.0.0-x86_64-w64-mingw32/lib/libmingwex.a: unknown symbol `__mingw_raise_matherr'
remote-iserv.exe:  | /nix/store/bkfn9c3pn25n3kf4s1x0bw14v5f0dm1r-x86_64-w64-mingw32-ghc-8.10.2/lib/x86_64-w64-mingw32-ghc-8.10.2/ghc-prim-0.6.1/HSghc-prim-0.6.1.o: unknown symbol `exp'
```