### PR TITLE
Change protocol types to use a param for the point type

### DIFF
--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -210,7 +210,7 @@ newtype ServerUpdates =
 
 type TraceEvent = (Tick, Either
   (TraceChainSyncClientEvent TestBlock)
-  (TraceSendRecv (ChainSync (Header TestBlock) (Tip TestBlock))))
+  (TraceSendRecv (ChainSync (Header TestBlock) (Point TestBlock) (Tip TestBlock))))
 
 data ChainSyncOutcome = ChainSyncOutcome {
       finalClientChain :: Chain TestBlock
@@ -299,7 +299,8 @@ runChainSync securityParam (ClientUpdates clientUpdates)
 
     -- Set up the server
     varChainProducerState <- uncheckedNewTVarM $ initChainProducerState Genesis
-    let server :: ChainSyncServer (Header TestBlock) (Tip TestBlock) m ()
+    let server :: ChainSyncServer (Header TestBlock) (Point TestBlock)
+                                  (Tip TestBlock) m ()
         server = chainSyncServerExample () varChainProducerState
 
     -- Schedule updates of the client and server chains

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -146,6 +146,7 @@ mkClient
   => [Point TestBlock]
   -> LocalStateQueryClient
        TestBlock
+       (Point TestBlock)
        (Query TestBlock)
        m
        [(Point TestBlock, Either AcquireFailure (Point TestBlock))]
@@ -155,7 +156,7 @@ mkServer
   :: IOLike m
   => SecurityParam
   -> Chain TestBlock
-  -> m (LocalStateQueryServer TestBlock (Query TestBlock) m ())
+  -> m (LocalStateQueryServer TestBlock (Point TestBlock) (Query TestBlock) m ())
 mkServer k chain = do
     lgrDB <- initLgrDB k chain
     return $

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
@@ -75,14 +75,14 @@ blockFetchServer
     -> ChainDB m blk
     -> NodeToNodeVersion
     -> ResourceRegistry m
-    -> BlockFetchServer (Serialised blk) m ()
+    -> BlockFetchServer (Serialised blk) (Point blk) m ()
 blockFetchServer _tracer chainDB _version registry = senderSide
   where
-    senderSide :: BlockFetchServer (Serialised blk) m ()
+    senderSide :: BlockFetchServer (Serialised blk) (Point blk) m ()
     senderSide = BlockFetchServer receiveReq' ()
 
-    receiveReq' :: ChainRange (Serialised blk)
-                -> m (BlockFetchBlockSender (Serialised blk) m ())
+    receiveReq' :: ChainRange (Point blk)
+                -> m (BlockFetchBlockSender (Serialised blk) (Point blk) m ())
     receiveReq' (ChainRange start end) =
       case (start, end) of
         (BlockPoint s h, BlockPoint s' h') ->
@@ -92,7 +92,7 @@ blockFetchServer _tracer chainDB _version registry = senderSide
 
     receiveReq :: RealPoint blk
                -> RealPoint blk
-               -> m (BlockFetchBlockSender (Serialised blk) m ())
+               -> m (BlockFetchBlockSender (Serialised blk) (Point blk) m ())
     receiveReq start end = do
       errIt <- ChainDB.stream
         chainDB
@@ -110,7 +110,7 @@ blockFetchServer _tracer chainDB _version registry = senderSide
         Right it -> SendMsgStartBatch $ sendBlocks it
 
     sendBlocks :: ChainDB.Iterator m blk (WithPoint blk (Serialised blk))
-               -> m (BlockFetchSendBlocks (Serialised blk) m ())
+               -> m (BlockFetchSendBlocks (Serialised blk) (Point blk) m ())
     sendBlocks it = do
       next <- ChainDB.iteratorNext it
       case next of

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -80,8 +80,8 @@ import           Ouroboros.Consensus.Storage.ChainDB (ChainDB,
                      InvalidBlockReason)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 
-type Consensus (client :: Type -> Type -> (Type -> Type) -> Type -> Type) blk m =
-   client (Header blk) (Tip blk) m ChainSyncClientResult
+type Consensus (client :: Type -> Type -> Type -> (Type -> Type) -> Type -> Type) blk m =
+   client (Header blk) (Point blk) (Tip blk) m ChainSyncClientResult
 
 -- | Abstract over the ChainDB
 data ChainDbView m blk = ChainDbView {
@@ -471,7 +471,8 @@ chainSyncClient mkPipelineDecision0 tracer cfg
       -- was an intersection within the last @k@ blocks of our current chain.
       -- If not, we could never switch to this candidate chain anyway.
       let maxOffset = fromIntegral (AF.length ourFrag)
-          points    = AF.selectPoints
+          points    = map castPoint
+                    $ AF.selectPoints
                         (map fromIntegral (offsets maxOffset))
                         ourFrag
           ourTip    = ourTipFromChain ourFrag

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -20,17 +20,18 @@ localStateQueryServer ::
      -- ^ Get a past ledger
   -> STM m (Point blk)
      -- ^ Get the immutable point
-  -> LocalStateQueryServer blk (Query blk) m ()
+  -> LocalStateQueryServer blk (Point blk) (Query blk) m ()
 localStateQueryServer cfg getPastLedger getImmutablePoint =
     LocalStateQueryServer $ return idle
   where
-    idle :: ServerStIdle blk (Query blk) m ()
+    idle :: ServerStIdle blk (Point blk) (Query blk) m ()
     idle = ServerStIdle {
           recvMsgAcquire = handleAcquire
         , recvMsgDone    = return ()
         }
 
-    handleAcquire :: Point blk -> m (ServerStAcquiring blk (Query blk) m ())
+    handleAcquire :: Point blk
+                  -> m (ServerStAcquiring blk (Point blk) (Query blk) m ())
     handleAcquire pt = do
         (mPastLedger, immutablePoint) <-
           atomically $ (,) <$> getPastLedger pt <*> getImmutablePoint
@@ -44,7 +45,8 @@ localStateQueryServer cfg getPastLedger getImmutablePoint =
             | otherwise
             -> SendMsgFailure AcquireFailurePointNotOnChain idle
 
-    acquired :: ExtLedgerState blk -> ServerStAcquired blk (Query blk) m ()
+    acquired :: ExtLedgerState blk
+             -> ServerStAcquired blk (Point blk) (Query blk) m ()
     acquired ledgerState = ServerStAcquired {
           recvMsgQuery     = handleQuery ledgerState
         , recvMsgReAcquire = handleAcquire
@@ -54,7 +56,7 @@ localStateQueryServer cfg getPastLedger getImmutablePoint =
     handleQuery ::
          ExtLedgerState blk
       -> Query blk result
-      -> m (ServerStQuerying blk (Query blk) m () result)
+      -> m (ServerStQuerying blk (Point blk) (Query blk) m () result)
     handleQuery ledgerState query = return $
         SendMsgResult
           (answerQuery cfg query ledgerState)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -87,7 +87,7 @@ import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 data Handlers m peer blk = Handlers {
       hChainSyncServer
         :: ResourceRegistry m
-        -> ChainSyncServer (Serialised blk) (Tip blk) m ()
+        -> ChainSyncServer (Serialised blk) (Point blk) (Tip blk) m ()
 
     , hTxSubmissionServer
         :: LocalTxSubmissionServer (GenTx blk) (ApplyTxErr blk) m ()
@@ -125,7 +125,7 @@ mkHandlers NodeArgs {cfg, tracers} NodeKernel {getChainDB, getMempool} =
 
 -- | Node-to-client protocol codecs needed to run 'Handlers'.
 data Codecs' blk serialisedBlk e m bCS bTX bSQ = Codecs {
-      cChainSyncCodec    :: Codec (ChainSync serialisedBlk (Tip blk))              e m bCS
+      cChainSyncCodec    :: Codec (ChainSync serialisedBlk (Point blk) (Tip blk))  e m bCS
     , cTxSubmissionCodec :: Codec (LocalTxSubmission (GenTx blk) (ApplyTxErr blk)) e m bTX
     , cStateQueryCodec   :: Codec (LocalStateQuery blk (Query blk))                e m bSQ
     }
@@ -247,7 +247,7 @@ clientCodecs ccfg version = Codecs {
 -- | Identity codecs used in tests.
 identityCodecs :: (Monad m, QueryLedger blk)
                => Codecs blk CodecFailure m
-                    (AnyMessage (ChainSync (Serialised blk) (Tip blk)))
+                    (AnyMessage (ChainSync (Serialised blk) (Point blk) (Tip blk)))
                     (AnyMessage (LocalTxSubmission (GenTx blk) (ApplyTxErr blk)))
                     (AnyMessage (LocalStateQuery blk (Query blk)))
 identityCodecs = Codecs {
@@ -265,7 +265,7 @@ type Tracers m peer blk e =
      Tracers'  peer blk e (Tracer m)
 
 data Tracers' peer blk e f = Tracers {
-      tChainSyncTracer    :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (Serialised blk) (Tip blk))))
+      tChainSyncTracer    :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (Serialised blk) (Point blk) (Tip blk))))
     , tTxSubmissionTracer :: f (TraceLabelPeer peer (TraceSendRecv (LocalTxSubmission (GenTx blk) (ApplyTxErr blk))))
     , tStateQueryTracer   :: f (TraceLabelPeer peer (TraceSendRecv (LocalStateQuery blk (Query blk))))
     }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -93,7 +93,7 @@ data Handlers m peer blk = Handlers {
         :: LocalTxSubmissionServer (GenTx blk) (ApplyTxErr blk) m ()
 
     , hStateQueryServer
-        :: LocalStateQueryServer blk (Query blk) m ()
+        :: LocalStateQueryServer blk (Point blk) (Query blk) m ()
     }
 
 mkHandlers
@@ -127,7 +127,7 @@ mkHandlers NodeArgs {cfg, tracers} NodeKernel {getChainDB, getMempool} =
 data Codecs' blk serialisedBlk e m bCS bTX bSQ = Codecs {
       cChainSyncCodec    :: Codec (ChainSync serialisedBlk (Point blk) (Tip blk))  e m bCS
     , cTxSubmissionCodec :: Codec (LocalTxSubmission (GenTx blk) (ApplyTxErr blk)) e m bTX
-    , cStateQueryCodec   :: Codec (LocalStateQuery blk (Query blk))                e m bSQ
+    , cStateQueryCodec   :: Codec (LocalStateQuery blk (Point blk) (Query blk))    e m bSQ
     }
 
 type Codecs blk e m bCS bTX bSQ =
@@ -249,7 +249,7 @@ identityCodecs :: (Monad m, QueryLedger blk)
                => Codecs blk CodecFailure m
                     (AnyMessage (ChainSync (Serialised blk) (Point blk) (Tip blk)))
                     (AnyMessage (LocalTxSubmission (GenTx blk) (ApplyTxErr blk)))
-                    (AnyMessage (LocalStateQuery blk (Query blk)))
+                    (AnyMessage (LocalStateQuery blk (Point blk) (Query blk)))
 identityCodecs = Codecs {
       cChainSyncCodec    = codecChainSyncId
     , cTxSubmissionCodec = codecLocalTxSubmissionId
@@ -267,7 +267,7 @@ type Tracers m peer blk e =
 data Tracers' peer blk e f = Tracers {
       tChainSyncTracer    :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (Serialised blk) (Point blk) (Tip blk))))
     , tTxSubmissionTracer :: f (TraceLabelPeer peer (TraceSendRecv (LocalTxSubmission (GenTx blk) (ApplyTxErr blk))))
-    , tStateQueryTracer   :: f (TraceLabelPeer peer (TraceSendRecv (LocalStateQuery blk (Query blk))))
+    , tStateQueryTracer   :: f (TraceLabelPeer peer (TraceSendRecv (LocalStateQuery blk (Point blk) (Query blk))))
     }
 
 instance (forall a. Semigroup (f a)) => Semigroup (Tracers' peer blk e f) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -122,7 +122,7 @@ data Handlers m peer blk = Handlers {
     , hBlockFetchServer
         :: NodeToNodeVersion
         -> ResourceRegistry m
-        -> BlockFetchServer (Serialised blk) m ()
+        -> BlockFetchServer (Serialised blk) (Point blk) m ()
 
     , hTxSubmissionClient
         :: NodeToNodeVersion
@@ -210,8 +210,8 @@ mkHandlers
 data Codecs blk e m bCS bSCS bBF bSBF bTX bKA = Codecs {
       cChainSyncCodec            :: Codec (ChainSync (Header blk) (Point blk) (Tip blk))           e m bCS
     , cChainSyncCodecSerialised  :: Codec (ChainSync (SerialisedHeader blk) (Point blk) (Tip blk)) e m bSCS
-    , cBlockFetchCodec           :: Codec (BlockFetch blk)                                         e m bBF
-    , cBlockFetchCodecSerialised :: Codec (BlockFetch (Serialised blk))                            e m bSBF
+    , cBlockFetchCodec           :: Codec (BlockFetch blk (Point blk))                             e m bBF
+    , cBlockFetchCodecSerialised :: Codec (BlockFetch (Serialised blk) (Point blk))                e m bSBF
     , cTxSubmissionCodec         :: Codec (TxSubmission (GenTxId blk) (GenTx blk))                 e m bTX
     , cKeepAliveCodec            :: Codec KeepAlive                                                e m bKA
     }
@@ -245,15 +245,15 @@ defaultCodecs ccfg version = Codecs {
         codecBlockFetch
           enc
           dec
-          (encodeRawHash p)
-          (decodeRawHash p)
+          (encodePoint (encodeRawHash p))
+          (decodePoint (decodeRawHash p))
 
     , cBlockFetchCodecSerialised =
         codecBlockFetch
           enc
           dec
-          (encodeRawHash p)
-          (decodeRawHash p)
+          (encodePoint (encodeRawHash p))
+          (decodePoint (decodeRawHash p))
 
     , cTxSubmissionCodec =
         codecTxSubmission
@@ -280,8 +280,8 @@ identityCodecs :: Monad m
                => Codecs blk CodecFailure m
                     (AnyMessage (ChainSync (Header blk) (Point blk) (Tip blk)))
                     (AnyMessage (ChainSync (SerialisedHeader blk) (Point blk) (Tip blk)))
-                    (AnyMessage (BlockFetch blk))
-                    (AnyMessage (BlockFetch (Serialised blk)))
+                    (AnyMessage (BlockFetch blk (Point blk)))
+                    (AnyMessage (BlockFetch (Serialised blk) (Point blk)))
                     (AnyMessage (TxSubmission (GenTxId blk) (GenTx blk)))
                     (AnyMessage KeepAlive)
 identityCodecs = Codecs {
@@ -304,8 +304,8 @@ type Tracers m peer blk e =
 data Tracers' peer blk e f = Tracers {
       tChainSyncTracer            :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (Header blk) (Point blk) (Tip blk))))
     , tChainSyncSerialisedTracer  :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (SerialisedHeader blk) (Point blk) (Tip blk))))
-    , tBlockFetchTracer           :: f (TraceLabelPeer peer (TraceSendRecv (BlockFetch blk)))
-    , tBlockFetchSerialisedTracer :: f (TraceLabelPeer peer (TraceSendRecv (BlockFetch (Serialised blk))))
+    , tBlockFetchTracer           :: f (TraceLabelPeer peer (TraceSendRecv (BlockFetch blk (Point blk))))
+    , tBlockFetchSerialisedTracer :: f (TraceLabelPeer peer (TraceSendRecv (BlockFetch (Serialised blk) (Point blk))))
     , tTxSubmissionTracer         :: f (TraceLabelPeer peer (TraceSendRecv (TxSubmission (GenTxId blk) (GenTx blk))))
     }
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -102,7 +102,7 @@ data Handlers m peer blk = Handlers {
         :: NodeToNodeVersion
         -> ControlMessageSTM m
         -> StrictTVar m (AnchoredFragment (Header blk))
-        -> ChainSyncClientPipelined (Header blk) (Tip blk) m ChainSyncClientResult
+        -> ChainSyncClientPipelined (Header blk) (Point blk) (Tip blk) m ChainSyncClientResult
         -- TODO: we should consider either bundling these context parameters
         -- into a record, or extending the protocol handler representation
         -- to support bracket-style initialisation so that we could have the
@@ -111,7 +111,7 @@ data Handlers m peer blk = Handlers {
     , hChainSyncServer
         :: NodeToNodeVersion
         -> ResourceRegistry m
-        -> ChainSyncServer (SerialisedHeader blk) (Tip blk) m ()
+        -> ChainSyncServer (SerialisedHeader blk) (Point blk) (Tip blk) m ()
 
     -- TODO block fetch client does not have GADT view of the handlers.
     , hBlockFetchClient
@@ -208,12 +208,12 @@ mkHandlers
 
 -- | Node-to-node protocol codecs needed to run 'Handlers'.
 data Codecs blk e m bCS bSCS bBF bSBF bTX bKA = Codecs {
-      cChainSyncCodec            :: Codec (ChainSync (Header blk) (Tip blk))           e m bCS
-    , cChainSyncCodecSerialised  :: Codec (ChainSync (SerialisedHeader blk) (Tip blk)) e m bSCS
-    , cBlockFetchCodec           :: Codec (BlockFetch blk)                             e m bBF
-    , cBlockFetchCodecSerialised :: Codec (BlockFetch (Serialised blk))                e m bSBF
-    , cTxSubmissionCodec         :: Codec (TxSubmission (GenTxId blk) (GenTx blk))     e m bTX
-    , cKeepAliveCodec            :: Codec KeepAlive                                    e m bKA
+      cChainSyncCodec            :: Codec (ChainSync (Header blk) (Point blk) (Tip blk))           e m bCS
+    , cChainSyncCodecSerialised  :: Codec (ChainSync (SerialisedHeader blk) (Point blk) (Tip blk)) e m bSCS
+    , cBlockFetchCodec           :: Codec (BlockFetch blk)                                         e m bBF
+    , cBlockFetchCodecSerialised :: Codec (BlockFetch (Serialised blk))                            e m bSBF
+    , cTxSubmissionCodec         :: Codec (TxSubmission (GenTxId blk) (GenTx blk))                 e m bTX
+    , cKeepAliveCodec            :: Codec KeepAlive                                                e m bKA
     }
 
 -- | Protocol codecs for the node-to-node protocols
@@ -278,8 +278,8 @@ defaultCodecs ccfg version = Codecs {
 -- | Identity codecs used in tests.
 identityCodecs :: Monad m
                => Codecs blk CodecFailure m
-                    (AnyMessage (ChainSync (Header blk) (Tip blk)))
-                    (AnyMessage (ChainSync (SerialisedHeader blk) (Tip blk)))
+                    (AnyMessage (ChainSync (Header blk) (Point blk) (Tip blk)))
+                    (AnyMessage (ChainSync (SerialisedHeader blk) (Point blk) (Tip blk)))
                     (AnyMessage (BlockFetch blk))
                     (AnyMessage (BlockFetch (Serialised blk)))
                     (AnyMessage (TxSubmission (GenTxId blk) (GenTx blk)))
@@ -302,8 +302,8 @@ type Tracers m peer blk e =
      Tracers'  peer blk e (Tracer m)
 
 data Tracers' peer blk e f = Tracers {
-      tChainSyncTracer            :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (Header blk) (Tip blk))))
-    , tChainSyncSerialisedTracer  :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (SerialisedHeader blk) (Tip blk))))
+      tChainSyncTracer            :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (Header blk) (Point blk) (Tip blk))))
+    , tChainSyncSerialisedTracer  :: f (TraceLabelPeer peer (TraceSendRecv (ChainSync (SerialisedHeader blk) (Point blk) (Tip blk))))
     , tBlockFetchTracer           :: f (TraceLabelPeer peer (TraceSendRecv (BlockFetch blk)))
     , tBlockFetchSerialisedTracer :: f (TraceLabelPeer peer (TraceSendRecv (BlockFetch (Serialised blk))))
     , tTxSubmissionTracer         :: f (TraceLabelPeer peer (TraceSendRecv (TxSubmission (GenTxId blk) (GenTx blk))))

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -450,7 +450,7 @@ serverBlockFetch sockAddr = withIOManager $ \iocp -> do
          codecBlockFetch
         (BlockFetch.blockFetchServerPeer (blockFetchServer prng))
 
-codecBlockFetch :: Codec (BlockFetch.BlockFetch Block)
+codecBlockFetch :: Codec (BlockFetch.BlockFetch Block (Point Block))
                          CBOR.DeserialiseFailure
                          IO LBS.ByteString
 codecBlockFetch =
@@ -572,7 +572,7 @@ chainSyncServer seed =
 
 blockFetchServer :: RandomGen g
                  => g
-                 -> BlockFetch.BlockFetchServer Block IO ()
+                 -> BlockFetch.BlockFetchServer Block (Point Block) IO ()
 blockFetchServer seed =
     let blocks = chainGenerator seed in
     idleState blocks
@@ -599,7 +599,7 @@ blockFetchServer seed =
         threadDelay 1000000
         return (sendingState batch blocks)
 
-selectBlockRange :: BlockFetch.ChainRange Block
+selectBlockRange :: BlockFetch.ChainRange (Point Block)
                  -> [Block]
                  -> Maybe ([Block], [Block])
 selectBlockRange (BlockFetch.ChainRange lower upper) blocks0 = do

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -26,7 +26,7 @@ import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec
 import           Ouroboros.Network.Driver.Simple (runConnectedPeers)
 
-import           Ouroboros.Network.Block (Serialised (..), StandardHash,
+import           Ouroboros.Network.Block (Serialised (..),
                      castPoint, genesisPoint, unwrapCBORinCBOR, wrapCBORinCBOR)
 import           Ouroboros.Network.MockChain.Chain (Chain, Point)
 import qualified Ouroboros.Network.MockChain.Chain as Chain
@@ -83,11 +83,11 @@ tests =
 -- Block fetch client and server used in many subsequent tests.
 --
 
-type TestClient m = BlockFetchClient Block m [Block]
-type TestServer m = BlockFetchServer Block m ()
+type TestClient m = BlockFetchClient Block (Point Block) m [Block]
+type TestServer m = BlockFetchServer Block (Point Block) m ()
 type TestClientPipelined m =
-       BlockFetchClientPipelined Block m
-                                 [Either (ChainRange Block) [Block]]
+       BlockFetchClientPipelined Block (Point Block) m
+                                 [Either (ChainRange (Point Block)) [Block]]
 
 testClient :: MonadSTM m => Chain Block -> [Point Block] -> TestClient m
 testClient chain points = blockFetchClientMap (pointsToRanges chain points)
@@ -183,7 +183,7 @@ connect_pipelined :: MonadSTM m
                   => TestClientPipelined m
                   -> Chain Block
                   -> [Bool]
-                  -> m [Either (ChainRange Block) [Block]]
+                  -> m [Either (ChainRange (Point Block)) [Block]]
 connect_pipelined client chain cs = do
     (res, _, TerminalStates TokDone TokDone)
       <- connectPipelined cs
@@ -313,14 +313,14 @@ prop_pipe_IO (TestChainAndPoints chain points) =
 --
 
 codec :: MonadST m
-      => Codec (BlockFetch Block)
+      => Codec (BlockFetch Block (Point Block))
                S.DeserialiseFailure
                m ByteString
 codec = codecBlockFetch S.encode S.decode
                         S.encode S.decode
 
 codecWrapped :: MonadST m
-             => Codec (BlockFetch Block)
+             => Codec (BlockFetch Block (Point Block))
                       S.DeserialiseFailure
                       m ByteString
 codecWrapped =
@@ -329,14 +329,14 @@ codecWrapped =
       S.encode                  S.decode
 
 codecSerialised :: MonadST m
-                => Codec (BlockFetch (Serialised Block))
+                => Codec (BlockFetch (Serialised Block) (Point Block))
                          S.DeserialiseFailure
                          m ByteString
 codecSerialised = codecBlockFetch S.encode S.decode S.encode S.decode
 
 genBlockFetch :: Gen block
-              -> Gen (ChainRange block)
-              -> Gen (AnyMessageAndAgency (BlockFetch block))
+              -> Gen (ChainRange point)
+              -> Gen (AnyMessageAndAgency (BlockFetch block point))
 genBlockFetch genBlock genChainRange = oneof
     [ AnyMessageAndAgency (ClientAgency TokIdle) <$>
         MsgRequestRange <$> genChainRange
@@ -348,11 +348,11 @@ genBlockFetch genBlock genChainRange = oneof
     , return $ AnyMessageAndAgency (ClientAgency TokIdle) MsgClientDone
     ]
 
-instance Arbitrary (AnyMessageAndAgency (BlockFetch Block)) where
+instance Arbitrary (AnyMessageAndAgency (BlockFetch Block (Point Block))) where
   arbitrary = genBlockFetch arbitrary arbitrary
 
-instance (StandardHash block, Eq block) =>
-         Eq (AnyMessage (BlockFetch block)) where
+instance (Eq block, Eq point) =>
+         Eq (AnyMessage (BlockFetch block point)) where
   AnyMessage (MsgRequestRange r1) == AnyMessage (MsgRequestRange r2) = r1 == r2
   AnyMessage MsgStartBatch        == AnyMessage MsgStartBatch        = True
   AnyMessage MsgNoBlocks          == AnyMessage MsgNoBlocks          = True
@@ -361,77 +361,77 @@ instance (StandardHash block, Eq block) =>
   AnyMessage MsgClientDone        == AnyMessage MsgClientDone        = True
   _                               ==                  _              = False
 
-instance Arbitrary (AnyMessageAndAgency (BlockFetch (Serialised Block))) where
+instance Arbitrary (AnyMessageAndAgency (BlockFetch (Serialised Block) (Point Block))) where
   arbitrary = genBlockFetch (serialiseBlock <$> arbitrary)
                             (toSerialisedChainRange <$> arbitrary)
     where
       serialiseBlock :: Block -> Serialised Block
       serialiseBlock = Serialised . S.serialise
 
-      toSerialisedChainRange :: ChainRange Block
-                             -> ChainRange (Serialised Block)
+      toSerialisedChainRange :: ChainRange (Point Block)
+                             -> ChainRange (Point Block)
       toSerialisedChainRange (ChainRange l u) =
         ChainRange (castPoint l) (castPoint u)
 
 prop_codec_BlockFetch
-  :: AnyMessageAndAgency (BlockFetch Block)
+  :: AnyMessageAndAgency (BlockFetch Block (Point Block))
   -> Bool
 prop_codec_BlockFetch msg =
   runST (prop_codecM codec msg)
 
 prop_codec_splits2_BlockFetch
-  :: AnyMessageAndAgency (BlockFetch Block)
+  :: AnyMessageAndAgency (BlockFetch Block (Point Block))
   -> Bool
 prop_codec_splits2_BlockFetch msg =
   runST (prop_codec_splitsM splits2 codec msg)
 
 prop_codec_splits3_BlockFetch
-  :: AnyMessageAndAgency (BlockFetch Block)
+  :: AnyMessageAndAgency (BlockFetch Block (Point Block))
   -> Bool
 prop_codec_splits3_BlockFetch msg =
   runST (prop_codec_splitsM splits3 codec msg)
 
 prop_codec_cbor_BlockFetch
-  :: AnyMessageAndAgency (BlockFetch Block)
+  :: AnyMessageAndAgency (BlockFetch Block (Point Block))
   -> Bool
 prop_codec_cbor_BlockFetch msg =
   runST (prop_codec_cborM codec msg)
 
 prop_codec_BlockFetchSerialised
-  :: AnyMessageAndAgency (BlockFetch (Serialised Block))
+  :: AnyMessageAndAgency (BlockFetch (Serialised Block) (Point Block))
   -> Bool
 prop_codec_BlockFetchSerialised msg =
   runST (prop_codecM codecSerialised msg)
 
 prop_codec_splits2_BlockFetchSerialised
-  :: AnyMessageAndAgency (BlockFetch (Serialised Block))
+  :: AnyMessageAndAgency (BlockFetch (Serialised Block) (Point Block))
   -> Bool
 prop_codec_splits2_BlockFetchSerialised msg =
   runST (prop_codec_splitsM splits2 codecSerialised msg)
 
 prop_codec_splits3_BlockFetchSerialised
-  :: AnyMessageAndAgency (BlockFetch (Serialised Block))
+  :: AnyMessageAndAgency (BlockFetch (Serialised Block) (Point Block))
   -> Bool
 prop_codec_splits3_BlockFetchSerialised msg =
   runST (prop_codec_splitsM splits3 codecSerialised msg)
 
 prop_codec_cbor_BlockFetchSerialised
-  :: AnyMessageAndAgency (BlockFetch (Serialised Block))
+  :: AnyMessageAndAgency (BlockFetch (Serialised Block) (Point Block))
   -> Bool
 prop_codec_cbor_BlockFetchSerialised msg =
   runST (prop_codec_cborM codecSerialised msg)
 
 
 prop_codec_binary_compat_BlockFetch_BlockFetchSerialised
-  :: AnyMessageAndAgency (BlockFetch Block)
+  :: AnyMessageAndAgency (BlockFetch Block (Point Block))
   -> Bool
 prop_codec_binary_compat_BlockFetch_BlockFetchSerialised msg =
     runST (prop_codec_binary_compatM codecWrapped codecSerialised stokEq msg)
   where
     stokEq
-      :: forall pr (stA :: BlockFetch Block).
+      :: forall pr (stA :: BlockFetch Block (Point Block)).
          PeerHasAgency pr stA
-      -> SamePeerHasAgency pr (BlockFetch (Serialised Block))
+      -> SamePeerHasAgency pr (BlockFetch (Serialised Block) (Point Block))
     stokEq (ClientAgency ca) = case ca of
       TokIdle -> SamePeerHasAgency $ ClientAgency TokIdle
     stokEq (ServerAgency sa) = case sa of
@@ -439,15 +439,15 @@ prop_codec_binary_compat_BlockFetch_BlockFetchSerialised msg =
       TokStreaming -> SamePeerHasAgency $ ServerAgency TokStreaming
 
 prop_codec_binary_compat_BlockFetchSerialised_BlockFetch
-  :: AnyMessageAndAgency (BlockFetch (Serialised Block))
+  :: AnyMessageAndAgency (BlockFetch (Serialised Block) (Point Block))
   -> Bool
 prop_codec_binary_compat_BlockFetchSerialised_BlockFetch msg =
     runST (prop_codec_binary_compatM codecSerialised codecWrapped stokEq msg)
   where
     stokEq
-      :: forall pr (stA :: BlockFetch (Serialised Block)).
+      :: forall pr (stA :: BlockFetch (Serialised Block) (Point Block)).
          PeerHasAgency pr stA
-      -> SamePeerHasAgency pr (BlockFetch Block)
+      -> SamePeerHasAgency pr (BlockFetch Block (Point Block))
     stokEq (ClientAgency ca) = case ca of
       TokIdle -> SamePeerHasAgency $ ClientAgency TokIdle
     stokEq (ServerAgency sa) = case sa of
@@ -465,7 +465,7 @@ pointsToRanges
   :: Chain.HasHeader block
   => Chain block
   -> [Point block]
-  -> [ChainRange block]
+  -> [ChainRange (Point block)]
 pointsToRanges chain points =
     go (reverse points)
   where

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Direct.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Direct.hs
@@ -10,8 +10,8 @@ import Ouroboros.Network.Protocol.ChainSync.Server as Server
 -- That's demonstrated here by constructing 'direct'.
 --
 direct :: Monad m
-       => ChainSyncServer header tip m a
-       -> ChainSyncClient header tip m b
+       => ChainSyncServer header point tip m a
+       -> ChainSyncClient header point tip m b
        -> m (a, b)
 direct (ChainSyncServer mserver) (ChainSyncClient mclient) = do
   server <- mserver
@@ -19,8 +19,8 @@ direct (ChainSyncServer mserver) (ChainSyncClient mclient) = do
   direct_ server client
 
 direct_ :: Monad m
-        => ServerStIdle header tip m a
-        -> ClientStIdle header tip m b
+        => ServerStIdle header point tip m a
+        -> ClientStIdle header point tip m b
         -> m (a, b)
 direct_  ServerStIdle{recvMsgRequestNext}
         (Client.SendMsgRequestNext stNext stAwait) = do

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/DirectPipelined.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/DirectPipelined.hs
@@ -11,17 +11,17 @@ import Ouroboros.Network.Protocol.ChainSync.Server as Server
 
 
 directPipelined :: Monad m
-                => ChainSyncServer header tip m a
-                -> ChainSyncClientPipelined header tip m b
+                => ChainSyncServer header point tip m a
+                -> ChainSyncClientPipelined header point tip m b
                 -> m (a, b)
 directPipelined (ChainSyncServer mserver) (ChainSyncClientPipelined mclient) =
     directStIdleM EmptyQ mserver mclient
 
 
 directStIdleM :: Monad m
-                 => Queue n (ChainSyncInstruction header tip)
-                 -> m (ServerStIdle            header tip m a)
-                 -> m (ClientPipelinedStIdle n header tip m b)
+                 => Queue n (ChainSyncInstruction header point tip)
+                 -> m (ServerStIdle            header point tip m a)
+                 -> m (ClientPipelinedStIdle n header point tip m b)
                  -> m (a, b)
 
 directStIdleM queue mServerStIdle mClientStIdle = do
@@ -31,9 +31,9 @@ directStIdleM queue mServerStIdle mClientStIdle = do
 
 
 directStIdle :: Monad m
-             => Queue n (ChainSyncInstruction header tip)
-             -> ServerStIdle            header tip m a
-             -> ClientPipelinedStIdle n header tip m b
+             => Queue n (ChainSyncInstruction header point tip)
+             -> ServerStIdle            header point tip m a
+             -> ClientPipelinedStIdle n header point tip m b
              -> m (a, b)
 directStIdle queue@EmptyQ ServerStIdle {recvMsgRequestNext} (SendMsgRequestNext stClientNext stClientAwait) = do
     mStServerNext <- recvMsgRequestNext

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/ExamplesPipelined.hs
@@ -36,13 +36,13 @@ chainSyncClientPipelined
          )
       => MkPipelineDecision
       -> StrictTVar m (Chain header)
-      -> Client header (Tip header) m a
-      -> ChainSyncClientPipelined header (Tip header) m a
+      -> Client header (Point header) (Tip header) m a
+      -> ChainSyncClientPipelined header (Point header) (Tip header) m a
 chainSyncClientPipelined mkPipelineDecision0 chainvar =
     ChainSyncClientPipelined . fmap initialise . getChainPoints
   where
-    initialise :: ([Point header], Client header (Tip header) m a)
-               -> ClientPipelinedStIdle Z header (Tip header) m a
+    initialise :: ([Point header], Client header (Point header) (Tip header) m a)
+               -> ClientPipelinedStIdle Z header (Point header) (Tip header) m a
     initialise (points, client) =
       SendMsgFindIntersect points $
       -- In this consumer example, we do not care about whether the server
@@ -63,8 +63,8 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
        -- ^ our head
        -> Tip header
        -- ^ head of the server
-       -> Client header (Tip header) m a
-       -> ClientPipelinedStIdle n header (Tip header) m a
+       -> Client header (Point header) (Tip header) m a
+       -> ClientPipelinedStIdle n header (Point header) (Tip header) m a
 
     go mkPipelineDecision n cliTipBlockNo srvTip client@Client {rollforward, rollbackward} =
       let srvTipBlockNo = getTipBlockNo srvTip in
@@ -143,7 +143,7 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
     -- outstanding responses and send 'MsgDone'.
     collectAndDone :: Nat n
                    -> a
-                   -> ClientPipelinedStIdle n header (Tip header) m a
+                   -> ClientPipelinedStIdle n header (Point header) (Tip header) m a
 
     collectAndDone Zero     a = SendMsgDone a
 
@@ -157,8 +157,8 @@ chainSyncClientPipelined mkPipelineDecision0 chainvar =
                                     }
 
 
-    getChainPoints :: Client header (Tip header) m a
-                   -> m ([Point header], Client header (Tip header) m a)
+    getChainPoints :: Client header (Point header) (Tip header) m a
+                   -> m ([Point header], Client header (Point header) (Tip header) m a)
     getChainPoints client = do
       pts <- Chain.selectPoints recentOffsets <$> atomically (readTVar chainvar)
       client' <- points client pts
@@ -243,8 +243,8 @@ chainSyncClientPipelinedMax
       => Word32
       -- ^ maximal number of outstanding requests
       -> StrictTVar m (Chain header)
-      -> Client header (Tip header) m a
-      -> ChainSyncClientPipelined header (Tip header) m a
+      -> Client header (Point header) (Tip header) m a
+      -> ChainSyncClientPipelined header (Point header) (Tip header) m a
 chainSyncClientPipelinedMax omax = chainSyncClientPipelined (constantPipelineDecision $ pipelineDecisionMax omax)
 
 -- | A pipelined chain-sycn client that pipelines at most @omax@ requests and
@@ -296,8 +296,8 @@ chainSyncClientPipelinedMin
       => Word32
       -- ^ maximal number of outstanding requests
       -> StrictTVar m (Chain header)
-      -> Client header (Tip header) m a
-      -> ChainSyncClientPipelined header (Tip header) m a
+      -> Client header (Point header) (Tip header) m a
+      -> ChainSyncClientPipelined header (Point header) (Tip header) m a
 chainSyncClientPipelinedMin omax = chainSyncClientPipelined (constantPipelineDecision $ pipelineDecisionMin omax)
 
 
@@ -311,6 +311,6 @@ chainSyncClientPipelinedLowHigh
       -> Word32
       -- ^ high mark
       -> StrictTVar m (Chain header)
-      -> Client header (Tip header) m a
-      -> ChainSyncClientPipelined header (Tip header) m a
+      -> Client header (Point header) (Tip header) m a
+      -> ChainSyncClientPipelined header (Point header) (Tip header) m a
 chainSyncClientPipelinedLowHigh lowMark highMark = chainSyncClientPipelined (pipelineDecisionLowHighMark lowMark highMark)

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -105,7 +105,7 @@ testClient
   :: MonadSTM m
   => StrictTVar m Bool
   -> Point Block
-  -> ChainSyncExamples.Client Block blockInfo m ()
+  -> ChainSyncExamples.Client Block (Point Block) blockInfo m ()
 testClient doneVar tip =
   ChainSyncExamples.Client {
       ChainSyncExamples.rollbackward = \point _ ->
@@ -131,8 +131,9 @@ chainSyncForkExperiment
      ( MonadST m
      , MonadSTM m
      )
-  => (forall a b. ChainSyncServer Block (Tip Block) m a
-      -> ChainSyncClient Block (Tip Block) m b
+  => (forall a b.
+         ChainSyncServer Block (Point Block) (Tip Block) m a
+      -> ChainSyncClient Block (Point Block) (Tip Block) m b
       -> m ())
   -> ChainProducerStateForkTest
   -> m Property
@@ -189,12 +190,12 @@ chainSyncPipelinedForkExperiment
      ( MonadST m
      , MonadSTM m
      )
-  => (forall a b. ChainSyncServer Block (Tip Block) m a
-      -> ChainSyncClientPipelined Block (Tip Block) m b
+  => (forall a b. ChainSyncServer Block (Point Block) (Tip Block) m a
+      -> ChainSyncClientPipelined Block (Point Block) (Tip Block) m b
       -> m ())
   -> (forall a. StrictTVar m (Chain Block)
-      -> Client Block (Tip Block) m a
-      -> ChainSyncClientPipelined Block (Tip Block) m a)
+      -> Client Block (Point Block) (Tip Block) m a
+      -> ChainSyncClientPipelined Block (Point Block) (Tip Block) m a)
   -> ChainProducerStateForkTest
   -> m Bool
 chainSyncPipelinedForkExperiment run mkClient (ChainProducerStateForkTest cps chain) = do
@@ -205,7 +206,7 @@ chainSyncPipelinedForkExperiment run mkClient (ChainProducerStateForkTest cps ch
   let server = ChainSyncExamples.chainSyncServerExample
         (error "chainSyncServerExample: lazy in the result type")
         cpsVar
-      client :: ChainSyncClientPipelined Block (Tip Block) m ()
+      client :: ChainSyncClientPipelined Block (Point Block) (Tip Block) m ()
       client = mkClient chainVar (testClient doneVar (Chain.headPoint pchain))
   _ <- run server client
 
@@ -325,10 +326,10 @@ propChainSyncPipelinedMinConnectIO cps choices (Positive omax) =
         (ChainSyncExamples.chainSyncClientPipelinedMin omax)
         cps
 
-genChainSync :: Gen (Point header)
+genChainSync :: Gen point
              -> Gen header
              -> Gen tip
-             -> Gen (AnyMessageAndAgency (ChainSync header tip))
+             -> Gen (AnyMessageAndAgency (ChainSync header point tip))
 genChainSync genPoint genHeader genTip = oneof
     [ return $ AnyMessageAndAgency (ClientAgency TokIdle) MsgRequestNext
     , return $ AnyMessageAndAgency (ServerAgency (TokNext TokCanAwait)) MsgAwaitReply
@@ -363,12 +364,19 @@ genChainSync genPoint genHeader genTip = oneof
     ]
 
 
-instance Arbitrary (AnyMessageAndAgency (ChainSync BlockHeader (Tip BlockHeader))) where
+-- type aliases to keep sizes down
+type ChainSync_BlockHeader =
+     ChainSync BlockHeader (Point BlockHeader) (Tip BlockHeader)
+
+type ChainSync_Serialised_BlockHeader =
+     ChainSync (Serialised BlockHeader) (Point BlockHeader) (Tip BlockHeader)
+
+instance Arbitrary (AnyMessageAndAgency ChainSync_BlockHeader) where
   arbitrary = genChainSync arbitrary arbitrary genTip
     where
       genTip = legacyTip <$> arbitrary <*> arbitrary
 
-instance Arbitrary (AnyMessageAndAgency (ChainSync (Serialised BlockHeader) (Tip BlockHeader))) where
+instance Arbitrary (AnyMessageAndAgency ChainSync_Serialised_BlockHeader) where
   arbitrary = genChainSync (castPoint <$> genPoint)
                            (serialiseBlock <$> arbitrary)
                            genTip
@@ -383,8 +391,9 @@ instance Arbitrary (AnyMessageAndAgency (ChainSync (Serialised BlockHeader) (Tip
 
 instance ( StandardHash header
          , Eq header
+         , Eq point
          , Eq tip
-         ) => Eq (AnyMessage (ChainSync header tip)) where
+         ) => Eq (AnyMessage (ChainSync header point tip)) where
   AnyMessage MsgRequestNext              == AnyMessage MsgRequestNext              = True
   AnyMessage MsgAwaitReply               == AnyMessage MsgAwaitReply               = True
   AnyMessage (MsgRollForward h1 tip1)    == AnyMessage (MsgRollForward h2 tip2)    = h1 == h2 && tip1 == tip2
@@ -399,7 +408,7 @@ codec :: ( MonadST m
          , S.Serialise block
          , S.Serialise (Chain.HeaderHash block)
          )
-      => Codec (ChainSync block (Tip block))
+      => Codec (ChainSync block (Point block) (Tip block))
                S.DeserialiseFailure
                m ByteString
 codec = codecChainSync S.encode             S.decode
@@ -410,7 +419,7 @@ codecWrapped :: ( MonadST m
                 , S.Serialise block
                 , S.Serialise (Chain.HeaderHash block)
                 )
-             => Codec (ChainSync block (Tip block))
+             => Codec (ChainSync block (Point block) (Tip block))
                       S.DeserialiseFailure
                       m ByteString
 codecWrapped =
@@ -419,13 +428,13 @@ codecWrapped =
                    (encodeTip S.encode)      (decodeTip S.decode)
 
 prop_codec_ChainSync
-  :: AnyMessageAndAgency (ChainSync BlockHeader (Tip BlockHeader))
+  :: AnyMessageAndAgency ChainSync_BlockHeader
   -> Bool
 prop_codec_ChainSync msg =
     ST.runST $ prop_codecM codec msg
 
 prop_codec_splits2_ChainSync
-  :: AnyMessageAndAgency (ChainSync BlockHeader (Tip BlockHeader))
+  :: AnyMessageAndAgency ChainSync_BlockHeader
   -> Bool
 prop_codec_splits2_ChainSync msg =
     ST.runST $ prop_codec_splitsM
@@ -434,7 +443,7 @@ prop_codec_splits2_ChainSync msg =
       msg
 
 prop_codec_splits3_ChainSync
-  :: AnyMessageAndAgency (ChainSync BlockHeader (Tip BlockHeader))
+  :: AnyMessageAndAgency ChainSync_BlockHeader
   -> Bool
 prop_codec_splits3_ChainSync msg =
     ST.runST $ prop_codec_splitsM
@@ -442,7 +451,7 @@ prop_codec_splits3_ChainSync msg =
       codec
       msg
 prop_codec_cbor
-  :: AnyMessageAndAgency (ChainSync BlockHeader (Tip BlockHeader))
+  :: AnyMessageAndAgency ChainSync_BlockHeader
   -> Bool
 prop_codec_cbor msg =
     ST.runST (prop_codec_cborM codec msg)
@@ -451,7 +460,7 @@ codecSerialised
   :: ( MonadST m
      , S.Serialise (Chain.HeaderHash block)
      )
-  => Codec (ChainSync (Serialised block) (Tip block))
+  => Codec (ChainSync (Serialised block) (Point block) (Tip block))
            S.DeserialiseFailure
            m ByteString
 codecSerialised = codecChainSync
@@ -460,13 +469,13 @@ codecSerialised = codecChainSync
     (encodeTip S.encode) (decodeTip S.decode)
 
 prop_codec_ChainSyncSerialised
-  :: AnyMessageAndAgency (ChainSync (Serialised BlockHeader) (Tip BlockHeader))
+  :: AnyMessageAndAgency ChainSync_Serialised_BlockHeader
   -> Bool
 prop_codec_ChainSyncSerialised msg =
     ST.runST $ prop_codecM codecSerialised msg
 
 prop_codec_splits2_ChainSyncSerialised
-  :: AnyMessageAndAgency (ChainSync (Serialised BlockHeader) (Tip BlockHeader))
+  :: AnyMessageAndAgency ChainSync_Serialised_BlockHeader
   -> Bool
 prop_codec_splits2_ChainSyncSerialised msg =
     ST.runST $ prop_codec_splitsM
@@ -475,7 +484,7 @@ prop_codec_splits2_ChainSyncSerialised msg =
       msg
 
 prop_codec_splits3_ChainSyncSerialised
-  :: AnyMessageAndAgency (ChainSync (Serialised BlockHeader) (Tip BlockHeader))
+  :: AnyMessageAndAgency ChainSync_Serialised_BlockHeader
   -> Bool
 prop_codec_splits3_ChainSyncSerialised msg =
     ST.runST $ prop_codec_splitsM
@@ -484,21 +493,21 @@ prop_codec_splits3_ChainSyncSerialised msg =
       msg
 
 prop_codec_cbor_ChainSyncSerialised
-  :: AnyMessageAndAgency (ChainSync (Serialised BlockHeader) (Tip BlockHeader))
+  :: AnyMessageAndAgency ChainSync_Serialised_BlockHeader
   -> Bool
 prop_codec_cbor_ChainSyncSerialised msg =
     ST.runST (prop_codec_cborM codecSerialised msg)
 
 prop_codec_binary_compat_ChainSync_ChainSyncSerialised
-  :: AnyMessageAndAgency (ChainSync BlockHeader (Tip BlockHeader))
+  :: AnyMessageAndAgency ChainSync_BlockHeader
   -> Bool
 prop_codec_binary_compat_ChainSync_ChainSyncSerialised msg =
     ST.runST (prop_codec_binary_compatM codecWrapped codecSerialised stokEq msg)
   where
     stokEq
-      :: forall pr (stA :: ChainSync BlockHeader (Tip BlockHeader)).
+      :: forall pr (stA :: ChainSync_BlockHeader).
          PeerHasAgency pr stA
-      -> SamePeerHasAgency pr (ChainSync (Serialised BlockHeader) (Tip BlockHeader))
+      -> SamePeerHasAgency pr ChainSync_Serialised_BlockHeader
     stokEq (ClientAgency ca) = case ca of
       TokIdle -> SamePeerHasAgency $ ClientAgency TokIdle
     stokEq (ServerAgency sa) = case sa of
@@ -506,15 +515,15 @@ prop_codec_binary_compat_ChainSync_ChainSyncSerialised msg =
       TokIntersect -> SamePeerHasAgency $ ServerAgency TokIntersect
 
 prop_codec_binary_compat_ChainSyncSerialised_ChainSync
-  :: AnyMessageAndAgency (ChainSync (Serialised BlockHeader) (Tip BlockHeader))
+  :: AnyMessageAndAgency ChainSync_Serialised_BlockHeader
   -> Bool
 prop_codec_binary_compat_ChainSyncSerialised_ChainSync msg =
     ST.runST (prop_codec_binary_compatM codecSerialised codecWrapped stokEq msg)
   where
     stokEq
-      :: forall pr (stA :: ChainSync (Serialised BlockHeader) (Tip BlockHeader)).
+      :: forall pr (stA :: ChainSync_Serialised_BlockHeader).
          PeerHasAgency pr stA
-      -> SamePeerHasAgency pr (ChainSync BlockHeader (Tip BlockHeader))
+      -> SamePeerHasAgency pr ChainSync_BlockHeader
     stokEq (ClientAgency ca) = case ca of
       TokIdle -> SamePeerHasAgency $ ClientAgency TokIdle
     stokEq (ServerAgency sa) = case sa of
@@ -538,12 +547,12 @@ chainSyncDemo clientChan serverChan (ChainProducerStateForkTest cps chain) = do
   chainVar <- atomically $ newTVar chain
   doneVar  <- atomically $ newTVar False
 
-  let server :: ChainSyncServer Block (Tip Block) m a
+  let server :: ChainSyncServer Block (Point Block) (Tip Block) m a
       server = ChainSyncExamples.chainSyncServerExample
         (error "chainSyncServerExample: lazy in the result type")
         cpsVar
 
-      client :: ChainSyncClient Block (Tip Block) m ()
+      client :: ChainSyncClient Block (Point Block) (Tip Block) m ()
       client = ChainSyncExamples.chainSyncClientExample chainVar (testClient doneVar (Chain.headPoint pchain))
 
   void $ forkIO (void $ runPeer nullTracer codec serverChan (chainSyncServerPeer server))
@@ -596,8 +605,8 @@ chainSyncDemoPipelined
   => Channel m ByteString
   -> Channel m ByteString
   -> (forall a. StrictTVar m (Chain Block)
-      -> Client Block (Tip Block) m a
-      -> ChainSyncClientPipelined Block (Tip Block) m a)
+      -> Client                   Block (Point Block) (Tip Block) m a
+      -> ChainSyncClientPipelined Block (Point Block) (Tip Block) m a)
   -> ChainProducerStateForkTest
   -> m Property
 chainSyncDemoPipelined clientChan serverChan mkClient (ChainProducerStateForkTest cps chain) = do
@@ -606,12 +615,12 @@ chainSyncDemoPipelined clientChan serverChan mkClient (ChainProducerStateForkTes
   chainVar <- atomically $ newTVar chain
   doneVar  <- atomically $ newTVar False
 
-  let server :: ChainSyncServer Block (Tip Block) m a
+  let server :: ChainSyncServer Block (Point Block) (Tip Block) m a
       server = ChainSyncExamples.chainSyncServerExample
         (error "chainSyncServerExample: lazy in the result type")
         cpsVar
 
-      client :: ChainSyncClientPipelined Block (Tip Block) m ()
+      client :: ChainSyncClientPipelined Block (Point Block) (Tip Block) m ()
       client = mkClient chainVar (testClient doneVar (Chain.headPoint pchain))
 
   void $ forkIO (void $ runPeer nullTracer codec serverChan (chainSyncServerPeer server))

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Direct.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Direct.hs
@@ -8,10 +8,10 @@ import           Ouroboros.Network.Protocol.LocalStateQuery.Client
 import           Ouroboros.Network.Protocol.LocalStateQuery.Server
 
 direct
-  :: forall block query m a b.
+  :: forall block point query m a b.
      Monad m
-  => LocalStateQueryClient block query m a
-  -> LocalStateQueryServer block query m b
+  => LocalStateQueryClient block point query m a
+  -> LocalStateQueryServer block point query m b
   -> m (a, b)
 direct (LocalStateQueryClient mclient) (LocalStateQueryServer mserver) = do
     client <- mclient
@@ -19,8 +19,8 @@ direct (LocalStateQueryClient mclient) (LocalStateQueryServer mserver) = do
     directIdle client server
   where
     directIdle
-      :: ClientStIdle block query m a
-      -> ServerStIdle block query m b
+      :: ClientStIdle block point query m a
+      -> ServerStIdle block point query m b
       -> m (a, b)
     directIdle (SendMsgAcquire pt client') ServerStIdle{recvMsgAcquire} = do
       server' <- recvMsgAcquire pt
@@ -30,8 +30,8 @@ direct (LocalStateQueryClient mclient) (LocalStateQueryServer mserver) = do
       return (a, b)
 
     directAcquiring
-      :: ClientStAcquiring block query m a
-      -> ServerStAcquiring block query m b
+      :: ClientStAcquiring block point query m a
+      -> ServerStAcquiring block point query m b
       -> m (a, b)
     directAcquiring ClientStAcquiring{recvMsgAcquired} (SendMsgAcquired server') =
       let client' = recvMsgAcquired
@@ -41,8 +41,8 @@ direct (LocalStateQueryClient mclient) (LocalStateQueryServer mserver) = do
       directIdle client' server'
 
     directAcquired
-      :: ClientStAcquired block query m a
-      -> ServerStAcquired block query m b
+      :: ClientStAcquired block point query m a
+      -> ServerStAcquired block point query m b
       -> m (a, b)
     directAcquired (SendMsgQuery query client') ServerStAcquired{recvMsgQuery} = do
       server' <- recvMsgQuery query
@@ -56,8 +56,8 @@ direct (LocalStateQueryClient mclient) (LocalStateQueryServer mserver) = do
       directIdle client' server'
 
     directQuerying
-      :: ClientStQuerying block query m a result
-      -> ServerStQuerying block query m b result
+      :: ClientStQuerying block point query m a result
+      -> ServerStQuerying block point query m b result
       -> m (a, b)
     directQuerying ClientStQuerying{recvMsgResult} (SendMsgResult result server') = do
       client' <- recvMsgResult result

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/LocalStateQuery/Test.hs
@@ -229,7 +229,7 @@ instance Arbitrary AcquireFailure where
 instance Arbitrary (Query (Point Block)) where
   arbitrary = pure QueryPoint
 
-instance Arbitrary (AnyMessageAndAgency (LocalStateQuery Block Query)) where
+instance Arbitrary (AnyMessageAndAgency (LocalStateQuery Block (Point Block) Query)) where
   arbitrary = oneof
     [ AnyMessageAndAgency (ClientAgency TokIdle) <$>
         (MsgAcquire <$> arbitrary)
@@ -259,7 +259,7 @@ instance Arbitrary (AnyMessageAndAgency (LocalStateQuery Block Query)) where
 instance ShowQuery Query where
   showResult QueryPoint = show
 
-instance  Eq (AnyMessage (LocalStateQuery Block Query)) where
+instance  Eq (AnyMessage (LocalStateQuery Block (Point Block) Query)) where
 
   (==) (AnyMessage (MsgAcquire pt))
        (AnyMessage (MsgAcquire pt')) = pt == pt'
@@ -293,7 +293,7 @@ instance  Eq (AnyMessage (LocalStateQuery Block Query)) where
 
 
 codec :: MonadST m
-      => Codec (LocalStateQuery Block Query)
+      => Codec (LocalStateQuery Block (Point Block) Query)
                 DeserialiseFailure
                 m ByteString
 codec = codecLocalStateQuery
@@ -317,24 +317,30 @@ codec = codecLocalStateQuery
 
 -- | Check the codec round trip property.
 --
-prop_codec :: AnyMessageAndAgency (LocalStateQuery Block Query) -> Bool
+prop_codec
+  :: AnyMessageAndAgency (LocalStateQuery Block (Point Block) Query)
+  -> Bool
 prop_codec msg =
   runST (prop_codecM codec msg)
 
 -- | Check for data chunk boundary problems in the codec using 2 chunks.
 --
-prop_codec_splits2 :: AnyMessageAndAgency (LocalStateQuery Block Query) -> Bool
+prop_codec_splits2
+  :: AnyMessageAndAgency (LocalStateQuery Block (Point Block) Query)
+  -> Bool
 prop_codec_splits2 msg =
   runST (prop_codec_splitsM splits2 codec msg)
 
 -- | Check for data chunk boundary problems in the codec using 3 chunks.
 --
-prop_codec_splits3 :: AnyMessageAndAgency (LocalStateQuery Block Query) -> Bool
+prop_codec_splits3
+  :: AnyMessageAndAgency (LocalStateQuery Block (Point Block) Query)
+  -> Bool
 prop_codec_splits3 msg =
   runST (prop_codec_splitsM splits3 codec msg)
 
 prop_codec_cbor
-  :: AnyMessageAndAgency (LocalStateQuery Block Query)
+  :: AnyMessageAndAgency (LocalStateQuery Block (Point Block) Query)
   -> Bool
 prop_codec_cbor msg =
   runST (prop_codec_cborM codec msg)

--- a/ouroboros-network/protocol-tests/Test/ChainGenerators.hs
+++ b/ouroboros-network/protocol-tests/Test/ChainGenerators.hs
@@ -130,7 +130,7 @@ instance Arbitrary (Point Block) where
          . shrink
          .     (castPoint :: Point Block -> Point BlockHeader)
 
-instance Arbitrary (ChainRange Block) where
+instance Arbitrary (ChainRange (Point Block)) where
   arbitrary = do
     low  <- arbitrary
     high <- arbitrary `suchThat` (\high -> pointSlot low <= pointSlot high)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -371,7 +371,7 @@ data TraceFetchClientState header =
        -- 'CompletedFetchBatch'.
        --
      | StartedFetchBatch
-         (ChainRange header)
+         (ChainRange (Point header))
          (PeerFetchInFlight header)
           PeerFetchInFlightLimits
          (PeerFetchStatus header)
@@ -388,7 +388,7 @@ data TraceFetchClientState header =
        -- | Mark the successful end of receiving a streaming batch of blocks
        --
      | CompletedFetchBatch
-         (ChainRange header)
+         (ChainRange (Point header))
          (PeerFetchInFlight header)
           PeerFetchInFlightLimits
          (PeerFetchStatus header)
@@ -397,7 +397,7 @@ data TraceFetchClientState header =
        -- instead of 'StartedFetchBatch' and 'CompletedFetchBatch'.
        --
      | RejectedFetchBatch
-         (ChainRange header)
+         (ChainRange (Point header))
          (PeerFetchInFlight header)
           PeerFetchInFlightLimits
          (PeerFetchStatus header)
@@ -504,7 +504,7 @@ acknowledgeFetchRequest tracer controlMessageSTM FetchClientStateVars {fetchClie
 startedFetchBatch :: MonadSTM m
                   => Tracer m (TraceFetchClientState header)
                   -> PeerFetchInFlightLimits
-                  -> ChainRange header
+                  -> ChainRange (Point header)
                   -> FetchClientStateVars m header
                   -> m ()
 startedFetchBatch tracer inflightlimits range
@@ -560,7 +560,7 @@ completeBlockDownload tracer blockFetchSize inflightlimits header
 completeFetchBatch :: MonadSTM m
                    => Tracer m (TraceFetchClientState header)
                    -> PeerFetchInFlightLimits
-                   -> ChainRange header
+                   -> ChainRange (Point header)
                    -> FetchClientStateVars m header
                    -> m ()
 completeFetchBatch tracer inflightlimits range
@@ -600,7 +600,7 @@ rejectedFetchBatch :: (MonadSTM m, HasHeader header)
                    => Tracer m (TraceFetchClientState header)
                    -> (header -> SizeInBytes)
                    -> PeerFetchInFlightLimits
-                   -> ChainRange header
+                   -> ChainRange (Point header)
                    -> [header]
                    -> FetchClientStateVars m header
                    -> m ()

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -611,8 +611,8 @@ type LocalConnectionId = ConnectionId LocalAddress
 --
 
 chainSyncPeerNull
-    :: forall (header :: Type) (tip :: Type) m a. MonadTimer m
-    => Peer (ChainSync.ChainSync header tip)
+    :: forall (header :: Type) (point :: Type) (tip :: Type) m a. MonadTimer m
+    => Peer (ChainSync.ChainSync header point tip)
             AsClient ChainSync.StIdle m a
 chainSyncPeerNull =
     ChainSync.chainSyncClientPeer

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -619,8 +619,9 @@ chainSyncPeerNull =
       (ChainSync.ChainSyncClient untilTheCowsComeHome )
 
 localStateQueryPeerNull
-    :: forall (block :: Type) (query :: Type -> Type) m a. MonadTimer m
-    => Peer (LocalStateQuery.LocalStateQuery block query)
+    :: forall (block :: Type) (point :: Type) (query :: Type -> Type) m a.
+       MonadTimer m
+    => Peer (LocalStateQuery.LocalStateQuery block point query)
             AsClient LocalStateQuery.StIdle m a
 localStateQueryPeerNull =
     LocalStateQuery.localStateQueryClientPeer

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Server.hs
@@ -12,56 +12,56 @@ import Network.TypedProtocol.Core
 import Ouroboros.Network.Protocol.BlockFetch.Type
 
 
-data BlockFetchServer block m a where
+data BlockFetchServer block point m a where
   BlockFetchServer
-    :: (ChainRange block -> m (BlockFetchBlockSender block m a))
+    :: (ChainRange point -> m (BlockFetchBlockSender block point m a))
     -> a
-    -> BlockFetchServer block m a
+    -> BlockFetchServer block point m a
 
 -- | Send batches of blocks, when a batch is sent loop using
 -- @'BlockFetchServer'@.
 --
-data BlockFetchBlockSender block m a where
+data BlockFetchBlockSender block point m a where
 
   -- | Initiate a batch of blocks.
   SendMsgStartBatch
-    :: m (BlockFetchSendBlocks block m a)
-    -> BlockFetchBlockSender block m a
+    :: m (BlockFetchSendBlocks block point m a)
+    -> BlockFetchBlockSender block point m a
 
   SendMsgNoBlocks
-    :: m (BlockFetchServer block m a)
-    -> BlockFetchBlockSender block m a
+    :: m (BlockFetchServer block point m a)
+    -> BlockFetchBlockSender block point m a
 
 -- | Stream batch of blocks
 --
-data BlockFetchSendBlocks block m a where
+data BlockFetchSendBlocks block point m a where
 
   -- | Send a single block and recurse.
   --
   SendMsgBlock
     :: block
-    -> m (BlockFetchSendBlocks block m a)
-    -> BlockFetchSendBlocks block m a
+    -> m (BlockFetchSendBlocks block point m a)
+    -> BlockFetchSendBlocks block point m a
 
   -- | End of the stream of block bodies.
   --
   SendMsgBatchDone
-    :: m (BlockFetchServer block m a)
-    -> BlockFetchSendBlocks block m a
+    :: m (BlockFetchServer block point m a)
+    -> BlockFetchSendBlocks block point m a
 
 blockFetchServerPeer
-  :: forall block m a.
+  :: forall block point m a.
      Functor m
-  => BlockFetchServer block m a
-  -> Peer (BlockFetch block) AsServer BFIdle m a
+  => BlockFetchServer block point m a
+  -> Peer (BlockFetch block point) AsServer BFIdle m a
 blockFetchServerPeer (BlockFetchServer requestHandler result) =
     Await (ClientAgency TokIdle) $ \msg -> case msg of
       MsgRequestRange range -> Effect $ sendBatch <$> requestHandler range
       MsgClientDone         -> Done TokDone result
  where
   sendBatch
-    :: BlockFetchBlockSender block m a
-    -> Peer (BlockFetch block) AsServer BFBusy m a
+    :: BlockFetchBlockSender block point m a
+    -> Peer (BlockFetch block point) AsServer BFBusy m a
 
   sendBatch (SendMsgStartBatch mblocks) =
     Yield (ServerAgency TokBusy) MsgStartBatch $
@@ -75,8 +75,8 @@ blockFetchServerPeer (BlockFetchServer requestHandler result) =
 
 
   sendBlocks
-    :: BlockFetchSendBlocks block m a
-    -> Peer (BlockFetch block) AsServer BFStreaming m a
+    :: BlockFetchSendBlocks block point m a
+    -> Peer (BlockFetch block point) AsServer BFStreaming m a
 
   sendBlocks (SendMsgBlock block next') =
     Yield (ServerAgency TokStreaming) (MsgBlock block) $

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Examples.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Examples.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Ouroboros.Network.Protocol.LocalStateQuery.Examples where
 
-import           Ouroboros.Network.Block (Point)
-
 import           Ouroboros.Network.Protocol.LocalStateQuery.Client
 import           Ouroboros.Network.Protocol.LocalStateQuery.Server
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type
@@ -20,37 +18,38 @@ import           Ouroboros.Network.Protocol.LocalStateQuery.Type
 -- the 'AcquireFailure' is returned instead of the query results.
 --
 localStateQueryClient
-  :: forall block query result m. Applicative m
-  => [(Point block, query result)]
-  -> LocalStateQueryClient block query m
-                           [(Point block, Either AcquireFailure result)]
+  :: forall block point query result m.
+     Applicative m
+  => [(point, query result)]
+  -> LocalStateQueryClient block point query m
+                           [(point, Either AcquireFailure result)]
 localStateQueryClient = LocalStateQueryClient . pure . goIdle []
   where
     goIdle
-      :: [(Point block, Either AcquireFailure result)]  -- ^ Accumulator
-      -> [(Point block, query result)]  -- ^ Remainder
-      -> ClientStIdle block query m
-                      [(Point block, Either AcquireFailure result)]
+      :: [(point, Either AcquireFailure result)]  -- ^ Accumulator
+      -> [(point, query result)]  -- ^ Remainder
+      -> ClientStIdle block point query m
+                      [(point, Either AcquireFailure result)]
     goIdle acc []              = SendMsgDone $ reverse acc
     goIdle acc ((pt, q):ptqs') = SendMsgAcquire pt $ goAcquiring acc pt q ptqs'
 
     goAcquiring
-      :: [(Point block, Either AcquireFailure result)]  -- ^ Accumulator
-      -> Point block
+      :: [(point, Either AcquireFailure result)]  -- ^ Accumulator
+      -> point
       -> query result
-      -> [(Point block, query result)]  -- ^ Remainder
-      -> ClientStAcquiring block query m
-                           [(Point block, Either AcquireFailure result)]
+      -> [(point, query result)]  -- ^ Remainder
+      -> ClientStAcquiring block point query m
+                           [(point, Either AcquireFailure result)]
     goAcquiring acc pt q ptqss' = ClientStAcquiring {
         recvMsgAcquired = goQuery q $ \r -> goAcquired ((pt, Right r):acc) ptqss'
       , recvMsgFailure  = \failure -> pure $ goIdle ((pt, Left failure):acc) ptqss'
       }
 
     goAcquired
-      :: [(Point block, Either AcquireFailure result)]
-      -> [(Point block, query result)]   -- ^ Remainder
-      -> ClientStAcquired block query m
-                          [(Point block, Either AcquireFailure result)]
+      :: [(point, Either AcquireFailure result)]
+      -> [(point, query result)]   -- ^ Remainder
+      -> ClientStAcquired block point query m
+                          [(point, Either AcquireFailure result)]
     goAcquired acc [] = SendMsgRelease $ pure $ SendMsgDone $ reverse acc
     goAcquired acc ((pt, qs):ptqss') = SendMsgReAcquire pt $
       goAcquiring acc pt qs ptqss'
@@ -58,9 +57,9 @@ localStateQueryClient = LocalStateQueryClient . pure . goIdle []
     goQuery
       :: forall a.
          query result
-      -> (result -> ClientStAcquired block query m a)
+      -> (result -> ClientStAcquired block point query m a)
          -- ^ Continuation
-      -> ClientStAcquired block query m a
+      -> ClientStAcquired block point query m a
     goQuery q k = SendMsgQuery q $ ClientStQuerying $ \r -> pure $ k r
 
 --
@@ -71,25 +70,25 @@ localStateQueryClient = LocalStateQueryClient . pure . goIdle []
 -- acquire a @state@, after which the second will be used to query the state.
 --
 localStateQueryServer
-  :: forall block query m state. Applicative m
-  => (Point block -> Either AcquireFailure state)
+  :: forall block point query m state. Applicative m
+  => (point -> Either AcquireFailure state)
   -> (forall result. state -> query result -> result)
-  -> LocalStateQueryServer block query m ()
+  -> LocalStateQueryServer block point query m ()
 localStateQueryServer acquire answer =
     LocalStateQueryServer $ pure goIdle
   where
-    goIdle :: ServerStIdle block query m ()
+    goIdle :: ServerStIdle block point query m ()
     goIdle = ServerStIdle {
         recvMsgAcquire = goAcquiring
       , recvMsgDone    = pure ()
       }
 
-    goAcquiring :: Point block -> m (ServerStAcquiring block query m ())
+    goAcquiring :: point -> m (ServerStAcquiring block point query m ())
     goAcquiring pt = pure $ case acquire pt of
       Left failure -> SendMsgFailure failure goIdle
       Right state  -> SendMsgAcquired $ goAcquired state
 
-    goAcquired :: state -> ServerStAcquired block query m ()
+    goAcquired :: state -> ServerStAcquired block point query m ()
     goAcquired state = ServerStAcquired {
         recvMsgQuery     = \query ->
           pure $ SendMsgResult (answer state query) $ goAcquired state

--- a/ouroboros-network/test-cddl/Main.hs
+++ b/ouroboros-network/test-cddl/Main.hs
@@ -84,7 +84,7 @@ tests specPath =
 
 -- The concrete/monomorphic types used for the test.
 type MonoCodec x = Codec x DeserialiseFailure IO ByteString
-type CS = ChainSync BlockHeader (Tip BlockHeader)
+type CS = ChainSync BlockHeader (Point BlockHeader) (Tip BlockHeader)
 type BF = BlockFetch Block
 type HS = Handshake VersionNumber CBOR.Term
 type TS = TxSubmission TxId Tx

--- a/ouroboros-network/test-cddl/Main.hs
+++ b/ouroboros-network/test-cddl/Main.hs
@@ -85,7 +85,7 @@ tests specPath =
 -- The concrete/monomorphic types used for the test.
 type MonoCodec x = Codec x DeserialiseFailure IO ByteString
 type CS = ChainSync BlockHeader (Point BlockHeader) (Tip BlockHeader)
-type BF = BlockFetch Block
+type BF = BlockFetch Block (Point Block)
 type HS = Handshake VersionNumber CBOR.Term
 type TS = TxSubmission TxId Tx
 type LT = LocalTxSubmission LocalTxSubmission.Tx LocalTxSubmission.Reject

--- a/ouroboros-network/test/Ouroboros/Network/MockNode.hs
+++ b/ouroboros-network/test/Ouroboros/Network/MockNode.hs
@@ -108,10 +108,10 @@ chainValidation peerChainVar candidateChainVar = do
 -- | Simulated network channels for a given network node.
 --
 data NodeChannels m block tip = NodeChannels
-  { consumerChans :: [Channel m (AnyMessage (ChainSync block tip))]
+  { consumerChans :: [Channel m (AnyMessage (ChainSync block (Point block) tip))]
     -- ^ channels on which the node will play the consumer role:
     -- sending @consMsg@ and receiving @prodMsg@ messages.
-  , producerChans :: [Channel m (AnyMessage (ChainSync block tip))]
+  , producerChans :: [Channel m (AnyMessage (ChainSync block (Point block) tip))]
     -- ^ channels on which the node will play the producer role:
     -- sending @prodMsg@ and receiving @consMsg@ messages.
   }
@@ -304,7 +304,7 @@ relayNode _nid initChain chans = do
     -- state between producers than necessary (here are producers share chain
     -- state and all the reader states, while we could share just the chain).
     startConsumer :: Int
-                  -> Channel m (AnyMessage (ChainSync block (Tip block)))
+                  -> Channel m (AnyMessage (ChainSync block (Point block) (Tip block)))
                   -> m (StrictTVar m (Chain block))
     startConsumer _cid channel = do
       chainVar <- atomically $ newTVar Genesis
@@ -315,9 +315,9 @@ relayNode _nid initChain chans = do
                                    consumer
       return chainVar
 
-    startProducer :: Peer (ChainSync block (Tip block)) AsServer StIdle m ()
+    startProducer :: Peer (ChainSync block (Point block) (Tip block)) AsServer StIdle m ()
                   -> Int
-                  -> Channel m (AnyMessage (ChainSync block (Tip block)))
+                  -> Channel m (AnyMessage (ChainSync block (Point block) (Tip block)))
                   -> m ()
     startProducer producer _pid channel =
       -- use 'void' because 'forkIO' only works with 'm ()'

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -121,7 +121,8 @@ demo chain0 updates delay = do
                (encodeTip encode) (decodeTip decode))
             consumerPeer
 
-        consumerPeer :: Peer (ChainSync.ChainSync block (Tip block)) AsClient ChainSync.StIdle m ()
+        consumerPeer :: Peer (ChainSync.ChainSync block (Point block) (Tip block))
+                             AsClient ChainSync.StIdle m ()
         consumerPeer = ChainSync.chainSyncClientPeer
                           (ChainSync.chainSyncClientExample consumerVar
                           (consumerClient done target consumerVar))
@@ -138,7 +139,8 @@ demo chain0 updates delay = do
                (encodeTip encode) (decodeTip decode))
             producerPeer
 
-        producerPeer :: Peer (ChainSync.ChainSync block (Tip block)) AsServer ChainSync.StIdle m ()
+        producerPeer :: Peer (ChainSync.ChainSync block (Point block) (Tip block))
+                        AsServer ChainSync.StIdle m ()
         producerPeer = ChainSync.chainSyncServerPeer (ChainSync.chainSyncServerExample () producerVar)
 
     let clientBearer = Mx.queuesAsMuxBearer activeTracer client_w client_r sduLen
@@ -187,7 +189,7 @@ demo chain0 updates delay = do
     consumerClient :: StrictTMVar m Bool
                    -> Point block
                    -> StrictTVar m (Chain block)
-                   -> ChainSync.Client block (Tip block) m ()
+                   -> ChainSync.Client block (Point block) (Tip block) m ()
     consumerClient done target chain =
       ChainSync.Client
         { ChainSync.rollforward = \_ -> checkTip target chain >>= \b ->

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -203,7 +203,7 @@ data Example1TraceEvent =
    | TraceFetchClientState    (TraceLabelPeer Int
                                 (TraceFetchClientState BlockHeader))
    | TraceFetchClientSendRecv (TraceLabelPeer Int
-                                (TraceSendRecv (BlockFetch Block)))
+                                (TraceSendRecv (BlockFetch Block (Point Block))))
 
 instance Show Example1TraceEvent where
   show (TraceFetchDecision       x) = "TraceFetchDecision " ++ show x

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -170,7 +170,7 @@ demo chain0 updates = do
                           (ChainSync.chainSyncClientExample consumerVar
                           (consumerClient done target consumerVar)))
 
-            server :: ChainSyncServer block (Tip block) IO ()
+            server :: ChainSyncServer block (Point block) (Tip block) IO ()
             server = ChainSync.chainSyncServerExample () producerVar
 
             producerApp ::OuroborosApplication ResponderMode String BL.ByteString IO Void ()
@@ -226,7 +226,7 @@ demo chain0 updates = do
     consumerClient :: StrictTMVar IO Bool
                    -> Point block
                    -> StrictTVar IO (Chain block)
-                   -> ChainSync.Client block (Tip block) IO ()
+                   -> ChainSync.Client block (Point block) (Tip block) IO ()
     consumerClient done target chain =
       ChainSync.Client
         { ChainSync.rollforward = \_ -> checkTip target chain >>= \b ->

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -132,7 +132,7 @@ demo chain0 updates = withIOManager $ \iocp -> do
                         (ChainSync.chainSyncClientExample consumerVar
                         (consumerClient done target consumerVar)))
 
-        server :: ChainSync.ChainSyncServer block (Tip block) IO ()
+        server :: ChainSync.ChainSyncServer block (Point block) (Tip block) IO ()
         server = ChainSync.chainSyncServerExample () producerVar
 
         responderApp
@@ -205,7 +205,7 @@ demo chain0 updates = withIOManager $ \iocp -> do
     consumerClient :: StrictTMVar IO Bool
                    -> Point block
                    -> StrictTVar IO (Chain block)
-                   -> ChainSync.Client block (Tip block) IO ()
+                   -> ChainSync.Client block (Point block) (Tip block) IO ()
     consumerClient done target chain =
       ChainSync.Client
         { ChainSync.rollforward = \_ -> checkTip target chain >>= \b ->


### PR DESCRIPTION
Instead of relying on the Point type family, paramaterise the protocol
types over a point type paramater. We still choose to use the protocols
at the same types, using Point, but it lets us write protocols at other
types.
    
In particular in the cardano-api where we want to present the node's
client protocols in as simple a way as possible, we would like to use
specific a monomorphic type for ChainPoint, rather than the (somewhat
complicated) Point type family used by the network and consensus layer.
So by allowing the protocol types to be instantiated with this surface
type we can both present a simpler interface, and still map it down to
the underlying types used by the consensus and network layers.