### PR TITLE
snocket: introduce LocalSocket and FileDescriptor newtypes

### DIFF
--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -70,6 +70,7 @@ library
                      , stm
                      , text
                      , time
+                     , quiet
 
                      , cardano-prelude
                      , contra-tracer

--- a/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DerivingVia         #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -31,6 +33,8 @@ import           Control.Monad.Class.MonadTime (DiffTime)
 import           Control.Tracer (Tracer)
 import           Data.Bifunctor (Bifunctor (..))
 import           Data.Hashable
+import           GHC.Generics (Generic)
+import           Quiet (Quiet (..))
 #if !defined(mingw32_HOST_OS)
 import           Network.Socket ( Family (AF_UNIX) )
 #endif
@@ -129,7 +133,8 @@ berkeleyAccept ioManager sock = go
 -- Windows with `named-pipes`.
 --
 newtype LocalAddress = LocalAddress { getFilePath :: FilePath }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord, Generic)
+  deriving Show via Quiet LocalAddress
 
 instance Hashable LocalAddress where
     hashWithSalt s (LocalAddress path) = hashWithSalt s path
@@ -281,7 +286,8 @@ type LocalHandle = Socket
 
 -- | System dependent LocalSnocket type
 newtype LocalSocket  = LocalSocket { getLocalHandle :: LocalHandle }
-    deriving (Eq, Show)
+    deriving (Eq, Generic)
+    deriving Show via Quiet LocalSocket
 
 -- | System dependent LocalSnocket
 type    LocalSnocket = Snocket IO LocalSocket LocalAddress
@@ -412,7 +418,8 @@ localAddressFromPath = LocalAddress
 -- | Socket file descriptor.
 --
 newtype FileDescriptor = FileDescriptor { getFileDescriptor :: Int }
-  deriving (Eq, Show)
+  deriving (Eq, Generic)
+  deriving Show via Quiet FileDescriptor
 
 socketFileDescriptor :: Socket -> IO FileDescriptor
 socketFileDescriptor = fmap (FileDescriptor . fromIntegral) . Socket.socketToFd

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -420,7 +420,7 @@ fromSnocket
     -> Server.Socket addr fd
 fromSnocket tblVar sn sd = go (Snocket.accept sn sd)
   where
-    go :: Snocket.Accept addr fd -> Server.Socket addr fd
+    go :: Snocket.Accept IO addr fd -> Server.Socket addr fd
     go (Snocket.Accept accept) = Server.Socket $ do
       (sd', remoteAddr, next) <- accept
       -- TOOD: we don't need to that on each accept

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -420,7 +420,7 @@ fromSnocket
     -> Server.Socket addr fd
 fromSnocket tblVar sn sd = go (Snocket.accept sn sd)
   where
-    go :: Snocket.Accept IO addr fd -> Server.Socket addr fd
+    go :: Snocket.Accept IO fd addr -> Server.Socket addr fd
     go (Snocket.Accept accept) = Server.Socket $ do
       (sd', remoteAddr, next) <- accept
       -- TOOD: we don't need to that on each accept

--- a/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Client.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Client.hs
@@ -16,7 +16,7 @@ import           Data.Functor.Identity (Identity (..))
 
 import           Ouroboros.Network.Snocket ( LocalAddress
                                            , LocalSnocket
-                                           , LocalFD
+                                           , LocalSocket
                                            )
 import           Ouroboros.Network.ErrorPolicy ( ErrorPolicies
                                                , ErrorPolicyTrace
@@ -47,7 +47,7 @@ clientSubscriptionWorker
     -> Tracer IO (WithAddr LocalAddress ErrorPolicyTrace)
     -> NetworkMutableState LocalAddress
     -> ClientSubscriptionParams a
-    -> (LocalFD -> IO a)
+    -> (LocalSocket -> IO a)
     -> IO Void
 clientSubscriptionWorker snocket
                          tracer

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -51,6 +51,7 @@ module Ouroboros.Network.NodeToClient (
   , withIOManager
   , LocalSnocket
   , localSnocket
+  , LocalSocket
   , LocalAddress (..)
 
     -- * Versions
@@ -327,7 +328,7 @@ withServer
   :: LocalSnocket
   -> NetworkServerTracers LocalAddress NodeToClientVersion
   -> NetworkMutableState LocalAddress
-  -> LocalFD
+  -> LocalSocket
   -> Versions NodeToClientVersion
               NodeToClientVersionData
               (OuroborosApplication ResponderMode LocalAddress BL.ByteString IO a b)
@@ -354,7 +355,7 @@ withServer_V1
   :: LocalSnocket
   -> NetworkServerTracers LocalAddress NodeToClientVersion
   -> NetworkMutableState LocalAddress
-  -> LocalFD
+  -> LocalSocket
   -> NodeToClientVersionData
   -- ^ Client version data sent during initial handshake protocol.  Client and
   -- server must agree on it.
@@ -382,7 +383,7 @@ withServer_V2
   :: LocalSnocket
   -> NetworkServerTracers LocalAddress NodeToClientVersion
   -> NetworkMutableState LocalAddress
-  -> LocalFD
+  -> LocalSocket
   -> NodeToClientVersionData
   -- ^ Client version data sent during initial handshake protocol.  Client and
   -- server must agree on it.


### PR DESCRIPTION
Provide a `LocalSocket` newtype wrapper and `FileDescriptor` type (newtype wrapper too).

`LocalSocket` is a uniform newtype for `HANDLE` on `Windows` and `Socket` on `Posix`.

FileDescriptor is a newtype wrapper for file descriptor numbers.  For
sockets or unix sockets we use file descriptor numbers, for windows
named pipes (`HANDLE`) we use the memory address as the file descriptor number. 
`FileDescriptor` only exposes `Eq` and `Show` instances, the constructor is private.
