### PR TITLE
Parameterise LedgerDB over blk instead of r

### DIFF
--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -72,7 +72,6 @@ import           Data.Foldable (find, toList)
 import           Data.Function (on)
 import           Data.Functor.Identity
 import           Data.Kind (Constraint, Type)
-import           Data.Proxy
 import qualified Data.Sequence as LazySeq
 import           Data.Sequence.Strict (StrictSeq ((:|>), Empty), (|>))
 import qualified Data.Sequence.Strict as Seq
@@ -134,12 +133,12 @@ import           Ouroboros.Consensus.Util.CBOR (decodeWithOrigin,
 -- blocks. For example, if we are on line (*), and roll back 6 blocks, we get
 --
 -- > L3 |> []
-data LedgerDB l r = LedgerDB {
+data LedgerDB l blk = LedgerDB {
       -- | Older ledger states
-      ledgerDbCheckpoints :: !(StrictSeq (Checkpoint l r))
+      ledgerDbCheckpoints :: !(StrictSeq (Checkpoint l blk))
 
       -- | Information about the state of the ledger /before/
-    , ledgerDbAnchor      :: !(ChainSummary l r)
+    , ledgerDbAnchor      :: !(ChainSummary l blk)
 
       -- | Ledger DB parameters
     , ledgerDbParams      :: !LedgerDbParams
@@ -165,9 +164,9 @@ ledgerDbDefaultParams securityParam = LedgerDbParams {
 -- | Ticking the ledger DB just ticks the current state
 --
 -- We don't push the new state into the DB until we apply a block.
-data instance Ticked (LedgerDB l r) = TickedLedgerDB {
+data instance Ticked (LedgerDB l blk) = TickedLedgerDB {
       tickedLedgerDbTicked :: Ticked l
-    , tickedLedgerDbOrig   :: LedgerDB l r
+    , tickedLedgerDbOrig   :: LedgerDB l blk
     }
 
 {-------------------------------------------------------------------------------
@@ -175,23 +174,23 @@ data instance Ticked (LedgerDB l r) = TickedLedgerDB {
 -------------------------------------------------------------------------------}
 
 -- | Checkpoint with a ledger state
-data Checkpoint l r = Checkpoint {
-      cpBlock :: !r
+data Checkpoint l blk = Checkpoint {
+      cpBlock :: !(RealPoint blk)
     , cpState :: !l
     }
   deriving (Show, Eq, Generic, NoThunks)
 
-cpToPair :: Checkpoint l r -> (r, l)
-cpToPair (Checkpoint r l) = (r, l)
+cpToPair :: Checkpoint l blk -> (RealPoint blk, l)
+cpToPair (Checkpoint b s) = (b, s)
 
 {-------------------------------------------------------------------------------
   Chain summary
 -------------------------------------------------------------------------------}
 
 -- | Summary of the chain at a particular point in time
-data ChainSummary l r = ChainSummary {
+data ChainSummary l blk = ChainSummary {
       -- | The tip of the chain
-      csTip    :: !(WithOrigin r)
+      csTip    :: !(Point blk)
 
       -- | Length of the chain
     , csLength :: !Word64
@@ -201,22 +200,22 @@ data ChainSummary l r = ChainSummary {
     }
   deriving (Show, Eq, Generic, NoThunks)
 
-genesisChainSummary :: l -> ChainSummary l r
-genesisChainSummary l = ChainSummary Origin 0 l
+genesisChainSummary :: l -> ChainSummary l blk
+genesisChainSummary = ChainSummary GenesisPoint 0
 
 {-------------------------------------------------------------------------------
   LedgerDB proper
 -------------------------------------------------------------------------------}
 
 -- | Ledger DB starting at the specified ledger state
-ledgerDbWithAnchor :: LedgerDbParams -> ChainSummary l r -> LedgerDB l r
+ledgerDbWithAnchor :: LedgerDbParams -> ChainSummary l blk -> LedgerDB l blk
 ledgerDbWithAnchor params anchor = LedgerDB {
       ledgerDbCheckpoints = Seq.empty
     , ledgerDbAnchor      = anchor
     , ledgerDbParams      = params
     }
 
-ledgerDbFromGenesis :: LedgerDbParams -> l -> LedgerDB l r
+ledgerDbFromGenesis :: LedgerDbParams -> l -> LedgerDB l blk
 ledgerDbFromGenesis params = ledgerDbWithAnchor params . genesisChainSummary
 
 {-------------------------------------------------------------------------------
@@ -236,15 +235,15 @@ ledgerDbFromGenesis params = ledgerDbWithAnchor params . genesisChainSummary
 -- must exist. If the 'ChainDB' is unable to fulfill the request, data
 -- corruption must have happened and the 'ChainDB' should trigger
 -- validation mode.
-type ResolveBlock m r b = r -> m b
+type ResolveBlock m blk = RealPoint blk -> m blk
 
 -- | Annotated ledger errors
-data AnnLedgerError l r = AnnLedgerError {
+data AnnLedgerError l blk = AnnLedgerError {
       -- | The ledger DB just /before/ this block was applied
-      annLedgerState  :: LedgerDB l r
+      annLedgerState  :: LedgerDB l blk
 
       -- | Reference to the block that had the error
-    , annLedgerErrRef :: r
+    , annLedgerErrRef :: RealPoint blk
 
       -- | The ledger error itself
     , annLedgerErr    :: LedgerErr l
@@ -254,39 +253,39 @@ data AnnLedgerError l r = AnnLedgerError {
 --
 -- To guide type inference, we insist that we must be able to infer the type
 -- of the block we are resolving from the type of the monad.
-class Monad m => ResolvesBlocks r b m | m -> b where
-  resolveBlock :: r -> m b
+class Monad m => ResolvesBlocks m blk | m -> blk where
+  resolveBlock :: ResolveBlock m blk
 
-instance Monad m => ResolvesBlocks r b (ReaderT (ResolveBlock m r b) m) where
+instance Monad m => ResolvesBlocks (ReaderT (ResolveBlock m blk) m) blk where
   resolveBlock r = ReaderT $ \f -> f r
 
-defaultResolveBlocks :: ResolveBlock m r b
-                     -> ReaderT (ResolveBlock m r b) m a
+defaultResolveBlocks :: ResolveBlock m blk
+                     -> ReaderT (ResolveBlock m blk) m a
                      -> m a
 defaultResolveBlocks = flip runReaderT
 
 -- Quite a specific instance so we can satisfy the fundep
 instance Monad m
-      => ResolvesBlocks r b (ExceptT e (ReaderT (ResolveBlock m r b) m)) where
+      => ResolvesBlocks (ExceptT e (ReaderT (ResolveBlock m blk) m)) blk where
   resolveBlock = lift . resolveBlock
 
-class Monad m => ThrowsLedgerError l r m where
-  throwLedgerError :: LedgerDB l r -> r -> LedgerErr l -> m a
+class Monad m => ThrowsLedgerError m l blk where
+  throwLedgerError :: LedgerDB l blk -> RealPoint blk -> LedgerErr l -> m a
 
-defaultThrowLedgerErrors :: ExceptT (AnnLedgerError l r) m a
-                         -> m (Either (AnnLedgerError l r) a)
+defaultThrowLedgerErrors :: ExceptT (AnnLedgerError l blk) m a
+                         -> m (Either (AnnLedgerError l blk) a)
 defaultThrowLedgerErrors = runExceptT
 
-defaultResolveWithErrors :: ResolveBlock m r b
-                         -> ExceptT (AnnLedgerError l r)
-                                    (ReaderT (ResolveBlock m r b) m)
+defaultResolveWithErrors :: ResolveBlock m blk
+                         -> ExceptT (AnnLedgerError l blk)
+                                    (ReaderT (ResolveBlock m blk) m)
                                     a
-                         -> m (Either (AnnLedgerError l r) a)
+                         -> m (Either (AnnLedgerError l blk) a)
 defaultResolveWithErrors resolve =
       defaultResolveBlocks resolve
     . defaultThrowLedgerErrors
 
-instance Monad m => ThrowsLedgerError l r (ExceptT (AnnLedgerError l r) m) where
+instance Monad m => ThrowsLedgerError (ExceptT (AnnLedgerError l blk) m) l blk where
   throwLedgerError l r e = throwError $ AnnLedgerError l r e
 
 -- | 'Ap' is used to pass information about blocks to ledger DB updates
@@ -300,42 +299,42 @@ instance Monad m => ThrowsLedgerError l r (ExceptT (AnnLedgerError l r) m) where
 -- * Compute the constraint @c@ on the monad @m@ in order to run the query:
 --   a. If we are passing a block by reference, we must be able to resolve it.
 --   b. If we are applying rather than reapplying, we might have ledger errors.
-data Ap :: (Type -> Type) -> Type -> Type -> Type -> Constraint -> Type where
-  ReapplyVal :: r -> b -> Ap m l r b ()
-  ApplyVal   :: r -> b -> Ap m l r b (                       ThrowsLedgerError l r m)
-  ReapplyRef :: r      -> Ap m l r b (ResolvesBlocks  r b m)
-  ApplyRef   :: r      -> Ap m l r b (ResolvesBlocks  r b m, ThrowsLedgerError l r m)
+data Ap :: (Type -> Type) -> Type -> Type -> Constraint -> Type where
+  ReapplyVal ::           blk -> Ap m l blk ()
+  ApplyVal   ::           blk -> Ap m l blk (                      ThrowsLedgerError m l blk)
+  ReapplyRef :: RealPoint blk -> Ap m l blk (ResolvesBlocks m blk)
+  ApplyRef   :: RealPoint blk -> Ap m l blk (ResolvesBlocks m blk, ThrowsLedgerError m l blk)
 
   -- | 'Weaken' increases the constraint on the monad @m@.
   --
   -- This is primarily useful when combining multiple 'Ap's in a single
   -- homogeneous structure.
-  Weaken :: (c' => c) => Ap m l r b c -> Ap m l r b c'
+  Weaken :: (c' => c) => Ap m l blk c -> Ap m l blk c'
 
 {-------------------------------------------------------------------------------
   Internal utilities for 'Ap'
 -------------------------------------------------------------------------------}
 
-apRef :: Ap m l r b c -> r
-apRef (ReapplyVal r _) = r
-apRef (ApplyVal   r _) = r
-apRef (ReapplyRef r  ) = r
-apRef (ApplyRef   r  ) = r
-apRef (Weaken     ap)  = apRef ap
+apRef :: HasHeader blk => Ap m l blk c -> RealPoint blk
+apRef (ReapplyVal b) = blockRealPoint b
+apRef (ApplyVal   b) = blockRealPoint b
+apRef (ReapplyRef r) = r
+apRef (ApplyRef   r) = r
+apRef (Weaken     a) = apRef a
 
 -- | Apply block to the current ledger state
 --
 -- We take in the entire 'LedgerDB' because we record that as part of errors.
-applyBlock :: forall m c l r b. (ApplyBlock l b, Monad m, c)
+applyBlock :: forall m c l blk. (ApplyBlock l blk, Monad m, c)
            => LedgerCfg l
-           -> Ap m l r b c
-           -> LedgerDB l r -> m l
+           -> Ap m l blk c
+           -> LedgerDB l blk -> m l
 applyBlock cfg ap db = case ap of
-    ReapplyVal _r b ->
+    ReapplyVal b ->
       return $
         tickThenReapply cfg b l
-    ApplyVal r b ->
-      either (throwLedgerError db r) return $ runExcept $
+    ApplyVal b ->
+      either (throwLedgerError db (blockRealPoint b)) return $ runExcept $
         tickThenApply cfg b l
     ReapplyRef r  -> do
       b <- resolveBlock r
@@ -356,44 +355,44 @@ applyBlock cfg ap db = case ap of
 -------------------------------------------------------------------------------}
 
 -- | The ledger state at the tip of the chain
-ledgerDbCurrent :: LedgerDB l r -> l
+ledgerDbCurrent :: LedgerDB l blk -> l
 ledgerDbCurrent LedgerDB{..} = case ledgerDbCheckpoints of
   Empty                  -> csLedger ledgerDbAnchor
   (_ :|> Checkpoint _ l) -> l
 
 -- | Total length of the chain (in terms of number of blocks)
-ledgerDbChainLength :: LedgerDB l r -> Word64
+ledgerDbChainLength :: LedgerDB l blk -> Word64
 ledgerDbChainLength LedgerDB{..} =
     csLength ledgerDbAnchor + fromIntegral (Seq.length ledgerDbCheckpoints)
 
 -- | References to blocks and corresponding ledger state (from old to new)
-ledgerDbToList :: LedgerDB l r -> [(r, l)]
+ledgerDbToList :: LedgerDB l blk -> [(RealPoint blk, l)]
 ledgerDbToList LedgerDB{..} = map cpToPair $ toList ledgerDbCheckpoints
 
 -- | All snapshots currently stored by the ledger DB (new to old)
 --
 -- This also includes the snapshot at the anchor. For each snapshot we also
 -- return the distance from the tip.
-ledgerDbSnapshots :: forall l r. LedgerDB l r -> [(Word64, l)]
+ledgerDbSnapshots :: forall l blk. LedgerDB l blk -> [(Word64, l)]
 ledgerDbSnapshots LedgerDB{..} = go 0 ledgerDbCheckpoints
   where
-    go :: Word64 -> StrictSeq (Checkpoint l r) -> [(Word64, l)]
+    go :: Word64 -> StrictSeq (Checkpoint l blk) -> [(Word64, l)]
     go !offset Empty                   = [(offset, csLedger ledgerDbAnchor)]
     go !offset (ss :|> Checkpoint _ l) = (offset, l) : go (offset + 1) ss
 
 -- | How many blocks can we currently roll back?
-ledgerDbMaxRollback :: LedgerDB l r -> Word64
+ledgerDbMaxRollback :: LedgerDB l blk -> Word64
 ledgerDbMaxRollback LedgerDB{..} = fromIntegral (Seq.length ledgerDbCheckpoints)
 
 -- | Reference to the block at the tip of the chain
-ledgerDbTip :: LedgerDB l r -> WithOrigin r
+ledgerDbTip :: LedgerDB l blk -> Point blk
 ledgerDbTip LedgerDB{..} =
     case ledgerDbCheckpoints of
       Empty    -> csTip ledgerDbAnchor
-      _ :|> cp -> NotOrigin (cpBlock cp)
+      _ :|> cp -> realPointToPoint (cpBlock cp)
 
 -- | Have we seen at least @k@ blocks?
-ledgerDbIsSaturated :: LedgerDB l r -> Bool
+ledgerDbIsSaturated :: LedgerDB l blk -> Bool
 ledgerDbIsSaturated LedgerDB{..} =
     fromIntegral (Seq.length ledgerDbCheckpoints) >= k
   where
@@ -405,15 +404,15 @@ ledgerDbIsSaturated LedgerDB{..} =
 -------------------------------------------------------------------------------}
 
 -- | Internal: shift the anchor given a bunch of checkpoints.
-shiftAnchor :: forall r l. HasCallStack
-            => StrictSeq (Checkpoint l r) -> ChainSummary l r -> ChainSummary l r
+shiftAnchor :: forall blk l. HasCallStack
+            => StrictSeq (Checkpoint l blk) -> ChainSummary l blk -> ChainSummary l blk
 shiftAnchor toRemove ChainSummary{..} = ChainSummary {
-      csTip    = NotOrigin csTip'
+      csTip    = realPointToPoint csTip'
     , csLength = csLength + fromIntegral (Seq.length toRemove)
     , csLedger = csLedger'
     }
   where
-    csTip'    :: r
+    csTip'    :: RealPoint blk
     csLedger' :: l
     (csTip', csLedger') =
         case toRemove of
@@ -433,7 +432,7 @@ ledgerDbCountToPrune LedgerDbParams{..} curSize'
     curSize = fromIntegral curSize'
 
 -- | Internal: drop unneeded snapshots from the head of the list
-prune :: HasCallStack => LedgerDB l r -> LedgerDB l r
+prune :: HasCallStack => LedgerDB l blk -> LedgerDB l blk
 prune db@LedgerDB{..} =
     if toPrune == 0
       then db
@@ -454,9 +453,9 @@ prune db@LedgerDB{..} =
 {-# INLINE prune #-}
 
 -- | Push an updated ledger state
-pushLedgerState :: l  -- ^ Updated ledger state
-                -> r  -- ^ Reference to the applied block
-                -> LedgerDB l r -> LedgerDB l r
+pushLedgerState :: l              -- ^ Updated ledger state
+                -> RealPoint blk  -- ^ Reference to the applied block
+                -> LedgerDB l blk -> LedgerDB l blk
 pushLedgerState current' ref db@LedgerDB{..}  = prune $ db {
       ledgerDbCheckpoints = snapshots
     }
@@ -468,11 +467,11 @@ pushLedgerState current' ref db@LedgerDB{..}  = prune $ db {
 -------------------------------------------------------------------------------}
 
 -- | Reconstruct ledger DB from a list of checkpoints
-reconstructFrom :: forall l r.
+reconstructFrom :: forall l blk.
                    LedgerDbParams
-                -> ChainSummary l r
-                -> StrictSeq (Checkpoint l r)
-                -> LedgerDB l r
+                -> ChainSummary l blk
+                -> StrictSeq (Checkpoint l blk)
+                -> LedgerDB l blk
 reconstructFrom params anchor snapshots =
     LedgerDB {
         ledgerDbCheckpoints = snapshots
@@ -481,26 +480,26 @@ reconstructFrom params anchor snapshots =
       }
 
 -- | Generalization of rollback using a function on the checkpoints
-rollbackTo :: (   ChainSummary l r
-               -> StrictSeq (Checkpoint l r)
-               -> Maybe (StrictSeq (Checkpoint l r))
+rollbackTo :: (   ChainSummary l blk
+               -> StrictSeq (Checkpoint l blk)
+               -> Maybe (StrictSeq (Checkpoint l blk))
               )
-           -> LedgerDB l r
-           -> Maybe (LedgerDB l r)
+           -> LedgerDB l blk
+           -> Maybe (LedgerDB l blk)
 rollbackTo f (LedgerDB checkpoints anchor params) =
     reconstructFrom params anchor <$> f anchor checkpoints
 
 -- | Rollback
 --
 -- Returns 'Nothing' if maximum rollback is exceeded.
-rollback :: forall l r.
+rollback :: forall l blk.
             Word64
-         -> LedgerDB l r
-         -> Maybe (LedgerDB l r)
+         -> LedgerDB l blk
+         -> Maybe (LedgerDB l blk)
 rollback 0 db = Just db
 rollback n db = rollbackTo (\_anchor -> go) db
   where
-    go :: StrictSeq (Checkpoint l r) -> Maybe (StrictSeq (Checkpoint l r))
+    go :: StrictSeq (Checkpoint l blk) -> Maybe (StrictSeq (Checkpoint l blk))
     go checkpoints =
         if Seq.length checkpoints >= fromIntegral n
           then Just $
@@ -515,57 +514,33 @@ rollback n db = rollbackTo (\_anchor -> go) db
 --
 --  \( O(\log n * \log n) \).
 --
--- When no 'Checkpoint' (or anchor) has the given @'WithOrigin' r@, 'Nothing' is
+-- When no 'Checkpoint' (or anchor) has the given 'Point', 'Nothing' is
 -- returned.
 --
 -- To avoid a linear search on the checkpoints (typically 2160 of them), we do a
 -- binary search benefitting from the cheap splits of the underlying
 -- 'StrictSeq' \( O(\log n) \).
---
--- For a binary search, the checkpoints have to be ordered by @r@. In practice,
--- we'll use 'RealPoint' for @r@, which, because of the existence of EBBs,
--- doesn't have a reliable ordering: it orders first on 'SlotNo', which is
--- correct. But in case of a tie, it will look at the hash, which is not what we
--- need: an EBB has the same slot as the block after it, so we'd want the
--- 'RealPoint' of an EBB to be /less/ than the 'RealPoint' of the regular block
--- in the same slot. But the decision is made based on the hash, so we won't get
--- a reliable answer.
---
--- Therefore, we take a projection @refOrder :: r -> ro@ as an argument. The
--- @ro@ type should have a correct ordering, so that the list below is correctly
--- ordered:
---
--- > map (refOrder . cpBlock) $ Seq.toList (ledgerDbCheckpoints db)
---
--- When instantiating @r@ to 'RealPoint', one should use 'realPointSlot' as
--- @refOrder@.
---
--- Note: we don't use @fingertree@ for the checkpoints (with its @search@
--- operation we could use here) because we'd have to impose more constraints on
--- the @r@ type. We could do an interpolation search if we assume more about the
--- @ro@ parameter ('SlotNo'), but that would be more complicated.
 ledgerDbPast ::
-     forall l r ro. (Ord ro, Eq r)
-  => (r -> ro)
-  -> WithOrigin r
-  -> LedgerDB l r
+     forall l blk. HasHeader blk
+  => Point blk
+  -> LedgerDB l blk
   -> Maybe l
-ledgerDbPast refOrder tip db
+ledgerDbPast tip db
     | tip == ledgerDbTip db
     = Just (ledgerDbCurrent db)
     | tip == csTip (ledgerDbAnchor db)
     = Just (csLedger (ledgerDbAnchor db))
-    | NotOrigin tip' <- tip
+    | NotOrigin tip' <- pointToWithOriginRealPoint tip
     = cpState <$> binarySearch tip' (Seq.getSeq (ledgerDbCheckpoints db))
     | otherwise
     = Nothing
   where
-    binarySearch :: r -> LazySeq.Seq (Checkpoint l r) -> Maybe (Checkpoint l r)
+    binarySearch :: RealPoint blk -> LazySeq.Seq (Checkpoint l blk) -> Maybe (Checkpoint l blk)
     binarySearch _   LazySeq.Empty = Nothing
     binarySearch ref checkpoints   = case LazySeq.splitAt middle checkpoints of
         (before, LazySeq.Empty)        -> binarySearch ref before
         (before, cp LazySeq.:<| after) ->
-          case (compare `on` refOrder) ref (cpBlock cp) of
+          case (compare `on` realPointSlot) ref (cpBlock cp) of
             LT -> binarySearch ref before
             GT -> binarySearch ref after
             EQ
@@ -573,24 +548,24 @@ ledgerDbPast refOrder tip db
               | otherwise  ->
                 -- Oh EBBs, why do you make everything so much harder? An EBB
                 -- has the same slot as the regular block after it. We look left
-                -- and right from @cp@ for checkpoints with the same @ro@
-                -- ('SlotNo' in practice) and do a linear search among those.
-                -- When it's indeed a slot populated by both a regular block and
-                -- EBB, we'll look at /one/ other checkpoint. In all other
-                -- cases, we'll look at /none/. Note that we have to look in
-                -- both directions because we don't know whether @cp@ is the EBB
-                -- or the regular block in the same slot.
+                -- and right from @cp@ for checkpoints with the same 'SlotNo'
+                -- and do a linear search among those. When it's indeed a slot
+                -- populated by both a regular block and EBB, we'll look at
+                -- /one/ other checkpoint. In all other cases, we'll look at
+                -- /none/. Note that we have to look in both directions because
+                -- we don't know whether @cp@ is the EBB or the regular block in
+                -- the same slot.
                 find isMatch (LazySeq.takeWhileR sameOrder before) `mplus`
                 find isMatch (LazySeq.takeWhileL sameOrder after)
       where
         middle :: Int
         middle = LazySeq.length checkpoints `div` 2
 
-        isMatch :: Checkpoint l r -> Bool
+        isMatch :: Checkpoint l blk -> Bool
         isMatch cp = cpBlock cp == ref
 
-        sameOrder :: Checkpoint l r -> Bool
-        sameOrder cp = refOrder (cpBlock cp) == refOrder ref
+        sameOrder :: Checkpoint l blk -> Bool
+        sameOrder cp = realPointSlot (cpBlock cp) == realPointSlot ref
 
 -- | Get a past ledger state
 --
@@ -600,16 +575,16 @@ ledgerDbPast refOrder tip db
 --
 -- Can be used in tests to compare against 'ledgerDbPast'.
 ledgerDbPastSpec ::
-     forall l r. Eq r
-  => WithOrigin r
-  -> LedgerDB l r
+     forall l blk. HasHeader blk
+  => Point blk
+  -> LedgerDB l blk
   -> Maybe l
 ledgerDbPastSpec tip db
     | tip == ledgerDbTip db
     = Just (ledgerDbCurrent db)
     | tip == csTip (ledgerDbAnchor db)
     = Just (csLedger (ledgerDbAnchor db))
-    | NotOrigin tip' <- tip
+    | NotOrigin tip' <- pointToWithOriginRealPoint tip
     = cpState <$> find ((== tip') . cpBlock) (ledgerDbCheckpoints db)
     | otherwise
     = Nothing
@@ -640,26 +615,26 @@ data ExceededRollback = ExceededRollback {
     , rollbackRequested :: Word64
     }
 
-ledgerDbPush :: forall m c l r b. (ApplyBlock l b, Monad m, c)
+ledgerDbPush :: forall m c l blk. (ApplyBlock l blk, Monad m, c)
              => LedgerCfg l
-             -> Ap m l r b c -> LedgerDB l r -> m (LedgerDB l r)
+             -> Ap m l blk c -> LedgerDB l blk -> m (LedgerDB l blk)
 ledgerDbPush cfg ap db =
     (\current' -> pushLedgerState current' (apRef ap) db) <$>
       applyBlock cfg ap db
 
 -- | Push a bunch of blocks (oldest first)
-ledgerDbPushMany :: (ApplyBlock l b, Monad m, c)
+ledgerDbPushMany :: (ApplyBlock l blk, Monad m, c)
                  => LedgerCfg l
-                 -> [Ap m l r b c] -> LedgerDB l r -> m (LedgerDB l r)
+                 -> [Ap m l blk c] -> LedgerDB l blk -> m (LedgerDB l blk)
 ledgerDbPushMany = repeatedlyM . ledgerDbPush
 
 -- | Switch to a fork
-ledgerDbSwitch :: (ApplyBlock l b, Monad m, c)
+ledgerDbSwitch :: (ApplyBlock l blk, Monad m, c)
                => LedgerCfg l
                -> Word64          -- ^ How many blocks to roll back
-               -> [Ap m l r b c]  -- ^ New blocks to apply
-               -> LedgerDB l r
-               -> m (Either ExceededRollback (LedgerDB l r))
+               -> [Ap m l blk c]  -- ^ New blocks to apply
+               -> LedgerDB l blk
+               -> m (Either ExceededRollback (LedgerDB l blk))
 ledgerDbSwitch cfg numRollbacks newBlocks db =
     case rollback numRollbacks db of
       Nothing ->
@@ -674,37 +649,32 @@ ledgerDbSwitch cfg numRollbacks newBlocks db =
   The LedgerDB itself behaves like a ledger
 -------------------------------------------------------------------------------}
 
-type instance LedgerCfg (LedgerDB l r) = LedgerCfg l
+type instance LedgerCfg (LedgerDB l blk) = LedgerCfg l
 
-type instance HeaderHash (LedgerDB l r) = HeaderHash l
+type instance HeaderHash (LedgerDB l blk) = HeaderHash l
 
-instance IsLedger l => GetTip (LedgerDB l r) where
+instance IsLedger l => GetTip (LedgerDB l blk) where
   getTip = castPoint . getTip . ledgerDbCurrent
 
-instance IsLedger l => GetTip (Ticked (LedgerDB l r)) where
+instance IsLedger l => GetTip (Ticked (LedgerDB l blk)) where
   getTip = castPoint . getTip . tickedLedgerDbOrig
 
-instance ( IsLedger l
-           -- Required superclass constraints of 'IsLedger'
-         , Show     r
-         , Eq       r
-         , NoThunks r
-         ) => IsLedger (LedgerDB l r) where
-  type LedgerErr (LedgerDB l r) = LedgerErr l
+instance (IsLedger l, HasHeader blk) => IsLedger (LedgerDB l blk) where
+  type LedgerErr (LedgerDB l blk) = LedgerErr l
 
   applyChainTick cfg slot db = TickedLedgerDB {
         tickedLedgerDbTicked = applyChainTick cfg slot (ledgerDbCurrent db)
       , tickedLedgerDbOrig   = db
       }
 
-instance ApplyBlock l blk => ApplyBlock (LedgerDB l (RealPoint blk)) blk where
+instance ApplyBlock l blk => ApplyBlock (LedgerDB l blk) blk where
   applyLedgerBlock cfg blk TickedLedgerDB{..} =
       push <$> applyLedgerBlock
                  cfg
                  blk
                  tickedLedgerDbTicked
    where
-     push :: l -> LedgerDB l (RealPoint blk)
+     push :: l -> LedgerDB l blk
      push l = pushLedgerState l (blockRealPoint blk) tickedLedgerDbOrig
 
   reapplyLedgerBlock cfg blk TickedLedgerDB{..} =
@@ -713,34 +683,29 @@ instance ApplyBlock l blk => ApplyBlock (LedgerDB l (RealPoint blk)) blk where
                blk
                tickedLedgerDbTicked
    where
-     push :: l -> LedgerDB l (RealPoint blk)
+     push :: l -> LedgerDB l blk
      push l = pushLedgerState l (blockRealPoint blk) tickedLedgerDbOrig
 
 {-------------------------------------------------------------------------------
-  Suppor for testing
+  Support for testing
 -------------------------------------------------------------------------------}
 
-pureBlock :: b -> Ap m l b b ()
-pureBlock b = ReapplyVal b b
+pureBlock :: blk -> Ap m l blk ()
+pureBlock = ReapplyVal
 
-triviallyResolve :: forall b a. Proxy b
-                 -> Reader (ResolveBlock Identity b b) a -> a
-triviallyResolve _ = runIdentity . defaultResolveBlocks return
-
-ledgerDbPush' :: ApplyBlock l b
-              => LedgerCfg l -> b -> LedgerDB l b -> LedgerDB l b
+ledgerDbPush' :: ApplyBlock l blk
+              => LedgerCfg l -> blk -> LedgerDB l blk -> LedgerDB l blk
 ledgerDbPush' cfg b = runIdentity . ledgerDbPush cfg (pureBlock b)
 
-ledgerDbPushMany' :: ApplyBlock l b
-                  => LedgerCfg l -> [b] -> LedgerDB l b -> LedgerDB l b
+ledgerDbPushMany' :: ApplyBlock l blk
+                  => LedgerCfg l -> [blk] -> LedgerDB l blk -> LedgerDB l blk
 ledgerDbPushMany' cfg bs = runIdentity . ledgerDbPushMany cfg (map pureBlock bs)
 
-ledgerDbSwitch' :: forall l b. ApplyBlock l b
+ledgerDbSwitch' :: forall l blk. ApplyBlock l blk
                 => LedgerCfg l
-                -> Word64 -> [b] -> LedgerDB l b -> Maybe (LedgerDB l b)
+                -> Word64 -> [blk] -> LedgerDB l blk -> Maybe (LedgerDB l blk)
 ledgerDbSwitch' cfg n bs db =
-    case triviallyResolve (Proxy @b) $
-           ledgerDbSwitch cfg n (map pureBlock bs) db of
+    case runIdentity $ ledgerDbSwitch cfg n (map pureBlock bs) db of
       Left  ExceededRollback{} -> Nothing
       Right db'                -> Just db'
 
@@ -748,26 +713,36 @@ ledgerDbSwitch' cfg n bs db =
   Serialisation
 -------------------------------------------------------------------------------}
 
-instance (Serialise l, Serialise r) => Serialise (ChainSummary l r) where
+instance (Serialise l, Serialise (HeaderHash blk))
+      => Serialise (ChainSummary l blk) where
   encode = encodeChainSummary encode encode
   decode = decodeChainSummary decode decode
 
 encodeChainSummary :: (l -> Encoding)
-                   -> (r -> Encoding)
-                   -> ChainSummary l r -> Encoding
-encodeChainSummary encodeLedger encodeRef ChainSummary{..} = mconcat [
+                   -> (HeaderHash blk -> Encoding)
+                   -> ChainSummary l blk -> Encoding
+encodeChainSummary encodeLedger encodeHash ChainSummary{..} = mconcat [
       Enc.encodeListLen 3
-    , encodeWithOrigin encodeRef csTip
+      -- Note: for backwards-compatibility, we encode it as a @WithOrigin
+      -- (RealPoint blk) instead of a @Point blk@, which have different
+      -- encodings.
+    , encodeWithOrigin
+        (encodeRealPoint encodeHash)
+        (pointToWithOriginRealPoint csTip)
     , Enc.encodeWord64 csLength
     , encodeLedger csLedger
     ]
 
 decodeChainSummary :: (forall s. Decoder s l)
-                   -> (forall s. Decoder s r)
-                   -> forall s. Decoder s (ChainSummary l r)
-decodeChainSummary decodeLedger decodeRef = do
+                   -> (forall s. Decoder s (HeaderHash blk))
+                   -> forall s. Decoder s (ChainSummary l blk)
+decodeChainSummary decodeLedger decodeHash = do
     Dec.decodeListLenOf 3
-    csTip    <- decodeWithOrigin decodeRef
+    -- Note: for backwards-compatibility, we encode it as a @WithOrigin
+    -- (RealPoint blk) instead of a @Point blk@, which have different
+    -- encodings.
+    csTip    <- withOriginRealPointToPoint <$>
+                  decodeWithOrigin (decodeRealPoint decodeHash)
     csLength <- Dec.decodeWord64
     csLedger <- decodeLedger
     return ChainSummary{..}

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/TraceSize.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/TraceSize.hs
@@ -54,7 +54,7 @@ data LedgerDbSize blk = LedgerDbSize {
 traceLedgerDbSize :: MonadIO m
                   => (Word64 -> Bool)
                   -> Tracer m (LedgerDbSize blk)
-                  -> Tracer m (LedgerDB l (RealPoint blk))
+                  -> Tracer m (LedgerDB l blk)
 traceLedgerDbSize p (Tracer f) = Tracer $ \(!db) -> do
     let !ledger = LedgerDB.ledgerDbCurrent db
         !tip    = LedgerDB.ledgerDbTip db
@@ -63,11 +63,11 @@ traceLedgerDbSize p (Tracer f) = Tracer $ \(!db) -> do
       sizeTip   <- liftIO $ computeHeapSize ledger
       sizeTotal <- liftIO $ computeHeapSize db
       f $ LedgerDbSize {
-              ledgerDbTip       = withOriginRealPointToPoint tip
+              ledgerDbTip       = tip
             , ledgerDbSizeTip   = sizeTip
             , ledgerDbSizeTotal = sizeTotal
             }
   where
-    shouldTrace :: WithOrigin (RealPoint blk) -> Bool
-    shouldTrace Origin         = p 0
-    shouldTrace (NotOrigin pt) = p (unSlotNo (realPointSlot pt))
+    shouldTrace :: Point blk -> Bool
+    shouldTrace GenesisPoint     = p 0
+    shouldTrace (BlockPoint s _) = p (unSlotNo s)


### PR DESCRIPTION
By being aware about `blk`, we can make some simplifications. For example, we
can later reuse the `AnchoredSeq` abstraction to reimplement the `LedgerDB`.