### PR TITLE
MetaData -> Metadata

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -131,8 +131,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 742e8525b96bf4b66fb61a00c8298d75d7931d5e
-  --sha256: 1132r58bjgdcf7yz3n77nlrkanqcmpn5b5km4nw151yar2dgifsv
+  tag: ee4e7b547a991876e6b05ba542f4e62909f4a571
+  --sha256: 0dg6ihgrn5mgqp95c4f11l6kh9k3y75lwfqf47hdp554w7wyvaw6
   subdir:
     cardano-prelude
     cardano-prelude-test
@@ -140,8 +140,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 2574600da11065937c1f07e4b234ecb451016a2e
-  --sha256: 0nq8bpzsr3fd2i59a6s6qb6slpymjh47zv57wlifjfvhh0xlgmpx
+  tag: 6a6ea9695ee898dd7d4fd7a5d2cc639d7d5764f7
+  --sha256: 1hkq5i9fjjr4picx3plq3s09isrmx6jifpqf57c7viqfdrwlhjnj
   subdir:
     binary
     binary/test
@@ -152,8 +152,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 9cd2b6cebfd19e73974a149ca25186aa8eaa036d
-  --sha256: 0sy9yqgr6izfw2a7bvpcj65035a1ijhidgsy55j2xfr02h29yjgh
+  tag: baa873c478ffa90c381e79d1ef3fdad0086b849f
+  --sha256: 14ccqy3x6616qm71cayfv240d6lsnzg3b9jm18n756bh6pmz6lkv
   subdir:
     byron/chain/executable-spec
     byron/crypto

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -88,7 +88,7 @@ import qualified Shelley.Spec.Ledger.Keys as SL (asWitness, hashWithSerialiser,
                      signedKES)
 import qualified Shelley.Spec.Ledger.LedgerState as SL (emptyDPState,
                      emptyPPUPState)
-import qualified Shelley.Spec.Ledger.MetaData as SL (MetaDataHash (..))
+import qualified Shelley.Spec.Ledger.Metadata as SL (MetadataHash (..))
 import qualified Shelley.Spec.Ledger.PParams as SL (emptyPParams,
                      emptyPParamsUpdate)
 import qualified Shelley.Spec.Ledger.Rewards as SL (emptyNonMyopic)
@@ -301,11 +301,11 @@ exampleTxBodyShelley = SL.TxBody
     (SL.Coin 3)
     (SlotNo 10)
     (SJust (SL.Update exampleProposedPPUpdates (EpochNo 0)))
-    (SJust metaDataHash)
+    (SJust metadataHash)
   where
     -- Dummy hash to decouple from the metadata in 'exampleTx'.
-    metaDataHash :: SL.MetaDataHash StandardShelley
-    metaDataHash = SL.MetaDataHash $ mkDummyHash (Proxy @(HASH StandardCrypto)) 30
+    metadataHash :: SL.MetadataHash StandardShelley
+    metadataHash = SL.MetadataHash $ mkDummyHash (Proxy @(HASH StandardCrypto)) 30
 
 exampleTxBodyMA ::
      forall era. (ShelleyBasedEra era, Val.EncodeMint (Core.Value era))
@@ -320,12 +320,12 @@ exampleTxBodyMA value = MA.TxBody
     (SL.Coin 3)
     (MA.ValidityInterval (SJust (SlotNo 2)) (SJust (SlotNo 4)))
     (SJust (SL.Update exampleProposedPPUpdates (EpochNo 0)))
-    (SJust metaDataHash)
+    (SJust metadataHash)
     value
   where
     -- Dummy hash to decouple from the metadata in 'exampleTx'.
-    metaDataHash :: SL.MetaDataHash era
-    metaDataHash = SL.MetaDataHash $ mkDummyHash (Proxy @(HASH (EraCrypto era))) 30
+    metadataHash :: SL.MetadataHash era
+    metadataHash = SL.MetadataHash $ mkDummyHash (Proxy @(HASH (EraCrypto era))) 30
 
 exampleTxBodyAllegra :: Core.TxBody StandardAllegra
 exampleTxBodyAllegra = exampleTxBodyMA exampleCoin
@@ -347,7 +347,7 @@ exampleScriptMA =
       , MA.RequireSignature (mkKeyHash 100)
       ]
 
-exampleMetadataMap :: Map Word64 SL.MetaDatum
+exampleMetadataMap :: Map Word64 SL.Metadatum
 exampleMetadataMap = Map.fromList [
       (1, SL.S "string")
     , (2, SL.B "bytes")
@@ -356,7 +356,7 @@ exampleMetadataMap = Map.fromList [
     ]
 
 exampleMetadataShelley :: Core.Metadata StandardShelley
-exampleMetadataShelley = SL.MetaData exampleMetadataMap
+exampleMetadataShelley = SL.Metadata exampleMetadataMap
 
 exampleMetadataMA :: (Crypto c, Typeable ma) => Core.Metadata (MA.ShelleyMAEra ma c)
 exampleMetadataMA =
@@ -625,7 +625,7 @@ examplePoolParams = SL.PoolParams {
     , _poolRAcnt  = SL.RewardAcnt SL.Testnet (keyToCredential exampleStakeKey)
     , _poolOwners = Set.singleton $ SL.hashKey $ SL.vKey exampleStakeKey
     , _poolRelays = StrictSeq.empty
-    , _poolMD     = SJust $ SL.PoolMetaData {
+    , _poolMD     = SJust $ SL.PoolMetadata {
           _poolMDUrl  = fromJust $ SL.textToUrl "consensus.pool"
         , _poolMDHash = "{}"
         }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -531,7 +531,7 @@ ledgerDbPast tip db
     | tip == csTip (ledgerDbAnchor db)
     = Just (csLedger (ledgerDbAnchor db))
     | NotOrigin tip' <- pointToWithOriginRealPoint tip
-    = cpState <$> binarySearch tip' (Seq.getSeq (ledgerDbCheckpoints db))
+    = cpState <$> binarySearch tip' (Seq.fromStrict (ledgerDbCheckpoints db))
     | otherwise
     = Nothing
   where


### PR DESCRIPTION
Makes the spelling consistent. Needs input-output-hk/cardano-ledger-specs#2036 merged first and the rev updated in `cabal.project`.

```
git ls-files -z | xargs -0 sed -i -e 's/MetaData/Metadata/g' -e 's/MetaDatum/Metadatum/g'
```