### PR TITLE
Fix QueryAnytimeMary

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
@@ -545,7 +545,7 @@ pattern QueryAnytimeAllegra q = QueryAnytime q (EraIndex (S (S (Z (K ())))))
 pattern QueryAnytimeMary
   :: QueryAnytime result
   -> CardanoQuery c result
-pattern QueryAnytimeMary q = QueryAnytime q (EraIndex (S (S (Z (K ())))))
+pattern QueryAnytimeMary q = QueryAnytime q (EraIndex (S (S (S (Z (K ()))))))
 
 {-# COMPLETE QueryIfCurrentByron
            , QueryIfCurrentShelley


### PR DESCRIPTION
Before this fix, QueryAnytimeMary had the same implementation as
QueryAnytimeAllegra. It should presumably have an extra `S`.

### Context
@piotr-iohk noticed that the wallet's reporting of Mary-hard-fork-dates were wrong.

Running GetEraStart for all eras on mainnet we get
```
Byron: Right (Just (Bound {boundTime = RelativeTime 0s, boundSlot = SlotNo 0, boundEpoch = EpochNo 0}))
Shelley: Right (Just (Bound {boundTime = RelativeTime 89856000s, boundSlot = SlotNo 4492800, boundEpoch = EpochNo 208}))
Allegra: Right (Just (Bound {boundTime = RelativeTime 101952000s, boundSlot = SlotNo 16588800, boundEpoch = EpochNo 236}))
Mary: Right (Just (Bound {boundTime = RelativeTime 101952000s, boundSlot = SlotNo 16588800, boundEpoch = EpochNo 236}))
```
which is weird as the Mary fork here is the same as Allegra, instead of Nothing.

Haven't built or tested this. CI should tell though.