### PR TITLE
Fix lint warnings

### DIFF
--- a/io-sim-classes/src/Control/Monad/Class/MonadSTM/Strict.hs
+++ b/io-sim-classes/src/Control/Monad/Class/MonadSTM/Strict.hs
@@ -22,6 +22,7 @@ module Control.Monad.Class.MonadSTM.Strict
   , newTVarIO
   , newTVarWithInvariantIO
   , readTVar
+  , readTVarIO
   , writeTVar
   , modifyTVar
   , stateTVar
@@ -122,6 +123,9 @@ newTVarWithInvariantM = newTVarWithInvariantIO
 
 readTVar :: MonadSTM m => StrictTVar m a -> STM m a
 readTVar StrictTVar { tvar } = Lazy.readTVar tvar
+
+readTVarIO :: MonadSTM m => StrictTVar m a -> m a
+readTVarIO tvar = atomically $ readTVar tvar
 
 writeTVar :: (MonadSTM m, HasCallStack) => StrictTVar m a -> a -> STM m ()
 writeTVar StrictTVar { tvar, invariant } !a =

--- a/ouroboros-consensus-test/ouroboros-consensus-test.cabal
+++ b/ouroboros-consensus-test/ouroboros-consensus-test.cabal
@@ -170,6 +170,7 @@ test-suite test-consensus
                      , quiet
                      , serialise
                      , sop-core
+                     , stm
                      , tasty
                      , tasty-hunit
                      , tasty-quickcheck

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -71,6 +71,9 @@ import           Test.Util.Orphans.IOLike ()
 import           Test.Util.TestBlock
 import           Test.Util.Tracer (recordingTracerTVar)
 
+{- HLINT ignore "Redundant $" -}
+{- HLINT ignore "Use list literal" -}
+
 {-------------------------------------------------------------------------------
   Top-level tests
 -------------------------------------------------------------------------------}
@@ -310,7 +313,7 @@ runChainSync securityParam (ClientUpdates clientUpdates)
       -- has thrown an exception or has gracefully terminated, so that at the
       -- end, we can read the chains in the states they were in when the
       -- exception was thrown.
-      stop <- fmap isJust $ atomically $ readTVar varClientResult
+      stop <- isJust <$> readTVarIO varClientResult
       unless stop $ do
         -- Client
         whenJust (Map.lookup tick clientUpdates) $ \chainUpdates ->

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -80,7 +80,7 @@ import           Test.Util.Tracer (recordingTracerTVar)
 
 tests :: TestTree
 tests = testGroup "ChainSyncClient"
-    [ testProperty "chainSync"                 $ prop_chainSync
+    [ testProperty "chainSync"                   prop_chainSync
     , testProperty "joinUpdates/spreadUpdates" $ prop_joinUpdates_spreadUpdates k
     , testProperty "genChainUpdates"           $ prop_genChainUpdates           k updatesToGenerate
     ]

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
 
 -- | Intended for qualified import
 module Ouroboros.Consensus.Network.NodeToClient (
@@ -79,6 +78,8 @@ import           Ouroboros.Consensus.Util.Orphans ()
 import           Ouroboros.Consensus.Util.ResourceRegistry
 
 import qualified Ouroboros.Consensus.Storage.ChainDB.API as ChainDB
+
+{- HLINT ignore "Reduce duplication" -}
 
 {-------------------------------------------------------------------------------
   Handlers
@@ -399,10 +400,10 @@ responder version Apps {..} =
     nodeToClientProtocols
       (\peer _shouldStopSTM -> NodeToClientProtocols {
           localChainSyncProtocol =
-            (ResponderProtocolOnly (MuxPeerRaw (aChainSyncServer peer))),
+            ResponderProtocolOnly (MuxPeerRaw (aChainSyncServer peer)),
           localTxSubmissionProtocol =
-            (ResponderProtocolOnly (MuxPeerRaw (aTxSubmissionServer peer))),
+            ResponderProtocolOnly (MuxPeerRaw (aTxSubmissionServer peer)),
           localStateQueryProtocol =
-            (ResponderProtocolOnly (MuxPeerRaw (aStateQueryServer peer)))
+            ResponderProtocolOnly (MuxPeerRaw (aStateQueryServer peer))
         })
       version

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -15,7 +15,7 @@ module Ouroboros.Consensus.Util.Orphans () where
 
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.Serialise (Serialise (..))
-import           Control.Concurrent.STM (readTVarIO)
+import qualified Control.Concurrent.STM as STM
 import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
 import           Data.IntPSQ (IntPSQ)
@@ -77,7 +77,7 @@ instance NoThunks a => NoThunks (StrictTVar IO a) where
   wNoThunks ctxt tv = do
       -- We can't use @atomically $ readTVar ..@ here, as that will lead to a
       -- "Control.Concurrent.STM.atomically was nested" exception.
-      a <- readTVarIO (toLazyTVar tv)
+      a <- STM.readTVarIO (toLazyTVar tv)
       noThunks ctxt a
 
 instance (NoThunks k, NoThunks v)

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -60,6 +60,9 @@ import           Test.QuickCheck hiding (Result)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
 
+{- HLINT ignore "Reduce duplication" -}
+{- HLINT ignore "Use camelCase" -}
+
 tests :: TestTree
 tests = testGroup "Ouroboros.Network.Protocol.ChainSyncProtocol"
   [ testProperty "direct ST" propChainSyncDirectST
@@ -139,16 +142,16 @@ chainSyncForkExperiment
   -> m Property
 chainSyncForkExperiment run (ChainProducerStateForkTest cps chain) = do
   let pchain = ChainProducerState.producerChain cps
-  cpsVar   <- atomically $ newTVar cps
-  chainVar <- atomically $ newTVar chain
-  doneVar  <- atomically $ newTVar False
+  cpsVar   <- newTVarIO cps
+  chainVar <- newTVarIO chain
+  doneVar  <- newTVarIO False
   let server = ChainSyncExamples.chainSyncServerExample
         (error "chainSyncServerExample: lazy in the result type")
         cpsVar
       client = ChainSyncExamples.chainSyncClientExample chainVar (testClient doneVar (Chain.headPoint pchain))
   _ <- run server client
 
-  cchain <- atomically $ readTVar chainVar
+  cchain <- readTVarIO chainVar
   return (pchain === cchain)
 
 propChainSyncDirectST :: ChainProducerStateForkTest -> Property
@@ -200,9 +203,9 @@ chainSyncPipelinedForkExperiment
   -> m Bool
 chainSyncPipelinedForkExperiment run mkClient (ChainProducerStateForkTest cps chain) = do
   let pchain = ChainProducerState.producerChain cps
-  cpsVar   <- atomically $ newTVar cps
-  chainVar <- atomically $ newTVar chain
-  doneVar  <- atomically $ newTVar False
+  cpsVar   <- newTVarIO cps
+  chainVar <- newTVarIO chain
+  doneVar  <- newTVarIO False
   let server = ChainSyncExamples.chainSyncServerExample
         (error "chainSyncServerExample: lazy in the result type")
         cpsVar
@@ -210,7 +213,7 @@ chainSyncPipelinedForkExperiment run mkClient (ChainProducerStateForkTest cps ch
       client = mkClient chainVar (testClient doneVar (Chain.headPoint pchain))
   _ <- run server client
 
-  cchain <- atomically $ readTVar chainVar
+  cchain <- readTVarIO chainVar
   return (pchain == cchain)
 
 --
@@ -543,9 +546,9 @@ chainSyncDemo
   -> m Property
 chainSyncDemo clientChan serverChan (ChainProducerStateForkTest cps chain) = do
   let pchain = ChainProducerState.producerChain cps
-  cpsVar   <- atomically $ newTVar cps
-  chainVar <- atomically $ newTVar chain
-  doneVar  <- atomically $ newTVar False
+  cpsVar   <- newTVarIO cps
+  chainVar <- newTVarIO chain
+  doneVar  <- newTVarIO False
 
   let server :: ChainSyncServer Block (Point Block) (Tip Block) m a
       server = ChainSyncExamples.chainSyncServerExample
@@ -562,7 +565,7 @@ chainSyncDemo clientChan serverChan (ChainProducerStateForkTest cps chain) = do
     done <- readTVar doneVar
     unless done retry
 
-  cchain <- atomically $ readTVar chainVar
+  cchain <- readTVarIO chainVar
   return (pchain === cchain)
 
 propChainSyncDemoST
@@ -611,9 +614,9 @@ chainSyncDemoPipelined
   -> m Property
 chainSyncDemoPipelined clientChan serverChan mkClient (ChainProducerStateForkTest cps chain) = do
   let pchain = ChainProducerState.producerChain cps
-  cpsVar   <- atomically $ newTVar cps
-  chainVar <- atomically $ newTVar chain
-  doneVar  <- atomically $ newTVar False
+  cpsVar   <- newTVarIO cps
+  chainVar <- newTVarIO chain
+  doneVar  <- newTVarIO False
 
   let server :: ChainSyncServer Block (Point Block) (Tip Block) m a
       server = ChainSyncExamples.chainSyncServerExample
@@ -630,7 +633,7 @@ chainSyncDemoPipelined clientChan serverChan mkClient (ChainProducerStateForkTes
     done <- readTVar doneVar
     unless done retry
 
-  cchain <- atomically $ readTVar chainVar
+  cchain <- readTVarIO chainVar
   return (pchain === cchain)
 
 propChainSyncDemoPipelinedMaxST

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/BlockFetch/Server.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+
 module Ouroboros.Network.Protocol.BlockFetch.Server where
 
 import Network.TypedProtocol.Core
@@ -55,7 +57,7 @@ blockFetchServerPeer
   => BlockFetchServer block point m a
   -> Peer (BlockFetch block point) AsServer BFIdle m a
 blockFetchServerPeer (BlockFetchServer requestHandler result) =
-    Await (ClientAgency TokIdle) $ \msg -> case msg of
+    Await (ClientAgency TokIdle) $ \case
       MsgRequestRange range -> Effect $ sendBatch <$> requestHandler range
       MsgClientDone         -> Done TokDone result
  where

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Inbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Inbound.hs
@@ -322,7 +322,7 @@ txSubmissionInbound _tracer maxUnacked mpReader mpWriter _version =
             -- This will happen incase of duplicate txids within the same window.
             live = filter (`elem` unacknowledgedTxIds') $ toList acknowledgedTxIds
             bufferedTxs3 = forceElemsToWHNF $ bufferedTxs2 <>
-                               (Map.fromList (zip live (repeat Nothing)))
+                               Map.fromList (zip live (repeat Nothing))
 
 
         _writtenTxids <- mempoolAddTxs txsReady
@@ -368,7 +368,7 @@ txSubmissionInbound _tracer maxUnacked mpReader mpWriter _version =
 
         availableTxidsU =
               Map.filterWithKey
-                (\txid _ -> notElem txid (unacknowledgedTxIds st))
+                (\txid _ -> txid `notElem` unacknowledgedTxIds st)
                 txidsMap
 
         availableTxids' = availableTxids st <> Map.intersection availableTxidsMp availableTxidsU
@@ -395,7 +395,7 @@ txSubmissionInbound _tracer maxUnacked mpReader mpWriter _version =
         -- If so we can remove acknowledged txs from our buffer provided that they
         -- are not still in unacknowledgedTxIds''. This happens in case of duplicate
         -- txids.
-        bufferedTxs'' = forceElemsToWHNF $ foldl' (\m txid -> if elem txid unacknowledgedTxIds''
+        bufferedTxs'' = forceElemsToWHNF $ foldl' (\m txid -> if txid `elem` unacknowledgedTxIds''
                                               then m
                                               else Map.delete txid m)
                                 bufferedTxs' acknowledgedTxIds

--- a/ouroboros-network/test/Test/Mux.hs
+++ b/ouroboros-network/test/Test/Mux.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 
 {-# OPTIONS_GHC -Wno-orphans            #-}
@@ -102,9 +101,9 @@ demo chain0 updates delay = do
     let sduLen = 1280
     let server_w = client_r
         server_r = client_w
-    producerVar <- atomically $ newTVar (CPS.initChainProducerState chain0)
-    consumerVar <- atomically $ newTVar chain0
-    done <- atomically newEmptyTMVar
+    producerVar <- newTVarIO (CPS.initChainProducerState chain0)
+    consumerVar <- newTVarIO chain0
+    done <- newEmptyTMVarIO
 
     let Just expectedChain = Chain.applyChainUpdates updates chain0
         target = Chain.headPoint expectedChain

--- a/ouroboros-network/test/Test/Pipe.hs
+++ b/ouroboros-network/test/Test/Pipe.hs
@@ -150,9 +150,9 @@ demo chain0 updates = do
         let chan1 = Mx.pipeChannelFromHandles hndRead1 hndWrite2
             chan2 = Mx.pipeChannelFromHandles hndRead2 hndWrite1
 #endif
-        producerVar <- atomically $ newTVar (CPS.initChainProducerState chain0)
-        consumerVar <- atomically $ newTVar chain0
-        done <- atomically newEmptyTMVar
+        producerVar <- newTVarIO (CPS.initChainProducerState chain0)
+        consumerVar <- newTVarIO chain0
+        done <- newEmptyTMVarIO
 
         let Just expectedChain = Chain.applyChainUpdates updates chain0
             target = Chain.headPoint expectedChain

--- a/ouroboros-network/test/Test/Socket.hs
+++ b/ouroboros-network/test/Test/Socket.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeFamilies        #-}
 
 {-# OPTIONS_GHC -Wno-orphans     #-}
@@ -113,7 +112,7 @@ demo chain0 updates = withIOManager $ \iocp -> do
 
     producerVar <- newTVarIO (CPS.initChainProducerState chain0)
     consumerVar <- newTVarIO chain0
-    done <- atomically newEmptyTMVar
+    done <- newEmptyTMVarIO
     networkState <- newNetworkMutableState
 
     let Just expectedChain = Chain.applyChainUpdates updates chain0


### PR DESCRIPTION
Everything in here is either fixing lint warnings or suppressing them, except for one useful addition which is a new `readTVarIO` function.

One alternate proposal is to add an `hlint.yaml` config to suppress all the lint warnings and not do any lint fixes, which helps me get around the problem where my IDE is flagging a lot of warnings which interferes with reading of the tooltips showing inferred types of expressions.