### PR TITLE
Upgrade stylish-haskell to 0.12.2.2

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -6,10 +6,10 @@
 , pkgs
 , haskell-nix
 , buildPackages
-, config ? {}
-# GHC attribute name
-, compiler ? config.haskellNix.compiler or "ghc8104"
-# Enable profiling
+, config ? { }
+  # GHC attribute name
+, compiler ? config.compiler
+  # Enable profiling
 , profiling ? config.haskellNix.profiling or false
 , libsodium ? pkgs.libsodium
 }:

--- a/nix/stylish-haskell.nix
+++ b/nix/stylish-haskell.nix
@@ -1,0 +1,16 @@
+{ pkgs
+}:
+let
+  hsPkgs = pkgs.haskell-nix.stackProject {
+    compiler-nix-name = "ghc8104";
+    modules = [ ];
+    src = pkgs.fetchFromGitHub {
+      owner = "jaspervdj";
+      repo = "stylish-haskell";
+      # 0.12.2.0 release
+      rev = "84770e33bb6286c163c3b2b10fa98d264f6672b8";
+      sha256 = "1jc844x8v93xgnl6fjrk31gb2zr96nxbqmgmnc4hdfhfyajh5y7w";
+    };
+  };
+in
+hsPkgs.stylish-haskell.components.exes.stylish-haskell

--- a/nix/stylish-haskell.nix
+++ b/nix/stylish-haskell.nix
@@ -1,8 +1,9 @@
 { pkgs
+, config
 }:
 let
   hsPkgs = pkgs.haskell-nix.stackProject {
-    compiler-nix-name = "ghc8104";
+    compiler-nix-name = config.compiler;
     modules = [ ];
     src = pkgs.fetchFromGitHub {
       owner = "jaspervdj";

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -18,8 +18,8 @@ import           Data.Maybe (fromMaybe)
 
 import qualified Byron.Spec.Ledger.Core as Spec
 import qualified Byron.Spec.Ledger.Delegation as Spec
-import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Byron.Spec.Ledger.UTxO as Spec
+import qualified Byron.Spec.Ledger.Update as Spec
 
 import qualified Test.Cardano.Chain.Elaboration.Block as Spec.Test
 import qualified Test.Cardano.Chain.Elaboration.Delegation as Spec.Test
@@ -29,9 +29,9 @@ import qualified Test.Cardano.Chain.UTxO.Model as Spec.Test
 
 import qualified Cardano.Chain.Block as Impl
 import qualified Cardano.Chain.Genesis as Impl
+import qualified Cardano.Chain.UTxO as Impl
 import qualified Cardano.Chain.Update as Impl
 import qualified Cardano.Chain.Update.Validation.Interface as Impl
-import qualified Cardano.Chain.UTxO as Impl
 
 import           Ouroboros.Consensus.HeaderValidation
 

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -27,8 +27,8 @@ import qualified Data.Map.Strict as Map
 import qualified Cardano.Chain.Block as CC.Block
 import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Chain.Common as CC
-import qualified Cardano.Chain.Update.Validation.Interface as CC.UPI
 import qualified Cardano.Chain.UTxO as CC
+import qualified Cardano.Chain.Update.Validation.Interface as CC.UPI
 
 import           Ouroboros.Network.Block (Serialised (..))
 
@@ -53,8 +53,8 @@ import           Test.Util.Serialisation.Roundtrip (SomeResult (..))
 
 import qualified Test.Cardano.Chain.Common.Example as CC
 import qualified Test.Cardano.Chain.Genesis.Dummy as CC
-import qualified Test.Cardano.Chain.Update.Example as CC
 import qualified Test.Cardano.Chain.UTxO.Example as CC
+import qualified Test.Cardano.Chain.Update.Example as CC
 
 import           Test.ThreadNet.Infra.Byron.ProtocolInfo (mkLeaderCredentials)
 

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -29,10 +29,10 @@ import qualified Cardano.Chain.Delegation.Validation.Scheduling as CC.Sched
 import qualified Cardano.Chain.Genesis as CC.Genesis
 import           Cardano.Chain.Slotting (EpochNumber, EpochSlots (..),
                      SlotNumber)
+import qualified Cardano.Chain.UTxO as CC.UTxO
 import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Chain.Update.Validation.Interface as CC.UPI
 import qualified Cardano.Chain.Update.Validation.Registration as CC.Reg
-import qualified Cardano.Chain.UTxO as CC.UTxO
 import           Cardano.Crypto (ProtocolMagicId (..))
 import           Cardano.Crypto.Hashing (Hash)
 
@@ -54,8 +54,8 @@ import qualified Test.Cardano.Chain.Common.Gen as CC
 import qualified Test.Cardano.Chain.Delegation.Gen as CC
 import qualified Test.Cardano.Chain.MempoolPayload.Gen as CC
 import qualified Test.Cardano.Chain.Slotting.Gen as CC
-import qualified Test.Cardano.Chain.Update.Gen as UG
 import qualified Test.Cardano.Chain.UTxO.Gen as CC
+import qualified Test.Cardano.Chain.Update.Gen as UG
 import qualified Test.Cardano.Crypto.Gen as CC
 
 import           Test.Util.Orphans.Arbitrary ()

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Crypto/DSIGN.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Crypto/DSIGN.hs
@@ -34,9 +34,8 @@ import           Cardano.Binary
 import qualified Cardano.Chain.Block as CC.Block
 import qualified Cardano.Chain.UTxO as CC.UTxO
 import           Cardano.Crypto (ProtocolMagicId, SignTag (..), Signature (..),
-                     SigningKey (..), VerificationKey (..),
-                     deterministicKeyGen, signRaw, toVerification,
-                     verifySignatureRaw)
+                     SigningKey (..), VerificationKey (..), deterministicKeyGen,
+                     signRaw, toVerification, verifySignatureRaw)
 import           Cardano.Crypto.DSIGN.Class
 import           Cardano.Crypto.Seed (SeedBytesExhausted (..), getBytesFromSeed)
 import qualified Cardano.Crypto.Signing as Crypto

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -27,8 +27,8 @@ import qualified Cardano.Chain.Delegation as CC.Delegation
 import qualified Cardano.Chain.Genesis as CC.Genesis
 import qualified Cardano.Chain.Slotting as CC.Slot
 import qualified Cardano.Chain.Ssc as CC.Ssc
-import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Chain.UTxO as CC.UTxO
+import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Crypto as Crypto
 import           Cardano.Crypto.DSIGN
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -59,10 +59,10 @@ import           Cardano.Binary (encodeListLen, enforceSize, fromCBOR, toCBOR)
 import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Chain.Genesis as Gen
+import qualified Cardano.Chain.UTxO as CC
 import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.Update.Validation.Endorsement as UPE
 import qualified Cardano.Chain.Update.Validation.Interface as UPI
-import qualified Cardano.Chain.UTxO as CC
 import qualified Cardano.Chain.ValidationMode as CC
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -60,8 +60,8 @@ import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.MempoolPayload as CC
-import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.UTxO as Utxo
+import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.ValidationMode as CC
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Orphans.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Orphans.hs
@@ -23,8 +23,8 @@ import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Common as CC
 import qualified Cardano.Chain.Delegation as CC
 import qualified Cardano.Chain.MempoolPayload as CC
-import qualified Cardano.Chain.Update as CC
 import qualified Cardano.Chain.UTxO as CC
+import qualified Cardano.Chain.Update as CC
 
 import           Ouroboros.Consensus.Util.Condense
 

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger.hs
@@ -10,10 +10,10 @@ module Ouroboros.Consensus.ByronSpec.Ledger (
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Block as X
 import           Ouroboros.Consensus.ByronSpec.Ledger.Forge as X
-import           Ouroboros.Consensus.ByronSpec.Ledger.Genesis as X
-                     (ByronSpecGenesis (..))
 import           Ouroboros.Consensus.ByronSpec.Ledger.GenTx as X
                      (ByronSpecGenTx (..), ByronSpecGenTxErr (..))
+import           Ouroboros.Consensus.ByronSpec.Ledger.Genesis as X
+                     (ByronSpecGenesis (..))
 import           Ouroboros.Consensus.ByronSpec.Ledger.Ledger as X
 import           Ouroboros.Consensus.ByronSpec.Ledger.Mempool as X
 import           Ouroboros.Consensus.ByronSpec.Ledger.Orphans as X ()

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/GenTx.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/GenTx.hs
@@ -21,8 +21,8 @@ import           GHC.Generics (Generic)
 
 import qualified Byron.Spec.Chain.STS.Rule.Chain as Spec
 import qualified Byron.Spec.Ledger.Delegation as Spec
-import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Byron.Spec.Ledger.UTxO as Spec
+import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Control.State.Transition as Spec
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Genesis

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Genesis.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Genesis.hs
@@ -27,8 +27,8 @@ import           Numeric.Natural (Natural)
 
 import qualified Byron.Spec.Chain.STS.Rule.Chain as Spec
 import qualified Byron.Spec.Ledger.Core as Spec
-import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Byron.Spec.Ledger.UTxO as Spec
+import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Control.State.Transition as Spec
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Orphans ()

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Orphans.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Orphans.hs
@@ -31,8 +31,8 @@ import qualified Byron.Spec.Ledger.Delegation as Spec
 import qualified Byron.Spec.Ledger.STS.UTXO as Spec
 import qualified Byron.Spec.Ledger.STS.UTXOW as Spec
 import qualified Byron.Spec.Ledger.STS.UTXOWS as Spec
-import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Byron.Spec.Ledger.UTxO as Spec
+import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Control.State.Transition as Spec
 
 import           Test.Cardano.Chain.Elaboration.Block as Spec.Test

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -16,9 +16,9 @@ import           Control.Exception (assert)
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe (maybeToList)
+import           Data.SOP.Strict
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
-import           Data.SOP.Strict
 
 import           Ouroboros.Consensus.Block (SlotNo (..))
 import           Ouroboros.Consensus.Config
@@ -39,10 +39,10 @@ import           Cardano.Chain.Genesis (GeneratedSecrets (..))
 
 import qualified Cardano.Ledger.SafeHash as SL
 import           Cardano.Ledger.Val ((<->))
+import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.Address as SL (BootstrapAddress (..))
 import qualified Shelley.Spec.Ledger.Address.Bootstrap as SL
                      (makeBootstrapWitness)
-import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.BaseTypes as SL (truncateUnitInterval)
 import qualified Shelley.Spec.Ledger.Tx as SL (WitnessSetHKD (..))
 import qualified Shelley.Spec.Ledger.UTxO as SL (makeWitnessVKey)

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/AllegraMary.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/AllegraMary.hs
@@ -22,9 +22,9 @@ import           Control.Monad (replicateM)
 import qualified Data.Map as Map
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
+import           Data.SOP.Strict (NP (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.SOP.Strict (NP (..))
 import           Data.Word (Word64)
 
 import           Test.QuickCheck

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
@@ -22,9 +22,9 @@ import           Control.Monad (replicateM)
 import qualified Data.Map as Map
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
+import           Data.SOP.Strict (NP (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.SOP.Strict (NP (..))
 import           Data.Word (Word64)
 
 import           Test.QuickCheck

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -31,7 +31,7 @@ import           Control.Monad.Except (Except, runExcept, throwError)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (listToMaybe, mapMaybe)
 import           Data.Proxy
-import           Data.SOP.Strict ((:.:) (..), NP (..), unComp)
+import           Data.SOP.Strict (NP (..), unComp, (:.:) (..))
 import           Data.Void (Void)
 import           Data.Word
 import           GHC.Generics (Generic)

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
@@ -23,8 +23,8 @@ import qualified Cardano.Crypto as Crypto
 
 import qualified Cardano.Chain.Block as Chain
 import qualified Cardano.Chain.Genesis as Genesis
-import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.UTxO as Chain
+import qualified Cardano.Chain.Update as Update
 
 import           Ouroboros.Consensus.Node.ProtocolInfo
 

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -410,7 +410,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
       forM vertexInfos0 $ \(coreNodeId, vertexStatusVar, readNodeInfo) -> do
         readTVar vertexStatusVar >>= \case
           VDown ch ldgr -> pure (coreNodeId, readNodeInfo, ch, ldgr)
-          _        -> retry
+          _             -> retry
 
     mkTestOutput vertexInfos
   where

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util/Expectations.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util/Expectations.hs
@@ -165,5 +165,5 @@ determineForkLength k (NodeJoinPlan joinPlan) (LeaderSchedule sched) =
         -- slot in which the node joins the network
         joinSlot :: CoreNodeId -> SlotNo
         joinSlot nid = case Map.lookup nid joinPlan of
-            Nothing -> error "determineForkLength: incomplete node join plan"
+            Nothing    -> error "determineForkLength: incomplete node join plan"
             Just slot' -> slot'

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Node.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Node.hs
@@ -29,11 +29,11 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
 
-import           Test.Util.FileLock
 import           Test.Util.FS.Sim.FsTree (FsTree (..))
 import           Test.Util.FS.Sim.MockFS (Files)
 import qualified Test.Util.FS.Sim.MockFS as Mock
 import           Test.Util.FS.Sim.STM (runSimFS)
+import           Test.Util.FileLock
 import           Test.Util.QuickCheck (ge)
 
 tests :: TestTree

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -28,8 +28,8 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.TreeDiff (defaultExprViaShow)
 import           Data.Typeable
-import qualified Generics.SOP as SOP
 import           GHC.Generics (Generic, Generic1)
+import qualified Generics.SOP as SOP
 
 import           Control.Monad.Class.MonadTimer
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
@@ -41,9 +41,9 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import           Data.TreeDiff (ToExpr (..), defaultExprViaShow)
 import           Data.Word (Word64)
-import qualified Generics.SOP as SOP
 import           GHC.Generics
 import           GHC.Stack
+import qualified Generics.SOP as SOP
 import           System.IO.Temp (withTempDirectory)
 import           System.Random (getStdRandom, randomR)
 import           Text.Read (readMaybe)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -39,9 +39,9 @@ import           Data.Maybe (listToMaybe)
 import           Data.TreeDiff (Expr (App), defaultExprViaShow)
 import           Data.Typeable (Typeable)
 import           Data.Word (Word16, Word32, Word64)
-import qualified Generics.SOP as SOP
 import           GHC.Generics (Generic, Generic1)
 import           GHC.Stack (HasCallStack)
+import qualified Generics.SOP as SOP
 import           NoThunks.Class (AllowThunk (..))
 import           System.Random (getStdRandom, randomR)
 import           Text.Show.Pretty (ppShow)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -30,9 +30,9 @@ import           Data.Maybe (catMaybes, listToMaybe, mapMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word
-import qualified Generics.SOP as SOP
 import           GHC.Generics
 import           GHC.Stack
+import qualified Generics.SOP as SOP
 import           System.Random (getStdRandom, randomR)
 import           Text.Show.Pretty (ppShow)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -74,11 +74,11 @@ import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..),
                      withOrigin, withOriginFromMaybe, withOriginToMaybe)
 import qualified Cardano.Slotting.Slot as Cardano
 
-import           Ouroboros.Network.Block (pattern BlockPoint, ChainHash (..),
-                     pattern GenesisPoint, HasHeader (..), HeaderFields (..),
-                     HeaderHash, Point, StandardHash, blockHash, blockNo,
-                     blockPoint, blockSlot, castHash, castHeaderFields,
-                     castPoint, pointHash, pointSlot)
+import           Ouroboros.Network.Block (ChainHash (..), HasHeader (..),
+                     HeaderFields (..), HeaderHash, Point, StandardHash,
+                     blockHash, blockNo, blockPoint, blockSlot, castHash,
+                     castHeaderFields, castPoint, pattern BlockPoint,
+                     pattern GenesisPoint, pointHash, pointSlot)
 
 import           Ouroboros.Consensus.Block.EBB
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
@@ -31,7 +31,7 @@ import           Control.Monad.Class.MonadSTM
 
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
-                     AnchoredSeq ((:>), Empty))
+                     AnchoredSeq (Empty, (:>)))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
@@ -33,12 +33,10 @@ import           Ouroboros.Consensus.HardFork.Combinator.Mempool as X
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol as X
 
 -- Instance for 'CommonProtocolParams'
-import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams as X
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams as X ()
 
 -- Instance for 'LedgerSupportsPeerSelection'
-import           Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection as X
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection as X ()
 
 -- Instances for 'ShowQuery' and 'QueryLedger'
 -- Definition of 'Query', required for serialisation code
@@ -70,8 +68,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Forging as X
 import           Ouroboros.Consensus.HardFork.Combinator.Node as X ()
 
 -- Instance for 'NodeInitStorage'
-import           Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage as X
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage as X ()
 
 -- Instance for 'BlockSupportsMetrics'
 import           Ouroboros.Consensus.HardFork.Combinator.Node.Metrics as X ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -44,18 +44,14 @@ import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger
-import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams ()
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
 import           Ouroboros.Consensus.HardFork.Combinator.Mempool
 import           Ouroboros.Consensus.HardFork.Combinator.Node ()
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
-                     ()
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient
-                     ()
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode ()
 
 {-------------------------------------------------------------------------------
   Simple patterns

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
@@ -19,8 +19,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Forging ()
-import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams ()
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection ()
 import           Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage ()
 import           Ouroboros.Consensus.HardFork.Combinator.Node.Metrics ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -48,10 +48,9 @@ import           Ouroboros.Consensus.HardFork.Combinator.Info
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
-                     (HardForkLedgerView, HardForkLedgerView_ (..),
-                     Ticked (..))
+                     (HardForkLedgerView, HardForkLedgerView_ (..), Ticked (..))
 import           Ouroboros.Consensus.HardFork.Combinator.State (HardForkState,
-                     HardForkState, Translate (..))
+                     Translate (..))
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 import           Ouroboros.Consensus.HardFork.Combinator.Translation
 import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation.hs
@@ -10,11 +10,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common as
                      HardForkSpecificNodeToClientVersion (..),
                      HardForkSpecificNodeToNodeVersion (..),
                      SerialiseConstraintsHFC, SerialiseHFC (..),
-                     isHardForkNodeToClientEnabled,
-                     isHardForkNodeToNodeEnabled)
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk as X
-                     ()
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient as X
-                     ()
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode as X
-                     ()
+                     isHardForkNodeToClientEnabled, isHardForkNodeToNodeEnabled)
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk as X ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient as X ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode as X ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -73,8 +73,7 @@ import           Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as Enc
 import           Codec.Serialise (Serialise)
 import qualified Codec.Serialise as Serialise
-import           Control.Exception (Exception)
-import           Control.Exception (throw)
+import           Control.Exception (Exception, throw)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as Short

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
@@ -45,8 +45,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
 import           Ouroboros.Consensus.HardFork.Combinator.Mempool
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk ()
 
 instance SerialiseHFC xs => SerialiseNodeToClientConstraints (HardForkBlock xs)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
@@ -40,8 +40,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Block
 import           Ouroboros.Consensus.HardFork.Combinator.Mempool
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk ()
 
 instance SerialiseHFC xs => SerialiseNodeToNodeConstraints (HardForkBlock xs) where
   estimateBlockSize = estimateHfcBlockSize

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
@@ -44,7 +44,7 @@ import qualified Data.Foldable as Foldable
 import           Data.List (sortOn)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Sequence.Strict (StrictSeq ((:<|), (:|>), Empty), (|>))
+import           Data.Sequence.Strict (StrictSeq (Empty, (:<|), (:|>)), (|>))
 import qualified Data.Sequence.Strict as Seq
 import           Data.Word
 import           GHC.Generics (Generic)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/Handle.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/Handle.hs
@@ -40,7 +40,7 @@ closeHandleOS :: HandleOS osHandle -> (osHandle -> IO ()) -> IO ()
 closeHandleOS (HandleOS _ hVar) close =
   modifyMVar hVar $ \case
     Nothing -> return (Nothing, ())
-    Just h -> close h >> return (Nothing, ())
+    Just h  -> close h >> return (Nothing, ())
 
 {-------------------------------------------------------------------------------
   Exceptions

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks.hs
@@ -10,5 +10,4 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal as X
                      (ChunkInfo (..), ChunkNo, ChunkSize (..),
                      chunkInfoSupportsEBBs, chunksBetween, compareRelativeSlot,
                      countChunks, firstChunkNo, getChunkSize, mkRelativeSlot,
-                     nextChunkNo, prevChunkNo, simpleChunkInfo,
-                     singleChunkInfo)
+                     nextChunkNo, prevChunkNo, simpleChunkInfo, singleChunkInfo)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
@@ -103,8 +103,7 @@ import qualified Codec.CBOR.Write as CBOR
 import           Control.Monad (replicateM_, unless, when)
 import           Control.Monad.Except (runExceptT)
 import           Control.Monad.State.Strict (get, lift, modify, put)
-import           Control.Tracer (Tracer, traceWith)
-import           Control.Tracer (nullTracer)
+import           Control.Tracer (Tracer, nullTracer, traceWith)
 import qualified Data.ByteString.Lazy as Lazy
 import           GHC.Stack (HasCallStack)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -19,7 +19,7 @@ import           Data.Word (Word64)
 import           GHC.Stack
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
-                     AnchoredSeq ((:>), Empty))
+                     AnchoredSeq (Empty, (:>)))
 import qualified Ouroboros.Network.AnchoredFragment as AF
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -27,14 +27,15 @@ import           Text.Printf (printf)
 import           Control.Monad.Class.MonadTime (Time (..))
 
 import           Cardano.Crypto.DSIGN (Ed25519DSIGN, Ed448DSIGN, MockDSIGN,
-                     SigDSIGN, pattern SigEd25519DSIGN, pattern SigEd448DSIGN,
-                     pattern SigMockDSIGN, SignedDSIGN (..), VerKeyDSIGN)
+                     SigDSIGN, SignedDSIGN (..), VerKeyDSIGN,
+                     pattern SigEd25519DSIGN, pattern SigEd448DSIGN,
+                     pattern SigMockDSIGN)
 import           Cardano.Crypto.Hash (Hash)
-import           Cardano.Crypto.KES (MockKES, NeverKES, SigKES,
+import           Cardano.Crypto.KES (MockKES, NeverKES, SigKES, SignedKES (..),
+                     SimpleKES, SingleKES, SumKES, VerKeyKES,
                      pattern SigMockKES, pattern SigSimpleKES,
                      pattern SigSingleKES, pattern SigSumKES,
-                     pattern SignKeyMockKES, SignedKES (..), SimpleKES,
-                     SingleKES, SumKES, VerKeyKES, pattern VerKeyMockKES,
+                     pattern SignKeyMockKES, pattern VerKeyMockKES,
                      pattern VerKeySingleKES, pattern VerKeySumKES)
 
 import           Ouroboros.Consensus.Util.HList (All, HList (..))

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,7 @@
 }:
 with pkgs;
 let
+  stylish-haskell = import ./nix/stylish-haskell.nix { inherit pkgs; };
   # This provides a development environment that can be used with nix-shell or
   # lorri. See https://input-output-hk.github.io/haskell.nix/user-guide/development/
   # NOTE: due to some cabal limitation,
@@ -22,12 +23,12 @@ let
 
     # These programs will be available inside the nix-shell.
     buildInputs = [
+      stylish-haskell
       niv
       pkgconfig
     ];
 
     tools = {
-      stylish-haskell = "0.11.0.0";
       ghcid = "0.8.7";
       cabal = "3.2.0.0";
       # todo: add back the build tools which are actually necessary

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 # This file is used by nix-shell.
 # It just takes the shell attribute from default.nix.
-{ config ? {}
-, sourcesOverride ? {}
+{ config ? { compiler = "ghc8104"; }
+, sourcesOverride ? { }
 , withHoogle ? false
 , pkgs ? import ./nix {
     inherit config sourcesOverride;
@@ -9,7 +9,7 @@
 }:
 with pkgs;
 let
-  stylish-haskell = import ./nix/stylish-haskell.nix { inherit pkgs; };
+  stylish-haskell = import ./nix/stylish-haskell.nix { inherit pkgs config; };
   # This provides a development environment that can be used with nix-shell or
   # lorri. See https://input-output-hk.github.io/haskell.nix/user-guide/development/
   # NOTE: due to some cabal limitation,


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/ouroboros-network/issues/2951

Some of the important changes in stylish since 0.11.0.0

*  Use ghc-lib-parser rather than haskell-src-exts (will work with 8.10.x features)
* when wrapping import lists over multiple lines, you can repeat the module name
* a new Step was added, `module_header`, which formats the export list of a module
* a new option for aligning only adjacent items
* support for aligning MultiWayIf syntax
  
Opens up new possibilities like https://github.com/input-output-hk/ouroboros-network/issues/2952

```
$> nix-shell

$> stylish-haskell --version
stylish-haskell 0.12.2.0
```