### PR TITLE
Allow multiple credentials for Cardano testnets

### DIFF
--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -187,7 +187,7 @@ instance ShelleyBasedHardForkConstraints era1 era2
 
 protocolInfoShelleyBasedHardFork ::
      forall m era1 era2. (IOLike m, ShelleyBasedHardForkConstraints era1 era2)
-  => ProtocolParamsShelleyBased era1 Identity
+  => ProtocolParamsShelleyBased era1
   -> SL.ProtVer
   -> SL.ProtVer
   -> ProtocolParamsTransition (ShelleyBlock era1) (ShelleyBlock era2)

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
@@ -498,7 +498,7 @@ mkProtocolCardanoAndHardForkTxs
         ProtocolParamsShelleyBased {
             shelleyBasedGenesis           = genesisShelley
           , shelleyBasedInitialNonce      = initialNonce
-          , shelleyBasedLeaderCredentials = Just leaderCredentialsShelley
+          , shelleyBasedLeaderCredentials = [leaderCredentialsShelley]
           }
         ProtocolParamsShelley {
             shelleyProtVer = SL.ProtVer shelleyMajorVersion 0

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
@@ -19,7 +19,6 @@ module Test.ThreadNet.ShelleyAllegra (
   ) where
 
 import           Control.Monad (replicateM)
-import           Data.Functor.Identity (Identity (..))
 import qualified Data.Map as Map
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
@@ -268,8 +267,9 @@ prop_simple_shelleyAllegra_convergence TestSetup
                     ProtocolParamsShelleyBased {
                         shelleyBasedGenesis           = genesisShelley
                       , shelleyBasedInitialNonce      = setupInitialNonce
-                      , shelleyBasedLeaderCredentials = Identity $
-                          Shelley.mkLeaderCredentials (coreNodes !! fromIntegral nid)
+                      , shelleyBasedLeaderCredentials =
+                          [Shelley.mkLeaderCredentials
+                            (coreNodes !! fromIntegral nid)]
                       }
                     (SL.ProtVer majorVersion1 0)
                     (SL.ProtVer majorVersion2 0)

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -42,6 +42,7 @@ library
                      , nothunks
                      , serialise         >=0.2   && <0.3
                      , text              >=1.2   && <1.3
+                     , these             >=1.1   && <1.2
 
                      , cardano-binary
                      , cardano-crypto-class

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -70,7 +70,6 @@ import           Ouroboros.Consensus.Cardano.ShelleyHFC
 
 type ProtocolByron   = HardForkProtocol '[ ByronBlock ]
 type ProtocolShelley = HardForkProtocol '[ ShelleyBlock StandardShelley ]
-type ProtocolMary    = HardForkProtocol '[ ShelleyBlock StandardMary ]
 type ProtocolCardano = HardForkProtocol '[ ByronBlock
                                          , ShelleyBlock StandardShelley
                                          , ShelleyBlock StandardAllegra
@@ -93,12 +92,6 @@ data Protocol (m :: Type -> Type) blk p where
     :: ProtocolParamsShelleyBased StandardShelley
     -> ProtocolParamsShelley
     -> Protocol m (ShelleyBlockHFC StandardShelley) ProtocolShelley
-
-  -- | Run TPraos against the Mary ledger
-  ProtocolMary
-    :: ProtocolParamsShelleyBased StandardMary
-    -> ProtocolParamsMary
-    -> Protocol m (ShelleyBlockHFC StandardMary) ProtocolMary
 
   -- | Run the protocols of /the/ Cardano block
   --
@@ -124,7 +117,6 @@ data Protocol (m :: Type -> Type) blk p where
 verifyProtocol :: Protocol m blk p -> (p :~: BlockProtocol blk)
 verifyProtocol ProtocolByron{}   = Refl
 verifyProtocol ProtocolShelley{} = Refl
-verifyProtocol ProtocolMary{}    = Refl
 verifyProtocol ProtocolCardano{} = Refl
 
 {-------------------------------------------------------------------------------
@@ -139,9 +131,6 @@ protocolInfo (ProtocolByron params) =
 
 protocolInfo (ProtocolShelley paramsShelleyBased paramsShelley) =
     inject $ protocolInfoShelley paramsShelleyBased paramsShelley
-
-protocolInfo (ProtocolMary paramsShelleyBased paramsMary) =
-    inject $ protocolInfoMary paramsShelleyBased paramsMary
 
 protocolInfo (ProtocolCardano
                paramsByron
@@ -169,7 +158,6 @@ protocolInfo (ProtocolCardano
 runProtocol :: Protocol m blk p -> Dict (RunNode blk)
 runProtocol ProtocolByron{}   = Dict
 runProtocol ProtocolShelley{} = Dict
-runProtocol ProtocolMary{}    = Dict
 runProtocol ProtocolCardano{} = Dict
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -90,20 +90,23 @@ data Protocol (m :: Type -> Type) blk p where
 
   -- | Run TPraos against the Shelley ledger
   ProtocolShelley
-    :: ProtocolParamsShelleyBased StandardShelley []
+    :: ProtocolParamsShelleyBased StandardShelley
     -> ProtocolParamsShelley
     -> Protocol m (ShelleyBlockHFC StandardShelley) ProtocolShelley
 
   -- | Run TPraos against the Mary ledger
   ProtocolMary
-    :: ProtocolParamsShelleyBased StandardMary []
+    :: ProtocolParamsShelleyBased StandardMary
     -> ProtocolParamsMary
     -> Protocol m (ShelleyBlockHFC StandardMary) ProtocolMary
 
   -- | Run the protocols of /the/ Cardano block
+  --
+  -- WARNING: only a single set of Shelley credentials is allowed when used for
+  -- mainnet. Testnets allow multiple Shelley credentials.
   ProtocolCardano
     :: ProtocolParamsByron
-    -> ProtocolParamsShelleyBased StandardShelley Maybe
+    -> ProtocolParamsShelleyBased StandardShelley
     -> ProtocolParamsShelley
     -> ProtocolParamsAllegra
     -> ProtocolParamsMary

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -100,7 +100,7 @@ mkCardanoProtocolInfo genesisByron signatureThreshold genesisShelley initialNonc
       ProtocolParamsShelleyBased {
           shelleyBasedGenesis           = genesisShelley
         , shelleyBasedInitialNonce      = initialNonce
-        , shelleyBasedLeaderCredentials = Nothing
+        , shelleyBasedLeaderCredentials = []
         }
       ProtocolParamsShelley {
           shelleyProtVer = ProtVer 2 0

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -405,7 +405,7 @@ mkProtocolShelley genesis initialNonce protVer coreNode =
       ProtocolParamsShelleyBased {
           shelleyBasedGenesis           = genesis
         , shelleyBasedInitialNonce      = initialNonce
-        , shelleyBasedLeaderCredentials = Just $ mkLeaderCredentials coreNode
+        , shelleyBasedLeaderCredentials = [mkLeaderCredentials coreNode]
         }
       ProtocolParamsShelley {
           shelleyProtVer = protVer

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -20,7 +20,6 @@
 module Ouroboros.Consensus.Shelley.Node (
     protocolInfoShelleyBased
   , protocolInfoShelley
-  , protocolInfoMary
   , ProtocolParamsShelleyBased (..)
   , ProtocolParamsShelley (..)
   , ProtocolParamsAllegra (..)
@@ -251,17 +250,6 @@ protocolInfoShelley protocolParamsShelleyBased
                     ProtocolParamsShelley {
                         shelleyProtVer = protVer
                       } =
-    protocolInfoShelleyBased protocolParamsShelleyBased protVer
-
-protocolInfoMary ::
-     forall m c. (IOLike m, ShelleyBasedEra (MaryEra c))
-  => ProtocolParamsShelleyBased (MaryEra c)
-  -> ProtocolParamsMary
-  -> ProtocolInfo m (ShelleyBlock (MaryEra c))
-protocolInfoMary protocolParamsShelleyBased
-                 ProtocolParamsMary {
-                     maryProtVer = protVer
-                   } =
     protocolInfoShelleyBased protocolParamsShelleyBased protVer
 
 protocolInfoShelleyBased ::


### PR DESCRIPTION
Allow multiple Shelley-based credentials for Cardano, but only for testnets, not for mainnnet.