### PR TITLE
Rename RealPBFT/RealTPraos to Byron/Shelley

### DIFF
--- a/.buildkite/slow-ThreadNet-tests.sh
+++ b/.buildkite/slow-ThreadNet-tests.sh
@@ -25,9 +25,9 @@ set -euo pipefail
 rows=(
     # From the slowest individual invocation ...
     '1 Cardano    1500'  # ~70 minutes per invocation
-    '2 RealTPraos 2000'  # ~35 minutes per invocation
-    '8 RealTPraos 400'   # ~13 minutes per invocation
-    '5 Cardano    200'   # ~9  minutes per invocation
+    '2 Shelley    2000'  # ~35 minutes per invocation
+    '8 Shelley     400'  # ~13 minutes per invocation
+    '5 Cardano     200'  # ~9  minutes per invocation
     # ... to fastest individual invocation
     #
     # And the number of invocations is non-decreasing.

--- a/default.nix
+++ b/default.nix
@@ -52,8 +52,8 @@ let
       gnuparallel = pkgs.parallel;
       glibcLocales = pkgs.glibcLocales;
 
-      Cardano    = haskellPackages.ouroboros-consensus-cardano-test.components.tests.test;
-      RealTPraos = haskellPackages.ouroboros-consensus-shelley-test.components.tests.test;
+      Cardano = haskellPackages.ouroboros-consensus-cardano-test.components.tests.test;
+      Shelley = haskellPackages.ouroboros-consensus-shelley-test.components.tests.test;
     };
 
     shell = import ./shell.nix {

--- a/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
+++ b/ouroboros-consensus-byron-test/ouroboros-consensus-byron-test.cabal
@@ -74,8 +74,8 @@ test-suite test
   other-modules:
                        Test.Consensus.Byron.Golden
                        Test.Consensus.Byron.Serialisation
-                       Test.ThreadNet.DualPBFT
-                       Test.ThreadNet.RealPBFT
+                       Test.ThreadNet.Byron
+                       Test.ThreadNet.DualByron
 
   build-depends:       base
                      , binary-search

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Ledger.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Ledger.hs
@@ -105,7 +105,7 @@ specToImplTx spec impl = SpecToImplIds $ Spec.Test.AbstractToConcreteIdMaps {
 -- The relation between the Byron implementation and specification for the
 -- /linear/ case is tested in the Byron implementation itself, specifically
 -- in 'ts_prop_generatedChainsAreValidated'. The main goal of the consensus
--- DualPBFT tests is to lift these tests to the general consensus setting,
+-- DualByron tests is to lift these tests to the general consensus setting,
 -- where time is not linear but branching.
 --
 -- In the linear case, the tests maintain some state linking the spec and

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/Genesis.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/Genesis.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Test.ThreadNet.Infra.Byron.Genesis (
-    realPBftParams
+    byronPBftParams
   , generateGenesisConfig
   ) where
 
@@ -26,8 +26,8 @@ import           Test.Util.Time
   Generating the genesis configuration
 -------------------------------------------------------------------------------}
 
-realPBftParams :: SecurityParam -> NumCoreNodes -> PBftParams
-realPBftParams paramK numCoreNodes = PBftParams
+byronPBftParams :: SecurityParam -> NumCoreNodes -> PBftParams
+byronPBftParams paramK numCoreNodes = PBftParams
   { pbftNumNodes           = numCoreNodes
   , pbftSecurityParam      = paramK
   , pbftSignatureThreshold = PBftSignatureThreshold $ (1 / n) + (1 / k) + epsilon

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
@@ -5,7 +5,7 @@
 module Test.ThreadNet.Infra.Byron.ProtocolInfo (
   theProposedProtocolVersion,
   theProposedSoftwareVersion,
-  mkProtocolRealPBFT,
+  mkProtocolByron,
   mkLeaderCredentials,
   ) where
 
@@ -30,7 +30,7 @@ import           Ouroboros.Consensus.Byron.Crypto.DSIGN (ByronDSIGN,
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import           Ouroboros.Consensus.Byron.Node
 
-mkProtocolRealPBFT ::
+mkProtocolByron ::
      forall m. (Monad m, HasCallStack)
   => PBftParams
   -> CoreNodeId
@@ -39,7 +39,7 @@ mkProtocolRealPBFT ::
   -> (ProtocolInfo m ByronBlock, SignKeyDSIGN ByronDSIGN)
      -- ^ We return the signing key which is needed in some tests, because it
      -- cannot easily be extracted from the 'ProtocolInfo'.
-mkProtocolRealPBFT params coreNodeId genesisConfig genesisSecrets =
+mkProtocolByron params coreNodeId genesisConfig genesisSecrets =
     (protocolInfo, signingKey)
   where
     leaderCredentials :: ByronLeaderCredentials
@@ -99,7 +99,7 @@ mkLeaderCredentials genesisConfig genesisSecrets (CoreNodeId i) =
 --
 -- This value occurs in two crucial places: the proposal and also the
 -- 'Byron.byronProtocolVersion' field of the static node config. See the
--- Haddock comment on 'mkProtocolRealPBftAndHardForkTxs'.
+-- Haddock comment on 'mkProtocolByronAndHardForkTxs'.
 --
 theProposedProtocolVersion :: Update.ProtocolVersion
 theProposedProtocolVersion = Update.ProtocolVersion 1 0 0

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.ThreadNet.Infra.Byron.TrackUpdates (
-  mkProtocolRealPBftAndHardForkTxs,
+  mkProtocolByronAndHardForkTxs,
   ProtocolVersionUpdateLabel (..),
   SoftwareVersionUpdateLabel (..),
   mkUpdateLabels,
@@ -366,7 +366,7 @@ data ProposalState =
 --    mitigating circumstances, such as the test not even being scheduled to
 --    reach the second epoch.
 --
-mkProtocolRealPBftAndHardForkTxs
+mkProtocolByronAndHardForkTxs
   :: forall m. (Monad m, HasCallStack)
   => PBftParams
   -> CoreNodeId
@@ -375,7 +375,7 @@ mkProtocolRealPBftAndHardForkTxs
   -> Update.ProtocolVersion
      -- ^ the protocol version that triggers the hard fork
   -> TestNodeInitialization m ByronBlock
-mkProtocolRealPBftAndHardForkTxs
+mkProtocolByronAndHardForkTxs
   params cid genesisConfig genesisSecrets propPV =
     TestNodeInitialization
       { tniCrucialTxs   = proposals ++ votes
@@ -388,7 +388,7 @@ mkProtocolRealPBftAndHardForkTxs
     pInfo :: ProtocolInfo m ByronBlock
     opKey :: Crypto.SigningKey
     (pInfo, Crypto.SignKeyByronDSIGN opKey) =
-        mkProtocolRealPBFT params cid genesisConfig genesisSecrets
+        mkProtocolByron params cid genesisConfig genesisSecrets
 
     proposals :: [Byron.GenTx ByronBlock]
     proposals =
@@ -440,7 +440,7 @@ mkHardForkProposal params genesisConfig genesisSecrets propPV =
     pInfo :: ProtocolInfo Identity ByronBlock
     opKey :: Crypto.SigningKey
     (pInfo, Crypto.SignKeyByronDSIGN opKey) =
-        mkProtocolRealPBFT params (CoreNodeId 0) genesisConfig genesisSecrets
+        mkProtocolByron params (CoreNodeId 0) genesisConfig genesisSecrets
 
     ProtocolInfo{pInfoConfig} = pInfo
     bcfg = configBlock pInfoConfig

--- a/ouroboros-consensus-byron-test/test/Main.hs
+++ b/ouroboros-consensus-byron-test/test/Main.hs
@@ -4,8 +4,8 @@ import           Test.Tasty
 
 import qualified Test.Consensus.Byron.Golden (tests)
 import qualified Test.Consensus.Byron.Serialisation (tests)
-import qualified Test.ThreadNet.DualPBFT (tests)
-import qualified Test.ThreadNet.RealPBFT (tests)
+import qualified Test.ThreadNet.Byron (tests)
+import qualified Test.ThreadNet.DualByron (tests)
 
 main :: IO ()
 main = defaultMain tests
@@ -15,6 +15,6 @@ tests =
   testGroup "byron"
   [ Test.Consensus.Byron.Golden.tests
   , Test.Consensus.Byron.Serialisation.tests
-  , Test.ThreadNet.RealPBFT.tests
-  , Test.ThreadNet.DualPBFT.tests
+  , Test.ThreadNet.Byron.tests
+  , Test.ThreadNet.DualByron.tests
   ]

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
@@ -480,7 +480,7 @@ prop_simple_cardano_convergence TestSetup
     -- Byron
 
     pbftParams :: PBftParams
-    pbftParams = Byron.realPBftParams setupK numCoreNodes
+    pbftParams = Byron.byronPBftParams setupK numCoreNodes
 
     -- the Byron ledger is designed to use a fixed epoch size, so this test
     -- does not randomize it
@@ -729,11 +729,11 @@ mkProtocolCardanoAndHardForkTxs
     crucialTxs =
         GenTxByron <$> tniCrucialTxs tniByron
       where
-        -- reuse the RealPBft logic for generating the crucial txs, ie the
+        -- reuse the Byron logic for generating the crucial txs, ie the
         -- proposal and votes
         tniByron :: TestNodeInitialization m ByronBlock
         tniByron =
-            Byron.mkProtocolRealPBftAndHardForkTxs
+            Byron.mkProtocolByronAndHardForkTxs
               pbftParams
               coreNodeId
               genesisByron

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -71,7 +71,7 @@ test-suite test
   other-modules:
                        Test.Consensus.Shelley.Golden
                        Test.Consensus.Shelley.Serialisation
-                       Test.ThreadNet.RealTPraos
+                       Test.ThreadNet.Shelley
 
   build-depends:       base
                      , bytestring

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -25,7 +25,7 @@ module Test.ThreadNet.Infra.Shelley (
   , mkKeyHash
   , mkKeyHashVrf
   , mkLeaderCredentials
-  , mkProtocolRealTPraos
+  , mkProtocolShelley
   , mkSetDecentralizationParamTxs
   , mkVerKey
   , networkId
@@ -380,14 +380,14 @@ mkGenesisConfig pVer k f d slotLength kesCfg coreNodes =
             , let vrfHash = SL.hashVerKeyVRF $ deriveVerKeyVRF cnVRF
             ]
 
-mkProtocolRealTPraos
+mkProtocolShelley
   :: forall m c. (IOLike m, TPraosCrypto (ShelleyEra c))
   => ShelleyGenesis (ShelleyEra c)
   -> SL.Nonce
   -> ProtVer
   -> CoreNode (ShelleyEra c)
   -> ProtocolInfo m (ShelleyBlock (ShelleyEra c))
-mkProtocolRealTPraos genesis initialNonce protVer coreNode =
+mkProtocolShelley genesis initialNonce protVer coreNode =
     protocolInfoShelley $ ProtocolParamsShelley {
         shelleyGenesis           = genesis
       , shelleyInitialNonce      = initialNonce

--- a/ouroboros-consensus-shelley-test/test/Main.hs
+++ b/ouroboros-consensus-shelley-test/test/Main.hs
@@ -7,7 +7,7 @@ import           Test.Util.Nightly
 
 import qualified Test.Consensus.Shelley.Golden (tests)
 import qualified Test.Consensus.Shelley.Serialisation (tests)
-import qualified Test.ThreadNet.RealTPraos (tests)
+import qualified Test.ThreadNet.Shelley (tests)
 
 main :: IO ()
 main = sodiumInit >> defaultMainWithIohkNightly tests
@@ -17,5 +17,5 @@ tests =
   testGroup "shelley"
   [ Test.Consensus.Shelley.Golden.tests
   , Test.Consensus.Shelley.Serialisation.tests
-  , Test.ThreadNet.RealTPraos.tests
+  , Test.ThreadNet.Shelley.tests
   ]

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/Shelley.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Test.ThreadNet.RealTPraos (tests) where
+module Test.ThreadNet.Shelley (tests) where
 
 import           Control.Monad (replicateM)
 import qualified Data.Map.Strict as Map
@@ -154,7 +154,7 @@ fifthTestCount (QuickCheckTests n) = QuickCheckTests $
     max 1 $ n `div` 5
 
 tests :: TestTree
-tests = testGroup "RealTPraos ThreadNet"
+tests = testGroup "Shelley ThreadNet"
     [ let name = "simple convergence" in
       askIohkNightlyEnabled $ \enabled ->
       if enabled
@@ -260,7 +260,7 @@ prop_simple_real_tpraos_convergence TestSetup
             { nodeInfo = \(CoreNodeId nid) ->
                 TestNodeInitialization
                   { tniProtocolInfo =
-                      mkProtocolRealTPraos
+                      mkProtocolShelley
                         genesisConfig
                         setupInitialNonce
                         nextProtVer

--- a/ouroboros-consensus-test/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/General.hs
@@ -403,7 +403,7 @@ noExpectedCannotForges _ _ _ = False
 -- multiple longest chains; see the PBFT reference simulator
 -- "Test.ThreadNet.Ref.PBFT".
 --
--- Specific tests make additional assumptions, eg the @RealPBFT@ tests make
+-- Specific tests make additional assumptions, eg the @Byron@ tests make
 -- assumptions about delegation certificates, update proposals, etc.
 prop_general ::
   forall blk.


### PR DESCRIPTION
The name `RealPBFT` was chosen because we were testing the protocol of Byron,
i.e., PBFT, and there already was a test for a mock block using the
PBFT protocol (`MockPBFT`).

For Shelley, we tried to remain consistent and picked `RealTPraos`, even though
there was no `MockTPraos` yet. Currently, we don't expect to ever introduce
`MockTPraos`.

In the end, these tests evolved so much that they have become tests of the
block, not just of the protocol. The existence of the Cardano ThreadNet, which
combines multiple eras and thus protocols into one test, illustrates this
nicely. So renaming `RealPBFT` to `Byron` now seems the right thing to do.

Similarly for `RealTPraos` and `Shelley`. Note that the upcoming eras, Allegra,
Mary, Goguen, ..., will all use the same `RealTPraos` protocol as Shelley. The
current `RealTPraos` tests are specific to the Shelley era, so the `RealTPraos`
name will be misleading. If we rename it to `Shelley`, we can later add
`Allegra` and `Mary`, if desired. Alternatively, if we later generalise the
`Shelley` tests to work with any Shelley-based era, we can rename it (or the
common infrastructure) to `ShelleyBased`.