### PR TITLE
Add support for duplicate txids.

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
@@ -174,6 +174,7 @@ txSubmissionOutbound tracer maxUnacked TxSubmissionMempoolReader{..} _version co
 
           MempoolSnapshot{mempoolLookupTx} <- atomically mempoolGetSnapshot
 
+          -- The window size is expected to be small (currently 10) so the find is acceptable.
           let txidxs  = [ find (\(t,_) -> t == txid) unackedSeq | txid <- txids ]
               txidxs' = map snd $ catMaybes txidxs
 


### PR DESCRIPTION
When the server asks for new txids from the client it can't assume that
those txids doesn't already exist in its buffer.

The TxSubmission test suite has been updated so that it doesn't generate
unique txids anymore.