### PR TITLE
network: add headerForgeUTCTime field to BlockFetchConsensusInterface

### DIFF
--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -317,11 +317,18 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
               compareCandidateChains,
 
               blockFetchSize         = \_ -> 1000,
-              blockMatchesHeader     = \_ _ -> True
+              blockMatchesHeader     = \_ _ -> True,
+
+              headerForgeUTCTime,
+              blockForgeUTCTime      = headerForgeUTCTime . fmap blockHeader
             }
           where
             plausibleCandidateChain cur candidate =
                 AF.headBlockNo candidate > AF.headBlockNo cur
+
+            headerForgeUTCTime (FromConsensus hdr) =
+                pure $
+                convertSlotToTimeForTestsAssumingNoHardFork (headerSlot hdr)
 
         compareCandidateChains c1 c2 =
           AF.headBlockNo c1 `compare` AF.headBlockNo c2

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -188,7 +188,8 @@ library
                        Ouroboros.Network.MockChain.ProducerState
                        Ouroboros.Network.Testing.ConcreteBlock
   build-depends:       hashable          >=1.2 && <1.4,
-                       text              >=1.2 && <1.3
+                       text              >=1.2 && <1.3,
+                       time              >=1.6 && <1.11
 
 library ouroboros-protocol-tests
   hs-source-dirs:      protocol-tests


### PR DESCRIPTION
Single commit PR. The message:

```
This field calculates the UTCTime at which the given header's corresponding
block was forged.

The `blockForgeUTCTime` is provided for convenience only: you could instead
extract the header from the block and call `headerForgeUTCTime`.

This field risks being extremely subtle footgun. Hence it has a rather severe
PRECONDITION and WARNING in its Haddock. We also introduce the intentionally
noisy `FromConsensus` newtype wrapper so that each call site must explicitly
claim that the argument satisfies the precondition.

This function is being currently provided in order to enable a _metric_. If it
were to be used for something more crucial, such as peer selection (which via
Ouroboros Genesis becomes directly relevant to the consensus algorithm!), we'd
hesitate further. We're generally weary of spreading time-conversions too
widely; we paid that price once when developing the HFC. Once bitten twice shy.
```