### PR TITLE
Update dependency on cardano-base

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -140,8 +140,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 6012e2fcbddc516490fcae07aad8d3e96fd729e3
-  --sha256: 1y64bjl83n2idrhyjwh10frmpiv7lqmbmrixaswvxg36r2iddrqk
+  tag: acac87c7af2652b8d86d92c583b6c29234634866
+  --sha256: 1awxr663zgkn8dw13pjzzlzzz5y9y5l2fy14f87331gbrw6n2xdg
   subdir:
     binary
     binary/test

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -57,10 +57,10 @@ protocolInfoMockPBFT params eraParams nid =
         }
 
     ledgerView :: PBftLedgerView PBftMockCrypto
-    ledgerView = PBftLedgerView $
-        Bimap.fromList [ (verKey n, verKey n)
-                       | n <- enumCoreNodes (pbftNumNodes params)
-                       ]
+    ledgerView = PBftLedgerView $ Bimap.fromList [
+          (PBftMockVerKeyHash (verKey n), PBftMockVerKeyHash (verKey n))
+        | n <- enumCoreNodes (pbftNumNodes params)
+        ]
 
     signKey :: CoreNodeId -> SignKeyDSIGN MockDSIGN
     signKey (CoreNodeId n) = SignKeyMockDSIGN n

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -29,6 +29,7 @@ module Ouroboros.Consensus.Protocol.PBFT (
     -- * Classes
   , PBftCrypto(..)
   , PBftMockCrypto
+  , PBftMockVerKeyHash(..)
   , PBftValidateView(..)
   , pbftValidateRegular
   , pbftValidateBoundary


### PR DESCRIPTION
Breaking change: https://github.com/input-output-hk/cardano-base/pull/179

We were using `VerKeyDSIGN MockDSIGN` as the `PBftVerKeyHash` for
`PBftMockCrypto`. Since `VerKeyDSIGN` no longer is allowed to implement `Ord`,
we can no longer derive `Ord` from the underlying `VerKeyDSIGN` type. Instead,
we derive `Ord` *via* the underlying `Word64` type.