### PR TITLE
Fix deployment of gh-pages

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -116,6 +116,8 @@ jobs:
 
     - name: deploy to gh-pages 🚀
       run: |
+        git config --local user.email "marcin.szamotulski@iohk.io"
+        git config --local user.name ${{ github.actor }}
         git fetch origin gh-pages:gh-pages
         git checkout gh-pages
         cp -r ./haddocks/* ./


### PR DESCRIPTION
Fixes #3011: it did pushed to `gh-pages` [the proof](https://github.com/input-output-hk/ouroboros-network/commits/gh-pages)