### PR TITLE
fixing github actions

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -70,7 +70,7 @@ jobs:
           cp -r ./haddocks/* ./
           rm -rf haddocks
           git add -A
-          git commit -m "Deployed haddocks" --alow-empty
+          git commit -m "Deployed haddocks" || true
           git push https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git HEAD:gh-pages
 
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Install GHC
         run: |
           choco install -y ghc --version 8.10.2 --allow-downgrade
-      - name: Fix GHC-8.10.2 installation
-        run: |
-          (Get-Content "C:\ProgramData\chocolatey\lib\ghc.8.10.2\tools\ghc-8.10.2\lib\settings") -replace('\("Merge objects command", .*\)', '("Merge objects command", "C:/ProgramData/chocolatey/lib/ghc.8.10.2/tools/ghc-8.10.2/mingw/bin/ld.exe")') | Out-File -FilePath "C:\ProgramData\chocolatey\lib\ghc.8.10.2\tools\ghc-8.10.2\lib\settings"
       - name: Print version
         run: |
           cabal --version

--- a/cabal.project.local.ci.windows
+++ b/cabal.project.local.ci.windows
@@ -1,4 +1,4 @@
-with-compiler: C:\\ProgramData\\chocolatey\\lib\\ghc.8.10.2\\tools\\ghc-8.10.2\\bin\\ghc
+with-compiler: C:\\ProgramData\\chocolatey\\lib\\ghc\\tools\\ghc-8.10.2\\bin\\ghc
 tests: True
 
 max-backjumps: 5000


### PR DESCRIPTION
Two gh workflow fixes:
* documentation, which I am not sure if it will fix the issue.
* windows CI; it seems `chocolatey` fixed `8.10.2` issue by themselves, `ghc` installation path has also changed.