### PR TITLE
Remove problematic apt-get repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,9 @@ jobs:
     - name: Install build environment
       if: matrix.os == 'ubuntu-20.04'
       run: |
+        # Remove problematic apt-get repository
+        sudo rm /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+
         sudo apt-get update
         sudo apt-get -y install libsodium23 libsodium-dev
         sudo apt-get -y install libsystemd0 libsystemd-dev


### PR DESCRIPTION
`apt-get update` can sometimes fail due to a problematic apt-get repository.  See https://github.com/actions/virtual-environments/issues/2919

Remove this repository since we don't use it anyway to work around the problem.