### PR TITLE
NodeToClient ChainSync with block metadata

### DIFF
--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -332,6 +332,7 @@ instance CardanoHardForkConstraints c
       , (NodeToClientV_6, CardanoNodeToClientVersion5)
       , (NodeToClientV_7, CardanoNodeToClientVersion6)
       , (NodeToClientV_8, CardanoNodeToClientVersion6)
+      , (NodeToClientV_9, CardanoNodeToClientVersion6)
       ]
 
   latestReleasedNodeVersion = latestReleasedNodeVersionDefault

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -104,6 +104,7 @@ library
                        Ouroboros.Consensus.HardFork.History.Caching
                        Ouroboros.Consensus.HardFork.History.EpochInfo
                        Ouroboros.Consensus.HardFork.History.EraParams
+                       Ouroboros.Consensus.HardFork.History.Follower
                        Ouroboros.Consensus.HardFork.History.Qry
                        Ouroboros.Consensus.HardFork.History.Summary
                        Ouroboros.Consensus.HardFork.History.Util

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
@@ -161,7 +161,7 @@ getCurrentSlot' :: forall m xs. IOLike m
                 -> m (CurrentSlot, RelativeTime, NominalDiffTime)
 getCurrentSlot' tracer SystemTime{..} run getBackoffDelay = do
     now   <- systemTimeCurrent
-    mSlot <- atomically $ HF.cachedRunQuery run $ HF.wallclockToSlot now
+    mSlot <- fst <$> (atomically $ HF.cachedRunQuery run $ HF.wallclockToSlot now)
     case mSlot of
       Left ex -> do
         -- give up for now and backoff; see 'BackoffDelay'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Follower.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Follower.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Consensus.HardFork.History.Follower (
+    -- * API
+    HistoryFollower (..)
+  , WithInterpreter (..)
+  , WithInterDefault
+  , mkWithInterpreter
+  , newHistoryFollower
+    -- * Client
+  , ClientHistoryFollower (..)
+  , WithInterClient
+  , newClientFollower
+  ) where
+
+import           Control.Monad.Class.MonadSTM.Strict hiding (newTVarIO)
+import           Data.Either (isRight)
+import           Data.SOP.Strict
+
+import           Ouroboros.Consensus.HardFork.Abstract
+import           Ouroboros.Consensus.HardFork.Combinator.Basics
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger ()
+import qualified Ouroboros.Consensus.HardFork.History as History
+import           Ouroboros.Consensus.HardFork.History.Qry
+import           Ouroboros.Consensus.Ledger.Basics
+import           Ouroboros.Consensus.Ledger.Extended
+import           Ouroboros.Consensus.Storage.ChainDB
+import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util.IOLike
+
+import           Ouroboros.Network.Block
+import           Ouroboros.Network.Point
+
+
+-- | The 'HistoryFollower' can be used to extend the 'Follower' with metadata
+-- which come from the ledger state. Currently this metadata is a History
+-- 'Interpreter' but it's technically possible to generalise this.
+--
+-- In the same way that a 'Follower' keeps track of the tip of a user, the
+-- 'HistoryFollower' keeps track and mirrors the Interpreter that a user has.
+-- Everytime a new 'Interpreter' is created and returned to the user, it is also
+-- cached. The api returns 'Nothing' when the cached 'Interpreter' is capable
+-- of serving the specified point, so the user doesn't need a new one.
+--
+newtype HistoryFollower m blk = HistoryFollower {
+      getInterpreter :: Point blk -> STM m (Maybe (Interpreter (HardForkIndices blk)))
+    }
+
+data WithInterpreter blk b = WithInterpreter {
+      payload     :: b
+    , interpreter :: Maybe (Interpreter (HardForkIndices blk))
+    } deriving Show
+
+type WithInterDefault blk = WithInterpreter blk (Serialised blk)
+
+mkWithInterpreter ::
+     b
+  -> Maybe (Interpreter (HardForkIndices blk))
+  -> WithInterpreter blk b
+mkWithInterpreter b mInter = WithInterpreter {
+      payload     = b
+    , interpreter = mInter
+    }
+
+instance (ShowProxy blk, ShowProxy b) => ShowProxy (WithInterpreter blk b) where
+    showProxy _ = mconcat [
+        "WithInterpreter "
+      , showProxy (Proxy :: Proxy blk)
+      , " "
+      , showProxy (Proxy :: Proxy b)
+      ]
+
+{-------------------------------------------------------------------------------
+  Implementation
+-------------------------------------------------------------------------------}
+
+newHistoryFollower ::
+     forall blk m.
+     ( IOLike m
+     , HasHardForkHistory blk
+     , IsLedger (LedgerState blk)
+     )
+  => LedgerConfig blk
+  -> ChainDB m blk
+  -> m (HistoryFollower m blk)
+newHistoryFollower cfg chainDB = do
+    varState <- newTVarIO Nothing
+    return $ HistoryFollower {
+        getInterpreter =
+          getInterpreterImpl cfg (ledgerState <$> getCurrentLedger chainDB) varState
+      }
+
+getInterpreterImpl ::
+     (IOLike m, HasHardForkHistory blk)
+  => LedgerConfig blk
+  -> STM m (LedgerState blk)
+  -> StrictTVar m (Maybe (Interpreter (HardForkIndices blk)))
+  -> Point blk
+  -> STM m (Maybe (Interpreter (HardForkIndices blk)))
+getInterpreterImpl cfg getState varInterpreter point = do
+    minter <- readTVar varInterpreter
+    case (minter, pointSlot point) of
+      (Just inter, At slot) | isSlotInHorizon slot inter -> return Nothing
+      _ -> do
+        st <- getState
+        let inter = History.mkInterpreter $ hardForkSummary cfg st
+        writeTVar varInterpreter $ Just inter
+        return $ Just inter
+
+-- | Run a sanity query to check if the slot is still in the Horizon.
+isSlotInHorizon :: SlotNo -> Interpreter xs -> Bool
+isSlotInHorizon slotNo inter = isRight $ interpretQuery inter query
+  where
+    query = (,) <$> slotToWallclock slotNo <*> slotToEpoch' slotNo
+
+{-------------------------------------------------------------------------------
+  Client History Follower
+-------------------------------------------------------------------------------}
+
+-- | This can be used by a client. Given a 'WithInterClient',
+-- 'getInterpreter' is the best effort to retrieve an 'Interpreter'.
+newtype ClientHistoryFollower m blk = ClientHistoryFollower {
+      getInterpreterClient :: WithInterClient blk
+                           -> STM m (Maybe (Interpreter (HardForkIndices blk)))
+    }
+
+newClientFollower :: MonadSTM m => m (ClientHistoryFollower m blk)
+newClientFollower = do
+    mInter <- newTVarIO Nothing
+    return $ ClientHistoryFollower $ getInterClientImpl mInter
+
+getInterClientImpl ::
+     MonadSTM m
+  => StrictTVar m (Maybe (Interpreter (HardForkIndices blk)))
+  -> WithInterClient blk
+  -> STM m (Maybe (Interpreter (HardForkIndices blk)))
+getInterClientImpl interVar withInter =
+    case interpreter withInter of
+      Just inter -> do
+        writeTVar interVar (Just inter)
+        return $ Just inter
+      Nothing -> do
+        mInter <- readTVar interVar
+        return mInter
+
+type WithInterClient blk = WithInterpreter blk blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Qry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Qry.hs
@@ -408,7 +408,7 @@ runQueryPure q = either throw id . runQuery q
 --
 -- The 'Summary' should be considered internal.
 newtype Interpreter xs = Interpreter (Summary xs)
-  deriving (Eq)
+  deriving (Eq, NoThunks)
 
 deriving instance SListI xs => Serialise (Interpreter xs)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts        #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 
 -- | Infrastructure required to run a node
 --
@@ -16,6 +17,8 @@ module Ouroboros.Consensus.Node.Run (
     -- * RunNode
   , RunNode
   ) where
+
+import           Data.SOP (SListI)
 
 import           Ouroboros.Network.Block (Serialised)
 
@@ -99,6 +102,7 @@ class ( LedgerSupportsProtocol           blk
       , ShowProxy                (Header blk)
       , ShowProxy                 (Query blk)
       , ShowProxy           (TxId (GenTx blk))
+      , SListI          (HardForkIndices blk)
       ) => RunNode blk
   -- This class is intentionally empty. It is not necessarily compositional - ie
   -- the instance for 'HardForkBlock' might do more than merely delegate to the

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -39,6 +39,8 @@ data NodeToClientVersion
     -- ^ enabled @CardanoNodeToClientVersion6@, adding a query
     | NodeToClientV_8
     -- ^ 'LocalStateQuery' protocol codec change, allows to acquire tip point.
+    | NodeToClientV_9
+    -- ^ 'ChainSync' protocol change, sends additional metadata with each block.
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 
 -- | We set 16ths bit to distinguish `NodeToNodeVersion` and
@@ -59,6 +61,7 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
       encodeTerm NodeToClientV_6 = CBOR.TInt (6 `setBit` nodeToClientVersionBit)
       encodeTerm NodeToClientV_7 = CBOR.TInt (7 `setBit` nodeToClientVersionBit)
       encodeTerm NodeToClientV_8 = CBOR.TInt (8 `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_9 = CBOR.TInt (9 `setBit` nodeToClientVersionBit)
 
       decodeTerm (CBOR.TInt tag) =
        case ( tag `clearBit` nodeToClientVersionBit
@@ -72,6 +75,7 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
         (6, True)  -> Right NodeToClientV_6
         (7, True)  -> Right NodeToClientV_7
         (8, True)  -> Right NodeToClientV_8
+        (9, True)  -> Right NodeToClientV_9
         (n, _)     -> Left ( T.pack "decode NodeToClientVersion: unknown tag: " <> T.pack (show tag)
                             , Just n)
       decodeTerm _  = Left ( T.pack "decode NodeToClientVersion: unexpected term"

--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Server.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/Server.hs
@@ -92,8 +92,8 @@ data ServerStIntersect header point tip m a where
 -- | Interpret a 'ChainSyncServer' action sequence as a 'Peer' on the server
 -- side of the 'ChainSyncProtocol'.
 --
-chainSyncServerPeer
-  :: forall header point tip m a.
+chainSyncServerPeer ::
+     forall header point tip m a.
      Monad m
   => ChainSyncServer header point tip m a
   -> Peer (ChainSync header point tip) AsServer StIdle m a


### PR DESCRIPTION
This extends the NodeToClient protocol with extra metadata (an Interpreter) for slot to time conversions. This is meant to simplify db-sync (also maybe the wallet), since it will no longer need to retrieve time metadata from the LocalStateQuery.

The server keeps track of the latest Interpreter that was sent to the client and only sends a new one, when the current slot is outside the horizon. So it doesn't need to send an Interpreter with every block, but only when it is necessary.

There are some things I could improve:
- I didn't extend the `ShelleyNodeToClientVersion`, only the `NodeToClientVersion`. Probably I should do both?
- I more and more think that the HistoryFollower that I introduce, should actually be part of the Follower. There could be a dedicated BlockComponent to retrieve the metadata. This could reduce race conditions, between reading a block and reading from LedgerDB.
- The client code could become easier to use.

