### PR TITLE
Use a single set of credentials for all Shelley-based eras 

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -46,7 +46,7 @@ import           Ouroboros.Consensus.NodeId
 import           Ouroboros.Consensus.Protocol.PBFT
 import qualified Ouroboros.Consensus.Protocol.PBFT.State as S
 import           Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB (..))
-import           Ouroboros.Consensus.Util ((.....:))
+import           Ouroboros.Consensus.Util ((.....:), (.:))
 
 import           Ouroboros.Consensus.Byron.Ledger
 import           Ouroboros.Consensus.Byron.Node
@@ -69,7 +69,8 @@ dualByronBlockForging
 dualByronBlockForging creds = BlockForging {
       forgeLabel       = forgeLabel
     , canBeLeader      = canBeLeader
-    , updateForgeState = fmap castForgeStateUpdateInfo . updateForgeState
+    , updateForgeState = \cfg ->
+        fmap castForgeStateUpdateInfo .: updateForgeState (dualTopLevelConfigMain cfg)
     , checkCanForge    = checkCanForge . dualTopLevelConfigMain
     , forgeBlock       = return .....: forgeDualByronBlock
     }

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -119,8 +119,7 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params credss =
            , headerState = genesisHeaderState S.empty
            }
       , pInfoBlockForging =
-           return . dualByronBlockForging . byronLeaderCredentials
-             <$> credss
+           return $ dualByronBlockForging . byronLeaderCredentials <$> credss
       }
   where
     initUtxo :: Impl.UTxO

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -130,7 +130,7 @@ byronBlockForging
 byronBlockForging creds = BlockForging {
       forgeLabel       = blcLabel creds
     , canBeLeader
-    , updateForgeState = \_ -> return $ ForgeStateUpdateInfo $ Unchanged ()
+    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Unchanged ()
     , checkCanForge    = \cfg slot tickedPBftState _isLeader () ->
                              pbftCheckCanForge
                                (configConsensus cfg)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -196,7 +196,7 @@ protocolInfoByron ProtocolParamsByron {
           , headerState = genesisHeaderState S.empty
           }
       , pInfoBlockForging =
-          return . byronBlockForging <$> maybeToList mLeaderCreds
+          return $ byronBlockForging <$> maybeToList mLeaderCreds
       }
   where
     compactedGenesisConfig = compactGenesisConfig genesisConfig

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
@@ -86,7 +86,7 @@ combineEras = mconcat . hcollapse . hap eraInjections
 
     injExamples ::
          String
-      -> Index blk (CardanoEras Crypto)
+      -> Index (CardanoEras Crypto) blk
       -> Examples blk
       -> Examples (CardanoBlock Crypto)
     injExamples eraName idx =
@@ -107,7 +107,7 @@ instance Inject SomeResult where
       SomeResult (QueryIfCurrent (injectQuery idx q)) (Right r)
 
 instance Inject Examples where
-  inject startBounds (idx :: Index x xs) Golden.Examples {..} = Golden.Examples {
+  inject startBounds (idx :: Index xs x) Golden.Examples {..} = Golden.Examples {
         exampleBlock            = inj (Proxy @I)                  exampleBlock
       , exampleSerialisedBlock  = inj (Proxy @Serialised)         exampleSerialisedBlock
       , exampleHeader           = inj (Proxy @Header)             exampleHeader

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
@@ -751,26 +751,26 @@ mkProtocolCardanoAndHardForkTxs
           , byronSoftwareVersion        = softVerByron
           , byronLeaderCredentials      = Just leaderCredentialsByron
           }
+        ProtocolParamsShelleyBased {
+            shelleyBasedGenesis           = genesisShelley
+          , shelleyBasedInitialNonce      = initialNonce
+          , shelleyBasedLeaderCredentials = Just leaderCredentialsShelley
+          }
         ProtocolParamsShelley {
-            shelleyGenesis           = genesisShelley
-          , shelleyInitialNonce      = initialNonce
-          , shelleyProtVer           = SL.ProtVer shelleyMajorVersion 0
-          , shelleyLeaderCredentials = Just leaderCredentialsShelley
+            shelleyProtVer = SL.ProtVer shelleyMajorVersion 0
           }
         ProtocolParamsAllegra {
-            allegraProtVer           = SL.ProtVer allegraMajorVersion 0
-          , allegraLeaderCredentials = Nothing
+            allegraProtVer = SL.ProtVer allegraMajorVersion 0
           }
         ProtocolParamsMary {
-            maryProtVer           = SL.ProtVer maryMajorVersion 0
-          , maryLeaderCredentials = Nothing
+            maryProtVer    = SL.ProtVer maryMajorVersion    0
           }
         protocolParamsByronShelley
         ProtocolParamsTransition {
-            transitionTrigger    = TriggerHardForkAtVersion allegraMajorVersion
+            transitionTrigger = TriggerHardForkAtVersion allegraMajorVersion
           }
         ProtocolParamsTransition {
-            transitionTrigger    = TriggerHardForkAtVersion maryMajorVersion
+            transitionTrigger = TriggerHardForkAtVersion maryMajorVersion
           }
 
     -- Byron

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/ApplyTxErr_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/ApplyTxErr_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/ApplyTxErr_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/ApplyTxErr_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/GenTx_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/GenTx_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/GenTx_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/GenTx_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetCurrentPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetCurrentPParams
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetEpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetEpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetGenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetGenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetLedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetLedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetNonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetNonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetStakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Allegra_GetStakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetCurrentPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetCurrentPParams
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetEpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetEpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetGenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetGenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetLedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetLedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetNonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetNonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetStakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Query_Mary_GetStakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_EmptyPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_EmptyPParams
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_EpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_EpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_GenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_GenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_LedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_LedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_NonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_NonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_ProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_ProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_StakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Allegra_StakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_EmptyPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_EmptyPParams
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_EpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_EpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_GenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_GenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_LedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_LedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_NonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_NonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_ProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_ProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_StakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion1/Result_Mary_StakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/ApplyTxErr_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/ApplyTxErr_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/ApplyTxErr_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/ApplyTxErr_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/GenTx_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/GenTx_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/GenTx_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/GenTx_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetCurrentPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetCurrentPParams
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetEpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetEpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetGenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetGenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetLedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetLedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetNonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetNonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetStakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Allegra_GetStakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetCurrentPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetCurrentPParams
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetEpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetEpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetGenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetGenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetLedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetLedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetNonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetNonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetStakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Query_Mary_GetStakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_EmptyPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_EmptyPParams
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_EpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_EpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_GenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_GenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_LedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_LedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_NonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_NonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_ProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_ProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_StakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Allegra_StakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_EmptyPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_EmptyPParams
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_EpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_EpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_GenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_GenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_LedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_LedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_NonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_NonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_ProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_ProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_StakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion2/Result_Mary_StakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/ApplyTxErr_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/ApplyTxErr_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/ApplyTxErr_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/ApplyTxErr_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/GenTx_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/GenTx_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/GenTx_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/GenTx_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetCurrentPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetCurrentPParams
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetEpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetEpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetGenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetGenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetLedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetLedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetNonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetNonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetStakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Allegra_GetStakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetCurrentPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetCurrentPParams
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetEpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetEpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetGenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetGenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetLedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetLedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetNonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetNonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetStakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Query_Mary_GetStakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_EmptyPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_EmptyPParams
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_EpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_EpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_GenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_GenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_LedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_LedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_NonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_NonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_ProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_ProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_StakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Allegra_StakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_EmptyPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_EmptyPParams
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_EpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_EpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_GenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_GenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_LedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_LedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_NonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_NonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_ProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_ProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_StakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion3/Result_Mary_StakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/ApplyTxErr_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/ApplyTxErr_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/GenTx_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/GenTx_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetCurrentPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetCurrentPParams
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetEpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetEpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetGenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetGenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetLedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetLedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetNonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetNonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetStakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Query_Mary_GetStakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_EmptyPParams
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_EmptyPParams
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_EpochNo
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_EpochNo
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_GenesisConfig
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_GenesisConfig
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_LedgerTip
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_LedgerTip
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_NonMyopicMemberRewards
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_NonMyopicMemberRewards
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_ProposedPParamsUpdates
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_ProposedPParamsUpdates
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_StakeDistribution
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToClientVersion4/Result_Mary_StakeDistribution
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/GenTxId_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/GenTxId_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/GenTxId_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/GenTxId_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/GenTx_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/GenTx_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/GenTx_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/GenTx_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/Header_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/Header_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/Header_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/Header_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/SerialisedHeader_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/SerialisedHeader_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/SerialisedHeader_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion1/SerialisedHeader_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderFutureEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/GenTxId_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/GenTxId_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/GenTxId_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/GenTxId_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/GenTx_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/GenTx_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/GenTx_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/GenTx_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/Header_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/Header_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/Header_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/Header_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/SerialisedHeader_Allegra
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/SerialisedHeader_Allegra
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Allegra"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/SerialisedHeader_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion2/SerialisedHeader_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion3/GenTxId_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion3/GenTxId_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion3/GenTx_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion3/GenTx_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion3/Header_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion3/Header_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion3/SerialisedHeader_Mary
+++ b/ouroboros-consensus-cardano-test/test/golden/CardanoNodeToNodeVersion3/SerialisedHeader_Mary
@@ -1,1 +1,1 @@
-HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Shelley"})
+HardForkEncoderDisabledEra (SingleEraInfo {singleEraName = "Mary"})

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -89,15 +89,17 @@ data Protocol (m :: Type -> Type) blk p where
 
   -- | Run TPraos against the real Shelley ledger
   ProtocolShelley
-    :: ProtocolParamsShelley StandardCrypto []
+    :: ProtocolParamsShelleyBased StandardShelley []
+    -> ProtocolParamsShelley
     -> Protocol m (ShelleyBlockHFC StandardShelley) ProtocolShelley
 
   -- | Run the protocols of /the/ Cardano block
   ProtocolCardano
     :: ProtocolParamsByron
-    -> ProtocolParamsShelley StandardCrypto Maybe
-    -> ProtocolParamsAllegra StandardCrypto Maybe
-    -> ProtocolParamsMary    StandardCrypto Maybe
+    -> ProtocolParamsShelleyBased StandardShelley Maybe
+    -> ProtocolParamsShelley
+    -> ProtocolParamsAllegra
+    -> ProtocolParamsMary
     -> ProtocolParamsTransition
          ByronBlock
          (ShelleyBlock StandardShelley)
@@ -124,11 +126,12 @@ protocolInfo :: forall m blk p. IOLike m
 protocolInfo (ProtocolByron params) =
     inject $ protocolInfoByron params
 
-protocolInfo (ProtocolShelley params) =
-    inject $ protocolInfoShelley params
+protocolInfo (ProtocolShelley paramsShelleyBased paramsShelley) =
+    inject $ protocolInfoShelley paramsShelleyBased paramsShelley
 
 protocolInfo (ProtocolCardano
                paramsByron
+               paramsShelleyBased
                paramsShelley
                paramsAllegra
                paramsMary
@@ -137,6 +140,7 @@ protocolInfo (ProtocolCardano
                paramsAllegraMary) =
     protocolInfoCardano
       paramsByron
+      paramsShelleyBased
       paramsShelley
       paramsAllegra
       paramsMary

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
@@ -8,6 +8,7 @@ module Ouroboros.Consensus.Cardano.Block (
     -- * Eras
     module Ouroboros.Consensus.Shelley.Eras
   , CardanoEras
+  , ShelleyBasedEras
     -- * Block
   , CardanoBlock
     -- Note: by exporting the pattern synonyms as part of the matching data
@@ -163,6 +164,9 @@ type CardanoEras c =
    , ShelleyBlock (AllegraEra c)
    , ShelleyBlock (MaryEra c)
    ]
+
+-- | The Shelley-based eras in the Cardano chain
+type ShelleyBasedEras c = '[ShelleyEra c, AllegraEra c, MaryEra c]
 
 {-------------------------------------------------------------------------------
   The block type of the Cardano block chain

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -308,7 +308,7 @@ instance ShelleyBasedEra era => SingleEraBlock (ShelleyBlock era) where
               ledgerState
 
   singleEraInfo _ = SingleEraInfo {
-      singleEraName = "Shelley"
+      singleEraName = shelleyBasedEraName (Proxy @era)
     }
 
 instance PraosCrypto c => HasPartialConsensusConfig (TPraos c) where

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -382,7 +382,7 @@ protocolInfoCardano protocolParamsByron@ProtocolParamsByron {
                   WrapChainDepState $
                     headerStateChainDep initHeaderStateByron
           }
-      , pInfoBlockForging = mconcat [
+      , pInfoBlockForging = sequence $ mconcat [
             [ return $ hardForkBlockForging $ Z $ byronBlockForging credsByron
             | credsByron <- maybeToList mCredsByron
             ]

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -97,28 +97,28 @@ mkCardanoProtocolInfo genesisByron signatureThreshold genesisShelley initialNonc
         , byronSoftwareVersion        = Byron.Update.SoftwareVersion (Byron.Update.ApplicationName "db-analyser") 2
         , byronLeaderCredentials      = Nothing
         }
+      ProtocolParamsShelleyBased {
+          shelleyBasedGenesis           = genesisShelley
+        , shelleyBasedInitialNonce      = initialNonce
+        , shelleyBasedLeaderCredentials = Nothing
+        }
       ProtocolParamsShelley {
-          shelleyGenesis           = genesisShelley
-        , shelleyInitialNonce      = initialNonce
-        , shelleyProtVer           = ProtVer 2 0
-        , shelleyLeaderCredentials = Nothing
+          shelleyProtVer = ProtVer 2 0
         }
       ProtocolParamsAllegra {
-          allegraProtVer           = ProtVer 3 0
-        , allegraLeaderCredentials = Nothing
+          allegraProtVer = ProtVer 3 0
         }
       ProtocolParamsMary {
-          maryProtVer           = ProtVer 4 0
-        , maryLeaderCredentials = Nothing
+          maryProtVer    = ProtVer 4 0
         }
       ProtocolParamsTransition {
-          transitionTrigger    = TriggerHardForkAtVersion 2
+          transitionTrigger = TriggerHardForkAtVersion 2
         }
       ProtocolParamsTransition {
-          transitionTrigger    = TriggerHardForkAtVersion 3
+          transitionTrigger = TriggerHardForkAtVersion 3
         }
       ProtocolParamsTransition {
-          transitionTrigger    = TriggerHardForkAtVersion 4
+          transitionTrigger = TriggerHardForkAtVersion 4
         }
 
 castHeaderHash ::

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
@@ -33,7 +33,8 @@ import           Ouroboros.Consensus.Shelley.Eras (ShelleyBasedEra,
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyBlock)
 import qualified Ouroboros.Consensus.Shelley.Ledger.Block as Shelley
 import           Ouroboros.Consensus.Shelley.Node (Nonce (..),
-                     ProtocolParamsShelley (..), ShelleyGenesis,
+                     ProtocolParamsShelley (..),
+                     ProtocolParamsShelleyBased (..), ShelleyGenesis,
                      protocolInfoShelley)
 
 import           HasAnalysis
@@ -75,12 +76,15 @@ mkShelleyProtocolInfo ::
   -> Nonce
   -> ProtocolInfo IO (ShelleyBlock StandardShelley)
 mkShelleyProtocolInfo genesis initialNonce =
-    protocolInfoShelley $ ProtocolParamsShelley {
-        shelleyGenesis           = genesis
-      , shelleyInitialNonce      = initialNonce
-      , shelleyProtVer           = SL.ProtVer 2 0
-      , shelleyLeaderCredentials = []
-      }
+    protocolInfoShelley
+      ProtocolParamsShelleyBased {
+          shelleyBasedGenesis           = genesis
+        , shelleyBasedInitialNonce      = initialNonce
+        , shelleyBasedLeaderCredentials = []
+        }
+      ProtocolParamsShelley {
+          shelleyProtVer = SL.ProtVer 2 0
+        }
 
 parseShelleyArgs :: Parser ShelleyBlockArgs
 parseShelleyArgs = ShelleyBlockArgs

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -78,7 +78,7 @@ simpleBlockForging ::
 simpleBlockForging canBeLeader forgeExt = BlockForging {
       forgeLabel       = "simpleBlockForging"
     , canBeLeader      = canBeLeader
-    , updateForgeState = \_ -> return $ ForgeStateUpdateInfo $ Unchanged ()
+    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Unchanged ()
     , checkCanForge    = \_ _ _ _ _ -> return ()
     , forgeBlock       = return .....: forgeSimple forgeExt
     }

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -46,7 +46,7 @@ protocolInfoBft numCoreNodes nid securityParam eraParams =
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState ())
-      , pInfoBlockForging = [return (simpleBlockForging nid forgeBftExt)]
+      , pInfoBlockForging = return [simpleBlockForging nid forgeBftExt]
       }
   where
     signKey :: CoreNodeId -> SignKeyDSIGN MockDSIGN

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -87,7 +87,7 @@ pbftBlockForging ::
 pbftBlockForging canBeLeader = BlockForging {
       forgeLabel       = "pbftBlockForging"
     , canBeLeader
-    , updateForgeState = \_ -> return $ ForgeStateUpdateInfo $ Unchanged ()
+    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Unchanged ()
     , checkCanForge    = \cfg slot tickedPBftState _isLeader ->
                            return $
                              pbftCheckCanForge

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -45,7 +45,7 @@ protocolInfoMockPBFT params eraParams nid =
           }
       , pInfoInitLedger = ExtLedgerState (genesisSimpleLedgerState addrDist)
                                          (genesisHeaderState S.empty)
-      , pInfoBlockForging = [return (pbftBlockForging canBeLeader)]
+      , pInfoBlockForging = return [pbftBlockForging canBeLeader]
       }
   where
     canBeLeader :: PBftCanBeLeader PBftMockCrypto

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -99,7 +99,7 @@ praosBlockForging cid initHotKey = do
     return $ BlockForging {
         forgeLabel       = "praosBlockForging"
       , canBeLeader      = cid
-      , updateForgeState = \sno -> updateMVar varHotKey $
+      , updateForgeState = \_ sno _ -> updateMVar varHotKey $
                                second ForgeStateUpdateInfo . evolveKey sno
       , checkCanForge    = \_ _ _ _ _ -> return ()
       , forgeBlock       = \cfg bno sno tickedLedgerSt txs isLeader -> do

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -56,7 +56,7 @@ protocolInfoPraos numCoreNodes nid params eraParams eta0 =
             ledgerState = genesisSimpleLedgerState addrDist
           , headerState = genesisHeaderState (PraosChainDepState [])
           }
-      , pInfoBlockForging = [praosBlockForging nid initHotKey]
+      , pInfoBlockForging = sequence [praosBlockForging nid initHotKey]
       }
   where
     signKeyVRF :: CoreNodeId -> SignKeyVRF MockVRF

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -57,7 +57,7 @@ protocolInfoPraosRule numCoreNodes
         { ledgerState = genesisSimpleLedgerState addrDist
         , headerState = genesisHeaderState ()
         }
-    , pInfoBlockForging = [return (simpleBlockForging () forgePraosRuleExt)]
+    , pInfoBlockForging = return [simpleBlockForging () forgePraosRuleExt]
     }
   where
     addrDist :: AddrDist

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -401,12 +401,15 @@ mkProtocolShelley ::
   -> CoreNode c
   -> ProtocolInfo m (ShelleyBlock (ShelleyEra c))
 mkProtocolShelley genesis initialNonce protVer coreNode =
-    protocolInfoShelley $ ProtocolParamsShelley {
-        shelleyGenesis           = genesis
-      , shelleyInitialNonce      = initialNonce
-      , shelleyProtVer           = protVer
-      , shelleyLeaderCredentials = Just $ mkLeaderCredentials coreNode
-      }
+    protocolInfoShelley
+      ProtocolParamsShelleyBased {
+          shelleyBasedGenesis           = genesis
+        , shelleyBasedInitialNonce      = initialNonce
+        , shelleyBasedLeaderCredentials = Just $ mkLeaderCredentials coreNode
+        }
+      ProtocolParamsShelley {
+          shelleyProtVer = protVer
+        }
 {-------------------------------------------------------------------------------
   Necessary transactions for updating the 'DecentralizationParam'
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE FlexibleInstances       #-}
+{-# LANGUAGE OverloadedStrings       #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 module Ouroboros.Consensus.Shelley.Eras (
     -- * Eras based on the Shelley ledger
     ShelleyEra
@@ -8,12 +11,14 @@ module Ouroboros.Consensus.Shelley.Eras (
   , StandardAllegra
   , StandardMary
     -- * Shelley-based era
-  , ShelleyBasedEra
+  , ShelleyBasedEra (..)
     -- * Type synonyms for convenience
   , EraCrypto
     -- * Re-exports
   , StandardCrypto
   ) where
+
+import           Data.Text (Text)
 
 import           Cardano.Ledger.Allegra (AllegraEra)
 import           Cardano.Ledger.Era (Crypto)
@@ -21,7 +26,7 @@ import           Cardano.Ledger.Mary (MaryEra)
 import           Cardano.Ledger.Shelley (ShelleyEra)
 
 import           Ouroboros.Consensus.Shelley.Protocol.Crypto (StandardCrypto)
-import           Shelley.Spec.Ledger.API (ShelleyBasedEra)
+import qualified Shelley.Spec.Ledger.API as SL
 
 {-------------------------------------------------------------------------------
   Eras instantiated with standard crypto
@@ -45,3 +50,34 @@ type StandardMary = MaryEra StandardCrypto
 -- of them qualified, define 'EraCrypto' as an alias of the former: /return the
 -- crypto used by this era/.
 type EraCrypto era = Crypto era
+
+{-------------------------------------------------------------------------------
+  Era polymorphism
+-------------------------------------------------------------------------------}
+
+-- | The ledger already defines 'SL.ShelleyBasedEra' as /the/ top-level
+-- constraint on an era, however, consensus often needs some more functionality
+-- than the ledger currently provides.
+--
+-- Either the functionality shouldn't or can't live in the ledger, in which case
+-- it can be part and remain part of 'ShelleyBasedEra'. Or, the functionality
+-- /should/ live in the ledger, but hasn't yet been added to the ledger, or it
+-- hasn't yet been propagated to this repository, in which case it can be added
+-- to this class until that is the case.
+--
+-- By having the same name as the class defined in ledger, we can, if this class
+-- becomes redundant, switch to the ledger-defined one without having to update
+-- all the code using it. We can just export the right one from this module.
+class SL.ShelleyBasedEra era => ShelleyBasedEra era where
+  -- | Return the name of the Shelley-based era, e.g., @"Shelley"@, @"Allegra"@,
+  -- etc.
+  shelleyBasedEraName :: proxy era -> Text
+
+instance SL.PraosCrypto c => ShelleyBasedEra (ShelleyEra c) where
+  shelleyBasedEraName _ = "Shelley"
+
+instance SL.PraosCrypto c => ShelleyBasedEra (AllegraEra c) where
+  shelleyBasedEraName _ = "Allegra"
+
+instance SL.PraosCrypto c => ShelleyBasedEra (MaryEra c) where
+  shelleyBasedEraName _ = "Mary"

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -161,7 +161,7 @@ shelleySharedBlockForging
     aux hotKey = BlockForging {
           forgeLabel       = label <> "_" <> shelleyBasedEraName (Proxy @era)
         , canBeLeader      = canBeLeader
-        , updateForgeState = \curSlot ->
+        , updateForgeState = \_ curSlot _ ->
                                  ForgeStateUpdateInfo <$>
                                    HotKey.evolve hotKey (slotToPeriod curSlot)
         , checkCanForge    = \cfg curSlot _tickedChainDepState ->

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -194,7 +194,7 @@ protocolInfoShelley ProtocolParamsShelley {
     ProtocolInfo {
         pInfoConfig       = topLevelConfig
       , pInfoInitLedger   = initExtLedgerState
-      , pInfoBlockForging = shelleyBlockForging tpraosParams <$> toList credentialss
+      , pInfoBlockForging = sequence $ shelleyBlockForging tpraosParams <$> toList credentialss
       }
   where
     maxMajorProtVer :: MaxMajorProtVer

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -3,18 +3,23 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE DuplicateRecordFields    #-}
 {-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE FlexibleInstances        #-}
 {-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE MultiParamTypeClasses    #-}
 {-# LANGUAGE NamedFieldPuns           #-}
 {-# LANGUAGE OverloadedStrings        #-}
 {-# LANGUAGE RecordWildCards          #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
 {-# LANGUAGE TypeApplications         #-}
 {-# LANGUAGE TypeFamilies             #-}
+{-# LANGUAGE TypeOperators            #-}
+{-# LANGUAGE UndecidableSuperClasses  #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Consensus.Shelley.Node (
     protocolInfoShelley
+  , ProtocolParamsShelleyBased (..)
   , ProtocolParamsShelley (..)
   , ProtocolParamsAllegra (..)
   , ProtocolParamsMary (..)
@@ -23,6 +28,7 @@ module Ouroboros.Consensus.Shelley.Node (
   , SL.ShelleyGenesisStaking (..)
   , TPraosLeaderCredentials (..)
   , shelleyBlockForging
+  , shelleySharedBlockForging
   , tpraosBlockIssuerVKey
   , SL.ProtVer (..)
   , SL.Nonce (..)
@@ -35,6 +41,7 @@ import           Data.Bifunctor (first)
 import           Data.Foldable (toList)
 import           Data.Functor.Identity (Identity)
 import qualified Data.Map.Strict as Map
+import           Data.SOP.Strict
 import           Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -65,6 +72,7 @@ import           Ouroboros.Consensus.Shelley.Ledger.Inspect ()
 import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion ()
 import           Ouroboros.Consensus.Shelley.Node.Serialisation ()
 import           Ouroboros.Consensus.Shelley.Protocol
+import           Ouroboros.Consensus.Shelley.Protocol.HotKey (HotKey)
 import qualified Ouroboros.Consensus.Shelley.Protocol.HotKey as HotKey
 
 {-------------------------------------------------------------------------------
@@ -99,33 +107,72 @@ type instance ForgeStateInfo (ShelleyBlock era) = HotKey.KESInfo
 
 type instance ForgeStateUpdateError (ShelleyBlock era) = HotKey.KESEvolutionError
 
+-- | Create a 'BlockForging' record for a single era.
+--
+-- In case the same credentials should be shared across multiple Shelley-based
+-- eras, use 'shelleySharedBlockForging'.
 shelleyBlockForging ::
      forall m era. (ShelleyBasedEra era, IOLike m)
   => TPraosParams
   -> TPraosLeaderCredentials (EraCrypto era)
   -> m (BlockForging m (ShelleyBlock era))
-shelleyBlockForging TPraosParams {..}
+shelleyBlockForging tpraosParams credentials =
+    aux <$> shelleySharedBlockForging (Proxy @'[era]) tpraosParams credentials
+  where
+    aux ::
+         NP (BlockForging m :.: ShelleyBlock) '[era]
+      -> BlockForging m (ShelleyBlock era)
+    aux = unComp . hd
+
+-- | Needed in 'shelleySharedBlockForging' because we can't partially apply
+-- equality constraints.
+class    (ShelleyBasedEra era, EraCrypto era ~ c) => ShelleyEraWithCrypto c era
+instance (ShelleyBasedEra era, EraCrypto era ~ c) => ShelleyEraWithCrypto c era
+
+-- | Create a 'BlockForging' record for each of the given Shelley-based eras,
+-- safely sharing the same set of credentials for all of them.
+--
+-- The name of the era (separated by a @_@) will be appended to each
+-- 'forgeLabel'.
+shelleySharedBlockForging ::
+     forall m c eras.
+     ( PraosCrypto c
+     , All (ShelleyEraWithCrypto c) eras
+     , IOLike m
+     )
+  => Proxy eras
+  -> TPraosParams
+  -> TPraosLeaderCredentials c
+  -> m (NP (BlockForging m :.: ShelleyBlock) eras)
+shelleySharedBlockForging
+                    _
+                    TPraosParams {..}
                     TPraosLeaderCredentials {
                         tpraosLeaderCredentialsInitSignKey = initSignKey
                       , tpraosLeaderCredentialsCanBeLeader = canBeLeader
                       , tpraosLeaderCredentialsLabel       = label
                       } = do
-    hotKey <- HotKey.mkHotKey initSignKey startPeriod tpraosMaxKESEvo
-    return BlockForging {
-        forgeLabel       = label
-      , canBeLeader      = canBeLeader
-      , updateForgeState = \curSlot ->
-                               ForgeStateUpdateInfo <$>
-                                 HotKey.evolve hotKey (slotToPeriod curSlot)
-      , checkCanForge    = \cfg curSlot _tickedChainDepState ->
-                               tpraosCheckCanForge
-                                 (configConsensus cfg)
-                                 forgingVRFHash
-                                 curSlot
-      , forgeBlock       = forgeShelleyBlock hotKey canBeLeader
-      }
+    hotKey <- HotKey.mkHotKey @m @c initSignKey startPeriod tpraosMaxKESEvo
+    return $ hcpure (Proxy @(ShelleyEraWithCrypto c)) (Comp (aux hotKey))
   where
-    forgingVRFHash :: SL.Hash (EraCrypto era) (SL.VerKeyVRF (EraCrypto era))
+    aux ::
+         forall era. ShelleyEraWithCrypto c era
+      => HotKey c m -> BlockForging m (ShelleyBlock era)
+    aux hotKey = BlockForging {
+          forgeLabel       = label <> "_" <> shelleyBasedEraName (Proxy @era)
+        , canBeLeader      = canBeLeader
+        , updateForgeState = \curSlot ->
+                                 ForgeStateUpdateInfo <$>
+                                   HotKey.evolve hotKey (slotToPeriod curSlot)
+        , checkCanForge    = \cfg curSlot _tickedChainDepState ->
+                                 tpraosCheckCanForge
+                                   (configConsensus cfg)
+                                   forgingVRFHash
+                                   curSlot
+        , forgeBlock       = forgeShelleyBlock hotKey canBeLeader
+        }
+
+    forgingVRFHash :: SL.Hash c (SL.VerKeyVRF c)
     forgingVRFHash =
           SL.hashVerKeyVRF
         . VRF.deriveVerKeyVRF
@@ -155,40 +202,52 @@ validateGenesis = first errsToString . SL.validateGenesis
         Text.unpack $ Text.unlines
           ("Invalid genesis config:" : map SL.describeValidationErr errs)
 
--- | Parameters needed to run Shelley
-data ProtocolParamsShelley c f = ProtocolParamsShelley {
-      shelleyGenesis           :: SL.ShelleyGenesis (ShelleyEra c)
+-- | Parameters common to all Shelley-based ledgers.
+--
+-- When running a chain with multiple Shelley-based eras, in addition to the
+-- per-era protocol parameters, one value of 'ProtocolParamsShelleyBased' will
+-- be needed, which is shared among all Shelley-based eras.
+--
+-- The @era@ parameter determines from which era the genesis config will be
+-- used.
+data ProtocolParamsShelleyBased era f = ProtocolParamsShelleyBased {
+      shelleyBasedGenesis           :: SL.ShelleyGenesis era
       -- | The initial nonce, typically derived from the hash of Genesis
       -- config JSON file.
       --
       -- WARNING: chains using different values of this parameter will be
       -- mutually incompatible.
-    , shelleyInitialNonce      :: SL.Nonce
-    , shelleyProtVer           :: SL.ProtVer
-    , shelleyLeaderCredentials :: f (TPraosLeaderCredentials c)
+    , shelleyBasedInitialNonce      :: SL.Nonce
+    , shelleyBasedLeaderCredentials :: f (TPraosLeaderCredentials (EraCrypto era))
+    }
+
+-- | Parameters needed to run Shelley
+data ProtocolParamsShelley = ProtocolParamsShelley {
+      shelleyProtVer :: SL.ProtVer
     }
 
 -- | Parameters needed to run Allegra
-data ProtocolParamsAllegra c f = ProtocolParamsAllegra {
-      allegraProtVer           :: SL.ProtVer
-    , allegraLeaderCredentials :: f (TPraosLeaderCredentials c)
+data ProtocolParamsAllegra = ProtocolParamsAllegra {
+      allegraProtVer :: SL.ProtVer
     }
 
 -- | Parameters needed to run Mary
-data ProtocolParamsMary c f = ProtocolParamsMary {
-      maryProtVer           :: SL.ProtVer
-    , maryLeaderCredentials :: f (TPraosLeaderCredentials c)
+data ProtocolParamsMary = ProtocolParamsMary {
+      maryProtVer :: SL.ProtVer
     }
 
 protocolInfoShelley ::
      forall m c f. (IOLike m, ShelleyBasedEra (ShelleyEra c), Foldable f)
-  => ProtocolParamsShelley c f
+  => ProtocolParamsShelleyBased (ShelleyEra c) f
+  -> ProtocolParamsShelley
   -> ProtocolInfo m (ShelleyBlock (ShelleyEra c))
-protocolInfoShelley ProtocolParamsShelley {
-                        shelleyGenesis           = genesis
-                      , shelleyInitialNonce      = initialNonce
-                      , shelleyProtVer           = protVer
-                      , shelleyLeaderCredentials = credentialss
+protocolInfoShelley ProtocolParamsShelleyBased {
+                        shelleyBasedGenesis           = genesis
+                      , shelleyBasedInitialNonce      = initialNonce
+                      , shelleyBasedLeaderCredentials = credentialss
+                      }
+                    ProtocolParamsShelley {
+                        shelleyProtVer = protVer
                       } =
     assertWithMsg (validateGenesis genesis) $
     ProtocolInfo {

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -884,9 +884,11 @@ runThreadNetwork systemTime ThreadNetworkArgs
                   void $ ChainDB.addBlock chainDB ebb
                   pure blk
 
-      blockForging <- forM pInfoBlockForging $ \initBlockForging -> do
-        bf <- initBlockForging
-        return bf { forgeBlock = customForgeBlock bf }
+      origBlockForging <- pInfoBlockForging
+      let blockForging =
+            [ bf { forgeBlock = customForgeBlock bf }
+            | bf <- origBlockForging
+            ]
 
       -- This variable holds the number of the earliest slot in which the
       -- crucial txs have not yet been added. In other words, it holds the

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -49,6 +49,7 @@ import           Ouroboros.Consensus.Protocol.LeaderSchedule
                      (LeaderSchedule (..), leaderScheduleFor)
 import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Counting
+import           Ouroboros.Consensus.Util.OptNP (OptNP (..))
 import           Ouroboros.Consensus.Util.Orphans ()
 
 import           Ouroboros.Consensus.HardFork.Combinator
@@ -236,8 +237,10 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
                                 (WrapChainDepState initChainDepState)
             }
         , pInfoBlockForging = return
-            [ hardForkBlockForging $     Z blockForgingA
-            , hardForkBlockForging $ S $ Z blockForgingB
+            [   hardForkBlockForging "Test"
+              $ OptCons blockForgingA
+              $ OptCons blockForgingB
+              $ OptNil
             ]
         }
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -235,9 +235,9 @@ prop_simple_hfc_convergence testSetup@TestSetup{..} =
                               initHardForkState
                                 (WrapChainDepState initChainDepState)
             }
-        , pInfoBlockForging =
-            [ return $ hardForkBlockForging $     Z blockForgingA
-            , return $ hardForkBlockForging $ S $ Z blockForgingB
+        , pInfoBlockForging = return
+            [ hardForkBlockForging $     Z blockForgingA
+            , hardForkBlockForging $ S $ Z blockForgingB
             ]
         }
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -284,7 +284,7 @@ blockForgingA :: Monad m => BlockForging m BlockA
 blockForgingA = BlockForging {
      forgeLabel       = "BlockA"
    , canBeLeader      = ()
-   , updateForgeState = \_ -> return $ ForgeStateUpdateInfo $ Unchanged ()
+   , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Unchanged ()
    , checkCanForge    = \_ _ _ _ _ -> return ()
    , forgeBlock       = return .....: forgeBlockA
    }

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -238,7 +238,7 @@ blockForgingB :: Monad m => BlockForging m BlockB
 blockForgingB = BlockForging {
      forgeLabel       = "BlockB"
    , canBeLeader      = ()
-   , updateForgeState = \_ -> return $ ForgeStateUpdateInfo $ Unchanged ()
+   , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Unchanged ()
    , checkCanForge    = \_ _ _ _ _ -> return ()
    , forgeBlock       = return .....: forgeBlockB
    }

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -166,6 +166,7 @@ library
                        Ouroboros.Consensus.Util.MonadSTM.NormalForm
                        Ouroboros.Consensus.Util.MonadSTM.RAWLock
                        Ouroboros.Consensus.Util.MonadSTM.StrictMVar
+                       Ouroboros.Consensus.Util.OptNP
                        Ouroboros.Consensus.Util.Orphans
                        Ouroboros.Consensus.Util.RedundantConstraints
                        Ouroboros.Consensus.Util.ResourceRegistry
@@ -295,6 +296,7 @@ library
                      , stm               >=2.5   && <2.6
                      , streaming
                      , text              >=1.2   && <1.3
+                     , these             >=1.1   && <1.2
                      , time
                      , transformers
                      , vector            >=0.12  && <0.13

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
@@ -60,7 +60,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Translation as X
 
 -- Combinator for 'BlockForging'
 import           Ouroboros.Consensus.HardFork.Combinator.Forging as X
-                     (HardForkForgeStateInfo, hardForkBlockForging)
+                     (HardForkForgeStateInfo (..), hardForkBlockForging)
 
 -- Instances for 'RunNode' and 'ConfigSupportsNode'
 import           Ouroboros.Consensus.HardFork.Combinator.Node as X ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -15,6 +15,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock (
   , EraIndex(..)
   , eraIndexEmpty
   , eraIndexFromNS
+  , eraIndexFromIndex
   , eraIndexZero
   , eraIndexSucc
   , eraIndexToInt
@@ -146,6 +147,9 @@ eraIndexEmpty (EraIndex ns) = case ns of {}
 
 eraIndexFromNS :: SListI xs => NS f xs -> EraIndex xs
 eraIndexFromNS = EraIndex . hmap (const (K ()))
+
+eraIndexFromIndex :: Index xs blk -> EraIndex xs
+eraIndexFromIndex index = EraIndex $ injectNS index (K ())
 
 eraIndexZero :: EraIndex (x ': xs)
 eraIndexZero = EraIndex (Z (K ()))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -25,10 +25,11 @@ module Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
   , PerEraCodecConfig(..)
   , PerEraLedgerConfig(..)
   , PerEraStorageConfig(..)
+    -- * Values for /some/ eras
+  , SomeErasCanBeLeader(..)
     -- * Value for /one/ era
   , OneEraApplyTxErr(..)
   , OneEraBlock(..)
-  , OneEraCanBeLeader(..)
   , OneEraCannotForge(..)
   , OneEraEnvelopeErr(..)
   , OneEraForgeStateInfo(..)
@@ -75,6 +76,7 @@ import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util (allEqual)
 import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.Condense (Condense (..))
+import           Ouroboros.Consensus.Util.OptNP (OptNP)
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.Info
@@ -94,12 +96,21 @@ newtype PerEraLedgerConfig    xs = PerEraLedgerConfig    { getPerEraLedgerConfig
 newtype PerEraStorageConfig   xs = PerEraStorageConfig   { getPerEraStorageConfig   :: NP StorageConfig              xs }
 
 {-------------------------------------------------------------------------------
+  Values for /some/ eras
+
+  The reason for using @OptNP 'False f xs@ as opposed to @NP (Maybe :.: f) xs@
+  is to maintain the isomorphism between @blk@ and @HardForkBlock '[blk]@ in
+  "Ouroboros.Consensus.HardFork.Combinator.Unary"
+-------------------------------------------------------------------------------}
+
+newtype SomeErasCanBeLeader xs = SomeErasCanBeLeader { getSomeErasCanBeLeader :: OptNP 'False WrapCanBeLeader xs }
+
+{-------------------------------------------------------------------------------
   Value for /one/ era
 -------------------------------------------------------------------------------}
 
 newtype OneEraApplyTxErr            xs = OneEraApplyTxErr            { getOneEraApplyTxErr            :: NS WrapApplyTxErr            xs }
 newtype OneEraBlock                 xs = OneEraBlock                 { getOneEraBlock                 :: NS I                         xs }
-newtype OneEraCanBeLeader           xs = OneEraCanBeLeader           { getOneEraCanBeLeader           :: NS WrapCanBeLeader           xs }
 newtype OneEraCannotForge           xs = OneEraCannotForge           { getOneEraCannotForge           :: NS WrapCannotForge           xs }
 newtype OneEraEnvelopeErr           xs = OneEraEnvelopeErr           { getOneEraEnvelopeErr           :: NS WrapEnvelopeErr           xs }
 newtype OneEraForgeStateInfo        xs = OneEraForgeStateInfo        { getOneEraForgeStateInfo        :: NS WrapForgeStateInfo        xs }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -210,15 +210,15 @@ distribAnnTip AnnTip{..} =
         AnnTip annTipSlotNo annTipBlockNo info
 
 undistribAnnTip :: SListI xs => NS AnnTip xs -> AnnTip (HardForkBlock xs)
-undistribAnnTip = hcollapse . hzipWith undistrib injections
+undistribAnnTip = hcollapse . himap undistrib
   where
-    undistrib :: (WrapTipInfo -.-> K (NS WrapTipInfo xs)) blk
+    undistrib :: Index xs blk
               -> AnnTip blk
               -> K (AnnTip (HardForkBlock xs)) blk
-    undistrib inj AnnTip{..} = K $
+    undistrib index AnnTip{..} = K $
         AnnTip annTipSlotNo
                annTipBlockNo
-               (OneEraTipInfo $ unK . apFn inj . WrapTipInfo $ annTipInfo)
+               (OneEraTipInfo . injectNS index . WrapTipInfo $ annTipInfo)
 
 {-------------------------------------------------------------------------------
   BasicEnvelopeValidation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Nary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Nary.hs
@@ -41,7 +41,7 @@ class Inject f where
        forall x xs. CanHardFork xs
     => Exactly xs History.Bound
        -- ^ Start bound of each era
-    -> Index x xs
+    -> Index xs x
     -> f x
     -> f (HardForkBlock xs)
 
@@ -52,7 +52,7 @@ inject' ::
      , Coercible a (f x)
      , Coercible b (f (HardForkBlock xs))
      )
-  => Proxy f -> Exactly xs History.Bound -> Index x xs -> a -> b
+  => Proxy f -> Exactly xs History.Bound -> Index xs x -> a -> b
 inject' _ startBounds idx = coerce . inject @f startBounds idx . coerce
 
 {-------------------------------------------------------------------------------
@@ -61,7 +61,7 @@ inject' _ startBounds idx = coerce . inject @f startBounds idx . coerce
 
 injectNestedCtxt_ ::
      forall f x xs a.
-     Index x xs
+     Index xs x
   -> NestedCtxt_ x f a
   -> NestedCtxt_ (HardForkBlock xs) f a
 injectNestedCtxt_ idx nc = case idx of
@@ -70,7 +70,7 @@ injectNestedCtxt_ idx nc = case idx of
 
 injectQuery ::
      forall x xs result.
-     Index x xs
+     Index xs x
   -> Query x result
   -> QueryIfCurrent xs result
 injectQuery idx q = case idx of
@@ -81,7 +81,7 @@ injectHardForkState ::
      forall f x xs.
      Exactly xs History.Bound
      -- ^ Start bound of each era
-  -> Index x xs
+  -> Index xs x
   -> f x
   -> HardForkState f xs
 injectHardForkState startBounds idx x =
@@ -89,7 +89,7 @@ injectHardForkState startBounds idx x =
   where
     go ::
          Exactly xs' History.Bound
-      -> Index x xs'
+      -> Index xs' x
       -> Telescope (K State.Past) (State.Current f) xs'
     go (ExactlyCons start _) IZ =
         TZ (State.Current { currentStart = start, currentState = x })
@@ -115,7 +115,7 @@ instance Inject SerialisedHeader where
       . serialisedHeaderToPair
 
 instance Inject WrapHeaderHash where
-  inject _ (idx :: Index x xs) =
+  inject _ (idx :: Index xs x) =
     case dictIndexAll (Proxy @SingleEraBlock) idx of
       Dict ->
           WrapHeaderHash

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -460,13 +460,13 @@ decodeNS ds = do
     i <- Dec.decodeWord8
     case nsFromIndex i of
       Nothing -> fail $ "decodeNS: invalid index " ++ show i
-      Just ns -> hcollapse $ hzipWith3 aux injections ds ns
+      Just ns -> hcollapse $ hizipWith aux ds ns
   where
-    aux :: (f -.-> K (NS f xs)) blk
+    aux :: Index xs blk
         -> (Decoder s :.: f) blk
         -> K () blk
         -> K (Decoder s (NS f xs)) blk
-    aux inj (Comp dec) (K ()) = K $ (unK . apFn inj) <$> dec
+    aux index (Comp dec) (K ()) = K $ injectNS index <$> dec
 
 decodeAnnNS :: SListI xs
             => NP (AnnDecoder f) xs
@@ -476,14 +476,13 @@ decodeAnnNS ds = do
     i <- Dec.decodeWord8
     case nsFromIndex i of
       Nothing -> fail $ "decodeAnnNS: invalid index " ++ show i
-      Just ns -> hcollapse $ hzipWith3 aux injections ds ns
+      Just ns -> hcollapse $ hizipWith aux ds ns
   where
-    aux :: (f -.-> K (NS f xs)) blk
+    aux :: Index xs blk
         -> AnnDecoder f blk
         -> K () blk
         -> K (Decoder s (Lazy.ByteString -> NS f xs)) blk
-    aux inj (AnnDecoder dec) (K ()) = K $
-       (\f -> unK . apFn inj . f ) <$> dec
+    aux index (AnnDecoder dec) (K ()) = K $ (injectNS index .) <$> dec
 
 {-------------------------------------------------------------------------------
   Dependent serialisation

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/DerivingVia.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/DerivingVia.hs
@@ -10,6 +10,7 @@
 module Ouroboros.Consensus.HardFork.Combinator.Util.DerivingVia (
     LiftNS(..)
   , LiftNP(..)
+  , LiftOptNP(..)
   , LiftTelescope(..)
   , LiftMismatch(..)
   , LiftNamedNS(..)
@@ -25,6 +26,8 @@ import           Data.SOP.Strict
 import           Data.Typeable
 import           GHC.TypeLits
 import           NoThunks.Class (NoThunks (..))
+
+import           Ouroboros.Consensus.Util.OptNP (OptNP (..))
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.Util.Match (Mismatch)
@@ -100,6 +103,26 @@ instance (All SingleEraBlock xs, forall x. SingleEraBlock x => Ord (f x))
 instance (All SingleEraBlock xs, forall x. SingleEraBlock x => Show (f x))
       => Show (LiftNP f xs) where
   show (LiftNP x) =
+      case liftEras (Proxy @xs) (Proxy @Show) (Proxy @f) of { Dict ->
+          show x
+        }
+
+{-------------------------------------------------------------------------------
+  LiftOptNP
+-------------------------------------------------------------------------------}
+
+newtype LiftOptNP empty f xs = LiftOptNP (OptNP empty f xs)
+
+instance (All SingleEraBlock xs, forall x. SingleEraBlock x => Eq (f x))
+      => Eq (LiftOptNP empty f xs) where
+  LiftOptNP x == LiftOptNP y =
+      case liftEras (Proxy @xs) (Proxy @Eq) (Proxy @f) of { Dict ->
+          x == y
+        }
+
+instance (All SingleEraBlock xs, forall x. SingleEraBlock x => Show (f x))
+      => Show (LiftOptNP empty f xs) where
+  show (LiftOptNP x) =
       case liftEras (Proxy @xs) (Proxy @Show) (Proxy @f) of { Dict ->
           show x
         }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -474,7 +474,7 @@ mkNodeKernelArgs
   -> Int
   -> StdGen
   -> TopLevelConfig blk
-  -> [m (BlockForging m blk)]
+  -> m [BlockForging m blk]
   -> Tracers m (ConnectionId addrNTN) (ConnectionId addrNTC) blk
   -> BlockchainTime m
   -> ChainDB m blk
@@ -489,7 +489,7 @@ mkNodeKernelArgs
   btime
   chainDB
   = do
-    blockForging <- sequence initBlockForging
+    blockForging <- initBlockForging
     return NodeKernelArgs
       { tracers
       , registry

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -38,7 +38,7 @@ enumCoreNodes (NumCoreNodes numNodes) =
 data ProtocolInfo m b = ProtocolInfo {
         pInfoConfig       :: TopLevelConfig b
       , pInfoInitLedger   :: ExtLedgerState b -- ^ At genesis
-      , pInfoBlockForging :: [m (BlockForging m b)]
+      , pInfoBlockForging :: m [BlockForging m b]
       }
 
 -- | Data required by clients of a node running the specified protocol.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/OptNP.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/OptNP.hs
@@ -1,0 +1,211 @@
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE EmptyCase            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE StandaloneDeriving   #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE UndecidableInstances #-}
+-- | NP with optional values
+--
+--
+-- Intended for qualified import
+--
+-- > import           Ouroboros.Consensus.Util.OptNP (OptNP (..), ViewOptNP (..))
+-- > import qualified Ouroboros.Consensus.Util.OptNP as OptNP
+module Ouroboros.Consensus.Util.OptNP (
+    OptNP(..)
+  , empty
+  , fromNonEmptyNP
+  , fromNP
+  , toNP
+  , at
+  , singleton
+  , fromSingleton
+    -- * View
+  , ViewOptNP(..)
+  , view
+    -- * Combining
+  , zipWith
+  , combine
+  , combineWith
+  ) where
+
+import           Prelude hiding (zipWith)
+
+import           Control.Monad (guard)
+import           Data.Functor.These (These1 (..))
+import           Data.Kind (Type)
+import           Data.Maybe (isJust)
+import           Data.SOP.Strict hiding (And)
+import           Data.Type.Equality
+import           GHC.Stack (HasCallStack)
+
+import           Ouroboros.Consensus.Util.SOP
+
+-- | Like an 'NP', but with optional values
+data OptNP (empty :: Bool) (f :: k -> Type) (xs :: [k]) where
+  OptNil  :: OptNP 'True f '[]
+  OptCons :: !(f x) -> !(OptNP empty f xs) -> OptNP 'False f (x ': xs)
+  OptSkip :: !(OptNP empty f xs) -> OptNP empty f (x ': xs)
+
+type instance AllN    (OptNP empty) c = All c
+type instance SListIN (OptNP empty)   = SListI
+type instance Prod    (OptNP empty)   = NP
+
+deriving instance All (Show `Compose` f) xs => Show (OptNP empty f xs)
+
+eq ::
+     All (Eq `Compose` f) xs
+  => OptNP empty f xs
+  -> OptNP empty' f xs -> Maybe (empty :~: empty')
+eq OptNil         OptNil         = Just Refl
+eq (OptSkip   xs) (OptSkip   ys) = eq xs ys
+eq (OptCons x xs) (OptCons y ys) = do guard (x == y)
+                                      Refl <- eq xs ys
+                                      return Refl
+eq _              _              = Nothing
+
+instance All (Eq `Compose` f) xs => Eq (OptNP empty f xs) where
+  xs == ys = isJust (eq xs ys)
+
+empty :: forall f xs. SListI xs => OptNP 'True f xs
+empty = case sList @xs of
+    SNil  -> OptNil
+    SCons -> OptSkip empty
+
+fromNonEmptyNP :: forall f xs. IsNonEmpty xs => NP f xs -> OptNP 'False f xs
+fromNonEmptyNP xs = case isNonEmpty (Proxy @xs) of
+    ProofNonEmpty {} ->
+      case xs of
+        x :* xs' -> fromNP (OptCons x) xs'
+
+fromNP :: (forall empty. OptNP empty f xs -> r) -> NP f xs -> r
+fromNP k Nil       = k OptNil
+fromNP k (x :* xs) = fromNP (k . OptCons x) xs
+
+toNP :: OptNP empty f xs -> NP (Maybe :.: f) xs
+toNP = go
+  where
+    go :: OptNP empty f xs -> NP (Maybe :.: f) xs
+    go OptNil         = Nil
+    go (OptCons x xs) = Comp (Just x) :* go xs
+    go (OptSkip   xs) = Comp Nothing  :* go xs
+
+at :: SListI xs => f x -> Index xs x -> OptNP 'False f xs
+at x IZ         = OptCons x empty
+at x (IS index) = OptSkip (at x index)
+
+singleton :: f x -> OptNP 'False f '[x]
+singleton x = OptCons x OptNil
+
+-- | If 'OptNP' is not empty, it must contain at least one value
+fromSingleton :: OptNP 'False f '[x] -> f x
+fromSingleton (OptCons x _) = x
+
+ap ::
+     NP (f -.-> g) xs
+  -> OptNP empty f xs
+  -> OptNP empty g xs
+ap = go
+  where
+    go :: NP (f -.-> g) xs -> OptNP empty f xs -> OptNP empty g xs
+    go (f :* fs) (OptCons x xs) = OptCons (apFn f x) (go fs xs)
+    go (_ :* fs) (OptSkip   xs) = OptSkip            (go fs xs)
+    go Nil       OptNil         = OptNil
+
+ctraverse' ::
+     forall c proxy empty xs f f' g. (All c xs, Applicative g)
+  => proxy c
+  -> (forall a. c a => f a -> g (f' a))
+  -> OptNP empty f xs  -> g (OptNP empty f' xs)
+ctraverse' _ f = go
+  where
+    go :: All c ys => OptNP empty' f ys -> g (OptNP empty' f' ys)
+    go (OptCons x xs) = OptCons <$> f x <*> go xs
+    go (OptSkip   xs) = OptSkip <$>         go xs
+    go OptNil         = pure OptNil
+
+instance HAp (OptNP empty) where
+  hap = ap
+
+instance HSequence (OptNP empty) where
+  hctraverse' = ctraverse'
+  htraverse'  = hctraverse' (Proxy @Top)
+  hsequence'  = htraverse' unComp
+
+{-------------------------------------------------------------------------------
+  View
+-------------------------------------------------------------------------------}
+
+data ViewOptNP f xs where
+  OptNP_ExactlyOne :: f x -> ViewOptNP f '[x]
+  OptNP_AtLeastTwo ::        ViewOptNP f (x ': y ': zs)
+
+view :: forall f xs. OptNP 'False f xs -> ViewOptNP f xs
+view = \case
+    OptCons x  OptNil       -> OptNP_ExactlyOne x
+    OptCons _ (OptCons _ _) -> OptNP_AtLeastTwo
+    OptCons _ (OptSkip _)   -> OptNP_AtLeastTwo
+    OptSkip   (OptCons _ _) -> OptNP_AtLeastTwo
+    OptSkip   (OptSkip _)   -> OptNP_AtLeastTwo
+
+{-------------------------------------------------------------------------------
+  Combining
+-------------------------------------------------------------------------------}
+
+type family And (x :: Bool) (y :: Bool) :: Bool where
+  And 'True  y      = y
+  And 'False _      = 'False
+  And _      'False = 'False
+
+zipWith ::
+     forall f g h empty1 empty2 xs.
+     (forall a. These1 f g a -> h a)
+  -> OptNP empty1              f xs
+  -> OptNP empty2              g xs
+  -> OptNP (And empty1 empty2) h xs
+zipWith f = go
+  where
+    go :: OptNP empty1'               f xs'
+       -> OptNP empty2'               g xs'
+       -> OptNP (And empty1' empty2') h xs'
+    go OptNil         OptNil         = OptNil
+    go (OptCons x xs) (OptSkip   ys) = OptCons (f (This1  x  )) (go xs ys)
+    go (OptSkip   xs) (OptCons y ys) = OptCons (f (That1    y)) (go xs ys)
+    go (OptCons x xs) (OptCons y ys) = OptCons (f (These1 x y)) (go xs ys)
+    go (OptSkip   xs) (OptSkip   ys) = OptSkip                  (go xs ys)
+
+combineWith ::
+     SListI xs
+  => (forall a. These1 f g a -> h a)
+  -> Maybe (OptNP 'False f xs)
+  -> Maybe (OptNP 'False g xs)
+  -> Maybe (OptNP 'False h xs)
+combineWith _ Nothing   Nothing   = Nothing
+combineWith f (Just xs) Nothing   = Just $ zipWith f xs    empty
+combineWith f Nothing   (Just ys) = Just $ zipWith f empty ys
+combineWith f (Just xs) (Just ys) = Just $ zipWith f xs    ys
+
+-- | Precondition: there is no overlap between the two given lists: if there is
+-- a 'Just' at a given position in one, it must be 'Nothing' at the same
+-- position in the other.
+combine ::
+     forall (f :: Type -> Type) xs.
+     -- 'These1' is not kind-polymorphic
+     (SListI xs, HasCallStack)
+  => Maybe (OptNP 'False f xs)
+  -> Maybe (OptNP 'False f xs)
+  -> Maybe (OptNP 'False f xs)
+combine = combineWith $ \case
+    This1 x   -> x
+    That1 y   -> y
+    These1 {} -> error "combine: precondition violated"

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
@@ -33,10 +33,20 @@ module Ouroboros.Consensus.Util.SOP (
   , checkIsNonEmpty
     -- * Indexing SOP types
   , Index(..)
+  , indices
   , dictIndexAll
   , injectNS
   , injectNS'
   , projectNP
+    -- * Zipping with indices
+  , himap
+  , hcimap
+  , hizipWith
+  , hcizipWith
+  , hizipWith3
+  , hcizipWith3
+  , hizipWith4
+  , hcizipWith4
   ) where
 
 import           Data.Coerce
@@ -185,6 +195,11 @@ data Index xs x where
   IZ ::               Index (x ': xs) x
   IS :: Index xs x -> Index (y ': xs) x
 
+indices :: forall xs. SListI xs => NP (Index xs) xs
+indices = case sList @xs of
+    SNil  -> Nil
+    SCons -> IZ :* hmap IS indices
+
 dictIndexAll :: All c xs => Proxy c -> Index xs x -> Dict c x
 dictIndexAll p = \case
     IZ      -> Dict
@@ -203,3 +218,97 @@ injectNS' _ idx = coerce . injectNS @f idx . coerce
 projectNP :: Index xs x -> NP f xs -> f x
 projectNP IZ        (x :* _) = x
 projectNP (IS idx) (_ :* xs) = projectNP idx xs
+
+{-------------------------------------------------------------------------------
+  Zipping with indices
+-------------------------------------------------------------------------------}
+
+hcimap ::
+     (HAp h, All c xs, Prod h ~ NP)
+  => proxy c
+  -> (forall a. c a => Index xs a -> f1 a -> f2 a)
+  -> h f1 xs
+  -> h f2 xs
+hcimap p f xs1 =
+    hcpure p (fn_2 f)
+      `hap` indices
+      `hap` xs1
+
+himap ::
+     (HAp h, SListI xs, Prod h ~ NP)
+  => (forall a. Index xs a -> f1 a -> f2 a)
+  -> h f1 xs
+  -> h f2 xs
+himap = hcimap (Proxy @Top)
+
+hcizipWith ::
+     (HAp h, All c xs, Prod h ~ NP)
+  => proxy c
+  -> (forall a. c a => Index xs a -> f1 a -> f2 a -> f3 a)
+  -> NP f1 xs
+  -> h  f2 xs
+  -> h  f3 xs
+hcizipWith p f xs1 xs2 =
+    hcpure p (fn_3 f)
+      `hap` indices
+      `hap` xs1
+      `hap` xs2
+
+hizipWith ::
+     (HAp h, SListI xs, Prod h ~ NP)
+  => (forall a. Index xs a -> f1 a -> f2 a -> f3 a)
+  -> NP f1 xs
+  -> h  f2 xs
+  -> h  f3 xs
+hizipWith = hcizipWith (Proxy @Top)
+
+hcizipWith3 ::
+     (HAp h, All c xs, Prod h ~ NP)
+  => proxy c
+  -> (forall a. c a => Index xs a -> f1 a -> f2 a -> f3 a -> f4 a)
+  -> NP f1 xs
+  -> NP f2 xs
+  -> h  f3 xs
+  -> h  f4 xs
+hcizipWith3 p f xs1 xs2 xs3 =
+    hcpure p (fn_4 f)
+      `hap` indices
+      `hap` xs1
+      `hap` xs2
+      `hap` xs3
+
+hizipWith3 ::
+     (HAp h, SListI xs, Prod h ~ NP)
+  => (forall a. Index xs a -> f1 a -> f2 a -> f3 a -> f4 a)
+  -> NP f1 xs
+  -> NP f2 xs
+  -> h  f3 xs
+  -> h  f4 xs
+hizipWith3 = hcizipWith3 (Proxy @Top)
+
+hcizipWith4 ::
+     (HAp h, All c xs, Prod h ~ NP)
+  => proxy c
+  -> (forall a. c a => Index xs a -> f1 a -> f2 a -> f3 a -> f4 a -> f5 a)
+  -> NP f1 xs
+  -> NP f2 xs
+  -> NP f3 xs
+  -> h  f4 xs
+  -> h  f5 xs
+hcizipWith4 p f xs1 xs2 xs3 xs4 =
+    hcpure p (fn_5 f)
+      `hap` indices
+      `hap` xs1
+      `hap` xs2
+      `hap` xs3
+      `hap` xs4
+
+hizipWith4 ::
+     (HAp h, SListI xs, Prod h ~ NP)
+  => (forall a. Index xs a -> f1 a -> f2 a -> f3 a -> f4 a -> f5 a)
+  -> NP f1 xs
+  -> NP f2 xs
+  -> NP f3 xs
+  -> h  f4 xs
+  -> h  f5 xs
+hizipWith4 = hcizipWith4 (Proxy @Top)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
@@ -181,25 +181,25 @@ checkIsNonEmpty _ = case sList @xs of
   Indexing SOP types
 -------------------------------------------------------------------------------}
 
-data Index x xs where
-  IZ ::               Index x (x ': xs)
-  IS :: Index x xs -> Index x (y ': xs)
+data Index xs x where
+  IZ ::               Index (x ': xs) x
+  IS :: Index xs x -> Index (y ': xs) x
 
-dictIndexAll :: All c xs => Proxy c -> Index x xs -> Dict c x
+dictIndexAll :: All c xs => Proxy c -> Index xs x -> Dict c x
 dictIndexAll p = \case
     IZ      -> Dict
     IS idx' -> dictIndexAll p idx'
 
-injectNS :: forall f x xs. Index x xs -> f x -> NS f xs
+injectNS :: forall f x xs. Index xs x -> f x -> NS f xs
 injectNS idx x = case idx of
     IZ      -> Z x
     IS idx' -> S (injectNS idx' x)
 
 injectNS' ::
      forall f a b x xs. (Coercible a (f x), Coercible b (NS f xs))
-  => Proxy f -> Index x xs -> a -> b
+  => Proxy f -> Index xs x -> a -> b
 injectNS' _ idx = coerce . injectNS @f idx . coerce
 
-projectNP :: Index x xs -> NP f xs -> f x
+projectNP :: Index xs x -> NP f xs -> f x
 projectNP IZ        (x :* _) = x
 projectNP (IS idx) (_ :* xs) = projectNP idx xs


### PR DESCRIPTION
We add the ability to share a single KES key by multiple Shelley-based eras.

Also, instead of a different thread per era, the hard fork combinator can now
combine `BlockForging` records from multiple eras into one `BlockForging` record
which picks the appropriate `BlockForging` based on the current era.

This means that the KES key shared by the Shelley-based eras will only be tried
to be evolved once, instead of once for each Shelley-based era (in the previous
approach, all threads would try to evolve it, but all but one would be an
identity operation). This should also improve tracing: instead of tracing
messages for each era, only messages of the current era are traced.

Note that multiple credentials *per era* (i.e. to benchmark multiple stakepools
on one node) will still result in multiple forging threads.

We refactor the protocol parameters for Shelley/Allegra/Mary to handle the
shared key: we now have a `ProtocolParamsShelleyBased` record which contains
everything needed for a Shelley-based chain, i.e., the genesis config and the
credentials. This record should be combined with the right era-specific ones.
This also paves the way for adding a Mary-only mode.