### PR TITLE
Allow for limited wallclock rollback

### DIFF
--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -958,17 +958,8 @@ runThreadNetwork systemTime ThreadNetworkArgs
         , hfbtSystemTime     = OracularClock.finiteSystemTime clock
         , hfbtTracer         =
             contramap
-            -- We don't really have a SystemStart in the tests
-            (let systemStart = SystemStart dawnOfTime
-             in \case
-               UnknownCurrentSlot t ex ->
-                 TraceCurrentSlotUnknown
-                   (fromRelativeTime systemStart t)
-                   ex
-               SystemClockMovedBackABit oldT newT ->
-                 TraceSystemClockMovedBack
-                   (fromRelativeTime systemStart oldT)
-                   (fromRelativeTime systemStart newT))
+              -- We don't really have a SystemStart in the tests
+              (fmap (fromRelativeTime (SystemStart dawnOfTime)))
               (blockchainTimeTracer tracers)
         , hfbtMaxClockRewind = secondsToNominalDiffTime 0
         }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Default.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Default.hs
@@ -4,7 +4,7 @@ module Ouroboros.Consensus.BlockchainTime.WallClock.Default (
 
 import           Control.Monad
 import           Control.Tracer
-import           Data.Time (diffUTCTime)
+import           Data.Time (UTCTime, diffUTCTime)
 
 import           Control.Monad.Class.MonadTime (MonadTime (..))
 
@@ -15,7 +15,7 @@ import           Ouroboros.Consensus.Util.Time
 
 defaultSystemTime :: (MonadTime m, MonadDelay m)
                   => SystemStart
-                  -> Tracer m TraceBlockchainTimeEvent
+                  -> Tracer m (TraceBlockchainTimeEvent UTCTime)
                   -> SystemTime m
 defaultSystemTime start tracer = SystemTime {
       systemTimeCurrent = toRelativeTime start <$> getCurrentTime
@@ -25,7 +25,7 @@ defaultSystemTime start tracer = SystemTime {
 -- | Wait until system start if necessary
 waitForSystemStart :: (MonadTime m, MonadDelay m)
                    => SystemStart
-                   -> Tracer m TraceBlockchainTimeEvent
+                   -> Tracer m (TraceBlockchainTimeEvent UTCTime)
                    -> m ()
 waitForSystemStart start tracer = do
     now <- getCurrentTime

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
 module Ouroboros.Consensus.BlockchainTime.WallClock.HardFork (
-    BackoffDelay (..),
-    HardForkBlockchainTimeArgs (..),
-    hardForkBlockchainTime,
+    BackoffDelay (..)
+  , HardForkBlockchainTimeArgs (..)
+  , hardForkBlockchainTime
+  , HardForkBlockchainTimeEvent (..)
   ) where
 
 import           Control.Monad
@@ -47,6 +47,18 @@ import           Ouroboros.Consensus.Util.Time
 -- incur computational overhead.)
 newtype BackoffDelay = BackoffDelay NominalDiffTime
 
+-- | Events traced by 'hardForkBlockchainTime'
+data HardForkBlockchainTimeEvent =
+    -- | The current slot is unknown
+    UnknownCurrentSlot RelativeTime HF.PastHorizonException
+
+    -- | The system clock moved back a bit, but less than 'hfbtMaxClockRewind',
+    -- e.g., because of an NTP sync. This is acceptable.
+    --
+    -- We include the old and the new time.
+  | SystemClockMovedBackABit RelativeTime RelativeTime
+  deriving (Show)
+
 data HardForkBlockchainTimeArgs m blk = HardForkBlockchainTimeArgs
   { hfbtBackoffDelay   :: m BackoffDelay
     -- ^ See 'BackoffDelay'
@@ -54,8 +66,18 @@ data HardForkBlockchainTimeArgs m blk = HardForkBlockchainTimeArgs
   , hfbtLedgerConfig   :: LedgerConfig blk
   , hfbtRegistry       :: ResourceRegistry m
   , hfbtSystemTime     :: SystemTime m
-  , hfbtTracer         :: Tracer m (RelativeTime, HF.PastHorizonException)
-    -- ^ Tracer used when current slot is unknown
+  , hfbtTracer         :: Tracer m HardForkBlockchainTimeEvent
+  , hfbtMaxClockRewind :: NominalDiffTime
+    -- ^ Maximum time the clock can be rewound without throwing a fatal
+    -- 'SystemClockMovedBack' exception.
+    --
+    -- When the slot length is short, e.g., Praos' 1s compared to PBFT's 20s,
+    -- the chances of an NTP sync causing the clock to go back to the previous
+    -- slot increase.
+    --
+    -- We allow the system clock to rewind up to 'hfbtMaxClockRewind', tracing a
+    -- 'SystemClockMovedBackABit' message in such cases. Note that the current
+    -- slot *never decreases*, we just wait a bit longer in the same slot.
   }
 
 -- | 'BlockchainTime' instance with support for the hard fork history
@@ -70,10 +92,10 @@ hardForkBlockchainTime args = do
     run <- HF.runWithCachedSummary (summarize <$> getLedgerState)
     systemTimeWait
 
-    (firstSlot, firstDelay) <- getCurrentSlot' tracer time run backoffDelay
+    (firstSlot, now, firstDelay) <- getCurrentSlot' tracer time run backoffDelay
     slotVar <- newTVarIO firstSlot
     void $ forkLinkedThread registry "hardForkBlockchainTime" $
-             loop run slotVar firstSlot firstDelay
+             loop run slotVar firstSlot now firstDelay
 
     return $ BlockchainTime {
         getCurrentSlot = readTVar slotVar
@@ -86,6 +108,7 @@ hardForkBlockchainTime args = do
       , hfbtRegistry       = registry
       , hfbtSystemTime     = time@SystemTime{..}
       , hfbtTracer         = tracer
+      , hfbtMaxClockRewind = maxClockRewind
       } = args
 
     summarize :: LedgerState blk -> HF.Summary (HardForkIndices blk)
@@ -94,57 +117,69 @@ hardForkBlockchainTime args = do
     loop :: HF.RunWithCachedSummary xs m
          -> StrictTVar m CurrentSlot
          -> CurrentSlot     -- Previous slot
+         -> RelativeTime    -- Current time
          -> NominalDiffTime -- Time to wait until next slot
          -> m Void
     loop run slotVar = go
       where
-        go :: CurrentSlot -> NominalDiffTime -> m Void
-        go prevSlot delay = do
+        go :: CurrentSlot -> RelativeTime -> NominalDiffTime -> m Void
+        go prevSlot prevTime delay = do
            threadDelay (nominalDelay delay)
-           (newSlot, newDelay) <- getCurrentSlot' tracer time run backoffDelay
-           checkValidClockChange (prevSlot, newSlot)
-           atomically $ writeTVar slotVar newSlot
-           go newSlot newDelay
+           (newSlot, newTime, newDelay) <- getCurrentSlot' tracer time run backoffDelay
+           newSlot' <- checkValidClockChange (prevSlot, prevTime) (newSlot, newTime)
+           atomically $ writeTVar slotVar newSlot'
+           go newSlot' newTime newDelay
 
-    checkValidClockChange :: (CurrentSlot, CurrentSlot) -> m ()
-    checkValidClockChange = \case
-        (CurrentSlotUnknown, CurrentSlot _) ->
-          -- Unknown-to-known typically happens when syncing catches up far
-          -- enough that we can now know what the current slot is.
-          return ()
-        (CurrentSlot _, CurrentSlotUnknown) ->
-          -- Known-to-unknown can happen when the ledger is no longer being
-          -- updated and time marches on past the end of the safe zone.
-          return ()
-        (CurrentSlotUnknown, CurrentSlotUnknown) ->
-          return ()
-        (CurrentSlot m, CurrentSlot n)
-          -- Normally we expect @n == m + 1@, but if the system is under heavy
-          -- load, we might miss a slot. We could have @n == m@ only if the
-          -- user's system clock was adjusted (say by an NTP process).
-          | m <  n    -> return ()
-          | m == n    -> return ()
-          | otherwise -> throwIO $ SystemClockMovedBack m n
+    checkValidClockChange ::
+         (CurrentSlot, RelativeTime)
+      -> (CurrentSlot, RelativeTime)
+      -> m CurrentSlot
+    checkValidClockChange (prevSlot, prevTime) (newSlot, newTime) =
+        case (prevSlot, newSlot) of
+          (CurrentSlotUnknown, CurrentSlot _)
+            -- Unknown-to-known typically happens when syncing catches up far
+            -- enough that we can now know what the current slot is.
+            -> return newSlot
+          (CurrentSlot _, CurrentSlotUnknown)
+            -- Known-to-unknown can happen when the ledger is no longer being
+            -- updated and time marches on past the end of the safe zone.
+            -> return newSlot
+          (CurrentSlotUnknown, CurrentSlotUnknown)
+            -> return newSlot
+          (CurrentSlot m, CurrentSlot n)
+            -- Normally we expect @n == m + 1@, but if the system is under heavy
+            -- load, we might miss a slot.
+            | m <  n
+            -> return newSlot
+            -- We could have @n == m@ or @n < m@ only if the user's system clock
+            -- was adjusted (say by an NTP process). We only allow a limited
+            -- rewinding of the clock, but never rewind the slot number
+            | m >= n
+            , prevTime `diffRelTime` newTime <= maxClockRewind
+            -> do traceWith tracer $ SystemClockMovedBackABit prevTime newTime
+                  return prevSlot
+            | otherwise
+            -> throwIO $ SystemClockMovedBack m n
 
 {-------------------------------------------------------------------------------
   Auxiliary
 -------------------------------------------------------------------------------}
 
--- | Get current slot, and delay until next slot
+-- | Get current slot, current time, and the delay until the next slot.
 getCurrentSlot' :: forall m xs. IOLike m
-                => Tracer m (RelativeTime, HF.PastHorizonException)
+                => Tracer m HardForkBlockchainTimeEvent
                 -> SystemTime m
                 -> HF.RunWithCachedSummary xs m
                 -> m BackoffDelay
-                -> m (CurrentSlot, NominalDiffTime)
+                -> m (CurrentSlot, RelativeTime, NominalDiffTime)
 getCurrentSlot' tracer SystemTime{..} run getBackoffDelay = do
     now   <- systemTimeCurrent
     mSlot <- atomically $ HF.cachedRunQuery run $ HF.wallclockToSlot now
     case mSlot of
       Left ex -> do
         -- give up for now and backoff; see 'BackoffDelay'
-        traceWith tracer (now, ex)
+        traceWith tracer $ UnknownCurrentSlot now ex
         BackoffDelay delay <- getBackoffDelay
-        return (CurrentSlotUnknown, delay)
+        return (CurrentSlotUnknown, now, delay)
       Right (slot, _inSlot, timeLeft) -> do
-        return (CurrentSlot slot, timeLeft)
+        return (CurrentSlot slot, now, timeLeft)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Simple.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Simple.hs
@@ -95,10 +95,11 @@ getWallClockSlot SystemTime{..} slotLen =
 -- due to the clock change, should not be considered immutable anymore.
 waitUntilNextSlot :: IOLike m
                   => SystemTime m
+                  -> NominalDiffTime -- ^ Max clock rewind
                   -> SlotLength
                   -> SlotNo    -- ^ Current slot number
                   -> m SlotNo
-waitUntilNextSlot time@SystemTime{..} slotLen oldCurrent = do
+waitUntilNextSlot time@SystemTime{..} maxClockRewind slotLen oldCurrent = do
     now <- systemTimeCurrent
 
     let delay = delayUntilNextSlot slotLen now
@@ -123,6 +124,6 @@ waitUntilNextSlot time@SystemTime{..} slotLen oldCurrent = do
     if | newCurrent > oldCurrent ->
            return newCurrent
        | newCurrent == oldCurrent ->
-           waitUntilNextSlot time slotLen oldCurrent
+           waitUntilNextSlot time maxClockRewind slotLen oldCurrent
        | otherwise ->
            throwIO $ SystemClockMovedBack oldCurrent newCurrent

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Util.hs
@@ -41,6 +41,19 @@ data TraceBlockchainTimeEvent =
     -- current time and the upper bound should rapidly decrease with consecutive
     -- 'TraceCurrentSlotUnknown' messages during syncing.
   | TraceCurrentSlotUnknown UTCTime PastHorizonException
+
+    -- | The system clock moved back an acceptable time span, e.g., because of
+    -- an NTP sync.
+    --
+    -- The system clock moved back such that the new current slot would be
+    -- smaller than the previous one. If this is within the configured limit, we
+    -- trace this warning but *do not change the current slot*. The current slot
+    -- never decreases, but the current slot may stay the same longer than
+    -- expected.
+    --
+    -- When the system clock moved back more than the configured limit, we shut
+    -- down with a fatal exception.
+  | TraceSystemClockMovedBack UTCTime UTCTime
   deriving (Show)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Util.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor   #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | Support for defining 'BlockchainTime' instances
@@ -9,7 +10,7 @@ module Ouroboros.Consensus.BlockchainTime.WallClock.Util (
   ) where
 
 import           Control.Exception (Exception)
-import           Data.Time (NominalDiffTime, UTCTime)
+import           Data.Time (NominalDiffTime)
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types
@@ -21,7 +22,10 @@ import           Ouroboros.Consensus.HardFork.History (PastHorizonException)
 -------------------------------------------------------------------------------}
 
 -- | Time related tracing
-data TraceBlockchainTimeEvent =
+--
+-- The @t@ parameter can be instantiated by the time, e.g., @UTCTime@ or
+-- @RelativeTime@.
+data TraceBlockchainTimeEvent t =
     -- | The start time of the blockchain time is in the future
     --
     -- We have to block (for 'NominalDiffTime') until that time comes.
@@ -40,7 +44,7 @@ data TraceBlockchainTimeEvent =
     -- bounds between which we /can/ do conversions. The distance between the
     -- current time and the upper bound should rapidly decrease with consecutive
     -- 'TraceCurrentSlotUnknown' messages during syncing.
-  | TraceCurrentSlotUnknown UTCTime PastHorizonException
+  | TraceCurrentSlotUnknown t PastHorizonException
 
     -- | The system clock moved back an acceptable time span, e.g., because of
     -- an NTP sync.
@@ -53,8 +57,8 @@ data TraceBlockchainTimeEvent =
     --
     -- When the system clock moved back more than the configured limit, we shut
     -- down with a fatal exception.
-  | TraceSystemClockMovedBack UTCTime UTCTime
-  deriving (Show)
+  | TraceSystemClockMovedBack t t
+  deriving (Show, Functor)
 
 {-------------------------------------------------------------------------------
   Exceptions

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE MonadComprehensions #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE Rank2Types          #-}
@@ -99,6 +100,7 @@ import           Ouroboros.Consensus.Util.Args
 import           Ouroboros.Consensus.Util.IOLike
 import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.ResourceRegistry
+import           Ouroboros.Consensus.Util.Time (secondsToNominalDiffTime)
 
 import           Ouroboros.Consensus.Storage.ChainDB (ChainDB, ChainDbArgs)
 import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
@@ -272,11 +274,17 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
           , hfbtSystemTime     = systemTime
           , hfbtTracer         =
               contramap
-                (\(t, ex) ->
-                    TraceCurrentSlotUnknown
-                      (fromRelativeTime systemStart t)
-                      ex)
+                (\case
+                   UnknownCurrentSlot t ex ->
+                     TraceCurrentSlotUnknown
+                       (fromRelativeTime systemStart t)
+                       ex
+                   SystemClockMovedBackABit oldT newT ->
+                     TraceSystemClockMovedBack
+                       (fromRelativeTime systemStart oldT)
+                       (fromRelativeTime systemStart newT))
                 (blockchainTimeTracer rnTraceConsensus)
+          , hfbtMaxClockRewind = secondsToNominalDiffTime 20
           }
 
       nodeKernelArgs <-

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -273,16 +273,7 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
           , hfbtRegistry       = registry
           , hfbtSystemTime     = systemTime
           , hfbtTracer         =
-              contramap
-                (\case
-                   UnknownCurrentSlot t ex ->
-                     TraceCurrentSlotUnknown
-                       (fromRelativeTime systemStart t)
-                       ex
-                   SystemClockMovedBackABit oldT newT ->
-                     TraceSystemClockMovedBack
-                       (fromRelativeTime systemStart oldT)
-                       (fromRelativeTime systemStart newT))
+              contramap (fmap (fromRelativeTime systemStart))
                 (blockchainTimeTracer rnTraceConsensus)
           , hfbtMaxClockRewind = secondsToNominalDiffTime 20
           }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -18,6 +18,7 @@ module Ouroboros.Consensus.Node.Tracers
 
 import           Control.Tracer (Tracer, nullTracer, showTracing)
 import           Data.Text (Text)
+import           Data.Time (UTCTime)
 
 import           Ouroboros.Network.BlockFetch (FetchDecision,
                      TraceFetchClientState, TraceLabelPeer)
@@ -59,7 +60,7 @@ data Tracers' remotePeer localPeer blk f = Tracers
   , localTxSubmissionServerTracer :: f (TraceLocalTxSubmissionServerEvent blk)
   , mempoolTracer                 :: f (TraceEventMempool blk)
   , forgeTracer                   :: f (TraceLabelCreds (TraceForgeEvent blk))
-  , blockchainTimeTracer          :: f  TraceBlockchainTimeEvent
+  , blockchainTimeTracer          :: f (TraceBlockchainTimeEvent UTCTime)
   , forgeStateInfoTracer          :: f (TraceLabelCreds (ForgeStateInfo blk))
   , keepAliveClientTracer         :: f (TraceKeepAliveClient remotePeer)
   }


### PR DESCRIPTION
Fixes #2781.

By default, we will allow the system clock to roll back three seconds to account for time changes because of NTP. When this happens, `TraceSystemClockMovedBack` will be traced. Not that the current slot won't decrease, we'll just stay in the same slot longer.

When the system clock rolls back more than three seconds, we still shut down with the fatal `SystemClockMovedBack` exception.