### PR TITLE
Preparatory changes for ThreadNet rewrite (PR number 2)

### DIFF
--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -14,6 +14,7 @@ module Control.Monad.IOSim (
   runSimTraceST,
   liftST,
   traceM,
+  traceSTM,
   -- * Simulation time
   setCurrentTime,
   unshareClock,

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -1005,6 +1005,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
                   -- see #1882, tests that can't cope with timeouts.
                   (pure $ NTN.ChainSyncTimeout
                      { canAwaitTimeout  = waitForever
+                     , intersectTimeout = waitForever
                      , mustReplyTimeout = waitForever
                      })
                   (NTN.mkHandlers nodeKernelArgs nodeKernel)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -574,6 +574,7 @@ stdChainSyncTimeout = do
     mustReplyTimeout <- Just <$> randomElem [90, 135, 180, 224, 269]
     return NTN.ChainSyncTimeout
       { canAwaitTimeout  = shortWait
+      , intersectTimeout = shortWait
       , mustReplyTimeout
       }
   where

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
@@ -56,6 +56,7 @@ byteLimitsChainSync = ProtocolSizeLimits stateToLimit
 --   (See @input-output-hk/ouroboros-network#2245@.)
 data ChainSyncTimeout = ChainSyncTimeout
   { canAwaitTimeout  :: Maybe DiffTime
+  , intersectTimeout :: Maybe DiffTime
   , mustReplyTimeout :: Maybe DiffTime
   }
 
@@ -64,7 +65,7 @@ data ChainSyncTimeout = ChainSyncTimeout
 -- > 'TokIdle'               'waitForever' (ie never times out)
 -- > 'TokNext TokCanAwait'   the given 'canAwaitTimeout'
 -- > 'TokNext TokMustReply'  the given 'mustReplyTimeout'
--- > 'TokIntersect'          'shortWait'
+-- > 'TokIntersect'          the given 'intersectTimeout'
 timeLimitsChainSync :: forall header point tip.
                        ChainSyncTimeout
                     -> ProtocolTimeLimits (ChainSync header point tip)
@@ -72,6 +73,7 @@ timeLimitsChainSync csTimeouts = ProtocolTimeLimits stateToLimit
   where
     ChainSyncTimeout
       { canAwaitTimeout
+      , intersectTimeout
       , mustReplyTimeout
       } = csTimeouts
 
@@ -80,7 +82,7 @@ timeLimitsChainSync csTimeouts = ProtocolTimeLimits stateToLimit
     stateToLimit (ClientAgency TokIdle)                = waitForever
     stateToLimit (ServerAgency (TokNext TokCanAwait))  = canAwaitTimeout
     stateToLimit (ServerAgency (TokNext TokMustReply)) = mustReplyTimeout
-    stateToLimit (ServerAgency TokIntersect)           = shortWait
+    stateToLimit (ServerAgency TokIntersect)           = intersectTimeout
 
 -- | Codec for chain sync that encodes/decodes headers
 --


### PR DESCRIPTION
This PR is the second of a few. These are relatively minor lower-level changes that I've needed for the ongoing ThreadNet rewrite. Since it's beginning to mature, I'm going to open a few PRs that contain a few of these changes.

This set of commits primary alteration is a configurable timeout for the response to ChainSync's `MsgFindIntersect` message. In the tests create large delays that are difficult to predict, so we simply suspend this timeout in the test (it is currently `shortWait` in the implementation).

We also provide some additional STM primitives that have been useful in tracing/debuging STM-based deadlocks in `io-sim`.

Lastly, there is a slightly more granular export that allows additional reuse in the rewritten ThreadNet code.