### PR TITLE
ledger state query to return everything possible

### DIFF
--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -73,7 +73,7 @@ instance CanMock era => Arbitrary (SomeBlock Query (ShelleyBlock era)) where
     , pure $ SomeBlock GetCurrentPParams
     , pure $ SomeBlock GetProposedPParamsUpdates
     , pure $ SomeBlock GetStakeDistribution
-    , pure $ SomeBlock GetCurrentEpochState
+    , pure $ SomeBlock GetCurrentShelleyState
     , (\(SomeBlock q) -> SomeBlock (GetCBOR q)) <$> arbitrary
     , SomeBlock . GetFilteredDelegationsAndRewardAccounts <$> arbitrary
     ]
@@ -86,7 +86,7 @@ instance CanMock era => Arbitrary (SomeResult (ShelleyBlock era)) where
     , SomeResult GetCurrentPParams <$> genPParams (Proxy @era)
     , SomeResult GetProposedPParamsUpdates <$> arbitrary
     , SomeResult GetStakeDistribution <$> arbitrary
-    , SomeResult GetCurrentEpochState <$> arbitrary
+    , SomeResult GetCurrentShelleyState <$> arbitrary
     , (\(SomeResult q r) ->
         SomeResult (GetCBOR q) (mkSerialised (encodeShelleyResult q) r)) <$>
       arbitrary


### PR DESCRIPTION
This (draft) PR extends the data returned by the ledger state query so that it returns the entire `ShelleyState`.

On the downside, it makes an already big state dump even bigger. It adds three maps approximately the size of the number of registered stake pools, and a map that is approximately the size of the number of registered stake credentials. On the upside, it will let us debug some things where we are currently in the dark. In particular, we'll be able to see the block counts, the pool distribution, and the reward update.

thoughts?