### PR TITLE
Handshake Improvements.

### DIFF
--- a/ouroboros-network-framework/demo/ping-pong.hs
+++ b/ouroboros-network-framework/demo/ping-pong.hs
@@ -111,6 +111,7 @@ clientPingPong pipelined =
       unversionedHandshakeCodec
       cborTermVersionDataCodec
       nullNetworkConnectTracers
+      (\DictVersion {} -> acceptableVersion)
       (unversionedProtocol app)
       Nothing
       defaultLocalSocketAddr
@@ -206,6 +207,7 @@ clientPingPong2 =
       unversionedHandshakeCodec
       cborTermVersionDataCodec
       nullNetworkConnectTracers
+      (\DictVersion {} -> acceptableVersion)
       (unversionedProtocol app)
       Nothing
       defaultLocalSocketAddr

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
@@ -108,11 +108,13 @@ runHandshakeClient
        )
     => MuxBearer m
     -> connectionId
+    -> (forall vData. extra vData -> vData -> vData -> Accept vData)
     -> HandshakeArguments connectionId vNumber extra m application agreedOptions
     -> m (Either (HandshakeException (HandshakeClientProtocolError vNumber))
                  (application, agreedOptions))
 runHandshakeClient bearer
                    connectionId
+                   acceptVersion
                    HandshakeArguments {
                      haHandshakeTracer,
                      haHandshakeCodec,
@@ -127,7 +129,7 @@ runHandshakeClient bearer
           byteLimitsHandshake
           timeLimitsHandshake
           (fromChannel (muxBearerAsChannel bearer handshakeProtocolNum InitiatorDir))
-          (handshakeClientPeer haVersionDataCodec haVersions))
+          (handshakeClientPeer haVersionDataCodec acceptVersion haVersions))
 
 
 -- | Run server side of the 'Handshake' protocol.
@@ -143,7 +145,7 @@ runHandshakeServer
        )
     => MuxBearer m
     -> connectionId
-    -> (forall vData. extra vData -> vData -> vData -> Accept)
+    -> (forall vData. extra vData -> vData -> vData -> Accept vData)
     -> HandshakeArguments connectionId vNumber extra m application agreedOptions
     -> m (Either
            (HandshakeException (RefuseReason vNumber))

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Server.hs
@@ -26,7 +26,7 @@ import           Ouroboros.Network.Protocol.Handshake.Version
 handshakeServerPeer
   :: Ord vNumber
   => VersionDataCodec extra vParams vNumber agreedOptions
-  -> (forall vData. extra vData -> vData -> vData -> Accept)
+  -> (forall vData. extra vData -> vData -> vData -> Accept vData)
   -> Versions vNumber extra r
   -> Peer (Handshake vNumber vParams)
           AsServer StPropose m
@@ -61,12 +61,12 @@ handshakeServerPeer VersionDataCodec {encodeData, decodeData, getAgreedOptions} 
                     -- We agree on the version; send back the agreed version
                     -- number @vNumber@ and encoded data associated with our
                     -- version.
-                    Accept ->
+                    Accept agreedData ->
                       Yield (ServerAgency TokConfirm)
-                            (MsgAcceptVersion vNumber (encodeData (versionExtra version) vData))
+                            (MsgAcceptVersion vNumber (encodeData (versionExtra version) agreedData))
                             (Done TokDone $ Right $
-                              ( runApplication (versionApplication version) vData vData'
-                              , getAgreedOptions (versionExtra version) vNumber vData'
+                              ( runApplication (versionApplication version) agreedData
+                              , getAgreedOptions (versionExtra version) vNumber agreedData
                               ))
 
                     -- We disagree on the version.

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Type.hs
@@ -127,6 +127,7 @@ instance Show (ServerHasAgency (st :: Handshake vNumber vParams)) where
 data HandshakeClientProtocolError vNumber
   = HandshakeError (RefuseReason vNumber)
   | NotRecognisedVersion vNumber
+  | InvalidServerSelection vNumber Text
   deriving (Eq, Show)
 
 instance (Typeable vNumber, Show vNumber)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Unversioned.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Unversioned.hs
@@ -40,7 +40,7 @@ data UnversionedProtocolData = UnversionedProtocolData
 
 instance Acceptable UnversionedProtocolData where
   acceptableVersion UnversionedProtocolData
-                    UnversionedProtocolData = Accept
+                    UnversionedProtocolData = Accept UnversionedProtocolData
 
 
 unversionedProtocolDataCodec :: CodecCBORTerm Text UnversionedProtocolData

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
@@ -255,6 +255,7 @@ prop_socket_send_recv initiatorAddr responderAddr f xs =
             unversionedHandshakeCodec
             cborTermVersionDataCodec
             (NetworkConnectTracers activeMuxTracer nullTracer)
+            (\DictVersion {} -> acceptableVersion)
             (unversionedProtocol initiatorApp)
             (Just initiatorAddr)
             responderAddr
@@ -489,6 +490,7 @@ prop_socket_client_connect_error _ xs =
         unversionedHandshakeCodec
         cborTermVersionDataCodec
         nullNetworkConnectTracers
+        (\DictVersion {} -> acceptableVersion)
         (unversionedProtocol app)
         (Just $ Socket.addrAddress clientAddr)
         (Socket.addrAddress serverAddr)

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Subscription.hs
@@ -612,6 +612,7 @@ prop_send_recv f xs _first = ioProperty $ withIOManager $ \iocp -> do
                 unversionedHandshakeCodec
                 cborTermVersionDataCodec
                 nullNetworkConnectTracers
+                (\DictVersion {} -> acceptableVersion)
                 (unversionedProtocol initiatorApp))
 
     res <- atomically $ (,) <$> takeTMVar sv <*> takeTMVar cv
@@ -776,6 +777,7 @@ prop_send_recv_init_and_rsp f xs = ioProperty $ withIOManager $ \iocp -> do
                   unversionedHandshakeCodec
                   cborTermVersionDataCodec
                   nullNetworkConnectTracers
+                  (\DictVersion {} -> acceptableVersion)
                   (unversionedProtocol (appX rrcfg)))
 
             atomically $ (,) <$> takeTMVar (rrcServerVar rrcfg)
@@ -847,6 +849,7 @@ _demo = ioProperty $ withIOManager $ \iocp -> do
                 unversionedHandshakeCodec
                 cborTermVersionDataCodec
                 nullNetworkConnectTracers
+                (\DictVersion {} -> acceptableVersion)
                 (unversionedProtocol appReq))
 
     threadDelay 130

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -158,6 +158,7 @@ clientChainSync sockPaths = withIOManager $ \iocp ->
         unversionedHandshakeCodec
         cborTermVersionDataCodec
         nullNetworkConnectTracers
+        (\DictVersion {} -> acceptableVersion)
         (simpleSingletonVersions
            UnversionedProtocol
            UnversionedProtocolData
@@ -365,6 +366,7 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
                           unversionedHandshakeCodec
                           cborTermVersionDataCodec
                           nullNetworkConnectTracers
+                          (\DictVersion {} -> acceptableVersion)
                           (simpleSingletonVersions
                             UnversionedProtocol
                             UnversionedProtocolData

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Direct.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/Handshake/Direct.hs
@@ -35,9 +35,9 @@ pureHandshake isTypeable acceptVersion (Versions serverVersions) (Versions clien
                         (Dict, Dict) -> case (cast vData, cast vData') of
                           (Just d, Just d') ->
                             ( if acceptVersion (versionExtra version) vData d'
-                                then Just $ runApplication (versionApplication version) vData d'
+                                then Just $ runApplication (versionApplication version) d'
                                 else Nothing
 
-                            , Just $ runApplication (versionApplication version') vData' d
+                            , Just $ runApplication (versionApplication version') d
                             )
                           _ -> (Nothing, Nothing)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -250,6 +250,7 @@ connectTo snocket tracers versions path =
                   nodeToClientHandshakeCodec
                   cborTermVersionDataCodec
                   tracers
+                  (\DictVersion {} -> acceptableVersion)
                   versions
                   Nothing
                   (localAddressFromPath path)
@@ -459,6 +460,7 @@ ncSubscriptionWorker
           nodeToClientHandshakeCodec
           cborTermVersionDataCodec
           (NetworkConnectTracers nsMuxTracer nsHandshakeTracer)
+          (\DictVersion {} -> acceptableVersion)
           versions)
 
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -73,7 +73,7 @@ newtype NodeToClientVersionData = NodeToClientVersionData
 instance Acceptable NodeToClientVersionData where
     acceptableVersion local remote
       | local == remote
-      = Accept
+      = Accept local
       | otherwise =  Refuse $ T.pack $ "version data mismatch: "
                                     ++ show local
                                     ++ " /= " ++ show remote

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -389,8 +389,8 @@ connectTo
   -> Maybe Socket.SockAddr
   -> Socket.SockAddr
   -> IO ()
-connectTo sn =
-    connectToNode sn nodeToNodeHandshakeCodec cborTermVersionDataCodec
+connectTo sn tr =
+    connectToNode sn nodeToNodeHandshakeCodec cborTermVersionDataCodec tr (\DictVersion {} -> acceptableVersion)
 
 
 -- | Like 'connectTo' but specific to 'NodeToNodeV_1'.
@@ -508,6 +508,7 @@ ipSubscriptionWorker
           nodeToNodeHandshakeCodec
           cborTermVersionDataCodec
           (NetworkConnectTracers nsMuxTracer nsHandshakeTracer)
+          (\DictVersion {} -> acceptableVersion)
           versions)
 
 
@@ -581,6 +582,7 @@ dnsSubscriptionWorker
         nodeToNodeHandshakeCodec
         cborTermVersionDataCodec
         (NetworkConnectTracers ndstMuxTracer ndstHandshakeTracer)
+        (\DictVersion {} -> acceptableVersion)
         versions)
 
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -88,8 +88,10 @@ data NodeToNodeVersionData = NodeToNodeVersionData
 
 instance Acceptable NodeToNodeVersionData where
     acceptableVersion local remote
+      | networkMagic local == networkMagic remote && diffusionMode remote == InitiatorOnlyDiffusionMode
+      = Accept remote
       | networkMagic local == networkMagic remote
-      = Accept
+      = Accept local
       | otherwise
       = Refuse $ T.pack $ "version data mismatch: "
                        ++ show local

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -174,6 +174,7 @@ demo chain0 updates = withIOManager $ \iocp -> do
           nodeToNodeHandshakeCodec
           cborTermVersionDataCodec
           nullNetworkConnectTracers
+          (\DictVersion {} -> acceptableVersion)
           (simpleSingletonVersions
             NodeToNodeV_1
             (NodeToNodeVersionData {


### PR DESCRIPTION
Change acceptableVersion so that it also returns the "acceptable" data
agreed upon by the client and server.
Update the client so that it checks that response is acceptable.
Change runApplication to take the result of the version negotiation
instead of a local and remote version of protocol options.