### PR TITLE
Allow permanent, named ledger snapshots and number based on slot

### DIFF
--- a/ouroboros-consensus-test/src/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/ToExpr.hs
@@ -28,6 +28,7 @@ instance ToExpr BlockNo
 
 instance ToExpr t => ToExpr (WithOrigin t)
 instance ToExpr (HeaderHash blk) => ToExpr (Point blk)
+instance ToExpr (HeaderHash blk) => ToExpr (RealPoint blk)
 instance (ToExpr slot, ToExpr hash) => ToExpr (Block slot hash)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -1148,7 +1148,6 @@ deriving instance ToExpr Fingerprint
 deriving instance ToExpr ReaderNext
 deriving instance ToExpr MaxSlotNo
 deriving instance ToExpr (HeaderHash blk) => ToExpr (ChainHash blk)
-deriving instance ToExpr (HeaderHash blk) => ToExpr (RealPoint blk)
 deriving instance ToExpr (HeaderHash blk) => ToExpr (ReaderState blk)
 deriving instance ToExpr blk => ToExpr (Chain blk)
 deriving instance ( ToExpr blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -295,7 +295,6 @@ updateLedgerSnapshots
   :: (IOLike m, LgrDbSerialiseConstraints blk)
   => ChainDbEnv m blk -> m ()
 updateLedgerSnapshots CDB{..} = do
-    -- TODO avoid taking multiple snapshots corresponding to the same tip.
     void $ LgrDB.takeSnapshot  cdbLgrDB
     void $ LgrDB.trimSnapshots cdbLgrDB
 


### PR DESCRIPTION
* Use the slot number of the ledger state as the number of the snapshot. This
  makes it more obvious to which block a snapshot corresponds.

  Note that we don't rely on these numbers being correct, we use them only to
  determine the order (descending) in which we try them when opening the ledger
  DB.

* Allow named, *permanent* snapshots. A snapshot can be given a name by
  appending a `_` and any string (even empty). Such snapshots are just like
  other automatically created snapshots, except that they will *never* be
  removed during a periodic trim of the snapshots (by default we only keep 2
  temporary snapshots around).

  For example, if you have a snapshot of the final Byron state lying around, you
  can call it, e.g., `4492799_last_Byron` and you don't have to worry about it
  being deleted.

* We no longer create a snapshot of the genesis ledger state. Not much point in
  doing that anyway.