### PR TITLE
Update comments: s/UnsafeUnbounded/UnsafeIndefiniteSafeZone/g

### DIFF
--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
@@ -670,7 +670,7 @@ genEvents = \(Eras eras) (HF.Shape shape) -> sized $ \sz -> do
               -- We are in the final era
               Nothing
           | Nothing <- mNextLo =
-              -- This era is 'UnsafeUnbounded'
+              -- This era is 'UnsafeIndefiniteSafeZone'
              Nothing
           | Just lo <- mNextLo =
               Just (pickStartOfNextEra lo)

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Infra.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Infra.hs
@@ -133,11 +133,11 @@ genShape eras = HF.Shape <$> erasMapStateM genParams eras (EpochNo 0)
     genParams _era startOfThis = do
         params      <- genEraParams
         startOfNext <- genStartOfNextEra startOfThis params
-        -- If startOfNext is 'Nothing', we used 'UnsafeUnbounded' for this
-        -- era. This means we should not be generating any events for any
-        -- succeeding eras, but to determine the /shape/ of the eras, and
-        -- set subsequent lower bounds, we just need to make sure that we
-        -- generate a valid shape: the next era must start after this one.
+        -- If startOfNext is 'Nothing', we used 'UnsafeIndefiniteSafeZone' for
+        -- this era. This means we should not be generating any events for any
+        -- succeeding eras, but to determine the /shape/ of the eras, and set
+        -- subsequent lower bounds, we just need to make sure that we generate a
+        -- valid shape: the next era must start after this one.
         return (params, fromMaybe (succ startOfThis) startOfNext)
 
 genSummary :: Eras xs -> Gen (HF.Summary xs)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Summary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Summary.hs
@@ -184,7 +184,7 @@ data EraEnd =
 
     -- | Unbounded era
     --
-    -- This arises from the use of 'UnsafeUnbounded'.
+    -- This arises from the use of 'UnsafeIndefiniteSafeZone'.
   | EraUnbounded
   deriving stock    (Show, Eq, Generic)
   deriving anyclass (NoThunks)


### PR DESCRIPTION
`UnsafeUnbounded` was renamed to `UnsafeIndefiniteSafeZone` at some point, but
some comments still mentioned the former. Update them.