### PR TITLE
socketFileDescriptor: use unsafeFdSocket

### DIFF
--- a/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
@@ -418,11 +418,15 @@ localAddressFromPath = LocalAddress
 -- | Socket file descriptor.
 --
 newtype FileDescriptor = FileDescriptor { getFileDescriptor :: Int }
-  deriving (Eq, Generic)
+  deriving Generic
   deriving Show via Quiet FileDescriptor
 
+-- | We use 'unsafeFdSocket' but 'FileDescriptor' constructor is not exposed.
+-- This forbids any usage of 'FileDescriptor' (at least in a straightforward
+-- way) using any low level functions which operate on file descriptors.
+--
 socketFileDescriptor :: Socket -> IO FileDescriptor
-socketFileDescriptor = fmap (FileDescriptor . fromIntegral) . Socket.socketToFd
+socketFileDescriptor = fmap (FileDescriptor . fromIntegral) . Socket.unsafeFdSocket
 
 localSocketFileDescriptor :: LocalSocket -> IO FileDescriptor
 #if defined(mingw32_HOST_OS)


### PR DESCRIPTION
Even if socket is garbage collected / closed and the file descriptor is reused by the system, `FileDescriptor` type does not make it easy to be used with any low level functions in `base` which take file descriptor as an argument, so one should not be able to act on a wrong file descriptor.  See [unsafeFdSocket](https://hackage.haskell.org/package/network-3.1.2.1/docs/Network-Socket.html#v:unsafeFdSocket).