### PR TITLE
Changes to support p2p

### DIFF
--- a/network-mux/src/Network/Mux.hs
+++ b/network-mux/src/Network/Mux.hs
@@ -30,6 +30,10 @@ module Network.Mux (
     , StartOnDemandOrEagerly (..)
     , stopMux
 
+     -- * Monitoring
+    , miniProtocolStateMap
+    , muxStopped
+
       -- * Errors
     , MuxError (..)
     , MuxErrorType (..)
@@ -71,6 +75,21 @@ data Mux (mode :: MuxMode) m =
        muxControlCmdQueue :: !(TQueue m (ControlCmd mode m)),
        muxStatus          :: StrictTVar m MuxStatus
      }
+
+
+miniProtocolStateMap :: Mux mode m -> Map (MiniProtocolNum, MiniProtocolDir)
+                                          (StrictTVar m MiniProtocolStatus)
+miniProtocolStateMap = fmap miniProtocolStatusVar . muxMiniProtocols
+
+-- | Await until mux stopped.
+--
+muxStopped :: MonadSTM m => Mux mode m -> STM m (Maybe SomeException)
+muxStopped Mux { muxStatus } =
+    readTVar muxStatus >>= \status -> case status of
+      MuxReady      -> retry
+      MuxFailed err -> return (Just err)
+      MuxStopped    -> return Nothing
+
 
 data MuxStatus = MuxReady | MuxFailed SomeException | MuxStopped
 

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -320,6 +320,7 @@ instance CardanoHardForkConstraints c
       , (NodeToNodeV_3, CardanoNodeToNodeVersion2)
       , (NodeToNodeV_4, CardanoNodeToNodeVersion3)
       , (NodeToNodeV_5, CardanoNodeToNodeVersion4)
+      , (NodeToNodeV_6, CardanoNodeToNodeVersion4)
       ]
 
   supportedNodeToClientVersions _ = Map.fromList $

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -55,7 +55,7 @@ library
                        Ouroboros.Network.Subscription.Subscriber
                        Ouroboros.Network.Subscription.Worker
 
-  -- other-modules:
+  other-modules:       Ouroboros.Network.Linger
   -- other-extensions:
   build-depends:       base            >=4.12  && <4.15
                      , async           >=2.1   && <2.3

--- a/ouroboros-network-framework/src/Ouroboros/Network/Linger.hsc
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Linger.hsc
@@ -1,0 +1,50 @@
+#include "HsNet.h"
+
+module Ouroboros.Network.Linger
+  ( StructLinger (..)
+  , reset
+  ) where
+
+import           Control.Monad (when)
+
+import           Foreign.C (CInt)
+import           Foreign.Storable (Storable (..))
+
+import           Network.Socket (Socket)
+import qualified Network.Socket as Socket
+
+
+data StructLinger = StructLinger {
+    -- | Set the linger option on.
+    sl_onoff  :: CInt,
+
+    -- | Linger timeout.
+    sl_linger :: CInt
+  }
+  deriving (Eq, Ord, Show)
+
+instance Storable StructLinger where
+    sizeOf    _ = (#const sizeof(struct linger))
+    alignment _ = alignment (0 :: CInt)
+
+    peek p = do
+        onoff  <- (#peek struct linger, l_onoff) p
+        linger <- (#peek struct linger, l_linger) p
+        return $ StructLinger onoff linger
+
+    poke p (StructLinger onoff linger) = do
+        (#poke struct linger, l_onoff)  p onoff
+        (#poke struct linger, l_linger) p linger
+
+
+-- | Reset a TCP connection, by setting 'RST' header on a 'TCP' @FIN@ packet
+-- when closing a socket.
+--
+reset :: Socket -> IO ()
+reset sock = do
+    when (Socket.isSupportedSocketOption Socket.Linger) $
+      Socket.setSockOpt sock
+                        Socket.Linger
+                        (StructLinger { sl_onoff  = 1,
+                                        sl_linger = 0 })
+    Socket.close sock

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
@@ -10,6 +10,9 @@ module Ouroboros.Network.Protocol.Handshake
   , runHandshakeServer
   , HandshakeArguments (..)
   , HandshakeException (..)
+  , HandshakeClientProtocolError (..)
+  , RefuseReason (..)
+  , Accept (..)
   ) where
 
 import           Control.Monad.Class.MonadAsync

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Unversioned.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Unversioned.hs
@@ -67,7 +67,7 @@ unversionedProtocol = simpleSingletonVersions UnversionedProtocol UnversionedPro
 -- | 'Handshake' codec used in various tests.
 --
 unversionedHandshakeCodec :: MonadST m
-                           => Codec (Handshake UnversionedProtocol CBOR.Term)
+                          => Codec (Handshake UnversionedProtocol CBOR.Term)
                                     CBOR.DeserialiseFailure m ByteString
 unversionedHandshakeCodec = codecHandshake unversionedProtocolCodec
   where

--- a/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
@@ -41,7 +41,6 @@ import           Network.Socket ( Family (AF_UNIX) )
 import           Network.Socket ( Socket
                                 , SockAddr (..)
                                 )
-import qualified Network.Socket as Socket
 #if defined(mingw32_HOST_OS)
 import           Data.Bits
 import           Foreign.Ptr (IntPtr (..), ptrToIntPtr)
@@ -51,6 +50,7 @@ import qualified System.Win32.Async      as Win32.Async
 
 import           Network.Mux.Bearer.NamedPipe (namedPipeAsBearer)
 #endif
+import qualified Network.Socket as Socket
 
 import           Network.Mux.Types (MuxBearer)
 import           Network.Mux.Trace (MuxTrace)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -248,13 +248,13 @@ connectToNode' sn handshakeCodec versionDataCodec NetworkConnectTracers {nctMuxT
       runHandshakeClient
         (Snocket.toBearer sn sduHandshakeTimeout muxTracer sd)
         connectionId
-        acceptVersion
         -- TODO: push 'HandshakeArguments' up the call stack.
         HandshakeArguments {
           haHandshakeTracer  = nctHandshakeTracer,
           haHandshakeCodec   = handshakeCodec,
           haVersionDataCodec = versionDataCodec,
-          haVersions         = versions
+          haVersions         = versions,
+          haAcceptVersion    = acceptVersion
         }
     ts_end <- getMonotonicTime
     case app_e of
@@ -368,12 +368,12 @@ beginConnection sn muxTracer handshakeTracer handshakeCodec versionDataCodec acc
           runHandshakeServer
             (Snocket.toBearer sn sduHandshakeTimeout muxTracer' sd)
             connectionId
-            acceptVersion
             HandshakeArguments {
               haHandshakeTracer  = handshakeTracer,
               haHandshakeCodec   = handshakeCodec,
               haVersionDataCodec = versionDataCodec,
-              haVersions         = versions
+              haVersions         = versions,
+              haAcceptVersion    = acceptVersion
             }
 
         case app_e of

--- a/ouroboros-network-framework/test/Main.hs
+++ b/ouroboros-network-framework/test/Main.hs
@@ -14,7 +14,7 @@ main = defaultMain tests
 
 tests :: TestTree
 tests =
-  testGroup "typed-protocols"
+  testGroup "ouroboros-network-framework"
   [ PingPong.tests
   , ReqResp.tests
   , Driver.tests

--- a/ouroboros-network-testing/ouroboros-network-testing.cabal
+++ b/ouroboros-network-testing/ouroboros-network-testing.cabal
@@ -25,6 +25,7 @@ library
   exposed-modules:
                        Ouroboros.Network.Testing.Serialise
                        Ouroboros.Network.Testing.QuickCheck
+                       Ouroboros.Network.Testing.Utils
   default-language:    Haskell2010
   other-extensions:    BangPatterns,
                        DataKinds,
@@ -49,7 +50,9 @@ library
                        TypeFamilies,
                        TypeInType
   build-depends:       base              >=4.9 && <4.15,
+                       contra-tracer,
                        io-sim,
+                       io-sim-classes,
 
                        cborg             >=0.2.1 && <0.3,
                        serialise         >=0.2 && <0.3,

--- a/ouroboros-network-testing/src/Ouroboros/Network/Testing/Utils.hs
+++ b/ouroboros-network-testing/src/Ouroboros/Network/Testing/Utils.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Test.Ouroboros.Network.Utils where
+module Ouroboros.Network.Testing.Utils where
 
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadSay
@@ -35,3 +35,4 @@ debugTracer = Tracer traceShowM
 
 sayTracer :: ( Show a, MonadSay m) => Tracer m a
 sayTracer = Tracer (say . show)
+

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -257,7 +257,6 @@ test-suite test
                        Test.AnchoredFragment
                        Test.Chain
                        Test.LedgerPeers
-                       Test.Ouroboros.Network.Utils
                        Test.Ouroboros.Network.BlockFetch
                        Test.Ouroboros.Network.KeepAlive
                        Test.Ouroboros.Network.MockNode
@@ -389,3 +388,5 @@ executable demo-chain-sync
   ghc-options:         -Wall
                        -threaded
                        -rtsopts
+
+

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -45,7 +45,7 @@ import           Ouroboros.Network.Mux (ControlMessage (..), continueForever)
 import           Ouroboros.Network.Protocol.BlockFetch.Type (BlockFetch)
 import           Ouroboros.Network.Testing.ConcreteBlock
 
-import           Test.Ouroboros.Network.Utils
+import           Ouroboros.Network.Testing.Utils
 
 
 --

--- a/ouroboros-network/test/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/TxSubmission.hs
@@ -54,7 +54,7 @@ import           Ouroboros.Network.TxSubmission.Inbound
 import           Ouroboros.Network.TxSubmission.Outbound
 import           Ouroboros.Network.NodeToNode (NodeToNodeVersion (..))
 
-import           Test.Ouroboros.Network.Utils
+import           Ouroboros.Network.Testing.Utils
 
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)


### PR DESCRIPTION
Changes from `p2p-master` branch which can make into `master`.

- handshake: add exports
- Unversioned - align code
- Renamed entry test group name of `ouroboros-network-framework` package.
- handshake: added accept version function to HandshakeArguments
- network-mux: miniProtocolStateMap & muxStopped
- Move testing utils module to ourboros-network-testing
- SO_LINGER with interval set to 0
- ~Snocket.Accept~
- Enable `NodeToNodeV_6`: `TxSubmission2`
