### PR TITLE
Allow to acquire tip by LocalStateQuery protocol client.

### DIFF
--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -111,4 +111,4 @@ versionedProtocols codecConfig networkMagic callback =
       versionedNodeToClientProtocols
         version
         (NodeToClientVersionData networkMagic)
-        (callback version (clientCodecs codecConfig blockVersion))
+        (callback version (clientCodecs codecConfig blockVersion version))

--- a/io-sim/src/Control/Monad/IOSim/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSim/Internal.hs
@@ -59,7 +59,7 @@ import           Data.Typeable (Typeable)
 import           Quiet (Quiet (..))
 import           GHC.Generics (Generic)
 
-import           Control.Applicative (Alternative (..))
+import           Control.Applicative (Alternative (..), liftA2)
 import           Control.Exception (ErrorCall (..), assert,
                      asyncExceptionFromException, asyncExceptionToException)
 import           Control.Monad (MonadPlus, join)
@@ -195,6 +195,16 @@ instance Monad (IOSim s) where
     fail = Fail.fail
 #endif
 
+instance Semigroup a => Semigroup (IOSim s a) where
+    (<>) = liftA2 (<>)
+
+instance Monoid a => Monoid (IOSim s a) where
+    mempty = pure mempty
+
+#if !(MIN_VERSION_base(4,11,0))
+    mappend = liftA2 mappend
+#endif
+
 instance Fail.MonadFail (IOSim s) where
   fail msg = IOSim $ \_ -> Throw (toException (IO.Error.userError msg))
 
@@ -235,7 +245,6 @@ instance Alternative (STM s) where
     (<|>) = orElse
 
 instance MonadPlus (STM s) where
-
 
 instance MonadSay (IOSim s) where
   say msg = IOSim $ \k -> Say msg (k ())

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -330,6 +330,7 @@ instance CardanoHardForkConstraints c
       , (NodeToClientV_5, CardanoNodeToClientVersion4)
       , (NodeToClientV_6, CardanoNodeToClientVersion5)
       , (NodeToClientV_7, CardanoNodeToClientVersion6)
+      , (NodeToClientV_8, CardanoNodeToClientVersion6)
       ]
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -120,6 +120,7 @@ mkHandlers NodeKernelArgs {cfg, tracers} NodeKernel {getChainDB, getMempool} =
       , hStateQueryServer =
           localStateQueryServer
             (ExtLedgerCfg cfg)
+            (ChainDB.getTipPoint getChainDB)
             (ChainDB.getPastLedger getChainDB)
             (castPoint . AF.anchorPoint <$> ChainDB.getCurrentChain getChainDB)
       }
@@ -165,8 +166,9 @@ defaultCodecs :: forall m blk.
                  )
               => CodecConfig blk
               -> BlockNodeToClientVersion blk
+              -> N.NodeToClientVersion
               -> DefaultCodecs blk m
-defaultCodecs ccfg version = Codecs {
+defaultCodecs ccfg version networkVersion = Codecs {
       cChainSyncCodec =
         codecChainSync
           enc
@@ -185,6 +187,7 @@ defaultCodecs ccfg version = Codecs {
 
     , cStateQueryCodec =
         codecLocalStateQuery
+          (networkVersion >= NodeToClientV_8)
           (encodePoint (encodeRawHash p))
           (decodePoint (decodeRawHash p))
           (enc . SomeSecond)
@@ -212,8 +215,9 @@ clientCodecs :: forall m blk.
                 )
              => CodecConfig blk
              -> BlockNodeToClientVersion blk
+             -> N.NodeToClientVersion
              -> ClientCodecs blk m
-clientCodecs ccfg version = Codecs {
+clientCodecs ccfg version networkVersion = Codecs {
       cChainSyncCodec =
         codecChainSync
           enc
@@ -232,6 +236,7 @@ clientCodecs ccfg version = Codecs {
 
     , cStateQueryCodec =
         codecLocalStateQuery
+          (networkVersion >= NodeToClientV_8)
           (encodePoint (encodeRawHash p))
           (decodePoint (decodeRawHash p))
           (enc . SomeSecond)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -326,11 +326,12 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
       :: NodeKernelArgs m (ConnectionId addrNTN) (ConnectionId addrNTC) blk
       -> NodeKernel     m (ConnectionId addrNTN) (ConnectionId addrNTC) blk
       -> BlockNodeToClientVersion blk
+      -> NodeToClientVersion
       -> NTC.Apps m (ConnectionId addrNTC) ByteString ByteString ByteString ()
-    mkNodeToClientApps nodeKernelArgs nodeKernel version =
+    mkNodeToClientApps nodeKernelArgs nodeKernel blockVersion networkVersion =
         NTC.mkApps
           rnTraceNTC
-          (NTC.defaultCodecs codecConfig version)
+          (NTC.defaultCodecs codecConfig blockVersion networkVersion)
           (NTC.mkHandlers nodeKernelArgs nodeKernel)
 
     mkDiffusionApplications
@@ -339,6 +340,7 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
           -> NTN.Apps m (ConnectionId addrNTN) ByteString ByteString ByteString ByteString ByteString ()
          )
       -> (   BlockNodeToClientVersion blk
+          -> NodeToClientVersion
           -> NTC.Apps m (ConnectionId addrNTC) ByteString ByteString ByteString ()
          )
       -> NodeKernel m (ConnectionId addrNTN) (ConnectionId addrNTC) blk
@@ -366,7 +368,7 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
               simpleSingletonVersions
                 version
                 llrnVersionDataNTC
-                (NTC.responder version $ ntcApps blockVersion)
+                (NTC.responder version $ ntcApps blockVersion version)
             | (version, blockVersion) <- Map.toList llrnNodeToClientVersions
             ]
         , daErrorPolicies = consensusErrorPolicy (Proxy @blk)

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -37,6 +37,8 @@ data NodeToClientVersion
     -- ^ enabled @CardanoNodeToClientVersion5@, i.e., Mary
     | NodeToClientV_7
     -- ^ enabled @CardanoNodeToClientVersion6@, adding a query
+    | NodeToClientV_8
+    -- ^ 'LocalStateQuery' protocol codec change, allows to acquire tip point.
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 
 -- | We set 16ths bit to distinguish `NodeToNodeVersion` and
@@ -56,6 +58,7 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
       encodeTerm NodeToClientV_5 = CBOR.TInt (5 `setBit` nodeToClientVersionBit)
       encodeTerm NodeToClientV_6 = CBOR.TInt (6 `setBit` nodeToClientVersionBit)
       encodeTerm NodeToClientV_7 = CBOR.TInt (7 `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_8 = CBOR.TInt (8 `setBit` nodeToClientVersionBit)
 
       decodeTerm (CBOR.TInt tag) =
        case ( tag `clearBit` nodeToClientVersionBit
@@ -68,6 +71,7 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
         (5, True)  -> Right NodeToClientV_5
         (6, True)  -> Right NodeToClientV_6
         (7, True)  -> Right NodeToClientV_7
+        (8, True)  -> Right NodeToClientV_8
         (n, _)     -> Left ( T.pack "decode NodeToClientVersion: unknown tag: " <> T.pack (show tag)
                             , Just n)
       decodeTerm _  = Left ( T.pack "decode NodeToClientVersion: unexpected term"

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Client.hs
@@ -52,7 +52,7 @@ localStateQueryClientNull =
 --  * a termination messge
 --
 data ClientStIdle block point query (m :: Type -> Type) a where
-  SendMsgAcquire :: point
+  SendMsgAcquire :: Maybe point
                  -> ClientStAcquiring block point query m a
                  -> ClientStIdle      block point query m a
 
@@ -85,7 +85,7 @@ data ClientStAcquired block point query m a where
                    -> ClientStQuerying block point query m a result
                    -> ClientStAcquired block point query m a
 
-  SendMsgReAcquire :: point
+  SendMsgReAcquire :: Maybe point
                    -> ClientStAcquiring block point query m a
                    -> ClientStAcquired  block point query m a
 
@@ -123,7 +123,7 @@ mapLocalStateQueryClient fpoint fquery fresult =
     goIdle :: ClientStIdle block  point  query  m a
            -> ClientStIdle block' point' query' m a
     goIdle (SendMsgAcquire pt k) =
-      SendMsgAcquire (fpoint pt) (goAcquiring k)
+      SendMsgAcquire (fpoint <$> pt) (goAcquiring k)
 
     goIdle (SendMsgDone a) = SendMsgDone a
 
@@ -139,7 +139,7 @@ mapLocalStateQueryClient fpoint fquery fresult =
                -> ClientStAcquired block' point' query' m a
     goAcquired (SendMsgQuery     q  k) = case fquery q of
                                            Some q' -> SendMsgQuery q' (goQuerying q q' k)
-    goAcquired (SendMsgReAcquire pt k) = SendMsgReAcquire (fpoint pt) (goAcquiring k)
+    goAcquired (SendMsgReAcquire pt k) = SendMsgReAcquire (fpoint <$> pt) (goAcquiring k)
     goAcquired (SendMsgRelease      k) = SendMsgRelease (fmap goIdle k)
 
     goQuerying :: forall result result'.

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Server.hs
@@ -36,7 +36,7 @@ newtype LocalStateQueryServer block point (query :: Type -> Type) m a = LocalSta
 -- It must be prepared to handle either.
 --
 data ServerStIdle block point query m a = ServerStIdle {
-       recvMsgAcquire :: point
+       recvMsgAcquire :: Maybe point
                       -> m (ServerStAcquiring block point query m a),
 
        recvMsgDone    :: m a
@@ -70,7 +70,7 @@ data ServerStAcquired block point query m a = ServerStAcquired {
                           query result
                        -> m (ServerStQuerying  block point query m a result),
 
-      recvMsgReAcquire :: point
+      recvMsgReAcquire :: Maybe point
                        -> m (ServerStAcquiring block point query m a),
 
       recvMsgRelease   :: m (ServerStIdle      block point query m a)

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Type.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/LocalStateQuery/Type.hs
@@ -80,8 +80,12 @@ instance Protocol (LocalStateQuery block point query) where
     -- the server's chain (within K of the tip) be made available to query,
     -- and waits for confirmation or failure.
     --
+    -- From 'NodeToClient_V8' onwards if the point is not specified, current tip
+    -- will be acquired.  For previous versions of the protocol 'point' must be
+    -- given.
+    --
     MsgAcquire
-      :: point
+      :: Maybe point
       -> Message (LocalStateQuery block point query) StIdle StAcquiring
 
     -- | The server can confirm that it has the state at the requested point.
@@ -125,8 +129,12 @@ instance Protocol (LocalStateQuery block point query) where
     -- Note that failure to re-acquire is equivalent to 'MsgRelease',
     -- rather than keeping the exiting acquired state.
     --
+    -- From 'NodeToClient_V8' onwards if the point is not specified, current tip
+    -- will be acquired.  For previous versions of the protocol 'point' must be
+    -- given.
+    --
     MsgReAcquire
-      :: point
+      :: Maybe point
       -> Message (LocalStateQuery block point query) StAcquired StAcquiring
 
     -- | The client can terminate the protocol.

--- a/ouroboros-network/test/Main.hs
+++ b/ouroboros-network/test/Main.hs
@@ -21,6 +21,7 @@ import qualified Ouroboros.Network.Protocol.BlockFetch.Test (tests)
 import qualified Ouroboros.Network.Protocol.Handshake.Test (tests)
 import qualified Ouroboros.Network.Protocol.TxSubmission.Test (tests)
 import qualified Ouroboros.Network.Protocol.TxSubmission2.Test (tests)
+import qualified Ouroboros.Network.Protocol.LocalStateQuery.Test (tests)
 import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Test (tests)
 import qualified Ouroboros.Network.Protocol.KeepAlive.Test (tests)
 import qualified Ouroboros.Network.Protocol.TipSample.Test (tests)
@@ -43,6 +44,7 @@ tests =
     -- protocols
   , Ouroboros.Network.Protocol.ChainSync.Test.tests
   , Ouroboros.Network.Protocol.BlockFetch.Test.tests
+  , Ouroboros.Network.Protocol.LocalStateQuery.Test.tests
   , Ouroboros.Network.Protocol.LocalTxSubmission.Test.tests
   , Ouroboros.Network.Protocol.TxSubmission.Test.tests
   , Ouroboros.Network.Protocol.TxSubmission2.Test.tests


### PR DESCRIPTION
* Change mini-protocol description
* Redefine codec, add a test which ensures that the new version of the codec is compatible with the previous one.
* Updated consensus, including the server.
* Added new supported version in `ouroboros-consensus-cardano`
As a bonus:
* `instance Monoid a => Monoid (IOSim s a)`