### PR TITLE
Allow skipping a prefix of the eras in Cardano mode

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -218,8 +219,11 @@ protocolInfoDualByron abstractGenesis@ByronSpecGenesis{..} params credss =
 
 instance NodeInitStorage DualByronBlock where
   -- Just like Byron, we need to start with an EBB
-  nodeInitChainDB cfg InitChainDB { addBlockIfEmpty } = do
-      addBlockIfEmpty (return genesisEBB)
+  nodeInitChainDB cfg InitChainDB { getCurrentLedger, addBlock } = do
+      tip <- ledgerTipPoint (Proxy @DualByronBlock) <$> getCurrentLedger
+      case tip of
+        BlockPoint {} -> return ()
+        GenesisPoint  -> addBlock genesisEBB
     where
       genesisEBB :: DualByronBlock
       genesisEBB = DualBlock {

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -32,6 +32,7 @@ library
                        Ouroboros.Consensus.Cardano.Condense
                        Ouroboros.Consensus.Cardano.CanHardFork
                        Ouroboros.Consensus.Cardano.Node
+                       Ouroboros.Consensus.Cardano.ShelleyBased
 
   build-depends:       base              >=4.9   && <4.15
                      , bytestring        >=0.10  && <0.11

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -53,13 +53,10 @@ import           Cardano.Prelude (cborError)
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import qualified Ouroboros.Consensus.HardFork.History as History
-import           Ouroboros.Consensus.HeaderValidation
-import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Node.NetworkProtocolVersion
 import           Ouroboros.Consensus.Node.ProtocolInfo
 import           Ouroboros.Consensus.Node.Run
 import           Ouroboros.Consensus.Storage.Serialisation
-import           Ouroboros.Consensus.TypeFamilyWrappers
 import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.Counting
 import           Ouroboros.Consensus.Util.IOLike
@@ -68,6 +65,7 @@ import qualified Ouroboros.Consensus.Util.OptNP as OptNP
 import           Ouroboros.Consensus.Util.SOP (Index (..))
 
 import           Ouroboros.Consensus.HardFork.Combinator
+import           Ouroboros.Consensus.HardFork.Combinator.Embed.Nary
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
@@ -378,17 +376,10 @@ protocolInfoCardano protocolParamsByron@ProtocolParamsByron {
     assertWithMsg (validateGenesis genesisShelley) $
     ProtocolInfo {
         pInfoConfig = cfg
-      , pInfoInitLedger = ExtLedgerState {
-            ledgerState =
-              HardForkLedgerState $
-                initHardForkState initLedgerStateByron
-          , headerState =
-              genesisHeaderState $
-                initHardForkState $
-                  WrapChainDepState $
-                    headerStateChainDep initHeaderStateByron
-          }
-      , pInfoBlockForging = maybeToList <$> mBlockForging
+      , pInfoInitLedger =
+          injectInitialExtLedgerState cfg initExtLedgerStateByron
+      , pInfoBlockForging =
+          maybeToList <$> mBlockForging
       }
   where
     -- The major protocol version of the last era is the maximum major protocol
@@ -403,10 +394,7 @@ protocolInfoCardano protocolParamsByron@ProtocolParamsByron {
           , topLevelConfigLedger   = ledgerConfigByron
           , topLevelConfigBlock    = blockConfigByron
           }
-      , pInfoInitLedger = ExtLedgerState {
-            ledgerState = initLedgerStateByron
-          , headerState = initHeaderStateByron
-          }
+      , pInfoInitLedger = initExtLedgerStateByron
       } = protocolInfoByron @m protocolParamsByron
 
     partialConsensusConfigByron :: PartialConsensusConfig (BlockProtocol ByronBlock)

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ShelleyBased.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ShelleyBased.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+module Ouroboros.Consensus.Cardano.ShelleyBased (
+    -- * Injection from Shelley-based eras into the Cardano eras
+    InjectShelley
+  , injectShelleyNP
+  , injectShelleyOptNP
+    -- * Transform Shelley-based types
+  , HasCrypto
+  , overShelleyBasedLedgerState
+  ) where
+
+import           Data.SOP.Strict
+
+import           Ouroboros.Consensus.Util.OptNP (OptNP (..))
+
+import           Ouroboros.Consensus.HardFork.Combinator
+
+import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
+import           Ouroboros.Consensus.Shelley.Protocol (PraosCrypto)
+
+import           Ouroboros.Consensus.Cardano.Block
+
+{-------------------------------------------------------------------------------
+  Injection from Shelley-based eras into the Cardano eras
+-------------------------------------------------------------------------------}
+
+-- | Witness the relation between the Cardano eras and the Shelley-based eras.
+class    cardanoEra ~ ShelleyBlock shelleyEra => InjectShelley shelleyEra cardanoEra
+instance cardanoEra ~ ShelleyBlock shelleyEra => InjectShelley shelleyEra cardanoEra
+
+injectShelleyNP ::
+     AllZip InjectShelley shelleyEras cardanoEras
+  => (   forall shelleyEra cardanoEra.
+         InjectShelley shelleyEra cardanoEra
+      => f shelleyEra -> g cardanoEra
+     )
+  -> NP f shelleyEras -> NP g cardanoEras
+injectShelleyNP _ Nil       = Nil
+injectShelleyNP f (x :* xs) = f x :* injectShelleyNP f xs
+
+injectShelleyOptNP ::
+     AllZip InjectShelley shelleyEras cardanoEras
+  => (   forall shelleyEra cardanoEra.
+         InjectShelley shelleyEra cardanoEra
+      => f shelleyEra -> g cardanoEra
+     )
+  -> OptNP empty f shelleyEras -> OptNP empty g cardanoEras
+injectShelleyOptNP _ OptNil         = OptNil
+injectShelleyOptNP f (OptSkip   xs) = OptSkip (injectShelleyOptNP f xs)
+injectShelleyOptNP f (OptCons x xs) = OptCons (f x) (injectShelleyOptNP f xs)
+
+{-------------------------------------------------------------------------------
+  Transform Shelley-based types
+-------------------------------------------------------------------------------}
+
+-- | Witness the relation between the crypto used by a Shelley-based era.
+--
+-- Can be partially applied while an equality constraint cannot.
+class EraCrypto era ~ c => HasCrypto c era
+instance EraCrypto era ~ c => HasCrypto c era
+
+-- | When the given ledger state corresponds to a Shelley-based era, apply the
+-- given function to it.
+overShelleyBasedLedgerState ::
+     forall c. PraosCrypto c
+  => (   forall era. (EraCrypto era ~ c, ShelleyBasedEra era)
+      => LedgerState (ShelleyBlock era)
+      -> LedgerState (ShelleyBlock era)
+     )
+  -> LedgerState (CardanoBlock c)
+  -> LedgerState (CardanoBlock c)
+overShelleyBasedLedgerState f (HardForkLedgerState st) =
+    HardForkLedgerState $ hap fs st
+  where
+    fs :: NP (LedgerState -.-> LedgerState)
+             (CardanoEras c)
+    fs = fn id
+        :* injectShelleyNP
+             reassoc
+             (hcpure
+               (Proxy @(And (HasCrypto c) ShelleyBasedEra))
+               (fn (Comp . f . unComp)))
+
+    reassoc ::
+         (     LedgerState :.: ShelleyBlock
+          -.-> LedgerState :.: ShelleyBlock
+         ) shelleyEra
+      -> (     LedgerState
+          -.-> LedgerState
+         ) (ShelleyBlock shelleyEra)
+    reassoc g = fn $ unComp . apFn g . Comp

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -37,7 +37,6 @@ module Ouroboros.Consensus.HardFork.Combinator.Embed.Unary (
 
 import           Data.Bifunctor (first)
 import           Data.Coerce
-import           Data.Functor.Contravariant
 import           Data.Kind (Type)
 import           Data.Proxy
 import           Data.SOP.Strict
@@ -60,6 +59,7 @@ import           Ouroboros.Consensus.TypeFamilyWrappers
 import qualified Ouroboros.Consensus.Util.OptNP as OptNP
 
 import           Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB)
+import qualified Ouroboros.Consensus.Storage.ChainDB.Init as InitChainDB
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
@@ -371,11 +371,11 @@ instance Isomorphic AnnTip where
 instance Functor m => Isomorphic (InitChainDB m) where
   project :: forall blk. NoHardForks blk
           => InitChainDB m (HardForkBlock '[blk]) -> InitChainDB m blk
-  project = contramap (inject' (Proxy @(I blk)))
+  project = InitChainDB.map (inject' (Proxy @(I blk))) project
 
   inject :: forall blk. NoHardForks blk
          => InitChainDB m blk -> InitChainDB m (HardForkBlock '[blk])
-  inject = contramap (project' (Proxy @(I blk)))
+  inject = InitChainDB.map (project' (Proxy @(I blk))) inject
 
 instance Isomorphic ProtocolClientInfo where
   project ProtocolClientInfo{..} = ProtocolClientInfo {

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node/InitStorage.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node/InitStorage.hs
@@ -4,14 +4,17 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage () where
 
-import           Data.Functor.Contravariant (contramap)
 import           Data.SOP.Strict
 
 import           Ouroboros.Consensus.Node.InitStorage
+import           Ouroboros.Consensus.Util.SOP
 
 import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
+
+import           Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB (..))
 
 instance CanHardFork xs => NodeInitStorage (HardForkBlock xs) where
   -- We use the chunk info from the first era
@@ -35,12 +38,32 @@ instance CanHardFork xs => NodeInitStorage (HardForkBlock xs) where
       aux :: NodeInitStorage blk => StorageConfig blk -> I blk -> K Bool blk
       aux cfg' (I blk') = K $ nodeCheckIntegrity cfg' blk'
 
-  -- Let the first era initialise the ChainDB
-  nodeInitChainDB cfg initChainDB =
+  -- Call the 'nodeInitChainDB' of the era in which the current ledger is.
+  --
+  -- In most cases, this will be the first era, except when one or more hard
+  -- forks are statically scheduled at the first slot.
+  nodeInitChainDB cfg (initChainDB :: InitChainDB m (HardForkBlock xs)) =
       case isNonEmpty (Proxy @xs) of
-        ProofNonEmpty {} ->
-          nodeInitChainDB
-            (hd cfgs)
-            (contramap (HardForkBlock . OneEraBlock . Z . I) initChainDB)
+        ProofNonEmpty {} -> do
+          currentLedger <- getCurrentLedger initChainDB
+          hcollapse $
+            hcizipWith
+              proxySingle
+              aux
+              cfgs
+              (State.tip (hardForkLedgerStatePerEra currentLedger))
     where
       cfgs = getPerEraStorageConfig (hardForkStorageConfigPerEra cfg)
+
+      aux ::
+           SingleEraBlock blk
+        => Index xs blk
+        -> StorageConfig blk
+        -> LedgerState blk
+        -> K (m ()) blk
+      aux index cfg' currentLedger = K $
+          nodeInitChainDB cfg' InitChainDB {
+              addBlock         = addBlock initChainDB
+                               . injectNS' (Proxy @I) index
+            , getCurrentLedger = return currentLedger
+            }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 -- | Intended for qualified import
 --
 -- > import Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB)
@@ -5,40 +6,41 @@
 module Ouroboros.Consensus.Storage.ChainDB.Init (
     InitChainDB(..)
   , fromFull
-  , cast
+  , map
   ) where
 
-import           Data.Coerce
-import           Data.Functor.Contravariant
+import           Prelude hiding (map)
 
-import           Ouroboros.Consensus.Block
+import           Ouroboros.Consensus.Ledger.Abstract
+import           Ouroboros.Consensus.Ledger.Extended
 import           Ouroboros.Consensus.Storage.ChainDB.API (ChainDB)
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
 import           Ouroboros.Consensus.Util.IOLike
 
 -- | Restricted interface to the 'ChainDB' used on node initialization
-newtype InitChainDB m blk = InitChainDB {
-      -- | Add a block to the DB when the current chain is empty.
-      --
-      -- The given action is only called when the current chain is empty.
-      addBlockIfEmpty :: m blk -> m ()
+data InitChainDB m blk = InitChainDB {
+      -- | Add a block to the DB
+      addBlock         :: blk -> m ()
+
+      -- | Return the current ledger state
+    , getCurrentLedger :: m (LedgerState blk)
     }
 
-instance Functor m => Contravariant (InitChainDB m) where
-  contramap f db = InitChainDB {
-        addBlockIfEmpty = addBlockIfEmpty db . (f <$>)
-      }
-
-fromFull :: IOLike m => ChainDB m blk -> InitChainDB m blk
+fromFull ::
+     (IsLedger (LedgerState blk), IOLike m)
+  => ChainDB m blk -> InitChainDB m blk
 fromFull db = InitChainDB {
-      addBlockIfEmpty = \mkBlk -> do
-          tip <- atomically $ ChainDB.getTipPoint db
-          case tip of
-            BlockPoint {} -> return ()
-            GenesisPoint  -> do
-              blk <- mkBlk
-              ChainDB.addBlock_ db blk
+      addBlock         = ChainDB.addBlock_ db
+    , getCurrentLedger =
+        atomically $ ledgerState <$> ChainDB.getCurrentLedger db
     }
 
-cast :: (Functor m, Coercible blk blk') => InitChainDB m blk -> InitChainDB m blk'
-cast = contramap coerce
+map ::
+     Functor m
+  => (blk' -> blk)
+  -> (LedgerState blk -> LedgerState blk')
+  -> InitChainDB m blk -> InitChainDB m blk'
+map f g db = InitChainDB {
+      addBlock         = addBlock db . f
+    , getCurrentLedger = g <$> getCurrentLedger db
+    }


### PR DESCRIPTION
Add support for immediately executing one or more hard forks during initialisation, when configured using `TriggerHardForkAtEpoch 0`. This will allow starting a node in Cardano mode directly in the Shelley, Allegra, or Mary era without having to spend an epoch in each preceding era.

For example, to start a Cardano node in the Mary era, add the following to your `cardano-node` configuration:

```
TestShelleyHardForkAtEpoch: 0
TestAllegraHardForkAtEpoch: 0
TestMaryHardForkAtEpoch:    0
```

Registering initial staking and funds is also allowed in Cardano mode, but will only take effect if configured to skip at least the Byron era.