### PR TITLE
Clarify chain selection

### DIFF
--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -795,7 +795,7 @@ validChains cfg m bs =
     sortChains $ chains bs
   where
     sortChains :: [Chain blk] -> [Chain blk]
-    sortChains = sortBy (flip (Fragment.compareAnchoredCandidates cfg `on`
+    sortChains = sortBy (flip (Fragment.compareAnchoredFragments cfg `on`
                                  (Chain.toAnchoredFragment . fmap getHeader)))
 
     classify :: ValidatedChain blk

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -463,12 +463,12 @@ mkNextEBB canContainEBB tb =
 
 data BftWithEBBs
 
-ebbAwareCompareCandidates
+ebbAwareCompareChains
     :: (BlockNo, IsEBB, ChainLength, TestHeaderHash)
     -> (BlockNo, IsEBB, ChainLength, TestHeaderHash)
     -> Ordering
-ebbAwareCompareCandidates (lBlockNo, lIsEBB, lChainLength, lHash)
-                          (rBlockNo, rIsEBB, rChainLength, rHash) =
+ebbAwareCompareChains (lBlockNo, lIsEBB, lChainLength, lHash)
+                      (rBlockNo, rIsEBB, rChainLength, rHash) =
     -- Prefer the highest block number, as it is a proxy for chain length
     case lBlockNo `compare` rBlockNo of
       LT -> LT
@@ -497,7 +497,7 @@ ebbAwareCompareCandidates (lBlockNo, lIsEBB, lChainLength, lHash)
 instance ChainSelection BftWithEBBs where
   type SelectView BftWithEBBs = (BlockNo, IsEBB, ChainLength, TestHeaderHash)
 
-  compareCandidates _ _ = ebbAwareCompareCandidates
+  compareChains _ _ = ebbAwareCompareChains
 
 type instance BlockProtocol TestBlock =
   ModChainSel (Bft BftMockCrypto) BftWithEBBs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -76,7 +76,7 @@ instance CanHardFork xs => ChainSelection (HardForkProtocol xs) where
 
   -- We leave 'preferCandidate' at the default
 
-  compareCandidates _ (PerEraChainSelConfig cfgs) l r =
+  compareChains _ (PerEraChainSelConfig cfgs) l r =
        acrossEraSelection
          cfgs
          hardForkChainSel

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
@@ -38,7 +38,7 @@ data AcrossEraSelection :: Type -> Type -> Type where
 
   -- | Two eras running the same protocol
   --
-  -- In this case, we can just call @compareCandidates@ even across eras.
+  -- In this case, we can just call @compareChains@ even across eras.
   -- (The 'ChainSelConfig' must also be the same in both eras: we assert this
   -- at the value level.)
   --
@@ -74,7 +74,7 @@ withinEra ::
   -> WrapSelectView blk
   -> Ordering
 withinEra (WrapChainSelConfig cfg) (WrapSelectView l) (WrapSelectView r) =
-    compareCandidates (Proxy @(BlockProtocol blk)) cfg l r
+    compareChains (Proxy @(BlockProtocol blk)) cfg l r
 
 acrossEras ::
      forall blk blk'. SingleEraBlock blk
@@ -91,7 +91,7 @@ acrossEras (WrapChainSelConfig cfgL)
     CompareBlockNo     -> compare bnoL bnoR
     CustomChainSel f   -> f cfgL cfgR l r
     SelectSameProtocol -> assertEqWithMsg (cfgL, cfgR) $
-                            compareCandidates
+                            compareChains
                               (Proxy @(BlockProtocol blk))
                               cfgL
                               l

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -278,7 +278,7 @@ initBlockFetchConsensusInterface cfg chainDB getCandidates blockFetchSize btime 
     compareCandidateChains :: AnchoredFragment (Header blk)
                            -> AnchoredFragment (Header blk)
                            -> Ordering
-    compareCandidateChains = compareAnchoredCandidates cfg
+    compareCandidateChains = compareAnchoredFragments cfg
 
 forkBlockForging
     :: forall m remotePeer localPeer blk.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -75,8 +75,7 @@ instance ChainSelection p => ChainSelection (WithLeaderSchedule p) where
   type ChainSelConfig (WithLeaderSchedule p) = ChainSelConfig p
   type SelectView     (WithLeaderSchedule p) = SelectView     p
 
-  preferCandidate   _ = preferCandidate   (Proxy @p)
-  compareCandidates _ = compareCandidates (Proxy @p)
+  compareChains _ = compareChains (Proxy @p)
 
 data instance ConsensusConfig (WithLeaderSchedule p) = WLSConfig
   { wlsConfigSchedule :: !LeaderSchedule

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/MockChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/MockChainSel.hs
@@ -41,7 +41,7 @@ selectChain :: forall proxy p hdr l. ChainSelection p
             -> Maybe (Chain hdr, l)
 selectChain p view cfg ours candidates =
     listToMaybe $
-      sortBy (flip (compareCandidates' `on` fst)) preferredCandidates
+      sortBy (flip (compareChains' `on` fst)) preferredCandidates
   where
     preferredCandidates :: [(Chain hdr, l)]
     preferredCandidates = filter (preferCandidate' . fst) candidates
@@ -58,14 +58,14 @@ selectChain p view cfg ours candidates =
         go (Just _) Nothing  = False
         go (Just a) (Just b) = preferCandidate p cfg (view a) (view b)
 
-    compareCandidates' :: Chain hdr -> Chain hdr -> Ordering
-    compareCandidates' = go `on` Chain.head
+    compareChains' :: Chain hdr -> Chain hdr -> Ordering
+    compareChains' = go `on` Chain.head
       where
         go :: Maybe hdr -> Maybe hdr -> Ordering
         go Nothing  Nothing  = EQ
         go Nothing  (Just _) = LT
         go (Just _) Nothing  = GT
-        go (Just a) (Just b) = compareCandidates p cfg (view a) (view b)
+        go (Just a) (Just b) = compareChains p cfg (view a) (view b)
 
 -- | Chain selection on unvalidated chains
 selectUnvalidatedChain :: ChainSelection p

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -35,8 +35,7 @@ instance ChainSelection s => ChainSelection (ModChainSel p s) where
   type ChainSelConfig (ModChainSel p s) = ChainSelConfig s
   type SelectView     (ModChainSel p s) = SelectView     s
 
-  preferCandidate   _ = preferCandidate   (Proxy @s)
-  compareCandidates _ = compareCandidates (Proxy @s)
+  compareChains _ = compareChains (Proxy @s)
 
 instance (Typeable p, Typeable s, ConsensusProtocol p, ChainSelection s)
       => ConsensusProtocol (ModChainSel p s) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -247,10 +247,10 @@ data instance ConsensusConfig (PBft c) = PBftConfig {
     }
   deriving (Generic, NoThunks)
 
-instance PBftCrypto c => ChainSelection (PBft c) where
+instance ChainSelection (PBft c) where
   type SelectView (PBft c) = PBftSelectView
 
-  compareCandidates _proxy _config (lBlockNo, lIsEBB) (rBlockNo, rIsEBB) =
+  compareChains _proxy _config (lBlockNo, lIsEBB) (rBlockNo, rIsEBB) =
       -- Prefer the highest block number, as it is a proxy for chain length
       case lBlockNo `compare` rBlockNo of
         LT -> LT

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -787,7 +787,7 @@ chainSelection chainSelEnv chainDiffs =
 
     sortCandidates :: [ChainDiff (Header blk)] -> [ChainDiff (Header blk)]
     sortCandidates =
-      sortBy (flip (compareAnchoredCandidates cfg) `on` Diff.getSuffix)
+      sortBy (flip (compareAnchoredFragments cfg) `on` Diff.getSuffix)
 
     -- 1. Take the first candidate from the list of sorted candidates
     -- 2. Validate it


### PR DESCRIPTION
Previously the `ChainSelection` class provided two method: `preferCandidate`, comparing a candidate chain to the current chain, and `compareCandidates`, comparing two candidate chains. However, there is no need for this generality: it suffices to say that _when comparing the current chain a candidate, and they are equally preferable, we prefer the current chain_. This is now defined once and for all outside of the class. In other words, `preferCandidate` is now defined in terms of `compareChains`, which replaces `compareCandidates` (which can be called with either two candidate chains, or with the current chain and a candidate).

We then do the same for `compareAnchoredCandidates`/`preferAnchoredCandidate`, but here the situation is a bit more subtle, and we need to change the precondition we rely on. The benefit however is that the new `compareAnchoredCandidates` is now entirely symmetric, simplifying the contract, and -- critically -- simplifying the formal description of chain selection in the Consensus Report.