### PR TITLE
Support extracting relay info from the ledger state

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsPeerSelection.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsPeerSelection.hs
@@ -2,17 +2,19 @@ module Ouroboros.Consensus.Ledger.SupportsPeerSelection (
     LedgerSupportsPeerSelection (..)
   , PoolStake
   , StakePoolRelay (..)
-  , stakePoolRelayDomainAddress
+  , stakePoolRelayAddress
     -- * Re-exports for convenience
+  , RelayAddress (..)
   , DomainAddress (..)
-  , Domain
+  , IP (..)
   , PortNumber
   ) where
 
 import           Data.List.NonEmpty (NonEmpty)
 
-import           Ouroboros.Network.PeerSelection.RootPeersDNS (Domain,
-                     DomainAddress (..), PortNumber)
+import           Ouroboros.Network.PeerSelection.RootPeersDNS
+                     (DomainAddress (..), IP (..), PortNumber,
+                     RelayAddress (..))
 
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
 
@@ -22,15 +24,15 @@ type PoolStake = Rational
 -- | A relay registered for a stake pool
 data StakePoolRelay =
     -- | One of the current relays
-    CurrentRelay DomainAddress
+    CurrentRelay RelayAddress
 
     -- | One of the future relays
-  | FutureRelay  DomainAddress
+  | FutureRelay  RelayAddress
   deriving (Show, Eq)
 
-stakePoolRelayDomainAddress :: StakePoolRelay -> DomainAddress
-stakePoolRelayDomainAddress (CurrentRelay da) = da
-stakePoolRelayDomainAddress (FutureRelay  da) = da
+stakePoolRelayAddress :: StakePoolRelay -> RelayAddress
+stakePoolRelayAddress (CurrentRelay ra) = ra
+stakePoolRelayAddress (FutureRelay  ra) = ra
 
 class LedgerSupportsPeerSelection blk where
   -- | Return peers registered in the ledger ordered by descending 'PoolStake'.

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -684,12 +684,12 @@ getPeersFromCurrentLedger ::
      (IOLike m, LedgerSupportsPeerSelection blk)
   => NodeKernel m remotePeer localPeer blk
   -> (LedgerState blk -> Bool)
-  -> STM m (Maybe [(PoolStake, NonEmpty DomainAddress)])
+  -> STM m (Maybe [(PoolStake, NonEmpty RelayAddress)])
 getPeersFromCurrentLedger kernel p = do
     immutableLedger <-
       ledgerState <$> ChainDB.getImmutableLedger (getChainDB kernel)
     return $ do
       guard (p immutableLedger)
       return
-        $ map (second (fmap stakePoolRelayDomainAddress))
+        $ map (second (fmap stakePoolRelayAddress))
         $ getPeers immutableLedger

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -13,6 +13,8 @@ module Ouroboros.Network.PeerSelection.RootPeersDNS (
     -- * DNS based provider for local root peers
     localRootPeersProvider,
     DomainAddress (..),
+    RelayAddress (..),
+    IP.IP (..),
     TraceLocalRootPeers(..),
 
     -- * DNS based provider for public root peers
@@ -23,7 +25,6 @@ module Ouroboros.Network.PeerSelection.RootPeersDNS (
     DNS.ResolvConf,
     DNS.Domain,
     DNS.TTL,
-    IPv4,
 
     -- * Socket type re-exports
     Socket.PortNumber,
@@ -57,6 +58,12 @@ import           Network.Mux.Timeout
 
 import           Ouroboros.Network.PeerSelection.Types
 
+-- | A relay can have either an IP address and a port number or
+-- a domain with a port number.
+-- TODO: move to a Ledger Peer file.
+data RelayAddress = RelayAddressDomain DomainAddress
+                  | RelayAddressAddr IP.IP Socket.PortNumber
+                  deriving (Show, Eq, Ord)
 
 -- | A product of a 'DNS.Domain' and 'Socket.PortNumber'.  After resolving the
 -- domain we will use the 'Socket.PortNumber' to form 'Socket.SockAddr'.


### PR DESCRIPTION
A relay can either be a domain name or an IP address therefor
DomainAddress isn't suitable.