### PR TITLE
Fix request/pipeling decision with 0 reqs

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/PipelineDecision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Protocol/ChainSync/PipelineDecision.hs
@@ -104,10 +104,10 @@ pipelineDecisionMax :: Word32 -> Nat n -> WithOrigin BlockNo -> WithOrigin Block
                     -> PipelineDecision n
 pipelineDecisionMax omax n cliTipBlockNo srvTipBlockNo =
     case n of
-      Zero   -- We are at most one block away from the server's tip. We use
+      Zero   -- We are insync with the server's tip. We use
              -- equality so that this does not get triggered when we are ahead
              -- of the producer, and it will send us 'MsgRollBackward'.
-             | cliTipBlockNo `bnoPlus` 1 == srvTipBlockNo
+             | cliTipBlockNo == srvTipBlockNo
              -> Request
 
              | otherwise
@@ -143,10 +143,10 @@ pipelineDecisionMin :: Word32 -> Nat n -> WithOrigin BlockNo -> WithOrigin Block
                     -> PipelineDecision n
 pipelineDecisionMin omax n cliTipBlockNo srvTipBlockNo =
     case n of
-      Zero   -- We are at most one block away from the server's tip. We use
+      Zero   -- We are insync with the server's tip. We use
              -- equality so that this does not get triggered when we are ahead
              -- of the producer, and it will send us 'MsgRollBackward'.
-             | cliTipBlockNo `bnoPlus` 1 == srvTipBlockNo
+             | cliTipBlockNo == srvTipBlockNo
              -> Request
 
              | otherwise
@@ -179,7 +179,7 @@ pipelineDecisionLowHighMark lowMark highMark =
     goZero :: Nat Z -> WithOrigin BlockNo -> WithOrigin BlockNo
            -> (PipelineDecision Z, MkPipelineDecision)
     goZero Zero clientTipBlockNo serverTipBlockNo
-      | clientTipBlockNo `bnoPlus` 1 == serverTipBlockNo
+      | clientTipBlockNo == serverTipBlockNo
       = (Request, goLow)
 
       | otherwise


### PR DESCRIPTION
The trigger for when we should use a Request rather than Pipeline
should be when the client and the server agree on the tip, that is they
are both waiting on the next block to be forged.

Previously the descision to do a Request only happened when the server
was exactly one block ahead of us and we had no outstanding requests.