### PR TITLE
Add map functions for the node-to-client protocol Client types

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Client.hs
@@ -126,8 +126,9 @@ data ClientStIntersect header tip m a =
 -- | Transform a 'ChainSyncClient' by mapping over the tx header and the
 -- chain tip values.
 --
--- Note the mapping is contravariant in both types since they are outputs of
--- the protocol, not inputs.
+-- Note the direction of the individual mapping functions corresponds to
+-- whether the types are used as protocol inputs or outputs (or both, as is
+-- the case for points).
 --
 mapChainSyncClient :: forall header header' tip tip' m a.
                       Functor m

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
@@ -98,11 +98,11 @@ data ClientStQuerying block query m a result = ClientStQuerying {
       recvMsgResult :: result -> m (ClientStAcquired block query m a)
     }
 
--- | Transform a 'LocalStateQueryClient' by mapping over the tx header and the
--- chain tip values.
+-- | Transform a 'LocalStateQueryClient' by mapping over the query and query
+-- result values.
 --
--- Note the mapping is contravariant in both types since they are outputs of
--- the protocol, not inputs.
+-- Note the direction of the individual mapping functions corresponds to
+-- whether the types are used as protocol inputs or outputs.
 --
 mapLocalStateQueryClient :: forall block block' query query' m a.
                             Functor m

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+
 module Ouroboros.Network.Protocol.LocalStateQuery.Client (
       -- * Protocol type for the client
       -- | The protocol states from the point of view of the client.
@@ -17,6 +19,9 @@ module Ouroboros.Network.Protocol.LocalStateQuery.Client (
 
       -- * Null local state query client
     , localStateQueryClientNull
+
+      -- * Utilities
+    , mapLocalStateQueryClient
     ) where
 
 import           Control.Monad (forever)
@@ -92,6 +97,62 @@ data ClientStAcquired block query m a where
 data ClientStQuerying block query m a result = ClientStQuerying {
       recvMsgResult :: result -> m (ClientStAcquired block query m a)
     }
+
+-- | Transform a 'LocalStateQueryClient' by mapping over the tx header and the
+-- chain tip values.
+--
+-- Note the mapping is contravariant in both types since they are outputs of
+-- the protocol, not inputs.
+--
+mapLocalStateQueryClient :: forall block block' query query' m a.
+                            Functor m
+                         => (Point block -> Point block')
+                         -> (forall result result'. query result -> query' result')
+                         -> (forall result result'.
+                                    query result
+                                 -> query' result'
+                                 -> result' -> result)
+                         -> LocalStateQueryClient block  query  m a
+                         -> LocalStateQueryClient block' query' m a
+mapLocalStateQueryClient fpoint fquery fresult =
+    \(LocalStateQueryClient c) -> LocalStateQueryClient (fmap goIdle c)
+  where
+    goIdle :: ClientStIdle block  query  m a
+           -> ClientStIdle block' query' m a
+    goIdle (SendMsgAcquire pt k) =
+      SendMsgAcquire (fpoint pt) (goAcquiring k)
+
+    goIdle (SendMsgDone a) = SendMsgDone a
+
+    goAcquiring :: ClientStAcquiring block  query  m a
+                -> ClientStAcquiring block' query' m a
+    goAcquiring ClientStAcquiring { recvMsgAcquired, recvMsgFailure } =
+      ClientStAcquiring {
+        recvMsgAcquired = goAcquired recvMsgAcquired,
+        recvMsgFailure  = \failure -> fmap goIdle (recvMsgFailure failure)
+      }
+
+    goAcquired :: ClientStAcquired block  query  m a
+               -> ClientStAcquired block' query' m a
+    goAcquired (SendMsgQuery     q  k) = SendMsgQuery q' (goQuerying q q' k)
+                                           where
+                                             q' = fquery q
+    goAcquired (SendMsgReAcquire pt k) = SendMsgReAcquire (fpoint pt) (goAcquiring k)
+    goAcquired (SendMsgRelease      k) = SendMsgRelease (fmap goIdle k)
+
+    goQuerying :: forall result result'.
+                  query  result
+               -> query' result'
+               -> ClientStQuerying block  query  m a result
+               -> ClientStQuerying block' query' m a result'
+    goQuerying q q' ClientStQuerying {recvMsgResult} =
+      ClientStQuerying {
+        recvMsgResult = \result' ->
+          let result :: result
+              result = fresult q q' result' in
+          fmap goAcquired (recvMsgResult result)
+      }
+
 
 -- | Interpret a 'LocalStateQueryClient' action sequence as a 'Peer' on the
 -- client side of the 'LocalStateQuery' protocol.

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Client.hs
@@ -81,8 +81,8 @@ data LocalTxClientStIdle tx reject m a where
 -- | Transform a 'LocalTxSubmissionClient' by mapping over the tx and the
 -- rejection errors.
 --
--- Note the mapping of the errors is contravariant since errors are an output
--- of the protocol, not an input.
+-- Note the direction of the individual mapping functions corresponds to
+-- whether the types are used as protocol inputs or outputs.
 --
 mapLocalTxSubmissionClient :: forall tx tx' reject reject' m a.
                               Functor m

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalTxSubmission/Type.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE DeriveFunctor       #-}
+
 
 -- | The type of the local transaction submission protocol.
 --
@@ -64,7 +66,7 @@ instance ( ShowProxy tx
 data SubmitResult reason
   = SubmitSuccess
   | SubmitFail reason
-  deriving Eq
+  deriving (Eq, Functor)
 
 instance Protocol (LocalTxSubmission tx reject) where
 


### PR DESCRIPTION
That is, for the wrapper types of the client side of all the
node-to-client protocols, specifically the types ChainSyncClient,
LocalStateQueryClient and LocalTxSubmissionClient.
    
These are useful for the cardano-api where we want to present the
protocol handlers using one set of types, but then execute them at the
proper wire types.

