### PR TITLE
db-converter: drop path and path-io dependencies

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "6e0810ad0dc6f340f0826c1e6dddc5017fbaa46d",
-        "sha256": "149haghrpdjq8r4pi9cidvnpn7a6kvvrih6a8h9n1v5crm8kpqzw",
+        "rev": "a9584f36e26f58f7fe116cbebac11a37a72e577c",
+        "sha256": "0yydsj22ap4ssz0sz4sdc66ljnf5kpqh1dx3mj4b9b88hzlalnpp",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/6e0810ad0dc6f340f0826c1e6dddc5017fbaa46d.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/a9584f36e26f58f7fe116cbebac11a37a72e577c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
+++ b/ouroboros-consensus-byron/ouroboros-consensus-byron.cabal
@@ -89,11 +89,10 @@ executable db-converter
                      , cardano-ledger
                      , cardano-slotting
                      , directory
+                     , filepath
                      , mtl
                      , optparse-applicative
                      , optparse-generic
-                     , path < 0.7
-                     , path-io
                      , resourcet
                      , streaming
                      , text


### PR DESCRIPTION
Since we use `canonicalizePath`, we know we are dealing with absolute paths so
there is not much confusion anymore. I don't think this is worth the two extra
dependencies that are not used anywhere else.