### PR TITLE
Configure stylish-haskell to format module header

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -16,6 +16,27 @@ steps:
   #     # true.
   #     add_language_pragma: true
 
+  - module_header:
+  #     # How many spaces use for indentation in the module header.
+      indent: 2
+  #
+  #     # Should export lists be sorted?  Sorting is only performed within the
+  #     # export section, as delineated by Haddock comments.
+      sort: true
+  #
+  #     # See `separate_lists` for the `imports` step.
+      separate_lists: true
+  #
+  #     # When to break the "where".
+  #     # Possible values:
+  #     # - exports: only break when there is an explicit export list.
+  #     # - single: only break when the export list counts more than one export.
+  #     # - inline: only break when the export list is too long. This is
+  #     #   determined by the `columns` setting. Not applicable when the export
+  #     #   list contains comments as newlines will be required.
+  #     # - always: always break before the "where".
+      break_where: exports
+
   # Align the right hand side of some elements.  This is quite conservative
   # and only applies to statements where each element occupies a single
   # line.

--- a/nix/stylish-haskell.nix
+++ b/nix/stylish-haskell.nix
@@ -1,0 +1,16 @@
+{ pkgs
+}:
+let
+  hsPkgs = pkgs.haskell-nix.stackProject {
+    compiler-nix-name = "ghc8104";
+    modules = [ ];
+    src = pkgs.fetchFromGitHub {
+      owner = "jaspervdj";
+      repo = "stylish-haskell";
+      # 0.12.2.0 release
+      rev = "84770e33bb6286c163c3b2b10fa98d264f6672b8";
+      sha256 = "1jc844x8v93xgnl6fjrk31gb2zr96nxbqmgmnc4hdfhfyajh5y7w";
+    };
+  };
+in
+hsPkgs.stylish-haskell.components.exes.stylish-haskell

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Ledger.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Ledger.hs
@@ -9,17 +9,17 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.ByronDual.Ledger (
-    -- * Shorthand
+module Ouroboros.Consensus.ByronDual.Ledger
+  ( -- * Shorthand
     DualByronBlock
   , DualByronBridge
     -- * Bridge
-  , ByronSpecBridge(..)
-  , SpecToImplIds(..)
-  , specToImplTx
-  , initByronSpecBridge
+  , ByronSpecBridge (..)
+  , SpecToImplIds (..)
   , bridgeToSpecKey
   , bridgeTransactionIds
+  , initByronSpecBridge
+  , specToImplTx
     -- * Block forging
   , forgeDualByronBlock
   ) where

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -18,8 +18,8 @@ import           Data.Maybe (fromMaybe)
 
 import qualified Byron.Spec.Ledger.Core as Spec
 import qualified Byron.Spec.Ledger.Delegation as Spec
-import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Byron.Spec.Ledger.UTxO as Spec
+import qualified Byron.Spec.Ledger.Update as Spec
 
 import qualified Test.Cardano.Chain.Elaboration.Block as Spec.Test
 import qualified Test.Cardano.Chain.Elaboration.Delegation as Spec.Test
@@ -29,9 +29,9 @@ import qualified Test.Cardano.Chain.UTxO.Model as Spec.Test
 
 import qualified Cardano.Chain.Block as Impl
 import qualified Cardano.Chain.Genesis as Impl
+import qualified Cardano.Chain.UTxO as Impl
 import qualified Cardano.Chain.Update as Impl
 import qualified Cardano.Chain.Update.Validation.Interface as Impl
-import qualified Cardano.Chain.UTxO as Impl
 
 import           Ouroboros.Consensus.HeaderValidation
 

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node.hs
@@ -8,8 +8,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.ByronDual.Node (
-    protocolInfoDualByron
+module Ouroboros.Consensus.ByronDual.Node
+  ( protocolInfoDualByron
   ) where
 
 import           Data.Either (fromRight)

--- a/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/src/Ouroboros/Consensus/ByronDual/Node/Serialisation.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.ByronDual.Node.Serialisation () where
+module Ouroboros.Consensus.ByronDual.Node.Serialisation
+  (
+  ) where
 
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Proxy

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -27,8 +27,8 @@ import qualified Data.Map.Strict as Map
 import qualified Cardano.Chain.Block as CC.Block
 import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Chain.Common as CC
-import qualified Cardano.Chain.Update.Validation.Interface as CC.UPI
 import qualified Cardano.Chain.UTxO as CC
+import qualified Cardano.Chain.Update.Validation.Interface as CC.UPI
 
 import           Ouroboros.Network.Block (Serialised (..))
 
@@ -53,8 +53,8 @@ import           Test.Util.Serialisation.Roundtrip (SomeResult (..))
 
 import qualified Test.Cardano.Chain.Common.Example as CC
 import qualified Test.Cardano.Chain.Genesis.Dummy as CC
-import qualified Test.Cardano.Chain.Update.Example as CC
 import qualified Test.Cardano.Chain.UTxO.Example as CC
+import qualified Test.Cardano.Chain.Update.Example as CC
 
 import           Test.ThreadNet.Infra.Byron.ProtocolInfo (mkLeaderCredentials)
 

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Examples.hs
@@ -1,24 +1,24 @@
 {-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE OverloadedStrings        #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
-module Test.Consensus.Byron.Examples (
-    -- * Setup
-    secParam
-  , windowSize
-  , cfg
+module Test.Consensus.Byron.Examples
+  ( -- * Setup
+    cfg
   , codecConfig
-  , ledgerConfig
   , leaderCredentials
+  , ledgerConfig
+  , secParam
+  , windowSize
     -- * Examples
-  , examples
+  , exampleApplyTxErr
   , exampleChainDepState
-  , exampleLedgerState
-  , exampleHeaderState
   , exampleExtLedgerState
-  , exampleHeaderHash
   , exampleGenTx
   , exampleGenTxId
-  , exampleApplyTxErr
+  , exampleHeaderHash
+  , exampleHeaderState
+  , exampleLedgerState
+  , examples
   ) where
 
 import           Control.Monad.Except (runExcept)

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -29,10 +29,10 @@ import qualified Cardano.Chain.Delegation.Validation.Scheduling as CC.Sched
 import qualified Cardano.Chain.Genesis as CC.Genesis
 import           Cardano.Chain.Slotting (EpochNumber, EpochSlots (..),
                      SlotNumber)
+import qualified Cardano.Chain.UTxO as CC.UTxO
 import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Chain.Update.Validation.Interface as CC.UPI
 import qualified Cardano.Chain.Update.Validation.Registration as CC.Reg
-import qualified Cardano.Chain.UTxO as CC.UTxO
 import           Cardano.Crypto (ProtocolMagicId (..))
 import           Cardano.Crypto.Hashing (Hash)
 
@@ -54,8 +54,8 @@ import qualified Test.Cardano.Chain.Common.Gen as CC
 import qualified Test.Cardano.Chain.Delegation.Gen as CC
 import qualified Test.Cardano.Chain.MempoolPayload.Gen as CC
 import qualified Test.Cardano.Chain.Slotting.Gen as CC
-import qualified Test.Cardano.Chain.Update.Gen as UG
 import qualified Test.Cardano.Chain.UTxO.Gen as CC
+import qualified Test.Cardano.Chain.Update.Gen as UG
 import qualified Test.Cardano.Crypto.Gen as CC
 
 import           Test.Util.Orphans.Arbitrary ()

--- a/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
+++ b/ouroboros-consensus-byron-test/src/Test/Consensus/Byron/Generators.hs
@@ -5,11 +5,11 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Consensus.Byron.Generators (
-    k
+module Test.Consensus.Byron.Generators
+  ( RegularBlock (..)
   , epochSlots
+  , k
   , protocolMagicId
-  , RegularBlock (..)
   ) where
 
 import           Control.Monad (replicateM)

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron.hs
@@ -1,5 +1,5 @@
-module Test.ThreadNet.Infra.Byron (
-    module X
+module Test.ThreadNet.Infra.Byron
+  ( module X
   ) where
 
 import           Test.ThreadNet.Infra.Byron.Genesis as X

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/Genesis.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/Genesis.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Test.ThreadNet.Infra.Byron.Genesis (
-    byronPBftParams
+module Test.ThreadNet.Infra.Byron.Genesis
+  ( byronPBftParams
   , generateGenesisConfig
   ) where
 

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/ProtocolInfo.hs
@@ -2,11 +2,11 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Test.ThreadNet.Infra.Byron.ProtocolInfo (
-  theProposedProtocolVersion,
-  theProposedSoftwareVersion,
-  mkProtocolByron,
-  mkLeaderCredentials,
+module Test.ThreadNet.Infra.Byron.ProtocolInfo
+  ( mkLeaderCredentials
+  , mkProtocolByron
+  , theProposedProtocolVersion
+  , theProposedSoftwareVersion
   ) where
 
 import           Data.Foldable (find)

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/Infra/Byron/TrackUpdates.hs
@@ -4,11 +4,11 @@
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Test.ThreadNet.Infra.Byron.TrackUpdates (
-  mkProtocolByronAndHardForkTxs,
-  ProtocolVersionUpdateLabel (..),
-  SoftwareVersionUpdateLabel (..),
-  mkUpdateLabels,
+module Test.ThreadNet.Infra.Byron.TrackUpdates
+  ( ProtocolVersionUpdateLabel (..)
+  , SoftwareVersionUpdateLabel (..)
+  , mkProtocolByronAndHardForkTxs
+  , mkUpdateLabels
   ) where
 
 import           Control.Exception (assert)

--- a/ouroboros-consensus-byron-test/src/Test/ThreadNet/TxGen/Byron.hs
+++ b/ouroboros-consensus-byron-test/src/Test/ThreadNet/TxGen/Byron.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.ThreadNet.TxGen.Byron () where
+module Test.ThreadNet.TxGen.Byron
+  (
+  ) where
 
 import           Ouroboros.Consensus.Byron.Ledger
 

--- a/ouroboros-consensus-byron-test/test/Main.hs
+++ b/ouroboros-consensus-byron-test/test/Main.hs
@@ -1,4 +1,6 @@
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import           Test.Tasty
 

--- a/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Golden.hs
+++ b/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Golden.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Consensus.Byron.Golden (tests) where
+module Test.Consensus.Byron.Golden
+  ( tests
+  ) where
 
 import           Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
 import           Ouroboros.Consensus.Byron.Node ()

--- a/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Serialisation.hs
+++ b/ouroboros-consensus-byron-test/test/Test/Consensus/Byron/Serialisation.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Consensus.Byron.Serialisation (tests) where
+module Test.Consensus.Byron.Serialisation
+  ( tests
+  ) where
 
 import           Codec.CBOR.Write (toLazyByteString)
 import qualified Data.ByteString.Lazy as Lazy

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/Byron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/Byron.hs
@@ -7,14 +7,14 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Test.ThreadNet.Byron (
-    tests
+module Test.ThreadNet.Byron
+  ( tests
     -- * To support the DualByron tests
   , TestSetup (..)
-  , noEBBs
   , byronPBftParams
-  , genTestSetup
   , expectedCannotForge
+  , genTestSetup
+  , noEBBs
   ) where
 
 import           Control.Monad (join)

--- a/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
+++ b/ouroboros-consensus-byron-test/test/Test/ThreadNet/DualByron.hs
@@ -5,8 +5,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.ThreadNet.DualByron (
-    tests
+module Test.ThreadNet.DualByron
+  ( tests
   ) where
 
 import           Control.Monad.Except

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Crypto/DSIGN.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Crypto/DSIGN.hs
@@ -34,9 +34,8 @@ import           Cardano.Binary
 import qualified Cardano.Chain.Block as CC.Block
 import qualified Cardano.Chain.UTxO as CC.UTxO
 import           Cardano.Crypto (ProtocolMagicId, SignTag (..), Signature (..),
-                     SigningKey (..), VerificationKey (..),
-                     deterministicKeyGen, signRaw, toVerification,
-                     verifySignatureRaw)
+                     SigningKey (..), VerificationKey (..), deterministicKeyGen,
+                     signRaw, toVerification, verifySignatureRaw)
 import           Cardano.Crypto.DSIGN.Class
 import           Cardano.Crypto.Seed (SeedBytesExhausted (..), getBytesFromSeed)
 import qualified Cardano.Crypto.Signing as Crypto

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Crypto/DSIGN.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Crypto/DSIGN.hs
@@ -15,12 +15,12 @@
 
 -- | Byron digital signatures.
 module Ouroboros.Consensus.Byron.Crypto.DSIGN
-    ( ByronDSIGN
-    , VerKeyDSIGN(..)
-    , SignKeyDSIGN(..)
-    , SigDSIGN(..)
-    , HasSignTag(..)
-    ) where
+  ( ByronDSIGN
+  , HasSignTag (..)
+  , SigDSIGN (..)
+  , SignKeyDSIGN (..)
+  , VerKeyDSIGN (..)
+  ) where
 
 
 import           Control.Exception (throw)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/EBBs.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/EBBs.hs
@@ -1,4 +1,6 @@
-module Ouroboros.Consensus.Byron.EBBs (knownEBBs) where
+module Ouroboros.Consensus.Byron.EBBs
+  ( knownEBBs
+  ) where
 
 import           Cardano.Chain.Block (HeaderHash)
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Byron.Ledger (
-    module X
+module Ouroboros.Consensus.Byron.Ledger
+  ( module X
   ) where
 
 -- Modules Aux, Conversions and Orphans are not re-exported, as they deal with

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Block.hs
@@ -9,28 +9,28 @@
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 
-module Ouroboros.Consensus.Byron.Ledger.Block (
-    -- * Hash
-    ByronHash(..)
+module Ouroboros.Consensus.Byron.Ledger.Block
+  ( -- * Hash
+    ByronHash (..)
   , mkByronHash
     -- * Block
-  , ByronBlock(..)
-  , mkByronBlock
+  , ByronBlock (..)
   , annotateByronBlock
+  , mkByronBlock
     -- * Header
-  , Header(..)
+  , Header (..)
+  , mkBoundaryByronHeader
   , mkByronHeader
   , mkRegularByronHeader
-  , mkBoundaryByronHeader
     -- * Dealing with EBBs
-  , byronHeaderIsEBB
   , byronBlockIsEBB
+  , byronHeaderIsEBB
   , knownEBBs
     -- * Low-level API
-  , UnsizedHeader(..)
+  , UnsizedHeader (..)
+  , joinSizeHint
   , mkUnsizedHeader
   , splitSizeHint
-  , joinSizeHint
   ) where
 
 import           Data.ByteString (ByteString)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Config.hs
@@ -6,18 +6,18 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Byron.Ledger.Config (
-    -- * Block config
-    BlockConfig(..)
-  , byronGenesisHash
-  , byronProtocolMagicId
-  , byronProtocolMagic
+module Ouroboros.Consensus.Byron.Ledger.Config
+  ( -- * Block config
+    BlockConfig (..)
   , byronEpochSlots
+  , byronGenesisHash
+  , byronProtocolMagic
+  , byronProtocolMagicId
     -- * Codec config
-  , CodecConfig(..)
+  , CodecConfig (..)
   , mkByronCodecConfig
     -- * Storage config
-  , StorageConfig(..)
+  , StorageConfig (..)
     -- * Compact genesis config
   , compactGenesisConfig
   ) where

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Conversions.hs
@@ -1,17 +1,17 @@
-module Ouroboros.Consensus.Byron.Ledger.Conversions (
-    -- * From @cardano-ledger-byron@ to @ouroboros-consensus@
-    fromByronSlotNo
+module Ouroboros.Consensus.Byron.Ledger.Conversions
+  ( -- * From @cardano-ledger-byron@ to @ouroboros-consensus@
+    fromByronBlockCount
   , fromByronBlockNo
-  , fromByronBlockCount
   , fromByronEpochSlots
   , fromByronSlotLength
+  , fromByronSlotNo
     -- * From @ouroboros-consensus@ to @cardano-ledger-byron@
-  , toByronSlotNo
   , toByronBlockCount
   , toByronSlotLength
+  , toByronSlotNo
     -- * Extract info from the genesis config
-  , genesisSecurityParam
   , genesisNumCoreNodes
+  , genesisSecurityParam
   , genesisSlotLength
   ) where
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -27,8 +27,8 @@ import qualified Cardano.Chain.Delegation as CC.Delegation
 import qualified Cardano.Chain.Genesis as CC.Genesis
 import qualified Cardano.Chain.Slotting as CC.Slot
 import qualified Cardano.Chain.Ssc as CC.Ssc
-import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Chain.UTxO as CC.UTxO
+import qualified Cardano.Chain.Update as CC.Update
 import qualified Cardano.Crypto as Crypto
 import           Cardano.Crypto.DSIGN
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Forge.hs
@@ -7,8 +7,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Byron.Ledger.Forge (
-    forgeByronBlock
+module Ouroboros.Consensus.Byron.Ledger.Forge
+  ( forgeByronBlock
   , forgeRegularBlock
     -- * For testing purposes
   , forgeEBB

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/HeaderValidation.hs
@@ -5,9 +5,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Byron.Ledger.HeaderValidation (
-    TipInfoIsEBB (..)
-  , ByronOtherHeaderEnvelopeError(..)
+module Ouroboros.Consensus.Byron.Ledger.HeaderValidation
+  ( ByronOtherHeaderEnvelopeError (..)
+  , TipInfoIsEBB (..)
   ) where
 
 import           Control.Monad.Except

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Inspect.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Inspect.hs
@@ -4,11 +4,11 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Byron.Ledger.Inspect (
-    ByronLedgerUpdate(..)
+module Ouroboros.Consensus.Byron.Ledger.Inspect
+  ( ByronLedgerUpdate (..)
     -- * Layer around the Byron protocol update inteface
-  , ProtocolUpdate(..)
-  , UpdateState(..)
+  , ProtocolUpdate (..)
+  , UpdateState (..)
   , protocolUpdates
   ) where
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Integrity.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Integrity.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 module Ouroboros.Consensus.Byron.Ledger.Integrity
-  ( verifyHeaderSignature
+  ( verifyBlockIntegrity
   , verifyHeaderIntegrity
-  , verifyBlockIntegrity
+  , verifyHeaderSignature
   ) where
 
 import           Data.Either (isRight)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -59,10 +59,10 @@ import           Cardano.Binary (encodeListLen, enforceSize, fromCBOR, toCBOR)
 import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Chain.Genesis as Gen
+import qualified Cardano.Chain.UTxO as CC
 import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.Update.Validation.Endorsement as UPE
 import qualified Cardano.Chain.Update.Validation.Interface as UPI
-import qualified Cardano.Chain.UTxO as CC
 import qualified Cardano.Chain.ValidationMode as CC
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Ledger.hs
@@ -16,27 +16,27 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Instances requires for consensus/ledger integration
-module Ouroboros.Consensus.Byron.Ledger.Ledger (
-    ByronTransition(..)
+module Ouroboros.Consensus.Byron.Ledger.Ledger
+  ( ByronTransition (..)
     -- * Ledger integration
-  , initByronLedgerState
   , byronEraParams
   , byronEraParamsNeverHardForks
+  , initByronLedgerState
     -- * Serialisation
-  , encodeByronAnnTip
   , decodeByronAnnTip
+  , decodeByronLedgerState
+  , decodeByronQuery
+  , decodeByronResult
+  , encodeByronAnnTip
   , encodeByronExtLedgerState
   , encodeByronHeaderState
   , encodeByronLedgerState
-  , decodeByronLedgerState
   , encodeByronQuery
-  , decodeByronQuery
   , encodeByronResult
-  , decodeByronResult
     -- * Type family instances
-  , Ticked(..)
-  , LedgerState(..)
-  , Query(..)
+  , LedgerState (..)
+  , Query (..)
+  , Ticked (..)
     -- * Auxiliary
   , validationErrorImpossible
   ) where

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -60,8 +60,8 @@ import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Byron.API as CC
 import qualified Cardano.Chain.Delegation as Delegation
 import qualified Cardano.Chain.MempoolPayload as CC
-import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.UTxO as Utxo
+import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.ValidationMode as CC
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Mempool.hs
@@ -14,25 +14,25 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Byron mempool integration
-module Ouroboros.Consensus.Byron.Ledger.Mempool (
-    -- * Mempool integration
-    GenTx(..)
-  , TxId(..)
+module Ouroboros.Consensus.Byron.Ledger.Mempool
+  ( -- * Mempool integration
+    GenTx (..)
+  , TxId (..)
     -- * Transaction IDs
-  , byronIdTx
   , byronIdDlg
   , byronIdProp
+  , byronIdTx
   , byronIdVote
     -- * Serialisation
-  , encodeByronGenTx
+  , decodeByronApplyTxError
   , decodeByronGenTx
-  , encodeByronGenTxId
   , decodeByronGenTxId
   , encodeByronApplyTxError
-  , decodeByronApplyTxError
+  , encodeByronGenTx
+  , encodeByronGenTxId
     -- * Low-level API (primarily for testing)
-  , toMempoolPayload
   , fromMempoolPayload
+  , toMempoolPayload
     -- * Auxiliary functions
   , countByronGenTxs
   ) where

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/NetworkProtocolVersion.hs
@@ -2,9 +2,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion (
-    ByronNodeToNodeVersion(..)
-  , ByronNodeToClientVersion(..)
+module Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
+  ( ByronNodeToClientVersion (..)
+  , ByronNodeToNodeVersion (..)
   ) where
 
 import qualified Data.Map.Strict as Map

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Orphans.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Orphans.hs
@@ -23,8 +23,8 @@ import qualified Cardano.Chain.Block as CC
 import qualified Cardano.Chain.Common as CC
 import qualified Cardano.Chain.Delegation as CC
 import qualified Cardano.Chain.MempoolPayload as CC
-import qualified Cardano.Chain.Update as CC
 import qualified Cardano.Chain.UTxO as CC
+import qualified Cardano.Chain.Update as CC
 
 import           Ouroboros.Consensus.Util.Condense
 

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Orphans.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Orphans.hs
@@ -5,7 +5,9 @@
 {-# LANGUAGE StandaloneDeriving #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Byron.Ledger.Orphans () where
+module Ouroboros.Consensus.Byron.Ledger.Orphans
+  (
+  ) where
 
 import           Codec.Serialise (Serialise, decode, encode)
 import           Control.Monad (void)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/PBFT.hs
@@ -6,13 +6,13 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 -- | Instances required to support PBFT
-module Ouroboros.Consensus.Byron.Ledger.PBFT (
-    toPBftLedgerView
-  , toTickedPBftLedgerView
-  , fromPBftLedgerView
+module Ouroboros.Consensus.Byron.Ledger.PBFT
+  ( decodeByronChainDepState
   , encodeByronChainDepState
-  , decodeByronChainDepState
+  , fromPBftLedgerView
   , mkByronContextDSIGN
+  , toPBftLedgerView
+  , toTickedPBftLedgerView
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Ledger/Serialisation.hs
@@ -11,31 +11,31 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Byron.Ledger.Serialisation (
-    -- * Data family instances
-    NestedCtxt_(..)
-  , RawHeader
+module Ouroboros.Consensus.Byron.Ledger.Serialisation
+  ( -- * Data family instances
+    NestedCtxt_ (..)
   , RawBoundaryHeader
+  , RawHeader
     -- * Serialisation
   , byronBlockEncodingOverhead
-  , encodeByronBlock
   , decodeByronBlock
-  , decodeByronRegularBlock
   , decodeByronBoundaryBlock
-  , encodeByronRegularHeader
-  , decodeByronRegularHeader
-  , encodeByronBoundaryHeader
   , decodeByronBoundaryHeader
-  , encodeByronHeaderHash
   , decodeByronHeaderHash
+  , decodeByronRegularBlock
+  , decodeByronRegularHeader
+  , encodeByronBlock
+  , encodeByronBoundaryHeader
+  , encodeByronHeaderHash
+  , encodeByronRegularHeader
     -- * Support for on-disk format
   , byronBinaryBlockInfo
     -- * Unsized header
   , addV1Envelope
-  , dropV1Envelope
-  , fakeByronBlockSizeHint
-  , encodeUnsizedHeader
   , decodeUnsizedHeader
+  , dropV1Envelope
+  , encodeUnsizedHeader
+  , fakeByronBlockSizeHint
   ) where
 
 import           Control.Monad.Except

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node.hs
@@ -6,16 +6,16 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Byron.Node (
-    protocolInfoByron
-  , ProtocolParamsByron(..)
-  , protocolClientInfoByron
-  , mkByronConfig
-  , PBftSignatureThreshold(..)
-  , defaultPBftSignatureThreshold
+module Ouroboros.Consensus.Byron.Node
+  ( PBftSignatureThreshold (..)
+  , ProtocolParamsByron (..)
   , byronBlockForging
+  , defaultPBftSignatureThreshold
+  , mkByronConfig
+  , protocolClientInfoByron
+  , protocolInfoByron
     -- * Secrets
-  , ByronLeaderCredentials(..)
+  , ByronLeaderCredentials (..)
   , ByronLeaderCredentialsError
   , mkByronLeaderCredentials
   , mkPBftCanBeLeader

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Node/Serialisation.hs
@@ -8,7 +8,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Byron.Node.Serialisation () where
+module Ouroboros.Consensus.Byron.Node.Serialisation
+  (
+  ) where
 
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Encoding as CBOR

--- a/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Protocol.hs
+++ b/ouroboros-consensus-byron/src/Ouroboros/Consensus/Byron/Protocol.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies          #-}
-module Ouroboros.Consensus.Byron.Protocol (
-    PBftByronCrypto
+module Ouroboros.Consensus.Byron.Protocol
+  ( PBftByronCrypto
   , genesisKeyCoreNodeId
   , nodeIdToGenesisKey
   ) where

--- a/ouroboros-consensus-byron/tools/db-converter/Main.hs
+++ b/ouroboros-consensus-byron/tools/db-converter/Main.hs
@@ -7,7 +7,9 @@
 {-# LANGUAGE TypeOperators      #-}
 
 -- | Database conversion tool.
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import           Control.Monad.Except (liftIO, runExceptT)
 import           Control.Monad.Trans.Resource (runResourceT)

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger.hs
@@ -10,10 +10,10 @@ module Ouroboros.Consensus.ByronSpec.Ledger (
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Block as X
 import           Ouroboros.Consensus.ByronSpec.Ledger.Forge as X
-import           Ouroboros.Consensus.ByronSpec.Ledger.Genesis as X
-                     (ByronSpecGenesis (..))
 import           Ouroboros.Consensus.ByronSpec.Ledger.GenTx as X
                      (ByronSpecGenTx (..), ByronSpecGenTxErr (..))
+import           Ouroboros.Consensus.ByronSpec.Ledger.Genesis as X
+                     (ByronSpecGenesis (..))
 import           Ouroboros.Consensus.ByronSpec.Ledger.Ledger as X
 import           Ouroboros.Consensus.ByronSpec.Ledger.Mempool as X
 import           Ouroboros.Consensus.ByronSpec.Ledger.Orphans as X ()

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.ByronSpec.Ledger (
-    module X
+module Ouroboros.Consensus.ByronSpec.Ledger
+  ( module X
   ) where
 
 -- Not all modules are re-exported, as some deal with wrapping

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Accessors.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Accessors.hs
@@ -3,20 +3,20 @@
 {-# LANGUAGE TupleSections   #-}
 
 -- | Working with the Byron spec chain state
-module Ouroboros.Consensus.ByronSpec.Ledger.Accessors (
-    -- * ChainState getters
+module Ouroboros.Consensus.ByronSpec.Ledger.Accessors
+  ( -- * ChainState getters
     GetChainState
-  , getChainStateSlot
-  , getChainStateHash
-  , getChainStateUtxoState
   , getChainStateDIState
+  , getChainStateHash
+  , getChainStateSlot
   , getChainStateUPIState
+  , getChainStateUtxoState
     -- * ChainState modifiers
   , ModChainState
-  , modChainStateSlot
-  , modChainStateUtxoState
   , modChainStateDIState
+  , modChainStateSlot
   , modChainStateUPIState
+  , modChainStateUtxoState
     -- * Auxiliary
   , getDIStateDSState
   , modDIStateDSState

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Block.hs
@@ -4,13 +4,14 @@
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE TypeFamilies      #-}
 
-module Ouroboros.Consensus.ByronSpec.Ledger.Block (
-    ByronSpecBlock(..)
-  , ByronSpecHeader -- type alias
-  , Header(..)
-  , BlockConfig(..)
-  , CodecConfig(..)
-  , StorageConfig(..)
+module Ouroboros.Consensus.ByronSpec.Ledger.Block
+  ( ByronSpecBlock (..)
+  , ByronSpecHeader
+    -- type alias
+  , BlockConfig (..)
+  , CodecConfig (..)
+  , Header (..)
+  , StorageConfig (..)
   ) where
 
 import           Codec.Serialise

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Conversions.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Conversions.hs
@@ -1,8 +1,8 @@
 -- | Conversions from ouroboros-consensus types to the Byron spec types
 --
 -- Intended for unqualified import.
-module Ouroboros.Consensus.ByronSpec.Ledger.Conversions (
-    -- * Spec to consensus
+module Ouroboros.Consensus.ByronSpec.Ledger.Conversions
+  ( -- * Spec to consensus
     fromByronSpecPrevHash
   , fromByronSpecSlotNo
     -- * Consensus to spec

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Forge.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Forge.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Ouroboros.Consensus.ByronSpec.Ledger.Forge (
-    forgeByronSpecBlock
+module Ouroboros.Consensus.ByronSpec.Ledger.Forge
+  ( forgeByronSpecBlock
   ) where
 
 import qualified Byron.Spec.Chain.STS.Block as Spec

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/GenTx.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/GenTx.hs
@@ -21,8 +21,8 @@ import           GHC.Generics (Generic)
 
 import qualified Byron.Spec.Chain.STS.Rule.Chain as Spec
 import qualified Byron.Spec.Ledger.Delegation as Spec
-import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Byron.Spec.Ledger.UTxO as Spec
+import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Control.State.Transition as Spec
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Genesis

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/GenTx.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/GenTx.hs
@@ -8,9 +8,9 @@
 --
 -- > import           Ouroboros.Consensus.ByronSpec.Ledger.GenTx (ByronSpecGenTx(..), ByronSpecGenTxErr(..))
 -- > import qualified Ouroboros.Consensus.ByronSpec.Ledger.GenTx as GenTx
-module Ouroboros.Consensus.ByronSpec.Ledger.GenTx (
-    ByronSpecGenTx(..)
-  , ByronSpecGenTxErr(..)
+module Ouroboros.Consensus.ByronSpec.Ledger.GenTx
+  ( ByronSpecGenTx (..)
+  , ByronSpecGenTxErr (..)
   , apply
   , partition
   ) where

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Genesis.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Genesis.hs
@@ -27,8 +27,8 @@ import           Numeric.Natural (Natural)
 
 import qualified Byron.Spec.Chain.STS.Rule.Chain as Spec
 import qualified Byron.Spec.Ledger.Core as Spec
-import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Byron.Spec.Ledger.UTxO as Spec
+import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Control.State.Transition as Spec
 
 import           Ouroboros.Consensus.ByronSpec.Ledger.Orphans ()

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Genesis.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Genesis.hs
@@ -8,16 +8,16 @@
 --
 -- > import           Ouroboros.Consensus.ByronSpec.Ledger.Genesis (ByronSpecGenesis)
 -- > import qualified Ouroboros.Consensus.ByronSpec.Ledger.Genesis as Genesis
-module Ouroboros.Consensus.ByronSpec.Ledger.Genesis (
-    ByronSpecGenesis(..)
-  , modPBftThreshold
+module Ouroboros.Consensus.ByronSpec.Ledger.Genesis
+  ( ByronSpecGenesis (..)
   , modFeeParams
+  , modPBftThreshold
+  , modPParams
   , modUtxo
   , modUtxoValues
-  , modPParams
     -- * Conversions
-  , toChainEnv
   , fromChainEnv
+  , toChainEnv
   ) where
 
 import           Data.Coerce (coerce)

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Ledger.hs
@@ -8,12 +8,12 @@
 
 {-# OPTIONS -Wno-orphans #-}
 
-module Ouroboros.Consensus.ByronSpec.Ledger.Ledger (
-    ByronSpecLedgerError(..)
+module Ouroboros.Consensus.ByronSpec.Ledger.Ledger
+  ( ByronSpecLedgerError (..)
   , initByronSpecLedgerState
     -- * Type family instances
-  , LedgerState(..)
-  , Ticked(..)
+  , LedgerState (..)
+  , Ticked (..)
   ) where
 
 import           Codec.Serialise

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Mempool.hs
@@ -5,9 +5,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.ByronSpec.Ledger.Mempool (
-    -- * Type family instances
-    GenTx(..)
+module Ouroboros.Consensus.ByronSpec.Ledger.Mempool
+  ( -- * Type family instances
+    GenTx (..)
   ) where
 
 import           Codec.Serialise

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Orphans.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Orphans.hs
@@ -31,8 +31,8 @@ import qualified Byron.Spec.Ledger.Delegation as Spec
 import qualified Byron.Spec.Ledger.STS.UTXO as Spec
 import qualified Byron.Spec.Ledger.STS.UTXOW as Spec
 import qualified Byron.Spec.Ledger.STS.UTXOWS as Spec
-import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Byron.Spec.Ledger.UTxO as Spec
+import qualified Byron.Spec.Ledger.Update as Spec
 import qualified Control.State.Transition as Spec
 
 import           Test.Cardano.Chain.Elaboration.Block as Spec.Test

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Orphans.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Orphans.hs
@@ -8,7 +8,9 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Missing instances for standard type classes in the Byron spec
-module Ouroboros.Consensus.ByronSpec.Ledger.Orphans () where
+module Ouroboros.Consensus.ByronSpec.Ledger.Orphans
+  (
+  ) where
 
 import           Codec.CBOR.Encoding (encodeListLen)
 import           Codec.Serialise

--- a/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Rules.hs
+++ b/ouroboros-consensus-byronspec/src/Ouroboros/Consensus/ByronSpec/Ledger/Rules.hs
@@ -10,26 +10,26 @@
 -- Intended for qualified import
 --
 -- import qualified Ouroboros.Consensus.ByronSpec.Ledger.Rules as Rules
-module Ouroboros.Consensus.ByronSpec.Ledger.Rules (
-    -- * Ledger
+module Ouroboros.Consensus.ByronSpec.Ledger.Rules
+  ( -- * Ledger
     applyChainTick
     -- * Lift STS transition rules to the chain level
   , liftCHAIN
   , liftSDELEG
-  , liftUTXOW
   , liftUPIREG
   , liftUPIVOTE
+  , liftUTXOW
     -- * STS initial rules
   , initStateCHAIN
     -- * Rule context (exported for the benefit of the tests
-  , RuleContext(..)
+  , RuleContext (..)
   , ctxtCHAIN
-  , ctxtEPOCH
   , ctxtDELEG
+  , ctxtEPOCH
   , ctxtSDELEG
-  , ctxtUTXOW
   , ctxtUPIREG
   , ctxtUPIVOTE
+  , ctxtUTXOW
   ) where
 
 import           Control.Monad

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Examples.hs
@@ -5,21 +5,21 @@
 {-# LANGUAGE TypeOperators       #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Consensus.Cardano.Examples (
-    -- * Setup
+module Test.Consensus.Cardano.Examples
+  ( -- * Setup
     codecConfig
     -- * Examples
-  , examples
-  , exampleEraMismatchByron
-  , exampleEraMismatchShelley
   , exampleApplyTxErrWrongEraByron
   , exampleApplyTxErrWrongEraShelley
+  , exampleEraMismatchByron
+  , exampleEraMismatchShelley
+  , exampleQueryAnytimeShelley
   , exampleQueryEraMismatchByron
   , exampleQueryEraMismatchShelley
-  , exampleQueryAnytimeShelley
+  , exampleResultAnytimeShelley
   , exampleResultEraMismatchByron
   , exampleResultEraMismatchShelley
-  , exampleResultAnytimeShelley
+  , examples
   ) where
 
 import           Data.Coerce (Coercible)

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Generators.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/Generators.hs
@@ -19,8 +19,8 @@
 --
 -- We combine the Byron and Shelley-based instances defined elsewhere into
 -- Cardano instances by picking randomly from one of the eras.
-module Test.Consensus.Cardano.Generators (
-    module Test.Consensus.Byron.Generators
+module Test.Consensus.Cardano.Generators
+  ( module Test.Consensus.Byron.Generators
   ) where
 
 import qualified Data.Map.Strict as Map

--- a/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/MockCrypto.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/Consensus/Cardano/MockCrypto.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Consensus.Cardano.MockCrypto (
-    MockCryptoCompatByron
+module Test.Consensus.Cardano.MockCrypto
+  ( MockCryptoCompatByron
   ) where
 
 import           Cardano.Crypto.DSIGN (Ed25519DSIGN)

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/ShelleyBasedHardFork.hs
@@ -11,10 +11,10 @@
 
 -- | Test infrastructure to test hard-forking from one Shelley-based era to
 -- another, e.g., Shelley to Allegra.
-module Test.ThreadNet.Infra.ShelleyBasedHardFork (
-    -- * Blocks
-    ShelleyBasedHardForkEras
-  , ShelleyBasedHardForkBlock
+module Test.ThreadNet.Infra.ShelleyBasedHardFork
+  ( -- * Blocks
+    ShelleyBasedHardForkBlock
+  , ShelleyBasedHardForkEras
     -- * Transactions
   , pattern GenTxShelley1
   , pattern GenTxShelley2

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/TwoEras.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/Infra/TwoEras.hs
@@ -7,13 +7,13 @@
 {-# LANGUAGE TypeOperators  #-}
 
 -- | Definitions used in ThreadNet tests that involve two eras.
-module Test.ThreadNet.Infra.TwoEras (
-    -- * Generators
+module Test.ThreadNet.Infra.TwoEras
+  ( -- * Generators
     Partition (..)
   , genNonce
   , genPartition
   , genTestConfig
-  -- * Era inspection
+    -- * Era inspection
   , ReachesEra2 (..)
   , activeSlotCoeff
   , isFirstEraBlock
@@ -23,9 +23,9 @@ module Test.ThreadNet.Infra.TwoEras (
   , partitionExclusiveUpperBound
   , secondEraOverlaySlots
   , shelleyEpochSize
-  -- * Properties
-  , label_hadActiveNonOverlaySlots
+    -- * Properties
   , label_ReachesEra2
+  , label_hadActiveNonOverlaySlots
   , prop_ReachesEra2
   , tabulateFinalIntersectionDepth
   , tabulatePartitionDuration

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Allegra.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Allegra.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.ThreadNet.TxGen.Allegra () where
+module Test.ThreadNet.TxGen.Allegra
+  (
+  ) where
 
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -16,9 +16,9 @@ import           Control.Exception (assert)
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe (maybeToList)
+import           Data.SOP.Strict
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
-import           Data.SOP.Strict
 
 import           Ouroboros.Consensus.Block (SlotNo (..))
 import           Ouroboros.Consensus.Config
@@ -39,10 +39,10 @@ import           Cardano.Chain.Genesis (GeneratedSecrets (..))
 
 import qualified Cardano.Ledger.SafeHash as SL
 import           Cardano.Ledger.Val ((<->))
+import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.Address as SL (BootstrapAddress (..))
 import qualified Shelley.Spec.Ledger.Address.Bootstrap as SL
                      (makeBootstrapWitness)
-import qualified Shelley.Spec.Ledger.API as SL
 import qualified Shelley.Spec.Ledger.BaseTypes as SL (truncateUnitInterval)
 import qualified Shelley.Spec.Ledger.Tx as SL (WitnessSetHKD (..))
 import qualified Shelley.Spec.Ledger.UTxO as SL (makeWitnessVKey)

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Cardano.hs
@@ -7,8 +7,8 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.ThreadNet.TxGen.Cardano (
-    CardanoTxGenExtra (..),
+module Test.ThreadNet.TxGen.Cardano
+  ( CardanoTxGenExtra (..)
   ) where
 
 import           Control.Exception (assert)

--- a/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Mary.hs
+++ b/ouroboros-consensus-cardano-test/src/Test/ThreadNet/TxGen/Mary.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.ThreadNet.TxGen.Mary () where
+module Test.ThreadNet.TxGen.Mary
+  (
+  ) where
 
 import           Ouroboros.Consensus.Shelley.Eras
 import           Ouroboros.Consensus.Shelley.Ledger

--- a/ouroboros-consensus-cardano-test/test/Main.hs
+++ b/ouroboros-consensus-cardano-test/test/Main.hs
@@ -1,4 +1,6 @@
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import           Cardano.Crypto.Libsodium (sodiumInit)
 

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/ByronCompatibility.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/ByronCompatibility.hs
@@ -10,7 +10,9 @@
 {-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
-module Test.Consensus.Cardano.ByronCompatibility (tests) where
+module Test.Consensus.Cardano.ByronCompatibility
+  ( tests
+  ) where
 
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Golden.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Golden.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Consensus.Cardano.Golden (tests) where
+module Test.Consensus.Cardano.Golden
+  ( tests
+  ) where
 
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation
 

--- a/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Serialisation.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/Consensus/Cardano/Serialisation.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-module Test.Consensus.Cardano.Serialisation (tests) where
+module Test.Consensus.Cardano.Serialisation
+  ( tests
+  ) where
 
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString.Lazy as Lazy

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/AllegraMary.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/AllegraMary.hs
@@ -22,9 +22,9 @@ import           Control.Monad (replicateM)
 import qualified Data.Map as Map
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
+import           Data.SOP.Strict (NP (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.SOP.Strict (NP (..))
 import           Data.Word (Word64)
 
 import           Test.QuickCheck

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/AllegraMary.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/AllegraMary.hs
@@ -14,8 +14,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.ThreadNet.AllegraMary (
-    tests
+module Test.ThreadNet.AllegraMary
+  ( tests
   ) where
 
 import           Control.Monad (replicateM)

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/Cardano.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Test.ThreadNet.Cardano (
-    tests
+module Test.ThreadNet.Cardano
+  ( tests
   ) where
 
 import           Control.Exception (assert)

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
@@ -22,9 +22,9 @@ import           Control.Monad (replicateM)
 import qualified Data.Map as Map
 import           Data.Maybe (maybeToList)
 import           Data.Proxy (Proxy (..))
+import           Data.SOP.Strict (NP (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.SOP.Strict (NP (..))
 import           Data.Word (Word64)
 
 import           Test.QuickCheck

--- a/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
+++ b/ouroboros-consensus-cardano-test/test/Test/ThreadNet/ShelleyAllegra.hs
@@ -14,8 +14,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.ThreadNet.ShelleyAllegra (
-    tests
+module Test.ThreadNet.ShelleyAllegra
+  ( tests
   ) where
 
 import           Control.Monad (replicateM)

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano.hs
@@ -4,29 +4,28 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators       #-}
 
-module Ouroboros.Consensus.Cardano (
-    -- * The block type of the Cardano block chain
+module Ouroboros.Consensus.Cardano
+  ( -- * The block type of the Cardano block chain
     CardanoBlock
     -- * Supported protocols
   , ProtocolByron
-  , ProtocolShelley
   , ProtocolCardano
+  , ProtocolShelley
     -- * Abstract over the various protocols
-  , ProtocolParamsByron(..)
-  , ProtocolParamsShelley(..)
-  , ProtocolParamsAllegra(..)
-  , ProtocolParamsMary(..)
-  , ProtocolParamsTransition(..)
-  , Protocol(..)
+  , Protocol (..)
+  , ProtocolParamsAllegra (..)
+  , ProtocolParamsByron (..)
+  , ProtocolParamsMary (..)
+  , ProtocolParamsShelley (..)
+  , ProtocolParamsTransition (..)
   , verifyProtocol
     -- * Data required to run a protocol
   , protocolInfo
     -- * Evidence that we can run all the supported protocols
-  , runProtocol
   , module X
-
+  , runProtocol
     -- * Client support for nodes running a protocol
-  , ProtocolClient(..)
+  , ProtocolClient (..)
   , protocolClientInfo
   , runProtocolClient
   , verifyProtocolClient

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Block.hs
@@ -4,10 +4,10 @@
 {-# LANGUAGE GADTs                    #-}
 {-# LANGUAGE PatternSynonyms          #-}
 {-# LANGUAGE ViewPatterns             #-}
-module Ouroboros.Consensus.Cardano.Block (
-    -- * Eras
-    module Ouroboros.Consensus.Shelley.Eras
-  , CardanoEras
+module Ouroboros.Consensus.Cardano.Block
+  ( -- * Eras
+    CardanoEras
+  , module Ouroboros.Consensus.Shelley.Eras
   , ShelleyBasedEras
     -- * Block
   , CardanoBlock
@@ -16,90 +16,37 @@ module Ouroboros.Consensus.Cardano.Block (
     -- checks from GHC. But GHC expects a data type, not a type family, that's
     -- why we sometimes mention the data type of the instance in these exports
     -- instead of the abstract type family.
-  , HardForkBlock (
-        BlockByron
-      , BlockShelley
-      , BlockAllegra
-      , BlockMary
-      )
+  , HardForkBlock (BlockByron, BlockShelley, BlockAllegra, BlockMary)
     -- * Headers
   , CardanoHeader
-  , Header (
-        HeaderByron
-      , HeaderShelley
-      , HeaderAllegra
-      , HeaderMary
-      )
+  , Header (HeaderByron, HeaderShelley, HeaderAllegra, HeaderMary)
     -- * Generalised transactions
-  , CardanoGenTx
-  , GenTx (
-        GenTxByron
-      , GenTxShelley
-      , GenTxAllegra
-      , GenTxMary
-      )
-  , CardanoGenTxId
-  , TxId (
-        GenTxIdByron
-      , GenTxIdShelley
-      , GenTxIdAllegra
-      , GenTxIdMary
-      )
   , CardanoApplyTxErr
-  , HardForkApplyTxErr (
-        ApplyTxErrByron
-      , ApplyTxErrShelley
-      , ApplyTxErrAllegra
-      , ApplyTxErrMary
-      , ApplyTxErrWrongEra
-      )
+  , CardanoGenTx
+  , CardanoGenTxId
+  , GenTx (GenTxByron, GenTxShelley, GenTxAllegra, GenTxMary)
+  , HardForkApplyTxErr (ApplyTxErrByron, ApplyTxErrShelley, ApplyTxErrAllegra, ApplyTxErrMary, ApplyTxErrWrongEra)
+  , TxId (GenTxIdByron, GenTxIdShelley, GenTxIdAllegra, GenTxIdMary)
     -- * LedgerError
   , CardanoLedgerError
-  , HardForkLedgerError (
-        LedgerErrorByron
-      , LedgerErrorShelley
-      , LedgerErrorAllegra
-      , LedgerErrorMary
-      , LedgerErrorWrongEra
-      )
+  , HardForkLedgerError (LedgerErrorByron, LedgerErrorShelley, LedgerErrorAllegra, LedgerErrorMary, LedgerErrorWrongEra)
     -- * OtherEnvelopeError
   , CardanoOtherHeaderEnvelopeError
-  , HardForkEnvelopeErr (
-        OtherHeaderEnvelopeErrorByron
-      , OtherHeaderEnvelopeErrorShelley
-      , OtherHeaderEnvelopeErrorAllegra
-      , OtherHeaderEnvelopeErrorMary
-      , OtherHeaderEnvelopeErrorWrongEra
-      )
+  , HardForkEnvelopeErr (OtherHeaderEnvelopeErrorByron, OtherHeaderEnvelopeErrorShelley, OtherHeaderEnvelopeErrorAllegra, OtherHeaderEnvelopeErrorMary, OtherHeaderEnvelopeErrorWrongEra)
     -- * TipInfo
   , CardanoTipInfo
-  , OneEraTipInfo (
-        TipInfoByron
-      , TipInfoShelley
-      , TipInfoAllegra
-      , TipInfoMary
-      )
+  , OneEraTipInfo (TipInfoByron, TipInfoShelley, TipInfoAllegra, TipInfoMary)
     -- * Query
   , CardanoQuery
-  , Query (
-        QueryIfCurrentByron
-      , QueryIfCurrentShelley
-      , QueryIfCurrentAllegra
-      , QueryIfCurrentMary
-      , QueryAnytimeByron
-      , QueryAnytimeShelley
-      , QueryAnytimeAllegra
-      , QueryAnytimeMary
-      , QueryHardFork
-     )
   , CardanoQueryResult
   , Either (QueryResultSuccess, QueryResultEraMismatch)
+  , Query (QueryIfCurrentByron, QueryIfCurrentShelley, QueryIfCurrentAllegra, QueryIfCurrentMary, QueryAnytimeByron, QueryAnytimeShelley, QueryAnytimeAllegra, QueryAnytimeMary, QueryHardFork)
     -- * CodecConfig
   , CardanoCodecConfig
   , CodecConfig (CardanoCodecConfig)
     -- * BlockConfig
-  , CardanoBlockConfig
   , BlockConfig (CardanoBlockConfig)
+  , CardanoBlockConfig
     -- * StorageConfig
   , CardanoStorageConfig
   , StorageConfig (CardanoStorageConfig)
@@ -111,20 +58,10 @@ module Ouroboros.Consensus.Cardano.Block (
   , HardForkLedgerConfig (CardanoLedgerConfig)
     -- * LedgerState
   , CardanoLedgerState
-  , LedgerState (
-        LedgerStateByron
-      , LedgerStateShelley
-      , LedgerStateAllegra
-      , LedgerStateMary
-      )
+  , LedgerState (LedgerStateByron, LedgerStateShelley, LedgerStateAllegra, LedgerStateMary)
     -- * ChainDepState
   , CardanoChainDepState
-  , HardForkState (
-        ChainDepStateByron
-      , ChainDepStateShelley
-      , ChainDepStateAllegra
-      , ChainDepStateMary
-      )
+  , HardForkState (ChainDepStateByron, ChainDepStateShelley, ChainDepStateAllegra, ChainDepStateMary)
     -- * EraMismatch
   , EraMismatch (..)
   ) where

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ByronHFC.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ByronHFC.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeApplications  #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Cardano.ByronHFC (
-    ByronBlockHFC
+module Ouroboros.Consensus.Cardano.ByronHFC
+  ( ByronBlockHFC
   ) where
 
 import qualified Data.Map.Strict as Map

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -31,7 +31,7 @@ import           Control.Monad.Except (Except, runExcept, throwError)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (listToMaybe, mapMaybe)
 import           Data.Proxy
-import           Data.SOP.Strict ((:.:) (..), NP (..), unComp)
+import           Data.SOP.Strict (NP (..), unComp, (:.:) (..))
 import           Data.Void (Void)
 import           Data.Word
 import           GHC.Generics (Generic)

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/CanHardFork.hs
@@ -17,11 +17,11 @@
 {-# LANGUAGE TypeOperators            #-}
 {-# LANGUAGE UndecidableInstances     #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Cardano.CanHardFork (
-    TriggerHardFork (..)
-  , ByronPartialLedgerConfig (..)
-  , ShelleyPartialLedgerConfig (..)
+module Ouroboros.Consensus.Cardano.CanHardFork
+  ( ByronPartialLedgerConfig (..)
   , CardanoHardForkConstraints
+  , ShelleyPartialLedgerConfig (..)
+  , TriggerHardFork (..)
   , forecastAcrossShelley
   , translateChainDepStateAcrossShelley
   ) where

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Condense.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Condense.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Cardano.Condense () where
+module Ouroboros.Consensus.Cardano.Condense
+  (
+  ) where
 
 import           Ouroboros.Consensus.HardFork.Combinator.Condense
 

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/Node.hs
@@ -10,26 +10,26 @@
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Cardano.Node (
-    protocolInfoCardano
-  , ProtocolParamsTransition (..)
+module Ouroboros.Consensus.Cardano.Node
+  ( CardanoHardForkConstraints
+  , MaxMajorProtVer (..)
   , ProtocolParamsAllegra (..)
   , ProtocolParamsMary (..)
-  , protocolClientInfoCardano
-  , CardanoHardForkConstraints
-  , MaxMajorProtVer (..)
+  , ProtocolParamsTransition (..)
   , TriggerHardFork (..)
+  , protocolClientInfoCardano
+  , protocolInfoCardano
     -- * SupportedNetworkProtocolVersion
-  , pattern CardanoNodeToNodeVersion1
-  , pattern CardanoNodeToNodeVersion2
-  , pattern CardanoNodeToNodeVersion3
-  , pattern CardanoNodeToNodeVersion4
   , pattern CardanoNodeToClientVersion1
   , pattern CardanoNodeToClientVersion2
   , pattern CardanoNodeToClientVersion3
   , pattern CardanoNodeToClientVersion4
   , pattern CardanoNodeToClientVersion5
   , pattern CardanoNodeToClientVersion6
+  , pattern CardanoNodeToNodeVersion1
+  , pattern CardanoNodeToNodeVersion2
+  , pattern CardanoNodeToNodeVersion3
+  , pattern CardanoNodeToNodeVersion4
   ) where
 
 import qualified Codec.CBOR.Decoding as CBOR

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ShelleyBased.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ShelleyBased.hs
@@ -6,8 +6,8 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
-module Ouroboros.Consensus.Cardano.ShelleyBased (
-    -- * Injection from Shelley-based eras into the Cardano eras
+module Ouroboros.Consensus.Cardano.ShelleyBased
+  ( -- * Injection from Shelley-based eras into the Cardano eras
     InjectShelley
   , injectShelleyNP
   , injectShelleyOptNP

--- a/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ShelleyHFC.hs
+++ b/ouroboros-consensus-cardano/src/Ouroboros/Consensus/Cardano/ShelleyHFC.hs
@@ -3,8 +3,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Cardano.ShelleyHFC (
-    ShelleyBlockHFC
+module Ouroboros.Consensus.Cardano.ShelleyHFC
+  ( ShelleyBlockHFC
   ) where
 
 import qualified Data.Map.Strict as Map

--- a/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
@@ -3,10 +3,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Analysis (
-    AnalysisName (..)
+module Analysis
+  ( AnalysisEnv (..)
+  , AnalysisName (..)
   , runAnalysis
-  , AnalysisEnv (..)
   ) where
 
 import           Control.Monad.Except

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
@@ -23,8 +23,8 @@ import qualified Cardano.Crypto as Crypto
 
 import qualified Cardano.Chain.Block as Chain
 import qualified Cardano.Chain.Genesis as Genesis
-import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.UTxO as Chain
+import qualified Cardano.Chain.Update as Update
 
 import           Ouroboros.Consensus.Node.ProtocolInfo
 

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Byron.hs
@@ -5,8 +5,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Block.Byron (
-    Args (..)
+module Block.Byron
+  ( Args (..)
   , ByronBlockArgs
   , openGenesisByron
   ) where

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Cardano.hs
@@ -8,8 +8,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Block.Cardano (
-    Args (..)
+module Block.Cardano
+  ( Args (..)
   , CardanoBlockArgs
   ) where
 

--- a/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Block/Shelley.hs
@@ -9,8 +9,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Block.Shelley (
-    Args (..)
+module Block.Shelley
+  ( Args (..)
   , ShelleyBlockArgs
   ) where
 

--- a/ouroboros-consensus-cardano/tools/db-analyser/HasAnalysis.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/HasAnalysis.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
-module HasAnalysis (
-    HasAnalysis (..)
+module HasAnalysis
+  ( HasAnalysis (..)
   , HasProtocolInfo (..)
   , SizeInBytes
   ) where

--- a/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Main.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE RecordWildCards  #-}
 -- | Database analyse tool.
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import           Data.Foldable (asum)
 import           Options.Applicative

--- a/ouroboros-consensus-mock-test/src/Test/Consensus/Ledger/Mock/Generators.hs
+++ b/ouroboros-consensus-mock-test/src/Test/Consensus/Ledger/Mock/Generators.hs
@@ -10,7 +10,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Consensus.Ledger.Mock.Generators () where
+module Test.Consensus.Ledger.Mock.Generators
+  (
+  ) where
 
 import           Codec.Serialise (Serialise, encode, serialise)
 import           Control.Monad

--- a/ouroboros-consensus-mock-test/src/Test/ThreadNet/TxGen/Mock.hs
+++ b/ouroboros-consensus-mock-test/src/Test/ThreadNet/TxGen/Mock.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.ThreadNet.TxGen.Mock () where
+module Test.ThreadNet.TxGen.Mock
+  (
+  ) where
 
 import           Control.Monad (replicateM)
 import qualified Data.Map.Strict as Map

--- a/ouroboros-consensus-mock-test/src/Test/ThreadNet/Util/HasCreator/Mock.hs
+++ b/ouroboros-consensus-mock-test/src/Test/ThreadNet/Util/HasCreator/Mock.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE FlexibleInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.ThreadNet.Util.HasCreator.Mock () where
+module Test.ThreadNet.Util.HasCreator.Mock
+  (
+  ) where
 
 import           Cardano.Crypto.DSIGN
 import           Data.Word (Word64)

--- a/ouroboros-consensus-mock-test/src/Test/ThreadNet/Util/SimpleBlock.hs
+++ b/ouroboros-consensus-mock-test/src/Test/ThreadNet/Util/SimpleBlock.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 
-module Test.ThreadNet.Util.SimpleBlock (
-  prop_validSimpleBlock,
+module Test.ThreadNet.Util.SimpleBlock
+  ( prop_validSimpleBlock
   ) where
 
 import           Data.Typeable

--- a/ouroboros-consensus-mock-test/test/Main.hs
+++ b/ouroboros-consensus-mock-test/test/Main.hs
@@ -1,4 +1,6 @@
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import           Test.Tasty
 

--- a/ouroboros-consensus-mock-test/test/Test/Consensus/Ledger/Mock.hs
+++ b/ouroboros-consensus-mock-test/test/Test/Consensus/Ledger/Mock.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Test.Consensus.Ledger.Mock (tests) where
+module Test.Consensus.Ledger.Mock
+  ( tests
+  ) where
 
 import           Codec.CBOR.Write (toLazyByteString)
 import           Codec.Serialise (Serialise, encode)

--- a/ouroboros-consensus-mock-test/test/Test/ThreadNet/BFT.hs
+++ b/ouroboros-consensus-mock-test/test/Test/ThreadNet/BFT.hs
@@ -3,8 +3,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Test.ThreadNet.BFT (
-    tests
+module Test.ThreadNet.BFT
+  ( tests
   ) where
 
 import           Test.QuickCheck

--- a/ouroboros-consensus-mock-test/test/Test/ThreadNet/LeaderSchedule.hs
+++ b/ouroboros-consensus-mock-test/test/Test/ThreadNet/LeaderSchedule.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE RecordWildCards  #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Test.ThreadNet.LeaderSchedule (
-    tests
+module Test.ThreadNet.LeaderSchedule
+  ( tests
   ) where
 
 import           Control.Monad (replicateM)

--- a/ouroboros-consensus-mock-test/test/Test/ThreadNet/PBFT.hs
+++ b/ouroboros-consensus-mock-test/test/Test/ThreadNet/PBFT.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Test.ThreadNet.PBFT (
-    tests
+module Test.ThreadNet.PBFT
+  ( tests
   ) where
 
 import qualified Data.Map.Strict as Map

--- a/ouroboros-consensus-mock-test/test/Test/ThreadNet/Praos.hs
+++ b/ouroboros-consensus-mock-test/test/Test/ThreadNet/Praos.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Test.ThreadNet.Praos (
-    tests
+module Test.ThreadNet.Praos
+  ( tests
   ) where
 
 import           Data.Word (Word64)

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Mock.Ledger (
-    module X
+module Ouroboros.Consensus.Mock.Ledger
+  ( module X
   ) where
 
 import           Ouroboros.Consensus.Mock.Ledger.Address as X

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Address.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Address.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Ouroboros.Consensus.Mock.Ledger.Address (
-    Addr
+module Ouroboros.Consensus.Mock.Ledger.Address
+  ( Addr
   , AddrDist
   , mkAddrDist
   ) where

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block.hs
@@ -23,43 +23,43 @@
 --
 -- None of the definitions in this module depend on, or even refer to, any
 -- specific consensus protocols.
-module Ouroboros.Consensus.Mock.Ledger.Block (
-    SimpleBlock
-  , SimpleHeader
-  , SimpleBlock'(..)
-  , Header(..)
-  , SimpleStdHeader(..)
-  , SimpleBody(..)
+module Ouroboros.Consensus.Mock.Ledger.Block
+  ( Header (..)
+  , Query (..)
+  , SimpleBlock
+  , SimpleBlock' (..)
+  , SimpleBody (..)
   , SimpleHash
-  , Query(..)
+  , SimpleHeader
+  , SimpleStdHeader (..)
     -- * Working with 'SimpleBlock'
-  , mkSimpleHeader
-  , matchesSimpleHeader
   , countSimpleGenTxs
+  , matchesSimpleHeader
+  , mkSimpleHeader
     -- * Configuration
-  , BlockConfig(..)
-  , CodecConfig(..)
-  , StorageConfig(..)
-  , SimpleLedgerConfig(..)
+  , BlockConfig (..)
+  , CodecConfig (..)
+  , SimpleLedgerConfig (..)
+  , StorageConfig (..)
     -- * Protocol-specific part
-  , MockProtocolSpecific(..)
+  , MockProtocolSpecific (..)
     -- * 'UpdateLedger'
-  , LedgerState(..)
-  , Ticked(..)
-  , updateSimpleLedgerState
+  , LedgerState (..)
+  , Ticked (..)
   , genesisSimpleLedgerState
+  , updateSimpleLedgerState
     -- * 'ApplyTx' (mempool support)
-  , GenTx(..)
-  , TxId(..)
+  , GenTx (..)
+  , TxId (..)
   , mkSimpleGenTx
   , txSize
     -- * Crypto
   , SimpleCrypto
-  , SimpleStandardCrypto
   , SimpleMockCrypto
+  , SimpleStandardCrypto
     -- * Serialisation
-  , encodeSimpleHeader
   , decodeSimpleHeader
+  , encodeSimpleHeader
   , simpleBlockBinaryBlockInfo
   ) where
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/BFT.hs
@@ -11,11 +11,11 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Mock.Ledger.Block.BFT (
-    SimpleBftBlock
+module Ouroboros.Consensus.Mock.Ledger.Block.BFT
+  ( SignedSimpleBft (..)
+  , SimpleBftBlock
+  , SimpleBftExt (..)
   , SimpleBftHeader
-  , SimpleBftExt(..)
-  , SignedSimpleBft(..)
   , forgeBftExt
   ) where
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PBFT.hs
@@ -12,11 +12,11 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Mock.Ledger.Block.PBFT (
-    SimplePBftBlock
+module Ouroboros.Consensus.Mock.Ledger.Block.PBFT
+  ( SignedSimplePBft (..)
+  , SimplePBftBlock
+  , SimplePBftExt (..)
   , SimplePBftHeader
-  , SimplePBftExt(..)
-  , SignedSimplePBft(..)
   , forgePBftExt
   ) where
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/Praos.hs
@@ -11,11 +11,11 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Mock.Ledger.Block.Praos (
-    SimplePraosBlock
+module Ouroboros.Consensus.Mock.Ledger.Block.Praos
+  ( SignedSimplePraos (..)
+  , SimplePraosBlock
+  , SimplePraosExt (..)
   , SimplePraosHeader
-  , SimplePraosExt(..)
-  , SignedSimplePraos(..)
   , forgePraosExt
   ) where
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Block/PraosRule.hs
@@ -11,11 +11,11 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Test the Praos chain selection rule (with explicit leader schedule)
-module Ouroboros.Consensus.Mock.Ledger.Block.PraosRule (
-    SimplePraosRuleBlock
-  , SimplePraosRuleExt(..)
+module Ouroboros.Consensus.Mock.Ledger.Block.PraosRule
+  ( PraosCryptoUnused
+  , SimplePraosRuleBlock
+  , SimplePraosRuleExt (..)
   , SimplePraosRuleHeader
-  , PraosCryptoUnused
   , forgePraosRuleExt
   ) where
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Forge.hs
@@ -5,8 +5,8 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeFamilies          #-}
 
-module Ouroboros.Consensus.Mock.Ledger.Forge (
-    ForgeExt (..)
+module Ouroboros.Consensus.Mock.Ledger.Forge
+  ( ForgeExt (..)
   , forgeSimple
   ) where
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Stake.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/Stake.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies               #-}
 
-module Ouroboros.Consensus.Mock.Ledger.Stake (
-    -- * Stakeholders
-    StakeHolder(..)
+module Ouroboros.Consensus.Mock.Ledger.Stake
+  ( -- * Stakeholders
+    StakeHolder (..)
     -- * Address distribution
   , AddrDist
     -- * Stake distribution
-  , StakeDist(..)
-  , stakeWithDefault
-  , relativeStakes
-  , totalStakes
+  , StakeDist (..)
   , equalStakeDist
   , genesisStakeDist
+  , relativeStakes
+  , stakeWithDefault
+  , totalStakes
     -- * Type family instances
-  , Ticked(..)
+  , Ticked (..)
   ) where
 
 import           Codec.Serialise (Serialise)

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/State.hs
@@ -5,10 +5,10 @@
 {-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Ouroboros.Consensus.Mock.Ledger.State (
-    -- * State of the mock ledger
-    MockState(..)
-  , MockError(..)
+module Ouroboros.Consensus.Mock.Ledger.State
+  ( -- * State of the mock ledger
+    MockError (..)
+  , MockState (..)
   , updateMockState
   , updateMockTip
   , updateMockUTxO

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs
@@ -5,24 +5,24 @@
 {-# LANGUAGE PatternSynonyms      #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Ouroboros.Consensus.Mock.Ledger.UTxO (
-    -- * Basic definitions
-    Tx(Tx)
+module Ouroboros.Consensus.Mock.Ledger.UTxO
+  ( -- * Basic definitions
+    Addr
+  , Amount
+  , Expiry (..)
+  , Ix
+  , Tx (Tx)
   , TxId
   , TxIn
   , TxOut
-  , Addr
-  , Amount
-  , Ix
   , Utxo
-  , Expiry(..)
     -- * Computing UTxO
-  , HasMockTxs(..)
+  , HasMockTxs (..)
+  , UtxoError (..)
+  , confirmed
   , txIns
   , txOuts
-  , confirmed
   , updateUtxo
-  , UtxoError(..)
     -- * Genesis
   , genesisTx
   , genesisUtxo

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node.hs
@@ -10,8 +10,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Mock.Node (
-    CodecConfig (..)
+module Ouroboros.Consensus.Mock.Node
+  ( CodecConfig (..)
   , simpleBlockForging
   ) where
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Abstract.hs
@@ -3,9 +3,9 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Mock.Node.Abstract (
-    CodecConfig(..)
-  , RunMockBlock(..)
+module Ouroboros.Consensus.Mock.Node.Abstract
+  ( CodecConfig (..)
+  , RunMockBlock (..)
   , constructMockNetworkMagic
   ) where
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/BFT.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Mock.Node.BFT (
-    MockBftBlock
+module Ouroboros.Consensus.Mock.Node.BFT
+  ( MockBftBlock
   , protocolInfoBft
   ) where
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PBFT.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE TypeFamilies      #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Mock.Node.PBFT (
-    MockPBftBlock
+module Ouroboros.Consensus.Mock.Node.PBFT
+  ( MockPBftBlock
   , protocolInfoMockPBFT
   ) where
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Praos.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE RecordWildCards   #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Mock.Node.Praos (
-    MockPraosBlock
+module Ouroboros.Consensus.Mock.Node.Praos
+  ( MockPraosBlock
   , protocolInfoPraos
   ) where
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/PraosRule.hs
@@ -1,6 +1,6 @@
 -- | Test the Praos chain selection rule but with explicit leader schedule
-module Ouroboros.Consensus.Mock.Node.PraosRule (
-    MockPraosRuleBlock
+module Ouroboros.Consensus.Mock.Node.PraosRule
+  ( MockPraosRuleBlock
   , protocolInfoPraosRule
   ) where
 

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Node/Serialisation.hs
@@ -9,9 +9,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Mock.Node.Serialisation (
-    MockBlock
-  , NestedCtxt_(..)
+module Ouroboros.Consensus.Mock.Node.Serialisation
+  ( MockBlock
+  , NestedCtxt_ (..)
   ) where
 
 import           Codec.Serialise (Serialise, decode, encode, serialise)

--- a/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
+++ b/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Protocol/Praos.hs
@@ -17,27 +17,27 @@
 {-# LANGUAGE UndecidableSuperClasses    #-}
 
 -- | Proof of concept implementation of Praos
-module Ouroboros.Consensus.Mock.Protocol.Praos (
-    Praos
-  , PraosFields(..)
-  , PraosExtraFields(..)
-  , PraosParams(..)
-  , PraosChainDepState(..)
-  , HotKey(..)
-  , forgePraosFields
-  , HotKeyEvolutionError(..)
+module Ouroboros.Consensus.Mock.Protocol.Praos
+  ( HotKey (..)
+  , HotKeyEvolutionError (..)
+  , Praos
+  , PraosChainDepState (..)
+  , PraosExtraFields (..)
+  , PraosFields (..)
+  , PraosParams (..)
   , evolveKey
+  , forgePraosFields
     -- * Tags
-  , PraosCrypto(..)
-  , PraosStandardCrypto
+  , PraosCrypto (..)
   , PraosMockCrypto
-  , PraosValidateView(..)
+  , PraosStandardCrypto
+  , PraosValidateView (..)
+  , PraosValidationError (..)
   , praosValidateView
-  , PraosValidationError(..)
     -- * Type instances
-  , ConsensusConfig(..)
-  , BlockInfo(..)
-  , Ticked(..)
+  , BlockInfo (..)
+  , ConsensusConfig (..)
+  , Ticked (..)
   ) where
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..), serializeEncoding')

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Examples.hs
@@ -6,33 +6,33 @@
 {-# LANGUAGE ScopedTypeVariables      #-}
 {-# LANGUAGE TypeApplications         #-}
 {-# LANGUAGE TypeFamilies             #-}
-module Test.Consensus.Shelley.Examples (
-    -- * Setup
-    testEpochInfo
-  , testShelleyGenesis
-  , codecConfig
-  , mkDummyHash
+module Test.Consensus.Shelley.Examples
+  ( -- * Setup
+    codecConfig
   , keyToCredential
+  , mkDummyHash
+  , testEpochInfo
+  , testShelleyGenesis
     -- * Examples
-  , examplesShelley
   , examplesAllegra
   , examplesMary
+  , examplesShelley
     -- * Era-specific examples
   , exampleCoin
     -- * Individual examples
-  , exampleBlock
-  , exampleHeaderHash
-  , exampleTx
   , exampleApplyTxErr
+  , exampleBlock
   , exampleChainDepState
-  , exampleLedgerState
-  , exampleHeaderState
   , exampleExtLedgerState
+  , exampleHeaderHash
+  , exampleHeaderState
+  , exampleLedgerState
+  , exampleTx
     -- * Keys
-  , examplePayKey
-  , exampleStakeKey
   , exampleKeys
+  , examplePayKey
   , examplePoolParams
+  , exampleStakeKey
   ) where
 
 import qualified Data.ByteString as Strict

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/Generators.hs
@@ -12,8 +12,8 @@
 {-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Consensus.Shelley.Generators (
-    SomeResult (..)
+module Test.Consensus.Shelley.Generators
+  ( SomeResult (..)
   ) where
 
 import           Ouroboros.Network.Block (mkSerialised)

--- a/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/MockCrypto.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/Consensus/Shelley/MockCrypto.hs
@@ -5,11 +5,11 @@
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Consensus.Shelley.MockCrypto (
-    MockCrypto
-  , MockShelley
-  , Block
+module Test.Consensus.Shelley.MockCrypto
+  ( Block
   , CanMock
+  , MockCrypto
+  , MockShelley
   ) where
 
 import           Test.QuickCheck (Arbitrary)

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/Infra/Shelley.hs
@@ -10,29 +10,29 @@
 {-# LANGUAGE ScopedTypeVariables      #-}
 {-# LANGUAGE TypeApplications         #-}
 {-# LANGUAGE TypeFamilies             #-}
-module Test.ThreadNet.Infra.Shelley (
-    CoreNode(..)
-  , CoreNodeKeyInfo(..)
-  , DecentralizationParam(..)
-  , KesConfig(..)
+module Test.ThreadNet.Infra.Shelley
+  ( CoreNode (..)
+  , CoreNodeKeyInfo (..)
+  , DecentralizationParam (..)
+  , KesConfig (..)
   , coreNodeKeys
   , genCoreNode
   , incrementMinorProtVer
+  , initialLovelacePerCoreNode
+  , mkAllegraSetDecentralizationParamTxs
   , mkCredential
   , mkEpochSize
   , mkGenesisConfig
   , mkKesConfig
   , mkKeyHash
   , mkKeyHashVrf
+  , mkKeyPair
   , mkLeaderCredentials
   , mkProtocolShelley
   , mkSetDecentralizationParamTxs
-  , mkAllegraSetDecentralizationParamTxs
   , mkVerKey
-  , mkKeyPair
   , networkId
   , tpraosSlotLength
-  , initialLovelacePerCoreNode
   ) where
 
 import           Control.Monad.Except (throwError)

--- a/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/src/Test/ThreadNet/TxGen/Shelley.hs
@@ -6,9 +6,9 @@
 {-# LANGUAGE TypeApplications         #-}
 {-# LANGUAGE TypeFamilies             #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.ThreadNet.TxGen.Shelley (
-    ShelleyTxGenExtra(..)
-  , WhetherToGeneratePPUs(..)
+module Test.ThreadNet.TxGen.Shelley
+  ( ShelleyTxGenExtra (..)
+  , WhetherToGeneratePPUs (..)
   , genTx
   , mkGenEnv
   ) where

--- a/ouroboros-consensus-shelley-test/test/Main.hs
+++ b/ouroboros-consensus-shelley-test/test/Main.hs
@@ -1,4 +1,6 @@
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import           Cardano.Crypto.Libsodium (sodiumInit)
 

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Golden.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Consensus.Shelley.Golden (tests) where
+module Test.Consensus.Shelley.Golden
+  ( tests
+  ) where
 
 import           Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
 import           Ouroboros.Consensus.Shelley.Node ()

--- a/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Serialisation.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/Consensus/Shelley/Serialisation.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-module Test.Consensus.Shelley.Serialisation (tests) where
+module Test.Consensus.Shelley.Serialisation
+  ( tests
+  ) where
 
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString.Lazy as Lazy

--- a/ouroboros-consensus-shelley-test/test/Test/ThreadNet/Shelley.hs
+++ b/ouroboros-consensus-shelley-test/test/Test/ThreadNet/Shelley.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Test.ThreadNet.Shelley (tests) where
+module Test.ThreadNet.Shelley
+  ( tests
+  ) where
 
 import           Control.Monad (replicateM)
 import qualified Data.Map.Strict as Map

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Eras.hs
@@ -4,15 +4,15 @@
 {-# LANGUAGE OverloadedStrings       #-}
 {-# LANGUAGE TypeFamilies            #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
-module Ouroboros.Consensus.Shelley.Eras (
-    -- * Eras based on the Shelley ledger
-    ShelleyEra
-  , AllegraEra
+module Ouroboros.Consensus.Shelley.Eras
+  ( -- * Eras based on the Shelley ledger
+    AllegraEra
   , MaryEra
+  , ShelleyEra
     -- * Eras instantiated with standard crypto
-  , StandardShelley
   , StandardAllegra
   , StandardMary
+  , StandardShelley
     -- * Shelley-based era
   , ShelleyBasedEra (..)
     -- * Type synonyms for convenience

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Shelley.Ledger (
-    module X
+module Ouroboros.Consensus.Shelley.Ledger
+  ( module X
   ) where
 
 import           Ouroboros.Consensus.Shelley.Ledger.Block as X

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Block.hs
@@ -12,21 +12,21 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
-module Ouroboros.Consensus.Shelley.Ledger.Block (
-    ShelleyBasedEra
-  , ShelleyHash (..)
-  , ShelleyBlock (..)
-  , mkShelleyBlock
-  , GetHeader (..)
+module Ouroboros.Consensus.Shelley.Ledger.Block
+  ( GetHeader (..)
   , Header (..)
+  , NestedCtxt_ (..)
+  , ShelleyBasedEra
+  , ShelleyBlock (..)
+  , ShelleyHash (..)
+  , mkShelleyBlock
   , mkShelleyHeader
-  , NestedCtxt_(..)
     -- * Serialisation
-  , encodeShelleyBlock
   , decodeShelleyBlock
-  , shelleyBinaryBlockInfo
-  , encodeShelleyHeader
   , decodeShelleyHeader
+  , encodeShelleyBlock
+  , encodeShelleyHeader
+  , shelleyBinaryBlockInfo
     -- * Conversion
   , fromShelleyPrevHash
   , toShelleyPrevHash

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Config.hs
@@ -7,14 +7,15 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Shelley.Ledger.Config (
-    BlockConfig (..)
-  , mkShelleyBlockConfig
+module Ouroboros.Consensus.Shelley.Ledger.Config
+  ( BlockConfig (..)
   , CodecConfig (..)
+  , CompactGenesis
   , StorageConfig (..)
-  , CompactGenesis -- opaque
-  , getCompactGenesis
+  , mkShelleyBlockConfig
+    -- opaque
   , compactGenesis
+  , getCompactGenesis
   ) where
 
 import           Data.Map.Strict (Map)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -11,8 +11,8 @@
 {-# LANGUAGE TypeApplications         #-}
 {-# LANGUAGE TypeFamilies             #-}
 
-module Ouroboros.Consensus.Shelley.Ledger.Forge (
-    forgeShelleyBlock
+module Ouroboros.Consensus.Shelley.Ledger.Forge
+  ( forgeShelleyBlock
   ) where
 
 import           Control.Exception

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
@@ -7,12 +7,12 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Shelley.Ledger.Inspect (
-    ProtocolUpdate(..)
-  , UpdateProposal(..)
-  , UpdateState(..)
-  , protocolUpdates
+module Ouroboros.Consensus.Shelley.Ledger.Inspect
+  ( ProtocolUpdate (..)
   , ShelleyLedgerUpdate (..)
+  , UpdateProposal (..)
+  , UpdateState (..)
+  , protocolUpdates
   ) where
 
 import           Control.Monad

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Integrity.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Integrity.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE FlexibleContexts         #-}
 {-# LANGUAGE NamedFieldPuns           #-}
 {-# LANGUAGE TypeFamilies             #-}
-module Ouroboros.Consensus.Shelley.Ledger.Integrity (
-    verifyHeaderIntegrity
-  , verifyBlockIntegrity
+module Ouroboros.Consensus.Shelley.Ledger.Integrity
+  ( verifyBlockIntegrity
+  , verifyHeaderIntegrity
   ) where
 
 import           Data.Either (isRight)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Ledger.hs
@@ -16,29 +16,29 @@
 {-# LANGUAGE UndecidableInstances       #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Shelley.Ledger.Ledger (
-    ShelleyLedgerError (..)
+module Ouroboros.Consensus.Shelley.Ledger.Ledger
+  ( LedgerState (..)
   , ShelleyBasedEra
+  , ShelleyLedgerError (..)
   , ShelleyTip (..)
-  , shelleyTipToPoint
+  , ShelleyTransition (..)
+  , Ticked (..)
   , shelleyLedgerTipPoint
-  , ShelleyTransition(..)
-  , LedgerState (..)
-  , Ticked(..)
+  , shelleyTipToPoint
     -- * Ledger config
   , ShelleyLedgerConfig (..)
-  , shelleyLedgerGenesis
   , mkShelleyLedgerConfig
   , shelleyEraParams
   , shelleyEraParamsNeverHardForks
+  , shelleyLedgerGenesis
     -- * Auxiliary
   , getPParams
     -- * Serialisation
-  , encodeShelleyAnnTip
   , decodeShelleyAnnTip
   , decodeShelleyLedgerState
-  , encodeShelleyLedgerState
+  , encodeShelleyAnnTip
   , encodeShelleyHeaderState
+  , encodeShelleyLedgerState
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Mempool.hs
@@ -17,12 +17,12 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Shelley mempool integration
-module Ouroboros.Consensus.Shelley.Ledger.Mempool (
-    SL.ApplyTxError (..)
-  , GenTx (..)
+module Ouroboros.Consensus.Shelley.Ledger.Mempool
+  ( GenTx (..)
+  , SL.ApplyTxError (..)
   , TxId (..)
-  , mkShelleyTx
   , fixedBlockBodyOverhead
+  , mkShelleyTx
   , perTxOverhead
   ) where
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs
@@ -2,9 +2,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion (
-    ShelleyNodeToNodeVersion(..)
-  , ShelleyNodeToClientVersion(..)
+module Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
+  ( ShelleyNodeToClientVersion (..)
+  , ShelleyNodeToNodeVersion (..)
   ) where
 
 import qualified Data.Map.Strict as Map

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs
@@ -5,7 +5,9 @@
 {-# LANGUAGE TypeFamilies        #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Shelley.Ledger.PeerSelection () where
+module Ouroboros.Consensus.Shelley.Ledger.PeerSelection
+  (
+  ) where
 
 import           Data.Bifunctor (second)
 import           Data.Foldable (toList)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Query.hs
@@ -11,15 +11,15 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Shelley.Ledger.Query (
-    Query (..)
+module Ouroboros.Consensus.Shelley.Ledger.Query
+  ( NonMyopicMemberRewards (..)
+  , Query (..)
   , querySupportedVersion
-  , NonMyopicMemberRewards (..)
     -- * Serialisation
-  , encodeShelleyQuery
   , decodeShelleyQuery
-  , encodeShelleyResult
   , decodeShelleyResult
+  , encodeShelleyQuery
+  , encodeShelleyResult
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/TPraos.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/TPraos.hs
@@ -5,7 +5,9 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 -- TODO where to put this?
-module Ouroboros.Consensus.Shelley.Ledger.TPraos () where
+module Ouroboros.Consensus.Shelley.Ledger.TPraos
+  (
+  ) where
 
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node.hs
@@ -17,27 +17,27 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Shelley.Node (
-    protocolInfoShelleyBased
-  , protocolInfoShelley
-  , ProtocolParamsShelleyBased (..)
-  , ProtocolParamsShelley (..)
+module Ouroboros.Consensus.Shelley.Node
+  ( MaxMajorProtVer (..)
   , ProtocolParamsAllegra (..)
   , ProtocolParamsMary (..)
-  , protocolClientInfoShelley
+  , ProtocolParamsShelley (..)
+  , ProtocolParamsShelleyBased (..)
+  , SL.Nonce (..)
+  , SL.ProtVer (..)
   , SL.ShelleyGenesis (..)
   , SL.ShelleyGenesisStaking (..)
+  , SL.emptyGenesisStaking
   , TPraosLeaderCredentials (..)
+  , protocolClientInfoShelley
+  , protocolInfoShelley
+  , protocolInfoShelleyBased
+  , registerGenesisStaking
+  , registerInitialFunds
   , shelleyBlockForging
   , shelleySharedBlockForging
   , tpraosBlockIssuerVKey
-  , SL.ProtVer (..)
-  , SL.Nonce (..)
-  , MaxMajorProtVer (..)
-  , SL.emptyGenesisStaking
   , validateGenesis
-  , registerGenesisStaking
-  , registerInitialFunds
   ) where
 
 import           Data.Bifunctor (first)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Node/Serialisation.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE TypeFamilies          #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Shelley.Node.Serialisation () where
+module Ouroboros.Consensus.Shelley.Node.Serialisation
+  (
+  ) where
 
 import           Control.Exception (Exception, throw)
 import qualified Data.ByteString.Lazy as Lazy

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol.hs
@@ -14,21 +14,21 @@
 --
 --   Transitional praos allows for the overlaying of Praos with an overlay
 --   schedule determining slots to be produced by BFT
-module Ouroboros.Consensus.Shelley.Protocol (
-    TPraos
-  , TPraosState (..)
-  , TPraosChainSelectView (..)
+module Ouroboros.Consensus.Shelley.Protocol
+  ( MaxMajorProtVer (..)
   , SelfIssued (..)
+  , TPraos
+  , TPraosCanBeLeader (..)
+  , TPraosChainSelectView (..)
   , TPraosFields (..)
-  , forgeTPraosFields
+  , TPraosIsLeader (..)
+  , TPraosParams (..)
+  , TPraosState (..)
   , TPraosToSign (..)
   , TPraosValidateView
-  , TPraosParams (..)
-  , mkTPraosParams
-  , TPraosCanBeLeader (..)
-  , TPraosIsLeader (..)
+  , forgeTPraosFields
   , mkShelleyGlobals
-  , MaxMajorProtVer (..)
+  , mkTPraosParams
     -- * Crypto
   , PraosCrypto
   , StandardCrypto

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Crypto.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TypeFamilies #-}
-module Ouroboros.Consensus.Shelley.Protocol.Crypto (
-    PraosCrypto
+module Ouroboros.Consensus.Shelley.Protocol.Crypto
+  ( PraosCrypto
   , StandardCrypto
   ) where
 

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/HotKey.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/HotKey.hs
@@ -8,8 +8,8 @@
 -- | Hot key
 --
 -- Intended for qualified import
-module Ouroboros.Consensus.Shelley.Protocol.HotKey (
-    -- * KES Info
+module Ouroboros.Consensus.Shelley.Protocol.HotKey
+  ( -- * KES Info
     KESEvolution
   , KESInfo (..)
   , kesAbsolutePeriod
@@ -17,11 +17,11 @@ module Ouroboros.Consensus.Shelley.Protocol.HotKey (
   , KESStatus (..)
   , kesStatus
     -- * Hot Key
+  , HotKey (..)
   , KESEvolutionError (..)
   , KESEvolutionInfo
-  , HotKey (..)
-  , sign
   , mkHotKey
+  , sign
   ) where
 
 import           Data.Word (Word64)

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Util.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Protocol/Util.hs
@@ -2,9 +2,9 @@
 --
 -- In particular, various things we need for integration with the @delegation@
 -- package from cardano-ledger-specs.
-module Ouroboros.Consensus.Shelley.Protocol.Util (
-    isNewEpoch
-  , firstSlotOfEpochOfSlot
+module Ouroboros.Consensus.Shelley.Protocol.Util
+  ( firstSlotOfEpochOfSlot
+  , isNewEpoch
   ) where
 
 import           Cardano.Slotting.EpochInfo

--- a/ouroboros-consensus-test/src/Test/ThreadNet/General.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/General.hs
@@ -9,8 +9,8 @@
 {-# LANGUAGE TypeApplications          #-}
 {-# LANGUAGE UndecidableInstances      #-}
 
-module Test.ThreadNet.General (
-    PropGeneralArgs (..)
+module Test.ThreadNet.General
+  ( PropGeneralArgs (..)
   , calcFinalIntersectionDepth
   , prop_general
   , prop_general_semisync

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -410,7 +410,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
       forM vertexInfos0 $ \(coreNodeId, vertexStatusVar, readNodeInfo) -> do
         readTVar vertexStatusVar >>= \case
           VDown ch ldgr -> pure (coreNodeId, readNodeInfo, ch, ldgr)
-          _        -> retry
+          _             -> retry
 
     mkTestOutput vertexInfos
   where

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -14,23 +14,23 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Setup network
-module Test.ThreadNet.Network (
-    runThreadNetwork
-  , CalcMessageDelay (..)
+module Test.ThreadNet.Network
+  ( CalcMessageDelay (..)
   , ForgeEbbEnv (..)
   , RekeyM
-  , ThreadNetworkArgs (..)
   , TestNodeInitialization (..)
+  , ThreadNetworkArgs (..)
+  , TracingConstraints
   , noCalcMessageDelay
   , plainTestNodeInitialization
-  , TracingConstraints
+  , runThreadNetwork
     -- * Tracers
   , MiniProtocolFatalException (..)
   , MiniProtocolState (..)
     -- * Test Output
-  , TestOutput (..)
-  , NodeOutput (..)
   , NodeDBs (..)
+  , NodeOutput (..)
+  , TestOutput (..)
   ) where
 
 import           Codec.CBOR.Read (DeserialiseFailure)

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Ref/PBFT.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Ref/PBFT.hs
@@ -7,21 +7,21 @@
 --
 -- See 'step'.
 --
-module Test.ThreadNet.Ref.PBFT (
-  Outcome (..),
-  Result (..),
-  State (..),
-  advanceUpTo,
-  definitelyEnoughBlocks,
-  emptyState,
-  mkLeaderOf,
-  nullState,
-  pbftLimit,
-  resultConstrName,
-  simulate,
-  simulateShort,
-  step,
-  viable,
+module Test.ThreadNet.Ref.PBFT
+  ( Outcome (..)
+  , Result (..)
+  , State (..)
+  , advanceUpTo
+  , definitelyEnoughBlocks
+  , emptyState
+  , mkLeaderOf
+  , nullState
+  , pbftLimit
+  , resultConstrName
+  , simulate
+  , simulateShort
+  , step
+  , viable
   ) where
 
 import           Control.Applicative ((<|>))

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Rekeying.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Rekeying.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE LambdaCase                #-}
 {-# LANGUAGE NamedFieldPuns            #-}
 
-module Test.ThreadNet.Rekeying (
-  Rekeying (..),
-  fromRekeyingToRekeyM,
+module Test.ThreadNet.Rekeying
+  ( Rekeying (..)
+  , fromRekeyingToRekeyM
   ) where
 
 import           Data.Functor ((<&>))

--- a/ouroboros-consensus-test/src/Test/ThreadNet/TxGen.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/TxGen.hs
@@ -5,8 +5,8 @@
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- | Transaction generator for testing
-module Test.ThreadNet.TxGen (
-    TxGen (..)
+module Test.ThreadNet.TxGen
+  ( TxGen (..)
     -- * Implementation for HFC
   , WrapTxGenExtra (..)
   , testGenTxsHfc

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util.hs
@@ -4,18 +4,18 @@
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeFamilies        #-}
 
-module Test.ThreadNet.Util (
-  -- * Chain properties
+module Test.ThreadNet.Util
+  ( -- * Chain properties
     chainCommonPrefix
   , prop_all_common_prefix
   , shortestLength
-  -- * LeaderSchedule
+    -- * LeaderSchedule
+  , consensusExpected
   , emptyLeaderSchedule
   , roundRobinLeaderSchedule
-  , consensusExpected
-  -- * GraphViz Dot
+    -- * GraphViz Dot
   , tracesToDot
-  -- * Re-exports
+    -- * Re-exports
   , module Test.ThreadNet.Util.Expectations
   ) where
 

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util/Expectations.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util/Expectations.hs
@@ -165,5 +165,5 @@ determineForkLength k (NodeJoinPlan joinPlan) (LeaderSchedule sched) =
         -- slot in which the node joins the network
         joinSlot :: CoreNodeId -> SlotNo
         joinSlot nid = case Map.lookup nid joinPlan of
-            Nothing -> error "determineForkLength: incomplete node join plan"
+            Nothing    -> error "determineForkLength: incomplete node join plan"
             Just slot' -> slot'

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util/Expectations.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util/Expectations.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Test.ThreadNet.Util.Expectations
-    ( NumBlocks (..)
-    , determineForkLength
-    ) where
+  ( NumBlocks (..)
+  , determineForkLength
+  ) where
 
 import           Data.Foldable (foldl')
 import qualified Data.Map.Strict as Map

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util/HasCreator.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util/HasCreator.hs
@@ -1,7 +1,7 @@
 -- | In tests we want to be able to map a block to the core node that produced
 -- it.
-module Test.ThreadNet.Util.HasCreator (
-    HasCreator(..)
+module Test.ThreadNet.Util.HasCreator
+  ( HasCreator (..)
   ) where
 
 import           Ouroboros.Consensus.NodeId (CoreNodeId (..))

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util/NodeRestarts.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util/NodeRestarts.hs
@@ -1,9 +1,9 @@
-module  Test.ThreadNet.Util.NodeRestarts (
-  NodeRestart (..),
-  NodeRestarts (..),
-  noRestarts,
-  genNodeRestarts,
-  shrinkNodeRestarts,
+module Test.ThreadNet.Util.NodeRestarts
+  ( NodeRestart (..)
+  , NodeRestarts (..)
+  , genNodeRestarts
+  , noRestarts
+  , shrinkNodeRestarts
   ) where
 
 import           Data.Map.Strict (Map)

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util/NodeToNodeVersion.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util/NodeToNodeVersion.hs
@@ -1,5 +1,5 @@
-module Test.ThreadNet.Util.NodeToNodeVersion (
-    genVersion
+module Test.ThreadNet.Util.NodeToNodeVersion
+  ( genVersion
   , genVersionFiltered
   , newestVersion
   ) where

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util/NodeTopology.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util/NodeTopology.hs
@@ -9,10 +9,10 @@ module Test.ThreadNet.Util.NodeTopology
   , coreNodeIdNeighbors
   , edgesNodeTopology
   , genNodeTopology
-  , shrinkNodeTopology
   , mapNodeTopology
   , meshNodeTopology
   , minimumDegreeNodeTopology
+  , shrinkNodeTopology
   , unionNodeTopology
   ) where
 

--- a/ouroboros-consensus-test/src/Test/ThreadNet/Util/Seed.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Util/Seed.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TypeApplications #-}
 -- | Seed used for the ThreadNet tests
-module Test.ThreadNet.Util.Seed (
-    Seed (..)
+module Test.ThreadNet.Util.Seed
+  ( Seed (..)
   , combineWith
   , runGen
   ) where

--- a/ouroboros-consensus-test/src/Test/Util/Blob.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Blob.hs
@@ -1,7 +1,7 @@
 module Test.Util.Blob
   ( Blob (..)
-  , blobToBS
   , blobFromBS
+  , blobToBS
   ) where
 
 import           Data.ByteString (ByteString)

--- a/ouroboros-consensus-test/src/Test/Util/BoolProps.hs
+++ b/ouroboros-consensus-test/src/Test/Util/BoolProps.hs
@@ -4,14 +4,14 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE TypeOperators     #-}
 
-module Test.Util.BoolProps (
-  CollectReqs (..),
-  Prereq (..),
-  Requirement (..),
-  checkReqs,
-  enabledIf,
-  gCollectReqs,
-  requiredIf,
+module Test.Util.BoolProps
+  ( CollectReqs (..)
+  , Prereq (..)
+  , Requirement (..)
+  , checkReqs
+  , enabledIf
+  , gCollectReqs
+  , requiredIf
   ) where
 
 import           Data.Kind (Type)

--- a/ouroboros-consensus-test/src/Test/Util/ChunkInfo.hs
+++ b/ouroboros-consensus-test/src/Test/Util/ChunkInfo.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
-module Test.Util.ChunkInfo (
-    SmallChunkInfo(..)
+module Test.Util.ChunkInfo
+  ( SmallChunkInfo (..)
   ) where
 
 import           Test.QuickCheck

--- a/ouroboros-consensus-test/src/Test/Util/Classify.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Classify.hs
@@ -6,11 +6,11 @@
 -- Intended for qualified import.
 --
 -- > import qualified Test.Util.Classify as C
-module Test.Util.Classify (
-    Predicate(..)
-  , predicate
-  , maximum
+module Test.Util.Classify
+  ( Predicate (..)
   , classify
+  , maximum
+  , predicate
     -- * Example
   , Tag
   , example

--- a/ouroboros-consensus-test/src/Test/Util/Corruption.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Corruption.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 module Test.Util.Corruption
   ( Corruption (..)
-  , detectCorruption
   , applyCorruption
+  , detectCorruption
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus-test/src/Test/Util/FS/Sim/Error.hs
+++ b/ouroboros-consensus-test/src/Test/Util/FS/Sim/Error.hs
@@ -11,30 +11,30 @@
 -- testing error handling.
 module Test.Util.FS.Sim.Error
   ( -- * Simulate Errors monad
-    runSimErrorFS
-  , mkSimErrorHasFS
+    mkSimErrorHasFS
+  , runSimErrorFS
   , withErrors
     -- * Streams
-  , Stream(..)
-  , mkStream
-  , null
-  , runStream
-  , always
-  , mkStreamGen
   , ErrorStream
   , ErrorStreamGetSome
   , ErrorStreamPutSome
+  , Stream (..)
+  , always
+  , mkStream
+  , mkStreamGen
+  , null
+  , runStream
     -- * Generating partial reads/writes
   , Partial (..)
   , hGetSomePartial
   , hPutSomePartial
     -- * Generating corruption for 'hPutSome'
-  , PutCorruption(..)
+  , PutCorruption (..)
   , corrupt
     -- * Error streams for 'HasFS'
-  , Errors(..)
-  , genErrors
+  , Errors (..)
   , allNull
+  , genErrors
   , simpleErrors
   ) where
 

--- a/ouroboros-consensus-test/src/Test/Util/FS/Sim/FsTree.hs
+++ b/ouroboros-consensus-test/src/Test/Util/FS/Sim/FsTree.hs
@@ -11,24 +11,24 @@
 --
 -- > import Test.Util.FS.Sim.FsTree (FsTree)
 -- > import Test.Util.FS.Sim.FsTree as FS
-module Test.Util.FS.Sim.FsTree (
-    -- * FsTree type and indexing functions
-    FsTree(..)
-  , FsTreeError(..)
+module Test.Util.FS.Sim.FsTree
+  ( -- * FsTree type and indexing functions
+    FsTree (..)
+  , FsTreeError (..)
   , example
     -- * Construction
   , empty
     -- * Indexing
-  , index
-  , getFile
   , getDir
+  , getFile
+  , index
     -- * File system operations
-  , openFile
-  , replace
   , createDirIfMissing
   , createDirWithParents
+  , openFile
   , removeFile
   , renameFile
+  , replace
     -- * Pretty-printing
   , pretty
   ) where

--- a/ouroboros-consensus-test/src/Test/Util/FS/Sim/MockFS.hs
+++ b/ouroboros-consensus-test/src/Test/Util/FS/Sim/MockFS.hs
@@ -17,39 +17,45 @@
 --
 -- > import Test.Util.FS.Sim.MockFS (MockFS)
 -- > import qualified Test.Util.FS.Sim.MockFS as Mock
-module Test.Util.FS.Sim.MockFS (
-    MockFS -- opaque
-  , HandleMock -- opaque
+module Test.Util.FS.Sim.MockFS
+  ( MockFS
+    -- opaque
+  , HandleMock
+    -- opaque
   , empty
   , example
-  , pretty
   , handleIsOpen
   , numOpenHandles
+  , pretty
     -- * Debugging
   , dumpState
     -- * Operations on files
-  , hOpen
   , hClose
-  , hIsOpen
-  , hSeek
+  , hGetSize
   , hGetSome
   , hGetSomeAt
+  , hIsOpen
+  , hOpen
   , hPutSome
+  , hSeek
   , hTruncate
-  , hGetSize
     -- * Operations on directories
   , createDirectory
   , createDirectoryIfMissing
-  , listDirectory
   , doesDirectoryExist
   , doesFileExist
+  , listDirectory
   , removeFile
   , renameFile
     -- * Exported for the benefit of tests only
-  , HandleState       -- opaque
-  , OpenHandleState   -- opaque
-  , ClosedHandleState -- opaque
-  , FilePtr           -- opaque
+  , HandleState
+    -- opaque
+  , OpenHandleState
+    -- opaque
+  , ClosedHandleState
+    -- opaque
+  , FilePtr
+    -- opaque
   , Files
   , mockFiles
   ) where

--- a/ouroboros-consensus-test/src/Test/Util/FS/Sim/Pure.hs
+++ b/ouroboros-consensus-test/src/Test/Util/FS/Sim/Pure.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-module Test.Util.FS.Sim.Pure (
-    PureSimFS -- opaque
-  , runPureSimFS
+module Test.Util.FS.Sim.Pure
+  ( PureSimFS
+    -- opaque
   , pureHasFS
+  , runPureSimFS
   ) where
 
 import           Control.Monad.Except

--- a/ouroboros-consensus-test/src/Test/Util/FS/Sim/STM.hs
+++ b/ouroboros-consensus-test/src/Test/Util/FS/Sim/STM.hs
@@ -2,10 +2,10 @@
 {-# LANGUAGE TypeApplications    #-}
 
 -- | 'HasFS' instance using 'MockFS' stored in an STM variable
-module Test.Util.FS.Sim.STM (
-      runSimFS
-    , simHasFS
-    ) where
+module Test.Util.FS.Sim.STM
+  ( runSimFS
+  , simHasFS
+  ) where
 
 import           Ouroboros.Consensus.Util
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus-test/src/Test/Util/FileLock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/FileLock.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
-module Test.Util.FileLock (
-    mockFileLock
+module Test.Util.FileLock
+  ( mockFileLock
   ) where
 
 import           Control.Monad (join, void)

--- a/ouroboros-consensus-test/src/Test/Util/HardFork/Future.hs
+++ b/ouroboros-consensus-test/src/Test/Util/HardFork/Future.hs
@@ -3,17 +3,17 @@
 {-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Test.Util.HardFork.Future (
-  EraSize (..),
-  Future (..),
-  futureEpochInFirstEra,
-  futureFirstEpochSize,
-  futureFirstSlotLength,
-  futureSlotLengths,
-  futureSlotToEpoch,
-  futureSlotToTime,
-  futureTimeToSlot,
-  singleEraFuture,
+module Test.Util.HardFork.Future
+  ( EraSize (..)
+  , Future (..)
+  , futureEpochInFirstEra
+  , futureFirstEpochSize
+  , futureFirstSlotLength
+  , futureSlotLengths
+  , futureSlotToEpoch
+  , futureSlotToTime
+  , futureTimeToSlot
+  , singleEraFuture
   ) where
 
 import qualified Data.Fixed

--- a/ouroboros-consensus-test/src/Test/Util/HardFork/OracularClock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/HardFork/OracularClock.hs
@@ -6,11 +6,11 @@
 --
 -- > import Test.Util.OracularClock (OracularClock(..))
 -- > import qualified Test.Util.OracularClock as OracularClock
-module Test.Util.HardFork.OracularClock (
-    OracularClock (..)
-  , mkOracularClock
+module Test.Util.HardFork.OracularClock
+  ( EndOfDaysException (..)
+  , OracularClock (..)
   , forkEachSlot
-  , EndOfDaysException (..)
+  , mkOracularClock
   ) where
 
 import           Control.Monad (void, when)

--- a/ouroboros-consensus-test/src/Test/Util/InvertedMap.hs
+++ b/ouroboros-consensus-test/src/Test/Util/InvertedMap.hs
@@ -1,18 +1,18 @@
-module Test.Util.InvertedMap (
-  -- * InvertedMap type
-  InvertedMap,
-  -- * Query
-  Test.Util.InvertedMap.null,
-  -- * Construction
-  toMap,
-  unsafeInvertedMap,
-  -- * Conversion
-  fromMap,
-  unsafeCoercion,
-  -- * Filter
-  spanAntitone,
-  -- * Min/Max
-  minViewWithKey,
+module Test.Util.InvertedMap
+  ( -- * InvertedMap type
+    InvertedMap
+    -- * Query
+  , Test.Util.InvertedMap.null
+    -- * Construction
+  , toMap
+  , unsafeInvertedMap
+    -- * Conversion
+  , fromMap
+  , unsafeCoercion
+    -- * Filter
+  , spanAntitone
+    -- * Min/Max
+  , minViewWithKey
   ) where
 
 import           Data.List.NonEmpty (NonEmpty)

--- a/ouroboros-consensus-test/src/Test/Util/LogicalClock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/LogicalClock.hs
@@ -7,18 +7,18 @@
 --
 -- > import Test.Util.LogicalClock (LogicalClock)
 -- > import qualified Test.Util.LogicalClock as LogicalClock
-module Test.Util.LogicalClock (
-    -- * API
-    LogicalClock(..)
-  , Tick(..)
-  , NumTicks(..)
+module Test.Util.LogicalClock
+  ( -- * API
+    LogicalClock (..)
+  , NumTicks (..)
+  , Tick (..)
     -- * Construction
   , new
   , sufficientTimeFor
     -- * Scheduling actions
-  , tickWatcher
-  , onTick
   , blockUntilTick
+  , onTick
+  , tickWatcher
   ) where
 
 import           Control.Monad

--- a/ouroboros-consensus-test/src/Test/Util/MockChain.hs
+++ b/ouroboros-consensus-test/src/Test/Util/MockChain.hs
@@ -4,10 +4,10 @@
 --
 -- Intended for qualified import
 -- > import qualified Test.Util.MockChain as Chain
-module Test.Util.MockChain (
-    lastSlot
-  , commonPrefix
+module Test.Util.MockChain
+  ( commonPrefix
   , dropLastBlocks
+  , lastSlot
   ) where
 
 import           Data.Foldable (foldl')

--- a/ouroboros-consensus-test/src/Test/Util/Nightly.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Nightly.hs
@@ -1,9 +1,9 @@
 -- | A @tasty@ command-line option for enabling nightly tests
-module Test.Util.Nightly (
-  IohkNightlyEnabled (..),
-  askIohkNightlyEnabled,
-  defaultMainWithIohkNightly,
-  iohkNightlyIngredient,
+module Test.Util.Nightly
+  ( IohkNightlyEnabled (..)
+  , askIohkNightlyEnabled
+  , defaultMainWithIohkNightly
+  , iohkNightlyIngredient
   ) where
 
 import           Data.Proxy (Proxy (..))

--- a/ouroboros-consensus-test/src/Test/Util/Orphans/Arbitrary.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/Arbitrary.hs
@@ -12,12 +12,12 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Util.Orphans.Arbitrary
-    ( genLimitedEpochSize
-    , genLimitedSlotNo
-    , genSmallEpochNo
-    , genSmallSlotNo
-    , SmallDiffTime (..)
-    ) where
+  ( SmallDiffTime (..)
+  , genLimitedEpochSize
+  , genLimitedSlotNo
+  , genSmallEpochNo
+  , genSmallSlotNo
+  ) where
 
 import           Data.Coerce (coerce)
 import           Data.SOP.Dict (Dict (..), all_NP, mapAll)

--- a/ouroboros-consensus-test/src/Test/Util/Orphans/IOLike.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/IOLike.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Util.Orphans.IOLike () where
+module Test.Util.Orphans.IOLike
+  (
+  ) where
 
 import           Control.Monad.IOSim
 import           Ouroboros.Consensus.Util.IOLike

--- a/ouroboros-consensus-test/src/Test/Util/Orphans/NoThunks.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/NoThunks.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Util.Orphans.NoThunks () where
+module Test.Util.Orphans.NoThunks
+  (
+  ) where
 
 import           NoThunks.Class (NoThunks (..))
 

--- a/ouroboros-consensus-test/src/Test/Util/Orphans/SignableRepresentation.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/SignableRepresentation.hs
@@ -2,7 +2,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Util.Orphans.SignableRepresentation () where
+module Test.Util.Orphans.SignableRepresentation
+  (
+  ) where
 
 import           Cardano.Crypto.Util
 

--- a/ouroboros-consensus-test/src/Test/Util/Orphans/Slotting/Arbitrary.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/Slotting/Arbitrary.hs
@@ -4,7 +4,9 @@
 
 -- Placed here to separate them from the other orphan instances due to a
 -- conflict with other instances in cardano-ledger-specs.
-module Test.Util.Orphans.Slotting.Arbitrary () where
+module Test.Util.Orphans.Slotting.Arbitrary
+  (
+  ) where
 
 import           Data.Word
 import           Test.QuickCheck

--- a/ouroboros-consensus-test/src/Test/Util/Orphans/ToExpr.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Orphans/ToExpr.hs
@@ -4,7 +4,9 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Util.Orphans.ToExpr () where
+module Test.Util.Orphans.ToExpr
+  (
+  ) where
 
 import           Data.TreeDiff (ToExpr (..))
 

--- a/ouroboros-consensus-test/src/Test/Util/Paths.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Paths.hs
@@ -3,8 +3,8 @@
 --
 -- Copied from
 -- <https://github.com/input-output-hk/cardano-wallet/blob/master/lib/test-utils/src/Test/Utils/Paths.hs>
-module Test.Util.Paths (
-    getGoldenDir
+module Test.Util.Paths
+  ( getGoldenDir
   , getRelPath
   , inNixBuild
   ) where

--- a/ouroboros-consensus-test/src/Test/Util/QSM.hs
+++ b/ouroboros-consensus-test/src/Test/Util/QSM.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Test.Util.QSM (
-    Example -- opaque
+module Test.Util.QSM
+  ( Example
+    -- opaque
+  , example
   , run
   , run'
-  , example
   ) where
 
 import           Control.Monad

--- a/ouroboros-consensus-test/src/Test/Util/QuickCheck.hs
+++ b/ouroboros-consensus-test/src/Test/Util/QuickCheck.hs
@@ -5,18 +5,18 @@
 {-# LANGUAGE TypeApplications    #-}
 
 -- | QuickCheck utilities
-module Test.Util.QuickCheck (
-    -- * Generic QuickCheck utilities
+module Test.Util.QuickCheck
+  ( -- * Generic QuickCheck utilities
     checkGenerator
-  , checkShrinker
   , checkInvariant
+  , checkShrinker
     -- * Comparison functions
-  , lt
-  , le
-  , gt
-  , ge
-  , strictlyIncreasing
   , expectRight
+  , ge
+  , gt
+  , le
+  , lt
+  , strictlyIncreasing
     -- * Comparing maps
   , isSubmapOfBy
     -- * Improved variants

--- a/ouroboros-consensus-test/src/Test/Util/Range.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Range.hs
@@ -1,8 +1,8 @@
-module Test.Util.Range (
-    RangeK(..)
-  , Range(..)
-  , rangeK
+module Test.Util.Range
+  ( Range (..)
+  , RangeK (..)
   , range
+  , rangeK
   ) where
 
 import qualified Data.List as L

--- a/ouroboros-consensus-test/src/Test/Util/RefEnv.hs
+++ b/ouroboros-consensus-test/src/Test/Util/RefEnv.hs
@@ -4,20 +4,21 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
 
-module Test.Util.RefEnv (
-    RefEnv -- opaque
-  , toList
-  , fromList
-  , empty
-  , union
-  , lookup
-  , (!)
-  , keys
+module Test.Util.RefEnv
+  ( RefEnv
+    -- opaque
   , elems
-  , null
-  , singleton
+  , empty
   , filter
+  , fromList
+  , keys
+  , lookup
+  , null
   , reverseLookup
+  , singleton
+  , toList
+  , union
+  , (!)
   ) where
 
 import           Prelude hiding (filter, lookup, null)

--- a/ouroboros-consensus-test/src/Test/Util/SOP.hs
+++ b/ouroboros-consensus-test/src/Test/Util/SOP.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Test.Util.SOP (
-    constrName
+module Test.Util.SOP
+  ( constrName
   , constrNames
   ) where
 

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Golden.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Golden.hs
@@ -11,19 +11,19 @@
 {-# LANGUAGE TypeApplications    #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Util.Serialisation.Golden (
-    Examples (..)
+module Test.Util.Serialisation.Golden
+  ( Examples (..)
+  , Labelled
+  , ToGoldenDirectory (..)
   , combineExamples
+  , goldenTest_SerialiseDisk
+  , goldenTest_SerialiseNodeToClient
+  , goldenTest_SerialiseNodeToNode
+  , goldenTest_all
+  , labelled
   , mapExamples
   , prefixExamples
-  , Labelled
   , unlabelled
-  , labelled
-  , ToGoldenDirectory (..)
-  , goldenTest_all
-  , goldenTest_SerialiseDisk
-  , goldenTest_SerialiseNodeToNode
-  , goldenTest_SerialiseNodeToClient
   ) where
 
 import           Codec.CBOR.Encoding (Encoding)

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
@@ -9,21 +9,21 @@
 {-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Test.Util.Serialisation.Roundtrip (
-    -- * Basic test helpers
+module Test.Util.Serialisation.Roundtrip
+  ( -- * Basic test helpers
     roundtrip
   , roundtrip'
     -- * Test skeleton
   , Arbitrary'
-  , roundtrip_all
-  , roundtrip_SerialiseDisk
-  , roundtrip_SerialiseNodeToNode
-  , roundtrip_SerialiseNodeToClient
-  , roundtrip_envelopes
-  , roundtrip_ConvertRawHash
-  , prop_hashSize
-  , WithVersion (..)
   , SomeResult (..)
+  , WithVersion (..)
+  , prop_hashSize
+  , roundtrip_ConvertRawHash
+  , roundtrip_SerialiseDisk
+  , roundtrip_SerialiseNodeToClient
+  , roundtrip_SerialiseNodeToNode
+  , roundtrip_all
+  , roundtrip_envelopes
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus-test/src/Test/Util/Shrink.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Shrink.hs
@@ -1,8 +1,8 @@
 -- | Utility functions for defining @QuickCheck@'s 'Test.QuickCheck.shrink'
 --
-module Test.Util.Shrink (
-  andId,
-  dropId,
+module Test.Util.Shrink
+  ( andId
+  , dropId
   ) where
 
 {-------------------------------------------------------------------------------

--- a/ouroboros-consensus-test/src/Test/Util/Slots.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Slots.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Test.Util.Slots (
-  NumSlots (..),
+module Test.Util.Slots
+  ( NumSlots (..)
   ) where
 
 import           Data.Word (Word64)

--- a/ouroboros-consensus-test/src/Test/Util/Split.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Split.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Test.Util.Split (
-    spanLeft,
-    spanLeft',
-    splitAtJust,
+module Test.Util.Split
+  ( spanLeft
+  , spanLeft'
+  , splitAtJust
   ) where
 
 import           Data.Bifunctor (first)

--- a/ouroboros-consensus-test/src/Test/Util/Stream.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Stream.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DeriveTraversable #-}
 
-module Test.Util.Stream (
-  Stream (..),
-  nubOrdBy,
+module Test.Util.Stream
+  ( Stream (..)
+  , nubOrdBy
   ) where
 
 import qualified Data.Set as Set

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -18,40 +18,40 @@
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 -- | Minimal instantiation of the consensus layer to be able to run the ChainDB
-module Test.Util.TestBlock (
-    -- * Blocks
-    TestHash(TestHash)
-  , unTestHash
-  , testHashFromList
-  , TestBlock(..)
-  , TestBlockError(..)
-  , Header(..)
-  , BlockConfig(..)
-  , CodecConfig(..)
-  , StorageConfig(..)
-  , Query(..)
+module Test.Util.TestBlock
+  ( -- * Blocks
+    BlockConfig (..)
+  , CodecConfig (..)
+  , Header (..)
+  , Query (..)
+  , StorageConfig (..)
+  , TestBlock (..)
+  , TestBlockError (..)
+  , TestHash (TestHash)
   , firstBlock
-  , successorBlock
-  , modifyFork
   , forkBlock
+  , modifyFork
+  , successorBlock
+  , testHashFromList
+  , unTestHash
     -- * Chain
-  , BlockChain(..)
+  , BlockChain (..)
   , blockChain
   , chainToBlocks
     -- * Tree
-  , BlockTree(..)
+  , BlockTree (..)
   , blockTree
+  , treePreferredChain
   , treeToBlocks
   , treeToChains
-  , treePreferredChain
     -- * Ledger infrastructure
   , lastAppliedBlock
-  , testInitLedger
-  , testInitExtLedger
   , singleNodeTestConfig
   , singleNodeTestConfigWithK
+  , testInitExtLedger
+  , testInitLedger
     -- * Support for tests
-  , Permutation(..)
+  , Permutation (..)
   , permute
   ) where
 

--- a/ouroboros-consensus-test/src/Test/Util/Time.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Time.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
-module Test.Util.Time (
-    dawnOfTime
+module Test.Util.Time
+  ( dawnOfTime
   ) where
 
 import           Data.Time (UTCTime (..), fromGregorian)

--- a/ouroboros-consensus-test/src/Test/Util/WithEq.hs
+++ b/ouroboros-consensus-test/src/Test/Util/WithEq.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Test.Util.WithEq
-  ( WithEq (..)
-  , Id (..)
+  ( Id (..)
+  , WithEq (..)
   ) where
 
 import           Data.Function (on)

--- a/ouroboros-consensus-test/test-consensus/Main.hs
+++ b/ouroboros-consensus-test/test-consensus/Main.hs
@@ -1,4 +1,6 @@
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import           Test.Tasty
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/BlockchainTime/Simple.hs
@@ -10,7 +10,9 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-module Test.Consensus.BlockchainTime.Simple (tests) where
+module Test.Consensus.BlockchainTime.Simple
+  ( tests
+  ) where
 
 import           Control.Monad.Except
 import           Control.Monad.Reader

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator.hs
@@ -19,7 +19,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Consensus.HardFork.Combinator (tests) where
+module Test.Consensus.HardFork.Combinator
+  ( tests
+  ) where
 
 import qualified Data.Map as Map
 import           Data.SOP.Strict hiding (shape)

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/A.hs
@@ -17,25 +17,25 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Consensus.HardFork.Combinator.A (
-    ProtocolA
-  , BlockA(..)
+module Test.Consensus.HardFork.Combinator.A
+  ( BlockA (..)
+  , ProtocolA
+  , blockForgingA
   , safeFromTipA
   , stabilityWindowA
-  , blockForgingA
     -- * Additional types
-  , PartialLedgerConfigA(..)
-  , TxPayloadA(..)
+  , PartialLedgerConfigA (..)
+  , TxPayloadA (..)
     -- * Type family instances
-  , BlockConfig(..)
-  , CodecConfig(..)
-  , StorageConfig(..)
-  , ConsensusConfig(..)
-  , GenTx(..)
-  , Header(..)
-  , LedgerState(..)
-  , NestedCtxt_(..)
-  , TxId(..)
+  , BlockConfig (..)
+  , CodecConfig (..)
+  , ConsensusConfig (..)
+  , GenTx (..)
+  , Header (..)
+  , LedgerState (..)
+  , NestedCtxt_ (..)
+  , StorageConfig (..)
+  , TxId (..)
   ) where
 
 import           Codec.Serialise

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Combinator/B.hs
@@ -17,21 +17,21 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Consensus.HardFork.Combinator.B (
-    ProtocolB
-  , BlockB(..)
-  , safeZoneB
+module Test.Consensus.HardFork.Combinator.B
+  ( BlockB (..)
+  , ProtocolB
   , blockForgingB
+  , safeZoneB
     -- * Type family instances
-  , BlockConfig(..)
-  , CodecConfig(..)
-  , StorageConfig(..)
-  , ConsensusConfig(..)
-  , GenTx(..)
-  , Header(..)
-  , LedgerState(..)
-  , NestedCtxt_(..)
-  , TxId(..)
+  , BlockConfig (..)
+  , CodecConfig (..)
+  , ConsensusConfig (..)
+  , GenTx (..)
+  , Header (..)
+  , LedgerState (..)
+  , NestedCtxt_ (..)
+  , StorageConfig (..)
+  , TxId (..)
   ) where
 
 import           Codec.Serialise

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Forecast.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Forecast.hs
@@ -10,10 +10,10 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 
-module Test.Consensus.HardFork.Forecast (
-    tests
+module Test.Consensus.HardFork.Forecast
+  ( tests
     -- Quell ghc warning
-  , LedgerView(..)
+  , LedgerView (..)
   ) where
 
 import           Control.Exception (assert)

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE StandaloneDeriving        #-}
 {-# LANGUAGE TypeOperators             #-}
 
-module Test.Consensus.HardFork.History (tests) where
+module Test.Consensus.HardFork.History
+  ( tests
+  ) where
 
 import           Control.Exception (throw)
 import           Control.Monad.Except

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Infra.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Infra.hs
@@ -10,18 +10,18 @@
 {-# LANGUAGE TypeOperators       #-}
 
 -- | Infrastructure shared by the various 'HardFork' tests
-module Test.Consensus.HardFork.Infra (
-    -- * Generate HardFork shape
-    Era(..)
-  , Eras(..)
-  , eraIndices
+module Test.Consensus.HardFork.Infra
+  ( -- * Generate HardFork shape
+    Era (..)
+  , Eras (..)
   , chooseEras
+  , eraIndices
   , erasMapStateM
   , erasUnfoldAtMost
     -- * Era-specified generators
   , genEraParams
-  , genStartOfNextEra
   , genShape
+  , genStartOfNextEra
   , genSummary
   ) where
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Summary.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Summary.hs
@@ -7,7 +7,9 @@
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE StandaloneDeriving        #-}
 
-module Test.Consensus.HardFork.Summary (tests) where
+module Test.Consensus.HardFork.Summary
+  ( tests
+  ) where
 
 import           Data.Time
 import           Data.Word

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Mempool.hs
@@ -9,7 +9,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
-module Test.Consensus.Mempool (tests) where
+module Test.Consensus.Mempool
+  ( tests
+  ) where
 
 import           Control.Exception (assert)
 import           Control.Monad (foldM, forM, forM_, void)

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -6,7 +6,9 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
-module Test.Consensus.MiniProtocol.ChainSync.Client ( tests ) where
+module Test.Consensus.MiniProtocol.ChainSync.Client
+  ( tests
+  ) where
 
 import           Control.Monad.State.Strict
 import           Control.Tracer (Tracer (..), contramap, nullTracer, traceWith)

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/LocalStateQuery/Server.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Consensus.MiniProtocol.LocalStateQuery.Server (tests) where
+module Test.Consensus.MiniProtocol.LocalStateQuery.Server
+  ( tests
+  ) where
 
 import           Control.Tracer (nullTracer)
 import           Data.Map (Map)

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Node.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Node.hs
@@ -29,11 +29,11 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
 
-import           Test.Util.FileLock
 import           Test.Util.FS.Sim.FsTree (FsTree (..))
 import           Test.Util.FS.Sim.MockFS (Files)
 import qualified Test.Util.FS.Sim.MockFS as Mock
 import           Test.Util.FS.Sim.STM (runSimFS)
+import           Test.Util.FileLock
 import           Test.Util.QuickCheck (ge)
 
 tests :: TestTree

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Node.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Node.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-module Test.Consensus.Node (tests) where
+module Test.Consensus.Node
+  ( tests
+  ) where
 
 import           Data.Bifunctor (second)
 import           Data.Functor ((<&>))

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -28,8 +28,8 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.TreeDiff (defaultExprViaShow)
 import           Data.Typeable
-import qualified Generics.SOP as SOP
 import           GHC.Generics (Generic, Generic1)
+import qualified Generics.SOP as SOP
 
 import           Control.Monad.Class.MonadTimer
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -14,7 +14,9 @@
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeApplications           #-}
 
-module Test.Consensus.ResourceRegistry (tests) where
+module Test.Consensus.ResourceRegistry
+  ( tests
+  ) where
 
 import           Prelude hiding (elem)
 

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Util/MonadSTM/RAWLock.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Util/MonadSTM/RAWLock.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE NumericUnderscores  #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-module Test.Consensus.Util.MonadSTM.RAWLock (tests) where
+module Test.Consensus.Util.MonadSTM.RAWLock
+  ( tests
+  ) where
 
 import           Control.Exception (throw)
 import           Control.Monad.Except

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/Util/Versioned.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/Util/Versioned.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RankNTypes            #-}
-module Test.Consensus.Util.Versioned (tests) where
+module Test.Consensus.Util.Versioned
+  ( tests
+  ) where
 
 import           Codec.CBOR.Read (deserialiseFromBytes)
 import           Codec.CBOR.Write (toLazyByteString)

--- a/ouroboros-consensus-test/test-infra/Main.hs
+++ b/ouroboros-consensus-test/test-infra/Main.hs
@@ -1,4 +1,6 @@
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import           Test.Tasty
 

--- a/ouroboros-consensus-test/test-infra/Test/ThreadNet/Util/Tests.hs
+++ b/ouroboros-consensus-test/test-infra/Test/ThreadNet/Util/Tests.hs
@@ -1,5 +1,5 @@
-module Test.ThreadNet.Util.Tests (
-    tests
+module Test.ThreadNet.Util.Tests
+  ( tests
   ) where
 
 import           Test.Tasty

--- a/ouroboros-consensus-test/test-infra/Test/Util/Split/Tests.hs
+++ b/ouroboros-consensus-test/test-infra/Test/Util/Split/Tests.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
-module Test.Util.Split.Tests (tests) where
+module Test.Util.Split.Tests
+  ( tests
+  ) where
 
 import           Data.Either (isLeft, isRight)
 import           Data.Maybe (mapMaybe)

--- a/ouroboros-consensus-test/test-storage/Main.hs
+++ b/ouroboros-consensus-test/test-storage/Main.hs
@@ -1,4 +1,6 @@
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import qualified System.Directory as Dir
 import           System.IO.Temp

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB.hs
@@ -1,5 +1,5 @@
-module Test.Ouroboros.Storage.ChainDB (
-    tests
+module Test.Ouroboros.Storage.ChainDB
+  ( tests
   ) where
 
 import           Test.Tasty

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/GcSchedule.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/GcSchedule.hs
@@ -3,7 +3,10 @@
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE RecordWildCards            #-}
-module Test.Ouroboros.Storage.ChainDB.GcSchedule (tests, example) where
+module Test.Ouroboros.Storage.ChainDB.GcSchedule
+  ( example
+  , tests
+  ) where
 
 import           Control.Monad (forM)
 import           Control.Tracer (nullTracer)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -16,67 +16,68 @@
 -- | Model implementation of the chain DB
 --
 -- Intended for qualified import
-module Test.Ouroboros.Storage.ChainDB.Model (
-    Model -- opaque
-  , IteratorId
+module Test.Ouroboros.Storage.ChainDB.Model
+  ( Model
+    -- opaque
   , CPS.FollowerId
+  , IteratorId
     -- * Construction
-  , empty
   , addBlock
-  , addBlocks
   , addBlockPromise
+  , addBlocks
+  , empty
     -- * Queries
   , currentChain
   , currentLedger
   , currentSlot
   , futureBlocks
-  , maxClockSkew
-  , lastK
-  , immutableChain
-  , volatileChain
-  , immutableBlockNo
-  , immutableSlotNo
-  , tipBlock
-  , tipPoint
   , getBlock
   , getBlockByPoint
   , getBlockComponentByPoint
+  , getIsValid
+  , getLedgerDB
+  , getMaxSlotNo
   , hasBlock
   , hasBlockByPoint
-  , getMaxSlotNo
-  , isOpen
+  , immutableBlockNo
+  , immutableChain
+  , immutableSlotNo
   , invalid
-  , getIsValid
+  , isOpen
   , isValid
-  , getLedgerDB
+  , lastK
+  , maxClockSkew
+  , tipBlock
+  , tipPoint
+  , volatileChain
     -- * Iterators
-  , stream
-  , iteratorNext
   , iteratorClose
+  , iteratorNext
+  , stream
     -- * Followers
-  , newFollower
-  , followerInstruction
-  , followerForward
   , followerClose
+  , followerForward
+  , followerInstruction
+  , newFollower
     -- * ModelSupportsBlock
   , ModelSupportsBlock
     -- * Exported for testing purposes
+  , advanceCurSlot
   , between
   , blocks
-  , volatileDbBlocks
-  , immutableDbChain
-  , validChains
-  , initLedger
-  , garbageCollectable
-  , garbageCollectablePoint
-  , garbageCollectableIteratorNext
-  , garbageCollect
-  , copyToImmutableDB
-  , closeDB
-  , reopen
-  , wipeVolatileDB
-  , advanceCurSlot
   , chains
+  , closeDB
+  , copyToImmutableDB
+  , garbageCollect
+  , garbageCollectable
+  , garbageCollectableIteratorNext
+  , garbageCollectablePoint
+  , immutableDbChain
+  , initLedger
+  , reopen
+  , validChains
+  , volatileDbBlocks
+  , wipeVolatileDB
   ) where
 
 import           Codec.Serialise (Serialise, serialise)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model/Test.hs
@@ -6,8 +6,8 @@
 {-# LANGUAGE TypeFamilies          #-}
 
 {-# OPTIONS_GHC -Wno-orphans -Wno-incomplete-uni-patterns #-}
-module Test.Ouroboros.Storage.ChainDB.Model.Test (
-    tests
+module Test.Ouroboros.Storage.ChainDB.Model.Test
+  ( tests
   ) where
 
 import           GHC.Stack

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Paths.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Paths.hs
@@ -8,7 +8,9 @@
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-module Test.Ouroboros.Storage.ChainDB.Paths (tests) where
+module Test.Ouroboros.Storage.ChainDB.Paths
+  ( tests
+  ) where
 
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -19,7 +19,9 @@
 {-# LANGUAGE UndecidableInstances  #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Ouroboros.Storage.ChainDB.StateMachine ( tests ) where
+module Test.Ouroboros.Storage.ChainDB.StateMachine
+  ( tests
+  ) where
 
 import           Prelude hiding (elem)
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/FS.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/FS.hs
@@ -1,4 +1,6 @@
-module Test.Ouroboros.Storage.FS (tests) where
+module Test.Ouroboros.Storage.FS
+  ( tests
+  ) where
 
 import qualified Test.Ouroboros.Storage.FS.StateMachine as StateMachine
 import           Test.Tasty (TestTree, testGroup)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
@@ -41,9 +41,9 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import           Data.TreeDiff (ToExpr (..), defaultExprViaShow)
 import           Data.Word (Word64)
-import qualified Generics.SOP as SOP
 import           GHC.Generics
 import           GHC.Stack
+import qualified Generics.SOP as SOP
 import           System.IO.Temp (withTempDirectory)
 import           System.Random (getStdRandom, randomR)
 import           Text.Read (readMaybe)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/FS/StateMachine.hs
@@ -17,9 +17,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Ouroboros.Storage.FS.StateMachine (
-    tests
-  , showLabelledExamples
+module Test.Ouroboros.Storage.FS.StateMachine
+  ( showLabelledExamples
+  , tests
   ) where
 
 import qualified Control.Exception as E

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB.hs
@@ -1,4 +1,6 @@
-module Test.Ouroboros.Storage.ImmutableDB (tests) where
+module Test.Ouroboros.Storage.ImmutableDB
+  ( tests
+  ) where
 
 import           Test.Tasty (TestTree, testGroup)
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/Mock.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-module Test.Ouroboros.Storage.ImmutableDB.Mock (openDBMock) where
+module Test.Ouroboros.Storage.ImmutableDB.Mock
+  ( openDBMock
+  ) where
 
 import           Data.Bifunctor (first)
 import           Data.Tuple (swap)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/Model.hs
@@ -8,30 +8,30 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Model for the 'ImmutableDB'.
-module Test.Ouroboros.Storage.ImmutableDB.Model (
-    DBModel(..)
-  , InSlot(..)
-  , initDBModel
-  , dbmTipBlock
-  , dbmTip
-  , dbmBlocks
-  , dbmCurrentChunk
+module Test.Ouroboros.Storage.ImmutableDB.Model
+  ( DBModel (..)
+  , InSlot (..)
   , IteratorId
   , IteratorModel
+  , closeAllIterators
+  , dbmBlocks
+  , dbmCurrentChunk
+  , dbmTip
+  , dbmTipBlock
+  , initDBModel
   , simulateCorruptions
   , tips
-  , closeAllIterators
     -- * ImmutableDB implementation
-  , getTipModel
-  , reopenModel
+  , appendBlockModel
   , deleteAfterModel
   , getBlockComponentModel
-  , appendBlockModel
-  , streamModel
-  , streamAllModel
-  , iteratorNextModel
-  , iteratorHasNextModel
+  , getTipModel
   , iteratorCloseModel
+  , iteratorHasNextModel
+  , iteratorNextModel
+  , reopenModel
+  , streamAllModel
+  , streamModel
   ) where
 
 import qualified Codec.CBOR.Write as CBOR

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/Primary.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/Primary.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans -Wno-incomplete-uni-patterns #-}
 
-module Test.Ouroboros.Storage.ImmutableDB.Primary (tests) where
+module Test.Ouroboros.Storage.ImmutableDB.Primary
+  ( tests
+  ) where
 
 import           Data.Functor ((<&>))
 import           Data.Maybe (fromJust)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -39,9 +39,9 @@ import           Data.Maybe (listToMaybe)
 import           Data.TreeDiff (Expr (App), defaultExprViaShow)
 import           Data.Typeable (Typeable)
 import           Data.Word (Word16, Word32, Word64)
-import qualified Generics.SOP as SOP
 import           GHC.Generics (Generic, Generic1)
 import           GHC.Stack (HasCallStack)
+import qualified Generics.SOP as SOP
 import           NoThunks.Class (AllowThunk (..))
 import           System.Random (getStdRandom, randomR)
 import           Text.Show.Pretty (ppShow)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -17,9 +17,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans      #-}
 module Test.Ouroboros.Storage.ImmutableDB.StateMachine
-    ( tests
-    , showLabelledExamples
-    ) where
+  ( showLabelledExamples
+  , tests
+  ) where
 
 import           Prelude hiding (elem, notElem)
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB.hs
@@ -1,5 +1,5 @@
-module Test.Ouroboros.Storage.LedgerDB (
-    tests
+module Test.Ouroboros.Storage.LedgerDB
+  ( tests
   ) where
 
 import           Test.Tasty

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/InMemory.hs
@@ -10,8 +10,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Ouroboros.Storage.LedgerDB.InMemory (
-    tests
+module Test.Ouroboros.Storage.LedgerDB.InMemory
+  ( tests
   ) where
 
 import           Codec.CBOR.FlatTerm (FlatTerm, TermToken (..), fromFlatTerm,

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/LedgerDB/OnDisk.hs
@@ -23,9 +23,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Ouroboros.Storage.LedgerDB.OnDisk (
-    tests
-  , showLabelledExamples
+module Test.Ouroboros.Storage.LedgerDB.OnDisk
+  ( showLabelledExamples
+  , tests
   ) where
 
 import           Prelude hiding (elem)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/Orphans.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/Orphans.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Ouroboros.Storage.Orphans () where
+module Test.Ouroboros.Storage.Orphans
+  (
+  ) where
 
 import           Data.Maybe (isJust)
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/TestBlock.hs
@@ -14,47 +14,47 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Ouroboros.Storage.TestBlock (
-    -- * Test block
-    TestBlock(..)
-  , TestHeader(..)
-  , TestHeaderHash(..)
-  , TestBody(..)
-  , TestBodyHash(..)
-  , Header(..)
-  , BlockConfig(..)
-  , CodecConfig(..)
-  , StorageConfig(..)
-  , EBB(..)
-  , ChainLength(..)
+module Test.Ouroboros.Storage.TestBlock
+  ( -- * Test block
+    BlockConfig (..)
+  , ChainLength (..)
+  , CodecConfig (..)
+  , EBB (..)
+  , Header (..)
+  , StorageConfig (..)
+  , TestBlock (..)
+  , TestBody (..)
+  , TestBodyHash (..)
+  , TestHeader (..)
+  , TestHeaderHash (..)
     -- ** Construction
-  , mkBlock
   , firstBlock
   , firstEBB
+  , mkBlock
   , mkNextBlock
-  , mkNextEBB
   , mkNextBlock'
+  , mkNextEBB
   , mkNextEBB'
     -- ** Query
-  , testBlockIsValid
-  , testBlockIsEBB
   , testBlockChainLength
+  , testBlockIsEBB
+  , testBlockIsValid
     -- ** Serialisation
-  , testBlockToBuilder
   , testBlockFromLazyByteString
+  , testBlockToBuilder
   , testBlockToLazyByteString
     -- * Ledger
-  , TestBlockError(..)
-  , testInitExtLedger
-  , TestBlockOtherHeaderEnvelopeError(..)
+  , TestBlockError (..)
+  , TestBlockOtherHeaderEnvelopeError (..)
   , mkTestConfig
+  , testInitExtLedger
     -- * Corruptions
   , Corruptions
-  , FileCorruption(..)
+  , FileCorruption (..)
+  , corruptFile
   , corruptionFiles
   , generateCorruptions
   , shrinkCorruptions
-  , corruptFile
   ) where
 
 import qualified Codec.CBOR.Read as CBOR

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB.hs
@@ -1,4 +1,6 @@
-module Test.Ouroboros.Storage.VolatileDB (tests) where
+module Test.Ouroboros.Storage.VolatileDB
+  ( tests
+  ) where
 
 import           Test.Tasty (TestTree, testGroup)
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/Mock.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Test.Ouroboros.Storage.VolatileDB.Mock (openDBMock) where
+module Test.Ouroboros.Storage.VolatileDB.Mock
+  ( openDBMock
+  ) where
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.Util ((.:))

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/Model.hs
@@ -10,28 +10,28 @@
 
 -- | In-memory model implementation of 'VolatileDB'
 module Test.Ouroboros.Storage.VolatileDB.Model
-    ( DBModel (..)
-    , initDBModel
-      -- * Basic API
-    , closeModel
-    , isOpenModel
-    , reOpenModel
-    , getBlockComponentModel
-    , putBlockModel
-    , garbageCollectModel
-    , getBlockInfoModel
-    , filterByPredecessorModel
-    , getMaxSlotNoModel
-      -- * Corruptions
-    , runCorruptionsModel
-      -- * Exported for testing purposes
-    , getDBFileIds
-    , getDBFiles
-    , getCurrentFile
-    , blockIndex
-    , blockHashes
-    , BlocksInFile (..)
-    ) where
+  ( DBModel (..)
+  , initDBModel
+    -- * Basic API
+  , closeModel
+  , filterByPredecessorModel
+  , garbageCollectModel
+  , getBlockComponentModel
+  , getBlockInfoModel
+  , getMaxSlotNoModel
+  , isOpenModel
+  , putBlockModel
+  , reOpenModel
+    -- * Corruptions
+  , runCorruptionsModel
+    -- * Exported for testing purposes
+  , BlocksInFile (..)
+  , blockHashes
+  , blockIndex
+  , getCurrentFile
+  , getDBFileIds
+  , getDBFiles
+  ) where
 
 import qualified Codec.CBOR.Write as CBOR
 import           Control.Monad.Except (MonadError, throwError)

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -30,9 +30,9 @@ import           Data.Maybe (catMaybes, listToMaybe, mapMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word
-import qualified Generics.SOP as SOP
 import           GHC.Generics
 import           GHC.Stack
+import qualified Generics.SOP as SOP
 import           System.Random (getStdRandom, randomR)
 import           Text.Show.Pretty (ppShow)
 

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/VolatileDB/StateMachine.hs
@@ -12,9 +12,9 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Ouroboros.Storage.VolatileDB.StateMachine
-    ( tests
-    , showLabelledExamples
-    ) where
+  ( showLabelledExamples
+  , tests
+  ) where
 
 import           Prelude hiding (elem)
 

--- a/ouroboros-consensus/docs/report/unsoundswitch/UnsoundSwitch.hs
+++ b/ouroboros-consensus/docs/report/unsoundswitch/UnsoundSwitch.hs
@@ -1,4 +1,6 @@
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import           Control.Monad
 import           System.IO

--- a/ouroboros-consensus/src-unix/Ouroboros/Consensus/Storage/IO.hs
+++ b/ouroboros-consensus/src-unix/Ouroboros/Consensus/Storage/IO.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE PackageImports #-}
 
-module Ouroboros.Consensus.Storage.IO (
-      FHandle
-    , open
-    , truncate
-    , seek
-    , read
-    , pread
-    , write
-    , close
-    , getSize
-    , sameError
-    ) where
+module Ouroboros.Consensus.Storage.IO
+  ( FHandle
+  , close
+  , getSize
+  , open
+  , pread
+  , read
+  , sameError
+  , seek
+  , truncate
+  , write
+  ) where
 
 import           Prelude hiding (read, truncate)
 

--- a/ouroboros-consensus/src-win32/Ouroboros/Consensus/Storage/IO.hs
+++ b/ouroboros-consensus/src-win32/Ouroboros/Consensus/Storage/IO.hs
@@ -1,16 +1,16 @@
 {-# OPTIONS_GHC -Wno-dodgy-imports #-}
-module Ouroboros.Consensus.Storage.IO (
-      FHandle
-    , open
-    , truncate
-    , seek
-    , read
-    , pread
-    , write
-    , close
-    , getSize
-    , sameError
-    ) where
+module Ouroboros.Consensus.Storage.IO
+  ( FHandle
+  , close
+  , getSize
+  , open
+  , pread
+  , read
+  , sameError
+  , seek
+  , truncate
+  , write
+  ) where
 
 import           Prelude hiding (read, truncate)
 

--- a/ouroboros-consensus/src/Data/SOP/Strict.hs
+++ b/ouroboros-consensus/src/Data/SOP/Strict.hs
@@ -18,15 +18,15 @@
 -- | Strict variant of SOP
 --
 -- This does not currently attempt to be exhaustive.
-module Data.SOP.Strict (
-    -- * NP
-    NP(..)
+module Data.SOP.Strict
+  ( -- * NP
+    NP (..)
   , hd
   , tl
     -- * NS
-  , NS(..)
-  , unZ
+  , NS (..)
   , index_NS
+  , unZ
     -- * Injections
   , Injection
   , injections

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
@@ -1,6 +1,6 @@
 -- | The consensus layer's abstract view of blocks
-module Ouroboros.Consensus.Block (
-    module X
+module Ouroboros.Consensus.Block
+  ( module X
   ) where
 
 import           Ouroboros.Consensus.Block.Abstract as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -74,11 +74,11 @@ import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..),
                      withOrigin, withOriginFromMaybe, withOriginToMaybe)
 import qualified Cardano.Slotting.Slot as Cardano
 
-import           Ouroboros.Network.Block (pattern BlockPoint, ChainHash (..),
-                     pattern GenesisPoint, HasHeader (..), HeaderFields (..),
-                     HeaderHash, Point, StandardHash, blockHash, blockNo,
-                     blockPoint, blockSlot, castHash, castHeaderFields,
-                     castPoint, pointHash, pointSlot)
+import           Ouroboros.Network.Block (ChainHash (..), HasHeader (..),
+                     HeaderFields (..), HeaderHash, Point, StandardHash,
+                     blockHash, blockNo, blockPoint, blockSlot, castHash,
+                     castHeaderFields, castPoint, pattern BlockPoint,
+                     pattern GenesisPoint, pointHash, pointSlot)
 
 import           Ouroboros.Consensus.Block.EBB
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Abstract.hs
@@ -5,32 +5,38 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies       #-}
 
-module Ouroboros.Consensus.Block.Abstract (
-    -- * Protocol
+module Ouroboros.Consensus.Block.Abstract
+  ( -- * Protocol
     BlockProtocol
     -- * Configuration
   , BlockConfig
   , CodecConfig
   , StorageConfig
     -- * Previous hash
-  , GetPrevHash(..)
+  , GetPrevHash (..)
   , blockPrevHash
     -- * Working with headers
+  , GetHeader (..)
   , Header
-  , GetHeader(..)
+  , blockIsEBB
+  , blockToIsEBB
   , getBlockHeaderFields
   , headerHash
   , headerPoint
   , headerToIsEBB
-  , blockIsEBB
-  , blockToIsEBB
     -- * Raw hash
-  , ConvertRawHash(..)
-  , encodeRawHash
+  , ConvertRawHash (..)
   , decodeRawHash
+  , encodeRawHash
     -- * Utilities for working with WithOrigin
   , succWithOrigin
     -- * Re-export basic definitions from @ouroboros-network@
+  , ChainHash (..)
+  , HasHeader (..)
+  , HeaderFields (..)
+  , HeaderHash
+  , Point (GenesisPoint, BlockPoint)
+  , StandardHash
   , blockHash
   , blockNo
   , blockPoint
@@ -38,23 +44,17 @@ module Ouroboros.Consensus.Block.Abstract (
   , castHash
   , castHeaderFields
   , castPoint
-  , ChainHash(..)
-  , HasHeader(..)
-  , HeaderFields(..)
-  , HeaderHash
-  , Point(GenesisPoint, BlockPoint)
   , pointHash
   , pointSlot
-  , StandardHash
     -- * Re-export basic definitions from @cardano-base@
-  , BlockNo(..)
-  , EpochNo(..)
-  , EpochSize(..)
+  , BlockNo (..)
+  , EpochNo (..)
+  , EpochSize (..)
+  , SlotNo (..)
+  , WithOrigin (Origin, NotOrigin)
   , fromWithOrigin
-  , SlotNo(..)
   , withOrigin
   , withOriginFromMaybe
-  , WithOrigin(Origin, NotOrigin)
   , withOriginToMaybe
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/EBB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/EBB.hs
@@ -2,10 +2,10 @@
 {-# LANGUAGE DeriveGeneric  #-}
 
 -- | Generic infrastructure for working with EBBs
-module Ouroboros.Consensus.Block.EBB (
-    IsEBB (..)
-  , toIsEBB
+module Ouroboros.Consensus.Block.EBB
+  ( IsEBB (..)
   , fromIsEBB
+  , toIsEBB
   ) where
 
 import           Codec.Serialise (Serialise (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forging.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Forging.hs
@@ -8,16 +8,16 @@
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Ouroboros.Consensus.Block.Forging (
-    CannotForge
+module Ouroboros.Consensus.Block.Forging
+  ( BlockForging (..)
+  , CannotForge
   , ForgeStateInfo
   , ForgeStateUpdateError
-  , ForgeStateUpdateInfo(..)
+  , ForgeStateUpdateInfo (..)
+  , ShouldForge (..)
   , castForgeStateUpdateInfo
-  , forgeStateUpdateInfoFromUpdateInfo
-  , BlockForging(..)
-  , ShouldForge(..)
   , checkShouldForge
+  , forgeStateUpdateInfoFromUpdateInfo
     -- * 'UpdateInfo'
   , UpdateInfo (..)
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/NestedContent.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/NestedContent.hs
@@ -11,13 +11,13 @@
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-module Ouroboros.Consensus.Block.NestedContent (
-    -- * Block contents
+module Ouroboros.Consensus.Block.NestedContent
+  ( -- * Block contents
     HasNestedContent (..)
   , NestedCtxt_
   , curriedNest
     -- * Flip type arguments
-  , NestedCtxt(..)
+  , NestedCtxt (..)
   , castNestedCtxt
   , mapNestedCtxt
     -- * Existentials

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/RealPoint.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/RealPoint.hs
@@ -7,19 +7,19 @@
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Ouroboros.Consensus.Block.RealPoint (
-    -- * Non-genesis points
-    RealPoint(..)
-  , encodeRealPoint
+module Ouroboros.Consensus.Block.RealPoint
+  ( -- * Non-genesis points
+    RealPoint (..)
   , decodeRealPoint
+  , encodeRealPoint
     -- * Derived
-  , realPointSlot
-  , realPointHash
   , blockRealPoint
   , headerRealPoint
+  , pointToWithOriginRealPoint
+  , realPointHash
+  , realPointSlot
   , realPointToPoint
   , withOriginRealPointToPoint
-  , pointToWithOriginRealPoint
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsMetrics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsMetrics.hs
@@ -1,6 +1,6 @@
 -- | See 'BlockSupportsMetrics'.
-module Ouroboros.Consensus.Block.SupportsMetrics (
-    BlockSupportsMetrics (..)
+module Ouroboros.Consensus.Block.SupportsMetrics
+  ( BlockSupportsMetrics (..)
   , WhetherSelfIssued (..)
   , isSelfIssuedConstUnknown
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/SupportsProtocol.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE TypeFamilies      #-}
 
-module Ouroboros.Consensus.Block.SupportsProtocol (
-    BlockSupportsProtocol(..)
+module Ouroboros.Consensus.Block.SupportsProtocol
+  ( BlockSupportsProtocol (..)
   ) where
 
 import           NoThunks.Class (NoThunks)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime.hs
@@ -1,4 +1,6 @@
-module Ouroboros.Consensus.BlockchainTime (module X) where
+module Ouroboros.Consensus.BlockchainTime
+  ( module X
+  ) where
 
 import           Ouroboros.Consensus.BlockchainTime.API as X
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Default as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/API.hs
@@ -6,9 +6,9 @@
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Ouroboros.Consensus.BlockchainTime.API (
-    BlockchainTime(..)
-  , CurrentSlot(..)
+module Ouroboros.Consensus.BlockchainTime.API
+  ( BlockchainTime (..)
+  , CurrentSlot (..)
   , knownSlotWatcher
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Default.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Default.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.BlockchainTime.WallClock.Default (
-    defaultSystemTime
+module Ouroboros.Consensus.BlockchainTime.WallClock.Default
+  ( defaultSystemTime
   ) where
 
 import           Control.Monad

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/HardFork.hs
@@ -3,8 +3,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Ouroboros.Consensus.BlockchainTime.WallClock.HardFork (
-    BackoffDelay (..)
+module Ouroboros.Consensus.BlockchainTime.WallClock.HardFork
+  ( BackoffDelay (..)
   , HardForkBlockchainTimeArgs (..)
   , hardForkBlockchainTime
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Simple.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Simple.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Ouroboros.Consensus.BlockchainTime.WallClock.Simple (
-    simpleBlockchainTime
+module Ouroboros.Consensus.BlockchainTime.WallClock.Simple
+  ( simpleBlockchainTime
     -- * Low-level API (exported primarily for testing)
   , getWallClockSlot
   , waitUntilNextSlot

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Types.hs
@@ -3,26 +3,27 @@
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Ouroboros.Consensus.BlockchainTime.WallClock.Types (
-    -- * System time
-    SystemStart(..)
+module Ouroboros.Consensus.BlockchainTime.WallClock.Types
+  ( -- * System time
+    SystemStart (..)
     -- * Relative time
-  , RelativeTime(..)
+  , RelativeTime (..)
   , addRelTime
   , diffRelTime
-  , toRelativeTime
   , fromRelativeTime
+  , toRelativeTime
     -- * Get current time (as 'RelativeTime')
-  , SystemTime(..)
+  , SystemTime (..)
     -- * Slot length
-  , SlotLength -- Opaque
+  , SlotLength
+    -- Opaque
   , getSlotLength
   , mkSlotLength
     -- ** Conversions
-  , slotLengthFromSec
-  , slotLengthToSec
   , slotLengthFromMillisec
+  , slotLengthFromSec
   , slotLengthToMillisec
+  , slotLengthToSec
   ) where
 
 import           Codec.Serialise

--- a/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/BlockchainTime/WallClock/Util.hs
@@ -2,11 +2,11 @@
 {-# LANGUAGE RecordWildCards #-}
 
 -- | Support for defining 'BlockchainTime' instances
-module Ouroboros.Consensus.BlockchainTime.WallClock.Util (
-    -- * Tracing
-    TraceBlockchainTimeEvent(..)
+module Ouroboros.Consensus.BlockchainTime.WallClock.Util
+  ( -- * Tracing
+    TraceBlockchainTimeEvent (..)
     -- * Exceptions
-  , SystemClockMovedBackException(..)
+  , SystemClockMovedBackException (..)
   ) where
 
 import           Control.Exception (Exception)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config.hs
@@ -5,16 +5,16 @@
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Ouroboros.Consensus.Config (
-    -- * The top-level node configuration
-    TopLevelConfig(..)
-  , mkTopLevelConfig
+module Ouroboros.Consensus.Config
+  ( -- * The top-level node configuration
+    TopLevelConfig (..)
   , castTopLevelConfig
+  , mkTopLevelConfig
     -- ** Derived extraction functions
-  , configConsensus
-  , configLedger
   , configBlock
   , configCodec
+  , configConsensus
+  , configLedger
   , configStorage
     -- ** Additional convenience functions
   , configSecurityParam

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config/SecurityParam.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config/SecurityParam.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Ouroboros.Consensus.Config.SecurityParam (
-    SecurityParam(..)
+module Ouroboros.Consensus.Config.SecurityParam
+  ( SecurityParam (..)
   ) where
 
 import           Data.Word

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Config/SupportsNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Config/SupportsNode.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Config.SupportsNode (
-    ConfigSupportsNode (..)
+module Ouroboros.Consensus.Config.SupportsNode
+  ( ConfigSupportsNode (..)
   ) where
 
 import           Ouroboros.Network.Magic (NetworkMagic)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Forecast.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Forecast.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE DeriveFunctor #-}
 
-module Ouroboros.Consensus.Forecast (
-    Forecast(..)
+module Ouroboros.Consensus.Forecast
+  ( Forecast (..)
+  , OutsideForecastRange (..)
+  , constantForecastOf
   , mapForecast
   , trivialForecast
-  , constantForecastOf
-  , OutsideForecastRange(..)
     -- * Utilities for constructing forecasts
   , crossEraForecastBound
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Diff.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Diff.hs
@@ -8,21 +8,21 @@
 -- > import Ouroboros.Consensus.Fragment.Diff (ChainDiff (..))
 -- > import qualified Ouroboros.Consensus.Fragment.Diff as Diff
 module Ouroboros.Consensus.Fragment.Diff
-  ( ChainDiff(..)
+  ( ChainDiff (..)
     -- * Queries
-  , getTip
   , getAnchorPoint
+  , getTip
   , rollbackExceedsSuffix
     -- * Constructors
-  , extend
   , diff
+  , extend
     -- * Application
   , apply
     -- * Manipulation
   , append
-  , truncate
-  , takeWhileOldest
   , mapM
+  , takeWhileOldest
+  , truncate
   ) where
 
 import           Prelude hiding (mapM, truncate)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
@@ -31,7 +31,7 @@ import           Control.Monad.Class.MonadSTM
 
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
-                     AnchoredSeq ((:>), Empty))
+                     AnchoredSeq (Empty, (:>)))
 
 import           Ouroboros.Consensus.Block
 import           Ouroboros.Consensus.BlockchainTime

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/InFuture.hs
@@ -9,12 +9,13 @@
 --
 -- > import Ouroboros.Consensus.Fragment.InFuture (CheckInFuture(..), ClockSkew(..))
 -- > import qualified Ouroboros.Consensus.Fragment.InFuture as InFuture
-module Ouroboros.Consensus.Fragment.InFuture (
-    CheckInFuture(..)
-  , InFuture(..)
+module Ouroboros.Consensus.Fragment.InFuture
+  ( CheckInFuture (..)
+  , InFuture (..)
   , reference
     -- * Clock skew
-  , ClockSkew -- opaque
+  , ClockSkew
+    -- opaque
   , clockSkewInSeconds
   , defaultClockSkew
     -- * Testing

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Validated.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/Validated.hs
@@ -10,8 +10,8 @@
 --
 -- > import Ouroboros.Consensus.Fragment.Validated (ValidatedFragment)
 -- > import qualified Ouroboros.Consensus.Fragment.Validated as VF
-module Ouroboros.Consensus.Fragment.Validated (
-    ValidatedFragment(ValidatedFragment)
+module Ouroboros.Consensus.Fragment.Validated
+  ( ValidatedFragment (ValidatedFragment)
   , validatedFragment
   , validatedLedger
   , validatedTip

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/ValidatedDiff.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Fragment/ValidatedDiff.hs
@@ -6,12 +6,12 @@
 -- > import Ouroboros.Consensus.Fragment.ValidatedDiff (ValidatedChainDiff (..))
 -- > import qualified Ouroboros.Consensus.Fragment.ValidatedDiff as ValidatedDiff
 module Ouroboros.Consensus.Fragment.ValidatedDiff
-  ( ValidatedChainDiff(ValidatedChainDiff)
+  ( ValidatedChainDiff (ValidatedChainDiff)
   , getChainDiff
   , getLedger
   , new
-  , toValidatedFragment
   , rollbackExceedsSuffix
+  , toValidatedFragment
   ) where
 
 import           Control.Monad.Except (throwError)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Abstract.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies    #-}
 
-module Ouroboros.Consensus.HardFork.Abstract (
-    HasHardForkHistory(..)
+module Ouroboros.Consensus.HardFork.Abstract
+  ( HasHardForkHistory (..)
   , neverForksHardForkSummary
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
@@ -33,12 +33,10 @@ import           Ouroboros.Consensus.HardFork.Combinator.Mempool as X
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol as X
 
 -- Instance for 'CommonProtocolParams'
-import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams as X
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams as X ()
 
 -- Instance for 'LedgerSupportsPeerSelection'
-import           Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection as X
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection as X ()
 
 -- Instances for 'ShowQuery' and 'QueryLedger'
 -- Definition of 'Query', required for serialisation code
@@ -70,8 +68,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Forging as X
 import           Ouroboros.Consensus.HardFork.Combinator.Node as X ()
 
 -- Instance for 'NodeInitStorage'
-import           Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage as X
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage as X ()
 
 -- Instance for 'BlockSupportsMetrics'
 import           Ouroboros.Consensus.HardFork.Combinator.Node.Metrics as X ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator.hs
@@ -1,8 +1,8 @@
 -- | The hard fork combinator
 --
 -- Intended for unqualified import
-module Ouroboros.Consensus.HardFork.Combinator (
-    module X
+module Ouroboros.Consensus.HardFork.Combinator
+  ( module X
   ) where
 
 -- Defines 'SingleEraInfo' and 'LedgerEraInfo'

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract.hs
@@ -1,8 +1,8 @@
-module Ouroboros.Consensus.HardFork.Combinator.Abstract (
-    module X
+module Ouroboros.Consensus.HardFork.Combinator.Abstract
+  ( module X
     -- * Re-exports
-  , IsNonEmpty(..)
-  , ProofNonEmpty(..)
+  , IsNonEmpty (..)
+  , ProofNonEmpty (..)
   ) where
 
 import           Ouroboros.Consensus.Util.SOP

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/CanHardFork.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE TypeOperators           #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork (
-    CanHardFork(..)
+module Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork
+  ( CanHardFork (..)
   ) where
 
 import           Data.SOP.Strict

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/NoHardForks.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/NoHardForks.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.HardFork.Combinator.Abstract.NoHardForks (
-    NoHardForks(..)
+module Ouroboros.Consensus.HardFork.Combinator.Abstract.NoHardForks
+  ( NoHardForks (..)
   , noHardForksEpochInfo
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Abstract/SingleEraBlock.hs
@@ -6,19 +6,19 @@
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock (
-    -- * Single era block
-    SingleEraBlock(..)
-  , singleEraTransition'
+module Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
+  ( -- * Single era block
+    SingleEraBlock (..)
   , proxySingle
+  , singleEraTransition'
     -- * Era index
-  , EraIndex(..)
+  , EraIndex (..)
   , eraIndexEmpty
-  , eraIndexFromNS
   , eraIndexFromIndex
-  , eraIndexZero
+  , eraIndexFromNS
   , eraIndexSucc
   , eraIndexToInt
+  , eraIndexZero
   ) where
 
 import           Codec.Serialise

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/AcrossEras.hs
@@ -18,43 +18,43 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
-    -- * Value for /each/ era
-    PerEraConsensusConfig(..)
-  , PerEraBlockConfig(..)
-  , PerEraCodecConfig(..)
-  , PerEraLedgerConfig(..)
-  , PerEraStorageConfig(..)
+module Ouroboros.Consensus.HardFork.Combinator.AcrossEras
+  ( -- * Value for /each/ era
+    PerEraBlockConfig (..)
+  , PerEraCodecConfig (..)
+  , PerEraConsensusConfig (..)
+  , PerEraLedgerConfig (..)
+  , PerEraStorageConfig (..)
     -- * Values for /some/ eras
-  , SomeErasCanBeLeader(..)
+  , SomeErasCanBeLeader (..)
     -- * Value for /one/ era
-  , OneEraApplyTxErr(..)
-  , OneEraBlock(..)
-  , OneEraCannotForge(..)
-  , OneEraEnvelopeErr(..)
-  , OneEraForgeStateInfo(..)
-  , OneEraForgeStateUpdateError(..)
-  , OneEraGenTx(..)
-  , OneEraGenTxId(..)
-  , OneEraHash(..)
-  , OneEraHeader(..)
-  , OneEraIsLeader(..)
-  , OneEraLedgerError(..)
-  , OneEraLedgerUpdate(..)
-  , OneEraLedgerWarning(..)
-  , OneEraSelectView(..)
-  , OneEraTipInfo(..)
-  , OneEraValidateView(..)
-  , OneEraValidationErr(..)
+  , OneEraApplyTxErr (..)
+  , OneEraBlock (..)
+  , OneEraCannotForge (..)
+  , OneEraEnvelopeErr (..)
+  , OneEraForgeStateInfo (..)
+  , OneEraForgeStateUpdateError (..)
+  , OneEraGenTx (..)
+  , OneEraGenTxId (..)
+  , OneEraHash (..)
+  , OneEraHeader (..)
+  , OneEraIsLeader (..)
+  , OneEraLedgerError (..)
+  , OneEraLedgerUpdate (..)
+  , OneEraLedgerWarning (..)
+  , OneEraSelectView (..)
+  , OneEraTipInfo (..)
+  , OneEraValidateView (..)
+  , OneEraValidationErr (..)
     -- * Value for two /different/ eras
-  , MismatchEraInfo(..)
-  , mismatchOneEra
+  , EraMismatch (..)
+  , MismatchEraInfo (..)
   , mismatchFutureEra
-  , EraMismatch(..)
+  , mismatchOneEra
   , mkEraMismatch
     -- * Utility
-  , oneEraBlockHeader
   , getSameValue
+  , oneEraBlockHeader
   ) where
 
 import           Codec.Serialise (Serialise (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Basics.hs
@@ -13,22 +13,22 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Basics (
-    -- * Hard fork protocol, block, and ledger state
-    HardForkProtocol
-  , HardForkBlock(..)
-  , LedgerState(..)
+module Ouroboros.Consensus.HardFork.Combinator.Basics
+  ( -- * Hard fork protocol, block, and ledger state
+    HardForkBlock (..)
+  , HardForkProtocol
+  , LedgerState (..)
     -- * Config
-  , ConsensusConfig(..)
-  , BlockConfig(..)
-  , CodecConfig(..)
-  , StorageConfig(..)
-  , HardForkLedgerConfig(..)
+  , BlockConfig (..)
+  , CodecConfig (..)
+  , ConsensusConfig (..)
+  , HardForkLedgerConfig (..)
+  , StorageConfig (..)
     -- ** Functions on config
-  , completeLedgerConfig'
-  , completeLedgerConfig''
   , completeConsensusConfig'
   , completeConsensusConfig''
+  , completeLedgerConfig'
+  , completeLedgerConfig''
   , distribLedgerConfig
   , distribTopLevelConfig
     -- ** Convenience re-exports

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Block.hs
@@ -15,10 +15,10 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Block (
-    -- * Type family instances
-    Header(..)
-  , NestedCtxt_(..)
+module Ouroboros.Consensus.HardFork.Combinator.Block
+  ( -- * Type family instances
+    Header (..)
+  , NestedCtxt_ (..)
     -- * AnnTip
   , distribAnnTip
   , undistribAnnTip

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Compat.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Compat.hs
@@ -6,12 +6,12 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators       #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Compat (
-    HardForkCompatQuery(..)
+module Ouroboros.Consensus.HardFork.Combinator.Compat
+  ( HardForkCompatQuery (..)
     -- * Convenience constructors
-  , compatIfCurrent
   , compatGetEraStart
   , compatGetInterpreter
+  , compatIfCurrent
     -- * Wrappers
   , forwardCompatQuery
   , singleEraCompatQuery

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Condense.hs
@@ -13,8 +13,8 @@
 -- within consensus.
 --
 -- NOTE: No guarantees are made about what these condense instances look like.
-module Ouroboros.Consensus.HardFork.Combinator.Condense (
-    CondenseConstraints
+module Ouroboros.Consensus.HardFork.Combinator.Condense
+  ( CondenseConstraints
   ) where
 
 import           Data.Coerce

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -44,18 +44,14 @@ import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger
-import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams ()
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
 import           Ouroboros.Consensus.HardFork.Combinator.Mempool
 import           Ouroboros.Consensus.HardFork.Combinator.Node ()
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
-                     ()
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient
-                     ()
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode ()
 
 {-------------------------------------------------------------------------------
   Simple patterns

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Degenerate.hs
@@ -10,24 +10,24 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Degenerate (
-    -- * Pattern synonyms
-    HardForkBlock (DegenBlock)
-  , Header (DegenHeader)
+module Ouroboros.Consensus.HardFork.Combinator.Degenerate
+  ( -- * Pattern synonyms
+    BlockConfig (DegenBlockConfig)
+  , CodecConfig (DegenCodecConfig)
+  , ConsensusConfig (DegenConsensusConfig)
+  , Either (DegenQueryResult)
   , GenTx (DegenGenTx)
-  , TxId (DegenGenTxId)
   , HardForkApplyTxErr (DegenApplyTxErr)
-  , HardForkLedgerError (DegenLedgerError)
+  , HardForkBlock (DegenBlock)
   , HardForkEnvelopeErr (DegenOtherHeaderEnvelopeError)
+  , HardForkLedgerConfig (DegenLedgerConfig)
+  , HardForkLedgerError (DegenLedgerError)
+  , Header (DegenHeader)
+  , LedgerState (DegenLedgerState)
   , OneEraTipInfo (DegenTipInfo)
   , Query (DegenQuery)
-  , Either (DegenQueryResult)
-  , CodecConfig (DegenCodecConfig)
-  , BlockConfig (DegenBlockConfig)
-  , ConsensusConfig (DegenConsensusConfig)
-  , HardForkLedgerConfig (DegenLedgerConfig)
   , TopLevelConfig (DegenTopLevelConfig)
-  , LedgerState (DegenLedgerState)
+  , TxId (DegenGenTxId)
   ) where
 
 import           Data.SOP.Strict

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Binary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Binary.hs
@@ -3,8 +3,8 @@
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-module Ouroboros.Consensus.HardFork.Combinator.Embed.Binary (
-    protocolInfoBinary
+module Ouroboros.Consensus.HardFork.Combinator.Embed.Binary
+  ( protocolInfoBinary
   ) where
 
 import           Control.Exception (assert)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Nary.hs
@@ -8,13 +8,13 @@
 {-# LANGUAGE ScopedTypeVariables      #-}
 {-# LANGUAGE TypeApplications         #-}
 {-# LANGUAGE TypeOperators            #-}
-module Ouroboros.Consensus.HardFork.Combinator.Embed.Nary (
-    Inject (..)
+module Ouroboros.Consensus.HardFork.Combinator.Embed.Nary
+  ( Inject (..)
   , inject'
     -- * Defaults
+  , injectHardForkState
   , injectNestedCtxt_
   , injectQuery
-  , injectHardForkState
     -- * Initial 'ExtLedgerState'
   , injectInitialExtLedgerState
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Embed/Unary.hs
@@ -17,22 +17,22 @@
 {-# LANGUAGE TypeOperators         #-}
 
 -- | Witness isomorphism between @b@ and @HardForkBlock '[b]@
-module Ouroboros.Consensus.HardFork.Combinator.Embed.Unary (
-    Isomorphic(..)
-  , project'
+module Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
+  ( Isomorphic (..)
   , inject'
+  , project'
     -- * Dependent types
-  , projQuery
-  , projQuery'
-  , ProjHardForkQuery(..)
+  , ProjHardForkQuery (..)
+  , injNestedCtxt
   , injQuery
-  , projQueryResult
   , injQueryResult
   , projNestedCtxt
-  , injNestedCtxt
+  , projQuery
+  , projQuery'
+  , projQueryResult
     -- * Convenience exports
-  , Proxy(..)
-  , I(..)
+  , I (..)
+  , Proxy (..)
   ) where
 
 import           Data.Bifunctor (first)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Forging.hs
@@ -7,11 +7,11 @@
 {-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
-module Ouroboros.Consensus.HardFork.Combinator.Forging (
-    HardForkCannotForge
-  , hardForkBlockForging
-  , HardForkForgeStateInfo(..)
+module Ouroboros.Consensus.HardFork.Combinator.Forging
+  ( HardForkCannotForge
+  , HardForkForgeStateInfo (..)
   , HardForkForgeStateUpdateError
+  , hardForkBlockForging
   ) where
 
 import           Data.Functor.Product

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Info.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Info.hs
@@ -3,10 +3,10 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Info (
-    -- * Era info
-    SingleEraInfo(..)
-  , LedgerEraInfo(..)
+module Ouroboros.Consensus.HardFork.Combinator.Info
+  ( -- * Era info
+    LedgerEraInfo (..)
+  , SingleEraInfo (..)
   ) where
 
 import           Codec.Serialise (Serialise)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/InjectTxs.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/InjectTxs.hs
@@ -6,8 +6,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators       #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.InjectTxs (
-    InjectTx(..)
+module Ouroboros.Consensus.HardFork.Combinator.InjectTxs
+  ( InjectTx (..)
   , cannotInjectTx
   , matchTx
   , matchTxNS

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger.hs
@@ -17,15 +17,15 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Ledger (
-    HardForkLedgerError(..)
-  , HardForkLedgerWarning(..)
-  , HardForkLedgerUpdate(..)
-  , HardForkEnvelopeErr(..)
+module Ouroboros.Consensus.HardFork.Combinator.Ledger
+  ( HardForkEnvelopeErr (..)
+  , HardForkLedgerError (..)
+  , HardForkLedgerUpdate (..)
+  , HardForkLedgerWarning (..)
     -- * Type family instances
-  , Ticked(..)
+  , Ticked (..)
     -- * Low-level API (exported for the benefit of testing)
-  , AnnForecast(..)
+  , AnnForecast (..)
   , mkHardForkForecast
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/CommonProtocolParams.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/CommonProtocolParams.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE RankNTypes #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams () where
+module Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
+  (
+  ) where
 
 import           Data.SOP.Strict
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/PeerSelection.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/PeerSelection.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection () where
+module Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection
+  (
+  ) where
 
 import           Data.SOP.Strict
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Ledger/Query.hs
@@ -18,18 +18,18 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Ledger.Query (
-    Query(..)
-  , QueryIfCurrent(..)
-  , HardForkQueryResult
-  , QueryAnytime(..)
-  , QueryHardFork(..)
+module Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
+  ( HardForkQueryResult
+  , Query (..)
+  , QueryAnytime (..)
+  , QueryHardFork (..)
+  , QueryIfCurrent (..)
+  , decodeQueryAnytimeResult
+  , decodeQueryHardForkResult
+  , encodeQueryAnytimeResult
+  , encodeQueryHardForkResult
   , getHardForkQuery
   , hardForkQueryInfo
-  , encodeQueryAnytimeResult
-  , decodeQueryAnytimeResult
-  , encodeQueryHardForkResult
-  , decodeQueryHardForkResult
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Mempool.hs
@@ -15,12 +15,12 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Mempool (
-    HardForkApplyTxErr(..)
-  , hardForkApplyTxErrToEither
+module Ouroboros.Consensus.HardFork.Combinator.Mempool
+  ( GenTx (..)
+  , HardForkApplyTxErr (..)
+  , TxId (..)
   , hardForkApplyTxErrFromEither
-  , GenTx(..)
-  , TxId(..)
+  , hardForkApplyTxErrToEither
   ) where
 
 import           Control.Monad.Except

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
@@ -19,8 +19,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Abstract
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras
 import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Forging ()
-import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams ()
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection ()
 import           Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage ()
 import           Ouroboros.Consensus.HardFork.Combinator.Node.Metrics ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node.hs
@@ -5,7 +5,9 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Node () where
+module Ouroboros.Consensus.HardFork.Combinator.Node
+  (
+  ) where
 
 import           Data.Proxy
 import           Data.SOP.Strict

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node/InitStorage.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node/InitStorage.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage () where
+module Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage
+  (
+  ) where
 
 import           Data.SOP.Strict
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node/Metrics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Node/Metrics.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.HardFork.Combinator.Node.Metrics () where
+module Ouroboros.Consensus.HardFork.Combinator.Node.Metrics
+  (
+  ) where
 
 import           Data.SOP.Strict
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/PartialConfig.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/PartialConfig.hs
@@ -5,15 +5,15 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.PartialConfig (
-    HasPartialConsensusConfig(..)
-  , HasPartialLedgerConfig(..)
+module Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+  ( HasPartialConsensusConfig (..)
+  , HasPartialLedgerConfig (..)
     -- * Newtype wrappers
-  , WrapPartialLedgerConfig(..)
-  , WrapPartialConsensusConfig(..)
+  , WrapPartialConsensusConfig (..)
+  , WrapPartialLedgerConfig (..)
     -- * Convenience re-exports
-  , EpochInfo(..)
-  , Identity(..)
+  , EpochInfo (..)
+  , Identity (..)
   ) where
 
 import           Data.Functor.Identity

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -48,10 +48,9 @@ import           Ouroboros.Consensus.HardFork.Combinator.Info
 import           Ouroboros.Consensus.HardFork.Combinator.PartialConfig
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
 import           Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
-                     (HardForkLedgerView, HardForkLedgerView_ (..),
-                     Ticked (..))
+                     (HardForkLedgerView, HardForkLedgerView_ (..), Ticked (..))
 import           Ouroboros.Consensus.HardFork.Combinator.State (HardForkState,
-                     HardForkState, Translate (..))
+                     Translate (..))
 import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
 import           Ouroboros.Consensus.HardFork.Combinator.Translation
 import           Ouroboros.Consensus.HardFork.Combinator.Util.InPairs

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol.hs
@@ -13,17 +13,17 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Protocol (
-    -- * Re-exports to keep 'Protocol.State' an internal module
-    HardForkChainDepState
+module Ouroboros.Consensus.HardFork.Combinator.Protocol
+  ( -- * Re-exports to keep 'Protocol.State' an internal module
+    HardForkCanBeLeader
+  , HardForkChainDepState
   , HardForkIsLeader
-  , HardForkCanBeLeader
-  , HardForkValidationErr(..)
+  , HardForkValidationErr (..)
     -- * Re-exports to keep 'Protocol.LedgerView' an internal module
-  , HardForkLedgerView_(..)
   , HardForkLedgerView
+  , HardForkLedgerView_ (..)
     -- * Type family instances
-  , Ticked(..)
+  , Ticked (..)
   ) where
 
 import           Control.Monad.Except

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/ChainSel.hs
@@ -7,10 +7,10 @@
 {-# LANGUAGE TypeApplications    #-}
 
 -- | Infrastructure for doing chain selection across eras
-module Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel (
-    AcrossEraSelection(..)
+module Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
+  ( AcrossEraSelection (..)
+  , WithBlockNo (..)
   , acrossEraSelection
-  , WithBlockNo(..)
   , mapWithBlockNo
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/LedgerView.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Protocol/LedgerView.hs
@@ -7,12 +7,12 @@
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView (
-    -- * Hard fork
-    HardForkLedgerView_(..)
-  , HardForkLedgerView
+module Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
+  ( -- * Hard fork
+    HardForkLedgerView
+  , HardForkLedgerView_ (..)
     -- * Type family instances
-  , Ticked(..)
+  , Ticked (..)
   ) where
 
 import           Data.SOP.Dict

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation.hs
@@ -10,11 +10,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common as
                      HardForkSpecificNodeToClientVersion (..),
                      HardForkSpecificNodeToNodeVersion (..),
                      SerialiseConstraintsHFC, SerialiseHFC (..),
-                     isHardForkNodeToClientEnabled,
-                     isHardForkNodeToNodeEnabled)
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk as X
-                     ()
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient as X
-                     ()
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode as X
-                     ()
+                     isHardForkNodeToClientEnabled, isHardForkNodeToNodeEnabled)
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk as X ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient as X ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode as X ()

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation.hs
@@ -1,6 +1,6 @@
 -- | Serialisation support for the HFC
-module Ouroboros.Consensus.HardFork.Combinator.Serialisation (
-    module X
+module Ouroboros.Consensus.HardFork.Combinator.Serialisation
+  ( module X
   ) where
 
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -73,8 +73,7 @@ import           Codec.CBOR.Encoding (Encoding)
 import qualified Codec.CBOR.Encoding as Enc
 import           Codec.Serialise (Serialise)
 import qualified Codec.Serialise as Serialise
-import           Control.Exception (Exception)
-import           Control.Exception (throw)
+import           Control.Exception (Exception, throw)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as Short

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/Common.hs
@@ -17,54 +17,54 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common (
-    -- * Conditions required by the HFC to support serialisation
-    SerialiseHFC(..)
+module Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
+  ( -- * Conditions required by the HFC to support serialisation
+    HardForkEncoderException (..)
   , SerialiseConstraintsHFC
-  , pSHFC
-  , HardForkEncoderException(..)
-  , futureEraException
+  , SerialiseHFC (..)
   , disabledEraException
+  , futureEraException
+  , pSHFC
     -- * Distinguish first era from the rest
   , FirstEra
   , LaterEra
   , isFirstEra
   , notFirstEra
     -- * Versioning
-  , HardForkSpecificNodeToNodeVersion(..)
-  , HardForkSpecificNodeToClientVersion(..)
-  , HardForkNodeToNodeVersion(..)
-  , HardForkNodeToClientVersion(..)
-  , EraNodeToNodeVersion(..)
-  , EraNodeToClientVersion(..)
-  , isHardForkNodeToNodeEnabled
+  , EraNodeToClientVersion (..)
+  , EraNodeToNodeVersion (..)
+  , HardForkNodeToClientVersion (..)
+  , HardForkNodeToNodeVersion (..)
+  , HardForkSpecificNodeToClientVersion (..)
+  , HardForkSpecificNodeToNodeVersion (..)
   , isHardForkNodeToClientEnabled
+  , isHardForkNodeToNodeEnabled
     -- * Dealing with annotations
-  , AnnDecoder(..)
+  , AnnDecoder (..)
     -- * Serialisation of telescopes
-  , encodeTelescope
   , decodeTelescope
+  , encodeTelescope
     -- * Serialisation of sums
-  , encodeNS
-  , decodeNS
   , decodeAnnNS
+  , decodeNS
+  , encodeNS
     -- * Dependent serialisation
-  , encodeNestedCtxt
+  , decodeNested
   , decodeNestedCtxt
   , encodeNested
-  , decodeNested
+  , encodeNestedCtxt
     -- * MismatchEraInfo
-  , encodeEitherMismatch
   , decodeEitherMismatch
+  , encodeEitherMismatch
     -- * Distributive properties
   , distribAnnTip
-  , undistribAnnTip
-  , distribSerialisedHeader
-  , undistribSerialisedHeader
   , distribQueryIfCurrent
+  , distribSerialisedHeader
+  , undistribAnnTip
   , undistribQueryIfCurrent
+  , undistribSerialisedHeader
     -- * Deriving-via support for tests
-  , SerialiseNS(..)
+  , SerialiseNS (..)
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseDisk.hs
@@ -4,7 +4,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk () where
+module Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
+  (
+  ) where
 
 import           Codec.CBOR.Encoding (Encoding)
 import qualified Data.ByteString.Lazy as Lazy

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
@@ -45,8 +45,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
 import           Ouroboros.Consensus.HardFork.Combinator.Mempool
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk ()
 
 instance SerialiseHFC xs => SerialiseNodeToClientConstraints (HardForkBlock xs)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToClient.hs
@@ -14,7 +14,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient (
+module Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient
+  (
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
@@ -40,8 +40,7 @@ import           Ouroboros.Consensus.HardFork.Combinator.Basics
 import           Ouroboros.Consensus.HardFork.Combinator.Block
 import           Ouroboros.Consensus.HardFork.Combinator.Mempool
 import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
-import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
-                     ()
+import           Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk ()
 
 instance SerialiseHFC xs => SerialiseNodeToNodeConstraints (HardForkBlock xs) where
   estimateBlockSize = estimateHfcBlockSize

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Serialisation/SerialiseNodeToNode.hs
@@ -12,7 +12,8 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode (
+module Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode
+  (
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State.hs
@@ -14,17 +14,17 @@
 --
 -- > import Ouroboros.Consensus.HardFork.Combinator.State (HardForkState(..))
 -- > import qualified Ouroboros.Consensus.HardFork.Combinator.State as State
-module Ouroboros.Consensus.HardFork.Combinator.State (
-    module X
+module Ouroboros.Consensus.HardFork.Combinator.State
+  ( module X
     -- * Support for defining instances
   , getTip
     -- * Serialisation support
   , recover
     -- * EpochInfo
-  , mostRecentTransitionInfo
-  , reconstructSummaryLedger
   , epochInfoLedger
   , epochInfoPrecomputedTransitionInfo
+  , mostRecentTransitionInfo
+  , reconstructSummaryLedger
     -- * Ledger specific functionality
   , extendToSlot
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Infra.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Infra.hs
@@ -9,16 +9,16 @@
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.State.Infra (
-    -- * Initialization
+module Ouroboros.Consensus.HardFork.Combinator.State.Infra
+  ( -- * Initialization
     initHardForkState
     -- * Lifting 'Telescope' operations
-  , tip
+  , fromTZ
   , match
   , sequence
-  , fromTZ
+  , tip
     -- * Situated
-  , Situated(..)
+  , Situated (..)
   , situate
     -- * Aligning
   , align

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Instances.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Instances.hs
@@ -13,12 +13,12 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.State.Instances (
-    -- * Serialisation support
-    encodeCurrent
-  , decodeCurrent
-  , encodePast
+module Ouroboros.Consensus.HardFork.Combinator.State.Instances
+  ( -- * Serialisation support
+    decodeCurrent
   , decodePast
+  , encodeCurrent
+  , encodePast
   ) where
 
 import           Prelude hiding (sequence)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Lift.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Lift.hs
@@ -1,8 +1,8 @@
 -- | Lifting functions for the various types used in 'HardForkState'
 --
 -- NOTE: These are internal and not exported in the toplevel @.State@ module.
-module Ouroboros.Consensus.HardFork.Combinator.State.Lift (
-    -- * Lifting functions on @f@ to @Current @f@
+module Ouroboros.Consensus.HardFork.Combinator.State.Lift
+  ( -- * Lifting functions on @f@ to @Current @f@
     lift
   , liftM
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/State/Types.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric  #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.State.Types (
-    -- * Main types
-    HardForkState(..)
-  , Current(..)
-  , Past(..)
+module Ouroboros.Consensus.HardFork.Combinator.State.Types
+  ( -- * Main types
+    Current (..)
+  , HardForkState (..)
+  , Past (..)
     -- * Supporting types
-  , Translate(..)
-  , TranslateForecast(..)
-  , TransitionInfo(..)
+  , TransitionInfo (..)
+  , Translate (..)
+  , TranslateForecast (..)
   ) where
 
 import           Prelude hiding (sequence)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Translation.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE DataKinds   #-}
 {-# LANGUAGE DerivingVia #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Translation (
-    -- * Translate from one era to the next
-    EraTranslation(..)
+module Ouroboros.Consensus.HardFork.Combinator.Translation
+  ( -- * Translate from one era to the next
+    EraTranslation (..)
   , trivialEraTranslation
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/DerivingVia.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/DerivingVia.hs
@@ -7,16 +7,16 @@
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeApplications      #-}
 
-module Ouroboros.Consensus.HardFork.Combinator.Util.DerivingVia (
-    LiftNS(..)
-  , LiftNP(..)
-  , LiftOptNP(..)
-  , LiftTelescope(..)
-  , LiftMismatch(..)
-  , LiftNamedNS(..)
-  , LiftNamedNP(..)
-  , LiftNamedTelescope(..)
-  , LiftNamedMismatch(..)
+module Ouroboros.Consensus.HardFork.Combinator.Util.DerivingVia
+  ( LiftMismatch (..)
+  , LiftNP (..)
+  , LiftNS (..)
+  , LiftNamedMismatch (..)
+  , LiftNamedNP (..)
+  , LiftNamedNS (..)
+  , LiftNamedTelescope (..)
+  , LiftOptNP (..)
+  , LiftTelescope (..)
   ) where
 
 import           Data.List (intercalate)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/InPairs.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/InPairs.hs
@@ -12,21 +12,21 @@
 --
 -- > import Ouroboros.Consensus.HardFork.Combinator.Util.InPairs (InPairs(..))
 -- > import qualified Ouroboros.Consensus.HardFork.Combinator.Util.InPairs as InPairs
-module Ouroboros.Consensus.HardFork.Combinator.Util.InPairs (
-    -- * InPairs
-    InPairs(..)
+module Ouroboros.Consensus.HardFork.Combinator.Util.InPairs
+  ( -- * InPairs
+    InPairs (..)
     -- * Convenience constructors
   , mk1
   , mk2
   , mk3
     -- * SOP-like operators
-  , hmap
   , hcmap
-  , hpure
   , hcpure
+  , hmap
+  , hpure
     -- * Requiring
-  , Requiring(..)
-  , RequiringBoth(..)
+  , Requiring (..)
+  , RequiringBoth (..)
   , ignoring
   , ignoringBoth
   , requiring

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Match.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Match.hs
@@ -17,23 +17,23 @@
 --
 -- > import Ouroboros.Consensus.HardFork.Combinator.Util.Match (Mismatch(..))
 -- > import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Match as Match
-module Ouroboros.Consensus.HardFork.Combinator.Util.Match (
-    Mismatch(..)
+module Ouroboros.Consensus.HardFork.Combinator.Util.Match
+  ( Mismatch (..)
+  , flip
   , matchNS
   , matchTelescope
-  , flip
     -- * Utilities
-  , mismatchToNS
-  , mismatchOne
-  , mismatchTwo
-  , mkMismatchTwo
   , mismatchNotEmpty
   , mismatchNotFirst
+  , mismatchOne
+  , mismatchToNS
+  , mismatchTwo
+  , mkMismatchTwo
   , mustMatchNS
     -- * SOP operators
   , bihap
-  , bihmap
   , bihcmap
+  , bihmap
   ) where
 
 import           Prelude hiding (flip)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Tails.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Tails.hs
@@ -10,17 +10,17 @@
 
 -- > import Ouroboros.Consensus.HardFork.Combinator.Util.Tails (Tails(..))
 -- > import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Tails as Tails
-module Ouroboros.Consensus.HardFork.Combinator.Util.Tails (
-    Tails(..)
+module Ouroboros.Consensus.HardFork.Combinator.Util.Tails
+  ( Tails (..)
     -- * Convenience constructors
   , mk1
   , mk2
   , mk3
     -- * SOP-like operators
-  , hmap
   , hcmap
-  , hpure
   , hcpure
+  , hmap
+  , hpure
   ) where
 
 import           Data.Kind (Type)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Telescope.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/Telescope.hs
@@ -16,34 +16,34 @@
 -- | Intended for qualified import
 --
 -- > import qualified Ouroboros.Consensus.HardFork.Combinator.Util.Telescope as Telescope
-module Ouroboros.Consensus.HardFork.Combinator.Util.Telescope (
-    -- * Telescope
-    Telescope(..)
+module Ouroboros.Consensus.HardFork.Combinator.Util.Telescope
+  ( -- * Telescope
+    Telescope (..)
   , sequence
     -- ** Utilities
-  , tip
-  , fromTip
-  , toAtMost
   , fromTZ
+  , fromTip
+  , tip
+  , toAtMost
     -- ** Bifunctor analogues of SOP functions
   , bihap
+  , bihczipWith
   , bihmap
   , bihzipWith
-  , bihczipWith
     -- * Extension, retraction, alignment
-  , Extend(..)
-  , extend
-  , Retract(..)
-  , retract
+  , Extend (..)
+  , Retract (..)
   , align
+  , extend
+  , retract
     -- ** Simplified API
-  , extendIf
-  , retractIf
   , alignExtend
   , alignExtendNS
+  , extendIf
+  , retractIf
     -- * Additional API
-  , SimpleTelescope(..)
-  , ScanNext(..)
+  , ScanNext (..)
+  , SimpleTelescope (..)
   , scanl
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History.hs
@@ -1,8 +1,8 @@
 -- | Intended for qualified import
 --
 -- > import qualified Ouroboros.Consensus.HardFork.History as History
-module Ouroboros.Consensus.HardFork.History (
-    module X
+module Ouroboros.Consensus.HardFork.History
+  ( module X
   ) where
 
 import           Ouroboros.Consensus.HardFork.History.Caching as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Caching.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Caching.hs
@@ -4,10 +4,10 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Ouroboros.Consensus.HardFork.History.Caching (
-    RunWithCachedSummary(..)
-  , runWithCachedSummary
+module Ouroboros.Consensus.HardFork.History.Caching
+  ( RunWithCachedSummary (..)
   , cachedRunQueryThrow
+  , runWithCachedSummary
   ) where
 
 import           Data.Kind (Type)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
@@ -3,10 +3,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Derive 'EpochInfo'
-module Ouroboros.Consensus.HardFork.History.EpochInfo (
-    summaryToEpochInfo
+module Ouroboros.Consensus.HardFork.History.EpochInfo
+  ( dummyEpochInfo
   , snapshotEpochInfo
-  , dummyEpochInfo
+  , summaryToEpochInfo
   ) where
 
 import           Data.Functor.Identity

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EraParams.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EraParams.hs
@@ -7,10 +7,10 @@
 {-# LANGUAGE TypeApplications   #-}
 {-# LANGUAGE TypeOperators      #-}
 
-module Ouroboros.Consensus.HardFork.History.EraParams (
-    -- * API
-    EraParams(..)
-  , SafeZone(..)
+module Ouroboros.Consensus.HardFork.History.EraParams
+  ( -- * API
+    EraParams (..)
+  , SafeZone (..)
     -- * Defaults
   , defaultEraParams
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Qry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Qry.hs
@@ -12,27 +12,29 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-module Ouroboros.Consensus.HardFork.History.Qry (
-    Qry -- Opaque
-  , Expr(..)
-  , PastHorizonException(..)
+module Ouroboros.Consensus.HardFork.History.Qry
+  ( Qry
+    -- Opaque
+  , Expr (..)
+  , PastHorizonException (..)
   , qryFromExpr
   , runQuery
-  , runQueryThrow
   , runQueryPure
+  , runQueryThrow
     -- * Interpreter
-  , Interpreter -- opaque
-  , mkInterpreter
+  , Interpreter
+    -- opaque
   , interpretQuery
+  , mkInterpreter
   , unsafeExtendSafeZone
     -- * Specific queries
-  , wallclockToSlot
-  , slotToWallclock
-  , slotToEpoch'
-  , slotToEpoch
-  , epochToSlot'
-  , epochToSlot
   , epochToSize
+  , epochToSlot
+  , epochToSlot'
+  , slotToEpoch
+  , slotToEpoch'
+  , slotToWallclock
+  , wallclockToSlot
   ) where
 
 import           Codec.Serialise (Serialise (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Summary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Summary.hs
@@ -16,29 +16,29 @@
 {-# LANGUAGE TypeOperators              #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-module Ouroboros.Consensus.HardFork.History.Summary (
-    -- * Bounds
-    Bound(..)
+module Ouroboros.Consensus.HardFork.History.Summary
+  ( -- * Bounds
+    Bound (..)
   , initBound
   , mkUpperBound
   , slotToEpochBound
     -- * Per-era summary
-  , EraSummary(..)
-  , EraEnd(..)
+  , EraEnd (..)
+  , EraSummary (..)
   , mkEraEnd
     -- * Overall summary
-  , Summary(..)
+  , Summary (..)
     -- ** Construction
-  , summaryWithExactly
   , neverForksSummary
+  , summaryWithExactly
     -- *** Summarize
-  , Shape(..)
-  , Transitions(..)
-  , singletonShape
-  , transitionsUnknown
-  , summarize
+  , Shape (..)
+  , Transitions (..)
   , invariantShape
   , invariantSummary
+  , singletonShape
+  , summarize
+  , transitionsUnknown
     -- ** Query
   , summaryBounds
   , summaryInit

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/Util.hs
@@ -1,10 +1,10 @@
-module Ouroboros.Consensus.HardFork.History.Util (
-    -- * Adding and subtracting slots/epochs
-    addSlots
-  , subSlots
-  , addEpochs
-  , countSlots
+module Ouroboros.Consensus.HardFork.History.Util
+  ( -- * Adding and subtracting slots/epochs
+    addEpochs
+  , addSlots
   , countEpochs
+  , countSlots
+  , subSlots
   ) where
 
 import           Control.Exception (assert)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderStateHistory.hs
@@ -10,12 +10,12 @@
 --
 -- > import           Ouroboros.Consensus.HeaderStateHistory (HeaderStateHistory)
 -- > import qualified Ouroboros.Consensus.HeaderStateHistory as HeaderStateHistory
-module Ouroboros.Consensus.HeaderStateHistory (
-    HeaderStateHistory(..)
-  , current
-  , trim
-  , rewind
+module Ouroboros.Consensus.HeaderStateHistory
+  ( HeaderStateHistory (..)
   , cast
+  , current
+  , rewind
+  , trim
     -- * Validation
   , validateHeader
     -- * Support for tests

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HeaderValidation.hs
@@ -15,43 +15,43 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 -- | Header validation
-module Ouroboros.Consensus.HeaderValidation (
-    validateHeader
-  , revalidateHeader
+module Ouroboros.Consensus.HeaderValidation
+  ( revalidateHeader
+  , validateHeader
     -- * Annotated tips
-  , AnnTip(..)
+  , AnnTip (..)
+  , HasAnnTip (..)
   , annTipHash
   , annTipPoint
   , annTipRealPoint
   , castAnnTip
-  , mapAnnTip
-  , HasAnnTip(..)
   , getAnnTip
+  , mapAnnTip
     -- * Header state
-  , HeaderState(..)
+  , HeaderState (..)
   , castHeaderState
-  , tickHeaderState
   , genesisHeaderState
   , headerStatePoint
+  , tickHeaderState
     -- * Validate header envelope
-  , BasicEnvelopeValidation(..)
-  , HeaderEnvelopeError(..)
+  , BasicEnvelopeValidation (..)
+  , HeaderEnvelopeError (..)
+  , ValidateEnvelope (..)
   , castHeaderEnvelopeError
-  , ValidateEnvelope(..)
     -- * Errors
-  , HeaderError(..)
+  , HeaderError (..)
   , castHeaderError
     -- * TipInfoIsEBB
-  , TipInfoIsEBB(..)
+  , TipInfoIsEBB (..)
     -- * Serialization
-  , defaultEncodeAnnTip
-  , defaultDecodeAnnTip
-  , encodeAnnTipIsEBB
   , decodeAnnTipIsEBB
-  , encodeHeaderState
   , decodeHeaderState
+  , defaultDecodeAnnTip
+  , defaultEncodeAnnTip
+  , encodeAnnTipIsEBB
+  , encodeHeaderState
     -- * Type family instances
-  , Ticked(..)
+  , Ticked (..)
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Abstract.hs
@@ -10,15 +10,15 @@
 {-# LANGUAGE UndecidableInstances  #-}
 
 -- | Interface to the ledger layer
-module Ouroboros.Consensus.Ledger.Abstract (
-    -- * Apply block
-    ApplyBlock(..)
+module Ouroboros.Consensus.Ledger.Abstract
+  ( -- * Apply block
+    ApplyBlock (..)
   , UpdateLedger
     -- ** Derived
-  , tickThenApply
-  , tickThenReapply
   , foldLedger
   , refoldLedger
+  , tickThenApply
+  , tickThenReapply
     -- ** Short-hand
   , ledgerTipHash
   , ledgerTipPoint

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Basics.hs
@@ -5,18 +5,18 @@
 --
 -- Normally this is imported from "Ouroboros.Consensus.Ledger.Abstract". We
 -- pull this out to avoid circular module dependencies.
-module Ouroboros.Consensus.Ledger.Basics (
-    -- * GetTip
-    GetTip(..)
+module Ouroboros.Consensus.Ledger.Basics
+  ( -- * GetTip
+    GetTip (..)
   , getTipHash
   , getTipSlot
     -- * Definition of a ledger independent of a choice of block
+  , IsLedger (..)
   , LedgerCfg
-  , IsLedger(..)
     -- * Link block to its ledger
-  , LedgerState
   , LedgerConfig
   , LedgerError
+  , LedgerState
   , TickedLedgerState
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/CommonProtocolParams.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/CommonProtocolParams.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Ledger.CommonProtocolParams (
-    CommonProtocolParams (..)
+module Ouroboros.Consensus.Ledger.CommonProtocolParams
+  ( CommonProtocolParams (..)
   ) where
 
 import           Data.Word (Word32)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Dual.hs
@@ -19,41 +19,41 @@
 {-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE UndecidableSuperClasses    #-}
 
-module Ouroboros.Consensus.Ledger.Dual (
-    Bridge(..)
+module Ouroboros.Consensus.Ledger.Dual
+  ( Bridge (..)
     -- * Pair types
-  , DualBlock(..)
+  , DualBlock (..)
+  , DualGenTxErr (..)
   , DualHeader
-  , DualLedgerConfig(..)
-  , DualLedgerError(..)
-  , DualGenTxErr(..)
+  , DualLedgerConfig (..)
+  , DualLedgerError (..)
     -- * Lifted functions
+  , ctxtDualMain
   , dualExtValidationErrorMain
   , dualTopLevelConfigMain
-  , ctxtDualMain
     -- * Type class family instances
-  , Header(..)
-  , BlockConfig(..)
-  , CodecConfig(..)
-  , StorageConfig(..)
-  , LedgerState(..)
-  , GenTx(..)
-  , TxId(..)
-  , NestedCtxt_(..)
-  , Ticked(..)
+  , BlockConfig (..)
+  , CodecConfig (..)
+  , GenTx (..)
+  , Header (..)
+  , LedgerState (..)
+  , NestedCtxt_ (..)
+  , StorageConfig (..)
+  , Ticked (..)
+  , TxId (..)
     -- * Serialisation
-  , encodeDualBlock
   , decodeDualBlock
-  , encodeDualHeader
-  , decodeDualHeader
-  , encodeDualGenTx
   , decodeDualGenTx
-  , encodeDualGenTxId
-  , decodeDualGenTxId
-  , encodeDualGenTxErr
   , decodeDualGenTxErr
-  , encodeDualLedgerState
+  , decodeDualGenTxId
+  , decodeDualHeader
   , decodeDualLedgerState
+  , encodeDualBlock
+  , encodeDualGenTx
+  , encodeDualGenTxErr
+  , encodeDualGenTxId
+  , encodeDualHeader
+  , encodeDualLedgerState
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Extended.hs
@@ -12,18 +12,18 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
-module Ouroboros.Consensus.Ledger.Extended (
-    -- * Extended ledger state
-    ExtLedgerState(..)
-  , ExtValidationError(..)
-  , ExtLedgerCfg(..)
+module Ouroboros.Consensus.Ledger.Extended
+  ( -- * Extended ledger state
+    ExtLedgerCfg (..)
+  , ExtLedgerState (..)
+  , ExtValidationError (..)
     -- * Serialisation
-  , encodeExtLedgerState
   , decodeExtLedgerState
+  , encodeExtLedgerState
     -- * Casts
   , castExtLedgerState
     -- * Type family instances
-  , Ticked(..)
+  , Ticked (..)
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Inspect.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Inspect.hs
@@ -5,11 +5,11 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
 
-module Ouroboros.Consensus.Ledger.Inspect (
-    LedgerEvent(..)
+module Ouroboros.Consensus.Ledger.Inspect
+  ( InspectLedger (..)
+  , LedgerEvent (..)
   , castLedgerEvent
   , partitionLedgerEvents
-  , InspectLedger(..)
   ) where
 
 import           Data.Either

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/Query.hs
@@ -4,10 +4,10 @@
 {-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE UndecidableInstances  #-}
-module Ouroboros.Consensus.Ledger.Query (
-    Query
-  , QueryLedger(..)
-  , ShowQuery(..)
+module Ouroboros.Consensus.Ledger.Query
+  ( Query
+  , QueryLedger (..)
+  , ShowQuery (..)
   ) where
 
 import           Data.Kind (Type)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsMempool.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies     #-}
-module Ouroboros.Consensus.Ledger.SupportsMempool (
-    GenTx
-  , ApplyTxErr
+module Ouroboros.Consensus.Ledger.SupportsMempool
+  ( ApplyTxErr
+  , GenTx
+  , GenTxId
+  , HasTxId (..)
+  , HasTxs (..)
   , LedgerSupportsMempool (..)
   , TxId
-  , HasTxId (..)
-  , GenTxId
-  , HasTxs (..)
   ) where
 
 import           Control.Monad.Except

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsPeerSelection.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsPeerSelection.hs
@@ -1,13 +1,13 @@
-module Ouroboros.Consensus.Ledger.SupportsPeerSelection (
-    LedgerSupportsPeerSelection (..)
+module Ouroboros.Consensus.Ledger.SupportsPeerSelection
+  ( LedgerSupportsPeerSelection (..)
   , PoolStake (..)
   , StakePoolRelay (..)
   , stakePoolRelayAddress
     -- * Re-exports for convenience
-  , RelayAddress (..)
   , DomainAddress (..)
   , IP (..)
   , PortNumber
+  , RelayAddress (..)
   ) where
 
 import           Data.List.NonEmpty (NonEmpty)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ledger/SupportsProtocol.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Ouroboros.Consensus.Ledger.SupportsProtocol (
-    LedgerSupportsProtocol(..)
+module Ouroboros.Consensus.Ledger.SupportsProtocol
+  ( LedgerSupportsProtocol (..)
   ) where
 
 import           Control.Monad.Except

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Mempool (
-    module X
+module Ouroboros.Consensus.Mempool
+  ( module X
   ) where
 
 import           Ouroboros.Consensus.Mempool.API as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/API.hs
@@ -8,17 +8,17 @@
 {-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE UndecidableSuperClasses    #-}
 
-module Ouroboros.Consensus.Mempool.API (
-    Mempool(..)
-  , addTxs
-  , ForgeLedgerState(..)
-  , MempoolCapacityBytes (..)
-  , MempoolSnapshot(..)
+module Ouroboros.Consensus.Mempool.API
+  ( ForgeLedgerState (..)
+  , Mempool (..)
   , MempoolAddTxResult (..)
+  , MempoolCapacityBytes (..)
+  , MempoolSize (..)
+  , MempoolSnapshot (..)
+  , TraceEventMempool (..)
+  , addTxs
   , isMempoolTxAdded
   , isMempoolTxRejected
-  , MempoolSize (..)
-  , TraceEventMempool(..)
     -- * Re-exports
   , TxSizeInBytes
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/Impl.hs
@@ -8,12 +8,12 @@
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Ouroboros.Consensus.Mempool.Impl (
-    openMempool
+module Ouroboros.Consensus.Mempool.Impl
+  ( LedgerInterface (..)
   , MempoolCapacityBytesOverride (..)
-  , LedgerInterface (..)
-  , chainDBLedgerInterface
   , TicketNo
+  , chainDBLedgerInterface
+  , openMempool
     -- * For testing purposes
   , openMempoolWithoutSyncThread
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Mempool/TxSeq.hs
@@ -11,20 +11,19 @@
 --
 -- > import           Ouroboros.Consensus.Mempool.TxSeq (TxSeq (..))
 -- > import qualified Ouroboros.Consensus.Mempool.TxSeq as TxSeq
-module Ouroboros.Consensus.Mempool.TxSeq (
-    TicketNo(..)
-  , TxTicket(..)
-  , TxSeq(Empty, (:>), (:<))
+module Ouroboros.Consensus.Mempool.TxSeq
+  ( TicketNo (..)
+  , TxSeq (Empty, (:>), (:<))
+  , TxTicket (..)
   , fromList
-  , toList
-  , toTuples
   , lookupByTicketNo
   , splitAfterTicketNo
   , splitAfterTxSize
-  , zeroTicketNo
+  , toList
   , toMempoolSize
-
-  -- * Reference implementations for testing
+  , toTuples
+  , zeroTicketNo
+    -- * Reference implementations for testing
   , splitAfterTxSizeSpec
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/BlockFetch/Server.hs
@@ -11,7 +11,7 @@
 module Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
   ( blockFetchServer
     -- * Trace events
-  , TraceBlockFetchServerEvent(..)
+  , TraceBlockFetchServerEvent (..)
     -- * Exceptions
   , BlockFetchServerException
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -21,19 +21,19 @@
 -- an unexplained thunk in 'KnownIntersectionState' and thus a space leak. See
 -- #1356.
 
-module Ouroboros.Consensus.MiniProtocol.ChainSync.Client (
-    Consensus
-  , chainSyncClient
-  , bracketChainSyncClient
-  , ChainSyncClientResult (..)
+module Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+  ( ChainDbView (..)
   , ChainSyncClientException (..)
-  , ChainDbView (..)
-  , defaultChainDbView
+  , ChainSyncClientResult (..)
+  , Consensus
   , Our (..)
   , Their (..)
+  , bracketChainSyncClient
+  , chainSyncClient
+  , defaultChainDbView
     -- * Trace events
-  , TraceChainSyncClientEvent (..)
   , InvalidBlockReason
+  , TraceChainSyncClientEvent (..)
   ) where
 
 import           Control.Monad

--- a/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/MiniProtocol/ChainSync/Server.hs
@@ -4,11 +4,11 @@
 {-# LANGUAGE TypeFamilies        #-}
 
 module Ouroboros.Consensus.MiniProtocol.ChainSync.Server
-  ( chainSyncHeadersServer
+  ( Tip
+  , chainSyncBlockServerFollower
   , chainSyncBlocksServer
   , chainSyncHeaderServerFollower
-  , chainSyncBlockServerFollower
-  , Tip
+  , chainSyncHeadersServer
     -- * Trace events
   , TraceChainSyncServerEvent (..)
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToClient.hs
@@ -7,17 +7,17 @@
 {-# LANGUAGE TypeApplications      #-}
 
 -- | Intended for qualified import
-module Ouroboros.Consensus.Network.NodeToClient (
-    -- * Handlers
+module Ouroboros.Consensus.Network.NodeToClient
+  ( -- * Handlers
     Handlers (..)
   , mkHandlers
     -- * Codecs
-  , Codecs' (..)
-  , Codecs
-  , DefaultCodecs
   , ClientCodecs
-  , defaultCodecs
+  , Codecs
+  , Codecs' (..)
+  , DefaultCodecs
   , clientCodecs
+  , defaultCodecs
   , identityCodecs
     -- * ClientCodecs
     -- * Tracers

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -7,8 +7,8 @@
 {-# LANGUAGE TypeApplications      #-}
 
 -- | Intended for qualified import
-module Ouroboros.Consensus.Network.NodeToNode (
-    -- * Handlers
+module Ouroboros.Consensus.Network.NodeToNode
+  ( -- * Handlers
     Handlers (..)
   , mkHandlers
     -- * Codecs
@@ -21,9 +21,9 @@ module Ouroboros.Consensus.Network.NodeToNode (
   , nullTracers
   , showTracers
     -- * Applications
+  , Apps (..)
   , ClientApp
   , ServerApp
-  , Apps (..)
   , mkApps
     -- ** Projections
   , initiator

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -14,41 +14,41 @@ module Ouroboros.Consensus.Node
   , runWith
     -- * Standard arguments
   , StdRunNodeArgs (..)
-  , stdLowLevelRunNodeArgsIO
   , stdBfcSaltIO
   , stdChainSyncTimeout
   , stdKeepAliveRngIO
+  , stdLowLevelRunNodeArgsIO
   , stdMkChainDbHasFS
   , stdRunDataDiffusion
   , stdVersionDataNTC
   , stdVersionDataNTN
   , stdWithCheckedDB
     -- * Exposed by 'run' et al
-  , DiffusionTracers (..)
-  , DiffusionArguments (..)
-  , LowLevelRunNodeArgs (..)
-  , RunNodeArgs (..)
-  , RunNode
-  , Tracers
-  , Tracers' (..)
+  , ChainDB.RelativeMountPoint (..)
   , ChainDB.TraceEvent (..)
-  , ProtocolInfo (..)
-  , LastShutDownWasClean (..)
   , ChainDbArgs (..)
+  , ConnectionId (..)
+  , DiffusionArguments (..)
+  , DiffusionTracers (..)
+  , DnsSubscriptionTarget (..)
   , HardForkBlockchainTimeArgs (..)
-  , NodeKernelArgs (..)
-  , NodeKernel (..)
+  , IPSubscriptionTarget (..)
+  , LastShutDownWasClean (..)
+  , LowLevelRunNodeArgs (..)
   , MaxTxCapacityOverride (..)
   , MempoolCapacityBytesOverride (..)
-  , IPSubscriptionTarget (..)
-  , DnsSubscriptionTarget (..)
-  , ConnectionId (..)
-  , ChainDB.RelativeMountPoint (..)
+  , NodeKernel (..)
+  , NodeKernelArgs (..)
+  , ProtocolInfo (..)
+  , RunNode
+  , RunNodeArgs (..)
+  , Tracers
+  , Tracers' (..)
     -- * Internal helpers
-  , openChainDB
   , mkChainDbArgs
   , mkNodeKernelArgs
   , nodeKernelArgsEnforceInvariants
+  , openChainDB
   ) where
 
 import           Codec.Serialise (DeserialiseFailure)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/DbLock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/DbLock.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-module Ouroboros.Consensus.Node.DbLock (
-    DbLocked (..)
+module Ouroboros.Consensus.Node.DbLock
+  ( DbLocked (..)
   , withLockDB
     -- * Defaults
   , dbLockFsPath

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/DbMarker.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/DbMarker.hs
@@ -2,12 +2,12 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Special file we store in the DB dir to avoid unintended deletions
-module Ouroboros.Consensus.Node.DbMarker (
-    DbMarkerError(..)
+module Ouroboros.Consensus.Node.DbMarker
+  ( DbMarkerError (..)
   , checkDbMarker
     -- * For the benefit of testing only
-  , dbMarkerFile
   , dbMarkerContents
+  , dbMarkerFile
   , dbMarkerParse
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ErrorPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ErrorPolicy.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE TypeApplications    #-}
 
 
-module Ouroboros.Consensus.Node.ErrorPolicy (consensusErrorPolicy) where
+module Ouroboros.Consensus.Node.ErrorPolicy
+  ( consensusErrorPolicy
+  ) where
 
 import           Data.Proxy (Proxy)
 import           Data.Time.Clock (DiffTime)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/InitStorage.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/InitStorage.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Node.InitStorage (
-    NodeInitStorage (..)
+module Ouroboros.Consensus.Node.InitStorage
+  ( NodeInitStorage (..)
   ) where
 
 import           Ouroboros.Consensus.Block.Abstract

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/NetworkProtocolVersion.hs
@@ -3,11 +3,11 @@
 {-# LANGUAGE TypeFamilies      #-}
 
 module Ouroboros.Consensus.Node.NetworkProtocolVersion
-  ( HasNetworkProtocolVersion(..)
-  , SupportedNetworkProtocolVersion(..)
+  ( HasNetworkProtocolVersion (..)
+  , SupportedNetworkProtocolVersion (..)
     -- * Re-exports
-  , NodeToNodeVersion(..)
-  , NodeToClientVersion(..)
+  , NodeToClientVersion (..)
+  , NodeToNodeVersion (..)
   ) where
 
 import           Data.Kind (Type)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/ProtocolInfo.hs
@@ -3,11 +3,11 @@
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE TypeFamilies               #-}
 
-module Ouroboros.Consensus.Node.ProtocolInfo (
-    NumCoreNodes(..)
+module Ouroboros.Consensus.Node.ProtocolInfo
+  ( NumCoreNodes (..)
+  , ProtocolClientInfo (..)
+  , ProtocolInfo (..)
   , enumCoreNodes
-  , ProtocolInfo(..)
-  , ProtocolClientInfo(..)
   ) where
 
 import           Data.Word

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Recovery.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Recovery.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Ouroboros.Consensus.Node.Recovery
-  ( createMarkerOnCleanShutdown
+  ( createCleanShutdownMarker
+  , createMarkerOnCleanShutdown
   , hasCleanShutdownMarker
-  , createCleanShutdownMarker
   , removeCleanShutdownMarker
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Run.hs
@@ -3,11 +3,11 @@
 -- | Infrastructure required to run a node
 --
 -- The definitions in this module are independent from any specific protocol.
-module Ouroboros.Consensus.Node.Run (
-    -- * SerialiseDisk
-    SerialiseDiskConstraints
-  , ImmutableDbSerialiseConstraints
+module Ouroboros.Consensus.Node.Run
+  ( -- * SerialiseDisk
+    ImmutableDbSerialiseConstraints
   , LgrDbSerialiseConstraints
+  , SerialiseDiskConstraints
   , VolatileDbSerialiseConstraints
     -- * SerialiseNodeToNode
   , SerialiseNodeToNodeConstraints (..)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Serialisation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Serialisation.hs
@@ -16,13 +16,13 @@
 -- encoder from the decoder, because the reasons don't apply: we always need
 -- both directions and we don't have access to the bytestrings that could be
 -- used for the annotations (we use CBOR-in-CBOR in those cases).
-module Ouroboros.Consensus.Node.Serialisation (
-    SerialiseNodeToNode (..)
-  , SerialiseNodeToClient (..)
+module Ouroboros.Consensus.Node.Serialisation
+  ( SerialiseNodeToClient (..)
+  , SerialiseNodeToNode (..)
   , SerialiseResult (..)
     -- * Defaults
-  , defaultEncodeCBORinCBOR
   , defaultDecodeCBORinCBOR
+  , defaultEncodeCBORinCBOR
     -- * Re-exported for convenience
   , Some (..)
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node/Tracers.hs
@@ -7,8 +7,8 @@
 
 module Ouroboros.Consensus.Node.Tracers
   ( -- * All tracers of a node bundled together
-    Tracers' (..)
-  , Tracers
+    Tracers
+  , Tracers' (..)
   , nullTracers
   , showTracers
     -- * Specific tracers

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeId.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeId.hs
@@ -4,10 +4,10 @@
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Ouroboros.Consensus.NodeId (
-    -- * Node IDs
-    NodeId (..)
-  , CoreNodeId (..)
+module Ouroboros.Consensus.NodeId
+  ( -- * Node IDs
+    CoreNodeId (..)
+  , NodeId (..)
   , fromCoreNodeId
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/NodeKernel.hs
@@ -10,18 +10,18 @@
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 
-module Ouroboros.Consensus.NodeKernel (
-    -- * Node kernel
-    NodeKernel (..)
-  , MaxTxCapacityOverride (..)
+module Ouroboros.Consensus.NodeKernel
+  ( -- * Node kernel
+    MaxTxCapacityOverride (..)
   , MempoolCapacityBytesOverride (..)
+  , NodeKernel (..)
   , NodeKernelArgs (..)
   , TraceForgeEvent (..)
-  , initNodeKernel
   , getMempoolReader
   , getMempoolWriter
   , getPeersFromCurrentLedger
   , getPeersFromCurrentLedgerAfterSlot
+  , initNodeKernel
   ) where
 
 import           Control.Monad

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Abstract.hs
@@ -2,13 +2,13 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE TypeFamilies      #-}
 
-module Ouroboros.Consensus.Protocol.Abstract (
-    -- * Abstract definition of the Ouroboros protocol
-    ConsensusProtocol(..)
+module Ouroboros.Consensus.Protocol.Abstract
+  ( -- * Abstract definition of the Ouroboros protocol
+    ConsensusConfig
+  , ConsensusProtocol (..)
   , preferCandidate
-  , ConsensusConfig
     -- * Convenience re-exports
-  , SecurityParam(..)
+  , SecurityParam (..)
   ) where
 
 import           Control.Monad.Except

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/BFT.hs
@@ -11,20 +11,20 @@
 {-# LANGUAGE TypeApplications          #-}
 {-# LANGUAGE TypeFamilies              #-}
 
-module Ouroboros.Consensus.Protocol.BFT (
-    Bft
-  , BftFields(..)
-  , BftParams(..)
-  , BftValidationErr(..)
+module Ouroboros.Consensus.Protocol.BFT
+  ( Bft
+  , BftFields (..)
+  , BftParams (..)
+  , BftValidationErr (..)
   , forgeBftFields
     -- * Classes
-  , BftCrypto(..)
-  , BftStandardCrypto
+  , BftCrypto (..)
   , BftMockCrypto
-  , BftValidateView(..)
+  , BftStandardCrypto
+  , BftValidateView (..)
   , bftValidateView
     -- * Type instances
-  , ConsensusConfig(..)
+  , ConsensusConfig (..)
   ) where
 
 import           Control.Monad.Except

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/LeaderSchedule.hs
@@ -5,11 +5,11 @@
 {-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
-module Ouroboros.Consensus.Protocol.LeaderSchedule (
-    LeaderSchedule (..)
-  , leaderScheduleFor
+module Ouroboros.Consensus.Protocol.LeaderSchedule
+  ( ConsensusConfig (..)
+  , LeaderSchedule (..)
   , WithLeaderSchedule
-  , ConsensusConfig (..)
+  , leaderScheduleFor
   ) where
 
 import           Data.Map.Strict (Map)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/ModChainSel.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies      #-}
 
-module Ouroboros.Consensus.Protocol.ModChainSel (
-    ModChainSel
+module Ouroboros.Consensus.Protocol.ModChainSel
+  ( ModChainSel
     -- * Type family instances
   , ConsensusConfig (..)
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT.hs
@@ -14,35 +14,35 @@
 {-# LANGUAGE TypeOperators             #-}
 {-# LANGUAGE UndecidableInstances      #-}
 
-module Ouroboros.Consensus.Protocol.PBFT (
-    PBft
-  , PBftSignatureThreshold(..)
-  , PBftSelectView(..)
+module Ouroboros.Consensus.Protocol.PBFT
+  ( PBft
+  , PBftCanBeLeader (..)
+  , PBftFields (..)
+  , PBftIsLeader (..)
+  , PBftLedgerView (..)
+  , PBftParams (..)
+  , PBftSelectView (..)
+  , PBftSignatureThreshold (..)
   , mkPBftSelectView
-  , PBftLedgerView(..)
-  , PBftFields(..)
-  , PBftParams(..)
-  , PBftCanBeLeader(..)
-  , PBftIsLeader(..)
-  , pbftWindowSize
   , pbftWindowExceedsThreshold
+  , pbftWindowSize
     -- * Forging
   , forgePBftFields
     -- * Classes
-  , PBftCrypto(..)
+  , PBftCrypto (..)
   , PBftMockCrypto
-  , PBftMockVerKeyHash(..)
-  , PBftValidateView(..)
-  , pbftValidateRegular
+  , PBftMockVerKeyHash (..)
+  , PBftValidateView (..)
   , pbftValidateBoundary
+  , pbftValidateRegular
     -- * CannotForge
-  , PBftCannotForge(..)
+  , PBftCannotForge (..)
   , pbftCheckCanForge
     -- * Type instances
-  , ConsensusConfig(..)
-  , Ticked(..)
+  , ConsensusConfig (..)
+  , Ticked (..)
     -- * Exported for tracing errors
-  , PBftValidationErr(..)
+  , PBftValidationErr (..)
   ) where
 
 import           Codec.Serialise (Serialise (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/Crypto.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/Crypto.hs
@@ -12,10 +12,10 @@
 {-# LANGUAGE UndecidableInstances   #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Protocol.PBFT.Crypto (
-    PBftCrypto(..)
+module Ouroboros.Consensus.Protocol.PBFT.Crypto
+  ( PBftCrypto (..)
   , PBftMockCrypto
-  , PBftMockVerKeyHash(..)
+  , PBftMockVerKeyHash (..)
   ) where
 
 import           Codec.Serialise (Serialise)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
@@ -44,7 +44,7 @@ import qualified Data.Foldable as Foldable
 import           Data.List (sortOn)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Sequence.Strict (StrictSeq ((:<|), (:|>), Empty), (|>))
+import           Data.Sequence.Strict (StrictSeq (Empty, (:<|), (:|>)), (|>))
 import qualified Data.Sequence.Strict as Seq
 import           Data.Word
 import           GHC.Generics (Generic)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
@@ -16,24 +16,24 @@
 -- | PBFT chain state
 --
 -- Intended for qualified import.
-module Ouroboros.Consensus.Protocol.PBFT.State (
-    PBftState(..)
-  , Ticked(..)
-  , WindowSize(..)
-  , PBftSigner(..)
+module Ouroboros.Consensus.Protocol.PBFT.State
+  ( PBftSigner (..)
+  , PBftState (..)
+  , Ticked (..)
+  , WindowSize (..)
     -- * Construction
-  , empty
   , append
+  , empty
     -- * Queries
   , countSignatures
   , countSignedBy
   , lastSignedSlot
     -- * Conversion
-  , toList
   , fromList
+  , toList
     -- * Serialization
-  , encodePBftState
   , decodePBftState
+  , encodePBftState
   ) where
 
 import           Codec.Serialise (Serialise (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Signed.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/Signed.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Support for protocols that include a signature
-module Ouroboros.Consensus.Protocol.Signed (
-    Signed
-  , SignedHeader(..)
+module Ouroboros.Consensus.Protocol.Signed
+  ( Signed
+  , SignedHeader (..)
   ) where
 
 import           Data.Kind (Type)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Storage.ChainDB (
-    module Ouroboros.Consensus.Storage.ChainDB.API
+module Ouroboros.Consensus.Storage.ChainDB
+  ( module Ouroboros.Consensus.Storage.ChainDB.API
   , module Ouroboros.Consensus.Storage.ChainDB.Impl
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/API.hs
@@ -16,50 +16,50 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Storage.ChainDB.API (
-    -- * Main ChainDB API
-    ChainDB(..)
-  , getCurrentTip
-  , getTipBlockNo
+module Ouroboros.Consensus.Storage.ChainDB.API
+  ( -- * Main ChainDB API
+    ChainDB (..)
   , getCurrentLedger
+  , getCurrentTip
+  , getHeaderStateHistory
   , getImmutableLedger
   , getPastLedger
-  , getHeaderStateHistory
+  , getTipBlockNo
     -- * Adding a block
-  , AddBlockPromise(..)
-  , addBlockWaitWrittenToDisk
+  , AddBlockPromise (..)
   , addBlock
+  , addBlockWaitWrittenToDisk
   , addBlock_
     -- * Serialised block/header with its point
-  , WithPoint(..)
+  , WithPoint (..)
+  , getPoint
   , getSerialisedBlockWithPoint
   , getSerialisedHeaderWithPoint
-  , getPoint
     -- * BlockComponent
-  , BlockComponent(..)
+  , BlockComponent (..)
     -- * Support for tests
-  , toChain
   , fromChain
+  , toChain
     -- * Iterator API
-  , StreamFrom(..)
-  , StreamTo(..)
-  , Iterator(..)
-  , IteratorResult(..)
+  , Iterator (..)
+  , IteratorResult (..)
+  , StreamFrom (..)
+  , StreamTo (..)
+  , UnknownRange (..)
   , emptyIterator
-  , traverseIterator
-  , UnknownRange(..)
-  , validBounds
   , streamAll
+  , traverseIterator
+  , validBounds
     -- * Invalid block reason
-  , InvalidBlockReason(..)
+  , InvalidBlockReason (..)
     -- * Followers
-  , Follower(..)
+  , Follower (..)
   , traverseFollower
     -- * Recovery
-  , ChainDbFailure(..)
-  , IsEBB(..)
+  , ChainDbFailure (..)
+  , IsEBB (..)
     -- * Exceptions
-  , ChainDbError(..)
+  , ChainDbError (..)
   ) where
 
 import           Control.Monad (void)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl.hs
@@ -5,33 +5,33 @@
 {-# LANGUAGE RecordWildCards          #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
 
-module Ouroboros.Consensus.Storage.ChainDB.Impl (
-    -- * Initialization
-    ChainDbArgs(..)
-  , defaultArgs
+module Ouroboros.Consensus.Storage.ChainDB.Impl
+  ( -- * Initialization
+    ChainDbArgs (..)
   , SerialiseDiskConstraints
-  , withDB
+  , defaultArgs
   , openDB
+  , withDB
     -- * Trace types
-  , TraceEvent (..)
+  , LgrDB.TraceLedgerReplayEvent
   , NewTipInfo (..)
   , TraceAddBlockEvent (..)
-  , TraceFollowerEvent (..)
   , TraceCopyToImmutableDBEvent (..)
+  , TraceEvent (..)
+  , TraceFollowerEvent (..)
   , TraceGCEvent (..)
-  , TraceValidationEvent (..)
   , TraceInitChainSelEvent (..)
-  , TraceOpenEvent (..)
   , TraceIteratorEvent (..)
-  , LgrDB.TraceLedgerReplayEvent
+  , TraceOpenEvent (..)
+  , TraceValidationEvent (..)
     -- * Re-exported for convenience
   , Args.RelativeMountPoint (..)
   , ImmutableDB.ImmutableDbSerialiseConstraints
   , LgrDB.LgrDbSerialiseConstraints
   , VolatileDB.VolatileDbSerialiseConstraints
     -- * Internals for testing purposes
-  , openDBInternal
   , Internal (..)
+  , openDBInternal
   ) where
 
 import           Control.Monad (when)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Background.hs
@@ -18,18 +18,18 @@ module Ouroboros.Consensus.Storage.ChainDB.Impl.Background
   ( -- * Launch background tasks
     launchBgTasks
     -- * Copying blocks from the VolatileDB to the ImmutableDB
-  , copyToImmutableDB
   , copyAndSnapshotRunner
+  , copyToImmutableDB
   , updateLedgerSnapshots
-     -- * Executing garbage collection
+    -- * Executing garbage collection
   , garbageCollect
     -- * Scheduling garbage collections
-  , GcSchedule
   , GcParams (..)
-  , newGcSchedule
-  , scheduleGC
+  , GcSchedule
   , computeTimeForGC
   , gcScheduleRunner
+  , newGcSchedule
+  , scheduleGC
     -- ** Testing
   , ScheduledGc (..)
   , dumpGcSchedule

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/BlockCache.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/BlockCache.hs
@@ -6,11 +6,12 @@
 -- > import           Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache (BlockCache)
 -- > import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache as BlockCache
 module Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache
-  ( BlockCache -- opaque
-  , empty
-  , singleton
+  ( BlockCache
+    -- opaque
   , cacheBlock
+  , empty
   , lookup
+  , singleton
   ) where
 
 import           Prelude hiding (lookup)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -13,10 +13,10 @@
 -- | Operations involving chain selection: the initial chain selection and
 -- adding a block.
 module Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel
-  ( initialChainSelection
-  , addBlockAsync
+  ( addBlockAsync
   , addBlockSync
   , chainSelectionForBlock
+  , initialChainSelection
     -- * Exported for testing purposes
   , olderThanK
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Follower.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Follower.hs
@@ -9,9 +9,9 @@
 
 -- | Followers
 module Ouroboros.Consensus.Storage.ChainDB.Impl.Follower
-  ( newFollower
+  ( closeAllFollowers
+  , newFollower
   , switchFork
-  , closeAllFollowers
   ) where
 
 import           Codec.CBOR.Write (toLazyByteString)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Iterator.hs
@@ -11,8 +11,8 @@
 
 -- | Iterators
 module Ouroboros.Consensus.Storage.ChainDB.Impl.Iterator
-  ( stream
-  , closeAllIterators
+  ( closeAllIterators
+  , stream
     -- * Exported for testing purposes
   , IteratorEnv (..)
   , newIterator

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/LgrDB.hs
@@ -11,38 +11,39 @@
 {-# LANGUAGE TypeFamilies        #-}
 
 -- | Thin wrapper around the LedgerDB
-module Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB (
-    LgrDB -- opaque
+module Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB
+  ( LgrDB
+    -- opaque
   , LedgerDB'
   , LgrDbSerialiseConstraints
     -- * Initialization
-  , LgrDbArgs(..)
+  , LgrDbArgs (..)
   , defaultArgs
   , openDB
     -- * 'TraceReplayEvent' decorator
   , TraceLedgerReplayEvent
   , decorateReplayTracer
     -- * Wrappers
-  , getCurrent
-  , setCurrent
   , currentPoint
+  , getCurrent
+  , getDiskPolicy
+  , setCurrent
   , takeSnapshot
   , trimSnapshots
-  , getDiskPolicy
     -- * Validation
+  , ValidateResult (..)
   , validate
-  , ValidateResult(..)
     -- * Previously applied blocks
-  , getPrevApplied
   , garbageCollectPrevApplied
+  , getPrevApplied
     -- * Re-exports
-  , ExceededRollback(..)
-  , LedgerDB.AnnLedgerError(..)
   , DiskPolicy (..)
   , DiskSnapshot
+  , ExceededRollback (..)
+  , LedgerDB.AnnLedgerError (..)
+  , LedgerDB.ledgerDbCurrent
   , TraceEvent (..)
   , TraceReplayEvent (..)
-  , LedgerDB.ledgerDbCurrent
     -- * Exported for testing purposes
   , mkLgrDB
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Paths.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Paths.hs
@@ -4,12 +4,12 @@
 {-# LANGUAGE NamedFieldPuns           #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
 {-# LANGUAGE StandaloneDeriving       #-}
-module Ouroboros.Consensus.Storage.ChainDB.Impl.Paths (
-    -- * LookupBlockInfo
+module Ouroboros.Consensus.Storage.ChainDB.Impl.Paths
+  ( -- * LookupBlockInfo
     LookupBlockInfo
     -- * Candidates
-  , maximalCandidates
   , extendWithSuccessors
+  , maximalCandidates
     -- * Path
   , Path (..)
   , computePath

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Query.hs
@@ -9,20 +9,20 @@
 -- | Queries
 module Ouroboros.Consensus.Storage.ChainDB.Impl.Query
   ( -- * Queries
-    getCurrentChain
+    getBlockComponent
+  , getCurrentChain
+  , getIsFetched
+  , getIsInvalidBlock
+  , getIsValid
   , getLedgerDB
+  , getMaxSlotNo
   , getTipBlock
   , getTipHeader
   , getTipPoint
-  , getBlockComponent
-  , getIsFetched
-  , getIsValid
-  , getIsInvalidBlock
-  , getMaxSlotNo
     -- * Low-level queries
+  , getAnyBlockComponent
   , getAnyKnownBlock
   , getAnyKnownBlockComponent
-  , getAnyBlockComponent
   ) where
 
 import qualified Data.Map.Strict as Map

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/Types.hs
@@ -15,48 +15,48 @@
 
 -- | Types used throughout the implementation: handle, state, environment,
 -- types, trace types, etc.
-module Ouroboros.Consensus.Storage.ChainDB.Impl.Types (
-    SerialiseDiskConstraints
+module Ouroboros.Consensus.Storage.ChainDB.Impl.Types
+  ( ChainDbEnv (..)
   , ChainDbHandle (..)
+  , ChainDbState (..)
+  , SerialiseDiskConstraints
   , getEnv
   , getEnv1
   , getEnv2
   , getEnvSTM
   , getEnvSTM1
-  , ChainDbState (..)
-  , ChainDbEnv (..)
     -- * Exposed internals for testing purposes
   , Internal (..)
     -- * Iterator-related
   , IteratorKey (..)
     -- * Follower-related
-  , FollowerKey (..)
   , FollowerHandle (..)
-  , FollowerState (..)
+  , FollowerKey (..)
   , FollowerRollState (..)
+  , FollowerState (..)
   , followerRollStatePoint
     -- * Invalid blocks
-  , InvalidBlocks
   , InvalidBlockInfo (..)
+  , InvalidBlocks
     -- * Future blocks
   , FutureBlocks
     -- * Blocks to add
-  , BlocksToAdd
   , BlockToAdd (..)
-  , newBlocksToAdd
+  , BlocksToAdd
   , addBlockToAdd
   , getBlockToAdd
+  , newBlocksToAdd
     -- * Trace types
-  , TraceEvent (..)
   , NewTipInfo (..)
   , TraceAddBlockEvent (..)
-  , TraceFollowerEvent (..)
   , TraceCopyToImmutableDBEvent (..)
+  , TraceEvent (..)
+  , TraceFollowerEvent (..)
   , TraceGCEvent (..)
-  , TraceValidationEvent (..)
   , TraceInitChainSelEvent (..)
-  , TraceOpenEvent (..)
   , TraceIteratorEvent (..)
+  , TraceOpenEvent (..)
+  , TraceValidationEvent (..)
   ) where
 
 import           Control.Tracer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Init.hs
@@ -3,8 +3,8 @@
 --
 -- > import Ouroboros.Consensus.Storage.ChainDB.Init (InitChainDB)
 -- > import qualified Ouroboros.Consensus.Storage.ChainDB.Init as InitChainDB
-module Ouroboros.Consensus.Storage.ChainDB.Init (
-    InitChainDB(..)
+module Ouroboros.Consensus.Storage.ChainDB.Init
+  ( InitChainDB (..)
   , fromFull
   , map
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/Common.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/Common.hs
@@ -8,8 +8,8 @@
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE TypeFamilies               #-}
 
-module Ouroboros.Consensus.Storage.Common (
-    -- * Indexing
+module Ouroboros.Consensus.Storage.Common
+  ( -- * Indexing
     tipIsGenesis
     -- * PrefixLen
   , PrefixLen (..)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API.hs
@@ -8,20 +8,20 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | An abstract view over the filesystem.
-module Ouroboros.Consensus.Storage.FS.API (
-      HasFS(..)
-    , Handle(..)
-    , hGetExactly
-    , hGetExactlyAt
-    , hGetAll
-    , hGetAllAt
-    , hPut
-    , hPutAll
-    , hPutAllStrict
-    , withFile
-    , hClose'
-    , SomeHasFS(..)
-    ) where
+module Ouroboros.Consensus.Storage.FS.API
+  ( Handle (..)
+  , HasFS (..)
+  , SomeHasFS (..)
+  , hClose'
+  , hGetAll
+  , hGetAllAt
+  , hGetExactly
+  , hGetExactlyAt
+  , hPut
+  , hPutAll
+  , hPutAllStrict
+  , withFile
+  ) where
 
 import           Control.Monad (foldM)
 import qualified Data.ByteString as BS

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/API/Types.hs
@@ -8,36 +8,37 @@
 
 -- For Show Errno and Condense SeekMode instances
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Ouroboros.Consensus.Storage.FS.API.Types (
-    -- * Modes
-    OpenMode(..)
-  , AllowExisting(..)
+module Ouroboros.Consensus.Storage.FS.API.Types
+  ( -- * Modes
+    AllowExisting (..)
+  , OpenMode (..)
+  , SeekMode (..)
   , allowExisting
-  , SeekMode(..)
     -- * Paths
-  , FsPath -- opaque
-  , fsPathToList
-  , fsPathFromList
-  , fsPathSplit
-  , fsPathInit
-  , mkFsPath
-  , MountPoint(..)
-  , fsToFilePath
+  , FsPath
+    -- opaque
+  , MountPoint (..)
   , fsFromFilePath
+  , fsPathFromList
+  , fsPathInit
+  , fsPathSplit
+  , fsPathToList
+  , fsToFilePath
+  , mkFsPath
     -- * Handles
-  , Handle(..)
+  , Handle (..)
     -- * Offset
-  , AbsOffset(..)
+  , AbsOffset (..)
     -- * Errors
-  , FsError(..)
-  , FsErrorType(..)
-  , FsErrorPath(..)
-  , sameFsError
-  , isFsErrorType
-  , prettyFsError
+  , FsError (..)
+  , FsErrorPath (..)
+  , FsErrorType (..)
   , fsToFsErrorPath
   , fsToFsErrorPathUnmounted
   , hasMountPoint
+  , isFsErrorType
+  , prettyFsError
+  , sameFsError
     -- * From 'IOError' to 'FsError'
   , ioToFsError
   , ioToFsErrorType

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/CRC.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/CRC.hs
@@ -4,16 +4,16 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 
 -- | Support for CRC
-module Ouroboros.Consensus.Storage.FS.CRC (
-    -- * Wrap digest functionality
-    CRC(..)
+module Ouroboros.Consensus.Storage.FS.CRC
+  ( -- * Wrap digest functionality
+    CRC (..)
+  , computeCRC
   , initCRC
   , updateCRC
-  , computeCRC
     -- * File system functions with CRC functionality
-  , hPutAllCRC
-  , hGetExactlyAtCRC
   , hGetAllAtCRC
+  , hGetExactlyAtCRC
+  , hPutAllCRC
   ) where
 
 import           Control.Monad (foldM)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/Handle.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/Handle.hs
@@ -40,7 +40,7 @@ closeHandleOS :: HandleOS osHandle -> (osHandle -> IO ()) -> IO ()
 closeHandleOS (HandleOS _ hVar) close =
   modifyMVar hVar $ \case
     Nothing -> return (Nothing, ())
-    Just h -> close h >> return (Nothing, ())
+    Just h  -> close h >> return (Nothing, ())
 
 {-------------------------------------------------------------------------------
   Exceptions

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/Handle.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/Handle.hs
@@ -2,13 +2,13 @@
 
 -- | This is meant to be used for the implementation of HasFS
 -- instances and not directly by client code.
-module Ouroboros.Consensus.Storage.FS.Handle (
-      HandleOS (..)
-    , isOpenHandleOS
-    , closeHandleOS
-    , withOpenHandle
-    , isHandleClosedException
-    ) where
+module Ouroboros.Consensus.Storage.FS.Handle
+  ( HandleOS (..)
+  , closeHandleOS
+  , isHandleClosedException
+  , isOpenHandleOS
+  , withOpenHandle
+  ) where
 
 import           Control.Concurrent.MVar
 import           Control.Exception hiding (handle)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/IO.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/FS/IO.hs
@@ -1,9 +1,9 @@
 -- | IO implementation of the 'HasFS' class
-module Ouroboros.Consensus.Storage.FS.IO (
-    -- * IO implementation & monad
-      HandleIO
-    , ioHasFS
-    ) where
+module Ouroboros.Consensus.Storage.FS.IO
+  ( -- * IO implementation & monad
+    HandleIO
+  , ioHasFS
+  ) where
 
 import           Control.Concurrent.MVar
 import qualified Control.Exception as E

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Storage.ImmutableDB (
-    module X
+module Ouroboros.Consensus.Storage.ImmutableDB
+  ( module X
   ) where
 
 import           Ouroboros.Consensus.Storage.ImmutableDB.API as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/API.hs
@@ -10,45 +10,45 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving  #-}
 {-# LANGUAGE TypeApplications    #-}
-module Ouroboros.Consensus.Storage.ImmutableDB.API (
-    -- * API
+module Ouroboros.Consensus.Storage.ImmutableDB.API
+  ( -- * API
     ImmutableDB (..)
     -- * Iterator API
   , Iterator (..)
   , IteratorResult (..)
-  , traverseIterator
   , iteratorToList
+  , traverseIterator
     -- * Types
-  , Tip (..)
-  , tipToRealPoint
-  , tipToPoint
-  , tipToAnchor
-  , blockToTip
   , CompareTip (..)
+  , Tip (..)
+  , blockToTip
+  , tipToAnchor
+  , tipToPoint
+  , tipToRealPoint
     -- * Errors
-  , ImmutableDBError (..)
   , ApiMisuse (..)
-  , throwApiMisuse
-  , UnexpectedFailure (..)
-  , throwUnexpectedFailure
+  , ImmutableDBError (..)
   , MissingBlock (..)
+  , UnexpectedFailure (..)
   , missingBlockPoint
+  , throwApiMisuse
+  , throwUnexpectedFailure
     -- * Wrappers that preserve 'HasCallStack'
-  , closeDB
-  , getTip
-  , getBlockComponent
   , appendBlock
+  , closeDB
+  , getBlockComponent
+  , getTip
   , stream
     -- * Derived functionality
-  , withDB
   , getKnownBlockComponent
+  , getTipAnchor
+  , getTipPoint
+  , getTipSlot
+  , hasBlock
   , streamAfterKnownPoint
   , streamAfterPoint
   , streamAll
-  , hasBlock
-  , getTipPoint
-  , getTipAnchor
-  , getTipSlot
+  , withDB
   ) where
 
 import qualified Codec.CBOR.Read as CBOR

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks.hs
@@ -10,5 +10,4 @@ import           Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal as X
                      (ChunkInfo (..), ChunkNo, ChunkSize (..),
                      chunkInfoSupportsEBBs, chunksBetween, compareRelativeSlot,
                      countChunks, firstChunkNo, getChunkSize, mkRelativeSlot,
-                     nextChunkNo, prevChunkNo, simpleChunkInfo,
-                     singleChunkInfo)
+                     nextChunkNo, prevChunkNo, simpleChunkInfo, singleChunkInfo)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Storage.ImmutableDB.Chunks (
-    module X
+module Ouroboros.Consensus.Storage.ImmutableDB.Chunks
+  ( module X
   ) where
 
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks/Internal.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks/Internal.hs
@@ -6,36 +6,36 @@
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE TypeApplications           #-}
 
-module Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal (
-    ChunkInfo(..)
+module Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
+  ( ChunkInfo (..)
+  , chunkInfoSupportsEBBs
   , simpleChunkInfo
   , singleChunkInfo
-  , chunkInfoSupportsEBBs
     -- * Chunk number
-  , ChunkNo(..)
-  , firstChunkNo
-  , chunkNoToInt
+  , ChunkNo (..)
   , chunkNoFromInt
+  , chunkNoToInt
+  , chunksBetween
+  , countChunks
+  , firstChunkNo
   , nextChunkNo
   , prevChunkNo
-  , countChunks
-  , chunksBetween
-  , unsafeEpochNoToChunkNo
   , unsafeChunkNoToEpochNo
+  , unsafeEpochNoToChunkNo
     -- * Chunk size
-  , ChunkSize(..)
+  , ChunkSize (..)
   , getChunkSize
     -- * Layout
-  , RelativeSlot(..)
-  , maxRelativeIndex
-  , mkRelativeSlot
+  , RelativeSlot (..)
   , assertRelativeSlotInChunk
   , compareRelativeSlot
+  , maxRelativeIndex
+  , mkRelativeSlot
     -- * Assertions
   , ChunkAssertionFailure
+  , assertChunkCanContainEBB
   , assertSameChunk
   , assertWithinBounds
-  , assertChunkCanContainEBB
   ) where
 
 import           Control.Exception

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks/Layout.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Chunks/Layout.hs
@@ -11,35 +11,36 @@
 --
 -- This module is not re-exported from the public Chunks API, since it's only
 -- relevant internally in the immutable DB.
-module Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Layout (
-    -- * Relative slots
-    RelativeSlot -- Opaque
-  , maxRelativeSlot
-  , relativeSlotIsEBB
-  , nthBlockOrEBB
+module Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Layout
+  ( -- * Relative slots
+    RelativeSlot
+    -- Opaque
+  , NextRelativeSlot (..)
   , firstBlockOrEBB
-  , NextRelativeSlot(..)
+  , maxRelativeSlot
   , nextRelativeSlot
+  , nthBlockOrEBB
+  , relativeSlotIsEBB
   , unsafeNextRelativeSlot
     -- * Chunks
   , chunkIndexOfSlot
     -- * Slots within a chunk
-  , ChunkSlot(..)
+  , ChunkSlot (..)
   , pattern ChunkSlot
     -- ** Translation /to/ 'ChunkSlot'
-  , chunkSlotForUnknownBlock
-  , chunkSlotForRegularBlock
-  , chunkSlotForBoundaryBlock
   , chunkSlotForBlockOrEBB
-  , chunkSlotForTip
+  , chunkSlotForBoundaryBlock
+  , chunkSlotForRegularBlock
   , chunkSlotForRelativeSlot
+  , chunkSlotForTip
+  , chunkSlotForUnknownBlock
     -- ** Translation /from/ 'ChunkSlot'
-  , chunkSlotToSlot
   , chunkSlotToBlockOrEBB
+  , chunkSlotToSlot
     -- ** Support for EBBs
-  , slotNoOfEBB
   , slotMightBeEBB
   , slotNoOfBlockOrEBB
+  , slotNoOfEBB
   ) where
 
 import           Control.Monad

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
@@ -103,8 +103,7 @@ import qualified Codec.CBOR.Write as CBOR
 import           Control.Monad (replicateM_, unless, when)
 import           Control.Monad.Except (runExceptT)
 import           Control.Monad.State.Strict (get, lift, modify, put)
-import           Control.Tracer (Tracer, traceWith)
-import           Control.Tracer (nullTracer)
+import           Control.Tracer (Tracer, nullTracer, traceWith)
 import qualified Data.ByteString.Lazy as Lazy
 import           GHC.Stack (HasCallStack)
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl.hs
@@ -82,21 +82,21 @@
 --
 --   * A \"primary index file\" that maps slots to offsets in the secondary
 --     index file.
-module Ouroboros.Consensus.Storage.ImmutableDB.Impl (
-    -- * Opening the databse
-    openDB
-  , ImmutableDbArgs (..)
-  , defaultArgs
+module Ouroboros.Consensus.Storage.ImmutableDB.Impl
+  ( -- * Opening the databse
+    ImmutableDbArgs (..)
   , ImmutableDbSerialiseConstraints
+  , defaultArgs
+  , openDB
     -- * Re-exported
-  , ValidationPolicy (..)
   , ChunkFileError (..)
-  , TraceEvent (..)
   , Index.CacheConfig (..)
+  , TraceEvent (..)
+  , ValidationPolicy (..)
     -- * Internals for testing purposes
-  , openDBInternal
   , Internal (..)
   , deleteAfter
+  , openDBInternal
   ) where
 
 import qualified Codec.CBOR.Write as CBOR

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index.hs
@@ -7,13 +7,13 @@
 module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index
   ( -- * Index
     Index (..)
-  , readOffset
   , readEntry
+  , readOffset
     -- * File-backed index
   , fileBackedIndex
     -- * Cached index
-  , cachedIndex
   , CacheConfig (..)
+  , cachedIndex
   ) where
 
 import           Control.Tracer (Tracer)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Cache.hs
@@ -14,24 +14,24 @@
 
 module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Cache
   ( -- * Environment
-    CacheEnv
-  , newEnv
-  , CacheConfig (..)
+    CacheConfig (..)
+  , CacheEnv
   , checkInvariants
+  , newEnv
     -- * Background thread
   , expireUnusedChunks
     -- * Operations
   , close
   , restart
     -- ** On the primary index
-  , readOffsets
-  , readFirstFilledSlot
-  , openPrimaryIndex
   , appendOffsets
+  , openPrimaryIndex
+  , readFirstFilledSlot
+  , readOffsets
     -- ** On the secondary index
-  , readEntries
-  , readAllEntries
   , appendEntry
+  , readAllEntries
+  , readEntries
   ) where
 
 import           Control.Exception (assert)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Primary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Primary.hs
@@ -16,32 +16,33 @@ module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary
   ( -- * SecondaryOffset
     SecondaryOffset
     -- * PrimaryIndex
-  , PrimaryIndex(..) -- Exported for the benefit of tests
+  , PrimaryIndex (..)
+    -- Exported for the benefit of tests
+  , appendOffsets
+  , backfill
+  , backfillChunk
+  , containsSlot
   , currentVersionNumber
-  , slots
-  , secondaryOffsetSize
+  , filledSlots
+  , firstFilledSlot
+  , getLastSlot
+  , isFilledSlot
+  , lastFilledSlot
+  , lastOffset
+  , load
+  , nextFilledSlot
+  , offsetOfSlot
+  , open
+  , readFirstFilledSlot
   , readOffset
   , readOffsets
-  , readFirstFilledSlot
-  , load
-  , write
+  , secondaryOffsetSize
+  , sizeOfSlot
+  , slots
   , truncateToSlot
   , truncateToSlotFS
   , unfinalise
-  , open
-  , appendOffsets
-  , lastOffset
-  , getLastSlot
-  , containsSlot
-  , offsetOfSlot
-  , sizeOfSlot
-  , isFilledSlot
-  , nextFilledSlot
-  , firstFilledSlot
-  , filledSlots
-  , lastFilledSlot
-  , backfill
-  , backfillChunk
+  , write
     -- * Exported for testing purposes
   , mk
   , toSecondaryOffsets

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Secondary.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Index/Secondary.hs
@@ -10,16 +10,16 @@
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeApplications           #-}
 module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary
-  ( Entry (..)
-  , entrySize
-  , BlockOffset (..)
+  ( BlockOffset (..)
+  , BlockSize (..)
+  , Entry (..)
   , HeaderOffset (..)
   , HeaderSize (..)
-  , BlockSize (..)
-  , readEntry
-  , readEntries
-  , readAllEntries
   , appendEntry
+  , entrySize
+  , readAllEntries
+  , readEntries
+  , readEntry
   , truncateToEntry
   , writeAllEntries
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Iterator.hs
@@ -7,11 +7,11 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving  #-}
-module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Iterator (
-    streamImpl
-  , getSlotInfo
-  , CurrentChunkInfo (..)
+module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Iterator
+  ( CurrentChunkInfo (..)
   , extractBlockComponent
+  , getSlotInfo
+  , streamImpl
   ) where
 
 import qualified Codec.CBOR.Read as CBOR

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Parser.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Parser.hs
@@ -7,10 +7,10 @@
 {-# LANGUAGE ScopedTypeVariables      #-}
 {-# LANGUAGE TupleSections            #-}
 {-# LANGUAGE TypeFamilies             #-}
-module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Parser (
-    parseChunkFile
+module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Parser
+  ( BlockSummary (..)
   , ChunkFileError (..)
-  , BlockSummary(..)
+  , parseChunkFile
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/State.hs
@@ -15,16 +15,16 @@ module Ouroboros.Consensus.Storage.ImmutableDB.Impl.State
   ( -- * State types
     ImmutableDBEnv (..)
   , InternalState (..)
-  , dbIsOpen
   , OpenState (..)
+  , dbIsOpen
     -- * State helpers
-  , mkOpenState
-  , getOpenState
   , ModifyOpenState
+  , cleanUp
+  , closeOpenHandles
+  , getOpenState
+  , mkOpenState
   , modifyOpenState
   , withOpenState
-  , closeOpenHandles
-  , cleanUp
   ) where
 
 import           Control.Monad.State.Strict

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Types.hs
@@ -1,18 +1,18 @@
 {-# LANGUAGE DeriveAnyClass    #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE DeriveTraversable #-}
-module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types (
-    -- * Misc types
+module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types
+  ( -- * Misc types
     BlockOrEBB (..)
-  , isBlockOrEBB
   , WithBlockSize (..)
+  , isBlockOrEBB
     -- * Validation policy
   , ValidationPolicy (..)
     -- * Chunk file error
   , ChunkFileError (..)
     -- * Tracing
-  , TraceEvent(..)
-  , TraceCacheEvent(..)
+  , TraceCacheEvent (..)
+  , TraceEvent (..)
   ) where
 
 import           Data.Text (Text)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Util.hs
@@ -7,21 +7,21 @@
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util (
-    -- * Utilities
+module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
+  ( -- * Utilities
     Two (..)
-  , renderFile
+  , checkChecksum
+  , dbFilesOnDisk
   , fsPathChunkFile
   , fsPathPrimaryIndexFile
   , fsPathSecondaryIndexFile
-  , wrapFsError
-  , tryImmutableDB
   , parseDBFile
-  , dbFilesOnDisk
   , removeFilesStartingFrom
+  , renderFile
   , runGet
   , runGetWithUnconsumed
-  , checkChecksum
+  , tryImmutableDB
+  , wrapFsError
   ) where
 
 import           Control.Monad (forM_)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Validation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Validation.hs
@@ -10,11 +10,11 @@
 {-# LANGUAGE TypeApplications    #-}
 
 module Ouroboros.Consensus.Storage.ImmutableDB.Impl.Validation
-  ( validateAndReopen
-  , ValidateEnv (..)
+  ( ValidateEnv (..)
+  , validateAndReopen
     -- * Exported for testing purposes
-  , reconstructPrimaryIndex
   , ShouldBeFinalised (..)
+  , reconstructPrimaryIndex
   ) where
 
 import           Control.Exception (assert)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/DiskPolicy.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/DiskPolicy.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RecordWildCards    #-}
 
-module Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy (
-    DiskPolicy(..)
+module Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
+  ( DiskPolicy (..)
   , defaultDiskPolicy
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/InMemory.hs
@@ -16,44 +16,45 @@
 {-# LANGUAGE TypeFamilies           #-}
 {-# LANGUAGE UndecidableInstances   #-}
 
-module Ouroboros.Consensus.Storage.LedgerDB.InMemory (
-     -- * LedgerDB proper
-     LedgerDB  -- opaque
-   , LedgerDbCfg(..)
-   , ledgerDbWithAnchor
-     -- ** Serialisation
-   , encodeSnapshot
-   , decodeSnapshotBackwardsCompatible
-     -- ** Queries
-   , ledgerDbCurrent
-   , ledgerDbTip
-   , ledgerDbAnchor
-   , ledgerDbPast
-   , ledgerDbSnapshots
-   , ledgerDbBimap
-   , ledgerDbPrune
-     -- ** Running updates
-   , Ap(..)
-   , AnnLedgerError(..)
-   , ResolveBlock
-   , ResolvesBlocks(..)
-   , ThrowsLedgerError(..)
-   , defaultThrowLedgerErrors
-   , defaultResolveBlocks
-   , defaultResolveWithErrors
-     -- ** Updates
-   , ExceededRollback(..)
-   , ledgerDbPush
-   , ledgerDbSwitch
-     -- * Exports for the benefit of tests
-     -- ** Additional queries
-   , ledgerDbMaxRollback
-   , ledgerDbIsSaturated
-     -- ** Pure API
-   , ledgerDbPush'
-   , ledgerDbPushMany'
-   , ledgerDbSwitch'
-   ) where
+module Ouroboros.Consensus.Storage.LedgerDB.InMemory
+  ( -- * LedgerDB proper
+    LedgerDB
+    -- opaque
+  , LedgerDbCfg (..)
+  , ledgerDbWithAnchor
+    -- ** Serialisation
+  , decodeSnapshotBackwardsCompatible
+  , encodeSnapshot
+    -- ** Queries
+  , ledgerDbAnchor
+  , ledgerDbBimap
+  , ledgerDbCurrent
+  , ledgerDbPast
+  , ledgerDbPrune
+  , ledgerDbSnapshots
+  , ledgerDbTip
+    -- ** Running updates
+  , AnnLedgerError (..)
+  , Ap (..)
+  , ResolveBlock
+  , ResolvesBlocks (..)
+  , ThrowsLedgerError (..)
+  , defaultResolveBlocks
+  , defaultResolveWithErrors
+  , defaultThrowLedgerErrors
+    -- ** Updates
+  , ExceededRollback (..)
+  , ledgerDbPush
+  , ledgerDbSwitch
+    -- * Exports for the benefit of tests
+    -- ** Additional queries
+  , ledgerDbIsSaturated
+  , ledgerDbMaxRollback
+    -- ** Pure API
+  , ledgerDbPush'
+  , ledgerDbPushMany'
+  , ledgerDbSwitch'
+  ) where
 
 import           Codec.Serialise.Decoding (Decoder)
 import qualified Codec.Serialise.Decoding as Dec

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/LedgerDB/OnDisk.hs
@@ -12,28 +12,29 @@
 {-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeApplications    #-}
 
-module Ouroboros.Consensus.Storage.LedgerDB.OnDisk (
-    -- * Opening the database
-    initLedgerDB
-  , InitLog(..)
-  , InitFailure(..)
+module Ouroboros.Consensus.Storage.LedgerDB.OnDisk
+  ( -- * Opening the database
+    InitFailure (..)
+  , InitLog (..)
+  , initLedgerDB
     -- ** Instantiate in-memory to @blk@
-  , LedgerDB'
   , AnnLedgerError'
+  , LedgerDB'
     -- ** Abstraction over the stream API
-  , NextBlock(..)
-  , StreamAPI(..)
+  , NextBlock (..)
+  , StreamAPI (..)
     -- * Write to disk
   , takeSnapshot
   , trimSnapshots
     -- * Low-level API (primarily exposed for testing)
-  , DiskSnapshot -- opaque
+  , DiskSnapshot
+    -- opaque
   , deleteSnapshot
   , snapshotToFileName
   , snapshotToPath
     -- * Trace events
-  , TraceEvent(..)
-  , TraceReplayEvent(..)
+  , TraceEvent (..)
+  , TraceReplayEvent (..)
   ) where
 
 import qualified Codec.CBOR.Write as CBOR

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/Serialisation.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/Serialisation.hs
@@ -28,35 +28,35 @@
 -- have the precise bytestring that we can pass in as the annotation). If we
 -- coupled the encoder to the decoder, we wouldn't be able to cleanly model
 -- this use case. Moreover, sometimes we only need a single direction.
-module Ouroboros.Consensus.Storage.Serialisation (
-    -- * Serialisation to/from disk storage
-    EncodeDisk (..)
-  , DecodeDisk (..)
+module Ouroboros.Consensus.Storage.Serialisation
+  ( -- * Serialisation to/from disk storage
+    DecodeDisk (..)
+  , EncodeDisk (..)
     -- * Support for dependent pairs
-  , EncodeDiskDepIx(..)
-  , EncodeDiskDep(..)
-  , DecodeDiskDepIx(..)
-  , DecodeDiskDep(..)
+  , DecodeDiskDep (..)
+  , DecodeDiskDepIx (..)
+  , EncodeDiskDep (..)
+  , EncodeDiskDepIx (..)
     -- * Serialised header
-  , SerialisedHeader(..)
-  , serialisedHeaderToPair
-  , serialisedHeaderFromPair
+  , SerialisedHeader (..)
   , castSerialisedHeader
-  , encodeTrivialSerialisedHeader
   , decodeTrivialSerialisedHeader
+  , encodeTrivialSerialisedHeader
+  , serialisedHeaderFromPair
+  , serialisedHeaderToPair
     -- * Reconstruct nested type
-  , ReconstructNestedCtxt (..)
   , PrefixLen (..)
+  , ReconstructNestedCtxt (..)
   , addPrefixLen
   , takePrefix
     -- * Binary block info
-  , HasBinaryBlockInfo (..)
   , BinaryBlockInfo (..)
+  , HasBinaryBlockInfo (..)
     -- * Re-exported for convenience
   , SizeInBytes
     -- * Exported for the benefit of tests
-  , encodeDepPair
   , decodeDepPair
+  , encodeDepPair
   ) where
 
 import           Codec.CBOR.Decoding (Decoder)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Storage.VolatileDB (
-    module X
+module Ouroboros.Consensus.Storage.VolatileDB
+  ( module X
   ) where
 
 import           Ouroboros.Consensus.Storage.VolatileDB.API as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/API.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/API.hs
@@ -10,20 +10,20 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeFamilies        #-}
 
-module Ouroboros.Consensus.Storage.VolatileDB.API (
-    -- * API
+module Ouroboros.Consensus.Storage.VolatileDB.API
+  ( -- * API
     VolatileDB (..)
     -- * Types
   , BlockInfo (..)
     -- * Errors
-  , VolatileDBError (..)
   , ApiMisuse (..)
   , UnexpectedFailure (..)
+  , VolatileDBError (..)
     -- * Derived functionality
-  , withDB
   , getIsMember
-  , getPredecessor
   , getKnownBlockComponent
+  , getPredecessor
+  , withDB
   ) where
 
 import qualified Codec.CBOR.Read as CBOR

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
@@ -101,19 +101,19 @@
 -- means deleting all of its contents. In order to achieve this, it truncates
 -- the files containing blocks if some blocks fail to parse, are invalid, or are
 -- duplicated.
-module Ouroboros.Consensus.Storage.VolatileDB.Impl (
-    -- * Opening the database
-    openDB
-  , VolatileDbArgs (..)
-  , defaultArgs
+module Ouroboros.Consensus.Storage.VolatileDB.Impl
+  ( -- * Opening the database
+    VolatileDbArgs (..)
   , VolatileDbSerialiseConstraints
+  , defaultArgs
+  , openDB
     -- * Re-exported
-  , BlocksPerFile
-  , mkBlocksPerFile
   , BlockValidationPolicy (..)
+  , BlocksPerFile
   , ParseError (..)
   , TraceEvent (..)
   , extractBlockInfo
+  , mkBlocksPerFile
   ) where
 
 import qualified Codec.CBOR.Read as CBOR

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/FileInfo.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/FileInfo.hs
@@ -8,17 +8,18 @@
 -- | Information about the files stored by the volatile DB
 --
 -- Intended for qualified import.
-module Ouroboros.Consensus.Storage.VolatileDB.Impl.FileInfo (
-    FileInfo      -- opaque
+module Ouroboros.Consensus.Storage.VolatileDB.Impl.FileInfo
+  ( FileInfo
+    -- opaque
     -- * Construction
-  , empty
   , addBlock
+  , empty
   , fromParsedBlockInfos
     -- * Queries
-  , maxSlotNo
-  , hashes
   , canGC
+  , hashes
   , isFull
+  , maxSlotNo
   , maxSlotNoInFiles
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Index.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Index.hs
@@ -5,15 +5,16 @@
 --
 -- Intended for qualified import
 -- > import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl.Index as Index
-module Ouroboros.Consensus.Storage.VolatileDB.Impl.Index (
-    Index -- opaque
-  , empty
-  , lookup
-  , insert
+module Ouroboros.Consensus.Storage.VolatileDB.Impl.Index
+  ( Index
+    -- opaque
   , delete
-  , toAscList
   , elems
+  , empty
+  , insert
   , lastFile
+  , lookup
+  , toAscList
   ) where
 
 import           Prelude hiding (lookup)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Parser.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Parser.hs
@@ -4,10 +4,10 @@
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving  #-}
-module Ouroboros.Consensus.Storage.VolatileDB.Impl.Parser (
-    parseBlockFile
+module Ouroboros.Consensus.Storage.VolatileDB.Impl.Parser
+  ( ParseError (..)
   , ParsedBlockInfo (..)
-  , ParseError (..)
+  , parseBlockFile
     -- * Auxiliary
   , extractBlockInfo
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/State.hs
@@ -9,26 +9,26 @@
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE TypeApplications          #-}
 
-module Ouroboros.Consensus.Storage.VolatileDB.Impl.State (
-    -- * Tracing
+module Ouroboros.Consensus.Storage.VolatileDB.Impl.State
+  ( -- * Tracing
     TraceEvent (..)
     -- * State types
+  , BlockOffset (..)
+  , BlockSize (..)
   , FileId
+  , InternalState (..)
+  , OpenState (..)
   , ReverseIndex
   , SuccessorsIndex
-  , BlockSize (..)
-  , BlockOffset (..)
   , VolatileDBEnv (..)
-  , InternalState (..)
   , dbIsOpen
-  , OpenState (..)
     -- * State helpers
   , ModifyOpenState
   , appendOpenState
-  , writeOpenState
-  , withOpenState
-  , mkOpenState
   , closeOpenHandles
+  , mkOpenState
+  , withOpenState
+  , writeOpenState
   ) where
 
 import           Control.Monad

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Types.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Types.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE StandaloneDeriving #-}
-module Ouroboros.Consensus.Storage.VolatileDB.Impl.Types (
-    -- * Blocks per file
-    BlocksPerFile -- opaque
-  , unBlocksPerFile
+module Ouroboros.Consensus.Storage.VolatileDB.Impl.Types
+  ( -- * Blocks per file
+    BlocksPerFile
+    -- opaque
   , mkBlocksPerFile
+  , unBlocksPerFile
     -- * Block validation policy
   , BlockValidationPolicy (..)
     -- * Parse error
@@ -13,12 +14,12 @@ module Ouroboros.Consensus.Storage.VolatileDB.Impl.Types (
     -- * Tracing
   , TraceEvent (..)
     -- * Internal indices
+  , BlockOffset (..)
+  , BlockSize (..)
   , FileId
+  , InternalBlockInfo (..)
   , ReverseIndex
   , SuccessorsIndex
-  , BlockSize (..)
-  , BlockOffset (..)
-  , InternalBlockInfo (..)
   ) where
 
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Util.hs
@@ -4,20 +4,18 @@
 {-# LANGUAGE TypeApplications    #-}
 
 module Ouroboros.Consensus.Storage.VolatileDB.Impl.Util
-    ( -- * FileId utilities
-      parseFd
-    , parseAllFds
-    , filePath
-    , findLastFd
-
-      -- * Exception handling
-    , wrapFsError
-    , tryVolatileDB
-
-      -- * Map of Set utilities
-    , insertMapSet
-    , deleteMapSet
-    ) where
+  ( -- * FileId utilities
+    filePath
+  , findLastFd
+  , parseAllFds
+  , parseFd
+    -- * Exception handling
+  , tryVolatileDB
+  , wrapFsError
+    -- * Map of Set utilities
+  , deleteMapSet
+  , insertMapSet
+  ) where
 
 import           Control.Monad
 import           Data.Bifunctor (first)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Ticked.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Ticked.hs
@@ -6,8 +6,8 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE TypeOperators              #-}
 
-module Ouroboros.Consensus.Ticked (
-    Ticked(..)
+module Ouroboros.Consensus.Ticked
+  ( Ticked (..)
   ) where
 
 import           Data.Kind (Type)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/TypeFamilyWrappers.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/TypeFamilyWrappers.hs
@@ -5,34 +5,34 @@
 {-# LANGUAGE UndecidableInstances       #-}
 
 -- | Newtypes around type families so that they can be partially applied
-module Ouroboros.Consensus.TypeFamilyWrappers (
-    -- * Block based
-    WrapApplyTxErr(..)
-  , WrapCannotForge(..)
-  , WrapEnvelopeErr(..)
-  , WrapForgeStateInfo(..)
-  , WrapForgeStateUpdateError(..)
-  , WrapGenTxId(..)
-  , WrapHeaderHash(..)
-  , WrapLedgerConfig(..)
-  , WrapLedgerErr(..)
-  , WrapLedgerUpdate(..)
-  , WrapLedgerWarning(..)
-  , WrapTipInfo(..)
+module Ouroboros.Consensus.TypeFamilyWrappers
+  ( -- * Block based
+    WrapApplyTxErr (..)
+  , WrapCannotForge (..)
+  , WrapEnvelopeErr (..)
+  , WrapForgeStateInfo (..)
+  , WrapForgeStateUpdateError (..)
+  , WrapGenTxId (..)
+  , WrapHeaderHash (..)
+  , WrapLedgerConfig (..)
+  , WrapLedgerErr (..)
+  , WrapLedgerUpdate (..)
+  , WrapLedgerWarning (..)
+  , WrapTipInfo (..)
     -- * Protocol based
-  , WrapCanBeLeader(..)
-  , WrapChainDepState(..)
-  , WrapConsensusConfig(..)
-  , WrapIsLeader(..)
-  , WrapLedgerView(..)
-  , WrapSelectView(..)
-  , WrapValidateView(..)
-  , WrapValidationErr(..)
+  , WrapCanBeLeader (..)
+  , WrapChainDepState (..)
+  , WrapConsensusConfig (..)
+  , WrapIsLeader (..)
+  , WrapLedgerView (..)
+  , WrapSelectView (..)
+  , WrapValidateView (..)
+  , WrapValidationErr (..)
     -- * Versioning
-  , WrapNodeToNodeVersion(..)
-  , WrapNodeToClientVersion(..)
+  , WrapNodeToClientVersion (..)
+  , WrapNodeToNodeVersion (..)
     -- * Type family instances
-  , Ticked(..)
+  , Ticked (..)
   ) where
 
 import           Codec.Serialise (Serialise)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -8,33 +8,33 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Miscellaneous utilities
-module Ouroboros.Consensus.Util (
-    -- * Type-level utility
-    Dict(..)
+module Ouroboros.Consensus.Util
+  ( -- * Type-level utility
+    Dict (..)
   , Empty
-  , Some(..)
-  , SomePair(..)
-  , SomeSecond(..)
-  , ShowProxy(..)
+  , ShowProxy (..)
+  , Some (..)
+  , SomePair (..)
+  , SomeSecond (..)
   , mustBeRight
     -- * Folding variations
   , foldlM'
-  , repeatedly
-  , repeatedlyM
   , nTimes
   , nTimesM
+  , repeatedly
+  , repeatedlyM
     -- * Lists
+  , allEqual
   , chunks
-  , pickOne
-  , markLast
-  , takeLast
   , dropLast
   , firstJust
-  , allEqual
-  , takeUntil
   , groupOn
   , groupSplit
+  , markLast
+  , pickOne
   , splits
+  , takeLast
+  , takeUntil
     -- * Safe variants of existing base functions
   , lastMaybe
   , safeMaximum
@@ -53,17 +53,17 @@ module Ouroboros.Consensus.Util (
     -- * Sets
   , allDisjoint
     -- * Composition
-  , (.:)
-  , (..:)
-  , (...:)
-  , (....:)
   , (.....:)
+  , (....:)
+  , (...:)
+  , (..:)
+  , (.:)
     -- * Product
   , pairFst
   , pairSnd
     -- * Miscellaneous
-  , fib
   , eitherToMaybe
+  , fib
   ) where
 
 import           Cardano.Crypto.Hash (Hash, HashAlgorithm, hashFromBytes,

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -19,7 +19,7 @@ import           Data.Word (Word64)
 import           GHC.Stack
 
 import           Ouroboros.Network.AnchoredFragment (AnchoredFragment,
-                     AnchoredSeq ((:>), Empty))
+                     AnchoredSeq (Empty, (:>)))
 import qualified Ouroboros.Network.AnchoredFragment as AF
 
 import           Ouroboros.Consensus.Block

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/AnchoredFragment.hs
@@ -5,11 +5,11 @@
 --
 -- Intended for qualified import
 -- > import qualified Ouroboros.Consensus.Util.AnchoredFragment as AF
-module Ouroboros.Consensus.Util.AnchoredFragment (
-    compareHeadBlockNo
+module Ouroboros.Consensus.Util.AnchoredFragment
+  ( compareAnchoredFragments
+  , compareHeadBlockNo
   , forksAtMostKBlocks
   , preferAnchoredCandidate
-  , compareAnchoredFragments
   ) where
 
 import           Control.Monad.Except (throwError)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Args.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Args.hs
@@ -28,8 +28,8 @@
 --
 -- Leaving out the 'hasNoDefault' field from 'theArgs' will result in a type
 -- error.
-module Ouroboros.Consensus.Util.Args (
-    Defaults (..)
+module Ouroboros.Consensus.Util.Args
+  ( Defaults (..)
   , HKD
   , MapHKD (..)
     -- * Re-exported for convenience

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Assert.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Assert.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE CPP              #-}
 {-# LANGUAGE TypeApplications #-}
 module Ouroboros.Consensus.Util.Assert
-  ( assertWithMsg
-  , assertEqWithMsg
+  ( assertEqWithMsg
+  , assertWithMsg
   ) where
 
 import           GHC.Stack (HasCallStack)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CBOR.hs
@@ -4,29 +4,29 @@
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Ouroboros.Consensus.Util.CBOR (
-    -- * Incremental parsing in I/O
-    IDecodeIO(..)
-  , fromIDecode
+module Ouroboros.Consensus.Util.CBOR
+  ( -- * Incremental parsing in I/O
+    IDecodeIO (..)
   , deserialiseIncrementalIO
+  , fromIDecode
     -- * Higher-level incremental interface
-  , Decoder(..)
+  , Decoder (..)
   , initDecoderIO
     -- * Decode as FlatTerm
   , decodeAsFlatTerm
     -- * HasFS interaction
-  , ReadIncrementalErr(..)
+  , ReadIncrementalErr (..)
   , readIncremental
   , withStreamIncrementalOffsets
     -- * Encoding/decoding containers
-  , encodeList
   , decodeList
-  , encodeSeq
-  , decodeSeq
-  , encodeMaybe
   , decodeMaybe
-  , encodeWithOrigin
+  , decodeSeq
   , decodeWithOrigin
+  , encodeList
+  , encodeMaybe
+  , encodeSeq
+  , encodeWithOrigin
   ) where
 
 import qualified Codec.CBOR.Decoding as CBOR.D

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/CallStack.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/CallStack.hs
@@ -3,8 +3,9 @@
 -- | CallStack with a nicer 'Show' instance
 --
 -- Use of this module is intended to /replace/ import of @GHC.Stack@
-module Ouroboros.Consensus.Util.CallStack (
-    PrettyCallStack -- Opaque
+module Ouroboros.Consensus.Util.CallStack
+  ( PrettyCallStack
+    -- Opaque
   , prettyCallStack
     -- * Re-exports
   , HasCallStack

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -27,14 +27,15 @@ import           Text.Printf (printf)
 import           Control.Monad.Class.MonadTime (Time (..))
 
 import           Cardano.Crypto.DSIGN (Ed25519DSIGN, Ed448DSIGN, MockDSIGN,
-                     SigDSIGN, pattern SigEd25519DSIGN, pattern SigEd448DSIGN,
-                     pattern SigMockDSIGN, SignedDSIGN (..), VerKeyDSIGN)
+                     SigDSIGN, SignedDSIGN (..), VerKeyDSIGN,
+                     pattern SigEd25519DSIGN, pattern SigEd448DSIGN,
+                     pattern SigMockDSIGN)
 import           Cardano.Crypto.Hash (Hash)
-import           Cardano.Crypto.KES (MockKES, NeverKES, SigKES,
+import           Cardano.Crypto.KES (MockKES, NeverKES, SigKES, SignedKES (..),
+                     SimpleKES, SingleKES, SumKES, VerKeyKES,
                      pattern SigMockKES, pattern SigSimpleKES,
                      pattern SigSingleKES, pattern SigSumKES,
-                     pattern SignKeyMockKES, SignedKES (..), SimpleKES,
-                     SingleKES, SumKES, VerKeyKES, pattern VerKeyMockKES,
+                     pattern SignKeyMockKES, pattern VerKeyMockKES,
                      pattern VerKeySingleKES, pattern VerKeySumKES)
 
 import           Ouroboros.Consensus.Util.HList (All, HList (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -3,9 +3,9 @@
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Ouroboros.Consensus.Util.Condense (
-    Condense(..)
-  , Condense1(..)
+module Ouroboros.Consensus.Util.Condense
+  ( Condense (..)
+  , Condense1 (..)
   , condense1
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Counting.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Counting.hs
@@ -19,37 +19,37 @@
 -- | Type-level counting
 --
 -- Intended for unqualified import.
-module Ouroboros.Consensus.Util.Counting (
-    Exactly(.., ExactlyNil, ExactlyCons)
-  , AtMost(..)
-  , NonEmpty(..)
+module Ouroboros.Consensus.Util.Counting
+  ( AtMost (..)
+  , Exactly (ExactlyNil, ExactlyCons)
+  , NonEmpty (..)
     -- * Working with 'Exactly'
-  , exactlyOne
-  , exactlyTwo
   , exactlyHead
+  , exactlyOne
+  , exactlyReplicate
   , exactlyTail
-  , exactlyZip
-  , exactlyZipFoldable
+  , exactlyTwo
   , exactlyWeaken
   , exactlyWeakenNonEmpty
-  , exactlyReplicate
+  , exactlyZip
+  , exactlyZipFoldable
     -- * Working with 'AtMost'
-  , atMostOne
-  , atMostInit
   , atMostHead
+  , atMostInit
   , atMostLast
-  , atMostZipFoldable
   , atMostNonEmpty
+  , atMostOne
+  , atMostZipFoldable
     -- * Working with 'NonEmpty'
-  , nonEmptyHead
-  , nonEmptyLast
-  , nonEmptyInit
   , nonEmptyFromList
-  , nonEmptyToList
-  , nonEmptyWeaken
-  , nonEmptyStrictPrefixes
+  , nonEmptyHead
+  , nonEmptyInit
+  , nonEmptyLast
   , nonEmptyMapOne
   , nonEmptyMapTwo
+  , nonEmptyStrictPrefixes
+  , nonEmptyToList
+  , nonEmptyWeaken
   ) where
 
 import           Control.Applicative

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/DepPair.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/DepPair.hs
@@ -6,20 +6,20 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 
-module Ouroboros.Consensus.Util.DepPair (
-    -- * Dependent pairs
-    GenDepPair(GenDepPair, DepPair)
-  , DepPair
+module Ouroboros.Consensus.Util.DepPair
+  ( -- * Dependent pairs
+    DepPair
+  , GenDepPair (GenDepPair, DepPair)
   , depPairFirst
     -- * Compare indices
-  , SameDepIndex(..)
+  , SameDepIndex (..)
     -- * Trivial dependency
-  , TrivialDependency(..)
+  , TrivialDependency (..)
   , fromTrivialDependency
   , toTrivialDependency
     -- * Convenience re-exports
-  , (:~:)(..)
-  , Proxy(..)
+  , Proxy (..)
+  , (:~:) (..)
   ) where
 
 import           Data.Kind (Type)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/EarlyExit.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/EarlyExit.hs
@@ -9,11 +9,12 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-module Ouroboros.Consensus.Util.EarlyExit (
-    WithEarlyExit -- opaque
+module Ouroboros.Consensus.Util.EarlyExit
+  ( WithEarlyExit
+    -- opaque
+  , exitEarly
   , withEarlyExit
   , withEarlyExit_
-  , exitEarly
     -- * Re-exports
   , lift
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/FileLock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/FileLock.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Util.FileLock (
-    FileLock (..)
+module Ouroboros.Consensus.Util.FileLock
+  ( FileLock (..)
   , ioFileLock
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/HList.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/HList.hs
@@ -13,25 +13,25 @@
 -- | Heterogeneous lists
 --
 -- Intended for qualified import
-module Ouroboros.Consensus.Util.HList (
-    -- * Basic definitions
-    HList(..)
-  , All
+module Ouroboros.Consensus.Util.HList
+  ( -- * Basic definitions
+    All
+  , HList (..)
     -- * Folding
+  , collapse
+  , foldMap
   , foldl
   , foldlM
   , foldr
-  , foldMap
   , repeatedly
   , repeatedlyM
-  , collapse
     -- * Singletons
+  , IsList (..)
   , SList
-  , IsList(..)
     -- * n-ary functions
   , Fn
-  , applyFn
   , afterFn
+  , applyFn
   ) where
 
 import           Data.Kind (Constraint, Type)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/IOLike.hs
@@ -1,44 +1,45 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 
-module Ouroboros.Consensus.Util.IOLike (
-    IOLike(..)
+module Ouroboros.Consensus.Util.IOLike
+  ( IOLike (..)
     -- * Re-exports
     -- *** MonadThrow
-  , MonadThrow(..)
-  , MonadCatch(..)
-  , MonadMask(..)
-  , Exception(..)
+  , Exception (..)
+  , ExitCase (..)
+  , MonadCatch (..)
+  , MonadMask (..)
+  , MonadThrow (..)
   , SomeException
-  , ExitCase(..)
     -- *** MonadSTM
   , module Ouroboros.Consensus.Util.MonadSTM.NormalForm
     -- *** MonadFork
-  , MonadFork(..) -- TODO: Should we hide this in favour of MonadAsync?
+  , MonadFork (..)
+    -- TODO: Should we hide this in favour of MonadAsync?
+  , MonadThread (..)
   , labelThisThread
-  , MonadThread(..)
     -- *** MonadAsync
-  , MonadAsyncSTM(..)
-  , MonadAsync(..)
-  , ExceptionInLinkedThread(..)
+  , ExceptionInLinkedThread (..)
+  , MonadAsync (..)
+  , MonadAsyncSTM (..)
   , link
   , linkTo
     -- *** MonadST
-  , MonadST(..)
+  , MonadST (..)
     -- *** MonadTime
-  , MonadMonotonicTime(..)
-  , Time(..)
   , DiffTime
+  , MonadMonotonicTime (..)
+  , Time (..)
   , addTime
   , diffTime
     -- *** MonadDelay
-  , MonadDelay(..)
+  , MonadDelay (..)
     -- *** MonadEventlog
-  , MonadEventlog(..)
+  , MonadEventlog (..)
     -- *** MonadEvaluate
-  , MonadEvaluate(..)
+  , MonadEvaluate (..)
     -- *** NoThunks
-  , NoThunks(..)
+  , NoThunks (..)
   ) where
 
 import           NoThunks.Class (NoThunks (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/NormalForm.hs
@@ -1,13 +1,13 @@
-module Ouroboros.Consensus.Util.MonadSTM.NormalForm (
-    module Control.Monad.Class.MonadSTM.Strict
+module Ouroboros.Consensus.Util.MonadSTM.NormalForm
+  ( module Control.Monad.Class.MonadSTM.Strict
   , module Ouroboros.Consensus.Util.MonadSTM.StrictMVar
-  , newTVarIO
-  , newMVar
   , newEmptyMVar
+  , newMVar
+  , newTVarIO
     -- * Temporary
-  , uncheckedNewTVarM
-  , uncheckedNewMVar
   , uncheckedNewEmptyMVar
+  , uncheckedNewMVar
+  , uncheckedNewTVarM
   ) where
 
 import           GHC.Stack

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/RAWLock.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/RAWLock.hs
@@ -11,17 +11,17 @@ module Ouroboros.Consensus.Util.MonadSTM.RAWLock
   ( -- * Public API
     RAWLock
   , new
-  , withReadAccess
-  , withAppendAccess
-  , withWriteAccess
-  , read
   , poison
+  , read
+  , withAppendAccess
+  , withReadAccess
+  , withWriteAccess
     -- * Exposed internals: non-bracketed acquire & release
-  , unsafeAcquireReadAccess
-  , unsafeReleaseReadAccess
   , unsafeAcquireAppendAccess
-  , unsafeReleaseAppendAccess
+  , unsafeAcquireReadAccess
   , unsafeAcquireWriteAccess
+  , unsafeReleaseAppendAccess
+  , unsafeReleaseReadAccess
   , unsafeReleaseWriteAccess
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/MonadSTM/StrictMVar.hs
@@ -5,26 +5,27 @@
 {-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeFamilies      #-}
 
-module Ouroboros.Consensus.Util.MonadSTM.StrictMVar (
-    StrictMVar(..) -- constructors exported for benefit of tests
+module Ouroboros.Consensus.Util.MonadSTM.StrictMVar
+  ( StrictMVar (..)
+    -- constructors exported for benefit of tests
   , castStrictMVar
-  , newMVar
-  , newMVarWithInvariant
-  , newEmptyMVar
-  , newEmptyMVarWithInvariant
-  , takeMVar
-  , tryTakeMVar
-  , putMVar
-  , tryPutMVar
-  , readMVar
-  , readMVarSTM
-  , tryReadMVar
-  , swapMVar
   , isEmptyMVar
-  , updateMVar
-  , updateMVar_
   , modifyMVar
   , modifyMVar_
+  , newEmptyMVar
+  , newEmptyMVarWithInvariant
+  , newMVar
+  , newMVarWithInvariant
+  , putMVar
+  , readMVar
+  , readMVarSTM
+  , swapMVar
+  , takeMVar
+  , tryPutMVar
+  , tryReadMVar
+  , tryTakeMVar
+  , updateMVar
+  , updateMVar_
   ) where
 
 import           Control.Concurrent.STM (readTVarIO)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/OptNP.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/OptNP.hs
@@ -21,22 +21,22 @@
 --
 -- > import           Ouroboros.Consensus.Util.OptNP (OptNP (..), ViewOptNP (..))
 -- > import qualified Ouroboros.Consensus.Util.OptNP as OptNP
-module Ouroboros.Consensus.Util.OptNP (
-    OptNP(..)
-  , empty
-  , fromNonEmptyNP
-  , fromNP
-  , toNP
+module Ouroboros.Consensus.Util.OptNP
+  ( OptNP (..)
   , at
-  , singleton
+  , empty
+  , fromNP
+  , fromNonEmptyNP
   , fromSingleton
+  , singleton
+  , toNP
     -- * View
-  , ViewOptNP(..)
+  , ViewOptNP (..)
   , view
     -- * Combining
-  , zipWith
   , combine
   , combineWith
+  , zipWith
   ) where
 
 import           Prelude hiding (zipWith)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs
@@ -11,7 +11,9 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Ouroboros.Consensus.Util.Orphans () where
+module Ouroboros.Consensus.Util.Orphans
+  (
+  ) where
 
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.Serialise (Serialise (..))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/RedundantConstraints.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/RedundantConstraints.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
-module Ouroboros.Consensus.Util.RedundantConstraints (
-    keepRedundantConstraint
+module Ouroboros.Consensus.Util.RedundantConstraints
+  ( keepRedundantConstraint
     -- * Convenience re-export
-  , Proxy(..)
+  , Proxy (..)
   ) where
 
 import           Data.Proxy

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/ResourceRegistry.hs
@@ -12,42 +12,45 @@
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
-module Ouroboros.Consensus.Util.ResourceRegistry (
-    ResourceRegistry -- opaque
-  , RegistryClosedException(..)
+module Ouroboros.Consensus.Util.ResourceRegistry
+  ( ResourceRegistry
+    -- opaque
+  , RegistryClosedException (..)
   , ResourceRegistryThreadException
     -- * Creating and releasing the registry itself
-  , withRegistry
   , bracketWithPrivateRegistry
   , registryThread
+  , withRegistry
     -- * Allocating and releasing regular resources
   , ResourceKey
   , allocate
   , allocateEither
   , release
-  , unsafeRelease
   , releaseAll
+  , unsafeRelease
   , unsafeReleaseAll
     -- * Threads
-  , Thread -- opaque
-  , threadId
-  , forkThread
+  , Thread
+    -- opaque
   , cancelThread
-  , withThread
-  , waitThread
-  , waitAnyThread
-  , linkToRegistry
   , forkLinkedThread
+  , forkThread
+  , linkToRegistry
+  , threadId
+  , waitAnyThread
+  , waitThread
+  , withThread
     -- * Temporary registry
-  , WithTempRegistry -- opaque
-  , runWithTempRegistry
-  , TempRegistryException(..)
+  , WithTempRegistry
+    -- opaque
+  , TempRegistryException (..)
   , allocateTemp
   , modifyWithTempRegistry
+  , runWithTempRegistry
     -- * Combinators primarily for testing
-  , unsafeNewRegistry
   , closeRegistry
   , countResources
+  , unsafeNewRegistry
   ) where
 
 import           Control.Applicative ((<|>))

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/SOP.hs
@@ -14,39 +14,39 @@
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Ouroboros.Consensus.Util.SOP (
-    -- * Minor variations on standard SOP operators
-    sequence_NS'
-  , map_NP'
-  , partition_NS
-  , npWithIndices
-  , nsToIndex
-  , nsFromIndex
-  , Lens(..)
-  , lenses_NP
-  , npToSListI
+module Ouroboros.Consensus.Util.SOP
+  ( -- * Minor variations on standard SOP operators
+    Lens (..)
   , allComposeShowK
   , fn_5
+  , lenses_NP
+  , map_NP'
+  , npToSListI
+  , npWithIndices
+  , nsFromIndex
+  , nsToIndex
+  , partition_NS
+  , sequence_NS'
     -- * Type-level non-empty lists
-  , IsNonEmpty(..)
-  , ProofNonEmpty(..)
+  , IsNonEmpty (..)
+  , ProofNonEmpty (..)
   , checkIsNonEmpty
     -- * Indexing SOP types
-  , Index(..)
-  , indices
+  , Index (..)
   , dictIndexAll
+  , indices
   , injectNS
   , injectNS'
   , projectNP
     -- * Zipping with indices
-  , himap
   , hcimap
-  , hizipWith
   , hcizipWith
-  , hizipWith3
   , hcizipWith3
-  , hizipWith4
   , hcizipWith4
+  , himap
+  , hizipWith
+  , hizipWith3
+  , hizipWith4
   ) where
 
 import           Data.Coerce

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/STM.hs
@@ -7,20 +7,20 @@
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 
-module Ouroboros.Consensus.Util.STM (
-    -- * 'Watcher'
+module Ouroboros.Consensus.Util.STM
+  ( -- * 'Watcher'
     Watcher (..)
   , forkLinkedWatcher
   , withWatcher
     -- * Misc
-  , blockUntilChanged
-  , runWhenJust
-  , blockUntilJust
-  , blockUntilAllJust
   , Fingerprint (..)
   , WithFingerprint (..)
+  , blockUntilAllJust
+  , blockUntilChanged
+  , blockUntilJust
+  , runWhenJust
     -- * Simulate various monad stacks in STM
-  , Sim(..)
+  , Sim (..)
   , simId
   , simStateT
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Singletons.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Singletons.hs
@@ -12,12 +12,12 @@
 --
 -- This provides the core of the 'singletons' package, using the same name,
 -- but without pulling in all the dependencies and craziness.
-module Ouroboros.Consensus.Util.Singletons (
-    Sing(..)
-  , SingI(..)
-  , SomeSing(..)
+module Ouroboros.Consensus.Util.Singletons
+  ( Sing (..)
+  , SingI (..)
+  , SingKind (..)
+  , SomeSing (..)
   , withSomeSing
-  , SingKind(..)
   ) where
 
 import           Data.Kind (Type)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Time.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Time.hs
@@ -1,5 +1,5 @@
-module Ouroboros.Consensus.Util.Time (
-    -- Conversions
+module Ouroboros.Consensus.Util.Time
+  ( -- Conversions
     nominalDelay
   , secondsToNominalDiffTime
   ) where

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/TraceSize.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/TraceSize.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Ouroboros.Consensus.Util.TraceSize (
-    -- * Generic
+module Ouroboros.Consensus.Util.TraceSize
+  ( -- * Generic
     traceSize
     -- * Ledger DB specific
-  , LedgerDbSize(..)
+  , LedgerDbSize (..)
   , traceLedgerDbSize
   ) where
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Versioned.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Versioned.hs
@@ -7,15 +7,16 @@
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 module Ouroboros.Consensus.Util.Versioned
-  ( Versioned (..)
-  , VersionNumber -- opaque
-  , VersionError (..)
+  ( VersionNumber
+  , Versioned (..)
+    -- opaque
   , VersionDecoder (..)
-  , encodeVersioned
-  , encodeVersion
-  , decodeVersioned
+  , VersionError (..)
   , decodeVersion
   , decodeVersionWithHook
+  , decodeVersioned
+  , encodeVersion
+  , encodeVersioned
   ) where
 
 import qualified Codec.CBOR.Decoding as Dec

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,7 @@
 }:
 with pkgs;
 let
+  stylish-haskell = import ./nix/stylish-haskell.nix { inherit pkgs; };
   # This provides a development environment that can be used with nix-shell or
   # lorri. See https://input-output-hk.github.io/haskell.nix/user-guide/development/
   # NOTE: due to some cabal limitation,
@@ -22,12 +23,12 @@ let
 
     # These programs will be available inside the nix-shell.
     buildInputs = [
+      stylish-haskell
       niv
       pkgconfig
     ];
 
     tools = {
-      stylish-haskell = "0.11.0.0";
       ghcid = "0.8.7";
       cabal = "3.2.0.0";
       # todo: add back the build tools which are actually necessary


### PR DESCRIPTION
Fixes https://github.com/input-output-hk/ouroboros-network/issues/2969
Blocked by https://github.com/input-output-hk/ouroboros-network/pull/2968 (it needs to be merged first)

It's pushing open bracket for export lines one line below, example

was:
```
module Ouroboros.Consensus.ByronDual.Node (
    protocolInfoDualByron
```

will be:
```
module Ouroboros.Consensus.ByronDual.Node
  ( protocolInfoDualByron
  ) where
```

This is something that could be fixes in stylish-haskell quite easy. I'm not short it is worth it though, I like this formatting better to be hones.