### PR TITLE
Revert "Modify DiskPolicy so that onDiskShouldTakeSnapshot takes SlotNo as an argument"

### DIFF
--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -60,13 +60,13 @@ import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Config
 import           Ouroboros.Consensus.Ledger.Abstract
 import           Ouroboros.Consensus.Ledger.Extended
-import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB as LgrDB
+import           Ouroboros.Consensus.Util
+import           Ouroboros.Consensus.Util.IOLike
+
 import           Ouroboros.Consensus.Storage.FS.API
 import           Ouroboros.Consensus.Storage.FS.API.Types
 import           Ouroboros.Consensus.Storage.LedgerDB.InMemory
 import           Ouroboros.Consensus.Storage.LedgerDB.OnDisk
-import           Ouroboros.Consensus.Util
-import           Ouroboros.Consensus.Util.IOLike
 
 import qualified Test.Util.Classify as C
 import qualified Test.Util.FS.Sim.MockFS as MockFS
@@ -595,13 +595,13 @@ runDB standalone@DB{..} cmd =
                 (map ApplyVal bs)
                 db
     go hasFS Snap = do
-        snapshotCandidate <- atomically $ LgrDB.oldestLedgerSnapshot . snd <$> readTVar dbState
+        (_, db) <- atomically $ readTVar dbState
         Snapped <$>
           takeSnapshot
             nullTracer
             hasFS
             S.encode
-            snapshotCandidate
+            db
     go hasFS Restore = do
         (initLog, db, _replayed) <-
           initLedgerDB

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BlockArguments           #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE FlexibleContexts         #-}
 {-# LANGUAGE LambdaCase               #-}
@@ -206,7 +205,7 @@ openDBInternal args launchBgTasks = do
         testing = Internal
           { intCopyToImmutableDB       = getEnv  h Background.copyToImmutableDB
           , intGarbageCollect          = getEnv1 h Background.garbageCollect
-          , intUpdateLedgerSnapshots   = getEnv  h updateLedgerSnapshots
+          , intUpdateLedgerSnapshots   = getEnv  h Background.updateLedgerSnapshots
           , intAddBlockRunner          = getEnv  h Background.addBlockRunner
           , intKillBgThreads           = varKillBgThreads
           }
@@ -221,10 +220,6 @@ openDBInternal args launchBgTasks = do
   where
     tracer = Args.cdbTracer args
     (argsImmutableDb, argsVolatileDb, argsLgrDb, _) = Args.fromChainDbArgs args
-    updateLedgerSnapshots = \case
-      CDB{..} -> do
-        snapshotCandidate <- atomically $ LgrDB.oldestLedgerSnapshot <$> LgrDB.getCurrent cdbLgrDB
-        Background.updateLedgerSnapshots cdbLgrDB snapshotCandidate
 
 isOpen :: IOLike m => ChainDbHandle m blk -> STM m Bool
 isOpen (CDBHandle varState) = readTVar varState <&> \case

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/DiskPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/DiskPolicy.hs
@@ -11,14 +11,11 @@ module Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (
 
 import           Data.Time.Clock (secondsToDiffTime)
 import           Data.Word
-
-import           Ouroboros.Consensus.Config.SecurityParam
-
 import           NoThunks.Class (NoThunks, OnlyCheckWhnf (..))
 
-import           Cardano.Slotting.Slot (SlotNo)
-
 import           Control.Monad.Class.MonadTime
+
+import           Ouroboros.Consensus.Config.SecurityParam
 
 -- | On-disk policy
 --
@@ -48,7 +45,7 @@ data DiskPolicy = DiskPolicy {
 
       -- | Should we write a snapshot of the ledger state to disk?
       --
-      -- This function is passed three bits of information:
+      -- This function is passed two bits of information:
       --
       -- * The time since the last snapshot, or 'Nothing' if none was taken yet.
       --   Note that 'Nothing' merely means no snapshot had been taking yet
@@ -63,17 +60,8 @@ data DiskPolicy = DiskPolicy {
       --   policy to decide to take a snapshot /on node startup/ if a lot of
       --   blocks had to be replayed.
       --
-      -- * Slot number - a slot that corresponds to a a tip of ledger state.
-      --   In other words: if you take a tip of a ledger state - that we are
-      --   considering to take a snapshot of - this value represents a slot
-      --   number in which that tip was forged.
-      --
       -- See also 'defaultDiskPolicy'
-    , onDiskShouldTakeSnapshot ::
-           Maybe DiffTime
-        -> Word64
-        -> SlotNo
-        -> Bool
+    , onDiskShouldTakeSnapshot :: Maybe DiffTime -> Word64 -> Bool
     }
   deriving NoThunks via OnlyCheckWhnf DiskPolicy
 
@@ -97,14 +85,10 @@ defaultDiskPolicy (SecurityParam k) = DiskPolicy {..}
     onDiskNumSnapshots :: Word
     onDiskNumSnapshots = 2
 
-    onDiskShouldTakeSnapshot ::
-           Maybe DiffTime
-        -> Word64
-        -> SlotNo
-        -> Bool
-    onDiskShouldTakeSnapshot (Just timeSinceLast) blocksSinceLast _slotNo =
+    onDiskShouldTakeSnapshot :: Maybe DiffTime -> Word64 -> Bool
+    onDiskShouldTakeSnapshot (Just timeSinceLast) blocksSinceLast =
            timeSinceLast >= secondsToDiffTime (fromIntegral (k * 2))
         || (   blocksSinceLast >= 50_000
             && timeSinceLast > 6 * secondsToDiffTime 60)
-    onDiskShouldTakeSnapshot Nothing blocksSinceLast _slotNo =
+    onDiskShouldTakeSnapshot Nothing blocksSinceLast =
            blocksSinceLast >= k


### PR DESCRIPTION
This reverts commit 86c63f0db1fe31fd723098ecefd228b7ffa7da8d.

After brief discussions with the ledger and benchmarking team - the
users of the snapshot feature - it turned out that the feature is no
longer required. A different feature (https://github.com/input-output-hk/ouroboros-network/issues/2949) was proposed instead.