### PR TITLE
Use uninterruptibleCancel in JobPool

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -27,7 +27,8 @@ packages: ./typed-protocols
 constraints:
   ip < 1.5,
   hedgehog >= 1.0,
-  bimap >= 0.4.0
+  bimap >= 0.4.0,
+  ListLike < 4.7.2
 
 package Win32-network
   tests: True


### PR DESCRIPTION
JobPool is using bracket which requires that the resource finalizer is
uninterruptible.  Could this introduce a deadlock? I don't think so, only if
there already was a deadlock which forbid to deliver asynchronous exception.
This could happen either deadlock in FFI, or a tight loop which does not
allocate.

Both `async` library is using `uninterruptibleCancel` in `withAsync`
combinator, and `ouroboros-consensus` is using it as well in their more
sophisticated version of `ResourceRegistery`.

- ouroboros-network:cddl: ListLike bound
- job-pool: use uninterruptible handler in bracket
