### PR TITLE
Export prop_estimateBlockSize

### DIFF
--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Roundtrip.hs
@@ -22,6 +22,7 @@ module Test.Util.Serialisation.Roundtrip (
   , roundtrip_envelopes
   , roundtrip_ConvertRawHash
   , prop_hashSize
+  , prop_estimateBlockSize
   , WithVersion (..)
   , SomeResult (..)
   ) where


### PR DESCRIPTION
This was the only individual test case not exported by this module, but
that's run by `roundtrip_all`