### PR TITLE
Labelled TVars & friends

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -199,7 +199,9 @@ class MonadSTMTx stm => MonadLabelledSTMTx stm where
   labelTQueue  :: TQueue_  stm a -> String -> stm ()
   labelTBQueue :: TBQueue_ stm a -> String -> stm ()
 
--- | A convenience class which provides 'MonadSTM' and 'MonadLabelledSTMTx' constraints.
+-- | A convenience class which provides 'MonadSTM' and 'MonadLabelledSTMTx'
+-- constraints.
+--
 class (MonadSTM m, MonadLabelledSTMTx (STM m))
    => MonadLabelledSTM m where
   labelTVarIO    :: TVar    m a -> String -> m ()
@@ -272,12 +274,16 @@ instance MonadSTM IO where
   newTMVarIO      = STM.newTMVarIO
   newEmptyTMVarIO = STM.newEmptyTMVarIO
 
+-- | noop instance
+--
 instance MonadLabelledSTMTx STM.STM where
   labelTVar    = \_  _ -> return ()
   labelTMVar   = \_  _ -> return ()
   labelTQueue  = \_  _ -> return ()
   labelTBQueue = \_  _ -> return ()
 
+-- | noop instance
+--
 instance MonadLabelledSTM IO where
   labelTVarIO    = \_  _ -> return ()
   labelTMVarIO   = \_  _ -> return ()

--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DefaultSignatures      #-}
 {-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE TypeFamilies           #-}
@@ -5,6 +6,8 @@
 module Control.Monad.Class.MonadSTM
   ( MonadSTM (..)
   , MonadSTMTx (..)
+  , MonadLabelledSTM (..)
+  , MonadLabelledSTMTx (..)
   , LazyTVar
   , LazyTMVar
   , TVar
@@ -14,6 +17,7 @@ module Control.Monad.Class.MonadSTM
 
   -- * Default 'TMVar' implementation
   , TMVarDefault (..)
+  , labelTMVarDefault
   , newTMVarDefault
   , newTMVarIODefault
   , newEmptyTMVarDefault
@@ -29,6 +33,7 @@ module Control.Monad.Class.MonadSTM
 
   -- * Default 'TBQueue' implementation
   , TQueueDefault (..)
+  , labelTQueueDefault
   , newTQueueDefault
   , readTQueueDefault
   , tryReadTQueueDefault
@@ -37,6 +42,7 @@ module Control.Monad.Class.MonadSTM
 
   -- * Default 'TBQueue' implementation
   , TBQueueDefault (..)
+  , labelTBQueueDefault
   , newTBQueueDefault
   , readTBQueueDefault
   , tryReadTBQueueDefault
@@ -184,6 +190,35 @@ newEmptyTMVarM  :: MonadSTM m => m (TMVar m a)
 newEmptyTMVarM = newEmptyTMVarIO
 {-# DEPRECATED newEmptyTMVarM "Use newEmptyTMVarIO" #-}
 
+
+-- | Labelled 'TVar's, 'TMVar's, 'TQueue's and 'TBQueue's.
+--
+class MonadSTMTx stm => MonadLabelledSTMTx stm where
+  labelTVar    :: TVar_    stm a -> String -> stm ()
+  labelTMVar   :: TMVar_   stm a -> String -> stm ()
+  labelTQueue  :: TQueue_  stm a -> String -> stm ()
+  labelTBQueue :: TBQueue_ stm a -> String -> stm ()
+
+-- | A convenience class which provides 'MonadSTM' and 'MonadLabelledSTMTx' constraints.
+class (MonadSTM m, MonadLabelledSTMTx (STM m))
+   => MonadLabelledSTM m where
+  labelTVarIO    :: TVar    m a -> String -> m ()
+  labelTMVarIO   :: TMVar   m a -> String -> m ()
+  labelTQueueIO  :: TQueue  m a -> String -> m ()
+  labelTBQueueIO :: TBQueue m a -> String -> m ()
+
+  default labelTVarIO :: TVar m a -> String -> m ()
+  labelTVarIO = \v l -> atomically (labelTVar v l)
+
+  default labelTMVarIO :: TMVar m a -> String -> m ()
+  labelTMVarIO = \v l -> atomically (labelTMVar v l)
+
+  default labelTQueueIO :: TQueue m a -> String -> m ()
+  labelTQueueIO = \v l -> atomically (labelTQueue v l)
+
+  default labelTBQueueIO :: TBQueue m a -> String -> m ()
+  labelTBQueueIO = \v l -> atomically (labelTBQueue v l)
+
 --
 -- Instance for IO uses the existing STM library implementations
 --
@@ -237,12 +272,24 @@ instance MonadSTM IO where
   newTMVarIO      = STM.newTMVarIO
   newEmptyTMVarIO = STM.newEmptyTMVarIO
 
+instance MonadLabelledSTMTx STM.STM where
+  labelTVar    = \_  _ -> return ()
+  labelTMVar   = \_  _ -> return ()
+  labelTQueue  = \_  _ -> return ()
+  labelTBQueue = \_  _ -> return ()
+
+instance MonadLabelledSTM IO where
+  labelTVarIO    = \_  _ -> return ()
+  labelTMVarIO   = \_  _ -> return ()
+  labelTQueueIO  = \_  _ -> return ()
+  labelTBQueueIO = \_  _ -> return ()
+
 -- | Wrapper around 'BlockedIndefinitelyOnSTM' that stores a call stack
 data BlockedIndefinitely = BlockedIndefinitely {
       blockedIndefinitelyCallStack :: CallStack
     , blockedIndefinitelyException :: BlockedIndefinitelyOnSTM
     }
-  deriving (Show)
+  deriving Show
 
 instance Exception BlockedIndefinitely where
   displayException (BlockedIndefinitely cs e) = unlines [
@@ -270,6 +317,11 @@ instance MonadSTM m => MonadSTM (ReaderT r m) where
 
 newtype TMVarDefault m a = TMVar (TVar m (Maybe a))
 
+labelTMVarDefault
+  :: MonadLabelledSTM m
+  => TMVarDefault m a -> String -> STM m ()
+labelTMVarDefault (TMVar tvar) = labelTVar tvar
+
 newTMVarDefault :: MonadSTM m => a -> STM m (TMVarDefault m a)
 newTMVarDefault a = do
   t <- newTVar (Just a)
@@ -291,7 +343,7 @@ newEmptyTMVarDefault = do
 
 newEmptyTMVarIODefault :: MonadSTM m => m (TMVarDefault m a)
 newEmptyTMVarIODefault = do
-  t <- newTVarM Nothing
+  t <- newTVarIO Nothing
   return (TMVar t)
 
 newEmptyTMVarMDefault :: MonadSTM m => m (TMVarDefault m a)
@@ -357,6 +409,13 @@ isEmptyTMVarDefault (TMVar t) = do
 data TQueueDefault m a = TQueue !(TVar m [a])
                                 !(TVar m [a])
 
+labelTQueueDefault
+  :: MonadLabelledSTM m
+  => TQueueDefault m a -> String -> STM m ()
+labelTQueueDefault (TQueue read write) label = do
+  labelTVar read (label ++ "-read")
+  labelTVar write (label ++ "-write")
+
 newTQueueDefault :: MonadSTM m => STM m (TQueueDefault m a)
 newTQueueDefault = do
   read  <- newTVar []
@@ -407,6 +466,15 @@ data TBQueueDefault m a = TBQueue
   !(TVar m Natural) -- write capacity
   !(TVar m [a])     -- written elements
   !Natural
+
+labelTBQueueDefault
+  :: MonadLabelledSTM m
+  => TBQueueDefault m a -> String -> STM m ()
+labelTBQueueDefault (TBQueue rsize read wsize write _size) label = do
+  labelTVar rsize (label ++ "-rsize")
+  labelTVar read (label ++ "-read")
+  labelTVar wsize (label ++ "-wsize")
+  labelTVar write (label ++ "-write")
 
 newTBQueueDefault :: MonadSTM m => Natural -> STM m (TBQueueDefault m a)
 newTBQueueDefault size = do

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -44,7 +44,8 @@ library
                        exceptions        >=0.10,
                        containers,
                        psqueues          >=0.2 && <0.3,
-                       time              >=1.6 && <1.11
+                       time              >=1.6 && <1.11,
+                       quiet
 
   ghc-options:         -Wall
                        -Wcompat

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -21,7 +21,7 @@ module Control.Monad.IOSim (
   Trace(..),
   TraceEvent(..),
   ThreadLabel,
-  LabeledThread (..),
+  LabelledThread (..),
   traceEvents,
   traceResult,
   selectTraceEvents,
@@ -104,12 +104,12 @@ data Failure =
        FailureException SomeException
 
        -- | The threads all deadlocked
-     | FailureDeadlock ![LabeledThread]
+     | FailureDeadlock ![LabelledThread]
 
        -- | The main thread terminated normally but other threads were still
        -- alive, and strict shutdown checking was requested.
        -- See 'runSimStrictShutdown'
-     | FailureSloppyShutdown [LabeledThread]
+     | FailureSloppyShutdown [LabelledThread]
   deriving Show
 
 instance Exception Failure where

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -21,7 +21,7 @@ module Control.Monad.IOSim (
   Trace(..),
   TraceEvent(..),
   ThreadLabel,
-  LabelledThread (..),
+  Labelled (..),
   traceEvents,
   traceResult,
   selectTraceEvents,
@@ -104,12 +104,12 @@ data Failure =
        FailureException SomeException
 
        -- | The threads all deadlocked
-     | FailureDeadlock ![LabelledThread]
+     | FailureDeadlock ![Labelled ThreadId]
 
        -- | The main thread terminated normally but other threads were still
        -- alive, and strict shutdown checking was requested.
        -- See 'runSimStrictShutdown'
-     | FailureSloppyShutdown [LabelledThread]
+     | FailureSloppyShutdown [Labelled ThreadId]
   deriving Show
 
 instance Exception Failure where

--- a/io-sim/src/Control/Monad/IOSim/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSim/Internal.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE ExistentialQuantification  #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GADTSyntax                 #-}
@@ -51,6 +54,8 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Time (UTCTime (..), fromGregorian)
 import           Data.Typeable (Typeable)
+import           Quiet (Quiet (..))
+import           GHC.Generics (Generic)
 
 import           Control.Applicative (Alternative (..))
 import           Control.Exception (ErrorCall (..), assert,
@@ -517,7 +522,8 @@ data LabelledThread = LabelledThread {
     labelledThreadId    :: ThreadId,
     labelledThreadLabel :: Maybe ThreadLabel
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Generic)
+  deriving Show via Quiet LabelledThread
 
 labelledThreads :: Map ThreadId (Thread s a) -> [LabelledThread]
 labelledThreads threadMap =

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -754,8 +754,8 @@ unit_async_13 =
            (uninterruptibleMask_ $ do
               tid <- forkIO $ atomically retry
               throwTo tid DivideByZero)
-       of Left FailureDeadlock -> property True
-          _                    -> property False
+       of Left FailureDeadlock {} -> property True
+          _                       -> property False
 
 
 unit_async_14 =


### PR DESCRIPTION
This series of patches allows to label TVars, TMVars, TQueues, TBQueues.  It
also provides an api to consistently name thread & 'TVar' hidden in 'Async'.

- io-sim: include threads in 'FailureDeadlock'
- io-sim: derive LabelThread instance using Quiet
- io-sim-classes: MonadLabeledSTM and MonadLabeledAsync
- io-sim: MonadLabeledSTM and MonadLabeledAsync IOSim instances
- io-sim: more labeled threads & tvars ids
