### PR TITLE
Add support for a response time tracer

### DIFF
--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -359,7 +359,7 @@ runChainSync securityParam (ClientUpdates clientUpdates)
                Map.insert serverId varCandidate
              (result, _) <-
                runPipelinedPeer protocolTracer codecChainSyncId clientChannel $
-                 chainSyncClientPeerPipelined $ client varCandidate
+                 chainSyncClientPeerPipelined nullTracer $ client varCandidate
              atomically $ writeTVar varClientResult (Just (Right result))
              return ()
         `catch` \(ex :: ChainSyncClientException) -> do

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -471,6 +471,7 @@ mkApps kernel Tracers {..} Codecs {..} genChainSyncTimeout Handlers {..} =
             (getNodeCandidates kernel)
             them $ \varCandidate -> do
               chainSyncTimeout <- genChainSyncTimeout
+              reqRspTr <- peerReqRspTracer (Node.chainSyncReqRspTracer (getTracers kernel)) them
               (_, trailing) <-
                 runPipelinedPeerWithLimits
                   (contramap (TraceLabelPeer them) tChainSyncTracer)
@@ -478,7 +479,7 @@ mkApps kernel Tracers {..} Codecs {..} genChainSyncTimeout Handlers {..} =
                   (byteLimitsChainSync (const 0)) -- TODO: Real Bytelimits, see #1727
                   (timeLimitsChainSync chainSyncTimeout)
                   channel
-                  $ chainSyncClientPeerPipelined
+                  $ chainSyncClientPeerPipelined reqRspTr
                   $ hChainSyncClient version controlMessageSTM varCandidate
               return ((), trailing)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -23,6 +23,8 @@ import           Data.Time (UTCTime)
 import           Ouroboros.Network.BlockFetch (FetchDecision,
                      TraceFetchClientState, TraceLabelPeer)
 import           Ouroboros.Network.KeepAlive (TraceKeepAliveClient)
+import           Ouroboros.Network.Protocol.ChainSync.ClientPipelined
+                     (TraceChainSyncClientReqRsp)
 import           Ouroboros.Network.TxSubmission.Inbound
                      (TraceTxSubmissionInbound)
 import           Ouroboros.Network.TxSubmission.Outbound
@@ -50,6 +52,7 @@ import           Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
 
 data Tracers' remotePeer localPeer blk f = Tracers
   { chainSyncClientTracer         :: f (TraceChainSyncClientEvent blk)
+  , chainSyncReqRspTracer         :: f (TraceChainSyncClientReqRsp remotePeer)
   , chainSyncServerHeaderTracer   :: f (TraceChainSyncServerEvent blk)
   , chainSyncServerBlockTracer    :: f (TraceChainSyncServerEvent blk)
   , blockFetchDecisionTracer      :: f [TraceLabelPeer remotePeer (FetchDecision [Point (Header blk)])]
@@ -69,6 +72,7 @@ instance (forall a. Semigroup (f a))
       => Semigroup (Tracers' remotePeer localPeer blk f) where
   l <> r = Tracers
       { chainSyncClientTracer         = f chainSyncClientTracer
+      , chainSyncReqRspTracer         = f chainSyncReqRspTracer
       , chainSyncServerHeaderTracer   = f chainSyncServerHeaderTracer
       , chainSyncServerBlockTracer    = f chainSyncServerBlockTracer
       , blockFetchDecisionTracer      = f blockFetchDecisionTracer
@@ -96,6 +100,7 @@ type Tracers m remotePeer localPeer blk =
 nullTracers :: Monad m => Tracers m remotePeer localPeer blk
 nullTracers = Tracers
     { chainSyncClientTracer         = nullTracer
+    , chainSyncReqRspTracer         = nullTracer
     , chainSyncServerHeaderTracer   = nullTracer
     , chainSyncServerBlockTracer    = nullTracer
     , blockFetchDecisionTracer      = nullTracer
@@ -125,6 +130,7 @@ showTracers :: ( Show blk
             => Tracer m String -> Tracers m remotePeer localPeer blk
 showTracers tr = Tracers
     { chainSyncClientTracer         = showTracing tr
+    , chainSyncReqRspTracer         = showTracing tr
     , chainSyncServerHeaderTracer   = showTracing tr
     , chainSyncServerBlockTracer    = showTracing tr
     , blockFetchDecisionTracer      = showTracing tr

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -30,6 +30,7 @@ library
                        Ouroboros.Network.IOManager
                        Ouroboros.Network.Mux
                        Ouroboros.Network.Util.ShowProxy
+                       Ouroboros.Network.Util.TaggedObserve
 
                        Ouroboros.Network.Protocol.Handshake
                        Ouroboros.Network.Protocol.Handshake.Type

--- a/ouroboros-network-framework/src/Ouroboros/Network/Util/TaggedObserve.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Util/TaggedObserve.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE LambdaCase #-}
+module Ouroboros.Network.Util.TaggedObserve (
+      TaggedObservable (..)
+    , matchTaggedObservations
+
+      -- reexports
+    , ObserveIndicator (..)
+    , Observable (..)
+    , matchObservations
+    ) where
+
+import           Control.Tracer
+import           Control.Tracer.Observe
+
+-- Like Observable but with a t tag type field too.
+data TaggedObservable t s e d = TOStart t s
+                              | TOEnd t e (Maybe d)
+                              --           ^^ holds the difference between start and end
+matchTaggedObservations
+    :: Monad m
+    => (t -> m (Maybe s))
+    -> (t -> s -> m ())
+    -> (s -> e -> d)
+    -> Tracer m (TaggedObservable t s e d)
+    -> Tracer m (TaggedObservable t s e d)
+matchTaggedObservations getStart putStart f tr = Tracer $ \case
+    obs@(TOStart t s) -> do
+        putStart t s
+        traceWith tr obs
+    (TOEnd t e _) -> do
+        before <- getStart t
+        traceWith tr $ TOEnd t e $ fmap (flip f e) before
+
+instance (Show t, Show s, Show e, Show d) => Show (TaggedObservable t s e d) where
+    show (TOStart t time)     = "TOStart " ++ show t ++ " " ++ show time
+    show (TOEnd t time mTime) = "TOEnd " ++ show t ++ " " ++ show time ++ ", ODiff " ++ show mTime
+

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -271,7 +271,7 @@ propChainSyncPipelinedMaxConnectST cps choices (Positive omax) =
         (\ser cli ->
             void $ connectPipelined
               choices
-              (chainSyncClientPeerPipelined cli)
+              (chainSyncClientPeerPipelined nullTracer cli)
               (chainSyncServerPeer ser)
         )
         (ChainSyncExamples.chainSyncClientPipelinedMax omax)
@@ -288,7 +288,7 @@ propChainSyncPipelinedMinConnectST cps choices (Positive omax) =
         (\ser cli ->
             void $ connectPipelined
               choices
-              (chainSyncClientPeerPipelined cli)
+              (chainSyncClientPeerPipelined nullTracer cli)
               (chainSyncServerPeer ser)
         )
         (ChainSyncExamples.chainSyncClientPipelinedMin omax)
@@ -304,7 +304,7 @@ propChainSyncPipelinedMaxConnectIO cps choices (Positive omax) =
         (\ser cli ->
             void $ connectPipelined
               choices
-              (chainSyncClientPeerPipelined cli)
+              (chainSyncClientPeerPipelined nullTracer cli)
               (chainSyncServerPeer ser)
         )
         (ChainSyncExamples.chainSyncClientPipelinedMax omax)
@@ -320,7 +320,7 @@ propChainSyncPipelinedMinConnectIO cps choices (Positive omax) =
         (\ser cli ->
             void $ connectPipelined
               choices
-              (chainSyncClientPeerPipelined cli)
+              (chainSyncClientPeerPipelined nullTracer cli)
               (chainSyncServerPeer ser)
         )
         (ChainSyncExamples.chainSyncClientPipelinedMin omax)
@@ -624,7 +624,7 @@ chainSyncDemoPipelined clientChan serverChan mkClient (ChainProducerStateForkTes
       client = mkClient chainVar (testClient doneVar (Chain.headPoint pchain))
 
   void $ forkIO (void $ runPeer nullTracer codec serverChan (chainSyncServerPeer server))
-  void $ forkIO (void $ runPipelinedPeer nullTracer codec clientChan (chainSyncClientPeerPipelined client))
+  void $ forkIO (void $ runPipelinedPeer nullTracer codec clientChan (chainSyncClientPeerPipelined nullTracer client))
 
   atomically $ do
     done <- readTVar doneVar


### PR DESCRIPTION
Add support for a response time tracer for chainsync requests that
should yield an immediate response.