### PR TITLE
Support for getting peers from ledger (not used)

### DIFF
--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs
@@ -44,7 +44,7 @@ instance LedgerSupportsPeerSelection (ShelleyBlock era) where
         -> [(SL.KeyHash 'SL.StakePool (EraCrypto era), PoolStake)]
       orderByStake =
             sortOn (Down . snd)
-          . map (second SL.individualPoolStake)
+          . map (second (PoolStake . SL.individualPoolStake))
           . Map.toList
           . SL.unPoolDistr
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsPeerSelection.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsPeerSelection.hs
@@ -1,6 +1,6 @@
 module Ouroboros.Consensus.Ledger.SupportsPeerSelection (
     LedgerSupportsPeerSelection (..)
-  , PoolStake
+  , PoolStake (..)
   , StakePoolRelay (..)
   , stakePoolRelayAddress
     -- * Re-exports for convenience
@@ -12,14 +12,11 @@ module Ouroboros.Consensus.Ledger.SupportsPeerSelection (
 
 import           Data.List.NonEmpty (NonEmpty)
 
-import           Ouroboros.Network.PeerSelection.RootPeersDNS
-                     (DomainAddress (..), IP (..), PortNumber,
+import           Ouroboros.Network.PeerSelection.LedgerPeers
+                     (DomainAddress (..), IP (..), PoolStake (..), PortNumber,
                      RelayAddress (..))
 
 import           Ouroboros.Consensus.Ledger.Abstract (LedgerState)
-
--- | The relative stake of the stakepool. A value in the [0, 1] range.
-type PoolStake = Rational
 
 -- | A relay registered for a stake pool
 data StakePoolRelay =

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -299,6 +299,7 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
                                     (miniProtocolParameters nodeKernelArgs)
                                     ntnApps
                                     ntcApps
+                                    nodeKernel
 
       llrnRunDataDiffusion registry diffusionApplications
   where
@@ -343,11 +344,12 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
       -> (   BlockNodeToClientVersion blk
           -> NTC.Apps m (ConnectionId addrNTC) ByteString ByteString ByteString ()
          )
+      -> NodeKernel m (ConnectionId addrNTN) (ConnectionId addrNTC) blk
       -> DiffusionApplications
            addrNTN addrNTC
            versionDataNTN versionDataNTC
            m
-    mkDiffusionApplications miniProtocolParams ntnApps ntcApps =
+    mkDiffusionApplications miniProtocolParams ntnApps ntcApps kernel =
       DiffusionApplications {
           daResponderApplication = combineVersions [
               simpleSingletonVersions
@@ -371,6 +373,7 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
             | (version, blockVersion) <- Map.toList llrnNodeToClientVersions
             ]
         , daErrorPolicies = consensusErrorPolicy
+        , daLedgerPeersCtx = LedgerPeersConsensusInterface (getPeersFromCurrentLedgerAfterSlot kernel)
         }
 
 -- | Did the ChainDB already have existing clean-shutdown marker on disk?

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -64,6 +64,7 @@ library
                        Ouroboros.Network.Point
                        Ouroboros.Network.PeerSelection.Types
                        Ouroboros.Network.PeerSelection.KnownPeers
+                       Ouroboros.Network.PeerSelection.LedgerPeers
                        Ouroboros.Network.PeerSelection.RootPeersDNS
                        Ouroboros.Network.PeerSelection.Governor
                        Ouroboros.Network.Protocol.ChainSync.Client
@@ -250,6 +251,7 @@ test-suite test-network
                        Test.AnchoredFragment
                        Test.Chain
                        Test.ChainFragment
+                       Test.LedgerPeers
                        Test.Ouroboros.Network.Utils
                        Test.Ouroboros.Network.BlockFetch
                        Test.Ouroboros.Network.KeepAlive

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -15,6 +15,7 @@ module Ouroboros.Network.Diffusion
   , IPSubscriptionTarget (..)
   , DnsSubscriptionTarget (..)
   , ConnectionId (..)
+  , LedgerPeersConsensusInterface (..)
   )
   where
 
@@ -49,6 +50,8 @@ import           Ouroboros.Network.NodeToNode ( NodeToNodeVersion (..)
                                               , RemoteAddress
                                               )
 import qualified Ouroboros.Network.NodeToNode   as NodeToNode
+import           Ouroboros.Network.PeerSelection.LedgerPeers ( LedgerPeersConsensusInterface (..)
+                                                             , TraceLedgerPeers)
 import           Ouroboros.Network.Socket ( ConnectionId (..)
                                           , NetworkMutableState
                                           , newNetworkMutableState
@@ -79,6 +82,7 @@ data DiffusionTracers = DiffusionTracers {
     , dtLocalErrorPolicyTracer :: Tracer IO (WithAddr LocalAddress ErrorPolicyTrace)
     , dtAcceptPolicyTracer     :: Tracer IO AcceptConnectionsPolicyTrace
       -- ^ Trace rate limiting of accepted connections
+    , dtLedgerPeersTracer      :: Tracer IO TraceLedgerPeers
     }
 
 
@@ -129,6 +133,9 @@ data DiffusionApplications ntnAddr ntcAddr ntnVersionData ntcVersionData m = Dif
 
     , daErrorPolicies :: ErrorPolicies
       -- ^ error policies
+
+    ,  daLedgerPeersCtx :: LedgerPeersConsensusInterface m
+      -- ^ Interface used to get peers from the current ledger.
     }
 
 data DiffusionFailure = UnsupportedLocalSocketType

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+module Ouroboros.Network.PeerSelection.LedgerPeers (
+    DomainAddress (..),
+    IP.IP (..),
+    LedgerPeersConsensusInterface (..),
+    RelayAddress (..),
+    PoolStake (..),
+    AccPoolStake (..),
+    TraceLedgerPeers (..),
+    pickPeers,
+    accPoolStake,
+
+    Socket.PortNumber
+    ) where
+
+
+import           Control.Monad.Class.MonadSTM
+import           Control.Tracer (Tracer, traceWith)
+import qualified Data.IP as IP
+import           Data.List (foldl')
+import           Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map.Strict as Map
+import           Data.Map.Strict (Map)
+import           Data.Ratio
+import           Data.Word
+import qualified Network.Socket as Socket
+import           System.Random
+
+import           Cardano.Slotting.Slot (SlotNo)
+import           Ouroboros.Network.PeerSelection.RootPeersDNS (DomainAddress (..))
+
+import           Text.Printf
+
+newtype LedgerPeersConsensusInterface m = LedgerPeersConsensusInterface {
+      lpGetPeers :: SlotNo -> STM m (Maybe [(PoolStake, NonEmpty RelayAddress)])
+    }
+
+-- | Trace LedgerPeers events.
+data TraceLedgerPeers =
+      PickedPeer !RelayAddress !AccPoolStake ! PoolStake
+      -- ^ Trace for a peer picked with accumulated and relative stake of its pool.
+    | PickedPeers !Word16 ![RelayAddress]
+      -- ^ Trace for the number of peers we wanted to pick and the list of peers picked.
+    | FetchingNewLedgerState !Int
+      -- ^ Trace for fetching a new list of peers from the ledger. Int is the number of peers
+      -- returned.
+
+
+instance Show TraceLedgerPeers where
+    show (PickedPeer addr ackStake stake) =
+        printf "PickedPeer %s ack stake %s ( %.04f) relative stake %s ( %.04f )"
+            (show addr)
+            (show $ unAccPoolStake ackStake)
+            (fromRational (unAccPoolStake ackStake) :: Double)
+            (show $ unPoolStake stake)
+            (fromRational (unPoolStake stake) :: Double)
+    show (PickedPeers n peers) =
+        printf "PickedPeers %d %s" n (show peers)
+    show (FetchingNewLedgerState cnt) =
+        printf "Fetching new ledgerstate, %d registered pools"
+            cnt
+
+
+data RelayAddress = RelayAddressDomain DomainAddress
+                  | RelayAddressAddr IP.IP Socket.PortNumber
+                  deriving (Show, Eq, Ord)
+
+-- | The relative stake of a stakepool in relation to the total amount staked.
+-- A value in the [0, 1] range.
+--
+newtype PoolStake = PoolStake { unPoolStake :: Rational }
+  deriving (Eq, Fractional, Num, Ord, Show)
+
+-- | The accumulated relative stake of a stake pool, like PoolStake but it also includes the
+-- relative stake of all preceding pools. A value in the range [0, 1].
+--
+newtype AccPoolStake = AccPoolStake { unAccPoolStake :: Rational }
+    deriving (Eq, Num, Ord)
+
+-- | Convert a list of pools with stake to a Map keyed on the accumulated stake.
+-- Consensus provides a list of pairs of relative stake and corresponding relays for all usable
+-- registered pools.
+-- By creating a Map keyed on the `AccPoolStake` that is the sum of the pool's relative stake and
+-- the stake of all preceding pools we can support weighted random selection in
+-- O(log n) time by taking advantage of Map.lookupGE (returns the smallest key greater or equal
+-- to the provided value).
+--
+accPoolStake :: [(PoolStake, NonEmpty RelayAddress)]
+             -> Map AccPoolStake (PoolStake, NonEmpty RelayAddress)
+accPoolStake pl =
+    let pl' = reRelativeStake pl
+        ackList = foldl' fn [] pl' in
+    Map.fromList ackList
+  where
+    fn :: [(AccPoolStake, (PoolStake, NonEmpty RelayAddress))]
+       -> (PoolStake, NonEmpty RelayAddress)
+       -> [(AccPoolStake, (PoolStake, NonEmpty RelayAddress))]
+    fn [] (s, rs) =
+        [(AccPoolStake (unPoolStake s), (s, rs))]
+    fn ps (s, !rs) =
+        let accst = AccPoolStake (unPoolStake s)
+            as = fst $ head ps
+            !acc = as + accst in
+        (acc, (s, rs)) : ps
+
+-- | Not all stake pools have valid \/ usable relay information. This means that we need to
+-- recalculate the relative stake for each pool.
+--
+reRelativeStake :: [(PoolStake, NonEmpty RelayAddress)]
+                -> [(PoolStake, NonEmpty RelayAddress)]
+reRelativeStake pl =
+    let total = sum $ map fst pl in
+    map (\(s, rls) -> (s / total, rls)) pl
+
+-- | Try to pick n random peers.
+pickPeers :: forall m. Monad m
+          => StdGen
+          -> Tracer m TraceLedgerPeers
+          -> Map AccPoolStake (PoolStake, NonEmpty RelayAddress)
+          -> Word16
+          -> m (StdGen, [RelayAddress])
+pickPeers inRng _ pools _ | Map.null pools = return (inRng, [])
+pickPeers inRng tracer pools cnt = go inRng cnt []
+  where
+    go :: StdGen -> Word16 -> [RelayAddress] -> m (StdGen, [RelayAddress])
+    go rng 0 picked = return (rng, picked)
+    go rng n picked =
+        let (r :: Word64, rng') = random rng
+            d = maxBound :: Word64
+            x = fromIntegral r % fromIntegral d in
+        case Map.lookupGE (AccPoolStake x) pools of
+             -- XXX We failed pick a peer. Shouldn't this be an error?
+             Nothing -> go rng' (n - 1) picked 
+             Just (ackStake, (stake, relays)) -> do
+                 let (ix, rng'') = randomR (0, NonEmpty.length relays - 1) rng'
+                     relay = relays NonEmpty.!! ix
+                 traceWith tracer $ PickedPeer relay ackStake stake
+                 go rng'' (n - 1) (relay : picked)

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -7,6 +7,7 @@ import qualified Test.ChainGenerators (tests)
 import qualified Test.Chain (tests)
 import qualified Test.ChainFragment (tests)
 import qualified Test.ChainProducerState (tests)
+import qualified Test.LedgerPeers (tests)
 import qualified Test.Pipe (tests)
 import qualified Test.PeerState (tests)
 import qualified Test.Version (tests)
@@ -60,6 +61,7 @@ tests =
   , Test.Ouroboros.Network.TxSubmission.tests
   , Ouroboros.Network.NodeToNode.Version.Test.tests
   , Ouroboros.Network.NodeToClient.Version.Test.tests
+  , Test.LedgerPeers.tests
 
     -- pseudo system-level
   , Test.Ouroboros.Network.MockNode.tests

--- a/ouroboros-network/test/Test/LedgerPeers.hs
+++ b/ouroboros-network/test/Test/LedgerPeers.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes        #-}
+
+module Test.LedgerPeers where
+
+import           Control.Exception (SomeException (..))
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadFork
+import           Control.Monad.Class.MonadSay
+import           Control.Monad.Class.MonadTime
+import           Control.Monad.Class.MonadThrow
+import           Control.Monad.IOSim
+import           Control.Tracer (showTracing, Tracer (..), traceWith)
+import           Data.List (foldl', intercalate)
+import           Data.List.NonEmpty (NonEmpty (..))
+import           Data.Word
+import           Data.Ratio
+import           System.Random
+
+import           Ouroboros.Network.PeerSelection.LedgerPeers
+
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+import           Test.QuickCheck
+import           Text.Printf
+
+tests :: TestTree
+tests = testGroup "LedgerPeers"
+  [ testProperty "Pick 100%" prop_pick100
+  , testProperty "Pick" prop_pick
+  ]
+
+newtype ArbitraryRelayAddress = ArbitraryRelayAddress RelayAddress
+
+instance Arbitrary ArbitraryRelayAddress where
+    arbitrary = do
+      ArbitraryRelayAddress <$> elements [ RelayAddressAddr (read "1.1.1.1") 1234
+               , RelayAddressDomain (DomainAddress "relay.iohk.example" 1234)
+               ]
+
+data StakePool = StakePool {
+      spStake :: !Word64
+    , spRelay :: NonEmpty RelayAddress
+    } deriving Show
+
+
+
+instance Arbitrary StakePool where
+    arbitrary = do
+        stake <- choose (0, 1000000)
+        (ArbitraryRelayAddress firstRelay) <- arbitrary
+        moreRelays <- map unAddr <$> arbitrary
+        return $ StakePool stake (firstRelay :| moreRelays)
+      where
+        unAddr (ArbitraryRelayAddress a) = a
+
+newtype LedgerPools = LedgerPools [(PoolStake, NonEmpty RelayAddress)] deriving Show
+
+instance Arbitrary LedgerPools where
+    arbitrary = LedgerPools . calculateRelativeStake <$> arbitrary
+
+      where
+        calculateRelativeStake :: [StakePool] -> [(PoolStake, NonEmpty RelayAddress)]
+        calculateRelativeStake sps =
+            let totalStake = foldl' (\s p -> s + spStake p) 0 sps in
+            map (\p -> ( PoolStake (fromIntegral (spStake p) % fromIntegral totalStake)
+                       , spRelay p)) sps
+
+-- | A pool with 100% stake should allways be picked.
+prop_pick100 :: Word16
+             -> Property
+prop_pick100 seed =
+    let rng = mkStdGen $ fromIntegral seed
+        sps = [ (1, RelayAddressAddr (read "1.1.1.1") 1  :| [])
+              , (0, RelayAddressAddr (read "0.0.0.0") 0  :| [])
+              ]
+        peerMap = accPoolStake sps
+        tr = (runSimTrace $ pickPeers rng verboseTracer peerMap 1) in
+    ioProperty $ do
+        tr' <- evaluateTrace tr
+        case tr' of
+             SimException e trace -> do
+                 return $ counterexample (intercalate "\n" $ show e : trace) False
+             SimDeadLock trace -> do
+                 return $ counterexample (intercalate "\n" $ "Deadlock" : trace) False
+             SimReturn (_, peers) _trace -> do
+                 -- printf "Log: %s\n" (intercalate "\n" _trace)
+                 return $ peers === [ RelayAddressAddr (read "1.1.1.1") 1 ]
+
+-- | Veify that given at least one peer we manage to pick `count` peers.
+prop_pick :: LedgerPools
+          -> Word16
+          -> Word16
+          -> Property
+prop_pick (LedgerPools lps) count seed =
+    let rng = mkStdGen $ fromIntegral seed
+        peerMap = accPoolStake lps
+        tr = runSimTrace (pickPeers rng verboseTracer peerMap count) in
+    ioProperty $ do
+        tr' <- evaluateTrace tr
+        case tr' of
+             SimException e trace -> do
+                 return $ counterexample (intercalate "\n" $ show e : trace) False
+             SimDeadLock trace -> do
+                 return $ counterexample (intercalate "\n" $ "Deadlock" : trace) False
+             SimReturn (_, peers) trace -> do
+                 if null lps
+                    then return $ property $ null peers
+                    else return $ counterexample (intercalate "\n" $ "Lenght missmatch" : trace)
+                                      (length peers == fromIntegral count)
+
+
+-- TODO: Belongs in iosim.
+data SimResult a = SimReturn a [String]
+                 | SimException SomeException [String]
+                 | SimDeadLock [String]
+
+-- Traverses a list of trace events and returns the result along with all log messages.
+-- Incase of a pure exception, ie an assert, all tracers evaluated so far are returned.
+evaluateTrace :: Trace a -> IO (SimResult a)
+evaluateTrace = go []
+  where
+    go as tr = do
+      r <- try (evaluate tr)
+      case r of
+        Right (Trace _ _ _ (EventSay s) tr') -> go (s : as) tr'
+        Right (Trace _ _ _ _ tr' )           -> go as tr'
+        Right (TraceMainReturn _ a _)        -> pure $ SimReturn a (reverse as)
+        Right (TraceMainException _ e _)     -> pure $ SimException e (reverse as)
+        Right (TraceDeadlock _ _)            -> pure $ SimDeadLock (reverse as)
+        Left  (SomeException e)              -> pure $ SimException (SomeException e) (reverse as)
+
+data WithThreadAndTime a = WithThreadAndTime {
+      wtatOccuredAt    :: !Time
+    , wtatWithinThread :: !String
+    , wtatEvent        :: !a
+    }
+
+instance (Show a) => Show (WithThreadAndTime a) where
+    show WithThreadAndTime {wtatOccuredAt, wtatWithinThread, wtatEvent} =
+        printf "%s: %s: %s" (show wtatOccuredAt) (show wtatWithinThread) (show wtatEvent)
+
+verboseTracer :: forall a m.
+                       ( MonadAsync m
+                       , MonadSay m
+                       , MonadMonotonicTime m
+                       , Show a
+                       )
+               => Tracer m a
+verboseTracer = threadAndTimeTracer $ showTracing $ Tracer say
+
+threadAndTimeTracer :: forall a m.
+                       ( MonadAsync m
+                       , MonadMonotonicTime m
+                       )
+                    => Tracer m (WithThreadAndTime a) -> Tracer m a
+threadAndTimeTracer tr = Tracer $ \s -> do
+    !now <- getMonotonicTime
+    !tid <- myThreadId
+    traceWith tr $ WithThreadAndTime now (show tid) s


### PR DESCRIPTION
Support for randomly picking peers from the current ledger state.
The peers are randomly choosen from the relays registered on chain, and
the chance to pick a given stake pools relay is weighted by the amount
of stake they control.