### PR TITLE
Add srnEnableDevelopmentalVersions to StdRunNodeArgs

### DIFF
--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
@@ -48,6 +48,8 @@ instance SupportedNetworkProtocolVersion DualByronBlock where
   supportedNodeToNodeVersions     _ = supportedNodeToNodeVersions     pb
   supportedNodeToClientVersions   _ = supportedNodeToClientVersions   pb
 
+  latestReleasedNodeVersion = latestReleasedNodeVersionDefault
+
 {-------------------------------------------------------------------------------
   EncodeDisk & DecodeDisk
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
@@ -41,3 +41,5 @@ instance SupportedNetworkProtocolVersion ByronBlock where
       , (NodeToClientV_2, ByronNodeToClientVersion1)
         -- V_3 enables the hard fork, not supported by Byron-only.
       ]
+
+  latestReleasedNodeVersion = latestReleasedNodeVersionDefault

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -181,6 +181,8 @@ instance ShelleyBasedHardForkConstraints era1 era2
       [ (maxBound, ShelleyBasedHardForkNodeToClientVersion1)
       ]
 
+  latestReleasedNodeVersion = latestReleasedNodeVersionDefault
+
 {-------------------------------------------------------------------------------
   Protocol info
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ByronHFC.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ByronHFC.hs
@@ -60,6 +60,8 @@ instance SupportedNetworkProtocolVersion ByronBlockHFC where
       Map.map HardForkNodeToClientDisabled $
       supportedNodeToClientVersions (Proxy @ByronBlock)
 
+  latestReleasedNodeVersion = latestReleasedNodeVersionDefault
+
 {-------------------------------------------------------------------------------
   SerialiseHFC instance
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -334,6 +334,8 @@ instance CardanoHardForkConstraints c
       , (NodeToClientV_8, CardanoNodeToClientVersion6)
       ]
 
+  latestReleasedNodeVersion = latestReleasedNodeVersionDefault
+
 {-------------------------------------------------------------------------------
   ProtocolInfo
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ShelleyHFC.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ShelleyHFC.hs
@@ -62,6 +62,8 @@ instance ShelleyBasedEra era
       Map.map HardForkNodeToClientDisabled $
       supportedNodeToClientVersions (Proxy @(ShelleyBlock era))
 
+  latestReleasedNodeVersion = latestReleasedNodeVersionDefault
+
 {-------------------------------------------------------------------------------
   SerialiseHFC instance
 -------------------------------------------------------------------------------}

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -45,6 +45,8 @@ instance SupportedNetworkProtocolVersion (SimpleBlock SimpleMockCrypto ext) wher
   supportedNodeToNodeVersions   _ = Map.singleton maxBound ()
   supportedNodeToClientVersions _ = Map.singleton maxBound ()
 
+  latestReleasedNodeVersion = latestReleasedNodeVersionDefault
+
 instance NodeInitStorage (SimpleBlock SimpleMockCrypto ext) where
   nodeImmutableDbChunkInfo (SimpleStorageConfig secParam) = simpleChunkInfo $
       EpochSize $ 10 * maxRollbacks secParam

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -50,3 +50,5 @@ instance SupportedNetworkProtocolVersion (ShelleyBlock era) where
         -- V_4 to enable 'ShelleyNodeToClientVersion3'.
       , (NodeToClientV_4, ShelleyNodeToClientVersion3)
       ]
+
+  latestReleasedNodeVersion = latestReleasedNodeVersionDefault

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -399,6 +399,8 @@ instance SupportedNetworkProtocolVersion TestBlock where
   supportedNodeToNodeVersions   _ = Map.singleton maxBound versionN2N
   supportedNodeToClientVersions _ = Map.singleton maxBound versionN2C
 
+  latestReleasedNodeVersion = latestReleasedNodeVersionDefault
+
 instance SerialiseHFC '[BlockA, BlockB]
   -- Use defaults
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -614,15 +614,19 @@ stdRunDataDiffusion = runDataDiffusion
 --
 -- See 'stdLowLevelRunNodeArgsIO'.
 data StdRunNodeArgs m blk = StdRunNodeArgs
-  { srnBfcMaxConcurrencyBulkSync :: Maybe Word
-  , srnBfcMaxConcurrencyDeadline :: Maybe Word
-  , srnChainDbValidateOverride   :: Bool
+  { srnBfcMaxConcurrencyBulkSync   :: Maybe Word
+  , srnBfcMaxConcurrencyDeadline   :: Maybe Word
+  , srnChainDbValidateOverride     :: Bool
     -- ^ If @True@, validate the ChainDB on init no matter what
-  , srnDatabasePath              :: FilePath
+  , srnDatabasePath                :: FilePath
     -- ^ Location of the DBs
-  , srnDiffusionArguments        :: DiffusionArguments
-  , srnDiffusionTracers          :: DiffusionTracers
-  , srnTraceChainDB              :: Tracer m (ChainDB.TraceEvent blk)
+  , srnDiffusionArguments          :: DiffusionArguments
+  , srnDiffusionTracers            :: DiffusionTracers
+  , srnEnableInDevelopmentVersions :: Bool
+    -- ^ If @False@, then the node will limit the negotiated NTN and NTC
+    -- versions to the latest " official " release (as chosen by Network and
+    -- Consensus Team, with input from Node Team)
+  , srnTraceChainDB                :: Tracer m (ChainDB.TraceEvent blk)
     -- ^ ChainDB Tracer
   }
 
@@ -661,9 +665,13 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo } StdRunNodeArgs{..} = do
             networkMagic
             (daDiffusionMode srnDiffusionArguments)
       , llrnNodeToNodeVersions =
-          supportedNodeToNodeVersions (Proxy @blk)
+          limitToLatestReleasedVersion
+            fst
+            (supportedNodeToNodeVersions (Proxy @blk))
       , llrnNodeToClientVersions =
-          supportedNodeToClientVersions (Proxy @blk)
+          limitToLatestReleasedVersion
+            snd
+            (supportedNodeToClientVersions (Proxy @blk))
       , llrnWithCheckedDB =
           stdWithCheckedDB (Proxy @blk) srnDatabasePath networkMagic
       , llrnMaxClockSkew =
@@ -696,6 +704,19 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo } StdRunNodeArgs{..} = do
         . maybe id
             (\mc bfc -> bfc { bfcMaxConcurrencyBulkSync = mc })
             srnBfcMaxConcurrencyBulkSync
+
+    -- Limit the node version unless srnEnableInDevelopmentVersions is set
+    limitToLatestReleasedVersion :: forall k v.
+         Ord k
+      => ((Maybe NodeToNodeVersion, Maybe NodeToClientVersion) -> Maybe k)
+      -> Map k v
+      -> Map k v
+    limitToLatestReleasedVersion prj =
+        if not srnEnableInDevelopmentVersions then id
+        else
+        case prj $ latestReleasedNodeVersion (Proxy @blk) of
+          Nothing      -> id
+          Just version -> Map.takeWhileAntitone (<= version)
 
 {-------------------------------------------------------------------------------
   Miscellany

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -616,7 +616,7 @@ stdRunDataDiffusion = runDataDiffusion
 data StdRunNodeArgs m blk = StdRunNodeArgs
   { srnBfcMaxConcurrencyBulkSync :: Maybe Word
   , srnBfcMaxConcurrencyDeadline :: Maybe Word
-  , srcChainDbValidateOverride   :: Bool
+  , srnChainDbValidateOverride   :: Bool
     -- ^ If @True@, validate the ChainDB on init no matter what
   , srnDatabasePath              :: FilePath
     -- ^ Location of the DBs
@@ -681,7 +681,7 @@ stdLowLevelRunNodeArgsIO RunNodeArgs{ rnProtocolInfo } StdRunNodeArgs{..} = do
       -> ChainDbArgs Defaults IO blk
     updateChainDbDefaults =
         (\x -> x { ChainDB.cdbTracer = srnTraceChainDB }) .
-        (if not srcChainDbValidateOverride then id else \x -> x
+        (if not srnChainDbValidateOverride then id else \x -> x
           { ChainDB.cdbImmutableDbValidation = ValidateAllChunks
           , ChainDB.cdbVolatileDbValidation  = ValidateAll
           })

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
@@ -5,6 +5,7 @@
 module Ouroboros.Consensus.Node.NetworkProtocolVersion
   ( HasNetworkProtocolVersion(..)
   , SupportedNetworkProtocolVersion(..)
+  , latestReleasedNodeVersionDefault
     -- * Re-exports
   , NodeToNodeVersion(..)
   , NodeToClientVersion(..)
@@ -12,6 +13,7 @@ module Ouroboros.Consensus.Node.NetworkProtocolVersion
 
 import           Data.Kind (Type)
 import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import           Data.Proxy
 
 import           Ouroboros.Network.NodeToClient
@@ -43,3 +45,22 @@ class HasNetworkProtocolVersion blk => SupportedNetworkProtocolVersion blk where
   -- | Enumerate all supported node-to-client versions
   supportedNodeToClientVersions
     :: Proxy blk -> Map NodeToClientVersion (BlockNodeToClientVersion blk)
+
+  -- | The latest released version
+  --
+  -- This is the latest version intended for deployment.
+  latestReleasedNodeVersion
+    :: Proxy blk -> (Maybe NodeToNodeVersion, Maybe NodeToClientVersion)
+
+-- | A default for 'latestReleasedNodeVersion'
+--
+-- Chooses the greatest in 'supportedNodeToNodeVersions' and
+-- 'supportedNodeToClientVersions'.
+latestReleasedNodeVersionDefault
+  :: SupportedNetworkProtocolVersion blk
+  => Proxy blk
+  -> (Maybe NodeToNodeVersion, Maybe NodeToClientVersion)
+latestReleasedNodeVersionDefault prx =
+    ( fmap fst $ Map.lookupMax $ supportedNodeToNodeVersions   prx
+    , fmap fst $ Map.lookupMax $ supportedNodeToClientVersions prx
+    )


### PR DESCRIPTION
Fixes #2938.

The interpretation of this new flag within `stdLowLevelRunNodeArgsIO` determines what the highest NTN and NTC version will be when the flag is disabled. When the flag is enabled, those bounds are ignored, and the relevant instance of `Ouroboros.Consensus.Node.NetworkProtocolVersion.SupportedNetworkProtocolVersion` is used unfiltered.