### PR TITLE
Update to latest cardano-ledger-spec.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -168,8 +168,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 721d350cbd71dae2ddd0a6a1b57901cc1940856b
-  --sha256: 18rq4ylsm8j8l6cnacy2z84r8pqlrv0a9pqm3bbac48w4gbfyxd0
+  tag: 0d0f001ec627a963fbc2cbe65273468fdb0f6b75
+  --sha256: 0aww7ls090gvsss0lq3dg95hzffblzmkhdv0x0nnz9d70srn3052
   subdir:
     byron/chain/executable-spec
     byron/crypto

--- a/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
+++ b/ouroboros-consensus-cardano-test/ouroboros-consensus-cardano-test.cabal
@@ -51,6 +51,7 @@ library
 
                      , shelley-spec-ledger
                      , shelley-spec-ledger-test
+                     , small-steps
 
                      , ouroboros-network
                      , ouroboros-consensus
@@ -126,4 +127,3 @@ test-suite test
                        -fno-ignore-asserts
                        -threaded
                        -rtsopts
-

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -43,7 +43,9 @@ import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
 import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
 import qualified Ouroboros.Consensus.HardFork.History as History
 
+import qualified Cardano.Ledger.Core as LC
 import qualified Cardano.Ledger.Era as SL
+import           Control.State.Transition (State)
 import qualified Shelley.Spec.Ledger.API as SL
 
 import           Ouroboros.Consensus.Shelley.Eras
@@ -130,11 +132,17 @@ type ShelleyBasedHardForkConstraints era1 era2 =
   , SL.TranslationContext era2 ~ ()
   )
 
-instance ShelleyBasedHardForkConstraints era1 era2
+instance ( ShelleyBasedHardForkConstraints era1 era2
+         , State (LC.EraRule "PPUP" era1) ~ SL.PPUPState era1
+         , State (LC.EraRule "PPUP" era2) ~ SL.PPUPState era2
+         )
       => SerialiseHFC (ShelleyBasedHardForkEras era1 era2)
    -- use defaults
 
-instance ShelleyBasedHardForkConstraints era1 era2
+instance ( ShelleyBasedHardForkConstraints era1 era2
+         , State (LC.EraRule "PPUP" era1) ~ SL.PPUPState era1
+         , State (LC.EraRule "PPUP" era2) ~ SL.PPUPState era2
+         )
       => CanHardFork (ShelleyBasedHardForkEras era1 era2) where
   hardForkEraTranslation = EraTranslation {
         translateLedgerState   = PCons translateLedgerState                PNil
@@ -171,7 +179,10 @@ instance ShelleyBasedHardForkConstraints era1 era2
       translateTx =
           fmap unComp . eitherToMaybe . runExcept . SL.translateEra () . Comp
 
-instance ShelleyBasedHardForkConstraints era1 era2
+instance ( ShelleyBasedHardForkConstraints era1 era2
+         , State (LC.EraRule "PPUP" era1) ~ SL.PPUPState era1
+         , State (LC.EraRule "PPUP" era2) ~ SL.PPUPState era2
+         )
       => SupportedNetworkProtocolVersion (ShelleyBasedHardForkBlock era1 era2) where
   supportedNodeToNodeVersions _ = Map.fromList $
       [ (maxBound, ShelleyBasedHardForkNodeToNodeVersion1)
@@ -186,7 +197,12 @@ instance ShelleyBasedHardForkConstraints era1 era2
 -------------------------------------------------------------------------------}
 
 protocolInfoShelleyBasedHardFork ::
-     forall m era1 era2. (IOLike m, ShelleyBasedHardForkConstraints era1 era2)
+     forall m era1 era2.
+     ( IOLike m
+     , ShelleyBasedHardForkConstraints era1 era2
+     , State (LC.EraRule "PPUP" era1) ~ SL.PPUPState era1
+     , State (LC.EraRule "PPUP" era2) ~ SL.PPUPState era2
+     )
   => ProtocolParamsShelleyBased era1
   -> SL.ProtVer
   -> SL.ProtVer
@@ -272,6 +288,8 @@ protocolInfoShelleyBasedHardFork protocolParamsShelleyBased
 instance ( TxGen (ShelleyBlock era1)
          , TxGen (ShelleyBlock era2)
          , ShelleyBasedHardForkConstraints era1 era2
+         , State (LC.EraRule "PPUP" era1) ~ SL.PPUPState era1
+         , State (LC.EraRule "PPUP" era2) ~ SL.PPUPState era2
          ) => TxGen (ShelleyBasedHardForkBlock era1 era2) where
   type TxGenExtra (ShelleyBasedHardForkBlock era1 era2) =
     NP WrapTxGenExtra (ShelleyBasedHardForkEras era1 era2)

--- a/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
+++ b/ouroboros-consensus-cardano/ouroboros-consensus-cardano.cabal
@@ -51,6 +51,7 @@ library
                      , cardano-prelude
                      , cardano-slotting
                      , shelley-spec-ledger
+                     , small-steps
                      , cardano-ledger-shelley-ma
 
                      , ouroboros-network

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -72,9 +72,11 @@ import           Ouroboros.Consensus.Shelley.Node ()
 import           Ouroboros.Consensus.Shelley.Protocol
 
 import           Cardano.Ledger.Allegra.Translation ()
+import qualified Cardano.Ledger.Core as LC
 import           Cardano.Ledger.Crypto (ADDRHASH, DSIGN, HASH)
 import qualified Cardano.Ledger.Era as SL
 import           Cardano.Ledger.Mary.Translation ()
+import           Control.State.Transition (State)
 import qualified Shelley.Spec.Ledger.API as SL
 
 import           Ouroboros.Consensus.Cardano.Block
@@ -202,8 +204,8 @@ byronTransition ByronPartialLedgerConfig{..} shelleyMajorVersion state =
 -------------------------------------------------------------------------------}
 
 shelleyTransition ::
-     forall era.
-     PartialLedgerConfig (ShelleyBlock era)
+     forall era. State (LC.EraRule "PPUP" era) ~ SL.PPUPState era
+  => PartialLedgerConfig (ShelleyBlock era)
   -> Word16   -- ^ Next era's major protocol version
   -> LedgerState (ShelleyBlock era)
   -> Maybe EpochNo
@@ -298,7 +300,8 @@ instance HasPartialLedgerConfig ByronBlock where
   SingleEraBlock Shelley
 -------------------------------------------------------------------------------}
 
-instance ShelleyBasedEra era => SingleEraBlock (ShelleyBlock era) where
+instance (ShelleyBasedEra era, State (LC.EraRule "PPUP" era) ~ SL.PPUPState era)
+   => SingleEraBlock (ShelleyBlock era) where
   singleEraTransition pcfg _eraParams _eraStart ledgerState =
       case shelleyTriggerHardFork pcfg of
         TriggerHardForkNever                         -> Nothing

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -72,7 +72,9 @@ import qualified Ouroboros.Consensus.Byron.Ledger.Conversions as Byron
 import           Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
 import           Ouroboros.Consensus.Byron.Node
 
+import qualified Cardano.Ledger.Core as LC
 import qualified Cardano.Ledger.Era as SL
+import           Control.State.Transition (State)
 import           Ouroboros.Consensus.Shelley.Ledger (ShelleyBlock)
 import qualified Ouroboros.Consensus.Shelley.Ledger as Shelley
 import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
@@ -90,7 +92,8 @@ import           Ouroboros.Consensus.Cardano.ShelleyBased
 -------------------------------------------------------------------------------}
 
 instance SerialiseConstraintsHFC ByronBlock
-instance ShelleyBasedEra era => SerialiseConstraintsHFC (ShelleyBlock era)
+instance (ShelleyBasedEra era, State (LC.EraRule "PPUP" era) ~ SL.PPUPState era)
+  => SerialiseConstraintsHFC (ShelleyBlock era)
 
 -- | Important: we need to maintain binary compatibility with Byron blocks, as
 -- they are already stored on disk.

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/MockCrypto.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/MockCrypto.hs
@@ -20,7 +20,7 @@ import           Cardano.Crypto.KES (MockKES)
 
 import qualified Cardano.Ledger.Core as Core
 import           Cardano.Ledger.Crypto (Crypto (..))
-import           Control.State.Transition.Extended (PredicateFailure)
+import           Control.State.Transition.Extended (PredicateFailure, State)
 import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.Tx as SL (ValidateScript)
 
@@ -66,4 +66,5 @@ type CanMock era =
   , Arbitrary (Core.TxOut era)
   , Arbitrary (Core.Value era)
   , Arbitrary (PredicateFailure (SL.UTXOW era))
+  , Arbitrary (State (Core.EraRule "PPUP" era))
   )

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
@@ -27,6 +27,8 @@ import           Ouroboros.Consensus.Ledger.Inspect
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.Condense
 
+import qualified Cardano.Ledger.Core as LC
+import           Control.State.Transition (State)
 import qualified Shelley.Spec.Ledger.API as SL
 import           Shelley.Spec.Ledger.BaseTypes (strictMaybeToMaybe)
 import qualified Shelley.Spec.Ledger.PParams as SL (PParamsUpdate)
@@ -96,8 +98,8 @@ data UpdateState c = UpdateState {
   deriving (Show, Eq)
 
 protocolUpdates ::
-       forall era.
-       SL.ShelleyGenesis era
+       forall era. (State (LC.EraRule "PPUP" era) ~ SL.PPUPState era)
+    => SL.ShelleyGenesis era
     -> LedgerState (ShelleyBlock era)
     -> [ProtocolUpdate era]
 protocolUpdates genesis st = [
@@ -155,7 +157,8 @@ data ShelleyLedgerUpdate era =
 instance Condense (ShelleyLedgerUpdate era) where
   condense = show
 
-instance InspectLedger (ShelleyBlock era) where
+instance State (LC.EraRule "PPUP" era) ~ SL.PPUPState era
+  => InspectLedger (ShelleyBlock era) where
   type LedgerWarning (ShelleyBlock era) = Void
   type LedgerUpdate  (ShelleyBlock era) = ShelleyLedgerUpdate era
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -66,8 +66,10 @@ import           Ouroboros.Consensus.Storage.ImmutableDB (simpleChunkInfo)
 import           Ouroboros.Consensus.Util.Assert
 import           Ouroboros.Consensus.Util.IOLike
 
+import qualified Cardano.Ledger.Core as LC
 import qualified Cardano.Ledger.Shelley.Constraints as SL (makeTxOut)
 import           Cardano.Ledger.Val (coin, inject, (<->))
+import           Control.State.Transition (State)
 import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.LedgerState as SL (stakeDistr)
 import qualified Shelley.Spec.Ledger.OCert as Absolute (KESPeriod (..))
@@ -254,7 +256,11 @@ protocolInfoShelley protocolParamsShelleyBased
     protocolInfoShelleyBased protocolParamsShelleyBased protVer
 
 protocolInfoShelleyBased ::
-     forall m era. (IOLike m, ShelleyBasedEra era)
+     forall m era.
+     ( IOLike m
+     , ShelleyBasedEra era
+     , State (LC.EraRule "PPUP" era) ~ SL.PPUPState era
+     )
   => ProtocolParamsShelleyBased era
   -> SL.ProtVer
   -> ProtocolInfo m (ShelleyBlock era)
@@ -404,7 +410,8 @@ instance ShelleyBasedEra era => NodeInitStorage (ShelleyBlock era) where
   RunNode instance
 -------------------------------------------------------------------------------}
 
-instance ShelleyBasedEra era => RunNode (ShelleyBlock era)
+instance (ShelleyBasedEra era, State (LC.EraRule "PPUP" era) ~ SL.PPUPState era)
+  => RunNode (ShelleyBlock era)
 
 {-------------------------------------------------------------------------------
   Register genesis staking


### PR DESCRIPTION
This is something of a slapdash patch. Crucially, the latest changes in
the ledger are to support the generalisation of the update system for
privilege, and this means that the state of the update system will
change. At the moment, consensus drills deep into the update state to
work out when to execute a hard fork.

This PR locks down the update state to the Shelley update state. The
correct solution will be to work out exactly what consensus needs to
know and add an additional class to the API which provides this.