### PR TITLE
Inject transactions from past eras when forging a block

### DIFF
--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
@@ -184,9 +184,9 @@ model = \need (Schedule ss) ->
         = go n ss' (offset, nextSlot)
         | nextSlot >  prevSlot
         = (nextSlot :) <$> go (n - 1) ss' (offset, nextSlot)
-        -- If time moved back, but less than 2s, we don't throw an exception
-        | prevOffset - offset < 2
-        = go n ss' (prevOffset, prevSlot)
+        -- If time moved back, but not more than 2s, we don't throw an exception
+        | prevOffset - offset <= 2
+        = go n ss' (offset, prevSlot)
         -- If time moved back too much, we should see an exception
         | otherwise
         = throwError (prevSlot, nextSlot)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Match.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Match.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -89,6 +90,22 @@ matchTelescope = go
     go (S r)  (TS  gx t) = bimap MS (TS gx) $ go r t
     go (Z hx) (TS _gx t) = Left $ ML hx (Telescope.tip t)
     go (S l)  (TZ fx)    = Left $ MR l fx
+
+{-------------------------------------------------------------------------------
+  SOP class instances for 'Mismatch'
+-------------------------------------------------------------------------------}
+
+type instance Prod    (Mismatch f)   = NP
+type instance SListIN (Mismatch f)   = SListI
+type instance AllN    (Mismatch f) c = All c
+
+instance HAp (Mismatch f) where
+  hap = go
+    where
+      go :: NP (g -.-> g') xs -> Mismatch f g xs -> Mismatch f g' xs
+      go (_ :* fs) (MS m)     = MS (go fs m)
+      go (_ :* fs) (ML fx gy) = ML fx (hap fs gy)
+      go (f :* _)  (MR fy gx) = MR fy (apFn f gx)
 
 {-------------------------------------------------------------------------------
   Utilities

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -511,6 +511,13 @@ forkBlockForging maxTxCapacityOverride IS{..} blockForging =
           exitEarly
 
         -- We successfully produced /and/ adopted a block
+        --
+        -- NOTE: we are tracing the transactions we retrieved from the Mempool,
+        -- not the transactions actually /in the block/. They should always
+        -- match, if they don't, that would be a bug. Unfortunately, we can't
+        -- assert this here because the ability to extract transactions from a
+        -- block, i.e., the @HasTxs@ class, is not implementable by all blocks,
+        -- e.g., @DualBlock@.
         trace $ TraceAdoptedBlock currentSlot newBlock txs
 
     trace :: TraceForgeEvent blk -> WithEarlyExit m ()


### PR DESCRIPTION
When the mempool verifies transactions, it injects transactions from past eras
into the current era. However, block production was not doing this.

Debugging this was made more difficult because the trace message that we were
outputting after creating a block (`TraceAdoptedBlock`) recorded the
transactions from the mempool, not the transactions that were actually included
in the block.

This means that injection now happens 3 times: once when we add transactions
into the mempool, once when we revalidate the mempool when we produce a block,
and then a third time when we actually construct the block. Streamlining this
however we can do at a later stage.