### PR TITLE
generalize Node.run for invocation from both real node and from ThreadNet tests and refine interface used by real node

### DIFF
--- a/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
@@ -167,11 +167,12 @@ analyse CmdLine {..} args =
       let chunkInfo  = Node.nodeImmutableDbChunkInfo (configStorage cfg)
           args' =
             Node.mkChainDbArgs
-              tracer registry InFuture.dontCheck cfg initLedger chunkInfo $
-              Node.stdMkChainDbHasFS dbDir
+              registry InFuture.dontCheck cfg initLedger chunkInfo $
+            ChainDB.defaultArgs (Node.stdMkChainDbHasFS dbDir)
           chainDbArgs = args' {
               ChainDB.cdbImmutableDbValidation = immValidationPolicy
             , ChainDB.cdbVolatileDbValidation  = volValidationPolicy
+            , ChainDB.cdbTracer                = tracer
             }
           (immutableDbArgs, _, _, _) = fromChainDbArgs chainDbArgs
 

--- a/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
@@ -165,8 +165,10 @@ analyse CmdLine {..} args =
       ProtocolInfo { pInfoInitLedger = initLedger, pInfoConfig = cfg } <-
         mkProtocolInfo args
       let chunkInfo  = Node.nodeImmutableDbChunkInfo (configStorage cfg)
-          args' = Node.mkChainDbArgs tracer registry InFuture.dontCheck
-                    dbDir cfg initLedger chunkInfo
+          args' =
+            Node.mkChainDbArgs
+              tracer registry InFuture.dontCheck cfg initLedger chunkInfo $
+              Node.stdMkChainDbHasFS dbDir
           chainDbArgs = args' {
               ChainDB.cdbImmutableDbValidation = immValidationPolicy
             , ChainDB.cdbVolatileDbValidation  = volValidationPolicy

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -965,7 +965,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
 
       let kaRng = case seed of
                     Seed s -> mkStdGen s
-      let nodeArgs = NodeArgs
+      let nodeKernelArgs = NodeKernelArgs
             { tracers
             , registry
             , cfg                     = pInfoConfig
@@ -994,7 +994,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                 }
             }
 
-      nodeKernel <- initNodeKernel nodeArgs
+      nodeKernel <- initNodeKernel nodeKernelArgs
       let mempool = getMempool nodeKernel
       let app = NTN.mkApps
                   nodeKernel
@@ -1007,7 +1007,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                      { canAwaitTimeout  = waitForever
                      , mustReplyTimeout = waitForever
                      })
-                  (NTN.mkHandlers nodeArgs nodeKernel)
+                  (NTN.mkHandlers nodeKernelArgs nodeKernel)
 
       -- In practice, a robust wallet/user can persistently add a transaction
       -- until it appears on the chain. This thread adds robustness for the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -99,10 +99,10 @@ data Handlers m peer blk = Handlers {
 mkHandlers
   :: forall m blk remotePeer localPeer.
      (IOLike m, LedgerSupportsMempool blk, QueryLedger blk)
-  => NodeArgs   m remotePeer localPeer blk
-  -> NodeKernel m remotePeer localPeer blk
-  -> Handlers   m            localPeer blk
-mkHandlers NodeArgs {cfg, tracers} NodeKernel {getChainDB, getMempool} =
+  => NodeKernelArgs m remotePeer localPeer blk
+  -> NodeKernel     m remotePeer localPeer blk
+  -> Handlers       m            localPeer blk
+mkHandlers NodeKernelArgs {cfg, tracers} NodeKernel {getChainDB, getMempool} =
     Handlers {
         hChainSyncServer =
           chainSyncBlocksServer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -158,11 +158,11 @@ mkHandlers
      , LedgerSupportsProtocol blk
      , Ord remotePeer
      )
-  => NodeArgs   m remotePeer localPeer blk
-  -> NodeKernel m remotePeer localPeer blk
-  -> Handlers   m remotePeer           blk
+  => NodeKernelArgs m remotePeer localPeer blk
+  -> NodeKernel     m remotePeer localPeer blk
+  -> Handlers       m remotePeer           blk
 mkHandlers
-      NodeArgs {keepAliveRng, miniProtocolParameters}
+      NodeKernelArgs {keepAliveRng, miniProtocolParameters}
       NodeKernel {getChainDB, getMempool, getTopLevelConfig, getTracers = tracers} =
     Handlers {
         hChainSyncClient =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -129,7 +129,7 @@ data RunNodeArgs m addrNTN addrNTC blk = RunNodeArgs {
     , rnProtocolInfo :: ProtocolInfo m blk
 
       -- | node-to-node protocol versions to run.
-    , rnNodeToNodeVersions   :: Map NodeToNodeVersion (BlockNodeToNodeVersion blk)
+    , rnNodeToNodeVersions :: Map NodeToNodeVersion (BlockNodeToNodeVersion blk)
 
       -- | node-to-client protocol versions to run.
     , rnNodeToClientVersions :: Map NodeToClientVersion (BlockNodeToClientVersion blk)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -142,11 +142,6 @@ data RunNodeArgs m addrNTN addrNTC blk = RunNodeArgs {
                        -> NodeKernel m (ConnectionId addrNTN) (ConnectionId addrNTC) blk
                        -> m ()
 
-      -- | Maximum clock skew.
-      --
-      -- Use 'defaultClockSkew' when unsure.
-    , rnMaxClockSkew :: ClockSkew
-
     }
 
 -- | Arguments that a non-testing invocation of 'runWith' would not need to
@@ -200,6 +195,8 @@ data LowLevelRunNodeArgs m addrNTN addrNTC versionDataNTN versionDataNTC blk = L
 
     , rnVersionDataNTN :: versionDataNTN
 
+      -- | Maximum clock skew
+    , rnMaxClockSkew :: ClockSkew
     }
 
 -- | Combination of 'runWith' and 'stdLowLevelRunArgsIO'
@@ -653,6 +650,8 @@ stdLowLevelRunNodeArgsIO StdRunNodeArgs{..} = do
             (daDiffusionMode srnDiffusionArguments)
       , rnWithCheckedDB =
           stdWithCheckedDB srnDatabasePath srnNetworkMagic
+      , rnMaxClockSkew =
+          InFuture.defaultClockSkew
       }
   where
     mkHasFS :: ChainDB.RelativeMountPoint -> SomeHasFS IO

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -46,11 +46,12 @@ import           System.Random (newStdGen, randomIO, randomRIO)
 import           Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..))
 import           Ouroboros.Network.Diffusion
 import           Ouroboros.Network.Magic
-import           Ouroboros.Network.NodeToClient (LocalConnectionId,
-                     NodeToClientVersionData (..))
+import           Ouroboros.Network.NodeToClient (LocalAddress,
+                     LocalConnectionId, NodeToClientVersionData (..))
 import           Ouroboros.Network.NodeToNode (MiniProtocolParameters (..),
-                     NodeToNodeVersionData (..), RemoteConnectionId,
-                     combineVersions, defaultMiniProtocolParameters)
+                     NodeToNodeVersionData (..), RemoteAddress,
+                     RemoteConnectionId, combineVersions,
+                     defaultMiniProtocolParameters)
 import           Ouroboros.Network.Protocol.Limits (shortWait)
 
 import           Ouroboros.Consensus.Block
@@ -299,6 +300,9 @@ run runargs@RunNodeArgs{..} =
           -> NTC.Apps IO LocalConnectionId      ByteString ByteString ByteString ()
          )
       -> DiffusionApplications
+           RemoteAddress LocalAddress
+           NodeToNodeVersionData NodeToClientVersionData
+           IO
     mkDiffusionApplications miniProtocolParams ntnApps ntcApps =
       DiffusionApplications {
           daResponderApplication = combineVersions [

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -15,7 +15,7 @@ module Ouroboros.Consensus.NodeKernel (
     NodeKernel (..)
   , MaxTxCapacityOverride (..)
   , MempoolCapacityBytesOverride (..)
-  , NodeArgs (..)
+  , NodeKernelArgs (..)
   , TraceForgeEvent (..)
   , initNodeKernel
   , getMempoolReader
@@ -114,7 +114,7 @@ data MaxTxCapacityOverride
     -- of a block.
 
 -- | Arguments required when initializing a node
-data NodeArgs m remotePeer localPeer blk = NodeArgs {
+data NodeKernelArgs m remotePeer localPeer blk = NodeKernelArgs {
       tracers                 :: Tracers m remotePeer localPeer blk
     , registry                :: ResourceRegistry m
     , cfg                     :: TopLevelConfig blk
@@ -138,11 +138,12 @@ initNodeKernel
        , Ord remotePeer
        , Hashable remotePeer
        )
-    => NodeArgs m remotePeer localPeer blk
+    => NodeKernelArgs m remotePeer localPeer blk
     -> m (NodeKernel m remotePeer localPeer blk)
-initNodeKernel args@NodeArgs { registry, cfg, tracers, maxTxCapacityOverride
-                             , blockForging, chainDB, initChainDB
-                             , blockFetchConfiguration } = do
+initNodeKernel args@NodeKernelArgs { registry, cfg, tracers, maxTxCapacityOverride
+                                   , blockForging, chainDB, initChainDB
+                                   , blockFetchConfiguration
+                                   } = do
 
     initChainDB (configStorage cfg) (InitChainDB.fromFull chainDB)
 
@@ -196,11 +197,12 @@ initInternalState
        , NoThunks remotePeer
        , RunNode blk
        )
-    => NodeArgs m remotePeer localPeer blk
+    => NodeKernelArgs m remotePeer localPeer blk
     -> m (InternalState m remotePeer localPeer blk)
-initInternalState NodeArgs { tracers, chainDB, registry, cfg,
-                             blockFetchSize, btime,
-                             mempoolCapacityOverride } = do
+initInternalState NodeKernelArgs { tracers, chainDB, registry, cfg
+                                 , blockFetchSize, btime
+                                 , mempoolCapacityOverride
+                                 } = do
     varCandidates <- newTVarIO mempty
     mempool       <- openMempool registry
                                  (chainDBLedgerInterface chainDB)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -25,6 +25,7 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl (
   , TraceIteratorEvent (..)
   , LgrDB.TraceLedgerReplayEvent
     -- * Re-exported for convenience
+  , Args.RelativeMountPoint (..)
   , ImmutableDB.ImmutableDbSerialiseConstraints
   , LgrDB.LgrDbSerialiseConstraints
   , VolatileDB.VolatileDbSerialiseConstraints

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -61,7 +61,6 @@ import qualified Data.Set as Set
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
-import           System.FilePath ((</>))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
@@ -80,9 +79,7 @@ import           Ouroboros.Consensus.Util.ResourceRegistry
 import           Ouroboros.Consensus.Storage.Common
 import           Ouroboros.Consensus.Storage.FS.API (SomeHasFS (..),
                      createDirectoryIfMissing)
-import           Ouroboros.Consensus.Storage.FS.API.Types (FsError,
-                     MountPoint (..), mkFsPath)
-import           Ouroboros.Consensus.Storage.FS.IO (ioHasFS)
+import           Ouroboros.Consensus.Storage.FS.API.Types (FsError, mkFsPath)
 
 import           Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
                      (DiskPolicy (..))
@@ -157,11 +154,11 @@ data LgrDbArgs f m blk = LgrDbArgs {
     }
 
 -- | Default arguments
-defaultArgs :: FilePath -> LgrDbArgs Defaults IO blk
-defaultArgs fp = LgrDbArgs {
+defaultArgs :: Applicative m => SomeHasFS m -> LgrDbArgs Defaults m blk
+defaultArgs lgrHasFS = LgrDbArgs {
       lgrDiskPolicy     = NoDefault
     , lgrGenesis        = NoDefault
-    , lgrHasFS          = SomeHasFS $ ioHasFS $ MountPoint (fp </> "ledger")
+    , lgrHasFS
     , lgrParams         = NoDefault
     , lgrTopLevelConfig = NoDefault
     , lgrTraceLedger    = nullTracer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
@@ -107,7 +107,6 @@ import           Control.Tracer (Tracer, traceWith)
 import           Control.Tracer (nullTracer)
 import qualified Data.ByteString.Lazy as Lazy
 import           GHC.Stack (HasCallStack)
-import           System.FilePath ((</>))
 
 import           Ouroboros.Consensus.Block hiding (headerHash)
 import           Ouroboros.Consensus.Util (SomePair (..))
@@ -120,7 +119,6 @@ import           Ouroboros.Consensus.Storage.Common
 import           Ouroboros.Consensus.Storage.FS.API
 import           Ouroboros.Consensus.Storage.FS.API.Types hiding (allowExisting)
 import           Ouroboros.Consensus.Storage.FS.CRC
-import           Ouroboros.Consensus.Storage.FS.IO (ioHasFS)
 import           Ouroboros.Consensus.Storage.Serialisation
 
 import           Ouroboros.Consensus.Storage.ImmutableDB.API
@@ -153,14 +151,14 @@ data ImmutableDbArgs f m blk = ImmutableDbArgs {
     , immValidationPolicy :: ValidationPolicy
     }
 
--- | Default arguments when using the 'IO' monad
-defaultArgs :: FilePath -> ImmutableDbArgs Defaults IO blk
-defaultArgs fp = ImmutableDbArgs {
+-- | Default arguments
+defaultArgs :: Applicative m => SomeHasFS m -> ImmutableDbArgs Defaults m blk
+defaultArgs immHasFS = ImmutableDbArgs {
       immCacheConfig      = cacheConfig
     , immCheckIntegrity   = NoDefault
     , immChunkInfo        = NoDefault
     , immCodecConfig      = NoDefault
-    , immHasFS            = SomeHasFS $ ioHasFS $ MountPoint (fp </> "immutable")
+    , immHasFS
     , immRegistry         = NoDefault
     , immTracer           = nullTracer
     , immValidationPolicy = ValidateMostRecentChunk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
@@ -130,7 +130,6 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
-import           System.FilePath ((</>))
 
 import           Ouroboros.Network.Block (MaxSlotNo (..))
 
@@ -144,7 +143,6 @@ import           Ouroboros.Consensus.Util.ResourceRegistry (allocateTemp,
 import           Ouroboros.Consensus.Storage.Common (BlockComponent (..))
 import           Ouroboros.Consensus.Storage.FS.API
 import           Ouroboros.Consensus.Storage.FS.API.Types
-import           Ouroboros.Consensus.Storage.FS.IO (ioHasFS)
 import           Ouroboros.Consensus.Storage.Serialisation
 
 import           Ouroboros.Consensus.Storage.VolatileDB.API
@@ -169,12 +167,12 @@ data VolatileDbArgs f m blk = VolatileDbArgs {
     , volValidationPolicy :: BlockValidationPolicy
     }
 
--- | Default arguments when using the 'IO' monad
-defaultArgs :: FilePath -> VolatileDbArgs Defaults IO blk
-defaultArgs fp = VolatileDbArgs {
+-- | Default arguments
+defaultArgs :: Applicative m => SomeHasFS m -> VolatileDbArgs Defaults m blk
+defaultArgs volHasFS = VolatileDbArgs {
       volCheckIntegrity   = NoDefault
     , volCodecConfig      = NoDefault
-    , volHasFS            = SomeHasFS $ ioHasFS $ MountPoint (fp </> "volatile")
+    , volHasFS
     , volMaxBlocksPerFile = mkBlocksPerFile 1000
     , volTracer           = nullTracer
     , volValidationPolicy = NoValidation

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -46,6 +46,7 @@ import           Ouroboros.Network.NodeToNode ( NodeToNodeVersion (..)
                                               , AcceptedConnectionsLimit (..)
                                               , AcceptConnectionsPolicyTrace (..)
                                               , DiffusionMode (..)
+                                              , RemoteAddress
                                               )
 import qualified Ouroboros.Network.NodeToNode   as NodeToNode
 import           Ouroboros.Network.Socket ( ConnectionId (..)
@@ -100,30 +101,30 @@ data DiffusionArguments = DiffusionArguments {
       -- ^ run in initiator only mode
     }
 
-data DiffusionApplications = DiffusionApplications {
+data DiffusionApplications ntnAddr ntcAddr ntnVersionData ntcVersionData m = DiffusionApplications {
 
       daResponderApplication      :: Versions
                                        NodeToNodeVersion
-                                       NodeToNodeVersionData
+                                       ntnVersionData
                                        (OuroborosApplication
-                                         ResponderMode SockAddr
-                                         ByteString IO Void ())
+                                         ResponderMode ntnAddr
+                                         ByteString m Void ())
       -- ^ NodeToNode reposnder application (server role)
 
     , daInitiatorApplication      :: Versions
                                        NodeToNodeVersion
-                                       NodeToNodeVersionData
+                                       ntnVersionData
                                        (OuroborosApplication
-                                         InitiatorMode SockAddr
-                                         ByteString IO () Void)
+                                         InitiatorMode ntnAddr
+                                         ByteString m () Void)
       -- ^ NodeToNode initiator application (client role)
 
     , daLocalResponderApplication :: Versions
                                        NodeToClientVersion
-                                       NodeToClientVersionData
+                                       ntcVersionData
                                        (OuroborosApplication
-                                         ResponderMode LocalAddress
-                                         ByteString IO Void ())
+                                         ResponderMode ntcAddr
+                                         ByteString m Void ())
       -- ^ NodeToClient responder applicaton (server role)
 
     , daErrorPolicies :: ErrorPolicies
@@ -140,6 +141,9 @@ runDataDiffusion
     :: DiffusionTracers
     -> DiffusionArguments 
     -> DiffusionApplications
+         RemoteAddress LocalAddress
+         NodeToNodeVersionData NodeToClientVersionData
+         IO
     -> IO ()
 runDataDiffusion tracers
                  DiffusionArguments { daIPv4Address

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -65,6 +65,7 @@ module Ouroboros.Network.NodeToNode (
 
   -- * Re-exports
   , ConnectionId (..)
+  , RemoteAddress
   , RemoteConnectionId
   , ProtocolLimitFailure
   , Handshake
@@ -749,4 +750,5 @@ localNetworkErrorPolicy = ErrorPolicies {
       epConErrorPolicies = []
     }
 
-type RemoteConnectionId = ConnectionId Socket.SockAddr
+type RemoteAddress      = Socket.SockAddr
+type RemoteConnectionId = ConnectionId RemoteAddress


### PR DESCRIPTION
This PR makes three changes to the `RunNodeArgs` interface.

1. It splits off some arguments of `RunNodeArgs` into a separate `LowLevelRunNodeArgs` record. `RunNodeArgs` are necessary arguments to `run`. `LowLeveRunNodeArgs` are the kinds of arguments that a "power user" such as the tests would use.

2. It introduces a new record `StdRunNodeArgs` that captures the exact fields that the real invocation from `cardano-node` would like to provide when invoking `run`. We also provide a function that maps `StdRunNodeArgs` to `LowLevelRunNodeArgs` by providing defaults, setting typical file paths, etc. This is how we hide `LowLevelRunNodeArgs` from the real invocation in `cardano-node`.

3. It renames the internal `NodeArgs` to `NodeKernelArgs`.