### PR TITLE
Added PeerSelectionCounters and respective tracers.

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -31,6 +31,7 @@ module Ouroboros.Network.PeerSelection.Governor (
     sanePeerSelectionTargets,
     establishedPeersStatus,
     PeerSelectionState(..),
+    PeerSelectionCounters(..)
 ) where
 
 import           Data.Void (Void)
@@ -44,7 +45,7 @@ import           Control.Monad.Class.MonadThrow
 import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTime
 import           Control.Monad.Class.MonadTimer
-import           Control.Tracer (Tracer(..), traceWith)
+import           Control.Tracer (Tracer(..), traceWith, contramap)
 
 import qualified Ouroboros.Network.PeerSelection.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.KnownPeers as KnownPeers
@@ -430,16 +431,20 @@ peerSelectionGovernor :: (MonadAsync m, MonadMask m, MonadTime m, MonadTimer m,
                           Ord peeraddr)
                       => Tracer m (TracePeerSelection peeraddr)
                       -> Tracer m (DebugPeerSelection peeraddr peerconn)
+                      -> Tracer m PeerSelectionCounters
                       -> PeerSelectionActions peeraddr peerconn m
                       -> PeerSelectionPolicy  peeraddr m
                       -> m Void
-peerSelectionGovernor tracer debugTracer actions policy =
+peerSelectionGovernor tracer debugTracer countersTracer actions policy =
     JobPool.withJobPool $ \jobPool ->
       peerSelectionGovernorLoop
-        tracer debugTracer
+        tracer (debugTracer <> contramap transform countersTracer)
         actions policy
         jobPool
         emptyPeerSelectionState
+  where
+    transform :: Ord peeraddr => DebugPeerSelection peeraddr peerconn -> PeerSelectionCounters
+    transform (TraceGovernorState _ _ st) = peerStateToCounters st
 
 
 -- | Our pattern here is a loop with two sets of guarded actions:

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -271,7 +271,7 @@ data PeerSelectionState peeraddr peerconn = PeerSelectionState {
 data PeerSelectionCounters = PeerSelectionCounters {
       coldPeers :: !Int,
       warmPeers :: !Int,
-      hotPeers :: !Int
+      hotPeers  :: !Int
     } deriving Show
 
 peerStateToCounters :: Ord peeraddr => PeerSelectionState peeraddr peerconn -> PeerSelectionCounters

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -268,6 +268,20 @@ data PeerSelectionState peeraddr peerconn = PeerSelectionState {
      }
   deriving (Show, Functor)
 
+data PeerSelectionCounters = PeerSelectionCounters {
+      coldPeers :: !Int,
+      warmPeers :: !Int,
+      hotPeers :: !Int
+    } deriving Show
+
+peerStateToCounters :: Ord peeraddr => PeerSelectionState peeraddr peerconn -> PeerSelectionCounters
+peerStateToCounters st = PeerSelectionCounters {..}
+  where
+    knownPeersSet = KnownPeers.toSet (knownPeers st)
+    establishedPeersSet = EstablishedPeers.toSet (establishedPeers st)
+    coldPeers = Set.size $ knownPeersSet Set.\\ establishedPeersSet
+    warmPeers = Set.size $ establishedPeersSet Set.\\ activePeers st
+    hotPeers  = Set.size $ activePeers st
 
 emptyPeerSelectionState :: PeerSelectionState peeraddr peerconn
 emptyPeerSelectionState =

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection.hs
@@ -297,7 +297,7 @@ _governorFindingPublicRoots targetNumberOfRootPeers domains =
       domains $ \requestPublicRootPeers ->
 
         peerSelectionGovernor
-          tracer tracer
+          tracer tracer tracer
           actions { requestPublicRootPeers }
           policy
   where

--- a/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/test/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -168,6 +168,7 @@ runGovernorInMockEnvironment mockEnv =
       peerSelectionGovernor
         tracerTracePeerSelection
         tracerDebugPeerSelection
+        tracerTracePeerSelectionCounters
         actions
         policy
 
@@ -384,6 +385,7 @@ mockPeerSelectionPolicy GovernorMockEnvironment {
 
 data TestTraceEvent = GovernorDebug (DebugPeerSelection PeerAddr ())
                     | GovernorEvent (TracePeerSelection PeerAddr)
+                    | GovernorCounters PeerSelectionCounters
                     | MockEnvEvent   TraceMockEnv
   deriving Show
 
@@ -393,6 +395,9 @@ tracerTracePeerSelection = contramap GovernorEvent tracerTestTraceEvent
 tracerDebugPeerSelection :: Tracer (IOSim s) (DebugPeerSelection PeerAddr peerconn)
 tracerDebugPeerSelection = contramap (GovernorDebug . fmap (const ()))
                                      tracerTestTraceEvent
+
+tracerTracePeerSelectionCounters :: Tracer (IOSim s) PeerSelectionCounters
+tracerTracePeerSelectionCounters = contramap GovernorCounters tracerTestTraceEvent
 
 tracerMockEnv :: Tracer (IOSim s) TraceMockEnv
 tracerMockEnv = contramap MockEnvEvent tracerTestTraceEvent


### PR DESCRIPTION
I've made this changes on top of `dcoutts/p2p-local-root-peers` since `p2p-master` does not have the new `test` structure. I then realized that this branch does not have the `PeerSelection` tracers in `DiffusionTracers` so that is still left TODO. Maybe after reviewing that the current additions make sense.