### PR TITLE
consensus-docs: fix report.pdf build

### DIFF
--- a/nix/consensus-docs.nix
+++ b/nix/consensus-docs.nix
@@ -15,6 +15,7 @@ in pkgs.runCommand "ouroboros-consensus-docs" {
       enumitem
       latexmk
       scheme-small
+      siunitx
       todonotes
     ;
   })];


### PR DESCRIPTION
After this commit, `nix-build -A consensus-docs` no longer fails.