### PR TITLE
Documented GovernorMockEnvironment Generator

### DIFF
--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -133,21 +133,19 @@ instance Arbitrary GovernorMockEnvironmentWithoutAsyncDemotion where
 -- | Invariant. Used to check the QC generator and shrinker.
 --
 validGovernorMockEnvironment :: GovernorMockEnvironment -> Bool
-validGovernorMockEnvironment
-    GovernorMockEnvironment
-        { peerGraph,
-          localRootPeers,
-          publicRootPeers,
-          targets
-        } =
-        validPeerGraph peerGraph
-            && LocalRootPeers.keysSet localRootPeers `Set.isSubsetOf` allPeersSet
-            && publicRootPeers `Set.isSubsetOf` allPeersSet
-            && Set.null (Set.intersection localRootPeersSet publicRootPeers)
-            && all (sanePeerSelectionTargets . fst) targets
-        where
-            allPeersSet = allPeers peerGraph
-            localRootPeersSet = LocalRootPeers.keysSet localRootPeers
+validGovernorMockEnvironment GovernorMockEnvironment {
+                               peerGraph,
+                               localRootPeers,
+                               publicRootPeers,
+                               targets
+                             } =
+      validPeerGraph peerGraph
+   && LocalRootPeers.keysSet localRootPeers `Set.isSubsetOf` allPeersSet
+   &&                       publicRootPeers `Set.isSubsetOf` allPeersSet
+   && all (sanePeerSelectionTargets . fst) targets
+  where
+    allPeersSet = allPeers peerGraph
+
 
 --
 -- Execution in the mock environment

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -133,19 +133,21 @@ instance Arbitrary GovernorMockEnvironmentWithoutAsyncDemotion where
 -- | Invariant. Used to check the QC generator and shrinker.
 --
 validGovernorMockEnvironment :: GovernorMockEnvironment -> Bool
-validGovernorMockEnvironment GovernorMockEnvironment {
-                               peerGraph,
-                               localRootPeers,
-                               publicRootPeers,
-                               targets
-                             } =
-      validPeerGraph peerGraph
-   && LocalRootPeers.keysSet localRootPeers `Set.isSubsetOf` allPeersSet
-   &&                       publicRootPeers `Set.isSubsetOf` allPeersSet
-   && all (sanePeerSelectionTargets . fst) targets
-  where
-    allPeersSet = allPeers peerGraph
-
+validGovernorMockEnvironment
+    GovernorMockEnvironment
+        { peerGraph,
+          localRootPeers,
+          publicRootPeers,
+          targets
+        } =
+        validPeerGraph peerGraph
+            && LocalRootPeers.keysSet localRootPeers `Set.isSubsetOf` allPeersSet
+            && publicRootPeers `Set.isSubsetOf` allPeersSet
+            && Set.null (Set.intersection localRootPeersSet publicRootPeers)
+            && all (sanePeerSelectionTargets . fst) targets
+        where
+            allPeersSet = allPeers peerGraph
+            localRootPeersSet = LocalRootPeers.keysSet localRootPeers
 
 --
 -- Execution in the mock environment

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -132,6 +132,10 @@ instance Arbitrary GovernorMockEnvironmentWithoutAsyncDemotion where
 
 -- | Invariant. Used to check the QC generator and shrinker.
 --
+-- NOTE: Local and Public Root Peers sets should be disjoint.
+-- However we do not check for that invariant here. The goal
+-- is to check if the actual Governor takes care of this and enforces
+-- the invariant.
 validGovernorMockEnvironment :: GovernorMockEnvironment -> Bool
 validGovernorMockEnvironment GovernorMockEnvironment {
                                peerGraph,
@@ -457,6 +461,8 @@ instance Arbitrary GovernorMockEnvironment where
             rootPeers = nub (map pick ixs)
         -- divide into local and public, but with a bit of overlap:
         local <- vectorOf (length rootPeers) (choose (0, 10 :: Int))
+        -- Deliberatly asking for a small intersection in order to test if
+        -- the Governor actually takes care of this invariant
         let localRootsSet  = Set.fromList [ x | (x, v) <- zip rootPeers local
                                               , v < 5 ]
             publicRootsSet = Set.fromList [ x | (x, v) <- zip rootPeers local

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -460,7 +460,7 @@ instance Arbitrary GovernorMockEnvironment where
         -- divide into local and public, but with a bit of overlap:
         local <- vectorOf (length rootPeers) (choose (0, 10 :: Int))
         let localRootsSet  = Set.fromList [ x | (x, v) <- zip rootPeers local
-                                              , v <= 5 ]
+                                              , v < 5 ]
             publicRootsSet = Set.fromList [ x | (x, v) <- zip rootPeers local
                                               , v >= 5 ]
         localRoots <- arbitraryLocalRootPeers localRootsSet


### PR DESCRIPTION
Added a check that local and public root peers are disjoint. Also tried very hard to extend some more governor properties with my new found insights from modelling the Governor with Alloy, and all that I found was this extra harmless check.

Trace properties already check for the validity of the `PeerSelectionStatee`, so we can be confident that at least the state is not corrupted after a certain amount of time. I also thought about adding consistency checks for each possible action (i.e. checking if there's no starvation of a particular action), but I am not sure if the `livelock` check covers that.