### PR TITLE
Trace block propagation delay

### DIFF
--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -37,6 +37,7 @@ import           Codec.CBOR.Read (DeserialiseFailure)
 import qualified Control.Exception as Exn
 import           Control.Monad
 import qualified Control.Monad.Class.MonadSTM as MonadSTM
+import           Control.Monad.Class.MonadTime (MonadTime)
 import           Control.Monad.Class.MonadTimer (MonadTimer)
 import qualified Control.Monad.Except as Exc
 import           Control.Tracer
@@ -274,6 +275,7 @@ type EdgeStatusVar m = StrictTVar m EdgeStatus
 -- each node.
 runThreadNetwork :: forall m blk.
                     ( IOLike m
+                    , MonadTime m
                     , MonadTimer m
                     , RunNode blk
                     , TxGen blk

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -35,6 +35,7 @@ module Ouroboros.Consensus.Network.NodeToNode (
 import           Codec.CBOR.Decoding (Decoder)
 import           Codec.CBOR.Encoding (Encoding)
 import           Control.Monad (forever)
+import           Control.Monad.Class.MonadTime (MonadTime)
 import           Control.Monad.Class.MonadTimer (MonadTimer)
 import           Control.Tracer
 import           Data.ByteString.Lazy (ByteString)
@@ -156,6 +157,7 @@ data Handlers m peer blk = Handlers {
 mkHandlers
   :: forall m blk remotePeer localPeer.
      ( IOLike m
+     , MonadTime m
      , MonadTimer m
      , LedgerSupportsMempool blk
      , HasTxId (GenTx blk)

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -317,7 +317,8 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
               compareCandidateChains,
 
               blockFetchSize         = \_ -> 1000,
-              blockMatchesHeader     = \_ _ -> True
+              blockMatchesHeader     = \_ _ -> True,
+              slotToTime             = \_ -> return Nothing
             }
           where
             plausibleCandidateChain cur candidate =

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -286,7 +286,8 @@ blockFetchLogic decisionTracer clientStateTracer
     fetchClientPolicy = FetchClientPolicy {
                           blockFetchSize,
                           blockMatchesHeader,
-                          addFetchedBlock
+                          addFetchedBlock,
+                          slotToTime
                         }
 
     fetchDecisionPolicy :: FetchDecisionPolicy header

--- a/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
@@ -276,7 +276,8 @@ sampleBlockFetchPolicy1 blockHeap currentChain candidateChains =
       compareCandidateChains,
 
       blockFetchSize         = \_ -> 2000,
-      blockMatchesHeader     = \_ _ -> True
+      blockMatchesHeader     = \_ _ -> True,
+      slotToTime             = \_ -> return Nothing
     }
   where
     plausibleCandidateChain cur candidate =

--- a/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/BlockFetch.hs
@@ -258,7 +258,7 @@ tracePropertyBlocksRequestedAndRecievedPerPeer fork1 fork2 es =
       Map.fromListWith (flip (++))
         [ (peer, [pt])
         | TraceFetchClientState
-            (TraceLabelPeer peer (CompletedBlockFetch pt _ _ _)) <- es
+            (TraceLabelPeer peer (CompletedBlockFetch pt _ _ _ _)) <- es
         ]
 
 
@@ -302,7 +302,7 @@ tracePropertyBlocksRequestedAndRecievedAllPeers fork1 fork2 es =
       Set.fromList
         [ pt
         | TraceFetchClientState
-            (TraceLabelPeer _ (CompletedBlockFetch pt _ _ _)) <- es
+            (TraceLabelPeer _ (CompletedBlockFetch pt _ _ _ _)) <- es
         ]
 
 


### PR DESCRIPTION
Trace the delay from when a block should have been forged to when we're
ready to adopt it.
The delay is not exact since it depends on the correctness of our's and
the block forges clock.