### PR TITLE
Update dependency on cardano-ledger-specs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -152,8 +152,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: baa873c478ffa90c381e79d1ef3fdad0086b849f
-  --sha256: 14ccqy3x6616qm71cayfv240d6lsnzg3b9jm18n756bh6pmz6lkv
+  tag: 973526751ee0c5b84b43326d5766b846c56af311
+  --sha256: 1dcy6j6n4a3206fi1ibqlksn2sks7bksk1n4ahpmv2gmd6lnjs43
   subdir:
     byron/chain/executable-spec
     byron/crypto

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Generators.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Generators.hs
@@ -347,6 +347,14 @@ instance c ~ MockCryptoCompatByron
               <$> (getHardForkEnabledNodeToClientVersion <$> arbitrary)
               <*> (HardForkApplyTxErrWrongEra <$> arbitrary))
       ]
+  shrink = traverse aux
+    where
+      aux :: CardanoApplyTxErr MockCryptoCompatByron
+         -> [CardanoApplyTxErr MockCryptoCompatByron]
+      aux (HardForkApplyTxErrFromEra (OneEraApplyTxErr x)) =
+          HardForkApplyTxErrFromEra . OneEraApplyTxErr <$> shrink x
+      aux (HardForkApplyTxErrWrongEra x) =
+          HardForkApplyTxErrWrongEra <$> shrink x
 
 instance Arbitrary (Some QueryAnytime) where
   arbitrary = return $ Some GetEraStart

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -68,10 +68,6 @@ instance CanMock era => Arbitrary (GenTx (ShelleyBlock era)) where
 instance CanMock era => Arbitrary (GenTxId (ShelleyBlock era)) where
   arbitrary = ShelleyTxId <$> arbitrary
 
-instance CanMock era => Arbitrary (SL.ApplyTxError era) where
-  arbitrary = SL.ApplyTxError <$> arbitrary
-  shrink (ApplyTxError xs) = [ApplyTxError xs' | xs' <- shrink xs]
-
 instance CanMock era => Arbitrary (SomeSecond Query (ShelleyBlock era)) where
   arbitrary = oneof
     [ pure $ SomeSecond GetLedgerTip


### PR DESCRIPTION
This brings in https://github.com/input-output-hk/cardano-ledger-specs/pull/2049

Also improve the shrinking of `CardanoApplyTxErr`. These shrinkers were added to help chase down the failure fixed in the PR above. Better to leave them in, in case it happens again.