### PR TITLE
Update `cardano-ledger-specs`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -153,8 +153,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: cf3b01490a2cc7ebbb5ac6f7a4de79e8b1d5c70f
-  --sha256: 1v15xqy0qvb7ll4080pplrq2ygqgnf443kaq5i6mj0105941mcjc
+  tag: da27cd3bc9ad4f67e361d011dc6b32a1e6849713
+  --sha256: 12w2511a5bgy65bn200k5xpycc4d2l8psdd8fkc90p29ws25z4id
   subdir:
     byron/chain/executable-spec
     byron/crypto

--- a/cabal.project
+++ b/cabal.project
@@ -153,8 +153,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: da27cd3bc9ad4f67e361d011dc6b32a1e6849713
-  --sha256: 12w2511a5bgy65bn200k5xpycc4d2l8psdd8fkc90p29ws25z4id
+  tag: 721d350cbd71dae2ddd0a6a1b57901cc1940856b
+  --sha256: 18rq4ylsm8j8l6cnacy2z84r8pqlrv0a9pqm3bbac48w4gbfyxd0
   subdir:
     byron/chain/executable-spec
     byron/crypto

--- a/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
+++ b/ouroboros-consensus-shelley-test/ouroboros-consensus-shelley-test.cabal
@@ -34,6 +34,7 @@ library
                      , cardano-prelude
                      , cardano-slotting
                      , containers        >=0.5   && <0.7
+                     , data-default-class
                      , generic-random
                      , hedgehog-quickcheck
                      , iproute

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -105,6 +105,7 @@ import qualified Test.Shelley.Spec.Ledger.Utils as SL hiding (mkKeyPair,
                      mkKeyPair', mkVRFKeyPair)
 
 import qualified Cardano.Ledger.Mary.Value as MA
+import qualified Cardano.Ledger.Shelley.Constraints as SL (makeTxOut)
 import qualified Cardano.Ledger.ShelleyMA as MA
 import qualified Cardano.Ledger.ShelleyMA.AuxiliaryData as MA
 import qualified Cardano.Ledger.ShelleyMA.Timelocks as MA
@@ -549,7 +550,7 @@ exampleNewEpochState value = SL.NewEpochState {
               _utxoState = SL.UTxOState {
                   _utxo      = SL.UTxO $ Map.fromList [
                       (SL.TxIn (SL.TxId (mkDummyHash Proxy 1)) 0,
-                       SL.TxOut addr value)
+                       SL.makeTxOut (Proxy @era) addr value)
                     ]
                 , _deposited = SL.Coin 1000
                 , _fees      = SL.Coin 1

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -37,6 +37,7 @@ module Test.Consensus.Shelley.Examples (
 
 import qualified Data.ByteString as Strict
 import           Data.Coerce (coerce)
+import           Data.Default.Class (def)
 import           Data.Functor.Identity (Identity (..))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -86,11 +87,8 @@ import qualified Shelley.Spec.Ledger.EpochBoundary as SL (BlocksMade (..),
 import qualified Shelley.Spec.Ledger.Hashing as SL (hashAnnotated)
 import qualified Shelley.Spec.Ledger.Keys as SL (asWitness, hashWithSerialiser,
                      signedKES)
-import qualified Shelley.Spec.Ledger.LedgerState as SL (emptyDPState,
-                     emptyPPUPState)
 import qualified Shelley.Spec.Ledger.PParams as SL (emptyPParams,
                      emptyPParamsUpdate)
-import qualified Shelley.Spec.Ledger.Rewards as SL (emptyNonMyopic)
 import qualified Shelley.Spec.Ledger.STS.Delegs as SL
                      (DelegsPredicateFailure (..))
 import qualified Shelley.Spec.Ledger.STS.Ledger as SL
@@ -253,7 +251,7 @@ examples value txBody auxiliaryData = Golden.Examples {
     results = labelled [
           ("LedgerTip",              SomeResult GetLedgerTip (blockPoint blk))
         , ("EpochNo",                SomeResult GetEpochNo 10)
-        , ("EmptyPParams",           SomeResult GetCurrentPParams SL.emptyPParams)
+        , ("EmptyPParams",           SomeResult GetCurrentPParams def)
         , ("ProposedPParamsUpdates", SomeResult GetProposedPParamsUpdates proposedPParamsUpdates)
         , ("StakeDistribution",      SomeResult GetStakeDistribution examplePoolDistr)
         , ("NonMyopicMemberRewards", SomeResult (GetNonMyopicMemberRewards Set.empty)
@@ -569,10 +567,10 @@ exampleNewEpochState value = SL.NewEpochState {
                     ]
                 , _deposited = SL.Coin 1000
                 , _fees      = SL.Coin 1
-                , _ppups     = SL.emptyPPUPState
+                , _ppups     = def
 
                 }
-            , _delegationState = SL.emptyDPState
+            , _delegationState = def
             }
         , esPrevPp       = SL.emptyPParams
         , esPp           = SL.emptyPParams { SL._minUTxOValue = SL.Coin 1 }
@@ -595,7 +593,7 @@ exampleNewEpochState value = SL.NewEpochState {
         }
 
     nonMyopic :: SL.NonMyopic (EraCrypto era)
-    nonMyopic = SL.emptyNonMyopic
+    nonMyopic = def
 
 exampleLedgerState ::
      forall era. ShelleyBasedEra era

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -490,12 +490,7 @@ exampleTx txBody auxiliaryData = SL.Tx txBody witnessSet (SJust auxiliaryData)
 -- TODO incomplete, this type has tons of constructors that can all change.
 -- <https://github.com/input-output-hk/ouroboros-network/issues/1896.
 exampleApplyTxErr :: ShelleyBasedEra era => ApplyTxErr (ShelleyBlock era)
-exampleApplyTxErr =
-      ApplyTxError
-    $ pure
-    $ SL.LedgerFailure
-    $ SL.DelegsFailure
-    $ SL.DelegateeNotRegisteredDELEG (mkKeyHash 1)
+exampleApplyTxErr = ApplyTxError []
 
 exampleAnnTip :: forall era. ShelleyBasedEra era => AnnTip (ShelleyBlock era)
 exampleAnnTip = AnnTip {

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/MockCrypto.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/MockCrypto.hs
@@ -63,6 +63,7 @@ type CanMock era =
   , Arbitrary (Core.AuxiliaryData era)
   , Arbitrary (Core.Script era)
   , Arbitrary (Core.TxBody era)
+  , Arbitrary (Core.TxOut era)
   , Arbitrary (Core.Value era)
   , Arbitrary (PredicateFailure (SL.UTXOW era))
   )

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -165,10 +165,14 @@ data instance LedgerState (ShelleyBlock era) = ShelleyLedgerState {
     , shelleyLedgerState      :: !(SL.NewEpochState era)
     , shelleyLedgerTransition :: !ShelleyTransition
     }
-  deriving (Generic, NoThunks)
+  deriving (Generic)
 
-deriving instance ShelleyBasedEra era => Show (LedgerState (ShelleyBlock era))
-deriving instance ShelleyBasedEra era => Eq   (LedgerState (ShelleyBlock era))
+deriving instance ShelleyBasedEra era
+  => Show (LedgerState (ShelleyBlock era))
+deriving instance ShelleyBasedEra era
+  => Eq   (LedgerState (ShelleyBlock era))
+deriving instance ShelleyBasedEra era
+  => NoThunks(LedgerState (ShelleyBlock era))
 
 -- | Information required to determine the hard fork point from Shelley to the
 -- next ledger
@@ -224,7 +228,10 @@ data instance Ticked (LedgerState (ShelleyBlock era)) = TickedShelleyLedgerState
     , tickedShelleyLedgerTransition :: !ShelleyTransition
     , tickedShelleyLedgerState      :: !(SL.NewEpochState era)
     }
-  deriving (Generic, NoThunks)
+  deriving (Generic)
+
+deriving instance ShelleyBasedEra era
+  => NoThunks (Ticked (LedgerState (ShelleyBlock era)))
 
 untickedShelleyLedgerTipPoint ::
      Ticked (LedgerState (ShelleyBlock era))

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -167,12 +167,9 @@ data instance LedgerState (ShelleyBlock era) = ShelleyLedgerState {
     }
   deriving (Generic)
 
-deriving instance ShelleyBasedEra era
-  => Show (LedgerState (ShelleyBlock era))
-deriving instance ShelleyBasedEra era
-  => Eq   (LedgerState (ShelleyBlock era))
-deriving instance ShelleyBasedEra era
-  => NoThunks(LedgerState (ShelleyBlock era))
+deriving instance ShelleyBasedEra era => Show     (LedgerState (ShelleyBlock era))
+deriving instance ShelleyBasedEra era => Eq       (LedgerState (ShelleyBlock era))
+deriving instance ShelleyBasedEra era => NoThunks (LedgerState (ShelleyBlock era))
 
 -- | Information required to determine the hard fork point from Shelley to the
 -- next ledger
@@ -231,7 +228,7 @@ data instance Ticked (LedgerState (ShelleyBlock era)) = TickedShelleyLedgerState
   deriving (Generic)
 
 deriving instance ShelleyBasedEra era
-  => NoThunks (Ticked (LedgerState (ShelleyBlock era)))
+               => NoThunks (Ticked (LedgerState (ShelleyBlock era)))
 
 untickedShelleyLedgerTipPoint ::
      Ticked (LedgerState (ShelleyBlock era))

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -66,8 +66,8 @@ import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.IOLike
 
-import           Cardano.Ledger.Val (coin, inject, (<->))
 import qualified Cardano.Ledger.Shelley.Constraints as SL (makeTxOut)
+import           Cardano.Ledger.Val (coin, inject, (<->))
 import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.LedgerState as SL (stakeDistr)
 import qualified Shelley.Spec.Ledger.OCert as Absolute (KESPeriod (..))
@@ -499,10 +499,10 @@ registerGenesisStaking staking nes = nes {
 --
 -- TODO move to @cardano-ledger-specs@.
 registerInitialFunds ::
-    forall era.
-    ( ShelleyBasedEra era
-    , HasCallStack
-    )
+     forall era.
+     ( ShelleyBasedEra era
+     , HasCallStack
+     )
   => Map (SL.Addr (EraCrypto era)) SL.Coin
   -> SL.NewEpochState era
   -> SL.NewEpochState era

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -67,6 +67,7 @@ import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.IOLike
 
 import           Cardano.Ledger.Val (coin, inject, (<->))
+import qualified Cardano.Ledger.Shelley.Constraints as SL (makeTxOut)
 import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.LedgerState as SL (stakeDistr)
 import qualified Shelley.Spec.Ledger.OCert as Absolute (KESPeriod (..))
@@ -498,7 +499,10 @@ registerGenesisStaking staking nes = nes {
 --
 -- TODO move to @cardano-ledger-specs@.
 registerInitialFunds ::
-     forall era. (ShelleyBasedEra era, HasCallStack)
+    forall era.
+    ( ShelleyBasedEra era
+    , HasCallStack
+    )
   => Map (SL.Addr (EraCrypto era)) SL.Coin
   -> SL.NewEpochState era
   -> SL.NewEpochState era
@@ -521,7 +525,7 @@ registerInitialFunds initialFunds nes = nes {
           (txIn, txOut)
         | (addr, amount) <- Map.toList initialFunds
         ,  let txIn  = SL.initialFundsPseudoTxIn addr
-               txOut = SL.TxOut addr (inject amount)
+               txOut = SL.makeTxOut (Proxy @era) addr (inject amount)
         ]
 
     utxo' = mergeUtxoNoOverlap utxo initialFundsUtxo


### PR DESCRIPTION
Most of this should be fairly straightforward, but note that we have to drop the example which manually constructs an `ApplyTxError`, since it assumed more than is allowed about the structure of the error.