### PR TITLE
Preparatory changes for ThreadNet rewrite

### DIFF
--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -132,7 +132,7 @@ byronBlockForging
 byronBlockForging creds = BlockForging {
       forgeLabel       = blcLabel creds
     , canBeLeader
-    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Unchanged ()
+    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Updated ()
     , checkCanForge    = \cfg slot tickedPBftState _isLeader () ->
                              pbftCheckCanForge
                                (configConsensus cfg)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -132,7 +132,7 @@ byronBlockForging
 byronBlockForging creds = BlockForging {
       forgeLabel       = blcLabel creds
     , canBeLeader
-    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Updated ()
+    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
     , checkCanForge    = \cfg slot tickedPBftState _isLeader () ->
                              pbftCheckCanForge
                                (configConsensus cfg)

--- a/ouroboros-consensus-mock-test/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus-mock-test/test/Test/ThreadNet/LeaderSchedule.hs
@@ -129,7 +129,6 @@ prop_simple_leader_schedule_convergence TestSetup
                   { praosSecurityParam = k
                   , praosSlotsPerEpoch = unEpochSize epochSize
                   , praosLeaderF       = dummyF
-                  , praosLifetimeKES   = 1000000
                   }
                   (HardFork.defaultEraParams k slotLength)
                   schedule

--- a/ouroboros-consensus-mock-test/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus-mock-test/test/Test/ThreadNet/Praos.hs
@@ -115,7 +115,6 @@ prop_simple_praos_convergence TestSetup
       { praosSecurityParam = k
       , praosSlotsPerEpoch = unEpochSize epochSize
       , praosLeaderF       = 0.5
-      , praosLifetimeKES   = 1000000
       }
 
     TestConfig{numCoreNodes} = testConfig

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -78,7 +78,7 @@ simpleBlockForging ::
 simpleBlockForging canBeLeader forgeExt = BlockForging {
       forgeLabel       = "simpleBlockForging"
     , canBeLeader      = canBeLeader
-    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Updated ()
+    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
     , checkCanForge    = \_ _ _ _ _ -> return ()
     , forgeBlock       = return .....: forgeSimple forgeExt
     }

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -78,7 +78,7 @@ simpleBlockForging ::
 simpleBlockForging canBeLeader forgeExt = BlockForging {
       forgeLabel       = "simpleBlockForging"
     , canBeLeader      = canBeLeader
-    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Unchanged ()
+    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Updated ()
     , checkCanForge    = \_ _ _ _ _ -> return ()
     , forgeBlock       = return .....: forgeSimple forgeExt
     }

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -87,7 +87,7 @@ pbftBlockForging ::
 pbftBlockForging canBeLeader = BlockForging {
       forgeLabel       = "pbftBlockForging"
     , canBeLeader
-    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Unchanged ()
+    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Updated ()
     , checkCanForge    = \cfg slot tickedPBftState _isLeader ->
                            return $
                              pbftCheckCanForge

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -87,7 +87,7 @@ pbftBlockForging ::
 pbftBlockForging canBeLeader = BlockForging {
       forgeLabel       = "pbftBlockForging"
     , canBeLeader
-    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Updated ()
+    , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
     , checkCanForge    = \cfg slot tickedPBftState _isLeader ->
                            return $
                              pbftCheckCanForge

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -100,7 +100,8 @@ praosBlockForging cid initHotKey = do
         forgeLabel       = "praosBlockForging"
       , canBeLeader      = cid
       , updateForgeState = \_ sno _ -> updateMVar varHotKey $
-                               second ForgeStateUpdateInfo . evolveKey sno
+                                 second forgeStateUpdateInfoFromUpdateInfo
+                               . evolveKey sno
       , checkCanForge    = \_ _ _ _ _ -> return ()
       , forgeBlock       = \cfg bno sno tickedLedgerSt txs isLeader -> do
                                hotKey <- readMVar varHotKey

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -491,7 +491,7 @@ instance PraosCrypto PraosStandardCrypto where
   type PraosHash PraosStandardCrypto = SHA256
 
 instance PraosCrypto PraosMockCrypto where
-  type PraosKES  PraosMockCrypto = MockKES 1000
+  type PraosKES  PraosMockCrypto = MockKES 10000
   type PraosVRF  PraosMockCrypto = MockVRF
   type PraosHash PraosMockCrypto = MD5
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -144,11 +144,11 @@ evolveKey ::
      PraosCrypto c
   => SlotNo
   -> HotKey c
-  -> (HotKey c, UpdateInfo (HotKey c) (HotKey c) HotKeyEvolutionError)
+  -> (HotKey c, UpdateInfo (HotKey c) HotKeyEvolutionError)
 evolveKey slotNo hotKey = case hotKey of
     HotKey keyPeriod oldKey
       | keyPeriod >= targetPeriod
-      -> (hotKey, Unchanged hotKey)
+      -> (hotKey, Updated hotKey)
       | otherwise
       -> case updateKES () oldKey keyPeriod of
            Nothing     ->

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -246,7 +246,6 @@ data PraosParams = PraosParams {
       praosLeaderF       :: !Double
     , praosSecurityParam :: !SecurityParam
     , praosSlotsPerEpoch :: !Word64
-    , praosLifetimeKES   :: !Natural
     }
   deriving (Generic, NoThunks)
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -167,7 +167,7 @@ shelleySharedBlockForging
           forgeLabel       = label <> "_" <> shelleyBasedEraName (Proxy @era)
         , canBeLeader      = canBeLeader
         , updateForgeState = \_ curSlot _ ->
-                                 ForgeStateUpdateInfo <$>
+                                 forgeStateUpdateInfoFromUpdateInfo <$>
                                    HotKey.evolve hotKey (slotToPeriod curSlot)
         , checkCanForge    = \cfg curSlot _tickedChainDepState ->
                                  tpraosCheckCanForge

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/HotKey.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/HotKey.hs
@@ -121,7 +121,7 @@ data KESEvolutionError =
   deriving (Show)
 
 -- | Result of evolving the KES key.
-type KESEvolutionInfo = UpdateInfo KESInfo KESInfo KESEvolutionError
+type KESEvolutionInfo = UpdateInfo KESInfo KESEvolutionError
 
 -- | API to interact with the key.
 data HotKey c m = HotKey {
@@ -212,7 +212,7 @@ mkHotKey initKey startPeriod@(Absolute.KESPeriod start) maxKESEvolutions = do
 --
 -- When the given KES period is before the start period of the 'HotKey' or
 -- when the given period is before the key's period, we don't evolve the key
--- and return 'Unchanged'.
+-- and return 'Updated'.
 --
 -- When the given KES period is within the range of the 'HotKey' and the given
 -- period is after the key's period, we evolve the key and return 'Updated'.
@@ -238,7 +238,7 @@ evolveKey varKESState targetPeriod = modifyMVar varKESState $ \kesState -> do
         -- update the key. 'checkCanForge' will say we can't forge because the
         -- key is not valid yet.
         BeforeKESStart {} ->
-            return (kesState, Unchanged info)
+            return (kesState, Updated info)
 
         -- When the absolute period is after the end period, we can't evolve
         -- anymore and poison the expired key.
@@ -249,7 +249,7 @@ evolveKey varKESState targetPeriod = modifyMVar varKESState $ \kesState -> do
         InKESRange targetEvolution
           -- No evolving needed
           | targetEvolution <= kesEvolution info
-          -> return (kesState, Unchanged info)
+          -> return (kesState, Updated info)
 
           -- Evolving needed
           | otherwise

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util/NodeTopology.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util/NodeTopology.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE DerivingVia         #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -18,7 +20,9 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
+import           Quiet (Quiet (..))
 import           Test.QuickCheck
 
 import           Ouroboros.Consensus.Node.ProtocolInfo
@@ -46,8 +50,10 @@ import           Ouroboros.Consensus.Util.Orphans ()
 -- connected components during the execution, but the base topology is
 -- connected.
 --
-newtype NodeTopology = NodeTopology (Map CoreNodeId (Set CoreNodeId))
-  deriving (Eq, Show)
+newtype NodeTopology =
+    NodeTopology {unNodeTopology :: Map CoreNodeId (Set CoreNodeId)}
+  deriving (Eq, Generic)
+  deriving (Show) via Quiet NodeTopology
 
 instance Condense NodeTopology where
   condense top@(NodeTopology m)

--- a/ouroboros-consensus-test/src/Test/Util/Slots.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Slots.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingVia   #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Test.Util.Slots (
   NumSlots (..),
@@ -7,13 +8,14 @@ module Test.Util.Slots (
 
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
 import           Quiet (Quiet (..))
 import           Test.QuickCheck (Arbitrary (..))
 import qualified Test.QuickCheck as QC
 
 -- | Number of slots
 newtype NumSlots = NumSlots {unNumSlots :: Word64}
-  deriving (Eq, Generic)
+  deriving (Eq, Generic, NoThunks)
   deriving (Show) via (Quiet NumSlots)
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -281,7 +281,7 @@ blockForgingA :: Monad m => BlockForging m BlockA
 blockForgingA = BlockForging {
      forgeLabel       = "BlockA"
    , canBeLeader      = ()
-   , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Unchanged ()
+   , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Updated ()
    , checkCanForge    = \_ _ _ _ _ -> return ()
    , forgeBlock       = return .....: forgeBlockA
    }

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -281,7 +281,7 @@ blockForgingA :: Monad m => BlockForging m BlockA
 blockForgingA = BlockForging {
      forgeLabel       = "BlockA"
    , canBeLeader      = ()
-   , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Updated ()
+   , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
    , checkCanForge    = \_ _ _ _ _ -> return ()
    , forgeBlock       = return .....: forgeBlockA
    }

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -235,7 +235,7 @@ blockForgingB :: Monad m => BlockForging m BlockB
 blockForgingB = BlockForging {
      forgeLabel       = "BlockB"
    , canBeLeader      = ()
-   , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Updated ()
+   , updateForgeState = \_ _ _ -> return $ ForgeStateUpdated ()
    , checkCanForge    = \_ _ _ _ _ -> return ()
    , forgeBlock       = return .....: forgeBlockB
    }

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -235,7 +235,7 @@ blockForgingB :: Monad m => BlockForging m BlockB
 blockForgingB = BlockForging {
      forgeLabel       = "BlockB"
    , canBeLeader      = ()
-   , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Unchanged ()
+   , updateForgeState = \_ _ _ -> return $ ForgeStateUpdateInfo $ Updated ()
    , checkCanForge    = \_ _ _ _ _ -> return ()
    , forgeBlock       = return .....: forgeBlockB
    }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -394,9 +394,6 @@ instance Isomorphic ForgeStateUpdateInfo where
         Updated forgeStateInfo ->
           Updated
             (project' (Proxy @(WrapForgeStateInfo blk)) forgeStateInfo)
-        Unchanged forgeStateInfo ->
-          Unchanged
-            (project' (Proxy @(WrapForgeStateInfo blk)) forgeStateInfo)
         UpdateFailed forgeStateUpdateError ->
           UpdateFailed
             (project' (Proxy @(WrapForgeStateUpdateError blk)) forgeStateUpdateError)
@@ -407,9 +404,6 @@ instance Isomorphic ForgeStateUpdateInfo where
       case forgeStateUpdateInfo of
         Updated forgeStateInfo ->
           Updated
-            (inject' (Proxy @(WrapForgeStateInfo blk)) forgeStateInfo)
-        Unchanged forgeStateInfo ->
-          Unchanged
             (inject' (Proxy @(WrapForgeStateInfo blk)) forgeStateInfo)
         UpdateFailed forgeStateUpdateError ->
           UpdateFailed

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -389,25 +389,27 @@ instance Isomorphic ProtocolClientInfo where
 instance Isomorphic ForgeStateUpdateInfo where
   project :: forall blk. NoHardForks blk
           => ForgeStateUpdateInfo (HardForkBlock '[blk]) -> ForgeStateUpdateInfo blk
-  project (ForgeStateUpdateInfo forgeStateUpdateInfo) = ForgeStateUpdateInfo $
+  project forgeStateUpdateInfo =
       case forgeStateUpdateInfo of
-        Updated forgeStateInfo ->
-          Updated
+        ForgeStateUpdated forgeStateInfo ->
+          ForgeStateUpdated
             (project' (Proxy @(WrapForgeStateInfo blk)) forgeStateInfo)
-        UpdateFailed forgeStateUpdateError ->
-          UpdateFailed
+        ForgeStateUpdateFailed forgeStateUpdateError ->
+          ForgeStateUpdateFailed
             (project' (Proxy @(WrapForgeStateUpdateError blk)) forgeStateUpdateError)
+        ForgeStateUpdateSuppressed -> ForgeStateUpdateSuppressed
 
   inject :: forall blk. NoHardForks blk
          => ForgeStateUpdateInfo blk -> ForgeStateUpdateInfo (HardForkBlock '[blk])
-  inject (ForgeStateUpdateInfo forgeStateUpdateInfo) = ForgeStateUpdateInfo $
+  inject forgeStateUpdateInfo =
       case forgeStateUpdateInfo of
-        Updated forgeStateInfo ->
-          Updated
+        ForgeStateUpdated forgeStateInfo ->
+          ForgeStateUpdated
             (inject' (Proxy @(WrapForgeStateInfo blk)) forgeStateInfo)
-        UpdateFailed forgeStateUpdateError ->
-          UpdateFailed
+        ForgeStateUpdateFailed forgeStateUpdateError ->
+          ForgeStateUpdateFailed
             (inject' (Proxy @(WrapForgeStateUpdateError blk)) forgeStateUpdateError)
+        ForgeStateUpdateSuppressed -> ForgeStateUpdateSuppressed
 
 instance Functor m => Isomorphic (BlockForging m) where
   project :: forall blk. NoHardForks blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
@@ -136,7 +136,6 @@ hardForkUpdateForgeState blockForging
     injectSingle forgeStateUpdateInfo = ForgeStateUpdateInfo $
         case getForgeStateUpdateInfo forgeStateUpdateInfo of
           Updated      info -> Updated      $ injInfo        index info
-          Unchanged    info -> Unchanged    $ injInfo        index info
           UpdateFailed err  -> UpdateFailed $ injUpdateError index err
       where
         index :: Index '[blk] blk
@@ -189,11 +188,10 @@ hardForkUpdateForgeState blockForging
         inj index (Comp mForgeStateUpdateInfo) =
             K $ ForgeStateUpdateInfo $
               case mForgeStateUpdateInfo of
-                Nothing -> Unchanged $ CurrentEraLacksBlockForging $ eraIndexFromIndex index
+                Nothing -> Updated $ CurrentEraLacksBlockForging $ eraIndexFromIndex index
                 Just forgeStateUpdateInfo ->
                   case getForgeStateUpdateInfo forgeStateUpdateInfo of
                     Updated      info -> Updated      $ injInfo        index info
-                    Unchanged    info -> Unchanged    $ injInfo        index info
                     UpdateFailed err  -> UpdateFailed $ injUpdateError index err
 
 -- | PRECONDITION: the ticked 'ChainDepState', the 'HardForkIsLeader', and the

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
@@ -133,10 +133,11 @@ hardForkUpdateForgeState blockForging
          xs ~ '[blk]
       => ForgeStateUpdateInfo blk
       -> ForgeStateUpdateInfo (HardForkBlock '[blk])
-    injectSingle forgeStateUpdateInfo = ForgeStateUpdateInfo $
-        case getForgeStateUpdateInfo forgeStateUpdateInfo of
-          Updated      info -> Updated      $ injInfo        index info
-          UpdateFailed err  -> UpdateFailed $ injUpdateError index err
+    injectSingle forgeStateUpdateInfo =
+        case forgeStateUpdateInfo of
+          ForgeStateUpdated      info -> ForgeStateUpdated      $ injInfo        index info
+          ForgeStateUpdateFailed err  -> ForgeStateUpdateFailed $ injUpdateError index err
+          ForgeStateUpdateSuppressed  -> ForgeStateUpdateSuppressed
       where
         index :: Index '[blk] blk
         index = IZ
@@ -186,13 +187,13 @@ hardForkUpdateForgeState blockForging
             -> (Maybe :.: ForgeStateUpdateInfo) blk
             -> K (ForgeStateUpdateInfo (HardForkBlock xs)) blk
         inj index (Comp mForgeStateUpdateInfo) =
-            K $ ForgeStateUpdateInfo $
-              case mForgeStateUpdateInfo of
-                Nothing -> Updated $ CurrentEraLacksBlockForging $ eraIndexFromIndex index
+            K $ case mForgeStateUpdateInfo of
+                Nothing -> ForgeStateUpdated $ CurrentEraLacksBlockForging $ eraIndexFromIndex index
                 Just forgeStateUpdateInfo ->
-                  case getForgeStateUpdateInfo forgeStateUpdateInfo of
-                    Updated      info -> Updated      $ injInfo        index info
-                    UpdateFailed err  -> UpdateFailed $ injUpdateError index err
+                  case forgeStateUpdateInfo of
+                    ForgeStateUpdated      info -> ForgeStateUpdated      $ injInfo        index info
+                    ForgeStateUpdateFailed err  -> ForgeStateUpdateFailed $ injUpdateError index err
+                    ForgeStateUpdateSuppressed  -> ForgeStateUpdateSuppressed
 
 -- | PRECONDITION: the ticked 'ChainDepState', the 'HardForkIsLeader', and the
 -- 'HardForkStateInfo' are all from the same era, and we must have a

--- a/ouroboros-network-framework/src/Ouroboros/Network/Mux.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Mux.hs
@@ -26,6 +26,9 @@ module Ouroboros.Network.Mux
   , MuxErrorType(..)
   , HasInitiator
   , HasResponder
+
+    -- * For Consensus ThreadNet Tests
+  , runMuxPeer
   ) where
 
 import           Control.Monad.Class.MonadAsync

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -89,6 +89,12 @@ module Ouroboros.Network.NodeToNode (
   , WithDomainName (..)
   , WithAddr (..)
   , HandshakeTr
+
+  -- * For Consensus ThreadNet Tests
+  , chainSyncMiniProtocolNum
+  , blockFetchMiniProtocolNum
+  , txSubmissionMiniProtocolNum
+  , keepAliveMiniProtocolNum
   ) where
 
 import           Control.Monad.Class.MonadST
@@ -244,22 +250,22 @@ nodeToNodeProtocols MiniProtocolParameters {
         ]
    where
     chainSyncMiniProtocol chainSyncProtocol = MiniProtocol {
-        miniProtocolNum    = MiniProtocolNum 2
+        miniProtocolNum    = chainSyncMiniProtocolNum
       , miniProtocolLimits = chainSyncProtocolLimits
       , miniProtocolRun    = chainSyncProtocol
       }
     blockFetchMiniProtocol blockFetchProtocol = MiniProtocol {
-        miniProtocolNum    = MiniProtocolNum 3
+        miniProtocolNum    = blockFetchMiniProtocolNum
       , miniProtocolLimits = blockFetchProtocolLimits
       , miniProtocolRun    = blockFetchProtocol
       }
     txSubmissionMiniProtocol txSubmissionProtocol = MiniProtocol {
-        miniProtocolNum    = MiniProtocolNum 4
+        miniProtocolNum    = txSubmissionMiniProtocolNum
       , miniProtocolLimits = txSubmissionProtocolLimits
       , miniProtocolRun    = txSubmissionProtocol
       }
     keepAliveMiniProtocol keepAliveProtocol = MiniProtocol {
-        miniProtocolNum    = MiniProtocolNum 8
+        miniProtocolNum    = keepAliveMiniProtocolNum
       , miniProtocolLimits = keepAliveProtocolLimits
       , miniProtocolRun    = keepAliveProtocol
       }
@@ -375,6 +381,18 @@ nodeToNodeProtocols MiniProtocolParameters {
           -- One small outstanding message.
           maximumIngressQueue = addSafetyMargin 1280
         }
+
+chainSyncMiniProtocolNum :: MiniProtocolNum
+chainSyncMiniProtocolNum = MiniProtocolNum 2
+
+blockFetchMiniProtocolNum :: MiniProtocolNum
+blockFetchMiniProtocolNum = MiniProtocolNum 3
+
+txSubmissionMiniProtocolNum :: MiniProtocolNum
+txSubmissionMiniProtocolNum = MiniProtocolNum 4
+
+keepAliveMiniProtocolNum :: MiniProtocolNum
+keepAliveMiniProtocolNum = MiniProtocolNum 8
 
 -- | A specialised version of @'Ouroboros.Network.Socket.connectToNode'@.
 --


### PR DESCRIPTION
This PR is the first of a few. These are relatively minor lower-level changes that I've needed for the ongoing ThreadNet rewrite. Since it's beginning to mature, I'm going to open a few PRs that contain a few of these changes.

They're easy to split off, if you'd like to review them separately. Let me know.

The main change in this set of commits is that we add the ability to _suppress_ a node's selection in a slot in the leader schedule. This is the core functionality enabling the "throttler" that prevents common prefix violations in the new ThreadNet tests despite small `k` and relatively large `f`. See `ForgeStateUpdateSuppressed`.