### PR TITLE
Update cardano ledger specs

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -168,8 +168,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-specs
-  tag: 0d0f001ec627a963fbc2cbe65273468fdb0f6b75
-  --sha256: 0aww7ls090gvsss0lq3dg95hzffblzmkhdv0x0nnz9d70srn3052
+  tag: 99e2f2e32ebfca3291fa523ddcae14c8cbb48fa0
+  --sha256: 0fy8y7cp10ls8p3zs2fqzqpd41vri6z0imhyif5wa9bi2rp57i3z
   subdir:
     byron/chain/executable-spec
     byron/crypto


### PR DESCRIPTION
This is because of https://input-output-rnd.slack.com/archives/GR599HMFX/p1612877178262400
and also because it's fairly common to copy dependency references from `ouroboros-network` for downstream repos.