### PR TITLE
DNS subscription refactor for A/AAAA lookup

### DIFF
--- a/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Dns.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Dns.hs
@@ -140,8 +140,8 @@ dnsResolve tracer getSeed withResolverFn peerStatesVar beforeConnect (DnsSubscri
     handleResult :: StrictTMVar m [Socket.SockAddr]
                  -> StrictTMVar m [Socket.SockAddr]
                  -> Either
-                      (Either SomeException (Maybe DNS.DNSError))
-                      (Either SomeException (Maybe DNS.DNSError))
+                      (Either SomeException ())
+                      (Either SomeException ())
                  -> m (SubscriptionTarget m Socket.SockAddr)
 
     handleResult _ ipv4Rsps (Left (Left e_ipv6)) = do
@@ -223,32 +223,29 @@ dnsResolve tracer getSeed withResolverFn peerStatesVar beforeConnect (DnsSubscri
 
     resolveAAAA :: Resolver m
                 -> StrictTMVar m [Socket.SockAddr]
-                -> m (Maybe DNS.DNSError)
+                -> m ()
     resolveAAAA resolver rspsVar = do
         r_e <- lookupAAAA resolver domain
         case r_e of
              Left e  -> do
                  atomically $ putTMVar rspsVar []
                  traceWith tracer $ DnsTraceLookupAAAAError e
-                 return $ Just e
              Right r -> do
                  traceWith tracer $ DnsTraceLookupAAAAResult r
 
                  -- XXX Addresses should be sorted here based on DeltaQueue.
                  atomically $ putTMVar rspsVar r
-                 return Nothing
 
     resolveA :: Resolver m
-             -> Async m (Maybe DNS.DNSError)
+             -> Async m ()
              -> StrictTMVar m [Socket.SockAddr]
-             -> m (Maybe DNS.DNSError)
+             -> m ()
     resolveA resolver aid_ipv6 rspsVar= do
         r_e <- lookupA resolver domain
         case r_e of
              Left e  -> do
                  atomically $ putTMVar rspsVar []
                  traceWith tracer $ DnsTraceLookupAError e
-                 return $ Just e
              Right r -> do
                  traceWith tracer $ DnsTraceLookupAResult r
 
@@ -265,7 +262,6 @@ dnsResolve tracer getSeed withResolverFn peerStatesVar beforeConnect (DnsSubscri
 
                  -- XXX Addresses should be sorted here based on DeltaQueue.
                  atomically $ putTMVar rspsVar r
-                 return Nothing
 
 
 dnsSubscriptionWorker'

--- a/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Dns.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Subscription/Dns.hs
@@ -187,9 +187,13 @@ dnsResolve tracer getSeed withResolverFn peerStatesVar beforeConnect (DnsSubscri
       :: [Socket.SockAddr]
       -> [Socket.SockAddr]
       -> m (Maybe (Socket.SockAddr, SubscriptionTarget m Socket.SockAddr))
-    targetCycle [] [] = return Nothing
-    targetCycle [] ipvB = targetCycle ipvB []
-    targetCycle (addr : addrs) ipvB = targetCons addr $ targetCycle ipvB addrs
+    targetCycle as bs = go (as `interleave` bs)
+      where
+        go []       = return Nothing
+        go (x : xs) = targetCons x (go xs)
+
+        interleave []       ys = ys
+        interleave (x : xs) ys = x : interleave ys xs
 
     resolveAAAA :: Resolver m
                 -> m [Socket.SockAddr]


### PR DESCRIPTION
While looking into that code I noticed that I could be improved a bit. This includes:
- Removing the need for any extra `TMVar`'s and `TVar`'s
- Previously only exceptions for the first thread to finish were caught and logged. Now exceptions for both threads are caught
- Simplify the code for more readability

Other than all thread exceptions now being caught, this is only a refactoring without any functional change. To convince myself of the correctness of this change, I split the changes into smallish commits, which should relatively easily be verifiable for equivalence.