### PR TITLE
Cardano: write some generators generically

### DIFF
--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -267,11 +267,14 @@ instance Arbitrary ByronTransition where
 instance Arbitrary (LedgerState ByronBlock) where
   arbitrary = ByronLedgerState <$> arbitrary <*> arbitrary <*> arbitrary
 
+instance Arbitrary (TipInfoIsEBB ByronBlock) where
+  arbitrary = TipInfoIsEBB <$> arbitrary <*> elements [IsEBB, IsNotEBB]
+
 instance Arbitrary (AnnTip ByronBlock) where
   arbitrary = AnnTip
     <$> arbitrary
     <*> (BlockNo <$> arbitrary)
-    <*> (TipInfoIsEBB <$> arbitrary <*> elements [IsEBB, IsNotEBB])
+    <*> arbitrary
 
 instance Arbitrary (PBftState PBftByronCrypto) where
   arbitrary = do

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -97,6 +97,7 @@ library
                      , quiet             >=0.2   && <0.3
                      , random
                      , serialise         >=0.2   && <0.3
+                     , sop-core
                      , tasty
                      , tasty-golden
                      , tasty-hunit


### PR DESCRIPTION
The Cardano generators are currently mostly written by enumerating all eras.
This approach doesn't scale as the number of eras will keep growing.

To improve this, add `Arbitrary` instances for a few era-generic types, e.g.,
`NS`, `Telescope`, ..., and use those.

There are still a bunch of generators that will need a similar treatment.
Related issue: #2368.