### PR TITLE
Set fill-column as emacs directory variable in ouroboros-consensus/docs

### DIFF
--- a/ouroboros-consensus/.dir-locals.el
+++ b/ouroboros-consensus/.dir-locals.el
@@ -1,0 +1,5 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((nil
+  (fill-column . 80)))


### PR DESCRIPTION
This helps ensure that at least all emacs users' paragraph wraps will be idempotent.