### PR TITLE
Change package descriptions so that we don't run tests of your external deps

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -101,7 +101,7 @@ package cardano-crypto-class
 package cardano-crypto-wrapper
   tests: False
 
-package cardano-prelude
+package cardano-prelude-test
   tests: False
 
 package contra-tracer
@@ -113,7 +113,22 @@ package byron-spec-chain
 package byron-spec-ledger
   tests: False
 
+package cardano-ledger
+  tests: False
+
+package cardano-ledger-shelley-ma-test
+  tests: False
+
+package cardano-ledger-test
+  tests: False
+
 package goblins
+  tests: False
+
+package shelley-spec-ledger-test
+  tests: False
+
+package shelley-spec-non-integral
   tests: False
 
 package small-steps


### PR DESCRIPTION
Currently, when running `cabal test all` we are running also tests of
our external dependencies. This commit modifies this behavior, tests
of our dependencies will be ignored.
This is unfortunately manual work - newly added dependencies will have to
adjust to this approach. Rumor has it that latest cabal fixes it, thus
if one day we will switch to cabal-3.4.0.0 why might get rid of all
those entries.