### PR TITLE
Always use qualified import for Data.List

### DIFF
--- a/io-sim-classes/io-sim-classes.cabal
+++ b/io-sim-classes/io-sim-classes.cabal
@@ -59,7 +59,7 @@ library
                        bytestring,
                        mtl   >=2.2 && <2.3,
                        stm   >=2.5 && <2.6,
-                       time  >=1.6 && <1.11
+                       time  >=1.9.1 && <1.11
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -Wcompat

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -44,7 +44,7 @@ library
                        exceptions        >=0.10,
                        containers,
                        psqueues          >=0.2 && <0.3,
-                       time              >=1.6 && <1.11,
+                       time              >=1.9.1 && <1.11,
                        quiet
 
   ghc-options:         -Wall
@@ -72,7 +72,7 @@ test-suite test
                        QuickCheck,
                        tasty,
                        tasty-quickcheck,
-                       time
+                       time               >= 1.9.1
 
   ghc-options:         -Wall
                        -fno-ignore-asserts

--- a/io-sim/test/Test/IOSim.hs
+++ b/io-sim/test/Test/IOSim.hs
@@ -11,9 +11,9 @@ module Test.IOSim
 import           Data.Array
 import           Data.Either (isLeft)
 import           Data.Fixed (Fixed (..), Micro)
-import           Data.Graph
 import           Data.Function (on)
-import           Data.List (sortBy)
+import           Data.Graph
+import qualified Data.List as L
 import           Data.Time.Clock (picosecondsToDiffTime)
 
 import           Control.Exception (ArithException (..))
@@ -21,8 +21,8 @@ import           Control.Monad
 import           System.IO.Error (ioeGetErrorString, isUserError)
 
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadSTM.Strict
+import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim
@@ -235,7 +235,7 @@ test_timers xs =
          -- all timers should fire
          (length tr === length xs)
          -- timers should fire in the right order
-      .&&. (sortBy (on sortFn fst) tr === tr)
+      .&&. (L.sortBy (on sortFn fst) tr === tr)
 
     -- timers with negative timeout never fired, so we treat them as they would
     -- all fired at once at @-∞@.  This is to say that the following function is

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -53,7 +53,7 @@ library
                        statistics-linreg
                                        >=0.3 && <0.4,
                        vector          >=0.12 && <0.13,
-                       time            >=1.6 && <1.11,
+                       time            >=1.9.1 && <1.11,
                        quiet
 
   if os(windows)

--- a/network-mux/src/Network/Mux/Ingress.hs
+++ b/network-mux/src/Network/Mux/Ingress.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE BangPatterns          #-}
-{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
 
 module Network.Mux.Ingress (
     -- $ingress
@@ -12,8 +12,8 @@ module Network.Mux.Ingress (
     ) where
 
 import           Data.Array
-import           Data.List (nub)
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.List as L
 import           Text.Printf
 
 import           Control.Monad
@@ -192,7 +192,7 @@ setupDispatchTable ptcls =
     -- The protocol numbers actually used, in the order of the first use within
     -- the 'ptcls' list. The order does not matter provided we do it
     -- consistently between the two arrays.
-    pnums   = nub $ map (miniProtocolNum . miniProtocolInfo) ptcls
+    pnums   = L.nub $ map (miniProtocolNum . miniProtocolInfo) ptcls
 
     -- The dense range of indexes of used protocol numbers.
     minpix, maxpix :: MiniProtocolIx

--- a/ntp-client/ntp-client.cabal
+++ b/ntp-client/ntp-client.cabal
@@ -25,7 +25,7 @@ library
                       , contra-tracer   >=0.1 && <0.2
                       , network         >= 3.1.2 && <3.2
                       , stm             >=2.4 && <2.6
-                      , time            >=1.6 && <1.11
+                      , time            >=1.9.1 && <1.11
                       , Win32-network   >=0.1 && <0.2
 
   hs-source-dirs:       src
@@ -46,7 +46,7 @@ test-suite test
   type:               exitcode-stdio-1.0
   build-depends:        base            >=4.9 && <4.15
                       , binary          >=0.8 && <0.11
-                      , time            >=1.6 && <1.11
+                      , time            >=1.9.1 && <1.11
                       , QuickCheck
                       , tasty
                       , tasty-quickcheck

--- a/ouroboros-consensus-byron/tools/db-converter/Main.hs
+++ b/ouroboros-consensus-byron/tools/db-converter/Main.hs
@@ -13,7 +13,7 @@ import           Control.Monad.Except (liftIO, runExceptT)
 import           Control.Monad.Trans.Resource (runResourceT)
 import qualified Data.ByteString as BS
 import           Data.Foldable (for_)
-import           Data.List (sort)
+import qualified Data.List as L
 import qualified Data.Text as T
 import           Data.Word (Word32, Word64)
 import           Options.Generic
@@ -54,7 +54,7 @@ main = do
     epochDir' <- canonicalizePath epochDir
     files     <- listDirectory epochDir'
     let magic = mkNetworkMagic networkMagic
-        epochFiles = sort $ filter (\f -> takeExtension f == ".epoch") files
+        epochFiles = L.sort $ filter (\f -> takeExtension f == ".epoch") files
     putStrLn $ "Writing to " <> show dbDir
     for_ epochFiles $ \f -> do
       putStrLn $ "Converting file " <> show f

--- a/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
+++ b/ouroboros-consensus-cardano/tools/db-analyser/Analysis.hs
@@ -10,7 +10,7 @@ module Analysis (
   ) where
 
 import           Control.Monad.Except
-import           Data.List (intercalate)
+import qualified Data.List as L
 import qualified Data.Map.Strict as Map
 import           Data.Word (Word16)
 
@@ -68,7 +68,7 @@ showSlotBlockNo AnalysisEnv { db, registry } =
     processAll_ db registry GetHeader process
   where
     process :: Header blk -> IO ()
-    process hdr = putStrLn $ intercalate "\t" [
+    process hdr = putStrLn $ L.intercalate "\t" [
         show (blockNo   hdr)
       , show (blockSlot hdr)
       ]
@@ -84,7 +84,7 @@ countTxOutputs AnalysisEnv { db, registry } = do
     process :: Int -> blk -> IO Int
     process cumulative blk = do
         let cumulative' = cumulative + count
-        putStrLn $ intercalate "\t" [
+        putStrLn $ L.intercalate "\t" [
             show slotNo
           , show count
           , show cumulative'
@@ -106,7 +106,7 @@ showHeaderSize AnalysisEnv { db, registry } = do
   where
     process :: Word16 -> (SlotNo, Word16) -> IO Word16
     process maxHeaderSize (slotNo, headerSize) = do
-        putStrLn $ intercalate "\t" [
+        putStrLn $ L.intercalate "\t" [
             show slotNo
           , "Header size = " <> show headerSize
           ]
@@ -121,7 +121,7 @@ showBlockTxsSize AnalysisEnv { db, registry } =
     processAll_ db registry GetBlock process
   where
     process :: blk -> IO ()
-    process blk = putStrLn $ intercalate "\t" [
+    process blk = putStrLn $ L.intercalate "\t" [
           show (blockSlot blk)
         , "Num txs in block = " <> show numBlockTxs
         , "Total size of txs in block = " <> show blockTxsSize
@@ -149,7 +149,7 @@ showEBBs AnalysisEnv { db, registry } = do
     process blk =
         case blockIsEBB blk of
           Just _epoch ->
-            putStrLn $ intercalate "\t" [
+            putStrLn $ L.intercalate "\t" [
                 show (blockHash blk)
               , show (blockPrevHash blk)
               , show (    Map.lookup

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Forge.hs
@@ -17,7 +17,7 @@ module Ouroboros.Consensus.Shelley.Ledger.Forge (
 
 import           Control.Exception
 import           Control.Monad.Except
-import           Data.List (foldl')
+import qualified Data.List as L
 import qualified Data.Sequence.Strict as Seq
 
 import           Ouroboros.Consensus.Block
@@ -88,7 +88,7 @@ forgeShelleyBlock hotKey canBeLeader cfg curNo curSlot tickedLedger txs isLeader
       = return ()
 
     estimatedBodySize, actualBodySize :: Int
-    estimatedBodySize = fromIntegral $ foldl' (+) 0 (map txInBlockSize txs)
+    estimatedBodySize = fromIntegral $ L.foldl' (+) 0 (map txInBlockSize txs)
     actualBodySize    = SL.bBodySize body
 
     mkBhBody toSign = SL.BHBody {

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/Inspect.hs
@@ -16,7 +16,7 @@ module Ouroboros.Consensus.Shelley.Ledger.Inspect (
   ) where
 
 import           Control.Monad
-import           Data.List (sortBy)
+import qualified Data.List as L
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Ord (comparing)
@@ -127,7 +127,7 @@ protocolUpdates genesis st = [
     proposalsInv :: [(SL.PParamsDelta era, [SL.KeyHash 'SL.Genesis (EraCrypto era)])]
     proposalsInv =
           groupSplit id
-        . sortBy (comparing fst)
+        . L.sortBy (comparing fst)
         $ map swap (Map.toList proposals)
 
     -- Updated proposed within the proposal window

--- a/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs
+++ b/ouroboros-consensus-shelley/src/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs
@@ -9,7 +9,7 @@ module Ouroboros.Consensus.Shelley.Ledger.PeerSelection () where
 
 import           Data.Bifunctor (second)
 import           Data.Foldable (toList)
-import           Data.List (sortOn)
+import qualified Data.List as L
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
@@ -45,7 +45,7 @@ instance c ~ EraCrypto era
            SL.PoolDistr c
         -> [(SL.KeyHash 'SL.StakePool c, PoolStake)]
       orderByStake =
-            sortOn (Down . snd)
+            L.sortOn (Down . snd)
           . map (second (PoolStake . SL.individualPoolStake))
           . Map.toList
           . SL.unPoolDistr

--- a/ouroboros-consensus-test/src/Test/Util/FS/Sim/Error.hs
+++ b/ouroboros-consensus-test/src/Test/Util/FS/Sim/Error.hs
@@ -43,7 +43,7 @@ import           Prelude hiding (null)
 import           Control.Monad (replicateM, void)
 
 import qualified Data.ByteString as BS
-import           Data.List (dropWhileEnd, intercalate)
+import qualified Data.List as L
 import           Data.Maybe (catMaybes, isNothing)
 import           Data.Word (Word64)
 
@@ -103,7 +103,7 @@ always a = Stream (repeat (Just a))
 -- 'Just' where 'Nothing' has likelihood 2.
 mkStreamGen :: Int -> Gen a -> Gen (Stream a)
 mkStreamGen justLikelihood genA =
-    mkStream . dropWhileEnd isNothing <$> replicateM 10 mbGenA
+    mkStream . L.dropWhileEnd isNothing <$> replicateM 10 mbGenA
   where
     mbGenA = QC.frequency
       [ (2, return Nothing)
@@ -267,7 +267,7 @@ allNull Errors {..} = null dumpStateE
 
 instance Show Errors where
   show Errors {..} =
-      "Errors {"  <> intercalate ", " streams <> "}"
+      "Errors {"  <> L.intercalate ", " streams <> "}"
     where
       -- | Show a stream unless it is empty
       s :: Show a => String -> Stream a -> Maybe String

--- a/ouroboros-consensus-test/src/Test/Util/RefEnv.hs
+++ b/ouroboros-consensus-test/src/Test/Util/RefEnv.hs
@@ -25,7 +25,7 @@ import qualified Prelude
 
 import           Data.Bifunctor
 import           Data.Functor.Classes
-import           Data.List (intercalate)
+import qualified Data.List as L
 import           Data.TreeDiff (ToExpr)
 import           GHC.Generics (Generic)
 import           GHC.Stack
@@ -50,7 +50,7 @@ extendMapping acc ((k, v) : kvs) =
       _otherwise        -> extendMapping ((k, v) : acc) kvs
   where
     renderError :: v -> String
-    renderError v' = intercalate " " [
+    renderError v' = L.intercalate " " [
           "Key"
         , show k
         , "with two different values"

--- a/ouroboros-consensus-test/src/Test/Util/Serialisation/Golden.hs
+++ b/ouroboros-consensus-test/src/Test/Util/Serialisation/Golden.hs
@@ -36,7 +36,7 @@ import           Control.Exception (SomeException, evaluate, try)
 import           Data.Bifunctor (first)
 import qualified Data.ByteString as Strict
 import qualified Data.ByteString.UTF8 as BS.UTF8
-import           Data.List (nub)
+import qualified Data.List as L
 import qualified Data.Map.Strict as Map
 import           Data.Proxy (Proxy (..))
 import           Data.TreeDiff (Expr (..), ToExpr (..), ansiWlEditExpr, ediff)
@@ -174,7 +174,7 @@ goldenTests ::
   -> FilePath  -- ^ Folder containing the golden files
   -> TestTree
 goldenTests testName examples enc goldenFolder
-  | nub labels /= labels
+  | L.nub labels /= labels
   = error $ "Examples with the same label for " <> testName
   | [(Nothing, example)] <- examples
     -- If there's just a single unlabelled example, no need for grouping,
@@ -394,7 +394,7 @@ goldenTest_SerialiseNodeToNode ::
 goldenTest_SerialiseNodeToNode codecConfig goldenDir Examples {..} =
     testGroup "SerialiseNodeToNode" [
         testVersion version
-      | version <- nub $ Map.elems $ supportedNodeToNodeVersions $ Proxy @blk
+      | version <- L.nub $ Map.elems $ supportedNodeToNodeVersions $ Proxy @blk
       ]
   where
     testVersion :: BlockNodeToNodeVersion blk -> TestTree
@@ -431,7 +431,7 @@ goldenTest_SerialiseNodeToClient ::
 goldenTest_SerialiseNodeToClient codecConfig goldenDir Examples {..} =
     testGroup "SerialiseNodeToClient" [
         testVersion version
-      | version <- nub $ Map.elems $ supportedNodeToClientVersions $ Proxy @blk
+      | version <- L.nub $ Map.elems $ supportedNodeToClientVersions $ Proxy @blk
       ]
   where
     testVersion :: BlockNodeToClientVersion blk -> TestTree

--- a/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
+++ b/ouroboros-consensus-test/src/Test/Util/TestBlock.hs
@@ -59,7 +59,7 @@ import           Codec.Serialise (Serialise (..))
 import           Control.DeepSeq (force)
 import           Control.Monad.Except (throwError)
 import           Data.Int
-import           Data.List (transpose)
+import qualified Data.List as L
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
@@ -547,7 +547,7 @@ mkTree threshold = go
 shrinkTree :: Tree a -> [Tree a]
 shrinkTree (Node a ts) = map (Node a) (shrinkList shrinkTree ts)
                          -- Also try shrinking all subtrees at once
-                      ++ map (Node a) (transpose (map shrinkTree ts))
+                      ++ map (Node a) (L.transpose (map shrinkTree ts))
 
 
 -- | Split list into two

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Forecast.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/Forecast.hs
@@ -20,7 +20,7 @@ import           Control.Exception (assert)
 import           Control.Monad.Except
 import           Data.Either (isRight)
 import           Data.Foldable (toList)
-import           Data.List (intercalate)
+import qualified Data.List as L
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe (catMaybes, listToMaybe)
@@ -360,7 +360,7 @@ prop_validTestSetup (Some setup@TestSetup{..}) = conjoin [
 
 prop_forecast :: Bool -> Some TestSetup -> Property
 prop_forecast useWithinEra (Some setup@TestSetup{..}) =
-      tabulate "(useWithinEra, isWithinEra, within range)" [intercalate "/" [
+      tabulate "(useWithinEra, isWithinEra, within range)" [L.intercalate "/" [
           show useWithinEra
         , show isWithinEra
         , show (isRight mForecastLedger)

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -11,7 +11,7 @@ module Test.Consensus.MiniProtocol.ChainSync.Client ( tests ) where
 import           Control.Monad.State.Strict
 import           Control.Tracer (Tracer (..), contramap, nullTracer, traceWith)
 import           Data.Bifunctor (first)
-import           Data.List (intercalate, unfoldr)
+import qualified Data.List as L
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, isJust)
@@ -600,7 +600,7 @@ genUpdateSchedule securityParam = do
 -- | Repeatedly remove the last entry (highest 'Tick')
 shrinkUpdateSchedule :: Schedule [ChainUpdate]
                      -> [Schedule [ChainUpdate]]
-shrinkUpdateSchedule = unfoldr (fmap (\(_, m) -> (m, m)) . Map.maxView)
+shrinkUpdateSchedule = L.unfoldr (fmap (\(_, m) -> (m, m)) . Map.maxView)
 
 -- | Spread out updates over a schedule, i.e. schedule a number of updates to
 -- be executed on each tick. Most ticks will have no planned updates.
@@ -746,7 +746,7 @@ ppFragment :: AnchoredFragment TestBlock -> String
 ppFragment f = ppBlocks (AF.anchorPoint f) (AF.toOldestFirst f)
 
 ppBlocks :: Point TestBlock -> [TestBlock] -> String
-ppBlocks a bs = ppPoint a <> " ] " <> intercalate " :> " (map ppBlock bs)
+ppBlocks a bs = ppPoint a <> " ] " <> L.intercalate " :> " (map ppBlock bs)
 
 ppUpdates :: Schedule [ChainUpdate] -> String
 ppUpdates = unlines
@@ -756,7 +756,7 @@ ppUpdates = unlines
   where
     showEntry :: Tick -> [ChainUpdate] -> String
     showEntry (Tick tick) updates = show tick <> ": " <>
-      intercalate ", " (map showChainUpdate updates)
+      L.intercalate ", " (map showChainUpdate updates)
 
     showChainUpdate :: ChainUpdate -> String
     showChainUpdate u = case u of

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/ResourceRegistry.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/ResourceRegistry.hs
@@ -23,7 +23,7 @@ import           Data.Foldable (toList)
 import           Data.Function (on)
 import           Data.Functor.Classes
 import           Data.Kind (Type)
-import           Data.List (delete, sort)
+import qualified Data.List as L
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.TreeDiff (defaultExprViaShow)
@@ -209,7 +209,7 @@ normalize (Resp r) = Resp $ aux <$> r
     aux :: Success MockThread -> Success MockThread
     aux (Unit ())    = Unit ()
     aux (Spawned t)  = Spawned t
-    aux (Threads ts) = Threads (sort ts)
+    aux (Threads ts) = Threads (L.sort ts)
 
 {-------------------------------------------------------------------------------
   Run against the mock implementation
@@ -330,7 +330,7 @@ newThread alive parentReg = \shouldLink -> do
                -> m ()
     threadBody childReg spawned comms = do
         us <- readMVar spawned
-        loop us `finally` (atomically $ modifyTVar alive (delete us))
+        loop us `finally` (atomically $ modifyTVar alive (L.delete us))
       where
         loop :: TestThread m -> m ()
         loop us = do

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/GcSchedule.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/GcSchedule.hs
@@ -8,7 +8,7 @@ module Test.Ouroboros.Storage.ChainDB.GcSchedule (tests, example) where
 import           Control.Monad (forM)
 import           Control.Tracer (nullTracer)
 import           Data.Fixed (div')
-import           Data.List (foldl', partition, sort)
+import qualified Data.List as L
 import           Data.Time.Clock
 import           Data.Void (Void)
 
@@ -223,7 +223,7 @@ runGc now gcState = GcState {
     }
   where
     (gcQueueLater, gcQueueNow) =
-      partition ((> now) . scheduledGcTime) (unGcQueue (gcQueue gcState))
+      L.partition ((> now) . scheduledGcTime) (unGcQueue (gcQueue gcState))
     mbHighestGCedSlot = safeMaximum $ map scheduledGcSlot gcQueueNow
     GcGarbageCollections pastGarbageCollections =
       gcGarbageCollections gcState
@@ -320,9 +320,9 @@ example gcParams = summarise gcParams 1000
 -- in the final 'GcGarbageCollections'.
 processQueueToEnd :: GcState -> GcGarbageCollections
 processQueueToEnd gcState@GcState { gcQueue = GcQueue queue } =
-    gcGarbageCollections (foldl' (flip runGc) gcState timesToGcAt)
+    gcGarbageCollections (L.foldl' (flip runGc) gcState timesToGcAt)
   where
-    timesToGcAt = sort (map scheduledGcTime queue)
+    timesToGcAt = L.sort (map scheduledGcTime queue)
 
 {-------------------------------------------------------------------------------
   Run the real GcSchedule

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Iterator.hs
@@ -11,7 +11,7 @@ import           Test.Tasty.QuickCheck
 
 import           Control.Monad.Except
 import           Control.Tracer
-import           Data.List (intercalate)
+import qualified Data.List as L
 import qualified Data.Map.Strict as Map
 
 import           Control.Monad.IOSim (runSimOrThrow)
@@ -287,7 +287,7 @@ prop_general_test setup from to expected =
     failure msg = counterexample msg False
 
     ppStream :: [Either (RealPoint TestBlock) TestBlock] -> String
-    ppStream = intercalate " :> " . map ppGCedOrBlock
+    ppStream = L.intercalate " :> " . map ppGCedOrBlock
 
 {-------------------------------------------------------------------------------
   Test setup
@@ -307,10 +307,10 @@ data TestSetup = TestSetup
 testSetupInfo :: TestSetup -> String
 testSetupInfo TestSetup { immutable, volatile } = mconcat
     [ "Immutable: "
-    , intercalate " :> " (map ppBlock (Chain.toOldestFirst immutable))
+    , L.intercalate " :> " (map ppBlock (Chain.toOldestFirst immutable))
     , "\n"
     , "Volatile:  "
-    , intercalate ", " (map ppBlock volatile)
+    , L.intercalate ", " (map ppBlock volatile)
     ]
 
 ppGCedOrBlock :: Either (RealPoint TestBlock) TestBlock -> String

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/Model.hs
@@ -84,7 +84,7 @@ import           Control.Monad (unless)
 import           Control.Monad.Except (runExcept)
 import qualified Data.ByteString.Lazy as Lazy
 import           Data.Function (on)
-import           Data.List (isInfixOf, isPrefixOf, sortBy)
+import qualified Data.List as L
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, isJust)
@@ -434,7 +434,7 @@ addBlock cfg blk m = Model {
 
     extendsImmutableChain :: Chain blk -> Bool
     extendsImmutableChain fork =
-      immutableChainHashes `isPrefixOf`
+      immutableChainHashes `L.isPrefixOf`
       map blockHash (Chain.toOldestFirst fork)
 
     newChain  :: Chain blk
@@ -779,7 +779,7 @@ validChains cfg m bs =
   where
     sortChains :: [Chain blk] -> [Chain blk]
     sortChains =
-      sortBy $ flip (
+      L.sortBy $ flip (
                Fragment.compareAnchoredFragments (configBlock cfg)
           `on` (Chain.toAnchoredFragment . fmap getHeader)
         )
@@ -819,7 +819,7 @@ between k from to m = do
 
     partOfCurrentChain :: AnchoredFragment blk -> Bool
     partOfCurrentChain fork =
-      map blockPoint (Fragment.toOldestFirst fork) `isInfixOf`
+      map blockPoint (Fragment.toOldestFirst fork) `L.isInfixOf`
       map blockPoint (Chain.toOldestFirst (currentChain m))
 
     -- A fragment for each possible chain in the database

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ChainDB/StateMachine.hs
@@ -34,7 +34,7 @@ import           Data.ByteString.Lazy (ByteString)
 import           Data.Foldable (toList)
 import           Data.Functor.Classes (Eq1, Show1)
 import           Data.Functor.Identity (Identity)
-import           Data.List (sortOn)
+import qualified Data.List as L
 import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Ord (Down (..))
@@ -916,7 +916,7 @@ generator genBlock m@Model {..} = At <$> frequency
 
     genFollowerForwardPoints :: Gen [Point blk]
     genFollowerForwardPoints = choose (1, 3) >>= \n ->
-      sortOn (Down . pointSlot) <$> replicateM n genFollowerForwardPoint
+      L.sortOn (Down . pointSlot) <$> replicateM n genFollowerForwardPoint
 
     genFollowerForwardPoint :: Gen (Point blk)
     genFollowerForwardPoint = genPoint

--- a/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
+++ b/ouroboros-consensus-test/test-storage/Test/Ouroboros/Storage/ImmutableDB/StateMachine.hs
@@ -31,7 +31,7 @@ import           Data.Foldable (toList)
 import           Data.Function (on)
 import           Data.Functor.Classes (Eq1, Show1)
 import           Data.Functor.Identity (Identity)
-import           Data.List (delete, partition, sortBy)
+import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import           Data.Map (Map)
 import qualified Data.Map as Map
@@ -263,7 +263,7 @@ run env@ImmutableDBEnv {
     -- Remove the iterator from 'varIters'
     iteratorClose' :: TestIterator IO -> IO ()
     iteratorClose' it = do
-      atomically $ modifyTVar varIters (delete it)
+      atomically $ modifyTVar varIters (L.delete it)
       iteratorClose (unWithEq it)
 
     giveWithEq :: a -> IO (WithEq a)
@@ -546,7 +546,7 @@ generateCmd Model {..} = At <$> frequency
     blocks = dbmBlocks dbModel
 
     ebbs, regularBlocks :: [TestBlock]
-    (ebbs, regularBlocks) = partition (fromIsEBB . blockToIsEBB) blocks
+    (ebbs, regularBlocks) = L.partition (fromIsEBB . blockToIsEBB) blocks
 
     empty, noRegularBlocks, noEBBs :: Bool
     empty           = null blocks
@@ -1027,7 +1027,7 @@ tag = C.classify
           _ -> Right $ tagIteratorStreamedN streamedPerIterator
       , C.predFinish = do
           -- Find the entry with the highest value, i.e. the iterator that has
-          (_, longestStream) <- listToMaybe $ sortBy (flip compare `on` snd) $
+          (_, longestStream) <- listToMaybe $ L.sortBy (flip compare `on` snd) $
             Map.toList streamedPerIterator
           return $ TagIteratorStreamedN longestStream
       }

--- a/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/DerivingVia.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/Combinator/Util/DerivingVia.hs
@@ -19,7 +19,7 @@ module Ouroboros.Consensus.HardFork.Combinator.Util.DerivingVia (
   , LiftNamedMismatch(..)
   ) where
 
-import           Data.List (intercalate)
+import qualified Data.List as L
 import           Data.Proxy
 import           Data.SOP.Dict
 import           Data.SOP.Strict
@@ -281,7 +281,7 @@ instance ( All SingleEraBlock xs
 
 showBlockTypes :: All SingleEraBlock xs => SList xs -> String
 showBlockTypes =
-    (\names -> "[" ++ intercalate "," names ++ "]") . hcollapse . go
+    (\names -> "[" ++ L.intercalate "," names ++ "]") . hcollapse . go
   where
     go :: All SingleEraBlock xs' => SList xs' -> NP (K String) xs'
     go SNil  = Nil

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/MockChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/MockChainSel.hs
@@ -6,7 +6,7 @@ module Ouroboros.Consensus.Protocol.MockChainSel
   , selectUnvalidatedChain
   ) where
 
-import           Data.List (sortOn)
+import qualified Data.List as L
 import           Data.Maybe (listToMaybe, mapMaybe)
 import           Data.Ord (Down (..))
 
@@ -40,7 +40,7 @@ selectChain :: forall proxy p hdr l. ConsensusProtocol p
 selectChain p view ours =
       listToMaybe
     . map snd
-    . sortOn (Down . fst)
+    . L.sortOn (Down . fst)
     . mapMaybe selectPreferredCandidate
   where
     -- | Only retain a candidate if it is preferred over the current chain. As

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Protocol/PBFT/State.hs
@@ -41,7 +41,7 @@ import           Codec.Serialise.Decoding (Decoder)
 import           Codec.Serialise.Encoding (Encoding)
 import           Control.Monad.Except
 import qualified Data.Foldable as Foldable
-import           Data.List (sortOn)
+import qualified Data.List as L
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Sequence.Strict (StrictSeq (Empty, (:<|), (:|>)), (|>))
@@ -285,7 +285,7 @@ invert =
 uninvert :: PBftCrypto c => Map (PBftVerKeyHash c) [SlotNo] -> PBftState c
 uninvert =
       fromList
-    . sortOn pbftSignerSlotNo
+    . L.sortOn pbftSignerSlotNo
     . concatMap (\(key, slots) -> map (`PBftSigner` key) slots)
     . Map.toList
 

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ChainDB/Impl/ChainSel.hs
@@ -26,7 +26,7 @@ import           Control.Monad.Except
 import           Control.Monad.Trans.State.Strict
 import           Control.Tracer (Tracer, contramap, traceWith)
 import           Data.Function (on)
-import           Data.List (partition, sortBy)
+import qualified Data.List as L
 import           Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import           Data.Map.Strict (Map)
@@ -790,7 +790,7 @@ chainSelection chainSelEnv chainDiffs =
 
     sortCandidates :: [ChainDiff (Header blk)] -> [ChainDiff (Header blk)]
     sortCandidates =
-      sortBy (flip (compareAnchoredFragments bcfg) `on` Diff.getSuffix)
+      L.sortBy (flip (compareAnchoredFragments bcfg) `on` Diff.getSuffix)
 
     -- 1. Take the first candidate from the list of sorted candidates
     -- 2. Validate it
@@ -972,7 +972,7 @@ futureCheckCandidate chainSelEnv validatedChainDiff =
 
       (suffix', inFuture) -> do
         let (exceedClockSkew, inNearFuture) =
-              partition InFuture.inFutureExceedsClockSkew inFuture
+              L.partition InFuture.inFutureExceedsClockSkew inFuture
         -- Record future blocks
         unless (null inNearFuture) $ do
           let futureHeaders = InFuture.inFutureHeader <$> inNearFuture

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/ImmutableDB/Impl/Util.hs
@@ -28,7 +28,7 @@ import           Control.Monad (forM_)
 import           Data.Binary.Get (Get)
 import qualified Data.Binary.Get as Get
 import qualified Data.ByteString.Lazy as Lazy
-import           Data.List (foldl')
+import qualified Data.List as L
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Text (Text)
@@ -87,7 +87,7 @@ parseDBFile s = case T.splitOn "." $ T.pack s of
 -- | Go through all files, making three sets: the set of chunk files, primary
 -- index files, and secondary index files, discarding all others.
 dbFilesOnDisk :: Set String -> (Set ChunkNo, Set ChunkNo, Set ChunkNo)
-dbFilesOnDisk = foldl' categorise mempty
+dbFilesOnDisk = L.foldl' categorise mempty
   where
     categorise fs@(!chunk, !primary, !secondary) file =
       case parseDBFile file of

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl.hs
@@ -123,7 +123,7 @@ import           Control.Monad.State.Strict (get, gets, lift, modify, put,
                      state)
 import           Control.Tracer (Tracer, nullTracer, traceWith)
 import qualified Data.ByteString.Lazy as Lazy
-import           Data.List (foldl')
+import qualified Data.List as L
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, mapMaybe)
 import           Data.Set (Set)
@@ -494,7 +494,7 @@ garbageCollectFile hasFS (fileId, fileInfo) = do
             (\h -> (, h) . biPrevHash . ibiBlockInfo <$> Map.lookup h currentRevMap)
             (Set.toList hashes)
         currentSuccMap' =
-          foldl' (flip (uncurry deleteMapSet)) currentSuccMap deletedPairs
+          L.foldl' (flip (uncurry deleteMapSet)) currentSuccMap deletedPairs
 
     put st {
         currentMap     = Index.delete fileId currentMap

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/State.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/State.hs
@@ -35,7 +35,7 @@ import           Control.Monad
 import           Control.Monad.State.Strict hiding (withState)
 import           Control.Tracer (Tracer, traceWith)
 import qualified Data.ByteString.Lazy as Lazy
-import           Data.List (foldl')
+import qualified Data.List as L
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -419,7 +419,7 @@ mkOpenStateHelper ccfg hasFS checkIntegrity validationPolicy tracer maxBlocksPer
 
       let fileInfo        = FileInfo.fromParsedBlockInfos acceptedBlocks
           currentMap'     = Index.insert fd fileInfo currentMap
-          currentSuccMap' = foldl'
+          currentSuccMap' = L.foldl'
             (\succMap ParsedBlockInfo { pbiBlockInfo } ->
               insertMapSet (biPrevHash pbiBlockInfo) (biHash pbiBlockInfo) succMap)
             currentSuccMap

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Storage/VolatileDB/Impl/Util.hs
@@ -21,7 +21,7 @@ module Ouroboros.Consensus.Storage.VolatileDB.Impl.Util
 
 import           Control.Monad
 import           Data.Bifunctor (first)
-import           Data.List (sortOn)
+import qualified Data.List as L
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy (Proxy (..))
@@ -61,7 +61,7 @@ parseFd file =
 --
 -- Return separately any 'FsPath' which failed to parse.
 parseAllFds :: [FsPath] -> ([(FileId, FsPath)], [FsPath])
-parseAllFds = first (sortOn fst) . foldr judge ([], [])
+parseAllFds = first (L.sortOn fst) . foldr judge ([], [])
   where
     judge fsPath (parsed, notParsed) = case parseFd fsPath of
       Nothing     -> (parsed, fsPath : notParsed)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util.hs
@@ -76,7 +76,7 @@ import           Data.Function (on)
 import           Data.Functor.Identity
 import           Data.Functor.Product
 import           Data.Kind (Constraint, Type)
-import           Data.List (foldl', maximumBy)
+import qualified Data.List as L
 import           Data.Maybe (fromMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
@@ -126,7 +126,7 @@ foldlM' f = go
     go !acc (x:xs) = f acc x >>= \acc' -> go acc' xs
 
 repeatedly :: (a -> b -> b) -> ([a] -> b -> b)
-repeatedly = flip . foldl' . flip
+repeatedly = flip . L.foldl' . flip
 
 repeatedlyM :: Monad m => (a -> b -> m b) -> ([a] -> b -> m b)
 repeatedlyM = flip . foldlM' . flip
@@ -260,7 +260,7 @@ safeMaximum = safeMaximumBy compare
 
 safeMaximumBy :: (a -> a -> Ordering) -> [a] -> Maybe a
 safeMaximumBy _cmp [] = Nothing
-safeMaximumBy cmp ls  = Just $ maximumBy cmp ls
+safeMaximumBy cmp ls  = Just $ L.maximumBy cmp ls
 
 safeMaximumOn :: Ord b => (a -> b) -> [a] -> Maybe a
 safeMaximumOn f = safeMaximumBy (compare `on` f)

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Util/Condense.hs
@@ -12,7 +12,7 @@ module Ouroboros.Consensus.Util.Condense (
 import qualified Data.ByteString as BS.Strict
 import qualified Data.ByteString.Lazy as BS.Lazy
 import           Data.Int
-import           Data.List (intercalate)
+import qualified Data.List as L
 import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy
@@ -101,7 +101,7 @@ instance Condense Rational where
   condense = printf "%.8f" . (fromRational :: Rational -> Double)
 
 instance Condense1 [] where
-  liftCondense f as = "[" ++ intercalate "," (map f as) ++ "]"
+  liftCondense f as = "[" ++ L.intercalate "," (map f as) ++ "]"
 
 instance Condense1 Set where
   liftCondense f = liftCondense f . Set.toList
@@ -142,7 +142,7 @@ instance Condense BS.Lazy.ByteString where
 -------------------------------------------------------------------------------}
 
 instance All Condense as => Condense (HList as) where
-  condense as = "(" ++ intercalate "," (HList.collapse (Proxy @Condense) condense as) ++ ")"
+  condense as = "(" ++ L.intercalate "," (HList.collapse (Proxy @Condense) condense as) ++ ")"
 
 {-------------------------------------------------------------------------------
   Orphans for ouroboros-network

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/RateLimiting.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/RateLimiting.hs
@@ -1,26 +1,26 @@
-{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Ouroboros.Network.RateLimiting where
 
 
-import           Control.Tracer (Tracer (..), contramapM)
 import           Control.Monad (when)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim
-import           Data.List (scanl')
+import           Control.Tracer (Tracer (..), contramapM)
+import qualified Data.List as L
 
 import           Ouroboros.Network.Server.RateLimiting
 
 import           Test.QuickCheck
-import           Text.Show.Functions ()
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
+import           Text.Show.Functions ()
 
 
 --
@@ -50,7 +50,7 @@ data Event
 
 
 data WithNumberOfConnections a = WithNumberOfConnections {
-    message :: a,
+    message             :: a,
     numberOfConnections :: Int
   }
 
@@ -80,7 +80,7 @@ fixEvents :: [Event] -> [Event]
 fixEvents = go 0
   where
     go :: Int -> [Event] -> [Event]
-    go _ [] = []
+    go _ []                                    = []
     go 0 (ConnectionTerminated _ : events)     =      go 0 events
     go n (ev@ConnectionTerminated {} : events) = ev : go (pred n) events
     go n (ev@IncomingConnection {}   : events) = ev : go (succ n) events
@@ -271,7 +271,7 @@ numberOfTurnsAboveHardLimit AcceptedConnectionsLimit
                               {acceptedConnectionsHardLimit} =
       length
     . filter (>= hardLimit)
-    . scanl' (flip (interpr hardLimit)) 0
+    . L.scanl' (flip (interpr hardLimit)) 0
   where
     hardLimit = fromIntegral acceptedConnectionsHardLimit
 
@@ -283,7 +283,7 @@ numberOfTurnsAboveSoftLimit AcceptedConnectionsLimit
                               {acceptedConnectionsSoftLimit} =
       length
     . filter (>= softLimit)
-    . scanl' (flip (interpr softLimit)) 0
+    . L.scanl' (flip (interpr softLimit)) 0
   where
     softLimit = fromIntegral acceptedConnectionsSoftLimit
 

--- a/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/test/Test/Ouroboros/Network/Socket.hs
@@ -11,52 +11,53 @@
 {-# OPTIONS_GHC -Wno-orphans     #-}
 module Test.Ouroboros.Network.Socket (tests) where
 
-import           Data.Void (Void)
-import           Data.List (mapAccumL)
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.List as L
 import           Data.Proxy (Proxy (..))
 import           Data.Time.Clock (UTCTime, getCurrentTime)
+import           Data.Void (Void)
 #ifndef mingw32_HOST_OS
 import           System.Directory (removeFile)
 import           System.IO.Error
 #endif
 import qualified Network.Socket as Socket
 #if defined(mingw32_HOST_OS)
-import qualified System.Win32.Async.Socket.ByteString.Lazy as Win32.Async (sendAll)
+import qualified System.Win32.Async.Socket.ByteString.Lazy as Win32.Async
+                     (sendAll)
 #else
 import qualified Network.Socket.ByteString.Lazy as Socket (sendAll)
 #endif
 
+import           Control.Concurrent (ThreadId)
+import           Control.Exception (IOException)
 import           Control.Monad
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork hiding (ThreadId)
 import           Control.Monad.Class.MonadSTM.Strict
 import           Control.Monad.Class.MonadThrow
-import           Control.Concurrent (ThreadId)
-import           Control.Exception (IOException)
 import           Control.Tracer
 
 import           Network.TypedProtocol.Core
-import qualified Network.TypedProtocol.ReqResp.Type   as ReqResp
 import qualified Network.TypedProtocol.ReqResp.Client as ReqResp
-import qualified Network.TypedProtocol.ReqResp.Server as ReqResp
-import qualified Network.TypedProtocol.ReqResp.Examples   as ReqResp
 import qualified Network.TypedProtocol.ReqResp.Codec.CBOR as ReqResp
+import qualified Network.TypedProtocol.ReqResp.Examples as ReqResp
+import qualified Network.TypedProtocol.ReqResp.Server as ReqResp
+import qualified Network.TypedProtocol.ReqResp.Type as ReqResp
 
 import           Ouroboros.Network.Driver
-import           Ouroboros.Network.Socket
-import           Ouroboros.Network.Snocket
 import           Ouroboros.Network.ErrorPolicy
 import           Ouroboros.Network.IOManager
+import           Ouroboros.Network.Snocket
+import           Ouroboros.Network.Socket
 -- TODO: remove Mx prefixes
 import           Ouroboros.Network.Mux
 
-import qualified Network.Mux as Mx (MuxError(..), MuxErrorType(..))
-import qualified Network.Mux.Compat as Mx (muxStart)
+import qualified Network.Mux as Mx (MuxError (..), MuxErrorType (..))
 import qualified Network.Mux.Bearer.Socket as Mx (socketAsMuxBearer)
-import           Network.Mux.Types ( MiniProtocolDir (..) , MuxSDU (..), MuxSDUHeader (..)
-                                   , RemoteClockModel (..), write)
+import qualified Network.Mux.Compat as Mx (muxStart)
 import           Network.Mux.Timeout
+import           Network.Mux.Types (MiniProtocolDir (..), MuxSDU (..),
+                     MuxSDUHeader (..), RemoteClockModel (..), write)
 
 import           Ouroboros.Network.Protocol.Handshake.Codec
 import           Ouroboros.Network.Protocol.Handshake.Unversioned
@@ -263,7 +264,7 @@ prop_socket_send_recv initiatorAddr responderAddr f xs =
             responderAddr
           atomically $ (,) <$> takeTMVar sv <*> takeTMVar cv
 
-    return (res == mapAccumL f 0 xs)
+    return (res == L.mapAccumL f 0 xs)
 
   where
     networkTracers = NetworkServerTracers {

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -13,13 +13,13 @@ module Main where
 
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Functor (void)
-import           Data.List
+import qualified Data.List as L
 import qualified Data.Map as Map
 import           Data.Proxy (Proxy (..))
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Text.Read (readMaybe)
 import           Data.Void (Void)
+import           Text.Read (readMaybe)
 
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.Async
@@ -39,11 +39,11 @@ import qualified Codec.Serialise as CBOR
 
 import qualified Ouroboros.Network.AnchoredFragment as AF
 import           Ouroboros.Network.Block
+import           Ouroboros.Network.IOManager
 import qualified Ouroboros.Network.MockChain.Chain as Chain
 import           Ouroboros.Network.Mux
 import           Ouroboros.Network.NodeToClient (LocalConnectionId)
 import           Ouroboros.Network.NodeToNode
-import           Ouroboros.Network.IOManager
 import           Ouroboros.Network.Point (WithOrigin (..))
 import           Ouroboros.Network.Snocket
 import           Ouroboros.Network.Socket
@@ -308,7 +308,7 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
               readFetchMode          = return FetchModeBulkSync,
               readFetchedBlocks      = (\h p -> castPoint p `Set.member` h) <$>
                                          getTestFetchedBlocks blockHeap,
-              readFetchedMaxSlotNo   = foldl' max NoMaxSlotNo .
+              readFetchedMaxSlotNo   = L.foldl' max NoMaxSlotNo .
                                        map (maxSlotNoFromWithOrigin . pointSlot) .
                                        Set.elems <$>
                                        getTestFetchedBlocks blockHeap,
@@ -348,7 +348,7 @@ clientBlockFetch sockAddrs = withIOManager $ \iocp -> do
                   -- downloaded candidate chain
                  --FIXME: there's something wrong here, we always get chains
                  -- of length 1.
-                  maximumBy compareCandidateChains $
+                  L.maximumBy compareCandidateChains $
                   [ candidateChainFetched
                   | candidateChain <- Map.elems candidates
                   , let candidateChainFetched =

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -189,7 +189,7 @@ library
                        Ouroboros.Network.Testing.ConcreteBlock
   build-depends:       hashable          >=1.2 && <1.4,
                        text              >=1.2 && <1.3,
-                       time              >=1.6 && <1.11
+                       time              >=1.9.1 && <1.11
 
 library ouroboros-protocol-tests
   hs-source-dirs:      protocol-tests

--- a/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Test.hs
+++ b/ouroboros-network/protocol-tests/Ouroboros/Network/Protocol/TxSubmission/Test.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE PolyKinds                  #-}
-{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE RankNTypes                 #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 -- usage of `MsgKThxBye` is safe in this module.
@@ -22,28 +22,27 @@ module Ouroboros.Network.Protocol.TxSubmission.Test (
    ,DistinctList (..)
    ) where
 
-import           Data.List (nub)
+import           Data.ByteString.Lazy (ByteString)
+import qualified Data.List as L
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Word (Word16)
-import           Data.ByteString.Lazy (ByteString)
 
-import           Control.Monad.ST (runST)
-import           Control.Monad.IOSim
 import           Control.Monad.Class.MonadAsync (MonadAsync)
 import           Control.Monad.Class.MonadST (MonadST)
 import           Control.Monad.Class.MonadThrow (MonadCatch)
-import           Control.Tracer (Tracer(..), nullTracer)
+import           Control.Monad.IOSim
+import           Control.Monad.ST (runST)
+import           Control.Tracer (Tracer (..), nullTracer)
 
 import           Codec.Serialise (Serialise)
-import qualified Codec.Serialise as Serialise (encode, decode)
+import qualified Codec.Serialise as Serialise (decode, encode)
 
 import           Network.TypedProtocol.Core
 import           Network.TypedProtocol.Proofs
 
-import           Ouroboros.Network.Codec hiding (prop_codec)
 import           Ouroboros.Network.Channel
-import           Ouroboros.Network.Driver.Simple
-                   (runConnectedPeersPipelined)
+import           Ouroboros.Network.Codec hiding (prop_codec)
+import           Ouroboros.Network.Driver.Simple (runConnectedPeersPipelined)
 import           Ouroboros.Network.Util.ShowProxy
 
 import           Ouroboros.Network.Protocol.TxSubmission.Client
@@ -53,7 +52,8 @@ import           Ouroboros.Network.Protocol.TxSubmission.Examples
 import           Ouroboros.Network.Protocol.TxSubmission.Server
 import           Ouroboros.Network.Protocol.TxSubmission.Type
 
-import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM, splits2, splits3)
+import           Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
+                     splits2, splits3)
 
 import           Test.QuickCheck as QC
 import           Test.Tasty (TestTree, testGroup)
@@ -378,8 +378,8 @@ newtype DistinctList a = DistinctList { fromDistinctList :: [a] }
   deriving Show
 
 instance (Eq a, Arbitrary a) => Arbitrary (DistinctList a) where
-  arbitrary = DistinctList . nub <$> arbitrary
+  arbitrary = DistinctList . L.nub <$> arbitrary
 
   shrink (DistinctList xs) =
-    [ DistinctList (nub xs') | xs' <- shrink xs ]
+    [ DistinctList (L.nub xs') | xs' <- shrink xs ]
 

--- a/ouroboros-network/protocol-tests/Test/ChainProducerState.hs
+++ b/ouroboros-network/protocol-tests/Test/ChainProducerState.hs
@@ -10,7 +10,7 @@ module Test.ChainProducerState
   )
  where
 
-import           Data.List (unfoldr)
+import qualified Data.List as L
 import qualified Data.Map as Map
 
 import           Test.QuickCheck
@@ -106,7 +106,7 @@ prop_producer_sync1 (TestBlockChainAndUpdates c us) =
      in
         consumer == producerChain producer
   where
-    iterateFollowerUntilDone rid = unfoldr (followerInstruction rid)
+    iterateFollowerUntilDone rid = L.unfoldr (followerInstruction rid)
 
 -- | A variation on 'prop_producer_sync1' where we take an arbitrary
 -- interleaving of applying changes to the producer and doing syncronisation

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
@@ -27,7 +27,7 @@ import qualified Data.Set as Set
 
 import           Data.Function (on)
 import           Data.Hashable
-import           Data.List (foldl', groupBy, sortBy, transpose)
+import qualified Data.List as L
 import           Data.Maybe (mapMaybe)
 import           Data.Set (Set)
 import           GHC.Stack (HasCallStack)
@@ -564,7 +564,7 @@ filterNotAlreadyInFlightWithOtherPeers FetchModeBulkSync chains =
         | (_, status, inflight, _) <- chains ]
 
     -- The highest slot number that is or has been in flight for any peer.
-    maxSlotNoInFlightWithOtherPeers = foldl' max NoMaxSlotNo
+    maxSlotNoInFlightWithOtherPeers = L.foldl' max NoMaxSlotNo
       [ peerFetchMaxSlotNo inflight | (_, _, inflight, _) <- chains ]
 
 -- | Filter a fragment. This is an optimised variant that will behave the same
@@ -620,16 +620,16 @@ prioritisePeerChains FetchModeDeadline compareCandidateChains blockFetchSize =
 
     map (\(decision, peer) ->
             (fmap (\(_,_,fragment) -> fragment) decision, peer))
-  . concatMap ( concat
-              . transpose
-              . groupBy (equatingFst
+  . concatMap ( L.concat
+              . L.transpose
+              . L.groupBy (equatingFst
                           (equatingRight
                             ((==) `on` chainHeadPoint)))
-              . sortBy  (comparingFst
+              . L.sortBy  (comparingFst
                           (comparingRight
                             (compare `on` chainHeadPoint)))
               )
-  . groupBy (equatingFst
+  . L.groupBy (equatingFst
               (equatingRight
                 (equatingPair
                    -- compare on probability band first, then preferred chain
@@ -637,7 +637,7 @@ prioritisePeerChains FetchModeDeadline compareCandidateChains blockFetchSize =
                    (equateCandidateChains `on` getChainSuffix)
                  `on`
                    (\(band, chain, _fragments) -> (band, chain)))))
-  . sortBy  (descendingOrder
+  . L.sortBy  (descendingOrder
               (comparingFst
                 (comparingRight
                   (comparingPair
@@ -670,7 +670,7 @@ prioritisePeerChains FetchModeDeadline compareCandidateChains blockFetchSize =
 prioritisePeerChains FetchModeBulkSync compareCandidateChains blockFetchSize =
     map (\(decision, peer) ->
             (fmap (\(_, _, fragment) -> fragment) decision, peer))
-  . sortBy (comparingFst
+  . L.sortBy (comparingFst
              (comparingRight
                (comparingPair
                   -- compare on preferred chain first, then duration
@@ -856,7 +856,7 @@ fetchRequestDecisions fetchDecisionPolicy fetchMode chains =
                maxSlotNoFetchedThisRound `max` maxSlotNoFetchedThisDecision)
               where
                 maxSlotNoFetchedThisDecision =
-                  foldl' max NoMaxSlotNo $ map MaxSlotNo $
+                  L.foldl' max NoMaxSlotNo $ map MaxSlotNo $
                   mapMaybe (withOriginToMaybe . AF.headSlot) fragments
 
                 blocksFetchedThisDecision =
@@ -887,7 +887,7 @@ fetchRequestDecisions fetchDecisionPolicy fetchMode chains =
     nPreferedPeers =
         map snd
       . take (fromIntegral maxConcurrentFetchPeers)
-      . sortBy (\a b -> comparePeerGSV nActivePeers (peerSalt fetchDecisionPolicy) a b)
+      . L.sortBy (\a b -> comparePeerGSV nActivePeers (peerSalt fetchDecisionPolicy) a b)
       . map (\(_, _, _, gsv, p, _) -> (gsv, p))
       $ chains
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
@@ -23,7 +23,7 @@ module Ouroboros.Network.PeerSelection.LedgerPeers (
 import           Control.Monad.Class.MonadSTM
 import           Control.Tracer (Tracer, traceWith)
 import qualified Data.IP as IP
-import           Data.List (foldl')
+import qualified Data.List as L
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
@@ -97,7 +97,7 @@ accPoolStake :: [(PoolStake, NonEmpty RelayAddress)]
              -> Map AccPoolStake (PoolStake, NonEmpty RelayAddress)
 accPoolStake pl =
     let pl' = reRelativeStake pl
-        ackList = foldl' fn [] pl' in
+        ackList = L.foldl' fn [] pl' in
     Map.fromList ackList
   where
     fn :: [(AccPoolStake, (PoolStake, NonEmpty RelayAddress))]

--- a/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/test/Ouroboros/Network/BlockFetch/Examples.hs
@@ -15,7 +15,7 @@ module Ouroboros.Network.BlockFetch.Examples (
 
 import           Codec.Serialise (Serialise (..))
 import qualified Data.ByteString.Lazy as LBS
-import           Data.List (foldl')
+import qualified Data.List as L
 import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
@@ -274,7 +274,7 @@ sampleBlockFetchPolicy1 headerFieldsForgeUTCTime blockHeap currentChain candidat
       readFetchMode          = return FetchModeBulkSync,
       readFetchedBlocks      = flip Set.member <$>
                                  getTestFetchedBlocks blockHeap,
-      readFetchedMaxSlotNo   = foldl' max NoMaxSlotNo .
+      readFetchedMaxSlotNo   = L.foldl' max NoMaxSlotNo .
                                map (maxSlotNoFromWithOrigin . pointSlot) .
                                Set.elems <$>
                                getTestFetchedBlocks blockHeap,

--- a/ouroboros-network/test/Ouroboros/Network/PeerSelection/Test.hs
+++ b/ouroboros-network/test/Ouroboros/Network/PeerSelection/Test.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE BangPatterns               #-}
 {-# LANGUAGE DeriveTraversable          #-}
-{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
@@ -20,7 +20,7 @@ import           Data.Function (on)
 import           Data.Functor (($>))
 import           Data.Graph (Graph)
 import qualified Data.Graph as Graph
-import           Data.List (groupBy, nub)
+import qualified Data.List as L
 import           Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map.Strict (Map)
@@ -35,8 +35,8 @@ import           Data.Void (Void)
 import           Control.Exception (throw)
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadSTM
-import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadThrow
+import           Control.Monad.Class.MonadTime
 import qualified Control.Monad.Fail as Fail
 import           Control.Tracer (Tracer (..), contramap, traceWith)
 
@@ -44,8 +44,8 @@ import           Control.Monad.Class.MonadTimer hiding (timeout)
 import           Control.Monad.IOSim
 
 import qualified Network.DNS as DNS (defaultResolvConf)
-import           Network.Socket (SockAddr)
 import           Network.Mux.Timeout
+import           Network.Socket (SockAddr)
 
 import           Ouroboros.Network.PeerSelection.Governor hiding
                      (PeerSelectionState (..))
@@ -699,7 +699,7 @@ prop_governor_connstatus (GovernorMockEnvironmentWAD env) =
               . selectPeerSelectionTraceEvents $
                   runGovernorInMockEnvironment env
         --TODO: check any actually get a true status output and try some deliberate bugs
-     in all ok (groupBy ((==) `on` fst) trace)
+     in all ok (L.groupBy ((==) `on` fst) trace)
   where
     -- We look at events when the environment's view of the state of all the
     -- peer connections changed, and check that before simulated time advances
@@ -866,7 +866,7 @@ instance Arbitrary GovernorMockEnvironment where
         numroots  <- choose (minroots, maxroots)
         ixs       <- vectorOf numroots (getNonNegative <$> arbitrary)
         let pick n    = Set.elemAt i peers where i = n `mod` Set.size peers
-            rootPeers = nub (map pick ixs)
+            rootPeers = L.nub (map pick ixs)
         -- divide into local and public, but with a bit of overlap:
         local <- vectorOf (length rootPeers) (choose (0, 10 :: Int))
         let localRoots  = [ x | (x, v) <- zip rootPeers local, v <= 5 ]

--- a/ouroboros-network/test/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/TxSubmission.hs
@@ -15,25 +15,26 @@ import           NoThunks.Class (NoThunks)
 import           Control.Exception (SomeException (..))
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSTM
+import           Control.Monad.Class.MonadSay
 import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
 import           Control.Monad.IOSim
-import           Control.Tracer (nullTracer, contramap, Tracer (..), showTracing, traceWith)
+import           Control.Tracer (Tracer (..), contramap, nullTracer,
+                     showTracing, traceWith)
 
-import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Decoding as CBOR
-import qualified Codec.CBOR.Read     as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Read as CBOR
 
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BSL
-import           Data.List (nubBy, intercalate)
-import           Data.Foldable (toList, find, foldl')
+import           Data.Foldable (find, foldl', toList)
 import           Data.Function (on)
-import           Data.Maybe (isJust, fromMaybe)
+import qualified Data.List as L
+import           Data.Maybe (fromMaybe, isJust)
 import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
@@ -44,21 +45,21 @@ import           Ouroboros.Network.Channel
 import           Ouroboros.Network.Codec
 import           Ouroboros.Network.Driver
 import           Ouroboros.Network.Mux
-import           Ouroboros.Network.Util.ShowProxy
-import           Ouroboros.Network.Protocol.TxSubmission.Type
-import           Ouroboros.Network.Protocol.TxSubmission.Client
-import           Ouroboros.Network.Protocol.TxSubmission.Server
-import           Ouroboros.Network.Protocol.TxSubmission.Codec
-import           Ouroboros.Network.TxSubmission.Mempool.Reader
-import           Ouroboros.Network.TxSubmission.Inbound
-import           Ouroboros.Network.TxSubmission.Outbound
 import           Ouroboros.Network.NodeToNode (NodeToNodeVersion (..))
+import           Ouroboros.Network.Protocol.TxSubmission.Client
+import           Ouroboros.Network.Protocol.TxSubmission.Codec
+import           Ouroboros.Network.Protocol.TxSubmission.Server
+import           Ouroboros.Network.Protocol.TxSubmission.Type
+import           Ouroboros.Network.TxSubmission.Inbound
+import           Ouroboros.Network.TxSubmission.Mempool.Reader
+import           Ouroboros.Network.TxSubmission.Outbound
+import           Ouroboros.Network.Util.ShowProxy
 
 import           Ouroboros.Network.Testing.Utils
 
+import           Test.QuickCheck
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (testProperty)
-import           Test.QuickCheck
 import           Text.Printf
 
 
@@ -152,7 +153,7 @@ getMempoolWriter (Mempool mempool) =
           atomically $ do
             mempoolTxs <- readTVar mempool
             let currentIds = Set.fromList (map getTxId (toList mempoolTxs))
-                validTxs = nubBy (on (==) getTxId)
+                validTxs = L.nubBy (on (==) getTxId)
                          $ filter
                              (\Tx { getTxId, getTxValid } ->
                                   getTxValid
@@ -290,12 +291,12 @@ prop_txSubmission (Positive maxUnacked) (NonEmpty outboundTxs) delay =
         tr' <- evaluateTrace tr
         case tr' of
              SimException e trace -> do
-                return $ counterexample (intercalate "\n" $ show e : trace) False
+                return $ counterexample (L.intercalate "\n" $ show e : trace) False
              SimDeadLock trace -> do
-                 return $ counterexample (intercalate "\n" $ "Deadlock" : trace) False
+                 return $ counterexample (L.intercalate "\n" $ "Deadlock" : trace) False
              SimReturn (inmp, outmp) _trace -> do
                  -- printf "Log: %s\n" (intercalate "\n" _trace)
-                 let outUniqueTxIds = nubBy (on (==) getTxId) outmp
+                 let outUniqueTxIds = L.nubBy (on (==) getTxId) outmp
                      outValidTxs    = filter getTxValid outmp
                  case (length outUniqueTxIds == length outmp, length outValidTxs == length outmp) of
                       (True, True) ->


### PR DESCRIPTION
This change will fix these potential warnings:

```
Error:     To ensure compatibility with future core libraries changes
    imports to Data.List should be
    either qualified or have an explicit import list.
   |
16 | import           Data.List
   |                  ^^^^^^^^^
```

The change is in anticipation of mitigating the effects of future core library changes.

Whilst it is possible to use explicit import lists, the use of qualified import by default will minimise future breakages, so that's the default option I'm taking.

Suggestions for exceptions to this rule welcome.