### PR TITLE
Update to latest cardano-ledger-spec

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -168,8 +168,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 721d350cbd71dae2ddd0a6a1b57901cc1940856b
-  --sha256: 18rq4ylsm8j8l6cnacy2z84r8pqlrv0a9pqm3bbac48w4gbfyxd0
+  tag: 0d0f001ec627a963fbc2cbe65273468fdb0f6b75
+  --sha256: 0aww7ls090gvsss0lq3dg95hzffblzmkhdv0x0nnz9d70srn3052
   subdir:
     byron/chain/executable-spec
     byron/crypto

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -202,8 +202,8 @@ byronTransition ByronPartialLedgerConfig{..} shelleyMajorVersion state =
 -------------------------------------------------------------------------------}
 
 shelleyTransition ::
-     forall era.
-     PartialLedgerConfig (ShelleyBlock era)
+     forall era. ShelleyBasedEra era
+  => PartialLedgerConfig (ShelleyBlock era)
   -> Word16   -- ^ Next era's major protocol version
   -> LedgerState (ShelleyBlock era)
   -> Maybe EpochNo

--- a/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
+++ b/ouroboros-consensus-shelley/ouroboros-consensus-shelley.cabal
@@ -55,6 +55,7 @@ library
                      , cardano-slotting
                      , cborg             >=0.2.2 && <0.3
                      , containers        >=0.5   && <0.7
+                     , data-default-class
                      , mtl               >=2.2   && <2.3
                      , nothunks
                      , serialise         >=0.2   && <0.3

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
@@ -96,8 +96,8 @@ data UpdateState c = UpdateState {
   deriving (Show, Eq)
 
 protocolUpdates ::
-       forall era.
-       SL.ShelleyGenesis era
+       forall era. ShelleyBasedEra era
+    => SL.ShelleyGenesis era
     -> LedgerState (ShelleyBlock era)
     -> [ProtocolUpdate era]
 protocolUpdates genesis st = [
@@ -155,7 +155,7 @@ data ShelleyLedgerUpdate era =
 instance Condense (ShelleyLedgerUpdate era) where
   condense = show
 
-instance InspectLedger (ShelleyBlock era) where
+instance ShelleyBasedEra era => InspectLedger (ShelleyBlock era) where
   type LedgerWarning (ShelleyBlock era) = Void
   type LedgerUpdate  (ShelleyBlock era) = ShelleyLedgerUpdate era
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -333,7 +333,9 @@ querySupportedVersion = \case
   Auxiliary
 -------------------------------------------------------------------------------}
 
-getProposedPPUpdates :: SL.NewEpochState era -> SL.ProposedPPUpdates era
+getProposedPPUpdates ::
+     ShelleyBasedEra era
+  => SL.NewEpochState era -> SL.ProposedPPUpdates era
 getProposedPPUpdates = SL.proposals . SL._ppups
                      . SL._utxoState . SL.esLState . SL.nesEs
 


### PR DESCRIPTION
This is something of a slapdash patch. Crucially, the latest changes in
the ledger are to support the generalisation of the update system for
privilege, and this means that the state of the update system will
change. At the moment, consensus drills deep into the update state to
work out when to execute a hard fork.

This PR locks down the update state to the Shelley update state. The
correct solution will be to work out exactly what consensus needs to
know and add an additional class to the API which provides this.

Replaces #2888