### PR TITLE
Export ProcessedTxCount

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Inbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Inbound.hs
@@ -13,6 +13,7 @@ module Ouroboros.Network.TxSubmission.Inbound (
     TxSubmissionMempoolWriter(..),
     TraceTxSubmissionInbound(..),
     TxSubmissionProtocolError(..),
+    ProcessedTxCount(..),
   ) where
 
 import           Data.Foldable (foldl', toList)


### PR DESCRIPTION
This is needed for `cardano-node` to unpack the two counters.