### PR TITLE
Disable all hlint rules

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,152 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Warnings currently triggered by your code
+- ignore: {name: "Unused LANGUAGE pragma"}
+- ignore: {name: "Redundant lambda"}
+- ignore: {name: "Use forM_"}
+- ignore: {name: "Use newtype instead of data"}
+- ignore: {name: "Redundant bracket"}
+- ignore: {name: "Reduce duplication"}
+- ignore: {name: "Avoid lambda"}
+- ignore: {name: "Redundant $"}
+- ignore: {name: "Use print"}
+- ignore: {name: "Use fewer imports"}
+- ignore: {name: "Use record patterns"}
+- ignore: {name: "Use const"}
+- ignore: {name: "Eta reduce"}
+- ignore: {name: "Use lambda-case"}
+- ignore: {name: "Use =<<"}
+- ignore: {name: "Redundant $!"}
+- ignore: {name: "Use readTVarIO"}
+- ignore: {name: "Use Just"}
+- ignore: {name: "Use catMaybes"}
+- ignore: {name: "Fuse foldr/map"}
+- ignore: {name: "Move brackets to avoid $"}
+- ignore: {name: "Use replicateM"}
+- ignore: {name: "Use newTVarIO"}
+- ignore: {name: "Use newTMVarIO"}
+- ignore: {name: "Use newEmptyTMVarIO"}
+- ignore: {name: "Replace case with maybe"}
+- ignore: {name: "Use fmap"}
+- ignore: {name: "Use bracket_"}
+- ignore: {name: "Use handle"}
+- ignore: {name: "Use handleJust"}
+- ignore: {name: "Use unless"}
+- ignore: {name: "Use <&>"}
+- ignore: {name: "Use <$>"}
+- ignore: {name: "Use list literal pattern"}
+- ignore: {name: "Use zipWith"}
+- ignore: {name: "Use all"}
+- ignore: {name: "Use foldr"}
+- ignore: {name: "Redundant fromInteger"}
+- ignore: {name: "Use list comprehension"}
+- ignore: {name: "Use camelCase"}
+- ignore: {name: "Evaluate"}
+- ignore: {name: "Use ++"}
+- ignore: {name: "Use second"}
+- ignore: {name: "Use join"}
+- ignore: {name: "Avoid lambda using `infix`"}
+- ignore: {name: "Use >=>"}
+- ignore: {name: "Redundant bang pattern"}
+- ignore: {name: "Use uncurry"}
+- ignore: {name: "Use list literal"}
+- ignore: {name: "Redundant return"}
+- ignore: {name: "Redundant <$>"}
+- ignore: {name: "Move guards forward"}
+- ignore: {name: "Replace case with fromMaybe"}
+- ignore: {name: "Use mapMaybe"}
+- ignore: {name: "Use tuple-section"}
+- ignore: {name: "Move map inside list comprehension"}
+- ignore: {name: "Use :"}
+- ignore: {name: "Use map once"}
+- ignore: {name: "Use unwords"}
+- ignore: {name: "Use gets"}
+- ignore: {name: "Use when"}
+- ignore: {name: "Use <$"}
+- ignore: {name: "Redundant fmap"}
+- ignore: {name: "Use &&"}
+- ignore: {name: "Use find"}
+- ignore: {name: "Move flip"}
+- ignore: {name: "Use section"}
+- ignore: {name: "Functor law"}
+- ignore: {name: "Use /="}
+- ignore: {name: "Use init"}
+- ignore: {name: "Use void"}
+- ignore: {name: "Use and"}
+- ignore: {name: "Redundant =="}
+- ignore: {name: "Use notElem"}
+- ignore: {name: "Use $"}
+- ignore: {name: "Use isNothing"}
+- ignore: {name: "Redundant if"}
+- ignore: {name: "Use first"}
+- ignore: {name: "Use infix"}
+- ignore: {name: "Hoist not"}
+- ignore: {name: "Use isSuffixOf"}
+- ignore: {name: "Use lambda"}
+- ignore: {name: "Use if"}
+- ignore: {name: "Use maybe"}
+- ignore: {name: "Use null"}
+- ignore: {name: "Use isJust"}
+- ignore: {name: "Use any"}
+- ignore: {name: "Use bimap"}
+- ignore: {name: "Use fewer LANGUAGE pragmas"}
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml


### PR DESCRIPTION
This is file was produced by running:

```
hlint . --ignore-glob='dist-newstyle/**' --default > .hlint.yaml
```

This PR does not enable `hlint` on the project nor create the expectation that any developer should start linting.

This is an alternative approach to avoid needing to something like in https://github.com/input-output-hk/ouroboros-network/pull/2873

It is only for the benefit for developers who have a `hlint` installed in their IDE to suppress all the warnings so as not to interfere with useful type tooltip functionality.

To confirm that all the rules have been disabled, run

```
hlint . --ignore-glob='dist-newstyle/**'
```

and check that it only prints `No hints`.  If the output is shows any lint warnings, the `.hlint.yaml` file can be recreated as above.

If/when the `ouroboros-network` project wishes to start using `hlint`, that would *separately* involve adding an `hlint` check to CI and then editing the this config file to re-enable the rules that make sense for this project.
